### PR TITLE
Shell telemetry: the dashboard shell records the long animation frames the browser reports to it alone, as its own romp perf client row

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -905,7 +905,10 @@ if [[ "${1:-}" == "perf" ]]; then
     # minutes per dashboard and pane (window percentiles from the summed histograms, the worst minute, the
     # slowest frames) and prints one screen. No kernel round trip: the files are read directly, so it works
     # with the kernel down. An absent file or one with no perf rows is said plainly: the bundles predate the
-    # telemetry, or no dashboard has been open since.
+    # telemetry, or no dashboard has been open since. The dashboard shell (the top-level window, app "shell";
+    # ui/webview/shell-perf.ts) posts the same minute row with no frame types: the long animation frames
+    # Chromium reports to the top-level document and never to the pane whose script ran them, so the pane
+    # script that blocked the page is named there, and this shows it as one more pane of its dashboard.
     if [[ "${1:-}" == "client" ]]; then
         shift
         _cusage="usage: romp perf client [--minutes <n>] [--json]"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1204,6 +1204,17 @@ frames it received is measured in the panes themselves, by
   keeps the function name in a key readable across rebuilds (the position
   still moves with any edit to the bundle); whitespace and syntax are still
   minified.
+- The dashboard shell (the top-level window that frames the panes) runs the
+  same collector under app `shell` with no frame types at all
+  (`ui/webview/shell-perf.ts`): Chromium reports a long animation frame to
+  the top-level document and never to the iframe whose script ran it, so a
+  pane script that blocked the main thread is attributed in the shell's row
+  (`chat.js:paintAll@9000`) and nowhere else. The row goes over the shell's
+  own socket; up to twenty rows are held, oldest dropped first, while that
+  socket is closed, and go ahead of the next row once it is open. A browser
+  that reports neither long animation frames nor long tasks gives the shell
+  nothing to observe, and an idle minute posts nothing, so no shell row
+  appears there.
 - Once a minute the pane posts ONE `clientDiag` row on the socket it already
   uses for breadcrumbs, only when something happened that minute (a frame
   arrived or a long frame was observed); the kernel appends it to
@@ -1229,14 +1240,14 @@ The two rows, as the kernel writes them (`t` its clock, `wid` the dashboard id):
   p50, p90, max} | null, loaf: {n, blocking_ms, worst_ms, top: [{k, ms, n,
   inv}], src}, slow: {sent, suppressed, suppressed_worst_ms}, heap_mb?, dom,
   visible, hidden_pane, ua}}`. `app` is the pane (`chat`, `feed`, `fleet`,
-  `timeline`); `since` is the minute's start on the browser's clock (epoch ms)
-  and `span_ms` its length (shorter than a minute when the page was
-  hidden or closed); `hist` is the 14 bucket counts; `free` is null when no
-  sample was taken; `loaf.top` is the five largest keys by summed duration,
-  `inv` the last invoker seen for each (`WebSocket.onmessage`,
-  `Window.requestAnimationFrame`, `DIV.onclick`), `src` is `loaf`, `longtask`
-  or `none`; `slow` counts the slowframe rows sent and the slow frames past
-  the cap, with the worst of those; `heap_mb` is
+  `timeline`), or `shell` for the top-level window; `since` is the minute's
+  start on the browser's clock (epoch ms) and `span_ms` its length (shorter
+  than a minute when the page was hidden or closed); `hist` is the 14 bucket
+  counts; `free` is null when no sample was taken; `loaf.top` is the five
+  largest keys by summed duration, `inv` the last invoker seen for each
+  (`WebSocket.onmessage`, `Window.requestAnimationFrame`, `DIV.onclick`),
+  `src` is `loaf`, `longtask` or `none`; `slow` counts the slowframe rows sent
+  and the slow frames past the cap, with the worst of those; `heap_mb` is
   `performance.memory.usedJSHeapSize` and is absent outside Chrome; `dom` is
   the element count; `visible` is the document's visibility, `hidden_pane`
   the pane shim's test for a pane the shell has set to `display:none`: its
@@ -1262,7 +1273,9 @@ entry; the top attributed keys with their invokers; the worst minute (the one
 with the most handler time: its span from the minute's start to the row's
 arrival at the kernel, frame counts and long frames); heap and DOM at the last
 sample; and the five slowest slow frames in the window with their attribution,
-plus how many more there were. An absent file or one without perf rows is
+plus how many more there were. The shell's row shows as one more pane of its
+dashboard: no frame types, the long frames it observed and the pane scripts
+they name. An absent file or one without perf rows is
 reported as no browser telemetry yet (the bundles predate it or no dashboard
 has loaded them: rebuild the bundles and reload the dashboard); perf rows all
 older than the window are reported with their age. `--json` prints the folded

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -49263,6 +49263,12 @@ def _landing():
             # bell panel's timestamps wear the same recency colours as every other "(Xm ago)" (the user
             # 2026-07-28). Loaded BEFORE the errs script, which reads it (with a dim fallback if absent).
             + ("<script src=/dist/age-color-global.js?v=%d></script>" % v) +
+            # the shell's performance collector (ui/webview/shell-perf.ts): Chromium reports a long animation
+            # frame to the top-level document, never to the iframe whose script ran it, so this page observes
+            # them and posts a minute row (app "shell") on its own socket (shellWS, window.__rompShellSend)
+            # for `romp perf client`. Early, so a long frame during the boot's own work is seen; the boot
+            # script runs first so the splash is not held behind a bundle fetch.
+            ("<script src=/dist/shell-perf.js?v=%d></script>" % v) +
             "<script>" + _LANDING_ERRS_JS + "</script>"
             "<script>" + _LANDING_USAGE_JS.replace("__ROMP_LOADER__", json.dumps(_loader_inner())) + "</script>"
             "<script>" + _LANDING_APIH_JS + "</script>"

--- a/tests/romp-perf-client.bats
+++ b/tests/romp-perf-client.bats
@@ -138,6 +138,54 @@ teardown() { rm -rf "$TEST_DIR"; }
     [ ! -f "$CURL_LOG" ]                                 # no kernel round trip
 }
 
+@test "romp perf client: the shell's row (long frames only, no frame types) renders as a pane of its dashboard without special handling" {
+    # The dashboard shell (the top-level window, ui/webview/shell-perf.ts) runs the panes' collector with no
+    # brackets at all: Chromium reports a long animation frame to the top-level document, never to the iframe
+    # whose script ran it, so the shell's row is where a pane script that blocked the page is named. The row
+    # has the minute row's shape with an empty frames map and no free sample, so the verb renders it like any pane's.
+    python3 - "$DIAG" <<'PY'
+import json, sys, time
+now = int(time.time())
+W1 = "11111111-2222-3333-4444-555555555555"
+def row(t, wid, what, data): return json.dumps({"t": t, "wid": wid, "surface": "perf", "what": what, "data": data})
+shell = {"app": "shell", "since": (now - 70) * 1000, "span_ms": 60000,
+         "frames": {}, "free": None,
+         "loaf": {"n": 1, "blocking_ms": 19950, "worst_ms": 20000,
+                  "top": [{"k": "chat.js:paintAll@9000", "ms": 19500, "n": 1, "inv": "Window.requestAnimationFrame"},
+                          {"k": "page:onMove@120", "ms": 150, "n": 1, "inv": "DIV.onpointermove"}], "src": "loaf"},
+         "slow": {"sent": 0, "suppressed": 0, "suppressed_worst_ms": 0}, "heap_mb": 60.0, "dom": 900, "visible": True, "hidden_pane": False, "ua": "chrome-desktop"}
+with open(sys.argv[1], "a") as f:
+    f.write(row(now - 10, W1, "minute", shell) + "\n")
+PY
+    run "$ROMP_SCRIPT" perf client
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"2 dashboards, 4 panes, 6 minute rows, 1 slow frame row"* ]]
+    # the shell: one more pane of dashboard 11111111, no frame types, the long frame it alone saw with the pane script the browser named
+    [[ "$output" == *"dashboard 11111111 · shell   chrome-desktop   1 min reported   heap 60.0 MB   dom 900   visible"* ]]
+    shell_block="$(echo "$output" | sed -n '/^dashboard 11111111 · shell/,/^dashboard 22222222/p')"
+    [[ "$shell_block" == *"handler      no frames"* ]]
+    [[ "$shell_block" == *"main thread  free after a frame p90 n/a   long frames 1.0/min   blocking 19950 ms/min   worst 20000 ms"* ]]
+    [[ "$shell_block" == *"attribution  chat.js:paintAll@9000 19500 ms (Window.requestAnimationFrame)   page:onMove@120 150 ms (DIV.onpointermove)"* ]]
+    [[ "$shell_block" == *"0 ms handler   no frames   long frames 1, blocking 19950 ms"* ]]
+    [[ "$shell_block" == *"slow frames  none"* ]]
+    # the feed pane's own screen is unchanged by the extra pane
+    [[ "$output" == *"feed           14.4/min    360 ms/min   p50 <4   p90 <32   p99 <128 ms   max 130   >16.7 ms 25%   >=100 ms 6%"* ]]
+    run "$ROMP_SCRIPT" perf client --json
+    [ "$status" -eq 0 ]
+    echo "$output" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+panes = {(p["wid"], p["app"]): p for p in d["panes"]}
+assert set(panes) == {("11111111", "feed"), ("11111111", "chat"), ("11111111", "shell"), ("22222222", "feed")}, set(panes)
+s = panes[("11111111", "shell")]
+assert s["frames"] == {} and s["total_ms_per_min"] == 0 and s["free_p90"] is None and s["minutes"] == 1, s
+assert s["loaf"] == {"per_min": 1.0, "blocking_ms_per_min": 19950.0, "worst_ms": 20000, "src": "loaf"}, s["loaf"]
+assert s["top"] == [{"k": "chat.js:paintAll@9000", "ms": 19500, "inv": "Window.requestAnimationFrame"}, {"k": "page:onMove@120", "ms": 150, "inv": "DIV.onpointermove"}], s["top"]
+assert s["worst_minute"]["total_ms"] == 0 and s["worst_minute"]["loaf_n"] == 1 and s["worst_minute"]["blocking_ms"] == 19950, s["worst_minute"]
+assert s["slow"] == [] and s["heap_mb"] == 60.0 and s["dom"] == 900
+'
+}
+
 @test "romp perf client --minutes: narrows the window, and a half-minute row is rated by its span" {
     run "$ROMP_SCRIPT" perf client --minutes 1
     [ "$status" -eq 0 ]

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7759,6 +7759,23 @@ class ServeSecurity(unittest.TestCase):
         html = km._landing()
         self.assertIn("<script src=/dist/palette-main.js?v=", html)
 
+    def test_shell_perf_bundle_wired(self):
+        # the shell's performance collector (ui/webview/shell-perf.ts): Chromium reports a long animation
+        # frame to the top-level document, never to the iframe whose script ran it, so the shell page
+        # observes them and posts a minute row (app "shell") on its own socket (shellWS,
+        # window.__rompShellSend). It is a dist bundle like age-color-global, loaded right after it and
+        # before the errs script so that a long frame during the boot's own work is seen; its behavior is
+        # tested in ui/webview/shell-perf.test.ts, and tests/test_landing_bundles_built.py checks that the
+        # build emits every bundle this page names.
+        html = km._landing()
+        self.assertIn("<script src=/dist/shell-perf.js?v=", html)
+        self.assertLess(html.index("/dist/age-color-global.js"), html.index("/dist/shell-perf.js"))
+        self.assertLess(html.index("/dist/shell-perf.js"), html.index("window.__rompAgeColor"))   # before the errs script
+        self.assertLess(html.index("/dist/shell-perf.js"), html.index("/dist/palette-main.js"))
+        # the socket it posts through is the shell's own, defined by the mobile-shell script, which runs
+        # later: the bundle reads window.__rompShellSend at call time, so the order is fine
+        self.assertIn("window.__rompShellSend=", html)
+
     def test_fleet_page_served(self):
         # Fleet (the user 2026-06-23): /fleet serves the by-session open-work view, rendered by dist/fleet.js.
         import urllib.request

--- a/tests/test_landing_bundles_built.py
+++ b/tests/test_landing_bundles_built.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Every bundle the dashboard shell's page names is one the webview build emits.
+
+The shell page (kernel.py _landing) loads its bundles by name from dist/ (age-color-global.js,
+shell-perf.js, palette-main.js), and vscode-extension/esbuild.js decides which entries the build
+writes. Nothing ties the two together: a tag for a bundle the build never emits serves a 404 the page
+swallows (the script does not run, the page loads, and every test of the html still passes), so the
+collector or hotkeys that tag was meant to load are silently absent. This runs the real webview build
+in memory (esbuild.js exports its config for the tests, and the build writes nothing to dist/ under
+write: false) and checks every /dist/ name the landing html carries against what the build emits. The
+names are derived from the html, so a new tag is covered the day it is added. Skips loudly without the
+extension deps (npm ci not run here), like the other served-page guards. Synthetic only: no state is
+read, none is written.
+"""
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+# Hermetic state BEFORE the load: the kernel resolves its state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)   # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = load_source("romp_kernel_landing_bundles", os.path.join(BIN, "romp-kernel"))
+
+# The webview build as esbuild.js configures it, run in memory: the basenames it would write to dist/.
+DRIVER = r"""
+const path = require("path");
+const esbuild = require("esbuild");
+const { webview } = require("./esbuild.js");
+esbuild.build({ ...webview, write: false, logLevel: "silent" }).then((r) => {
+  process.stdout.write(JSON.stringify(r.outputFiles.map((f) => path.basename(f.path))));
+}, (e) => { console.error(String(e && e.message || e)); process.exit(1); });
+"""
+
+
+class LandingBundlesBuilt(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "esbuild")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here): the build guard needs them")
+        b = subprocess.run(["node", "-e", DRIVER], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        cls.emitted = set(json.loads(b.stdout))
+
+    def test_every_bundle_the_shell_page_names_is_emitted_by_the_build(self):
+        named = sorted(set(re.findall(r"<script src=/dist/([\w.-]+\.js)\?v=", km._landing())))
+        self.assertTrue(named, "no bundle tag found in the landing html: did the tag's shape change?")
+        self.assertTrue(self.emitted, "the build emitted nothing")
+        for name in named:
+            self.assertIn(name, self.emitted,
+                          "%s is loaded by the shell page but the webview build emits no such bundle "
+                          "(vscode-extension/esbuild.js entryPoints)" % name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/shell-perf.test.ts
+++ b/ui/webview/shell-perf.test.ts
@@ -1,0 +1,181 @@
+// shell-perf.ts: the dashboard shell's performance collector. The shell is the top-level window that frames
+// the panes; it receives no frames, but Chromium reports a long animation frame to the top-level document and
+// never to the iframe whose script ran it, so the shell runs the panes' collector (perf-telemetry.ts) under app
+// "shell" and posts its minute row through its own kernel socket (window.__rompShellSend). Stood in the way the
+// perf-telemetry install tests stand a window in: a fake window with performance.now, a setInterval that hands
+// back the minute timer, and a PerformanceObserver whose callback the test drives; the module is imported once
+// the fakes are in place, since its boot line installs on import. Synthetic URLs and ids only: host h, the
+// placeholder session id.
+import { test, after } from "node:test";
+import * as assert from "node:assert/strict";
+
+const SID = "11111111-2222-3333-4444-555555555555";
+const g: any = globalThis;
+const hadWindow = "window" in g, prevWindow = g.window;
+const hadDocument = "document" in g, prevDocument = g.document;
+
+let now = 5000;
+let observerCb: ((list: { getEntries(): any[] }) => void) | null = null;
+let observed: any = null;
+let minuteTimer: (() => void) | null = null;   // the collector's flush, captured from the fake window's setInterval
+let minuteMs = 0;
+const sent: any[] = [];
+let socketOpen = true;
+
+const win: any = new EventTarget();
+win.performance = { now: () => now, memory: { usedJSHeapSize: 96 * 1048576 } };
+win.navigator = { userAgent: "Mozilla/5.0 (Macintosh) Chrome/128.0.0.0 Safari/537.36", maxTouchPoints: 0 };
+win.location = { href: "http://h:1/?token=abc" };   // the shell page: its URL, token and all, is the sourceURL of every inline shell script
+win.parent = win;                                    // the top-level window
+win.innerWidth = 1200; win.innerHeight = 800;
+win.setInterval = (cb: () => void, ms: number) => { minuteTimer = cb; minuteMs = ms; return { unref() {} }; };
+win.PerformanceObserver = class {
+  static supportedEntryTypes = ["long-animation-frame", "longtask"];
+  constructor(cb: (list: { getEntries(): any[] }) => void) { observerCb = cb; }
+  observe(opts: any): void { observed = opts; }
+  disconnect(): void {}
+};
+const doc: any = new EventTarget();
+doc.visibilityState = "visible";
+doc.getElementsByTagName = () => ({ length: 900 });
+g.window = win;
+g.document = doc;
+after(() => {
+  if (hadWindow) g.window = prevWindow; else delete g.window;
+  if (hadDocument) g.document = prevDocument; else delete g.document;
+});
+
+/** The browser reports one long-animation-frame entry. */
+const report = (entry: any) => { assert.ok(observerCb, "the observer is installed"); observerCb!({ getEntries: () => [entry] }); };
+const longFrame = (ms: number, scripts: any[]) => ({ startTime: now, duration: ms, blockingDuration: Math.max(0, ms - 50), scripts });
+/** The minute timer fires. */
+const minutePasses = () => { assert.ok(minuteTimer, "the minute timer is armed"); minuteTimer!(); };
+const paneScript = (file: string, fn: string, pos: number, invoker: string, duration: number) =>
+  ({ sourceURL: "http://h:1/dist/" + file + "?v=1757100000", sourceFunctionName: fn, sourceCharPosition: pos, invoker, duration });
+
+test("importing the bundle installs the panes' collector on the shell window as app shell, observing long-animation-frame entries on a minute timer, before the socket script has run; an idle minute posts nothing", async () => {
+  assert.equal(win.__rompShellSend, undefined, "the socket script has not run when the bundle loads");
+  const mod = await import("./shell-perf");
+  assert.equal(win.__rompShellSend, undefined, "the bundle defines no send of its own");
+  assert.equal(mod.SHELL_APP, "shell");
+  const p = win.__rompPerf;
+  assert.ok(p && typeof p.tick === "function", "published as window.__rompPerf like every pane's");
+  assert.equal(p.snapshot().app, "shell");
+  assert.equal(p.snapshot().observer, "loaf", "long-animation-frame, with attribution");
+  assert.deepEqual(observed, { type: "long-animation-frame", buffered: false });
+  assert.equal(minuteMs, 60_000);
+  // the socket script runs after the bundles on the page, so the send exists only now
+  win.__rompShellSend = (m: any) => { if (!socketOpen) return false; sent.push(m); return true; };
+  minutePasses();
+  assert.equal(sent.length, 0, "no frame and no long frame: nothing to say");
+  assert.deepEqual(Object.keys(p.snapshot().frames), [], "the shell brackets nothing");
+});
+
+test("a long frame the browser attributes to a pane's script becomes one scrubbed minute row through window.__rompShellSend, read at call time (it did not exist when the collector installed): script basenames without query, page: for the shell's own inline script, invokers without element ids or URLs; no string in the row carries a slash, a query or a session id", () => {
+  const p = win.__rompPerf;
+  report(longFrame(20_000, [
+    // a pane's bundle, as Chromium names it: the full URL with its dist token, run from the pane's animation frame
+    paneScript("chat.js", "paintAll", 9000, "Window.requestAnimationFrame", 19_500),
+    // the pane's inline shim, whose sourceURL is the pane page with its token and the session it shows
+    { sourceURL: "http://h:1/chat?token=abc&sid=" + SID, sourceFunctionName: "", sourceCharPosition: 4000, invoker: "WebSocket.onmessage", duration: 300 },
+    // the shell's own inline script (a divider drag): its sourceURL is the shell page itself, and the element id names a session
+    { sourceURL: "http://h:1/?token=abc", sourceFunctionName: "onMove", sourceCharPosition: 120, invoker: "DIV#pane-divider-" + SID + ".onpointermove", duration: 150 },
+    // an image the chat pane loaded, its source a file path with the session
+    paneScript("render.js", "", 77, "IMG[src=/file?path=/repo/notes-api/docs/plot.png&sid=" + SID + "].onload", 50),
+  ]));
+  report({ startTime: now + 100, duration: 30, scripts: [paneScript("feed.js", "x", 1, "WebSocket.onmessage", 30)] });   // under 50 ms: not a long frame
+  minutePasses();
+  assert.equal(sent.length, 1, "one row for the minute");
+  const row = sent[0];
+  assert.equal(row.type, "clientDiag"); assert.equal(row.surface, "perf"); assert.equal(row.what, "minute");
+  const d = row.data;
+  assert.equal(d.app, "shell");
+  assert.deepEqual(d.frames, {}, "no frame types: the shell receives no frames");
+  assert.equal(d.free, null, "no frame, no main-thread-free sample");
+  assert.deepEqual({ n: d.loaf.n, worst_ms: d.loaf.worst_ms, blocking_ms: d.loaf.blocking_ms, src: d.loaf.src }, { n: 1, worst_ms: 20_000, blocking_ms: 19_950, src: "loaf" });
+  assert.deepEqual(d.loaf.top, [
+    { k: "chat.js:paintAll@9000", ms: 19_500, n: 1, inv: "Window.requestAnimationFrame" },
+    { k: "chat:(anonymous)@4000", ms: 300, n: 1, inv: "WebSocket.onmessage" },
+    { k: "page:onMove@120", ms: 150, n: 1, inv: "DIV.onpointermove" },
+    { k: "render.js:(anonymous)@77", ms: 50, n: 1, inv: "IMG[src].onload" },
+  ]);
+  assert.equal(d.heap_mb, 96);
+  assert.equal(d.dom, 900);
+  assert.equal(d.ua, "chrome-desktop");
+  assert.equal(d.visible, true);
+  assert.equal(d.hidden_pane, false, "the top-level window is never a hidden pane");
+  // the privacy contract over every string in the row, keys included: the shell page's URL carries the token
+  const strings: string[] = [];
+  (function walk(v: unknown, at: string) {
+    if (typeof v === "string") strings.push(at + "=" + v);
+    else if (Array.isArray(v)) v.forEach((x, i) => walk(x, at + "[" + i + "]"));
+    else if (v && typeof v === "object") for (const k of Object.keys(v as object)) { strings.push(at + "." + k); walk((v as any)[k], at + "." + k); }
+  })(row, "row");
+  assert.ok(strings.length > 10);
+  for (const s of strings) {
+    assert.ok(!s.includes("/"), "no slash: " + s);
+    assert.ok(!s.includes("?") && !s.includes("&") && !s.includes("token"), "no query: " + s);
+    assert.ok(!s.includes(SID) && !s.includes("11111111"), "no session id: " + s);
+    assert.ok(!s.includes("notes-api") && !s.includes("plot.png") && !s.includes("h:1"), "no path or host: " + s);
+  }
+});
+
+test("a row the socket refuses is held and goes ahead of the next one that finds it open, in order; nothing is sent while it stays closed", () => {
+  sent.length = 0;
+  socketOpen = false;
+  report(longFrame(120, [paneScript("feed.js", "render", 1, "WebSocket.onmessage", 120)]));
+  minutePasses();
+  assert.equal(sent.length, 0, "closed: held");
+  report(longFrame(130, [paneScript("feed.js", "render", 1, "WebSocket.onmessage", 130)]));
+  minutePasses();
+  assert.equal(sent.length, 0, "still closed: both held");
+  socketOpen = true;
+  report(longFrame(140, [paneScript("feed.js", "render", 1, "WebSocket.onmessage", 140)]));
+  minutePasses();
+  assert.deepEqual(sent.map((m) => m.data.loaf.worst_ms), [120, 130, 140], "the held rows first, then the new one");
+});
+
+test("shellPost alone: no send yet (the socket script has not run) holds too; past HELD_MAX the oldest held row goes; a send that fails mid-drain keeps the rest in order", async () => {
+  const { shellPost, HELD_MAX } = await import("./shell-perf");
+  let send: ((m: any) => boolean) | undefined;
+  const out: any[] = [];
+  const post = shellPost(() => send);
+  for (let i = 0; i < HELD_MAX + 3; i++) post({ i });
+  send = (m) => { out.push(m); return true; };
+  post({ i: "last" });
+  assert.equal(out.length, HELD_MAX + 1);
+  assert.deepEqual(out.map((m) => m.i), [...Array.from({ length: HELD_MAX }, (_, k) => k + 3), "last"], "the three oldest went; the rest in arrival order");
+  // the socket closes again mid-drain: what went stays sent, the rest stay held in order, the new row behind them
+  out.length = 0;
+  send = () => false;
+  post({ i: "a" }); post({ i: "b" }); post({ i: "c" });
+  let calls = 0;
+  send = (m) => { calls++; if (calls === 2) return false; out.push(m); return true; };
+  post({ i: "d" });
+  assert.deepEqual(out.map((m) => m.i), ["a"], "a went; b failed and stopped the drain");
+  send = (m) => { out.push(m); return true; };
+  post({ i: "e" });
+  assert.deepEqual(out.map((m) => m.i), ["a", "b", "c", "d", "e"], "the rest followed in order once the socket answered");
+  // a send that throws counts as refused: the row is held, never lost, and nothing reaches the page
+  send = () => { throw new Error("socket gone"); };
+  post({ i: "f" });
+  send = (m) => { out.push(m); return true; };
+  post({ i: "g" });
+  assert.deepEqual(out.map((m) => m.i), ["a", "b", "c", "d", "e", "f", "g"]);
+});
+
+test("a browser that reports neither long animation frames nor long tasks: the collector installs with no observer, and a minute passes with nothing to post", async () => {
+  // last, because it replaces the window's collector: the install is once per window, so a fresh one needs the slot empty
+  const { installShellPerf } = await import("./shell-perf");
+  sent.length = 0;
+  delete win.__rompPerf;
+  win.PerformanceObserver.supportedEntryTypes = [];
+  observed = null;
+  const p: any = installShellPerf();
+  assert.ok(p, "installed: heap and DOM are still measurable");
+  assert.equal(win.__rompPerf, p);
+  assert.equal(p.snapshot().observer, "none");
+  assert.equal(observed, null, "nothing observed");
+  minutePasses();
+  assert.equal(sent.length, 0, "no long frames to report and no frames: the shell has nothing to say there");
+});

--- a/ui/webview/shell-perf.ts
+++ b/ui/webview/shell-perf.ts
@@ -1,0 +1,63 @@
+// The dashboard shell's performance collector. The shell is the top-level window that frames the panes: it
+// receives no frames and loads only the small bundles the landing page names (age-color-global.ts,
+// palette-main.ts), so nothing measured it. Chromium reports a long animation frame to the top-level document
+// and never to the iframe whose script ran it, so when a pane script blocked the main thread for seconds, every
+// pane's minute row arrived late and none carried a long frame; the shell, had it been listening, would have seen
+// the frame with the pane script the browser named (`chat.js:paintAll@9000`). This bundle installs the collector
+// every pane runs (perf-telemetry.ts) under app "shell", with no frame brackets at all: its minute row is the
+// long frames it observed, heap and DOM, posted on the shell's own kernel socket (window.__rompShellSend, defined
+// by the kernel's mobile-shell script) on the clientDiag channel the panes use, so `romp perf client` shows it as
+// one more pane of its dashboard. Keys are scrubbed as on every pane (perf-telemetry.ts scriptKey,
+// sanitizeInvoker): a script URL to its basename with no query, an inline shell script as `page:` (the shell
+// page's URL carries the token; the collector strips query and fragment before comparing), an invoker with no
+// element id or URL. A browser that reports neither long animation frames nor long tasks gives the collector
+// nothing to observe, and an idle minute posts nothing, so the shell is silent there.
+//
+// Transport: window.__rompShellSend does not exist until the mobile-shell script runs, after this bundle, and
+// answers false while the shell socket is not open (it redials on a close). A row it refuses is HELD, at most
+// HELD_MAX of them with the oldest dropped first (the newest minute is the one worth having; the pane shim's cap
+// on queued breadcrumbs is the same twenty), and the held rows go ahead of the next row that finds the socket
+// open, in order. No timer of its own: the collector's minute flush is the retry, so a held row waits for the
+// next minute with something to report, and a row still held when the page closes goes with it; one late row
+// beats a lost one.
+//
+// Loaded by the landing page (kernel.py _landing) as its own dist entry (vscode-extension/esbuild.js). Nothing
+// here throws into the page; a window without performance.now gets nothing (installPerfTelemetry returns null).
+import { installPerfTelemetry, type PerfPost, type RompPerf } from "./perf-telemetry";
+
+export const SHELL_APP = "shell";
+export const HELD_MAX = 20;
+
+type ShellSend = (m: Record<string, unknown>) => boolean;
+
+/** The shell's clientDiag transport. `send` is looked up at every call (the socket script runs after this
+ *  bundle); a row the send refuses, or that arrives before the send exists, is held; held rows drain in order
+ *  ahead of the row in hand, and a refusal mid-drain stops the drain with the order kept. */
+export function shellPost(send: () => ShellSend | undefined): PerfPost {
+  const held: Record<string, unknown>[] = [];
+  const hold = (m: Record<string, unknown>): void => {
+    if (held.length >= HELD_MAX) held.shift();
+    held.push(m);
+  };
+  const deliver = (s: ShellSend, m: Record<string, unknown>): boolean => {
+    try { return !!s(m); } catch (e) { return false; }   // a throwing send is a closed socket, not a lost row
+  };
+  return (m) => {
+    const s = send();
+    if (typeof s !== "function") { hold(m); return; }
+    while (held.length) {
+      if (!deliver(s, held[0])) { hold(m); return; }
+      held.shift();
+    }
+    if (!deliver(s, m)) hold(m);
+  };
+}
+
+/** Install the shell's collector on this window; null where nothing can be measured. */
+export function installShellPerf(): RompPerf | null {
+  if (typeof window === "undefined") return null;
+  const w: any = window;
+  return installPerfTelemetry(SHELL_APP, { post: shellPost(() => w.__rompShellSend) });
+}
+
+installShellPerf();

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -48,6 +48,7 @@ const webview = {
     "../ui/webview/federation.ts",   // multi-kernel manager: loaded after the shim on chat/feed/fleet pages
     "../ui/webview/age-color-global.ts",   // window.__rompAgeColor for the kernel's inline shell scripts (bell panel)
     "../ui/webview/palette-main.ts",   // command palette + Cmd/Ctrl+O/P hotkeys for the kernel's shell page
+    "../ui/webview/shell-perf.ts",     // the shell page's performance collector (a pane's long animation frames are reported to the top-level window)
     "../ui/webview/editor-chunk.ts",   // CodeMirror editing substrate — ON-DEMAND (file-view loads it by
                                        // script tag on first edit); nothing else may import it, so the
                                        // main bundles stay byte-stable for people who never edit


### PR DESCRIPTION
The dashboard shell (the top-level window that frames the panes) now runs the panes' performance collector under app `shell`, so the long animation frames Chromium reports to it alone, with the pane script they name, reach `romp perf client` as one more row.

## Design

**Why the shell.** When a pane script blocks the main thread for seconds, every pane's minute row arrives late and none carries a long frame: Chromium reports a long animation frame to the top-level document, never to the iframe whose script ran it. The shell is that document, and it ran no collector (it receives no frames and loads only the age-color and palette bundles). The collector goes where the report lands.

**What the row carries.** `ui/webview/shell-perf.ts` is a dist entry that calls `installPerfTelemetry("shell", { post })` from `perf-telemetry.ts` with no frame brackets. Its minute row has the documented shape with an empty `frames` map and `free: null`: the long frames observed (`loaf`: count, blocking, worst, and the top attributed keys such as `chat.js:paintAll@9000` with their invokers), heap and DOM, visibility and UA. `romp perf client` already renders any app, so the shell shows as one more pane of its dashboard with no change to the verb. Firefox and Safari report neither long animation frames nor long tasks; there the collector has nothing to observe, an idle minute posts nothing, and no shell row appears. The docs say so rather than promising long frames on every browser.

**Transport.** The row goes on the shell's own kernel socket through `window.__rompShellSend`, read at call time because the mobile-shell script that defines it runs after this bundle. That send answers false while the socket is closed (it redials on a close). A refused row, or one posted before the send exists, is held: at most 20 (`HELD_MAX`; the pane shim caps its queued breadcrumbs at the same count), oldest dropped first, since the newest minute is the one worth having. Held rows drain in order ahead of the next row that finds the socket open, and a refusal mid-drain stops the drain with the order kept. A send that throws counts as a refusal. There is no timer of its own: the collector's minute flush is the retry, so a held row waits for the next minute with something to report, and a row still held when the page closes goes with it.

**Privacy.** The shell page's URL carries the token. `perf-telemetry.ts` strips query and fragment before comparing a script's `sourceURL` with the page, so the shell's inline scripts key as `page:<fn>@<pos>`; a pane bundle keys as its basename with no query; an invoker loses element ids and URLs (`DIV#pane-divider-<sid>.onpointermove` becomes `DIV.onpointermove`, `IMG[src=/file?path=...]` becomes `IMG[src]`). The test walks every string in the row, keys included, and fails on a slash, `?`, `&`, `token` or the session id.

**Load order.** The tag sits right after `age-color-global.js` and before the errs script: after the boot script so the splash is not held behind a bundle fetch, early enough to observe a long frame during the boot's own work. The kernel test pins the order.

**Considered and not done.** Reusing `window.__rompShellDiag` as the transport: it forces `surface: 'shell'`, and `romp perf client` keeps only `surface: "perf"` rows. Defining a second `__rompShellSend`: the mobile-shell script already has one, and the bundle reads it at call time. Draining held rows on the socket's open event: it would need a hook in the mobile-shell script to save one late row per outage, and the minute flush already retries. Timing the file viewer's paint pass under its host pane: a separate change.

## Tests

- `ui/webview/shell-perf.test.ts` (5 cases, `node --test`): stands a fake window in (performance.now, a PerformanceObserver whose callback the test drives, a setInterval that hands back the minute timer, a location with a query token) and imports the module, then asserts: the collector is published as `window.__rompPerf` under app `shell`, observing `long-animation-frame` on a 60 s timer, before the socket script has run, and an idle minute posts nothing; a 20 s long frame attributed to `chat.js`, a pane's inline shim, the shell's own inline script and an image becomes one minute row of the documented shape with scrubbed keys and no slash, query or session id in any string, through a send that did not exist when the collector installed; rows refused by a closed socket are held and drain in order; `shellPost` alone holds before the send exists, drops the oldest past `HELD_MAX`, keeps order across a refusal mid-drain and treats a throwing send as a refusal; a browser with no observer installs and posts nothing. Before the change the file does not build: `Could not resolve "./shell-perf"`. Capturing the send at install time instead of reading it per call fails cases 2 and 3.
- `tests/test_kernel.py::ServeSecurity::test_shell_perf_bundle_wired`: the landing page carries `<script src=/dist/shell-perf.js?v=` after `age-color-global.js`, before the errs script and before `palette-main.js`, and defines `window.__rompShellSend`. Before the change: `'<script src=/dist/shell-perf.js?v=' not found`.
- `tests/test_landing_bundles_built.py`: runs the webview build in memory (`esbuild.js` exports its config; `write: false`) and checks that every `/dist/<name>.js` the landing html names is a bundle the build emits, the names derived from the html. Green before the change and after it; it fails when the tag is added without its `esbuild.js` entry (`shell-perf.js is loaded by the shell page but the webview build emits no such bundle`), which no other test catches: the html pins pass and the served-page tests do not assert on `/dist/` fetch statuses. Skips without the extension deps, like the other served-page guards.
- `tests/romp-perf-client.bats`, "the shell's row (long frames only, no frame types) renders as a pane of its dashboard without special handling": a saved shell row (empty frames, one 20 s long frame attributed `chat.js:paintAll@9000`) renders as `handler      no frames`, `long frames 1.0/min   blocking 19950 ms/min   worst 20000 ms`, its attribution line and worst minute, on the screen and in `--json`, with the other panes unchanged. A regression pin: it passes before the change too, because the verb already renders any app.

Runs on this branch: `npm run typecheck` clean; `node --test` over the new file 5/5; `pytest tests/test_kernel.py tests/test_landing_bundles_built.py tests/test_state_isolation_order.py` targeted green; `bats tests/romp-perf-client.bats` 11/11; full `npm test` 4079 pass, 0 fail, plus the timeline-tags-scale file run alone 22 pass; full `pytest tests/` with 6 workers 11114 passed, 41 skipped, 2 failed in `tests/test_kernel_webpush.py::LandingRevealOffers` (a real-clock `ageS` of 6 where 5 was expected: the class seeds a record five seconds old and its node driver started a second late under the parallel load; the class passes alone, 9/9, and its driver runs the inline reveal script, which this change does not touch).

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
