### PR TITLE
/file sandboxes an SVG: Content-Security-Policy sandbox on every image/svg+xml success, local and relayed

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40953,9 +40953,33 @@ _img_cache = {}                                  # "path:mtime:size" → dataURL
 #      the actual bytes over HTTP (behind _authorize, like everything else) instead of a data-URL round
 #      trip — the browser lazy-loads, caches, and renders a PDF natively in the lightbox iframe. The
 #      allowlist is RENDERABLE media only; anything else 404s and the client shows a plain link. SVG is
-#      served as an image (an <img> never runs its scripts); the files are the user's own, written by
-#      their own agents, on their own machine.
+#      served as an image (an <img> never runs its scripts; a tab NAVIGATED to one is a document, which
+#      _media_policy_headers below sandboxes); the files are the user's own, written by their own agents,
+#      on their own machine.
 _PREVIEW_MIME = dict(_IMG_MIME, **{".pdf": "application/pdf"})
+
+
+def _media_policy_headers(mime):
+    """The extra headers a /file SUCCESS carries for its media type: `Content-Security-Policy: sandbox`
+    on image/svg+xml, nothing on anything else.
+
+    An SVG is the one type on the allowlist that is ALSO a document. Served to an <img> it is a picture
+    and its scripts never run; but the own-tab opener (ui/webview/preview.ts openFileTab) hands this route
+    ANY path on a modified click since the PDF-only gate came off, and a tab NAVIGATED to /file?path=x.svg
+    parses it as a page and runs its inline <script> at the kernel's origin, with the dashboard's session
+    cookie attached (the 1204 review, 2026-09-10). nosniff is no help there: the type is declared, and
+    image/svg+xml is the scriptable one. `sandbox` closes it: a sandboxed document runs no script and
+    gets an opaque origin, so it can reach nothing of the dashboard's. The <img> path is unaffected (no
+    document is created, so no policy is read), and the chat's thumbnails, the viewer's inline preview
+    and the lightbox keep rendering. Sent on EVERY svg success, all three shapes (HEAD, 206, 200), never
+    gated on _is_navigation: harmless on a fetch or an <img>, and closing the hole must not hinge on
+    Sec-Fetch headers a plain-http dashboard never sends (see _is_navigation). On the 200 it rides
+    BESIDE _send's frame-ancestors policy as a second header of the same name, which a browser enforces
+    in addition; the framing policy itself is untouched. The /remote/<host>/file relay rebuilds every
+    interpretation header from OUR mime (it never mirrors the remote's), so it restates this too."""
+    return {"Content-Security-Policy": "sandbox"} if mime == _IMG_MIME[".svg"] else {}
+
+
 _PREVIEW_MAX_BYTES = 50_000_000                  # a plot/report, not a dataset — bigger 413s (fail loudly)
 
 # ---- …and the SOURCE/TEXT half of the same route (the user 2026-08-08). Clicking a file link used to
@@ -50128,6 +50152,8 @@ class Handler(BaseHTTPRequestHandler):
             if mime == "application/pdf":                     # the probe agrees with the GET (below) on the tab's name
                 self.send_header("Content-Disposition", _attachment_disposition(os.path.basename(fp), kind="inline"))
             self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
+            for k, v in _media_policy_headers(mime).items():        # sandbox on an SVG (see _media_policy_headers)
+                self.send_header(k, v)
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):         # the chat's fetch-HEAD probe rides CORS too
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
@@ -50156,6 +50182,8 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(raw)))
             self.send_header("Content-Range", "bytes %d-%d/%d" % (rng, size - 1, size))
             self.send_header("X-Content-Type-Options", "nosniff")
+            for k, v in _media_policy_headers(mime).items():        # sandbox on an SVG (see _media_policy_headers)
+                self.send_header(k, v)
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
@@ -50183,6 +50211,7 @@ class Handler(BaseHTTPRequestHandler):
                               headers={"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns,
                                        "X-Romp-Text-Utf8": u8})
         extra = {"Last-Modified": lastmod, "X-Romp-Mtime-Ns": mtime_ns}
+        extra.update(_media_policy_headers(mime))            # sandbox on an SVG (see _media_policy_headers)
         if mime == "application/pdf":
             # INLINE, with the file's name (2026-09-06): a PDF opens in its own browser tab now (preview.ts
             # openPdfTab), and the browser titles that tab and names a Save from this header — without it
@@ -53547,6 +53576,8 @@ class Handler(BaseHTTPRequestHandler):
             if status == 200 and mime == "application/pdf":   # the tab's name — OURS, from the requested path
                 self.send_header("Content-Disposition", _attachment_disposition(os.path.basename(rp), kind="inline"))
             self.send_header("X-Content-Type-Options", "nosniff")   # _send's guarantee, restated on the HEAD path
+            for k, v in _media_policy_headers(mime).items():        # the SVG sandbox, from OUR mime like the type
+                self.send_header(k, v)
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
@@ -53563,6 +53594,8 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(len(body)))
             self.send_header("Content-Range", crange)
             self.send_header("X-Content-Type-Options", "nosniff")
+            for k, v in _media_policy_headers(mime).items():        # the SVG sandbox, from OUR mime like the type
+                self.send_header(k, v)
             self.send_header("Cache-Control", "no-cache")
             if getattr(self, "_cors_origin", None):
                 self.send_header("Access-Control-Allow-Origin", self._cors_origin)
@@ -53575,6 +53608,10 @@ class Handler(BaseHTTPRequestHandler):
         # and the Edit gate ride on them, and deriving them locally would lie about a remote disk.
         mirrored = {k: v for k, v in (("Last-Modified", lastmod), ("X-Romp-Mtime-Ns", r_ns),
                                       ("X-Romp-Text-Utf8", r_u8)) if v}
+        # …and the SVG sandbox is NOT mirrored but derived here from our mime, like the type and the
+        # disposition: the relay rebuilds every header that tells this browser how to interpret the bytes
+        # (_media_policy_headers has the hole), so the local route's policy has to be restated on this arm.
+        mirrored.update(_media_policy_headers(mime))
         if status == 200 and mime == "application/pdf":
             # A remote session's PDF opens in its own tab too (2026-09-06): the tab's title and a Save's name
             # come from this header — derived HERE from the requested basename, like the Content-Type, never

--- a/tests/test_kernel_preview.py
+++ b/tests/test_kernel_preview.py
@@ -415,6 +415,96 @@ class AttachmentDisposition(unittest.TestCase):
     def test_an_empty_name_still_yields_a_usable_filename(self):
         self.assertIn('filename="download"', km._attachment_disposition(""))
 
+# a synthetic SVG that carries the payload the hole is about: markup on disk, a page when a tab navigates
+# to it, and its <script> would run wherever the document lands
+SVG_WITH_SCRIPT = (b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+                   b'<script>document.title = "ran at the kernel origin"</script></svg>')
+
+
+class SvgSandboxPolicy(unittest.TestCase):
+    """An SVG on the media allowlist is ALSO a document: when a tab navigates to /file?path=x.svg the
+    browser parses it as a page and runs its inline <script> at the kernel's origin, with the dashboard's
+    session cookie attached. The own-tab opener (ui/webview/preview.ts openFileTab) hands the route ANY
+    path on a modified click since the PDF-only gate came off, so an agent-written .svg gets there in one
+    gesture (the 1204 review, 2026-09-10). nosniff cannot help: the type is declared, and image/svg+xml is
+    the scriptable one. Every image/svg+xml response therefore carries `Content-Security-Policy: sandbox`,
+    on all three success shapes (200, HEAD, 206): a sandboxed document runs no script and has an opaque
+    origin. An <img> load creates no document and reads no policy, so the chat's thumbnails, the viewer's
+    inline preview and the lightbox keep rendering. Ordinary media and text carry no sandbox."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.svg = os.path.join(cls.tmp.name, "chart.svg")
+        with open(cls.svg, "wb") as f:
+            f.write(SVG_WITH_SCRIPT)
+        cls.png = os.path.join(cls.tmp.name, "plot.png")
+        with open(cls.png, "wb") as f:
+            f.write(PNG)
+        cls.md = os.path.join(cls.tmp.name, "notes.md")
+        with open(cls.md, "w") as f:
+            f.write("# notes\n\nplain text, never a document with script\n")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.tmp.cleanup()
+
+    def _req(self, path, method="GET", headers=None):
+        # returns the raw header MESSAGE, not a dict: a dict keeps one value per name, and the sandbox
+        # policy rides BESIDE _send's frame-ancestors one under the same header name on the 200 branch
+        url = "http://127.0.0.1:%d/file?path=%s&token=%s" % (self.port, urllib.parse.quote(path), TOKEN)
+        req = urllib.request.Request(url, method=method, headers=headers or {})
+        try:
+            with urllib.request.urlopen(req, timeout=3) as r:
+                return r.status, r.headers, r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, e.headers, e.read()
+
+    @staticmethod
+    def _csp(msg):
+        # every Content-Security-Policy header the response carries, joined: a browser enforces them all
+        return "; ".join(msg.get_all("Content-Security-Policy") or [])
+
+    def test_a_get_of_an_svg_is_a_sandboxed_document(self):
+        code, msg, body = self._req(self.svg)
+        self.assertEqual(code, 200)
+        self.assertEqual(msg.get("Content-Type"), "image/svg+xml")
+        self.assertEqual(body, SVG_WITH_SCRIPT, "the bytes are untouched: the policy, not a rewrite, disarms them")
+        self.assertIn("sandbox", msg.get_all("Content-Security-Policy") or [], self._csp(msg))   # the bare policy, exactly: a weakened `sandbox allow-scripts` must fail
+        self.assertIn("frame-ancestors 'self'", self._csp(msg), "_send's framing policy still rides the 200")
+        self.assertEqual(msg.get("X-Content-Type-Options"), "nosniff")
+
+    def test_the_head_probe_carries_the_same_policy(self):
+        code, msg, body = self._req(self.svg, method="HEAD")
+        self.assertEqual((code, body), (200, b""))
+        self.assertEqual(msg.get("Content-Type"), "image/svg+xml")
+        self.assertIn("sandbox", msg.get_all("Content-Security-Policy") or [], self._csp(msg))   # the bare policy, exactly: a weakened `sandbox allow-scripts` must fail
+
+    def test_a_resumed_range_carries_the_same_policy(self):
+        # the resumable retry's 206 is a response a tab can be handed too: the tail of the document
+        code, msg, body = self._req(self.svg, headers={"Range": "bytes=1-"})
+        self.assertEqual(code, 206)
+        self.assertEqual(body, SVG_WITH_SCRIPT[1:])
+        self.assertEqual(msg.get("Content-Range"), "bytes 1-%d/%d" % (len(SVG_WITH_SCRIPT) - 1, len(SVG_WITH_SCRIPT)))
+        self.assertEqual(msg.get("Content-Type"), "image/svg+xml")
+        self.assertIn("sandbox", msg.get_all("Content-Security-Policy") or [], self._csp(msg))   # the bare policy, exactly: a weakened `sandbox allow-scripts` must fail
+
+    def test_ordinary_media_and_text_carry_no_sandbox(self):
+        # a PNG is never a document; text is served as text/plain, which never executes — neither is sandboxed,
+        # so a policy meant for SVG cannot leak onto the viewer's other branches
+        for method, headers in (("GET", None), ("HEAD", None), ("GET", {"Range": "bytes=1-"})):
+            code, msg, _ = self._req(self.png, method=method, headers=headers)
+            self.assertIn(code, (200, 206), (method, headers))
+            self.assertNotIn("sandbox", self._csp(msg), (method, headers, self._csp(msg)))
+        code, msg, _ = self._req(self.md)
+        self.assertEqual(code, 200)
+        self.assertTrue(msg.get("Content-Type", "").startswith("text/plain"), msg.get("Content-Type"))
+        self.assertNotIn("sandbox", self._csp(msg), self._csp(msg))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_kernel_remote_file_relay.py
+++ b/tests/test_kernel_remote_file_relay.py
@@ -42,6 +42,8 @@ REMOTE_TOKEN = "remote-token-DO-NOT-USE"
 PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-png-bytes"
 PDF_BYTES = b"%PDF-1.4\n1 0 obj<</Type/Catalog>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n"   # a minimal synthetic PDF
 PY_BYTES = b"print('hello from the remote box')\n"
+SVG_BYTES = (b'<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+             b'<script>document.title = "ran at the local origin"</script></svg>')   # synthetic
 # the download fixture: NUL-ridden, off every view allowlist, and BIGGER than one relay stream chunk,
 # so the pass-through provably crosses a chunk boundary intact
 BIN_BYTES = bytes(range(256)) * ((km._DOWNLOAD_CHUNK // 256) + 60)
@@ -72,6 +74,21 @@ class _FakeRemoteFileHandler(BaseHTTPRequestHandler):
                     self.close_connection = True
                 else:
                     self.wfile.write(BIN_BYTES)
+            return
+        if "chart.svg" in self.path:
+            # the remote's own .svg: whole, or the tail a suffix Range asks for (its _file_preview's 206 shape).
+            # The remote CLAIMS image/svg+xml here; the relay derives its own type and policy regardless.
+            rng = self.headers.get("Range") or ""
+            start = int(rng[len("bytes="):-1]) if rng.startswith("bytes=") and rng.endswith("-") else 0
+            body = SVG_BYTES[start:]
+            self.send_response(206 if start else 200)
+            self.send_header("Content-Type", "image/svg+xml")
+            self.send_header("Content-Length", str(len(body)))
+            if start:
+                self.send_header("Content-Range", "bytes %d-%d/%d" % (start, len(SVG_BYTES) - 1, len(SVG_BYTES)))
+            self.end_headers()
+            if not head:
+                self.wfile.write(body)
             return
         if "app.py" in self.path:
             self.send_response(200)
@@ -403,6 +420,37 @@ class RemoteFileRelay(unittest.TestCase):
         self._register("gpu1", dead_port)
         status, _, _ = self._get("/remote/gpu1/file?path=%2Ftmp%2Fplot.png")
         self.assertEqual(status, 502)
+
+    def _get_msg(self, path, method="GET", headers=None):
+        # the raw header MESSAGE: a dict keeps one value per name, and the SVG sandbox policy rides beside
+        # _send's frame-ancestors one under the same header name
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method=method,
+                                     headers=headers or {})
+        req.add_header("X-Romp-Token", km.TOKEN)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, r.read(), r.headers
+        except urllib.error.HTTPError as e:
+            return e.code, e.read(), e.headers
+
+    def test_a_remote_svg_is_a_sandboxed_document_by_the_relays_own_policy(self):
+        # The relay derives every header that tells THIS browser how to interpret the bytes (the type, the
+        # disposition) from the requested extension and discards the remote's, so the local route's SVG
+        # defence (tests/test_kernel_preview.py SvgSandboxPolicy: a tab navigated to an SVG runs its inline
+        # script at the serving origin) has to be restated here, from OUR mime — a remote session's .svg
+        # opened in its own tab is a document at this kernel's origin, cookie and all (the 1204 review,
+        # 2026-09-10). All three success shapes; a remote PNG carries none.
+        self._register("gpu1", self.fake.server_address[1])
+        csp = lambda msg: "; ".join(msg.get_all("Content-Security-Policy") or [])
+        for method, headers, want in (("GET", None, 200), ("HEAD", None, 200), ("GET", {"Range": "bytes=1-"}, 206)):
+            status, body, msg = self._get_msg("/remote/gpu1/file?path=%2Ftmp%2Fchart.svg", method=method, headers=headers)
+            self.assertEqual(status, want, (method, headers))
+            self.assertEqual(msg.get("Content-Type"), "image/svg+xml", (method, headers))
+            self.assertIn("sandbox", msg.get_all("Content-Security-Policy") or [], (method, headers, csp(msg)))   # exact value: a weakened `sandbox allow-scripts` must fail
+            self.assertEqual(body, b"" if method == "HEAD" else SVG_BYTES[1 if headers else 0:], (method, headers))
+        status, _, msg = self._get_msg("/remote/gpu1/file?path=%2Ftmp%2Fplot.png")
+        self.assertEqual(status, 200)
+        self.assertNotIn("sandbox", csp(msg), csp(msg))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A tab navigated to `/file?path=x.svg` parses the SVG as a document and runs its inline script at the kernel's origin with the dashboard's session cookie. The own-tab opener (`openFileTab`, since the PDF-only gate came off in the file-viewer links change) hands that route any path on a Cmd/Ctrl or middle click, so a path link to an SVG inside a shown file (a cloned repository's README, say) is a script-execution hole. Found in the review of that change (2026-09-10).

## What changes

- `_media_policy_headers(mime)` in `kernel/kernel.py`: `Content-Security-Policy: sandbox` when the mime is `image/svg+xml`, nothing otherwise. A sandboxed document runs no script and gets an opaque origin, so it can reach nothing of the dashboard's.
- Sent on every SVG success shape of `/file` (HEAD, 206 Range, 200) and of the `/remote/<host>/file` relay, which rebuilds its interpretation headers from our mime rather than mirroring the remote's, so it has to restate the policy.
- Never gated on `_is_navigation`: harmless on a fetch or an `<img>` load (no document is created, so the chat's thumbnails, the viewer's inline preview and the lightbox keep rendering), and closing the hole must not hinge on Sec-Fetch headers a plain-http dashboard never sends.
- On the 200 branch the header rides beside `_send`'s `frame-ancestors 'self'` as a second policy header, enforced additively; the framing policy is untouched. `nosniff` alone does not help here because the type is declared.

## Tests (red before the change)

- `tests/test_kernel_preview.py` `SvgSandboxPolicy`: a GET of a synthetic SVG carrying an inline script is `200 image/svg+xml` with the exact `sandbox` policy (and the framing policy still present); the HEAD probe and a `bytes=1-` 206 carry it; a `.png` (GET, HEAD, Range) and a `.md` text response carry no sandbox. 25 to 29 cases.
- `tests/test_kernel_remote_file_relay.py`: a remote `.svg` through the relay carries the relay's own sandbox policy on GET, HEAD and 206, and a remote PNG does not. 16 to 17 cases.
- Assertions check the exact header value, so a weakened `sandbox allow-scripts` would fail.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
