### PR TITLE
Judges: a Fast judging setting adds Claude Code's fast-mode opt-in to Opus judge calls

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -459,6 +459,8 @@ permission/API-error floors: one interrupt at a time, the present event first.
 
 - Toggles: `CLOSER_ON`, `GROUPER_ON`, `DISTILLER_ON`, `CONSOLIDATE_ON`.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
+  Fast judging: `STATE/judge-fast` (`on` | `off`, off by default; read per
+  call, and the fast-mode opt-in rides only a call whose model is Opus).
   Pool width: `STATE/judge-concurrency` (the gear's Judge concurrency, 1..16,
   read fresh each pass; empty = `ROMP_JUDGE_CONCURRENCY` as read at load,
   else 6). Every pool reads it at call time (`_conc`, or `_judge_concurrency()`
@@ -486,7 +488,8 @@ permission/API-error floors: one interrupt at a time, the present event first.
   the sessions the evidence gate ran. Outside
   a pass frame (`romp-judge --plan`) the evidence gate stamps nothing, and
   the inner gate does the skipping.
-- Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt),
+- Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt, and
+  the CLI's `fast_mode_state` as `fast`),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
   call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable,
   task-key-collision (a duplicated to-do mirror key, reconciled per node

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -485,6 +485,24 @@ through to `install.sh`:
   and follows to every connected machine like the other judge settings; its
   Default option clears the setting back to the variable, else 6.
 
+### Fast judging
+
+- **Fast judging** (the gear's Judges section; off by default) runs the judges
+  in Claude Code's fast mode, an Opus-only research preview billed at a premium
+  over standard Opus rates. The setting is read per call: a judge call whose
+  model is Opus, by the bare alias or a pinned Opus version, carries the CLI's
+  fast-mode opt-in in its per-call settings; a call on any other model runs
+  exactly as before, so with every tier on Sonnet and Haiku the setting changes
+  nothing until a tier is pinned to Opus. Fast requests draw on fast mode's own
+  rate limits, the pool your sessions' fast toggles share. Whether fast engaged
+  is the CLI's answer, per account (an account with extra usage turned off, or
+  an organisation with fast mode disabled, reports it off with the setting on):
+  each row of `judge-usage.jsonl` keeps that answer in its `fast` field (`on`,
+  `off` or `cooldown`; `null` when the CLI reported none), so a checkbox that
+  reads on beside rows that read off names the account, not the setting. Like
+  the other judge settings, a change applies on the judges' next pass with no
+  restart and follows to every connected machine.
+
 ### Session backends
 
 - **Enable Claude Code tmux backend** (the gear's Updates & debug section; off

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -243,6 +243,8 @@ def _index_effort():  return _state_str("index-effort", "")
 def _judge_engine():  return _state_str("judge-engine", "claude")   # "claude" | "codex" — which model
 #   harness runs the judges (docs/codex.md §judges). "codex" lets a machine with no Claude login keep
 #   the board thinking: every judge becomes a one-shot `codex exec` billing the machine's codex login.
+def _judge_fast():    return _state_str("judge-fast", "off") == "on"   # gear "Fast judging": the CLI's fast-mode
+#   opt-in rides every judge call whose model is Opus (_judge_cmd); off by default. Read per call, like the tiers.
 INDEX_EFFORT_DEFAULT = "low"   # the index tier's cost lever on models that take --effort (2026-09-01; see _judge_env)
 
 
@@ -854,12 +856,26 @@ def _judge_cmd(model, sys_prompt, effort=None, auth=None):
            "--output-format", "json"]                 # stdout = {"result", "usage", "duration_ms", "total_cost_usd"}
     if effort:
         cmd += ["--effort", effort]
+    # The per-call settings layer. `--settings` takes ONE value (a path or a JSON string), so every key the
+    # call needs rides one overlay; --safe-mode drops only the auto-discovered settings, an explicit
+    # --settings still loads. Two keys can ride it:
+    overlay = {}
+    if _judge_fast() and _model_family_version(model)[0] == "opus":
+        # Fast judging (the gear's Judges section, off by default): the CLI refuses fast mode to a
+        # non-interactive client unless the flag-settings layer carries this exact key, the same opt-in a
+        # fast-picked session's launch uses (sdk_backend.flag_settings_path), and fast mode is an Opus-only
+        # preview, so the key rides only a call whose model reads as the opus family: the bare alias or a
+        # pinned version id (a tier pinned to a version id reaches here with that id). Whether fast then
+        # engaged is the CLI's answer, per account: the envelope's fast_mode_state, kept on the usage row.
+        overlay["fastMode"] = True
     if auth == "login":
         # A login-billed call must not bill the key (2026-09-08): in the CLI's precedence apiKeyHelper outranks
         # every login form, so the per-call settings layer disables the helper. The empty string is the value
         # the CLI takes as unset (null falls through to the settings files; verified on 2.1.257), the same
         # lever a login-picked session's launch uses (sdk_backend.flag_settings_path).
-        cmd += ["--settings", '{"apiKeyHelper": ""}']
+        overlay["apiKeyHelper"] = ""
+    if overlay:
+        cmd += ["--settings", json.dumps(overlay)]
     return cmd
 
 
@@ -1484,6 +1500,8 @@ def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
                                 "in": u.get("input_tokens"), "out": u.get("output_tokens"),
                                 "cache_w": u.get("cache_creation_input_tokens"),
                                 "cache_r": u.get("cache_read_input_tokens"),
+                                "fast": wrap.get("fast_mode_state"),   # the CLI's word on whether fast mode engaged
+                                #   ("on" | "off" | "cooldown"; null when the envelope carries none): Fast judging's readback
                                 "cost": wrap.get("total_cost_usd")}) + "\n")
     except Exception:
         pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1137,6 +1137,7 @@ def _version_info():
             "commentEffort": jd._state_str("comment-effort", "session"),
             "commentFast": jd._state_str("comment-fast", "session"),
             "tmuxBackend": jd._state_str("tmux-backend", "off"),   # T288: "on" offers Claude Code (tmux) in the picker and the gear
+            "judgeFast": jd._state_str("judge-fast", "off"),   # RAW "on" | "off": Fast judging, the fast-mode opt-in on Opus judge calls
             # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
@@ -1156,7 +1157,8 @@ def _version_info():
                          "commentModel": jd._state_str("comment-model", "session"),
                          "commentEffort": jd._state_str("comment-effort", "session"),
                          "commentFast": jd._state_str("comment-fast", "session"),
-                         "tmuxBackend": jd._state_str("tmux-backend", "off")},
+                         "tmuxBackend": jd._state_str("tmux-backend", "off"),
+                         "judgeFast": jd._state_str("judge-fast", "off")},
             # every gt-gated store's last-applied gesture stamp (epoch-ms ints, nothing path-shaped):
             # the gear stamps its next gesture above these instead of trusting the device clock.
             # Top-level, not lifted into /tunnels rows — a remote's newer stamp reaches the dashboard
@@ -40066,6 +40068,11 @@ def _set_comment_fast(v, gt=None):   return _set_judge_state("comment-fast", v, 
 # ids and the protocol are unchanged. Rides the judge-knob machinery (validated, stamped, propagated to
 # every linked kernel: the 2026-08-14 gear rule, one value across machines).
 def _set_tmux_backend(v, gt=None):   return _set_judge_state("tmux-backend", v, {"on", "off"}, gt=gt)
+# Fast judging (the gear's Judges section): "on" runs every judge call whose model is Opus in the CLI's fast
+# mode (jd._judge_cmd adds the flag-settings opt-in per call; a call on any other model is untouched); off by
+# default. Fast mode bills Opus at a premium and draws on fast mode's own rate limits, so it is a deliberate
+# pick. Rides the judge-knob machinery: validated, stamped, propagated to every linked kernel.
+def _set_judge_fast(v, gt=None):     return _set_judge_state("judge-fast", v, {"on", "off"}, gt=gt)
 
 
 # The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
@@ -40090,7 +40097,8 @@ _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_i
                          # /judge-settings is the tunnel-side propagation that already does it
                          ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
                          ("commentFast", _set_comment_fast),
-                         ("tmuxBackend", _set_tmux_backend))   # T288: the tmux backend's offer, "on" | "off"
+                         ("tmuxBackend", _set_tmux_backend),   # T288: the tmux backend's offer, "on" | "off"
+                         ("judgeFast", _set_judge_fast))       # Fast judging, "on" | "off"
 
 # The per-field PICK STAMPS this leg carried from 2026-08-30 (each field's STATE-file mtime in a
 # body "stamps" dict, preserved by utime at the receiver — the distill-pick stomp fix) are
@@ -40142,7 +40150,8 @@ def _apply_judge_settings(body):
             "commentModel": jd._state_str("comment-model", "session"),
             "commentEffort": jd._state_str("comment-effort", "session"),
             "commentFast": jd._state_str("comment-fast", "session"),
-            "tmuxBackend": jd._state_str("tmux-backend", "off")}
+            "tmuxBackend": jd._state_str("tmux-backend", "off"),
+            "judgeFast": jd._state_str("judge-fast", "off")}
 
 
 def _propagate_judge_settings(body):
@@ -40353,7 +40362,7 @@ def _adopt_peer_settings(host, rver):
 _GT_STORES = ("auto-nudge", "compact-suggest", "file-editing", "update-mode", "thinking-summaries",
               "judge-model", "index-model", "judge-effort", "index-effort", "judge-concurrency",
               "distill-model", "distill-effort", "comment-model", "comment-effort", "comment-fast",
-              "tmux-backend")
+              "tmux-backend", "judge-fast")
 
 
 def _setting_stored_gt(name):
@@ -52754,6 +52763,21 @@ class Handler(BaseHTTPRequestHandler):
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
                                  args=({"tmuxBackend": _tbv, "gt": _jgt},), daemon=True).start()
+            else:
+                _tell_stale_gesture(client, msg)
+        elif msg and msg.get("type") == "setJudgeFast" and msg.get("enabled") is not None:
+            # gear "Fast judging": a checkbox, stored as on/off and read by the judges per call (jd._judge_fast).
+            # The boolean is checked like its siblings' (_as_bool), and a malformed frame is refused with a
+            # warn, unwritten; an applied pick fans out to every linked kernel under its gesture stamp.
+            _jfe, ferr = _as_bool(msg.get("enabled"), "enabled")
+            if ferr:
+                _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
+                return
+            _jfv = "on" if _jfe else "off"
+            _jgt = _set_judge_fast(_jfv, gt=_gesture_ms(msg))
+            if _jgt is not None:
+                threading.Thread(target=_propagate_judge_settings,
+                                 args=({"judgeFast": _jfv, "gt": _jgt},), daemon=True).start()
             else:
                 _tell_stale_gesture(client, msg)
         else:

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -263,6 +263,26 @@ class JudgeArgvBilling(_JudgeAuthBase):
             self.assertNotIn("--settings", jd._judge_cmd("sonnet", "SYS", None, auth=auth), repr(auth))
         self.assertNotIn("--settings", jd._judge_cmd("sonnet", "SYS", None), "the default: no auth argument")
 
+    def test_a_fast_login_billed_call_rides_one_overlay_with_both_keys(self):
+        # `--settings` takes ONE value. With Fast judging on (STATE/judge-fast "on"), an Opus login-billed call
+        # carries the fastMode opt-in and the helper suppression in one JSON overlay; a login-billed call on a
+        # model that cannot run fast keeps HELPER_OFF byte for byte; a key-billed or unpicked Opus call carries
+        # the opt-in alone, and the helper key never appears in it.
+        (jd.STATE / "judge-fast").write_text("on")
+        jd._state_cache.clear()
+        try:
+            cmd = jd._judge_cmd("opus", "SYS", None, auth="login")
+            self.assertEqual(cmd.count("--settings"), 1, "one overlay, never two --settings")
+            self.assertEqual(json.loads(cmd[-1]), {"fastMode": True, "apiKeyHelper": ""})
+            self.assertEqual(jd._judge_cmd("sonnet", "SYS", None, auth="login")[-2:], HELPER_OFF)
+            for auth in ("key", None):
+                cmd = jd._judge_cmd("opus", "SYS", None, auth=auth)
+                self.assertEqual(cmd.count("--settings"), 1, repr(auth))
+                self.assertEqual(json.loads(cmd[-1]), {"fastMode": True}, repr(auth))
+        finally:
+            (jd.STATE / "judge-fast").unlink()
+            jd._state_cache.clear()
+
 
 class RuntimeJudgeBilling(_JudgeAuthBase):
     """_judge_run's pre-launch path: the usage gate and the codex engine touch no Anthropic credential."""
@@ -401,7 +421,7 @@ class JudgeRunBilling(_JudgeAuthBase):
     """_judge_run end to end with a fake CLI: the envelope drives the latch, the env and argv carry the
     billing. A helper is staged unless a test says otherwise, so the unpicked default is the key."""
 
-    def _run(self, envelope, auth_reg=None, helper=True):
+    def _run(self, envelope, auth_reg=None, helper=True, model="sonnet"):
         if helper:
             self._helper()
         if auth_reg:
@@ -418,7 +438,7 @@ class JudgeRunBilling(_JudgeAuthBase):
         jd.subprocess.run = fake_run
         try:
             with patch.object(jd, "_judge_engine", return_value="claude"):
-                out = jd._judge_run("sonnet", "SYS", "u", judge="planner", tier="triage")
+                out = jd._judge_run(model, "SYS", "u", judge="planner", tier="triage")
         finally:
             jd.subprocess.run = saved
         return out, seen
@@ -468,6 +488,32 @@ class JudgeRunBilling(_JudgeAuthBase):
         self.assertEqual(seen["env"].get("CLAUDE_CODE_OAUTH_TOKEN"), "synthetic-login-token")
         i = seen["cmd"].index("--settings")
         self.assertEqual(seen["cmd"][i:i + 2], HELPER_OFF)
+
+    def test_a_fast_login_pick_on_opus_launches_with_one_overlay_and_logs_the_readback(self):
+        # end to end through _judge_run: Fast judging on, a login pick, an Opus model. The child gets ONE
+        # --settings overlay carrying both keys, the login tokens, no key; the usage row keeps the envelope's
+        # fast_mode_state, the CLI's own word on whether fast engaged.
+        jd._LOGIN_AUTH_ENV_FN = lambda: {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-login-token"}
+        (jd.STATE / "judge-fast").write_text("on")
+        jd._state_cache.clear()
+        saved_usage = jd.USAGE
+        jd.USAGE = jd.STATE / ("judge-usage-%s.jsonl" % os.getpid())
+        try:
+            with patch.dict(os.environ, {"ANTHROPIC_API_KEY": AMBIENT}):
+                out, seen = self._run({"result": "ok", "usage": {}, "duration_ms": 3, "fast_mode_state": "on"},
+                                      auth_reg="login", model="opus")
+            rows = [json.loads(ln) for ln in jd.USAGE.read_text().splitlines()]
+        finally:
+            jd.USAGE = saved_usage
+            (jd.STATE / "judge-fast").unlink()
+            jd._state_cache.clear()
+        self.assertEqual(out, "ok")
+        self.assertNotIn("ANTHROPIC_API_KEY", seen["env"])
+        self.assertEqual(seen["env"].get("CLAUDE_CODE_OAUTH_TOKEN"), "synthetic-login-token")
+        self.assertEqual(seen["cmd"].count("--settings"), 1)
+        self.assertEqual(json.loads(seen["cmd"][seen["cmd"].index("--settings") + 1]),
+                         {"fastMode": True, "apiKeyHelper": ""})
+        self.assertEqual([(r["model"], r["fast"]) for r in rows], [("opus", "on")])
 
 
 class KeylessKeyBilledCalls(_JudgeAuthBase):

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -35,7 +35,7 @@ class ApplySettings(unittest.TestCase):
     def setUp(self):
         for f in ("judge-model", "index-model", "judge-effort", "index-effort",
                   "distill-model", "distill-effort",
-                  "comment-model", "comment-effort", "comment-fast"):
+                  "comment-model", "comment-effort", "comment-fast", "judge-fast"):
             for name in (f, f + ".gt"):   # the value and its gesture-stamp sidecar (gesture ordering)
                 try:
                     (km.jd.STATE / name).unlink()
@@ -72,6 +72,20 @@ class ApplySettings(unittest.TestCase):
         res = km._apply_judge_settings({"commentModel": "gpt-99", "commentFast": "true"})
         self.assertEqual((res["commentModel"], res["commentFast"]), ("claude-opus-5", "on"),
                          "garbage never reaches the files or `claude --model`")
+
+    def test_judge_fast_applies_and_reports_raw(self):
+        # Fast judging rides the same cross-kernel door as the judge tiers: "on" | "off", off by default,
+        # answered RAW, a value outside the pair ignored and visible in the ack
+        self.assertEqual(km._apply_judge_settings({})["judgeFast"], "off")
+        res = km._apply_judge_settings({"judgeFast": "on"})
+        self.assertEqual(res["judgeFast"], "on")
+        self.assertEqual((km.jd.STATE / "judge-fast").read_text(), "on")
+        res = km._apply_judge_settings({"judgeFast": "true"})
+        self.assertEqual(res["judgeFast"], "on", "a value outside on|off never reaches the file")
+        self.assertEqual((km.jd.STATE / "judge-fast").read_text(), "on")
+        res = km._apply_judge_settings({"judgeFast": "off"})
+        self.assertEqual(res["judgeFast"], "off")
+        self.assertEqual((km.jd.STATE / "judge-fast").read_text(), "off")
 
     def test_an_older_propagated_value_never_overwrites_a_newer_pick(self):
         # THE REPORTED STOMP (the user 2026-08-30, whose Distilling pick kept resetting): any
@@ -226,9 +240,10 @@ class OneHopNeverALoop(unittest.TestCase):
                      'args=({"commentModel": str(msg["model"]), "gt": _jgt},)',
                      'args=({"commentEffort": str(msg["effort"]), "gt": _jgt},)',
                      'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)',
-                     'args=({"tmuxBackend": _tbv, "gt": _jgt},)'):   # T288
+                     'args=({"tmuxBackend": _tbv, "gt": _jgt},)',   # T288
+                     'args=({"judgeFast": _jfv, "gt": _jgt},)'):    # Fast judging
             self.assertIn(frag, self.src, frag)
-        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 11,
+        self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 12,
                                 "every judge-tier fan-out is gated on the pick actually applying")
 
     def test_the_gear_copy_says_the_pick_follows(self):

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -8,9 +8,14 @@ Crucially the model vocabulary lives in ONE place: the kernel's MODEL_CHOICES / 
 and shared by the chat statusline picker, the timeline lane picker, AND these judge dropdowns. Defaults are
 `claude --model` aliases (haiku / sonnet) that auto-track the latest of each family.
 """
+import contextlib
 import inspect
+import io
+import json
 import os
 import tempfile
+import threading as _real_threading
+import types
 import unittest
 from romp_load import load_source
 
@@ -156,6 +161,147 @@ class JudgeSettings(unittest.TestCase):
         ksrc = inspect.getsource(km)
         for t in ("setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort"):
             self.assertIn('msg.get("type") == "%s"' % t, ksrc)
+
+
+T_OLD, T_NEW = 1_700_000_000_000, 1_700_000_360_000
+HELPER_OFF = ["--settings", '{"apiKeyHelper": ""}']   # the login-billed call's helper suppression, verbatim
+
+
+class _InlineThread:
+    """threading.Thread stand-in: the propagation fan-out runs inline, so a test sees every call at once."""
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+        self._target, self._args, self._kwargs = target, args, (kwargs or {})
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+class FastJudging(unittest.TestCase):
+    """Fast judging: STATE/judge-fast ("on" | "off", off by default) adds the CLI's fastMode opt-in to
+    judge calls whose model is Opus. The CLI refuses fast mode to a non-interactive client unless the
+    flag-settings layer carries that exact key (sdk_backend.flag_settings_path is the sessions' twin),
+    and fast mode is an Opus-only preview, so the key rides only a call whose model reads as the opus
+    family through _model_family_version (the bare alias or a pinned version id); every other model's
+    argv is the toggle-off argv, byte for byte. `--settings` takes ONE value, so when a login-billed
+    call also needs the helper suppression both keys share one JSON overlay, and the login-only overlay
+    keeps the exact string the auth-billing tests pin. The setting is a kernel setting in the shape of
+    the other judge knobs: validated, gesture-stamped, in /version raw (top level and the cross-machine
+    settings dict), applied and acked by /judge-settings, propagated from the socket op, and the
+    judge-usage row keeps the CLI's own word on whether fast engaged (fast_mode_state)."""
+
+    def setUp(self):
+        import tempfile as _t
+        from pathlib import Path as _P
+        self._saved_state = jd.STATE
+        self._td = _t.mkdtemp()
+        jd.STATE = _P(self._td)
+        jd._state_cache.clear()
+
+    def tearDown(self):
+        import shutil as _sh
+        jd.STATE = self._saved_state
+        jd._state_cache.clear()
+        _sh.rmtree(self._td, ignore_errors=True)
+
+    def _ws(self, msg):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        jd._state_cache.clear()   # the getters cache by mtime: read the file the op wrote, not the cache
+        return sent
+
+    def test_off_by_default_and_the_argv_is_untouched(self):
+        self.assertFalse(jd._judge_fast())
+        for m in ("opus", "claude-opus-4-6", "sonnet"):
+            self.assertNotIn("--settings", jd._judge_cmd(m, "SYS"), m)
+        v = km._version_info()
+        self.assertEqual(v["judgeFast"], "off", "/version top level, RAW")
+        self.assertEqual(v["settings"]["judgeFast"], "off", "the cross-machine settings dict (the gear's mixed marks)")
+        self.assertIn("judge-fast", v["settingsGt"], "its stamp rides with the other stores'")
+
+    def test_fast_adds_the_opt_in_for_opus_alias_and_version_ids(self):
+        models = ("opus", "claude-opus-4-6", "claude-opus-5", "sonnet", "haiku", "fable")
+        off = {m: jd._judge_cmd(m, "SYS") for m in models}
+        (jd.STATE / "judge-fast").write_text("on")
+        jd._state_cache.clear()
+        self.assertTrue(jd._judge_fast())
+        for m in ("opus", "claude-opus-4-6", "claude-opus-5"):
+            cmd = jd._judge_cmd(m, "SYS")
+            self.assertEqual(cmd.count("--settings"), 1, m)
+            i = cmd.index("--settings")
+            self.assertEqual(json.loads(cmd[i + 1]), {"fastMode": True}, m)
+            self.assertEqual(cmd[:i], off[m], "%s: the opt-in is appended and nothing else moves" % m)
+        for m in ("sonnet", "haiku", "fable"):
+            self.assertEqual(jd._judge_cmd(m, "SYS"), off[m], "%s cannot run fast: the toggle-off argv" % m)
+        cmd = jd._judge_cmd("opus", "SYS", "high")
+        self.assertIn("--effort", cmd, "the effort flag still lands beside the overlay")
+        self.assertEqual(json.loads(cmd[-1]), {"fastMode": True})
+        # a login-billed Opus call: ONE overlay with both keys (--settings takes one value)
+        cmd = jd._judge_cmd("opus", "SYS", None, auth="login")
+        self.assertEqual(cmd.count("--settings"), 1)
+        self.assertEqual(json.loads(cmd[-1]), {"fastMode": True, "apiKeyHelper": ""})
+        # ...and a login-billed call on a model that cannot run fast keeps the login-only string verbatim
+        self.assertEqual(jd._judge_cmd("sonnet", "SYS", None, auth="login")[-2:], HELPER_OFF)
+
+    def test_the_setting_is_a_kernel_setting_like_the_other_judge_knobs(self):
+        self.assertIn("judge-fast", km._GT_STORES)
+        self.assertIn("judgeFast", dict(km._JUDGE_SETTING_FIELDS))
+        self.assertIsNotNone(km._set_judge_fast("on"))
+        self.assertEqual((jd.STATE / "judge-fast").read_text(), "on")
+        self.assertTrue(jd._judge_fast())
+        for bad in ("yes", "true", "1", "", "ON"):
+            self.assertIsNone(km._set_judge_fast(bad), "%r is refused unwritten" % bad)
+        self.assertEqual((jd.STATE / "judge-fast").read_text(), "on", "the refused values wrote nothing")
+        v = km._version_info()
+        self.assertEqual((v["judgeFast"], v["settings"]["judgeFast"]), ("on", "on"))
+        self.assertIsNotNone(km._set_judge_fast("off"))
+        self.assertFalse(jd._judge_fast())
+        self.assertEqual(km._version_info()["judgeFast"], "off")
+
+    def test_the_socket_op_stores_on_off_propagates_and_orders_by_gesture(self):
+        propagated = []
+        saved_threading, saved_prop = km.threading, km._propagate_judge_settings
+        ns = {k: getattr(_real_threading, k) for k in dir(_real_threading) if not k.startswith("__")}
+        ns["Thread"] = _InlineThread
+        km.threading = types.SimpleNamespace(**ns)
+        km._propagate_judge_settings = lambda body: propagated.append(body)
+        try:
+            # the gear's checkbox posts a boolean; the kernel stores on/off and fans the applied value out
+            self.assertEqual(self._ws({"type": "setJudgeFast", "enabled": True, "gt": T_NEW}), [])
+            self.assertTrue(jd._judge_fast())
+            self.assertEqual(propagated, [{"judgeFast": "on", "gt": T_NEW}])
+            # an OLDER gesture stands down: nothing applied, nothing propagated, the delivering socket hears it
+            sent = self._ws({"type": "setJudgeFast", "enabled": False, "gt": T_OLD})
+            self.assertTrue(jd._judge_fast())
+            self.assertEqual(len(propagated), 1)
+            self.assertEqual([m["setting"] for m in sent if m.get("type") == "settingStale"], ["judge-fast"])
+            # a newer one applies and turns it off again
+            self._ws({"type": "setJudgeFast", "enabled": False, "gt": T_NEW + 1})
+            self.assertFalse(jd._judge_fast())
+            self.assertEqual(propagated[-1], {"judgeFast": "off", "gt": T_NEW + 1})
+            # a flag that is not a boolean is refused unwritten, with a warn on the delivering socket
+            sent = self._ws({"type": "setJudgeFast", "enabled": "on", "gt": T_NEW + 2})
+            self.assertFalse(jd._judge_fast())
+            self.assertEqual([m["type"] for m in sent], ["warn"])
+            self.assertEqual(len(propagated), 2)
+        finally:
+            km.threading, km._propagate_judge_settings = saved_threading, saved_prop
+
+    def test_the_usage_row_keeps_the_cli_s_fast_readback(self):
+        # whether fast engaged is the CLI's call, per account: the result envelope's fast_mode_state is the
+        # one readback, so each usage row keeps it (None when the envelope carries none)
+        saved_usage = jd.USAGE
+        jd.USAGE = jd.STATE / "judge-usage.jsonl"
+        try:
+            jd._log_judge_usage("planner", "triage", "opus", None,
+                                {"usage": {"input_tokens": 1}, "duration_ms": 5, "fast_mode_state": "on"}, 1.0, 2.0)
+            jd._log_judge_usage("captioner", "index", "haiku", None, {"usage": {}, "duration_ms": 5}, 3.0, 4.0)
+            rows = [json.loads(ln) for ln in jd.USAGE.read_text().splitlines()]
+        finally:
+            jd.USAGE = saved_usage
+        self.assertEqual([r["fast"] for r in rows], ["on", None])
+        self.assertEqual(rows[0]["model"], "opus")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -855,6 +855,7 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
             ("setThinkingSummaries", "enabled", {}, km._thinking_summaries_on, warn),
             ("setConserve", "enabled", {}, km._conserve_on, warn),
             ("setTmuxBackend", "enabled", {}, lambda: km.jd._state_str("tmux-backend", "off") == "on", warn),   # T288
+            ("setJudgeFast", "enabled", {}, lambda: km.jd._state_str("judge-fast", "off") == "on", warn),   # Fast judging
             ("setGlobalRetryPaused", "value", {}, km._retry_paused_on, warn),
             ("setSessionFlag", "value", {"id": self.SID, "flag": "hideFromFeed"},
              lambda: km._session_flag(self.SID, "hideFromFeed"), lane),

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -56,6 +56,8 @@ class SettingsSectionsTest(unittest.TestCase):
         # Judges sit low: the six dropdowns between Judges and the bottom group
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgemodel") < h.index(">Updates & debug<"))
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-indexeffort") < h.index(">Updates & debug<"))
+        # Fast judging: a checkbox row among the judge picks, in the Judges section like the knobs it rides with
+        self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgefast") < h.index(">Updates & debug<"))
         self.assertNotIn("rs-oldest", h)
         # Updates & debug (the very bottom): auto-updates, the judge-SHOW toggles, analytics, version
         self.assertLess(h.index(">Updates & debug<"), h.index("id=rs-updates"))
@@ -100,6 +102,17 @@ class SettingsSectionsTest(unittest.TestCase):
             self.assertRegex(h, r"rs-jrow'><b>[^<]+<span class=rs-mixed hidden></span></b>"
                                 r"<span class=rs-sub>[^<]*</span><select id=" + sel)
         self.assertIn("#rsettings .rs-jrow select {", _gear_css_src())
+
+    def test_fast_judging_is_a_label_row_with_a_mixed_mark(self):
+        # a checkbox row in the shape of Fast comment threads (label + checkbox, the mixed mark beside the name),
+        # not an .rs-jrow: the one-line label + picker count above stays at nine
+        h = _gear_src()
+        self.assertIn("<label class='rs-row'><input type=checkbox id=rs-judgefast>", h)
+        self.assertIn("<span><b>Fast judging</b><span class=rs-mixed hidden></span>", h)
+        row = h[h.index("id=rs-judgefast"):]
+        row = row[:row.index("</label>")]
+        self.assertIn("Opus", row, "the copy says which calls the setting reaches")
+        self.assertIn("connected machine's kernel", row, "the copy says the pick follows to the other machines")
 
     def test_collapse_gaps_is_wired_to_the_shared_collapseGaps_setting(self):
         # the gear JS persists/loads romp:settings.collapseGaps; the timeline reads it (see romp-timeline-view.js)

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -795,7 +795,7 @@ class VersionReportsEveryStoredStamp(_Base):
     def test_a_fresh_install_reports_every_store_at_zero(self):
         gts = km._version_info()["settingsGt"]
         self.assertEqual(set(gts), set(km._GT_STORES), "one key per gt-gated store, no more, no less")
-        self.assertEqual(len(km._GT_STORES), 16, "five toggles/modes + eleven kernel-side stores (judge-concurrency since T277, tmux-backend since T288)")
+        self.assertEqual(len(km._GT_STORES), 17, "five toggles/modes + twelve kernel-side stores (judge-concurrency since T277, tmux-backend since T288, judge-fast with Fast judging)")
         self.assertEqual(set(gts.values()), {0}, "nothing applied yet reads 0 — nothing to outrank")
         self.assertEqual(json.loads(json.dumps(gts)), gts, "plain JSON — ints, no paths, nothing to redact")
 
@@ -807,10 +807,11 @@ class VersionReportsEveryStoredStamp(_Base):
         self.assertEqual(km._set_update_mode("auto", gt=T_NEW + 7), T_NEW + 7)
         self.assertEqual(km._set_thinking_summaries(True, gt=T_NEW + 8), T_NEW + 8)
         self.assertEqual(km._set_comment_fast("on", gt=T_NEW + 9), T_NEW + 9)
+        self.assertEqual(km._set_judge_fast("on", gt=T_NEW + 10), T_NEW + 10)
         gts = km._version_info()["settingsGt"]
         want = {"judge-model": T_NEW, "auto-nudge": T_OLD, "compact-suggest": T_NEW + 5,
                 "file-editing": T_NEW + 6, "update-mode": T_NEW + 7, "thinking-summaries": T_NEW + 8,
-                "comment-fast": T_NEW + 9}
+                "comment-fast": T_NEW + 9, "judge-fast": T_NEW + 10}
         for store, gt in want.items():
             self.assertEqual(gts[store], gt, store)
         for store in set(km._GT_STORES) - set(want):
@@ -837,7 +838,7 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setDistillModel", "model": "haiku"},
                  {"type": "setDistillEffort", "effort": "high"}, {"type": "setCommentModel", "model": "haiku"},
                  {"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentFast", "fast": "on"},
-                 {"type": "setTmuxBackend", "enabled": True}]
+                 {"type": "setTmuxBackend", "enabled": True}, {"type": "setJudgeFast", "enabled": True}]
         older = [{"type": "setAutoNudge", "enabled": True}, {"type": "setCompactSuggest", "enabled": False},
                  {"type": "setFileEditing", "enabled": False}, {"type": "setUpdateMode", "mode": "off"},
                  {"type": "setThinkingSummaries", "enabled": False}, {"type": "setJudgeModel", "model": "opus"},
@@ -846,14 +847,14 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setDistillModel", "model": "triage"},
                  {"type": "setDistillEffort", "effort": "low"}, {"type": "setCommentModel", "model": "session"},
                  {"type": "setCommentEffort", "effort": "session"}, {"type": "setCommentFast", "fast": "session"},
-                 {"type": "setTmuxBackend", "enabled": False}]
+                 {"type": "setTmuxBackend", "enabled": False}, {"type": "setJudgeFast", "enabled": False}]
         with contextlib.redirect_stderr(io.StringIO()):
             for n, o in zip(newer, older):
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(n, gt=T_NEW), client)
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(o, gt=T_OLD), client)
         named = {m["setting"] for m in sent if m.get("type") == "settingStale"}
         self.assertEqual(named, set(km._version_info()["settingsGt"]), "frames and the report share one vocabulary")
-        self.assertEqual(len(named), 16)   # eleven kernel-side stores since T288
+        self.assertEqual(len(named), 17)   # twelve kernel-side stores since Fast judging
 
 
 class ASkewedClockCannotLockTheStore(_Base):

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -82,7 +82,8 @@ const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel"
                                 "setDistillModel", "setDistillEffort", "setFileEditing",
                                 "setCompactSuggest",
                                 "setCommentModel", "setCommentEffort", "setCommentFast",
-                                "setTmuxBackend"]);   // T288: the tmux backend's offer, one value across machines
+                                "setTmuxBackend",   // T288: the tmux backend's offer, one value across machines
+                                "setJudgeFast"]);   // Fast judging: the judges' fast-mode opt-in, one value across machines
 
 /** Return a COPY of an inbound message with every session-id field prefixed by `host`. The local host
  *  ("") is the identity transform, so local messages are untouched. Unknown fields pass through. */

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -162,6 +162,10 @@ var GEAR_HTML =
   '<div class=rs-sec>Judges</div>' +
   "<div class='rs-row rs-jrow'><b>Triage model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
   "<div class='rs-row rs-jrow'><b>Triage effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
+  "<label class='rs-row'><input type=checkbox id=rs-judgefast>" +
+  '<span><b>Fast judging</b><span class=rs-mixed hidden></span>' +
+  "<span class=rs-sub>Run the judges in fast mode (an Opus-only research preview, billed at a premium over standard Opus rates). Engages only on calls whose model is Opus, whichever tier; every other model runs as before. Fast requests draw on fast mode's own rate limits, the same pool your sessions' fast toggles use. Off by default. Applies on the judges' next pass; no restart. Follows to every connected machine's kernel.</span>" +
+  '</span></label>' +
   "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select></div>" +
   "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
@@ -250,6 +254,7 @@ function initGear(post) {
     dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
     cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
     cmf = document.getElementById('rs-cmtfast'),
+    jf = document.getElementById('rs-judgefast'),
     tb = document.getElementById('rs-tmuxbackend'), bkn = document.getElementById('rs-backend-note'),
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
@@ -750,6 +755,8 @@ function initGear(post) {
   // the tmux backend's offer (T288): a kernel setting like the judge knobs (stamped, propagated); the Default
   // backend list repaints at once so the pick and the offer never disagree in the same modal
   if (tb) tb.addEventListener('change', function () { post({ type: 'setTmuxBackend', enabled: tb.checked, gt: gclock.stamp('tmux-backend') }); paintBackendOffer(tb.checked); });
+  // Fast judging: a kernel setting like the judge knobs (stamped, propagated); the judges read it per call
+  if (jf) jf.addEventListener('change', function () { post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') }); });
   // "Claude Code (tmux)" is in the Default backend list only while the setting is on; a saved default of tmux
   // while it is off is set aside (the select shows Claude Code and the note says so), never erased: it returns
   // with the setting. The option is removed rather than hidden: the facade paints from sel.options.
@@ -827,7 +834,8 @@ function initGear(post) {
     'index-model': 'Indexing model', 'index-effort': 'Indexing effort', 'judge-concurrency': 'Judge concurrency',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
-    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend', 'thinking-summaries': 'Thinking summaries' };
+    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend', 'judge-fast': 'Fast judging',
+    'thinking-summaries': 'Thinking summaries' };
   // store name → the message type that sets it: the whitelist for the toast's Apply anyway (a frame
   // may re-issue the one setting it names, nothing else) and the completeness pin's map
   // (gear.test.ts checks every emitter stamps through the clock under its own store name)
@@ -837,7 +845,7 @@ function initGear(post) {
     'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort', 'judge-concurrency': 'setJudgeConcurrency',
     'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
     'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast',
-    'tmux-backend': 'setTmuxBackend' };
+    'tmux-backend': 'setTmuxBackend', 'judge-fast': 'setJudgeFast' };
   // store name → the words its select shows for the sentinel options whose value is not the word. The
   // effort selects' Default is the EMPTY value (no effort flag), which read as no value at all, so a
   // refused Default pick drew the value-less copy and a plain Apply anyway — in the frozen-tab case, the
@@ -1111,7 +1119,8 @@ function initGear(post) {
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
      ['indexEffort', ie], ['judgeConcurrency', jc], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
      ['compactSuggest', csg],
-     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf], ['tmuxBackend', tb]].forEach(function (pair) {
+     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf], ['tmuxBackend', tb],
+     ['judgeFast', jf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
       var row = el.closest ? el.closest('.rs-row') : null;
@@ -1157,6 +1166,7 @@ function initGear(post) {
     if (typeof v.commentEffort === 'string') setShow(cme, v.commentEffort);
     if (cmf && typeof v.commentFast === 'string') cmf.checked = v.commentFast === 'on';
     if (tb && typeof v.tmuxBackend === 'string') { tb.checked = v.tmuxBackend === 'on'; paintBackendOffer(tb.checked); }   // T288: the offer, then the list follows it
+    if (jf && typeof v.judgeFast === 'string') jf.checked = v.judgeFast === 'on';   // RAW on/off: the kernel's persisted answer
     cmtFastGate(false);
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
     // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -46,8 +46,24 @@ test("the gear posts kernel ops through ONE shared channel (never re-acquires th
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort", "setJudgeConcurrency",
     "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast", "setTmuxBackend",
-    "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
+    "setJudgeFast", "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
+});
+
+test("Fast judging is a kernel setting: a stamped emitter under its own store name, a toast name, a mixed mark, and it follows to every machine", () => {
+  assert.ok(GEAR.includes("post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') })"),
+    "the click posts the kernel's designed message with the gesture stamp minted in the literal");
+  assert.ok(GEAR.includes("jf.checked = v.judgeFast === 'on'"),
+    "the checkbox shows the kernel's persisted answer (RAW on/off), never a page default");
+  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'judge-fast': 'Fast judging'/,
+    "a stood-down gesture toasts under the row's own name");
+  assert.match(GEAR, /STALE_TYPE = \{[\s\S]*?'judge-fast': 'setJudgeFast'/,
+    "the store maps to its message type (the toast's Apply anyway whitelist)");
+  assert.match(GEAR, /\['judgeFast', jf\]/, "the row carries the mixed mark where machines disagree");
+  const FED = read("ui", "webview", "federation.ts");
+  const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(setSrc && setSrc[1].includes('"setJudgeFast"'),
+    "one click writes every attached kernel, like the other judge settings");
 });
 
 test("EVERY queued-class kernel setting is emitted with its gesture time (completeness-pinned to federation's own set)", () => {

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -508,6 +508,7 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setCommentModel", model: "claude-opus-5" },
                      { type: "setCommentEffort", effort: "high" },
                      { type: "setCommentFast", fast: "on" },
+                     { type: "setJudgeFast", enabled: true },
                      { type: "setFileEditing", enabled: true },
                      { type: "setCompactSuggest", enabled: true }]) {   // T248: no longer per-install
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));


### PR DESCRIPTION
A kernel setting, **Fast judging** in the gear's Judges section (off by default), runs judge calls whose model is Opus in Claude Code's fast mode. The judges are `claude -p` subprocesses, and the CLI refuses fast mode to a non-interactive client unless the flag-settings layer carries the `fastMode` opt-in; sessions get that key through `flag_settings_path`, and the judges had no way to ask for it, so a triage or distilling tier pinned to Opus always ran at normal speed.

## Design

- **A kernel setting in the shape of the tmux-backend and comment-fast settings.** `STATE/judge-fast` holds `on` or `off`; `_set_judge_fast` validates and gesture-stamps it; it sits in `_JUDGE_SETTING_FIELDS` and `_GT_STORES`; `/version` reports it raw at the top level and in the cross-machine `settings` dict; `/judge-settings` applies and acks it; the `setJudgeFast` socket op reads a boolean `enabled` through `_as_bool`, stores on/off, and fans the applied value out to every linked kernel under its gesture stamp, standing down on a stale one with a `settingStale` frame. The gear row is a label-row checkbox with the mixed mark, a stamped emitter under its own store name, `STALE_LABELS` and `STALE_TYPE` entries, and `KERNEL_SETTING` carries `setJudgeFast`, so one click writes every attached kernel like the other judge settings.
- **Decided per call, by model family.** `_judge_cmd` adds `fastMode: true` when the setting is on and the call's model reads as the opus family through `_model_family_version`: the bare `opus` alias or a pinned Opus version id, since the judge tiers accept version ids. A call on Sonnet, Haiku or Fable gets the argv it always got, byte for byte. There is no triage-model gate on the checkbox: the mechanism is per call, and the distilling or indexing tier may be Opus while triage is not. `cmtFastGate` is the pattern if a gate is wanted.
- **One `--settings` overlay.** `--settings` takes one value, so the fast opt-in and a login-billed call's `apiKeyHelper: ""` share one `json.dumps` overlay when both apply. The login-only overlay is the same string as before, byte for byte, so the auth-billing pins hold unchanged. No settings file is written.
- **The CLI's answer is recorded.** Whether fast engaged is per account: an account with extra usage turned off, or an organisation with fast mode disabled, reports it off with the setting on. Each `judge-usage.jsonl` row now keeps the envelope's `fast_mode_state` as `fast` (`on`, `off`, `cooldown`, or `null` when the CLI reported none), so the setting has a readback and a checkbox that reads on beside rows that read off names the account, not the setting.
- **Cost.** Fast mode bills Opus at a premium (twice the standard Opus rate at the time of writing) and draws on fast mode's own rate limits, the pool sessions' fast toggles share. The row copy and docs/reference.md say so. The setting ships off, and nothing turns it on for an existing install.
- **Considered: a per-install setting** (the thinking-summaries shape). The judge model and effort picks already follow to every connected machine, and a judge tier that runs Opus on one machine and Opus in fast mode on another is the per-machine surprise the propagation rule exists to prevent, so this follows too. If per-install is preferred, the change is dropping the `KERNEL_SETTING`, `_JUDGE_SETTING_FIELDS` and fan-out entries; the rest stands.
- **Left out on purpose.** No triage-model gate on the checkbox, no static settings file, no third state beyond on/off.

Docs: docs/reference.md gets a Fast judging section after Judge concurrency; docs/judges.md lists `STATE/judge-fast` under Ops and knobs and names the usage row's `fast` field.

## Tests

Executing tests, each red before the change:

- `tests/test_kernel_judge_model.py::FastJudging` (5 tests): off by default with the argv untouched and `/version` reporting `off`; the opt-in on the `opus` alias and on two pinned Opus version ids with the sonnet, haiku and fable argv equal to the toggle-off argv, `--effort` still beside the overlay, and a login-billed Opus call riding one overlay with both keys while the sonnet login argv keeps the verbatim helper-off string; the setter's value space (`yes`, `true`, `1`, `""`, `ON` refused unwritten), `_GT_STORES`, `_JUDGE_SETTING_FIELDS` and `/version`; the socket op storing on/off, fanning out `{"judgeFast": ..., "gt": ...}`, standing a stale gesture down with a `settingStale` frame naming `judge-fast`, and refusing a non-boolean with a `warn`; the usage row keeping `fast`. Before the change: `AttributeError: module 'romp_judge' has no attribute '_judge_fast'`, and `_judge_cmd` emits no `--settings` outside the login branch.
- `tests/test_judge_auth_billing.py`: `test_a_fast_login_billed_call_rides_one_overlay_with_both_keys` (one overlay parsing to `{"fastMode": true, "apiKeyHelper": ""}`; the sonnet login argv still ends in `HELPER_OFF`; key-billed and unpicked Opus calls carry the opt-in alone) and `test_a_fast_login_pick_on_opus_launches_with_one_overlay_and_logs_the_readback` (end to end through `_judge_run` with a fake CLI: one overlay, the login tokens, no key, and a usage row reading `("opus", "on")`). Before the change the Opus login argv carries only the helper key and the usage row has no `fast` field.
- `tests/test_judge_settings_sync.py::ApplySettings::test_judge_fast_applies_and_reports_raw`: `{}` acks `off`; `on` lands and acks; `true` is ignored with the ack still `on`; `off` clears. Before the change: `KeyError: 'judgeFast'`. The fan-out pin gains `args=({"judgeFast": _jfv, "gt": _jgt},)`.
- `tests/test_setting_gesture_order.py`: the gt-store count 16 -> 17, `_set_judge_fast("on", gt=T)` reported under `judge-fast` with nothing else moving, and `setJudgeFast` in the frames-and-report vocabulary walk.
- `tests/test_kernel_session_flags.py`: a `setJudgeFast` row in the `_as_bool` table (every non-boolean refused unwritten with the warn frame; real booleans apply and flip back).
- `tests/test_kernel_settings_sections.py`: `rs-judgefast` between Judges and Updates & debug; a label row in the Fast comment threads shape with the mixed mark; the `.rs-jrow` count unchanged at nine.
- `ui/webview/multi-kernel-merge.test.ts`: `setJudgeFast` in the routeOutbound list, so the op reaches every attached kernel with the same message to each; red with the op missing from `KERNEL_SETTING` (it falls through to the local kernel alone).
- `ui/webview/gear.test.ts`: the stamped emitter under `judge-fast`, the `STALE_LABELS` and `STALE_TYPE` entries, the mixed-mark pair, the fill from the raw value, and the `KERNEL_SETTING` member; the existing completeness pin over federation's set covers the emitter as well.

Runs on the final tree: the six modules above plus the suite's loader rule, 208 passed; `npm run typecheck` clean; `gear.test.js` 18/18 and `multi-kernel-merge.test.js` 56/56; full `pytest -n 6 tests/` and full `npm test` (the main leg plus the timeline-tags-scale file alone): full `pytest -n 6 tests/` 11148 passed, 41 skipped, 0 failed, 1707 subtests passed (the served-page modules running against Chromium); full `npm test` 4097 tests, 4097 pass, 0 fail (4075 in the main run plus the 22 of the timeline-tags-scale file run alone).

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
