### PR TITLE
Tab strip: the state dot explains its state on hover, in the feed's words

### DIFF
--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -36,7 +36,7 @@ import { reconcileTabOrder } from "./tab-order";
 import { writeViewOrder } from "./view-order";
 import { planStrip, readTabGroups, writeTabGroups, setSectionCollapsed, sectionRef, isPinned, setPinned, prunePinned, reachableFrom, headWords,
          followAdoption, reorderTagOrder, TABGROUPS_KEY, TABGROUPS_EVENT, type TabSection } from "./tab-groups";
-import { tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
+import { tabStateClass, tabDotClass, tabDotTitle, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
 import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindings";
 import { DEFAULT_CHORDS } from "./commands";
 import { NavHistory } from "./nav-history";
@@ -5362,8 +5362,12 @@ function applyTabStatus(tab: HTMLElement, s: { status: Partial<Status> }): ChipS
   // loader dot (the user 2026-08-10). The slot itself is there in EVERY state (T262g, the user 2026-09-08):
   // a dot that came and went with the state changed the tab's width, and with the strip at a wrap boundary
   // that added or removed a row and slid the transcript under the reader by a row's height (tabDotClass).
+  // Each pip explains itself on hover, the same titles the feed's DOT_TIP speaks (the user 2026-07-22; tab-state.ts
+  // tabDotTitle, beside the class rule); the hidden slot and the compacting bar say nothing.
   const dotCls = tabDotClass(st);
   if (dotCls) tab.appendChild(el("span", dotCls));
+  const dotTip = dotCls ? tabDotTitle(st) : null;
+  if (dotTip) (tab.lastElementChild as HTMLElement).title = dotTip;
   // compacting → a tiny animated compaction bar before the name (the tab gets no outline for this state,
   // so the bar IS the cue). A teal fill whose right edge slides left and loops — the same "compression"
   // motion as the statusline ctx-scan bar (.ctx-compress), miniaturised. Replaces the static ⇲ glyph the

--- a/ui/webview/tab-dot-slot.test.ts
+++ b/ui/webview/tab-dot-slot.test.ts
@@ -7,14 +7,17 @@
 // fault. Fix: every tab carries the dot's slot in every state — laid out, hidden when the state has no dot — so the
 // strip's row count changes only when tabs are added, removed or renamed. The compacting bar keeps its own wider
 // slot (a rare, deliberate state). Pure rule executed here; render.ts and the CSS pinned.
+// The dot also explains itself on hover (tabDotTitle, the rule beside tabDotClass in tab-state.ts), in the feed's
+// words: executed here against feed.ts's own phrases, and the render wiring pinned.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { tabDotClass } from "./tab-state";
+import { tabDotClass, tabDotTitle } from "./tab-state";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("every state maps to a dot class; the ones without a visible dot get the hidden slot; compacting gets no dot (its bar)", () => {
   assert.equal(tabDotClass("working"), "tab-dot");
@@ -31,6 +34,42 @@ test("render.ts appends the slot from the one rule; the compacting bar branch st
   assert.match(RENDER, /const dotCls = tabDotClass\(st\);\s*\n\s*if \(dotCls\) tab\.appendChild\(el\("span", dotCls\)\);/);
   assert.doesNotMatch(RENDER, /if \(st === "working"\) tab\.appendChild\(el\("span", "tab-dot"\)\);/, "the per-state appends are gone");
   assert.match(RENDER, /const ci = el\("span", "tab-compacting-bar"\);/);
+});
+
+// The dot explains itself on hover (the user 2026-07-22: learn the states from tooltips, not the CLI), in the feed's
+// own words: the feed's status pip has spoken these phrases since then (feed.ts DOT_TIP), and the strip's dot is the
+// same mark on another surface, so the phrases are read from feed.ts here and must match it byte for byte. The
+// hidden slot says nothing (there is no state to explain), and compacting has no dot: its bar carries its own title
+// (render.ts). The two rules sit side by side in tab-state.ts and agree on which states have a dot.
+test("every visible dot explains itself on hover in the feed's words; the hidden slot and the compacting bar say nothing", () => {
+  const at = FEED.indexOf("const DOT_TIP");
+  assert.ok(at > 0, "feed.ts DOT_TIP not found");
+  const block = FEED.slice(at, FEED.indexOf("};", at));
+  const tip: Record<string, string> = Object.fromEntries([...block.matchAll(/^\s*(work|await|unknown): "([^"]+)",/gm)].map((m) => [m[1], m[2]]));
+  assert.deepEqual(Object.keys(tip).sort(), ["await", "unknown", "work"], "feed.ts DOT_TIP names its three states");
+  assert.equal(tabDotTitle("working"), tip.work);
+  assert.equal(tabDotTitle("awaitingBg"), tip.await);
+  assert.equal(tabDotTitle(undefined), tip.unknown);
+  assert.equal(tabDotTitle(""), tip.unknown);
+  // opening has no feed twin (the feed draws no opening pip), so its phrase is the strip's own, in the feed's shape:
+  // the state word, the feed's separator (read from its working phrase), then what the state means
+  const sep = /^working(\s\S\s)/.exec(tip.work)![1];
+  assert.equal(tabDotTitle("opening"), "opening" + sep + "this session is still starting up", "opening: the state word, the feed's separator, an explanation");
+  assert.equal(tabDotTitle("compacting"), null, "compacting: no dot, and the bar carries its own title");
+  for (const st of ["waiting", "idle", "blocked", "closed", "dead", "needsYou"]) assert.equal(tabDotTitle(st), null, st + ": the hidden slot says nothing");
+  // the two rules agree: a state has a title exactly when the class rule gives it a visible dot
+  for (const st of ["working", "awaitingBg", undefined, "", "opening", "compacting", "waiting", "idle", "blocked", "closed", "dead", "needsYou"]) {
+    const cls = tabDotClass(st);
+    assert.equal(tabDotTitle(st) !== null, cls !== null && cls !== "tab-dot none", String(st) + ": titled iff visibly dotted");
+  }
+});
+
+test("render.ts titles the slot it just appended, from the title rule beside the class rule", () => {
+  assert.match(RENDER, /import \{[^}]*\btabDotTitle\b[^}]*\} from "\.\/tab-state";/);
+  // the title is written while the slot is still the tab's last child: right after the append, before the
+  // compacting bar (and the label, gauge and close button the callers add after)
+  assert.match(RENDER, /const dotCls = tabDotClass\(st\);\s*\n\s*if \(dotCls\) tab\.appendChild\(el\("span", dotCls\)\);\s*\n\s*const dotTip = dotCls \? tabDotTitle\(st\) : null;\s*\n\s*if \(dotTip\) \(tab\.lastElementChild as HTMLElement\)\.title = dotTip;/,
+    "the title lands on the slot while it is the tab's last child");
 });
 
 test("the hidden slot is laid out (visibility, never display:none), same box as the dot", () => {

--- a/ui/webview/tab-state.ts
+++ b/ui/webview/tab-state.ts
@@ -96,3 +96,15 @@ export function tabDotClass(st: string | undefined | null): string | null {
   if (st === "opening") return "tab-dot opening";
   return "tab-dot none";
 }
+
+/** What a tab's dot says on hover (the user 2026-07-22: each pip explains itself, the same titles the feed's
+ *  DOT_TIP speaks), beside the class rule above so the two can never disagree on what a dot means: working,
+ *  awaitingBg, a missing state and opening have a title; the hidden slot ("tab-dot none") and the compacting
+ *  bar (no dot) say nothing. render.ts sets it on the slot tabDotClass classed. */
+export function tabDotTitle(st: string | undefined | null): string | null {
+  if (st === "working") return "working — a turn is running right now";
+  if (st === "awaitingBg") return "awaiting — idle, but background work it dispatched is still running";
+  if (!st) return "state unknown — romp couldn't read this session's live state";
+  if (st === "opening") return "opening — this session is still starting up";
+  return null;
+}

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -12,7 +12,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
 import { planStrip, parseTabGroups, headWords } from "./tab-groups";
-import { tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
+import { tabStateClass, tabDotClass, tabDotTitle, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
 import { newSkeletonState, renderKind } from "./skeleton-tabs";
 import type { TagUnion } from "./session-views";
 
@@ -43,6 +43,7 @@ class FakeEl {
   append(...cs: FakeEl[]): void { for (const c of cs) this.appendChild(c); }
   replaceChildren(...cs: FakeEl[]): void { this.wipes++; this.children = []; this.append(...cs); }
   get firstChild(): FakeEl | null { return this.children[0] ?? null; }
+  get lastElementChild(): FakeEl | null { return this.children[this.children.length - 1] ?? null; }   // the dot's hover title lands on the slot just appended
   contains(n: unknown): boolean { return n === this || this.children.some((c) => c.contains(n)); }
   setAttribute(k: string, v: string): void { this.attrs[k] = v; }
   addEventListener(t: string, f: Function): void { (this.listeners[t] ??= []).push(f); }
@@ -63,7 +64,7 @@ type Hooks = {
   phone: boolean;             // the phone layout: the plan is the flat strip there
   heads: HeadCall[];          // every group header the paint minted, in order
   planStrip: typeof planStrip; parseTabGroups: typeof parseTabGroups; headWords: typeof headWords;
-  tabStateClass: typeof tabStateClass; tabDotClass: typeof tabDotClass; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
+  tabStateClass: typeof tabStateClass; tabDotClass: typeof tabDotClass; tabDotTitle: typeof tabDotTitle; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
   newSkeletonState: typeof newSkeletonState; renderKind: typeof renderKind;   // the skeleton strip (2026-09-07): empty here, so every listed id is a loaded tab or a placeholder
   skeletons: number;          // skeleton tabs minted (none expected: the set stays empty in these worlds)
 };
@@ -110,7 +111,7 @@ function lift(): (hooks: Hooks) => Api {
     const readTabGroups = (u) => H.parseTabGroups(H.groupsRaw, u);
     const tabGroups = () => readTabGroups(H.unions); const writeTabGroups = () => {};
     const phoneLayout = () => H.phone;
-    const tabStateClass = H.tabStateClass, tabDotClass = H.tabDotClass, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;   // tabDotClass: the state-dot slot every tab carries (the tab-strip fix, 2026-09-08)
+    const tabStateClass = H.tabStateClass, tabDotClass = H.tabDotClass, tabDotTitle = H.tabDotTitle, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;   // tabDotClass: the state-dot slot every tab carries (the tab-strip fix, 2026-09-08); tabDotTitle: what the slot says on hover
     function makeGroupHead(sec, folded, active, hidden) {
       const h = el("div", "tab-group-head" + (folded ? " collapsed" : ""));
       h.dataset.group = String(sec.name);
@@ -152,7 +153,7 @@ function world(): { H: Hooks; api: Api; sessions: Map<string, any>; tabMeta: Map
   const H: Hooks = { FakeEl, bar: new FakeEl("div"), mslot: null, only: "", hidden: new Set(), down: new Set(), notes: {},
                      keyHint: "Open a session (K)", lens: { all: true }, unions: [], tips: [], aftermaths: [], rowPaints: 0, tagSyncs: 0, placeholders: 0,
                      groupsRaw: null, phone: false, heads: [],
-                     planStrip, parseTabGroups, headWords, tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle,
+                     planStrip, parseTabGroups, headWords, tabStateClass, tabDotClass, tabDotTitle, sectionPip, sectionPipMembers, sectionPipTitle,
                      newSkeletonState, renderKind, skeletons: 0 };
   const api = lift()(H);
   const sessions = new Map<string, any>([["a", session("web", "ready")], ["b", session("api", "working")]]);
@@ -287,6 +288,39 @@ test("the paint wears the shared state → class rule (tab-state.ts), and the si
   assert.equal(H.bar.wipes, 2);
   const tab2 = H.bar.tabs().find((t) => t.dataset.id === "a")!;
   assert.ok(tab2.has("tab-retrying") && !tab2.has("tab-blocked"), "a transient API error auto-retries: amber");
+});
+
+test("the dot slot explains its state on hover: a visible dot carries the feed's phrase for that state, the hidden slot says nothing", () => {
+  // the phrases are the feed's (feed.ts DOT_TIP), read from its source so the two surfaces cannot drift apart
+  const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+  const at = FEED.indexOf("const DOT_TIP");
+  const tip: Record<string, string> = Object.fromEntries([...FEED.slice(at, FEED.indexOf("};", at)).matchAll(/^\s*(work|await|unknown): "([^"]+)",/gm)].map((m) => [m[1], m[2]]));
+  assert.deepEqual(Object.keys(tip).sort(), ["await", "unknown", "work"]);
+  const sep = /^working(\s\S\s)/.exec(tip.work)![1];   // the feed's separator: the opening phrase (no feed twin) keeps the feed's shape
+  const { H, api, sessions } = world();
+  api.renderTabs();
+  // the dot is found BY CLASS: the label, the context gauge and the close button follow it, so once the paint is
+  // done it is not the tab's last child (it is at the moment applyTabStatus writes the title)
+  const dot = (id: string): FakeEl => {
+    const d = H.bar.tabs().find((t) => t.dataset.id === id)!.children.filter((c) => c.has("tab-dot"));
+    assert.equal(d.length, 1, id + ": one dot slot");
+    return d[0];
+  };
+  assert.ok(!dot("b").has("none"), "working: a visible dot");
+  assert.equal(dot("b").title, tip.work, "the working dot speaks the feed's working phrase");
+  assert.ok(dot("a").has("none"), "ready: the hidden slot");
+  assert.equal(dot("a").title, "", "the hidden slot says nothing");
+  const a = sessions.get("a");
+  a.status = { state: "awaitingBg" }; api.renderTabs();
+  assert.ok(dot("a").has("await")); assert.equal(dot("a").title, tip.await, "awaiting background work: the feed's awaiting phrase");
+  a.status = {}; api.renderTabs();
+  assert.ok(dot("a").has("unknown")); assert.equal(dot("a").title, tip.unknown, "no state: the feed's unknown phrase");
+  a.status = { state: "opening" }; api.renderTabs();
+  assert.ok(dot("a").has("opening")); assert.equal(dot("a").title, "opening" + sep + "this session is still starting up", "opening: the strip's own phrase (the feed draws no opening pip)");
+  a.status = { state: "compacting" }; api.renderTabs();
+  const tabA = H.bar.tabs().find((t) => t.dataset.id === "a")!;
+  assert.equal(tabA.children.filter((c) => c.has("tab-dot")).length, 0, "compacting: no dot");
+  assert.ok(tabA.children.find((c) => c.has("tab-compacting-bar"))!.title.startsWith("compacting"), "the bar carries its own title");
 });
 
 test("a render held by the pressed-tab or rename guard is not lost to the skip", () => {

--- a/ui/webview/tab-strip-skip.test.ts
+++ b/ui/webview/tab-strip-skip.test.ts
@@ -60,7 +60,7 @@ test("every input the strip renders is in the signature", () => {
   const chip = RENDER.slice(RENDER.indexOf("function applyTabStatus("), RENDER.indexOf("function wireTabDrag("));
   assert.match(fn, /const st = applyTabStatus\(tab, s\);/);
   assert.match(chip, /const stateCls = tabStateClass\(s\.status\);\s*\n\s*if \(stateCls\) tab\.classList\.add\(stateCls\);/);
-  assert.match(RENDER, /^import \{ tabStateClass, tabDotClass, sectionPip, sectionPipMembers, sectionPipTitle \} from "\.\/tab-state";/m);   // + tabDotClass: the dot slot every tab carries derives from st.state, already in the signature (the tab-strip fix, 2026-09-08)
+  assert.match(RENDER, /^import \{ tabStateClass, tabDotClass, tabDotTitle, sectionPip, sectionPipMembers, sectionPipTitle \} from "\.\/tab-state";/m);   // + tabDotClass: the dot slot every tab carries derives from st.state, already in the signature (the tab-strip fix, 2026-09-08); + tabDotTitle: the slot's hover title, from the same state
 });
 
 test("a tab drag resets the signature (its live reorder changes the strip's DOM outside renderTabs), and the tooltip reads the session fresh", () => {


### PR DESCRIPTION
A tab's state dot now carries a hover title in the feed's words: the working dot says a turn is running, the await-green dot says the session is idle with background work still running, the gray ring says its live state could not be read, and the opening dot says the session is still starting. The hidden slot and the compacting bar are unchanged (the bar already titles itself).

## Design

**What changes on screen.** Hover a tab's state dot and a native tooltip names the state and what it means. The feed's status pip has done this since 2026-07-22 (feed.ts `DOT_TIP`: working, awaiting, state unknown); the tab's own hover popover names the directory, branch, worktree, mode, model, effort, backend, billing and context but never the turn state, so the strip was the one surface where a dot's meaning could not be learned from the dashboard. Nothing changes for a tab with no visible dot: the hidden slot (`tab-dot none`) gets no title, and compacting has no dot, its bar carrying its own title as before.

**Skeleton tabs get the same titles.** `applyTabStatus` is shared with `makeSkeletonTab`, so a skeleton tab's dot is titled from the kernel's status frames like a loaded tab's; a skeleton has no rich popover, so this is the one place its turn state is named. One consequence for the reviewer's call: a skeleton before its first status frame lands draws the gray ring (the shared helper's rule for an empty status), and that ring now carries the feed's unknown phrase while the tab around it still says it is not loaded yet. The window is the frame or so between the tab list and the status burst after a reconnect; if the ring should say nothing there, the skeleton path can drop the slot's title when it has no status yet. The same shadowing applies to a tab whose host is down: its note stays on the tab, and over the dot the state phrase shows, as the dot's colour already shows that state.

**Why this shape.**
- The title rule sits beside the class rule. `tabDotTitle` in tab-state.ts follows `tabDotClass`, so the two rules that decide what a dot looks like and what it says are read together and cannot drift apart; the new test checks they agree on which states have a visible dot.
- One vocabulary, byte for byte. The working, awaiting and unknown phrases are the feed's `DOT_TIP` strings exactly, and both new tests read them from feed.ts's source rather than repeating them, so a change to the feed's wording fails here until the strip follows. The opening phrase has no feed twin (the feed draws no opening pip); it keeps the same form as the other three, the state word, the feed's dash, then what the state means, so the four read as one set.
- The title is written where the slot is appended. `applyTabStatus` sets it right after `tab.appendChild(el("span", dotCls))`, while the slot is still the tab's last child; the compacting bar, label, context gauge and close button are appended after. The two slot lines themselves are untouched, so every existing pin on them (tab-dot-slot, awaiting-state, provisional, skeleton-tabs-wiring, feed-status-pips) holds, and `applyTabStatus` stays the one site that appends the slot.
- A native title, like the feed's dot and the compacting bar. The feed's dot sets `.title` (feed.ts `setWorkDot`), and the compacting bar in the same helper sets `ci.title`; the strip's own hover popover (`showTabTip`) is a separate surface about the session, not the dot. The styled tooltip (tip.ts `setTip`) was considered; if preferred it is a one-line swap plus a stub in the exec test's sandbox.

**Left out.** No CSS (the slot's classes already exist), no kernel change, no documentation change, and no turn-state row in the tab's popover: that popover is about the session, and the dot is the mark the title explains.

**Relation to open PRs.** #994 and #1259 edit render.ts and the two skip tests in other hunks (neither touches `applyTabStatus`, the tab-state import, the `FakeEl` class, the `Hooks` type, the sandbox's tab-state line or the world's hook object), and #1267 and #1126 edit render.ts away from `applyTabStatus`. No open PR adds a title to the tab's dot.

## Tests

- `ui/webview/tab-dot-slot.test.ts` gains two tests. The first executes `tabDotTitle` for every state against the three phrases parsed from feed.ts's `const DOT_TIP` block (working, awaitingBg, and both `undefined` and `""` for the unknown ring), checks the opening phrase equals the state word, the feed's separator (read from its working phrase) and the explanation, null for compacting and for waiting, idle, blocked, closed, dead and needsYou, and that a state is titled exactly when `tabDotClass` gives it a visible dot. The second pins render.ts: the tab-state import carries `tabDotTitle`, and the two title lines directly follow the two slot lines inside `applyTabStatus`.
- `ui/webview/tab-strip-skip-exec.test.ts` gains one test over the lifted `applyTabStatus` and `renderTabs` (`FakeEl` gains `lastElementChild`, which the title write reads). It finds each tab's dot by class, never by position (the label, gauge and close button follow it), and checks: the working tab's dot carries the feed's working phrase; the ready tab's hidden slot has an empty title; a session moved through awaitingBg, no state, opening and compacting carries the feed's awaiting phrase, the feed's unknown phrase, the opening phrase composed the same way, and then no dot with the bar's own title. The no-state step passes the same empty status a skeleton tab passes before its first frame.
- `ui/webview/tab-strip-skip.test.ts`: the exact import-line pin carries the new name (a per-name check was considered and left out as the larger change).
- Before the change: the test bundle does not build (esbuild reports no matching export `tabDotTitle` in tab-state.ts from both new files). With `tabDotTitle` added but render.ts unwired: the exec test fails on the working dot's title (`''` where the feed's working phrase is expected), and the two source pins fail (tab-dot-slot test 4, tab-strip-skip test 2). A changed feed phrase or a changed opening phrase fails both new tests.
- Ran: the three files (5, 5 and 11 tests), the neighbouring pins (awaiting-state 8, provisional 15, skeleton-tabs-wiring 20, feed-status-pips 9, tab-state 4), `npm run typecheck` (clean), and the full `npm test`: 4077 passed, 0 failed, plus the tags-scale file run alone, 22 passed.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
