### PR TITLE
Tests: one shared git runner for throwaway-repo fixtures forbids background work; the restart-classifier fixture moves onto it (T299, 1 of 2)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -130,6 +130,23 @@ the developer's git configuration (CI has none), and the env identity outranks
 exports its own `GIT_AUTHOR_*` after the floor. `tests/test_tempdir_hygiene.py`
 and `tests/git-hermetic.bats` pin all of it.
 
+**A fixture that builds a throwaway git repository runs git through
+`tests/git_fixture.py`** (`from git_fixture import git, init_repo,
+forbid_background`, registered under the bare name like `romp_load`). Every
+command it runs carries `-c` flags that forbid background work
+(`maintenance.auto`, `maintenance.autoDetach`, `gc.auto`, `gc.autoDetach`,
+`core.fsmonitor`), `init_repo` writes the same keys into the repo's own config,
+and `forbid_background` does so for a clone or worktree the kernel will run git
+against: `git commit`, fetch and merge spawn `git maintenance run --auto`,
+which on recent git detaches from its parent and can still be writing into
+`.git` while the fixture's `TemporaryDirectory` removes the repo (the CI flake
+`Directory not empty: '.git'` from `rmtree`, 2026-09-10). A file keeps its own
+thin runner (its identity, timeout and return shape) and delegates the body;
+read-only git against the real checkout stays a plain `subprocess.run`.
+`tests/test_git_fixture.py` pins the runner with git's own trace: a commit
+through it, and a plain fetch in a `forbid_background` clone, spawn no
+maintenance or gc child.
+
 **A served-page class copies the built `vscode-extension/dist/` with
 `tests.dist_copy.copy_dist`, never `shutil.copytree`.** Under `pytest -n` a
 sibling class's build renames or removes its staging files

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -81,3 +81,7 @@ os.environ["ROMP_SERVE_PORT"] = "1"
 # sys.path itself. One module object either way.
 from . import romp_load as _romp_load  # noqa: E402
 sys.modules.setdefault("romp_load", _romp_load)
+# `from git_fixture import git, init_repo` (tests/git_fixture.py, T299): the throwaway-repo fixtures' one git
+# runner, registered the same way for the same reason.
+from . import git_fixture as _git_fixture  # noqa: E402
+sys.modules.setdefault("git_fixture", _git_fixture)

--- a/tests/git_fixture.py
+++ b/tests/git_fixture.py
@@ -1,0 +1,61 @@
+"""One git runner for every test fixture that builds a throwaway repository (T298, T299).
+
+Every git the fixtures run forbids BACKGROUND work. `git commit` (and fetch, merge, rebase, am) spawns
+`git maintenance run --auto`, which on recent git detaches from its parent (maintenance.autoDetach, on by
+default; older git's `gc --auto` detached once it had work), so the child can still be writing into .git
+while a fixture's TemporaryDirectory removes the repo: the CI flake "OSError: [Errno 39] Directory not
+empty: '.git'" from rmtree (tests/test_restart_classifier.py, the Python 3.10 job, 2026-09-10). The keys
+below ride every invocation as -c flags, and init_repo / forbid_background write them into the repo's own
+config so a git that the KERNEL runs against the repo, through its own subprocess, obeys them too. The
+fsmonitor daemon is off for the same reason on hosts where git has one.
+
+The runner keeps each fixture's habits as parameters rather than choosing for them: the identity (every
+file commits as its own synthetic author), the timeout, whether a failure raises, the environment (files
+that pin git's config floor pass GIT_CONFIG_GLOBAL and friends themselves), and text or bytes output. It
+returns the CompletedProcess; a file's local wrapper keeps whatever shape its call sites expect (a
+stripped stdout, an AssertionError instead of CalledProcessError, nothing).
+"""
+import subprocess
+
+GIT_NO_BACKGROUND = {"maintenance.auto": "false", "maintenance.autoDetach": "false", "gc.auto": "0",
+                     "gc.autoDetach": "false", "core.fsmonitor": "false"}
+GIT_C = [x for k, v in GIT_NO_BACKGROUND.items() for x in ("-c", "%s=%s" % (k, v))]
+
+
+def _ident_pairs(ident):
+    """ident: None, an (email, name) pair, or a mapping of git config keys to values."""
+    if not ident:
+        return []
+    if isinstance(ident, dict):
+        return list(ident.items())
+    email, name = ident
+    return [("user.email", email), ("user.name", name)]
+
+
+def git(repo, *args, env=None, ident=None, timeout=60, check=True, text=True):
+    """`git -C <repo> <no-background flags> [identity flags] <args>`, both streams captured. Returns the
+    CompletedProcess; with check, a nonzero exit raises subprocess.CalledProcessError carrying the captured
+    output, exactly as subprocess.run(check=True) would."""
+    argv = ["git", "-C", str(repo)] + GIT_C + [x for k, v in _ident_pairs(ident) for x in ("-c", "%s=%s" % (k, v))]
+    r = subprocess.run(argv + list(args), capture_output=True, text=text, env=env, timeout=timeout)
+    if check:
+        r.check_returncode()
+    return r
+
+
+def forbid_background(repo, env=None, timeout=60):
+    """Write GIT_NO_BACKGROUND into an EXISTING repo's local config: for a clone or a worktree the fixture
+    did not init itself but that the kernel will run git against. Returns repo."""
+    for k, v in GIT_NO_BACKGROUND.items():
+        git(repo, "config", k, v, env=env, timeout=timeout)
+    return repo
+
+
+def init_repo(path, *init_args, env=None, ident=None, timeout=60):
+    """`git init <init_args>` at path (an existing directory), then forbid_background and, when an
+    identity is given, write it into the repo's local config too. Returns path."""
+    git(path, "init", *init_args, env=env, timeout=timeout)
+    forbid_background(path, env=env, timeout=timeout)
+    for k, v in _ident_pairs(ident):
+        git(path, "config", k, v, env=env, timeout=timeout)
+    return path

--- a/tests/test_git_fixture.py
+++ b/tests/test_git_fixture.py
@@ -3,6 +3,7 @@
 background work, init_repo and forbid_background write the same keys into the repo, and a commit or a
 fetch through the runner spawns no maintenance or gc child, read off git's own trace. Synthetic content;
 hermetic temp dirs; this module loads no romp code."""
+import calendar
 import os
 import subprocess
 import tempfile
@@ -63,7 +64,8 @@ class Runner(unittest.TestCase):
             self.assertEqual(git(td, "config", "--get", "user.name", ident=("pair@TESTHOST", "pair")).stdout.strip(), "pair", "…and a pair does")
             env = dict(os.environ, GIT_AUTHOR_DATE="2026-01-02T03:04:05+0000", GIT_COMMITTER_DATE="2026-01-02T03:04:05+0000")
             git(td, "commit", "-qm", "two", "--allow-empty", env=env)
-            self.assertEqual(git(td, "log", "-1", "--format=%aI").stdout.strip(), "2026-01-02T03:04:05+00:00", "the env reaches git")
+            # compared as epoch seconds: git spells a zero offset in %aI as "+00:00" or "Z" depending on its version
+            self.assertEqual(git(td, "log", "-1", "--format=%at").stdout.strip(), str(calendar.timegm((2026, 1, 2, 3, 4, 5, 0, 0, 0))), "the env reaches git")
 
 
 class NoBackgroundWork(unittest.TestCase):

--- a/tests/test_git_fixture.py
+++ b/tests/test_git_fixture.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""tests/git_fixture.py, the one git runner for throwaway-repo fixtures (T299): every invocation forbids
+background work, init_repo and forbid_background write the same keys into the repo, and a commit or a
+fetch through the runner spawns no maintenance or gc child, read off git's own trace. Synthetic content;
+hermetic temp dirs; this module loads no romp code."""
+import os
+import subprocess
+import tempfile
+import unittest
+
+from git_fixture import GIT_C, GIT_NO_BACKGROUND, forbid_background, git, init_repo
+
+IDENT = ("t@TESTHOST", "t")
+
+
+def _traced(fn):
+    """Run fn(env) with GIT_TRACE pointed at a fresh file; return the trace text."""
+    with tempfile.NamedTemporaryFile("r", suffix=".log") as trace:
+        fn(dict(os.environ, GIT_TRACE=trace.name))
+        return trace.read()
+
+
+class Keys(unittest.TestCase):
+    def test_the_keys_forbid_auto_maintenance_gc_their_detach_and_the_fsmonitor_daemon(self):
+        self.assertEqual(GIT_NO_BACKGROUND, {"maintenance.auto": "false", "maintenance.autoDetach": "false",
+                                             "gc.auto": "0", "gc.autoDetach": "false", "core.fsmonitor": "false"})
+        self.assertEqual(GIT_C, [x for k, v in GIT_NO_BACKGROUND.items() for x in ("-c", "%s=%s" % (k, v))])
+
+    def test_every_invocation_carries_the_keys_even_against_a_repo_that_lacks_them(self):
+        with tempfile.TemporaryDirectory() as td:
+            subprocess.run(["git", "init", "-q", td], check=True, capture_output=True)   # a plain init: no local keys
+            for k, v in GIT_NO_BACKGROUND.items():
+                self.assertEqual(git(td, "config", "--get", k).stdout.strip(), v, k + " rides the command line")
+                self.assertNotEqual(git(td, "config", "--local", "--get", k, check=False).returncode, 0, "…and only there")
+
+
+class Runner(unittest.TestCase):
+    def test_a_failure_raises_calledprocesserror_with_the_captured_streams_and_check_false_returns_it(self):
+        with tempfile.TemporaryDirectory() as td:
+            init_repo(td, "-q")
+            with self.assertRaises(subprocess.CalledProcessError) as cm:
+                git(td, "rev-parse", "--verify", "no-such-ref")
+            self.assertEqual(cm.exception.returncode, 128)
+            self.assertIn("fatal", cm.exception.stderr)
+            r = git(td, "rev-parse", "--verify", "no-such-ref", check=False)
+            self.assertEqual(r.returncode, 128)
+            self.assertIsInstance(git(td, "rev-parse", "--git-dir").stdout, str)
+            self.assertIsInstance(git(td, "rev-parse", "--git-dir", text=False).stdout, bytes)
+
+    def test_the_identity_env_and_init_args_pass_through(self):
+        with tempfile.TemporaryDirectory() as td:
+            init_repo(td, "-q", "-b", "main", ident=IDENT)
+            self.assertEqual(git(td, "symbolic-ref", "--short", "HEAD").stdout.strip(), "main", "init args reach git init")
+            self.assertEqual(git(td, "config", "--local", "--get", "user.email").stdout.strip(), IDENT[0], "the identity lands in the repo")
+            open(os.path.join(td, "a"), "w").write("a\n")
+            git(td, "add", "a")
+            git(td, "commit", "-qm", "one")
+            # a per-call identity rides the command line as -c flags (read back through config: under the
+            # suite the conftest floor sets the author through GIT_AUTHOR_* variables, which git ranks above
+            # every config, so the commit's author cannot show which config won)
+            r = git(td, "config", "--get", "user.name", ident={"user.email": "other@TESTHOST", "user.name": "other"})
+            self.assertEqual(r.stdout.strip(), "other", "a per-call identity (a mapping) reaches git")
+            self.assertEqual(git(td, "config", "--get", "user.name", ident=("pair@TESTHOST", "pair")).stdout.strip(), "pair", "…and a pair does")
+            env = dict(os.environ, GIT_AUTHOR_DATE="2026-01-02T03:04:05+0000", GIT_COMMITTER_DATE="2026-01-02T03:04:05+0000")
+            git(td, "commit", "-qm", "two", "--allow-empty", env=env)
+            self.assertEqual(git(td, "log", "-1", "--format=%aI").stdout.strip(), "2026-01-02T03:04:05+00:00", "the env reaches git")
+
+
+class NoBackgroundWork(unittest.TestCase):
+    def test_init_repo_writes_the_keys_into_the_repo_and_a_commit_through_the_runner_spawns_no_child(self):
+        with tempfile.TemporaryDirectory() as td:
+            init_repo(td, "-q", ident=IDENT)
+            for k, v in GIT_NO_BACKGROUND.items():
+                self.assertEqual(git(td, "config", "--local", "--get", k).stdout.strip(), v, k)
+            open(os.path.join(td, "a"), "w").write("a\n")
+            git(td, "add", "a")
+            t = _traced(lambda env: git(td, "commit", "-qm", "traced", env=env))
+        self.assertIn("built-in: git commit", t, "the trace is on")
+        self.assertNotIn("maintenance", t, "no auto-maintenance child:\n" + t)
+        self.assertNotIn("run_command: git gc", t, "no gc child")
+
+    def test_a_clone_lacks_the_keys_until_forbid_background_and_then_a_fetch_spawns_no_child(self):
+        # the kernel's update paths fetch and merge into clones the fixture did not init: forbid_background
+        # is what covers a git the kernel runs there, and `fetch` is one of the commands that runs auto
+        # maintenance afterwards
+        with tempfile.TemporaryDirectory() as td:
+            src, clone = os.path.join(td, "src"), os.path.join(td, "clone")
+            os.makedirs(src)
+            init_repo(src, "-q", "-b", "main", ident=IDENT)
+            git(src, "commit", "-qm", "seed", "--allow-empty")
+            subprocess.run(["git", "clone", "-q", src, clone], check=True, capture_output=True)   # a plain clone, as the kernel's would be
+            self.assertNotEqual(git(clone, "config", "--local", "--get", "maintenance.auto", check=False).returncode, 0, "a clone starts without the keys")
+            forbid_background(clone)
+            for k, v in GIT_NO_BACKGROUND.items():
+                self.assertEqual(git(clone, "config", "--local", "--get", k).stdout.strip(), v, k)
+            git(src, "commit", "-qm", "more", "--allow-empty")
+            # a PLAIN git (no -c flags: the kernel's own subprocess) fetching in the clone, traced
+            t = _traced(lambda env: subprocess.run(["git", "-C", clone, "fetch", "-q", "origin"], check=True, capture_output=True, env=env))
+        self.assertIn("built-in: git fetch", t)
+        self.assertNotIn("maintenance", t, "the repo's config alone keeps a plain git from spawning maintenance:\n" + t)
+        self.assertNotIn("run_command: git gc", t)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_classifier.py
+++ b/tests/test_restart_classifier.py
@@ -11,9 +11,9 @@ Every verdict below is driven through a REAL throwaway git repo — the exact di
 dispatch names — never a mocked file list. Synthetic content only; hermetic state."""
 import json
 import os
-import subprocess
 import tempfile
 import unittest
+from git_fixture import GIT_C, GIT_NO_BACKGROUND, git, init_repo
 from romp_load import load_source
 from pathlib import Path
 
@@ -29,19 +29,13 @@ load_source("romp_judge", os.path.join(BIN, "romp-judge"))
 km = load_source("romp_kernel_rclass", os.path.join(BIN, "romp-kernel"))
 
 
-# T298: every git the fixture runs forbids BACKGROUND work. `git commit` spawns `git maintenance run --auto`,
-# which on current git detaches from its parent (maintenance.autoDetach, on by default in recent git; older git's
-# `gc --auto` detached once it had work) and can still be writing into .git while tearDownClass removes the
-# temp repo — the CI flake "Directory not empty: '.git'" raised by TemporaryDirectory.cleanup's rmtree (the
-# Python 3.10 job, 2026-09-10). The repo's own config carries the same keys (setUpClass), so a git the KERNEL
-# runs against the repo obeys them too; fsmonitor is off for the same reason on hosts where it has a daemon.
-GIT_NO_BACKGROUND = {"maintenance.auto": "false", "maintenance.autoDetach": "false", "gc.auto": "0",
-                     "gc.autoDetach": "false", "core.fsmonitor": "false"}
-_GIT_C = [x for k, v in GIT_NO_BACKGROUND.items() for x in ("-c", "%s=%s" % (k, v))]
-
-
+# T298/T299: every git the fixture runs forbids BACKGROUND work, through the suite's shared runner
+# (tests/git_fixture.py, which explains why: `git commit` spawns `git maintenance run --auto`, which on recent
+# git detaches and can still be writing into .git while tearDownClass removes the temp repo — the CI flake
+# "Directory not empty: '.git'" from TemporaryDirectory.cleanup's rmtree, the Python 3.10 job, 2026-09-10).
+# init_repo writes the same keys into the repo's own config, so a git the KERNEL runs against it obeys them too.
 def _git(repo, *args, env=None):
-    r = subprocess.run(["git", "-C", str(repo)] + _GIT_C + list(args), capture_output=True, text=True, env=env)
+    r = git(repo, *args, env=env, check=False)
     assert r.returncode == 0, r.stderr
     return r.stdout.strip()
 
@@ -56,9 +50,7 @@ class RealDiffShapes(unittest.TestCase):
         cls.repo = repo
         for sub in ("kernel", "bin", "postal", "cli", "docs", "tests", "ui/webview"):
             (repo / sub).mkdir(parents=True)
-        _git(repo, "init", "-q")
-        for k, v in GIT_NO_BACKGROUND.items():   # T298: in the repo too, for any git run against it
-            _git(repo, "config", k, v)
+        init_repo(repo, "-q")   # T298: the no-background keys land in the repo too, for any git run against it
         _git(repo, "config", "user.email", "t@TESTHOST")
         _git(repo, "config", "user.name", "t")
         (repo / "kernel/mod.py").write_text('def f():\n    """doc."""\n    return 1  # one\n')
@@ -213,7 +205,7 @@ class RealDiffShapes(unittest.TestCase):
         # through the helper spawns none.
         for k, v in GIT_NO_BACKGROUND.items():
             self.assertEqual(_git(self.repo, "config", "--local", "--get", k), v, "the repo's config carries " + k)
-            self.assertIn("%s=%s" % (k, v), _GIT_C, "…and so does every helper invocation")
+            self.assertIn("%s=%s" % (k, v), GIT_C, "…and so does every runner invocation")
         self._reset()
         (self.repo / "docs/a.md").write_text("# docs, traced\n")
         with tempfile.NamedTemporaryFile("r", suffix=".log") as trace:


### PR DESCRIPTION
Follow-up to the restart-classifier flake fix (the `Directory not empty: '.git'` teardown error): the no-background git configuration moves into one shared runner for every test fixture that builds a throwaway git repository. This is the first of two PRs; the second moves the twelve other files onto it (kept separate so each stays reviewable).

**The helper**, `tests/git_fixture.py`: `GIT_NO_BACKGROUND` (maintenance.auto, maintenance.autoDetach, gc.auto, gc.autoDetach, core.fsmonitor), `git(repo, *args, env=None, ident=None, timeout=60, check=True, text=True)` running every command with the keys as `-c` flags, `init_repo(path, *init_args, ...)` writing them into the repo's own config at init, and `forbid_background(repo)` for a clone or worktree the kernel will run git against. The docstring carries the why: `git commit`, fetch and merge spawn `git maintenance run --auto`, which on recent git detaches from its parent and can still be writing into `.git` while a fixture's `TemporaryDirectory` removes the repo. `tests/__init__.py` registers the module under its bare name the way it does `romp_load`; `tests/README.md` says where fixture git goes.

**Pins**, `tests/test_git_fixture.py`: the keys ride every invocation even against a repo that lacks them; `init_repo` and `forbid_background` land them in the repo; a commit through the runner, and a plain fetch (no flags, as the kernel's own subprocess would run it) in a `forbid_background` clone, spawn no maintenance or gc child, read off `GIT_TRACE`; failures raise `CalledProcessError` with the streams attached and `check=False` returns the process; identity, env and init args pass through. The restart-classifier fixture's runner delegates to the shared one, keeping its shape and its own per-file pin (its kernel-run git reads the repo). No assertion changes beyond that pin's constant rename.
