### PR TITLE
Tests: the trace pins match git's maintenance spawn line, not a bare substring; a missing key is named; the bare clones are pinned

### DIFF
--- a/tests/git_fixture.py
+++ b/tests/git_fixture.py
@@ -45,7 +45,10 @@ def git(repo, *args, env=None, ident=None, timeout=60, check=True, text=True):
 
 def forbid_background(repo, env=None, timeout=60):
     """Write GIT_NO_BACKGROUND into an EXISTING repo's local config: for a clone or a worktree the fixture
-    did not init itself but that the kernel will run git against. Returns repo."""
+    did not init itself but that the kernel will run git against. A linked worktree shares its main
+    repository's config, so on a worktree of an init_repo repo, or of a clone already given this call, the
+    write rewrites the same values; a worktree needs the call only when its parent was made by a plain git.
+    Returns repo."""
     for k, v in GIT_NO_BACKGROUND.items():
         git(repo, "config", k, v, env=env, timeout=timeout)
     return repo

--- a/tests/test_git_fixture.py
+++ b/tests/test_git_fixture.py
@@ -76,16 +76,17 @@ class NoBackgroundWork(unittest.TestCase):
                 self.assertEqual(git(td, "config", "--local", "--get", k).stdout.strip(), v, k)
             open(os.path.join(td, "a"), "w").write("a\n")
             git(td, "add", "a")
-            t = _traced(lambda env: git(td, "commit", "-qm", "traced", env=env))
+            t = _traced(lambda env: git(td, "commit", "-qm", "maintenance-traced", env=env))
         self.assertIn("built-in: git commit", t, "the trace is on")
-        self.assertNotIn("maintenance", t, "no auto-maintenance child:\n" + t)
+        self.assertIn("maintenance-traced", t, "the trace names the commit's argv: the pin below cannot be a bare substring")
+        self.assertNotIn("run_command: git maintenance", t, "no auto-maintenance child:\n" + t)
         self.assertNotIn("run_command: git gc", t, "no gc child")
 
     def test_a_clone_lacks_the_keys_until_forbid_background_and_then_a_fetch_spawns_no_child(self):
         # the kernel's update paths fetch and merge into clones the fixture did not init: forbid_background
         # is what covers a git the kernel runs there, and `fetch` is one of the commands that runs auto
         # maintenance afterwards
-        with tempfile.TemporaryDirectory() as td:
+        with tempfile.TemporaryDirectory(prefix="maintenance-") as td:
             src, clone = os.path.join(td, "src"), os.path.join(td, "clone")
             os.makedirs(src)
             init_repo(src, "-q", "-b", "main", ident=IDENT)
@@ -99,7 +100,8 @@ class NoBackgroundWork(unittest.TestCase):
             # a PLAIN git (no -c flags: the kernel's own subprocess) fetching in the clone, traced
             t = _traced(lambda env: subprocess.run(["git", "-C", clone, "fetch", "-q", "origin"], check=True, capture_output=True, env=env))
         self.assertIn("built-in: git fetch", t)
-        self.assertNotIn("maintenance", t, "the repo's config alone keeps a plain git from spawning maintenance:\n" + t)
+        self.assertIn("maintenance-", t, "the trace names the fetch source by path: the pin below cannot be a bare substring")
+        self.assertNotIn("run_command: git maintenance", t, "the repo's config alone keeps a plain git from spawning maintenance:\n" + t)
         self.assertNotIn("run_command: git gc", t)
 
 

--- a/tests/test_github_repo.py
+++ b/tests/test_github_repo.py
@@ -78,6 +78,15 @@ def _repo(root, name, origin=None):
     return d
 
 
+def _bare_clone(root, src, name="bare.git"):
+    """A bare clone of `src` at root/name, its own config forbidding background git work: a clone starts
+    without the keys, and the kernel's git runs against it through its own subprocess, not _git."""
+    bare = os.path.join(root, name)
+    _git("clone", "-q", "--bare", src, bare, cwd=root)
+    forbid_background(bare)
+    return bare
+
+
 def _bump_mtime(path):
     """Move a file's mtime forward by a whole second, so a rewrite within the same clock tick still
     reads as a change — the memo keys on mtime, and the test must not depend on filesystem resolution."""
@@ -794,9 +803,7 @@ class BareRepository(unittest.TestCase):
 
     def test_a_bare_repositorys_branch_is_the_one_its_head_names_memoized_on_head(self):
         src = _repo(self.root, "src", HTTPS_ORIGIN)
-        bare = os.path.join(self.root, "bare.git")
-        _git("clone", "-q", "--bare", src, bare, cwd=self.root)
-        forbid_background(bare)
+        bare = _bare_clone(self.root, src)
         self.assertEqual([km._git_branch(bare) for _ in range(3)], ["main"] * 3)
         self.assertEqual(self.forks, {"--show-toplevel": 1, "--abbrev-ref": 1}, "asked once each, then memoized")
         self.assertIsNone(km._github_repo_of(bare), "no work tree, no tree-derived repo — as before")
@@ -808,14 +815,18 @@ class BareRepository(unittest.TestCase):
 
     def test_a_worktree_beside_the_bare_clone_is_an_ordinary_tree(self):
         src = _repo(self.root, "src", HTTPS_ORIGIN)
-        bare = os.path.join(self.root, "bare.git")
-        _git("clone", "-q", "--bare", src, bare, cwd=self.root)
-        forbid_background(bare)
+        bare = _bare_clone(self.root, src)
         wt = os.path.join(self.root, "topic")
         _git("worktree", "add", "-q", "-b", "topic", wt, "main", cwd=bare)
         forbid_background(wt)
         self.assertEqual(km._git_branch(wt), "topic")
         self.assertEqual(km._github_repo_of(wt), None, "the bare clone has no origin remote")
+
+    def test_the_bare_clones_forbid_background_git_work(self):
+        # as _Fixtures' repos are pinned: the kernel's git runs against the bare clone through its own
+        # subprocess, not _git, so the keys must sit in the clone's own config, which a clone starts without
+        bare = _bare_clone(self.root, _repo(self.root, "src", HTTPS_ORIGIN))
+        self.assertEqual(git(bare, "config", "--local", "--get", "maintenance.auto").stdout.strip(), "false", bare)
 
     def test_a_directory_outside_every_repository_is_still_no_branch_and_no_fork(self):
         d = os.path.join(self.root, "notes")

--- a/tests/test_restart_classifier.py
+++ b/tests/test_restart_classifier.py
@@ -204,17 +204,19 @@ class RealDiffShapes(unittest.TestCase):
         # Pinned at the source and by behaviour: git's own trace names every child it runs, and a commit
         # through the helper spawns none.
         for k, v in GIT_NO_BACKGROUND.items():
-            self.assertEqual(_git(self.repo, "config", "--local", "--get", k), v, "the repo's config carries " + k)
+            # --default: a missing key reaches this assertion and its message, not the runner's exit check
+            self.assertEqual(_git(self.repo, "config", "--local", "--get", "--default", "", k), v, "the repo's config carries " + k)
             self.assertIn("%s=%s" % (k, v), GIT_C, "…and so does every runner invocation")
         self._reset()
         (self.repo / "docs/a.md").write_text("# docs, traced\n")
         with tempfile.NamedTemporaryFile("r", suffix=".log") as trace:
             env = dict(os.environ, GIT_TRACE=trace.name)
             _git(self.repo, "add", "-A", env=env)
-            _git(self.repo, "commit", "-qm", "traced", env=env)
+            _git(self.repo, "commit", "-qm", "maintenance-traced", env=env)
             t = trace.read()
         self.assertIn("built-in: git commit", t, "the trace is on")
-        self.assertNotIn("maintenance", t, "no auto-maintenance child is spawned:\n" + t)
+        self.assertIn("maintenance-traced", t, "the trace names the commit's argv: the pin below cannot be a bare substring")
+        self.assertNotIn("run_command: git maintenance", t, "no auto-maintenance child is spawned:\n" + t)
         self.assertNotIn("run_command: git gc", t, "no gc child is spawned")
 
     def test_unknown_shas_and_git_failure_restart(self):


### PR DESCRIPTION
## Symptom

A green tree fails `tests/test_git_fixture.py::NoBackgroundWork::test_a_clone_lacks_the_keys_until_forbid_background_and_then_a_fetch_spawns_no_child` under any temp root whose path contains the word `maintenance`, with no maintenance child spawned: the failure message prints a trace whose only matches are the two upload-pack lines naming the fetch source by path (`run_command: ... git-upload-pack '<root>/maintenance-.../src'` and `built-in: git upload-pack <root>/maintenance-.../src`). Two more pins have the same shape, on the commit traces in the same file and in `tests/test_restart_classifier.py`; a commit trace names the commit's argv (`built-in: git commit -qm <message>`), so the same bare substring fails on any commit message that carries the word. With the message `traced` those two do not fail today.

In `tests/test_restart_classifier.py`, a repo whose local config lacks one of the no-background keys fails the pin with `AssertionError: ` (empty): `git config --local --get` exits 1 with nothing on stderr, and the runner's returncode assert fires before the assertEqual that would have named the key.

In `tests/test_github_repo.py`, deleting both `forbid_background(bare)` calls under `BareRepository` leaves the module green: the bare clones were the one fixture shape without a pin on their own config, while `_Fixtures`' repos have one.

## Cause

`GIT_TRACE` records the argv of every command and child: a fetch from a local path spawns `upload-pack` with the source path in its argv (`run_command: ... git-upload-pack '<src>'` and `built-in: git upload-pack <src>`), and a commit's line carries its message (`built-in: git commit -qm <message>`). The pin was `assertNotIn("maintenance", t)`, a bare substring over that text; `tests/conftest.py` nests the run's temp root under the incoming `TMPDIR`, so a developer's `TMPDIR` alone decided whether the fetch test passed. The gc pin beside it already used the exact-spawn form, `run_command: git gc`.

## Fix

Tests only.

- `tests/test_git_fixture.py`: the two trace pins read `assertNotIn("run_command: git maintenance", t, ...)`, which matches git's spawn line (`run_command: git maintenance run --auto --quiet`) and cannot match a path or a message. Each traced command now carries the word itself, with an `assertIn` whose message says why, so the bare form is red on every run and not only under a `TMPDIR` that happens to carry the word: the fetch test makes its temp root with `tempfile.TemporaryDirectory(prefix="maintenance-")` and asserts `"maintenance-" in t`; the commit test commits with the message `maintenance-traced` and asserts it is in the trace.
- `tests/test_restart_classifier.py`: the same one-token form, `maintenance-traced` message and `assertIn` for its commit-trace pin. The config read becomes `config --local --get --default "" <key>` (the `--default` flag exists in git 2.18 and later), so a missing key reaches the assertEqual and fails as `'' != 'false' : the repo's config carries maintenance.auto`. `_git` is unchanged.
- `tests/test_github_repo.py`: a module-level `_bare_clone(root, src, name="bare.git")` runs the bare clone, then `forbid_background`, and returns the path; both `BareRepository` tests call it in place of their bare-path, clone and `forbid_background` lines (same flags, same order, so the git counts they assert are unchanged). A new `BareRepository.test_the_bare_clones_forbid_background_git_work` builds one through the helper and asserts `config --local --get maintenance.auto` is `false`. The worktree's own `forbid_background(wt)` call stays.
- `tests/git_fixture.py`: one sentence in `forbid_background`'s docstring: a linked worktree shares its main repository's config, so the call on a worktree of an `init_repo` repo, or of a clone already given the call, rewrites the same values, and a worktree needs it only when its parent was made by a plain git. The existing worktree calls stay: they are harmless, and one uniform rule (every clone, worktree and bare repo the kernel touches gets the call) is easier to follow than a per-site check of each worktree's parent.

Not in this PR: `tests/README.md` describes the trace pins without naming the form, so it needs no edit; the eleven per-module `maintenance.auto` config pins are unchanged.

## Tests

- `tests/test_git_fixture.py::NoBackgroundWork::test_a_clone_lacks_the_keys_until_forbid_background_and_then_a_fetch_spawns_no_child` (executing, red first): with the `maintenance-` prefix and the added `assertIn` in place but the pin still the bare substring, it fails on every run (`'maintenance' unexpectedly found in "... git-upload-pack '<root>/maintenance-<x>/src' ... built-in: git upload-pack <root>/maintenance-<x>/src ..."`; 1 failed, 5 passed in the module); with the spawn-line form it passes. Mutation the other way: with `maintenance.auto` unset in the clone before the fetch, the trace gains `run_command: git maintenance run --auto --quiet` and the new form fails on it, so the one-token pin still catches a real spawn.
- `tests/test_git_fixture.py::NoBackgroundWork::test_init_repo_writes_the_keys_into_the_repo_and_a_commit_through_the_runner_spawns_no_child` and `tests/test_restart_classifier.py::RealDiffShapes::test_the_fixture_forbids_background_git_work` (executing, red first): with the `maintenance-traced` message and the added `assertIn` in place but the pin still the bare substring, each fails on every run (`'maintenance' unexpectedly found in '... built-in: git commit -qm maintenance-traced'`; 1 failed, 5 passed and 1 failed, 22 passed in their modules); with the spawn-line form both pass.
- `tests/test_github_repo.py::BareRepository::test_the_bare_clones_forbid_background_git_work` (new, red by mutation): removing `forbid_background` from `_bare_clone` fails it with `CalledProcessError` on `config --local --get maintenance.auto` (a bare clone starts without the key); the module was green with both calls deleted before this test existed. The helper's `clone --bare` and the pin's `config --get` carry none of the argv words `_count_git` tallies, so the two memoization tests' counts are unchanged.
- `tests/test_restart_classifier.py::RealDiffShapes::test_the_fixture_forbids_background_git_work`, the config read (message quality, mutation only): with `forbid_background` writing nothing, the pin fails at the runner's returncode assert as `AssertionError: ` (empty) before this change, and as `AssertionError: '' != 'false' : the repo's config carries maintenance.auto` after it.
- Targeted: `pytest tests/test_git_fixture.py tests/test_restart_classifier.py tests/test_github_repo.py`: 86 passed (85 before, plus the new pin).
- Full suite on the final tree (`pytest -n 6 tests/`, with `vscode-extension/node_modules` installed so the served-page legs run): 1 failed, 11401 passed, 43 skipped, 1744 subtests passed in 193 s. The one failure, tests/test_notification_tap_resume_browser.py's worker-click landing case (a served-page browser leg), passed when run alone on the same head in 3.8 s and reads nothing this change touches (the four files are git-fixture tests).

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)