### PR TITLE
Postal cards: the kind as coloured text, a delivery-state icon, both ends in their sessions' colours, no wash

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -26389,17 +26389,49 @@ def _postal_index():
     if hit is not None and hit[0] == key:
         return hit[1]
     idx = {}
+    later = {}                                        # mid -> its outcome rows, in log order (folded after the scan)
     for o in _messages_rows(p):                       # append-incremental rows (2026-09-03): a send no
         if not isinstance(o, dict):                   # longer re-decodes the whole log on the active tab
             continue
-        if o.get("ev") == "sent" and o.get("id"):
-            idx[o["id"]] = {"id": o["id"], "from": o.get("from", "?"), "fromId": o.get("from_id", ""),
-                            # the sender's host as the log stamped it: "" for this kernel's own sessions,
-                            # a peer's name for relayed mail — and None when the row carries NO field, a
-                            # row from before the field existed, whose sender could be either (2026-09-06)
-                            "fromHost": o.get("from_host"),
-                            "toId": o.get("to_id", ""), "body": o.get("body", ""), "kind": o.get("kind", ""),
-                            "t": o["t"] if isinstance(o.get("t"), (int, float)) else 0, "park": bool(o.get("park"))}
+        ev, mid = o.get("ev"), o.get("id")
+        if ev == "sent" and mid:
+            idx[mid] = {"id": mid, "from": o.get("from", "?"), "fromId": o.get("from_id", ""),
+                        # the sender's host as the log stamped it: "" for this kernel's own sessions,
+                        # a peer's name for relayed mail — and None when the row carries NO field, a
+                        # row from before the field existed, whose sender could be either (2026-09-06)
+                        "fromHost": o.get("from_host"),
+                        "toId": o.get("to_id", ""), "body": o.get("body", ""), "kind": o.get("kind", ""),
+                        "t": o["t"] if isinstance(o.get("t"), (int, float)) else 0, "park": bool(o.get("park"))}
+            continue
+        # The message's LATER outcomes ride the same record (T302): the sent card's delivery icon reads them.
+        # Each is the ledger's own event, never inferred — `exec` is the recipient's inbox drain consuming
+        # the message (a REAL read), `unexec` a claimed-then-rolled-back drain (not read after all),
+        # `relayed` the far host's end-to-end ack, `bounced` a return (with the refusal's why), `recall`
+        # the sender unsending it. Collected here and folded after the scan, the postal service's own
+        # reader's shape (_sent_receipts): deliver() publishes the file before it appends the sent row, and
+        # a drain can log its exec in that instant, so an outcome may sit BEFORE its sent row. Row order
+        # within one id still decides (exec then unexec is not read).
+        if mid and ev in ("exec", "unexec", "relayed", "bounced", "recall") and isinstance(o.get("t"), (int, float)):
+            later.setdefault(mid, []).append(o)
+    for mid, rows in later.items():
+        rec = idx.get(mid)
+        if rec is None:                               # an outcome for a message this log never sent
+            continue
+        for o in rows:
+            ev = o.get("ev")
+            if ev == "exec":
+                rec["read"] = o["t"]
+            elif ev == "unexec":
+                rec.pop("read", None)
+            elif ev == "relayed":
+                rec["relayed"] = o["t"]
+            elif ev == "bounced":
+                rec["bounced"] = o["t"]
+                why = str(o.get("why") or "")
+                if why:
+                    rec["bouncedWhy"] = re.sub(r"[\x00-\x1f\x7f]+", " ", why)[:200]
+            elif ev == "recall":
+                rec["recalled"] = o["t"]
     _postal_index_memo[0] = (key, idx, _postal_body_map(idx))
     return idx
 
@@ -26600,6 +26632,19 @@ def _hydrate_postal(events, index, sid=None, captions=None):
             cap = caption_for(rec["id"])
             if cap:
                 card["summary"] = cap
+            # the ledger's outcomes for this message (T302): the delivery icon moves after the send —
+            # read (the recipient consumed it), relayed (a far host acked), bounced (+ why), recalled;
+            # `remote` says the send crossed the peer bus, where the tool's "delivered" is only "handed
+            # to the relay". Only what the ledger holds; an empty receipt is not sent at all.
+            # — never on a send that ERRORED (status None): the body-keyed join would hand a refused send the
+            # outcomes of its retry with the same words, and a message that never left has no receipt.
+            receipt = {k: rec[k] for k in ("read", "relayed", "bounced", "recalled") if rec.get(k)}
+            if rec.get("bouncedWhy"):
+                receipt["why"] = rec["bouncedWhy"]
+            if str(rec.get("toId") or "").startswith("peer:"):
+                receipt["remote"] = True
+            if receipt and card.get("status") is not None:
+                card["receipt"] = receipt
         return card
     for ev in events:
         if ev.get("kind") == "tool" and _SEND_TOOL_RE.search(ev.get("name") or ""):

--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""T302 (the user 2026-09-10): the postal cards in the chat pane, rendered by the real /chat page of a hermetic
+kernel over a synthetic chat with web (the viewed session), api and tests (its peers) — every state at once.
+
+Asserted on the page: the interaction KIND is coloured text (Delegation / Coordination / Question in the old chip
+colours), never a chip; the DELIVERY STATE is one icon per state at the head's right edge with a worded title
+(delivered, read, parked, bounced, recalled, and sent for a message handed to the relay), from what the kernel
+files (the send-time stamp, and the postal ledger's exec / relayed / bounced / recall rows joined by message id);
+both ENDS wear their sessions' colours (the peer's chip, then this session's own chip); no card wears a background
+wash; incoming cards are boxed, sent ones slim; a sent card whose message has not landed wears the pending
+send's own provisional dress (the queued bubble's class). With POSTAL_SHOTS=<dir> the driver also writes
+screenshots at 1000 px and 520 px. Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC
+fixtures only (the notes-api demo world: web / api / tests; host TESTHOST)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+WEB = "aaaaaaaa-1111-2222-3333-444444444444"
+API = "bbbbbbbb-1111-2222-3333-444444444444"
+TESTS = "cccccccc-1111-2222-3333-444444444444"
+BAR = "#" * 44
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def hhmm(t):
+    return datetime.fromtimestamp(t).strftime("%H:%M")
+
+
+def banner(frm, kind, mid, body, t):
+    """The delivered banner the postal service injects (bin/romp-postal-service format_push), as a user record."""
+    return "\n".join([BAR, "## 📬 from %s · %s" % (frm, hhmm(t)), BAR, body, "<!-- romp-msg-id: %s -->" % mid,
+                      "<!-- romp-msg-kind: %s -->" % kind, BAR,
+                      "(to reply, only if substantive: romp mail send --kind delegate|coordinate|question %s \"...\")" % frm])
+
+
+def user(t, uuid, parent, text):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "sdk", "sessionId": WEB,
+            "message": {"role": "user", "content": text}}
+
+
+def send_pair(t, uuid, parent, to, kind, body, result, is_error=False):
+    tu = "tu_" + uuid
+    return [
+        {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "sessionId": WEB,
+         "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "tool_use",
+                     "content": [{"type": "tool_use", "id": tu, "name": "mcp__romp-postal-service__send_message",
+                                  "input": {"to": to, "body": body, "kind": kind}}]}},
+        {"type": "user", "timestamp": iso(t + 1), "uuid": uuid + "r", "parentUuid": uuid, "sessionId": WEB,
+         "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tu, "content": result, "is_error": is_error}]}},
+    ]
+
+
+def sent_row(mid, frm, frm_id, to_id, body, t, kind, park=False):
+    r = {"t": t, "ev": "sent", "id": mid, "from": frm, "from_id": frm_id, "to_id": to_id, "body": body, "kind": kind, "from_host": ""}
+    if park:
+        r["park"] = True
+    return r
+
+
+# The world: nine cards, every kind and every state. Bodies are invented notes-api chatter.
+def world(t0):
+    msgs = {
+        "in-deleg": ("api", API, "delegate", "Take the retry-loop rewrite in notes-api: exponential backoff with jitter, cap at two minutes, tests included."),
+        "in-coord": ("tests", TESTS, "coordinate", "Heads-up: the integration suite now needs the fixtures directory; nothing to do on your side."),
+        "in-quest": ("api", API, "question", "Which cap do we want on the backoff, two minutes or five?"),
+        "out-deliv": ("web", WEB, "coordinate", "The backoff branch is up; review when you have a moment."),
+        "out-read": ("web", WEB, "question", "Did the fixtures land on your side yet?"),
+        "out-parked": ("web", WEB, "delegate", "Please run the whole integration suite once the fixtures are in."),
+        "out-queued": ("web", WEB, "coordinate", "The remote build is green; merging in an hour unless you object."),
+        "out-bounced": ("web", WEB, "delegate", "Take the cap decision and write it down in the README."),
+        "out-recalled": ("web", WEB, "coordinate", "Ignore my last note, wrong thread."),
+    }
+    log, recs = [], []
+    t = t0
+    parent = None
+    # incoming: api delegates, tests coordinates (parked while web was offline), api asks
+    for i, (mid, frm, fid, kind, body, park) in enumerate([
+            ("in-deleg", "api", API, "delegate", msgs["in-deleg"][3], False),
+            ("in-coord", "tests", TESTS, "coordinate", msgs["in-coord"][3], True),
+            ("in-quest", "api", API, "question", msgs["in-quest"][3], False)]):
+        t += 60
+        log.append(sent_row(mid, frm, fid, WEB, body, t, kind, park=park))
+        u = "u-in-%d" % i
+        recs.append(user(t + 1, u, parent, banner(frm, kind, mid, body, t)))
+        parent = u
+    # outgoing, one per state
+    outs = [
+        ("out-deliv", "api", API, "Delivered to 'api'.", False, []),
+        ("out-read", "api", API, "Delivered to 'api' as a question — you are now recorded as waiting on their answer.", False,
+         [lambda t: {"t": t + 20, "ev": "exec", "id": "out-read"}]),
+        ("out-parked", "tests", TESTS, "parked for tests (unreachable) — delivers on reconnect · id out-parked", False, []),
+        ("out-queued", "TESTHOST:api", "peer:TESTHOST", "Delivered to 'TESTHOST:api'.", False, []),
+        ("out-bounced", "api", API, "Delivered to 'api' as a handoff — they own it now.", False,
+         [lambda t: {"t": t + 30, "ev": "bounced", "id": "out-bounced", "why": "refused: the mailbox is isolated"}]),
+        ("out-recalled", "tests", TESTS, "Delivered to 'tests'.", False,
+         [lambda t: {"t": t + 40, "ev": "recall", "id": "out-recalled"}]),
+    ]
+    for i, (mid, to_name, to_id, result, err, later) in enumerate(outs):
+        t += 60
+        _, _, kind, body = msgs[mid]
+        log.append(sent_row(mid, "web", WEB, to_id, body, t, kind))
+        for mk in later:
+            log.append(mk(t))
+        pair = send_pair(t + 1, "a-out-%d" % i, parent, to_name, kind, body, result, err)
+        recs.extend(pair)
+        parent = pair[-1]["uuid"]
+    return log, recs
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const measure = () => page.evaluate(() => {
+  const probe = document.createElement("div"); probe.style.background = "var(--box-bg)"; document.body.appendChild(probe);
+  const boxBg = getComputedStyle(probe).backgroundColor; probe.remove();
+  const cards = Array.from(document.querySelectorAll(".turn-postal-service")).map((t) => {
+    const n = t.querySelector(".notice");
+    const kind = t.querySelector(".postal-kind");
+    const icon = t.querySelector(".postal-delivery");
+    const self = t.querySelector(".notice-src-self");
+    const peer = t.querySelector(".notice-src-chip:not(.notice-src-self)");
+    const cs = getComputedStyle(n);
+    return {
+      dir: t.classList.contains("postal-service-in") ? "in" : "out",
+      boxed: t.classList.contains("notice-boxed"), slim: n.classList.contains("notice-slim"),
+      kind: kind ? kind.textContent : null, kindColor: kind ? getComputedStyle(kind).color : null,
+      kindClipped: kind ? kind.scrollWidth > kind.clientWidth + 1 : null,
+      chip: !!t.querySelector(".notice-chip, .postal-service-intent"),
+      state: icon ? icon.dataset.state : null, title: icon ? (icon.getAttribute("aria-label") || "") : null,
+      iconRight: icon && n ? Math.round(n.getBoundingClientRect().right - icon.getBoundingClientRect().right) : null,
+      peerText: peer ? peer.textContent : null, peerBg: peer ? getComputedStyle(peer).backgroundColor : null,
+      selfText: self ? self.textContent : null, selfBg: self ? getComputedStyle(self).backgroundColor : null,
+      selfWidth: self ? Math.round(self.getBoundingClientRect().width) : null,
+      bg: cs.backgroundColor, border: cs.borderTopStyle, provisional: n.classList.contains("queued-bubble"),
+      gist: (t.querySelector(".notice-gist") || {}).textContent || "",
+      gistWrap: t.querySelector(".notice-gist") ? getComputedStyle(t.querySelector(".notice-gist")).whiteSpace : null,
+      collapsible: n.classList.contains("notice-collapsible"),
+      selfDot: !!(self && self.querySelector(".peer-dot")),
+    };
+  });
+  // the page colour under the text, and the two kind colours, for a contrast check per theme
+  const pg = document.createElement("div"); pg.style.background = "var(--bg)"; document.body.appendChild(pg);
+  const pageBg = getComputedStyle(pg).backgroundColor; pg.remove();
+  const kinds = {};
+  for (const k of ["delegate", "coordinate", "question"]) { const e = document.querySelector(".postal-kind-" + k); if (e) kinds[k] = getComputedStyle(e).color; }
+  return { boxBg, pageBg, kinds, theme: document.body.classList.contains("theme-light") ? "light" : "dark", cards, pendingBubbleClass: !!document.querySelector(".queued-bubble") };
+});
+const contrast = (a, b) => {
+  const lum = (css) => { const m = css.match(/\d+(\.\d+)?/g).slice(0, 3).map(Number).map((v) => v / 255).map((c) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)); return 0.2126 * m[0] + 0.7152 * m[1] + 0.0722 * m[2]; };
+  const la = lum(a), lb = lum(b); return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+};
+const results = {};
+let page;
+for (const pass of [{ width: 1000, theme: "dark" }, { width: 520, theme: "dark" }, { width: 340, theme: "dark" }, { width: 1000, theme: "light" }]) {
+  const width = pass.width;
+  page = await browser.newPage({ viewport: { width, height: 1000 }, deviceScaleFactor: 2 });
+  await page.goto(cfg.chat);
+  await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+  try { await page.waitForFunction((n) => document.querySelectorAll(".turn-postal-service").length >= n, cfg.count, { timeout: 30000 }); }
+  catch (e) {
+    const st = await page.evaluate(() => ({ n: document.querySelectorAll(".turn-postal-service").length,
+      turns: Array.from(document.querySelectorAll(".turn")).map((t) => t.className.slice(5, 50)).slice(0, 20) }));
+    console.error("cards missing at " + width + ": " + JSON.stringify(st)); process.exit(1);
+  }
+  await page.waitForTimeout(500);
+  if (pass.theme === "light") { await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(200); }
+  // open one incoming card so the fold shows, then bring the tail into view for the shot
+  const head = await page.$('.turn-postal-service.postal-service-in .notice-head[data-act="noticetoggle"]');
+  if (head) { await head.click(); await page.waitForTimeout(200); }
+  await page.evaluate(() => { const c = document.getElementById("content"); if (c) c.scrollTop = c.scrollHeight; });
+  await page.waitForTimeout(300);
+  const m = await measure();
+  m.contrast = { delegate: m.kinds.delegate ? contrast(m.kinds.delegate, m.pageBg) : null, coordinate: m.kinds.coordinate ? contrast(m.kinds.coordinate, m.pageBg) : null, question: m.kinds.question ? contrast(m.kinds.question, m.pageBg) : null };
+  results[pass.theme === "light" ? "light" : String(width)] = m;
+  if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-postal-cards-" + (pass.theme === "light" ? "light" : width) + ".png", fullPage: false }); }
+  await page.close();
+}
+fs.writeSync(1, "RESULT:" + JSON.stringify(results) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedPostalCards(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="postal-cards-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)   # tests/dist_copy: skips the bundler's staging files
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states", "timeline"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        # the viewed session and its two peers, each with an identity colour (the chip and the rail read it)
+        Path(state, "names", WEB).write_text("web\t%s\t#9cd2ff\t#0c1a2e\n" % cwd)
+        Path(state, "names", API).write_text("api\t%s\t#1EA1EB\t#ffffff\n" % cwd)
+        Path(state, "names", TESTS).write_text("tests\t%s\t#54B204\t#ffffff\n" % cwd)
+        Path(state, "sdk", WEB + ".json").write_text(json.dumps(
+            {"sid": WEB, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": WEB, "alive": True,
+             "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        t0 = int(time.time()) - 3600
+        log, recs = world(t0)
+        Path(state, "timeline", "messages.jsonl").write_text("".join(json.dumps(r) + "\n" for r in log))
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.count = 9
+        cls.port, cls.token = _free_port(), "testtok-postal"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
+                   ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
+        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+            env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_every_kind_and_delivery_state_renders_as_ruled(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "count": self.count,
+                       "shots": os.environ.get("POSTAL_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        wide, narrow, phone, light = r["1000"], r["520"], r["340"], r["light"]
+        cards = wide["cards"]
+        self.assertEqual(len(cards), 9, cards)
+        by = {c["gist"][:24]: c for c in cards}
+        def card(prefix):
+            m = [c for c in cards if c["gist"].startswith(prefix)]
+            self.assertEqual(len(m), 1, "one card starts with %r: %r" % (prefix, [c["gist"] for c in cards]))
+            return m[0]
+        # (1) the kind: coloured text, never a chip
+        for c in cards:
+            self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
+            self.assertFalse(c["chip"], "no chip: %r" % c)
+        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(176, 140, 255)", "delegation violet")
+        self.assertEqual(card("Heads-up")["kindColor"], "rgb(20, 184, 166)", "coordination teal")
+        # (2) the delivery icon per state, at the head's right edge, with a worded title
+        states = {c["gist"][:20]: c["state"] for c in cards}
+        self.assertIsNone(card("Take the retry-loop")["state"], "an incoming message in hand: no icon")
+        self.assertEqual(card("Heads-up")["state"], "parked", "waited while web was offline")
+        self.assertIn("waited while you were offline", card("Heads-up")["title"], "in hand: the title says it waited, not that it will deliver")
+        self.assertEqual(card("The backoff branch")["state"], "delivered")
+        self.assertEqual(card("Did the fixtures")["state"], "read", "the ledger's exec row: the recipient consumed it")
+        self.assertEqual(card("Please run the whole")["state"], "parked")
+        self.assertEqual(card("The remote build")["state"], "sent", "handed to the relay, no far-host ack yet")
+        self.assertEqual(card("Take the cap decision")["state"], "bounced")
+        self.assertEqual(card("Ignore my last note")["state"], "recalled")
+        for c in cards:
+            if c["state"]:
+                self.assertTrue(c["title"] and c["title"].split(" ")[0] in ("Delivered", "Read", "Parked", "Sent", "Bounced", "Recalled"), c)
+                self.assertLessEqual(c["iconRight"], 16, "the icon sits at the head's right edge: %r" % c)
+        self.assertIn("isolated", card("Take the cap decision")["title"], "a bounce carries its reason")
+        # (3) both ends, each in its session's colour; no wash; boxed vs slim
+        for c in cards:
+            self.assertTrue(c["peerText"], c)
+            self.assertTrue(c["selfText"] and "web" in c["selfText"], "this session's own end: %r" % c)
+            self.assertEqual(c["selfBg"], "rgb(156, 210, 255)", "web's own colour on its chip: %r" % c)
+            if c["dir"] == "in":
+                self.assertTrue(c["boxed"] and not c["slim"], "incoming is boxed: %r" % c)
+                self.assertEqual(c["bg"], wide["boxBg"], "no wash: the box is the plain box colour: %r" % c)
+                if not c["collapsible"]:
+                    self.assertEqual(c["gistWrap"], "normal", "a boxed one-liner with nothing to fold wraps, never an ellipsis with nothing behind it: %r" % c)
+            else:
+                self.assertTrue(c["slim"], "sent stays slim: %r" % c)
+            self.assertFalse(c["selfDot"], "the own chip wears no working dot: %r" % c)
+        self.assertEqual(card("Take the retry-loop")["peerBg"], "rgb(30, 161, 235)", "api's colour on its chip")
+        self.assertEqual(card("Heads-up")["peerBg"], "rgb(84, 178, 4)", "tests' colour on its chip")
+        # (amendment) the provisional dress: the pending send's own class on the not-yet-landed sent cards only
+        prov = {c["gist"][:20]: c["provisional"] for c in cards}
+        self.assertTrue(card("Please run the whole")["provisional"], "parked → provisional")
+        self.assertTrue(card("The remote build")["provisional"], "queued for relay → provisional")
+        for pfx in ("The backoff branch", "Did the fixtures", "Take the cap decision", "Ignore my last note", "Take the retry-loop"):
+            self.assertFalse(card(pfx)["provisional"], "landed, bounced, recalled and incoming are solid: %r" % pfx)
+        self.assertEqual(card("Please run the whole")["border"], "dashed", "the bubble's dashed border by the shared rule")
+        # (narrow) both colours still show: this session's chip collapses to its dot
+        for c in narrow["cards"]:
+            self.assertTrue(c["selfBg"] == "rgb(156, 210, 255)" and c["selfWidth"] is not None and c["selfWidth"] <= 12,
+                            "at 520 px the own chip is its coloured dot: %r" % c)
+            self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), "the kind is never truncated: %r" % c)
+        # (phone) under the 360 px container query the GIST yields; the kind word is never clipped
+        for c in phone["cards"]:
+            self.assertFalse(c["kindClipped"], "at 340 px the kind word is whole: %r" % c)
+        # (light theme) the two raw kind colours re-ink for the cream page: text contrast at or above 4.5:1
+        self.assertEqual(light["theme"], "light")
+        for k in ("delegate", "coordinate", "question"):
+            self.assertGreaterEqual(light["contrast"][k] or 0, 4.5, "%s reads on the light page: %r" % (k, light["contrast"]))
+            self.assertGreaterEqual(wide["contrast"][k] or 0, 4.5, "%s reads on the dark page: %r" % (k, wide["contrast"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_receipts.py
+++ b/tests/test_postal_receipts.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""T302: a SENT postal card carries the ledger's later outcomes for its message, so the chat's delivery icon
+can move after the send. The kernel used to stamp a sent card only at send time (delivered | parked); the
+postal ledger also records, per message id, `exec` (the recipient's inbox drain consumed it: a real read),
+`unexec` (a claimed-then-rolled-back drain), `relayed` (a far host's end-to-end ack), `bounced` (+ why) and
+`recall`. The postal index folds them onto the message's record and _hydrate_postal hands them to the sent
+card as `receipt`, with `remote` when the send crossed the peer bus. SYNTHETIC fixtures."""
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+em = load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
+
+WEB = "aaaaaaaa-1111-2222-3333-444444444444"
+API = "bbbbbbbb-1111-2222-3333-444444444444"
+T0 = 1_789_000_000
+
+
+def sent(mid, body, t, to=API, **extra):
+    row = {"t": t, "ev": "sent", "id": mid, "from": "web", "from_id": WEB, "to_id": to, "body": body,
+           "kind": "coordinate", "from_host": ""}
+    row.update(extra)
+    return row
+
+
+class ReceiptsRideTheIndex(unittest.TestCase):
+    def setUp(self):
+        self._saved = jd.STATE
+        self._td = tempfile.mkdtemp()
+        jd._rebind_state(Path(self._td))
+        (jd.STATE / "timeline").mkdir(parents=True, exist_ok=True)
+        self.log = jd.STATE / "timeline" / "messages.jsonl"
+        km._postal_index_memo[0] = None
+        self._saved_msgsum = km._msg_summaries
+        km._msg_summaries = lambda: {}
+
+    def tearDown(self):
+        km._msg_summaries = self._saved_msgsum
+        km._postal_index_memo[0] = None
+        jd._rebind_state(self._saved)
+
+    def _write(self, rows):
+        self.log.write_text("".join(json.dumps(r) + "\n" for r in rows))
+        km._postal_index_memo[0] = None
+
+    def test_the_index_folds_every_later_outcome_onto_the_sent_record(self):
+        self._write([
+            sent("m1", "ship the notes-api docs", T0),
+            {"t": T0 + 5, "ev": "exec", "id": "m1"},
+            sent("m2", "review the retry loop", T0 + 10, to="peer:TESTHOST"),
+            {"t": T0 + 12, "ev": "relayed", "id": "m2"},
+            sent("m3", "and the cap?", T0 + 20, to="peer:TESTHOST"),
+            {"t": T0 + 21, "ev": "bounced", "id": "m3", "why": "refused: the mailbox is isolated"},
+            sent("m4", "never mind", T0 + 30),
+            {"t": T0 + 31, "ev": "recall", "id": "m4"},
+            sent("m5", "claimed then rolled back", T0 + 40),
+            {"t": T0 + 41, "ev": "exec", "id": "m5"},
+            {"t": T0 + 42, "ev": "unexec", "id": "m5"},
+            {"t": T0 + 50, "ev": "exec", "id": "m-not-here"},      # an outcome for a message this log never sent
+        ])
+        idx = km._postal_index()
+        self.assertEqual(idx["m1"]["read"], T0 + 5)
+        self.assertEqual(idx["m2"]["relayed"], T0 + 12)
+        self.assertEqual(idx["m3"]["bounced"], T0 + 21)
+        self.assertEqual(idx["m3"]["bouncedWhy"], "refused: the mailbox is isolated")
+        self.assertEqual(idx["m4"]["recalled"], T0 + 31)
+        self.assertNotIn("read", idx["m5"], "a rolled-back drain is not a read")
+        self.assertNotIn("m-not-here", idx)
+        self.assertEqual(idx["m1"]["body"], "ship the notes-api docs", "the sent record's own fields are untouched")
+
+    def test_an_outcome_logged_before_its_sent_row_still_folds(self):
+        # deliver() publishes the file before it appends the sent row, and a drain can claim the file in that
+        # instant and log exec first; the postal service's own reader joins the two regardless of order, and so
+        # does the index (review, 2026-09-10)
+        self._write([
+            {"t": T0 + 1, "ev": "exec", "id": "m1"},
+            sent("m1", "ship the notes-api docs", T0),
+            {"t": T0 + 2, "ev": "exec", "id": "m2"},
+            {"t": T0 + 3, "ev": "unexec", "id": "m2"},
+            sent("m2", "rolled back", T0),
+        ])
+        idx = km._postal_index()
+        self.assertEqual(idx["m1"]["read"], T0 + 1)
+        self.assertNotIn("read", idx["m2"], "row order within an id still decides: exec then unexec is not read")
+
+    def _sent_event(self, body, t, output="Delivered to 'api'."):
+        return {"kind": "tool", "name": "mcp__romp-postal-service__send_message",
+                "input": json.dumps({"to": "api", "body": body, "kind": "coordinate"}),
+                "output": output, "ts": em_iso(t), "uuid": "u-" + str(t)}
+
+    def test_a_sent_card_carries_the_receipt_and_knows_a_remote_send(self):
+        self._write([
+            sent("m1", "ship the notes-api docs", T0),
+            {"t": T0 + 5, "ev": "exec", "id": "m1"},
+            sent("m2", "review the retry loop", T0 + 10, to="peer:TESTHOST"),
+            sent("m3", "and the cap?", T0 + 20, to="peer:TESTHOST"),
+            {"t": T0 + 21, "ev": "bounced", "id": "m3", "why": "undeliverable"},
+            sent("m6", "plain local send, nothing yet", T0 + 60),
+        ])
+        idx = km._postal_index()
+        cards = km._hydrate_postal([self._sent_event("ship the notes-api docs", T0),
+                                    self._sent_event("review the retry loop", T0 + 10),
+                                    self._sent_event("and the cap?", T0 + 20, output="parked for TESTHOST (unreachable)"),
+                                    self._sent_event("plain local send, nothing yet", T0 + 60)], idx)
+        by = {c["mid"]: c for c in cards}
+        self.assertEqual(by["m1"]["receipt"], {"read": T0 + 5}, "read: the recipient consumed it")
+        self.assertEqual(by["m2"]["receipt"], {"remote": True}, "across the relay, nothing acked yet: the icon reads sent")
+        self.assertEqual(by["m3"]["status"], "parked")
+        self.assertEqual(by["m3"]["receipt"], {"bounced": T0 + 21, "why": "undeliverable", "remote": True})
+        self.assertNotIn("receipt", by["m6"], "no outcome, no receipt field at all")
+        self.assertEqual(by["m6"]["status"], "delivered")
+
+    def test_an_errored_send_gets_no_receipt_even_when_a_same_body_row_exists(self):
+        # a refused send retried with the same words seconds later: the body-keyed join would hand the errored
+        # card the retry's outcomes; a message that never left carries none (review, 2026-09-10)
+        self._write([sent("m1", "ship the notes-api docs", T0 + 5), {"t": T0 + 9, "ev": "exec", "id": "m1"}])
+        idx = km._postal_index()
+        ev = self._sent_event("ship the notes-api docs", T0, output="mailbox refused")
+        ev["isError"] = True
+        cards = km._hydrate_postal([ev, self._sent_event("ship the notes-api docs", T0 + 5)], idx)
+        self.assertIsNone(cards[0]["status"])
+        self.assertNotIn("receipt", cards[0])
+        self.assertEqual(cards[1]["receipt"], {"read": T0 + 9})
+
+
+def em_iso(t):
+    from datetime import datetime, timezone
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -1,0 +1,104 @@
+// T302 (the user 2026-09-10, after seeing old and new postal cards side by side): the kind is coloured TEXT in the
+// old chip colours, the delivery state is an icon at the head's right edge (sent / delivered / read / parked /
+// bounced / recalled, from what the kernel files), both ENDS wear their sessions' colours (the peer's chip, then
+// this session's own), no card wears a background wash, and a sent card whose message has not landed wears the
+// pending send's own provisional dress (the queued bubble's class and rule). Source pins (render.ts has
+// import-time DOM side effects); the pure module is executed in postal-state.test.ts.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+function fn(name: string): string {
+  const i = RENDER.indexOf("function " + name + "(");
+  return RENDER.slice(i, RENDER.indexOf("\n}\n", i));
+}
+const CARD = fn("renderPostalService");
+
+test("the kind is coloured text in the meta slot, never a chip, in the old chip colours", () => {
+  assert.match(RENDER, /import \{ kindLabel, deliveryOf, deliveryTitle[^}]*\} from "\.\/postal-state";/);
+  assert.match(CARD, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
+  assert.match(CARD, /meta = el\("span", "postal-kind postal-kind-" \+ intent\.cls\); meta\.textContent = kind;/);
+  assert.doesNotMatch(CARD, /postal-service-intent|notice-chip/, "no chip");
+  // the two raw colours are TOKENS with light-theme values (2.2:1 and 2.1:1 on the cream page otherwise; review):
+  // 5.4:1 and 5.3:1 there, 6.4:1 and 6.7:1 on the dark page (WCAG text contrast 4.5:1)
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #b08cff\); \}/);
+  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #14b8a6\); \}/);
+  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, var\(--st-working-bg\)\); \}/);
+  assert.match(CSS, /\n  --postal-delegate: #b08cff;\s+--postal-coordinate: #14b8a6;\s+--postal-question: var\(--st-working-bg\);/, "the dark tokens (the old chip colours)");
+  const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
+  assert.match(light, /--postal-delegate: #6e3fd0;\s+--postal-coordinate: #0d6b64;\s+--postal-question: #7d5600;/, "the light tokens re-ink the three kinds (the working amber alone measured 4.26:1 on cream)");
+  // under the narrow container query the GIST yields, never the kind word (the ruling: the kind never truncates)
+  assert.match(CSS, /@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-gist \{ min-width: min\(100%, 4ch\); \}\n\}/);
+  assert.doesNotMatch(CSS, /@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-meta/, "the meta no longer shrinks under it");
+  // never truncated: the postal meta stays rigid
+  assert.match(CSS, /\.turn-postal-service \.notice-meta \{ flex: 0 0 auto; \}/);
+});
+
+test("the delivery state is one icon per state at the head's right edge, each with a worded title", () => {
+  for (const st of ["sent", "delivered", "read", "parked", "bounced", "recalled"]) {
+    assert.match(RENDER, new RegExp("^  " + st + ": '<", "m"), st + " has a glyph");
+  }
+  assert.match(RENDER, /const DELIVERY_GLYPHS: Record<PostalDeliveryState, string>/);
+  assert.match(fn("deliveryIcon"), /span\.dataset\.state = d\.state;/);
+  assert.match(fn("deliveryIcon"), /span\.setAttribute\("role", "img"\);/, "a labelled span is announced only with an image role");
+  assert.match(fn("deliveryIcon"), /const title = deliveryTitle\(d, clockOf\);[^\n]*\n\s*setTip\(span, title\);[^\n]*\n\s*span\.setAttribute\("role", "img"\);[^\n]*\n\s*span\.setAttribute\("aria-label", title\);/);
+  assert.match(CARD, /const delivery = deliveryOf\(ev\);/);
+  assert.match(CARD, /turn\.querySelector\("\.notice-head"\)\?\.appendChild\(deliveryIcon\(delivery\)\);/);
+  assert.match(CSS, /\.postal-delivery \{ flex: 0 0 auto; margin-left: auto;/, "the right edge");
+  // on a fold-less card whose one line wraps, the icon sits on the FIRST line like the glyph, not centred over the block
+  assert.match(CSS, /\.turn-postal-service \.notice:not\(\.notice-collapsible\) \.postal-delivery \{ align-self: flex-start; margin-top: 4px; \}/);
+  assert.match(CSS, /\.postal-delivery-read \{ color: var\(--accent\); \}/);
+  assert.match(CSS, /\.postal-delivery-parked \{ color: var\(--warn\); \}/);
+  assert.match(CSS, /\.postal-delivery-bounced \{ color: var\(--st-blocked-bg\); \}/);
+  // the words "delivered" / "parked" left the meta text: no meta words are pushed any more
+  assert.doesNotMatch(CARD, /meta\.push\(/);
+  // the event carries the ledger's receipt
+  assert.match(RENDER, /receipt\?: PostalReceipt;/);
+});
+
+test("both ends wear their sessions' colours: the peer's chip, then this session's own; a narrow head keeps its dot", () => {
+  assert.match(CARD, /const src = el\("span", "notice-src-ends"\);/);
+  // the own end is the session that OWNS the transcript being built (a comment popover's parent, a subagent
+  // viewer's session), the same chain every other owner lookup in the file uses (review, 2026-09-10)
+  assert.match(CARD, /const ownId = renderingOwnerSid \?\? renderingSid \?\? activeId;/);
+  assert.match(CARD, /const own = ownId && sessions\.has\(ownId\) \? sessions\.get\(ownId\) : undefined;/);
+  // the working dot is the peer chip's; the own chip never gains one from the next working frame (no flap)
+  assert.match(fn("refreshPostalDots"), /querySelectorAll\("\.notice-src-chip:not\(\.notice-src-self\)"\)/);
+  assert.match(CARD, /ev\.direction === "in" \? "from " : "to "/);
+  assert.match(CARD, /ev\.direction === "in" \? " to " : " from "/);
+  assert.match(CARD, /const self = el\("span", "notice-src-chip notice-src-self"\);/);
+  assert.match(CARD, /nm\.append\(\.\.\.hostNameNodes\(own\.name, ownId\)\);/, "the host label muted, as the tab wears it");
+  assert.match(CARD, /self\.style\.setProperty\("--peer-bg", own\.color\.bg\); self\.style\.setProperty\("--peer-fg", own\.color\.fg\);/);
+  assert.match(CSS, /@container \(max-width: 520px\) \{\n  \.turn-postal-service \.notice-src-self \{ width: 10px; height: 10px; padding: 0; border-radius: 50%;/);
+  assert.match(CSS, /\.turn-postal-service \.notice-src-self \.notice-src-name \{ display: none; \}/);
+});
+
+test("no card wears a background wash in a session's colour; incoming keeps border + rail, sent stays slim", () => {
+  assert.doesNotMatch(CSS, /\.notice-peer > \.notice:not\(\.notice-slim\)/, "the 6% peer wash is gone");
+  assert.doesNotMatch(CSS, /color-mix\(in srgb, var\(--notice-rail, transparent\) 6%/);
+  assert.match(CARD, /rail: ev\.color \? ev\.color\.bg : undefined,/, "the rail still names the peer");
+  // the shared notice rule (a body → a card, head-only → slim) stands, and the postal card overrides it for ONE
+  // direction: incoming keeps its box even with nothing to fold; sent stays slim
+  assert.match(fn("notice"), /const boxed = collapsible \|\| acts\.length > 0;/);
+  assert.match(CARD, /if \(ev\.direction === "in"\) \{ turn\.classList\.add\("notice-boxed"\); turn\.querySelector\("\.notice"\)\?\.classList\.remove\("notice-slim"\); \}/);
+  // …and a boxed card with nothing to fold still WRAPS its one line (T294's rule, now keyed on the fold, not on
+  // slimness): an ellipsis with nothing behind it to click is the dead end the rule forbids (review, 2026-09-10)
+  assert.match(CSS, /\.turn-postal-service \.notice:not\(\.notice-collapsible\) \.notice-gist \{ white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; \}/);
+  assert.match(CSS, /\.turn-postal-service \.notice:not\(\.notice-collapsible\) \.notice-glyph \{ align-self: flex-start; margin-top: 4px; \}/);
+  assert.doesNotMatch(CARD, /notice-peer/, "the wash hook is gone with the wash");
+});
+
+test("a sent card that has not landed wears the pending send's own provisional dress: the same class and rule", () => {
+  assert.match(CARD, /if \(ev\.direction === "out" && \(delivery\.state === "sent" \|\| delivery\.state === "parked"\)\) \{\s*\n\s*turn\.querySelector\("\.notice"\)\?\.classList\.add\("queued-bubble"\);/);
+  // the pending bubble's rule reaches the notice by a selector on the SAME declaration block — no lookalike copy
+  assert.match(CSS, /\.queued-bubble, \.notice\.notice-slim\.queued-bubble \{/);
+  assert.match(CSS, /\.notice\.notice-slim\.queued-bubble \{ max-width: none; display: block; \}/, "the row keeps its width (same specificity as the shared rule, later)");
+  // the bubble's border + padding move the head line down: the rail dot follows, as it does for a boxed card
+  assert.match(CARD, /turn\.classList\.add\("postal-provisional"\)/);
+  assert.match(CSS, /\.turn-postal-service\.postal-provisional > \.dot, \.turn-postal-service\.postal-provisional > \.time-marker \{ top: 18px; \}/);
+  assert.equal((CSS.match(/border: 1px dashed color-mix\(in srgb, var\(--you\) 65%, transparent\)/g) || []).length, 1,
+               "one dashed --you border rule in the file: the bubble's");
+});

--- a/ui/webview/postal-head.test.ts
+++ b/ui/webview/postal-head.test.ts
@@ -79,8 +79,8 @@ test("render.ts builds the postal card's head through postalHead and the shared 
 
 test("the head's meta never shrinks to a letter, and a head-only postal line wraps instead of truncating", () => {
   const CSS = read("ui", "webview", "styles.css");
-  assert.match(CSS, /\.turn-postal-service \.notice-head \{ container-type: inline-size; \}\n\.turn-postal-service \.notice-meta \{ flex: 0 0 auto; \}\n@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-meta \{ flex: 0 1 auto; min-width: min\(100%, 6ch\); \}\n\}/,
-               "the postal meta is rigid, and on a phone-width head (under 360px) it yields to a floor of its own inside the card");
+  assert.match(CSS, /\.turn-postal-service \.notice-head \{ container-type: inline-size; \}\n\.turn-postal-service \.notice-meta \{ flex: 0 0 auto; \}\n@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-gist \{ min-width: min\(100%, 4ch\); \}\n\}/,
+               "the head is the size container and the postal meta is rigid at every width; under 360px the GIST yields to a smaller floor, never the kind word (T302)");
   // scoped to the postal card: every other notice head's meta still yields (an API-error meta is a sentence, a compact
   // group head's meta is a whole gist, and both sit beside actions that must stay on the pane)
   assert.match(CSS, /\n\.notice-meta \{ flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/);
@@ -95,8 +95,8 @@ test("the head's meta never shrinks to a letter, and a head-only postal line wra
   // phone-width pane
   assert.match(CSS, /\n\.notice-gist \{ flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/);
   assert.match(CSS, /\n\.notice-head\[data-gkey\] \.notice-gist, \.turn-postal-service \.notice-gist \{ min-width: min\(100%, 10ch\); \}/);
-  assert.match(CSS, /\.turn-postal-service \.notice-slim \.notice-gist \{ white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; \}/,
+  assert.match(CSS, /\.turn-postal-service \.notice:not\(\.notice-collapsible\) \.notice-gist \{ white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; \}/,
                "a bare link (no space to break at) wraps too instead of running off the head");
   // the wrapped head keeps its glyph on the first line: a centred glyph sank to the middle of a three-line block
-  assert.match(CSS, /\.turn-postal-service \.notice-slim \.notice-glyph \{ align-self: flex-start; margin-top: 4px; \}/);
+  assert.match(CSS, /\.turn-postal-service \.notice:not\(\.notice-collapsible\) \.notice-glyph \{ align-self: flex-start; margin-top: 4px; \}/);   // keyed on the fold since T302 (a boxed incoming one-liner wraps too)
 });

--- a/ui/webview/postal-intent.test.ts
+++ b/ui/webview/postal-intent.test.ts
@@ -33,11 +33,12 @@ test("the DECLARED kind (ev.intent) drives the chip; the body-token parse is onl
   assert.match(RENDER, /intent\?: string;/);   // the event carries the declared kind
 });
 
-test("the intent reads as META text on the postal notice head — no coloured chip (2026-09-08)", () => {
-  // the notice-vocabulary pass: the three per-type colours (raw #b08cff / #14b8a6, the working yellow at 1.59:1 on
-  // cream) are retired; the label rides the head's meta slot beside the delivery state
-  assert.match(RENDER, /if \(intent\) meta\.push\(intent\.label\);/);
-  assert.match(RENDER, /else if \(ev\.status === "delivered"\) meta\.push\("delivered"\);/);
+test("the intent reads as coloured TEXT in the postal head's meta slot — no chip (2026-09-08; colours back as text, T302)", () => {
+  // the notice-vocabulary pass retired the chip; T302 (the user 2026-09-10) brings the three per-type colours back as
+  // TEXT colours on the word (a chip reads as a tag now): postal-state.ts kindLabel, postal-card.test.ts pins the rest.
+  // The word "delivered" left the meta for the delivery icon.
+  assert.match(RENDER, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
+  assert.doesNotMatch(RENDER, /meta\.push\("delivered"\)/);
   assert.doesNotMatch(CSS, /\.postal-service-intent/);
-  assert.doesNotMatch(CSS, /#b08cff/);
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #b08cff\); \}/);
 });

--- a/ui/webview/postal-state.test.ts
+++ b/ui/webview/postal-state.test.ts
@@ -1,0 +1,65 @@
+// T302: the postal card's kind word and delivery state, from what the kernel files (executed tests on the pure
+// module; the render pins live in postal-card.test.ts).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { kindLabel, deliveryOf, deliveryTitle } from "./postal-state";
+
+const clock = (t: number) => "T" + t;
+
+test("the kind is a capitalised word per class, empty when unknown", () => {
+  assert.equal(kindLabel("delegate"), "Delegation");
+  assert.equal(kindLabel("coordinate"), "Coordination");
+  assert.equal(kindLabel("question"), "Question");
+  assert.equal(kindLabel("fyi"), "");
+  assert.equal(kindLabel(null), "");
+});
+
+test("an incoming message in hand shows no delivery icon; one that waited while offline shows parked", () => {
+  assert.equal(deliveryOf({ direction: "in", t: 100 }), null);
+  assert.deepEqual(deliveryOf({ direction: "in", park: true, t: 100 }),
+                   { state: "parked", word: "Parked", t: 100, note: "waited while you were offline" });
+});
+
+test("a local send stamped delivered is delivered; read once the recipient consumed it", () => {
+  assert.deepEqual(deliveryOf({ direction: "out", status: "delivered", ts: "2026-09-10T16:41:00.000Z" }),
+                   { state: "delivered", word: "Delivered", t: Math.floor(Date.parse("2026-09-10T16:41:00.000Z") / 1000) });
+  assert.deepEqual(deliveryOf({ direction: "out", status: "delivered", receipt: { read: 200 } }),
+                   { state: "read", word: "Read", t: 200 });
+});
+
+test("across the relay: sent until the far host acks, then delivered; the recipient's read still wins", () => {
+  assert.equal(deliveryOf({ direction: "out", status: "delivered", receipt: { remote: true }, t: 100 })!.state, "sent");
+  assert.deepEqual(deliveryOf({ direction: "out", status: "delivered", receipt: { remote: true, relayed: 150 } }),
+                   { state: "delivered", word: "Delivered", t: 150 });
+  assert.equal(deliveryOf({ direction: "out", status: "delivered", receipt: { remote: true, relayed: 150, read: 160 } })!.state, "read");
+});
+
+test("parked, bounced and recalled outrank the send-time stamp; a bounce carries its reason", () => {
+  assert.deepEqual(deliveryOf({ direction: "out", status: "parked", t: 100 }), { state: "parked", word: "Parked", t: 100 });
+  assert.deepEqual(deliveryOf({ direction: "out", status: "parked", receipt: { bounced: 300, why: "refused: isolated" } }),
+                   { state: "bounced", word: "Bounced", t: 300, why: "refused: isolated" });
+  assert.deepEqual(deliveryOf({ direction: "out", status: "delivered", receipt: { recalled: 400 } }),
+                   { state: "recalled", word: "Recalled", t: 400 });
+  assert.equal(deliveryOf({ direction: "out", status: "delivered", receipt: { bounced: 300, read: 200 } })!.state, "bounced",
+               "a bounce is final whatever else the ledger says");
+});
+
+test("a send that errored has no state icon: the tool row itself says what happened", () => {
+  assert.equal(deliveryOf({ direction: "out", status: null }), null);
+  assert.equal(deliveryOf({ direction: "out" }), null);
+  // …even when the body-keyed join handed it a neighbour's receipt (a refused send retried with the same
+  // words seconds later): a message that never left wears no checks (review, 2026-09-10)
+  assert.equal(deliveryOf({ direction: "out", status: null, receipt: { read: 1 } }), null);
+  assert.equal(deliveryOf({ direction: "out", receipt: { relayed: 1, remote: true } }), null);
+});
+
+test("the title carries the word, the clock and the reason", () => {
+  assert.equal(deliveryTitle({ state: "delivered", word: "Delivered", t: 5 }, clock), "Delivered T5");
+  assert.equal(deliveryTitle({ state: "read", word: "Read" }, clock), "Read");
+  assert.equal(deliveryTitle({ state: "bounced", word: "Bounced", t: 7, why: "undeliverable" }, clock), "Bounced T7 — undeliverable");
+  assert.match(deliveryTitle({ state: "parked", word: "Parked", t: 9 }, clock), /^Parked T9 — delivers when/);
+  // an incoming message that waited is in hand: its title says so, never a future delivery (review, 2026-09-10)
+  assert.equal(deliveryTitle({ state: "parked", word: "Parked", t: 9, note: "waited while you were offline" }, clock),
+               "Parked T9 — waited while you were offline");
+  assert.match(deliveryTitle({ state: "sent", word: "Sent", t: 9 }, clock), /^Sent T9 — on its way/);
+});

--- a/ui/webview/postal-state.ts
+++ b/ui/webview/postal-state.ts
@@ -1,0 +1,76 @@
+// The postal card's two WORDS and its DELIVERY STATE (T302, the user 2026-09-10, after seeing old and new
+// renderings side by side): the interaction KIND is coloured text, never a chip (chips read as tags now), and
+// the delivery state is an ICON the way messaging apps show sent / delivered / read, at the head's right edge.
+// Side-effect-free, so the dashboard bundle and the node tests both load it.
+//
+// What the kernel actually files (kernel.py _postal_out_card, _cli_send_card, _hydrate_postal; the postal
+// ledger's events in postal/postal_service.py): a SENT card carries `status` as stamped at send time —
+// "delivered" (the send tool answered "Delivered to …"), "parked" (the recipient was unreachable or dead, the
+// message waits), or nothing (the send errored) — plus, joined by message id from the ledger, a `receipt`:
+// `read` (the recipient's inbox drain consumed it: a REAL read event, the ledger's `exec`), `relayed` (a far
+// host's end-to-end delivery ack), `bounced` (+ `why`: refused, or undeliverable), `recalled` (the sender
+// unsent it), `remote` (addressed across the peer bus). An INCOMING card is in hand by definition; it carries
+// only `park` (it waited while this session was offline).
+
+export type PostalDeliveryState = "sent" | "delivered" | "read" | "parked" | "bounced" | "recalled";
+
+export interface PostalReceipt {
+  read?: number;      // epoch s: the recipient consumed it
+  relayed?: number;   // epoch s: the far host acked delivery
+  bounced?: number;   // epoch s: returned
+  why?: string;       // a refusal's reason (bounced)
+  recalled?: number;  // epoch s: the sender unsent it
+  remote?: boolean;   // addressed across the peer bus (queued for relay until relayed)
+}
+
+export interface PostalDelivery {
+  state: PostalDeliveryState;
+  word: string;      // the title's word, capitalised: "Delivered"
+  t?: number;        // epoch s the state was reached, when the kernel knows it
+  why?: string;      // bounced: the reason
+  note?: string;     // a state's own tail for the title (an incoming parked message: it waited, it is in hand)
+}
+
+const KIND_WORDS: Record<string, string> = { delegate: "Delegation", coordinate: "Coordination", question: "Question" };
+
+/** The kind as coloured TEXT: "Delegation" / "Coordination" / "Question" (first letter capitalised), "" for an
+ *  unknown or absent kind. Takes the intent CLASS the render layer already resolves (delegate|coordinate|question). */
+export function kindLabel(cls: string | null | undefined): string {
+  return (cls && KIND_WORDS[cls]) || "";
+}
+
+/** The delivery state of a card, from what the kernel filed. null = no icon: an incoming message that is
+ *  simply in hand, or a sent one whose send errored (the tool row itself says what happened). */
+export function deliveryOf(ev: { direction: "in" | "out"; status?: string | null; park?: boolean; ts?: string; t?: number;
+                                receipt?: PostalReceipt | null }): PostalDelivery | null {
+  const sentAt = ev.t || (ev.ts ? Math.floor(Date.parse(ev.ts) / 1000) || undefined : undefined);
+  if (ev.direction === "in") {
+    // in hand by definition; `park` says it waited for this session while it was offline (the sent row's flag)
+    return ev.park ? { state: "parked", word: "Parked", t: sentAt, note: "waited while you were offline" } : null;
+  }
+  // a send that ERRORED has no state: the tool row itself says what happened — and never a neighbour's
+  // receipt (the body-keyed join can hand a refused send the outcomes of its retry with the same words)
+  if (ev.status == null) return null;
+  const r = ev.receipt || {};
+  if (r.bounced) return { state: "bounced", word: "Bounced", t: r.bounced, why: r.why || undefined };
+  if (r.recalled) return { state: "recalled", word: "Recalled", t: r.recalled };
+  if (r.read) return { state: "read", word: "Read", t: r.read };
+  if (r.relayed) return { state: "delivered", word: "Delivered", t: r.relayed };
+  if (ev.status === "parked") return { state: "parked", word: "Parked", t: sentAt };
+  if (ev.status === "delivered") {
+    // across the peer bus the send tool's "delivered" means handed to the relay: sent, not yet delivered
+    return r.remote ? { state: "sent", word: "Sent", t: sentAt } : { state: "delivered", word: "Delivered", t: sentAt };
+  }
+  return null;
+}
+
+/** The icon's title: the word, the clock when known, the reason for a bounce. `clock` formats an epoch. */
+export function deliveryTitle(d: PostalDelivery, clock: (epochS: number) => string): string {
+  let s = d.word;
+  if (d.t) s += " " + clock(d.t);
+  if (d.note) s += " — " + d.note;
+  else if (d.state === "parked") s += " — delivers when the session is reachable";
+  else if (d.state === "sent") s += " — on its way across the relay";
+  if (d.why) s += " — " + d.why;
+  return s;
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -91,6 +91,7 @@ import { reconcileRewindPass, type RewindEvent } from "./rewind-reconcile";
 import { watchChatVisibility, browserChatVisibilityDeps } from "./chat-visibility";
 import type { PaneHiddenHost } from "./paint-gate";
 import { gistOf, collapseWs, postalHead } from "./gist";   // the shared gist rule + the postal head (T294)
+import { kindLabel, deliveryOf, deliveryTitle, type PostalDelivery, type PostalDeliveryState, type PostalReceipt } from "./postal-state";   // the postal card's kind word + delivery state (T302)
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -182,7 +183,8 @@ type ChatEvent = (
       mid?: string;      // postal message id (joins feed-modal handoff hovers to this card)
       t?: number;        // epoch seconds (incoming)
       park?: boolean;
-      status?: "delivered" | "parked"; // outgoing
+      status?: "delivered" | "parked"; // outgoing, as stamped at send time
+      receipt?: PostalReceipt;         // outgoing: the ledger's later outcomes, joined by message id (read / relayed / bounced / recalled / remote)
       ts?: string;
       uuid?: string;
     }
@@ -4679,7 +4681,9 @@ function setPeerDot(peerEl: HTMLElement, on: boolean) {
   else if (!on && has) prev!.remove();
 }
 function refreshPostalDots() {
-  document.querySelectorAll(".notice-src-chip").forEach((p) => setPeerDot(p as HTMLElement, workingSet.has((p.textContent || "").trim())));
+  // the PEER chips only: this session's own end (.notice-src-self) shows its state elsewhere, and a dot that
+  // arrives with the next working frame and leaves on the next rebuild would only flap (T302 review)
+  document.querySelectorAll(".notice-src-chip:not(.notice-src-self)").forEach((p) => setPeerDot(p as HTMLElement, workingSet.has((p.textContent || "").trim())));
 }
 
 
@@ -4703,25 +4707,70 @@ function postalServiceIntent(body: string | undefined): { label: string; cls: st
   return m ? (POSTAL_INTENTS[m[1].toUpperCase()] || null) : null;
 }
 
+// The delivery-state icon at the postal head's right edge (T302, the user 2026-09-10): the way messaging apps
+// show sent / delivered / read. One check = sent (handed to the relay), two dim checks = delivered (in the
+// recipient's inbox, or the far host's ack), two coloured checks = read (the recipient consumed it: the
+// ledger's own exec event, never inferred), a clock = parked, a red mark = bounced, a return arrow = recalled.
+// Each carries a worded title with the clock. States and words: postal-state.ts.
+const DELIVERY_GLYPHS: Record<PostalDeliveryState, string> = {
+  sent: '<path d="M3 8.6 L6.4 12 L13 5"/>',
+  delivered: '<path d="M1.6 8.6 L4.8 11.8 L10.2 5.4"/><path d="M6.6 11.6 L14.4 5.4"/>',
+  read: '<path d="M1.6 8.6 L4.8 11.8 L10.2 5.4"/><path d="M6.6 11.6 L14.4 5.4"/>',
+  parked: '<circle cx="8" cy="8" r="5.6"/><path d="M8 4.8 V8.2 L10.4 9.6"/>',
+  bounced: '<path d="M4.5 4.5 L11.5 11.5"/><path d="M11.5 4.5 L4.5 11.5"/>',
+  recalled: '<path d="M6.6 4.6 L3.2 8 L6.6 11.4"/><path d="M3.2 8 H10 A2.8 2.8 0 0 0 12.8 5.2"/>',
+};
+function clockOf(epochS: number): string {
+  return new Date(epochS * 1000).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+function deliveryIcon(d: PostalDelivery): HTMLElement {
+  const span = el("span", "postal-delivery postal-delivery-" + d.state);
+  span.dataset.state = d.state;
+  span.innerHTML = '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + DELIVERY_GLYPHS[d.state] + "</svg>";
+  const title = deliveryTitle(d, clockOf);
+  setTip(span, title);                       // the pane's styled tip on hover…
+  span.setAttribute("role", "img");          // …and the same words for a screen reader: a labelled span is announced
+  span.setAttribute("aria-label", title);    //    only with an image role (the icon has no text)
+  return span;
+}
+
 function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>): HTMLElement {
-  // SOURCE = "from"/"to" + the house session chip naming the peer (the ONE coloured element in the notice
-  // vocabulary — the peer's identity colour, as the tab wears it); click the name → that session's tab
-  const chip = el("span", "notice-src-chip");
-  chip.textContent = ev.peer;
-  if (ev.color) { chip.style.setProperty("--peer-bg", ev.color.bg); chip.style.setProperty("--peer-fg", ev.color.fg); }
-  makeSessionChip(chip, ev.peer);
-  setPeerDot(chip, workingSet.has(ev.peer));   // working dot before the peer name if that session is working
-  const src = el("span");
+  // BOTH ENDS in the head, each in its session's colour (T302, the user 2026-09-10, after seeing old and new
+  // renderings): "from <peer> to <this session>" for incoming, "to <peer> from <this session>" for sent — the
+  // peer's chip in the peer's identity colour, this session's chip in its own, and NO wash of either colour on
+  // the card (a wash read as this session's colour). Click a name → that session's tab.
+  const peer = el("span", "notice-src-chip");
+  peer.textContent = ev.peer;
+  if (ev.color) { peer.style.setProperty("--peer-bg", ev.color.bg); peer.style.setProperty("--peer-fg", ev.color.fg); }
+  makeSessionChip(peer, ev.peer);
+  setPeerDot(peer, workingSet.has(ev.peer));   // working dot before the peer name if that session is working
+  // the session that OWNS the transcript being built (a comment popover's parent, a subagent viewer's session),
+  // the same chain every other owner lookup in this file uses; an id the tab set does not know draws no own end
+  const ownId = renderingOwnerSid ?? renderingSid ?? activeId;
+  const own = ownId && sessions.has(ownId) ? sessions.get(ownId) : undefined;
+  const src = el("span", "notice-src-ends");
   src.appendChild(document.createTextNode(ev.direction === "in" ? "from " : "to "));
-  src.appendChild(chip);
-  // interaction type (delegation / coordination / question) + delivery state, as META text — prefer the
-  // sender's DECLARED kind (send_message's `kind` param, surfaced by the kernel); the old leading-token
-  // parse of the body is only a legacy fallback now that the kind rides as an explicit field
+  src.appendChild(peer);
+  if (own && ownId) {
+    // this session's own end: its name (the host label muted, as the tab wears it) in its identity colour; a
+    // narrow head collapses it to its coloured dot (the container query in styles.css) — both colours still show
+    const self = el("span", "notice-src-chip notice-src-self");
+    const nm = el("span", "notice-src-name"); nm.append(...hostNameNodes(own.name, ownId));
+    self.appendChild(nm);
+    self.title = own.name;
+    if (own.color) { self.style.setProperty("--peer-bg", own.color.bg); self.style.setProperty("--peer-fg", own.color.fg); }
+    src.appendChild(document.createTextNode(ev.direction === "in" ? " to " : " from "));
+    src.appendChild(self);
+  }
+  // the interaction KIND as coloured text, never a chip (chips read as tags now): Delegation / Coordination /
+  // Question in the kind's colour — prefer the sender's DECLARED kind (send_message's `kind` param, surfaced by
+  // the kernel); the old leading-token parse of the body is only a legacy fallback. The postal meta is rigid,
+  // so the word is never truncated.
   const intent = (ev.intent && POSTAL_INTENTS[ev.intent.toUpperCase()]) || postalServiceIntent(ev.body);
-  const meta: string[] = [];
-  if (intent) meta.push(intent.label);
-  if (ev.park || ev.status === "parked") meta.push("parked");
-  else if (ev.status === "delivered") meta.push("delivered");
+  const kind = kindLabel(intent ? intent.cls : null);
+  let meta: HTMLElement | undefined;
+  if (kind && intent) { meta = el("span", "postal-kind postal-kind-" + intent.cls); meta.textContent = kind; }
   // Gist: ALWAYS a one-line summary, the incoming caption, else the first line of the message CLIPPED (gist.ts
   // postalHead), with the full message one click deeper whenever the gist does not carry all of it (the user
   // 2026-06-16; T294, the user 2026-09-10, whose one-paragraph sent card had no fold at all). KEYED (the user
@@ -4731,10 +4780,25 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
   if (fullMd) { body = el("div", "notice-md md"); body.innerHTML = md(fullMd, postalRepoFor(ev)); highlight(body); }
   // an incoming QUESTION opens by default: a reply is owed, and the whole ask is what you need to read
   const owed = !!intent && intent.cls === "question" && ev.direction === "in";
-  const turn = notice({ src, glyph: "peer", gist: summaryText, meta: meta.join(" · ") || undefined, body, open: owed,
+  const turn = notice({ src, glyph: "peer", gist: summaryText, meta, body, open: owed,
                         key: "postal:" + (ev.mid || ev.uuid || ""), rail: ev.color ? ev.color.bg : undefined,
-                        cls: "turn-postal-service postal-service-" + ev.direction + " notice-peer",
-                        tip: intent ? "interaction type: " + intent.label : undefined });
+                        cls: "turn-postal-service postal-service-" + ev.direction,
+                        tip: kind ? "interaction type: " + kind.toLowerCase() : undefined });
+  // the delivery state: an icon at the head's right edge, and — while the message has not landed (handed to the
+  // relay, or parked for an unreachable host) — the SAME provisional dress the user's own pending send wears
+  // (the queued bubble's class and tokens, the T302 amendment): solid again once the receipt says delivered,
+  // relayed or read; bounced keeps its red mark. Incoming: only a parked clock (it waited while you were offline).
+  const delivery = deliveryOf(ev);
+  if (delivery) {
+    turn.querySelector(".notice-head")?.appendChild(deliveryIcon(delivery));
+    if (ev.direction === "out" && (delivery.state === "sent" || delivery.state === "parked")) {
+      turn.querySelector(".notice")?.classList.add("queued-bubble");
+      turn.classList.add("postal-provisional");   // the bubble's border + padding move the head line: the rail dot follows
+    }
+  }
+  // an INCOMING message keeps its box (border + rail) even when its one line carries the whole message and there
+  // is nothing to fold; a SENT one stays the slim line (the ruling's density rule for the two directions)
+  if (ev.direction === "in") { turn.classList.add("notice-boxed"); turn.querySelector(".notice")?.classList.remove("notice-slim"); }
   if (ev.mid) turn.dataset.mid = ev.mid;   // joins feed-modal handoff hovers to this card
   return turn;
 }

--- a/ui/webview/romp-bubble.test.ts
+++ b/ui/webview/romp-bubble.test.ts
@@ -41,7 +41,7 @@ test("the swirl LOGO is on EVERY romp bubble, next to the 'romp' tag (the user 2
 test("a postal notice wears the peer's envelope glyph; the swirl is romp's OWN source glyph (2026-09-08)", () => {
   // the notice-vocabulary pass: one glyph per SOURCE — a peer's mail is from the peer (envelope + its session chip),
   // a romp notice is from romp (the swirl, the one non-stroke glyph)
-  assert.match(RENDER, /notice\(\{ src, glyph: "peer", gist: summaryText, meta: meta\.join\(" · "\) \|\| undefined, body, open: owed,/);
+  assert.match(RENDER, /notice\(\{ src, glyph: "peer", gist: summaryText, meta, body, open: owed,/);   // T302: the meta is the kind's coloured text element
   assert.match(RENDER, /if \(kind === "romp"\) \{\s*\n\s*const logo = el\("img"\) as HTMLImageElement;\s*\n\s*logo\.src = mediaSrc\("romp-swirl-glyph\.svg"\)/);
   assert.doesNotMatch(CSS, /\.postal-service-romp-logo/);
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -90,6 +90,9 @@ body.scheme-solarized-dark {
   --err: #c0392b;   /* unified with the awaiting/blocked red (the user 2026-06-24): one "needs you" red. API-error (--st-blocked-bg #e5484d) stays distinct. */
   --warn: #d7a23a;  /* the heads-up amber — "attention, not an error". Was referenced with fallbacks but never
                        defined (a phantom token) until 2026-08-26; mirrored in feed.css (own :root). */
+  /* the postal card's two KIND colours (T302): the pre-rewrite chip colours as text on the dark page (6.4:1 and
+     6.7:1); the light theme re-inks both (they read 2.2:1 and 2.1:1 on cream otherwise) */
+  --postal-delegate: #b08cff;  --postal-coordinate: #14b8a6;  --postal-question: var(--st-working-bg);
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
@@ -222,6 +225,9 @@ body.theme-light {
   --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
+  --postal-delegate: #6e3fd0;  --postal-coordinate: #0d6b64;  --postal-question: #7d5600;   /* 5.4:1, 5.3:1 and 5.5:1 on the
+                                                                                            cream page (T302); the working
+                                                                                            amber alone read 4.26:1 there */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
@@ -1879,11 +1885,14 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .turn-queued { display: flex; flex-direction: column; align-items: flex-end; padding: 6px 0 10px; gap: 5px; }
 .queued-head { display: inline-flex; align-items: center; gap: 5px; font-size: 0.82em; color: var(--dim); letter-spacing: 0.02em; }
 .queued-head .queued-icon { color: var(--accent); display: flex; }   /* wireframe hourglass in the accent blue */
-.queued-bubble {
+.queued-bubble, .notice.notice-slim.queued-bubble {   /* …and a SENT postal card whose message has not landed yet wears the
+                                                         same dress by the same class (T302): one provisional vocabulary */
   max-width: 72%; overflow-wrap: anywhere; display: flow-root;
   background: color-mix(in srgb, var(--you) 10%, transparent); border: 1px dashed color-mix(in srgb, var(--you) 65%, transparent);
   border-radius: 14px; padding: 7px 12px; color: var(--fg); opacity: 0.85;
 }
+.notice.notice-slim.queued-bubble { max-width: none; display: block; }   /* the notice keeps its row width and flex head; only the
+                                                                            dress is the bubble's (same specificity as the shared rule, later) */
 /* A CANCELABLE queued bubble carries an explicit ✕ (the user 2026-07-08 — the old whole-bubble click was
    undiscoverable and re-render-fragile). The bubble itself is no longer clickable; only the ✕ acts. It sits
    in the top-right corner (the bubble reserves padding for it) — dim until the bubble is hovered, red on
@@ -2167,9 +2176,10 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 
 /* ---------- postal cards (romp peer mail) + teammate messages ---------- */
 /* Both are THE notice since 2026-09-08 (renderPostalService / renderTeammate): a peer's mail wears its
-   identity colour on the rail + dot + the session chip in the SOURCE slot and a 6% wash of it (.notice-peer);
-   the intent and delivery state read as meta text; a teammate message is the plain notice under the
-   "teammate <name>" label (the dashed frame said what the label now says). One keyed fold each. */
+   identity colour on the rail + dot and on the peer's chip in the SOURCE slot, beside this session's own chip in
+   ITS colour (T302, the user 2026-09-10: no wash of either colour — a wash read as this session's); the kind is
+   coloured text and the delivery state an icon at the head's right edge; a teammate message is the plain notice
+   under the "teammate <name>" label (the dashed frame said what the label now says). One keyed fold each. */
 .dot.mail { background: var(--peer-bg, var(--dim)); border: none; }
 /* a session-name chip that navigates on click (sender/recipient name) */
 .chip-nav { cursor: pointer; }
@@ -2275,8 +2285,8 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 .notice-sev-needs > .notice:not(.notice-slim), .notice.notice-sev-needs:not(.notice-slim) {
   box-shadow: inset 3px 0 0 var(--st-awaiting-bg); }
 /* a peer's mail: a 6% wash of the peer's identity colour (the rail/dot take it inline) */
-.notice-peer > .notice:not(.notice-slim), .notice.notice-peer:not(.notice-slim) {
-  background: color-mix(in srgb, var(--notice-rail, transparent) 6%, var(--box-bg)); }
+/* (the peer-colour wash a postal card once wore is gone — T302, the user 2026-09-10: it read as THIS session's
+   colour. The two ends carry the colours now: the peer's chip and this session's chip in the head.) */
 .turn-notice { padding-top: 6px; padding-bottom: 6px; }
 .turn-notice > .dot, .turn-notice > .time-marker { top: 10px; }              /* slim: on the head line */
 .turn-notice.notice-boxed > .dot, .turn-notice.notice-boxed > .time-marker { top: 18px; }   /* boxed: past the border + padding */
@@ -2326,18 +2336,44 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    become "q…"). Scoped to the postal card: an API-error head carries a sentence-long meta and a compact notice-group
    head carries a whole gist there, and those must still yield to the actions beside them on a narrow pane. The head is
    the size container: on a phone-width one (under 360px) even the short words do not fit beside the gist's floor, and
-   there the meta yields again, to a floor of its own, inside the card instead of running out of it. */
+   there the GIST yields further, to a smaller floor, and the kind word stays whole (T302: the kind never truncates). */
 .turn-postal-service .notice-head { container-type: inline-size; }
 .turn-postal-service .notice-meta { flex: 0 0 auto; }
 @container (max-width: 360px) {
-  .turn-postal-service .notice-meta { flex: 0 1 auto; min-width: min(100%, 6ch); }
+  .turn-postal-service .notice-gist { min-width: min(100%, 4ch); }
 }
-/* a head-only postal line hides nothing behind a fold, so it may not hide anything behind an ellipsis either: a
-   one-liner that outgrows the head wraps, an unbroken token (a bare link) included (T294) */
-.turn-postal-service .notice-slim .notice-gist { white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; }
+/* T302 (the user 2026-09-10): the interaction KIND is coloured TEXT in the meta slot — a chip reads as a tag now — in
+   the colours the old chips wore: delegation violet, coordination teal, question the working amber. */
+.postal-kind { font-weight: 600; }
+.postal-kind-delegate { color: var(--postal-delegate, #b08cff); }
+.postal-kind-coordinate { color: var(--postal-coordinate, #14b8a6); }
+.postal-kind-question { color: var(--postal-question, var(--st-working-bg)); }
+/* BOTH ENDS of a postal card in the head, each in its session's identity colour (the peer's chip as before, and this
+   session's own chip after it); a narrow head collapses this session's chip to its coloured dot, so both colours
+   still show where the words would not fit */
+.notice-src-ends { display: inline-flex; align-items: baseline; gap: 4px; white-space: nowrap; }
+@container (max-width: 520px) {
+  .turn-postal-service .notice-src-self { width: 10px; height: 10px; padding: 0; border-radius: 50%; align-self: center; overflow: hidden; }
+  .turn-postal-service .notice-src-self .notice-src-name { display: none; }
+}
+/* the DELIVERY STATE icon at the head's right edge (postal-state.ts for the map): dim for sent and delivered, the
+   accent for read, the heads-up amber for parked, the blocked red for bounced */
+.postal-delivery { flex: 0 0 auto; margin-left: auto; display: inline-flex; align-self: center; color: var(--dim); }
+.postal-delivery-read { color: var(--accent); }
+.postal-delivery-parked { color: var(--warn); }   /* the heads-up amber: waiting, not an error */
+.postal-delivery-bounced { color: var(--st-blocked-bg); }
+/* a postal card with NOTHING TO FOLD hides nothing behind a fold, so it may not hide anything behind an ellipsis
+   either: a one-liner that outgrows the head wraps, an unbroken token (a bare link) included (T294). Keyed on the
+   fold, not on slimness (T302): an incoming one-liner is boxed now and must wrap the same way. */
+.turn-postal-service .notice:not(.notice-collapsible) .notice-gist { white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: anywhere; }
 /* and its glyph sits on the FIRST line of the wrapped head (the centred glyph of a one-line head drifts to the
    middle of a three-line block otherwise); 4px is the centred offset within the head's own line */
-.turn-postal-service .notice-slim .notice-glyph { align-self: flex-start; margin-top: 4px; }
+.turn-postal-service .notice:not(.notice-collapsible) .notice-glyph { align-self: flex-start; margin-top: 4px; }
+/* …and so does the delivery icon at the right edge: on the first line, not centred over the wrapped block */
+.turn-postal-service .notice:not(.notice-collapsible) .postal-delivery { align-self: flex-start; margin-top: 4px; }
+/* a sent card in the provisional dress wears the bubble's border + padding: its rail dot and time marker sit where a
+   boxed card's do (T302 review) */
+.turn-postal-service.postal-provisional > .dot, .turn-postal-service.postal-provisional > .time-marker { top: 18px; }
 .notice-acts { flex: 0 0 auto; margin-left: auto; display: inline-flex; gap: 4px; align-self: center; }
 /* word buttons on the button vocabulary: the sm box, the T141 rest, pattern-A hover, the press cue */
 .notice-act { font-family: var(--sans); font-size: var(--btn-fs-sm); line-height: 1.4; padding: var(--btn-pad-sm);


### PR DESCRIPTION
## What

The postal cards in the chat pane, as the user ruled after seeing the old and new renderings side by side (2026-09-10), building on the gist-and-fold fix already on main. Kept: the envelope glyph, the FROM / TO words, the one-line gist with its fold.

1. **The kind is coloured TEXT, never a chip** (chips read as tags now): "Delegation" `#b08cff`, "Coordination" `#14b8a6`, "Question" `var(--st-working-bg)`, the colours the pre-rewrite chips wore, placed in the head's meta slot, which stays rigid so the word is never truncated.
2. **The delivery state is an icon at the head's right edge**, the way messaging apps show sent / delivered / read, each with a worded title and the clock ("Delivered 9:41 AM"). The states are the ones the kernel actually files: a sent card is stamped at send time (delivered | parked | nothing on error), and the postal ledger records, per message id, `exec` (the recipient's inbox drain consumed it: a real read event), `relayed` (the far host's end-to-end ack), `bounced` (+ why), `recall`. The kernel's postal index now folds those onto the message's record and the sent card carries them as `receipt` (with `remote` for a send across the peer bus). Map (`ui/webview/postal-state.ts`): one check = sent (handed to the relay), two dim checks = delivered, two accent checks = read, a clock = parked, a red mark = bounced (the title carries the reason), a return arrow = recalled; an incoming card in hand shows no icon, one that waited while the session was offline shows the clock. The word "delivered" left the meta text.
3. **Both ends wear their sessions' colours, and no card wears a wash**: the head reads FROM <peer chip, peer colour> TO <this session's chip, its own colour> for incoming, TO / FROM for sent; under 520 px this session's chip collapses to its coloured dot so both colours still show. The 6% peer-colour wash is gone (it read as this session's colour). Incoming messages keep their box (border + rail) even when their one line carries the whole message; sent ones stay slim lines.
4. **Amendment (the user, same day): a sent message that has not landed wears the pending send's own provisional dress.** A sent card in the sent or parked state carries the queued bubble's class (`queued-bubble`), and the bubble's dashed rule reaches it by a selector on the same declaration block, not a copy; it turns solid when the receipt says delivered, relayed or read; bounced keeps its red mark. The icon and the dress agree by construction (both read `deliveryOf`).

## Tests

- `ui/webview/postal-state.test.ts`: the pure rules (kind word, state per receipt, titles).
- `ui/webview/postal-card.test.ts`: pins for the kind text and colours, the icon-per-state map and its right-edge placement, the both-ends head and its narrow collapse, the no-wash rule, the boxed-incoming rule, the shared provisional class and rule.
- `tests/test_postal_receipts.py`: the index folds exec / unexec / relayed / bounced / recall; a sent card carries `receipt` and `remote`.
- `tests/test_postal_cards_served.py`: the real /chat page of a hermetic kernel over a synthetic chat (web with peers api and tests, nine cards, every kind and state) at 1000 px and 520 px: kind words and colours, icon per state with its title, both chips with their colours, no wash, boxed vs slim, the provisional dress on the two not-landed cards only, the narrow collapse. With `POSTAL_SHOTS` set it writes the screenshots.
- Two existing pins updated (the intent's meta-text pin; the notice-vocabulary retirement of the colours, which now return as text colours).

Design points: the two surfaces share one provisional vocabulary (the class, not a lookalike); the read state is real (the ledger's exec event), never inferred; the fold-through of ledger outcomes costs one pass over the same append-incremental log the index already reads.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
