### PR TITLE
Idle dots: a tmux stall no longer kills the daemon; sweep()'s except arm returns the pair the loop unpacks

### DIFF
--- a/cli/idle_dots.py
+++ b/cli/idle_dots.py
@@ -131,9 +131,12 @@ def _heal(name, since0, now):
 
 def sweep():
     """One pass. Sets ⚪ on any READY romp session quiet > STALE_AFTER_SECS, only
-    where it differs (no needless churn). Returns False when there are NO romp
-    sessions, so the daemon loop can exit; True otherwise (incl. tmux hiccups —
-    don't exit on a transient error)."""
+    where it differs (no needless churn). Returns the pair `(alive, compacting)`
+    the daemon loop unpacks: alive is False only when there are NO romp sessions,
+    so the loop can exit; compacting picks the fast cadence while a session
+    compacts. A tmux hiccup (list-sessions past its timeout, a spawn that raises)
+    returns (True, False): the daemon keeps its normal cadence and retries on the
+    next sweep instead of dying on a transient error."""
     now = int(time.time())
     try:
         p = subprocess.run(
@@ -141,7 +144,7 @@ def sweep():
              "#{@romp}|#{session_name}|#{@claude-state}|#{@claude-state-since}|#{@romp-emoji}|#{pane_in_mode}"],
             capture_output=True, text=True, timeout=5)
     except Exception:
-        return True
+        return True, False       # alive, not compacting: the caller unpacks a pair
     any_romp = changed = compacting = False
     for line in (p.stdout or "").splitlines():
         f = line.split("|")

--- a/tests/test_romp_idle_dots.py
+++ b/tests/test_romp_idle_dots.py
@@ -11,9 +11,11 @@ pane content can ("esc to interrupt" = genuinely busy; idle composer ❯ = heal)
 Run:  python3 tests/test_romp_idle_dots.py
 """
 import os
+import subprocess
 import sys
 import unittest
 from romp_load import load_source
+from unittest import mock
 import tempfile
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -105,6 +107,35 @@ class TestCompactPct(unittest.TestCase):
         first ~50% (the user). Guards against regressing INTERVAL back up."""
         self.assertLessEqual(dots.INTERVAL, 10, "sweep cadence must catch a compaction's start")
         self.assertLessEqual(dots.COMPACT_INTERVAL, dots.INTERVAL, "fast-poll while compacting")
+
+
+class TestSweepReturnShape(unittest.TestCase):
+    """sweep() returns the pair `(alive, compacting)` on EVERY path, the except arm included.
+
+    The daemon loop unpacks that pair (`alive, compacting = sweep()`). When `tmux list-sessions`
+    stalls past its 5 s timeout on a loaded box (subprocess.TimeoutExpired), or subprocess.run
+    raises for any other reason, the except arm used to return a bare True from the older
+    truthy-loop shape: the unpack raised TypeError, daemon() exited, its finally unlinked the pid
+    file, and the detached daemon (stderr on /dev/null) died silently until the next --ensure:
+    no idle dot faded, no Esc-stranded working state healed, no compaction percentage published.
+    These unpack exactly as the daemon does, so a bare bool fails here the way it failed there."""
+
+    def _sweep_with_run_raising(self, exc):
+        with mock.patch.object(dots.subprocess, "run", side_effect=exc) as run:
+            alive, compacting = dots.sweep()          # daemon()'s own unpack
+        self.assertEqual(run.call_count, 1, "the hiccup ends the sweep at list-sessions")
+        return alive, compacting
+
+    def test_list_sessions_timeout_keeps_the_daemon_alive_at_normal_cadence(self):
+        alive, compacting = self._sweep_with_run_raising(
+            subprocess.TimeoutExpired(cmd="tmux", timeout=5))
+        self.assertIs(alive, True)
+        self.assertIs(compacting, False)
+
+    def test_any_spawn_failure_keeps_the_daemon_alive_at_normal_cadence(self):
+        alive, compacting = self._sweep_with_run_raising(FileNotFoundError("tmux"))
+        self.assertIs(alive, True)
+        self.assertIs(compacting, False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main`: the idle-dots daemon, the small process that fades a quiet tmux session's status dot and heals a session left showing "working" after an Esc, promised in its own docstring to survive a transient tmux error. It did not. Its sweep returned a bare `True` from the error arm while every other path returned the pair its caller unpacks, so a `tmux list-sessions` that stalled past its five-second timeout on a loaded box, or any other raise from the spawn, ended the daemon with a `TypeError`. Its exit handler removed the pid file, and since the daemon runs detached with its streams on `/dev/null`, nothing said so. Until the next hook event respawned it, no dot faded, no stranded "working" state healed, and no compaction percentage was published. The mismatch dates from the change that made the sweep return a pair and left the error arm as it was.

## What changes
The error arm returns the pair: alive, and not compacting, so the daemon keeps its normal cadence and retries on the next pass. The docstring now describes the pair contract as the code has it, including that a hiccup returns exactly that. No new log line, because the daemon has no stream to carry one and a documented retry is not a silent fallback to worse data.

## Deliberately left out
The same docstring's first sentence names the inactive dot with a glyph that differs from the constant the code writes; that wording is shared with the hook and its test and is a small sweep of its own.

## Tests
Two cases drive the real sweep with only the subprocess call patched, one raising the timeout and one raising a spawn failure, and unpack the result the way the daemon does. On `main` both fail with `TypeError: cannot unpack non-iterable bool object`. The module passes 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
