### PR TITLE
Tests: the chat signature's _World fixture resets the mention-pins latch per world, so a torn-down world's state root is never recreated

### DIFF
--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -415,8 +415,9 @@ class _World(unittest.TestCase):
         state.mkdir()
         self.saved = (jd.STATE, jd.PROJECTS, km.NAMES, km.WORKING_DIR, km._GLOBAL_CLAUDE_MD, km._tmux_sessions, km._sdk,
                       os.environ.get("CLAUDE_CONFIG_DIR"), os.environ.get("ROMP_HOST_NAME"),
-                      len(km._downtime), km._claude_account_label, km._auth_avail_status)
+                      len(km._downtime), km._claude_account_label, km._auth_avail_status, km._MENTION_PINS)
         jd._rebind_state(state)                       # every STATE-derived dir (goals, states, episodes, gone, sdk, ...)
+        km._MENTION_PINS = None                       # the pin dir latches at first use (_pin_dir): this world's root, not a prior one's
         jd.PROJECTS = proj
         jd.NAMES.mkdir()
         (jd.NAMES / SID).write_text("web\t%s\t#1EA1EB\twhite\n" % self.cdir)
@@ -435,11 +436,12 @@ class _World(unittest.TestCase):
         self.sess = {"sid": SID, "name": "web", "path": str(self.tpath), "anchor": SID}
 
     def tearDown(self):
-        (state, proj, names, wdir, gmd, tmux, sdk, cfg, host, ndown, acct, avail) = self.saved
+        (state, proj, names, wdir, gmd, tmux, sdk, cfg, host, ndown, acct, avail, pins) = self.saved
         jd._rebind_state(state)
         jd.PROJECTS = proj
         km.NAMES, km.WORKING_DIR, km._GLOBAL_CLAUDE_MD, km._tmux_sessions, km._sdk = names, wdir, gmd, tmux, sdk
         km._claude_account_label, km._auth_avail_status = acct, avail
+        km._MENTION_PINS = pins
         for k, v in (("CLAUDE_CONFIG_DIR", cfg), ("ROMP_HOST_NAME", host)):
             if v is None:
                 os.environ.pop(k, None)
@@ -817,16 +819,38 @@ class Differential(_World):
         self.sig(deps=pending())                            # the first world: the resolve loads SID's sidecar, which is empty
         self.tearDown()
         self.setUp()                                        # the next test's world (its temp dir is cleaned by the final tearDown)
-        saved = km._MENTION_PINS
-        km._MENTION_PINS = None                             # the pin dir latches at first use: point it at this world's root
-        try:
-            with open(km._pin_assoc_dir() / (SID + ".jsonl"), "w", encoding="utf-8") as f:
-                f.write(json.dumps({"u": "u9", "t": "notes/report.md", "p": "pin1"}) + "\n")
-            s = self.sig(deps=pending())
-        finally:
-            km._MENTION_PINS = saved
+        with open(km._pin_assoc_dir() / (SID + ".jsonl"), "w", encoding="utf-8") as f:
+            f.write(json.dumps({"u": "u9", "t": "notes/report.md", "p": "pin1"}) + "\n")
+        s = self.sig(deps=pending())
         self.assertEqual(s[km._CHAT_SIG_LABELS.index("pathlink")][0][2], {"notes/report.md": "pin1"},
                          "pinned from this world's sidecar, not a prior world's memo")
+
+    def test_each_world_latches_its_own_pin_directory(self):
+        """The pin directory latches at first use (_pin_dir) and the sidecar's memo is cleared per sid at
+        tearDown, so a later world's first resolve reloads the sidecar through _pin_assoc_dir, which
+        mkdirs under the latched path. Left alone, that path is a torn-down world's: the fixture resets
+        the latch per world and restores it at tearDown, so each resolve lands under its own state root
+        and nothing is recreated under a removed one. Two worlds through the fixture's own hooks, as the
+        sidecar test above. Between them the latch must no longer point at the first world, and is then
+        set back to it, the value a fixture that never reset would inherit, so the second setUp has to
+        reset it rather than find it clear."""
+        def pending():
+            km._PATH_LINK_CACHE[(SID, "u9")] = ({}, ("notes/report.md",), {})
+            (self.cdir / "notes").mkdir()
+            (self.cdir / "notes" / "report.md").write_text("42\n")
+            return {"task_outs": [], "pl_pending": [("u9", "see notes/report.md for the numbers")],
+                    "pl_at": (("u9", None, None),), "pl_check": None, "postal_any": False, "postal_cards": []}
+        self.sig(deps=pending())                            # the first world resolves: the pin dir latches
+        first = Path(self.td.name)
+        self.tearDown()
+        self.assertNotEqual(km._MENTION_PINS, first / "state" / "mention-pins",
+                            "the latch does not point at the torn-down world")
+        self.addCleanup(setattr, km, "_MENTION_PINS", km._MENTION_PINS)   # the final tearDown restores the stale value set below; put back the one before it
+        km._MENTION_PINS = first / "state" / "mention-pins"   # a stale latch on the removed world: setUp resets it rather than inheriting it
+        self.setUp()                                        # the next test's world (its temp dir is cleaned by the final tearDown)
+        self.sig(deps=pending())                            # the memo was popped, so the resolve reloads through _pin_assoc_dir
+        self.assertEqual(km._MENTION_PINS, jd.STATE / "mention-pins", "the pin directory is this world's")
+        self.assertFalse(first.exists(), "nothing is recreated under the torn-down first world")
 
     def test_a_postal_dependency_misses_under_postal_when_the_log_moves_or_a_caption_changes(self):
         caps = {}
@@ -1130,7 +1154,9 @@ class RecordedDependencies(unittest.TestCase):
     records stamped against the real clock, which discovery keys on. Message ids are salted per test
     instance and tearDown clears the sid's per-message caches (_PATH_LINK_CACHE, _SPACE_PATH_CACHE, the pin
     sidecar's memo): a verdict cached under (sid, uuid) is served without re-reading the text, so an id
-    reused across tests would hand one test's verdict to another's message."""
+    reused across tests would hand one test's verdict to another's message. The pin directory's latch
+    (_MENTION_PINS) is reset per world and restored at tearDown, as in _World, so a resolve never mkdirs
+    under a torn-down world's state root."""
 
     _salt = itertools.count()                    # one value per test instance, read in setUp
 
@@ -1153,8 +1179,10 @@ class RecordedDependencies(unittest.TestCase):
         self.saved = {nm: getattr(km, nm) for nm in self.STUBS}
         self.saved_state = (jd.STATE, jd.PROJECTS, km.NAMES, km._GLOBAL_CLAUDE_MD, os.environ.get("CLAUDE_CONFIG_DIR"),
                             dict(km._built_chat), dict(km._prev_chat_events), dict(km._prev_chat_ledger),
-                            list(km._last_tab_order), [set(km._thread_fold_keep[0]), set(km._thread_fold_keep[1])])
+                            list(km._last_tab_order), [set(km._thread_fold_keep[0]), set(km._thread_fold_keep[1])],
+                            km._MENTION_PINS)
         jd._rebind_state(td / "state")
+        km._MENTION_PINS = None                       # the pin dir latches at first use (_pin_dir): this world's root, as _World
         jd.PROJECTS = proj
         jd.NAMES.mkdir(parents=True, exist_ok=True)
         (jd.NAMES / SID_R).write_text("web\t%s\t#1EA1EB\twhite\n" % self.cdir)
@@ -1186,10 +1214,11 @@ class RecordedDependencies(unittest.TestCase):
     def tearDown(self):
         for nm, v in self.saved.items():
             setattr(km, nm, v)
-        st, proj, names, gmd, cfg, bc, pe, pl, lo, keep = self.saved_state
+        st, proj, names, gmd, cfg, bc, pe, pl, lo, keep, pins = self.saved_state
         jd._rebind_state(st)
         jd.PROJECTS = proj
         km.NAMES, km._GLOBAL_CLAUDE_MD = names, gmd
+        km._MENTION_PINS = pins
         if cfg is None:
             os.environ.pop("CLAUDE_CONFIG_DIR", None)
         else:


### PR DESCRIPTION
Follow-up to the merge comment on #1296.

## Symptom
A run of `tests/test_chat_build_sig_inputs.py` could recreate `<temp dir>/state/mention-pins/assoc` under a test world's temp directory after that world was torn down, and leave it behind. Under pytest the conftest's removal of its temp root takes the recreated chain with it, and under `python -m unittest tests.test_chat_build_sig_inputs` the package's atexit hook removes it (every `TemporaryDirectory` goes through the `mkdtemp` the package records). The leak shows only in a direct script run or a unittest run from inside `tests/`, and those runs already leave the module's own import-time state root beside it. No verdict was affected: `_pin_assoc` reads an absent sidecar as `{}` under either path, every resolved token in the module is a `.md` that `_pin_mention` refuses before touching the pin directory, and no test enumerates the state directory.

## Cause
`_pin_dir()` latches `jd.STATE / "mention-pins"` in `km._MENTION_PINS` at first use and keeps it for the process. `_World.setUp` rebinds every judge-derived directory per world through `jd._rebind_state`, but the latch is kernel-owned and was not among the values the fixture saved and restored. So the first test that resolved a path token latched its own world's root, and that path outlived the world. Every later world's first resolve missed the sidecar memo (`tearDown` pops `_PIN_ASSOC_MEMO` for the sid) and reloaded through `_pin_assoc_dir()`, which mkdirs `<latched>/assoc` with parents, under the torn-down root. The sidecar test (`test_a_fresh_worlds_pin_sidecar_is_read_under_a_reused_id`) worked around this in-test with a save, a `None` and a `try/finally` restore, and the value it restored was always a torn-down world's path.

## Fix
`tests/test_chat_build_sig_inputs.py` only.
- `_World.setUp` saves `km._MENTION_PINS` beside the other saved values and sets it to `None` after `jd._rebind_state(state)`, so each world's first `_pin_dir()` latches its own root. `tearDown` restores it beside the other restores, before the temp dir is removed.
- The sidecar test drops its in-test latch lines (the save, the `None`, the `try/finally`). Its verdict is unchanged: `{'notes/report.md': 'pin1'}`.
- `RecordedDependencies.setUp` and `tearDown` mirror the same save, reset and restore, so the two fixtures stay in step. Its two-world test otherwise left the latch on its removed second world; nothing recreates under it today because no later test in that class resolves a token, so this mirror has no test of its own.

## Tests
- New: `Differential.test_each_world_latches_its_own_pin_directory`, beside the sidecar test. It resolves `notes/report.md` in one world, records that world's directory and tears the world down. It then asserts that `km._MENTION_PINS` no longer points at that directory (the restore), sets the latch back to that directory's `state/mention-pins` (the value a fixture that never reset would inherit; an `addCleanup` puts the preceding value back after the final `tearDown`), sets up a second world and resolves again, and asserts that `km._MENTION_PINS` is the second world's `jd.STATE / "mention-pins"` (the reset) and that the first directory no longer exists. It asserts on the global rather than on `_pin_dir()`, so a resolve that skipped the reload cannot latch at the assertion and pass.
  - Before the change, alone: the first assertion fails, `PosixPath('<first>/state/mention-pins') == PosixPath('<first>/state/mention-pins')`, since nothing restored the latch. With that assertion removed for the record, the equality fails (`PosixPath('<first>/state/mention-pins') != PosixPath('<second>/state/mention-pins')`) and `first.exists()` is `True`.
  - Before the change, in the whole module: pytest runs unittest methods in sorted name order, so the sidecar test runs first and its `finally` restores its own torn-down first-world path, a different one; the first assertion passes, the unreset fixture inherits the stale path set on the latch, and the equality fails on it; 1 failed, 49 passed.
  - After the change: 50 passed, serial and under `-n 4`.
  - Deleting only the fixture's reset (`km._MENTION_PINS = None` in `_World.setUp`) fails the test at the equality; deleting only its restore (`km._MENTION_PINS = pins` in `_World.tearDown`) fails it at the first assertion. Both alone and in the whole module.
- The sidecar test keeps its verdict with its latch lines gone.
- Full pytest suite on this head: 11227 passed, 41 skipped, 1726 subtests passed (`-n 6`).

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)