### PR TITLE
Kernel exit path: a dead stderr no longer skips the drain or the exit, and the cut row names the reason helper's fault (reasonError)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1780,7 +1780,11 @@ receive it. A kernel whose manager disappears writes a row with action
 `parent-gone` before it exits. `restart-cuts.jsonl` gets one row per exit
 naming the turns the drain cut and the reason: the audit row's `action:
 reason`, the `signal` row's reason, or `parent-gone: the manager exited; the
-kernel followed it`. A second SIGTERM during the drain is ignored; the first
+kernel followed it`. When the helper that files the `signal` row fails (a
+`ROMP_MANAGER_PID` the kernel cannot use as a pid), no `signal` row is written,
+and the cut row carries the plain `signal, not requested through the manager`
+verdict plus a `reasonError` naming the fault, so the missing row is explained
+on disk. A second SIGTERM during the drain is ignored; the first
 writes the row. The manager's log says `exited without a restart request
 (signal or crash); respawning` when a kernel exits that it did not ask to stop
 or restart.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -53614,6 +53614,7 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     (_unrequested_signal_reason: an empty reason used to be all restart-cuts.jsonl had for such a restart)."""
     res = {}
     err = ""
+    reason_err = ""
     be = _sdk_backend or None
     try:
         sys.stderr.write("romp-kernel: %s, draining SDK sessions\n" % what)
@@ -53630,17 +53631,28 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
             if not reason and signum is not None:
                 # the helper's own guard: it reads ROMP_MANAGER_PID and writes to stderr, and a raise
                 # there (a pid too large for os.kill, a stderr the dying supervisor closed) must not
-                # skip the cut row this exit exists to leave; the reason falls back to the plain verdict
+                # skip the cut row this exit exists to leave. The reason falls back to the plain verdict
+                # and the row names the fault (reasonError, drainError's recipe): the helper's raise
+                # paths precede its `signal` row, so this exit has none, and a row with the plain verdict
+                # alone read as a healthy exit of that kind with the row it promises missing
                 try:
                     reason = _unrequested_signal_reason(signum, be)
                 except Exception:
                     reason = SIGNAL_REASON_UNREQUESTED
+                    reason_err = traceback.format_exc().strip().splitlines()[-1][:200]
+                    try:                              # best-effort: a closed stderr is one of the causes
+                        sys.stderr.write("romp-kernel: the signal's reason helper failed, the cut row "
+                                         "carries the plain verdict and reasonError: %s\n" % reason_err)
+                    except Exception:
+                        pass
             row = _restart_cut_row(res, watches_armed=len(_pr_watches) + len(_watches),
                                    audit_reason=reason)
             if audit:
                 row["auditT"] = int(audit["t"])     # the audit row this cut CONSUMED (see _recent_restart_audit)
             if err:
                 row["drainError"] = err.strip().splitlines()[-1][:200]
+            if reason_err:
+                row["reasonError"] = reason_err     # the reason helper's fault: no `signal` row was filed
             _append_restart_cut(row)
         except Exception:
             sys.stderr.write("romp-kernel: cut ledger failed: %s\n" % traceback.format_exc())

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -53546,6 +53546,17 @@ _TERMINATING = [False]   # set the moment an exit path takes the lock: the watch
 #                          know an exit is underway ask this instead of touching the lock
 
 
+def _exit_log(text):
+    """One stderr line on the exit path, best-effort. The kernel writes on the stdio bin/romp-manager
+    spawned it with (stdio inherit), so a supervisor closing its own stderr does not close this
+    descriptor, but a reset journal stream, a closed tty or a full log disk makes the write raise, and
+    nothing said here is worth skipping the drain, filing the fault as the drain's, or skipping the exit."""
+    try:
+        sys.stderr.write(text)
+    except Exception:
+        pass
+
+
 def _parent_watch():
     """Exit if the manager that spawned us (ROMP_MANAGER_PID) dies, so a supervisor crash doesn't
     orphan the kernel. No-op when launched standalone (no ROMP_MANAGER_PID). The exit leaves the same
@@ -53611,19 +53622,21 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     `audit` the audit row it was read from (the cut row records its t as `auditT`, so the same request
     never names a later, anonymous cut too); empty with a `signum` means the signal reached this pid
     with no request on record, which is worth a row of its own plus a cut reason that says so
-    (_unrequested_signal_reason: an empty reason used to be all restart-cuts.jsonl had for such a restart)."""
+    (_unrequested_signal_reason: an empty reason used to be all restart-cuts.jsonl had for such a restart).
+    Every stderr line here goes through _exit_log, so a stderr that raises can neither skip the drain, be
+    recorded as the drain's error, nor skip the exit."""
     res = {}
     err = ""
     reason_err = ""
     be = _sdk_backend or None
+    _exit_log("romp-kernel: %s, draining SDK sessions\n" % what)
     try:
-        sys.stderr.write("romp-kernel: %s, draining SDK sessions\n" % what)
         if be is not None and hasattr(be, "drain"):
             res = be.drain(2.0)
     except Exception:
         # log-and-record, never die recordless (T143: a raising drain lost 2 of 18 restarts' rows)
         err = traceback.format_exc()
-        sys.stderr.write("romp-kernel: drain failed: %s\n" % err)
+        _exit_log("romp-kernel: drain failed: %s\n" % err)
     finally:
         # the restart-cut ledger (T121): one row per restart, ALWAYS: an empty cutTurns row is the
         # clean-drain metric, and a drain that errored writes what it knew plus the error (T143).
@@ -53640,11 +53653,8 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
                 except Exception:
                     reason = SIGNAL_REASON_UNREQUESTED
                     reason_err = traceback.format_exc().strip().splitlines()[-1][:200]
-                    try:                              # best-effort: a closed stderr is one of the causes
-                        sys.stderr.write("romp-kernel: the signal's reason helper failed, the cut row "
-                                         "carries the plain verdict and reasonError: %s\n" % reason_err)
-                    except Exception:
-                        pass
+                    _exit_log("romp-kernel: the signal's reason helper failed, the cut row carries the "
+                              "plain verdict and reasonError: %s\n" % reason_err)
             row = _restart_cut_row(res, watches_armed=len(_pr_watches) + len(_watches),
                                    audit_reason=reason)
             if audit:
@@ -53655,7 +53665,7 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
                 row["reasonError"] = reason_err     # the reason helper's fault: no `signal` row was filed
             _append_restart_cut(row)
         except Exception:
-            sys.stderr.write("romp-kernel: cut ledger failed: %s\n" % traceback.format_exc())
+            _exit_log("romp-kernel: cut ledger failed: %s\n" % traceback.format_exc())
         os._exit(0)
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14707,7 +14707,8 @@ def _sdk_locked():
                 push_session=_push_session_now,   # targeted one-session push for per-session chip events (connect)
                 mcp_config=(str(_SDK_MCP) if _SDK_MCP.exists() else None),
                 append_prompt_path=(str(_SDK_PROMPT) if _SDK_PROMPT.exists() else None),
-                log=lambda m: sys.stderr.write("sdk-backend: %s\n" % m),
+                log=_backend_log,   # best-effort, through _exit_log: SdkBackend.drain logs its summary after
+                #                     its work is done, and a stderr that raises there must not carry the result away
                 reconcile=True,   # boot reconcile: reap orphaned CLIs, resume cut turns, deliver persisted queues
                 # the API-health aggregator's boot clock: this kernel's own _STARTED, which the aggregator
                 # truncates to the millisecond (the precision of every stamp in the payload) and serves as
@@ -53547,7 +53548,8 @@ _TERMINATING = [False]   # set the moment an exit path takes the lock: the watch
 
 
 def _exit_log(text):
-    """One stderr line on the exit path, best-effort. The kernel writes on the stdio bin/romp-manager
+    """One stderr line on the exit path, best-effort, and every line the SDK backend logs, for the kernel's
+    whole life (_backend_log below). The kernel writes on the stdio bin/romp-manager
     spawned it with (stdio inherit), so a supervisor closing its own stderr does not close this
     descriptor, but a reset journal stream, a closed tty or a full log disk makes the write raise, and
     nothing said here is worth skipping the drain, filing the fault as the drain's, or skipping the exit."""
@@ -53555,6 +53557,17 @@ def _exit_log(text):
         sys.stderr.write(text)
     except Exception:
         pass
+
+
+def _backend_log(m):
+    """The SDK backend's log callback (the `log=` wire in _sdk_locked): one `sdk-backend:` stderr line,
+    best-effort through _exit_log. SdkBackend.drain logs its summary AFTER every session is shut down,
+    joined and reaped, immediately before its return, so as a bare sys.stderr.write this line was the one
+    the exit path's guards did not cover: under a dead stderr it raised out of be.drain with the work done,
+    and _drain_and_exit filed an empty cutTurns row with a drainError naming the stderr fault, the misfiled
+    row those guards exist to close. The guard covers the backend's whole life, not the exit alone: no
+    backend line is worth a raise out of the path that logged it. Pinned in tests/test_restart_cuts.py."""
+    _exit_log("sdk-backend: %s\n" % m)
 
 
 def _parent_watch():
@@ -53623,8 +53636,9 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     never names a later, anonymous cut too); empty with a `signum` means the signal reached this pid
     with no request on record, which is worth a row of its own plus a cut reason that says so
     (_unrequested_signal_reason: an empty reason used to be all restart-cuts.jsonl had for such a restart).
-    Every stderr line here goes through _exit_log, so a stderr that raises can neither skip the drain, be
-    recorded as the drain's error, nor skip the exit."""
+    Every stderr line here goes through _exit_log, and so does every line the backend logs during the drain
+    (_backend_log; its summary line follows the drain's work), so a stderr that raises can neither skip the
+    drain, be recorded as the drain's error, nor skip the exit."""
     res = {}
     err = ""
     reason_err = ""

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -9,6 +9,7 @@ watch primitive is the fix), and un-write the CLI's own interrupted-by-user tran
 (romp never rewrites CLI transcripts; romp's own records already distinguish machine cuts).
 Hermetic state; synthetic sids only."""
 import errno
+import io
 import json
 import os
 import signal
@@ -312,13 +313,21 @@ class UnrequestedSignal(unittest.TestCase):
     def test_a_raising_reason_helper_still_leaves_the_cut_row(self):
         # the helper reads ROMP_MANAGER_PID (a pid too large for os.kill raises OverflowError out of
         # _pid_alive) and writes to a stderr the dying supervisor may have closed; a raise there used
-        # to skip the cut row this exit exists to leave. The row lands with the plain verdict instead.
-        with mock.patch.object(km, "_unrequested_signal_reason", side_effect=OverflowError("pid")):
+        # to skip the cut row this exit exists to leave. The row lands with the plain verdict instead,
+        # and names the fault: the helper died before it filed the `signal` row, so the cut row is the
+        # only record of this exit, and without the field it read as a healthy unrequested one
+        with mock.patch.object(km, "_unrequested_signal_reason", side_effect=OverflowError("pid")), \
+             mock.patch.object(km.sys, "stderr", new_callable=io.StringIO) as err:
             self._fire()
         cuts = self._rows(km.RESTART_CUTS_FILE)
         self.assertEqual(len(cuts), 1, "the cut row is written whether or not the reason helper survives")
         self.assertEqual(cuts[0]["reason"], km.SIGNAL_REASON_UNREQUESTED)
         self.assertEqual(cuts[0]["cutTurns"], [])
+        self.assertEqual(cuts[0]["reasonError"], "OverflowError: pid",
+                         "the row names the fault the helper died of, as drainError names a drain's")
+        self.assertNotIn("drainError", cuts[0], "the drain itself ran clean; the fault is the helper's")
+        self.assertEqual(self._rows(self.AUDIT), [], "no `signal` row on this path: the cut row is the only record")
+        self.assertIn("reasonError", err.getvalue(), "and the fault is said on stderr")
 
     def test_an_unlabeled_row_is_neither_the_request_nor_consumed(self):
         # the CLI's actionless refresh row alone, fresh, and the SIGTERM arrives (the manager's note never

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -54,11 +54,15 @@ class DeadTty:
 
 
 class LiveDrain:
-    """A backend with one session in flight: drain() records that it ran and names the turn it cut."""
+    """A backend with one session in flight: drain() records that it ran and names the turn it cut. It says
+    so through the kernel's backend log wire before returning, as SdkBackend.drain does after its work: a
+    wire that raised there carried the finished drain's result away (an empty cutTurns row, a drainError
+    naming the stderr fault), so the dead-stderr cases below drive that line too."""
     called = False
 
     def drain(self, timeout):
         self.called = True
+        km._backend_log("drain: stopped 1 session(s), 1 in-flight turn(s) interrupted")
         return {"cutTurns": [{"sid": SID, "name": "web"}], "stopped": 1}
 
 
@@ -225,6 +229,26 @@ class CutRow(unittest.TestCase):
         self.assertIn("audit_reason=reason", block)
         self.assertIn("if not _EXIT_ONCE.acquire(blocking=False):", block,
                       "a second SIGTERM mid-drain must not nest a second drain and a second cut row")
+
+    def test_the_backends_log_wire_is_best_effort(self):
+        # SdkBackend.drain logs its summary after every session is shut down, joined and reaped, right
+        # before its return, through the kernel's `log=` callback. Wired as a bare sys.stderr.write, a dead
+        # stderr raised there out of be.drain with the work done, and _drain_and_exit filed an empty
+        # cutTurns row with a drainError naming the stderr fault: the misfiled row the exit path's own
+        # _exit_log guards close, reopened by the one line they did not cover. The wire is _backend_log,
+        # _exit_log with the backend's prefix; the LiveDrain fake logs through it, so the two
+        # test_a_raising_stderr_does_not_skip_the_drain cases drive this line through the handlers
+        src = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn("log=_backend_log,", src, "the backend is wired to the best-effort line")
+        self.assertNotIn('log=lambda m: sys.stderr.write("sdk-backend', src,
+                         "never the bare write: it raised out of be.drain under a dead stderr")
+        line = "drain: stopped 1 session(s), 0 in-flight turn(s) interrupted"
+        with mock.patch.object(km.sys, "stderr", DeadTty()):
+            km._backend_log(line)                    # no raise: the line is lost, the caller's result is not
+        with mock.patch.object(km.sys, "stderr", new_callable=io.StringIO) as err:
+            km._backend_log(line)
+        self.assertEqual(err.getvalue(), "sdk-backend: %s\n" % line,
+                         "with a healthy stderr the line is the one the kernel log always carried")
 
 
 class UnrequestedSignal(unittest.TestCase):

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -42,6 +42,26 @@ STATE_ROOT = km.RESTART_CUTS_FILE.parent
 REFRESH_CLI_ROW = {"ppid": 4242, "parent": "bash", "sid": "", "name": "", "tty": "/dev/pts/0", "tmux": ""}
 
 
+class DeadTty:
+    """A stderr whose every write raises: the kernel writes on the stdio the manager spawned it with, and
+    a pty whose master closed answers EIO (a reset journal stream answers EPIPE the same way)."""
+
+    def write(self, s):
+        raise OSError(errno.EIO, "Input/output error")
+
+    def flush(self):
+        pass
+
+
+class LiveDrain:
+    """A backend with one session in flight: drain() records that it ran and names the turn it cut."""
+    called = False
+
+    def drain(self, timeout):
+        self.called = True
+        return {"cutTurns": [{"sid": SID, "name": "web"}], "stopped": 1}
+
+
 def _own_state_root(case):
     """Aim the shared judge module's STATE at this kernel's own root for one test, and put the previous
     binding back afterwards; returns the audit path both sides now use. The kernel writes the restart
@@ -309,6 +329,8 @@ class UnrequestedSignal(unittest.TestCase):
         self.assertEqual(cuts[0]["reason"], "signal, not requested through the manager",
                          "the cut row used to say nothing at all here")
         self.assertEqual(cuts[0]["cutTurns"], [])
+        self.assertNotIn("drainError", cuts[0], "a clean exit's row carries neither fault field")
+        self.assertNotIn("reasonError", cuts[0], "(each appears only when its fault did)")
 
     def test_a_raising_reason_helper_still_leaves_the_cut_row(self):
         # the helper reads ROMP_MANAGER_PID (a pid too large for os.kill raises OverflowError out of
@@ -328,6 +350,24 @@ class UnrequestedSignal(unittest.TestCase):
         self.assertNotIn("drainError", cuts[0], "the drain itself ran clean; the fault is the helper's")
         self.assertEqual(self._rows(self.AUDIT), [], "no `signal` row on this path: the cut row is the only record")
         self.assertIn("reasonError", err.getvalue(), "and the fault is said on stderr")
+
+    def test_a_raising_reason_helper_under_a_dead_stderr_still_leaves_the_cut_row(self):
+        # the two faults arrive together in practice: a ROMP_MANAGER_PID the kernel cannot use, on a
+        # stream that is gone. The line that names the helper's fault is best-effort like every other on
+        # the exit path; were it not, its raise would leave the inner except for the outer one, which
+        # writes no row, and the cut row this exit exists to leave would be lost. The stderr is a closed
+        # file object (its write raises ValueError), so the exit path's guard is pinned for any exception,
+        # not one errno, as the helper's own guard is (test_a_closed_stderr_... below)
+        closed = io.StringIO()
+        closed.close()
+        with mock.patch.object(km, "_unrequested_signal_reason", side_effect=OverflowError("pid")), \
+             mock.patch.object(km.sys, "stderr", closed):
+            self._fire()
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1, "the cut row lands under a dead stderr and a dead helper")
+        self.assertEqual(cuts[0]["reason"], km.SIGNAL_REASON_UNREQUESTED)
+        self.assertEqual(cuts[0]["reasonError"], "OverflowError: pid")
+        self.assertEqual(self._rows(self.AUDIT), [])
 
     def test_an_unlabeled_row_is_neither_the_request_nor_consumed(self):
         # the CLI's actionless refresh row alone, fresh, and the SIGTERM arrives (the manager's note never
@@ -417,9 +457,8 @@ class UnrequestedSignal(unittest.TestCase):
         # row, logs a line, and returns the reason; the line is best-effort. Were it not, the raise would
         # leave _drain_and_exit its fallback, the plain unrequested verdict, on a cut row whose `signal`
         # row says the manager was stopped: two records of one exit disagreeing. So the manager pid here
-        # is a reaped child's (stopped), and the cut row must carry the verdict the row does. The cut row
-        # also carries a drainError (the drain's own stderr writes raise under the same stream); that is
-        # not asserted
+        # is a reaped child's (stopped), and the cut row must carry the verdict the row does. The exit
+        # path's own stderr lines are best-effort too, so the row carries no drainError (the cases below)
         class Gone:
             def write(self, s):
                 raise OSError(errno.EPIPE, "Broken pipe")
@@ -441,6 +480,32 @@ class UnrequestedSignal(unittest.TestCase):
              mock.patch("sys.stderr", Gone()):
             self.assertEqual(km._unrequested_signal_reason(signal.SIGTERM, wait=0), km.SIGNAL_REASON_MANAGER_STOPPED,
                              "the reason comes back with the log line lost, not the other way round")
+
+    def test_a_raising_stderr_does_not_skip_the_drain(self):
+        # the drain announcement was the first statement of the drain's try, so a stderr that raises (a
+        # closed tty on a kernel that outlived the hangup, a reset journal stream, a full log disk) jumped
+        # to the except before be.drain ran: no session was drained, their claude children orphaned with
+        # in-flight turns uninterrupted, and the row read as a clean drain whose drainError named the
+        # stderr fault. Every stderr line on the exit path is best-effort: the drain runs, and drainError
+        # names a fault of the drain alone
+        be = LiveDrain()
+        with mock.patch.object(km.sys, "stderr", DeadTty()):
+            self._fire(backend=be)
+        self.assertTrue(be.called, "the drain runs whatever stderr does")
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0]["cutTurns"], [{"sid": SID, "name": "web"}])
+        self.assertNotIn("drainError", cuts[0], "drainError is the drain's fault, never stderr's")
+
+    def test_a_raising_stderr_when_the_cut_row_fails_still_exits(self):
+        # a row builder that raises reaches the outer except, whose stderr line stood before os._exit(0)
+        # unguarded: with stderr dead the line raised out of the handler and the exit never ran. From
+        # _graceful_term that ended the interpreter with no row; from _parent_watch it ended that thread
+        # alone, and the kernel lived on with the exit lock held, so every later SIGTERM returned at once
+        with mock.patch.object(km.sys, "stderr", DeadTty()), \
+             mock.patch.object(km, "_restart_cut_row", side_effect=RuntimeError("row")):
+            self._fire()                             # asserts os._exit(0) was reached, once
+        self.assertEqual(self._rows(km.RESTART_CUTS_FILE), [], "no row to write; the exit still ran")
 
     def test_a_stray_sigterm_with_a_quiet_park_on_record_does_not_spend_the_park(self):
         # a quiet converge parked with the manager (the row _run_main_update writes), then a SIGTERM the
@@ -962,6 +1027,27 @@ class ParentGone(unittest.TestCase):
         cuts = self._rows(km.RESTART_CUTS_FILE)
         self.assertEqual(len(cuts), 1)
         self.assertEqual(cuts[0]["reason"], "parent-gone: the manager exited; the kernel followed it")
+
+    def test_a_raising_stderr_does_not_skip_the_drain(self):
+        # the exit a closed tty reaches: a manager running in its own session with the tty on its stderr
+        # dies of its own write fault when the tty goes, and this watchdog notices with the kernel's stderr,
+        # the same descriptor, dead too. The drain still runs and both rows land
+        p = subprocess.Popen(["true"])
+        p.wait()
+        be = LiveDrain()
+        with mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(p.pid)}), \
+             mock.patch.object(km, "_sdk_backend", be), \
+             mock.patch.object(km.sys, "stderr", DeadTty()), \
+             mock.patch.object(km.os, "_exit", side_effect=SystemExit) as ex:
+            with self.assertRaises(SystemExit):
+                km._parent_watch()
+        ex.assert_called_once_with(0)
+        self.assertTrue(be.called, "the drain runs whatever stderr does")
+        self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["parent-gone"])
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0]["cutTurns"], [{"sid": SID, "name": "web"}])
+        self.assertNotIn("drainError", cuts[0])
 
     def test_standalone_kernel_has_no_parent_to_watch(self):
         env = {k: v for k, v in os.environ.items() if k != "ROMP_MANAGER_PID"}

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -517,6 +517,26 @@ class UnrequestedSignal(unittest.TestCase):
         self.assertIs(row["managerStopped"], True)
         self.assertIs(row["managerRequested"], False, "still not a request: nobody asked the manager")
 
+    def test_a_closed_stderr_does_not_undo_the_service_stop_verdict(self):
+        # the helper's own log line comes AFTER the `signal` row lands and BEFORE the return, so a stderr
+        # that raises there must not carry the verdict away with it: _drain_and_exit would take its
+        # fallback, the plain wording, and the cut row would contradict the row already on disk. The
+        # case above drives a broken pipe (an OSError) through _graceful_term and then calls the helper
+        # alone asserting the return only; this one's stderr is a closed file object, whose write raises
+        # ValueError (the guard is for any exception, not one errno: a supervisor that reset the stream
+        # leaves that kind behind), and it asserts on the direct call that the audit row's managerStopped
+        # and reason agree with the verdict returned
+        closed = io.StringIO()
+        closed.close()
+        with mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(self._dead_pid())}), \
+             mock.patch.object(km.sys, "stderr", closed):
+            reason = km._unrequested_signal_reason(signal.SIGTERM, wait=0, now=1000)
+        self.assertEqual(reason, km.SIGNAL_REASON_MANAGER_STOPPED)
+        rows = self._rows(self.AUDIT)
+        self.assertEqual(len(rows), 1)
+        self.assertIs(rows[0]["managerStopped"], True)
+        self.assertEqual(rows[0]["reason"], reason, "the verdict returned is the one the row carries")
+
     def test_the_managers_stop_note_landing_after_our_signal_is_the_service_stop_wording(self):
         # the manager writes its note BEFORE it kills, so a note that lands AFTER our signal did not
         # send it: the manager is going down alongside us (node's handler ran after ours)


### PR DESCRIPTION
Follows the merged #1302 and lands on main (rebased onto 5c8ccebe on 2026-09-10, three commits replayed unchanged); the change to review is the three commits. All three items are the follow-ups recorded on #1286 after its merge, against its review-fix commit f36ddba8.

## Symptom

Three gaps on the kernel's exit path (`_drain_and_exit`, shared by `_graceful_term` and `_parent_watch`):

1. When `_unrequested_signal_reason` raised before filing its `signal` row (a `ROMP_MANAGER_PID` the kernel cannot use as a pid: a digit string `int()` rejects, or a pid past the C int range, which `_pid_alive` does not catch), the inner guard fell back to the plain verdict and recorded nothing else: no stderr line, no field. The cut row was indistinguishable from a healthy unrequested exit, and the `signal` row docs/reference.md promises was missing with nothing on disk to say why. The same block already records a drain fault as `drainError`.
2. The helper's own stderr line sits after the `signal` row lands and before the return, so a stderr that raises there would carry the verdict away (the plain wording on the cut row beside `managerStopped: true` in the audit row). The write is guarded, and the existing broken-pipe test drives an OSError through `_graceful_term` and then calls the helper alone asserting the return only. Two things were unpinned: the guard's breadth beyond OSError, and that the audit row filed on the direct call agrees with the verdict returned.
3. The kernel writes on the stdio the manager spawned it with (stdio inherit). A stream that raises at write time (a reset journal stream, a closed tty on a kernel that outlived the hangup, a full log disk) hit the drain announcement, the first statement of the drain's `try`, so the `except` ran before `be.drain`: no session was drained, their claude children orphaned with in-flight turns uninterrupted, and the cut row read as a clean drain (`cutTurns` empty) with a `drainError` naming the stderr fault, not a drain's. The "drain failed" line raised again inside the except. And when the row builder raised, the outer except's own line stood before `os._exit(0)` unguarded: with stderr dead it raised out of the handler and the exit never ran. From `_graceful_term` that ends the interpreter with no row; from `_parent_watch` it ends that thread alone and the kernel lives on with the exit lock held, so every later SIGTERM returns at once.

## Cause

The inner `except Exception:` only reset the reason. Three `sys.stderr.write` calls on the exit path were unguarded, one of them inside the `try` whose body is the drain; only the reason helper's own line had a guard.

## Fix

- Commit 1: the except keeps the plain verdict, keeps the traceback's last line (200 characters, the recipe `drainError` uses two lines below) and writes it to the row as `reasonError` beside the `drainError` line, and says so on stderr best-effort. The pinned `reason = _unrequested_signal_reason(signum, be)` line is unchanged. One sentence in docs/reference.md's restart-files passage describes the field.
- Commit 2: tests only (below).
- Commit 3: `_exit_log`, a best-effort stderr line defined above `_graceful_term` (outside the pinned `_graceful_term`..`main()` block), carries every line on the exit path. The announcement now precedes the `try`, whose body is the drain alone, so `drainError` names a fault of the drain only. The row-failed line goes through it, so `os._exit(0)` is reached whatever stderr does, and the line that names the reason helper's fault does too, so its raise cannot leave the inner except for the outer one, which writes no row. The drain-failed line follows for hygiene: the finally reaches `os._exit(0)` either way. With a healthy stderr the output is unchanged. The `_drain_and_exit` docstring states the property.

## Tests

All in tests/test_restart_cuts.py. Every case runs the real code in-process under the module's own state root with `sys.stderr` swapped for the call and restored, and only reaped pids as `ROMP_MANAGER_PID`; the handler-level cases run `_graceful_term` or `_parent_watch` with `os._exit` patched to raise SystemExit, the direct-call case swaps stderr only.

- `UnrequestedSignal::test_a_raising_reason_helper_still_leaves_the_cut_row` (extended): asserts `reasonError == "OverflowError: pid"`, no `drainError`, no `signal` row on this path, and that the stderr line names the field. Before commit 1: `KeyError: 'reasonError'`.
- `UnrequestedSignal::test_a_closed_stderr_does_not_undo_the_service_stop_verdict` (new, commit 2): a closed `io.StringIO` as stderr (its write raises ValueError, the kind a reset stream leaves behind), a reaped pid, the helper called with `wait=0`; asserts `SIGNAL_REASON_MANAGER_STOPPED`, one audit row with `managerStopped` true, and the row's reason equal to the return. Red by mutation: with the helper's guard removed, `ValueError: I/O operation on closed file` out of the call (the broken-pipe test beside it goes red through the handler as well; every other case stays green). No kernel change in this commit.
- `UnrequestedSignal::test_a_raising_stderr_does_not_skip_the_drain` (new): a `DeadTty` stderr (OSError EIO) and a `LiveDrain` backend through `_graceful_term`; asserts the drain ran, `cutTurns` names the turn, and no `drainError`. Before commit 3: `False is not true: the drain runs whatever stderr does` (cutTurns empty, drainError naming the OSError).
- `UnrequestedSignal::test_a_raising_stderr_when_the_cut_row_fails_still_exits` (new): `_restart_cut_row` raising RuntimeError under the dead stderr; asserts `os._exit(0)` was reached once and no row. Before: `OSError: [Errno 5] Input/output error` raised out of the handler in place of the exit.
- `ParentGone::test_a_raising_stderr_does_not_skip_the_drain` (new): the same through `_parent_watch` with a reaped manager pid; asserts the drain ran and both rows land. Before: the drain was skipped.
- `UnrequestedSignal::test_a_raising_reason_helper_under_a_dead_stderr_still_leaves_the_cut_row` (new): the helper raising OverflowError under a closed `io.StringIO` stderr; asserts one cut row with the plain verdict and `reasonError == "OverflowError: pid"`, no `signal` row. Red by mutation: with that one line a bare `sys.stderr.write`, no row lands (`0 != 1`); with `_exit_log` narrowed to `except OSError`, ValueError out of the handler.
- `UnrequestedSignal::test_the_handler_files_the_row_and_the_cut_reason_when_nothing_asked` (extended): a clean exit's row carries neither `drainError` nor `reasonError`. Red with the field set unconditionally.

Targeted run on the final tree (tests/test_restart_cuts.py, test_main_drift_notice, test_restart_seam, test_restart_audit, test_kernel_headless_ops): 148 passed, 26 subtests. The source pins in CutRow, test_restart_seam, test_kernel_headless_ops and test_main_drift_notice hold unchanged. Full pytest (`-n 6`, extension node modules installed so the served-page legs run): 11235 passed, 41 skipped, 1740 subtests passed.

Added after the review (2026-09-10, commit 3d4188b3, the fourth commit): the SDK backend's `log=` wire in `_sdk_locked` was a bare `sys.stderr.write` lambda, and `SdkBackend.drain` logs its summary line after every session is shut down, joined and reaped, immediately before it returns, so under a dead stderr that one line raised out of `be.drain` with the work already done and `_drain_and_exit` filed an empty `cutTurns` row with a `drainError` naming the stderr fault, the misfiled row the guards in commit 3 exist to close. The wire now goes through a `_backend_log` callback that writes the `sdk-backend:` line through `_exit_log`, so the guard covers the backend's whole life, not the exit alone. Tests: the `LiveDrain` fake logs its summary through the wired callback, `UnrequestedSignal.test_a_raising_stderr_does_not_skip_the_drain` therefore exercises the summary line under the raising stderr, and `CutRow.test_the_backends_log_wire_is_best_effort` pins the wire (`log=_backend_log`) and that `_backend_log` swallows a raising stderr. Not changed: the codex backend's `log=` wire keeps the bare lambda; `CodexBackend` has no drain and `_drain_and_exit` drains the SDK backend alone, so it is off the exit path.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

