### PR TITLE
docs/guide.md and docs/read-side.md name every token-exempt kernel route: the web manifest and the install icons beside the liveness probes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,8 +50,8 @@ The token-exempt routes are the no-side-effect liveness probes (`/healthz`,
 of names, not a path prefix). A browser fetches those with credentials omitted
 when the dashboard is added to a home screen, so a token gate there would break
 the install. They are static and read no session state: the manifest is a
-fixed JSON literal (app name, colors, start URL and icon list) and the icons
-are three PNG files.
+fixed JSON literal (app name and short name, display mode, colors, start URL
+and icon list) and the icons are three PNG files.
 
 The practical consequence: another local user on a **shared machine** cannot
 reach your kernel or bus — `/send` (which injects text into a live Claude

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -677,8 +677,12 @@ ports, so without this any other user could inject prompts into your live
 sessions. The token is 144-bit random and lives at
 `~/.local/state/romp/serve-token` with mode `0600` (readable only by your own
 user account). Local tools (the CLI, hooks, the bus, the editor extension) read
-that file and send it automatically, so you never type it. Only liveness probes
-(`/healthz`, `/version`, `/busy`, and the bus's `/ping`) are exempt.
+that file and send it automatically, so you never type it. Only two kinds of
+request skip the token: the liveness probes (`/healthz`, `/version`, `/busy`,
+and the bus's `/ping`), and the files a browser fetches without credentials
+when you add Romp to the Home Screen (`/manifest.webmanifest` and three icons
+under `/media/`). Those files are fixed (the app's name, colors and icon art)
+and read no session state.
 
 The kernel and the bus mint that file when it is missing, one mint between them
 under a sibling lock file, `serve-token.lock`. An existing token is never

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -725,9 +725,14 @@ The Python kernel (`kernel/kernel.py`) closes it.
   the cookie, and `X-Romp-Token` (CLI/hooks/daemons, read from the file). The
   token is baked into how the kernel launches (env/autostart), never a manual
   per-launch flag; a bare browser open of `/` gets a paste-the-token login page
-  (bare `romp` prints the link + opens a browser). Only the no-side-effect liveness
-  probes are exempt (`/healthz`, `/version`, `/busy`; bus `/ping`) so liveness
-  never breaks token-less monitors. `tailscale serve` traffic needs the token
+  (bare `romp` prints the link + opens a browser). Two kinds of route are exempt:
+  the no-side-effect liveness probes (`/healthz`, `/version`, `/busy`; bus
+  `/ping`) so liveness never breaks token-less monitors, and the install files
+  (`/manifest.webmanifest`, plus three icon names under `/media/`, an allowlist
+  rather than a prefix) because a browser fetches a manifest and its icons with
+  credentials omitted, so a gated manifest 403s the moment "Add to Home Screen"
+  consults it. The install files are static (a JSON literal, three PNG files)
+  and read no session state. `tailscale serve` traffic needs the token
   once per device like any browser — and funnel (public internet through the
   same proxy) must still never be enabled for this port, since the token would
   then be the only gate with no device identity in front of it.


### PR DESCRIPTION
Follows #1285 (merged), SECURITY.md's token-exempt inventory. One commit, three documentation files.

## Symptom

docs/guide.md's "Security and trust" section and docs/read-side.md's serve-layer gate bullet tell the reader that the liveness probes (`/healthz`, `/version`, `/busy`, and the bus's `/ping`) are the only routes served without the serve token. SECURITY.md, since #1285, names two more kinds: the web manifest and the three install icons. A reader who trusts either doc for the unauthenticated surface is told less than the kernel serves.

## Cause

`do_GET` in kernel/kernel.py answers `/manifest.webmanifest` and `/media/<name>` for the three names in `_INSTALL_ICONS` (`romp-touch-180.png`, `romp-app-192.png`, `romp-app-512.png`) before `_authorize` runs, because a browser fetches a web app manifest and its icons with credentials omitted: gated, the manifest returns 403 at the moment "Add to Home Screen" consults it. The two docs were written when the probes were the whole exempt set and were not updated when the manifest arrived.

## Fix

Prose only, three files. The guide's sentence now says two kinds of request skip the token, names the manifest and the three icons under `/media/`, says a browser fetches them without credentials when Romp is added to the Home Screen, and says what they are (the app's name, colors and icon art, reading no session state). The design doc's bullet names the probes and the install files (the manifest, and three icon names under `/media/` as an allowlist rather than a prefix), says why the browser needs them without credentials, and what they are (a JSON literal, three PNG files). In both files the closing sentence takes the install files as its subject, so it cannot be read as calling the probes static: `/busy` and `/version` answer from live state. SECURITY.md's parenthetical on the manifest literal now lists its display mode and short name among the fields, still one sentence. Nothing moves: no heading and no other paragraph changes, so the tests that slice these files by anchor read the same text. Only routes `do_GET` serves before the gate are named.

## Tests

No executing test is possible for prose, and none is added (a source-text pin over a sentence is not a test). The manual check: `git grep -n manifest.webmanifest -- docs/guide.md docs/read-side.md` is empty at the base and finds one line in each file at this head.

The behaviour the sentences describe is already pinned: tests/test_kernel_installable_app.py asserts that `/manifest.webmanifest` and the three icons answer 200 with no token and no cookie and that the rest of `/media/` stays gated; tests/test_kernel_auth_hardening.py asserts that the exempt block precedes the gate in `do_GET`. Both pass at this head.

Every test that reads one of the three files was run at this head and passes:

- pytest: tests/test_api_health_hover.py, tests/test_new_session_dir.py, tests/test_kernel.py, tests/test_kernel_auth_hardening.py, tests/test_tag_edit_ack.py and tests/test_tier_policy.py, together with tests/test_kernel_installable_app.py: 853 passed, 18 subtests passed.
- ui/webview (after `npm ci` and `npm run typecheck` in vscode-extension, both clean): dense-chrome, md-sanitize, md-url-view, pdf-new-tab, tab-groups, file-view-links, file-view-links-browser (headless Chromium, ran rather than skipped), net-popover-known, pane-shim-stale: 181 passed, 0 failed, 0 skipped. md-sanitize.test.ts slices SECURITY.md from "## What is already hardened", below the edited paragraph, and still passes.

tests/docs-serve.bats matches a name search for guide.md but writes its own fixture guide and serves that, so it does not read this change; it passes regardless (6 passed).

The same readers were also run with the three files at the base and pass there too: no existing test reads the edited sentences, so the manual check above is the before-and-after evidence.

No full suite was run: the change touches no code and no test, so the full pytest and npm test legs would exercise nothing this commit changes.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)