### PR TITLE
Postal cards fold whenever the gist does not carry the whole message, and the head's meta never shrinks (T294)

### DIFF
--- a/ui/webview/gist.ts
+++ b/ui/webview/gist.ts
@@ -1,0 +1,30 @@
+// The gist rule every text-derived notice head shares, and the postal card's head built on it. A pure module
+// (no DOM) so the rule is unit-testable: render.ts imports it, and the one-line heads it builds, a peer's mail,
+// a background report, a romp notice, a harness note, all clip the same way.
+
+// The first meaningful line of a message, clipped for a head.
+export function gistOf(text: string, max = 90): string {
+  const lines = text.split("\n").map((l) => l.trim());
+  const first = lines.find((l) => l && !l.startsWith(">")) || lines.find((l) => l) || text.trim();
+  return first.length > max ? first.slice(0, max - 2).replace(/\s+\S*$/, "") + "…" : first;
+}
+
+export const collapseWs = (s: string): string => s.replace(/\s+/g, " ").trim();
+
+// A postal card's head: the gist the head shows, and the message the fold holds beneath it, as sent (null when
+// the gist already carries the whole message, so nothing is hidden and there is nothing to open).
+export interface PostalHead {
+  gist: string;
+  body: string | null;
+}
+
+export function postalHead(ev: { body?: string; summary?: string }): PostalHead {
+  const raw = ev.body || "";
+  const full = raw.trim();
+  const cap = ev.summary && ev.summary.trim();
+  const gist = cap || gistOf(full);   // CLIPPED: an unclipped first line equalled a one-paragraph message and left it no fold (T294)
+  // the fold holds the message AS SENT, not the trimmed copy the comparison uses: a leading indent is markdown (four
+  // spaces open a code block) and the trim would have flattened it into prose
+  const body = !!full && collapseWs(full) !== collapseWs(gist) ? raw : null;
+  return { gist, body };
+}

--- a/ui/webview/postal-expand.test.ts
+++ b/ui/webview/postal-expand.test.ts
@@ -6,7 +6,7 @@
 //
 // 2026-07-25 (the user, from a real sent card): three more guarantees pinned here —
 //   1. the expand is KEYED (openFolds), because the unkeyed toggle was silently re-collapsed by the
-//      next kernel push ("it expands for like a second and then something collapses it");
+//      next kernel push (the user watched a card open and snap shut a moment later);
 //   2. expanded shows the full message ALONE — the summary line was repeating the same words right
 //      above the body;
 //   3. the collapsed fallback is clamped by CSS to two full lines, not pre-truncated at 100 chars,
@@ -18,22 +18,26 @@ import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const GIST = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "gist.ts"), "utf8");   // T294: the head rule lives here (postalHead)
 
-test("a postal summary is the caption, or the first non-empty line of the body when there's none", () => {
-  assert.match(RENDER, /function postalServiceSummary/);
-  assert.match(RENDER, /const cap = ev\.summary && ev\.summary\.trim\(\)/);
-  assert.match(RENDER, /\.split\("\\n"\)\.map\(\(s\) => s\.trim\(\)\)\.find\(Boolean\)/);
+test("a postal summary is the caption, or the CLIPPED first line of the body when there's none", () => {
+  // T294 (2026-09-10): the rule is gist.ts postalHead: the caption, else gistOf's clip of the first line; an UNCLIPPED
+  // first line equalled a one-paragraph message, which then had no fold and nothing past the head's ellipsis
+  assert.match(GIST, /export function postalHead\(ev: \{ body\?: string; summary\?: string \}\): PostalHead \{/);
+  assert.match(GIST, /const cap = ev\.summary && ev\.summary\.trim\(\);/);
+  assert.match(GIST, /const gist = cap \|\| gistOf\(full\);/);
   assert.doesNotMatch(RENDER, /slice\(0, 99\)/, "the 100-char pre-truncation must be gone");
+  assert.doesNotMatch(RENDER, /function postalServiceSummary/, "the unclipped first-line rule is gone from render.ts");
   // 2026-09-08 (the notice-vocabulary pass): the summary is the notice GIST — one nowrap line with an ellipsis, the
   // head grammar every notice shares (the two-line clamp went with the bespoke card)
-  assert.match(RENDER, /const summaryText = postalServiceSummary\(ev\) \|\| gistOf\(fullText\);/);
+  assert.match(RENDER, /const \{ gist: summaryText, body: fullMd \} = postalHead\(ev\);/);
   assert.match(CSS, /\.notice-gist \{[^}]*text-overflow: ellipsis/);
 });
 
 test("both directions render the summary + a click-to-expand full body (no hover tooltip)", () => {
-  assert.match(RENDER, /const expandable = .*collapseWs\(fullText\) !== collapseWs\(summaryText\)/);
+  assert.match(GIST, /const body = !!full && collapseWs\(full\) !== collapseWs\(gist\) \? raw : null;/, "the fold holds the message as sent; the trim is the comparison's");
   // 2026-09-08: the full message is the notice BODY, markdown-rendered against the sender's repo
-  assert.match(RENDER, /if \(expandable\) \{ body = el\("div", "notice-md md"\); body\.innerHTML = md\(ev\.body, postalRepoFor\(ev\)\); highlight\(body\); \}/);
+  assert.match(RENDER, /if \(fullMd\) \{ body = el\("div", "notice-md md"\); body\.innerHTML = md\(fullMd, postalRepoFor\(ev\)\); highlight\(body\); \}/);
   assert.doesNotMatch(RENDER, /body\.title = ev\.body/, "the old hover-tooltip full body must be gone");
   assert.doesNotMatch(RENDER, /caption \|\| ev\.body/, "no longer 'caption else whole body'");
 });

--- a/ui/webview/postal-head.test.ts
+++ b/ui/webview/postal-head.test.ts
@@ -1,0 +1,102 @@
+// T294 (the user 2026-09-10, from a sent card in their chat): a postal message must ALWAYS be reachable. Since the
+// notice rewrite the card's head is one nowrap line with an ellipsis, and the fold under it exists only when the
+// gist differs from the message. For mail without a recipient caption the gist was the message's first line,
+// UNCLIPPED, so a one-paragraph message (most sent mail, and every inbound message the recipient's judge has not
+// captioned yet, the inbound question included) compared equal to itself: no fold, no click, and everything past
+// the ellipsis was gone. The pre-rewrite card rendered the whole body in exactly that case.
+//
+// The rule now (ui/webview/gist.ts postalHead): the gist is the caption, else the first line CLIPPED by gistOf;
+// the fold holds the full message whenever the gist does not carry all of it. A short one-liner keeps no fold
+// (nothing is hidden) and, as a head-only postal notice, wraps instead of truncating. The head's meta (the kind,
+// the delivery state) never shrinks to a letter: the gist is the one flexible slot.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { postalHead, gistOf } from "./gist";
+
+const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
+
+const PARAGRAPH = "Search endpoint is in: GET /notes?q= ranks title matches above body matches, ignores case, and returns "
+  + "the same envelope as the unfiltered list, so the client needs no change beyond passing the parameter; the request "
+  + "test covers an empty query, a title hit, a body-only hit and a query with no matches.";
+
+test("a one-paragraph message without a caption: the gist is the clipped first line and the fold holds the whole message", () => {
+  const h = postalHead({ body: PARAGRAPH });
+  assert.equal(h.gist, gistOf(PARAGRAPH), "the head shows the clipped gist, not the unclipped paragraph");
+  assert.ok(h.gist.endsWith("…") && h.gist.length <= 90, "clipped at the shared head width: " + JSON.stringify(h.gist));
+  assert.equal(h.body, PARAGRAPH, "the whole message is one click away");
+});
+
+test("the same for inbound mail the recipient's judge has not captioned yet (the question that opens by default included)", () => {
+  const ask = "Which pagination shape do you want on GET /notes: page/perPage query params, or a cursor token? The client "
+    + "mock currently assumes page/perPage. Reply needed before I wire the route.";
+  const h = postalHead({ body: ask, summary: "" });
+  assert.notEqual(h.body, null, "an uncaptioned inbound message keeps its fold");
+  assert.equal(h.body, ask);
+});
+
+test("a short one-liner hides nothing: the gist is the message and there is no fold", () => {
+  const h = postalHead({ body: "Fixture move done; nothing else changed." });
+  assert.equal(h.gist, "Fixture move done; nothing else changed.");
+  assert.equal(h.body, null);
+});
+
+test("a multi-line message: the first line is the gist, the fold holds all of it", () => {
+  const body = "Pagination decision: page/perPage, default 20, max 100.\n\n- the envelope gains total and page\n- an out-of-range page returns an empty list";
+  const h = postalHead({ body });
+  assert.equal(h.gist, "Pagination decision: page/perPage, default 20, max 100.");
+  assert.equal(h.body, body);
+});
+
+test("a caption is the gist, the fold holds the message; a caption that IS the message leaves no fold", () => {
+  const h = postalHead({ body: PARAGRAPH, summary: "search endpoint shipped with tests" });
+  assert.equal(h.gist, "search endpoint shipped with tests");
+  assert.equal(h.body, PARAGRAPH);
+  const same = postalHead({ body: "ship it", summary: "  ship   it " });
+  assert.equal(same.body, null, "whitespace-only differences hide nothing");
+  assert.deepEqual(postalHead({ body: "" }), { gist: "", body: null });
+});
+
+test("the fold holds the message AS SENT: a leading indent (a markdown code block) survives, the comparison alone trims", () => {
+  const body = "    GET /notes?q=x -> 200\n    GET /notes     -> 200\n\nboth cases pass";
+  const h = postalHead({ body });
+  assert.equal(h.gist, "GET /notes?q=x -> 200");
+  assert.equal(h.body, body, "the four-space indent that opens the code block is still there");
+  assert.equal(postalHead({ body: "  ship it  " }).body, null, "surrounding whitespace alone hides nothing");
+});
+
+test("render.ts builds the postal card's head through postalHead and the shared gist rule lives in gist.ts", () => {
+  const RENDER = read("ui", "webview", "render.ts");
+  assert.match(RENDER, /import \{ [^}]*\bpostalHead\b[^}]* \} from "\.\/gist";/);
+  assert.doesNotMatch(RENDER, /\nfunction gistOf\(/, "one gist rule, in gist.ts");
+  const start = RENDER.indexOf("function renderPostalService(");
+  const fn = RENDER.slice(start, RENDER.indexOf("\nfunction ", start + 10));
+  assert.match(fn, /const \{ gist: summaryText, body: fullMd \} = postalHead\(ev\);/);
+  assert.match(fn, /if \(fullMd\) \{ body = el\("div", "notice-md md"\); body\.innerHTML = md\(fullMd, postalRepoFor\(ev\)\); highlight\(body\); \}/);
+  assert.doesNotMatch(fn, /postalServiceSummary\(ev\)|collapseWs\(fullText\)/, "the old in-place rule is gone");
+});
+
+test("the head's meta never shrinks to a letter, and a head-only postal line wraps instead of truncating", () => {
+  const CSS = read("ui", "webview", "styles.css");
+  assert.match(CSS, /\.turn-postal-service \.notice-head \{ container-type: inline-size; \}\n\.turn-postal-service \.notice-meta \{ flex: 0 0 auto; \}\n@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-meta \{ flex: 0 1 auto; min-width: min\(100%, 6ch\); \}\n\}/,
+               "the postal meta is rigid, and on a phone-width head (under 360px) it yields to a floor of its own inside the card");
+  // scoped to the postal card: every other notice head's meta still yields (an API-error meta is a sentence, a compact
+  // group head's meta is a whole gist, and both sit beside actions that must stay on the pane)
+  assert.match(CSS, /\n\.notice-meta \{ flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/);
+  // the case that keeps the base rule shrinkable: the compact-mode notice-group head puts the first notice's WHOLE
+  // gist (up to 90 chars) in the meta slot while folded, and the system-context notice a model · dir · N CLAUDE.md
+  // string; rigid, either would push the head past a phone-width pane with the gist collapsed to nothing
+  const RENDER = read("ui", "webview", "render.ts");
+  assert.match(RENDER, /gist: `\$\{evs\.length\} notices`, meta: open \? undefined : b\.gist,/, "renderNoticeGroup's meta is a whole gist");
+  assert.doesNotMatch(CSS, /\n\.notice-meta \{ flex: 0 0 auto/, "the rigid meta is never the base rule");
+  // and the gist keeps a legible floor beside that long meta on the group head and the postal card (measured at 390 px:
+  // "2 notices" had shrunk to 20 px), but NOT as the base rule: a floor on the API-error head pushed its buttons off a
+  // phone-width pane
+  assert.match(CSS, /\n\.notice-gist \{ flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/);
+  assert.match(CSS, /\n\.notice-head\[data-gkey\] \.notice-gist, \.turn-postal-service \.notice-gist \{ min-width: min\(100%, 10ch\); \}/);
+  assert.match(CSS, /\.turn-postal-service \.notice-slim \.notice-gist \{ white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; \}/,
+               "a bare link (no space to break at) wraps too instead of running off the head");
+  // the wrapped head keeps its glyph on the first line: a centred glyph sank to the middle of a three-line block
+  assert.match(CSS, /\.turn-postal-service \.notice-slim \.notice-glyph \{ align-self: flex-start; margin-top: 4px; \}/);
+});

--- a/ui/webview/pr-links.test.ts
+++ b/ui/webview/pr-links.test.ts
@@ -828,7 +828,7 @@ test("the session frame's githubRepo rides the Session and survives a chatTail d
 
 test("postal bodies link against the SENDER's frame-known repo only: outbound = the writer's own, inbound = senderPrRepo over the session map by the card's host and name, never the reader's as a fallback", () => {
   // 2026-09-08 (the notice-vocabulary pass): ONE render path — the full message is the notice body (the summary is the head)
-  assert.match(RENDER, /body\.innerHTML = md\(ev\.body, postalRepoFor\(ev\)\);/);
+  assert.match(RENDER, /body\.innerHTML = md\(fullMd, postalRepoFor\(ev\)\);/);   // T294: the fold's markdown is postalHead's body (the message when the gist does not carry all of it)
   const fn = RENDER.match(/function postalRepoFor\([\s\S]*?\n\}/)?.[0] || "";
   assert.match(fn, /if \(ev\.direction === "out"\) return prRepoFor\(\);/);
   assert.match(fn, /const cardHost = hostOf\(renderingOwnerSid \?\? renderingSid \?\? activeId \?\? ""\);/,

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -90,6 +90,7 @@ import { turnWorkedSecs as workedSecsOf, workedFooterPlan } from "./worked-foote
 import { reconcileRewindPass, type RewindEvent } from "./rewind-reconcile";
 import { watchChatVisibility, browserChatVisibilityDeps } from "./chat-visibility";
 import type { PaneHiddenHost } from "./paint-gate";
+import { gistOf, collapseWs, postalHead } from "./gist";   // the shared gist rule + the postal head (T294)
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -1642,13 +1643,6 @@ function noticeLiveGlyph(inner: HTMLElement): HTMLElement {
   const span = el("span", "notice-glyph notice-glyph-wide");
   span.appendChild(inner);
   return span;
-}
-
-// The first meaningful line of a message, clipped for a head (the gist rule every text-derived head shares).
-function gistOf(text: string, max = 90): string {
-  const lines = text.split("\n").map((l) => l.trim());
-  const first = lines.find((l) => l && !l.startsWith(">")) || lines.find((l) => l) || text.trim();
-  return first.length > max ? first.slice(0, max - 2).replace(/\s+\S*$/, "") + "…" : first;
 }
 
 // The fold toggle's tail work when a notice opens: the /clear boundary's body lazy-loads the cleared
@@ -4688,18 +4682,6 @@ function refreshPostalDots() {
   document.querySelectorAll(".notice-src-chip").forEach((p) => setPeerDot(p as HTMLElement, workingSet.has((p.textContent || "").trim())));
 }
 
-// A Romp Postal Service message, as a compact identity-coloured card.
-// One-line summary for a postal card: the judge's gist when one exists (the recipient session's caption
-// of this message, joined by msg id — the kernel now fills it for OUTGOING mail too), else the first
-// non-empty line of the body. The fallback is NOT hard-truncated here: a 100-char slice parked its "…"
-// mid-line and wasted the rest (the user 2026-07-25) — CSS clamps the summary to two full lines instead,
-// and the gist replaces it on a later render once the recipient's judge has captioned the message.
-function postalServiceSummary(ev: Extract<ChatEvent, { kind: "postal-service" }>): string {
-  const cap = ev.summary && ev.summary.trim();
-  if (cap) return cap;
-  return (ev.body || "").split("\n").map((s) => s.trim()).find(Boolean) || "";
-}
-const collapseWs = (s: string) => s.replace(/\s+/g, " ").trim();
 
 // The interaction TYPE of a postal message, parsed from its leading intent token → a small chip on the
 // card head, shown in both the compact and expanded views (the user 2026-06-16). There are THREE
@@ -4740,14 +4722,13 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
   if (intent) meta.push(intent.label);
   if (ev.park || ev.status === "parked") meta.push("parked");
   else if (ev.status === "delivered") meta.push("delivered");
-  // Gist: ALWAYS a one-line summary — the incoming caption, or (sent mail / no caption) the first line of the
-  // message — with the full message one click deeper (the user 2026-06-16). KEYED (the user 2026-07-25:
-  // "it expands for like a second and then collapses again" — a DOM-only toggle died with every push).
-  const fullText = (ev.body || "").trim();
-  const summaryText = postalServiceSummary(ev) || gistOf(fullText);
-  const expandable = !!fullText && collapseWs(fullText) !== collapseWs(summaryText);
+  // Gist: ALWAYS a one-line summary, the incoming caption, else the first line of the message CLIPPED (gist.ts
+  // postalHead), with the full message one click deeper whenever the gist does not carry all of it (the user
+  // 2026-06-16; T294, the user 2026-09-10, whose one-paragraph sent card had no fold at all). KEYED (the user
+  // 2026-07-25, who watched a card open and snap shut a moment later: a DOM-only toggle died with every push).
+  const { gist: summaryText, body: fullMd } = postalHead(ev);   // gist.ts: the caption, else the CLIPPED first line; the fold whenever the gist does not carry the whole message (T294)
   let body: HTMLElement | null = null;
-  if (expandable) { body = el("div", "notice-md md"); body.innerHTML = md(ev.body, postalRepoFor(ev)); highlight(body); }
+  if (fullMd) { body = el("div", "notice-md md"); body.innerHTML = md(fullMd, postalRepoFor(ev)); highlight(body); }
   // an incoming QUESTION opens by default: a reply is owed, and the whole ask is what you need to read
   const owed = !!intent && intent.cls === "question" && ev.direction === "in";
   const turn = notice({ src, glyph: "peer", gist: summaryText, meta: meta.join(" · ") || undefined, body, open: owed,

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2304,10 +2304,32 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   text-transform: none; font-weight: 700; background: var(--peer-bg, var(--overlay-10)); color: var(--peer-fg, var(--fg)); }
 .notice-gist { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-size: 0.92em; color: var(--fg); }
+/* where the gist shares the head with a long META and no actions, it keeps a legible floor: flex shrinks the two in
+   proportion to their widths, so a compact notice-group head ("2 notices" beside a 90-char gist in its meta slot) on a
+   phone-width pane squeezed the gist to a letter while the meta kept most of the row; the meta yields first there. Not
+   on heads with actions (the API-error card): a floor there pushed the buttons off a phone-width pane (T294) */
+.notice-head[data-gkey] .notice-gist, .turn-postal-service .notice-gist { min-width: min(100%, 10ch); }
 .notice-gist[data-act] { cursor: pointer; text-decoration: underline dotted; text-underline-offset: 2px; }   /* a gist that is a link (the branch divider) */
 .notice-gist[data-act]:hover { text-decoration: underline; }
 .notice-meta { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   font-size: 0.82em; color: var(--dim); font-variant-numeric: tabular-nums; }
+/* the POSTAL card's meta (the kind, the delivery state: a few short words) keeps its width, so a long gist squeezes
+   itself and never the word beside it down to a letter (T294, the user 2026-09-10, whose card's "question" had
+   become "q…"). Scoped to the postal card: an API-error head carries a sentence-long meta and a compact notice-group
+   head carries a whole gist there, and those must still yield to the actions beside them on a narrow pane. The head is
+   the size container: on a phone-width one (under 360px) even the short words do not fit beside the gist's floor, and
+   there the meta yields again, to a floor of its own, inside the card instead of running out of it. */
+.turn-postal-service .notice-head { container-type: inline-size; }
+.turn-postal-service .notice-meta { flex: 0 0 auto; }
+@container (max-width: 360px) {
+  .turn-postal-service .notice-meta { flex: 0 1 auto; min-width: min(100%, 6ch); }
+}
+/* a head-only postal line hides nothing behind a fold, so it may not hide anything behind an ellipsis either: a
+   one-liner that outgrows the head wraps, an unbroken token (a bare link) included (T294) */
+.turn-postal-service .notice-slim .notice-gist { white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; }
+/* and its glyph sits on the FIRST line of the wrapped head (the centred glyph of a one-line head drifts to the
+   middle of a three-line block otherwise); 4px is the centred offset within the head's own line */
+.turn-postal-service .notice-slim .notice-glyph { align-self: flex-start; margin-top: 4px; }
 .notice-acts { flex: 0 0 auto; margin-left: auto; display: inline-flex; gap: 4px; align-self: center; }
 /* word buttons on the button vocabulary: the sm box, the T141 rest, pattern-A hover, the press cue */
 .notice-act { font-family: var(--sans); font-size: var(--btn-fs-sm); line-height: 1.4; padding: var(--btn-pad-sm);


### PR DESCRIPTION
## Summary

A postal card whose message is one paragraph could not be opened, and nothing past the head's ellipsis was reachable. Since the notice rewrite the card's head is one nowrap line, and the fold under it exists only when the gist differs from the message. For mail without a recipient caption the gist was the message's first line, unclipped, so a one-paragraph message compared equal to itself: no fold, no click. That is most sent mail, and every inbound message the recipient's judge has not captioned yet, the inbound question that is meant to open by default included. The pre-rewrite card rendered the whole body in exactly that case. Alongside it the head's meta text (the kind, the delivery state) shrank to a letter ("q…") beside a long gist.

## The fix

- `ui/webview/gist.ts` (new): the shared gist rule (`gistOf`, `collapseWs`, moved out of render.ts) and `postalHead(ev)`: the gist is the caption, else the first line CLIPPED by `gistOf`; the fold holds the full message whenever the gist does not carry all of it. A short one-liner keeps no fold, since nothing is hidden.
- `ui/webview/render.ts`: `renderPostalService` builds its head through `postalHead`; the in-place rule and `postalServiceSummary` are gone.
- `ui/webview/styles.css`: the POSTAL card's `.notice-meta` never shrinks (the gist is the one flexible slot of its head); scoped to the postal card, because an API-error head carries a sentence-long meta and a compact notice-group head a whole gist there, and both must still yield to the actions beside them on a narrow pane. A head-only postal line wraps instead of truncating (a bare link included, `overflow-wrap: anywhere`), with its glyph pinned to the first line.

**From the adversarial review, folded in before arming.** The no-shrink meta was global at first and would have pushed an API-error card's buttons off a narrow pane; it is the postal card's alone now. The wrap rule had no break opportunity for an unbroken token, so a one-line link message still ran off the head; it breaks anywhere now. The fold rendered the TRIMMED message, which flattened a leading indented code block into prose; the fold holds the message as sent and only the comparison trims. The comment above the head rule quoted the user verbatim and described the old rule; it paraphrases and describes the rule that is there. Measuring at a 390 px pane: the compact notice-group head ("2 notices" beside a 90-character gist in its meta slot) had its gist squeezed to 20 px by proportional flex shrink, before and after this change alike, so the gist keeps a floor of `min(100%, 10ch)` on the group head and the postal card (not as the base rule: a floor on the API-error head pushed its buttons off the pane). And on a phone-width postal head even the short kind and delivery words do not fit beside that floor, so the postal head is a size container and under 360 px its meta yields again to a floor of its own inside the card (`@container (max-width: 360px)`). Every postal meta measured inside its head at 390, 520 and 1000 px; whole at 520 and 1000.

## Tests

- `ui/webview/postal-head.test.ts` (new): unit tests of the rule (a one-paragraph message without a caption folds; uncaptioned inbound mail folds; a short one-liner has no fold; a multi-line message folds; a caption is the gist), red on the old rule, plus pins on the render.ts call site and the two CSS rules.
- `ui/webview/postal-expand.test.ts`: the rule pins moved to gist.ts.

Verified on a hermetic served chat with synthetic mail (inbound delegation, coordination and question, a sent one-paragraph message, a sent multi-line message): before, four of five cards were slim head-only lines with no click; after, all five fold and open, the inbound question opens by default, and the kind and delivery state read in full.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
