### PR TITLE
Comment threads: a signature that raises on the thread path is said once per fault episode, the chat loop's rule

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -13466,7 +13466,12 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     the task store, the pending cut, the backend's live revision and queue, the snapshot row, the
     shared files), without the dependency tail (a thread records no build dependencies), plus the
     thread's own states row; the serve yields to _views_dirty for the dependencies that tail would
-    have carried. A thread with no keyable input (no transcript yet) is built every time, never cached."""
+    have carried. A thread with no keyable input (no transcript yet) is built every time, never cached.
+    A signature that RAISES (one of its component reads failed) is said once per fault episode, on
+    stderr with the traceback and as a refused bell row, the chat loop's rule for the same signature
+    (_chat_sig_fault; a signature that is taken ends the episode, _chat_sig_ok), and the thread is
+    built uncached until a signature is taken: before this, the fault was swallowed into an uncached
+    build and left no trace anywhere."""
     reg = _thread_reg(tsid)
     if reg.get("forkOf"):
         return []
@@ -13477,6 +13482,7 @@ def _thread_events(tsid, cut_uuid, now, tmux):
     key = None
     try:
         sig = _chat_build_sig(sess, tm, now, tmux=tmux, deps=False)
+        _chat_sig_ok(tsid)                          # a signature that was taken ends its fault episode
         if sig is not None:
             # plus the thread's OWN state rows (review 2026-09-08): the backend writes states/<tsid>.jsonl under
             # the romp sid, while the key above stats states/<fsid>.jsonl for the reg's lastSid (_sdk_sess hands
@@ -13489,7 +13495,10 @@ def _thread_events(tsid, cut_uuid, now, tmux):
             except OSError:
                 states = None
             key = sig + (states,)
-    except Exception:
+    except Exception as e:
+        _chat_sig_fault(sess, e)                # once per fault episode: stderr and a bell row, the chat loop's rule.
+        #                                         _chat_sig_faults is sid-keyed; the chat loop builds only a PROMOTED
+        #                                         thread and the frame never hands one here, so no entry is shared.
         key = None                              # an input we cannot key → build, never cache
     hit = _built_thread.get(tsid)
     if key is not None and hit is not None and hit[0] == key and hit[1] == cut_uuid and _views_dirty[0] <= hit[3]:

--- a/tests/test_comment_threads.py
+++ b/tests/test_comment_threads.py
@@ -10,6 +10,7 @@ order. All fixtures SYNTHETIC: invented text, placeholder UUIDs.
 """
 import contextlib
 import errno
+import io
 import json
 import os
 import shutil
@@ -441,6 +442,69 @@ class ThreadProjection(CommentBase):
             self.assertEqual(calls.count(THREAD), n1 + 1, "and is served again afterwards")
         finally:
             km.build_session = real
+            km._views_dirty[0] = 0.0
+            km._built_thread.clear()
+
+    def test_a_signature_that_raises_on_the_thread_path_is_said_once_per_episode(self):
+        """One of the signature's component reads raising for a thread: the fault is written to stderr with
+        its traceback and filed as one refused bell row naming the thread, ONCE per fault episode (the chat
+        loop's rule for the same signature); a build is attempted every frame and nothing is stored while
+        the key cannot be taken. The same fault the next frame says nothing, a different fault is a new
+        episode, a signature that is taken ends it, and the same fault after that is said anew."""
+        self._seed_thread()
+        km._built_thread.clear()
+        km._views_dirty[0] = 0.0
+        saved = (km._watch_awaiting, km.build_session, list(km._SYNC_NOTICES), dict(km._chat_sig_faults))
+        del km._SYNC_NOTICES[:]
+        km._chat_sig_faults.clear()
+        fail = ["synthetic: the watch rows cannot be read"]
+        orig, real = saved[0], saved[1]
+        calls = []
+
+        def watch(sid):
+            if sid == THREAD and fail[0]:
+                raise OSError(fail[0])
+            return orig(sid)
+
+        km._watch_awaiting = watch
+        km.build_session = lambda sid, now, tm=None, **kw: (calls.append(sid), real(sid, now, tm, **kw))[1]
+
+        head = "push build: chat signature %s" % THREAD[:8]
+        seen = []
+
+        def frame():
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                km._comments_frame(PARENT)
+            seen.append(err.getvalue())
+            return seen[-1].count(head)
+        try:
+            self.assertEqual(frame(), 1, "the first frame says it")
+            self.assertIn(head + ": Traceback (most recent call last)", seen[-1], "...with the traceback")
+            self.assertIn(fail[0], seen[-1], "...naming the fault")
+            self.assertEqual(frame(), 0, "the second frame, same fault: not again")
+            self.assertEqual(frame(), 0)
+            self.assertEqual(calls.count(THREAD), 3, "a build is attempted every frame while the key cannot be taken")
+            self.assertNotIn(THREAD, km._built_thread, "nothing is stored")
+            self.assertEqual(len(km._SYNC_NOTICES), 1, "one episode, one bell row")
+            self.assertIn("thread-x", km._SYNC_NOTICES[-1]["text"], "the row names the thread")
+            self.assertEqual(km._SYNC_NOTICES[-1].get("kind"), "refused")
+            fail[0] = "synthetic: a different fault on the same thread"
+            self.assertEqual(frame(), 1, "a different fault is a new episode")
+            self.assertEqual(len(km._SYNC_NOTICES), 2)
+            fail[0] = ""
+            self.assertEqual(frame(), 0)
+            self.assertNotIn(THREAD, km._chat_sig_faults, "a signature that is taken ends the episode")
+            self.assertIn(THREAD, km._built_thread, "...and the build is cached like any other")
+            fail[0] = "synthetic: the watch rows cannot be read"
+            self.assertEqual(frame(), 1, "the same fault after a success is a new episode, said anew")
+        finally:
+            km._watch_awaiting = orig
+            km.build_session = real
+            del km._SYNC_NOTICES[:]
+            km._SYNC_NOTICES.extend(saved[2])
+            km._chat_sig_faults.clear()
+            km._chat_sig_faults.update(saved[3])
             km._views_dirty[0] = 0.0
             km._built_thread.clear()
 


### PR DESCRIPTION
## Symptom
A comment thread whose change signature cannot be taken (one of the reads behind `_chat_build_sig` raises: a torn state file, a directory that cannot be listed) is rebuilt on every pusher cycle, and nothing says so: no stderr line, no bell row. The same exception from the same function on a chat tab is reported once per fault episode, with the traceback on stderr and a refused bell row on the dashboard.

## Cause
`_thread_events` (kernel/kernel.py) takes the thread's signature inside a `try` whose handler only sets `key = None`. The chat loop takes the same signature under `_chat_sig_ok` / `_chat_sig_fault`. On the thread path a `None` key is always a swallowed exception: `_sdk_sess` always hands a thread a transcript path, so `_chat_build_sig`'s own `None` return (no path) is unreachable there.

## Fix
The handler becomes `except Exception as e: _chat_sig_fault(sess, e); key = None`, and a signature that is taken calls `_chat_sig_ok(tsid)` so the episode closes. The thread still builds uncached until the read succeeds; the fault is said once per fault text per thread, on stderr with the traceback and as one refused bell row. `sess` is the `_sdk_sess` dict (`sid` is the thread sid, `name` the reg's name or the sid's first eight characters), the shape `_chat_sig_fault` reads.

`_chat_sig_faults` is keyed by sid, and the two writers never meet on one. A thread stays out of the chat loop's session list on both of its sources: its names entry is withheld, so discover never lists it, and the backend's live set skips a threadOf reg. Once promotion writes the names entry and clears threadOf, `_comments_frame` stops handing the thread to `_thread_events`. The promote step does those two writes in sequence, so one pusher cycle inside it could run both paths for the sid; the worst case there is one report said twice or suppressed once in that cycle.

`_chat_sig_fault` itself is unchanged, so the bell row reads "the pane for <thread name> cannot be cached"; a noun for the thread case would touch the chat path and is left out of this fix. The `_thread_events` docstring gains a sentence.

## Tests
- `tests/test_comment_threads.py::ThreadProjection::test_a_signature_that_raises_on_the_thread_path_is_said_once_per_episode` (new). `_watch_awaiting`, a read the signature makes unconditionally, is replaced by one that raises for the thread. The first frame writes one `push build: chat signature <sid>` line to stderr, followed by the traceback and the fault text, and files one `refused` bell row naming the thread; the second and third frames write nothing more, while `build_session` is attempted on each frame and nothing is stored under the thread; a different fault text is a new episode (a second line, a second row); a signature that is taken ends the episode (the thread leaves `_chat_sig_faults` and the build is cached); the first fault re-armed after that is said anew. The injected read also fails the real `build_session` for the thread (through `_session_awaiting`), so the test asserts nothing on the frame's events while the fault stands; every assertion holds either way. Every replaced function and module table is restored in `finally`. Before the change it fails at the first assertion: the first frame writes nothing (`0 != 1`), and no bell row is filed. Two further checks were run and turn it red: without the `_chat_sig_ok` call it fails at "a signature that is taken ends the episode"; with a plain stderr write in place of `_chat_sig_fault` it fails at "the second frame, same fault: not again".
- The three existing thread-cache tests in the class stay green: a build that raises under a good signature is still uncached; that path is outside this fix.
- Targeted: `tests/test_comment_threads.py`, `tests/test_chat_build_sig_inputs.py`, `tests/test_pusher_change_gates.py`: 173 passed.
- Full `pytest tests/` on this commit (six workers, the served-page modules running against Chromium): 11116 passed, 41 skipped, 0 failed, 1705 subtests passed.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)