### PR TITLE
The deep-link landing test pins the address the dashboard token scrub leaves; the tap itself was landing all along (T307)

### DIFF
--- a/tests/test_notification_tap_resume_browser.py
+++ b/tests/test_notification_tap_resume_browser.py
@@ -30,9 +30,10 @@ Three scenarios against the REAL shell, the REAL worker and the REAL kernel (her
   2. THE LINK ROAD (what an iOS tap produces): the page is navigated to the deep link the declarative message's
      `navigate` names — '/?push-reveal=<api>&push-pid=<pid>' — as iOS does on a tap. The page must land it at boot:
      ONE /reveal via 'link' with boot:true, parked by the kernel and consumed on the chat pane's ready (the tab
-     becomes `api`), /push/landed for the pid, the params stripped from the URL, the 'deeplink' row on file. Then the
-     open page GAINS the params without a load (history.pushState + pageshow, the window iOS navigates in place)
-     for a second push: landed live via 'link' (no boot flag), settled, stripped.
+     becomes `api`), /push/landed for the pid, the params stripped from the URL (and the ?token= it was opened
+     with, which the shell drops once the cookie is set), the 'deeplink' row on file. Then the open page GAINS the
+     params without a load (history.pushState + pageshow, the window iOS navigates in place) for a second push:
+     landed live via 'link' (no boot flag), settled, stripped.
   3. THE VANISH ROAD (what a LIVE iOS app leaves): three test pushes (`api`, `tests`, `docs`) filed at the kernel and
      acked shown by pid, as the phone's worker acks them; the page stubs getNotifications by data.pid and comes forward
      three times. Two of three displayed → exactly the missing one lands: ONE /reveal via 'vanish', the tab on `api`,
@@ -167,6 +168,7 @@ const active = () => chat.evaluate(() => (document.querySelector("#tabs .tab.act
 out.landed = await chat.waitForFunction((sid) => (document.querySelector("#tabs .tab.active") || {}).dataset?.id === sid, cfg.sidB, { timeout: 20000 }).then(() => true).catch(() => false);
 out.after = await active();
 out.urlAfterBoot = page.url();
+out.cookies = (await context.cookies(cfg.origin)).map((c) => ({ name: c.name, value: c.value }));   // the token's home once the address drops it
 for (let i = 0; i < 40 && !out.ledger.length; i++) await page.waitForTimeout(50);
 out.boot = { reveals: out.reveals.slice(), ledger: out.ledger.slice() };
 // back to `web`, so the second arrival has something to change
@@ -328,7 +330,7 @@ class ServedTapLanding(unittest.TestCase):
         base = "http://127.0.0.1:%d" % self.port
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump(dict({"origin": base, "landing": base + "/?token=" + self.token, "sidA": SID_A, "sidB": SID_B}, **extra), f)
+            json.dump(dict({"origin": base, "landing": base + "/?token=" + self.token, "token": self.token, "sidA": SID_A, "sidB": SID_B}, **extra), f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(driver_src)
@@ -490,7 +492,16 @@ class ServedTapLanding(unittest.TestCase):
         self.assertEqual(b["ledger"], [{"pid": pid}], "the row the link named is settled")
         self.assertNotIn("push-reveal", out["urlAfterBoot"], "the params are stripped once read: %r" % out["urlAfterBoot"])
         self.assertNotIn("push-pid", out["urlAfterBoot"])
-        self.assertIn("token=", out["urlAfterBoot"], "…and only OUR params go")
+        # The token leaves the address too, by a different hand: the shell's head drops ?token= the moment the page runs,
+        # once the response that served it has turned it into the romp_token cookie (the dashboard token scrub, 2026-09-10,
+        # which landed on main the same morning as this test and after its pin that "only our params go" was written).
+        # What the user has after a tap is a clean address and a signed-in page: the cookie is what every later request
+        # rides, including the second arrival below. Until this change the line read assertIn, and on main it failed for
+        # that reason alone; the tap itself had landed (every assertion above it passed).
+        self.assertNotIn("token=", out["urlAfterBoot"], "the address keeps no token once the cookie is set: %r" % out["urlAfterBoot"])
+        self.assertEqual([c["value"] for c in out["cookies"] if c["name"] == "romp_token"], [self.token],
+                         "the token must live on as the cookie the page rides, or the clean address is a logout: %r" % out["cookies"])
+        self.assertEqual(out["urlAfterBoot"].rstrip("/"), "http://127.0.0.1:%d" % self.port, "nothing else is left on the address: %r" % out["urlAfterBoot"])
         # THE IN-PLACE ARRIVAL: the open page gained the link without a load and landed it live
         self.assertTrue(out["landed2"], "the open page gaining the link must land it; the tab is %r, reveals %r\n  kernel: %s" % (out["after2"], out["later"]["reveals"], self._reveal_lines()))
         l = out["later"]


### PR DESCRIPTION
The browser-backed deep-link landing test (`tests/test_notification_tap_resume_browser.py`, the link road) fails on a pristine `upstream/main`: after the page boots on `/?token=…&push-reveal=…&push-pid=…`, the address is the bare origin, and the test pinned that `token=` must stay. That pin is stale, not a regression: the same morning the test landed (mobile-tap-3, 09:47 UTC), the dashboard token scrub landed in parallel (dashboard-token-scrub-offer, 10:14 UTC, neither commit an ancestor of the other) and made the shell's head drop `?token=` the moment the page runs, once the response that served it has turned the token into the `romp_token` cookie every later request rides. Everything the test asserts about the tap itself passed on main before the token line: the chat pane's active tab became the linked session, exactly one `/reveal` via `link` with the boot flag, the ledger row settled, the push params stripped. The click and vanish scenarios pass on main as well.

What the user sees after a notification tap: the session opens and the address bar shows a clean origin with no token in it; the cookie keeps them signed in (the second, in-place arrival the same test drives rides that cookie and lands too). No login prompt, no dead landing.

The change: the driver reports the browser context's cookie names after boot; the test now pins the scrub's contract instead of the pre-scrub address: no `token=` in the address, the `romp_token` cookie present (a clean address WITHOUT the cookie would be a logout, which is the regression this line now guards), and nothing else left on the address. Red-first: the file was red on main for the stale line alone; with the re-pin all three scenarios pass (3 passed, 6.2 s, Chromium via playwright, hermetic kernel per class).

Why CI could not catch it: the Python jobs install no node dependencies and no browser, so every served-page test (ten files, `tests/*browser*.py` and `tests/*served*.py`) raises SkipTest there; the extension job does install playwright's Chromium, but only for the pane bench (`node --test tests/ui-bench.test.mjs`), and never runs the Python browser tests. Recommendation, for a separate change: run those ten in the extension job right after `npx playwright install chromium` (python3 and the built dist are already there), as one step with the same skip-to-failure stance the bench uses, so a runner missing the browser turns the job red rather than green with the coverage gone; they took about six seconds per file here, so the cost is minutes. This PR changes no CI.

Tier: fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
