### PR TITLE
Gear: the judges' fast-mode box says Fast mode, sits on the Triage model row, and greys out while no judge tier is on Opus

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -459,8 +459,9 @@ permission/API-error floors: one interrupt at a time, the present event first.
 
 - Toggles: `CLOSER_ON`, `GROUPER_ON`, `DISTILLER_ON`, `CONSOLIDATE_ON`.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
-  Fast judging: `STATE/judge-fast` (`on` | `off`, off by default; read per
-  call, and the fast-mode opt-in rides only a call whose model is Opus).
+  Fast mode for the judges (the gear's Fast mode box beside the Triage model
+  picker): `STATE/judge-fast` (`on` | `off`, off by default; read per call, and
+  the fast-mode opt-in rides only a call whose model is Opus).
   Pool width: `STATE/judge-concurrency` (the gear's Judge concurrency, 1..16,
   read fresh each pass; empty = `ROMP_JUDGE_CONCURRENCY` as read at load,
   else 6). Every pool reads it at call time (`_conc`, or `_judge_concurrency()`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -485,18 +485,21 @@ through to `install.sh`:
   and follows to every connected machine like the other judge settings; its
   Default option clears the setting back to the variable, else 6.
 
-### Fast judging
+### Fast mode for the judges
 
-- **Fast judging** (the gear's Judges section; off by default) runs the judges
-  in Claude Code's fast mode, an Opus-only research preview billed at a premium
-  over standard Opus rates. The setting is read per call: a judge call whose
-  model is Opus, by the bare alias or a pinned Opus version, carries the CLI's
-  fast-mode opt-in in its per-call settings; a call on any other model runs
-  exactly as before, so with every tier on Sonnet and Haiku the setting changes
-  nothing until a tier is pinned to Opus. Fast requests draw on fast mode's own
-  rate limits, the pool your sessions' fast toggles share. Whether fast engaged
-  is the CLI's answer, per account (an account with extra usage turned off, or
-  an organisation with fast mode disabled, reports it off with the setting on):
+- **Fast mode** (the checkbox beside the gear's Triage model picker; off by
+  default) runs the judges in Claude Code's fast mode, the same Opus-only
+  research preview the chat statusline's Fast badge toggles for a session,
+  billed at a premium over standard Opus rates. The setting is read per call: a
+  judge call whose model is Opus, by the bare alias or a pinned Opus version,
+  carries the CLI's fast-mode opt-in in its per-call settings; a call on any
+  other model runs exactly as before, so with every tier on Sonnet and Haiku the
+  setting changes nothing until a tier is pinned to Opus. The gear says so: while
+  no judge tier (triage, distilling, or indexing) is on Opus, the box is greyed
+  and its hint names the reason. Fast requests draw on fast mode's own rate
+  limits, the pool your sessions' fast toggles share. Whether fast engaged is
+  the CLI's answer, per account (an account with extra usage turned off, or an
+  organisation with fast mode disabled, reports it off with the setting on):
   each row of `judge-usage.jsonl` keeps that answer in its `fast` field (`on`,
   `off` or `cooldown`; `null` when the CLI reported none), so a checkbox that
   reads on beside rows that read off names the account, not the setting. Like

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -243,7 +243,7 @@ def _index_effort():  return _state_str("index-effort", "")
 def _judge_engine():  return _state_str("judge-engine", "claude")   # "claude" | "codex" — which model
 #   harness runs the judges (docs/codex.md §judges). "codex" lets a machine with no Claude login keep
 #   the board thinking: every judge becomes a one-shot `codex exec` billing the machine's codex login.
-def _judge_fast():    return _state_str("judge-fast", "off") == "on"   # gear "Fast judging": the CLI's fast-mode
+def _judge_fast():    return _state_str("judge-fast", "off") == "on"   # the gear's Fast mode box (Triage model row): the CLI's fast-mode
 #   opt-in rides every judge call whose model is Opus (_judge_cmd); off by default. Read per call, like the tiers.
 INDEX_EFFORT_DEFAULT = "low"   # the index tier's cost lever on models that take --effort (2026-09-01; see _judge_env)
 
@@ -861,7 +861,7 @@ def _judge_cmd(model, sys_prompt, effort=None, auth=None):
     # --settings still loads. Two keys can ride it:
     overlay = {}
     if _judge_fast() and _model_family_version(model)[0] == "opus":
-        # Fast judging (the gear's Judges section, off by default): the CLI refuses fast mode to a
+        # Fast mode for the judges (the gear's box beside the Triage model picker, off by default): the CLI refuses fast mode to a
         # non-interactive client unless the flag-settings layer carries this exact key, the same opt-in a
         # fast-picked session's launch uses (sdk_backend.flag_settings_path), and fast mode is an Opus-only
         # preview, so the key rides only a call whose model reads as the opus family: the bare alias or a
@@ -1501,7 +1501,7 @@ def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
                                 "cache_w": u.get("cache_creation_input_tokens"),
                                 "cache_r": u.get("cache_read_input_tokens"),
                                 "fast": wrap.get("fast_mode_state"),   # the CLI's word on whether fast mode engaged
-                                #   ("on" | "off" | "cooldown"; null when the envelope carries none): Fast judging's readback
+                                #   ("on" | "off" | "cooldown"; null when the envelope carries none): the judges' fast-mode readback
                                 "cost": wrap.get("total_cost_usd")}) + "\n")
     except Exception:
         pass

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1137,7 +1137,7 @@ def _version_info():
             "commentEffort": jd._state_str("comment-effort", "session"),
             "commentFast": jd._state_str("comment-fast", "session"),
             "tmuxBackend": jd._state_str("tmux-backend", "off"),   # T288: "on" offers Claude Code (tmux) in the picker and the gear
-            "judgeFast": jd._state_str("judge-fast", "off"),   # RAW "on" | "off": Fast judging, the fast-mode opt-in on Opus judge calls
+            "judgeFast": jd._state_str("judge-fast", "off"),   # RAW "on" | "off": the judges' Fast mode box, the fast-mode opt-in on Opus judge calls
             # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
@@ -40565,7 +40565,7 @@ def _set_comment_fast(v, gt=None):   return _set_judge_state("comment-fast", v, 
 # ids and the protocol are unchanged. Rides the judge-knob machinery (validated, stamped, propagated to
 # every linked kernel: the 2026-08-14 gear rule, one value across machines).
 def _set_tmux_backend(v, gt=None):   return _set_judge_state("tmux-backend", v, {"on", "off"}, gt=gt)
-# Fast judging (the gear's Judges section): "on" runs every judge call whose model is Opus in the CLI's fast
+# Fast mode for the judges (the gear's box beside the Triage model picker): "on" runs every judge call whose model is Opus in the CLI's fast
 # mode (jd._judge_cmd adds the flag-settings opt-in per call; a call on any other model is untouched); off by
 # default. Fast mode bills Opus at a premium and draws on fast mode's own rate limits, so it is a deliberate
 # pick. Rides the judge-knob machinery: validated, stamped, propagated to every linked kernel.
@@ -40595,7 +40595,7 @@ _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_i
                          ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
                          ("commentFast", _set_comment_fast),
                          ("tmuxBackend", _set_tmux_backend),   # T288: the tmux backend's offer, "on" | "off"
-                         ("judgeFast", _set_judge_fast))       # Fast judging, "on" | "off"
+                         ("judgeFast", _set_judge_fast))       # the judges' Fast mode, "on" | "off"
 
 # The per-field PICK STAMPS this leg carried from 2026-08-30 (each field's STATE-file mtime in a
 # body "stamps" dict, preserved by utime at the receiver — the distill-pick stomp fix) are
@@ -53745,7 +53745,7 @@ class Handler(BaseHTTPRequestHandler):
             else:
                 _tell_stale_gesture(client, msg)
         elif msg and msg.get("type") == "setJudgeFast" and msg.get("enabled") is not None:
-            # gear "Fast judging": a checkbox, stored as on/off and read by the judges per call (jd._judge_fast).
+            # the gear's Fast mode box on the Triage model row: a checkbox, stored as on/off and read by the judges per call (jd._judge_fast).
             # The boolean is checked like its siblings' (_as_bool), and a malformed frame is refused with a
             # warn, unwritten; an applied pick fans out to every linked kernel under its gesture stamp.
             _jfe, ferr = _as_bool(msg.get("enabled"), "enabled")

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -56,7 +56,7 @@ class SettingsSectionsTest(unittest.TestCase):
         # Judges sit low: the six dropdowns between Judges and the bottom group
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgemodel") < h.index(">Updates & debug<"))
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-indexeffort") < h.index(">Updates & debug<"))
-        # Fast judging: a checkbox row among the judge picks, in the Judges section like the knobs it rides with
+        # Fast mode for the judges: a checkbox on the Triage model row, in the Judges section like the knobs it rides with
         self.assertTrue(h.index(">Judges<") < h.index("id=rs-judgefast") < h.index(">Updates & debug<"))
         self.assertNotIn("rs-oldest", h)
         # Updates & debug (the very bottom): auto-updates, the judge-SHOW toggles, analytics, version
@@ -103,16 +103,30 @@ class SettingsSectionsTest(unittest.TestCase):
                                 r"<span class=rs-sub>[^<]*</span><select id=" + sel)
         self.assertIn("#rsettings .rs-jrow select {", _gear_css_src())
 
-    def test_fast_judging_is_a_label_row_with_a_mixed_mark(self):
-        # a checkbox row in the shape of Fast comment threads (label + checkbox, the mixed mark beside the name),
-        # not an .rs-jrow: the one-line label + picker count above stays at nine
+    def test_fast_mode_for_the_judges_sits_on_the_triage_model_row(self):
+        # The user 2026-09-10: the box says Fast mode (the chat statusline's own word for it) and sits
+        # with the model, after the Triage model picker, not on a row of its own under a paragraph. Its
+        # label carries its own mixed mark; the row count above stays at nine (no .rs-jrow added).
         h = _gear_src()
-        self.assertIn("<label class='rs-row'><input type=checkbox id=rs-judgefast>", h)
-        self.assertIn("<span><b>Fast judging</b><span class=rs-mixed hidden></span>", h)
-        row = h[h.index("id=rs-judgefast"):]
-        row = row[:row.index("</label>")]
-        self.assertIn("Opus", row, "the copy says which calls the setting reaches")
-        self.assertIn("connected machine's kernel", row, "the copy says the pick follows to the other machines")
+        self.assertNotIn("Fast judging", h)
+        row = h[h.index("<b>Triage model "):]
+        row = row[:row.index("<b>Triage effort ")]
+        self.assertIn("<select id=rs-judgemodel></select>", row)
+        self.assertIn("<label class=rs-fastin id=rs-judgefast-wrap><input type=checkbox id=rs-judgefast>Fast mode"
+                      "<span class=rs-mixed hidden></span>", row)
+        self.assertLess(row.index("id=rs-judgemodel"), row.index("id=rs-judgefast"), "the box follows the picker")
+        self.assertIn("<span class=rs-sub id=rs-judgefast-sub>", row, "a row hint like its neighbours', swapped by the gate")
+        self.assertEqual(row.count("</div>"), 1, "one row: the box closes inside the Triage model row")
+        # the one-line hint: the Opus-only condition and the premium, and where the pick goes
+        hint = h[h.index("var JUDGEFAST_SUB = "):]
+        hint = hint[:hint.index(";\n")]
+        self.assertIn("Opus-only", hint)
+        self.assertIn("premium", hint)
+        self.assertIn("connected machine's kernel", hint, "the copy says the pick follows to the other machines")
+        # greyed with the reason while no judge tier is on Opus (the box is inert then: the opt-in rides only Opus calls)
+        self.assertIn("function judgeFastGate", h)
+        self.assertIn("var JUDGEFAST_SUB_OFF = \"Fast mode is Opus-only, and no judge tier is on Opus.", h)
+        self.assertIn("#rsettings .rs-fastin.rs-off {", _gear_css_src())
 
     def test_collapse_gaps_is_wired_to_the_shared_collapseGaps_setting(self):
         # the gear JS persists/loads romp:settings.collapseGaps; the timeline reads it (see romp-timeline-view.js)

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -83,7 +83,7 @@ const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel"
                                 "setCompactSuggest",
                                 "setCommentModel", "setCommentEffort", "setCommentFast",
                                 "setTmuxBackend",   // T288: the tmux backend's offer, one value across machines
-                                "setJudgeFast"]);   // Fast judging: the judges' fast-mode opt-in, one value across machines
+                                "setJudgeFast"]);   // Fast mode for the judges: their fast-mode opt-in, one value across machines
 
 // ── what a send to a host whose relay socket is NOT open does, by message class (2026-09-10) ─────────
 // Three classes, decided by an EXPLICIT list — never guessed from the type's spelling at run time:

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -78,6 +78,22 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
 #rsettings .rs-jrow b { flex: 1 1 auto; }
 #rsettings .rs-jrow select { flex: 0 0 auto; width: 45%; background: var(--bg, #1e1e1e); color: var(--fg, #ccc);
   border: 1px solid var(--hairline, #3a3a3a); border-radius: 5px; padding: 3px 4px; cursor: pointer; }
+/* Fast mode rides the Triage model row, after the picker (the user 2026-09-10, who wanted the setting to speak
+   the chat's own words and sit with the model): a compact box + word at the row's size, greyed (.rs-off) while
+   no judge tier is on Opus. Hover shows ONE description: the box's own over the box, the row's elsewhere. */
+#rsettings .rs-fastin { display: inline-flex; align-items: center; gap: 5px; margin-left: 10px; flex: 0 0 auto; white-space: nowrap; cursor: pointer; }
+#rsettings .rs-fastin input { margin: 0; }
+#rsettings .rs-fastin.rs-off { opacity: .4; cursor: default; }
+#rsettings .rs-fastin.rs-off input { cursor: default; }
+#rsettings .rs-row:hover .rs-fastin .rs-sub { display: none; }
+#rsettings .rs-row:has(.rs-fastin:hover) > .rs-sub { display: none; }
+#rsettings .rs-row:has(.rs-fastin:hover) .rs-fastin .rs-sub { display: block; }
+/* the label's nowrap keeps the box and its word together; the hint must NOT inherit it, or it runs off
+   the card as one line with the Opus-only condition and the premium cut off at the right edge */
+#rsettings .rs-fastin .rs-sub { white-space: normal; }
+/* the box's own mixed mark carries a native title naming the machines that differ; while it is hovered the
+   hint stands down, so one tooltip shows at a time (the rule the section's other mixed marks follow above) */
+#rsettings .rs-row:has(.rs-fastin .rs-mixed:hover) .rs-fastin .rs-sub { display: none; }
 /* feed-colormap dropdown: the button shows the picked map's gradient bar; the list is one bar per map. */
 #rs-cmap { position: relative; margin-top: 5px; }
 #rs-cmap-btn { width: 100%; height: 20px; border-radius: 5px; border: 1px solid var(--hairline, #3a3a3a); cursor: pointer; padding: 0; display: block; }

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -44,6 +44,11 @@ var SHORTCUT_ROWS =
 // machines disagree — the row then has to say WHICH ones, and this is the one level down from the label.
 var AUTONUDGE_SUB = "When a session goes idle but its goal still shows working (not blocked, not awaiting agents or a job "
   + "you), automatically nudge it once for a status update. Applies to every connected machine's kernel.";
+// Fast mode's one-line hint, in a var because judgeFastGate() swaps it for the greyed-out reason when no
+// judge tier is on Opus (the opt-in rides only a call whose model is Opus, so the box is inert then).
+var JUDGEFAST_SUB = "Judge calls on Opus run in Claude Code's fast mode (an Opus-only research preview, billed at a premium). "
+  + "Off by default. Follows to every connected machine's kernel.";
+var JUDGEFAST_SUB_OFF = "Fast mode is Opus-only, and no judge tier is on Opus. Pick Opus for triage, distilling or indexing to use it.";
 
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/
 // effort selects start empty and are filled from /models (see fill()).
@@ -169,12 +174,13 @@ var GEAR_HTML =
   '<div id=rs-pal-list hidden></div></div></span></div>' +
   '<div class=rs-sec>Keyboard shortcuts</div>' + SHORTCUT_ROWS +
   '<div class=rs-sec>Judges</div>' +
-  "<div class='rs-row rs-jrow'><b>Triage model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Triage model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the triage judges use — planner, grouper, closer, courier (the judgment-heavy tier). Applies on the judges' next pass; no restart. A pick here follows to every connected machine's kernel.</span><select id=rs-judgemodel></select>" +
+  // Fast mode sits with the model (the user 2026-09-10, who wanted the setting to speak the chat's own words
+  // and sit with the model): the chat's statusline badge and docs/reference.md call it fast mode, so this
+  // does too. The box keeps its id and message (setJudgeFast, judgeFast): the kernel side is untouched.
+  "<label class=rs-fastin id=rs-judgefast-wrap><input type=checkbox id=rs-judgefast>Fast mode<span class=rs-mixed hidden></span>" +
+  "<span class=rs-sub id=rs-judgefast-sub>" + JUDGEFAST_SUB + "</span></label></div>" +
   "<div class='rs-row rs-jrow'><b>Triage effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
-  "<label class='rs-row'><input type=checkbox id=rs-judgefast>" +
-  '<span><b>Fast judging</b><span class=rs-mixed hidden></span>' +
-  "<span class=rs-sub>Run the judges in fast mode (an Opus-only research preview, billed at a premium over standard Opus rates). Engages only on calls whose model is Opus, whichever tier; every other model runs as before. Fast requests draw on fast mode's own rate limits, the same pool your sessions' fast toggles use. Off by default. Applies on the judges' next pass; no restart. Follows to every connected machine's kernel.</span>" +
-  '</span></label>' +
   "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select></div>" +
   "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
@@ -738,12 +744,12 @@ function initGear(post) {
     versionMenu(cmm, [{ value: 'session', label: 'Same as the session', versions: [] },
                       { value: 'default', label: 'Default', versions: [] }]);
   });
-  if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value, gt: gclock.stamp('judge-model') }); });
-  if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value, gt: gclock.stamp('index-model') }); });
+  if (jm) jm.addEventListener('change', function () { post({ type: 'setJudgeModel', model: jm.value, gt: gclock.stamp('judge-model') }); judgeFastGate(); });
+  if (im) im.addEventListener('change', function () { post({ type: 'setIndexModel', model: im.value, gt: gclock.stamp('index-model') }); judgeFastGate(); });
   if (je) je.addEventListener('change', function () { post({ type: 'setJudgeEffort', effort: je.value, gt: gclock.stamp('judge-effort') }); });
   if (ie) ie.addEventListener('change', function () { post({ type: 'setIndexEffort', effort: ie.value, gt: gclock.stamp('index-effort') }); });
   if (jc) jc.addEventListener('change', function () { post({ type: 'setJudgeConcurrency', value: jc.value, gt: gclock.stamp('judge-concurrency') }); });
-  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value, gt: gclock.stamp('distill-model') }); });
+  if (dm) dm.addEventListener('change', function () { post({ type: 'setDistillModel', model: dm.value, gt: gclock.stamp('distill-model') }); judgeFastGate(); });
   if (de) de.addEventListener('change', function () { post({ type: 'setDistillEffort', effort: de.value, gt: gclock.stamp('distill-effort') }); });
   // Fast is an Opus-only research preview (render.ts fastAvailable, the same rule): a pinned
   // non-Opus comment model makes the box a dead control, so it disables — and a model pick that
@@ -766,8 +772,26 @@ function initGear(post) {
   // the tmux backend's offer (T288): a kernel setting like the judge knobs (stamped, propagated); the Default
   // backend list repaints at once so the pick and the offer never disagree in the same modal
   if (tb) tb.addEventListener('change', function () { post({ type: 'setTmuxBackend', enabled: tb.checked, gt: gclock.stamp('tmux-backend') }); paintBackendOffer(tb.checked); });
-  // Fast judging: a kernel setting like the judge knobs (stamped, propagated); the judges read it per call
+  // Fast mode for the judges: a kernel setting like the judge knobs (stamped, propagated); the judges read it per call
   if (jf) jf.addEventListener('change', function () { post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') }); });
+  // Fast mode is an Opus-only research preview (render.ts fastAvailable and cmtFastGate above, the same rule),
+  // and the judges' opt-in rides only a call whose model is Opus: with no tier on Opus the box is inert, so it
+  // greys and its hint says why (a review finding on the setting's first cut: with the default tiers the box
+  // did nothing and the gear did not say so). The stored value is left alone, unlike cmtFastGate's uncheck:
+  // nothing fires or toasts while it is inert, and a tier pinned to Opus later brings it back without a
+  // second click. Distilling on Follow triage resolves to the triage pick; a tier whose value has not
+  // loaded is unknown, never a refusal (the benefit of the doubt fastAvailable gives an unknown model).
+  function judgeFastGate() {
+    if (!jf) return;
+    var wrap = document.getElementById('rs-judgefast-wrap'), sub = document.getElementById('rs-judgefast-sub');
+    var tri = jm ? (jm.value || '') : '', dis = dm ? (dm.value || '') : '', idx = im ? (im.value || '') : '';
+    if (dis === 'triage') dis = tri;
+    var picks = [tri, dis, idx].filter(function (v) { return !!v; });
+    var can = !picks.length || picks.some(function (v) { return v.toLowerCase().indexOf('opus') !== -1; });
+    jf.disabled = !can;
+    if (wrap) wrap.classList.toggle('rs-off', !can);
+    if (sub) sub.textContent = can ? JUDGEFAST_SUB : JUDGEFAST_SUB_OFF;
+  }
   // "Claude Code (tmux)" is in the Default backend list only while the setting is on; a saved default of tmux
   // while it is off is set aside (the select shows Claude Code and the note says so), never erased: it returns
   // with the setting. The option is removed rather than hidden: the facade paints from sel.options.
@@ -845,7 +869,7 @@ function initGear(post) {
     'index-model': 'Indexing model', 'index-effort': 'Indexing effort', 'judge-concurrency': 'Judge concurrency',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
-    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend', 'judge-fast': 'Fast judging',
+    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend', 'judge-fast': 'Fast mode (judges)',
     'thinking-summaries': 'Thinking summaries' };
   // store name → the message type that sets it: the whitelist for the toast's Apply anyway (a frame
   // may re-issue the one setting it names, nothing else) and the completeness pin's map
@@ -1134,7 +1158,9 @@ function initGear(post) {
      ['judgeFast', jf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
-      var row = el.closest ? el.closest('.rs-row') : null;
+      // the mark nearest the control: a checkbox's own <label> (the fast-mode box shares the Triage model
+      // row, whose first mark belongs to the picker), else the row
+      var row = el.closest ? (el.closest('label') || el.closest('.rs-row')) : null;
       var mark = row ? row.querySelector('.rs-mixed') : null;
       if (mark) { mark.hidden = true; mark.textContent = ''; mark.removeAttribute('title'); }
       if (!mine || typeof mine[key] === 'undefined' || !mark) return;
@@ -1179,6 +1205,7 @@ function initGear(post) {
     if (tb && typeof v.tmuxBackend === 'string') { tb.checked = v.tmuxBackend === 'on'; paintBackendOffer(tb.checked); }   // T288: the offer, then the list follows it
     if (jf && typeof v.judgeFast === 'string') jf.checked = v.judgeFast === 'on';   // RAW on/off: the kernel's persisted answer
     cmtFastGate(false);
+    judgeFastGate();   // the tiers are set above; the box follows them
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
     // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to
     // vanish into a macOS-only dialog. Drop the button rather than offer one that cannot work; the

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -50,13 +50,13 @@ test("the gear posts kernel ops through ONE shared channel (never re-acquires th
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 
-test("Fast judging is a kernel setting: a stamped emitter under its own store name, a toast name, a mixed mark, and it follows to every machine", () => {
+test("Fast mode for the judges is a kernel setting: a stamped emitter under its own store name, a toast name, a mixed mark, and it follows to every machine", () => {
   assert.ok(GEAR.includes("post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') })"),
     "the click posts the kernel's designed message with the gesture stamp minted in the literal");
   assert.ok(GEAR.includes("jf.checked = v.judgeFast === 'on'"),
     "the checkbox shows the kernel's persisted answer (RAW on/off), never a page default");
-  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'judge-fast': 'Fast judging'/,
-    "a stood-down gesture toasts under the row's own name");
+  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'judge-fast': 'Fast mode \(judges\)'/,
+    "a stood-down gesture toasts under the control's own name");
   assert.match(GEAR, /STALE_TYPE = \{[\s\S]*?'judge-fast': 'setJudgeFast'/,
     "the store maps to its message type (the toast's Apply anyway whitelist)");
   assert.match(GEAR, /\['judgeFast', jf\]/, "the row carries the mixed mark where machines disagree");
@@ -64,6 +64,34 @@ test("Fast judging is a kernel setting: a stamped emitter under its own store na
   const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
   assert.ok(setSrc && setSrc[1].includes('"setJudgeFast"'),
     "one click writes every attached kernel, like the other judge settings");
+});
+
+test("the judges' fast-mode box sits on the Triage model row in the chat's words, and greys when no tier is on Opus", () => {
+  // The user 2026-09-10: say Fast mode, the word the chat's statusline badge and its tip already use
+  // (render.ts FAST_CHOICES / "toggle fast mode"), never a coinage of the gear's own; and put the box
+  // with the model rather than on a row of its own under a paragraph. The ids and the message stay,
+  // so the kernel side and the cross-machine propagation are untouched.
+  assert.ok(!GEAR.includes("Fast judging"), "the old label is gone from the gear");
+  assert.match(GEAR, /<select id=rs-judgemodel><\/select>" \+[\s\S]{0,600}?<label class=rs-fastin id=rs-judgefast-wrap><input type=checkbox id=rs-judgefast>Fast mode<span class=rs-mixed hidden><\/span>/,
+    "the box follows the triage picker inside the same row, with its own mixed mark");
+  assert.ok(GEAR.includes("<span class=rs-sub id=rs-judgefast-sub>"), "its hint is a row hint like its neighbours', not a paragraph");
+  assert.match(GEAR, /var JUDGEFAST_SUB = "[^"]*Opus-only[^"]*premium/, "the one-line hint carries the Opus-only condition and the premium");
+  // the gate, mirroring cmtFastGate: the opt-in rides only a call whose model is Opus, so with no tier on
+  // Opus the box is inert; the gear greys it and the hint says why, instead of a dead control
+  assert.ok(GEAR.includes("function judgeFastGate"), "the availability gate must exist");
+  assert.ok(GEAR.includes("jf.disabled = !can"), "the box disables when no tier is on Opus");
+  assert.ok(GEAR.includes("sub.textContent = can ? JUDGEFAST_SUB : JUDGEFAST_SUB_OFF"), "the hint says why while greyed");
+  assert.ok(GEAR.includes("if (dis === 'triage') dis = tri;"), "distilling on Follow triage counts as the triage pick");
+  for (const store of ["judge-model", "index-model", "distill-model"])
+    assert.match(GEAR, new RegExp("gclock\\.stamp\\('" + store + "'\\) \\}\\); judgeFastGate\\(\\);"), `a ${store} pick re-runs the gate`);
+  assert.match(GEAR, /cmtFastGate\(false\);\n\s*judgeFastGate\(\);/, "fill() re-checks availability after the tiers are set");
+  // the mixed mark is the one inside the box's own label, not the picker's (both share the row now)
+  assert.ok(GEAR.includes("el.closest('label') || el.closest('.rs-row')"), "fillMixedMarks scopes to the control's own label first");
+  const CSS = read("ui", "webview", "gear.css");
+  assert.ok(CSS.includes("#rsettings .rs-fastin.rs-off { opacity: .4;"), "the greyed look");
+  assert.ok(CSS.includes("#rsettings .rs-row:has(.rs-fastin:hover) > .rs-sub { display: none; }"), "one hover description at a time");
+  assert.ok(CSS.includes("#rsettings .rs-fastin .rs-sub { white-space: normal; }"), "the hint wraps: the label's nowrap (box + word on one line) must not reach the hint, or it runs off the card");
+  assert.ok(CSS.includes("#rsettings .rs-row:has(.rs-fastin .rs-mixed:hover) .rs-fastin .rs-sub { display: none; }"), "the box's mixed mark keeps its title alone: no hint under it");
 });
 
 test("EVERY queued-class kernel setting is emitted with its gesture time (completeness-pinned to federation's own set)", () => {


### PR DESCRIPTION
Follow-up to the Fast judging setting that merged this morning, on the maintainer's call (2026-09-10): keep the feature, change how it presents.

## What changes

- **The words.** The box says **Fast mode**, the term the chat's statusline badge and its tip already use for the same CLI feature, instead of "Fast judging". The stood-down-gesture toast calls it "Fast mode (judges)" so it cannot be confused with "Fast comment threads".
- **The place.** The box rides the **Triage model row**, after the picker, as a compact checkbox and word at the row's size; the standalone row and its paragraph are gone. The help shrinks to the row-hint style its neighbours use, and hovering shows one description at a time (the box's own over the box, the row's elsewhere).
- **The inert state is visible.** With the shipped defaults (triage on Sonnet, indexing on Haiku, the rest following triage) the box did nothing and the gear did not say so, a finding in the review of the original change. Now, while no judge tier is on Opus, the box is greyed and its hint says why and what to pick. It keeps the stored value rather than unchecking, so pinning Opus later revives it without a second click.

## What does not change

The element ids, the `setJudgeFast` op and its gesture stamp, the `judgeFast` fill, the kernel's stored `judge-fast` value and its propagation to linked kernels. The edits to `kernel/kernel.py`, `kernel/judge.py` and `ui/webview/federation.ts` are comments naming the new label.

## Tests

`ui/webview/gear.test.ts`: the renamed setting test, and a new test pinning the row placement, the words, the hint content, the gate wiring, the mixed-mark scoping and the hover and wrap rules (19 tests). `tests/test_kernel_settings_sections.py`: the old label-row test replaced by one that finds the box on the Triage model row. Both green here, along with the gear select matrix test. Docs (`docs/reference.md`, `docs/judges.md`) renamed to match.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
