### PR TITLE
Tests: the venv python stub reads /dev/null (no hang on an inherited stdin); the uv version_info comments name both shapes

### DIFF
--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -438,9 +438,10 @@ EOF
 
 # A stub python that claims one X.Y (and, with a third argument `t`, a free-threaded build): answers
 # pick_python's minor check for that X.Y only, the >= 3.10 gate, the version and tag prints and the
-# ensurepip probe, and stands in for `python -m venv` by laying down a pip and a python that read stdin
-# and exit 0, plus the tagged lib/python3.X{t} directory a real venv has, logging which python built
-# which venv.
+# ensurepip probe, and stands in for `python -m venv` by laying down a pip and a python that exit 0
+# (the python's cat reads /dev/null, never the caller's stdin: romp-codex-setup runs it once with no
+# heredoc, and a bats run from a terminal would otherwise hang there until that stdin closed), plus the
+# tagged lib/python3.X{t} directory a real venv has, logging which python built which venv.
 write_stub_py() {   # $1 path, $2 the X.Y it claims, [$3 abi suffix: t]
     mkdir -p "$(dirname "$1")"
     cat > "$1" <<EOF
@@ -449,7 +450,7 @@ if [ "\${1:-}" = "-m" ] && [ "\${2:-}" = "venv" ]; then
   echo "venv-build $2${3:-} \$3" >> "\$CALL_LOG"
   mkdir -p "\$3/bin" "\$3/lib/python$2${3:-}/site-packages"
   printf '#!/usr/bin/env bash\nexit 0\n' > "\$3/bin/pip"
-  printf '#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n' > "\$3/bin/python"
+  printf '#!/usr/bin/env bash\ncat >/dev/null </dev/null\nexit 0\n' > "\$3/bin/python"
   chmod +x "\$3/bin/pip" "\$3/bin/python"
   printf 'version = $2.0\nexecutable = $1\n' > "\$3/pyvenv.cfg"
   exit 0

--- a/tests/install-optional-deps.bats
+++ b/tests/install-optional-deps.bats
@@ -397,11 +397,12 @@ EOF
 }
 
 @test "romp-sdk-setup: a uv-built venv (home plus version_info, no executable) is followed and kept, not rebuilt" {
-    # uv writes `version_info = X.Y.Z` and neither `version =` nor `executable =`. Both readers in the script
-    # must take that key: pick_python, to follow the venv's interpreter, and venv_built_for, to read the tag
-    # it was built for; with either reading nothing, the run rebuilds a venv that already matches. The venv
-    # has no lib directory on purpose: with one, venv_built_for takes the tag from lib/python3.X and this
-    # case would hold with the cfg read gone.
+    # uv writes `version_info =` (X.Y for one of its managed interpreters, X.Y.Z for a system python) and
+    # neither `version =` nor `executable =`. Both readers in the script must take that key, and its X.Y
+    # prefix from either shape (this cfg carries the longer one): pick_python, to follow the venv's
+    # interpreter, and venv_built_for, to read the tag it was built for; with either reading nothing, the
+    # run rebuilds a venv that already matches. The venv has no lib directory on purpose: with one,
+    # venv_built_for takes the tag from lib/python3.X and this case would hold with the cfg read gone.
     VENV="$TEST_DIR/state/sdkvenv"; mkdir -p "$VENV/bin"
     write_stub_py "$TEST_DIR/uvhome/python3.12" 3.12          # the venv's interpreter, off PATH
     ln -s "$TEST_DIR/uvhome/python3.12" "$VENV/bin/python"

--- a/tests/romp-serve.bats
+++ b/tests/romp-serve.bats
@@ -373,10 +373,12 @@ STUB
 }
 
 @test "pick_python: a uv-built venv (home plus version_info, no executable) still names its interpreter" {
-    # uv writes `home =` and `version_info = X.Y.Z` and no `executable =` line (the stdlib's venv writes
-    # `version =`), so the X.Y that gates every home candidate comes from the version_info key alone. The
-    # `version_info` fake_python matches is in the probe's Python source, a different thing: every other
-    # cfg in this file writes `version =` or no version line, so the key was read by nothing here.
+    # uv writes `home =` and `version_info =` (X.Y for one of its managed interpreters, X.Y.Z for a system
+    # python) and no `executable =` line (the stdlib's venv writes `version =`), so the X.Y that gates every
+    # home candidate comes from the version_info key alone; the reader takes the X.Y prefix of either shape,
+    # and this cfg carries the longer one. The `version_info` fake_python matches is in the probe's Python
+    # source, a different thing: every other cfg in this file writes `version =` or no version line, so the
+    # key was read by nothing here.
     fakebin="$TEST_DIR/fakebin-uv"; mkdir -p "$fakebin"
     fake_python "$fakebin/python3.14" 3.14
     fake_python "$TEST_DIR/uvhome/python3.12" 3.12


### PR DESCRIPTION
Two small follow-ups to the review of #1295, both in the install-script bats files. Commit 1 fixes a hang; commit 2 corrects two comments.

## Symptom

`bats tests/install-optional-deps.bats`, run from a terminal or from any shell that leaves stdin open, stops at the second romp-codex-setup case and does not return until that stdin closes. CI does not show it (no open stdin there). With `</dev/null` on the bats command the file passes.

Separately, the comments on the two uv-built-venv cases (`tests/romp-serve.bats`, the pick_python case; `tests/install-optional-deps.bats`, the romp-sdk-setup case) say uv writes `version_info = X.Y.Z`. For one of uv's managed interpreters it writes X.Y; X.Y.Z is what a venv over a system python gets.

## Cause

`write_stub_py`'s venv python is `cat >/dev/null; exit 0`, which drains the heredoc romp-sdk-setup and romp-codex-setup pipe into `bin/python -` for the ready message. romp-codex-setup also runs that python once with no heredoc, to stage the CLI (`"$VENV/bin/python" "$_INSTALLER" "$STATE"`); there the stub's cat reads the caller's stdin and waits for EOF. The two cases that build a venv reach that call; the first case refuses ROMP_PYTHON before it.

uv writes the version_info key in two shapes and the comments named only the system-python one. Checked with uv 0.12.1: a managed 3.13 gives `version_info = 3.13`, `/usr/bin/python3.12` gives `version_info = 3.12.3`.

## Fix

Commit 1: the stub's cat reads /dev/null (`cat >/dev/null </dev/null`). Nothing else in the stub changes, and the heredoc callers do not depend on the document being read (the runs below go through them). The stub's header comment says why the redirect is there.

Commit 2: the two comments name both shapes and say the fixture carries the longer one. Both readers take the X.Y prefix of either shape (pick_python's `^([0-9]+\.[0-9]+)` match, venv_built_for's sed), so no script changes. The fixture value stays `version_info = 3.12.3`: it is the shape that exercises the prefix read, and a bare X.Y would leave the X.Y.Z handling of this key untested.

## Tests

Commit 1, before the change: `timeout 60 bats -f codex-setup tests/install-optional-deps.bats` with stdin held open (a fifo a background sleep keeps open) exits 124 at 60 s; the first case passes and the second never returns. After the change the same invocation passes 3/3 in 1 s. The whole file passes 24/24 with stdin held open and with `</dev/null`.

Commit 2 changes comments only, so no test fails before it. After it, `tests/romp-serve.bats` passes 42/42 and `tests/install-optional-deps.bats` 24/24 (stdin from /dev/null, and held open). As a check on the comments' claim, each uv case was also run once with the fixture flipped to the bare `version_info = 3.12` and passed; the fixture in the PR is unchanged.

Every run had ROMP_STATE_DIR and XDG_STATE_HOME at a scratch directory, ROMP_MANAGER_PORT=1 and the kernel port variables unset, on top of what each file's setup does. The full suites were not run for two bats-file edits; the two files ran as above.

## Tier

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)