### PR TITLE
Tests: the bats git floor forbids background maintenance in fixture repos and their bare remotes, so a teardown's rm -rf never races a detached git child

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -124,8 +124,15 @@ stderr: `[tests] not removed at run end: <path>`, instead of the run ending
 green over it. The same conftest gives git no global or system config
 (`GIT_CONFIG_GLOBAL`, `GIT_CONFIG_NOSYSTEM`) and a synthetic identity through
 `GIT_AUTHOR_*` / `GIT_COMMITTER_*`; bats suites that run git get the same from
-`load git-hermetic` + `git_hermetic` in `setup`. A fixture must not depend on
-the developer's git configuration (CI has none), and the env identity outranks
+`load git-hermetic` + `git_hermetic` in `setup`, with a global config file of
+the floor's own in place of none. That floor also forbids background git work:
+the five no-background keys of `tests/git_fixture.py` (below) ride the
+environment as `GIT_CONFIG_COUNT` pairs, inherited by every git a test, a script
+under test or a hook runs, and sit in the floor's global file, which receive-pack
+in a bare fixture remote reads (a push over a local path starts it without the
+pairs); so no detached `git maintenance` writes into a fixture repo while its
+teardown removes it. A fixture must not depend on the developer's git
+configuration (CI has none), and the env identity outranks
 `git config user.*` and `-c user.*` — a test that must pin a particular author
 exports its own `GIT_AUTHOR_*` after the floor. `tests/test_tempdir_hygiene.py`
 and `tests/git-hermetic.bats` pin all of it.

--- a/tests/git-hermetic.bash
+++ b/tests/git-hermetic.bash
@@ -1,7 +1,9 @@
-# tests/git-hermetic.bash: git in a bats test reads none of the developer's configuration.
+# tests/git-hermetic.bash: git in a bats test reads none of the developer's configuration and
+# spawns no background work.
 #
 # Use from a bats file: `load git-hermetic` at the top and `git_hermetic` as the first line of
-# setup(), before any git command runs.
+# setup(), before any git command runs. It writes a config file under BATS_TEST_TMPDIR, so it runs
+# inside a test (setup, the test body or teardown), not at file load and not in setup_file.
 #
 # Why (2026-09-06): the fixture repos here are built with `git init` + `git commit` in temp dirs,
 # and those commands honoured the developer's global git config. On one box a global
@@ -13,9 +15,41 @@
 # GIT_AUTHOR_* cannot leak into fixture commits either. The env identity outranks `git config
 # user.*` and `-c user.*`, so a test that must pin a particular author exports its own
 # GIT_AUTHOR_* / GIT_COMMITTER_* after this call; other config keys still yield to `-c`.
+#
+# No background work (2026-09-10): `git commit`, fetch and merge spawn `git maintenance run --auto`,
+# and receive-pack runs the receiving repository's auto gc or maintenance after every push. On git
+# 2.47 and later the maintenance child takes .git/maintenance.lock and then detaches from its
+# parent, so it can still be writing under .git when teardown's `rm -rf` runs; rm exits 1 on the
+# directory it could not empty and bats fails the test whose teardown failed. The install-sh,
+# release-sh, gitleaks-config, docs-serve, pre-push-hook and bootstrap-sh suites commit or push
+# into repos their teardown removes (CI's runners had git 2.55.0 on 2026-09-10; a git that does
+# not detach shows the same spawn in GIT_TRACE without the race). The five keys are the ones
+# tests/git_fixture.py passes as -c flags on the python side (GIT_NO_BACKGROUND). Here they travel
+# two ways, because neither way alone reaches every git a test starts:
+# - as GIT_CONFIG_COUNT runtime pairs in the environment (git >= 2.31), which every git the test,
+#   a script under test (install.sh, release.sh, bootstrap.sh, docs-serve.sh, the pre-push hook)
+#   or a hook runs inherits; they override every config file and yield to any -c a test passes.
+#   A test that needs pairs of its own re-exports the whole set: git refuses to run when
+#   GIT_CONFIG_COUNT names a pair that has no GIT_CONFIG_KEY_n or GIT_CONFIG_VALUE_n.
+# - in the floor's own global config file, which GIT_CONFIG_GLOBAL names in place of /dev/null. A
+#   push over a local path starts receive-pack with GIT_CONFIG_COUNT stripped (the same rule keeps
+#   a -c from crossing into the other repository), so the pairs never reach the receiving side;
+#   GIT_CONFIG_GLOBAL survives, and the file is what receive-pack in a bare fixture remote reads.
+#   A suite that points GIT_CONFIG_GLOBAL at a file of its own gives that half up.
 
 git_hermetic() {
-    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1
+    export GIT_CONFIG_NOSYSTEM=1
     export GIT_AUTHOR_NAME="romp tests" GIT_AUTHOR_EMAIL="tests@example.invalid"
     export GIT_COMMITTER_NAME="romp tests" GIT_COMMITTER_EMAIL="tests@example.invalid"
+    # The same five keys, in the same order, as GIT_NO_BACKGROUND in tests/git_fixture.py.
+    export GIT_CONFIG_COUNT=5
+    export GIT_CONFIG_KEY_0=maintenance.auto       GIT_CONFIG_VALUE_0=false
+    export GIT_CONFIG_KEY_1=maintenance.autoDetach GIT_CONFIG_VALUE_1=false
+    export GIT_CONFIG_KEY_2=gc.auto                GIT_CONFIG_VALUE_2=0
+    export GIT_CONFIG_KEY_3=gc.autoDetach          GIT_CONFIG_VALUE_3=false
+    export GIT_CONFIG_KEY_4=core.fsmonitor         GIT_CONFIG_VALUE_4=false
+    # The same five keys as the only global config, for the git that starts without the count.
+    export GIT_CONFIG_GLOBAL="${BATS_TEST_TMPDIR:?git_hermetic runs inside a bats test}/gitconfig"
+    printf '[maintenance]\n\tauto = false\n\tautoDetach = false\n[gc]\n\tauto = 0\n\tautoDetach = false\n[core]\n\tfsmonitor = false\n' \
+        > "$GIT_CONFIG_GLOBAL"
 }

--- a/tests/git-hermetic.bats
+++ b/tests/git-hermetic.bats
@@ -1,7 +1,9 @@
 #!/usr/bin/env bats
 
-# tests/git-hermetic.bash: after git_hermetic, git reads no global or system config and every
-# commit has an identity, whatever the box is configured with.
+# tests/git-hermetic.bash: after git_hermetic, git reads none of the developer's global or system
+# config, every commit has an identity, whatever the machine is configured with, and neither a
+# commit nor a push's receive-pack runs the background maintenance that could still be writing
+# under .git when a teardown removes the repo.
 #
 # Skips on git < 2.32 with the same message as tests/test_tempdir_hygiene.GitFloor: GIT_CONFIG_GLOBAL
 # and GIT_CONFIG_SYSTEM arrived in 2.32, so on an older git the config half of the floor is inert
@@ -28,7 +30,7 @@ setup() {
     chmod +x "$TEST_DIR/hooks/pre-commit"
     printf '[core]\n\thooksPath = %s\n[user]\n\tname = Global Person\n\temail = global@example.invalid\n' \
         "$TEST_DIR/hooks" > "$HOME/.gitconfig"
-    unset GIT_CONFIG_GLOBAL GIT_CONFIG_NOSYSTEM XDG_CONFIG_HOME
+    unset GIT_CONFIG_GLOBAL GIT_CONFIG_NOSYSTEM GIT_CONFIG_COUNT XDG_CONFIG_HOME
     unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
     REPO="$TEST_DIR/repo"
     git init -q "$REPO"
@@ -84,4 +86,64 @@ teardown() { rm -rf "${TEST_DIR:-}"; }
     # particular author exports its own GIT_AUTHOR_* / GIT_COMMITTER_* after git_hermetic.
     GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@e.invalid git -C "$REPO" commit -qm seed
     [ "$(git -C "$REPO" log -1 --format='%an <%ae>')" = "t <t@e.invalid>" ]
+}
+
+@test "with git_hermetic the no-background keys read back from the environment and the floor's global file, not from the repo" {
+    # The deterministic pin. Each key is configuration twice: from the floor's global config file
+    # (the `global` scope) and from the GIT_CONFIG_COUNT pairs (the `command` scope, the label -c
+    # reports too; -c itself still outranks them), and never from the repo's own config. Before the
+    # floor carried them, each --get exited 1 with nothing printed.
+    git_hermetic
+    local kv
+    for kv in maintenance.auto=false maintenance.autoDetach=false gc.auto=0 gc.autoDetach=false core.fsmonitor=false; do
+        [ "$(git -C "$REPO" config --show-scope --get-all "${kv%%=*}")" = "$(printf 'global\t%s\ncommand\t%s' "${kv#*=}" "${kv#*=}")" ]
+    done
+    [ "$GIT_CONFIG_COUNT" = 5 ]                                                    # these five pairs and no other
+    [ "$(git config --file "$GIT_CONFIG_GLOBAL" --list | wc -l | tr -d ' ')" = 5 ]   # and the file carries the same five
+    run git -C "$REPO" config --local --get maintenance.auto
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+    # Precedence: the pairs beat a value the repo's own config sets, and a test's -c beats the pairs.
+    git -C "$REPO" config maintenance.auto true
+    [ "$(git -C "$REPO" config --get maintenance.auto)" = "false" ]
+    [ "$(git -C "$REPO" -c maintenance.auto=true config --get maintenance.auto)" = "true" ]
+}
+
+@test "with git_hermetic a commit spawns no maintenance or gc child" {
+    # A smoke check on the git running the suite, read off git's own trace the way
+    # tests/test_git_fixture.py reads it (the same substrings: a bare `maintenance` also catches
+    # the --detach argument recent git appends); the config pin above is the deterministic half.
+    # Without the keys, `git commit` spawns `git maintenance run --auto`, the child that can still
+    # be writing under .git when a teardown's rm -rf runs.
+    git_hermetic
+    GIT_TRACE="$TEST_DIR/trace" git -C "$REPO" commit -qm seed
+    [ -s "$TEST_DIR/trace" ]
+    grep -q 'built-in: git commit' "$TEST_DIR/trace"
+    run grep 'maintenance' "$TEST_DIR/trace"
+    [ "$status" -ne 0 ]
+    run grep 'run_command: git gc' "$TEST_DIR/trace"
+    [ "$status" -ne 0 ]
+}
+
+@test "with git_hermetic a push's receive-pack reads the no-background keys in the receiving repository" {
+    # A push over a local path starts receive-pack with GIT_CONFIG_COUNT stripped, so the pairs
+    # alone would leave the receiving side to its own auto gc or maintenance in a repo the teardown
+    # removes; the floor's global config file is what reaches it. Read from inside receive-pack's
+    # environment through --receive-pack: a stand-in records two keys as it sees them, untraced, and
+    # then runs the real receive-pack. Before the floor wrote the file, both reads exited 1 with
+    # nothing printed. The trace check is the smoke half: a git whose receive-pack spawns
+    # `gc --auto` directly rather than through maintenance shows that child either way, and
+    # gc.auto=0 has it exit without work.
+    git_hermetic
+    git -C "$REPO" commit -qm seed
+    git init -q --bare "$TEST_DIR/remote.git"
+    printf '#!/bin/sh\n{ GIT_TRACE=0 git -C "$1" config --get maintenance.auto; GIT_TRACE=0 git -C "$1" config --get gc.auto; } > "%s" 2>&1\nexec git receive-pack "$@"\n' \
+        "$TEST_DIR/remote-saw" > "$TEST_DIR/receive-pack"
+    chmod +x "$TEST_DIR/receive-pack"
+    GIT_TRACE="$TEST_DIR/trace" git -C "$REPO" push -q --receive-pack="$TEST_DIR/receive-pack" "$TEST_DIR/remote.git" HEAD:refs/heads/main
+    [ "$(git -C "$TEST_DIR/remote.git" rev-parse refs/heads/main)" = "$(git -C "$REPO" rev-parse HEAD)" ]
+    [ "$(cat "$TEST_DIR/remote-saw")" = "$(printf 'false\n0')" ]
+    grep -q 'built-in: git receive-pack' "$TEST_DIR/trace"
+    run grep 'maintenance' "$TEST_DIR/trace"
+    [ "$status" -ne 0 ]
 }

--- a/tests/pre-push-hook.bats
+++ b/tests/pre-push-hook.bats
@@ -23,14 +23,18 @@
 ROMP_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 HOOK="$ROMP_DIR/.githooks/pre-push"
 
+load git-hermetic
+
 setup() {
-    TEST_DIR="$(mktemp -d)"
     # Hermetic git: the fixtures commit and merge with plain defaults, and a developer's global
     # config (merge.ff=only, commit.gpgsign, a hooks path) must not reach them (the #968 review).
+    # The floor (tests/git-hermetic.bash) also forbids background git work in the repos below and
+    # in the bare remote the pushes land in, and its exported identity is the one every commit
+    # carries; the user.* lines below give the repo a configured user for anything that reads one.
+    git_hermetic
+    TEST_DIR="$(mktemp -d)"
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"
-    export GIT_CONFIG_GLOBAL="$TEST_DIR/gitconfig" GIT_CONFIG_NOSYSTEM=1
-    : > "$GIT_CONFIG_GLOBAL"
     REPO="$TEST_DIR/repo"
     mkdir -p "$REPO"
     git -C "$REPO" init -q


### PR DESCRIPTION
## Symptom

A bats suite that commits, merges, fetches or pushes into a repo its teardown removes can fail on that teardown: `rm -rf "$TEST_DIR"` exits 1 on a `.git` it could not empty, and bats fails the test whose teardown failed. Six suites write into such repos: install-sh, release-sh, gitleaks-config, docs-serve, pre-push-hook and bootstrap-sh (docs-serve's teardown returns 0 after the rm, so there the race leaves a directory behind instead of failing). The same race showed on the python side as `Directory not empty: '.git'` from rmtree (#1312).

## Cause

`git commit`, fetch and merge spawn `git maintenance run --auto`, and receive-pack runs the receiving repository's auto gc or maintenance after every push. On git 2.47 and later the maintenance child takes `.git/maintenance.lock` and detaches from its parent, so it can still be writing under `.git` after the test's git call has returned. CI's runners have git 2.55.0. #1314 and #1315 forbid that work for the python fixtures per call (`tests/git_fixture.py`, `GIT_NO_BACKGROUND`); the bats floor in `tests/git-hermetic.bash` exported no maintenance or gc key, and `tests/pre-push-hook.bats` did not load the floor at all.

## Fix

- `tests/git-hermetic.bash`: `git_hermetic` carries the five `GIT_NO_BACKGROUND` keys (maintenance.auto=false, maintenance.autoDetach=false, gc.auto=0, gc.autoDetach=false, core.fsmonitor=false; the same order as `tests/git_fixture.py`) two ways, because neither alone reaches every git a test starts:
  - as `GIT_CONFIG_COUNT=5` runtime pairs in the environment (`GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n`; git 2.31 and later, inside the floor's existing 2.32 requirement), which every git the test, a script under test (install.sh, release.sh, bootstrap.sh, docs-serve.sh, the pre-push hook) or a hook runs inherits; they override every config file and yield to any `-c` a test passes. A test that needs pairs of its own re-exports the whole set, since a count naming a missing pair is a fatal error for every git call.
  - in a global config file of the floor's own under `BATS_TEST_TMPDIR`, which `GIT_CONFIG_GLOBAL` names in place of `/dev/null`. A push over a local path starts receive-pack with `GIT_CONFIG_COUNT` stripped (the same rule keeps a `-c` from crossing into the other repository), so the pairs never reach the receiving side; `GIT_CONFIG_GLOBAL` survives, and the file is what receive-pack in a bare fixture remote reads. On a git whose receive-pack still spawns `gc --auto` directly, that child reads gc.auto=0 and exits before taking any lock.
  The header comment says all of this. Because the floor writes a file, `git_hermetic` runs inside a test (setup, body or teardown), not at file load or in setup_file; every current caller is in setup or a test body.
- `tests/pre-push-hook.bats`: loads git-hermetic and calls `git_hermetic` first in setup, in place of the empty `GIT_CONFIG_GLOBAL` file it kept for itself: nothing read that file, and keeping it would hide the floor's file from this suite's own bare remote. No test in the file asserts on author or committer and the hook reads no identity field, so the floor's exported identity changes no outcome; the setup comment says the repo-local `user.*` lines give the repo a configured user for anything that reads one.
- `tests/README.md`: the hermetic paragraph names both mechanisms and points at `tests/git_fixture.py`.

No production code changes; no assertion in any existing test changes.

## Tests

`tests/git-hermetic.bats` gains three cases behind its existing 2.32 skip, and its setup unsets `GIT_CONFIG_COUNT` alongside `GIT_CONFIG_GLOBAL` so the pins measure `git_hermetic`, not the caller's shell.

- "with git_hermetic the no-background keys read back from the environment and the floor's global file, not from the repo": each of the five keys reads back through `git config --show-scope --get-all` once at the `global` scope and once at the `command` scope; `GIT_CONFIG_COUNT` is 5 and the floor's file lists exactly five keys; `config --local --get maintenance.auto` exits nonzero with no output; a repo-local `maintenance.auto=true` still reads back false (the pairs beat a file value) and `-c maintenance.auto=true` reads back true (`-c` beats the pairs). Before the change it fails at the first read (git exits 1, nothing printed). This is the deterministic pin.
- "with git_hermetic a push's receive-pack reads the no-background keys in the receiving repository": commits, inits a bare repo, and pushes into it through a `--receive-pack` stand-in that records `maintenance.auto` and `gc.auto` as receive-pack's own environment sees them (untraced) and then runs the real receive-pack; asserts the push landed, both reads say `false` and `0`, the trace names `built-in: git receive-pack` and carries no `maintenance` line. Before the change both reads exit 1 with nothing printed; with the pairs alone (no file) they still do, which is what this pin exists to catch. The trace part is a smoke check: a git whose receive-pack spawns `gc --auto` directly shows that child either way.
- "with git_hermetic a commit spawns no maintenance or gc child": a commit under `GIT_TRACE` writes a trace containing `built-in: git commit` and no line containing `maintenance` or `run_command: git gc` (the substrings `tests/test_git_fixture.py` reads; a bare `maintenance` also covers the `--detach` argument recent git appends). Before the change it fails on the `maintenance` grep, the trace carrying `run_command: git maintenance run --auto --quiet`. A smoke check on the git running the suite; the config pin is the red-first that does not depend on what this git spawns.

Runs on git 2.43.0, bats 1.10.0, stdin from /dev/null: git-hermetic 8/8, pre-push-hook 22/22, install-sh 44/44, release-sh 29/29, gitleaks-config 9/9 (gitleaks installed, nothing skipped), docs-serve 6/6, bootstrap-sh 13/13 (its origin is a local fixture repo, no network, nothing skipped). Removing the file half of the floor turns the config and push pins red; removing the pairs turns the config pin red while the file still covers the commit and the push. No python file changes, so no pytest run.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)