### PR TITLE
Hold the pane's own bookkeeping for a down remote host instead of toasting about it

### DIFF
--- a/ui/webview/federation-send-queue.test.ts
+++ b/ui/webview/federation-send-queue.test.ts
@@ -374,3 +374,178 @@ test("the pending-settings flush rides the socket's open event, never a timer", 
   assert.ok(flushFn.length > 0, "flushPending exists");
   assert.doesNotMatch(flushFn, /setTimeout|setInterval/, "no timer anywhere in the flush");
 });
+
+// ── the pane's OWN bookkeeping (2026-09-10): a toast about a message the user never sent. dropWarn was added
+// so a GESTURE at an unreachable remote (creating a session there) gives feedback — but it fired for anything
+// routed to a host whose socket was not open, and the chat pane sends plenty on its own: on the phone, a fresh
+// page whose active tab was a remote session posted `activeTab` before the relay socket to that host had
+// opened, and the tap the user had just made (which had worked) was answered with a warning that "activeTab"
+// was not delivered. Bookkeeping now HOLDS on the conn like a setting (latest per key, flushed on the open,
+// one hostconn row) and never toasts; a gesture, and any UNKNOWN type, still toasts — a silent drop of
+// something that mattered is the worse failure. The classes are an explicit list (BOOKKEEPING), not a guess
+// from the type's name.
+import { BOOKKEEPING, bookkeepingKey, routeOutbound } from "./federation";
+
+const V = "66666666-7777-8888-9999-000000000000";
+
+test("activeTab to a host whose socket is not open is HELD, not toasted: no warn, no senddrop, one hold row, flushed on the open", () => {
+  withFed((fm, winEvents, localSends) => {
+    const sock = attach(fm, "TESTHOSTA");           // CONNECTING: the fresh page's relay, not open yet
+    fm.outbound({ type: "activeTab", id: "TESTHOSTA:" + U });
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 0, "no toast about a message the user never sent");
+    assert.equal(diags(localSends, "senddrop").length, 0, "held, not dropped");
+    assert.equal(diags(localSends, "sendqueue").length, 0, "not a setting's row either");
+    const hold = diags(localSends, "hostconn").filter((d) => d.data.ev === "hold");
+    assert.deepEqual(hold.map((d) => d.data), [{ host: "TESTHOSTA", ev: "hold", msgType: "activeTab", rs: 0 }],
+      "one hostconn row says the hold began, naming the host and the type");
+    assert.deepEqual(sock.sent, [], "nothing can ride a CONNECTING socket");
+    sock.open();
+    assert.deepEqual(sock.sent.map((s) => JSON.parse(s)), [{ type: "activeTab", id: U }],
+      "the open event itself delivers it, id bared for that host");
+    const open = diags(localSends, "hostconn").filter((d) => d.data.ev === "open").pop();
+    assert.deepEqual(open.data, { host: "TESTHOSTA", ev: "open", flushed: ["activeTab"] }, "the open row names what flushed, by type");
+  });
+});
+
+test("latest-wins: two activeTabs held while down deliver only the newest tab, and the hold row is written once", () => {
+  withFed((fm, winEvents, localSends) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "activeTab", id: "TESTHOSTA:" + U });
+    fm.outbound({ type: "activeTab", id: "TESTHOSTA:" + V });   // the user moved on before the socket opened
+    assert.equal(diags(localSends, "hostconn").filter((d) => d.data.ev === "hold").length, 1,
+      "the row marks the not-held → held transition, not every message");
+    sock.open();
+    assert.deepEqual(sock.sent.map((s) => JSON.parse(s)), [{ type: "activeTab", id: V }], "the stale tab is never sent");
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 0);
+  });
+});
+
+test("a held needFull keys by SESSION: asks for two sessions both flush (a type-only key would leave one pane-side dedupe gagged)", () => {
+  withFed((fm) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "needFull", id: "TESTHOSTA:" + U, why: "prefetch" });
+    fm.outbound({ type: "needFull", id: "TESTHOSTA:" + V, why: "gap" });
+    fm.outbound({ type: "needFull", id: "TESTHOSTA:" + U, why: "skeleton-click" });   // the same session again: one ask
+    sock.open();
+    assert.deepEqual(sock.sent.map((s) => JSON.parse(s)),
+      [{ type: "needFull", id: U, why: "skeleton-click" }, { type: "needFull", id: V, why: "gap" }]);
+  });
+});
+
+test("a pointer echo keys by TYPE: hovers while down hold one entry and flush only the newest (a leave clears)", () => {
+  withFed((fm, winEvents) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "dotHover", sid: "TESTHOSTA:" + U, uuid: "a1", t: 1 });
+    fm.outbound({ type: "dotHover", sid: "TESTHOSTA:" + U, uuid: "a2", t: 2 });
+    fm.outbound({ type: "showAskPath", itemId: U + ":g1", sid: "TESTHOSTA:" + U, locate: false });
+    fm.outbound({ type: "showAskPath", itemId: U + ":g1", sid: "TESTHOSTA:" + U, off: true });
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 0, "a hover over a down host's card never toasts");
+    sock.open();
+    assert.deepEqual(sock.sent.map((s) => JSON.parse(s)), [
+      { type: "dotHover", sid: U, uuid: "a2", t: 2 },
+      { type: "showAskPath", itemId: U + ":g1", sid: U, off: true },
+    ]);
+  });
+});
+
+test("showAskPath's JUMP is the click itself, a gesture: it toasts and is never replayed; its hover glow holds", () => {
+  withFed((fm, winEvents, localSends) => {
+    const sock = attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "showAskPath", itemId: U + ":g1", sid: "TESTHOSTA:" + U, locate: false, jump: true });
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 1, "the jump the user clicked did not land: say so");
+    assert.equal(diags(localSends, "senddrop").length, 1);
+    sock.open();
+    assert.deepEqual(sock.sent, [], "a jump minutes later would land the user somewhere they no longer asked for");
+  });
+});
+
+test("a gesture to a down host keeps the toast: sendMessage (routed by id) and createSession (explicit host)", () => {
+  withFed((fm, winEvents, localSends) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3;
+    fm.outbound({ type: "sendMessage", id: "TESTHOSTA:" + U, text: "hello" });
+    fm.outbound({ type: "createSession", host: "TESTHOSTA", name: "web", dir: "~/proj" });
+    const warns = winEvents.filter((m) => m.type === "warn").map((m) => m.text);
+    assert.equal(warns.length, 2);
+    assert.match(warns[0], /TESTHOSTA is unreachable .*“sendMessage” was not delivered/);
+    assert.match(warns[1], /TESTHOSTA is unreachable .*“createSession” was not delivered/);
+    assert.deepEqual(diags(localSends, "senddrop").map((d) => d.data.msgType), ["sendMessage", "createSession"]);
+    assert.equal(fm.conns.get("TESTHOSTA").pending.size, 0, "a gesture is never held for a later replay");
+  });
+});
+
+test("an UNKNOWN type to a down host toasts: the default is the loud arm, never a silent hold", () => {
+  withFed((fm, winEvents, localSends) => {
+    attach(fm, "TESTHOSTA");
+    fm.outbound({ type: "zzzNotAKnownType", id: "TESTHOSTA:" + U });
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 1);
+    assert.deepEqual(diags(localSends, "senddrop").map((d) => d.data.msgType), ["zzzNotAKnownType"]);
+    assert.equal(fm.conns.get("TESTHOSTA").pending.size, 0);
+  });
+});
+
+test("bookkeeping for a host this page holds NO connection to is dropped with a breadcrumb — no toast, nothing to hold it on", () => {
+  withFed((fm, winEvents, localSends) => {
+    fm.hostSeq.push("TESTHOSTB");                    // known from a frame, never dialed (no /tunnels row)
+    fm.outbound({ type: "activeTab", id: "TESTHOSTB:" + U });
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 0);
+    assert.deepEqual(diags(localSends, "senddrop").map((d) => d.data), [{ host: "TESTHOSTB", msgType: "activeTab", why: "no-conn" }]);
+  });
+});
+
+test("a held entry rides the re-dial like a setting, and a detach names the held TYPES it discards", () => {
+  withFed((fm, _win, localSends) => {
+    const s1 = attach(fm, "TESTHOSTA");
+    s1.open();
+    s1.readyState = 3;
+    fm.outbound({ type: "activeTab", id: "TESTHOSTA:" + U });
+    fm.outbound({ type: "needFull", id: "TESTHOSTA:" + V, why: "gap" });
+    const s2 = redial(fm, "TESTHOSTA");
+    s2.open();
+    assert.deepEqual(s2.types(), ["activeTab", "needFull"], "held bookkeeping flushes on the fresh socket's open");
+    fm.outbound({ type: "activeTab", id: "TESTHOSTA:" + V });   // live now
+    s2.readyState = 3;
+    fm.outbound({ type: "needFull", id: "TESTHOSTA:" + U, why: "gap" });
+    fm.closeRemote("TESTHOSTA");
+    const det = diags(localSends, "hostconn").filter((d) => d.data.ev === "detach").pop();
+    assert.deepEqual(det.data, { host: "TESTHOSTA", ev: "detach", pendingDropped: ["needFull"] },
+      "the detach row lists types, never composite keys (a key carries the sid)");
+  });
+});
+
+test("redial stays LOCAL with its host INTACT: the local kernel owns the tunnel, and a down host must not eat the ask with a toast", () => {
+  withFed((fm, winEvents, localSends) => {
+    attach(fm, "TESTHOSTA");                          // the tunnel is down: exactly when the composer asks for a redial
+    fm.outbound({ type: "redial", host: "TESTHOSTA" });
+    assert.deepEqual(localSends.filter((m) => m.type === "redial"), [{ type: "redial", host: "TESTHOSTA" }]);
+    assert.equal(winEvents.filter((m) => m.type === "warn").length, 0, "no toast about the redial on top of the refusal's own");
+    assert.equal(fm.conns.get("TESTHOSTA").pending.size, 0);
+    assert.deepEqual(routeOutbound({ type: "redial", host: "TESTHOSTA" }), [{ host: "", msg: { type: "redial", host: "TESTHOSTA" } }]);
+  });
+});
+
+test("the classes are an explicit list: every held type is in BOOKKEEPING, a gesture and an unknown type are not, and a key never leaks a type-only collision across sessions", () => {
+  for (const t of ["activeTab", "needFull", "needSlot", "loadOlder", "loadEpisode", "imgRequest", "commentSeen",
+                   "dotHover", "hoverHighlight", "showAskPath", "timelineHover", "dirComplete",
+                   "cardOpened", "locateDiag", "orderAudit"])
+    assert.ok(BOOKKEEPING.has(t), t + " is held, not toasted");
+  for (const t of ["sendMessage", "createSession", "openSession", "renameSession", "askClear", "askClearMany", "clearAll",
+                   "undoClear", "tagEdit", "editTag", "reviveSession", "interrupt", "stopTask", "cardNotify", "viewReadOnly",
+                   "requestSessions", "reply", "zzzNotAKnownType"])
+    assert.equal(bookkeepingKey({ type: t, id: U }), null, t + " is a gesture (or unknown): it toasts");
+  assert.notEqual(bookkeepingKey({ type: "needFull", id: U }), bookkeepingKey({ type: "needFull", id: V }), "one ask per session");
+  assert.equal(bookkeepingKey({ type: "activeTab", id: U }), bookkeepingKey({ type: "activeTab", id: V }), "one active tab per pane");
+  assert.equal(bookkeepingKey({ type: "showAskPath", sid: U, jump: true }), null, "the jump click is the gesture");
+  assert.equal(bookkeepingKey(null), null);
+  assert.equal(bookkeepingKey({ id: U }), null, "no type: the loud arm");
+});
+
+test("sendRemote consults the bookkeeping list AFTER the settings queue and BEFORE the drop arm — the drop arm is the default", () => {
+  const seg = FED.slice(FED.indexOf("private sendRemote"), FED.indexOf("private flushPending"));
+  const iSetting = seg.indexOf("KERNEL_SETTING.has(msg.type)");
+  const iBook = seg.indexOf("bookkeepingKey(msg)");
+  const iDrop = seg.indexOf("this.dropWarn(host, msg)");
+  assert.ok(iSetting > 0 && iBook > iSetting && iDrop > iBook, "settings, then bookkeeping, then the toast");
+  assert.doesNotMatch(seg, /startsWith\(|endsWith\(|\/\^|test\(msg\.type/, "the class is looked up, never guessed from the type's spelling");
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -84,6 +84,59 @@ const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel"
                                 "setCommentModel", "setCommentEffort", "setCommentFast",
                                 "setTmuxBackend"]);   // T288: the tmux backend's offer, one value across machines
 
+// ── what a send to a host whose relay socket is NOT open does, by message class (2026-09-10) ─────────
+// Three classes, decided by an EXPLICIT list — never guessed from the type's spelling at run time:
+// - a KERNEL_SETTING (above) queues on the conn, latest per type, and flushes on the socket's open;
+// - the pane's own BOOKKEEPING (this map) queues the same way, latest per KEY, and never toasts. These
+//   are messages the pane emits on its own — a hint, a fetch it dedupes itself, a read watermark, a
+//   metric row, a pointer position — so the user made no gesture that this message is the outcome of,
+//   and a toast about it names a message they never sent (the user 2026-09-10: on the phone, a fresh
+//   page whose active tab was a remote session posted activeTab before the relay socket to that host had
+//   opened, and the tap they had just made, which had in fact worked, was answered with a warning that
+//   "activeTab" was not delivered). HELD rather than dropped because the drop is what gagged the pane:
+//   needFull's awaitingFull, imgRequest's imgRequested, loadEpisode's episodePendingKey and loadOlder's
+//   loadingOlder each hold their re-ask until a reply lands, and a dead socket's never does;
+// - everything else is a GESTURE — the message IS the action (sendMessage, createSession, renameSession,
+//   askClear, a tag edit…) and the remote kernel doing it is the whole point, so a drop is said to the
+//   user (dropWarn's toast) and never replayed later (a stale action can be worse than a dropped one).
+//   An UNKNOWN type takes this arm too: a toast about a message that did not matter costs a glance; a
+//   silent drop of one that did loses the thread.
+// The value is the queue KEY, so "latest wins per key" mirrors the settings queue's per-type dedupe with
+// the granularity each message needs: one active tab per pane, so activeTab keys by type alone and the
+// newest supersedes; a fetch keys by what it fetches, so asks for two sessions both stand (a type-only
+// key would flush one and leave the other's pane-side dedupe holding forever); a pointer position keys
+// by type, since only the newest means anything and a leave clears; a metric or audit row keys by type,
+// so a long outage holds one row and not an unbounded backlog — a row lost to an outage is a metric,
+// never a gesture. A key function may answer null for an INSTANCE that is a gesture after all: the
+// feed's showAskPath is the card hover's glow, but with `jump` it is the click that lands the chat on
+// that card, and a jump minutes later would put the user somewhere they no longer asked to be.
+const K = "\u001f";   // the key separator: a control character no session id, path or slot name contains
+export const BOOKKEEPING: ReadonlyMap<string, (m: any) => string | null> = new Map<string, (m: any) => string | null>([
+  ["activeTab",      ()  => "activeTab"],                          // render.ts notifyActive: the tab this pane is looking at
+  ["needFull",       (m) => "needFull" + K + m.id],                // render.ts requestFullSession: a session's re-send (gap / nobase / skeleton / prefetch)
+  ["needSlot",       (m) => "needSlot" + K + m.slot],              // fleet.ts: a view slot's re-send after a rejected delta
+  ["loadOlder",      (m) => "loadOlder" + K + m.id],               // render.ts: the head's older page on a scroll-up or a deep link into it
+  ["loadEpisode",    (m) => "loadEpisode" + K + m.id],             // render.ts noticeOpened: a clear notice's conversation on first expand
+  ["imgRequest",     (m) => "imgRequest" + K + m.id + K + m.path], // render.ts: an inline image's bytes, asked on render
+  ["commentSeen",    (m) => "commentSeen" + K + m.id + K + m.tid], // render.ts: a thread's read watermark as its popover opens or a reply lands in it
+  ["dotHover",       ()  => "dotHover"],                           // render.ts: the chat's hovered dot (a bare dotHover is the leave)
+  ["hoverHighlight", ()  => "hoverHighlight"],                     // feed.ts: the hovered card's rows on the timeline
+  ["showAskPath",    (m) => (m.jump ? null : "showAskPath")],      // feed.ts: the hovered / pinned card's path glow (`off` clears); `jump` is the click
+  ["timelineHover",  ()  => "timelineHover"],                      // timeline-boot.ts: the hovered lane segment (`off` clears, broadcast)
+  ["dirComplete",    ()  => "dirComplete"],                        // render.ts: the + picker's typed-ahead path query (its reply carries reqId; a stale one is dropped there)
+  ["cardOpened",     ()  => "cardOpened"],                         // feed.ts: the open-metric row
+  ["locateDiag",     ()  => "locateDiag"],                         // render.ts: a chat landing attempt's audit row
+  ["orderAudit",     ()  => "orderAudit"],                         // render.ts auditTabOrder: a tab-order permutation's audit row
+]);
+
+/** The key a held bookkeeping message dedupes under on the conn's queue, or null when the message is a
+ *  gesture (an instance the list's function declines, a type not listed, or no type at all): the loud arm. */
+export function bookkeepingKey(msg: any): string | null {
+  if (!msg || typeof msg !== "object" || typeof msg.type !== "string") return null;
+  const f = BOOKKEEPING.get(msg.type);
+  return f ? f(msg) : null;
+}
+
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */
 export function prefixInbound(host: string, msg: any): any {
@@ -273,6 +326,12 @@ export function stripHost(host: string, id: string): string {
 
 export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route[] {
   if (!msg || typeof msg !== "object") return [{ host: LOCAL, msg }];
+
+  // redial ALWAYS stays LOCAL, `host` INTACT: it asks the kernel THIS page talks to for a fresh dial of its
+  // tunnel to `host` (the composer's refusal on a downed host, render.ts). The explicit-host rule below
+  // carried it to that very host — down, so it dropped with a toast about "redial" on top of the refusal's
+  // own copy — with the field stripped, which the kernel's handler requires (2026-09-10).
+  if (msg.type === "redial") return [{ host: LOCAL, msg }];
 
   // an explicit `host` field wins (the + modal's createSession picks the target kernel): route there with
   // the field stripped — the kernel's handlers are host-blind.
@@ -775,11 +834,18 @@ interface Conn {
   lastRecv: number; // epoch ms of the last frame on the CURRENT socket (keepalives count); 0 = none yet
   resumeProvisional: number; // the `resume` stamp lastRecv rests on until a frame confirms it (the watchdog runs at REMOTE_PROVISIONAL_MS meanwhile); 0 = confirmed, or no stamp
   connT: number;    // when the current socket's connect() attempt started — the watchdog's reference point
-  // KERNEL_SETTING messages that arrived while this host's socket was down, newest per type only —
-  // flushed on the socket's open event (sendRemote/flushPending). Bounded by construction: at most
-  // one entry per setting type. Lives on the CONN, not the socket, so it survives every re-dial —
-  // the onclose retry, the poll's, and the liveness watchdog's abandon-and-dial (watchdog()).
+  // KERNEL_SETTING messages (newest per type) and the pane's own BOOKKEEPING (newest per key, see
+  // BOOKKEEPING) that arrived while this host's socket was down — flushed on the socket's open event
+  // (sendRemote/flushPending). Bounded by construction: one entry per setting type, per bookkeeping
+  // key. Lives on the CONN, not the socket, so it survives every re-dial — the onclose retry, the
+  // poll's, and the liveness watchdog's abandon-and-dial (watchdog()).
   pending: Map<string, any>;
+}
+
+/** The TYPES held on a conn's queue, for the hostconn rows (flush-halt's `held`, detach's `pendingDropped`):
+ *  a bookkeeping key carries the sid it is per, and the journal names what, not which. */
+function pendingTypes(c: Conn): string[] {
+  return [...c.pending.values()].map((m) => (m && typeof m.type === "string" ? m.type : ""));
 }
 
 export class FederationManager {
@@ -1317,9 +1383,12 @@ export class FederationManager {
   //   time, which would forge freshness onto an hours-old pick. Queueing is journaled (`sendqueue`),
   //   so a later disagreement between machines is attributable to this tab holding the pick while
   //   the host was down, and to the older pick of the same type it replaced;
-  // - anything else keeps its behavior (replaying an arbitrary action minutes later can be worse
-  //   than dropping it — a deliberate non-goal) but the drop lands a client-diag breadcrumb naming
-  //   the type and host, beside the existing warn toast: a drop is never silent.
+  // - the pane's own BOOKKEEPING (the BOOKKEEPING list, above) holds the same way, latest per key, and
+  //   never toasts: the user sent nothing for a toast to be about (2026-09-10);
+  // - anything else — a GESTURE, or an unknown type — keeps its behavior (replaying an arbitrary action
+  //   minutes later can be worse than dropping it — a deliberate non-goal) but the drop lands a
+  //   client-diag breadcrumb naming the type and host, beside the existing warn toast: a drop is never
+  //   silent.
   private sendRemote(host: string, msg: any): void {
     const c = this.conns.get(host);
     if (c && c.ws && c.ws.readyState === 1) {
@@ -1336,6 +1405,18 @@ export class FederationManager {
       this.diag("sendqueue", { host, msgType: msg.type, gt: typeof msg.gt === "number" ? msg.gt : 0,
                                rs: c.ws ? c.ws.readyState : -1,
                                ...(prev ? { superseded: typeof prev.gt === "number" ? prev.gt : true } : {}) });
+      return;
+    }
+    const key = bookkeepingKey(msg);
+    if (key !== null) {
+      // the pane's own bookkeeping (BOOKKEEPING): held for the open, never toasted — the user sent
+      // nothing for a toast to be about. A host this page holds no conn for (known from a frame, never
+      // dialed, or detached since) has nothing to hold it on: dropped with the breadcrumb alone. Journaled
+      // once per KEY, at the not-held → held transition, in the hostconn family: a hover held per pointer
+      // move would otherwise write a row per move; the open row names everything that flushed.
+      if (!c) { this.diag("senddrop", { host, msgType: msg.type, why: "no-conn" }); return; }
+      if (!c.pending.has(key)) this.diag("hostconn", { host, ev: "hold", msgType: msg.type, rs: c.ws ? c.ws.readyState : -1 });
+      c.pending.set(key, msg);
       return;
     }
     this.diag("senddrop", { host, msgType: (msg && msg.type) || "" });
@@ -1357,22 +1438,24 @@ export class FederationManager {
   private flushPending(conn: Conn): string[] {
     if (!conn.pending.size || !conn.ws || conn.ws.readyState !== 1) return [];
     const flushed: string[] = [];
-    for (const [t, m] of conn.pending) {   // deleting the current entry mid-iteration is spec-safe on a Map
+    for (const [k, m] of conn.pending) {   // deleting the current entry mid-iteration is spec-safe on a Map
       try {
         conn.ws.send(JSON.stringify(m));
       } catch (e) {
-        this.diag("hostconn", { host: conn.host, ev: "flush-halt", flushed: [...flushed], held: [...conn.pending.keys()] });
+        this.diag("hostconn", { host: conn.host, ev: "flush-halt", flushed: [...flushed], held: pendingTypes(conn) });
         break;
       }
-      conn.pending.delete(t);
-      flushed.push(t);
+      conn.pending.delete(k);
+      flushed.push(m && typeof m.type === "string" ? m.type : k);   // by TYPE: a bookkeeping key carries the sid it is per
     }
     return flushed;
   }
 
-  // A route to a host whose socket isn't open would otherwise VANISH — creating a session on an
+  // A GESTURE routed to a host whose socket isn't open would otherwise VANISH — creating a session on an
   // unreachable remote gave no feedback at all (the user 2026-07-10). Surface the drop as a local
   // `warn` (render.ts toasts it), naming the host and the action so the user knows what didn't land.
+  // Only for a gesture: the pane's own bookkeeping is held instead (BOOKKEEPING), since a toast about a
+  // message the user never sent reads as a failure of the tap they did make (2026-09-10).
   private dropWarn(host: string, msg: any): void {
     window.dispatchEvent(new MessageEvent("message", { data: { type: "warn",
       text: `${host} is unreachable (its kernel isn't answering) — “${(msg && msg.type) || "action"}” was not delivered` } }));
@@ -1537,7 +1620,7 @@ export class FederationManager {
     // /tunnels no longer lists it → its cards drop NOW. A detach also discards any settings still
     // queued for the host (the user removed it from the mesh; a later reattach re-syncs through the
     // gear's mixed marks) — named in the breadcrumb, because a drop is never silent.
-    this.diag("hostconn", c.pending.size ? { host, ev: "detach", pendingDropped: [...c.pending.keys()] }
+    this.diag("hostconn", c.pending.size ? { host, ev: "detach", pendingDropped: pendingTypes(c) }
                                          : { host, ev: "detach" });
     c.closed = true;
     try {

--- a/ui/webview/flicker-diag.test.ts
+++ b/ui/webview/flicker-diag.test.ts
@@ -40,7 +40,8 @@ test("federation: every remote socket open/close/detach posts a hostconn breadcr
   const relayAt = onopen.indexOf('"romp:hostRelayUp"');
   assert.ok(flushAt >= 0 && crumbAt > flushAt && relayAt > crumbAt, "onopen order: flush, breadcrumb, relay-up dispatch");
   assert.match(FED, /this\.diag\("hostconn", \{ host: conn\.host, ev: "close", code: ev\.code, clean: ev\.wasClean, detached: conn\.closed \}\);/);
-  assert.match(FED, /this\.diag\("hostconn", c\.pending\.size \? \{ host, ev: "detach", pendingDropped: \[\.\.\.c\.pending\.keys\(\)\] \}\s*\n\s*: \{ host, ev: "detach" \}\);/);
+  // …by TYPE (pendingTypes): a held bookkeeping entry's queue key carries the sid it is per (2026-09-10)
+  assert.match(FED, /this\.diag\("hostconn", c\.pending\.size \? \{ host, ev: "detach", pendingDropped: pendingTypes\(c\) \}\s*\n\s*: \{ host, ev: "detach" \}\);/);
   // breadcrumbs ride the LOCAL kernel socket into the same client-diag journal the feed writes
   assert.match(FED, /s\(\{ type: "clientDiag", surface: "federation", what, data \}\);/);
 });

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -753,3 +753,11 @@ test("re-based times cannot strand a connector after its sender's last bar (the 
   assert.equal(msg.sent, 990);
   assert.deepEqual(lane, { start: 910, end: 995 });
 });
+
+test("routeOutbound: redial ALWAYS stays local with its host field INTACT — it asks the LOCAL kernel to re-dial that tunnel", () => {
+  // the composer's refusal on a downed host posts {type:"redial", host} (render.ts, 2026-08-16). The explicit-host
+  // rule carried it to that very host — down, so it dropped with a toast about "redial" on top of the refusal's own
+  // copy — with the field stripped, which the kernel's handler requires (2026-09-10).
+  assert.deepEqual(routeOutbound({ type: "redial", host: "gpu1" }), [{ host: "", msg: { type: "redial", host: "gpu1" } }]);
+  assert.deepEqual(routeOutbound({ type: "redial", host: "gpu1" }, new Set(["gpu1"])), [{ host: "", msg: { type: "redial", host: "gpu1" } }]);
+});


### PR DESCRIPTION
Tier: fix

## The bug
`ui/webview/federation.ts` `dropWarn` toasted "`<host>` is unreachable … `<type>` was not delivered" for ANY message routed to a remote host whose relay socket was not open. It was added so a user gesture at an unreachable remote (creating a session there) gives feedback, but it also fired for bookkeeping the chat pane emits on its own. On the phone, a fresh page whose active tab was a remote session posted `activeTab` before the relay socket to that host had opened; the tap the user had just made had worked, and they got a warning about a message they never sent.

## The fix
`sendRemote` classifies outbound routed messages by an explicit list, `BOOKKEEPING` (type → queue-key function), never by guessing from the type's name at run time:
- **Kernel settings** queue on the conn, latest per type (unchanged).
- **Bookkeeping** the pane emits on its own is held the same way, latest per key, flushed on the socket's open, no toast, one `hostconn` `hold` row at the not-held → held transition: `activeTab`, `needFull`, `needSlot`, `loadOlder`, `loadEpisode`, `imgRequest`, `commentSeen`, `dotHover`, `hoverHighlight`, `showAskPath` (its hover glow; the `jump` click stays a gesture), `timelineHover`, `dirComplete`, `cardOpened`, `locateDiag`, `orderAudit`. Keys: `activeTab` per type (one active tab per pane, newest wins); fetches per target so asks for two sessions both stand (the pane's own dedupe, e.g. `awaitingFull`, otherwise holds the second one's re-ask forever); pointer echoes and metric rows per type so a long outage holds one entry.
- **Gestures and any unknown type** keep today's behavior: `senddrop` row plus the toast. A silent drop of something that mattered is the worse failure, so unknown defaults loud.
- The `flush-halt`, `detach` and `open` rows name held entries by type (a key carries a sid).

Also fixes an adjacent misroute found while enumerating call sites: `redial` (the composer's ask to re-dial a downed host's tunnel) carried an explicit `host` field, so `routeOutbound` sent it to that very host, down, with the field stripped that the kernel handler requires. The local kernel never re-dialed and the user got this same toast on top of the refusal. It now stays local with the field intact, like `openFolder`.

## Tests (fail first)
`ui/webview/federation-send-queue.test.ts`: `activeTab` held with no warn/senddrop and one hold row, flushed on open; latest-wins for two `activeTab`s; `needFull` keyed per session; pointer echoes keyed per type; `showAskPath` jump toasts; gesture (`sendMessage`, `createSession`) toasts; unknown type toasts; no-conn bookkeeping drops with a breadcrumb only; held entries ride a re-dial and detach names types; `redial` stays local; the explicit list and the arm order (source pin). `ui/webview/multi-kernel-merge.test.ts`: `redial` routing. `flicker-diag.test.ts`'s detach-row pin updated to the type-naming form.

`npm run typecheck`, `npm test`, `npm run build`: 4105/4109 pass; the one failure (`md-sanitize-postpass-browser` KaTeX fraction geometry) fails identically on `origin/main` on this machine and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
