### PR TITLE
Catalog boot residues: the health-hover stub covers the boot helper, the words follow the first-boot rule, a corrupt fetch time cannot raise

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1684,9 +1684,11 @@ _models_rev = [int(time.time() * 1000)]
 # new version ids into the families, ADD-ONLY: an id the API omits but the seed knows stays (key-scoped
 # visibility differs per account); a dated snapshot, a suffixed variant (-fast) or the pre-4 naming
 # never joins (routing ids, not versions — the alias-table lesson); every family stays newest-first.
-# Cached durably (STATE/model-catalog.json) so a dead API never blanks a picker. Refreshed on exact
-# EVENTS — boot, and a claude-* id reaching a set path or the pick store that the merged list does not
-# know (the very moment staleness bites) — never on a timer. Unreachable API = serve seed+cache and
+# Cached durably (STATE/model-catalog.json) so a dead API never blanks a picker. Fetched on exact
+# EVENTS — an install's first boot, when no cache exists, and a claude-* id reaching a set path or the
+# pick store that the merged list does not know (the very moment staleness bites) — never on a timer,
+# and not at a boot that has a cache (T296: the fetch runs the apiKeyHelper, a desktop prompt on some
+# boxes; a boot is a clock). Unreachable API = serve seed+cache and
 # SAY SO (stderr + /version), never a quietly stale list. ROMP_MODEL_CATALOG=off disables the fetch
 # outright — hermetic labs must never reach the network; ROMP_MODELS_URL points tests at a fake.
 MODEL_CATALOG_FILE_NAME = "model-catalog.json"
@@ -1800,7 +1802,8 @@ def _catalog_cache_path():
 
 def _load_model_catalog_cache():
     """Boot: install the last fetched catalog BEFORE any picker asks, so a dead API never blanks a
-    picker and the seed alone is only what this build shipped with. Returns the cached row count."""
+    picker and the seed alone is only what this build shipped with. Returns the cached row count; zero
+    (absent, unreadable, or no rows) is what makes _model_catalog_boot fetch, the one boot that does."""
     try:
         d = json.loads(_catalog_cache_path().read_text())
         rows = d.get("models") if isinstance(d, dict) else None
@@ -1925,8 +1928,11 @@ def _model_catalog_boot(_async=True):
     n = _load_model_catalog_cache()
     if n:
         fetched = _catalog_status.get("fetchedAt")
-        when = (datetime.fromtimestamp(int(fetched), timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-                if isinstance(fetched, (int, float)) and fetched else "an unknown time")
+        try:                                           # a corrupt fetchedAt (out of range, NaN, a string) must not
+            when = (datetime.fromtimestamp(int(fetched), timezone.utc).strftime("%Y-%m-%d %H:%M UTC")   # turn the
+                    if isinstance(fetched, (int, float)) and fetched else "an unknown time")           # served
+        except (ValueError, OverflowError, OSError, TypeError):                                        # cache into a
+            when = "an unknown time"                                                                  # swallowed traceback
         sys.stderr.write("model catalog (boot): serving the cached list (%d id(s), fetched %s); it refreshes when a "
                          "session reports a model it lacks, not at boot\n" % (n, when))
         return False
@@ -1939,9 +1945,9 @@ def _note_unknown_model(mid):
     refresh per unknown id per kernel life (dedup by id, never a clock); aliases, dated snapshots
     and garbage never fire. Returns whether a refresh was started.
     The id is marked asked only when its refresh actually STARTS: the refresh is single-flight, so a
-    sighting while one is inflight — the boot fetch, exactly when a running session's CLI first
-    reports a new release — starts nothing, and marking it then spent the id's one refresh on a
-    no-op. Unmarked, the next sighting after the inflight fetch lands (every /models read re-derives
+    sighting while one is inflight — an install's first-boot fetch, or another id's, exactly when a
+    running session's CLI first reports a new release — starts nothing, and marking it then spent the
+    id's one refresh on a no-op. Unmarked, the next sighting after the inflight fetch lands (every /models read re-derives
     the learned list) asks for real if the catalog still lacks the id; a catalog that caught up
     short-circuits on _VERSION_FAMILY first."""
     mid = str(mid or "")

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -25,6 +25,7 @@ Synthetic only: a private synthetic sid, invented key material assembled at run 
 import hashlib
 import inspect
 import io
+from contextlib import redirect_stderr
 import json
 import math
 import os
@@ -267,8 +268,8 @@ class OneClock(unittest.TestCase):
 
         fake = types.SimpleNamespace(SdkBackend=_Recorder, startup_auth_env=lambda *a, **k: {})
 
-        names = ("_sdk_backend", "load_source", "_ensure_sdk_on_path", "_load_model_catalog_cache",
-                 "_refresh_model_catalog", "_claude_bin", "_mark_boot", "_sdk_problem")
+        names = ("_sdk_backend", "load_source", "_ensure_sdk_on_path", "_model_catalog_boot",
+                 "_claude_bin", "_mark_boot", "_sdk_problem")
         saved = {n: getattr(km, n) for n in names}
         saved_jd = (km.jd._LOGIN_AUTH_ENV_FN, km.jd._USAGE_REFRESH_FN)
         problems = []
@@ -276,17 +277,20 @@ class OneClock(unittest.TestCase):
             km._sdk_backend = None
             km.load_source = lambda name, path: fake
             km._ensure_sdk_on_path = lambda: True
-            km._load_model_catalog_cache = lambda: None
-            km._refresh_model_catalog = lambda why: None
+            km._model_catalog_boot = lambda _async=True: False   # the boot's one catalog call (T296): stubbed whole
             km._claude_bin = lambda: "/bin/true"
             km._mark_boot = lambda *a, **k: None
             km._sdk_problem = problems.append
-            be = km._sdk_locked()
+            err = io.StringIO()
+            with redirect_stderr(err):
+                be = km._sdk_locked()
         finally:
             for n in names:
                 setattr(km, n, saved[n])
             km.jd._LOGIN_AUTH_ENV_FN, km.jd._USAGE_REFRESH_FN = saved_jd
         self.assertEqual(problems, [], "the construction ran clean")
+        self.assertNotIn("model catalog boot:", err.getvalue(),
+                         "...and so did the catalog leg: no swallowed traceback under the boot's own except (T296b)")
         self.assertEqual(len(built), 1, "one backend built")
         self.assertIsInstance(be, _Recorder)
         kw = built[0]

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -6,8 +6,9 @@ credential and merges new version ids into the families — ADD-ONLY (an id the 
 knows stays; key-scoped visibility differs per account), newest-first by each id's own version tuple,
 labels from display_name. The seed is also the LOUD fallback: an unreachable API or a credential-less
 box serves seed+cache and says so (stderr + /version.modelCatalog), never a quietly stale list. The
-refresh is EVENT-keyed — boot, plus the exact staleness event of a claude-* id reaching a set path or
-the pick store that the merged list does not know — never a timer. A durable cache
+fetch is EVENT-keyed — an install's first boot, when no cache exists, plus the exact staleness event of
+a claude-* id reaching a set path or the pick store that the merged list does not know — never a timer,
+and not a boot that has a cache (T296). A durable cache
 (STATE/model-catalog.json) means a dead API never blanks a picker.
 
 The Models API leg runs against a HERMETIC fake here (a local HTTP server; the kernel's fetch URL is
@@ -444,6 +445,20 @@ class BootPolicy(FetchAndFallback):
         km._atomic_write(km._catalog_cache_path(), json.dumps({"fetchedAt": 1, "models": []}))
         started, _ = self._boot()
         self.assertTrue(started, "a cache with no rows serves nothing: fetch")
+
+    def test_a_corrupt_fetch_time_in_the_cache_still_serves_and_says_an_unknown_time(self):
+        # T296b: an out-of-range, NaN, negative-beyond-epoch, string or null fetchedAt must not turn the served
+        # cache into a swallowed traceback under the boot's own except; the line says "an unknown time"
+        rows = json.dumps(list(FAKE_ROWS))
+        for stamp in ('"corrupt"', "1e30", "NaN", "-1e18", "null"):
+            _reset_catalog(); _FakeModelsAPI.seen = []
+            km._catalog_cache_path().write_text('{"fetchedAt": %s, "models": %s}' % (stamp, rows))
+            started, err = self._boot()
+            self.assertFalse(started, stamp)
+            self.assertEqual(self._runs(), 0, stamp)
+            self.assertIn("fetched an unknown time", err, stamp)
+            self.assertNotIn("Traceback", err, stamp)
+            self.assertEqual(km._catalog_status["source"], "cache", "the cache serves whatever its stamp says")
 
     def test_an_unknown_id_still_refreshes_with_a_cache_present(self):
         km._atomic_write(km._catalog_cache_path(), json.dumps({"fetchedAt": 1_800_000_000, "models": list(FAKE_ROWS)}))


### PR DESCRIPTION
Tier: fix

## What

Three residues of the catalog boot change (the post-merge review):

1. **A stale stub hid a swallowed error.** The health-hover test that builds the backend with the kernel's own start stubbed the cache loader and the refresh with their old signatures; on main the boot path calls the new boot helper, which handed the stubbed refresh an unexpected keyword, and the boot's own `except` swallowed the traceback to stderr while the test stayed green. The test now stubs the boot helper itself and asserts that stderr carries no catalog-boot line, so the leg is proven clean. Red first: the assertion fails against the stale stubs.
2. **The words follow the rule.** The catalog's events header, the cache loader's docstring, the staleness event's inflight example and the test module's docstring said boot was a refresh event; they now say what holds: an install's first boot with no cache fetches, then only the staleness event, and never a boot that has a cache.
3. **The fetch-time line cannot raise.** A corrupt `fetchedAt` in the cache (out of range, NaN, negative beyond the epoch, a string, null) made the timestamp formatting raise inside the boot's try after the cache had already installed, a swallowed traceback; the formatting is guarded and says "an unknown time".

No behaviour of the catalog changes beyond the guarded line; no card-move rule is involved.

## Review (lean, by hand)

The stub replaces exactly the boot's one catalog call with the same return shape (no fetch); the stderr capture wraps only the build. The guard catches the exceptions the formatting can raise (`ValueError`, `OverflowError`, `OSError`, `TypeError`) and nothing that would hide a different fault. The comment rewrites name the same functions the code calls.

## Tests

`tests/test_api_health_hover.py`: the backend build asserts no catalog-boot stderr line (red against the stale stubs). `tests/test_model_catalog.py`: a cache whose `fetchedAt` is a string, out of range, NaN, hugely negative or null still serves as the cache, runs no helper, says "an unknown time" and writes no traceback.
