### PR TITLE
Files pane: the file viewer as a dashboard column of its own, off by default, with a File links open in setting

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,10 @@
 
 Romp is one always-on **kernel**: a single Python process that reads each
 session's Claude Code transcript, builds an event tree, runs the **judges**
-that write the durable records, and serves the four views over HTTP +
+that write the durable records, and serves the five views over HTTP +
 WebSocket.
 
-![From transcripts, through the kernel and judges, to the four views](assets/guide/architecture.png){ width="75%" }
+![From transcripts, through the kernel and judges, to the five views](assets/guide/architecture.png){ width="75%" }
 
 The judges are small `claude -p` calls with no tools and MCP disabled: they can
 caption, index, and file work, but structurally cannot act. They spend a little

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -4,7 +4,7 @@ This guide covers how to use Romp and how its back end works.
 
 ## The Romp user interface
 
-Romp gathers all your Claude Code sessions into one interface, with four
+Romp gathers all your Claude Code sessions into one interface, with five
 complementary views of what the agents are doing:
 
 - **[The chat](#the-chat)** is the regular interface for talking to a coding
@@ -16,6 +16,8 @@ complementary views of what the agents are doing:
   chat.
 - **[The outline](#the-outline)** lists every session with its tasks, for
   reviewing what a session has done and searching across all of them.
+- **[Files](#files)** holds the file viewer in a column of its own, so a file
+  stays open beside the chat and the feed. Off by default.
 
 ### The chat
 
@@ -241,6 +243,19 @@ beneath. Open the outline to review what a session has worked through, or to
 find past work: the search box reaches every session, live or closed.
 
 ![The outline: each session's tasks as a tree](assets/guide/outline.png){ width="100%" }
+
+### Files
+
+The Files pane holds the file viewer in a column of its own, beside the chat
+and the feed, so an open file covers neither. While the pane is open, a file
+link clicked in the chat opens in it. When it is closed, the gear's **File
+links open in** setting decides where a link opens: over the pane you clicked
+(the default), or in the Files pane, which then opens and stays open; on a
+phone, closing the file takes you back to the tab you came from. Selecting a
+passage in the viewer puts the quote in the chat's composer, as it does from
+the viewer over the chat. When no file is open, the pane lists the files most
+recently opened in it; click one to open it again. The pane is off by default;
+the bottom bar turns it on, and on a phone it is a tab like the others.
 
 ## Automatic nudges
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -6559,7 +6559,7 @@ def _conserve_tick(now):
     if not be or not hasattr(be, "conserve_close"):
         return
     with _clients_lock:
-        viewer = any(c.get("alive", True) and c.get("app") in ("chat", "fleet", "timeline", "feed")
+        viewer = any(c.get("alive", True) and c.get("app") in ("chat", "fleet", "timeline", "feed", "files")
                      for c in _clients)
     if viewer:
         _conserve_last_viewer[0] = now
@@ -44584,13 +44584,19 @@ def _reload_core_js(v=0, boot=None):
     return js[i + len(a):j]
 
 
-def _shim(app, v=0):
+def _shim(app, v=0, no_stale=False):
     # `v` = the dist build token this page was served with (its ?v= urls). The shim compares it against the
     # `dv` riding every keepalive and, on drift, asks the reload core it embeds as the template's first slot
     # (window.__rompReload, _RELOAD_CORE_JS) to reload the page — never mid-gesture (the user 2026-09-08,
     # superseding the 2026-07-13 banner; the build bar is only the refused fallback). EVERY kernel-served page
     # notices, not just the dashboard landing's /version poll (the user 2026-07-13: a standalone pane sat
     # silent through rebuilds).
+    # `no_stale` = this page receives no pushed view (the Files pane: request/response only), so the
+    # "may be stale" prompt is never armed for it and never retired by it (NOSTALE below). The prompt is
+    # armed on an unannounced reconnect and retired by the resync frame; a page that gets no resync would
+    # raise the dashboard-wide banner on the second keepalive after every reconnect, for content a dropped
+    # socket cannot make stale, and its own op replies would retire a prompt another pane raised. The build
+    # drift reload is separate and stands for every page.
     return """
 %s
 (function(){/*shim-core*/var queue=[],ws=null,everConnected=false;
@@ -44607,7 +44613,7 @@ try{if(!wid)wid=window.sessionStorage.getItem("romp:wid")||"";}catch(e){}
 // kernel retires this page's previous socket on a reconnect, and never another page's (a duplicated tab copies
 // sessionStorage, and with it wid; it must not copy this).
 var IID="";try{IID=(window.crypto&&crypto.randomUUID)?crypto.randomUUID():"";}catch(e){}if(!IID)IID=String(Math.random()).slice(2)+"-"+Date.now();
-var APP="%s";var LOADEDV=%d;var lastRecv=0;var STALE_MS=30000;   // watchdog: no frame (incl. keepalive) for this long → the socket is dead → reconnect
+var APP="%s";var LOADEDV=%d;var NOSTALE=%s;var lastRecv=0;var STALE_MS=30000;   // watchdog: no frame (incl. keepalive) for this long → the socket is dead → reconnect
 var PROVISIONAL_MS=15000,resumeProvisional=0;   // a resumed keep is PROVISIONAL (review find, 2026-09-08): the `resume` stamp below re-bases the watchdog on a socket the browser still holds OPEN, but the far end can have died without a FIN reaching the browser, and only the kernel's next frame can tell. Until one lands the watchdog runs at 1.5 keepalive periods (KEEPALIVE_S is 10 s, so 15 s: one beat may be in flight, two missing is silence) instead of STALE_MS. resumeProvisional holds the stamp a kept socket rests on; 0 once a frame confirmed it (or the socket is a fresh one)
 var connT=0;   // when the current socket's connect() attempt started — the progress watchdog's reference point
 // Tell the shell this pane's WS state so it can show ONE "disconnected" banner (the user 2026-06-27): a real
@@ -44637,6 +44643,7 @@ function selfStale(){selfBar("romp lost the live connection, so what you see may
 // the first non-keepalive frame after a reconnect — the event, not a timer. A BUILD prompt is untouched:
 // new code is not delivered by a resync, so only a reload can answer that one.
 function clearStale(){stalePending="";   // armed but never shown → nothing to see
+if(NOSTALE)return;   // a page with no pushed view armed nothing, so it retires nothing: its op replies must not clear a prompt another pane raised
 if(window.parent!==window){try{window.parent.postMessage({romp:"wsFresh"},"*");}catch(e){}}
 else{var b=document.getElementById("romp-stale-self");if(b&&b.dataset.kind==="conn")b.remove();}
 try{window.dispatchEvent(new Event("romp:wsfresh"));}catch(e){}}   // the pane's own reconnecting cue (_pane_spin's corner badge) ends on FRESH DATA, not on the socket opening (the user 2026-09-07: over a slow link the resync ran for seconds with no cue, so the dashboard looked frozen)
@@ -44724,7 +44731,7 @@ if(window.parent!==window){try{window.parent.postMessage({romp:"wsStale"},"*");}
 // last opened (the close rule applies to a socket that OPENED and armed, never to the one the foreground
 // path itself closes).
 var stalePending="",staleKa=0,pendingWhy="",openSock=null,openT=0;
-function armStale(why){stalePending=why;staleKa=0;}
+function armStale(why){if(NOSTALE)return;stalePending=why;staleKa=0;}   // NOSTALE: no pushed view, so no resync could ever retire the arm (the Files pane)
 // BUILD drift: the keepalive carries the kernel's current dist token (dv); a page whose baked LOADEDV is older is
 // running outdated code against newer kernel state. The user 2026-07-13 wanted EVERY kernel-served page to notice
 // (a standalone pane sat silent through rebuilds); the user 2026-09-08 ruled the page RELOADS ITSELF, superseding
@@ -44933,7 +44940,7 @@ pendingWhy="foreground";freshPending=true;   // the reconnect's arm reads "foreg
 if(ws&&ws.readyState===1)abandon();else{try{if(ws&&ws.readyState===0)ws.close();}catch(e){}}   // OPEN-but-quiet → abandoned + redialed below, now; stuck-CONNECTING → aborted, onclose retries
 if(!ws||ws.readyState===3)connect();
 returnDiag("return",row);});/*end-shim-core*/})();   // filed AFTER the redial so it queues for the new socket instead of vanishing into the dead one
-""" % (_reload_core(v), app, int(v), app, app)
+""" % (_reload_core(v), app, int(v), "true" if no_stale else "false", app, app)
 
 
 def _shim_core_js(app="test", v=0):
@@ -45320,6 +45327,36 @@ def _fleet_page():
             % (v, THEME_CSS, fleet_css, _pane_spin("fleet-list"), _shim("fleet", v), v, v))
 
 
+# Files: the file VIEWER as a dashboard column of its own (app=files), hosting the same shared viewer
+# (ui/webview/file-view.ts) the chat and the feed host as a modal, pane-resident by CSS alone. The pane is
+# not a feed consumer: the viewer is request/response (bytes over HTTP /file; saveFile and fileGitLink
+# answer the sending socket), so nothing is built or pushed for app=files, and the shim runs with the stale
+# opt-out (no resync frame will ever come). ui/webview/files.ts renders it; it loads the chat's styles.css
+# for the viewer's dress. Its layout CSS lives in ui/webview/files-pane.css, ONE file, read live here and
+# bundled into the VS Code VSIX by vscode-extension/esbuild.js, so the two hosts cannot drift. No
+# _pane_spin: an empty pane is not a loading state.
+def _files_page():
+    try:
+        files_css = (UI / "webview" / "files-pane.css").read_text()
+    except OSError:
+        return ("<!DOCTYPE html><html><body style='font-family:Inter,system-ui,-apple-system,sans-serif;color:#999;"
+                "background:#1e1e1e;padding:12px'>romp's Files pane needs the ui/ modules "
+                "(webview/files-pane.css).</body></html>")
+    v = _dist_ver()
+    return ("<!DOCTYPE html><html lang=en><head><meta charset=UTF-8>"
+            "<meta name=viewport content='width=device-width,initial-scale=1'>"
+            "<link rel=icon type=image/svg+xml href=/media/romp-swirl-glyph.svg><title>Romp · files</title>"
+            # the chat's stylesheet provides the viewer's dress (.fileview-*, the file browser, the code
+            # palette); files-pane.css (in the <style> AFTER it) owns the page layout and the pane-resident
+            # variant keyed on body.fileview-pane, so the two mirrored viewer sheets stay byte-equal.
+            "<link href=/dist/styles.css?v=%d rel=stylesheet>"
+            "<style>%s\n%s</style></head><body class=fileview-pane>"
+            "<div id=files-empty></div>"
+            "<script>%s</script><script src=/dist/federation.js?v=%d></script>"   # multi-kernel manager: after the shim
+            "<script src=/dist/files.js?v=%d></script></body></html>"
+            % (v, THEME_CSS, files_css, _shim("files", v, no_stale=True), v, v))
+
+
 # The romp-tl-* wrapper styles live in ui/webview/timeline-pane.css — ONE file, read live here (like the
 # view JS itself) and bundled into the VS Code VSIX by vscode-extension/esbuild.js, so the two hosts cannot drift.
 
@@ -45457,15 +45494,16 @@ col.style.setProperty('--tl',Math.max(48,Math.min(mx,px))+'px');}
 function up(){document.body.classList.remove('drag','dragh');
 window.removeEventListener('mousemove',mv);window.removeEventListener('mouseup',up);}
 window.addEventListener('mousemove',mv);window.addEventListener('mouseup',up);});
-// ── pane gutters (chat|fleet|feed, fixed order) sized by flex-grow. gv-a is always chat|fleet; gv-b's left
-// neighbour is fleet when shown else chat (so it's the chat|feed gutter when fleet is off). On grab we
-// normalise every visible pane's grow to its px width so the drag shifts only that pair; grows persist.
-var PANES=['chat-pane','fleet-pane','feed-pane'];
-var GK='romp-pane-grow',grow={chat:60,fleet:34,feed:40};
+// ── pane gutters (chat|outline|feed|files, fixed order) sized by flex-grow. gv-a is always chat|outline; gv-b's
+// left neighbour is the outline when shown else chat (so it's the chat|feed gutter when the outline is off);
+// gv-c's is the rightmost of feed, outline, chat that is shown. On grab we normalise every visible pane's grow
+// to its px width so the drag shifts only that pair; grows persist.
+var PANES=['chat-pane','fleet-pane','feed-pane','files-pane'];
+var GK='romp-pane-grow',grow={chat:60,fleet:34,feed:40,files:40};
 try{var g=JSON.parse(localStorage.getItem(GK)||'null');if(g)grow=Object.assign(grow,g);}catch(e){}
 function setGrow(k,v){grow[k]=v;row.style.setProperty('--g-'+k,v);}
 for(var k in grow)setGrow(k,grow[k]);
-function key(id){return id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':'feed';}
+function key(id){return id==='chat-pane'?'chat':id==='fleet-pane'?'fleet':id==='feed-pane'?'feed':'files';}
 function shown(id){var p=document.getElementById(id);return p&&getComputedStyle(p).display!=='none';}
 // a pane re-shown from the rail gets a grow comparable to the panes already visible, so it never slots back
 // in as a sliver after the others were dragged to extreme widths (grows are stored as px). Timeline is the
@@ -45494,6 +45532,7 @@ window.removeEventListener('mousemove',mv);window.removeEventListener('mouseup',
 show();window.addEventListener('mousemove',mv);window.addEventListener('mouseup',up);});}
 gutter('gv-a',function(){return 'chat-pane';},'fleet-pane');
 gutter('gv-b',function(){return document.body.classList.contains('po-fleet')?'fleet-pane':'chat-pane';},'feed-pane');
+gutter('gv-c',function(){var c=document.body.classList;return c.contains('po-feed')?'feed-pane':c.contains('po-fleet')?'fleet-pane':'chat-pane';},'files-pane');
 tf&&tf.addEventListener('load',function(){autosize();
 try{new ResizeObserver(autosize).observe(tf.contentDocument.body);}catch(e){}});
 window.addEventListener('resize',autosize);
@@ -45508,8 +45547,8 @@ window.addEventListener('romp-panes',autosize);   // re-fit when the Timeline to
 # all EVENT-based (no polling). Re-wires on every iframe (re)load; chat is the default focus on open. Inert on
 # mobile (one pane at a time; .pane is display:contents).
 _LANDING_FOCUS_JS = """
-(function(){var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-timeline':'tl-pane'};   // Fleet is its own pane
-var COLS=['f-chat','f-fleet','f-feed'];   // the side-by-side column panes, left->right (Fleet = the Outline)
+(function(){var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-files':'files-pane','f-timeline':'tl-pane'};   // the Outline (key fleet) is its own pane
+var COLS=['f-chat','f-fleet','f-feed','f-files'];   // the side-by-side column panes, left->right (the Outline's key is fleet; Files last)
 var TL='f-timeline';                       // the timeline is a bottom BAND under the columns
 var curFocus='f-chat', lastCol='f-chat';   // for Shift-Up out of the timeline: return to the last column used
 // The active pane gets a focus RING (.pane-focused). Same-origin iframes, so the shell sets it directly on
@@ -45612,7 +45651,7 @@ setTimeout(hide,5000);})();
 # together; a second hardcoded list is the bug this replaces (the bell's PN was the last one, the
 # #957 review). Defined above _LANDING_ERRS_JS because that string is built from it at import.
 # Keys stay internal (timeline/fleet); labels are the user-facing names.
-_PANE_ORDER = (("chat", "Chat"), ("timeline", "Sessions"), ("fleet", "Outline"), ("feed", "Feed"))
+_PANE_ORDER = (("chat", "Chat"), ("timeline", "Sessions"), ("fleet", "Outline"), ("feed", "Feed"), ("files", "Files"))
 
 _LANDING_ERRS_JS = """
 (function(){var icon=document.getElementById('rail-errs'),micon=document.getElementById('merr'),
@@ -45775,7 +45814,7 @@ else{var nt=document.getElementById('rnet-back');
 if(nt&&!nt.hidden&&window.__rompCloseNet){window.__rompCloseNet();closed=true;}}}}}}
 if(closed){e.preventDefault();e.stopPropagation();}}
 document.addEventListener('keydown',onEsc,true);
-['f-chat','f-fleet','f-feed','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
+['f-chat','f-fleet','f-feed','f-files','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
 var wire=function(){try{if(f.contentDocument)f.contentDocument.addEventListener('keydown',onEsc,true);}catch(e){}};
 f.addEventListener('load',wire);wire();});
 })();
@@ -46832,11 +46871,38 @@ if(m.romp==='settings')document.body.classList.toggle('settings-open',!!m.on);
 if(m.romp==='openLog'&&window.__rompOpenErrs)window.__rompOpenErrs();
 // the /chat iframe's new-session picker asks the shell to lift it full-window (see body.picker-open CSS)
 if(m.romp==='picker')document.body.classList.toggle('picker-open',!!m.on);
+// A file link clicked in the chat and routed to the FILES pane (ui/webview/file-route.ts fileLinkRoute,
+// decided at the click in render.ts openPath: the pane is on screen, or the gear's "File links open in"
+// names it) posts viewFile up with pane:'pane'. The shell brings that pane forward, the click being the
+// one gesture that moves it, and forwards the click with the session's identity the chat resolved (name
+// and colour: the pane has no session list to name the file's session by; files.ts caches it for the
+// viewer's chip). The pane STAYS up, so nothing is owed back to the shell: no was-off flag, no ack, no
+// restore. On a phone (one pane at a time) the Files tab comes forward only in the mobile layout (on
+// desktop the column is already visible, and show() would only persist a stale romp-mobile-tab for a later
+// narrow layout), and the tab the click came from is remembered so the viewer's close puts the person back
+// (filesViewerClosed below). The forward itself waits for a Files page that is still loading (the dashboard
+// just opened; a phone's hidden iframe boots late): a postMessage into a document whose files.js has not
+// registered its listener yet would be dropped with the pane brought forward empty, so the iframe's load
+// event, after which the listener exists, is when a click that arrived early is delivered. A viewFile
+// naming no pane is not this arm's: the chat opens those in place.
+if(m.romp==='viewFile'&&m.pane==='pane'){var ff=document.getElementById('f-files');
+  try{window.__rompPaneToggle&&window.__rompPaneToggle('files',true);}catch(e){}
+  try{if(window.__rompMobileOn&&window.__rompMobileOn()){var cur=document.body.getAttribute('data-tab')||'chat';
+    if(cur!=='files'){window.__rompFilesTabFrom=cur;window.__rompMobileTab&&window.__rompMobileTab('files');}}}catch(e){}
+  var fwd=function(){try{ff&&ff.contentWindow&&ff.contentWindow.postMessage({romp:'viewFile',path:m.path,sid:m.sid,identity:m.identity||null},'*');}catch(e){}};
+  var rd='';try{rd=(ff&&ff.contentDocument)?ff.contentDocument.readyState:'';}catch(e){}
+  if(ff&&rd!=='complete'){var once=function(){ff.removeEventListener('load',once);fwd();};ff.addEventListener('load',once);}else fwd();}
+// the Files pane's viewer closed (files.ts posts it on the close edge: nothing left up in the pane): on a
+// phone, where the arm above switched tabs to show it, go back to the tab the click came from; on desktop
+// the column simply shows its recent list again. The remembered tab is dropped either way, so a rotation to
+// desktop in between makes the return a no-op, never a stale switch later.
+if(m.romp==='filesViewerClosed'){var back=window.__rompFilesTabFrom;window.__rompFilesTabFrom=null;
+  if(back&&window.__rompMobileOn&&window.__rompMobileOn()){try{window.__rompMobileTab&&window.__rompMobileTab(back);}catch(e){}}}
 // "Browse files" from any pane surfaces the FILE BROWSER in the FEED pane, which is a different
 // document — so the shell relays it. If the feed pane is toggled off we turn it on for the duration
 // and remember to put it back, so the browser never costs the user their layout. (File VIEWS need
 // none of this since 2026-08-15: the viewer is a modal over whatever document clicked, so it never
-// touches the panes and has nothing to restore.)
+// touches the panes and has nothing to restore; a view routed to the Files pane is the arm above.)
 if(m.romp==='browseFiles'){var bf=document.getElementById('f-feed');
   if(!document.body.classList.contains('po-feed')){window.__rompFeedWasOff=true;
     try{window.__rompPaneToggle&&window.__rompPaneToggle('feed',true);}catch(e){}}
@@ -47549,6 +47615,11 @@ refresh();   // self-schedules (fast while attaching, slow keep-alive otherwise)
 # app=shell WebSocket when a feed/timeline tap brings the chat forward (see _reveal_chat_for), and the
 # timeline deep-link posts the same shape as a window message. The active tab persists in localStorage.
 # Entirely inert on desktop, where #mtabs is hidden and all three panes are shown at once.
+# The mobile LAYOUT's one media query: the stylesheet lays the grid out by it (_landing's @media block) and
+# the mobile script answers __rompMobileOn by it, so the two can never disagree. Narrow, OR a touch device up
+# to 1024px, is one pane at a time with bottom tabs; mouse desktops keep the grid.
+_MOBILE_MQ = "(max-width:820px),(pointer:coarse) and (max-width:1024px)"
+
 _LANDING_MOBILE_JS = """
 (function(){
 // The shell's own client-diag rows (2026-09-08): the bell's and the tap-landing scripts record what they saw
@@ -47630,26 +47701,46 @@ document.addEventListener('focusout',refit);
 if(window.visualViewport){window.visualViewport.addEventListener('resize',refit);
 window.visualViewport.addEventListener('scroll',refit);}
 function hearBlur(f){try{if(!f.contentDocument)return;f.contentWindow.addEventListener('focusout',refit);}catch(e){}}   // cross-origin → nothing to hear
-['f-chat','f-fleet','f-feed','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
+['f-chat','f-fleet','f-feed','f-files','f-timeline'].forEach(function(id){var f=document.getElementById(id);if(!f)return;
 f.addEventListener('load',function(){hearBlur(f);});hearBlur(f);});   // now (already loaded) + on every (re)load, as the Alt+Arrow wiring does
+// The mobile LAYOUT, as the stylesheet decides it: the SAME media query the grid collapses on (_MOBILE_MQ,
+// one constant for the CSS and this probe), one pane at a time, bottom tabs, the po-* classes ignored. Read by
+// the pane-set broadcast (on a phone "on" means the tab showing, not the po flag) and by the viewFile relay's
+// tab switch, which is meaningless on desktop. Above the bar lookup on purpose: a desktop layout has no bar
+// and returns there, and must still answer (false). A window without matchMedia leaves MQ null: false too.
+var MQ=(window.matchMedia&&matchMedia(""" + json.dumps(_MOBILE_MQ) + """))||null;
+function mobileOn(){return !!(MQ&&MQ.matches);}
+window.__rompMobileOn=mobileOn;
 var bar=document.getElementById('mtabs');if(!bar)return;
-var F={chat:document.getElementById('f-chat'),fleet:document.getElementById('f-fleet'),feed:document.getElementById('f-feed'),timeline:document.getElementById('f-timeline')};
+var F={chat:document.getElementById('f-chat'),fleet:document.getElementById('f-fleet'),feed:document.getElementById('f-feed'),files:document.getElementById('f-files'),timeline:document.getElementById('f-timeline')};
 // ONLY the pane tabs (the user 2026-09-08, on the phone: the bell wore its OFF slash while its popover said
 // on). This list once took EVERY button in the bar, and show() toggled `.on` to data-pane===p on each — for
 // the action buttons and the bell (no data-pane) that is always off, so every pane switch stripped the
 // bell's `.on`, the class _LANDING_PUSH_JS paints from the master + this device's subscription and the
 // slash rule keys on, until the next paint event. A tab or a reveal decides which pane shows, nothing else.
 var B=bar.querySelectorAll('button[data-pane]'),KT='romp-mobile-tab';
-function show(p){if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)F[k].classList.toggle('m-on',k===p);
+function show(p){if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)if(F[k])F[k].classList.toggle('m-on',k===p);   // a pane this shell lacks is skipped, never a TypeError
 for(var i=0;i<B.length;i++)B[i].classList.toggle('on',B[i].getAttribute('data-pane')===p);
-try{localStorage.setItem(KT,p);}catch(e){}}
+try{localStorage.setItem(KT,p);}catch(e){}
+// a tab switch changes what is on screen: re-tell the panes (the collapse script's broadcast; absent only
+// before that script parses, and its boot apply then tells them)
+try{window.__rompPanesTell&&window.__rompPanesTell();}catch(e){}}
+window.__rompMobileTab=show;   // the shell's relays bring a pane's tab forward on a phone (the settings listener)
+// the layout flipping (a rotation, a resize across the breakpoint) changes what is on screen with no toggle
+// and no tab switch: the media query's own change event IS that flip, so re-tell the panes on it
+var retell=function(){try{window.__rompPanesTell&&window.__rompPanesTell();}catch(e){}};
+if(MQ){if(MQ.addEventListener)MQ.addEventListener('change',retell);else if(MQ.addListener)MQ.addListener(retell);}
 // A REVEAL un-hides a desktop-toggled-off pane before the mobile tab switch (the user 2026-08-13: a feed
 // click that jumps into a CLOSED chat used to land invisibly — the hidden iframe's WS stays live, so the
 // scroll ran under display:none and nothing appeared to happen). Same __rompPaneToggle(…, true) the Log
 // jump (feed) and toggleFleet (chat) precedents use; it persists via romp-panes like any manual toggle.
 // Guarded: the collapse script that defines __rompPaneToggle parses after this one — fine at message time.
-function reveal(p){try{window.__rompPaneToggle&&window.__rompPaneToggle(p,true);}catch(e){}show(p);}
-for(var i=0;i<B.length;i++)(function(b){var pk=b.getAttribute('data-pane');b.addEventListener('click',function(){show(pk);});})(B[i]);
+function reveal(p){try{window.__rompPaneToggle&&window.__rompPaneToggle(p,true);}catch(e){}userSwitch(p);}
+// a switch the person made (a tab tap, a reveal aimed at them, the chat header's Outline pill) is not the file
+// relay's: the tab the relay remembered for the viewer's close (the settings listener's __rompFilesTabFrom) is
+// dropped, so closing a file much later cannot jump them back to a tab they left on their own
+function userSwitch(p){window.__rompFilesTabFrom=null;show(p);}
+for(var i=0;i<B.length;i++)(function(b){var pk=b.getAttribute('data-pane');b.addEventListener('click',function(){userSwitch(pk);});})(B[i]);
 // the rail's actions on mobile: settings opens the feed iframe's modal (same path as the desktop
 // gear), net opens the shell's remotes panel, usage opens the tooltip's window bars as a modal, and
 // restart reuses the rail refresh's kernel restart (the user 2026-07-22 — the rail is hidden on mobile)
@@ -47661,7 +47752,7 @@ errs:function(){try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}}
 Array.prototype.forEach.call(bar.querySelectorAll('button[data-act]'),function(b){
 b.addEventListener('click',function(){var f=A[b.getAttribute('data-act')];if(f)f();});});
 window.addEventListener('message',function(e){var m=e.data;if(!m)return;if(m.romp==='reveal'&&m.pane)reveal(m.pane);// the chat header's Fleet pill / the fleet's back-to-chat post toggleFleet — on mobile that IS a tab switch
-if(m.romp==='toggleFleet')show(m.to==='chat'?'chat':'fleet');});
+if(m.romp==='toggleFleet')userSwitch(m.to==='chat'?'chat':'fleet');});
 var shellOpened=false;   // T265: this socket's REOPEN is the kernel-restart signal — the shell asks /version whose kernel answered
 function shellWS(){try{var proto=location.protocol==='https:'?'wss://':'ws://';
 var ws=new WebSocket(proto+location.host+'/ws?app=shell&wid='+encodeURIComponent(wid()));
@@ -48140,25 +48231,49 @@ _STALE_JS = (
     "check();setInterval(check,30000);})();")
 
 
-# Pane layout controller (the user 2026-06-24/25). The far-left rail holds Chat / Fleet / Feed / Timeline
-# toggles; each pane is an independent binary on/off (body.po-chat/po-fleet/po-feed/po-timeline → CSS shows/
-# hides the pane + the gutters between visible panes). Fixed visual order — Chat, Fleet, Feed, Timeline left
-# to right (timeline is the bottom BAND). Default Chat+Feed+Timeline on, Fleet off (the user 2026-06-25);
-# state persists in localStorage and ?panes=chat,timeline bookmarks a set. Exposes window.__rompPaneToggle(
-# key,to?) so the legacy toggleFleet postMessage (_LANDING_FLEET_JS) routes through the same path.
+# Pane layout controller (the user 2026-06-24/25). The far-left rail holds a toggle per pane (Chat, the
+# Outline, Feed, Timeline, Files); each pane is an independent binary on/off (body.po-chat/po-fleet/po-feed/
+# po-timeline/po-files: CSS shows/hides the pane + the gutters between visible panes). Fixed visual order,
+# chat, outline, feed, files left to right (timeline is the bottom BAND). Default Chat+Feed+Timeline on, the
+# Outline off (the user 2026-06-25) and the Files pane off; state persists in localStorage and
+# ?panes=chat,timeline bookmarks a set. Exposes window.__rompPaneToggle(key,to?) so the legacy toggleFleet
+# postMessage (_LANDING_FLEET_JS) routes through the same path. It also TELLS the panes what is on screen
+# ({romp:'panes',on:{key:bool}} into every pane iframe on every apply, on each iframe's load, and, from
+# _LANDING_MOBILE_JS, on a mobile tab switch or layout flip; the keys are _PANE_ORDER's, baked in below like
+# the bell's PN map): the chat routes file links by it. Defined after _PANE_ORDER because the string is built
+# from it at import.
 _LANDING_COLLAPSE_JS = """
 (function(){
-  var PK='romp-panes',po={chat:true,fleet:false,feed:true,timeline:true};
+  var PK='romp-panes',po={chat:true,fleet:false,feed:true,timeline:true,files:false};
   try{var s=JSON.parse(localStorage.getItem(PK)||'null');if(s)po=Object.assign(po,s);}catch(e){}
   var qp=new URLSearchParams(location.search).get('panes');
-  if(qp!==null){po={chat:false,fleet:false,feed:false,timeline:false};qp.split(',').forEach(function(k){k=k.trim();if(k in po)po[k]=true;});}
+  if(qp!==null){po={chat:false,fleet:false,feed:false,timeline:false,files:false};qp.split(',').forEach(function(k){k=k.trim();if(k in po)po[k]=true;});}
   function saveP(){try{localStorage.setItem(PK,JSON.stringify(po));}catch(e){}}
-  var LBL={chat:'chat',fleet:'fleet',feed:'feed',timeline:'timeline'};
+  var LBL={chat:'chat',fleet:'fleet',feed:'feed',timeline:'timeline',files:'files pane'};
+  // The pane KEYS, from _PANE_ORDER (the one list of panes), so a pane added there is broadcast below without
+  // anyone remembering this block. The panes learn which panes are ON SCREEN from the shell, which holds that
+  // state: {romp:'panes',on:{key:bool}} goes to every pane iframe on every apply(), a toggle being the event
+  // of the set changing (the boot apply seeds it; the storage and romp:keys re-applies re-send an unchanged
+  // set, redundant and harmless), again on each iframe's own load, so a pane that boots or reloads after the
+  // shell still hears the current set (the focus ring's "wire now + on every (re)load", _LANDING_FOCUS_JS),
+  // and from _LANDING_MOBILE_JS on a tab switch or a layout flip (what is on screen changed with no toggle).
+  // The chat routes a file-link click by it (ui/webview/file-route.ts fileLinkRoute: an OPEN Files pane takes
+  // the click whatever the "File links open in" setting says, since the pane being open IS the intent).
+  var KEYS=""" + json.dumps([k for k, _ in _PANE_ORDER]) + """;
+  // on[k] is "this pane is on screen", not the po flag: in the mobile layout (one tab at a time, the po-*
+  // classes ignored, _LANDING_MOBILE_JS) it is the current tab, so a po.files left true by a desktop session
+  // or an earlier bring-forward cannot silently steer a phone's file links into a tab nobody is looking at
+  function panesMsg(){var mob=!!(window.__rompMobileOn&&window.__rompMobileOn()),tab=mob?document.body.getAttribute('data-tab'):null;
+    var on={};KEYS.forEach(function(k){on[k]=mob?(k===tab):!!po[k];});return {romp:'panes',on:on};}
+  function tell(f,m){try{f&&f.contentWindow&&f.contentWindow.postMessage(m,'*');}catch(e){}}
+  function broadcast(){var m=panesMsg();KEYS.forEach(function(k){tell(document.getElementById('f-'+k),m);});}
+  window.__rompPanesTell=broadcast;   // the mobile script re-tells on a tab switch / layout flip
   function apply(){
     document.body.classList.toggle('po-chat',!!po.chat);
     document.body.classList.toggle('po-fleet',!!po.fleet);
     document.body.classList.toggle('po-feed',!!po.feed);
     document.body.classList.toggle('po-timeline',!!po.timeline);
+    document.body.classList.toggle('po-files',!!po.files);
     Array.prototype.forEach.call(document.querySelectorAll('.rail-btn[data-pane]'),function(b){
       var k=b.getAttribute('data-pane');b.classList.toggle('on',!!po[k]);
       // tooltip carries the pane command's CURRENT binding (hover discoverability, the user 2026-08-10) —
@@ -48166,14 +48281,17 @@ _LANDING_COLLAPSE_JS = """
       var h=(window.__rompKeyHint&&window.__rompKeyHint('pane.'+(k==='fleet'?'outline':k)))||'';
       b.title=(po[k]?'hide':'show')+' the '+(LBL[k]||k)+(h?' ('+h+')':'');});
     try{window.dispatchEvent(new Event('romp-panes'));}catch(e){}   // nudge the timeline band to auto-fit when toggled
+    broadcast();
   }
   function togglePane(k,to){if(!(k in po))return;var nv=(to===undefined)?!po[k]:!!to;
+    if(nv===!!po[k])return;   // already so (a relay's bring-forward on an open pane): nothing changed, so no re-apply and no broadcast claiming one
     if(nv&&!po[k]&&window.__rompGrowFair)window.__rompGrowFair(k);   // newly shown → fair width, not a sliver
     po[k]=nv;apply();saveP();}
   window.__rompPaneToggle=togglePane;
   Array.prototype.forEach.call(document.querySelectorAll('.rail-btn[data-pane]'),function(b){
     b.addEventListener('click',function(){togglePane(b.getAttribute('data-pane'));});});
   apply();
+  KEYS.forEach(function(k){var f=document.getElementById('f-'+k);if(f)f.addEventListener('load',function(){tell(f,panesMsg());});});   // wired after the boot apply: both orders (iframe first / shell first) are covered
   window.addEventListener('romp:keys',apply);   // a rebind (or palette-main's boot nudge) refreshes the titles
   window.addEventListener('storage',apply);     // …including one made in another tab
 })();
@@ -49006,14 +49124,16 @@ def _landing():
             # the host heading's size without its lowercase-italic host vocabulary
             ".ru-tip-acct{font:400 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;"
             "color:#9aa0a6;margin:0 0 4px}"
-            # the three TOP panes flex-grow by a per-pane var (resized by the gutters, persisted); toggling one
-            # off hides it AND the now-orphaned gutters. Fixed order: chat, fleet, feed. Timeline is the band.
-            "#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}"
-            "body:not(.po-chat) #chat-pane{display:none}body:not(.po-fleet) #fleet-pane{display:none}body:not(.po-feed) #feed-pane{display:none}"
+            # the four TOP panes flex-grow by a per-pane var (resized by the gutters, persisted); toggling one
+            # off hides it AND the now-orphaned gutters. Fixed order: chat, outline, feed, files. Timeline is the band.
+            "#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}#files-pane{flex:var(--g-files,40) 1 0}"
+            "body:not(.po-chat) #chat-pane{display:none}body:not(.po-fleet) #fleet-pane{display:none}body:not(.po-feed) #feed-pane{display:none}body:not(.po-files) #files-pane{display:none}"
             ".row>.gv{flex:0 0 7px}"
-            # gv-a sits chat|fleet (only when both shown); gv-b sits (fleet|chat)|feed — the chat|feed gutter when fleet off.
+            # gv-a sits chat|outline (only when both shown); gv-b sits (outline|chat)|feed, so it is the chat|feed gutter when
+            # the outline is off; gv-c sits (feed|outline|chat)|files, hidden when files is off or no column is shown to its left.
             "body:not(.po-chat) #gv-a,body:not(.po-fleet) #gv-a{display:none}"
             "body:not(.po-feed) #gv-b,body:not(.po-chat):not(.po-fleet) #gv-b{display:none}"
+            "body:not(.po-files) #gv-c,body:not(.po-chat):not(.po-fleet):not(.po-feed) #gv-c{display:none}"
             # ── timeline BOTTOM BAND (the user 2026-06-25): a full-width band UNDER the pane row, shown only when
             # po-timeline (the rail's Timeline toggle); the gh gutter above it resizes it (auto-fits otherwise).
             # Band + gutter both hide when the toggle is off, so the pane row fills the height.
@@ -49065,7 +49185,8 @@ def _landing():
             "#tap-offer.acted{opacity:.55}"   # the press acknowledged at once; the chip goes the moment the record is retired
             "#mtabs{display:none}"
             # narrow OR a touch device up to 1024px → one pane + bottom tabs; mouse desktops keep the grid
-            "@media (max-width:820px),(pointer:coarse) and (max-width:1024px){"
+            # (_MOBILE_MQ: the same query the mobile script's __rompMobileOn probe answers by)
+            "@media " + _MOBILE_MQ + "{"
             # The bar is GLUED to the true viewport bottom (position:fixed;bottom:0 — see #mtabs below),
             # not flex-placed at the bottom of a body whose height is a viewport ESTIMATE. Every prior
             # approach keyed the bar's bottom to a height value (100dvh, then --app-h from
@@ -49095,11 +49216,11 @@ def _landing():
             ".pane.pane-focused::after{display:none}"
             # the Outline (fleet) rides the tab bar like every other pane (the user 2026-07-11, who couldn't
             # access the outline view in the mobile UI — it was desktop-only before)
-            "#chat-pane,#fleet-pane,#feed-pane,#tl-pane{display:contents!important}"
+            "#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}"
             # reset the desktop iframe absolute-fill (the bare `iframe` reset below re-flows them as tab panes)
             ".pane>iframe{position:static;inset:auto;width:100%;height:100%}"
             "iframe{position:static;display:none;width:100%;height:100%;border:0}"
-            "#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on{display:block}"
+            "#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on,#f-files.m-on{display:block}"
             "#f-timeline{flex:1 1 auto;min-height:0}#f-timeline.m-on{display:block}"
             "body[data-tab=timeline] .row{display:none}"    # timeline tab active → collapse the chat/feed row so the band fills
             # compact text-only switcher, FIXED to the visible viewport bottom so nothing can sit below it.
@@ -49372,6 +49493,8 @@ def _landing():
             "<div class=pane id=fleet-pane><iframe id=f-fleet src=/fleet></iframe></div>"
             "<div class=gv id=gv-b></div>"
             "<div class=pane id=feed-pane><iframe id=f-feed src=/feed></iframe></div>"
+            "<div class=gv id=gv-c></div>"
+            "<div class=pane id=files-pane><iframe id=f-files src=/files></iframe></div>"
             "</div>"
             "<div id=gv-ghost></div>"   # the divider drag's landing line (position:fixed; gutter() in _LANDING_JS moves it)
             # the timeline BOTTOM BAND: full-width below the pane row, with a row-resize gutter above it. Both
@@ -50502,6 +50625,9 @@ class Handler(BaseHTTPRequestHandler):
             if p == "/fleet":
                 _client_seen[0] = time.time()
                 return self._send(200, _fleet_page(), "text/html; charset=utf-8", cache="no-cache")
+            if p == "/files":
+                _client_seen[0] = time.time()
+                return self._send(200, _files_page(), "text/html; charset=utf-8", cache="no-cache")
             if p == "/sw.js":
                 # the push service worker (see _SW_JS). Behind the gate on purpose: the browser's
                 # register() fetch is same-origin and carries the cookie, and only an authed shell

--- a/tests/test_files_pane.py
+++ b/tests/test_files_pane.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""The Files pane (app=files): the file viewer as a dashboard column of its own, beside Chat,
+Sessions, Outline and Feed, off by default, with the gear's "File links open in" setting routing a
+chat file-link click into it. The kernel side, pinned here:
+
+- the pane is not a feed consumer. The viewer is request/response (HTTP /file for the bytes; the
+  saveFile and fileGitLink ops answer the sending client), so app=files is outside the feed audience
+  and _push builds nothing for it; it counts only where a live pane must count, the conserve-memory
+  viewer check.
+- the /files page: the chat's styles.css for the viewer's dress, files-pane.css read live for the
+  layout and the pane-resident variant (body.fileview-pane), no romp loader (an empty pane is not a
+  loading state), the shim with the stale opt-out (a page that receives no pushed view never arms
+  the shared "may be stale" prompt), federation.js before files.js.
+- the shell: a fifth column after Feed, off by default, with its gutter, grow var, focus, Escape and
+  mobile wiring, and the _PANE_ORDER label "Files"; the viewFile relay's pane arm, which brings the
+  pane forward and forwards the click, identity included, into it. The arms are executed under node
+  in tests/test_pane_state_broadcast.py; this module pins the served pages and the kernel's shape.
+
+Synthetic fixtures only (the notes-api demo world, placeholder sids); nothing here mints a goal.
+"""
+import json
+import os
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from romp_load import load_source
+
+
+def _has(tc, needle, text, msg=""):
+    """assertIn without the dump: a failure names the needle, never a whole page or source file."""
+    tc.assertTrue(needle in text, msg or ("missing: %r" % needle))
+
+
+def _lacks(tc, needle, text, msg=""):
+    tc.assertFalse(needle in text, msg or ("present: %r" % needle))
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["ROMP_SERVE_TOKEN"] = "testtok"
+km = load_source("romp_kernel_fpane", os.path.join(BIN, "romp-kernel"))
+SRC = open(os.path.join(BIN, "romp-kernel")).read()
+UI = Path(ROOT) / "ui" / "webview"
+
+
+class _Backend:
+    """The conserve-memory pass's backend, with nothing running: the pass then only records
+    whether a viewer is connected, which is the one fact these tests read."""
+
+    def running_sids(self):
+        return []
+
+    def live_sessions(self):
+        return {}
+
+    def conserve_idle(self, sid):
+        return True
+
+    def conserve_close(self, sid):
+        return False
+
+
+class Plumbing(unittest.TestCase):
+    """app=files is a viewer to the kernel, not a feed client: keepalives and its own op replies ride
+    its socket, nothing is built for it, and it counts as a live dashboard for conserve-memory."""
+
+    def test_files_is_outside_the_feed_audience(self):
+        # the ONE question _push asks of its targets (want_feed) and the route asks of the connected set
+        self.assertFalse(km._feed_audience([{"app": "files"}]))
+        self.assertTrue(km._feed_audience([{"app": "feed"}]))
+        self.assertTrue(km._feed_audience([{"app": "files"}, {"app": "chat"}]))
+        push = SRC[SRC.index("def _push(targets"):]
+        push = push[:push.index("\ndef ")]
+        _lacks(self, '"files"', push, "_push names every app it builds for; the Files pane is not one")
+
+    def test_the_socket_accepts_any_app_name(self):
+        # the handshake has no allowlist, so app=files connects on a kernel exactly as the other panes do
+        _has(self, 'app = (q.get("app") or ["chat"])[0]', SRC)
+
+    def test_an_open_files_pane_counts_as_a_viewer_for_conserve_memory(self):
+        # executed: the pass stamps the last-viewer clock when a Files pane is the only client; a socket
+        # with no pane behind it (the shell's) does not
+        def tick(app, now):
+            clients = [{"app": app, "alive": True}]
+            with mock.patch.object(km, "_conserve_on", lambda: True), \
+                 mock.patch.object(km, "_sdk", lambda: _Backend()), \
+                 mock.patch.object(km, "_views_client", lambda: {}), \
+                 mock.patch.object(km, "_clients", clients), \
+                 mock.patch.object(km, "_conserve_last_viewer", [0]) as last:
+                km._conserve_tick(now)
+                return last[0]
+        self.assertEqual(tick("files", 4242), 4242, "a Files pane is a viewer")
+        self.assertEqual(tick("feed", 4243), 4243)
+        self.assertEqual(tick("shell", 4244), 0, "the shell's own socket is not a pane")
+
+    def test_the_page_carries_the_shared_dress_the_stale_opt_out_and_no_loader(self):
+        page = km._files_page()
+        _has(self, "app=files", page)
+        _has(self, "var NOSTALE=true;", page, "the shim's stale opt-out is on for this page")
+        _has(self, "/dist/styles.css", page)   # the viewer's .fileview-* dress
+        _has(self, "<body class=fileview-pane>", page)   # keys the pane-resident variant
+        _has(self, "<div id=files-empty></div>", page)
+        _has(self, "/dist/federation.js", page)
+        _has(self, "/dist/files.js", page)
+        self.assertLess(page.index("/dist/federation.js"), page.index("/dist/files.js"), "manager before the bundle")
+        _lacks(self, "id=pane-spin", page, "an empty pane is not a loading state")
+        _lacks(self, "rel=manifest", page, "a pane, not an install target")
+        _has(self, 'if p == "/files":', SRC)
+        _has(self, "_files_page()", SRC)
+        # the sheet is read live, like fleet-pane.css; a missing one fails loudly on the page, never blank
+        css = (UI / "files-pane.css").read_text()
+        _has(self, css.splitlines()[-1], page)
+        with mock.patch.object(Path, "read_text", side_effect=OSError("gone")):
+            _has(self, "needs the ui/ modules", km._files_page())
+
+    def test_the_page_is_served_on_its_route(self):
+        import threading
+        import urllib.request
+        from http.server import ThreadingHTTPServer
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            with urllib.request.urlopen("http://127.0.0.1:%d/files?token=testtok" % srv.server_address[1], timeout=5) as r:
+                self.assertEqual(r.status, 200)
+                _has(self, "text/html", r.headers.get("Content-Type", ""))
+                body = r.read().decode("utf-8", "replace")
+        finally:
+            srv.shutdown()
+        _has(self, "<body class=fileview-pane>", body)
+        _has(self, "/dist/files.js", body)
+        _has(self, "body.fileview-pane #romp-fileview{", body, "files-pane.css is inlined live")
+
+    def test_the_stale_opt_out_is_a_keyword_only_this_page_passes(self):
+        """The shim arms the "connection lost, what you see may be stale" prompt on an unannounced
+        reconnect and retires it on the kernel's connect-time push, the first non-keepalive frame.
+        app=files gets no such push (nothing is built for it), so the arm would never clear and the
+        second keepalive would raise the shell's shared banner after every unannounced reconnect, for a
+        file fetched over HTTP on demand, which a dropped socket cannot make stale. The page renders the
+        shim with no_stale=True, which bakes NOSTALE into the template so armStale and clearStale return
+        early (the executed state machine is ui/webview/pane-shim-stale.test.ts). The build-drift prompt
+        is a separate raise and stands. Every other pane has a live pushed view and keeps the arm."""
+        on = km._shim("files", 1, no_stale=True)
+        _has(self, "var NOSTALE=true;", on)
+        _has(self, "function armStale(why){if(NOSTALE)return;stalePending=why;staleKa=0;}", on)
+        _has(self, 'function clearStale(){stalePending="";   // armed but never shown → nothing to see\nif(NOSTALE)return;', on)
+        _has(self, "function raiseBuild(){if(buildRaised)return;buildRaised=true;", on, "the build prompt is not gated")
+        _has(self, "var NOSTALE=false;", km._shim("feed", 1), "the default keeps the arm")
+        for page in (km._chat_page(), km._feed_page(), km._fleet_page(), km._timeline_page()):
+            _has(self, "var NOSTALE=false;", page)
+            _lacks(self, "var NOSTALE=true;", page)
+        # the one page that passes it; the other pane pages call the shim exactly as they did
+        shims = re.findall(r'_shim\("(\w+)", v(?:, ([^)]*))?\)', SRC)
+        self.assertEqual([app for app, kw in shims if "no_stale=True" in (kw or "")], ["files"])
+        self.assertEqual(sorted(app for app, kw in shims), ["chat", "feed", "files", "fleet", "timeline"])
+
+    def test_the_editor_chunk_derives_from_the_pages_own_bundle_tag(self):
+        # file-view.ts loads its CodeMirror chunk from a URL rewritten off the page's running bundle
+        # <script src>. The Files page's bundle must be one that derivation recognizes, or every Edit in
+        # the pane rejects with the raw "no bundle script tag" error and falls to the textarea. The pattern
+        # is lifted from the source and run against the tags this page emits.
+        view = (UI / "file-view.ts").read_text()
+        m = re.search(r"\.find\(\(u\) => /(.+?)/\.test\(u\)\)", view)
+        self.assertIsNotNone(m, "the derivation's find literal is where the pin expects it")
+        pat = re.compile(m.group(1))
+        srcs = re.findall(r"<script src=([^ >]+)", km._files_page())
+        self.assertTrue(srcs)
+        hits = [s for s in srcs if pat.search("http://TESTHOST:1" + s)]   # the browser's absolute .src
+        self.assertEqual(hits, [s for s in srcs if s.startswith("/dist/files.js?v=")], "the bundle, and only the bundle")
+
+    def test_the_pane_resident_variant_lives_only_in_the_pane_sheet(self):
+        # the modal variant is mirrored byte-equal in styles.css and feed.css (fileview-parity.test.ts);
+        # the pane's override must not enter either, or the mirrors drift
+        css = (UI / "files-pane.css").read_text()
+        _has(self, "body.fileview-pane #romp-fileview{position:relative;inset:auto;flex:1 1 auto;min-height:0;background:none}", css)
+        _has(self, "body.fileview-pane .fileview{width:100%;height:100%;border:0;border-radius:0;box-shadow:none}", css)
+        for sheet in ("styles.css", "feed.css"):
+            _lacks(self, "fileview-pane", (UI / sheet).read_text(), sheet)
+        _lacks(self, "fleet", css.lower(), "no fleet vocabulary in the new sheet")
+
+
+class Shell(unittest.TestCase):
+    """The dashboard grows a fifth pane: the far-right column after Feed, OFF by default (the viewFile
+    relay brings it forward when a click routes there), with its own gutter, grow var, and every
+    hand-written pane list in the landing JS extended: focus ring, Alt+Arrow columns, Escape wiring, the
+    Log's pane names, the mobile tab map, the pane controller. One label, "Files", from _PANE_ORDER."""
+
+    def setUp(self):
+        self.html = km._landing()
+
+    def test_the_pane_is_in_the_one_ordering_last(self):
+        self.assertEqual(km._PANE_ORDER[-1], ("files", "Files"))
+        _has(self, "<div class=rail-btn data-pane=files>Files</div>", self.html)
+        _has(self, "<button data-pane=files>Files</button>", self.html)
+
+    def test_the_column_sits_after_the_feed_with_its_gutter_and_grow_var(self):
+        flat = self.html.replace('"\n            "', "")
+        _has(self, '<div class=gv id=gv-c></div><div class=pane id=files-pane><iframe id=f-files src=/files></iframe></div>', flat)
+        self.assertLess(self.html.index("id=feed-pane"), self.html.index("id=gv-c"))
+        self.assertLess(self.html.index("id=gv-c"), self.html.index("id=files-pane"))
+        self.assertLess(self.html.index("id=files-pane"), self.html.index("id=gh"), "before the timeline band")
+        _has(self, "#files-pane{flex:var(--g-files,40) 1 0}", self.html)
+        _has(self, "body:not(.po-files) #files-pane{display:none}", self.html)
+        # the gutter shows only between two visible panes: hidden when Files is off, or when no column sits to its left
+        _has(self, "body:not(.po-files) #gv-c,body:not(.po-chat):not(.po-fleet):not(.po-feed) #gv-c{display:none}", self.html)
+
+    def test_off_by_default_and_toggled_by_the_controller(self):
+        _has(self, "<body class='po-chat po-feed po-timeline'>", self.html)   # not po-files
+        _has(self, "po={chat:true,fleet:false,feed:true,timeline:true,files:false}", self.html)
+        _has(self, "po={chat:false,fleet:false,feed:false,timeline:false,files:false}", self.html)   # the ?panes= reset
+        _has(self, "document.body.classList.toggle('po-files',!!po.files)", self.html)
+        _has(self, "files:'files pane'", self.html)   # the rail tooltip's words
+
+    def test_every_pane_list_in_the_landing_js_names_it(self):
+        _has(self, "'f-files':'files-pane'", km._LANDING_FOCUS_JS)
+        _has(self, "var COLS=['f-chat','f-fleet','f-feed','f-files']", km._LANDING_FOCUS_JS)
+        _has(self, "['f-chat','f-fleet','f-feed','f-files','f-timeline'].forEach", km._LANDING_ESC_JS)
+        _has(self, "['f-chat','f-fleet','f-feed','f-files','f-timeline'].forEach", km._LANDING_MOBILE_JS)
+        # the Log's connection-lost label reads the one map, so the pane's row in _PANE_ORDER is the pin
+        _has(self, "var PN=" + json.dumps(dict(km._PANE_ORDER)) + ";", km._LANDING_ERRS_JS)
+        self.assertEqual(dict(km._PANE_ORDER).get("files"), "Files")
+        _has(self, "files:document.getElementById('f-files')", km._LANDING_MOBILE_JS)
+        _has(self, "var PANES=['chat-pane','fleet-pane','feed-pane','files-pane'];", self.html)
+        _has(self, "grow={chat:60,fleet:34,feed:40,files:40}", self.html)
+        _has(self, "id==='feed-pane'?'feed':'files'", self.html)
+        _has(self, "gutter('gv-c',function(){var c=document.body.classList;return c.contains('po-feed')?'feed-pane':"
+                      "c.contains('po-fleet')?'fleet-pane':'chat-pane';},'files-pane');", self.html)
+
+    def test_mobile_tab_and_the_palette_command(self):
+        _has(self, "#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}", self.html)
+        _has(self, "#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on,#f-files.m-on{display:block}", self.html)
+        pal = (UI / "palette-main.ts").read_text()
+        _has(self, '["files", "files"]', pal)
+        _has(self, '"f-files"', pal)
+
+
+class Relay(unittest.TestCase):
+    """The shell's message listener gains a viewFile pane arm: a click routed to the Files pane brings
+    that pane forward (desktop toggle, phone tab) and forwards the click, identity included, into
+    #f-files. The pane stays up, so no restore is owed; the browseFiles arm the feed's browser rides is
+    untouched. The arms run under node in tests/test_pane_state_broadcast.py; these pin the shape."""
+
+    HEAD = "if(m.romp==='viewFile'&&m.pane==='pane'){var ff=document.getElementById('f-files');"
+
+    @staticmethod
+    def _code(js):
+        return "\n".join(l for l in js.splitlines() if not l.lstrip().startswith("//"))
+
+    def test_the_pane_arm_brings_the_files_pane_forward_and_forwards_the_identity(self):
+        js = km._LANDING_SETTINGS_JS
+        _has(self, self.HEAD, js)
+        self.assertEqual(js.count("m.romp==='viewFile'"), 1, "one viewFile arm in the shell, aimed at the Files pane")
+        self.assertEqual(SRC.count("m.romp==='viewFile'"), 1, "and no other viewFile arm anywhere in the kernel")
+        branch = self._code(js.split(self.HEAD)[1].split("if(m.romp==='filesViewerClosed')")[0])
+        _has(self, "window.__rompPaneToggle&&window.__rompPaneToggle('files',true)", branch)
+        # phone: the Files tab comes forward only in the mobile layout, and the tab the click came from is
+        # remembered so the viewer's close puts the person back
+        _has(self, "if(window.__rompMobileOn&&window.__rompMobileOn()){var cur=document.body.getAttribute('data-tab')||'chat';", branch)
+        _has(self, "if(cur!=='files'){window.__rompFilesTabFrom=cur;window.__rompMobileTab&&window.__rompMobileTab('files');}", branch)
+        _has(self, "postMessage({romp:'viewFile',path:m.path,sid:m.sid,identity:m.identity||null},'*')", branch)
+        self.assertEqual(branch.count("postMessage("), 1, "one forward, carrying the whole click")
+        for tok in ("__rompFeedWasOff", "'f-feed'", "browseClosed"):
+            _lacks(self, tok, branch, tok + " belongs to the feed's browser route")
+
+    def test_the_files_viewers_close_restores_the_remembered_tab_mobile_only(self):
+        js = km._LANDING_SETTINGS_JS
+        handler = ("if(m.romp==='filesViewerClosed'){var back=window.__rompFilesTabFrom;window.__rompFilesTabFrom=null;\n"
+                   "  if(back&&window.__rompMobileOn&&window.__rompMobileOn()){try{window.__rompMobileTab&&window.__rompMobileTab(back);}catch(e){}}}")
+        _has(self, handler, js)
+        # the sender: files.ts posts the close EDGE up (executed in ui/webview/files.test.ts)
+        files = (UI / "files.ts").read_text()
+        _has(self, 'if (viewerUp && !up && window.parent !== window) window.parent.postMessage({ romp: "filesViewerClosed" }, "*");', files)
+
+    def test_the_feeds_browse_relay_is_untouched(self):
+        js = km._LANDING_SETTINGS_JS
+        _has(self, "if(m.romp==='browseFiles'){var bf=document.getElementById('f-feed');", js)
+        _has(self, "try{window.__rompMobileTab&&window.__rompMobileTab('feed');}catch(e){}   // phone: one pane at a time", js)
+        _has(self, "if(m.romp==='browseClosed'&&window.__rompFeedWasOff){window.__rompFeedWasOff=false;", js)
+
+    def test_the_two_ends_agree_on_the_message(self):
+        # the chat names its target and carries the session's identity (render.ts openPath, through the
+        # gesture reader); the pane validates the identity and caches it per sid (files.ts)
+        render = (UI / "render.ts").read_text()
+        _has(self, 'window.parent.postMessage({ romp: "viewFile", path, sid: to, pane: "pane",', render)
+        _has(self, "fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true)", render)
+        files = (UI / "files.ts").read_text()
+        _has(self, "asIdentity(m.identity)", files)
+        route = (UI / "file-route.ts").read_text()
+        _has(self, "export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean): FileRoute {", route)
+
+    def test_the_gear_and_the_guide_say_the_open_pane_wins(self):
+        gear = (UI / "gear.js").read_text()
+        _has(self, "While the Files pane is open, the file opens there.", gear)
+        _has(self, "<option value=chat>The pane you clicked</option><option value=pane>The Files pane</option>", gear)
+        guide = (Path(ROOT) / "docs" / "guide.md").read_text()
+        _has(self, "### Files\n", guide)
+        _has(self, "While the pane is open, a file link clicked in the chat opens in it.", guide.replace("\n", " "))
+        self.assertLess(guide.index("### The outline"), guide.index("### Files"))
+        self.assertLess(guide.index("### Files"), guide.index("## Automatic nudges"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7717,7 +7717,7 @@ class ServeSecurity(unittest.TestCase):
         self.assertNotIn("nav-typing", html)                           # the typing/dimming logic is gone
         # the wiring: maps each iframe id → its pane, toggles pane-focused exclusively, defaults to chat.
         # Fleet is its OWN pane now (the user 2026-06-24), so f-fleet maps to fleet-pane, not the chat pane.
-        self.assertIn("var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-timeline':'tl-pane'}", html)
+        self.assertIn("var PANE={'f-chat':'chat-pane','f-fleet':'fleet-pane','f-feed':'feed-pane','f-files':'files-pane','f-timeline':'tl-pane'}", html)
         self.assertIn("classList.toggle('pane-focused'", html)
         self.assertIn("d.addEventListener('pointerdown',emit,true)", html)
         self.assertIn("d.addEventListener('focusin',emit,true)", html)
@@ -7807,6 +7807,28 @@ class ServeSecurity(unittest.TestCase):
         self.assertIn("window.addEventListener('romp:wsdown',function(){if(ready()){badge(true);}else{show();}});", body)   # T217: content → badge; empty pane → the sheet
         self.assertIn('dispatchEvent(new Event("romp:wsdown"))', body)            # shim fires it on close
         self.assertIn("function show(){o.classList.remove('gone')", body)         # kept in the DOM, not removed
+
+    def test_files_page_served(self):
+        # Files: /files serves the file viewer as its own pane, rendered by dist/files.js. It connects as its OWN
+        # app (app=files) with the shim's stale opt-out: the viewer is request/response (HTTP /file for the bytes,
+        # op replies to the sending client), never a feed consumer. The chat's styles.css supplies the viewer's
+        # dress; files-pane.css is inlined live for the layout and the pane-resident variant. No romp loader: an
+        # empty pane is not a loading state. The pane's own module is tests/test_files_pane.py.
+        import urllib.request
+        with urllib.request.urlopen("http://127.0.0.1:%d/files?token=testtok" % self.port, timeout=5) as r:
+            self.assertEqual(r.status, 200)
+            body = r.read().decode("utf-8", "replace")
+        self.assertIn("<body class=fileview-pane>", body)
+        self.assertIn("<div id=files-empty></div>", body)
+        self.assertIn("/dist/styles.css", body)
+        self.assertIn("/dist/federation.js", body)
+        self.assertIn("/dist/files.js", body)
+        self.assertLess(body.index("/dist/federation.js"), body.index("/dist/files.js"), "manager before the bundle")
+        self.assertIn("app=files", body)
+        self.assertIn("var NOSTALE=true;", body)   # no pushed view, so the "may be stale" prompt is never armed here
+        self.assertIn("body.fileview-pane #romp-fileview{", body, "files-pane.css is inlined live")
+        self.assertNotIn("id=pane-spin", body)
+        self.assertNotIn("rel=manifest", body)   # a pane, not an install target
 
     def test_landing_fleet_is_its_own_pane_toggled_from_the_rail(self):
         # Fleet is its OWN pane now (the user 2026-06-24): the old .show-fleet SWAP (Fleet living inside the

--- a/tests/test_kernel_disconnect_banner.py
+++ b/tests/test_kernel_disconnect_banner.py
@@ -243,7 +243,9 @@ process.stdout.write(JSON.stringify({
         # disowns the socket's onclose, so it runs the close rule itself; without that, every silent cycle
         # re-armed from zero and the prompt never came). Nothing else. pane-shim-stale.test.ts RUNS the rule;
         # these pins hold its text.
-        self.assertIn("function armStale(why){stalePending=why;staleKa=0;}", js, "arming records the path, shows nothing")
+        self.assertIn("function armStale(why){if(NOSTALE)return;stalePending=why;staleKa=0;}", js,
+                      "arming records the path, shows nothing (a page with no pushed view, NOSTALE, never arms: the Files pane)")
+        self.assertIn("var NOSTALE=false;", js, "every pushed pane keeps the arm")
         self.assertNotIn("setTimeout(function(){staleTimer=0;raiseStale(why);},1000)", js, "the timer is gone")
         self.assertNotIn("staleTimer", js)
         self.assertIn('if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}', js,

--- a/tests/test_kernel_mobile.py
+++ b/tests/test_kernel_mobile.py
@@ -37,7 +37,7 @@ class LandingShell(unittest.TestCase):
         # explicitly desktop-only (#fleet-pane display:none!important, no tab, no switcher entry).
         html = km._landing()
         self.assertIn(">Outline</button>", html)                       # the tab exists, labeled Outline
-        self.assertIn("#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on{display:block}", html)   # ...and shows as the active pane
+        self.assertIn("#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on,#f-files.m-on{display:block}", html)   # ...and shows as the active pane
         self.assertNotIn("#fleet-pane{display:none!important}", html)  # the desktop-only exclusion is gone
         self.assertIn("fleet:document.getElementById('f-fleet')", km._LANDING_MOBILE_JS)
         # the chat header's Fleet pill / the fleet's back-to-chat (toggleFleet) is a tab switch on mobile

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -48,13 +48,13 @@ class PaneRailTest(unittest.TestCase):
         self.assertNotIn("tl-collapse", self.html)
         self.assertNotIn("cc-tl", self.html)
 
-    def test_three_top_panes_in_fixed_order_then_the_timeline_band(self):
-        # the TOP row is chat | gv-a | fleet | gv-b | feed; the timeline is the bottom band (gh + #tl-pane) AFTER
-        # the row closes — so the DOM order is row panes first, then the gh gutter, then #tl-pane.
-        order = ["id=chat-pane", "id=gv-a", "id=fleet-pane", "id=gv-b", "id=feed-pane", "id=gh", "id=tl-pane"]
+    def test_four_top_panes_in_fixed_order_then_the_timeline_band(self):
+        # the TOP row is chat | gv-a | fleet (the Outline) | gv-b | feed | gv-c | files; the timeline is the bottom band (gh +
+        # #tl-pane) AFTER the row closes, so the DOM order is row panes first, then the gh gutter, then #tl-pane.
+        order = ["id=chat-pane", "id=gv-a", "id=fleet-pane", "id=gv-b", "id=feed-pane", "id=gv-c", "id=files-pane", "id=gh", "id=tl-pane"]
         idxs = [self.html.index(tok) for tok in order]
         self.assertEqual(idxs, sorted(idxs), "row panes, then the gh gutter, then the timeline band")
-        self.assertNotIn("id=gv-c", self.html)                   # no 4th-pane gutter
+        self.assertNotIn("id=gv-d", self.html)                   # no 5th-pane gutter
         # the pane rail is the BOTTOM BAR (the user 2026-07-05): LAST child of .col, AFTER the timeline band —
         # no longer the first child of .row. So its markup falls after #tl-pane.
         self.assertGreater(self.html.index("class=pane-rail"), self.html.index("id=tl-pane"),
@@ -63,6 +63,7 @@ class PaneRailTest(unittest.TestCase):
         self.assertIn("body:not(.po-chat) #chat-pane{display:none}", self.html)
         self.assertIn("body:not(.po-fleet) #fleet-pane{display:none}", self.html)
         self.assertIn("body:not(.po-feed) #feed-pane{display:none}", self.html)
+        self.assertIn("body:not(.po-files) #files-pane{display:none}", self.html)
         self.assertIn("body:not(.po-timeline) #gh,body:not(.po-timeline) #tl-pane{display:none}", self.html)
 
     def test_default_layout_is_chat_feed_timeline(self):
@@ -75,6 +76,8 @@ class PaneRailTest(unittest.TestCase):
         # gv-b sits (fleet|chat)|feed → it doubles as the chat|feed gutter when fleet is off, so it hides only
         # when feed is off OR neither chat nor fleet is on (feed would then be the lone pane)
         self.assertIn("body:not(.po-feed) #gv-b,body:not(.po-chat):not(.po-fleet) #gv-b{display:none}", self.html)
+        # gv-c sits (feed|fleet|chat)|files: hidden when files is off, or when no column is shown to its left
+        self.assertIn("body:not(.po-files) #gv-c,body:not(.po-chat):not(.po-fleet):not(.po-feed) #gv-c{display:none}", self.html)
 
     def test_lit_rail_button_is_the_romp_accent(self):
         # the shell defines the accent locally (it loads no styles.css) and the ON toggle uses it
@@ -84,7 +87,7 @@ class PaneRailTest(unittest.TestCase):
     def test_rail_drives_a_persisted_pane_controller_exposed_for_the_legacy_toggle(self):
         # the controller toggles po-* from the rail, persists the set, and exposes __rompPaneToggle so the
         # legacy {romp:'toggleFleet'} postMessage routes through the same path
-        self.assertIn("var PK='romp-panes',po={chat:true,fleet:false,feed:true,timeline:true}", self.html)
+        self.assertIn("var PK='romp-panes',po={chat:true,fleet:false,feed:true,timeline:true,files:false}", self.html)
         self.assertIn("window.__rompPaneToggle=togglePane", self.html)
         self.assertIn("togglePane(b.getAttribute('data-pane'))", self.html)
         self.assertIn("document.body.classList.toggle('po-chat',!!po.chat)", self.html)
@@ -94,7 +97,7 @@ class PaneRailTest(unittest.TestCase):
     def test_panes_are_resizable_by_flex_grow_persisted_per_pane(self):
         # each pane grows by a per-pane var the gutters write; the drag normalises visible panes to their px
         # widths first (so it shifts only the pair it sits between) and persists the grows across reloads
-        self.assertIn("#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}", self.html)
+        self.assertIn("#chat-pane{flex:var(--g-chat,60) 1 0}#fleet-pane{flex:var(--g-fleet,34) 1 0}#feed-pane{flex:var(--g-feed,40) 1 0}#files-pane{flex:var(--g-files,40) 1 0}", self.html)
         self.assertNotIn("--g-timeline", self.html)              # timeline is the fixed-height band, not a row grow
         self.assertIn("var GK='romp-pane-grow'", self.html)
         self.assertIn("setGrow(key(id),document.getElementById(id).offsetWidth)", self.html)
@@ -110,9 +113,9 @@ class PaneRailTest(unittest.TestCase):
         # (.pane-focused::after is z-index 6) so a focused pane does not cover it
         self.assertIn("<div id=gv-ghost></div>", self.html)
         self.assertIn("#gv-ghost{display:none;position:fixed;width:7px;pointer-events:none;z-index:40;", self.html)
-        # a child of .col right after the row closes (the feed pane's close, then the row's) and before the
+        # a child of .col right after the row closes (the files pane's close, then the row's) and before the
         # timeline's gutter: fixed, so a flex item of neither
-        self.assertIn("<iframe id=f-feed src=/feed></iframe></div></div><div id=gv-ghost></div>", self.html)
+        self.assertIn("<iframe id=f-files src=/files></iframe></div></div><div id=gv-ghost></div>", self.html)
         self.assertLess(self.html.index("<div id=gv-ghost></div>"), self.html.index("<div class=gh id=gh></div>"))
 
     def test_timeline_is_the_rail_toggled_bottom_band(self):
@@ -206,7 +209,7 @@ class PaneRailTest(unittest.TestCase):
         # mobile shows one pane at a time via the bottom tab bar, not the rail; the desktop po-* pane-hiding
         # must NOT leak in (the tab bar governs), so chat/feed/timeline panes are forced back to display:contents
         self.assertIn(".gv,.gh,.pane-rail{display:none}", self.html)
-        self.assertIn("#chat-pane,#fleet-pane,#feed-pane,#tl-pane{display:contents!important}", self.html)
+        self.assertIn("#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}", self.html)
         # the Outline (fleet) is a mobile TAB now, no longer desktop-only (the user 2026-07-11)
         self.assertNotIn("#fleet-pane{display:none!important}", self.html)
         self.assertIn("body[data-tab=timeline] .row{display:none}", self.html)   # timeline tab → band fills

--- a/tests/test_kernel_panenav.py
+++ b/tests/test_kernel_panenav.py
@@ -23,7 +23,7 @@ JS = km._LANDING_FOCUS_JS
 
 class PaneNav(unittest.TestCase):
     def test_spatial_layout_constants(self):
-        self.assertIn("var COLS=['f-chat','f-fleet','f-feed']", JS, "the three side-by-side columns, left->right")
+        self.assertIn("var COLS=['f-chat','f-fleet','f-feed','f-files']", JS, "the four side-by-side columns, left->right")
         self.assertIn("var TL='f-timeline'", JS, "the timeline is the bottom band")
 
     def test_alt_arrow_is_the_trigger_only_outside_text_fields(self):

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -46,7 +46,7 @@ class SettingsSectionsTest(unittest.TestCase):
                     "id=rs-conserve", "id=rs-thinksum", "id=rs-fileedit"):
             self.assertTrue(h.index(">Sessions<") < h.index(rid) < h.index(">Chat<"), rid)
         # Chat: transcript prefs AND the comment defaults (comments are part of the chat)
-        for rid in ("id=rs-compact", "id=rs-dense", "id=rs-branch", "id=rs-striprows", "id=rs-cmtmodel", "id=rs-cmtfast"):
+        for rid in ("id=rs-compact", "id=rs-dense", "id=rs-branch", "id=rs-striprows", "id=rs-filelink", "id=rs-cmtmodel", "id=rs-cmtfast"):
             self.assertTrue(h.index(">Chat<") < h.index(rid) < h.index(">Sessions pane<"), rid)
         # Sessions pane, then Feed, then Colors
         self.assertTrue(h.index(">Sessions pane<") < h.index("id=rs-collapsegaps") < h.index(">Feed<"))

--- a/tests/test_pane_gutter_drag.py
+++ b/tests/test_pane_gutter_drag.py
@@ -10,14 +10,16 @@ writes the pair's grows once and persists them.
 
 This EXECUTES the real _LANDING_JS in node against a DOM stub (the test_error_center.py pattern; a source
 pin cannot show that a handler writes nothing) and drives two drags on the chat | feed gutter, a grab
-whose right pane is gone, and a drag on the Outline | feed gutter with the Outline pane shown:
+whose right pane is gone, a drag on the Outline | feed gutter with the Outline pane shown, and three grabs
+on the Files gutter (gv-c), whose left pane is the rightmost shown of feed, the Outline and chat:
 
   the grab normalises the shown panes' grows to their widths and shows the ghost at the divider, spanning
   the row; the move repositions the ghost and writes no grow; the release writes exactly the pair's two
   grows, hides the ghost, drops the drag classes, persists the grows and removes its window listeners; a
   far drag clamps both the ghost and the release at the pair's minimum, min(120 px, a quarter of the pair);
   a grab whose pane is missing arms nothing and leaves no drag cursor behind; a left pane that is not the
-  leftmost places the ghost from its own client left, and a narrow pair clamps at a quarter of itself.
+  leftmost places the ghost from its own client left, and a narrow pair clamps at a quarter of itself; the
+  Files gutter pairs the Files pane with the feed, else the Outline, else the chat, by what is shown.
 
 Synthetic only: no browser, no real DOM. The stub is told the layout the browser would produce from the
 written grows (layout()), since a stub has no layout engine of its own.
@@ -72,12 +74,13 @@ function mkEl(id, w, left, display) {
   };
 }
 const EL = {};
-['gh', 'gv-a', 'gv-b', 'f-timeline'].forEach((id) => { EL[id] = mkEl(id, 7, 0, 'flex'); });
+['gh', 'gv-a', 'gv-b', 'gv-c', 'f-timeline'].forEach((id) => { EL[id] = mkEl(id, 7, 0, 'flex'); });
 // chat 600 px at the left edge, the Outline pane hidden (so gv-b is the chat | feed gutter), feed 400 px
-// after the 7 px gutter: the divider sits at x = 600
+// after the 7 px gutter: the divider sits at x = 600; the Files pane hidden until the last drags
 EL['chat-pane'] = mkEl('chat-pane', 600, 0, 'flex');
 EL['fleet-pane'] = mkEl('fleet-pane', 300, 0, 'none');
 EL['feed-pane'] = mkEl('feed-pane', 400, 607, 'flex');
+EL['files-pane'] = mkEl('files-pane', 300, 0, 'none');
 EL['gv-ghost'] = mkEl('gv-ghost', 7, 0, 'none');
 EL['gv-ghost'].style.display = 'none';
 const WL = {};
@@ -112,7 +115,7 @@ function snap() {
 // shown panes' widths, left to right, and places each after the one before it plus the 7 px gutter
 function layout(widths) {
   let x = 0;
-  [['chat', 'chat-pane'], ['fleet', 'fleet-pane'], ['feed', 'feed-pane']].forEach(([k, id]) => {
+  [['chat', 'chat-pane'], ['fleet', 'fleet-pane'], ['feed', 'feed-pane'], ['files', 'files-pane']].forEach(([k, id]) => {
     if (!(k in widths)) return;
     EL[id].offsetWidth = widths[k]; EL[id]._left = x; x += widths[k] + 7;
   });
@@ -160,6 +163,36 @@ out.move3far = snap();
 winFire('mouseup', {});
 out.release3 = snap();
 out.release3Writes = WRITES.slice(out.move3far.writes);
+// 5) the Files pane shown: gv-c's left pane is the rightmost SHOWN of feed, the Outline and chat. All four
+//    shown first (chat 300 | Outline 100 | feed 300 | files 200, the divider at 714), then the feed hidden
+//    (chat 300 | Outline 250 | files 250, the divider at 557), then the Outline hidden too (chat 500 | files 300,
+//    the divider at 500); each drag moves the pointer 50 px left of the divider
+BODY.add('po-files');
+EL['files-pane']._display = 'flex';
+layout({ chat: 300, fleet: 100, feed: 300, files: 200 });
+EL['gv-c'].fire('mousedown', { preventDefault() {}, clientX: 714 });
+out.grab5 = snap();
+winFire('mousemove', { clientX: 664 });
+winFire('mouseup', {});
+out.release5 = snap();
+out.release5Writes = WRITES.slice(out.grab5.writes);
+BODY.delete('po-feed');
+EL['feed-pane']._display = 'none';
+layout({ chat: 300, fleet: 250, files: 250 });
+EL['gv-c'].fire('mousedown', { preventDefault() {}, clientX: 557 });
+out.grab6 = snap();
+winFire('mousemove', { clientX: 507 });
+winFire('mouseup', {});
+out.release6Writes = WRITES.slice(out.grab6.writes);
+BODY.delete('po-fleet');
+EL['fleet-pane']._display = 'none';
+layout({ chat: 500, files: 300 });
+EL['gv-c'].fire('mousedown', { preventDefault() {}, clientX: 500 });
+out.grab7 = snap();
+winFire('mousemove', { clientX: 450 });
+winFire('mouseup', {});
+out.release7Writes = WRITES.slice(out.grab7.writes);
+out.release7 = snap();
 console.log(JSON.stringify(out));
 """
 
@@ -178,10 +211,10 @@ class PaneGutterDragExecutes(unittest.TestCase):
         assert r.returncode == 0, "the gutter script threw: " + r.stderr[:800]
         cls.out = json.loads(r.stdout.strip().splitlines()[-1])
 
-    def test_boot_writes_the_three_default_grows_and_shows_no_ghost(self):
+    def test_boot_writes_the_four_default_grows_and_shows_no_ghost(self):
         b = self.out["boot"]
-        self.assertEqual(b["writes"], 3)
-        self.assertEqual(b["grows"], {"--g-chat": 60, "--g-fleet": 34, "--g-feed": 40})
+        self.assertEqual(b["writes"], 4)
+        self.assertEqual(b["grows"], {"--g-chat": 60, "--g-fleet": 34, "--g-feed": 40, "--g-files": 40})
         self.assertEqual(b["ghost"]["display"], "none")
         self.assertFalse(b["drag"] or b["dragv"])
         self.assertEqual(b["listeners"], {"move": 0, "up": 0}, "no drag listeners before a grab")
@@ -190,7 +223,7 @@ class PaneGutterDragExecutes(unittest.TestCase):
         g = self.out["grab"]
         # the two shown panes are written as their px widths (the hidden Outline pane keeps its grow)
         self.assertEqual(g["writes"], self.out["boot"]["writes"] + 2)
-        self.assertEqual(g["grows"], {"--g-chat": 600, "--g-fleet": 34, "--g-feed": 400})
+        self.assertEqual(g["grows"], {"--g-chat": 600, "--g-fleet": 34, "--g-feed": 400, "--g-files": 40})
         # the ghost shows at the divider, spanning the row (its rect, not the pane's)
         self.assertEqual(g["ghost"], {"display": "block", "left": "600px", "top": "24px", "height": "760px"})
         self.assertTrue(g["drag"] and g["dragv"], "body.drag and body.dragv during the drag")
@@ -209,23 +242,23 @@ class PaneGutterDragExecutes(unittest.TestCase):
         self.assertEqual(self.out["releaseWrites"], [["--g-chat", 500], ["--g-feed", 500]],
                          "exactly the pair's two grows, written at release")
         self.assertEqual(r["writes"], m["writes"] + 2)
-        self.assertEqual(r["grows"], {"--g-chat": 500, "--g-fleet": 34, "--g-feed": 500})
+        self.assertEqual(r["grows"], {"--g-chat": 500, "--g-fleet": 34, "--g-feed": 500, "--g-files": 40})
         self.assertEqual(r["ghost"]["display"], "none", "the ghost hides at release")
         self.assertFalse(r["drag"] or r["dragv"], "body.drag and body.dragv are removed")
-        self.assertEqual(r["store"], {"chat": 500, "fleet": 34, "feed": 500}, "the grows persist at release")
+        self.assertEqual(r["store"], {"chat": 500, "fleet": 34, "feed": 500, "files": 40}, "the grows persist at release")
         self.assertEqual(r["listeners"], {"move": 0, "up": 0}, "the drag's window listeners are removed")
 
     def test_a_far_drag_clamps_the_ghost_and_the_release_at_the_pair_minimum(self):
         # chat 500 | feed 500: the pair's minimum is min(120, 1000 * 0.25) = 120, so the pointer at 1590
         # (asking for chat 1590) lands the divider at 880
         g2, m2, r2 = self.out["grab2"], self.out["move2"], self.out["release2"]
-        self.assertEqual(g2["grows"], {"--g-chat": 500, "--g-fleet": 34, "--g-feed": 500})
+        self.assertEqual(g2["grows"], {"--g-chat": 500, "--g-fleet": 34, "--g-feed": 500, "--g-files": 40})
         self.assertEqual(g2["ghost"].get("left"), "500px", "the ghost shows at the new divider")
         self.assertEqual(m2["writes"], g2["writes"], "still no grow written while the pointer moves")
         self.assertEqual(m2["ghost"].get("left"), "880px", "the ghost clamps at the pair's minimum")
         self.assertEqual(self.out["release2Writes"], [["--g-chat", 880], ["--g-feed", 120]])
-        self.assertEqual(r2["grows"], {"--g-chat": 880, "--g-fleet": 34, "--g-feed": 120})
-        self.assertEqual(r2["store"], {"chat": 880, "fleet": 34, "feed": 120})
+        self.assertEqual(r2["grows"], {"--g-chat": 880, "--g-fleet": 34, "--g-feed": 120, "--g-files": 40})
+        self.assertEqual(r2["store"], {"chat": 880, "fleet": 34, "feed": 120, "files": 40})
         self.assertEqual(r2["ghost"]["display"], "none")
 
     def test_a_grab_whose_pane_is_gone_arms_nothing(self):
@@ -243,7 +276,7 @@ class PaneGutterDragExecutes(unittest.TestCase):
         # left is that pane's client left plus the dragged width, not the width alone
         o, g3, m3 = self.out["orphan"], self.out["grab3"], self.out["move3"]
         self.assertEqual(g3["writes"], o["writes"] + 3, "all three shown panes are normalised")
-        self.assertEqual(g3["grows"], {"--g-chat": 300, "--g-fleet": 200, "--g-feed": 200})
+        self.assertEqual(g3["grows"], {"--g-chat": 300, "--g-fleet": 200, "--g-feed": 200, "--g-files": 40})
         self.assertEqual(g3["ghost"], {"display": "block", "left": "507px", "top": "24px", "height": "760px"},
                          "the line shows at the Outline | feed divider")
         self.assertEqual(m3["writes"], g3["writes"], "no grow written while the pointer moves")
@@ -255,11 +288,30 @@ class PaneGutterDragExecutes(unittest.TestCase):
         m3, r3 = self.out["move3far"], self.out["release3"]
         self.assertEqual(m3["ghost"]["left"], "407px", "the line clamps at a quarter of the pair")
         self.assertEqual(self.out["release3Writes"], [["--g-fleet", 100], ["--g-feed", 300]])
-        self.assertEqual(r3["grows"], {"--g-chat": 300, "--g-fleet": 100, "--g-feed": 300}, "the chat grow is untouched")
-        self.assertEqual(r3["store"], {"chat": 300, "fleet": 100, "feed": 300})
+        self.assertEqual(r3["grows"], {"--g-chat": 300, "--g-fleet": 100, "--g-feed": 300, "--g-files": 40}, "the chat grow is untouched")
+        self.assertEqual(r3["store"], {"chat": 300, "fleet": 100, "feed": 300, "files": 40})
         self.assertEqual(r3["ghost"]["display"], "none")
         self.assertFalse(r3["drag"] or r3["dragv"])
         self.assertEqual(r3["listeners"], {"move": 0, "up": 0})
+
+    def test_the_files_gutter_pairs_the_files_pane_with_the_rightmost_shown_column_to_its_left(self):
+        # every shown pane is normalised at the grab (four, then three, then two), the ghost shows at the divider
+        # placed from the left pane's own client left, and the release writes the PAIR the gutter resolved by
+        # what is shown at grab time: feed | files, then Outline | files, then chat | files
+        r3, g5, g6, g7, r7 = self.out["release3"], self.out["grab5"], self.out["grab6"], self.out["grab7"], self.out["release7"]
+        self.assertEqual(g5["writes"], r3["writes"] + 4, "all four shown panes are normalised")
+        self.assertEqual(g5["grows"], {"--g-chat": 300, "--g-fleet": 100, "--g-feed": 300, "--g-files": 200})
+        self.assertEqual(g5["ghost"], {"display": "block", "left": "714px", "top": "24px", "height": "760px"}, "the feed | files divider")
+        self.assertEqual(self.out["release5Writes"], [["--g-feed", 250], ["--g-files", 250]], "the feed is the left pane while it is shown")
+        self.assertEqual(g6["grows"], {"--g-chat": 300, "--g-fleet": 250, "--g-feed": 250, "--g-files": 250}, "the hidden feed keeps its grow")
+        self.assertEqual(g6["ghost"]["left"], "557px", "the Outline | files divider: the Outline's client left 307 plus its 250")
+        self.assertEqual(self.out["release6Writes"], [["--g-fleet", 200], ["--g-files", 300]], "feed hidden: the Outline is the left pane")
+        self.assertEqual(g7["ghost"]["left"], "500px")
+        self.assertEqual(self.out["release7Writes"], [["--g-chat", 450], ["--g-files", 350]], "feed and Outline hidden: the chat is")
+        self.assertEqual(r7["store"], {"chat": 450, "fleet": 200, "feed": 250, "files": 350}, "the grows persist at release")
+        self.assertEqual(r7["ghost"]["display"], "none")
+        self.assertFalse(r7["drag"] or r7["dragv"])
+        self.assertEqual(r7["listeners"], {"move": 0, "up": 0})
 
 
 if __name__ == "__main__":

--- a/tests/test_pane_hidden_word_browser.py
+++ b/tests/test_pane_hidden_word_browser.py
@@ -31,10 +31,10 @@ km = load_source("romp_kernel_panehiddenword", os.path.join(BIN, "romp-kernel"))
 # the shell's two ways of hiding a pane, as the served landing page carries them (setUp checks they are still there)
 DESKTOP_RULE = "body:not(.po-chat) #chat-pane{display:none}body:not(.po-fleet) #fleet-pane{display:none}body:not(.po-feed) #feed-pane{display:none}"
 PHONE_RULES = (
-    "#chat-pane,#fleet-pane,#feed-pane,#tl-pane{display:contents!important}",
+    "#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}",
     ".pane>iframe{position:static;inset:auto;width:100%;height:100%}",
     "iframe{position:static;display:none;width:100%;height:100%;border:0}",
-    "#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on{display:block}",
+    "#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on,#f-files.m-on{display:block}",
 )
 
 

--- a/tests/test_pane_order_parity.py
+++ b/tests/test_pane_order_parity.py
@@ -43,7 +43,7 @@ class PaneOrderParity(unittest.TestCase):
         self.assertEqual(_pane_seq(mtabs), _pane_seq(rail),
                          "one ordering, not two: #mtabs must list the panes exactly as the "
                          "desktop rail strip does (change one, both move)")
-        self.assertEqual(len(_pane_seq(rail)), 4, "all four panes present on both surfaces")
+        self.assertEqual(len(_pane_seq(rail)), 5, "all five panes present on both surfaces")
 
     def test_both_surfaces_render_from_the_one_constant(self):
         # the mechanism, not just the outcome: a future hand-edit of either HTML block back to a

--- a/tests/test_pane_state_broadcast.py
+++ b/tests/test_pane_state_broadcast.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""The shell tells its panes which panes are on screen, and relays a file click into the Files pane.
+
+A file link clicked in the chat while the Files pane is open must open there whatever the "File links
+open in" setting says (the pane being open is the intent), and the chat has no way to see the pane on
+its own. The shell owns pane state (_LANDING_COLLAPSE_JS: the po object, apply(), __rompPaneToggle), so
+the shell broadcasts it: {romp:'panes',on:{key:bool}} into every pane iframe on every apply(), the
+exact event of the set changing (a toggle, the boot apply, another tab's storage event), again on each
+iframe's own load, so a pane that boots or reloads after the shell hears the current set, and from the
+mobile script on a tab switch or a layout flip. On a phone "on" means the tab showing, not the po flag,
+so a po.files left true by a desktop session cannot steer a phone's file links into a tab nobody is
+looking at. The chat caches the set and routes by it (render.ts panesOn; ui/webview/file-route.ts).
+
+The three shell scripts involved are the kernel's own inline JavaScript, so they run here under node
+against a fake window and document, and the messages they post are read back: the collapse controller,
+the mobile script (__rompMobileOn, __rompMobileTab, the re-tell, and the switches the person makes, a tab
+tap, a reveal, the chat header's Outline pill, which drop the relay's remembered tab) and the settings
+listener's arms (viewFile with pane:'pane', filesViewerClosed, and the browseFiles arm the feed's browser
+keeps).
+Synthetic only: placeholder sids, the notes-api demo world, TESTHOST.
+"""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads: they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = load_source("romp_kernel_psb", os.path.join(BIN, "romp-kernel"))
+
+SID = "11111111-2222-3333-4444-555555555555"
+
+
+def _run(js):
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as f:
+        f.write(js)
+        path = f.name
+    try:
+        r = subprocess.run(["node", path], capture_output=True, text=True, timeout=30)
+    finally:
+        os.unlink(path)
+    assert r.returncode == 0, "the shell script threw: " + r.stderr[:1200]
+    return json.loads(r.stdout.strip().splitlines()[-1])
+
+
+# ── the pane controller ───────────────────────────────────────────────────────────────────────────
+# One iframe per pane key; the desktop shell (no rail buttons: querySelectorAll is empty), the feed and
+# chat and timeline on, the Outline and the Files pane off, the way the served body class starts.
+_COLLAPSE_HARNESS = r"""
+'use strict';
+const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {};
+const KEYS = __KEYS__;
+const frames = {};
+KEYS.forEach((k) => { frames['f-' + k] = {
+  contentWindow: { postMessage: (m) => { (POSTED[k] = POSTED[k] || []).push(JSON.parse(JSON.stringify(m))); } },
+  addEventListener: (ev, f) => { if (ev === 'load') (LOADS[k] = LOADS[k] || []).push(f); } }; });
+let TAB = 'chat', MOBILE = false;
+global.window = global;
+global.localStorage = { getItem: (k) => (k in STORE ? STORE[k] : null), setItem: (k, v) => { STORE[k] = v; } };
+global.location = { search: '' };
+global.URLSearchParams = class { get() { return null; } };
+global.Event = class { constructor(t) { this.type = t; } };
+global.addEventListener = () => {};
+global.dispatchEvent = () => true;
+global.document = {
+  body: { classList: { toggle: (c, on) => { if (on) CLS.add(c); else CLS.delete(c); }, contains: (c) => CLS.has(c) },
+          getAttribute: (a) => (a === 'data-tab' ? TAB : null) },
+  querySelectorAll: () => [],
+  getElementById: (id) => frames[id] || null,
+};
+window.__rompMobileOn = () => MOBILE;
+"""
+_COLLAPSE_DRIVER = r"""
+const counts = () => Object.fromEntries(KEYS.map((k) => [k, (POSTED[k] || []).length]));
+const last = (k) => (POSTED[k] || []).slice(-1)[0];
+const out = {};
+out.boot = { counts: counts(), chat: last('chat'), files: last('files') };
+window.__rompPaneToggle('files', true);
+out.on = { counts: counts(), chat: last('chat'), cls: CLS.has('po-files'), store: JSON.parse(STORE['romp-panes'] || 'null') };
+window.__rompPaneToggle('files', true);        // already so: no change, so no message claiming one
+out.same = { counts: counts() };
+(LOADS.chat || []).forEach((f) => f());        // the chat iframe reloads: it hears the current set again
+out.reload = { counts: counts(), chat: last('chat') };
+MOBILE = true; TAB = 'chat'; window.__rompPanesTell();
+out.phoneChat = last('chat');
+TAB = 'files'; window.__rompPanesTell();
+out.phoneFiles = last('files');
+MOBILE = false;
+window.__rompPaneToggle('files');              // no `to`: flips it off
+out.off = { chat: last('chat'), cls: CLS.has('po-files'), store: JSON.parse(STORE['romp-panes'] || 'null') };
+out.teller = typeof window.__rompPanesTell;
+console.log(JSON.stringify(out));
+"""
+
+
+class Broadcast(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.keys = [k for k, _ in km._PANE_ORDER]
+        cls.out = _run(_COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(cls.keys)) + km._LANDING_COLLAPSE_JS + _COLLAPSE_DRIVER)
+
+    def test_the_boot_apply_tells_every_pane_the_set_as_the_flags_stand(self):
+        self.assertEqual(self.out["boot"]["counts"], {k: 1 for k in self.keys}, "one message per pane at boot")
+        self.assertEqual(self.out["boot"]["chat"], {"romp": "panes", "on": {"chat": True, "timeline": True, "fleet": False, "feed": True, "files": False}})
+        self.assertEqual(self.out["boot"]["files"], self.out["boot"]["chat"], "every pane hears the same set")
+
+    def test_a_toggle_is_the_event_and_a_no_change_toggle_is_silent(self):
+        self.assertEqual(self.out["on"]["counts"], {k: 2 for k in self.keys})
+        self.assertTrue(self.out["on"]["chat"]["on"]["files"], "the Files pane is on after the toggle")
+        self.assertTrue(self.out["on"]["cls"], "and the body class the CSS shows the column by")
+        self.assertEqual((self.out["on"]["store"] or {}).get("files"), True, "and the set persists")
+        # a repeated bring-forward (the viewFile relay on an already-open pane) changes nothing, so it says
+        # nothing: a message is a claim that something changed, and the panes must be able to trust it
+        self.assertEqual(self.out["same"]["counts"], {k: 2 for k in self.keys})
+
+    def test_a_pane_that_loads_after_the_shell_hears_the_set(self):
+        self.assertEqual(self.out["reload"]["counts"]["chat"], 3, "the chat's load handler re-tells it")
+        self.assertEqual(self.out["reload"]["counts"]["files"], 2, "and nobody else")
+        self.assertEqual(self.out["reload"]["chat"]["on"]["files"], True, "with the current set")
+
+    def test_on_a_phone_on_means_the_tab_showing_not_the_flag(self):
+        # po.files is true here (the toggle above), yet the phone on the chat tab reports it off
+        self.assertEqual(self.out["phoneChat"]["on"], {"chat": True, "timeline": False, "fleet": False, "feed": False, "files": False})
+        self.assertEqual(self.out["phoneFiles"]["on"], {"chat": False, "timeline": False, "fleet": False, "feed": False, "files": True})
+
+    def test_a_toggle_off_reports_the_pane_off(self):
+        self.assertFalse(self.out["off"]["chat"]["on"]["files"])
+        self.assertFalse(self.out["off"]["cls"])
+        self.assertEqual((self.out["off"]["store"] or {}).get("files"), False)
+
+    def test_the_mobile_script_can_re_tell(self):
+        self.assertEqual(self.out["teller"], "function", "window.__rompPanesTell is the mobile script's hook")
+
+    def test_the_key_set_is_the_one_pane_list(self):
+        # derived from _PANE_ORDER, never a second hand-written list: a pane added there is broadcast
+        js = km._LANDING_COLLAPSE_JS
+        self.assertIn("var KEYS=" + json.dumps(self.keys) + ";", js)
+        self.assertIn('var KEYS=""" + json.dumps([k for k, _ in _PANE_ORDER]) + """;', open(os.path.join(BIN, "romp-kernel")).read())
+        self.assertEqual(len(self.keys), 5)
+        # every key ships an iframe by the id the broadcast addresses, or a pane is silently never told
+        html = km._landing()
+        for k in self.keys:
+            self.assertIn("<iframe id=f-%s " % k, html, "no iframe for pane key %r" % k)
+
+
+# ── the mobile script ─────────────────────────────────────────────────────────────────────────────
+_MOBILE_HARNESS = r"""
+'use strict';
+const TOGGLES = [], TELLS = [], MQL = [], MSGS = [], STORE = {};
+let MATCHES = true, TAB = null;
+global.window = global;
+global.innerHeight = 844; global.innerWidth = 390; global.scrollY = 0;
+global.scrollTo = () => {};
+global.matchMedia = (q) => ({ get matches() { return MATCHES; }, query: q, addEventListener: (ev, f) => { if (ev === 'change') MQL.push(f); } });   // matches reads live, as a MediaQueryList's does
+global.requestAnimationFrame = (f) => 1;
+global.addEventListener = (ev, f) => { if (ev === 'message') MSGS.push(f); };   // the script's window-message arms (reveal, toggleFleet), driven below
+global.visualViewport = { height: 844, scale: 1, addEventListener: () => {} };
+global.WebSocket = class { constructor() { this.readyState = 0; } send() {} };
+global.encodeURIComponent = (s) => s;
+global.location = { protocol: 'http:', host: 'TESTHOST:1' };
+global.sessionStorage = { getItem: () => 'wid1' };
+global.setTimeout = () => 0;
+const pane = (id) => ({ id, classList: { toggle: (c, on) => { TOGGLES.push([id, c, !!on]); } }, contentDocument: {},
+  contentWindow: { addEventListener: () => {} }, addEventListener: () => {} });
+const PANES = {};
+['f-chat', 'f-fleet', 'f-feed', 'f-files', 'f-timeline'].forEach((id) => { PANES[id] = pane(id); });
+const TAPS = {};
+const button = (key) => ({ getAttribute: (a) => (a === 'data-pane' ? key : null), classList: { toggle() {} },
+  addEventListener: (ev, f) => { if (ev === 'click') TAPS[key] = f; } });
+const BAR = { offsetHeight: 44, querySelectorAll: (sel) => (sel === 'button[data-pane]' ? [button('chat'), button('feed'), button('files')] : []) };
+global.document = {
+  visibilityState: 'visible',
+  addEventListener: () => {},
+  documentElement: { scrollTop: 0, style: { setProperty() {} } },
+  body: { setAttribute: (a, v) => { if (a === 'data-tab') TAB = v; }, getAttribute: (a) => (a === 'data-tab' ? TAB : null) },
+  getElementById: (id) => (id === 'mtabs' ? BAR : (PANES[id] || null)),
+};
+global.localStorage = { getItem: (k) => (k in STORE ? STORE[k] : null), setItem: (k, v) => { STORE[k] = v; } };
+window.__rompPanesTell = () => TELLS.push(TAB);
+"""
+_MOBILE_DRIVER = r"""
+const out = {};
+out.boot = { tab: TAB, on: window.__rompMobileOn(), tells: TELLS.slice() };
+TOGGLES.length = 0; TELLS.length = 0;
+window.__rompMobileTab('files');
+out.files = { tab: TAB, mOn: TOGGLES.filter((t) => t[1] === 'm-on' && t[2]).map((t) => t[0]), tells: TELLS.slice(), store: STORE['romp-mobile-tab'] };
+TELLS.length = 0;
+MQL.forEach((f) => f({}));                                 // the layout flips (a rotation across the breakpoint)
+out.flip = { tells: TELLS.slice(), listeners: MQL.length };
+MATCHES = false;
+out.desktop = window.__rompMobileOn();
+window.__rompMobileTab('nowhere');
+out.unknown = { tab: TAB };
+// the relay remembered a tab; the person's own tap on another tab drops that memory, the relay's own switch keeps it
+window.__rompFilesTabFrom = 'chat'; TAPS.feed();
+out.tap = { tab: TAB, from: window.__rompFilesTabFrom };
+window.__rompFilesTabFrom = 'chat'; window.__rompMobileTab('files');
+out.relaySwitch = { tab: TAB, from: window.__rompFilesTabFrom };
+// a reveal aimed at the person (a feed card's tap into a session, the kernel's reveal) and the chat header's
+// Outline pill (toggleFleet) arrive as window messages and are switches they made too
+const arrive = (m) => MSGS.forEach((f) => f({ data: m }));
+window.__rompFilesTabFrom = 'chat'; arrive({ romp: 'reveal', pane: 'feed' });
+out.reveal = { tab: TAB, from: window.__rompFilesTabFrom, listeners: MSGS.length };
+window.__rompFilesTabFrom = 'chat'; arrive({ romp: 'toggleFleet', to: 'chat' });
+out.pill = { tab: TAB, from: window.__rompFilesTabFrom };
+window.__rompFilesTabFrom = 'chat'; arrive({ romp: 'toggleFleet' });
+out.pillOutline = { tab: TAB, from: window.__rompFilesTabFrom };
+console.log(JSON.stringify(out));
+"""
+
+
+class MobileScript(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.out = _run(_MOBILE_HARNESS + km._LANDING_MOBILE_JS + _MOBILE_DRIVER)
+
+    def test_the_layout_probe_answers_the_stylesheets_own_media_query(self):
+        # one constant lays out the grid AND answers the JS, never two strings that can drift
+        self.assertIn("@media " + km._MOBILE_MQ + "{", km._landing())
+        self.assertIn("matchMedia(" + json.dumps(km._MOBILE_MQ) + ")", km._LANDING_MOBILE_JS)
+        self.assertTrue(self.out["boot"]["on"], "the fake matchMedia matches: the phone layout")
+        self.assertFalse(self.out["desktop"], "and reads live: unmatched is the desktop")
+        # defined ABOVE the tab-bar lookup, so a desktop shell (no bar) still answers
+        js = km._LANDING_MOBILE_JS
+        self.assertLess(js.index("window.__rompMobileOn=mobileOn;"), js.index("\nvar bar=document.getElementById('mtabs');if(!bar)return;\n"))
+
+    def test_the_boot_show_lands_on_the_chat_and_the_tab_switch_re_tells_the_panes(self):
+        self.assertEqual(self.out["boot"]["tab"], "chat")
+        self.assertEqual(self.out["boot"]["tells"], ["chat"], "the boot show re-tells too (a no-op before the collapse script parses)")
+        self.assertEqual(self.out["files"]["tab"], "files")
+        self.assertEqual(self.out["files"]["mOn"], ["f-files"], "exactly one pane wears m-on")
+        self.assertEqual(self.out["files"]["tells"], ["files"], "the switch is the event: re-told once, after data-tab moved")
+        self.assertEqual(self.out["files"]["store"], "files")
+        self.assertEqual(self.out["unknown"]["tab"], "files", "a key the shell has no pane for switches nothing")
+
+    def test_a_layout_flip_re_tells_the_panes(self):
+        self.assertEqual(self.out["flip"]["listeners"], 1, "one change listener on the media query")
+        self.assertEqual(self.out["flip"]["tells"], ["files"])
+
+    def test_a_tab_tap_drops_the_relays_remembered_tab_and_the_relays_own_switch_keeps_it(self):
+        # phone: the relay remembered 'chat' and switched to Files; the person taps Feed, works there, comes back
+        # to Files and closes the file. Without this the close would jump them to Chat, a tab they left on their own.
+        self.assertEqual(self.out["tap"], {"tab": "feed", "from": None})
+        self.assertEqual(self.out["relaySwitch"], {"tab": "files", "from": "chat"}, "__rompMobileTab itself is the relay's path and keeps the memory")
+
+    def test_a_reveal_and_the_chat_headers_outline_pill_drop_the_remembered_tab_too(self):
+        # the same rule as the tap: the relay's memory serves the file's close only while the person has not
+        # moved on their own; a reveal (the feed's tap into a session) and the header pill are their moves
+        self.assertEqual(self.out["reveal"], {"tab": "feed", "from": None, "listeners": 1})
+        self.assertEqual(self.out["pill"], {"tab": "chat", "from": None})
+        self.assertEqual(self.out["pillOutline"], {"tab": "fleet", "from": None})
+
+    def test_the_hook_is_exported_for_the_relay(self):
+        self.assertIn("window.__rompMobileTab=show;", km._LANDING_MOBILE_JS)
+        # the mobile script parses BEFORE the collapse script (its boot show() finds no teller yet; the boot
+        # apply that follows tells the panes), and the relay's tab switch happens at message time, after both
+        html = km._landing()
+        self.assertLess(html.index("window.__rompMobileTab=show;"), html.index("window.__rompPanesTell=broadcast;"))
+
+
+# ── the settings listener's arms ──────────────────────────────────────────────────────────────────
+# The whole settings script runs (it registers the one message listener this drives); the rest of it
+# finds no elements and does nothing. `mobile` answers __rompMobileOn; `tab` is the tab showing.
+_ARMS_HARNESS = r"""
+'use strict';
+const LISTENERS = [], TOGGLES = [], TABS = [];
+const POSTED = { 'f-files': [], 'f-feed': [], 'f-chat': [] };
+let MOBILE = false, TAB = 'chat', FILES_READY = 'complete', FILES_LOADS = [];
+const frame = (id) => ({ contentWindow: { postMessage: (m) => POSTED[id].push(JSON.parse(JSON.stringify(m))) },
+  contentDocument: { get readyState() { return id === 'f-files' ? FILES_READY : 'complete'; } },
+  addEventListener: (ev, f) => { if (ev === 'load' && id === 'f-files') FILES_LOADS.push(f); },
+  removeEventListener: (ev, f) => { if (id === 'f-files') FILES_LOADS = FILES_LOADS.filter((g) => g !== f); } });
+global.window = global;
+global.addEventListener = (ev, f) => { if (ev === 'message') LISTENERS.push(f); };
+global.__rompPaneToggle = (k, on) => TOGGLES.push([k, on]);
+global.__rompMobileTab = (t) => TABS.push(t);
+global.__rompMobileOn = () => MOBILE;
+const stub = () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {}, contains: () => false }, appendChild() {}, setAttribute() {}, addEventListener() {}, remove() {} });
+global.document = {
+  body: { classList: { toggle() {}, contains: (c) => c === 'po-chat' || c === 'po-feed' || c === 'po-timeline' },
+          getAttribute: (a) => (a === 'data-tab' ? TAB : null), appendChild() {} },
+  getElementById: (id) => (id in POSTED ? frame(id) : null),
+  createElement: stub, documentElement: { style: { setProperty() {} } },
+  querySelectorAll: () => [], querySelector: () => null, addEventListener() {},
+};
+global.localStorage = { getItem: () => null, setItem() {} };
+global.sessionStorage = { getItem: () => 'wid1', setItem() {} };
+global.location = { protocol: 'http:', host: 'TESTHOST:1', search: '', reload() {} };
+global.fetch = () => new Promise(() => {});
+global.setTimeout = () => 0; global.setInterval = () => 0; global.clearTimeout = () => {};
+global.Event = class { constructor(t) { this.type = t; } };
+"""
+_ARMS_DRIVER = r"""
+const send = (m) => LISTENERS.forEach((f) => f({ data: m }));
+const snap = () => ({ toggles: TOGGLES.slice(), tabs: TABS.slice(), files: POSTED['f-files'].slice(), feed: POSTED['f-feed'].slice(),
+  chat: POSTED['f-chat'].slice(), from: window.__rompFilesTabFrom === undefined ? 'undef' : window.__rompFilesTabFrom });
+const reset = () => { TOGGLES.length = 0; TABS.length = 0; for (const k in POSTED) POSTED[k].length = 0; delete window.__rompFilesTabFrom; };
+const SID = '__SID__';
+const identity = { name: 'web', color: { bg: '#123456', fg: '#ffffff' } };
+const out = { listeners: LISTENERS.length };
+send({ romp: 'viewFile', pane: 'pane', path: '/repo/notes-api/src/app.py', sid: SID, identity });
+out.desktop = snap(); reset();
+send({ romp: 'viewFile', pane: 'pane', path: '/repo/notes-api/README.md', sid: 'TESTHOST:' + SID });
+out.bare = snap(); reset();
+MOBILE = true; TAB = 'chat';
+send({ romp: 'viewFile', pane: 'pane', path: '/repo/notes-api/src/app.py', sid: SID, identity });
+out.phone = snap();
+send({ romp: 'filesViewerClosed' });
+out.phoneClosed = snap();
+send({ romp: 'filesViewerClosed' });
+out.phoneClosedAgain = snap(); reset();
+TAB = 'files';
+send({ romp: 'viewFile', pane: 'pane', path: '/p', sid: SID });
+out.already = snap(); reset();
+MOBILE = false; window.__rompFilesTabFrom = 'chat';
+send({ romp: 'filesViewerClosed' });
+out.deskClosed = snap(); reset();
+const probe = window.__rompMobileOn; delete window.__rompMobileOn;
+send({ romp: 'viewFile', pane: 'pane', path: '/p', sid: SID });
+out.noProbe = snap(); reset(); window.__rompMobileOn = probe;
+send({ romp: 'viewFile', path: '/p', sid: SID });
+out.noPane = snap(); reset();
+send({ romp: 'browseFiles', path: '/repo/notes-api', sid: SID });
+out.browse = snap(); reset();
+// the Files page is still loading when the click arrives: the forward waits for the iframe's load, once
+FILES_READY = 'loading';
+send({ romp: 'viewFile', pane: 'pane', path: '/repo/notes-api/src/app.py', sid: SID, identity });
+out.early = { toggles: TOGGLES.slice(), files: POSTED['f-files'].slice(), waiting: FILES_LOADS.length };
+FILES_READY = 'complete'; FILES_LOADS.slice().forEach((f) => f());
+out.loaded = { files: POSTED['f-files'].slice(), waiting: FILES_LOADS.length };
+FILES_LOADS.slice().forEach((f) => f());
+out.reloaded = { files: POSTED['f-files'].slice() }; reset();
+send({ type: 'editorSelection', text: 'the auth check', sid: SID, src: 'src/app.py:12' });
+out.seed = snap(); reset();
+console.log(JSON.stringify(out));
+"""
+
+
+class RelayArms(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        js = km._LANDING_SETTINGS_JS.replace("__ROMP_BOOT__", json.dumps("boot-1")).replace("__ROMP_LOADER__", json.dumps(""))
+        cls.out = _run(_ARMS_HARNESS + js + _ARMS_DRIVER.replace("__SID__", SID))
+
+    def test_the_script_registers_one_message_listener(self):
+        self.assertEqual(self.out["listeners"], 1)
+
+    def test_desktop_a_pane_click_brings_the_files_pane_forward_and_forwards_the_identity(self):
+        d = self.out["desktop"]
+        self.assertEqual(d["toggles"], [["files", True]], "the Files pane comes forward; the feed is not touched")
+        self.assertEqual(d["tabs"], [], "desktop: no mobile tab switch (the column is already visible)")
+        self.assertEqual(d["from"], "undef", "and nothing to remember")
+        self.assertEqual(d["files"], [{"romp": "viewFile", "path": "/repo/notes-api/src/app.py", "sid": SID,
+                                       "identity": {"name": "web", "color": {"bg": "#123456", "fg": "#ffffff"}}}])
+        self.assertEqual(d["feed"], [], "nothing reaches the feed")
+        self.assertEqual(d["chat"], [])
+        # no identity on the relay: the forward carries null (never undefined), and the pane falls to the stub;
+        # a remote session's prefixed sid rides through untouched
+        b = self.out["bare"]
+        self.assertEqual(b["files"], [{"romp": "viewFile", "path": "/repo/notes-api/README.md", "sid": "TESTHOST:" + SID, "identity": None}])
+
+    def test_phone_the_relay_switches_to_the_files_tab_and_the_close_puts_the_person_back_once(self):
+        p = self.out["phone"]
+        self.assertEqual(p["tabs"], ["files"])
+        self.assertEqual(p["from"], "chat", "the tab the click came from is remembered")
+        self.assertEqual(p["toggles"], [["files", True]], "the desktop bring-forward still runs (keeps po in step)")
+        c = self.out["phoneClosed"]
+        self.assertEqual(c["tabs"], ["files", "chat"], "close: back to the remembered tab")
+        self.assertIsNone(c["from"], "and the memory is consumed")
+        self.assertEqual(self.out["phoneClosedAgain"]["tabs"], ["files", "chat"], "a second close with nothing remembered switches nothing")
+        a = self.out["already"]
+        self.assertEqual(a["tabs"], [], "already on the Files tab: nothing to switch")
+        self.assertEqual(a["from"], "undef", "and nothing to remember")
+
+    def test_desktop_close_drops_a_stale_memory_without_replaying_it(self):
+        d = self.out["deskClosed"]
+        self.assertEqual(d["tabs"], [])
+        self.assertIsNone(d["from"], "dropped, never replayed later (a rotation to desktop between open and close)")
+
+    def test_a_shell_without_the_layout_probe_does_not_throw(self):
+        n = self.out["noProbe"]
+        self.assertEqual(n["tabs"], [])
+        self.assertEqual(len(n["files"]), 1, "the forward still happens")
+
+    def test_a_view_file_naming_no_pane_is_not_relayed(self):
+        # the chat opens in place for "here"; a message with no target is not this arm's and goes nowhere
+        n = self.out["noPane"]
+        self.assertEqual(n["files"], [])
+        self.assertEqual(n["feed"], [])
+        self.assertEqual(n["toggles"], [])
+
+    def test_a_click_before_the_files_page_has_loaded_is_delivered_on_its_load_once(self):
+        # the dashboard just opened (or a phone's hidden iframe boots late): a postMessage into a document whose
+        # files.js has not registered its listener would be dropped with the pane brought forward empty
+        e = self.out["early"]
+        self.assertEqual(e["toggles"], [["files", True]], "the pane still comes forward at once")
+        self.assertEqual(e["files"], [], "nothing is posted into a document that cannot hear it yet")
+        self.assertEqual(e["waiting"], 1, "one load listener holds the click")
+        l = self.out["loaded"]
+        self.assertEqual(len(l["files"]), 1, "the load delivers it")
+        self.assertEqual(l["files"][0]["path"], "/repo/notes-api/src/app.py")
+        self.assertEqual(l["waiting"], 0, "and the listener is gone")
+        self.assertEqual(len(self.out["reloaded"]["files"]), 1, "a later reload of the pane does not replay it")
+
+    def test_the_feeds_browse_relay_and_the_quote_seed_forward_are_untouched(self):
+        b = self.out["browse"]
+        self.assertEqual(b["feed"], [{"romp": "browseFiles", "path": "/repo/notes-api", "sid": SID}])
+        self.assertEqual(b["tabs"], ["feed"], "the feed's browser still switches a phone to the Feed tab")
+        self.assertEqual(b["files"], [])
+        s = self.out["seed"]
+        self.assertEqual(s["chat"], [{"type": "editorSelection", "text": "the auth check", "sid": SID, "src": "src/app.py:12"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_reveal_unhide.py
+++ b/tests/test_shell_reveal_unhide.py
@@ -15,8 +15,10 @@ SRC = open(os.path.join(os.path.dirname(HERE), "bin", "romp-kernel")).read()
 class RevealUnhidesThePane(unittest.TestCase):
     def test_the_reveal_helper_unhides_then_tab_switches(self):
         self.assertIn("function reveal(p){try{window.__rompPaneToggle&&window.__rompPaneToggle(p,true);}"
-                      "catch(e){}show(p);}", SRC,
-                      "un-hide FIRST (guarded — the collapse script parses later), then the mobile tab")
+                      "catch(e){}userSwitch(p);}", SRC,
+                      "un-hide FIRST (guarded: the collapse script parses later), then the mobile tab through userSwitch, "
+                      "which drops the file relay's remembered tab the way a tab tap does (tests/test_pane_state_broadcast.py)")
+        self.assertIn("function userSwitch(p){window.__rompFilesTabFrom=null;show(p);}", SRC)
 
     def test_both_reveal_arrivals_use_it(self):
         self.assertIn("if(m.romp==='reveal'&&m.pane)reveal(m.pane);", SRC,

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
-# ui/ — the front-end source (all four panes)
+# ui/: the front-end source (all five panes)
 
-The web UI the kernel serves: **chat**, **feed**, **fleet**, and **timeline**.
+The web UI the kernel serves: **chat**, **feed**, the outline (**fleet**), **files**, and **timeline**.
 One set of sources renders everywhere — a browser tab on the kernel's port and
 the VS Code/Cursor webviews (`vscode-extension/`) run the same bundles, so the
 two hosts cannot drift.
@@ -8,7 +8,8 @@ two hosts cannot drift.
 ## Layout
 
 - **`webview/`** — the pane sources: `render.ts` (chat), `feed.ts` + `feed.css`
-  (feed), `fleet.ts` + `fleet-pane.css` (fleet), `timeline-main.ts` +
+  (feed), `fleet.ts` + `fleet-pane.css` (fleet), `files.ts` + `files-pane.css`
+  (files: the file viewer as its own column), `timeline-main.ts` +
   `timeline-pane.css` (timeline boot glue), plus shared pieces (`styles.css`,
   `actions.ts` click-safety helpers, `federation.ts` multi-kernel merge,
   `settings.ts`, `compact.ts`, …). Node tests sit beside their sources

--- a/ui/webview/editor-lazy.test.ts
+++ b/ui/webview/editor-lazy.test.ts
@@ -31,8 +31,10 @@ test("the chunk is its own esbuild entry, and no main-bundle source imports Code
 });
 
 test("file-view loads the chunk from its own bundle's URL (same dir, same ?v= token), latch cleared on failure", () => {
-  assert.match(VIEW, /\.find\(\(u\) => \/\\\/\(render\|feed\)\\\.js\/\.test\(u\)\)/);
-  assert.match(VIEW, /sc\.src = self\.replace\(\/\\\/\(render\|feed\)\\\.js\/, "\/editor-chunk\.js"\);/);
+  // the three bundles that host the viewer: render.js (chat), feed.js (feed), files.js (the Files pane); a page
+  // whose bundle the pattern misses sends every Edit to the textarea with the raw "no bundle script tag" error
+  assert.match(VIEW, /\.find\(\(u\) => \/\\\/\(render\|feed\|files\)\\\.js\/\.test\(u\)\)/);
+  assert.match(VIEW, /sc\.src = self\.replace\(\/\\\/\(render\|feed\|files\)\\\.js\/, "\/editor-chunk\.js"\);/);
   assert.match(VIEW, /sc\.onerror = \(\) => \{ edChunk = null; rej\(/,
     "a failed load clears the latch so a later edit retries fresh");
 });

--- a/ui/webview/esc-close.test.ts
+++ b/ui/webview/esc-close.test.ts
@@ -15,7 +15,7 @@ const ESC = KERNEL.split('_LANDING_ESC_JS = """')[1].split('"""')[0];
 
 test("the shared Escape block wires the shell document AND every pane document", () => {
   assert.ok(ESC.includes("document.addEventListener('keydown',onEsc,true);"));
-  assert.ok(ESC.includes("['f-chat','f-fleet','f-feed','f-timeline'].forEach"));
+  assert.ok(ESC.includes("['f-chat','f-fleet','f-feed','f-files','f-timeline'].forEach"));
   assert.ok(ESC.includes("f.contentDocument.addEventListener('keydown',onEsc,true);"));
   assert.ok(ESC.includes("f.addEventListener('load',wire);wire();"), "re-attached on every iframe (re)load");
   // and the block is actually spliced into the landing page

--- a/ui/webview/file-route.test.ts
+++ b/ui/webview/file-route.test.ts
@@ -1,0 +1,37 @@
+// Where a FILE click opens (render.ts openPath): one ladder, pure and DOM-free (file-route.ts), so the
+// whole table runs here. The inputs are read at click time by the caller: the gear's "File links open in"
+// value as stored (anything), whether a shell frames this document, and whether the shell says the Files
+// pane is on screen (render.ts panesOn, the shell's own broadcast). An OPEN Files pane takes the click
+// whatever the setting says: the pane being open is the intent, and a file that opened as a modal over the
+// chat while the pane sat there empty was the bug. Closed, the setting decides; "here" is the viewer as a
+// modal over the pane that was clicked, the default and the only route where no shell exists.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { fileLinkRoute } from "./file-route";
+
+const SETTINGS = ["chat", "pane", undefined, null, "purple", 42];   // the gear's two values, an unset store, foreign values
+
+test("fileLinkRoute: no shell (standalone /chat), everything opens in place", () => {
+  for (const setting of SETTINGS) for (const open of [true, false]) {
+    assert.equal(fileLinkRoute(setting, false, open), "here", `setting=${String(setting)}, filesOpen=${open}`);
+  }
+});
+
+test("fileLinkRoute: Files pane OPEN, the click goes there whatever the setting says", () => {
+  for (const setting of SETTINGS) assert.equal(fileLinkRoute(setting, true, true), "pane", `setting=${String(setting)}`);
+});
+
+test("fileLinkRoute: Files pane CLOSED, the setting decides; only the literal 'pane' opts in", () => {
+  assert.equal(fileLinkRoute("pane", true, false), "pane", "the setting names the Files pane: the shell brings it forward");
+  assert.equal(fileLinkRoute("chat", true, false), "here", "the default: the viewer over the pane you clicked");
+  assert.equal(fileLinkRoute(undefined, true, false), "here", "an unset store reads as the default");
+  assert.equal(fileLinkRoute(null, true, false), "here");
+  assert.equal(fileLinkRoute("purple", true, false), "here", "a foreign stored value falls to the default");
+  assert.equal(fileLinkRoute(42, true, false), "here");
+});
+
+test("fileLinkRoute names only the two targets this chat can open", () => {
+  const seen = new Set<string>();
+  for (const setting of SETTINGS) for (const framed of [true, false]) for (const open of [true, false]) seen.add(fileLinkRoute(setting, framed, open));
+  assert.deepEqual([...seen].sort(), ["here", "pane"]);
+});

--- a/ui/webview/file-route.ts
+++ b/ui/webview/file-route.ts
@@ -1,0 +1,21 @@
+// Where a click on a FILE opens: one ladder, pure and DOM-free so the table runs for real in tests
+// (file-route.test.ts). The caller (render.ts openPath) reads every input at CLICK time:
+//   pane       the gear's "File links open in" (settings.fileLinkPane): "chat" (the default) or "pane";
+//              a foreign stored value reads as the default.
+//   framed     window.parent !== window: a shell exists to relay to. Standalone /chat has no shell and no
+//              other pane, so everything opens in place there.
+//   filesOpen  the shell's Files-pane bit (render.ts panesOn.files, cached from the shell's own broadcast):
+//              the pane is ON SCREEN, a desktop column toggled on or the tab showing on a phone.
+// A verdict names the TARGET: "pane" is the Files pane (the shell brings a closed one forward; the click is
+// the gesture), "here" is this document, the viewer as a modal over the pane that was clicked.
+
+export type FileRoute = "pane" | "here";
+
+/** An OPEN Files pane takes the click whatever the setting says: the pane being open IS the intent, and a
+ *  file that opened as a modal over the chat while the pane sat there empty was the bug. Closed, the
+ *  setting decides; "here" is the default. */
+export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean): FileRoute {
+  if (!framed) return "here";
+  if (filesOpen) return "pane";
+  return pane === "pane" ? "pane" : "here";
+}

--- a/ui/webview/file-view-links.test.ts
+++ b/ui/webview/file-view-links.test.ts
@@ -796,7 +796,7 @@ test("source: the body's listener and its gesture: a drag-select opens nothing, 
 });
 
 test("source: a link's line scrolls the code view's row once the text lands, spent once; a line past the end says so in the viewer's notice and lands on the last row; a markdown file takes its Raw view for that open without saving the preference", () => {
-  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): void \{/);
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): boolean \{/);
   assert.match(VIEW, /const scrollToLine = \(n: number\) => \{\n\s*const rows = body\.querySelectorAll\("code\.hljs \.fv-cl"\);\n\s*if \(!rows\.length\) return;\n\s*if \(n > rows\.length\) noteBar\("Line " \+ n \+ " is past the end of this file, which has " \+ rows\.length \+ \(rows\.length === 1 \? " line" : " lines"\) \+ "; showing the last line\."\);\n\s*\(rows\[Math\.min\(Math\.max\(0, n - 1\), rows\.length - 1\)\] as HTMLElement\)\.scrollIntoView\(\{ block: "center" \}\);/);
   assert.match(VIEW, /let pendingLine: number \| null = opts && typeof opts\.line === "number" && opts\.line > 0 \? Math\.floor\(opts\.line\) : null;/);
   assert.match(VIEW, /text = t;\n\s*\/\/[^\n]*\n\s*if \(pendingLine !== null && isMd && fmt\.md === "rendered"\) fmt\.md = "raw";\n\s*renderBody\(\);\n\s*if \(pendingLine !== null\) \{ scrollToLine\(pendingLine\); pendingLine = null; \}/);

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -20,12 +20,16 @@ const FEED = web("feed.ts");
 const FEED_CSS = web("feed.css");
 const CHAT_CSS = web("styles.css");
 
-test("openPath routes by HOST: the in-pane viewer modal on the web, the editor in VS Code", () => {
+test("openPath routes by HOST: the in-pane viewer modal on the web (or the Files pane, by the ladder), the editor in VS Code", () => {
   assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void/);   // ev: the click, for a PDF's modified-click tab
-  // web → the viewer opens in THIS document, framed or standalone alike — no shell relay, no fallback
-  assert.match(RENDER, /openFileClick\(ev, path, sid \|\| activeId \|\| null\);/);   // via the gesture reader: a plain click is openFileView (pdf-new-tab.test.ts)
+  // web → the ladder decides at the click (file-route.ts fileLinkRoute, its table in file-route.test.ts): "here" opens
+  // the viewer in THIS document through the gesture reader; "pane" hands a plain click to the shell for the Files pane
+  assert.match(RENDER, /const route = fileLinkRoute\(settings\.fileLinkPane, window\.parent !== window, panesOn\.files === true\);/);
+  assert.match(RENDER, /openFileClick\(ev, path, to, route === "pane" \? \(\) => \{/);   // via the gesture reader: a plain click is openFileView or the relay (pdf-new-tab.test.ts)
   assert.match(RENDER, /import \{ openFileClick \} from "\.\/file-view";/);   // the gesture reader is the chat's only way in; openFileView is not imported
-  assert.doesNotMatch(RENDER, /romp: "viewFile"/, "the chat→shell→feed relay is gone");
+  assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "viewFile", path, sid: to, pane: "pane",\n\s*identity: s && s\.name \? \{ name: s\.name, color: s\.color \?\? null \} : null \}, "\*"\);/);
+  assert.equal((RENDER.match(/romp: "viewFile"/g) || []).length, 1, "one relay, aimed at the Files pane; the feed is never a file's target");
+  assert.doesNotMatch(RENDER, /pane: "feed"/);
   // VS Code keeps the host editor
   assert.match(RENDER, /vscodeApi\.postMessage\(sid \? \{ type: "openFile", path, id: sid \} : \{ type: "openFile", path \}\);/);
 });
@@ -38,12 +42,13 @@ test("every file-link surface in the chat goes through openPath — no direct op
                "both remaining mentions are the two arms of openPath's fallback");
 });
 
-test("the VIEWER's shell relay is gone; the BROWSER's stays — the feed pane is only juggled for it", () => {
+test("the VIEWER's shell relay serves the Files pane only; the BROWSER's stays, and the feed pane is only juggled for it", () => {
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  // the viewer lives in the clicking document now, so the shell no longer forwards viewFile clicks
-  // (the user 2026-08-15: a file view must never touch the feed) — and the viewer, being a modal over
-  // whatever pane opened it, has nothing to restore and nothing to announce
-  assert.doesNotMatch(KERNEL, /m\.romp==='viewFile'/);
+  // the viewer lives in the clicking document (the user 2026-08-15: a file view must never touch the feed), so
+  // the shell forwards a viewFile click to ONE place, the Files pane, and only when the click names it; the
+  // pane stays up, so the viewer has nothing to restore and nothing to announce. The arm itself is the kernel's
+  // and is pinned and run in the Python lane (tests/test_files_pane.py Relay, tests/test_pane_state_broadcast.py)
+  assert.doesNotMatch(KERNEL, /postMessage\(\{romp:'viewFile',path:m\.path,sid:m\.sid\},'\*'\)/, "no forward into the feed");
   assert.doesNotMatch(VIEW, /viewFileClosed/, "nothing to restore → nothing to announce");
   // the file BROWSER still lives in the FEED pane, so its ask still relays through the shell from
   // any pane, still turns a toggled-off feed on, and still restores it on browseClosed — that
@@ -795,9 +800,11 @@ test("the title bar carries a session chip resolved from the sid — never inven
     "capitalized like this bar's other tooltips; 'session' so a name like web is not read as a place");
   assert.match(openFn, /bar\.appendChild\(name\); if \(sess\) bar\.appendChild\(sess\); bar\.appendChild\(acts\);/,
     "between the path and the actions");
-  // the signatures every opener and the relay pin depend on are exactly as they were
-  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): void \{/);   // frag: a sibling link's fragment lands after the render
-  assert.match(VIEW, /export function initFileView\(poster: \(m: Record<string, unknown>\) => void\): void \{/);
+  // the signatures every opener and the relay pin depend on: the open answers whether it happened (a
+  // dirty-edit veto is false, so the Files pane's recent list records only real opens), and the listener
+  // takes an optional relay contract (files.ts takes the shell's relay whole)
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): boolean \{/);   // frag: a sibling link's fragment lands after the render
+  assert.match(VIEW, /export function initFileView\(poster: \(m: Record<string, unknown>\) => void,\n\s*onRelay\?: \(m: \{ path: string; sid\?: unknown; identity\?: unknown \}\) => void\): void \{/);
 });
 
 test("both hosting documents register a resolver beside their initFileView boot", () => {
@@ -867,4 +874,33 @@ test("the chip's dress is in BOTH sheets: a fixed-width pill that never yields t
     // (~1:1 contrast for a remote session's chip). opacity keeps it quiet without dimming to gray.
     assert.match(css, /\.fileview-sess \.host-prefix \{ color: inherit; opacity: 0\.75; \}/, "the host: token uses the pill's fg, quiet");
   }
+});
+
+// executed: openFileView's verdict, the head of the function lifted from file-view.ts (plain JS up to the guard's
+// reset) and run over a document that does or does not hold a viewer and a close guard that does or does not
+// veto. The Files pane's recent list records an open only when this answers true (files.ts openHere), so a
+// dirty-edit veto that answered true would list a file that never opened.
+test("openFileView answers false when the dirty-edit guard keeps the previous viewer, and falls through otherwise", () => {
+  const at = VIEW.indexOf("export function openFileView(");
+  const head = VIEW.slice(VIEW.indexOf("): boolean {", at) + "): boolean {".length, VIEW.indexOf("closeGuard = null;", at) + "closeGuard = null;".length);
+  assert.match(head, /if \(document\.getElementById\("romp-fileview"\) && closeGuard && !closeGuard\(\)\) return false;/);
+  const run = (viewerUp: boolean, guard: (() => boolean) | null) => {
+    let asked = 0;
+    const document = { getElementById: (id: string) => (viewerUp && id === "romp-fileview" ? {} : null) };
+    const closeGuard = guard ? () => { asked++; return guard(); } : null;
+    const out = (new Function("document", "closeGuard", "return (function () {" + head + " return { through: true, guard: closeGuard }; })();") as
+      (d: unknown, g: unknown) => false | { through: true; guard: unknown })(document, closeGuard);
+    return { out, asked };
+  };
+  const veto = run(true, () => false);
+  assert.equal(veto.out, false, "a viewer up whose guard refuses: the open did not happen");
+  assert.equal(veto.asked, 1, "the guard was asked once");
+  const ok = run(true, () => true);
+  assert.deepEqual(ok.out, { through: true, guard: null }, "the guard allowed it: the head falls through and the guard is dropped for the new viewer");
+  const none = run(false, () => false);
+  assert.deepEqual(none.out, { through: true, guard: null }, "no viewer up: nothing to ask, the guard is not consulted");
+  assert.equal(none.asked, 0);
+  assert.deepEqual(run(true, null).out, { through: true, guard: null }, "a viewer with no guard (nothing edited) is replaced");
+  // and the other end of the function: a completed open answers true
+  assert.match(VIEW, /body\.replaceChildren\(why\);\n\s*\}\);\n\s*return true;\n\}/, "openFileView ends by answering true");
 });

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -473,9 +473,14 @@ export function closeFileView(): void {
  *  gesture: deciding on the fetched Content-Type would lose the gesture, and every browser would then
  *  block the tab. Every clicked file lands here, so this is the one place the choice lives; a relayed
  *  viewFile or a Reload has no gesture and opens the viewer directly. A BLOCKED popup falls through to
- *  the viewer, so the PDF is never unreachable, and a non-PDF is simply not the opener's business. */
-export function openFileClick(ev: MouseEvent | KeyboardEvent | null | undefined, path: string, sid?: string | null): void {
+ *  the viewer, so the PDF is never unreachable, and a non-PDF is simply not the opener's business.
+ *  `relay`: where a plain click goes when the hosting document routes it elsewhere (render.ts openPath
+ *  handing the open to the shell for the Files pane): the gesture is still read first, so a modified click
+ *  on a PDF takes its own tab whichever pane the plain click would have landed in. */
+export function openFileClick(ev: MouseEvent | KeyboardEvent | null | undefined, path: string, sid?: string | null,
+                              relay?: (path: string, sid: string | null) => void): void {
   if (wantsOwnTab(ev) && openPdfTab(path, sid ?? null)) return;
+  if (relay) { relay(path, sid ?? null); return; }
   openFileView(path, sid);
 }
 
@@ -483,11 +488,13 @@ export function openFileClick(ev: MouseEvent | KeyboardEvent | null | undefined,
  *  `opts.line`: a line the open should show (a `path:12` link inside another file, file-view-links.ts): the code
  *  view scrolls its row into view once the text lands; a markdown file opens in its Raw view for THIS open (the
  *  Rendered view has no rows), without touching the saved preference.
- *  `opts.frag`: a sibling link's `#fragment` (`[see](report.md#results)`) to land on after the first rendered paint. */
-export function openFileView(path: string, sid?: string | null, opts?: { line?: number | null; frag?: string | null }): void {
+ *  `opts.frag`: a sibling link's `#fragment` (`[see](report.md#results)`) to land on after the first rendered paint.
+ *  Returns whether the open happened: false when the dirty-edit guard kept the previous viewer, so a caller
+ *  that records the open (the Files pane's recent list) records only real ones. */
+export function openFileView(path: string, sid?: string | null, opts?: { line?: number | null; frag?: string | null }): boolean {
   // The replace path bypasses closeFileView, so it needs the same dirty ask: opening file B over an
   // edited-but-unsaved file A must not silently eat A's buffer.
-  if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return;
+  if (document.getElementById("romp-fileview") && closeGuard && !closeGuard()) return false;
   closeGuard = null;
   editHooks = null;
   gitHooks = null;                                     // the replace path skips closeFileView — same drop
@@ -955,10 +962,10 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
     const w = window as any;
     if (w.__rompEditor) return res(w.__rompEditor);
     const self = Array.from(document.querySelectorAll("script[src]"))
-      .map((n) => (n as HTMLScriptElement).src).find((u) => /\/(render|feed)\.js/.test(u));
+      .map((n) => (n as HTMLScriptElement).src).find((u) => /\/(render|feed|files)\.js/.test(u));
     if (!self) return rej(new Error("no bundle script tag to derive the editor chunk URL from"));
     const sc = document.createElement("script");
-    sc.src = self.replace(/\/(render|feed)\.js/, "/editor-chunk.js");
+    sc.src = self.replace(/\/(render|feed|files)\.js/, "/editor-chunk.js");
     sc.onload = () => { const e = (window as any).__rompEditor; e ? res(e) : rej(new Error("editor chunk loaded but did not register")); };
     sc.onerror = () => { edChunk = null; rej(new Error("the editor bundle failed to load")); };
     document.head.appendChild(sc);
@@ -1147,6 +1154,7 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
     }
     body.replaceChildren(why);
   });
+  return true;
 }
 
 // Which fetch failures still deserve a Download offer? Exactly the ones that mean the file EXISTS:
@@ -1631,17 +1639,20 @@ function pdfBlock(objUrl: string, path: string): HTMLElement {
 }
 
 /** Bind the pane's WS poster and route saveFile + fileGitLink replies back to the open viewer.
- *  Called once, from the pane's boot (render.ts and feed.ts today — either document, one mechanism);
+ *  Called once, from the pane's boot (render.ts, feed.ts and files.ts: any document, one mechanism);
  *  every reply is reqId-guarded so one landing after a close or a replace-open touches nothing. The
- *  viewFile branch honors a shell's relay of a chat file-link click — nothing sends it since the
- *  viewer moved into the chat document, but a not-yet-reloaded shell page still might, and honoring
- *  it costs nothing. */
-export function initFileView(poster: (m: Record<string, unknown>) => void): void {
+ *  viewFile branch honors a shell's relay of a chat file-link click: the Files pane is its receiver
+ *  (kernel.py's landing shell forwards the click there with the session's identity), and a document
+ *  with a relay contract of its own passes `onRelay` and takes the relayed message whole instead of
+ *  the plain open (files.ts caches the identity for its chip and keeps its recent list). */
+export function initFileView(poster: (m: Record<string, unknown>) => void,
+                             onRelay?: (m: { path: string; sid?: unknown; identity?: unknown }) => void): void {
   post = poster;
   window.addEventListener("message", (e: MessageEvent) => {
     const m = e.data;
     if (!m) return;
     if (m.romp === "viewFile" && typeof m.path === "string" && m.path) {
+      if (onRelay) { onRelay(m); return; }   // this document's own contract (the Files pane) takes the message whole
       openFileView(m.path, typeof m.sid === "string" ? m.sid : null);
     } else if (m.type === "fileGitLink" && gitHooks && m.reqId === gitHooks.reqId) {
       const h = gitHooks; gitHooks = null;

--- a/ui/webview/files-pane.css
+++ b/ui/webview/files-pane.css
@@ -1,0 +1,42 @@
+/* The Files pane's layout styles (ui/webview/files.ts): the file VIEWER as a COLUMN of the dashboard
+   instead of a modal over another pane. bin/romp-kernel reads this file live for the /files page and
+   vscode-extension/esbuild.js bundles it to dist/files-pane.css. The viewer's own dress (.fileview-*, the
+   file browser, the code palette) comes from the chat's styles.css, linked before this file; the rules
+   here own the page layout, the pane-resident variant of the viewer, and the empty state. */
+html,body{margin:0;height:100%;background:var(--vscode-editor-background,#1e1e1e);
+color:var(--vscode-foreground,#cccccc);font-family:'Inter',var(--vscode-font-family,system-ui,-apple-system,'Segoe UI',sans-serif);
+font-size:13px;display:flex;flex-direction:column;overflow:hidden}
+/* The viewer FILLS the pane. The modal variant lives in styles.css and feed.css, byte-equal (the parity
+   test); this variant lives HERE so those two sheets stay mirrors. No backdrop, no card inset, no rounded
+   corners or shadow. position:relative rather than static keeps the viewer's z-index in force, so a viewer
+   opened from a file-browser row still paints above the browser's fixed overlay (the back button's path). */
+body.fileview-pane #romp-fileview{position:relative;inset:auto;flex:1 1 auto;min-height:0;background:none}
+body.fileview-pane .fileview{width:100%;height:100%;border:0;border-radius:0;box-shadow:none}
+/* The file BROWSER, reached from the viewer's directory link, fills the pane the same way: the chat sheet
+   dresses it as a centered card over a dimmed backdrop (styles.css #romp-filebrowse / .filebrowse), which in
+   a column floated in a dim pane. The backdrop stays fixed and goes clear; the card fills the backdrop. Its
+   z layer stays beneath the viewer's, so a file opened from a row still paints over the listing. */
+body.fileview-pane #romp-filebrowse{background:none}
+body.fileview-pane .filebrowse{width:100%;height:100%;border:0;border-radius:0;box-shadow:none}
+/* The empty state: what the pane is for, and the files most recently open here as re-open links. The rows
+   wear the viewer's own title-bar classes (.fileview-name / -dir / -base / -sess), so a path and its session
+   chip read exactly as they do in the bar above an open file. */
+#files-empty{flex:1 1 auto;min-height:0;overflow-y:auto;padding:26px 14px}
+#files-empty[hidden]{display:none}
+.fs-title{opacity:.7;text-align:center;line-height:1.5}
+.fs-hint{opacity:.55;text-align:center;line-height:1.5;font-size:11px;margin-top:4px}
+.fs-recent{margin:22px auto 0;max-width:560px}
+.fs-recent-head{font-size:11px;font-weight:650;opacity:.6;text-transform:uppercase;letter-spacing:.04em;padding:0 8px 4px}
+.fs-row{display:flex;align-items:center;gap:8px;min-width:0;padding:5px 8px;border-radius:6px;cursor:pointer}
+.fs-row:hover{background:var(--overlay-05,rgba(255,255,255,0.05))}
+/* Print: this sheet's own screen rules undone so a file prints as a document. The base sheet's print block
+   (styles.css, loaded first) keys on :root and body.fileview-open, which outrank the html,body rule above for
+   height, overflow and colour whatever the order; but it never touches html's display:flex, it cannot beat the
+   more specific .fileview size rule above (body.fileview-pane .fileview), and with no file open (no
+   fileview-open on the body) it does not apply at all. So the page and the viewer grow to the file's height,
+   the ink is black on white (keywords: this sheet holds no bare hex), and the empty state never prints, with
+   or without a file open (the base sheet hides it only under fileview-open). The viewer's position:relative
+   above stands in print too: in flow it prints as a block. */
+@media print{html,body{height:auto;overflow:visible;display:block;background:white;color:black}
+body.fileview-pane .fileview{width:auto;height:auto}
+#files-empty{display:none}}

--- a/ui/webview/files-recent.ts
+++ b/ui/webview/files-recent.ts
@@ -1,0 +1,42 @@
+// The Files pane's recent-files list (files.ts): the pure half, importable by the tests. When nothing is
+// open the pane lists the files most recently open there as re-open links, so a thread dropped yesterday
+// costs one click to pick up. Stored per browser (localStorage), most recent first, one row per path and
+// session, capped; the identity a row carries is whatever the shell's relay handed over when the file was
+// opened, so the row's session chip re-renders without a session list of the pane's own.
+export interface RecentIdentity { name: string; color: { bg: string; fg: string } | null }
+export interface RecentFile { path: string; sid: string | null; identity: RecentIdentity | null; t: number }
+export const RECENT_KEY = "romp:files-recent";
+export const RECENT_MAX = 8;
+
+/** A relayed or stored identity, validated to the chip's shape. Anything else is no identity: the chip is
+ *  looked up, never invented (file-view.ts's rule), and a resolver miss falls to the kernel's stub there. */
+export function asIdentity(x: unknown): RecentIdentity | null {
+  if (!x || typeof x !== "object") return null;
+  const o = x as { name?: unknown; color?: unknown };
+  if (typeof o.name !== "string" || !o.name) return null;
+  const c = o.color as { bg?: unknown; fg?: unknown } | null | undefined;
+  const color = c && typeof c === "object" && typeof c.bg === "string" && typeof c.fg === "string" ? { bg: c.bg, fg: c.fg } : null;
+  return { name: o.name, color };
+}
+
+/** The stored list, tolerant of junk: a corrupt entry costs the list, never the pane. */
+export function parseRecent(raw: string | null): RecentFile[] {
+  if (!raw) return [];
+  try {
+    const v = JSON.parse(raw);
+    if (!Array.isArray(v)) return [];
+    const out: RecentFile[] = [];
+    for (const e of v) {
+      if (!e || typeof e !== "object" || typeof e.path !== "string" || !e.path) continue;
+      out.push({ path: e.path, sid: typeof e.sid === "string" && e.sid ? e.sid : null,
+                 identity: asIdentity(e.identity), t: typeof e.t === "number" ? e.t : 0 });
+    }
+    return out.slice(0, RECENT_MAX);
+  } catch { return []; }
+}
+
+/** Most recent first, one row per path and session (a re-open moves the row up and refreshes its identity), capped. */
+export function rememberRecent(list: RecentFile[], entry: RecentFile, max = RECENT_MAX): RecentFile[] {
+  const rest = list.filter((r) => !(r.path === entry.path && r.sid === entry.sid));
+  return [entry, ...rest].slice(0, max);
+}

--- a/ui/webview/files.test.ts
+++ b/ui/webview/files.test.ts
@@ -1,0 +1,268 @@
+// The Files pane (files.ts): the file viewer as its own column of the dashboard, hosting the shared viewer
+// pane-resident, with an empty state that lists the files most recently open there. No jsdom harness, so
+// the boot wiring is pinned at source; what can run, runs: the pure half (the recent list and the relayed
+// identity's validation, files-recent.ts), the viewer's relay guard (lifted from file-view.ts, plain JS
+// inside the listener), and the pane's own open and close-edge functions (openHere, onBodyChange, lifted
+// from files.ts with esbuild at run time, the chat-exact-tail-exec.test.ts idiom) over stubs for the viewer,
+// the store and the shell. The shell's own arms run in tests/test_pane_state_broadcast.py; nothing here
+// reads the kernel. Synthetic rows: the notes-api demo world, placeholder sids, TESTHOST for a remote host.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { asIdentity, parseRecent, rememberRecent, RECENT_MAX, type RecentFile } from "./files-recent";
+
+const requireCjs = createRequire(__filename);
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const read = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+const SRC = read("files.ts");
+const HELPERS = read("files-recent.ts");
+const VIEW = read("file-view.ts");
+const CSS = read("files-pane.css");
+const ESBUILD = fs.readFileSync(path.resolve(process.cwd(), "esbuild.js"), "utf8");
+
+const SID = "11111111-2222-3333-4444-555555555555";
+const SID2 = "11111111-2222-3333-4444-666666666666";
+const row = (p: string, sid: string | null, name = "web", t = 1): RecentFile =>
+  ({ path: p, sid, identity: { name, color: { bg: "#123456", fg: "#ffffff" } }, t });
+
+// files.ts's own functions, lifted whole (an anchored function, to its closing brace at column 0) and run
+// over stubs: the viewer (openFileView answers H.openOk and records the identity it could resolve at that
+// moment), the store, the repaint, the document (which surfaces are up, by id) and the shell (window.parent).
+const ts = (code: string): string => requireCjs("esbuild").transformSync(code, { loader: "ts" }).code;
+function fnSlice(startAnchor: string): string {
+  const a = SRC.indexOf(startAnchor);
+  assert.ok(a > 0, startAnchor.slice(0, 40) + " moved; re-anchor");
+  const b = SRC.indexOf("\n}\n", a);
+  assert.ok(b > a);
+  return SRC.slice(a, b + 3);
+}
+type PaneHooks = { up: Set<string>; openOk: boolean; opens: Array<[string, string | null, unknown]>; writes: RecentFile[][]; paints: number; framed: boolean; posted: unknown[] };
+type PaneApi = { openHere: (p: string, sid: string | null, identity: unknown) => void; onBodyChange: () => void; recent: () => RecentFile[]; identities: Map<string, unknown> };
+function liftPane(over: Partial<PaneHooks> = {}): { H: PaneHooks; api: PaneApi } {
+  const H: PaneHooks = { up: new Set(), openOk: true, opens: [], writes: [], paints: 0, framed: true, posted: [], ...over };
+  const js = ts(fnSlice("function surfaceUp(): boolean {") + fnSlice("function openHere(") + fnSlice("let viewerUp = surfaceUp();\nfunction onBodyChange(): void {"));
+  const prelude = `
+    const H = HOOKS;
+    const identities = new Map();
+    let recent = [];
+    const writeStore = () => { H.writes.push(recent.slice()); };
+    const paint = () => { H.paints++; };
+    const openFileView = (p, sid) => { H.opens.push([p, sid, (sid && identities.get(sid)) || null]); return H.openOk; };
+    const document = { getElementById: (id) => (H.up.has(id) ? { id } : null) };
+    const window = {};
+    window.parent = H.framed ? { postMessage: (m) => { H.posted.push(m); } } : window;
+    const Date = { now: () => 777 };
+  `;
+  const api = (new Function("HOOKS", "rememberRecent", prelude + js + "return { openHere, onBodyChange, recent: () => recent, identities };") as
+    (h: PaneHooks, rr: typeof rememberRecent) => PaneApi)(H, rememberRecent);
+  return { H, api };
+}
+
+test("the pane hosts the shared viewer and takes the shell's relay WHOLE: its own contract, not the default open", () => {
+  // initFileView's second argument replaces the default relay branch for this document: the relay carries
+  // the session's identity, which the pane caches before opening, and the open enters the Recent list
+  assert.match(SRC, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\), \(m\) => \{\n\s*openHere\(m\.path, typeof m\.sid === "string" \? m\.sid : null, asIdentity\(m\.identity\)\);\n\}\);/);
+  assert.match(VIEW, /export function initFileView\(poster: \(m: Record<string, unknown>\) => void,\n\s*onRelay\?: \(m: \{ path: string; sid\?: unknown; identity\?: unknown \}\) => void\): void \{/);
+  const relayBranch = VIEW.split('if (m.romp === "viewFile"')[1].split("} else if")[0];
+  const guard = "if (onRelay) { onRelay(m); return; }";
+  // presence first: indexOf's -1 for an ABSENT guard is less than any index, so an ordering check alone
+  // would stay green with the dispatch deleted
+  assert.ok(relayBranch.indexOf(guard) >= 0, "the dispatch guard is present");
+  assert.ok(relayBranch.indexOf("openFileView(m.path") >= 0, "the default open is present");
+  assert.ok(relayBranch.indexOf(guard) < relayBranch.indexOf("openFileView(m.path"),
+    "a document's own contract takes the message before the default open runs");
+  // the viewer's directory link opens the file browser in this document, as it does over the chat
+  assert.match(SRC, /initFileBrowse\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
+  // not a feed consumer: no frame parsing of any kind
+  assert.doesNotMatch(SRC, /m\.type === "feed"|feedDelta|ledgers|\.asks\b|needFullFeed/);
+  assert.match(SRC, /vscodeApi\?\.postMessage\(\{ type: "ready" \}\)/, "the ready handshake, as every pane sends it");
+});
+
+// executed: the relay branch of initFileView's listener, lifted from file-view.ts (plain JS inside the TS
+// listener, so it runs as written) with openFileView stubbed. With onRelay the message is taken whole and
+// the branch returns before the default open; without it the default open runs exactly as before.
+test("the relay guard, executed: onRelay takes the message and short-circuits the default open", () => {
+  const branch = VIEW.split('if (m.romp === "viewFile"')[1].split("} else if")[0];
+  const body = '(function () { if (m.romp === "viewFile"' + branch + "} })();";
+  const fn = new Function("m", "onRelay", "openFileView", body) as
+    (m: unknown, onRelay: ((m: unknown) => void) | undefined, open: (p: string, sid: string | null) => boolean) => void;
+  const run = (m: unknown, onRelay: ((m: unknown) => void) | undefined) => {
+    const opened: Array<[string, string | null]> = [];
+    fn(m, onRelay, (p, sid) => { opened.push([p, sid]); return true; });
+    return opened;
+  };
+  const identity = { name: "web", color: { bg: "#123456", fg: "#ffffff" } };
+  const msg = { romp: "viewFile", path: "/repo/notes-api/src/app.py", sid: SID, identity };
+  const taken: unknown[] = [];
+  assert.deepEqual(run(msg, (m) => taken.push(m)), [], "the default open never runs");
+  assert.deepEqual(taken, [msg], "the pane's contract gets the message WHOLE, identity included");
+  assert.deepEqual(run(msg, undefined), [["/repo/notes-api/src/app.py", SID]], "no contract of its own: the default open");
+  const junk: unknown[] = [];
+  run({ romp: "viewFile", path: "" }, (m) => junk.push(m));
+  run({ romp: "viewFile", path: 42 }, (m) => junk.push(m));
+  run({ type: "fileSaved", reqId: 1 }, (m) => junk.push(m));
+  assert.deepEqual(junk, [], "the outer guard still filters: no path, no relay");
+});
+
+test("the session chip resolves from what the relay carried, cached per sid, else the kernel's stub", () => {
+  assert.match(SRC, /setFileViewIdentity\(\(id\) => identities\.get\(id\) \?\? hostStub\(id\)\);/);
+  const openFn = SRC.split("function openHere(")[1].split("\n}")[0];
+  assert.ok(openFn.indexOf("identities.set(sid, identity);") >= 0 && openFn.indexOf("openFileView(path, sid)") >= 0
+    && openFn.indexOf("identities.set(sid, identity);") < openFn.indexOf("openFileView(path, sid)"),
+    "the cache is filled BEFORE the open, so the title bar's chip resolves on the first paint");
+  assert.match(openFn, /if \(sid && identity\) identities\.set\(sid, identity\);/);
+  assert.doesNotMatch(SRC, /sessionsMeta|tabMeta|sessions\.get/, "the pane has no session list of its own");
+});
+
+// executed: openHere as files.ts spells it. The identity is cached BEFORE the viewer opens (the chip's resolver
+// runs during the open, so a cache filled after it would miss on the first paint); a vetoed open (the viewer
+// kept a dirty edit, openFileView false) records nothing and repaints nothing; a real one enters Recent with
+// the identity the relay carried, else the one cached for the sid, else none, and persists.
+test("openHere, executed: the identity is cached before the open, a vetoed open records nothing, a real one enters Recent and persists", () => {
+  const identity = { name: "web", color: { bg: "#123456", fg: "#ffffff" } };
+  const { H, api } = liftPane({ openOk: false });
+  api.openHere("/repo/notes-api/src/app.py", SID, identity);
+  assert.deepEqual(H.opens, [["/repo/notes-api/src/app.py", SID, identity]], "the viewer was asked, and could already resolve the chip");
+  assert.deepEqual(api.recent(), [], "the veto: nothing recorded");
+  assert.deepEqual(H.writes, [], "nothing persisted");
+  assert.equal(H.paints, 0, "nothing repainted");
+  H.openOk = true;
+  api.openHere("/repo/notes-api/src/app.py", SID, identity);
+  assert.deepEqual(api.recent(), [{ path: "/repo/notes-api/src/app.py", sid: SID, identity, t: 777 }], "a real open enters Recent");
+  assert.deepEqual(H.writes, [api.recent()], "and persists once");
+  assert.equal(H.paints, 1, "and repaints the rows once");
+  // a recent row re-opened carries its own identity; a relay with none falls to the identity cached for the sid
+  api.openHere("/repo/notes-api/README.md", SID, null);
+  assert.deepEqual(api.recent()[0], { path: "/repo/notes-api/README.md", sid: SID, identity, t: 777 }, "the cached identity");
+  assert.equal(api.recent().length, 2);
+  // no sid and no identity: a row with no chip, never an invented one
+  api.openHere("/repo/notes-api/notes.md", null, null);
+  assert.deepEqual(api.recent()[0], { path: "/repo/notes-api/notes.md", sid: null, identity: null, t: 777 });
+  assert.equal(H.opens.length, 4);
+  assert.equal(H.writes.length, 3); assert.equal(H.paints, 3);
+});
+
+test("recent files: recorded only on a REAL open, painted as re-open rows in the viewer's own dress, click-safe", () => {
+  const openFn = SRC.split("function openHere(")[1].split("\n}")[0];
+  assert.match(openFn, /if \(!openFileView\(path, sid\)\) return;\n\s*const known = /, "a dirty-edit veto records nothing");
+  assert.match(openFn, /recent = rememberRecent\(recent, \{ path, sid, identity: known, t: Date\.now\(\) \}\);/);
+  assert.match(SRC, /let recent: RecentFile\[\] = parseRecent\(readStore\(\)\);/, "persisted per browser");
+  assert.match(SRC, /"No file open"/);
+  // the rows wear the viewer's title-bar classes, so a path and its chip read as they do above an open file
+  for (const cls of ['"fileview-name"', '"fileview-dir"', '"fileview-base"', '"fileview-sess"']) assert.ok(SRC.includes(cls), cls);
+  assert.match(SRC, /sess\.replaceChildren\(\.\.\.hostNameNodes\(r\.identity\.name, r\.sid\)\)/);
+  // delegated on the stable container (actions.ts): a repaint between mousedown and mouseup still lands
+  assert.match(SRC, /delegate\(empty, \{\n\s*open: \(x\) => \{ const r = recent\[Number\(x\.dataset\.i\)\]; if \(r\) openHere\(r\.path, r\.sid, r\.identity\); \},/);
+  assert.match(SRC, /row\.dataset\.act = "open"; row\.dataset\.i = String\(i\);/);
+});
+
+test("close returns to the empty state: the placeholder repaints on the viewer element's removal, never a hidden pane", () => {
+  // closeFileView only removes #romp-fileview; the body's childList mutation IS the close event, and one
+  // observer covers every open/close path (relay, recent row, the browser's rows and back, the close button, Escape, Reload)
+  assert.match(SRC, /new MutationObserver\(onBodyChange\)\.observe\(document\.body, \{ childList: true \}\);/);
+  assert.match(SRC, /function onBodyChange\(\): void \{\n\s*paint\(\);/, "the repaint rides the observer");
+  // "open" is either surface: the viewer OR the browser, by element presence
+  assert.match(SRC, /const open = surfaceUp\(\);\n\s*empty\.hidden = open;\n\s*if \(open\) return;/);
+  assert.match(SRC, /function surfaceUp\(\): boolean \{\n\s*return !!\(document\.getElementById\("romp-fileview"\) \|\| document\.getElementById\("romp-filebrowse"\)\);\n\}/);
+  assert.doesNotMatch(SRC, /setInterval|setTimeout/, "event-based, no polling");
+});
+
+// The close is also told to the SHELL: on a phone the viewFile relay switched tabs to show this pane, and
+// closing the file would otherwise strand the person on the Files tab's recent list. The shell restores the
+// tab the click came from, mobile only (kernel.py filesViewerClosed; tests/test_pane_state_broadcast.py).
+test("the viewer's close EDGE posts filesViewerClosed up to the shell: once, framed only, never on an open-over-open", () => {
+  assert.match(SRC, /let viewerUp = surfaceUp\(\);/);
+  assert.match(SRC, /const up = surfaceUp\(\);\n\s*if \(viewerUp && !up && window\.parent !== window\) window\.parent\.postMessage\(\{ romp: "filesViewerClosed" \}, "\*"\);\n\s*viewerUp = up;/);
+  assert.equal((SRC.match(/filesViewerClosed/g) || []).length, 2, "one post site (plus its comment)");
+  // executed: onBodyChange as files.ts spells it, the observer's callback, driven by what is up in the document
+  // (the viewer's wrap, the browser's overlay, by id) between calls
+  const run = (states: string[][], framed: boolean): { posts: unknown[]; paints: number } => {
+    const { H, api } = liftPane({ framed, up: new Set(states[0]) });   // the module's initial viewerUp reads the document at boot
+    for (const up of states.slice(1)) { H.up = new Set(up); api.onBodyChange(); }
+    return { posts: H.posted, paints: H.paints };
+  };
+  const V = "romp-fileview", B = "romp-filebrowse";
+  assert.deepEqual(run([[], [V], []], true), { posts: [{ romp: "filesViewerClosed" }], paints: 2 }, "open then close: one notice, a repaint per mutation");
+  assert.deepEqual(run([[], [V], [V], []], true).posts, [{ romp: "filesViewerClosed" }], "the Reload replace / open-over-open (still up when the observer runs) is not a close");
+  assert.deepEqual(run([[], [V], [], [V], []], true).posts, [{ romp: "filesViewerClosed" }, { romp: "filesViewerClosed" }], "two closes: two notices");
+  assert.deepEqual(run([[], []], true).posts, [], "an unrelated body mutation with nothing open posts nothing");
+  assert.deepEqual(run([[V, B], [B], []], true).posts, [{ romp: "filesViewerClosed" }], "a viewer closing onto the listing beneath it is no edge; the listing's close is");
+  assert.deepEqual(run([[], [V], []], false), { posts: [], paints: 2 }, "unframed (no shell): nothing to tell, the repaint still runs");
+});
+
+test("the pane-resident variant is keyed on the page's body class and lives ONLY in the pane sheet", () => {
+  assert.ok(CSS.includes("body.fileview-pane #romp-fileview{position:relative;inset:auto;flex:1 1 auto;min-height:0;background:none}"));
+  assert.ok(CSS.includes("body.fileview-pane .fileview{width:100%;height:100%;border:0;border-radius:0;box-shadow:none}"));
+  // relative, not static: the viewer keeps its z-index, so a file opened from a browser row still paints
+  // above the browser's fixed overlay (styles.css .filebrowse) and the back button has something to go back to
+  assert.doesNotMatch(CSS, /position:static/);
+  for (const sheet of ["styles.css", "feed.css"]) assert.doesNotMatch(read(sheet), /fileview-pane/, sheet + " stays a mirror");
+  for (const sel of ["#files-empty{", ".fs-title{", ".fs-hint{", ".fs-recent{", ".fs-row{"]) assert.ok(CSS.includes(sel), sel);
+  // print: the pane's own screen rules (a clipped, flexed page) are undone so a file prints as a document,
+  // the way the base sheets' print block does for the modal
+  assert.match(CSS, /@media print\{html,body\{height:auto;overflow:visible;display:block/);
+});
+
+test("wired and vocabulary-clean: esbuild entries, no federation import, no fleet identifiers or prose", () => {
+  assert.match(ESBUILD, /"\.\.\/ui\/webview\/files\.ts",/);
+  assert.match(ESBUILD, /"\.\.\/ui\/webview\/files-pane\.css",/);
+  for (const [name, src] of [["files.ts", SRC], ["files-recent.ts", HELPERS], ["files-pane.css", CSS]] as const) {
+    assert.doesNotMatch(src, /from "\.\/federation"/, name + ": importing it boots a second FederationManager");
+    assert.doesNotMatch(src, /fleet/i, name + ": no fleet identifiers or prose");
+  }
+});
+
+// executed: the pure half
+
+test("rememberRecent: most recent first, one row per path + session, capped", () => {
+  let list: RecentFile[] = [];
+  list = rememberRecent(list, row("/repo/notes-api/src/app.py", SID));
+  list = rememberRecent(list, row("/repo/notes-api/README.md", SID, "web", 2));
+  assert.deepEqual(list.map((r) => r.path), ["/repo/notes-api/README.md", "/repo/notes-api/src/app.py"]);
+  // a re-open moves the row up and refreshes it (a renamed session's new identity lands)
+  list = rememberRecent(list, row("/repo/notes-api/src/app.py", SID, "web-2", 3));
+  assert.deepEqual(list.map((r) => [r.path, r.identity!.name]), [["/repo/notes-api/src/app.py", "web-2"], ["/repo/notes-api/README.md", "web"]]);
+  // the same path from ANOTHER session is another row: the chip is what tells them apart
+  list = rememberRecent(list, row("/repo/notes-api/src/app.py", SID2, "api", 4));
+  assert.equal(list.length, 3);
+  assert.deepEqual(list[0].sid, SID2);
+  // capped at RECENT_MAX, dropping the oldest
+  for (let i = 0; i < RECENT_MAX + 3; i++) list = rememberRecent(list, row("/repo/notes-api/f" + i + ".txt", SID, "web", 10 + i));
+  assert.equal(list.length, RECENT_MAX);
+  assert.equal(list[0].path, "/repo/notes-api/f" + (RECENT_MAX + 2) + ".txt");
+  assert.ok(!list.some((r) => r.path === "/repo/notes-api/README.md"), "the oldest rows fell off");
+});
+
+test("parseRecent tolerates junk: a corrupt store costs the list, never the pane", () => {
+  assert.deepEqual(parseRecent(null), []);
+  assert.deepEqual(parseRecent("not json"), []);
+  assert.deepEqual(parseRecent('{"path":"/x"}'), [], "not an array");
+  const raw = JSON.stringify([
+    { path: "/repo/notes-api/a.md", sid: SID, identity: { name: "web", color: { bg: "#123456", fg: "#fff" } }, t: 5 },
+    { path: "", sid: SID },                       // no path: skipped
+    { sid: SID2 },                                // no path: skipped
+    { path: "/repo/notes-api/b.md", sid: 42, identity: "web", t: "soon" },   // foreign fields normalise
+    "junk", null,
+  ]);
+  const got = parseRecent(raw);
+  assert.deepEqual(got, [
+    { path: "/repo/notes-api/a.md", sid: SID, identity: { name: "web", color: { bg: "#123456", fg: "#fff" } }, t: 5 },
+    { path: "/repo/notes-api/b.md", sid: null, identity: null, t: 0 },
+  ]);
+  // an overlong store is capped on read, so a bloated entry cannot grow the list past the cap
+  const many = JSON.stringify(Array.from({ length: RECENT_MAX + 5 }, (_, i) => ({ path: "/p" + i, sid: null })));
+  assert.equal(parseRecent(many).length, RECENT_MAX);
+});
+
+test("asIdentity validates the relayed identity to the chip's shape; anything else is no identity", () => {
+  assert.deepEqual(asIdentity({ name: "web", color: { bg: "#123456", fg: "#ffffff" } }), { name: "web", color: { bg: "#123456", fg: "#ffffff" } });
+  assert.deepEqual(asIdentity({ name: "TESTHOST:api", color: null }), { name: "TESTHOST:api", color: null }, "a remote session's prefixed name, uncolored");
+  assert.deepEqual(asIdentity({ name: "web", color: { bg: 1 } }), { name: "web", color: null }, "a malformed colour is dropped, the name kept");
+  assert.equal(asIdentity({ name: "" }), null);
+  assert.equal(asIdentity({ color: { bg: "#123456", fg: "#fff" } }), null, "no name, no chip: never invented");
+  assert.equal(asIdentity(null), null);
+  assert.equal(asIdentity("web"), null);
+});

--- a/ui/webview/files.ts
+++ b/ui/webview/files.ts
@@ -1,0 +1,145 @@
+// "Files": the file VIEWER as its own column of the dashboard. A file opened over the chat or the feed
+// covers what the person was reading and goes the moment they look away; this pane keeps the file up
+// beside the chat and the feed, and when nothing is open it lists the files most recently open here as
+// re-open links, so a thread dropped yesterday costs one click.
+//
+// It hosts the same shared viewer (file-view.ts) every other document does, pane-resident by CSS alone
+// (files-pane.css, keyed on body.fileview-pane: no backdrop, no card inset). The pane is NOT a feed
+// consumer: the viewer is request/response (bytes over HTTP /file, host-routed for a remote session's
+// file), and its WS ops answer this socket, so no frame is parsed here; the shim opens app=files with the
+// stale opt-out (kernel.py _files_page), and federation.js (loaded by the page, never imported) routes a
+// host:sid op to the kernel that owns the session through the fake acquireVsCodeApi.
+//
+// Two things the pane supplies itself, because it has NO session list of its own:
+//   * the shell's relay ({romp:"viewFile", path, sid, identity}) carries the session's name and colour,
+//     resolved at the click site (render.ts openPath knows its tabs); the pane caches them per sid and
+//     registers that cache as the viewer's identity resolver, so the title bar's session chip renders
+//     here exactly as it does over the chat (the kernel's 8-character stub when the relay carried none);
+//   * the relay is taken WHOLE (initFileView's onRelay), so the identity is cached before the open and the
+//     open enters the Recent list; the pane owes the shell nothing back, since it stays up.
+// The viewer's directory link opens the shared file browser in this document, as it does over the chat
+// (initFileBrowse, the default contract); a file picked from its rows opens the viewer over the listing. That
+// browser still posts {romp:"browseClosed"} up on its close, as it does over the chat; the shell acts on it
+// only while a feed-routed browse has turned the feed on (window.__rompFeedWasOff), so from this pane it is
+// inert. A contract of the pane's own for the browser comes with the folder route into this pane.
+// Close returns to the empty state, never to a hidden pane: closeFileView and closeFileBrowse only remove
+// their element, and the placeholder repaints when neither is up (a body childList observer, the event
+// itself, no polling), which also covers the browser's back path and the conflict Reload's replace.
+import { initFileView, openFileView, setFileViewIdentity, hostStub, type FileViewIdentity } from "./file-view";
+import { initFileBrowse } from "./file-browse";
+import { delegate } from "./actions";
+import { applyTheme } from "./theme";
+import { loadSettings, installSettingsSync, onExternalSettingsChange } from "./settings";
+import { hostNameNodes } from "./host-prefix";
+import { asIdentity, parseRecent, rememberRecent, RECENT_KEY, type RecentFile } from "./files-recent";
+
+const vscodeApi =
+  typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
+
+// sid to the identity the relay (or a recent row) handed over; the viewer's session chip resolves through it
+const identities = new Map<string, FileViewIdentity>();
+let recent: RecentFile[] = parseRecent(readStore());
+
+function el(tag: string, cls?: string): HTMLElement { const e = document.createElement(tag); if (cls) e.className = cls; return e; }
+// The pane is SHOWING something while the viewer or the browser is up: both are body children by id (the
+// viewer's wrap, the browser's overlay), both come and go by element, so presence is the state.
+function surfaceUp(): boolean {
+  return !!(document.getElementById("romp-fileview") || document.getElementById("romp-filebrowse"));
+}
+function readStore(): string | null { try { return localStorage.getItem(RECENT_KEY); } catch { return null; } }
+function writeStore(): void { try { localStorage.setItem(RECENT_KEY, JSON.stringify(recent)); } catch { /* storage may be denied */ } }
+
+/** Open `path` here: cache the identity so the chip resolves, open the shared viewer, and record the file
+ *  as recent only when the open really happened (a dirty-edit veto keeps the previous viewer up). */
+function openHere(path: string, sid: string | null, identity: FileViewIdentity | null): void {
+  if (sid && identity) identities.set(sid, identity);
+  if (!openFileView(path, sid)) return;
+  const known = identity ?? (sid ? identities.get(sid) ?? null : null);
+  recent = rememberRecent(recent, { path, sid, identity: known, t: Date.now() });
+  writeStore();
+  paint();
+}
+
+// The empty state: the pane's purpose in one line, and the recent files as re-open rows. The rows wear
+// the viewer's own title-bar classes (path split dir/base, the session chip), so a path reads here
+// exactly as it does above an open file. Hidden, not removed, while a viewer or the browser is up.
+function paint(): void {
+  const empty = document.getElementById("files-empty");
+  if (!empty) return;
+  const open = surfaceUp();
+  empty.hidden = open;
+  if (open) return;
+  const title = el("div", "fs-title"); title.textContent = "No file open";
+  const hint = el("div", "fs-hint");
+  hint.textContent = "While this pane is open, a file clicked in the chat opens here. To open files here while it is closed, set File links open in to The Files pane in the gear.";
+  const out: HTMLElement[] = [title, hint];
+  if (recent.length) {
+    const list = el("div", "fs-recent");
+    const head = el("div", "fs-recent-head"); head.textContent = "Recent";
+    list.appendChild(head);
+    recent.forEach((r, i) => {
+      const row = el("div", "fs-row");
+      row.dataset.act = "open"; row.dataset.i = String(i); row.title = r.path;
+      const name = el("div", "fileview-name");
+      const cut = r.path.lastIndexOf("/");
+      const dir = el("span", "fileview-dir"); dir.textContent = cut >= 0 ? r.path.slice(0, cut + 1) : "";
+      const base = el("span", "fileview-base"); base.textContent = r.path.slice(cut + 1);
+      name.append(dir, base);
+      row.appendChild(name);
+      if (r.identity) {
+        const sess = el("span", "fileview-sess");
+        sess.replaceChildren(...hostNameNodes(r.identity.name, r.sid));
+        if (r.identity.color) { sess.style.background = r.identity.color.bg; sess.style.color = r.identity.color.fg; }
+        row.appendChild(sess);
+      }
+      list.appendChild(row);
+    });
+    out.push(list);
+  }
+  empty.replaceChildren(...out);
+}
+
+// boot
+applyTheme(document, loadSettings());
+installSettingsSync();
+onExternalSettingsChange((s) => applyTheme(document, s));
+
+// the chip's resolver: what the relay told us about the sid, else the kernel's 8-character stub
+setFileViewIdentity((id) => identities.get(id) ?? hostStub(id));
+// the shared viewer, with this pane's own relay contract (see the header); saves and the GitHub link ride
+// this socket's poster
+initFileView((m) => vscodeApi?.postMessage(m), (m) => {
+  openHere(m.path, typeof m.sid === "string" ? m.sid : null, asIdentity(m.identity));
+});
+// the viewer's directory link opens the file browser here, over this pane, as it does over the chat
+initFileBrowse((m) => vscodeApi?.postMessage(m));
+
+// re-open rows: delegated on the stable #files-empty (actions.ts), so a repaint mid-click still lands
+(() => {
+  const empty = document.getElementById("files-empty");
+  if (!empty) return;
+  delegate(empty, {
+    open: (x) => { const r = recent[Number(x.dataset.i)]; if (r) openHere(r.path, r.sid, r.identity); },
+  });
+})();
+// the viewer's or the browser's element coming and going IS the open/close event: one observer on the body
+// covers every path (the relay, a recent row, the browser's rows and its back button, the close button,
+// Escape, the Reload replace). The CLOSE edge, nothing left up, is also told to the shell
+// ({romp:"filesViewerClosed"}): on a phone the relay switched tabs to show this pane, and the shell puts the
+// person back on the tab the click came from (a no-op on desktop, where the column simply shows its recent
+// list again). Edge, not every mutation: the Reload replace and an open-over-open remove and re-add in the
+// same mutation delivery, so the viewer is still up when the observer runs; and a viewer closing back onto the listing
+// beneath it is no edge either, since the browser is still up.
+let viewerUp = surfaceUp();
+function onBodyChange(): void {
+  paint();
+  const up = surfaceUp();
+  if (viewerUp && !up && window.parent !== window) window.parent.postMessage({ romp: "filesViewerClosed" }, "*");
+  viewerUp = up;
+}
+new MutationObserver(onBodyChange).observe(document.body, { childList: true });
+
+paint();
+vscodeApi?.postMessage({ type: "ready" });   // the handshake every pane sends: this socket carries keepalives and op replies only
+
+export {};   // module scope

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -121,6 +121,14 @@ var GEAR_HTML =
   '</select>' +
   "<div id=rs-tabctx-pick style='position:relative;margin-top:5px'></div>" +
   '</span></div>' +
+  // where a file clicked in the chat opens (render.ts openPath through file-route.ts): the hidden select is
+  // the value holder, selectPick below dresses it as a house menu like the other selects
+  "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>File links open in</b>" +
+  '<span class=rs-sub>Where a file clicked in the chat opens. While the Files pane is open, the file opens there. When the pane is closed, this setting decides: over the pane you clicked, or in the Files pane, which then opens and stays open. Browser dashboard only: in VS Code file links open in the editor, and a chat tab opened on its own has no Files pane.</span>' +
+  "<select id=rs-filelink style='display:none'>" +
+  '<option value=chat>The pane you clicked</option><option value=pane>The Files pane</option>' +
+  '</select>' +
+  '</span></div>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>Text scheme</b>" +
   "<span class=rs-sub>Chat text colors only. Each option previews its own tiers — prose, the dimmer tool text, code. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
   "<div id=rs-chatscheme style='position:relative;margin-top:5px'></div>" +
@@ -236,7 +244,7 @@ function initGear(post) {
     cvm = document.getElementById('rs-conserve'),
     csg = document.getElementById('rs-suggestcompact'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
-    tc = document.getElementById('rs-tabctx'),
+    tc = document.getElementById('rs-tabctx'), fl = document.getElementById('rs-filelink'),
     sr = document.getElementById('rs-striprows'),
     dn = document.getElementById('rs-dense'),
     cs = document.getElementById('rs-chatscheme'),
@@ -254,7 +262,7 @@ function initGear(post) {
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', fileLinkPane: 'chat', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', fileLinkPane: 'chat', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -278,6 +286,7 @@ function initGear(post) {
   // compact tabs and agents (off by default): render.ts applies a body class on the save, and the strip and the panel repaint through the cascade
   if (dn) dn.addEventListener('change', function () { var s = load(); s.denseChrome = dn.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
+  if (fl) fl.addEventListener('change', function () { var s = load(); s.fileLinkPane = fl.value; save(s); });   // webview-local pref read at click time (render.ts openPath)
   // ── the settings' value-picker DROPDOWNS (T117, the user 2026-08-27, screenshot: the Chat
   // tabs and Text scheme pickers rendered every option always-expanded, and the description spans
   // ran off the card's right edge). Progressive disclosure: the CLOSED state is ONE row — the
@@ -454,6 +463,7 @@ function initGear(post) {
   }
   selectPick(upm, 'margin-top:5px');
   selectPick(bk, 'margin-top:5px');
+  selectPick(fl, 'margin-top:5px');
   selectPick(je, 'flex:0 0 auto;width:45%');
   selectPick(ie, 'flex:0 0 auto;width:45%');
   selectPick(jc, 'flex:0 0 auto;width:45%');   // T277: the concurrency select wears the same facade as the effort picks
@@ -1205,7 +1215,7 @@ function initGear(post) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/md-url-view.test.ts
+++ b/ui/webview/md-url-view.test.ts
@@ -409,7 +409,7 @@ test("rendered markdown never carries data-* attributes into the page, in the vi
 });
 
 test("local file mode: a sibling link's #fragment lands after the first RENDERED paint, once", () => {
-  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): void \{/);
+  assert.match(VIEW, /export function openFileView\(path: string, sid\?: string \| null, opts\?: \{ line\?: number \| null; frag\?: string \| null \}\): boolean \{/);
   assert.match(OPEN_FN, /let pendingFrag: string \| null = opts\?\.frag \|\| null;/);
   assert.match(OPEN_FN, /if \(rendered && pendingFrag\) \{\s*\n\s*const h = pendingFrag; pendingFrag = null;\s*\n\s*requestAnimationFrame\(\(\) => \{ if \(wrap\.isConnected\) scrollToFragment\(body, h\); \}\);/);
 });

--- a/ui/webview/open-path-exec.test.ts
+++ b/ui/webview/open-path-exec.test.ts
@@ -1,0 +1,185 @@
+// The chat end of "an open Files pane takes the click", EXECUTED: render.ts's shell-message arm for
+// {romp:"panes"} (the cache of which panes are on screen, panesOn) and openPath (the click's route through
+// fileLinkRoute and the gesture reader) are lifted from render.ts, with the viewer's real openFileClick lifted
+// from file-view.ts beneath them, and driven over stubs: a fake window.parent that records what is posted up,
+// a session list and tab set for the identity lookup, and hooks in place of the PDF tab opener and the
+// in-document viewer. chat-exact-tail-exec.test.ts's idiom (an anchored slice, esbuild at run time, new
+// Function). The ladder's own table runs in file-route.test.ts; this file drives the CALLER: the cache is
+// filled by the shell's message and replaced whole by the next one, a click while the pane is on screen posts
+// viewFile up with the session's looked-up identity, a click while it is off opens in place unless the
+// setting names the pane, a modified click on a PDF takes its own tab before any of that, and VS Code and
+// an unframed page never relay. Synthetic: the notes-api demo world, placeholder sids.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { fileLinkRoute } from "./file-route";
+
+const requireCjs = createRequire(__filename);
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
+const VIEW = fs.readFileSync(path.join(UI, "file-view.ts"), "utf8");
+
+function slice(src: string, startAnchor: string, endAnchor: string, name: string): string {
+  const a = src.indexOf(startAnchor), b = src.indexOf(endAnchor, a);
+  assert.ok(a > 0 && b > a, name + ": anchors not found (" + startAnchor.slice(0, 40) + " / " + endAnchor.slice(0, 40) + "); re-anchor");
+  return src.slice(a, b);
+}
+const ts = (code: string): string => requireCjs("esbuild").transformSync(code, { loader: "ts" }).code;
+
+const SID = "11111111-2222-3333-4444-555555555555";       // a session on the tab strip, named and coloured
+const SID_TAB = "11111111-2222-3333-4444-666666666666";   // a session the tab set names but the session list does not
+const SID_NONE = "11111111-2222-3333-4444-777777777777";  // a sid neither names
+const COLOR = { bg: "#123456", fg: "#ffffff" };
+
+type Hooks = {
+  vs: unknown[]; up: Array<[unknown, string]>; tabs: Array<[string, string | null]>; views: Array<[string, string | null | undefined]>;
+  tabOpens: boolean; settings: { fileLinkPane: unknown }; framed: boolean; protocol: string; vscodeApi: boolean;
+  activeId: string | null;
+};
+type Api = { openPath: (p: string, sid?: string | null, ev?: unknown) => void; onShellMessage: (m: unknown) => void; panesOn: () => Record<string, boolean> };
+
+function lift(): (h: Hooks, route: typeof fileLinkRoute) => Api {
+  // file-view.ts: the gesture reader as written (its own tests are pdf-new-tab.test.ts); the tab opener and
+  // the viewer are the hooks
+  const click = ts(slice(VIEW, "export function openFileClick(", "\n}\n", "openFileClick") + "\n}\n").replace(/^export /m, "");
+  // render.ts: the cache and openPath, then the shell-message arm that fills the cache, wrapped as a function of the message
+  const open = ts(slice(RENDER, "let panesOn: Record<string, boolean> = {};", "\n// A middle-click on a path pill is the same open", "openPath"));
+  const arm = ts(slice(RENDER, 'if (m.romp === "panes") {', "// the pipe's down edge", "the panes arm"));
+  const prelude = `
+    const H = HOOKS;
+    const vscodeApi = H.vscodeApi ? { postMessage: (m) => { H.vs.push(m); } } : undefined;
+    const location = { protocol: H.protocol };
+    const window = {};
+    window.parent = H.framed ? { postMessage: (m, origin) => { H.up.push([m, origin]); } } : window;
+    const settings = H.settings;
+    let activeId = H.activeId;
+    const sessions = new Map([[${JSON.stringify(SID)}, { id: ${JSON.stringify(SID)}, name: "web", color: ${JSON.stringify(COLOR)} }]]);
+    const tabMeta = new Map([[${JSON.stringify(SID_TAB)}, { name: "api", color: null }]]);
+    const wantsOwnTab = (ev) => !!(ev && ev.mod);
+    const openPdfTab = (p, sid) => { H.tabs.push([p, sid]); return H.tabOpens; };
+    const openFileView = (p, sid) => { H.views.push([p, sid]); return true; };
+  `;
+  const epilogue = `
+    function onShellMessage(m) { ${arm} }
+    return { openPath, onShellMessage, panesOn: () => panesOn };
+  `;
+  return new Function("HOOKS", "fileLinkRoute", prelude + click + open + epilogue) as (h: Hooks, route: typeof fileLinkRoute) => Api;
+}
+
+function world(over: Partial<Hooks> = {}) {
+  const H: Hooks = { vs: [], up: [], tabs: [], views: [], tabOpens: true, settings: { fileLinkPane: "chat" }, framed: true,
+    protocol: "http:", vscodeApi: true, activeId: SID, ...over };
+  return { H, api: lift()(H, fileLinkRoute) };   // the real ladder (file-route.ts) under the lifted caller
+}
+
+const PANES_ON = (on: Record<string, unknown>) => ({ romp: "panes", on });
+const relayed = (H: Hooks) => H.up.map(([m]) => m);
+
+test("the default world: no shell message yet and the setting at its default, so a click opens the viewer in place", () => {
+  const { H, api } = world();
+  assert.deepEqual(api.panesOn(), {}, "nothing heard from the shell reads as all-off");
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(H.views, [["/repo/notes-api/src/app.py", SID]], "the in-document viewer");
+  assert.deepEqual(H.up, [], "nothing posted to the shell");
+  assert.deepEqual(H.tabs, [], "a plain click asks for no tab");
+});
+
+test("the shell's panes message fills the cache, and a click while the Files pane is on screen is handed up with the session's identity", () => {
+  const { H, api } = world();
+  api.onShellMessage(PANES_ON({ chat: true, timeline: true, fleet: false, feed: true, files: true }));
+  assert.deepEqual(api.panesOn(), { chat: true, timeline: true, fleet: false, feed: true, files: true });
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(H.views, [], "the viewer here is not opened");
+  assert.deepEqual(H.up, [[{ romp: "viewFile", path: "/repo/notes-api/src/app.py", sid: SID, pane: "pane", identity: { name: "web", color: COLOR } }, "*"]],
+    "one message up, naming the target pane, with the name and colour the tab strip shows for the session");
+  // the identity is LOOKED UP, never invented: a session only the tab set names sends its name with no colour;
+  // a sid neither list names sends null, and the pane falls to the kernel's stub
+  api.openPath("/repo/notes-api/README.md", SID_TAB, { mod: false });
+  assert.deepEqual(relayed(H)[1], { romp: "viewFile", path: "/repo/notes-api/README.md", sid: SID_TAB, pane: "pane", identity: { name: "api", color: null } });
+  api.openPath("/repo/notes-api/README.md", SID_NONE, { mod: false });
+  assert.deepEqual(relayed(H)[2], { romp: "viewFile", path: "/repo/notes-api/README.md", sid: SID_NONE, pane: "pane", identity: null });
+  // no sid on the click: the active session's, as the in-place open resolves it
+  api.openPath("/repo/notes-api/notes.md", null, { mod: false });
+  assert.deepEqual(relayed(H)[3], { romp: "viewFile", path: "/repo/notes-api/notes.md", sid: SID, pane: "pane", identity: { name: "web", color: COLOR } });
+  assert.deepEqual(H.views, [], "none of them opened here");
+});
+
+test("the cache is replaced WHOLE by each message: a pane the shell stops naming reads as off, a foreign value as off, a message without a set changes nothing", () => {
+  const { H, api } = world();
+  api.onShellMessage(PANES_ON({ chat: true, feed: true, files: true }));
+  api.onShellMessage(PANES_ON({ chat: true, feed: true }));   // the Files pane toggled off: the next set has no files key
+  assert.deepEqual(api.panesOn(), { chat: true, feed: true });
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(H.views, [["/repo/notes-api/src/app.py", SID]], "off: in place again");
+  assert.deepEqual(H.up, []);
+  api.onShellMessage(PANES_ON({ chat: true, files: "yes" }));   // only the boolean true is on
+  assert.deepEqual(api.panesOn(), { chat: true, files: false });
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.equal(H.views.length, 2, "a non-boolean is not on");
+  api.onShellMessage(PANES_ON({ files: true }));
+  api.onShellMessage({ romp: "panes" });                   // no set: not a claim about the panes
+  assert.deepEqual(api.panesOn(), { files: true }, "the cache stands");
+  api.onShellMessage({ romp: "panes", on: "files" });      // a set that is not an object: the same
+  assert.deepEqual(api.panesOn(), { files: true });
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.equal(H.up.length, 1, "and routes by it");
+});
+
+test("the Files pane off: the setting decides; 'pane' hands the click up (the shell brings the pane forward), anything else opens in place", () => {
+  const { H, api } = world({ settings: { fileLinkPane: "pane" } });
+  api.onShellMessage(PANES_ON({ chat: true, feed: true, files: false }));
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(relayed(H), [{ romp: "viewFile", path: "/repo/notes-api/src/app.py", sid: SID, pane: "pane", identity: { name: "web", color: COLOR } }]);
+  assert.deepEqual(H.views, []);
+  // the setting is read at CLICK time: flipped back, the next click opens here
+  H.settings.fileLinkPane = "chat";
+  api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(H.views, [["/repo/notes-api/src/app.py", SID]]);
+  H.settings.fileLinkPane = "purple";                      // a foreign stored value is the default
+  api.openPath("/repo/notes-api/README.md", SID, { mod: false });
+  assert.equal(H.views.length, 2);
+  assert.equal(H.up.length, 1, "no further relay");
+  // and an open pane overrides the setting the other way
+  api.onShellMessage(PANES_ON({ chat: true, files: true }));
+  api.openPath("/repo/notes-api/README.md", SID, { mod: false });
+  assert.equal(H.up.length, 2, "on screen: the pane takes it whatever the setting says");
+});
+
+test("the gesture is read FIRST: a Cmd/Ctrl- or middle-clicked PDF takes its own tab whichever pane the plain click would have landed in; a blocked tab falls through to the route", () => {
+  const { H, api } = world();
+  api.onShellMessage(PANES_ON({ files: true }));
+  api.openPath("/repo/notes-api/docs/spec.pdf", SID, { mod: true });
+  assert.deepEqual(H.tabs, [["/repo/notes-api/docs/spec.pdf", SID]], "the browser's own tab");
+  assert.deepEqual(H.up, [], "the relay never fires for a modified click that took its tab");
+  assert.deepEqual(H.views, []);
+  // the popup blocked (openPdfTab false): the plain route, here the pane, so the file is never unreachable
+  H.tabOpens = false;
+  api.openPath("/repo/notes-api/docs/spec.pdf", SID, { mod: true });
+  assert.equal(H.tabs.length, 2);
+  assert.equal(H.up.length, 1, "falls through to the route");
+  // a plain click on a PDF with the pane off and the default setting: the viewer, no tab
+  api.onShellMessage(PANES_ON({ files: false }));
+  api.openPath("/repo/notes-api/docs/spec.pdf", SID, { mod: false });
+  assert.equal(H.tabs.length, 2, "no tab asked for");
+  assert.deepEqual(H.views, [["/repo/notes-api/docs/spec.pdf", SID]]);
+});
+
+test("no shell to relay to (standalone /chat) or no web host (VS Code): the cache and the setting never route a click away", () => {
+  const solo = world({ framed: false, settings: { fileLinkPane: "pane" } });
+  solo.api.onShellMessage(PANES_ON({ files: true }));
+  solo.api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(solo.H.views, [["/repo/notes-api/src/app.py", SID]], "unframed: in place, whatever the cache or setting says");
+  assert.deepEqual(solo.H.up, []);
+  const code = world({ protocol: "vscode-webview:", settings: { fileLinkPane: "pane" } });
+  code.api.onShellMessage(PANES_ON({ files: true }));
+  code.api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual(code.H.vs, [{ type: "openFile", path: "/repo/notes-api/src/app.py", id: SID }], "the host editor, by the extension's message");
+  code.api.openPath("/repo/notes-api/src/app.py", null, { mod: false });
+  assert.deepEqual(code.H.vs[1], { type: "openFile", path: "/repo/notes-api/src/app.py" }, "no sid: the extension picks");
+  assert.deepEqual(code.H.views, []); assert.deepEqual(code.H.up, []);
+  const none = world({ vscodeApi: false });
+  none.api.openPath("/repo/notes-api/src/app.py", SID, { mod: false });
+  assert.deepEqual([none.H.views, none.H.up, none.H.vs], [[], [], []], "no host at all: nothing");
+});

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -136,7 +136,7 @@ installMenuEcho();
   registerCommand({ id: "kernel.restart", title: "Restart the romp kernel", run: () => { if (w.__rompRestart) w.__rompRestart(); } });
   // Pane toggles. The Outline pane's INTERNAL key stays 'fleet' (the pane controller's API);
   // the command speaks the user-facing name.
-  const panes: Array<[string, string]> = [["chat", "chat"], ["timeline", "timeline"], ["fleet", "outline"], ["feed", "feed"]];
+  const panes: Array<[string, string]> = [["chat", "chat"], ["timeline", "timeline"], ["fleet", "outline"], ["feed", "feed"], ["files", "files"]];
   for (const [key, label] of panes) {
     registerCommand({
       id: "pane." + label, title: "Show or hide the " + label + " pane",
@@ -215,7 +215,7 @@ installMenuEcho();
   // render.ts's own window-capture Cmd+O handler stands down inside the shell (inRompShell),
   // so a keystroke in the chat document lands here exactly once.
   document.addEventListener("keydown", onKey, true);
-  ["f-chat", "f-fleet", "f-feed", "f-timeline"].forEach((id) => {
+  ["f-chat", "f-fleet", "f-feed", "f-files", "f-timeline"].forEach((id) => {
     const f = pane(id);
     if (!f) return;
     const wire = () => {

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -82,7 +82,7 @@ test("the defaults hold — Mod+O jump, Mod+Shift+O picker, Mod+P palette — th
 
 test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND every pane doc, re-wired on load", () => {
   assert.match(MAIN, /document\.addEventListener\("keydown", onKey, true\);/);
-  assert.match(MAIN, /\["f-chat", "f-fleet", "f-feed", "f-timeline"\]\.forEach/);
+  assert.match(MAIN, /\["f-chat", "f-fleet", "f-feed", "f-files", "f-timeline"\]\.forEach/);
   assert.match(MAIN, /f\.contentDocument\.addEventListener\("keydown", onKey, true\)/);
   assert.match(MAIN, /f\.addEventListener\("load", wire\);\s*\n\s*wire\(\);/);
 });

--- a/ui/webview/pane-shim-stale.test.ts
+++ b/ui/webview/pane-shim-stale.test.ts
@@ -24,15 +24,16 @@ import * as vm from "node:vm";
 
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
-function shimJs(app: string): string {
-  const def = KERNEL.indexOf("def _shim(app, v=0):");
+function shimJs(app: string, noStale = false): string {
+  const def = KERNEL.indexOf("def _shim(app, v=0, no_stale=False):");
   assert.ok(def > 0, "the shim renderer exists");
   const start = KERNEL.indexOf('return """', def) + 'return """'.length;
   // the tuple's first slot is the reload core (T265, its own executed test in tests/test_dashboard_auto_reload.py);
-  // an empty core here leaves window.__rompReload undefined, so the shim's raise takes its fallback path
-  const end = KERNEL.indexOf('""" % (_reload_core(v), app, int(v), app, app)', start);
+  // an empty core here leaves window.__rompReload undefined, so the shim's raise takes its fallback path. The
+  // fourth slot is the stale opt-out the Files page renders with (no_stale=True): a JS boolean literal.
+  const end = KERNEL.indexOf('""" % (_reload_core(v), app, int(v), "true" if no_stale else "false", app, app)', start);
   assert.ok(end > start, "the template's format tuple is the one the test substitutes");
-  const args = ["", app, "5", app, app];
+  const args = ["", app, "5", noStale ? "true" : "false", app, app];
   let i = 0;
   return KERNEL.slice(start, end).replace(/%[sd]/g, () => args[i++]).replace(/%%/g, "%");
 }
@@ -357,4 +358,34 @@ test("queued breadcrumbs are capped while the socket is down; other queued messa
   assert.deepEqual(diag.map((m) => m.data.i), [...Array(20).keys()], "the oldest are kept: the rows about the drop that started it");
   assert.equal(h.sent.filter((m) => m.type === "activeTab").length, 1, "a non-diagnostic message is never dropped");
   assert.equal(h.sent.length, 21);
+});
+
+// The Files pane's page (kernel.py _files_page) is served with the opt-out: nothing is pushed to app=files
+// (the viewer is request/response, so the kernel builds no frame for it), and without the opt-out the
+// reconnect arm would never be retired by a resync that never comes, so the second keepalive raised the
+// dashboard-wide "may be stale" prompt after every unannounced reconnect, for a file fetched over HTTP on
+// demand, which a dropped socket cannot make stale. With it, neither the arm nor the retire runs: the
+// page's own op replies (a GitHub-link answer) must not clear a prompt another pane raised either.
+test("a page served with the stale opt-out never arms the prompt after a reconnect, and never retires one", () => {
+  const h = new Harness(shimJs("files", true));
+  assert.match(h.ws.url, /^ws:\/\/TESTHOST:29855\/ws\?app=files&delta=1&iid=/, "the same dial as every pane");
+  h.ws.open(); h.bundleReady();
+  h.ws.close(); h.runTimers();
+  assert.equal(h.sockets.length, 2, "the close redialed");
+  h.ws.open();
+  h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 }); h.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(h.stale(), 0, "three keepalives with no resync: nothing is raised");
+  assert.equal(h.diags("stale-raise").length, 0, "and no raise breadcrumb");
+  h.ws.msg({ type: "fileGitLink", reqId: 1, url: "" });   // an op reply, the only non-keepalive frame this page sees
+  assert.equal(h.fresh(), 0, "an op reply retires nothing: wsFresh would clear a prompt another pane raised");
+  assert.equal(h.toBundle.filter((m) => m.type === "fileGitLink").length, 1, "the reply still reaches the bundle");
+  h.ws.close();
+  assert.equal(h.stale(), 0, "the reconnected socket closing raises nothing either");
+  h.runTimers(); h.ws.open();
+  h.settles(0);
+  // the control: the same script without the opt-out raises on the second keepalive (the rule the cases above run)
+  const g = new Harness(shimJs("files"));
+  g.reconnected();
+  g.ws.msg({ type: "ka", dv: 0 }); g.ws.msg({ type: "ka", dv: 0 });
+  assert.equal(g.stale(), 1, "the opt-out is the difference, not the app name");
 });

--- a/ui/webview/pdf-new-tab.test.ts
+++ b/ui/webview/pdf-new-tab.test.ts
@@ -103,8 +103,10 @@ test("wiring: every click on a PDF carries its gesture; modified → the tab, pl
   assert.match(opener, /if \(!w\) return false;[^\n]*\n\s+try \{ w\.opener = null; \}/, "…so the link is severed on the handle instead, before anything else");
   assert.doesNotMatch(opener, /await|\.then\(/, "the open happens inside the click gesture, never after a fetch");
   // the viewer: the ONE place a clicked file's gesture is read — openFileClick — and the plain open below it
-  // never opens a tab (a relayed viewFile, a Reload: no gesture, the viewer)
-  assert.match(VIEW, /export function openFileClick\(ev: MouseEvent \| KeyboardEvent \| null \| undefined, path: string, sid\?: string \| null\): void \{\n  if \(wantsOwnTab\(ev\) && openPdfTab\(path, sid \?\? null\)\) return;\n  openFileView\(path, sid\);\n\}/);
+  // never opens a tab (a relayed viewFile, a Reload: no gesture, the viewer). The gesture is read BEFORE the
+  // host's relay (render.ts hands a plain click to the shell for the Files pane): a modified click on a PDF
+  // takes its own tab whichever pane the plain click would have landed in.
+  assert.match(VIEW, /export function openFileClick\(ev: MouseEvent \| KeyboardEvent \| null \| undefined, path: string, sid\?: string \| null,\n\s*relay\?: \(path: string, sid: string \| null\) => void\): void \{\n  if \(wantsOwnTab\(ev\) && openPdfTab\(path, sid \?\? null\)\) return;\n  if \(relay\) \{ relay\(path, sid \?\? null\); return; \}\n  openFileView\(path, sid\);\n\}/);
   // no click site bypasses the gesture reader: the chat and the browser never call openFileView themselves
   assert.equal((RENDER.match(/openFileView\(/g) || []).length, 0, "render.ts opens files through openFileClick only");
   assert.equal((BROWSE.match(/openFileView\(/g) || []).length, 0, "file-browse.ts opens files through openFileClick only");
@@ -126,7 +128,7 @@ test("wiring: every click on a PDF carries its gesture; modified → the tab, pl
   assert.match(BROWSE, /list\.addEventListener\("auxclick", \(ev\) => \{[\s\S]*?if \(ev\.button !== 1\) return;[\s\S]*?const row = fileRowOf\(ev\);[\s\S]*?onAct\(row, ev\);/);
   assert.match(BROWSE, /if \(active\) \{ e\.preventDefault\(\); onAct\(active, e\); \}/, "Enter on a row carries its modifiers: Cmd/Ctrl+Enter on a PDF → its own tab");
   assert.match(BROWSE, /if \(row\.dataset\.act === "file"\) \{ openFileClick\(ev, p, curSid\); return; \}/);
-  assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void \{[\s\S]*?openFileClick\(ev, path, sid \|\| activeId \|\| null\);/);
+  assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void \{[\s\S]*?const to = sid \|\| activeId \|\| null;[\s\S]*?openFileClick\(ev, path, to, route === "pane" \? \(\) => \{/);   // the gesture first, whichever pane the plain click lands in (the Files pane's relay is the fourth argument)
   assert.match(RENDER, /function onMiddleClick\(a: HTMLElement, fn: \(e: MouseEvent\) => void\): void \{\n  a\.addEventListener\("mousedown", \(e\) => \{ if \(e\.button === 1\) e\.preventDefault\(\); \}\);\n  a\.addEventListener\("auxclick", \(e\) => \{ if \(e\.button !== 1\) return; e\.stopPropagation\(\); fn\(e\); \}\);/);
   assert.match(RENDER, /x\.addEventListener\("auxclick", \(e\) => e\.stopPropagation\(\)\);/, "a middle-click on the composer attachment's ✕ is inert, never the box's open");
   assert.equal((RENDER.match(/onMiddleClick\(/g) || []).length, 5, "the declaration and the four path pills: tool file, image path, path link, composer attachment");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -53,6 +53,7 @@ import { injectedHead, type InjectedSource } from "./injected-source";
 import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, subHeadParts, openIconSvg, pinIconSvg, type SubMeta, type AgentGist, type AgentGistRow, type GistLine } from "./subagent-view";
 import { previewKind, previewFull, canPreview, fileUrl, retryFailedPreviews, refreshSettledPreviews, installMdImgHeal, mdImgPostPass, setLightboxNav, type LightboxNavEntry } from "./preview";
 import { openFileClick } from "./file-view";                  // a clicked file WITH its gesture (pdf-new-tab.test.ts)
+import { fileLinkRoute } from "./file-route";                 // where the click opens: here, or the Files pane (file-route.test.ts)
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { openUrlView } from "./file-view";                 // the URL mode of the same viewer (md-url-view.test.ts)
@@ -1387,13 +1388,43 @@ document.addEventListener("click", (e) => {
 //     first cut filled the feed pane, and reading a file cost the cards). The bytes come to the
 //     browser over /file, which is the fix for the original break (the user 2026-08-08): the kernel
 //     used to run an opener on ITS machine, the wrong screen entirely from another device.
+//   • Web dashboard, the Files pane on screen, or the gear's "File links open in" naming it → the
+//     open is handed to the SHELL, which brings that pane forward and forwards the click into it
+//     (kernel.py's landing shell; ui/webview/files.ts): the viewer as a column of its own, which stays
+//     up beside the chat and the feed instead of covering either.
 //
-// Same document as the click, so there is no shell relay and no fallback ladder: standalone /chat
-// and the framed pane behave identically.
+// The route is fileLinkRoute (ui/webview/file-route.ts), pure so the table is testable: an OPEN Files
+// pane takes the click whatever the setting says (the pane being open is the intent); a closed one
+// only when the setting names it; a relay only when a shell exists to relay to (framed). Standalone
+// /chat has no shell and no other pane, so the setting quietly means "here", the in-document modal.
+// The gate lives at THIS end deliberately: the shell forwards whatever arrives, so a message never
+// sent is a click that opens in place, and no setting check shell-side can swallow a click.
+//
+// panesOn is the shell's pane set as the shell last told it: {romp:"panes", on:{chat,feed,files,...}},
+// posted on every pane toggle (its apply(), the exact event of the set changing), on this iframe's
+// load and on a phone's tab switch (kernel.py _LANDING_COLLAPSE_JS, _LANDING_MOBILE_JS), so a chat that
+// boots or reloads after the shell hears it too. A cache of the shell's state refreshed by the shell's
+// own event, never a per-click guess (no reading the parent's DOM, no polling). Standalone /chat never
+// hears one and reads as all-off, which the framed gate makes moot anyway.
+let panesOn: Record<string, boolean> = {};
 function openPath(path: string, sid?: string | null, ev?: MouseEvent | null): void {
   if (!vscodeApi) return;
   if (location.protocol === "http:" || location.protocol === "https:") {
-    openFileClick(ev, path, sid || activeId || null);   // with its gesture: a Cmd/Ctrl- or middle-click on a PDF → the browser's own tab
+    const to = sid || activeId || null;
+    const route = fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true);
+    // with its gesture, read first: a Cmd/Ctrl- or middle-click on a PDF takes the browser's own tab wherever
+    // the plain click would have landed; a plain click routed to the Files pane is handed to the shell
+    openFileClick(ev, path, to, route === "pane" ? () => {
+      // Fire-and-forget by nature: postMessage to a live parent never throws, so there is no catchable
+      // failure here and no honest in-document fallback exists. The message names its target pane and
+      // carries the session's IDENTITY (name and colour, the tab set's own, the way the viewer's resolver
+      // below names a session) for the Files pane, which has no session list to resolve a title-bar chip
+      // from. Looked up, never invented: a sid neither list names sends null, and the pane's resolver
+      // falls to the kernel's stub.
+      const s = to ? (sessions.get(to) ?? tabMeta.get(to)) : undefined;
+      window.parent.postMessage({ romp: "viewFile", path, sid: to, pane: "pane",
+        identity: s && s.name ? { name: s.name, color: s.color ?? null } : null }, "*");
+    } : undefined);
     return;
   }
   vscodeApi.postMessage(sid ? { type: "openFile", path, id: sid } : { type: "openFile", path });
@@ -15208,6 +15239,17 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
   }
   // the shell's palette / shell-focus chords: the chat owns the nav trail, the shell just asks
   if (m.romp === "chatNav") { navHist.go(m.dir === 1 ? 1 : -1); return; }
+  // the shell's pane set, which panes are on screen by key: the cache openPath routes file links by (panesOn
+  // above; the shell posts it on every toggle, on this iframe's load and on a phone's tab switch). Whole-set
+  // replace: a key the shell stopped naming must not linger as on.
+  if (m.romp === "panes") {
+    if (m.on && typeof m.on === "object") {
+      const on: Record<string, boolean> = {};
+      for (const k of Object.keys(m.on)) on[k] = m.on[k] === true;
+      panesOn = on;
+    }
+    return;
+  }
   // the pipe's down edge is the VS Code twin of the shim's romp:wsdown: unconfirmed sends say so (markPendingLost)
   if (m.type === "pipeState") { if (!m.up) markPendingLost("connection"); pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   // any kernel message proves the kernel is reachable again — heal previews whose fetch died in a

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -8,7 +8,7 @@ const store: Record<string, string> = {};
   setItem: (k: string, v: string) => { store[k] = v; },
   removeItem: (k: string) => { delete store[k]; },
 };
-import { loadSettings, saveSettings, DEFAULT_SETTINGS } from "./settings";
+import { loadSettings, saveSettings, DEFAULT_SETTINGS, fileLinkPane } from "./settings";
 
 test("loadSettings returns defaults when nothing is stored", () => {
   delete store["romp:settings"];
@@ -105,5 +105,26 @@ test("Compact tabs and agents defaults OFF (the user 2026-09-08); the opt-in rou
   assert.equal(loadSettings().denseChrome, true, "the opt-in survives a reload (localStorage)");
   store["romp:settings"] = JSON.stringify({ compact: true });
   assert.equal(loadSettings().denseChrome, false, "a store written before the key reads as off");
+  delete store["romp:settings"];
+});
+
+// Where a chat file-link click opens on the web (the Files pane, a column of its own, or the viewer over
+// the pane you clicked): OFF by default, so a dashboard that never turns it on changes nothing. Only the
+// literal "pane" opts in; anything else a store might hold reads as the default, so a corrupt entry may
+// cost the preference, never the click (tabCtxMode's normalization idiom). Read at click time
+// (render.ts openPath through file-route.ts fileLinkRoute).
+test("File links open in defaults to the pane you clicked; the Files pane opt-in round-trips, and a foreign value reads as the default", () => {
+  assert.equal(DEFAULT_SETTINGS.fileLinkPane, "chat");
+  delete store["romp:settings"];
+  assert.equal(loadSettings().fileLinkPane, "chat", "a fresh install opens in place");
+  saveSettings({ fileLinkPane: "pane" });
+  assert.equal(loadSettings().fileLinkPane, "pane", "the opt-in survives a reload (localStorage)");
+  store["romp:settings"] = JSON.stringify({ compact: true });
+  assert.equal(loadSettings().fileLinkPane, "chat", "a store written before the key reads as the default");
+  store["romp:settings"] = JSON.stringify({ fileLinkPane: "purple" });
+  assert.equal(loadSettings().fileLinkPane, "chat", "a foreign stored value normalizes to the default");
+  assert.equal(fileLinkPane("pane"), "pane");
+  assert.equal(fileLinkPane("feed"), "chat", "no other target exists here");
+  assert.equal(fileLinkPane(undefined), "chat");
   delete store["romp:settings"];
 });

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -17,6 +17,7 @@ export interface RompSettings {
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session starts there; the tab menu's "Move to folder…" can change it later. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
+  fileLinkPane: FileLinkPane;   // where a chat file-link click opens on the WEB while the Files pane is CLOSED: "chat" (the default: the viewer over the pane you clicked) or "pane" (the Files pane, a column of its own that comes forward and stays up). An OPEN Files pane takes the click whatever this says (file-route.ts). Read at click time (render.ts openPath); VS Code (the host editor) and standalone /chat (no shell to relay to) are unaffected.
   stripGroupRows: boolean;   // chat tabs, grouped by tag: start EVERY tag group on its own row (T264, the row breaks in render.ts). ON by default; off, the groups follow one another across the strip and wrap as they need, the untagged trail behind its divider. Per browser profile, like every setting here. Read by renderTabs and part of the strip's rebuild signature, so a gear flip repaints at once.
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
   chatTabTheme: ChatTabTheme;   // LEGACY, derived (2026-08-28): the chat TAB STRIP's appearance (T113). Now computed from `theme` on every load/save ("classic" -> classic strip, anything else -> the yatharth strip) so older panes/extension builds keep working; never set it directly.
@@ -38,6 +39,13 @@ export function theme(v: unknown): Theme {
 export function chatScheme(v: unknown): ChatScheme {
   return v === "high-contrast" || v === "solarized-dark" ? v : "default";
 }
+// Where a chat file-link click opens on the web while the Files pane is closed. tabCtxMode's normalization
+// idiom: only the literal "pane" is the opt-in; anything else a store might hold reads as the default, so
+// a corrupt entry may cost the preference, never the click.
+export type FileLinkPane = "chat" | "pane";
+export function fileLinkPane(v: unknown): FileLinkPane {
+  return v === "pane" ? "pane" : "chat";
+}
 // When the tab strip's context gauge shows. "over50" is the default (the user 2026-08-08): a gauge
 // on every tab is clutter while nothing is filling up — it should appear only when it has news.
 export type TabCtxMode = "always" | "over50" | "never";
@@ -52,7 +60,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", stripGroupRows: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", fileLinkPane: "chat", stripGroupRows: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {
@@ -62,6 +70,7 @@ export function loadSettings(): RompSettings {
       const parsed = JSON.parse(raw);
       const s = { ...DEFAULT_SETTINGS, ...parsed };
       s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
+      s.fileLinkPane = fileLinkPane(s.fileLinkPane);   // only "pane" opts in; anything else reads as the default
       s.chatScheme = chatScheme(s.chatScheme);   // unknown/legacy values normalize to "default"
       // theme migration (2026-08-28): a store from before `theme` existed seeds it from the old
       // tab-strip pick, so a yatharth strip stays a yatharth strip. chatTabTheme itself is DERIVED

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -41,6 +41,8 @@ const webview = {
     "../ui/webview/feed.css",
     "../ui/webview/fleet.ts",
     "../ui/webview/fleet-pane.css",      // fleet page layout — the kernel reads the same file live
+    "../ui/webview/files.ts",            // the Files pane: the file viewer as its own column (kernel /files)
+    "../ui/webview/files-pane.css",      // its page layout + the viewer's pane-resident variant; the kernel reads the same file live
     "../ui/webview/timeline-main.ts",    // VS Code timeline view: boot glue + ui/romp-timeline-view.js inlined
     "../ui/webview/timeline-pane.css",   // timeline wrapper styles — the kernel reads the same file live
     "../ui/webview/strip.css",           // the romp strip (VS Code-only bottom rail stand-in)


### PR DESCRIPTION
A Files pane: the file viewer as a dashboard column of its own, off by default, with a "File links open in" setting that routes a chat file click there.

## What this adds

A file opened from the chat is a modal over the transcript: it covers what you were reading and closes when you move on, and a file you had open yesterday has to be found again. The Files pane keeps a file open beside the chat and the feed, as a fifth column after Feed.

- **Off by default, opt-in.** A dashboard that never turns the pane on changes nothing: the rail gains a Files toggle, the palette a "Show or hide the files pane" command, and a phone a Files tab. The default route for a file click stays the viewer over the pane you clicked.
- **An open pane takes the click.** While the Files pane is on screen, a file link clicked in the chat opens there whatever the setting says: the pane being open is the intent. While it is closed, the gear's **File links open in** (Chat section) decides: "The pane you clicked" (the default) or "The Files pane", which then comes forward on that click and stays open; on a phone, closing the file takes you back to the tab you came from. On desktop nothing moves at close: the column shows its recent list again.
- **Recent files.** With nothing open the pane lists the files most recently open there (per browser, in localStorage: paths, session name and colour, no file content; eight rows), each a re-open row in the viewer's own title-bar dress.
- **Request/response, no feed frame.** The pane connects as app=files. It is outside the feed audience and nothing is built or pushed for it; the viewer fetches bytes over /file and its saveFile and fileGitLink ops answer the sending socket. It counts as a viewer for conserve-memory like the other panes.
- **A per-page stale opt-out in the shim.** `_shim(app, v, no_stale=True)` bakes `NOSTALE` into the template so `armStale` and `clearStale` return early. Without it a page that receives no pushed view raises the dashboard-wide "may be stale" prompt on the second keepalive after every unannounced reconnect (no resync ever retires its arm), and its own op replies would retire a prompt another pane raised. The build-drift reload is separate and stands. Only the Files page passes it.
- **The shell tells its panes what is on screen.** The pane controller posts `{romp:'panes', on:{key:bool}}` into every pane iframe on every `apply()` (a toggle is the event of the set changing), on each iframe's load, and on a mobile tab switch or layout flip. The keys come from `_PANE_ORDER`, so a future pane is broadcast without editing the block. On a phone "on" means the tab showing, not the stored flag, so a flag left true by a desktop session cannot steer a phone's file links into a tab nobody is looking at. A toggle that changes nothing sends nothing. The chat caches the set (`panesOn`, replaced whole by each message) and routes by it.
- **The routing is a pure ladder, decided at the click.** `fileLinkRoute(setting, framed, filesOpen)` in `ui/webview/file-route.ts`: no shell means in place; an open pane means the pane; otherwise the setting. The chat posts `{romp:"viewFile", pane:"pane", path, sid, identity}` to the shell with the session's name and colour looked up from its tabs (never invented; a sid neither list names sends null, and the pane falls to the kernel's stub). A Cmd/Ctrl- or middle-clicked PDF still takes its own tab first: `openFileClick` reads the gesture before the relay.
- **Every pane move keys on a gesture or the shell's own events.** The click brings the pane forward; the toggle, the iframe load and the tab switch re-tell the set; the viewer's close edge (a body childList observer in files.ts, nothing left up) posts `filesViewerClosed`, and on a phone the shell puts you back on the tab the click came from. A switch you make in between (a tab tap, a reveal aimed at you, the chat header's Outline pill) drops that memory, so a close much later never jumps you to a tab you left on your own. A click that arrives before the Files page has finished loading is held for the iframe's load event rather than posted into a document with no listener yet. No poll, no timer, no restore request: the pane stays up, so the shell has nothing to restore.
- **`__rompMobileTab` and `__rompMobileOn` are defined now.** The settings listener's browseFiles arm already called `window.__rompMobileTab('feed')` behind a guard, with no definition; the mobile script now exports it (and `__rompMobileOn`, which reads the one media query the CSS lays out by, `_MOBILE_MQ`). That arm's only remaining sender is a pane page served before the file browser moved into the clicking document (the viewer's directory link posts `browseFiles` to its own window today), so on a current build the definition changes nothing visible; on such a stale page a browse would switch a phone to the Feed tab, as the arm's comment says. That definition, and the pane controller no longer re-applying and re-saving on a toggle that changes nothing, are the only behaviour changes outside the new pane.
- **Browser shell only.** The VS Code webviews are untouched; a VS Code panel mirror of the pane is a separate change.

The viewer's directory link opens the shared file browser inside the pane (the default contract the chat uses), so no control in the pane is dead. That browser still posts `browseClosed` up on its close, as it does over the chat; the shell acts on it only while a feed-routed browse has turned the feed on, so from this pane it is inert, and a contract of the pane's own for the browser comes with the folder route below. Recent records a file opened through the relay or a Recent row; a file picked from that browser inside the pane, or opened from a link inside a viewed file, shows but is not recorded (the browser's host hook and the in-file links hook come with the follow-ups below). The chat's own file browser (a folder click) is unchanged: it opens over the chat and its rows open the viewer there. The /files iframe loads with the dashboard like the Outline's does while the pane is off (one more pane socket with keepalives; the Outline set the precedent). `files-pane.css` carries its own `@media print` block: the base print sheet (styles.css) keys on `body.fileview-open`, so it cannot undo this sheet's more specific `.fileview` size rule or html's `display:flex`, and with no file open it does not apply at all. What is deliberately left out of this PR: a folder click in the chat routed into the pane (the browser as a column, with its own host contract, and a pick entering Recent) follows as a stacked PR; the in-file links hook so a linked file enters Recent (a few lines once both are in); a feed-pane route for file links (the 2026-08-24 design opens files over the pane you clicked and this keeps that default).

Kernel surface: `_PANE_ORDER` gains `("files", "Files")` last; `/files` serves `_files_page()` (the chat's styles.css for the viewer's dress, files-pane.css read live, the pane-resident variant keyed on `body.fileview-pane`, no loader); every hand-written pane list in the landing JS is extended (PANES, grow, `key()`, the gv-c gutter whose left neighbour is the rightmost shown of feed, outline, chat; the focus map and COLS; the Escape and focusout wiring; the mobile tab map; both po literals; the CSS rules; the markup after `#feed-pane`). docs/guide.md gains a Files section, and docs/architecture.md and ui/README.md count five views. Collisions to expect: #1126 (chat split screen) rewrites the gutter registrations, COLS and palette-main's pane list this PR appends to; whichever lands second re-resolves those hunks.

## Tests

Each executing test fails on the tree before this change as noted.

- `tests/test_files_pane.py` (new): the served `/files` page and route (fails: `AttributeError: no _files_page`, HTTP 404), the stale opt-out on this page only (`TypeError: _shim() got an unexpected keyword argument 'no_stale'`), the conserve-memory viewer check executed against a stub backend (`0 != 4242`), `_PANE_ORDER[-1] == ("files", "Files")` and the rail and tab strings (`('feed', 'Feed') != ('files', 'Files')`), every pane list in the landing, the relay arm's shape and that it is the kernel's one viewFile arm, the gear and guide copy.
- `tests/test_pane_state_broadcast.py` (new): the pane controller, the mobile script and the settings listener run under node against a fake window and document. The boot broadcast to every pane, a toggle, a no-change toggle, an iframe load, the phone's tab rule, a layout flip, a tab tap, a reveal and the chat header's Outline pill each dropping the remembered tab, the relay on desktop and on a phone, a click that arrives before the Files page has loaded (held, delivered once on its load), the close's way back once, a stale memory dropped on desktop, a shell without the layout probe, a viewFile naming no pane, and the untouched browse and quote arms. Before the change: `TypeError: window.__rompPanesTell is not a function`, `TypeError: window.__rompMobileOn is not a function`, `[] != [['files', True]]`.
- `tests/test_pane_gutter_drag.py`: three grabs on the Files gutter in the executed drag harness, all four panes shown, then the feed hidden, then the Outline hidden too: the release writes feed | files, then Outline | files, then chat | files. Before: no `gv-c` gutter is registered, so the grab writes nothing.
- `ui/webview/open-path-exec.test.ts` (new): render.ts's `panes` arm and `openPath` lifted with the viewer's real `openFileClick` beneath them and run over a recording `window.parent`, a session list and tab set: the cache filled by the shell's message and replaced whole by the next (a key no longer named reads off, a non-boolean reads off, a message without a set changes nothing); a plain click while the pane is on screen posted up as `{romp:"viewFile", pane:"pane", path, sid, identity}` with the identity from the session list, from the tab set with no colour, or null; the setting deciding while the pane is off and read at click time; a Cmd/Ctrl-clicked PDF taking its own tab before any of that and a blocked tab falling through to the route; an unframed page and VS Code never relaying. Before: the test build refuses (`Could not resolve "./file-route"`); the lifted anchors are absent.
- `ui/webview/file-route.test.ts` (new): the ladder's table. Before: `Could not resolve "./file-route"`.
- `ui/webview/files.test.ts` (new): the recent list and identity validation executed; the viewer's relay guard lifted from file-view.ts and executed with and without a relay contract; `openHere` and `onBodyChange` lifted from files.ts and executed: the identity is cached before the viewer opens (the chip resolves on the first paint), a vetoed open records, persists and repaints nothing, a real one enters Recent with the relayed identity or the cached one, and the close edge posts `filesViewerClosed` once, never on an open-over-open or a viewer closing onto the listing beneath it, and never unframed; the boot wiring pinned. Before: `Could not resolve "./files-recent"`.
- `ui/webview/file-view.test.ts`: `openFileView`'s head lifted and executed: false when a viewer is up and the dirty-edit guard refuses, through (with the guard dropped) when it allows, when no viewer is up (the guard is not asked) or when there is no guard; the function ends by answering true. Before: the head has no `return false` (openFileView returned void). The kernel-side pins this file held for the relay arm moved to the Python lane; only the pre-existing check that nothing forwards viewFile into the feed remains.
- `ui/webview/pane-shim-stale.test.ts`: `shimJs()` re-anchored to the new signature and format tuple, plus the opt-out case: a reconnect followed by three keepalives and an op reply raises and retires nothing, and the same script without the opt-out raises. Against the unchanged shim the case fails at "three keepalives with no resync: nothing is raised" (expected 0, actual 1).
- `ui/webview/settings.test.ts`: `fileLinkPane` defaults to "chat", the opt-in round-trips, a foreign value reads as the default.
- Re-pinned to the fifth column and the new signatures: `tests/test_kernel_pane_rail.py`, `test_kernel_panenav.py`, `test_kernel_mobile.py`, `test_kernel_settings_sections.py`, `test_kernel_disconnect_banner.py`, `test_pane_order_parity.py`, `test_pane_hidden_word_browser.py`, `test_kernel.py` (the focus map, plus `test_files_page_served` beside the Outline's), `test_shell_reveal_unhide.py` (the reveal helper now routes through `userSwitch`); `ui/webview/esc-close.test.ts`, `palette.test.ts`, `pdf-new-tab.test.ts`, `editor-lazy.test.ts`, `file-view-links.test.ts`, `md-url-view.test.ts`.

Run on this head: `npm run typecheck` clean; the bundles this change touches pass when run one at a time (open-path-exec 6, files 12, file-route 4, pane-shim-stale 15, filebrowse 25, file-view 40, settings 13, esc-close 3, palette 19, pdf-new-tab 10, editor-lazy 9, file-view-links 25, md-url-view 29), and the full `npm test` below covers all 454 webview bundles and 63 others. No playwright leg is added by this PR (the browser legs belong to the folder-route follow-up). Full suites on this head: `pytest -n 6 tests/` 11267 passed, 41 skipped, 1726 subtests passed; `npm test` 4115 tests, 4115 pass, 0 fail (plus the tags-scale file run alone: 22 pass, 0 fail), both legs exit 0.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
