### PR TITLE
Kernel: every file-path import goes through load_source, so the kernel loads clean under Python's load_module() deprecation

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -514,4 +514,4 @@ permission/API-error floors: one interrupt at a time, the present event first.
   `STATE/judge-auth.json` (the per-session judge-auth-down latch; see
   "Billing" above).
 - Debugging: run the judge's own code against the live store
-  (`SourceFileLoader` on `kernel/judge.py`) rather than inferring from logs.
+  (loaded by file path from `kernel/judge.py`) rather than inferring from logs.

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -43,6 +43,6 @@ kernel before anything is spawned when a retired key path is still configured
 kernel's own environment), naming variable names and paths only. See
 `docs/reference.md` for setup and rotation.
 
-Everything here is loaded by file path (`SourceFileLoader`), not installed as a
-package; the repo runs straight from a git clone. Python tests live in
-`tests/test_*.py`.
+Everything here is loaded by file path (`loadsource.load_source`, the
+`spec_from_loader` + `exec_module` idiom), not installed as a package; the repo
+runs straight from a git clone. Python tests live in `tests/test_*.py`.

--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -5,7 +5,7 @@ Drives OpenAI Codex sessions through the official openai-codex Python SDK's sync
 (JSON-RPC to `codex app-server` over stdio) and materializes each thread as Claude-transcript-shaped
 JSONL via kernel/codex_events.ThreadNormalizer, so romp's entire read side parses Codex sessions
 unchanged. Duck-types the SessionBackend ABC exactly like SdkBackend does (the kernel loads backends
-via SourceFileLoader; a conformance test asserts every abstract method exists).
+by file path; a conformance test asserts every abstract method exists).
 
 Shape of the machine:
 - ONE CodexClient per backend — the app-server hosts many threads, unlike Claude's one-CLI-per-
@@ -34,20 +34,24 @@ import threading
 import time
 import traceback
 import uuid as uuidlib
-from importlib.machinery import SourceFileLoader
+import importlib.util
 from pathlib import Path
 
 HERE = Path(os.path.dirname(os.path.realpath(__file__)))
-_events = SourceFileLoader("romp_codex_events", str(HERE / "codex_events.py")).load_module()
-_runtime = SourceFileLoader("romp_codex_runtime", str(HERE / "codex_runtime.py")).load_module()
+_ls_spec = importlib.util.spec_from_file_location("romp_loadsource", str(HERE / "loadsource.py"))
+_ls_mod = importlib.util.module_from_spec(_ls_spec)
+_ls_spec.loader.exec_module(_ls_mod)
+load_source = _ls_mod.load_source   # file-path imports with load_module()'s sys.modules semantics (kernel/loadsource.py)
+_events = load_source("romp_codex_events", HERE / "codex_events.py")
+_runtime = load_source("romp_codex_runtime", HERE / "codex_runtime.py")
 # The by-text KEY RULE (session_backend.echo_text_key): the one normalization under which an input echo's
 # text is compared with a transcript record's, shared with the kernel's _atom_user_texts and
 # SdkBackend.prune_live, so an echo whose text carries a trailing newline still lands. The kernel's own
 # copy of that module when it is loaded (kernel.py loads it as romp_session_backend, and TmuxBackend
 # subclasses that copy's ABC); otherwise the file is loaded under its OWN module name, as sdk_backend
 # does, so re-executing the source never rebinds the ABC out from under a subclass.
-echo_text_key = (sys.modules.get("romp_session_backend") or SourceFileLoader(
-    "romp_session_backend_keys", str(HERE / "session_backend.py")).load_module()).echo_text_key
+echo_text_key = (sys.modules.get("romp_session_backend")
+                 or load_source("romp_session_backend_keys", HERE / "session_backend.py")).echo_text_key
 
 SDK_PIN = "openai-codex==0.144.4"     # bin/romp-codex-setup installs exactly this into codexvenv
 SETUP_HINT = ("Session not created: the Codex backend isn't installed. "

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13,9 +13,8 @@ CLI:
   romp-judge --once               # one caption pass over the live fleet (writes captions/)
   romp-judge --test <transcript>  # caption one transcript's recent units, print them (no write)
 """
-import contextlib, copy, hashlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading, traceback
+import contextlib, copy, hashlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading, traceback, importlib.util
 from pathlib import Path
-from importlib.machinery import SourceFileLoader
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
@@ -62,9 +61,12 @@ class _TimedPool(ThreadPoolExecutor):
 ThreadPoolExecutor = _TimedPool      # every pool below is a timed one (see above)
 
 HERE = Path(__file__).resolve().parent
-em = SourceFileLoader("romp_event_model", str(HERE / "event_model.py")).load_module()
-_cred = sys.modules.get("romp_credentials") or SourceFileLoader(
-    "romp_credentials", str(HERE / "credentials.py")).load_module()
+_ls_spec = importlib.util.spec_from_file_location("romp_loadsource", str(HERE / "loadsource.py"))
+_ls_mod = importlib.util.module_from_spec(_ls_spec)
+_ls_spec.loader.exec_module(_ls_mod)
+load_source = _ls_mod.load_source   # file-path imports with load_module()'s sys.modules semantics (kernel/loadsource.py)
+em = load_source("romp_event_model", HERE / "event_model.py")
+_cred = sys.modules.get("romp_credentials") or load_source("romp_credentials", HERE / "credentials.py")
 
 HOME     = Path.home()
 STATE    = Path(os.environ.get("ROMP_STATE_DIR")   # per-kernel state root override (plans/multi-kernel.md)
@@ -1032,7 +1034,7 @@ _judge_ctx = threading.local()                       # per-thread: the fsid bein
 # In-flight judge calls, so the live timeline can draw a run-span GROWING to now the moment a call STARTS,
 # instead of the bar only appearing (back-dated to its real start) once the call returns and its usage line
 # is written (the user 2026-06-23). In-process registry: the kernel runs the judge in its own threads
-# (SourceFileLoader), so it reads `active_runs()` directly — no file, no cross-process race. Self-cleaning:
+# (loaded by file path), so it reads `active_runs()` directly — no file, no cross-process race. Self-cleaning:
 # every call deregisters in a `finally`, so a timeout/parse-fail/exception can't leak a forever-growing bar.
 _active = {}                                          # run_id -> {"judge", "fsid", "sent"}
 _PASS_DONE = {}                                       # (tier, fsid) -> wall clock of that tier's last COMPLETED

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13,22 +13,25 @@ Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
 import copy
 import math
-import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools, fcntl, inspect
+import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools, fcntl, inspect, importlib.util
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
-from importlib.machinery import SourceFileLoader
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, quote, unquote, urlencode
 
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
 BIN = ROOT / "bin"
-em = SourceFileLoader("romp_event_model", str(HERE / "event_model.py")).load_module()
-jd = SourceFileLoader("romp_judge", str(HERE / "judge.py")).load_module()
-cm = SourceFileLoader("romp_colormap", str(HERE / "colormap.py")).load_module()  # age → recency tint
-pal = SourceFileLoader("romp_palette", str(HERE / "palette.py")).load_module()  # session-identity palettes (selectable)
-ap = SourceFileLoader("romp_askparse", str(HERE / "askparse.py")).load_module()  # tmux-pane → live AskUserQuestion picker
-sb = SourceFileLoader("romp_session_backend", str(HERE / "session_backend.py")).load_module()  # the SessionBackend ABC
+_ls_spec = importlib.util.spec_from_file_location("romp_loadsource", str(HERE / "loadsource.py"))
+_ls_mod = importlib.util.module_from_spec(_ls_spec)
+_ls_spec.loader.exec_module(_ls_mod)
+load_source = _ls_mod.load_source   # file-path imports with load_module()'s sys.modules semantics (kernel/loadsource.py)
+em = load_source("romp_event_model", HERE / "event_model.py")
+jd = load_source("romp_judge", HERE / "judge.py")
+cm = load_source("romp_colormap", HERE / "colormap.py")  # age → recency tint
+pal = load_source("romp_palette", HERE / "palette.py")  # session-identity palettes (selectable)
+ap = load_source("romp_askparse", HERE / "askparse.py")  # tmux-pane → live AskUserQuestion picker
+sb = load_source("romp_session_backend", HERE / "session_backend.py")  # the SessionBackend ABC
 CHAT_VIEW = ROOT / "vscode-extension"               # the tuned UI, current in this worktree via `git merge main`
 # ROMP_DIST_DIR: test seam (romp-lab serves a COPY of the built bundles, so its rebuild simulations —
 # mtime bumps that must raise the reload banner — never touch the dist the LIVE kernel serves).
@@ -7306,7 +7309,7 @@ _REBUILT_FOR = [""]   # the checkout sha this RUNNING kernel already converged t
 def _restart_class(path):
     """Which RUNNING PROCESS a changed file's code lives in — "kernel", "bus", or "skip" (T216).
     Verified process boundaries, not guesses: the kernel process loads exactly kernel/*.py +
-    bin/romp-kernel in-process (every kernel module rides SourceFileLoader at import; judges run
+    bin/romp-kernel in-process (every kernel module is loaded by file path at import; judges run
     in-process too). postal/ is NEVER imported here — the bus is its own process with its own
     restart verb, and bouncing the kernel for a bus change restarts the WRONG thing. cli/ is
     loaded per `romp` invocation, never by this process — the next run picks it up. .md files
@@ -14574,7 +14577,7 @@ def _sdk_locked():
                 # is what puts this line in front of the user instead of only in the kernel log. Before
                 # that, a fresh install whose romp-sdk-setup had bailed looked like romp silently eating
                 # every message (the user 2026-07-28).
-            sbmod = SourceFileLoader("romp_sdk_backend", str(HERE / "sdk_backend.py")).load_module()
+            sbmod = load_source("romp_sdk_backend", HERE / "sdk_backend.py")
             # The backend claims the login tokens out of os.environ once (startup_auth_env), and the judges
             # read that same stash through this wire for their login-billed children. No key rides here:
             # romp holds none (credentials.py, 2026-09-08), and every child resolves Claude Code's own
@@ -14681,7 +14684,7 @@ def _codex():
     with _codex_lock:
         if _codex_backend is None:
             try:
-                cxmod = SourceFileLoader("romp_codex_backend", str(HERE / "codex_backend.py")).load_module()
+                cxmod = load_source("romp_codex_backend", HERE / "codex_backend.py")
                 _codex_backend = cxmod.CodexBackend(
                     jd.STATE, notify=_send_to_app,
                     poke=_wake_kernel, push=_pusher_wake.set,

--- a/kernel/loadsource.py
+++ b/kernel/loadsource.py
@@ -1,0 +1,55 @@
+"""load_source(name, path): import a Python file by path under a chosen module name.
+
+Everything under kernel/ is loaded by file path, not installed as a package (the repo runs from a
+clone; bin/ holds symlinks with the stable names, and cli/ and postal/ run as scripts through them).
+Every such load used to be `SourceFileLoader(name, path).load_module()`. `load_module()` has been
+deprecated since Python 3.4, emits a DeprecationWarning on 3.10 and later, and its removal is
+documented for 3.15, so this is the one replacement, built from the documented pieces
+(`spec_from_loader`, `module_from_spec`, `exec_module`) and keeping what the kernel relied on in the
+old call:
+
+- The module is registered in `sys.modules[name]` before it executes, so a module that loads
+  another under the same name during its own import gets the same object.
+- A name that is ALREADY in `sys.modules` is re-executed into the existing module object rather
+  than replaced. kernel.py, judge.py and every test module load `romp_event_model` and
+  `romp_judge` by these fixed names, so `km.jd is jd` holds in a test that loaded both, and a
+  test's `jd._rebind_state(...)` is seen by the kernel it then drives. The two places that must
+  NOT share (sdk_backend's and codex_backend's key imports of session_backend, loaded as
+  `romp_session_backend_keys`) already use a distinct name for exactly this reason.
+- A failed first load leaves no half-built entry in `sys.modules`.
+
+An explicit SourceFileLoader is required: the bin/ names carry no `.py` suffix, and
+`spec_from_file_location` without a loader returns None for a path it cannot map to one.
+
+Loaded by path itself (`spec_from_file_location`, `module_from_spec` and `exec_module` in each
+module that needs it); tests reach it through tests/romp_load.py.
+"""
+import importlib.util
+import sys
+from importlib.machinery import SourceFileLoader
+
+
+def load_source(name, path):
+    """Execute the source file at `path` as module `name` and return the module (see the module
+    docstring for the `sys.modules` semantics)."""
+    loader = SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_loader(name, loader)
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        try:
+            loader.exec_module(mod)
+        except BaseException:
+            sys.modules.pop(name, None)
+            raise
+    else:
+        # the attributes load_module() re-stamped on a reused module (importlib's
+        # _init_module_attrs with override=True), so a module re-executed from a differently
+        # spelled path reports where its code now comes from
+        mod.__spec__ = spec
+        mod.__loader__ = loader
+        mod.__file__ = spec.origin
+        mod.__cached__ = spec.cached
+        loader.exec_module(mod)
+    return sys.modules.get(name, mod)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -45,13 +45,17 @@ from pathlib import Path
 # The tmux launcher picks the first unused colour; for an SDK session we pick deterministically by a
 # stable hash of the sid (the launcher's own fallback when all are taken), so the session gets a
 # consistent colour without cross-backend "used" bookkeeping.
-from importlib.machinery import SourceFileLoader as _SFL
-_pal = _SFL("romp_palette", str(Path(__file__).resolve().parent / "palette.py")).load_module()
+import importlib.util
+_HERE = Path(__file__).resolve().parent
+_ls_spec = importlib.util.spec_from_file_location("romp_loadsource", str(_HERE / "loadsource.py"))
+_ls_mod = importlib.util.module_from_spec(_ls_spec)
+_ls_spec.loader.exec_module(_ls_mod)
+load_source = _ls_mod.load_source   # file-path imports with load_module()'s sys.modules semantics (kernel/loadsource.py)
+_pal = load_source("romp_palette", _HERE / "palette.py")
 # How romp reaches an API credential (credentials.py: stdlib only, loaded the same way as event_model so
 # the standalone judges and the kernel share one copy). romp holds no key of its own since 2026-09-08:
 # the module reads Claude Code's apiKeyHelper for the kernel's two calls and checks the boot environment.
-_cred = sys.modules.get("romp_credentials") or _SFL(
-    "romp_credentials", str(Path(__file__).resolve().parent / "credentials.py")).load_module()
+_cred = sys.modules.get("romp_credentials") or load_source("romp_credentials", _HERE / "credentials.py")
 # The by-text KEY RULES (session_backend.echo_text_key, and command_text_key for a slash send): the one
 # normalization under which an input echo's text is compared with a transcript record's, shared with the
 # kernel's _atom_user_texts so the landing scan below can never find what prune_live cannot retire. The
@@ -59,8 +63,8 @@ _cred = sys.modules.get("romp_credentials") or _SFL(
 # is loaded under its OWN module name: the kernel loads it as romp_session_backend and TmuxBackend
 # subclasses that copy's ABC, and re-executing the source into that module object would rebind the class
 # out from under the subclass.
-_keys = (sys.modules.get("romp_session_backend") or _SFL(
-    "romp_session_backend_keys", str(Path(__file__).resolve().parent / "session_backend.py")).load_module())
+_keys = (sys.modules.get("romp_session_backend")
+         or load_source("romp_session_backend_keys", _HERE / "session_backend.py"))
 echo_text_key = _keys.echo_text_key
 command_text_key = _keys.command_text_key
 echo_keys = _keys.echo_keys                  # both keys of a text, the "either key" rule written once

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,8 +3,11 @@
 Every bug fix or feature change lands with a test (repo rule). Five suites:
 
 - **`test_*.py`** (pytest) — the Python pipeline: event model, judges, kernel,
-  backends, postal. They load the sources by file path via `SourceFileLoader`
-  (through the stable `bin/` names) and isolate state with `XDG_STATE_HOME`.
+  backends, postal. They load the sources by file path through the stable
+  `bin/` names and isolate state with `XDG_STATE_HOME`. The loader is
+  `from romp_load import load_source` (`tests/romp_load.py`, which reaches
+  `kernel/loadsource.py`); the older `SourceFileLoader(...).load_module()` form
+  still loads but is deprecated, with removal documented for Python 3.15.
   Golden transcript fixtures: `test_romp_events_golden.py` + `fixtures/`.
   Run: `python3 -m pytest tests/ -q` (~20s; a stalled run is a hang, not slow).
   The `_HAVE_SDK`-gated classes in `test_sdk_backend.py` (OptionsAssembly, the

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,7 @@ script run — the per-module preambles do, and tests/test_state_isolation_order
 import atexit
 import os
 import shutil
+import sys
 import tempfile
 
 # Temp-directory hygiene, the in-process half (2026-09-06): the suite used to leak every directory it
@@ -67,3 +68,10 @@ os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")
 # thread method ends a hung run that way), so a hung run leaves this dir beside the root.
 STATE_DIR = os.environ["XDG_STATE_HOME"]
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+
+# `from romp_load import load_source` in a test module (tests/romp_load.py): under pytest and
+# `python -m unittest tests.test_x` the test modules are imported as members of this package, so the
+# bare name resolves only because it is registered here; a direct script run finds the file on
+# sys.path itself. One module object either way.
+from . import romp_load as _romp_load  # noqa: E402
+sys.modules.setdefault("romp_load", _romp_load)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,7 +327,7 @@ def _stub_place_llm(monkeypatch):
 
 
 # No test may leave the shared judge or a call-time environment seam changed (2026-09-09). kernel.py
-# loads the judge as SourceFileLoader("romp_judge", ...).load_module(), and load_module re-executes
+# loads the judge as load_source("romp_judge", ...) (kernel/loadsource.py), which re-executes
 # into the module object already in sys.modules under that name, so every kernel-loading test
 # module's km.jd is ONE process-wide object. A test that rebinds jd.STATE to a temp dir and removes
 # that dir in tearDown without restoring the prior value leaves every later STATE reader in the

--- a/tests/romp_load.py
+++ b/tests/romp_load.py
@@ -1,0 +1,24 @@
+"""The test suite's file-path importer: `from romp_load import load_source`.
+
+A test module loads the code under test by path through the stable bin/ names
+(`load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))`). The older form,
+`SourceFileLoader(...).load_module()`, emits a DeprecationWarning on Python 3.10 and later and its
+removal is documented for 3.15; the replacement is kernel/loadsource.py, and this module is how a
+test reaches it without a package import. It is importable under every way the suite runs: pytest
+and `python -m unittest tests.test_x` import the tests package first, whose __init__ registers this
+module under the bare name; a direct `python tests/test_x.py` (or `cd tests && python -m unittest
+test_x`) has this directory on sys.path already.
+
+The semantics a test may lean on are load_module()'s, kept on purpose: a name already in
+sys.modules is re-executed into the SAME module object, so a test that loads `romp_judge` and then
+`romp_kernel` gets a kernel whose `jd` IS its own `jd` handle (and a `_rebind_state` on one is seen
+by the other). A test that needs a private copy loads under a private name, as before.
+"""
+import importlib.util
+import os
+
+_SRC = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "kernel", "loadsource.py")
+_spec = importlib.util.spec_from_file_location("romp_loadsource", _SRC)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+load_source = _mod.load_source

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -267,21 +267,14 @@ class OneClock(unittest.TestCase):
 
         fake = types.SimpleNamespace(SdkBackend=_Recorder, startup_auth_env=lambda *a, **k: {})
 
-        class _Loader:
-            def __init__(self, name, path):
-                pass
-
-            def load_module(self):
-                return fake
-
-        names = ("_sdk_backend", "SourceFileLoader", "_ensure_sdk_on_path", "_load_model_catalog_cache",
+        names = ("_sdk_backend", "load_source", "_ensure_sdk_on_path", "_load_model_catalog_cache",
                  "_refresh_model_catalog", "_claude_bin", "_mark_boot", "_sdk_problem")
         saved = {n: getattr(km, n) for n in names}
         saved_jd = (km.jd._LOGIN_AUTH_ENV_FN, km.jd._USAGE_REFRESH_FN)
         problems = []
         try:
             km._sdk_backend = None
-            km.SourceFileLoader = _Loader
+            km.load_source = lambda name, path: fake
             km._ensure_sdk_on_path = lambda: True
             km._load_model_catalog_cache = lambda: None
             km._refresh_model_catalog = lambda why: None

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -220,12 +220,11 @@ class HeadlessRoutes(unittest.TestCase):
 
 
 class CodexRuntimeSelection(unittest.TestCase):
+    # The kernel loads codex_backend.py through load_source (kernel/loadsource.py): patch that.
     def test_path_codex_does_not_override_managed_runtime(self):
         fake_mod = mock.Mock()
-        fake_loader = mock.Mock()
-        fake_loader.load_module.return_value = fake_mod
         with mock.patch.object(km, "_codex_backend", None), \
-             mock.patch.object(km, "SourceFileLoader", return_value=fake_loader), \
+             mock.patch.object(km, "load_source", return_value=fake_mod), \
              mock.patch.object(km.shutil, "which", return_value="/TESTBIN/codex"):
             backend = km._codex()
             self.assertIs(backend, fake_mod.CodexBackend.return_value)
@@ -238,9 +237,8 @@ class CodexRuntimeSelection(unittest.TestCase):
         # PATH is ignored, but the one explicit knob the judges already read (ROMP_CODEX_BIN) governs
         # sessions too — an opt-in, not the ambient PATH accident #929 closed (review fold, 2026-09-07)
         fake_mod = mock.Mock()
-        fake_loader = mock.Mock(); fake_loader.load_module.return_value = fake_mod
         with mock.patch.object(km, "_codex_backend", None), \
-             mock.patch.object(km, "SourceFileLoader", return_value=fake_loader), \
+             mock.patch.object(km, "load_source", return_value=fake_mod), \
              mock.patch.dict(km.os.environ, {"ROMP_CODEX_BIN": "/opt/codex/bin/codex"}), \
              mock.patch.object(km.shutil, "which", return_value="/TESTBIN/codex"):
             km._codex()
@@ -266,13 +264,11 @@ class SdkSingleFlight(unittest.TestCase):
 
         fake_mod = mock.Mock()
         fake_mod.SdkBackend = lambda *a, **k: FakeBackend()
-        fake_loader = mock.Mock()
-        fake_loader.load_module.return_value = fake_mod
         prev = km._sdk_backend
         try:
             km._sdk_backend = None
             results = [None] * 6
-            with mock.patch.object(km, "SourceFileLoader", return_value=fake_loader), \
+            with mock.patch.object(km, "load_source", return_value=fake_mod), \
                  mock.patch.object(km, "_ensure_sdk_on_path", return_value=True):
                 ts = [threading.Thread(target=lambda i=i: results.__setitem__(i, km._sdk()))
                       for i in range(6)]

--- a/tests/test_loadsource.py
+++ b/tests/test_loadsource.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""kernel/loadsource.py replaces SourceFileLoader.load_module() for the kernel's file-path imports.
+
+load_module() emits a DeprecationWarning on Python 3.10 and later, and its removal is documented for
+3.15. The first class here runs each kernel module's import in a fresh interpreter with that one
+warning turned into an error: a kernel module (or one it loads at import) still calling load_module()
+fails at the line that does, and the child's traceback names it. The second class pins the properties
+of load_module() that the kernel and the tests rely on (registered before executing, the same object on
+a second load under one name, no entry after a failed first load, the object a module put in sys.modules
+in place of itself, a suffix-less path), against throwaway modules written to a temp dir under a private
+name: nothing under test reads romp state.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+KERNEL = os.path.join(os.path.dirname(HERE), "kernel")
+# Hermetic state BEFORE the loads: the ratchet counts every load_source call as a load. The modules
+# loaded in-process here are throwaway, and the floor costs two lines.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+
+NAME = "romp_loadsource_probe"           # private: no other module loads under it
+
+# Run in a child interpreter: import one file by path under a private name with load_module()'s own
+# DeprecationWarning promoted to an error. The filter is narrow (the message, not the category), so a
+# deprecation elsewhere in the kernel's imports cannot trip it; the child's own load goes through
+# spec_from_file_location + exec_module, so only a load_module() call inside the loaded code can raise.
+_CHILD = r"""
+import importlib.util, sys, warnings
+warnings.filterwarnings("error", message=r".*load_module\(\).*")
+name, path = sys.argv[1:3]
+spec = importlib.util.spec_from_file_location(name, path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules[name] = mod
+spec.loader.exec_module(mod)
+print("loaded", mod.__name__)
+"""
+
+
+class KernelModulesLoadWithoutTheDeprecatedCall(unittest.TestCase):
+    """Each kernel module that imports other files by path is loaded in its own fresh interpreter, so
+    every one of its load sites runs (a module already in sys.modules would short-circuit the guarded
+    ones) and nothing leaks into this process's shared modules."""
+
+    def _load_in_a_fresh_interpreter(self, filename):
+        with tempfile.TemporaryDirectory() as state:
+            env = dict(os.environ)
+            env["XDG_STATE_HOME"] = state          # the child resolves its state root at import
+            env.pop("ROMP_STATE_DIR", None)
+            proc = subprocess.run(
+                [sys.executable, "-c", _CHILD, "romp_loadsource_probe_" + filename[:-3],
+                 os.path.join(KERNEL, filename)],
+                env=env, capture_output=True, text=True, timeout=120)
+        self.assertEqual(proc.returncode, 0,
+            "kernel/%s (or a module it loads at import) still calls SourceFileLoader.load_module(), "
+            "deprecated (its DeprecationWarning is emitted on Python 3.10 and later; removal documented "
+            "for 3.15); the traceback names the site:\n%s" % (filename, proc.stderr))
+        self.assertIn("loaded romp_loadsource_probe_" + filename[:-3], proc.stdout)
+
+    def test_kernel_py_loads_under_the_load_module_warning_as_error(self):
+        self._load_in_a_fresh_interpreter("kernel.py")
+
+    def test_judge_py_loads_under_the_load_module_warning_as_error(self):
+        self._load_in_a_fresh_interpreter("judge.py")
+
+    def test_sdk_backend_py_loads_under_the_load_module_warning_as_error(self):
+        self._load_in_a_fresh_interpreter("sdk_backend.py")
+
+    def test_codex_backend_py_loads_under_the_load_module_warning_as_error(self):
+        self._load_in_a_fresh_interpreter("codex_backend.py")
+
+
+class LoadSource(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.dir = Path(self.td.name)
+        sys.modules.pop(NAME, None)
+
+    def tearDown(self):
+        sys.modules.pop(NAME, None)
+        self.td.cleanup()
+
+    def _write(self, name, body):
+        p = self.dir / name
+        p.write_text(body)
+        return p
+
+    def test_a_fresh_load_is_registered_before_it_executes(self):
+        p = self._write("a.py", "import sys\nSELF = sys.modules.get(__name__)\nVALUE = 1\n")
+        mod = load_source(NAME, p)
+        self.assertIs(mod.SELF, mod, "the module saw itself in sys.modules while its own body ran")
+        self.assertIs(sys.modules[NAME], mod)
+        self.assertEqual(mod.__name__, NAME)
+        self.assertEqual(mod.__file__, str(p))
+        self.assertEqual(mod.__spec__.origin, str(p))
+        self.assertEqual(mod.VALUE, 1)
+
+    def test_a_second_load_under_the_same_name_reexecutes_the_same_object(self):
+        # kernel.py and judge.py both load romp_event_model, and a test module loads romp_judge before
+        # the kernel does: the second load must land in the FIRST module object (km.jd is jd), with the
+        # module's own attributes saying where its code now comes from
+        a = self._write("a.py", "VALUE = 1\n")
+        b = self._write("b.py", "VALUE = 2\n")
+        first = load_source(NAME, a)
+        second = load_source(NAME, b)
+        self.assertIs(second, first)
+        self.assertIs(sys.modules[NAME], first)
+        self.assertEqual(first.VALUE, 2, "re-executed from the new path")
+        self.assertEqual(first.__file__, str(b))
+        self.assertEqual(first.__spec__.origin, str(b))
+        self.assertIs(first.__loader__, first.__spec__.loader)
+
+    def test_a_failing_first_load_leaves_no_entry(self):
+        p = self._write("bad.py", "import sys\nassert __name__ in sys.modules\nraise RuntimeError('boom')\n")
+        with self.assertRaises(RuntimeError):
+            load_source(NAME, p)
+        self.assertNotIn(NAME, sys.modules, "a half-built module is never left behind")
+
+    def test_a_failing_reload_keeps_the_existing_module_registered(self):
+        # load_module()'s behaviour, kept: the re-executed object stays what it was, in sys.modules
+        good = self._write("good.py", "VALUE = 1\n")
+        bad = self._write("bad.py", "raise RuntimeError('boom')\n")
+        mod = load_source(NAME, good)
+        with self.assertRaises(RuntimeError):
+            load_source(NAME, bad)
+        self.assertIs(sys.modules[NAME], mod)
+
+    def test_a_module_that_replaces_itself_in_sys_modules_is_returned_as_the_replacement(self):
+        # load_module()'s behaviour, kept: the caller gets whatever the name maps to once the body has
+        # run, so a module that installs a stand-in for itself hands that stand-in to its importer
+        p = self._write("a.py", "import sys, types\nsys.modules[__name__] = types.SimpleNamespace(VALUE=9)\n")
+        mod = load_source(NAME, p)
+        self.assertEqual(mod.VALUE, 9)
+        self.assertIs(sys.modules[NAME], mod)
+
+    def test_a_path_without_a_py_suffix_loads(self):
+        # the bin/ names (romp-kernel, romp-judge) carry no suffix, which is why an explicit
+        # SourceFileLoader is built rather than spec_from_file_location guessing one
+        p = self._write("romp-probe", "VALUE = 3\n")
+        self.assertEqual(load_source(NAME, p).VALUE, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_isolation_order.py
+++ b/tests/test_state_isolation_order.py
@@ -14,8 +14,8 @@ conftest gives pytest, but neither covers `cd tests && python -m unittest test_x
 script run, so the per-module preamble is the primary defence and this test is the ratchet.
 
 The rule this file enforces, per tests/test_*.py module: if the module loads romp code (any
-SourceFileLoader call, or an import of the kernel/postal/cli packages), then BEFORE the first
-such load, at module top level, it must (a) assign os.environ["XDG_STATE_HOME"] (or
+load_source or SourceFileLoader call, or an import of the kernel/postal/cli packages), then BEFORE
+the first such load, at module top level, it must (a) assign os.environ["XDG_STATE_HOME"] (or
 ["ROMP_STATE_DIR"]) and (b) handle ROMP_STATE_DIR (assign it, or pop it — a live kernel exports
 it to its sessions, and it outranks the XDG floor). The canonical preamble:
 
@@ -25,8 +25,9 @@ it to its sessions, and it outranks the XDG floor). The canonical preamble:
     os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 
 Static AST scan, ordered by line number; every in-process load call counts as state-touching —
-SourceFileLoader and the importlib idioms (spec_from_file_location/exec_module/import_module/
-__import__) alike, since most bin/* files are or transitively load a STATE-resolving module, and
+load_source (tests/romp_load.py), SourceFileLoader and the importlib idioms
+(spec_from_file_location/exec_module/import_module/__import__) alike, since most bin/* files are or
+transitively load a STATE-resolving module, and
 the few that aren't pay two harmless lines rather than this test resolving targets. Out of scope by design: a subprocess
 spawned with a hand-built env= dict that carries the real HOME — env construction is dynamic and
 defeats static checking; the preamble covers the common case because a child spawned without
@@ -34,6 +35,7 @@ env= inherits the mutated os.environ.
 """
 import ast
 import os
+import tempfile
 import unittest
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -48,11 +50,11 @@ PREAMBLE = (
 )
 
 ROOT_PACKAGES = {"kernel", "postal", "cli"}
-# Every in-process load form counts, not just the repo's usual SourceFileLoader: the
+# Every in-process load form counts, not just the repo's usual load_source and SourceFileLoader: the
 # spec_from_file_location + exec_module idiom (tests/test_colormap.py) aimed at a STATE-resolving
 # bin file would recreate the corruption with the ratchet silent otherwise.
-LOAD_CALLS = {"SourceFileLoader", "spec_from_file_location", "exec_module", "import_module",
-              "__import__"}
+LOAD_CALLS = {"load_source", "SourceFileLoader", "spec_from_file_location", "exec_module",
+              "import_module", "__import__"}
 
 
 def _is_environ_attr(node):
@@ -123,8 +125,23 @@ class StateIsolationOrder(unittest.TestCase):
             "These modules load romp code before making the state root hermetic — under a bare\n"
             "unittest or script run they operate on the REAL ~/.local/state/romp (which is how\n"
             "tests/test_kernel.py overwrote the real remotes.json on 2026-08-12). Put this at\n"
-            "module top level, above the first SourceFileLoader line:\n\n%s\n\n%s"
+            "module top level, above the first load_source or SourceFileLoader line:\n\n%s\n\n%s"
             % (PREAMBLE, "\n".join(bad)))
+
+    def test_scan_counts_a_load_source_call_as_a_load(self):
+        # tests/romp_load.py's load_source is a load like the others: a module that calls it before
+        # the floor must be caught, or the ratchet is blind to every module written that way
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "test_probe.py")
+            with open(path, "w") as f:
+                f.write('import os\n'
+                        'from romp_load import load_source\n'
+                        'km = load_source("romp_kernel_probe", "bin/romp-kernel")\n'
+                        'os.environ["XDG_STATE_HOME"] = "too late"\n')
+            first_load, first_set, rsd_handled = scan(path)
+        self.assertEqual(first_load, 3, "the load_source call is the module's first load")
+        self.assertEqual(first_set, 4)
+        self.assertIsNone(rsd_handled)
 
     def test_the_suite_wide_floors_stay_in_place(self):
         # The suspenders: conftest.py (pytest) and __init__.py (unittest package runs) each set the


### PR DESCRIPTION
## Symptom

Every file-path import in `kernel/kernel.py`, `kernel/judge.py`, `kernel/sdk_backend.py` and `kernel/codex_backend.py` raises `DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead` on Python 3.10 through 3.13 (the 3.14 interpreter's text names 3.15). Python's default filter drops it on a plain kernel start (the warning is attributed to importlib, not `__main__`), so it shows under pytest, `-W default` or `-X dev`; the test run today reports thousands of them. With the warning promoted to an error, `kernel/kernel.py` stops importing at line 26; on the release that removes the call it stops importing outright.

## Cause

The four kernel modules import their sibling modules with `SourceFileLoader(name, path).load_module()`: six loads at kernel.py's head plus the two lazy backend loads, `judge.py`'s event-model and guarded credentials loads, `sdk_backend.py`'s palette, guarded credentials and guarded session-backend loads, and `codex_backend.py`'s codex_events, codex_runtime and guarded session-backend loads. `load_module()` has been deprecated since Python 3.4, emits a DeprecationWarning on 3.10 and later (verified 3.10 through 3.14), and its removal is documented for 3.15. Nothing in the repo replaced it, and the test run has no warning filter, so the warnings have been summary noise.

## Fix

`kernel/loadsource.py` (new, stdlib only): `load_source(name, path)` builds the module from `spec_from_loader`, `module_from_spec` and `exec_module` over an explicit `SourceFileLoader` (the `bin/` names carry no `.py` suffix, which `spec_from_file_location` alone cannot map) and keeps the `sys.modules` properties the kernel and the tests rely on:

- registered in `sys.modules[name]` before it executes, so a module that loads another under the same name during its own import gets the same object;
- a name already in `sys.modules` is re-executed into the SAME module object rather than replaced, so `km.jd` is a test's `jd` and a `_rebind_state` on one is seen by the other (the semantics the shared-judge rule in `tests/conftest.py` describes), with `__file__`, `__spec__`, `__loader__` and `__cached__` re-stamped the way `load_module()` did;
- a failed first load leaves no half-built entry;
- a module that puts a stand-in for itself in `sys.modules` while its body runs hands the stand-in to its importer, as `load_module()` did.

Each of the four kernel modules bootstraps it with a four-line block (three `importlib.util` calls and the `load_source` binding) and calls `load_source` for every load (`kernel.py` also for the lazy `sdk_backend` and `codex_backend` loads). The guards that reuse an already-loaded `romp_credentials` (judge.py, sdk_backend.py) and `romp_session_backend` (both backends) are unchanged; `sdk_backend.py` gains `_HERE` in place of three inline `Path(__file__).resolve().parent` spellings.

`tests/romp_load.py` (new) exposes the loader to test modules as `from romp_load import load_source`, and `tests/__init__.py` registers it under that bare name so the import resolves under pytest and `python -m unittest tests.test_x`; a direct script run finds the file on `sys.path`. The existing test modules keep their own `SourceFileLoader` loads, which still work; converting them is a separate change.

Two test modules stubbed `km.SourceFileLoader` and now stub `km.load_source`, since the name is gone from the kernel: `tests/test_kernel_headless_ops.py` (CodexRuntimeSelection, SdkSingleFlight) and `tests/test_api_health_hover.py` (the boot_at construction test). `tests/test_state_isolation_order.py` counts a `load_source` call as a load, so a module that loads through it before setting the state floor is caught like one that loads through `SourceFileLoader`. The comments and doc lines that named the old call now name `load_source` or say "loaded by file path": `kernel/kernel.py` (the restart-classifier docstring), `kernel/judge.py` (the active_runs registry note), `kernel/codex_backend.py` (module docstring), `tests/conftest.py` (the shared-judge rule), `kernel/README.md`, `tests/README.md` and `docs/judges.md`.

Not in this change: the test modules' own loads (above), and `tools/perf-bench.py`, which still loads the kernel with `load_module()` outside both the kernel and the test tree.

## Tests

`tests/test_loadsource.py` (new, 10 tests):

- `KernelModulesLoadWithoutTheDeprecatedCall` (4): each of the four kernel modules is imported by path in a fresh interpreter (`sys.executable`) with `warnings.filterwarnings("error", message=r".*load_module\(\).*")`, the message rather than the category, so an unrelated deprecation in the kernel's imports cannot trip it, and with `XDG_STATE_HOME` pointed at a temp dir in the child. One module per child, so every guarded load executes instead of short-circuiting on an already-loaded module, and nothing touches this process's shared modules. Before the change all four fail and the child traceback names the site: `kernel/kernel.py` line 26, `kernel/judge.py` line 65, `kernel/sdk_backend.py` line 49, `kernel/codex_backend.py` line 41, verified on CPython 3.10.20, 3.11.15, 3.12.3, 3.13.14, 3.14.6 and 3.14.6 free-threaded. After the change all four pass on the same interpreters.
- `LoadSource` (6): a fresh load is registered before it executes (the module sees itself in `sys.modules` while its body runs); a second load under the same name re-executes the same object and re-stamps `__file__`, `__spec__` and `__loader__`; a failing first load leaves no entry; a failing reload keeps the existing module registered; a module that replaces itself in `sys.modules` is returned as the replacement; a path without a `.py` suffix loads. Before the change the module cannot collect (`romp_load` does not exist). Each loader line has a test that fails without it: removing the pre-registration fails four, disabling the reuse branch or making it replace the object fails two, and removing the failed-load pop, the `__file__` re-stamp, the `__spec__` re-stamp or the `sys.modules` lookup on return fails one each.

`tests/test_state_isolation_order.py::test_scan_counts_a_load_source_call_as_a_load`: `scan()` over a module that calls `load_source` before its state-floor assignment reports the call as the module's first load. Before the change it finds no load.

`tests/test_kernel_headless_ops.py` (CodexRuntimeSelection, SdkSingleFlight) and `tests/test_api_health_hover.py` (the boot_at construction test) run against the converted kernel through the `load_source` stub; left unconverted they would fail with AttributeError at the `SourceFileLoader` lookup once the name is gone.

Full suite on this head: `pytest -q -n 6 tests/` on Python 3.12.3: 11002 passed, 41 skipped, 1705 subtests passed, 0 failed, in 176 s, with the served-page modules running against Chromium. The run's 5504 warnings are all the `load_module()` DeprecationWarning, attributed to importlib's shim and to test modules and never to `kernel/`: the test modules' own `load_module()` calls (and `tools/perf-bench.py`'s, exercised by `tests/test_perf_bench.py`), unchanged here.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)