### PR TITLE
Tests: twelve throwaway-repo fixtures move onto the shared no-background git runner (T299, 2 of 2)

### DIFF
--- a/tests/test_converge_main_branch.py
+++ b/tests/test_converge_main_branch.py
@@ -11,9 +11,9 @@ checkout, a second clone to advance the remote's main.
 
 Hermetic state, synthetic content; the restart leg is stopped before the manager POST."""
 import os
-import subprocess
 import tempfile
 import unittest
+from git_fixture import git as fixture_git, init_repo, forbid_background
 from romp_load import load_source
 from pathlib import Path
 from unittest import mock
@@ -35,8 +35,13 @@ else:
     os.environ["ROMP_STATE_DIR"] = _PREV_STATE_DIR
 
 
+# T299: every git here goes through the suite's shared runner (tests/git_fixture.py), which forbids BACKGROUND
+# work: `git commit`, fetch and merge spawn `git maintenance run --auto`, which on recent git detaches from its
+# parent and can still be writing into .git while the TemporaryDirectory removes the repo (the CI flake
+# "Directory not empty: '.git'", tests/test_restart_classifier.py, 2026-09-10). init_repo writes the same keys
+# into each fixture repo's own config, so the git the KERNEL runs against the checkout obeys them too.
 def git(cwd, *args):
-    r = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=30)
+    r = fixture_git(cwd, *args, timeout=30, check=False)
     if r.returncode != 0:
         raise AssertionError("git %s failed: %s%s" % (" ".join(args), r.stdout, r.stderr))
     return r.stdout.strip()
@@ -56,12 +61,14 @@ class ConvergeMovesMain(unittest.TestCase):
         self.remote = root / "remote.git"
         seed = root / "seed"
         seed.mkdir()
-        git(seed, "init", "-q", "-b", "main")
+        init_repo(seed, "-q", "-b", "main")
         self.base = commit(seed, "one")
-        git(seed, "init", "-q", "--bare", "-b", "main", str(self.remote))   # HEAD -> main, so clones start on main
+        self.remote.mkdir()
+        init_repo(self.remote, "-q", "--bare", "-b", "main")   # HEAD -> main, so clones start on main
         git(seed, "push", "-q", str(self.remote), "main")
         self.checkout = root / "checkout"
         git(root, "clone", "-q", str(self.remote), str(self.checkout))
+        forbid_background(self.checkout)   # the kernel runs git against this clone through its own subprocess
         # advance the remote's main from a second clone: the target the verdict advertises
         other = root / "other"
         git(root, "clone", "-q", str(self.remote), str(other))
@@ -91,8 +98,7 @@ class ConvergeMovesMain(unittest.TestCase):
             return list(km._SYNC_NOTICES)
 
     def head_branch(self):
-        r = subprocess.run(["git", "symbolic-ref", "-q", "--short", "HEAD"], cwd=str(self.checkout),
-                           capture_output=True, text=True)
+        r = fixture_git(self.checkout, "symbolic-ref", "-q", "--short", "HEAD", check=False)   # exits 1 when detached
         return r.stdout.strip()
 
     def test_main_that_is_an_ancestor_is_fast_forwarded_and_checked_out(self):
@@ -145,6 +151,13 @@ class ConvergeMovesMain(unittest.TestCase):
         self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "HEAD"), local)
         self.assertEqual(git(self.checkout, "rev-parse", "--short=8", "main"), local)
         self.assertTrue(any("not a fast-forward" in n["text"] and not n["ok"] for n in self.notices()))
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # T299: the kernel runs its own `git fetch` / `git checkout` against the checkout (and the fetch reaches
+        # the bare remote), so the no-background keys must sit in each repo's own config, not only ride the
+        # fixture runner's -c flags
+        for repo in (self.checkout, self.remote):
+            self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto"), "false", str(repo))
 
 
 if __name__ == "__main__":

--- a/tests/test_file_github.py
+++ b/tests/test_file_github.py
@@ -29,6 +29,7 @@ os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 # pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+from git_fixture import git, init_repo
 km = load_source("romp_kernel_github", os.path.join(BIN, "romp-kernel"))
 
 
@@ -38,12 +39,18 @@ km = load_source("romp_kernel_github", os.path.join(BIN, "romp-kernel"))
 # process environment's git, as in production — and the tests whose kernel call reaches origin pin
 # THAT environment the same way (_WithOrigin below). GIT_CONFIG_GLOBAL is honoured by git >= 2.32.
 _GIT_ENV = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+_IDENT = ("t@testhost", "t")
+
+
+def _git_env():
+    return dict(_GIT_ENV, GIT_SSH_COMMAND=os.environ.get("GIT_SSH_COMMAND", "ssh"))
 
 
 def _git(*args, cwd):
-    subprocess.run(["git", "-c", "user.email=t@testhost", "-c", "user.name=t"] + list(args),
-                   cwd=cwd, check=True, capture_output=True,
-                   env=dict(_GIT_ENV, GIT_SSH_COMMAND=os.environ.get("GIT_SSH_COMMAND", "ssh")))
+    # Through the shared runner: `git commit`, fetch and merge spawn a detached `git maintenance run --auto`
+    # that can still be writing into .git while the fixture tempdir is removed (the CI flake "Directory not
+    # empty: '.git'", 2026-09-10); git_fixture forbids that work on every call and in every repo init_repo makes.
+    git(cwd, *args, ident=_IDENT, env=_git_env(), text=False)
 
 
 def _local_origin(repo):
@@ -55,8 +62,8 @@ def _local_origin(repo):
     so origin starts with that branch. Returns the root; the caller owns restoring GIT_SSH_COMMAND."""
     root = tempfile.mkdtemp()
     bare = os.path.join(root, "TESTORG", "notes-api.git")
-    os.makedirs(os.path.dirname(bare))
-    _git("init", "-q", "--bare", bare, cwd=root)
+    os.makedirs(bare)
+    init_repo(bare, "-q", "--bare", ident=_IDENT, env=_git_env())
     sh = os.path.join(root, "stand-in-ssh")
     with open(sh, "w") as f:
         f.write('#!/bin/sh\nfor a in "$@"; do cmd=$a; done\ncd "%s" && eval "$cmd"\n' % root)
@@ -96,7 +103,7 @@ def _git_version():
 class _Repo(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
-        _git("init", "-q", "-b", "main", cwd=self.tmp)
+        init_repo(self.tmp, "-q", "-b", "main", ident=_IDENT, env=_git_env())
         os.makedirs(os.path.join(self.tmp, "src", "deep dir"))
         self.fp = os.path.join(self.tmp, "src", "app.py")
         with open(self.fp, "w") as f:
@@ -173,8 +180,7 @@ class GitHubUrl(_Repo):
 
     def test_a_detached_head_links_the_sha(self):
         _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=self.tmp)
-        sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,
-                             capture_output=True, text=True).stdout.strip()
+        sha = git(self.tmp, "rev-parse", "HEAD", check=False).stdout.strip()
         _git("checkout", "-q", sha, cwd=self.tmp)
         self.assertEqual(km._file_github_url(self.fp, None),
                          "https://github.com/TESTORG/notes-api/blob/%s/src/app.py" % sha)
@@ -250,7 +256,7 @@ class GitHubUrl(_Repo):
     def test_a_file_staged_on_no_commit_is_not_committed(self):
         # an unborn branch: ls-files sees the index entry, but HEAD names nothing to link
         fresh = tempfile.mkdtemp()
-        _git("init", "-q", "-b", "main", cwd=fresh)
+        init_repo(fresh, "-q", "-b", "main", ident=_IDENT, env=_git_env())
         _git("remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", cwd=fresh)
         fp = os.path.join(fresh, "new.py")
         with open(fp, "w") as f:
@@ -310,8 +316,7 @@ class GitHubUrl(_Repo):
         os.environ["PATH"] = old + os.pathsep + os.environ["PATH"]
         self.assertEqual(km._file_github_url(self.fp, None),
                          "https://github.com/TESTORG/notes-api/blob/main/src/app.py")
-        sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,
-                             capture_output=True, text=True).stdout.strip()
+        sha = git(self.tmp, "rev-parse", "HEAD", check=False).stdout.strip()
         _git("checkout", "-q", sha, cwd=self.tmp)
         self.assertEqual(km._file_github_url(self.fp, None),
                          "https://github.com/TESTORG/notes-api/blob/%s/src/app.py" % sha,
@@ -426,8 +431,7 @@ class BranchOnOrigin(_WithOrigin):
         self.assertEqual(calls["communicate"], 2, "…and the dead group is reaped")
 
     def test_a_detached_sha_is_never_checked(self):
-        sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=self.tmp,
-                             capture_output=True, text=True).stdout.strip()
+        sha = git(self.tmp, "rev-parse", "HEAD", check=False).stdout.strip()
         _git("checkout", "-q", sha, cwd=self.tmp)
         os.environ["GIT_SSH_COMMAND"] = "false"
         self.assertEqual(km._file_github_link(self.fp, None), (self.URL % sha, ""))
@@ -632,8 +636,8 @@ class NoPromptOnOrigin(_WithOrigin):
         _git("remote", "set-url", "origin", "http://127.0.0.1:%d/TESTORG/notes-api.git" % srv.server_address[1],
              cwd=self.tmp)
         _git("checkout", "-q", "-b", "wip", cwd=self.tmp)
-        subprocess.run(["git", "-C", self.tmp, "ls-remote", "--heads", "origin", "refs/heads/wip"],
-                       env=dict(os.environ, GIT_TERMINAL_PROMPT="0"), capture_output=True, timeout=30)
+        git(self.tmp, "ls-remote", "--heads", "origin", "refs/heads/wip",
+            env=dict(os.environ, GIT_TERMINAL_PROMPT="0"), timeout=30, check=False, text=False)
         self.assertTrue(os.path.exists(marker), "control: under GIT_TERMINAL_PROMPT=0 alone git runs the askpass")
         os.remove(marker)
         self.assertIsNone(km._origin_has_branch(self.tmp, "wip"), "a credential-wanting origin reads as unchecked")
@@ -678,6 +682,17 @@ class GitLinkWire(_WithOrigin):
         r = self.send_and_wait({"type": "fileGitLink", "path": self.fp, "reqId": 8})
         self.assertEqual(r["url"], "https://github.com/TESTORG/notes-api/blob/wip/src/app.py")
         self.assertEqual(r["reason"], "branch wip is not on origin")
+
+
+class FixtureReposForbidBackgroundGitWork(_WithOrigin):
+    """The kernel runs its own git against these repos (rev-parse, ls-files, ls-remote through the stand-in
+    ssh into the bare origin), so the no-background keys must sit in each repo's LOCAL config, not only ride
+    the fixture runner's -c flags."""
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        for repo in (self.tmp, os.path.join(self.root, "TESTORG", "notes-api.git")):
+            self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(),
+                             "false", repo)
 
 
 if __name__ == "__main__":

--- a/tests/test_git_pointer_file_bytes.py
+++ b/tests/test_git_pointer_file_bytes.py
@@ -20,13 +20,13 @@ import contextlib
 import io
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import threading
 import unittest
 from datetime import datetime, timezone
 from romp_load import load_source
+from git_fixture import git, init_repo, forbid_background
 from pathlib import Path
 from unittest import mock
 
@@ -67,15 +67,20 @@ def _tm():
             "context": None, "compactPct": None, "backend": "tmux"}
 
 
+_IDENT = ("t@TESTHOST", "t")                    # the fixture's synthetic author
+
+
 def _git(*args, cwd):
-    subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t", *args],
-                   cwd=cwd, capture_output=True, text=True, timeout=10, check=True)
+    # Through the shared runner: `git commit` (and fetch, merge) spawn `git maintenance run --auto`, which detaches
+    # and can still be writing into .git while TemporaryDirectory removes the repo (the CI flake "Directory not
+    # empty: '.git'", 2026-09-10); the runner forbids that background work on every invocation and every repo it inits.
+    git(cwd, *args, ident=_IDENT, timeout=10)
 
 
 def _mk_repo(td, name="repo"):
     repo = Path(td) / name
     repo.mkdir()
-    _git("init", "-q", "-b", "main", cwd=repo)
+    init_repo(repo, "-q", "-b", "main", ident=_IDENT, timeout=10)
     (repo / "a.txt").write_text("a\n")
     _git("add", "a.txt", cwd=repo)
     _git("commit", "-q", "-m", "seed", cwd=repo)
@@ -202,9 +207,9 @@ class Resolver(unittest.TestCase):
             repo = _mk_repo(parent)
             wt = Path(td) / "wt"                                    # a clean cwd, as the registry carries it
             _git("worktree", "add", "-q", "-b", "feature", str(wt), cwd=repo)
+            forbid_background(wt)                                   # the kernel forks its own git against it
             self.assertIn(b"\xe9", (wt / ".git").read_bytes(), "premise: git wrote the byte into the pointer")
-            r = subprocess.run(["git", "-C", str(wt), "rev-parse", "--abbrev-ref", "HEAD"],
-                               capture_output=True, text=True, timeout=10)
+            r = git(wt, "rev-parse", "--abbrev-ref", "HEAD", check=False, timeout=10)
             self.assertEqual((r.returncode, r.stdout.strip()), (0, "feature"), "premise: git reads it fine")
             with _stderr() as err, mock.patch.object(km.subprocess, "run", wraps=km.subprocess.run) as run:
                 hp = km._git_head_file(str(wt))
@@ -385,6 +390,21 @@ class PushCycle(unittest.TestCase):
         self.assertTrue(seen, "premise: the second push re-derived the torn pointer file's fault (a fault is never cached)")
         self.assertEqual([l for l in err2.splitlines() if str(self.torn / ".git") in l], [],
                          "a second push logs nothing new: %r" % err2.splitlines())
+
+
+class FixtureRepos(unittest.TestCase):
+    """The kernel forks its own git against the fixture repos (the rev-parse fallback, the worktree's branch), so
+    the no-background keys must sit in each repo's config, not only on the fixture runner's command line."""
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        with tempfile.TemporaryDirectory() as td:
+            repo = _mk_repo(td)
+            wt = Path(td) / "wt"
+            _git("worktree", "add", "-q", "-b", "feature", str(wt), cwd=repo)
+            forbid_background(wt)
+            for path in (repo, wt):
+                self.assertEqual(git(path, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false",
+                                 "background git work is forbidden in %s" % path)
 
 
 if __name__ == "__main__":

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -32,6 +32,7 @@ import subprocess
 import tempfile
 import unittest
 from romp_load import load_source
+from git_fixture import git, init_repo, forbid_background
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -52,16 +53,22 @@ REPO = "example-org/notes-api"
 PRIVATE_SID = "7a7a7a7a-1a1a-4b4b-8c8c-9d9d9d9d9d9d"
 
 
+IDENT = ("t@TESTHOST", "t")   # the fixtures' synthetic author, on every invocation and in every repo's config
+
+
 def _git(*args, cwd):
-    subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t"] + list(args),
-                   cwd=cwd, check=True, capture_output=True)
+    # through the suite's shared runner (tests/git_fixture.py, T299), which forbids git's BACKGROUND work:
+    # `git commit`, fetch and merge spawn `git maintenance run --auto`, which on recent git detaches from its
+    # parent and can still be writing into .git while the temp dir is removed (the CI flake "Directory not
+    # empty: '.git'", tests/test_restart_classifier.py, 2026-09-10). Bytes output and check=True, as before.
+    git(cwd, *args, ident=IDENT, text=False)
 
 
 def _repo(root, name, origin=None):
     """A one-commit repo on branch main under `root`, with `origin` set when given."""
     d = os.path.join(root, name)
     os.makedirs(d)
-    _git("init", "-q", "-b", "main", cwd=d)
+    init_repo(d, "-q", "-b", "main", ident=IDENT)
     with open(os.path.join(d, "f.txt"), "w") as f:
         f.write("x\n")
     _git("add", "f.txt", cwd=d)
@@ -92,6 +99,7 @@ class _Fixtures(unittest.TestCase):
         os.makedirs(cls.sub)
         cls.wt = os.path.join(cls.root, "https-repo-feature")
         _git("worktree", "add", "-q", "-b", "feature", cls.wt, "HEAD", cwd=cls.https)
+        forbid_background(cls.wt)
         cls.ssh = _repo(cls.root, "ssh-repo", SSH_ORIGIN)
         cls.elsewhere = _repo(cls.root, "elsewhere-repo", ELSEWHERE_ORIGIN)
         cls.noorigin = _repo(cls.root, "no-origin-repo")
@@ -144,6 +152,12 @@ class GitHubRepoOf(_Fixtures):
         src = inspect.getsource(km._github_repo_of)
         self.assertIn("_GITHUB_REMOTE.match(remote)", src, "one spelling of what counts as GitHub")
         self.assertIn('_git_out(["remote", "get-url", "origin"], top)', src, "the same authoritative read")
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # the kernel's own git runs against these through its subprocess, not _git: the keys live in each
+        # repo's local config (a worktree reads its clone's), so that git obeys them too
+        for repo in (self.https, self.wt, self.ssh, self.elsewhere, self.noorigin):
+            self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false", repo)
 
 
 class Memo(unittest.TestCase):
@@ -225,7 +239,7 @@ class LateRepo(unittest.TestCase):
     def _init_with_origin(self, d):
         """What `git init` + a first commit + `gh repo create --push` leave behind (an unborn branch — init
         with no commit — reads as no branch, like a detached HEAD; the repo is still found)."""
-        _git("init", "-q", "-b", "main", cwd=d)
+        init_repo(d, "-q", "-b", "main", ident=IDENT)
         with open(os.path.join(d, "f.txt"), "w") as f:
             f.write("x\n")
         _git("add", "f.txt", cwd=d)
@@ -341,7 +355,7 @@ class RejectedDotGit(unittest.TestCase):
         self.assertEqual(self._build(sub), [(("", ""), None, None)] * 3)
         self.assertEqual(self.forks, {"--show-toplevel": 1}, "git rejects the empty .git once; no build after it forks")
         # `git init` populates the directory (its mtime moves): the next call asks git again and finds the tree
-        _git("init", "-q", "-b", "main", cwd=proj)
+        init_repo(proj, "-q", "-b", "main", ident=IDENT)
         _git("remote", "add", "origin", HTTPS_ORIGIN, cwd=proj)
         self.assertEqual(km._github_repo_of(sub), REPO)
         self.assertEqual(self.forks["--show-toplevel"], 2)
@@ -358,7 +372,7 @@ class RejectedDotGit(unittest.TestCase):
         top = os.path.realpath(plain)
         self.assertEqual(self._build(svc), [((top, "main"), REPO, REPO)] * 3, "found: the PARENT's tree, as git says")
         self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1, "get-url": 1}, "asked once, then stats")
-        _git("init", "-q", "-b", "svc", cwd=svc)
+        init_repo(svc, "-q", "-b", "svc", ident=IDENT)
         with open(os.path.join(svc, "g.txt"), "w") as f:
             f.write("y\n")
         _git("add", "g.txt", cwd=svc)
@@ -395,6 +409,7 @@ class RejectedDotGit(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-x")
         _git("worktree", "add", "-q", "-b", "x", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         self.assertEqual(km._github_repo_of(wt), REPO, "a live worktree names the clone's repo")
         backup = os.path.join(self.root, "backup")
         shutil.copytree(main, backup, symlinks=True)
@@ -416,6 +431,7 @@ class RejectedDotGit(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-y")
         _git("worktree", "add", "-q", "-b", "y", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         pointer = os.path.join(wt, ".git")
         good = open(pointer).read()
         with open(pointer, "w") as f:
@@ -495,6 +511,7 @@ class DeadOrReshapedTree(unittest.TestCase):
         other = _repo(self.root, "other", "https://github.com/other-org/other-repo.git")
         shutil.rmtree(solo)
         _git("worktree", "add", "-q", "-b", "reshaped", solo, "HEAD", cwd=other)   # .git is a FILE now
+        forbid_background(solo)
         self.forks.clear()
         self.assertEqual(self._builds(solo), [("reshaped", "other-org/other-repo")] * 3,
                          "the new shape's branch and repo, from its pointer file")
@@ -512,6 +529,7 @@ class DeadOrReshapedTree(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-web")
         _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
         shutil.rmtree(wt)
         _repo(self.root, "main-web", "https://github.com/other-org/fresh.git")   # a plain clone where the worktree was
@@ -531,9 +549,11 @@ class DeadOrReshapedTree(unittest.TestCase):
         b = _repo(self.root, "b", "https://github.com/other-org/fork.git")
         wt = os.path.join(self.root, "shared-name")
         _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=a)
+        forbid_background(wt)
         self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
         shutil.rmtree(wt)
         _git("worktree", "add", "-q", "-b", "feature", wt, "HEAD", cwd=b)
+        forbid_background(wt)
         _bump_mtime(os.path.join(wt, ".git"))   # a new pointer; its mtime must differ even within one clock tick
         self.forks.clear()
         self.assertEqual(self._builds(wt), [("feature", "other-org/fork")] * 3)
@@ -551,12 +571,14 @@ class DeadOrReshapedTree(unittest.TestCase):
         b = _repo(self.root, "b", "https://github.com/other-org/fork.git")
         wt = os.path.join(self.root, "shared-name")
         _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=a)
+        forbid_background(wt)
         self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
         pointer = os.path.join(wt, ".git")
         old = os.stat(pointer)
         os.link(pointer, os.path.join(self.root, "keep-the-old-pointer-allocated"))
         shutil.rmtree(wt)
         _git("worktree", "add", "-q", "-b", "feature", wt, "HEAD", cwd=b)
+        forbid_background(wt)
         os.utime(pointer, ns=(old.st_atime_ns, old.st_mtime_ns))   # the same tick, as a coarse filesystem reports it
         new = os.stat(pointer)
         self.assertEqual(new.st_mtime, old.st_mtime, "the mtime says nothing changed")
@@ -604,6 +626,7 @@ class DeadOrReshapedTree(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-web")
         _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
         top = os.path.realpath(wt)
         self.assertIn(top, km._top_shape)
@@ -643,6 +666,7 @@ class DeadOrReshapedTree(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-web")
         _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         self.assertEqual(self._builds(wt), [("web", REPO)] * 3)
         self.assertEqual(self._builds(main), [("main", REPO)] * 3)
         self.forks.clear()
@@ -713,6 +737,7 @@ class PerCallCost(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-web")
         _git("worktree", "add", "-q", "-b", "web", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         self.assertEqual(self._cost(lambda: km._tree_of(main)), (2, 0), "the chain's stat and HEAD's")
         self.assertEqual(self._cost(lambda: km._tree_of(wt)), (3, 0), "…plus the pointer target's; the pointer itself is not read")
         self.assertEqual(self._cost(lambda: km._github_repo_of(wt)), (4, 0), "…plus the config file's")
@@ -726,6 +751,7 @@ class PerCallCost(unittest.TestCase):
         main = _repo(self.root, "main", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-x")
         _git("worktree", "add", "-q", "-b", "x", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         self.assertEqual(self._cost(lambda: km._tree_of(wt)), (3, 0))
         pointer = os.path.join(wt, ".git")
         with open(pointer) as f:
@@ -770,6 +796,7 @@ class BareRepository(unittest.TestCase):
         src = _repo(self.root, "src", HTTPS_ORIGIN)
         bare = os.path.join(self.root, "bare.git")
         _git("clone", "-q", "--bare", src, bare, cwd=self.root)
+        forbid_background(bare)
         self.assertEqual([km._git_branch(bare) for _ in range(3)], ["main"] * 3)
         self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1}, "asked once each, then memoized")
         self.assertIsNone(km._github_repo_of(bare), "no work tree, no tree-derived repo — as before")
@@ -783,8 +810,10 @@ class BareRepository(unittest.TestCase):
         src = _repo(self.root, "src", HTTPS_ORIGIN)
         bare = os.path.join(self.root, "bare.git")
         _git("clone", "-q", "--bare", src, bare, cwd=self.root)
+        forbid_background(bare)
         wt = os.path.join(self.root, "topic")
         _git("worktree", "add", "-q", "-b", "topic", wt, "main", cwd=bare)
+        forbid_background(wt)
         self.assertEqual(km._git_branch(wt), "topic")
         self.assertEqual(km._github_repo_of(wt), None, "the bare clone has no origin remote")
 
@@ -927,6 +956,7 @@ class ConfigFile(unittest.TestCase):
         main = _repo(self.root, "main-repo", HTTPS_ORIGIN)
         wt = os.path.join(self.root, "main-repo-wt")
         _git("worktree", "add", "-q", "-b", "wtb", wt, "HEAD", cwd=main)
+        forbid_background(wt)
         with open(os.path.join(wt, ".git")) as f:
             gd = f.readline().strip()[len("gitdir:"):].strip()
         self.assertTrue(os.path.isabs(gd), "git writes the pointer absolute")

--- a/tests/test_kernel_fork_burn.py
+++ b/tests/test_kernel_fork_burn.py
@@ -18,7 +18,6 @@ per session per pass:
 
 Real git repos in temp dirs; fork counts observed by wrapping subprocess.run. SYNTHETIC only."""
 import os
-import subprocess
 import tempfile
 import unittest
 from romp_load import load_source
@@ -30,19 +29,23 @@ os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+from git_fixture import git, init_repo, forbid_background
 load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
 load_source("romp_judge", os.path.join(BIN, "romp-judge"))
 km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
 
 
 def _git(*args, cwd):
-    subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=10, check=True)
+    # Through the shared runner: `git commit` spawns `git maintenance run --auto`, which detaches and can still
+    # be writing into .git while the TemporaryDirectory removes the repo (the CI flake "Directory not empty:
+    # '.git'", tests/test_restart_classifier.py, 2026-09-10); the runner forbids that work on every call.
+    git(cwd, *args, timeout=10)
 
 
 def _mk_repo(td):
     repo = Path(td) / "repo"
     repo.mkdir()
-    _git("init", "-q", "-b", "main", cwd=repo)
+    init_repo(repo, "-q", "-b", "main", timeout=10)
     _git("config", "user.email", "t@TESTHOST", cwd=repo)
     _git("config", "user.name", "t", cwd=repo)
     (repo / "a.txt").write_text("a\n")
@@ -73,6 +76,7 @@ class WorktreeBranchCache(unittest.TestCase):
             repo = _mk_repo(td)
             wt = Path(td) / "wt"
             _git("worktree", "add", "-q", "-b", "feature", str(wt), "HEAD", cwd=repo)
+            forbid_background(wt)
             km._branch_cache.clear(); km._head_path_cache.clear()
             with ForkCounter() as fc:
                 self.assertEqual(km._git_branch(str(wt)), "feature")
@@ -100,6 +104,7 @@ class WorktreeBranchCache(unittest.TestCase):
             repo = _mk_repo(td)
             wt = Path(td) / "wt2"
             _git("worktree", "add", "-q", "-b", "wtb", str(wt), "HEAD", cwd=repo)
+            forbid_background(wt)
             km._head_path_cache.clear()
             self.assertTrue(km._git_head_file(str(repo)).endswith("/.git/HEAD"))
             hp = km._git_head_file(str(wt))
@@ -136,6 +141,20 @@ class HeadTtlOutlastsThePoll(unittest.TestCase):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('if now - _HEAD_CACHE["ts"] > 15:', src,
                       "the /tunnels poll is 4s; a shorter TTL re-forks git on every poll")
+
+
+class FixtureReposForbidBackgroundGitWork(unittest.TestCase):
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # The kernel runs its OWN git against these repos (rev-parse, ls-files), which the runner's -c flags
+        # cannot reach: the repo's local config is what keeps a detached maintenance child out of the
+        # TemporaryDirectory teardown. The worktree shares the main repo's config.
+        with tempfile.TemporaryDirectory() as td:
+            repo = _mk_repo(td)
+            wt = Path(td) / "wt"
+            _git("worktree", "add", "-q", "-b", "feature", str(wt), "HEAD", cwd=repo)
+            forbid_background(wt)
+            for r in (repo, wt):
+                self.assertEqual(git(r, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false")
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_remote_update.py
+++ b/tests/test_kernel_remote_update.py
@@ -10,6 +10,7 @@ import subprocess
 import tempfile
 import unittest
 from romp_load import load_source
+from git_fixture import git, init_repo
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")
@@ -504,12 +505,15 @@ class ApplyHonesty(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.home, True)
         self.repo = os.path.join(self.home, "romp")
         env = dict(os.environ, GIT_CONFIG_GLOBAL="/dev/null", GIT_CONFIG_NOSYSTEM="1", HOME=self.home)
+        # every git here rides the shared runner (T299): `git commit` spawns a detached `git maintenance run
+        # --auto` that can still be writing into .git while the temp dir is removed (the CI flake "Directory
+        # not empty: '.git'", tests/test_restart_classifier.py, 2026-09-10); the runner forbids that work on
+        # every invocation, and init_repo writes the same keys into the repo the apply's own git runs against
         def g(*a, **kw):
-            return subprocess.run(["git", "-C", self.repo] + list(a), capture_output=True, text=True,
-                                  env=env, check=True, **kw).stdout.strip()
+            return git(self.repo, *a, env=env, **kw).stdout.strip()
         self.g = g
         os.makedirs(self.repo)
-        subprocess.run(["git", "init", "-q", "-b", "main", self.repo], check=True, env=env)
+        init_repo(self.repo, "-q", "-b", "main", env=env)
         self.f = os.path.join(self.repo, "f")
         def commit(text, msg):
             with open(self.f, "w") as fh:
@@ -559,8 +563,7 @@ class ApplyHonesty(unittest.TestCase):
         return ok, detail, calls
 
     def _scratch(self):
-        r = subprocess.run(["git", "-C", self.repo, "rev-parse", "--verify", "--quiet", "refs/heads/" + km._P2P_REF],
-                           capture_output=True, text=True)
+        r = git(self.repo, "rev-parse", "--verify", "--quiet", "refs/heads/" + km._P2P_REF, check=False)
         return r.stdout.strip()
 
     def _sibling_push_at_the_apply(self, dirty=False):
@@ -586,6 +589,11 @@ class ApplyHonesty(unittest.TestCase):
                      'exec env -i HOME="%s" PATH="%s:/usr/bin:/bin" ROMP_REPO_ROOT="%s" bash -c "$last"\n'
                      % (self.home, shim_dir, self.repo))
         return lambda: open(marker, "w").close()
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # the probe and the apply run git against this repo through the ssh stub, under `env -i` and the
+        # kernel's own subprocess, so the no-background keys must sit in the repo's own config (T299)
+        self.assertEqual(git(self.repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false")
 
     def test_an_edit_landing_after_the_probe_is_refused_and_survives(self):
         # the probe saw a clean tree; an edit lands before the apply; the apply must see it itself

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -18,6 +18,7 @@ import time
 import unittest
 from unittest import mock
 from romp_load import load_source
+from git_fixture import git, init_repo, forbid_background
 from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -944,13 +945,19 @@ class ReleaseChannelMigration(unittest.TestCase):
         and DETACHED at c3 — ahead of v9.9.9, on no tag: the walked-onto-main shape."""
         env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
                "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid"}
+        # Through the shared runner (T299): `git commit`, fetch and merge spawn `git maintenance run
+        # --auto`, which on recent git detaches and can still be writing into .git while the
+        # TemporaryDirectory removes the repo (the CI flake "Directory not empty: '.git'",
+        # tests/test_restart_classifier.py, 2026-09-10); the runner forbids that work on every call,
+        # and init_repo / forbid_background write the same keys into each repo's own config so the
+        # update script's fetch + merge, run by the kernel's bash and not by this runner, obey them too.
         def g(cwd, *args):
-            r = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True)
+            r = git(cwd, *args, env=env, check=False)
             self.assertEqual(r.returncode, 0, "git %s: %s%s" % (" ".join(args), r.stdout, r.stderr))
             return r.stdout.strip()
         src = os.path.join(tmp, "src")
         os.makedirs(src)
-        g(src, "init", "-q", "-b", "main")
+        init_repo(src, "-q", "-b", "main", env=env)
         with open(os.path.join(src, "install.sh"), "w") as f:
             f.write("#!/bin/sh\nexit 0\n")
         os.chmod(os.path.join(src, "install.sh"), 0o755)
@@ -962,10 +969,22 @@ class ReleaseChannelMigration(unittest.TestCase):
         g(src, "commit", "-qm", "c3", "--allow-empty")
         bare = os.path.join(tmp, "origin.git")
         g(tmp, "clone", "-q", "--bare", src, bare)
+        forbid_background(bare, env=env)                         # the script's fetch is served from here
         inst = os.path.join(tmp, "install")
         g(tmp, "clone", "-q", bare, inst)
+        forbid_background(inst, env=env)                         # the script's fetch + merge run here
         g(inst, "checkout", "-q", "--detach", "origin/main")     # the old banner's walk
         return g, inst
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # The pin for the keys above: the update script runs fetch, merge and checkout against the
+        # install through its own bash (the fetch served from the bare origin), never through g, so
+        # the no-background config must sit in each repo's LOCAL config, not only on the runner's flags.
+        with tempfile.TemporaryDirectory() as tmp:
+            _, inst = self._repos(tmp)
+            for repo in (inst, os.path.join(tmp, "origin.git"), os.path.join(tmp, "src")):
+                self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(),
+                                 "false", repo)
 
     def _run(self, tag, inst):
         """Capture _run_update's script via the Popen seam, run it SYNCHRONOUSLY. The log and
@@ -1121,14 +1140,16 @@ class BootOnTheTag(Fresh):
     def test_a_release_checkout_reads_the_plus_and_the_boot_still_says_it_runs_it(self):
         env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
                "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid"}
+        # the shared runner, for the reason ReleaseChannelMigration._repos gives (T299); the kernel's
+        # own `git rev-parse` reads this repo through ROOT, so init_repo puts the keys in its config
         def g(cwd, *args):
-            r = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True)
+            r = git(cwd, *args, env=env, check=False)
             self.assertEqual(r.returncode, 0, "git %s: %s%s" % (" ".join(args), r.stdout, r.stderr))
             return r.stdout.strip()
         with tempfile.TemporaryDirectory() as tmp:
             src = os.path.join(tmp, "src")
             os.makedirs(src)
-            g(src, "init", "-q", "-b", "main")
+            init_repo(src, "-q", "-b", "main", env=env)
             with open(os.path.join(src, "VERSION"), "w") as f:
                 f.write("9.9.9\n")
             g(src, "add", "VERSION")

--- a/tests/test_kernel_worktree_display.py
+++ b/tests/test_kernel_worktree_display.py
@@ -19,7 +19,6 @@ repos with fixture identities.
 import json
 import os
 import shutil
-import subprocess
 import tempfile
 import unittest
 from romp_load import load_source
@@ -31,11 +30,17 @@ os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XD
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
 km = load_source("romp_kernel_worktree", os.path.join(BIN, "romp-kernel"))
+from git_fixture import git, init_repo, forbid_background
+
+_IDENT = ("t@TESTHOST", "t")
 
 
 def _git(*args, cwd=None):
-    return subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t", *args],
-                          cwd=cwd, capture_output=True, text=True, check=True)
+    # Delegates to the shared runner (tests/git_fixture.py): `git commit`, fetch and merge spawn
+    # `git maintenance run --auto`, which on recent git detaches from its parent and can still be writing
+    # into .git while the fixture's tmp dir is removed (the CI flake "Directory not empty: '.git'",
+    # tests/test_restart_classifier.py, 2026-09-10); the runner forbids that work on every invocation.
+    return git(cwd or ".", *args, ident=_IDENT)
 
 
 class NormBranch(unittest.TestCase):
@@ -85,12 +90,13 @@ class TreeOf(unittest.TestCase):
         cls.root = tempfile.mkdtemp()
         cls.main = os.path.join(cls.root, "repo")
         os.makedirs(cls.main)
-        _git("init", "-q", "-b", "main", cwd=cls.main)
+        init_repo(cls.main, "-q", "-b", "main", ident=_IDENT)
         open(os.path.join(cls.main, "f.txt"), "w").write("x\n")
         _git("add", "f.txt", cwd=cls.main)
         _git("commit", "-q", "-m", "seed", cwd=cls.main)
         cls.wt = os.path.join(cls.root, "repo-feature")
         _git("worktree", "add", "-q", "-b", "feature", cls.wt, "HEAD", cwd=cls.main)
+        forbid_background(cls.wt)   # the kernel's own subprocess runs git here (_tree_of)
         os.makedirs(os.path.join(cls.wt, "sub"))
 
     @classmethod
@@ -111,6 +117,13 @@ class TreeOf(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             self.assertEqual(km._tree_of(d), ("", ""))
         self.assertEqual(km._tree_of(""), ("", ""))
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        """The kernel runs git against both trees through its own subprocess, so the no-background keys
+        must sit in the repo's own config, not only on the fixture runner's command line."""
+        for repo in (self.main, self.wt):
+            self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(),
+                             "false", repo)
 
 
 class PayloadWiring(unittest.TestCase):

--- a/tests/test_perf_bench.py
+++ b/tests/test_perf_bench.py
@@ -50,6 +50,8 @@ os.environ["XDG_STATE_HOME"] = _XDG_TMP
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 atexit.register(shutil.rmtree, _XDG_TMP, ignore_errors=True)
 
+from git_fixture import git, init_repo   # after the state-root preamble; it imports only the standard library
+
 SID_WEB = "11111111-2222-3333-4444-555555555555"
 SID_API = "22222222-3333-4444-5555-666666666666"
 SID_TESTS = "33333333-4444-5555-6666-777777777777"
@@ -195,12 +197,21 @@ def _transcript(path, sid, cwd, n_turns, t0):
 ORIGIN = "https://github.com/example-org/notes-api.git"   # fabricated; `remote get-url` reads config, no network
 
 
+GIT_IDENT = {"user.email": "t@TESTHOST", "user.name": "t", "commit.gpgsign": "false"}   # the fixture's synthetic author
+
+
+def _git_env():
+    """No global or system config: a developer's commit signing or url.insteadOf must not bend the fixture."""
+    return dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+
+
 def _git(*args, cwd):
     """A fixture git call that reads no global or system config (a developer's commit signing or
-    url.insteadOf must not bend the fixture) and commits as a synthetic author."""
-    env = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
-    subprocess.run(["git", "-c", "user.email=t@TESTHOST", "-c", "user.name=t", "-c", "commit.gpgsign=false"] + list(args),
-                   cwd=str(cwd), check=True, capture_output=True, env=env)
+    url.insteadOf must not bend the fixture) and commits as a synthetic author. It runs through the shared
+    runner (tests/git_fixture.py), which forbids background git work: `git commit` spawns `git maintenance
+    run --auto`, which on recent git detaches from its parent and can still be writing into .git while the
+    fixture's directory is removed (the CI flake "Directory not empty: '.git'", 2026-09-10)."""
+    git(cwd, *args, env=_git_env(), ident=GIT_IDENT, text=False)
 
 
 def build_synthetic(root, web_turns=WEB_TURNS, age_api_days=0):
@@ -217,7 +228,7 @@ def build_synthetic(root, web_turns=WEB_TURNS, age_api_days=0):
     state = root / "romp"
     cwd = root / "notes-api"
     cwd.mkdir(parents=True)
-    _git("init", "-q", "-b", "main", cwd=cwd)
+    init_repo(cwd, "-q", "-b", "main", env=_git_env(), ident=GIT_IDENT)
     (cwd / "README.md").write_text("# notes-api\n")
     _git("add", "README.md", cwd=cwd)
     _git("commit", "-q", "-m", "seed", cwd=cwd)
@@ -393,6 +404,12 @@ class PerfBench(unittest.TestCase):
             self.assertEqual(set(b[row]["git_per_build"]) - {"rev-parse", "ls-files"}, set(), "only admitted queries ran")
         checkout, plain = b["build_session_cold:11111111"]["git_per_build"], b["build_session_cold:22222222"]["git_per_build"]
         self.assertLess(sum(checkout.values()), sum(plain.values()), "the checkout's answers are cached across the kept samples: %s vs %s" % (checkout, plain))
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # the kernel's own git queries (rev-parse, ls-files, through the tool's tripwire, not this file's
+        # runner) run against the sessions' checkout, so the no-background keys sit in that repo's own config
+        repo = os.path.join(self.root, "notes-api")
+        self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false")
 
     def test_push_rows_report_bytes_and_rebuild_flags(self):
         b = self._out()["benchmarks"]
@@ -814,7 +831,7 @@ class Tripwire(unittest.TestCase):
         cls.root = tempfile.mkdtemp(prefix="perf-bench-tripwire-")
         cls.repo = os.path.join(cls.root, "notes-api")
         os.makedirs(cls.repo)
-        _git("init", "-q", "-b", "main", cwd=cls.repo)
+        init_repo(cls.repo, "-q", "-b", "main", env=_git_env(), ident=GIT_IDENT)
         _git("remote", "add", "origin", ORIGIN, cwd=cls.repo)
 
     @classmethod
@@ -857,7 +874,7 @@ class Tripwire(unittest.TestCase):
         self.assertEqual(tw.git_calls, {})
         with self.assertRaises(self.pb.BenchError):
             tw.run(["git", "-C", self.repo, "remote"], capture_output=True, text=True)
-        r = subprocess.run(["git", "-C", self.repo, "remote", "get-url", "origin"], capture_output=True, text=True)
+        r = git(self.repo, "remote", "get-url", "origin", check=False)
         self.assertEqual(r.stdout.strip(), ORIGIN, "the refused set-url never ran")
 
     def test_no_git_answers_the_repo_query_as_a_failure(self):

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -19,6 +19,11 @@ os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
+# Fixture git goes through the shared runner: `git commit` spawns `git maintenance run --auto`, which on recent
+# git detaches from its parent and can still be writing into .git while the fixture's directory is removed (the
+# CI flake "Directory not empty: '.git'", tests/test_restart_classifier.py, 2026-09-10); the runner forbids that
+# background work on every invocation and in every repo it inits.
+from git_fixture import git, init_repo
 
 
 class FakeBackend:
@@ -529,29 +534,42 @@ class SdkMetadataParity(unittest.TestCase):
         self.assertEqual(km._git_branch(tempfile.mkdtemp()), "", "not a repo → ''")
         self.assertEqual(km._git_branch(""), "", "no dir → ''")
 
-    def test_git_branch_is_empty_on_a_detached_head(self):
-        """Detached HEAD → '' is the CONTRACT (kernel _git_branch docstring), not an accident. Pinned on a
-        purpose-built repo so it holds regardless of how the checkout running these tests is shaped."""
-        import subprocess, tempfile
+    # -c identity so this never depends on (or is polluted by) the machine's global git config.
+    IDENT = ("romp-test@example.invalid", "romp test")
+
+    def _committed_repo(self):
+        """A purpose-built repo with one commit on a branch: the fixture the kernel's own `git rev-parse`
+        (_git_branch) runs against."""
+        import tempfile
         d = tempfile.mkdtemp()
-        # -c identity so this never depends on (or is polluted by) the machine's global git config.
-        git = ["git", "-C", d, "-c", "user.email=romp-test@example.invalid", "-c", "user.name=romp test"]
         # --template= (empty): a machine-global init.templateDir would otherwise copy its hooks into
         # this repo — a maintainer's gitleaks pre-commit hook failed the commit below whenever the
         # scanner wasn't on the test shell's PATH (2026-08-10). The test is about branch derivation;
         # no machine hook belongs in it.
-        subprocess.run(["git", "init", "-q", "--template=", d], check=True, capture_output=True)
+        init_repo(d, "-q", "--template=", ident=self.IDENT)
         open(os.path.join(d, "f"), "w").write("x")
-        subprocess.run(git + ["add", "f"], check=True, capture_output=True)
-        subprocess.run(git + ["commit", "-qm", "c"], check=True, capture_output=True)
+        git(d, "add", "f", ident=self.IDENT, text=False)
+        git(d, "commit", "-qm", "c", ident=self.IDENT, text=False)
+        return d
+
+    def test_git_branch_is_empty_on_a_detached_head(self):
+        """Detached HEAD → '' is the CONTRACT (kernel _git_branch docstring), not an accident. Pinned on a
+        purpose-built repo so it holds regardless of how the checkout running these tests is shaped."""
+        d = self._committed_repo()
         # _git_branch caches per cwd keyed on .git/HEAD's mtime. Both calls here land in the same test, so
         # on a coarse-granularity filesystem the two HEAD writes could share an mtime and serve a stale hit.
         # Clear between calls: this test is about the branch derivation, not the cache.
         km._branch_cache.clear()
         self.assertNotEqual(km._git_branch(d), "", "attached: a real branch name")
-        subprocess.run(git + ["checkout", "-q", "--detach"], check=True, capture_output=True)
+        git(d, "checkout", "-q", "--detach", ident=self.IDENT, text=False)
         km._branch_cache.clear()
         self.assertEqual(km._git_branch(d), "", "detached HEAD is not a branch name")
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        # the kernel forks its own `git rev-parse` at this repo (_git_branch), outside the fixture runner's
+        # -c flags, so the no-background keys have to sit in the repo's own config
+        d = self._committed_repo()
+        self.assertEqual(git(d, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false")
 
     def test_open_eager_connects_sdk_branch_fallback_and_ctx_passthrough(self):
         with open(os.path.join(BIN, "romp-kernel")) as f:

--- a/tests/test_stage0_log_readers.py
+++ b/tests/test_stage0_log_readers.py
@@ -24,6 +24,7 @@ em = load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
 jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
+from git_fixture import git, init_repo
 
 SID = "11111111-2222-3333-4444-999999999901"     # private synthetic sid: this module owns its states file
 NOW = 1781100000
@@ -72,6 +73,18 @@ def _append_rows(path, rows):
     with open(path, "a") as f:
         for r in rows:
             f.write(json.dumps(r) + "\n")
+
+
+def _repo_on_main():
+    """A throwaway repository with one commit on `main`, the shape test_d3 reads a branch from. Built through
+    the shared runner (tests/git_fixture.py): `git commit` spawns `git maintenance run --auto`, which on
+    recent git detaches and can still be writing into .git while the temp dir is removed (the CI flake
+    "Directory not empty: '.git'", 2026-09-10); init_repo also writes the no-background keys into the repo's
+    own config, so the git the KERNEL forks against it (the branch memo) obeys them too."""
+    repo = tempfile.mkdtemp()
+    init_repo(repo, "-q", "-b", "main")
+    git(repo, "commit", "-q", "--allow-empty", "-m", "init", ident=("t@example.invalid", "t"))   # main is born: the branch resolves
+    return repo
 
 
 class _OpenCounter:
@@ -490,11 +503,7 @@ class EveryTabIsServedOnTheCompleteKey(_StateSandbox):
     def test_d3_the_branch_of_a_subdirectory_cwd_is_keyed(self):
         """build_session reads the branch of the registered cwd's tree (and of the last edited file's tree);
         the key carries them by value through the branch memo, which is keyed on the tree's HEAD."""
-        import subprocess
-        repo = tempfile.mkdtemp()
-        subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
-        subprocess.run(["git", "-C", repo, "-c", "user.name=t", "-c", "user.email=t@example.invalid",
-                        "commit", "-q", "--allow-empty", "-m", "init"], check=True)   # main is born: the branch resolves
+        repo = _repo_on_main()
         sub = os.path.join(repo, "pkg"); os.makedirs(sub)
         saved_cwd = km._cwd_of
         km._cwd_of = lambda sid: sub                       # a cwd INSIDE the repo, not its top
@@ -502,12 +511,19 @@ class EveryTabIsServedOnTheCompleteKey(_StateSandbox):
             s1 = self.sig()
             cwd_i = km._CHAT_SIG_LABELS.index("cwd")
             self.assertEqual(s1[cwd_i][1], "main", "the repo's branch is read for a subdirectory cwd: %r" % (s1[cwd_i],))
-            subprocess.run(["git", "-C", repo, "checkout", "-q", "-b", "feature"], check=True)
+            git(repo, "checkout", "-q", "-b", "feature")
             s2 = self.sig()
             self.assertNotEqual(s1, s2, "a branch switch moves the key")
             self.assertEqual(s2[cwd_i][1], "feature")
         finally:
             km._cwd_of = saved_cwd
+
+    def test_the_fixture_repos_forbid_background_git_work(self):
+        """The kernel runs git against test_d3's repo through its own subprocess (_git_out, the branch memo),
+        so the no-background keys must sit in the repo's own config, not only on the fixture runner's
+        command line."""
+        repo = _repo_on_main()
+        self.assertEqual(git(repo, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false", repo)
 
     def test_e_the_backend_leg_and_the_watches_move_the_key(self):
         """A stub backend stands in for the SDK: the live-tail revision, the send queue and the brackets each

--- a/tests/test_tempdir_hygiene.py
+++ b/tests/test_tempdir_hygiene.py
@@ -38,6 +38,8 @@ import textwrap
 import unittest
 from unittest.mock import patch
 
+from git_fixture import git, init_repo
+
 HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 IDENT = "romp tests <tests@example.invalid>"
@@ -47,6 +49,14 @@ under_conftest = unittest.skipUnless("tests.conftest" in sys.modules,
 
 
 def _run(cmd, **kw):
+    # T299: a git handed a cwd runs against a FIXTURE repository here and goes through the suite's shared runner
+    # (tests/git_fixture.py), which forbids BACKGROUND work on every invocation: `git commit` spawns
+    # `git maintenance run --auto`, which on recent git detaches and can still be writing into .git while the
+    # TemporaryDirectory removes the repo (the CI flake "Directory not empty: '.git'",
+    # tests/test_restart_classifier.py, 2026-09-10). A git with no cwd reads the checkout running the tests, or
+    # no repository at all (`--version`, `config --global --list`), and stays the plain run it was.
+    if cmd[0] == "git" and "cwd" in kw:
+        return git(kw.pop("cwd"), *cmd[1:], check=kw.pop("check", False), timeout=60, **kw)
     return subprocess.run(cmd, capture_output=True, text=True, timeout=60, **kw)
 
 
@@ -434,7 +444,7 @@ class GitFloor(unittest.TestCase):
             f.write("[core]\n\thooksPath = %s\n" % hooks)
         repo = os.path.join(td, "repo")
         os.makedirs(repo)
-        _run(["git", "init", "-q"], cwd=repo, check=True)
+        init_repo(repo, "-q")   # no ident: the commit below pins the conftest floor's identity, not a local one
         with open(os.path.join(repo, "a.txt"), "w") as f:
             f.write("a\n")
         _run(["git", "add", "a.txt"], cwd=repo, check=True)
@@ -477,6 +487,7 @@ class GitFloor(unittest.TestCase):
 
 LEAKY_MODULE = textwrap.dedent('''\
     import os, subprocess, tempfile, unittest
+    from git_fixture import git, init_repo    # the suite's runner (tests/__init__.py registers it under tests.conftest)
     ROOT = os.environ["TMPDIR"]
     STATE = tempfile.mkdtemp()            # a module preamble's state root: never cleaned by the module
 
@@ -486,10 +497,10 @@ LEAKY_MODULE = textwrap.dedent('''\
             d = tempfile.mkdtemp()            # a seed repo, the shape that leaked: never cleaned
             fd, f = tempfile.mkstemp()
             os.close(fd)
-            subprocess.run(["git", "init", "-q", d], check=True)
+            init_repo(d, "-q")                # no background git work: a detached maintenance would outlive the run
             open(os.path.join(d, "a.txt"), "w").write("a\\n")
-            subprocess.run(["git", "-C", d, "add", "a.txt"], check=True)
-            subprocess.run(["git", "-C", d, "commit", "-q", "-m", "seed"], check=True)
+            git(d, "add", "a.txt")
+            git(d, "commit", "-q", "-m", "seed")
             sh = subprocess.run(["mktemp", "-d"], capture_output=True, text=True, check=True).stdout.strip()
             for p in (STATE, d, f, sh):
                 self.assertEqual(os.path.commonpath([ROOT, p]), ROOT, p)


### PR DESCRIPTION
Second of two PRs (T299): the twelve remaining test files that build throwaway git repositories move onto `tests/git_fixture.py`, the shared runner that forbids background git work (the `Directory not empty: '.git'` teardown flake).

**Mechanical, and no assertion changes.** Each file keeps its local runner's name, signature and what it returns or raises (a stripped stdout, a `CompletedProcess`, `None`; `AssertionError` or `CalledProcessError`); only the body delegates to `git()`, passing the file's own identity, environment, timeout and text-ness. Fixture inits go through `init_repo`; clones, worktrees and bare repos the kernel runs git against get `forbid_background` right after they are made; inline git calls on fixture repos move onto the runner. Read-only git against the real checkout (`git --version`, `--exec-path`, rev-parse on the repo running the tests) stays a plain `subprocess.run`. The touched assertion lines in the diff are exactly the pins below.

**Per-file pins.** Eleven of the twelve make the kernel, or a script under test, run its own git against a fixture repo; each carries one small test that the repos the kernel touches hold `maintenance.auto=false` in their local config. `test_tempdir_hygiene` runs all its git through its own runner, so the shared pin in `tests/test_git_fixture.py` covers it and it adds none.

Files: test_kernel_update, test_kernel_remote_update, test_converge_main_branch, test_github_repo, test_file_github, test_kernel_fork_burn, test_git_pointer_file_bytes, test_kernel_worktree_display, test_tempdir_hygiene, test_sdk_kernel, test_stage0_log_readers, test_perf_bench.
