### PR TITLE
Restart-classifier tests: the fixture's git forbids background work, so no child writes into .git during teardown (T298)

### DIFF
--- a/tests/test_restart_classifier.py
+++ b/tests/test_restart_classifier.py
@@ -29,8 +29,19 @@ load_source("romp_judge", os.path.join(BIN, "romp-judge"))
 km = load_source("romp_kernel_rclass", os.path.join(BIN, "romp-kernel"))
 
 
-def _git(repo, *args):
-    r = subprocess.run(["git", "-C", str(repo)] + list(args), capture_output=True, text=True)
+# T298: every git the fixture runs forbids BACKGROUND work. `git commit` spawns `git maintenance run --auto`,
+# which on current git detaches from its parent (maintenance.autoDetach, on by default in recent git; older git's
+# `gc --auto` detached once it had work) and can still be writing into .git while tearDownClass removes the
+# temp repo — the CI flake "Directory not empty: '.git'" raised by TemporaryDirectory.cleanup's rmtree (the
+# Python 3.10 job, 2026-09-10). The repo's own config carries the same keys (setUpClass), so a git the KERNEL
+# runs against the repo obeys them too; fsmonitor is off for the same reason on hosts where it has a daemon.
+GIT_NO_BACKGROUND = {"maintenance.auto": "false", "maintenance.autoDetach": "false", "gc.auto": "0",
+                     "gc.autoDetach": "false", "core.fsmonitor": "false"}
+_GIT_C = [x for k, v in GIT_NO_BACKGROUND.items() for x in ("-c", "%s=%s" % (k, v))]
+
+
+def _git(repo, *args, env=None):
+    r = subprocess.run(["git", "-C", str(repo)] + _GIT_C + list(args), capture_output=True, text=True, env=env)
     assert r.returncode == 0, r.stderr
     return r.stdout.strip()
 
@@ -46,6 +57,8 @@ class RealDiffShapes(unittest.TestCase):
         for sub in ("kernel", "bin", "postal", "cli", "docs", "tests", "ui/webview"):
             (repo / sub).mkdir(parents=True)
         _git(repo, "init", "-q")
+        for k, v in GIT_NO_BACKGROUND.items():   # T298: in the repo too, for any git run against it
+            _git(repo, "config", k, v)
         _git(repo, "config", "user.email", "t@TESTHOST")
         _git(repo, "config", "user.name", "t")
         (repo / "kernel/mod.py").write_text('def f():\n    """doc."""\n    return 1  # one\n')
@@ -192,6 +205,25 @@ class RealDiffShapes(unittest.TestCase):
         changed, cc = self._verdict(self.base, sha)
         self.assertTrue(changed, "the running kernel LOSES a module it loaded — restart")
         self.assertIn("kernel/mod.py", cc["kernel"])
+
+    def test_the_fixture_forbids_background_git_work(self):
+        # T298: the repo's config and every helper invocation forbid auto maintenance, gc and its detach, and
+        # the fsmonitor daemon, so no git child outlives the command that spawned it (see GIT_NO_BACKGROUND).
+        # Pinned at the source and by behaviour: git's own trace names every child it runs, and a commit
+        # through the helper spawns none.
+        for k, v in GIT_NO_BACKGROUND.items():
+            self.assertEqual(_git(self.repo, "config", "--local", "--get", k), v, "the repo's config carries " + k)
+            self.assertIn("%s=%s" % (k, v), _GIT_C, "…and so does every helper invocation")
+        self._reset()
+        (self.repo / "docs/a.md").write_text("# docs, traced\n")
+        with tempfile.NamedTemporaryFile("r", suffix=".log") as trace:
+            env = dict(os.environ, GIT_TRACE=trace.name)
+            _git(self.repo, "add", "-A", env=env)
+            _git(self.repo, "commit", "-qm", "traced", env=env)
+            t = trace.read()
+        self.assertIn("built-in: git commit", t, "the trace is on")
+        self.assertNotIn("maintenance", t, "no auto-maintenance child is spawned:\n" + t)
+        self.assertNotIn("run_command: git gc", t, "no gc child is spawned")
 
     def test_unknown_shas_and_git_failure_restart(self):
         self.assertTrue(km._kernel_code_changed("", "abc"), "unknown shas: restart")


### PR DESCRIPTION
Fixes the flake in `tests/test_restart_classifier.py` where `RealDiffShapes`' teardown raised `OSError: [Errno 39] Directory not empty: '.git'` from `TemporaryDirectory.cleanup` (the Python 3.10 job of a webview-only PR, 2026-09-10).

**Writer, found at source.** `git commit` spawns `git maintenance run --auto`. On current git that child detaches from its parent (`maintenance.autoDetach`, on by default in recent git; on older git `gc --auto` detached once it had work), so it can still be writing into `.git` when the fixture's `rmtree` runs a few milliseconds after the class's last commit. Git's own trace (`GIT_TRACE`) shows the spawn on every fixture commit: 450 `run_command: git maintenance run --auto --quiet` lines over thirty runs locally. Locally (git 2.43) the maintenance process does not detach and the race never fired in thirty niced runs, so the flake is not reproducible here; the pin is red-first on the mechanism instead.

**Fix.** Every git the fixture runs carries `-c maintenance.auto=false -c maintenance.autoDetach=false -c gc.auto=0 -c gc.autoDetach=false -c core.fsmonitor=false`, and `setUpClass` writes the same keys into the repo's own config so a git the kernel runs against the repo obeys them too. Nothing retries the `rmtree`.

**Pin.** `test_the_fixture_forbids_background_git_work` reads each key back from the repo's local config, checks the helper's flags carry it, and traces a commit through the helper: the trace names the commit and no maintenance or gc child. Before the fix the trace named `git maintenance run --auto --quiet`, so the test was red.

Five further traced runs of the class after the fix show zero `run_command` children of any kind.
