### PR TITLE
romp update: a help request or an unknown option is refused, not answered by updating every remote

### DIFF
--- a/cli/update.py
+++ b/cli/update.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""romp-update — push THIS machine's committed romp to attached REMOTE kernels + restart them
-(`romp update [host...]`).
+"""usage: romp update [host...]
 
-Peer-to-peer, no GitHub (the user 2026-07-04): the local kernel pushes its committed HEAD straight to each
-host over ssh and restarts it, so the remote runs exactly the local code — no `git pull` from origin, no round
-trip through GitHub. With NO host it updates every attached remote that is out of date (running a different
-commit than local). Uncommitted local edits are NOT sent — commit first. (To update THIS machine, use your own
-`git pull`/checkout then `romp refresh`.)
+Push THIS machine's committed romp to attached REMOTE kernels and restart them, so each runs exactly the
+local code. With no host, every attached remote that is out of date (running a different commit than local)
+is updated; naming hosts updates just those. The local kernel pushes its committed HEAD straight to each
+host over ssh and restarts it: peer-to-peer, no `git pull` from origin, no round trip through GitHub.
+Uncommitted local edits are NOT sent; commit first. To update THIS machine, `git pull` or check out the
+commit you want, then `romp refresh`.
+
+  -h, --help   print this and do nothing else. There are no other options: an unknown one is refused,
+               and nothing is pushed.
 """
+# Peer-to-peer, no GitHub, by the user's 2026-07-04 decision. The docstring doubles as the -h text, so it
+# reads as usage first and keeps attributions down here.
 import json
 import os
 import sys
@@ -67,11 +72,22 @@ def _post(u, path, body):
 
 
 def main(argv):
+    # bin/romp hands over every word after `update`, and this command defines no option, so a dash-prefixed
+    # word is either a help request or a mistake. Both are answered here, before anything is pushed. Dropping
+    # them unread, as the hosts line alone used to, sent `romp update --help` down the no-host path, which
+    # force-pushed the local HEAD to every out-of-date remote and restarted it, cutting its sessions' turns.
+    flags = [a for a in argv if a.startswith("-")]
+    if "-h" in flags or "--help" in flags:                          # help needs no kernel and touches nothing
+        sys.stdout.write(__doc__)
+        return 0
+    if flags:
+        sys.stderr.write("romp update: unknown option %s (usage: romp update [host...])\n" % flags[0])
+        return 2
     u = _kernel()
     if not u:
         sys.stderr.write("romp update: no running kernel found (is romp on? try `romp status`)\n")
         return 2
-    hosts = [a for a in argv if not a.startswith("-")]
+    hosts = list(argv)
     if not hosts:                                                   # no host → the out-of-date attached remotes
         try:
             tuns = _get(u, "/tunnels?fresh=1").get("tunnels", [])    # judged against the head this checkout is at NOW, not the dashboard's 15 s cache

--- a/tests/test_romp_update_flags.py
+++ b/tests/test_romp_update_flags.py
@@ -1,0 +1,89 @@
+"""`romp update` answers a help request or an unknown option by refusing, never by updating. bin/romp hands
+romp-update every word after `update`, and the command defines no option; before this the dash-prefixed
+words were dropped unread, so `romp update --help` (or `-n`, or a misspelled option) took the no-host path
+and pushed the local HEAD to every out-of-date attached remote, restarting it and cutting its sessions'
+turns, with exit 0 and an "ok" line. Now -h/--help prints the usage and returns 0, any other option names
+itself on stderr with the usage and returns 2, and neither posts anything; the no-host path itself is
+unchanged. SYNTHETIC host; the kernel seams (_kernel/_get/_post) are stubbed so nothing connects."""
+import contextlib
+import io
+import os
+import tempfile
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+# Hermetic state BEFORE the load (tests/test_state_isolation_order.py's ratchet): romp modules resolve
+# their state root at import time, and only pytest runs conftest's floor.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+ru = load_source("romp_update_flags", os.path.join(BIN, "romp-update"))
+
+USAGE = "romp update [host...]"
+
+
+class UpdateFlagsRefused(unittest.TestCase):
+    def setUp(self):
+        self._k, self._g, self._p = ru._kernel, ru._get, ru._post
+        ru._kernel = lambda: "http://127.0.0.1:29855"
+        # one out-of-date remote: the no-host path WOULD update it, so any flag that falls through shows up here
+        ru._get = lambda u, path: {"tunnels": [{"host": "TESTHOST", "outOfDate": True}]}
+        self.posted = []
+        ru._post = lambda u, path, body: (self.posted.append((path, body)) or {"ok": True, "detail": "updated"})
+
+    def tearDown(self):
+        ru._kernel, ru._get, ru._post = self._k, self._g, self._p
+
+    def _run(self, argv):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = ru.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
+    def _assert_help(self, flag):
+        rc, out, err = self._run([flag])
+        self.assertEqual(self.posted, [], "%s is a help request; it must push to no remote" % flag)
+        self.assertEqual(rc, 0)
+        self.assertIn(USAGE, out, "the help text names the usage")
+        self.assertEqual(out, ru.__doc__, "the module docstring is the help text")
+        self.assertEqual(err, "")
+
+    def test_long_help_prints_the_usage_and_updates_nothing(self):
+        self._assert_help("--help")
+
+    def test_short_help_prints_the_usage_and_updates_nothing(self):
+        self._assert_help("-h")
+
+    def test_help_needs_no_running_kernel(self):
+        ru._kernel = lambda: None
+        rc, out, err = self._run(["--help"])
+        self.assertEqual((rc, self.posted), (0, []))
+        self.assertIn(USAGE, out)
+
+    def _assert_refused(self, argv, option):
+        rc, out, err = self._run(argv)
+        self.assertEqual(self.posted, [], "%s is not an option this command has; it must push to no remote" % option)
+        self.assertEqual(rc, 2)
+        self.assertEqual(out, "", "no 'updating … ok' line for a refused command")
+        self.assertIn(option, err, "the refusal names the option")
+        self.assertIn(USAGE, err, "the refusal names the usage")
+        self.assertEqual(err.count("\n"), 1, "one plain line on stderr")
+
+    def test_an_unknown_short_option_is_refused(self):
+        self._assert_refused(["-n"], "-n")
+
+    def test_an_unknown_option_is_refused_even_with_a_host_named(self):
+        self._assert_refused(["--dry-run", "TESTHOST"], "--dry-run")
+
+    def test_no_arg_still_updates_the_out_of_date_remote(self):
+        # the control: the no-host path is what the flags used to fall into, and it still does its job
+        rc, out, err = self._run([])
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.posted, [("/tunnels/update", {"host": "TESTHOST"})])
+        self.assertIn("updating TESTHOST", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main`: `romp update` never looked at its flags. It kept only the arguments that did not start with a dash as host names, and with none left it took the no-host form, which updates every attached remote that is behind: a forced push of the local HEAD over ssh, a reset of the remote checkout, and a restart of its kernel that cuts the turns of every session on that machine. The wrapper answers `-h` and `--help` only as the first word and otherwise hands the rest of the line through, so `romp update --help`, `romp update -n`, or a misspelled option performed the command's most disruptive action in answer to a request for help, exited 0, and printed that the remotes were updated and restarting. No flag was defined anywhere, so the filter had nothing legitimate to drop; the sibling commands print usage or refuse.

## What changes
Before it probes the kernel or reads anything, the command looks at its dash-prefixed arguments. `-h` or `--help` prints the usage and exits 0, whether or not a kernel is running, and wins whenever present. Any other flag prints one line naming the unknown option and the usage, and exits 2, the conventional status for a usage error. Neither posts anything. The module's docstring is now the usage a person sees, with the reasoning behind the peer-to-peer design kept as a code comment rather than printed.

## Deliberately left out
The wrapper's first-word-only help handling for other subcommands is pre-existing and lives in a file another open PR is rewriting.

## Tests
A new module drives the real command with only its three seams stubbed: with one remote reported behind, `--help` and `-h` post nothing and exit 0, `--help` with no kernel running still exits 0, `-n` and `--dry-run TESTHOST` post nothing and exit 2, and the plain no-host form still posts the update as its control. On `main` the five flag cases fail because the update was posted or the exit code was wrong. The module passes 6, the existing command cases 7, and the suite's state-isolation check passes with the new module in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
