### PR TITLE
Postal drain hook: a message carrying a control byte still reaches the session as a decision Claude Code can parse

### DIFF
--- a/hooks/romp-postal-drain.sh
+++ b/hooks/romp-postal-drain.sh
@@ -38,9 +38,19 @@ postal="$(cd "$(dirname "$src")/../bin" 2>/dev/null && pwd)/romp-postal-service"
 msgs="$("$postal" drain --id "$sid" 2>/dev/null || true)"
 [[ -n "${msgs//[[:space:]]/}" ]] || exit 0
 
-# JSON-escape in pure bash (no Homebrew/python dependency in the hook path).
+# JSON-escape in pure bash (no Homebrew/python dependency in the hook path). Backslash first, so
+# the escapes added after it are not doubled. Every other byte 0x01-0x1f becomes \u00XX: JSON
+# forbids a raw control character inside a string, and Claude Code drops a decision it cannot
+# parse without a word, AFTER the drain has already consumed the mail, so a message carrying
+# pasted terminal output (colour sequences, a form feed) used to vanish on the way to the
+# session. CR is dropped as before; NUL cannot reach this block ($(...) strips it) and DEL
+# (0x7f) is legal as it is. Builtins only (printf -v), no fork per byte.
 esc="$(printf '%s' "$msgs" | { s="$(cat)"
     s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/\\n}"; s="${s//$'\t'/\\t}"; s="${s//$'\r'/}"
+    for i in 1 2 3 4 5 6 7 8 11 12 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31; do
+        printf -v o '%03o' "$i"; printf -v c "\\$o"; printf -v h '%04x' "$i"
+        s="${s//$c/\\u$h}"
+    done
     printf '%s' "$s"; })"
 printf '{"decision":"block","reason":"%s"}\n' "$esc"
 exit 0

--- a/tests/romp-postal-drain-hook.bats
+++ b/tests/romp-postal-drain-hook.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+# hooks/romp-postal-drain.sh is the Stop hook that hands drained peer mail back to the session as
+# one Stop-hook decision line, `{"decision":"block","reason":<the mail>}`, JSON-escaped in pure
+# bash. Claude Code parses that line; a line it cannot parse is dropped without a word, and the
+# drain is CONSUMING, so by then the mail is already marked read: the session never sees the
+# message and neither side is told. These tests drive the real hook with a stub
+# romp-postal-service beside it (the hook resolves ../bin from its own real path) and read its
+# stdout with a strict JSON parser, so the decision must parse and the body must come back
+# byte for byte.
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    unset ROMP_STATE_DIR
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    # HOME under the test dir: the hook's off-switch is $HOME/.claude/romp-postal-off, and a
+    # developer who has it set must not see these tests pass as no-ops.
+    export HOME="$TEST_DIR/home"; mkdir -p "$HOME/.claude"
+    # The summarizer guard exits the hook before it drains; a suite run from inside a summarizing
+    # shell would otherwise pass every test with no output.
+    unset ROMP_SUMMARIZING
+    mkdir -p "$TEST_DIR/hooks" "$TEST_DIR/bin"
+    cp "$(cd "$(dirname "$BATS_TEST_FILENAME")/../hooks" && pwd)/romp-postal-drain.sh" "$TEST_DIR/hooks/"
+    HOOK="$TEST_DIR/hooks/romp-postal-drain.sh"
+    export DRAIN_LOG="$TEST_DIR/drain.log"
+    SID="11111111-2222-3333-4444-555555555555"
+    INPUT="{\"session_id\":\"$SID\"}"
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+# Stub romp-postal-service: logs its argv, and on `drain` prints the body the test wrote (a printf
+# format, so the test can spell control bytes as octal escapes). The body travels through a file,
+# never through the stub's own source, so no shell quoting stands between the bytes and the hook.
+stub_drain() {   # $1 printf format for the body
+    printf "$1" > "$TEST_DIR/body"
+    cat > "$TEST_DIR/bin/romp-postal-service" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DRAIN_LOG"
+[ "${1:-}" = drain ] || exit 0
+cat "$(dirname "$0")/../body"
+STUB
+    chmod +x "$TEST_DIR/bin/romp-postal-service"
+}
+
+run_hook() { run bash -c 'printf "%s" "$1" | "$2"' _ "$INPUT" "$HOOK"; }
+
+# Parses the hook's stdout as JSON and checks the decision is block and the reason is the body,
+# byte for byte, after what the hook does by design: `$(...)` strips the drain's trailing newlines.
+# Extra assertions on the reason arrive as Python expressions in $1 (an empty string for none).
+assert_decision_carries_body() {   # $1 extra Python expression over `reason`
+    printf '%s' "$output" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)          # raises on a raw control byte: "Invalid control character"
+assert d["decision"] == "block", d
+reason = d["reason"]
+body = open(sys.argv[1], "rb").read().decode("utf-8").rstrip("\n")
+assert reason == body, (repr(reason), repr(body))
+if sys.argv[2]:
+    assert eval(sys.argv[2]), (sys.argv[2], repr(reason))
+' "$TEST_DIR/body" "$1"
+}
+
+@test "a body carrying an ANSI colour sequence and a form feed reaches the session intact" {
+    # Pasted terminal output is the everyday shape of this: an escape byte and a form feed, neither
+    # of which the hook used to escape, so the decision line was not JSON and the mail was lost.
+    stub_drain 'hello \033[31mred\033[0m\fworld\n'
+    run_hook
+    [ "$status" -eq 0 ]
+    assert_decision_carries_body '"\x1b[31m" in reason and "\f" in reason'
+}
+
+@test "every control byte a message can carry survives, beside quote, backslash, tab and newline" {
+    # Every byte 0x01-0x1f except the three the hook already handled (TAB and LF as escapes, CR
+    # dropped by design), plus DEL, which JSON allows as it is. NUL cannot ride a shell string.
+    stub_drain 'a\\b"c\001\002\003\004\005\006\007\010\011\012\013\014\016\017\020\021\022\023\024\025\026\027\030\031\032\033\034\035\036\037\177z\n'
+    run_hook
+    [ "$status" -eq 0 ]
+    assert_decision_carries_body 'len(reason) == 37'
+}
+
+@test "a plain body is delivered as before, from a drain of the session's own id" {
+    stub_drain 'alpha says: "done", see notes\\draft\n\tnext: beta\n'
+    run_hook
+    [ "$status" -eq 0 ]
+    assert_decision_carries_body '"\n\tnext: beta" in reason'
+    grep -qx -- "drain --id $SID" "$DRAIN_LOG"
+}


### PR DESCRIPTION
Tier: fix

## What was wrong
Verified on `main`: the stop hook that drains a session's mailbox and hands the mail to Claude Code as a JSON decision escaped only backslash, quote, newline and tab, and dropped carriage returns. Every other control byte was printed raw inside the JSON string, which JSON forbids and both Python and Node reject. A peer message carrying pasted terminal output, an ANSI colour sequence or a form feed, was consumed from the mailbox, renamed as read with a receipt to match, and then handed over as unparseable JSON at exit 0. The session never saw it, and neither side was told.

## What changes
The same pure-bash escape block now turns every remaining control byte into its `\u00XX` escape, using a loop of builtin pattern substitutions rather than a subshell per byte, so a small body costs about the same as before. Carriage returns are still dropped, as the existing line chose; a NUL cannot survive the capture; DEL is legal JSON as is. Every byte from 0x01 to 0x1f, plus backslash and quote, round-trips byte for byte through Python's strict parser on the bash available here. The constructs used, `printf -v` and pattern substitution, are documented for bash 3.2 as well, but that was not run, and nothing about it is claimed.

## Deliberately left out
The drain still runs before the escape and has no size cap, so a body large enough to push the hook past its ten-second timeout is lost the same way on `main` and here; that is a separate fix. The hook's README needs no change.

## Tests
A new bats file copies the hook beside a stub mail service whose drain prints the body under test, with a fresh home and no off marker, and pipes the session JSON in. A body with an ANSI colour sequence and a form feed parses as a block decision with the body intact; a body carrying every control byte beside quote, backslash, tab and newline survives byte for byte; a plain body is delivered exactly as before, from a drain of the session's own id. On `main` the first two fail with the parser's "Invalid control character". The file passes 3 of 3 and sets the state floor the suite's isolation check expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
