### PR TITLE
File viewer: each paint of a shown file or URL document is timed as fileview:paint in the hosting pane's browser telemetry

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1181,7 +1181,12 @@ frames it received is measured in the panes themselves, by
   hosts (the VS Code bundle directly; the kernel page's inline boot through
   the `window.__rompPerf` that `federation.js` publishes before it runs), so
   `data`, `bars`, `hover`, `activeChat`, `revealEvent` and `models` are timed
-  like any pane's frames.
+  like any pane's frames. The file viewer (`ui/webview/file-view.ts`) brackets
+  each paint of a shown document's text body (a file on disk or a markdown URL,
+  as rendered markdown or as the code view) as `fileview:paint` under the pane
+  that hosts it (`chat` or `feed`), so painting a large document shows per
+  minute beside the pane's frames, with the main-thread-free sample the
+  collector takes after it.
 - Per type and minute: count, summed and maximum handler time, the exact
   number of frames over 16.7 ms (one dropped frame at 60 Hz) and at or over
   100 ms, and a 14-bucket log2 histogram (under 1 ms, 1-2, 2-4, ..., 2048-4096,

--- a/ui/webview/file-view-perf.test.ts
+++ b/ui/webview/file-view-perf.test.ts
@@ -1,0 +1,333 @@
+// The viewer's paint bracket, run FOR REAL: openFileView and openUrlView mount against the tree-aware DOM
+// stand-in file-view-notice.test.ts uses, a fake fetch lands the document, and the page's performance collector
+// (perf-telemetry.ts, on a fake clock through PerfDeps) is read back for what the paint recorded. Every paint of
+// the text body, the first when the bytes land, one more per Rendered/Raw toggle and one when the editor closes
+// (Save, Cancel and Escape leave through the same exit), is one `fileview:paint` frame of the collector the
+// page publishes as window.__rompPerf, so the cost of painting a large document shows in the hosting pane's
+// minute row and in `romp perf client`. The loader, the editor's surfaces, a picture, a PDF and the SVG Source
+// view are not paints of that kind and record nothing; a page with no collector, or one of another shape, paints
+// exactly as before. The stand-in has no DOM the sanitizer can run on, so the rendered view takes mdBlock's
+// bare-text fallback here; the bracket is what is under test, not the render.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { createPerfTelemetry, type PerfDeps } from "./perf-telemetry";
+
+// ── a DOM stand-in with a tree: parentNode, insertBefore, remove, getElementById over it, and the query
+// methods mdBlock's post-passes call (nothing to find: the fallback text carries no headings or fences) ──
+class El {
+  id = ""; title = ""; hidden = false; type = ""; disabled = false; tabIndex = -1; innerHTML = "";
+  href = ""; target = ""; rel = ""; spellcheck = true; value = "";
+  style: Record<string, string> = {};
+  dataset: Record<string, string> = {};
+  parentNode: El | null = null;
+  childNodes: Array<El | string> = [];
+  replaceCalls = 0;                                  // swaps of this node's children: one per paint of the body
+  private attrs = new Map<string, string>();
+  private classes = new Set<string>();
+  private listeners = new Map<string, Array<(ev: any) => void>>();
+  classList = {
+    add: (...c: string[]) => { for (const x of c) this.classes.add(x); },
+    remove: (...c: string[]) => { for (const x of c) this.classes.delete(x); },
+    toggle: (c: string, on?: boolean) => { if (on ?? !this.classes.has(c)) this.classes.add(c); else this.classes.delete(c); },
+    contains: (c: string) => this.classes.has(c),
+  };
+  constructor(public tagName: string) {}
+  get className(): string { return [...this.classes].join(" "); }
+  set className(v: string) { this.classes = new Set(v.split(/\s+/).filter(Boolean)); }
+  get textContent(): string { return this.childNodes.map((c) => (typeof c === "string" ? c : c.textContent)).join(""); }
+  set textContent(v: string) { this.replaceChildren(...(v === "" ? [] : [v])); }
+  get children(): El[] { return this.childNodes.filter((c): c is El => c instanceof El); }
+  get isConnected(): boolean { let n: El = this; while (n.parentNode) n = n.parentNode; return n === docBody; }
+  private adopt(c: El | string): void { if (c instanceof El) { c.remove(); c.parentNode = this; } }
+  appendChild<T extends El>(c: T): T { this.adopt(c); this.childNodes.push(c); return c; }
+  prepend(...cs: Array<El | string>): void { for (const c of cs) this.adopt(c); this.childNodes.unshift(...cs); }
+  insertBefore<T extends El>(c: T, ref: El | null): T {
+    if (ref && !this.childNodes.includes(ref)) throw new Error("insertBefore: the reference node is not a child of this node");
+    this.adopt(c);
+    const i = ref ? this.childNodes.indexOf(ref) : -1;
+    if (i < 0) this.childNodes.push(c); else this.childNodes.splice(i, 0, c);
+    return c;
+  }
+  replaceChildren(...cs: Array<El | string>): void {
+    this.replaceCalls++;
+    for (const c of this.childNodes) if (c instanceof El) c.parentNode = null;
+    this.childNodes = [];
+    for (const c of cs) this.adopt(c);
+    this.childNodes = [...cs];
+  }
+  remove(): void {
+    const p = this.parentNode;
+    if (!p) return;
+    const i = p.childNodes.indexOf(this);
+    if (i >= 0) p.childNodes.splice(i, 1);
+    this.parentNode = null;
+  }
+  contains(n: El): boolean { let x: El | null = n; while (x) { if (x === this) return true; x = x.parentNode; } return false; }
+  querySelectorAll(): El[] { return []; }
+  querySelector(): El | null { return null; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  removeAttribute(k: string): void { this.attrs.delete(k); }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? null; }
+  hasAttribute(k: string): boolean { return this.attrs.has(k); }
+  addEventListener(type: string, fn: (ev: any) => void): void {
+    const l = this.listeners.get(type) || [];
+    l.push(fn); this.listeners.set(type, l);
+  }
+  removeEventListener(type: string, fn: (ev: any) => void): void {
+    this.listeners.set(type, (this.listeners.get(type) || []).filter((f) => f !== fn));
+  }
+  focus(): void {}
+  dispatch(type: string, ev: Record<string, unknown> = {}): void {
+    for (const fn of [...(this.listeners.get(type) || [])]) fn({ type, target: this, preventDefault() {}, ...ev });
+  }
+  click(): void { this.dispatch("click"); }
+}
+const docBody = new El("body");
+function findById(n: El, id: string): El | null {
+  if (n.id === id) return n;
+  for (const c of n.childNodes) if (c instanceof El) { const hit = findById(c, id); if (hit) return hit; }
+  return null;
+}
+const win: any = new EventTarget();
+win.parent = win;
+(globalThis as any).window = win;
+(globalThis as any).document = {
+  createElement: (tag: string) => new El(tag),
+  createTextNode: (s: string) => s,
+  getElementById: (id: string) => findById(docBody, id),
+  querySelectorAll: () => [],                   // no bundle <script src>: the editor chunk cannot load, so Edit takes the plain textarea
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  body: docBody,
+};
+const store = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, String(v)); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+// ── fixtures: a notes-api world, synthetic throughout ──
+const ROOT = "/tmp/notes-api";
+const README = ROOT + "/docs/README.md";
+const FIG = ROOT + "/docs/fig.svg";
+const PAPER = ROOT + "/docs/paper.pdf";
+const TEXT = "# Notes API\n\nThe service and its tests.\n";
+const SVG_XML = '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>';
+const HREF = "http://notes-api.test/reports/run-1/evidence.md";
+const URL_DOC = "# Evidence\n\nThe web session's report.\n";
+type Served = { bytes: string | Uint8Array; type: string };
+const disk: Record<string, Served> = {
+  [README]: { bytes: TEXT, type: "text/plain; charset=utf-8" },
+  [FIG]: { bytes: SVG_XML, type: "image/svg+xml" },
+  [PAPER]: { bytes: new Uint8Array([0x25, 0x50, 0x44, 0x46]), type: "application/pdf" },
+};
+// The fetches the flows make: the kernel's /file (its Content-Type is the verdict: text, an SVG, a PDF; a text file
+// carries the faithful-UTF-8 and ns-mtime headers, so Edit arms), its /version (editing already allowed, so no
+// consent popup), and a same-origin document for the URL viewer, answered as a real Response so the streamed,
+// capped read runs as it does in a browser.
+(globalThis as any).fetch = (url: string) => {
+  if (url.startsWith("/version")) return Promise.resolve({ json: () => Promise.resolve({ fileEditing: true }) });
+  if (/^https?:/.test(url)) return Promise.resolve(new Response(URL_DOC, { status: 200, headers: { "Content-Type": "text/markdown; charset=utf-8" } }));
+  const p = decodeURIComponent((/[?&]path=([^&]*)/.exec(url) || [])[1] || "");
+  const f = disk[p];
+  assert.ok(f, "a fetch for a fixture file: " + url);
+  const headers = new Map([["Content-Type", f.type], ["X-Romp-Text-Utf8", "1"], ["X-Romp-Mtime-Ns", "1700000000000000000"]]);
+  return Promise.resolve({
+    ok: true, status: 200, headers: { get: (k: string) => headers.get(k) ?? null },
+    text: () => Promise.resolve(String(f.bytes)),
+    blob: () => Promise.resolve(new Blob([f.bytes as unknown as BlobPart], { type: f.type })),
+  });
+};
+/** Let every pending promise chain run: the fetch settles, a blob decodes, the editor chunk's rejection reaches its catch. */
+const settle = async () => { for (let i = 0; i < 8; i++) await new Promise((r) => setImmediate(r)); };
+
+let bound: Promise<typeof import("./file-view")> | null = null;
+function view(): Promise<typeof import("./file-view")> {
+  if (!bound) bound = import("./file-view").then((fv) => { fv.initFileView(() => {}); return fv; });
+  return bound;
+}
+
+/** A collector on a fake clock, as perf-telemetry.test.ts builds one, posting into `posted`. */
+function collector(app: string, posted: any[]) {
+  const clock = { t: 1000, wall: 1_700_000_000_000 };
+  const deps: PerfDeps = {
+    now: () => clock.t,
+    wallNow: () => clock.wall,
+    post: (m) => posted.push(m),
+    raf: null, caf: null, setInterval: null, observer: null, supportedEntryTypes: [],
+    heapBytes: () => null, domCount: () => null,
+    visible: () => true, hiddenPane: () => false,
+    ua: "chrome-desktop", pageUrl: "http://h:1/" + app,
+    windowEvents: null, documentEvents: null,
+  };
+  return { perf: createPerfTelemetry(app, deps), clock };
+}
+
+type Card = { body: El; btn: (label: string) => El };
+/** The card up now: its body and its title-bar buttons by label. */
+function card(): Card {
+  const wrap = docBody.children[docBody.children.length - 1];
+  assert.equal(wrap.id, "romp-fileview");
+  const root = wrap.children[0];
+  const bar = root.children[0];
+  const body = root.children[root.children.length - 1];
+  assert.equal(body.className, "fileview-body");
+  const acts = bar.children.find((c) => c.classList.contains("fileview-acts"))!;
+  const btn = (label: string) => { const b = acts.children.find((c) => c.tagName === "button" && c.textContent === label); assert.ok(b, "the " + label + " button"); return b!; };
+  return { body, btn };
+}
+/** Open the file and let the bytes land. Every open starts from the stored default: Rendered. */
+async function openFile(p: string): Promise<Card> {
+  const fv = await view();
+  store.clear();
+  fv.openFileView(p, null);
+  await settle();
+  return card();
+}
+/** Open the markdown URL and let the streamed read land. */
+async function openUrl(): Promise<Card> {
+  const fv = await view();
+  store.clear();
+  fv.openUrlView(HREF);
+  await settle();
+  return card();
+}
+const rows = (body: El) => body.children.map((c) => c.className);
+type Perf = ReturnType<typeof createPerfTelemetry>;
+const frames = (perf: Perf) => Object.keys(perf.snapshot().frames as object);
+const paints = (perf: Perf) => ((perf.snapshot().frames as Record<string, any>)["fileview:paint"]?.n ?? 0) as number;
+/** Every string a row carries, keys included, for the privacy walk. */
+function strings(v: unknown, at: string, out: string[]): string[] {
+  if (typeof v === "string") out.push(at + "=" + v);
+  else if (Array.isArray(v)) v.forEach((x, i) => strings(x, at + "[" + i + "]", out));
+  else if (v && typeof v === "object") for (const k of Object.keys(v as object)) { out.push(at + "." + k); strings((v as any)[k], at + "." + k, out); }
+  return out;
+}
+/** The one minute row the pane posted after `perf.tick()` a minute on, under `app`, with the paint alone in it. */
+function minuteRow(posted: any[], app: string, n: number): any {
+  const minutes = posted.filter((m) => m.what === "minute");
+  assert.equal(minutes.length, 1);
+  assert.equal(minutes[0].type, "clientDiag");
+  assert.equal(minutes[0].surface, "perf");
+  assert.equal(minutes[0].data.app, app, "counted under the pane that hosts the viewer");
+  assert.deepEqual(Object.keys(minutes[0].data.frames), ["fileview:paint"]);
+  assert.equal(minutes[0].data.frames["fileview:paint"].n, n);
+  return minutes[0].data;
+}
+
+test("a file: each paint of the text body is one fileview:paint frame of the page's collector, when the bytes land, per Rendered/Raw toggle, and when the editor closes", async () => {
+  const posted: any[] = [];
+  const { perf, clock } = collector("chat", posted);
+  win.__rompPerf = perf;
+  try {
+    const c = await openFile(README);
+    assert.deepEqual(rows(c.body), ["fileview-md"], "the markdown file opened Rendered");
+    assert.deepEqual(frames(perf), ["fileview:paint"], "the paint, and nothing else, was timed");
+    assert.equal(paints(perf), 1, "one paint: the loader that held the body before the bytes landed is not one");
+    let swaps = c.body.replaceCalls;
+    c.btn("Raw").click();
+    assert.deepEqual(rows(c.body), ["fileview-code"], "Raw repainted the body as the code view");
+    assert.equal(paints(perf), 2, "the toggle's paint counted too");
+    assert.equal(c.body.replaceCalls, swaps + 1, "the bracket ran the pass once: one swap of the body per paint");
+    swaps = c.body.replaceCalls;
+    c.btn("Rendered").click();
+    assert.deepEqual(rows(c.body), ["fileview-md"]);
+    assert.equal(paints(perf), 3);
+    assert.equal(c.body.replaceCalls, swaps + 1);
+    // Edit takes the body (no editor chunk here, so the plain textarea): the loader and the editor are not paints
+    c.btn("Edit").click();
+    await settle();
+    assert.deepEqual(rows(c.body), ["fileview-editor"], "the fallback editor holds the body");
+    assert.equal(paints(perf), 3, "entering the editor painted no text body");
+    swaps = c.body.replaceCalls;
+    c.btn("Cancel").click();
+    assert.deepEqual(rows(c.body), ["fileview-code"], "leaving the editor repaints the text body (Edit works on the Raw view)");
+    assert.equal(paints(perf), 4, "the repaint on leaving the editor is a paint");
+    assert.equal(c.body.replaceCalls, swaps + 1);
+    // the minute row the pane posts carries the bracket under the pane's own app, and no file path
+    clock.wall += 60_000;
+    perf.tick();
+    const d = minuteRow(posted, "chat", 4);
+    for (const s of strings(d, "data", [])) {
+      assert.ok(!s.includes("/"), "no slash: " + s);
+      assert.ok(!s.includes("notes-api") && !s.includes("README"), "no path: " + s);
+    }
+  } finally {
+    delete win.__rompPerf;
+  }
+});
+
+test("a URL document: the same bracket, when the bytes land and per toggle, under the hosting pane, with no host or document name in the row", async () => {
+  const posted: any[] = [];
+  const { perf, clock } = collector("feed", posted);
+  win.__rompPerf = perf;
+  try {
+    const c = await openUrl();
+    assert.deepEqual(rows(c.body), ["fileview-md"], "the document opened Rendered");
+    assert.deepEqual(frames(perf), ["fileview:paint"], "the paint, and nothing else, was timed");
+    assert.equal(paints(perf), 1, "one paint: the loader that held the body before the bytes landed is not one");
+    const swaps = c.body.replaceCalls;
+    c.btn("Raw").click();
+    assert.deepEqual(rows(c.body), ["fileview-code"]);
+    assert.equal(paints(perf), 2, "the toggle's paint counted too");
+    assert.equal(c.body.replaceCalls, swaps + 1, "one swap of the body per paint");
+    clock.wall += 60_000;
+    perf.tick();
+    const d = minuteRow(posted, "feed", 2);
+    for (const s of strings(d, "data", [])) {
+      assert.ok(!s.includes("/"), "no slash: " + s);
+      assert.ok(!s.includes("notes-api") && !s.includes("evidence"), "no host or document name: " + s);
+    }
+  } finally {
+    delete win.__rompPerf;
+  }
+});
+
+test("a picture, a PDF and the SVG Source view are not paints of the text body: the collector records no frame", async () => {
+  const posted: any[] = [];
+  const { perf } = collector("chat", posted);
+  win.__rompPerf = perf;
+  try {
+    const svg = await openFile(FIG);
+    assert.deepEqual(rows(svg.body), ["fileview-imgbox"], "an SVG is shown as a picture");
+    assert.deepEqual(frames(perf), [], "a picture is not a paint of the text body");
+    svg.btn("Source").click();
+    await settle();
+    assert.deepEqual(rows(svg.body), ["fileview-code"], "the Source view is the highlighted XML, from the fetched bytes");
+    assert.deepEqual(frames(perf), [], "nor is the Source view");
+    const pdf = await openFile(PAPER);
+    assert.deepEqual(rows(pdf.body), ["fileview-frame"], "a PDF is the browser's own viewer in a frame");
+    assert.deepEqual(frames(perf), [], "nor is a PDF");
+  } finally {
+    delete win.__rompPerf;
+  }
+});
+
+test("no collector on the page, or one of another shape: the paint runs untimed and the body is the same", async () => {
+  const posted: any[] = [];
+  const { perf } = collector("feed", posted);
+  win.__rompPerf = perf;
+  let timed: Card;
+  try { timed = await openFile(README); } finally { delete win.__rompPerf; }
+  assert.equal(paints(perf), 1);
+  const shown = { rows: rows(timed.body), text: timed.body.textContent };
+  // nothing published
+  const bare = await openFile(README);
+  assert.deepEqual(rows(bare.body), shown.rows);
+  assert.equal(bare.body.textContent, shown.text, "the same paint, untimed");
+  bare.btn("Raw").click();
+  assert.deepEqual(rows(bare.body), ["fileview-code"]);
+  assert.equal(paints(perf), 1, "the detached collector saw none of it");
+  // a slot holding something that is not the collector (another script's object): left alone, no throw
+  win.__rompPerf = { snapshot: () => ({}) };
+  try {
+    const odd = await openFile(README);
+    assert.deepEqual(rows(odd.body), shown.rows);
+    assert.equal(odd.body.textContent, shown.text);
+    const url = await openUrl();
+    assert.deepEqual(rows(url.body), ["fileview-md"], "the URL view too");
+  } finally {
+    delete win.__rompPerf;
+  }
+});

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -125,6 +125,23 @@ function el(tag: string, cls?: string): HTMLElement {
   return e;
 }
 
+// ── the paint bracket ──────────────────────────────────────────────────────────────────────────────
+// Runs one pass of the viewer as a timed frame of the page's performance collector (perf-telemetry.ts; the
+// page publishes it as window.__rompPerf, federation.js on a kernel page and the pane's own bundle in VS Code),
+// under the type `fileview:<why>`; one pass is timed today, `paint`, the text body painted anew, in the file
+// view and the URL view alike. The viewer receives no frames of its own, so without this the cost of painting
+// a large document (marked, the sanitizer, the highlight, the link pass) reached the pane's minute row only as
+// a long animation frame attributed to whichever callback ran it, and `romp perf client` could not name the
+// viewer.
+// Counted under the pane that hosts the viewer (app chat or feed), with the main-thread-free sample the
+// collector takes after an outermost bracket. No collector on the page (a page without one, a stand-in), or a
+// slot holding something of another shape: the pass runs untimed, exactly as before.
+function perfTimed<T>(why: string, fn: () => T): T {
+  let p: any = null;
+  try { p = typeof window !== "undefined" ? (window as any).__rompPerf : null; } catch { p = null; }
+  return p && typeof p.timed === "function" ? p.timed("fileview:" + why, fn) : fn();
+}
+
 // ── text size (A−, A+, Ctrl/Cmd + wheel) ───────────────────────────────────────────────────────────
 // The viewer's text sizes, as percentages of the page's own size: a FIXED table with ends, not a free
 // multiplier, so the buttons, the wheel and the stored value all land on the same few sizes and a size can
@@ -881,8 +898,11 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
       return;
     }
     if (text === null || editing) return;   // loading, or the textarea owns the body right now
-    body.replaceChildren(rendered ? mdBlock(text, { kind: "file", path, sid: sid || null }) : codeBlock(text, path, true));
-    if (rendered) stampBodyWidth();           // a fresh root's tables take the width last reported (the property sits on the tables)
+    perfTimed("paint", () => {                // the paint, as one fileview:paint frame of the page's collector (perfTimed above)
+      if (text === null) return;              // never taken (the guard above): a let's narrowing does not reach into the closure
+      body.replaceChildren(rendered ? mdBlock(text, { kind: "file", path, sid: sid || null }) : codeBlock(text, path, true));
+      if (rendered) stampBodyWidth();         // a fresh root's tables take the width last reported (the property sits on the tables)
+    });
     if (rendered && pendingFrag) {
       const h = pendingFrag; pendingFrag = null;
       requestAnimationFrame(() => { if (wrap.isConnected) scrollToFragment(body, h); });
@@ -1283,11 +1303,14 @@ export function openUrlView(href: string): void {
     }
     textSize.sync();                                   // shown once the document's text is up
     if (text === null) return;                         // the loader holds the body until the bytes land
-    body.replaceChildren(fmt.md === "rendered"
-      ? mdBlock(text, { kind: "url", href: loc })      // relative refs resolve against where it LIVES
-      : codeBlock(text, parts.base, true));            // basename → langFor → markdown highlighting
-    landFragment();                                    // after the paint, and only a rendered one lands
-    if (fmt.md === "rendered") stampBodyWidth();       // a fresh root's tables take the width last reported
+    perfTimed("paint", () => {                         // the paint, as one fileview:paint frame of the page's collector (perfTimed above)
+      if (text === null) return;                       // never taken (the guard above): a let's narrowing does not reach into the closure
+      body.replaceChildren(fmt.md === "rendered"
+        ? mdBlock(text, { kind: "url", href: loc })    // relative refs resolve against where it LIVES
+        : codeBlock(text, parts.base, true));          // basename → langFor → markdown highlighting
+      landFragment();                                  // after the paint, and only a rendered one lands (it schedules the scroll)
+      if (fmt.md === "rendered") stampBodyWidth();     // a fresh root's tables take the width last reported
+    });
   };
   renderBody();
 

--- a/ui/webview/perf-telemetry.test.ts
+++ b/ui/webview/perf-telemetry.test.ts
@@ -512,6 +512,40 @@ test("long frames: distinct attribution keys are capped per minute; the overflow
   assert.equal(s.loaf.n, 2);
 });
 
+test("a chat minute with the viewer's paint bracket: fileview:paint with the pass cost, the free sample after it, the long frames the pane sees; no string carries a slash, a query, a path or a session id", () => {
+  // The file viewer times each paint of a shown file's text body through the hosting pane's collector (file-view.ts
+  // perfTimed, run for real in file-view-perf.test.ts); this is the row that pass produces, with the long frame the
+  // browser attributes to the pane's bundle and to an inline image load off the /file route, which carries a path.
+  const SID = "33333333-4444-5555-6666-777777777777";
+  const h = harness({ pageUrl: "http://h:1/chat", observer: FakeObserver as any, supportedEntryTypes: ["long-animation-frame"] });
+  const p = createPerfTelemetry("chat", h.deps);
+  p.timed("fileview:paint", () => { h.clock.t += 180; });   // a large file painted
+  h.runRafs(); h.clock.t += 40; h.runRafs();                // two animation frames later: the free sample
+  FakeObserver.deliver([{ startTime: 1000, duration: 190, blockingDuration: 140, scripts: [
+    { sourceURL: "http://h:1/dist/chat.js?v=1757100000&sid=" + SID, sourceFunctionName: "paintAll", sourceCharPosition: 9000, invoker: "Window.requestAnimationFrame", duration: 150 },
+    { sourceURL: "http://h:1/chat?token=abc&sid=" + SID, sourceFunctionName: "", sourceCharPosition: 4000, invoker: "IMG[src=/file?path=/repo/notes-api/docs/plot.png&sid=" + SID + "].onload", duration: 30 },
+  ] }]);
+  h.clock.wall += 60_000;
+  p.tick();
+  const rows = minuteRows(h.posted);
+  assert.equal(rows.length, 1);
+  const d = rows[0].data;
+  assert.equal(d.app, "chat");
+  assert.deepEqual(d.frames["fileview:paint"], stat(1, 180, 180, 1, 1, hist({ 8: 1 })));    // 128-256 ms
+  assert.deepEqual(d.free, { n: 1, p50: 40, p90: 40, max: 40 });
+  assert.equal(d.loaf.n, 1);
+  assert.deepEqual(d.loaf.top.map((t: any) => t.k), ["chat.js:paintAll@9000", "page:(anonymous)@4000"]);
+  assert.deepEqual(d.loaf.top.map((t: any) => t.inv), ["Window.requestAnimationFrame", "IMG[src].onload"]);
+  assert.equal(slowRows(h.posted).length, 1, "a 180 ms paint is a slow frame too, with the report's attribution");
+  // the privacy contract, over the minute row and the slowframe row: every string is a code identifier (so no
+  // slash, no query), and neither the session id nor a path word the inputs carried appears anywhere, keys included
+  const both = h.posted.map((m) => m.data);
+  assertIdentifiersOnly(both);
+  const text = JSON.stringify(both);
+  assert.ok(!text.includes(SID) && !text.includes("33333333"), "no session id in either row");
+  assert.ok(!text.includes("notes-api") && !text.includes("plot.png"), "no path in either row");
+});
+
 test("longtask fallback: no long-animation-frame support observes longtask, blocking is time over 50 ms, no attribution", () => {
   const h = harness({ observer: FakeObserver as any, supportedEntryTypes: ["longtask", "mark"] });
   const p = createPerfTelemetry("feed", h.deps);

--- a/ui/webview/perf-telemetry.ts
+++ b/ui/webview/perf-telemetry.ts
@@ -6,6 +6,9 @@
 // window.__rompPerf that federation.js publishes before it runs); federation times its own merge and
 // dispatch of every frame as `fed:<type>`, nested outside the pane's handler, and the collector records
 // each level's OWN time (the outer minus what its inner brackets took), so the per-type figures add up.
+// The file viewer (file-view.ts perfTimed) brackets each paint of a shown document's text body, a file on disk
+// or a markdown URL, as `fileview:paint` under the pane that hosts it (chat or feed), so a large document's paint
+// shows per minute beside the pane's frames.
 // Per frame type the module keeps a count, the summed and maximum handler time, exact counts over 16.7 ms
 // (one dropped frame at 60 Hz) and at or over 100 ms, and a fixed log2 histogram (one increment per frame),
 // which is additive across minutes so `romp perf client` computes true window percentiles. Two


### PR DESCRIPTION
The file viewer times each paint of a shown document's text body, a file on disk or a markdown URL, as a `fileview:paint` frame of the hosting pane's browser telemetry, so `romp perf client` names the viewer when painting a large document stalls a pane.

## Design

- **What was missing.** The browser telemetry (`ui/webview/perf-telemetry.ts`) times the frames a pane receives. The viewer receives none: it paints the text body when the document's bytes land, on each Rendered/Raw toggle and when the editor closes (Save, Cancel and Escape leave through one exit), inside a fetch callback or a click handler. The cost of painting a large document (marked, the sanitizer, the highlight, the link pass) reached the pane's minute row only as a long animation frame attributed to whichever callback ran it, and no row named the viewer.
- **The bracket.** Both paints in `file-view.ts`, the file view's `renderBody` and the URL view's, run through `perfTimed("paint", ...)`, a module-private helper that reads `window.__rompPerf` at call time and hands the pass to its `timed()` under the type `fileview:paint` (the `fileview:` prefix leaves room for other viewer passes). It is the bracket a frame handler gets, so the paint has a count, milliseconds, the log2 histogram, the slowframe row at 100 ms and the main-thread-free sample the collector takes after an outermost bracket. One key for both views: a reader of `romp perf client` wants to know the viewer painted, not which of its two entry points did.
- **Under the hosting pane, not a collector of the viewer's own.** The collector is one per page (`installPerfTelemetry` returns the page's existing one; `federation.js` publishes it on a kernel page, the pane's own bundle in VS Code) and the viewer is a modal inside the chat and feed documents, so its paints belong in that pane's row; `romp perf client` already renders any frame type per pane. The paint appears under app `chat` or `feed`, beside the pane's frame types.
- **Inside and outside the bracket.** Inside: the swap of the body (`body.replaceChildren(...)`) and the width stamp that follows a rendered paint (a property write on the fresh tables); in the URL view also the fragment-landing check, which only schedules a frame. Outside: the scroll to a fragment (a `requestAnimationFrame`), the loader that holds the body before the bytes land, the editor's surfaces (the loader while the editor chunk loads, the editor itself), and the picture, PDF and SVG Source views, which are not paints of the text body. A text-size step or a width change reflows the rendered document through the sheets; the width watch's report is the same per-table property write, nothing to time.
- **Unchanged.** The `mdBlock(text, { kind: "file", path, sid: sid || null })`, `mdBlock(text, { kind: "url", href: loc })` and `codeBlock(text, parts.base, true)` call texts keep their form (md-url-view.test.ts pins them), the stamp still follows the file view's paint directly and the URL view's fragment landing (file-view.test.ts pins that), and the landing still follows the URL view's paint (md-url-view.test.ts). A page without a collector, or one whose `__rompPerf` slot holds an object of another shape, paints untimed, as before; the helper never throws into the viewer.
- **Rows.** The bracket adds one frame-type key to the pane's row; nothing else in the row changes. The key is an identifier, so the row still carries no file path, URL or host; the long-frame attribution an image load from the viewer may produce (`IMG[src=/file?path=...]`) was already reduced to `IMG[src]` by the collector.
- **Docs.** The telemetry section of `docs/reference.md` and the module header name the bracket.

## Tests

- `ui/webview/file-view-perf.test.ts` (new, 4 cases) runs `openFileView` and `openUrlView` for real over the DOM stand-in `file-view-notice.test.ts` uses, with a collector on a fake clock (`createPerfTelemetry("chat", deps)`) in `window.__rompPerf`, a fake `/file` that lands a markdown file, an SVG or a PDF, and a real `Response` for the markdown URL so the streamed read runs. The file case asserts the collector's frames after the bytes land are exactly `["fileview:paint"]` with `n` 1, `n` 2 after Raw, 3 after Rendered, still 3 while the editor holds the body and 4 after Cancel; that each paint is exactly one swap of the body (a bracket that ran the pass twice fails here); and the minute row under app `chat` with that one key and no slash or path in any string. The URL case asserts the same for a markdown URL under app `feed`, with no host or document name in the row. Before the change both fail on their first frames assertion: `frames` is `{}`, since neither `renderBody` called `timed()`. The third case asserts a picture, a PDF and the SVG Source view record no frame (green before; it pins the negative claims above). The fourth asserts the same body rows and text with no collector and with a foreign object in the slot, for both views, and that the detached collector saw nothing.
- `ui/webview/perf-telemetry.test.ts` gains one case: a chat minute with a 180 ms `fileview:paint`, the free sample after it and a long frame attributed to the pane's bundle and to an inline image load off `/file` with a session id in the URL; it asserts the stat, the free sample, the two attribution keys and invokers, the slowframe row, and (through the file's `assertIdentifiersOnly`) that every string in either row is a code identifier and none carries the session id or a path. Green before the change: it pins the privacy contract of the row the viewer now contributes to.
- The existing viewer pins hold: `file-view.test.ts` (the paint-then-stamp order in both views), `md-url-view.test.ts` (the mdBlock and codeBlock call texts, the landing after the paint), `file-view-text-size.test.ts` (the renderBody slice), `md-sanitize.test.ts`, `fileview-chip`, `file-view-notice`, `fileview-parity`, `pdf-new-tab`, `file-view-links` and `file-view-fence-source`: 196 tests across the twelve viewer, sanitizer and telemetry files, 196 pass.
- `npm run typecheck` clean. Full `npm test` on the head (`node --test` over every bundle, with the timeline-tags-scale file run alone as a second leg): 4101 tests, 4101 pass, 0 fail.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
