### PR TITLE
Nudge: a reply on a Working card is judged unless the card itself is done; all-children-done no longer swallows it into a procedural block

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10083,7 +10083,13 @@ def _plan_session(fsid, path, now):
                 # this response is processed; the old unconditional _reopen below then UN-completed it, and a "blocked
                 # on you" reply re-blocked it — a completed→blocked flip, which must never happen. If the goal is
                 # already done, the nudge is moot (its "what's the status?" is answered by completion): record the
-                # unit processed and place NOTHING, leaving the completed goal completed.
+                # unit processed and place NOTHING, leaving the completed goal completed. "Done" here is the
+                # target's OWN verdict (nodeComplete) or its sticky settle — never all-children-done: rollup's
+                # is_complete retired that bottom-up rule (VERDICTS ONLY, the user 2026-07-15), so a top whose
+                # steps are all done but which carries no verdict of its own reads WORKING on the board, its
+                # nudge fires legitimately, and its reply must reach the planner. Reading it through
+                # _subtree_done discarded that reply here (nothing placed, plan_llm never called), after which
+                # the kernel's follow-up-failed path filed a procedural block with no brief (2026-09-10).
                 _nkids = {}
                 for _nid, _nd in store["nodes"].items():
                     _nkids.setdefault(_nd.get("parentId"), []).append(_nid)
@@ -10101,7 +10107,7 @@ def _plan_session(fsid, path, now):
                         _open_items.append(_x)
                     _stack.extend(_nkids.get(_x, []))
                 if (not _open_items and not _fold_node(store["nodes"][target])["held"]
-                        and (_subtree_done(store["nodes"], _nkids, target)
+                        and (store["nodes"][target].get("nodeComplete")
                              or store["nodes"][target].get("settledDone"))):
                     # (held check 2026-07-07: a user reopen no verdict has answered means the user asserted
                     # NOT done — an all-done subtree under it is exactly why they were asked; never moot.)

--- a/tests/test_judge_nudge_no_reopen_completed.py
+++ b/tests/test_judge_nudge_no_reopen_completed.py
@@ -53,16 +53,17 @@ class NudgeNoReopenCompleted(unittest.TestCase):
     def tearDown(self):
         jd.plan_llm, jd.opener_llm, jd._group_store = self._saved
 
-    def _nudge_transcript(self, declared_todo=None):
+    def _nudge_transcript(self, declared_todo=None, sid=SID, gid=GID):
         """One ENDED turn opened by an AUTO-nudge message (romp-injected + romp-auto + romp-goal-id) targeting
-        GID, with an assistant 'waiting on you' reply → classified as a nudge unit for GID. `declared_todo`
+        `gid` (GID by default), with an assistant 'waiting on you' reply → classified as a nudge unit for it,
+        written as `sid`'s transcript. `declared_todo`
         prepends a prior turn declaring that item OPEN via the Task tool, so _sync_declared_plan (which reads
         the WHOLE session) sees the agentTask fixture's item as genuinely still open instead of flipping it
         to completed for being absent from the declared plan."""
-        path = os.path.join(self.td, SID + ".jsonl")
+        path = os.path.join(self.td, sid + ".jsonl")
         t = 3000
         nudge_text = ("Status on the goal above: what's done, what's left, and is anything blocked?"
-                      "<!-- romp-injected --><!-- romp-auto --><!-- romp-goal-id: %s -->" % GID)
+                      "<!-- romp-injected --><!-- romp-auto --><!-- romp-goal-id: %s -->" % gid)
         recs = []
         parent = None
         if declared_todo:
@@ -157,6 +158,50 @@ class NudgeNoReopenCompleted(unittest.TestCase):
         self.assertTrue(store["nodes"][GID].get("nodeComplete"))
         self.assertFalse(store["nodes"][GID].get("blocked"))
         self.assertEqual(self._plan_calls, [], "still moot without open agent to-dos")
+
+    def test_a_working_top_whose_steps_are_all_done_still_gets_its_reply_judged(self):
+        # The top's steps are ALL done but the top itself carries no verdict: rollup's is_complete reads it
+        # WORKING (verdicts only, the user 2026-07-15), so the auto-nudge fires legitimately and the agent
+        # answers with a blocker. The moot-guard read the top through _subtree_done, the bottom-up rule rollup
+        # retired, so it took the top as done, discarded the reply (nothing placed, the planner never consulted)
+        # and left the top unblocked — after which the kernel's follow-up-failed path files a procedural block
+        # with no brief. Done, for the guard, is the target's OWN nodeComplete (or its sticky settle).
+        # A PRIVATE synthetic sid (CLAUDE.md, goal-store fixtures): the store is minted here, and another
+        # module's journaled override against the shared placeholder must not land on this g1. The journal lives
+        # under the per-test state root setUp rebinds, so it dies with that root.
+        psid = "7a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d"
+        gid, s2, s3 = psid + ":g1", psid + ":g2", psid + ":g3"
+        store = {"rompUuid": psid, "seq": 1, "placementsV": jd.PLACEMENTS_V,
+                 "nodes": {gid: {"id": gid, "text": "Ship the schema change", "parentId": None,
+                                 "nodeComplete": False, "blocked": False, "cleared": False,
+                                 "trail": [], "t": 1000, "mt": 2000},
+                           s2: {"id": s2, "text": "write the migration", "parentId": gid,
+                                "nodeComplete": True, "blocked": False, "cleared": False,
+                                "trail": [], "t": 1200, "mt": 1300},
+                           s3: {"id": s3, "text": "run it on the staging copy", "parentId": gid,
+                                "nodeComplete": True, "blocked": False, "cleared": False,
+                                "trail": [], "t": 1400, "mt": 1500}},
+                 "placements": {}, "status": {gid: "working"}, "lastNode": gid}
+        jd.rollup_status(store, False)
+        self.assertEqual(store["status"][gid], "working", "premise: the board shows the verdict-less top WORKING")
+        jd.save_goals(psid, store)
+        captured = {}
+
+        def fake_plan(text, menu_text, **k):
+            captured.update(k); captured["menu"] = menu_text
+            return '{"ops":[{"do":"block","goal":1,"why":"approve the schema change"}]}'
+        jd.plan_llm = fake_plan
+        path = self._nudge_transcript(sid=psid, gid=gid)
+        jd._plan_session(psid, path, time.time())
+        store = jd.load_goals(psid)
+        self.assertIn("menu", captured, "the planner IS consulted: the top has no verdict of its own")
+        self.assertIn("Ship the schema change", captured["menu"], "…over the menu the top leads")
+        self.assertTrue(store["nodes"][gid]["blocked"], "the reply's blocker lands on the top")
+        self.assertEqual(store["nodes"][gid]["blockWhy"], "approve the schema change")
+        self.assertTrue(store["nodes"][s2]["nodeComplete"] and store["nodes"][s3]["nodeComplete"],
+                        "the genuinely-done steps keep their verdicts across the reopen")
+        jd.rollup_status(store, False)
+        self.assertEqual(store["status"][gid], "blocked", "…and the top rolls up blocked/needs-you")
 
     def test_open_menu_seal_respects_a_user_clear_over_the_agent_list(self):
         # the user's cross-off outranks the agent's to-do list: a CLEARED umbrella seals its subtree even


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main`: when a session answered the automatic follow-up on a card that was still Working, the planner decided whether that answer was moot with a helper that treats a parent as done when all of its children are done. That bottom-up rule was retired from the board's own completion logic weeks ago, which now completes a card only on its own verdict, so the two disagreed. A card the board showed as Working, with every step complete but no verdict of its own, read as done to this guard: the agent's reply, "blocked on you: approve the schema change", was discarded without the planner ever seeing it, and the kernel then filed the procedural "followed up once and the response didn't resolve this" block with no brief. A false needs-you on a card whose agent had just answered, and the follow-up itself was legitimate, since the fire path reads the board's completion truth.

## What changes
The guard reads the card's own completion flag, the same flag the board's completion logic and the closer read. The settled-card arm stays. The retired helper is untouched, because the group-level closer still uses it and a test pins that.

## Deliberately left out
The board's umbrella carve-out, which completes a container when all its children complete, is not mirrored: the old helper applied the retired rule to grandchildren too, so it was no exact mirror either, and a completed container never fires a follow-up; only the window between firing and reply is affected, where the reply is now judged rather than dropped. The guard also does not read the rolled-up status export, because the export can lag a verdict applied moments earlier within one pass, while the card's own flag is live.

## Tests
One new case in the existing module under a private synthetic session id: a Working top with no verdict of its own and two completed steps, a reply to the follow-up, and a fake planner returning a block. It asserts the planner was consulted with the top in its menu and the top is blocked with the reply's reason. On `main` the planner is never called and the assertion reads `'menu' not found in {}`. The module passes 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
