### PR TITLE
docs/guide.md names the token file in the minting sentence, and the chat signature's _World fixture clears the pin memo and _SPACE_PATH_CACHE beside _PATH_LINK_CACHE

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -684,8 +684,8 @@ when you add Romp to the Home Screen (`/manifest.webmanifest` and three icons
 under `/media/`). Those files are fixed (the app's name, colors and icon art)
 and read no session state.
 
-The kernel and the bus mint that file when it is missing, one mint between them
-under a sibling lock file, `serve-token.lock`. An existing token is never
+The kernel and the bus mint the token file when it is missing, one mint between
+them under a sibling lock file, `serve-token.lock`. An existing token is never
 replaced: a file left looser than `0600` is tightened at the next start (its
 value is kept, so every client stays valid), and a token that exists but cannot
 be read, or a symlink at that path, refuses to start instead of minting a

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -455,8 +455,10 @@ class _World(unittest.TestCase):
         km._live_scope.names = None
         km._live_scope.snapshot = None
         km._live_scope.chat_shared = None
-        for k in [k for k in km._PATH_LINK_CACHE if k[0] == SID]:
-            km._PATH_LINK_CACHE.pop(k, None)
+        for cache in (km._PATH_LINK_CACHE, km._SPACE_PATH_CACHE):
+            for k in [k for k in cache if k[0] == SID]:
+                cache.pop(k, None)
+        km._PIN_ASSOC_MEMO.pop(SID, None)
         self.td.cleanup()
 
     def sig(self, now=NOW, deps=None, tm=None):
@@ -779,6 +781,33 @@ class Differential(_World):
         (self.cdir / "notes" / "report.md").write_text("42\n")
         b = self.sig(deps=rec)
         self.assertEqual(self.moved(a, b), ("pathlink",), "the mention became a link")
+
+    def test_a_fresh_worlds_pin_sidecar_is_read_under_a_reused_id(self):
+        """The pin sidecar is loaded once per sid and served from memory from then on (_pin_assoc), so a
+        world that resolved a token leaves the next world reading a sidecar it never wrote: an empty map
+        where its own file says a pin was latched. The hazard is cross-test by construction, so this test
+        runs two worlds itself, through the fixture's own hooks: the first resolves notes/report.md for u9,
+        which loads the empty sidecar; the second writes one sidecar row for the same message and must
+        build with that pin."""
+        def pending():
+            km._PATH_LINK_CACHE[(SID, "u9")] = ({}, ("notes/report.md",), {})
+            (self.cdir / "notes").mkdir()
+            (self.cdir / "notes" / "report.md").write_text("42\n")
+            return {"task_outs": [], "pl_pending": [("u9", "see notes/report.md for the numbers")],
+                    "pl_at": (("u9", None, None),), "pl_check": None, "postal_any": False, "postal_cards": []}
+        self.sig(deps=pending())                            # the first world: the resolve loads SID's sidecar, which is empty
+        self.tearDown()
+        self.setUp()                                        # the next test's world (its temp dir is cleaned by the final tearDown)
+        saved = km._MENTION_PINS
+        km._MENTION_PINS = None                             # the pin dir latches at first use: point it at this world's root
+        try:
+            with open(km._pin_assoc_dir() / (SID + ".jsonl"), "w", encoding="utf-8") as f:
+                f.write(json.dumps({"u": "u9", "t": "notes/report.md", "p": "pin1"}) + "\n")
+            s = self.sig(deps=pending())
+        finally:
+            km._MENTION_PINS = saved
+        self.assertEqual(s[km._CHAT_SIG_LABELS.index("pathlink")][0][2], {"notes/report.md": "pin1"},
+                         "pinned from this world's sidecar, not a prior world's memo")
 
     def test_a_postal_dependency_misses_under_postal_when_the_log_moves_or_a_caption_changes(self):
         caps = {}


### PR DESCRIPTION
Follows #1294 (the token-exempt routes in docs/guide.md and docs/read-side.md) and #1293 (the chat signature's clock case and the RecordedDependencies fixture), both merged. The branch is cut from #1294's head, 21b28305, so the diff against main is the two commits above it, one per change. The first comes from the review note on #1294; the second gives _World.tearDown the three-way clear #1293 gave RecordedDependencies.tearDown.

### Symptom
1. In docs/guide.md, the paragraph after the token paragraph opens "The kernel and the bus mint that file when it is missing". Since #1294 the token paragraph ends by naming the web manifest and the three install icons, so a reader takes "that file" as one of those rather than the serve token, and the sentence reads as if the kernel and the bus mint the manifest.
2. In tests/test_chat_build_sig_inputs.py, _World.tearDown pops its sid's _PATH_LINK_CACHE entries but not its _SPACE_PATH_CACHE entries or its _PIN_ASSOC_MEMO entry, while RecordedDependencies.tearDown in the same module clears all three since #1293. The pin memo is the pin sidecar's lazy load, read once per sid and served from memory from then on, so every _World test that resolves a path token loads it for SID and the old tearDown left it there for every later test of the run. A test in RecordedDependencies' two-world shape shows the effect: the second world reads the first world's memo and pins nothing where its own sidecar says a pin was latched. No existing test's verdict is wrong today, because no _World test writes the sidecar, so the carried map is the empty map a fresh load of the absent sidecar returns. The two message-keyed caches hold nothing for SID in this module: _PATH_LINK_CACHE was popped already, and no _World message carries a backtick span, so _space_paths never caches one.

### Cause
1. #1294 appended the install files to the token paragraph; the next paragraph's "that file" was written when the token was the last file named before it.
2. #1293 added the three-way clear to RecordedDependencies and left _World's one-cache pop as it was.

### Fix
1. "that file" becomes "the token file" in that one sentence (docs/guide.md). The first line grew past 80 columns, so its last word moves to the second line; the paragraph's wrap is unchanged and no other sentence of the guide changes.
2. _World.tearDown clears, for each of _PATH_LINK_CACHE and _SPACE_PATH_CACHE, the keys whose first element is SID, and pops _PIN_ASSOC_MEMO[SID]: the shape RecordedDependencies.tearDown uses. The existing _PATH_LINK_CACHE pop is kept inside that loop. A two-world test covers the memo pop.

### Tests
- test_a_fresh_worlds_pin_sidecar_is_read_under_a_reused_id (Differential; the shape of RecordedDependencies' test_a_fresh_worlds_message_under_a_reused_id_is_verified_on_its_own_text) fails at the old tearDown and passes at the new one. The first world resolves notes/report.md for u9, which loads SID's empty sidecar; the test then runs the fixture's tearDown and setUp; the second world writes one sidecar row for the same message and builds the signature, whose pins element must carry that pin. At the old tearDown the second world is served the first world's memo and pins nothing: None != {'notes/report.md': 'pin1'}. Removing only the memo pop fails it the same way. Removing only the _SPACE_PATH_CACHE pop leaves the module green, so that pop is parity with RecordedDependencies; this module has no _SPACE_PATH_CACHE leak it could show. The test passes alone. It repoints the lazily latched pin directory (_MENTION_PINS) at the second world's root for its duration and restores it, so no sidecar is written under a torn-down root.
- The docs change admits no test: it is prose, and no test reads the sentence (a grep for its phrases under tests/, ui/ and vscode-extension/src finds none). The guide's readers at this head: tests/test_api_health_hover.py, tests/test_new_session_dir.py and tests/test_tier_policy.py, 209 passed; tests/docs-serve.bats, 6 passed; the eight ui/webview modules that read docs/guide.md (dense-chrome, file-view-links, file-view-links-browser, md-sanitize, md-url-view, net-popover-known, pdf-new-tab, tab-groups), 167 passed, the browser leg included.
- tests/test_chat_build_sig_inputs.py twice in a row at this head: 48 passed each run (47 at the base, before the new test).
- No full suite was run: the change is one sentence of documentation, two extra pops in a fixture teardown and one test in that fixture's module, and the modules above are every reader of either file.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)