### PR TITLE
Model catalog: a boot with a cache serves it and runs no helper; only an install's first boot fetches

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -707,7 +707,10 @@ token included. Its output must be one non-empty line with no whitespace, at
 most 16 KiB; a trailing newline is forgiven. A helper that fails is a problem
 row in the Log panel in static words. With no helper configured the catalog
 serves its cached list, or its built-in one, and the kernel log says why at
-each refresh attempt (boot, and once per model id it does not know); the
+each refresh attempt (an install's first boot, when no cache exists, and once
+per model id it does not know; a boot with a cache serves it, says so with the
+cache's fetch time, and never runs the helper: the helper can be a desktop
+prompt, and a boot is not an event); the
 pickers still work, and Claude Code's own alias table still tracks each
 family's newest. The fast-mode probe then leaves the CLI's own check standing
 and says nothing.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1913,6 +1913,26 @@ def _refresh_model_catalog(reason, _async=True):
     return True
 
 
+def _model_catalog_boot(_async=True):
+    """The catalog at kernel boot (T296, the user 2026-09-10): install the last fetched list, and fetch from
+    the Models API ONLY when no cache exists (an install's first boot). The fetch runs Claude Code's
+    apiKeyHelper, which on some boxes is a password-manager read that raises a desktop prompt; a boot is
+    a clock, not an event, and several deploy converges a day each put up a prompt nobody answered and
+    timed out. With a cache the list serves as is and refreshes on the designed trigger alone, the
+    staleness event (_note_unknown_model: an unknown claude-* id from a reg or a pick, once per id per
+    kernel life). One stderr line says so, naming the cache's fetch time; /version's modelCatalog reads
+    "cache" until an event refreshes it. Returns whether a fetch started."""
+    n = _load_model_catalog_cache()
+    if n:
+        fetched = _catalog_status.get("fetchedAt")
+        when = (datetime.fromtimestamp(int(fetched), timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+                if isinstance(fetched, (int, float)) and fetched else "an unknown time")
+        sys.stderr.write("model catalog (boot): serving the cached list (%d id(s), fetched %s); it refreshes when a "
+                         "session reports a model it lacks, not at boot\n" % (n, when))
+        return False
+    return _refresh_model_catalog("boot", _async=_async)
+
+
 def _note_unknown_model(mid):
     """The staleness EVENT: a claude-* version id reached a set path or the pick store and the merged
     list does not know it — exactly when a hand-updated table used to go quietly stale. Fires ONE
@@ -14700,11 +14720,12 @@ def _sdk_locked():
             # apiKeyHelper itself.
             jd._LOGIN_AUTH_ENV_FN = sbmod.startup_auth_env   # the login tokens the backend claimed at boot; romp
             #                                                  holds no key to wire (credentials.py, 2026-09-08)
-            # T222: the live model catalog — the last fetched list installs before any picker asks,
-            # then the BOOT event refreshes it (async; the key is claimable from here on)
+            # T222: the live model catalog — the last fetched list installs before any picker asks; a
+            # first boot with no cache fetches (async; the key is claimable from here on), every later boot
+            # serves the cache and leaves the refresh to the staleness event (T296: the fetch runs the
+            # apiKeyHelper, a desktop prompt on some boxes, and boot is not an event)
             try:
-                _load_model_catalog_cache()
-                _refresh_model_catalog("boot")
+                _model_catalog_boot()
             except Exception:
                 sys.stderr.write("model catalog boot: %s\n" % traceback.format_exc())
             _sdk_backend = sbmod.SdkBackend(

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -403,6 +403,68 @@ class FetchAndFallback(unittest.TestCase):
         self.assertIsNone(v["lastError"])
 
 
+class BootPolicy(FetchAndFallback):
+    """T296 (the user 2026-09-10): boot fetches only when no catalog cache exists. The fetch runs Claude Code's
+    apiKeyHelper, a desktop prompt on some boxes, and several converges a day each raised one nobody
+    answered; with a cache the list serves as is and the staleness event alone refreshes it."""
+
+    def _boot(self):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            started = km._model_catalog_boot(_async=False)
+        return started, err.getvalue()
+
+    def test_a_boot_with_a_cache_runs_no_helper_and_serves_the_cache(self):
+        km._atomic_write(km._catalog_cache_path(), json.dumps({"fetchedAt": 1_800_000_000, "models": list(FAKE_ROWS)}))
+        started, err = self._boot()
+        self.assertFalse(started, "no fetch")
+        self.assertEqual(self._runs(), 0, "the helper never ran: no prompt on the user's box")
+        self.assertEqual(_FakeModelsAPI.seen, [], "the API was not asked")
+        self.assertEqual(km._catalog_status["source"], "cache")
+        self.assertEqual(km._catalog_status["fetchedAt"], 1_800_000_000)
+        self.assertIn("claude-opus-9-9", km._VERSION_FAMILY, "the cached list serves")
+        self.assertIn("serving the cached list (%d id(s), fetched 2027-01-15" % len(FAKE_ROWS), err)
+        self.assertIn("refreshes when a session reports a model it lacks, not at boot", err)
+        self.assertEqual(km._catalog_public_status()["source"], "cache", "/version stays honest")
+
+    def test_a_first_boot_with_no_cache_fetches(self):
+        self.assertFalse(km._catalog_cache_path().exists())
+        started, err = self._boot()
+        self.assertTrue(started)
+        self.assertEqual(self._runs(), 1, "the helper ran once, for the one fetch an install's first boot needs")
+        self.assertTrue(_FakeModelsAPI.seen)
+        self.assertEqual(km._catalog_status["source"], "api")
+        self.assertTrue(km._catalog_cache_path().exists(), "...and cached, so the next boot serves it")
+
+    def test_an_empty_or_unreadable_cache_counts_as_none(self):
+        km._catalog_cache_path().write_text("{not json")
+        started, _ = self._boot()
+        self.assertTrue(started, "an unreadable cache is no cache: fetch")
+        _reset_catalog(); _FakeModelsAPI.seen = []
+        km._atomic_write(km._catalog_cache_path(), json.dumps({"fetchedAt": 1, "models": []}))
+        started, _ = self._boot()
+        self.assertTrue(started, "a cache with no rows serves nothing: fetch")
+
+    def test_an_unknown_id_still_refreshes_with_a_cache_present(self):
+        km._atomic_write(km._catalog_cache_path(), json.dumps({"fetchedAt": 1_800_000_000, "models": list(FAKE_ROWS)}))
+        self._boot()
+        self.assertEqual(self._runs(), 0)
+        fired = []
+        orig = km._refresh_model_catalog
+        km._refresh_model_catalog = lambda reason, _async=True: (fired.append(reason), True)[1]
+        try:
+            self.assertTrue(km._note_unknown_model("claude-opus-9-10"), "the staleness event is untouched by the boot policy")
+        finally:
+            km._refresh_model_catalog = orig
+        self.assertEqual(fired, ["unknown model id claude-opus-9-10"])
+
+    def test_the_kernel_boots_through_the_policy(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("                _model_catalog_boot()\n", src)
+        self.assertNotIn('_refresh_model_catalog("boot")\n', src.split("def _model_catalog_boot")[0] + src.split("def _model_catalog_boot")[1].split("def _note_unknown_model")[1],
+                         "no other boot-time fetch remains")
+
+
 class StalenessEvent(unittest.TestCase):
     """The refresh fires on the exact event — an unknown claude-* id — once per id, never on a clock."""
 


### PR DESCRIPTION
Tier: fix

## What

The kernel's boot no longer runs the apiKeyHelper to refresh the model catalog when a catalog cache exists. The refresh runs Claude Code's configured helper in-process, and on the user's laptop that helper is a password-manager read that raises a desktop prompt; every kernel boot there, several deploy converges a day, put up a prompt nobody answered and the run timed out after 15 s (two boots minutes apart this morning, both timing out). The user asked for romp's unnecessary asks of the password manager to go; this was the one romp itself made.

**Change.** `_model_catalog_boot` installs the last fetched list as before and fetches from the Models API only when no cache exists (an install's first boot). With a cache the list serves as is, one stderr line says so, naming the cache's fetch time and that the list refreshes when a session reports a model it lacks, and `/version`'s `modelCatalog.source` reads `cache` until an event refreshes it. The refresh trigger is the existing staleness event alone (an unknown `claude-*` id from a reg or a pick, once per id per kernel life): the designed trigger, event over time; a boot is a clock. No periodic refresh was added. Every existing failure path of the fetch is unchanged and loud. An unreadable cache or one with no rows counts as no cache and fetches.

No card-move rule is involved.

## Review (lean, by hand)

The helper is the only boot-time caller of the refresh (pinned: no other `"boot"` fetch remains); the staleness event's dedup and single-flight are untouched. The cache loader's zero return covers absent, unreadable and empty caches alike, so the first-boot fetch still happens whenever nothing usable is on disk. The stderr line formats the cached `fetchedAt` when it is a number and says "an unknown time" otherwise, never raising. The off switch (`ROMP_MODEL_CATALOG=off`) still stops the first-boot fetch inside `_refresh_model_catalog`, as before.

## Tests

`tests/test_model_catalog.py`, new class on the hermetic fixture (per-test `XDG_STATE_HOME` root and `CLAUDE_CONFIG_DIR` with a counting fixture helper, the Models API a local fake): a boot with a cache present runs the helper zero times, asks the API nothing, serves the cache with source `cache` and its fetch time, and logs the line; a first boot with no cache fetches once and writes the cache; an unreadable cache and an empty one count as none; an unknown id still fires the refresh with a cache present; the kernel boots through the policy and no other boot-time fetch remains. Red before the change (the helper ran at boot), green after. `docs/reference.md`: the catalog sentence.
