### PR TITLE
A stop of one kernel no longer consumes a parked quiet converge: the manager's stop note with trigger stop names the cut and the park stays on record

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1762,7 +1762,13 @@ converge until the window opens, and the note written at the window names its
 delivery the same way. A SIGTERM that reaches a kernel with a quiet-window
 request parked and no manager note for its pid (a note naming no pid counts as
 its own) is not that request's delivery: the kernel files a `signal` row and
-leaves the request on record for the kernel the window will restart.
+leaves the request on record for the kernel the window will restart. The
+manager's stop of one kernel (a `stop` note with trigger `stop`, which leaves
+the manager's parked request armed; a stop of every kernel writes the same
+note) is not the delivery either: that cut is named by the note,
+`manager-sigterm: stop`, and the request stays on record. A restart note, or
+the self-bounce's `refresh` note, is the delivery: the cut row names the
+request and consumes it.
 
 When no row qualifies, the kernel writes a row with action `signal`: the signal
 name, its pid and its parent's pid, the manager pid it was started with,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21657,9 +21657,10 @@ SIGNAL_MANAGER_NOTE_WAIT_S = 0.5   # how long an unexplained SIGTERM waits for t
 
 
 def _manager_sigterm_row_for_us(now=None, window=90, started=None, reasons=("stop",)):
-    """Whether the audit tail holds a `manager-sigterm` note aimed at THIS kernel (its `pid` is ours, or
+    """The newest `manager-sigterm` note in the audit tail aimed at THIS kernel (its `pid` is ours, or
     it names none) with a `reason` in `reasons`, within `window` seconds and not before this kernel's
-    start (`started`; the default is the process start, _STARTED, in whole seconds as the rows are).
+    start (`started`; the default is the process start, _STARTED, in whole seconds as the rows are), as
+    the row itself, or None when there is none; a caller reads the note's `trigger` off the row.
     With the default, only `reason: stop` counts: the manager's note that it is stopping us, which is
     what _unrequested_signal_reason takes as the manager going down alongside us. A `restart` note means
     the manager is alive and about to respawn the kernel, and one landing during the drain of an
@@ -21667,17 +21668,20 @@ def _manager_sigterm_row_for_us(now=None, window=90, started=None, reasons=("sto
     stop with `managerStopped: true` while the manager's own log shows a requested restart. With
     `reasons=("restart", "stop")` the question is whether the manager noted ANY kill of this kernel,
     which is how _graceful_term tells the delivery of a parked quiet request from a signal nobody sent
-    through the manager. The start bound is the one _recent_restart_audit
-    applies: the note this waits for lands AFTER our signal, so a stop note for our pid from before the
-    process existed is a predecessor's, left behind when a reboot reused the pid (the machine back inside
-    the window, the kernel up under the pid the previous one had, then a stray kill), and without the
-    bound it would read as the manager going down now. The tail is as deep as _recent_restart_audit's:
+    through the manager; the note's `trigger` then tells the stop of this kernel alone (`stop`, which
+    leaves the manager's park armed, so no delivery) from a restart or the self-bounce's `refresh` (the
+    delivery), which is why the row comes back and not a flag. The start bound is the one
+    _recent_restart_audit applies: the note this waits for lands AFTER our signal, so a stop note for our
+    pid from before the process existed is a predecessor's, left behind when a reboot reused the pid (the
+    machine back inside the window, the kernel up under the pid the previous one had, then a stray kill),
+    and without the bound it would read as the manager going down now. The tail is as deep as
+    _recent_restart_audit's:
     a service stop notes every kernel, and each session's own end-on-idle row lands in the same file,
     so a short tail would miss the note behind a dozen such rows and file the stop as a stray signal."""
     try:
         tail = (jd.STATE / "restart-audit.jsonl").read_text().strip().splitlines()
     except Exception:
-        return False
+        return None
     t0 = int(now if now is not None else time.time())
     born = int(_STARTED if started is None else started)
     for line in reversed(tail[-200:]):
@@ -21688,10 +21692,10 @@ def _manager_sigterm_row_for_us(now=None, window=90, started=None, reasons=("sto
         if not (isinstance(rec, dict) and rec.get("action") == "manager-sigterm" and isinstance(rec.get("t"), int)):
             continue
         if t0 - rec["t"] > window or rec["t"] < born:
-            return False
+            return None
         if rec.get("pid") in (None, os.getpid()) and rec.get("reason") in reasons:
-            return True
-    return False
+            return rec
+    return None
 
 
 def _unrequested_signal_reason(signum, be=None, wait=None, sleep=time.sleep, now=None, started=None):
@@ -21916,9 +21920,10 @@ def _recent_restart_audit(window=90, now=None, started=None):
         kernel that filed it. With the manager's note for us on record the note answers (below); with none
         the parked row itself is returned, unless a row above it shows it delivered or dropped. That
         no-note return serves the label and _parked_quiet_deploy, not consumption: _graceful_term
-        consumes a quiet row only when the manager noted a kill of this pid (its delivery), and files a
-        SIGTERM with a park on record and no such note as unrequested, the park untouched. Delivered or
-        dropped: a `manager-sigterm` note for a restart (every restart the manager
+        consumes a quiet row only when the manager noted a kill of this pid that delivers it (a restart, or
+        the self-bounce's `refresh`), files a SIGTERM with a park on record and no such note as unrequested,
+        the park untouched, and names a `stop` note with trigger `stop` as the cut instead (below). Delivered
+        or dropped: a `manager-sigterm` note for a restart (every restart the manager
         sends clears the park in passing) or for the stop of this kernel or of every kernel (the manager's
         own shutdown takes the park down with it), a verdict that the manager was gone (`parent-gone`, or
         `signal` with `managerStopped`), or a cut row that already joined it (`auditT`: the restart it asked
@@ -21931,8 +21936,10 @@ def _recent_restart_audit(window=90, now=None, started=None):
         passed over (or settles the park) and never ends the walk with the park unread. A park this kernel
         filed itself (its t at or after the start) is its own request whatever sits above it, inside the
         window and past it alike: a note for this pid above it is the delivery of that very park, or the
-        stop of this kernel, which the rule above already reads as taking the park down, and the settled
-        rule reads predecessors' parks only;
+        stop of this kernel alone, and the two are told apart at the cut, not here: _graceful_term takes a
+        `stop` note with trigger `stop` as the cut's request and leaves the park unconsumed (the manager
+        may still hold it), a restart or `refresh` note as the park's delivery. The settled rule reads
+        predecessors' parks only;
       - a row with an action is a request and wins, unless a cut row already consumed it: spent on the
         cut it asked for, this cut is anonymous;
       - a `when: quiet` request is pending until the restart it asked for lands, up to the far manager's
@@ -53608,8 +53615,12 @@ def _graceful_term(signum, frame):
     backend here: no SDK sessions were running if it doesn't exist. A second SIGTERM while the first
     is draining returns at once (_EXIT_ONCE): the first finishes and exits. A parked quiet request on
     record is consumed only when the manager noted a kill of this kernel (its `manager-sigterm` row for
-    this pid, or one naming none): the manager delivers the park, so a SIGTERM with no such note is not
-    its delivery, and the park stays on record for the kernel the quiet window will restart."""
+    this pid, or one naming none) that delivers it: a restart note, or the stale-manager self-bounce's
+    stop note with trigger `refresh`, since the manager clears its park before either. A SIGTERM with no
+    such note is not its delivery, and neither is a stop note with trigger `stop`: the stop of this
+    kernel alone leaves the manager's park armed, the stop of every kernel drops it, the note cannot tell
+    them apart, and that cut is named by the note. Either way the park stays on record for the kernel
+    the quiet window will restart."""
     if not _EXIT_ONCE.acquire(blocking=False):
         return
     _TERMINATING[0] = True                          # the parent-watch stands down (see _parent_watch)
@@ -53621,17 +53632,31 @@ def _graceful_term(signum, frame):
     # this). A row that lands during the drain below did not send this signal. The row itself rides
     # along so the cut row can join it and consume it (auditT; see _recent_restart_audit).
     rec = _recent_restart_audit()
-    if isinstance(rec, dict) and rec.get("when") == "quiet" \
-            and not _manager_sigterm_row_for_us(reasons=("restart", "stop")):
-        # A parked quiet request is delivered by the manager, and the manager notes every kill it sends
-        # before sending it. With no note for this pid inside the window and this kernel's lifetime, this
-        # SIGTERM is not that delivery: the manager still holds the park for whatever kernel runs at the
-        # quiet window (a dynamic kernel or a stateDir-less aux shares this root and this park). Consuming
-        # the park here stamped its t as auditT, which hid it from every reader under the root
-        # (_consumed_audit_t), labeled a signal nobody asked for as the deploy, filed no `signal` row,
-        # and counted a stray kill as a deploy landing (_last_deploy_restart_t). So the pick is dropped
-        # and the exit takes the unrequested path below: a `signal` row, the unrequested reason, no auditT.
-        rec = None
+    if isinstance(rec, dict) and rec.get("when") == "quiet":
+        note = _manager_sigterm_row_for_us(reasons=("restart", "stop"))
+        if not note:
+            # A parked quiet request is delivered by the manager, and the manager notes every kill it sends
+            # before sending it. With no note for this pid inside the window and this kernel's lifetime, this
+            # SIGTERM is not that delivery: the manager still holds the park for whatever kernel runs at the
+            # quiet window (a dynamic kernel or a stateDir-less aux shares this root and this park). Consuming
+            # the park here stamped its t as auditT, which hid it from every reader under the root
+            # (_consumed_audit_t), labeled a signal nobody asked for as the deploy, filed no `signal` row,
+            # and counted a stray kill as a deploy landing (_last_deploy_restart_t). So the pick is dropped
+            # and the exit takes the unrequested path below: a `signal` row, the unrequested reason, no auditT.
+            rec = None
+        elif note.get("reason") == "stop" and (note.get("trigger") or note.get("reason")) == "stop":
+            # The manager's stop note with trigger `stop` (the default mirrors its writer: trigger, else
+            # reason) is the stop of this kernel alone (POST /stop naming one kernel: the manager keeps its
+            # park armed for whatever kernel runs at the quiet window) or of every kernel (its shutdown drops
+            # the park), and the note cannot tell them apart; neither delivers the park. Taking the park as
+            # this cut's request consumed it just the same (auditT = the park's t, hidden from every reader
+            # under the root), and only for the kernel that filed the park: the reader's walk already named
+            # the note for a sibling born after the park, so the row differed by birth order. The note is
+            # the cut's request instead ("manager-sigterm: stop", auditT = the note's t, no `signal` row, as
+            # for a single stop with nothing parked), and the park stays on record. A restart note (every
+            # restart the manager sends clears its park first) and the self-bounce's stop note with trigger
+            # `refresh` (shutdownAll clears the park before it notes) deliver the park and consume it.
+            rec = note
     _drain_and_exit(_audit_reason_text(rec), signum=signum, what="SIGTERM", audit=rec)
 
 

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -573,6 +573,157 @@ class UnrequestedSignal(unittest.TestCase):
         self.assertEqual(cuts[0]["auditT"], t, "the park is consumed by the kernel the manager noted before killing it")
         self.assertEqual(km._parked_quiet_deploy("1111111", now=t), 0, "and nothing is parked any more")
 
+    def test_the_managers_restart_of_this_kernel_alone_delivers_a_quiet_park_too(self):
+        # the park filed by this kernel, then the manager's `restart` note for this pid with trigger `restart`
+        # (POST /restart naming one kernel, bin/romp-manager restartKernel). Every restart the manager sends
+        # clears its park before it notes and kills, so this note is the delivery like the restart-all note
+        # is, and the cut row names the park and consumes it. Distinct seconds, so the auditT stamp says which
+        # row was consumed; the process start is pinned so the park sits inside this kernel's lifetime
+        t = int(time.time())
+        park = {"t": t - 5, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": t, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(),
+                "reason": "restart", "trigger": "restart"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(note) + "\n")
+        with mock.patch.object(km, "_STARTED", t - 10), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self._fire()
+            self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["main-converge", "manager-sigterm"],
+                             "delivered: no signal row")
+            cuts = self._rows(km.RESTART_CUTS_FILE)
+            self.assertEqual(len(cuts), 1)
+            self.assertEqual(cuts[0]["reason"], "main-converge")
+            self.assertEqual(cuts[0]["auditT"], t - 5, "the park is consumed, not the note")
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), 0, "and nothing is parked any more")
+
+    def test_a_stop_of_this_kernel_alone_does_not_spend_a_quiet_park_on_record(self):
+        # the same park, then the manager's `stop` note for this pid with trigger `stop`. That note is POST
+        # /stop naming one kernel (bin/romp-manager stopKernel), which leaves the manager's park armed for
+        # whatever kernel runs at the quiet window, or a service stop, which writes the same note for every
+        # kernel and drops the park with the manager; the note cannot tell them apart, and neither is the
+        # park's delivery. Reading it as one stamped the park's t as auditT, which hid the park from every
+        # reader under this root (_consumed_audit_t): the drift stand-down for the kernel the window will
+        # restart read nothing parked, and _last_deploy_restart_t counted the stop as a deploy landing. The
+        # cut row names the note instead, as the reader's walk already did for a sibling kernel born after
+        # the park, and the park stays on record
+        t = int(time.time())
+        park = {"t": t - 5, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": t, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(),
+                "reason": "stop", "trigger": "stop"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(note) + "\n")
+        with mock.patch.object(km, "_STARTED", t - 10), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):   # alive: one kernel's stop
+            self._fire()
+            self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["main-converge", "manager-sigterm"],
+                             "the note names the cut: no signal row")
+            cuts = self._rows(km.RESTART_CUTS_FILE)
+            self.assertEqual(len(cuts), 1)
+            self.assertEqual(cuts[0]["reason"], "manager-sigterm: stop", "the note, not the park")
+            self.assertEqual(cuts[0]["auditT"], t, "the note is consumed; the park is not")
+            self.assertNotEqual(km._consumed_audit_t(), t - 5, "every reader under this root still sees the park")
+            self.assertEqual(km._recent_restart_audit(window=90, now=t, started=t - 10)["t"], t - 5,
+                             "still the request on record for the kernel the window will restart")
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), t - 5, "the drift stand-down still holds")
+
+    def test_a_stop_note_without_a_trigger_reads_as_the_stop_of_this_kernel_alone(self):
+        # the same rows with no `trigger` key on the note. The reader takes such a note by its reason
+        # (test_a_note_without_a_trigger_falls_back_to_its_reason), and the handler's default mirrors that
+        # and the manager's own writer (trigger, else reason): a trigger-less `stop` note is the stop of this
+        # kernel alone, so it names the cut and the park stays on record. Without the default the note would
+        # pass for a delivery and consume the park
+        t = int(time.time())
+        park = {"t": t - 5, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": t, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(), "reason": "stop"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(note) + "\n")
+        with mock.patch.object(km, "_STARTED", t - 10), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self._fire()
+            self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["main-converge", "manager-sigterm"],
+                             "the note names the cut: no signal row")
+            cuts = self._rows(km.RESTART_CUTS_FILE)
+            self.assertEqual(len(cuts), 1)
+            self.assertEqual(cuts[0]["reason"], "manager-sigterm: stop", "the note, read by its reason")
+            self.assertEqual(cuts[0]["auditT"], t, "the note is consumed; the park is not")
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), t - 5, "the drift stand-down still holds")
+
+    def test_a_sibling_born_after_the_park_files_the_same_row_for_the_stop_of_itself(self):
+        # the same park and stop/stop note read by a kernel started AFTER the park (a dynamic kernel or a
+        # stateDir-less aux under this root; its start sits between the two rows). To this kernel's walk the
+        # park is a predecessor's and the note answers, so the cut row names the note, as it did before the
+        # change; the kernel that filed the park files the same row now (the case above), so which kernel
+        # the manager stopped no longer decides the record, and the park stays visible to the one that filed it
+        t = int(time.time())
+        park = {"t": t - 5, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": t, "action": "manager-sigterm", "kernel": "k29900", "pid": os.getpid(),
+                "reason": "stop", "trigger": "stop"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(note) + "\n")
+        with mock.patch.object(km, "_STARTED", t - 3), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self._fire()
+        self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["main-converge", "manager-sigterm"],
+                         "the note names the cut: no signal row")
+        cuts = self._rows(km.RESTART_CUTS_FILE)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0]["reason"], "manager-sigterm: stop", "the same row the kernel that filed the park files")
+        self.assertEqual(cuts[0]["auditT"], t)
+        with mock.patch.object(km, "_STARTED", t - 10):      # the kernel that filed the park
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), t - 5, "still parked for the kernel that filed it")
+
+    def _service_stop_left_on_record(self, t):
+        """What a service stop during a parked quiet converge now leaves under the root: the park, the
+        stop/stop note for the kernel it stopped (a pid nothing owns any more), and that kernel's cut row
+        naming the note (auditT = the note's t; the park unconsumed). The successor starts after all three."""
+        gone = self._dead_pid()
+        park = {"t": t - 20, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        stopped = {"t": t - 15, "action": "manager-sigterm", "kernel": "main", "pid": gone,
+                   "reason": "stop", "trigger": "stop"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(stopped) + "\n")
+        cut = {"t": t - 15, "pid": gone, "cutTurns": [], "stopped": 0, "unjoined": 0, "reaped": 0,
+               "watchesArmed": 0, "reason": "manager-sigterm: stop", "auditT": t - 15}
+        km.RESTART_CUTS_FILE.write_text(json.dumps(cut) + "\n")
+
+    def test_a_restart_of_the_successor_settles_the_park_a_service_stop_left_on_record(self):
+        # the successor reads the park a service stop left as a live predecessor's: the note names another
+        # pid, and a stop/stop note settles nothing in the walk (the manager may hold the park). That is inert
+        # while the successor runs the checkout (_main_drift_check consults the park only when it does not)
+        # and expires at RESTART_EXPECT_MAX_S; the manager's next restart note for the successor settles it
+        # before then. The note names the successor's cut, and nothing reads as parked afterwards
+        t = int(time.time())
+        self._service_stop_left_on_record(t)
+        with mock.patch.object(km, "_STARTED", t - 10), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), t - 20,
+                             "the park a service stop left reads as a live predecessor's")
+            restart = {"t": t, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(),
+                       "reason": "restart", "trigger": "restart"}
+            with self.AUDIT.open("a") as f:
+                f.write(json.dumps(restart) + "\n")
+            self._fire()
+            self.assertEqual([r["action"] for r in self._rows(self.AUDIT)],
+                             ["main-converge", "manager-sigterm", "manager-sigterm"], "no signal row")
+            cuts = self._rows(km.RESTART_CUTS_FILE)
+            self.assertEqual(len(cuts), 2)
+            self.assertEqual(cuts[1]["reason"], "manager-sigterm: restart")
+            self.assertEqual(cuts[1]["auditT"], t, "the note names this cut; the stale park is settled, not consumed")
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), 0, "and nothing reads as parked any more")
+
+    def test_a_stray_kill_of_the_successor_leaves_the_park_a_service_stop_left_on_record(self):
+        # the same record and a SIGTERM the manager did not send to the successor: no note for its pid, so
+        # the park is not this signal's request. The exit is filed as unrequested with the manager alive, the
+        # cut row consumes nothing, and the park stays where the service stop left it
+        t = int(time.time())
+        self._service_stop_left_on_record(t)
+        with mock.patch.object(km, "_STARTED", t - 10), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self._fire()
+            rows = self._rows(self.AUDIT)
+            self.assertEqual([r["action"] for r in rows], ["main-converge", "manager-sigterm", "signal"])
+            self.assertIs(rows[2]["managerStopped"], False)
+            cuts = self._rows(km.RESTART_CUTS_FILE)
+            self.assertEqual(len(cuts), 2)
+            self.assertEqual(cuts[1]["reason"], km.SIGNAL_REASON_UNREQUESTED)
+            self.assertNotIn("auditT", cuts[1], "a signal that delivered nothing consumes nothing")
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), t - 20, "still parked, as the service stop left it")
+
     def test_a_second_sigterm_mid_drain_does_not_write_a_second_row(self):
         # a service stop signals the kernel, then the manager's shutdownAll signals it again while the
         # first handler drains; the second invocation returns and the first finishes: ONE cut row

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -573,6 +573,34 @@ class UnrequestedSignal(unittest.TestCase):
         self.assertEqual(cuts[0]["auditT"], t, "the park is consumed by the kernel the manager noted before killing it")
         self.assertEqual(km._parked_quiet_deploy("1111111", now=t), 0, "and nothing is parked any more")
 
+    def test_the_stale_manager_self_bounce_delivers_a_quiet_park_too(self):
+        # a variant of the delivery test: the note is the stale-manager self-bounce's, reason `stop`
+        # with trigger `refresh` (bin/romp-manager restartAllOrSelf: a supervised manager whose binary changed
+        # since it started stops every kernel so the supervisor respawns it on the new code, and the quiet
+        # apply goes through the same path). shutdownAll clears the manager's park before it notes and kills,
+        # so this stop note is the park's delivery like a restart note is, and the cut row consumes the park.
+        # Pinned at the handler because the `stop` member of the predicate's reasons had no case of its own:
+        # dropping it turned nothing red, and the exit then took the unrequested path (a `signal` row with
+        # managerStopped, the park left on record for a manager that no longer holds it). The trigger is what
+        # keeps this note a delivery: a stop note with trigger `stop` is the one _graceful_term reads as none.
+        # Distinct seconds, so the auditT stamp says which row was consumed (_consumed_audit_t keys on t
+        # alone); the process start is pinned so the park sits inside this kernel's lifetime
+        t = int(time.time())
+        park = {"t": t - 5, "action": "main-converge", "tag": "restart", "when": "quiet", "sha": "1111111"}
+        note = {"t": t, "action": "manager-sigterm", "kernel": "main", "pid": os.getpid(),
+                "reason": "stop", "trigger": "refresh"}
+        self.AUDIT.write_text(json.dumps(park) + "\n" + json.dumps(note) + "\n")
+        with mock.patch.object(km, "_STARTED", t - 10), \
+             mock.patch.dict(os.environ, {"ROMP_MANAGER_PID": str(os.getpid())}):
+            self._fire()
+            self.assertEqual([r["action"] for r in self._rows(self.AUDIT)], ["main-converge", "manager-sigterm"],
+                             "delivered: no signal row")
+            cuts = self._rows(km.RESTART_CUTS_FILE)
+            self.assertEqual(len(cuts), 1)
+            self.assertEqual(cuts[0]["reason"], "main-converge")
+            self.assertEqual(cuts[0]["auditT"], t - 5, "the park is consumed, not the note")
+            self.assertEqual(km._parked_quiet_deploy("1111111", now=t), 0, "and nothing is parked any more")
+
     def test_the_managers_restart_of_this_kernel_alone_delivers_a_quiet_park_too(self):
         # the park filed by this kernel, then the manager's `restart` note for this pid with trigger `restart`
         # (POST /restart naming one kernel, bin/romp-manager restartKernel). Every restart the manager sends


### PR DESCRIPTION
## Symptom

The manager's stop of one kernel consumed a parked quiet converge it does not deliver. The park is the `when: quiet` row `_run_main_update` writes; the manager holds it and restarts whatever kernel runs at the quiet window. When the manager stopped one kernel (`POST /stop` naming it, `stopKernel` in bin/romp-manager), that kernel's `_graceful_term` took the park as the request behind its SIGTERM: the cut row read `main-converge` with `auditT` = the park's t. `_consumed_audit_t` then answered the park's t for every reader under the root, so the park read as spent while the manager still held it: `_parked_quiet_deploy` returned 0, `_main_drift_check` dropped its stand-down and logged the parked deploy as no longer pending, and `_last_deploy_restart_t` counted the stop as a deploy landing. Which row was filed depended on birth order: a sibling kernel born after the park (a dynamic kernel or a stateDir-less aux shares the main root) got `manager-sigterm: stop` from the reader's walk, with the park untouched. A stop of every kernel (`shutdownAll`) writes the same note and consumed the park the same way.

## Cause

`_graceful_term` kept a `when: quiet` pick whenever `_manager_sigterm_row_for_us(reasons=("restart", "stop"))` was truthy, and that helper matched a note on pid and reason alone; the note's `trigger` never entered it. `stopKernel` writes reason `stop` with trigger `stop` and does not clear the manager's park (`clearPendingQuiet` is called by the quiet apply, `shutdownAll`, `/restart-all` and `/restart`). The notes that follow a clear are the restart notes (trigger `restart` or `restart-all`) and the stale-manager self-bounce's stop note with trigger `refresh`. A stop note with trigger `stop` follows no clear, and it cannot say whether one kernel or every kernel is stopping.

## Fix

Two commits.

Commit 1 (kernel/kernel.py, docs/reference.md, tests). `_manager_sigterm_row_for_us` returns the matching row or None instead of True or False; its two callers and the six tests that call it check truthiness only. In `_graceful_term`'s quiet pick, a note whose reason is `stop` and whose trigger is `stop` (the trigger defaults to the reason, as the manager's writer does with `trigger || reason`) becomes the cut's request: the row reads `manager-sigterm: stop` with `auditT` = the note's t, no `signal` row is filed, and the park stays on record. That is the row a sibling born after the park already got, so both birth orders now file the same one. A restart note and the stop/refresh note deliver and consume the park as before, and a quiet pick with no note takes the unrequested path as before. The walk in `_recent_restart_audit` is unchanged. The docstrings of `_graceful_term`, `_manager_sigterm_row_for_us` and `_recent_restart_audit` say so; the restart-audit paragraph in docs/reference.md gains the sentence.

Commit 2 (tests only). The self-bounce's stop/refresh note is pinned as a delivery at the handler; see Tests.

Design points:

- A service stop during a parked quiet converge now files `manager-sigterm: stop` instead of the park's text and leaves the park on disk. The successor reads it as a live predecessor's park (the stop note names the predecessor's pid, and a stop/stop note for another pid settles nothing in the walk). That is inert: `_main_drift_check` consults `_parked_quiet_deploy` only while the kernel does not run the checkout, and the successor does; the park expires at `RESTART_EXPECT_MAX_S`. A restart note for the successor inside that window settles the park in the walk, so the successor's cut row reads `manager-sigterm: restart` and `_parked_quiet_deploy` answers 0 afterwards; a stray kill of the successor files an unrequested `signal` row with no `auditT`, as before, and the park stays visible to `_parked_quiet_deploy`. Both are tested (the two successor cases under Tests).
- The one cost: `_last_deploy_restart_t` no longer anchors the converge cool-down to a service restart that landed a parked quiet converge. The cut row's text was its only source for a quiet main-converge; its audit-row source counts `when: now` only.
- Rejected, `rec = None` for the stop/stop note: the unrequested path's default look (`reasons=("stop",)`) finds the same note and files `managerStopped: true`, a false verdict on a single-kernel stop with the manager alive. And a main kernel respawned after a crash, whose park is a predecessor's that the manager still holds (`spawnKernel`'s exit handler clears nothing), would read its park as settled by that verdict, so the park is lost in that sub-case.
- Rejected, a manager-side trigger split so that `shutdownAll` writes a trigger of its own: the principled disambiguation, but a bin/romp-manager change with a mixed-version window, and the kernel must still read `stop` ambiguously from an older manager. A candidate follow-up.
- Rejected, a post-drain re-check of the manager pid: timing inference over the manager's 800 ms exit.
- Same-second t: `_consumed_audit_t` keys on t alone, so a stop note landing in the same second as the park marks the park spent too. Pre-existing on the sibling's path; every test here puts the park and the note in distinct seconds so the `auditT` stamp says which row was consumed.

## Tests

All in `tests/test_restart_cuts.py`, class `UnrequestedSignal`, through `_graceful_term` with `os._exit` patched to raise, against a rebound state root with the test process as the manager pid; a test whose park predates its note pins the process start (`_STARTED`) before the park so the park sits inside the kernel's lifetime.

Commit 1:

- `test_a_stop_of_this_kernel_alone_does_not_spend_a_quiet_park_on_record` (the fix's test): a park at t-5, a stop/stop note for this pid at t, the manager alive. Asserts no `signal` row; one cut row reading `manager-sigterm: stop` with `auditT` = t; `_consumed_audit_t` not the park's t; `_recent_restart_audit` still returning the park; `_parked_quiet_deploy` still t-5. Before the change: `'main-converge' != 'manager-sigterm: stop'`; the cut row carried `auditT` = t-5, `_consumed_audit_t` answered t-5, `_parked_quiet_deploy` returned 0 and the reader's walk returned the note.
- `test_a_stop_note_without_a_trigger_reads_as_the_stop_of_this_kernel_alone`: the same rows with no `trigger` key on the note (the shape the reader already reads by its reason); the same assertions. Before the change: the same mismatch. With the handler's default to reason dropped (`note.get("trigger") == "stop"` alone), this is the one test in the module that turns red (1 failed, 72 passed).
- `test_a_sibling_born_after_the_park_files_the_same_row_for_the_stop_of_itself`: the same rows read by a kernel whose start sits between them. Asserts the cut reads `manager-sigterm: stop` with `auditT` = t, and `_parked_quiet_deploy` still t-5 for the kernel that filed the park. Green before and after: the row the change makes both birth orders file.
- `test_the_managers_restart_of_this_kernel_alone_delivers_a_quiet_park_too`: the same park under a restart/restart note (`POST /restart` naming one kernel). Asserts the cut reads `main-converge` with `auditT` = the park's t and `_parked_quiet_deploy` 0. Green before and after: the member the change keeps.
- `test_a_restart_of_the_successor_settles_the_park_a_service_stop_left_on_record` and `test_a_stray_kill_of_the_successor_leaves_the_park_a_service_stop_left_on_record`: the record a service stop now leaves (the park at t-20, the stop/stop note at t-15 for a pid nothing owns, that kernel's cut row naming the note with `auditT` = t-15), read by a successor started at t-10 under a live manager. The first asserts `_parked_quiet_deploy` answers t-20, then, under a restart/restart note for the successor's pid at t: no `signal` row, a second cut row reading `manager-sigterm: restart` with `auditT` = t, and `_parked_quiet_deploy` 0. The second, with no note for the successor: a `signal` row with `managerStopped` false, a second cut row with the unrequested reason and no `auditT`, and `_parked_quiet_deploy` still t-20. Both green before and after: the first design point's two claims.

Commit 2:

- `test_the_stale_manager_self_bounce_delivers_a_quiet_park_too`: a variant of the existing delivery test with the self-bounce's stop/refresh note, the park at t-5 and the note at t. Asserts no `signal` row, the cut reading `main-converge` with `auditT` = t-5, `_parked_quiet_deploy` 0. Green as it stands. Red by mutation with the predicate narrowed to `reasons=("restart",)`: `['main-converge', 'manager-sigterm', 'signal'] != ['main-converge', 'manager-sigterm']`. On the code before commit 1 under that mutation, with commit 1's two stop/stop tests deselected (they fail there on the defect itself), this pin is the only test in the module that turns red (1 failed, 71 passed); on this tree the two stop/stop tests turn red with it (3 failed, 71 passed). With the handler's trigger check reduced to the reason alone (every stop note taken as the cut), the pin fails at the cut-row reason: `'manager-sigterm: refresh' != 'main-converge'`.

The existing `test_a_stray_sigterm_with_a_quiet_park_on_record_does_not_spend_the_park` (no note) and `test_the_managers_delivery_of_a_quiet_park_consumes_it` (a restart-all note) stay green, so each of the four note shapes the manager writes has a handler-level case.

Targeted run at the final tree (`tests/test_restart_cuts.py`, `test_main_drift_notice.py`, `test_restart_seam.py`, `test_restart_audit.py`, `test_kernel_headless_ops.py`): 156 passed, 26 subtests passed. Full suite at the final tree (`pytest -q -n 6 tests/`, with the extension's node_modules installed): 11253 passed, 41 skipped, 1744 subtests passed in 171.96s, no failures.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)