### PR TITLE
Tests: the chat signature's clock case arms the interrupt stamp and crosses its cap; the recorded-dependencies fixture salts its ids and clears its caches per test

### DIFF
--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -587,6 +587,24 @@ class Differential(_World):
         km._model_switch_pending[SID] = {"target": "other", "until": time.time() + 60}
         self.assertEqual(self.moved(s3, self.sig(now=NOW + 4, tm=tm)), ("clock",), "a model switch in flight")
         km._model_switch_pending.pop(SID, None)
+        # the interrupt stamp, on the transcript path (a tmux row has no interrupting flag): the stop is in
+        # flight until the CLI's stop record lands or 120 s pass, and the signature's own read pops the
+        # stamp at the cap exactly as the build's would. Read at or after NOW + 2, where faded already holds.
+        km._interrupt_clicked[SID] = NOW - 118
+        s5 = self.sig(now=NOW + 2, tm=tm)                    # 120 s: the stop is in flight
+        self.assertEqual(self.moved(s3, s5), ("clock",), "a stop dispatched: interrupting")
+        self.assertEqual(self.sig(now=NOW + 2, tm=tm), s5, "a repeat read holds")
+        self.assertEqual(self.sig(now=NOW + 3, tm=tm), s3, "121 s: the cap ran out, back to the clicked-nothing key")
+        self.assertNotIn(SID, km._interrupt_clicked, "the signature's read popped the stamp, as the build's own would")
+        # the same stamp with an SDK row, whose own flag is the settle: the row component strips the flag
+        # and the snapshot stamp, so the clock component alone carries it
+        km._interrupt_clicked[SID] = NOW - 118
+        sdk = dict(tm, interrupting=True, snapT=NOW + 2)     # a snapshot taken after the click
+        s6 = self.sig(now=NOW + 2, tm=sdk)
+        self.assertEqual(self.moved(s3, s6), ("clock",), "the backend's own in-flight flag, under clock alone")
+        sdk["interrupting"] = False
+        self.assertEqual(self.sig(now=NOW + 2, tm=sdk), s3, "the flag's settle: back to the clicked-nothing key")
+        self.assertNotIn(SID, km._interrupt_clicked)
 
     def test_parked_ops_miss_under_ops_and_the_limit_hold_is_read_only_while_something_is_queued(self):
         a = self.sig()

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -30,6 +30,7 @@ import ast
 import contextlib
 import inspect
 import io
+import itertools
 import json
 import os
 import re
@@ -1097,7 +1098,12 @@ class RecordedDependencies(unittest.TestCase):
     _read_task_output, _subagent_meta_map, _subagent_file and _agent_steps), a fold hit carries the sealed
     prefix's outputs into the record, a raw postal event flags the log as a dependency, and the pusher
     consumes the record and leaves none on its thread. Synthetic session under a hermetic state root;
-    records stamped against the real clock, which discovery keys on."""
+    records stamped against the real clock, which discovery keys on. Message ids are salted per test
+    instance and tearDown clears the sid's per-message caches (_PATH_LINK_CACHE, _SPACE_PATH_CACHE, the pin
+    sidecar's memo): a verdict cached under (sid, uuid) is served without re-reading the text, so an id
+    reused across tests would hand one test's verdict to another's message."""
+
+    _salt = itertools.count()                    # one value per test instance, read in setUp
 
     STUBS = ("_tmux_sessions", "_live_names", "_chat_tab_sessions", "_cached_feed", "_cached_timeline",
              "build_timeline", "_fleet_view_sig", "_comments_frame", "_retry_parked_creates", "_sdk", "_msg_summaries")
@@ -1143,6 +1149,7 @@ class RecordedDependencies(unittest.TestCase):
         km._parse_cache.clear(); km._task_out_cache.clear(); km._chat_fold.pop(SID_R, None)
         if isinstance(jd._discover_cache, dict):
             jd._discover_cache.clear()
+        self.salt = next(self._salt)
         self.n = 0
         self.last = None
         self.chat = {"app": "chat", "alive": True, "sent": {}, "active": None, "send": lambda s: None}
@@ -1165,6 +1172,10 @@ class RecordedDependencies(unittest.TestCase):
         km._thread_fold_keep[0], km._thread_fold_keep[1] = keep
         km._tmux_echo.pop(SID_R, None); km._tmux_echo_rev.pop(SID_R, None)
         km._chat_fold.pop(SID_R, None); km._parse_cache.clear(); km._task_out_cache.clear()
+        for cache in (km._PATH_LINK_CACHE, km._SPACE_PATH_CACHE):
+            for k in [k for k in cache if k[0] == SID_R]:
+                cache.pop(k, None)
+        km._PIN_ASSOC_MEMO.pop(SID_R, None)
         km._chat_dep_scope.deps = None
         if isinstance(jd._discover_cache, dict):
             jd._discover_cache.clear()
@@ -1172,7 +1183,7 @@ class RecordedDependencies(unittest.TestCase):
     # ── the transcript ──
     def uid(self):
         self.n += 1
-        return "cccccccc-0000-0000-0000-%012d" % self.n
+        return "cccccccc-0000-0000-%04x-%012d" % (self.salt, self.n)
 
     def tick(self, dt=5):
         self.t += dt
@@ -1373,6 +1384,24 @@ class RecordedDependencies(unittest.TestCase):
                 km._clients[:] = [c for c in km._clients if c is not self.chat]
         self.assertTrue(self.chat["sent"], "the session reached the client")
         self.assertIsNone(getattr(km._chat_dep_scope, "deps", None))
+
+    def test_a_fresh_worlds_message_under_a_reused_id_is_verified_on_its_own_text(self):
+        """The path-link verdict is cached per (sid, uuid) and a hit is served without re-reading the text
+        (_path_links), so a message id one test minted and a later test reused would carry the earlier
+        message's verdict into the later test. The hazard is cross-test by construction, so this test runs
+        two worlds itself, through the fixture's own hooks: the first caches a verdict for a token-free line,
+        the second names a real file from the same counter position and must be verified on its own text."""
+        self.append(self.turn(1))                           # the first world's user line: no path token
+        km._push([self.chat])
+        self.tearDown()
+        self.setUp()                                        # the next test's world (a second temp dir cleanup is registered; both run when the test ends)
+        (self.cdir / "notes").mkdir()
+        (self.cdir / "notes" / "report.md").write_text("42\n")
+        u, a = self.uid(), self.uid()                       # the first world's counter position again: the same id but for the salt
+        self.append([_uline(self.tick(), "see notes/report.md", u, None), _aline(self.tick(), "Read it.", a, u)])
+        km._push([self.chat])
+        ev = next(e for e in km._built_chat[SID_R][1]["events"] if e.get("uuid") == u)
+        self.assertIn("notes/report.md", ev.get("pathLinks") or {}, "verified on its own text, not a prior message's")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two tests-only changes in `tests/test_chat_build_sig_inputs.py`, one commit each. No kernel or docs change.

## 1. The clock case arms the interrupt stamp and crosses its 120 s cap

**Symptom.** A regression that dropped the interrupt boolean from the chat signature's clock component would pass every test. The user would see a tab whose chip misses the Interrupting arm (the interrupt handler marks the views dirty but never busts `_built_chat`, so the chat key alone decides whether a cached tab is rebuilt) and a tab cached with the chip reading Interrupting served past the cap, until some other input moved.

**Cause.** `Differential.test_each_clock_boolean_misses_under_clock_exactly_at_its_crossing` moved three of the four booleans the clock component resolves (the faded hour, the compact click's cap, the model-switch stamp) and never wrote `_interrupt_clicked`. The Tests bullet of https://github.com/romp-on/romp/pull/1277 ("each clock boolean at its crossing") overstated the shipped test; this closes the gap. `tests/test_kernel_interrupt.py` pins the cap by calling `_interrupting` directly, never through the signature, and no other test compares signatures across an armed stamp.

**Fix.** The test arms the stamp at `NOW - 118` against a base key taken at `NOW + 2`, so the click is 120 s before the base read's instant. It reads at that same instant (exactly 120 s after the click: a miss under `clock` alone), reads again (holds), and reads one second later (121 s: back to the clicked-nothing key, with the stamp popped by the signature's own read as the build's would be), all on the transcript path a tmux row takes. Then the same stamp with an SDK row whose own `interrupting` flag is the settle, with `snapT` after the click: a miss under `clock` alone, since the row component strips `interrupting` and `snapT`, and the key back at the base once the flag reads False. Every read is at or after the faded crossing the test already made, so the miss is the stamp's and the return-to-base compare holds.

**Tests.** The case pins present behaviour, so its red is under a mutation of `kernel/kernel.py`, run and reverted, on the tree this PR ships:
- The clock component's first element replaced by `False`. With the original test, this module and `tests/test_kernel_interrupt.py`, `tests/test_stage0_log_readers.py`, `tests/test_chat_delta_resync.py`, `tests/test_chat_fixed_cost_memos.py`, `tests/test_kernel_rewind.py` and `tests/test_perf_stats.py` stay green (276 passed). With the extended test the new in-flight assertion fails, `() != ('clock',)`, and nothing else in the module (1 failed, 47 passed) or in `tests/test_kernel_interrupt.py` (1 failed, 96 passed over both).
- The transcript path's cap pop in `_interrupting` dropped. The 121 s read fails here (element 12, `clock`, reads `(True, False, True, False)` against `(False, False, True, False)`), and `test_wedged_turn_falls_back_after_the_safety_cap` in `tests/test_kernel_interrupt.py` fails as it did before this change.

## 2. The recorded-dependencies fixture salts its message ids per test and clears the path-link cache for its sid

**Symptom.** A test added to `RecordedDependencies` that names a file under a message id an earlier test used would pass or fail by method order and process placement: its event carries the earlier message's path-link verdict.

**Cause.** `uid()` counted from zero in every `setUp`, so every test minted the same ids in order, and `tearDown` never cleared `_PATH_LINK_CACHE` for `SID_R`. `_path_links` serves a hit for `(sid, uuid)` without re-reading the text and stores an entry for every message with a uuid and a non-empty text, a token-free one included, so test N's entry was served to test N+1's different message under the same id. Harmless so far: no text the class writes reaches the writer with a path-shaped token (the shell task-notification's absolute path is peeled into the reminders first, leaving an empty prompt the writer skips). `_World.tearDown` already clears the cache for its own sid.

**Fix.** `uid()` salts the fourth uuid group from a class-level `itertools.count()` read once per test instance, so an id is never reused across tests even when a clear is missed (nothing in the class compares an id to a literal). `tearDown` pops every `_PATH_LINK_CACHE` and `_SPACE_PATH_CACHE` key for `SID_R` (same key shape) and `_PIN_ASSOC_MEMO[SID_R]`, which the path-link resolve populates when a token resolves. The `_SPACE_PATH_CACHE` clear and the memo pop have no test of their own: they are hygiene on the same rationale (an entry keyed by `(sid, uuid)` and served without re-deriving), and the class docstring says so.

**Tests.** `test_a_fresh_worlds_message_under_a_reused_id_is_verified_on_its_own_text` runs two worlds itself through the fixture's own hooks: the first pushes a token-free user line (its verdict is cached), the second creates `notes/report.md` under the working directory, names it from the same counter position and requires `pathLinks` on that event. Red on the unchanged class (`'notes/report.md' not found in {}`, with the salt and the clears both absent); green with either half of the change alone and with both.

Full suite on the tree this PR ships (`pytest -q -n 6 tests/`): 11140 passed, 41 skipped, 1707 subtests passed, no failures.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)