### PR TITLE
SECURITY.md: why the token cookie is the one credential bound to the Origin check (cookies are scoped by host, not by port)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,9 +22,27 @@ same-user gate**. Same-user clients (the CLI, hooks, the bus, the VS Code
 extension) read the file and send it as an `X-Romp-Token` header; the browser
 presents it once as `?token=` (print the ready-made link with `romp url`, or
 paste the token into the login page a bare open of the dashboard serves) and
-rides an `HttpOnly` cookie afterwards. An Origin check additionally protects
-the browser surfaces against cross-site requests, including the WebSocket
-upgrade. The only token-exempt routes are the no-side-effect liveness probes:
+rides an `HttpOnly` cookie afterwards. That cookie authorizes only when the
+request's Origin is one the gate accepts: the dashboard's own origin (the
+`Host` the request arrived at, or the kernel's own port on `127.0.0.1` or
+`localhost`), the VS Code webview, or no `Origin` header at all. The check
+protects the browser surfaces, the WebSocket upgrade included, against
+cross-site requests. It is needed because cookies are scoped by host and
+**not by port** (RFC 6265 §8.5): every `http://127.0.0.1:<port>` page on your
+machine is same-site with the dashboard, so anything else you run on loopback
+(a dev server in a repo an agent cloned) would otherwise ride your cookie into
+`/ws`, which streams every session and accepts text to send into any of them. A
+request with no `Origin` header passes on its cookie because a same-origin
+navigation and non-browser clients send none; a page on another loopback port
+loading an `<img>` aimed at the kernel sends none either and still carries the
+cookie, which is why the hold behind `/busy?drain=1` arms only for an
+explicitly presented token (a request without one still gets the count and arms
+nothing): while a `romp refresh --quiet` waits for the sessions to finish their
+turns, that hold keeps every session from starting a new turn, a side effect no
+subresource load may trigger. A token presented explicitly, as `?token=` or
+`X-Romp-Token`, is accepted from any Origin: federated (cross-machine) calls
+need it, and a cross-site page cannot obtain it.
+The only token-exempt routes are the no-side-effect liveness probes:
 `/healthz`, `/version`, `/busy` on the kernel and `/ping` on the bus.
 
 The practical consequence: another local user on a **shared machine** cannot

--- a/tests/test_kernel_auth_hardening.py
+++ b/tests/test_kernel_auth_hardening.py
@@ -190,6 +190,20 @@ class CookieDoesNotBypassOrigin(unittest.TestCase):
                                   "Host": "127.0.0.1:%d" % km.PORT})
         self.assertTrue(ok)
 
+    def test_cookie_still_authorizes_the_kernels_own_loopback_origin_under_another_host(self):
+        # the kernel's own origin reached under its other loopback name: a page served at
+        # http://127.0.0.1:<port> whose request arrives with Host localhost:<port>, or the reverse.
+        # The Host string no longer matches the Origin, so same-origin-by-Host does not apply and
+        # the gate's own-loopback branch is the one that accepts (the case SECURITY.md names as the
+        # kernel's own port on 127.0.0.1 or localhost); it fails when that branch is removed.
+        for origin, host in (("http://127.0.0.1:%d" % km.PORT, "localhost:%d" % km.PORT),
+                             ("http://localhost:%d" % km.PORT, "127.0.0.1:%d" % km.PORT)):
+            with self.subTest(origin=origin, host=host):
+                ok, _, why = _auth(headers={"Cookie": "romp_token=" + TOK,
+                                            "Origin": origin, "Host": host})
+                self.assertTrue(ok, "the kernel's own loopback origin authorizes the cookie under "
+                                    "either of its names: " + why)
+
     def test_cookie_still_authorizes_the_vscode_webview(self):
         ok, _, _ = _auth(headers={"Cookie": "romp_token=" + TOK,
                                   "Origin": "vscode-webview://0p9m1abc"})


### PR DESCRIPTION
## Symptom

A reader of SECURITY.md who runs a dev server on loopback beside the dashboard cannot learn from the document that its pages are same-site with the dashboard and ride the token cookie, or what keeps that from reaching `/ws`. The trust-model section states the Origin check in one sentence ("An Origin check additionally protects the browser surfaces against cross-site requests, including the WebSocket upgrade.") and gives no reason.

## Cause

https://github.com/romp-on/romp/pull/337 made the code match that sentence (its body says so) and left the document alone, so the reasoning lives only in the docstrings of `Handler._authorize` and of the test class `CookieDoesNotBypassOrigin`, which a security reader is not pointed at. No other document in the repository mentions that a cookie is scoped by host and not by port.

## Fix

Replace the sentence with a paragraph that follows the code as it is:

- The cookie authorizes only when the Origin is one `_origin_ok` accepts: same-origin by `Host`, the kernel's own port on `127.0.0.1` or `localhost`, the VS Code webview, or no `Origin` header at all.
- Why: cookies are scoped by host and not by port (RFC 6265 §8.5), so every `http://127.0.0.1:<port>` page is same-site with the dashboard and would otherwise ride the cookie into `/ws`, which streams every session and accepts text to send into any of them.
- A request with no Origin passes on its cookie (same-origin navigations and non-browser clients send none), and a page on another loopback port loading an `<img>` aimed at the kernel sends none either while still carrying the cookie. That is why the hold behind `/busy?drain=1` arms only for an explicitly presented token (`_write_token_ok`); a request without one still gets the count and arms nothing. The hold keeps every session from starting a new turn while a `romp refresh --quiet` waits for the sessions to finish their turns, a side effect no subresource load may trigger.
- An explicit `?token=` or `X-Romp-Token` is accepted from any Origin: federated (cross-machine) calls need it and a cross-site page cannot obtain it.

The sentence on the token-exempt liveness probes and the "What is already hardened" bullet are unchanged, and the edit stays above that heading. One file of prose; the only code change is the one added test below.

Not changed here: the token-exempt sentence predates the install manifest and its icons (`/manifest.webmanifest` and the `/media/` icon allowlist), which `do_GET` also serves before the gate because the browser fetches them without credentials. That is a separate one-line correction.

## Tests

One test is added, `tests/test_kernel_auth_hardening.py::CookieDoesNotBypassOrigin::test_cookie_still_authorizes_the_kernels_own_loopback_origin_under_another_host`: a cookie with Origin `http://127.0.0.1:<port>` and Host `localhost:<port>` (and the reverse) authorizes. The Host branch of `_origin_ok` does not match there, so only its own-loopback branch accepts. The test passes on the current code and fails when that branch is replaced by `return False` (2 subtests red, the other 49 tests in the module green). Without it the paragraph's "the kernel's own port on `127.0.0.1` or `localhost`" had no executing test: with that branch removed, the auth-hardening, CORS, WS-auth and serve-token modules all stayed green.

The paragraph's other claims are executed by tests that already exist in the same file: `CookieDoesNotBypassOrigin` (a cookie from another loopback port or an offsite origin is denied; an absent Origin, the dashboard's own origin and the VS Code webview authorize; an explicit token bypasses the gate) and `BusyDrainWriteGate` (a token-less or cookie-only `/busy?drain=1` reads the count and arms nothing; an `X-Romp-Token` or `?token=` arms it). Making `_write_token_ok` accept the cookie turns two `BusyDrainWriteGate` tests red and none of `CookieDoesNotBypassOrigin`'s.

The prose itself has no executing test; the manual check is `git grep -n 'not by port' -- SECURITY.md`: empty before this change, one line after it.

Runs: `tests/test_kernel_auth_hardening.py` with `test_kernel_cors.py`, `test_kernel_ws_auth.py` and `test_kernel_serve_token_mode.py`, 85 passed; the full `pytest tests/` on this head 11042 passed, 41 skipped, 0 failed. `ui/webview/md-sanitize.test.ts`, the one test that reads SECURITY.md, slices from the "What is already hardened" heading to the Output-sanitization bullet, below this edit; 13/13 pass, and `npm run typecheck` passes in `vscode-extension`. No full npm test run was made for a prose change plus one Python test; CI runs it.

## Tier

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)