### PR TITLE
release.sh: the tag goes on main only; a re-run after an unmerged version PR refuses instead of tagging the release branch

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -141,6 +141,18 @@ say "releasing $tag (VERSION currently reads $current)."
 
 # ── 2. the tree must be releasable ────────────────────────────────────
 [ -z "$(git status --porcelain)" ] || die "working tree is dirty — commit or stash first."
+# And checked out on $REF: the tag goes on whatever HEAD is, bootstrap.sh installs the newest
+# v* tag, so a tag cut anywhere else ships a commit that is not on $REF. The way to be here
+# off $REF is a bump run that died with its version PR unmerged — the PR could not be opened,
+# or the wait for it ran out — still on release-X.Y.Z, where VERSION already reads the target,
+# so the advertised re-run would skip the bump and tag that branch. Checked once, here: the
+# bump path below either ends back on $REF or dies, so it still holds at the tag step, and
+# refusing now spends no suite run and no macOS wait on a release that cannot be cut. A detached
+# HEAD is named as such: `symbolic-ref` prints nothing for it (and exits 1, hence `|| true`
+# under set -e), where `rev-parse --abbrev-ref` would have blamed a branch called HEAD.
+on_branch="$(git symbolic-ref -q --short HEAD || true)"
+[ -n "$on_branch" ] || die "detached HEAD, not on $REF — a release is cut from $REF only; switch to it and pull first."
+[ "$on_branch" = "$REF" ] || die "on branch $on_branch, not $REF — the version PR may still be open; switch to $REF and pull once it lands."
 
 # ── 3. land the version bump, if there is one ─────────────────────────
 # Skipped entirely when VERSION already carries the target, which is the normal case when a
@@ -155,8 +167,10 @@ if [ "$current" != "$target" ]; then
     if [ "$dry_run" -eq 1 ]; then
         say "[dry-run] would branch, commit VERSION=$target, open a PR, and auto-merge it."
     else
-        printf '%s\n' "$target" > VERSION
+        # Branch FIRST, then write: a branch that already exists dies here, and main is left as it
+        # was rather than holding a modified VERSION nobody asked for.
         git switch -c "$branch" >/dev/null 2>&1 || die "could not create branch $branch."
+        printf '%s\n' "$target" > VERSION
         git add VERSION
         git commit -qm "VERSION $target" || die "nothing to commit for the version bump."
         git push -q -u "$publish" "$branch" || die "could not push $branch to $publish."
@@ -198,7 +212,9 @@ if [ "$current" != "$target" ]; then
             if [ "$POLL" = "0" ]; then break; fi
             sleep "$POLL"
         done
-        [ "$state" = "MERGED" ] || die "the version PR did not merge — check $UPSTREAM."
+        # Still on the release branch here, so the way forward is spelled out: local $REF is behind
+        # the merge until it is pulled, and a re-run on this branch is refused (step 2).
+        [ "$state" = "MERGED" ] || die "the version PR did not merge — check $UPSTREAM; once it lands, switch to $REF and pull, then re-run."
         git switch "$REF" >/dev/null 2>&1 || die "could not switch back to $REF."
         # The merge landed on the CANONICAL repo. With a fork layout that is `upstream`, not
         # `origin`: reading `origin/main` there would fast-forward onto the fork's stale main

--- a/tests/release-sh.bats
+++ b/tests/release-sh.bats
@@ -174,6 +174,8 @@ STUB
     STUB_PR_STATE=OPEN run "$REPO/scripts/release.sh" minor --skip-tests
     [ "$status" -ne 0 ]
     [[ "$output" == *"did not merge"* ]]
+    # it dies on the release branch, so it says how to converge: local main is behind the merge
+    [[ "$output" == *"switch to main and pull"* ]]
     run git -C "$REPO" tag -l
     [ -z "$output" ]
 }
@@ -183,6 +185,54 @@ STUB
     STUB_PR_STATE=CLOSED run "$REPO/scripts/release.sh" minor --skip-tests
     [ "$status" -ne 0 ]
     [[ "$output" == *"closed without merging"* ]]
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
+}
+
+@test "release: a re-run while the version PR is still open refuses — it never tags the release branch" {
+    # A bump run whose PR has not landed when the wait runs out dies still checked out on the
+    # release branch, where VERSION already reads the target. The script advertises re-running to
+    # resume; unchecked, that re-run saw VERSION at the target, skipped the bump, and tagged HEAD —
+    # the release branch — then pushed the tag, so bootstrap.sh installed a commit that is not on
+    # main while main's VERSION lagged. The re-run must refuse, by name, and before spending CI.
+    _stub_gh
+    STUB_PR_STATE=OPEN run "$REPO/scripts/release.sh" minor --skip-tests
+    [ "$status" -ne 0 ]
+    [ "$(git -C "$REPO" rev-parse --abbrev-ref HEAD)" = "release-0.2.0" ]
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"on branch release-0.2.0, not main"* ]]
+    [[ "$output" == *"switch to main and pull"* ]]     # the same way forward as the run that left it here
+    run git -C "$REPO" tag -l
+    [ -z "$output" ]
+    run git -C "$TEST_DIR/origin.git" tag -l
+    [ -z "$output" ]
+    run grep -q "workflow run" "$GH_LOG"      # refused before any CI was dispatched
+    [ "$status" -ne 0 ]
+}
+
+@test "release: a release branch that already exists refuses before VERSION is touched — main stays clean" {
+    # The bump used to write VERSION first and branch second, so a branch that already existed
+    # died with a modified VERSION sitting on main, which then failed the next run's dirty-tree
+    # check for no reason the user had caused.
+    _stub_gh
+    git -C "$REPO" branch release-0.2.0
+    run "$REPO/scripts/release.sh" minor --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not create branch release-0.2.0"* ]]
+    [ "$(git -C "$REPO" rev-parse --abbrev-ref HEAD)" = "main" ]
+    [ -z "$(git -C "$REPO" status --porcelain)" ]
+    [ "$(cat "$REPO/VERSION")" = "0.1.0" ]
+}
+
+@test "release: a detached HEAD refuses by that name — there is no branch to blame" {
+    # `git rev-parse --abbrev-ref HEAD` prints the word HEAD when detached, which would have made the
+    # refusal name a branch that cannot exist and offer the open-PR diagnosis that does not fit.
+    _stub_gh
+    git -C "$REPO" switch -q --detach main
+    run "$REPO/scripts/release.sh" --skip-tests
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"detached HEAD, not on main"* ]]
     run git -C "$REPO" tag -l
     [ -z "$output" ]
 }


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main` and reproduced in a throwaway repository against the script itself: when a version bump's pull request did not merge, the release script died while the checkout was still on the release branch, because the switch back to main ran only on the merged path. The advertised re-run then found the version file already at the target, skipped the bump, tagged whatever was checked out and pushed the tag. That put a release tag on a commit not on main, which the bootstrap installer then installs, while main's version lagged. Every bump run on today's upstream ends in that state: the label the script asks for no longer exists, so the PR fails to open before any wait, or the tier check holds a version PR and the wait runs out. The script also wrote the version file before creating the release branch, so a failed branch creation left a modified file on main.

## What changes
Beside the existing dirty-tree checks, the script now requires the checkout to be on the canonical branch before it does anything, including under a dry run. On another branch it refuses and names that branch, with the way forward: switch to main and pull once the version PR lands. A detached checkout is refused by that name, since there is no branch to blame. The "did not merge" refusal gained the same way forward, so the two refusals an operator meets in that flow agree. The release branch is created before the version file is written, so a failed creation leaves main clean. The stricter comparison against a freshly fetched canonical head was deliberately not added, because existing tests pin the offline shape.

## Deliberately left out
The test harness's stub for `gh` uses an unquoted heredoc with a backticked command in a comment, so every case runs the real `gh` once; harmless today, and its own change.

## Tests
Three new cases with the existing stub: a first run whose PR stays open leaves the repository on the release branch, and a bare re-run refuses, names the branch, creates no tag and dispatches no CI; a release branch that already exists refuses before the version file is touched and main stays clean; a detached checkout refuses by that name. The never-merges case now also checks the way forward. On `main` four assertions fail: the re-run exits 0, the pre-existing branch leaves a modified version file, the detached run is not refused, and the old refusal lacks the way forward. The module passes 32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
