### PR TITLE
Restart audit: a live quiet park survives an aged verdict or note, a stray SIGTERM does not consume it, and the manager's never-throws test runs its catch

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1759,7 +1759,10 @@ read. A row with no action (the `romp refresh` row) is skipped, and the
 manager's `restart-all` note written after it is what names the refresh; a
 `romp refresh --quiet` row is the parked deploy that holds the automatic
 converge until the window opens, and the note written at the window names its
-delivery the same way.
+delivery the same way. A SIGTERM that reaches a kernel with a quiet-window
+request parked and no manager note for its pid (a note naming no pid counts as
+its own) is not that request's delivery: the kernel files a `signal` row and
+leaves the request on record for the kernel the window will restart.
 
 When no row qualifies, the kernel writes a row with action `signal`: the signal
 name, its pid and its parent's pid, the manager pid it was started with,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1752,11 +1752,14 @@ request, and are passed over. The manager's `manager-sigterm` row is a note
 that the manager sent the signal, not a request: it answers only when no
 request row written before it lies within the window and this kernel's
 lifetime, with `manager-sigterm: <trigger>` as the reason, and a note aimed at
-another kernel's pid is ignored. A row with no action (the `romp refresh` row)
-is skipped, and the manager's `restart-all` note written after it is what
-names the refresh; a `romp refresh --quiet` row is the parked deploy that
-holds the automatic converge until the window opens, and the note written at
-the window names its delivery the same way.
+another kernel's pid is ignored. Verdicts and notes are passed over wherever
+they sit, an aged one included: one older than the window or older than this
+kernel never ends the walk, so a quiet-window request beneath it is still
+read. A row with no action (the `romp refresh` row) is skipped, and the
+manager's `restart-all` note written after it is what names the refresh; a
+`romp refresh --quiet` row is the parked deploy that holds the automatic
+converge until the window opens, and the note written at the window names its
+delivery the same way.
 
 When no row qualifies, the kernel writes a row with action `signal`: the signal
 name, its pid and its parent's pid, the manager pid it was started with,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21649,15 +21649,18 @@ def _audit_unrequested_signal(signum, pending=False, now=None, manager_stopped=F
 SIGNAL_MANAGER_NOTE_WAIT_S = 0.5   # how long an unexplained SIGTERM waits for the manager's own stop note
 
 
-def _manager_sigterm_row_for_us(now=None, window=90, started=None):
-    """Whether the audit tail holds a `manager-sigterm` STOP note aimed at THIS kernel (its `pid` is
-    ours, or it names none) within `window` seconds and not before this kernel's start (`started`; the
-    default is the process start, _STARTED, in whole seconds as the rows are): the manager's note that
-    it is stopping us, which is what _unrequested_signal_reason takes as the manager going down
-    alongside us. Only `reason: stop` counts. A `restart` note means the manager is alive and about to
-    respawn the kernel, and one landing during the drain of an unrelated signal (a stray kill, then the
-    rail's restart button) must not file that exit as a service stop with `managerStopped: true` while
-    the manager's own log shows a requested restart. The start bound is the one _recent_restart_audit
+def _manager_sigterm_row_for_us(now=None, window=90, started=None, reasons=("stop",)):
+    """Whether the audit tail holds a `manager-sigterm` note aimed at THIS kernel (its `pid` is ours, or
+    it names none) with a `reason` in `reasons`, within `window` seconds and not before this kernel's
+    start (`started`; the default is the process start, _STARTED, in whole seconds as the rows are).
+    With the default, only `reason: stop` counts: the manager's note that it is stopping us, which is
+    what _unrequested_signal_reason takes as the manager going down alongside us. A `restart` note means
+    the manager is alive and about to respawn the kernel, and one landing during the drain of an
+    unrelated signal (a stray kill, then the rail's restart button) must not file that exit as a service
+    stop with `managerStopped: true` while the manager's own log shows a requested restart. With
+    `reasons=("restart", "stop")` the question is whether the manager noted ANY kill of this kernel,
+    which is how _graceful_term tells the delivery of a parked quiet request from a signal nobody sent
+    through the manager. The start bound is the one _recent_restart_audit
     applies: the note this waits for lands AFTER our signal, so a stop note for our pid from before the
     process existed is a predecessor's, left behind when a reboot reused the pid (the machine back inside
     the window, the kernel up under the pid the previous one had, then a stray kill), and without the
@@ -21679,7 +21682,7 @@ def _manager_sigterm_row_for_us(now=None, window=90, started=None):
             continue
         if t0 - rec["t"] > window or rec["t"] < born:
             return False
-        if rec.get("pid") in (None, os.getpid()) and rec.get("reason") == "stop":
+        if rec.get("pid") in (None, os.getpid()) and rec.get("reason") in reasons:
             return True
     return False
 
@@ -21904,8 +21907,11 @@ def _recent_restart_audit(window=90, now=None, started=None):
         the deploy as the reason the service went down. The one exception is a `when: quiet` request: the
         manager parks it and restarts whatever kernel is running at the quiet window, so it outlives the
         kernel that filed it. With the manager's note for us on record the note answers (below); with none
-        (a manager build that wrote no notes) the parked row itself names the cut, unless a row above it
-        shows it delivered or dropped: a `manager-sigterm` note for a restart (every restart the manager
+        the parked row itself is returned, unless a row above it shows it delivered or dropped. That
+        no-note return serves the label and _parked_quiet_deploy, not consumption: _graceful_term
+        consumes a quiet row only when the manager noted a kill of this pid (its delivery), and files a
+        SIGTERM with a park on record and no such note as unrequested, the park untouched. Delivered or
+        dropped: a `manager-sigterm` note for a restart (every restart the manager
         sends clears the park in passing) or for the stop of this kernel or of every kernel (the manager's
         own shutdown takes the park down with it), a verdict that the manager was gone (`parent-gone`, or
         `signal` with `managerStopped`), or a cut row that already joined it (`auditT`: the restart it asked
@@ -53570,7 +53576,10 @@ def _graceful_term(signum, frame):
     mutation, and a cut turn keeps its 'working' state tail: the NEXT kernel's boot reconcile
     resumes exactly those. Bounded (~2s) so `romp refresh` stays snappy. Never construct the
     backend here: no SDK sessions were running if it doesn't exist. A second SIGTERM while the first
-    is draining returns at once (_EXIT_ONCE): the first finishes and exits."""
+    is draining returns at once (_EXIT_ONCE): the first finishes and exits. A parked quiet request on
+    record is consumed only when the manager noted a kill of this kernel (its `manager-sigterm` row for
+    this pid, or one naming none): the manager delivers the park, so a SIGTERM with no such note is not
+    its delivery, and the park stays on record for the kernel the quiet window will restart."""
     if not _EXIT_ONCE.acquire(blocking=False):
         return
     _TERMINATING[0] = True                          # the parent-watch stands down (see _parent_watch)
@@ -53582,6 +53591,17 @@ def _graceful_term(signum, frame):
     # this). A row that lands during the drain below did not send this signal. The row itself rides
     # along so the cut row can join it and consume it (auditT; see _recent_restart_audit).
     rec = _recent_restart_audit()
+    if isinstance(rec, dict) and rec.get("when") == "quiet" \
+            and not _manager_sigterm_row_for_us(reasons=("restart", "stop")):
+        # A parked quiet request is delivered by the manager, and the manager notes every kill it sends
+        # before sending it. With no note for this pid inside the window and this kernel's lifetime, this
+        # SIGTERM is not that delivery: the manager still holds the park for whatever kernel runs at the
+        # quiet window (a dynamic kernel or a stateDir-less aux shares this root and this park). Consuming
+        # the park here stamped its t as auditT, which hid it from every reader under the root
+        # (_consumed_audit_t), labeled a signal nobody asked for as the deploy, filed no `signal` row,
+        # and counted a stray kill as a deploy landing (_last_deploy_restart_t). So the pick is dropped
+        # and the exit takes the unrequested path below: a `signal` row, the unrequested reason, no auditT.
+        rec = None
     _drain_and_exit(_audit_reason_text(rec), signum=signum, what="SIGTERM", audit=rec)
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21698,7 +21698,11 @@ def _unrequested_signal_reason(signum, be=None, wait=None, sleep=time.sleep, now
     manager that wrote no note (one older than auditSigterm) can exit during it. A genuinely stray
     signal pays the wait and reads as unrequested; nothing here asserts who sent it. `started` bounds
     the note walk at this kernel's start (the process start by default; the tests pass their own, as
-    _recent_restart_reason's do)."""
+    _recent_restart_reason's do). The log line is best-effort, like the audit write: the kernel runs on
+    the manager's stdio, and a stream that is gone makes the write raise. It sits between filing the
+    `signal` row and the return, so an unguarded raise would hand _drain_and_exit its fallback, the plain
+    unrequested verdict, for a cut row whose `signal` row says the manager was stopped; guarded, the
+    reason returned is the one that row carries."""
     pending = False
     try:
         pending = bool(be.drain_holding()) if be is not None and hasattr(be, "drain_holding") else False
@@ -21909,7 +21913,13 @@ def _recent_restart_audit(window=90, now=None, started=None):
         kernel's pid settles nothing: POST /stop naming one kernel leaves the manager's park armed, and the
         row cannot be told from the stop that took every kernel down, so the park stays on record (the
         error to prefer: a held converge self-heals at the backstop bound, a released one cuts the turns
-        the quiet window was to spare);
+        the quiet window was to spare). Settled or not is decided by the rows above the park at ANY age:
+        verdicts and notes are classified before this bound and the window, so one older than either is
+        passed over (or settles the park) and never ends the walk with the park unread. A park this kernel
+        filed itself (its t at or after the start) is its own request whatever sits above it, inside the
+        window and past it alike: a note for this pid above it is the delivery of that very park, or the
+        stop of this kernel, which the rule above already reads as taking the park down, and the settled
+        rule reads predecessors' parks only;
       - a row with an action is a request and wins, unless a cut row already consumed it: spent on the
         cut it asked for, this cut is anonymous;
       - a `when: quiet` request is pending until the restart it asked for lands, up to the far manager's
@@ -21918,13 +21928,18 @@ def _recent_restart_audit(window=90, now=None, started=None):
       - the kernel's OWN verdict rows (EXIT_VERDICT_ACTIONS: `signal`, `parent-gone`) are never a request,
         whatever pid they carry. They have an action, so without the rule a SIGTERM reaching the next
         kernel within the window reads a predecessor's verdict as the request, copies it onto its own cut
-        row and writes no `signal` row of its own (two stray kills within 90 seconds, one row);
+        row and writes no `signal` row of its own (two stray kills within 90 seconds, one row). They and
+        the manager's notes are classified before the window and the start bound, wherever they sit: an
+        aged one is passed over, not the end of the walk, so a live quiet park beneath it is still read
+        (a `signal` verdict with the manager alive, or another kernel's single stop, that aged past 90 s
+        before the drift check read the park);
       - a `manager-sigterm` row (bin/romp-manager auditSigterm, written before every SIGTERM it sends) is
         a mechanism note, not a request: it says the manager was the messenger, and its `trigger` names
         what set it off (`restart`, `restart-all`, `refresh`, `stop`), so that is the label it answers
         with (a note without one falls back to its `reason`). It never outranks a request row beneath it
         within the window, answers only when no request is on record (a `romp-manager restart`, a service stop
-        that noted before it killed), and one aimed at another kernel pid is not about us;
+        that noted before it killed) and only from inside the window and this kernel's lifetime, and one
+        aimed at another kernel pid is not about us;
       - a row with no action is skipped, never taken as the answer. The CLI's `romp refresh` writes its
         caller-attribution row with no action field ({t, ppid, parent, sid, name, tty, tmux}), and taking
         that row's empty label as the verdict would file every deploy as an unrequested signal; the
@@ -21952,17 +21967,12 @@ def _recent_restart_audit(window=90, now=None, started=None):
             action = str(rec.get("action") or "")
             if action in _NO_RESTART_ACTIONS:
                 continue                                    # restarted no kernel; says nothing about this cut
-            quiet = rec.get("when") == "quiet"
-            win = max(window, RESTART_EXPECT_MAX_S) if quiet else window
-            if t0 - rec["t"] > win:
-                break                                       # older rows are older still
-            spent = bool(consumed) and rec["t"] == consumed  # a cut row already joined it (auditT)
-            if rec["t"] < born:
-                # a predecessor's row; only a parked quiet request survives the kernel that filed it
-                if quiet and action not in EXIT_VERDICT_ACTIONS + ("manager-sigterm",) \
-                        and not park_settled and not spent:
-                    return rec
-                break
+            # Rows that are never the answer are classified BEFORE the window and the start bound, wherever
+            # they sit: what a verdict or a manager note says about a parked quiet request beneath it holds
+            # at any age, and the walk has to reach that park. A live park is inside its own 20-minute
+            # window long after a row above it has aged past the 90 s one, or was filed before this kernel
+            # started; ending the walk at such a row read the park as nothing on record, for the cut row's
+            # reason and for the drift stand-down that reads the park through this walk.
             if action in EXIT_VERDICT_ACTIONS:
                 if action == "parent-gone" or (action == "signal" and rec.get("managerStopped")):
                     park_settled = True                     # the manager was gone, its park with it
@@ -21971,9 +21981,20 @@ def _recent_restart_audit(window=90, now=None, started=None):
                 ours = rec.get("pid") in (None, os.getpid())    # a note about THIS kernel (or one naming none)
                 if ours or rec.get("reason") != "stop" or rec.get("trigger", "stop") != "stop":
                     park_settled = True                     # a restart, or the manager's own shutdown: the park went with it
-                if ours and via_manager is None:
-                    via_manager = rec
+                if ours and via_manager is None and t0 - rec["t"] <= window and rec["t"] >= born:
+                    via_manager = rec                       # the answer only inside the window and this kernel's lifetime
                 continue
+            # The bounds: only a row that can answer (a request, a park, an unlabeled row) reaches them.
+            quiet = rec.get("when") == "quiet"
+            win = max(window, RESTART_EXPECT_MAX_S) if quiet else window
+            if t0 - rec["t"] > win:
+                break                                       # older rows are older still
+            spent = bool(consumed) and rec["t"] == consumed  # a cut row already joined it (auditT)
+            if rec["t"] < born:
+                # a predecessor's row; only a parked quiet request survives the kernel that filed it
+                if quiet and not park_settled and not spent:
+                    return rec
+                break
             if not action and not quiet:
                 continue                                    # an unlabeled row parks nothing; nothing to answer with
             if spent:

--- a/tests/manager-exit-attribution.test.js
+++ b/tests/manager-exit-attribution.test.js
@@ -79,7 +79,19 @@ test('an aux kernel\'s row goes to ITS state root (the kernel reads the audit fi
 });
 
 test('auditSigterm never throws: an unwritable root is a lost note, not a lost restart', () => {
-  assert.doesNotThrow(() => auditSigterm({ id: 'x', port: 1, stateDir: path.join(STATE, 'no', 'such', 'file.txt', 'dir') }, 1, 'restart'));
+  // A regular file as a component of the root's path: recursive mkdir cannot create the root
+  // (ENOTDIR), so the function's catch is what keeps this from throwing. An earlier fixture named a
+  // path under STATE that did not exist yet, which recursive mkdir created, so the row was written and
+  // the catch never ran: the case passed with the try/catch deleted. The mkdirSync self-check keeps the
+  // fixture uncreatable, so the case cannot go vacuous again without failing here first.
+  const file = path.join(STATE, 'a-file.txt');
+  fs.writeFileSync(file, '');
+  const root = path.join(file, 'dir');
+  assert.throws(() => fs.mkdirSync(root, { recursive: true }));
+  let t;
+  assert.doesNotThrow(() => { t = auditSigterm({ id: 'x', port: 1, stateDir: root }, 1, 'restart'); });
+  assert.equal(typeof t, 'number');                                          // the stamp comes back regardless
+  assert.equal(fs.existsSync(path.join(root, 'restart-audit.jsonl')), false); // the note is lost, nothing else happens
 });
 
 // The wiring: the row goes on disk BEFORE the signal, and the record says what was asked. The pure

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -8,6 +8,7 @@ kernel cannot do: count in-session watchers/Claude-side workflows (invisible her
 watch primitive is the fix), and un-write the CLI's own interrupted-by-user transcript stamps
 (romp never rewrites CLI transcripts; romp's own records already distinguish machine cuts).
 Hermetic state; synthetic sids only."""
+import errno
 import json
 import os
 import signal
@@ -401,6 +402,37 @@ class UnrequestedSignal(unittest.TestCase):
         self.assertEqual(cuts[0]["auditT"], t, "the cut row records the note's t as the audit row it consumed")
         self.assertEqual(km._consumed_audit_t(), t)
 
+    def test_a_stderr_that_refuses_the_write_keeps_the_cut_row_agreeing_with_the_signal_row(self):
+        # the kernel runs on the manager's stdio, and a stream that is gone (a reset journal stream, a
+        # closed tty) makes every stderr write raise (EPIPE). _unrequested_signal_reason files the `signal`
+        # row, logs a line, and returns the reason; the line is best-effort. Were it not, the raise would
+        # leave _drain_and_exit its fallback, the plain unrequested verdict, on a cut row whose `signal`
+        # row says the manager was stopped: two records of one exit disagreeing. So the manager pid here
+        # is a reaped child's (stopped), and the cut row must carry the verdict the row does. The cut row
+        # also carries a drainError (the drain's own stderr writes raise under the same stream); that is
+        # not asserted
+        class Gone:
+            def write(self, s):
+                raise OSError(errno.EPIPE, "Broken pipe")
+
+            def flush(self):
+                pass
+        with mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(self._dead_pid())}), \
+             mock.patch("sys.stderr", Gone()):
+            self._fire()
+        rows = self._rows(self.AUDIT)
+        self.assertEqual([r["action"] for r in rows], ["signal"])
+        self.assertIs(rows[0]["managerStopped"], True)
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1, "the cut row is written whatever stderr does")
+        self.assertEqual(cuts[0]["reason"], km.SIGNAL_REASON_MANAGER_STOPPED,
+                         "the cut row carries the verdict the signal row does, not the fallback")
+        self.AUDIT.unlink()
+        with mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(self._dead_pid())}), \
+             mock.patch("sys.stderr", Gone()):
+            self.assertEqual(km._unrequested_signal_reason(signal.SIGTERM, wait=0), km.SIGNAL_REASON_MANAGER_STOPPED,
+                             "the reason comes back with the log line lost, not the other way round")
+
     def test_a_second_sigterm_mid_drain_does_not_write_a_second_row(self):
         # a service stop signals the kernel, then the manager's shutdownAll signals it again while the
         # first handler drains; the second invocation returns and the first finishes: ONE cut row
@@ -748,32 +780,60 @@ class RequestOnRecord(unittest.TestCase):
                       {"t": 1010, "action": "parent-gone", "pid": os.getpid() + 100000, "reason": km.PARENT_GONE_REASON},
                       {"t": 1010, "action": "signal", "pid": os.getpid() + 100000, "managerStopped": True,
                        "reason": km.SIGNAL_REASON_MANAGER_STOPPED}):
-            with self.subTest(above=above["action"] + ":" + str(above.get("trigger") or above.get("reason"))):
-                self._write({"t": 1000, "action": "kernel-asks-manager-restart-all", "reason": "self-update",
-                             "when": "quiet"}, above)
-                self.assertEqual(self._reason(now=1080, started=1003), "")
+            for now, started in ((1080, 1003), (1101, 1003), (1080, 1011)):
+                with self.subTest(above=above["action"] + ":" + str(above.get("trigger") or above.get("reason")),
+                                  now=now, started=started):
+                    self._write({"t": 1000, "action": "kernel-asks-manager-restart-all", "reason": "self-update",
+                                 "when": "quiet"}, above)
+                    self.assertEqual(self._reason(now=now, started=started), "",
+                                     "settled wherever the row sits: inside the bounds, past the window, or before this kernel")
         # a stop note for THIS kernel above the park: the manager is stopping us, and that note is the answer
         self._write({"t": 1000, "action": "kernel-asks-manager-restart-all", "reason": "self-update", "when": "quiet"},
                     {"t": 1010, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(),
                      "reason": "stop", "trigger": "stop"})
         self.assertEqual(self._reason(now=1080, started=1003), "manager-sigterm: stop")
+        self.assertEqual(self._reason(now=1101, started=1003), "", "a note older than the window is not this exit's")
+        self.assertEqual(self._reason(now=1080, started=1011), "", "nor is one from before this kernel started")
 
     def test_a_quiet_request_survives_a_stop_of_one_other_kernel(self):
         # POST /stop naming one kernel (a dynamic kernel under this root has no root of its own) writes a
         # `stop` note with trigger `stop` for that pid and leaves the manager's park armed; the row cannot be
         # told from the stop that took every kernel down, so the park stays on record, and so does a stray
         # kill of the predecessor with the manager alive. The held converge self-heals at the backstop bound;
-        # a released one would cut the turns the quiet window was to spare
+        # a released one would cut the turns the quiet window was to spare. The row above settles nothing
+        # wherever it sits: a note or a verdict is classified before the 90 s window and the start bound end
+        # the walk, so one older than the window (now=1101) or older than this kernel (started=1011) is
+        # passed over and the park beneath it is still read
         for above in ({"t": 1010, "action": "manager-sigterm", "kernel": "k29900", "pid": os.getpid() + 100000,
                        "reason": "stop", "trigger": "stop"},
                       {"t": 1010, "action": "signal", "pid": os.getpid() + 100000, "managerStopped": False,
                        "reason": km.SIGNAL_REASON_UNREQUESTED}):
-            with self.subTest(above=above["action"]):
-                self._write({"t": 1000, "action": "kernel-asks-manager-restart-all", "reason": "self-update",
-                             "when": "quiet"}, above)
-                self.assertEqual(self._reason(now=1080, started=1003), "kernel-asks-manager-restart-all: self-update")
-                self.assertEqual(km._recent_restart_audit(window=90, now=1080, started=1003)["t"], 1000,
-                                 "the park the drift stand-down reads")
+            for now, started in ((1080, 1003), (1101, 1003), (1080, 1011)):
+                with self.subTest(above=above["action"], now=now, started=started):
+                    self._write({"t": 1000, "action": "kernel-asks-manager-restart-all", "reason": "self-update",
+                                 "when": "quiet"}, above)
+                    self.assertEqual(self._reason(now=now, started=started),
+                                     "kernel-asks-manager-restart-all: self-update")
+                    self.assertEqual((km._recent_restart_audit(window=90, now=now, started=started) or {}).get("t"),
+                                     1000, "the park the drift stand-down reads")
+
+    def test_a_park_this_kernel_filed_is_its_own_past_a_settling_row_at_any_age(self):
+        # the kernel that filed a quiet converge (started 900, park at 1000) sees another kernel's restart
+        # noted above it at 1010 (POST /restart of that kernel): the note is classified before the bounds and
+        # settles a PREDECESSOR's park only, so the row stays this kernel's own request inside the window
+        # (now=1080, as before) and past it (now=1101, where a note older than 90 s used to end the walk
+        # and the same park read as nothing on record). The same rows for a kernel started after the park
+        # are a predecessor's park settled by the restart above it, at either age
+        park = {"t": 1000, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": 1010, "action": "manager-sigterm", "kernel": "k29900", "pid": os.getpid() + 100000,
+                "reason": "restart", "trigger": "restart"}
+        self._write(park, note)
+        for now in (1080, 1101):
+            with self.subTest(now=now):
+                self.assertEqual(self._reason(now=now, started=900), "main-converge")
+                self.assertEqual(km._recent_restart_audit(window=90, now=now, started=900), park)
+                self.assertEqual(self._reason(now=now, started=1003), "",
+                                 "a predecessor's park, settled by the restart noted above it")
 
     def test_a_previous_kernels_verdict_rows_are_never_the_request(self):
         # the kernel's own `signal` and `parent-gone` rows have an action and the OLD pid; with the bound

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -433,6 +433,48 @@ class UnrequestedSignal(unittest.TestCase):
             self.assertEqual(km._unrequested_signal_reason(signal.SIGTERM, wait=0), km.SIGNAL_REASON_MANAGER_STOPPED,
                              "the reason comes back with the log line lost, not the other way round")
 
+    def test_a_stray_sigterm_with_a_quiet_park_on_record_does_not_spend_the_park(self):
+        # a quiet converge parked with the manager (the row _run_main_update writes), then a SIGTERM the
+        # manager did not send: no manager-sigterm note for this pid. The manager still holds the park and
+        # delivers it to whatever kernel runs at the quiet window, so the park is not this signal's request.
+        # Taking it stamped the park's t as auditT, and _consumed_audit_t then hid the park from every reader
+        # under this root (a sibling kernel sharing it, the successor's drift stand-down); the cut row named
+        # the deploy, no `signal` row was filed, and _last_deploy_restart_t counted a stray kill as a deploy
+        # landing. The signal is filed as unrequested and the park stays on record
+        t = int(time.time())
+        park = {"t": t, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        self.AUDIT.write_text(json.dumps(park) + "\n")
+        with mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):   # alive, and wrote no note
+            self._fire()
+        rows = self._rows(self.AUDIT)
+        self.assertEqual([r["action"] for r in rows], ["main-converge", "signal"])
+        self.assertIs(rows[1]["managerStopped"], False)
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0]["reason"], km.SIGNAL_REASON_UNREQUESTED)
+        self.assertNotIn("auditT", cuts[0], "the park is not consumed by a signal that did not deliver it")
+        self.assertEqual(km._recent_restart_audit(window=90, now=t, started=t - 10)["t"], t,
+                         "still the request on record for a sibling kernel or the successor")
+        self.assertEqual(km._parked_quiet_deploy("1111111", now=t), t, "the drift stand-down still holds")
+
+    def test_the_managers_delivery_of_a_quiet_park_consumes_it(self):
+        # the same park with the manager's restart-all note for this pid above it: that SIGTERM is the
+        # delivery, so the cut row names the park and consumes it, as it did before the stray-kill rule
+        t = int(time.time())
+        park = {"t": t, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": t, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(),
+                "reason": "restart", "trigger": "restart-all"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(note) + "\n")
+        with mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self._fire()
+        self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["main-converge", "manager-sigterm"],
+                         "delivered: no signal row")
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0]["reason"], "main-converge")
+        self.assertEqual(cuts[0]["auditT"], t, "the park is consumed by the kernel the manager noted before killing it")
+        self.assertEqual(km._parked_quiet_deploy("1111111", now=t), 0, "and nothing is parked any more")
+
     def test_a_second_sigterm_mid_drain_does_not_write_a_second_row(self):
         # a service stop signals the kernel, then the manager's shutdownAll signals it again while the
         # first handler drains; the second invocation returns and the first finishes: ONE cut row


### PR DESCRIPTION
Follows the merged #1286 and lands on main: the reader rules that PR added to `_recent_restart_audit`, the unrequested-signal path beside them, and the manager-side `auditSigterm` test are what the three commits below correct, one item per commit. The romp down feature PR that follows is stacked on this one; it extends the same reader with `down` and `down-failed` rules and will rebase onto this. For that rebase: the first commit creates a block at the top of the walk holding every rule that continues without answering, before the window and the start bound. The `down-failed` continue and the superseded-`down` continue belong in that block (both decide without the bounds, and a superseded pair older than 90 s above a live park would otherwise end the walk the same way), while an unsuperseded `down` stays below the bounds as a request row.

## 1. Verdicts and manager notes are classified before the reader's bounds

### Symptom
A quiet restart request parked with the manager (a quiet converge's `main-converge` row, a `romp refresh --quiet`) read as nothing on record once a row above it had aged past the 90 s window or had been filed before this kernel started, when that row was one that never answers: another kernel's stop note (`POST /stop` naming one kernel notes the stop for that pid and leaves the manager's park armed) or a predecessor's `signal` verdict with the manager alive. A SIGTERM arriving then carried no request on its cut row, and `_parked_quiet_deploy` returned 0, so `_main_drift_check` said the parked deploy was no longer pending and converged at once, cutting the turns the quiet window was to spare. Inside the bounds the same rows kept the park, as the reader's docstring and `test_a_quiet_request_survives_a_stop_of_one_other_kernel` said they should.

### Cause
`_recent_restart_audit` applied the window break and the start-bound break to every row before the rules that pass over verdict rows and manager notes, so a row that could never be the answer ended the walk whenever it sat out of bounds, with the live park beneath it unread.

### Fix
The verdict and `manager-sigterm` classification now runs first, wherever the row sits; `via_manager` is set only for a note about this pid inside the window and at or after the start, the two bounds its old position applied implicitly. The window and the start bound apply only to rows that can answer (a request, a park, an unlabeled row). A design point that widens behaviour: `park_settled` is consulted for a predecessor's park only, as before, so a park this kernel filed is its own request past a settling row at any age, which inside the window it already was. Consulting it for in-lifetime parks would relabel the filing kernel's cut at the quiet window from the park's text to the manager's note, and `_last_deploy_restart_t` counts a quiet `main-converge` as a deploy landing only through that text; so it stays predecessor-only, and the docstring and docs/reference.md say so.

No code change in `_unrequested_signal_reason`: its stderr line has been guarded since #1286's review commit, and `_drain_and_exit` falls back to the plain verdict if the helper raises. That guard had no test that reached it (the existing test replaces the helper), which #1286's post-merge record lists as a follow-up. This commit adds the test and a docstring sentence naming what the guard protects: without it, a stderr that raises after the `signal` row has landed leaves that row saying the manager was stopped while the cut row gets the fallback's plain unrequested verdict, two records of one exit disagreeing.

### Tests
tests/test_restart_cuts.py, against the module's own state root, fake pids, `os._exit` patched. Red-first figures are from this PR's tests run against main's `kernel/kernel.py` (03feab4d).
- `RequestOnRecord::test_a_quiet_request_survives_a_stop_of_one_other_kernel` probes `(now, started)` in `(1080, 1003), (1101, 1003), (1080, 1011)` for both the other-pid stop note and the `signal` verdict. Before the change the four subtests for the two new pairs fail with `'' != 'kernel-asks-manager-restart-all: self-update'` (the walk breaks at the window, respectively at the start bound).
- `test_a_park_this_kernel_filed_is_its_own_past_a_settling_row_at_any_age` pins the design point above: the now=1101 subtest fails before the change; and the same rows for a kernel started after the park are a settled predecessor's park at either age.
- `test_a_quiet_request_delivered_or_dropped_before_this_kernel_is_consumed`, widened to the same pairs, is green before and after: a settling row out of bounds still settles a predecessor's park.
- `UnrequestedSignal::test_a_stderr_that_refuses_the_write_keeps_the_cut_row_agreeing_with_the_signal_row` fires the handler with a reaped manager pid under a stderr whose write raises EPIPE, then calls the helper directly under the same stream: the `signal` row says the manager was stopped, the one cut row carries the same verdict, and the direct call returns it. Green on main as it stands. With the guard removed (the write left bare) the cut row reads the plain unrequested verdict while the row says stopped, and the direct call raises: 1 failed. The cut row also carries a `drainError` from the drain's own writes under that stream; not asserted.

## 2. A SIGTERM nobody sent through the manager does not consume a parked quiet request

### Symptom
With a quiet restart request parked with the manager, a SIGTERM the manager did not send took the park as its request: a stray kill of this kernel, or of a dynamic (`/ensure`) or stateDir-less aux kernel sharing the state root and so the park. The cut row read `main-converge` with the park's t as `auditT`, no `signal` row was filed (the case that row exists for), and `_consumed_audit_t` then hid the park from every reader under the root: `_parked_quiet_deploy` returned 0, `_main_drift_check` logged the parked deploy as no longer pending, and `_last_deploy_restart_t` counted the stray cut as a deploy landing, anchoring the converge cool-down to a kill that deployed nothing, while the manager still held the park (the stray-exit path in `spawnKernel` clears no `pendingQuiet`).

Under default settings this restarted nothing by itself: the cool-down (`ROMP_CONVERGE_COOLDOWN`, 25 min) outlasts the park's 15-minute backstop, so the released stand-down posted no immediate restart-all. The cost was the misleading "no longer pending" line, a cool-down anchored to a stray kill (the next legitimate auto converge waited up to 25 min on a restart that was no deploy), and a park lost to every reader under the root. Only a `ROMP_CONVERGE_COOLDOWN` below the park's remaining time turned it into the immediate restart the quiet window was to prevent. In the single-kernel case the successor runs the checkout, so the stand-down never engaged and the cost was the attribution alone.

### Cause
`_graceful_term` handed whatever `_recent_restart_audit` returned to `_drain_and_exit`, which stamps `auditT` for any row. The reader returns a quiet park with or without a manager note, because the label and the drift stand-down need it, and nothing checked that this SIGTERM was the manager's delivery of the park. The manager notes every kill it sends before sending it (`auditSigterm`), so a SIGTERM with no note for this pid is not one. The reader's own `test_a_quiet_request_survives_a_stop_of_one_other_kernel` already described a `signal` verdict with `managerStopped: false` above a live park; no code path produced one, because the handler consumed the park instead.

### Fix
`_graceful_term` drops a `when: quiet` pick when `_manager_sigterm_row_for_us(reasons=("restart", "stop"))` finds no `manager-sigterm` note for this pid (or naming none) inside the window and this kernel's lifetime, and `_drain_and_exit` takes its existing unrequested path: `_unrequested_signal_reason` files the `signal` row (managerStopped decided as before, pid liveness plus the bounded look for a stop note) and the cut row carries `SIGNAL_REASON_UNREQUESTED` with no `auditT`, so the park stays on record for the kernel the quiet window will restart. `_manager_sigterm_row_for_us` gains the `reasons` parameter; its default `("stop",)` keeps the service-stop look's semantics for its existing caller, `_unrequested_signal_reason`, and for the tests that call it. The `_drain_and_exit(_audit_reason_text(rec), signum=signum` call shape is unchanged. Rejected shape: skipping only the `auditT` stamp would leave the stray kill's cut row labeled as the deploy, file no `signal` row, and let `_last_deploy_restart_t` count it as a deploy landing. Mixed-version note: a manager that writes no notes delivering a quiet restart is now filed as a stray signal and the park stays unconsumed until it expires; the successor runs the checkout, so the stand-down never engages, and the cost is one cut's attribution. Docstrings of `_graceful_term`, `_recent_restart_audit` and `_manager_sigterm_row_for_us`, and one sentence in docs/reference.md.

### Tests
tests/test_restart_cuts.py, `UnrequestedSignal`, with the note wait patched to 0.
- `test_a_stray_sigterm_with_a_quiet_park_on_record_does_not_spend_the_park` parks a `main-converge` quiet row (the shape `_run_main_update` writes), sets `ROMP_MANAGER_PID` to a live pid that wrote no note and fires the handler. Before the change: the audit file holds `['main-converge']` with no `signal` row (`['main-converge'] != ['main-converge', 'signal']`), the cut row reads `main-converge` with `auditT` set, and `_parked_quiet_deploy` returns 0. After: the `signal` row (managerStopped false) is filed, the cut row carries the unrequested reason and no `auditT`, `_recent_restart_audit` still returns the park for a sibling or the successor, and `_parked_quiet_deploy` returns the park's t.
- `test_the_managers_delivery_of_a_quiet_park_consumes_it`, the same park under the manager's `restart-all` note for this pid, is green before and after: the cut row names and consumes the park, no `signal` row, nothing parked afterwards.

## 3. The manager's never-throws case runs auditSigterm's catch

### Symptom
tests/manager-exit-attribution.test.js's case "auditSigterm never throws: an unwritable root is a lost note, not a lost restart" was vacuous: with `auditSigterm`'s try/catch removed it still passed, so it pinned nothing about the property it names.

### Cause
Its root, `STATE/no/such/file.txt/dir`, did not exist yet, and Node's recursive `mkdirSync` creates every missing component, `file.txt` included; the row was written, nothing threw, and the catch never ran.

### Fix
The case writes an empty regular file under STATE and uses it as a component of the root's path (`a-file.txt/dir`): recursive `mkdirSync` fails with ENOTDIR, so the catch is what keeps the call from throwing. An `assert.throws` on the same `mkdirSync` keeps the fixture uncreatable (the case cannot go vacuous again without failing there first), the return is still a number, and no `restart-audit.jsonl` appears under the root. The comment says why the path is a file. `bin/romp-manager` is unchanged. The stray file sits directly under STATE; the row-counting cases read `STATE/restart-audit.jsonl`, not the directory listing, and stay green. The error code is not pinned (ENOTDIR here; another platform may report EEXIST).

### Tests
Red first with `auditSigterm`'s catch mutated to rethrow: the old case passed (17 of 17); the rewritten case fails with `ENOTDIR: not a directory, mkdir '.../a-file.txt/dir'` thrown out of `doesNotThrow` (16 of 17). With the real catch all 17 pass, and `node --test tests/manager-*.test.js` passes 96 of 96.

## Verification
- Targeted: tests/test_restart_cuts.py with test_main_drift_notice, test_restart_seam, test_restart_audit, test_kernel_headless_ops and test_kernel_tunnel_truth: 176 passed, 26 subtests passed.
- `node --test tests/manager-*.test.js`: 96 passed.
- This PR's tests against main's kernel.py (03feab4d), the tree it lands on: 6 failed (the four new pairs of the stop-of-one-other-kernel test, the in-lifetime park at now=1101, the stray-SIGTERM park test), 5 passed, 15 subtests passed; the stderr test, the delivered-or-dropped test and the manager's-delivery test pass there.
- Full pytest suite on the final tree (vscode-extension dependencies installed, so the served-page legs ran): 11230 passed, 41 skipped, 1740 subtests passed in 163 s, no failures.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)