### PR TITLE
Postal: a comment thread's mail waits like any live session's; the orphan sweep no longer bounces it as 'that session has exited'

### DIFF
--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1049,8 +1049,12 @@ def local_agents(threads=False):
     `threads` (the user 2026-08-22): also include COMMENT-THREAD sessions — real forked sessions the
     kernel hides from tabs/lanes/cards until promotion. Opt-in per consumer so the default listing and
     every other reader stay exactly as they were: self-identity, recipient resolution, and the agents
-    listing pass True (a thread mails its parent under its OWN name and is addressable for replies);
-    everything else never sees them."""
+    listing pass True (a thread mails its parent under its OWN name and is addressable for replies),
+    and so does every reader that judges a MAILBOX live or dead — the heartbeat (2026-09-06), the
+    orphan sweep, the stuck-mail warning, the revive wake and the retry pass (2026-09-10: those four
+    read the default listing, so a live thread's box was dead to them — the sweep destroyed a parent's
+    reply to its own thread after ORPHAN_GRACE and told the sender the thread had exited, and the
+    retry and wake never delivered it). Readers that only count or show presence keep the default."""
     return _agent_rows(_kernel_sessions(threads=threads))
 
 
@@ -1647,7 +1651,7 @@ def _sweep_orphans():
     the grace still gets its mail. Run periodically by the bus monitor."""
     if not MAILROOT.is_dir():
         return
-    live = local_agents()
+    live = local_agents(threads=True)                 # a comment thread's box is live while its row is (2026-09-10)
     if not live:                                       # tmux hiccup, not "everyone died" — don't mass-bounce
         return
     live_ids = {a["id"] for a in live}
@@ -1741,7 +1745,7 @@ def _warn_stuck_mail():
     messages are pruned so WARNED stays bounded to currently-pending mail."""
     if not MAILROOT.is_dir():
         return
-    live = local_agents()
+    live = local_agents(threads=True)                 # thread rows too: an idle thread can be stuck like any session
     if not live:                                       # kernel hiccup, not "everyone's stuck" — don't warn
         return
     by_id = {a["id"]: a for a in live}
@@ -1994,7 +1998,7 @@ def _wake_when_ready(sid):
             newd = MAILROOT / sid / "new"
             if not (newd.is_dir() and any(newd.iterdir())):
                 return                                        # nothing pending (or already delivered)
-            agent = next((a for a in local_agents() if a["id"] == sid), None)
+            agent = next((a for a in local_agents(threads=True) if a["id"] == sid), None)   # a reviving thread is a live row
             if not agent:
                 return                                        # session died during load
             if _push(sid, agent):                             # injected (drain + submit → forces a turn) → done
@@ -2556,7 +2560,7 @@ def _retry_pending():
             _mark_pending(sid)                 # stale marker -> clear it
             continue
         if live is None:
-            live = {a["id"]: a for a in local_agents()}
+            live = {a["id"]: a for a in local_agents(threads=True)}   # a thread's marker retries like any live session's
         if sid in live:
             try:
                 _push(sid, live[sid])          # re-attempt; the kernel defers again if still unsafe

--- a/tests/test_postal_heartbeat_fetches.py
+++ b/tests/test_postal_heartbeat_fetches.py
@@ -263,7 +263,8 @@ class Counting(unittest.TestCase):
         # is the only fetch (28 per 30 s poll on a box with 58 mailboxes, review 2026-09-06)
         self._dead_boxes(["ghost-a", "ghost-b", "ghost-c"])
         pm._sweep_orphans()
-        self.assertEqual(self.fetches, [False], "one listing for the whole sweep")
+        self.assertEqual(self.fetches, [True], "one listing for the whole sweep, thread rows included: a comment "
+                                               "thread's box is live while its row is (2026-09-10)")
 
     def test_recall_by_a_dead_name_fetches_once(self):
         dead = self._dead_boxes(["ghost-a", "ghost-b", "ghost-c"])
@@ -337,7 +338,8 @@ class Counting(unittest.TestCase):
             pm.deliver(WEB, "api", API, "synthetic reply", kind="coordinate")
             self.fetches.clear()
             pm._retry_pending()
-            self.assertEqual(self.fetches, [False], "one listing fetch for the whole pass, not one per marker")
+            self.assertEqual(self.fetches, [True], "one listing fetch for the whole pass, not one per marker; "
+                                                   "thread rows included so a thread's marker is retried")
             self.assertEqual(sorted(pushed), sorted([API, WEB]))
         finally:
             pm._push = saved_push

--- a/tests/test_postal_undelivered.py
+++ b/tests/test_postal_undelivered.py
@@ -26,6 +26,7 @@ pm = load_source("romp_postal_undelivered", os.path.join(BIN, "romp-postal-servi
 
 SENDER = "11111111-1111-1111-1111-111111111111"
 RECIP = "22222222-2222-2222-2222-222222222222"
+THREAD = "44444444-4444-4444-4444-444444444444"   # a comment thread of SENDER: live, but off the default listing
 
 
 class StuckMailWarning(unittest.TestCase):
@@ -251,6 +252,75 @@ class TheSweepMovesAnUnreadableFileAside(unittest.TestCase):
         pm._sweep_orphans()
         self.assertTrue((pm.MAILROOT / RECIP).is_dir(), "the emptied box is not tidied away while it holds evidence")
         self.assertEqual(len([p for p, b in self.told if p == "/postal-notice"]), 1, "said once")
+
+
+class AThreadsMailWaitsLikeAnyLiveSessions(unittest.TestCase):
+    """A comment thread is a real forked session the kernel serves only behind ?threads=1 (the seam filters
+    the same way); resolve_recipient addresses it with thread rows and deliver() writes MAILROOT/<tsid>/new.
+    The four reads that judge a MAILBOX live or dead read the default listing, so a live thread's box was
+    dead to them: the orphan sweep destroyed its unread mail after ORPHAN_GRACE and told the sender the
+    thread had exited, the retry pass skipped its marker, the revive wake ruled it died during load, and
+    the stuck-mail warning never saw its idle state. Each now reads the listing with thread rows, as
+    _record_heartbeat has since 2026-09-06. Mutants: any one read back on the default listing (its own
+    test fails). _push is the one seam stubbed: under ROMP_SESSIONS_FILE it declines every wake, and
+    the wake is what the retry and revive tests count."""
+
+    def setUp(self):
+        self._seamfile = os.path.join(tempfile.mkdtemp(), "sessions.json")
+        self._prior_seam = os.environ.get("ROMP_SESSIONS_FILE")
+        os.environ["ROMP_SESSIONS_FILE"] = self._seamfile
+        for d in (pm.MAILROOT, pm.WARNED, pm.MAILPENDING):
+            shutil.rmtree(d, ignore_errors=True)
+        try:
+            (pm.TLDIR / "messages.jsonl").unlink()
+        except OSError:
+            pass
+        Path(self._seamfile).write_text(json.dumps(
+            [{"id": SENDER, "name": "alice", "state": "idle"},
+             {"id": THREAD, "name": "alice-t1", "state": "idle", "thread": True, "parent": SENDER}]))
+        self._push, self.pushed = pm._push, []
+        pm._push = lambda sid, row: self.pushed.append(sid) is None      # records the wake; True = injected
+
+    def tearDown(self):
+        pm._push = self._push
+        restore_env("ROMP_SESSIONS_FILE", self._prior_seam)
+
+    def _age(self, secs):
+        old = time.time() - secs
+        for f in (pm.MAILROOT / THREAD / "new").iterdir():
+            os.utime(f, (old, old))
+
+    def _rows(self):
+        p = pm.TLDIR / "messages.jsonl"
+        return [json.loads(l) for l in p.read_text().splitlines() if l] if p.exists() else []
+
+    def test_the_sweep_leaves_a_live_threads_unread_mail_where_it_is(self):
+        mid = pm.deliver(THREAD, "alice", SENDER, "reply to the thread")
+        self._age(pm.ORPHAN_GRACE + 60)
+        pm._sweep_orphans()
+        self.assertTrue((pm.MAILROOT / THREAD / "new" / mid).exists(),
+                        "the thread is live: its mail waits for it like any live session's")
+        self.assertEqual(pm.read_box(SENDER, consume=False), [], "no 'has exited' note to the sender")
+        self.assertEqual([r["ev"] for r in self._rows() if r.get("id") == mid], ["sent"], "nothing was destroyed")
+
+    def test_the_retry_pass_wakes_a_thread_holding_mail(self):
+        pm.deliver(THREAD, "alice", SENDER, "reply to the thread")
+        pm._retry_pending()
+        self.assertEqual(self.pushed, [THREAD], "the thread's pending marker is retried, not skipped as dead")
+
+    def test_the_revive_wake_finds_the_thread(self):
+        pm.deliver(THREAD, "alice", SENDER, "reply to the thread")
+        pm._wake_when_ready(THREAD)
+        self.assertEqual(self.pushed, [THREAD], "a reviving thread is a live row, not one that died during load")
+
+    def test_a_threads_stuck_mail_warns_the_sender_like_any_idle_recipients(self):
+        mid = pm.deliver(THREAD, "alice", SENDER, "reply to the thread")
+        self._age(pm.STUCK_GRACE + 60)
+        pm._warn_stuck_mail()
+        warns = pm.read_box(SENDER, consume=False)
+        self.assertEqual(len(warns), 1, "an idle thread that never read is as stuck as any idle session")
+        self.assertIn("alice-t1", warns[0]["body"], "and the warning names the thread")
+        self.assertTrue((pm.MAILROOT / THREAD / "new" / mid).exists(), "the mail itself is left for delivery")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main`: the mail bus lists sessions without their comment threads unless it asks for them, and four of its mailbox judges never asked. Mail can be addressed to a thread, and is delivered into the thread's own box, yet the orphan sweep, the stuck-mail warning, the revive wake and the retry pass all read the thread-blind listing. So a parent's reply to its own live thread, deferred once by the documented no-push flag or a non-idle state, was destroyed by the sweep after the grace period, with a false "your message was never read; that session has exited" bounce to the sender, while the thread was alive and never saw it. Retries and wakes skipped threads the same way. The heartbeat already read the listing with threads since an earlier fix; these four did not.

## What changes
The four judges read the listing with threads, each with a one-line reason, so a thread's mail waits like any live session's, is retried and woken like any other, and is warned about when stuck. A dead thread is still swept: ending the parent marks its threads dead, and they leave the listing. The same listing also decides who receives the bounce or the stuck warning, so a thread that sent mail to a recipient that then died now receives that note and is woken for it, where before its orphan was destroyed with no note to anyone. Presence counters keep the plain listing, since a thread's presence is its parent's. The listing function's docstring now says which callers ask for threads.

## Deliberately left out
Whether a remote sender can address a thread at all is a separate question: today no far side ever puts a thread id on the wire, so the relay and quarantine paths never meet one.

## Tests
One test per changed read, driving the real functions through the sessions-file seam with only the push stubbed: the sweep leaves a live thread's mail and files no bounce; the retry wakes the thread; the revive wake finds it; the stuck warning names it. Two existing heartbeat fetch-count pins flip their recorded flag; the count they pin is unchanged. On `main` the four new tests fail because the seam drops the thread row, and the two pins fail on the flag. The two modules pass 12 and 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
