### PR TITLE
Composer: "@" plus letters lists the live sessions by name, and Enter, Tab or a click inserts the plain @name

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -53,6 +53,20 @@ A pull request number in a message, a card, or a note (`#123`, `PR #123`, or
 directory has as its `origin` remote; when that remote is not on GitHub, the number stays
 plain text.
 
+**Naming another session.** Type `@` and the first letters of a session's name in the
+message box, and the sessions whose names match are listed above it, twelve at most; when
+more match, the last row says how many, and more letters narrow the list. Arrow to one and
+press **⏎** or **Tab**, or click it, and `@name` goes into the message as plain text, the
+name the session's mail tools take. Which form goes in depends on the session you are
+writing to. When you write to a session on this machine, a session on another machine goes
+in as `@host:name`, the way this machine knows it. When you write to a session on another
+machine, every name goes in bare, because the dashboard cannot see what that machine calls
+its peers; if the bare name is ambiguous there, the session's mail tools refuse the send and
+list the candidates as `host:name`, and the session picks one. **Escape** closes the list
+without inserting, and it stays closed for that `@` until you delete it: more letters, or a
+caret move away and back, do not reopen it. In the sent message, a name that matches a live
+session is shown as a chip in that session's color.
+
 **A message that has not gone yet.** Send to a busy session and your message waits as a
 dashed bubble under an hourglass until the session takes it — while it compacts, while a
 turn runs, or in the beat before the kernel confirms the send. Until then it is still

--- a/ui/webview/ask-draft-predates.test.ts
+++ b/ui/webview/ask-draft-predates.test.ts
@@ -37,7 +37,7 @@ test("every send path ends the draft, and a send re-arms the picker's claim on t
   const clears = RENDER.match(/draftStartedAt\.delete\(activeId\)/g) || [];
   assert.ok(clears.length >= 4, "cleared on the ask/rewind/plain sends + the emptied box, got " + clears.length);
   // once the box is empty again the picker takes it back → just type the answer
-  assert.match(RENDER, /ta\.style\.height = "";\s*\n\s*\/\/ The box is empty again[\s\S]*?setComposerAskMode\(\);/);
+  assert.match(RENDER, /clearBox\(\);[^\n]*\n\s*\/\/ The box is empty again[\s\S]*?setComposerAskMode\(\);/);   // clearBox: the composer's one clear path (composer-mention-pane.test.ts)
   // and a mode flip while typing repaints the box's own cue (the "answering" tint)
   assert.match(RENDER, /if \(had !== draftStartedAt\.has\(activeId\)\) setComposerAskMode\(\);/);
 });

--- a/ui/webview/composer-mention-pane.test.ts
+++ b/ui/webview/composer-mention-pane.test.ts
@@ -1,0 +1,560 @@
+// The @-mention card's DOM half, run for real. The mention block of setupComposer and the transcript's chip
+// functions are sliced from render.ts by their banner comments, bundled with composer-mention.ts the way the
+// webview is built, and driven in headless Chromium against a real textarea, so the browser decides what
+// Ctrl+A, PageUp, Home, Ctrl+Z and a synthetic IME keystroke do to the caret, the selection and the undo
+// stack. Skips by name when playwright or its browser is missing (md-sanitize-browser.test.ts's idiom; CI's
+// test step runs before its Chromium install, so the browser cases skip there). Source pins hold only the
+// wiring the slices cannot carry: the one clear helper every clear site calls, the keydown order, the roster
+// hook at the top of renderTabs, the transcript hook.
+// Synthetic names only (romp, rompdocs, web, api, TESTHOST; placeholder ids).
+import { test, after } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const PKG = process.cwd();                                   // vscode-extension, where npm test runs
+const UI = path.resolve(PKG, "..", "ui", "webview");
+const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
+const req = createRequire(path.join(PKG, "package.json"));   // runtime requires: esbuild must not bundle playwright
+
+let pw: any = null;
+try { pw = req("playwright"); } catch { pw = null; }
+
+// ── the slices ──────────────────────────────────────────────────────────────────────────────────────────
+
+/** The composer's mention block: from its banner to the prompt history's, inside setupComposer. */
+function mentionBlock(): string {
+  const a = RENDER.indexOf("  // ── @-MENTION autocomplete");
+  const b = RENDER.indexOf("  // ── PROMPT HISTORY");
+  assert.ok(a > 0 && b > a, "the mention block sits between the slash menu and the prompt history");
+  return RENDER.slice(a, b);
+}
+/** The transcript side: the roster signature, the chip dress and markMentions, up to setupComposer's banner. */
+function chipBlock(): string {
+  const a = RENDER.indexOf('let mentionRosterSig = "";');
+  const b = RENDER.indexOf("// Composer: Enter sends the message");
+  assert.ok(a > 0 && b > a, "the chip functions sit just before setupComposer");
+  return RENDER.slice(a, b);
+}
+
+/** Both slices, bundled as the webview is built (in memory), each wrapped with the closure it lives in:
+ *  the block's free names are the composer's (ta, sessions, activeId, the stubs the card paints with), the
+ *  chips' are the module's (sessions, views, CHIP_LABEL). Handed to the page as window.__mention. */
+function bundle(): string {
+  const esbuild = req("esbuild");
+  const contents = `
+import { MENTION_MAX_ROWS, mentionQuery, rankMentions, mentionMoreNote, mentionToken, insertMention, mentionKeyAction, mentionSegments } from "./composer-mention";
+const CHIP_LABEL: any = { working: "Working", ready: "Ready", idle: "Idle", closed: "Closed", needsInput: "Blocked" };
+const el = (tag: string, cls?: string) => { const e = document.createElement(tag); if (cls) e.className = cls; return e; };
+const hostNameNodes = (name: string, _id: string) => [document.createTextNode(name)];
+const isProvisionalId = (id: string) => id.startsWith("prov:");
+(window as any).__mention = {
+  mount(ta: HTMLTextAreaElement, env: any) {
+    const sessions: Map<string, any> = env.sessions;
+    let activeId: string | null = env.activeId ?? null;
+    let composerManualH: number | null = 7;
+    let refreshMentionCard: any = null, clearComposerBox: any = null;
+    const updateSlash = () => { env.slashUpdates = (env.slashUpdates || 0) + 1; };
+${mentionBlock()}
+    return { updateMention, mentionKey, pickMention, closeMention, clearBox,
+      refresh: () => refreshMentionCard(), clearViaHook: () => clearComposerBox(),
+      setActive: (id: string | null) => { activeId = id; },
+      state: () => ({ open: !!mPop, items: mItems.map((c) => c.name), sel: mSel, at: mAt, dismissedAt: mDismissedAt, more: mMore, manualH: composerManualH,
+                      rows: mPop ? Array.from(mPop.children).map((r) => (r.classList.contains("sel") ? "*" : "") + (r.classList.contains("mention-more") ? "+" : "") + (r.querySelector(".mention-name")?.textContent ?? r.textContent)) : [] }) };
+  },
+  chips(env: any) {
+    const sessions: Map<string, any> = env.sessions, views: Map<string, any> = env.views;
+    let refreshMentionCard: any = env.refreshMentionCard || null;
+${chipBlock()}
+    return { markMentions, refreshMentionChips, remarkMentions, mentionRosterChanged, dressMentionChip };
+  },
+};
+`;
+  const r = esbuild.buildSync({
+    stdin: { contents, resolveDir: UI, loader: "ts", sourcefile: "mention-probe.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(PKG, "node_modules")], logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+
+// The page: the composer's textarea and a transcript root. The harness wires the composer's keydown order
+// (the card's keys first, then an IME's Enter is left alone, then Cmd/Ctrl+Enter stages, then Enter sends; each
+// clear goes through clearBox) and the input listener, as render.ts does; the source pins below hold that order.
+const PAGE = `<!DOCTYPE html><html><head><meta charset=utf-8><style>
+body { margin: 0; padding: 200px 20px 20px; } textarea { width: 400px; height: 80px; font: 14px monospace; }
+.mention-pop { position: fixed; }
+</style></head><body><div id="content"></div><textarea id="composer-input" rows="4"></textarea>
+<script src="/dist/mention.js"></script>
+<script>
+window.__setup = (roster, activeId) => {
+  const w = window;
+  if (w.__api) w.__api.closeMention();
+  document.getElementById("mention-pop")?.remove();
+  const old = document.getElementById("composer-input");
+  const ta = document.createElement("textarea"); ta.id = "composer-input"; ta.rows = 4; old.replaceWith(ta);
+  const env = { sessions: new Map(roster.map((r) => [r.id, { id: r.id, name: r.name, color: r.color || null, status: { state: r.state || "ready" } }])),
+                activeId: activeId || null, sent: [], staged: [] };
+  const api = w.__mention.mount(ta, env);
+  ta.addEventListener("keydown", (e) => {
+    if (api.mentionKey(e)) return;
+    if (e.key === "Enter" && (e.isComposing || e.keyCode === 229)) return;
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey) && !e.shiftKey) { e.preventDefault(); if (ta.value.trim()) { env.staged.push(ta.value); api.clearBox(); } return; }
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); if (ta.value.trim()) { env.sent.push(ta.value); api.clearBox(); } }
+  });
+  ta.addEventListener("input", () => api.updateMention());
+  w.__api = api; w.__env = env; w.__ta = ta;
+  ta.focus();
+};
+</script></body></html>`;
+
+const SID = (n: number) => "1111111" + n + "-2222-4333-8444-555555555555";
+const ROSTER = [
+  { id: SID(1), name: "romp", color: { bg: "#3a7bd5", fg: "#ffffff" }, state: "working" },
+  { id: SID(2), name: "rompdocs" },
+  { id: SID(3), name: "web" },
+  { id: "TESTHOST:" + SID(4), name: "TESTHOST:web" },
+];
+
+let browserP: Promise<any> | null = null;
+const browser = () => (browserP ||= pw.chromium.launch());
+after(async () => { if (browserP) { try { await (await browserP).close(); } catch { /* never launched */ } } });
+
+type Harness = { page: any; state: () => Promise<any>; value: () => Promise<string>; env: () => Promise<any>; settle: () => Promise<unknown>; errors: string[] };
+
+/** A fresh page on the harness, its composer mounted over `roster`, writing to `activeId`; null (and the test
+ *  skipped, by name) when no playwright browser can be launched here. */
+async function open(t: any, roster: unknown[] = ROSTER, activeId: string | null = null): Promise<Harness | null> {
+  if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser leg needs it (CI's test step runs before its Chromium install)"); return null; }
+  let b: any;
+  try { b = await browser(); }
+  catch (e) { t.skip("no playwright browser on this machine; the browser leg needs one (CI's test step runs before its Chromium install): " + String((e as Error).message).split("\n")[0]); return null; }
+  const js = bundle();
+  const page = await b.newPage({ viewport: { width: 800, height: 600 } });
+  const errors: string[] = [];
+  page.on("pageerror", (e: Error) => errors.push(e.message));
+  await page.route("http://romp.test/**", (route: any) => {
+    const u = new URL(route.request().url());
+    if (u.pathname === "/page") return route.fulfill({ contentType: "text/html", body: PAGE });
+    if (u.pathname === "/dist/mention.js") return route.fulfill({ contentType: "application/javascript", body: js });
+    return route.fulfill({ status: 404, body: "" });
+  });
+  await page.goto("http://romp.test/page");
+  await page.evaluate(([r, a]: [unknown[], string | null]) => (window as any).__setup(r, a), [roster, activeId]);
+  const state = () => page.evaluate(() => (window as any).__api.state());
+  const value = () => page.evaluate(() => (window as any).__ta.value as string);
+  const env = () => page.evaluate(() => { const e = (window as any).__env; return { sent: e.sent, staged: e.staged, slashUpdates: e.slashUpdates || 0 }; });
+  // selectionchange is queued as a task after the selection moves: let it run before reading the card
+  const settle = () => page.evaluate(() => new Promise((r) => setTimeout(r, 30)));
+  return { page, state, value, env, settle, errors };
+}
+
+// ── the card, executed ──────────────────────────────────────────────────────────────────────────────────
+
+test("in Chromium: @ plus letters opens the card, Enter inserts the token through the undo stack, and Ctrl+Z puts the typed query back", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("ask @ro");
+  let s = await h.state();
+  assert.equal(s.open, true);
+  assert.deepEqual(s.rows, ["*romp", "rompdocs"], "prefix matches, the best highlighted, in the card's rows");
+  assert.equal(await h.page.evaluate(() => document.getElementById("mention-pop")?.getAttribute("role")), "listbox");
+  await h.page.keyboard.press("Enter");
+  assert.equal(await h.value(), "ask @romp ", "the pick replaced the typed query with the plain token");
+  assert.deepEqual((await h.env()).sent, [], "Enter with the card open picks; it never sends");
+  s = await h.state();
+  assert.equal(s.open, false);
+  await h.page.keyboard.press("Control+z");
+  assert.equal(await h.value(), "ask @ro", "the pick sits on the textarea's undo stack (a value assignment would have dropped it)");
+  // (the undo restores the pre-command selection, "@ro" selected: a selection is not a caret, so the card stays closed)
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: Tab picks too, and a click on a row picks that row while the textarea keeps focus", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("@ro");
+  await h.page.keyboard.press("Tab");
+  assert.equal(await h.value(), "@romp ", "Tab picks the highlighted row");
+  assert.equal(await h.page.evaluate(() => document.activeElement?.id), "composer-input", "focus never left the composer");
+  await h.page.keyboard.type("and @ro");
+  assert.deepEqual((await h.state()).rows, ["*romp", "rompdocs"]);
+  await h.page.click(".mention-row[data-idx='1']");
+  assert.equal(await h.value(), "@romp and @rompdocs ", "the clicked row, not the highlighted one");
+  assert.equal(await h.page.evaluate(() => document.activeElement?.id), "composer-input", "a mousedown on the card does not take focus");
+  assert.equal((await h.state()).open, false);
+  assert.deepEqual((await h.env()).sent, []);
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: Ctrl+A with the card open closes it (a selection is not a caret), and Enter then sends the draft as typed, never a duplicate", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("ask @ro");
+  assert.equal((await h.state()).open, true);
+  await h.page.keyboard.press("Control+a");
+  await h.settle();
+  assert.equal((await h.state()).open, false, "selectionchange closed the card");
+  await h.page.keyboard.press("Enter");
+  assert.deepEqual((await h.env()).sent, ["ask @ro"], "the draft as typed: not 'ask @romp ask @ro'");
+  assert.equal(await h.value(), "");
+  // and the pick itself refuses a caret the card has not followed yet (selectionchange is asynchronous, so a
+  // pick can land first): the token the caret ends must be the one the card is about
+  await h.page.keyboard.type("ask @ro");
+  const r = await h.page.evaluate(() => {
+    const w = window as any; const ta = w.__ta as HTMLTextAreaElement;
+    ta.setSelectionRange(0, 0);
+    w.__api.pickMention({ id: "x", name: "romp" });   // the same task: mAt is still the stale token
+    return { value: ta.value, open: w.__api.state().open };
+  });
+  assert.deepEqual(r, { value: "ask @ro", open: false }, "nothing inserted, the card closed");
+  // and when the caret ends ANOTHER token than the card's: two tokens, the card about the second, the caret
+  // moved to the end of the first before the card followed; the pick must not splice the first
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.keyboard.type("@we @ro");
+  assert.deepEqual((await h.state()).at, { start: 4, query: "ro" });
+  const r2 = await h.page.evaluate(() => {
+    const w = window as any; const ta = w.__ta as HTMLTextAreaElement;
+    ta.setSelectionRange(3, 3);   // the caret now ends "@we": a token, but not the card's
+    w.__api.pickMention({ id: "x", name: "romp" });
+    return { value: ta.value, open: w.__api.state().open };
+  });
+  assert.deepEqual(r2, { value: "@we @ro", open: false }, "a token that is not the card's: nothing inserted, the card closed");
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: PageUp on a two-line draft closes the card, and Enter sends the two lines unchanged", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("line one that is long enough");
+  await h.page.keyboard.press("Shift+Enter");
+  await h.page.keyboard.type("ask @ro");
+  assert.equal((await h.state()).open, true);
+  await h.page.keyboard.press("PageUp");
+  await h.settle();
+  assert.equal((await h.state()).open, false);
+  await h.page.keyboard.press("Enter");
+  assert.deepEqual((await h.env()).sent, ["line one that is long enough\nask @ro"]);
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: a clear (Cmd/Ctrl+Enter stages, the module-level hook cancelComposerEdit uses) closes the card; Enter then sends nothing and inserts nothing", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("ask @ro");
+  assert.equal((await h.state()).open, true);
+  await h.page.keyboard.press("Control+Enter");
+  let s = await h.state();
+  assert.equal(s.open, false, "the stage's clear went through clearBox, which the card sees");
+  assert.equal(s.manualH, null, "the drag height snapped back with it");
+  assert.deepEqual((await h.env()).staged, ["ask @ro"]);
+  await h.page.keyboard.press("Enter");
+  assert.equal(await h.value(), "", "a stale '@romp ' must not appear over the emptied composer");
+  assert.deepEqual((await h.env()).sent, []);
+  // the module-level hook (cancelComposerEdit's path) is the same helper, and the slash menu is refreshed too
+  await h.page.keyboard.type("ask @ro");
+  assert.equal((await h.state()).open, true);
+  const before = (await h.env()).slashUpdates;
+  await h.page.evaluate(() => (window as any).__api.clearViaHook());
+  s = await h.state();
+  assert.equal(s.open, false);
+  assert.equal(await h.value(), "");
+  assert.equal((await h.env()).slashUpdates, before + 1);
+  // the other direction: text put INTO the box by code, no input event (a queued message taken back for
+  // editing). The assignment lands the caret at the end and selectionchange fires, so the card follows a
+  // draft that ends in an @query as it follows typing; that path needs no call of its own
+  await h.page.evaluate(() => { (window as any).__ta.value = "ask @ro"; });
+  await h.settle();
+  assert.deepEqual((await h.state()).rows, ["*romp", "rompdocs"], "a fill by code opens the card for the token the caret now ends");
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: an IME composition's keys are not the card's, and the card waits for compositionend to re-read the composer", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("@ro");
+  assert.equal((await h.state()).open, true);
+  const r = await h.page.evaluate(() => {
+    const w = window as any; const ta = w.__ta as HTMLTextAreaElement;
+    // the card's handler alone: the harness's own Enter-to-send is not what this test is about
+    const fire = (key: string) => { const e = new KeyboardEvent("keydown", { key, isComposing: true, cancelable: true, bubbles: true }); return w.__api.mentionKey(e) || e.defaultPrevented; };
+    const enter = fire("Enter"), down = fire("ArrowDown");
+    const afterKeys = { ...w.__api.state(), value: ta.value };
+    // and through the composer's whole keydown order: the commit Enter, bare or with Ctrl, neither sends nor stages
+    const commits = [new KeyboardEvent("keydown", { key: "Enter", isComposing: true, cancelable: true, bubbles: true }),
+                     new KeyboardEvent("keydown", { key: "Enter", isComposing: true, ctrlKey: true, cancelable: true, bubbles: true })];
+    for (const k of commits) ta.dispatchEvent(k);
+    const afterCommit = { prevented: commits.some((k) => k.defaultPrevented), value: ta.value, sent: w.__env.sent.slice(), staged: w.__env.staged.slice(), open: w.__api.state().open };
+    ta.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+    ta.value = "@rom"; ta.setSelectionRange(4, 4); ta.dispatchEvent(new Event("input", { bubbles: true }));
+    const composing = w.__api.state();
+    ta.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+    const ended = w.__api.state();
+    return { enter, down, afterKeys, afterCommit, composing, ended };
+  });
+  assert.equal(r.enter, false, "Enter mid-composition commits the IME's text, not a pick");
+  assert.equal(r.down, false, "ArrowDown mid-composition walks the IME's candidates");
+  assert.equal(r.afterKeys.open, true); assert.equal(r.afterKeys.sel, 0); assert.equal(r.afterKeys.value, "@ro");
+  assert.deepEqual(r.afterCommit, { prevented: false, value: "@ro", sent: [], staged: [], open: true }, "the commit Enter is the IME's: nothing sent, nothing staged, the browser's default kept");
+  assert.equal(r.composing.at.query, "ro", "the interim text is the IME's: the card did not re-read it");
+  assert.equal(r.ended.at.query, "rom", "compositionend re-reads the composer");
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: a roster re-rank under the open card keeps the highlight on the SESSION, and a rename reaches the card's rows; a viewer, a closed session and a provisional tab are not listed", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("@ro");
+  await h.page.keyboard.press("ArrowDown");
+  assert.deepEqual((await h.state()).rows, ["romp", "*rompdocs"]);
+  // a peer renames romp to zromp: the rows re-rank, the highlight stays on rompdocs (a highlight kept by row
+  // index would land on zromp)
+  await h.page.evaluate((sid: string) => { const w = window as any; w.__env.sessions.get(sid).name = "zromp"; w.__api.refresh(); }, SID(1));
+  assert.deepEqual((await h.state()).rows, ["*rompdocs", "zromp"]);
+  await h.page.keyboard.press("Enter");
+  assert.equal(await h.value(), "@rompdocs ");
+  // the highlighted session itself renamed: the highlight follows it, and the pick inserts the NEW name
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.evaluate((sid: string) => { (window as any).__env.sessions.get(sid).name = "romp"; }, SID(1));
+  await h.page.keyboard.type("@ro");
+  assert.deepEqual((await h.state()).rows, ["*romp", "rompdocs"]);
+  await h.page.evaluate((sid: string) => { const w = window as any; w.__env.sessions.get(sid).name = "zromp"; w.__api.refresh(); }, SID(1));
+  assert.deepEqual((await h.state()).rows, ["rompdocs", "*zromp"]);
+  await h.page.keyboard.press("Enter");
+  assert.equal(await h.value(), "@zromp ", "never the stale name postal would no longer resolve");
+  // the highlighted session left the roster: the first row is highlighted
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.keyboard.type("@ro");
+  await h.page.keyboard.press("ArrowDown");
+  assert.deepEqual((await h.state()).rows, ["rompdocs", "*zromp"]);
+  await h.page.evaluate((sid: string) => { const w = window as any; w.__env.sessions.delete(sid); w.__api.refresh(); }, SID(1));
+  assert.deepEqual((await h.state()).rows, ["*rompdocs"]);
+  // a subagent viewer is a tab, not a session: its row (sub set, named by the agent's description) takes no mail
+  await h.page.evaluate((sid: string) => { const w = window as any; w.__env.sessions.set(sid + "/agent/abc", { id: sid + "/agent/abc", name: "roster walk", color: null, status: { state: "idle" }, sub: { parentId: sid, agentId: "abc" } }); w.__api.refresh(); }, SID(3));
+  assert.deepEqual((await h.state()).rows, ["*rompdocs"], "the viewer's name is not listed");
+  // a closed session and a provisional tab are not listed: neither can take mail
+  await h.page.evaluate(() => { const w = window as any; w.__env.sessions.set("prov:1", { id: "prov:1", name: "rompnew", color: null, status: { state: "ready" } }); w.__env.sessions.get("11111112-2222-4333-8444-555555555555").status = { state: "closed" }; w.__api.refresh(); });
+  assert.equal((await h.state()).open, false, "nothing left to list: the card closed");
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: Escape latches the card closed for that @ until it is deleted; a caret move away and back, or more letters, do not reopen it", async (t) => {
+  const h = await open(t); if (!h) return;
+  await h.page.keyboard.type("ask @we");
+  assert.equal((await h.state()).open, true);
+  await h.page.keyboard.press("Escape");
+  let s = await h.state();
+  assert.equal(s.open, false); assert.equal(s.dismissedAt, 4);
+  await h.page.keyboard.press("Home"); await h.settle();
+  s = await h.state();
+  assert.equal(s.dismissedAt, 4, "the caret left the token; the latch holds while its @ does");
+  await h.page.keyboard.press("End"); await h.settle();
+  s = await h.state();
+  assert.equal(s.open, false, "back at the token's end the card the user dismissed stays dismissed");
+  await h.page.keyboard.type("b");
+  assert.equal((await h.state()).open, false, "more letters of the same token do not re-pop it");
+  // the query backspaced away to the bare "@", then retyped: the same "@", still dismissed
+  for (let i = 0; i < 3; i++) await h.page.keyboard.press("Backspace");   // "ask @"
+  assert.equal(await h.value(), "ask @");
+  assert.equal((await h.state()).dismissedAt, 4, "the latch holds on the bare @");
+  await h.page.keyboard.type("w");
+  s = await h.state();
+  assert.equal(s.open, false, "the query typed again does not reopen the card");
+  assert.equal(s.dismissedAt, 4);
+  // an edit BEFORE the "@" moves it, and the latch follows
+  await h.page.keyboard.press("Home"); await h.settle();
+  await h.page.keyboard.type("so ");
+  assert.equal(await h.value(), "so ask @w");
+  assert.equal((await h.state()).dismissedAt, 7, "the latch moved with its @");
+  await h.page.keyboard.press("End"); await h.settle();
+  assert.equal((await h.state()).open, false, "back at the token's end, still dismissed");
+  await h.page.keyboard.press("Home"); await h.settle();
+  for (let i = 0; i < 3; i++) await h.page.keyboard.press("Delete");   // "ask @w"
+  assert.equal(await h.value(), "ask @w");
+  assert.equal((await h.state()).dismissedAt, 4, "a deletion before the @ moves it back");
+  await h.page.keyboard.press("End"); await h.settle();
+  assert.equal((await h.state()).open, false);
+  for (let i = 0; i < 2; i++) await h.page.keyboard.press("Backspace");   // "ask "
+  assert.equal(await h.value(), "ask ");
+  assert.equal((await h.state()).dismissedAt, -1, "the @ is gone: the latch re-arms");
+  await h.page.keyboard.type("@we");
+  assert.equal((await h.state()).open, true, "a fresh @ opens again");
+  // a selection over the token BEFORE the latched "@" deleted in one step: the edit ends at the caret, so the
+  // latch moves by what went ("@w " less), where a prefix/suffix diff alone would read the deletion as the
+  // later "@w" and drop the latch
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.keyboard.type("@w @we");
+  await h.page.keyboard.press("Escape");
+  assert.equal((await h.state()).dismissedAt, 3);
+  await h.page.keyboard.press("Home"); await h.settle();
+  for (let i = 0; i < 3; i++) await h.page.keyboard.press("Shift+ArrowRight");
+  await h.page.keyboard.press("Delete");
+  assert.equal(await h.value(), "@we");
+  assert.equal((await h.state()).dismissedAt, 0, "the latch followed its @ to the start");
+  await h.page.keyboard.press("End"); await h.settle();
+  assert.equal((await h.state()).open, false, "the same dismissed token, still dismissed");
+  // the caret lands on the latched token while a card for ANOTHER token is up (a click from "@ro" back onto
+  // "@we"): that card comes down; the latch is not a bare no-op
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.keyboard.type("ask @we");
+  await h.page.keyboard.press("Escape");
+  await h.page.keyboard.type(" @ro");
+  assert.deepEqual((await h.state()).rows, ["*romp", "rompdocs"], "a card for the second token");
+  await h.page.evaluate(() => { (window as any).__ta.setSelectionRange(7, 7); });   // the end of "@we"
+  await h.settle();
+  s = await h.state();
+  assert.equal(s.open, false, "the @ro card closed when the caret reached the dismissed @we");
+  assert.equal(s.dismissedAt, 4);
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+test("in Chromium: past twelve matches the last row counts the rest and takes no pick; the token follows the recipient's kernel", async (t) => {
+  const many = Array.from({ length: 14 }, (_, i) => ({ id: SID(i + 1) + i, name: "romp-" + String(i + 1).padStart(2, "0") }));
+  const h = await open(t, [...many, ROSTER[3]], SID(9)); if (!h) return;
+  await h.page.keyboard.type("@romp");
+  const s = await h.state();
+  assert.equal(s.items.length, 12);
+  assert.equal(s.rows[12], "+2 more, keep typing", "the cap is visible, as the guide says");
+  assert.equal(s.rows.length, 13);
+  await h.page.keyboard.press("ArrowUp");
+  assert.equal((await h.state()).sel, 11, "the arrows wrap over the rows only, never onto the count");
+  const picked = await h.page.evaluate(() => {
+    const more = document.querySelector(".mention-more") as HTMLElement;
+    more.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    return (window as any).__ta.value;
+  });
+  assert.equal(picked, "@romp", "a mousedown on the count inserts nothing");
+  // writing to a LOCAL session, a remote peer goes in as the display name this kernel knows it by
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.keyboard.type("@TESTHOST:w");
+  await h.page.keyboard.press("Enter");
+  assert.equal(await h.value(), "@TESTHOST:web ");
+  // writing to a REMOTE session, every name goes in bare (composer-mention.ts, mentionToken)
+  await h.page.evaluate(() => (window as any).__api.setActive("TESTHOST:" + "99999999-2222-4333-8444-555555555555"));
+  await h.page.keyboard.press("Control+a"); await h.page.keyboard.press("Backspace");
+  await h.page.keyboard.type("@TESTHOST:w");
+  await h.page.keyboard.press("Enter");
+  assert.equal(await h.value(), "@web ");
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+// ── the transcript's chips, executed ────────────────────────────────────────────────────────────────────
+
+test("in Chromium: chips are exact-name only, keyed by session id, re-dressed on a state, color or name change, never a viewer's, and a name that joins the roster later gets its chip without nesting", async (t) => {
+  const h = await open(t); if (!h) return;
+  const r = await h.page.evaluate(([api, webId]: [string, string]) => {
+    const w = window as any;
+    const sessions = new Map<string, any>([[api, { id: api, name: "api", color: { bg: "#d5643a", fg: "#ffffff" }, status: { state: "working" } }]]);
+    // a subagent viewer under api whose description is the one word "web": a tab, not a session, so "@web" is
+    // not its name (and it must not stand in for web's name in the roster's name set: web's frame is NEW below)
+    sessions.set(api + "/agent/abc", { id: api + "/agent/abc", name: "web", color: null, status: { state: "idle" }, sub: { parentId: api, agentId: "abc" } });
+    const root = document.getElementById("content")!;
+    const thread = document.createElement("div"); root.appendChild(thread);
+    const views = new Map([["v1", { el: thread }]]);
+    let refreshed = 0;
+    const chips = w.__mention.chips({ sessions, views, refreshMentionCard: () => { refreshed++; } });
+    const bubble = document.createElement("div"); bubble.className = "user-bubble md";
+    bubble.innerHTML = "<p>ask @web and @api and @API, not <code>@api</code> or <a href='#'>@api</a></p>";
+    thread.appendChild(bubble);
+    chips.markMentions(bubble);
+    const snap = () => Array.from(bubble.querySelectorAll(".mention-chip")).map((c) => {
+      const e = c as HTMLElement;
+      return { text: e.textContent, sid: e.dataset.sid, title: e.title, bg: e.style.getPropertyValue("--chip-bg") };
+    });
+    const out: any = {};
+    out.first = snap(); out.marked = bubble.dataset.mentions;
+    chips.mentionRosterChanged();                                   // the roster as it is: the signature is taken
+    const taken = refreshed;
+    // web's frame lands after the bubble rendered: a NEW name re-marks the bubble
+    sessions.set(webId, { id: webId, name: "web", color: null, status: { state: "ready" } });
+    chips.mentionRosterChanged();
+    out.afterWeb = snap(); out.nested = bubble.querySelectorAll(".mention-chip .mention-chip").length; out.refreshed1 = refreshed - taken;
+    out.text = bubble.textContent;
+    // api changes state and color: the chip follows without a re-render
+    const a = sessions.get(api); a.status = { state: "ready" }; a.color = { bg: "#112233", fg: "#ffffff" };
+    chips.mentionRosterChanged();
+    out.afterState = snap();
+    // a rename: the chip's text stays as typed, its title names the session as it is now
+    a.name = "api2"; chips.mentionRosterChanged();
+    out.afterRename = snap();
+    // an unchanged roster does nothing (no refresh of the card)
+    const before = refreshed; chips.mentionRosterChanged(); out.idle = refreshed - before;
+    // the session closes; its struck tab keeps it in the map: the chip reads Closed in its color
+    a.status = { state: "closed" }; chips.mentionRosterChanged();
+    out.afterClosed = snap();
+    // a viewer that carries the name is no namesake: the chip stays on the closed session
+    sessions.set(api + "/agent/v", { id: api + "/agent/v", name: "api", color: { bg: "#000000", fg: "#ffffff" }, status: { state: "idle" }, sub: { parentId: api, agentId: "v" } });
+    chips.mentionRosterChanged();
+    out.afterViewer = snap();
+    // a live session takes the name the text carries while the closed one is still in the map: the chip is
+    // re-keyed to it now, not when the closed tab is dismissed (which says nothing about the mention)
+    sessions.set("new-1", { id: "new-1", name: "api", color: { bg: "#445566", fg: "#000000" }, status: { state: "working" } });
+    chips.mentionRosterChanged();
+    out.afterNamesake = snap(); out.closedStillHeld = sessions.has(api);
+    // the closed tab is dismissed: nothing about the mention changed, so nothing moves
+    sessions.delete(api); chips.mentionRosterChanged();
+    out.afterDismiss = snap();
+    // the session is gone from the map: the chip reads Closed and keeps its color
+    sessions.delete("new-1"); chips.mentionRosterChanged();
+    out.afterGone = snap();
+    // a new session takes the name the text carries: the chip is re-keyed to it
+    sessions.set("new-2", { id: "new-2", name: "api", color: { bg: "#667788", fg: "#000000" }, status: { state: "ready" } });
+    chips.mentionRosterChanged();
+    out.afterNew = snap();
+    return out;
+  }, [SID(2), SID(3)]);
+  assert.deepEqual(r.first, [{ text: "@api", sid: SID(2), title: "api · Working", bg: "#d5643a" }],
+    "the exact name only: @API is not a name postal takes, @web names nothing yet (a viewer's description is not a name), the code span and the link are left alone");
+  assert.equal(r.marked, "1", "the bubble is marked for a later re-mark");
+  assert.deepEqual(r.afterWeb.map((c: any) => c.text), ["@web", "@api"], "web's chip arrived with its frame");
+  assert.equal(r.nested, 0, "the existing chip was not wrapped again");
+  assert.equal(r.text, "ask @web and @api and @API, not @api or @api", "the text reads as typed");
+  assert.equal(r.refreshed1, 1, "the open card was re-ranked for the roster change");
+  assert.equal(r.afterState[1].title, "api · Ready"); assert.equal(r.afterState[1].bg, "#112233");
+  assert.equal(r.afterRename[1].title, "api2 · Ready"); assert.equal(r.afterRename[1].text, "@api");
+  assert.equal(r.idle, 0, "the same roster twice: nothing re-ranked");
+  assert.deepEqual(r.afterClosed[1], { text: "@api", sid: SID(2), title: "api2 · Closed", bg: "#112233" }, "closed, no namesake: the chip stays keyed to it");
+  assert.deepEqual(r.afterViewer, r.afterClosed, "a viewer named api is not a session: no re-key");
+  assert.equal(r.closedStillHeld, true, "the closed session was still in the map when the namesake arrived");
+  assert.deepEqual(r.afterNamesake[1], { text: "@api", sid: "new-1", title: "api · Working", bg: "#445566" }, "re-keyed on the namesake going live, not on the closed tab's dismissal");
+  assert.deepEqual(r.afterDismiss, r.afterNamesake, "the dismissal moved nothing");
+  assert.equal(r.afterGone[1].title, "api · Closed"); assert.equal(r.afterGone[1].bg, "#445566"); assert.equal(r.afterGone[1].sid, "new-1");
+  assert.equal(r.afterNew[1].sid, "new-2"); assert.equal(r.afterNew[1].title, "api · Ready"); assert.equal(r.afterNew[1].bg, "#667788");
+  assert.deepEqual(h.errors, []);
+  await h.page.close();
+});
+
+// ── source pins: the wiring the slices cannot carry ─────────────────────────────────────────────────────
+
+test("every clear of the composer goes through clearBox, which refreshes both menus; cancelComposerEdit clears through the module-level hook", () => {
+  const stmts = RENDER.match(/^\s*ta\.value = "";/gm) || [];
+  assert.equal(stmts.length, 1, "one bare clear statement in the file: clearBox's own");
+  assert.match(RENDER, /const clearBox = \(\) => \{\s*\n\s*ta\.value = ""; composerManualH = null; ta\.style\.height = "";\s*\n\s*updateSlash\(\); updateMention\(\);\s*\n\s*\};\s*\n\s*clearComposerBox = clearBox;/);
+  const composer = RENDER.slice(RENDER.indexOf("function setupComposer()"), RENDER.indexOf("  // ── PROMPT HISTORY"));
+  assert.equal((composer.match(/\bclearBox\(\);/g) || []).length, 6, "the stage, the picker answer, the edit, the provisional queue, the send and /mcp");
+  assert.match(RENDER, /function cancelComposerEdit\(sid: string\): void \{\s*\n[^\n]*\n[^\n]*\n\s*clearComposerBox\?\.\(\);/);
+});
+
+test("the composer's keydown: the slash menu, then the card, then an IME's commit Enter is left alone, then the stage, then the send", () => {
+  const start = RENDER.indexOf('  ta.addEventListener("keydown", (e) => {\n    if (slashKey(e)) return;');
+  const end = RENDER.indexOf('  ta.addEventListener("input", () => {', start);
+  assert.ok(start > 0 && end > start, "the composer's keydown listener, up to its input listener");
+  const keys = RENDER.slice(start, end);
+  const card = keys.indexOf("if (mentionKey(e)) return;");
+  const guard = keys.indexOf('if (e.key === "Enter" && (e.isComposing || e.keyCode === 229)) return;');
+  const stage = keys.indexOf('if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {');
+  const send = keys.indexOf('if (e.key === "Enter" && !e.shiftKey && !isCoarsePointer()) {');
+  assert.ok(card > 0 && guard > card && stage > guard && send > stage, "the card, then the IME guard, then the stage, then the send");
+  assert.equal((keys.match(/sendComposer\(\)/g) || []).length, 1, "one send in the listener, behind the guard");
+  assert.match(RENDER, /updateSlash\(\);[^\n]*\n\s*updateMention\(\);/, "the input handler refreshes the card as the query changes");
+});
+
+test("renderTabs opens with the whole-roster hook, ahead of its guards; the user's bubble is marked after its path links, and so is the echo of a send", () => {
+  assert.match(RENDER, /function renderTabs\(\) \{\n  mentionRosterChanged\(\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*if \(kind === "user"\) markMentions\(bubble\);/);
+  // the echo keeps the pinned renderer statement as it stands (chat-md and queued-indicator hold it verbatim); the chip is the next statement
+  assert.match(RENDER, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\);[^\n]*\n\s*if \(!t\.romp && !isCmd\) markMentions\(bubble\);/);
+});

--- a/ui/webview/composer-mention.test.ts
+++ b/ui/webview/composer-mention.test.ts
@@ -1,0 +1,192 @@
+// @-mention autocomplete in the composer: "@ro" lists the live sessions whose names match, and a pick
+// inserts the plain "@name " an agent's mail tools take. The rules live in composer-mention.ts, a pure
+// module, and run for real here: the trigger (an "@" opening a word, never inside an email address or a
+// path), the matcher (a prefix before a substring, case-insensitive, the session being written to left
+// out, twelve rows at most with a count of the rest, remote names by host or by name), the token
+// (relative to the RECIPIENT's kernel: the display name when writing to a local session, the bare name
+// when writing to a remote one), the insertion (refused when the caret no longer ends the token), the
+// keyboard model (Enter picks while the card is open and is not consumed otherwise, so it keeps sending)
+// and the transcript segmenter (the trigger's word rule). The DOM half runs in headless Chromium in
+// composer-mention-pane.test.ts. Synthetic names only (web, api, tests, notes-api, TESTHOST; placeholder ids).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { MENTION_MAX_ROWS, insertMention, matchMentions, mentionBareName, mentionKeyAction, mentionMoreNote,
+         mentionQuery, mentionSegments, mentionToken, rankMentions } from "./composer-mention";
+import type { MentionCandidate } from "./composer-mention";
+
+const SELF = "11111111-2222-4333-8444-555555555555";
+const c = (id: string, name: string, extra: Partial<MentionCandidate> = {}): MentionCandidate => ({ id, name, ...extra });
+const ROSTER: MentionCandidate[] = [
+  c(SELF, "web", { color: { bg: "#3a7bd5", fg: "#ffffff" } }),
+  c("22222222-3333-4444-8555-666666666666", "api", { color: { bg: "#d5643a", fg: "#ffffff" } }),
+  c("33333333-4444-4555-8666-777777777777", "tests"),
+  c("44444444-5555-4666-8777-888888888888", "notes-api"),
+  c("TESTHOST:55555555-6666-4777-8888-999999999999", "TESTHOST:web"),
+  c("TESTHOST:66666666-7777-4888-8999-aaaaaaaaaaaa", "TESTHOST:apidocs"),
+];
+
+// ── the trigger ──
+
+test("an @ opening a word, plus one or more characters, with the caret ending the word, is the query", () => {
+  assert.deepEqual(mentionQuery("@ro", 3), { start: 0, query: "ro" }, "at the start of the composer");
+  assert.deepEqual(mentionQuery("ask @ro", 7), { start: 4, query: "ro" }, "after a space");
+  assert.deepEqual(mentionQuery("first line\n@a", 13), { start: 11, query: "a" }, "after a newline");
+  assert.deepEqual(mentionQuery("ask @ro to look", 7), { start: 4, query: "ro" }, "with text after the word, the caret at its end");
+  assert.deepEqual(mentionQuery("@TESTHOST:we", 12), { start: 0, query: "TESTHOST:we" }, "a host-prefixed query keeps its colon");
+});
+
+test("no query: a bare @, an @ inside an email or a path, a space after the word, a caret inside the word", () => {
+  assert.equal(mentionQuery("@", 1), null, "the bare @ opens nothing: one character at least");
+  assert.equal(mentionQuery("mail a@b.example", 16), null, "an email address");
+  assert.equal(mentionQuery("see /tmp/@x", 11), null, "a path");
+  assert.equal(mentionQuery("ask @ro ", 8), null, "a space closes the token");
+  assert.equal(mentionQuery("ask @romp", 7), null, "the caret inside the word (@ro|mp)");
+  assert.equal(mentionQuery("ask @ro@mp", 10), null, "a second @ is not part of a name");
+  assert.equal(mentionQuery("", 0), null);
+  assert.equal(mentionQuery("@ro", 9), null, "a caret past the end is no caret");
+  assert.equal(mentionQuery("@ro", -1), null);
+});
+
+// ── the matcher ──
+
+test("a prefix of the name ranks before a substring, case-insensitively, alphabetical within a rank", () => {
+  const names = (q: string) => matchMentions(q, ROSTER, null).map((x) => x.name);
+  assert.deepEqual(names("api"), ["api", "TESTHOST:apidocs", "notes-api"], "prefixes first, then the substring hit");
+  assert.deepEqual(names("API"), ["api", "TESTHOST:apidocs", "notes-api"], "case does not matter");
+  assert.deepEqual(names("s"), ["TESTHOST:apidocs", "notes-api", "tests", "TESTHOST:web"],
+    "substring hits (a remote's host counts) stay alphabetical by bare name");
+  assert.deepEqual(names("zzz"), [], "a query nothing matches is empty: the card closes");
+  assert.deepEqual(names(""), [], "an empty query matches nothing");
+});
+
+test("the session being written to is left out; the others stay", () => {
+  assert.deepEqual(matchMentions("we", ROSTER, SELF).map((x) => x.name), ["TESTHOST:web"], "the local web is the writer's own session");
+  assert.deepEqual(matchMentions("we", ROSTER, null).map((x) => x.name), ["web", "TESTHOST:web"],
+    "with no self both webs are listed: same rank, same bare name, the local one first");
+});
+
+test("a remote session matches by its bare name (ranked with the locals) and by its host prefix", () => {
+  const remote = ROSTER[4];
+  assert.equal(mentionBareName(remote), "web");
+  assert.equal(mentionBareName(ROSTER[1]), "api", "a local name is its own bare name");
+  // by host: "@te" finds every session on that host, after the local whose NAME starts with it and
+  // before the substring hit (notes-api)
+  assert.deepEqual(matchMentions("te", ROSTER, null).map((x) => x.name), ["tests", "TESTHOST:apidocs", "TESTHOST:web", "notes-api"]);
+});
+
+test("the list stops at twelve rows, best matches first, and the count of the rest is a note, never a silent drop", () => {
+  const many = Array.from({ length: 20 }, (_, i) => c("id-" + i, "romp-" + String(i).padStart(2, "0")));
+  const out = matchMentions("ro", many, null);
+  assert.equal(out.length, MENTION_MAX_ROWS);
+  assert.equal(MENTION_MAX_ROWS, 12);
+  assert.deepEqual(out.map((x) => x.name), many.slice(0, 12).map((x) => x.name), "alphabetical within the prefix rank");
+  const all = rankMentions("ro", many, null);
+  assert.equal(all.length, 20, "the ranking itself is uncapped");
+  assert.deepEqual(all.slice(0, MENTION_MAX_ROWS), out, "the card's rows are the ranking's head");
+  assert.equal(mentionMoreNote(all.length), "8 more, keep typing");
+  assert.equal(mentionMoreNote(13), "1 more, keep typing");
+  assert.equal(mentionMoreNote(12), null, "every match shown: no note");
+  assert.equal(mentionMoreNote(0), null);
+  assert.equal(rankMentions("zzz", many, null).length, 0);
+  assert.deepEqual(rankMentions("api", ROSTER, SELF), matchMentions("api", ROSTER, SELF), "under the cap the two agree, self excluded in both");
+});
+
+test("a roster entry with no name, or a missing entry, is skipped rather than thrown on", () => {
+  const odd = [c("a", ""), null as unknown as MentionCandidate, c("b", "web")];
+  assert.deepEqual(rankMentions("w", odd, null).map((x) => x.id), ["b"]);
+});
+
+// ── the token and the insertion ──
+
+test("the token is @ plus the name the RECEIVING agent's mail tools take, then one space", () => {
+  const local = ROSTER[1];                  // api, on this kernel
+  const remote = ROSTER[4];                 // TESTHOST:web, on the kernel this one labels TESTHOST
+  const remoteSib = ROSTER[5];              // TESTHOST:apidocs, same kernel as remote
+  const third = c("OTHERHOST:77777777-8888-4999-8aaa-bbbbbbbbbbbb", "OTHERHOST:api");   // a third kernel
+  // writing to a session on THIS kernel: the display name, which is what this kernel's postal resolves
+  // (a peer is registered under the label the frame prefixes)
+  for (const to of [undefined, null, "", SELF]) {
+    assert.equal(mentionToken(local, to), "@api ", "local recipient, local session");
+    assert.equal(mentionToken(remote, to), "@TESTHOST:web ", "local recipient, remote session: this kernel's label for its peer");
+    assert.equal(mentionToken(third, to), "@OTHERHOST:api ");
+  }
+  assert.equal(mentionToken(local), "@api ", "the recipient may be omitted: the local rule");
+  // writing to a session on ANOTHER kernel: that kernel's postal resolves the token, and the frame
+  // knows none of its labels, so every name goes in bare
+  assert.equal(mentionToken(remoteSib, remote.id), "@apidocs ", "a sibling on the recipient's own kernel is local there");
+  assert.equal(mentionToken(local, remote.id), "@api ", "a session on this kernel: its label over there is unknown, bare");
+  assert.equal(mentionToken(third, remote.id), "@api ", "a session on a third kernel: likewise bare");
+  assert.equal(mentionToken(remote, third.id), "@web ", "and the other way round");
+});
+
+test("inserting replaces the typed @query and lands the caret after the space; the tail is kept", () => {
+  const at = mentionQuery("ask @ap to look", 7)!;
+  const out = insertMention("ask @ap to look", at, 7, mentionToken(ROSTER[1]));
+  assert.equal(out.text, "ask @api  to look");
+  assert.equal(out.caret, "ask @api ".length);
+  const end = insertMention("@te", { start: 0, query: "te" }, 3, "@tests ");
+  assert.deepEqual(end, { text: "@tests ", caret: 7 });
+});
+
+test("an insert is refused, text and caret unchanged, when the caret no longer ends the token (a caret move the card never saw)", () => {
+  const at = { start: 4, query: "ro" };
+  // Ctrl+A put the caret at 0 with the card still open; a splice here would repeat the draft
+  assert.deepEqual(insertMention("ask @ro", at, 0, "@romp "), { text: "ask @ro", caret: 0 }, "never 'ask @romp ask @ro'");
+  assert.deepEqual(insertMention("ask @ro", at, 2, "@romp "), { text: "ask @ro", caret: 2 }, "a caret before the @");
+  assert.deepEqual(insertMention("ask @ro", at, 6, "@romp "), { text: "ask @ro", caret: 6 }, "a caret inside the token");
+  assert.deepEqual(insertMention("ask @ro now", at, 11, "@romp "), { text: "ask @ro now", caret: 11 }, "a caret past the token's end");
+  assert.deepEqual(insertMention("ask @ro", at, 8, "@romp "), { text: "ask @ro", caret: 8 }, "a caret past the text");
+  assert.deepEqual(insertMention("ask @xy", at, 7, "@romp "), { text: "ask @xy", caret: 7 }, "a stale token: the text under it changed");
+  assert.deepEqual(insertMention("line one\nask @ro", at, 0, "@romp "), { text: "line one\nask @ro", caret: 0 }, "PageUp on a two-line draft");
+  // and the same token with the caret where it belongs still inserts
+  assert.deepEqual(insertMention("ask @ro", at, 7, "@romp "), { text: "ask @romp ", caret: 10 });
+  assert.deepEqual(insertMention("ask @ro now", at, 7, "@romp "), { text: "ask @romp  now", caret: 10 });
+});
+
+// ── the keyboard model ──
+
+test("with the card CLOSED no key is consumed, so Enter keeps sending and Escape keeps leaving the composer", () => {
+  for (const k of ["Enter", "Tab", "Escape", "ArrowUp", "ArrowDown"]) assert.equal(mentionKeyAction(k, false, 0, 3), null, k);
+  assert.equal(mentionKeyAction("Enter", true, 0, 0), null, "an open flag with no rows is not a card");
+});
+
+test("with the card OPEN: arrows move and wrap, Enter and Tab pick the highlighted row, Escape closes, a modifier passes through", () => {
+  assert.deepEqual(mentionKeyAction("ArrowDown", true, 0, 3), { kind: "move", sel: 1 });
+  assert.deepEqual(mentionKeyAction("ArrowDown", true, 2, 3), { kind: "move", sel: 0 }, "wraps to the top");
+  assert.deepEqual(mentionKeyAction("ArrowUp", true, 0, 3), { kind: "move", sel: 2 }, "wraps to the bottom");
+  assert.deepEqual(mentionKeyAction("Enter", true, 1, 3), { kind: "pick", sel: 1 });
+  assert.deepEqual(mentionKeyAction("Tab", true, 1, 3), { kind: "pick", sel: 1 });
+  assert.deepEqual(mentionKeyAction("Enter", true, 7, 3), { kind: "pick", sel: 2 }, "a highlight past the rows picks the last one");
+  assert.deepEqual(mentionKeyAction("Escape", true, 1, 3), { kind: "close" });
+  assert.equal(mentionKeyAction("a", true, 1, 3), null, "typing narrows through the input handler, not here");
+  assert.equal(mentionKeyAction("Enter", true, 1, 3, true), null, "Shift+Enter stays a newline, Cmd+Enter stays stage");
+});
+
+// ── the transcript segmenter ──
+
+test("a typed @name that names a live session is a segment with the hit; other words, emails and paths stay text", () => {
+  const live = new Map([["web", "S-web"], ["TESTHOST:api", "S-rapi"]]);
+  const lookup = (w: string) => live.get(w) ?? null;
+  assert.deepEqual(mentionSegments("ask @web and @nobody, cc a@b.example /tmp/@x", lookup),
+    [{ text: "ask " }, { text: "@web", hit: "S-web" }, { text: " and @nobody, cc a@b.example /tmp/@x" }]);
+  assert.deepEqual(mentionSegments("@web.", lookup), [{ text: "@web", hit: "S-web" }, { text: "." }], "trailing punctuation stays outside");
+  assert.deepEqual(mentionSegments("(@TESTHOST:api) please", lookup), [{ text: "(@TESTHOST:api) please" }], "an @ after a bracket is not a word start, the trigger's rule");
+  assert.deepEqual(mentionSegments("@web @TESTHOST:api", lookup),
+    [{ text: "@web", hit: "S-web" }, { text: " " }, { text: "@TESTHOST:api", hit: "S-rapi" }], "two in a row");
+  assert.deepEqual(mentionSegments("plain text", lookup), [{ text: "plain text" }]);
+  assert.deepEqual(mentionSegments("", lookup), []);
+  for (const s of ["ask @web and @nobody.", "@web, @web!", "x @web", "cc @web@mastodon.example"]) {
+    assert.equal(mentionSegments(s, lookup).map((g) => g.text).join(""), s, "the segments concatenate back to the input");
+  }
+});
+
+test("a word with a second @ in it is not a mention, the trigger's rule: @name@handle stays text, whole", () => {
+  const live = new Map([["web", "S-web"]]);
+  const lookup = (w: string) => live.get(w) ?? null;
+  assert.deepEqual(mentionSegments("cc @web@mastodon.example", lookup), [{ text: "cc @web@mastodon.example" }], "a fediverse-style handle");
+  assert.deepEqual(mentionSegments("@web@web", lookup), [{ text: "@web@web" }], "no chip on the head");
+  assert.deepEqual(mentionSegments("@web@", lookup), [{ text: "@web@" }], "a trailing @");
+  assert.deepEqual(mentionSegments("ask @web,@web", lookup), [{ text: "ask @web,@web" }], "punctuation then @ is still one word");
+  assert.deepEqual(mentionSegments("@web@x and @web", lookup), [{ text: "@web@x and " }, { text: "@web", hit: "S-web" }], "the clean one after it still chips");
+  assert.equal(mentionQuery("cc @web@mastodon.example", 7), null, "and the trigger opened no card for it either");
+});

--- a/ui/webview/composer-mention.ts
+++ b/ui/webview/composer-mention.ts
@@ -1,0 +1,154 @@
+// @-mention autocomplete for the composer (the user 2026-09-07): typing "@ro" in the message box lists
+// the live sessions whose names match, and a pick puts the plain name in the text the way an agent
+// addresses a peer with its mail tools ("@web ", or "@host:web " for a session on another kernel, the
+// form postal takes to break a name tie; see mentionToken for whose kernel the host is relative to).
+// This module is the PURE half, so it runs for real under node --test: the trigger rule, the matcher,
+// the insertion arithmetic, the keyboard model and the transcript segmenter. render.ts owns the DOM:
+// the card, its rows, the composer wiring, the chip.
+import { hostOf, hostPrefix } from "./host-prefix";
+
+export interface MentionCandidate {
+  id: string;        // the session id as the webview holds it ("host:uuid" for a session on another kernel)
+  name: string;      // the display name as the webview holds it ("host:name" for a session on another kernel)
+  color?: { bg: string; fg: string } | null;
+}
+
+/** The "@query" token the caret ends: where its "@" sits and the text after it. */
+export interface MentionQuery { start: number; query: string; }
+
+/** Rows the card shows at most. Twelve fit its 40vh without a scroll on any laptop; past that the
+ *  final row says how many matches were left out (mentionMoreNote), so a cap is never a silent drop. */
+export const MENTION_MAX_ROWS = 12;
+
+/** The "@query" token the caret sits at the end of, or null. The "@" must OPEN a word: at the start
+ *  of the text or after whitespace, so an email address (a@b.example) or a path (/tmp/@x) never
+ *  triggers. The query is the run of characters after the "@" up to the caret, with no whitespace and
+ *  no second "@", at least one character long; and the caret must END the word, so a caret placed back
+ *  inside "@ro|mp" opens nothing. */
+export function mentionQuery(text: string, caret: number): MentionQuery | null {
+  if (typeof text !== "string" || caret < 0 || caret > text.length) return null;
+  if (caret < text.length && !/\s/.test(text[caret])) return null;
+  const m = /(^|\s)@([^\s@]+)$/.exec(text.slice(0, caret));
+  if (!m) return null;
+  return { start: caret - m[2].length - 1, query: m[2] };
+}
+
+/** The name without the "host:" the viewer prefixed onto a session from another kernel (host-prefix.ts). */
+export function mentionBareName(c: MentionCandidate): string {
+  const p = hostPrefix(c.name, c.id);
+  return p ? p.rest : c.name;
+}
+
+/** Every match in the roster, ranked, case-insensitively: a prefix of the name first, then a prefix
+ *  of the whole "host:name" (a remote session found by its host), then a substring anywhere;
+ *  alphabetical by bare name within a rank, and a local session ahead of a remote namesake. The
+ *  session being written to is left out (a message to it never needs its own name). An empty query
+ *  matches nothing: the card opens on "@" plus a character, never on the bare "@". Uncapped: the card
+ *  shows the first MENTION_MAX_ROWS (matchMentions) and says how many more there were (mentionMoreNote). */
+export function rankMentions(query: string, roster: readonly MentionCandidate[], selfId: string | null | undefined): MentionCandidate[] {
+  const q = (query || "").toLowerCase();
+  if (!q) return [];
+  const scored: { c: MentionCandidate; rank: number; key: string; remote: number }[] = [];
+  for (const c of roster) {
+    if (!c || !c.name || (selfId && c.id === selfId)) continue;
+    const bareName = mentionBareName(c);
+    const bare = bareName.toLowerCase();
+    const full = c.name.toLowerCase();
+    const rank = bare.startsWith(q) ? 3 : full.startsWith(q) ? 2 : full.includes(q) ? 1 : 0;
+    if (rank) scored.push({ c, rank, key: bare, remote: bareName === c.name ? 0 : 1 });
+  }
+  scored.sort((a, b) => b.rank - a.rank || a.key.localeCompare(b.key) || a.remote - b.remote || a.c.name.localeCompare(b.c.name));
+  return scored.map((x) => x.c);
+}
+
+/** The rows the card shows: the best MENTION_MAX_ROWS of rankMentions. */
+export function matchMentions(query: string, roster: readonly MentionCandidate[], selfId: string | null | undefined): MentionCandidate[] {
+  return rankMentions(query, roster, selfId).slice(0, MENTION_MAX_ROWS);
+}
+
+/** The card's last row when the cap dropped matches: "N more, keep typing", plain and not selectable,
+ *  so the user sees that a narrower query is the way to the rest; null when every match is shown.
+ *  `total` is rankMentions' length. */
+export function mentionMoreNote(total: number): string | null {
+  const more = total - MENTION_MAX_ROWS;
+  return more > 0 ? more + " more, keep typing" : null;
+}
+
+/** The text a pick inserts: "@" + the name as the RECEIVING agent's mail tools take it, then one
+ *  space so typing continues. Plain text, no markup: the agent reads the name literally.
+ *
+ *  Postal resolves "host:name" on the kernel the agent runs on: the host must be that kernel's own
+ *  postal name or the label under which IT peers with the named kernel (postal_service.py,
+ *  resolve_recipient and peer_route). So the right form depends on who is being written to:
+ *  - a session on THIS kernel: the display name the webview holds is exactly right. Bare for a local
+ *    session; "host:name" for a remote one, since this kernel registers that peer under the same host
+ *    label the frame prefixes (kernel.py _notify_bus_peer).
+ *  - a session on ANOTHER kernel: the frame carries none of that kernel's labels. The viewer's label
+ *    for it need not be its own hostname, and its labels for the viewer's kernel or a third host are
+ *    unknowable here. Every name goes in bare: the recipient's own siblings resolve as locals there,
+ *    and a name that is ambiguous there is refused by postal with the candidates listed as host:name,
+ *    which the agent can pick from (docs/guide.md says so).
+ *  `recipientId` is the session being written to as the webview holds it ("host:uuid" for a remote);
+ *  omitted, or a local session, and the display name stands. */
+export function mentionToken(c: MentionCandidate, recipientId?: string | null): string {
+  return "@" + (hostOf(recipientId || "") ? mentionBareName(c) : c.name) + " ";
+}
+
+/** Replace the typed "@query" (from its "@" to the caret) with the token; the caret lands after it.
+ *  The caret must still END that token, so text.slice(at.start, caret) is "@" + at.query. When it does
+ *  not (the card stayed open across a caret move the input handler never saw: Ctrl+A, PageUp, a drag
+ *  that ended outside the composer), the splice would repeat the draft between the two positions ("ask
+ *  @ro" with the caret at 0 would come out as "ask @romp ask @ro"), so the insert is REFUSED: the text
+ *  and the caret come back unchanged, and the caller closes the card. */
+export function insertMention(text: string, at: MentionQuery, caret: number, token: string): { text: string; caret: number } {
+  if (caret < at.start || caret > text.length || text.slice(at.start, caret) !== "@" + at.query) return { text, caret };
+  const head = text.slice(0, at.start);
+  return { text: head + token + text.slice(caret), caret: head.length + token.length };
+}
+
+export type MentionKeyAction =
+  | { kind: "move"; sel: number }
+  | { kind: "pick"; sel: number }
+  | { kind: "close" }
+  | null;
+
+/** What a key does while the card is open, given the highlighted row and the row count. Up and down
+ *  move the highlight and wrap; Enter and Tab pick the highlighted row; Escape closes without
+ *  inserting. Null means the key is not the card's: the composer handles it as usual. With the card
+ *  closed nothing is consumed, so Enter keeps sending; and a modifier (Shift+Enter for a newline,
+ *  Cmd/Ctrl+Enter to stage) keeps its own meaning even while the card is up. */
+export function mentionKeyAction(key: string, open: boolean, sel: number, count: number, modifier = false): MentionKeyAction {
+  if (!open || count <= 0 || modifier) return null;
+  if (key === "ArrowDown") return { kind: "move", sel: (sel + 1) % count };
+  if (key === "ArrowUp") return { kind: "move", sel: (sel - 1 + count) % count };
+  if (key === "Enter" || key === "Tab") return { kind: "pick", sel: Math.min(Math.max(sel, 0), count - 1) };
+  if (key === "Escape") return { kind: "close" };
+  return null;
+}
+
+export interface MentionSegment<T> { text: string; hit?: T; }
+
+/** Split a run of plain text at the "@name" tokens that name a live session: `lookup` answers the
+ *  session for a word, or null. The same word rule as the trigger: the "@" opens the word and the word
+ *  runs to whitespace or the end with no second "@" in it, so an email address, a path and a
+ *  "@name@handle" (a fediverse-style handle, or a typo; the trigger never opened a card for it) all
+ *  stay text. Trailing sentence punctuation is left outside the token ("ask @web." names web). A word
+ *  that names nothing stays text. The segments concatenate back to the input exactly. */
+export function mentionSegments<T>(text: string, lookup: (word: string) => T | null | undefined): MentionSegment<T>[] {
+  const out: MentionSegment<T>[] = [];
+  const re = /(^|\s)@([^\s@]+)(?=\s|$)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    const word = m[2].replace(/[.,;:!?)\]}'"]+$/, "");
+    const hit = word ? lookup(word) : null;
+    if (!hit) continue;
+    const start = m.index + m[1].length;
+    if (start > last) out.push({ text: text.slice(last, start) });
+    out.push({ text: "@" + word, hit });
+    last = start + 1 + word.length;
+    re.lastIndex = last;   // rescan from the token's end, so stripped punctuation stays plain text
+  }
+  if (last < text.length) out.push({ text: text.slice(last) });
+  return out;
+}

--- a/ui/webview/composer-resize.test.ts
+++ b/ui/webview/composer-resize.test.ts
@@ -34,8 +34,9 @@ test("dragging sets composerManualH + the height, clamped between min and 60vh",
 });
 
 test("a send snaps the box back to one line (composerManualH cleared)", () => {
-  // in sendComposer, before clearing the inline height
-  assert.match(RENDER, /composerManualH = null;\s*\/\/ a drag-expanded box snaps back to one line after a send/);
+  // in sendComposer's deliver, through the composer's one clear path (clearBox resets the drag height with the text)
+  assert.match(RENDER, /clearBox\(\);\s*\/\/ a drag-expanded box snaps back to one line after a send/);
+  assert.match(RENDER, /const clearBox = \(\) => \{\s*\n\s*ta\.value = ""; composerManualH = null; ta\.style\.height = "";/);
 });
 
 test("a double-click on the handle resets to auto without sending", () => {

--- a/ui/webview/mcp-panel.test.ts
+++ b/ui/webview/mcp-panel.test.ts
@@ -20,7 +20,7 @@ test("the composer intercepts /mcp before it can reach the CLI", () => {
   assert.match(RENDER, /if \(\/\^\\\/mcp\\s\*\$\/\.test\(text\)\) \{/);
   assert.match(RENDER, /openMcpPanel\(sid\);/);
   // the box clears like any consumed command, and the draft with it
-  assert.match(RENDER, /ta\.value = ""; composerManualH = null; ta\.style\.height = "";\s*\n\s*drafts\.delete\(sid\); persistDrafts\(\);\s*\n\s*openMcpPanel\(sid\);/);
+  assert.match(RENDER, /clearBox\(\);\s*\n\s*drafts\.delete\(sid\); persistDrafts\(\);\s*\n\s*openMcpPanel\(sid\);/);   // clearBox: the composer's one clear path, so the menus see the box go empty
 });
 
 test("the panel reads the SDK's designed control requests through the kernel", () => {

--- a/ui/webview/reload-notices.test.ts
+++ b/ui/webview/reload-notices.test.ts
@@ -207,6 +207,7 @@ function liftToastSites(): (w: World) => Lifted {
     const renderComposerChips = () => {};
     const drafts = new Map(), draftStartedAt = new Map();
     let composerManualH = null;
+    const clearBox = () => { ta.value = ""; composerManualH = null; ta.style.height = ""; };   // the composer's one clear path; its menu refreshes are not lifted (composer-mention-pane.test.ts)
     const persistDrafts = () => { W.persists++; };
     const renderStagedStrip = () => {};
     const sessions = W.sessions;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -63,6 +63,8 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
+import { MENTION_MAX_ROWS, mentionQuery, rankMentions, mentionMoreNote, mentionToken, insertMention, mentionKeyAction, mentionSegments } from "./composer-mention";   // the @-mention card's rules, pure; the DOM is setupComposer's mention block and markMentions
+import type { MentionCandidate, MentionQuery } from "./composer-mention";
 import { defaultCommentName, defaultBreakoutName, defaultForkName, nameToSend } from "./comment-name";
 import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink } from "./scroll-keep";
 import { retainLiveOmitted } from "./tab-order";
@@ -3207,6 +3209,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         // summary, command stdout — shares this branch and stays on the assistant grammar
         bubble.innerHTML = kind === "user" ? userMd(ev.md) : md(ev.md);
         linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins);   // bare file:// URLs in a message → clickable (open in the host's default app)
+        if (kind === "user") markMentions(bubble);   // in the user's own bubble a typed "@name" that names a live session wears that session's color; a harness note is not the user naming a session
       }
       // images, IN the bubble (part of his message): thumbnail + open/copy caption;
       // a literal path in the typed text becomes the same open-link inline.
@@ -4297,6 +4300,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
       xHost = rb;   // the ✕ in the bubble's corner, as a landed bubble would wear it — never floating in the wrapper's gap
     }
     if (!t.romp && !isCmd) bubble.innerHTML = userMd(t.md);   // the user's words, newlines kept — byte-for-byte what the landed bubble shows
+    if (!t.romp && !isCmd) markMentions(bubble);   // and a typed @name chipped, as the landed bubble wears it (renderEventInner). A statement of its own, not a brace around both: tests pin the line above verbatim (chat-md, queued-indicator)
     // An optimistic echo's dragged images render as THUMBNAILS, not just their trailing paths (the
     // user 2026-08-25: composer preview → path-only provisional → thumbnail landing flashed). Same
     // machinery end to end: userImage with the landed form's exact "path:" shape — buildPathImg's
@@ -5674,6 +5678,7 @@ function scheduleAppendActive(): void {
 }
 
 function renderTabs() {
+  mentionRosterChanged();   // the @-mention card and the transcript's chips follow the WHOLE roster, ahead of the strip's own guards and its visible-tabs signature
   if (renameActive) { renderPendingAfterRename = true; return; }
   if (tabPointerHeld) { renderPendingWhilePressed = true; return; }   // don't destroy a tab mid-click (see tabPointerHeld)
   const bar = document.getElementById("tabs");
@@ -14089,8 +14094,7 @@ function fireRewindDelete(sid: string, uuid: string): void {
 function cancelComposerEdit(sid: string): void {
   if (!composerEdits.delete(sid)) return;
   if (sid !== activeId) return;
-  const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
-  if (ta) { ta.value = ""; composerManualH = null; ta.style.height = ""; }
+  clearComposerBox?.();   // the composer's one clear path: the menus see the message box go empty
   drafts.delete(sid); persistDrafts();
   renderComposerChips(sid);
 }
@@ -15882,6 +15886,117 @@ function growComposer(ta: HTMLTextAreaElement) {
 // a one-line description, an optional argument hint, and any aliases.
 interface SlashCmd { name: string; description?: string; argumentHint?: string; aliases?: string[]; }
 
+// Re-rank an OPEN @-mention card against the current roster (set by setupComposer). Null before the
+// composer is wired, and a no-op while no card is up. mentionRosterChanged calls it on every roster change.
+let refreshMentionCard: (() => void) | null = null;
+// Empty the message box (set by setupComposer): the ONE path every clear takes, so the @-mention card and
+// the slash menu see it go empty. A bare `ta.value = ""` fires no input event, so with the card up a Send
+// click or Cmd/Ctrl+Enter would leave it open over the emptied composer, where the next Enter inserts a stale
+// "@name ". cancelComposerEdit clears from outside the composer's closure through it.
+let clearComposerBox: (() => void) | null = null;
+
+// The roster as the @-mention surfaces see it: every session the webview holds, hidden ones included, by
+// id, name, color and state. renderTabs compares it on every kernel push; a change re-ranks the open card
+// and re-dresses the transcript's chips, and a NAME the roster did not hold before re-marks the bubbles, so
+// a peer whose frame lands after the active transcript rendered gets its chip (the connect push sends the
+// active tab first). The strip's own signature covers the visible tabs only, so a session in another view
+// renamed, recolored or changing state would never reach these surfaces through it. The cost is one JSON
+// row per session per push, nothing at dozens of sessions, and on a change one query per view for the chips
+// once any chip exists (mentionChipsMade: a transcript with no chip is never walked). A subagent viewer is a
+// tab, not a session (s.sub): nothing behind it takes mail, so its row names nothing here or on the card.
+let mentionRosterSig = "";
+let mentionNames = new Set<string>();
+let mentionChipsMade = 0;   // chips markMentions has made, ever; zero means no view holds one to re-dress
+function mentionRosterChanged(): void {
+  const rows: unknown[] = [];
+  const names = new Set<string>();
+  for (const [id, s] of sessions) {
+    rows.push([id, s.name, s.color?.bg, s.color?.fg, s.status.state]);
+    if (s.status.state !== "closed" && !s.sub && s.name) names.add(s.name);
+  }
+  const sig = JSON.stringify(rows);
+  if (sig === mentionRosterSig) return;
+  mentionRosterSig = sig;
+  refreshMentionCard?.();
+  refreshMentionChips();
+  let fresh = false;
+  for (const n of names) if (!mentionNames.has(n)) { fresh = true; break; }
+  mentionNames = names;
+  if (fresh) remarkMentions();
+}
+
+// A chip's dress from the session it names: the identity color and, as its title, the name and the state.
+// The chip is keyed by the session's id (data-sid) and re-dressed on every roster change, so a rename or a
+// state change reaches a chip rendered long before (the sent text itself stays as typed). A session gone
+// reads Closed and keeps its last color, so the reader still sees who was meant.
+function dressMentionChip(chip: HTMLElement, s: Session | null): void {
+  if (!s) { chip.title = (chip.textContent || "").replace(/^@/, "") + " · " + CHIP_LABEL.closed; return; }
+  if (s.color) { chip.style.setProperty("--chip-bg", s.color.bg); chip.style.setProperty("--chip-fg", s.color.fg); }
+  chip.title = s.name + " · " + (CHIP_LABEL[s.status.state] || s.status.state);
+}
+function refreshMentionChips(): void {
+  if (!mentionChipsMade) return;
+  const byName = new Map<string, Session>();
+  for (const s of sessions.values()) if (s.status.state !== "closed" && !s.sub && s.name) byName.set(s.name, s);
+  for (const v of views.values()) {
+    for (const chip of Array.from(v.el.querySelectorAll<HTMLElement>(".mention-chip[data-sid]"))) {
+      let s = sessions.get(chip.dataset.sid || "") || null;
+      // The keyed session gone, or closed, while a live one carries the name: the text names THAT one now (the
+      // name is what postal resolves), so the chip re-keys as soon as the namesake is live. Membership in the map
+      // is not the test: a closed session stays in it until its tab is dismissed, and a chip keyed on that would
+      // read "Closed" beside a live namesake, then flip when the tab went, with nothing new about the mention.
+      if (!s || s.status.state === "closed") {
+        const again = byName.get((chip.textContent || "").replace(/^@/, ""));
+        if (again) { chip.dataset.sid = again.id; s = again; }
+      }
+      dressMentionChip(chip, s);
+    }
+  }
+}
+// Mark again every bubble that carries an "@" outside a chip (data-mentions, set when it rendered): a name
+// that was plain text because its session's frame had not landed yet becomes a chip. Idempotent: text
+// already inside a chip is skipped, so a chip is never wrapped twice.
+function remarkMentions(): void {
+  for (const v of views.values()) for (const b of Array.from(v.el.querySelectorAll<HTMLElement>("[data-mentions]"))) markMentions(b);
+}
+
+// A typed "@name" that names a live session wears that session's identity color (the user 2026-09-07):
+// the reader sees who was meant, and a hover says how that session is doing. A quiet chip, the tab's
+// own dress, with no link behavior; a word that names nothing stays plain text. Text nodes only, never
+// inside code, a fenced block, a link or a chip already made, so a path or an email address is left
+// alone. The same boundary rule as the composer's trigger (composer-mention.ts mentionSegments). Exact
+// names only: postal's direct match is exact, so a hand-typed "@API" for the session "api" is not a name
+// its mail tools would take, and the chip must not say it is. The user's own bubbles: the landed one and
+// the optimistic echo of a send (renderEventInner, the echo's paint), never a harness note.
+function markMentions(root: HTMLElement): void {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const texts: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    if ((n.nodeValue || "").includes("@") && !n.parentElement?.closest("code, pre, a, .mention-chip")) texts.push(n as Text);
+  }
+  if (!texts.length) return;
+  root.dataset.mentions = "1";   // a bubble remarkMentions revisits when a new name joins the roster
+  const live = new Map<string, Session>();
+  for (const s of sessions.values()) if (s.status.state !== "closed" && !s.sub && s.name) live.set(s.name, s);
+  if (!live.size) return;
+  const lookup = (w: string) => live.get(w) || null;
+  for (const t of texts) {
+    const segs = mentionSegments(t.nodeValue || "", lookup);
+    if (!segs.some((sg) => sg.hit)) continue;
+    const frag = document.createDocumentFragment();
+    for (const sg of segs) {
+      if (!sg.hit) { frag.appendChild(document.createTextNode(sg.text)); continue; }
+      const chip = el("span", "mention-chip");
+      chip.textContent = sg.text;
+      chip.dataset.sid = sg.hit.id;
+      dressMentionChip(chip, sg.hit);
+      frag.appendChild(chip);
+      mentionChipsMade++;
+    }
+    t.replaceWith(frag);
+  }
+}
+
 // Composer: Enter sends the message to the active session as its next prompt,
 // Shift+Enter inserts a newline; the box auto-grows a few lines.
 function setupComposer() {
@@ -15908,7 +16023,7 @@ function setupComposer() {
     stagedMsgs.push(activeId, { text: typed, cites: (composerCitations.get(activeId) || []).slice() });
     composerCitations.delete(activeId); renderComposerChips(activeId);   // the chips now live on the staged item
     drafts.delete(activeId); draftStartedAt.delete(activeId);
-    ta.value = ""; composerManualH = null; ta.style.height = "";
+    clearBox();
     persistDrafts();
     renderStagedStrip(activeId, { reveal: "last" });   // the new item is the one event that moves the list: show it
   };
@@ -15964,7 +16079,7 @@ function setupComposer() {
     if (askRoute) {
       if (askRoute === "custom") addCustomLiveAsk(typed); else sendTextLiveAsk(typed);
       drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();
-      ta.value = ""; composerManualH = null; ta.style.height = "";
+      clearBox();
       return;
     }
     // EDIT mode → a rewindSend: branch the conversation from just before the edited message. No
@@ -15980,7 +16095,7 @@ function setupComposer() {
       const s = liveSession(activeId);
       if (s) { reconcileRewind(s); appendActive(); }   // paint the overlay NOW (stale → window re-render)
       drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();
-      ta.value = ""; composerManualH = null; ta.style.height = "";
+      clearBox();
       return;
     }
     // A QUEUED-message edit → editQueued: the entry is replaced in place, kernel-side. No registerOptimistic
@@ -16056,7 +16171,7 @@ function setupComposer() {
         histWalk.delete(sid);                         // …and the history walk starts fresh
         if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }
         drafts.delete(sid); draftStartedAt.delete(sid); persistDrafts();
-        ta.value = ""; composerManualH = null; ta.style.height = "";
+        clearBox();
         return;
       }
       lastSent.set(activeId, text);   // remembered for a possible Ctrl+C restore
@@ -16086,9 +16201,7 @@ function setupComposer() {
       histWalk.delete(sid);                         // …and the history walk starts fresh
       if (attached.length) { composerFiles.delete(sid); if (sid === activeId) renderComposerFiles(sid); }   // the strip emptied into this message
       drafts.delete(activeId); draftStartedAt.delete(activeId); persistDrafts();   // sent — no draft to restore on a later switch-back
-      ta.value = "";
-      composerManualH = null;   // a drag-expanded box snaps back to one line after a send (the user 2026-07-07)
-      ta.style.height = "";
+      clearBox();   // a drag-expanded box snaps back to one line after a send (the user 2026-07-07)
       // The box is empty again, so a live picker re-takes it: send your pre-question draft, then just type the
       // answer (the user 2026-07-16). Repaints the "answering" tint that draftPredatesAsk had suppressed.
       setComposerAskMode();
@@ -16102,7 +16215,7 @@ function setupComposer() {
     // the SDK's control requests instead — status, enable/disable, reconnect. Intercepted here, the
     // one point that sees a command before it runs (the /clear precedent below).
     if (/^\/mcp\s*$/.test(text)) {
-      ta.value = ""; composerManualH = null; ta.style.height = "";
+      clearBox();
       drafts.delete(sid); persistDrafts();
       openMcpPanel(sid);
       return;
@@ -16339,6 +16452,198 @@ function setupComposer() {
   ta.addEventListener("blur", () => window.setTimeout(closeSlash, 120));   // close when leaving (a row's mousedown keeps focus, so it fires only on a real leave)
   window.addEventListener("resize", positionSlash);
 
+  // ── @-MENTION autocomplete (the user 2026-09-07): an "@" opening a word, plus one or more characters,
+  // lists the live sessions whose names match (composer-mention.ts holds the rules and runs under test;
+  // this is the DOM). A pick puts "@name " in place of the typed query, plain text, the name an agent's
+  // mail tools take, so the receiving agent reads it literally. The card sits just ABOVE the composer,
+  // left-aligned with it, like the slash menu: a textarea exposes no caret geometry short of a mirror
+  // element, and the composer is one to a few lines tall, so its top edge is never far from the caret.
+  // It never takes focus: rows pick on mousedown, through ONE listener on the card itself, so a repaint
+  // between mousedown and mouseup (a kernel push renaming a session) cannot lose the pick (the click-safe
+  // rule); the row's index resolves against the list painted at that moment.
+  let mPop: HTMLElement | null = null;
+  let mItems: MentionCandidate[] = [];
+  let mMore: string | null = null;      // the "N more, keep typing" row when the cap left matches out
+  let mSel = 0;
+  let mAt: MentionQuery | null = null;   // the token the open card is about
+  // Escape latches the card closed for THIS "@" (its index in the text) until that "@" is gone, the slash
+  // menu's rule: typing more of the same query after an Esc must not re-pop it, and neither may a caret
+  // that leaves the token and comes back. The latch holds on the bare "@" too (the query backspaced away
+  // and retyped is the same "@"; the slash latch holds on a bare "/"), and it follows the "@" through
+  // edits before it (Home, a word, End: the same token, still dismissed), so only deleting the "@", or
+  // the whitespace that opens its word, re-arms.
+  let mDismissedAt = -1;
+  let mLatchText = "";     // the text as the latch last saw it; the diff against it is how the latch follows its "@"
+  // an IME composition in progress: its keystrokes and its interim text are the IME's, not the card's
+  let mComposing = false;
+  // the sessions a mention can name: every live session the webview knows, the one being written to
+  // excluded by rankMentions; hidden (background) sessions included, since mail reaches them like any other;
+  // a closed session, a tab still being created and a subagent viewer (a read-only tab, s.sub, with no
+  // session behind it) cannot take mail, so none of them is listed
+  const mentionRoster = (): MentionCandidate[] => {
+    const out: MentionCandidate[] = [];
+    for (const [id, s] of sessions) {
+      if (s.status.state === "closed" || s.sub || isProvisionalId(id)) continue;
+      out.push({ id, name: s.name, color: s.color });
+    }
+    return out;
+  };
+  const closeMention = () => { if (mPop) { mPop.remove(); mPop = null; } mItems = []; mMore = null; mAt = null; };
+  const positionMention = () => {
+    if (!mPop) return;
+    const r = ta.getBoundingClientRect();
+    mPop.style.left = r.left + "px";
+    mPop.style.maxWidth = Math.max(r.width, 220) + "px";
+    mPop.style.bottom = (window.innerHeight - r.top + 6) + "px";   // just ABOVE the composer, like the slash menu
+  };
+  // the "@query" the caret ends right now, or null; a selection is not a caret (Ctrl+A, Shift+Home, a drag)
+  const caretMention = (): MentionQuery | null =>
+    ta.selectionStart === ta.selectionEnd ? mentionQuery(ta.value, ta.selectionStart) : null;
+  // is the "@" the Escape latch is about still at `start`, opening a word? A bare "@" counts: the guide says the
+  // list stays closed for that "@" until it is deleted, not until its query is.
+  const mentionAtOpens = (text: string, start: number): boolean =>
+    start >= 0 && start < text.length && text[start] === "@" && (start === 0 || /\s/.test(text[start - 1]));
+  // Keep the latch on its "@" as the text changes. The textarea hands over no edit deltas, so each read diffs
+  // the text against the last one seen: the edit replaced prev[start, oldEnd) with the text between the same
+  // start and its new end. Wholly before the "@", it moved the "@" by what it added or removed; covering the
+  // "@", it deleted it; wholly after, the "@" stands. Then the "@" must still open a word where it sits, or the
+  // latch is off. The region comes from the caret when it can: after an edit the caret sits at the edit's end,
+  // and the text after the caret is then what followed the region, so the edit ends at the caret and starts at
+  // the smallest edit consistent with that (a longer one retyped identical text, which reads as unchanged). A
+  // caret elsewhere (an undo restores a selection) falls back to the longest common prefix and suffix, which
+  // alone reads a deletion beside repeated text as the later of the two ("@b @bb" less "@b " or less " @b" is
+  // "@bb" either way, and the later region is the "@" itself). The diff reads the text, not the keystrokes: a
+  // selection replaced by text that puts an "@" back where the old one stood reads as that "@", unchanged,
+  // as the reader sees it.
+  const followLatch = (text: string, caret: number): void => {
+    const prev = mLatchText;
+    mLatchText = text;
+    if (mDismissedAt < 0 || text === prev) return;
+    const max = Math.min(prev.length, text.length);
+    let p = 0;
+    while (p < max && prev[p] === text[p]) p++;
+    let s = 0;
+    while (s < max - p && prev[prev.length - 1 - s] === text[text.length - 1 - s]) s++;
+    let start = p, oldEnd = prev.length - s;
+    const caretEnd = caret + prev.length - text.length;   // where an edit ending at the caret ended in prev
+    if (caretEnd >= 0 && prev.slice(caretEnd) === text.slice(caret)) { oldEnd = caretEnd; start = Math.min(p, caret, oldEnd); }
+    if (oldEnd <= mDismissedAt) mDismissedAt += text.length - prev.length;
+    else if (start <= mDismissedAt) mDismissedAt = -1;
+    if (!mentionAtOpens(text, mDismissedAt)) mDismissedAt = -1;
+  };
+  const pickMention = (c: MentionCandidate) => {
+    // The card is about mAt; the pick replaces the token the caret ends NOW, and the two must agree. Splicing
+    // the cached token against a caret the card had not followed would repeat the draft between them ("ask
+    // @ro", Ctrl+A, Enter would give "ask @romp ask @ro"). The selectionchange listener below closes the card
+    // on such a move, but it is asynchronous, so a pick can land first: then there is nothing to replace.
+    const at = caretMention();
+    if (!at || !mAt || at.start !== mAt.start || at.query !== mAt.query) { closeMention(); return; }
+    const token = mentionToken(c, activeId);
+    const caret = ta.selectionStart;
+    closeMention();
+    ta.focus();
+    // Through the browser's own editing command where it works, so the pick sits on the textarea's undo
+    // stack (Ctrl+Z puts the typed "@ro" back) and fires the input event the draft bookkeeping listens to;
+    // assigning ta.value drops the undo history, so that is the fallback, with the same input event
+    // dispatched by hand. execCommand is deprecated, but every engine keeps it for exactly this and reports
+    // false where it does not apply.
+    ta.setSelectionRange(at.start, caret);
+    let done = false;
+    try { done = typeof document.execCommand === "function" && document.execCommand("insertText", false, token); } catch { done = false; }
+    if (done && ta.value.slice(at.start, at.start + token.length) !== token) done = false;
+    if (!done) {
+      const next = insertMention(ta.value, at, caret, token);
+      ta.value = next.text;
+      ta.setSelectionRange(next.caret, next.caret);
+      ta.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  };
+  const paintMention = () => {
+    if (!mPop) return;
+    mPop.replaceChildren();
+    mItems.forEach((c, i) => {
+      const row = el("div", "ctx-item mention-row" + (i === mSel ? " sel" : ""));
+      row.dataset.idx = String(i);
+      row.setAttribute("role", "option");
+      row.setAttribute("aria-selected", i === mSel ? "true" : "false");
+      const nm = el("span", "mention-name");
+      nm.replaceChildren(...hostNameNodes(c.name, c.id));   // a remote "host:" prefix renders as quiet metadata
+      if (c.color?.bg) nm.style.color = c.color.bg;   // the name in the session's identity color, the tab's own dress
+      row.appendChild(nm);
+      row.addEventListener("mousemove", () => { if (mSel !== i) { mSel = i; paintMention(); } });   // hover highlights; the pick is the card's listener
+      mPop!.appendChild(row);
+    });
+    // the matches the cap left out, counted, so a narrower query is the visible way to them (not a row: no pick)
+    if (mMore) { const more = el("div", "mention-more"); more.textContent = mMore; mPop.appendChild(more); }
+    positionMention();
+    (mPop.querySelector(".mention-row.sel") as HTMLElement | null)?.scrollIntoView({ block: "nearest" });
+  };
+  const openMention = () => {
+    if (mPop) return;
+    mPop = el("div", "ctx-menu mention-pop");
+    mPop.id = "mention-pop";
+    mPop.setAttribute("role", "listbox");
+    mPop.addEventListener("mousedown", (ev) => {
+      ev.preventDefault();   // the textarea keeps focus and its caret
+      const row = (ev.target as HTMLElement | null)?.closest?.(".mention-row") as HTMLElement | null;
+      const i = row ? Number(row.dataset.idx) : -1;
+      if (i >= 0 && i < mItems.length) pickMention(mItems[i]);
+    });
+    document.body.appendChild(mPop);
+  };
+  const updateMention = () => {
+    if (mComposing) return;                                    // the IME owns the text until compositionend, which runs this again
+    followLatch(ta.value, ta.selectionStart);                  // the Esc latch stands while its "@" does, wherever an edit moved it
+    const at = caretMention();
+    if (!at) { closeMention(); return; }                       // no "@query" at the caret (a space typed, the caret moved, a selection): closed
+    if (mDismissedAt === at.start) { closeMention(); return; }   // Esc'd this "@": no card for it until it is gone
+    const all = rankMentions(at.query, mentionRoster(), activeId);
+    const items = all.slice(0, MENTION_MAX_ROWS);
+    if (!items.length) { closeMention(); return; }             // nothing matches: no card, the "@word" is ordinary text
+    // The highlight follows the SESSION, not the row number: a roster re-rank under an open card (a rename, a
+    // session gone or arrived; pushes land every few seconds) would move a different name under the kept index,
+    // and an Enter within reaction time would pick it. A new query starts at the best match; a highlighted
+    // session that left the list falls back to the first row.
+    const same = !!mAt && mAt.start === at.start && mAt.query === at.query;
+    const keep = same ? mItems[mSel]?.id : undefined;
+    const idx = keep ? items.findIndex((c) => c.id === keep) : -1;
+    mSel = idx >= 0 ? idx : 0;
+    mAt = at; mItems = items; mMore = mentionMoreNote(all.length);
+    openMention();
+    paintMention();
+  };
+  refreshMentionCard = () => { if (mPop) updateMention(); };
+  // Empty the message box: the one path for every clear (a send, a stage, a picker answer, an edit, /mcp, a
+  // cancelled edit), so the menus see it go empty; see clearComposerBox. The drag height snaps back with it.
+  const clearBox = () => {
+    ta.value = ""; composerManualH = null; ta.style.height = "";
+    updateSlash(); updateMention();
+  };
+  clearComposerBox = clearBox;
+  // ↑/↓/⏎/Tab/Esc while the card is OPEN; true when the key was the card's, so the composer's own
+  // Enter-to-send, history and Escape-to-tabs handlers below do not also fire. A modifier passes through,
+  // and so does every key of an IME composition: Enter commits the IME's text and the arrows walk its
+  // candidates there (the type-from-anywhere handler's rule).
+  const mentionKey = (e: KeyboardEvent): boolean => {
+    if (e.isComposing || e.keyCode === 229) return false;
+    const act = mentionKeyAction(e.key, !!mPop, mSel, mItems.length, e.shiftKey || e.ctrlKey || e.metaKey || e.altKey);
+    if (!act) return false;
+    e.preventDefault();
+    if (act.kind === "move") { mSel = act.sel; paintMention(); }
+    else if (act.kind === "pick") pickMention(mItems[act.sel]);
+    else { mDismissedAt = mAt ? mAt.start : -1; closeMention(); }
+    return true;
+  };
+  // A caret move without an edit changes which token the caret ends. selectionchange fires on the text
+  // control itself for every one (a click, Home/End, PageUp, Ctrl+A, a drag) in every current engine,
+  // asynchronously, so the card follows the caret wherever it goes; an allowlist of arrow, Home and End
+  // keyups would miss Ctrl+A and PageUp.
+  ta.addEventListener("selectionchange", updateMention);
+  ta.addEventListener("compositionstart", () => { mComposing = true; });
+  ta.addEventListener("compositionend", () => { mComposing = false; updateMention(); });
+  ta.addEventListener("blur", () => window.setTimeout(closeMention, 120));   // a row's mousedown keeps focus, so this fires only on a real leave
+  window.addEventListener("resize", positionMention);
+
   // ── PROMPT HISTORY (the user 2026-08-16): ↑ with the caret on the box's FIRST line recalls the
   // session's previously SENT prompts, shell-style; ↓ on the last line walks forward again, and
   // walking past the newest restores the draft you were typing (stashed on the first ↑). History is
@@ -16357,6 +16662,7 @@ function setupComposer() {
   };
   ta.addEventListener("keydown", (e) => {
     if (slashKey(e)) return;   // the slash menu owns ↑/↓/⏎/Tab/Esc while it's open
+    if (mentionKey(e)) return;   // and so does the @-mention card: Enter picks a session here, it never sends
     // ↑/↓ recall history ONLY from an EMPTY box (the user 2026-08-17, tightening the first cut's
     // first-line rule: any text already in the box — even one character — means a draft in progress,
     // and arrows must never hijack it). Once a walk is ACTIVE the recalled text is the walk's own, so
@@ -16432,6 +16738,11 @@ function setupComposer() {
     // Shift+Enter, and the software return key should just return. Mobile sends with the explicit Send
     // button only (the user 2026-07-15). Desktop keeps ⏎ send / ⇧⏎ newline. The `!isCoarsePointer()` guard
     // lets Enter fall through to the textarea's native newline on touch.
+    // An IME's commit Enter (isComposing; keyCode 229 on engines that report the composition that way) is the
+    // composition's, not a send or a stage. The mention card declines it above so the IME can take it, and so
+    // must the two Enter branches here, or the commit sends the half-composed text (the type-from-anywhere
+    // handler's guard). Left to the browser, the keystroke commits the text.
+    if (e.key === "Enter" && (e.isComposing || e.keyCode === 229)) return;
     // ⌘⏎ / Ctrl+⏎ stages (the user 2026-08-15) — and focus STAYS in the box, because the whole point
     // is highlighting the next spot and typing again. Checked before the plain-Enter send below.
     if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
@@ -16453,6 +16764,7 @@ function setupComposer() {
     if (!recalling && activeId) histWalk.delete(activeId);
     growComposer(ta);
     updateSlash();   // open/refresh/close the slash-command menu as the leading "/token" changes
+    updateMention();   // and the @-mention card as the "@query" at the caret changes (typing narrows; a space closes)
     // keep the per-tab draft (and its persisted copy) current as you type, so a reload restores it
     if (activeId) {
       const had = draftStartedAt.has(activeId);

--- a/ui/webview/scroll-movers.test.ts
+++ b/ui/webview/scroll-movers.test.ts
@@ -44,10 +44,10 @@ test("render.ts: every mover of #content is a writeScroll — scrollBy and scrol
   // outside #content (a comment popover's reply, found through userContentTarget's document fallback) scrolls its own
   // container the browser's way, and the #content arm is taken first
   assert.match(RENDER, /if \(cont && cont\.contains\(target\)\) scrollElInto\(cont, target, "start", "section-link"\);\s*\n\s*else target\.scrollIntoView\(\{ block: "start" \}\);/, "the section link");
-  // the scrollIntoView calls that remain are on OTHER scrollers (the tab strip, picker rows, the slash popup, the awaiting
-  // box, and the section link's else arm above, which the #content test keeps off the transcript)
+  // the scrollIntoView calls that remain are on OTHER scrollers (the tab strip, picker rows, the slash popup, the @-mention
+  // card, the awaiting box, and the section link's else arm above, which the #content test keeps off the transcript)
   const rest = RENDER.split("\n").filter((l) => /scrollIntoView\(/.test(l));
-  assert.equal(rest.length, 5, "five scrollIntoView calls remain, none on a #content child: " + rest.map((l) => l.trim().slice(0, 60)).join(" | "));
+  assert.equal(rest.length, 6, "six scrollIntoView calls remain, none on a #content child: " + rest.map((l) => l.trim().slice(0, 60)).join(" | "));
   for (const l of rest) if (!/else target\.scrollIntoView/.test(l)) assert.doesNotMatch(l, /target|el0|realign/, l);
 });
 

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -15,9 +15,10 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   assert.match(RENDER, /if \(!romp && !injected && !tagged && ev\.md && renderSlashCmd\(bubble, ev\.md\)\) \{/);
   assert.match(RENDER, /const chip = el\("span", "slash-cmd-chip"\); chip\.textContent = m\[1\];/);
   assert.match(RENDER, /const args = el\("span", "slash-cmd-args"\); args\.textContent = rest;/);
-  // the non-command path still renders markdown as before (now also linkifies bare file:// URLs);
-  // the user's own words through userMd (newlines kept), a harness note through md
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*\}/);
+  // the non-command path still renders markdown as before (now also linkifies bare file:// URLs, and in the
+  // user's own bubble marks a typed @name that names a live session: composer-mention-pane.test.ts); the
+  // user's own words through userMd (newlines kept), a harness note through md
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins\);[^\n]*\n\s*if \(kind === "user"\) markMentions\(bubble\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1207,6 +1207,24 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   animation: slash-spin 2.4s linear infinite; }
 @keyframes slash-spin { to { transform: rotate(-360deg); } }
 @media (prefers-reduced-motion: reduce) { .slash-spin { animation: none; } }
+
+/* ── @-mention autocomplete (the user 2026-09-07) ── the live sessions whose names match the "@query" at
+   the caret, floating just above the composer like the slash menu. A .ctx-menu card (the menu tokens and
+   size), one row per session: the name in its identity color, a remote host as the quiet .host-prefix
+   metadata. The highlighted row wears the menu's row wash, not the accent fill the slash menu uses: the
+   names carry their own colors and must stay readable on it. */
+.mention-pop { z-index: 120; max-height: 40vh; overflow-y: auto; min-width: 160px; }
+.mention-row { display: flex; align-items: center; gap: 7px; }
+.mention-row.sel { background: var(--menu-hover); }
+.mention-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; font-weight: 600; }
+/* the matches the cap left out ("N more, keep typing"): the menu's sub-line dress, not a row (no wash, no pick) */
+.mention-more { padding: 4px 10px; font-size: 0.82em; opacity: 0.6; cursor: default; white-space: nowrap; }
+/* a sent message's "@name" that names a live session: a small pill in the session's identity color (the
+   tab's own --chip-bg/--chip-fg, set inline), over the blue you-bubble; the thin light ring keeps a blue
+   identity apart from the bubble. No link: the title carries the session's state. */
+.mention-chip { display: inline-block; padding: 0 6px; border-radius: 9px; line-height: 1.35;
+  background: var(--chip-bg, rgba(255, 255, 255, 0.18)); color: var(--chip-fg, currentColor);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3); }
 /* The two buttons are the SAME rounded square, exactly as tall as the one-line message box beside them
    (the user 2026-07-30, round 2: the first cut's circles sat taller than the resting box, and a rounded
    rectangle reads better than a full circle). The size is the input's own min-height calc written

--- a/ui/webview/tab-close-clicksafe.test.ts
+++ b/ui/webview/tab-close-clicksafe.test.ts
@@ -16,8 +16,9 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 test("renderTabs defers its rebuild while a pointer is pressed on the tab strip", () => {
   assert.match(RENDER, /let tabPointerHeld = false;/);
   assert.match(RENDER, /let renderPendingWhilePressed = false;/);
-  // the guard sits at the TOP of renderTabs, alongside the rename guard, so no push rebuilds mid-press
-  assert.match(RENDER, /function renderTabs\(\) \{\s*\n\s*if \(renameActive\)[\s\S]*?\n\s*if \(tabPointerHeld\) \{ renderPendingWhilePressed = true; return; \}/);
+  // the guard sits at the TOP of renderTabs, alongside the rename guard, so no push rebuilds mid-press (the
+  // @-mention roster hook ahead of both touches no strip DOM: composer-mention-pane.test.ts)
+  assert.match(RENDER, /function renderTabs\(\) \{\s*\n\s*mentionRosterChanged\(\);[^\n]*\n\s*if \(renameActive\)[\s\S]*?\n\s*if \(tabPointerHeld\) \{ renderPendingWhilePressed = true; return; \}/);
 });
 
 test("the press guard is armed on #tabs pointerdown and released on pointerup/cancel/blur", () => {

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -112,6 +112,7 @@ function lift(): (hooks: Hooks) => Api {
     const tabGroups = () => readTabGroups(H.unions); const writeTabGroups = () => {};
     const phoneLayout = () => H.phone;
     const tabStateClass = H.tabStateClass, tabDotClass = H.tabDotClass, tabDotTitle = H.tabDotTitle, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;   // tabDotClass: the state-dot slot every tab carries (the tab-strip fix, 2026-09-08); tabDotTitle: what the slot says on hover
+    const mentionRosterChanged = () => {};   // the @-mention roster hook at the top of renderTabs: not the strip's (composer-mention-pane.test.ts)
     function makeGroupHead(sec, folded, active, hidden) {
       const h = el("div", "tab-group-head" + (folded ? " collapsed" : ""));
       h.dataset.group = String(sec.name);


### PR DESCRIPTION
Typing `@` and the first letters of a session's name in the composer lists the live sessions whose names match; Enter, Tab or a click inserts the plain `@name` the session's mail tools take, and a sent `@name` shows as a chip in that session's color.

## Tier

Rebased onto main at 610793f9 by the maintainer on 2026-09-10 (the same patch, replayed). An independent replay of the same commit onto ac44ee51 matched it commit for commit (range-diff equal); on that replay `npm run typecheck` is clean, the full `npm test` passes (4154 in the main run plus 22 in the tags-scale file run alone), and the full pytest passes 11311 with one failure in tests/test_notification_tap_resume_browser.py, the served-tap browser test, which fails the same way on plain main on the machine that ran it and is skipped on CI; this change touches nothing it reads.

Tier: feature

## What it does

Type `@ro` and a card above the composer lists the live sessions whose names match, best match highlighted. Arrows move the highlight; Enter, Tab or a click picks; Escape closes. The pick puts `@romp ` in place of what you typed, as plain text, and Ctrl+Z puts the typed query back. A space, a caret move off the token or a query nothing matches closes the card; `@` alone opens nothing. In the sent message `@romp` wears romp's identity color, from the moment the echo of the send is painted, and its hover says how that session is doing. `docs/guide.md` describes it under "Naming another session".

## Design

- **The trigger is the mail tools' own word rule.** An `@` that opens a word (at the start, or after whitespace), then one or more characters with no whitespace and no second `@`, with the caret ending the word. An email address, a path and a `@name@handle` never open the card. The transcript's chip uses the same rule (`mentionSegments`), with trailing punctuation left outside the token, so "ask @web." names web.
- **The inserted name is the form the recipient's postal resolves.** `resolve_recipient` in `postal_service.py` takes a bare name or `host:name`, where the host is the receiving kernel's own postal name or the label under which it peers with the named kernel (`peer_route`), and it refuses an ambiguous bare name, listing the candidates as `host:name`. So writing to a session on this kernel inserts the display name the dashboard holds: bare for a local session, `host:name` for a remote one, which is the label this kernel registers that peer under. Writing to a session on another kernel inserts every name bare, because the dashboard cannot see that kernel's labels; a tie there is refused by postal with the candidates named, and the agent picks one. `mentionToken` is that rule, and the guide paragraph states it in the user's terms.
- **Who is listed.** Every session the dashboard holds that can take mail, hidden ones included: not a closed session, not a tab still being created, and not a subagent viewer (a read-only tab over one agent's transcript, `s.sub`; there is no session behind it to write to, and its name is the agent's description). The same three are left out of the chip's name lookups, so a viewer whose description happens to be a session's name never stands in for it.
- **Ranking.** Case-insensitive: a prefix of the bare name, then a prefix of the whole `host:name` (a remote session found by its host), then a substring anywhere; alphabetical by bare name within a rank, a local session ahead of a remote namesake; the session being written to left out. Twelve rows at most; past that the last row reads "N more, keep typing" and takes no pick, so the cap is visible.
- **The keyboard model is the slash menu's.** Arrows move and wrap, Enter and Tab pick, Escape closes. With the card closed no key is consumed, so Enter keeps sending and Escape keeps leaving the composer; a modifier passes through, so Shift+Enter stays a newline and Cmd/Ctrl+Enter stays stage. Escape latches the card closed for that `@` (by its index, followed through edits before it, a one-step deletion of a selection included) until the `@` or the whitespace opening its word is deleted: more letters, or a caret move away and back, do not reopen it, and a caret that lands on the latched token while a card for another token is up brings that card down. The highlight is kept by session id across a re-rank, so a kernel push that renames or removes a session under an open card cannot move a different name under Enter. The card follows the caret through the input and selectionchange events, so a draft put back into the composer by code (a queued message taken back for editing) that ends in an `@query` opens the card the way typing would; that path needs no call of its own.
- **An IME's commit Enter belongs to the composition.** `mentionKey` declines every key while `isComposing` (or `keyCode` 229), and the composer's own keydown now returns on an Enter with that mark ahead of the stage and send branches, the test the type-from-anywhere handler already applies. Before this change the commit keystroke sent the half-composed text.
- **One clear path.** A bare `ta.value = ""` fires no event, so the stage, the Send button and every other clear left the card open over the emptied composer, where the next Enter inserted a stale `@name `. Every clear now goes through `clearBox()` (the value, the drag height, then `updateSlash()` and `updateMention()`), and `cancelComposerEdit` reaches it from outside the closure through `clearComposerBox`. The pick itself re-reads the caret's token and refuses a mismatch, both a caret with no token under it (Ctrl+A or PageUp with the card open, before selectionchange has closed it) and a caret on a different token than the card's, so a splice against a moved caret cannot repeat or damage the draft.
- **A click-safe card.** The card never takes focus. Rows pick on mousedown through one listener on the card itself, and the row's index resolves against the list painted at that moment, so a repaint between mousedown and mouseup cannot lose the pick. It is a `.ctx-menu` on the menu tokens; the highlighted row wears `--menu-hover` rather than the accent fill the slash menu uses, because the names carry their own identity colors.
- **The chip is the user's.** `markMentions` runs on the user's own bubbles: the landed one, after its path links, and the optimistic echo of a send, so the chip is there from the first paint and the echo matches what lands. A harness note that shares the markdown branch (a compact summary, command stdout) is not the user naming a session and is left alone.
- **The chip follows the roster.** `renderTabs` opens with `mentionRosterChanged()`, which compares one row per session (id, name, color, state) on every kernel push. On a change it re-ranks an open card, re-dresses every chip (title "name · State"; a session gone reads Closed and keeps its last color) and re-keys a chip to a live namesake as soon as one is live. A name the roster did not hold before re-marks the bubbles that carry an `@`, so a peer whose frame lands after the transcript rendered gets its chip. Exact names only: postal's match is exact, so a hand-typed `@API` for the session `api` is not a name its tools take and does not chip. The strip's own signature covers the visible tabs only, so this reads the whole roster; the cost is one JSON row per session per push, plus, on a change and only once any chip has been made, one query per view for the chips to re-dress (a transcript that holds no chip is never walked).
- **Deliberately left out.** The pick carries the name, not the session's id, so a rename after the send breaks the address the way it does for a hand-typed name; carrying the id with the pick (postal already treats the uuid as the rename-proof address) is a separate change on top of this one. No card for `@` alone, no fuzzy matching, no picking a session that is closed or still being created or a subagent viewer (none can take mail), no case-insensitive chip.

## Tests

- `ui/webview/composer-mention.test.ts` (14 tests) runs the pure module: the trigger and its refusals, prefix-before-substring ranking with the self exclusion and the remote-by-host case, the twelve-row cap and the count note, the token per recipient (local, remote, sibling on the remote kernel, third kernel), the insertion and its refusal on a moved caret, the keyboard model open and closed, the segmenter and the `@name@handle` rule. Before this change the module does not exist, so the file fails to build.
- `ui/webview/composer-mention-pane.test.ts` (13 tests) slices the mention block and the chip functions out of render.ts by their banner comments, bundles them with the module and drives a real textarea in headless Chromium: the pick through the undo stack and Ctrl+Z; Tab and a click on a row with focus staying in the composer; Ctrl+A and PageUp closing the card and Enter then sending the draft as typed, and a pick refused when the caret ends another token than the card's; the stage and the module-level clear closing the card, and a fill by code opening it; an IME's keys passing through the whole keydown order; a roster re-rank keeping the highlight on the session, with a viewer, a closed session and a provisional tab left out of the list; the Escape latch through Home/End edits, a one-step deletion of the selected token before the latched `@`, the bare `@`, an insertion before the `@`, and the caret landing on the latched token under another token's card; the count row taking no pick; the token per recipient; the chips (exact-name, keyed by id, re-dressed, re-marked without nesting, re-keyed to a namesake, never to a viewer). The browser cases skip by name when playwright or its browser is missing (CI runs `npm test` before its Chromium install, so they skip there), as `md-sanitize-browser.test.ts` does. Three pins hold the wiring the slices cannot carry: one bare `ta.value = ""` in the file (clearBox's own) and six `clearBox()` calls in setupComposer, with `cancelComposerEdit` on `clearComposerBox`; the keydown order (slash menu, card, IME guard, stage, send) and `updateMention()` after `updateSlash()`; the renderTabs hook, the transcript hook on the user's bubble and the echo's. Before this change every case fails on the slice anchors and the pins.
- Re-anchored: `ask-draft-predates`, `composer-resize` and `mcp-panel` (the clear sites now read `clearBox();`), `slash-cmd-chip` (`markMentions(bubble)` on the user's bubble after the path links), `tab-close-clicksafe` (the roster hook ahead of the guards), `scroll-movers` (six `scrollIntoView` calls where it counted five). `tab-strip-skip-exec` and `reload-notices`, which lift renderTabs and the send path into a sandbox, stub the two new names. The first full run went red in three pin files, `chat-md`, `queued-indicator` and `scroll-movers`: the first two hold the queued bubble's renderer statement verbatim (the echo renders through `userMd` exactly as the landed bubble does), so that statement stays byte-for-byte and the chip call is the next statement, not a brace around both; the third counts the `scrollIntoView` calls on scrollers other than the transcript, and the card's own scroller is one more of those, so its count reads six and the rule that only `writeScroll` moves the transcript still holds.
- `npm run typecheck` clean. The two new files and the eight neighbouring pins and sandboxes (81 tests) pass in one run with the 10 Chromium cases executed; full `npm test` 4123 tests, 4123 pass, 0 fail (4101 in the main run plus the 22 of the timeline-tags-scale file run alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
