### PR TITLE
Tab strip: the section holding the tab being read folds like any other, and a header click shows the section at a glance in the transcript's place

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -174,9 +174,10 @@ the tab and pick **Show when folded** under **Tags**;
 the header's count then leaves that tab out; when every tab in a section is set to
 show, the folded header shows the full count and its tooltip says nothing is hidden. Pick it
 again to fold the tab with the rest. A tab set to show when folded keeps that setting when its
-group is renamed. The section of the tab you are reading never
-folds (its header says so, and a click there changes nothing), and the `archived` section
-starts folded. Drag a header to reorder the groups, which
+group is renamed. The section of the tab you are reading folds like any other; its header marks
+that it holds the tab (the tag's name is underlined), and folded, the header stands in for the tab:
+focus lands on it, and the left and right arrows step from there. The `archived` section starts
+folded. Drag a header to reorder the groups, which
 reorders the tags on every surface (the timeline's tag table shows the same order). To move
 a tab into another group, right-click it and pick **Move to <tag>** under **Tags**: one click
 adds that tag and drops the tag of the group you right-clicked it in, leaving its other tags alone. The row's
@@ -185,6 +186,23 @@ button's menu, turns the sections off for this browser. Every group starts on it
 the gear's **One tag group per row in the tab strip** lets the groups follow one another across the
 strip and wrap as they need, with the untagged sessions behind a thin divider, so a strip with many
 tags stays short.
+
+**A section at a glance.** Clicking a header also shows the section in the transcript's place: one
+row per session, with its color, a dot for its state (yellow working, red stopped on a prompt or an
+API error only you can clear, amber retrying an API error on its own, teal compacting, green waiting
+on background work, none while it is idle), a **needs you** or **waiting** word, what it is doing
+now in a few words, and how long ago it last did anything. **Needs you** appears when the feed shows
+one of the session's cards under Blocked, or when the session is stopped on a prompt or an API error
+only you can clear; **waiting**, when it is waiting on background work. A session that asked a
+question and went quiet shows the word with no dot: the dot follows the session's own state, the
+word follows the feed. What it is doing now comes from its current task, else from the headline of
+its work so far, else from the last task it had; a session that has published a note of what it is
+working on shows the note as a quieter second line. Hover a row for its last message, shown without
+its formatting; click one to open that session, which also opens its section if the section is
+folded (with several tags, the first folded group of them). The rows update as the sessions work and
+change only when something about a session changes; the **needs you** word follows the feed, one
+refresh behind it at most. The transcript comes back when you pick a session, press Escape, or click
+that header again while its section is open and holds the tab you are reading.
 
 **Coming back after a dropped connection.** When the dashboard's link to the kernel
 drops and comes back (a laptop lid closed and opened, a network change, a phone that

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1076,7 +1076,7 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `gone`, `tasks`, `cut`, `live`, `row`, `clock`, `backend`, `ops`, `limit`,
   `retry`, `bg`, `watch`, `stamp`, `anchors`, `downtime`, `names`, `flags`,
   `ncards`, `colormap`, `acct`, `cleared`, `host`, `cwd`, `claudemd`, `fork`,
-  `taskout`, `pathlink`, `postal`, plus `cold` for a tab with no cached
+  `note`, `needs`, `taskout`, `pathlink`, `postal`, plus `cold` for a tab with no cached
   build and `nosig` for one whose signature could not be taken) to the
   background rebuilds it caused. A rebuild with several moved components
   counts under each, so the map's sum can exceed `bg_built`. One session's

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -183,7 +183,7 @@ def _process_stats():
 _CHAT_SIG_LABELS = ("transcript", "states", "store", "hold", "archive", "episodes", "reg", "gone", "tasks", "cut",
                     "live", "row", "clock", "backend", "ops", "limit", "retry", "bg", "watch", "stamp", "anchors",
                     "downtime", "names", "flags", "ncards", "colormap", "acct", "cleared", "host",
-                    "cwd", "claudemd", "fork",
+                    "cwd", "claudemd", "fork", "note", "needs",
                     "taskout", "pathlink", "postal")
 _CHAT_SIG_DEPS = ("taskout", "pathlink", "postal")
 
@@ -27990,6 +27990,17 @@ def _chat_build_sig(sess, tm=None, now=None, tmux=None, deps=None):
         # the sdk/ directory's mtime, which moves at turn rate; the per-sid value moves only when a fork of
         # THIS session appears, is promoted or is deleted).
         sig.append((_be.fork_children().get(sid) if _be and hasattr(_be, "fork_children") else None) or None)
+        # note: the session's postal working note (working/<sid>), by identity: the ledger carries its text
+        # (workingNote), and a `romp mail working` from a shell, a peer's forwarded write and the kernel's own
+        # idle-and-done lift all change it with no transcript, states or store write.
+        _np = _working_note_path(sid)
+        sig.append(_chat_ident(_np) if _np is not None else None)
+        # needs: the feed's per-session needs-you verdict the ledger carries (needsInput), as the boolean "a
+        # card of THIS session is filed under needs-you". The set behind it is None until the first feed build
+        # since start, and a push builds the chat sessions BEFORE the feed, so the raw tri-state would give
+        # every tab a None on the first push and a False on the next: one whole-strip rebuild for a value the
+        # row reads the same (needsInput === true). Only True is a verdict.
+        sig.append(_feed_needs_input_of(sid) is True)
         sig.extend(((), (), None) if deps is False else _chat_sig_deps(sid, deps))   # taskout, pathlink, postal
         return tuple(sig)
 
@@ -32762,7 +32773,21 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
     if _session_flag(sid, "hideFromFeed"):       # muted → out of task tracking: the ledger shows no goal tree / current task
         tree, current, recent_tops = [], None, []
     ledger = {"summary": arch.get("headline", ""), "tree": tree[:80],
-              "current": current, "recent": recent_tops}
+              "current": current, "recent": recent_tops,
+              # the postal working note (set_working: the session's claim to a branch and files, written for
+              # peer sessions), "" when none. The chat's section-at-a-glance view shows it as a row's second
+              # line. Kept for a muted session: it is the session's own statement, not a goal the judges track.
+              "workingNote": Sessions.working_note(sid),
+              # the FEED's per-session needs-you verdict: True when the last feed build filed a card of this
+              # session under needs_input (the column the feed's Blocked list is: a judge-filed block, a live
+              # prompt, an on-you API error), False when none, None before the first feed build since start.
+              # The section view's row reads it for its "needs you" word, so the two panes agree; the tab's own
+              # chip rule misses the common case (a session that asked and went idle). Read from the feed build
+              # rather than re-derived: the column's rule lives in build_feed with a dozen inputs. The feed
+              # builds AFTER the chat sessions in a push, so this trails the feed by one push cycle (the chat
+              # signature's `needs` component brings the change forward on the next one). A muted session has
+              # no cards, so it reads False.
+              "needsInput": _feed_needs_input_of(sid)}
     # work-timer base, in MILLISECONDS (render's elapsedMs does Date.now()ms - sinceEpoch; a seconds
     # value showed ~494,000h — the user's "400,000 hours" bug): the current open turn's start while
     # working, else the last activity; None when unknown (render then shows no timer).
@@ -42820,6 +42845,26 @@ _VIEW_STATS = {"feedBuild": 0, "feedServe": 0, "tlBuild": 0, "tlServe": 0,
                # would forge the bug signature above, or bury a pusher regression (review find, 2026-09-08)
                "feedJsonBuild": 0, "feedJsonServe": 0}
 _built_timeline = [None, None, 0.0, 0.0]          # [fleet_sig, payload, built_at, build_started_at]
+# The sids the LAST feed build filed under needs_input: the per-session form of the feed's Blocked column,
+# read by build_session's ledger (needsInput) so the chat's section-at-a-glance rows say "needs you" exactly
+# when the feed does. None until the first feed build since start (a chat client alone makes the push build
+# the feed, so that is one push cycle). Set by _cached_feed on every rebuild, from the same payload the badge
+# and the bells read (_needs_you_count), never re-derived.
+_feed_needs_input = [None]
+
+
+def _needs_input_sids(feed):
+    """The sids with a card in the feed's needs_input column: the filing rule the feed client maps
+    (feed.ts askColumn: it.column == "needs_input"), applied per session. Placeholders count too: the
+    Blocked list shows them."""
+    return frozenset(str(a.get("sid")) for a in (feed.get("asks") or [])
+                     if a.get("column") == "needs_input" and a.get("sid"))
+
+
+def _feed_needs_input_of(sid):
+    """build_session's read: True/False from the last feed build, None before the first one."""
+    sids = _feed_needs_input[0]
+    return None if sids is None else (str(sid) in sids)
 # Wire-form caches for the two heavy shared payloads (the 2026-08-10 CPU fix, round three): the last
 # (source-identity key, lazy serialization, dedup sig, per-entry split) for the feed and the timeline bars,
 # so an unchanged build is never re-serialized cycle after cycle (~357KB + ~1.65MB per cycle measured with
@@ -42954,6 +42999,7 @@ def _cached_feed(now, tmux, sig, connect=False):
     _PERF_STATS.build("feed", False, time.monotonic() - _t0)
     feed["buildId"] = bid
     _built_feed[:] = [sig, feed, time.time(), started]
+    _feed_needs_input[0] = _needs_input_sids(feed)        # the per-session needs-you the session ledgers read
     _badge = _needs_you_count(feed)
     _fired = _feed_notifications(feed)                    # armed bells: fresh builds are the transition event
     _buzzed = []

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -94,6 +94,7 @@ CENSUS = {
     "_effort_changes": ("sig", "states"),
     "_effort_color": ("pure", "over the effort string and the colormap name"),
     "_effort_tone": ("pure", "over the effort string"),
+    "_feed_needs_input_of": ("sig", "needs", "the last feed build's needs-you set, as the boolean for this session (None and False share a value)"),
     "_fold_tasks": ("memo", "pure over the parse's turns (transcript, live); the per-turn memo is keyed on each turn's atoms and fingerprint"),
     "_genuine_queued": ("pure", "over a queued text"),
     "_git_branch": ("sig", "cwd"),
@@ -169,6 +170,7 @@ CENSUS = {
 # Attribute calls whose base is a module-level object or one of the backend locals build_session binds.
 DOTTED = {
     "Sessions.backend_for": ("sig", "reg", "ownership: the SDK backend owns a sid whose reg exists"),
+    "Sessions.working_note": ("sig", "note", "the working-note file (working/<sid>) by identity"),
     "jd.episode_rows": ("sig", "episodes"),
     "jd.episode_settles": ("sig", "episodes"),
     "jd.load_archive": ("sig", "archive"),
@@ -730,6 +732,35 @@ class Differential(_World):
         self.assertEqual(self.moved(d, e), ("cleared",))
         os.environ["ROMP_HOST_NAME"] = "otherhost"
         self.assertEqual(self.moved(e, self.sig()), ("host",))
+
+    def test_the_working_note_misses_under_note_and_its_clear_restores_the_signature(self):
+        # the ledger carries the session's postal working note (the section-at-a-glance row's second line); a
+        # note write touches no transcript, states file or store, so it is a component of its own, by identity
+        a = self.sig()
+        km._set_working_note(SID, "editing the notes-api tests")
+        b = self.sig()
+        self.assertEqual(self.moved(a, b), ("note",))
+        self.assertEqual(self.sig(), b, "byte-stable while the note stands: no rebuild per push")
+        km._set_working_note(SID, "")
+        self.assertEqual(self.sig(), a, "the clear (the kernel's idle-and-done lift, or the session's own) restores it")
+
+    def test_the_feed_verdict_misses_under_needs_only_as_a_verdict_on_this_session(self):
+        # the ledger carries the feed's per-session needs-you (needsInput); the set behind it is None until the
+        # first feed build since start, and a push builds the chat sessions before the feed, so the raw tri-state would
+        # give every tab a None on the first push and a False on the next: a whole-strip rebuild for a value the
+        # row reads the same. Only True is a verdict.
+        saved = km._feed_needs_input[0]
+        try:
+            km._feed_needs_input[0] = None
+            a = self.sig()
+            km._feed_needs_input[0] = frozenset()
+            self.assertEqual(self.sig(), a, "the first feed build, no card of this session under needs-you: nothing the row shows changed")
+            km._feed_needs_input[0] = frozenset([PEER])
+            self.assertEqual(self.sig(), a, "another session's card: not this tab's")
+            km._feed_needs_input[0] = frozenset([SID])
+            self.assertEqual(self.moved(a, self.sig()), ("needs",), "a card of this session under needs-you is the verdict that rebuilds")
+        finally:
+            km._feed_needs_input[0] = saved
 
     def test_the_billing_readers_move_acct(self):
         a = self.sig()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -957,6 +957,77 @@ class ViewBuilder(unittest.TestCase):
         self.assertIsNotNone(cur, "an open (unfinished) turn → the Fleet recency stamp")
         self.assertEqual(cur, {"t": NOW}, "slimmed to the one field its reader (fleet stamp) uses")
 
+    def test_ledger_carries_the_working_note(self):
+        """The postal set_working note rides the per-session ledger: the chat's section-at-a-glance view
+        shows it as a row's own second line under the task. Read from the backend-agnostic store
+        (working/<sid>); "" when the session published none, never a missing key."""
+        saved = km.WORKING_DIR
+        km.WORKING_DIR = jd.STATE / "working"
+        try:
+            self.assertEqual(km.build_session(SID, NOW)["ledger"]["workingNote"], "", "no note: an empty string")
+            km._set_working_note(SID, "  editing the notes-api tests  \n")
+            self.assertEqual(km.build_session(SID, NOW)["ledger"]["workingNote"], "editing the notes-api tests", "the note, stripped")
+            km._set_working_note(SID, "")
+            self.assertEqual(km.build_session(SID, NOW)["ledger"]["workingNote"], "", "cleared: empty again")
+        finally:
+            km.WORKING_DIR = saved
+
+    def test_muted_session_keeps_its_working_note(self):
+        """hideFromFeed empties the ledger's task tracking (tree, current, recent) but NOT the note: the note is
+        the session's own statement of what it holds, not a goal the judges track. Pinned because the
+        hideFromFeed branch is the natural place to empty the ledger, and a field moved inside it would flip
+        this with every other test green."""
+        saved = km.WORKING_DIR
+        km.WORKING_DIR = jd.STATE / "working"
+        try:
+            km._set_working_note(SID, "editing the notes-api tests")
+            km._set_session_flag(SID, "hideFromFeed", True); km._flags_cache.clear()
+            led = km.build_session(SID, NOW)["ledger"]
+            self.assertEqual((led["tree"], led["current"], led["recent"]), ([], None, []), "muted: out of task tracking")
+            self.assertEqual(led["workingNote"], "editing the notes-api tests", "but the note stays: the session's claim, not a goal")
+        finally:
+            km._set_session_flag(SID, "hideFromFeed", False); km._flags_cache.clear()
+            km.WORKING_DIR = saved
+
+    def test_ledger_carries_the_feed_needs_you_verdict(self):
+        """ledger.needsInput is the FEED's per-session needs-you: True when the last feed build filed a card of
+        this session under needs_input (here the fixture's judge-filed block, g2, on an IDLE session, the case
+        the tab's chip rule never sees), False when none, None before the first feed build. Read from the feed
+        build's own payload, never re-derived; a muted session has no cards. The section-at-a-glance row's
+        "needs you" reads it so the two panes agree. The goal store this rewrites, and the override journal
+        load_goals replays over it, live under the fixture's own temp root (setUp rebinds jd.GOALDIR and
+        jd.STATE), so no other module's journaled gesture on the shared placeholder sid reaches it."""
+        tmux = km._tmux_sessions()
+        saved = (list(km._built_feed), km._feed_needs_input[0], km._views_dirty[0])
+        km._built_feed[:] = [None, None, 0.0, 0.0]; km._feed_needs_input[0] = None; km._views_dirty[0] = 0.0
+        try:
+            self.assertIsNone(km.build_session(SID, NOW)["ledger"]["needsInput"], "no feed build yet: None, not a verdict")
+            feed = km._cached_feed(NOW, tmux, km._fleet_view_sig(NOW, tmux))
+            self.assertTrue(any(a["sid"] == SID and a["column"] == "needs_input" for a in feed["asks"]),
+                            "the fixture's blocked goal files a needs_input card for the idle session")
+            self.assertEqual(tmux[SID]["state"], "idle", "while the chip is idle: the tab's rule alone shows nothing")
+            self.assertIs(km.build_session(SID, NOW)["ledger"]["needsInput"], True, "the row's needs-you = the feed's column")
+            # the judges rule the block answered: the store now holds the goal working; a dirty mark bypasses
+            # the rebuild throttle the way the reply handler does
+            store = json.loads((jd.GOALDIR / (SID + ".json")).read_text())
+            g2 = "%s:g2" % SID
+            store["nodes"][g2]["blocked"] = False; store["status"][g2] = "working"
+            (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
+            km._mark_views_dirty()
+            feed = km._cached_feed(NOW, tmux, km._fleet_view_sig(NOW, tmux))
+            self.assertFalse(any(a["sid"] == SID and a["column"] == "needs_input" for a in feed["asks"]))
+            self.assertIs(km.build_session(SID, NOW)["ledger"]["needsInput"], False, "no card under needs-you: False")
+            # muted: out of the feed altogether, so no cards, so False, whatever the store says
+            store["nodes"][g2]["blocked"] = True; store["status"][g2] = "blocked"
+            (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(store))
+            km._set_session_flag(SID, "hideFromFeed", True); km._flags_cache.clear()
+            km._mark_views_dirty()
+            km._cached_feed(NOW, tmux, km._fleet_view_sig(NOW, tmux))
+            self.assertIs(km.build_session(SID, NOW)["ledger"]["needsInput"], False, "a muted session is out of task tracking")
+        finally:
+            km._set_session_flag(SID, "hideFromFeed", False); km._flags_cache.clear()
+            km._built_feed[:], km._feed_needs_input[0], km._views_dirty[0] = saved
+
     def test_host_sleep_closes_a_turn_left_open(self):
         # A turn still open when the laptop slept must NOT keep reading as "working": the kernel records the
         # suspend interval and the ledger closes the turn at last activity — no working-on line, no multi-hour

--- a/ui/webview/docreview.ts
+++ b/ui/webview/docreview.ts
@@ -14,7 +14,7 @@ function norm(s: string): string {
 // Strip the inline markdown the RENDERER consumed, so a span selected out of rendered text can still be
 // found in the source. Deliberately does NOT touch `_`: snake_case identifiers are far commoner in these
 // docs than underscore emphasis, and stripping them would break more matches than it fixes.
-function stripInline(line: string): string {
+export function stripInline(line: string): string {
   return line
     .replace(/^\s*(?:[#]{1,6}\s+|>\s?|[-*+]\s+|\d+[.)]\s+)/, "")   // block markers: heading, quote, list
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")                       // image → its alt text

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -18,8 +18,10 @@ test("peek OPEN: every activation routes the peek decision — setActive derives
   // nav-history's apply all land here), before its already-active early-return
   // the window between the derivation and the early return widened on 2026-09-05: the subagent viewer's
   // two lines sit there (pruneSubViews — an activation is the event that closes an unpinned viewer — and the
-  // reopen of a viewer id whose tab is gone), both BEFORE the return by design, see plans/subagent-transcripts.md
-  assert.match(RENDER, /function setActive\(id: string[\s\S]{0,500}?assertPeekFor\(id\);[\s\S]{0,900}?if \(activeId === id && anchor == null && anchorT == null\) return;/);
+  // reopen of a viewer id whose tab is gone), both BEFORE the return by design, see plans/subagent-transcripts.md;
+  // the section-at-a-glance view's clear and the folded-away tab's unfold sit there too, and the early return
+  // grew a body (a pick of the tab already active puts its transcript back over the view: tab-snapshot-pane.test.ts)
+  assert.match(RENDER, /function setActive\(id: string[\s\S]{0,500}?assertPeekFor\(id\);[\s\S]{0,900}?if \(activeId === id && anchor == null && anchorT == null\) \{/);
   // the derivation: in-view → no peek; out-of-view → THIS session is the peek
   assert.match(RENDER, /const next = chatVisible\(id\) \? null : id;\s*\n\s*if \(next !== peekId\) \{ peekId = next; renderTabs\(\); \}/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -35,7 +35,9 @@ import { newSkeletonState, applyTabOrderSkeleton, onStatus, onFull, onDismiss, o
 import { reconcileTabOrder, adoptArrival } from "./tab-order";
 import { writeViewOrder } from "./view-order";
 import { planStrip, readTabGroups, writeTabGroups, setSectionCollapsed, sectionRef, isPinned, setPinned, prunePinned, reachableFrom, headWords,
-         followAdoption, reorderTagOrder, TABGROUPS_KEY, TABGROUPS_EVENT, type TabSection } from "./tab-groups";
+         followAdoption, reorderTagOrder, homeSectionOf, neighborOfFolded, TABGROUPS_KEY, TABGROUPS_EVENT, type TabSection, type StripItem } from "./tab-groups";
+import { snapshotModel, snapshotHeading, rowWords, type SnapModel, type SnapRow } from "./tab-snapshot";
+import { rowStillOpen, installSnapshotEscape, reconcileRows } from "./tab-snapshot-view";
 import { tabStateClass, tabDotClass, tabDotTitle, sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
 import { titleWithKey, chordOf, effectiveChord, loadOverrides } from "./keybindings";
 import { DEFAULT_CHORDS } from "./commands";
@@ -946,9 +948,16 @@ function assertPeekFor(id: string): void {
 }
 function tabInView(id: string): boolean { return id === peekId || chatVisible(id); }
 // TAB SECTIONS (tab-groups.ts): the ids the last render folded away under a collapsed section
-// header. Keyboard cycling walks the VISIBLE order, and a folded tab is not visible — the active
-// tab's section never renders folded, so the active id is always in it.
+// header. Keyboard cycling walks the VISIBLE order, and a folded tab is not visible. The active tab's
+// section folds like any other, so the active id can be folded away too: its header is then its
+// stand-in (focusActiveTab lands there, the arrows step from its position through neighborOfFolded over
+// the last plan's items, kept here for both), and the pane shows the section at a glance
+// (renderSnapshot) instead of a transcript whose tab is nowhere on the strip.
 let collapsedTabIds = new Set<string>();
+// the strip plan the last render painted (planStrip's items): what the stand-in rules and the section view
+// read between renders (which header holds a folded-away id, which tab is next to it, which section a
+// pick of one opens: unfoldSectionOf's per-holder rule)
+let lastStripItems: StripItem[] = [];
 /** Every tab the strip knows — the kernel's order plus any pushed tab not yet in it (a placeholder):
  *  the "does this session still exist" of the pin prune (tab-groups.ts prunePinned). */
 function knownTabIds(): Set<string> { return new Set<string>([...order, ...tabMeta.keys()]); }
@@ -1157,7 +1166,7 @@ const draftStartedAt = new Map<string, number>();
 // 2026-06-16). Empty/false → explicit done (full disc).
 interface LedgerTreeNode { id: string; text: string; depth: number; done: boolean; blocked: boolean; t?: number; mt?: number; current: boolean; derived?: boolean; cleared?: boolean; onpath?: boolean; promptAnchorUuid?: string | null; anchorUuid?: string | null; children?: string[]; summary?: string | null; blockSummary?: string | null; _rec?: number; }   // summary/blockSummary = the distiller's takeaway / decision brief, revealed by the row's ⊕ expander; _rec = render-stamped subtree-rolled-up recency
 interface LedgerRecent { text: string; t: number; }   // tab-hover "Recent": up-to-5 most-recent TOP tasks across live + archive, any status (the user 2026-06-30)
-interface Ledger { summary: string; tree?: LedgerTreeNode[]; current?: { t?: number } | null; recent?: LedgerRecent[]; }
+interface Ledger { summary: string; tree?: LedgerTreeNode[]; current?: { t?: number } | null; recent?: LedgerRecent[]; workingNote?: string; needsInput?: boolean | null; }   // two fields the kernel's build_session puts on the ledger for the section-at-a-glance view (tab-snapshot.ts): workingNote, the session's postal working note (the row's second line); needsInput, the feed's needs-you verdict for the session from the kernel's last feed build (null before the first), the row's "needs you" word. Both optional on the wire: a remote host's older kernel sends neither
 const ledgers = new Map<string, Ledger | null>();
 
 function el(tag: string, cls?: string): HTMLElement {
@@ -5256,8 +5265,8 @@ function releaseTabStrip(): void {
 // against a real accessibility tree): the chevron, the color bar and the pip are decoration
 // (aria-hidden — the caret glyph was read aloud before the name), the header's name is an aria-label
 // in words (name and count, plus the pip's phrase when it wears one), so nothing runs into it
-// unplanned; and the header holding the active tab is a labeled group, not a button — it takes no
-// action and no focus, and "button, expanded" promised both.
+// unplanned; and the header holding the active tab is the same button as the rest, marked current: it
+// folds like any other, and folded it is the hidden tab's stand-in.
 function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean, hidden: readonly string[]): HTMLElement {
   // the untagged trail (unlabeled by the user's ruling): a row of its own under the one-group-per-row
   // setting, else behind a divider
@@ -5265,33 +5274,57 @@ function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean
   const name = sec.name;
   const head = el("div", "tab-group-head" + (collapsed ? " collapsed" : "") + (holdsActive ? " holds-active" : ""));
   head.dataset.group = name;
-  // The section holding the ACTIVE tab is UNFOLDABLE while it is active — planStrip renders it open
-  // whatever the store says (keyboard focus must never land on a hidden node) — so its header carries
-  // NO fold action: a click there used to store folded=true that could not render, so "click to fold
-  // this group" did nothing visible on every click and then bit when the user switched tabs.
-  // group-active is a no-op the delegate still flashes (the click is acknowledged); the header still
-  // drags to reorder the groups. Every other header derives the click from the state it RENDERED
-  // (data-folded), never from the store.
-  head.dataset.act = holdsActive ? "group-active" : "toggle-group";
+  // Every header folds, the one holding the ACTIVE tab too: folded, that header is the hidden tab's stand-in
+  // (focusActiveTab lands on it, the arrows step from it) and the pane shows the section at a glance, so no
+  // keyboard focus lands on a hidden node. The click derives the next fold state from the one it RENDERED
+  // (data-folded), never from the store, and the delegate (toggle-group) also shows the section in the pane.
+  head.dataset.act = "toggle-group";
   head.dataset.folded = collapsed ? "1" : "0";
+  // `shown`: the pane is showing this section, whatever the fold: the one bit the header's mark, its words
+  // (headWords) and its own way back are derived from
+  const shown = snapView === name;
+  if (shown) head.classList.add("snap-shown");
+  // THE WAY BACK: the header whose section the pane shows, OPEN, holding the tab being read, is the click that
+  // put the section in the pane; a second click puts the transcript back (show-transcript, leaveSnapshot)
+  // instead of folding the section under its reader. Derived from the rendered state, as the fold is, and
+  // the title says which click this is. Escape does the same from anywhere.
+  const back = shown && !collapsed && holdsActive;
+  if (back) head.dataset.act = "show-transcript";
   const total = sec.ids.length;
-  const words = headWords(name, total, hidden.length, collapsed, holdsActive);
+  const words = headWords(name, total, hidden.length, collapsed, holdsActive, back, shown);
   head.title = words.title;
   let spoken = words.label;
-  if (holdsActive) {
-    // no fold action and no tab stop (a stop that does nothing is noise in the tab order), so not a
-    // button either: a labeled group, read once, promising nothing
-    head.setAttribute("role", "group");
-  } else {
-    // a label the keyboard can fold: Enter or Space go through the same click → delegate path as the
-    // pointer.
-    head.setAttribute("role", "button");
-    head.setAttribute("aria-expanded", collapsed ? "false" : "true");
-    head.tabIndex = 0;
-    head.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); head.click(); }
-    });
-  }
+  // a label the keyboard can fold: Enter or Space go through the same click → delegate path as the pointer
+  head.setAttribute("role", "button");
+  // not a disclosure while its press puts the transcript back (`back`): "expanded" would promise a fold that
+  // press never does, so the state is left off and the label (headWords) names the action instead
+  if (!back) head.setAttribute("aria-expanded", collapsed ? "false" : "true");
+  // the header holding the tab being read says so to assistive tech as well as by its mark (the chip
+  // accent-underlined): the tab itself may be folded out of the tree
+  if (holdsActive) head.setAttribute("aria-current", "true");
+  head.tabIndex = 0;
+  head.addEventListener("keydown", (e) => {
+    // THE STAND-IN's keys (the active tab folded away, and THIS header the one planStrip marked for it: with
+    // several folded holders only the first is marked, wears aria-current and the chip's mark, and is where
+    // neighborOfFolded steps from, so only it answers as the tab): what a focused tab answers. The arrows
+    // step to the neighbouring tab on the strip from the header's place, focus following (onTabKey's rule;
+    // the window's arrows do the same when focus is elsewhere). Enter drops back into the message box while
+    // the transcript shows and the box takes input (the mirror of the box's Escape, which lands here); with
+    // the box disabled (the section view up, a closed session) Enter presses the header as Space does. Space
+    // always presses: fold or open with the section in the pane (toggle-group), or the transcript back
+    // (show-transcript). Any other header: the arrows bubble to the window's handler (they step the ACTIVE
+    // tab, focus staying put) and Enter presses, as on any button.
+    const aid = activeId;
+    const standIn = holdsActive && !!aid && collapsedTabIds.has(aid) && sec.ids.includes(aid);
+    if (aid && standIn && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
+      e.preventDefault();
+      const nb = neighborOfFolded(lastStripItems, aid, e.key === "ArrowRight" ? 1 : -1);
+      if (nb) { setActive(nb); focusActiveTab(); }
+      return;
+    }
+    if (e.key === "Enter" && standIn && !snapView && focusComposerOrAsk()) { e.preventDefault(); return; }
+    if (e.key === "Enter" || e.key === " ") { e.preventDefault(); head.click(); }
+  });
   // The header's order mirrors the feed's grouped headers (T284, the user 2026-09-09: the caret sat
   // beside the chip at the left; the feed's Working / Blocked / Completed headers and its session
   // headers put the name at the left and the caret with its count together at the RIGHT): the tag's
@@ -5723,8 +5756,9 @@ function renderTabs() {
   // section's tabs, and the untagged trail (the sessions in no tag) on its own line, or behind a
   // divider with the one-group-per-row setting off (tab-groups.ts owns the rule). A folded section
   // renders its header alone, with the count and a pip when a member is working or blocked, so the
-  // gist survives the fold (progressive disclosure). The ACTIVE tab's section never renders folded —
-  // keyboard focus must never land on a hidden node — and visibleOrder() drops the folded ids so ←/→
+  // gist survives the fold (progressive disclosure). The ACTIVE tab's section folds like any other: its
+  // header is then the hidden tab's stand-in (focus, the arrows) and the pane shows the section at a
+  // glance (renderSnapshot); the keyboard walk (visibleOrder()) drops the folded ids so ←/→
   // skip them. DESKTOP ONLY: on the phone layout (phoneLayout — the kernel page's own media rule) the
   // plan is the flat strip, since the phone's session list is scraped from every rendered tab and has
   // no header to unfold. A create in flight (the provisional tab) sections under the tags its request
@@ -5733,11 +5767,14 @@ function renderTabs() {
   const plan = planStrip(visibleIds, unions, readTabGroups(unions), activeId, phoneLayout(),
                          provisionalId ? { id: provisionalId, tags: provisionalTags } : null);
   collapsedTabIds = plan.folded;
+  lastStripItems = plan.items;   // before the skip below: the section view (stripAftermath, renderSnapshot) and the folded stand-in read the plan from here on either path
   // AN UNCHANGED STRIP IS NOT REBUILT. The signature is every input the loop below and the controls after
   // it paint: the active and peek tabs, the ids and the visible ids in order, whether the active tab is in
   // view (the all-hidden blank reads it), the strip plan — each section's tag, color and members, whether
   // it is folded or holds the active tab, and the members its folded header stands in for (the header's
-  // chip, count and pip read those; the pip's state and names come from the per-id records) — and per
+  // chip, count and pip read those; the pip's state and names come from the per-id records), the section
+  // the pane shows at a glance (snapView: a header's mark, its way-back act and its words derive from it,
+  // and leaveSnapshot changes it with no fold change), and per
   // visible id either a placeholder's meta or the session's name, color, state and its tab class, faded,
   // context and its tint, viewer flag, host-down mark and note; plus the context-gauge setting, the
   // one-group-per-row setting (the row breaks and the trail's boundary read it), the theme
@@ -5755,6 +5792,7 @@ function renderTabs() {
     activeId, peekId, ids, visibleIds, activeId ? tabInView(activeId) : null, plan.items,
     settings.tabCtx, settings.stripGroupRows, settings.theme, settings.colormap, titleWithKey("Open a session", "session.new"),
     surfaceLens(effViews(), "chat"), unions,
+    snapView,   // the section whose view the pane shows (makeGroupHead: the header's mark and its way-back act)
     visibleIds.map((id) => {
       const s = sessions.get(id), down = hostIsDown(id), note = down ? hostDownNote(id) : "";
       if (renderKind(skeletonTabs, id, !!s) === "skeleton") {                                              // makeSkeletonTab's reads:
@@ -5969,11 +6007,24 @@ function renderTabs() {
   // (The collapse caret moved OFF the tab bar into the #ledger strip's title row — the strip now always
   // shows the session title + caret, expanding to goals / working-on / done. See renderLedger. 2026-06-16)
 }
-/** What follows a strip render whether or not the strip was rebuilt: the no-sessions placeholder and the
- *  all-hidden blank. Both are idempotent, and both read live state a skipped rebuild must not leave behind:
- *  the active view is built lazily, so it can appear between two renders whose strips are equal. */
+/** What follows a strip render whether or not the strip was rebuilt: the no-sessions placeholder, the section
+ *  view's refresh (its rows read session state the strip's signature does not carry: a member's last event,
+ *  its working note), and the all-hidden blank. All are idempotent, and all read live state a skipped
+ *  rebuild must not leave behind: the active view is built lazily, so it can appear between two renders
+ *  whose strips are equal. */
 function stripAftermath(visibleIds: readonly string[], ids: readonly string[]): void {
   syncNoSessionsPlaceholder(visibleIds.length, ids.length);
+  // the section view follows the push (renderTabs runs on every one): a no-op when nothing a row shows has
+  // changed (snapshotModel's same-object return). The section GONE from the plan (its tag deleted or
+  // renamed, its last member hidden or moved out, sectioning turned off) is the event that ends the view:
+  // renderSnapshot clears snapView and hides the host, and the pane goes back to the active session's
+  // transcript HERE (showActive, which re-enables the composer), because no other caller follows a push
+  // with showActive. A row that held focus is hidden with the host, so focus goes to the active tab, as
+  // after the user's own Escape (snapshotHoldsFocus, read before renderSnapshot hides it).
+  const shown = snapView;
+  const held = shown ? snapshotHoldsFocus() : false;
+  if (snapView) renderSnapshot();
+  if (shown && !snapView) { showActive(); if (held) focusActiveTab(); }
   // Hiding the LAST visible session must also blank its transcript: a strip with no tabs cannot sit
   // over a hidden session's live chat (the ghost would show exactly what the hide asked to put away).
   // Restored the moment anything is visible again — the placeholder owns the empty state meanwhile.
@@ -6568,7 +6619,9 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
 // repaint per connect/drop, not per poll (the user 2026-07-29).
 window.addEventListener("romp-hosts", () => { renderTabs(); });
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
-window.addEventListener("keydown", (e) => { if (e.key === "Escape") dismissTabMenu(); }, true);
+// an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
+// (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it
+window.addEventListener("keydown", (e) => { if (e.key === "Escape" && ctxMenuEl) { dismissTabMenu(); e.preventDefault(); } }, true);
 window.addEventListener("scroll", dismissTabMenu, true);
 window.addEventListener("blur", () => dismissTabMenu());
 
@@ -6643,10 +6696,14 @@ function onTabKey(e: KeyboardEvent) {
   if (!activeId || !order.length) return;
   if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
     e.preventDefault();
+    const dir = e.key === "ArrowRight" ? 1 : -1;
     const ord = visibleOrder();                 // never cycle onto a view-hidden session
     const i = ord.indexOf(activeId);
-    if (i < 0) return;
-    const dir = e.key === "ArrowRight" ? 1 : -1;
+    if (i < 0) {                                // the active tab is folded away: step from its header's place
+      const nb = neighborOfFolded(lastStripItems, activeId, dir);
+      if (nb) { setActive(nb); focusActiveTab(); }
+      return;
+    }
     setActive(ord[(i + dir + ord.length) % ord.length]);
     focusActiveTab();
   } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
@@ -6664,7 +6721,20 @@ function onTabKey(e: KeyboardEvent) {
 }
 function focusActiveTab() {
   const bar = document.getElementById("tabs");
-  (bar?.querySelector(`.tab[data-id="${activeId}"]`) as HTMLElement | null)?.focus();
+  const tab = bar?.querySelector(`.tab[data-id="${activeId}"]`) as HTMLElement | null;
+  if (tab) { tab.focus(); return; }
+  // the active tab is folded away under its section: the header is its stand-in (tab-groups.ts)
+  const home = activeId ? homeSectionOf(lastStripItems, activeId) : null;
+  if (!home || home.name === null || !bar) return;
+  Array.from(bar.querySelectorAll<HTMLElement>(".tab-group-head")).find((h) => h.dataset.group === home.name)?.focus();
+}
+/** Open a section that puts a folded-away tab on screen: a session pick names the tab, so its tab must be on
+ *  screen. Per holder, since a session under several tags has a copy under each and every copy's fold stands on
+ *  its own (T264b): the first folded holder in the strip's order opens. The store write notifies
+ *  (TABGROUPS_EVENT) and the listener re-renders the strip. */
+function unfoldSectionOf(id: string): void {
+  const holder = lastStripItems.find((it) => "head" in it && it.head.name !== null && it.folded && it.head.ids.includes(id));
+  if (holder && "head" in holder && holder.head.name !== null) writeTabGroups(setSectionCollapsed(tabGroups(), holder.head.name, false));
 }
 // "Enter to start typing" lands on whatever's actually showing below the transcript: when a live
 // AskUserQuestion picker is up the PICKER CARD owns the keyboard (↑/↓ step the options, Enter confirms), so
@@ -6704,11 +6774,18 @@ window.addEventListener("keydown", (e) => {
   if (document.querySelector(".picker-overlay")) return;   // #picker / #confirm open
   if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
     if (!activeId || order.length < 2) return;
+    const dir = e.key === "ArrowRight" ? 1 : -1;
     const ord = visibleOrder();                 // never cycle onto a view-hidden session
     const i = ord.indexOf(activeId);
-    if (i < 0) return;
+    if (i < 0) {
+      // the active tab folded away under its section header (tab-groups.ts): the header is its stand-in,
+      // so the step starts from the header's place on the strip (onTabKey's and cycleTab's rule). A
+      // view-hidden active id is not on the strip at all: nothing to step from, as before.
+      const nb = collapsedTabIds.has(activeId) ? neighborOfFolded(lastStripItems, activeId, dir) : null;
+      if (nb) { e.preventDefault(); setActive(nb); }
+      return;
+    }
     e.preventDefault();
-    const dir = e.key === "ArrowRight" ? 1 : -1;
     setActive(ord[(i + dir + ord.length) % ord.length]);
   } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
     const content = document.getElementById("content");
@@ -10764,6 +10841,212 @@ function runPrebuild(deadline: IdleDeadline): void {
   renderingOwnerSid = savedOwnerSid;
 }
 
+// A SECTION AT A GLANCE (tab-snapshot.ts owns the model). `snapView` is the section the pane is showing:
+// page state like the peek, never stored. A header click sets it (the #tabs delegate's toggle-group), any
+// session pick clears it (setActive), Escape and the header's second click leave it (leaveSnapshot). The
+// host is ONE stable node under #content, made once with its delegate installed once (the click-safe rule:
+// the rows are rebuilt from every push that changes one), and `snapModel` is the last model painted:
+// snapshotModel hands it back unchanged when no row differs, and then only the "ago" texts are refreshed
+// in place, so a push that changed nothing moves nothing.
+let snapView: string | null = null;
+let snapModel: SnapModel | null = null;
+// The reader's place in the hidden transcript, held across the view. The host is a child of #content, so
+// while the view shows the pane's scroll is the view's, and the #content scroll listener (scroll-keep.ts
+// followReader, which makes the saved spot follow the reader) would record the reveal's clamp and every
+// scroll of a long list as the ACTIVE view's saved spot; leaving would then land at the bottom or on the
+// list's offset instead of the line being read. Captured from the view once, in the synchronous pass that
+// hides the views (showActive's branch: the clamp's scroll event is only queued by then, so the fields
+// still hold the reader's spot); written back when the view hides (hideSnapshot, every exit path), before
+// landActive reads the spot.
+let snapKeep: { v: View; scrollTop: number; stick: boolean } | null = null;
+function snapshotHost(): HTMLElement | null {
+  let host = document.getElementById("tab-snapshot");
+  if (host) return host;
+  const content = document.getElementById("content");
+  if (!content) return null;
+  host = el("div", "tab-snapshot");
+  host.id = "tab-snapshot";
+  host.setAttribute("role", "region");
+  host.style.display = "none";
+  content.appendChild(host);
+  // a row opens its session: setActive unfolds the section when the tab is folded away and clears
+  // snapView; focus follows onto the tab (the strip's own select does the same)
+  delegate(host, { open: (node) => {
+    const id = node.dataset.id;
+    if (!id) return;
+    // A ROW WHOSE SESSION LEFT MID-PRESS: click safety keeps the pressed row until the release, so a session
+    // dismissed between mousedown and mouseup is still under the click, and setActive on its id would put up
+    // an "opening…" loader, composer enabled, for a session that never arrives (the strip's meta lingers
+    // until the next tabOrder frame). The row's session must still be on the strip (tab-snapshot-view.ts
+    // rowStillOpen); otherwise nothing moves. The removal is that frame's event, and the release's flush
+    // (releaseTabStrip → renderTabs → renderSnapshot) repaints the rows without it.
+    if (!rowStillOpen(snapModel?.rows.find((r) => r.id === id), sessions.has(id), tabMeta.has(id), closingTabs.has(id))) return;
+    setActive(id); focusActiveTab();
+  } });
+  // CLICK-SAFE (ui/CLAUDE.md): the rows are rebuilt by renderTabs on every push that changes one, and a rebuild
+  // between mousedown and mouseup leaves the click with no row under it. A press on the view latches the
+  // STRIP's hold (tabPointerHeld): renderTabs, and renderSnapshot's own rebuild, wait for the release
+  // (pointerup / pointercancel / blur on the window, releaseTabStrip's one path), and the deferred flush
+  // repaints the strip and the view together. One latch for two surfaces one gesture can span.
+  host.addEventListener("pointerdown", () => { tabPointerHeld = true; });
+  return host;
+}
+function hideSnapshot(): void {
+  const host = document.getElementById("tab-snapshot");
+  if (host) host.style.display = "none";
+  snapModel = null;
+  // the transcript comes back where the reader left it, not where the view's scrolls put the spot (snapKeep)
+  if (snapKeep) { snapKeep.v.scrollTop = snapKeep.scrollTop; snapKeep.v.stick = snapKeep.stick; snapKeep = null; }
+}
+/** Whether keyboard focus is on the view (a row a keyboard user Tabbed or arrowed onto). THE EXIT HANDS
+ *  FOCUS ON: leaving hides the host (hideSnapshot, display none), and hiding the focused element drops focus
+ *  to body (the browser's focus fixup); nothing else would put it anywhere, so the user's Escape would leave
+ *  them on body, arrows and Enter dead until a click. The strip's own refocus reads the strip (bar.contains),
+ *  which the host, under #content, is not in. So each exit reads this BEFORE its hide, since after it
+ *  activeElement is already body, and when it was on the view hands focus to the active tab once the
+ *  transcript is back: where the composer's own Escape puts it, and a row pick (tab mode: arrows switch
+ *  sessions, Enter drops into the message box). Focus anywhere else is left alone. */
+function snapshotHoldsFocus(): boolean {
+  const host = document.getElementById("tab-snapshot");
+  return !!host && !!document.activeElement && host.contains(document.activeElement);
+}
+/** Back to the active session's transcript without picking a session. Two gestures land here: Escape while
+ *  the view shows (below), and a click on the header whose section the pane shows when the section is open
+ *  and holds the tab being read (show-transcript: the click that put the section in the pane, undone).
+ *  Nothing about "active" moves: renderTabs drops the header's snap-shown mark, showActive puts the
+ *  transcript back and re-enables the composer. A row that held focus is hidden with the host, so focus goes
+ *  to the active tab (snapshotHoldsFocus, read before the hide). */
+function leaveSnapshot(): void {
+  if (!snapView) return;
+  const held = snapshotHoldsFocus();
+  snapView = null;
+  renderTabs();
+  showActive();
+  if (held) focusActiveTab();
+}
+// ESCAPE LEAVES THE VIEW, and yields to every layer that owns its own Escape: two phases on the window
+// (tab-snapshot-view.ts installSnapshotEscape). Armed at capture, while this page's layers are still on the
+// page to be seen: the menus (the tab menu's closer, registered before this one, runs first and marks the
+// Escape it consumed), the picker and confirm overlays, the pane's own panels, the full-pane surfaces, a
+// comment thread, a citation preview; a typing target keeps its Escape (a rename box, a dialog's field; the
+// composer is disabled under the view). Decided at bubble, after the SHELL's Escape chain (on this frame's
+// document at capture, kernel.py _LANDING_ESC_JS) has closed, marked and stopped an Escape aimed at one of
+// its panels, which live in the shell document, out of this page's sight (the log, usage and network
+// panels). Nothing else claims Escape while the view shows: the transcript is hidden.
+installSnapshotEscape(window, {
+  showing: () => !!snapView,
+  typing: isTypingTarget,
+  layerOpen: () => !!(ctxMenuEl || metaMenuEl || citePreviewEl || openCommentKey || document.querySelector(".picker-overlay"))
+    || !!document.querySelector("#rsettings:not([hidden]), #ra-back:not([hidden])")
+    || !!(document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse") || document.getElementById("romp-lightbox")),
+  leave: leaveSnapshot,
+});
+/** Paint (or refresh) the view of `snapView`. False when that section is not on the strip any more: snapView
+ *  is cleared and the caller shows the transcript; the section's absence is the event. */
+function renderSnapshot(): boolean {
+  if (!snapView) return false;
+  const head = lastStripItems.find((it) => "head" in it && it.head.name === snapView);
+  if (!head || !("head" in head)) { snapView = null; hideSnapshot(); return false; }
+  const host = snapshotHost();
+  if (!host) return false;
+  const now = Date.now() / 1000;
+  const next = snapshotModel(head.head, (id) => sessions.get(id) ?? null, (id) => ledgers.get(id) ?? null, snapModel, (id) => tabMeta.get(id) ?? null);
+  if (next === snapModel && host.childElementCount) {
+    // nothing a row shows changed: the times tick in place, the DOM stands
+    for (const w of host.querySelectorAll<HTMLElement>(".snap-when[data-t]")) {
+      const t = Number(w.dataset.t); if (!t) continue;
+      w.textContent = agehms(now - t) + " ago"; w.style.color = ageColorReadable(now - t);
+    }
+    host.style.display = "";
+    return true;
+  }
+  // a rebuild while a row is pressed would drop the click (the strip's rule, tabPointerHeld): showActive can
+  // land here mid-press (the active tab's payload arriving), so the rebuild waits for the release: the flush
+  // renders the strip, and the strip renders this. The times above still ticked in place: no node was lost.
+  if (tabPointerHeld && host.childElementCount) { renderPendingWhilePressed = true; return true; }
+  snapModel = next;
+  const words = snapshotHeading(next.name, next.rows.length);
+  host.setAttribute("aria-label", words.label);
+  // THE ROWS UPDATE IN PLACE, KEYED BY SESSION ID (tab-snapshot-view.ts reconcileRows). The heading and the
+  // list are made once, with the host's first paint; from then on the heading's parts are patched and the
+  // rows reconciled: a standing row keeps its node (fillSnapshotRow rewrites its parts), a row that came is
+  // made, one that went is removed, a reordered one moved. The strip keeps focus across its rebuild by
+  // re-focusing the active tab; the rows keep it by keeping their nodes: sameRow folds lastT and lastMsg, so
+  // the model changes on nearly every push while a member works, and a wholesale replaceChildren would
+  // destroy the button the user had Tabbed onto (focus to body, Enter dead) and dismiss a hover's title.
+  let list = host.querySelector<HTMLElement>(":scope > .snap-list");
+  if (!list) {
+    const h = document.createElement("h2"); h.className = "snap-head";
+    // the heading's own bar (snap-swatch) and the name: the strip's header wears the tag chip; this heading
+    // keeps a bar + name pair, whose parts the patch below rewrites in place (the rows' rule: nothing is remade)
+    const sw = el("span", "snap-swatch"); sw.setAttribute("aria-hidden", "true");
+    h.append(sw, el("span", "snap-name"), el("span", "snap-count"));
+    list = el("div", "snap-list"); list.setAttribute("role", "list");
+    host.replaceChildren(h, list);
+  }
+  const part = (cls: string) => host.querySelector<HTMLElement>(".snap-head > ." + cls)!;
+  part("snap-swatch").style.background = next.color || "";
+  part("snap-name").textContent = next.name;
+  part("snap-count").textContent = words.count;
+  // a MOVED row: insertBefore detaches and re-attaches its node, which blurs it (the browser's focus fixup); the
+  // same event puts focus back on it (the strip's refocus rule, by node instead of by id). A row GONE from under
+  // focus (its session left the section): the row now in its place takes it, the last when it was last, so a
+  // removal does not drop the keyboard user to body either.
+  const focused = document.activeElement as HTMLElement | null;
+  const focusedAt = focused && list.contains(focused) ? Array.from(list.children).indexOf(focused.closest(".snap-item")!) : -1;
+  reconcileRows<SnapRow, Element>(list, next.rows, (n) => n.getAttribute("data-id"), (r) => snapshotRowNode(r, now), (n, r) => fillSnapshotRow(n.firstElementChild as HTMLElement, r, now));
+  if (focused && list.contains(focused)) { if (document.activeElement !== focused) focused.focus(); }
+  else if (focusedAt >= 0 && list.children.length) list.children[Math.min(focusedAt, list.children.length - 1)].querySelector<HTMLElement>(".snap-row")?.focus();
+  host.style.display = "";
+  return true;
+}
+// One row: a real button (Tab reaches it, Enter opens) carrying data-act="open" for the host's delegate, in an
+// item that carries the row's key (the session id) for the keyed update. The button is the node that stands
+// across rebuilds (focus and the title are its), so a made row and a patched row take their parts from the one
+// fillSnapshotRow.
+function snapshotRowNode(r: SnapRow, now: number): HTMLElement {
+  const item = el("div", "snap-item"); item.setAttribute("role", "listitem");
+  item.dataset.id = r.id;
+  const btn = document.createElement("button");
+  btn.type = "button";
+  item.appendChild(btn);
+  fillSnapshotRow(btn, r, now);
+  return item;
+}
+// The row's attributes and parts, written onto its button: on a made row once, on a standing row at every
+// model change (the classes rewritten whole, the parts emptied and appended in order). The parts reuse the
+// strip's vocabulary: the tab's state colors on the pip (tab-state.ts's rule, tab-snapshot.ts rowState), the
+// session's identity color on its name, the remote "host:" prefix as quiet metadata (host-prefix.ts), and
+// the age color the tab tip gives its times.
+function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
+  btn.className = "snap-row" + (r.closed ? " closed" : "") + (r.loading ? " loading" : "");
+  btn.dataset.act = "open"; btn.dataset.id = r.id;
+  const words = rowWords(r);
+  btn.setAttribute("aria-label", words.label);
+  btn.title = words.title;
+  btn.replaceChildren();
+  const pip = el("span", "snap-pip" + (r.pip ? " " + r.pip : "")); pip.setAttribute("aria-hidden", "true");   // a dot says nothing aloud: its phrase rides the label
+  btn.appendChild(pip);
+  const name = el("span", "snap-sess"); name.replaceChildren(...hostNameNodes(r.name, r.id));
+  if (r.color) name.style.color = r.color.bg;
+  btn.appendChild(name);
+  if (r.needsYou) { const f = el("span", "snap-flag needs"); f.textContent = "needs you"; btn.appendChild(f); }
+  else if (r.waiting) { const f = el("span", "snap-flag"); f.textContent = "waiting"; btn.appendChild(f); }
+  const nowEl = el("span", "snap-now"); nowEl.textContent = r.loading ? "opening…" : r.now; btn.appendChild(nowEl);
+  if (r.lastT) {
+    const when = el("span", "snap-when"); when.dataset.t = String(r.lastT);
+    when.textContent = agehms(now - r.lastT) + " ago"; when.style.color = ageColorReadable(now - r.lastT);
+    btn.appendChild(when);
+  }
+  if (r.note) {
+    // the session's own note (the postal working note, its claim to a branch and files; tab-snapshot.ts
+    // noteLine): a quieter second line under the now line, never in its place. Appended last, so the
+    // wrapping row puts it under the first line's parts; spoken by the label (rowWords), like the flag
+    const note = el("span", "snap-note"); note.textContent = r.note; note.setAttribute("aria-hidden", "true");
+    btn.appendChild(note);
+  }
+}
+
 // `keep` (review find, 2026-09-08): a caller that must EMPTY the view before showing it (rerenderAll on a
 // settings change) captures the reader's anchor first and hands it here — by the time this runs there is
 // no DOM left to capture from and the emptied box no longer overflows. undefined = capture here.
@@ -10776,6 +11059,36 @@ function showActive(keep?: { uuid: string; y: number } | null) {
   renderLiveAsk(); // swap in the active session's pending picker (or hide if none)
   renderBgTasks(); // swap in the active session's background-task box (or hide if none)
   let empty = document.getElementById("empty-state");
+  // A SECTION AT A GLANCE: while snapView names a section, the pane shows its sessions instead of any
+  // transcript: every view hidden, the composer disabled with a placeholder that says what to do (a message
+  // typed here has no session to go to), the statusline blank (updateStatusline). activeId is untouched: the
+  // kernel's active hint, the MRU and the drafts still point at the session being read, and its header wears
+  // the mark. renderSnapshot answers false when the section is gone from the strip (a tag deleted, its last
+  // member hidden): then the transcript.
+  if (snapView && renderSnapshot()) {
+    for (const v of views.values()) v.el.style.display = "none";
+    // the reader's place (snapKeep; once per visit): the hide above only queues the clamp's scroll event, so the
+    // view's fields still hold what the reader's last scroll recorded
+    const av = activeId ? views.get(activeId) : null;
+    if (av && !snapKeep) snapKeep = { v: av, scrollTop: av.scrollTop, stick: av.stick };
+    // THE ACTIVE CHANGED UNDER THE VIEW: the session being read closed while the view showed (dismissSession
+    // hands activeId to the MRU survivor and comes back here with snapView set), so the held spot names a view
+    // followReader no longer writes to. The old view gets its spot back and the new active's is held from now,
+    // read before the view's next scroll event: leaving lands the survivor where its reader left it.
+    if (av && snapKeep && snapKeep.v !== av) {
+      snapKeep.v.scrollTop = snapKeep.scrollTop; snapKeep.v.stick = snapKeep.stick;
+      snapKeep = { v: av, scrollTop: av.scrollTop, stick: av.stick };
+    }
+    document.getElementById("tab-loading")?.remove();
+    if (empty) empty.style.display = "none";
+    const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+    if (ta) { ta.disabled = true; ta.placeholder = "Pick a session above to write to it"; }
+    const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
+    if (sendBtn) sendBtn.disabled = true;
+    updateStatusline();
+    return;
+  }
+  hideSnapshot();
   const s = activeId ? liveSession(activeId) : null;
   if (!s) {
     for (const v of views.values()) v.el.style.display = "none";
@@ -10801,6 +11114,13 @@ function showActive(keep?: { uuid: string; y: number } | null) {
       else wait.appendChild(rompLoaderInner("opening " + what + "…"));
       content.appendChild(wait);
       if (empty) empty.style.display = "none";
+      // a pick that lands here from the section view (a row's "opening…" session): the view disabled the box
+      // with its own placeholder, and this branch never touched the composer, so the box takes input for the
+      // picked session again; the first session frame's showActive sets its closed/live state
+      const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+      if (ta) { ta.disabled = false; ta.placeholder = composerRestingPlaceholder(); }
+      const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
+      if (sendBtn) sendBtn.disabled = false;
       // …and ask for it NOW. Every path that lands on a skeleton active comes through here — the click
       // (setActive), the teardown's MRU fallback (dismissSession), a strip that re-lists the tab we are on
       // (noteSkeletonTabOrder) — and nothing else would load it: the idle prefetch skips the active tab by
@@ -11980,7 +12300,7 @@ function renderBgTasks() {
   const host = document.getElementById("bg-tasks");
   if (!host) return;
   host.replaceChildren();
-  const s = activeId ? liveSession(activeId) : null;
+  const s = activeId && !snapView ? liveSession(activeId) : null;   // (snapView: the pane shows a section, not this session)
   const tasks: BgTask[] = (s && s.bgTasks && s.bgTasks.tasks) || [];
   // Keyed on CONTENT, never the chip state (the user 2026-08-30, paraphrased: even while working, anything
   // the session has in flight shows at the chat bottom). The rows ride awaitingItems in both turn states;
@@ -12337,7 +12657,7 @@ function renderLiveAsk() {
   // inline "add your own" field, and the NORMAL composer becomes that field (see composerAnswersAsk /
   // sendComposer). So you keep every control in view and can still type a free-text answer.
   if (footer) footer.style.display = "";
-  if (!activeId || skeletonTabs.ids.has(activeId) || !liveAsks.has(activeId)) {   // a skeleton's pre-outage picker is stale — hidden until the tab loads (2026-09-07)
+  if (!activeId || skeletonTabs.ids.has(activeId) || !liveAsks.has(activeId) || snapView) {   // a skeleton's pre-outage picker is stale — hidden until the tab loads (2026-09-07); snapView: the pane shows a section, not this session
     host.style.display = "none";
     liveTextValue = "";
     setComposerAskMode();   // no picker → the composer's normal placeholder + behavior
@@ -13398,6 +13718,7 @@ function updateStatusline() {
   const sl = document.getElementById("statusline");
   const s = activeId ? liveSession(activeId) : null;
   if (!sl) return;
+  if (snapView) { sl.replaceChildren(); return; }   // the pane shows a section, not a session: no session's chip
   if (activeId && !s) {
     // the tab is a loading placeholder (its session payload hasn't arrived) — the statusline said
     // whatever the PREVIOUS tab said, or a spawn stub's "Working" over a broken clock (the user
@@ -14578,10 +14899,15 @@ function noteMru(id: string): void {
 // "now", the sessions map for liveness, and a land that pre-seeds the per-tab scroll restore (views)
 // BEFORE setActive — so the entering tab's own restore applies the remembered spot — then re-asserts
 // it once the pane is visible (a same-tab jump returns early from setActive and needs the direct set).
+// While the section at a glance shows, #content's scroll is the view's list, not the reader's spot in
+// the hidden transcript: "now" records the spot the view holds for the active tab (snapKeep), so a pick
+// from the view leaves a trail entry that walks back to the line being read (tab-snapshot-pane.test.ts).
 const navHist = new NavHistory({
   now: () => {
     const c = document.getElementById("content");
-    return activeId && c ? { sid: activeId, top: c.scrollTop } : null;
+    if (!activeId || !c) return null;
+    const kept = snapKeep && snapKeep.v === views.get(activeId) ? snapKeep.scrollTop : null;   // the view up: the held spot
+    return { sid: activeId, top: kept ?? c.scrollTop };
   },
   alive: (sid) => sessions.has(sid),
   apply: (spot) => {
@@ -14606,7 +14932,16 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     const p = subParts(id);
     if (p) { openSubagentView(p.parentId, p.agentId, null); return; }
   }
-  if (activeId === id && anchor == null && anchorT == null) return; // already active, nothing to do
+  // A session pick ends the section view (the header put it up; the pick names a session) and brings the
+  // picked tab on screen: a tab folded away under its header (a row of the view, a feed deep link, the
+  // arrows from the header) opens its section, since the gesture named that session.
+  const leavingSnap = snapView !== null;
+  snapView = null;
+  if (collapsedTabIds.has(id)) unfoldSectionOf(id);   // per holder: see unfoldSectionOf
+  if (activeId === id && anchor == null && anchorT == null) {   // already active, nothing to do…
+    if (leavingSnap) { renderTabs(); showActive(); }             // …except put its transcript back
+    return;
+  }
   navHist.record();   // every real navigation records the spot being LEFT (the user 2026-08-14: Ctrl+M / Ctrl+, walk the trail)
   closeMetaMenu(); // an open model/effort menu targets the tab we're leaving
   // a comment popover belongs to its parent session's view — leaving that session closes it (the
@@ -14653,7 +14988,11 @@ function cycleTab(dir: number) {
   const ord = visibleOrder();                   // never cycle onto a view-hidden session
   if (ord.length < 2 || !activeId) return;
   const i = ord.indexOf(activeId);
-  if (i < 0) return;
+  if (i < 0) {                                  // folded away: step from its header's place (onTabKey's rule)
+    const nb = neighborOfFolded(lastStripItems, activeId, dir > 0 ? 1 : -1);
+    if (nb) setActive(nb);
+    return;
+  }
   setActive(ord[(i + dir + ord.length) % ord.length]);
 }
 
@@ -17413,17 +17752,21 @@ setupSettings();
     // is consistent: tab focused → Enter drops into the message box; Escape there returns to the tabs.
     select: (el) => { const id = el.dataset.id; if (id) { setActive(id); focusActiveTab(); } },
     // a section header (tab groups): fold or open that group — the new state is the opposite of the
-    // one the header RENDERED (data-folded), never a toggle of the stored bit: the active tab's
-    // section renders open whatever the store says, so a stored toggle there inverted the click. The
-    // write notifies (TABGROUPS_EVENT) and the listener re-renders — one render path for a local
-    // toggle and a sibling pane's alike.
+    // one the header RENDERED (data-folded), never a toggle of the stored bit (a header can render a
+    // state the store does not hold). The write notifies (TABGROUPS_EVENT) and the listener re-renders:
+    // one render path for a local toggle and a sibling pane's alike. The same click shows the section at
+    // a glance in the transcript's place (snapView; showActive paints it), open or folded: the user
+    // looks at the group they just folded or opened, and a session pick puts a transcript back.
     "toggle-group": (el) => {
       const name = el.dataset.group;
-      if (name) writeTabGroups(setSectionCollapsed(tabGroups(), name, el.dataset.folded !== "1"));
+      if (!name) return;
+      snapView = name;
+      writeTabGroups(setSectionCollapsed(tabGroups(), name, el.dataset.folded !== "1"));
+      showActive();
     },
-    // the header of the section holding the ACTIVE tab (makeGroupHead): unfoldable while active, so
-    // the click stores nothing — the delegate's flash is the whole acknowledgement
-    "group-active": () => { /* acknowledged by the flash; nothing to store */ },
+    // the header whose section the pane shows, open and holding the tab being read (makeGroupHead): a
+    // second click puts the transcript back
+    "show-transcript": () => leaveSnapshot(),
     close: (el) => {
       const id = el.dataset.id;
       if (id && isSubId(id)) { closeSubagentView(id); return; }   // a subagent viewer: nothing to end, just close

--- a/ui/webview/skeleton-tabs-wiring.test.ts
+++ b/ui/webview/skeleton-tabs-wiring.test.ts
@@ -217,8 +217,8 @@ test("every ACTIVE-tab display path reads through liveSession; only name reads a
   for (const f of ["updateStatusline", "renderBgTasks", "renderSubHead", "paintScrollMarks", "updateCommentRail", "landNearestMoment", "virtualizeToViewport", "updateJumpBtn", "updateReplyChips"]) {
     assert.match(fn(f), /liveSession\(activeId\)/, f + " reads the gated session");
   }
-  assert.match(fn("renderLiveAsk"), /if \(!activeId \|\| skeletonTabs\.ids\.has\(activeId\) \|\| !liveAsks\.has\(activeId\)\) \{/,
-    "a skeleton's pre-outage picker is stale — hidden until the tab loads");
+  assert.match(fn("renderLiveAsk"), /if \(!activeId \|\| skeletonTabs\.ids\.has\(activeId\) \|\| !liveAsks\.has\(activeId\) \|\| snapView\) \{/,
+    "a skeleton's pre-outage picker is stale — hidden until the tab loads (and none shows under a section at a glance: snapView)");
 });
 
 test("styles: the skeleton label wears the placeholder's own muted value, and nothing else is new", () => {
@@ -231,7 +231,7 @@ test("the click path's loader latch: showActive latches the skeleton it is loadi
   // on the click path the strip that RELEASES the id lands before its full, so onFull() reports no skeleton —
   // the latch is what routes that full to showActive (review find 2026-09-07)
   assert.match(RENDER, /let skeletonLoading: string \| null = null;/);
-  const show = RENDER.slice(RENDER.indexOf("function showActive("), RENDER.indexOf("function showActive(") + 6000);
+  const show = RENDER.slice(RENDER.indexOf("function showActive("), RENDER.indexOf("function showActive(") + 9000);   // the section-at-a-glance branch sits ahead of the loading branch
   assert.match(show, /const skeleton = skeletonTabs\.ids\.has\(activeId\);\s*\n\s*skeletonLoading = skeleton \? activeId : null;/);
   assert.match(show, /document\.getElementById\("tab-loading"\)\?\.remove\(\);[^\n]*\n\s*skeletonLoading = null;/);
   assert.doesNotMatch(RENDER, /window\.addEventListener\("romp:wsup", \(\) => \{ onSocketUp/, "the socket flip is a frame now, never the onopen event");
@@ -318,6 +318,9 @@ function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript
     const { sessions, views, tabMeta, skeletonTabs, commentThreads, jumpBtn, replyChips, atBottomDist, isReplyReady, hostOf, el, rompLoaderInner, HOOKS } = W;
     let activeId = null, skeletonLoading = null, replyChipSig = "";
     const placeReviveLoader = () => {}, notifyActive = () => {}, renderLedger = () => {}, renderLiveAsk = () => {}, renderBgTasks = () => {}, renderSubHead = () => {}, updateStatusline = () => {};
+    // the section-at-a-glance view, inert: no section shows (snapView null), so showActive's branch is not taken
+    let snapView = null, snapKeep = null;
+    const renderSnapshot = () => false, hideSnapshot = () => {}, composerRestingPlaceholder = () => "";
     const requestFullSession = (id, why) => { HOOKS.fulls.push(why + ":" + id); };
   `;
   const epilogue = `

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -397,9 +397,15 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    by construction; the uncoloured "(no tags)" chip lifts from --dim toward --fg, the old label's exact cue */
 .tab-group-head:hover .tab-group-chip, .tab-group-head:focus-visible .tab-group-chip { filter: brightness(1.3); }
 .tab-group-head:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
-/* the section holding the active tab: unfoldable while active (no fold action on its header), so no
-   pointer cursor promising a click — it still drags to reorder the groups */
-.tab-group-head.holds-active { cursor: default; }
+/* the section holding the tab being read, open or folded: it folds like any other (its cursor promises the
+   click), and its header says whose it is by the tag's chip, accent-underlined (the chip is coloured by
+   identity inline, which a colour rule cannot reach; the underline is a property it never sets), so the
+   header that stands in for a folded-away tab is found by the same mark it wore while open. Distinct from
+   the hover lift (a fold cue) and from .snap-shown (the pane shows the section). */
+.tab-group-head.holds-active .tab-group-chip { text-decoration: underline; text-decoration-color: var(--accent); text-underline-offset: 2px; }
+/* the section whose sessions the pane is SHOWING at a glance (render.ts sets .snap-shown on its header): the
+   accent wash the picker's active row wears, on the header the chip's inline style never reaches */
+.tab-group-head.snap-shown { background: var(--accent-wash); }
 .tab-group-head.dragging { opacity: 0.45; }
 .tab-group-head.drop-target { box-shadow: inset 2px 0 0 var(--accent); }
 /* the disclosure chevron: ▸ folded, turned down while open — the fold-caret idiom (a CSS transition on
@@ -1225,6 +1231,42 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .mention-chip { display: inline-block; padding: 0 6px; border-radius: 9px; line-height: 1.35;
   background: var(--chip-bg, rgba(255, 255, 255, 0.18)); color: var(--chip-fg, currentColor);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3); }
+
+/* A SECTION AT A GLANCE (tab-snapshot.ts, render.ts renderSnapshot): one row per session of a tab-strip
+   section, in the transcript's place. Two sizes only: the body size for the name and the now line, and
+   0.82em, the header's label size, for the heading, the flag word, the time and the note (labels match
+   labels, times match the strip's sub-lines). The heading wears the header's own dress (letter-spaced dim
+   label + the tag's swatch bar); a row is a real button with the one action hover (accent border + accent
+   wash) and the accent focus ring; the pip wears the tab's state colors by the tab's rule (the retrying
+   amber is the same status token the tab and the folded header's pip use); the name takes the session's
+   identity color inline. Tokens only, so it reads in every theme without a light override. */
+#tab-snapshot { padding: 6px 14px 14px; }
+.snap-head { display: flex; align-items: center; gap: 6px; margin: 4px 0 8px; font-size: 0.82em; font-weight: 600; letter-spacing: 0.04em; color: var(--dim); }
+.snap-swatch { flex: 0 0 auto; width: 3px; height: 12px; border-radius: 1px; background: var(--dim); }
+.snap-count { font-weight: 400; opacity: 0.7; }
+.snap-list { display: flex; flex-direction: column; gap: 2px; }
+.snap-row { display: flex; flex-wrap: wrap; align-items: center; gap: 2px 8px; width: 100%; min-width: 0; padding: 5px 8px; border: 1px solid transparent; border-radius: 6px;
+  background: none; color: var(--fg); font: inherit; text-align: left; cursor: pointer; }
+.snap-row:hover { border-color: var(--accent); background: var(--accent-wash); }
+.snap-row:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
+.snap-pip { flex: 0 0 auto; width: 7px; height: 7px; border-radius: 50%; background: transparent; }
+.snap-pip.working { background: var(--st-working-bg); }
+.snap-pip.blocked { background: var(--st-blocked-bg); }
+.snap-pip.awaiting { background: var(--st-awaiting-bg); }
+.snap-pip.retrying { background: var(--st-retrying-bg); }
+.snap-pip.compacting { background: var(--st-compacting-bg); }
+.snap-pip.waiting { background: var(--st-awaitbg-bg); }
+.snap-pip.unknown { box-shadow: inset 0 0 0 1.5px var(--dim); }
+.snap-sess { flex: 0 0 auto; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
+.snap-row.closed .snap-sess { text-decoration: line-through; opacity: 0.6; }
+.snap-row.loading .snap-sess { opacity: 0.6; }
+.snap-flag { flex: 0 0 auto; padding: 0 6px; border: 1px solid var(--box-border); border-radius: var(--radius-pill); font-size: 0.82em; color: var(--dim); }
+.snap-flag.needs { border-color: transparent; background: var(--st-blocked-bg); color: var(--st-blocked-fg); }
+.snap-now { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--dim); }
+/* the row's second line: the session's own working note (render.ts fillSnapshotRow), the header's 0.82em in
+   the dim token a step quieter, one line, indented past the pip and its gap so it sits under the name */
+.snap-note { flex: 1 0 100%; min-width: 0; padding-left: 15px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.82em; color: var(--dim); opacity: 0.7; }
+.snap-when { flex: 0 0 auto; font-size: 0.82em; font-variant-numeric: tabular-nums; color: var(--dim); }
 /* The two buttons are the SAME rounded square, exactly as tall as the one-line message box beside them
    (the user 2026-07-30, round 2: the first cut's circles sat taller than the resting box, and a rounded
    rectangle reads better than a full circle). The size is the input's own min-height calc written

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -13,7 +13,7 @@ import * as TG_MOD from "./tab-groups";
 import { sectionTabs, anySectioned, parseTabGroups, readTabGroups, writeTabGroups, isSectionCollapsed,
          toggleSectionCollapsed, setSectionCollapsed, planStrip, reorderTagOrder, applyTagOrder, TABGROUPS_KEY,
          DEFAULT_COLLAPSED, sectionRef, isPinned, setPinned, togglePinned, prunePinned, reachableFrom, tagRenames, followTagRenames, followAdoption,
-         sameTagNames, headWords, type TabSection, type SectionRef, type TabGroupsState } from "./tab-groups";
+         sameTagNames, headWords, homeSectionOf, neighborOfFolded, type TabSection, type SectionRef, type TabGroupsState } from "./tab-groups";
 import { sectionPipTitle } from "./tab-state";
 import { DEFAULT_SETTINGS } from "./settings";
 
@@ -131,7 +131,7 @@ test("the strip renders sections when the switch is on and some tag holds a visi
     "a header paints from the plan (T264: on its own line under the setting, opened by the break ahead of it; T264b: it names the group the copies below sit in)");
 });
 
-test("executed: planStrip — sections + folds; the flat strip when off or untagged; the ACTIVE tab's section never folds", () => {
+test("executed: planStrip — sections + folds; the flat strip when off or untagged; the ACTIVE tab's section folds like any other, marked", () => {
   const unions = viewTagUnion({ ...V, tags: [...V.tags, { id: "g4", name: "archived", color: "#6b7280", members: ["old1", "old2"] }] });
   const st = parseTabGroups(null);
   const p = planStrip(["web", "old1", "loose", "old2"], unions, st, "web", false);
@@ -143,9 +143,10 @@ test("executed: planStrip — sections + folds; the flat strip when off or untag
   ], "archived starts folded: its header alone stands in for old1/old2; infra holds the active tab");
   assert.deepEqual([...p.folded], ["old1", "old2"], "the ids keyboard cycling skips");
   const active = planStrip(["web", "old1", "loose"], unions, st, "old1", false);
-  assert.deepEqual(active.items[2], { head: { name: "archived", localId: "g4", color: "#6b7280", ids: ["old1"] }, folded: false, active: true, hidden: [] },
-    "the active tab's section renders open whatever the store says, and is marked as holding it");
-  assert.deepEqual([...active.folded], []);
+  assert.deepEqual(active.items[2], { head: { name: "archived", localId: "g4", color: "#6b7280", ids: ["old1"] }, folded: true, active: true, hidden: ["old1"] },
+    "the active tab's section folds as the store says and is marked as holding it: the header is the hidden tab's stand-in");
+  assert.deepEqual([...active.folded], ["old1"], "the active id is folded away too: visibleOrder drops it, the header takes its place");
+  assert.equal(active.items.some((i) => "id" in i && i.id === "old1"), false, "no tab node for it: nothing hidden takes focus");
   assert.ok(!planStrip(["web", "old1"], unions, st, null, false).items.some((i) => "head" in i && i.active), "no active tab: no section holds it");
   const off = planStrip(["web", "old1"], unions, { ...st, on: false }, null, false);
   assert.deepEqual(off.items, [{ id: "web" }, { id: "old1" }], "switch off: the flat strip");
@@ -181,10 +182,9 @@ test("executed: the PHONE layout renders the flat strip — every visible id, no
     "installed once at module scope with the other strip listeners, never inside a render");
 });
 
-test("executed + pinned: the section holding the ACTIVE tab is unfoldable while active — no fold action on its header, a title that says so, a click that stores nothing", () => {
-  // planStrip renders the active tab's section open whatever the store says, so a fold click there
-  // used to store folded=true that could not render: "click to fold this group" did nothing visible
-  // on every click, and the stored fold bit when the user switched to another section
+test("executed + pinned: the section holding the ACTIVE tab folds like any other: marked, its header the hidden tab's stand-in for focus and the arrows", () => {
+  // planStrip folds it as the store says and marks its header; render.ts gives that header the same fold click
+  // as the rest, and folded, the header is where focus and the arrows go for the hidden tab
   const unions = viewTagUnion(V);
   const st = parseTabGroups(null);
   const marks = (activeId: string | null) => planStrip(["web", "api", "tests", "loose"], unions, st, activeId, false).items
@@ -192,24 +192,51 @@ test("executed + pinned: the section holding the ACTIVE tab is unfoldable while 
   assert.deepEqual(marks("web"), [["qa", false], ["infra", true], [null, false]], "exactly the section holding the active tab");
   assert.deepEqual(marks("tests"), [["qa", true], ["infra", false], [null, false]]);
   assert.deepEqual(marks(null), [["qa", false], ["infra", false], [null, false]]);
-  // a user-folded section holding the active tab: open AND marked (the fold stays stored for later)
+  // a user-folded section holding the active tab: FOLDED and marked; its hidden set holds the active id
   const folded = setSectionCollapsed(st, "infra", true);
-  const inf = planStrip(["web", "tests"], unions, folded, "web", false).items
-    .find((i) => "head" in i && i.head.name === "infra") as { head: TabSection; folded: boolean; active: boolean };
-  assert.deepEqual([inf.folded, inf.active], [false, true]);
-  // render.ts: that header carries NO fold action (a distinct data-act the delegate flashes and
-  // otherwise ignores), a title that says why, and no pointer cursor promising a click
+  const plan = planStrip(["web", "api", "tests"], unions, folded, "web", false);   // qa: api, tests | infra(folded): web, api (T264b: api is under both)
+  const inf = plan.items.find((i) => "head" in i && i.head.name === "infra") as { head: TabSection; folded: boolean; active: boolean; hidden: string[] };
+  assert.deepEqual([inf.folded, inf.active, inf.hidden], [true, true, ["web", "api"]], "the fold hides every copy inside it (api's infra copy too; its qa copy is on screen)");
+  assert.deepEqual([...plan.folded], ["web"], "api keeps its place in the keyboard order through its qa copy");
+  // a pinned active tab shows through the fold like any pinned member: then it is on screen and no stand-in is needed
+  const pinnedActive = planStrip(["web", "api", "tests"], unions, { ...folded, pinned: [{ sid: "web", name: "infra", id: "g2" }] }, "web", false);
+  assert.ok(pinnedActive.items.some((i) => "id" in i && i.id === "web"), "the pinned active tab renders");
+  assert.deepEqual([...pinnedActive.folded], []);
+  // the stand-in rules, pure: the header a folded id is homed in, and where the arrows land from it
+  assert.deepEqual(homeSectionOf(plan.items, "web")?.name, "infra");
+  assert.deepEqual(homeSectionOf(plan.items, "tests")?.name, "qa", "an id on screen has a home too: the same lookup");
+  assert.equal(homeSectionOf(plan.items, "nope"), null);
+  assert.deepEqual(plan.items.map((i) => ("head" in i ? "#" + i.head.name : i.id)), ["#qa", "api", "tests", "#infra"]);
+  assert.equal(neighborOfFolded(plan.items, "web", 1), "api", "right from the folded infra header (last on the strip): wraps round to the first tab");
+  assert.equal(neighborOfFolded(plan.items, "web", -1), "tests", "left from it: the last tab before it");
+  const two = planStrip(["tests", "web", "api", "loose"], unions, folded, "web", false).items;   // qa: tests, api | infra(folded): web | sep | loose
+  assert.equal(neighborOfFolded(two, "web", 1), "loose", "the untagged separator is a head too: skipped, like any header");
+  assert.equal(neighborOfFolded(two, "web", -1), "api");
+  assert.equal(neighborOfFolded(two, "nope", 1), null, "no header holds it");
+  assert.equal(neighborOfFolded(planStrip(["web"], unions, folded, "web", false).items, "web", 1), null, "no tab on screen at all");
+  assert.equal(neighborOfFolded(planStrip(["web", "api"], unions, { ...st, on: false }, "web", false).items, "web", 1), null, "the flat strip: no headers");
+  // render.ts: EVERY named header is the fold button (one data-act, one role, the fold state on it); the one
+  // holding the active tab adds aria-current and the CSS mark, and keeps its pointer cursor: it folds
   const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
   assert.match(head, /function makeGroupHead\(sec: TabSection, collapsed: boolean, holdsActive: boolean, hidden: readonly string\[\]\): HTMLElement \{/);
-  assert.match(head, /head\.dataset\.act = holdsActive \? "group-active" : "toggle-group";/);
-  assert.equal(headWords("infra", 1, 0, false, true).title, "infra — 1 session; holds the active tab, so it stays open; drag to reorder the groups");
-  assert.match(head, /const words = headWords\(name, total, hidden\.length, collapsed, holdsActive\);\s*\n\s*head\.title = words\.title;/, "the words are the pure module's");
+  assert.match(head, /head\.dataset\.act = "toggle-group";/);
+  assert.ok(!head.includes("group-active"), "the no-op action is gone");
+  assert.match(head, /if \(holdsActive\) head\.setAttribute\("aria-current", "true"\);/);
   assert.match(head, /\+ \(holdsActive \? " holds-active" : ""\)\);/);
   assert.match(head, /head\.draggable = true;/, "it still drags to reorder the groups");
-  const del = RENDER.slice(RENDER.indexOf('"group-active": () => {'), RENDER.indexOf('"group-active": () => {') + 120);
-  assert.match(del, /^"group-active": \(\) => \{ \/\* [^*]*\*\/ \},/, "a no-op: the delegate's flash is the whole acknowledgement");
-  assert.ok(!del.includes("writeTabGroups"), "…and nothing is stored");
-  assert.match(CSS, /\.tab-group-head\.holds-active \{ cursor: default; \}/);
+  assert.equal(headWords("infra", 1, 0, false, true).title, "infra — 1 session; holds the tab you are reading; click to fold this group and see its sessions at a glance; drag to reorder the groups");
+  assert.match(head, /const words = headWords\(name, total, hidden\.length, collapsed, holdsActive, back, shown\);\s*\n\s*head\.title = words\.title;/, "the words are the pure module's");
+  assert.ok(!RENDER.includes('"group-active"'), "no delegate handler for a no-op either");
+  assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active \{ cursor: default; \}/, "the header folds, so its cursor promises the click");
+  assert.match(CSS, /\.tab-group-head\.holds-active \.tab-group-chip \{ text-decoration: underline; text-decoration-color: var\(--accent\);/, "the mark: the tag's chip accent-underlined");
+  // the hidden active tab's stand-in in render.ts: focus lands on the header, the arrows step from it, and a
+  // pick of a folded-away session opens its section (tab-snapshot-pane.test.ts runs these)
+  assert.match(RENDER, /const home = activeId \? homeSectionOf\(lastStripItems, activeId\) : null;\s*\n\s*if \(!home \|\| home\.name === null \|\| !bar\) return;\s*\n\s*Array\.from\(bar\.querySelectorAll<HTMLElement>\("\.tab-group-head"\)\)\.find\(\(h\) => h\.dataset\.group === home\.name\)\?\.focus\(\);/,
+    "focusActiveTab falls back to the header");
+  assert.match(RENDER, /const nb = neighborOfFolded\(lastStripItems, activeId, dir\);\s*\n\s*if \(nb\) \{ setActive\(nb\); focusActiveTab\(\); \}/, "onTabKey (a focused tab's arrows)");
+  assert.match(RENDER, /function unfoldSectionOf\(id: string\): void \{\s*\n\s*const holder = lastStripItems\.find\(\(it\) => "head" in it && it\.head\.name !== null && it\.folded && it\.head\.ids\.includes\(id\)\);\s*\n\s*if \(holder && "head" in holder && holder\.head\.name !== null\) writeTabGroups\(setSectionCollapsed\(tabGroups\(\), holder\.head\.name, false\)\);/,
+    "the first folded holder opens (per holder: a session under several tags has a copy under each)");
+  assert.match(RENDER, /collapsedTabIds = plan\.folded;\s*\n\s*lastStripItems = plan\.items;/, "the plan the stand-in rules read is the one the strip rendered");
 });
 
 test("executed: a create in flight sections under EVERY requested tag from the first paint (T264b)", () => {
@@ -248,8 +275,8 @@ test("executed: the header click sets the fold state from what it RENDERED — n
   // the header carries its rendered state; the delegate reads it
   const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
   assert.match(head, /head\.dataset\.folded = collapsed \? "1" : "0";/);
-  assert.match(RENDER, /if \(name\) writeTabGroups\(setSectionCollapsed\(tabGroups\(\), name, el\.dataset\.folded !== "1"\)\);/,
-    "rendered open → fold; rendered folded → open");
+  assert.match(RENDER, /if \(!name\) return;\s*\n\s*snapView = name;\s*\n\s*writeTabGroups\(setSectionCollapsed\(tabGroups\(\), name, el\.dataset\.folded !== "1"\)\);/,
+    "rendered open → fold; rendered folded → open (and the section shows in the pane: snapView)");
 });
 
 test("a folded section renders its header alone with the folded-away count and one MEMBER-derived pip after it — a label, not a session; cycling skips folded ids", () => {
@@ -315,11 +342,12 @@ test("the picker's Tags row is for SDK and Codex sessions: disabled behind a not
 });
 
 test("headers are click-safe: data-act on the node, the action on the stable #tabs delegate, one render path via the event", () => {
-  assert.match(RENDER, /head\.dataset\.act = holdsActive \? "group-active" : "toggle-group";/);
-  assert.match(RENDER, /"toggle-group": \(el\) => \{\s*\n\s*const name = el\.dataset\.group;\s*\n\s*if \(name\) writeTabGroups\(setSectionCollapsed\(tabGroups\(\), name, el\.dataset\.folded !== "1"\)\);/);
+  assert.match(RENDER, /head\.dataset\.act = "toggle-group";/);
+  // the click derives the next fold state from the one the header RENDERED (data-folded), never from the store, and
+  // shows the section in the pane (snapView; tab-snapshot-pane.test.ts)
+  assert.match(RENDER, /"toggle-group": \(el\) => \{\s*\n\s*const name = el\.dataset\.group;\s*\n\s*if \(!name\) return;\s*\n\s*snapView = name;\s*\n\s*writeTabGroups\(setSectionCollapsed\(tabGroups\(\), name, el\.dataset\.folded !== "1"\)\);/);
   assert.match(RENDER, /window\.addEventListener\(TABGROUPS_EVENT, \(\) => renderTabs\(\)\);/, "the same-window delivery");
   assert.match(RENDER, /window\.addEventListener\("storage", \(e\) => \{ if \(e\.key === TABGROUPS_KEY\) renderTabs\(\); \}\);/, "…and a sibling pane's");
-  assert.match(RENDER, /if \(name\) writeTabGroups\(setSectionCollapsed/);
   assert.doesNotMatch(RENDER.slice(RENDER.indexOf('"toggle-group": (el) => {'), RENDER.indexOf('"toggle-group": (el) => {') + 300), /renderTabs\(\)/,
     "the toggle does not render itself — the event does, so a local toggle and a sibling pane's take one path");
 });
@@ -529,10 +557,12 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
   // none of a tab's affordances
   assert.ok(!head.includes("tab-close") && !head.includes("tabStateClass(") && !head.includes("tab-dot") && !head.includes("tabCtxGauge("),
     "no close, no state class of its own, no tab pip, no gauge");
-  // keyboard: a button to the keyboard, through the same click → delegate path as the pointer; the active
-  // tab's header (no fold action) is not a tab stop and not a button (the accessibility test below)
-  assert.match(head, /\} else \{[^]*?head\.setAttribute\("role", "button"\);\s*\n\s*head\.setAttribute\("aria-expanded", collapsed \? "false" : "true"\);\s*\n\s*head\.tabIndex = 0;\s*\n\s*head\.addEventListener\("keydown", \(e\) => \{\s*\n\s*if \(e\.key === "Enter" \|\| e\.key === " "\) \{ e\.preventDefault\(\); head\.click\(\); \}\s*\n\s*\}\);\s*\n\s*\}/,
-    "role, expanded state, tab stop and key handler together");
+  // keyboard: a button to the keyboard, through the same click → delegate path as the pointer, on EVERY named
+  // header, the one holding the tab being read too (it folds; aria-current marks it; the accessibility test
+  // below). The stand-in's own keys come first in the handler (tab-snapshot-pane.test.ts runs them).
+  assert.match(head, /head\.setAttribute\("role", "button"\);\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(!back\) head\.setAttribute\("aria-expanded", collapsed \? "false" : "true"\);\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(holdsActive\) head\.setAttribute\("aria-current", "true"\);\s*\n\s*head\.tabIndex = 0;\s*\n\s*head\.addEventListener\("keydown", \(e\) => \{/,
+    "role, expanded state, the current mark, tab stop and key handler together");
+  assert.match(head, /if \(e\.key === "Enter" \|\| e\.key === " "\) \{ e\.preventDefault\(\); head\.click\(\); \}\s*\n\s*\}\);/, "Enter and Space press the header");
   // a push mid-read must not kick focus off the header: renderTabs re-focuses the same group after the rebuild
   assert.match(RENDER, /const focusedGroup = \(focusedEl\?\.closest\("\.tab-group-head"\) as HTMLElement \| null\)\?\.dataset\.group;\s*\n\s*const refocusTab = bar\.contains\(document\.activeElement\);/,
     "captured before the tab rule (chat-focus-model.test pins that rule's two-line shape)");
@@ -572,10 +602,11 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
   for (const m of CSS.matchAll(/\n\.tab-group-head:hover[^{\n]*\{([^}]*)\}/g)) assert.doesNotMatch(m[1], /background/, "no wash on hover");
   assert.match(CSS, /\.tab-group-head:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/);
   assert.match(head, /head\.draggable = true;/, "still drags to reorder the groups");
-  assert.match(head, /head\.dataset\.act = holdsActive \? "group-active" : "toggle-group";/, "…and still folds through the delegate");
+  assert.match(head, /head\.dataset\.act = "toggle-group";/, "…and still folds through the delegate");
   // theme: every section rule resolves through tokens — no raw hex or rgba — so the light theme needs no
   // override, and the tokens are ones the strip already wears (theme-parity.test.ts checks --fg/--dim/
-  // --accent against --bg in both themes)
+  // --accent against --bg in both themes); --accent-wash is the shown section's header (the pane shows it:
+  // .snap-shown), the wash the picker's active row already wears
   const rules = Array.from(CSS.matchAll(/\n(\.tab-group-[^{\n]*)\{([^}]*)\}/g));
   assert.ok(rules.length >= 15, "the section rules were found: " + rules.length);
   for (const [, sel, body] of rules) {
@@ -585,7 +616,7 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
   assert.equal(CSS.match(/\.tab-group-pip\.retrying \{ background: (var\(--st-retrying-bg\)); \}/)![1], CSS.match(/\.tab\.tab-retrying \{ --state: (var\(--st-retrying-bg\)); \}/)![1],
     "the pip's retrying amber IS the tab's — the same status token");
   const toks = new Set((rules.map((m) => m[2]).join(" ").match(/var\((--[a-z-]+)/g) || []).map((m) => m.slice(4)));
-  for (const t of toks) assert.ok(["--fg", "--dim", "--accent", "--box-border", "--st-working-bg", "--st-blocked-bg", "--st-retrying-bg"].includes(t), "a token the strip does not already wear: " + t);
+  for (const t of toks) assert.ok(["--fg", "--dim", "--accent", "--accent-wash", "--box-border", "--st-working-bg", "--st-blocked-bg", "--st-retrying-bg"].includes(t), "a token the strip does not already wear: " + t);
 });
 
 // SHOW WHEN FOLDED (the user 2026-09-06): a member pinned to its section keeps its tab on the strip
@@ -634,8 +665,9 @@ test("executed: a folded section with one PINNED member renders the header, then
   assert.deepEqual(two.pinned, [{ sid: "old2", name: "archived", id: "g4" }, { sid: "old3", name: "archived", id: "g4" }]);
   assert.deepEqual(setPinned(two, ARCH, "old3", false).pinned, [{ sid: "old2", name: "archived", id: "g4" }]);
   assert.deepEqual(setPinned(two, ARCH, "old2", true).pinned, [{ sid: "old3", name: "archived", id: "g4" }, { sid: "old2", name: "archived", id: "g4" }], "set on again: one entry, moved to the end");
-  // an open section: nothing hidden, pins irrelevant
-  assert.deepEqual(headsOf(planStrip(["old1", "old2"], unions, st, "old1", false))[0].hidden, []);
+  // an open section: nothing hidden, pins irrelevant (archived starts folded, so it is opened first: the
+  // active tab's section folds like any other now)
+  assert.deepEqual(headsOf(planStrip(["old1", "old2"], unions, setSectionCollapsed(st, "archived", false), "old1", false))[0].hidden, []);
   // the untagged trail has no fold: nothing pins there
   assert.deepEqual(setPinned(st, { name: null, localId: null }, "loose", true), st);
 });
@@ -1651,7 +1683,7 @@ test("the toggle is a row in the tab menu's Tags flyout beside the Move-to rows:
   assert.match(RENDER, /function tabGroups\(\) \{ return readTabGroups\(viewTagUnion\(effViews\(\)\)\); \}/);
   assert.match(RENDER, /const unions = viewTagUnion\(effViews\(\)\);\s*\n\s*const plan = planStrip\(visibleIds, unions, readTabGroups\(unions\), activeId, phoneLayout\(\),/);
   assert.match(RENDER, /toggle: \(\) => \{ const st = tabGroups\(\); writeTabGroups\(\{ \.\.\.st, on: !st\.on \}\); \}/);
-  assert.equal((RENDER.match(/writeTabGroups\(setSectionCollapsed\(tabGroups\(\)/g) || []).length, 1, "the fold write (toggle-group)");
+  assert.equal((RENDER.match(/writeTabGroups\(setSectionCollapsed\(tabGroups\(\)/g) || []).length, 2, "the fold writes: the header's click (toggle-group) and the pick of a folded-away tab (unfoldSectionOf), which opens its holder");
   assert.equal((RENDER.match(/readTabGroups\(/g) || []).length, 5, "five reads in all…");
   assert.equal((RENDER.match(/readTabGroups\(unions\)/g) || []).length, 2, "…the adoption's and the plan's, with the unions in hand…");
   assert.equal((RENDER.match(/readTabGroups\(viewTagUnion\(effViews\(\)\)\)/g) || []).length, 1, "…tabGroups() for every write path…");
@@ -1687,22 +1719,30 @@ test("executed: a folded section whose EVERY member is pinned stays folded — t
   // the words render.ts paints for that header
   assert.deepEqual(headWords("infra", 2, 0, true, false), {
     count: "2", label: "infra, 2 sessions, folded, all shown",
-    title: "infra — folded, but all 2 sessions are set to show when folded, so none is hidden; click to open",
-  }, "the total, never a 0 beside two visible tabs; the title names the menu row that did it");
-  assert.equal(headWords("infra", 1, 0, true, false).title, "infra — folded, but its one session is set to show when folded, so none is hidden; click to open");
+    title: "infra — folded, but all 2 sessions are set to show when folded, so none is hidden; click to open and see its sessions at a glance",
+  }, "the total, never a 0 beside two visible tabs; the title names the menu row that did it (and the click's other effect: the section in the pane)");
+  assert.equal(headWords("infra", 1, 0, true, false).title, "infra — folded, but its one session is set to show when folded, so none is hidden; click to open and see its sessions at a glance");
   // …and for the ordinary folded, part-pinned, open and active headers
-  assert.deepEqual(headWords("infra", 2, 2, true, false), { count: "2", label: "infra, 2 sessions folded", title: "infra — 2 sessions folded; click to open" });
-  assert.deepEqual(headWords("infra", 2, 1, true, false), { count: "1", label: "infra, 1 session folded", title: "infra — 1 session folded; click to open" },
+  assert.deepEqual(headWords("infra", 2, 2, true, false), { count: "2", label: "infra, 2 sessions folded", title: "infra — 2 sessions folded; click to open and see its sessions at a glance" });
+  assert.deepEqual(headWords("infra", 2, 1, true, false), { count: "1", label: "infra, 1 session folded", title: "infra — 1 session folded; click to open and see its sessions at a glance" },
     "one pinned: the hidden count, the pinned tab shows itself");
-  assert.deepEqual(headWords("infra", 2, 0, false, false), { count: "2", label: "infra, 2 sessions", title: "infra — 2 sessions; click to fold this group; drag to reorder the groups" });
-  assert.deepEqual(headWords("infra", 3, 0, false, true), { count: "3", label: "infra, 3 sessions", title: "infra — 3 sessions; holds the active tab, so it stays open; drag to reorder the groups" });
-  assert.match(MAKE_HEAD, /const words = headWords\(name, total, hidden\.length, collapsed, holdsActive\);\s*\n\s*head\.title = words\.title;/);
+  // while the pane already shows the section (`shown`) the title names the fold alone; the open, shown header
+  // holding the tab being read is the way back (`back`) and its spoken label names the action (render.ts
+  // drops that header's aria-expanded, so a reader would otherwise hear a plain button with no word about it)
+  assert.equal(headWords("infra", 2, 2, true, false, false, true).title, "infra — 2 sessions folded; click to open this group");
+  assert.equal(headWords("infra", 2, 0, false, false, false, true).title, "infra — 2 sessions; click to fold this group; drag to reorder the groups");
+  assert.deepEqual(headWords("infra", 3, 0, false, true, true, true), { count: "3", label: "infra, 3 sessions, holds the tab you are reading; back to the transcript",
+    title: "infra — 3 sessions; holds the tab you are reading; click to go back to the transcript; drag to reorder the groups" });
+  assert.deepEqual(headWords("infra", 3, 0, false, true, false, false), headWords("infra", 3, 0, false, true), "the defaults are the ordinary open header");
+  assert.deepEqual(headWords("infra", 2, 0, false, false), { count: "2", label: "infra, 2 sessions", title: "infra — 2 sessions; click to fold this group and see its sessions at a glance; drag to reorder the groups" });
+  assert.deepEqual(headWords("infra", 3, 0, false, true), { count: "3", label: "infra, 3 sessions, holds the tab you are reading", title: "infra — 3 sessions; holds the tab you are reading; click to fold this group and see its sessions at a glance; drag to reorder the groups" });
+  assert.match(MAKE_HEAD, /const words = headWords\(name, total, hidden\.length, collapsed, holdsActive, back, shown\);\s*\n\s*head\.title = words\.title;/);
   assert.match(MAKE_HEAD, /n\.textContent = words\.count;/);
   assert.ok(!MAKE_HEAD.includes("hidden.length : total"), "no second count rule beside the pure one");
   assert.match(GUIDE, /when every tab in a section is set to\s+show, the folded header shows the full count and its tooltip says nothing is hidden\./);
 });
 
-test("assistive tech hears a label: decoration is aria-hidden, the header's name is words (name, count, the pip's phrase), and the active section's header is a labeled group — never a button it cannot be", () => {
+test("assistive tech hears a label: decoration is aria-hidden, the header's name is words (name, count, the pip's phrase), and the active section's header is the same button as the rest, marked current", () => {
   // a real accessibility tree read the folded header as a button named "▸ archived 2" — the caret glyph
   // folded into the name — and the active section's header as "button, expanded" with no focus and a
   // no-op click
@@ -1718,11 +1758,15 @@ test("assistive tech hears a label: decoration is aria-hidden, the header's name
     "archived, 2 sessions folded; 2 sessions in this group are blocked or waiting on you: api, tests",
     "the spoken label of a folded header wearing the pip");
   assert.ok(!MAKE_HEAD.includes('label.setAttribute("aria-hidden"'), "the name is the name: not hidden");
-  assert.match(MAKE_HEAD, /if \(holdsActive\) \{[^}]*head\.setAttribute\("role", "group"\);\s*\n\s*\} else \{/, "no action, no stop → a labeled group");
-  assert.equal(MAKE_HEAD.split('"aria-expanded"').length - 1, 1, "aria-expanded only where the fold is — inside the foldable branch");
+  // the header holding the tab being read is the same button as the rest (it folds; the section at a glance is the
+  // pane's answer to a folded active tab), marked current: no header is a no-op "labeled group" any more
+  assert.ok(!MAKE_HEAD.includes('"role", "group"'), "no header is a no-op group: every one folds");
+  assert.equal(MAKE_HEAD.split('"aria-expanded"').length - 1, 1, "aria-expanded once, on the one fold button every named header is (left off only while its press puts the transcript back)");
   assert.equal(MAKE_HEAD.split('"role", "button"').length - 1, 1);
-  assert.ok(MAKE_HEAD.indexOf('"role", "group"') < MAKE_HEAD.indexOf('"role", "button"'), "the active branch first, as the source reads");
+  assert.match(MAKE_HEAD, /if \(!back\) head\.setAttribute\("aria-expanded", collapsed \? "false" : "true"\);[\s\S]{0,400}if \(holdsActive\) head\.setAttribute\("aria-current", "true"\);/, "the header holding the tab being read says so");
+  assert.match(MAKE_HEAD, /head\.tabIndex = 0;/, "…and takes focus like the rest: it is the hidden tab's stand-in");
   assert.equal(headWords("archived", 2, 2, true, false).label, "archived, 2 sessions folded");
+  assert.equal(headWords("archived", 2, 2, true, true).label, "archived, 2 sessions folded, holds the tab you are reading", "the stand-in says whose it is");
 });
 
 
@@ -1810,7 +1854,7 @@ test("the tab menu speaks for the right-clicked copy's group: Move to drops THAT
   assert.match(RENDER, /plus\.title = "add this tag too — the session keeps its other tags";/);
 });
 
-test("executed: activating a session under several tags springs no fold — only the open holders are active; all folded → the first opens (T264b review)", () => {
+test("executed: activating a session under several tags springs no fold: a holder showing a copy is marked; all folded, the first is the stand-in and nothing opens (T264b)", () => {
   // web=[s1,s2], archived=[s2,s3,s4], archived folded by default: activating s2 (a live session also
   // tagged archived to put it away later) must not spring the whole archived row open
   const unions = viewTagUnion({ tags: [{ id: "t-web", name: "web", color: "#1EA1EB", members: ["s1", "s2"] },
@@ -1821,14 +1865,16 @@ test("executed: activating a session under several tags springs no fold — only
   assert.deepEqual(marks("s2"), ["#web(active)", "s1", "s2", "#archived(folded)"], "archived stays folded: s2 shows under web");
   assert.deepEqual(marks("s1"), ["#web(active)", "s1", "s2", "#archived(folded)"]);
   assert.deepEqual([...planStrip(["s1", "s2", "s3", "s4"], unions, st, "s2", false).folded], ["s3", "s4"], "s2 is on screen (under web): not skipped");
-  // both holders folded, nothing pinned: exactly one — the first in tagOrder — opens, as a single holder always did
+  // both holders folded, nothing pinned: NOTHING springs open (the active tab's section folds like any other);
+  // exactly one holder, the first in tagOrder, is marked: the header that stands in for the tab
   const both = setSectionCollapsed(st, "web", true);
-  assert.deepEqual(marks("s2", both), ["#web(active)", "s1", "s2", "#archived(folded)"], "web forced open for the active tab; archived left as stored");
-  // a copy pinned through a fold counts as shown: no holder is forced open, the pinned copy carries focus
+  assert.deepEqual(marks("s2", both), ["#web(active)(folded)", "#archived(folded)"], "both folds stand; web's header is s2's stand-in");
+  assert.deepEqual([...planStrip(["s1", "s2", "s3", "s4"], unions, both, "s2", false).folded], ["s1", "s2", "s3", "s4"], "every copy off the strip: s2 is folded away too");
+  // a copy pinned through a fold counts as shown: that holder is the one marked, and the pinned copy carries focus
   const pinned = setPinned(both, { name: "archived", localId: "t-arch" }, "s2", true);
-  assert.deepEqual(marks("s2", pinned), ["#web(folded)", "#archived(folded)", "s2"], "both folds stand; s2 shows through archived's fold");
-  // a single holder is unchanged: open and unfoldable whatever the store says
-  assert.deepEqual(marks("s3", both), ["#web(folded)", "#archived(active)", "s2", "s3", "s4"]);
+  assert.deepEqual(marks("s2", pinned), ["#web(folded)", "#archived(active)(folded)", "s2"], "both folds stand; s2 shows through archived's fold, whose header is marked");
+  // a single holder: marked whatever the fold, folded as the store says
+  assert.deepEqual(marks("s3", both), ["#web(folded)", "#archived(active)(folded)"]);
 });
 
 test("the guide states the every-tag rule (T264b)", () => {

--- a/ui/webview/tab-groups.ts
+++ b/ui/webview/tab-groups.ts
@@ -565,22 +565,34 @@ export function followAdoption(st: TabGroupsState, prev: SessionViews | null | u
  *  truthful either way — the section IS folded, and the click opens it. */
 export interface HeadWords { count: string; title: string; label: string }
 
-export function headWords(name: string, total: number, hidden: number, folded: boolean, holdsActive: boolean): HeadWords {
+// The click's clause: a click also shows the section in the pane (the section at a glance, tab-snapshot.ts),
+// open or folded, so every title says so, except while the pane already shows the section (`shown`): then the
+// clause names the fold alone, or the way back to the transcript when the open section also holds the tab
+// being read (`back`). `holdsActive`, the section holds the tab being read, is a phrase in the words, not a
+// different action: the section folds like any other, and folded, its header is the tab's stand-in.
+export function headWords(name: string, total: number, hidden: number, folded: boolean, holdsActive: boolean, back = false, shown = false): HeadWords {
   const n = (k: number) => `${k} session${k === 1 ? "" : "s"}`;
-  if (holdsActive) {
-    return { count: String(total), label: `${name}, ${n(total)}`,
-             title: `${name} — ${n(total)}; holds the active tab, so it stays open; drag to reorder the groups` };
-  }
+  const reading = holdsActive ? "; holds the tab you are reading" : "";
+  const here = holdsActive ? ", holds the tab you are reading" : "";
   if (!folded) {
-    return { count: String(total), label: `${name}, ${n(total)}`,
-             title: `${name} — ${n(total)}; click to fold this group; drag to reorder the groups` };
+    // `back`: the pane is showing this section, the section is open and holds the tab being read: the click
+    // puts that transcript back (render.ts show-transcript), so the title says so, not "fold", and the spoken
+    // label names the action too (render.ts drops the header's aria-expanded in that state, since the press
+    // folds nothing). `shown` without `back`: the pane shows this open section but the tab being read is
+    // elsewhere, so the click still folds, and the title does not promise to show what the pane already shows.
+    const click = back ? "click to go back to the transcript" : shown ? "click to fold this group" : "click to fold this group and see its sessions at a glance";
+    return { count: String(total), label: `${name}, ${n(total)}${here}${back ? "; back to the transcript" : ""}`,
+             title: `${name} — ${n(total)}${reading}; ${click}; drag to reorder the groups` };
   }
+  // folded and `shown`: the header's click just folded the section and put its sessions in the pane, so the
+  // click opens it and the title says that alone
+  const open = shown ? "click to open this group" : "click to open and see its sessions at a glance";
   if (hidden === 0) {
     const all = total === 1 ? "its one session is" : `all ${total} sessions are`;
-    return { count: String(total), label: `${name}, ${n(total)}, folded, all shown`,
-             title: `${name} — folded, but ${all} set to show when folded, so none is hidden; click to open` };
+    return { count: String(total), label: `${name}, ${n(total)}, folded, all shown${here}`,
+             title: `${name} — folded, but ${all} set to show when folded, so none is hidden${reading}; ${open}` };
   }
-  return { count: String(hidden), label: `${name}, ${n(hidden)} folded`, title: `${name} — ${n(hidden)} folded; click to open` };
+  return { count: String(hidden), label: `${name}, ${n(hidden)} folded${here}`, title: `${name} — ${n(hidden)} folded${reading}; ${open}` };
 }
 
 /** One strip item: a section header (folded or open; `active` = it holds the active tab; `hidden` =
@@ -605,14 +617,17 @@ export interface StripPlan {
  *  - A folded section hides its members EXCEPT the pinned ones (the tab menu's "Show when folded"),
  *    which keep their place under the header in strip order; the header stands in for `hidden` alone
  *    (its count reads those), and only those ids join the `folded` set.
- *  - The ACTIVE tab never renders hidden: keyboard focus must never land on a hidden node. Its
- *    section's header is marked `active`, and render.ts gives that header no fold action: a fold stored
- *    there could not render (nothing changed on screen, on every click) and then bit when the user
- *    switched tabs. The section is unfoldable while it holds the active tab. A session under several
- *    tags (T264b) has a copy in each: while any copy is on screen under the stored folds (an open
- *    section, or pinned through a fold) every fold stands and only the OPEN holders are marked active;
- *    only when every copy would be hidden is exactly one holder — the first in tagOrder — forced open.
- *    (Activating a live session also tagged `archived` must not spring the whole archived row open.) */
+ *  - The ACTIVE tab's section folds like any other. Its header is marked `active` whether open or
+ *    folded: folded, the header is the hidden tab's stand-in, so keyboard focus never lands on a hidden
+ *    node. render.ts focuses it where it would focus the tab, the arrows step from its position
+ *    (neighborOfFolded), and the pane shows the section at a glance (tab-snapshot.ts) instead of a
+ *    transcript whose tab is nowhere on screen.
+ *  - A session under several tags (T264b) has a copy in each section, and each copy's fold stands on
+ *    its own. The header of a holder that SHOWS a copy (open, or folded with the copy pinned through the
+ *    fold) is marked `active`; when no copy shows anywhere exactly one holder, the first in tagOrder, is
+ *    marked: the header that stands in for the tab. Nothing springs open (the active tab's section folds
+ *    like any other, above). A tab joins the `folded` set only when EVERY copy is off the strip; one
+ *    copy on screen keeps it in the keyboard order. */
 export function planStrip(visibleIds: readonly string[], unions: readonly TagUnion[], st: TabGroupsState,
                           activeId: string | null, phone: boolean,
                           pending?: { id: string; tags: readonly string[] } | null): StripPlan {
@@ -629,15 +644,17 @@ export function planStrip(visibleIds: readonly string[], unions: readonly TagUni
     return { items, folded, sectioned };
   }
   const secs = sectionTabs(visibleIds, u);
-  const open = (sec: TabSection) => sec.name === null || !isSectionCollapsed(st, sec.name);
+  // does this section put a copy of `id` on the strip: open, or folded with the copy pinned through the fold
+  const shows = (sec: TabSection, id: string): boolean => sec.name === null || !isSectionCollapsed(st, sec.name) || isPinned(st, sec, id);
   const holders = activeId !== null ? secs.filter((sec) => sec.ids.includes(activeId)) : [];
-  const shownSomewhere = activeId !== null && holders.some((sec) => open(sec) || isPinned(st, sec, activeId));
+  const shownSomewhere = activeId !== null && holders.some((sec) => shows(sec, activeId));
   for (const sec of secs) {
-    // one holder: open and unfoldable, as always. several (T264b): the open ones are active; a folded
-    // one stays folded (a pinned copy shows through it) unless NO copy shows anywhere — then the first
-    // holder in tagOrder opens
-    const active = holders.includes(sec) && (holders.length === 1 || open(sec) || (!shownSomewhere && sec === holders[0]));
-    const f = sec.name !== null && !active && isSectionCollapsed(st, sec.name);
+    // a holder showing a copy is marked; when NO copy shows anywhere the first holder in tagOrder is the
+    // one stand-in (T264b; a single holder is holders[0], so it is marked whatever its fold: folded, its
+    // header is the hidden tab's stand-in). No fold is forced open here: the active tab's section folds
+    // like any other
+    const active = activeId !== null && holders.includes(sec) && (shows(sec, activeId) || (!shownSomewhere && sec === holders[0]));
+    const f = sec.name !== null && isSectionCollapsed(st, sec.name);
     const hidden = f ? sec.ids.filter((id) => !isPinned(st, sec, id)) : [];
     items.push({ head: sec, folded: f, active, hidden });
     for (const id of sec.ids) { if (hidden.includes(id)) folded.add(id); else items.push({ id }); }
@@ -646,6 +663,28 @@ export function planStrip(visibleIds: readonly string[], unions: readonly TagUni
   // keyboard — only when EVERY copy is; one copy on screen keeps it in the order
   for (const it of items) if ("id" in it) folded.delete(it.id);
   return { items, folded, sectioned };
+}
+
+/** The section a tab is homed in, from a rendered plan's items: the first header whose ids include it,
+ *  or null (a flat strip, or an id the plan does not know). */
+export function homeSectionOf(items: readonly StripItem[], id: string): TabSection | null {
+  for (const it of items) if ("head" in it && it.head.ids.includes(id)) return it.head;
+  return null;
+}
+
+/** Where the arrows land when the active tab is folded away: the header holding it is its stand-in, so
+ *  the step starts THERE. `dir` +1 is the first tab rendered after that header, -1 the last one before
+ *  it, wrapping round the strip. Folded ids are not items, so the walk sees only tabs on screen. Null
+ *  when no header holds the id or no tab is on screen at all. */
+export function neighborOfFolded(items: readonly StripItem[], id: string, dir: 1 | -1): string | null {
+  const at = items.findIndex((it) => "head" in it && it.head.ids.includes(id));
+  if (at < 0) return null;
+  const n = items.length;
+  for (let k = 1; k <= n; k++) {
+    const it = items[(at + dir * k + n * k) % n];
+    if ("id" in it) return it.id;
+  }
+  return null;
 }
 
 /** The header drag: `from` takes `to`'s slot in the FULL union order (every name, not only the

--- a/ui/webview/tab-snapshot-pane.test.ts
+++ b/ui/webview/tab-snapshot-pane.test.ts
@@ -1,0 +1,660 @@
+// A SECTION AT A GLANCE, THE PANE (render.ts): the view's block (snapView, the host, renderSnapshot, the exits),
+// the strip's key handlers (onTabKey, focusActiveTab, unfoldSectionOf), the section header (makeGroupHead), the
+// #tabs delegate's two header acts and the nav trail's deps are LIFTED out of render.ts and run over a small fake
+// DOM, the way tab-strip-skip-exec.test.ts drives renderTabs: the rows paint from the model, a push that changes
+// nothing ticks only the ago texts, a changed row keeps its node, the section gone from the strip ends the view,
+// Escape leaves it in two phases, a row click opens its session only while the session is still on the strip,
+// the folded-away active tab's header is its stand-in for focus, the arrows and Enter, a header click folds and
+// shows the section and the way back is the same header's next click, a pick from the view records the reader's
+// spot on the trail, and a pick of a folded-away tab opens its section. The wiring the slices cannot reach
+// (showActive's branch, setActive, the strip's follow) is pinned at the source. The notes-api demo world.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { viewTagUnion } from "./session-views";
+import { parseTabGroups, planStrip, setSectionCollapsed, homeSectionOf, neighborOfFolded, headWords, type StripItem, type TabSection } from "./tab-groups";
+import { sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
+import { snapshotModel, snapshotHeading, rowWords, type SnapModel } from "./tab-snapshot";
+import { rowStillOpen, installSnapshotEscape, reconcileRows } from "./tab-snapshot-view";
+
+const requireCjs = createRequire(__filename);
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const CSS = ui("webview", "styles.css");
+const SHOW_SIG = "function showActive(keep?: { uuid: string; y: number } | null) {";
+const SHOW_AT = RENDER.indexOf(SHOW_SIG);
+assert.ok(SHOW_AT >= 0, "render.ts: showActive's signature moved; re-anchor");
+const SNAP_AT = RENDER.indexOf("let snapView: string | null = null;");
+const SHOW = RENDER.slice(SHOW_AT, SHOW_AT + 7500);
+const KEYS_AT = RENDER.indexOf("function onTabKey(e: KeyboardEvent) {");
+const KEYS_END = RENDER.indexOf('// "Enter to start typing" lands on whatever', KEYS_AT);
+const TABS = RENDER.slice(RENDER.indexOf("function renderTabs() {"), RENDER.indexOf("function dismissTabMenu() {"));
+const HEAD = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("function sectionHeadOf("));
+const ACTS_AT = RENDER.indexOf('"toggle-group": (el) => {');
+const ACTS = RENDER.slice(ACTS_AT, RENDER.indexOf("close: (el) => {", ACTS_AT));   // the #tabs delegate's two header acts, up to the tab's close
+const NAV = RENDER.slice(RENDER.indexOf("const navHist = new NavHistory({"), RENDER.indexOf("function setActive(id: string"));
+
+// ── a fake DOM: enough of Element for the pane's paint, with a small selector engine for the queries it makes ──
+type Compound = { scope: boolean; id: string | null; classes: string[]; attrs: Array<[string, string | null]> };
+function parseCompound(s: string): Compound {
+  const c: Compound = { scope: false, id: null, classes: [], attrs: [] };
+  const re = /:scope|#([\w-]+)|\.([\w-]+)|\[([\w-]+)(?:="([^"]*)")?\]/g;
+  for (const m of s.matchAll(re)) {
+    if (m[0] === ":scope") c.scope = true;
+    else if (m[1]) c.id = m[1];
+    else if (m[2]) c.classes.push(m[2]);
+    else if (m[3]) c.attrs.push([m[3], m[4] ?? null]);
+  }
+  return c;
+}
+/** right-to-left: [[compound, combinator to its LEFT neighbour], ...] */
+function parseSelector(sel: string): Array<{ c: Compound; comb: ">" | " " | null }> {
+  const parts = sel.trim().split(/\s*>\s*|\s+/);
+  const combs = sel.trim().match(/\s*>\s*|\s+/g) || [];
+  const out = parts.map((p, i) => ({ c: parseCompound(p), comb: i === 0 ? null : (combs[i - 1].includes(">") ? ">" : " ") as ">" | " " | null }));
+  return out;
+}
+class FakeDoc { activeElement: FakeEl | null = null; body = new FakeEl("body"); }
+const camel = (k: string) => k.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+class FakeEl {
+  tag: string; id = ""; className: string; children: FakeEl[] = []; parent: FakeEl | null = null;
+  dataset: Record<string, string> = {}; attrs: Record<string, string> = {}; listeners: Record<string, Function[]> = {};
+  textContent = ""; title = ""; tabIndex = -1; type = ""; disabled = false; scrollTop = 0; draggable = false;
+  style: Record<string, string> = { display: "", background: "", color: "" };
+  classList: { add: (...c: string[]) => void; remove: (...c: string[]) => void; contains: (c: string) => boolean; toggle: (c: string, on?: boolean) => void };
+  constructor(tag: string, cls = "") {
+    this.tag = tag; this.className = cls;
+    const self = this;
+    this.classList = {
+      add(...c) { for (const x of c) if (!self.has(x)) self.className = (self.className + " " + x).trim(); },
+      remove(...c) { for (const x of c) self.className = self.className.split(/\s+/).filter((y) => y !== x).join(" "); },
+      contains(x) { return self.has(x); },
+      toggle(x, on) { if (on === undefined ? !self.has(x) : on) this.add(x); else this.remove(x); },
+    };
+  }
+  has(x: string): boolean { return this.className.split(/\s+/).includes(x); }
+  get childElementCount(): number { return this.children.length; }
+  get firstElementChild(): FakeEl | null { return this.children[0] ?? null; }
+  get lastElementChild(): FakeEl | null { return this.children[this.children.length - 1] ?? null; }
+  appendChild(c: FakeEl): FakeEl { this.insertBefore(c, null); return c; }
+  append(...cs: FakeEl[]): void { for (const c of cs) this.appendChild(c); }
+  replaceChildren(...cs: FakeEl[]): void { for (const c of [...this.children]) this.removeChild(c); this.append(...cs); }
+  insertBefore(c: FakeEl, ref: FakeEl | null): FakeEl {
+    // the DOM's rule: a node already in a tree is detached first, and a detached focused node loses focus (the
+    // browser's focus fixup), which is what the pane's refocus answers
+    if (c.parent) { const p = c.parent; p.children = p.children.filter((x) => x !== c); c.parent = null; if (DOC.activeElement && c.contains(DOC.activeElement)) DOC.activeElement = DOC.body; }
+    c.parent = this;
+    const j = ref ? this.children.indexOf(ref) : -1;
+    if (j < 0) this.children.push(c); else this.children.splice(j, 0, c);
+    return c;
+  }
+  removeChild(c: FakeEl): FakeEl { this.children = this.children.filter((x) => x !== c); c.parent = null; if (DOC.activeElement && c.contains(DOC.activeElement)) DOC.activeElement = DOC.body; return c; }
+  remove(): void { this.parent?.removeChild(this); }
+  contains(n: unknown): boolean { return n === this || this.children.some((c) => c.contains(n)); }
+  setAttribute(k: string, v: string): void { if (k.startsWith("data-")) this.dataset[camel(k.slice(5))] = v; else this.attrs[k] = v; }
+  getAttribute(k: string): string | null { if (k.startsWith("data-")) return this.dataset[camel(k.slice(5))] ?? null; return this.attrs[k] ?? null; }
+  addEventListener(t: string, f: Function): void { (this.listeners[t] ??= []).push(f); }
+  fire(t: string, ev: any = {}): void { for (const f of this.listeners[t] ?? []) f(ev); }
+  focus(): void { DOC.activeElement = this; }
+  click(): void { CLICKS.push(this); }   // a header's Enter or Space presses it; the real click bubbles to the #tabs delegate (tabsActs below)
+  matches1(c: Compound, scope: FakeEl): boolean {
+    if (c.scope && this !== scope) return false;
+    if (c.id !== null && this.id !== c.id) return false;
+    if (!c.classes.every((x) => this.has(x))) return false;
+    return c.attrs.every(([k, v]) => (v === null ? this.getAttribute(k) !== null : this.getAttribute(k) === v));
+  }
+  matchesChain(chain: ReturnType<typeof parseSelector>, i: number, scope: FakeEl): boolean {
+    if (!this.matches1(chain[i].c, scope)) return false;
+    if (i === 0) return true;
+    const comb = chain[i].comb;
+    if (comb === ">") return !!this.parent && this.parent.matchesChain(chain, i - 1, scope);
+    for (let p = this.parent; p; p = p.parent) if (p.matchesChain(chain, i - 1, scope)) return true;
+    return false;
+  }
+  *walk(): Generator<FakeEl> { for (const c of this.children) { yield c; yield* c.walk(); } }
+  querySelectorAll(sel: string): FakeEl[] { const chain = parseSelector(sel); return [...this.walk()].filter((n) => n.matchesChain(chain, chain.length - 1, this)); }
+  querySelector(sel: string): FakeEl | null { return this.querySelectorAll(sel)[0] ?? null; }
+  closest(sel: string): FakeEl | null { const chain = parseSelector(sel); for (let n: FakeEl | null = this; n; n = n.parent) if (n.matchesChain(chain, chain.length - 1, n)) return n; return null; }
+  byId(id: string): FakeEl | null { if (this.id === id) return this; for (const c of this.children) { const f = c.byId(id); if (f) return f; } return null; }
+  text(): string { return this.children.length ? this.children.map((c) => c.text()).join("") : this.textContent; }
+}
+const DOC = new FakeDoc();
+const CLICKS: FakeEl[] = [];
+
+type Hooks = {
+  content: FakeEl; bar: FakeEl; composer: FakeEl; sendBtn: FakeEl;
+  sessions: Map<string, any>; ledgers: Map<string, any>; tabMeta: Map<string, any>; closingTabs: Map<string, number>; views: Map<string, any>;
+  lastStripItems: StripItem[]; order: string[]; collapsed: Set<string>; nowMs: number; pickerOpen: boolean;
+  calls: string[]; delegates: Array<{ root: FakeEl; handlers: Record<string, (node: FakeEl, ev: Event) => void> }>;
+  winCap: Function[]; winBub: Function[]; writes: any[];
+  FakeEl: typeof FakeEl; doc: FakeDoc;
+  snapshotModel: typeof snapshotModel; snapshotHeading: typeof snapshotHeading; rowWords: typeof rowWords;
+  rowStillOpen: typeof rowStillOpen; installSnapshotEscape: typeof installSnapshotEscape; reconcileRows: typeof reconcileRows;
+  homeSectionOf: typeof homeSectionOf; neighborOfFolded: typeof neighborOfFolded; setSectionCollapsed: typeof setSectionCollapsed;
+  headWords: typeof headWords; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
+  groups: ReturnType<typeof parseTabGroups>;
+  navDeps: { now: () => { sid: string; top: number } | null } | null;   // what render.ts hands NavHistory (the stub constructor keeps it)
+};
+type Api = {
+  renderSnapshot: () => boolean; hideSnapshot: () => void; leaveSnapshot: () => void; snapshotHost: () => FakeEl | null;
+  onTabKey: (e: any) => void; focusActiveTab: () => void; unfoldSectionOf: (id: string) => void;
+  makeGroupHead: (sec: TabSection, collapsed: boolean, holdsActive: boolean, hidden: readonly string[]) => FakeEl;
+  acts: { "toggle-group": (el: FakeEl) => void; "show-transcript": () => void };
+  get: () => { snapView: string | null; snapModel: SnapModel | null; snapKeep: any; tabPointerHeld: boolean; renderPendingWhilePressed: boolean; activeId: string | null };
+  set: (p: Record<string, unknown>) => void;
+};
+
+function lift(): (H: Hooks) => Api {
+  assert.ok(SNAP_AT > 0 && SNAP_AT < SHOW_AT, "the pane block sits right above showActive: re-anchor");
+  assert.ok(KEYS_AT > 0 && KEYS_END > KEYS_AT, "onTabKey .. focusActiveTab .. unfoldSectionOf run together above the composer-focus helper: re-anchor");
+  assert.ok(HEAD.length > 0 && ACTS.includes('"show-transcript"') && NAV.includes("apply: (spot) => {"), "makeGroupHead, the #tabs delegate's header acts or the nav trail's deps moved: re-anchor");
+  const js = requireCjs("esbuild").transformSync(RENDER.slice(SNAP_AT, SHOW_AT) + RENDER.slice(KEYS_AT, KEYS_END) + HEAD + NAV
+    + "const tabsActs = {\n" + ACTS + "};\n", { loader: "ts" }).code;
+  const prelude = `
+    const H = HOOKS;
+    let activeId = null, tabPointerHeld = false, renderPendingWhilePressed = false, draggedGroup = null;
+    let ctxMenuEl = null, metaMenuEl = null, citePreviewEl = null, openCommentKey = null;
+    const settings = { stripGroupRows: true };
+    let order = H.order, lastStripItems = H.lastStripItems, collapsedTabIds = H.collapsed;
+    const sessions = H.sessions, ledgers = H.ledgers, tabMeta = H.tabMeta, closingTabs = H.closingTabs, views = H.views;
+    const el = (tag, cls) => new H.FakeEl(tag, cls);
+    const document = {
+      get activeElement() { return H.doc.activeElement; },
+      get body() { return H.doc.body; },
+      getElementById: (id) => id === "content" ? H.content : id === "tabs" ? H.bar : id === "composer-input" ? H.composer : id === "composer-send" ? H.sendBtn : H.content.byId(id),
+      createElement: (tag) => new H.FakeEl(tag),
+      createTextNode: (t) => { const n = new H.FakeEl("#text"); n.textContent = t; return n; },
+      querySelector: (sel) => (sel === ".picker-overlay" && H.pickerOpen ? new H.FakeEl("div", "picker-overlay") : null),
+    };
+    const window = { addEventListener: (t, f, cap) => { (cap ? H.winCap : H.winBub).push(f); } };
+    const Date = { now: () => H.nowMs };
+    const delegate = (root, handlers) => { H.delegates.push({ root, handlers }); };
+    const setActive = (id) => { H.calls.push("setActive:" + id); activeId = id; };   // recorded, and the pick lands: focusActiveTab then reads the new active
+    const renderTabs = () => { H.calls.push("renderTabs"); };
+    const showActive = () => { H.calls.push("showActive"); };
+    const focusComposerOrAsk = () => { H.calls.push("focusComposerOrAsk"); return !H.composer.disabled; };
+    const tabInAdjacentRow = () => null;
+    const visibleOrder = () => order.filter((id) => !collapsedTabIds.has(id));
+    const isTypingTarget = (t) => !!t && t.typing === true;
+    const agehms = (s) => Math.floor(s) + "s";
+    const ageColorReadable = (s) => "age-" + Math.floor(s);
+    const hostNameNodes = (name) => [document.createTextNode(name)];
+    const snapshotModel = H.snapshotModel, snapshotHeading = H.snapshotHeading, rowWords = H.rowWords;
+    const rowStillOpen = H.rowStillOpen, installSnapshotEscape = H.installSnapshotEscape, reconcileRows = H.reconcileRows;
+    const homeSectionOf = H.homeSectionOf, neighborOfFolded = H.neighborOfFolded, setSectionCollapsed = H.setSectionCollapsed;
+    const tabGroups = () => H.groups;
+    const writeTabGroups = (st) => { H.writes.push(st); };
+    // the header's parts and gestures: the pure words and pip rules for real, the tag chip and the drag helpers stubs
+    const headWords = H.headWords, sectionPip = H.sectionPip, sectionPipMembers = H.sectionPipMembers, sectionPipTitle = H.sectionPipTitle;
+    const tagChip = (label) => { const c = el("span", "tag-chip"); c.textContent = label; return c; };
+    const dragImageBlank = () => el("div"); const hideTabTip = () => {};
+    // the nav trail: the class a stub that keeps the deps render.ts hands it; the landing's helpers inert
+    class NavHistory { constructor(deps) { H.navDeps = deps; } }
+    const whenChatVisible = (f) => f(); const writeScroll = () => {};
+  `;
+  const epilogue = `
+    return { renderSnapshot, hideSnapshot, leaveSnapshot, snapshotHost, onTabKey, focusActiveTab, unfoldSectionOf, makeGroupHead, acts: tabsActs,
+      get: () => ({ snapView, snapModel, snapKeep, tabPointerHeld, renderPendingWhilePressed, activeId }),
+      set: (p) => { for (const k of Object.keys(p)) {
+        if (k === "snapView") snapView = p[k]; else if (k === "snapKeep") snapKeep = p[k]; else if (k === "activeId") activeId = p[k];
+        else if (k === "tabPointerHeld") tabPointerHeld = p[k]; else if (k === "lastStripItems") lastStripItems = p[k]; else if (k === "collapsedTabIds") collapsedTabIds = p[k];
+        else if (k === "ctxMenuEl") ctxMenuEl = p[k]; else if (k === "order") order = p[k];
+        else throw new Error("unknown knob " + k); } } };
+  `;
+  return new Function("HOOKS", prelude + js + epilogue) as (H: Hooks) => Api;
+}
+
+const T0 = 1781100000;
+const iso = (t: number) => new Date(t * 1000).toISOString();
+const V = { active: "all", tags: [{ id: "g1", name: "qa", color: "#DD42FF", members: ["tests", "api"] }, { id: "g2", name: "infra", color: "#4EC9B0", members: ["web", "api"] }] };
+const unions = viewTagUnion(V);
+
+/** The notes-api world: infra (web, api) and qa (api, tests), web active, infra's view about to show. */
+function world(active = "web", groups = parseTabGroups(null), ids = ["web", "api", "tests"]) {
+  DOC.activeElement = null; CLICKS.length = 0;
+  const content = new FakeEl("div"); content.id = "content";
+  const bar = new FakeEl("div"); bar.id = "tabs";
+  const plan = planStrip(ids, unions, groups, active, false);
+  for (const it of plan.items) {
+    if ("head" in it) { const h = new FakeEl("div", "tab-group-head" + (it.folded ? " collapsed" : "")); h.dataset.group = String(it.head.name); h.tabIndex = 0; bar.appendChild(h); }
+    else { const t = new FakeEl("div", "tab"); t.dataset.id = it.id; t.tabIndex = 0; bar.appendChild(t); }
+  }
+  const composer = new FakeEl("textarea"); composer.id = "composer-input";
+  const sessions = new Map<string, any>([
+    ["web", { name: "web", color: { bg: "#3a7bd5", fg: "#ffffff" }, status: { state: "working", sinceEpoch: (T0 - 30) * 1000 },
+              events: [{ kind: "assistant", md: "Adding the **list** page.", ts: iso(T0 - 40) }] }],
+    ["api", { name: "api", color: { bg: "#d53a3a", fg: "#ffffff" }, status: { state: "idle", sinceEpoch: (T0 - 600) * 1000 }, events: [] }],
+  ]);
+  const ledgers = new Map<string, any>([
+    ["web", { summary: "Building the notes-api web pages", workingNote: "editing the list page", needsInput: false, tree: [{ text: "Add the notes list page", current: true }] }],
+    ["api", { summary: "Designing the notes schema", needsInput: true, tree: [] }],
+  ]);
+  const H: Hooks = { content, bar, composer, sendBtn: new FakeEl("button"), sessions, ledgers, tabMeta: new Map([["tests", { name: "tests", color: null }]]),
+    closingTabs: new Map(), views: new Map(), lastStripItems: plan.items, order: ids, collapsed: plan.folded, nowMs: T0 * 1000, pickerOpen: false,
+    calls: [], delegates: [], winCap: [], winBub: [], writes: [], FakeEl, doc: DOC,
+    snapshotModel, snapshotHeading, rowWords, rowStillOpen, installSnapshotEscape, reconcileRows, homeSectionOf, neighborOfFolded, setSectionCollapsed,
+    headWords, sectionPip, sectionPipMembers, sectionPipTitle, groups, navDeps: null };
+  const api = lift()(H);
+  api.set({ activeId: active });
+  return { H, api, content, bar, sessions, ledgers };
+}
+const rowsOf = (host: FakeEl) => host.querySelectorAll(".snap-item");
+type Head = { head: TabSection; folded: boolean; active: boolean; hidden: string[] };
+const headOf = (items: readonly StripItem[], name: string) => items.find((i) => "head" in i && i.head.name === name) as Head;
+/** The header render.ts would paint for a section of the plan, replacing the world's stand-in node for it on the bar. */
+function realHead(api: Api, bar: FakeEl, it: Head): FakeEl {
+  const head = api.makeGroupHead(it.head, it.folded, it.active, it.hidden);
+  const fake = bar.querySelector(`.tab-group-head[data-group="${it.head.name}"]`);
+  if (fake) { const at = bar.children.indexOf(fake); bar.removeChild(fake); bar.insertBefore(head, bar.children[at] ?? null); }
+  return head;
+}
+const keyOn = (node: FakeEl, key: string) => { const e: any = { key, prevented: false, preventDefault() { this.prevented = true; } }; node.fire("keydown", e); return e as { prevented: boolean }; };
+const esc = (H: Hooks, target: any = null) => {
+  const e: any = { key: "Escape", target, defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+  for (const f of H.winCap) f(e);
+  for (const f of H.winBub) f(e);
+  return e;
+};
+
+test("executed: the view paints one row per member from the model: heading, keyed items, a real button per row with the pip, the name in its color, the words, the now line, the note and the time", () => {
+  const { H, api, content } = world();
+  api.set({ snapView: "infra" });
+  assert.equal(api.renderSnapshot(), true);
+  const host = content.byId("tab-snapshot")!;
+  assert.ok(host, "the host hangs off #content");
+  assert.equal(host.getAttribute("role"), "region"); assert.equal(host.style.display, "");
+  assert.equal(host.getAttribute("aria-label"), "infra: 2 sessions; click one to open it");
+  const head = host.children[0];
+  assert.deepEqual([head.tag, head.className, head.children.map((c) => c.className)], ["h2", "snap-head", ["snap-swatch", "snap-name", "snap-count"]]);
+  assert.equal(head.children[0].style.background, "#4EC9B0"); assert.equal(head.children[1].textContent, "infra"); assert.equal(head.children[2].textContent, "2 sessions");
+  const items = rowsOf(host);
+  assert.deepEqual(items.map((i) => [i.getAttribute("role"), i.dataset.id]), [["listitem", "web"], ["listitem", "api"]], "keyed by the session id, in strip order");
+  const [web, api_] = items.map((i) => i.children[0]);
+  assert.deepEqual([web.tag, web.type, web.dataset.act, web.dataset.id, web.className], ["button", "button", "open", "web", "snap-row"], "a real button: Tab reaches it, Enter opens; the stable host's delegate acts");
+  assert.equal(web.getAttribute("aria-label"), "web; working; Add the notes list page; its note: editing the list page");
+  assert.equal(web.title, "Last message: Adding the list page.\nClick to open this session.");
+  const parts = web.children.map((c) => c.className);
+  assert.deepEqual(parts, ["snap-pip working", "snap-sess", "snap-now", "snap-when", "snap-note"], "pip, name, now, when, the note last (the wrapping row puts it under the first line)");
+  assert.equal(web.children[0].getAttribute("aria-hidden"), "true", "the pip is decoration: its phrase rides the label");
+  assert.equal(web.children[1].text(), "web"); assert.equal(web.children[1].style.color, "#3a7bd5", "the identity color on the name");
+  assert.equal(web.children[2].textContent, "Add the notes list page");
+  assert.deepEqual([web.children[3].dataset.t, web.children[3].textContent, web.children[3].style.color], [String(T0 - 40), "40s ago", "age-40"], "the model carries the epoch; the renderer formats it");
+  assert.equal(web.children[4].textContent, "editing the list page");
+  assert.deepEqual(api_.children.map((c) => c.className), ["snap-pip", "snap-sess", "snap-flag needs", "snap-now", "snap-when"], "an idle session the feed files under needs-you: no pip, the word");
+  assert.equal(api_.children[2].textContent, "needs you");
+  assert.equal(H.delegates.length, 1, "one delegate, on the stable host, installed with it");
+  assert.equal(H.delegates[0].root, host);
+});
+
+test("executed: a push that changes nothing a row shows moves nothing: the same nodes stand and only the ago texts tick; a changed row keeps its node, patched; a member gone or come adds or removes one node", () => {
+  const { H, api, content, sessions } = world();
+  api.set({ snapView: "infra" });
+  api.renderSnapshot();
+  const host = content.byId("tab-snapshot")!;
+  const [webItem, apiItem] = rowsOf(host);
+  const webBtn = webItem.children[0];
+  const partsBefore = [...webBtn.children];
+  // a fresh frame: new objects, the same content, the clock 10 s on
+  sessions.set("web", JSON.parse(JSON.stringify(sessions.get("web"))));
+  H.nowMs = (T0 + 10) * 1000;
+  const m1 = api.get().snapModel;
+  assert.equal(api.renderSnapshot(), true);
+  assert.equal(api.get().snapModel, m1, "the same model object");
+  assert.deepEqual(rowsOf(host), [webItem, apiItem], "the same nodes");
+  assert.equal(webBtn.querySelector(".snap-when")!.textContent, "50s ago", "the time ticked in place");
+  assert.ok(webBtn.children.length === partsBefore.length && webBtn.children.every((c, i) => c === partsBefore[i]),
+    "the row's parts stand too (the same pip, name and time nodes): the tick re-texts, it does not refill the row, so a hover's title and a focused part are untouched");
+  assert.equal(host.children[0], host.querySelector(".snap-head"), "the heading stands too");
+  // new information: web's state changes; its node is kept and patched
+  sessions.set("web", { ...sessions.get("web"), status: { state: "ready", sinceEpoch: T0 * 1000 } });
+  api.renderSnapshot();
+  assert.notEqual(api.get().snapModel, m1);
+  assert.equal(rowsOf(host)[0], webItem, "the item node stands"); assert.equal(webItem.children[0], webBtn, "and so does its button");
+  assert.equal(webBtn.children[0].className, "snap-pip", "with the new parts (no pip while ready)");
+  assert.equal(webBtn.getAttribute("aria-label"), "web; Add the notes list page; its note: editing the list page");
+  // a member gone from the section and one come: the standing node stays, one is removed, one made
+  api.set({ lastStripItems: [{ head: { name: "infra", localId: "g2", color: "#4EC9B0", ids: ["web", "tests"] }, folded: false, active: true, hidden: [] }, { id: "web" }, { id: "tests" }] });
+  api.renderSnapshot();
+  const after = rowsOf(host);
+  assert.deepEqual(after.map((i) => i.dataset.id), ["web", "tests"]);
+  assert.equal(after[0], webItem, "web's node stands");
+  assert.deepEqual([after[1].children[0].className, after[1].children[0].getAttribute("aria-label")], ["snap-row loading", "tests; opening"], "a placeholder tab (its meta alone) is a loading row");
+  assert.equal(after[1].children[0].querySelector(".snap-now")!.textContent, "opening…");
+  assert.equal(host.getAttribute("aria-label"), "infra: 2 sessions; click one to open it");
+});
+
+test("executed: focus survives the push that changes the rows: a moved row is re-focused on its own node, a removed row hands focus to the row in its place", () => {
+  const { api, content } = world();
+  api.set({ snapView: "infra" });
+  api.renderSnapshot();
+  const host = content.byId("tab-snapshot")!;
+  const [webItem, apiItem] = rowsOf(host);
+  apiItem.children[0].focus();
+  // a reorder: api's node moves (insertBefore detaches it, which the DOM turns into a blur); the same node is focused again
+  api.set({ lastStripItems: [{ head: { name: "infra", localId: "g2", color: "#4EC9B0", ids: ["api", "web"] }, folded: false, active: true, hidden: [] }, { id: "api" }, { id: "web" }] });
+  api.renderSnapshot();
+  assert.deepEqual(rowsOf(host), [apiItem, webItem], "moved, not remade");
+  assert.equal(DOC.activeElement, apiItem.children[0], "focus back on the moved node");
+  // the focused row's session leaves the section: the row now in its place takes focus (the last, when it was last)
+  api.set({ lastStripItems: [{ head: { name: "infra", localId: "g2", color: "#4EC9B0", ids: ["web"] }, folded: false, active: true, hidden: [] }, { id: "web" }] });
+  api.renderSnapshot();
+  assert.deepEqual(rowsOf(host), [webItem]);
+  assert.equal(DOC.activeElement, webItem.children[0], "not dropped to body");
+});
+
+test("executed: the section gone from the strip ends the view (the absence is the event): snapView clears, the host hides, and the caller is told to show the transcript; the held reading spot is written back", () => {
+  const { api, content, H } = world();
+  const v = { el: new FakeEl("div"), scrollTop: 1200, stick: false };
+  H.views.set("web", v);
+  api.set({ snapView: "infra", snapKeep: { v, scrollTop: 300, stick: true } });
+  api.renderSnapshot();
+  const host = content.byId("tab-snapshot")!;
+  v.scrollTop = 40; v.stick = false;   // the scroll listener recorded the view's scrolls onto the active view meanwhile
+  api.set({ lastStripItems: planStrip(["tests"], unions, parseTabGroups(null), "web", false).items });   // infra's last visible member gone: no infra header
+  assert.equal(api.renderSnapshot(), false);
+  assert.equal(api.get().snapView, null); assert.equal(api.get().snapModel, null);
+  assert.equal(host.style.display, "none");
+  assert.deepEqual([v.scrollTop, v.stick], [300, true], "the reader's place, from before the view, is back on the view");
+  assert.equal(api.get().snapKeep, null);
+  assert.equal(api.renderSnapshot(), false, "nothing to paint without a section");
+});
+
+test("executed: leaving puts the transcript back through the strip and showActive, and hands focus to the active tab only when a row held it", () => {
+  const { api, content, H, bar } = world();
+  api.set({ snapView: "infra" });
+  api.renderSnapshot();
+  const host = content.byId("tab-snapshot")!;
+  H.calls.length = 0;
+  bar.children[1].focus();   // focus on a tab of the strip, not on the view
+  api.leaveSnapshot();
+  assert.equal(api.get().snapView, null);
+  assert.deepEqual(H.calls, ["renderTabs", "showActive"], "the strip drops the header's mark, showActive puts the transcript back; focus is left where it was");
+  api.leaveSnapshot();
+  assert.deepEqual(H.calls, ["renderTabs", "showActive"], "not showing: nothing to leave");
+  api.set({ snapView: "infra" }); api.renderSnapshot(); H.calls.length = 0;
+  rowsOf(host)[0].children[0].focus();
+  api.leaveSnapshot();
+  assert.equal(DOC.activeElement, bar.querySelector('.tab[data-id="web"]'), "focus was on a row: the active tab takes it (hiding the host would drop it to body)");
+});
+
+test("executed: Escape leaves the view in two phases on the window: armed at capture unless a layer of this page or a typing target owns it, decided at bubble unless something marked it in between", () => {
+  const { api, H } = world();
+  api.set({ snapView: "infra" }); api.renderSnapshot();
+  assert.equal(H.winCap.length, 1); assert.equal(H.winBub.length, 1, "one listener per phase, installed with the module");
+  H.calls.length = 0;
+  let e = esc(H);
+  assert.equal(api.get().snapView, null, "left"); assert.equal(e.defaultPrevented, true, "and marked as taken");
+  assert.deepEqual(H.calls, ["renderTabs", "showActive"]);
+  api.set({ snapView: "infra" }); api.renderSnapshot(); H.calls.length = 0;
+  api.set({ ctxMenuEl: new FakeEl("div") });
+  esc(H); assert.equal(api.get().snapView, "infra", "a menu open: its Escape, not ours");
+  api.set({ ctxMenuEl: null }); H.pickerOpen = true;
+  esc(H); assert.equal(api.get().snapView, "infra", "the picker or a confirm up: theirs");
+  H.pickerOpen = false;
+  esc(H, { typing: true }); assert.equal(api.get().snapView, "infra", "a field keeps its Escape");
+  e = { key: "Escape", target: null, defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+  for (const f of H.winCap) f(e); e.defaultPrevented = true; for (const f of H.winBub) f(e);
+  assert.equal(api.get().snapView, "infra", "marked between the phases (the shell's chain closed a panel): yielded");
+  esc(H); assert.equal(api.get().snapView, null, "the next unclaimed Escape leaves");
+});
+
+test("executed: a row's click opens its session and focuses its tab, only while the session is still on the strip; a press on the view latches the strip's click-safe hold", () => {
+  const { api, H, content } = world();
+  api.set({ snapView: "infra" }); api.renderSnapshot();
+  const host = content.byId("tab-snapshot")!;
+  const open = H.delegates[0].handlers.open;
+  H.calls.length = 0;
+  open(rowsOf(host)[0].children[0], {} as Event);
+  assert.deepEqual(H.calls, ["setActive:web"], "the pick, then the strip's own focus rule");
+  assert.equal(DOC.activeElement, H.bar.querySelector('.tab[data-id="web"]'));
+  H.calls.length = 0;
+  H.sessions.delete("api"); H.tabMeta.set("api", { name: "api" });   // its closed frame arrived mid-press; the strip's meta lingers until the next tabOrder frame
+  open(rowsOf(host)[1].children[0], {} as Event);
+  assert.deepEqual(H.calls, [], "a session gone from under the row opens nothing");
+  H.sessions.set("api", { name: "api", status: { state: "idle" } }); H.closingTabs.set("api", 1);
+  open(rowsOf(host)[1].children[0], {} as Event);
+  assert.deepEqual(H.calls, [], "a tab the user closed opens nothing, whatever the maps still hold");
+  H.closingTabs.clear();
+  const stray = new FakeEl("button"); open(stray, {} as Event);
+  assert.deepEqual(H.calls, [], "no id, nothing");
+  assert.equal(api.get().tabPointerHeld, false);
+  host.fire("pointerdown");
+  assert.equal(api.get().tabPointerHeld, true, "a press on a row holds the strip's rebuild until the release, as a press on the strip does");
+  // a rebuild while pressed waits for the release: the times still tick, the DOM stands
+  const before = rowsOf(host);
+  H.sessions.set("web", { ...H.sessions.get("web"), status: { state: "ready", sinceEpoch: T0 * 1000 } });
+  assert.equal(api.renderSnapshot(), true);
+  assert.deepEqual(rowsOf(host), before); assert.equal(api.get().renderPendingWhilePressed, true);
+});
+
+test("executed: the folded-away active tab's header is its stand-in: focusActiveTab lands on it, the arrows step from its place, and a pick of a folded-away tab opens the first folded holder", () => {
+  const folded = setSectionCollapsed(parseTabGroups(null), "infra", true);
+  const { api, H, bar } = world("web", folded);   // qa: api, tests | infra(folded): web, api
+  assert.ok(H.collapsed.has("web") && !bar.querySelector('.tab[data-id="web"]'), "web has no tab node: infra's header stands in for it");
+  api.focusActiveTab();
+  assert.equal(DOC.activeElement, bar.querySelector('.tab-group-head[data-group="infra"]'), "focus lands on the header");
+  H.calls.length = 0;
+  api.onTabKey({ key: "ArrowRight", preventDefault() {} });
+  assert.deepEqual(H.calls, ["setActive:api"], "from the header's place (last on the strip) the step wraps to the first tab");
+  assert.equal(DOC.activeElement, bar.querySelector('.tab[data-id="api"]'), "focus follows onto the tab");
+  api.set({ activeId: "web" }); H.calls.length = 0;   // the folded-away tab read again: the header stands in again
+  api.onTabKey({ key: "ArrowLeft", preventDefault() {} });
+  assert.deepEqual(H.calls, ["setActive:tests"], "and from the header's place to the last tab before it");
+  // a pick of the folded-away tab: its first folded holder opens (the store write; the event re-renders the strip)
+  api.unfoldSectionOf("web");
+  assert.equal(H.writes.length, 1);
+  assert.deepEqual([H.writes[0].collapsed, H.writes[0].expanded], [[], []], "infra's fold is cleared (a name is stored only where it differs from the default)");
+  api.unfoldSectionOf("tests");
+  assert.equal(H.writes.length, 1, "a tab on screen opens nothing");
+  // several holders, both folded: the first in the strip's order opens, the other stands
+  const both = setSectionCollapsed(folded, "qa", true);
+  const w2 = world("api", both);
+  w2.api.unfoldSectionOf("api");
+  assert.deepEqual(w2.H.writes[0].collapsed, ["infra"], "qa (first) opens; infra stays folded");
+  // an open holder: the active tab has a node, focus goes there and the arrows walk the visible order
+  const w3 = world("web");
+  w3.api.focusActiveTab();
+  assert.equal(DOC.activeElement, w3.bar.querySelector('.tab[data-id="web"]'));
+  w3.api.onTabKey({ key: "ArrowRight", preventDefault() {} });
+  assert.deepEqual(w3.H.calls, ["setActive:api"]);
+});
+
+test("executed: the stand-in header answers a tab's keys: the arrows step from its place with focus following, Enter drops into the message box while it takes input and presses the header otherwise, Space presses; an unmarked holder and any other header are plain buttons", () => {
+  const folded = setSectionCollapsed(parseTabGroups(null), "infra", true);
+  const { api, H, bar } = world("web", folded);   // qa: api, tests | infra(folded): web, api
+  const inf = headOf(H.lastStripItems, "infra");
+  assert.deepEqual([inf.folded, inf.active, inf.hidden], [true, true, ["web", "api"]]);
+  const head = realHead(api, bar, inf);
+  assert.deepEqual([head.dataset.act, head.dataset.folded, head.getAttribute("role"), head.getAttribute("aria-expanded"), head.getAttribute("aria-current"), head.tabIndex],
+    ["toggle-group", "1", "button", "false", "true", 0], "the same fold button as the rest, marked current, a tab stop");
+  assert.ok(head.has("collapsed") && head.has("holds-active") && !head.has("snap-shown"));
+  assert.equal(head.title, headWords("infra", 2, 2, true, true).title, "the pure module's words");
+  assert.equal(head.getAttribute("aria-label"), headWords("infra", 2, 2, true, true).label + "; " + sectionPipTitle("working", ["web"]),
+    "the folded gist: web (hidden, working) puts the working pip on the header, and its phrase rides the spoken label");
+  assert.deepEqual(head.children.map((c) => c.className), ["tag-chip tab-group-chip", "tab-group-caret", "tab-group-count", "tab-group-pip"], "chip, caret, count, then the pip");
+  head.focus(); H.calls.length = 0;
+  let e = keyOn(head, "ArrowRight");
+  assert.equal(e.prevented, true);
+  assert.deepEqual(H.calls, ["setActive:api"], "from the header's place (last on the strip) the step wraps to the first tab");
+  assert.equal(DOC.activeElement, bar.querySelector('.tab[data-id="api"]'), "focus follows onto the tab (focusActiveTab)");
+  api.set({ activeId: "web" }); head.focus(); H.calls.length = 0;
+  e = keyOn(head, "ArrowLeft");
+  assert.deepEqual([e.prevented, H.calls, DOC.activeElement], [true, ["setActive:tests"], bar.querySelector('.tab[data-id="tests"]')], "and to the last tab before it");
+  // Enter: the message box while the transcript shows and the box takes input; the header's press otherwise
+  api.set({ activeId: "web" }); head.focus(); H.calls.length = 0;
+  e = keyOn(head, "Enter");
+  assert.deepEqual([e.prevented, H.calls, CLICKS.length], [true, ["focusComposerOrAsk"], 0], "into the message box: the mirror of the box's Escape, which lands on this header");
+  H.composer.disabled = true; H.calls.length = 0;
+  e = keyOn(head, "Enter");
+  assert.deepEqual([e.prevented, H.calls, CLICKS], [true, ["focusComposerOrAsk"], [head]], "the box disabled (a closed session): Enter presses the header, as Space does");
+  H.composer.disabled = false; api.set({ snapView: "infra" }); H.calls.length = 0;
+  keyOn(head, "Enter");
+  assert.deepEqual([H.calls, CLICKS.length], [[], 2], "the view up: Enter presses (the fold click), the box is not asked");
+  keyOn(head, " ");
+  assert.equal(CLICKS.length, 3, "Space presses");
+  api.set({ snapView: null });
+  // any other header (qa's, open, not holding web): the arrows are left to bubble (the window's handler steps the
+  // active tab, focus staying put), Enter presses
+  const qh = api.makeGroupHead(headOf(H.lastStripItems, "qa").head, false, false, []);
+  assert.deepEqual([qh.dataset.act, qh.getAttribute("aria-expanded"), qh.getAttribute("aria-current")], ["toggle-group", "true", null]);
+  H.calls.length = 0; CLICKS.length = 0;
+  e = keyOn(qh, "ArrowRight");
+  assert.deepEqual([e.prevented, H.calls], [false, []], "not the stand-in: the arrows bubble");
+  keyOn(qh, "Enter");
+  assert.deepEqual([H.calls, CLICKS], [[], [qh]], "Enter presses a plain header");
+  // a session under two folded tags: the holder planStrip marked (the first in tag order) is the stand-in; the other
+  // holder's header, unmarked (no aria-current, no chip mark), is a plain fold button, so what the user sees marked
+  // is what answers as the tab
+  const both = setSectionCollapsed(folded, "qa", true);
+  const w2 = world("api", both, ["web", "api", "tests", "loose"]);   // qa(folded, marked): api, tests | infra(folded): web, api | loose
+  const qa2 = headOf(w2.H.lastStripItems, "qa"), inf2 = headOf(w2.H.lastStripItems, "infra");
+  assert.deepEqual([qa2.active, inf2.active], [true, false]);
+  const qaHead = realHead(w2.api, w2.bar, qa2), infHead = realHead(w2.api, w2.bar, inf2);
+  assert.deepEqual([qaHead.getAttribute("aria-current"), infHead.getAttribute("aria-current")], ["true", null]);
+  assert.deepEqual([qaHead.has("holds-active"), infHead.has("holds-active")], [true, false]);
+  w2.H.calls.length = 0;
+  e = keyOn(qaHead, "ArrowRight");
+  assert.deepEqual([e.prevented, w2.H.calls], [true, ["setActive:loose"]], "the marked holder steps: over both folded headers and the trail to the one tab on screen");
+  w2.api.set({ activeId: "api" }); w2.H.calls.length = 0;
+  e = keyOn(infHead, "ArrowRight");
+  assert.deepEqual([e.prevented, w2.H.calls], [false, []], "the unmarked holder does not: its arrows bubble like any other header's");
+  keyOn(infHead, "Enter");
+  assert.deepEqual([w2.H.calls, CLICKS.at(-1)], [[], infHead], "and its Enter presses the header, not the message box");
+});
+
+test("executed: a header click folds or opens the section AND shows it at a glance; the way back is that header's next click once the section is open and holds the tab being read; a click on another header swaps the view", () => {
+  const { api, H, bar } = world("web");   // infra open (web, api), web active; qa open (api, tests)
+  let plan = planStrip(["web", "api", "tests"], unions, H.groups, "web", false);
+  let head = realHead(api, bar, headOf(plan.items, "infra"));
+  assert.deepEqual([head.dataset.act, head.getAttribute("aria-expanded"), head.getAttribute("aria-current"), head.has("snap-shown")], ["toggle-group", "true", "true", false],
+    "open and holding the tab being read: a fold button like the rest, marked current");
+  assert.equal(head.title, headWords("infra", 2, 0, false, true).title, "the title promises the fold and the view");
+  H.calls.length = 0;
+  api.acts["toggle-group"](head);
+  assert.equal(api.get().snapView, "infra", "the section shows in the pane");
+  assert.deepEqual([H.writes.length, H.writes[0].collapsed], [1, ["infra"]], "and folds: the one fold write, from the state the header RENDERED");
+  assert.deepEqual(H.calls, ["showActive"], "showActive paints the view; the write's event re-renders the strip");
+  // the strip re-renders from the store: infra folded, shown, holding the tab being read
+  H.groups = H.writes[0]; plan = planStrip(["web", "api", "tests"], unions, H.groups, "web", false); api.set({ lastStripItems: plan.items, collapsedTabIds: plan.folded });
+  let inf = headOf(plan.items, "infra");
+  assert.deepEqual([inf.folded, inf.active, inf.hidden], [true, true, ["web", "api"]]);
+  head = realHead(api, bar, inf);
+  assert.deepEqual([head.dataset.act, head.dataset.folded, head.getAttribute("aria-expanded"), head.has("snap-shown"), head.getAttribute("aria-current")], ["toggle-group", "1", "false", true, "true"],
+    "folded and shown: the header wears the mark and its next click opens");
+  assert.equal(head.title, headWords("infra", 2, 2, true, true, false, true).title, "the title names the open alone: the pane already shows the section");
+  H.calls.length = 0;
+  api.acts["toggle-group"](head);
+  assert.deepEqual([H.writes.length, H.writes[1].collapsed, api.get().snapView, H.calls], [2, [], "infra", ["showActive"]], "opened; the view stays");
+  H.groups = H.writes[1]; plan = planStrip(["web", "api", "tests"], unions, H.groups, "web", false); api.set({ lastStripItems: plan.items, collapsedTabIds: plan.folded });
+  inf = headOf(plan.items, "infra");
+  head = realHead(api, bar, inf);
+  assert.deepEqual([head.dataset.act, head.getAttribute("aria-expanded"), head.has("snap-shown"), head.getAttribute("aria-current")], ["show-transcript", null, true, "true"],
+    "open, shown and holding the tab being read: the way back, and not a disclosure (its press folds nothing)");
+  assert.equal(head.getAttribute("aria-label"), headWords("infra", 2, 0, false, true, true, true).label, "the spoken label names the action");
+  assert.equal(head.title, headWords("infra", 2, 0, false, true, true, true).title);
+  H.calls.length = 0;
+  api.acts["show-transcript"]();
+  assert.deepEqual([api.get().snapView, H.calls, H.writes.length], [null, ["renderTabs", "showActive"], 2], "the transcript back; no fold write: the way back moves no fold");
+  // the way back is only that header's: qa's header (open, not holding web) while infra shows folds qa and swaps the view to it
+  api.set({ snapView: "infra" });
+  const qh = realHead(api, bar, headOf(plan.items, "qa"));
+  assert.deepEqual([qh.dataset.act, qh.getAttribute("aria-expanded"), qh.has("snap-shown")], ["toggle-group", "true", false]);
+  api.acts["toggle-group"](qh);
+  assert.deepEqual([api.get().snapView, H.writes[2].collapsed], ["qa", ["qa"]], "the view swaps to the clicked section, which folds");
+  // the shown header that does NOT hold the tab being read is a fold button still, marked shown
+  api.set({ snapView: "qa" });
+  const qh2 = api.makeGroupHead(headOf(plan.items, "qa").head, false, false, []);
+  assert.deepEqual([qh2.dataset.act, qh2.has("snap-shown"), qh2.title], ["toggle-group", true, headWords("qa", 2, 0, false, false, false, true).title], "shown, open, the tab being read elsewhere: the click folds");
+  const nameless = new FakeEl("div", "tab-group-head");   // no data-group
+  H.writes.length = 0; api.set({ snapView: null });
+  api.acts["toggle-group"](nameless);
+  assert.deepEqual([H.writes.length, api.get().snapView], [0, null], "no group name: nothing");
+});
+
+test("executed: the nav trail records the reader's spot while the view shows: the spot the view holds for the tab being read (snapKeep), not the list's scroll that #content carries under the view", () => {
+  const { api, H } = world();
+  const now = () => H.navDeps!.now();
+  const v = { el: new FakeEl("div"), scrollTop: 1200, stick: false };
+  H.views.set("web", v);
+  H.content.scrollTop = 1200;
+  assert.deepEqual(now(), { sid: "web", top: 1200 }, "the transcript showing: the pane's scroll is the reader's spot");
+  // the header put the view up: showActive's branch held the reader's spot; the reveal's clamp and the list's own
+  // scrolls then move #content (and, through followReader, the active view's saved spot)
+  api.set({ snapView: "infra", snapKeep: { v, scrollTop: 1200, stick: false } });
+  api.renderSnapshot();
+  H.content.scrollTop = 0; v.scrollTop = 0;
+  assert.deepEqual(now(), { sid: "web", top: 1200 }, "a pick from the view records the line being read: Ctrl+M walks back to it, not to the list's top");
+  // the held spot names another view (the session being read closed under the view and the survivor is active): the
+  // pane's scroll, as without the view; showActive's branch re-holds the survivor's spot on its next pass
+  H.views.set("api", { el: new FakeEl("div"), scrollTop: 300, stick: true }); api.set({ activeId: "api" }); H.content.scrollTop = 7;
+  assert.deepEqual(now(), { sid: "api", top: 7 });
+  api.set({ activeId: null });
+  assert.equal(now(), null, "no active tab: no spot");
+  api.set({ activeId: "web" }); api.hideSnapshot();
+  assert.deepEqual([api.get().snapKeep, now()], [null, { sid: "web", top: 7 }], "the view hidden (its spot written back to the view): the pane's scroll again");
+});
+
+test("pinned: the wiring the lifted slices cannot reach: showActive's branch, the exits, setActive's pick, the strip's follow", () => {
+  // showActive: while a section shows, every transcript is hidden, the reader's place held, the composer disabled with a
+  // placeholder that says what to do; the transcript path hides the host first
+  assert.match(SHOW, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*for \(const v of views\.values\(\)\) v\.el\.style\.display = "none";/);
+  assert.match(SHOW, /const av = activeId \? views\.get\(activeId\) : null;\s*\n\s*if \(av && !snapKeep\) snapKeep = \{ v: av, scrollTop: av\.scrollTop, stick: av\.stick \};/, "the reader's place, once per visit");
+  assert.match(SHOW, /if \(av && snapKeep && snapKeep\.v !== av\) \{\s*\n\s*snapKeep\.v\.scrollTop = snapKeep\.scrollTop; snapKeep\.v\.stick = snapKeep\.stick;\s*\n\s*snapKeep = \{ v: av, scrollTop: av\.scrollTop, stick: av\.stick \};\s*\n\s*\}/, "the active changed under the view (the session being read closed): the survivor's place is held instead");
+  assert.match(SHOW, /if \(ta\) \{ ta\.disabled = true; ta\.placeholder = "Pick a session above to write to it"; \}/);
+  assert.match(SHOW, /hideSnapshot\(\);\s*\n\s*const s = activeId \? liveSession\(activeId\) : null;/, "a transcript showing: the view hidden, its place written back");
+  const loading = SHOW.slice(SHOW.indexOf("if (activeId && (tabMeta.has(activeId) || hostOf(activeId))) {"), SHOW.indexOf("} else if (!empty) {"));
+  assert.match(loading, /if \(ta\) \{ ta\.disabled = false; ta\.placeholder = composerRestingPlaceholder\(\); \}/, "a pick that lands on a still-loading tab takes the box back from the view's disabled state");
+  assert.match(RENDER, /if \(snapView\) \{ sl\.replaceChildren\(\); return; \}/, "no session's statusline chip under a section list");
+  assert.match(RENDER, /if \(!activeId \|\| skeletonTabs\.ids\.has\(activeId\) \|\| !liveAsks\.has\(activeId\) \|\| snapView\) \{/, "no live ask card under it");
+  assert.match(RENDER, /const s = activeId && !snapView \? liveSession\(activeId\) : null;/, "no background-task box under it");
+  // setActive: a pick ends the view, opens a folded-away tab's section before the early return, and puts the transcript
+  // back even when the pick is the tab already active
+  assert.match(RENDER, /const leavingSnap = snapView !== null;\s*\n\s*snapView = null;\s*\n\s*if \(collapsedTabIds\.has\(id\)\) unfoldSectionOf\(id\);[^\n]*\n\s*if \(activeId === id && anchor == null && anchorT == null\) \{[^\n]*\n\s*if \(leavingSnap\) \{ renderTabs\(\); showActive\(\); \}[^\n]*\n\s*return;\s*\n\s*\}/);
+  // the strip: the plan the view reads is the one just rendered; every push refreshes the view; the section gone puts the transcript back
+  assert.match(TABS, /collapsedTabIds = plan\.folded;\s*\n\s*lastStripItems = plan\.items;/);
+  assert.match(TABS, /const shown = snapView;\s*\n\s*const held = shown \? snapshotHoldsFocus\(\) : false;\s*\n\s*if \(snapView\) renderSnapshot\(\);\s*\n\s*if \(shown && !snapView\) \{ showActive\(\); if \(held\) focusActiveTab\(\); \}/);
+  assert.equal((TABS.match(/stripAftermath\(visibleIds, ids\)/g) || []).length, 2, "on the skip path and the rebuild path alike");
+  // the header and the #tabs delegate's two header acts run above (lifted); what the lift cannot show is that the acts
+  // are the ones the strip's delegate installs, and that the no-op act is gone
+  const TABS_DELEGATE_AT = RENDER.indexOf("delegate(tabs, {");
+  assert.ok(TABS_DELEGATE_AT > 0 && ACTS_AT > TABS_DELEGATE_AT && !RENDER.slice(TABS_DELEGATE_AT + 1, ACTS_AT).includes("delegate("), "the header acts sit on the #tabs delegate");
+  assert.ok(!RENDER.includes('"group-active"'), "the no-op act is gone: every header folds");
+  // the tab menu's closer marks the Escape it consumed, so the view's Escape yields to it
+  assert.match(RENDER, /window\.addEventListener\("keydown", \(e\) => \{ if \(e\.key === "Escape" && ctxMenuEl\) \{ dismissTabMenu\(\); e\.preventDefault\(\); \} \}, true\);/);
+  // the window's arrows and the host's next/prev commands step from the header's place too
+  assert.match(RENDER, /const nb = collapsedTabIds\.has\(activeId\) \? neighborOfFolded\(lastStripItems, activeId, dir\) : null;\s*\n\s*if \(nb\) \{ e\.preventDefault\(\); setActive\(nb\); \}/, "the window's arrows");
+  assert.match(RENDER, /const nb = neighborOfFolded\(lastStripItems, activeId, dir > 0 \? 1 : -1\);\s*\n\s*if \(nb\) setActive\(nb\);/, "cycleTab (nextTab / prevTab)");
+  // the client's Ledger type declares the two fields the rows read
+  assert.match(RENDER, /^interface Ledger \{ summary: string; tree\?: LedgerTreeNode\[\]; current\?: \{ t\?: number \} \| null; recent\?: LedgerRecent\[\]; workingNote\?: string; needsInput\?: boolean \| null; \}/m);
+});
+
+test("pinned: the sheet: the shown header's wash and the stand-in's mark on the tab-group rules; the view's two sizes, tokens only, the tab's state colors on the pip", () => {
+  assert.match(CSS, /\.tab-group-head\.snap-shown \{ background: var\(--accent-wash\); \}/, "the shown section's header wears the accent wash");
+  assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active \{ cursor: default; \}/, "the header folds, so its cursor promises the click");
+  assert.match(CSS, /\.tab-group-head\.holds-active \.tab-group-chip \{ text-decoration: underline; text-decoration-color: var\(--accent\);/, "the stand-in's mark: the tag's chip accent-underlined");
+  const block = CSS.slice(CSS.indexOf("#tab-snapshot {"), CSS.indexOf(".snap-when {") + 200);
+  assert.ok(block.length > 200, "the sheet was found");
+  assert.deepEqual([...new Set(block.match(/font-size: [^;]+/g))], ["font-size: 0.82em"], "one sub-line size, the header's; the rest inherit the body");
+  assert.match(block, /\.snap-pip\.working \{ background: var\(--st-working-bg\); \}/);
+  assert.match(block, /\.snap-pip\.blocked \{ background: var\(--st-blocked-bg\); \}/);
+  assert.match(block, /\.snap-pip\.awaiting \{ background: var\(--st-awaiting-bg\); \}/);
+  assert.match(block, /\.snap-pip\.waiting \{ background: var\(--st-awaitbg-bg\); \}/);
+  assert.match(block, /\.snap-pip\.retrying \{ background: var\(--st-retrying-bg\); \}/, "the same status token the tab and the folded header's pip use");
+  assert.match(block, /\.snap-row:hover \{ border-color: var\(--accent\); background: var\(--accent-wash\); \}/);
+  assert.match(block, /\.snap-row:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/);
+  assert.match(block, /\.snap-flag\.needs \{ border-color: transparent; background: var\(--st-blocked-bg\); color: var\(--st-blocked-fg\); \}/, "needs you in the status red, not the accent");
+  const stripped = block.replace(/\/\*[\s\S]*?\*\//g, "").replace(/var\([^)]*\)/g, "V");
+  assert.equal(stripped.match(/#[0-9a-fA-F]{3,8}\b/g), null, "no raw color: the light theme needs no override");
+});
+
+test("executed: the guide describes the fold rule and the view", () => {
+  const GUIDE = fs.readFileSync(path.resolve(process.cwd(), "..", "docs", "guide.md"), "utf8");
+  const prose = (t: string) => new RegExp(t.replace(/[.()*]/g, "\\$&").split(" ").join("\\s+"));   // the guide wraps its lines
+  assert.match(GUIDE, prose("The section of the tab you are reading folds like any other; its header marks that it holds the tab (the tag's name is underlined), and folded, the header stands in for the tab: focus lands on it, and the left and right arrows step from there."));
+  assert.doesNotMatch(GUIDE, prose("never folds (its header says so, and a click there changes nothing)"), "the old rule is gone");
+  assert.match(GUIDE, prose("**A section at a glance.** Clicking a header also shows the section in the transcript's place"));
+  assert.match(GUIDE, prose("The transcript comes back when you pick a session, press Escape, or click that header again while its section is open and holds the tab you are reading."));
+  assert.match(GUIDE, prose("a session that has published a note of what it is working on shows the note as a quieter second line."));
+});

--- a/ui/webview/tab-snapshot-view.test.ts
+++ b/ui/webview/tab-snapshot-view.test.ts
@@ -1,0 +1,153 @@
+// A SECTION AT A GLANCE, THE VIEW HELPERS (tab-snapshot-view.ts): the pane-side rules render.ts applies to
+// the view, pure so they execute here without a DOM: which row click may open a session, how Escape yields
+// to every layer that owns its own Escape, and how the rows update in place. The model and its words are
+// tab-snapshot.ts; the pane's wiring is tab-snapshot-pane.test.ts. Synthetic only: the notes-api demo world.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { rowStillOpen, installSnapshotEscape, reconcileRows } from "./tab-snapshot-view";
+
+test("a row whose session left the strip mid-press opens nothing: a frame's row needs its session, a placeholder's row its meta, and a closing tab is neither", () => {
+  // click safety keeps the pressed row in the DOM until the release, so a session dismissed between mousedown
+  // and mouseup (the kernel's closed frame, a tabOrder push without it) is still under the click; setActive on
+  // that id would find tabMeta still holding it (dismissSession leaves tabMeta to the next tabOrder frame) and
+  // put up a loader for a session that never arrives
+  const frame = { loading: false }, placeholder = { loading: true };
+  assert.equal(rowStillOpen(frame, true, true, false), true, "a live row with its session: opens");
+  assert.equal(rowStillOpen(frame, false, true, false), false, "its session gone, its meta lingering: nothing opens");
+  assert.equal(rowStillOpen(frame, false, false, false), false, "session and meta gone: nothing opens");
+  assert.equal(rowStillOpen(placeholder, false, true, false), true, "a placeholder row (no frame yet) with its meta: opens, the loading branch is its state");
+  assert.equal(rowStillOpen(placeholder, false, false, false), false, "a placeholder whose meta left: nothing opens");
+  assert.equal(rowStillOpen(placeholder, true, false, false), true, "a placeholder whose frame landed mid-press: the session is there, it opens");
+  assert.equal(rowStillOpen(frame, true, true, true), false, "the user closed it (closingTabs): nothing opens, whatever the maps still hold");
+  assert.equal(rowStillOpen(undefined, true, true, false), true, "no model row for the id (never expected): the session decides");
+  assert.equal(rowStillOpen(undefined, false, true, false), false);
+});
+
+// A stand-in for one keydown's dispatch through the chat frame, in DOM order: the window's capture listeners,
+// the DOCUMENT's capture listeners (where the shell's Escape chain sits: kernel.py _LANDING_ESC_JS wires onEsc
+// onto this frame's contentDocument at capture), then the target and the bubble back up to the window. A
+// listener that stops propagation ends the walk, as in a browser.
+type Fn = (e: KeyboardEvent) => void;
+function frame() {
+  const winCap: Fn[] = [], winBub: Fn[] = [], docCap: Fn[] = [];
+  const win = { addEventListener: (_t: "keydown", fn: Fn, capture?: boolean) => { (capture ? winCap : winBub).push(fn); } };
+  const dispatch = (e: KeyboardEvent) => {
+    const ev = e as unknown as { stopped: boolean };
+    for (const f of winCap) f(e); if (ev.stopped) return;
+    for (const f of docCap) f(e); if (ev.stopped) return;
+    for (const f of winBub) f(e);
+  };
+  return { win, docCap, winCap, winBub, dispatch };
+}
+const key = (k: string, target: EventTarget | null = null) => {
+  const e = { key: k, target, defaultPrevented: false, stopped: false,
+    preventDefault() { this.defaultPrevented = true; }, stopPropagation() { this.stopped = true; } };
+  return e as unknown as KeyboardEvent;
+};
+// the shell's chain, as _LANDING_ESC_JS behaves: a panel open, close it, mark the Escape, stop it; else nothing
+const shell = (panel: { open: boolean }) => (e: KeyboardEvent) => { if (e.key === "Escape" && panel.open) { panel.open = false; e.preventDefault(); e.stopPropagation(); } };
+
+test("Escape leaves the view only when no layer claimed it: the shell's panels live out of this page's sight, so the decision waits for the shell's chain", () => {
+  // a one-phase handler at the window's capture would run before the shell's document-capture chain and could
+  // not see the shell document's panels: an Escape aimed at the log panel would close it AND swap the pane. Two
+  // phases: armed at capture (this page's own layers still on the page to be seen), decided at bubble, which an
+  // Escape the shell stopped never reaches
+  const f = frame();
+  const panel = { open: true };
+  f.docCap.push(shell(panel));
+  let showing = true, left = 0, layer = false;
+  installSnapshotEscape(f.win, { showing: () => showing, typing: () => false, layerOpen: () => layer, leave: () => { left++; showing = false; } });
+  assert.equal(f.winCap.length, 1); assert.equal(f.winBub.length, 1, "one listener per phase");
+  let e = key("Escape"); f.dispatch(e);
+  assert.equal(panel.open, false, "the shell closed its panel");
+  assert.equal(left, 0, "and the view stayed");
+  assert.equal(e.defaultPrevented, true, "the shell's mark");
+  e = key("Escape"); f.dispatch(e);
+  assert.equal(left, 1, "nothing open anywhere: the Escape reaches the bubble unclaimed; the view leaves, once");
+  assert.equal(e.defaultPrevented, true, "and is marked as taken");
+  f.dispatch(key("Escape"));
+  assert.equal(left, 1, "not showing any more: nothing to leave");
+});
+
+test("the arm yields to this page's own layers at capture, to an earlier capture listener's mark, and to a typing target; a stale arm never fires on a later key", () => {
+  const f = frame();
+  let left = 0, layer = false, typing = false;
+  installSnapshotEscape(f.win, { showing: () => true, typing: () => typing, layerOpen: () => layer, leave: () => { left++; } });
+  layer = true; f.dispatch(key("Escape")); assert.equal(left, 0, "a page layer open at capture (a menu, the picker, a preview): not armed, even though nothing marks the Escape later");
+  layer = false; typing = true; f.dispatch(key("Escape")); assert.equal(left, 0, "a field keeps its Escape");
+  typing = false;
+  // the tab menu's closer: a window-capture listener registered before this one, marking the Escape it consumed
+  f.winCap.unshift((e) => { if (e.key === "Escape") e.preventDefault(); });
+  f.dispatch(key("Escape")); assert.equal(left, 0, "an Escape already marked at capture is not ours");
+  f.winCap.shift();
+  // an Escape the shell stopped leaves the arm set; the next key must not inherit it
+  const panel = { open: true }; f.docCap.push(shell(panel));
+  f.dispatch(key("Escape")); assert.equal(left, 0, "stopped by the shell");
+  f.docCap.pop();
+  f.dispatch(key("a")); assert.equal(left, 0, "a later, unrelated key reaching the bubble does not fire the stale arm");
+  f.dispatch(key("Escape")); assert.equal(left, 1, "the next unclaimed Escape does");
+  // a mark set BETWEEN the phases by a listener that does not stop propagation (a target-phase handler) also wins
+  f.docCap.push((e) => { if (e.key === "Escape") e.preventDefault(); });
+  f.dispatch(key("Escape")); assert.equal(left, 1, "marked between the phases: yielded");
+});
+
+// A stand-in for the list node: children in order, the DOM's insertBefore (a node already in the list is
+// moved: detached, then put before the reference; a null reference appends) and removeChild. Each row's node
+// is a plain object, so identity is what the assertions compare.
+type Row = { id: string; now: string };
+type Node = { id: string | null; text: string };
+class List {
+  children: Node[] = [];
+  insertBefore(n: Node, ref: Node | null): void {
+    const i = this.children.indexOf(n); if (i >= 0) this.children.splice(i, 1);
+    const j = ref ? this.children.indexOf(ref) : -1;
+    if (j < 0) this.children.push(n); else this.children.splice(j, 0, n);
+  }
+  removeChild(n: Node): void { const i = this.children.indexOf(n); if (i >= 0) this.children.splice(i, 1); }
+}
+const rows = (...rs: Array<[string, string]>): Row[] => rs.map(([id, now]) => ({ id, now }));
+
+test("a changed row keeps its node, patched; a row that came is made and one that went is removed with the others standing; a reorder moves without remaking", () => {
+  // sameRow (tab-snapshot.ts) folds lastT and lastMsg, so the model changes on nearly every push while a member
+  // works: a wholesale repaint would destroy the button a keyboard user had Tabbed onto within seconds (focus to
+  // body, Enter dead) and dismiss a hover's title. Focus and the title belong to the NODE, so the node is kept.
+  const list = new List();
+  const made: string[] = [], patched: string[] = [];
+  const key = (n: Node) => n.id;
+  const make = (r: Row): Node => { made.push(r.id); return { id: r.id, text: r.now }; };
+  const patch = (n: Node, r: Row) => { patched.push(r.id); n.text = r.now; };
+  let out = reconcileRows(list, rows(["web", "building the list page"], ["api", "idle"], ["tests", "running the suite"]), key, make, patch);
+  assert.deepEqual(out, { kept: 0, made: 3, moved: 0, removed: 0 }, "the first paint: every row made, in the model's order");
+  assert.deepEqual(list.children.map((n) => n.id), ["web", "api", "tests"]);
+  const [web, api, tests] = list.children;
+  made.length = 0; patched.length = 0;
+  out = reconcileRows(list, rows(["web", "building the list page"], ["api", "reading the schema"], ["tests", "running the suite"]), key, make, patch);
+  assert.equal(list.children[1], api, "the same object: focus and the hover title stay on it");
+  assert.equal(api.text, "reading the schema", "with the new parts");
+  assert.deepEqual(made, [], "nothing remade");
+  assert.deepEqual(patched, ["web", "api", "tests"], "every standing row takes the model's parts");
+  assert.deepEqual(out, { kept: 3, made: 0, moved: 0, removed: 0 });
+  made.length = 0;
+  out = reconcileRows(list, rows(["web", "building the list page"], ["tests", "running the suite"], ["docs", "drafting the guide"]), key, make, patch);
+  assert.deepEqual(list.children.map((n) => n.id), ["web", "tests", "docs"], "a row gone and a row come: the others' nodes stand where they were");
+  assert.equal(list.children[0], web); assert.equal(list.children[1], tests);
+  assert.deepEqual(made, ["docs"]);
+  assert.deepEqual(out, { kept: 2, made: 1, moved: 0, removed: 1 });
+  const docs = list.children[2];
+  out = reconcileRows(list, rows(["docs", "drafting the guide"], ["web", "building the list page"], ["tests", "running the suite"]), key, make, patch);
+  assert.deepEqual(list.children, [docs, web, tests], "a reorder: the same three objects, in the new order");
+  assert.deepEqual(out, { kept: 3, made: 0, moved: 1, removed: 0 });
+  out = reconcileRows(list, rows(), key, make, patch);
+  assert.deepEqual(list.children, [], "an empty section: every row removed");
+  assert.deepEqual(out, { kept: 0, made: 0, moved: 0, removed: 3 });
+});
+
+test("a node without a key and a second node under one key (never expected) are removed, not reused: one node per row", () => {
+  const list = new List();
+  const stray: Node = { id: null, text: "" }, web: Node = { id: "web", text: "" }, web2: Node = { id: "web", text: "twin" };
+  list.children.push(stray, web, web2);
+  const out = reconcileRows(list, rows(["web", "building"]), (n) => n.id, (r) => ({ id: r.id, text: r.now }), (n, r) => { n.text = r.now; });
+  assert.deepEqual(list.children, [web], "the first node under the key is the row's; the stray and the twin go");
+  assert.equal(web.text, "building");
+  assert.deepEqual(out, { kept: 1, made: 0, moved: 0, removed: 2 });
+});

--- a/ui/webview/tab-snapshot-view.ts
+++ b/ui/webview/tab-snapshot-view.ts
@@ -1,0 +1,89 @@
+// A SECTION AT A GLANCE, VIEW SIDE: the rules render.ts applies to the pane that are not about what a row
+// SAYS (tab-snapshot.ts owns the model and its words) but about how the pane behaves under the strip's
+// events: which row click may open a session, how Escape yields to the layers that own their own Escape,
+// and how the rows update in place. PURE, shaped on the minimal "Like" views of render.ts's state (the
+// tab-state.ts idiom), so each rule executes in node tests without a DOM (tab-snapshot-view.test.ts);
+// render.ts wires them.
+
+/** Whether a row's click may open its session: the session the row showed must still be on the strip.
+ *  Click safety keeps the pressed row in the DOM until the release (tabPointerHeld), so a session dismissed
+ *  between mousedown and mouseup (the kernel's closed frame, a tabOrder push without it) is still under the
+ *  click; opening that id would put up a loader for a session that never arrives, because the strip's meta
+ *  lingers until the next tabOrder frame. A row that had a frame needs its session; a placeholder row (no
+ *  frame yet, `loading`) needs its meta, or the frame that landed meanwhile; a tab the user closed
+ *  (closingTabs) is neither. `row` is the model row the click landed on; none (never expected) defers to
+ *  the session. */
+export function rowStillOpen(row: { loading: boolean } | undefined, hasSession: boolean, hasMeta: boolean, closing: boolean): boolean {
+  if (closing) return false;
+  if (hasSession) return true;
+  return !!row?.loading && hasMeta;
+}
+
+/** What installSnapshotEscape needs of the page: `showing` (the view is up), `typing` (the target keeps its
+ *  own Escape: a field, an editable), `layerOpen` (a layer of this page owns Escape right now: a menu, the
+ *  picker or a confirm overlay, a panel, a preview, a comment thread) and `leave` (the exit). */
+export interface EscapeHooks { showing(): boolean; typing(target: EventTarget | null): boolean; layerOpen(): boolean; leave(): void }
+export interface EscapeTarget { addEventListener(type: "keydown", fn: (e: KeyboardEvent) => void, capture?: boolean): void }
+
+/** ESCAPE LEAVES THE VIEW, and yields to every layer that owns its own Escape, in two phases on one window.
+ *  ARMED at the window's capture phase, so this page's layers are still on the page to be seen (a menu
+ *  closes itself on Escape and is gone by the bubble); an Escape a listener registered before this one
+ *  already marked (the tab menu's closer) is not ours. DECIDED at the window's bubble phase, after the
+ *  SHELL's Escape chain has run: its panels (the log, usage and network panels) live in the shell document,
+ *  out of this page's sight, and its chain sits on this frame's DOCUMENT at capture (kernel.py
+ *  _LANDING_ESC_JS), so it runs after the arm and before the decision, and marks and stops the Escape it
+ *  consumed, which then never reaches the decision. A one-phase capture handler would swap the pane on an
+ *  Escape aimed at the log panel. The arm is the event itself, checked by identity at the bubble, so an
+ *  Escape stopped between the phases leaves nothing a later key can inherit. */
+export function installSnapshotEscape(win: EscapeTarget, hooks: EscapeHooks): void {
+  let armed: KeyboardEvent | null = null;
+  win.addEventListener("keydown", (e) => {
+    armed = null;
+    if (e.key !== "Escape" || !hooks.showing() || e.defaultPrevented) return;
+    if (hooks.typing(e.target) || hooks.layerOpen()) return;
+    armed = e;
+  }, true);
+  win.addEventListener("keydown", (e) => {
+    if (e !== armed) return;
+    armed = null;
+    if (e.defaultPrevented || !hooks.showing()) return;
+    e.preventDefault();
+    hooks.leave();
+  }, false);
+}
+
+/** The least of a list node the keyed row update needs: the DOM's HTMLElement, or a test's stand-in. */
+export interface RowList<N> { readonly children: ArrayLike<N>; insertBefore(node: N, ref: N | null): unknown; removeChild(node: N): unknown }
+
+/** THE ROWS UPDATE IN PLACE, KEYED BY SESSION ID. sameRow (tab-snapshot.ts) folds lastT and lastMsg, so the
+ *  model changes on nearly every push while a member works; a wholesale repaint would destroy the button a
+ *  keyboard user had Tabbed onto within seconds (focus to body, Enter dead) and dismiss a hover's title.
+ *  Focus and the title belong to the NODE, so the node is what a rebuild keeps: a row whose key stands is
+ *  patched (`patch`), a row that came is made (`make`) and put in its place, a row that went is removed, a
+ *  reordered row moved (insertBefore, which on a real DOM detaches and re-attaches the node: the caller
+ *  re-focuses a moved row). A node with no key, or a second node under a key (never expected), is removed,
+ *  never reused. Moves are per row, not a longest-common-subsequence: a section holds a handful of rows,
+ *  and a reorder is rare. Returns the counts, for the tests. */
+export function reconcileRows<R extends { id: string }, N>(
+  list: RowList<N>, rows: readonly R[], keyOf: (node: N) => string | null | undefined,
+  make: (row: R) => N, patch: (node: N, row: R) => void,
+): { kept: number; made: number; moved: number; removed: number } {
+  const want = new Set(rows.map((r) => r.id));
+  const standing = new Map<string, N>();
+  let removed = 0;
+  for (const n of Array.from(list.children)) {
+    const k = keyOf(n);
+    if (k && want.has(k) && !standing.has(k)) standing.set(k, n);
+    else { list.removeChild(n); removed++; }
+  }
+  let kept = 0, made = 0, moved = 0;
+  rows.forEach((row, i) => {
+    let node = standing.get(row.id);
+    if (node) { patch(node, row); kept++; } else { node = make(row); made++; }
+    const at = list.children[i] ?? null;
+    if (at === node) return;
+    list.insertBefore(node, at);
+    if (standing.has(row.id)) moved++;
+  });
+  return { kept, made, moved, removed };
+}

--- a/ui/webview/tab-snapshot.test.ts
+++ b/ui/webview/tab-snapshot.test.ts
@@ -1,0 +1,202 @@
+// A SECTION AT A GLANCE, THE MODEL (tab-snapshot.ts): a header click shows the section's sessions in the
+// transcript's place, one row each: name, identity color, a state pip, a needs-you or waiting word, what
+// the session is doing now, when it last did anything, its last message on hover. Executed on the pure
+// model from synthetic frame data; the pane's wiring is tab-snapshot-pane.test.ts and the view helpers
+// tab-snapshot-view.test.ts. The demo world only: a notes-api with web / api / tests sessions, invented text.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { snapshotModel, snapshotRow, snapshotHeading, rowWords, rowState, nowLine, noteLine, lastActivity, lastMessage,
+         plainText, sameModel, FEED_BLOCK_STATE, type SnapSessionLike, type SnapLedgerLike } from "./tab-snapshot";
+
+const T0 = 1781100000;
+const iso = (t: number) => new Date(t * 1000).toISOString();
+const ms = (t: number) => t * 1000;   // status.sinceEpoch is MILLISECONDS on the wire (the kernel's since_ms, render's Date.now())
+const sec = { name: "infra", color: "#4EC9B0", ids: ["web", "api", "tests"] };
+const sessions = new Map<string, SnapSessionLike>([
+  ["web", { name: "web", color: { bg: "#3a7bd5", fg: "#ffffff" }, status: { state: "working", sinceEpoch: ms(T0 - 30) },
+            events: [{ kind: "user", md: "please add the notes list page", ts: iso(T0 - 300) },
+                     { kind: "assistant", md: "Adding the list page now: the\n\nroute and the template.", ts: iso(T0 - 40) }, { kind: "tool", ts: iso(T0 - 20) }] }],
+  ["api", { name: "api", color: { bg: "#d53a3a", fg: "#ffffff" }, status: { state: "needsInput", sinceEpoch: ms(T0 - 600) },
+            events: [{ kind: "assistant", md: "Which database should the notes table use?", ts: iso(T0 - 600) }] }],
+  ["tests", { name: "tests", color: null, status: { state: "awaitingBg", sinceEpoch: ms(T0 - 900) }, events: [] }],
+]);
+const ledgers = new Map<string, SnapLedgerLike>([
+  ["web", { summary: "Building the notes-api web pages", workingNote: "editing the list page template", needsInput: false,
+            tree: [{ text: "Add the notes list page", current: true }], recent: [{ text: "Add the notes list page", t: T0 - 300 }] }],
+  ["api", { summary: "Designing the notes schema", needsInput: true, tree: [{ text: "Pick a database", current: true }], recent: [] }],
+  ["tests", { summary: "", needsInput: false, tree: [], recent: [{ text: "Run the notes-api suite", t: T0 - 4000 }] }],
+]);
+const look = (m: Map<string, unknown>) => (id: string) => (m.get(id) as any) ?? null;
+
+test("executed: one row per member in strip order, from what the client already holds: name, color, pip by the tab's rule, words, now line, note, last activity", () => {
+  const m = snapshotModel(sec, look(sessions), look(ledgers), null);
+  assert.equal(m.name, "infra"); assert.equal(m.color, "#4EC9B0");
+  assert.deepEqual(m.rows.map((r) => r.id), ["web", "api", "tests"], "strip order, never re-sorted");
+  const [web, api, tests] = m.rows;
+  assert.deepEqual([web.name, web.color, web.pip, web.state, web.needsYou, web.waiting, web.closed, web.loading],
+    ["web", { bg: "#3a7bd5", fg: "#ffffff" }, "working", "working", false, false, false, false]);
+  assert.equal(web.now, "Add the notes list page", "the now line is the judges' current task, in the user's terms, even when a note is published");
+  assert.equal(web.note, "editing the list page template", "the working note is the row's own second line, never the now line");
+  assert.equal(web.lastT, T0 - 20, "the newest event in the tail, whatever its kind");
+  assert.equal(web.lastMsg, "Adding the list page now: the route and the template.", "the last ASSISTANT message, one line");
+  assert.deepEqual([api.pip, api.state, api.needsYou], ["awaiting", "needs you: waiting on your answer", true], "a live prompt is on you: the tab's red");
+  assert.equal(api.now, "Pick a database", "the current task");
+  assert.equal(api.note, "", "no note, no second line");
+  assert.deepEqual([tests.pip, tests.state, tests.waiting, tests.needsYou], ["waiting", "waiting on background work", true, false], "awaitingBg: waiting, not on you");
+  assert.equal(tests.now, "Run the notes-api suite", "no current task, no summary: the most recent top");
+  assert.equal(tests.lastT, T0 - 900, "an empty tail: the state's start, converted from the wire's milliseconds");
+  assert.equal(tests.lastMsg, "");
+});
+
+test("executed: the now line's precedence (current task, summary, recent top, nothing), one line always; the note is its own line", () => {
+  assert.equal(nowLine({ workingNote: "a note", tree: [{ text: "done one", current: false }, { text: "the current one", current: true }], summary: "s" }), "the current one", "a note never leads");
+  assert.equal(nowLine({ tree: [{ text: "", current: true }], summary: "the headline" }), "the headline", "a blank current text does not win");
+  assert.equal(nowLine({ workingNote: "a note", summary: "   ", recent: [{ text: "" }, { text: "last top" }] }), "last top", "nor stands in for a missing task");
+  assert.equal(nowLine({ workingNote: "a note" }), "", "a note alone leaves the now line empty: it is not what the session is accomplishing");
+  assert.equal(nowLine({}), ""); assert.equal(nowLine(null), "");
+  assert.equal(nowLine({ summary: "x".repeat(300) }).length, 200, "capped: the row is one line and the model stays small");
+  assert.equal(noteLine({ workingNote: "  a  note\nwith   breaks ", summary: "s" }), "a note with breaks", "the note, one line");
+  assert.equal(noteLine({ workingNote: "", summary: "s" }), ""); assert.equal(noteLine({}), ""); assert.equal(noteLine(null), "");
+  assert.equal(noteLine({ workingNote: "x".repeat(300) }).length, 200, "the same cap");
+});
+
+test("executed: needs you follows the FEED's column, not the tab's chip: a judge-filed block flags the row whether the session is idle or active", () => {
+  // the common case the tab's rule misses: the agent asked a question and went idle; the feed files its card under needs-you
+  const idle = snapshotRow("web", { name: "web", status: { state: "idle" } }, { needsInput: true, tree: [{ text: "Pick a database", current: true }] });
+  assert.deepEqual([idle.pip, idle.needsYou, idle.state], ["", true, FEED_BLOCK_STATE], "idle + feed needs-you: flagged, with the feed's word; the pip stays the tab's (none)");
+  const ready = snapshotRow("web", { name: "web", status: { state: "ready" } }, { needsInput: true });
+  assert.deepEqual([ready.pip, ready.needsYou, ready.state], ["", true, FEED_BLOCK_STATE]);
+  // blocked while active: the feed's verdict stands until the judges rule again, even with a turn open (a rejudge in flight)
+  const active = snapshotRow("web", { name: "web", status: { state: "working" } }, { needsInput: true });
+  assert.deepEqual([active.pip, active.needsYou, active.state], ["working", true, "working"], "active + feed needs-you: flagged; the tab's own state word and pip stay");
+  // no feed verdict for this session: the tab's rule alone
+  assert.equal(snapshotRow("web", { name: "web", status: { state: "idle" } }, { needsInput: false }).needsYou, false);
+  assert.equal(snapshotRow("web", { name: "web", status: { state: "idle" } }, { needsInput: false }).state, "");
+  assert.equal(snapshotRow("web", { name: "web", status: { state: "idle" } }, { needsInput: null }).needsYou, false, "null = no feed build yet: not a verdict");
+  assert.equal(snapshotRow("web", { name: "web", status: { state: "needsInput" } }, { needsInput: null }).needsYou, true, "the tab's live prompt still counts (the feed trails the chip by a push)");
+  assert.equal(snapshotRow("web", { name: "web", status: { state: "blocked", apiTooLong: true } }, { needsInput: false }).needsYou, true, "the tab's on-you API error too");
+  assert.equal(snapshotRow("web", { name: "web", status: { state: "closed" } }, { needsInput: true }).state, "closed", "a closed session keeps its own word");
+  assert.equal(rowWords(idle).label, "web; needs you; Pick a database", "the spoken label carries the feed's word, once");
+});
+
+test("executed: the feed's word claims only what is true of every card in its column: needs you, nothing about being stopped", () => {
+  // the column also holds a peer's held message waiting for approval (the session idle, taking input); the
+  // feed's own word for a goal in that column is the one every card there deserves
+  assert.equal(FEED_BLOCK_STATE, "needs you");
+  assert.doesNotMatch(FEED_BLOCK_STATE, /stop|answer/);
+});
+
+test("executed: the spoken label carries NEEDS YOU whenever the row wears it, whatever the state word, and never twice", () => {
+  const prompt = snapshotRow("api", { name: "api", status: { state: "needsInput" } }, { needsInput: true });
+  assert.equal(rowWords(prompt).label, "api; needs you: waiting on your answer");
+  const apiErr = snapshotRow("api", { name: "api", status: { state: "blocked", apiTooLong: true } }, null);
+  assert.equal(rowWords(apiErr).label, "api; needs you: stopped on an API error");
+  const rejudge = snapshotRow("web", { name: "web", status: { state: "working" } }, { needsInput: true, tree: [{ text: "Pick a database", current: true }] });
+  assert.equal(rowWords(rejudge).label, "web; needs you; working; Pick a database");
+  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "closed" } }, { needsInput: true })).label, "web; needs you; closed");
+  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "working" } }, { needsInput: false })).label, "web; working");
+  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "awaitingBg" } }, { needsInput: null })).label, "web; waiting on background work");
+  assert.equal(rowWords(snapshotRow("new1", null, { needsInput: true })).label, "(unnamed); needs you; opening", "a loading row can wear the flag only through a ledger the client has no session for; spoken all the same");
+});
+
+test("executed: the pip and the state word follow tab-state.ts: on-you red, transient amber, closed struck, idle none", () => {
+  assert.deepEqual(rowState({ state: "blocked", apiTooLong: true }), { pip: "blocked", state: "needs you: stopped on an API error", needsYou: true, waiting: false, closed: false });
+  assert.equal(rowState({ state: "blocked" }).pip, "retrying", "a transient API error is the tab's amber, not red");
+  assert.deepEqual(rowState({ state: "retrying" }), { pip: "retrying", state: "API error, retrying on its own", needsYou: false, waiting: false, closed: false });
+  assert.equal(rowState({ state: "awaiting" }).pip, "awaiting", "the legacy name an older remote kernel sends");
+  assert.deepEqual(rowState({ state: "compacting" }), { pip: "compacting", state: "compacting", needsYou: false, waiting: false, closed: false });
+  assert.equal(rowState({ state: "clearing" }).state, "clearing");
+  assert.deepEqual(rowState({ state: "closed" }), { pip: "", state: "closed", needsYou: false, waiting: false, closed: true });
+  for (const st of ["ready", "idle"]) assert.deepEqual(rowState({ state: st }), { pip: "", state: "", needsYou: false, waiting: false, closed: false }, st + ": no pip");
+  assert.equal(rowState({ state: "opening" }).pip, "unknown");
+  assert.equal(rowState({ state: "interrupting" }).state, "interrupting");
+  assert.equal(rowState(null).pip, "unknown");
+});
+
+test("executed: a placeholder tab (no session frame yet) is a loading row with the meta it has; a closed session is struck", () => {
+  const r = snapshotRow("new1", null, null);
+  assert.deepEqual([r.name, r.pip, r.loading, r.lastT, r.now, r.lastMsg], ["(unnamed)", "unknown", true, null, "", ""]);
+  const meta = snapshotRow("new1", null, null, { name: "new1", color: { bg: "#123456", fg: "#ffffff" } });   // the strip's tabMeta: name + color, no frame yet
+  assert.deepEqual([meta.name, meta.pip, meta.loading, meta.color], ["new1", "unknown", true, { bg: "#123456", fg: "#ffffff" }], "a loading row wears the tab's name and color");
+  assert.equal(rowWords(meta).label, "new1; opening");
+  const landed = snapshotRow("new1", { name: "new1", status: { state: "ready" } }, null, { name: "old-name" });
+  assert.deepEqual([landed.name, landed.loading], ["new1", false], "the frame outranks the meta once it lands");
+  assert.equal(snapshotRow("old", { name: "old", status: { state: "closed" } }, null).closed, true);
+  assert.equal(rowWords(snapshotRow("new1", null, null)).label, "(unnamed); opening");
+  assert.equal(snapshotRow("x", { name: "x", color: { bg: "#123456", fg: "" } }, null).color, null, "half a color is no color");
+});
+
+test("executed: lastActivity walks the tail from the end and skips undated atoms; the sinceEpoch fallback converts the wire's milliseconds", () => {
+  assert.equal(lastActivity({ events: [{ kind: "assistant", ts: iso(T0 - 10) }, { kind: "tool" }], status: { state: "working", sinceEpoch: ms(T0 - 99) } }), T0 - 10);
+  assert.equal(lastActivity({ events: [{ kind: "postal-service", t: T0 - 5.7 }] }), T0 - 6, "a postal card carries its own epoch");
+  assert.equal(lastActivity({ events: [{ kind: "tool", ts: "not a date" }], status: { state: "ready", sinceEpoch: ms(T0 - 1) } }), T0 - 1);
+  assert.equal(lastActivity({ events: [], status: { state: "ready", sinceEpoch: null } }), null);
+  // a just-created session (events: [], sinceEpoch: Date.now() in ms) 90 s ago must read as 90 s, not as a time far in the future
+  const nowS = 1788723633;
+  const t = lastActivity({ events: [], status: { state: "opening", sinceEpoch: ms(nowS - 90) } });
+  assert.equal(t, nowS - 90); assert.equal(nowS - t!, 90, "an age of 90 s, in the unit the renderer subtracts");
+  assert.equal(lastActivity({ events: [], status: { state: "ready", sinceEpoch: ms(T0) + 999 } }), T0, "sub-second ms floor to the second");
+});
+
+test("executed: lastMessage takes the newest assistant text as PLAIN words on one line, markdown markers and fences stripped as the file viewer strips them", () => {
+  assert.equal(lastMessage({ events: [{ kind: "assistant", md: "first" }, { kind: "user", md: "q" }, { kind: "assistant", md: "  second   line \n two " }, { kind: "tool" }] }), "second line two");
+  assert.equal(lastMessage({ events: [{ kind: "assistant", md: "" }] }), "");
+  assert.equal(lastMessage({ events: [{ kind: "assistant", md: "**Done.** See `ui/x.ts`:\n```ts\nconst a = 1;\n```\nand [the guide](docs/guide.md)." }] }),
+    "Done. See ui/x.ts: const a = 1; and the guide.", "no ** or backticks, no fence line, a link keeps its label");
+  assert.equal(plainText("# Heading\n- item *one*\n> quoted ~~gone~~\n1. step", 400), "Heading item one quoted gone step", "block markers go line by line");
+  assert.equal(plainText("~~~\ncode\n~~~\nafter", 400), "code after", "tilde fences too: the fence lines go, the fenced body's words stay");
+  assert.equal(plainText("x".repeat(500), 400).length, 400, "capped");
+  assert.equal(lastMessage({ events: [{ kind: "assistant", text: "plain `text` field" }] }), "plain text field", "the text field when there is no md");
+});
+
+test("executed: plainText drops inline HTML and underscore emphasis too: the transcript renders them as structure, a tooltip would show them as typed", () => {
+  assert.equal(plainText("<b>x</b>", 400), "x");
+  assert.equal(plainText("_x_", 400), "x");
+  assert.equal(plainText("<details><summary>Test output</summary>\n12 passed\n</details>", 400), "Test output 12 passed", "the common reply shape: tags go, words stay");
+  assert.equal(plainText("<b>bold</b> and <a href='x'>l</a> &amp; <br>", 400), "bold and l &", "tags of every kind, an entity decoded once the tags are gone");
+  assert.equal(plainText("__Done__ _emph_ and snake_case __strong__", 400), "Done emph and snake_case strong", "emphasis at word edges goes; snake_case keeps its underscores, as in the file viewer");
+  assert.equal(plainText("a < b and c > d", 400), "a < b and c > d", "a bare comparison is not a tag");
+  assert.equal(plainText("say &lt;b&gt; &quot;hi&quot; it&#39;s x&nbsp;y", 400), 'say <b> "hi" it\'s x y', "escaped text stays text: decoded after the tag pass, so a typed <b> is not stripped");
+  assert.equal(plainText("before <!-- a note\nfor no one --> after", 400), "before after", "an HTML comment goes whole, across lines");
+  assert.equal(plainText("line<br>next<br/>last", 400), "line next last", "a break is a space, not a joined word");
+});
+
+test("executed: a push that changes nothing a row shows returns the SAME model object: the no-rebuild contract", () => {
+  const a = snapshotModel(sec, look(sessions), look(ledgers), null);
+  // a fresh frame: new session objects, new arrays, the same content (the client rebuilds them per push)
+  const clone = new Map<string, SnapSessionLike>([...sessions].map(([k, v]) => [k, JSON.parse(JSON.stringify(v))]));
+  const b = snapshotModel(sec, look(clone), look(ledgers), a);
+  assert.equal(b, a, "same object: the renderer skips the rebuild (only the ago texts tick)");
+  assert.equal(snapshotModel({ ...sec, ids: [...sec.ids] }, look(clone), look(ledgers), a), a, "a fresh section object, the same content: the same model");
+  // a status the row does not show (sinceEpoch when the tail has events) changes nothing
+  const noisy = new Map(clone); noisy.set("web", { ...clone.get("web")!, status: { state: "working", sinceEpoch: T0 - 1 } });
+  assert.equal(snapshotModel(sec, look(noisy), look(ledgers), a), a, "a flapping input the row never reads cannot move it");
+  assert.ok(sameModel(a, a) && !sameModel(null, a));
+});
+
+test("executed: new information yields a NEW model: a state change, a new event, a note, a member, a rename, a color, the feed's verdict", () => {
+  const a = snapshotModel(sec, look(sessions), look(ledgers), null);
+  const with_ = (id: string, patch: Partial<SnapSessionLike>) => { const m = new Map(sessions); m.set(id, { ...sessions.get(id)!, ...patch }); return m; };
+  assert.notEqual(snapshotModel(sec, look(with_("web", { status: { state: "ready" } })), look(ledgers), a), a, "state");
+  assert.notEqual(snapshotModel(sec, look(with_("web", { events: [...sessions.get("web")!.events!, { kind: "assistant", md: "Done.", ts: iso(T0) }] })), look(ledgers), a), a, "a new event (time and last message)");
+  assert.notEqual(snapshotModel(sec, look(with_("web", { name: "web2" })), look(ledgers), a), a, "a rename");
+  const l2 = new Map(ledgers); l2.set("web", { ...ledgers.get("web")!, workingNote: "reviewing the tests" });
+  assert.notEqual(snapshotModel(sec, look(sessions), look(l2), a), a, "the working note");
+  const l3 = new Map(ledgers); l3.set("web", { ...ledgers.get("web")!, needsInput: true });
+  assert.notEqual(snapshotModel(sec, look(sessions), look(l3), a), a, "the feed's needs-you verdict");
+  const l4 = new Map(ledgers); l4.set("api", { ...ledgers.get("api")!, needsInput: false });
+  assert.equal(snapshotModel(sec, look(sessions), look(l4), a), a, "not when the tab's own live prompt already flags the row: nothing shown changed");
+  assert.notEqual(snapshotModel({ ...sec, ids: ["web", "api"] }, look(sessions), look(ledgers), a), a, "a member gone");
+  assert.notEqual(snapshotModel({ ...sec, name: "infra2" }, look(sessions), look(ledgers), a), a, "the section itself");
+  assert.notEqual(snapshotModel(sec, look(with_("web", { color: { bg: "#000000", fg: "#ffffff" } })), look(ledgers), a), a, "the identity color");
+});
+
+test("executed: the words: the heading's count and label, the row's spoken label and hover title", () => {
+  assert.deepEqual(snapshotHeading("infra", 3), { count: "3 sessions", label: "infra: 3 sessions; click one to open it" });
+  assert.equal(snapshotHeading("qa", 1).count, "1 session");
+  const m = snapshotModel(sec, look(sessions), look(ledgers), null);
+  assert.equal(rowWords(m.rows[0]).label, "web; working; Add the notes list page; its note: editing the list page template", "the task first, the note last, named as the session's own");
+  assert.equal(rowWords(m.rows[0]).title, "Last message: Adding the list page now: the route and the template.\nClick to open this session.");
+  assert.equal(rowWords(m.rows[1]).label, "api; needs you: waiting on your answer; Pick a database");
+  assert.equal(rowWords(m.rows[2]).title, "No messages yet.\nClick to open this session.");
+});

--- a/ui/webview/tab-snapshot.ts
+++ b/ui/webview/tab-snapshot.ts
@@ -1,0 +1,249 @@
+// A SECTION AT A GLANCE: the pane the transcript normally fills shows one compact row per session in a
+// tab-strip section (name, state pip, what it is doing now in the user's terms, when it last did anything,
+// and whether it needs the user), so a group can be surveyed at a glance and any of its sessions opened
+// from there. It shows when a section header is clicked (which also folds or opens the section) and stays
+// until a session is picked; a section holding the tab being read folds like any other, its header
+// standing in for the hidden tab (tab-groups.ts planStrip).
+//
+// PURE: the model is a function from what the chat client already holds per session (the session frame:
+// name, color, status, the events tail; and its ledger: the same summary / current task / recent tops the
+// tab hover tip renders, plus two fields the kernel puts on the ledger for this view: the postal working
+// note, and whether the feed files one of the session's cards under needs-you) to plain rows, with NO
+// clock in it: the last-activity time is an epoch the renderer formats, so a push that changed nothing
+// yields the SAME object (snapshotModel returns `prev`) and the renderer rebuilds nothing. render.ts
+// paints it; the shapes below are the minimal "Like" views of render.ts's types (the tab-state.ts idiom),
+// so the rule runs in node tests without a DOM.
+import { tabStateClass, type TabStateLike } from "./tab-state";
+import { stripInline } from "./docreview";
+
+export interface SnapStatusLike extends TabStateLike { sinceEpoch?: number | null }
+export interface SnapEventLike { kind?: string; md?: string; text?: string; ts?: string; t?: number }
+export interface SnapColor { bg: string; fg: string }
+export interface SnapSessionLike {
+  name?: string; color?: SnapColor | null; status?: SnapStatusLike | null;
+  events?: ReadonlyArray<SnapEventLike> | null;
+}
+export interface SnapLedgerLike {
+  summary?: string | null; workingNote?: string | null;
+  /** the feed's verdict, from the kernel's last feed build: true when one of this session's cards is filed
+   *  under needs-you there (the column the feed's Blocked list is), false when none is, null when no feed
+   *  has been built since the kernel started (the first push cycle) */
+  needsInput?: boolean | null;
+  tree?: ReadonlyArray<{ text?: string; current?: boolean }> | null;
+  recent?: ReadonlyArray<{ text?: string; t?: number }> | null;
+}
+export interface SnapSectionLike { name: string | null; color: string; ids: readonly string[] }
+/** The strip's meta for a tab whose session frame has not landed (render.ts tabMeta): its name and color alone. */
+export interface SnapMetaLike { name?: string; color?: SnapColor | null }
+
+/** The pip a row wears: the tab's own colors by the tab's own rule (tab-state.ts), plus the two states the
+ *  strip paints on the chip rather than the tab: `waiting` (idle, but background work it dispatched is
+ *  still running) and `unknown` (no session frame yet). An idle or ready session wears none. */
+export type SnapPip = "working" | "blocked" | "awaiting" | "retrying" | "compacting" | "waiting" | "unknown" | "";
+
+export interface SnapRow {
+  id: string;
+  name: string;
+  color: SnapColor | null;
+  pip: SnapPip;
+  /** the state in words: the row's spoken label and its title; "" for idle/ready */
+  state: string;
+  /** on YOU, by the feed's rule: a card of this session filed under needs-you in the kernel's last feed
+   *  build (the same column the feed's Blocked list shows: a question the agent asked and stopped on, a
+   *  live prompt, an API error only you can clear); plus the tab's own alarm-red cases, which the feed
+   *  build can trail by one push */
+  needsYou: boolean;
+  /** waiting on something that is not you: dispatched background work */
+  waiting: boolean;
+  /** what it is doing now, in the user's terms: the judges' current task, else the archiver's headline,
+   *  else the most recent top task; "" when nothing is known */
+  now: string;
+  /** the session's own note of what it is working on (the postal working note: its claim to a branch and
+   *  files, written for peer sessions), one line; "" when it has published none. A quieter second line of
+   *  the row, under the now line, never in its place. */
+  note: string;
+  /** when it last did anything (epoch s): the newest event in the tail, else the state's start */
+  lastT: number | null;
+  /** the last assistant message, for the hover */
+  lastMsg: string;
+  closed: boolean;
+  /** no session frame yet (a placeholder tab): name and color from the strip's meta alone */
+  loading: boolean;
+}
+
+export interface SnapModel { name: string; color: string; rows: SnapRow[] }
+
+const NOW_MAX = 200;      // the now line: one row, the CSS ellipsis does the rest; the cap bounds the model
+const MSG_MAX = 400;      // the hover excerpt
+
+const oneLine = (s: unknown, max: number): string => {
+  const t = String(s ?? "").replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+};
+
+function eventEpoch(ev: SnapEventLike): number | null {
+  if (ev.ts) { const ms = Date.parse(ev.ts); if (!isNaN(ms)) return Math.floor(ms / 1000); }
+  if (ev.kind === "postal-service" && ev.t != null) return Math.floor(ev.t);
+  return null;
+}
+
+/** THE now line, in the user's terms: the judges' current task, then the archiver's headline, then the
+ *  most recent top task. The working note is NOT a rung here: it is the session's claim to a branch and
+ *  files, written for peer sessions, so it rides the row as its own line (noteLine) and never stands in
+ *  for what the session is accomplishing. */
+export function nowLine(lg: SnapLedgerLike | null | undefined): string {
+  if (!lg) return "";
+  const cur = (lg.tree || []).find((n) => n.current && oneLine(n.text, NOW_MAX));
+  if (cur) return oneLine(cur.text, NOW_MAX);
+  if (lg.summary && oneLine(lg.summary, NOW_MAX)) return oneLine(lg.summary, NOW_MAX);
+  const r = (lg.recent || []).find((x) => oneLine(x.text, NOW_MAX));
+  return r ? oneLine(r.text, NOW_MAX) : "";
+}
+
+/** The row's second line: the postal working note, one line, "" when none. */
+export function noteLine(lg: SnapLedgerLike | null | undefined): string {
+  return lg ? oneLine(lg.workingNote, NOW_MAX) : "";
+}
+
+/** The newest event's time, else the state's start. The tail is in transcript order, so the walk is
+ *  from the end; an event with no time (a live-stream atom) is skipped, not zero. sinceEpoch is in
+ *  MILLISECONDS everywhere (the kernel's since_ms, the client's own Date.now() placeholders), while the
+ *  row's lastT is epoch SECONDS like the event times: passed through unconverted it would read as a time
+ *  far in the future and every empty-tail row would say "0s ago". */
+export function lastActivity(s: SnapSessionLike): number | null {
+  const evs = s.events || [];
+  for (let i = evs.length - 1; i >= 0; i--) { const t = eventEpoch(evs[i]); if (t) return t; }
+  return s.status?.sinceEpoch ? Math.floor(s.status.sinceEpoch / 1000) : null;
+}
+
+const ENTITIES: Record<string, string> = { amp: "&", lt: "<", gt: ">", quot: '"', "#39": "'", apos: "'", nbsp: " " };
+
+/** A markdown message as plain words on one line, for a title attribute (a native tooltip renders text,
+ *  so the source's markers would show as typed): HTML comments go whole, fence lines go, each remaining
+ *  line loses its block and inline markers (docreview.ts stripInline, the file viewer's rule), the lines
+ *  join with spaces, and the join loses what the viewer keeps on purpose and the transcript never shows
+ *  as typed: HTML tags (the chat renders a reply through marked and DOMPurify, so <details>, <summary>,
+ *  <br>, <b> paint as structure, never as text; each becomes a space), the entities that stand for a
+ *  character once the tags are gone (&amp; &lt; &gt; &quot; &#39; &nbsp;), and underscore emphasis at
+ *  word edges (_x_, __x__). snake_case keeps its underscores, as in the viewer; code spans are not
+ *  parsed, so a tag typed inside backticks goes with the rest. */
+export function plainText(md: string, max: number): string {
+  const lines = md.replace(/<!--[\s\S]*?-->/g, " ").replace(/\r\n?/g, "\n").split("\n").filter((l) => !/^\s*(```|~~~)/.test(l));
+  const joined = lines.map(stripInline).join(" ")
+    .replace(/<\/?[A-Za-z][^<>]*>/g, " ")
+    .replace(/&(amp|lt|gt|quot|#39|apos|nbsp);/g, (_, e: string) => ENTITIES[e])
+    .replace(/(^|[^\w])_{1,2}([^_\s](?:[^_]*?[^_\s])?)_{1,2}(?=[^\w]|$)/g, "$1$2");
+  return oneLine(joined, max);
+}
+
+/** The last assistant message in the tail, one line of plain text, for the hover. */
+export function lastMessage(s: SnapSessionLike): string {
+  const evs = s.events || [];
+  for (let i = evs.length - 1; i >= 0; i--) {
+    const e = evs[i];
+    if (e.kind === "assistant") { const t = plainText(String(e.md ?? e.text ?? ""), MSG_MAX); if (t) return t; }
+  }
+  return "";
+}
+
+/** The pip and the state word for a status: the tab's rule for the colors, the statusline's words. */
+export function rowState(st: SnapStatusLike | null | undefined): { pip: SnapPip; state: string; needsYou: boolean; waiting: boolean; closed: boolean } {
+  if (!st) return { pip: "unknown", state: "", needsYou: false, waiting: false, closed: false };
+  const cls = tabStateClass(st);
+  const s = st.state || "";
+  if (cls === "tab-blocked") return { pip: "blocked", state: "needs you: stopped on an API error", needsYou: true, waiting: false, closed: false };
+  if (cls === "tab-awaiting") return { pip: "awaiting", state: "needs you: waiting on your answer", needsYou: true, waiting: false, closed: false };
+  if (cls === "tab-retrying") return { pip: "retrying", state: "API error, retrying on its own", needsYou: false, waiting: false, closed: false };
+  if (cls === "tab-compacting") return { pip: "compacting", state: s === "clearing" ? "clearing" : "compacting", needsYou: false, waiting: false, closed: false };
+  if (cls === "tab-closed") return { pip: "", state: "closed", needsYou: false, waiting: false, closed: true };
+  if (cls === "tab-working") return { pip: "working", state: "working", needsYou: false, waiting: false, closed: false };
+  if (s === "awaitingBg") return { pip: "waiting", state: "waiting on background work", needsYou: false, waiting: true, closed: false };
+  if (s === "interrupting") return { pip: "", state: "interrupting", needsYou: false, waiting: false, closed: false };
+  if (s === "opening") return { pip: "unknown", state: "opening", needsYou: false, waiting: false, closed: false };
+  return { pip: "", state: "", needsYou: false, waiting: false, closed: false };
+}
+
+/** The state word for a session the feed files under needs-you while the tab's own rule sees nothing (an
+ *  idle session that asked a question and stopped, the common case): the feed's own word for that column,
+ *  and nothing more. The column also holds cards that stop nothing (a peer's held message waiting for your
+ *  approval), so a claim like "stopped until you answer" would be false for some rows the word reaches;
+ *  "needs you" is true of every card there. */
+export const FEED_BLOCK_STATE = "needs you";
+
+/** A member's name as its tab shows it; "(unnamed)" for a blank one (the tab-state.ts rule). */
+const memberName = (s: { name?: string } | null | undefined): string => String(s?.name || "").trim() || "(unnamed)";
+
+/** One row. `s` is the session frame (null for a placeholder tab, whose frame has not landed); `meta` the
+ *  strip's meta for it (name and color), read only when the frame is absent, so a loading row still wears
+ *  the tab's name and color. */
+export function snapshotRow(id: string, s: SnapSessionLike | null | undefined, lg: SnapLedgerLike | null | undefined,
+                            meta?: SnapMetaLike | null): SnapRow {
+  const st = rowState(s?.status);
+  const src: SnapMetaLike | null | undefined = s ?? meta;
+  // NEEDS YOU is the feed's call: the tab's rule (tab-state.ts) knows only the live states the chip carries
+  // (a permission or picker prompt, an on-you API error), so a judge-filed block on a session that went idle
+  // after asking would show a plain idle row here while the feed shows a red card. lg.needsInput is that
+  // column, per session, from the kernel's last feed build (build_session); the tab's own cases stay as a
+  // floor because the feed build trails the chip by one push.
+  const feedBlock = lg?.needsInput === true;
+  return {
+    id,
+    name: memberName(src),
+    color: src?.color && src.color.bg && src.color.fg ? { bg: src.color.bg, fg: src.color.fg } : null,
+    pip: s ? st.pip : "unknown",
+    state: st.state || (feedBlock && !st.closed ? FEED_BLOCK_STATE : ""),
+    needsYou: feedBlock || st.needsYou,
+    waiting: st.waiting,
+    now: nowLine(lg),
+    note: noteLine(lg),
+    lastT: s ? lastActivity(s) : null,
+    lastMsg: s ? lastMessage(s) : "",
+    closed: st.closed,
+    loading: !s,
+  };
+}
+
+const sameRow = (a: SnapRow, b: SnapRow): boolean =>
+  a.id === b.id && a.name === b.name && a.pip === b.pip && a.state === b.state
+  && a.needsYou === b.needsYou && a.waiting === b.waiting && a.now === b.now && a.note === b.note
+  && a.lastT === b.lastT && a.lastMsg === b.lastMsg && a.closed === b.closed && a.loading === b.loading
+  && (a.color === b.color || (!!a.color && !!b.color && a.color.bg === b.color.bg && a.color.fg === b.color.fg));
+
+export function sameModel(a: SnapModel | null | undefined, b: SnapModel): boolean {
+  return !!a && a.name === b.name && a.color === b.color && a.rows.length === b.rows.length
+    && a.rows.every((r, i) => sameRow(r, b.rows[i]));
+}
+
+/** The rows of one section: one per member in strip order. `session`/`ledger`/`meta` look up what the
+ *  client holds (a null session = a placeholder tab, whose row takes its name and color from `meta`).
+ *  Returns `prev` ITSELF when nothing a row shows has changed, so the caller can skip the rebuild (the
+ *  same-object contract the tests pin). */
+export function snapshotModel(sec: SnapSectionLike, session: (id: string) => SnapSessionLike | null | undefined,
+                              ledger: (id: string) => SnapLedgerLike | null | undefined, prev: SnapModel | null,
+                              meta?: (id: string) => SnapMetaLike | null | undefined): SnapModel {
+  const next: SnapModel = { name: sec.name ?? "", color: sec.color || "",
+                            rows: sec.ids.map((id) => snapshotRow(id, session(id), ledger(id), meta ? meta(id) : null)) };
+  return prev && sameModel(prev, next) ? prev : next;
+}
+
+/** The heading's words: the section's name and its count, and the spoken label for the region. */
+export function snapshotHeading(name: string, n: number): { count: string; label: string } {
+  const count = `${n} session${n === 1 ? "" : "s"}`;
+  return { count, label: `${name}: ${count}; click one to open it` };
+}
+
+/** A row's spoken label (name, needs you, state, what it is doing, its own note) and its hover title.
+ *  NEEDS YOU is spoken whenever the row wears it: the tab's own state words carry it in their text; every
+ *  other state word (working, closed, compacting) gets the word in front of it, where the painted chip sits
+ *  beside the pip. The button's aria-label replaces its content for a reader, so a word only the chip
+ *  carried would never be spoken. */
+export function rowWords(r: SnapRow): { label: string; title: string } {
+  const parts = [r.name];
+  const stateWord = r.loading ? "opening" : r.state;
+  if (r.needsYou && !stateWord.startsWith(FEED_BLOCK_STATE)) parts.push(FEED_BLOCK_STATE);
+  if (stateWord) parts.push(stateWord);
+  if (r.now) parts.push(r.now);
+  if (r.note) parts.push(`its note: ${r.note}`);
+  const title = (r.lastMsg ? `Last message: ${r.lastMsg}` : r.loading ? "opening…" : "No messages yet.") + "\nClick to open this session.";
+  return { label: parts.join("; "), title };
+}

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -101,6 +101,11 @@ function lift(): (hooks: Hooks) => Api {
     const auditTabOrder = () => {}; const onlyTag = () => H.only; const matchesOnly = (name, only) => name.includes(only);
     const tabInView = (id) => id === peekId || !H.hidden.has(id);
     const setActive = () => {}; const setTimeout = () => 0;
+    // the section-at-a-glance view's readers on the strip, inert: the plan the view reads (lastStripItems), the
+    // section the pane shows (snapView, null: no view open, so stripAftermath's follow does nothing), and the
+    // view's own painter and focus probe (never reached while snapView is null)
+    let lastStripItems = [], snapView = null;
+    const renderSnapshot = () => false; const snapshotHoldsFocus = () => false; const showActive = () => {};
     const titleWithKey = () => H.keyHint; const surfaceLens = () => H.lens; const effViews = () => null; const viewTagUnion = () => H.unions;
     const hostIsDown = (id) => H.down.has(id); const hostDownNote = (id) => H.notes[id] ?? "";
     function makePlaceholderTab(id) { const t = el("div", "tab tab-placeholder"); t.dataset.id = id; H.placeholders++; return t; }

--- a/ui/webview/tab-strip-skip.test.ts
+++ b/ui/webview/tab-strip-skip.test.ts
@@ -47,6 +47,7 @@ test("every input the strip renders is in the signature", () => {
     "activeId", "peekId", "ids", "visibleIds", "tabInView(activeId)", "plan.items",
     "settings.tabCtx", "settings.stripGroupRows", "settings.theme", "settings.colormap", 'titleWithKey("Open a session", "session.new")',
     'surfaceLens(effViews(), "chat")', "unions",
+    "snapView",   // the section the pane shows at a glance: a header's mark, its way-back act and its words derive from it
     "m?.name", "m?.color?.bg", "m?.color?.fg",
     "s.name", "s.color?.bg", "s.color?.fg", "st.state", "tabStateClass(st)", "!!st.faded",
     "st.ctx", "st.ctxColor", "st.ctxTone", "!!s.sub", "hostIsDown(id)", "hostDownNote(id)",

--- a/vscode-extension/src/chat-focus-model.test.ts
+++ b/vscode-extension/src/chat-focus-model.test.ts
@@ -43,7 +43,7 @@ test("Enter from the bare chat area (no focused control) drops into the message 
   // gated on activeElement === body so it never steals Enter from a control/tab/the live-ask card, and it
   // hooks no clicks → highlighting + expanding folds are unaffected
   const i = SRC.indexOf('window.addEventListener("keydown"', SRC.indexOf("NAV_SCROLL_STEP"));
-  const block = SRC.slice(i, i + 2800);   // the tail grew a hold line (T236: the hand-over note stands the default down)
+  const block = SRC.slice(i, i + 3600);   // the tail grew a hold line (T236: the hand-over note stands the default down) and the arrows' folded-away branch (the header as the active tab's stand-in)
   assert.match(block, /e\.key === "Enter"/);
   assert.match(block, /const ae = document\.activeElement;\s*if \(ae && ae !== document\.body\) return;/);
   assert.match(block, /if \(focusComposerOrAsk\(\)\) e\.preventDefault\(\);/);


### PR DESCRIPTION
The section of the tab you are reading folds like any other (its header stands in for the tab), and a header click shows the section's sessions at a glance in the transcript's place.

## What changes for a user

- Every tab-strip section folds, the one holding the tab you are reading too. Until now planStrip forced that section open whatever the store said, and its header carried a no-op click: "click to fold this group" did nothing visible, on every click. A fold stored while another tab was active took effect when the user switched back. The header of the section holding the tab you are reading is marked whether open or folded (the tag's chip is accent-underlined and the header carries `aria-current`); folded, that header is the hidden tab's stand-in: focus lands on it, the left and right arrows step from its place (wrapping over the tabs on screen), Enter drops into the message box while it takes input and presses the header otherwise.
- A header click also shows the section at a glance: one row per session with its color, a state dot by the tab's own rule, a "needs you" or "waiting" word, what it is doing now, when it last did anything, its working note as a quieter second line, and its last message on hover. A row opens its session (and opens its folded section, so the tab is on screen). The way back: pick a session, press Escape, or click that header again while its section is open and holds the tab you are reading. The back/forward trail (Ctrl+M, Ctrl+,) records the line you were reading when a pick leaves the view, not the list's scroll.
- A session under several tags keeps one stand-in: the holder showing a copy (open, or folded with the copy pinned through the fold), else the first holder in tag order; with several folded holders only the marked header answers as the tab, so what you see marked is what the keys act on. Activating a folded-away session opens no section any more (the T264b rule that forced the first holder open is removed); a pick of a folded-away tab opens its first folded holder instead.

## Design points

1. **The header click both folds and shows the section.** One gesture: the user looks at the group they just folded or opened, and the fold is the same click it always was. If a fold-only header with a separate control for the view is preferred, the swap is two lines in the `toggle-group` handler (`snapView = name`, and the `showActive()` after the fold write) plus the `show-transcript` act and its words, so moving it onto a glyph is a small change, not a redesign. The first click on an open section that holds the tab being read folds it and shows the view; the next click opens it (view stays); the click after that is the way back.
2. **The view is page state, never stored.** `snapView` behaves like the peek: a header click sets it, a session pick clears it, Escape and the header's second click leave it. Nothing is written to the tab-groups store for it; the fold write is the one it always was.
3. **The rows are a pure model with no clock in it** (`ui/webview/tab-snapshot.ts`). `snapshotModel` returns the same object when nothing a row shows changed, so a push that changed nothing only re-texts the ages and the row's nodes stand; when rows change they are reconciled by session id (`reconcileRows`), so the button a keyboard user is on and a hover's title survive the push. The rows move only on new information.
4. **Escape yields to every layer that owns its own Escape**, in two phases on the window (`installSnapshotEscape`): armed at capture (menus, the picker and confirm overlays, the pane's own panels, the full-pane surfaces, a typing target), decided at bubble after the shell's chain on this frame's document has marked and stopped an Escape aimed at one of its panels (the log, usage and network panels live in the shell document, out of this page's sight; `_LANDING_ESC_JS` sets `defaultPrevented` on a consumed Escape). The tab menu's closer now marks the Escape it consumed for the same reason.
5. **Click safety.** The rows live on one stable host with one delegate; a press on a row latches the strip's `tabPointerHeld` so no rebuild lands between mousedown and mouseup, and a row whose session left the strip mid-press opens nothing (`rowStillOpen`).
6. **The kernel puts two fields on the ledger the chat already receives**, no new frame: `workingNote` (the postal set_working note; kept for a muted session, since it is the session's own statement, not a goal the judges track) and `needsInput` (the feed's per-session needs-you verdict from the last feed build; `None` before the first). The row's "needs you" follows the feed's Blocked column, which the tab's chip rule misses for the common case (a session that asked a question and went idle). Both join the chat build signature as components: `note` (the working-note file by identity) and `needs` (the verdict as a boolean, so the first feed build's `None` to `False` flip rebuilds no tab); `docs/reference.md`'s list of the signature's components gains the two. `needsInput` trails the feed by one push (the feed builds after the chat sessions); the `needs` component brings the change forward on the next push.
7. **The reader's place is held across the view.** The view's host is a child of `#content`, so while it shows the pane's scroll is the list's; `snapKeep` captures the active view's spot once when the view goes up, writes it back on every exit, and the nav trail's `now()` reads it while it stands, so neither the transcript nor the trail lands on the list's offset.
8. **Deliberately left out:** nothing on the rows beyond what the client already holds (no emoji, no todo count), no hide/show of members from the view, and no separate control for the view (design point 1).

## Tests

Executing tests, each red before the change:

- `ui/webview/tab-groups.test.ts`: the planStrip case with the active id inside the default-folded `archived` section now expects `folded: true, active: true, hidden: ["old1"]` and `folded` = `["old1"]` (failed on the forced-open holder); `homeSectionOf` and `neighborOfFolded` executed (missing exports); the header words with `back`/`shown`; the T264b multi-holder case with nothing springing open. The pins of the old rule (`group-active`, `role="group"`, the `holds-active` cursor rule, "stays open") are re-derived. 63 pass.
- `ui/webview/tab-snapshot.test.ts` (13, new): the model's rows in strip order, the now line's precedence, needs-you from the feed's bit on an idle session, the placeholder row from the strip's meta, `lastActivity`'s ms to s fallback, `plainText`, the same-object contract and what breaks it, the words.
- `ui/webview/tab-snapshot-view.test.ts` (5, new): `rowStillOpen`, the two-phase Escape yielding to the shell's chain, a marked capture listener and a typing target, `reconcileRows` keeping a patched node.
- `ui/webview/tab-snapshot-pane.test.ts` (14, new): the pane block, the strip's key handlers, `makeGroupHead`, the `#tabs` delegate's two header acts and the nav trail's deps lifted out of render.ts (esbuild at run time, the exec-test pattern) and run over a fake DOM: the paint; a no-change push ticking only the ages with the row's part nodes standing (a rebuild that happened to keep the rows would fail it); a changed row keeping its node; focus across a moved or removed row; the section gone ending the view and writing the reading spot back; the exits; the Escape phases; a row click gated on the session still being on the strip; the stand-in header's focus, arrows (focus following), Enter (the message box while it takes input, the header's press otherwise) and Space, with an unmarked second holder and a plain header left as plain buttons (deleting the arrows block, the Enter line or the marked-holder gate each fails it); the header click's fold and view, the folded header's open, the open shown header's way back with no fold write, a click on another header swapping the view (deleting `snapView = name` or the `show-transcript` act fails it); the trail's `now()` returning the held spot under the view (reverting it to `#content`'s scroll fails it); `unfoldSectionOf` per holder. The wiring the slices cannot reach (showActive's branch, setActive, the strip's follow, the sheet, the guide) is pinned.
- `ui/webview/tab-strip-skip-exec.test.ts` and `tab-strip-skip.test.ts`: the executing prelude declares `lastStripItems` and `snapView`; the signature's needle list gains `snapView`. `peek-tab.test.ts`, `vscode-extension/src/chat-focus-model.test.ts` and `skeleton-tabs-wiring.test.ts` re-pinned for the grown setActive early return, the window's arrow branch and showActive's new branch (the lifted showActive needs the view's variables declared).
- `tests/test_kernel.py` ViewBuilder: `test_ledger_carries_the_working_note` (KeyError before), `test_muted_session_keeps_its_working_note`, `test_ledger_carries_the_feed_needs_you_verdict` (AttributeError before: the fixture's judge-filed block on an idle session reads `True`, the judges ruling it answered reads `False`, a muted session `False`; its goal store and override journal live under the fixture's own temp root).
- `tests/test_chat_build_sig_inputs.py`: the census gains `Sessions.working_note` under `note` and `_feed_needs_input_of` under `needs` (red: an unclassified read, and a label the signature had no component for); one differential case per component (the note write misses under `note` alone and its clear restores the signature; the verdict misses under `needs` only as `True` for this session).

Runs on this head: `npm run typecheck` clean; the full `npm test` 4106 pass, 0 fail (main leg) plus the timeline-tags-scale file run alone, 22 pass, 0 fail; the full `pytest -n 6 tests/` 11144 passed, 41 skipped, 1707 subtests passed, exit 0.

Rebased onto main at 54baf25e by the maintainer on 2026-09-10 (the same patch, replayed). An independent replay of the same commit onto 3815ed6f matched it commit for commit (range-diff equal); on that replay `npm run typecheck` is clean, the full `npm test` passes (4159 in the main run plus 22 in the tags-scale file run alone), and the full pytest passes 11322 with one failure in tests/test_notification_tap_resume_browser.py, the served-tap browser test, which fails the same way on plain main on the machine that ran it and is skipped on CI; this change touches nothing it reads.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

