### PR TITLE
Chat: the mention chip wears the awaiting chip's dress, the bare name in its session colour on a dark backing

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -65,7 +65,9 @@ its peers; if the bare name is ambiguous there, the session's mail tools refuse 
 list the candidates as `host:name`, and the session picks one. **Escape** closes the list
 without inserting, and it stays closed for that `@` until you delete it: more letters, or a
 caret move away and back, do not reopen it. In the sent message, a name that matches a live
-session is shown as a chip in that session's color.
+session is shown as a chip: the name without its `@`, in that session's color on a dark
+backing, the way the Awaiting chip names the session it waits on. Hover it for how that
+session is doing; the message itself still carries the `@name` you typed.
 
 **A message that has not gone yet.** Send to a busy session and your message waits as a
 dashed bubble under an hourglass until the session takes it — while it compacts, while a

--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -47,8 +47,11 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
   assert.match(chip, /nm\.style\.color = chipPeers\[0\]\.color\.bg/);
   assert.ok(!/nm\.textContent = .*host/.test(chip), "no one-string concatenation of host and name");
   assert.match(chip, /chipPeers\.length \+ " peers"/, "several peers keep the one-line rule as a count");
-  assert.match(CSS, /\.chip-peer-name \{ background: rgba\(0, 0, 0, 0\.85\); color: #fff; border-radius: 7px;/,
+  // the backing is ONE rule shared with the transcript's mention chip since 2026-09-10 (the user, who wanted a
+  // typed @name to wear this chip's look); the peer name keeps its own #fff default beside it
+  assert.match(CSS, /^\.chip-peer-name, \.mention-chip \{ background: rgba\(0, 0, 0, 0\.85\); border-radius: 7px; padding: 0 5px; \}/m,
     "the ~85% black backing — any colour reads on it, the chip hue still glows around it");
+  assert.match(CSS, /^\.chip-peer-name \{ color: #fff;/m, "the no-identity name's default stays the peer chip's own");
   assert.ok(!/\.chip-peer-dot/.test(CSS), "the dot's CSS goes with it");
 });
 

--- a/ui/webview/composer-mention-pane.test.ts
+++ b/ui/webview/composer-mention-pane.test.ts
@@ -47,7 +47,7 @@ function bundle(): string {
 import { MENTION_MAX_ROWS, mentionQuery, rankMentions, mentionMoreNote, mentionToken, insertMention, mentionKeyAction, mentionSegments } from "./composer-mention";
 const CHIP_LABEL: any = { working: "Working", ready: "Ready", idle: "Idle", closed: "Closed", needsInput: "Blocked" };
 const el = (tag: string, cls?: string) => { const e = document.createElement(tag); if (cls) e.className = cls; return e; };
-const hostNameNodes = (name: string, _id: string) => [document.createTextNode(name)];
+import { hostNameNodes } from "./host-prefix";   // the real renderer: a remote chip's host must wear .host-prefix
 const isProvisionalId = (id: string) => id.startsWith("prov:");
 (window as any).__mention = {
   mount(ta: HTMLTextAreaElement, env: any) {
@@ -462,7 +462,7 @@ test("in Chromium: chips are exact-name only, keyed by session id, re-dressed on
     chips.markMentions(bubble);
     const snap = () => Array.from(bubble.querySelectorAll(".mention-chip")).map((c) => {
       const e = c as HTMLElement;
-      return { text: e.textContent, sid: e.dataset.sid, title: e.title, bg: e.style.getPropertyValue("--chip-bg") };
+      return { text: e.textContent, token: e.dataset.token, sid: e.dataset.sid, title: e.title, bg: e.style.getPropertyValue("--chip-bg") };
     });
     const out: any = {};
     out.first = snap(); out.marked = bubble.dataset.mentions;
@@ -504,30 +504,60 @@ test("in Chromium: chips are exact-name only, keyed by session id, re-dressed on
     sessions.set("new-2", { id: "new-2", name: "api", color: { bg: "#667788", fg: "#000000" }, status: { state: "ready" } });
     chips.mentionRosterChanged();
     out.afterNew = snap();
+    // a session on another kernel, as this viewer holds it ("host:name", "host:uuid"): the chip wears the house
+    // idiom the awaiting chip wears, the host as .host-prefix and only the NAME in the identity colour
+    sessions.set("TESTHOST:" + webId, { id: "TESTHOST:" + webId, name: "TESTHOST:web", color: { bg: "#8899aa", fg: "#000000" }, status: { state: "working" } });
+    const far = document.createElement("div"); far.className = "user-bubble md";
+    far.innerHTML = "<p>ping @TESTHOST:web</p>"; thread.appendChild(far);
+    chips.markMentions(far);
+    const fc = far.querySelector(".mention-chip") as HTMLElement;
+    const hp = fc.querySelector(".host-prefix");
+    out.remote = { text: fc.textContent, token: fc.dataset.token, sid: fc.dataset.sid, title: fc.title, bg: fc.style.getPropertyValue("--chip-bg"),
+                   host: hp ? hp.textContent : null, nameNode: fc.lastChild && fc.lastChild.nodeType === 3 ? fc.lastChild.textContent : null };
     return out;
   }, [SID(2), SID(3)]);
-  assert.deepEqual(r.first, [{ text: "@api", sid: SID(2), title: "api · Working", bg: "#d5643a" }],
-    "the exact name only: @API is not a name postal takes, @web names nothing yet (a viewer's description is not a name), the code span and the link are left alone");
+  assert.deepEqual(r.first, [{ text: "api", token: "@api", sid: SID(2), title: "api · Working", bg: "#d5643a" }],
+    "the exact name only: @API is not a name postal takes, @web names nothing yet (a viewer's description is not a name), the code span and the link are left alone; the chip reads the bare name, the token as typed rides data-token, the identity colour is the chip's --chip-bg (its text colour: the sheet paints it on the awaiting chip's dark backing)");
   assert.equal(r.marked, "1", "the bubble is marked for a later re-mark");
-  assert.deepEqual(r.afterWeb.map((c: any) => c.text), ["@web", "@api"], "web's chip arrived with its frame");
+  assert.deepEqual(r.afterWeb.map((c: any) => c.text), ["web", "api"], "web's chip arrived with its frame");
   assert.equal(r.nested, 0, "the existing chip was not wrapped again");
-  assert.equal(r.text, "ask @web and @api and @API, not @api or @api", "the text reads as typed");
+  assert.equal(r.text, "ask web and api and @API, not @api or @api", "the chips read the bare names (the user 2026-09-10); everything outside a chip reads as typed");
   assert.equal(r.refreshed1, 1, "the open card was re-ranked for the roster change");
   assert.equal(r.afterState[1].title, "api · Ready"); assert.equal(r.afterState[1].bg, "#112233");
-  assert.equal(r.afterRename[1].title, "api2 · Ready"); assert.equal(r.afterRename[1].text, "@api");
+  assert.equal(r.afterRename[1].title, "api2 · Ready"); assert.equal(r.afterRename[1].text, "api"); assert.equal(r.afterRename[1].token, "@api");
   assert.equal(r.idle, 0, "the same roster twice: nothing re-ranked");
-  assert.deepEqual(r.afterClosed[1], { text: "@api", sid: SID(2), title: "api2 · Closed", bg: "#112233" }, "closed, no namesake: the chip stays keyed to it");
+  assert.deepEqual(r.afterClosed[1], { text: "api", token: "@api", sid: SID(2), title: "api2 · Closed", bg: "#112233" }, "closed, no namesake: the chip stays keyed to it");
   assert.deepEqual(r.afterViewer, r.afterClosed, "a viewer named api is not a session: no re-key");
   assert.equal(r.closedStillHeld, true, "the closed session was still in the map when the namesake arrived");
-  assert.deepEqual(r.afterNamesake[1], { text: "@api", sid: "new-1", title: "api · Working", bg: "#445566" }, "re-keyed on the namesake going live, not on the closed tab's dismissal");
+  assert.deepEqual(r.afterNamesake[1], { text: "api", token: "@api", sid: "new-1", title: "api · Working", bg: "#445566" }, "re-keyed on the namesake going live, not on the closed tab's dismissal");
   assert.deepEqual(r.afterDismiss, r.afterNamesake, "the dismissal moved nothing");
   assert.equal(r.afterGone[1].title, "api · Closed"); assert.equal(r.afterGone[1].bg, "#445566"); assert.equal(r.afterGone[1].sid, "new-1");
   assert.equal(r.afterNew[1].sid, "new-2"); assert.equal(r.afterNew[1].title, "api · Ready"); assert.equal(r.afterNew[1].bg, "#667788");
+  assert.deepEqual(r.remote, { text: "TESTHOST:web", token: "@TESTHOST:web", sid: "TESTHOST:" + SID(3), title: "TESTHOST:web · Working", bg: "#8899aa", host: "TESTHOST:", nameNode: "web" },
+    "a remote session's chip: the host as .host-prefix (its own quiet colour), the bare name as the text node the identity colour paints, the whole host:name as textContent for the roster re-key");
   assert.deepEqual(h.errors, []);
   await h.page.close();
 });
 
 // ── source pins: the wiring the slices cannot carry ─────────────────────────────────────────────────────
+
+test("the mention chip wears the awaiting chip's dress: one shared rule for the dark backing, radius and padding, the identity colour as the name's own colour", () => {
+  // (the user 2026-09-10, who wanted the two chips to look the same: no colour fill, no @). The page above loads
+  // no sheet, so the look is pinned at the source: the shared selector list, and the mention chip's own rule
+  // setting none of the shared properties (a later same-specificity rule would otherwise win the cascade).
+  const STYLES = fs.readFileSync(path.join(UI, "styles.css"), "utf8");
+  const shared = STYLES.match(/^\.chip-peer-name, \.mention-chip \{([^}]*)\}/m);
+  assert.ok(shared, "the backing, radius and padding are declared once for both chips");
+  assert.match(shared![1], /background: rgba\(0, 0, 0, 0\.85\);/); assert.match(shared![1], /border-radius: 7px;/); assert.match(shared![1], /padding: 0 5px;/);
+  assert.doesNotMatch(shared![1], /\bcolor:/, "the colour is each chip's own: the peer name's #fff default, the mention chip's identity colour");
+  const own = STYLES.match(/^\.mention-chip \{([^}]*)\}/m);
+  assert.ok(own, "the mention chip's own rule");
+  assert.match(own![1], /color: var\(--chip-bg, #fff\);/, "the identity colour is the TEXT colour, from the inline --chip-bg");
+  assert.doesNotMatch(own![1], /background|border-radius|padding|box-shadow/, "no fill, no ring, nothing the shared rule owns");
+  assert.doesNotMatch(chipBlock(), /--chip-fg/, "the fill's text colour is gone with the fill");
+  assert.match(chipBlock(), /chip\.replaceChildren\(\.\.\.hostNameNodes\(sg\.text\.slice\(1\), sg\.hit\.id\)\)/,
+    "the name through the house session-reference renderer, as the awaiting chip names its peer: a remote host wears .host-prefix");
+});
 
 test("every clear of the composer goes through clearBox, which refreshes both menus; cancelComposerEdit clears through the module-level hook", () => {
   const stmts = RENDER.match(/^\s*ta\.value = "";/gm) || [];

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -16328,13 +16328,15 @@ function mentionRosterChanged(): void {
   if (fresh) remarkMentions();
 }
 
-// A chip's dress from the session it names: the identity color and, as its title, the name and the state.
-// The chip is keyed by the session's id (data-sid) and re-dressed on every roster change, so a rename or a
-// state change reaches a chip rendered long before (the sent text itself stays as typed). A session gone
-// reads Closed and keeps its last color, so the reader still sees who was meant.
+// A chip's dress from the session it names: the identity colour as the NAME's own colour (--chip-bg, the
+// tab label's foreground idiom; the sheet paints it on the awaiting chip's dark backing, .chip-peer-name's
+// declarations) and, as its title, the name and the state. The chip is keyed by the session's id (data-sid)
+// and re-dressed on every roster change, so a rename or a state change reaches a chip rendered long before
+// (the chip's text stays the name as typed). A session gone reads Closed and keeps its last colour, so the
+// reader still sees who was meant.
 function dressMentionChip(chip: HTMLElement, s: Session | null): void {
-  if (!s) { chip.title = (chip.textContent || "").replace(/^@/, "") + " · " + CHIP_LABEL.closed; return; }
-  if (s.color) { chip.style.setProperty("--chip-bg", s.color.bg); chip.style.setProperty("--chip-fg", s.color.fg); }
+  if (!s) { chip.title = (chip.textContent || "") + " · " + CHIP_LABEL.closed; return; }
+  if (s.color) chip.style.setProperty("--chip-bg", s.color.bg);
   chip.title = s.name + " · " + (CHIP_LABEL[s.status.state] || s.status.state);
 }
 function refreshMentionChips(): void {
@@ -16349,7 +16351,7 @@ function refreshMentionChips(): void {
       // is not the test: a closed session stays in it until its tab is dismissed, and a chip keyed on that would
       // read "Closed" beside a live namesake, then flip when the tab went, with nothing new about the mention.
       if (!s || s.status.state === "closed") {
-        const again = byName.get((chip.textContent || "").replace(/^@/, ""));
+        const again = byName.get(chip.textContent || "");   // the chip's text is the bare name (the token as typed rides data-token)
         if (again) { chip.dataset.sid = again.id; s = again; }
       }
       dressMentionChip(chip, s);
@@ -16363,9 +16365,12 @@ function remarkMentions(): void {
   for (const v of views.values()) for (const b of Array.from(v.el.querySelectorAll<HTMLElement>("[data-mentions]"))) markMentions(b);
 }
 
-// A typed "@name" that names a live session wears that session's identity color (the user 2026-09-07):
-// the reader sees who was meant, and a hover says how that session is doing. A quiet chip, the tab's
-// own dress, with no link behavior; a word that names nothing stays plain text. Text nodes only, never
+// A typed "@name" that names a live session becomes a chip reading the bare NAME in that session's
+// identity colour (the user 2026-09-07; the @ dropped and the awaiting chip's dress adopted 2026-09-10,
+// the user, who wanted the two chips to look the same: the name in its colour on a dark backing, no
+// fill): the reader sees who was meant, and a hover says how that session is doing. The token as typed
+// rides data-token, so what was SENT is still on the element; a word that names nothing stays plain
+// text, and the chip carries no link behaviour. Text nodes only, never
 // inside code, a fenced block, a link or a chip already made, so a path or an email address is left
 // alone. The same boundary rule as the composer's trigger (composer-mention.ts mentionSegments). Exact
 // names only: postal's direct match is exact, so a hand-typed "@API" for the session "api" is not a name
@@ -16390,7 +16395,11 @@ function markMentions(root: HTMLElement): void {
     for (const sg of segs) {
       if (!sg.hit) { frag.appendChild(document.createTextNode(sg.text)); continue; }
       const chip = el("span", "mention-chip");
-      chip.textContent = sg.text;
+      // the name without its "@", through the house session-reference renderer, as the awaiting chip
+      // names its peer: a remote "host:" prefix wears .host-prefix (quiet, italic) and only the NAME
+      // takes the identity colour; textContent still reads the whole "host:name" the roster keys by
+      chip.replaceChildren(...hostNameNodes(sg.text.slice(1), sg.hit.id));
+      chip.dataset.token = sg.text;          // the mention as typed and sent, for anyone reading the element
       chip.dataset.sid = sg.hit.id;
       dressMentionChip(chip, sg.hit);
       frag.appendChild(chip);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1231,12 +1231,13 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .mention-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; font-weight: 600; }
 /* the matches the cap left out ("N more, keep typing"): the menu's sub-line dress, not a row (no wash, no pick) */
 .mention-more { padding: 4px 10px; font-size: 0.82em; opacity: 0.6; cursor: default; white-space: nowrap; }
-/* a sent message's "@name" that names a live session: a small pill in the session's identity color (the
-   tab's own --chip-bg/--chip-fg, set inline), over the blue you-bubble; the thin light ring keeps a blue
-   identity apart from the bubble. No link: the title carries the session's state. */
-.mention-chip { display: inline-block; padding: 0 6px; border-radius: 9px; line-height: 1.35;
-  background: var(--chip-bg, rgba(255, 255, 255, 0.18)); color: var(--chip-fg, currentColor);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3); }
+/* a sent message's "@name" that names a live session: the NAME, its "@" dropped, in the session's identity
+   colour (--chip-bg inline, the tab label's foreground idiom) on the awaiting chip's dark backing (the user
+   2026-09-10, who wanted the chip to look like the awaiting chip: no fill, no @). The backing, radius and
+   padding are .chip-peer-name's, declared in ONE rule with it (below, beside the status chips) so the two
+   chips cannot drift; the colour and the prose weight are this chip's own, and this rule sets no property
+   the shared one sets, so their order does not matter. No link: the title carries the session's state. */
+.mention-chip { display: inline-block; line-height: 1.35; font-weight: 600; color: var(--chip-bg, #fff); }
 
 /* A SECTION AT A GLANCE (tab-snapshot.ts, render.ts renderSnapshot): one row per session of a tab-strip
    section, in the transcript's place. Two sizes only: the body size for the name and the now line, and
@@ -1366,8 +1367,11 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* the awaiting chip's peer NAME wears the identity colour itself (the user 2026-08-26, round two —
    the dot retired). The backing is ~85% black: opaque enough that any colour reads on it regardless
    of the chip hue behind (their green-on-green case), translucent enough to keep the chip's flavor.
-   #fff default = the no-identity (cross-host) name stays legible on the dark backing. */
-.chip-peer-name { background: rgba(0, 0, 0, 0.85); color: #fff; border-radius: 7px; padding: 0 5px; margin-left: 1px; }
+   #fff default = the no-identity (cross-host) name stays legible on the dark backing. The backing, radius
+   and padding are ONE rule with the transcript's .mention-chip (the user 2026-09-10, who wanted a typed
+   @name to wear this chip's look): the two cannot drift; each sets its own colour and spacing. */
+.chip-peer-name, .mention-chip { background: rgba(0, 0, 0, 0.85); border-radius: 7px; padding: 0 5px; }
+.chip-peer-name { color: #fff; margin-left: 1px; }
 .chip-awaitingBg { background: var(--st-awaitbg-bg); color: var(--st-awaitbg-fg); }
 /* the Awaiting chip is a BUTTON (slice 2, 2026-09-05): click opens the awaiting box below. The UA
    button chrome is reset so it wears the chip exactly (.chip supplies size, weight, padding, radius);


### PR DESCRIPTION
Follow-up to the composer @-mention picker that merged earlier today, on the maintainer's call (2026-09-10): the chip a sent @name becomes should look like the Awaiting box's session chip, not a colour-filled pill, and should read just the name.

## What changes

- **The look.** The mention chip drops its identity-colour fill, ring and 9px radius and takes the awaiting chip's dress: the 85% black backing, 7px radius and 0 5px padding, declared **once** in a rule shared by `.chip-peer-name` and `.mention-chip` so the two cannot drift. The mention chip's own rule sets only what is its own (display, line height, weight, and the session's identity colour as the text colour), none of the shared properties, so cascade order does not matter.
- **The text.** The chip shows the bare session name; the `@` is gone from the chip. The typed token rides a `data-token` attribute, and what is sent is untouched: the composer still inserts `@name `, the segmenter and the postal address rules are unchanged. A remote session's `host:` prefix wears the same quiet prefix treatment the awaiting chip gives it. The closed-session state keeps its last colour and its hover title.
- **Docs.** The guide's paragraph on naming another session describes the chip's new look.

## Tests

- `ui/webview/awaiting-peer-name.test.ts`: its pin on the awaiting chip's rule follows the shared rule (this was the one existing test the change broke before review caught it).
- `ui/webview/composer-mention-pane.test.ts`: the chip cases read the bare name and the token, cover a remote session's prefix, and pin the shared stylesheet rule and that the chip's own rule sets none of its properties.
- The pure segmenter tests are unchanged since what is sent is unchanged. Typecheck clean; the three touched files pass (32 tests) under the capped wrapper, browser cases executed.

Render of the two chips side by side, from a synthetic fixture, is at the reviewer's disposal on the maintainer's machine.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
