### PR TITLE
Restart monitors: what kernel restarts do to the sessions, measured (stage 0 of #1317)

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -658,6 +658,7 @@ EOF
     _romp_cmd "romp up [--foreground]"     romp-manager "Start the kernel manager: through the login service when installed, else in the foreground"
     _romp_cmd "romp version"               romp-version "Versions across the parts (tree, kernel, served vs built bundles)"
     _romp_cmd "romp spend-rebuild"         romp-spend-rebuild "Recount the spend ledger's token columns from the transcripts (dry run; --apply writes, dollars untouched)"
+    _romp_cmd "romp restart-metrics [--json|--window day|week]" romp-restart-metrics "What kernel restarts do to the sessions, from the state ledgers and the kernel's routes: turns cut, outage and reconcile times, quiet-window waits, orphans and reaps, crash heals, redo cost, turn latency, per-session memory and CPU"
     _romp_cmd "romp uninstall"             romp-uninstall "Remove romp's installed footprint (--purge also deletes recorded state)"
     _romp_cmd "romp help"                  -            "Show this help"
     cat <<'EOF'
@@ -753,6 +754,17 @@ fi
 if [[ "${1:-}" == "spend-rebuild" ]]; then
     shift
     exec romp-spend-rebuild "$@"
+fi
+
+# `romp restart-metrics [--json] [--window day|week] [--anchor D] [--since D] [--until D] [--tz Z] [--no-live]`
+# — the restart monitors (stage 0 of the restart-surviving sessions program, 2026-09-10): what kernel
+# restarts do to the sessions, read from the state ledgers (restart-cuts, restart-audit, session-events,
+# turns, the state logs, spend) and the running kernel's /version and /perf; a text summary per window, or
+# the whole document as JSON for the figure script. Read-only; never loads a kernel module. Delegates to
+# romp-restart-metrics (python, cli/restart_metrics.py).
+if [[ "${1:-}" == "restart-metrics" ]]; then
+    shift
+    exec romp-restart-metrics "$@"
 fi
 
 # The kernel serve token — required on EVERY kernel/bus request, loopback included (Jupyter's

--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -266,6 +266,31 @@ function auditSigterm(spec, pid, reason, trigger) {
 // kernel's row names the same cause.
 function stopTrigger() { return downMarkerHeld() ? 'cli-down' : 'stop'; }
 
+// T304: the quiet window's OWN row in restart-audit.jsonl, written when the parked refresh APPLIES, so the
+// wait from parked to restart and the fifteen-minute backstop's firing are machine-readable (until now they
+// were the `applying deferred refresh … waited Ns` log line alone). A mechanism note like manager-sigterm,
+// never a request: the kernel's reason walk lists `quiet-window` in _NO_RESTART_ACTIONS and passes it over;
+// the restart it releases writes its own manager-sigterm note. `since` and `t` are epoch seconds; `reason`
+// is quietGate's verdict verbatim ('quiet', 'backstop cap', or the unreachable-kernel sentence), `backstop`
+// the one bit a reader wants most; the drain counts are the park's evidence (queueQuietRestart records them).
+function quietWindowRow(park, g, now) {
+  const p = park || {}; const since = Number(p.since) || now;
+  return { t: Math.floor(now / 1000), action: 'quiet-window', since: Math.floor(since / 1000),
+           waitedS: Math.max(0, Math.round((now - since) / 1000)), reason: String((g && g.reason) || ''),
+           backstop: !!(g && g.reason === 'backstop cap'), coalesced: p.count || 1, mode: String(p.mode || 'all'),
+           lastInflight: p.lastInflight === undefined ? null : p.lastInflight, misses: p.misses || 0,
+           drainRefusedCount: p.drainRefusedCount || 0, drainArmedCount: p.drainArmedCount || 0,
+           drainRefusedAfterArm: p.drainRefusedAfterArm || 0 };
+}
+function auditQuietWindow(park, g, now) {
+  const row = quietWindowRow(park, g, now || Date.now());
+  try {
+    fs.mkdirSync(STATE_ROOT, { recursive: true });
+    fs.appendFileSync(path.join(STATE_ROOT, 'restart-audit.jsonl'), JSON.stringify(row) + '\n');
+  } catch (e) { /* a lost note, not a lost restart */ }
+  return row;
+}
+
 // The exit handler's verdict (pure, exported for tests): what to log and whether to respawn. A
 // kernel we asked to stop is reaped; one we SIGTERMed for a restart keeps the plain respawn line;
 // one that exited with NEITHER on record (a signal from elsewhere, or a crash) says so, because
@@ -653,6 +678,7 @@ function queueQuietRestart(mode) {
           : p.drainRefusedAfterArm > 0
             ? ` — the drain hold armed and was then LOST for this park (refused ${p.drainRefusedAfterArm} time(s) after arming, ${p.drainRefusedCount - p.drainRefusedAfterArm} before), so turns started after the loss may be cut`
             : ` — the drain hold was refused ${p.drainRefusedCount} time(s) before arming for this park, so turns started before it armed may be cut`;
+      auditQuietWindow(p, g, Date.now());   // the row before the restart it releases (T304: the wait, measured)
       log(`applying deferred refresh — ${g.reason}${cause} (${p.count} request(s) coalesced, waited ${Math.round((Date.now() - p.since) / 1000)}s)`);
       if (p.mode === 'all') restartAllOrSelf(); else restartKernel(p.mode);
     },
@@ -1041,6 +1067,7 @@ module.exports = { restartGate, quietGate, quietTick, loadSpecs, specEnv, fileSt
                    placementFromCgroup, tmuxServerPlacement, bareEnsuredLine, TMUX_SERVER_PID_ARGV,
                    withoutOpCredentials, retiredCredentialNames, retiredCredentialMessage, exitLine, auditSigterm,
                    ensureDecision, downMarkerHeld, clearDownMarker, DOWN_MARKER,
+                   quietWindowRow, auditQuietWindow,
                    // the SIGTERM wiring, for tests that seed `kernels` with a stand-in child or point
                    // ROMP_SERVE_BIN at a stand-in launcher
                    restartKernel, restartAll, restartAllOrSelf, stopKernel, shutdownAll, stopTrigger, spawnKernel, kernels };

--- a/bin/romp-restart-metrics
+++ b/bin/romp-restart-metrics
@@ -1,0 +1,1 @@
+../cli/restart_metrics.py

--- a/cli/restart_metrics.py
+++ b/cli/restart_metrics.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""romp-restart-metrics — what kernel restarts do to the sessions, measured. `romp restart-metrics`.
+"""romp-restart-metrics: what kernel restarts do to the sessions, measured. `romp restart-metrics`.
 
 Stage 0 of the restart-surviving sessions program (part of #1317): before any restart behaviour changes,
 the monitors exist, a baseline is recorded, and the same reader keeps running after the change. This is
@@ -22,7 +22,7 @@ Sources, and what each stamp is (every stamp is an EVENT's time, never the clock
                          atom), resultT (the ResultMessage), the CLI's own durationMs / apiMs, the spend
                          fold's usd and tokens, resumeNotice (a turn redoing cut work)
   states/<sid>.jsonl     the state log: working (written at the feed pop) to waiting (the ResultMessage),
-                         one-second resolution — the latency the baseline has for turns before turns.jsonl
+                         one-second resolution, the latency the baseline has for turns before turns.jsonl
                          existed; machineCut rows count romp's own cuts by cause
   spend.json             hour and day buckets per session (no per-turn rows: redo cost cannot come from it,
                          and this says so); the day's total dollars, for the redo ratio
@@ -129,20 +129,31 @@ def day_start(date_str: str, tz=None) -> float:
     return d.timestamp()
 
 
+def _date(s: str):
+    from datetime import date
+    y, m, d = (int(x) for x in s.split("-"))
+    return date(y, m, d)
+
+
 def bucket_key(t, kind: str, anchor: str, tz=None) -> str:
     """The window a stamp falls in: the day's date, or for weeks the anchor date plus a whole number of
-    weeks ("week of YYYY-MM-DD"); days before the anchor bucket backwards the same way."""
+    weeks ("week of YYYY-MM-DD"); days before the anchor bucket backwards the same way. Weeks are counted
+    in LOCAL DATES, not multiples of 604800 seconds, so a daylight-saving change inside a week moves no
+    boundary off local midnight (review find, 2026-09-10)."""
     if kind == "day":
         return local_date(t, tz)
-    a = day_start(anchor, tz)
-    n = int((float(t) - a) // (7 * 86400))
-    return "week of " + local_date(a + n * 7 * 86400 + 3600, tz)
+    days = (_date(local_date(t, tz)) - _date(anchor)).days
+    n = days // 7
+    return "week of " + (_date(anchor) + timedelta(days=7 * n)).isoformat()
 
 
 def bucket_bounds(key: str, kind: str, tz=None) -> tuple[float, float]:
+    """[start, end) of a bucket in epoch seconds: local midnight of its first day to local midnight of the
+    day after its last (a week's end is the SEVENTH local midnight, whatever the clocks did in between)."""
     date = key.replace("week of ", "")
     s = day_start(date, tz)
-    return s, s + (7 * 86400 if kind == "week" else 86400)
+    e = day_start((_date(date) + timedelta(days=7 if kind == "week" else 1)).isoformat(), tz)
+    return s, e
 
 
 # ── the ledgers, parsed ─────────────────────────────────────────────────────────────────────────────────
@@ -267,7 +278,7 @@ def parse_turns(rows: list[dict]) -> list[dict]:
 def state_log_turns(lines: list[str]) -> tuple[list[dict], dict]:
     """(turns, machine cuts) from one states/<sid>.jsonl: each `working` row followed by a `waiting` row
     (not romp's own `by`-marked settle, an interrupt) is a turn with feedToResultS at one-second
-    resolution — the feed pop and the ResultMessage are what those two writes ARE. machineCut rows count
+    resolution; the feed pop and the ResultMessage are what those two writes ARE. machineCut rows count
     romp's cuts by cause. Pure."""
     turns, cuts = [], {}
     open_t = None
@@ -281,6 +292,8 @@ def state_log_turns(lines: list[str]) -> tuple[list[dict], dict]:
         if "machineCut" in r:
             c = str(r["machineCut"])
             cuts[c] = cuts.get(c, 0) + 1
+            open_t = None      # the cut turn never gets its result: the resumed turn's `waiting` is not its end
+            #                    (review find, 2026-09-10: the pair spanned the outage and the redo)
             continue
         st = r.get("state")
         t = r.get("t")
@@ -435,7 +448,9 @@ def build_buckets(restarts, quiet, events, turns, statelog_turns, machine_cuts, 
         b["stateLogLatencyS"] = stats(b.pop("_sl"))
         b["kernelAtExit"] = {"rssMb": stats(b.pop("_k_rss")), "cpuS": stats(b.pop("_k_cpu"))}
         b["redo"]["usd"] = round(b["redo"]["usd"], 4)
-        b["cutTurnsPerRestart"] = round(b["cutTurns"] / b["restarts"], 2) if b["restarts"] else None
+        b["measuredRestarts"] = b["restarts"] - b["restartsWithoutCutRow"]   # a boot with no cut row cut an UNKNOWN
+        #                                                                        number of turns, not zero (review find)
+        b["cutTurnsPerRestart"] = round(b["cutTurns"] / b["measuredRestarts"], 2) if b["measuredRestarts"] else None
         out.append(b)
     return out
 
@@ -697,8 +712,10 @@ def collect(state: Path, kind="day", anchor=None, tz=None, since=None, until=Non
                      "reader's kernel change landed; the spend ledger (spend.json) has hour and day buckets per "
                      "session and no per-turn rows, so it cannot attribute a turn's cost.",
                      "Turn latency: turns.jsonl stamps are event stamps at millisecond resolution (feed pop, "
-                     "first work atom, ResultMessage); stateLogLatencyS is the same feed-to-result interval "
-                     "from the state log at one-second resolution, available for turns before turns.jsonl."]}
+                     "first work atom, ResultMessage), present only for turns this kernel fed (a turn the CLI "
+                     "opened by itself has no feed and is not a latency sample); stateLogLatencyS is the same "
+                     "feed-to-result interval from the state log at one-second resolution, available for turns "
+                     "before turns.jsonl, and a pair broken by a machine cut is not a turn."]}
     doc["live"] = live_snapshot(state) if live else {"skipped": True}
     return doc
 
@@ -741,7 +758,7 @@ def summary(doc: dict) -> str:
     """The one-screen text per window."""
     w = doc["window"]
     src = doc["sources"]
-    lines = ["restart metrics: %s, %s windows, anchor %s, times %s"
+    lines = ["restart metrics: %s, %s windows, anchor %s, dates in %s time"
              % (doc.get("label") or DEFAULT_LABEL, w["kind"], w["anchor"], w["tz"])]
     missing = [k for k in ("restartCuts", "restartAudit", "sessionEvents", "turns") if not (src.get(k) or {}).get("present")]
     if missing:
@@ -750,9 +767,9 @@ def summary(doc: dict) -> str:
         lines.append("  no rows in range")
     for b in doc["buckets"]:
         lines.append("")
-        lines.append("%s  (%s to %s)" % (b["key"], time.strftime("%Y-%m-%d", time.localtime(b["start"])),
-                                          time.strftime("%Y-%m-%d", time.localtime(b["end"] - 1))))
-        per = (" (%s per restart)" % b["cutTurnsPerRestart"]) if b["cutTurnsPerRestart"] is not None else ""
+        tz = None if w.get("tz") in (None, "local") else w["tz"]
+        lines.append("%s  (%s to %s)" % (b["key"], local_date(b["start"], tz), local_date(b["end"] - 1, tz)))
+        per = (" (%s per measured restart)" % b["cutTurnsPerRestart"]) if b["cutTurnsPerRestart"] is not None else ""
         lines.append("  restarts %d · turns cut %d%s · clean restarts %d · boots with no cut row %d"
                      % (b["restarts"], b["cutTurns"], per, b["cleanRestarts"], b["restartsWithoutCutRow"]))
         if b["reasons"]:
@@ -821,6 +838,8 @@ def main(argv=None) -> int:
     try:
         since = day_start(a.since, a.tz) if a.since else None
         until = day_start(a.until, a.tz) if a.until else None
+        if a.anchor:
+            day_start(a.anchor, a.tz)
     except ValueError as e:
         sys.stderr.write("romp restart-metrics: bad date: %s\n" % e)
         return 2

--- a/cli/restart_metrics.py
+++ b/cli/restart_metrics.py
@@ -1,0 +1,834 @@
+#!/usr/bin/env python3
+"""romp-restart-metrics — what kernel restarts do to the sessions, measured. `romp restart-metrics`.
+
+Stage 0 of the restart-surviving sessions program (part of #1317): before any restart behaviour changes,
+the monitors exist, a baseline is recorded, and the same reader keeps running after the change. This is
+the READER: it reads the state directory's ledgers and the running kernel's routes, never a kernel module
+(loading one against live state runs the boot reconcile as a second actor), and it changes nothing.
+
+Sources, and what each stamp is (every stamp is an EVENT's time, never the clock at read time):
+  restart-cuts.jsonl     one row per kernel exit (cutTurns: the sessions whose in-flight turn the drain
+                         interrupted; stopped, unjoined, reaped; reason) and one bootSettled row per boot
+                         (firstServe, reconcileDone, settleS, outageS = firstServe minus the previous cut's t)
+  restart-audit.jsonl    the requests and notes around a restart; the manager's `quiet-window` row is the
+                         parked deploy's wait from parked to restart (waitedS) and whether the fifteen-minute
+                         backstop fired (backstop)
+  session-events.jsonl   what went wrong with a session's process (kernel/sdk_backend.py problem_row): an
+                         orphaned CLI ended at boot, a leftover scope stopped, two CLIs holding one
+                         conversation, a crash heal or loop, a session the drain left closing, the lease
+                         work's `lease.*` kinds; plus reconcile.boot, the boot sweep's summary (resumed =
+                         continuation notices queued)
+  turns.jsonl            one row per settled turn: fedT (the feed pop), firstOutT (the first streamed work
+                         atom), resultT (the ResultMessage), the CLI's own durationMs / apiMs, the spend
+                         fold's usd and tokens, resumeNotice (a turn redoing cut work)
+  states/<sid>.jsonl     the state log: working (written at the feed pop) to waiting (the ResultMessage),
+                         one-second resolution — the latency the baseline has for turns before turns.jsonl
+                         existed; machineCut rows count romp's own cuts by cause
+  spend.json             hour and day buckets per session (no per-turn rows: redo cost cannot come from it,
+                         and this says so); the day's total dollars, for the redo ratio
+  live (skipped with --no-live): each romp-session-* scope's memory.current and cpu.stat on Linux (ps on
+                         macOS), the kernel's GET /version and GET /perf (its own CPU and the pusher's
+                         idle-cycle counter), and a `ps` scan for two CLIs holding one conversation now
+
+Output: --json, the whole document (schema 1), or the one-screen text summary per window. Windows are
+days or weeks (--window), the week anchored on --anchor (default: the day of the first restart in range),
+in the machine's local time unless --tz names a zone. Missing sources are said, never silently zero.
+"""
+import argparse
+import glob
+import json
+import os
+import platform
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCHEMA = 1
+SCOPE_RE = re.compile(r"romp-session-([0-9a-fA-F]{1,8})-(\d+)-\d+\.scope\Z")
+SDK_CLI_MARK = "--input-format stream-json"
+PROBLEM_KINDS = ("reconcile.orphan-reaped", "reconcile.scope-stopped", "reconcile.duplicate-cli",
+                 "crash.heal", "crash.loop", "drain.unjoined")
+QUIET_JOIN_S = 180        # a cut row within this many seconds after a quiet-window row is that window's restart
+
+
+# ── where things are ────────────────────────────────────────────────────────────────────────────────────
+def state_dir() -> Path:
+    return Path(os.environ.get("ROMP_STATE_DIR")
+                or Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state")) / "romp")
+
+
+def host_name() -> str:
+    env = os.environ.get("ROMP_HOST_NAME")
+    return env if env else (socket.gethostname() or "?").split(".")[0]
+
+
+def _read_jsonl(path: Path) -> tuple[list[dict], dict]:
+    """(rows, source note): every parseable object row, in file order, the rotated predecessor
+    (<name>.1, kernel/sdk_backend.py LEDGER_ROTATE_BYTES) first when one exists; the note says what was
+    read."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return [], {"path": path.name, "present": False, "rows": 0}
+    except OSError as e:
+        return [], {"path": path.name, "present": True, "rows": 0, "error": str(e)}
+    prev = path.with_name(path.name + ".1")
+    if prev.exists():
+        try:
+            text = prev.read_text(encoding="utf-8") + "\n" + text
+        except OSError:
+            pass
+    rows, bad = [], 0
+    for ln in text.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            r = json.loads(ln)
+        except Exception:
+            bad += 1
+            continue
+        if isinstance(r, dict):
+            rows.append(r)
+    note = {"path": path.name, "present": True, "rows": len(rows)}
+    if bad:
+        note["unparseable"] = bad
+    return rows, note
+
+
+# ── stats and windows ───────────────────────────────────────────────────────────────────────────────────
+def stats(values) -> dict:
+    """n, mean, p50, p90, max over the numbers given (nearest-rank percentiles); {} when empty."""
+    xs = sorted(float(v) for v in values if isinstance(v, (int, float)) and not isinstance(v, bool))
+    if not xs:
+        return {"n": 0}
+    def pct(p):
+        k = max(0, min(len(xs) - 1, int(round(p / 100.0 * (len(xs) - 1)))))
+        return xs[k]
+    return {"n": len(xs), "mean": round(sum(xs) / len(xs), 3), "p50": round(pct(50), 3),
+            "p90": round(pct(90), 3), "max": round(xs[-1], 3)}
+
+
+def _zone(tz: str | None):
+    if not tz:
+        return None
+    from zoneinfo import ZoneInfo
+    return ZoneInfo(tz)
+
+
+def local_date(t, tz=None) -> str:
+    return datetime.fromtimestamp(float(t), tz=_zone(tz)).strftime("%Y-%m-%d")
+
+
+def day_start(date_str: str, tz=None) -> float:
+    d = datetime.strptime(date_str, "%Y-%m-%d")
+    d = d.replace(tzinfo=_zone(tz)) if tz else d
+    return d.timestamp()
+
+
+def bucket_key(t, kind: str, anchor: str, tz=None) -> str:
+    """The window a stamp falls in: the day's date, or for weeks the anchor date plus a whole number of
+    weeks ("week of YYYY-MM-DD"); days before the anchor bucket backwards the same way."""
+    if kind == "day":
+        return local_date(t, tz)
+    a = day_start(anchor, tz)
+    n = int((float(t) - a) // (7 * 86400))
+    return "week of " + local_date(a + n * 7 * 86400 + 3600, tz)
+
+
+def bucket_bounds(key: str, kind: str, tz=None) -> tuple[float, float]:
+    date = key.replace("week of ", "")
+    s = day_start(date, tz)
+    return s, s + (7 * 86400 if kind == "week" else 86400)
+
+
+# ── the ledgers, parsed ─────────────────────────────────────────────────────────────────────────────────
+def parse_restarts(rows: list[dict]) -> list[dict]:
+    """One record per kernel exit from restart-cuts.jsonl (rows carrying cutTurns), each joined with the
+    boot that followed it: the bootSettled row whose prevCutT names it, else the first boot row after it.
+    A boot the ledger shows with no preceding cut (a crash, a SIGKILL: no drain ran) becomes a record of its
+    own with `noCutRow` so the outage is still counted where the boot row measured it."""
+    cuts = sorted([r for r in rows if isinstance(r.get("t"), (int, float)) and "cutTurns" in r], key=lambda r: r["t"])
+    boots = [r for r in rows if isinstance(r.get("t"), (int, float)) and r.get("bootSettled")]
+    used = set()
+    out = []
+    for n, c in enumerate(cuts):
+        next_t = cuts[n + 1]["t"] if n + 1 < len(cuts) else float("inf")
+        boot = None
+        for i, b in enumerate(boots):
+            if i not in used and b.get("prevCutT") == c["t"]:
+                boot = b
+                used.add(i)
+                break
+        if boot is None:
+            # a boot row with no prevCutT (the kernel writes one only when a cut precedes it; older rows
+            # have none) joins the cut only when it sits BEFORE the next cut: a cut with no boot row of
+            # its own (the ledger predates the boot rows, or the boot never settled) must not take a
+            # later restart's boot, which cascaded through the whole ledger (found on the live file)
+            for i, b in enumerate(boots):
+                if i not in used and b.get("prevCutT") is None and c["t"] <= b["t"] < next_t:
+                    boot = b
+                    used.add(i)
+                    break
+        names = [x.get("name") or str(x.get("sid") or "")[:8] for x in (c.get("cutTurns") or []) if isinstance(x, dict)]
+        rec = {"t": int(c["t"]), "pid": c.get("pid"), "reason": str(c.get("reason") or ""),
+               "cutTurns": len(c.get("cutTurns") or []), "cutSessions": names,
+               "stopped": int(c.get("stopped") or 0), "unjoined": int(c.get("unjoined") or 0),
+               "reaped": int(c.get("reaped") or 0), "watchesArmed": int(c.get("watchesArmed") or 0),
+               "auditT": c.get("auditT"), "drainError": c.get("drainError"), "reasonError": c.get("reasonError"),
+               "rssKb": c.get("rssKb"), "cpuS": c.get("cpuS")}   # the kernel's own size and CPU at its exit
+        if boot is not None:
+            rec["boot"] = {"t": int(boot["t"]), "firstServe": boot.get("firstServe"),
+                           "reconcileDone": boot.get("reconcileDone"), "settleS": boot.get("settleS"),
+                           "rssKb": boot.get("rssKb"), "cpuS": boot.get("cpuS"),
+                           "outageS": boot.get("outageS") if boot.get("outageS") is not None
+                           else (round(float(boot["firstServe"]) - c["t"], 2) if isinstance(boot.get("firstServe"), (int, float)) else None)}
+        out.append(rec)
+    for i, b in enumerate(boots):
+        if i in used:
+            continue
+        out.append({"t": int(b["t"]), "pid": b.get("pid"), "reason": "", "cutTurns": 0, "cutSessions": [],
+                    "stopped": 0, "unjoined": 0, "reaped": 0, "watchesArmed": 0, "noCutRow": True,
+                    "boot": {"t": int(b["t"]), "firstServe": b.get("firstServe"), "reconcileDone": b.get("reconcileDone"),
+                             "settleS": b.get("settleS"), "outageS": b.get("outageS"),
+                             "rssKb": b.get("rssKb"), "cpuS": b.get("cpuS")}})
+    out.sort(key=lambda r: r["t"])
+    return out
+
+
+def kernel_series(restarts: list[dict]) -> list[dict]:
+    """The kernel process's own resident size and CPU, sampled at the two events the restart ledger records
+    (T304): each exit (the cut row, kind "exit": the process at the end of its life) and each settled boot
+    (kind "boot": the process just born). Rows older than the sample carry none and are skipped. Time order."""
+    out = []
+    for r in restarts:
+        if isinstance(r.get("rssKb"), (int, float)) and not r.get("noCutRow"):
+            out.append({"t": r["t"], "kind": "exit", "pid": r.get("pid"), "rssMb": round(r["rssKb"] / 1024.0, 1),
+                        "cpuS": r.get("cpuS")})
+        b = r.get("boot") or {}
+        if isinstance(b.get("rssKb"), (int, float)):
+            out.append({"t": b["t"], "kind": "boot", "pid": None, "rssMb": round(b["rssKb"] / 1024.0, 1), "cpuS": b.get("cpuS")})
+    out.sort(key=lambda x: (x["t"], x["kind"] == "boot"))
+    return out
+
+
+def parse_quiet_windows(audit_rows: list[dict], restarts: list[dict]) -> list[dict]:
+    """The manager's quiet-window rows, each joined to the first restart within QUIET_JOIN_S after it."""
+    out = []
+    for r in audit_rows:
+        if r.get("action") != "quiet-window" or not isinstance(r.get("t"), (int, float)):
+            continue
+        q = {"t": int(r["t"]), "since": r.get("since"), "waitedS": r.get("waitedS"), "reason": str(r.get("reason") or ""),
+             "backstop": bool(r.get("backstop")), "coalesced": r.get("coalesced"), "mode": r.get("mode"),
+             "lastInflight": r.get("lastInflight"), "drainRefusedCount": r.get("drainRefusedCount"),
+             "drainArmedCount": r.get("drainArmedCount")}
+        hit = next((x for x in restarts if q["t"] <= x["t"] <= q["t"] + QUIET_JOIN_S), None)
+        q["restartT"] = hit["t"] if hit else None
+        q["cutTurns"] = hit["cutTurns"] if hit else None
+        out.append(q)
+    return out
+
+
+def audit_counts(audit_rows: list[dict]) -> dict:
+    """How many rows of each action the audit ledger holds, plus manager-sigterm triggers."""
+    by, trig = {}, {}
+    for r in audit_rows:
+        a = str(r.get("action") or "(none)")
+        by[a] = by.get(a, 0) + 1
+        if a == "manager-sigterm":
+            t = str(r.get("trigger") or r.get("reason") or "?")
+            trig[t] = trig.get(t, 0) + 1
+    return {"byAction": by, "sigtermTriggers": trig}
+
+
+def parse_events(rows: list[dict]) -> list[dict]:
+    return [r for r in rows if isinstance(r.get("t"), (int, float)) and isinstance(r.get("kind"), str)]
+
+
+def parse_turns(rows: list[dict]) -> list[dict]:
+    """turns.jsonl rows with the derived seconds: feedToResultS, feedToFirstOutS (when both stamps exist)."""
+    out = []
+    for r in rows:
+        if not isinstance(r.get("t"), (int, float)):
+            continue
+        rec = dict(r)
+        fed, res, fo = r.get("fedT"), r.get("resultT"), r.get("firstOutT")
+        if isinstance(fed, (int, float)) and fed > 0 and isinstance(res, (int, float)) and res >= fed:
+            rec["feedToResultS"] = round(float(res) - float(fed), 3)
+            if isinstance(fo, (int, float)) and fo >= fed:
+                rec["feedToFirstOutS"] = round(float(fo) - float(fed), 3)
+        out.append(rec)
+    return out
+
+
+def state_log_turns(lines: list[str]) -> tuple[list[dict], dict]:
+    """(turns, machine cuts) from one states/<sid>.jsonl: each `working` row followed by a `waiting` row
+    (not romp's own `by`-marked settle, an interrupt) is a turn with feedToResultS at one-second
+    resolution — the feed pop and the ResultMessage are what those two writes ARE. machineCut rows count
+    romp's cuts by cause. Pure."""
+    turns, cuts = [], {}
+    open_t = None
+    for ln in lines:
+        try:
+            r = json.loads(ln)
+        except Exception:
+            continue
+        if not isinstance(r, dict):
+            continue
+        if "machineCut" in r:
+            c = str(r["machineCut"])
+            cuts[c] = cuts.get(c, 0) + 1
+            continue
+        st = r.get("state")
+        t = r.get("t")
+        if not isinstance(t, (int, float)) or not st:
+            continue
+        if st == "working":
+            if open_t is None:
+                open_t = float(t)
+        elif st == "waiting":
+            if open_t is not None and not r.get("by"):
+                turns.append({"t": int(t), "fedT": int(open_t), "feedToResultS": round(float(t) - open_t, 3)})
+            open_t = None
+        elif st in ("idle",):
+            open_t = None
+    return turns, cuts
+
+
+def spend_by_day(spend: dict) -> dict:
+    """{date: usd} from spend.json's day buckets."""
+    out = {}
+    days = spend.get("days") if isinstance(spend, dict) else None
+    for k, v in (days or {}).items():
+        if isinstance(v, dict) and isinstance(v.get("usd"), (int, float)):
+            out[str(k)] = float(v["usd"])
+    return out
+
+
+# ── the buckets ─────────────────────────────────────────────────────────────────────────────────────────
+def build_buckets(restarts, quiet, events, turns, statelog_turns, machine_cuts, spend_days, kind, anchor,
+                  tz=None, since=None, until=None) -> list[dict]:
+    """One dict per window with every metric the figures read. Rows outside [since, until) are dropped."""
+    def inside(t):
+        return (since is None or t >= since) and (until is None or t < until)
+    B = {}
+    def get(t):
+        k = bucket_key(t, kind, anchor, tz)
+        if k not in B:
+            s, e = bucket_bounds(k, kind, tz)
+            B[k] = {"key": k, "start": int(s), "end": int(e), "restarts": 0, "cutTurns": 0, "cleanRestarts": 0,
+                    "restartsWithoutCutRow": 0, "cutSessions": {}, "reasons": {}, "_outage": [], "_settle": [],
+                    "drainUnjoinedCount": 0, "drainReapedCount": 0,
+                    "quietWindows": 0, "backstopFires": 0, "_quietWait": [],
+                    "events": {}, "orphansReaped": 0, "scopesStopped": 0, "duplicateClis": 0, "crashHeals": 0,
+                    "crashLoops": 0, "drainLeftClosing": 0, "leaseProblems": 0, "boots": 0, "resumedTurns": 0,
+                    "redo": {"turns": 0, "usd": 0.0, "tokens": 0}, "_l_res": [], "_l_first": [], "_l_api": [],
+                    "_l_dur": [], "turns": 0, "_sl": [], "stateLogTurns": 0, "machineCuts": {}, "spendUsd": None,
+                    "_k_rss": [], "_k_cpu": []}
+        return B[k]
+    for r in restarts:
+        if not inside(r["t"]):
+            continue
+        b = get(r["t"])
+        b["restarts"] += 1
+        b["cutTurns"] += r["cutTurns"]
+        if r.get("noCutRow"):
+            b["restartsWithoutCutRow"] += 1
+        elif r["cutTurns"] == 0:
+            b["cleanRestarts"] += 1
+        for n in r["cutSessions"]:
+            b["cutSessions"][n] = b["cutSessions"].get(n, 0) + 1
+        why = (r["reason"].split(":", 1)[0] or "(none)") if r["reason"] else ("(no cut row)" if r.get("noCutRow") else "(none)")
+        b["reasons"][why] = b["reasons"].get(why, 0) + 1
+        b["drainUnjoinedCount"] += r["unjoined"]
+        b["drainReapedCount"] += r["reaped"]
+        bt = r.get("boot") or {}
+        if isinstance(bt.get("outageS"), (int, float)):
+            b["_outage"].append(bt["outageS"])
+        if isinstance(bt.get("settleS"), (int, float)):
+            b["_settle"].append(bt["settleS"])
+        if isinstance(r.get("rssKb"), (int, float)) and not r.get("noCutRow"):
+            b["_k_rss"].append(r["rssKb"] / 1024.0)
+        if isinstance(r.get("cpuS"), (int, float)) and not r.get("noCutRow"):
+            b["_k_cpu"].append(r["cpuS"])
+    for q in quiet:
+        if not inside(q["t"]):
+            continue
+        b = get(q["t"])
+        b["quietWindows"] += 1
+        b["backstopFires"] += 1 if q["backstop"] else 0
+        if isinstance(q.get("waitedS"), (int, float)):
+            b["_quietWait"].append(q["waitedS"])
+    for e in events:
+        if not inside(e["t"]):
+            continue
+        b = get(e["t"])
+        k = e["kind"]
+        b["events"][k] = b["events"].get(k, 0) + 1
+        if k == "reconcile.boot":
+            b["boots"] += 1
+            b["resumedTurns"] += int(e.get("resumed") or 0)
+        elif k == "reconcile.orphan-reaped":
+            b["orphansReaped"] += 1
+        elif k == "reconcile.scope-stopped":
+            b["scopesStopped"] += 1
+        elif k == "reconcile.duplicate-cli" or k == "lease.duplicate-cli":
+            b["duplicateClis"] += 1
+        elif k == "crash.heal":
+            b["crashHeals"] += 1
+        elif k == "crash.loop":
+            b["crashLoops"] += 1
+        elif k == "drain.unjoined":
+            b["drainLeftClosing"] += 1
+        if k.startswith("lease."):
+            b["leaseProblems"] += 1
+    for tr in turns:
+        if not inside(tr["t"]):
+            continue
+        b = get(tr["t"])
+        b["turns"] += 1
+        if "feedToResultS" in tr:
+            b["_l_res"].append(tr["feedToResultS"])
+        if "feedToFirstOutS" in tr:
+            b["_l_first"].append(tr["feedToFirstOutS"])
+        if isinstance(tr.get("apiMs"), (int, float)):
+            b["_l_api"].append(tr["apiMs"] / 1000.0)
+        if isinstance(tr.get("durationMs"), (int, float)):
+            b["_l_dur"].append(tr["durationMs"] / 1000.0)
+        if tr.get("resumeNotice"):
+            b["redo"]["turns"] += 1
+            b["redo"]["usd"] += float(tr.get("usd") or 0)
+            b["redo"]["tokens"] += sum(int(tr.get(k) or 0) for k in ("tokIn", "tokOut", "tokCacheR", "tokCacheW"))
+    for tr in statelog_turns:
+        if not inside(tr["t"]):
+            continue
+        b = get(tr["t"])
+        b["stateLogTurns"] += 1
+        b["_sl"].append(tr["feedToResultS"])
+    for (t, cause) in machine_cuts:
+        if not inside(t):
+            continue
+        b = get(t)
+        b["machineCuts"][cause] = b["machineCuts"].get(cause, 0) + 1
+    for date, usd in spend_days.items():
+        try:
+            t = day_start(date, tz) + 3600
+        except ValueError:
+            continue
+        if not inside(t):
+            continue
+        b = get(t)
+        b["spendUsd"] = round((b["spendUsd"] or 0.0) + usd, 4)
+    out = []
+    for k in sorted(B):
+        b = B[k]
+        b["samples"] = {"feedToResultS": _cap(b["_l_res"]), "feedToFirstOutS": _cap(b["_l_first"]),
+                        "stateLogS": _cap(b["_sl"])}
+        b["outageS"] = stats(b.pop("_outage"))
+        b["settleS"] = stats(b.pop("_settle"))
+        b["quietWaitS"] = stats(b.pop("_quietWait"))
+        b["latency"] = {"feedToResultS": stats(b.pop("_l_res")), "feedToFirstOutS": stats(b.pop("_l_first")),
+                        "apiS": stats(b.pop("_l_api")), "durationS": stats(b.pop("_l_dur"))}
+        b["stateLogLatencyS"] = stats(b.pop("_sl"))
+        b["kernelAtExit"] = {"rssMb": stats(b.pop("_k_rss")), "cpuS": stats(b.pop("_k_cpu"))}
+        b["redo"]["usd"] = round(b["redo"]["usd"], 4)
+        b["cutTurnsPerRestart"] = round(b["cutTurns"] / b["restarts"], 2) if b["restarts"] else None
+        out.append(b)
+    return out
+
+
+# ── live reads (never a kernel module; files and HTTP only) ─────────────────────────────────────────────
+def _regs(state: Path) -> dict:
+    """sid -> {name, lastSid, alive} from sdk/*.json (read, never written)."""
+    out = {}
+    for p in glob.glob(str(state / "sdk" / "*.json")):
+        try:
+            d = json.loads(Path(p).read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if isinstance(d, dict):
+            sid = str(d.get("sid") or Path(p).stem)
+            out[sid] = {"name": str(d.get("name") or sid[:8]), "lastSid": str(d.get("lastSid") or ""),
+                        "alive": bool(d.get("alive"))}
+    return out
+
+
+def _read_int(path: str):
+    try:
+        return int(open(path).read().split()[0])
+    except Exception:
+        return None
+
+
+def cgroup_scope_dirs(root="/sys/fs/cgroup") -> list[str]:
+    hits = glob.glob(os.path.join(root, "user.slice", "user-*.slice", "user@*.service", "*", "romp-session-*.scope"))
+    if not hits:
+        hits = glob.glob(os.path.join(root, "**", "romp-session-*.scope"), recursive=True)
+    return sorted(hits)
+
+
+def scope_stats(scope_dir: str) -> dict:
+    """memory.current (bytes), memory.peak when the kernel offers it, cpu.stat usage_usec, and the pid count
+    of one romp-session-* scope's cgroup. Read-only."""
+    unit = os.path.basename(scope_dir)
+    m = SCOPE_RE.match(unit)
+    out = {"scope": unit, "sid8": m.group(1).lower() if m else "", "cliPid": int(m.group(2)) if m else None}
+    out["memBytes"] = _read_int(os.path.join(scope_dir, "memory.current"))
+    out["memPeakBytes"] = _read_int(os.path.join(scope_dir, "memory.peak"))
+    cpu = None
+    try:
+        for ln in open(os.path.join(scope_dir, "cpu.stat")):
+            if ln.startswith("usage_usec"):
+                cpu = int(ln.split()[1]) / 1e6
+                break
+    except Exception:
+        pass
+    out["cpuS"] = round(cpu, 3) if cpu is not None else None
+    try:
+        out["procs"] = len([x for x in open(os.path.join(scope_dir, "cgroup.procs")).read().split() if x])
+    except Exception:
+        out["procs"] = None
+    return out
+
+
+def ps_lines() -> list[str]:
+    try:
+        return subprocess.run(["ps", "-axwwo", "pid=,ppid=,rss=,pcpu=,command="], capture_output=True,
+                              text=True, timeout=10).stdout.splitlines()
+    except Exception:
+        return []
+
+
+def parse_ps(lines: list[str]) -> dict[int, dict]:
+    procs = {}
+    for ln in lines:
+        parts = ln.strip().split(None, 4)
+        if len(parts) < 5 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+        try:
+            rss = int(float(parts[2]))
+            pcpu = float(parts[3])
+        except ValueError:
+            continue
+        procs[int(parts[0])] = {"ppid": int(parts[1]), "rssKb": rss, "pcpu": pcpu, "cmd": parts[4]}
+    return procs
+
+
+def cli_sid_of(cmd: str, sids) -> str | None:
+    for s in sids:
+        if not s:
+            continue
+        for flag in ("--resume", "--session-id"):
+            if (flag + " " + s) in cmd or (flag + "=" + s) in cmd:
+                return s
+    return None
+
+
+def duplicate_clis(procs: dict[int, dict], lastsids) -> dict[str, list[int]]:
+    """Conversation ids more than one SDK-driven CLI holds right now, id -> pids (the same match the kernel's
+    boot reap uses: the stream-json mark plus a --resume / --session-id spelling)."""
+    seen = {}
+    for pid in sorted(procs):
+        cmd = procs[pid]["cmd"]
+        if SDK_CLI_MARK not in cmd:
+            continue
+        s = cli_sid_of(cmd, lastsids)
+        if s:
+            seen.setdefault(s, []).append(pid)
+    return {s: p for s, p in seen.items() if len(p) > 1}
+
+
+def ps_session_trees(procs: dict[int, dict], regs: dict) -> list[dict]:
+    """Per-session memory and CPU from a ps listing (macOS, or Linux without cgroup access): each SDK CLI
+    that carries a session's conversation id, with its descendants' rss summed."""
+    kids = {}
+    for pid, p in procs.items():
+        kids.setdefault(p["ppid"], []).append(pid)
+    by_fsid = {r["lastSid"]: (sid, r) for sid, r in regs.items() if r.get("lastSid")}
+    out = []
+    for pid, p in procs.items():
+        if SDK_CLI_MARK not in p["cmd"]:
+            continue
+        fsid = cli_sid_of(p["cmd"], list(by_fsid))
+        if not fsid:
+            continue
+        stack, tree = [pid], []
+        while stack:
+            x = stack.pop()
+            tree.append(x)
+            stack.extend(kids.get(x, []))
+        sid, r = by_fsid[fsid]
+        out.append({"sid": sid, "name": r["name"], "cliPid": pid, "procs": len(tree),
+                    "memBytes": sum(procs[x]["rssKb"] for x in tree) * 1024,
+                    "cpuPct": round(sum(procs[x]["pcpu"] for x in tree), 2)})
+    return out
+
+
+def _kernel_port(state: Path) -> int:
+    env = os.environ.get("ROMP_KERNEL_PORT")
+    if env and env.isdigit():
+        return int(env)
+    try:
+        return int((state / "serve-port").read_text().strip())
+    except Exception:
+        return 29855
+
+
+def _kernel_token(state: Path) -> str:
+    return os.environ.get("ROMP_SERVE_TOKEN") or (state / "serve-token").read_text().strip() if (state / "serve-token").exists() else (os.environ.get("ROMP_SERVE_TOKEN") or "")
+
+
+def kernel_live(state: Path) -> dict:
+    """GET /version (auth-exempt) and GET /perf (token): the kernel's pid, uptime, CPU seconds, resident size
+    and the pusher's idle-cycle share. Unreachable or refused is SAID in `error`, never a silent zero."""
+    port = _kernel_port(state)
+    base = "http://127.0.0.1:%d" % port
+    out = {"port": port}
+    try:
+        with urllib.request.urlopen(base + "/version", timeout=2) as r:
+            v = json.loads(r.read().decode())
+        out.update({"pid": v.get("pid"), "started": v.get("started"), "uptimeS": v.get("uptime_s"),
+                    "kernelSha": v.get("kernel_sha"), "bootId": v.get("boot")})
+    except Exception as e:
+        out["error"] = "kernel not reachable on :%d (%s)" % (port, e.__class__.__name__)
+        return out
+    try:
+        tok = _kernel_token(state)
+        req = urllib.request.Request(base + "/perf", headers={"X-Romp-Token": tok} if tok else {})
+        with urllib.request.urlopen(req, timeout=3) as r:
+            pf = json.loads(r.read().decode())
+        proc, pusher = pf.get("process") or {}, pf.get("pusher") or {}
+        cyc = pusher.get("cycles") or 0
+        out["perf"] = {"cpuS": proc.get("cpu_s"), "rssKb": proc.get("rss_kb"), "threads": proc.get("threads"),
+                       "cycles": cyc, "idleCycles": pusher.get("idle_cycles"),
+                       "idleShare": round(float(pusher.get("idle_cycles") or 0) / cyc, 3) if cyc else None,
+                       "cycleMsP50": pusher.get("cycle_ms_p50"), "cycleMsP90": pusher.get("cycle_ms_p90")}
+    except Exception as e:
+        out["perfError"] = "GET /perf failed (%s)" % e.__class__.__name__
+    return out
+
+
+def live_snapshot(state: Path) -> dict:
+    regs = _regs(state)
+    out = {"host": host_name(), "platform": platform.system(), "t": int(time.time()), "sessions": [], "errors": []}
+    by8 = {}
+    for sid, r in regs.items():
+        if r.get("lastSid"):
+            by8.setdefault(r["lastSid"][:8].lower(), (sid, r))
+    dirs = cgroup_scope_dirs() if os.path.isdir("/sys/fs/cgroup") else []
+    if dirs:
+        out["source"] = "cgroup"
+        for d in dirs:
+            s = scope_stats(d)
+            sid, r = by8.get(s["sid8"], (None, None))
+            s["sid"], s["name"] = sid, (r["name"] if r else s["sid8"])
+            out["sessions"].append(s)
+    else:
+        out["source"] = "ps"
+        procs = parse_ps(ps_lines())
+        out["sessions"] = ps_session_trees(procs, regs)
+    procs = parse_ps(ps_lines())
+    lastsids = [r["lastSid"] for r in regs.values() if r.get("lastSid")]
+    dups = duplicate_clis(procs, lastsids)
+    by_fsid = {r["lastSid"]: r["name"] for r in regs.values() if r.get("lastSid")}
+    out["duplicateClis"] = [{"fsid": f, "name": by_fsid.get(f, f[:8]), "pids": p} for f, p in dups.items()]
+    out["kernel"] = kernel_live(state)
+    mem = [s["memBytes"] for s in out["sessions"] if isinstance(s.get("memBytes"), int)]
+    out["memTotalBytes"] = sum(mem) if mem else None
+    out["sessionsCounted"] = len(out["sessions"])
+    return out
+
+
+# ── the document and its summary ────────────────────────────────────────────────────────────────────────
+def collect(state: Path, kind="day", anchor=None, tz=None, since=None, until=None, live=True) -> dict:
+    cuts, n_cuts = _read_jsonl(state / "restart-cuts.jsonl")
+    audit, n_audit = _read_jsonl(state / "restart-audit.jsonl")
+    ev, n_ev = _read_jsonl(state / "session-events.jsonl")
+    tu, n_tu = _read_jsonl(state / "turns.jsonl")
+    restarts = parse_restarts(cuts)
+    quiet = parse_quiet_windows(audit, restarts)
+    events = parse_events(ev)
+    turns = parse_turns(tu)
+    sl_turns, machine_cuts, n_states = [], [], 0
+    for p in sorted(glob.glob(str(state / "states" / "*.jsonl"))):
+        try:
+            lines = Path(p).read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        n_states += 1
+        t_list, cuts_by = state_log_turns(lines)
+        sl_turns.extend(t_list)
+        # machineCut rows carry their own float t; count them where they happened
+        for ln in lines:
+            try:
+                r = json.loads(ln)
+            except Exception:
+                continue
+            if isinstance(r, dict) and "machineCut" in r and isinstance(r.get("t"), (int, float)):
+                machine_cuts.append((float(r["t"]), str(r["machineCut"])))
+    spend, spend_note = {}, {"path": "spend.json", "present": False}
+    try:
+        spend = json.loads((state / "spend.json").read_text(encoding="utf-8"))
+        spend_note = {"path": "spend.json", "present": True, "days": len((spend or {}).get("days") or {})}
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        spend_note = {"path": "spend.json", "present": True, "error": str(e)}
+    stamps = [r["t"] for r in restarts] + [e["t"] for e in events]
+    if anchor is None:
+        first = min([t for t in stamps if since is None or t >= since] or [time.time()])
+        anchor = local_date(first, tz)
+    buckets = build_buckets(restarts, quiet, events, turns, sl_turns, machine_cuts, spend_by_day(spend),
+                            kind, anchor, tz, since, until)
+    doc = {"schema": SCHEMA, "generatedAt": int(time.time()), "host": host_name(),
+           "window": {"kind": kind, "anchor": anchor, "tz": tz or "local"},
+           "range": {"since": since, "until": until},
+           "sources": {"restartCuts": n_cuts, "restartAudit": n_audit, "sessionEvents": n_ev, "turns": n_tu,
+                       "stateLogs": n_states, "spend": spend_note},
+           "audit": audit_counts(audit),
+           "restarts": restarts, "quietWindows": quiet, "kernelSeries": kernel_series(restarts),
+           "events": {"byKind": _count(e["kind"] for e in events), "recent": events[-50:]},
+           "buckets": buckets,
+           "notes": ["Redo cost (redo.usd, redo.tokens) is read from turns.jsonl, whose rows begin when this "
+                     "reader's kernel change landed; the spend ledger (spend.json) has hour and day buckets per "
+                     "session and no per-turn rows, so it cannot attribute a turn's cost.",
+                     "Turn latency: turns.jsonl stamps are event stamps at millisecond resolution (feed pop, "
+                     "first work atom, ResultMessage); stateLogLatencyS is the same feed-to-result interval "
+                     "from the state log at one-second resolution, available for turns before turns.jsonl."]}
+    doc["live"] = live_snapshot(state) if live else {"skipped": True}
+    return doc
+
+
+SAMPLE_CAP = 4000     # latency samples kept per bucket for the distribution figure (evenly strided past this)
+
+
+def _cap(xs, cap=SAMPLE_CAP):
+    xs = [round(float(x), 3) for x in xs]
+    if len(xs) <= cap:
+        return xs
+    step = len(xs) / float(cap)
+    return [xs[int(i * step)] for i in range(cap)]
+
+
+def _count(it):
+    c = {}
+    for k in it:
+        c[k] = c.get(k, 0) + 1
+    return c
+
+
+def _fmt_s(x):
+    if not isinstance(x, (int, float)):
+        return "-"
+    return ("%.1f s" % x) if x < 100 else ("%d s" % round(x))
+
+
+def _st(s: dict, unit=_fmt_s) -> str:
+    if not s or not s.get("n"):
+        return "none"
+    return "n=%d p50 %s p90 %s max %s" % (s["n"], unit(s["p50"]), unit(s["p90"]), unit(s["max"]))
+
+
+def _mb(b):
+    return "-" if not isinstance(b, (int, float)) else ("%.0f MB" % (b / 1048576.0))
+
+
+def summary(doc: dict) -> str:
+    """The one-screen text per window."""
+    w = doc["window"]
+    src = doc["sources"]
+    lines = ["restart metrics — host %s — %s windows, anchor %s, times %s" % (doc["host"], w["kind"], w["anchor"], w["tz"])]
+    missing = [k for k in ("restartCuts", "restartAudit", "sessionEvents", "turns") if not (src.get(k) or {}).get("present")]
+    if missing:
+        lines.append("  MISSING ledgers (nothing measured from them): " + ", ".join((src[k] or {}).get("path", k) for k in missing))
+    if not doc["buckets"]:
+        lines.append("  no rows in range")
+    for b in doc["buckets"]:
+        lines.append("")
+        lines.append("%s  (%s to %s)" % (b["key"], time.strftime("%Y-%m-%d", time.localtime(b["start"])),
+                                          time.strftime("%Y-%m-%d", time.localtime(b["end"] - 1))))
+        per = (" (%s per restart)" % b["cutTurnsPerRestart"]) if b["cutTurnsPerRestart"] is not None else ""
+        lines.append("  restarts %d · turns cut %d%s · clean restarts %d · boots with no cut row %d"
+                     % (b["restarts"], b["cutTurns"], per, b["cleanRestarts"], b["restartsWithoutCutRow"]))
+        if b["reasons"]:
+            lines.append("  reasons: " + ", ".join("%s %d" % (k, v) for k, v in sorted(b["reasons"].items(), key=lambda kv: -kv[1])))
+        lines.append("  outage to first serve %s · reconcile settle %s" % (_st(b["outageS"]), _st(b["settleS"])))
+        lines.append("  quiet windows %d · wait %s · backstop fired %d" % (b["quietWindows"], _st(b["quietWaitS"]), b["backstopFires"]))
+        lines.append("  boot sweeps %d · orphans reaped %d · scopes stopped %d · duplicate CLIs %d · crash heals %d · "
+                     "crash loops %d · drain left closing %d (cut rows: unjoined %d, reaped %d) · lease problems %d"
+                     % (b["boots"], b["orphansReaped"], b["scopesStopped"], b["duplicateClis"], b["crashHeals"],
+                        b["crashLoops"], b["drainLeftClosing"], b["drainUnjoinedCount"], b["drainReapedCount"], b["leaseProblems"]))
+        red = b["redo"]
+        spend = (" of $%.2f that day" % b["spendUsd"]) if isinstance(b.get("spendUsd"), (int, float)) and w["kind"] == "day" else \
+                (" of $%.2f in the window" % b["spendUsd"]) if isinstance(b.get("spendUsd"), (int, float)) else ""
+        lines.append("  continuation notices %d · redo turns %d · redo cost $%.2f%s · redo tokens %s"
+                     % (b["resumedTurns"], red["turns"], red["usd"], spend, "{:,}".format(red["tokens"])))
+        lat = b["latency"]
+        lines.append("  turn latency: feed to result %s · feed to first output %s · api %s"
+                     % (_st(lat["feedToResultS"]), _st(lat["feedToFirstOutS"]), _st(lat["apiS"])))
+        lines.append("  state-log latency (1 s resolution) %s · machine cuts %s"
+                     % (_st(b["stateLogLatencyS"]), ", ".join("%s %d" % kv for kv in sorted(b["machineCuts"].items())) or "none"))
+        k = b["kernelAtExit"]
+        lines.append("  kernel process at its exits: resident %s · cpu %s"
+                     % (_st(k["rssMb"], lambda x: "%.0f MB" % x), _st(k["cpuS"])))
+    live = doc.get("live") or {}
+    lines.append("")
+    if live.get("skipped"):
+        lines.append("live: skipped")
+    else:
+        sess = live.get("sessions") or []
+        top = sorted([s for s in sess if isinstance(s.get("memBytes"), int)], key=lambda s: -s["memBytes"])[:3]
+        lines.append("live (%s): %d session scopes · memory total %s · top: %s"
+                     % (live.get("source", "?"), len(sess), _mb(live.get("memTotalBytes")),
+                        ", ".join("%s %s" % (s.get("name"), _mb(s["memBytes"])) for s in top) or "-"))
+        k = live.get("kernel") or {}
+        if k.get("error"):
+            lines.append("kernel: " + k["error"])
+        else:
+            pf = k.get("perf") or {}
+            idle = ("%.0f%%" % (100 * pf["idleShare"])) if isinstance(pf.get("idleShare"), float) else "-"
+            lines.append("kernel: pid %s · up %s · cpu %s · rss %s · pusher idle cycles %s%s"
+                         % (k.get("pid"), _fmt_s(k.get("uptimeS")), _fmt_s(pf.get("cpuS")),
+                            _mb((pf.get("rssKb") or 0) * 1024) if pf.get("rssKb") else "-", idle,
+                            (" · " + k["perfError"]) if k.get("perfError") else ""))
+        if live.get("duplicateClis"):
+            lines.append("DUPLICATE CLIs NOW: " + "; ".join("%s pids %s" % (d["name"], d["pids"]) for d in live["duplicateClis"]))
+    lines.append("")
+    for n in doc.get("notes") or []:
+        lines.append("note: " + n)
+    return "\n".join(lines)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(prog="romp restart-metrics", description=__doc__.split("\n\n")[0])
+    ap.add_argument("--json", action="store_true", help="print the whole document as JSON")
+    ap.add_argument("--window", choices=("day", "week"), default="day")
+    ap.add_argument("--anchor", help="YYYY-MM-DD the weeks start from (default: the first restart's day)")
+    ap.add_argument("--since", help="YYYY-MM-DD, inclusive")
+    ap.add_argument("--until", help="YYYY-MM-DD, exclusive")
+    ap.add_argument("--tz", help="a zone name for the day boundaries (default: the machine's local time)")
+    ap.add_argument("--no-live", action="store_true", help="skip the live reads (scopes, ps, the kernel's routes)")
+    ap.add_argument("--state", help="a state directory other than this machine's")
+    a = ap.parse_args(argv)
+    state = Path(a.state) if a.state else state_dir()
+    try:
+        since = day_start(a.since, a.tz) if a.since else None
+        until = day_start(a.until, a.tz) if a.until else None
+    except ValueError as e:
+        sys.stderr.write("romp restart-metrics: bad date: %s\n" % e)
+        return 2
+    doc = collect(state, kind=a.window, anchor=a.anchor, tz=a.tz, since=since, until=until, live=not a.no_live)
+    if a.json:
+        sys.stdout.write(json.dumps(doc, indent=1, sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(summary(doc) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/restart_metrics.py
+++ b/cli/restart_metrics.py
@@ -40,7 +40,6 @@ import json
 import os
 import platform
 import re
-import socket
 import subprocess
 import sys
 import time
@@ -62,9 +61,8 @@ def state_dir() -> Path:
                 or Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state")) / "romp")
 
 
-def host_name() -> str:
-    env = os.environ.get("ROMP_HOST_NAME")
-    return env if env else (socket.gethostname() or "?").split(".")[0]
+DEFAULT_LABEL = "this machine"   # the document's name for itself; never the hostname (a personal identifier
+#                                  the user's rules keep out of anything they read) unless the caller passes one
 
 
 def _read_jsonl(path: Path) -> tuple[list[dict], dict]:
@@ -615,7 +613,7 @@ def kernel_live(state: Path) -> dict:
 
 def live_snapshot(state: Path) -> dict:
     regs = _regs(state)
-    out = {"host": host_name(), "platform": platform.system(), "t": int(time.time()), "sessions": [], "errors": []}
+    out = {"platform": platform.system(), "t": int(time.time()), "sessions": [], "errors": []}
     by8 = {}
     for sid, r in regs.items():
         if r.get("lastSid"):
@@ -645,7 +643,8 @@ def live_snapshot(state: Path) -> dict:
 
 
 # ── the document and its summary ────────────────────────────────────────────────────────────────────────
-def collect(state: Path, kind="day", anchor=None, tz=None, since=None, until=None, live=True) -> dict:
+def collect(state: Path, kind="day", anchor=None, tz=None, since=None, until=None, live=True,
+            label=DEFAULT_LABEL) -> dict:
     cuts, n_cuts = _read_jsonl(state / "restart-cuts.jsonl")
     audit, n_audit = _read_jsonl(state / "restart-audit.jsonl")
     ev, n_ev = _read_jsonl(state / "session-events.jsonl")
@@ -685,7 +684,7 @@ def collect(state: Path, kind="day", anchor=None, tz=None, since=None, until=Non
         anchor = local_date(first, tz)
     buckets = build_buckets(restarts, quiet, events, turns, sl_turns, machine_cuts, spend_by_day(spend),
                             kind, anchor, tz, since, until)
-    doc = {"schema": SCHEMA, "generatedAt": int(time.time()), "host": host_name(),
+    doc = {"schema": SCHEMA, "generatedAt": int(time.time()), "label": str(label or DEFAULT_LABEL),
            "window": {"kind": kind, "anchor": anchor, "tz": tz or "local"},
            "range": {"since": since, "until": until},
            "sources": {"restartCuts": n_cuts, "restartAudit": n_audit, "sessionEvents": n_ev, "turns": n_tu,
@@ -742,7 +741,8 @@ def summary(doc: dict) -> str:
     """The one-screen text per window."""
     w = doc["window"]
     src = doc["sources"]
-    lines = ["restart metrics — host %s — %s windows, anchor %s, times %s" % (doc["host"], w["kind"], w["anchor"], w["tz"])]
+    lines = ["restart metrics: %s, %s windows, anchor %s, times %s"
+             % (doc.get("label") or DEFAULT_LABEL, w["kind"], w["anchor"], w["tz"])]
     missing = [k for k in ("restartCuts", "restartAudit", "sessionEvents", "turns") if not (src.get(k) or {}).get("present")]
     if missing:
         lines.append("  MISSING ledgers (nothing measured from them): " + ", ".join((src[k] or {}).get("path", k) for k in missing))
@@ -814,6 +814,8 @@ def main(argv=None) -> int:
     ap.add_argument("--tz", help="a zone name for the day boundaries (default: the machine's local time)")
     ap.add_argument("--no-live", action="store_true", help="skip the live reads (scopes, ps, the kernel's routes)")
     ap.add_argument("--state", help="a state directory other than this machine's")
+    ap.add_argument("--label", default=DEFAULT_LABEL,
+                    help="what the document calls this machine (default: '%s'; never the hostname unless you say so)" % DEFAULT_LABEL)
     a = ap.parse_args(argv)
     state = Path(a.state) if a.state else state_dir()
     try:
@@ -822,7 +824,8 @@ def main(argv=None) -> int:
     except ValueError as e:
         sys.stderr.write("romp restart-metrics: bad date: %s\n" % e)
         return 2
-    doc = collect(state, kind=a.window, anchor=a.anchor, tz=a.tz, since=since, until=until, live=not a.no_live)
+    doc = collect(state, kind=a.window, anchor=a.anchor, tz=a.tz, since=since, until=until, live=not a.no_live,
+                  label=a.label)
     if a.json:
         sys.stdout.write(json.dumps(doc, indent=1, sort_keys=True) + "\n")
     else:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2034,13 +2034,16 @@ split on the marker. `GET /session-events?since=<epoch s>&limit=<n>`
 kernel's boot; at most 1000), each with `host`, and `count`, this kernel's
 problems since its boot, never a sum across kernels. `turns.jsonl` gets one
 row per settled turn: `t`, `sid`, `name`, `fedT` (the feed pop, when the text
-left the queue for the CLI's stdin), `firstOutT` (the first streamed work
-atom), `resultT` (the ResultMessage), the CLI's own `durationMs`, `apiMs`,
+left the queue for the CLI's stdin, at millisecond resolution), `firstOutT`
+(the first streamed work atom), `resultT` (the ResultMessage), the CLI's own `durationMs`, `apiMs`,
 `numTurns` and `isError`, the spend fold's `usd` and token columns (`tokIn`,
 `tokOut`, `tokCacheR`, `tokCacheW`), `opener` (`human` or `injected`),
 `fedTexts`, and `resumeNotice`, true when a text fed into the turn was the
 boot or crash continuation notice, the turn that redoes cut work. Every stamp
-is an event's time. Both files rotate at 32 MB to `<name>.1`, one predecessor
+is an event's time, and `fedT` and `firstOutT` are present only for a turn
+this kernel fed: a turn the CLI opened by itself (a channel message, a
+background task's notification, a scheduled prompt) has no feed, so its row
+carries neither rather than the previous turn's stamps. Both files rotate at 32 MB to `<name>.1`, one predecessor
 kept, so each pair stays under 64 MB; the reader reads both. The restart rows
 of `restart-cuts.jsonl` carry the kernel process's own `rssKb` and `cpuS`,
 sampled at its exit (the cut row) and at its settled boot (the boot row), so
@@ -2085,7 +2088,9 @@ state directory's ledgers (`restart-cuts.jsonl`, `restart-audit.jsonl`,
 `spend.json` for the day's total dollars) and from the running kernel's
 `GET /version` and `GET /perf`; it loads no kernel module and writes nothing.
 The text form prints one screen per window: restarts and the turns they cut
-(with the clean restarts and the boots that had no cut row, a crash respawn),
+(with the clean restarts and the boots that had no cut row, a crash respawn,
+whose cut count is unknown; the per-restart rate divides by the measured
+restarts alone),
 the reasons, the outage from exit to first serve and the reconcile settle (from
 the `bootSettled` rows), the quiet windows' waits and backstop firings (from
 the manager's `quiet-window` rows), the boot sweeps' orphans reaped, scopes
@@ -2097,14 +2102,16 @@ so), turn latency from the feed pop to the result and to the first output (from
 `turns.jsonl`, at millisecond resolution) beside the same interval from the
 state log's `working` and `waiting` rows (one-second resolution, the only
 latency available for turns before `turns.jsonl` existed), the machine cuts by
-cause, and the kernel process's resident memory and CPU at its exits. The live
+cause (a state-log pair broken by a machine cut is not a turn), and the kernel
+process's resident memory and CPU at its exits. The live
 block reads each `romp-session-*` scope's `memory.current` and `cpu.stat` on
 Linux (a `ps` tree walk where there is no cgroup), the kernel's pid, uptime,
 CPU, resident size and the pusher's idle-cycle share, and lists any
 conversation two Claude Code processes hold right now. Windows are days or
 weeks (`--window`), weeks anchored on `--anchor` (default the first restart's
 day in range), bounded by `--since` and `--until`, in the machine's local time
-unless `--tz` names a zone. The header names the machine `this machine`
+unless `--tz` names a zone; weeks are counted in local dates, so a clock change
+inside a week moves no boundary off local midnight. The header names the machine `this machine`
 unless `--label` says otherwise, so no hostname reaches the text by default. A
 missing ledger is named at the top, never a silent zero. `--json` prints the whole document (`schema` 1): `restarts`
 (each cut row joined to the boot that followed it), `quietWindows` (each

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2104,8 +2104,9 @@ CPU, resident size and the pusher's idle-cycle share, and lists any
 conversation two Claude Code processes hold right now. Windows are days or
 weeks (`--window`), weeks anchored on `--anchor` (default the first restart's
 day in range), bounded by `--since` and `--until`, in the machine's local time
-unless `--tz` names a zone. A missing ledger is named at the top, never a
-silent zero. `--json` prints the whole document (`schema` 1): `restarts`
+unless `--tz` names a zone. The header names the machine `this machine`
+unless `--label` says otherwise, so no hostname reaches the text by default. A
+missing ledger is named at the top, never a silent zero. `--json` prints the whole document (`schema` 1): `restarts`
 (each cut row joined to the boot that followed it), `quietWindows` (each
 joined to the restart it released), `kernelSeries`, `events`, `buckets` (every
 metric above per window, with capped latency samples for the distribution
@@ -2127,7 +2128,12 @@ window, continuation notices and redo dollars, the turn-latency distribution,
 resident memory per session scope and the kernel's own, and the kernel's
 resident memory at each exit and boot over the days of each document; beside
 them `figures.json` carries the numbers drawn and `summary.txt` the reader's
-text per document. Without cleanplots the script says so and draws nothing.
+text per document. Session names are hidden by default (`session 1..N` by
+memory rank; the kernel's own bar keeps its name and its own colour) for any
+output directory outside your state root, because real session names are
+private and must not reach a repository, an issue or a pull request; `--named`
+shows them, and inside your own state root they show by default. Without
+cleanplots the script says so and draws nothing.
 
 ## Switches
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -36,6 +36,7 @@ These are for scripting and for agents rather than daily use:
 | `romp perf [--interval <s>] [--json]`, `romp perf log on\|off` | The kernel's performance counters as rates over two snapshots (below); `--json` prints one raw snapshot; `log on\|off` turns the `romp-perf` stderr log on or off without a restart |
 | `romp perf client [--minutes <n>] [--json]` | What the open dashboards' browsers spent on the frames they received (below): handler milliseconds per minute by frame type with window p50/p90/p99 and max, the worst minute's main-thread-free p90, long animation frames and their attributed callbacks, the worst minute, heap and DOM, the slowest frames, per dashboard and pane over the last `<n>` minutes (default 10) |
 | `romp api-health` | The API-health signal as JSON (see [The API-health signal](#the-api-health-signal)): per-credential, per-model-family retry and give-up rates over rolling windows, with a derived state |
+| `romp restart-metrics [--json] [--window day\|week] [--anchor D] [--since D] [--until D] [--tz Z] [--no-live]` | What kernel restarts do to the sessions (see [Restart metrics](#restart-metrics)): turns cut per restart and per window, outage and reconcile times, quiet-window waits, orphans and reaps, crash heals, redo cost, turn latency, per-session and kernel memory and CPU; a text summary per window, or the whole document as JSON |
 | `romp mail …` | The postal service from the shell (below) |
 | `romp send <session> [--tag <label>] <text>` | Hand a session a message, on either backend. Anything a script, cron job, or launcher composes SHOULD carry a tag (one word, letters/digits/dashes, up to 24 chars): the chat then renders it as machine-sent under that label instead of as the user's typed words. Raw POST /send callers pass it as the JSON `tag` field (`{name, text, tag}`; a malformed tag fails the whole send, loudly); `--tag` is the CLI's equivalent. Both resolve to the `<!-- romp-tag: <label> -->` marker in the delivered text |
 | `romp new --env NAME=VALUE <name>` | A per-session env var for the SDK session, repeatable; a re-run against a running `<name>` replaces the whole set; vars not re-named are dropped |
@@ -2011,6 +2012,45 @@ writes the row. The manager's log says `exited without a restart request
 (signal or crash); respawning` when a kernel exits that it did not ask to stop
 or restart.
 
+Two more ledgers there record what restarts do to the sessions, appended by
+the SDK backend and read by `romp restart-metrics` (below). `session-events.jsonl`
+gets one flat row per thing that went wrong with a session's process and one
+per boot sweep: `{"t": <epoch s>, "pid": <the writing kernel>, "kind":
+"<writer>.<what>", "sid": <the session, when about one>, "name": <its name
+then>, ...fields, "text": <the prose>}`. The kinds: `reconcile.boot` (every
+boot's sweep summary: `sessions`, `resumed` continuation notices queued,
+`restored`, `notified`, `reaped`, `scopesStopped`, `toStart`, `durationS`),
+`reconcile.orphan-reaped` (`cliPid`, `fsid`, `scope`, `signaled`, `forced`,
+`tree`), `reconcile.scope-stopped` (`unit`, `sid8`, `cliPid`),
+`reconcile.duplicate-cli` (two Claude Code processes holding one conversation
+as the boot's process listing stood: `fsid`, `pids`, `n`), `crash.heal` and
+`crash.loop` (`attempt`), `drain.unjoined` (a session the drain's bound left
+closing: `inflight`, `reaped`), and the lease work's `lease.*` kinds. Every kind
+but the boot summary is also a problem-ring entry (the bell and error center
+show its prose) and a kernel-log line of the form `<prose> ;; problem-row
+{json}`, the same object after the marker, so a log reader parses it with a
+split on the marker. `GET /session-events?since=<epoch s>&limit=<n>`
+(token-gated) returns the rows newest first since the stamp (default this
+kernel's boot; at most 1000), each with `host`, and `count`, this kernel's
+problems since its boot, never a sum across kernels. `turns.jsonl` gets one
+row per settled turn: `t`, `sid`, `name`, `fedT` (the feed pop, when the text
+left the queue for the CLI's stdin), `firstOutT` (the first streamed work
+atom), `resultT` (the ResultMessage), the CLI's own `durationMs`, `apiMs`,
+`numTurns` and `isError`, the spend fold's `usd` and token columns (`tokIn`,
+`tokOut`, `tokCacheR`, `tokCacheW`), `opener` (`human` or `injected`),
+`fedTexts`, and `resumeNotice`, true when a text fed into the turn was the
+boot or crash continuation notice, the turn that redoes cut work. Every stamp
+is an event's time. Both files rotate at 32 MB to `<name>.1`, one predecessor
+kept, so each pair stays under 64 MB; the reader reads both. The restart rows
+of `restart-cuts.jsonl` carry the kernel process's own `rssKb` and `cpuS`,
+sampled at its exit (the cut row) and at its settled boot (the boot row), so
+the kernel's growth between restarts is a series without a sampler of its own.
+And the manager writes a `quiet-window` row to `restart-audit.jsonl` when a
+parked deploy refresh applies (`since`, `waitedS`, `reason` as the gate's
+verdict, `backstop` when the fifteen-minute cap fired, `coalesced`, `mode`,
+`lastInflight`, `misses`, and the park's drain-hold counts); it is a note, not
+a request, and the kernel's restart-reason walk passes it over.
+
 The two host registries there, `remotes.json` (attached and checked-in
 machines, each row with that machine's serve token) and `remotes-known.json`
 (machines remembered for re-attach, with the mail tier you set for each), are
@@ -2036,6 +2076,58 @@ kind. At start the bus removes the temporary files a crash left behind (a
 message written but never placed, a store record never finished), closes each
 one's receipt as refused, and says so once. The sidecars are yours to inspect
 or delete.
+
+## Restart metrics
+
+`romp restart-metrics` reads what kernel restarts do to the sessions, from the
+state directory's ledgers (`restart-cuts.jsonl`, `restart-audit.jsonl`,
+`session-events.jsonl`, `turns.jsonl`, the state logs under `states/`, and
+`spend.json` for the day's total dollars) and from the running kernel's
+`GET /version` and `GET /perf`; it loads no kernel module and writes nothing.
+The text form prints one screen per window: restarts and the turns they cut
+(with the clean restarts and the boots that had no cut row, a crash respawn),
+the reasons, the outage from exit to first serve and the reconcile settle (from
+the `bootSettled` rows), the quiet windows' waits and backstop firings (from
+the manager's `quiet-window` rows), the boot sweeps' orphans reaped, scopes
+stopped, duplicate processes, crash heals and loops, sessions the drain left
+closing, and lease problems (from `session-events.jsonl`), the continuation
+notices and the redo turns with their dollars and tokens (from `turns.jsonl`;
+the spend ledger's buckets cannot attribute a turn's cost, and the summary says
+so), turn latency from the feed pop to the result and to the first output (from
+`turns.jsonl`, at millisecond resolution) beside the same interval from the
+state log's `working` and `waiting` rows (one-second resolution, the only
+latency available for turns before `turns.jsonl` existed), the machine cuts by
+cause, and the kernel process's resident memory and CPU at its exits. The live
+block reads each `romp-session-*` scope's `memory.current` and `cpu.stat` on
+Linux (a `ps` tree walk where there is no cgroup), the kernel's pid, uptime,
+CPU, resident size and the pusher's idle-cycle share, and lists any
+conversation two Claude Code processes hold right now. Windows are days or
+weeks (`--window`), weeks anchored on `--anchor` (default the first restart's
+day in range), bounded by `--since` and `--until`, in the machine's local time
+unless `--tz` names a zone. A missing ledger is named at the top, never a
+silent zero. `--json` prints the whole document (`schema` 1): `restarts`
+(each cut row joined to the boot that followed it), `quietWindows` (each
+joined to the restart it released), `kernelSeries`, `events`, `buckets` (every
+metric above per window, with capped latency samples for the distribution
+figure), `sources`, and `live`.
+
+`scripts/restart_metrics_report.py` draws the before-versus-after figures from
+two or more of those JSON documents with cleanplots, which is not a romp
+dependency, so it runs under uv:
+
+```
+uvx --with cleanplots --with matplotlib --with pandas python \
+    scripts/restart_metrics_report.py --doc baseline=baseline.json --doc after=after.json --out DIR
+```
+
+The figures land in `--out` (default
+`~/.local/state/romp-research/restart-metrics/`): turns cut per window and per
+restart, outage and settle times, quiet-window waits, sessions gone wrong per
+window, continuation notices and redo dollars, the turn-latency distribution,
+resident memory per session scope and the kernel's own, and the kernel's
+resident memory at each exit and boot over the days of each document; beside
+them `figures.json` carries the numbers drawn and `summary.txt` the reader's
+text per document. Without cleanplots the script says so and draws nothing.
 
 ## Switches
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2017,8 +2017,8 @@ the SDK backend and read by `romp restart-metrics` (below). `session-events.json
 gets one flat row per thing that went wrong with a session's process and one
 per boot sweep: `{"t": <epoch s>, "pid": <the writing kernel>, "kind":
 "<writer>.<what>", "sid": <the session, when about one>, "name": <its name
-then>, ...fields, "text": <the prose>}`. The kinds: `reconcile.boot` (every
-boot's sweep summary: `sessions`, `resumed` continuation notices queued,
+then>, ...fields, "text": <the prose>}`. The kinds: `reconcile.boot` (the
+sweep summary of every boot that had a session to reconcile: `sessions`, `resumed` continuation notices queued,
 `restored`, `notified`, `reaped`, `scopesStopped`, `toStart`, `durationS`),
 `reconcile.orphan-reaped` (`cliPid`, `fsid`, `scope`, `signaled`, `forced`,
 `tree`), `reconcile.scope-stopped` (`unit`, `sid8`, `cliPid`),

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7566,7 +7566,9 @@ def _in_place_converge(target):
 
 _DEPLOY_RESTART_REASONS = ("main-converge", "p2p-update", "self-update",   # ledger reasons that ARE a
                            "kernel-asks-manager-restart-all: self-update")   # deploy restart of this kernel
-_NO_RESTART_ACTIONS = {"main-converge-skip", "bus-converge", "end-on-idle"}   # audit rows that restart no
+_NO_RESTART_ACTIONS = {"main-converge-skip", "bus-converge", "end-on-idle",   # audit rows that restart no
+                       "quiet-window"}   # (the manager's note of a quiet window APPLYING: a wait measured, T304;
+                                         #  the restart it releases writes its own manager-sigterm note)
 #                                                                              kernel (in-place converges; a
 #                                                                              session's own self-close ask)
 
@@ -15094,6 +15096,38 @@ def _sdk_problem_rows(limit=20, cap=400):
     return out
 
 
+SESSION_EVENTS_TAIL = 5000     # lines of session-events.jsonl one GET /session-events reads (newest)
+
+
+def _session_event_rows(since=0.0, limit=200, tail=SESSION_EVENTS_TAIL):
+    """(rows, count) for GET /session-events (T304): the session-event ledger the SDK backend appends
+    (kernel/sdk_backend.py SESSION_EVENTS_FILE: an orphaned CLI ended at boot, a leftover scope stopped, two
+    CLIs holding one conversation, a crash heal or loop, a session the drain left closing, and the boot
+    sweep's summary), newest first, rows with t >= `since`, at most `limit`, each carrying `host` (this
+    kernel's own name, _self_host) so a federated shell merges per-host maps and never sums across kernels.
+    `count` is the problems since THIS kernel's boot on THIS host: every row at or after _STARTED except the
+    boot summary (reconcile.boot, which every boot writes). Reads the file's tail only; a missing or
+    unreadable ledger is ([], 0)."""
+    path = jd.STATE / "session-events.jsonl"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()[-int(tail):]
+    except OSError:
+        return [], 0
+    rows = []
+    for ln in lines:
+        try:
+            r = json.loads(ln)
+        except Exception:
+            continue
+        if isinstance(r, dict) and isinstance(r.get("t"), (int, float)) and r.get("kind"):
+            rows.append(r)
+    boot_t = int(_STARTED)
+    count = sum(1 for r in rows if r["t"] >= boot_t and r["kind"] != "reconcile.boot")
+    host = _self_host()
+    out = [dict(r, host=host) for r in reversed(rows) if r["t"] >= since][:max(1, int(limit))]
+    return out, count
+
+
 # ── slash-command list for the composer's "/" autocomplete (the user 2026-06-29) ──────────────────────────────
 # The DESIGNED source is the Agent SDK's get_server_info()['commands'] — each {name, description, argumentHint,
 # aliases} — and it covers BOTH backends, because the command set is fixed by the `claude` binary + config + cwd,
@@ -21845,14 +21879,29 @@ def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None):
     so the ledger documents the cut honestly on our side and the stamps stay a documented CLI
     artifact."""
     d = drain_res if isinstance(drain_res, dict) else {}
-    return {"t": int(now if now is not None else time.time()),
-            "pid": os.getpid(),
-            "cutTurns": list(d.get("cutTurns") or []),
-            "stopped": int(d.get("stopped") or 0),
-            "unjoined": int(d.get("unjoined") or 0),
-            "reaped": int(d.get("reaped") or 0),
-            "watchesArmed": int(watches_armed or 0),
-            "reason": str(audit_reason or "")}
+    row = {"t": int(now if now is not None else time.time()),
+           "pid": os.getpid(),
+           "cutTurns": list(d.get("cutTurns") or []),
+           "stopped": int(d.get("stopped") or 0),
+           "unjoined": int(d.get("unjoined") or 0),
+           "reaped": int(d.get("reaped") or 0),
+           "watchesArmed": int(watches_armed or 0),
+           "reason": str(audit_reason or "")}
+    row.update(_kernel_process_sample())   # T304: the kernel's own size and CPU at the end of its life
+    return row
+
+
+def _kernel_process_sample() -> dict:
+    """{rssKb, cpuS} of THIS kernel process (T304): its resident size and CPU seconds, sampled at the two
+    events the restart ledger already records, the exit (the cut row: the process at the end of its life)
+    and the settled boot (the boot row: the process just born), so the kernel's own growth between restarts
+    is a series with no sampler of its own. _process_stats reads /proc (macOS: ru_maxrss, the peak). Never
+    raises; an unreadable process is an empty dict, and the row simply lacks the two fields."""
+    try:
+        ps = _process_stats()
+        return {"rssKb": int(ps.get("rss_kb") or 0), "cpuS": round(float(ps.get("cpu_s") or 0.0), 2)}
+    except Exception:
+        return {}
 
 
 def _append_restart_cut(row):
@@ -21893,6 +21942,7 @@ def _append_boot_settled(first_serve, reconcile_done):
         row = {"t": int(time.time()), "pid": os.getpid(), "bootSettled": True,
                "firstServe": round(first_serve, 2), "reconcileDone": round(reconcile_done, 2),
                "settleS": round(reconcile_done - first_serve, 2)}
+        row.update(_kernel_process_sample())   # T304: the just-born kernel's size, the series' other bookend
         if prev_cut and isinstance(prev_cut.get("t"), int) and first_serve >= prev_cut["t"]:
             row["prevCutT"] = prev_cut["t"]
             row["outageS"] = round(first_serve - prev_cut["t"], 2)
@@ -51237,6 +51287,24 @@ class Handler(BaseHTTPRequestHandler):
                     sys.stderr.write("api-health: tmux coverage count failed: %s\n" % e)
                     out["coverage"]["tmuxSessionsUncovered"] = None
                 return self._send(200, json.dumps(out), "application/json", cache="no-cache")
+            if p == "/session-events":
+                # T304: the session-event ledger for the dashboard's "sessions gone wrong" cue and `romp
+                # restart-metrics` (_session_event_rows): ?since=<epoch s> (default this kernel's boot),
+                # ?limit=<n> (default 200, at most 1000). AUTHED like /api-health, by the plain _authorize:
+                # session names ride it. `count` is this kernel's alone, never a cross-kernel sum (a federated
+                # shell keeps per-host maps; every row names its host for that merge).
+                try:
+                    since = float((q.get("since") or [""])[0] or _STARTED)
+                except ValueError:
+                    since = float(_STARTED)
+                try:
+                    limit = max(1, min(1000, int((q.get("limit") or [""])[0] or 200)))
+                except ValueError:
+                    limit = 200
+                rows, count = _session_event_rows(since, limit)
+                return self._send(200, json.dumps({"host": _self_host(), "bootId": _BOOT_ID, "bootAt": int(_STARTED),
+                                                   "count": count, "since": since, "rows": rows}),
+                                  "application/json", cache="no-cache")
             if p == "/mcp":                                   # the MCP panel's data (the user 2026-08-05): `/mcp`
                 # in a romp session hits the CLI's INTERACTIVE panel, which an SDK session can't render — it
                 # just says "use a terminal". These are the SAME facts via the SDK's designed control request

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1533,18 +1533,24 @@ LEDGER_ROTATE_BYTES = 32 * 1024 * 1024   # a ledger past this size is rotated to
 #                                          thousand turns a day, turns.jsonl holds about a month; the reader reads both
 
 
+_LEDGER_LOCK = threading.Lock()   # one appender at a time across the ledgers: two threads crossing the
+#                                    rotation size together would rotate twice, moving a one-row file over the
+#                                    predecessor just made and losing its month of rows (review find, 2026-09-10)
+
+
 def _append_ledger_row(state_dir: Path, name: str, row: dict) -> None:
     try:
         p = Path(state_dir) / name
         p.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            if p.stat().st_size >= LEDGER_ROTATE_BYTES:
-                os.replace(p, p.with_name(p.name + ".1"))   # the older predecessor, if any, is dropped
-        except FileNotFoundError:
-            pass
-        with open(p, "a", encoding="utf-8") as f:
-            f.write(json.dumps(row) + "\n")
-            f.flush()
+        with _LEDGER_LOCK:
+            try:
+                if p.stat().st_size >= LEDGER_ROTATE_BYTES:
+                    os.replace(p, p.with_name(p.name + ".1"))   # the older predecessor, if any, is dropped
+            except FileNotFoundError:
+                pass
+            with open(p, "a", encoding="utf-8") as f:
+                f.write(json.dumps(row) + "\n")
+                f.flush()
     except Exception:
         pass
 
@@ -4378,6 +4384,9 @@ class SdkSession:
         #                                instructions payload (parent_tool_use_id link) as a skillMd atom
         self.since = 0
         self._first_out_t = None   # the turn's first streamed WORK atom (turns.jsonl firstOutT; reset per fresh feed)
+        self._fed_t = None         # the fresh feed's pop at millisecond resolution (turns.jsonl fedT; `since` stays whole
+        #                            seconds for its other readers); both are spent at the settle, so a turn the CLI
+        #                            opens by itself never inherits the previous fed turn's stamps
         self.model = reg.get("liveModel") or ""   # seed from the last-known model so the badge/picker show on
         #                                           OPEN (even once eager-connected, before init/a turn reports)
         self._model_id = reg.get("liveModelId") or ""   # the RAW id behind that name (claude-fable-5-1), the
@@ -5521,6 +5530,7 @@ class SdkSession:
                     self._interrupted = False        # a fresh turn → clear any stale interrupt flag
                     self._intr_level = 0             #   ...and its escalation episode (a new stop starts polite)
                     self._first_out_t = None         # the turn's first output is still to come (turns.jsonl)
+                    self._fed_t = time.time()        # the pop, at millisecond resolution (turns.jsonl fedT)
                 self._note_turn_opener(fed_text_opener(item), fresh)   # who this turn is for (the Stop hook stamps it)
                 if item.startswith(RENAME_PING_HEAD):
                     self._ping_feeding = True       # hold feeds until this turn's first streamed message
@@ -5891,13 +5901,21 @@ class SdkSession:
         now = time.time() if now is None else float(now)
         fed = [x for x in (getattr(self, "_inflight_texts", None) or []) if isinstance(x, str)]
         row = {"t": int(now), "sid": str(self.sid), "name": str(getattr(self, "name", "") or ""),
-               "fedT": int(getattr(self, "since", 0) or 0), "resultT": round(now, 3),
+               "resultT": round(now, 3),
                "opener": str(getattr(self, "_turn_opener", None) or ""),
                "resumeNotice": any(x.startswith((BOOT_RESUME_NUDGE, CRASH_RESUME_NUDGE)) for x in fed),
                "fedTexts": len(fed)}
-        fo = getattr(self, "_first_out_t", None)
-        if isinstance(fo, (int, float)) and fo:
-            row["firstOutT"] = round(float(fo), 3)
+        # fedT and firstOutT only for a turn THIS session fed and whose pop was stamped: a turn the CLI opened
+        # by itself (a channel message, a task notification, a scheduled prompt) or a mid-turn forward run as
+        # its own turn has no feed of its own, and the stamps still in memory would be the PREVIOUS fed
+        # turn's (review find, 2026-09-10: hours of feed-to-result, a duplicated first output). Absent, never
+        # wrong; the reader measures latency only where fedT is present.
+        ft = getattr(self, "_fed_t", None)
+        if fed and isinstance(ft, (int, float)) and ft:
+            row["fedT"] = round(float(ft), 3)
+            fo = getattr(self, "_first_out_t", None)
+            if isinstance(fo, (int, float)) and fo >= ft:
+                row["firstOutT"] = round(float(fo), 3)
         for attr, key in (("duration_ms", "durationMs"), ("duration_api_ms", "apiMs"), ("num_turns", "numTurns")):
             v = getattr(msg, attr, None)
             if isinstance(v, (int, float)) and not isinstance(v, bool):
@@ -6463,6 +6481,7 @@ class SdkSession:
         elif isinstance(msg, ResultMessage) and self._consume_move_settle(msg):
             pass   # the accepted move's turn-less result — nothing ended, so nothing settles (see the def)
         elif isinstance(msg, ResultMessage):
+            delta = turn_u = None            # the spend fold's figures for the turn ledger row (set when the fold ran)
             try:
                 # (This try is the whole branch: its body is the result's BOOKKEEPING, its finally is
                 # THE SETTLE — the finally's comment has the rule. The spend accounting runs LAST in the
@@ -6511,7 +6530,6 @@ class SdkSession:
                 # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
                 # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
                 # (The scheduled refreshes above cannot run before this synchronous step: nothing yields.)
-                delta = turn_u = None            # (read by the turn ledger row below; set when the fold ran)
                 total = getattr(msg, "total_cost_usd", None)
                 if isinstance(total, (int, float)) and total > 0:
                     delta = total - self._last_cost_total if total >= self._last_cost_total else total
@@ -6540,14 +6558,18 @@ class SdkSession:
                                           "would be wrong only if a CLI that restores cost history read a different "
                                           "transcript than the connect-time seed (last_cost_state)."
                                           % (self.name, delta, SANE_TURN_USD, total), problem=False)
+            finally:
                 # T304: one durable row per settled turn (turns.jsonl, see the ledger note by
-                # append_turn_row) — the event stamps the restart monitors read. Guarded on its own and
-                # LAST: a failing append costs the row, never the settle below or the spend fold above.
+                # append_turn_row) — the event stamps the restart monitors read. In the finally, ahead of
+                # the settle, so a bookkeeping exception (a spend-fold fault: exactly the anomalous turn)
+                # still leaves its row (review find, 2026-09-10); guarded on its own, so a failing append
+                # costs the row alone and never the settle below.
                 try:
                     append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, delta, turn_u))
                 except Exception as e:
                     self.backend._log("turn ledger (%s): %s" % (self.name, e), problem=False)
-            finally:
+                self._fed_t = None               # the turn's feed stamps are spent (see _turn_ledger_row)
+                self._first_out_t = None
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the
                 # bookkeeping above did (the rewind flags, the live-tail sweep, the refreshes, the spend
                 # accounting last: any step may raise and stop the rest). The rule

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4384,6 +4384,8 @@ class SdkSession:
         #                                instructions payload (parent_tool_use_id link) as a skillMd atom
         self.since = 0
         self._first_out_t = None   # the turn's first streamed WORK atom (turns.jsonl firstOutT; reset per fresh feed)
+        self._turn_spend = None    # (delta usd, turn usage) the spend fold recorded for the turn in flight, read by the
+        #                            turn ledger row at the settle and spent with it
         self._fed_t = None         # the fresh feed's pop at millisecond resolution (turns.jsonl fedT; `since` stays whole
         #                            seconds for its other readers); both are spent at the settle, so a turn the CLI
         #                            opens by itself never inherits the previous fed turn's stamps
@@ -6481,7 +6483,6 @@ class SdkSession:
         elif isinstance(msg, ResultMessage) and self._consume_move_settle(msg):
             pass   # the accepted move's turn-less result — nothing ended, so nothing settles (see the def)
         elif isinstance(msg, ResultMessage):
-            delta = turn_u = None            # the spend fold's figures for the turn ledger row (set when the fold ran)
             try:
                 # (This try is the whole branch: its body is the result's BOOKKEEPING, its finally is
                 # THE SETTLE — the finally's comment has the rule. The spend accounting runs LAST in the
@@ -6539,6 +6540,7 @@ class SdkSession:
                     # the tokens: THIS turn's counts, from whichever result counter is a running total —
                     # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
                     turn_u = self._turn_usage(msg)
+                    self._turn_spend = (delta, turn_u)   # for the turn ledger row the finally writes (T304)
                     self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
                                                sid=self.thread_of or self.sid)   # the rail's spend —
                     #   a comment THREAD bills its owning session (T144: whole-session truth for the
@@ -6565,9 +6567,11 @@ class SdkSession:
                 # still leaves its row (review find, 2026-09-10); guarded on its own, so a failing append
                 # costs the row alone and never the settle below.
                 try:
-                    append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, delta, turn_u))
+                    _sp = getattr(self, "_turn_spend", None) or (None, None)   # the fold's figures, when it ran
+                    append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, _sp[0], _sp[1]))
                 except Exception as e:
                     self.backend._log("turn ledger (%s): %s" % (self.name, e), problem=False)
+                self._turn_spend = None          # spent with the row, like the feed stamps below
                 self._fed_t = None               # the turn's feed stamps are spent (see _turn_ledger_row)
                 self._first_out_t = None
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1528,12 +1528,20 @@ def append_resume_fork(state_dir: Path, sid: str, from_fsid: str, to_fsid: str, 
 SESSION_EVENTS_FILE = "session-events.jsonl"
 TURNS_FILE = "turns.jsonl"
 PROBLEM_ROW_MARK = " ;; problem-row "
+LEDGER_ROTATE_BYTES = 32 * 1024 * 1024   # a ledger past this size is rotated to <name>.1 (one predecessor kept),
+#                                          so the pair is bounded at twice this: at ~300 bytes a turn and a few
+#                                          thousand turns a day, turns.jsonl holds about a month; the reader reads both
 
 
 def _append_ledger_row(state_dir: Path, name: str, row: dict) -> None:
     try:
         p = Path(state_dir) / name
         p.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            if p.stat().st_size >= LEDGER_ROTATE_BYTES:
+                os.replace(p, p.with_name(p.name + ".1"))   # the older predecessor, if any, is dropped
+        except FileNotFoundError:
+            pass
         with open(p, "a", encoding="utf-8") as f:
             f.write(json.dumps(row) + "\n")
             f.flush()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -8523,11 +8523,14 @@ class SdkBackend:
                           "process trees, stopped %d leftover session scope(s)"
                           % (resumed, restored, notified, reaped, scopes_stopped))
                 self._poke()
-            # T304: the sweep's summary row, EVERY boot (a boot that recovered nothing is the baseline the
-            # restart monitors compare against); `resumed` is the count of continuation notices queued
-            append_session_event(self.state_dir, "reconcile.boot", sessions=len(alive), resumed=resumed,
-                                 restored=restored, notified=notified, reaped=reaped, scopesStopped=scopes_stopped,
-                                 toStart=len(to_start), durationS=round(time.time() - t_boot0, 3))
+            # T304: the sweep's summary row, every boot that had a session to reconcile (a boot that
+            # recovered nothing is the baseline the restart monitors compare against; a boot with no
+            # sessions at all measures nothing and writes nothing, so a read-only route's lazy backend
+            # build leaves the state directory untouched); `resumed` counts the continuation notices queued
+            if alive:
+                append_session_event(self.state_dir, "reconcile.boot", sessions=len(alive), resumed=resumed,
+                                     restored=restored, notified=notified, reaped=reaped, scopesStopped=scopes_stopped,
+                                     toStart=len(to_start), durationS=round(time.time() - t_boot0, 3))
             # STAGGERED spawn (see BOOT_RESUME_CONCURRENCY): every reg above is already fixed —
             # queues persisted, heals applied — so even a death mid-stagger loses nothing (the next
             # boot's sweep picks the rest up). Spawns hold a slot on the backend-wide _spawn_sem —

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1505,6 +1505,97 @@ def append_resume_fork(state_dir: Path, sid: str, from_fsid: str, to_fsid: str, 
         f.write(json.dumps(rec) + "\n")
 
 
+# ── The session-event ledger and the per-turn ledger (T304 stage 0 of the restart-surviving sessions
+# program, 2026-09-10; the row shape agreed with the lease work, T305, which writes its `lease.*` kinds
+# through the same helper). Two append-only files under the state directory, read by `romp restart-metrics`
+# (cli/restart_metrics.py), which reads FILES and the kernel's routes only, never the kernel log:
+#   session-events.jsonl  one row per thing that went wrong with a session's process, or per boot sweep:
+#                         {"t": epoch s (int), "pid": the writing kernel, "kind": "<writer>.<what>",
+#                          "sid": romp sid when about a session, "name": its name then, ...flat fields}.
+#                         Kinds this file writes: reconcile.boot (the sweep's summary, every boot, ledger only),
+#                         reconcile.orphan-reaped, reconcile.scope-stopped, reconcile.duplicate-cli, crash.heal,
+#                         crash.loop, drain.unjoined. Every kind that IS a problem also lands on the backend's
+#                         problem ring (the dashboard's bell and error center) as its prose, and on the kernel
+#                         log as `<prose> ;; problem-row {json}` so a log reader parses the same object with
+#                         `line.rsplit(PROBLEM_ROW_MARK, 1)[1]`.
+#   turns.jsonl           one row per settled turn (SdkSession._turn_ledger_row): the event stamps the latency
+#                         and redo-cost figures read. Every stamp is an EVENT's time: fedT is the feed pop
+#                         (the turn left the queue for the CLI's stdin), firstOutT the first streamed work atom,
+#                         resultT the ResultMessage; durationMs / apiMs are the CLI's own figures on that
+#                         result; usd and the token columns are what the spend fold recorded for the turn;
+#                         resumeNotice marks a turn whose fed text was a boot or crash continuation notice.
+# Both writers are best-effort and never raise: a ledger must not be able to break the thing it measures.
+SESSION_EVENTS_FILE = "session-events.jsonl"
+TURNS_FILE = "turns.jsonl"
+PROBLEM_ROW_MARK = " ;; problem-row "
+
+
+def _append_ledger_row(state_dir: Path, name: str, row: dict) -> None:
+    try:
+        p = Path(state_dir) / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "a", encoding="utf-8") as f:
+            f.write(json.dumps(row) + "\n")
+            f.flush()
+    except Exception:
+        pass
+
+
+def append_session_event(state_dir: Path, kind: str, *, sid=None, name=None, t=None, **fields) -> dict:
+    """One session-events.jsonl row (see the ledger note above). Fields are FLAT by contract: a scalar rides
+    as is, None is dropped, anything else is its str. Returns the row written (pid and t filled in)."""
+    row = {"t": int(time.time() if t is None else t), "pid": os.getpid(), "kind": str(kind)}
+    if sid:
+        row["sid"] = str(sid)
+    if name:
+        row["name"] = str(name)
+    for k, v in fields.items():
+        if v is None:
+            continue
+        row[k] = v if isinstance(v, (str, int, float, bool)) else str(v)
+    _append_ledger_row(state_dir, SESSION_EVENTS_FILE, row)
+    return row
+
+
+def problem_row(state_dir: Path, prose: str, kind: str, *, sid=None, name=None, log=None, ring=True,
+                **fields) -> str:
+    """A session problem said three ways at once: the ledger row (append_session_event, `text` = the
+    prose), the kernel-log line `<prose> ;; problem-row {json}` (returned; written when `log` is given), and
+    the prose alone on the problem ring when `ring` (SdkBackend._log's ring_text, so the error center stays
+    readable while the log line stays parseable). `log` is the backend's _log; a plainer callable gets the
+    line alone."""
+    row = append_session_event(state_dir, kind, sid=sid, name=name, text=str(prose), **fields)
+    line = str(prose) + PROBLEM_ROW_MARK + json.dumps(row)
+    if log is not None:
+        try:
+            log(line, problem=bool(ring), ring_text=str(prose))
+        except TypeError:
+            try:
+                log(line)
+            except Exception:
+                pass
+        except Exception:
+            pass
+    return line
+
+
+def parse_problem_row(line: str) -> "dict | None":
+    """The JSON object a `;; problem-row` log line carries, or None for any other line."""
+    if PROBLEM_ROW_MARK not in str(line):
+        return None
+    try:
+        obj = json.loads(str(line).rsplit(PROBLEM_ROW_MARK, 1)[1])
+    except Exception:
+        return None
+    return obj if isinstance(obj, dict) else None
+
+
+def append_turn_row(state_dir: Path, row: dict) -> None:
+    """One turns.jsonl row (SdkSession._turn_ledger_row builds it). Best-effort, never raises."""
+    if isinstance(row, dict) and row:
+        _append_ledger_row(state_dir, TURNS_FILE, row)
+
+
 def append_awaiting(state_dir: Path, sid: str, awaiting: bool, why: str = "") -> None:
     """Append an "awaiting" OVERLAY record to states/<sid>.jsonl (interleaved with the state
     records; the kernel reader scans for the latest line carrying an "awaiting" key). "Awaiting" =
@@ -3235,6 +3326,37 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str], own_pid: int) -> 
     return out
 
 
+def cli_sid_of(cmd: str, sids) -> "str | None":
+    """The one of `sids` this CLI's argv names (_cli_carries_sid's match, returning the id), or None."""
+    for s in sids:
+        if not s:
+            continue
+        for flag in ("--resume", "--session-id"):
+            if (flag + " " + s) in cmd or (flag + "=" + s) in cmd:
+                return s
+    return None
+
+
+def duplicate_clis(ps_lines: list[str], lastsids: list[str]) -> dict[str, list[int]]:
+    """Conversation ids that MORE THAN ONE SDK-driven CLI in a PS_ARGV listing is holding, id -> pids in
+    listing order (T304: two writers for one transcript is the failure the boot reap exists to prevent, and
+    until now nothing recorded when it was found). Same match as find_orphan_clis (the stream-json mark plus
+    a --resume/--session-id spelling), whatever the parents are: an orphan beside this kernel's live child
+    counts, and so do two orphans. Pure."""
+    seen: dict[str, list[int]] = {}
+    for ln in ps_lines:
+        parts = ln.strip().split(None, 2)
+        if len(parts) < 3 or not parts[0].isdigit():
+            continue
+        cmd = parts[2]
+        if _SDK_CLI_MARK not in cmd:
+            continue
+        s = cli_sid_of(cmd, lastsids)
+        if s:
+            seen.setdefault(s, []).append(int(parts[0]))
+    return {s: pids for s, pids in seen.items() if len(pids) > 1}
+
+
 # ENDING A CUT TURN'S WHOLE TREE (T276, the user 2026-09-08). Reaping the orphaned CLI alone left its Bash
 # tool's processes alive: a stress harness's 32 busy loops and a benchmark's 11 (setsid'd from tool shells,
 # re-parented to the user manager once the shells died) burned cores for over an hour after restarts.
@@ -4247,6 +4369,7 @@ class SdkSession:
         self._skill_tool_ids = set()   # Skill tool_use ids seen on THIS stream → classify their injected
         #                                instructions payload (parent_tool_use_id link) as a skillMd atom
         self.since = 0
+        self._first_out_t = None   # the turn's first streamed WORK atom (turns.jsonl firstOutT; reset per fresh feed)
         self.model = reg.get("liveModel") or ""   # seed from the last-known model so the badge/picker show on
         #                                           OPEN (even once eager-connected, before init/a turn reports)
         self._model_id = reg.get("liveModelId") or ""   # the RAW id behind that name (claude-fable-5-1), the
@@ -5389,6 +5512,7 @@ class SdkSession:
                     self.since = int(time.time())    # a new turn starts now (mid-turn forwards keep the turn's clock)
                     self._interrupted = False        # a fresh turn → clear any stale interrupt flag
                     self._intr_level = 0             #   ...and its escalation episode (a new stop starts polite)
+                    self._first_out_t = None         # the turn's first output is still to come (turns.jsonl)
                 self._note_turn_opener(fed_text_opener(item), fresh)   # who this turn is for (the Stop hook stamps it)
                 if item.startswith(RENAME_PING_HEAD):
                     self._ping_feeding = True       # hold feeds until this turn's first streamed message
@@ -5747,6 +5871,41 @@ class SdkSession:
         turn it is closing."""
         if fresh or opener == "human":
             self._turn_opener = opener
+
+    def _turn_ledger_row(self, msg, usd=None, turn_u=None, now=None) -> dict:
+        """The turns.jsonl row for the ResultMessage `msg` (see the ledger note by append_turn_row): the
+        turn's event stamps (fedT = since, the feed pop; firstOutT = the first streamed work atom; resultT =
+        now), the CLI's own duration_ms / duration_api_ms / num_turns / is_error when the result carries
+        them, the spend fold's usd and token counts when it ran (`usd`, `turn_u` as _turn_usage returns
+        it), who opened the turn, and resumeNotice: whether any text fed into this turn was the boot or the
+        crash continuation notice — the turn that REDOES cut work, the redo-cost marker. Pure over its
+        inputs; getattr throughout so a __new__-built test double works."""
+        now = time.time() if now is None else float(now)
+        fed = [x for x in (getattr(self, "_inflight_texts", None) or []) if isinstance(x, str)]
+        row = {"t": int(now), "sid": str(self.sid), "name": str(getattr(self, "name", "") or ""),
+               "fedT": int(getattr(self, "since", 0) or 0), "resultT": round(now, 3),
+               "opener": str(getattr(self, "_turn_opener", None) or ""),
+               "resumeNotice": any(x.startswith((BOOT_RESUME_NUDGE, CRASH_RESUME_NUDGE)) for x in fed),
+               "fedTexts": len(fed)}
+        fo = getattr(self, "_first_out_t", None)
+        if isinstance(fo, (int, float)) and fo:
+            row["firstOutT"] = round(float(fo), 3)
+        for attr, key in (("duration_ms", "durationMs"), ("duration_api_ms", "apiMs"), ("num_turns", "numTurns")):
+            v = getattr(msg, attr, None)
+            if isinstance(v, (int, float)) and not isinstance(v, bool):
+                row[key] = int(v)
+        ie = getattr(msg, "is_error", None)
+        if isinstance(ie, bool):
+            row["isError"] = ie
+        if isinstance(usd, (int, float)) and not isinstance(usd, bool):
+            row["usd"] = round(float(usd), 6)
+        if isinstance(turn_u, dict):
+            for k, kk in (("input_tokens", "tokIn"), ("output_tokens", "tokOut"),
+                          ("cache_read_input_tokens", "tokCacheR"), ("cache_creation_input_tokens", "tokCacheW")):
+                v = turn_u.get(k)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    row[kk] = int(v)
+        return row
 
     def _mark(self, state: str) -> None:
         """Persist a lifecycle STATE to states/<sid>.jsonl AND track whether the CLI is producing.
@@ -6344,6 +6503,7 @@ class SdkSession:
                 # session-so-far cost and the spend readout compounds into fiction (the user 2026-08-08). A
                 # total below the last seen means a counter we didn't watch reset — fold it whole, never negative.
                 # (The scheduled refreshes above cannot run before this synchronous step: nothing yields.)
+                delta = turn_u = None            # (read by the turn ledger row below; set when the fold ran)
                 total = getattr(msg, "total_cost_usd", None)
                 if isinstance(total, (int, float)) and total > 0:
                     delta = total - self._last_cost_total if total >= self._last_cost_total else total
@@ -6372,6 +6532,13 @@ class SdkSession:
                                           "would be wrong only if a CLI that restores cost history read a different "
                                           "transcript than the connect-time seed (last_cost_state)."
                                           % (self.name, delta, SANE_TURN_USD, total), problem=False)
+                # T304: one durable row per settled turn (turns.jsonl, see the ledger note by
+                # append_turn_row) — the event stamps the restart monitors read. Guarded on its own and
+                # LAST: a failing append costs the row, never the settle below or the spend fold above.
+                try:
+                    append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, delta, turn_u))
+                except Exception as e:
+                    self.backend._log("turn ledger (%s): %s" % (self.name, e), problem=False)
             finally:
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the
                 # bookkeeping above did (the rewind flags, the live-tail sweep, the refreshes, the spend
@@ -8163,6 +8330,12 @@ class SdkBackend:
             try:
                 run(["systemctl", "--user", "stop", unit], capture_output=True, text=True, timeout=SCOPE_STOP_TIMEOUT)
                 stopped += 1
+                m = _SESSION_SCOPE_RE.match(unit)
+                problem_row(self.state_dir,
+                            "boot: stopped the leftover session scope %s (its CLI was gone; processes it left "
+                            "behind were still running)" % unit,
+                            "reconcile.scope-stopped", log=self._log, unit=unit,
+                            sid8=(m.group(1).lower() if m else ""), cliPid=sp)
             except Exception as e:
                 self._log("cut-turn reap: stopping leftover %s failed: %s" % (unit, e))
         return stopped
@@ -8191,21 +8364,49 @@ class SdkBackend:
                     self._log("boot reconcile: cwdPending heal for %s failed: %s"
                               % (r.get("sid"), traceback.format_exc()))
         try:
+            t_boot0 = time.time()
             alive = [r for r in regs if r.get("alive") and r.get("sid")]
             reaped = 0
             scopes_stopped = 0
             lastsids = [str(r.get("lastSid") or "") for r in alive if r.get("lastSid")]
+            by_fsid = {str(r.get("lastSid")): r for r in alive if r.get("lastSid")}   # conversation id -> its reg
             if lastsids:
                 try:
                     ps = subprocess.run(PS_ARGV, capture_output=True, text=True, timeout=10).stdout
                     ps_lines = ps.splitlines()
+                    cmd_of: dict[int, str] = {}
+                    for ln in ps_lines:
+                        parts = ln.strip().split(None, 2)
+                        if len(parts) == 3 and parts[0].isdigit():
+                            cmd_of[int(parts[0])] = parts[2]
+                    # T304: two CLIs holding ONE conversation, as the listing stands before the reap — the
+                    # two-writers hazard itself, recorded even though the reap below usually resolves it
+                    for fsid, pids in duplicate_clis(ps_lines, lastsids).items():
+                        r0 = by_fsid.get(fsid) or {}
+                        problem_row(self.state_dir,
+                                    "boot: %d claude processes were holding session %s's conversation at once "
+                                    "(pids %s); the orphans are being ended" % (len(pids), r0.get("name") or fsid[:8],
+                                                                                 ", ".join(str(p) for p in pids)),
+                                    "reconcile.duplicate-cli", log=self._log, sid=r0.get("sid"), name=r0.get("name"),
+                                    fsid=fsid, pids=",".join(str(p) for p in pids), n=len(pids))
                     for pid in find_orphan_clis(ps_lines, lastsids, os.getpid()):
                         if pid == os.getpid():
                             continue
                         # the CLI AND its tree (T276): its scope unit, then every process still under it
                         try:
-                            self._end_cli_tree(pid, ps_lines)
+                            res = self._end_cli_tree(pid, ps_lines)
                             reaped += 1
+                            fsid = cli_sid_of(cmd_of.get(pid, ""), lastsids) or ""
+                            r0 = by_fsid.get(fsid) or {}
+                            res = res if isinstance(res, dict) else {}
+                            problem_row(self.state_dir,
+                                        "boot: ended an orphaned claude process (pid %d) still holding session %s's "
+                                        "conversation from before the restart%s" % (
+                                            pid, r0.get("name") or fsid[:8] or "?",
+                                            ", with its scope %s" % res["scope"] if res.get("scope") else ""),
+                                        "reconcile.orphan-reaped", log=self._log, sid=r0.get("sid"), name=r0.get("name"),
+                                        cliPid=pid, fsid=fsid, scope=res.get("scope") or "",
+                                        signaled=res.get("signaled"), forced=res.get("forced"), tree=res.get("tree"))
                         except (ProcessLookupError, PermissionError):
                             pass
                     # …and the scopes whose CLI already died but whose children live on
@@ -8314,6 +8515,11 @@ class SdkBackend:
                           "process trees, stopped %d leftover session scope(s)"
                           % (resumed, restored, notified, reaped, scopes_stopped))
                 self._poke()
+            # T304: the sweep's summary row, EVERY boot (a boot that recovered nothing is the baseline the
+            # restart monitors compare against); `resumed` is the count of continuation notices queued
+            append_session_event(self.state_dir, "reconcile.boot", sessions=len(alive), resumed=resumed,
+                                 restored=restored, notified=notified, reaped=reaped, scopesStopped=scopes_stopped,
+                                 toStart=len(to_start), durationS=round(time.time() - t_boot0, 3))
             # STAGGERED spawn (see BOOT_RESUME_CONCURRENCY): every reg above is already fixed —
             # queues persisted, heals applied — so even a death mid-stagger loses nothing (the next
             # boot's sweep picks the rest up). Spawns hold a slot on the backend-wide _spawn_sem —
@@ -8560,6 +8766,7 @@ class SdkBackend:
                 s.thread.join(max(0.05, deadline - time.time()))
         unjoined = [s for s in sessions if s.thread is not None and s.thread.is_alive()]
         reaped = []
+        reaped_sids = set()
         for s in unjoined:
             try:
                 pid = self._session_cli_pid(s)
@@ -8575,10 +8782,15 @@ class SdkBackend:
                 else:
                     kill(pid, signal.SIGKILL)            # a wedged CLI still never outlives us
                 reaped.append("%s(pid %d)" % (s.name, pid))
+                reaped_sids.add(s.sid)
             except ProcessLookupError:
                 pass                                     # exited between the join and the reap — fine
             except Exception:
                 self._log("drain: reap failed for %s: %s" % (s.name, traceback.format_exc()))
+        for s in unjoined:   # T304: the sessions the bound left closing, one ledger row each (the cut row's
+            #                 `unjoined` is the count alone); the process is exiting, so the ring is not asked
+            append_session_event(self.state_dir, "drain.unjoined", sid=s.sid, name=s.name,
+                                 inflight=int(bool(getattr(s, "inflight", 0))), reaped=(s.sid in reaped_sids))
         if sessions:
             names = [s.name for s in unjoined]
             self._log("drain: stopped %d session(s), %d in-flight turn(s) interrupted%s%s"
@@ -9258,7 +9470,7 @@ class SdkBackend:
     # ---- logging / wakeups ----
     PROBLEM_RING = 100        # how many backend problems are kept for the dashboard (oldest dropped)
 
-    def _log(self, m, problem=None, key=None):
+    def _log(self, m, problem=None, key=None, ring_text=None):
         """Every backend line goes to the kernel log; the ones that report a FAILURE also land in a ring
         the dashboard's error center reads, so an SDK problem shows up where the user is looking instead
         of only in a file nobody tails (the user 2026-07-28, who could tell exceptions were happening and
@@ -9277,6 +9489,9 @@ class SdkBackend:
         key whose entry the ring has since dropped enters again as new."""
         if problem is None:
             problem = sys.exc_info()[0] is not None
+        # ring_text (T304): the ring's readable text when the LOG line carries more than prose — a
+        # `;; problem-row {json}` tail (problem_row) belongs in the log a reader parses, not in the bell
+        rt = str(m if ring_text is None else ring_text)
         if problem:
             with self._problem_lock:
                 hit = None
@@ -9293,9 +9508,9 @@ class SdkBackend:
                         hit.get("first", hit["text"]), reps, "" if reps == 1 else "s")
                 else:
                     self._problem_seq += 1
-                    row = {"seq": self._problem_seq, "t": time.time(), "text": str(m)}
+                    row = {"seq": self._problem_seq, "t": time.time(), "text": rt}
                     if key is not None:
-                        row.update(key=key, first=str(m), count=1)
+                        row.update(key=key, first=rt, count=1)
                     self._problems.append(row)
                     if len(self._problems) > self.PROBLEM_RING:
                         del self._problems[:-self.PROBLEM_RING]
@@ -12034,6 +12249,9 @@ class SdkBackend:
         # queued in the CLI that started streaming after the previous turn's Result). Only on the
         # transition, so it never spams the log. This is what makes the signal self-heal without a count.
         if not atom.get("_echo_text") and not atom.get("command") and not atom.get("isApiError") \
+                and getattr(sess, "_first_out_t", None) is None and getattr(sess, "inflight", 0):
+            sess._first_out_t = time.time()   # the turn's FIRST streamed work atom — turns.jsonl's firstOutT (T304)
+        if not atom.get("_echo_text") and not atom.get("command") and not atom.get("isApiError") \
                 and not sess._cli_working:
             sess._mark("working")   # (an isApiError settle is the turn DYING, not producing — never 'working')
         self._wake_push()
@@ -12496,11 +12714,14 @@ class SdkBackend:
             attempts = self._heal_attempts.get(sid, 0)
             self._heal_attempts[sid] = attempts + 1
         if attempts >= 1:
-            self._log("session %s: claude process died mid-turn AGAIN before completing a turn — "
-                      "crash loop; NOT resuming again, turn left cut for the next kernel restart"
-                      % sess.name)
+            problem_row(self.state_dir,
+                        "session %s: claude process died mid-turn AGAIN before completing a turn — "
+                        "crash loop; NOT resuming again, turn left cut for the next kernel restart" % sess.name,
+                        "crash.loop", log=self._log, sid=sid, name=sess.name, attempt=attempts + 1)
             return
-        self._log("session %s: claude process died mid-turn — resuming with history intact" % sess.name)
+        problem_row(self.state_dir,
+                    "session %s: claude process died mid-turn — resuming with history intact" % sess.name,
+                    "crash.heal", log=self._log, sid=sid, name=sess.name, attempt=attempts + 1)
         try:
             with self._reg_lock:
                 reg = read_reg(self.state_dir, sid) or {"sid": sid}

--- a/scripts/restart_metrics_report.py
+++ b/scripts/restart_metrics_report.py
@@ -195,8 +195,8 @@ def fig_restart_timing(cp, fr, out):
     pal = _palette(cp, fr["labels"])
     f, axs = cp.fig(rows=1, cols=2, w=16, h=max(3.5, 0.5 * len(rows) + 1.5))
     f.subplots_adjust(wspace=0.3)
-    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Exit to first serve (s): dot p50, line to p90 — shorter better")
-    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Reconcile settle (s): dot p50, line to p90 — shorter better")
+    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Exit to first serve (s) — shorter better\ndot p50, line to p90")
+    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Reconcile settle (s) — shorter better\ndot p50, line to p90")
     axs[1].set_yticklabels([""] * len(rows))
     return _save(f, out, "restart_timing.png")
 

--- a/scripts/restart_metrics_report.py
+++ b/scripts/restart_metrics_report.py
@@ -151,19 +151,23 @@ def fig_cut_turns(cp, fr, out):
     f, axs = cp.fig(rows=1, cols=2, w=14, h=max(3.5, 0.5 * len(rows) + 1.5))
     ax1, ax2 = axs if hasattr(axs, "__len__") else (axs, None)
     ys = list(range(len(rows)))
-    ax1.barh(ys, [r["cutTurns"] for r in rows], color=[pal[r["label"]] for r in rows], legend=False)
+    vals = [r["cutTurns"] for r in rows]
+    ax1.barh(ys, vals, color=[pal[r["label"]] for r in rows], legend=False)
     for y, r in zip(ys, rows):
-        ax1.annotate("%d of %d restarts cut a turn" % (r["restarts"] - r["cleanRestarts"], r["restarts"]),
+        ax1.annotate("%d of %d restarts cut" % (r["restarts"] - r["cleanRestarts"], r["restarts"]),
                      (r["cutTurns"], y), xytext=(4, 0), textcoords="offset points", va="center", fontsize=11)
     ax1.set_yticks(ys)
     ax1.set_yticklabels(_ylabels(rows))
     ax1.clean(xlabel="Turns cut by restarts, per window — fewer better", ylabel="")
-    ax1.set_xlim(left=0)
-    ax2.scatter([r["cutTurnsPerRestart"] or 0 for r in rows], ys, color=[pal[r["label"]] for r in rows], legend=False, s=60)
+    ax1.set_xlim(0, max(vals + [1]) * 1.6)         # room for the annotation past the longest bar
+    f.subplots_adjust(wspace=0.3)
+    per = [r["cutTurnsPerRestart"] or 0 for r in rows]
+    ax2.scatter(per, ys, color=[pal[r["label"]] for r in rows], legend=False, s=60)
     ax2.set_yticks(ys)
     ax2.set_yticklabels([""] * len(ys))
     ax2.clean(xlabel="Turns cut per restart — fewer better", ylabel="")
-    ax2.set_xlim(left=0)
+    ax2.set_xlim(0, max(per + [1]) * 1.3)           # from zero, the natural origin; no degenerate tick pair
+    ax2.set_xticks([0, round(max(per + [1]), 2)])
     return _save(f, out, "cut_turns.png")
 
 
@@ -217,10 +221,10 @@ def fig_boot_events(cp, fr, out):
         return None
     import pandas as pd
     df = pd.DataFrame({title: [r["events"][k] for r in rows] for k, title in EVENT_COLUMNS}, index=_ylabels(rows))
-    f, ax = cp.fig(w=11, h=max(4, 0.9 * len(rows) + 1.5))
+    f, ax = cp.fig(w=12, h=max(4, 0.9 * len(rows) + 1.5))
     ax.barh(df)
     ax.clean(xlabel="Sessions gone wrong, per window — fewer better", ylabel="", color_labels="auto")
-    ax.set_xlim(left=0)
+    ax.set_xlim(0, max(float(df.values.max()) if len(df.values) else 1.0, 1.0) * 1.8)   # the labels sit in the clear
     return _save(f, out, "boot_events.png")
 
 
@@ -235,7 +239,8 @@ def fig_redo_cost(cp, fr, out):
                        "Redo turns recorded": [r["redoTurns"] for r in rows]}, index=_ylabels(rows))
     axs[0].barh(df)
     axs[0].clean(xlabel="Turns resumed after a cut, per window — fewer better", ylabel="", color_labels="auto")
-    axs[0].set_xlim(left=0)
+    axs[0].set_xlim(0, max(float(df.values.max()) if len(df.values) else 1.0, 1.0) * 1.8)
+    f.subplots_adjust(wspace=0.3)
     ys = list(range(len(rows)))
     axs[1].barh(ys, [r["redoUsd"] for r in rows], color=[pal[r["label"]] for r in rows], legend=False)
     for y, r in zip(ys, rows):
@@ -257,7 +262,9 @@ def fig_turn_latency(cp, fr, out):
         return None
     pal = _palette(cp, fr["labels"])
     have_first = [(r, r["firstOutSamples"]) for r in rows if r["firstOutSamples"]]
-    f, axs = cp.fig(rows=1, cols=2 if have_first else 1, w=14 if have_first else 8, h=max(4, 0.6 * len(series) + 2))
+    f, axs = cp.fig(rows=1, cols=2 if have_first else 1, w=16 if have_first else 8, h=max(4, 0.6 * len(series) + 2))
+    if have_first:
+        f.subplots_adjust(wspace=0.35)
     ax = axs[0] if have_first else axs
     positions = list(range(len(series)))
     for pos, (r, s, ev) in zip(positions, series):
@@ -266,7 +273,7 @@ def fig_turn_latency(cp, fr, out):
                     xytext=(6, 0), textcoords="offset points", va="center", fontsize=10)
     ax.set_yticks(positions)
     ax.set_yticklabels(["%s · %s" % (r["label"], r["window"]) for r, _, _ in series])
-    ax.clean(xlabel="Turn latency, feed to result (s) — box: quartiles, whiskers to 1.5 IQR; shorter better", ylabel="")
+    ax.clean(xlabel="Feed to result (s): box quartiles, whiskers 1.5 IQR — shorter better", ylabel="")
     ax.set_xlim(left=0)
     if have_first:
         ax2 = axs[1]
@@ -274,8 +281,9 @@ def fig_turn_latency(cp, fr, out):
         for pos, (r, s) in zip(pos2, have_first):
             ax2.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
         ax2.set_yticks(pos2)
-        ax2.set_yticklabels(["%s · %s" % (r["label"], r["window"]) for r, _ in have_first])
-        ax2.clean(xlabel="Feed to first assistant output (s) — shorter better", ylabel="")
+        same_rows = [(r["label"], r["window"]) for r, _ in have_first] == [(r["label"], r["window"]) for r, _, _ in series]
+        ax2.set_yticklabels([""] * len(pos2) if same_rows else ["%s · %s" % (r["label"], r["window"]) for r, _ in have_first])
+        ax2.clean(xlabel="Feed to first output (s) — shorter better", ylabel="")
         ax2.set_xlim(left=0)
     return _save(f, out, "turn_latency.png")
 
@@ -315,7 +323,7 @@ def fig_kernel_memory(cp, fr, out):
                     color=pal[s["label"]], marker="o", linewidth=1.2)
         if boots:
             ax.scatter([p["days"] for p in boots], [p["rssMb"] for p in boots], label="%s, at boot" % s["label"],
-                       color=pal[s["label"]], marker="x", s=30, alpha=0.6)
+                       color=pal[s["label"]], marker="x", s=70, alpha=0.9)
     ax.clean(xlabel="Days since the document's first restart", ylabel="Kernel resident memory (MB) — lower better",
              color_labels="auto")
     ax.set_ylim(bottom=0)

--- a/scripts/restart_metrics_report.py
+++ b/scripts/restart_metrics_report.py
@@ -33,7 +33,19 @@ import os
 import sys
 from pathlib import Path
 
-DEFAULT_OUT = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state")) / "romp-research" / "restart-metrics"
+STATE_ROOT = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state"))
+DEFAULT_OUT = STATE_ROOT / "romp-research" / "restart-metrics"
+
+
+def anonymize_default(out) -> bool:
+    """Whether session names are hidden by default for figures written to `out`: they are, unless `out`
+    lies inside the user's own state root (their local named view). Real session names are private (other
+    projects' sessions sit among them), so nothing rendered for a repo, an issue or a pull request may carry
+    them; `--named` is the caller's explicit ask for the local view elsewhere."""
+    try:
+        return not Path(out).resolve().is_relative_to(STATE_ROOT.resolve())
+    except (OSError, ValueError):
+        return True
 EVENT_COLUMNS = (("orphansReaped", "Orphans reaped at boot"), ("scopesStopped", "Leftover scopes stopped"),
                  ("duplicateClis", "Two CLIs on one conversation"), ("crashHeals", "Crash heals"),
                  ("crashLoops", "Crash loops"), ("drainLeftClosing", "Drain left closing"),
@@ -62,8 +74,9 @@ def _st(b, *keys):
     return d if isinstance(d, dict) else {}
 
 
-def frames(docs) -> dict:
-    """Everything the figures draw, as plain lists keyed by figure: one row per (label, window)."""
+def frames(docs, anonymize=True) -> dict:
+    """Everything the figures draw, as plain lists keyed by figure: one row per (label, window). With
+    `anonymize` the live sessions are named "session 1..N" by memory rank (the kernel row keeps its name)."""
     rows = []
     for label, doc in docs:
         for b in doc.get("buckets") or []:
@@ -94,9 +107,13 @@ def frames(docs) -> dict:
             continue
         sess = [{"name": s.get("name") or s.get("sid8") or "?", "memMb": s["memBytes"] / 1048576.0,
                  "cpuS": s.get("cpuS")} for s in (lv.get("sessions") or []) if isinstance(s.get("memBytes"), (int, float))]
+        sess.sort(key=lambda s: -s["memMb"])
+        if anonymize:
+            for i, s in enumerate(sess, 1):
+                s["name"] = "session %d" % i
         k = lv.get("kernel") or {}
         pf = k.get("perf") or {}
-        live.append({"label": label, "sessions": sorted(sess, key=lambda s: -s["memMb"]),
+        live.append({"label": label, "sessions": sess,
                      "kernelRssMb": (pf["rssKb"] / 1024.0) if isinstance(pf.get("rssKb"), (int, float)) else None,
                      "kernelCpuS": pf.get("cpuS"), "kernelIdleShare": pf.get("idleShare"), "kernelPid": k.get("pid")})
     series = []
@@ -108,7 +125,7 @@ def frames(docs) -> dict:
         series.append({"label": label, "t0": t0,
                        "points": [{"days": round((k["t"] - t0) / 86400.0, 4), "rssMb": k["rssMb"], "kind": k["kind"],
                                    "cpuS": k.get("cpuS")} for k in ks]})
-    return {"windows": rows, "live": live, "labels": [l for l, _ in docs], "kernel": series}
+    return {"windows": rows, "live": live, "labels": [l for l, _ in docs], "kernel": series, "anonymized": bool(anonymize)}
 
 
 def _ylabels(rows):
@@ -158,14 +175,14 @@ def fig_cut_turns(cp, fr, out):
                      (r["cutTurns"], y), xytext=(4, 0), textcoords="offset points", va="center", fontsize=11)
     ax1.set_yticks(ys)
     ax1.set_yticklabels(_ylabels(rows))
-    ax1.clean(xlabel="Turns cut by restarts, per window — fewer better", ylabel="")
+    ax1.clean(xlabel="Turns cut by restarts, per window, fewer is better", ylabel="")
     ax1.set_xlim(0, max(vals + [1]) * 1.6)         # room for the annotation past the longest bar
     f.subplots_adjust(wspace=0.3)
     per = [r["cutTurnsPerRestart"] or 0 for r in rows]
     ax2.scatter(per, ys, color=[pal[r["label"]] for r in rows], legend=False, s=60)
     ax2.set_yticks(ys)
     ax2.set_yticklabels([""] * len(ys))
-    ax2.clean(xlabel="Turns cut per restart — fewer better", ylabel="")
+    ax2.clean(xlabel="Turns cut per restart, fewer is better", ylabel="")
     ax2.set_xlim(0, max(per + [1]) * 1.3)           # from zero, the natural origin; no degenerate tick pair
     ax2.set_xticks([0, round(max(per + [1]), 2)])
     return _save(f, out, "cut_turns.png")
@@ -195,8 +212,8 @@ def fig_restart_timing(cp, fr, out):
     pal = _palette(cp, fr["labels"])
     f, axs = cp.fig(rows=1, cols=2, w=16, h=max(3.5, 0.5 * len(rows) + 1.5))
     f.subplots_adjust(wspace=0.3)
-    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Exit to first serve (s) — shorter better\ndot p50, line to p90")
-    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Reconcile settle (s) — shorter better\ndot p50, line to p90")
+    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Exit to first serve (s), shorter is better\ndot p50, line to p90")
+    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Reconcile settle (s), shorter is better\ndot p50, line to p90")
     axs[1].set_yticklabels([""] * len(rows))
     return _save(f, out, "restart_timing.png")
 
@@ -207,7 +224,7 @@ def fig_quiet_window(cp, fr, out):
         return None
     pal = _palette(cp, fr["labels"])
     f, ax = cp.fig(w=10, h=max(3.5, 0.5 * len(rows) + 1.5))
-    _dots_with_p90(cp, ax, rows, "quietP50", "quietP90", pal, "Quiet-window wait, parked to restart (s): dot p50, line to p90 — shorter better")
+    _dots_with_p90(cp, ax, rows, "quietP50", "quietP90", pal, "Quiet-window wait, parked to restart (s): dot p50, line to p90, shorter is better")
     for y, r in enumerate(rows):
         if r["quietWindows"]:
             ax.annotate("%d windows, backstop fired %d" % (r["quietWindows"], r["backstopFires"]),
@@ -224,7 +241,7 @@ def fig_boot_events(cp, fr, out):
     df = pd.DataFrame({title: [r["events"][k] for r in rows] for k, title in EVENT_COLUMNS}, index=_ylabels(rows))
     f, ax = cp.fig(w=12, h=max(4, 0.9 * len(rows) + 1.5))
     ax.barh(df)
-    ax.clean(xlabel="Sessions gone wrong, per window — fewer better", ylabel="", color_labels="auto")
+    ax.clean(xlabel="Sessions gone wrong, per window, fewer is better", ylabel="", color_labels="auto")
     ax.set_xlim(0, max(float(df.values.max()) if len(df.values) else 1.0, 1.0) * 1.8)   # the labels sit in the clear
     return _save(f, out, "boot_events.png")
 
@@ -239,7 +256,7 @@ def fig_redo_cost(cp, fr, out):
     df = pd.DataFrame({"Continuation notices": [r["resumedTurns"] for r in rows],
                        "Redo turns recorded": [r["redoTurns"] for r in rows]}, index=_ylabels(rows))
     axs[0].barh(df)
-    axs[0].clean(xlabel="Turns resumed after a cut, per window — fewer better", ylabel="", color_labels="auto")
+    axs[0].clean(xlabel="Turns resumed after a cut, per window, fewer is better", ylabel="", color_labels="auto")
     axs[0].set_xlim(0, max(float(df.values.max()) if len(df.values) else 1.0, 1.0) * 1.8)
     f.subplots_adjust(wspace=0.3)
     ys = list(range(len(rows)))
@@ -250,7 +267,7 @@ def fig_redo_cost(cp, fr, out):
                             xytext=(4, 0), textcoords="offset points", va="center", fontsize=11)
     axs[1].set_yticks(ys)
     axs[1].set_yticklabels([""] * len(ys))
-    axs[1].clean(xlabel="Dollars spent redoing cut work, per window — fewer better", ylabel="")
+    axs[1].clean(xlabel="Dollars spent redoing cut work, per window, fewer is better", ylabel="")
     axs[1].set_xlim(left=0)
     return _save(f, out, "redo_cost.png")
 
@@ -274,7 +291,7 @@ def fig_turn_latency(cp, fr, out):
                     xytext=(6, 0), textcoords="offset points", va="center", fontsize=10)   # past the axis, clear of the whiskers
     ax.set_yticks(positions)
     ax.set_yticklabels(["%s · %s" % (r["label"], r["window"]) for r, _, _ in series])
-    ax.clean(xlabel="Feed to result (s): box quartiles, whiskers 1.5 IQR — shorter better", ylabel="")
+    ax.clean(xlabel="Feed to result (s): box quartiles, whiskers 1.5 IQR, shorter is better", ylabel="")
     ax.set_xlim(left=0)
     if have_first:
         ax2 = axs[1]
@@ -284,7 +301,7 @@ def fig_turn_latency(cp, fr, out):
         ax2.set_yticks(pos2)
         same_rows = [(r["label"], r["window"]) for r, _ in have_first] == [(r["label"], r["window"]) for r, _, _ in series]
         ax2.set_yticklabels([""] * len(pos2) if same_rows else ["%s · %s" % (r["label"], r["window"]) for r, _ in have_first])
-        ax2.clean(xlabel="Feed to first output (s) — shorter better", ylabel="")
+        ax2.clean(xlabel="Feed to first output (s), shorter is better", ylabel="")
         ax2.set_xlim(left=0)
     return _save(f, out, "turn_latency.png")
 
@@ -298,14 +315,16 @@ def fig_session_resources(cp, fr, out):
     f, axs = cp.fig(rows=1, cols=n, w=6 * n + 2, h=max(4, 0.4 * rows_max + 2))
     axs = list(axs) if hasattr(axs, "__len__") else [axs]
     pal = _palette(cp, fr["labels"])
+    kernel_color = list(cp.colors)[-1]          # the kernel's own bar in a colour no document uses, so the eye finds it
     for ax, l in zip(axs, live):
         names = [s["name"] for s in l["sessions"]] + (["kernel (pid %s)" % l["kernelPid"]] if l["kernelRssMb"] else [])
         vals = [s["memMb"] for s in l["sessions"]] + ([l["kernelRssMb"]] if l["kernelRssMb"] else [])
+        colors = [pal[l["label"]]] * len(l["sessions"]) + ([kernel_color] if l["kernelRssMb"] else [])
         ys = list(range(len(names)))[::-1]
-        ax.barh(ys, vals, color=pal[l["label"]], legend=False)
+        ax.barh(ys, vals, color=colors, legend=False)
         ax.set_yticks(ys)
         ax.set_yticklabels(names)
-        ax.clean(xlabel="Resident memory (MB) — %s%s" % (l["label"], (", kernel CPU %.0f s, pusher idle %.0f%%" % (l["kernelCpuS"], 100 * l["kernelIdleShare"])) if isinstance(l.get("kernelIdleShare"), float) and l.get("kernelCpuS") is not None else ""), ylabel="")
+        ax.clean(xlabel="Resident memory (MB), %s%s" % (l["label"], (", kernel CPU %.0f s, pusher idle %.0f%%" % (l["kernelCpuS"], 100 * l["kernelIdleShare"])) if isinstance(l.get("kernelIdleShare"), float) and l.get("kernelCpuS") is not None else ""), ylabel="")
         ax.set_xlim(left=0)
     return _save(f, out, "session_resources.png")
 
@@ -325,7 +344,7 @@ def fig_kernel_memory(cp, fr, out):
         if boots:
             ax.scatter([p["days"] for p in boots], [p["rssMb"] for p in boots], label="%s, at boot" % s["label"],
                        color=pal[s["label"]], marker="x", s=70, alpha=0.9)
-    ax.clean(xlabel="Days since the document's first restart", ylabel="Kernel resident memory (MB) — lower better",
+    ax.clean(xlabel="Days since the document's first restart", ylabel="Kernel resident memory (MB), lower is better",
              color_labels="auto")
     ax.set_ylim(bottom=0)
     ax.set_xlim(left=0)
@@ -336,11 +355,13 @@ FIGURES = (fig_cut_turns, fig_restart_timing, fig_quiet_window, fig_boot_events,
            fig_session_resources, fig_kernel_memory)
 
 
-def render(docs, out: Path) -> dict:
-    """Draw every figure; returns {figure name: path or None (no data)} and writes figures.json + summary.txt."""
+def render(docs, out: Path, anonymize=None) -> dict:
+    """Draw every figure; returns {figure name: path or None (no data)} and writes figures.json + summary.txt.
+    `anonymize` None means anonymize_default(out): names hidden everywhere but the user's own state root."""
     cp = _cp()
+    out = Path(out)
     out.mkdir(parents=True, exist_ok=True)
-    fr = frames(docs)
+    fr = frames(docs, anonymize=anonymize_default(out) if anonymize is None else bool(anonymize))
     made = {}
     for fn in FIGURES:
         made[fn.__name__.replace("fig_", "")] = fn(cp, fr, out)
@@ -360,9 +381,13 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     ap.add_argument("--doc", action="append", required=True, help="label=path of a `romp restart-metrics --json` document; repeat in order (baseline first)")
     ap.add_argument("--out", default=str(DEFAULT_OUT))
+    ap.add_argument("--named", action="store_true",
+                    help="show real session names (the default only inside your own state root; real names never go into a repo, an issue or a pull request)")
     a = ap.parse_args(argv)
     docs = load_docs(a.doc)
-    made = render(docs, Path(a.out))
+    anon = False if a.named else anonymize_default(a.out)
+    made = render(docs, Path(a.out), anonymize=anon)
+    sys.stdout.write("session names: %s\n" % ("hidden (session 1..N by memory rank; --named shows them)" if anon else "shown"))
     for k, v in made.items():
         sys.stdout.write("%-20s %s\n" % (k, v or "(no data)"))
     return 0

--- a/scripts/restart_metrics_report.py
+++ b/scripts/restart_metrics_report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""restart_metrics_report — the before-versus-after figures for the restart monitors (T304, stage 0 of the
+"""restart_metrics_report: the before-versus-after figures for the restart monitors (T304, stage 0 of the
 restart-surviving sessions program, part of #1317).
 
 Reads one or more documents `romp restart-metrics --json` wrote (a baseline snapshot and a later one, or
@@ -46,6 +46,7 @@ def anonymize_default(out) -> bool:
         return not Path(out).resolve().is_relative_to(STATE_ROOT.resolve())
     except (OSError, ValueError):
         return True
+SMALL_N = 5   # below this many turns a window's latency is drawn as its points, not a box (the small-n ruling)
 EVENT_COLUMNS = (("orphansReaped", "Orphans reaped at boot"), ("scopesStopped", "Leftover scopes stopped"),
                  ("duplicateClis", "Two CLIs on one conversation"), ("crashHeals", "Crash heals"),
                  ("crashLoops", "Crash loops"), ("drainLeftClosing", "Drain left closing"),
@@ -86,6 +87,8 @@ def frames(docs, anonymize=True) -> dict:
             rows.append({
                 "label": label, "window": b["key"], "restarts": b.get("restarts", 0), "cutTurns": b.get("cutTurns", 0),
                 "cutTurnsPerRestart": b.get("cutTurnsPerRestart"), "cleanRestarts": b.get("cleanRestarts", 0),
+                "measuredRestarts": b.get("measuredRestarts", b.get("restarts", 0) - b.get("restartsWithoutCutRow", 0)),
+                "unmeasuredRestarts": b.get("restartsWithoutCutRow", 0),
                 "outageP50": out.get("p50"), "outageP90": out.get("p90"), "outageN": out.get("n", 0),
                 "settleP50": set_.get("p50"), "settleP90": set_.get("p90"),
                 "quietWindows": b.get("quietWindows", 0), "quietP50": qw.get("p50"), "quietP90": qw.get("p90"),
@@ -171,7 +174,8 @@ def fig_cut_turns(cp, fr, out):
     vals = [r["cutTurns"] for r in rows]
     ax1.barh(ys, vals, color=[pal[r["label"]] for r in rows], legend=False)
     for y, r in zip(ys, rows):
-        ax1.annotate("%d of %d restarts cut" % (r["restarts"] - r["cleanRestarts"], r["restarts"]),
+        unm = (", %d unmeasured" % r["unmeasuredRestarts"]) if r["unmeasuredRestarts"] else ""
+        ax1.annotate("%d of %d measured restarts cut%s" % (r["measuredRestarts"] - r["cleanRestarts"], r["measuredRestarts"], unm),
                      (r["cutTurns"], y), xytext=(4, 0), textcoords="offset points", va="center", fontsize=11)
     ax1.set_yticks(ys)
     ax1.set_yticklabels(_ylabels(rows))
@@ -286,7 +290,10 @@ def fig_turn_latency(cp, fr, out):
     ax = axs[0] if have_first else axs
     positions = list(range(len(series)))
     for pos, (r, s, ev) in zip(positions, series):
-        ax.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
+        if len(s) < SMALL_N:
+            ax.scatter(s, [pos] * len(s), color=pal[r["label"]], legend=False, s=50)
+        else:
+            ax.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
         ax.annotate("n=%d%s" % (len(s), "" if ev else ", state log (1 s)"), (1.0, pos), xycoords=("axes fraction", "data"),
                     xytext=(6, 0), textcoords="offset points", va="center", fontsize=10)   # past the axis, clear of the whiskers
     ax.set_yticks(positions)
@@ -297,7 +304,10 @@ def fig_turn_latency(cp, fr, out):
         ax2 = axs[1]
         pos2 = list(range(len(have_first)))
         for pos, (r, s) in zip(pos2, have_first):
-            ax2.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
+            if len(s) < SMALL_N:
+                ax2.scatter(s, [pos] * len(s), color=pal[r["label"]], legend=False, s=50)
+            else:
+                ax2.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
         ax2.set_yticks(pos2)
         same_rows = [(r["label"], r["window"]) for r, _ in have_first] == [(r["label"], r["window"]) for r, _, _ in series]
         ax2.set_yticklabels([""] * len(pos2) if same_rows else ["%s · %s" % (r["label"], r["window"]) for r, _ in have_first])

--- a/scripts/restart_metrics_report.py
+++ b/scripts/restart_metrics_report.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""restart_metrics_report — the before-versus-after figures for the restart monitors (T304, stage 0 of the
+restart-surviving sessions program, part of #1317).
+
+Reads one or more documents `romp restart-metrics --json` wrote (a baseline snapshot and a later one, or
+any number labelled in order) and draws, with cleanplots, one figure per question into --out (default
+~/.local/state/romp-research/restart-metrics/):
+
+  cut_turns.png          turns cut per window, and per restart
+  restart_timing.png     outage to first serve, and reconcile settle, per window (p50 dot, p90 whisker end)
+  quiet_window.png       the parked deploy's wait from parked to restart per window, backstop firings noted
+  boot_events.png        orphans reaped, scopes stopped, duplicate CLIs, crash heals, drain left closing
+  redo_cost.png          continuation notices, redo turns and the dollars they cost, per window
+  turn_latency.png       feed-to-result latency distribution per window (box per window; the state-log
+                         series where turns.jsonl has none), and feed-to-first-output where recorded
+  session_resources.png  resident memory per session scope and the kernel's own, per snapshot
+  kernel_memory.png      the kernel process's resident memory at each of its exits and boots, over the days
+                         of each document (the restart rows sample it; the same axis for every document)
+
+Every axis label says what is better where that is not obvious. Bars start at zero; nothing is on a log
+scale. The numbers behind each figure also go to figures.json beside them, and summary.txt carries the
+reader's one-screen text per document, so a reader who wants the values has them without a table in prose.
+
+Run (cleanplots and matplotlib are not romp dependencies; uv fetches them):
+    uvx --with cleanplots --with matplotlib --with pandas python scripts/restart_metrics_report.py \\
+        --doc baseline=path/to/baseline.json --doc after=path/to/after.json [--out DIR]
+Data shaping (frames) is pure and importable without matplotlib; the drawing needs cleanplots and says so
+when it is missing rather than falling back to another look.
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_OUT = Path(os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local/state")) / "romp-research" / "restart-metrics"
+EVENT_COLUMNS = (("orphansReaped", "Orphans reaped at boot"), ("scopesStopped", "Leftover scopes stopped"),
+                 ("duplicateClis", "Two CLIs on one conversation"), ("crashHeals", "Crash heals"),
+                 ("crashLoops", "Crash loops"), ("drainLeftClosing", "Drain left closing"),
+                 ("leaseProblems", "Lease problems"))
+
+
+# ── data shaping (pure) ─────────────────────────────────────────────────────────────────────────────────
+def load_docs(specs) -> list[tuple[str, dict]]:
+    """[(label, doc)] from `label=path` specs (a bare path is labelled by its file stem)."""
+    out = []
+    for s in specs:
+        label, _, path = s.rpartition("=") if "=" in s else ("", "", s)
+        p = Path(path)
+        with open(p, encoding="utf-8") as f:
+            doc = json.load(f)
+        if not isinstance(doc, dict) or "buckets" not in doc:
+            raise SystemExit("%s is not a restart-metrics document (no buckets)" % p)
+        out.append((label or p.stem, doc))
+    return out
+
+
+def _st(b, *keys):
+    d = b
+    for k in keys:
+        d = (d or {}).get(k)
+    return d if isinstance(d, dict) else {}
+
+
+def frames(docs) -> dict:
+    """Everything the figures draw, as plain lists keyed by figure: one row per (label, window)."""
+    rows = []
+    for label, doc in docs:
+        for b in doc.get("buckets") or []:
+            lat, sl, out, set_, qw = (_st(b, "latency", "feedToResultS"), _st(b, "stateLogLatencyS"),
+                                      _st(b, "outageS"), _st(b, "settleS"), _st(b, "quietWaitS"))
+            first = _st(b, "latency", "feedToFirstOutS")
+            rows.append({
+                "label": label, "window": b["key"], "restarts": b.get("restarts", 0), "cutTurns": b.get("cutTurns", 0),
+                "cutTurnsPerRestart": b.get("cutTurnsPerRestart"), "cleanRestarts": b.get("cleanRestarts", 0),
+                "outageP50": out.get("p50"), "outageP90": out.get("p90"), "outageN": out.get("n", 0),
+                "settleP50": set_.get("p50"), "settleP90": set_.get("p90"),
+                "quietWindows": b.get("quietWindows", 0), "quietP50": qw.get("p50"), "quietP90": qw.get("p90"),
+                "quietMax": qw.get("max"), "backstopFires": b.get("backstopFires", 0),
+                "events": {k: b.get(k, 0) for k, _ in EVENT_COLUMNS},
+                "resumedTurns": b.get("resumedTurns", 0), "redoTurns": (b.get("redo") or {}).get("turns", 0),
+                "redoUsd": (b.get("redo") or {}).get("usd", 0.0), "spendUsd": b.get("spendUsd"),
+                "latencyN": lat.get("n", 0), "latencyP50": lat.get("p50"), "latencyP90": lat.get("p90"),
+                "firstOutN": first.get("n", 0), "firstOutP50": first.get("p50"), "firstOutP90": first.get("p90"),
+                "stateLogN": sl.get("n", 0), "stateLogP50": sl.get("p50"), "stateLogP90": sl.get("p90"),
+                "latencySamples": (b.get("samples") or {}).get("feedToResultS") or [],
+                "stateLogSamples": (b.get("samples") or {}).get("stateLogS") or [],
+                "firstOutSamples": (b.get("samples") or {}).get("feedToFirstOutS") or [],
+            })
+    live = []
+    for label, doc in docs:
+        lv = doc.get("live") or {}
+        if lv.get("skipped"):
+            continue
+        sess = [{"name": s.get("name") or s.get("sid8") or "?", "memMb": s["memBytes"] / 1048576.0,
+                 "cpuS": s.get("cpuS")} for s in (lv.get("sessions") or []) if isinstance(s.get("memBytes"), (int, float))]
+        k = lv.get("kernel") or {}
+        pf = k.get("perf") or {}
+        live.append({"label": label, "sessions": sorted(sess, key=lambda s: -s["memMb"]),
+                     "kernelRssMb": (pf["rssKb"] / 1024.0) if isinstance(pf.get("rssKb"), (int, float)) else None,
+                     "kernelCpuS": pf.get("cpuS"), "kernelIdleShare": pf.get("idleShare"), "kernelPid": k.get("pid")})
+    series = []
+    for label, doc in docs:
+        ks = [k for k in (doc.get("kernelSeries") or []) if isinstance(k.get("rssMb"), (int, float))]
+        if not ks:
+            continue
+        t0 = min(k["t"] for k in ks)
+        series.append({"label": label, "t0": t0,
+                       "points": [{"days": round((k["t"] - t0) / 86400.0, 4), "rssMb": k["rssMb"], "kind": k["kind"],
+                                   "cpuS": k.get("cpuS")} for k in ks]})
+    return {"windows": rows, "live": live, "labels": [l for l, _ in docs], "kernel": series}
+
+
+def _ylabels(rows):
+    return ["%s · %s" % (r["label"], r["window"]) for r in rows]
+
+
+# ── the figures (cleanplots) ────────────────────────────────────────────────────────────────────────────
+def _cp():
+    try:
+        import cleanplots as cp
+        import matplotlib
+        matplotlib.use("Agg")
+    except ImportError as e:
+        raise SystemExit("cleanplots and matplotlib are required for the figures (%s): run under "
+                         "`uvx --with cleanplots --with matplotlib --with pandas python …`" % e)
+    return cp
+
+
+def _palette(cp, labels):
+    cols = list(cp.colors)
+    return {l: cols[i % len(cols)] for i, l in enumerate(labels)}
+
+
+def _save(f, out: Path, name: str):
+    p = out / name
+    f.savefig(p, dpi=150, bbox_inches="tight")
+    try:
+        import matplotlib.pyplot as plt
+        plt.close(f)
+    except Exception:
+        pass
+    return str(p)
+
+
+def fig_cut_turns(cp, fr, out):
+    rows = fr["windows"]
+    if not rows:
+        return None
+    pal = _palette(cp, fr["labels"])
+    f, axs = cp.fig(rows=1, cols=2, w=14, h=max(3.5, 0.5 * len(rows) + 1.5))
+    ax1, ax2 = axs if hasattr(axs, "__len__") else (axs, None)
+    ys = list(range(len(rows)))
+    ax1.barh(ys, [r["cutTurns"] for r in rows], color=[pal[r["label"]] for r in rows], legend=False)
+    for y, r in zip(ys, rows):
+        ax1.annotate("%d of %d restarts cut a turn" % (r["restarts"] - r["cleanRestarts"], r["restarts"]),
+                     (r["cutTurns"], y), xytext=(4, 0), textcoords="offset points", va="center", fontsize=11)
+    ax1.set_yticks(ys)
+    ax1.set_yticklabels(_ylabels(rows))
+    ax1.clean(xlabel="Turns cut by restarts, per window — fewer better", ylabel="")
+    ax1.set_xlim(left=0)
+    ax2.scatter([r["cutTurnsPerRestart"] or 0 for r in rows], ys, color=[pal[r["label"]] for r in rows], legend=False, s=60)
+    ax2.set_yticks(ys)
+    ax2.set_yticklabels([""] * len(ys))
+    ax2.clean(xlabel="Turns cut per restart — fewer better", ylabel="")
+    ax2.set_xlim(left=0)
+    return _save(f, out, "cut_turns.png")
+
+
+def _dots_with_p90(cp, ax, rows, p50k, p90k, pal, xlabel):
+    ys = list(range(len(rows)))
+    for y, r in zip(ys, rows):
+        p50, p90 = r.get(p50k), r.get(p90k)
+        if p50 is None:
+            ax.annotate("no rows", (0, y), xytext=(4, 0), textcoords="offset points", va="center", fontsize=11, color="gray")
+            continue
+        c = pal[r["label"]]
+        if p90 is not None and p90 > p50:
+            ax.plot([p50, p90], [y, y], color=c, linewidth=2, alpha=0.6)
+        ax.scatter([p50], [y], color=c, s=60, legend=False)
+    ax.set_yticks(ys)
+    ax.set_yticklabels(_ylabels(rows))
+    ax.clean(xlabel=xlabel, ylabel="")
+    ax.set_xlim(left=0)
+
+
+def fig_restart_timing(cp, fr, out):
+    rows = fr["windows"]
+    if not rows:
+        return None
+    pal = _palette(cp, fr["labels"])
+    f, axs = cp.fig(rows=1, cols=2, w=14, h=max(3.5, 0.5 * len(rows) + 1.5))
+    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Outage, kernel exit to first serve (s): dot p50, line to p90 — shorter better")
+    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Boot reconcile settle (s): dot p50, line to p90 — shorter better")
+    axs[1].set_yticklabels([""] * len(rows))
+    return _save(f, out, "restart_timing.png")
+
+
+def fig_quiet_window(cp, fr, out):
+    rows = fr["windows"]
+    if not rows:
+        return None
+    pal = _palette(cp, fr["labels"])
+    f, ax = cp.fig(w=9, h=max(3.5, 0.5 * len(rows) + 1.5))
+    _dots_with_p90(cp, ax, rows, "quietP50", "quietP90", pal, "Quiet-window wait, parked to restart (s): dot p50, line to p90 — shorter better")
+    for y, r in enumerate(rows):
+        if r["quietWindows"]:
+            ax.annotate("%d windows, backstop fired %d" % (r["quietWindows"], r["backstopFires"]),
+                        (r.get("quietMax") or r.get("quietP90") or r.get("quietP50") or 0, y), xytext=(6, 0),
+                        textcoords="offset points", va="center", fontsize=11)
+    return _save(f, out, "quiet_window.png")
+
+
+def fig_boot_events(cp, fr, out):
+    rows = fr["windows"]
+    if not rows:
+        return None
+    import pandas as pd
+    df = pd.DataFrame({title: [r["events"][k] for r in rows] for k, title in EVENT_COLUMNS}, index=_ylabels(rows))
+    f, ax = cp.fig(w=11, h=max(4, 0.9 * len(rows) + 1.5))
+    ax.barh(df)
+    ax.clean(xlabel="Sessions gone wrong, per window — fewer better", ylabel="", color_labels="auto")
+    ax.set_xlim(left=0)
+    return _save(f, out, "boot_events.png")
+
+
+def fig_redo_cost(cp, fr, out):
+    rows = fr["windows"]
+    if not rows:
+        return None
+    import pandas as pd
+    pal = _palette(cp, fr["labels"])
+    f, axs = cp.fig(rows=1, cols=2, w=14, h=max(3.5, 0.5 * len(rows) + 1.5))
+    df = pd.DataFrame({"Continuation notices": [r["resumedTurns"] for r in rows],
+                       "Redo turns recorded": [r["redoTurns"] for r in rows]}, index=_ylabels(rows))
+    axs[0].barh(df)
+    axs[0].clean(xlabel="Turns resumed after a cut, per window — fewer better", ylabel="", color_labels="auto")
+    axs[0].set_xlim(left=0)
+    ys = list(range(len(rows)))
+    axs[1].barh(ys, [r["redoUsd"] for r in rows], color=[pal[r["label"]] for r in rows], legend=False)
+    for y, r in zip(ys, rows):
+        if isinstance(r.get("spendUsd"), (int, float)) and r["spendUsd"]:
+            axs[1].annotate("%.1f%% of $%.0f" % (100.0 * r["redoUsd"] / r["spendUsd"], r["spendUsd"]), (r["redoUsd"], y),
+                            xytext=(4, 0), textcoords="offset points", va="center", fontsize=11)
+    axs[1].set_yticks(ys)
+    axs[1].set_yticklabels([""] * len(ys))
+    axs[1].clean(xlabel="Dollars spent redoing cut work, per window — fewer better", ylabel="")
+    axs[1].set_xlim(left=0)
+    return _save(f, out, "redo_cost.png")
+
+
+def fig_turn_latency(cp, fr, out):
+    rows = fr["windows"]
+    series = [(r, r["latencySamples"] or r["stateLogSamples"], bool(r["latencySamples"])) for r in rows]
+    series = [(r, s, ev) for r, s, ev in series if s]
+    if not series:
+        return None
+    pal = _palette(cp, fr["labels"])
+    have_first = [(r, r["firstOutSamples"]) for r in rows if r["firstOutSamples"]]
+    f, axs = cp.fig(rows=1, cols=2 if have_first else 1, w=14 if have_first else 8, h=max(4, 0.6 * len(series) + 2))
+    ax = axs[0] if have_first else axs
+    positions = list(range(len(series)))
+    for pos, (r, s, ev) in zip(positions, series):
+        ax.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
+        ax.annotate("n=%d%s" % (len(s), "" if ev else ", state log (1 s)"), (max(s) if len(s) < 4 else sorted(s)[int(0.75 * (len(s) - 1))], pos),
+                    xytext=(6, 0), textcoords="offset points", va="center", fontsize=10)
+    ax.set_yticks(positions)
+    ax.set_yticklabels(["%s · %s" % (r["label"], r["window"]) for r, _, _ in series])
+    ax.clean(xlabel="Turn latency, feed to result (s) — box: quartiles, whiskers to 1.5 IQR; shorter better", ylabel="")
+    ax.set_xlim(left=0)
+    if have_first:
+        ax2 = axs[1]
+        pos2 = list(range(len(have_first)))
+        for pos, (r, s) in zip(pos2, have_first):
+            ax2.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
+        ax2.set_yticks(pos2)
+        ax2.set_yticklabels(["%s · %s" % (r["label"], r["window"]) for r, _ in have_first])
+        ax2.clean(xlabel="Feed to first assistant output (s) — shorter better", ylabel="")
+        ax2.set_xlim(left=0)
+    return _save(f, out, "turn_latency.png")
+
+
+def fig_session_resources(cp, fr, out):
+    live = fr["live"]
+    if not live:
+        return None
+    n = len(live)
+    rows_max = max([len(l["sessions"]) for l in live] + [1])
+    f, axs = cp.fig(rows=1, cols=n, w=6 * n + 2, h=max(4, 0.4 * rows_max + 2))
+    axs = list(axs) if hasattr(axs, "__len__") else [axs]
+    pal = _palette(cp, fr["labels"])
+    for ax, l in zip(axs, live):
+        names = [s["name"] for s in l["sessions"]] + (["kernel (pid %s)" % l["kernelPid"]] if l["kernelRssMb"] else [])
+        vals = [s["memMb"] for s in l["sessions"]] + ([l["kernelRssMb"]] if l["kernelRssMb"] else [])
+        ys = list(range(len(names)))[::-1]
+        ax.barh(ys, vals, color=pal[l["label"]], legend=False)
+        ax.set_yticks(ys)
+        ax.set_yticklabels(names)
+        ax.clean(xlabel="Resident memory (MB) — %s%s" % (l["label"], (", kernel CPU %.0f s, pusher idle %.0f%%" % (l["kernelCpuS"], 100 * l["kernelIdleShare"])) if isinstance(l.get("kernelIdleShare"), float) and l.get("kernelCpuS") is not None else ""), ylabel="")
+        ax.set_xlim(left=0)
+    return _save(f, out, "session_resources.png")
+
+
+def fig_kernel_memory(cp, fr, out):
+    series = fr["kernel"]
+    if not series:
+        return None
+    pal = _palette(cp, fr["labels"])
+    f, ax = cp.fig(w=11, h=5)
+    for s in series:
+        exits = [p for p in s["points"] if p["kind"] == "exit"]
+        boots = [p for p in s["points"] if p["kind"] == "boot"]
+        if exits:
+            ax.line([p["days"] for p in exits], [p["rssMb"] for p in exits], label="%s, at exit" % s["label"],
+                    color=pal[s["label"]], marker="o", linewidth=1.2)
+        if boots:
+            ax.scatter([p["days"] for p in boots], [p["rssMb"] for p in boots], label="%s, at boot" % s["label"],
+                       color=pal[s["label"]], marker="x", s=30, alpha=0.6)
+    ax.clean(xlabel="Days since the document's first restart", ylabel="Kernel resident memory (MB) — lower better",
+             color_labels="auto")
+    ax.set_ylim(bottom=0)
+    ax.set_xlim(left=0)
+    return _save(f, out, "kernel_memory.png")
+
+
+FIGURES = (fig_cut_turns, fig_restart_timing, fig_quiet_window, fig_boot_events, fig_redo_cost, fig_turn_latency,
+           fig_session_resources, fig_kernel_memory)
+
+
+def render(docs, out: Path) -> dict:
+    """Draw every figure; returns {figure name: path or None (no data)} and writes figures.json + summary.txt."""
+    cp = _cp()
+    out.mkdir(parents=True, exist_ok=True)
+    fr = frames(docs)
+    made = {}
+    for fn in FIGURES:
+        made[fn.__name__.replace("fig_", "")] = fn(cp, fr, out)
+    (out / "figures.json").write_text(json.dumps({"figures": made, "windows": fr["windows"], "live": fr["live"],
+                                                  "kernel": fr["kernel"]},
+                                                 indent=1, sort_keys=True, default=str))
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "cli"))
+        import restart_metrics as rm
+        (out / "summary.txt").write_text("\n\n".join("== %s ==\n%s" % (l, rm.summary(d)) for l, d in docs) + "\n")
+    except Exception as e:
+        (out / "summary.txt").write_text("summary unavailable: %s\n" % e)
+    return made
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--doc", action="append", required=True, help="label=path of a `romp restart-metrics --json` document; repeat in order (baseline first)")
+    ap.add_argument("--out", default=str(DEFAULT_OUT))
+    a = ap.parse_args(argv)
+    docs = load_docs(a.doc)
+    made = render(docs, Path(a.out))
+    for k, v in made.items():
+        sys.stdout.write("%-20s %s\n" % (k, v or "(no data)"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/restart_metrics_report.py
+++ b/scripts/restart_metrics_report.py
@@ -193,9 +193,10 @@ def fig_restart_timing(cp, fr, out):
     if not rows:
         return None
     pal = _palette(cp, fr["labels"])
-    f, axs = cp.fig(rows=1, cols=2, w=14, h=max(3.5, 0.5 * len(rows) + 1.5))
-    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Outage, kernel exit to first serve (s): dot p50, line to p90 — shorter better")
-    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Boot reconcile settle (s): dot p50, line to p90 — shorter better")
+    f, axs = cp.fig(rows=1, cols=2, w=16, h=max(3.5, 0.5 * len(rows) + 1.5))
+    f.subplots_adjust(wspace=0.3)
+    _dots_with_p90(cp, axs[0], rows, "outageP50", "outageP90", pal, "Exit to first serve (s): dot p50, line to p90 — shorter better")
+    _dots_with_p90(cp, axs[1], rows, "settleP50", "settleP90", pal, "Reconcile settle (s): dot p50, line to p90 — shorter better")
     axs[1].set_yticklabels([""] * len(rows))
     return _save(f, out, "restart_timing.png")
 
@@ -205,7 +206,7 @@ def fig_quiet_window(cp, fr, out):
     if not rows:
         return None
     pal = _palette(cp, fr["labels"])
-    f, ax = cp.fig(w=9, h=max(3.5, 0.5 * len(rows) + 1.5))
+    f, ax = cp.fig(w=10, h=max(3.5, 0.5 * len(rows) + 1.5))
     _dots_with_p90(cp, ax, rows, "quietP50", "quietP90", pal, "Quiet-window wait, parked to restart (s): dot p50, line to p90 — shorter better")
     for y, r in enumerate(rows):
         if r["quietWindows"]:
@@ -269,8 +270,8 @@ def fig_turn_latency(cp, fr, out):
     positions = list(range(len(series)))
     for pos, (r, s, ev) in zip(positions, series):
         ax.box([s], positions=[pos], showfliers=False, color=pal[r["label"]], legend=False, widths=0.6, vert=False)
-        ax.annotate("n=%d%s" % (len(s), "" if ev else ", state log (1 s)"), (max(s) if len(s) < 4 else sorted(s)[int(0.75 * (len(s) - 1))], pos),
-                    xytext=(6, 0), textcoords="offset points", va="center", fontsize=10)
+        ax.annotate("n=%d%s" % (len(s), "" if ev else ", state log (1 s)"), (1.0, pos), xycoords=("axes fraction", "data"),
+                    xytext=(6, 0), textcoords="offset points", va="center", fontsize=10)   # past the axis, clear of the whiskers
     ax.set_yticks(positions)
     ax.set_yticklabels(["%s · %s" % (r["label"], r["window"]) for r, _, _ in series])
     ax.clean(xlabel="Feed to result (s): box quartiles, whiskers 1.5 IQR — shorter better", ylabel="")

--- a/tests/manager-quiet-window-audit.test.js
+++ b/tests/manager-quiet-window-audit.test.js
@@ -1,0 +1,50 @@
+// T304: the quiet window's own restart-audit.jsonl row, written when a parked deploy refresh APPLIES. Until
+// now the wait from parked to restart and the backstop's firing lived in one manager log line; the restart
+// monitors (`romp restart-metrics`) read this row instead. Pure shape first (quietWindowRow), then the append
+// under a hermetic ROMP_STATE_DIR. Run: node --test tests/manager-quiet-window-audit.test.js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const STATE = fs.mkdtempSync(path.join(os.tmpdir(), 'romp-mgr-quiet-'));
+process.env.ROMP_STATE_DIR = STATE;                 // before the require: the manager binds STATE_ROOT at load
+const { quietWindowRow, auditQuietWindow } = require(path.join(__dirname, '..', 'bin', 'romp-manager'));
+
+test('quietWindowRow: the park and the verdict, in epoch seconds', () => {
+  const park = { since: 1_700_000_000_000, count: 3, mode: 'all', lastInflight: 2, misses: 0,
+                 drainRefusedCount: 1, drainArmedCount: 4, drainRefusedAfterArm: 0 };
+  const row = quietWindowRow(park, { action: 'apply', reason: 'backstop cap' }, 1_700_000_900_000);
+  assert.deepEqual(row, { t: 1_700_000_900, action: 'quiet-window', since: 1_700_000_000, waitedS: 900,
+                          reason: 'backstop cap', backstop: true, coalesced: 3, mode: 'all', lastInflight: 2,
+                          misses: 0, drainRefusedCount: 1, drainArmedCount: 4, drainRefusedAfterArm: 0 });
+});
+
+test('quietWindowRow: a quiet apply is not a backstop; unknown counts read as zero, not undefined', () => {
+  const row = quietWindowRow({ since: 1_700_000_000_000 }, { reason: 'quiet' }, 1_700_000_012_000);
+  assert.equal(row.backstop, false);
+  assert.equal(row.waitedS, 12);
+  assert.equal(row.coalesced, 1);
+  assert.equal(row.lastInflight, null, 'never polled → null, distinguishable from zero in flight');
+  assert.equal(row.drainRefusedCount, 0);
+  assert.equal(JSON.parse(JSON.stringify(row)).misses, 0, 'every field survives JSON');
+});
+
+test('auditQuietWindow appends one JSON line to restart-audit.jsonl under the state root', () => {
+  auditQuietWindow({ since: 1_700_000_000_000, count: 2, mode: 'main' }, { reason: 'quiet' }, 1_700_000_005_000);
+  const lines = fs.readFileSync(path.join(STATE, 'restart-audit.jsonl'), 'utf8').trim().split('\n');
+  assert.equal(lines.length, 1);
+  const row = JSON.parse(lines[0]);
+  assert.equal(row.action, 'quiet-window');
+  assert.equal(row.waitedS, 5);
+  assert.equal(row.mode, 'main');
+});
+
+test('auditQuietWindow never throws on an unwritable root (a lost note, not a lost restart)', () => {
+  // the root is bound at load; make the FILE a directory so the append fails
+  const bad = path.join(STATE, 'restart-audit.jsonl');
+  fs.rmSync(bad); fs.mkdirSync(bad);
+  assert.doesNotThrow(() => auditQuietWindow({ since: 1 }, { reason: 'quiet' }, 2000));
+  fs.rmdirSync(bad);
+});

--- a/tests/romp-restart-metrics.bats
+++ b/tests/romp-restart-metrics.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+# `romp restart-metrics` — the restart monitors' reader (T304). bin/romp hands the verb and its arguments
+# to romp-restart-metrics (python, cli/restart_metrics.py), which reads the state ledgers and, unless
+# --no-live, the running kernel's routes. Run here for REAL against an empty hermetic state directory with
+# --no-live: nothing reads a kernel, and a missing ledger is named loudly, never printed as a quiet zero.
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    unset ROMP_STATE_DIR ROMP_SERVE_TOKEN
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    export ROMP_HOST_NAME=TESTHOST
+}
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp restart-metrics runs the reader against the state dir and names a missing ledger" {
+    run "$ROMP_SCRIPT" restart-metrics --no-live --tz UTC
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"restart metrics — host TESTHOST"* ]]
+    [[ "$output" == *"MISSING ledgers"* ]]
+    [[ "$output" == *"restart-cuts.jsonl"* ]]
+    [[ "$output" == *"live: skipped"* ]]
+}
+
+@test "romp restart-metrics --json prints the document with its schema and window" {
+    printf '%s\n' '{"t": 1700000000, "pid": 1, "cutTurns": [], "stopped": 1, "unjoined": 0, "reaped": 0, "watchesArmed": 0, "reason": "p2p-update"}' \
+        > "$XDG_STATE_HOME/romp/restart-cuts.jsonl"
+    run "$ROMP_SCRIPT" restart-metrics --json --no-live --window week --anchor 2023-11-14 --tz UTC
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"schema": 1'* ]]
+    [[ "$output" == *'"week of 2023-11-14"'* ]]
+    [[ "$output" == *'"restarts": 1'* ]]
+}
+
+@test "a bad date is refused with exit 2" {
+    run "$ROMP_SCRIPT" restart-metrics --no-live --since not-a-date
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"bad date"* ]]
+}
+
+@test "romp help lists the verb" {
+    run "$ROMP_SCRIPT" help
+    [[ "$output" == *"romp restart-metrics"* ]]
+}

--- a/tests/romp-restart-metrics.bats
+++ b/tests/romp-restart-metrics.bats
@@ -12,15 +12,14 @@ setup() {
     TEST_DIR="$(mktemp -d)"
     export XDG_STATE_HOME="$TEST_DIR/state"
     mkdir -p "$XDG_STATE_HOME/romp"
-    export ROMP_HOST_NAME=TESTHOST
 }
 
 teardown() { rm -rf "$TEST_DIR"; }
 
 @test "romp restart-metrics runs the reader against the state dir and names a missing ledger" {
-    run "$ROMP_SCRIPT" restart-metrics --no-live --tz UTC
+    run "$ROMP_SCRIPT" restart-metrics --no-live --tz UTC --label TESTHOST
     [ "$status" -eq 0 ]
-    [[ "$output" == *"restart metrics — host TESTHOST"* ]]
+    [[ "$output" == *"restart metrics: TESTHOST, day windows"* ]]
     [[ "$output" == *"MISSING ledgers"* ]]
     [[ "$output" == *"restart-cuts.jsonl"* ]]
     [[ "$output" == *"live: skipped"* ]]
@@ -34,6 +33,14 @@ teardown() { rm -rf "$TEST_DIR"; }
     [[ "$output" == *'"schema": 1'* ]]
     [[ "$output" == *'"week of 2023-11-14"'* ]]
     [[ "$output" == *'"restarts": 1'* ]]
+}
+
+@test "the default header names this machine, never the hostname" {
+    run "$ROMP_SCRIPT" restart-metrics --no-live --tz UTC
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"restart metrics: this machine, day windows"* ]]
+    host="$(hostname -s 2>/dev/null || hostname)"
+    [[ -z "$host" || "$output" != *"$host"* ]]
 }
 
 @test "a bad date is refused with exit 2" {

--- a/tests/test_restart_metrics.py
+++ b/tests/test_restart_metrics.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""T304: `romp restart-metrics` (cli/restart_metrics.py), the read-only reader of what kernel restarts do to
+the sessions. Hermetic: synthetic ledgers under a private state directory (placeholder uuids, TESTHOST, no
+live reads), every row kind the reader parses, the window arithmetic, the summary text, the live helpers on
+synthetic cgroup files and ps lines, and the JSON document's shape. Nothing here touches a kernel."""
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+rm = load_source("romp_restart_metrics", os.path.join(BIN, "romp-restart-metrics"))
+
+SID = "11111111-2222-4333-8444-000000000304"
+SID2 = "22222222-3333-4444-8555-000000000304"
+TZ = "UTC"
+D0 = rm.day_start("2026-09-10", TZ)          # the anchor day, midnight UTC
+
+
+def _write(state: Path, name: str, rows):
+    (state / name).parent.mkdir(parents=True, exist_ok=True)
+    with open(state / name, "w") as f:
+        for r in rows:
+            f.write((json.dumps(r) if isinstance(r, dict) else r) + "\n")
+
+
+def _fixture(state: Path):
+    """A synthetic week: two restarts on day 0 (one quiet-window deploy, one backstop cut), a crash-only
+    boot on day 2, events, turns (one a redo turn), a state log, spend."""
+    t1 = D0 + 3600            # day 0, 01:00: a quiet-window deploy that cut two turns
+    t2 = D0 + 7200            # day 0, 02:00: a backstop-cut restart, one turn
+    t3 = D0 + 2 * 86400 + 60  # day 2: a boot with no cut row (a crash)
+    _write(state, "restart-cuts.jsonl", [
+        {"t": t1, "pid": 100, "cutTurns": [{"sid": SID, "name": "web"}, {"sid": SID2, "name": "api"}],
+         "stopped": 5, "unjoined": 1, "reaped": 1, "watchesArmed": 3, "reason": "manager-sigterm: restart-all", "auditT": t1 - 2,
+         "rssKb": 4 * 1024 * 1024, "cpuS": 900.5},
+        {"t": t1 + 2, "pid": 101, "bootSettled": True, "firstServe": t1 + 2.5, "reconcileDone": t1 + 2.7,
+         "settleS": 0.2, "prevCutT": t1, "outageS": 2.5, "rssKb": 300 * 1024, "cpuS": 1.5},
+        "this line is not json",
+        {"t": t2, "pid": 101, "cutTurns": [{"sid": SID, "name": "web"}], "stopped": 5, "unjoined": 0, "reaped": 0,
+         "watchesArmed": 3, "reason": "p2p-update", "rssKb": 2 * 1024 * 1024, "cpuS": 300.0},
+        {"t": t2 + 4, "pid": 102, "bootSettled": True, "firstServe": t2 + 4.0, "reconcileDone": t2 + 4.3,
+         "settleS": 0.3, "prevCutT": t2, "outageS": 4.0},
+        {"t": t3, "pid": 103, "bootSettled": True, "firstServe": t3 + 0.5, "reconcileDone": t3 + 0.6, "settleS": 0.1},
+    ])
+    _write(state, "restart-audit.jsonl", [
+        {"t": t1 - 300, "action": "p2p-update", "reason": "deploy", "when": "quiet"},
+        {"t": t1 - 3, "action": "quiet-window", "since": t1 - 300, "waitedS": 297, "reason": "quiet", "backstop": False,
+         "coalesced": 2, "mode": "all", "lastInflight": 0, "misses": 0, "drainRefusedCount": 0, "drainArmedCount": 3},
+        {"t": t1 - 2, "action": "manager-sigterm", "kernel": "main", "pid": 100, "reason": "restart", "trigger": "restart-all"},
+        {"t": t2 - 1, "action": "quiet-window", "since": t2 - 901, "waitedS": 900, "reason": "backstop cap", "backstop": True,
+         "coalesced": 1, "mode": "all", "lastInflight": 2, "misses": 0, "drainRefusedCount": 0, "drainArmedCount": 300},
+        {"t": t2 - 1, "action": "manager-sigterm", "kernel": "main", "pid": 101, "reason": "restart", "trigger": "restart-all"},
+        {"t": t3 + 5, "action": "signal", "reason": "signal, not requested through the manager"},
+    ])
+    _write(state, "session-events.jsonl", [
+        {"t": t1 - 1, "pid": 100, "kind": "drain.unjoined", "sid": SID, "name": "web", "inflight": 1, "reaped": True},
+        {"t": t1 + 3, "pid": 101, "kind": "reconcile.duplicate-cli", "sid": SID, "name": "web", "fsid": SID, "pids": "7,8", "n": 2},
+        {"t": t1 + 3, "pid": 101, "kind": "reconcile.orphan-reaped", "sid": SID, "name": "web", "cliPid": 7},
+        {"t": t1 + 3, "pid": 101, "kind": "reconcile.scope-stopped", "unit": "romp-session-11111111-7-1.scope", "sid8": "11111111"},
+        {"t": t1 + 3, "pid": 101, "kind": "reconcile.boot", "sessions": 5, "resumed": 2, "restored": 0, "notified": 0,
+         "reaped": 1, "scopesStopped": 1, "toStart": 2, "durationS": 0.2},
+        {"t": t2 + 5, "pid": 102, "kind": "reconcile.boot", "sessions": 5, "resumed": 1, "reaped": 0, "scopesStopped": 0},
+        {"t": t2 + 900, "pid": 102, "kind": "crash.heal", "sid": SID2, "name": "api", "attempt": 1},
+        {"t": t2 + 960, "pid": 102, "kind": "crash.loop", "sid": SID2, "name": "api", "attempt": 2},
+        {"t": t3 + 1, "pid": 103, "kind": "reconcile.boot", "sessions": 5, "resumed": 0, "reaped": 0, "scopesStopped": 0},
+        {"t": t3 + 2, "pid": 103, "kind": "lease.stale-heartbeat", "sid": SID, "name": "web", "leasePid": 9},
+        {"kind": "no-stamp"},
+    ])
+    _write(state, "turns.jsonl", [
+        {"t": t1 + 40, "sid": SID, "name": "web", "fedT": t1 + 3, "firstOutT": t1 + 5.5, "resultT": t1 + 40.0,
+         "durationMs": 37000, "apiMs": 30000, "numTurns": 4, "usd": 0.5, "tokIn": 100, "tokOut": 200, "tokCacheR": 3000,
+         "tokCacheW": 400, "opener": "injected", "resumeNotice": True, "fedTexts": 1},
+        {"t": t1 + 100, "sid": SID2, "name": "api", "fedT": t1 + 90, "firstOutT": t1 + 91.0, "resultT": t1 + 100.0,
+         "durationMs": 10000, "apiMs": 8000, "usd": 0.1, "opener": "human", "resumeNotice": False, "fedTexts": 1},
+        {"t": t2 + 50, "sid": SID2, "name": "api", "fedT": 0, "resultT": t2 + 50.0, "opener": "", "resumeNotice": False},
+    ])
+    _write(state, "states/%s.jsonl" % SID, [
+        {"t": int(t1 - 100), "state": "working"}, {"t": int(t1 - 70), "state": "waiting"},
+        {"t": t1 - 0.5, "machineCut": "restart"},
+        {"t": int(t1 + 3), "state": "working"}, {"t": int(t1 + 3), "awaiting": False}, {"t": int(t1 + 40), "state": "waiting"},
+        {"t": int(t1 + 200), "state": "working"}, {"t": int(t1 + 210), "state": "waiting", "by": "interrupt"},
+        {"t": int(t2 + 10), "state": "working"}, {"t": int(t2 + 20), "state": "idle"},
+        {"t": t2 + 899.5, "machineCut": "crash"},
+    ])
+    (state / "spend.json").write_text(json.dumps({"days": {"2026-09-10": {"usd": 12.5, "turns": 30},
+                                                            "2026-09-12": {"usd": 3.0, "turns": 4}}, "hours": {}}))
+    return t1, t2, t3
+
+
+class Parsers(unittest.TestCase):
+    def setUp(self):
+        self.state = Path(tempfile.mkdtemp())
+        self.t1, self.t2, self.t3 = _fixture(self.state)
+
+    def test_restarts_join_cuts_to_boots(self):
+        rows, note = rm._read_jsonl(self.state / "restart-cuts.jsonl")
+        self.assertEqual(note["unparseable"], 1)
+        rs = rm.parse_restarts(rows)
+        self.assertEqual([r["t"] for r in rs], [int(self.t1), int(self.t2), int(self.t3)])
+        a, b, c = rs
+        self.assertEqual((a["cutTurns"], a["cutSessions"], a["unjoined"], a["reaped"]), (2, ["web", "api"], 1, 1))
+        self.assertEqual(a["boot"]["outageS"], 2.5)
+        self.assertEqual(a["boot"]["settleS"], 0.2)
+        self.assertEqual(a["reason"], "manager-sigterm: restart-all")
+        self.assertEqual((b["cutTurns"], b["boot"]["outageS"]), (1, 4.0))
+        self.assertTrue(c["noCutRow"], "a boot with no cut before it is a crash respawn; its boot row still counts")
+        self.assertEqual(c["cutTurns"], 0)
+
+    def test_quiet_windows_join_the_restart_they_released(self):
+        cuts, _ = rm._read_jsonl(self.state / "restart-cuts.jsonl")
+        audit, _ = rm._read_jsonl(self.state / "restart-audit.jsonl")
+        rs = rm.parse_restarts(cuts)
+        q = rm.parse_quiet_windows(audit, rs)
+        self.assertEqual([(x["waitedS"], x["backstop"], x["restartT"], x["cutTurns"]) for x in q],
+                         [(297, False, int(self.t1), 2), (900, True, int(self.t2), 1)])
+        counts = rm.audit_counts(audit)
+        self.assertEqual(counts["byAction"]["quiet-window"], 2)
+        self.assertEqual(counts["sigtermTriggers"], {"restart-all": 2})
+
+    def test_events_turns_and_state_log(self):
+        ev, _ = rm._read_jsonl(self.state / "session-events.jsonl")
+        events = rm.parse_events(ev)
+        self.assertEqual(len(events), 10, "the stamp-less row is dropped")
+        tu, _ = rm._read_jsonl(self.state / "turns.jsonl")
+        turns = rm.parse_turns(tu)
+        self.assertEqual(turns[0]["feedToResultS"], 37.0)
+        self.assertEqual(turns[0]["feedToFirstOutS"], 2.5)
+        self.assertNotIn("feedToResultS", turns[2], "fedT 0 (no feed stamp) → no interval, never a bogus one")
+        lines = (self.state / "states" / (SID + ".jsonl")).read_text().splitlines()
+        sl, cuts = rm.state_log_turns(lines)
+        self.assertEqual([x["feedToResultS"] for x in sl], [30.0, 37.0],
+                         "working→waiting pairs; an interrupt's by-marked settle and an idle close are not turns")
+        self.assertEqual(cuts, {"restart": 1, "crash": 1})
+        self.assertEqual(rm.spend_by_day(json.loads((self.state / "spend.json").read_text())), {"2026-09-10": 12.5, "2026-09-12": 3.0})
+
+
+class BootJoin(unittest.TestCase):
+    def test_a_cut_without_a_boot_row_does_not_take_the_next_restarts_boot(self):
+        rows = [{"t": 1000, "cutTurns": [], "stopped": 1},                       # a legacy cut: no boot row ever followed
+                {"t": 2000, "cutTurns": [{"sid": SID, "name": "web"}], "stopped": 1},
+                {"t": 2003, "bootSettled": True, "firstServe": 2003.5, "reconcileDone": 2003.6, "settleS": 0.1},   # legacy boot: no prevCutT
+                {"t": 3000, "cutTurns": [], "stopped": 1},
+                {"t": 3002, "bootSettled": True, "firstServe": 3002.5, "reconcileDone": 3002.6, "settleS": 0.1,
+                 "prevCutT": 3000, "outageS": 2.5}]
+        rs = rm.parse_restarts(rows)
+        self.assertEqual([(r["t"], (r.get("boot") or {}).get("t")) for r in rs], [(1000, None), (2000, 2003), (3000, 3002)])
+        self.assertEqual(rs[1]["boot"]["outageS"], 3.5, "computed from firstServe when the boot row has no outageS")
+
+    def test_rotated_predecessor_is_read_first(self):
+        state = Path(tempfile.mkdtemp())
+        _write(state, "turns.jsonl.1", [{"t": 1, "sid": SID}])
+        _write(state, "turns.jsonl", [{"t": 2, "sid": SID}])
+        rows, note = rm._read_jsonl(state / "turns.jsonl")
+        self.assertEqual([r["t"] for r in rows], [1, 2])
+        self.assertEqual(note["rows"], 2)
+
+
+class Windows(unittest.TestCase):
+    def test_bucket_keys_days_and_weeks(self):
+        self.assertEqual(rm.bucket_key(D0 + 10, "day", "2026-09-10", TZ), "2026-09-10")
+        self.assertEqual(rm.bucket_key(D0 + 86400 * 6 + 10, "week", "2026-09-10", TZ), "week of 2026-09-10")
+        self.assertEqual(rm.bucket_key(D0 + 86400 * 7, "week", "2026-09-10", TZ), "week of 2026-09-17")
+        self.assertEqual(rm.bucket_key(D0 - 10, "week", "2026-09-10", TZ), "week of 2026-09-03", "before the anchor buckets backwards")
+        s, e = rm.bucket_bounds("week of 2026-09-10", "week", TZ)
+        self.assertEqual((s, e), (D0, D0 + 7 * 86400))
+        s, e = rm.bucket_bounds("2026-09-10", "day", TZ)
+        self.assertEqual((s, e), (D0, D0 + 86400))
+
+    def test_sample_cap_strides_evenly(self):
+        self.assertEqual(rm._cap(list(range(10)), cap=5), [0.0, 2.0, 4.0, 6.0, 8.0])
+        self.assertEqual(rm._cap([1, 2], cap=5), [1.0, 2.0])
+
+    def test_stats(self):
+        self.assertEqual(rm.stats([]), {"n": 0})
+        st = rm.stats([1, 2, 3, 4, 10])
+        self.assertEqual((st["n"], st["p50"], st["p90"], st["max"], st["mean"]), (5, 3.0, 10.0, 10.0, 4.0))
+        self.assertEqual(rm.stats([True, "x", 2])["n"], 1, "only numbers, never bools or strings")
+
+
+class Document(unittest.TestCase):
+    def setUp(self):
+        self.state = Path(tempfile.mkdtemp())
+        self.t1, self.t2, self.t3 = _fixture(self.state)
+
+    def test_week_buckets_carry_every_metric(self):
+        doc = rm.collect(self.state, kind="week", anchor="2026-09-10", tz=TZ, live=False)
+        self.assertEqual(doc["schema"], 1)
+        self.assertEqual(doc["window"], {"kind": "week", "anchor": "2026-09-10", "tz": TZ})
+        self.assertTrue(doc["live"]["skipped"])
+        (b,) = doc["buckets"]
+        self.assertEqual(b["key"], "week of 2026-09-10")
+        self.assertEqual((b["restarts"], b["cutTurns"], b["cleanRestarts"], b["restartsWithoutCutRow"]), (3, 3, 0, 1))
+        self.assertEqual(b["cutTurnsPerRestart"], 1.0)
+        self.assertEqual(b["cutSessions"], {"web": 2, "api": 1})
+        self.assertEqual(b["reasons"], {"manager-sigterm": 1, "p2p-update": 1, "(no cut row)": 1})
+        self.assertEqual((b["outageS"]["n"], b["outageS"]["max"]), (2, 4.0))
+        self.assertEqual((b["settleS"]["n"], b["settleS"]["max"]), (3, 0.3))
+        self.assertEqual((b["quietWindows"], b["backstopFires"], b["quietWaitS"]["p50"], b["quietWaitS"]["max"]), (2, 1, 297.0, 900.0))
+        self.assertEqual((b["boots"], b["resumedTurns"]), (3, 3))
+        self.assertEqual((b["orphansReaped"], b["scopesStopped"], b["duplicateClis"], b["crashHeals"], b["crashLoops"],
+                          b["drainLeftClosing"], b["leaseProblems"]), (1, 1, 1, 1, 1, 1, 1))
+        self.assertEqual((b["drainUnjoinedCount"], b["drainReapedCount"]), (1, 1))
+        self.assertEqual(b["redo"], {"turns": 1, "usd": 0.5, "tokens": 3700})
+        self.assertEqual(b["turns"], 3)
+        self.assertEqual((b["latency"]["feedToResultS"]["n"], b["latency"]["feedToResultS"]["max"]), (2, 37.0))
+        self.assertEqual(b["latency"]["feedToFirstOutS"]["p50"], 1.0)
+        self.assertEqual(b["latency"]["apiS"]["max"], 30.0)
+        self.assertEqual((b["stateLogTurns"], b["stateLogLatencyS"]["max"]), (2, 37.0))
+        self.assertEqual(b["machineCuts"], {"restart": 1, "crash": 1})
+        self.assertEqual(b["spendUsd"], 15.5)
+        self.assertEqual(b["samples"]["feedToResultS"], [37.0, 10.0])
+        self.assertEqual((b["kernelAtExit"]["rssMb"]["n"], b["kernelAtExit"]["rssMb"]["max"], b["kernelAtExit"]["cpuS"]["max"]),
+                         (2, 4096.0, 900.5), "the crash boot has no cut row and so no exit sample")
+        self.assertEqual([(k["kind"], k["rssMb"]) for k in doc["kernelSeries"]],
+                         [("exit", 4096.0), ("boot", 300.0), ("exit", 2048.0)])
+        self.assertEqual(b["samples"]["stateLogS"], [30.0, 37.0])
+        self.assertEqual(doc["events"]["byKind"]["reconcile.boot"], 3)
+        self.assertEqual(doc["sources"]["stateLogs"], 1)
+        self.assertEqual(doc["sources"]["restartCuts"]["rows"], 5)
+
+    def test_day_buckets_and_range(self):
+        doc = rm.collect(self.state, kind="day", tz=TZ, live=False, since=D0, until=D0 + 86400)
+        self.assertEqual([b["key"] for b in doc["buckets"]], ["2026-09-10"])
+        b = doc["buckets"][0]
+        self.assertEqual((b["restarts"], b["cutTurns"], b["spendUsd"]), (2, 3, 12.5))
+        self.assertEqual(doc["window"]["anchor"], "2026-09-10", "the default anchor is the first restart's day in range")
+        full = rm.collect(self.state, kind="day", tz=TZ, live=False)
+        self.assertEqual([b["key"] for b in full["buckets"]], ["2026-09-10", "2026-09-12"])
+        self.assertEqual(full["buckets"][1]["restartsWithoutCutRow"], 1)
+
+    def test_summary_text_names_the_numbers(self):
+        doc = rm.collect(self.state, kind="week", anchor="2026-09-10", tz=TZ, live=False)
+        doc["host"] = "TESTHOST"
+        text = rm.summary(doc)
+        self.assertIn("host TESTHOST", text)
+        self.assertIn("week of 2026-09-10", text)
+        self.assertIn("restarts 3 · turns cut 3 (1.0 per restart) · clean restarts 0 · boots with no cut row 1", text)
+        self.assertIn("quiet windows 2 · wait n=2 p50 297 s p90 900 s max 900 s · backstop fired 1", text)
+        self.assertIn("orphans reaped 1 · scopes stopped 1 · duplicate CLIs 1 · crash heals 1 · crash loops 1 · drain left closing 1", text)
+        self.assertIn("continuation notices 3 · redo turns 1 · redo cost $0.50 of $15.50 in the window · redo tokens 3,700", text)
+        self.assertIn("feed to result n=2 p50 10.0 s p90 37.0 s", text)
+        self.assertIn("machine cuts crash 1, restart 1", text)
+        self.assertIn("kernel process at its exits: resident n=2 p50 2048 MB p90 4096 MB max 4096 MB · cpu n=2 p50 300 s", text)
+        self.assertIn("live: skipped", text)
+        self.assertIn("note: Redo cost", text)
+        self.assertNotIn("MISSING", text)
+
+    def test_missing_ledgers_are_said(self):
+        empty = Path(tempfile.mkdtemp())
+        doc = rm.collect(empty, kind="day", tz=TZ, live=False)
+        self.assertEqual(doc["buckets"], [])
+        self.assertFalse(doc["sources"]["restartCuts"]["present"])
+        text = rm.summary(doc)
+        self.assertIn("MISSING ledgers", text)
+        self.assertIn("restart-cuts.jsonl", text)
+        self.assertIn("no rows in range", text)
+
+    def test_main_json_and_text(self):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = rm.main(["--json", "--window", "week", "--anchor", "2026-09-10", "--tz", TZ, "--no-live", "--state", str(self.state)])
+        self.assertEqual(rc, 0)
+        doc = json.loads(out.getvalue())
+        self.assertEqual(doc["buckets"][0]["restarts"], 3)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = rm.main(["--no-live", "--state", str(self.state), "--tz", TZ])
+        self.assertEqual(rc, 0)
+        self.assertIn("restart metrics", out.getvalue())
+        self.assertEqual(rm.main(["--since", "not-a-date", "--no-live", "--state", str(self.state)]), 2)
+
+
+class LiveHelpers(unittest.TestCase):
+    """The live reads, on synthetic files and listings: no cgroup, no ps, no kernel is touched."""
+
+    def test_scope_stats_from_synthetic_cgroup_files(self):
+        d = Path(tempfile.mkdtemp()) / "romp-session-11111111-4242-1757374800.scope"
+        d.mkdir()
+        (d / "memory.current").write_text("104857600\n")
+        (d / "memory.peak").write_text("209715200\n")
+        (d / "cpu.stat").write_text("usage_usec 12500000\nuser_usec 1\nsystem_usec 2\n")
+        (d / "cgroup.procs").write_text("4242\n4300\n4301\n")
+        s = rm.scope_stats(str(d))
+        self.assertEqual((s["sid8"], s["cliPid"], s["memBytes"], s["memPeakBytes"], s["cpuS"], s["procs"]),
+                         ("11111111", 4242, 104857600, 209715200, 12.5, 3))
+        self.assertEqual(rm.cgroup_scope_dirs(str(d.parent)), [str(d)])
+
+    def test_ps_parsing_trees_and_duplicates(self):
+        lines = ["  100     1  1000  0.5 /x/claude --output-format stream-json --resume %s --input-format stream-json" % SID,
+                 "  101   100   500  1.0 bash -c tool",
+                 "  102   101   250  0.0 sleep 3",
+                 "  200     1  2000  2.0 /x/claude --output-format stream-json --resume=%s --input-format stream-json" % SID,
+                 "  300     1   900  0.0 /x/claude --output-format stream-json --resume %s --input-format stream-json" % SID2,
+                 "  400     1   100  0.0 claude --resume %s" % SID,
+                 "garbage"]
+        procs = rm.parse_ps(lines)
+        self.assertEqual(len(procs), 6)
+        regs = {SID: {"name": "web", "lastSid": SID, "alive": True}, SID2: {"name": "api", "lastSid": SID2, "alive": True}}
+        trees = sorted(rm.ps_session_trees(procs, regs), key=lambda t: t["cliPid"])
+        self.assertEqual([(t["name"], t["cliPid"], t["procs"], t["memBytes"], t["cpuPct"]) for t in trees],
+                         [("web", 100, 3, 1750 * 1024, 1.5), ("web", 200, 1, 2000 * 1024, 2.0), ("api", 300, 1, 900 * 1024, 0.0)])
+        self.assertEqual(rm.duplicate_clis(procs, [SID, SID2]), {SID: [100, 200]}, "the tmux CLI (no mark) never counts")
+
+    def test_kernel_live_unreachable_is_said(self):
+        state = Path(tempfile.mkdtemp())
+        (state / "serve-port").write_text("1\n")          # nothing listens on port 1
+        os.environ.pop("ROMP_KERNEL_PORT", None)
+        k = rm.kernel_live(state)
+        self.assertEqual(k["port"], 1)
+        self.assertIn("not reachable", k["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_metrics.py
+++ b/tests/test_restart_metrics.py
@@ -239,9 +239,9 @@ class Document(unittest.TestCase):
 
     def test_summary_text_names_the_numbers(self):
         doc = rm.collect(self.state, kind="week", anchor="2026-09-10", tz=TZ, live=False)
-        doc["host"] = "TESTHOST"
+        doc["label"] = "TESTHOST"
         text = rm.summary(doc)
-        self.assertIn("host TESTHOST", text)
+        self.assertIn("restart metrics: TESTHOST, week windows", text)
         self.assertIn("week of 2026-09-10", text)
         self.assertIn("restarts 3 · turns cut 3 (1.0 per restart) · clean restarts 0 · boots with no cut row 1", text)
         self.assertIn("quiet windows 2 · wait n=2 p50 297 s p90 900 s max 900 s · backstop fired 1", text)
@@ -253,6 +253,41 @@ class Document(unittest.TestCase):
         self.assertIn("live: skipped", text)
         self.assertIn("note: Redo cost", text)
         self.assertNotIn("MISSING", text)
+
+    def test_default_label_is_this_machine_and_nothing_the_user_reads_carries_an_em_dash(self):
+        """Two of the user's standing rules for anything they read (the manager's fold, 2026-09-10): the
+        hostname is a personal identifier, so the default header names 'this machine' and the hostname
+        appears nowhere unless --label passes it; and no em-dash anywhere in the summary."""
+        import socket
+        host = (socket.gethostname() or "").split(".")[0]
+        doc = rm.collect(self.state, kind="week", anchor="2026-09-10", tz=TZ, live=False)
+        self.assertEqual(doc["label"], "this machine")
+        self.assertNotIn("host", doc, "no host field at all: the document names itself by label only")
+        text = rm.summary(doc)
+        self.assertIn("restart metrics: this machine, week windows", text)
+        if host:
+            self.assertNotIn(host, text)
+            self.assertNotIn(host, json.dumps(doc))
+        self.assertNotIn("\u2014", text)
+        self.assertNotIn("\u2014", json.dumps(doc))
+        labelled = rm.collect(self.state, kind="week", anchor="2026-09-10", tz=TZ, live=False, label="web box")
+        self.assertIn("restart metrics: web box,", rm.summary(labelled))
+
+    def test_no_em_dash_in_any_output_string_of_the_reader_or_the_report(self):
+        """Every non-docstring string literal of the two modules (the summary lines, the figure labels, the
+        notes) is free of em-dashes, by AST, so a new label cannot bring one back."""
+        import ast
+        for path in (os.path.join(BIN, "romp-restart-metrics"), os.path.join(os.path.dirname(HERE), "scripts", "restart_metrics_report.py")):
+            tree = ast.parse(open(path, encoding="utf-8").read())
+            docstrings = set()
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    body = node.body
+                    if body and isinstance(body[0], ast.Expr) and isinstance(getattr(body[0], "value", None), ast.Constant):
+                        docstrings.add(id(body[0].value))
+            offenders = [(n.lineno, n.value) for n in ast.walk(tree)
+                         if isinstance(n, ast.Constant) and isinstance(n.value, str) and "\u2014" in n.value and id(n) not in docstrings]
+            self.assertEqual(offenders, [], "%s carries an em-dash in an output string" % os.path.basename(path))
 
     def test_missing_ledgers_are_said(self):
         empty = Path(tempfile.mkdtemp())

--- a/tests/test_restart_metrics.py
+++ b/tests/test_restart_metrics.py
@@ -11,6 +11,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from unittest import mock
 from romp_load import load_source
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -140,6 +141,16 @@ class Parsers(unittest.TestCase):
         self.assertEqual([x["feedToResultS"] for x in sl], [30.0, 37.0],
                          "working→waiting pairs; an interrupt's by-marked settle and an idle close are not turns")
         self.assertEqual(cuts, {"restart": 1, "crash": 1})
+
+    def test_state_log_pair_breaks_at_a_machine_cut(self):
+        """Review find (2026-09-10): a cut turn's `working` row was closed by the RESUMED turn's `waiting`, so
+        the interval spanned the outage and the redo. A machineCut row ends the open pair unmeasured."""
+        lines = [json.dumps(r) for r in (
+            {"t": 1000, "state": "working"}, {"t": 1300.5, "machineCut": "restart"},
+            {"t": 1400, "state": "working"}, {"t": 1410, "state": "waiting"})]
+        sl, cuts = rm.state_log_turns(lines)
+        self.assertEqual([(x["fedT"], x["feedToResultS"]) for x in sl], [(1400, 10.0)])
+        self.assertEqual(cuts, {"restart": 1})
         self.assertEqual(rm.spend_by_day(json.loads((self.state / "spend.json").read_text())), {"2026-09-10": 12.5, "2026-09-12": 3.0})
 
 
@@ -165,6 +176,16 @@ class BootJoin(unittest.TestCase):
 
 
 class Windows(unittest.TestCase):
+    def test_week_bounds_follow_local_midnight_across_a_daylight_saving_change(self):
+        """Review find (2026-09-10): seven times 86400 seconds from the anchor drifted an hour off local
+        midnight after a clock change; weeks are counted in local dates."""
+        la = "America/Los_Angeles"          # clocks fall back on 2026-11-01
+        s, e = rm.bucket_bounds("week of 2026-10-29", "week", la)
+        self.assertEqual(e - s, 7 * 86400 + 3600, "the week holds the extra hour and still ends at local midnight")
+        self.assertEqual(rm.local_date(e, la), "2026-11-05")
+        self.assertEqual(rm.bucket_key(rm.day_start("2026-11-04", la) + 12 * 3600, "week", "2026-10-29", la), "week of 2026-10-29")
+        self.assertEqual(rm.bucket_key(rm.day_start("2026-11-05", la) + 60, "week", "2026-10-29", la), "week of 2026-11-05")
+
     def test_bucket_keys_days_and_weeks(self):
         self.assertEqual(rm.bucket_key(D0 + 10, "day", "2026-09-10", TZ), "2026-09-10")
         self.assertEqual(rm.bucket_key(D0 + 86400 * 6 + 10, "week", "2026-09-10", TZ), "week of 2026-09-10")
@@ -199,7 +220,8 @@ class Document(unittest.TestCase):
         (b,) = doc["buckets"]
         self.assertEqual(b["key"], "week of 2026-09-10")
         self.assertEqual((b["restarts"], b["cutTurns"], b["cleanRestarts"], b["restartsWithoutCutRow"]), (3, 3, 0, 1))
-        self.assertEqual(b["cutTurnsPerRestart"], 1.0)
+        self.assertEqual(b["measuredRestarts"], 2, "a boot with no cut row cut an unknown number of turns, not zero")
+        self.assertEqual(b["cutTurnsPerRestart"], 1.5, "3 cut turns over the 2 MEASURED restarts (review find)")
         self.assertEqual(b["cutSessions"], {"web": 2, "api": 1})
         self.assertEqual(b["reasons"], {"manager-sigterm": 1, "p2p-update": 1, "(no cut row)": 1})
         self.assertEqual((b["outageS"]["n"], b["outageS"]["max"]), (2, 4.0))
@@ -243,7 +265,8 @@ class Document(unittest.TestCase):
         text = rm.summary(doc)
         self.assertIn("restart metrics: TESTHOST, week windows", text)
         self.assertIn("week of 2026-09-10", text)
-        self.assertIn("restarts 3 · turns cut 3 (1.0 per restart) · clean restarts 0 · boots with no cut row 1", text)
+        self.assertIn("restarts 3 · turns cut 3 (1.5 per measured restart) · clean restarts 0 · boots with no cut row 1", text)
+        self.assertIn("dates in UTC time", text)
         self.assertIn("quiet windows 2 · wait n=2 p50 297 s p90 900 s max 900 s · backstop fired 1", text)
         self.assertIn("orphans reaped 1 · scopes stopped 1 · duplicate CLIs 1 · crash heals 1 · crash loops 1 · drain left closing 1", text)
         self.assertIn("continuation notices 3 · redo turns 1 · redo cost $0.50 of $15.50 in the window · redo tokens 3,700", text)
@@ -273,21 +296,31 @@ class Document(unittest.TestCase):
         labelled = rm.collect(self.state, kind="week", anchor="2026-09-10", tz=TZ, live=False, label="web box")
         self.assertIn("restart metrics: web box,", rm.summary(labelled))
 
-    def test_no_em_dash_in_any_output_string_of_the_reader_or_the_report(self):
-        """Every non-docstring string literal of the two modules (the summary lines, the figure labels, the
-        notes) is free of em-dashes, by AST, so a new label cannot bring one back."""
+    def test_no_em_dash_in_any_string_of_the_reader_or_the_report(self):
+        """Every string literal of the two modules, docstrings included (--help prints the module docstring's
+        first paragraph), is free of em-dashes, by AST, so a new label cannot bring one back."""
         import ast
         for path in (os.path.join(BIN, "romp-restart-metrics"), os.path.join(os.path.dirname(HERE), "scripts", "restart_metrics_report.py")):
             tree = ast.parse(open(path, encoding="utf-8").read())
-            docstrings = set()
-            for node in ast.walk(tree):
-                if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                    body = node.body
-                    if body and isinstance(body[0], ast.Expr) and isinstance(getattr(body[0], "value", None), ast.Constant):
-                        docstrings.add(id(body[0].value))
-            offenders = [(n.lineno, n.value) for n in ast.walk(tree)
-                         if isinstance(n, ast.Constant) and isinstance(n.value, str) and "\u2014" in n.value and id(n) not in docstrings]
-            self.assertEqual(offenders, [], "%s carries an em-dash in an output string" % os.path.basename(path))
+            offenders = [(n.lineno, n.value[:60]) for n in ast.walk(tree)
+                         if isinstance(n, ast.Constant) and isinstance(n.value, str) and "\u2014" in n.value]
+            self.assertEqual(offenders, [], "%s carries an em-dash in a string" % os.path.basename(path))
+        out = io.StringIO()
+        with redirect_stdout(out), self.assertRaises(SystemExit):
+            rm.main(["--help"])
+        self.assertNotIn("\u2014", out.getvalue())
+
+    def test_summary_dates_follow_the_documents_zone(self):
+        """Review find (2026-09-10): the window bounds were rendered in the machine's zone, ignoring --tz. A
+        zone fourteen hours ahead of UTC puts the anchor's local midnight on the previous UTC day."""
+        far = "Pacific/Kiritimati"
+        doc = rm.collect(self.state, kind="day", tz=far, live=False, since=rm.day_start("2026-09-10", far),
+                         until=rm.day_start("2026-09-11", far))
+        text = rm.summary(doc)
+        self.assertIn("2026-09-10  (2026-09-10 to 2026-09-10)", text, "the machine's UTC clock would have said 2026-09-09")
+
+    def test_bad_anchor_is_refused_like_the_other_dates(self):
+        self.assertEqual(rm.main(["--anchor", "yesterday", "--no-live", "--state", str(self.state)]), 2)
 
     def test_missing_ledgers_are_said(self):
         empty = Path(tempfile.mkdtemp())
@@ -348,8 +381,9 @@ class LiveHelpers(unittest.TestCase):
     def test_kernel_live_unreachable_is_said(self):
         state = Path(tempfile.mkdtemp())
         (state / "serve-port").write_text("1\n")          # nothing listens on port 1
-        os.environ.pop("ROMP_KERNEL_PORT", None)
-        k = rm.kernel_live(state)
+        with mock.patch.dict(os.environ):                 # the suite's dead-port floor comes back after (review find)
+            os.environ.pop("ROMP_KERNEL_PORT", None)
+            k = rm.kernel_live(state)
         self.assertEqual(k["port"], 1)
         self.assertIn("not reachable", k["error"])
 

--- a/tests/test_restart_metrics_report.py
+++ b/tests/test_restart_metrics_report.py
@@ -46,7 +46,9 @@ class Frames(unittest.TestCase):
         self.assertEqual(fr["labels"], ["baseline", "after"])
         self.assertEqual([r["label"] for r in fr["windows"]], ["baseline", "after"])
         w = fr["windows"][0]
-        self.assertEqual((w["window"], w["restarts"], w["cutTurns"], w["cutTurnsPerRestart"]), ("week of 2026-09-10", 3, 3, 1.0))
+        self.assertEqual((w["window"], w["restarts"], w["cutTurns"], w["cutTurnsPerRestart"]), ("week of 2026-09-10", 3, 3, 1.5))
+        self.assertEqual((w["measuredRestarts"], w["unmeasuredRestarts"]), (2, 1))
+        self.assertEqual(rep.SMALL_N, 5)
         self.assertEqual((w["outageP50"], w["outageP90"], w["quietP50"], w["backstopFires"]), (2.5, 4.0, 297.0, 1))
         self.assertEqual(w["events"]["orphansReaped"], 1)
         self.assertEqual((w["resumedTurns"], w["redoTurns"], w["redoUsd"], w["spendUsd"]), (3, 1, 0.5, 15.5))

--- a/tests/test_restart_metrics_report.py
+++ b/tests/test_restart_metrics_report.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""T304: the figure script (scripts/restart_metrics_report.py) over a synthetic `romp restart-metrics --json`
+document. The data shaping is pure and always tested; the drawing runs end to end when cleanplots and
+matplotlib import (they are not romp dependencies: `uvx --with cleanplots --with matplotlib --with pandas
+pytest tests/test_restart_metrics_report.py`), and is SKIPPED with a named reason otherwise, never
+replaced by another look. Synthetic only."""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sys.path.insert(0, HERE)
+from romp_load import load_source   # noqa: E402
+
+rep = load_source("romp_restart_metrics_report", os.path.join(ROOT, "scripts", "restart_metrics_report.py"))
+rm = load_source("romp_restart_metrics_for_report", os.path.join(ROOT, "bin", "romp-restart-metrics"))
+from test_restart_metrics import _fixture, SID   # noqa: E402  (the synthetic week)
+
+HAVE_PLOT = importlib.util.find_spec("cleanplots") is not None and importlib.util.find_spec("matplotlib") is not None \
+    and importlib.util.find_spec("pandas") is not None
+
+
+def _doc(label_shift=0):
+    state = Path(tempfile.mkdtemp())
+    _fixture(state)
+    doc = rm.collect(state, kind="week", anchor="2026-09-10", tz="UTC", live=False)
+    doc["host"] = "TESTHOST"
+    doc["live"] = {"host": "TESTHOST", "source": "cgroup", "t": 1, "errors": [], "duplicateClis": [],
+                   "sessions": [{"sid": SID, "name": "web", "memBytes": 300 * 1048576, "cpuS": 12.5, "sid8": "11111111"},
+                                {"sid": None, "name": "22222222", "memBytes": 100 * 1048576, "cpuS": None, "sid8": "22222222"}],
+                   "kernel": {"port": 1, "pid": 42, "uptimeS": 100, "perf": {"cpuS": 55.0, "rssKb": 2048 * 1024, "idleShare": 0.4}},
+                   "memTotalBytes": 400 * 1048576, "sessionsCounted": 2}
+    return doc
+
+
+class Frames(unittest.TestCase):
+    def test_frames_from_two_documents(self):
+        fr = rep.frames([("baseline", _doc()), ("after", _doc())])
+        self.assertEqual(fr["labels"], ["baseline", "after"])
+        self.assertEqual([r["label"] for r in fr["windows"]], ["baseline", "after"])
+        w = fr["windows"][0]
+        self.assertEqual((w["window"], w["restarts"], w["cutTurns"], w["cutTurnsPerRestart"]), ("week of 2026-09-10", 3, 3, 1.0))
+        self.assertEqual((w["outageP50"], w["outageP90"], w["quietP50"], w["backstopFires"]), (2.5, 4.0, 297.0, 1))
+        self.assertEqual(w["events"]["orphansReaped"], 1)
+        self.assertEqual((w["resumedTurns"], w["redoTurns"], w["redoUsd"], w["spendUsd"]), (3, 1, 0.5, 15.5))
+        self.assertEqual(w["latencySamples"], [37.0, 10.0])
+        self.assertEqual(w["stateLogSamples"], [30.0, 37.0])
+        self.assertEqual(len(fr["live"]), 2)
+        lv = fr["live"][0]
+        self.assertEqual([s["name"] for s in lv["sessions"]], ["web", "22222222"], "largest first")
+        self.assertEqual((lv["kernelRssMb"], lv["kernelCpuS"], lv["kernelIdleShare"], lv["kernelPid"]), (2048.0, 55.0, 0.4, 42))
+        ks = fr["kernel"][0]
+        self.assertEqual(ks["label"], "baseline")
+        self.assertEqual([(p["kind"], p["rssMb"]) for p in ks["points"]], [("exit", 4096.0), ("boot", 300.0), ("exit", 2048.0)])
+        self.assertEqual(ks["points"][0]["days"], 0.0)
+
+    def test_load_docs_labels(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "base.json").write_text(json.dumps(_doc()))
+        docs = rep.load_docs(["baseline=%s" % (d / "base.json"), str(d / "base.json")])
+        self.assertEqual([l for l, _ in docs], ["baseline", "base"])
+        (d / "bad.json").write_text("{}")
+        with self.assertRaises(SystemExit):
+            rep.load_docs([str(d / "bad.json")])
+
+
+@unittest.skipUnless(HAVE_PLOT, "cleanplots, matplotlib and pandas are not importable here; run under uvx --with cleanplots --with matplotlib --with pandas")
+class Render(unittest.TestCase):
+    def test_every_figure_is_drawn_end_to_end(self):
+        out = Path(tempfile.mkdtemp()) / "figs"
+        made = rep.render([("baseline", _doc()), ("after", _doc())], out)
+        expected = {"cut_turns", "restart_timing", "quiet_window", "boot_events", "redo_cost", "turn_latency", "session_resources",
+                    "kernel_memory"}
+        self.assertEqual(set(made), expected)
+        for name, path in made.items():
+            self.assertIsNotNone(path, name + " drew nothing")
+            self.assertGreater(os.path.getsize(path), 1000, name + " is empty")
+            self.assertTrue(path.endswith(".png"))
+        self.assertTrue((out / "figures.json").exists())
+        self.assertIn("host TESTHOST", (out / "summary.txt").read_text())
+
+    def test_main_prints_the_paths(self):
+        d = Path(tempfile.mkdtemp())
+        (d / "b.json").write_text(json.dumps(_doc()))
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = rep.main(["--doc", "baseline=%s" % (d / "b.json"), "--out", str(d / "out")])
+        self.assertEqual(rc, 0)
+        self.assertIn("cut_turns", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_metrics_report.py
+++ b/tests/test_restart_metrics_report.py
@@ -31,8 +31,8 @@ def _doc(label_shift=0):
     state = Path(tempfile.mkdtemp())
     _fixture(state)
     doc = rm.collect(state, kind="week", anchor="2026-09-10", tz="UTC", live=False)
-    doc["host"] = "TESTHOST"
-    doc["live"] = {"host": "TESTHOST", "source": "cgroup", "t": 1, "errors": [], "duplicateClis": [],
+    doc["label"] = "TESTHOST"
+    doc["live"] = {"source": "cgroup", "t": 1, "errors": [], "duplicateClis": [],
                    "sessions": [{"sid": SID, "name": "web", "memBytes": 300 * 1048576, "cpuS": 12.5, "sid8": "11111111"},
                                 {"sid": None, "name": "22222222", "memBytes": 100 * 1048576, "cpuS": None, "sid8": "22222222"}],
                    "kernel": {"port": 1, "pid": 42, "uptimeS": 100, "perf": {"cpuS": 55.0, "rssKb": 2048 * 1024, "idleShare": 0.4}},
@@ -42,7 +42,7 @@ def _doc(label_shift=0):
 
 class Frames(unittest.TestCase):
     def test_frames_from_two_documents(self):
-        fr = rep.frames([("baseline", _doc()), ("after", _doc())])
+        fr = rep.frames([("baseline", _doc()), ("after", _doc())], anonymize=False)   # the named view; the default is pinned below
         self.assertEqual(fr["labels"], ["baseline", "after"])
         self.assertEqual([r["label"] for r in fr["windows"]], ["baseline", "after"])
         w = fr["windows"][0]
@@ -60,6 +60,19 @@ class Frames(unittest.TestCase):
         self.assertEqual(ks["label"], "baseline")
         self.assertEqual([(p["kind"], p["rssMb"]) for p in ks["points"]], [("exit", 4096.0), ("boot", 300.0), ("exit", 2048.0)])
         self.assertEqual(ks["points"][0]["days"], 0.0)
+
+    def test_session_names_are_hidden_by_default_outside_the_state_root(self):
+        """The manager's fold (2026-09-10): real session names (other projects' among them) are private, so
+        every figure written outside the user's own state root names sessions by memory rank, and only the
+        caller's explicit ask shows them."""
+        fr = rep.frames([("baseline", _doc())])                       # anonymize=True is the frames default
+        self.assertEqual([s["name"] for s in fr["live"][0]["sessions"]], ["session 1", "session 2"])
+        self.assertTrue(fr["anonymized"])
+        named = rep.frames([("baseline", _doc())], anonymize=False)
+        self.assertEqual([s["name"] for s in named["live"][0]["sessions"]], ["web", "22222222"])
+        self.assertTrue(rep.anonymize_default(tempfile.mkdtemp()), "a scratch dir is outside the state root")
+        self.assertFalse(rep.anonymize_default(rep.STATE_ROOT / "romp-research" / "restart-metrics"), "the user's own state root shows names")
+        self.assertTrue(rep.anonymize_default(Path("/nonexistent/place")))
 
     def test_load_docs_labels(self):
         d = Path(tempfile.mkdtemp())
@@ -83,8 +96,13 @@ class Render(unittest.TestCase):
             self.assertIsNotNone(path, name + " drew nothing")
             self.assertGreater(os.path.getsize(path), 1000, name + " is empty")
             self.assertTrue(path.endswith(".png"))
-        self.assertTrue((out / "figures.json").exists())
-        self.assertIn("host TESTHOST", (out / "summary.txt").read_text())
+        figs = (out / "figures.json").read_text()
+        self.assertNotIn("web", figs, "a scratch out dir is outside the state root: names hidden by default")
+        self.assertIn("session 1", figs)
+        self.assertIn("restart metrics: TESTHOST", (out / "summary.txt").read_text())
+        made2 = rep.render([("baseline", _doc())], out / "named", anonymize=False)
+        self.assertIn("web", (out / "named" / "figures.json").read_text())
+        self.assertIsNotNone(made2["session_resources"])
 
     def test_main_prints_the_paths(self):
         d = Path(tempfile.mkdtemp())
@@ -96,6 +114,11 @@ class Render(unittest.TestCase):
             rc = rep.main(["--doc", "baseline=%s" % (d / "b.json"), "--out", str(d / "out")])
         self.assertEqual(rc, 0)
         self.assertIn("cut_turns", buf.getvalue())
+        self.assertIn("session names: hidden", buf.getvalue())
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rep.main(["--doc", "baseline=%s" % (d / "b.json"), "--out", str(d / "out2"), "--named"])
+        self.assertIn("session names: shown", buf.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -319,12 +319,14 @@ class TurnLedgerRow(unittest.TestCase):
         import inspect
         src = inspect.getsource(sb.SdkSession._on_message)
         i_fin = src.index("finally:\n                # T304: one durable row per settled turn")
-        i_row = src.index("append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, delta, turn_u))")
+        i_row = src.index("append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, _sp[0], _sp[1]))")
         i_reset = src.index("self._fed_t = None               # the turn's feed stamps are spent")
         i_settle = src.index("everything that makes the turn over for the kernel")   # the finally's own comment
         self.assertTrue(i_fin < i_row < i_reset < i_settle, "row, then the reset, then the settle, all inside the finally")
-        self.assertIn("elif isinstance(msg, ResultMessage):\n            delta = turn_u = None", src,
-                      "the fold's names exist before the branch's try, so the finally can always read them")
+        self.assertIn("elif isinstance(msg, ResultMessage):\n            try:", src,
+                      "the branch stays ONE try (the settle pins), so the fold hands its figures over by attribute")
+        self.assertIn("self._turn_spend = (delta, turn_u)", src[src.index("turn_u = self._turn_usage(msg)"):i_fin])
+        self.assertIn("self._turn_spend = None", src[i_row:i_settle], "spent with the row")
 
     def test_row_fields_and_stamps(self):
         s = self._sess(["do the thing"], first_out=1700000004.25, fed_t=1700000000)

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""T304 (stage 0 of the restart-surviving sessions program, 2026-09-10): the two ledgers the restart monitors
+read. session-events.jsonl gets one flat row per thing that went wrong with a session's process (an orphaned
+CLI ended at boot, a leftover scope stopped, two CLIs holding one conversation, a crash heal or crash loop, a
+session the drain's bound left closing) and one summary row per boot sweep; every problem also lands on the
+backend's problem ring as its prose and on the kernel log as `<prose> ;; problem-row {json}` (the shape agreed
+with the lease work, which writes its `lease.*` kinds through the same helper). turns.jsonl gets one row per
+settled turn with the event stamps the latency and redo-cost figures read. Synthetic fixtures only: placeholder
+uuids, fake pids above pid_max, scripted `run` / `kill` seams, no real CLI."""
+import json
+import os
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE the load
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_CLI_SCOPE"] = "0"
+sb = load_source("romp_sdk_backend_t304_ledger", os.path.join(BIN, "romp_sdk_backend.py"))
+
+SID = "11111111-2222-4333-8444-000000000304"
+SID2 = "22222222-3333-4444-8555-000000000304"
+
+
+def _pid_max() -> int:
+    try:
+        return int(open("/proc/sys/kernel/pid_max").read().strip())
+    except (OSError, ValueError):
+        return 4194304
+
+
+P = _pid_max()
+CLI, CLI2, TOOL, LIVE, KERNEL = P + 304, P + 305, P + 306, P + 307, P + 90304
+
+
+def _backend(d, log=None):
+    be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=log or (lambda *a, **k: None))
+    be._t304_ring0 = len(be.problems())   # the constructor's own verdicts (no SDK here) are not under test
+    return be
+
+
+def _ring(be):
+    """The problem-ring rows this test added, past the constructor's own."""
+    return be.problems()[be._t304_ring0:]
+
+
+def _reg(d, sid, name, fsid=None):
+    r = {"sid": sid, "name": name, "cwd": "/tmp", "alive": True, "lastSid": fsid or sid}
+    sb.write_reg(Path(d), sid, r)
+    return r
+
+
+def _events(d):
+    p = Path(d) / sb.SESSION_EVENTS_FILE
+    return [json.loads(ln) for ln in p.read_text().splitlines()] if p.exists() else []
+
+
+class ProblemRowShape(unittest.TestCase):
+    """One helper, three outputs: the ledger row, the parseable log line, the readable ring text."""
+
+    def test_row_line_and_ring(self):
+        d = tempfile.mkdtemp()
+        lines = []
+        be = _backend(d, log=lambda m: lines.append(m))
+        line = sb.problem_row(be.state_dir, "session web: something went wrong", "test.kind", log=be._log,
+                              sid=SID, name="web", cliPid=CLI, scope=None, extra=1.5, flag=True)
+        rows = _events(d)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["kind"], "test.kind")
+        self.assertEqual(row["sid"], SID)
+        self.assertEqual(row["name"], "web")
+        self.assertEqual(row["pid"], os.getpid())
+        self.assertIsInstance(row["t"], int)
+        self.assertEqual(row["cliPid"], CLI)
+        self.assertNotIn("scope", row, "None fields are dropped: the row stays flat and honest")
+        self.assertEqual(row["extra"], 1.5)
+        self.assertIs(row["flag"], True)
+        self.assertEqual(row["text"], "session web: something went wrong")
+        # the log line: prose, the marker, the SAME object — parseable by rsplit on the marker
+        self.assertTrue(line.startswith("session web: something went wrong" + sb.PROBLEM_ROW_MARK))
+        self.assertEqual(sb.parse_problem_row(line), row)
+        self.assertEqual(lines[-1], line, "the kernel log gets the whole line (after the constructor's own lines)")
+        # the ring gets the prose alone, so the bell and error center stay readable
+        ring = _ring(be)
+        self.assertEqual([r["text"] for r in ring], ["session web: something went wrong"])
+
+    def test_ring_false_keeps_the_ring_clean(self):
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        sb.problem_row(be.state_dir, "an informational line", "test.info", log=be._log, ring=False)
+        self.assertEqual(_ring(be), [])
+        self.assertEqual(_events(d)[0]["kind"], "test.info")
+
+    def test_parse_rejects_other_lines(self):
+        self.assertIsNone(sb.parse_problem_row("drain: stopped 3 session(s)"))
+        self.assertIsNone(sb.parse_problem_row("x" + sb.PROBLEM_ROW_MARK + "not json"))
+        self.assertIsNone(sb.parse_problem_row("x" + sb.PROBLEM_ROW_MARK + "[1, 2]"))
+
+    def test_a_plain_log_callable_gets_the_line(self):
+        d = tempfile.mkdtemp()
+        got = []
+        def plain(m):          # a callable without problem= / ring_text= (an older seam, a test lambda)
+            got.append(m)
+        line = sb.problem_row(Path(d), "prose", "test.plain", log=plain)
+        self.assertEqual(got, [line])
+
+    def test_nested_values_flatten_to_str(self):
+        d = tempfile.mkdtemp()
+        row = sb.append_session_event(Path(d), "test.flat", pids=[1, 2], t=1700000000)
+        self.assertEqual(row["pids"], "[1, 2]")
+        self.assertEqual(row["t"], 1700000000)
+
+
+class LogRingText(unittest.TestCase):
+    """SdkBackend._log's ring_text: the ring keeps the readable text while the log line carries the tail."""
+
+    def test_ring_text_and_repeat_count(self):
+        be = _backend(tempfile.mkdtemp())
+        be._log("prose ;; tail", problem=True, key="k", ring_text="prose")
+        be._log("prose ;; tail", problem=True, key="k", ring_text="prose")
+        (row,) = _ring(be)
+        self.assertTrue(row["text"].startswith("prose (1 repeat"), row["text"])
+        self.assertEqual(row["first"], "prose")
+
+    def test_default_is_the_line_itself(self):
+        be = _backend(tempfile.mkdtemp())
+        be._log("plain problem", problem=True)
+        self.assertEqual(_ring(be)[0]["text"], "plain problem")
+
+
+class PureHelpers(unittest.TestCase):
+    def test_cli_sid_of_every_spelling(self):
+        self.assertEqual(sb.cli_sid_of("claude --resume %s --input-format stream-json" % SID, [SID]), SID)
+        self.assertEqual(sb.cli_sid_of("claude --resume=%s" % SID, [SID2, SID]), SID)
+        self.assertEqual(sb.cli_sid_of("claude --session-id %s" % SID2, [SID, SID2]), SID2)
+        self.assertIsNone(sb.cli_sid_of("claude --resume other", [SID]))
+        self.assertIsNone(sb.cli_sid_of("claude --resume %s" % SID, [""]))
+
+    def test_duplicate_clis(self):
+        ps = ["  %d 1 /x/claude --output-format stream-json --resume %s --input-format stream-json" % (CLI, SID),
+              "  %d %d /x/claude --output-format stream-json --resume %s --input-format stream-json" % (LIVE, KERNEL, SID),
+              "  %d 1 /x/claude --output-format stream-json --resume=%s --input-format stream-json" % (CLI2, SID2),
+              "  %d 1 claude --resume %s" % (TOOL, SID),          # a tmux CLI: no stream-json mark, never counted
+              "  garbage line"]
+        self.assertEqual(sb.duplicate_clis(ps, [SID, SID2]), {SID: [CLI, LIVE]})
+        self.assertEqual(sb.duplicate_clis(ps, [SID2]), {})
+
+
+class BootReconcileRows(unittest.TestCase):
+    def test_orphan_duplicate_scope_and_summary_rows(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        _reg(d, SID, "web")
+        sb.append_state(Path(d), SID, "working")
+        ps = ("  %d 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              "  %d %d bash -c tool\n"
+              "  %d 1 /usr/bin/python3 /x/romp/bin/romp-kernel\n"
+              "  %d %d /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              ) % (CLI, SID, TOOL, CLI, KERNEL, LIVE, KERNEL, SID)
+        listing = "romp-session-11111111-%d-1757374800.scope loaded active running claude\n" % CLI
+        def run(argv, **kw):
+            return mock.Mock(stdout=ps if argv == sb.PS_ARGV else (listing if argv == sb.SCOPE_LIST_ARGV else ""), returncode=0)
+        with mock.patch.object(sb.subprocess, "run", side_effect=run), \
+             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: None), \
+             mock.patch.object(sb.SdkBackend, "_pid_alive", lambda self, p: False), \
+             mock.patch.object(sb.SdkBackend, "_ensure", lambda self, sid, **k: None):
+            be._boot_reconcile([sb.read_reg(Path(d), SID)])
+        rows = _events(d)
+        kinds = [r["kind"] for r in rows]
+        self.assertEqual(kinds, ["reconcile.duplicate-cli", "reconcile.orphan-reaped", "reconcile.scope-stopped",
+                                 "reconcile.boot"], kinds)
+        dup, orphan, scope, boot = rows
+        self.assertEqual((dup["sid"], dup["name"], dup["fsid"], dup["n"]), (SID, "web", SID, 2))
+        self.assertEqual(dup["pids"], "%d,%d" % (CLI, LIVE), "listing order, before the reap")
+        self.assertEqual((orphan["sid"], orphan["name"], orphan["cliPid"], orphan["fsid"]), (SID, "web", CLI, SID))
+        self.assertEqual(orphan["tree"], 1, "the orphan's one descendant")
+        self.assertEqual(orphan["scope"], "", "no scope: the cgroup seam read nothing (a scope it did not start is treated as none)")
+        self.assertEqual((scope["unit"], scope["sid8"], scope["cliPid"]),
+                         ("romp-session-11111111-%d-1757374800.scope" % CLI, "11111111", CLI))
+        self.assertEqual((boot["sessions"], boot["resumed"], boot["reaped"], boot["scopesStopped"], boot["toStart"]),
+                         (1, 1, 1, 1, 1))
+        self.assertIn("durationS", boot)
+        # the problems reached the ring as prose (no json tail), the summary did not
+        texts = [r["text"] for r in _ring(be)]
+        self.assertEqual(len(texts), 3, texts)
+        self.assertTrue(all(sb.PROBLEM_ROW_MARK not in t for t in texts))
+        self.assertTrue(texts[0].startswith("boot: 2 claude processes were holding session web's conversation"))
+
+    def test_quiet_boot_writes_the_summary_alone(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        _reg(d, SID, "web")
+        sb.append_state(Path(d), SID, "waiting")
+        with mock.patch.object(sb.subprocess, "run", side_effect=lambda argv, **kw: mock.Mock(stdout="", returncode=0)):
+            be._boot_reconcile([sb.read_reg(Path(d), SID)])
+        rows = _events(d)
+        self.assertEqual([r["kind"] for r in rows], ["reconcile.boot"])
+        self.assertEqual((rows[0]["sessions"], rows[0]["resumed"], rows[0]["reaped"], rows[0]["toStart"]), (1, 0, 0, 0))
+        self.assertEqual(_ring(be), [])
+
+
+class CrashRows(unittest.TestCase):
+    def test_heal_then_loop(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        _reg(d, SID, "web")
+        sess = types.SimpleNamespace(sid=SID, name="web")
+        with mock.patch.object(sb.SdkBackend, "_ensure", lambda self, sid, **k: None):
+            be._heal_cut_session(sess)
+            be._heal_cut_session(sess)
+        rows = _events(d)
+        self.assertEqual([(r["kind"], r["sid"], r["name"], r["attempt"]) for r in rows],
+                         [("crash.heal", SID, "web", 1), ("crash.loop", SID, "web", 2)])
+        texts = [r["text"] for r in _ring(be)]
+        self.assertEqual(len(texts), 2)
+        self.assertIn("resuming with history intact", texts[0])
+        self.assertIn("crash loop", texts[1])
+        self.assertTrue(all(sb.PROBLEM_ROW_MARK not in t for t in texts))
+
+
+class DrainRows(unittest.TestCase):
+    def test_unjoined_sessions_get_a_row_each(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        class Thr:
+            def __init__(self, alive): self._alive = alive
+            def join(self, *_): pass
+            def is_alive(self): return self._alive
+        def sess(sid, name, alive, inflight):
+            return types.SimpleNamespace(sid=sid, name=name, inflight=inflight, ended=False, thread=Thr(alive),
+                                         shutdown=lambda: None)
+        stuck = sess(SID, "web", True, 1)
+        clean = sess(SID2, "api", False, 0)
+        be.sessions = {SID: stuck, SID2: clean}
+        with mock.patch.object(sb.SdkBackend, "_session_cli_pid", lambda self, s: None):
+            res = be.drain(0.01)
+        self.assertEqual((res["stopped"], res["unjoined"], res["reaped"]), (2, 1, 0))
+        rows = _events(d)
+        self.assertEqual([(r["kind"], r["sid"], r["name"], r["inflight"], r["reaped"]) for r in rows],
+                         [("drain.unjoined", SID, "web", 1, False)])
+
+
+class TurnLedgerRow(unittest.TestCase):
+    def _sess(self, fed, first_out=None):
+        s = object.__new__(sb.SdkSession)
+        s.sid, s.name, s.since = SID, "web", 1700000000
+        s._inflight_texts = list(fed)
+        s._turn_opener = "human"
+        s._first_out_t = first_out
+        return s
+
+    def test_row_fields_and_stamps(self):
+        s = self._sess(["do the thing"], first_out=1700000004.25)
+        msg = types.SimpleNamespace(duration_ms=12345, duration_api_ms=9000, num_turns=3, is_error=False)
+        row = s._turn_ledger_row(msg, 0.1234567, {"input_tokens": 10, "output_tokens": 20,
+                                                   "cache_read_input_tokens": 30, "cache_creation_input_tokens": 40},
+                                 now=1700000012.5)
+        self.assertEqual(row["sid"], SID)
+        self.assertEqual(row["name"], "web")
+        self.assertEqual((row["t"], row["fedT"], row["firstOutT"], row["resultT"]),
+                         (1700000012, 1700000000, 1700000004.25, 1700000012.5))
+        self.assertEqual((row["durationMs"], row["apiMs"], row["numTurns"], row["isError"]), (12345, 9000, 3, False))
+        self.assertEqual(row["usd"], 0.123457)
+        self.assertEqual((row["tokIn"], row["tokOut"], row["tokCacheR"], row["tokCacheW"]), (10, 20, 30, 40))
+        self.assertEqual((row["opener"], row["resumeNotice"], row["fedTexts"]), ("human", False, 1))
+
+    def test_resume_notice_marks_the_redo_turn(self):
+        s = self._sess([sb.BOOT_RESUME_NUDGE, "and my queued question"])
+        row = s._turn_ledger_row(types.SimpleNamespace(), None, None, now=1700000001)
+        self.assertTrue(row["resumeNotice"])
+        self.assertEqual(row["fedTexts"], 2)
+        self.assertNotIn("firstOutT", row, "no output yet → no stamp, never a zero")
+        self.assertNotIn("usd", row, "no spend fold → no cost columns, never zeros")
+        s2 = self._sess([sb.CRASH_RESUME_NUDGE])
+        self.assertTrue(s2._turn_ledger_row(types.SimpleNamespace(), now=1)["resumeNotice"])
+
+    def test_append_turn_row(self):
+        d = tempfile.mkdtemp()
+        sb.append_turn_row(Path(d), {"t": 1, "sid": SID})
+        sb.append_turn_row(Path(d), {})            # nothing to write
+        rows = [json.loads(ln) for ln in (Path(d) / sb.TURNS_FILE).read_text().splitlines()]
+        self.assertEqual(rows, [{"t": 1, "sid": SID}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -244,6 +244,19 @@ class DrainRows(unittest.TestCase):
                          [("drain.unjoined", SID, "web", 1, False)])
 
 
+class LedgerRotation(unittest.TestCase):
+    def test_a_full_ledger_rotates_to_one_predecessor(self):
+        d = Path(tempfile.mkdtemp())
+        with mock.patch.object(sb, "LEDGER_ROTATE_BYTES", 60):
+            for i in range(6):
+                sb.append_turn_row(d, {"t": i, "sid": SID})          # ~45 bytes a row: rotates every second row
+        cur = [json.loads(x) for x in (d / sb.TURNS_FILE).read_text().splitlines()]
+        prev = [json.loads(x) for x in (d / (sb.TURNS_FILE + ".1")).read_text().splitlines()]
+        self.assertEqual([r["t"] for r in cur], [4, 5])
+        self.assertEqual([r["t"] for r in prev], [2, 3], "the older predecessor is dropped, never a third file")
+        self.assertFalse((d / (sb.TURNS_FILE + ".2")).exists())
+
+
 class TurnLedgerRow(unittest.TestCase):
     def _sess(self, fed, first_out=None):
         s = object.__new__(sb.SdkSession)

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -253,6 +253,23 @@ class DrainRows(unittest.TestCase):
 
 
 class LedgerRotation(unittest.TestCase):
+    def test_the_rotate_step_runs_under_the_ledger_lock(self):
+        """Review find (2026-09-10): two appenders crossing the size together would rotate twice and lose the
+        predecessor; the stat, the rename and the append share one lock."""
+        d = Path(tempfile.mkdtemp())
+        held = []
+        class Probe:
+            def __enter__(self_):
+                held.append("in")
+            def __exit__(self_, *a):
+                held.append("out")
+        with mock.patch.object(sb, "_LEDGER_LOCK", Probe()), mock.patch.object(sb, "LEDGER_ROTATE_BYTES", 10):
+            sb.append_turn_row(d, {"t": 1, "sid": SID})
+            sb.append_turn_row(d, {"t": 2, "sid": SID})       # rotates
+        self.assertEqual(held, ["in", "out", "in", "out"])
+        self.assertTrue((d / (sb.TURNS_FILE + ".1")).exists())
+        self.assertIsInstance(sb._LEDGER_LOCK, type(sb.threading.Lock()))
+
     def test_a_full_ledger_rotates_to_one_predecessor(self):
         d = Path(tempfile.mkdtemp())
         with mock.patch.object(sb, "LEDGER_ROTATE_BYTES", 60):
@@ -266,16 +283,51 @@ class LedgerRotation(unittest.TestCase):
 
 
 class TurnLedgerRow(unittest.TestCase):
-    def _sess(self, fed, first_out=None):
+    def _sess(self, fed, first_out=None, fed_t=1700000000.125):
         s = object.__new__(sb.SdkSession)
         s.sid, s.name, s.since = SID, "web", 1700000000
         s._inflight_texts = list(fed)
         s._turn_opener = "human"
         s._first_out_t = first_out
+        s._fed_t = fed_t
         return s
 
+    def test_a_turn_the_cli_opened_itself_carries_no_feed_stamps(self):
+        """Review find (2026-09-10): a self-opened turn (a channel message, a task notification, a scheduled
+        prompt) has nothing fed, and the stamps still in memory belong to the PREVIOUS fed turn, so the row
+        must carry neither fedT nor firstOutT rather than hours of feed-to-result."""
+        s = self._sess([], first_out=1700000004.25)
+        row = s._turn_ledger_row(types.SimpleNamespace(), now=1700003600)
+        self.assertNotIn("fedT", row)
+        self.assertNotIn("firstOutT", row)
+        self.assertEqual(row["fedTexts"], 0)
+        # a fed turn whose pop stamp was spent (a mid-turn forward run as its own turn) is unknown too
+        s2 = self._sess(["forwarded"], first_out=1700000004.25, fed_t=None)
+        self.assertNotIn("fedT", s2._turn_ledger_row(types.SimpleNamespace(), now=1700000010))
+
+    def test_fed_stamp_is_the_pop_at_millisecond_resolution(self):
+        s = self._sess(["x"], first_out=1700000004.25, fed_t=1700000000.125)
+        row = s._turn_ledger_row(types.SimpleNamespace(), now=1700000012.5)
+        self.assertEqual(row["fedT"], 1700000000.125, "the pop's own stamp, not `since` truncated to the second")
+        s.since = 1700000000   # `since` stays whole seconds for its other readers and is not what the row reads
+        self.assertEqual(s._turn_ledger_row(types.SimpleNamespace(), now=1700000012.5)["fedT"], 1700000000.125)
+
+    def test_feed_stamps_are_spent_at_the_settle(self):
+        """The ResultMessage branch resets _fed_t and _first_out_t right after the row, in the finally, ahead of
+        the settle; and the row is written from the finally, so a bookkeeping fault (a spend-fold exception)
+        still leaves it. Pinned on the source, which is where the ordering lives."""
+        import inspect
+        src = inspect.getsource(sb.SdkSession._on_message)
+        i_fin = src.index("finally:\n                # T304: one durable row per settled turn")
+        i_row = src.index("append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, delta, turn_u))")
+        i_reset = src.index("self._fed_t = None               # the turn's feed stamps are spent")
+        i_settle = src.index("everything that makes the turn over for the kernel")   # the finally's own comment
+        self.assertTrue(i_fin < i_row < i_reset < i_settle, "row, then the reset, then the settle, all inside the finally")
+        self.assertIn("elif isinstance(msg, ResultMessage):\n            delta = turn_u = None", src,
+                      "the fold's names exist before the branch's try, so the finally can always read them")
+
     def test_row_fields_and_stamps(self):
-        s = self._sess(["do the thing"], first_out=1700000004.25)
+        s = self._sess(["do the thing"], first_out=1700000004.25, fed_t=1700000000)
         msg = types.SimpleNamespace(duration_ms=12345, duration_api_ms=9000, num_turns=3, is_error=False)
         row = s._turn_ledger_row(msg, 0.1234567, {"input_tokens": 10, "output_tokens": 20,
                                                    "cache_read_input_tokens": 30, "cache_creation_input_tokens": 40},
@@ -290,7 +342,7 @@ class TurnLedgerRow(unittest.TestCase):
         self.assertEqual((row["opener"], row["resumeNotice"], row["fedTexts"]), ("human", False, 1))
 
     def test_resume_notice_marks_the_redo_turn(self):
-        s = self._sess([sb.BOOT_RESUME_NUDGE, "and my queued question"])
+        s = self._sess([sb.BOOT_RESUME_NUDGE, "and my queued question"], fed_t=1700000000.5)
         row = s._turn_ledger_row(types.SimpleNamespace(), None, None, now=1700000001)
         self.assertTrue(row["resumeNotice"])
         self.assertEqual(row["fedTexts"], 2)

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -205,6 +205,14 @@ class BootReconcileRows(unittest.TestCase):
         self.assertEqual(_ring(be), [])
 
 
+    def test_a_boot_with_no_sessions_writes_nothing(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        with mock.patch.object(sb.subprocess, "run", side_effect=lambda argv, **kw: mock.Mock(stdout="", returncode=0)):
+            be._boot_reconcile([])
+        self.assertEqual(_events(d), [], "a read-only route's lazy backend build must leave the state dir untouched")
+        self.assertFalse((Path(d) / sb.SESSION_EVENTS_FILE).exists())
+
+
 class CrashRows(unittest.TestCase):
     def test_heal_then_loop(self):
         d = tempfile.mkdtemp(); be = _backend(d)

--- a/tests/test_session_events_route.py
+++ b/tests/test_session_events_route.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""T304: GET /session-events, the kernel's read of the session-event ledger for the dashboard's
+"sessions gone wrong" cue and `romp restart-metrics`: rows newest first since a stamp (default this
+kernel's boot), each naming its host, and `count`, this kernel's problems since its boot (the boot
+sweep's own summary row excluded; never a cross-kernel sum). Token-gated like /api-health. Also pins
+that the manager's `quiet-window` audit note is passed over by the restart-reason walk. Drives the
+REAL Handler over HTTP (the test_color_route.py pattern). Synthetic only."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+km = load_source("romp_kernel_sevents", os.path.join(BIN, "romp-kernel"))
+
+SID = "11111111-2222-4333-8444-000000000304"
+BOOT = 1_700_000_100
+
+
+class SessionEventsRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self._saved = (km.jd.STATE, km._STARTED, km._self_host)
+        km.jd.STATE = self.tmp
+        km._STARTED = float(BOOT)
+        km._self_host = lambda: "TESTHOST"
+        rows = [
+            {"t": BOOT - 30, "pid": 1, "kind": "drain.unjoined", "sid": SID, "name": "web", "inflight": 1, "reaped": False},
+            {"t": BOOT + 1, "pid": 2, "kind": "reconcile.orphan-reaped", "sid": SID, "name": "web", "cliPid": 77},
+            {"t": BOOT + 1, "pid": 2, "kind": "reconcile.boot", "sessions": 3, "resumed": 1, "reaped": 1},
+            {"t": BOOT + 40, "pid": 2, "kind": "crash.heal", "sid": SID, "name": "web", "attempt": 1},
+        ]
+        (self.tmp / "session-events.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\nnot json\n" + json.dumps({"t": "x", "kind": "bad"}) + "\n")
+
+    def tearDown(self):
+        km.jd.STATE, km._STARTED, km._self_host = self._saved
+
+    def _get(self, qs="", token=True):
+        req = urllib.request.Request("http://127.0.0.1:%d/session-events%s" % (self.port, qs),
+                                     headers={"X-Romp-Token": km.TOKEN} if token else {})
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                return r.status, json.loads(r.read().decode())
+        except urllib.error.HTTPError as e:
+            return e.code, None
+
+    def test_rows_newest_first_since_boot_with_host_and_count(self):
+        code, d = self._get()
+        self.assertEqual(code, 200)
+        self.assertEqual(d["host"], "TESTHOST")
+        self.assertEqual(d["bootAt"], BOOT)
+        self.assertEqual(d["count"], 2, "the orphan reap and the crash heal; the boot summary is not a problem")
+        self.assertEqual([r["kind"] for r in d["rows"]], ["crash.heal", "reconcile.boot", "reconcile.orphan-reaped"],
+                         "since the boot, newest first; the previous kernel's drain row is before the boot")
+        self.assertTrue(all(r["host"] == "TESTHOST" for r in d["rows"]))
+
+    def test_since_and_limit(self):
+        code, d = self._get("?since=%d&limit=2" % (BOOT - 60))
+        self.assertEqual(code, 200)
+        self.assertEqual(len(d["rows"]), 2, "the limit caps the newest")
+        self.assertEqual(d["count"], 2, "count is since the boot whatever `since` asks")
+        code, d = self._get("?since=%d" % (BOOT - 60))
+        self.assertEqual([r["kind"] for r in d["rows"]][-1], "drain.unjoined")
+        code, d = self._get("?since=garbage&limit=zero")
+        self.assertEqual(code, 200, "bad parameters fall back to the defaults")
+        self.assertEqual(len(d["rows"]), 3)
+
+    def test_missing_ledger_is_empty_not_an_error(self):
+        (self.tmp / "session-events.jsonl").unlink()
+        code, d = self._get()
+        self.assertEqual((code, d["rows"], d["count"]), (200, [], 0))
+
+    def test_token_required(self):
+        code, _ = self._get(token=False)
+        self.assertIn(code, (401, 403))
+
+
+class QuietWindowNoteIsNotARequest(unittest.TestCase):
+    def test_walk_passes_over_the_quiet_window_row(self):
+        tmp = Path(tempfile.mkdtemp())
+        saved = km.jd.STATE
+        km.jd.STATE = tmp
+        try:
+            now = 1_700_000_500
+            rows = [{"t": now - 20, "action": "remote-restart", "reason": "requested from TESTHOST"},
+                    {"t": now - 3, "action": "quiet-window", "since": now - 600, "waitedS": 597, "reason": "quiet",
+                     "backstop": False, "coalesced": 1, "mode": "all"}]
+            (tmp / "restart-audit.jsonl").write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+            (tmp / "restart-cuts.jsonl").write_text("")
+            self.assertIn("quiet-window", km._NO_RESTART_ACTIONS)
+            rec = km._recent_restart_audit(window=90, now=now, started=now - 1000)
+            self.assertEqual(rec["action"], "remote-restart", "the note is passed over; the request beneath names the cut")
+        finally:
+            km.jd.STATE = saved
+
+
+class KernelSampleOnRestartRows(unittest.TestCase):
+    """T304: the kernel process's own resident size and CPU ride the cut row and the boot row."""
+
+    def test_cut_row_carries_the_sample(self):
+        row = km._restart_cut_row({"cutTurns": []}, now=1)
+        self.assertIsInstance(row["rssKb"], int)
+        self.assertIsInstance(row["cpuS"], float)
+        self.assertGreater(row["cpuS"], 0.0)
+        self.assertEqual(row["cutTurns"], [], "the row's existing fields are untouched")
+
+    def test_boot_row_carries_the_sample(self):
+        tmp = Path(tempfile.mkdtemp())
+        saved = km.RESTART_CUTS_FILE
+        km.RESTART_CUTS_FILE = tmp / "restart-cuts.jsonl"
+        try:
+            km._append_restart_cut(km._restart_cut_row({"cutTurns": []}, now=100))
+            km._append_boot_settled(103.0, 103.4)
+            rows = [json.loads(x) for x in km.RESTART_CUTS_FILE.read_text().splitlines()]
+        finally:
+            km.RESTART_CUTS_FILE = saved
+        boot = rows[-1]
+        self.assertTrue(boot["bootSettled"])
+        self.assertEqual((boot["prevCutT"], boot["outageS"]), (100, 3.0))
+        self.assertIsInstance(boot["rssKb"], int)
+        self.assertIsInstance(boot["cpuS"], float)
+
+    def test_sample_never_raises(self):
+        saved = km._process_stats
+        km._process_stats = lambda: (_ for _ in ()).throw(RuntimeError("no proc"))
+        try:
+            self.assertEqual(km._kernel_process_sample(), {})
+            self.assertNotIn("rssKb", km._restart_cut_row({"cutTurns": []}, now=1))
+        finally:
+            km._process_stats = saved
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #1317, stage 0 ("Measurement comes first"): before any restart behaviour changes, the monitors exist, a baseline is recorded over a deploy week, and the same reader keeps running after the change. Everything here is additive: no restart behaviour changes.

## What lands

**Ledgers (kernel/sdk_backend.py).** Two append-only files under the state directory, written best-effort and rotated at 32 MB with one predecessor kept:
- `session-events.jsonl`: one flat row per thing that went wrong with a session's process (an orphaned CLI ended at boot, a leftover scope stopped, two CLIs holding one conversation, a crash heal or loop, a session the drain's bound left closing) and one summary row per boot sweep that had sessions to reconcile. Written through `problem_row()`, which also puts the prose on the problem ring (the bell) and the kernel-log line as `<prose> ;; problem-row {json}`; the row shape is shared with the lease work (T305), which writes its `lease.*` kinds through the same helper. `SdkBackend._log` gains `ring_text` so the ring stays readable while the log line carries the object.
- `turns.jsonl`: one row per settled turn with event stamps only: the feed pop (`fedT`), the first streamed work atom (`firstOutT`, new: there was no durable stamp for it), the ResultMessage (`resultT`), the CLI's own `durationMs` and `apiMs`, the spend fold's dollars and tokens, and `resumeNotice` for a turn that redoes cut work.

**Restart rows carry the kernel's own size.** `restart-cuts.jsonl`'s cut and boot rows gain `rssKb` and `cpuS`, sampled at the two events the ledger already records, so the kernel's growth between restarts is a series with no sampler of its own.

**The manager's quiet window writes a row.** `quiet-window` in `restart-audit.jsonl` at apply: the wait from parked to restart, whether the fifteen-minute backstop fired, the coalesced requests and the park's drain-hold counts. A note, not a request: the kernel's restart-reason walk lists it in `_NO_RESTART_ACTIONS`.

**`GET /session-events`** (token-gated): the ledger newest first since a stamp, each row with `host`, and `count` since this kernel's boot (never summed across kernels; the dashboard cue is the existing bell, per the T301 vocabulary).

**`romp restart-metrics`** (cli/restart_metrics.py, read-only, no kernel module loaded): turns cut per restart and per window, outage and reconcile times, quiet-window waits and backstop firings, orphans and reaps, duplicate CLIs, crash heals, drain leftovers, lease problems, continuation notices and redo cost, turn latency (feed to result and to first output, beside the state log's one-second series for turns before `turns.jsonl`), machine cuts by cause, per-session memory and CPU from the `romp-session-*` cgroups (ps where there is none), the kernel's own CPU, resident size and idle-cycle share from `/version` and `/perf`, and a live check for two CLIs on one conversation. Day or week windows, `--json` for the figure script, a missing ledger named loudly.

**`scripts/restart_metrics_report.py`**: the before-versus-after figures with cleanplots under uv (not a romp dependency; the script says so when absent): cut turns, restart timing, quiet-window wait, sessions gone wrong, redo cost, turn-latency distribution, session and kernel memory, the kernel's memory at each exit and boot.

## Design points
- Every stamp is an event's time; nothing is sampled by a timer.
- Redo cost comes from `turns.jsonl`; the spend ledger has hour and day buckets per session and no per-turn rows, and the summary says so.
- A boot with no sessions writes no summary row, so a read-only route's lazy backend build leaves the state directory untouched.
- Limits: `turns.jsonl` at about 300 bytes a turn and the 32 MB rotation holds roughly a month here.

## Tests
`tests/test_session_events_ledger.py` (every row kind, the log-line parse, the ring text, rotation, the pure duplicate-CLI helper, the turn row), `tests/test_session_events_route.py` (the route, the audit-walk exclusion, the kernel sample on restart rows), `tests/test_restart_metrics.py` (every parser, the window arithmetic, the cut-to-boot join, the summary text, the live helpers on synthetic cgroup files and ps lines), `tests/test_restart_metrics_report.py` (data shaping always; drawing end to end under cleanplots, skipped with a named reason without it), `tests/manager-quiet-window-audit.test.js`, `tests/romp-restart-metrics.bats`. Docs: `docs/reference.md` (the command table, the ledger and row formats, a Restart metrics section).

Merge order with the stacked lease pull request (T305): this one first; it rebases.