### PR TITLE
Comments: the interrupt, parked-op, move, drain and retry call sites and the relay re-arm note describe the one chat signature

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8452,7 +8452,9 @@ def _auto_resume_session_retry(now, tmux):
                 changed = True
                 sys.stderr.write("retry-suppress: re-armed session %s — a successful turn landed\n" % sid)
     if changed:
-        _mark_views_dirty()      # the flag lives in a file the fleet sig doesn't watch → dirty-rebuild the chat status
+        _mark_views_dirty()      # the chat signature's retry component carries the flag; this cycle's push already
+                                 # ran, so the mark's wake starts the next cycle at once and its chat build ships the
+                                 # re-armed status; the feed and timeline the mark busts read no retry state
 
 
 def _mark_auto_nudged(gid, turn_id, count, arm_atoms=None, at=None):
@@ -15526,7 +15528,8 @@ def _drive(msg, client):
                                                           # already aborted any in-flight CLI retry; this stops the relapse
         if err:                                           # …and a stop that did NOT land is said, the rewind ops' warn-toast
             client["send"](json.dumps({"type": "warn", "text": err}))   # idiom (fail loudly; the interrupt itself happened)
-        _mark_views_dirty()                               # the stamp lives in memory — no sig sees it
+        _mark_views_dirty()                               # the chat signature's clock component carries the stamp; the
+                                                          # mark busts the feed and timeline and wakes the pusher
     elif t in ("compact", "compactSession"):
         # Mid-turn (or behind an existing queue) the click PARKS as a queued /compact chip and fires when
         # the turn ends (the user 2026-07-02, who saw the icon blink with nothing happening while working — now
@@ -28723,7 +28726,8 @@ def _park_op(sid, op):
     list); the pusher wake comes AFTER the release, so the cycle it brings finds the lock free."""
     with _pending_ops_lock:
         _park_op_locked(sid, op)
-    _mark_views_dirty()               # the queue lives in memory — no sig sees it; the woken push renders the chip
+    _mark_views_dirty()               # the chat signature's ops component carries the queue; the mark busts the feed
+                                      # and timeline, and the wake renders the chip now
 
 
 def _park_op_locked(sid, op):
@@ -28937,7 +28941,8 @@ def _move_now(be, sid, path, tries, wid):
         _move_failed(sid, nm, wid, res)
         return res
     _commands_for_cwd(_cwd_of(sid))          # the new folder's slash commands warm before the next "/"
-    _mark_views_dirty()                       # the cwd lives in names/ — no sig sees it; rebuild past the sig
+    _mark_views_dirty()                       # the chat signature's cwd component (and the names digest) carries the
+                                              # move; the mark busts the feed and timeline, and the wake pushes now
     _push_soon()
     _send_to_view("chat", {"type": "moved", "id": sid, "name": nm, "cwd": _tilde(_cwd_of(sid))}, wid)
     return res
@@ -29820,7 +29825,9 @@ def _apply_pending_ops(now=None):
                     _pending_ops.pop(sid, None)
             if changed:
                 _save_pending_ops()           # every delivery/drop shrinks the disk mirror too
-                _mark_views_dirty()           # the queue shrank (in-memory) → rebuild past the sig so chips retire
+                _mark_views_dirty()           # the queue shrank (in-memory): the chat signature's ops component carries
+                                              # it; the mark busts the feed and timeline, and this cycle's push, which
+                                              # follows the drain, retires the chips
     finally:
         _live_scope.usage = _UNSET
         _live_scope.spend_pause = None

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13600,12 +13600,15 @@ window.addEventListener("romp:hostRelayUp", (e) => {
   refreshSettledPreviews();
   // …and the tab this pane is LOOKING AT, when that host owns it (T246, the user 2026-09-07): the relay's
   // open is the moment the remote kernel holds a FRESH client for this pane — after that kernel restarted,
-  // one with no active tab at all. Its pusher keys only a client's active tab on the live change key (the
-  // backend's stream, its queue, the snapshot row); every other session is served from the file-stat
-  // cache, so the session the user was watching streamed nothing until their next send moved a file
-  // input. The pane shim's local socket re-arms the LOCAL kernel with its ?active= connect hint on every
-  // dial; the relay has no hint, so the same fact is re-sent here as the activeTab message every tab
-  // switch sends (notifyActive; routeOutbound strips the host prefix). Decision in relay-active.ts.
+  // one with no active tab at all. Its pusher builds and flushes a client's active tab first; every tab is
+  // served from its cached build while its complete signature (_chat_build_sig: the backend's live tail,
+  // its queue, the snapshot row, every side file) holds. Under the key of the time, which keyed no
+  // in-memory input for a background tab, the session the user was watching streamed nothing until their
+  // next send moved a file input; today a missing hint costs the watched tab its place at the head of the
+  // build order and the first flush. The pane shim's local socket re-arms the LOCAL kernel with its ?active=
+  // connect hint on every dial; the relay has no hint, so the same fact is re-sent here as the activeTab
+  // message every tab switch sends (notifyActive; routeOutbound strips the host prefix). Decision in
+  // relay-active.ts.
   if (activeTabToReannounce(activeId, h)) notifyActive();
 });
 


### PR DESCRIPTION
## Symptom

Six comments describe a chat-refresh mechanism the code no longer has. The trailing comments on the `_mark_views_dirty()` calls in the WebSocket interrupt handler, `_park_op` and `_move_now` say the interrupt stamp, the parked-op queue and the cwd are inputs "no sig sees"; the one in `_apply_pending_ops` says the mark rebuilds the chat "past the sig" so chips retire, and the one in `_auto_resume_session_retry` says it dirty-rebuilds the chat status for a flag the view signature does not watch. The `romp:hostRelayUp` note in `ui/webview/render.ts` says the pusher keys only a client's active tab on "the live change key" and serves every other session from the file-stat cache, so the watched session streamed nothing until a file input moved. A reader learning from either file how a chat tab is refreshed is misdirected.

## Cause

Both accounts describe the watched tab's separate key and its dirty watermark, which the one chat signature retired. `_chat_build_sig` serves every tab, the watched one included, from its cached build while the complete signature holds, and its components read the inputs the comments say no signature sees: the clock component reads the interrupt stamp through `_interrupting`, the ops component reads `_pending_ops` by value, the retry component reads `_session_retry_suppressed`, and the cwd component reads `_session_cwd`, with the names digest among the shared components. The pusher's cache hit test compares the signature tuple alone and never reads the dirty mark.

The mark still has work at each site: it busts the feed and the timeline and wakes the pusher. The view signature stats files and reads the liveness badges; it holds none of the in-memory inputs (the interrupt stamp, the parked ops) and never stats the retry file, while the names file a move rewrites is among the files it stats, so at the move site the mark brings the rebuild forward past the minimum rebuild interval. The drain runs at the head of the pusher cycle, so the same cycle's push retires the chips; the retry re-arm runs after that push, so the wake starts the next cycle at once, and neither the feed nor the timeline reads the flag. The header comment of `ui/webview/relay-active.ts` was rewritten with the signature; the `render.ts` twin of that note and the call-site comments were not.

## Fix

Comment text only, at six sites; no code or test behaviour changes.

- `kernel/kernel.py`: the five trailing comments now name the chat signature component that carries the input and what the mark does at that site: it busts the feed and the timeline and wakes the pusher; at the drain, this cycle's push retires the chips; at the retry re-arm, the wake starts the next cycle. Each `_mark_views_dirty()` call is unchanged.
- `ui/webview/render.ts`: the `romp:hostRelayUp` note now carries the `relay-active.ts` account: the pusher builds and flushes the active tab first, every tab is served from its cached build while its complete signature holds, and a missing hint costs the watched tab its place at the head of the build order and the first flush. The T246 attribution, the `?active=` connect-hint and `activeTab` sentences and the pointer to `relay-active.ts` stay.

The `_views_dirty` definition comment and the other notes that call a store write invisible to the view signature describe the feed and timeline watermark, which still works that way, and are left as they are. The new text names no retired identifier.

## Tests

No executing test can fail before a comment edit, so none is added; an assertion on the old wording would be a source-text pin rather than a test and is not added either. The suites that cover these lines were run before and after the change and show the behaviour unchanged:

- `tests/test_chat_build_sig_inputs.py` and `tests/test_stage0_log_readers.py`: 83 passed in both runs. The census that maps every `build_session` read to a signature component and the differential cases that move the compact and model-switch stamps, the faded hour, and the ops, retry and cwd inputs are among them; no name moved.
- `tests/test_kernel_push_responsiveness.py`: 15 passed. It pins the interrupt, `_park_op` and `_apply_pending_ops` calls to `_mark_views_dirty()`, which stay.
- `cd vscode-extension && npm run typecheck`: clean.

With both files at their pre-change text the same 98 cases pass, so no test reads the old wording.

The full suites were not run for a comment-only change.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)