### PR TITLE
API health across every connected kernel: one dot in the spend readout, a plain-words reading, a graph (T301)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -807,17 +807,20 @@ separating your sessions from the judge pipeline. You can also reconfigure the
 judges from the gear: the high-volume indexing tier defaults to Haiku, and the
 judgment tier defaults to Sonnet.
 
-The bottom bar's **API** cell, a dot and a word, shows how the API is treating
-your sessions. Gray **ok** means no session is waiting on the API. Amber shows
-how many sessions are waiting and names the problem: **rate limited**,
-**overloaded**, **offline** (this machine cannot reach the API), or **errors**.
-Red **paused** means auto-retry and the judges are stopped, and says why: a
-usage limit, the monthly spend cap, or that you stopped them. Hover for the same
-reading with the waiting sessions listed, and the history under it: the API's
-state over the last 1, 5 and 15 minutes (attempts, the 429 and 5xx shares,
-give-ups, sessions that retried) and the most recent state changes with how long
-each held. A kernel restart shows as its own line there, because the counts
-start over with the kernel. Click the cell, or press Enter on it,
-for the detail: each waiting session (click one to open that session), a button
-that stops auto-retry for every session while sessions are waiting and resumes
-it while paused, and links to the usage figures and the Log.
+The bottom bar's API readout carries one small dot, right after its **API**
+label, that shows how the API is treating your sessions on
+every connected kernel. Blue (the romp accent) means everything is fine. Red means errors are
+being met somewhere: a 429 rate-limit storm, 5xx failures, a machine that
+cannot reach the API, or auto-retry paused (a usage limit, the monthly spend
+cap, or you stopped it). Gray means the API is not being used right now: no
+traffic in the last 15 minutes on any machine. Hover for the reading in plain
+words (for example, 4 requests in the last 15 minutes, all succeeded), one
+line per machine when several are connected, the waiting sessions listed, and
+the history under it: a graph of attempts per minute over the last 15 minutes
+with rate-limited attempts in red and server errors in orange, one sentence
+explaining the codes, and the most recent state changes with how long each
+held. A kernel restart shows as its own line there, because the counts start
+over with the kernel. Click the dot, or press Enter on it, for the detail:
+each waiting session (click one to open that session), a button that stops
+auto-retry for every session while sessions are waiting and resumes it while
+paused, and links to the usage figures and the Log.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -809,11 +809,14 @@ judgment tier defaults to Sonnet.
 
 The bottom bar's API readout carries one small dot, right after its **API**
 label, that shows how the API is treating your sessions on
-every connected kernel. Blue (the romp accent) means everything is fine. Red means errors are
-being met somewhere: a 429 rate-limit storm, 5xx failures, a machine that
-cannot reach the API, or auto-retry paused (a usage limit, the monthly spend
-cap, or you stopped it). Gray means the API is not being used right now: no
-traffic in the last 15 minutes on any machine. Hover for the reading in plain
+every connected kernel. The accent colour (blue in the dark theme, clay in the
+light one) means everything is fine. Red means errors are being met somewhere:
+a 429 rate-limit storm, 5xx failures, a machine that cannot reach the API, or
+auto-retry paused (a usage limit, the monthly spend cap, or you stopped it), and
+it stays red while a failed attempt sits in the last 15 minutes anywhere. Gray
+means the API is not being used right now: no traffic in the last 15 minutes on
+any machine. A machine whose link is down is named in the popup with what it
+last said and does not colour the dot. Hover for the reading in plain
 words (for example, 4 requests in the last 15 minutes, all succeeded), one
 line per machine when several are connected, the waiting sessions listed, and
 the history under it: a graph of attempts per minute over the last 15 minutes

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1750,11 +1750,22 @@ orange, and one sentence explains the codes.
 The signal covers every connected kernel, not only the one serving the page.
 Each kernel serves its own last shell frame at `GET /api-health/frame` (its
 local half only, never its view of its peers), and the tunnel supervisor polls
-every attached host's frame (every 10 seconds, kept on a blip, cleared when the
-host answers that it has none) and carries them in the shell frame under
-`hosts`, a map keyed by host name with each machine's `state`, class, headline,
-waiting count, since, pause reason and a `stale` mark when that tunnel is not
-up. The hover's history reads each attached host's document through `GET
+every attached host's frame (once per supervisor pass, about every 15 s; kept on
+a blip; kept and marked with a `fault` when the read is refused, a 403 from a
+rotated token or a 500; cleared when the host answers that it has none) and
+carries them in the shell frame under `hosts`, a map keyed by host name with
+each machine's `state`, class, headline, waiting count, since, pause reason,
+its `quiet` and `errs` flags when that kernel sends them, and a `stale` mark
+when that tunnel is not up or the read was refused (the frame's own `type`,
+`sessions` and `seq` stay on their kernel). The frame's `quiet` says that
+kernel saw no API event in its longest window and `errs` counts the attempts
+that failed in it; both come from the aggregator every cycle, so the frame
+changes, and is pushed, the moment the last failure ages out. The dot follows
+the frames alone: red when any reachable machine's frame is degraded, paused or
+holds a failed attempt (`errs`), gray when every reachable machine's frame says
+quiet, the accent otherwise; a machine whose tunnel is down or whose frame
+could not be read is named in the popup and has no say. The hover's history
+reads each attached host's document through `GET
 /remote/<host>/api-health`, a read relay beside the `/ws` and `/file` relays:
 the local token gates it, the remote's own token goes in the forwarded request,
 its document passes through as answered (404 for an unknown host, 502 when the
@@ -1891,12 +1902,12 @@ again to a shell that sends `ready`:
 {"type": "apiHealth", "state": "ok | degraded | paused",
  "cls": "429 | 529 | offline | errors | ''", "reason": "'' | limit | spend | manual",
  "text": "<the rail's words>", "waiting": 0, "retrying": 0, "blocked": 0,
- "since": 0, "tmux": 0, "seq": 0, "quiet": false,
+ "since": 0, "tmux": 0, "seq": 0, "quiet": false, "errs": 0,
  "sessions": [{"sid": "", "name": "", "color": null, "kind": "retrying | blocked",
                "cls": "", "status": null, "since": 0, "suppressed": false}],
  "hosts": {"<host>": {"state": "ok | degraded | paused", "cls": "", "text": "", "waiting": 0,
                       "retrying": 0, "blocked": 0, "since": 0, "reason": "", "tmux": 0, "quiet": false,
-                      "stale": false}}}
+                      "errs": 0, "stale": false, "fault": "HTTP 403 (only when the last read was refused)"}}}
 ```
 
 `seq` counts the retry-pause file's writes since the kernel started. A press

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1724,6 +1724,43 @@ own model and are exact.
   (the counter it landed in); `kind` (`retry` or `gaveup`). There is no text
   field, by design: the wire carries none today, and the transcript's 429 text
   names the organisation and the model.
+- `series`: attempts per minute over the longest window, for a graph: `binS`
+  (60), `from` (the start of the first bin; the last bin ends at `asOf`), and
+  five arrays of one integer per bin, oldest first: `ok`, `rateLimited` (429),
+  `serverErrors` (529 and other 5xx, the `rate5xx` numerator), `noStatus`
+  (connection-level failures) and `other`. Additive: the field arrived after
+  the document's other fields and `schema` stayed `1`; a reader that ignores it
+  sees the document it always saw.
+
+### On the dashboard
+
+The shell's rail carries one dot for the signal, placed after the `API` label
+of the spend readout: the accent colour when every connected kernel is fine,
+red when errors are being met anywhere (a 429 storm, 5xx failures, a machine
+offline, auto-retry paused), and the label gray when no kernel has API traffic
+in the windows. The hover and the pinned detail read the document in plain
+words rather than the state machine's vocabulary: traffic with no errors reads
+as what happened ("4 requests in the last 15 min, all succeeded"), with "too
+few requests to call a trend" as a sub-line while the machine still says
+`unknown`; errors read as the failures counted; no traffic reads as quiet. The
+word `unknown` stays in the document and appears nowhere on the dashboard. The
+graph is attempts per minute from `series`, 429 attempts in red and 5xx in
+orange, and one sentence explains the codes.
+
+The signal covers every connected kernel, not only the one serving the page.
+Each kernel serves its own last shell frame at `GET /api-health/frame` (its
+local half only, never its view of its peers), and the tunnel supervisor polls
+every attached host's frame (every 10 seconds, kept on a blip, cleared when the
+host answers that it has none) and carries them in the shell frame under
+`hosts`, a map keyed by host name with each machine's `state`, class, headline,
+waiting count, since, pause reason and a `stale` mark when that tunnel is not
+up. The hover's history reads each attached host's document through `GET
+/remote/<host>/api-health`, a read relay beside the `/ws` and `/file` relays:
+the local token gates it, the remote's own token goes in the forwarded request,
+its document passes through as answered (404 for an unknown host, 502 when the
+tunnel is down). The merge happens in the browser and follows the federation
+rule: per-host maps in, one line per machine out, the worst state wins for the
+dot, and no count or clock is ever added to or compared with another kernel's.
 
 ### Derived state
 
@@ -1819,9 +1856,10 @@ logged, and never keeps the SDK backend from starting.
 
 ### The bottom bar's indicator
 
-The dashboard's bottom bar carries an API cell (a dot and a word beside the
-usage readout) that is computed independently of this signal, from two things
-the kernel owns directly:
+The dashboard's bottom bar carries an API cell (one small dot, placed inside
+the spend readout right after its `API` label; see "On the dashboard" above
+for its colours and its reading) whose frame is computed independently of this
+signal, from two things the kernel owns directly:
 
 - Each alive session's newest transcript API-error record, latched until the
   session produces assistant output again (a user prompt does not clear it,
@@ -1853,9 +1891,12 @@ again to a shell that sends `ready`:
 {"type": "apiHealth", "state": "ok | degraded | paused",
  "cls": "429 | 529 | offline | errors | ''", "reason": "'' | limit | spend | manual",
  "text": "<the rail's words>", "waiting": 0, "retrying": 0, "blocked": 0,
- "since": 0, "tmux": 0, "seq": 0,
+ "since": 0, "tmux": 0, "seq": 0, "quiet": false,
  "sessions": [{"sid": "", "name": "", "color": null, "kind": "retrying | blocked",
-               "cls": "", "status": null, "since": 0, "suppressed": false}]}
+               "cls": "", "status": null, "since": 0, "suppressed": false}],
+ "hosts": {"<host>": {"state": "ok | degraded | paused", "cls": "", "text": "", "waiting": 0,
+                      "retrying": 0, "blocked": 0, "since": 0, "reason": "", "tmux": 0, "quiet": false,
+                      "stale": false}}}
 ```
 
 `seq` counts the retry-pause file's writes since the kernel started. A press
@@ -1871,33 +1912,45 @@ session's event (a record's timestamp, or the retrying turn's start), else 0.
 transcripts only. Every timestamp is an event's time, never the clock, so an
 unchanged world sends nothing. On-you failures (a too-long prompt, a spent
 model allowance, a dead credential, a refusal) are not counted; a spend cap is,
-and engages the `spend` pause in the same cycle.
+and engages the `spend` pause in the same cycle. `quiet` is true when this
+kernel's API-health aggregator saw no event in its longest window (or the
+kernel has no SDK backend), the fact behind the dot's gray before any history
+is read. `hosts` is every attached
+machine's own frame as the tunnel supervisor last heard it (the fields above
+minus `sessions` and `seq`, which stay on their kernel), keyed by host name,
+with `stale` true while that tunnel is not up; a kernel with no attached
+machines sends an empty map, and a kernel serving `GET /api-health/frame` to
+a peer sends its own frame without this map, so two kernels attached to each
+other never nest each other's view.
 
 The cell's hover and its click detail carry a **History** section read from
-this signal: the shell fetches `GET /api-health` when the hover or the detail
-opens, and again when a frame lands on an open one, authenticating with the
-dashboard's own cookie the way its other reads do. Nothing polls; the frame
-carries no history and is unchanged. The section shows `overall.state` with
-the worst bucket's `stateSince` and `why` (naming the bucket and the bucket
-count when there is more than one; a bucket the boot seeded is `unknown`
-since `bootAt`: the boot time or, when an older kernel's last row overlaps
-it, one millisecond past that row, because the backend seeds its `stateSince`
-with the stamp it serves as `bootAt`, the one the tail uses for the boot),
-one row per window from `config.windows` (`requests` plus `noStatus` as the
-attempts, saying how many of them had no status when there are any, `rate429`
-and `rate5xx` as percentages over the attempts with a status, `gaveUp`, and
-`sessionsRetrying` as the sessions that retried in the window; a window
-reads `no attempts` only when every one of those is zero; a window whose
-`complete` is false says how long the kernel has been up), up to six rows
-of `transitions` newest first with the state entered and how long it held
-(until the same bucket's next transition, `so far` for the current one; a
-hold from before `bootAt` ends at the boot, since every bucket comes back
-`unknown` at a restart), and the payload's `asOf`. A row the boot filed
+this signal: the shell fetches `GET /api-health` for this machine and `GET
+/remote/<host>/api-health` for every host in the frame's `hosts` when the
+hover or the detail opens, and again when a frame lands on an open one,
+authenticating with the dashboard's own cookie the way its other reads do.
+Nothing polls; the frame carries no history and is unchanged. Each machine's
+document is read in the plain words of "On the dashboard" above: over the
+longest window of `config.windows`, `requests` plus `noStatus` are the
+attempts, `rateLimited`, `serverErrors` (with `overloaded`), `otherErrors`
+and `noStatus` the failures, and `gaveUp` the turns that gave up; traffic with
+no failures reads as the successes counted, failures read counted in the
+machine's phrase (`thrashing` as a rate-limit storm, `degraded` as the API
+failing), and no attempts read as quiet; the state machine's word itself is
+never shown. Under each machine's reading sits the graph from `series`, then
+one legend sentence for the codes, and this machine's State changes: up to
+four rows of `transitions` newest first with the state entered in plain words
+(`rate-limit storm`, `API failing`, `recovering`, `fine`, `quiet`) and how
+long it held (until the same bucket's next transition, `so far` for the
+current one; a hold from before `bootAt` ends at the boot, since every bucket
+comes back `unknown` at a restart; a bucket the boot seeded is `unknown` since
+`bootAt`: the boot time or, when an older kernel's last row overlaps it, one
+millisecond past that row, because the backend seeds its `stateSince` with the
+stamp it serves as `bootAt`), and the payload's `asOf`. A row the boot filed
 (`<state> -> unknown`, its `why` the restart reason) reads `kernel
 restarted`; where the tail crosses `bootAt` without such a row (the bucket
 was already `unknown` when the previous kernel stopped, so the boot filed
 nothing), a `kernel restarted` divider is inserted, and it takes none of the
-six slots. A read that fails (a non-2xx, no answer, or an answer without
+four slots. A read that fails (a non-2xx, no answer, or an answer without
 the signal's shape) shows one line saying so in place of the rows,
 never the previous numbers.
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19606,6 +19606,36 @@ def _poll_remote_usage(r):
         return r.get("usage")   # keep the last good reading rather than blanking the bars on one blip
 
 
+REMOTE_APIH_EVERY = 10.0    # the API-health frame: a storm shows within a few passes; the frame is a few hundred bytes
+
+
+def _poll_remote_api_health(r):
+    """GET a remote kernel's /api-health/frame THROUGH the -L tunnel: that machine's own apiHealth shell frame
+    (its local half only, never its view of ITS peers), so this kernel's shell frame can carry every attached
+    machine's state as a per-host map (T301, the user 2026-09-10: the signal must cover every connected kernel,
+    not this one alone). Returns the parsed frame, {} when the host answered that it has none yet (an older
+    build's 404 too: the row is then cleared rather than kept stale), or None when nothing answered (keep the
+    last reading, as the usage poll does). Rate-limited to REMOTE_APIH_EVERY per host."""
+    import urllib.parse
+    now = time.time()
+    if now - float(r.get("_apih_at") or 0) < REMOTE_APIH_EVERY:
+        return r.get("apiHealth")
+    try:
+        c = http.client.HTTPConnection("127.0.0.1", int(r["local_port"]), timeout=5)
+        path = "/api-health/frame" + (("?token=" + urllib.parse.quote(r["token"])) if r.get("token") else "")
+        c.request("GET", path)
+        resp = c.getresponse()
+        data = resp.read()
+        c.close()
+        r["_apih_at"] = now
+        if resp.status != 200:
+            return {}                                   # no frame there (not yet, or an older kernel): clear
+        u = json.loads(data.decode("utf-8"))
+        return u if isinstance(u, dict) and u.get("state") else {}
+    except Exception:
+        return r.get("apiHealth")                       # a blip keeps the last good reading
+
+
 def _poll_remote_views(r):
     """GET a remote kernel's /views THROUGH the -L tunnel — the read half of tag federation v0 (the
     user 2026-08-24): each attached kernel's own tags ride to this viewer read-only, and
@@ -22377,6 +22407,7 @@ def _tunnel_supervisor():
                 # a different one (self-rate-limited to a minute — these windows are hours wide)
                 ruse = _poll_remote_usage(r) if up else None
                 rviews = _poll_remote_views(r) if up else None   # tag federation v0: the read half
+                rapih = _poll_remote_api_health(r) if up else None   # its API-health frame, for the shell's per-host map (T301)
                 with _remotes_lock:
                     if r["host"] not in _remotes:
                         continue
@@ -22481,6 +22512,12 @@ def _tunnel_supervisor():
                             r["usage"] = ruse
                         else:
                             r.pop("usage", None)
+                    if rapih is not None:
+                        # the same contract as usage: {} = answered with no frame → clear; None = no answer → keep
+                        if rapih:
+                            r["apiHealth"] = rapih
+                        else:
+                            r.pop("apiHealth", None)
                     _cache_remote_views(r, rviews)     # a CHANGED reading wakes the pusher: the tags reach the pane by its frame
                     auto_check = (st == "up")
                     peer_up = (st == "up")
@@ -43751,7 +43788,56 @@ def _api_health_frame(now, tmux):
             # the pause file's write count (_RETRY_PAUSE_SEQ): a press on the detail's pause button writes it,
             # so the frame after the press differs from every frame before it even when the auto-pause put
             # the same state back within the same second; the shell clears its acknowledgment on that
-            "seq": _RETRY_PAUSE_SEQ[0]}
+            "seq": _RETRY_PAUSE_SEQ[0],
+            # no API traffic in the longest window (T301): the dot reads gray on this alone, before any history is read;
+            # True with no SDK backend (nothing can have talked to the API through this kernel)
+            "quiet": _apih_quiet(now),
+            # every attached machine's own frame, by host (T301): a per-host MAP, never a merged count or a
+            # compared clock (the federation rule: merged payloads keep local scalars and carry per-host maps);
+            # the shell merges it for the dot (worst state wins) and names each machine. `stale` marks a row
+            # whose tunnel is not up: the frame is the last one heard, and the shell says so
+            "hosts": _api_health_hosts()}
+
+
+_APIH_HOST_KEYS = ("state", "cls", "text", "waiting", "retrying", "blocked", "since", "reason", "tmux", "quiet")
+
+
+def _apih_quiet(now):
+    """Whether this kernel's API-health aggregator saw no event in the longest window (T301): the frame's `quiet`."""
+    try:
+        be = _sdk()
+        ah = getattr(be, "api_health", None) if be else None
+        return True if ah is None else bool(ah.quiet(now))
+    except Exception:
+        return True
+
+
+def _api_health_hosts():
+    """{host: {state, cls, text, waiting, retrying, blocked, since, reason, tmux, stale}} for every attached
+    machine whose frame the tunnel supervisor has cached (_poll_remote_api_health). Deterministic for an
+    unchanged world (no clock), so an identical fleet still yields an identical frame and no push."""
+    out = {}
+    with _remotes_lock:
+        rows = [(r["host"], dict(r.get("apiHealth") or {}), r.get("status")) for r in _remotes.values()
+                if isinstance(r.get("apiHealth"), dict) and r.get("apiHealth")]
+    for host, f, st in rows:
+        row = {k: f.get(k) for k in _APIH_HOST_KEYS if k in f}
+        row["stale"] = st != "up"
+        out[host] = row
+    return out
+
+
+def _apih_local_frame():
+    """The last frame this kernel pushed, minus its `hosts` map: what GET /api-health/frame serves a PEER, so
+    two kernels attached to each other never nest each other's maps (the peer builds its own from this)."""
+    if _APIH_LAST[0] is None:
+        return None
+    try:
+        f = dict(json.loads(_APIH_LAST[0]))
+    except Exception:
+        return None
+    f.pop("hosts", None)
+    return f
 
 
 # The last apiHealth frame the shells heard, as its sorted serialization (None = nothing since boot): the
@@ -46708,7 +46794,7 @@ var seg=function(k,lbl,cav){return '<div class=ru-name>'+lbl+(cav?' \u26a0':'')+
 +'<div class=ru-pct>'+fmtUsd(sum[k].usd)+' \u00b7 '+fmtTok(sum[k].tok)+' tok</div>';};
 var monthCav=legacyN>0;   // some machine's calendar month was left out of this rolling segment (T235b)
 return '<div class="ru-w ru-api">'
-+'<div class=ru-name>API</div>'
++'<div class=ru-name>API</div><span class=ah-slot></span>'   // the API-health dot's place (T301): the stable #rail-api moves in
 +seg('day','1 day')+seg('month','1 month',monthCav)
 +'</div>';}
 // The collapsed rail is the AGGREGATE story (the user 2026-08-08; supersedes the one-set-per-account
@@ -46734,7 +46820,11 @@ for(k in u)v[k]=u[k];
 ['fiveHour','sevenDay','fable','t','limited','acctLabel'].forEach(function(w){
 if(b[w]!==undefined)v[w]=b[w];else delete v[w];});
 r.usage=v;});});}
-function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];
+var RAIL_HOME=(function(){var c=document.getElementById('rail-api');return c?c.parentNode:null;})();   // where the dot lives with no readout
+// the API-health dot may sit INSIDE this cell (in the readout's slot); every innerHTML write below would destroy it
+// with the readout, so it is parked back at its own place first and moved into the fresh slot after (T301)
+function parkApiCell(){var c=document.getElementById('rail-api');if(c&&el.contains(c)&&RAIL_HOME)RAIL_HOME.insertBefore(c,el.nextSibling);}
+function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];parkApiCell();
 var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
 shareFreshest(live);
@@ -46742,6 +46832,10 @@ LAST=live.map(function(r){var det={};det._t=(typeof r.usage.t==='number')?r.usag
 winDet(r.usage,det);spendDet(r.usage,det);
 return {host:r.host||selfHost||'this machine',det:det};});
 el.innerHTML=aggBarsHTML(LAST)+apiCellHTML(LAST);
+// the API-health dot rides the readout (T301): the STABLE #rail-api node moves into the readout's slot, and back to
+// its own place in the rail when no readout renders; a move keeps its listeners, an innerHTML copy would not
+(function(){var cell=document.getElementById('rail-api');if(!cell)return;var slot=el.querySelector('.ah-slot');
+if(slot){slot.appendChild(cell);}else if(cell.parentNode!==RAIL_HOME&&RAIL_HOME){RAIL_HOME.insertBefore(cell,el.nextSibling);}})();
 // a HOVER tip already open re-renders in place when fresh data lands (the 60s pull, the timeline's
 // live forward) — the user 2026-08-14, replacing the footer's click-me hint with the refresh itself.
 // Re-anchor the top edge after the swap: new content can change the tip's height, and it hangs ABOVE
@@ -46938,7 +47032,9 @@ var bs=document.getElementById('ru-bysession');if(bs)bs.onclick=function(e){e.st
 window.__rompUsageClose=off;
 back.onclick=off;}
 pullFleet().then(openIt,openIt);};
-el.addEventListener('mouseenter',showTip);
+// the API-health dot sits inside this cell (T301): a pointer arriving on the DOT gets the dot's own tip, not this one
+el.addEventListener('mouseenter',function(ev){var c=document.getElementById('rail-api');
+if(c&&ev&&typeof ev.clientX==='number'){var at=document.elementFromPoint(ev.clientX,ev.clientY);if(at&&(at===c||c.contains(at)))return;}showTip(ev);});
 el.addEventListener('mouseleave',function(){tip.style.display='none';});
 // Refresh-from-source (the user 2026-06-30): GET /usage re-reads usage.json — the snapshot Claude Code's
 // statusline (tmux) OR the SDK backend's RateLimitEvent capture writes — and re-renders. `pull(ack)` is the
@@ -47293,7 +47389,13 @@ window.addEventListener('message',function(e){var m=e.data;if(m&&m.romp==='usage
 # token) and the phone's Usage-modal section (no rail on the phone) are named follow-ups.
 _LANDING_APIH_JS = """
 (function(){var el=document.getElementById('rail-api');if(!el)return;
-var txt=el.querySelector('.ah-text');
+// the merge and reading rules (ui/webview/api-health-merge.ts via api-health-global.ts); absent (a stale dist), the
+// local frame alone paints the dot and the popup says so in the kernel's own words
+var MERGE=window.__rompApiHealthMerge||null;
+var READINGS={};   // per host: the history reading (readHistory), null until read; the frame merge takes it
+var DOTWORD={fine:'fine',errors:'errors',quiet:'no traffic'};
+var LEGEND='429 = the API told us to slow down (rate limit) \u00b7 5xx = the API itself failed (server error) \u00b7 offline = no connection';
+var STATE_WORD={thrashing:'rate-limit storm',degraded:'API failing',recovering:'recovering',healthy:'fine',unknown:'quiet'};
 var tip=document.createElement('div');tip.id='ah-tip';tip.style.display='none';
 tip.setAttribute('role','tooltip');tip.setAttribute('aria-label','API health');tip.tabIndex=-1;document.body.appendChild(tip);
 // what the cell is described by while the hover shows (aria-describedby): a SHORT visually-hidden summary, refreshed
@@ -47322,7 +47424,7 @@ var LAST=null,pinned=false,held=false,dirty=false,pending=null,pendSeq=null,hint
 var HIST=null,histSeq=0,skipFocus=false,winFocusEl=null;
 window.addEventListener('focus',function(){winFocusEl=document.activeElement;requestAnimationFrame(function(){winFocusEl=null;});});
 var RESTART_WHY='kernel restarted: the event ring is empty';   // sdk_backend.API_HEALTH_RESTART_WHY: the row the boot files
-var HIST_ROWS=6;
+var HIST_ROWS=4;   // the State changes list, capped (T301: a glance, not a log)
 function esc(s){return String(s).replace(/[&<>"]/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});}
 function hm(ep){return new Date(ep*1000).toTimeString().slice(0,5);}
 function hms(ep){return new Date(ep*1000).toTimeString().slice(0,8);}
@@ -47331,13 +47433,11 @@ function hmd(ep){var d=new Date(ep*1000),n=new Date();if(d.toDateString()===n.to
 return ('0'+(d.getMonth()+1)).slice(-2)+'-'+('0'+d.getDate()).slice(-2)+' '+hm(ep);}
 function dur(s){s=Math.max(0,Math.round(s));if(s<60)return s+' s';var m=Math.round(s/60);if(m<60)return m+' min';
 var h=Math.floor(m/60);m-=h*60;if(h<24)return h+' h'+(m?' '+m+' min':'');var d=Math.floor(h/24);h-=d*24;return d+' d'+(h?' '+h+' h':'');}
-function pct(r){return (r==null?0:Math.round(r*100))+'%';}
 function pl(n,w){n=n||0;return n+' '+w+(n===1?'':'s');}
 // The plain-words pause reasons and the ok line: the kernel's `text` is the headline, these say what it means.
 var PAUSE={limit:'Auto-retry and the judges are paused until your usage limit resets.',
 spend:'Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.',
 manual:'Auto-retry and the judges are paused: you stopped them.'};
-var OK='No session is waiting on the API. Auto-retry and the judges are running.';
 var RESUME='Resume all auto-retries',STOP='Stop all auto-retries';   // the chat card's own words
 var NOTSENT='Not sent: the dashboard is disconnected. Try again.';
 var LOST='Connection lost before the answer arrived. When it is back, the button shows the current state.';
@@ -47361,12 +47461,38 @@ return '<div class="ru-tip-row ah-row'+(full?'':' ah-ro')+'"'+(full?' role=butto
 // own read is in flight. A frame on an open card re-reads behind the stamped answer the card shows, and a pin from
 // hidden behind the last hover's answer (its as-of says when it was read; the dots only before the first answer):
 // the card the user opened is not blanked for the read's duration, on purpose.
+// HIST is {host: document | {error}} with '' for this machine (T301): this kernel's /api-health and every attached
+// host's through /remote/<host>/api-health, read together; a host that fails is its own {error}, never dropped
+function fetchDoc(u){return fetch(u,{cache:'no-store'}).then(function(r){
+if(!r.ok){var tp=(typeof r.text==='function')?r.text():Promise.resolve('');
+return tp.then(function(t){return {error:'HTTP '+r.status+(t?' \u00b7 '+String(t).slice(0,120):'')};},function(){return {error:'HTTP '+r.status};});}
+return r.json().then(function(d){return (d&&d.buckets)?d:{error:'malformed answer'};},function(){return {error:'malformed answer'};});})
+.catch(function(e){return {error:String((e&&e.message)||e)};});}
+function hostsOf(m){return Object.keys((m&&m.hosts)||{}).sort();}
 function load(fresh){var n=++histSeq;if(fresh)HIST=null;
-fetch('/api-health',{cache:'no-store'}).then(function(r){if(!r.ok)throw new Error('HTTP '+r.status);return r.json();})
-.then(function(d){if(n!==histSeq)return;HIST=(d&&d.buckets)?d:{error:'malformed answer'};
-if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();},
-function(e){if(n!==histSeq)return;HIST={error:String((e&&e.message)||e)};
+var hs=hostsOf(LAST),reads=[fetchDoc('/api-health')].concat(hs.map(function(h){return fetchDoc('/remote/'+encodeURIComponent(h)+'/api-health');}));
+Promise.all(reads).then(function(docs){if(n!==histSeq)return;var by={'':docs[0]};hs.forEach(function(h,i){by[h]=docs[i+1];});HIST=by;
+READINGS=MERGE?MERGE.mergeHistories(by).readings:{};paintCell();
 if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();});}
+// the merged view of the frame: the dot and one line per machine (worst state wins; per-host maps, nothing summed)
+function merged(){if(!LAST)return {dot:'fine',worst:'',machines:[],n:1};
+if(MERGE)return MERGE.mergeFrames(LAST,LAST.hosts||{},READINGS);
+var d=LAST.state==='ok'?'fine':'errors';return {dot:d,worst:'',machines:[{host:'',dot:d,text:'this machine: '+LAST.text,stale:false}],n:1};}
+function readingOf(host){var d=HIST&&HIST[host];if(!d||d.error||!MERGE)return null;return MERGE.readHistory(d);}
+// the cell: the dot's state and its description, from the merge; the DOM is touched only on a change
+function paintCell(){var mg=merged();if(el.getAttribute('data-dot')!==mg.dot)el.setAttribute('data-dot',mg.dot);
+var lab='API health: '+DOTWORD[mg.dot]+(mg.n>1?' across '+mg.n+' machines':'');if(el.getAttribute('aria-label')!==lab)el.setAttribute('aria-label',lab);}
+// the head's words: a pause in the kernel's own words; errors as the worst machine's line; else what happened
+function headWords(m,mg){if(m.state==='paused')return m.text;
+var rd=readingOf('');
+if(mg.n>1){   // several machines: the head sums them up in one line; each machine's own line follows
+var bad=mg.machines.filter(function(x){return x.dot==='errors';}).map(function(x){return x.host||'this machine';});
+if(bad.length)return 'Errors on '+bad.join(', ');
+if(mg.dot==='quiet')return 'No API traffic on any machine.';
+return 'All '+mg.n+' machines fine.';}
+if(mg.dot==='errors'){if(m.state!=='ok')return m.text;   // this machine's frame: sessions waiting on the API, in the kernel's words
+return rd?rd.headline:m.text;}   // the window in errors: the reading's sentence
+if(rd)return rd.headline;return mg.dot==='quiet'?'No API traffic in the last 15 min.':'Fine.';}
 // a bucket's name for the card: its model family, plus its auth label when another bucket shares the family
 function bname(d,key){var b=(d.buckets||{})[key]||{},fam=b.family||key.split('|')[1]||key,dup=false;
 Object.keys(d.buckets||{}).forEach(function(k){if(k!==key&&((d.buckets[k]||{}).family||'')===fam)dup=true;});
@@ -47379,11 +47505,26 @@ return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}
 // are named when there are any (an offline window would otherwise read 'no attempts' and hide its give-ups). A mixed
 // window counts every attempt once and says how many of them had no status, with the shares' base named beside them:
 // '15 attempts, 7 of them without a status · 25% 429 · 0% 5xx of the other 8'.
-function winRow(w,c,up){var lab=(w%60===0?(w/60)+' min':w+' s');if(c&&c.complete===false&&typeof up==='number')lab+=' · kernel up '+dur(up);
-var v,rq=(c&&c.requests)||0,ns=(c&&c.noStatus)||0;if(!c||!(rq||ns||c.gaveUp||c.sessionsRetrying))v='no attempts';
-else{v=rq?(pl(rq+ns,'attempt')+(ns?', '+ns+' of them without a status':'')+' · '+pct(c.rate429)+' 429 · '+pct(c.rate5xx)+' 5xx'+(ns?' of the other '+(rq===1?'one':rq):'')):(pl(ns,'attempt')+' without a status');
-v+=' · '+(c.gaveUp||0)+' gave up · '+pl(c.sessionsRetrying,'session')+' retried';}
-return '<div class="ru-tip-row ah-hrow"><span class=ru-tip-k>'+esc(lab)+'</span><span class=ru-tip-v>'+esc(v)+'</span></div>';}
+// attempts per minute over the longest window, in the usage hover's graph grammar (T301): the polyline + fill for
+// every attempt, 429 attempts in the blocked red and 5xx in the warn amber over it so a storm reads at a glance, ONE
+// ceiling label, a tick every five minutes. Colours through the tokens (fallbacks for a var-less harness).
+function graphHTML(sr){var n=sr.ok.length,W=168,H=48,tot=[],mx=0;
+for(var i=0;i<n;i++){var v=(sr.ok[i]||0)+(sr.rateLimited[i]||0)+(sr.serverErrors[i]||0)+(sr.noStatus[i]||0);tot.push(v);if(v>mx)mx=v;}
+if(mx<=0)return '';
+var steps=[1,2,5,10,20,50,100,200,500,1000],top=steps[steps.length-1];for(var k=0;k<steps.length;k++)if(steps[k]>=mx){top=steps[k];break;}
+var X=function(i){return (n>1?i/(n-1):0.5)*W;},Y=function(v){return H-1-Math.max(0,Math.min(1,v/top))*(H-2);};
+var line=function(arr,color,op){var pts=[],anyv=false;for(var i=0;i<n;i++){var v=arr[i]||0;if(v)anyv=true;pts.push(X(i).toFixed(1)+','+Y(v).toFixed(1));}
+if(!anyv)return '';return '<polyline points="'+pts.join(' ')+'" fill="none" style="stroke:'+color+'" stroke-width="1.5" vector-effect="non-scaling-stroke"/>'
++'<polygon points="0,'+(H-1)+' '+pts.join(' ')+' '+W+','+(H-1)+'" style="fill:'+color+'" opacity="'+op+'" stroke="none"/>';};
+var ty=Y(top),grid='<line x1="0" y1="'+ty.toFixed(1)+'" x2="'+W+'" y2="'+ty.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"/>',xlab='';
+var per=Math.max(1,Math.round(300/(sr.binS||60)));   // a tick every five minutes
+for(var i=0;i<n;i++){var ago=(n-1-i)*(sr.binS||60);if(i===n-1||(ago%300===0&&ago>0)){var gx=X(i);
+grid+='<line x1="'+gx.toFixed(1)+'" y1="0" x2="'+gx.toFixed(1)+'" y2="'+H+'" stroke="rgba(255,255,255,0.06)" stroke-width="1" vector-effect="non-scaling-stroke"/>';
+xlab+='<span style="left:'+(gx/W*100).toFixed(1)+'%">'+(i===n-1?'now':(ago/60)+'m')+'</span>';}}
+var body=line(tot,'var(--accent,#9cd2ff)',0.18)+line(sr.serverErrors,'var(--warn,#e67e22)',0.35)+line(sr.rateLimited,'var(--st-blocked-bg,#e5484d)',0.35);
+return '<div class=ru-tip-row><span class=ru-tip-k>attempts / min \u00b7 15 min</span><span class=ru-tip-v>peak '+mx+'</span></div>'
++'<div class=ru-tip-graph><svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">'+grid+body+'</svg>'
++'<span class=ru-tip-gy style="top:'+(ty/H*56).toFixed(0)+'px">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}
 // the newest HIST_ROWS transitions, newest first: the time, the state entered (with its bucket when there are
 // several), and how long it held (until the same bucket's next transition; 'so far' for the current one, a flag and
 // never a stamp comparison: the transition the hover's own read files carries that read's asOf as its time, and the
@@ -47402,43 +47543,49 @@ if(!crossed&&pre){crossed=true;
 if(!sawRestart){out+='<div class="ru-tip-row ah-hrow ah-boot"><span class=ru-tip-k>'+hmd(boot)+'</span><span class=ah-hword>kernel restarted</span></div>';}}
 var end=now,cur=true;for(var j=i-1;j>=0;j--)if(rows[j].bucket===r.bucket){end=rows[j].t;cur=false;break;}
 if(pre&&end>boot){end=boot;cur=false;}
-var word=(multi?bname(d,r.bucket)+' ':'')+r.to+(restart?' · kernel restarted':'');
+var word=(multi?bname(d,r.bucket)+' ':'')+(STATE_WORD[r.to]||r.to)+(restart?' \u00b7 kernel restarted':'');
 out+='<div class="ru-tip-row ah-hrow"><span class=ru-tip-k>'+hmd(r.t)+'</span><span class=ah-hword>'+esc(word)+'</span><span class=ru-tip-v>'+dur(end-r.t)+(cur?' so far':'')+'</span></div>';
 if(restart)sawRestart=true;shown++;}
 return out;}
-function histHTML(){var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'
-+((HIST&&!HIST.error&&typeof HIST.asOf==='number')?'<span class=ru-tip-reset>as of '+hms(HIST.asOf)+'</span>':'')+'</div>';
+// History (T301): what happened, per machine, in plain words; the graph; the legend; this machine's State changes,
+// capped and worded plainly. The state machine's word appears only inside the plain phrasing (readHistory), and
+// "unknown" nowhere: traffic with no errors reads as the successes counted, no traffic reads as quiet.
+function localFirst(a,b){return a===''?-1:b===''?1:(a<b?-1:a>b?1:0);}
+function levelDot(rd){return rd?(rd.level==='errors'?'errors':rd.level==='quiet'?'quiet':'fine'):'fine';}
+function histHTML(){var loc=HIST&&HIST[''],asOf=(loc&&!loc.error&&typeof loc.asOf==='number')?'<span class=ru-tip-reset>as of '+hms(loc.asOf)+'</span>':'';
+var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'+asOf+'</div>';
 if(!HIST)return h+'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div></div>';
-if(HIST.error)return h+'<div class="ah-line ah-err">Could not read the API history: '+esc(HIST.error)+'</div></div>';
-var d=HIST,ov=d.overall||{},key=ov.worstBucket,b=key?(d.buckets||{})[key]:null,nb=Object.keys(d.buckets||{}).length,st=ov.state||'unknown';
-// since is the bucket's stateSince as the backend files it: a bucket the boot seeded is unknown since the kernel's
-// own start (SdkBackend seeds the aggregator with the boot clock the payload serves as bootAt), so the head, the
-// tail's divider and the boot's row name one time with no branch here
-var since=b?b.stateSince:0;
-h+='<div class="ru-tip-row ah-head"><i class=ah-dot data-state='+esc(st)+'></i><span class=ah-word>'+esc(st)+'</span>'
-+((nb>1&&b)?'<span class=ah-hsub>'+esc(bname(d,key))+' · worst of '+nb+' buckets</span>':'')
-+(since?'<span class=ah-since>since '+hmd(since)+'</span>':'')+'</div>';
-if(b&&b.why)h+='<div class="ah-line ru-tip-reset">'+esc(b.why)+'</div>';
-if(!b)h+='<div class=ah-line>No API traffic seen'+(typeof d.bootAt==='number'?' since the kernel started at '+hmd(d.bootAt):' yet')+'.</div>';
-else ((d.config&&d.config.windows)||[60,300,900]).forEach(function(w){h+=winRow(w,(b.windows||{})[String(w)],d.uptimeS);});
-var tr=transRows(d);if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes</span></div>'+tr;
+var hs=Object.keys(HIST).sort(localFirst),many=hs.length>1;
+hs.forEach(function(host){var d=HIST[host],name=host||'this machine';
+if(!d||d.error){h+='<div class="ah-line ah-err">Could not read the API history'+(many?' of '+esc(name):'')+': '+esc((d&&d.error)||'no answer')+'</div>';return;}
+var rd=MERGE?MERGE.readHistory(d):null;
+// with several machines each gets its line (the head already carries this machine's when alone)
+if(many)h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+levelDot(rd)+'></i><span class=ah-nm>'+esc(name)+'</span><span class=ah-desc>'+esc(rd?rd.headline:'')+'</span></div>';
+if(rd&&rd.sub&&many)h+='<div class="ah-line ru-tip-reset">'+esc(rd.sub)+'</div>';
+var sr=MERGE?MERGE.documentSeries(d):null;if(sr)h+=graphHTML(sr);});
+h+='<div class="ah-line ah-legend">'+LEGEND+'</div>';
+var tr=(loc&&!loc.error)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 this machine':'')+'</span></div>'+tr;
 return h+'</div>';}
 // the cell's description while the hover shows: the state word and its since, then how to reach the rest. Before the
 // answer lands it carries the state word the frame already put on the cell (assistive tech reads the description once,
 // at focus time, and the landed text replaces it with nothing to announce the change: a loading line with no state
 // word would leave a screen-reader user with none) and says the read is in flight; the landed line adds the since; a
 // failed read says so in the same words as the section's line
-function descText(){var tail=' Press Enter to open it.';if(!HIST)return 'History: '+((LAST&&LAST.text)||'unknown')+'. Reading the details.'+tail;
-if(HIST.error)return 'Could not read the API history: '+HIST.error+'.'+tail;
-var ov=HIST.overall||{},key=ov.worstBucket,b=key?(HIST.buckets||{})[key]:null;
-return 'History: '+(ov.state||'unknown')+((b&&b.stateSince)?' since '+hmd(b.stateSince):'')+'.'+tail;}
+function descText(){var tail=' Press Enter to open it.';var mg=merged();var w=LAST?headWords(LAST,mg):'';
+if(!/[.!?]$/.test(w))w+='.';
+var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;
+if(!HIST)return 'API health: '+w+' Reading the details.'+tail;
+return 'API health: '+w+tail;}
 // full=false is the HOVER: the same reading with no controls. The hover sits under pointer-events:none and hides
 // on mouseleave, so a button there could not be honored; the click is where the actions live.
-function html(m,full){var h='<div class=ru-tip-win><div class=ru-tip-name><span>API · this machine</span></div>'
-+'<div class="ru-tip-row ah-head"><i class=ah-dot data-state='+esc(m.state)+'></i><span class=ah-word>'+esc(m.text)+'</span>'
-+(m.since?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';
+function html(m,full){var mg=merged(),rd=readingOf('');
+var h='<div class=ru-tip-win><div class=ru-tip-name><span>API health'+(mg.n>1?' \u00b7 '+mg.n+' machines':'')+'</span></div>'
++'<div class="ru-tip-row ah-head"><i class=ah-dot data-dot='+esc(mg.dot)+'></i><span class=ah-word>'+esc(headWords(m,mg))+'</span>'
++((m.since&&m.state!=='ok')?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';
 if(m.state==='paused')h+='<div class=ah-line>'+(PAUSE[m.reason]||PAUSE.manual)+'</div>';
-else if(m.state==='ok')h+='<div class=ah-line>'+OK+'</div>';
+if(rd&&rd.sub&&mg.n===1)h+='<div class="ah-line ru-tip-reset">'+esc(rd.sub)+'</div>';
+// several machines: one line each, the dot in that machine's state, a stale link said plainly
+if(mg.n>1)mg.machines.forEach(function(x){h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+esc(x.dot)+'></i><span class=ah-desc>'+esc(x.text)+(x.stale?' \u00b7 last heard before its link dropped':'')+'</span></div>';});
 if(full)h+=btnHTML(m);
 h+='</div>';
 var rows=m.sessions||[];
@@ -47569,7 +47716,7 @@ window.__rompApiHealth=function(m){if(!m||!m.state)return;LAST=m;hint='';   // a
 // that cleared only on a frame whose state matched the press would leave a Resume disabled and mislabeled for the window.
 if(pending!==null&&(m.seq==null||m.seq!==pendSeq))pending=null;
 if(el.hidden)el.hidden=false;   // the first frame reveals the cell (a kernel that sends none shows nothing)
-if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}
+paintCell();
 if(tip.style.display!=='block')return;   // an open detail re-renders from the new frame, nothing else does
 load();   // and re-reads the history: the world changed
 if(held){dirty=true;return;}render();};
@@ -49652,12 +49799,16 @@ def _landing():
             # without this author rule the rail would show a gray 'API ok' from page load, and forever on a
             # kernel that never sends a frame (the #mtabs button[hidden] idiom).
             "#rail-api[hidden]{display:none}"
-            ".ah-dot{width:7px;height:7px;border-radius:50%;background:#9aa4ad;opacity:.55;flex:0 0 auto}"
-            "#rail-api[data-state=degraded] .ah-dot,.ah-dot[data-state=degraded]{background:#e67e22;opacity:1}"
-            "#rail-api[data-state=paused] .ah-dot,.ah-dot[data-state=paused]{background:#e5484d;opacity:1}"
-            ".ah-text{font:600 10px 'Inter',system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#cfe6ff;font-variant-numeric:tabular-nums;white-space:nowrap}"
-            "#rail-api[data-state=ok] .ah-text{color:#9aa4ad}"
-            "#rail-api{cursor:pointer;margin-left:4px}"
+            # the dot's THREE states (T301, the user 2026-09-10): the accent when every connected kernel is fine, the
+            # blocked red when errors are being met anywhere (a 429 storm, 5xx, offline, paused), the label gray when
+            # no kernel has API traffic in the windows. Tokens with fallbacks (a var-less harness). The same dot,
+            # keyed by its own data-dot, heads the detail card and each machine's line.
+            ".ah-dot{width:7px;height:7px;border-radius:50%;background:var(--dim,#9aa4ad);opacity:.55;flex:0 0 auto}"
+            "#rail-api[data-dot=fine] .ah-dot,.ah-dot[data-dot=fine]{background:var(--accent,#9cd2ff);opacity:1}"
+            "#rail-api[data-dot=errors] .ah-dot,.ah-dot[data-dot=errors]{background:var(--st-blocked-bg,#e5484d);opacity:1}"
+            "#rail-api[data-dot=quiet] .ah-dot,.ah-dot[data-dot=quiet]{background:var(--dim,#9aa4ad);opacity:.55}"
+            "#rail-api{cursor:pointer;margin:0 1px;padding:4px 2px}"   # a 15px hit target around a 7px dot; sits inside the readout's slot
+            ".ah-slot{display:inline-flex;align-items:center}"
             # the detail card's own rows, in the tip's font and palette (#ah-tip shares #ru-tip's skin below)
             ".ah-head{gap:7px}.ah-word{font-weight:700;color:#e8eef5}.ah-since{opacity:.55;margin-left:auto}"
             ".ah-line{margin-top:4px;max-width:340px}"
@@ -49679,8 +49830,9 @@ def _landing():
             # caps it to (the room above the rail): border-box, so the cap is the outline the user sees and not the
             # content plus 18 px of padding and border; .ru-modal's own overflow-y:auto outranks the clip on the
             # pinned card, which scrolls as before.
-            ".ah-dot[data-state=thrashing]{background:#e5484d;opacity:1}.ah-dot[data-state=recovering]{background:#e67e22;opacity:.7}"
             ".ah-hword{opacity:.8}.ah-hsub{opacity:.55}.ah-boot .ah-hword{font-style:italic;opacity:.6}"
+            # the graph (T301): the usage hover's own .ru-tip-graph grammar; the legend and the machine lines are sub-lines
+            ".ah-legend{opacity:.6;margin-top:4px;max-width:340px}.ah-mline{gap:7px}.ah-mline .ah-desc{opacity:.9}"
             ".ah-hname{margin-top:6px}.ah-err{color:#ef6b6f}.ah-wait{margin:5px 0 2px}"
             ".ah-row.ah-ro{cursor:default}.ah-row.ah-ro:hover{background:transparent}"
             "#ah-tip:focus{outline:none}#ah-tip{overflow:hidden;box-sizing:border-box}"
@@ -50091,7 +50243,6 @@ def _landing():
             "body.theme-light .ru-tip-name{color:#1F1E1D}"
             "body.theme-light .ru-name{color:#5D574E}"
             "body.theme-light .ru-pct{color:#1F1E1D}"
-            "body.theme-light .ah-text{color:#1F1E1D}"
             # the ok dot: the dark label gray at .55 blends into the light rail (about 1.4:1); the light label
             # color at the same opacity keeps the glyph where the eye expects it. Scoped to the ok state: a
             # bare `body.theme-light .ah-dot` (0,2,1) would outrank the detail's `.ah-dot[data-state=...]`
@@ -50099,12 +50250,10 @@ def _landing():
             # theme while the rail's id-scoped dot kept them
             # and the History head's dot for the signal's quiet states (healthy, unknown) is the same glyph: the base
             # gray falls to about 1.6:1 on the white tip too
-            "body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok],"
-            "body.theme-light .ah-dot[data-state=healthy],body.theme-light .ah-dot[data-state=unknown]{background:#5D574E}"
+            "body.theme-light #rail-api[data-dot=quiet] .ah-dot,body.theme-light .ah-dot[data-dot=quiet]{background:#5D574E}"
             # the failure line in the light theme's error-text red (styles.css --err #B02A1C, about 6.6:1 on white;
             # the dark line's #ef6b6f is 3.0:1 there)
             "body.theme-light .ah-err{color:#B02A1C}"
-            "body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}"
             "body.theme-light .ah-word{color:#1F1E1D}"
             "body.theme-light .ah-btn{background:#F1EAE2;border-color:rgba(0,0,0,0.12);color:#1F1E1D}"
             "body.theme-light .ah-row:hover{background:rgba(0,0,0,0.05)}"
@@ -50181,15 +50330,18 @@ def _landing():
             # the Claude /usage rate-limit bars (Pro/Max): three compact vertical bar-pairs (used % colored +
             # elapsed % slate), %-label, full detail on hover — side-by-side in the bottom bar.
             "<div id=rail-usage data-keycmd=usage.open></div>"
-            # the API health cell: its own label, a 7px dot, one word, painted by _LANDING_APIH_JS from the
-            # kernel's apiHealth push. Ships HIDDEN: it shows on its first frame, so a kernel that never sends
+            # the API health cell (T301, the user 2026-09-10): ONE small dot and nothing else, no second "API" word
+            # and no "ok". It ships here after the usage bars and MOVES into the spend readout's slot (.ah-slot,
+            # right after that readout's existing API label and left of its 1-day segment) whenever the readout
+            # renders (_LANDING_USAGE_JS renderRows re-parents the node, so its listeners survive every rebuild
+            # of the readout's innerHTML); with no spend readout it stays here. Painted by _LANDING_APIH_JS from the
+            # kernel's apiHealth push, merged across every attached machine. Ships HIDDEN: it shows on its first frame, so a kernel that never sends
             # one shows nothing rather than a false ok. Its own element, not a child of #rail-usage (renderRows
             # empties that one when there are no bars and no spend). No title (the rail's no-title rule); no
             # data-keycmd yet. role=button + tabindex=0 make it a keyboard control (Enter / Space open the
             # detail); aria-label follows the frame's text.
-            "<div id=rail-api class=\"ru-w ru-ah\" hidden role=button tabindex=0 aria-label=\"API ok\" data-state=ok>"
-            "<span class=ru-name>API</span>"
-            "<i class=ah-dot></i><span class=ah-text>ok</span></div>"
+            "<div id=rail-api class=\"ru-w ru-ah\" hidden role=button tabindex=0 aria-label=\"API health\" data-dot=fine>"
+            "<i class=ah-dot></i></div>"
             "</div>"   # /.rail-scroll
             # refresh + network + settings, pinned to the far RIGHT (settings last), always visible:
             "<div class=rail-acts>"
@@ -50363,6 +50515,10 @@ def _landing():
             # for `romp perf client`. Early, so a long frame during the boot's own work is seen; the boot
             # script runs first so the splash is not held behind a bundle fetch.
             ("<script src=/dist/shell-perf.js?v=%d></script>" % v) +
+            # the API-health merge and reading rules (ui/webview/api-health-merge.ts), published as
+            # window.__rompApiHealthMerge for _LANDING_APIH_JS the same way (T301): pure, unit-tested, and the
+            # one place the multi-host merge and the plain-words reading live
+            ("<script src=/dist/api-health-global.js?v=%d></script>" % v) +
             "<script>" + _LANDING_ERRS_JS + "</script>"
             "<script>" + _LANDING_USAGE_JS.replace("__ROMP_LOADER__", json.dumps(_loader_inner())) + "</script>"
             "<script>" + _LANDING_APIH_JS + "</script>"
@@ -50976,6 +51132,10 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(403, "forbidden: " + why, "text/plain")
             if p == "/ws":
                 return self._ws()
+            if p.startswith("/remote/") and p.endswith("/api-health"):
+                # the API-health signal of an attached host, relayed (T301): one JSON read, that kernel's own
+                # token rewritten in, its document passed through as it answered it
+                return self._remote_api_health(unquote(p[len("/remote/"):-len("/api-health")]))
             if p.startswith("/remote/") and p.endswith("/ws"):
                 # federated dashboard, viewed off this machine: relay to the attached host's kernel
                 return self._remote_ws(unquote(p[len("/remote/"):-len("/ws")]), u.query)
@@ -51200,6 +51360,14 @@ class Handler(BaseHTTPRequestHandler):
                 if (q.get("local") or [""])[0]:
                     return self._send(200, json.dumps(_spend_detail_local()), "application/json", cache="no-cache")
                 return self._send(200, json.dumps(_spend_detail()), "application/json", cache="no-cache")
+            if p == "/api-health/frame":
+                # This kernel's LAST apiHealth shell frame, its local half only (no `hosts`): what an attached
+                # peer's tunnel supervisor polls to carry this machine in ITS shell's per-host map (T301). Authed
+                # like /api-health (it names sessions). 503 before the first cycle has built one.
+                f = _apih_local_frame()
+                if f is None:
+                    return self._send(503, json.dumps({"error": "no API-health frame yet"}), "application/json", cache="no-cache")
+                return self._send(200, json.dumps(f), "application/json", cache="no-cache")
             if p == "/api-health":
                 # The API-health signal (docs/reference.md): per-(auth label, model family) attempt /
                 # response / give-up counts over rolling windows and a thrash/degraded/recovering state
@@ -54181,6 +54349,37 @@ class Handler(BaseHTTPRequestHandler):
                 up.close()                       # ours alone — safe to close fully
             except OSError:
                 pass
+
+    def _remote_api_health(self, host):
+        """GET /remote/<host>/api-health: relay ONE read of an attached host's API-health signal through this
+        kernel's tunnel (T301). The same shape as the /file relay: the local auth gate has run, the remote's own
+        token goes in the request (the browser needs only its local credential), and this kernel mirrors the
+        status and the JSON body it got, bounded, under a Content-Type this side sets. The remote's numbers are
+        the remote's: the shell keeps them under that host's name and never adds them to this kernel's. A dead
+        tunnel is a 502 and a redial, as for every relay."""
+        with _remotes_lock:
+            r = _remotes.get(host)
+            port, rtok = (r or {}).get("local_port") or 0, (r or {}).get("token") or ""
+        if not port:
+            return self._send(404, "no attached host %r" % host, "text/plain")
+        conn = http.client.HTTPConnection("127.0.0.1", int(port), timeout=10)
+        try:
+            conn.request("GET", "/api-health", headers=({"X-Romp-Token": rtok} if rtok else {}))
+            resp = conn.getresponse()
+            body = resp.read(1 << 20)
+            status = resp.status
+        except (OSError, http.client.HTTPException) as e:
+            _demand_redial(host, "refused" if isinstance(e, ConnectionRefusedError) else "timeout")
+            return self._send(502, "tunnel to %s is not answering: re-dialing now" % host, "text/plain")
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        if status != 200:
+            # the remote's verdict in prose (an older build's 404, its 401, its 503): the shell names it per host
+            return self._send(status, body[:2000].decode("utf-8", "replace") or ("HTTP %d" % status), "text/plain")
+        return self._send(200, body, "application/json", cache="no-cache")
 
     def _remote_file(self, host, query, head=False):
         """GET/HEAD /remote/<host>/file — relay ONE preview request to an attached host's kernel

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18965,6 +18965,9 @@ _NOT_SAVED = ("proc",       # the live Popen
               #               ITSELF stays: _remotes_load keeps it and
               #               _views_client serves every cached reading, status aside, so a down host's tags
               #               survive a kernel restart; the boot's first poll re-reads, the gate unstamped
+              "apiHealth",  # a remote's API-health frame (T301): re-polled within a pass of any boot; saved, a dead
+              "_apih_at",   #   host's last-life storm came back at boot and painted the dot red with no date, and the
+              "_apih_fault",#   poll's stamp rewrote this 0600 file every pass forever (the _usage_at story again)
               "misses",     # the poll run counters: they describe THIS connection, and a fresh boot
               "ok_polls",   # dials from scratch, so carrying them across would judge a link that is gone
               "upSeq",      # the recovery counter (T291b): the same per-process story; the dashboard skips a first observation
@@ -19612,10 +19615,12 @@ REMOTE_APIH_EVERY = 10.0    # the API-health frame: a storm shows within a few p
 def _poll_remote_api_health(r):
     """GET a remote kernel's /api-health/frame THROUGH the -L tunnel: that machine's own apiHealth shell frame
     (its local half only, never its view of ITS peers), so this kernel's shell frame can carry every attached
-    machine's state as a per-host map (T301, the user 2026-09-10: the signal must cover every connected kernel,
-    not this one alone). Returns the parsed frame, {} when the host answered that it has none yet (an older
-    build's 404 too: the row is then cleared rather than kept stale), or None when nothing answered (keep the
-    last reading, as the usage poll does). Rate-limited to REMOTE_APIH_EVERY per host."""
+    machine's state as a per-host map (T301, the user 2026-09-10, who wanted the signal to cover every connected
+    kernel, not this one alone). Returns the parsed frame, {} when the host answered that it has none yet (503) or
+    is an older build (404): the row is then cleared rather than kept stale; or the row's last frame when nothing
+    answered or the read was refused (a 403 from a rotated token, a 500): kept, as the usage and views polls keep
+    theirs, and the refusal recorded in `_apih_fault` so the shell names the machine with its fault instead of
+    losing it (review find, 2026-09-10). Rate-limited to REMOTE_APIH_EVERY per host."""
     import urllib.parse
     now = time.time()
     if now - float(r.get("_apih_at") or 0) < REMOTE_APIH_EVERY:
@@ -19628,8 +19633,13 @@ def _poll_remote_api_health(r):
         data = resp.read()
         c.close()
         r["_apih_at"] = now
-        if resp.status != 200:
+        if resp.status in (503, 404):
+            r.pop("_apih_fault", None)
             return {}                                   # no frame there (not yet, or an older kernel): clear
+        if resp.status != 200:
+            r["_apih_fault"] = "HTTP %d" % resp.status  # refused: keep the last frame, say why
+            return r.get("apiHealth")
+        r.pop("_apih_fault", None)
         u = json.loads(data.decode("utf-8"))
         return u if isinstance(u, dict) and u.get("state") else {}
     except Exception:
@@ -43792,6 +43802,10 @@ def _api_health_frame(now, tmux):
             # no API traffic in the longest window (T301): the dot reads gray on this alone, before any history is read;
             # True with no SDK backend (nothing can have talked to the API through this kernel)
             "quiet": _apih_quiet(now),
+            # failed attempts in that window (T301 review): the dot reads red for a storm the window still holds when
+            # no session waits right now, and clears the cycle the last failure ages out; the frame is rebuilt every
+            # cycle and pushed on change, so the browser never polls the history for the dot
+            "errs": _apih_errs(now),
             # every attached machine's own frame, by host (T301): a per-host MAP, never a merged count or a
             # compared clock (the federation rule: merged payloads keep local scalars and carry per-host maps);
             # the shell merges it for the dot (worst state wins) and names each machine. `stale` marks a row
@@ -43799,7 +43813,7 @@ def _api_health_frame(now, tmux):
             "hosts": _api_health_hosts()}
 
 
-_APIH_HOST_KEYS = ("state", "cls", "text", "waiting", "retrying", "blocked", "since", "reason", "tmux", "quiet")
+_APIH_HOST_KEYS = ("state", "cls", "text", "waiting", "retrying", "blocked", "since", "reason", "tmux", "quiet", "errs")
 
 
 def _apih_quiet(now):
@@ -43812,17 +43826,33 @@ def _apih_quiet(now):
         return True
 
 
+def _apih_errs(now):
+    """How many attempts failed inside this kernel's longest window (T301): the frame's `errs`. 0 with no backend."""
+    try:
+        be = _sdk()
+        ah = getattr(be, "api_health", None) if be else None
+        return 0 if ah is None else int(ah.window_errors(now))
+    except Exception:
+        return 0
+
+
 def _api_health_hosts():
-    """{host: {state, cls, text, waiting, retrying, blocked, since, reason, tmux, stale}} for every attached
-    machine whose frame the tunnel supervisor has cached (_poll_remote_api_health). Deterministic for an
-    unchanged world (no clock), so an identical fleet still yields an identical frame and no push."""
+    """{host: {state, cls, text, waiting, retrying, blocked, since, reason, tmux, quiet, errs, stale[, fault]}} for
+    every attached machine whose frame the tunnel supervisor has cached (_poll_remote_api_health), and for one
+    whose read it refused (`fault`, the HTTP status; the frame keys are then whatever was last heard). `stale`
+    marks both a tunnel that is not up and a refused read: the shell names such a machine and gives it no say in
+    the dot. Deterministic for an unchanged world (no clock), so the same hosts in the same states yield an
+    identical frame and no push."""
     out = {}
     with _remotes_lock:
-        rows = [(r["host"], dict(r.get("apiHealth") or {}), r.get("status")) for r in _remotes.values()
-                if isinstance(r.get("apiHealth"), dict) and r.get("apiHealth")]
-    for host, f, st in rows:
+        rows = [(r["host"], dict(r.get("apiHealth") or {}), r.get("status"), r.get("_apih_fault"))
+                for r in _remotes.values()
+                if (isinstance(r.get("apiHealth"), dict) and r.get("apiHealth")) or r.get("_apih_fault")]
+    for host, f, st, fault in rows:
         row = {k: f.get(k) for k in _APIH_HOST_KEYS if k in f}
-        row["stale"] = st != "up"
+        row["stale"] = st != "up" or bool(fault)
+        if fault:
+            row["fault"] = str(fault)
         out[host] = row
     return out
 
@@ -46823,7 +46853,11 @@ r.usage=v;});});}
 var RAIL_HOME=(function(){var c=document.getElementById('rail-api');return c?c.parentNode:null;})();   // where the dot lives with no readout
 // the API-health dot may sit INSIDE this cell (in the readout's slot); every innerHTML write below would destroy it
 // with the readout, so it is parked back at its own place first and moved into the fresh slot after (T301)
-function parkApiCell(){var c=document.getElementById('rail-api');if(c&&el.contains(c)&&RAIL_HOME)RAIL_HOME.insertBefore(c,el.nextSibling);}
+// a DOM move blurs a focused node: the dot's script is told the move is ours (__rompApiCellMoving) so its blur and
+// focus handlers stand down, and focus is put back after, so a focus-shown hover survives the readout's minute repaint
+function moveApiCell(c,into){var had=document.activeElement===c,mv=window.__rompApiCellMoving;if(mv)mv(true);
+into();if(had){try{c.focus({preventScroll:true});}catch(e){}}if(mv)mv(false);}
+function parkApiCell(){var c=document.getElementById('rail-api');if(c&&el.contains(c)&&RAIL_HOME)moveApiCell(c,function(){RAIL_HOME.insertBefore(c,el.nextSibling);});}
 function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];parkApiCell();
 var live=ROWS.filter(function(r){return hasBars(r.usage)||hasSpend(r.usage);});
 if(!live.length){el.innerHTML='';tip.style.display='none';return;}
@@ -46835,7 +46869,7 @@ el.innerHTML=aggBarsHTML(LAST)+apiCellHTML(LAST);
 // the API-health dot rides the readout (T301): the STABLE #rail-api node moves into the readout's slot, and back to
 // its own place in the rail when no readout renders; a move keeps its listeners, an innerHTML copy would not
 (function(){var cell=document.getElementById('rail-api');if(!cell)return;var slot=el.querySelector('.ah-slot');
-if(slot){slot.appendChild(cell);}else if(cell.parentNode!==RAIL_HOME&&RAIL_HOME){RAIL_HOME.insertBefore(cell,el.nextSibling);}})();
+if(slot){moveApiCell(cell,function(){slot.appendChild(cell);});}else if(cell.parentNode!==RAIL_HOME&&RAIL_HOME){moveApiCell(cell,function(){RAIL_HOME.insertBefore(cell,el.nextSibling);});}})();
 // a HOVER tip already open re-renders in place when fresh data lands (the 60s pull, the timeline's
 // live forward) — the user 2026-08-14, replacing the footer's click-me hint with the refresh itself.
 // Re-anchor the top edge after the swap: new content can change the tip's height, and it hangs ABOVE
@@ -47036,6 +47070,11 @@ pullFleet().then(openIt,openIt);};
 el.addEventListener('mouseenter',function(ev){var c=document.getElementById('rail-api');
 if(c&&ev&&typeof ev.clientX==='number'){var at=document.elementFromPoint(ev.clientX,ev.clientY);if(at&&(at===c||c.contains(at)))return;}showTip(ev);});
 el.addEventListener('mouseleave',function(){tip.style.display='none';});
+// the dot's own tip takes over while the pointer is on the dot (T301 review): the dot's script hides this tip as its
+// own shows and asks for it back when the pointer slides from the dot onto the readout's figures (its mouseenter
+// and mouseleave, never a timer), so the two tips are never up at once
+window.__rompUsageTipHide=function(){tip.style.display='none';};
+window.__rompUsageTipShow=function(ev){showTip(ev);};
 // Refresh-from-source (the user 2026-06-30): GET /usage re-reads usage.json — the snapshot Claude Code's
 // statusline (tmux) OR the SDK backend's RateLimitEvent capture writes — and re-renders. `pull(ack)` is the
 // shared path: a CLICK forces it now (ack=true → instant dim pulse before the round-trip, per the button
@@ -47392,7 +47431,8 @@ _LANDING_APIH_JS = """
 // the merge and reading rules (ui/webview/api-health-merge.ts via api-health-global.ts); absent (a stale dist), the
 // local frame alone paints the dot and the popup says so in the kernel's own words
 var MERGE=window.__rompApiHealthMerge||null;
-var READINGS={};   // per host: the history reading (readHistory), null until read; the frame merge takes it
+var READINGS={};   // per host: the history reading (readHistory), null until read; the machine lines take it (the dot follows the frames)
+var moving=false;  // the readout is re-parenting the cell (moveApiCell): its blur and focus are not the user's
 var DOTWORD={fine:'fine',errors:'errors',quiet:'no traffic'};
 var LEGEND='429 = the API told us to slow down (rate limit) \u00b7 5xx = the API itself failed (server error) \u00b7 offline = no connection';
 var STATE_WORD={thrashing:'rate-limit storm',degraded:'API failing',recovering:'recovering',healthy:'fine',unknown:'quiet'};
@@ -47469,16 +47509,19 @@ return tp.then(function(t){return {error:'HTTP '+r.status+(t?' \u00b7 '+String(t
 return r.json().then(function(d){return (d&&d.buckets)?d:{error:'malformed answer'};},function(){return {error:'malformed answer'};});})
 .catch(function(e){return {error:String((e&&e.message)||e)};});}
 function hostsOf(m){return Object.keys((m&&m.hosts)||{}).sort();}
-function load(fresh){var n=++histSeq;if(fresh)HIST=null;
-var hs=hostsOf(LAST),reads=[fetchDoc('/api-health')].concat(hs.map(function(h){return fetchDoc('/remote/'+encodeURIComponent(h)+'/api-health');}));
-Promise.all(reads).then(function(docs){if(n!==histSeq)return;var by={'':docs[0]};hs.forEach(function(h,i){by[h]=docs[i+1];});HIST=by;
-READINGS=MERGE?MERGE.mergeHistories(by).readings:{};paintCell();
-if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();});}
+// one read per machine, each landing on its own (review find): a hung tunnel holds its relay for the relay's timeout,
+// and this machine's numbers must not wait on it. A fresh show starts every machine as a loader line; a re-read while
+// open keeps each machine's last answer until its new one lands. The newest read wins a race (histSeq).
+function load(fresh){var n=++histSeq,names=[''].concat(hostsOf(LAST)),by={};
+names.forEach(function(h){by[h]=(!fresh&&HIST&&HIST[h]&&!HIST[h].pending)?HIST[h]:{pending:true};});HIST=by;
+names.forEach(function(h){fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health').then(function(d){if(n!==histSeq)return;by[h]=d;
+READINGS=MERGE?MERGE.mergeHistories(by).readings:{};
+if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();});});}
 // the merged view of the frame: the dot and one line per machine (worst state wins; per-host maps, nothing summed)
 function merged(){if(!LAST)return {dot:'fine',worst:'',machines:[],n:1};
 if(MERGE)return MERGE.mergeFrames(LAST,LAST.hosts||{},READINGS);
 var d=LAST.state==='ok'?'fine':'errors';return {dot:d,worst:'',machines:[{host:'',dot:d,text:'this machine: '+LAST.text,stale:false}],n:1};}
-function readingOf(host){var d=HIST&&HIST[host];if(!d||d.error||!MERGE)return null;return MERGE.readHistory(d);}
+function readingOf(host){var d=HIST&&HIST[host];if(!d||d.error||d.pending||!MERGE)return null;return MERGE.readHistory(d);}
 // the cell: the dot's state and its description, from the merge; the DOM is touched only on a change
 function paintCell(){var mg=merged();if(el.getAttribute('data-dot')!==mg.dot)el.setAttribute('data-dot',mg.dot);
 var lab='API health: '+DOTWORD[mg.dot]+(mg.n>1?' across '+mg.n+' machines':'');if(el.getAttribute('aria-label')!==lab)el.setAttribute('aria-label',lab);}
@@ -47487,11 +47530,14 @@ function headWords(m,mg){if(m.state==='paused')return m.text;
 var rd=readingOf('');
 if(mg.n>1){   // several machines: the head sums them up in one line; each machine's own line follows
 var bad=mg.machines.filter(function(x){return x.dot==='errors';}).map(function(x){return x.host||'this machine';});
-if(bad.length)return 'Errors on '+bad.join(', ');
+var away=mg.machines.filter(function(x){return x.stale;}).map(function(x){return x.host||'this machine';});   // named, not counted
+if(bad.length)return 'Errors on '+bad.join(', ')+(away.length?'; '+away.join(', ')+' not reachable':'');
+if(away.length)return (mg.dot==='quiet'?'No API traffic':'Fine')+' on the reachable machines; '+away.join(', ')+' not reachable.';
 if(mg.dot==='quiet')return 'No API traffic on any machine.';
 return 'All '+mg.n+' machines fine.';}
 if(mg.dot==='errors'){if(m.state!=='ok')return m.text;   // this machine's frame: sessions waiting on the API, in the kernel's words
-return rd?rd.headline:m.text;}   // the window in errors: the reading's sentence
+if(rd)return rd.headline;   // the window in errors: the reading's sentence once read
+return (m.errs||0)>0?m.errs+' failed attempt'+(m.errs===1?'':'s')+' in the last 15 min.':m.text;}   // before it lands: the frame's own count
 if(rd)return rd.headline;return mg.dot==='quiet'?'No API traffic in the last 15 min.':'Fine.';}
 // a bucket's name for the card: its model family, plus its auth label when another bucket shares the family
 function bname(d,key){var b=(d.buckets||{})[key]||{},fam=b.family||key.split('|')[1]||key,dup=false;
@@ -47511,7 +47557,7 @@ return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}
 function graphHTML(sr){var n=sr.ok.length,W=168,H=48,tot=[],mx=0;
 for(var i=0;i<n;i++){var v=(sr.ok[i]||0)+(sr.rateLimited[i]||0)+(sr.serverErrors[i]||0)+(sr.noStatus[i]||0);tot.push(v);if(v>mx)mx=v;}
 if(mx<=0)return '';
-var steps=[1,2,5,10,20,50,100,200,500,1000],top=steps[steps.length-1];for(var k=0;k<steps.length;k++)if(steps[k]>=mx){top=steps[k];break;}
+var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),m=mx/p,top=(m<=1?1:m<=2?2:m<=5?5:10)*p;   // a 1-2-5 ceiling at any magnitude: the peak is never clipped
 var X=function(i){return (n>1?i/(n-1):0.5)*W;},Y=function(v){return H-1-Math.max(0,Math.min(1,v/top))*(H-2);};
 var line=function(arr,color,op){var pts=[],anyv=false;for(var i=0;i<n;i++){var v=arr[i]||0;if(v)anyv=true;pts.push(X(i).toFixed(1)+','+Y(v).toFixed(1));}
 if(!anyv)return '';return '<polyline points="'+pts.join(' ')+'" fill="none" style="stroke:'+color+'" stroke-width="1.5" vector-effect="non-scaling-stroke"/>'
@@ -47557,6 +47603,8 @@ var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</spa
 if(!HIST)return h+'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div></div>';
 var hs=Object.keys(HIST).sort(localFirst),many=hs.length>1;
 hs.forEach(function(host){var d=HIST[host],name=host||'this machine';
+// a machine whose answer is still in flight: its loader line (alone, the section's loader), never a blank
+if(d&&d.pending){h+=many?'<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot=quiet></i><span class=ah-nm>'+esc(name)+'</span><span class="rl-dots ah-wait"><i></i><i></i><i></i></span></div>':'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div>';return;}
 if(!d||d.error){h+='<div class="ah-line ah-err">Could not read the API history'+(many?' of '+esc(name):'')+': '+esc((d&&d.error)||'no answer')+'</div>';return;}
 var rd=MERGE?MERGE.readHistory(d):null;
 // with several machines each gets its line (the head already carries this machine's when alone)
@@ -47564,7 +47612,7 @@ if(many)h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+levelDot
 if(rd&&rd.sub&&many)h+='<div class="ah-line ru-tip-reset">'+esc(rd.sub)+'</div>';
 var sr=MERGE?MERGE.documentSeries(d):null;if(sr)h+=graphHTML(sr);});
 h+='<div class="ah-line ah-legend">'+LEGEND+'</div>';
-var tr=(loc&&!loc.error)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 this machine':'')+'</span></div>'+tr;
+var tr=(loc&&!loc.error&&!loc.pending)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 this machine':'')+'</span></div>'+tr;
 return h+'</div>';}
 // the cell's description while the hover shows: the state word and its since, then how to reach the rest. Before the
 // answer lands it carries the state word the frame already put on the cell (assistive tech reads the description once,
@@ -47574,7 +47622,7 @@ return h+'</div>';}
 function descText(){var tail=' Press Enter to open it.';var mg=merged();var w=LAST?headWords(LAST,mg):'';
 if(!/[.!?]$/.test(w))w+='.';
 var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;
-if(!HIST)return 'API health: '+w+' Reading the details.'+tail;
+if(!HIST||(HIST['']&&HIST[''].pending))return 'API health: '+w+' Reading the details.'+tail;
 return 'API health: '+w+tail;}
 // full=false is the HOVER: the same reading with no controls. The hover sits under pointer-events:none and hides
 // on mouseleave, so a button there could not be honored; the click is where the actions live.
@@ -47584,8 +47632,8 @@ var h='<div class=ru-tip-win><div class=ru-tip-name><span>API health'+(mg.n>1?' 
 +((m.since&&m.state!=='ok')?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';
 if(m.state==='paused')h+='<div class=ah-line>'+(PAUSE[m.reason]||PAUSE.manual)+'</div>';
 if(rd&&rd.sub&&mg.n===1)h+='<div class="ah-line ru-tip-reset">'+esc(rd.sub)+'</div>';
-// several machines: one line each, the dot in that machine's state, a stale link said plainly
-if(mg.n>1)mg.machines.forEach(function(x){h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+esc(x.dot)+'></i><span class=ah-desc>'+esc(x.text)+(x.stale?' \u00b7 last heard before its link dropped':'')+'</span></div>';});
+// several machines: one line each, the dot in that machine's state (a machine not reachable says so in its line)
+if(mg.n>1)mg.machines.forEach(function(x){h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+esc(x.dot)+'></i><span class=ah-desc>'+esc(x.text)+'</span></div>';});
 if(full)h+=btnHTML(m);
 h+='</div>';
 var rows=m.sessions||[];
@@ -47618,6 +47666,7 @@ try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}}}
 // The shown, unpinned tip is a TOOLTIP (the role, the cell described by the short summary, no aria-modal): a keyboard
 // user who Tabs onto the cell must not meet a modal dialog their focus sits outside of. open() makes it the dialog.
 function show(ev){if(!LAST)return;lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;
+try{window.__rompUsageTipHide&&window.__rompUsageTipHide();}catch(e){}   // the readout's tip yields while ours shows (the cell sits inside it)
 tip.classList.remove('ru-modal');tip.setAttribute('role','tooltip');tip.removeAttribute('aria-modal');
 tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();}
 function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');}
@@ -47643,17 +47692,24 @@ window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}if(!wa
 // document did not change, so no re-read and no flash to the loader's dots
 el.addEventListener('mouseenter',function(ev){if(pinned)return;
 if(tip.style.display==='block'){if(typeof ev.clientX==='number')lastX=ev.clientX;anchor();return;}show(ev);});
-el.addEventListener('mouseleave',function(){if(!pinned)hide();});
+el.addEventListener('mouseleave',function(ev){if(pinned)return;hide();
+// the pointer slid from the dot onto the readout's own figures: the readout's tip comes back (its mouseenter fired
+// before ours and yielded to the dot, so nothing else would show it now); a pointer that left the readout too gets none
+var ru=document.getElementById('rail-usage'),to=ev&&ev.relatedTarget;if(ru&&to&&ru.contains(to)&&window.__rompUsageTipShow)window.__rompUsageTipShow(ev);});
 // keyboard focus shows the hover as the pointer does (the tooltip pattern) and blur hides it; a pinned detail is
 // unmoved, a hover the pointer already opened is left where it anchored, and a focus the browser re-dispatches
 // because the window regained focus while the cell already held it (winFocusEl) is not the user reaching for the cell
-el.addEventListener('focus',function(){if(skipFocus||winFocusEl===el||pinned||tip.style.display==='block')return;show(null);});
-el.addEventListener('blur',function(){if(!pinned)hide();});
-el.addEventListener('click',function(){if(pinned)close();else open();});
+el.addEventListener('focus',function(){if(moving||skipFocus||winFocusEl===el||pinned||tip.style.display==='block')return;show(null);});
+el.addEventListener('blur',function(){if(moving)return;if(!pinned)hide();});
+// the readout re-parents the cell on every repaint (moveApiCell): while it does, the blur and the focus it causes are
+// not the user's, and once it is done a shown hover is re-anchored from the cell's new place
+window.__rompApiCellMoving=function(on){moving=!!on;if(!on&&!pinned&&tip.style.display==='block')anchor();};
+// the cell sits INSIDE the spend readout, whose own click opens the spend modal: ours must not reach it (review find)
+el.addEventListener('click',function(ev){if(ev&&ev.stopPropagation)ev.stopPropagation();if(pinned)close();else open();});
 // Escape on the focused cell dismisses the hover that focus showed, without moving focus (content shown on focus
 // must be dismissible in place); the pinned dialog's Escape lands via _LANDING_ESC_JS, inert while no modal is on
 el.addEventListener('keydown',function(ev){if(ev.key==='Escape'){if(!pinned&&tip.style.display==='block'){ev.preventDefault();hide();}return;}
-if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});
+if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();ev.stopPropagation();if(pinned)close();else open();}});
 // Click-safe across a frame (ui/CLAUDE.md): a frame that lands while a pointer is DOWN over the detail is painted
 // on release, never under the press, so the pressed button survives to its click. A PRIMARY release inside the
 // detail is followed by the click, so the flush waits for it (a swap between mouseup and click would detach the
@@ -49808,7 +49864,10 @@ def _landing():
             "#rail-api[data-dot=errors] .ah-dot,.ah-dot[data-dot=errors]{background:var(--st-blocked-bg,#e5484d);opacity:1}"
             "#rail-api[data-dot=quiet] .ah-dot,.ah-dot[data-dot=quiet]{background:var(--dim,#9aa4ad);opacity:.55}"
             "#rail-api{cursor:pointer;margin:0 1px;padding:4px 2px}"   # a 15px hit target around a 7px dot; sits inside the readout's slot
-            ".ah-slot{display:inline-flex;align-items:center}"
+            # the slot is not a flex item of its own (display:contents), so the readout pays no gap for a dot that is
+            # still hidden and exactly one for a shown one (review find: the API label and the 1-day label sat 14 px
+            # apart before the first frame and jumped when the dot appeared)
+            ".ah-slot{display:contents}"
             # the detail card's own rows, in the tip's font and palette (#ah-tip shares #ru-tip's skin below)
             ".ah-head{gap:7px}.ah-word{font-weight:700;color:#e8eef5}.ah-since{opacity:.55;margin-left:auto}"
             ".ah-line{margin-top:4px;max-width:340px}"

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2551,6 +2551,15 @@ class ApiHealth:
             last = self._last_event_at
         return last is None or (now - last) > max(api_health_config()["windows"])
 
+    def window_errors(self, now: float | None = None) -> int:
+        """Failed attempts (a retry or a give-up) inside the longest window ending at `now` (T301): the frame's
+        `errs`, so the rail's dot reads red for a storm the window still holds while no session waits, and clears
+        the cycle the last failure ages out. Clock-derived like quiet(): the frame that carries it changes then."""
+        now = time.time() if now is None else float(now)
+        lo = now - max(api_health_config()["windows"])
+        with self._lock:
+            return sum(1 for e in self._ring if e.kind != "ok" and lo < e.t <= now)
+
     def snapshot(self, now: float | None = None, uptime_s=None) -> dict:
         """The /api-health payload minus `bootId` (the kernel stamps that from /version's globals; `bootAt`
         is this aggregator's `boot_stamp`, the number every seeded stateSince and every restart row

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2000,6 +2000,38 @@ def api_health_counts(events, now: float, window: int, uptime_s=None) -> dict:
             "rate5xx": None if r5xx is None else round(r5xx, 4)}
 
 
+def api_health_series(events, now: float, window: int, bin_s: int = 60) -> dict:
+    """Attempts per bin over (now - window, now], for the dashboard's graph (T301, the user 2026-09-10, who
+    wanted a storm visible at a glance instead of per-window percentages): `binS` seconds per bin, the last
+    bin ending at `now`, `from` the start of the first. Four parallel arrays, oldest first, one integer per
+    bin: `ok` (successful responses), `rateLimited` (429 attempts), `serverErrors` (529 and other 5xx attempts,
+    the rate5xx numerator), `noStatus` (connection-level failures: the offline class). Other-status errors
+    are counted in `other`. ADDITIVE to the payload (schema 1 unchanged): a reader that ignores it sees the
+    document it always saw. Pure: the same events at the same now give the same arrays."""
+    bin_s = max(1, int(bin_s))
+    n = max(1, int(-(-int(window) // bin_s)))       # ceil(window / bin_s) bins
+    start = now - n * bin_s
+    keys = ("ok", "rateLimited", "serverErrors", "noStatus", "other")
+    out = {k: [0] * n for k in keys}
+    for e in events:
+        if not (start < e.t <= now):
+            continue
+        i = min(n - 1, int((e.t - start) // bin_s))
+        if e.kind == "ok":
+            k = "ok"
+        elif e.cls == "429":
+            k = "rateLimited"
+        elif e.cls in ("529", "5xx"):
+            k = "serverErrors"
+        elif e.cls == "none":
+            k = "noStatus"
+        else:
+            k = "other"
+        out[k][i] += 1
+    out.update({"binS": bin_s, "from": round(start, 3)})
+    return out
+
+
 API_HEALTH_SEVERITY = {"unknown": 0, "healthy": 1, "recovering": 2, "degraded": 3, "thrashing": 4}
 API_HEALTH_RESTART_WHY = "kernel restarted: the event ring is empty"
 
@@ -2510,6 +2542,15 @@ class ApiHealth:
                 pass
 
     # ---- the read ----
+    def quiet(self, now: float | None = None) -> bool:
+        """No API event (attempt, response, give-up) inside the longest window ending at `now`: the rail's gray
+        dot (T301). A clock-derived answer, so the frame that carries it changes at the moment the last event
+        ages out of the window, which is an event of its own."""
+        now = time.time() if now is None else float(now)
+        with self._lock:
+            last = self._last_event_at
+        return last is None or (now - last) > max(api_health_config()["windows"])
+
     def snapshot(self, now: float | None = None, uptime_s=None) -> dict:
         """The /api-health payload minus `bootId` (the kernel stamps that from /version's globals; `bootAt`
         is this aggregator's `boot_stamp`, the number every seeded stateSince and every restart row
@@ -2540,18 +2581,19 @@ class ApiHealth:
             auth, fam = (evs[0].auth, evs[0].family) if evs else (prev["auth"], prev["family"])
             st = api_health_state(evs, now, (prev["state"], prev["since"]) if prev else None, cfg)
             wins = {str(w): api_health_counts(evs, now, w, uptime_s) for w in cfg["windows"]}
+            series = api_health_series(evs, now, max(cfg["windows"]))   # the graph's per-minute bins (T301)
             last_err = None
             for e in reversed(evs):
                 if e.kind != "ok":
                     last_err = {"at": round(e.t, 3), "status": e.status, "category": e.category or None,
                                 "class": e.cls, "kind": e.kind}
                     break
-            derived.append((key, auth, fam, prev, st, wins, last_err))
+            derived.append((key, auth, fam, prev, st, wins, last_err, series))
         buckets = {}
         worst, worst_key = "unknown", None
         filed = False
         with self._lock:
-            for key, auth, fam, prev, st, wins, last_err in derived:
+            for key, auth, fam, prev, st, wins, last_err, series in derived:
                 cur = self._last_state.get(key)
                 if cur != prev:
                     rec = cur                    # a concurrent read filed this bucket first: its record stands
@@ -2569,7 +2611,7 @@ class ApiHealth:
                                 "state": rec["state"], "stateSince": round(rec["since"], 3),
                                 "evidence": rec["evidence"], "why": rec["why"],
                                 "transitions": list(self._by_bucket.get(key, ())),
-                                "lastError": last_err}
+                                "lastError": last_err, "series": series}
                 if API_HEALTH_SEVERITY[rec["state"]] > API_HEALTH_SEVERITY[worst] or worst_key is None:
                     worst, worst_key = rec["state"], key
             if filed:

--- a/tests/test_api_health_browser.py
+++ b/tests/test_api_health_browser.py
@@ -68,7 +68,7 @@ const R = await page.evaluate((SID) => {
   const R = { err: {} };
   window.__realShellSend = window.__rompShellSend;             // the page's own binding, before the steps stub it
   const step = (name, fn) => { try { fn(); } catch (e) { R.err[name] = String(e && e.stack || e); } };
-  const el = document.getElementById("rail-api"), txt = el.querySelector(".ah-text");
+  const el = document.getElementById("rail-api");   // T301: a dot alone, its state on data-dot; no text beside it
   const tip = () => document.getElementById("ah-tip");
   const back = document.getElementById("ru-back");
   const disp = (n) => getComputedStyle(n).display;
@@ -87,7 +87,7 @@ const R = await page.evaluate((SID) => {
   R.role = el.getAttribute("role"); R.tabindex = el.getAttribute("tabindex");
   // 2. the first frame reveals it and names the state for a screen reader
   window.__rompApiHealth(frame());
-  R.firstFrameDisplay = disp(el); R.firstFrameText = txt.textContent; R.ariaLabel = el.getAttribute("aria-label");
+  R.firstFrameDisplay = disp(el); R.firstFrameDot = el.getAttribute("data-dot"); R.firstFrameText = el.textContent.trim(); R.ariaLabel = el.getAttribute("aria-label");
   step('hover', () => {
   // 3. the hover surface is inert: no button, no data-act; a growing frame re-anchors it above the rail
   el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, clientX: el.getBoundingClientRect().left + 10 }));
@@ -348,7 +348,7 @@ await step2('socket', async () => {
   await open(1);
   R.sock1Ready = (await sock(1)).sent;
   await feed(1, PAUSED);
-  R.sockPainted = await page.evaluate(() => document.getElementById("rail-api").querySelector(".ah-text").textContent);
+  R.sockPainted = await page.evaluate(() => document.getElementById("rail-api").getAttribute("data-dot"));
   await page.evaluate(() => { document.getElementById("rail-api").click(); });
   await press();
   R.sockPressSent = (await sock(1)).sent;
@@ -431,15 +431,17 @@ class ServedCell(unittest.TestCase):
         self.assertTrue(self.R["preFrameHidden"], "the markup ships the attribute")
         self.assertEqual(self.R["preFrameDisplay"], "none", "and the attribute must actually hide it: %r" % self.R)
         self.assertEqual(self.R["firstFrameDisplay"], "flex", "the first frame reveals the cell")
-        self.assertEqual(self.R["firstFrameText"], "overloaded · 1 waiting")
+        self.assertEqual(self.R["firstFrameDot"], "errors", "a degraded frame paints the errors dot (T301)")
+        self.assertEqual(self.R["firstFrameText"], "", "a dot alone: no word beside it")
 
     def test_the_driver_hit_no_script_error(self):
         self.assertEqual(self.R["err"], {})
 
-    def test_the_light_theme_gives_the_ok_dot_the_label_color(self):
-        # .ah-dot's dark label gray at .55 blends into the light rail (about 1.4:1), so the ok glyph would vanish
-        self.assertEqual(self.R["lightDot"], "rgb(93, 87, 78)", "errors: %r" % self.R.get("err"))
-        self.assertEqual(self.R["lightDotOpacity"], "0.55")
+    def test_the_light_theme_gives_the_fine_dot_its_accent(self):
+        # T301: an ok frame with no history read yet is the FINE dot, the theme's accent (the light clay, not the dark
+        # sky blue); the quiet gray (rgb(93, 87, 78), the light label colour) is pinned in tests/test_api_health_fleet.py
+        self.assertEqual(self.R["lightDot"], "rgb(194, 65, 12)", "errors: %r" % self.R.get("err"))
+        self.assertEqual(self.R["lightDotOpacity"], "1")
 
     def test_an_emptied_usage_cell_takes_no_gap(self):
         # renderRows empties #rail-usage on a login-only machine; as a zero-width flex item it would still pay the
@@ -448,7 +450,7 @@ class ServedCell(unittest.TestCase):
 
     def test_the_cell_is_a_keyboard_reachable_button_that_names_its_state(self):
         self.assertEqual((self.R["role"], self.R["tabindex"]), ("button", "0"))
-        self.assertEqual(self.R["ariaLabel"], "API overloaded · 1 waiting")
+        self.assertEqual(self.R["ariaLabel"], "API health: errors")
         self.assertTrue(self.R["kbOpened"], "Enter opens the pinned detail: %r" % self.R.get("err"))
         self.assertTrue(self.R["kbFocusInTip"], "focus moves into the detail")
         self.assertEqual(self.R["tipRole"], "dialog")
@@ -511,10 +513,11 @@ class ServedCell(unittest.TestCase):
     def test_the_light_theme_keeps_the_head_dot_s_state_colors(self):
         # a bare light rule on the dot would outrank the state rules, so the detail's headline dot would read the
         # label gray while the rail's id-scoped dot kept amber and red
-        amber, red, gray = "rgb(230, 126, 34)", "rgb(229, 72, 77)", "rgb(93, 87, 78)"
-        self.assertEqual(self.R["lightDegraded"], {"rail": amber, "head": amber, "headOpacity": "1"}, "errors: %r" % self.R.get("err"))
+        # T301: degraded and paused are both the ERRORS dot (the blocked red); ok is the fine dot (the accent)
+        red, accent = "rgb(229, 72, 77)", "rgb(194, 65, 12)"
+        self.assertEqual(self.R["lightDegraded"], {"rail": red, "head": red, "headOpacity": "1"}, "errors: %r" % self.R.get("err"))
         self.assertEqual(self.R["lightPaused"], {"rail": red, "head": red})
-        self.assertEqual(self.R["lightOkHead"], {"head": gray, "headOpacity": "0.55"})
+        self.assertEqual(self.R["lightOkHead"], {"head": accent, "headOpacity": "1"})
 
     def test_the_driver_s_second_phase_hit_no_error(self):
         self.assertEqual(self.R["err2"], {})
@@ -557,7 +560,7 @@ class ServedCell(unittest.TestCase):
         self.assertEqual(R["shellSendRestored"], "function", "the shell's own send survives the driver's stubs")
         self.assertEqual(R["sockRedialed"], 2, "a close redials")
         self.assertEqual(R["sock1Ready"], [ready], "the open sends ready")
-        self.assertEqual(R["sockPainted"], "paused · usage limit · 1 waiting", "a frame on the socket paints the cell")
+        self.assertEqual(R["sockPainted"], "errors", "a frame on the socket paints the cell (T301: a paused frame is the errors dot)")
         self.assertEqual(R["sockPressSent"], [ready, pressed], "the press rode the real socket")
         self.assertEqual(R["sockAcked"], {"disabled": True, "label": "Stop all auto-retries", "acted": True, "hint": ""})
         self.assertEqual(R["sockDropped"], {"disabled": False, "label": "Resume all auto-retries", "acted": False,

--- a/tests/test_api_health_browser.py
+++ b/tests/test_api_health_browser.py
@@ -113,6 +113,35 @@ const R = await page.evaluate((SID) => {
   R.kbClosed = tip().style.display === "none" && !back.classList.contains("on");
   R.kbFocusBack = document.activeElement === el;
   });
+  step('inside', () => {
+  // 4b. the cell sits inside the spend readout (T301 review): its click must not reach the readout's own click (the
+  // spend modal), the readout's tip yields while the dot's shows and comes back when the pointer slides onto the
+  // figures, and the readout's repaint (a move of the cell) keeps focus and a focus-shown hover
+  const ru = document.getElementById("rail-usage"); let bubbled = 0; ru.addEventListener("click", () => { bubbled++; });
+  let hid = 0, shown = 0; window.__rompUsageTipHide = () => { hid++; }; window.__rompUsageTipShow = () => { shown++; };
+  ru.appendChild(el);
+  el.click();
+  R.insideOpened = tip().style.display === "block" && tip().classList.contains("ru-modal"); R.insideBubbled = bubbled;
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  el.focus(); el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+  R.insideKbOpened = tip().classList.contains("ru-modal"); R.insideKbBubbled = bubbled;
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  el.blur();
+  const hid0 = hid;   // the focus above showed the hover once already (and hid the readout's tip then)
+  el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, clientX: el.getBoundingClientRect().left + 10 }));
+  R.usageTipHidOnEnter = hid - hid0;
+  el.dispatchEvent(new MouseEvent("mouseleave", { relatedTarget: ru }));
+  R.usageTipBackOnLeave = shown; R.dotTipHiddenAfterLeave = tip().style.display === "none";
+  el.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false, clientX: el.getBoundingClientRect().left + 10 }));
+  el.dispatchEvent(new MouseEvent("mouseleave", { relatedTarget: document.body }));
+  R.usageTipBackOnLeaveOutside = shown;
+  el.focus();
+  R.focusShown = tip().style.display === "block" && !tip().classList.contains("ru-modal");
+  window.__rompApiCellMoving(true); document.body.appendChild(el); ru.appendChild(el); el.focus({ preventScroll: true }); window.__rompApiCellMoving(false);
+  R.movedKeptFocus = document.activeElement === el; R.movedKeptHover = tip().style.display === "block" && !tip().classList.contains("ru-modal");
+  el.blur();
+  R.blurHidesAfterMove = tip().style.display === "none";
+  });
   step('usage', () => {
   // 5. an open usage modal is closed first, explicitly, so the shared backdrop never serves two modals
   let usageClosed = false;
@@ -439,7 +468,7 @@ class ServedCell(unittest.TestCase):
 
     def test_the_light_theme_gives_the_fine_dot_its_accent(self):
         # T301: an ok frame with no history read yet is the FINE dot, the theme's accent (the light clay, not the dark
-        # sky blue); the quiet gray (rgb(93, 87, 78), the light label colour) is pinned in tests/test_api_health_fleet.py
+        # sky blue); the quiet gray (rgb(93, 87, 78), the light label colour) is pinned in tests/test_api_health_hosts.py
         self.assertEqual(self.R["lightDot"], "rgb(194, 65, 12)", "errors: %r" % self.R.get("err"))
         self.assertEqual(self.R["lightDotOpacity"], "1")
 
@@ -509,6 +538,24 @@ class ServedCell(unittest.TestCase):
         # the page's own __rompShellSend, not a stub: no socket was ever opened, so it refuses and the row says why
         self.assertEqual(self.R["rowDead"], {"hintBefore": "", "open": True, "hint": "Not sent: the dashboard is disconnected. Try again."},
                          "errors: %r" % self.R.get("err"))
+
+    def test_a_click_inside_the_spend_readout_opens_the_detail_and_never_reaches_the_readout_s_own_click(self):
+        self.assertTrue(self.R["insideOpened"])
+        self.assertEqual(self.R["insideBubbled"], 0, "the click did not bubble to #rail-usage (the spend modal)")
+        self.assertTrue(self.R["insideKbOpened"])
+        self.assertEqual(self.R["insideKbBubbled"], 0)
+
+    def test_the_readout_s_tip_yields_to_the_dot_s_and_comes_back_when_the_pointer_slides_onto_the_figures(self):
+        self.assertEqual(self.R["usageTipHidOnEnter"], 1, "the dot's show hides the readout's tip")
+        self.assertEqual(self.R["usageTipBackOnLeave"], 1, "a leave onto the readout asks for its tip back")
+        self.assertTrue(self.R["dotTipHiddenAfterLeave"])
+        self.assertEqual(self.R["usageTipBackOnLeaveOutside"], 1, "a leave out of the readout asks for nothing")
+
+    def test_the_readout_s_repaint_moves_the_cell_without_losing_focus_or_a_focus_shown_hover(self):
+        self.assertTrue(self.R["focusShown"])
+        self.assertTrue(self.R["movedKeptFocus"], "focus is put back after the move")
+        self.assertTrue(self.R["movedKeptHover"], "the blur the move caused was not the user's")
+        self.assertTrue(self.R["blurHidesAfterMove"], "a real blur still hides it")
 
     def test_the_light_theme_keeps_the_head_dot_s_state_colors(self):
         # a bare light rule on the dot would outrank the state rules, so the detail's headline dot would read the

--- a/tests/test_api_health_fleet.py
+++ b/tests/test_api_health_fleet.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""T301 (the user 2026-09-10): the API-health signal covers EVERY connected kernel. Kernel half:
+  - GET /api-health/frame serves this kernel's last apiHealth shell frame, its local half only (no `hosts`),
+    authed, 503 before the first cycle;
+  - the tunnel supervisor's poll of an attached host's frame (_poll_remote_api_health) is rate-gated, keeps
+    the last reading on a blip and clears it when the host answers that it has none;
+  - the shell frame carries every cached remote frame under `hosts` as a per-host MAP with a `stale` mark,
+    and an unchanged fleet yields an identical frame (no push);
+  - GET /remote/<host>/api-health relays one read of an attached host's document: 404 for an unknown host, the
+    remote's own token in the forwarded request, the status and JSON passed through, 502 on a dead tunnel;
+  - the snapshot's additive per-bucket `series` (api_health_series) bins attempts per minute over the slow
+    window, oldest first, with the last bin ending at asOf.
+Synthetic hosts (TESTHOST, PEERHOST), placeholder ids, hermetic state."""
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+# the rail test's kernel load (hermetic XDG, ROMP_SERVE_TOKEN, NO_OPEN) and its frame fixture: ONE kernel module for
+# the fixture's patched seams and these routes alike
+from tests.test_api_health_rail import _Fixture, km  # noqa: E402
+sys.path.insert(0, os.path.join(ROOT, "kernel"))
+import sdk_backend as sb  # noqa: E402
+
+REMOTE_TOKEN = "remote-token-DO-NOT-USE"
+FRAME_A = {"type": "apiHealth", "state": "degraded", "cls": "429", "text": "rate limited · 2 waiting", "waiting": 2,
+           "retrying": 2, "blocked": 0, "since": 1000, "reason": "", "tmux": 0, "sessions": [], "seq": 3}
+DOC = {"schema": 1, "asOf": 2000.0, "overall": {"state": "healthy", "worstBucket": "key:helper|fable"}, "buckets": {}}
+
+
+class _FakeRemote(BaseHTTPRequestHandler):
+    """A remote kernel that serves /api-health (the document) and /api-health/frame (its frame) to the right
+    token only, and records what it was asked."""
+    frame = FRAME_A
+    doc = DOC
+    seen = []
+
+    def do_GET(self):
+        _FakeRemote.seen.append((self.path, self.headers.get("X-Romp-Token")))
+        tok = self.headers.get("X-Romp-Token") or (self.path.split("token=")[1].split("&")[0] if "token=" in self.path else "")
+        if tok != REMOTE_TOKEN:
+            self.send_response(401); self.end_headers(); self.wfile.write(b"bad token"); return
+        if self.path.startswith("/api-health/frame"):
+            body = json.dumps(_FakeRemote.frame).encode() if _FakeRemote.frame else b""
+            if not _FakeRemote.frame:
+                self.send_response(503); self.end_headers(); self.wfile.write(b'{"error":"no frame"}'); return
+        elif self.path.startswith("/api-health"):
+            body = json.dumps(_FakeRemote.doc).encode()
+        else:
+            self.send_response(404); self.end_headers(); self.wfile.write(b"nope"); return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+def _free_port():
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); p = s.getsockname()[1]; s.close(); return p
+
+
+class HostsMap(_Fixture):
+    """The frame's per-host map, from the supervisor's cached remote frames."""
+
+    def setUp(self):
+        super().setUp()
+        with km._remotes_lock:
+            self._saved = dict(km._remotes)
+            km._remotes.clear()
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.clear()
+            km._remotes.update(self._saved)
+        super().tearDown()
+
+    def _row(self, host, frame, status="up"):
+        with km._remotes_lock:
+            km._remotes[host] = {"host": host, "kernel_port": 1, "local_port": 1, "token": REMOTE_TOKEN,
+                                 "status": status, "apiHealth": frame}
+
+    def test_no_attached_host_gives_an_empty_map_and_the_local_scalars_stand(self):
+        f = self.frame()
+        self.assertEqual(f["hosts"], {})
+        self.assertEqual(f["state"], "ok")
+        self.assertIs(f["quiet"], True, "the fixture has no SDK backend traffic: quiet")
+
+    def test_quiet_follows_the_aggregator_s_last_event(self):
+        ah = sb.ApiHealth(Path(self.td.name) / "api-health-state.json") if hasattr(sb, "ApiHealth") else None
+        self.assertIsNotNone(ah)
+        self.assertTrue(ah.quiet(1000.0), "no event yet")
+        with ah._lock:
+            ah._last_event_at = 1000.0 - 100
+        self.assertFalse(ah.quiet(1000.0), "an event inside the longest window")
+        self.assertTrue(ah.quiet(1000.0 + 901), "aged out of the 900 s window")
+
+    def test_every_cached_remote_frame_rides_under_its_host_with_the_frame_keys_and_a_stale_mark(self):
+        self._row("TESTHOST", FRAME_A)
+        self._row("PEERHOST", dict(FRAME_A, state="ok", cls="", text="ok", waiting=0, retrying=0), status="down")
+        f = self.frame()
+        self.assertEqual(sorted(f["hosts"]), ["PEERHOST", "TESTHOST"])
+        t = f["hosts"]["TESTHOST"]
+        self.assertEqual((t["state"], t["cls"], t["waiting"], t["since"], t["stale"]), ("degraded", "429", 2, 1000, False))
+        self.assertNotIn("quiet", t, "a peer frame that carries no flag gets none invented")
+        self.assertNotIn("sessions", t, "the rows stay on their own kernel: the map carries the summary")
+        self.assertNotIn("seq", t, "a pause-file counter is per kernel and never compared across hosts")
+        self.assertTrue(f["hosts"]["PEERHOST"]["stale"], "a row whose tunnel is not up is marked, its last frame kept")
+        # the LOCAL scalars are this kernel's alone: a remote storm does not change them
+        self.assertEqual((f["state"], f["waiting"]), ("ok", 0))
+
+    def test_an_unchanged_fleet_yields_an_identical_frame_so_nothing_is_pushed_twice(self):
+        self._row("TESTHOST", FRAME_A)
+        a = json.dumps(self.frame(), sort_keys=True)
+        b = json.dumps(self.frame(), sort_keys=True)
+        self.assertEqual(a, b)
+        km._api_health_push(self.frame())
+        km._api_health_push(self.frame())
+        self.assertEqual(len(self.sent), 1, "the second identical frame is not sent")
+
+    def test_the_local_frame_route_serves_the_last_frame_minus_hosts_and_503_before_the_first(self):
+        km._APIH_LAST[0] = None
+        self.assertIsNone(km._apih_local_frame())
+        self._row("TESTHOST", FRAME_A)
+        km._api_health_push(self.frame())
+        f = km._apih_local_frame()
+        self.assertNotIn("hosts", f, "a peer gets this kernel's local half only: no nesting between two attached kernels")
+        self.assertEqual(f["state"], "ok")
+
+
+class RemotePoll(unittest.TestCase):
+    """_poll_remote_api_health against a fake remote."""
+
+    def setUp(self):
+        _FakeRemote.frame, _FakeRemote.seen = FRAME_A, []
+        self.fake = ThreadingHTTPServer(("127.0.0.1", 0), _FakeRemote)
+        threading.Thread(target=self.fake.serve_forever, daemon=True).start()
+        self.row = {"host": "TESTHOST", "local_port": self.fake.server_address[1], "token": REMOTE_TOKEN, "status": "up"}
+
+    def tearDown(self):
+        self.fake.shutdown(); self.fake.server_close()
+
+    def test_the_poll_reads_the_frame_with_the_remote_token_and_is_rate_gated(self):
+        f = km._poll_remote_api_health(self.row)
+        self.assertEqual(f["state"], "degraded")
+        self.assertEqual(len(_FakeRemote.seen), 1)
+        self.assertIn("token=" + REMOTE_TOKEN, _FakeRemote.seen[0][0])
+        self.row["apiHealth"] = f
+        again = km._poll_remote_api_health(self.row)
+        self.assertEqual(again, f, "inside the gate the cached reading comes back")
+        self.assertEqual(len(_FakeRemote.seen), 1, "and the remote is not asked again")
+
+    def test_an_answered_no_frame_clears_and_a_dead_port_keeps_the_last_reading(self):
+        _FakeRemote.frame = None
+        self.assertEqual(km._poll_remote_api_health(dict(self.row)), {}, "503 = answered with no frame: clear")
+        dead = {"host": "TESTHOST", "local_port": _free_port(), "token": REMOTE_TOKEN, "apiHealth": FRAME_A}
+        self.assertEqual(km._poll_remote_api_health(dead), FRAME_A, "no answer keeps the last reading")
+
+
+class Relay(unittest.TestCase):
+    """GET /remote/<host>/api-health through km.Handler."""
+
+    def setUp(self):
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+        _FakeRemote.frame, _FakeRemote.seen = FRAME_A, []
+        self.fake = ThreadingHTTPServer(("127.0.0.1", 0), _FakeRemote)
+        threading.Thread(target=self.fake.serve_forever, daemon=True).start()
+        with km._remotes_lock:
+            self._saved = dict(km._remotes)
+            km._remotes.clear()
+            km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": self.fake.server_address[1],
+                                       "token": REMOTE_TOKEN, "status": "up", "sids": [], "trust": "directed"}
+            km._remotes["DEADHOST"] = {"host": "DEADHOST", "kernel_port": 29855, "local_port": _free_port(),
+                                       "token": REMOTE_TOKEN, "status": "up", "sids": [], "trust": "directed"}
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.clear(); km._remotes.update(self._saved)
+        self.srv.shutdown(); self.srv.server_close()
+        self.fake.shutdown(); self.fake.server_close()
+
+    def _get(self, path, token=True):
+        import http.client
+        c = http.client.HTTPConnection("127.0.0.1", self.srv.server_address[1], timeout=10)
+        c.request("GET", path, headers=({"X-Romp-Token": km.TOKEN} if token else {}))
+        r = c.getresponse(); body = r.read(); ct = r.getheader("Content-Type") or ""; c.close()
+        return r.status, body, ct
+
+    def test_the_document_passes_through_under_our_content_type_with_the_remote_token_rewritten_in(self):
+        st, body, ct = self._get("/remote/TESTHOST/api-health")
+        self.assertEqual(st, 200, body[:200])
+        self.assertEqual(json.loads(body), DOC)
+        self.assertTrue(ct.startswith("application/json"))
+        self.assertEqual(_FakeRemote.seen[-1], ("/api-health", REMOTE_TOKEN), "the remote saw its OWN token, never the browser's")
+
+    def test_an_unknown_host_is_404_and_a_dead_tunnel_is_502(self):
+        st, body, _ = self._get("/remote/NOSUCHHOST/api-health")
+        self.assertEqual(st, 404)
+        self.assertIn(b"no attached host", body)
+        st, body, _ = self._get("/remote/DEADHOST/api-health")
+        self.assertEqual(st, 502)
+        self.assertIn(b"not answering", body)
+
+    def test_the_relay_is_behind_the_local_auth_gate(self):
+        st, _, _ = self._get("/remote/TESTHOST/api-health", token=False)
+        self.assertIn(st, (401, 403))
+        self.assertEqual([s for s in _FakeRemote.seen if s[0] == "/api-health"], [], "an unauthenticated read never reaches the remote")
+
+
+class Series(unittest.TestCase):
+    """api_health_series: per-minute bins over the slow window, additive to the payload."""
+
+    class E:
+        def __init__(self, t, kind, cls="", status=None):
+            self.t, self.kind, self.cls, self.status, self.category = t, kind, cls, status, None
+            self.auth, self.family, self.sid, self.turn = "key:helper", "fable", "s", "t"
+
+    def test_bins_are_oldest_first_with_the_last_ending_at_now_and_the_classes_land_in_their_arrays(self):
+        now = 10000.0
+        E = self.E
+        evs = [E(now - 5, "ok"), E(now - 30, "retry", "429"), E(now - 61, "retry", "5xx"), E(now - 62, "retry", "529"),
+               E(now - 899, "retry", "none"), E(now - 901, "ok"), E(now - 100, "gaveup", "other")]
+        s = sb.api_health_series(evs, now, 900)
+        self.assertEqual((s["binS"], len(s["ok"])), (60, 15))
+        self.assertEqual(s["from"], now - 900)
+        self.assertEqual(s["ok"][-1], 1, "the newest bin holds the event 5 s ago")
+        self.assertEqual(s["rateLimited"][-1], 1)
+        self.assertEqual(s["serverErrors"][-2], 2, "529 and 5xx both count as server errors, in the bin 61-62 s back")
+        self.assertEqual(s["noStatus"][0], 1, "the oldest bin holds the event 899 s back")
+        self.assertEqual(sum(s["ok"]), 1, "an event older than the window is outside every bin")
+        self.assertEqual(s["other"][-2], 1)
+
+    def test_the_snapshot_carries_it_per_bucket_and_the_documented_keys_hold(self):
+        src = Path(ROOT, "kernel", "sdk_backend.py").read_text()
+        self.assertIn('"lastError": last_err, "series": series}', src)
+        doc = Path(ROOT, "docs", "reference.md").read_text()
+        self.assertIn("`series`", doc, "the reference names the additive field")
+
+
+class CellCss(unittest.TestCase):
+    """The rail cell (T301): a dot alone, three states through tokens, no second API word and no ok text."""
+
+    def test_the_dot_s_three_states_wear_the_tokens_and_the_cell_carries_no_text(self):
+        html = km._landing()
+        html = html if isinstance(html, str) else html.decode("utf-8")
+        self.assertIn("#rail-api[data-dot=fine] .ah-dot,.ah-dot[data-dot=fine]{background:var(--accent,#9cd2ff);opacity:1}", html)
+        self.assertIn("#rail-api[data-dot=errors] .ah-dot,.ah-dot[data-dot=errors]{background:var(--st-blocked-bg,#e5484d);opacity:1}", html)
+        self.assertIn("#rail-api[data-dot=quiet] .ah-dot,.ah-dot[data-dot=quiet]{background:var(--dim,#9aa4ad);opacity:.55}", html)
+        self.assertNotIn(".ah-text", html, "no word beside the dot")
+        self.assertNotIn('<span class=ru-name>API</span>', html.split("id=rail-api")[1][:200], "no second API label: the readout's own is the label")
+        self.assertIn('<div id=rail-api class="ru-w ru-ah" hidden role=button tabindex=0 aria-label="API health" data-dot=fine><i class=ah-dot></i></div>', html)
+        # the readout's slot the dot moves into, right after its API label
+        self.assertIn("<div class=ru-name>API</div><span class=ah-slot></span>", html)
+        # the dot lives inside #rail-usage while the readout renders, and that cell's innerHTML is rewritten on every
+        # pull: the usage script parks the dot outside before any write and moves it into the fresh slot after
+        usage = km._LANDING_USAGE_JS
+        self.assertIn("function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];parkApiCell();", usage)
+        self.assertIn("function parkApiCell(){var c=document.getElementById('rail-api');if(c&&el.contains(c)&&RAIL_HOME)RAIL_HOME.insertBefore(c,el.nextSibling);}", usage)
+        self.assertIn("var slot=el.querySelector('.ah-slot');\nif(slot){slot.appendChild(cell);}", usage)
+        self.assertIn("body.theme-light #rail-api[data-dot=quiet] .ah-dot,body.theme-light .ah-dot[data-dot=quiet]{background:#5D574E}", html)
+        self.assertIn("/dist/api-health-global.js?v=", html)
+
+    def test_the_shell_script_reads_every_connected_kernel_and_never_says_unknown(self):
+        js = km._LANDING_APIH_JS
+        self.assertIn("fetchDoc('/remote/'+encodeURIComponent(h)+'/api-health')", js)
+        self.assertIn("MERGE.mergeFrames(LAST,LAST.hosts||{},READINGS)", js)
+        self.assertIn("MERGE.readHistory(d)", js)
+        self.assertNotIn("'unknown'", js.replace("unknown:'quiet'", ""), "the word appears only as the key the plain word replaces")
+        self.assertNotIn("API · this machine", js)
+        self.assertIn("var HIST_ROWS=4;", js)
+        self.assertIn("429 = the API told us to slow down (rate limit)", js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_hosts.py
+++ b/tests/test_api_health_hosts.py
@@ -4,8 +4,11 @@
     authed, 503 before the first cycle;
   - the tunnel supervisor's poll of an attached host's frame (_poll_remote_api_health) is rate-gated, keeps
     the last reading on a blip and clears it when the host answers that it has none;
-  - the shell frame carries every cached remote frame under `hosts` as a per-host MAP with a `stale` mark,
-    and an unchanged fleet yields an identical frame (no push);
+  - the shell frame carries every cached remote frame under `hosts` as a per-host MAP with a `stale` mark (a
+    down tunnel or a refused read, the read's `fault` beside it), and the same hosts in the same states yield an
+    identical frame (no push); its `quiet` and `errs` flags come from the aggregator through the _sdk seam;
+  - a remote's frame, its poll stamp and its fault are per process: never written to the 0600 remotes file (a
+    polled frame must not rewrite the credential file every pass), never restored at boot;
   - GET /remote/<host>/api-health relays one read of an attached host's document: 404 for an unknown host, the
     remote's own token in the forwarded request, the status and JSON passed through, 502 on a dead tunnel;
   - the snapshot's additive per-bucket `series` (api_health_series) bins attempts per minute over the slow
@@ -48,7 +51,7 @@ class _FakeRemote(BaseHTTPRequestHandler):
         _FakeRemote.seen.append((self.path, self.headers.get("X-Romp-Token")))
         tok = self.headers.get("X-Romp-Token") or (self.path.split("token=")[1].split("&")[0] if "token=" in self.path else "")
         if tok != REMOTE_TOKEN:
-            self.send_response(401); self.end_headers(); self.wfile.write(b"bad token"); return
+            self.send_response(403); self.end_headers(); self.wfile.write(b"bad token"); return
         if self.path.startswith("/api-health/frame"):
             body = json.dumps(_FakeRemote.frame).encode() if _FakeRemote.frame else b""
             if not _FakeRemote.frame:
@@ -86,10 +89,39 @@ class HostsMap(_Fixture):
             km._remotes.update(self._saved)
         super().tearDown()
 
-    def _row(self, host, frame, status="up"):
+    def _row(self, host, frame, status="up", fault=None):
         with km._remotes_lock:
             km._remotes[host] = {"host": host, "kernel_port": 1, "local_port": 1, "token": REMOTE_TOKEN,
-                                 "status": status, "apiHealth": frame}
+                                 "status": status}
+            if frame is not None:
+                km._remotes[host]["apiHealth"] = frame
+            if fault:
+                km._remotes[host]["_apih_fault"] = fault
+
+    def test_the_flags_come_from_the_aggregator_through_the_sdk_seam_and_no_backend_is_built(self):
+        class AH:
+            def quiet(self, now): return False
+            def window_errors(self, now): return 3
+        class BE:
+            api_health = AH()
+        before = km._sdk_backend
+        f = self.frame()
+        self.assertEqual((f["quiet"], f["errs"]), (True, 0), "no backend: quiet, nothing failed")
+        self.backend = BE()
+        f = self.frame()
+        self.assertEqual((f["quiet"], f["errs"]), (False, 3), "the aggregator's own answers")
+        self.assertTrue(self.sdk_calls, "the frame asked the seam, not the module singleton")
+        self.assertIs(km._sdk_backend, before, "no SdkBackend was constructed by building a frame")
+
+    def test_a_refused_read_names_the_host_with_its_fault_and_marks_it_stale(self):
+        self._row("TESTHOST", FRAME_A, fault="HTTP 403")
+        self._row("PEERHOST", None, fault="HTTP 500")
+        f = self.frame()
+        t = f["hosts"]["TESTHOST"]
+        self.assertEqual((t["state"], t["fault"], t["stale"]), ("degraded", "HTTP 403", True), "the last frame, marked, never dropped")
+        p = f["hosts"]["PEERHOST"]
+        self.assertEqual((p["fault"], p["stale"]), ("HTTP 500", True))
+        self.assertNotIn("state", p, "no frame was ever heard: the fault alone names the machine")
 
     def test_no_attached_host_gives_an_empty_map_and_the_local_scalars_stand(self):
         f = self.frame()
@@ -120,7 +152,7 @@ class HostsMap(_Fixture):
         # the LOCAL scalars are this kernel's alone: a remote storm does not change them
         self.assertEqual((f["state"], f["waiting"]), ("ok", 0))
 
-    def test_an_unchanged_fleet_yields_an_identical_frame_so_nothing_is_pushed_twice(self):
+    def test_the_same_hosts_in_the_same_states_yield_an_identical_frame_so_nothing_is_pushed_twice(self):
         self._row("TESTHOST", FRAME_A)
         a = json.dumps(self.frame(), sort_keys=True)
         b = json.dumps(self.frame(), sort_keys=True)
@@ -137,6 +169,48 @@ class HostsMap(_Fixture):
         f = km._apih_local_frame()
         self.assertNotIn("hosts", f, "a peer gets this kernel's local half only: no nesting between two attached kernels")
         self.assertEqual(f["state"], "ok")
+
+
+class HostFramesArePerProcess(unittest.TestCase):
+    """A remote's frame, poll stamp and fault never reach the 0600 remotes file and never come back at boot."""
+
+    def setUp(self):
+        with km._remotes_lock:
+            self._saved = dict(km._remotes)
+            km._remotes.clear()
+            km._remotes["TESTHOST"] = {"host": "TESTHOST", "kernel_port": 29855, "local_port": 1, "token": REMOTE_TOKEN,
+                                       "status": "up", "sids": [], "trust": "directed", "proc": None}
+        km._remotes_save()          # baseline: disk agrees with memory
+
+    def tearDown(self):
+        with km._remotes_lock:
+            km._remotes.clear(); km._remotes.update(self._saved)
+
+    def test_a_polled_frame_its_stamp_and_its_fault_are_not_a_change_to_the_credential_file(self):
+        for k in ("apiHealth", "_apih_at", "_apih_fault"):
+            self.assertIn(k, km._NOT_SAVED)
+        with km._remotes_lock:
+            km._remotes["TESTHOST"]["apiHealth"] = FRAME_A
+            km._remotes["TESTHOST"]["_apih_at"] = 1785272930.0
+            km._remotes["TESTHOST"]["_apih_fault"] = "HTTP 403"
+        self.assertFalse(km._remotes_save_if_changed(),
+                         "a frame polled every pass must not rewrite the 0600 token file every pass (the _usage_at story)")
+        row = json.loads(km.REMOTES_FILE.read_text())[0]
+        for k in ("apiHealth", "_apih_at", "_apih_fault"):
+            self.assertNotIn(k, row)
+
+    def test_a_file_an_older_build_wrote_with_a_frame_loads_without_it_so_a_dead_host_s_last_storm_never_paints_the_dot_at_boot(self):
+        rows = [{"host": "TESTHOST", "kernel_port": 29855, "local_port": 1, "token": REMOTE_TOKEN, "status": "up", "sids": [],
+                 "trust": "directed", "apiHealth": FRAME_A, "_apih_at": 1.0, "_apih_fault": "HTTP 403"}]
+        km.REMOTES_FILE.write_text(json.dumps(rows))
+        with km._remotes_lock:
+            km._remotes.clear()
+        km._remotes_load()
+        with km._remotes_lock:
+            r = dict(km._remotes["TESTHOST"])
+        for k in ("apiHealth", "_apih_at", "_apih_fault"):
+            self.assertNotIn(k, r, "a frame from a process that is gone describes nothing this one knows")
+        self.assertEqual(km._api_health_hosts(), {}, "the host is not on the surface until it answers again")
 
 
 class RemotePoll(unittest.TestCase):
@@ -160,6 +234,14 @@ class RemotePoll(unittest.TestCase):
         again = km._poll_remote_api_health(self.row)
         self.assertEqual(again, f, "inside the gate the cached reading comes back")
         self.assertEqual(len(_FakeRemote.seen), 1, "and the remote is not asked again")
+
+    def test_a_refused_read_keeps_the_last_frame_and_records_the_fault_which_a_good_read_clears(self):
+        row = dict(self.row, token="rotated-token-DO-NOT-USE", apiHealth=FRAME_A)
+        self.assertEqual(km._poll_remote_api_health(row), FRAME_A, "a 403 keeps the last frame: the machine does not vanish")
+        self.assertEqual(row["_apih_fault"], "HTTP 403")
+        row["token"], row["_apih_at"] = REMOTE_TOKEN, 0
+        self.assertEqual(km._poll_remote_api_health(row)["state"], "degraded")
+        self.assertNotIn("_apih_fault", row, "a good read clears the fault")
 
     def test_an_answered_no_frame_clears_and_a_dead_port_keeps_the_last_reading(self):
         _FakeRemote.frame = None
@@ -213,6 +295,27 @@ class Relay(unittest.TestCase):
         self.assertEqual(st, 502)
         self.assertIn(b"not answering", body)
 
+    def test_the_local_frame_route_answers_503_before_the_first_frame_and_the_local_half_after(self):
+        km._APIH_LAST[0] = None
+        saved = km._send_to_app
+        km._send_to_app = lambda app, m: None
+        try:
+            st, body, _ = self._get("/api-health/frame")
+            self.assertEqual(st, 503)
+            self.assertIn(b"no API-health frame yet", body)
+            km._api_health_push(dict(FRAME_A, hosts={"PEERHOST": {"state": "ok", "stale": False}}))
+            st, body, ct = self._get("/api-health/frame")
+            self.assertEqual(st, 200, body[:200])
+            f = json.loads(body)
+            self.assertEqual(f["state"], "degraded")
+            self.assertNotIn("hosts", f, "a peer gets this kernel's local half only")
+            self.assertTrue(ct.startswith("application/json"))
+            st, _, _ = self._get("/api-health/frame", token=False)
+            self.assertIn(st, (401, 403))
+        finally:
+            km._send_to_app = saved
+            km._APIH_LAST[0] = None
+
     def test_the_relay_is_behind_the_local_auth_gate(self):
         st, _, _ = self._get("/remote/TESTHOST/api-health", token=False)
         self.assertIn(st, (401, 403))
@@ -242,9 +345,24 @@ class Series(unittest.TestCase):
         self.assertEqual(sum(s["ok"]), 1, "an event older than the window is outside every bin")
         self.assertEqual(s["other"][-2], 1)
 
-    def test_the_snapshot_carries_it_per_bucket_and_the_documented_keys_hold(self):
-        src = Path(ROOT, "kernel", "sdk_backend.py").read_text()
-        self.assertIn('"lastError": last_err, "series": series}', src)
+    def test_the_snapshot_carries_the_series_per_bucket_from_the_ring_and_the_frame_flags_read_the_same_ring(self):
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        ah = sb.ApiHealth(Path(td.name))
+        now = 10000.0
+        ah.note_ok(now - 5, auth="key:helper", family="fable", sid="s", message_id="m1")
+        ah.note_retry(now - 30, auth="key:helper", family="fable", status=429, sid="s", turn=1)
+        ah.note_retry(now - 61, auth="key:helper", family="fable", status=529, sid="s", turn=1)
+        ah.note_ok(now - 890, auth="key:helper", family="fable", sid="s", message_id="m0")
+        s = ah.snapshot(now)["buckets"]["key:helper|fable"]["series"]
+        self.assertEqual((s["binS"], len(s["ok"]), s["from"]), (60, 15, now - 900))
+        self.assertEqual((s["ok"][-1], s["rateLimited"][-1], s["serverErrors"][-2]), (1, 1, 1))
+        self.assertEqual(s["ok"][0], 1, "the oldest bin holds the response 890 s back")
+        self.assertEqual(sum(s["ok"]) + sum(s["rateLimited"]) + sum(s["serverErrors"]), 4, "every attempt once")
+        # the frame's flags read the same ring: two failed attempts in the window, traffic seen; nothing once it ages out
+        self.assertEqual(ah.window_errors(now), 2)
+        self.assertFalse(ah.quiet(now))
+        self.assertEqual(ah.window_errors(now + 1000), 0)
         doc = Path(ROOT, "docs", "reference.md").read_text()
         self.assertIn("`series`", doc, "the reference names the additive field")
 
@@ -267,14 +385,21 @@ class CellCss(unittest.TestCase):
         # pull: the usage script parks the dot outside before any write and moves it into the fresh slot after
         usage = km._LANDING_USAGE_JS
         self.assertIn("function renderRows(rows,selfHost){ROWS=rows||[];LAST=[];parkApiCell();", usage)
-        self.assertIn("function parkApiCell(){var c=document.getElementById('rail-api');if(c&&el.contains(c)&&RAIL_HOME)RAIL_HOME.insertBefore(c,el.nextSibling);}", usage)
-        self.assertIn("var slot=el.querySelector('.ah-slot');\nif(slot){slot.appendChild(cell);}", usage)
+        self.assertIn("function parkApiCell(){var c=document.getElementById('rail-api');if(c&&el.contains(c)&&RAIL_HOME)moveApiCell(c,function(){RAIL_HOME.insertBefore(c,el.nextSibling);});}", usage)
+        self.assertIn("var slot=el.querySelector('.ah-slot');\nif(slot){moveApiCell(cell,function(){slot.appendChild(cell);});}", usage)
+        # the move keeps focus and tells the dot's script (review find: the minute repaint blurred a focused cell and
+        # hid a focus-shown hover)
+        self.assertIn("function moveApiCell(c,into){var had=document.activeElement===c,mv=window.__rompApiCellMoving;if(mv)mv(true);\ninto();if(had){try{c.focus({preventScroll:true});}catch(e){}}if(mv)mv(false);}", usage)
+        # the readout's tip yields to the dot's and comes back when the pointer slides onto the figures
+        self.assertIn("window.__rompUsageTipHide=function(){tip.style.display='none';};\nwindow.__rompUsageTipShow=function(ev){showTip(ev);};", usage)
+        self.assertIn(".ah-slot{display:contents}", html, "the slot is no flex item: a hidden dot costs the readout no gap")
+        self.assertNotIn(".ah-slot{display:inline-flex", html)
         self.assertIn("body.theme-light #rail-api[data-dot=quiet] .ah-dot,body.theme-light .ah-dot[data-dot=quiet]{background:#5D574E}", html)
         self.assertIn("/dist/api-health-global.js?v=", html)
 
     def test_the_shell_script_reads_every_connected_kernel_and_never_says_unknown(self):
         js = km._LANDING_APIH_JS
-        self.assertIn("fetchDoc('/remote/'+encodeURIComponent(h)+'/api-health')", js)
+        self.assertIn("fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health')", js)
         self.assertIn("MERGE.mergeFrames(LAST,LAST.hosts||{},READINGS)", js)
         self.assertIn("MERGE.readHistory(d)", js)
         self.assertNotIn("'unknown'", js.replace("unknown:'quiet'", ""), "the word appears only as the key the plain word replaces")

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -176,7 +176,7 @@ class Payload(unittest.TestCase):
         m = re.search(r"var HIST_ROWS=(\d+);", JS)
         self.assertIsNotNone(m, "the section caps its rows")
         self.assertLessEqual(int(m.group(1)), sb.API_HEALTH_TRANSITIONS_KEEP, "the section shows a slice of the tail")
-        self.assertEqual(int(m.group(1)), 6, "about six rows: what fits the hover")
+        self.assertEqual(int(m.group(1)), 4, "four rows: a glance, not a log (T301)")
 
     def test_a_restart_files_the_row_the_section_matches(self):
         self.storm(T0 - 600, T0)
@@ -251,8 +251,8 @@ class OneClock(unittest.TestCase):
         self._check(be.api_health.snapshot(T0 + 31), T0 + 30)
         self.assertIn('"bootAt": self.boot_stamp', inspect.getsource(sb.ApiHealth.snapshot))
         self.assertNotIn('out["bootAt"]', inspect.getsource(km.Handler.do_GET))
-        # and the section reads stateSince alone: no why-keyed branch, nothing for it to be dead on
-        self.assertIn("var since=b?b.stateSince:0;", HIST)
+        # and the section keys the divider on bootAt alone: no why-keyed branch, nothing for it to be dead on
+        self.assertIn("boot=d.bootAt,", HIST)
         self.assertNotIn("b.why===RESTART_WHY", HIST)
 
     def test_the_kernel_builds_the_backend_with_its_own_start_as_boot_at(self):
@@ -360,8 +360,7 @@ class OneClock(unittest.TestCase):
         self.assertIn(int(out["bootAt"]), (int(km._STARTED), int(km._STARTED) + 1),
                       "the clamp may cross the second; /version's started stays int(_STARTED)")
         self.assertEqual(len([ln for ln in lines if "not before this boot" in ln]), 1, lines)
-        # the section reads the three from these fields and nothing else, so they show one time
-        self.assertIn("var since=b?b.stateSince:0;", HIST)
+        # the section reads the divider and the restart row from these fields and nothing else, so they show one time
         self.assertIn("boot=d.bootAt,", HIST)
         self.assertIn("<span class=ru-tip-k>'+hmd(boot)+'</span><span class=ah-hword>kernel restarted</span>", HIST)
 
@@ -572,7 +571,8 @@ class Route(unittest.TestCase):
         status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK,
                                                   "Origin": "http://evil.example", "Host": "127.0.0.1:%d" % km.PORT})
         self.assertEqual(status, 403, "a cross-site page's cookie is refused")
-        self.assertIn("fetch('/api-health',{cache:'no-store'})", JS)
+        self.assertIn("fetchDoc('/api-health')", JS)
+        self.assertIn("fetch(u,{cache:'no-store'})", JS)
         self.assertIn("fetch('/usage/fleet',{cache:'no-store'})", km._LANDING_USAGE_JS, "the same shape as the shell's other read")
 
     def test_a_missing_backend_is_a_loud_503_that_the_section_shows_as_its_failure_line(self):
@@ -580,9 +580,10 @@ class Route(unittest.TestCase):
         status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK})
         self.assertEqual(status, 503)
         self.assertIn("error", json.loads(body))
-        self.assertIn("if(!r.ok)throw new Error('HTTP '+r.status);", HIST, "a non-2xx is the failure, with its status")
-        self.assertIn("HIST={error:String((e&&e.message)||e)};", HIST)
-        self.assertIn("Could not read the API history: '+esc(HIST.error)", HIST)
+        self.assertIn("if(!r.ok){var tp=(typeof r.text==='function')?r.text():Promise.resolve('');", HIST, "a non-2xx is the failure, with its status")
+        self.assertIn("return {error:'HTTP '+r.status+(t?", HIST)
+        self.assertIn(".catch(function(e){return {error:String((e&&e.message)||e)};});}", HIST)
+        self.assertIn("Could not read the API history'+(many?' of '+esc(name):'')+': '+esc((d&&d.error)||'no answer')", HIST)
 
 
 class FrameUnchanged(unittest.TestCase):
@@ -609,7 +610,7 @@ class FrameUnchanged(unittest.TestCase):
         km._api_health_push(f1)
         self.assertEqual(len(self.sent), 1)
         self.assertEqual(set(f1), {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked",
-                                   "since", "tmux", "sessions", "seq"}, "the documented keys, nothing added")
+                                   "since", "tmux", "sessions", "seq", "hosts", "quiet"}, "the documented keys, nothing added")
         for k in ("windows", "transitions", "buckets", "history", "overall", "bootAt"):
             self.assertNotIn(k, f1)
         # a hover reads the route in between (the read files a transition: the storm classifies)
@@ -632,9 +633,12 @@ class Docs(unittest.TestCase):
         sec = self._section()
         self.assertIn("**History**", sec)
         self.assertIn("`GET /api-health`", sec)
-        for k in ("`overall.state`", "`stateSince`", "`why`", "`config.windows`", "`requests`", "`rate429`", "`rate5xx`",
-                  "`gaveUp`", "`sessionsRetrying`", "`complete`", "`transitions`", "`asOf`", "`bootAt`"):
+        # T301: the reading counts the failures over the longest window and draws `series`; the state machine's word
+        # is read only through the plain phrasing, so `overall.state` is no longer what the section describes
+        for k in ("`config.windows`", "`requests`", "`noStatus`", "`rateLimited`", "`serverErrors`", "`gaveUp`", "`series`",
+                  "`transitions`", "`asOf`", "`bootAt`", "`hosts`", "`quiet`"):
             self.assertIn(k, sec, k)
+        self.assertNotIn("`overall.state` with", sec, "the machine's word is not what the user reads")
         self.assertIn("`kernel restarted`", sec)
         self.assertIn("never the previous numbers", sec)
         self.assertIn("Nothing polls", sec)
@@ -651,8 +655,9 @@ class Docs(unittest.TestCase):
     def test_the_guide_tells_the_user_what_the_hover_shows(self):
         guide = Path(DOCS, "guide.md").read_text()
         self.assertIn("the history under it", guide)
-        self.assertIn("last 1, 5 and 15 minutes", guide)
+        self.assertIn("the last 15 minutes", guide)
         self.assertIn("A kernel restart shows as its own line there", guide)
+        self.assertIn("every connected kernel", guide)
 
     def test_the_reference_names_the_three_failed_reads(self):
         self.assertIn("A read that fails (a non-2xx, no answer, or an answer without the signal's shape) shows one line "
@@ -684,37 +689,47 @@ class Script(unittest.TestCase):
         self.assertNotIn("setInterval", JS)
         self.assertIn("window.addEventListener('focus',function(){winFocusEl=document.activeElement;requestAnimationFrame(function(){winFocusEl=null;});});", JS,
                       "the window-focus mark is cleared on the next animation frame, an event")
-        self.assertEqual(HIST.count("if(n!==histSeq)return;"), 2, "both arms of the read drop an answer a newer read superseded")
-        self.assertEqual(HIST.count("if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();"), 2,
+        # T301: ONE arm (Promise.all over this machine's document and every attached host's), so one guard of each
+        self.assertEqual(HIST.count("if(n!==histSeq)return;"), 1, "the read drops an answer a newer read superseded")
+        self.assertEqual(HIST.count("if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();"), 1,
                          "the answer repaints an open card only, and never under a held pointer")
+        self.assertIn("Promise.all(reads)", HIST, "every machine's document in one read")
+        self.assertIn(".catch(function(e){return {error:String((e&&e.message)||e)};});}", HIST, "a rejected fetch is that machine's failure line, never an unhandled rejection")
 
     def test_a_failed_read_is_one_line_in_place_of_the_rows(self):
-        self.assertIn("HIST=(d&&d.buckets)?d:{error:'malformed answer'};", HIST, "an answer without the signal's shape is a failure too")
-        self.assertIn("if(HIST.error)return h+'<div class=\"ah-line ah-err\">Could not read the API history: '+esc(HIST.error)+'</div></div>';", HIST,
-                      "the line stands where the rows would, and the function returns before any row")
+        self.assertIn("return (d&&d.buckets)?d:{error:'malformed answer'};", HIST, "an answer without the signal's shape is a failure too")
+        # T301: per machine: the line stands where that machine's reading would, named when there are several
+        self.assertIn("if(!d||d.error){h+='<div class=\"ah-line ah-err\">Could not read the API history'+(many?' of '+esc(name):'')+': '+esc((d&&d.error)||'no answer')+'</div>';return;}", HIST)
         self.assertIn("if(!HIST)return h+'<div class=\"rl-dots ah-wait\"><i></i><i></i><i></i></div></div>';", HIST,
                       "before the first answer: the loader's dots")
 
-    def test_the_rows_wear_the_spend_hover_s_grammar(self):
-        self.assertIn("'<div class=\"ru-tip-win ah-hist\"><div class=ru-tip-name><span>History</span>'", HIST)
-        self.assertIn("'<span class=ru-tip-reset>as of '+hms(HIST.asOf)+'</span>'", HIST, "the payload's asOf on the heading")
-        self.assertIn("'<div class=\"ru-tip-row ah-head\"><i class=ah-dot data-state='+esc(st)+'></i><span class=ah-word>'+esc(st)+'</span>'", HIST)
-        self.assertIn("if(b&&b.why)h+='<div class=\"ah-line ru-tip-reset\">'+esc(b.why)+'</div>';", HIST, "the reason in the small annotation grammar")
-        self.assertIn("((d.config&&d.config.windows)||[60,300,900]).forEach(function(w){h+=winRow(w,(b.windows||{})[String(w)],d.uptimeS);});", HIST,
-                      "the windows come from the config in force")
-        self.assertIn("var lab=(w%60===0?(w/60)+' min':w+' s');if(c&&c.complete===false&&typeof up==='number')lab+=' · kernel up '+dur(up);", HIST)
-        self.assertIn("var v,rq=(c&&c.requests)||0,ns=(c&&c.noStatus)||0;if(!c||!(rq||ns||c.gaveUp||c.sessionsRetrying))v='no attempts';", HIST,
-                      "a window is quiet only when every count is zero")
-        self.assertIn("v+=' · '+(c.gaveUp||0)+' gave up · '+pl(c.sessionsRetrying,'session')+' retried';}", HIST)
-        self.assertNotIn("' retrying'", HIST, "no present-tense label on a windowed count")
-        self.assertIn("'<div class=\"ru-tip-row ah-hrow\"><span class=ru-tip-k>'+esc(lab)+'</span><span class=ru-tip-v>'+esc(v)+'</span></div>'", HIST,
-                      "the spend row's classes")
+    def test_the_section_wears_the_usage_hover_s_grammar_the_graph_the_legend_and_plain_words(self):
+        # T301: no per-window rows; the graph in the usage hover's grammar (polyline + fill, ONE ceiling label, five-minute
+        # ticks), the codes explained once, every machine's line in the small annotation grammar
+        self.assertIn("var h='<div class=\"ru-tip-win ah-hist\"><div class=ru-tip-name><span>History</span>'+asOf+'</div>';", HIST)
+        self.assertIn("'<span class=ru-tip-reset>as of '+hms(loc.asOf)+'</span>'", HIST, "this machine's asOf on the heading")
+        self.assertIn("<span class=ru-tip-k>attempts / min ", HIST)
+        self.assertIn("<span class=ru-tip-v>peak '+mx+'</span></div>'", HIST)
+        self.assertIn("'<div class=ru-tip-graph><svg viewBox=\"0 0 '+W+' '+H+'\" preserveAspectRatio=\"none\">'+grid+body+'</svg>'", HIST, "the usage graph's own container")
+        self.assertIn("'<span class=ru-tip-gy style=\"top:'+(ty/H*56).toFixed(0)+'px\">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}", HIST, "one ceiling label; the ticks under")
+        self.assertIn("line(tot,'var(--accent,#9cd2ff)',0.18)+line(sr.serverErrors,'var(--warn,#e67e22)',0.35)+line(sr.rateLimited,'var(--st-blocked-bg,#e5484d)',0.35)", HIST,
+                      "every attempt in the accent, 5xx in the warn amber, 429 in the blocked red, through the tokens")
+        self.assertIn("var LEGEND='429 = the API told us to slow down (rate limit) ", JS)
+        self.assertIn("5xx = the API itself failed (server error) ", JS)
+        self.assertIn("offline = no connection';", JS)
+        self.assertIn("h+='<div class=\"ah-line ah-legend\">'+LEGEND+'</div>';", HIST, "the legend stands under the graphs, once")
+        self.assertIn("if(many)h+='<div class=\"ru-tip-row ah-mline\"><i class=ah-dot data-dot='+levelDot(rd)+'></i><span class=ah-nm>'+esc(name)+'</span><span class=ah-desc>'+esc(rd?rd.headline:'')+'</span></div>';", HIST,
+                      "several machines: one line each, that machine's own reading")
+        self.assertNotIn("winRow", JS, "the per-window rows are gone")
+        self.assertNotIn("worst of", JS, "and the bucket-count caveat with them")
+        self.assertNotIn("kernel up", JS, "and the uptime caveat")
         self.assertEqual(sb._AH_COUNTED, ("ok", "429", "529", "5xx", "other"),
                          "requests excludes 'none', so requests plus noStatus counts every attempt once")
         self.assertIn("rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}\nh+=histHTML();\nif(m.tmux>0)h+=", JS,
                       "the section sits after the sessions waiting and before the tmux line, in hover and detail alike")
 
-    def test_the_tail_holds_six_rows_newest_first_each_state_s_hold_and_a_restart_never_hidden(self):
+    def test_the_tail_holds_four_rows_newest_first_in_plain_words_each_state_s_hold_and_a_restart_never_hidden(self):
+        self.assertIn("var HIST_ROWS=4;", JS, "T301: a glance, not a log")
         self.assertIn(".sort(function(a,b){return b.t-a.t;})", HIST, "newest first")
         self.assertIn("var end=now,cur=true;for(var j=i-1;j>=0;j--)if(rows[j].bucket===r.bucket){end=rows[j].t;cur=false;break;}", HIST,
                       "a state holds until the SAME bucket's next change")
@@ -724,7 +739,8 @@ class Script(unittest.TestCase):
         self.assertIn("pre=hasBoot&&r.t<boot;", HIST)
         self.assertIn("if(restart)sawRestart=true;shown++;}", HIST, "any restart row above suppresses the divider")
         self.assertEqual(HIST.count("shown++"), 1, "shown counts transition rows only: the divider takes no slot")
-        self.assertIn("var word=(multi?bname(d,r.bucket)+' ':'')+r.to", HIST, "a bucket is named only when there are several")
+        self.assertIn("var word=(multi?bname(d,r.bucket)+' ':'')+(STATE_WORD[r.to]||r.to)", HIST, "a bucket is named only when there are several; the state in plain words")
+        self.assertIn("var STATE_WORD={thrashing:'rate-limit storm',degraded:'API failing',recovering:'recovering',healthy:'fine',unknown:'quiet'};", JS)
         self.assertIn("return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}", HIST, "two of one family are told apart by auth")
 
     def test_the_roles_follow_the_mode_and_the_cell_is_described_by_the_short_summary(self):
@@ -732,8 +748,11 @@ class Script(unittest.TestCase):
         self.assertNotIn("winFocus=true", JS, "the mark is an element, not a flag")
         self.assertIn("var desc=document.createElement('span');desc.id='ah-summary';desc.className='ah-vh';document.body.appendChild(desc);", JS)
         self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();desc.textContent=descText();", JS, "refreshed on every render")
-        self.assertIn("function descText(){var tail=' Press Enter to open it.';if(!HIST)return 'History: '+((LAST&&LAST.text)||'unknown')+'. Reading the details.'+tail;", HIST)
-        self.assertIn("return 'History: '+(ov.state||'unknown')+((b&&b.stateSince)?' since '+hmd(b.stateSince):'')+'.'+tail;}", HIST)
+        # T301: the description is the head's plain words, a failed read said as such, and the read in flight named
+        self.assertIn("function descText(){var tail=' Press Enter to open it.';var mg=merged();var w=LAST?headWords(LAST,mg):'';", HIST)
+        self.assertIn("var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;", HIST)
+        self.assertIn("if(!HIST)return 'API health: '+w+' Reading the details.'+tail;\nreturn 'API health: '+w+tail;}", HIST)
+        self.assertNotIn("'unknown'", HIST.replace("unknown:'quiet'", ""), "the machine's word never reaches the description")
         self.assertNotIn("'aria-describedby','ah-tip'", JS, "the tip's whole text is never the description")
         self.assertIn("tip.setAttribute('role','tooltip');tip.setAttribute('aria-label','API health');tip.tabIndex=-1;", JS, "created as a tooltip")
         self.assertIn("tip.classList.remove('ru-modal');tip.setAttribute('role','tooltip');tip.removeAttribute('aria-modal');", JS, "show: tooltip")
@@ -753,12 +772,16 @@ class Skin(unittest.TestCase):
     def setUpClass(cls):
         cls.html = km._landing()
 
-    def test_the_dot_wears_status_hexes_never_the_accent_and_the_rows_are_quiet(self):
-        self.assertIn(".ah-dot[data-state=thrashing]{background:#e5484d;opacity:1}.ah-dot[data-state=recovering]{background:#e67e22;opacity:.7}", self.html)
-        rules = re.findall(r"[^{}]*\.ah-(?:dot|err)[^{}]*\{[^}]*\}", self.html)
-        self.assertGreater(len(rules), 3)
+    def test_the_dot_wears_the_accent_when_fine_the_status_tokens_otherwise_and_the_rows_are_quiet(self):
+        # T301 (the user 2026-09-10): the fine dot IS the romp accent; errors wear the blocked red, quiet the label gray;
+        # every colour through a token with a fallback for a var-less harness
+        self.assertIn("#rail-api[data-dot=fine] .ah-dot,.ah-dot[data-dot=fine]{background:var(--accent,#9cd2ff);opacity:1}", self.html)
+        self.assertIn("#rail-api[data-dot=errors] .ah-dot,.ah-dot[data-dot=errors]{background:var(--st-blocked-bg,#e5484d);opacity:1}", self.html)
+        self.assertIn("#rail-api[data-dot=quiet] .ah-dot,.ah-dot[data-dot=quiet]{background:var(--dim,#9aa4ad);opacity:.55}", self.html)
+        self.assertNotIn("data-state=thrashing", self.html, "the machine's words are not colours any more")
+        rules = re.findall(r"[^{}]*\.ah-err[^{}]*\{[^}]*\}", self.html)
         for rule in rules:
-            self.assertNotIn("var(--accent)", rule, rule)
+            self.assertNotIn("var(--accent", rule, "the failure line is never the accent: " + rule)
         self.assertIn(".ah-hword{opacity:.8}.ah-hsub{opacity:.55}.ah-boot .ah-hword{font-style:italic;opacity:.6}", self.html)
         self.assertIn(".ah-hname{margin-top:6px}.ah-err{color:#ef6b6f}.ah-wait{margin:5px 0 2px}", self.html)
         self.assertIn("body.theme-light .ah-err{color:#B02A1C}", self.html, "the light theme's error-text red")

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -571,7 +571,7 @@ class Route(unittest.TestCase):
         status, body = _serve_get("/api-health", {"Cookie": "romp_token=" + TOK,
                                                   "Origin": "http://evil.example", "Host": "127.0.0.1:%d" % km.PORT})
         self.assertEqual(status, 403, "a cross-site page's cookie is refused")
-        self.assertIn("fetchDoc('/api-health')", JS)
+        self.assertIn("fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health')", JS)
         self.assertIn("fetch(u,{cache:'no-store'})", JS)
         self.assertIn("fetch('/usage/fleet',{cache:'no-store'})", km._LANDING_USAGE_JS, "the same shape as the shell's other read")
 
@@ -610,7 +610,7 @@ class FrameUnchanged(unittest.TestCase):
         km._api_health_push(f1)
         self.assertEqual(len(self.sent), 1)
         self.assertEqual(set(f1), {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked",
-                                   "since", "tmux", "sessions", "seq", "hosts", "quiet"}, "the documented keys, nothing added")
+                                   "since", "tmux", "sessions", "seq", "hosts", "quiet", "errs"}, "the documented keys, nothing added")
         for k in ("windows", "transitions", "buckets", "history", "overall", "bootAt"):
             self.assertNotIn(k, f1)
         # a hover reads the route in between (the read files a transition: the storm classifies)
@@ -673,7 +673,7 @@ class Script(unittest.TestCase):
     def test_the_history_is_the_one_read_fired_by_the_show_the_open_from_hidden_and_a_frame_on_an_open_card(self):
         self.assertTrue(HIST, "the cell's script carries a History block")
         self.assertEqual(JS.count("fetch("), 1, "one read in the cell's script: the history's")
-        self.assertIn("function load(fresh){var n=++histSeq;if(fresh)HIST=null;", HIST)
+        self.assertIn("function load(fresh){var n=++histSeq,names=[''].concat(hostsOf(LAST)),by={};", HIST)
         self.assertIn("tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();}", JS,
                       "show drops the last answer and reads")
         self.assertIn("var was=tip.style.display==='block';", JS)
@@ -689,11 +689,11 @@ class Script(unittest.TestCase):
         self.assertNotIn("setInterval", JS)
         self.assertIn("window.addEventListener('focus',function(){winFocusEl=document.activeElement;requestAnimationFrame(function(){winFocusEl=null;});});", JS,
                       "the window-focus mark is cleared on the next animation frame, an event")
-        # T301: ONE arm (Promise.all over this machine's document and every attached host's), so one guard of each
+        # T301: one read per machine (this machine's document and every attached host's, each landing on its own), so one guard of each
         self.assertEqual(HIST.count("if(n!==histSeq)return;"), 1, "the read drops an answer a newer read superseded")
         self.assertEqual(HIST.count("if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();"), 1,
                          "the answer repaints an open card only, and never under a held pointer")
-        self.assertIn("Promise.all(reads)", HIST, "every machine's document in one read")
+        self.assertIn("names.forEach(function(h){fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health')", HIST, "one read per machine, each landing on its own")
         self.assertIn(".catch(function(e){return {error:String((e&&e.message)||e)};});}", HIST, "a rejected fetch is that machine's failure line, never an unhandled rejection")
 
     def test_a_failed_read_is_one_line_in_place_of_the_rows(self):
@@ -744,14 +744,14 @@ class Script(unittest.TestCase):
         self.assertIn("return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}", HIST, "two of one family are told apart by auth")
 
     def test_the_roles_follow_the_mode_and_the_cell_is_described_by_the_short_summary(self):
-        self.assertIn("el.addEventListener('focus',function(){if(skipFocus||winFocusEl===el||pinned||tip.style.display==='block')return;show(null);});", JS)
+        self.assertIn("el.addEventListener('focus',function(){if(moving||skipFocus||winFocusEl===el||pinned||tip.style.display==='block')return;show(null);});", JS)
         self.assertNotIn("winFocus=true", JS, "the mark is an element, not a flag")
         self.assertIn("var desc=document.createElement('span');desc.id='ah-summary';desc.className='ah-vh';document.body.appendChild(desc);", JS)
         self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();desc.textContent=descText();", JS, "refreshed on every render")
         # T301: the description is the head's plain words, a failed read said as such, and the read in flight named
         self.assertIn("function descText(){var tail=' Press Enter to open it.';var mg=merged();var w=LAST?headWords(LAST,mg):'';", HIST)
         self.assertIn("var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;", HIST)
-        self.assertIn("if(!HIST)return 'API health: '+w+' Reading the details.'+tail;\nreturn 'API health: '+w+tail;}", HIST)
+        self.assertIn("if(!HIST||(HIST['']&&HIST[''].pending))return 'API health: '+w+' Reading the details.'+tail;\nreturn 'API health: '+w+tail;}", HIST)
         self.assertNotIn("'unknown'", HIST.replace("unknown:'quiet'", ""), "the machine's word never reaches the description")
         self.assertNotIn("'aria-describedby','ah-tip'", JS, "the tip's whole text is never the description")
         self.assertIn("tip.setAttribute('role','tooltip');tip.setAttribute('aria-label','API health');tip.tabIndex=-1;", JS, "created as a tooltip")
@@ -759,7 +759,7 @@ class Script(unittest.TestCase):
         self.assertIn("tip.setAttribute('role','dialog');tip.setAttribute('aria-modal','true');el.removeAttribute('aria-describedby');", JS, "open: dialog")
         self.assertEqual(JS.count("'aria-modal'"), 2, "set by open, removed by show, nowhere else")
         self.assertIn("function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');}", JS)
-        self.assertIn("el.addEventListener('blur',function(){if(!pinned)hide();});", JS)
+        self.assertIn("el.addEventListener('blur',function(){if(moving)return;if(!pinned)hide();});", JS)
         self.assertIn("skipFocus=true;try{(fb&&fb.focus?fb:el).focus();}catch(e){}skipFocus=false;}", JS,
                       "the close's refocus fires the cell's focus event; the flag covers that one call")
 

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -298,7 +298,12 @@ await ev(() => { const real = window.fetch; window.__fetchN = 0; window.__doneN 
     const p = real.apply(window, arguments);
     return api ? p.then((r) => { const j = r.json.bind(r); r.json = () => j().then((d) => { window.__doneN++; return d; }); return r; }) : p; }; };
   window.__restoreFetch(); });
-await ev((f) => { window.__rompApiHealth(f); }, frame());
+// the frame's quiet and errs flags come from the kernel's own ring, the same events the document counts (T301 review:
+// the dot follows the frame, a reading only words the lines), so the lab derives them from the served document with the
+// page's own reading rule and pushes a frame that says what a kernel serving that document would say
+const flagsFor = () => ev(() => window.__realFetch("/api-health").then((r) => r.json()).then((d) => {
+  const r = window.__rompApiHealthMerge.readHistory(d); return { quiet: r.level === "quiet", errs: r.level === "errors" ? (r.errors || 1) : 0 }; }));
+await ev((f) => { window.__rompApiHealth(f); }, frame(await flagsFor()));
 await step("storm", async () => {
   // 1. the hover: the loader's dots first, the rows when the read lands; the cell is described by the tip
   const first = await enter();
@@ -309,7 +314,7 @@ await step("storm", async () => {
   R.stormHidden = !(await shown()); R.stormDescribedAfter = await described();
 });
 // each later show is sampled the same way: a fresh show drops the last answer (the dots stand in again) and reads once
-const show = async (name) => { await variant(name); const e = await enter(); R[name + "Wait"] = e.wait; R[name + "Rows0"] = e.rows; };
+const show = async (name) => { await variant(name); await ev((f) => { window.__rompApiHealth(f); }, frame(await flagsFor())); const e = await enter(); R[name + "Wait"] = e.wait; R[name + "Rows0"] = e.rows; };
 await step("quiet", async () => {
   // 2. the tail crosses bootAt with no restart row: the divider; the hold from before the boot ends at the boot
   await show("quiet"); await waitRows();
@@ -412,7 +417,9 @@ await step("theme", async () => {
 });
 await step("race", async () => {
   // 10. two reads in flight (enter, leave, enter): the older answer landing first is dropped, the dots stay until
-  //     the newer one lands, and the newer one is what shows
+  //     the newer one lands, and the newer one is what shows. The frame is a plain fine one (the last show pushed the
+  //     stale variant's quiet flag): the head's word while the dots stand is the frame's, so it must be known here
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ quiet: false, errs: 0 }));
   await ev(async () => { const rf = window.__realFetch;
     await rf("/variant/storm"); window.__A = await (await rf("/api-health")).json();
     await rf("/variant/quiet"); window.__B = await (await rf("/api-health")).json();
@@ -923,8 +930,10 @@ class ServedHistory(unittest.TestCase):
 
     def test_the_cell_is_described_by_a_short_summary_and_never_by_the_rows(self):
         R = self.R
-        self.assertEqual(R["stormDesc0"], "API health: Fine. Reading the details. Press Enter to open it.",
-                         "before the answer: the frame's own word and the read in flight, not the loader's markup")
+        # the frame carries the kernel's own count of failed attempts in the window (T301 review: the dot follows the
+        # frame), so the description names it before the document is read, then the reading's sentence replaces it
+        self.assertEqual(R["stormDesc0"], "API health: 10 failed attempts in the last 15 min. Reading the details. Press Enter to open it.",
+                         "before the answer: the frame's own count and the read in flight, not the loader's markup")
         m = R["storm"]["mode"]
         d = m["descText"]
         self.assertEqual(d, "API health: " + 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.' + " Press Enter to open it.", "the reading in plain words, how to reach the rest")

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -74,8 +74,11 @@ SID = "11111111-2222-4333-8444-000000000001"      # a placeholder sid for the fr
 
 
 def _win(requests, r429, r5xx, gave, sess, complete=True, no_status=0):
-    return {"complete": complete, "requests": requests, "ok": requests, "rateLimited": 0, "overloaded": 0,
-            "serverErrors": 0, "otherErrors": 0, "noStatus": no_status, "gaveUp": gave, "retries": 0,
+    # the counts follow the rates (T301: the reading counts the failures; the old fixture carried rates alone)
+    n429 = int(round(requests * (r429 or 0))) if requests else 0
+    n5xx = int(round(requests * (r5xx or 0))) if requests else 0
+    return {"complete": complete, "requests": requests, "ok": requests - n429 - n5xx, "rateLimited": n429, "overloaded": 0,
+            "serverErrors": n5xx, "otherErrors": 0, "noStatus": no_status, "gaveUp": gave, "retries": n429 + n5xx,
             "sessionsRetrying": sess, "turnsRetrying": sess, "rate429": r429, "rate5xx": r5xx}
 
 
@@ -136,13 +139,13 @@ PAYLOADS = {
                     buckets={KEY: _bucket(KEY, "thrashing", NOW - 300, WHY, STORM_WINS),
                              OTHER: _bucket(OTHER, "healthy", NOW - 500, None, {"60": _win(11, 0.0, 0.0, 0, 0), "300": _win(11, 0.0, 0.0, 0, 0), "900": _win(11, 0.0, 0.0, 0, 0, complete=False)})},
                     transitions=[_tr(NOW - 500, OTHER, "unknown", "healthy"), _tr(NOW - 300, KEY, "unknown", "thrashing")]),
-    # this machine cannot reach the API: every attempt fails at the connection level, so `requests` (attempts WITH
-    # a status) is 0 while noStatus, gaveUp and sessionsRetrying are not; the 5 min window mixes both kinds; the
-    # 15 min window is quiet
+    # this machine cannot reach the API: attempts fail at the connection level, so `requests` (attempts WITH a
+    # status) is small while noStatus, gaveUp and sessionsRetrying are not; the windows NEST (the 15 min window
+    # holds everything the 5 min one does), as a real document's do
     "offline": _base(overall={"state": "unknown", "worstBucket": KEY},
                      buckets={KEY: _bucket(KEY, "unknown", NOW - 200, FEW, {"60": _win(0, None, None, 1, 2, no_status=5),
                                                                           "300": _win(8, 0.25, 0.0, 1, 2, no_status=7),
-                                                                          "900": _win(0, None, None, 0, 0, complete=False)})},
+                                                                          "900": _win(8, 0.25, 0.0, 1, 2, no_status=7, complete=False)})},
                      transitions=[_tr(NOW - 500, KEY, "unknown", "healthy"), _tr(NOW - 200, KEY, "healthy", "unknown", FEW)]),
     # a bucket unknown since before the boot with nothing since: the boot found it unknown, filed no row and seeded
     # its stateSince from the kernel's boot clock (bootAt itself; the backend is seeded with it); the read that
@@ -243,15 +246,20 @@ const ev = (fn, arg) => page.evaluate(fn, arg);
 const rows = () => ev(() => Array.from(document.querySelectorAll("#ah-tip .ah-hist .ah-hrow")).map((n) => ({
   k: (n.querySelector(".ru-tip-k") || {}).textContent || "", w: n.querySelector(".ah-hword") ? n.querySelector(".ah-hword").textContent : null,
   v: n.querySelector(".ru-tip-v") ? n.querySelector(".ru-tip-v").textContent : null, boot: n.classList.contains("ah-boot") })));
-const head = () => ev(() => { const h = document.querySelector("#ah-tip .ah-hist");
+// T301: the reading sits in the FIRST section's head (word + dot); the History section holds the legend, the graph
+// (when the document carries a series), the machine lines with several hosts, and this machine's State changes
+const head = () => ev(() => { const h = document.querySelector("#ah-tip .ah-hist"), top = document.querySelector("#ah-tip > .ru-tip-win");
   const q = (s) => { const n = h && h.querySelector(s); return n ? n.textContent : null; };
-  return { word: q(".ah-head .ah-word"), dot: h && h.querySelector(".ah-head .ah-dot") ? h.querySelector(".ah-head .ah-dot").getAttribute("data-state") : null,
-           since: q(".ah-since"), sub: q(".ah-hsub"), why: q(".ah-line.ru-tip-reset"), asOf: q(".ru-tip-name .ru-tip-reset"),
-           line: q(".ah-line:not(.ru-tip-reset):not(.ah-err)"), err: q(".ah-err"), wait: !!(h && h.querySelector(".ah-wait")),
+  const qt = (s) => { const n = top && top.querySelector(s); return n ? n.textContent : null; };
+  return { word: qt(".ah-head .ah-word"), dot: top && top.querySelector(".ah-head .ah-dot") ? top.querySelector(".ah-head .ah-dot").getAttribute("data-dot") : null,
+           since: qt(".ah-since"), sub: qt(".ah-line.ru-tip-reset"), title: qt(".ru-tip-name span"), asOf: q(".ru-tip-name .ru-tip-reset"),
+           legend: q(".ah-legend"), graphs: h ? h.querySelectorAll(".ru-tip-graph").length : 0, err: q(".ah-err"), wait: !!(h && h.querySelector(".ah-wait")),
+           mlines: Array.from(document.querySelectorAll("#ah-tip .ah-mline")).map((n) => n.textContent),
+           unknown: /unknown/i.test(document.getElementById("ah-tip").innerText),
            names: Array.from(h ? h.querySelectorAll(".ru-tip-name span:first-child") : []).map((n) => n.textContent) }; });
 const shown = () => ev(() => document.getElementById("ah-tip").style.display === "block");
 // the colours the theme resolves to, read from the computed style of the head's dot and of the failure line
-const dotColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip .ah-hist .ah-head .ah-dot")).backgroundColor);
+const dotColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip > .ru-tip-win .ah-head .ah-dot")).backgroundColor);
 const errColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip .ah-hist .ah-err")).color);
 const described = () => ev(() => document.getElementById("rail-api").getAttribute("aria-describedby"));
 // the tip's role and modal flag, whether focus sits inside it, and whether it is the centered card
@@ -285,7 +293,8 @@ const geo = () => ev(() => { const tip = document.getElementById("ah-tip"), t = 
 // answer), so a step can wait for an answer to have landed in the script rather than for a fetch to have started.
 // __restoreFetch puts the wrapper back after a step swapped fetch out.
 await ev(() => { const real = window.fetch; window.__fetchN = 0; window.__doneN = 0; window.__realFetch = real;
-  window.__restoreFetch = function () { window.fetch = function (u) { const api = String(u).indexOf("/api-health") === 0; if (api) window.__fetchN++;
+  window.__lastUrls = [];
+  window.__restoreFetch = function () { window.fetch = function (u) { const api = String(u).indexOf("/api-health") === 0; if (api) window.__fetchN++; window.__lastUrls.push(String(u));
     const p = real.apply(window, arguments);
     return api ? p.then((r) => { const j = r.json.bind(r); r.json = () => j().then((d) => { window.__doneN++; return d; }); return r; }) : p; }; };
   window.__restoreFetch(); });
@@ -309,7 +318,7 @@ await step("quiet", async () => {
 });
 await step("empty", async () => {
   // 3. no bucket: the head says so, no rows
-  await show("empty"); await waitSel("#ah-tip .ah-hist .ah-line");
+  await show("empty"); await waitSel("#ah-tip .ah-hist .ah-legend");
   R.empty = { head: await head(), rows: await rows() };
   await leave();
 });
@@ -429,6 +438,17 @@ await step("order", async () => {
   R.order = await ev(() => Array.from(document.querySelectorAll("#ah-tip > .ru-tip-win")).map((w) => { const n = w.querySelector(".ru-tip-name span"); return n ? n.textContent : w.textContent.slice(0, 24); }));
   await leave();
   await ev((f) => { window.__rompApiHealth(f); }, frame());
+});
+await step("hosts", async () => {
+  // 11b. T301: a frame carrying an attached host's frame reads that host's document through the relay and names
+  //      every machine: the section counts them, the dot is the worst state, the History carries a line per machine
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ hosts: { TESTHOST: { state: "degraded", cls: "429", text: "rate limited · 2 waiting", waiting: 2, retrying: 2, blocked: 0, since: NOW_PLACEHOLDER, reason: "", tmux: 0, stale: false } } }));
+  await variant("quiet");
+  await enter(); await waitSel("#ah-tip .ah-hist .ah-legend");
+  R.hosts = { head: await head(), rows: await rows(), fetched: await ev(() => window.__lastUrls || null) };
+  await leave();
+  await ev((f) => { window.__rompApiHealth(f); }, frame());
+  await variant("storm");
 });
 await step("focus", async () => {
   // 12. keyboard focus shows the hover as the pointer does; blur hides it. The focus and the look at the description
@@ -610,6 +630,12 @@ class _Lab(http.server.SimpleHTTPRequestHandler):
         path = self.path.split("?", 1)[0]
         if path == "/api-health":
             return self._json(PAYLOADS[self.variant[0]])
+        if path == "/remote/TESTHOST/api-health":            # T301: an attached host's document through the relay
+            return self._json(PAYLOADS["storm"])
+        if path == "/dist/api-health-global.js":            # the merge + reading rules the shell script reads
+            body = open(os.path.join(EXT, "dist", "api-health-global.js"), "rb").read()
+            self.send_response(200); self.send_header("Content-Type", "application/javascript")
+            self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body); return
         if path.startswith("/variant/"):
             name = path.rsplit("/", 1)[1]
             if name in PAYLOADS:
@@ -627,6 +653,10 @@ class ServedHistory(unittest.TestCase):
         if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
             raise unittest.SkipTest("extension deps absent (npm ci not run here): the served hover needs a browser")
         cls.lab = tempfile.mkdtemp(prefix="apih-hover-browser-")
+        if not os.path.exists(os.path.join(EXT, "dist", "api-health-global.js")):
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
         html = km._landing()
         with open(os.path.join(cls.lab, "index.html"), "w") as f:
             f.write(html if isinstance(html, str) else html.decode("utf-8"))
@@ -677,164 +707,147 @@ class ServedHistory(unittest.TestCase):
             self.assertEqual(R[name + "Rows0"], 0, name)
         self.assertEqual(R["racePending"], 2, "enter, leave, enter: two reads in flight")
         self.assertTrue(R["raceAfterOld"]["wait"], "the older answer landing first is dropped: the dots stay")
-        self.assertIsNone(R["raceAfterOld"]["word"])
-        self.assertEqual(R["raceAfterNew"]["word"], "healthy", "the newer read's answer is what shows")
+        self.assertEqual(R["raceAfterOld"]["word"], "Fine.", "and the head still reads the frame's own word")
+        self.assertEqual(R["raceAfterNew"]["word"], '30 requests in the last 15 min, all succeeded.', "the newer read's answer is what shows")
         self.assertFalse(R["raceAfterNew"]["wait"])
 
-    def test_the_storm_reads_as_state_since_why_windows_and_the_tail_with_its_restart_row(self):
+    def test_the_storm_reads_in_plain_words_with_the_legend_and_the_tail_with_its_restart_row(self):
+        # T301: no per-window rows and no state-machine word: the head says what happened over the longest window
+        # (the counts, the machine's verdict as a plain phrase), the dot is red for a window in errors even with
+        # nothing waiting right now, the legend explains the codes, and the tail is capped at four in plain words
         h, rows = self.R["storm"]["head"], self.R["storm"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ("thrashing", "thrashing"))
-        self.assertEqual(h["since"], "since " + _hmd(NOW - 300))
-        self.assertEqual(h["why"], WHY)
-        self.assertIsNone(h["sub"], "one bucket: no bucket name, no count")
+        self.assertEqual((h["word"], h["dot"]), ('Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.', "errors"))
+        self.assertEqual(h["title"], "API health", "one machine: no count")
+        self.assertIsNone(h["since"], "the frame is ok: no since on the head")
+        self.assertIsNone(h["sub"], "the machine has a verdict: no trend caveat")
         self.assertEqual(h["asOf"], "as of " + time.strftime("%H:%M:%S", time.localtime(NOW)))
         self.assertEqual(h["names"], ["History", "State changes"])
-        wins = rows[:3]
-        self.assertEqual([r["k"] for r in wins], ["1 min", "5 min", "15 min · kernel up 10 min"],
-                         "the third window outreaches the uptime and says so")
-        self.assertEqual([r["v"] for r in wins],
-                         ["4 attempts · 50% 429 · 0% 5xx · 0 gave up · 1 session retried",
-                          "20 attempts · 40% 429 · 0% 5xx · 1 gave up · 2 sessions retried",
-                          "45 attempts · 20% 429 · 2% 5xx · 1 gave up · 2 sessions retried"],
-                         "the window's totals in the window's tense")
-        self.assertTrue(all(r["w"] is None and not r["boot"] for r in wins))
-        tail = rows[3:]
-        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
-                         [(_hmd(NOW - 300), "thrashing", "5 min so far", False),
-                          (_hmd(BOOT + 1), "unknown · kernel restarted", "5 min", False),
-                          (_hmd(NOW - 1200), "thrashing", "10 min", False),
-                          (_hmd(NOW - 3000), "healthy", "30 min", False)],
+        self.assertEqual(h["legend"], "429 = the API told us to slow down (rate limit) · 5xx = the API itself failed (server error) · offline = no connection")
+        self.assertEqual(h["graphs"], 0, "this fixture carries no series: no graph")
+        self.assertFalse(h["unknown"], "the word never reaches the user")
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in rows],
+                         [(_hmd(NOW - 300), "rate-limit storm", "5 min so far", False),
+                          (_hmd(BOOT + 1), "quiet · kernel restarted", "5 min", False),
+                          (_hmd(NOW - 1200), "rate-limit storm", "10 min", False),
+                          (_hmd(NOW - 3000), "fine", "30 min", False)],
                          "newest first; each state held until the bucket's next change; the boot's own row names the restart, so no divider")
 
     def test_a_tail_crossing_boot_at_without_a_restart_row_gets_the_divider_and_the_hold_ends_at_the_boot(self):
         h, rows = self.R["quiet"]["head"], self.R["quiet"]["rows"]
-        self.assertEqual(h["word"], "healthy")
-        self.assertIsNone(h["why"], "no reason line when the bucket has none")
-        tail = rows[3:]
-        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
-                         [(_hmd(NOW - 100), "healthy", "2 min so far", False),
+        self.assertEqual((h["word"], h["dot"]), ('30 requests in the last 15 min, all succeeded.', "fine"))
+        self.assertIsNone(h["sub"], "healthy: no trend caveat")
+        self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in rows],
+                         [(_hmd(NOW - 100), "fine", "2 min so far", False),
                           (_hmd(BOOT), "kernel restarted", None, True),
-                          (_hmd(NOW - 3500), "unknown", "48 min", False),
-                          (_hmd(NOW - 4000), "healthy", "8 min", False)],
+                          (_hmd(NOW - 3500), "quiet", "48 min", False),
+                          (_hmd(NOW - 4000), "fine", "8 min", False)],
                          "the unknown from before the boot ended at the boot (every bucket comes back unknown), not at the next change")
 
     def test_a_bucket_the_boot_seeded_reads_since_the_boot_in_the_head_and_the_tail_alike(self):
         h, rows = self.R["stale"]["head"], self.R["stale"]["rows"]
-        self.assertEqual(h["word"], "unknown")
-        self.assertEqual(h["since"], "since " + _hmd(BOOT), "stateSince is the boot clock itself: the backend is seeded with it")
-        self.assertEqual(h["why"], FEW, "the read's own reason, as the live route serves it; the head keys on nothing in it")
-        self.assertEqual([r["v"] for r in rows[:3]], ["no attempts"] * 3)
-        tail = rows[3:]
+        self.assertEqual((h["word"], h["dot"]), ('No API traffic in the last 15 min.', "quiet"), "no traffic reads quiet and gray, never the machine's word")
+        self.assertFalse(h["unknown"])
+        tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
                          [(_hmd(BOOT), "kernel restarted", None, True),
-                          (_hmd(NOW - 100000), "unknown", "1 d 3 h", False),
-                          (_hmd(NOW - 183000), "degraded", "23 h 3 min", False),
-                          (_hmd(NOW - 190000), "healthy", "1 h 57 min", False)],
-                         "the divider and the head name one time; the pre-boot unknown is closed at the boot, never 'so far'")
-        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == divider stamp")
+                          (_hmd(NOW - 100000), "quiet", "1 d 3 h", False),
+                          (_hmd(NOW - 183000), "API failing", "23 h 3 min", False),
+                          (_hmd(NOW - 190000), "fine", "1 h 57 min", False)],
+                         "the divider at the boot; the pre-boot quiet is closed at the boot, never 'so far'")
         self.assertTrue(all(" so far" not in (r["v"] or "") for r in tail), "no open-ended state for a bucket the boot seeded")
         self.assertTrue(all(re.match(r"\d\d-\d\d \d\d:\d\d$", r["k"]) for r in tail[1:]), "stamps from another day carry their date")
 
     def test_a_boot_at_58_seconds_reads_one_time_in_the_head_and_on_its_restart_row(self):
         h, rows = self.R["minute"]["head"], self.R["minute"]["rows"]
-        self.assertEqual(h["word"], "unknown")
-        self.assertEqual(h["since"], "since " + _hmd(BOOT_M))
-        tail = rows[3:]
+        self.assertEqual((h["word"], h["dot"]), ('No API traffic in the last 15 min.', "quiet"))
+        tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
-                         [(_hmd(BOOT_M), "unknown · kernel restarted", _min(NOW - BOOT_M) + " so far", False),
-                          (_hmd(NOW - 1500), "thrashing", _min(BOOT_M - (NOW - 1500)), False),
-                          (_hmd(NOW - 3000), "healthy", "25 min", False)],
+                         [(_hmd(BOOT_M), "quiet · kernel restarted", _min(NOW - BOOT_M) + " so far", False),
+                          (_hmd(NOW - 1500), "rate-limit storm", _min(BOOT_M - (NOW - 1500)), False),
+                          (_hmd(NOW - 3000), "fine", "25 min", False)],
                          "the boot's own row names the restart (no divider); the pre-boot hold ends at the boot")
-        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == the restart row's stamp: one clock")
         self.assertFalse(any(r["boot"] for r in tail))
         self.assertEqual(BOOT_M % 60, 58, "the payload's boot sits two seconds before a minute boundary")
 
     def test_the_restart_row_sorts_above_the_previous_kernel_s_last_row_filed_in_the_same_second(self):
         h, rows = self.R["inversion"]["head"], self.R["inversion"]["rows"]
-        self.assertEqual(h["word"], "unknown")
-        self.assertEqual(h["since"], "since " + _hmd(BOOT + 0.9), "the seeded stateSince, the boot to the millisecond")
-        tail = rows[3:]
+        self.assertEqual(h["word"], 'No API traffic in the last 15 min.')
+        tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
-                         [(_hmd(BOOT + 0.9), "unknown · kernel restarted", _dur(NOW - (BOOT + 0.9)) + " so far", False),
-                          (_hmd(BOOT + 0.7), "healthy", "0 s", False),
-                          (_hmd(NOW - 1500), "thrashing", _dur(BOOT + 0.7 - (NOW - 1500)), False),
-                          (_hmd(NOW - 3000), "healthy", "25 min", False)],
+                         [(_hmd(BOOT + 0.9), "quiet · kernel restarted", _dur(NOW - (BOOT + 0.9)) + " so far", False),
+                          (_hmd(BOOT + 0.7), "fine", "0 s", False),
+                          (_hmd(NOW - 1500), "rate-limit storm", _dur(BOOT + 0.7 - (NOW - 1500)), False),
+                          (_hmd(NOW - 3000), "fine", "25 min", False)],
                          "the restart row is the newest; the previous kernel's last state closed at the restart, never 'so far'; "
                          "the boot's own row names the restart, so no divider")
-        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == the restart row's stamp")
         self.assertEqual(sum(1 for r in tail if " so far" in (r["v"] or "")), 1)
         self.assertFalse(any(r["boot"] for r in tail))
 
     def test_a_row_the_previous_kernel_filed_after_this_start_sits_under_the_clamped_restart_row_with_one_mark(self):
         h, rows = self.R["clamped"]["head"], self.R["clamped"]["rows"]
-        self.assertEqual(h["since"], "since " + _hmd(BOOT + 0.951), "the head reads the clamped stamp, which is bootAt")
-        tail = rows[3:]
+        tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
-                         [(_hmd(BOOT + 0.951), "unknown · kernel restarted", _dur(NOW - (BOOT + 0.951)) + " so far", False),
-                          (_hmd(BOOT + 0.95), "healthy", "0 s", False),
-                          (_hmd(NOW - 1500), "thrashing", _dur(BOOT + 0.95 - (NOW - 1500)), False),
-                          (_hmd(NOW - 3000), "healthy", "25 min", False)],
+                         [(_hmd(BOOT + 0.951), "quiet · kernel restarted", _dur(NOW - (BOOT + 0.951)) + " so far", False),
+                          (_hmd(BOOT + 0.95), "fine", "0 s", False),
+                          (_hmd(NOW - 1500), "rate-limit storm", _dur(BOOT + 0.95 - (NOW - 1500)), False),
+                          (_hmd(NOW - 3000), "fine", "25 min", False)],
                          "the old row is the first pre-boot row (its hold ends at the restart row, one millisecond on); the row "
                          "before it closed at the old row; the restart row above suppresses the divider: one restart, one mark")
-        self.assertEqual(h["since"], "since " + tail[0]["k"], "head since == the restart row's stamp == bootAt: one number")
         self.assertFalse(any(r["boot"] for r in tail), "no divider under a shown restart row")
         self.assertEqual(sum(1 for r in tail if "kernel restarted" in (r["w"] or "")), 1)
 
     def test_a_transition_the_hover_s_own_read_filed_closes_the_state_before_it(self):
         h, rows = self.R["ownread"]["head"], self.R["ownread"]["rows"]
-        self.assertEqual(h["since"], "since " + _hmd(NOW), "the state entered at this read's asOf")
-        tail = rows[3:]
+        self.assertEqual(h["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.')
+        tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"]) for r in tail],
-                         [(_hmd(NOW), "thrashing", "0 s so far"), (_hmd(NOW - 500), "healthy", "8 min")],
+                         [(_hmd(NOW), "rate-limit storm", "0 s so far"), (_hmd(NOW - 500), "fine", "8 min")],
                          "the closed state reads its duration with no 'so far' although its end is asOf; the new one is 'so far'")
         self.assertEqual(sum(1 for r in tail if " so far" in r["v"]), 1)
 
-    def test_no_bucket_says_so_in_place_of_the_rows(self):
+    def test_no_bucket_reads_quiet_and_gray_with_no_rows(self):
         h, rows = self.R["empty"]["head"], self.R["empty"]["rows"]
-        self.assertEqual(h["word"], "unknown")
-        self.assertEqual(h["line"], "No API traffic seen since the kernel started at %s." % _hmd(BOOT))
+        self.assertEqual((h["word"], h["dot"]), ('No API traffic in the last 15 min.', "quiet"))
         self.assertEqual(rows, [])
         self.assertIsNone(h["since"])
+        self.assertIsNotNone(h["legend"], "the legend stands whatever the traffic")
+        self.assertFalse(h["unknown"])
 
-    def test_two_buckets_of_one_family_are_told_apart_by_auth_and_counted(self):
+    def test_two_buckets_of_one_family_read_as_one_machine_and_the_tail_tells_them_apart_by_auth(self):
+        # T301: the head counts every bucket of this machine (one kernel's buckets share its clock); the "worst of N
+        # buckets" caveat is gone; the tail still names a bucket by family and auth when two share the family
         h, rows = self.R["two"]["head"], self.R["two"]["rows"]
-        self.assertEqual(h["word"], "thrashing")
-        self.assertEqual(h["sub"], "fable · %s · worst of 2 buckets" % AUTH)
-        tail = rows[3:]
-        self.assertEqual([r["w"] for r in tail], ["fable · %s thrashing" % AUTH, "fable · %s healthy" % LAUTH])
+        self.assertEqual(h["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 56 attempts in the last 15 min; 1 turn gave up.')
+        tail = rows
+        self.assertEqual([r["w"] for r in tail], ["fable · %s rate-limit storm" % AUTH, "fable · %s fine" % LAUTH])
         self.assertEqual([r["v"] for r in tail], ["5 min so far", "8 min so far"], "each bucket's current state is its own 'so far'")
 
     def test_two_buckets_of_two_families_are_named_by_family_alone(self):
         h, rows = self.R["twoFam"]["head"], self.R["twoFam"]["rows"]
-        self.assertEqual(h["sub"], "fable · worst of 2 buckets")
-        self.assertEqual([r["w"] for r in rows[3:]], ["fable thrashing", "opus healthy"])
+        self.assertEqual(h["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 56 attempts in the last 15 min; 1 turn gave up.')
+        self.assertEqual([r["w"] for r in rows], ["fable rate-limit storm", "opus fine"])
 
-    def test_an_offline_window_names_its_no_status_attempts_with_its_give_ups_and_sessions(self):
+    def test_an_offline_window_reads_its_no_connection_attempts_in_plain_words(self):
         h, rows = self.R["offline"]["head"], self.R["offline"]["rows"]
-        self.assertEqual(h["word"], "unknown")
-        self.assertEqual([r["v"] for r in rows[:3]],
-                         ["5 attempts without a status · 1 gave up · 2 sessions retried",
-                          "15 attempts, 7 of them without a status · 25% 429 · 0% 5xx of the other 8 · 1 gave up · 2 sessions retried",
-                          "no attempts"],
-                         "never 'no attempts' while give-ups or sessions are non-zero; a mixed window counts every attempt once "
-                         "(requests 8 with a status plus 7 without: noStatus sits outside requests) and names the shares' base")
+        self.assertEqual((h["word"], h["dot"]), ('Errors: 2 rate-limited attempts, 7 attempts with no connection among 15 attempts in the last 15 min; 1 turn gave up.', "errors"),
+                         "attempts without a status are counted as no connection; the machine's word (unknown) is never said")
+        self.assertFalse(h["unknown"])
 
-    def test_the_cap_shows_six_transitions_with_the_divider_extra_and_six_without_one(self):
-        rows = self.R["cap"]["rows"][3:]
+    def test_the_cap_shows_four_transitions_with_the_divider_extra_and_four_without_one(self):
+        # T301: the State changes list is a glance, not a log: four rows, in plain words
+        rows = self.R["cap"]["rows"]
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in rows],
-                         [(_hmd(NOW - 200), "degraded", "3 min so far", False),
-                          (_hmd(NOW - 400), "healthy", "3 min", False),
+                         [(_hmd(NOW - 200), "API failing", "3 min so far", False),
+                          (_hmd(NOW - 400), "fine", "3 min", False),
                           (_hmd(BOOT), "kernel restarted", None, True),
-                          (_hmd(NOW - 2500), "unknown", "32 min", False),
-                          (_hmd(NOW - 3000), "recovering", "8 min", False),
-                          (_hmd(NOW - 3500), "thrashing", "8 min", False),
-                          (_hmd(NOW - 4000), "healthy", "8 min", False)],
-                         "six transitions and the divider, the two oldest changes cut")
-        self.assertEqual(sum(1 for r in rows if not r["boot"]), 6)
-        rows = self.R["capPost"]["rows"][3:]
-        self.assertEqual(len(rows), 6)
+                          (_hmd(NOW - 2500), "quiet", "32 min", False),
+                          (_hmd(NOW - 3000), "recovering", "8 min", False)],
+                         "four transitions and the divider, the four oldest changes cut")
+        self.assertEqual(sum(1 for r in rows if not r["boot"]), 4)
+        rows = self.R["capPost"]["rows"]
+        self.assertEqual(len(rows), 4)
         self.assertFalse(any(r["boot"] for r in rows), "nothing crosses the boot: no divider")
-        self.assertEqual([r["w"] for r in rows], ["healthy", "degraded", "healthy", "recovering", "thrashing", "healthy"])
+        self.assertEqual([r["w"] for r in rows], ["fine", "API failing", "fine", "recovering"])
         self.assertEqual(rows[0]["v"], "1 min so far")
 
     def test_a_failed_read_is_one_loud_line_and_never_the_previous_numbers(self):
@@ -845,12 +858,12 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual(R["failReject"]["rows"], [])
         self.assertEqual(R["failMalformed"]["head"]["err"], "Could not read the API history: malformed answer")
         self.assertIsNone(R["fail503"]["head"]["asOf"], "no as-of stamp on a failure")
-        self.assertEqual(R["recovered"]["head"]["word"], "thrashing", "the next successful read replaces the failure")
+        self.assertEqual(R["recovered"]["head"]["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.', "the next successful read replaces the failure")
         self.assertIsNone(R["recovered"]["head"]["err"])
 
     def test_the_section_sits_between_the_sessions_waiting_and_the_tmux_line(self):
         order = self.R["order"]
-        self.assertEqual(order[:3], ["API · this machine", "Sessions waiting", "History"])
+        self.assertEqual(order[:3], ["API health", "Sessions waiting", "History"])
         self.assertTrue(order[3].startswith("1 tmux session is seen"), order)
 
     def test_focus_shows_the_hover_and_blur_hides_it(self):
@@ -910,30 +923,29 @@ class ServedHistory(unittest.TestCase):
 
     def test_the_cell_is_described_by_a_short_summary_and_never_by_the_rows(self):
         R = self.R
-        self.assertEqual(R["stormDesc0"], "History: ok. Reading the details. Press Enter to open it.",
-                         "before the answer: the state word the frame put on the cell and the read in flight, not the loader's markup")
+        self.assertEqual(R["stormDesc0"], "API health: Fine. Reading the details. Press Enter to open it.",
+                         "before the answer: the frame's own word and the read in flight, not the loader's markup")
         m = R["storm"]["mode"]
         d = m["descText"]
-        self.assertEqual(d, "History: thrashing since %s. Press Enter to open it." % _hmd(NOW - 300), "the state word, its since, how to reach the rest")
-        self.assertLess(len(d), 90, "bounded: a sentence, not the tip")
-        for w in ("attempts", "429", "5xx", "gave up", "retried", "kernel restarted", "as of", "State changes"):
-            self.assertNotIn(w, d, "no window row, no transition, no stamp in the description")
+        self.assertEqual(d, "API health: " + 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.' + " Press Enter to open it.", "the reading in plain words, how to reach the rest")
+        self.assertLess(len(d), 160, "bounded: a sentence, not the tip")
+        for w in ("kernel restarted", "as of", "State changes", "unknown"):
+            self.assertNotIn(w, d, "no transition, no stamp, no machine word in the description")
         self.assertTrue(m["descInTree"])
         self.assertLessEqual(max(m["descBox"]), 1.0, "visually hidden: one pixel or less each way")
         self.assertEqual(R["fail503"]["desc"], "Could not read the API history: HTTP 503. Press Enter to open it.")
-        # at focus time, in the focus's own task (where assistive tech reads it), the description carries the state
-        # word the frame already put on the cell; the landed one carries the since
-        self.assertEqual(R["focusDesc0"], "History: rate limited · 1 waiting. Reading the details. Press Enter to open it.")
+        # at focus time, in the focus's own task (where assistive tech reads it), the description carries the frame's
+        # own words (a session waiting on a 429); the landed one keeps them: the frame's errors outrank the reading
+        self.assertEqual(R["focusDesc0"], "API health: rate limited · 1 waiting. Reading the details. Press Enter to open it.")
         self.assertIn("rate limited", R["focusDesc0"], "the frame's own words, before any read")
-        self.assertEqual(R["focusDesc"], "History: thrashing since %s. Press Enter to open it." % _hmd(NOW - 300))
-        self.assertIn(" since ", R["focusDesc"])
+        self.assertEqual(R["focusDesc"], "API health: rate limited · 1 waiting. Press Enter to open it.")
 
     def test_enter_pins_the_section_a_frame_re_reads_it_and_escape_does_not_re_pop_the_hover(self):
         R = self.R
         self.assertTrue(R["kbPinned"])
         self.assertEqual(R["kbFetchPost"], R["kbFetchPre"], "the pin reads nothing new: the focus show's read is the same document")
         self.assertGreater(R["kbRows"], 3)
-        self.assertEqual(R["kbHead"]["word"], "thrashing")
+        self.assertEqual(R["kbHead"]["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.')
         self.assertGreater(R["kbFetchAfter"], R["kbFetchBefore"], "a frame on the open detail re-reads the history")
         self.assertTrue(R["escHidden"])
         self.assertTrue(R["escFocusBack"], "focus returns to the cell")
@@ -955,17 +967,34 @@ class ServedHistory(unittest.TestCase):
 
     def test_an_answer_under_a_held_pointer_paints_on_release(self):
         R = self.R
-        self.assertEqual(R["heldWord"], "thrashing", "the frame's re-read landed under the held pointer: not painted")
-        self.assertEqual(R["releasedWord"], "healthy", "the release paints it")
+        # the detail still shows the previous frame's word (overloaded, from the frame that re-read the history) until
+        # the release: nothing painted under the press
+        self.assertEqual(R["heldWord"], "overloaded · 1 waiting", "the frame's re-read landed under the held pointer: not painted")
+        self.assertEqual(R["releasedWord"], '30 requests in the last 15 min, all succeeded.', "the release paints it")
 
-    def test_the_light_theme_colours_the_quiet_head_dot_and_the_failure_line(self):
+    def test_the_light_theme_colours_the_fine_and_quiet_head_dots_and_the_failure_line(self):
         R = self.R
-        # the ok state's #5D574E on the head's dot for the signal's quiet states (the base gray #9aa4ad is about 1.6:1
-        # on the white tip), and the light error red #B02A1C on the failure line; the dark line keeps #ef6b6f
-        self.assertEqual((R["lightHealthyDot"]["word"], R["lightHealthyDot"]["color"]), ("healthy", "rgb(93, 87, 78)"))
-        self.assertEqual((R["lightUnknownDot"]["word"], R["lightUnknownDot"]["color"]), ("unknown", "rgb(93, 87, 78)"))
+        # T301: fine wears the light theme's accent (the clay), quiet the light label gray #5D574E (the base gray #9aa4ad
+        # is about 1.6:1 on the white tip), and the failure line the light error red #B02A1C; the dark line keeps #ef6b6f
+        self.assertEqual((R["lightHealthyDot"]["word"], R["lightHealthyDot"]["color"]), ('30 requests in the last 15 min, all succeeded.', "rgb(194, 65, 12)"))
+        self.assertEqual((R["lightUnknownDot"]["word"], R["lightUnknownDot"]["color"]), ('No API traffic in the last 15 min.', "rgb(93, 87, 78)"))
         self.assertEqual(R["lightErr"], "rgb(176, 42, 28)", "the light theme's error-text red")
         self.assertEqual(R["fail503"]["errColor"], "rgb(239, 107, 111)", "the dark tip's status red")
+
+    def test_an_attached_host_is_read_through_the_relay_and_every_machine_is_named(self):
+        # T301: the frame's hosts map (a per-host MAP the kernel's tunnel supervisor filled) makes the shell read that
+        # host's document through /remote/<host>/api-health and name every machine; worst state wins for the dot
+        h = self.R["hosts"]["head"]
+        self.assertEqual(h["title"], "API health · 2 machines")
+        self.assertEqual(h["dot"], "errors", "TESTHOST's storm reddens the merged dot")
+        self.assertEqual(h["word"], "Errors on TESTHOST", "several machines: the head sums them up; each line follows")
+        self.assertEqual(h["mlines"][:2], ["this machine: fine · 30 requests in the last 15 min, all succeeded", "TESTHOST: rate limited · 2 waiting"],
+                         "one line per machine in the first section, local first")
+        self.assertTrue(any(m.startswith("TESTHOST") and "Rate-limit storm" in m for m in h["mlines"][2:]),
+                        "the History names TESTHOST with ITS reading (its own document, never summed into this machine's)")
+        self.assertIn("State changes · this machine", h["names"])
+        self.assertIn("/remote/TESTHOST/api-health", self.R["hosts"]["fetched"] or [], "the relay read")
+        self.assertFalse(h["unknown"])
 
     def test_the_hover_keeps_its_margin_at_830_wide_and_stays_above_the_rail_on_a_short_window(self):
         g = self.R["geo830"]
@@ -985,7 +1014,10 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual(g["ih"], 280)
         self.assertGreaterEqual(g["t"], 5.5)
         self.assertLessEqual(g["b"], g["cellTop"] - 8 + 0.5, "above the rail, never over it or the cell")
-        self.assertTrue(g["clipped"], "the section's oldest rows are clipped rather than spilled")
+        # T301: the section is shorter (no window rows), so on this height it may fit under the cap; when it does not,
+        # it clips rather than spills
+        self.assertTrue(g["clipped"] or g["h"] <= float(str(g["maxH"]).replace("px", "") or 0) + 0.5,
+                        "the section's oldest rows are clipped rather than spilled: %r" % g)
         self.assertLessEqual(g["h"], g["cellTop"] - 14 + 0.5)
         g = self.R["geoWide"]
         self.assertFalse(g["clipped"], "1200x800: the whole section fits")

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -37,7 +37,7 @@ MDOT = "·"
 
 
 def _frame_keys():
-    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq"}
+    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq", "hosts", "quiet"}
 
 
 class Reference(unittest.TestCase):
@@ -452,9 +452,13 @@ class Detail(unittest.TestCase):
         for s in ("Auto-retry and the judges are paused until your usage limit resets.",
                   "Auto-retry and the judges are paused: you have reached the monthly spend limit. Raise it at claude.ai/settings/usage.",
                   "Auto-retry and the judges are paused: you stopped them.",
-                  "No session is waiting on the API. Auto-retry and the judges are running.",
-                  "API %s this machine" % MDOT, "Sessions waiting", "since "):
+                  "API health", "Sessions waiting", "since "):
             self.assertIn(s, self.JS)
+        # T301: the head reads what happened across every connected kernel; the old one-machine label and the ok
+        # sentence are gone, and the state machine's word never reaches the user
+        self.assertNotIn("API %s this machine" % MDOT, self.JS)
+        self.assertNotIn("No session is waiting on the API.", self.JS)
+        self.assertIn("429 = the API told us to slow down (rate limit)", self.JS)
 
     def test_the_pause_button_is_the_chat_card_s_and_acknowledges_before_the_round_trip(self):
         self.assertIn("'Resume all auto-retries'", self.JS)
@@ -487,8 +491,11 @@ class Detail(unittest.TestCase):
         # the cell and the frame's reading render from the last frame only; the History section is the one fetch,
         # GET /api-health at show time, and there is still no timer anywhere (test_api_health_hover.py holds the
         # section's own pins)
-        self.assertEqual(self.JS.count("fetch("), 1, "one read: the history's")
-        self.assertIn("fetch('/api-health',{cache:'no-store'})", self.JS)
+        self.assertEqual(self.JS.count("fetch("), 1, "one read path: fetchDoc, the history's")
+        self.assertIn("fetchDoc('/api-health')", self.JS)
+        # T301: every attached host's document rides the same read, through the kernel's relay, kept per host
+        self.assertIn("fetchDoc('/remote/'+encodeURIComponent(h)+'/api-health')", self.JS)
+        self.assertIn("Promise.all(reads)", self.JS)
         self.assertNotIn("setInterval", self.JS)
         self.assertNotIn("setTimeout", self.JS)
         self.assertIn("window.__rompApiHealth=function(m){", self.JS)
@@ -496,8 +503,12 @@ class Detail(unittest.TestCase):
 
     def test_the_cell_repaints_only_when_state_or_text_changed_and_shows_on_the_first_frame(self):
         self.assertIn("if(el.hidden)el.hidden=false;", self.JS)
-        self.assertIn("if(el.getAttribute('data-state')!==m.state||txt.textContent!==m.text){el.setAttribute('data-state',m.state);"
-                      "txt.textContent=m.text;el.setAttribute('aria-label','API '+m.text);}", self.JS)
+        # T301: the cell is a dot alone, painted from the MERGED view (every connected kernel); the DOM is touched only
+        # when the merged state or the description changed
+        self.assertIn("paintCell();", self.JS)
+        self.assertIn("if(el.getAttribute('data-dot')!==mg.dot)el.setAttribute('data-dot',mg.dot);", self.JS)
+        self.assertIn("var lab='API health: '+DOTWORD[mg.dot]+(mg.n>1?' across '+mg.n+' machines':'');if(el.getAttribute('aria-label')!==lab)el.setAttribute('aria-label',lab);", self.JS)
+        self.assertNotIn(".ah-text", self.JS)
         self.assertIn("if(tip.style.display!=='block')return;", self.JS)
         self.assertIn("if(held){dirty=true;return;}render();};", self.JS)
 
@@ -581,7 +592,7 @@ class Detail(unittest.TestCase):
     def test_the_cell_is_a_keyboard_button_and_the_detail_takes_and_returns_focus(self):
         self.assertIn("el.addEventListener('keydown',function(ev){if(ev.key==='Escape')", self.JS)
         self.assertIn("if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});", self.JS)
-        self.assertIn("el.setAttribute('aria-label','API '+m.text)", self.JS)
+        self.assertIn("el.setAttribute('aria-label',lab)", self.JS)   # T301: the merged description ("API health: fine|errors|no traffic")
         self.assertIn("tip.setAttribute('role','dialog')", self.JS)
         self.assertIn("focusBack=document.activeElement;", self.JS)
         self.assertIn("try{tip.focus();}catch(e){}", self.JS)

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -37,7 +37,7 @@ MDOT = "·"
 
 
 def _frame_keys():
-    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq", "hosts", "quiet"}
+    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq", "hosts", "quiet", "errs"}
 
 
 class Reference(unittest.TestCase):
@@ -84,10 +84,16 @@ class _Fixture(unittest.TestCase):
         km._send_to_app = lambda app, m: self.sent.append((app, m))
         km.Sessions.backend_for = staticmethod(lambda sid: km._TMUX if sid in self.tmux_sids else object())
         km._name_color = lambda sid: self.colors.get(sid)
+        # the frame's quiet and errs flags ask the SDK backend through km._sdk (T301): patched, so no test builds a
+        # real SdkBackend in-process (its boot reconcile thread and catalog fetch); `self.backend` is what it answers
+        self.backend, self.sdk_calls = None, []
+        self._sdk = km._sdk
+        km._sdk = lambda: (self.sdk_calls.append(1), self.backend)[1]
         km._APIH_LAST[0] = None
         km._retry_suppress_cache.clear()
 
     def tearDown(self):
+        km._sdk = self._sdk
         km.jd.STATE = self._state
         km._alive_sessions = self._alive
         km._api_last_failed = self._last
@@ -492,10 +498,10 @@ class Detail(unittest.TestCase):
         # GET /api-health at show time, and there is still no timer anywhere (test_api_health_hover.py holds the
         # section's own pins)
         self.assertEqual(self.JS.count("fetch("), 1, "one read path: fetchDoc, the history's")
-        self.assertIn("fetchDoc('/api-health')", self.JS)
+        self.assertIn("fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health')", self.JS)
         # T301: every attached host's document rides the same read, through the kernel's relay, kept per host
-        self.assertIn("fetchDoc('/remote/'+encodeURIComponent(h)+'/api-health')", self.JS)
-        self.assertIn("Promise.all(reads)", self.JS)
+        self.assertIn("names.forEach(function(h){fetchDoc(h?", self.JS)
+        self.assertIn("names.forEach(function(h){fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health')", self.JS)
         self.assertNotIn("setInterval", self.JS)
         self.assertNotIn("setTimeout", self.JS)
         self.assertIn("window.__rompApiHealth=function(m){", self.JS)
@@ -591,7 +597,7 @@ class Detail(unittest.TestCase):
 
     def test_the_cell_is_a_keyboard_button_and_the_detail_takes_and_returns_focus(self):
         self.assertIn("el.addEventListener('keydown',function(ev){if(ev.key==='Escape')", self.JS)
-        self.assertIn("if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();if(pinned)close();else open();}});", self.JS)
+        self.assertIn("if(ev.key==='Enter'||ev.key===' '){ev.preventDefault();ev.stopPropagation();if(pinned)close();else open();}});", self.JS)
         self.assertIn("el.setAttribute('aria-label',lab)", self.JS)   # T301: the merged description ("API health: fine|errors|no traffic")
         self.assertIn("tip.setAttribute('role','dialog')", self.JS)
         self.assertIn("focusBack=document.activeElement;", self.JS)
@@ -604,7 +610,7 @@ class Detail(unittest.TestCase):
 
     def test_actions_are_delegated_on_the_stable_tip_node(self):
         self.assertIn("var el=document.getElementById('rail-api');", self.JS)
-        self.assertIn("el.addEventListener('click',function(){if(pinned)close();else open();});", self.JS)
+        self.assertIn("el.addEventListener('click',function(ev){if(ev&&ev.stopPropagation)ev.stopPropagation();if(pinned)close();else open();});", self.JS)
         self.assertNotIn("el.innerHTML", self.JS, "the frame handler writes the cell's children, never the cell")
         self.assertIn("tip.addEventListener('click',function(ev){", self.JS)
         self.assertEqual(self.JS.count("addEventListener('click'"), 2, "one on #rail-api, one on #ah-tip; none per row")

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -229,10 +229,15 @@ class ApiHealthCell(unittest.TestCase):
         self.assertLess(i_api, i_acts, "inside .rail-scroll, before the pinned actions")
         self.assertGreater(i_api, self.html.index("<div class=rail-scroll>"))
 
-    def test_the_cell_ships_hidden_with_its_own_label_a_dot_and_the_word(self):
-        tag = ('<div id=rail-api class="ru-w ru-ah" hidden role=button tabindex=0 aria-label="API ok" data-state=ok>'
-               '<span class=ru-name>API</span><i class=ah-dot></i><span class=ah-text>ok</span></div>')
-        self.assertTrue(tag in self.html, "the cell's markup: hidden, a keyboard button, its own label, a dot, the word")
+    def test_the_cell_ships_hidden_as_a_dot_alone(self):
+        # T301 (the user 2026-09-10): no second API word and no "ok"; the dot moves into the spend readout's slot
+        # (.ah-slot, right after the readout's own API label) whenever that readout renders
+        tag = ('<div id=rail-api class="ru-w ru-ah" hidden role=button tabindex=0 aria-label="API health" data-dot=fine>'
+               '<i class=ah-dot></i></div>')
+        self.assertTrue(tag in self.html, "the cell's markup: hidden, a keyboard button, a dot and nothing else")
+        self.assertNotIn(".ah-text", self.html, "no word beside the dot")
+        self.assertIn("<div class=ru-name>API</div><span class=ah-slot></span>", self.html, "the readout's slot for the dot")
+        self.assertIn(".ah-slot{display:inline-flex;align-items:center}", self.html)
         tag = re.search(r"<div id=rail-api[^>]*>", self.html).group(0)
         self.assertNotIn("title", tag, "the rail's no-title rule: the detail is the one hover surface")
         self.assertNotIn("data-keycmd", tag, "no palette command yet")
@@ -244,21 +249,18 @@ class ApiHealthCell(unittest.TestCase):
         self.assertTrue(".ru-w{display:flex;" in self.html, "the author display rule the attribute must beat")
         self.assertTrue("#rail-api[hidden]{display:none}" in self.html, "no author [hidden] rule for #rail-api")
 
-    def test_the_word_wears_the_usage_cell_s_exact_font(self):
-        pct = re.search(r"\.ru-pct\{([^}]*)\}", self.html).group(1)
-        txt = re.search(r"\.ah-text\{([^}]*)\}", self.html).group(1)
-        self.assertEqual(pct, txt, "byte for byte: no new font size on the rail")
-        self.assertIn("#rail-api[data-state=ok] .ah-text{color:#9aa4ad}", self.html, "ok in the label gray")
-        self.assertIn("body.theme-light .ah-text{color:#1F1E1D}", self.html)
-        self.assertIn("body.theme-light #rail-api[data-state=ok] .ah-text{color:#5D574E}", self.html)
-        self.assertIn("#rail-api{cursor:pointer;margin-left:4px}", self.html)
+    def test_the_cell_adds_no_font_size_and_sits_in_the_readout_s_slot(self):
+        self.assertNotIn(".ah-text", self.html, "T301: no word on the rail, so no font rule for one")
+        self.assertIn("#rail-api{cursor:pointer;margin:0 1px;padding:4px 2px}", self.html, "a 15 px hit target around a 7 px dot")
 
-    def test_the_dot_wears_status_hexes_never_the_accent(self):
-        self.assertIn(".ah-dot{width:7px;height:7px;border-radius:50%;background:#9aa4ad;opacity:.55;flex:0 0 auto}", self.html)
-        self.assertIn("#rail-api[data-state=degraded] .ah-dot,.ah-dot[data-state=degraded]{background:#e67e22;opacity:1}", self.html)
-        self.assertIn("#rail-api[data-state=paused] .ah-dot,.ah-dot[data-state=paused]{background:#e5484d;opacity:1}", self.html)
-        for rule in re.findall(r"[^{}]*\.ah-dot[^{}]*\{[^}]*\}", self.html):
-            self.assertNotIn("var(--accent)", rule, "status colors keep their own meaning")
+    def test_the_dot_wears_the_accent_when_fine_and_the_status_tokens_otherwise(self):
+        # T301 (the user 2026-09-10): the fine dot IS the romp accent; errors the blocked red; quiet the label gray;
+        # every colour through a token with a fallback for a var-less harness
+        self.assertIn(".ah-dot{width:7px;height:7px;border-radius:50%;background:var(--dim,#9aa4ad);opacity:.55;flex:0 0 auto}", self.html)
+        self.assertIn("#rail-api[data-dot=fine] .ah-dot,.ah-dot[data-dot=fine]{background:var(--accent,#9cd2ff);opacity:1}", self.html)
+        self.assertIn("#rail-api[data-dot=errors] .ah-dot,.ah-dot[data-dot=errors]{background:var(--st-blocked-bg,#e5484d);opacity:1}", self.html)
+        self.assertIn("#rail-api[data-dot=quiet] .ah-dot,.ah-dot[data-dot=quiet]{background:var(--dim,#9aa4ad);opacity:.55}", self.html)
+        self.assertNotIn("data-state=degraded", self.html, "the machine's words are not colours any more")
 
     def test_the_light_theme_keeps_the_ok_dot_visible_and_the_state_dots_their_colors(self):
         # the dark label gray at .55 blends into the light rail; the light label color keeps the glyph. Scoped to
@@ -266,11 +268,11 @@ class ApiHealthCell(unittest.TestCase):
         # rules (0,2,0), and the card's headline dot would lose its amber and red. The History head shows the signal's
         # quiet states (healthy, unknown) with the same glyph, so the rule names them too (the base gray falls to
         # about 1.6:1 on the white tip)
-        self.assertTrue("body.theme-light #rail-api[data-state=ok] .ah-dot,body.theme-light .ah-dot[data-state=ok],"
-                        "body.theme-light .ah-dot[data-state=healthy],body.theme-light .ah-dot[data-state=unknown]{background:#5D574E}" in self.html,
-                        "the light override names the ok state and the History head's quiet states")
+        # T301: the quiet dot alone needs the light override (fine and errors read on white as they are)
+        self.assertTrue("body.theme-light #rail-api[data-dot=quiet] .ah-dot,body.theme-light .ah-dot[data-dot=quiet]{background:#5D574E}" in self.html,
+                        "the light override names the quiet state, on the rail and in the popup alike")
         self.assertNotIn("body.theme-light .ah-dot{", self.html, "no bare light rule on the dot")
-        self.assertNotIn("body.theme-light .ah-dot[data-state=degraded]", self.html, "the state rules are not restated per theme")
+        self.assertNotIn("body.theme-light .ah-dot[data-dot=errors]", self.html, "the state rules are not restated per theme")
 
     def test_the_shell_socket_carries_the_dashboard_s_wid_minted_before_it_connects(self):
         # the detail's openSession rides the shell socket; with no wid on it the kernel's reveal would fall to the

--- a/tests/test_kernel_pane_rail.py
+++ b/tests/test_kernel_pane_rail.py
@@ -237,7 +237,7 @@ class ApiHealthCell(unittest.TestCase):
         self.assertTrue(tag in self.html, "the cell's markup: hidden, a keyboard button, a dot and nothing else")
         self.assertNotIn(".ah-text", self.html, "no word beside the dot")
         self.assertIn("<div class=ru-name>API</div><span class=ah-slot></span>", self.html, "the readout's slot for the dot")
-        self.assertIn(".ah-slot{display:inline-flex;align-items:center}", self.html)
+        self.assertIn(".ah-slot{display:contents}", self.html)   # no flex item of its own: a hidden dot costs no gap
         tag = re.search(r"<div id=rail-api[^>]*>", self.html).group(0)
         self.assertNotIn("title", tag, "the rail's no-title rule: the detail is the one hover surface")
         self.assertNotIn("data-keycmd", tag, "no palette command yet")

--- a/tests/test_kernel_rail_usage.py
+++ b/tests/test_kernel_rail_usage.py
@@ -80,7 +80,9 @@ class RailUsage(unittest.TestCase):
 
     def test_the_usage_tooltip_is_one_shared_panel_reproducing_both_windows_bars(self):
         # a SINGLE tooltip on the whole rail-usage area (mouseenter on el), not a per-window panel
-        self.assertIn("el.addEventListener('mouseenter',showTip)", self.html, "one shared tooltip for the area")
+        # T301: the API-health dot sits inside this cell; the shared tip yields while the pointer is on the dot
+        self.assertIn("el.addEventListener('mouseenter',function(ev){var c=document.getElementById('rail-api');", self.html, "one shared tooltip for the area")
+        self.assertIn("if(at&&(at===c||c.contains(at)))return;}showTip(ev);});", self.html)
         self.assertIn("['fiveHour','sevenDay','fable'].filter", self.html, "the tooltip covers ALL windows at once")
         # it reproduces the used + elapsed bars (the exact set that used to sit under the timeline)
         self.assertIn("ru-tip-track", self.html, "horizontal used/elapsed bars in the tooltip")

--- a/tests/test_usage_per_account.py
+++ b/tests/test_usage_per_account.py
@@ -178,7 +178,7 @@ class RailRendering(unittest.TestCase):
         # 2026-08-08, evening); each window then wears its ONE display name LEFT of its dollars+tokens
         # (the user 2026-08-09 — same words, font and position as the account bars); the spend bar
         # graphs are gone everywhere (2026-08-08, morning: they told you nothing)
-        self.assertIn("'<div class=ru-name>API</div>'", self.js)
+        self.assertIn("'<div class=ru-name>API</div><span class=ah-slot></span>'", self.js)   # T301: the API-health dot's slot follows the label
         self.assertNotIn("_tail", self.js)
         # pay-per-token wears calendar-ish windows (the user 2026-08-13): 1 day + 1 month on the cell
         # (1 week rides the hover); day||fiveHour keeps an older remote's spend visible (version skew)

--- a/ui/webview/api-health-global.ts
+++ b/ui/webview/api-health-global.ts
@@ -1,0 +1,10 @@
+// Publish the API-health merge and reading rules (./api-health-merge) to the kernel's landing SHELL, whose
+// inline script (_LANDING_APIH_JS) paints the rail's dot and its popup but cannot import a module. Built as its
+// own tiny dist entry (esbuild.js) and included by _landing() before that script, the way age-color-global.ts
+// publishes the recency colour; the consumer feature-tests `window.__rompApiHealthMerge` and falls back to the
+// local frame alone, so a stale dist cannot break the rail (T301).
+import { mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText } from "./api-health-merge";
+
+(window as unknown as { __rompApiHealthMerge: unknown }).__rompApiHealthMerge = {
+  mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText,
+};

--- a/ui/webview/api-health-merge.test.ts
+++ b/ui/webview/api-health-merge.test.ts
@@ -1,0 +1,142 @@
+// T301 (the user 2026-09-10): the rail's API-health dot covers EVERY connected kernel, merged as per-host maps
+// (worst state wins, every machine named, no count or clock compared across hosts), and the popup reads what
+// happened in plain words: traffic with no errors is fine and blue however the state machine words it, no
+// traffic is quiet and gray, and "unknown" is never the headline.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText, HistoryDoc } from "./api-health-merge";
+
+const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
+
+const OK = { state: "ok", cls: "", text: "ok", waiting: 0 };
+const STORM = { state: "degraded", cls: "429", text: "rate limited · 2 waiting", waiting: 2, since: 1000 };
+const PAUSED = { state: "paused", cls: "", reason: "limit", text: "paused: usage limit · 1 waiting", waiting: 1 };
+
+test("worst state wins across machines: one storm anywhere makes the dot red, and that host is named as the cause", () => {
+  const m = mergeFrames(OK, { PEERHOST: OK, TESTHOST: STORM });
+  assert.equal(m.dot, "errors");
+  assert.equal(m.worst, "TESTHOST");
+  assert.equal(m.n, 3, "the local machine and two peers");
+  assert.deepEqual(m.machines.map((x) => x.host), ["", "PEERHOST", "TESTHOST"], "local first, then by name");
+  assert.deepEqual(m.machines.map((x) => x.dot), ["fine", "fine", "errors"]);
+  assert.equal(m.machines[2].text, "TESTHOST: rate limited · 2 waiting");
+});
+
+test("a pause on the local machine is an error state too, and every machine keeps its own line", () => {
+  const m = mergeFrames(PAUSED, { TESTHOST: OK });
+  assert.equal(m.dot, "errors");
+  assert.equal(m.worst, "", "the local machine set it");
+  assert.equal(m.machines[0].text, "this machine: paused until the usage limit resets · 1 waiting");
+  assert.equal(m.machines[1].text, "TESTHOST: fine");
+});
+
+test("every machine fine and quiet reads gray; fine with traffic anywhere reads the accent; a stale host is marked", () => {
+  const QUIET = readHistory(doc({})), FINE = readHistory(doc({ req: 40, ok: 40, state: "healthy" }));
+  const quiet = mergeFrames(OK, { TESTHOST: { ...OK, stale: true } }, { "": QUIET, TESTHOST: QUIET });
+  assert.equal(quiet.dot, "quiet");
+  assert.equal(quiet.machines[0].text, "this machine: no API traffic");
+  assert.equal(quiet.machines[1].stale, true);
+  const fine = mergeFrames(OK, { TESTHOST: OK }, { "": QUIET, TESTHOST: FINE });
+  assert.equal(fine.dot, "fine", "traffic on one machine and no errors anywhere is the accent");
+  assert.equal(fine.machines[1].text, "TESTHOST: fine · 40 requests in the last 15 min, all succeeded");
+  // the frame's own quiet flag (no event in the kernel's longest window) reads gray before any history is read
+  const q = mergeFrames({ ...OK, quiet: true }, { TESTHOST: { ...OK, quiet: true } });
+  assert.equal(q.dot, "quiet");
+  assert.equal(q.machines[1].text, "TESTHOST: no API traffic");
+  assert.equal(mergeFrames({ ...OK, quiet: true }, { TESTHOST: OK }).dot, "fine", "a peer whose frame carries no flag is not assumed quiet");
+  assert.equal(mergeFrames(OK, {}).dot, "fine", "with no history read yet the frame's own word stands: fine");
+  assert.equal(frameDot(STORM, FINE), "errors");
+  assert.equal(frameDot(OK, QUIET), "quiet");
+  // a storm in the WINDOW with nothing waiting right now: the frame says ok, the reading says errors, the dot is red
+  const stormy = readHistory(doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }));
+  assert.equal(frameDot(OK, stormy), "errors");
+  const m = mergeFrames(OK, { TESTHOST: OK }, { "": FINE, TESTHOST: stormy });
+  assert.equal(m.dot, "errors");
+  assert.equal(m.worst, "TESTHOST");
+  assert.match(m.machines[1].text, /^TESTHOST: Rate-limit storm: 20 rate-limited attempts/);
+  assert.equal(machineText("PEERHOST", { state: "degraded", cls: "offline", waiting: 3 }), "PEERHOST: offline · 3 waiting");
+});
+
+test("no cross-host arithmetic: the merge never adds a waiting count or compares a since across hosts", () => {
+  const SRC = read("ui", "webview", "api-health-merge.ts");
+  // a count added to another host's count, or one host's since compared with another's, is the shape the rule bans
+  assert.doesNotMatch(SRC, /\+=\s*[a-z.]*\.waiting\b|\.waiting\s*\+\s*[a-z.]*\.waiting\b|\.since\s*[<>]=?\s*[a-z.]*\.since\b/, "per-host maps in, per-host lines out");
+  const m = mergeFrames({ ...STORM, waiting: 2 }, { TESTHOST: { ...STORM, waiting: 5 } });
+  assert.match(m.machines[0].text, /2 waiting/);
+  assert.match(m.machines[1].text, /5 waiting/);
+  assert.equal(m.machines.filter((x) => /7 waiting/.test(x.text)).length, 0, "no summed count anywhere");
+});
+
+function doc(over: Partial<HistoryDoc> & { req?: number; ok?: number; r429?: number; r5xx?: number; none?: number; state?: string }): HistoryDoc {
+  const req = over.req || 0, ok = over.ok || 0, r429 = over.r429 || 0, r5xx = over.r5xx || 0, none = over.none || 0;
+  return {
+    asOf: 2000, bootAt: 100, config: { windows: [60, 300, 900], minRequests: 10 },
+    overall: { state: over.state || "unknown", worstBucket: req || none ? "key:helper|fable" : null },
+    buckets: req || none ? { "key:helper|fable": { state: over.state || "unknown", windows: {
+      "900": { requests: req, ok, rateLimited: r429, serverErrors: r5xx, noStatus: none, gaveUp: 0 } } } } : {},
+  };
+}
+
+test("the reading rule: traffic and no errors reads what happened, fine and blue, with the trend caveat as a sub-line", () => {
+  const r = readHistory(doc({ req: 4, ok: 4, state: "unknown" }));
+  assert.equal(r.level, "fine");
+  assert.equal(r.headline, "4 requests in the last 15 min, all succeeded.");
+  assert.equal(r.sub, "Too few requests to call a trend yet.");
+  assert.equal(r.traffic, true);
+  assert.doesNotMatch(r.headline, /unknown/);
+  const healthy = readHistory(doc({ req: 40, ok: 40, state: "healthy" }));
+  assert.equal(healthy.level, "fine");
+  assert.equal(healthy.sub, null, "the machine has a verdict: no caveat");
+});
+
+test("no traffic at all reads quiet and gray; errors read the failures in plain words with the machine's own word", () => {
+  const q = readHistory(doc({}));
+  assert.equal(q.level, "quiet");
+  assert.equal(q.headline, "No API traffic in the last 15 min.");
+  assert.equal(q.traffic, false);
+  const s = readHistory(doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }));
+  assert.equal(s.level, "errors");
+  assert.equal(s.headline, "Rate-limit storm: 20 rate-limited attempts among 30 attempts in the last 15 min.");
+  const d = readHistory(doc({ req: 12, ok: 9, r5xx: 3, state: "degraded" }));
+  assert.equal(d.headline, "The API is failing: 3 server errors among 12 attempts in the last 15 min.");
+  const off = readHistory(doc({ none: 5 }));
+  assert.equal(off.level, "errors");
+  assert.equal(off.headline, "Errors: 5 attempts with no connection among 5 attempts in the last 15 min.");
+  assert.equal(readHistory(null).level, "quiet", "no document yet reads as no traffic, never as a word the user must decode");
+});
+
+test("histories merge as per-host rows: each machine keeps its sentence, the worst level leads, a failed read is its own line", () => {
+  const m = mergeHistories({ "": doc({ req: 4, ok: 4 }), TESTHOST: doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }), PEERHOST: { error: "HTTP 502" } });
+  assert.equal(m.level, "errors");
+  assert.deepEqual(m.rows.map((r) => r.host), ["", "PEERHOST", "TESTHOST"]);
+  assert.equal(m.rows[0].reading!.headline, "4 requests in the last 15 min, all succeeded.");
+  assert.equal(m.rows[1].error, "HTTP 502");
+  assert.match(m.rows[2].reading!.headline, /^Rate-limit storm/);
+  assert.deepEqual(m.traffic, { "": true, PEERHOST: null, TESTHOST: true });
+  assert.equal(m.readings[""]!.level, "fine");
+  assert.equal(m.readings.PEERHOST, null, "a failed read is no reading: the frame's word stands for that host");
+  assert.equal(m.rows.filter((r) => r.reading && /34 requests/.test(r.reading.headline)).length, 0, "4 + 30 is never said");
+});
+
+test("a document's per-minute series sums its OWN buckets bin by bin, and none is null", () => {
+  const d: HistoryDoc = { buckets: {
+    a: { series: { binS: 60, from: 0, ok: [1, 2, 3], rateLimited: [0, 1, 0], serverErrors: [0, 0, 1], noStatus: [0, 0, 0], other: [0, 0, 0] } },
+    b: { series: { binS: 60, from: 0, ok: [1, 0, 0], rateLimited: [2, 0, 0], serverErrors: [0, 0, 0], noStatus: [1, 0, 0], other: [0, 0, 0] } },
+  } };
+  const s = documentSeries(d)!;
+  assert.deepEqual(s.ok, [2, 2, 3]);
+  assert.deepEqual(s.rateLimited, [2, 1, 0]);
+  assert.deepEqual(s.serverErrors, [0, 0, 1]);
+  assert.deepEqual(s.noStatus, [1, 0, 0]);
+  assert.equal(documentSeries({ buckets: { a: {} } }), null);
+});
+
+test("the shell loads the merge module before its API-health script and the bundle lists it", () => {
+  const KERNEL = read("kernel", "kernel.py");
+  const i = KERNEL.indexOf("/dist/api-health-global.js?v=%d"), j = KERNEL.indexOf('"<script>" + _LANDING_APIH_JS + "</script>"');
+  assert.ok(i > 0 && j > i, "the global module is included, and before the script that reads it");
+  assert.match(read("vscode-extension", "esbuild.js"), /"\.\.\/ui\/webview\/api-health-global\.ts"/);
+  assert.match(read("ui", "webview", "api-health-global.ts"), /__rompApiHealthMerge = \{\s*mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText,/);
+});

--- a/ui/webview/api-health-merge.test.ts
+++ b/ui/webview/api-health-merge.test.ts
@@ -1,7 +1,8 @@
 // T301 (the user 2026-09-10): the rail's API-health dot covers EVERY connected kernel, merged as per-host maps
 // (worst state wins, every machine named, no count or clock compared across hosts), and the popup reads what
 // happened in plain words: traffic with no errors is fine and blue however the state machine words it, no
-// traffic is quiet and gray, and "unknown" is never the headline.
+// traffic is quiet and gray, and "unknown" is never the headline. The dot follows the FRAMES (each kernel's
+// quiet and errs flags, pushed on change); a history reading words a line and never colours the dot.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -10,9 +11,10 @@ import { mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, mac
 
 const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
 
-const OK = { state: "ok", cls: "", text: "ok", waiting: 0 };
-const STORM = { state: "degraded", cls: "429", text: "rate limited · 2 waiting", waiting: 2, since: 1000 };
+const OK = { state: "ok", cls: "", text: "ok", waiting: 0, quiet: false, errs: 0 };
+const STORM = { state: "degraded", cls: "429", text: "rate limited · 2 waiting", waiting: 2, since: 1000, quiet: false, errs: 12 };
 const PAUSED = { state: "paused", cls: "", reason: "limit", text: "paused: usage limit · 1 waiting", waiting: 1 };
+const QUIET = { ...OK, quiet: true };
 
 test("worst state wins across machines: one storm anywhere makes the dot red, and that host is named as the cause", () => {
   const m = mergeFrames(OK, { PEERHOST: OK, TESTHOST: STORM });
@@ -32,37 +34,55 @@ test("a pause on the local machine is an error state too, and every machine keep
   assert.equal(m.machines[1].text, "TESTHOST: fine");
 });
 
-test("every machine fine and quiet reads gray; fine with traffic anywhere reads the accent; a stale host is marked", () => {
-  const QUIET = readHistory(doc({})), FINE = readHistory(doc({ req: 40, ok: 40, state: "healthy" }));
-  const quiet = mergeFrames(OK, { TESTHOST: { ...OK, stale: true } }, { "": QUIET, TESTHOST: QUIET });
-  assert.equal(quiet.dot, "quiet");
-  assert.equal(quiet.machines[0].text, "this machine: no API traffic");
-  assert.equal(quiet.machines[1].stale, true);
-  const fine = mergeFrames(OK, { TESTHOST: OK }, { "": QUIET, TESTHOST: FINE });
-  assert.equal(fine.dot, "fine", "traffic on one machine and no errors anywhere is the accent");
-  assert.equal(fine.machines[1].text, "TESTHOST: fine · 40 requests in the last 15 min, all succeeded");
-  // the frame's own quiet flag (no event in the kernel's longest window) reads gray before any history is read
-  const q = mergeFrames({ ...OK, quiet: true }, { TESTHOST: { ...OK, quiet: true } });
-  assert.equal(q.dot, "quiet");
-  assert.equal(q.machines[1].text, "TESTHOST: no API traffic");
-  assert.equal(mergeFrames({ ...OK, quiet: true }, { TESTHOST: OK }).dot, "fine", "a peer whose frame carries no flag is not assumed quiet");
-  assert.equal(mergeFrames(OK, {}).dot, "fine", "with no history read yet the frame's own word stands: fine");
-  assert.equal(frameDot(STORM, FINE), "errors");
-  assert.equal(frameDot(OK, QUIET), "quiet");
-  // a storm in the WINDOW with nothing waiting right now: the frame says ok, the reading says errors, the dot is red
-  const stormy = readHistory(doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }));
-  assert.equal(frameDot(OK, stormy), "errors");
-  const m = mergeFrames(OK, { TESTHOST: OK }, { "": FINE, TESTHOST: stormy });
+test("the dot is the frames' alone: quiet everywhere reads gray, traffic anywhere the accent, failed attempts in a window red", () => {
+  assert.equal(mergeFrames(QUIET, { TESTHOST: QUIET }).dot, "quiet");
+  assert.equal(mergeFrames(QUIET, { TESTHOST: QUIET }).machines[1].text, "TESTHOST: no API traffic");
+  assert.equal(mergeFrames(QUIET, { TESTHOST: OK }).dot, "fine", "one machine with traffic and no errors: the accent");
+  assert.equal(mergeFrames(QUIET, { TESTHOST: { state: "ok" } }).dot, "fine", "a peer whose frame carries no flag (an older kernel) is not assumed quiet");
+  assert.equal(mergeFrames({ state: "ok" }, {}).dot, "fine", "a frame without the flags stands on its state word");
+  // a storm in the WINDOW with nothing waiting right now: the frame says ok and counts the failures, the dot is red
+  const m = mergeFrames(OK, { TESTHOST: { ...OK, errs: 20 } });
   assert.equal(m.dot, "errors");
   assert.equal(m.worst, "TESTHOST");
-  assert.match(m.machines[1].text, /^TESTHOST: Rate-limit storm: 20 rate-limited attempts/);
+  assert.equal(m.machines[1].text, "TESTHOST: 20 failed attempts in the last 15 min");
+  assert.equal(frameDot({ ...OK, errs: 1 }), "errors");
+  assert.equal(frameDot(QUIET), "quiet");
+  assert.equal(frameDot(STORM), "errors");
   assert.equal(machineText("PEERHOST", { state: "degraded", cls: "offline", waiting: 3 }), "PEERHOST: offline · 3 waiting");
+});
+
+test("a history reading words a machine's line and never colours the dot: a stale reading cannot pin it red or gray", () => {
+  const FINE = readHistory(doc({ req: 40, ok: 40, state: "healthy" })), stormy = readHistory(doc({ req: 30, ok: 10, r429: 20, state: "thrashing" })), NONE = readHistory(doc({}));
+  const fine = mergeFrames(OK, { TESTHOST: OK }, { "": NONE, TESTHOST: FINE });
+  assert.equal(fine.machines[1].text, "TESTHOST: fine · 40 requests in the last 15 min, all succeeded");
+  assert.equal(fine.dot, "fine");
+  // the reading from a hover during a storm, the storm since over and the frame back to ok with no failures in the window
+  assert.equal(mergeFrames(OK, { TESTHOST: OK }, { TESTHOST: stormy }).dot, "fine", "the frame is the newer word: the dot is not red");
+  // the reading from a hover during a quiet spell, traffic since resumed (the frame's quiet flag dropped)
+  assert.equal(mergeFrames(OK, {}, { "": NONE }).dot, "fine", "the dot is not gray");
+  // a window in errors with a reading in hand: the reading's sentence words the line, the frame's count colours the dot
+  const m = mergeFrames(OK, { TESTHOST: { ...OK, errs: 20 } }, { TESTHOST: stormy });
+  assert.equal(m.dot, "errors");
+  assert.match(m.machines[1].text, /^TESTHOST: Rate-limit storm: 20 rate-limited attempts/);
+});
+
+test("a machine whose tunnel is down or whose frame could not be read is named and has no say in the dot", () => {
+  const down = mergeFrames(OK, { TESTHOST: { ...STORM, stale: true } });
+  assert.equal(down.dot, "fine", "its last frame is old news: a storm heard before the link dropped does not keep the dot red");
+  assert.equal(down.machines[1].stale, true);
+  assert.equal(down.machines[1].dot, "quiet");
+  assert.equal(down.machines[1].text, "TESTHOST: not reachable, last seen rate limited · 2 waiting");
+  assert.equal(mergeFrames(QUIET, { TESTHOST: { ...OK, stale: true } }).dot, "quiet", "nor does a fine frame heard before the drop block gray");
+  const refused = mergeFrames(OK, { TESTHOST: { ...OK, stale: true, fault: "HTTP 403" } });
+  assert.equal(refused.dot, "fine");
+  assert.equal(refused.machines[1].text, "TESTHOST: could not read its API health (HTTP 403), last seen fine");
+  assert.equal(mergeFrames(OK, { TESTHOST: { state: "", stale: true, fault: "HTTP 500" } }).machines[1].text, "TESTHOST: could not read its API health (HTTP 500)", "a fault before any frame was heard");
 });
 
 test("no cross-host arithmetic: the merge never adds a waiting count or compares a since across hosts", () => {
   const SRC = read("ui", "webview", "api-health-merge.ts");
   // a count added to another host's count, or one host's since compared with another's, is the shape the rule bans
-  assert.doesNotMatch(SRC, /\+=\s*[a-z.]*\.waiting\b|\.waiting\s*\+\s*[a-z.]*\.waiting\b|\.since\s*[<>]=?\s*[a-z.]*\.since\b/, "per-host maps in, per-host lines out");
+  assert.doesNotMatch(SRC, /\+=\s*[a-z.]*\.waiting\b|\.waiting\s*\+\s*[a-z.]*\.waiting\b|\.since\s*[<>]=?\s*[a-z.]*\.since\b|\+=\s*[a-z.]*\.errs\b/, "per-host maps in, per-host lines out");
   const m = mergeFrames({ ...STORM, waiting: 2 }, { TESTHOST: { ...STORM, waiting: 5 } });
   assert.match(m.machines[0].text, /2 waiting/);
   assert.match(m.machines[1].text, /5 waiting/);
@@ -107,16 +127,19 @@ test("no traffic at all reads quiet and gray; errors read the failures in plain 
   assert.equal(readHistory(null).level, "quiet", "no document yet reads as no traffic, never as a word the user must decode");
 });
 
-test("histories merge as per-host rows: each machine keeps its sentence, the worst level leads, a failed read is its own line", () => {
-  const m = mergeHistories({ "": doc({ req: 4, ok: 4 }), TESTHOST: doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }), PEERHOST: { error: "HTTP 502" } });
+test("histories merge as per-host rows: each machine keeps its sentence, the worst level leads, a failed or pending read is its own row", () => {
+  const m = mergeHistories({ "": doc({ req: 4, ok: 4 }), TESTHOST: doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }), PEERHOST: { error: "HTTP 502" }, FARHOST: { pending: true } });
   assert.equal(m.level, "errors");
-  assert.deepEqual(m.rows.map((r) => r.host), ["", "PEERHOST", "TESTHOST"]);
+  assert.deepEqual(m.rows.map((r) => r.host), ["", "FARHOST", "PEERHOST", "TESTHOST"]);
   assert.equal(m.rows[0].reading!.headline, "4 requests in the last 15 min, all succeeded.");
-  assert.equal(m.rows[1].error, "HTTP 502");
-  assert.match(m.rows[2].reading!.headline, /^Rate-limit storm/);
-  assert.deepEqual(m.traffic, { "": true, PEERHOST: null, TESTHOST: true });
+  assert.equal(m.rows[1].pending, true, "a read still in flight is no reading and no error");
+  assert.equal(m.rows[1].reading, null);
+  assert.equal(m.rows[2].error, "HTTP 502");
+  assert.match(m.rows[3].reading!.headline, /^Rate-limit storm/);
+  assert.deepEqual(m.traffic, { "": true, FARHOST: null, PEERHOST: null, TESTHOST: true });
   assert.equal(m.readings[""]!.level, "fine");
   assert.equal(m.readings.PEERHOST, null, "a failed read is no reading: the frame's word stands for that host");
+  assert.equal(m.readings.FARHOST, null);
   assert.equal(m.rows.filter((r) => r.reading && /34 requests/.test(r.reading.headline)).length, 0, "4 + 30 is never said");
 });
 

--- a/ui/webview/api-health-merge.ts
+++ b/ui/webview/api-health-merge.ts
@@ -6,6 +6,11 @@
 // The federation rule holds throughout: per-host MAPS in, per-host lines out; nothing here adds a count from
 // one kernel to a count from another or compares two kernels' clocks. "Worst state wins" is a comparison of
 // STATE WORDS, which are the same vocabulary on every kernel.
+//
+// The dot follows the FRAMES alone (review find, 2026-09-10): each kernel's frame carries `quiet` (no API event
+// in its longest window) and `errs` (failed attempts in it), rebuilt every cycle and pushed on change, so the dot
+// changes on the kernel's events and never on a history reading the browser took at some earlier hover. The
+// readings only word each machine's line in the popup.
 
 /** One kernel's apiHealth shell frame, local half (the fields the merge reads). */
 export interface HostFrame {
@@ -15,8 +20,10 @@ export interface HostFrame {
   waiting?: number;
   reason?: string;       // a pause's reason: limit | spend | manual
   since?: number;
-  quiet?: boolean;       // that kernel saw no API event in its longest window (T301): gray before any history is read
-  stale?: boolean;       // the tunnel to that host is not up: the frame is the last one heard
+  quiet?: boolean;       // that kernel saw no API event in its longest window (T301): gray
+  errs?: number;         // failed attempts that kernel counted in its longest window (T301): red while any
+  stale?: boolean;       // the tunnel to that host is not up, or its frame could not be read: the frame is the last one heard
+  fault?: string;        // why the last read of that host's frame was refused ("HTTP 403"), when it was
 }
 
 /** The dot's three states: the accent when everything is fine, red when errors are being met, gray when quiet. */
@@ -26,7 +33,7 @@ export interface MachineLine {
   host: string;
   dot: Dot;
   text: string;          // one plain line for the popup: "TESTHOST: rate limited · 2 waiting"
-  stale: boolean;
+  stale: boolean;        // named, not counted: a machine not reachable right now has no say in the dot
 }
 
 export interface Merged {
@@ -41,13 +48,13 @@ function frameRank(f: HostFrame): number {
   return f.state === "paused" || f.state === "degraded" ? 2 : f.state === "ok" ? 1 : 0;
 }
 
-/** A frame's dot with its history reading in hand: errors when the kernel's frame says so OR the reading found
- *  errors in the window; quiet when the reading found no traffic; else fine. A frame alone (no reading yet) is
- *  errors or fine on its own words. */
-export function frameDot(f: HostFrame, reading?: Reading | null): Dot {
+/** A frame's dot, from the frame alone: errors when its kernel says a session is waiting on the API (degraded),
+ *  is paused, or counted a failed attempt in its longest window (`errs`); quiet when it saw no event in that window;
+ *  else fine. A frame with neither flag (an older kernel) is fine or errors on its state word. */
+export function frameDot(f: HostFrame): Dot {
   if (f.state === "paused" || f.state === "degraded") return "errors";
-  if (reading && reading.level === "errors") return "errors";
-  if (reading ? !reading.traffic : f.quiet === true) return "quiet";
+  if ((f.errs || 0) > 0) return "errors";
+  if (f.quiet === true) return "quiet";
   return "fine";
 }
 
@@ -55,29 +62,43 @@ const CLS_WORDS: Record<string, string> = {
   "429": "rate limited", "529": "overloaded", "offline": "offline", "errors": "errors",
 };
 
-/** One machine's line for the popup, in plain words: the kernel's own headline when its frame carries one (a pause,
- *  sessions waiting on the API), else what the history reading says happened. */
-export function machineText(host: string, f: HostFrame, reading?: Reading | null): string {
-  const name = host || "this machine";
+/** What one machine's frame says, in plain words: the kernel's own headline when its frame carries one (a pause,
+ *  sessions waiting on the API), the failures counted when its window holds some (the history reading's sentence
+ *  when read, the frame's count otherwise), the successes counted when fine and read, quiet when its window is empty. */
+function stateWords(f: HostFrame, reading?: Reading | null): string {
   if (f.state === "paused") {
     const why = f.reason === "limit" ? "paused until the usage limit resets" : f.reason === "spend" ? "paused at the spend limit" : "paused by you";
-    return name + ": " + why + (f.waiting ? " · " + f.waiting + " waiting" : "");
+    return why + (f.waiting ? " · " + f.waiting + " waiting" : "");
   }
   if (f.state === "degraded") {
-    return name + ": " + (CLS_WORDS[f.cls || ""] || "errors") + (f.waiting ? " · " + f.waiting + " waiting" : "");
+    return (CLS_WORDS[f.cls || ""] || "errors") + (f.waiting ? " · " + f.waiting + " waiting" : "");
   }
-  if (reading && reading.level === "errors") return name + ": " + reading.headline.replace(/\.$/, "");
-  if (reading ? !reading.traffic : f.quiet === true) return name + ": no API traffic";
-  if (reading) return name + ": fine · " + plural(reading.requests, "request") + " in the last 15 min, all succeeded";
-  return name + ": fine";
+  if ((f.errs || 0) > 0) {
+    if (reading && reading.level === "errors") return reading.headline.replace(/\.$/, "");
+    return plural(f.errs as number, "failed attempt") + " in the last 15 min";
+  }
+  if (f.quiet === true) return "no API traffic";
+  if (reading && reading.level === "fine") return "fine · " + plural(reading.requests, "request") + " in the last 15 min, all succeeded";
+  return "fine";
+}
+
+/** One machine's line for the popup. A machine not reachable right now is named with what was last heard from
+ *  it (and why the read failed, when a read was refused), and reads as such rather than as its old state. */
+export function machineText(host: string, f: HostFrame, reading?: Reading | null): string {
+  const name = host || "this machine";
+  const words = f.state ? stateWords(f, reading) : "";
+  if (f.fault) return name + ": could not read its API health (" + f.fault + ")" + (words ? ", last seen " + words : "");
+  if (f.stale) return name + ": not reachable, last seen " + (words || "fine");
+  return name + ": " + words;
 }
 
 /**
  * The dot and the machine lines over the local frame, the per-host map the kernel's frame carries, and each
- * machine's history reading when read (`readings[host]`; absent or null = not read yet: the frame's word stands
- * alone). Worst state wins: one machine in errors (its frame, or its window) makes the dot red whatever the others
- * say; every machine known quiet (its reading, or its frame's flag) makes it gray; otherwise the accent. Per-host
- * in, per-host out.
+ * machine's history reading when read (`readings[host]`; absent or null = not read yet). The dot is the frames':
+ * worst state wins, so one machine in errors (waiting sessions, a pause, or failed attempts in its window) makes
+ * the dot red whatever the others say; every reachable machine quiet makes it gray; otherwise the accent. A
+ * machine whose tunnel is down or whose frame could not be read is named and has no say (its frame is old news).
+ * The readings word the lines only. Per-host in, per-host out.
  */
 export function mergeFrames(local: HostFrame, hosts: Record<string, HostFrame> | undefined,
                             readings?: Record<string, Reading | null | undefined>): Merged {
@@ -87,12 +108,14 @@ export function mergeFrames(local: HostFrame, hosts: Record<string, HostFrame> |
   let worstRank = -1, worst = "", allQuiet = true;
   const machines: MachineLine[] = rows.map(([host, f]) => {
     const rd = readings ? readings[host] || null : null;
-    const d = frameDot(f, rd);
-    const traffic = rd ? rd.traffic : (f.quiet === true ? false : null);
-    if (traffic !== false) allQuiet = false;   // gray only when EVERY machine is known quiet; an unread peer is not assumed so
-    const r = d === "errors" ? 2 : frameRank(f);
-    if (r > worstRank) { worstRank = r; worst = host; }
-    return { host, dot: d, text: machineText(host, f, rd), stale: !!f.stale };
+    const away = !!(f.stale || f.fault);
+    const d: Dot = away ? "quiet" : frameDot(f);
+    if (!away) {
+      if (f.quiet !== true) allQuiet = false;   // gray only when EVERY reachable machine says quiet; a frame without the flag is not assumed so
+      const r = d === "errors" ? 2 : frameRank(f);
+      if (r > worstRank) { worstRank = r; worst = host; }
+    }
+    return { host, dot: d, text: machineText(host, f, rd), stale: away };
   });
   let dot: Dot;
   if (worstRank >= 2) dot = "errors";
@@ -173,12 +196,14 @@ export function readHistory(d: HistoryDoc | null | undefined): Reading {
   return { level: state === "recovering" && errors === 0 ? "fine" : "errors", state, headline: head, sub: null, requests, errors, traffic, windowS: slow };
 }
 
-/** One machine's reading, kept under its name; a failed read is its own line. */
-export interface HostReading { host: string; reading: Reading | null; error: string | null }
+/** One machine's reading, kept under its name; a failed read is its own line; a read still in flight is pending. */
+export interface HostReading { host: string; reading: Reading | null; error: string | null; pending: boolean }
 
-/** The histories merged for the popup: per-host readings (the map the frame merge takes), the worst level, and
- *  the traffic verdicts. No document's counts are added to another's: each machine keeps its own sentence. */
-export function mergeHistories(byHost: Record<string, HistoryDoc | { error: string } | null | undefined>): {
+/** The histories merged for the popup: per-host readings (the map the frame merge takes for its lines), the worst
+ *  level, and the traffic verdicts. No document's counts are added to another's: each machine keeps its own
+ *  sentence. A `{pending: true}` entry (the shell's placeholder while that machine's read is in flight) and an
+ *  `{error}` entry are no reading. */
+export function mergeHistories(byHost: Record<string, HistoryDoc | { error: string } | { pending: true } | null | undefined>): {
   level: "errors" | "fine" | "quiet" | "unread"; rows: HostReading[]; traffic: Record<string, boolean | null>;
   readings: Record<string, Reading | null>;
 } {
@@ -190,10 +215,11 @@ export function mergeHistories(byHost: Record<string, HistoryDoc | { error: stri
   const rank = { unread: -1, quiet: 0, fine: 1, errors: 2 };
   for (const h of names) {
     const d = byHost[h];
-    if (!d) { rows.push({ host: h, reading: null, error: null }); traffic[h] = null; readings[h] = null; continue; }
-    if ((d as { error?: string }).error) { rows.push({ host: h, reading: null, error: String((d as { error: string }).error) }); traffic[h] = null; readings[h] = null; continue; }
+    if (!d) { rows.push({ host: h, reading: null, error: null, pending: false }); traffic[h] = null; readings[h] = null; continue; }
+    if ((d as { pending?: boolean }).pending) { rows.push({ host: h, reading: null, error: null, pending: true }); traffic[h] = null; readings[h] = null; continue; }
+    if ((d as { error?: string }).error) { rows.push({ host: h, reading: null, error: String((d as { error: string }).error), pending: false }); traffic[h] = null; readings[h] = null; continue; }
     const r = readHistory(d as HistoryDoc);
-    rows.push({ host: h, reading: r, error: null });
+    rows.push({ host: h, reading: r, error: null, pending: false });
     traffic[h] = r.traffic; readings[h] = r;
     if (rank[r.level] > rank[level]) level = r.level;
   }

--- a/ui/webview/api-health-merge.ts
+++ b/ui/webview/api-health-merge.ts
@@ -1,0 +1,217 @@
+// The API-health signal on the shell's rail, across EVERY connected kernel (T301, the user 2026-09-10): the
+// merge of the per-host frames into the one dot, the plain-words reading of one kernel's /api-health document,
+// and the merge of several such documents. Pure (no DOM), so the rules are unit-tested; the shell's inline
+// script (kernel.py _LANDING_APIH_JS) reaches them through window.__rompApiHealthMerge (api-health-global.ts).
+//
+// The federation rule holds throughout: per-host MAPS in, per-host lines out; nothing here adds a count from
+// one kernel to a count from another or compares two kernels' clocks. "Worst state wins" is a comparison of
+// STATE WORDS, which are the same vocabulary on every kernel.
+
+/** One kernel's apiHealth shell frame, local half (the fields the merge reads). */
+export interface HostFrame {
+  state: "ok" | "degraded" | "paused" | string;
+  cls?: string;          // "429" | "529" | "offline" | "errors" | ""
+  text?: string;         // the kernel's own headline
+  waiting?: number;
+  reason?: string;       // a pause's reason: limit | spend | manual
+  since?: number;
+  quiet?: boolean;       // that kernel saw no API event in its longest window (T301): gray before any history is read
+  stale?: boolean;       // the tunnel to that host is not up: the frame is the last one heard
+}
+
+/** The dot's three states: the accent when everything is fine, red when errors are being met, gray when quiet. */
+export type Dot = "fine" | "errors" | "quiet";
+
+export interface MachineLine {
+  host: string;
+  dot: Dot;
+  text: string;          // one plain line for the popup: "TESTHOST: rate limited · 2 waiting"
+  stale: boolean;
+}
+
+export interface Merged {
+  dot: Dot;
+  worst: string;                 // the host that set the dot ("" for the local machine)
+  machines: MachineLine[];       // one line per machine, local first, then by name
+  n: number;                     // machines counted
+}
+
+/** Rank of a frame's state for "worst wins": paused and degraded are both errors; ok is fine. */
+function frameRank(f: HostFrame): number {
+  return f.state === "paused" || f.state === "degraded" ? 2 : f.state === "ok" ? 1 : 0;
+}
+
+/** A frame's dot with its history reading in hand: errors when the kernel's frame says so OR the reading found
+ *  errors in the window; quiet when the reading found no traffic; else fine. A frame alone (no reading yet) is
+ *  errors or fine on its own words. */
+export function frameDot(f: HostFrame, reading?: Reading | null): Dot {
+  if (f.state === "paused" || f.state === "degraded") return "errors";
+  if (reading && reading.level === "errors") return "errors";
+  if (reading ? !reading.traffic : f.quiet === true) return "quiet";
+  return "fine";
+}
+
+const CLS_WORDS: Record<string, string> = {
+  "429": "rate limited", "529": "overloaded", "offline": "offline", "errors": "errors",
+};
+
+/** One machine's line for the popup, in plain words: the kernel's own headline when its frame carries one (a pause,
+ *  sessions waiting on the API), else what the history reading says happened. */
+export function machineText(host: string, f: HostFrame, reading?: Reading | null): string {
+  const name = host || "this machine";
+  if (f.state === "paused") {
+    const why = f.reason === "limit" ? "paused until the usage limit resets" : f.reason === "spend" ? "paused at the spend limit" : "paused by you";
+    return name + ": " + why + (f.waiting ? " · " + f.waiting + " waiting" : "");
+  }
+  if (f.state === "degraded") {
+    return name + ": " + (CLS_WORDS[f.cls || ""] || "errors") + (f.waiting ? " · " + f.waiting + " waiting" : "");
+  }
+  if (reading && reading.level === "errors") return name + ": " + reading.headline.replace(/\.$/, "");
+  if (reading ? !reading.traffic : f.quiet === true) return name + ": no API traffic";
+  if (reading) return name + ": fine · " + plural(reading.requests, "request") + " in the last 15 min, all succeeded";
+  return name + ": fine";
+}
+
+/**
+ * The dot and the machine lines over the local frame, the per-host map the kernel's frame carries, and each
+ * machine's history reading when read (`readings[host]`; absent or null = not read yet: the frame's word stands
+ * alone). Worst state wins: one machine in errors (its frame, or its window) makes the dot red whatever the others
+ * say; every machine known quiet (its reading, or its frame's flag) makes it gray; otherwise the accent. Per-host
+ * in, per-host out.
+ */
+export function mergeFrames(local: HostFrame, hosts: Record<string, HostFrame> | undefined,
+                            readings?: Record<string, Reading | null | undefined>): Merged {
+  const names = Object.keys(hosts || {}).sort();
+  const rows: Array<[string, HostFrame]> = [["", local]];
+  for (const h of names) rows.push([h, (hosts as Record<string, HostFrame>)[h]]);
+  let worstRank = -1, worst = "", allQuiet = true;
+  const machines: MachineLine[] = rows.map(([host, f]) => {
+    const rd = readings ? readings[host] || null : null;
+    const d = frameDot(f, rd);
+    const traffic = rd ? rd.traffic : (f.quiet === true ? false : null);
+    if (traffic !== false) allQuiet = false;   // gray only when EVERY machine is known quiet; an unread peer is not assumed so
+    const r = d === "errors" ? 2 : frameRank(f);
+    if (r > worstRank) { worstRank = r; worst = host; }
+    return { host, dot: d, text: machineText(host, f, rd), stale: !!f.stale };
+  });
+  let dot: Dot;
+  if (worstRank >= 2) dot = "errors";
+  else if (allQuiet) dot = "quiet";
+  else dot = "fine";
+  if (worstRank < 2) worst = "";
+  return { dot, worst, machines, n: rows.length };
+}
+
+/** The bits of a /api-health document the reading needs. */
+export interface HistoryDoc {
+  asOf?: number;
+  bootAt?: number;
+  overall?: { state?: string; worstBucket?: string | null };
+  buckets?: Record<string, {
+    state?: string; stateSince?: number; why?: string;
+    windows?: Record<string, { requests?: number; ok?: number; noStatus?: number; gaveUp?: number; rateLimited?: number; serverErrors?: number; overloaded?: number; otherErrors?: number; complete?: boolean }>;
+    series?: { binS: number; from: number; ok: number[]; rateLimited: number[]; serverErrors: number[]; noStatus: number[]; other: number[] };
+  }>;
+  config?: { windows?: number[]; minRequests?: number };
+}
+
+export interface Reading {
+  level: "errors" | "fine" | "quiet";
+  state: string;             // the machine's own word, for the record (never the headline when it is "unknown")
+  headline: string;          // what the user reads first
+  sub: string | null;        // the trend caveat, when the machine has too little to call one
+  requests: number;          // attempts with a status over the longest window, every bucket
+  errors: number;            // failed attempts over it (429 + 5xx + other + no status)
+  traffic: boolean;          // any attempt at all over the longest window
+  windowS: number;
+}
+
+const SEV: Record<string, number> = { unknown: 0, healthy: 1, recovering: 2, degraded: 3, thrashing: 4 };
+
+function minutes(s: number): string { return s % 60 === 0 ? (s / 60) + " min" : s + " s"; }
+function plural(n: number, w: string): string { return n + " " + w + (n === 1 ? "" : "s"); }
+
+/**
+ * The reading rule (part C): the machine's `unknown` is a documented signal and stays in the document, but the
+ * user reads what HAPPENED. Traffic and no errors: "N requests in the last 15 min, all succeeded" (fine; when the
+ * machine still says unknown, the sub-line says too few to call a trend). Errors: the failures counted, in the
+ * machine's word when it has one (thrashing / degraded / recovering), else plainly. No traffic: quiet. The word
+ * "unknown" is never the headline.
+ */
+export function readHistory(d: HistoryDoc | null | undefined): Reading {
+  const wins = (d && d.config && d.config.windows) || [60, 300, 900];
+  const slow = Math.max.apply(null, wins);
+  const buckets = (d && d.buckets) || {};
+  let requests = 0, ok = 0, noStatus = 0, gaveUp = 0, r429 = 0, r5xx = 0, other = 0;
+  let worst = "unknown";
+  for (const k of Object.keys(buckets)) {
+    const b = buckets[k];
+    const w = (b.windows || {})[String(slow)] || {};
+    requests += w.requests || 0; ok += w.ok || 0; noStatus += w.noStatus || 0; gaveUp += w.gaveUp || 0;
+    r429 += w.rateLimited || 0; r5xx += (w.serverErrors || 0) + (w.overloaded || 0); other += w.otherErrors || 0;
+    if ((SEV[b.state || "unknown"] || 0) > (SEV[worst] || 0)) worst = b.state || worst;
+  }
+  const errors = r429 + r5xx + other + noStatus;
+  const attempts = requests + noStatus;
+  const traffic = attempts > 0;
+  const state = (d && d.overall && d.overall.state) || worst;
+  const win = minutes(slow);
+  if (!traffic) {
+    return { level: "quiet", state, headline: "No API traffic in the last " + win + ".", sub: null, requests, errors, traffic, windowS: slow };
+  }
+  if (errors === 0) {
+    const sub = state === "unknown" || SEV[state] === undefined ? "Too few requests to call a trend yet." : null;
+    return { level: "fine", state, headline: plural(requests, "request") + " in the last " + win + ", all succeeded.", sub, requests, errors, traffic, windowS: slow };
+  }
+  const parts: string[] = [];
+  if (r429) parts.push(plural(r429, "rate-limited attempt"));
+  if (r5xx) parts.push(plural(r5xx, "server error"));
+  if (noStatus) parts.push(plural(noStatus, "attempt") + " with no connection");
+  if (other) parts.push(plural(other, "other error"));
+  const word = state === "thrashing" ? "Rate-limit storm" : state === "degraded" ? "The API is failing" : state === "recovering" ? "Recovering" : "Errors";
+  const head = word + ": " + parts.join(", ") + " among " + plural(attempts, "attempt") + " in the last " + win + (gaveUp ? "; " + plural(gaveUp, "turn") + " gave up" : "") + ".";
+  return { level: state === "recovering" && errors === 0 ? "fine" : "errors", state, headline: head, sub: null, requests, errors, traffic, windowS: slow };
+}
+
+/** One machine's reading, kept under its name; a failed read is its own line. */
+export interface HostReading { host: string; reading: Reading | null; error: string | null }
+
+/** The histories merged for the popup: per-host readings (the map the frame merge takes), the worst level, and
+ *  the traffic verdicts. No document's counts are added to another's: each machine keeps its own sentence. */
+export function mergeHistories(byHost: Record<string, HistoryDoc | { error: string } | null | undefined>): {
+  level: "errors" | "fine" | "quiet" | "unread"; rows: HostReading[]; traffic: Record<string, boolean | null>;
+  readings: Record<string, Reading | null>;
+} {
+  const names = Object.keys(byHost).sort((a, b) => (a === "" ? -1 : b === "" ? 1 : a < b ? -1 : 1));
+  const rows: HostReading[] = [];
+  const traffic: Record<string, boolean | null> = {};
+  const readings: Record<string, Reading | null> = {};
+  let level: "errors" | "fine" | "quiet" | "unread" = "unread";
+  const rank = { unread: -1, quiet: 0, fine: 1, errors: 2 };
+  for (const h of names) {
+    const d = byHost[h];
+    if (!d) { rows.push({ host: h, reading: null, error: null }); traffic[h] = null; readings[h] = null; continue; }
+    if ((d as { error?: string }).error) { rows.push({ host: h, reading: null, error: String((d as { error: string }).error) }); traffic[h] = null; readings[h] = null; continue; }
+    const r = readHistory(d as HistoryDoc);
+    rows.push({ host: h, reading: r, error: null });
+    traffic[h] = r.traffic; readings[h] = r;
+    if (rank[r.level] > rank[level]) level = r.level;
+  }
+  return { level, rows, traffic, readings };
+}
+
+/** The per-minute series of every bucket in one document, summed BIN BY BIN (one kernel's buckets share its
+ *  clock, so this is within-host arithmetic, which the federation rule allows); null when no bucket has one. */
+export function documentSeries(d: HistoryDoc | null | undefined): { binS: number; from: number; ok: number[]; rateLimited: number[]; serverErrors: number[]; noStatus: number[] } | null {
+  const buckets = (d && d.buckets) || {};
+  let out: { binS: number; from: number; ok: number[]; rateLimited: number[]; serverErrors: number[]; noStatus: number[] } | null = null;
+  for (const k of Object.keys(buckets)) {
+    const s = buckets[k].series;
+    if (!s || !s.ok) continue;
+    if (!out) { out = { binS: s.binS, from: s.from, ok: s.ok.slice(), rateLimited: s.rateLimited.slice(), serverErrors: s.serverErrors.slice(), noStatus: s.noStatus.slice() }; continue; }
+    for (let i = 0; i < out.ok.length && i < s.ok.length; i++) {
+      out.ok[i] += s.ok[i]; out.rateLimited[i] += s.rateLimited[i]; out.serverErrors[i] += s.serverErrors[i]; out.noStatus[i] += s.noStatus[i];
+    }
+  }
+  return out;
+}

--- a/ui/webview/rail-spend.test.ts
+++ b/ui/webview/rail-spend.test.ts
@@ -89,7 +89,8 @@ test("the web rail's API cell is numbers under a constant label — no spend bar
   // window cells' own grammar — the window's ONE display name, name-font, LEFT of its value, with
   // dollars AND tokens (the user 2026-08-09: no more '$12 5h' second vocabulary trailing the number)
   assert.ok(usageJS.includes("function apiCellHTML(live)"));
-  assert.ok(usageJS.includes("'<div class=ru-name>API</div>'"));
+  // T301: the API-health dot's slot follows the label (the stable #rail-api node moves into it); the label itself is unchanged
+  assert.ok(usageJS.includes("'<div class=ru-name>API</div><span class=ah-slot></span>'"));
   assert.ok(!usageJS.includes("_tail"), "no tail plumbing survives in the rail JS");
   // the month segment carries the version-skew caveat (T235b): a legacy host's calendar month is left
   // out of the rolling segment, and the segment's title says how many machines were not counted

--- a/vscode-extension/esbuild.js
+++ b/vscode-extension/esbuild.js
@@ -49,6 +49,7 @@ const webview = {
     "../ui/webview/gear.css",            // the settings modal (linked by the kernel feed page + VS Code chat/feed)
     "../ui/webview/federation.ts",   // multi-kernel manager: loaded after the shim on chat/feed/fleet pages
     "../ui/webview/age-color-global.ts",   // window.__rompAgeColor for the kernel's inline shell scripts (bell panel)
+    "../ui/webview/api-health-global.ts",   // window.__rompApiHealthMerge: the API-health merge + reading rules for the shell's rail (T301)
     "../ui/webview/palette-main.ts",   // command palette + Cmd/Ctrl+O/P hotkeys for the kernel's shell page
     "../ui/webview/shell-perf.ts",     // the shell page's performance collector (a pane's long animation frames are reported to the top-level window)
     "../ui/webview/editor-chunk.ts",   // CodeMirror editing substrate — ON-DEMAND (file-view loads it by


### PR DESCRIPTION
## Summary

The API health indicator on the shell's rail is redesigned to the user's spec (T301). It covers every connected kernel, it is one small dot inside the spend readout, it reads in plain words instead of the state machine's vocabulary, and its popup carries a graph instead of per-window percentage rows.

## Design points

**Every connected kernel.** Each kernel serves its last local apiHealth shell frame at `GET /api-health/frame` (its local half only, never its view of its peers, so two kernels attached to each other never nest). The tunnel supervisor's pass polls every attached host's frame (once per pass, about every 15 s; kept on a blip; kept and marked with a `fault` when the read is refused, so a rotated token names the machine instead of losing it; cleared when the host answers that it has none) and the shell frame carries them under `hosts`, a per-host map with a `stale` mark (a down tunnel or a refused read). Each frame also carries `quiet` (no API event in that kernel's longest window) and `errs` (failed attempts in it), from the aggregator every cycle, so the frame changes and is pushed the moment the last failure ages out. The remote's frame, its poll stamp and its fault are per process (`_NOT_SAVED`): never written to the 0600 remotes file, never restored at boot. For the history the browser reads `GET /remote/<host>/api-health`, a read relay beside the `/ws` and `/file` relays (404 unknown host, the remote's token rewritten in, JSON passed through, 502 and a redial on a dead tunnel). The merge is client-side in `ui/webview/api-health-merge.ts` (loaded by the shell as `/dist/api-health-global.js`, the age-colour module's pattern): per-host maps in, one line per machine out, worst state wins for the dot, no count or clock added to or compared with another kernel's. The dot follows the frames alone (their state, `quiet` and `errs`); a history reading only words a machine's line, so a reading taken at an earlier hover can never pin the dot. A machine whose tunnel is down or whose frame could not be read is named with what it last said and has no say in the dot. Why the split: the dot must be live without the browser polling N hosts and the supervisor already dials every host, so the frame rides the push the shell listens to; the history is on demand and a few KB.

**The rail cell.** `#rail-api` is a dot alone (no second API word, no "ok"). It moves into the spend readout's slot right after that readout's `API` label and left of its 1-day segment whenever the readout renders (the stable node is re-parented, so its listeners survive the readout's rebuilds), and sits after the usage bars when there is no readout. Colours through tokens with fallbacks: the accent when every kernel is fine, the blocked red when errors are being met anywhere (429 storm, 5xx, offline, paused), the label gray when no kernel has API traffic in the windows. The usage tip yields while the pointer is on the dot and comes back when the pointer slides onto the figures (the dot's mouseenter and mouseleave, no timer); the dot's click and keyboard activation stop at the dot, so they never open the spend modal; the readout's minute repaint re-parents the dot with focus kept and a focus-shown hover intact; the slot is `display:contents`, so a hidden dot costs the readout no gap.

**The reading.** The state machine and `/api-health`'s schema are unchanged. The popup reads what happened over the longest window: traffic with no errors is "N requests in the last 15 min, all succeeded" (with "too few requests to call a trend yet" as a sub-line while the machine still says `unknown`), errors are counted in plain words ("Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up."), no traffic is quiet. A storm in the window reddens the dot even with nothing waiting right now (the frame's `errs`). The word `unknown` appears nowhere the user reads. With several machines the head sums them up ("Errors on TESTHOST") and each machine gets its own line.

**The popup.** The per-window rows are gone. The snapshot gains an additive per-bucket `series` (attempts per minute over the 900 s window: ok / 429 / 5xx / no status / other; schema stays 1), and the popup draws it in the usage hover's graph grammar (polyline + fill, one ceiling label, a tick every five minutes) with 429 attempts in the blocked red and 5xx in the warn amber (a 1-2-5 ceiling at any magnitude), followed by one legend sentence for the codes. Each machine's document lands on its own, so a hung tunnel never holds back this machine's numbers. The "worst of N buckets" and "kernel up" caveats are gone; State changes are capped at four and worded plainly (rate-limit storm, API failing, recovering, fine, quiet); the pause control and its plain-words reasons stay.

## Tests

- `tests/test_api_health_hosts.py` (new): the frame's hosts map, its quiet and errs flags through the patched `_sdk` seam (no backend built), a refused read's fault, `/api-health/frame` through the handler (503 then the local half), the supervisor poll's rate gate and clear/keep/fault contract (403 pinned), the relay (auth, 404, 502, token rewrite, passthrough), the series bins from a synthetic ring through `snapshot()`, the per-process keys never reaching the remotes file or coming back at boot, the CSS pins for the dot's three states, the slot, the tip hooks and the focus-keeping move.
- `ui/webview/api-health-merge.test.ts` (new): worst-state merge, per-host lines, the dot from the frames alone (a stale reading cannot pin it), a down or refused machine named and not counted, no cross-host arithmetic (a source pin too), the reading rule (traffic and no errors reads fine; none reads quiet; errors in plain words), the histories merge with pending and failed reads, the per-document series sum, the shell's module load.
- `tests/test_api_health_browser.py`, `tests/test_api_health_hover_browser.py`, `tests/test_api_health_hover.py`, `tests/test_api_health_rail.py`, `ui/webview/rail-spend.test.ts`: pins moved to the dot, the plain-words reading, the graph and legend, the four-row tail, a new served scenario with an attached host read through the relay, and the served cell inside the readout: its click never reaches the readout's click, the two tips never show at once, the repaint's move keeps focus and the hover.

## Docs

`docs/reference.md`: the `series` field, an "On the dashboard" subsection (the dot's colours and reading, the multi-host merge), the frame block gains `hosts`, `quiet`, `errs` and the per-host `fault`; the indicator section describes the new reading, the poll cadence (once per pass, about every 15 s) and what has no say in the dot. `docs/guide.md`: the bottom bar paragraph.

## Review fixes folded before arming

The adversarial review confirmed nine findings on the first head, all folded here with pins: the remote frame keys never persisted to the 0600 remotes file (they rewrote it every pass and restored a dead host's storm at boot); the dot's click no longer opens the spend modal; the fixtures patch the `_sdk` seam so no test builds a real backend; the two tips never show at once; the dot follows the frames instead of a hover's reading; the empty slot costs no gap; a refused frame read keeps the machine with its fault; the series is pinned from `snapshot()`; the docs give the real poll cadence. Also from the review: a down machine's last frame no longer votes, a hung tunnel no longer holds back this machine's history, the graph's ceiling scales past 1000, and the readout's repaint keeps focus.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
