### PR TITLE
Chat build: one complete per-session signature serves every tab, and a judge pass rebuilds only the tab whose store it moved

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1254,11 +1254,13 @@ for k in ("chat", "feed", "timeline", "feedJson"):     # feedJson: GET /feed.jso
         # moved, then per signature component the background rebuilds it caused; a kernel from before the
         # split reports neither field and prints the line as before
         active, bg = dl("builds", k, "active_built"), dl("builds", k, "bg_built")
+        moved = dl("builds", k, "moved")             # builds not cached because an input moved while they ran
         if active or bg:
             labels = sorted(((b.get("builds") or {}).get("chat") or {}).get("bg_miss") or {})
             causes = ", ".join("%s %d" % (lab, dl("builds", k, "bg_miss", lab)) for lab in labels
                                if dl("builds", k, "bg_miss", lab))
-            split = "; %d watched, %d background%s" % (active, bg, (": " + causes) if causes else "")
+            split = "; %d watched, %d background%s%s" % (active, bg, (": " + causes) if causes else "",
+                                                          ("; %d moved" % moved) if moved else "")
     parts.append("%s %d built / %d cached%s"
                  % (k, built, cached, (" (%.0f ms avg%s)" % (ms / built, split)) if built else ""))
 print("builds    " + "   ".join(parts))

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -973,15 +973,31 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `push.*` stages count every push, including the one a connecting page gets,
   so they can add up to more than `push`.
 - `builds`: `chat`, `feed`, `timeline`, each with `cached`, `built`, `ms`.
-  `chat` also carries `active_built` and `bg_built` (rebuilds of the watched
-  tab, served while its exact key holds, against rebuilds of a background tab
-  whose signature moved) and `bg_miss`, a map from each labelled component of
-  the chat-build signature (`transcript`, `states`, `judge_gen`, `tasks`,
-  `cut`, `row`, plus `cold` for a tab with no cached build and `nosig` for
-  one whose signature could not be taken) to the background rebuilds it
-  caused. A rebuild with several moved components counts under each, so the
-  map's sum can exceed `bg_built`. `romp perf` prints the split and the
-  non-zero causes after the chat average.
+  Every chat tab, the watched one included, is served from its cached build
+  while one complete per-session signature holds: one component per input the
+  build reads (the transcript and states files, the session's goal store and
+  its journal and archive, the task store, the backend's live tail by
+  revision, its queue and brackets, the liveness row, the clock crossings the
+  payload renders, the parked ops, the account hold behind a queued bubble,
+  the retry state, the live background-task rows, the watches, the awaiting
+  stamp, the shared files, the cwd's branch and repository, the instruction
+  files, and the files and postal values the last build embedded). `chat`
+  also carries `active_built` and `bg_built` (rebuilds of the watched tab
+  against rebuilds of a background tab), `moved` (builds not cached because
+  an input moved while they ran; the next cycle builds them again) and
+  `bg_miss`, a map from each labelled component of that signature
+  (`transcript`, `states`, `store`, `hold`, `archive`, `episodes`, `reg`,
+  `gone`, `tasks`, `cut`, `live`, `row`, `clock`, `backend`, `ops`, `limit`,
+  `retry`, `bg`, `watch`, `stamp`, `anchors`, `downtime`, `names`, `flags`,
+  `ncards`, `colormap`, `acct`, `cleared`, `host`, `cwd`, `claudemd`, `fork`,
+  `taskout`, `pathlink`, `postal`, plus `cold` for a tab with no cached
+  build and `nosig` for one whose signature could not be taken) to the
+  background rebuilds it caused. A rebuild with several moved components
+  counts under each, so the map's sum can exceed `bg_built`. One session's
+  goal-store publish moves that session's `store` component and no other
+  tab's; the judge-pass generation busts the feed and timeline caches only.
+  `romp perf` prints the split and the non-zero causes after the chat
+  average, and the moved count when it is non-zero.
 - `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
   `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
   was built and compared, then not sent.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -171,6 +171,20 @@ def _process_stats():
             "pid": os.getpid()}
 
 
+# The chat-build signature's components, in the order _chat_build_sig appends them. One label per position:
+# the signature is a flat tuple of exactly this length, so a miss is attributed by comparing positions
+# (_chat_sig_miss) and /perf's builds.chat.bg_miss carries one counter per label. The last three
+# (_CHAT_SIG_DEPS) are the build-time dependencies a cached build recorded (_chat_build_deps), re-evaluated
+# per cycle over that record. _chat_build_sig's docstring says what each component is;
+# tests/test_chat_build_sig_inputs.py maps every read build_session makes to one of them.
+_CHAT_SIG_LABELS = ("transcript", "states", "store", "hold", "archive", "episodes", "reg", "gone", "tasks", "cut",
+                    "live", "row", "clock", "backend", "ops", "limit", "retry", "bg", "watch", "stamp", "anchors",
+                    "downtime", "names", "flags", "ncards", "colormap", "acct", "cleared", "host",
+                    "cwd", "claudemd", "fork",
+                    "taskout", "pathlink", "postal")
+_CHAT_SIG_DEPS = ("taskout", "pathlink", "postal")
+
+
 class _PerfStats:
     """Always-on counters behind GET /perf (`romp perf`): where the kernel's threads spend their time,
     kept cheap enough to leave running. Every writer takes the lock and does a few dict operations;
@@ -211,13 +225,15 @@ class _PerfStats:
                                    from the build cache vs rebuilt, and the rebuild time. feedJson is
                                    GET /feed.json's own reads (_pure_feed), kept apart from `feed`,
                                    the pusher's (review find, 2026-09-08). chat also carries
-                                   active_built / bg_built (rebuilds of the watched tab, served while
-                                   its exact key holds, against rebuilds of a background tab whose
-                                   signature moved) and bg_miss {transcript, states, judge_gen, tasks,
-                                   cut, row, cold, nosig}: per labelled _chat_build_sig component, the
-                                   background rebuilds it caused (one count per differing component,
-                                   so the sum can exceed bg_built; cold = no cached build, nosig = no
-                                   signature could be taken); see build_chat
+                                   active_built / bg_built (rebuilds of the watched tab against
+                                   rebuilds of a background tab, every tab served on the one complete
+                                   signature while it holds), moved (builds not cached because the
+                                   signature moved during the build: an anchor learned, a file
+                                   landing mid-build) and bg_miss, one counter per _CHAT_SIG_LABELS
+                                   label plus cold and nosig: per component, the background rebuilds
+                                   it caused (one count per differing component, so the sum can
+                                   exceed bg_built; cold = no cached build, nosig = no signature could
+                                   be taken); see build_chat
       sends                        full / delta / deduped -> {slot: {count, bytes}} per dedup-slot
                                    name (chat, feed, bars, taborder, ...; at most SLOTS names, the rest
                                    under "other"). A deduped frame was built and compared, not sent
@@ -270,9 +286,9 @@ class _PerfStats:
     SLOTS = 32
     STAGES = ("jobs", "push", "push.chat", "push.feed", "push.timeline", "push.send")
     BUILDS = ("chat", "feed", "timeline", "feedJson", "thread")
-    # builds.chat's bg_miss labels: _chat_build_sig's components (the transcript and states sections, then
-    # _CHAT_SIG_TAIL), a tab with no cached build, and a tab whose signature could not be taken
-    CHAT_MISS = ("transcript", "states", "judge_gen", "tasks", "cut", "row", "cold", "nosig")
+    # builds.chat's bg_miss labels: _chat_build_sig's components, a tab with no cached build, and a tab whose
+    # signature could not be taken
+    CHAT_MISS = _CHAT_SIG_LABELS + ("cold", "nosig")
     SEND_KINDS = ("full", "delta", "deduped")
 
     def __init__(self):
@@ -289,7 +305,7 @@ class _PerfStats:
             self.ring = collections.deque(maxlen=self.RING)
             self.stages = {k: 0.0 for k in self.STAGES}
             self.builds = {k: {"cached": 0, "built": 0, "ms": 0.0} for k in self.BUILDS}
-            self.builds["chat"].update({"active_built": 0, "bg_built": 0,
+            self.builds["chat"].update({"active_built": 0, "bg_built": 0, "moved": 0,
                                         "bg_miss": {k: 0 for k in self.CHAT_MISS}})   # see build_chat
             self.sends = {k: {} for k in self.SEND_KINDS}
             self.judge = {"passes": 0, "ms_sum": 0.0, "ms_last": 0.0, "cpu_ms_sum": 0.0}
@@ -367,6 +383,13 @@ class _PerfStats:
             bm = b["bg_miss"]
             for lab in miss:
                 bm[lab] = bm.get(lab, 0) + 1
+
+    def build_chat_moved(self):
+        """A chat build whose signature moved while it ran (the post-build signature differs from the
+        pre-build one on a static component): the payload is not cached, the next cycle builds it again,
+        and this counts the cost so a tab that never settles shows up in /perf."""
+        with self.lock:
+            self.builds["chat"]["moved"] += 1
 
     def send(self, key, kind, nbytes):
         slot = key[0] if isinstance(key, tuple) else key
@@ -8215,12 +8238,12 @@ def _auto_resume_retry(now, tmux):
     Delivery (the two auto-pause siblings above do the same): no inline push from this thread.
     _set_retry_paused ends in _mark_views_dirty, which stamps the dirty mark and sets _pusher_wake, so
     the pusher's next cycle rebuilds past the mark and its globalRetryPaused frame (sent to every chat
-    client on every push) carries the flip, one cycle start after the write, sub-second; the active
-    tab's key stats retry-paused.json as well (_ACTIVE_SIG_FILES), so the queued-hold reason follows on
-    that same push. The inline _push_all that used to end this branch spared no rebuild — the next
-    cycle's dirty-forced build is the same one — and cost a second push's fixed work per flip. A
-    BACKGROUND chat tab's queued-hold reason still waits for its own key to move (_chat_build_sig folds
-    neither the flag's file nor the dirty mark): pre-existing, unchanged. The re-arm below is a store
+    client on every push) carries the flip, one cycle start after the write, sub-second; a chat tab
+    with a queued bubble folds the hold by value (_chat_build_sig's limit component), so the
+    queued-hold reason follows on that same push, and a tab with nothing queued renders no hold and
+    reads none. The inline _push_all that used to end this branch spared no rebuild (the next
+    cycle's dirty-forced feed build is the same one) and cost a second push's fixed work per flip.
+    The re-arm below is a store
     write the cards show (a given-up card's summary sentinel goes back to None), made after the flag's
     own stamp, so it marks the views dirty itself: the write is the new information."""
     if not _retry_paused_on():
@@ -13430,12 +13453,12 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     SERVED, not rebuilt, while the thread's inputs stand (2026-09-08): this ran a full build_session
     for every non-promoted thread on every pusher cycle — fifty-odd cold reshapes of forked
     transcripts per cycle on an idle box, the single largest slice of the pusher's burn (py-spy: the
-    _comments_frame → _thread_events → build_session → _read_task_store chain). The key is the WATCHED
-    tab's own exact key, _active_chat_sig (transcript and states stats, judge generation, task store,
-    pending cut, the backend's live revision and queue, the snapshot row), falling back to the
-    file-stat _chat_build_sig when the exact one cannot be formed, and the serve yields to _views_dirty
-    like every other served build. A thread with no keyable input (no transcript yet) is built every
-    time, never cached."""
+    _comments_frame → _thread_events → build_session → _read_task_store chain). The key is the chat
+    tabs' own complete signature, _chat_build_sig (transcript and states stats, the store's identity,
+    the task store, the pending cut, the backend's live revision and queue, the snapshot row, the
+    shared files), without the dependency tail (a thread records no build dependencies), plus the
+    thread's own states row; the serve yields to _views_dirty for the dependencies that tail would
+    have carried. A thread with no keyable input (no transcript yet) is built every time, never cached."""
     reg = _thread_reg(tsid)
     if reg.get("forkOf"):
         return []
@@ -13445,9 +13468,7 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     tm = tmux.get(tsid)
     key = None
     try:
-        base = _chat_build_sig(sess, tm)
-        asig = _active_chat_sig(sess, tm, now, base=base) if base is not None else None
-        sig = ("exact", asig) if asig is not None else (("stat", base) if base is not None else None)
+        sig = _chat_build_sig(sess, tm, now, tmux=tmux, deps=False)
         if sig is not None:
             # plus the thread's OWN state rows (review 2026-09-08): the backend writes states/<tsid>.jsonl under
             # the romp sid, while the key above stats states/<fsid>.jsonl for the reg's lastSid (_sdk_sess hands
@@ -13471,7 +13492,9 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     try:
         m = build_session(tsid, now, tmux)
     except Exception:
+        _chat_dep_scope.deps = None                  # a thread records no build dependencies (see _chat_build_deps)
         return []
+    _chat_dep_scope.deps = None
     _PERF_STATS.build("thread", False, time.monotonic() - _t0)
     evs = (m or {}).get("events") or []
     if cut_uuid:
@@ -24827,8 +24850,10 @@ def _read_task_output(of):
     try:
         st = os.stat(of)
     except OSError:
+        _chat_dep_note_taskout(of, None)       # absent: its appearance is a change to the payload that asked
         return ""
     key = (st.st_mtime, st.st_size)
+    _chat_dep_note_taskout(of, key)            # the running chat build's dependency record: stat'd before the read
     hit = _task_out_cache.get(of)
     if hit and hit[0] == key:
         return hit[1]
@@ -24967,10 +24992,15 @@ def _subagent_meta_map(path):
     timer). {} when the directory does not exist (older CLIs wrote no subagent files)."""
     d = _subagents_dir(path)
     try:
-        key = os.stat(d).st_mtime_ns
+        st = os.stat(d)
     except OSError:
         _SUBAGENT_META_CACHE.pop(str(d), None)
+        _chat_dep_note_taskout(str(d), None)              # a running chat build: the directory's absence is a dependency too
         return {}
+    key = st.st_mtime_ns
+    # the running chat build's dependency record (the taskout idiom, _chat_dep_note_taskout): a sidecar landing
+    # moves the directory's mtime, which the next cycle's signature re-stats
+    _chat_dep_note_taskout(str(d), (st.st_mtime, st.st_size))
     hit = _SUBAGENT_META_CACHE.get(str(d))
     if hit is not None and hit[0] == key:
         return hit[1]
@@ -25018,7 +25048,14 @@ def _subagent_file(path, agent_id):
     ap = _subagents_dir(path) / ("agent-%s.jsonl" % agent_id)
     if ap.exists():
         return ap
+    # A miss is a dependency of the chat payload that asked (the taskout idiom, _chat_dep_note_taskout): the
+    # file appearing at its own place, or a sibling fsid's directory gaining one, changes the Agent card.
+    _chat_dep_note_taskout(str(ap), None)
     try:
+        for d in Path(str(path)).parent.iterdir():
+            if d.is_dir():                                # the directory the glob below reads: a file landing in
+                sd = d / "subagents"                      # <sib>/subagents/ moves ITS mtime, not the sibling's
+                _chat_dep_note_taskout(str(sd), _chat_stat_key(str(sd)))
         for cand in Path(str(path)).parent.glob("*/subagents/agent-%s.jsonl" % agent_id):
             return cand
     except OSError:
@@ -25073,6 +25110,7 @@ def _agent_steps(agent_path):
     finished file costs one read, then a stat per build). None when unreadable or empty. Shipped on the
     event as agentSteps + stepsTotal whether the agent runs or has finished (the fold shows the list
     either way); the running preview's clock (agentGist: calls/since/last) rides only while it runs."""
+    _chat_dep_note_taskout(str(agent_path), _chat_stat_key(str(agent_path)))   # a growing agent file moves the key
     try:
         st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step)
     except Exception:
@@ -26509,13 +26547,14 @@ _parse_cache = {}                                # realpath → ((mtime, size, p
 # Built-chat cache (the user 2026-06-24, who found the UI sluggish): the pusher rebuilt EVERY open chat tab on
 # every 0.5s poll — a full transcript reshape into ChatEvent[] AND a json.dumps of the whole chat, per tab,
 # even when nothing changed. With transcripts now tens of MB, that pegged the kernel and starved the
-# webview. Cache each session's built payload + its serialized string, keyed on the transcript+states
-# (mtime,size) — the same trust model as _parse_cache. The ACTIVE tab(s) are served while _active_chat_sig
-# is unchanged (its key carries what no file records: the owning backend's live tail and queue, the snapshot
-# facts, the side files, the clock predicates — 2026-09-03/05); an unchanged BACKGROUND tab reuses the
-# cache on its file-stat + snapshot key → one stat() instead of a reshape+serialize. A real change (or
-# switching to the tab) rebuilds.
-_built_chat = {}                                 # sid → (sig, payload_dict, serialized_str, active_sig, build_started_at)
+# webview. Cache each session's built payload + its serialized string, keyed on ONE complete per-session
+# signature (_chat_build_sig: the transcript and states files, the store's identity, the owning backend's
+# live tail and queue, the snapshot row, the clock booleans, the side files, the build's own recorded
+# dependencies): the same trust model as _parse_cache. Every tab, the watched one included, is served
+# while its signature is unchanged and rebuilt when a component moved; the watched tab used to have a
+# second, exact key beside the background tabs' file-stat one (2026-09-03/05).
+_built_chat = {}                                 # sid → (sig, payload_dict, serialized_str, deps record): one entry per
+#                                                  tab shown, the watched one included, keyed on _chat_build_sig alone
 def _judge_store_fp():
     """Fingerprint of every store a judge pass can WRITE — goal trees, captions, archives, the cleared
     archive and the episode log: (dir, name, mtime_ns, size) per file, from one scandir each. Two equal
@@ -26545,9 +26584,11 @@ _last_judge_fp = [None]   # the stores' fingerprint at the END of the last produ
 def _bump_judge_gen_if_changed(before_fp=None):
     """Advance the judge generation when the judge-written stores changed since the LAST time this looked
     (the end of the previous pass) — not merely during the pass: a kernel-side save between passes (a
-    user's clear or resolve, the awaiting lift, a nudge verdict) moves a store too, and the background
-    chat tabs refresh on this generation alone (review 2026-09-03). `before_fp` is accepted for callers
-    that hold one but the comparison anchor is the previous look. Returns True when it advanced."""
+    user's clear or resolve, the awaiting lift, a nudge verdict) moves a store too, and the feed and
+    timeline view signature refresh on this generation (review 2026-09-03). The chat tabs no longer read
+    it: each tab keys its own store's identity (_chat_build_sig), so one session's publish rebuilds that
+    session's tab and no other. `before_fp` is accepted for callers that hold one but the comparison
+    anchor is the previous look. Returns True when it advanced."""
     cur = _judge_store_fp()
     anchor = _last_judge_fp[0] if _last_judge_fp[0] is not None else before_fp
     _last_judge_fp[0] = cur
@@ -26557,8 +26598,9 @@ def _bump_judge_gen_if_changed(before_fp=None):
     return False
 
 
-_judge_gen = [0]                                 # bumped when a producer pass CHANGED a store → busts the cache when the judge
-                                                 # may have changed goal/caption state without a transcript write
+_judge_gen = [0]                                 # bumped when a producer pass CHANGED a store → busts the feed and timeline
+                                                 # caches when the judge may have changed goal/caption state without a
+                                                 # transcript write (the chat tabs key their own store's identity instead)
 
 # ATOMIC JUDGE-PASS VISIBILITY (the user 2026-06-30): the triage judges (planner → closer → courier →
 # grouper → distiller) each write goals/<sid>.json INCREMENTALLY within one producer pass, and build_feed
@@ -26778,49 +26820,10 @@ def _feed_goals(sid):
 # events holds the last-built events per session; _chat_diff finds the first index that differs from it — the
 # exact point content changed (a new event OR a tool output that just filled an earlier card). Diffing by
 # CONTENT (not a fixed window) is robust to _hydrate_postal turning one event into several cards mid-array.
-def _clock_predicates(sid, tm, now, path=None):
-    """The clock-derived facts build_session renders, as the booleans they resolve to — so a cache key
-    that carries them changes EXACTLY when the rendered payload would (the flip is the event), never on a
-    tick: the faded look at an hour idle (_idle_faded), an interrupt whose 120 s in-flight cap has run
-    out (_interrupting), a model switch whose 20 s cap has (_model_pending_now), a compaction whose 180 s
-    optimistic cap has (_compacting_optimistic), and each live background task past its recorded
-    deadline (em._bg_expired). These are the only reasons an identical-input build can differ."""
-    tm = tm or {}
-    since = tm.get("since") or 0
-    ic = _interrupt_clicked.get(sid)
-    mp = _model_switch_pending.get(sid) or {}
-    cc = _compact_clicked.get(sid)
-    # the live-task set AFTER the build's own expiry filter (_bg_live_norm joins each task's recorded
-    # deadline from the launch ledger and drops the expired ones) — a task expiring is a tid dropping
-    # out of this tuple. The raw snapshot rows carry no deadline, so a predicate over them could never
-    # flip (review 2026-09-03).
-    try:
-        live_ids = tuple(sorted(str(r.get("tid") or "") for r in _bg_live_norm(sid, path) if isinstance(r, dict)))
-    except Exception:
-        live_ids = None
-    return (bool(since) and bool(_idle_faded(tm.get("state") or "", since, now)),
-            bool(since) and (now - since > FADED_S),   # the hour mark itself: the build derives the chip's
-            #                                            state (a stuck 'compacting' overridden, "" → ready),
-            #                                            so key the flip whatever the raw state says
-            bool(ic) and (now - ic > 120),
-            bool(mp) and (now > (mp.get("until") or 0)),
-            bool(cc) and (now - cc > 180),
-            live_ids)
-
-
-_ACTIVE_SIG_FILES = ("sdk/{sid}.json", "sdk", "goals/{sid}.json", "overrides/{sid}.jsonl", "archive/{sid}.json",
-                     "goals-archive/{sid}.json", "captions/{sid}.jsonl", "episodes/{sid}.jsonl", "cleared.jsonl",
-                     "timeline/messages.jsonl", "colormap", "session-flags.json", "notify-cards.json",
-                     "retry-suppressed.json", "auto-nudge.json",
-                     "watches.json", "pr-watches.json",   # the kernel-owned watch set the awaiting box renders
-                     "usage.json",                        # the account limit hold behind the queued bubble
-                     "retry-paused.json")                 # the spend hold the queued bubble renders (review 2026-09-05)
-
-
 def _claudemd_paths(cwd):
     """The CLAUDE.md files _claudemd_docs reads for `cwd`, in load order — the global file, then each project
-    file from the git root down to cwd. Shared with the active-tab key so an edit to any of them is a
-    keyed event, not a silent lag."""
+    file from the git root down to cwd. Shared with the chat-build signature's claudemd component so an edit
+    to any of them is a keyed event, not a silent lag."""
     out = [str(_GLOBAL_CLAUDE_MD)]
     home = os.path.expanduser("~")
     chain = []
@@ -26835,114 +26838,6 @@ def _claudemd_paths(cwd):
         d = parent
     out += [os.path.join(dd, "CLAUDE.md") for dd in reversed(chain)]
     return out
-
-
-def _external_sig(sid, path=None):
-    """(stat, …) of the inputs OUTSIDE the state root that build_session renders: the account file the
-    billing badge reads; the HEAD files of the git trees its branch rows read — the registered cwd's
-    tree AND the tree of the last edited file (the per-session worktree, under this repo's convention),
-    both resolved through _tree_of exactly as the build does, so a subdirectory cwd keys its repo's
-    HEAD too; the CLAUDE.md chain (the docs card); and the output file of every running background
-    task, whose tail the task box shows live. cwd falls back to the transcript's own stamp when the
-    registry has none, as the build's does. These are external edits with no romp event; a stat is the
-    honest key (review 2026-09-03). Accepted lag, documented: a path token that becomes a link because a
-    PEER created the file it names re-resolves on the next keyed change, not on the file's creation."""
-    meta = _session_meta(path) if path else {}
-    cwd = _cwd_of(sid) or (meta.get("cwd") if isinstance(meta, dict) else "") or ""
-    paths = [os.path.expanduser("~/.claude.json")]
-    paths += jd._cred.settings_files(cwd or None)       # the settings files' apiKeyHelper decides authBoth (2026-09-08)
-    tops = []
-    for d in (os.path.expanduser(cwd) if cwd else "",
-              os.path.dirname((meta.get("lastEditPath") if isinstance(meta, dict) else "") or "")):
-        if not d:
-            continue
-        try:
-            top = _tree_of(d)[0]
-        except Exception:
-            top = ""
-        if top and top not in tops:
-            tops.append(top)
-    for top in tops:
-        try:
-            hp = _git_head_file(top)
-        except Exception:
-            hp = ""
-        if hp:
-            paths.append(hp)
-    paths += _claudemd_paths(cwd) if cwd else [str(_GLOBAL_CLAUDE_MD)]
-    if path:
-        try:
-            for tk in _bg_scan_cached(path):
-                if isinstance(tk, dict) and tk.get("status") == "running" and tk.get("outputFile"):
-                    paths.append(os.path.expanduser(str(tk["outputFile"])))
-        except Exception:
-            pass
-    out = []
-    for p in paths:
-        try:
-            st = os.stat(p)
-            out.append((st.st_mtime_ns, st.st_size, st.st_ino))
-        except OSError:
-            out.append(None)
-    return tuple(out)
-
-
-def _active_chat_sig(sess, tm, now, base=None):
-    """The exact change key for the WATCHED chat tab (2026-09-03). The active tab used to rebuild on every
-    pusher cycle "by design" — its payload moves with inputs no file records: the SDK live tail, the
-    snapshot facts, the send queue, the compacting/clearing brackets, kernel-side stamps — so the
-    background tabs' file-stat signature could not serve it, and an 80 MB session cost ~0.4-0.9 s of
-    reshape per 0.5 s cycle whether or not anything moved (the offline replay). This key names each of
-    those inputs: _chat_build_sig (transcript/states/judge gen/task store/pending cut) + the backend's live
-    revision, queue, brackets + the snapshot row minus its volatile timestamp + the stat of every side file
-    the build reads + the names registry + the clock predicates that flip the rendered output + the
-    in-flight judge set. Kernel-side stamps that lack a stat are covered by _views_dirty at the serve
-    site (the _cached_feed idiom). None → never cache (no transcript, or an input we cannot key).
-    `base` is the pusher's already-computed _chat_build_sig for this tab (one stat pass, not two)."""
-    base = _chat_build_sig(sess, tm) if base is None else base
-    if base is None:
-        return None
-    sid = str(sess.get("sid") or "")
-    try:
-        snap = json.dumps({kk: vv for kk, vv in (tm or {}).items() if kk != "snapT"}, sort_keys=True, default=str)
-    except Exception:
-        return None
-    # The live tail of the backend that OWNS the session — not only the SDK's (review 2026-09-05: a tmux
-    # session's composer echo and a Codex session's queue live in their own stores, which the build renders
-    # but no file records; keyed on _sdk() alone the watched tmux tab served its last build with the send
-    # missing until some file moved). The SDK backend counts its mutations (live_rev); the others are
-    # digested from exactly what the build reads: each live atom's identity and dropped flag, the queue,
-    # the brackets and the launch error.
-    be = Sessions.backend_for(sid)
-    live = ()
-    if be is not None:
-        try:
-            if hasattr(be, "live_rev"):
-                live = (be.live_rev(sid), tuple(be.pending_queued(sid) or ()), be.compacting(sid), be.clearing(sid))
-            else:
-                atoms = tuple((str(a.get("uuid") or a.get("id") or ""), bool(a.get("dropped")), str(a.get("text") or "")[:64])
-                              for a in (be.live_atoms(sid) or ()) if isinstance(a, dict))
-                le = be.launch_error(sid) if hasattr(be, "launch_error") else None
-                live = (atoms, tuple(be.pending_queued(sid) or ()),
-                        be.compacting(sid) if hasattr(be, "compacting") else None,
-                        be.clearing(sid) if hasattr(be, "clearing") else None, bool(le))
-        except Exception:
-            return None
-    files = []
-    for rel in _ACTIVE_SIG_FILES:
-        try:
-            st = os.stat(jd.STATE / rel.format(sid=sid))
-            files.append((st.st_mtime_ns, st.st_size, st.st_ino))
-        except OSError:
-            files.append(None)
-    try:
-        ext = _external_sig(sid, sess.get("path"))
-    except Exception:
-        return None
-    names = getattr(_live_scope, "names", None)
-    names_key = hash(repr(sorted(names.items()))) if isinstance(names, dict) else None
-    return base + (snap, live, tuple(files), names_key, _clock_predicates(sid, tm, now, sess.get("path")),
-                   jd.active_change(), ext)
 
 
 _prev_chat_events = {}                           # sid → the events list from the previous build (to diff against)
@@ -27168,99 +27063,444 @@ def _chat_diff(prev, cur):
     return i
 
 
-def _chat_build_sig(sess, tm=None):
-    """A cheap (transcript mtime,size, states mtime,size) signature for the chat-build cache — busts on any
-    new content OR a state transition (idle/working), the two things that change a session's chat payload,
-    plus the judge generation, the task store, the pending cut, and — when the caller hands the session's
-    snapshot row `tm` — the facts the build renders from it (state, model, context, effort, subagents, background
-    tasks, pending picks, retry count, connected, spawning). The judge generation used to advance every pass
-    and so rebuilt every background tab within ~3 s whatever changed; it now advances only when a judge-
-    written store moved, so the snapshot digest is what keeps a background tab's chips within one cycle of
-    the truth (review 2026-09-05). What still lags for a BACKGROUND tab until one of those inputs moves: the
-    side files only the active key stats (watches, usage, cleared cards, notify cards) — acceptable for a tab
-    the user isn't looking at; it is rebuilt the moment it becomes the active one. Returns None (→ never
-    cache, always rebuild) if the session has no transcript path or it can't be stat'd. The row is one
-    component either way (None when the caller hands none), so every position of the tuple has a label
-    (_chat_sig_labels) and a background rebuild can be attributed to the components that moved."""
+def _chat_ident(path):
+    """(ino, mtime_ns, size) of a file, or None when it is missing: the identity the chat-build signature
+    folds for a file it names by path (the jd._store_identity shape). Every writer of the files it is used
+    on publishes by rename, so the bytes under an inode never change once it is at its path, and a rewrite
+    that keeps the mtime still moves the inode."""
+    try:
+        st = os.stat(str(path))
+    except OSError:
+        return None
+    return (st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def _names_digest(snap):
+    """The names registry's content as one value for the chat-build signature: a digest of every entry's
+    fields (the snapshot _names_snapshot returns, {sid: tab fields}). build_session reads names in many
+    places (the tab's own name and colour, a fork parent's name, every postal card's peer, every awaited
+    peer), all through the snapshot the thread holds, so one digest over the whole snapshot keys them all;
+    a rename busts every tab once. A function of the CONTENT, not of the thread: a connect push on a
+    handler thread (its own snapshot, _chat_push_scopes_open) and the pusher's next cycle produce the same
+    component for an unchanged registry, so the one warms the other's cache instead of each rebuilding
+    every tab."""
+    return hashlib.sha1(json.dumps(sorted((k, list(v)) for k, v in snap.items()), ensure_ascii=False).encode("utf-8")).hexdigest()
+
+
+def _chat_sig_shared():
+    """The chat-build signature's components that are the same for every tab, read ONCE per push (_push
+    sets _live_scope.chat_shared for its chat loop; a caller outside a push reads them per call): the
+    identities of session-flags.json and notify-cards.json, the colormap name, the login label with the
+    both-bit and the availability half of the Billing choices (_auth_avail_status: on a machine with no
+    labelled login a key or managed-helper flip moves neither the label nor the bit), cleared.jsonl's
+    identity, this host's name, the names snapshot's digest (_names_digest; the thread's snapshot, else one
+    read here) and the count of recorded host suspensions (_downtime, append-only, read by
+    _session_working). A shared file that moves mid-push is read old here and new by that push's builds,
+    which caches new content under the old identity: the next push takes the new identity, misses and
+    rebuilds: one extra build, never a stale hit that lasts."""
+    return {"flags": _chat_ident(jd.STATE / "session-flags.json"),
+            "ncards": _chat_ident(jd.STATE / "notify-cards.json"),
+            "colormap": _colormap(),
+            "acct": (_claude_account_label(), _auth_both(), tuple(sorted(_auth_avail_status().items()))),
+            "cleared": _chat_ident(jd.STATE / "cleared.jsonl"),
+            "host": _self_host(),
+            "names": _names_digest(getattr(_live_scope, "names", None) or _names_snapshot()),
+            "downtime": len(_downtime)}
+
+
+def _chat_push_scopes_open():
+    """Open what the chat loop reads once per push and would otherwise read once per TAB on a thread with
+    no pusher-cycle scope (a connect push on a handler thread): the shared signature components
+    (_chat_sig_shared), the caption-map slot (_msg_summaries_scoped) and the names snapshot (a registry
+    scan per outgoing postal card without it). A pusher cycle already holds the last two, so only the
+    absent ones are opened, and the record says which; _chat_push_scopes_close clears exactly what was
+    opened here, so a cycle's own scopes are never touched. A names snapshot on a handler thread makes
+    that push's postal values one read (the fold's `_scoped`), which is the condition the recorded values
+    rest on, and gives the signature's names digest the same content the pusher's has."""
+    owned = ["chat_shared"]
+    if getattr(_live_scope, "msgsum", None) is None:
+        _live_scope.msgsum = [_MSGSUM_UNSET]
+        owned.append("msgsum")
+    if getattr(_live_scope, "names", None) is None:
+        _live_scope.names = _names_snapshot()
+        owned.append("names")
+    _live_scope.chat_shared = _chat_sig_shared()
+    _live_scope.chat_push_owned = owned
+
+
+def _chat_push_scopes_close():
+    """Clear the scopes _chat_push_scopes_open opened on this thread, and only those. Called after the
+    chat loop, at the top of every _push (a previous push on this thread that raised inside the loop
+    left them set) and in _pusher_cycle's finally."""
+    for k in getattr(_live_scope, "chat_push_owned", None) or ():
+        setattr(_live_scope, k, None)
+    _live_scope.chat_push_owned = None
+
+
+def _claudemd_key(cwd):
+    """The identity of every file _claudemd_docs(cwd) reads: (path, _chat_ident) per file on the chain,
+    the global CLAUDE.md first. The chain is part of the key (which directory first carries a .git
+    decides where the walk stops), because the paths ride along with their identities."""
+    return tuple((p, _chat_ident(p)) for p in _claudemd_paths(cwd))
+
+
+_chat_dep_scope = threading.local()   # .deps = the running build_session's dependency record, per thread
+#                                       (see _chat_build_deps); None for an override render
+
+
+def _chat_dep_note_taskout(of, key):
+    """A reader's report to the running chat build: it read `of` (a task's output file, an agent's
+    transcript, a sidecar directory) under `key`, the (mtime, size) it stat'd BEFORE the read (so a write
+    landing after the stat pairs the old key with new content, and the next signature check misses,
+    never a stale hit); None when the path was absent, so its appearance is a change too. Nothing to
+    report outside a chat build."""
+    d = getattr(_chat_dep_scope, "deps", None)
+    if d is not None:
+        d["task_outs"].append((of, key))
+
+
+_DEPS_UNSET = object()
+
+
+def _chat_build_deps(sid, payload):
+    """The build-time dependencies of a chat payload, taken from the build that just produced it (the
+    per-thread _chat_dep_scope record and the payload's own events) and stored on its _built_chat entry
+    so _chat_build_sig can re-evaluate them every cycle as its three trailing components
+    (_CHAT_SIG_DEPS): the files whose tails the payload embeds, each with the identity it was read under
+    (taskout); the messages whose path tokens are still unresolved (a mention precedes its file, so the
+    build retries them), with the links and pins as rendered (pathlink); and the postal cards, with the
+    log's identity and the embedded values (_postal_card_deps) read from the index and caption map the
+    build hydrated against, never from a fresh read (postal). `at_build` is the three components as this
+    build embedded them, the tail of the signature stored with the entry; the next cycle's
+    _chat_sig_deps evaluates the same record against the world then. A cold tab records its dependencies
+    on its first build and is cached from then on."""
+    sc = getattr(_chat_dep_scope, "deps", None) or {}
+    touts = {}
+    for of, key in sc.get("task_outs") or ():
+        touts.setdefault(of, key)                        # the first identity a build read a file under
+    events = payload.get("events") or []
+    pl = []
+    for ev in events:
+        if ev.get("kind") in ("user", "assistant") and ev.get("uuid") and ev.get("md"):
+            hit = _PATH_LINK_CACHE.get((sid, ev["uuid"]))
+            if hit is not None and hit[1]:               # misses left: retried on every build by design
+                pl.append((ev["uuid"], ev["md"], ev.get("pathLinks"), ev.get("pathPins")))
+    cards = [ev for ev in events if ev.get("kind") == "postal-service"]
+    postal_any = bool(cards) or bool(sc.get("postal_any"))
+    postal = None
+    if postal_any:
+        pk = sc.get("postal_key", _DEPS_UNSET)
+        if pk is _DEPS_UNSET:
+            pk = _chat_postal_key()
+        pidx = sc.get("pidx")
+        msum = sc.get("msum") or _msg_summaries_scoped
+        postal = (pk, _postal_card_deps(cards, pidx if pidx is not None else _postal_index(), msum))
+    pl_at = tuple((u, l, p) for u, _md, l, p in pl)
+    # `pl_check` starts None: the next cycle's signature re-resolves the pending tokens once (the build's
+    # own resolves ran before any pre-check could be taken) and vouches from there (_chat_sig_deps)
+    return {"task_outs": list(touts.items()), "pl_pending": [(u, md) for u, md, _l, _p in pl],
+            "pl_at": pl_at, "pl_check": None,
+            "postal_any": postal_any, "postal_cards": cards,
+            "at_build": (tuple(touts.items()), pl_at, postal)}
+
+
+def _chat_pl_precheck(sid, pending, prev=None):
+    """What a tab's pending path tokens (`pending`: the (uuid, md) pairs _chat_build_deps recorded) could
+    resolve into, as a key over exactly the filesystem state _resolve_path_token reads: the session's cwd
+    (a token resolves relative to it), the repo-index key (tiers 2 and 3 answer from _repo_file_index,
+    memoized on that key, so the same key is the same index and the same candidates), each message's
+    candidate directories (tier 1's `cwd/token` and the one tier-2/3 candidate's directory, where a file
+    appearing moves the directory's mtime, and a directory that does not exist yet reads None until it
+    does) and the identity of every such directory. Outside a git tree the repo key is a constant (tiers
+    2 and 3 cannot answer there, and asking would fork git per call), so only the tier-1 directories
+    decide. Returns (cwd, k, per_msg, idents): per_msg maps a message's uuid to its sorted candidate
+    directories, idents each directory to its _chat_ident. `prev` is the record's last key: while the cwd
+    and the repo key hold, the candidate directories are the same strings and are reused, so a cycle
+    costs one tree scandir and one stat per distinct directory. None when it cannot vouch (a tree that
+    cannot be scanned): the caller re-resolves everything, as every build did before. Per DIRECTORY,
+    because a transcript's mentions name busy places too (a state directory, a log directory): with one
+    key over all of them, one churning directory re-resolved every token of the tab each cycle."""
+    cwd = _cwd_of(sid)
+    in_tree = bool(cwd) and bool(_tree_of(cwd)[0])       # outside a git tree `git ls-files` fails: tiers 2/3 stand down
+    k = _repo_index_key(cwd) if in_tree else ("notree",)
+    if k is None:
+        return None
+    if prev is not None and prev[0] == cwd and prev[1] == k:
+        per_msg = prev[2]
+    else:
+        hit = _repo_index_cache.get(cwd) if in_tree else None
+        idx = (hit[1] if hit is not None and hit[0] == k else _repo_file_index(cwd)) if in_tree else None
+        per_msg = {}
+        for u, md in pending:
+            ent = _PATH_LINK_CACHE.get((sid, u))
+            toks = ent[1] if ent is not None else tuple(t for t in _path_tokens(md) if not t.lower().startswith("file://"))
+            mdirs = set()
+            for tok in toks:
+                ap = os.path.expanduser(str(tok))
+                if not os.path.isabs(ap) and cwd:
+                    ap = os.path.join(cwd, ap)
+                if os.path.isabs(ap):
+                    mdirs.add(os.path.dirname(ap))
+                if idx is not None:
+                    cands = idx.get(tok.rsplit("/", 1)[-1]) or []
+                    if "/" in tok:
+                        cands = [c for c in cands if c == tok or c.endswith("/" + tok)]
+                    if len(cands) == 1:
+                        mdirs.add(os.path.dirname(os.path.join(cwd, cands[0])))
+            per_msg[u] = tuple(sorted(mdirs))
+    dirs = set()
+    for ds in per_msg.values():
+        dirs.update(ds)
+    # one stat per distinct directory per PUSH: tabs in one tree name the same directories, and the push's
+    # shared slot (_chat_sig_shared) carries the identities taken so far; a change between two tabs' looks
+    # within a push is seen by the next push, the shared components' own rule
+    shared = getattr(_live_scope, "chat_shared", None)
+    memo = shared.setdefault("dirs", {}) if shared is not None else {}
+    idents = {}
+    for d in dirs:
+        ident = memo.get(d, _DEPS_UNSET)
+        if ident is _DEPS_UNSET:
+            ident = memo[d] = _chat_ident(d)
+        idents[d] = ident
+    return (cwd, k, per_msg, idents)
+
+
+def _chat_sig_deps(sid, deps):
+    """The three dependency components evaluated NOW over a cached build's record (_chat_build_deps):
+    each recorded file re-stat'd (taskout); each pending path token re-resolved with its pins (the retry
+    the build ran per pass before, moved into the key), except that a message none of whose candidate
+    directories moved since the record's answers were verified (_chat_pl_precheck) keeps those answers,
+    and only the messages a moved directory could have resolved are re-resolved (pathlink); and the
+    postal cards' embedded values re-read from the current index and caption map beside the log's
+    identity (postal). No record (a cold tab) → the empty components, which a first build's record then
+    replaces. The pre-check is taken BEFORE the re-resolve and stored on the record only when every
+    answer held (stat-then-read): a file landing between the two is seen by the resolve, one landing
+    after moves the next pre-check."""
+    if not deps:
+        return ((), (), None)
+    touts = tuple((of, _chat_stat_key(of)) for of, _k in deps["task_outs"])
+    pl = ()
+    if deps["pl_pending"]:
+        prev = deps.get("pl_check")
+        at = deps.get("pl_at") or ()
+        pre = _chat_pl_precheck(sid, deps["pl_pending"], prev)
+        redo = None                                      # None: every message
+        if pre is not None and prev is not None and pre[0] == prev[0] and pre[1] == prev[1] \
+                and len(at) == len(deps["pl_pending"]):
+            moved = {d for d, ident in pre[3].items() if prev[3].get(d, _DEPS_UNSET) != ident}
+            redo = {u for u, ds in pre[2].items() if prev[2].get(u) != ds or any(d in moved for d in ds)}
+        out, memo = [], {}                               # memo: _resolve_path_token's per-sid cwd and repo index
+        for i, (u, md) in enumerate(deps["pl_pending"]):
+            if redo is not None and u not in redo:
+                out.append(at[i])                        # no candidate directory moved: the recorded answer holds
+            else:
+                out.append((u, _path_links(md, sid, u, memo), _path_pins(sid, u) or None))
+        pl = tuple(out)
+        if pre is not None and pl == at:
+            deps["pl_check"] = pre                       # every answer holds under this state: vouch from here
+    postal = None
+    if deps["postal_any"]:
+        # the caption map through the cycle's slot on the pusher (_msg_summaries_scoped): the same map every
+        # build of the cycle hydrates against, one fetch per cycle; a handler thread reads it fresh
+        postal = (_chat_postal_key(), _postal_card_deps(deps["postal_cards"], _postal_index(), _msg_summaries_scoped))
+    return (touts, tuple(pl), postal)
+
+
+def _chat_build_sig(sess, tm=None, now=None, tmux=None, deps=None):
+    """The chat-build cache's signature: one component per input build_session reads that can change a
+    tab's payload, in _CHAT_SIG_LABELS order (tests/test_chat_build_sig_inputs.py maps every read
+    build_session makes to one of them). Every tab, the watched one included, is served from _built_chat
+    while this is unchanged, so the rule is the memo rule: a cached payload may only be what the uncached
+    build would return NOW, which holds when every input is in the key: by identity (a file's stat), by
+    value (a small in-memory input), by revision (the live tail, the warm-anchor table), by digest (the
+    names registry) or as the boolean a clock crossing produces (so the key moves exactly at the
+    crossing). Until this key the background tabs folded the global judge-pass counter (_judge_gen) as a
+    proxy for the judge's outputs, so one session's goal-store publish rebuilt every other tab
+    byte-identical, and the watched tab had a second key of its own (an exact key beside a file-stat one)
+    with a start-keyed dirty watermark for the in-memory stamps neither key named; the proxy and the
+    second key are gone and the inputs are named.
+
+    `tm` is the session's liveness row (the push hands the row it holds; None reads it from `tmux`),
+    `tmux` the liveness map the build will read (None reads the thread's snapshot, else a fresh one) and
+    `now` the push's clock. The map is served to every nested liveness read for the duration (_serve_live),
+    so the row, the task rows and the awaiting sources read the same snapshot the build will. `deps` is the
+    cached build's dependency record (_chat_build_deps; None reads the tab's own entry): the three trailing
+    components re-evaluate what that build embedded. Returns None only when the session has no transcript
+    path at all; a transcript that does not exist yet is a component (None), so a just-created session
+    caches like any other. `deps=False` appends the three components EMPTY: for a signature whose
+    dependency tail is discarded (every post-build signature, compared on the static components only)
+    the re-evaluation (stats, token resolves, card values) is skipped; every pre-build signature evaluates
+    it, since every tab checks the cache. The components shared by every tab come from _chat_sig_shared,
+    once per push. The session chip is NOT a component: it is a function of components that are (the
+    parse and live tail, the row, the backend brackets, the clock booleans, the task rows, the watches,
+    the states overlay, the store), so the build derives it once and the key derives nothing twice."""
     path = sess.get("path")
     if not path:
         return None
-    try:
-        st = os.stat(path)
-        sig = [st.st_mtime, st.st_size]
-    except OSError:
-        return None
+    sid = str(sess.get("sid") or "")
     fsid = os.path.basename(path).rsplit(".", 1)[0]   # transcript filename stem == the fsid
-    # Fold in EVERY states file that can change this payload. The fsid is not always the key the state
-    # transitions are written under: a session that forked (a resume/clear mints a new transcript) keeps
-    # writing states/<anchor>.jsonl while its lane is keyed by the new fsid, so a states/<fsid>.jsonl stat
-    # silently fell to [0,0] and no settle EVER busted that lane's cache. Since a settle writes only to
-    # states/ (never the transcript), a forked lane's chat could latch "working" until the next transcript
-    # write (the user 2026-07-28; verified live: two live sessions had a states file under their identity
-    # id and none under the fsid their lane was keyed by). Stat both and keep the pair.
-    for _k in dict.fromkeys([fsid, str(sess.get("anchor") or "")]):
-        if not _k:
-            continue
+    if now is None:
+        now = int(time.time())
+    if tmux is None:
+        tmux = _tmux_sessions()
+    if tm is None:
+        tm = tmux.get(sid)
+    # the handed map is served to every nested liveness read for the duration (_bg_live_norm, the awaiting
+    # sources, the watch rows), so the components read the snapshot the build will; a pusher cycle's own
+    # scope is already set and left alone
+    with _serve_live(tmux):
+        shared = getattr(_live_scope, "chat_shared", None) or _chat_sig_shared()
+        if deps is None:
+            _hit = _built_chat.get(sid)
+            deps = _hit[3] if _hit is not None and len(_hit) > 3 else None
+        be = Sessions.backend_for(sid)
+        sig = []
+        # transcript: (mtime, size), or None while the file does not exist yet (a just-created session).
         try:
-            ss = os.stat(jd.STATESDIR / (_k + ".jsonl"))
-            sig += [ss.st_mtime, ss.st_size]
+            st = os.stat(path)
+            sig.append((st.st_mtime, st.st_size))
         except OSError:
-            sig += [0, 0]
-    sig.append(_judge_gen[0])     # a judge pass (goal/caption change) busts every tab's cache once
-    sig.append(_task_store_fp(fsid))   # a store update (incl. a subagent completing a task) refreshes the to-do card
-    # a pending DELETE rollback changes the payload with NO transcript write (the parse-cache lesson,
-    # one level up): without this a BACKGROUND tab's cached, uncut payload keeps pushing the deleted
-    # tail until the file next changes. Cheap: live SDK sessions answer from memory, no I/O.
-    _be = _sdk()
-    sig.append(_be.pending_cut(sess.get("sid") or "") if _be else "")
-    # the push's row for this sid (its live facts), ONE component either way so the tail keeps a fixed
-    # length for _chat_sig_labels: None when the push has no row for the sid (2026-09-09)
-    t = tm
-    sig.append(None if t is None else
-               (t.get("state"), t.get("model"), t.get("context"), t.get("effort"), t.get("mode"), t.get("fast"), t.get("since"),
-                len(t.get("subagents") or ()), len(t.get("bgTasks") or ()), bool(t.get("interrupting")),
-                bool(t.get("modelPending")), bool(t.get("effortPending")), bool(t.get("authPending")),
-                int(t.get("retryCount") or 0), bool(t.get("connected")), bool(t.get("spawning")),
-                t.get("auth"), t.get("authLive")))
-    return tuple(sig)
-
-
-# The labels of _chat_build_sig's components after the two transcript values and the per-states-file pairs,
-# in append order. The sig stays a flat tuple (its callers compare it whole), so the labels are derived from
-# the tuple's SHAPE: the states section is the only one whose length varies (one or two files, two values
-# each); the head and the tail are fixed. A component appended to _chat_build_sig must be appended here too
-# and to _PerfStats.CHAT_MISS; tests/test_chat_fixed_cost_memos.py pins the three against each other.
-_CHAT_SIG_TAIL = ("judge_gen", "tasks", "cut", "row")
-
-
-def _chat_sig_labels(sig):
-    """One label per position of a _chat_build_sig tuple (see _CHAT_SIG_TAIL)."""
-    n_states = len(sig) - 2 - len(_CHAT_SIG_TAIL)
-    return ("transcript", "transcript") + ("states",) * max(n_states, 0) + _CHAT_SIG_TAIL
+            sig.append(None)
+        # states: EVERY states file that can change this payload, one (mtime, size) each. The fsid is not
+        # always the key the state transitions are written under: a session that forked (a resume/clear
+        # mints a new transcript) keeps writing states/<anchor>.jsonl while its lane is keyed by the new
+        # fsid, so a states/<fsid>.jsonl stat alone let a forked lane's chat latch "working" until the next
+        # transcript write (the user 2026-07-28; verified live). Stat both and keep the pair.
+        states = []
+        for _k in dict.fromkeys([fsid, str(sess.get("anchor") or "")]):
+            if not _k:
+                continue
+            try:
+                ss = os.stat(jd.STATESDIR / (_k + ".jsonl"))
+                states.append((ss.st_mtime, ss.st_size))
+            except OSError:
+                states.append(None)
+        sig.append(tuple(states))
+        # store: the LIVE identity of what load_goals_shared reads for this sid: the store, its override
+        # journal and its goals-archive (jd._store_identity, stat-then-read order). build_session reads the
+        # live store (the ledger tree, the seams, the awaiting stamps, the recent tops), so a publish busts
+        # the tab at once, mid-pass included, and no other tab.
+        sig.append(jd._store_identity(sid)[1:])
+        # hold: an armed rewind filters the store's view per build (_apply_rewind_hold) and bypasses memos.
+        _hold = _rewind_hold_get(sid)
+        sig.append((_hold.get("cutT"), _hold.get("leaf"), _hold.get("at")) if _hold else None)
+        sig.append(_chat_ident(jd.ARCHDIR / (sid + ".json")))         # archive: the ledger headline
+        sig.append(_chat_ident(jd.EPIDIR / (sid + ".jsonl")))         # episodes: the note floor, the boundary card
+        sig.append(_chat_ident(jd.STATE / "sdk" / (sid + ".json")))   # reg: forkedFrom, alive, bgLedger, spawnedAt, cwd
+        sig.append(_chat_ident(jd.GONEDIR / (sid + ".json")))         # gone: the death marker behind the spawn epoch
+        sig.append(_task_store_fp(fsid))   # a store update (incl. a subagent completing a task) refreshes the to-do card
+        # a pending DELETE rollback changes the payload with NO transcript write (the parse-cache lesson,
+        # one level up): without this a BACKGROUND tab's cached, uncut payload keeps pushing the deleted
+        # tail until the file next changes. Cheap: live SDK sessions answer from memory, no I/O.
+        _be = _sdk()
+        sig.append(_be.pending_cut(sess.get("sid") or "") if _be else "")
+        # live: the in-memory tail's revision (Sessions.live_rev): the SDK stream's atoms ahead of the disk,
+        # the input echoes, their dropped/landed flags: by count of changes, never by hashing the atoms.
+        sig.append(Sessions.live_rev(sid, be))
+        # row: the liveness row the build reads (state, since, model, effort, mode, the badges, the live
+        # subagent and task sets, spawning, retry info), minus snapT (a per-snapshot stamp that moves every
+        # cycle) and interrupting (read only through _interrupting, whose boolean is folded below); with
+        # whether the map holds anything at all (the no-tmux fallback status when the row is missing).
+        sig.append(({k: v for k, v in tm.items() if k not in ("snapT", "interrupting")} if tm else None, bool(tmux)))
+        # clock: the booleans the clock decides, so the signature moves exactly at each crossing and at no
+        # other tick: the interrupt stamp's 120 s cap and its settle (_interrupting, which pops the stamp
+        # exactly as the build's call would), the model-switch stamp's 20 s cap (_model_pending_now), the
+        # faded look's hour (_idle_faded, asked as if the chip read ready: when it does not, the payload
+        # ignores the answer and a flip costs one rebuild at the crossing), and the compact click's 180 s
+        # cap (_compacting_optimistic). The two stamp-keyed ones need the parse only while a stamp is armed.
+        _t0 = _interrupt_clicked.get(sid)
+        _c0 = _compact_clicked.get(sid)
+        _pz = _parse(path, sid, now) if (_t0 is not None or _c0 is not None) else None
+        sig.append((_interrupting(sid, _pz, now, tm) if _t0 is not None else False,
+                    _model_pending_now(sid, tm),
+                    _idle_faded("ready", (tm or {}).get("since"), now),
+                    _compacting_optimistic(sid, _pz, now) if _c0 is not None else False))
+        # backend: the owning backend's in-memory state the build reads by value: the compacting and
+        # clearing brackets, the queue (the SDK's in-memory list; the tmux fold is over the transcript, so
+        # for tmux this repeats a component already held) with each copy's identity beside its text (the
+        # qid and enqueue stamp the build ships on the queued bubble, pending_queued_meta; a pop and an
+        # append of an equal text leave the texts equal and move the ids, so the texts alone would serve a
+        # bubble wearing another copy's id), whether a queued bubble is still recallable, and the CLI's
+        # launch error.
+        try:
+            _bc = be.compacting(sid) if hasattr(be, "compacting") else None
+        except Exception:
+            _bc = None
+        queued = tuple(be.pending_queued(sid))
+        try:
+            _qmeta = tuple(((m or {}).get("qid"), (m or {}).get("qts")) for m in (be.pending_queued_meta(sid) or ())) \
+                if hasattr(be, "unqueue") and hasattr(be, "pending_queued_meta") else None
+        except Exception:
+            _qmeta = None
+        sig.append((_bc, _clearing_now(sid), queued, _qmeta,
+                    _queue_recallable(be, sid) if hasattr(be, "unqueue") else None, _launch_error(sid)))
+        # ops: the ops parked for this session while it compacts or is held (the kernel FIFO), by value.
+        ops = tuple(tuple(o) for o in (_pending_ops.get(sid) or ()))
+        sig.append(ops)
+        # limit: the account-level hold the queued bubble names (_limit_hold: usage windows and their reset
+        # clock, the spend pause, a limit-shaped launch error), by value, read whenever the build can render
+        # a queued bubble: something queued or parked, or on a tmux backend an input echo still in flight,
+        # which the build folds into the queue while the session is busy. None otherwise, and the build
+        # never asks.
+        _echoes = bool(be.live_atoms(sid)) if not hasattr(be, "unqueue") else False
+        sig.append(_limit_hold(sid) if (queued or ops or _echoes) else None)
+        # retry: the per-session auto-retry state the status carries (suppressed; the ladder's count and
+        # next-attempt time).
+        sig.append((_session_retry_suppressed(sid),) + tuple(_retry_gate_state(sid)))
+        # bg: the live background-task rows the awaiting sources and the task box read (_bg_live_norm: the
+        # row's task set joined with the reg's launch ledger, the transcript's pairing for a tmux CLI, each
+        # row gone once em._bg_expired says its deadline passed, a clock crossing this fold carries).
+        sig.append(tuple((r.get("tid"), r.get("desc"), r.get("t"), r.get("type"), r.get("deadline"), r.get("agentId"))
+                         for r in _bg_live_norm(sid, path)))
+        # watch: the kernel watches this session registered, as the awaiting source reads them AND as the
+        # payload renders them: beside the why, since, tasks and count, every row's item (its id, the cancel
+        # handle watchId, the predicate as detail, the note as label, its own since; a PR watch's repo and
+        # number). A watch cancelled and re-armed under the same note with a new id or predicate leaves the
+        # (why, since, tasks, count) projection unchanged, so the items are keyed too.
+        _w = _watch_awaiting(sid)
+        sig.append((_w.get("why"), _w.get("since"), tuple(_w.get("tasks") or ()), _w.get("count"),
+                    tuple(tuple(sorted(it.items())) for it in (_w.get("items") or ()))) if _w else None)
+        # stamp: the session's durable awaiting-stamp view (_session_stamp_read: the freshest live stamp, the
+        # stamped tops, the delegation peers), by value through its own memo, which is keyed on the store,
+        # the override journal, the POSTAL LOG (a peer's answer supersedes a peer wait, so mail landing
+        # changes the chip and the awaiting fields of a tab that carries no postal card at all) and the
+        # stamp transcript's cache warmth; a hit costs stats, and the build's own read then hits too.
+        sig.append(_session_stamp_read(sid))
+        # anchors: the warm-anchor table's revision for this sid (_node_anchor_rev): a resolve another
+        # build landed changes a cold node's deep-link anchors. Read here BEFORE the build; a build that
+        # learns an anchor bumps it, and the post-build signature then differs, so that build is not cached
+        # and the next cycle's is (one extra build per anchor learned).
+        sig.append(_node_anchor_rev.get(sid, 0))
+        for _k in ("downtime", "names", "flags", "ncards", "colormap", "acct", "cleared", "host"):
+            sig.append(shared[_k])                          # the shared components, in label order
+        # cwd: the directory-derived rows (the cwd itself: the names entry's, else the transcript's
+        # stamp; its git branch and GitHub repository; the work tree the newest edit names and the
+        # registered tree's top), by value through their own memos, which are keyed on the .git evidence
+        # they rest on and cost stats, never a fork, while it holds.
+        meta = _session_meta(path) or {}
+        scwd = _session_cwd(sid, meta=meta)
+        sig.append((scwd, _git_branch(scwd), _github_repo_of(scwd),
+                    _tree_of(os.path.dirname(meta.get("lastEditPath") or "") or ""),
+                    _tree_of(os.path.expanduser(scwd)) if scwd else ("", "")))
+        sig.append(_claudemd_key(scwd))                     # claudemd: the instruction files on the chain, by identity
+        # fork: the branches that left from this session, by value (fork_children's own memo is keyed on
+        # the sdk/ directory's mtime, which moves at turn rate; the per-sid value moves only when a fork of
+        # THIS session appears, is promoted or is deleted).
+        sig.append((_be.fork_children().get(sid) if _be and hasattr(_be, "fork_children") else None) or None)
+        sig.extend(((), (), None) if deps is False else _chat_sig_deps(sid, deps))   # taskout, pathlink, postal
+        return tuple(sig)
 
 
 def _chat_sig_miss(old, new):
-    """Why a background tab rebuilt: the sorted labels of every _chat_build_sig component that differs
-    between the cached signature `old` and the fresh one `new` (the bg_miss attribution under builds.chat
-    in /perf). No cached build is ("cold",); a fresh signature of None (no transcript path, or one that
-    cannot be stat'd) is ("nosig",). Signatures of different lengths differ in their states section (the
-    session's anchor appeared or went), so that label is set and the fixed head and tail are compared from
-    their own ends."""
+    """Why a tab rebuilt: the sorted labels of every _chat_build_sig component that differs between the
+    cached signature `old` and the fresh one `new` (the bg_miss attribution under builds.chat in /perf).
+    No cached build is ("cold",); a fresh signature of None (no transcript path) is ("nosig",). Both
+    signatures have _CHAT_SIG_LABELS's length, so the compare is by position."""
     if new is None:
         return ("nosig",)
-    if old is None:
+    if old is None or len(old) != len(new):
         return ("cold",)
-    labels = _chat_sig_labels(new)
-    if len(old) == len(new):
-        return tuple(sorted({labels[i] for i in range(len(new)) if old[i] != new[i]}))
-    out = {"states"}
-    for i in range(2):                                 # the head: the transcript's (mtime, size)
-        if old[i] != new[i]:
-            out.add(labels[i])
-    for j in range(1, len(_CHAT_SIG_TAIL) + 1):        # the tail, aligned from the end
-        if old[-j] != new[-j]:
-            out.add(_CHAT_SIG_TAIL[-j])
-    return tuple(sorted(out))
+    return tuple(sorted(lab for lab, a, b in zip(_CHAT_SIG_LABELS, old, new) if a != b))
 
 
 def _parse(path, sid, now):
@@ -30822,6 +31062,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     # live-atom merge, so the optimistic input echo can SUPPRESS any text already shown as queued — the
     # event-based queued indicator owns that case, so no double-show. The kind:"queued" event is appended at
     # the bottom later.
+    # The dependency record this build hands the pusher (_chat_build_deps): every file whose tail the payload
+    # embeds, noted by the readers as they read it (_chat_dep_note_taskout), and whether the payload carries
+    # postal traffic. None for an override render, which is never cached.
+    _chat_dep_scope.deps = None if path_override else {"task_outs": [], "postal_any": False}
     be = Sessions.backend_for(sid)
     queued = [] if path_override else be.pending_queued(sid)   # override = a closed episode; nothing is live
     parsed = _parse(sess["path"], sid, now)
@@ -31061,6 +31305,11 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     if _fold_ok:
         _fk = _fe["n"]
         _chat_fold_count("fold")
+        if _chat_dep_scope.deps is not None:
+            # the sealed prefix's output tails are embedded but not re-read on a fold hit: their
+            # identities join this build's record (the gate above re-stat'd them under these keys)
+            _chat_dep_scope.deps["task_outs"].extend(_fe["task_outs"])
+            _chat_dep_scope.deps["postal_any"] = bool(_fe["postal_raw"])
         events = list(_fe["events"])              # a NEW list of the SAME dicts — never written into (see above)
         _pref_len = len(events)
         uuid2seg, seg_anchors, seg_trig, seg_work = (dict(_fe["seg"][0]), dict(_fe["seg"][1]),
@@ -31474,6 +31723,12 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
         _raw_turn[id(_ev)] = _ti
         if _ev.get("uuid") and _ev["uuid"] not in _raw_turn:
             _raw_turn[_ev["uuid"]] = _ti
+    # A raw postal event that did not hydrate (its message not in the index yet) renders from the log alone and
+    # depends on the postal log, so the signature folds the log's identity even when no card rendered
+    # (_chat_build_deps: postal_any); the record keeps the index and caption map this build hydrated against.
+    if _chat_dep_scope.deps is not None:
+        _chat_dep_scope.deps["postal_any"] = _chat_dep_scope.deps["postal_any"] or any(_chat_postal_relevant(_e) for _e in _raw_tail)
+        _chat_dep_scope.deps["postal_key"], _chat_dep_scope.deps["pidx"], _chat_dep_scope.deps["msum"] = _pk, _pidx, _msum
     events = _hydrate_postal(events, _pidx, sid, captions=_msum)   # swap postal traffic for clean in/out cards (no boilerplate)
     _stamp_interrupt_causes(events)                     # a restart/crash resume notice names the seam's cause
     for ev in events:
@@ -40869,6 +41124,26 @@ _PATH_LINK_CACHE = {}                 # (sid, uuid) -> (links dict, misses tuple
 _repo_index_cache = {}   # cwd -> (key, index) — key = (git-index mtime, toplevel-dir mtime), see below
 
 
+def _repo_index_key(cwd):
+    """The events that change _repo_file_index's answer for `cwd`, as one key: the git INDEX file's mtime,
+    the repo top dir's mtime and the mtimes of the top's immediate subdirs (see _repo_file_index). None when
+    the tree cannot be scanned (the same backstop as _git_branch: no key means an uncached listing, never a
+    raise). Shared with the chat-build signature's pathlink pre-check, which vouches for a message's
+    unresolved tokens only while this key and the message's candidate directories hold."""
+    tree = _tree_of(cwd)[0] or cwd                   # _tree_of returns (toplevel, branch)
+    try:
+        gi = _git_head_file(tree)                    # <gitdir>/HEAD: the index sits beside it
+        subs = []
+        with os.scandir(tree) as it:
+            for e in it:
+                if e.name != ".git" and e.is_dir(follow_symlinks=False):
+                    subs.append((e.name, e.stat().st_mtime))
+        return ((os.path.getmtime(os.path.join(os.path.dirname(gi), "index")) if gi else None),
+                os.path.getmtime(tree), tuple(sorted(subs)))
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
 def _repo_file_index(cwd):
     """basename -> [repo-relative paths] for every tracked or untracked-unignored file under `cwd`,
     or None when there is no list to be had (not a git repo, git absent/failing, or a listing past
@@ -40883,19 +41158,7 @@ def _repo_file_index(cwd):
     fork multipliers behind the Mac 66% CPU burn (2026-08-16). A creation the key can't see (depth
     two or deeper, untracked) only delays that file's tier-2/3 path LINK until the next observable
     touch — a rendering nicety, never data; a click's own resolution is unaffected."""
-    tree = _tree_of(cwd)[0] or cwd                   # _tree_of returns (toplevel, branch)
-    key = None
-    try:
-        gi = _git_head_file(tree)                    # <gitdir>/HEAD — the index sits beside it
-        subs = []
-        with os.scandir(tree) as it:
-            for e in it:
-                if e.name != ".git" and e.is_dir(follow_symlinks=False):
-                    subs.append((e.name, e.stat().st_mtime))
-        key = ((os.path.getmtime(os.path.join(os.path.dirname(gi), "index")) if gi else None),
-               os.path.getmtime(tree), tuple(sorted(subs)))
-    except (OSError, UnicodeDecodeError):   # the same backstop as _git_branch: no key → an uncached listing, never a raise
-        key = None
+    key = _repo_index_key(cwd)
     hit = _repo_index_cache.get(cwd)
     if hit is not None and key is not None and hit[0] == key:
         return hit[1]
@@ -41311,6 +41574,37 @@ def _chat_build_ok(sid):
             _chat_build_faults.pop(str(sid), None)
 
 
+_chat_sig_faults = {}   # sid -> the fault text of its CURRENT signature episode (_chat_sig_fault), the build ledger's twin
+
+
+def _chat_sig_fault(s, exc):
+    """Name a session whose chat-build SIGNATURE raised (one of _chat_build_sig's component reads failed), on
+    stderr with the traceback and as a refused bell row, ONCE per fault episode: _chat_build_fault's rule
+    with its own ledger. The tab still builds (sig None: built every cycle, never cached, counted under
+    nosig), so the pane keeps updating and the cost is the cache; but a fault that stands (a torn state
+    file, a directory that cannot be listed) would otherwise write a full traceback every 0.5-3 s for as
+    long as it lasts. The episode is the fault text; a signature that is taken ends it (_chat_sig_ok)."""
+    sid = str(s.get("sid") or "")
+    text = "%s: %s" % (type(exc).__name__, exc)
+    with _chat_build_faults_lock:
+        if _chat_sig_faults.get(sid) == text:
+            return
+        _chat_sig_faults[sid] = text
+    sys.stderr.write("push build: chat signature %s: %s\n" % (sid[:8], traceback.format_exc()))
+    try:
+        _sync_notice("chat: the pane for %s cannot be cached (%s); it is rebuilt every cycle until the read succeeds"
+                     % (s.get("name") or sid[:8], text), ok=False, kind="refused")
+    except Exception:
+        pass
+
+
+def _chat_sig_ok(sid):
+    """A signature that was taken ends the session's fault episode, so the same fault later is said anew."""
+    if _chat_sig_faults:
+        with _chat_build_faults_lock:
+            _chat_sig_faults.pop(str(sid), None)
+
+
 def _push(targets, connect=False, tmux=None):
     """Build the payloads once (cached parses) and send each target only the pieces that CHANGED for it.
     Drives both the periodic pusher (all clients) and a fresh connect (one client): a new/reconnecting
@@ -41323,6 +41617,7 @@ def _push(targets, connect=False, tmux=None):
         return
     now = int(time.time())
     tmux = _tmux_sessions() if tmux is None else tmux   # one liveness read per push, shared by all builders
+    _chat_push_scopes_close()                     # a previous push on this thread that raised inside the chat loop
     _seen_live.update(tmux)                       # remember who's been alive → keep their tab when they die
     want_chat = any(c["app"] == "chat" for c in targets)
     # The FLEET connects as its OWN app (the user 2026-06-29) so we build its per-session ledgers EVEN when no
@@ -41369,26 +41664,33 @@ def _push(targets, connect=False, tmux=None):
             # dots on a session that had been ready for all of it (the user 2026-08-08).
             build_order = sorted(chat_list, key=lambda s: 0 if s["sid"] in active
                                  or not os.path.exists(s["path"]) else 1)
+            # ONE key for every tab (_chat_build_sig): the watched tab and the background tabs alike are served
+            # from _built_chat while the complete signature holds, and rebuilt when a component moved. The
+            # watched tab used to have a second, exact key beside the background tabs' file-stat one, with a
+            # start-keyed dirty watermark for the in-memory stamps neither key named; every stamp is a
+            # component now, so a bare _mark_views_dirty rebuilds no chat tab (it still busts the feed and the
+            # timeline). The shared components, the caption map and the names snapshot are opened once per
+            # push (_chat_push_scopes_open; a pusher cycle already holds the last two).
+            _chat_push_scopes_open()
+            _nd = len(_CHAT_SIG_DEPS)
             for s in build_order:
-                is_active = s["sid"] in active           # the watched tab(s): rebuilt only when an input moved
-                sig = _chat_build_sig(s, tmux.get(s["sid"]))
+                is_active = s["sid"] in active           # the watched tab(s): served like any tab while the key holds
+                _tm = tmux.get(s["sid"])
+                try:
+                    sig = _chat_build_sig(s, _tm, now, tmux=tmux)
+                    _chat_sig_ok(s["sid"])               # a signature that was taken ends its fault episode
+                except Exception as e:
+                    _chat_sig_fault(s, e)                # once per fault episode: stderr and a bell row
+                    sig = None                           # an input that cannot be keyed: build, never cache
                 hit = _built_chat.get(s["sid"])
-                # The active tab is served from its last build when its EXACT key is unchanged and no
-                # kernel-side mutation postdates that build's start (2026-09-03; before, it rebuilt on
-                # every cycle by design — see _active_chat_sig). Background tabs keep their file-stat key.
-                asig = _active_chat_sig(s, tmux.get(s["sid"]), now, base=sig) if is_active else None
-                if is_active:
-                    fresh = (hit is not None and asig is not None and hit[3] == asig and _views_dirty[0] <= hit[4])
-                else:
-                    fresh = (hit is not None and sig is not None and hit[0] == sig)
-                if fresh:
-                    m, ms, asig, started = hit[1], hit[2], hit[3], hit[4]   # unchanged → reuse, no reshape/serialize
+                post, served, _rec = None, False, None
+                if hit is not None and sig is not None and hit[0] == sig:
+                    m, ms, served = hit[1], hit[2], True   # unchanged → reuse, no reshape/serialize
                     _VIEW_STATS["chatServeActive" if is_active else "chatServeBg"] += 1
                     _perf("chatbuild", sid=str(s["sid"])[:8], cached=1, ms=0, active=int(is_active))
                     _PERF_STATS.build_chat(True)
                 else:
                     _VIEW_STATS["chatBuildActive" if is_active else "chatBuildBg"] += 1
-                    started = time.time()                # the _views_dirty floor for this build (start-keyed)
                     _t0 = time.monotonic()
                     try:
                         m = build_session(s["sid"], now, tmux)
@@ -41400,6 +41702,7 @@ def _push(targets, connect=False, tmux=None):
                         # Said ONCE per fault episode, on stderr and as a dashboard bell row, so the pane
                         # that stopped updating is not a silent degrade (review find, 2026-09-08).
                         _chat_build_fault(s, e)
+                        _chat_dep_scope.deps = None      # the failed build's record is nobody's
                         continue
                     _chat_build_ok(s["sid"])             # a build that succeeds ends its fault episode
                     # The full serialization is LAZY (the 2026-08-10 CPU fix, round two): steady state
@@ -41409,14 +41712,22 @@ def _push(targets, connect=False, tmux=None):
                     # _send_chat materializes it on the first FULL send (a fresh client, a fork) and hands
                     # it back; the post-send cache store below keeps whatever materialized.
                     ms = None
-                    # The ACTIVE tab skips the cache above by design, so this build is what the watched
-                    # session pays on every single push. If chat ever feels slow again, this number and
-                    # the deduped= on the matching send say which half is at fault.
                     _dt = time.monotonic() - _t0
-                    # WHY a background tab rebuilt (2026-09-09): the labelled _chat_build_sig components that
-                    # moved against the cached signature, so /perf can say which input drives the background
-                    # rebuilds; the watched tab rebuilds on its exact key and is counted, not attributed
-                    _miss = () if is_active else _chat_sig_miss(hit[0] if hit is not None else None, sig)
+                    # The build's dependency record (_chat_build_deps) and the POST-build signature: the cache
+                    # entry is stored only when the static components held across the build (an input that
+                    # moved mid-build would otherwise be served stale); the dependency tail is skipped here
+                    # (deps=False) and taken from the record instead, since it was just read by the build.
+                    _rec = _chat_build_deps(s["sid"], m) if (sig is not None and m) else None
+                    _chat_dep_scope.deps = None          # consumed: a reader outside a build must not append to it
+                    if sig is not None:
+                        try:
+                            post = _chat_build_sig(s, _tm, now, tmux=tmux, deps=False)
+                        except Exception:
+                            post = None
+                    # WHY a tab rebuilt (2026-09-09): the labelled _chat_build_sig components that moved
+                    # against the cached signature, so /perf can say which input drives the rebuilds; the
+                    # watched tab's rebuilds are counted under active_built and not attributed
+                    _miss = _chat_sig_miss(hit[0] if hit is not None else None, sig)
                     _PERF_STATS.build_chat(False, _dt, active=is_active, miss=_miss)
                     if _PERF:                            # the keyword values below cost lookups; skip them when off
                         _perf("chatbuild", sid=str(s["sid"])[:8], cached=0, active=int(is_active),
@@ -41434,7 +41745,7 @@ def _push(targets, connect=False, tmux=None):
                     _note_empty_build(s["sid"], s.get("path"), len(_prev_chat_events.get(m["id"]) or ()))
                     if hit is None:
                         continue
-                    m, ms = hit[1], hit[2]
+                    m, ms, _rec = hit[1], hit[2], hit[3]   # the stand-in payload keeps its own dependency record
                 else:
                     _clear_empty_build_note(s["sid"])
                 _note_chat_divergence(s["sid"], m.get("name") or "",
@@ -41468,7 +41779,18 @@ def _push(targets, connect=False, tmux=None):
                 if sig is not None:
                     while len(_built_chat) > 256:        # bounded by the session count; evict oldest-inserted, never clear
                         _built_chat.pop(next(iter(_built_chat)))
-                    _built_chat[s["sid"]] = (sig, m, ms, asig, started)
+                    if served:
+                        _built_chat[s["sid"]] = (hit[0], m, ms, hit[3])
+                    elif post is not None and post[:-_nd] == sig[:-_nd] and _rec is not None:
+                        # the static components held across the build: cached under the pre-build signature
+                        # with the dependency tail AS THIS BUILD EMBEDDED IT (the record's at_build), never
+                        # from a re-read; the record is what the next cycle's signature evaluates
+                        _built_chat[s["sid"]] = (post[:-_nd] + _rec["at_build"], m, ms, _rec)
+                    elif post is not None:
+                        _PERF_STATS.build_chat_moved()   # an input moved mid-build: not cached, built again next cycle
+                        if _PERF:
+                            _perf("chatsig", sid=str(s["sid"])[:8],
+                                  moved=",".join(l for l in _chat_sig_miss(sig, post) if l not in _CHAT_SIG_DEPS))
             shown_sids = {s["sid"] for s in chat_list}
             for sid in list(_built_chat):                # drop cache for tabs no longer shown (closed/×-hidden)
                 if sid not in shown_sids:
@@ -41520,6 +41842,7 @@ def _push(targets, connect=False, tmux=None):
             # OPEN SUBAGENT VIEWERS (plans/subagent-transcripts.md): each rides its own per-client dedup slot
             # like the comment frames, rebuilt only when the agent's file or liveness moved.
             _push_subagents(chat_clients, now, tmux)
+            _chat_push_scopes_close()                    # after the threads' signatures, which read the shared components too
         _PERF_STATS.stage("push.chat", time.monotonic() - _t_stage)
         _t_stage = time.monotonic()
         fsig = _fleet_view_sig(now, tmux) if (want_feed or want_tl) else None
@@ -41630,6 +41953,7 @@ def _push(targets, connect=False, tmux=None):
         _PERF_STATS.stage("push.timeline", time.monotonic() - _t_stage)
     except Exception:
         sys.stderr.write("push build: %s\n" % traceback.format_exc())
+        _chat_push_scopes_close()                 # a raise inside the chat loop must not leave this thread's scopes open
         return
     # Serialize the shared payloads once per BUILD, not per cycle (the 2026-08-10 CPU fix, round
     # three). Round two had brought feed/bars down to one dumps each per cycle — measured on a QUIET
@@ -41822,8 +42146,11 @@ def _push_session_now(sid):
             return                                   # hidden / raced a teardown — the periodic pusher owns the rest
         tab_order = [s["sid"] for s in chat_list]
         tab_meta = [{"id": s["sid"], "name": s.get("name", ""), "color": _name_color(s["sid"])} for s in chat_list]
-        m = build_session(sid, now, tmux)
-        if not m:
+        try:
+            m = build_session(sid, now, tmux)
+        finally:
+            _chat_dep_scope.deps = None              # a targeted push caches nothing: its record is nobody's, and a
+        if not m:                                    # later reader on this thread must not append to it
             return
         if _empty_build_regresses(m, _prev_chat_events.get(sid)):
             _note_empty_build(sid, next((s.get("path") for s in chat_list if s["sid"] == sid), None),
@@ -43452,6 +43779,7 @@ def _pusher_cycle():
         #                                       the finally, or the liveness scope above leaks set
         _pusher_cycle_jobs(now, tmux, any_client)
     finally:
+        _chat_push_scopes_close()
         _live_scope.snapshot = None
         _live_scope.names = None
         _live_scope.paths = None
@@ -51160,7 +51488,10 @@ class Handler(BaseHTTPRequestHandler):
             try:
                 sid = str(msg["id"]); before = int(msg.get("before") or 0)
                 if before > 0:
-                    m = build_session(sid, int(time.time()))
+                    try:
+                        m = build_session(sid, int(time.time()))
+                    finally:
+                        _chat_dep_scope.deps = None   # a slice for one client caches nothing (see _chat_build_deps)
                     evs = (m or {}).get("events") or []
                     if evs:
                         before = min(before, len(evs)); frm = max(0, before - WIRE_CHUNK)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16576,6 +16576,11 @@ class TmuxBackend(sb.SessionBackend):
     def live_atoms(self, sid):
         return _tmux_echo_atoms(str(sid))
 
+    def live_rev(self, sid):
+        """The sid's echo-store revision (_tmux_echo_rev): the chat-build signature's live-tail component for
+        a tmux session, the twin of SdkBackend.live_rev. 0 until the first echo, one more per change."""
+        return _tmux_echo_rev.get(str(sid), 0)
+
     def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
         # The floor never PRUNES a plain tmux echo: it must SURVIVE a later turn to keep a dropped send
         # visible, so retirement stays text/uuid-only. It does SETTLE it — an echo the transcript has
@@ -16603,6 +16608,7 @@ class TmuxBackend(sb.SessionBackend):
                 continue
             if (uuid is not None and k == uuid) or (t is not None and int(a.get("t") or 0) == t):
                 d.pop(k, None)
+                _tmux_echo_bump(str(sid))                 # the dismissal is a change to the tail
                 if not d:
                     _tmux_echo.pop(str(sid), None)
                 return a.get("_echo_text")
@@ -16937,6 +16943,23 @@ class Sessions:
                 sys.stderr.write("codex live_sessions merge: %s\n" % traceback.format_exc())
         _unify_model_labels(out)
         return out
+
+    @staticmethod
+    def live_rev(sid, be=None):
+        """The revision of the sid's live tail (the atoms live_atoms merges ahead of the transcript) as a
+        value that changes on every change to the tail (an add, a prune, a settle mark, a dismiss, a flag
+        write, a reworded echo) and only then, so the chat-build signature can key a tab on its tail
+        without hashing the atoms per cycle. The SDK and tmux backends count (SdkBackend.live_rev via
+        _touch_live; TmuxBackend.live_rev via _tmux_echo_bump). A backend with no counter (the Codex
+        backend, whose live_atoms builds fresh dicts from a short per-session list; a test fake) answers
+        with the tail's serialized value instead: exact, and small for the list-shaped tails those keep.
+        `be`: the owning backend when the caller already resolved it (the chat-build signature)."""
+        if be is None:
+            be = Sessions.backend_for(sid)
+        fn = getattr(be, "live_rev", None)
+        if fn is not None:
+            return fn(str(sid))
+        return json.dumps(be.live_atoms(str(sid)), sort_keys=True, default=str)
 
     # coordination — the working-note ("what I'm working on" ownership claim list_agents shows) lives in ONE
     # backend-agnostic kernel store (working/<sid> files), so both backends publish it and the postal bus
@@ -30176,6 +30199,19 @@ def _echo_landed_in(text, tx_texts):
 # turn lands. A SUCCESSFUL send's echo prunes when the turn writes; a DROPPED send's echo PERSISTS, so the
 # lost message stays visible (no response) instead of vanishing silently.
 _tmux_echo = {}                                       # sid -> {key -> synthetic user atom}
+_tmux_echo_rev = {}                                   # sid -> the store's revision, advanced by _tmux_echo_bump at
+#                                                       every change to the sid's echoes (an add, a prune, a settle
+#                                                       mark, a dismiss): the chat-build signature's live-tail
+#                                                       component for tmux sids (Sessions.live_rev), the twin of
+#                                                       SdkBackend._touch_live
+
+
+def _tmux_echo_bump(sid):
+    """Advance the sid's echo-store revision (_tmux_echo_rev), after the write it records. Only a change calls
+    it (an add, a pop, a `dropped` mark); a prune or settle that touched nothing leaves the revision alone,
+    so a chat build's own merge never moves the signature under it (the SDK backend's _touch_live rule)."""
+    _tmux_echo_rev[sid] = _tmux_echo_rev.get(sid, 0) + 1
+
 
 def _tmux_echo_add(sid, text, author="human"):
     key = "echo:" + uuid.uuid4().hex
@@ -30185,6 +30221,7 @@ def _tmux_echo_add(sid, text, author="human"):
         # Matches the real transcript atom's author so the optimistic echo reads identically until it lands.
         "author": author, "_echo_text": text,
         "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+    _tmux_echo_bump(sid)
 
 def _tmux_echo_atoms(sid):
     return list(_tmux_echo.get(sid, {}).values())
@@ -30202,8 +30239,11 @@ def _tmux_echo_prune(sid, tx_uuids, tx_texts):
 
     def _landed(a):
         return a.get("uuid") in tx_uuids or _echo_landed_in(a.get("_echo_text"), tx_texts)
-    for k in [k for k, a in d.items() if _landed(a)]:
+    gone = [k for k, a in d.items() if _landed(a)]
+    for k in gone:
         d.pop(k, None)
+    if gone:
+        _tmux_echo_bump(sid)                              # the tail changed; a prune that retired nothing is no change
     if not d:
         _tmux_echo.pop(sid, None)
 
@@ -30263,6 +30303,7 @@ def _tmux_echo_settle(sid, human_floor, still_queued=()):
         return
     owed = {t.strip() for t in still_queued if isinstance(t, str)}
     path_bearing = getattr(sys.modules.get("romp_sdk_backend"), "_path_bearing", None)
+    changed = False
     for k in list(d.keys()):
         a = d[k]
         if not _echo_overtaken(a, human_floor):
@@ -30271,8 +30312,12 @@ def _tmux_echo_settle(sid, human_floor, still_queued=()):
             continue                                     # still owed by the queue ledger → waiting, not lost
         if path_bearing is not None and path_bearing(a.get("_echo_text") or ""):
             d.pop(k, None)
-        else:
+            changed = True
+        elif not a.get("dropped"):
             a["dropped"] = True
+            changed = True                               # a mark already made is no change
+    if changed:
+        _tmux_echo_bump(sid)
     if not d:
         _tmux_echo.pop(sid, None)
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -7470,7 +7470,7 @@ class SdkBackend:
         #                                           writes come from kernel AND loop threads)
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
-        self._live_rev: dict[str, int] = {}       # sid -> count of changes to its live tail (add/edit/drop/flag) —
+        self._live_rev: dict[str, int] = {}       # sid -> count of changes to its live tail (add/edit/drop/flag):
         #                                           the exact "the live tail moved" event the kernel's chat-build
         #                                           signature keys every tab on (Sessions.live_rev); bumped by
         #                                           _touch_live once per mutating call, never read as a value

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -7470,10 +7470,11 @@ class SdkBackend:
         #                                           writes come from kernel AND loop threads)
         self._pending_ask: dict[str, bool] = {}   # sid -> has an ask awaiting answer
         self._live: dict[str, dict] = {}          # sid -> {key -> atom}: the in-memory LIVE TAIL (ahead of disk)
-        self._live_rev: dict[str, int] = {}       # sid -> count of changes to its live tail (add/edit/drop) —
-        #                                           the exact "the live tail moved" event the kernel's active-tab
-        #                                           cache keys on (2026-09-03); bumped by _touch_live at every
-        #                                           mutation site, never read as a value beyond equality
+        self._live_rev: dict[str, int] = {}       # sid -> count of changes to its live tail (add/edit/drop/flag) —
+        #                                           the exact "the live tail moved" event the kernel's chat-build
+        #                                           signature keys every tab on (Sessions.live_rev); bumped by
+        #                                           _touch_live once per mutating call, never read as a value
+        #                                           beyond equality
         # THE LIVE-TAIL LOCK (2026-09-06). `_live` and every per-sid dict inside it are shared by the
         # kernel thread (send, recall, dismiss_echo, the pusher's live_atoms/prune_live) and each
         # session's loop thread (_forward, the settle's retire_live_work, _mark_dropped_echoes at
@@ -9556,13 +9557,16 @@ class SdkBackend:
         if text is not None:
             with self._live_lock:                          # find + pop + the sid-level pop, one step
                 live = self._live.get(sid) or {}
+                popped = False
                 if qid:
-                    live.pop(qid, None)                    # the cancelled copy's own echo, by the shared key; already gone: nothing else
+                    popped = live.pop(qid, None) is not None   # the cancelled copy's own echo, by the shared key; already gone: nothing else
                 else:
                     for k, a in list(live.items()):
                         if a.get("_echo_text") == text:
-                            live.pop(k, None)              # one echo per canceled message
+                            popped = live.pop(k, None) is not None   # one echo per canceled message
                             break
+                if popped:
+                    self._touch_live(sid)                  # the tail changed: the chat signature's live component
                 if not live and self._live.get(sid) is live:
                     self._live.pop(sid, None)
             self._persist_echoes(sid)                      # the canceled echo leaves the restart mirror too
@@ -9596,6 +9600,7 @@ class SdkBackend:
                                     break
                         elif isinstance(c, str):
                             m["content"] = text
+                    self._touch_live(sid)                  # the reworded echo is a change to the tail (see _touch_live)
                     break                                  # one echo per edited message
             self._persist_echoes(sid)                      # the restart mirror carries the new words
             self._wake_push()                              # repaint with them
@@ -9844,6 +9849,8 @@ class SdkBackend:
                 elif seen:
                     a["_landed"] = True                    # the verdict, for prune_live and the next boot
                     landed.add(a["_echo_text"])
+                    with self._live_lock:
+                        self._touch_live(sid)              # a flag write outside the lock: still a change to the tail
         if redeliver:
             # The LIVE-session caller (a fresh spawn's _run) must deliver through the session's
             # own queue: there the in-memory _pending is authoritative and its very next
@@ -9897,7 +9904,8 @@ class SdkBackend:
             a["dropped"] = True
             if hasattr(self, "forget_fed"):
                 self.forget_fed(sid, a.get("uuid"))   # its landing will never come (T252c)
-            self._touch_live(sid)
+            with self._live_lock:
+                self._touch_live(sid)                  # a flag write outside the lock: still a change to the tail
             self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
                       "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
         self._persist_echoes(sid)
@@ -11584,15 +11592,33 @@ class SdkBackend:
         threading.Thread(target=run, name="sdk-push-session", daemon=True).start()
 
     def _touch_live(self, sid: str) -> None:
-        """Record that `sid`'s live tail changed (see _live_rev)."""
-        revs = getattr(self, "_live_rev", None)          # a bare __new__ backend (tests drive prune_live on one)
-        if revs is None:                                 # has no counters yet: mint them rather than raise
+        """Record that `sid`'s live tail changed: advance its revision (`_live_rev[sid]`), the integer the
+        kernel's chat-build signature folds for the tail (Sessions.live_rev). A tab whose in-memory tail
+        changed rebuilds because this moved, and one whose tail did not is served from its cache without
+        anyone hashing the atoms. Called with `_live_lock` HELD, AFTER the change it records: the write
+        first, then the revision, so a reader that took the revision before its read and stored it misses
+        on its next check; the other order could pair a new revision with the old atoms and never heal.
+
+        THE RULE: every site that adds, replaces, pops, flags or REWORDS an atom in `_live` calls this,
+        once per call that changed something: _stash_live, _forward (its eviction included), unqueue (the
+        cancelled copy's echo), edit_queued (the echo's new words), dismiss_echo, prune_live,
+        retire_live_work, and the two flag writes _mark_dropped_echoes makes outside the lock (each takes
+        the lock for its bump). tests/test_live_tail_rev.py pins the set by source, so a new queue or echo
+        mutator that touches `_live` fails that census until it bumps. Only a CHANGE bumps: a prune that
+        retired nothing, a settle over echoes already marked, a queue miss and every read leave the
+        revision where it was. The chat build itself prunes on every merge, so a bump per CALL would move
+        every build's own signature under it. A bare __new__ backend (tests drive prune_live on one) has
+        no counters yet: mint them rather than raise."""
+        revs = getattr(self, "_live_rev", None)
+        if revs is None:
             revs = self._live_rev = {}
         revs[sid] = revs.get(sid, 0) + 1
 
     def live_rev(self, sid: str) -> int:
-        """How many times `sid`'s live tail has changed this process — equality means nothing moved."""
-        return getattr(self, "_live_rev", {}).get(sid, 0)
+        """The sid's live-tail revision (see _touch_live): 0 until the tail first changes, then one more per
+        change. Equality means nothing moved. Read under the live-tail lock, like the atoms it counts."""
+        with self._live_lock:
+            return (getattr(self, "_live_rev", None) or {}).get(sid, 0)
 
     def live_atoms(self, sid: str) -> list:
         """The session's in-memory live-tail atoms (newest last), for build_session to merge ahead of disk."""
@@ -11662,6 +11688,7 @@ class SdkBackend:
             return any(k in text_t and float(text_t[k] or 0) >= float(a.get("t") or 0) for k in keys)
         echo_removed = False
         vanished = 0
+        changed = False
         with self._live_lock:
             d = self._live.get(sid)
             if not d:
@@ -11678,7 +11705,10 @@ class SdkBackend:
                     echo_removed = echo_removed or bool(et and not a.get("command"))
                     if d.pop(k, None) is None:
                         vanished += 1
-                    self._touch_live(sid)
+                    else:
+                        changed = True
+            if changed:
+                self._touch_live(sid)      # once per call that retired something (see _touch_live)
             if not d and self._live.get(sid) is d:
                 self._live.pop(sid, None)
         if vanished:
@@ -11735,9 +11765,11 @@ class SdkBackend:
                     except Exception:
                         self._log("orphan-reply persist failed: %s" % traceback.format_exc())
         with self._live_lock:
+            changed = False
             for k, _a in work:
-                d.pop(k, None)
-                self._touch_live(sid)
+                changed = (d.pop(k, None) is not None) or changed
+            if changed:
+                self._touch_live(sid)      # once per settle that retired something (see _touch_live)
             if not d and self._live.get(sid) is d:
                 self._live.pop(sid, None)
 

--- a/tests/romp-perf.bats
+++ b/tests/romp-perf.bats
@@ -34,7 +34,8 @@ setup() {
     # A and B: the same kernel process ten seconds apart. Over the window: 20 cycles, 60 wakes, 6 s of
     # cycle time (4 s of it in push, 3 s of that in the chat block), 300 ms of pusher CPU and 50 ms of
     # judge CPU inside 500 ms of process CPU, 2 chat rebuilds (one of the watched tab, one of a background
-    # tab whose judge_gen component moved) against 18 cache hits, 1 MB sent as chat
+    # tab whose store component moved) against 18 cache hits, 3 builds not cached because an input moved
+    # while they ran, 1 MB sent as chat
     # full frames, one GET /feed.json build (150 ms) against 4 of its cache hits, 100 goal loads, 2 judge
     # passes totalling 2400 ms, 5 /tick requests and 3 WebSocket connects. B's lifetime figures (cycle_ms_max 900, ms_mean 1012.5) differ from the window's
     # (ring max 700, mean 1200) so a line printing the wrong one is caught.
@@ -45,7 +46,7 @@ setup() {
             "cycle_ms_max": 900.0, "cycle_ms_last": 200.0, "cycle_cpu_ms_sum": 10000.0,
             "cycle_ms_p50": 180.0, "cycle_ms_p90": 400.0, "cycle_ms_ring_max": 900.0, "ring_n": 100},
  "stages_ms": {"jobs": 5000.0, "push": 20000.0, "push.chat": 15000.0, "push.feed": 3000.0, "push.timeline": 1000.0, "push.send": 500.0},
- "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0, "active_built": 12, "bg_built": 8, "bg_miss": {"transcript": 5, "states": 2, "judge_gen": 1, "tasks": 0, "cut": 0, "row": 0, "cold": 1, "nosig": 0}}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}, "feedJson": {"cached": 5, "built": 1, "ms": 300.0}},
+ "builds": {"chat": {"cached": 80, "built": 20, "ms": 800.0, "active_built": 12, "bg_built": 8, "moved": 0, "bg_miss": {"transcript": 5, "states": 2, "store": 1, "tasks": 0, "cut": 0, "row": 0, "cold": 1, "nosig": 0}}, "feed": {"cached": 90, "built": 10, "ms": 5000.0}, "timeline": {"cached": 95, "built": 5, "ms": 4000.0}, "feedJson": {"cached": 5, "built": 1, "ms": 300.0}},
  "sends": {"full": {"chat": {"count": 10, "bytes": 1000000}}, "delta": {"chat": {"count": 100, "bytes": 50000}}, "deduped": {"feed": {"count": 90, "bytes": 9000000}}},
  "goals": {"loads": 1000, "saves": 200, "writes": 50},
  "judge": {"passes": 30, "ms_sum": 30000.0, "ms_last": 1000.0, "ms_mean": 1000.0, "cpu_ms_sum": 2000.0, "cpu_ms_workers": 1500.0},
@@ -58,7 +59,7 @@ JSON
             "cycle_ms_max": 900.0, "cycle_ms_last": 250.0, "cycle_cpu_ms_sum": 10300.0,
             "cycle_ms_p50": 190.0, "cycle_ms_p90": 420.0, "cycle_ms_ring_max": 700.0, "ring_n": 120},
  "stages_ms": {"jobs": 6000.0, "push": 24000.0, "push.chat": 18000.0, "push.feed": 3600.0, "push.timeline": 1200.0, "push.send": 600.0},
- "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0, "active_built": 13, "bg_built": 9, "bg_miss": {"transcript": 5, "states": 2, "judge_gen": 2, "tasks": 0, "cut": 0, "row": 0, "cold": 1, "nosig": 0}}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}, "feedJson": {"cached": 9, "built": 2, "ms": 450.0}},
+ "builds": {"chat": {"cached": 98, "built": 22, "ms": 880.0, "active_built": 13, "bg_built": 9, "moved": 3, "bg_miss": {"transcript": 5, "states": 2, "store": 2, "tasks": 0, "cut": 0, "row": 0, "cold": 1, "nosig": 0}}, "feed": {"cached": 108, "built": 12, "ms": 6000.0}, "timeline": {"cached": 114, "built": 6, "ms": 4800.0}, "feedJson": {"cached": 9, "built": 2, "ms": 450.0}},
  "sends": {"full": {"chat": {"count": 12, "bytes": 2048576}}, "delta": {"chat": {"count": 120, "bytes": 60000}}, "deduped": {"feed": {"count": 108, "bytes": 10800000}}},
  "goals": {"loads": 1100, "saves": 220, "writes": 55},
  "judge": {"passes": 32, "ms_sum": 32400.0, "ms_last": 1200.0, "ms_mean": 1012.5, "cpu_ms_sum": 2050.0, "cpu_ms_workers": 1540.0},
@@ -129,9 +130,10 @@ teardown() { rm -rf "$TEST_DIR"; }
 @test "romp perf: builds, sends, goals, judge and http lines carry the window's deltas" {
     run "$ROMP_SCRIPT" perf --interval 0
     [ "$status" -eq 0 ]
-    # the chat line's split: the watched tab's rebuild against the background one's, and per signature
-    # component the background rebuilds it caused (only the non-zero causes; judge_gen moved once in the window)
-    [[ "$output" == *"chat 2 built / 18 cached (40 ms avg; 1 watched, 1 background: judge_gen 1)"* ]]
+    # the chat line's split: the watched tab's rebuild against the background one's, per signature component
+    # the background rebuilds it caused (only the non-zero causes; the store moved once in the window), and the
+    # builds not cached because an input moved while they ran (three in the window; printed only when non-zero)
+    [[ "$output" == *"chat 2 built / 18 cached (40 ms avg; 1 watched, 1 background: store 1; 3 moved)"* ]]
     # GET /feed.json's own reads print beside the pusher's feed, never folded into it (review find, 2026-09-08)
     [[ "$output" == *"feedJson 1 built / 4 cached (150 ms avg)"* ]]
     [[ "$output" == *"full 102 KB/s (chat 2 frames 102 KB/s)"* ]]        # 1048576 bytes over 10 s, bytes beside the count

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -1,0 +1,1361 @@
+#!/usr/bin/env python3
+"""The chat-build signature's input census.
+
+_built_chat serves every tab's payload, the watched one included, from its cache while _chat_build_sig(sess)
+is unchanged, so the signature must contain every input build_session reads that can change the payload.
+This module is the census that argument rests on: CENSUS classifies every module-level helper build_session
+calls by name, DOTTED every attribute call on a module object or a backend local, and GLOBALS every module
+global it reads without calling. Each entry is one of:
+
+  sig    an input the signature folds, under the named label (_CHAT_SIG_LABELS);
+  pure   a function of inputs already classified (the parse, the events, the args, a store the
+         signature keys) and nothing else; the note says of what;
+  memo   a cache whose own key is made of classified inputs, or that latches its first answer for
+         the process's life (then constant, and an uncached build now would read the same entry);
+  const  fixed for the life of the process (a module constant, an environment value, a path);
+  out    a write or a counter, not an input.
+
+The test derives the three sets from build_session's source by AST and requires each to EQUAL the
+table's keys, so a helper added to build_session without a classification fails the suite, and so
+does a stale entry for one removed. A second test requires every `sig` label to exist in the
+signature's label tuple. Names, not lines: the tables say what each read is, the signature module
+says how it is keyed. The census enforces ONE level: the helpers build_session calls directly. What
+each helper reads in turn is the classification's claim (the note), verified by the differential
+tests below that move one input at a time, not derived; a helper that gains a new read keeps its
+entry and is caught only if a differential test covers the input.
+
+Synthetic fixtures only: private synthetic sids, invented text, a hermetic state root.
+"""
+import ast
+import contextlib
+import inspect
+import io
+import json
+import os
+import re
+import tempfile
+import time
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()      # hermetic state BEFORE the load (import-time root)
+os.environ.pop("ROMP_STATE_DIR", None)
+km = SourceFileLoader("romp_kernel_chatsiginputs", os.path.join(BIN, "romp-kernel")).load_module()
+jd = km.jd
+
+
+# ── the read inventory ───────────────────────────────────────────────────────────────────────────
+# Module-level functions build_session calls by name. Where a helper reads through several inputs the
+# label names the one that identifies it and the note lists the rest; every listed input has a label.
+CENSUS = {
+    "_agent_open_set": ("pure", "over the goal store (store)"),
+    "_api_error": ("pure", "the transcript's tail, memoized on its (mtime, size) (transcript)"),
+    "_apply_rewind_hold": ("sig", "hold", "and the store; the kept-chain read is over the transcript, states and cut"),
+    "_archive_roots": ("sig", "store", "the goals-archive identity is the store triple's third member"),
+    "_ask_fill_answers": ("pure", "over a tool event and its result block"),
+    "_ask_fill_chosen": ("pure", "over a tool event's output string"),
+    "_atom_md": ("pure", "over an atom"),
+    "_atom_user_texts": ("pure", "over an atom"),
+    "_auth_avail_status": ("sig", "acct", "the availability half of the Billing choices, memoized once per pusher cycle: the account's tri-state read, the key presence and the managed-helper flag, folded whole beside the login label and the both-bit"),
+    "_auth_both": ("sig", "acct", "the credential store's login and the settings' key presence"),
+    "_awaiting_task_descs": ("sig", "bg", "the live task rows; the split reads the stamped tops (stamp), the store and the transcript"),
+    "_awaiting_task_ids": ("sig", "bg", "as _awaiting_task_descs"),
+    "_awaiting_items_payload": ("sig", "bg", "the wait's own rows (as _session_awaiting), else the rows in flight mid-turn: the row's agents (row), the live task rows and the watches (watch)"),
+    "_bg_tasks": ("sig", "row", "the row's live task set gates the transcript's scan; each output tail is a taskout dep; the spawn epoch reads reg and gone"),
+    "_chat_agent_open_at": ("pure", "over the events"),
+    "_chat_agents_moved": ("pure", "the fold's sealed-agent gate: over the sidecar map (a taskout dep, recorded by _subagent_meta_map), the transcript's task scan (transcript), the row and the spawn epoch (row, reg, gone)"),
+    "_chat_fold_count": ("out", "a fold counter"),
+    "_chat_fold_demote": ("out", "a fold counter"),
+    "_chat_fold_get": ("memo", "the sealed prefix: every gate it checks is an input classified here, and its output is the events an unfolded build produces"),
+    "_chat_fold_put": ("out", "the fold entry's write"),
+    "_chat_memo_bump": ("out", "a memo counter's increment"),
+    "_chat_postal_key": ("sig", "postal", "the log's identity, folded when the payload carries postal traffic"),
+    "_chat_postal_relevant": ("pure", "over a raw event"),
+    "_chat_seam_open_at": ("pure", "over the events"),
+    "_chat_stat_key": ("sig", "taskout", "the fold's per-output identity; the same stat the taskout dep re-takes"),
+    "_chat_turn_fp": ("pure", "over a turn"),
+    "_claude_account_label": ("sig", "acct"),
+    "_claudemd_docs": ("sig", "claudemd", "the CLAUDE.md files on the chain from the cwd to its git root, plus the global one"),
+    "_cleared_ids": ("sig", "cleared"),
+    "_clearing_now": ("sig", "backend", "the backend's clearing bracket"),
+    "_cmd_gestures": ("sig", "states"),
+    "_colormap": ("sig", "colormap"),
+    "_compacting": ("sig", "backend", "the backend's compacting bracket; else the row's state and since, the parse, and the optimistic stamp's clock boolean (clock)"),
+    "_echo_landed_in": ("pure", "over an echo's text and the user-text keys built from the parse (transcript)"),
+    "_echo_overtaken": ("pure", "over an atom and the parse's human floor"),
+    "_edit_diff": ("pure", "over a tool input"),
+    "_effort_changes": ("sig", "states"),
+    "_effort_color": ("pure", "over the effort string and the colormap name"),
+    "_effort_tone": ("pure", "over the effort string"),
+    "_fold_tasks": ("memo", "pure over the parse's turns (transcript, live); the per-turn memo is keyed on each turn's atoms and fingerprint"),
+    "_genuine_queued": ("pure", "over a queued text"),
+    "_git_branch": ("sig", "cwd"),
+    "_github_repo_of": ("sig", "cwd"),
+    "_has_tmux": ("const", "whether a tmux binary is on PATH"),
+    "_human_turn_floor": ("pure", "over the parse"),
+    "_hydrate_postal": ("sig", "postal", "the index, the caption map and each card's peer identity (names)"),
+    "_idle_faded": ("sig", "clock", "the faded boolean, from the row's since and now"),
+    "_interrupt_settle": ("pure", "over the events and an atom"),
+    "_launch_error": ("sig", "backend"),
+    "_limit_hold": ("sig", "limit", "folded as its value while the tab can render a queued bubble (a queue, parked ops, or a tmux session's in-flight echo); None otherwise, when the build never reads it"),
+    "_merge_live_atoms": ("sig", "live", "the backend's tail by revision; the transcript-side sets are pure over the parse"),
+    "_model_color": ("pure", "over the model string and the colormap name"),
+    "_model_pending_now": ("sig", "clock", "the row's flag, the kernel's stamp and its 20 s cap as one boolean"),
+    "_model_tone": ("pure", "over the model string"),
+    "_msg_summaries_scoped": ("sig", "postal", "the cycle's caption map (one fetch per pusher cycle; fresh on a handler thread), read only through the caption values each card embeds (the postal deps)"),
+    "_name_color": ("sig", "names"),
+    "_name_of": ("sig", "names"),
+    "_node_anchor_uuids": ("sig", "anchors", "the warm-anchor table by this sid's revision; else pure over the node and the parse's segment maps"),
+    "_norm_branch": ("pure", "over a branch string"),
+    "_notify_session_effective": ("sig", "ncards", "the master bell; the session's own override is in flags"),
+    "_op_qid": ("pure", "over a parked op"),
+    "_orphan_replies": ("sig", "states"),
+    "_parked_md": ("pure", "over a parked op"),
+    "_parse": ("sig", "transcript", "memoized on the transcript's (mtime, size), the pending cut (cut) and the states file (states)"),
+    "_parse_task_notification": ("pure", "over a reminder string"),
+    "_patch_rows": ("pure", "over a structured patch"),
+    "_path_links": ("sig", "pathlink", "a resolved token latches for the message's life; an unresolved one is retried, and the retry is the pathlink dep"),
+    "_path_pins": ("sig", "pathlink", "the pins latched beside the links"),
+    "_postal_card_deps": ("sig", "postal"),
+    "_postal_index": ("sig", "postal", "memoized on the log's identity"),
+    "_queue_recallable": ("sig", "backend"),
+    "_queued_romp_flags": ("pure", "over a queued text"),
+    "_read_task_store": ("sig", "tasks"),
+    "_retry_gate_state": ("sig", "retry"),
+    "_retry_gaveups": ("sig", "states"),
+    "_retry_recoveries": ("sig", "states"),
+    "_rewind_hold_get": ("sig", "hold"),
+    "_romp_system_gist": ("pure", "over a notice's text"),
+    "_sdk": ("const", "the SDK backend singleton, fixed once made"),
+    "_sdk_sess": ("sig", "reg", "a transcript-less SDK session's row: its reg and names entry"),
+    "_sdk_spawned_at": ("sig", "reg", "the reg's spawnedAt and the death marker (gone)"),
+    "_seg_anchors": ("pure", "over a segment's atoms"),
+    "_seg_jump": ("pure", "over a segment's atoms"),
+    "_seg_key": ("pure", "over a segment id"),
+    "_segs_seam": ("pure", "over a turn and the store's seams (store)"),
+    "_self_host": ("sig", "host"),
+    "_session_awaiting": ("sig", "bg", "the row's subagents and task set, the live task rows, the watches (watch), the states overlay (states), the durable stamp view with its delegation peers (stamp: the store, the journal and the postal log, since a peer's answer supersedes a peer wait), the blocked-yield read of the store (store, hold) and the peers' names (names)"),
+    "_session_backend": ("sig", "row", "the row's backend field; else the reg's existence (reg)"),
+    "_session_chip": ("pure", "over classified inputs: the parse and live tail, the row, the backend brackets, the clock booleans, the live task rows, the watches, the states overlay, the store and the downtime list"),
+    "_session_cwd": ("sig", "cwd", "the names entry's cwd, else the transcript's stamp"),
+    "_session_flag": ("sig", "flags"),
+    "_session_meta": ("pure", "over the transcript's records, memoized by record identity (transcript)"),
+    "_session_retry_suppressed": ("sig", "retry"),
+    "_session_working": ("sig", "downtime", "over the turns, and the host suspensions recorded since boot"),
+    "_sessions": ("sig", "names", "the cycle's discovery rows: the transcript path (transcript), the display name (names), and the 48 h discovery window (clock: a session that ages out leaves the roster and the tab list, so no signature is taken for it)"),
+    "_space_paths": ("memo", "the first resolution of a message's spaced spans latches for the process's life"),
+    "_split_followup": ("pure", "over a text"),
+    "_split_reminders": ("pure", "over a text"),
+    "_stamp_agents": ("sig", "taskout", "the sidecar directory and each agent transcript it reads are taskout deps (stat'd before the read, re-stat'd per cycle); the task scan is over the transcript, the liveness gate over the row and the spawn epoch (row, reg, gone)"),
+    "_stamp_interrupt_causes": ("pure", "over the events"),
+    "_stat_key": ("sig", "cleared", "cleared.jsonl's identity, the ledger memo's key beside the set _cleared_ids reads"),
+    "_strip_hook_notices": ("pure", "over a text"),
+    "_task_outputs_for": ("sig", "taskout", "the launch record from the transcript's scan; each output file's tail is a taskout dep"),
+    "_thread_reg": ("sig", "reg"),
+    "_tilde": ("const", "the home directory"),
+    "_tmux_sessions": ("sig", "row", "the liveness map when the caller passed none"),
+    "_tree_of": ("sig", "cwd"),
+    "_user_images": ("pure", "over a turn's blocks and text"),
+    "iso": ("pure", "over a timestamp"),
+}
+
+# Attribute calls whose base is a module-level object or one of the backend locals build_session binds.
+DOTTED = {
+    "Sessions.backend_for": ("sig", "reg", "ownership: the SDK backend owns a sid whose reg exists"),
+    "jd.episode_rows": ("sig", "episodes"),
+    "jd.episode_settles": ("sig", "episodes"),
+    "jd.load_archive": ("sig", "archive"),
+    "jd.load_goals_shared_or_fault": ("sig", "store", "the shared read behind the per-session fault boundary"),
+    "em.MSG_TAG_RE.search": ("pure", "over a text"),
+    "em.parse_teammate_message": ("pure", "over a text"),
+    "em.injected_source": ("pure", "over a message record"),
+    "em.strip_harness_preamble": ("pure", "over a text"),
+    "sb.echo_text_key": ("pure", "over a text"),
+    "cm.context_rgb": ("pure", "over a percentage"),
+    "cm.ramp": ("pure", "over a fraction and the colormap's stops"),
+    "cm.stops_for": ("pure", "over the colormap name"),
+    "_SEND_TOOL_RE.search": ("const", "a module regex"),
+    "_PATH_LINK_CACHE.get": ("sig", "pathlink", "which tokens are still unresolved"),
+    "_chat_fold.pop": ("out", "the fold entry's eviction"),
+    "_ledger_memo.get": ("memo", "keyed on the seams, cleared.jsonl and the anchor revision, held by parse and store identity"),
+    "_node_anchor_rev.get": ("sig", "anchors"),
+    "_parse_mode.get": ("memo", "the parse's own mode, written under the parse's key"),
+    "_pending_ops.get": ("sig", "ops"),
+    "be.owns": ("sig", "reg"),
+    "be.pending_queued": ("sig", "backend", "the SDK queue by value; the tmux queue is folded from the transcript"),
+    "_cbe.pending_queued_meta": ("sig", "backend", "each queued copy's (qid, qts) beside its text, folded as _qmeta where the backend keeps them"),
+    "be.live_atoms": ("sig", "live"),
+    "be.qids_for_landing": ("sig", "live", "the queued-copy ids a landed record pairs with: a landing is a transcript record (transcript) or a live-tail change (live), and the fed ledger it reads fills with the feed that bumps live_rev"),
+    "_be_fk.fork_children": ("sig", "fork"),
+    "os.path.exists": ("sig", "transcript", "whether the transcript exists yet"),
+    "os.path.realpath": ("sig", "cwd", "the two tree tops compared through the filesystem"),
+    "os.path.expanduser": ("const", "the home directory"),
+    "os.path.basename": ("pure", "over a path string"),
+    "os.path.dirname": ("pure", "over a path string"),
+    "json.dumps": ("pure", "over a value"),
+    "re.sub": ("pure", "over a text"),
+    "bisect.bisect_right": ("pure", "over a list"),
+    "sys.stderr.write": ("out", "a log line"),
+    "traceback.format_exc": ("out", "a log line"),
+}
+
+# Module globals build_session reads without calling.
+GLOBALS = {
+    "Sessions": ("const", "the backend-agnostic session API class; its calls are in DOTTED"),
+    "_CHAT_FOLD_STATS": ("out", "counters"),
+    "_PATH_LINK_CACHE": ("sig", "pathlink"),
+    "_SEND_TOOL_RE": ("const", "a module regex"),
+    "_chat_fold": ("memo", "see _chat_fold_get"),
+    "_chat_fold_last": ("out", "the perf line's per-thread record"),
+    "_chat_fold_lock": ("const", "a lock"),
+    "_chat_fold_warned": ("out", "a once-flag"),
+    "_chat_dep_scope": ("out", "the running build's dependency record, written for the pusher (see _chat_build_deps)"),
+    "_chat_postal_stats": ("out", "counters"),
+    "_ledger_memo": ("memo", "see _ledger_memo.get"),
+    "_ledger_memo_stats": ("out", "counters"),
+    "_live_scope": ("sig", "names", "the names snapshot the thread holds (the cycle's, or the push's own), digested"),
+    "_node_anchor_rev": ("sig", "anchors"),
+    "_parse_mode": ("memo", "see _parse_mode.get"),
+    "_pending_ops": ("sig", "ops"),
+    "bisect": ("const", "a module"), "cm": ("const", "a module"), "em": ("const", "a module"),
+    "jd": ("const", "a module"), "json": ("const", "a module"), "os": ("const", "a module"),
+    "re": ("const", "a module"), "sb": ("const", "a module"), "sys": ("const", "a module"),
+    "traceback": ("const", "a module"),
+}
+
+# The local names build_session binds a backend to, derived from its source by AST (_backend_locals: every
+# name assigned from a call to _sdk(), _codex() or Sessions.backend_for(), or from another such name,
+# transitively) and pinned here, so a read through a backend bound to a new name, or a method called
+# directly on _sdk()/_codex() (reported as `_sdk().<attr>`), reaches DOTTED instead of slipping past it.
+BACKEND_LOCALS = ("_be_fk", "_cbe", "be")
+BACKEND_FACTORIES = ("_sdk", "_codex")
+KINDS = ("sig", "pure", "memo", "const", "out")
+
+
+def _module_names():
+    """Every name bound at kernel module level: functions, classes, assignments, imports."""
+    tree = ast.parse(inspect.getsource(km))
+    names = set()
+    for n in tree.body:
+        if isinstance(n, (ast.FunctionDef, ast.ClassDef)):
+            names.add(n.name)
+        elif isinstance(n, ast.Assign):
+            for t in n.targets:
+                for x in ast.walk(t):
+                    if isinstance(x, ast.Name):
+                        names.add(x.id)
+        elif isinstance(n, (ast.Import, ast.ImportFrom)):
+            for a in n.names:
+                names.add((a.asname or a.name).split(".")[0])
+    return names
+
+
+def _is_backend_factory(call):
+    f = call.func
+    return ((isinstance(f, ast.Name) and f.id in BACKEND_FACTORIES)
+            or (isinstance(f, ast.Attribute) and isinstance(f.value, ast.Name)
+                and f.value.id == "Sessions" and f.attr == "backend_for"))
+
+
+def _backend_locals(fn):
+    """Every local name bound to a backend object, transitively: assigned from a backend factory call, or
+    from a name already known to hold one."""
+    names, changed = set(), True
+    while changed:
+        changed = False
+        for x in ast.walk(fn):
+            if not (isinstance(x, ast.Assign) and len(x.targets) == 1 and isinstance(x.targets[0], ast.Name)):
+                continue
+            v = x.value
+            bound = (isinstance(v, ast.Call) and _is_backend_factory(v)) or (isinstance(v, ast.Name) and v.id in names)
+            if bound and x.targets[0].id not in names:
+                names.add(x.targets[0].id)
+                changed = True
+    return names
+
+
+def _census_of(fn_src, module_names):
+    """(calls, dotted, globals, backend_locals): the module-level functions called by name, the
+    attribute-call chains on module objects or backend locals (a method called on a factory's result
+    directly reads `_sdk().<attr>`), the module globals read without a call, and the backend locals the
+    function binds (derived, see _backend_locals)."""
+    fn = ast.parse(fn_src).body[0]
+    backends = _backend_locals(fn)
+    local = set()
+    for x in ast.walk(fn):
+        if isinstance(x, ast.Name) and isinstance(x.ctx, ast.Store):
+            local.add(x.id)
+        elif isinstance(x, ast.FunctionDef) and x is not fn:
+            local.add(x.name)
+        elif isinstance(x, ast.arg):
+            local.add(x.arg)
+        elif isinstance(x, ast.ExceptHandler) and x.name:
+            local.add(x.name)
+    calls, dotted, reads = set(), set(), set()
+    for x in ast.walk(fn):
+        if isinstance(x, ast.Call):
+            f = x.func
+            if isinstance(f, ast.Name) and f.id in module_names and f.id not in local:
+                calls.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                base, chain = f.value, [f.attr]
+                while isinstance(base, ast.Attribute):
+                    chain.insert(0, base.attr)
+                    base = base.value
+                if isinstance(base, ast.Name) and ((base.id in module_names and base.id not in local)
+                                                   or base.id in backends):
+                    dotted.add(base.id + "." + ".".join(chain))
+                elif isinstance(base, ast.Call) and _is_backend_factory(base) and isinstance(base.func, ast.Name):
+                    dotted.add(base.func.id + "()." + ".".join(chain))   # a method called on the factory's result
+        if isinstance(x, ast.Name) and isinstance(x.ctx, ast.Load) and x.id in module_names and x.id not in local:
+            reads.add(x.id)
+    return calls, dotted, reads - calls, backends
+
+
+class Census(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.names = _module_names()
+        cls.calls, cls.dotted, cls.reads, cls.backends = _census_of(inspect.getsource(km.build_session), cls.names)
+
+    def test_every_helper_build_session_calls_is_classified_and_nothing_stale_remains(self):
+        self.assertEqual(self.calls, set(CENSUS),
+                         "a helper build_session calls by name is missing from CENSUS (an unclassified read), "
+                         "or CENSUS names one build_session no longer calls: %r"
+                         % sorted(self.calls ^ set(CENSUS)))
+
+    def test_every_attribute_call_on_a_module_object_or_backend_is_classified(self):
+        self.assertEqual(self.dotted, set(DOTTED), sorted(self.dotted ^ set(DOTTED)))
+
+    def test_the_backend_locals_are_the_pinned_ones(self):
+        self.assertEqual(self.backends, set(BACKEND_LOCALS),
+                         "build_session binds a backend to a new name (or dropped one): pin it so its reads are censused")
+        src = "def f():\n    be = _sdk()\n    x = be\n    y = Sessions.backend_for(sid)\n    z = other()\n    _codex().owns(sid)\n    y.pending_queued(sid)\n"
+        calls, dotted, reads, backends = _census_of(src, {"_sdk", "Sessions", "other", "_codex"})
+        self.assertEqual(backends, {"be", "x", "y"}, "transitive: a name assigned from a backend name is one too")
+        self.assertEqual(dotted, {"_codex().owns", "y.pending_queued", "Sessions.backend_for"})
+
+    def test_every_module_global_read_is_classified(self):
+        self.assertEqual(self.reads, set(GLOBALS), sorted(self.reads ^ set(GLOBALS)))
+
+    def test_every_entry_has_a_known_kind_and_a_sig_entry_names_a_label(self):
+        for table in (CENSUS, DOTTED, GLOBALS):
+            for name, ent in table.items():
+                self.assertIn(ent[0], KINDS, name)
+                self.assertGreaterEqual(len(ent), 2, "%s: a sig entry names its label; every other kind says of what" % name)
+
+    def test_the_census_names_resolve_in_the_kernel(self):
+        for name in CENSUS:
+            self.assertTrue(callable(getattr(km, name, None)), name)
+        for name in GLOBALS:
+            self.assertTrue(hasattr(km, name), name)
+
+    def test_every_sig_entry_is_a_component_of_the_signature(self):
+        labels = set(km._CHAT_SIG_LABELS)
+        for table in (CENSUS, DOTTED, GLOBALS):
+            for name, ent in table.items():
+                if ent[0] == "sig":
+                    self.assertIn(ent[1], labels, "%s is keyed under %r, which the signature has no component for" % (name, ent[1]))
+        self.assertNotIn("judge_gen", labels, "the global judge-pass counter is no longer a chat input")
+        self.assertEqual(km._PerfStats.CHAT_MISS, km._CHAT_SIG_LABELS + ("cold", "nosig"),
+                         "the /perf attribution carries one counter per label")
+        self.assertEqual(km._CHAT_SIG_LABELS[-len(km._CHAT_SIG_DEPS):], km._CHAT_SIG_DEPS,
+                         "the dependency components are the tail, so a post-build signature can be compared without them")
+        for retired in ("_active_chat_sig", "_clock_predicates", "_external_sig", "_ACTIVE_SIG_FILES"):
+            self.assertFalse(hasattr(km, retired), "%s: the watched tab's separate key is retired" % retired)
+
+
+# ── the differential tests ────────────────────────────────────────────────────────────────────────
+# One hermetic world (a tmux-less session discovery finds, with a fixed liveness row); each test moves one
+# input and requires the signature to miss under exactly that input's label, so a component that stopped
+# covering its input fails here by name. The dependency components are exercised through a hand-made cache
+# record, the way _chat_sig_deps evaluates one; the pusher tests drive the REAL build_session through _push.
+SID = "77777777-8888-9999-aaaa-ccccccccccc1"      # this module's private synthetic sids: goal stores are minted under SID
+PEER = "77777777-8888-9999-aaaa-ccccccccccc2"
+NOW = 1781100000
+T0 = NOW - 3600
+
+
+def _iso(t):
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def _aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+class _World(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.cdir = td / "launchdir"
+        self.cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(self.cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        self.tpath.write_text("\n".join(json.dumps(r) for r in [
+            _uline(T0, "start the notes-api spike", "u1"), _aline(T0 + 40, "Spike is up.", "a1", "u1"),
+            _uline(T0 + 100, "now the tests", "u2", "a1"), _aline(T0 + 140, "Tests pass.", "a2", "u2")]) + "\n")
+        state = td / "state"
+        state.mkdir()
+        self.saved = (jd.STATE, jd.PROJECTS, km.NAMES, km.WORKING_DIR, km._GLOBAL_CLAUDE_MD, km._tmux_sessions, km._sdk,
+                      os.environ.get("CLAUDE_CONFIG_DIR"), os.environ.get("ROMP_HOST_NAME"),
+                      len(km._downtime), km._claude_account_label, km._auth_avail_status)
+        jd._rebind_state(state)                       # every STATE-derived dir (goals, states, episodes, gone, sdk, ...)
+        jd.PROJECTS = proj
+        jd.NAMES.mkdir()
+        (jd.NAMES / SID).write_text("web\t%s\t#1EA1EB\twhite\n" % self.cdir)
+        km.NAMES = jd.NAMES
+        km.WORKING_DIR = state / "working"
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        os.environ["CLAUDE_CONFIG_DIR"] = str(td / "claude")   # the task-store root (_tasks_base)
+        self.row = {"state": "idle", "since": NOW - 100, "model": "", "effort": "", "context": None,
+                    "compactPct": None, "color": None, "backend": "tmux"}
+        self.tmux = {SID: self.row}
+        km._tmux_sessions = lambda: self.tmux
+        km._sdk = lambda: None
+        km._built_chat.clear()
+        km._live_scope.chat_shared = None
+        km._live_scope.usage = km._live_scope.spend_pause = None   # a drain scope another module left on this thread
+        self.sess = {"sid": SID, "name": "web", "path": str(self.tpath), "anchor": SID}
+
+    def tearDown(self):
+        (state, proj, names, wdir, gmd, tmux, sdk, cfg, host, ndown, acct, avail) = self.saved
+        jd._rebind_state(state)
+        jd.PROJECTS = proj
+        km.NAMES, km.WORKING_DIR, km._GLOBAL_CLAUDE_MD, km._tmux_sessions, km._sdk = names, wdir, gmd, tmux, sdk
+        km._claude_account_label, km._auth_avail_status = acct, avail
+        for k, v in (("CLAUDE_CONFIG_DIR", cfg), ("ROMP_HOST_NAME", host)):
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        del km._downtime[ndown:]
+        for d in (km._tmux_echo, km._tmux_echo_rev, km._node_anchor_rev, km._pending_ops, km._auto_retry_state,
+                  km._interrupt_clicked, km._compact_clicked, km._model_switch_pending):
+            d.pop(SID, None)
+        with km._watch_lock:
+            km._watches[:] = [w for w in km._watches if w.get("sid") != SID]
+        km._rewind_hold_clear(SID)
+        km._built_chat.clear()
+        km._live_scope.names = None
+        km._live_scope.snapshot = None
+        km._live_scope.chat_shared = None
+        for k in [k for k in km._PATH_LINK_CACHE if k[0] == SID]:
+            km._PATH_LINK_CACHE.pop(k, None)
+        self.td.cleanup()
+
+    def sig(self, now=NOW, deps=None, tm=None):
+        """The complete key, as the pusher takes it: the session, its liveness row, the push's clock and map."""
+        return km._chat_build_sig(self.sess, self.row if tm is None else tm, now, tmux=self.tmux, deps=deps)
+
+    def moved(self, before, after):
+        return km._chat_sig_miss(before, after)
+
+    def store(self, nodes=None, status=None):
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({"rompUuid": SID, "nodes": nodes or {}, "status": status or {}}))
+
+
+class Differential(_World):
+    def test_a_quiet_world_holds_and_has_one_value_per_label(self):
+        a = self.sig()
+        self.assertEqual(len(a), len(km._CHAT_SIG_LABELS))
+        self.assertEqual(self.sig(), a)
+        self.assertEqual(self.moved(a, self.sig()), ())
+
+    def test_a_transcript_append_misses_under_transcript_alone(self):
+        a = self.sig()
+        with open(self.tpath, "a") as f:
+            f.write(json.dumps(_uline(T0 + 200, "and the docs", "u3", "a2")) + "\n")
+        self.assertEqual(self.moved(a, self.sig()), ("transcript",))
+
+    def test_a_states_row_misses_under_states(self):
+        a = self.sig()
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.STATESDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": T0 + 150, "state": "idle"}) + "\n")
+        self.assertEqual(self.moved(a, self.sig()), ("states",))
+
+    def test_the_goal_store_its_journal_and_its_archive_each_miss_under_store_and_a_judge_pass_alone_does_not(self):
+        a = self.sig()
+        # a judge pass that moved nothing this session reads: not a chat input. The global generation used to be a
+        # component, so one session's publish rebuilt every other tab byte-identical
+        km._judge_gen[0] += 1
+        try:
+            self.assertEqual(self.moved(a, self.sig()), (), "the judge-pass counter alone moves no tab's key")
+        finally:
+            km._judge_gen[0] -= 1
+        self.store()
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("store",), "a publish busts the tab at once (the live identity)")
+        jd._overrides_dir().mkdir(parents=True, exist_ok=True)
+        with open(jd._overrides_dir() / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": T0, "op": "noop"}) + "\n")
+        c = self.sig()
+        self.assertEqual(self.moved(b, c), ("store",), "the override journal is the store triple's second member")
+        jd.GOALARCHDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALARCHDIR / (SID + ".json")).write_text(json.dumps({"rompUuid": SID, "nodes": {}, "status": {}}))
+        self.assertEqual(self.moved(c, self.sig()), ("store",), "...and the goals-archive the third")
+
+    def test_another_sessions_publish_moves_nothing_of_this_tabs_key(self):
+        a = self.sig()
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GOALDIR / (PEER + ".json")).write_text(json.dumps({"rompUuid": PEER, "nodes": {}, "status": {}}))
+        km._bump_judge_gen_if_changed()                   # the producer pass's own bump over the moved store dir
+        self.assertEqual(self.sig(), a, "one session's goal-store publish rebuilds no other session's tab")
+
+    def test_a_rewind_hold_misses_under_hold_and_its_clear_restores_the_signature(self):
+        a = self.sig()
+        km._rewind_hold_set(SID, T0 + 10, "u1")
+        self.assertEqual(self.moved(a, self.sig()), ("hold",))
+        km._rewind_hold_clear(SID)
+        self.assertEqual(self.sig(), a)
+
+    def test_the_archive_headline_and_the_episode_log_each_miss_under_their_own_label(self):
+        a = self.sig()
+        jd.ARCHDIR.mkdir(parents=True, exist_ok=True)
+        (jd.ARCHDIR / (SID + ".json")).write_text(json.dumps({"headline": "a spike", "abstract": ""}))
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("archive",))
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        with open(jd.EPIDIR / (SID + ".jsonl"), "a") as f:
+            f.write(json.dumps({"t": T0 + 50, "kind": "clear"}) + "\n")
+        self.assertEqual(self.moved(b, self.sig()), ("episodes",))
+
+    def test_the_sdk_registry_and_the_death_marker_each_miss_under_their_own_label(self):
+        a = self.sig()
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (SID + ".json")).write_text(json.dumps({"sid": SID, "name": "web", "alive": False}))
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("reg",))
+        jd.GONEDIR.mkdir(parents=True, exist_ok=True)
+        (jd.GONEDIR / (SID + ".json")).write_text(json.dumps({"t": NOW - 10, "by": "test"}))
+        self.assertEqual(self.moved(b, self.sig()), ("gone",))
+
+    def test_the_task_store_misses_under_tasks(self):
+        a = self.sig()
+        d = Path(os.environ["CLAUDE_CONFIG_DIR"]) / "tasks" / SID
+        d.mkdir(parents=True)
+        (d / "1.json").write_text(json.dumps({"id": "1", "subject": "write the tests", "status": "pending"}))
+        self.assertEqual(self.moved(a, self.sig()), ("tasks",))
+
+    def test_the_live_tail_misses_under_live_for_an_echo_and_for_its_dropped_mark(self):
+        a = self.sig()
+        km._tmux_echo_add(SID, "please also fix the header")
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("live",))
+        t = km._tmux_echo_atoms(SID)[0]["t"]
+        km._tmux_echo_settle(SID, human_floor=t + 5)
+        self.assertEqual(self.moved(b, self.sig()), ("live",), "the dropped mark is a change to the tail")
+
+    def test_the_liveness_row_misses_under_row_and_its_snapshot_stamp_does_not(self):
+        a = self.sig()
+        self.assertEqual(self.sig(tm=dict(self.row, snapT=NOW + 3)), a, "snapT moves every cycle and is not rendered")
+        self.assertEqual(self.moved(a, self.sig(tm=dict(self.row, state="working"))), ("row",))
+        self.assertEqual(self.moved(a, self.sig(tm=dict(self.row, context=42))), ("row",))
+        self.assertEqual(self.moved(a, km._chat_build_sig(self.sess, None, NOW, tmux={})), ("row",),
+                         "no row for the sid, and an empty map: a different key, never a false hit")
+
+    def test_each_clock_boolean_misses_under_clock_exactly_at_its_crossing(self):
+        tm = dict(self.row, state="ready", since=NOW - 3599)
+        s0 = self.sig(now=NOW, tm=tm)
+        self.assertEqual(self.sig(now=NOW + 1, tm=tm), s0, "one second short of the hour: nothing moved")
+        s2 = self.sig(now=NOW + 2, tm=tm)
+        self.assertEqual(self.moved(s0, s2), ("clock",), "faded flips at the hour")
+        km._compact_clicked[SID] = NOW - 179
+        s3 = self.sig(now=NOW + 2, tm=tm)                    # 181 s: the optimistic cap ran out (the stamp is popped)
+        self.assertEqual(s2, s3, "a cap that already ran out is no fact")
+        km._compact_clicked[SID] = NOW - 177
+        s4 = self.sig(now=NOW + 2, tm=tm)                    # 179 s: still compacting, optimistically
+        self.assertEqual(self.moved(s3, s4), ("clock",))
+        self.assertEqual(self.sig(now=NOW + 4, tm=tm), s3, "...back to the clicked-nothing key, exactly at the crossing")
+        km._model_switch_pending[SID] = {"target": "other", "until": time.time() + 60}
+        self.assertEqual(self.moved(s3, self.sig(now=NOW + 4, tm=tm)), ("clock",), "a model switch in flight")
+        km._model_switch_pending.pop(SID, None)
+
+    def test_parked_ops_miss_under_ops_and_the_limit_hold_is_read_only_while_something_is_queued(self):
+        a = self.sig()
+        lim = km._CHAT_SIG_LABELS.index("limit")
+        self.assertIsNone(a[lim], "nothing queued or parked: the hold is not read")
+        km._pending_ops[SID] = [("send", "a parked message", True)]
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("ops",), "the parked op; the hold is now read and, unlimited, still None")
+        km._set_retry_paused(True, reason="spend")
+        try:
+            c = self.sig()
+            self.assertEqual(self.moved(b, c), ("limit",), "the spend hold the queued bubble names")
+            self.assertEqual(c[lim]["reason"], "spend")
+        finally:
+            km._set_retry_paused(False)
+        km._pending_ops.pop(SID, None)
+        km._set_retry_paused(True, reason="spend")
+        try:
+            self.assertEqual(self.sig(), a, "with no bubble to render the hold is neither read nor keyed")
+        finally:
+            km._set_retry_paused(False)
+
+    def test_the_limit_hold_is_read_for_a_tmux_sessions_in_flight_echo_too(self):
+        lim = km._CHAT_SIG_LABELS.index("limit")
+        self.assertIsNone(self.sig()[lim])
+        km._tmux_echo_add(SID, "typed while busy")
+        km._set_retry_paused(True, reason="spend")
+        try:
+            self.assertEqual(self.sig()[lim]["reason"], "spend", "a tmux echo folds into the queue while busy, so the hold is read")
+        finally:
+            km._set_retry_paused(False)
+
+    def test_the_retry_state_misses_under_retry(self):
+        a = self.sig()
+        km._auto_retry_state[SID] = {"n": 2, "next": NOW + 30}
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("retry",))
+        self.assertTrue(km._write_retry_suppress({SID: NOW}), "the suppression ledger's one writer")
+        self.assertEqual(self.moved(b, self.sig()), ("retry",))
+
+    def test_the_live_task_rows_miss_under_bg_as_the_builds_own_filter_returns_them(self):
+        """The bg component is the row list _bg_live_norm returns, the build's own filtered view (a row
+        drops out of it when em._bg_expired says its deadline passed, which that filter decides against
+        the wall clock); the component follows the list, so a row leaving it is a change."""
+        saved = km._bg_live_norm
+        rows = [{"tid": "t1", "desc": "a watcher", "t": NOW - 60, "type": "local_bash"}]
+        km._bg_live_norm = lambda sid, path: list(rows)
+        try:
+            a = self.sig()
+            self.assertEqual(self.sig(now=NOW + 1), a)
+            rows.clear()                                  # the filter dropped the row (as at its deadline)
+            self.assertEqual(self.moved(a, self.sig(now=NOW + 2)), ("bg",))
+        finally:
+            km._bg_live_norm = saved
+
+    def test_a_kernel_watch_misses_under_watch_and_so_does_one_replaced_under_the_same_note(self):
+        a = self.sig()
+        with km._watch_lock:
+            km._watches.append({"id": "w-1", "cmd": "test -f done", "every": 60, "timeoutS": 600, "sid": SID,
+                                "note": "the build", "at": NOW - 5})
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("watch",))
+        with km._watch_lock:                              # cancelled and re-armed under the same note, a new id and predicate
+            km._watches[:] = [w for w in km._watches if w.get("id") != "w-1"]
+            km._watches.append({"id": "w-2", "cmd": "test -f really-done", "every": 60, "timeoutS": 600, "sid": SID,
+                                "note": "the build", "at": NOW - 5})
+        self.assertEqual(self.moved(b, self.sig()), ("watch",), "the cancel handle and the predicate the box renders moved")
+
+    def test_the_awaiting_stamp_view_misses_under_stamp_when_the_postal_log_lands(self):
+        """The durable awaiting stamp is read through _session_stamp_read, whose memo is keyed on the store, the
+        override journal and the POSTAL LOG: a peer's answer supersedes a peer wait, so mail landing changes the
+        chip of a tab that carries no postal card at all. The supersede predicate is held here (its own tests
+        are elsewhere); the log append is the real event that re-reads the view."""
+        a = self.sig()
+        g = SID + ":g1"
+        self.store({g: {"id": g, "text": "wait for the api", "parentId": None, "t": T0, "awaitingAt": T0 + 10,
+                        "awaitingWhy": "waiting on api", "trail": []}}, {g: "working"})
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("stamp", "store"), "the stamp filed: the store's identity and the stamp view")
+        saved = km._peer_stamp_superseded
+        km._peer_stamp_superseded = lambda nd, answered: T0 + 20   # the awaited answer arrived after the stamp
+        try:
+            self.assertEqual(self.sig(), b, "the predicate is not re-asked while the view's inputs stand")
+            jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+            with open(jd.MESSAGES, "a") as f:
+                f.write(json.dumps({"ev": "sent", "id": "m1", "from_id": PEER, "to_id": SID, "body": "done", "t": T0 + 20}) + "\n")
+            moved = self.moved(b, self.sig())
+            self.assertIn("stamp", moved, "the log moved, the view re-read, the stamp superseded")
+            self.assertLessEqual(set(moved), {"stamp", "postal"})
+        finally:
+            km._peer_stamp_superseded = saved
+
+    def test_the_anchor_revision_the_suspension_list_and_the_names_digest(self):
+        a = self.sig()
+        km._node_anchor_rev[SID] = km._node_anchor_rev.get(SID, 0) + 1
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("anchors",))
+        km._downtime.append((NOW - 500, NOW - 400))
+        c = self.sig()
+        self.assertEqual(self.moved(b, c), ("downtime",))
+        (jd.NAMES / SID).write_text("web-renamed\t%s\t#1EA1EB\twhite\n" % self.cdir)
+        self.assertEqual(self.moved(c, self.sig()), ("names",))
+
+    def test_the_shared_files_each_miss_under_their_own_label(self):
+        a = self.sig()
+        (jd.STATE / "session-flags.json").write_text(json.dumps({SID: {"hideFromFeed": True}}))
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("flags",))
+        (jd.STATE / "notify-cards.json").write_text(json.dumps({"*": True}))
+        c = self.sig()
+        self.assertEqual(self.moved(b, c), ("ncards",))
+        (jd.STATE / "colormap").write_text("viridis\n")
+        d = self.sig()
+        self.assertEqual(self.moved(c, d), ("colormap",))
+        with open(jd.STATE / "cleared.jsonl", "a") as f:
+            f.write(json.dumps({"id": "x", "t": NOW}) + "\n")
+        e = self.sig()
+        self.assertEqual(self.moved(d, e), ("cleared",))
+        os.environ["ROMP_HOST_NAME"] = "otherhost"
+        self.assertEqual(self.moved(e, self.sig()), ("host",))
+
+    def test_the_billing_readers_move_acct(self):
+        a = self.sig()
+        km._claude_account_label = lambda: "someone@example.invalid"
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("acct",), "the login label")
+        km._auth_avail_status = lambda: {"login": True, "key": False, "keyWhy": "no helper"}
+        self.assertEqual(self.moved(b, self.sig()), ("acct",), "the availability half the Billing hover reads")
+
+    def test_the_cwd_rows_and_the_claudemd_chain(self):
+        a = self.sig()
+        (self.cdir / "CLAUDE.md").write_text("# project rules\n")
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("claudemd",))
+        (jd.NAMES / SID).write_text("web\t%s\t#1EA1EB\twhite\n" % (self.cdir / "sub"))
+        moved = self.moved(b, self.sig())
+        self.assertIn("cwd", moved)
+        self.assertLessEqual(set(moved), {"cwd", "claudemd", "names"})
+
+    def test_the_handed_liveness_map_is_served_to_every_nested_read(self):
+        """_chat_build_sig serves the map it was handed (_serve_live) to the reads beneath it, so the bg
+        component (through _bg_live_norm), the awaiting sources and the watch rows read the snapshot the
+        build will, and a signature outside a pusher cycle (a connect push on a handler thread) forks no
+        tmux and sweeps no registry per tab. A fresh liveness read during the call is the failure."""
+        def fresh():
+            raise AssertionError("a nested read took a fresh liveness snapshot instead of the handed map")
+        km._tmux_sessions = self.saved[5]                 # the kernel's own reader: the served snapshot, else Sessions.live()
+        saved_live = km.Sessions.live
+        km.Sessions.live = staticmethod(fresh)
+        aid = "a0123456789abcdef"
+        row = dict(self.row)
+        row["bgTasks"] = [{"toolUseId": "tu_1", "desc": "Running Map the parser", "since": NOW - 30,
+                           "type": "local_agent", "taskId": aid}]
+        try:
+            s = km._chat_build_sig(self.sess, row, NOW, tmux={SID: row})
+            self.assertEqual(s[km._CHAT_SIG_LABELS.index("bg")],
+                             (("tu_1", "Map the parser", NOW - 30, "local_agent", None, aid),),
+                             "the task rows come from the handed row, through the build's own normalizer")
+            self.assertIsNone(getattr(km._live_scope, "snapshot", None), "the scope closes with the call")
+            s2 = km._chat_build_sig(self.sess, row, NOW, tmux={SID: row})
+            self.assertEqual(s, s2)
+        finally:
+            km.Sessions.live = saved_live
+
+    def test_a_recorded_task_output_that_grows_misses_under_taskout(self):
+        out = Path(self.td.name) / "task-out.log"
+        out.write_text("line 1\n")
+        rec = {"task_outs": [(str(out), km._chat_stat_key(str(out)))], "pl_pending": [], "pl_at": (), "pl_check": None,
+               "postal_any": False, "postal_cards": []}
+        a = self.sig(deps=rec)
+        self.assertEqual(self.sig(deps=rec), a)
+        with open(out, "a") as f:
+            f.write("line 2\n")
+        self.assertEqual(self.moved(a, self.sig(deps=rec)), ("taskout",))
+        absent = Path(self.td.name) / "not-yet.log"
+        rec2 = {"task_outs": [(str(absent), None)], "pl_pending": [], "pl_at": (), "pl_check": None,
+                "postal_any": False, "postal_cards": []}
+        b = self.sig(deps=rec2)
+        absent.write_text("appeared\n")
+        self.assertEqual(self.moved(b, self.sig(deps=rec2)), ("taskout",), "a file the build found absent appearing is a change")
+
+    def test_a_pending_path_token_whose_file_appears_misses_under_pathlink(self):
+        md = "see notes/report.md for the numbers"
+        km._PATH_LINK_CACHE[(SID, "u9")] = ({}, ("notes/report.md",), {})
+        rec = {"task_outs": [], "pl_pending": [("u9", md)], "pl_at": (("u9", None, None),), "pl_check": None,
+               "postal_any": False, "postal_cards": []}
+        a = self.sig(deps=rec)
+        self.assertEqual(self.sig(deps=rec), a, "unresolved and nothing moved: the record's answers hold")
+        (self.cdir / "notes").mkdir()
+        (self.cdir / "notes" / "report.md").write_text("42\n")
+        b = self.sig(deps=rec)
+        self.assertEqual(self.moved(a, b), ("pathlink",), "the mention became a link")
+
+    def test_a_postal_dependency_misses_under_postal_when_the_log_moves_or_a_caption_changes(self):
+        caps = {}
+        saved = km._msg_summaries
+        km._msg_summaries = lambda: dict(caps)
+        try:
+            jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+            with open(jd.MESSAGES, "a") as f:
+                f.write(json.dumps({"ev": "sent", "id": "m7", "from_id": PEER, "to_id": SID, "body": "hello", "t": T0}) + "\n")
+            card = {"kind": "postal-service", "direction": "in", "mid": "m7", "peer": "api"}
+            rec = {"task_outs": [], "pl_pending": [], "pl_at": (), "pl_check": None, "postal_any": True, "postal_cards": [card]}
+            a = self.sig(deps=rec)
+            self.assertEqual(self.sig(deps=rec), a)
+            caps["m7"] = "api: said hello"
+            b = self.sig(deps=rec)
+            self.assertEqual(self.moved(a, b), ("postal",), "a caption the card embeds landed")
+            with open(jd.MESSAGES, "a") as f:
+                f.write(json.dumps({"ev": "sent", "id": "m8", "from_id": PEER, "to_id": SID, "body": "more", "t": T0 + 1}) + "\n")
+            moved = self.moved(b, self.sig(deps=rec))
+            self.assertIn("postal", moved, "the log moved")
+        finally:
+            km._msg_summaries = saved
+
+
+class KeyCost(_World):
+    def test_the_precheck_vouches_and_a_quiet_cycle_re_resolves_nothing(self):
+        md = "see notes/report.md and docs/plan.md"
+        km._PATH_LINK_CACHE[(SID, "u9")] = ({}, ("notes/report.md", "docs/plan.md"), {})
+        # tokens present, none resolved: the build stores pathLinks {} (a verdict was rendered), no pins
+        rec = {"task_outs": [], "pl_pending": [("u9", md)], "pl_at": (("u9", {}, None),), "pl_check": None,
+               "postal_any": False, "postal_cards": []}
+        km._live_scope.chat_shared = None
+        self.sig(deps=rec)                                    # the first cycle re-resolves and vouches
+        self.assertIsNotNone(rec["pl_check"], "every answer held: the pre-check is stored")
+        calls = []
+        saved = km._path_links
+        km._path_links = lambda *a, **k: calls.append(a) or saved(*a, **k)
+        try:
+            km._live_scope.chat_shared = None
+            self.sig(deps=rec)
+            self.assertEqual(calls, [], "no candidate directory moved: nothing is re-resolved")
+            (self.cdir / "docs").mkdir()
+            (self.cdir / "docs" / "plan.md").write_text("the plan\n")
+            km._live_scope.chat_shared = None
+            s = self.sig(deps=rec)
+            self.assertEqual(len(calls), 1, "a moved directory re-resolves the message that named it")
+            self.assertEqual(s[km._CHAT_SIG_LABELS.index("pathlink")][0][1], {"docs/plan.md": "docs/plan.md"})
+        finally:
+            km._path_links = saved
+
+    def test_a_push_outside_a_cycle_opens_its_own_scopes_and_closes_them(self):
+        km._live_scope.names = None
+        km._live_scope.msgsum = None
+        km._chat_push_scopes_open()
+        try:
+            self.assertIsNotNone(km._live_scope.chat_shared)
+            self.assertIsNotNone(km._live_scope.names)
+            self.assertIsNotNone(km._live_scope.msgsum)
+        finally:
+            km._chat_push_scopes_close()
+        self.assertIsNone(km._live_scope.chat_shared)
+        self.assertIsNone(km._live_scope.names, "a scope this push opened is closed by it")
+        self.assertIsNone(km._live_scope.msgsum)
+        km._live_scope.names = {"kept": ["x"]}
+        km._chat_push_scopes_open()
+        km._chat_push_scopes_close()
+        self.assertEqual(km._live_scope.names, {"kept": ["x"]}, "a cycle's own scope is never touched")
+        km._live_scope.names = None
+
+    def test_a_cycle_closes_the_push_scopes_its_jobs_left_open(self):
+        """A push that raised between _chat_push_scopes_open and its close leaves the shared components on
+        the pusher thread; _pusher_cycle's finally closes them, so the next cycle reads them fresh."""
+        saved = km._pusher_cycle_jobs
+
+        def jobs(now, tmux, any_client):
+            km._chat_push_scopes_open()                       # ...and nothing closes them
+            self.assertIsNotNone(km._live_scope.chat_shared)
+        km._pusher_cycle_jobs = jobs
+        try:
+            km._pusher_cycle()
+        finally:
+            km._pusher_cycle_jobs = saved
+        self.assertIsNone(getattr(km._live_scope, "chat_shared", None), "closed by the cycle's finally")
+        self.assertIsNone(getattr(km._live_scope, "chat_push_owned", None))
+        self.assertIsNone(getattr(km._live_scope, "names", None), "the cycle's own scopes are closed too")
+
+
+# ── the pusher: one key for every tab ─────────────────────────────────────────────────────────────
+SID_A = "77777777-8888-9999-aaaa-ddddddddddd1"
+SID_B = "77777777-8888-9999-aaaa-ddddddddddd2"
+
+
+class Pusher(unittest.TestCase):
+    """_push with the builders stubbed: which tabs rebuild, and why."""
+
+    STUBS = ("_tmux_sessions", "_live_names", "_chat_tab_sessions", "build_session",
+             "_cached_feed", "_cached_timeline", "build_timeline", "_fleet_view_sig", "_comments_frame",
+             "_retry_parked_creates", "_sdk")
+
+    def setUp(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        self.tmp = td.name
+        names = Path(self.tmp) / "names"
+        names.mkdir()
+        for sid, nm in ((SID_A, "web"), (SID_B, "api")):
+            (names / sid).write_text("%s\t/proj/TESTHOST/app\t#1EA1EB\twhite\n" % nm)
+        self.tx = {sid: Path(self.tmp) / (sid + ".jsonl") for sid in (SID_A, SID_B)}
+        for p in self.tx.values():
+            p.write_text('{"type": "user"}\n')
+        self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
+        self.saved_state = (jd.STATE, dict(km._built_chat), dict(km._prev_chat_events),
+                            dict(km._prev_chat_ledger), list(km._last_tab_order), km._judge_gen[0], km.NAMES,
+                            [set(km._thread_fold_keep[0]), set(km._thread_fold_keep[1])])
+        jd._rebind_state(Path(self.tmp) / "state")
+        for d in (jd.STATESDIR, jd.GOALDIR):
+            d.mkdir(parents=True, exist_ok=True)
+        km.NAMES = names
+        self.tmux = {}
+        km._tmux_sessions = lambda: dict(self.tmux)
+        km._sdk = lambda: None
+        km._live_names = lambda tm: {"web": SID_A, "api": SID_B}
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": s, "name": n, "path": str(self.tx[s]), "anchor": s}
+                                                  for s, n in ((SID_A, "web"), (SID_B, "api"))]
+        km.build_session = self._build_session
+        km._cached_feed = lambda now, tmux, sig, connect=False: {"working": [], "awaiting": [], "now": now}
+        km._cached_timeline = lambda now, tmux, sig, connect=False: {"turns": {}, "judging": [], "messages": [], "now": now}
+        km.build_timeline = lambda now, tmux, **kw: {"lanes": [], "now": now}
+        km._fleet_view_sig = lambda now, tmux: {"probe": 1}
+        km._comments_frame = lambda sid, tmux: None
+        km._retry_parked_creates = lambda: None
+        km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        self.built = []
+        self.chat = {"app": "chat", "alive": True, "sent": {}, "active": None, "send": lambda s: None}
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        st, bc, pe, pl, lo, jg, names, keep = self.saved_state
+        jd._rebind_state(st)
+        km.NAMES = names
+        km._built_chat.clear(); km._built_chat.update(bc)
+        km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
+        km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
+        km._last_tab_order[:] = lo
+        km._judge_gen[0] = jg
+        km._thread_fold_keep[0], km._thread_fold_keep[1] = keep
+        for sid in (SID_A, SID_B):
+            km._tmux_echo.pop(sid, None); km._tmux_echo_rev.pop(sid, None)
+
+    def _build_session(self, sid, now, tmux):
+        self.built.append(sid)
+        return {"type": "session", "id": sid, "name": "x", "events": [{"uuid": "e1", "type": "user"}],
+                "ledger": None, "status": {"state": "waiting"}, "color": None}
+
+    @staticmethod
+    def _chat():
+        return km._PERF_STATS.snapshot()["builds"]["chat"]
+
+    @staticmethod
+    def _delta(before, after):
+        d = {k: after[k] - before[k] for k in ("cached", "built", "active_built", "bg_built", "moved")}
+        d["bg_miss"] = {k: v - before["bg_miss"][k] for k, v in after["bg_miss"].items() if v - before["bg_miss"][k]}
+        return d
+
+    def test_one_sessions_store_publish_rebuilds_that_tab_alone(self):
+        """Two background tabs; B's goal store is published and the producer's generation bump follows, as a
+        judge pass does. Only B rebuilds, under the store label. Before this, the global judge generation was
+        a component of every tab's key, so A rebuilt too, byte-identical."""
+        km._push([self.chat])
+        km._push([self.chat])
+        self.assertEqual(sorted(self.built), sorted([SID_A, SID_B]), "the second push served both from the cache")
+        c0 = self._chat()
+        (jd.GOALDIR / (SID_B + ".json")).write_text(json.dumps({"rompUuid": SID_B, "nodes": {}, "status": {}}))
+        self.assertTrue(km._bump_judge_gen_if_changed(), "the store directory moved: the producer bumps the generation")
+        km._push([self.chat])
+        self.assertEqual(self.built[2:], [SID_B], "B alone rebuilt")
+        self.assertEqual(self._delta(c0, self._chat())["bg_miss"], {"store": 1})
+        km._judge_gen[0] += 1                                 # a pass that moved nothing this world reads
+        km._push([self.chat])
+        self.assertEqual(self.built[2:], [SID_B], "the generation alone rebuilds no tab")
+
+    def test_a_bare_dirty_mark_rebuilds_nothing_and_a_live_tail_echo_rebuilds_its_tab(self):
+        self.chat["active"] = SID_A
+        km._push([self.chat]); km._push([self.chat])
+        n = len(self.built)
+        km._mark_views_dirty()
+        km._push([self.chat])
+        self.assertEqual(len(self.built), n, "a dirty mark with no moved input is no new information for the chat")
+        km._tmux_echo_add(SID_A, "and also fix the header")
+        km._push([self.chat])
+        self.assertEqual(self.built[n:], [SID_A], "the watched tab's live tail moved: it rebuilds, and B is served")
+
+    def test_the_cache_entry_is_the_signature_the_payload_its_serialization_and_the_dependency_record(self):
+        self.chat["active"] = SID_A
+        km._push([self.chat])
+        for sid in (SID_A, SID_B):
+            ent = km._built_chat[sid]
+            self.assertEqual(len(ent), 4)
+            self.assertEqual(len(ent[0]), len(km._CHAT_SIG_LABELS))
+            self.assertEqual(ent[1]["id"], sid)
+            self.assertIn("task_outs", ent[3])
+            self.assertTrue(ent[2] is None or isinstance(ent[2], str), "index 2: the lazy serialization, a string once a full send materialized it")
+
+    def test_a_build_whose_signature_moved_during_the_build_is_not_cached_and_counts_under_moved(self):
+        def build(sid, now, tmux):
+            self.built.append(sid)
+            if sid == SID_B:
+                km._node_anchor_rev[SID_B] = km._node_anchor_rev.get(SID_B, 0) + 1   # the build learned an anchor
+            return {"type": "session", "id": sid, "name": "x", "events": [], "ledger": None,
+                    "status": {"state": "waiting"}, "color": None}
+        km.build_session = build
+        try:
+            c0 = self._chat()
+            km._push([self.chat])
+            self.assertNotIn(SID_B, km._built_chat, "the post-build signature differs: not cached")
+            self.assertIn(SID_A, km._built_chat)
+            self.assertEqual(self._delta(c0, self._chat())["moved"], 1)
+        finally:
+            km._node_anchor_rev.pop(SID_B, None)
+
+    def test_a_signature_that_raises_is_said_once_per_episode_and_the_tab_builds_uncached(self):
+        """One component's read raising for one session: its tab is built every cycle and never cached
+        (counted under nosig), the fault is written to stderr with its traceback and filed as one bell row,
+        ONCE per fault episode (the chat-build fault's rule): the same fault the next cycle says nothing, a
+        different fault is a new episode, a signature that is taken ends it."""
+        saved = (km._watch_awaiting, list(km._SYNC_NOTICES), dict(km._chat_sig_faults))
+        del km._SYNC_NOTICES[:]
+        km._chat_sig_faults.clear()
+        fail = ["synthetic: the watch rows cannot be read"]
+        orig = saved[0]
+
+        def watch(sid):
+            if sid == SID_B and fail[0]:
+                raise OSError(fail[0])
+            return orig(sid)
+        km._watch_awaiting = watch
+
+        def push():
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                km._push([self.chat])
+            return err.getvalue().count("push build: chat signature %s" % SID_B[:8])
+        try:
+            c0 = self._chat()
+            self.assertEqual(push(), 1, "the first cycle says it")
+            self.assertEqual(push(), 0, "the second cycle, same fault: not again")
+            self.assertEqual(push(), 0)
+            self.assertEqual(self.built.count(SID_B), 3, "the tab builds every cycle while its key cannot be taken")
+            self.assertEqual(self.built.count(SID_A), 1, "the other tab is served")
+            self.assertNotIn(SID_B, km._built_chat, "never cached")
+            self.assertEqual(self._delta(c0, self._chat())["bg_miss"].get("nosig"), 3)
+            self.assertEqual(len(km._SYNC_NOTICES), 1, "one episode, one bell row")
+            self.assertIn("api", km._SYNC_NOTICES[-1]["text"])
+            self.assertEqual(km._SYNC_NOTICES[-1].get("kind"), "refused")
+            fail[0] = "synthetic: a different fault on the same session"
+            self.assertEqual(push(), 1, "a different fault is a new episode")
+            self.assertEqual(len(km._SYNC_NOTICES), 2)
+            fail[0] = ""
+            self.assertEqual(push(), 0)
+            self.assertNotIn(SID_B, km._chat_sig_faults, "a signature that is taken ends the episode")
+            self.assertIn(SID_B, km._built_chat, "...and the tab is cached like any other")
+            fail[0] = "synthetic: the watch rows cannot be read"
+            self.assertEqual(push(), 1, "the same fault after a success is a new episode, said anew")
+        finally:
+            km._watch_awaiting = orig
+            del km._SYNC_NOTICES[:]
+            km._SYNC_NOTICES.extend(saved[1])
+            km._chat_sig_faults.clear()
+            km._chat_sig_faults.update(saved[2])
+
+    def test_a_push_closes_the_scopes_a_previous_push_on_its_thread_left_open(self):
+        """A push that raised inside its chat loop leaves the scopes it opened set on the thread; the next
+        push closes them first, so it opens its own fresh ones (and closes them) instead of adopting a
+        stale names snapshot as a cycle's and leaving it on the thread for good."""
+        km._live_scope.names = {"stale": ["x"]}
+        km._live_scope.msgsum = [object()]
+        km._live_scope.chat_shared = {"stale": 1}
+        km._live_scope.chat_push_owned = ["chat_shared", "msgsum", "names"]
+        try:
+            km._push([self.chat])
+            for k in ("names", "msgsum", "chat_shared", "chat_push_owned"):
+                self.assertIsNone(getattr(km._live_scope, k, None), "%s: the stale scope is gone after the push" % k)
+        finally:
+            for k in ("names", "msgsum", "chat_shared", "chat_push_owned"):
+                setattr(km._live_scope, k, None)
+
+
+# ── the recording half: the real build makes the record the differential tests hand over ──────────
+SID_R = "77777777-8888-9999-aaaa-eeeeeeeeeee1"
+AID = "a0123456789abcdef"                        # an agent id of the CLI's shape: a plus 16 hex digits
+
+
+class RecordedDependencies(unittest.TestCase):
+    """The dependency record through the REAL build_session under _push. The differential tests above hand
+    _chat_build_sig a record made by hand and check the re-evaluation; these pin the other half: the readers
+    note the files whose tails the payload embeds as they read them (_chat_dep_note_taskout from
+    _read_task_output, _subagent_meta_map, _subagent_file and _agent_steps), a fold hit carries the sealed
+    prefix's outputs into the record, a raw postal event flags the log as a dependency, and the pusher
+    consumes the record and leaves none on its thread. Synthetic session under a hermetic state root;
+    records stamped against the real clock, which discovery keys on."""
+
+    STUBS = ("_tmux_sessions", "_live_names", "_chat_tab_sessions", "_cached_feed", "_cached_timeline",
+             "build_timeline", "_fleet_view_sig", "_comments_frame", "_retry_parked_creates", "_sdk", "_msg_summaries")
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.addCleanup(self.td.cleanup)
+        td = Path(self.td.name)
+        self.cdir = td / "launchdir"
+        self.cdir.mkdir()
+        proj = td / "projects"
+        self.pdir = proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(self.cdir)))
+        self.pdir.mkdir(parents=True)
+        self.tpath = self.pdir / (SID_R + ".jsonl")
+        self.tpath.write_text("")
+        self.now = int(time.time())
+        self.t = self.now - 3 * 86400
+        self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
+        self.saved_state = (jd.STATE, jd.PROJECTS, km.NAMES, km._GLOBAL_CLAUDE_MD, os.environ.get("CLAUDE_CONFIG_DIR"),
+                            dict(km._built_chat), dict(km._prev_chat_events), dict(km._prev_chat_ledger),
+                            list(km._last_tab_order), [set(km._thread_fold_keep[0]), set(km._thread_fold_keep[1])])
+        jd._rebind_state(td / "state")
+        jd.PROJECTS = proj
+        jd.NAMES.mkdir(parents=True, exist_ok=True)
+        (jd.NAMES / SID_R).write_text("web\t%s\t#1EA1EB\twhite\n" % self.cdir)
+        km.NAMES = jd.NAMES
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        os.environ["CLAUDE_CONFIG_DIR"] = str(td / "claude")
+        self.row = {"state": "working", "since": self.now - 100, "model": "", "effort": "", "context": None,
+                    "compactPct": None, "color": None, "backend": "tmux"}
+        km._tmux_sessions = lambda: {SID_R: self.row}
+        km._sdk = lambda: None
+        km._msg_summaries = lambda: {}
+        km._live_names = lambda tm: {"web": SID_R}
+        km._chat_tab_sessions = lambda now, tmux: [{"sid": SID_R, "name": "web", "path": str(self.tpath), "anchor": SID_R}]
+        km._cached_feed = lambda now, tmux, sig, connect=False: {"working": [], "awaiting": [], "now": now}
+        km._cached_timeline = lambda now, tmux, sig, connect=False: {"turns": {}, "judging": [], "messages": [], "now": now}
+        km.build_timeline = lambda now, tmux, **kw: {"lanes": [], "now": now}
+        km._fleet_view_sig = lambda now, tmux: {"probe": 1}
+        km._comments_frame = lambda sid, tmux: None
+        km._retry_parked_creates = lambda: None
+        km._built_chat.clear(); km._prev_chat_events.clear(); km._prev_chat_ledger.clear()
+        km._parse_cache.clear(); km._task_out_cache.clear(); km._chat_fold.pop(SID_R, None)
+        if isinstance(jd._discover_cache, dict):
+            jd._discover_cache.clear()
+        self.n = 0
+        self.last = None
+        self.chat = {"app": "chat", "alive": True, "sent": {}, "active": None, "send": lambda s: None}
+
+    def tearDown(self):
+        for nm, v in self.saved.items():
+            setattr(km, nm, v)
+        st, proj, names, gmd, cfg, bc, pe, pl, lo, keep = self.saved_state
+        jd._rebind_state(st)
+        jd.PROJECTS = proj
+        km.NAMES, km._GLOBAL_CLAUDE_MD = names, gmd
+        if cfg is None:
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+        else:
+            os.environ["CLAUDE_CONFIG_DIR"] = cfg
+        km._built_chat.clear(); km._built_chat.update(bc)
+        km._prev_chat_events.clear(); km._prev_chat_events.update(pe)
+        km._prev_chat_ledger.clear(); km._prev_chat_ledger.update(pl)
+        km._last_tab_order[:] = lo
+        km._thread_fold_keep[0], km._thread_fold_keep[1] = keep
+        km._tmux_echo.pop(SID_R, None); km._tmux_echo_rev.pop(SID_R, None)
+        km._chat_fold.pop(SID_R, None); km._parse_cache.clear(); km._task_out_cache.clear()
+        km._chat_dep_scope.deps = None
+        if isinstance(jd._discover_cache, dict):
+            jd._discover_cache.clear()
+
+    # ── the transcript ──
+    def uid(self):
+        self.n += 1
+        return "cccccccc-0000-0000-0000-%012d" % self.n
+
+    def tick(self, dt=5):
+        self.t += dt
+        return self.t
+
+    def append(self, recs):
+        with open(self.tpath, "a") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+        os.utime(self.tpath, None)
+
+    def turn(self, i):
+        u, a = self.uid(), self.uid()
+        recs = [_uline(self.tick(), "step %d: tighten the notes-api search" % i, u, self.last),
+                _aline(self.tick(), "Step %d done." % i, a, u)]
+        self.last = a
+        return recs
+
+    def agent_turn(self, out):
+        """An Agent dispatched in the background and still running: the tool_use, the async launch ack naming
+        the agent and its output file, a closing reply."""
+        u, a, r, b = self.uid(), self.uid(), self.uid(), self.uid()
+        recs = [_uline(self.tick(), "map the parser in the background", u, self.last),
+                {"type": "assistant", "timestamp": _iso(self.tick()), "uuid": a, "parentUuid": u,
+                 "message": {"role": "assistant", "content": [
+                     {"type": "text", "text": "Dispatching."},
+                     {"type": "tool_use", "id": "tu_agent1", "name": "Agent",
+                      "input": {"description": "Map the parser", "prompt": "map the parser end to end",
+                                "subagent_type": "general-purpose", "run_in_background": True}}],
+                             "stop_reason": "tool_use"}},
+                {"type": "user", "timestamp": _iso(self.tick()), "uuid": r, "parentUuid": a,
+                 "toolUseResult": {"isAsync": True, "status": "async_launched", "agentId": AID,
+                                   "description": "Map the parser", "prompt": "map the parser end to end",
+                                   "outputFile": str(out)},
+                 "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_agent1",
+                                                          "content": [{"type": "text", "text": "Async agent launched successfully."}]}]}},
+                _aline(self.tick(), "The agent is running.", b, r)]
+        self.last = b
+        return recs
+
+    def bash_turn(self, out):
+        """A backgrounded shell command whose result landed: the launch, the task notification naming its
+        output file (the standalone user-record shape), a closing reply. The card's detail embeds the file's tail."""
+        u, a, r, b = self.uid(), self.uid(), self.uid(), self.uid()
+        note = ("<task-notification>\n<task-id>bkv4ddzb1</task-id>\n<tool-use-id>tu_bash1</tool-use-id>\n"
+                "<output-file>%s</output-file>\n<status>completed</status>\n<summary>Tests finished</summary>\n"
+                "</task-notification>" % out)
+        recs = [_uline(self.tick(), "run the tests in the background", u, self.last),
+                {"type": "assistant", "timestamp": _iso(self.tick()), "uuid": a, "parentUuid": u,
+                 "message": {"role": "assistant", "content": [
+                     {"type": "text", "text": "Running them."},
+                     {"type": "tool_use", "id": "tu_bash1", "name": "Bash",
+                      "input": {"run_in_background": True, "command": "uv run pytest -q", "description": "Run the tests"}}],
+                             "stop_reason": "tool_use"}},
+                {"type": "user", "timestamp": _iso(self.tick()), "uuid": r, "parentUuid": a,
+                 "message": {"role": "user", "content": note}, "promptSource": "sdk", "userType": "external"},
+                _aline(self.tick(), "They pass.", b, r)]
+        self.last = b
+        return recs
+
+    def agent_files(self, where=None):
+        """The agent's sidecar meta and its own transcript beside the parent transcript (or under `where`)."""
+        sdir = (where or self.pdir / SID_R) / "subagents"
+        sdir.mkdir(parents=True, exist_ok=True)
+        (sdir / ("agent-%s.meta.json" % AID)).write_text(json.dumps(
+            {"toolUseId": "tu_agent1", "agentId": AID, "agentType": "general-purpose", "description": "Map the parser"}))
+        ap = sdir / ("agent-%s.jsonl" % AID)
+        with open(ap, "w") as f:
+            f.write(json.dumps({"type": "assistant", "timestamp": _iso(self.tick()), "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "tu_a1", "name": "Read", "input": {"file_path": "parser.py"}}]}}) + "\n")
+        return sdir, ap
+
+    @staticmethod
+    def _chat():
+        return km._PERF_STATS.snapshot()["builds"]["chat"]
+
+    def rebuilds(self, before):
+        after = self._chat()
+        return {k: v - before["bg_miss"][k] for k, v in after["bg_miss"].items() if v - before["bg_miss"][k]}
+
+    def record(self):
+        ent = km._built_chat.get(SID_R)
+        self.assertIsNotNone(ent, "the build is cached: its static components held across it")
+        return ent[1], ent[3], dict(ent[3]["task_outs"])
+
+    def test_a_running_tasks_output_and_the_agents_own_transcript_are_recorded_as_they_are_read(self):
+        out = Path(self.td.name) / "agent-out.log"
+        out.write_text("line 1\n")
+        sdir, ap = self.agent_files()
+        self.append(self.turn(1) + self.agent_turn(out))
+        km._push([self.chat])
+        self.assertIsNone(getattr(km._chat_dep_scope, "deps", None), "the pusher consumed the record and left none")
+        m, rec, touts = self.record()
+        self.assertEqual(touts.get(str(out)), km._chat_stat_key(str(out)),
+                         "the task box read the running task's output: recorded under the identity it was read under")
+        self.assertEqual(m["bgTasks"]["tasks"][0]["output"], "line 1")
+        self.assertEqual(touts.get(str(ap)), km._chat_stat_key(str(ap)), "the Agent card read the agent's own transcript")
+        self.assertIn(str(sdir), touts, "and the sidecar directory whose listing named the agent")
+        head = next(ev for ev in m["events"] if ev.get("kind") == "tool" and ev.get("name") == "Agent")
+        self.assertEqual(head.get("stepsTotal"), 1)
+        c = self._chat()
+        with open(out, "a") as f:
+            f.write("line 2\n")
+        km._push([self.chat])
+        self.assertEqual(self.rebuilds(c), {"taskout": 1}, "the output grew: the tab rebuilds under taskout")
+        m, rec, touts = self.record()
+        self.assertEqual(m["bgTasks"]["tasks"][0]["output"], "line 1\nline 2")
+        c = self._chat()
+        with open(ap, "a") as f:
+            f.write(json.dumps({"type": "assistant", "timestamp": _iso(self.tick()), "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "tu_a2", "name": "Grep", "input": {"pattern": "def parse"}}]}}) + "\n")
+        km._push([self.chat])
+        self.assertEqual(self.rebuilds(c), {"taskout": 1}, "the agent's transcript grew: the tab rebuilds under taskout")
+        m, rec, touts = self.record()
+        head = next(ev for ev in m["events"] if ev.get("kind") == "tool" and ev.get("name") == "Agent")
+        self.assertEqual(head.get("stepsTotal"), 2)
+
+    def test_an_agent_file_found_under_a_sibling_directory_records_the_directory_the_lookup_reads(self):
+        """The agent's file is not beside its parent transcript (the sidecar directory moved under a fork's
+        stem): the lookup lists every sibling's subagents/ directory. Those directories are the dependency,
+        not their parents: a file landing inside <sib>/subagents/ moves that directory's mtime and no other."""
+        out = Path(self.td.name) / "agent-out.log"
+        out.write_text("line 1\n")
+        other = self.pdir / "77777777-8888-9999-aaaa-eeeeeeeeeee2"
+        sdir, ap = self.agent_files(where=other)
+        self.append(self.turn(1) + self.agent_turn(out))
+        km._push([self.chat])
+        m, rec, touts = self.record()
+        self.assertEqual(touts.get(str(ap)), km._chat_stat_key(str(ap)), "found under the sibling, and read")
+        self.assertIn(str(sdir), touts, "the sibling's subagents/ directory is the recorded dependency")
+        self.assertEqual(touts[str(sdir)], km._chat_stat_key(str(sdir)))
+        own = self.pdir / SID_R / "subagents"
+        self.assertEqual(touts.get(str(own / ("agent-%s.jsonl" % AID)), "unset"), None,
+                         "the file's own place is recorded absent: its appearance there is a change")
+        c = self._chat()
+        (sdir / ("agent-%s.meta.json" % "a0123456789abcdee")).write_text("{}")   # a sibling file lands in the directory
+        km._push([self.chat])
+        self.assertEqual(self.rebuilds(c), {"taskout": 1}, "the directory the lookup reads moved")
+
+    def test_a_fold_hit_carries_the_sealed_cards_output_into_the_record(self):
+        """A completed task's card embeds its output file's tail; once its turn is sealed in the fold prefix
+        the card is reused without re-reading the file, so the sealed prefix's outputs join the record on a
+        fold hit. Without that a rebuild served from the prefix would drop the file from the key, and the
+        card would show a stale tail until an unrelated input moved."""
+        out = Path(self.td.name) / "tests-out.log"
+        out.write_text("2 passed\n")
+        self.append(self.bash_turn(out) + self.turn(2))
+        km._push([self.chat])
+        m, rec, touts = self.record()
+        self.assertEqual(touts.get(str(out)), km._chat_stat_key(str(out)), "the cold build read the card's tail")
+        self.assertIn(str(out), dict(km._chat_fold_get(SID_R)["task_outs"]), "and the seal recorded it")
+        km._tmux_echo_add(SID_R, "and the coverage")        # the live tail moves: a rebuild over the same parse
+        km._push([self.chat])
+        self.assertGreater(km._chat_fold_last_info().get("prefix", 0), 0, "the second build reused the sealed prefix")
+        m, rec, touts = self.record()
+        self.assertEqual(touts.get(str(out)), km._chat_stat_key(str(out)),
+                         "the fold hit's record still names the sealed card's output")
+        c = self._chat()
+        with open(out, "a") as f:
+            f.write("1 failed\n")
+        km._push([self.chat])
+        self.assertEqual(self.rebuilds(c), {"taskout": 1}, "the sealed card's file grew: the tab rebuilds")
+
+    def test_a_raw_postal_event_that_did_not_hydrate_makes_the_log_a_dependency(self):
+        """A peer's message marker in the tail whose id the postal index does not hold yet renders from the
+        log alone; the record flags postal traffic even though no card rendered, so the log landing (the
+        index catching up) rebuilds the tab."""
+        self.append(self.turn(1))
+        u, a = self.uid(), self.uid()
+        self.append([_uline(self.tick(), "<!-- romp-msg-id: m9 -->\nthe api tests are green now", u, self.last),
+                     _aline(self.tick(), "Noted.", a, u)])
+        self.last = a
+        km._push([self.chat])
+        m, rec, touts = self.record()
+        self.assertFalse([ev for ev in m["events"] if ev.get("kind") == "postal-service"], "no card: the id is not indexed")
+        self.assertTrue(rec["postal_any"], "the raw marker event depends on the log")
+        c = self._chat()
+        jd.MESSAGES.parent.mkdir(parents=True, exist_ok=True)
+        with open(jd.MESSAGES, "a") as f:
+            f.write(json.dumps({"ev": "sent", "id": "m9", "from_id": PEER, "to_id": SID_R, "body": "the api tests are green now",
+                                "t": self.t}) + "\n")
+        km._push([self.chat])
+        self.assertIn("postal", self.rebuilds(c), "the log landed: the tab rebuilds under postal")
+
+    def test_a_targeted_push_leaves_no_dependency_record_on_its_thread(self):
+        """_push_session_now builds one session outside the pusher's cache and must not leave the build's
+        record on the handler thread, where a later reader (a subagent viewer's step fold) would append to it."""
+        out = Path(self.td.name) / "agent-out.log"
+        out.write_text("line 1\n")
+        self.agent_files()
+        self.append(self.turn(1) + self.agent_turn(out))
+        with km._clients_lock:
+            km._clients.append(self.chat)
+        try:
+            km._push_session_now(SID_R)
+        finally:
+            with km._clients_lock:
+                km._clients[:] = [c for c in km._clients if c is not self.chat]
+        self.assertTrue(self.chat["sent"], "the session reached the client")
+        self.assertIsNone(getattr(km._chat_dep_scope, "deps", None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_fixed_cost_memos.py
+++ b/tests/test_chat_fixed_cost_memos.py
@@ -54,9 +54,9 @@ def _clear_memos():
 
 # ── the signature's labels and the chat writer ───────────────────────────────────────────────────
 class SigLabels(unittest.TestCase):
-    """_chat_build_sig is a flat tuple; a background rebuild is attributed to the components that moved, by
-    position: two transcript values, two per states file, then the fixed tail. The row the push hands over
-    is one slot either way (None without a row), so the tail has one shape and every position a label."""
+    """_chat_build_sig is a flat tuple with one labelled position per component (_CHAT_SIG_LABELS); a rebuild
+    is attributed to the components that moved, by position. The row the push hands over is one slot
+    either way (None without a row), so every signature has the same shape."""
 
     def setUp(self):
         td = tempfile.TemporaryDirectory()
@@ -65,35 +65,34 @@ class SigLabels(unittest.TestCase):
         self.tx = Path(self.tmp) / (SID_A + ".jsonl")
         self.tx.write_text('{"type": "user"}\n')
         self.sess = {"sid": SID_A, "path": str(self.tx), "anchor": SID_A}
-        self.saved = km._sdk
+        self.saved = (km._sdk, km._tmux_sessions)
         km._sdk = lambda: None
+        km._tmux_sessions = lambda: {}
 
     def tearDown(self):
-        km._sdk = self.saved
+        km._sdk, km._tmux_sessions = self.saved
 
     def test_a_real_signature_has_one_label_per_position_and_a_row_slot_either_way(self):
         sig = km._chat_build_sig(self.sess)
-        self.assertEqual(km._CHAT_SIG_TAIL, ("judge_gen", "tasks", "cut", "row"))
-        self.assertEqual(km._chat_sig_labels(sig), ("transcript", "transcript", "states", "states") + km._CHAT_SIG_TAIL,
-                         "one states file: the fsid is the anchor")
-        self.assertEqual(len(sig), 8)
-        self.assertIsNone(sig[-1], "no row handed over: the slot is None, so the tail keeps one shape")
+        self.assertEqual(len(sig), len(km._CHAT_SIG_LABELS))
+        row_i = km._CHAT_SIG_LABELS.index("row")
+        self.assertEqual(sig[row_i], (None, False), "no row handed over and an empty map: the slot says so")
         self.assertEqual(km._chat_build_sig(self.sess), sig, "stable while nothing moved")
-        row = {"state": "idle", "model": "m", "context": 10, "effort": "e", "mode": None, "fast": False, "since": 1,
-               "subagents": [], "bgTasks": [], "connected": True}
+        row = {"state": "idle", "model": "m", "context": 10, "effort": "e", "mode": None, "fast": False,
+               "since": int(time.time()) - 5, "subagents": [], "bgTasks": [], "connected": True}   # since: recent, so the faded boolean holds
         sig2 = km._chat_build_sig(self.sess, row)
         self.assertEqual(len(sig2), len(sig))
         self.assertEqual(km._chat_sig_miss(sig, sig2), ("row",), "the row handed over is the row component")
         forked = dict(self.sess, anchor=SID_B)                # a forked lane stats two states files
         sig3 = km._chat_build_sig(forked)
-        self.assertEqual(km._chat_sig_labels(sig3), ("transcript", "transcript") + ("states",) * 4 + km._CHAT_SIG_TAIL)
-        self.assertEqual(km._PerfStats.CHAT_MISS, ("transcript", "states") + km._CHAT_SIG_TAIL + ("cold", "nosig"))
+        self.assertEqual(len(sig3), len(sig), "the states component holds both files; the shape never changes")
+        self.assertEqual(km._chat_sig_miss(sig, sig3), ("states",))
+        self.assertEqual(km._PerfStats.CHAT_MISS, km._CHAT_SIG_LABELS + ("cold", "nosig"))
         self.assertIsNone(km._chat_build_sig({"sid": SID_A, "path": ""}), "no path: no signature")
 
-    def test_each_moved_component_is_named_and_a_reshaped_key_names_the_states_section(self):
-        base = ("mt", "sz", "smt", "ssz", 3, ("fp",), "", None)
-        labels = km._chat_sig_labels(base)
-        for i, lab in enumerate(labels):
+    def test_each_moved_component_is_named(self):
+        base = tuple(range(len(km._CHAT_SIG_LABELS)))
+        for i, lab in enumerate(km._CHAT_SIG_LABELS):
             new = list(base)
             new[i] = "changed"
             self.assertEqual(km._chat_sig_miss(base, tuple(new)), (lab,), lab)
@@ -101,14 +100,11 @@ class SigLabels(unittest.TestCase):
         self.assertEqual(km._chat_sig_miss(None, base), ("cold",), "no cached build")
         self.assertEqual(km._chat_sig_miss(base, None), ("nosig",), "no signature could be taken")
         two = list(base)
-        two[0], two[4] = "x", 4
-        self.assertEqual(km._chat_sig_miss(base, tuple(two)), ("judge_gen", "transcript"),
+        two[km._CHAT_SIG_LABELS.index("transcript")] = "x"
+        two[km._CHAT_SIG_LABELS.index("store")] = "y"
+        self.assertEqual(km._chat_sig_miss(base, tuple(two)), ("store", "transcript"),
                          "several moved components are each named, sorted")
-        # the anchor appeared: the states section grew by one file, the tail still compares from its end
-        grown = ("mt", "sz", "smt", "ssz", "amt", "asz", 4, ("fp",), "", None)
-        self.assertEqual(km._chat_sig_miss(base, grown), ("judge_gen", "states"))
-        self.assertEqual(km._chat_sig_miss(base, ("mt2", "sz", "smt", "ssz", "amt", "asz", 3, ("fp",), "", None)),
-                         ("states", "transcript"))
+        self.assertEqual(km._chat_sig_miss(base, base[:-1]), ("cold",), "a signature of another shape is no cached build")
 
 
 class Collector(unittest.TestCase):
@@ -119,14 +115,15 @@ class Collector(unittest.TestCase):
         st = km._PerfStats()
         st.build_chat(True)
         st.build_chat(False, 0.010, active=True)
-        st.build_chat(False, 0.020, active=False, miss=("judge_gen",))
+        st.build_chat(False, 0.020, active=False, miss=("store",))
         st.build_chat(False, 0.030, active=False, miss=("states", "transcript"))
         st.build_chat(False, 0.005, active=False, miss=("cold",))
+        st.build_chat_moved()
         c = st.snapshot()["builds"]["chat"]
-        self.assertEqual((c["cached"], c["built"], c["active_built"], c["bg_built"]), (1, 4, 1, 3))
+        self.assertEqual((c["cached"], c["built"], c["active_built"], c["bg_built"], c["moved"]), (1, 4, 1, 3, 1))
         self.assertAlmostEqual(c["ms"], 65.0)
         self.assertEqual({k: v for k, v in c["bg_miss"].items() if v},
-                         {"judge_gen": 1, "states": 1, "transcript": 1, "cold": 1},
+                         {"store": 1, "states": 1, "transcript": 1, "cold": 1},
                          "one count per moved component: the two-component miss counts under both")
         self.assertEqual(set(c["bg_miss"]), set(km._PerfStats.CHAT_MISS))
         st.build_chat(False, 0.001, miss=("cold",))
@@ -261,7 +258,7 @@ class TwoTabAttribution(unittest.TestCase):
         km._push([self.chat, self.tl])
         c2 = self._chat()
         self.assertEqual(self._delta(c1, c2), {"cached": 2, "built": 0, "active_built": 0, "bg_built": 0, "bg_miss": {}},
-                         "nothing moved: both tabs are served, the watched one on its exact key")
+                         "nothing moved: both tabs are served on the one key")
         with open(self.tx[SID_B], "a") as f:
             f.write('{"type": "assistant"}\n')
         km._push([self.chat, self.tl])
@@ -269,12 +266,17 @@ class TwoTabAttribution(unittest.TestCase):
         self.assertEqual(self._delta(c2, c3), {"cached": 1, "built": 1, "active_built": 0, "bg_built": 1,
                                                "bg_miss": {"transcript": 1}},
                          "the background tab's transcript grew; the watched one is served")
-        km._judge_gen[0] += 1
+        (jd.GOALDIR / (SID_B + ".json")).write_text(json.dumps({"rompUuid": SID_B, "nodes": {}, "status": {}}))
+        km._bump_judge_gen_if_changed()                    # the producer's own bump after a pass that moved a store
         km._push([self.chat, self.tl])
         c4 = self._chat()
-        self.assertEqual(self._delta(c3, c4)["bg_miss"], {"judge_gen": 1},
-                         "a judge pass that changed a store rebuilds the background tab under judge_gen")
+        self.assertEqual(self._delta(c3, c4)["bg_miss"], {"store": 1},
+                         "a judge pass that published this session's store rebuilds its tab under store")
         self.assertEqual(self._delta(c3, c4)["bg_built"], 1)
+        km._judge_gen[0] += 1                              # a pass that moved nothing this world reads
+        km._push([self.chat, self.tl])
+        self.assertEqual(self._delta(c4, self._chat())["built"], 0, "the judge-pass counter alone rebuilds no tab")
+        c4 = self._chat()
         with open(jd.STATESDIR / (SID_B + ".jsonl"), "a") as f:
             f.write('{"t": 1, "state": "idle"}\n')
         km._push([self.chat, self.tl])

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -2860,10 +2860,12 @@ class ViewBuilder(unittest.TestCase):
         # the kernel on multi-MB transcripts and starved the webview. A BACKGROUND tab whose transcript+states
         # are unchanged reuses its built payload (one stat() instead of a reshape+serialize). The ACTIVE tab
         # used to rebuild on every push "to stay live"; since 2026-09-03 it too is served from its last build
-        # while its EXACT key (_active_chat_sig: file stats + live tail + snapshot + clock predicates) is
-        # unchanged and no kernel-side mutation postdates the build — so a watched 80 MB session no longer
-        # costs a reshape per 0.5 s cycle with nothing moving. Liveness is unchanged: any input that can
-        # move the payload is in the key, and _mark_views_dirty busts it for in-memory stamps.
+        # while its key is unchanged, so a watched 80 MB session no longer costs a reshape per 0.5 s cycle
+        # with nothing moving. That key is now the one complete per-session signature every tab shares
+        # (_chat_build_sig): every input that can move the payload is a component, the in-memory stamps
+        # included, so a tab rebuilds when an input moved and on nothing else. A bare _mark_views_dirty (the
+        # watermark that used to stand in for the stamps no file records) is not new information for the
+        # chat and rebuilds no tab; a live-tail echo, which the payload renders, is and does.
         import tempfile
         d = tempfile.mkdtemp()
         pa, pb = os.path.join(d, "A.jsonl"), os.path.join(d, "B.jsonl")
@@ -2872,8 +2874,9 @@ class ViewBuilder(unittest.TestCase):
                 f.write("{}\n")
         calls = []
         saved = (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
-                 km.build_timeline, km._send_client)
+                 km.build_timeline, km._send_client, km._sdk)
         km._tmux_sessions = lambda: {}
+        km._sdk = lambda: None                                          # both tabs tmux-owned
         km._chat_tab_sessions = lambda now, tmux: [{"sid": "A", "path": pa}, {"sid": "B", "path": pb}]
         km.build_session = lambda sid, now, tmux: (calls.append(sid) or
                                                    {"id": sid, "name": sid, "color": None, "status": None, "ledger": None})
@@ -2896,18 +2899,23 @@ class ViewBuilder(unittest.TestCase):
             os.utime(pa, None)
             km._push([client])                       # 4th: A rebuilt
             after_four = list(calls)
-            km._mark_views_dirty()                   # a kernel-side mutation no file records
-            km._push([client])                       # 5th: A rebuilt (dirty postdates its build)
+            km._mark_views_dirty()                   # a dirty mark with no moved input
+            km._push([client])                       # 5th: A still served (the key names inputs, not marks)
+            after_five = list(calls)
+            km._tmux_echo_add("A", "and also fix the header")   # a kernel-side mutation no file records: the live tail
+            km._push([client])                       # 6th: A rebuilt (its live-tail revision moved)
         finally:
             (km._tmux_sessions, km._chat_tab_sessions, km.build_session, km.build_feed,
-             km.build_timeline, km._send_client) = saved
+             km.build_timeline, km._send_client, km._sdk) = saved
             km._built_chat.clear()
+            km._tmux_echo.pop("A", None); km._tmux_echo_rev.pop("A", None)
         self.assertEqual(after_two.count("A"), 1, "an unchanged ACTIVE tab is served on the 2nd push")
         self.assertEqual(after_two.count("B"), 1, "an unchanged BACKGROUND tab is NOT rebuilt on the 2nd push")
         self.assertEqual(after_three.count("B"), 2, "the background tab rebuilds once its transcript actually changes")
         self.assertEqual(after_three.count("A"), 1, "…and that does not rebuild the active tab")
         self.assertEqual(after_four.count("A"), 2, "the active tab rebuilds once ITS transcript changes")
-        self.assertEqual(calls.count("A"), 3, "a kernel-side mutation (views dirty) rebuilds the active tab")
+        self.assertEqual(after_five.count("A"), 2, "a dirty mark alone is no new information for the chat: still served")
+        self.assertEqual(calls.count("A"), 3, "a kernel-side mutation no file records (a live-tail echo) rebuilds the active tab")
 
     def _orphaned_goal(self, idle=True, closer_done=True, planned=True):
         # an idle (or still-open) session whose top goal still shows "working". closer_done puts the latest

--- a/tests/test_live_tail_rev.py
+++ b/tests/test_live_tail_rev.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""The live-tail revision. Both backends keep an in-memory tail the chat merges ahead of the transcript
+(the SDK backend's `_live`, the kernel's `_tmux_echo` store), and the chat-build signature keys a tab on
+that tail without hashing its atoms per cycle. Each backend therefore counts: a per-sid revision that
+advances on every change to the tail and only then (the SDK backend's _touch_live, the kernel's
+_tmux_echo_bump). The tests here pin the two halves of that contract: every writer bumps (an add, a
+replace, a pop, a flag write, a reworded echo, including the flag writes _mark_dropped_echoes makes
+outside the live-tail lock), and a call that changed nothing (a read, a prune that retired nothing, a
+settle over echoes already marked, a queue miss) leaves the revision alone; plus the kernel's dispatcher,
+Sessions.live_rev, and its fallback for a backend with no counter.
+
+Synthetic fixtures only: private synthetic sids, invented text, a hermetic state root.
+"""
+import inspect
+import json
+import os
+import tempfile
+import types
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = SourceFileLoader("romp_kernel_livetailrev", os.path.join(BIN, "romp-kernel")).load_module()
+sb = SourceFileLoader("romp_sdk_backend_livetailrev", os.path.join(BIN, "romp_sdk_backend.py")).load_module()
+ek = km.sb.echo_text_key                          # the one text key both backends prune by
+
+SID = "77777777-8888-9999-aaaa-bbbbbbbbbbb1"      # this module's own synthetic sids: nothing else writes under them
+SID2 = "77777777-8888-9999-aaaa-bbbbbbbbbbb2"
+
+
+def _backend():
+    d = tempfile.mkdtemp()
+    return sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+
+
+def _work(uuid, t):
+    return {"type": "assistant", "uuid": uuid, "t": t,
+            "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_" + uuid,
+                                                          "name": "Bash", "input": {}}]}}
+
+
+def _echo(key, text, t, **flags):
+    a = {"type": "user", "uuid": key, "session_id": SID, "t": t, "parentUuid": None, "author": "human",
+         "_echo_text": text, "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+    a.update(flags)
+    return a
+
+
+# ---- message doubles for _forward: the SDK's shapes, by class name (msg_to_atom keys on them) ----
+class _TextBlock:
+    def __init__(self, text): self.text = text
+class _AssistantMessage:
+    def __init__(self, content, model="claude-x", uuid="a1", parent_tool_use_id=None):
+        self.content, self.model, self.uuid = content, model, uuid
+        self.parent_tool_use_id, self.stop_reason, self.error = parent_tool_use_id, "end_turn", None
+_TextBlock.__name__ = "TextBlock"; _AssistantMessage.__name__ = "AssistantMessage"
+
+
+class SdkLiveTailRevision(unittest.TestCase):
+    def setUp(self):
+        self.be = _backend()
+
+    def rev(self, sid=SID):
+        return self.be.live_rev(sid)
+
+    def test_starts_at_zero_and_reads_do_not_move_it(self):
+        self.assertEqual(self.rev(), 0)
+        self.assertEqual(self.be.live_atoms(SID), [])
+        self.assertEqual(self.be.live_atom_kinds(SID), [])
+        self.assertEqual(self.rev(), 0, "a read is not a change")
+        self.assertEqual(self.rev(SID2), 0, "per sid")
+
+    def test_a_stash_bumps_once_per_add_and_once_per_replace(self):
+        self.be._stash_live(SID, "e1", _echo("e1", "first message", 10))
+        self.assertEqual(self.rev(), 1)
+        self.be._stash_live(SID, "e2", _echo("e2", "second message", 11))
+        self.assertEqual(self.rev(), 2)
+        self.be._stash_live(SID, "e2", _echo("e2", "second message, edited", 12))   # the same key: a replace
+        self.assertEqual(self.rev(), 3)
+        self.assertEqual(self.rev(SID2), 0, "another sid's tail is untouched")
+        self.be.live_atoms(SID)
+        self.assertEqual(self.rev(), 3, "the pusher's read leaves it where it was")
+
+    def test_forward_bumps_for_a_streamed_atom(self):
+        s = sb.SdkSession(self.be, {"sid": SID, "name": "web", "cwd": "/tmp"})
+        self.be._forward(s, _AssistantMessage([_TextBlock("a streamed reply")], uuid="m1"))
+        self.assertEqual(self.rev(), 1)
+        self.assertEqual([a["uuid"] for a in self.be.live_atoms(SID)], ["m1"])
+        self.be._forward(s, _AssistantMessage([_TextBlock("more of it")], uuid="m2"))
+        self.assertEqual(self.rev(), 2)
+
+    def test_prune_bumps_once_per_call_that_retired_something(self):
+        self.be._stash_live(SID, "w1", _work("w1", 5))
+        self.be._stash_live(SID, "w2", _work("w2", 6))
+        self.be._stash_live(SID, "e1", _echo("e1", "typed while it ran", 7))
+        r0 = self.rev()
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts={}, human_floor=0)
+        self.assertEqual(self.rev(), r0, "nothing landed: the tail did not change, so the revision holds")
+        self.be.prune_live(SID, tx_uuids={"w1", "w2"}, tx_user_texts={}, human_floor=0)
+        self.assertEqual(self.rev(), r0 + 1, "two work atoms landed by uuid in one call: one change, one bump")
+        self.assertEqual([a["uuid"] for a in self.be.live_atoms(SID)], ["e1"])
+        self.be.prune_live(SID, tx_uuids=set(), tx_user_texts={ek("typed while it ran"): 8}, human_floor=0)
+        self.assertEqual(self.rev(), r0 + 2, "the echo landed by text")
+        self.assertEqual(self.be.live_atoms(SID), [])
+        self.be.prune_live(SID, tx_uuids={"w1"}, tx_user_texts={}, human_floor=0)
+        self.assertEqual(self.rev(), r0 + 2, "an empty tail: no change")
+
+    def test_retire_live_work_bumps_only_when_work_atoms_were_held(self):
+        self.be._stash_live(SID, "e1", _echo("e1", "an echo, not work", 6))
+        r0 = self.rev()
+        self.be.retire_live_work(SID)
+        self.assertEqual(self.rev(), r0, "an echo-only tail holds no work: nothing retired, no bump")
+        self.be._stash_live(SID, "w1", _work("w1", 7))
+        self.be._stash_live(SID, "w2", _work("w2", 8))
+        r1 = self.rev()
+        self.be.retire_live_work(SID)
+        self.assertEqual(self.rev(), r1 + 1, "two work atoms retired in one settle: one bump")
+        self.assertEqual([a["uuid"] for a in self.be.live_atoms(SID)], ["e1"], "the echo stays, the work went")
+
+    def test_dismiss_echo_bumps_on_a_hit_and_not_on_a_miss(self):
+        self.be._stash_live(SID, "e1", _echo("e1", "never delivered", 6, dropped=True))
+        self.be._stash_live(SID, "e2", _echo("e2", "still in flight", 7))
+        r0 = self.rev()
+        self.assertIsNone(self.be.dismiss_echo(SID, uuid="e2"), "a live echo is not dismissable")
+        self.assertEqual(self.rev(), r0, "a miss changes nothing")
+        self.assertEqual(self.be.dismiss_echo(SID, uuid="e1"), "never delivered")
+        self.assertEqual(self.rev(), r0 + 1)
+
+    def test_unqueue_drops_the_canceled_echo_and_bumps(self):
+        self.be._stash_live(SID, "e1", _echo("e1", "cancel me", 6))
+        self.be.sessions[SID] = types.SimpleNamespace(unqueue=lambda idx, expect=None, qid=None: "cancel me")
+        r0 = self.rev()
+        self.assertEqual(self.be.unqueue(SID, 0), "cancel me")
+        self.assertEqual(self.rev(), r0 + 1)
+        self.assertEqual(self.be.live_atoms(SID), [])
+        self.be.sessions[SID] = types.SimpleNamespace(unqueue=lambda idx, expect=None, qid=None: None)
+        self.assertIsNone(self.be.unqueue(SID, 0))
+        self.assertEqual(self.rev(), r0 + 1, "a queue miss pops no echo and bumps nothing")
+        self.be.sessions[SID] = types.SimpleNamespace(unqueue=lambda idx, expect=None, qid=None: "already gone")
+        self.assertEqual(self.be.unqueue(SID, 0), "already gone")
+        self.assertEqual(self.rev(), r0 + 1, "a queue hit whose echo was retired ahead of it changes no atom")
+
+    def test_edit_queued_rewords_the_echo_and_bumps(self):
+        """The queue-edit route rewrites a queued message's echo in place (its text and its message block),
+        so the tab that renders the echo changed with no file moving: a change to the tail, one bump."""
+        self.be._stash_live(SID, "e1", _echo("e1", "the old words", 6))
+        self.be.sessions[SID] = types.SimpleNamespace(replace_queued=lambda idx, text, expect=None: "the old words")
+        r0 = self.rev()
+        self.assertEqual(self.be.edit_queued(SID, 0, "the new words"), "the old words")
+        self.assertEqual(self.rev(), r0 + 1, "the reworded echo is a change to the tail")
+        self.assertEqual(self.be.live_atoms(SID)[0]["_echo_text"], "the new words")
+        self.be.sessions[SID] = types.SimpleNamespace(replace_queued=lambda idx, text, expect=None: None)
+        self.assertIsNone(self.be.edit_queued(SID, 0, "nothing to edit"))
+        self.assertEqual(self.rev(), r0 + 1, "a queue miss rewords nothing and bumps nothing")
+        self.be.sessions[SID] = types.SimpleNamespace(replace_queued=lambda idx, text, expect=None: "no echo wears this")
+        self.assertEqual(self.be.edit_queued(SID, 0, "still nothing"), "no echo wears this")
+        self.assertEqual(self.rev(), r0 + 1, "a queue hit with no matching echo changes no atom")
+
+    def test_mark_dropped_echoes_bumps_for_its_flag_writes_outside_the_lock(self):
+        """The two in-place flag writes (`dropped`, `_landed`) change atoms the pusher already holds by
+        identity, without the live-tail lock; each is a change to the tail and advances the revision."""
+        self.be._stash_live(SID, "e1", _echo("e1", "lost with its process", 6))
+        r0 = self.rev()
+        self.be._mark_dropped_echoes(SID, queued_texts=(), refeed=False)   # the flag path only
+        self.assertTrue(self.be.live_atoms(SID)[0].get("dropped"))
+        self.assertEqual(self.rev(), r0 + 1, "the `dropped` verdict is a change")
+        self.be._mark_dropped_echoes(SID, queued_texts=(), refeed=False)
+        self.assertEqual(self.rev(), r0 + 1, "already flagged: nothing newly dropped, no bump")
+        self.be._stash_live(SID, "e2", _echo("e2", "landed, un-pruned", 7))
+        self.be._text_landed = lambda sid, text, t=None, off=None, fsid=None: True
+        r1 = self.rev()
+        self.be._mark_dropped_echoes(SID, queued_texts=())                  # the scan finds the record
+        e2 = next(a for a in self.be.live_atoms(SID) if a["uuid"] == "e2")
+        self.assertTrue(e2.get("_landed"))
+        self.assertFalse(e2.get("dropped"))
+        self.assertEqual(self.rev(), r1 + 1, "the `_landed` verdict is a change too, counted once")
+
+    def test_every_writer_site_bumps_by_source(self):
+        """The writer set _touch_live's docstring names, pinned by source beside the behavioural tests above
+        (which carry the claim that each bump happens): each mutator's source calls _touch_live, the two
+        flag-writing lines in _mark_dropped_echoes are each followed by one, and _stash_live and _forward are
+        the only sites that stash into _live, so a new mutator fails here until it is classified."""
+        for name in ("_stash_live", "_forward", "unqueue", "edit_queued", "dismiss_echo", "prune_live",
+                     "retire_live_work", "_mark_dropped_echoes"):
+            src = inspect.getsource(getattr(sb.SdkBackend, name))
+            self.assertIn("self._touch_live(", src, "%s changes the tail without advancing its revision" % name)
+        mde = inspect.getsource(sb.SdkBackend._mark_dropped_echoes)
+        self.assertIn('a["_landed"] = True', mde)
+        self.assertIn('a["dropped"] = True', mde)
+        self.assertEqual(mde.count("self._touch_live(sid)"), 2, "one bump per flag-writing pass")
+        for name in ("live_atoms", "live_atom_kinds", "_persist_echoes"):
+            src = inspect.getsource(getattr(sb.SdkBackend, name))
+            self.assertNotIn("_touch_live", src, "%s is a read" % name)
+        whole = inspect.getsource(sb.SdkBackend)
+        self.assertEqual(whole.count("self._live.setdefault("), 2, "_stash_live and _forward are the only stashes")
+        bump = inspect.getsource(sb.SdkBackend._touch_live)
+        self.assertIn("revs[sid] = revs.get(sid, 0) + 1", bump)
+        self.assertNotIn("with self._live_lock", bump, "the caller holds the lock; the bump takes nothing")
+        self.assertIn("with self._live_lock", inspect.getsource(sb.SdkBackend.live_rev),
+                      "the read is under the lock, like the atoms it counts")
+
+    def test_a_bare_double_that_borrows_the_mutator_and_the_bump_gets_a_counter_of_its_own(self):
+        """tests/test_restart_redelivery.py binds _mark_dropped_echoes onto a plain class whose own
+        _touch_live is a no-op; a double that borrows the real _touch_live too gets the revision map made
+        in the instance on first use, so neither kind of double declares a counter."""
+        class BE:
+            _live = {}
+            _live_lock = __import__("threading").RLock()
+            def _log(self, msg, problem=False): pass
+            def _persist_echoes(self, sid): pass
+            def _wake_push(self): pass
+        be = BE()
+        be._live.setdefault(SID, {})["echo:x"] = {"_echo_text": "typed", "author": "human", "t": 3}
+        be._mark_dropped_echoes = sb.SdkBackend._mark_dropped_echoes.__get__(be)
+        be._touch_live = sb.SdkBackend._touch_live.__get__(be)
+        be._mark_dropped_echoes(SID, queued_texts=(), refeed=False)
+        self.assertEqual(be.__dict__["_live_rev"], {SID: 1})
+        BE._live.clear()
+
+
+class TmuxEchoRevision(unittest.TestCase):
+    def setUp(self):
+        km._tmux_echo.pop(SID, None)
+        km._tmux_echo_rev.pop(SID, None)
+
+    tearDown = setUp
+
+    def rev(self):
+        return km._TMUX.live_rev(SID)
+
+    def test_add_prune_settle_and_dismiss_each_bump_and_no_ops_do_not(self):
+        self.assertEqual(self.rev(), 0)
+        km._tmux_echo_add(SID, "a typed line")
+        self.assertEqual(self.rev(), 1)
+        km._tmux_echo_add(SID, "a second one")
+        self.assertEqual(self.rev(), 2)
+        km._tmux_echo_atoms(SID)
+        self.assertEqual(self.rev(), 2, "a read is not a change")
+        km._tmux_echo_prune(SID, set(), set())
+        self.assertEqual(self.rev(), 2, "a prune that retires nothing is not a change")
+        km._tmux_echo_prune(SID, set(), {ek("a typed line")})
+        self.assertEqual(self.rev(), 3, "the echo landed by text")
+        self.assertEqual([a["_echo_text"] for a in km._tmux_echo_atoms(SID)], ["a second one"])
+        t = km._tmux_echo_atoms(SID)[0]["t"]
+        km._tmux_echo_settle(SID, human_floor=t - 1)
+        self.assertEqual(self.rev(), 3, "not overtaken: nothing marked")
+        km._tmux_echo_settle(SID, human_floor=t + 5, still_queued=("a second one",))
+        self.assertEqual(self.rev(), 3, "still owed by the queue ledger: the settle stands down, no change")
+        km._tmux_echo_settle(SID, human_floor=t + 5)
+        self.assertEqual(self.rev(), 4, "the `dropped` mark is a change")
+        self.assertTrue(km._tmux_echo_atoms(SID)[0].get("dropped"))
+        km._tmux_echo_settle(SID, human_floor=t + 5)
+        self.assertEqual(self.rev(), 4, "already marked: a second settle changes nothing")
+        self.assertEqual(km._TMUX.dismiss_echo(SID, t=t), "a second one")
+        self.assertEqual(self.rev(), 5)
+        self.assertIsNone(km._TMUX.dismiss_echo(SID, t=t), "a miss (already gone)")
+        self.assertEqual(self.rev(), 5)
+        self.assertNotIn(SID, km._tmux_echo, "the sid entry went with its last echo")
+        self.assertEqual(self.rev(), 5, "...and its revision stays readable")
+
+    def test_every_writer_site_bumps_by_source(self):
+        for fn in (km._tmux_echo_add, km._tmux_echo_prune, km._tmux_echo_settle, km._TMUX.dismiss_echo):
+            self.assertIn("_tmux_echo_bump(", inspect.getsource(fn), fn.__name__)
+        self.assertNotIn("_tmux_echo_bump(", inspect.getsource(km._tmux_echo_atoms), "a read")
+
+
+class SessionsLiveRevDispatch(unittest.TestCase):
+    def setUp(self):
+        self._saved = km._sdk
+        km._tmux_echo.pop(SID, None)
+        km._tmux_echo_rev.pop(SID, None)
+
+    def tearDown(self):
+        km._sdk = self._saved
+        km._tmux_echo.pop(SID, None)
+        km._tmux_echo_rev.pop(SID, None)
+
+    def test_a_tmux_sid_reads_the_echo_store_revision(self):
+        km._sdk = lambda: None
+        self.assertEqual(km.Sessions.live_rev(SID), 0)
+        km._tmux_echo_add(SID, "hello")
+        self.assertEqual(km.Sessions.live_rev(SID), 1)
+
+    def test_an_sdk_sid_reads_the_backend_counter(self):
+        be = _backend()
+        be.owns = lambda sid: sid == SID
+        km._sdk = lambda: be
+        self.assertEqual(km.Sessions.live_rev(SID), 0)
+        be._stash_live(SID, "e1", _echo("e1", "typed", 1))
+        self.assertEqual(km.Sessions.live_rev(SID), 1)
+        km._tmux_echo_add(SID, "a stray tmux echo under the same sid")
+        self.assertEqual(km.Sessions.live_rev(SID), 1, "dispatch by the owning backend, not a union")
+
+    def test_a_backend_without_a_counter_answers_with_the_tail_itself(self):
+        atoms = [{"uuid": "c1", "t": 1, "message": {"content": [{"type": "text", "text": "hi"}]}}]
+        fake = types.SimpleNamespace(owns=lambda sid: sid == SID, live_atoms=lambda sid: list(atoms))
+        km._sdk = lambda: fake
+        v0 = km.Sessions.live_rev(SID)
+        self.assertEqual(v0, json.dumps(atoms, sort_keys=True, default=str), "exact: the serialized tail")
+        self.assertEqual(km.Sessions.live_rev(SID), v0, "stable while the tail is")
+        atoms[0]["t"] = 2
+        self.assertNotEqual(km.Sessions.live_rev(SID), v0, "an in-place change to an atom moves it")
+        atoms.append({"uuid": "c2", "t": 3})
+        self.assertNotEqual(km.Sessions.live_rev(SID), v0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -201,7 +201,7 @@ class Collector(unittest.TestCase):
         # chat also carries the watched/background split and the per-component attribution (2026-09-09); the
         # plain writer counts the build and attributes nothing
         self.assertEqual(snap["builds"]["chat"], {"cached": 1, "built": 1, "ms": 40.0, "active_built": 0, "bg_built": 0,
-                                                  "bg_miss": {k: 0 for k in km._PerfStats.CHAT_MISS}})
+                                                  "moved": 0, "bg_miss": {k: 0 for k in km._PerfStats.CHAT_MISS}})
         self.assertEqual(snap["builds"]["feed"]["built"], 1)
         self.assertEqual(snap["builds"]["timeline"], {"cached": 0, "built": 0, "ms": 0.0})
         self.assertEqual(snap["judge"]["passes"], 2)

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -355,10 +355,16 @@ class ViewSignatureKeysOnExactInputs(_StateSandbox):
             jd._active_end(rid)
 
 
-class ActiveTabIsServedOnAnExactKey(_StateSandbox):
+class EveryTabIsServedOnTheCompleteKey(_StateSandbox):
     """The watched chat tab used to rebuild from all atoms on every pusher cycle "by design", because its
-    payload moves with inputs no file records. _active_chat_sig names every one of them, so an identical
-    world serves the last build and any moved input rebuilds. Synthetic session, private sid."""
+    payload moves with inputs no file records; since 2026-09-03 it was served on a separate exact key
+    beside the background tabs' file-stat key. There is ONE key for every tab now, the complete per-session
+    signature (_chat_build_sig), and these tests pin the same observable through it: an identical world
+    yields the same key and any moved payload input moves it, attributed to its component. Of the old
+    key's inputs, the captions store is keyed through what the payload embeds from it (the postal cards'
+    caption values, the postal component; tests/test_chat_build_sig_inputs.py moves one), and the
+    in-flight judge set is not keyed because build_session does not read it (the census there is the
+    check). Synthetic session, private sid."""
 
     SID = "11111111-2222-3333-4444-999999999941"
 
@@ -371,185 +377,248 @@ class ActiveTabIsServedOnAnExactKey(_StateSandbox):
                                           "message": {"role": "user", "content": "hi"}}) + "\n")
         self.sess = {"sid": self.SID, "path": str(self.tpath), "anchor": self.SID}
         self.tm = {"state": "waiting", "since": NOW - 100, "model": "m", "subagents": [], "bgTasks": [], "snapT": NOW}
-        km._interrupt_clicked.pop(self.SID, None); km._model_switch_pending.pop(self.SID, None); km._compact_clicked.pop(self.SID, None)
+        self.saved_sdk = km._sdk
+        km._sdk = lambda: None                                    # tmux-owned unless a test says otherwise
+        km._built_chat.pop(self.SID, None)
+        km._live_scope.usage = km._live_scope.spend_pause = None   # a drain scope another module left on this thread
+        self._clear_stamps()
 
     def tearDown(self):
+        km._sdk = self.saved_sdk
         for p in (self.path, self.tpath):
             try: os.unlink(p)
             except OSError: pass
-        km._interrupt_clicked.pop(self.SID, None); km._model_switch_pending.pop(self.SID, None); km._compact_clicked.pop(self.SID, None)
+        self._clear_stamps()
+        km._built_chat.pop(self.SID, None)
+        with km._watch_lock:
+            km._watches[:] = [w for w in km._watches if w.get("sid") != self.SID]
+
+    def _clear_stamps(self):
+        for d in (km._interrupt_clicked, km._model_switch_pending, km._compact_clicked, km._tmux_echo, km._tmux_echo_rev):
+            d.pop(self.SID, None)
+
+    def sig(self, tm=None, now=NOW, **kw):
+        """The complete key, as the pusher takes it: the session, its liveness row, the push's clock and map."""
+        tm = self.tm if tm is None else tm
+        return km._chat_build_sig(self.sess, tm, now, tmux={self.SID: tm} if tm is not None else {}, **kw)
 
     def test_a_an_identical_world_yields_the_same_key_and_a_volatile_stamp_does_not_matter(self):
-        s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+        s1 = self.sig()
         self.assertIsNotNone(s1)
+        self.assertEqual(len(s1), len(km._CHAT_SIG_LABELS), "one value per labelled component")
         tm2 = dict(self.tm); tm2["snapT"] = NOW + 7
-        self.assertEqual(s1, km._active_chat_sig(self.sess, tm2, NOW + 1), "snapT and the clock alone move nothing")
+        self.assertEqual(s1, self.sig(tm2, NOW + 1), "snapT and the clock alone move nothing")
 
     def test_b_each_input_class_moves_the_key(self):
-        s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+        s1 = self.sig()
         tm = dict(self.tm); tm["state"] = "working"
-        self.assertNotEqual(s1, km._active_chat_sig(self.sess, tm, NOW), "a snapshot fact")
+        self.assertNotEqual(s1, self.sig(tm), "a snapshot fact")
         _append_rows(self.path, [{"t": NOW - 5, "state": "working"}])
-        s2 = km._active_chat_sig(self.sess, self.tm, NOW)
+        s2 = self.sig()
         self.assertNotEqual(s1, s2, "a states row")
-        jd.CAPDIR.mkdir(parents=True, exist_ok=True)
-        cap = jd.CAPDIR / (self.SID + ".jsonl")
+        # the judge's OUTPUT the payload reads is the goal store (the ledger, the seams, the awaiting stamps):
+        # a publish moves the key at once, through the store's live identity, and no other tab's
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        gs = jd.GOALDIR / (self.SID + ".json")
         try:
-            cap.write_text(json.dumps({"id": "seg-1", "gist": "did a thing"}) + "\n")
-            s3 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertNotEqual(s2, s3, "a caption landed")
+            gs.write_text(json.dumps({"rompUuid": self.SID, "nodes": {}, "status": {}}))
+            s3 = self.sig()
+            self.assertNotEqual(s2, s3, "a goal store published")
+            self.assertEqual(km._chat_sig_miss(s2, s3), ("store",), "...attributed to the store component alone")
+            g0 = km._judge_gen[0]
+            km._judge_gen[0] += 1
+            try:
+                self.assertEqual(self.sig(), s3, "the judge-pass counter is not a chat input")
+            finally:
+                km._judge_gen[0] = g0
         finally:
-            try: os.unlink(cap)
+            try: os.unlink(gs)
             except OSError: pass
-        rid = jd._active_begin("closer", self.SID, 0)
-        try:
-            self.assertNotEqual(s2, km._active_chat_sig(self.sess, self.tm, NOW), "a judge call in flight")
-        finally:
-            jd._active_end(rid)
 
-    def test_c_clock_predicates_flip_exactly_at_their_deadlines(self):
+    def test_c_clock_booleans_flip_exactly_at_their_deadlines(self):
+        """The clock enters the key only as the booleans the build derives from it, so the key moves at each
+        crossing and at no other tick (the clock component)."""
         tm = {"state": "ready", "since": NOW - 3599, "bgTasks": []}
-        p0 = km._clock_predicates(self.SID, tm, NOW)
-        self.assertEqual(p0[:5], (False, False, False, False, False))
-        self.assertEqual(km._clock_predicates(self.SID, tm, NOW + 2)[0], True, "faded flips at the hour")
-        odd = dict(tm, state="")                          # the build derives 'ready' from an empty raw state
-        self.assertEqual(km._clock_predicates(self.SID, odd, NOW + 2)[1], True, "…keyed whatever the raw state says")
-        km._interrupt_clicked[self.SID] = NOW - 119
-        self.assertFalse(km._clock_predicates(self.SID, tm, NOW)[2])
-        self.assertTrue(km._clock_predicates(self.SID, tm, NOW + 2)[2], "the interrupt cap ran out")
-        s1 = km._active_chat_sig(self.sess, tm, NOW)
-        self.assertNotEqual(s1, km._active_chat_sig(self.sess, tm, NOW + 2), "…and the key follows the flip")
-
+        s0 = self.sig(tm, NOW)
+        self.assertEqual(s0, self.sig(tm, NOW + 1), "one second short of the hour: nothing moved")
+        s2 = self.sig(tm, NOW + 2)
+        self.assertNotEqual(s0, s2, "faded flips at the hour, and the key follows the flip")
+        self.assertEqual(km._chat_sig_miss(s0, s2), ("clock",))
+        km._compact_clicked[self.SID] = NOW - 179
+        s3 = self.sig(tm, NOW + 2)                                # 181 s: the compaction's optimistic cap ran out (stamp popped)
+        self.assertEqual(s2, s3, "a cap that already ran out is no fact: the key reads as if never clicked")
+        km._compact_clicked[self.SID] = NOW - 177
+        s4 = self.sig(tm, NOW + 2)                                # 179 s: still compacting, optimistically
+        self.assertNotEqual(s3, s4, "an armed compaction is a clock fact")
+        self.assertEqual(km._chat_sig_miss(s3, s4), ("clock",))
+        s5 = self.sig(tm, NOW + 4)                                # 181 s: the cap ran out, and the key follows the flip
+        self.assertEqual(s5, s3, "...back to the clicked-nothing key, exactly at the crossing")
 
     def test_d_a_live_task_expiring_moves_the_key_through_the_builds_own_filter(self):
         """The raw snapshot rows carry no deadline; the build joins each task's recorded deadline from the
-        launch ledger and drops expired ones. The key carries that filtered set, so an expiry — a tid
-        dropping out — moves it exactly when the awaiting box would change (review 2026-09-03)."""
+        launch ledger and drops expired ones. The key carries that filtered set (the bg component), so an
+        expiry, a tid dropping out, moves it exactly when the awaiting box would change (review 2026-09-03)."""
         saved = km._bg_live_norm
         rows = [{"tid": "t1", "desc": "watch", "t": NOW - 60}]
         km._bg_live_norm = lambda sid, path: list(rows)
         try:
-            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW + 1))
+            s1 = self.sig()
+            self.assertEqual(s1, self.sig(now=NOW + 1))
             rows.clear()                                     # the watcher passed its deadline → filtered out
-            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW + 2))
+            s2 = self.sig(now=NOW + 2)
+            self.assertNotEqual(s1, s2)
+            self.assertEqual(km._chat_sig_miss(s1, s2), ("bg",))
         finally:
             km._bg_live_norm = saved
 
     def test_d2_a_running_tasks_output_growing_moves_the_key(self):
-        """The task box shows a running task's output tail, read live from a file outside the state root; the
-        key stats that file so the tail keeps moving (review 2026-09-03)."""
+        """The task box shows a running task's output tail, read live from a file outside the state root. The
+        build records each output it read as a dependency of its payload (_chat_build_deps), and the key
+        re-stats the recorded file every cycle (the taskout component), so the tail keeps moving (review
+        2026-09-03; the old watched-tab key stat'd the running tasks' files itself)."""
         out = jd.STATE / "task-out.log"; out.write_text("line 1\n")
-        saved = km._bg_scan_cached
-        km._bg_scan_cached = lambda path: [{"id": "toolu_1", "status": "running", "outputFile": str(out)}]
-        try:
-            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW))
-            with open(out, "a") as f:
-                f.write("line 2\n")
-            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW), "the tail grew")
-        finally:
-            km._bg_scan_cached = saved
+        rec = {"task_outs": [(str(out), km._chat_stat_key(str(out)))], "pl_pending": [], "pl_at": (), "pl_check": None,
+               "postal_any": False, "postal_cards": []}
+        s1 = self.sig(deps=rec)
+        self.assertEqual(s1, self.sig(deps=rec))
+        with open(out, "a") as f:
+            f.write("line 2\n")
+        s2 = self.sig(deps=rec)
+        self.assertNotEqual(s1, s2, "the tail grew")
+        self.assertEqual(km._chat_sig_miss(s1, s2), ("taskout",))
 
-    def test_d3_the_branch_of_a_subdirectory_cwd_and_of_the_last_edited_files_tree_is_keyed(self):
-        """build_session reads the branch of the registered cwd's tree and of the last edited file's tree
-        (the per-session worktree); both HEADs are in the key, resolved through _tree_of like the build."""
+    def test_d3_the_branch_of_a_subdirectory_cwd_is_keyed(self):
+        """build_session reads the branch of the registered cwd's tree (and of the last edited file's tree);
+        the key carries them by value through the branch memo, which is keyed on the tree's HEAD."""
         import subprocess
         repo = tempfile.mkdtemp()
         subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+        subprocess.run(["git", "-C", repo, "-c", "user.name=t", "-c", "user.email=t@example.invalid",
+                        "commit", "-q", "--allow-empty", "-m", "init"], check=True)   # main is born: the branch resolves
         sub = os.path.join(repo, "pkg"); os.makedirs(sub)
         saved_cwd = km._cwd_of
         km._cwd_of = lambda sid: sub                       # a cwd INSIDE the repo, not its top
         try:
-            e1 = km._external_sig(self.SID, str(self.tpath))
-            hp = km._git_head_file(repo)
-            st = os.stat(hp)
-            self.assertIn((st.st_mtime_ns, st.st_size, st.st_ino), e1,
-                          "the repo's HEAD is stat'd for a subdirectory cwd: %r" % (e1,))
-            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
+            s1 = self.sig()
+            cwd_i = km._CHAT_SIG_LABELS.index("cwd")
+            self.assertEqual(s1[cwd_i][1], "main", "the repo's branch is read for a subdirectory cwd: %r" % (s1[cwd_i],))
             subprocess.run(["git", "-C", repo, "checkout", "-q", "-b", "feature"], check=True)
-            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW), "a branch switch moves the key")
+            s2 = self.sig()
+            self.assertNotEqual(s1, s2, "a branch switch moves the key")
+            self.assertEqual(s2[cwd_i][1], "feature")
         finally:
             km._cwd_of = saved_cwd
 
-    def test_e_the_backend_leg_and_the_watch_files_move_the_key(self):
+    def test_e_the_backend_leg_and_the_watches_move_the_key(self):
         """A stub backend stands in for the SDK: the live-tail revision, the send queue and the brackets each
-        move the key; so does the kernel-owned watch registry's file (review 2026-09-03)."""
+        move the key; so does a kernel-owned watch this session registered (review 2026-09-03; the watch
+        registry is read as the build reads it, from the in-memory list its file persists)."""
         class Stub:
             rev = 0; queue = []; comp = False; clr = False
             def owns(self, sid): return True
             def live_rev(self, sid): return self.rev
+            def live_atoms(self, sid): return []
             def pending_queued(self, sid): return list(self.queue)
             def compacting(self, sid): return self.comp
             def clearing(self, sid): return self.clr
             def pending_cut(self, sid): return ""
-        stub = Stub(); saved = km._sdk
+        stub = Stub()
         km._sdk = lambda: stub
-        try:
-            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW))
-            stub.rev += 1;  s2 = km._active_chat_sig(self.sess, self.tm, NOW); self.assertNotEqual(s1, s2, "a live atom")
-            stub.queue = ["x"]; s3 = km._active_chat_sig(self.sess, self.tm, NOW); self.assertNotEqual(s2, s3, "a queued send")
-            stub.comp = True;  s4 = km._active_chat_sig(self.sess, self.tm, NOW); self.assertNotEqual(s3, s4, "compacting")
-            (jd.STATE / "watches.json").write_text(json.dumps([{"sid": self.SID, "what": "a build"}]))
-            self.assertNotEqual(s4, km._active_chat_sig(self.sess, self.tm, NOW), "a watch armed")
-        finally:
-            km._sdk = saved
-
+        s1 = self.sig()
+        self.assertEqual(s1, self.sig())
+        stub.rev += 1;  s2 = self.sig(); self.assertNotEqual(s1, s2, "a live atom")
+        self.assertEqual(km._chat_sig_miss(s1, s2), ("live",))
+        stub.queue = ["x"]; s3 = self.sig(); self.assertNotEqual(s2, s3, "a queued send")
+        stub.comp = True;  s4 = self.sig(); self.assertNotEqual(s3, s4, "compacting")
+        with km._watch_lock:
+            km._watches.append({"id": "w-stage0", "cmd": "true", "every": 60, "timeoutS": 600, "sid": self.SID,
+                                "note": "a build", "at": NOW})
+        s5 = self.sig()
+        self.assertNotEqual(s4, s5, "a watch armed")
+        self.assertEqual(km._chat_sig_miss(s4, s5), ("watch",))
 
     def test_f_the_owning_backends_live_tail_moves_the_key_for_a_tmux_session(self):
-        """Review 2026-09-05: the key read only the SDK backend's tail, so a tmux session's composer echo — a
-        kernel-side store the build renders — left the watched tab served stale until some file moved."""
-        saved_sdk = km._sdk
-        km._sdk = lambda: None                                    # this sid is tmux-owned
-        km._tmux_echo.pop(self.SID, None)
-        try:
-            s1 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertIsNotNone(s1)
-            km._tmux_echo_add(self.SID, "please also fix the header")
-            s2 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertNotEqual(s1, s2, "the echo the build renders is in the key")
-            t = km._tmux_echo_atoms(self.SID)[0]["t"]
-            km._tmux_echo_settle(self.SID, human_floor=t + 5)     # the pane dropped the keystroke: marked, rendered differently
-            self.assertTrue(km._tmux_echo_atoms(self.SID)[0].get("dropped"))
-            s3 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertNotEqual(s2, s3, "…and so is its dropped flag")
-            self.assertEqual(km._TMUX.dismiss_echo(self.SID, t=t), "please also fix the header")   # dismissed
-            s4 = km._active_chat_sig(self.sess, self.tm, NOW)
-            self.assertNotEqual(s3, s4, "the dismissal is a change too")
-            # the tmux echo store counts its changes (TmuxBackend.live_rev, the SDK backend's rule), so the key
-            # never returns to an earlier value: one rebuild per change, never a stale hit
-            self.assertNotEqual(s4, s1)
-        finally:
-            km._sdk = saved_sdk
-            km._tmux_echo.pop(self.SID, None)
+        """Review 2026-09-05: the key read only the SDK backend's tail, so a tmux session's composer echo, a
+        kernel-side store the build renders, left the watched tab served stale until some file moved. The
+        tmux echo store counts its changes (TmuxBackend.live_rev) the way the SDK backend does, and
+        Sessions.live_rev dispatches to the owning backend."""
+        s1 = self.sig()
+        self.assertIsNotNone(s1)
+        km._tmux_echo_add(self.SID, "please also fix the header")
+        s2 = self.sig()
+        self.assertNotEqual(s1, s2, "the echo the build renders is in the key")
+        t = km._tmux_echo_atoms(self.SID)[0]["t"]
+        km._tmux_echo_settle(self.SID, human_floor=t + 5)          # the pane dropped the keystroke: marked, rendered differently
+        self.assertTrue(km._tmux_echo_atoms(self.SID)[0].get("dropped"))
+        s3 = self.sig()
+        self.assertNotEqual(s2, s3, "...and so is its dropped flag")
+        self.assertEqual(km._TMUX.dismiss_echo(self.SID, t=t), "please also fix the header")
+        s4 = self.sig()
+        self.assertNotEqual(s3, s4, "the dismissal is a change too")
+        # a revision counts changes, so the key never returns to an earlier value (one rebuild per change,
+        # never a stale hit); the old key's digest of the atoms did
+        self.assertEqual([km._chat_sig_miss(a, b) for a, b in ((s1, s2), (s2, s3), (s3, s4))], [("live",)] * 3)
 
-    def test_g_the_background_key_carries_the_snapshot_facts_a_tabs_chips_render(self):
-        """The judge generation no longer advances every pass, so a background tab's chips (state, retrying,
-        subagents, pending picks…) are keyed on the snapshot row itself (review 2026-09-05)."""
-        b1 = km._chat_build_sig(self.sess, self.tm)
+    def test_g_the_key_carries_the_snapshot_facts_a_tabs_chips_render(self):
+        """The judge generation no longer advances every pass, so a tab's chips (state, retrying, subagents,
+        pending picks...) are keyed on the snapshot row itself (review 2026-09-05), minus its volatile stamp."""
+        b1 = self.sig()
         self.assertIsNotNone(b1)
         tm2 = dict(self.tm); tm2["snapT"] = NOW + 30
-        self.assertEqual(b1, km._chat_build_sig(self.sess, tm2), "the volatile stamp alone moves nothing")
+        self.assertEqual(b1, self.sig(tm2), "the volatile stamp alone moves nothing")
         for k, v in (("state", "retrying"), ("subagents", ["a"]), ("retryCount", 3), ("modelPending", True),
                      ("connected", True), ("spawning", True), ("model", "other"), ("auth", "key")):
             tm3 = dict(self.tm); tm3[k] = v
-            self.assertNotEqual(b1, km._chat_build_sig(self.sess, tm3), k)
-        self.assertNotEqual(b1, km._chat_build_sig(self.sess), "no row handed → a different (row-less) key, never a false hit")
+            b3 = self.sig(tm3)
+            self.assertNotEqual(b1, b3, k)
+            self.assertIn("row", km._chat_sig_miss(b1, b3), k)   # modelPending is a clock input too (_model_pending_now)
+        self.assertNotEqual(b1, km._chat_build_sig(self.sess, None, NOW, tmux={}),
+                            "no row for the sid: a different (row-less) key, never a false hit")
 
-    def test_h_the_spend_hold_moves_the_key_and_marks_the_views_dirty(self):
-        s1 = km._active_chat_sig(self.sess, self.tm, NOW)
-        before = km._views_dirty[0]
-        km._set_retry_paused(True, reason="spend")
+    def test_h_the_spend_hold_moves_the_key_of_a_tab_with_a_queued_send_and_marks_the_views_dirty(self):
+        """The account-level hold is what a QUEUED bubble names, so the key folds it exactly when the build
+        can render one (a queue, parked ops, an in-flight tmux echo) and never asks otherwise; the old
+        watched-tab key stat'd retry-paused.json for every watched tab. The writer still stamps the dirty
+        mark: the feed and the timeline rebuild past it."""
+        class Stub:
+            def owns(self, sid): return True
+            def live_rev(self, sid): return 0
+            def live_atoms(self, sid): return []
+            def pending_queued(self, sid): return ["a message waiting on the account"]
+            def unqueue(self, sid, idx, expect=None): return None
+            def queue_recallable(self, sid): return True
+            def compacting(self, sid): return False
+            def clearing(self, sid): return False
+            def pending_cut(self, sid): return ""
+            def launch_error(self, sid): return None
+        km._sdk = lambda: Stub()
+        # the hold reader, held for this test over the real pause file: other modules loading this same kernel
+        # module stub _limit_hold to a no-op at import (the drive-op gates), so the shared copy's may be theirs
+        saved_hold = km._limit_hold
+        km._limit_hold = lambda sid: ({"reason": "spend", "resetsAt": None, "what": "waiting for your monthly spend limit to be raised"}
+                                      if (km._retry_paused_on() and km._retry_pause_reason() == "spend") else None)
+        lim = km._CHAT_SIG_LABELS.index("limit")
         try:
-            self.assertNotEqual(s1, km._active_chat_sig(self.sess, self.tm, NOW), "retry-paused.json is a keyed side file")
-            self.assertGreater(km._views_dirty[0], before, "every writer of the hold publishes the flip")
+            s1 = self.sig()
+            self.assertIsNone(s1[lim], "a queue, no hold: read, and None")
+            before = km._views_dirty[0]
+            km._set_retry_paused(True, reason="spend")
+            try:
+                s2 = self.sig()
+                self.assertNotEqual(s1, s2, "the spend hold the queued bubble renders is in the key")
+                self.assertEqual(km._chat_sig_miss(s1, s2), ("limit",))
+                self.assertEqual(s2[lim]["reason"], "spend")
+                self.assertGreater(km._views_dirty[0], before, "every writer of the hold publishes the flip to the feed and timeline")
+            finally:
+                km._set_retry_paused(False)
+            km._sdk = lambda: None                                # nothing queued, nothing parked, no echo
+            km._set_retry_paused(True, reason="spend")
+            try:
+                self.assertIsNone(self.sig()[lim], "with no queued bubble to render, the hold is not read and not keyed")
+            finally:
+                km._set_retry_paused(False)
         finally:
-            km._set_retry_paused(False)
-
-    def test_i_the_active_key_reuses_the_pushers_base(self):
-        base = km._chat_build_sig(self.sess, self.tm)
-        self.assertEqual(km._active_chat_sig(self.sess, self.tm, NOW, base=base), km._active_chat_sig(self.sess, self.tm, NOW))
+            km._limit_hold = saved_hold
 
 
 class PerBuildReadersAreCached(_StateSandbox):

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -509,12 +509,17 @@ class ActiveTabIsServedOnAnExactKey(_StateSandbox):
             km._tmux_echo_add(self.SID, "please also fix the header")
             s2 = km._active_chat_sig(self.sess, self.tm, NOW)
             self.assertNotEqual(s1, s2, "the echo the build renders is in the key")
-            for a in km._tmux_echo.get(self.SID, {}).values():
-                a["dropped"] = True                               # the pane dropped the keystroke: rendered differently
+            t = km._tmux_echo_atoms(self.SID)[0]["t"]
+            km._tmux_echo_settle(self.SID, human_floor=t + 5)     # the pane dropped the keystroke: marked, rendered differently
+            self.assertTrue(km._tmux_echo_atoms(self.SID)[0].get("dropped"))
             s3 = km._active_chat_sig(self.sess, self.tm, NOW)
             self.assertNotEqual(s2, s3, "…and so is its dropped flag")
-            km._tmux_echo.pop(self.SID, None)                     # dismissed
-            self.assertEqual(km._active_chat_sig(self.sess, self.tm, NOW), s1, "back to the world before the send")
+            self.assertEqual(km._TMUX.dismiss_echo(self.SID, t=t), "please also fix the header")   # dismissed
+            s4 = km._active_chat_sig(self.sess, self.tm, NOW)
+            self.assertNotEqual(s3, s4, "the dismissal is a change too")
+            # the tmux echo store counts its changes (TmuxBackend.live_rev, the SDK backend's rule), so the key
+            # never returns to an earlier value: one rebuild per change, never a stale hit
+            self.assertNotEqual(s4, s1)
         finally:
             km._sdk = saved_sdk
             km._tmux_echo.pop(self.SID, None)

--- a/tools/perf-bench.py
+++ b/tools/perf-bench.py
@@ -699,6 +699,7 @@ def make_backend(sbmod, state, dormant_rows, all_regs):
     be.__dict__.update({
         "state_dir": Path(state), "claude_bin": "/bin/false", "sessions": {},
         "_lock": threading.Lock(), "_reg_lock": threading.Lock(), "_pending_ask": {}, "_live": {},
+        "_live_rev": {},    # the live tail's per-sid revision (Sessions.live_rev reads it for every chat signature)
         "_owns_memo": {},   # owns() memoizes on the reg file's identity here, and build_session and
         #   _alive_sessions reach owns() through Sessions.backend_for: without the slot the first chat
         #   build raises on the attribute instead of answering

--- a/ui/webview/relay-active-rearm.test.ts
+++ b/ui/webview/relay-active-rearm.test.ts
@@ -1,14 +1,16 @@
 // T246 (the user 2026-09-07): after an ATTACHED kernel restarts, the chat pane stopped receiving live events
 // for that host's ACTIVE session until the user's next send.
 //
-// Why: a kernel keys the tab a client is LOOKING AT (its per-client `active`, set by the `?active=` connect
-// hint or an `activeTab` message) on the live change key (_active_chat_sig: the backend's live tail, its
-// queue, the snapshot row, every side file); every OTHER session is served from the file-stat cache
-// (_chat_build_sig), which no in-memory stream ever busts. The pane shim's local socket carries `?active=`
+// Why: a kernel builds and flushes the tab a client is LOOKING AT (its per-client `active`, set by the
+// `?active=` connect hint or an `activeTab` message) first, and serves every tab from its cached build while
+// its complete signature (_chat_build_sig: the backend's live tail, its queue, the snapshot row, every side
+// file) holds. The pane shim's local socket carries `?active=`
 // on every dial, so a LOCAL kernel restart re-arms it. The federation relay (federation.ts connect) carries
-// no such hint, and nothing re-sent `activeTab` on the relay's reopen — so the restarted remote kernel
-// minted a client with no active tab, served the watched session as a background one, and its reply
-// streamed nowhere until the user's next send moved a file-stat input. Reproduced on two real hermetic
+// no such hint, and nothing re-sent `activeTab` on the relay's reopen, so the restarted remote kernel
+// minted a client with no active tab and served the watched session as a background one. Under the key of
+// the time, which folded no in-memory input for a background tab, its reply streamed nowhere until the
+// user's next send moved a file-stat input; today the missing hint costs the watched tab the head of the
+// build order and the first flush. Reproduced on two real hermetic
 // kernels (one attached to the other through the relay, a browser on the first): after the remote's restart
 // the in-memory probe never arrived in 12 s while that kernel logged the session as active=0 on every cycle;
 // a transcript append still flowed; a tab click flipped it back to active=1. The fix re-announces the active

--- a/ui/webview/relay-active.ts
+++ b/ui/webview/relay-active.ts
@@ -2,14 +2,16 @@
 // kernel restarted, the pane stopped receiving live events for that host's active session until the user's
 // next send).
 //
-// A kernel serves the tab a client is LOOKING AT from the live change key (its per-client `active`:
-// _active_chat_sig folds in the backend's live tail, its queue, the snapshot row and every side file) and
-// every other session from the file-stat cache (_chat_build_sig), which no in-memory stream ever busts. A
-// client declares its tab two ways: the `?active=` connect hint (the pane shim's LOCAL socket carries it on
-// every dial, from the PERSISTED state) and the `activeTab` message (render.ts notifyActive, on every tab
-// switch). The federation relay carries no connect hint, and a remote kernel that restarted mints a fresh
-// client with no active tab — so the session the user was watching streamed nowhere until their next send
-// moved a file-stat input. federation.ts dispatches romp:hostRelayUp on the relay's own open, the exact
+// A kernel builds the tab a client is LOOKING AT (its per-client `active`) first and flushes it first; every
+// tab is served from its cached build while its complete signature (_chat_build_sig: the backend's live tail,
+// its queue, the snapshot row, every side file) holds, so the hint decides the build order and the first
+// flush. A client declares its tab two ways: the `?active=` connect hint (the pane shim's LOCAL socket
+// carries it on every dial, from the PERSISTED state) and the `activeTab` message (render.ts notifyActive,
+// on every tab switch). The federation relay carries no connect hint, and a remote kernel that restarted
+// mints a fresh client with no active tab. Under the key of the time, which folded no in-memory input for a
+// background tab, the session the user was watching then streamed nowhere until their next send moved a
+// file-stat input; today it costs the watched tab its place at the head of the build and the first flush.
+// federation.ts dispatches romp:hostRelayUp on the relay's own open, the exact
 // moment the fresh kernel-side client exists; render.ts re-announces the active tab on it through
 // notifyActive (routeOutbound strips the host prefix), when this decision says that host owns the tab.
 //


### PR DESCRIPTION
Builds on https://github.com/romp-on/romp/pull/1251 (the chat build's fixed-cost memos and the per-input rebuild attribution), which has merged: this branch is rebased onto main and its three commits are the whole diff.

## Symptom

Publish one session's goal store and every open chat tab rebuilds, byte-identical. On a board with many tabs the judge's passes made the pusher spend most of its time re-reshaping transcripts nothing had changed in: in the replay on the branch this work was derived from, 420 of 435 chat builds per 120 s were rebuilds of background tabs whose only moved input was the global judge-pass counter (that figure was not re-measured here). The watched tab had a second key of its own (an exact key beside the background tabs' file-stat key) and a start-keyed dirty watermark standing in for the in-memory stamps neither key named. An input that key did not name left the tab stale until some file moved (a tmux session's composer echo, until 2026-09-05), and every edit inside the exact key had to be expressed in two places.

## Cause

`_chat_build_sig` included `_judge_gen[0]`, the counter every producer pass advances when any judge-written store moved, as a proxy for the judge's outputs, so a publish in session B moved session A's key. The watched tab's second key (`_active_chat_sig`, with `_clock_predicates`, `_external_sig` and `_ACTIVE_SIG_FILES`) stat'd a fixed list of side files and digested the tail's atoms for a backend without a revision, and the `_views_dirty` watermark covered whatever was left. Two writers of the SDK backend's live tail (`unqueue`, `edit_queued`) and one flag write (`_landed`) did not advance the tail's revision, and the tmux echo store had no revision at all.

## Fix

Three commits.

**1. The live-tail revision.** Every change to a session's in-memory tail advances one per-session revision on both backends. The SDK backend's `_touch_live` gains `unqueue`, `edit_queued` and the `_landed` flag write; `prune_live` and `retire_live_work` bump once per settling call; the two flag writes `_mark_dropped_echoes` makes outside the lock each take it for their bump; `live_rev` reads under the live-tail lock; the rule is written on `_touch_live`, and `tests/test_live_tail_rev.py` pins the writer set by source, so a queue or echo mutator that touches `_live` fails until it bumps. The kernel's tmux echo store gets `_tmux_echo_rev`, bumped by `_tmux_echo_add`, `_tmux_echo_prune`, `_tmux_echo_settle` and `TmuxBackend.dismiss_echo` only when something was added, dropped or marked; `TmuxBackend.live_rev` reads it. `Sessions.live_rev` dispatches to the owning backend and serializes the tail for a backend with no counter. The bench's constructor-free backend carries the revision slot.

**2. One signature for every tab.** `_chat_build_sig` is a flat tuple with one labelled component per input `build_session` reads (`_CHAT_SIG_LABELS`, 35 labels), and every tab is served while its signature holds. The components, in groups:

- Files by identity: the transcript and states files; the session's own goal store with its journal and archive (`jd._store_identity`, so a publish busts the owning tab at once and no other); the archive headline; the episode log; the registry and the death marker; the task store; the instruction files on the chain.
- In-memory state by value or revision: the rewind hold; the pending cut; the live tail by revision; the liveness row minus its per-cycle stamp; the backend's brackets and queue with each copy's identity, its recallability and launch error; the parked ops; the account hold, read only while a queued bubble can render (a queue, parked ops, or a tmux echo in flight); the retry state; the live background-task rows after the build's own expiry filter; the watches as rendered; the awaiting-stamp view; the warm-anchor revision; the branches forked from the session; the cwd's branch and repository and the trees it names.
- The clock, as the booleans the payload renders: the interrupt and compaction caps, the model-switch cap, the faded hour. The key moves at each crossing and at no other tick.
- Shared by every tab and taken once per push (`_chat_sig_shared`): the suspension count, a digest of the names registry, the flags, bell and colormap files, the login label with the availability half `_auth_avail_status` returns, `cleared.jsonl`, the host name.
- Three dependency components re-evaluated each cycle over the record the last build left (`_chat_build_deps`): the files whose tails the payload embeds, noted by `_read_task_output`, `_subagent_meta_map`, `_subagent_file` and `_agent_steps` as they read them (the sibling-directory fallback in `_subagent_file` records each sibling's `subagents/` directory, the directory its glob reads: a file landing there moves that directory's mtime, not the sibling's); the unresolved path tokens, re-resolved only for the messages whose candidate directories moved (`_chat_pl_precheck`, sharing `_repo_index_key` with the repo file index); and the postal cards' embedded values beside the log's identity, where a raw postal event that did not hydrate flags the log as a dependency too.

A build is cached only when the static components held across it (compared on a post-build signature taken without the dependency tail); otherwise it counts under `builds.chat.moved` and the next cycle builds it again. The cache entry is `(signature, payload, serialization, dependency record)`; index 2 stays the lazy serialization, so `tests/test_chat_skeleton_reconnect.py`'s pins hold. The pusher consumes the record after each build and leaves none on its thread; `_push_session_now` and the scroll-back slice, which cache nothing, leave none either. The comment threads' cache keys on the same signature without the dependency tail plus the thread's own states row, and keeps the dirty watermark for what that tail would have carried.

The liveness map the push holds is served to the signature's nested reads through the existing `_serve_live` scope, so `_bg_live_norm`, the awaiting sources and the watch rows read the snapshot the build will, and a connect push on a handler thread forks no tmux per tab; the liveness helpers keep their shapes. A signature that raises (one component's read failed) is said once per fault episode, on stderr with the traceback and as a refused bell row, the rule the chat-build fault follows; while the fault stands the tab is built every cycle and never cached (counted under `nosig`), and a signature that is taken ends the episode.

Retired: `_active_chat_sig`, `_clock_predicates`, `_external_sig`, `_ACTIVE_SIG_FILES` and the chat cache's `_views_dirty` watermark. `_judge_gen` stays for the feed and timeline view signature. `/perf`'s `bg_miss` carries one counter per label plus `cold` and `nosig`; `builds.chat` gains `moved`; `romp perf` prints the moved count beside the split when it is non-zero.

**3. Docs and the two webview comments** that explained the active-tab re-arm through the retired key. They now date the streamed-nowhere symptom to that key and say what a missing hint costs today: the watched tab's place at the head of the build order and the first flush.

Design points a reviewer may want to weigh:

- A bare `_mark_views_dirty` no longer rebuilds the watched tab. The post-build signature is the event-based form of the start-keyed watermark: the cache asks whether any named input differed between the signature before the build and the one after it. The accepted gap is an input moving between the post-build signature and the send, which the next cycle's signature sees (one cycle, the watermark's own granularity). `test_kernel.py`'s push-cache test is rewritten for this and pins that a live-tail echo, which the payload renders, does rebuild.
- Every tab now pays the signature per push. Measured with `tools/perf-bench.py` against one copy of this machine's state directory (8 live sessions, all tabs served, `--iters 5`), main at 8786f5f1 against this head: `push_steady` 19.52 ms to 24.04 ms per push (+4.5 ms, about 0.6 ms per tab); `push_connect:chat` 37.45 ms to 42.43 ms (+5.0 ms: the connect push now takes the signature and opens its shared scopes on the handler thread). `build_session_warm` moved within 1.5 ms per session and `push_cold_cycle` within 0.8 % (noise). On one copy of the state, base and head produce the same chat bytes. A first compare, on an earlier copy, differed by 243 bytes between its two runs; a second base run on the same copy as the head matched the head and the first base run, so the difference was a running task's output tail, read outside the copy, growing between the runs. The bench runs no judge pass between pushes, so it does not measure the rebuilds a publish no longer causes; that mechanism is pinned by the pusher tests below.
- The pathlink pre-check vouches for a message's unresolved tokens while the cwd, the repo-index key and the identities of its candidate directories hold, so a quiet cycle re-resolves nothing; a directory that moved re-resolves only the messages that named it.
- The signature is compared by position with `==` (its values include the liveness row's lists and the stamp view's frozenset), never hashed.

## Tests

Executing tests, each red before the change it covers:

- `tests/test_live_tail_rev.py` (new, 16 tests): every writer of either tail bumps once per changing call, by behaviour and by source; a read, a prune that retired nothing, a settle over marked echoes and a queue miss do not; `Sessions.live_rev` dispatches to the owning backend and serializes the tail for one without a counter. On main before commit 1, 11 fail (`unqueue`, `edit_queued` and the `_landed` write bump nothing; `prune_live` and `retire_live_work` bump per atom; `_tmux_echo_rev`, `TmuxBackend.live_rev` and `Sessions.live_rev` do not exist).
- `tests/test_chat_build_sig_inputs.py` (new, 47 tests; before commit 2, 43 fail, the four passing being the census's self-checks):
  - The census derives every helper call, dotted call and module global of `build_session` by AST and requires each to be classified, every `sig` label to be a component of the signature, and the retired names to be absent.
  - A differential suite over a hermetic world moves one input at a time and requires the miss under exactly that input's label: a transcript append, a states row, the store and its journal and archive, another session's publish plus the producer's generation bump, a rewind hold, the archive and episode log, the registry and death marker, the task store, a tmux echo and its dropped mark, the liveness row and its per-cycle stamp, each clock boolean at its crossing, parked ops and the account hold, the retry state, the task rows, a watch and one re-armed under the same note, the awaiting stamp and a postal-log landing, the anchor revision, the suspension list and the names digest, the shared files, the billing readers, the cwd and instruction files, a recorded task output that grows or appears, a pending path token whose file appears, a postal card's caption and the log. The handed liveness map is served to every nested read: a fresh liveness read during the signature fails the test.
  - The pusher with stubbed builders: a session's store publish rebuilds that tab alone under `store`, a bare dirty mark rebuilds nothing, a live-tail echo rebuilds its tab, the entry is the four-tuple, a build whose signature moved is not cached and counts under `moved`, a signature that raises is said once per episode (one stderr line, one bell row, the tab built and uncached under `nosig` until the read succeeds), and a push closes the scopes a previous push on its thread left open.
  - The pre-check and the scopes: a quiet cycle re-resolves no token, a moved directory re-resolves the message that named it, a push outside a cycle opens and closes its own scopes, and the cycle's finally closes what its jobs left open.
  - The real `build_session` under `_push`: a running task's output file and the agent's own transcript are recorded under the identity they were read under, and each growing rebuilds the tab under `taskout`; an agent file found under a sibling directory records that sibling's `subagents/` directory, and a file landing there rebuilds the tab; a fold hit over the same parse carries the sealed card's output into the record; a raw postal marker the index does not hold flags the log, and the log landing rebuilds under `postal`; a targeted push leaves no record on its thread.
- `tests/test_stage0_log_readers.py`: the watched-tab key class is rewritten as `EveryTabIsServedOnTheCompleteKey`, the same observables through the one key, each attributed to its component. The `base=` reuse test went with the parameter; the captions store is covered by the postal component; the in-flight judge set is not an input of `build_session`. Commit 1 also routes that class's tmux drop through the store's own settle and expects a new key after the dismissal, since a revision counts changes and never returns.
- `tests/test_kernel.py`: the push-cache test's dirty-mark step (the first design point).
- `tests/test_chat_fixed_cost_memos.py`, `tests/test_perf_stats.py`, `tests/romp-perf.bats`: the label pins, the `moved` field and the CLI fixture follow the new labels (`store` where `judge_gen` was); the CLI fixture's window carries three moved builds and the chat line asserts `; 3 moved`, red without the `bin/romp` change.

Mutation checks, each turned red by a test above: a reader that stops noting its file (`_read_task_output`, `_agent_steps`, `_subagent_meta_map`, `_subagent_file`); the sibling fallback noting the sibling instead of its `subagents/`; a fold hit dropping the sealed prefix's outputs; `build_session` ignoring the raw tail for the postal flag; `_chat_build_sig` serving no handed map; the pusher or `_push_session_now` leaving the record on the thread; the push scopes left open at the top of a push or by the cycle's finally; the signature fault written every cycle; `romp perf` printing no moved count.

Runs on the final tree: `pytest -n 6 tests/` 11071 passed, 41 skipped, 0 failed, 1705 subtests passed (162 s); `npm run typecheck` clean; `npm test` 4094 passed (4072 in the main leg, 22 in the timeline-tags-scale leg run alone), 0 failed; `bats tests/romp-perf.bats` 15 of 15.

Not included: the working note and the user todos are not inputs of `build_session` here, so they have no component; a later change that reads one in the build fails the census until it is classified and keyed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)