### PR TITLE
Session leases: a CLI is owned by pid, start time and heartbeat, not by its parent (stage 1 of #1317)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -971,10 +971,12 @@ its CLIs are reaped as before, keeping one writer per transcript. The scope swee
 spares an owned CLI's scope, and the interrupt escalation signals the leased CLI
 first, so a re-parented CLI is still stoppable. Every anomaly the census meets (a
 CLI without a lease, a lease without a live process or holder, a stale
-heartbeat, two CLIs on one conversation, a lease from another code version) is
-a problem row: prose in the error center, the same prose with a JSON object on
-the kernel log line, and one JSON line in `session-events.jsonl` under the state
-directory, the shape the restart monitors read.
+heartbeat, a lease from another code version) is a problem row: prose in the
+error center, the same prose with a JSON object on the kernel log line, and one
+JSON line in `session-events.jsonl` under the state directory, the shape the
+restart monitors read. Two CLIs on one conversation is the boot sweep's own row
+there. The CLI takes no lock on a transcript it resumes, so the one writer per
+conversation is entirely the lease's to keep.
 
 A message the kernel cannot handle does not end the session's CLI. The kernel
 handles each streamed message on its own: when a handler raises, it logs the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -951,6 +951,31 @@ re-checks the two facts that need no model call (the second initialize, the
 `--bg` refusal) when run with `ROMP_CLI_PROBE_LIVE=1` and a `claude` on PATH; it
 skips otherwise, as every test that would reach the live CLI must.
 
+Who owns a running CLI is a lease, not its parent process. The kernel writes
+`leases/<sid>.json` under the state directory the moment the SDK connect hands
+it a CLI: the CLI's pid and start time, the kernel's own pid and start time as
+the holder, the kernel's code version, and a heartbeat the kernel refreshes
+every three seconds while the CLI runs; the lease holds for twelve seconds past
+its last beat (the deploy drain hold's cadence: four beats, so it outlives a
+missed beat and not a dead holder). The lease is removed when the CLI's client
+closes, so only a kernel death leaves one behind. A lease is valid when its beat
+is fresh, its holder is alive and its CLI is alive, each identified by pid and
+start time together, never pid alone. The boot reaper reads the leases: a CLI
+with a valid lease is owned by its holder whatever its parent, so a CLI
+re-parented by a wrapper or a debugger (and, later, one kept by a per-session
+host) survives the boot; a CLI parented to a live kernel without a lease is kept
+and reported, so the sessions of a kernel from before leases survive the upgrade
+boot; every other CLI of ours is an orphan and is ended with its tree. Since the
+kernel is the holder, a crashed kernel's leases are invalid at the next boot and
+its CLIs are reaped as before, keeping one writer per transcript. The scope sweep
+spares an owned CLI's scope, and the interrupt escalation signals the leased CLI
+first, so a re-parented CLI is still stoppable. Every anomaly the census meets (a
+CLI without a lease, a lease without a live process or holder, a stale
+heartbeat, two CLIs on one conversation, a lease from another code version) is
+a problem row: prose in the error center, the same prose with a JSON object on
+the kernel log line, and one JSON line in `session-events.jsonl` under the state
+directory, the shape the restart monitors read.
+
 A message the kernel cannot handle does not end the session's CLI. The kernel
 handles each streamed message on its own: when a handler raises, it logs the
 exception type and the failing frame (file, line and function, first on the line

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14750,7 +14750,8 @@ def _sdk_locked():
                 # would sort under a row the previous kernel filed in that same second, and the tail would read
                 # the old kernel's last state as current above the restart row. /version's `started` is the
                 # same start in whole seconds.
-                boot_at=_STARTED)
+                boot_at=_STARTED,
+                code_version=_kernel_sha())   # stamped on every session lease this kernel writes (T305)
             # a limit-shaped judge error envelope pokes ONE exact usage poll (get_usage rides turn
             # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
             # only as good as that file); the backend picks any live login session to ask

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -8607,15 +8607,16 @@ class SdkBackend:
                  "spawnedAt": int(now), "t": now}
         with self._lock:
             self._leases[str(sess.sid)] = (sess, lease)
-            need = self._lease_thread is None or not self._lease_thread.is_alive()
-            if need:
+            if self._lease_thread is None or not self._lease_thread.is_alive():
+                # started UNDER the lock: an unstarted thread reads as not alive, so a second session
+                # connecting in the first's write window would otherwise adopt it too and both would call
+                # start() on one Thread (RuntimeError out of the connect; the review of T305, 2026-09-10)
                 self._lease_thread = threading.Thread(target=self._lease_beat_loop, name="sdk-lease-beat", daemon=True)
+                self._lease_thread.start()
         try:
             write_lease(self.state_dir, lease)
         except Exception as e:
             self._log("lease (%s): write failed: %s" % (sess.name, e), problem=True)
-        if need:
-            self._lease_thread.start()
 
     def _lease_close(self, sess) -> None:
         """The CLI is gone or being ended on purpose (the session's client closed, a drain reap): drop
@@ -8631,12 +8632,20 @@ class SdkBackend:
         with self._lock:
             items = list(self._leases.values())
         for sess, lease in items:
-            lease["t"] = now
-            lease["fsid"] = str(sess.resume_sid or sess.sid)
-            try:
-                write_lease(self.state_dir, lease)
-            except Exception as e:
-                self._log("lease (%s): heartbeat write failed: %s" % (sess.name, e), problem=True)
+            err = None
+            with self._lock:
+                held = self._leases.get(str(sess.sid))
+                if held is None or held[1] is not lease:
+                    continue          # closed since the snapshot: its file is gone and must stay gone (a rewrite
+                #                       would file a false no-live-process row at the next boot; the T305 review)
+                lease["t"] = now
+                lease["fsid"] = str(sess.resume_sid or sess.sid)
+                try:                  # the write sits under the lock so a close can never slip between the
+                    write_lease(self.state_dir, lease)   # membership check and the file landing
+                except Exception as e:
+                    err = e
+            if err is not None:
+                self._log("lease (%s): heartbeat write failed: %s" % (sess.name, err), problem=True)
         return len(items)
 
     def _lease_beat_loop(self) -> None:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3396,10 +3396,14 @@ def _is_kernel_cmd(cmd: str) -> bool:
     return False
 
 
-def find_orphan_clis(ps_lines: list[str], lastsids: list[str], own_pid: int) -> list[int]:
+def find_orphan_clis(ps_lines: list[str], lastsids: list[str], own_pid: int, leases: list[dict] | None = None,
+                     now: float | None = None, start=None, version: str = "") -> list[int]:
     """PIDs of ORPHANED SDK-driven `claude` CLIs holding one of OUR sessions (--resume/--session-id
-    in either flag spelling, + the stream-json mark — see _cli_carries_sid). Orphaned = its PARENT
-    is not a live romp kernel (absent from the listing, or a process that is not a kernel): a live
+    in either flag spelling, + the stream-json mark — see _cli_carries_sid). With `leases` (the
+    session leases on disk, list_leases) the verdict is lease_census's: a CLI with a VALID lease is
+    owned by its holder whatever its parent, and a CLI with no valid lease and no live kernel parent is
+    an orphan (T305; the rules and the anomaly rows are documented there). Without leases, the
+    parentage rule below stands alone. Orphaned = its PARENT is not a live romp kernel (absent from the listing, or a process that is not a kernel): a live
     SDK CLI is always a child of the kernel that spawned it, so only a dead kernel's leftover — a
     zombie writer that would fight the resume for the transcript — has any other parent. The parent
     check is load-bearing: matching on the command line alone let a duplicate backend's reconcile
@@ -3420,6 +3424,8 @@ def find_orphan_clis(ps_lines: list[str], lastsids: list[str], own_pid: int) -> 
     a full service restart, which empties the unit's cgroup (systemd's default KillMode=control-group),
     ever ended such a CLI. The definition now names the property the ppid-1 check approximated. Pure
     (takes PS_ARGV's `ps -axwwo pid=,ppid=,command=` lines) so tests need no live processes."""
+    if leases is not None:
+        return lease_census(ps_lines, lastsids, own_pid, leases, now=now, start=start, version=version)["orphans"]
     procs: dict[int, tuple[int, str]] = {}    # pid -> (ppid, command), in listing order
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
@@ -3469,6 +3475,217 @@ def duplicate_clis(ps_lines: list[str], lastsids: list[str]) -> dict[str, list[i
             seen.setdefault(s, []).append(int(parts[0]))
     return {s: pids for s, pids in seen.items() if len(pids) > 1}
 
+
+# ── SESSION OWNERSHIP LEASES (T305, stage 1 of sessions that survive a kernel restart) ─────────────
+# Who owns a running CLI used to be answered by parentage: a live SDK CLI was a child of the kernel that
+# spawned it, so "parent is a live romp kernel" meant owned and anything else meant an orphan to reap.
+# That fact is wrong the moment a CLI is re-parented on purpose — a wrapper or a debugger between the
+# kernel and the CLI, or (stage 4 of the same program) a per-session host process that outlives the
+# kernel — and the reaper then kills a live session at the next boot. Ownership is now a LEASE: one file
+# per session under STATE/leases/, written by whoever holds the CLI (this kernel, in this stage; the host
+# in stage 4) the moment it knows the CLI's pid, refreshed on a heartbeat, and removed when the holder
+# ends the CLI on purpose. A lease is VALID when its heartbeat is fresh, its holder is alive and its CLI
+# is alive — each process named by pid AND start time, never pid alone (a pid is reused; a start time is
+# not). A CLI with a valid lease is owned by whoever holds it, whatever its parent is; a CLI with no
+# valid lease and no live kernel parent is an orphan. The precedent is the deploy-drain hold below
+# (refresh_drain_hold / DRAIN_HOLD_TTL): a lease the holder refreshes and a fresh boot reads, never a
+# latch. Its cadence is that hold's, exactly: the manager's parked poll refreshes the drain hold every
+# ~3 s and the hold lasts 12 s (four beats), so it outlives a missed beat and not a dead holder; the
+# lease beats every LEASE_HEARTBEAT_S and is fresh for LEASE_TTL_S, the same two numbers. Holder
+# identity is the primary check (a crashed kernel's leases are invalid at the next boot because their
+# holder is gone, so its CLIs are reaped exactly as before and the transcript keeps one writer); the
+# heartbeat is the second line, against a holder that is alive but wedged.
+LEASE_DIR = "leases"
+LEASE_HEARTBEAT_S = 3.0      # the drain hold's poll cadence
+LEASE_TTL_S = 12.0           # DRAIN_HOLD_TTL: four beats, outlives a missed beat, not a dead holder
+LEASE_FIELDS = ("sid", "fsid", "pid", "start", "holder", "version", "t", "spawnedAt", "name")
+
+LEASE_ANOMALIES = ("lease.cli-without-lease",   # an SDK CLI of ours with no valid lease, kept because a live kernel parents it
+                   "lease.no-live-process",     # a lease whose pid is gone, or now names another process
+                   "lease.holder-gone",         # a live CLI whose lease holder is gone (a crashed kernel): reaped
+                   "lease.stale-heartbeat",     # a live CLI whose holder lives but stopped beating: reaped
+                   "lease.version-skew")        # a valid lease written by another code version (owned, reported)
+# Every anomaly is a PROBLEM ROW through problem_row above (the T304 helper): prose on the ring, prose plus the
+# JSON object on the kernel-log line, one JSON line in session-events.jsonl. Two CLIs on one conversation are
+# the boot sweep's own row (reconcile.duplicate-cli, duplicate_clis), filed once, not again here.
+
+
+def proc_start(pid: int, run=None) -> str | None:
+    """The process's start-time identity as text: /proc/<pid>/stat field 22 (clock ticks since boot)
+    where there is a procfs, else `ps -o lstart=` (macOS). None when the pid is gone. Writer and reader
+    run on the same box, so the two forms never meet; a fake pid above pid_max reads None on both."""
+    if os.path.isdir("/proc"):
+        t = _read_starttime(pid)
+        return None if t is None else str(t)
+    run = run or subprocess.run
+    try:
+        out = run(["ps", "-o", "lstart=", "-p", str(int(pid))], capture_output=True, text=True, timeout=5).stdout
+    except Exception:
+        return None
+    out = (out or "").strip()
+    return out or None
+
+
+def lease_path(state_dir, sid: str) -> Path:
+    return Path(state_dir) / LEASE_DIR / (str(sid) + ".json")
+
+
+def write_lease(state_dir, lease: dict) -> None:
+    """Write one session's lease atomically (writer-unique temp + os.replace, as write_reg does: the
+    outgoing and the incoming kernel may touch one sid's files at a restart)."""
+    p = lease_path(state_dir, lease["sid"])
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name("%s.%d.%s.tmp" % (p.name, os.getpid(), uuid.uuid4().hex[:8]))
+    try:
+        tmp.write_text(json.dumps(lease, sort_keys=True))
+        os.replace(tmp, p)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def read_lease(state_dir, sid: str) -> dict | None:
+    """The session's lease as written, or None when there is none (or it does not parse)."""
+    try:
+        d = json.loads(lease_path(state_dir, sid).read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(d, dict) or not d.get("sid"):
+        return None
+    return d
+
+
+def remove_lease(state_dir, sid: str) -> bool:
+    """Drop the session's lease; True when a file was removed."""
+    try:
+        os.unlink(lease_path(state_dir, sid))
+        return True
+    except OSError:
+        return False
+
+
+def list_leases(state_dir) -> list[dict]:
+    """Every parseable lease under STATE/leases/, in name order. A file that does not parse is skipped
+    (a half-written temp is never a `.json`; a corrupt one is nobody's claim)."""
+    d = Path(state_dir) / LEASE_DIR
+    out = []
+    try:
+        names = sorted(os.listdir(d))
+    except OSError:
+        return out
+    for n in names:
+        if not n.endswith(".json"):
+            continue
+        lease = read_lease(state_dir, n[:-len(".json")])
+        if lease is not None:
+            out.append(lease)
+    return out
+
+
+def lease_state(lease: dict, now: float, start=None) -> str:
+    """Why a lease does or does not hold: 'valid', or the first failing check in the order a reader
+    should report it — 'no-live-process' (its CLI pid is gone or now names another process),
+    'holder-gone' (the holder's pid is gone or reused), 'stale-heartbeat' (the holder lives but has
+    not beaten within LEASE_TTL_S). Identity is pid plus start time on both processes; `start` is the
+    identity reader (proc_start), a seam for tests with fake pids. A lease missing a field fails the
+    check that needs it."""
+    start = start or proc_start
+    try:
+        pid, pstart = int(lease.get("pid")), str(lease.get("start") or "")
+    except (TypeError, ValueError):
+        return "no-live-process"
+    if not pstart or start(pid) != pstart:
+        return "no-live-process"
+    holder = lease.get("holder") if isinstance(lease.get("holder"), dict) else {}
+    try:
+        hpid, hstart = int(holder.get("pid")), str(holder.get("start") or "")
+    except (TypeError, ValueError):
+        return "holder-gone"
+    if not hstart or start(hpid) != hstart:
+        return "holder-gone"
+    try:
+        beat = float(lease.get("t") or 0)
+    except (TypeError, ValueError):
+        beat = 0.0
+    if now - beat > LEASE_TTL_S:
+        return "stale-heartbeat"
+    return "valid"
+
+
+def lease_census(ps_lines: list[str], lastsids: list[str], own_pid: int, leases: list[dict],
+                 now: float | None = None, start=None, version: str = "") -> dict:
+    """The ownership verdict over a PS_ARGV listing and the leases on disk. Returns
+    {"orphans": [pid…], "owned": {pid: reason}, "dead_leases": [sid…], "problems": [row…]} where a
+    problem row is a flat dict with `kind` (LEASE_ANOMALIES), `cliPid`, `fsid`, `sid`, `text`, ready for
+    problem_row. Rules, per SDK CLI carrying one of OUR conversation ids (the stream-json mark plus
+    _cli_carries_sid, as before):
+      * a VALID lease naming its pid (lease_state) → owned by that lease's holder, whoever it is; a
+        lease from another code `version` is owned and reported (the deploy-week skew the monitors count);
+      * else a direct child of `own_pid` → owned: the window between this kernel's spawn and its
+        connect-time lease write is by design, and not a row;
+      * else a child of a live romp kernel (_is_kernel_cmd) → owned and REPORTED (`cli-without-lease`):
+        the previous code version's kernel wrote no leases, and its sessions survive the upgrade boot
+        exactly as they did before leases existed;
+      * else an ORPHAN, reported with its lease's failing check when it has a lease (`holder-gone`,
+        `stale-heartbeat`, or `no-live-process` when the lease's identity no longer matches the pid).
+    A lease naming no live CLI at all is `no-live-process` and listed in `dead_leases` for removal. Two
+    CLIs on one conversation id are each judged by their own rule (the boot sweep files that event itself,
+    reconcile.duplicate-cli). Pure on its inputs."""
+    now = time.time() if now is None else now
+    start = start or proc_start
+    procs: dict[int, tuple[int, str]] = {}
+    for ln in ps_lines:
+        parts = ln.strip().split(None, 2)
+        if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
+            continue
+        procs[int(parts[0])] = (int(parts[1]), parts[2])
+    clis = {pid: (ppid, cmd) for pid, (ppid, cmd) in procs.items()
+            if _SDK_CLI_MARK in cmd and _cli_carries_sid(cmd, lastsids)}
+    by_pid: dict[int, dict] = {}
+    for lease in leases:
+        try:
+            by_pid.setdefault(int(lease.get("pid")), lease)
+        except (TypeError, ValueError):
+            continue
+    states = {pid: lease_state(lease, now, start) for pid, lease in by_pid.items()}
+    problems: list[dict] = []
+    def row(kind, text, pid=None, lease=None, fsid=None):
+        problems.append({"kind": kind, "text": text, "cliPid": pid,
+                         "sid": (lease or {}).get("sid"), "fsid": fsid or (lease or {}).get("fsid")})
+    orphans: list[int] = []
+    owned: dict[int, str] = {}
+    for pid, (ppid, cmd) in clis.items():
+        lease = by_pid.get(pid)
+        fsid = cli_sid_of(cmd, lastsids)
+        if lease is not None and states.get(pid) == "valid":
+            owned[pid] = "lease"
+            if version and str(lease.get("version") or "") != version:
+                row("lease.version-skew", "lease of session %s (pid %d) was written by code version %s; this kernel runs %s"
+                    % (str(lease.get("sid") or "")[:8], pid, lease.get("version") or "unknown", version), pid, lease)
+            continue
+        if ppid == own_pid:
+            owned[pid] = "own-child"
+            continue
+        parent = procs.get(ppid)
+        if parent is not None and _is_kernel_cmd(parent[1]):
+            owned[pid] = "kernel-child"
+            row("lease.cli-without-lease", "CLI pid %d on conversation %s is a live kernel's child (pid %d) with no valid lease; kept, not reaped"
+                % (pid, (fsid or "")[:8], ppid), pid, lease, fsid)
+            continue
+        orphans.append(pid)
+        if lease is not None:
+            why = states.get(pid)
+            row("lease." + why, "CLI pid %d of session %s has a lease that does not hold (%s); reaped as an orphan"
+                % (pid, str(lease.get("sid") or "")[:8], why.replace("-", " ")), pid, lease, fsid)
+    for pid, lease in by_pid.items():
+        if pid in clis:
+            continue
+        row("lease.no-live-process", "lease of session %s names pid %d, which is not a live CLI of that session; lease dropped"
+            % (str(lease.get("sid") or "")[:8], pid), pid, lease)
+    dead = [str(lease.get("sid")) for pid, lease in by_pid.items() if pid not in clis]
+    return {"orphans": orphans, "owned": owned, "dead_leases": dead, "problems": problems}
 
 # ENDING A CUT TURN'S WHOLE TREE (T276, the user 2026-09-08). Reaping the orphaned CLI alone left its Bash
 # tool's processes alive: a stress harness's 32 busy loops and a benchmark's 11 (setsid'd from tool shells,
@@ -3577,13 +3794,30 @@ def _read_ppid(pid: int) -> int | None:
         return None
 
 
-def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int) -> int | None:
-    """The LIVE CLI pid holding one of `sids` as a child of `parent_pid` (this kernel), or None.
+def find_session_cli(ps_lines: list[str], sids: list[str], parent_pid: int, lease: dict | None = None,
+                     start=None) -> int | None:
+    """The LIVE CLI pid holding one of `sids` as a child of `parent_pid` (this kernel), or None. With
+    the session's `lease` (T305), the lease's pid comes first: when the listing shows it as an SDK CLI
+    carrying one of `sids` and its start time still matches the lease (`start`, proc_start), that is the
+    session's CLI whatever its parent — a re-parented CLI is reachable by the escalation. Otherwise the
+    child scan below stands.
     The interrupt escalation's (and the drain reap's) target: same signature match as
     find_orphan_clis (_cli_carries_sid + the stream-json mark) but the OPPOSITE parent check — it
     may only signal our own child, never a tmux CLI (no mark), never another kernel's, never an
     orphan (a CLI whose parent is no live kernel — the reaper's territory). Pure (takes
     PS_ARGV's `ps -axwwo pid=,ppid=,command=` lines) so tests need no live processes."""
+    if lease:
+        start = start or proc_start
+        try:
+            lpid, lstart = int(lease.get("pid")), str(lease.get("start") or "")
+        except (TypeError, ValueError):
+            lpid, lstart = None, ""
+        for ln in ps_lines:
+            parts = ln.strip().split(None, 2)
+            if len(parts) < 3 or not parts[0].isdigit() or int(parts[0]) != lpid:
+                continue
+            if _SDK_CLI_MARK in parts[2] and _cli_carries_sid(parts[2], sids) and lstart and start(lpid) == lstart:
+                return lpid
     for ln in ps_lines:
         parts = ln.strip().split(None, 2)
         if len(parts) < 3 or not parts[0].isdigit() or not parts[1].isdigit():
@@ -5678,6 +5912,7 @@ class SdkSession:
                 async with ClaudeSDKClient(options=opts) as client:
                     connected = True
                     self.client = client
+                    self.backend._lease_open(self, client)   # ownership by lease (T305): pid + start time, heartbeat
                     # The handshake IS the "this session is open" event (snapshot `connected`, the flip
                     # the kernel's opening chip stands down on) — push THIS session now. Left to the
                     # periodic cycle, a fresh session wore the opening dots seconds after its CLI was
@@ -5771,6 +6006,10 @@ class SdkSession:
                     # silent by design. Without this the only trace is a kernel stderr line nobody reads.
                     self.backend._record_launch_error(self, e)
                 raise
+            finally:
+                # the client has closed (the SDK's own close ends the process), or never opened: the
+                # lease is dropped either way — only a kernel DEATH leaves one behind (T305)
+                self.backend._lease_close(self)
             if self.ended or not self._reconnect:
                 break        # drain ended on its own (process exit) or we're shutting down → done
 
@@ -8079,9 +8318,13 @@ class SdkBackend:
     def __init__(self, state_dir, claude_bin: str, notify, poke=None, push=None,
                  push_session=None,
                  mcp_config: str | None = None, append_prompt_path: str | None = None,
-                 log=None, reconcile: bool = False, boot_at=None):
+                 log=None, reconcile: bool = False, boot_at=None, code_version=None):
         self.state_dir = Path(state_dir)
         self.claude_bin = claude_bin
+        self.code_version = str(code_version or "")   # the kernel's git sha, stamped on every lease this kernel
+        #                                               writes (lease_census reports a skew as lease.version-skew)
+        self._leases: dict = {}            # sid -> (session, lease dict): the leases this kernel holds (T305)
+        self._lease_thread = None          # the heartbeat, started at the first lease, ends when none are held
         self.thread_wake_model = None      # kernel-installed: model_id -> replacement or None, consulted
         #                                    ONLY when a comment THREAD is explicitly woken (T223 rider) —
         #                                    the catalog lives in the kernel; the backend never imports it
@@ -8334,16 +8577,97 @@ class SdkBackend:
         except Exception as e:
             self._log("awaiting heal (%s): %s" % (sid[:8], e))
 
+    # ── session ownership leases (T305): see the module-level LEASE_* block ──────────────────────
+    def _lease_holder(self) -> dict:
+        """This kernel as a lease holder: its pid and start-time identity."""
+        return {"pid": os.getpid(), "start": proc_start(os.getpid()) or ""}
+
+    def _lease_open(self, sess, client) -> None:
+        """The SDK connect just handed us a CLI: write the session's lease and start the heartbeat if it
+        is not running. The CLI's pid is the SDK transport's subprocess (the one designed handle: the
+        SDK exposes no pid accessor, so the transport's process object is read directly, and a
+        transport that has none is said loudly — the session then runs unleased and the boot reaper
+        judges it by parentage, as before leases)."""
+        pid = None
+        try:
+            pid = client._transport._process.pid
+        except AttributeError:
+            pid = None
+        if not pid:
+            self._log("lease (%s): the SDK transport exposes no CLI pid; the session runs unleased and a boot "
+                      "judges it by parentage" % sess.name, problem=True)
+            return
+        start = proc_start(int(pid))
+        if start is None:
+            self._log("lease (%s): CLI pid %d has no readable start time; the session runs unleased" % (sess.name, pid),
+                      problem=True)
+            return
+        now = time.time()
+        lease = {"sid": str(sess.sid), "fsid": str(sess.resume_sid or sess.sid), "name": str(sess.name),
+                 "pid": int(pid), "start": start, "holder": self._lease_holder(), "version": self.code_version,
+                 "spawnedAt": int(now), "t": now}
+        with self._lock:
+            self._leases[str(sess.sid)] = (sess, lease)
+            need = self._lease_thread is None or not self._lease_thread.is_alive()
+            if need:
+                self._lease_thread = threading.Thread(target=self._lease_beat_loop, name="sdk-lease-beat", daemon=True)
+        try:
+            write_lease(self.state_dir, lease)
+        except Exception as e:
+            self._log("lease (%s): write failed: %s" % (sess.name, e), problem=True)
+        if need:
+            self._lease_thread.start()
+
+    def _lease_close(self, sess) -> None:
+        """The CLI is gone or being ended on purpose (the session's client closed, a drain reap): drop
+        the lease. Idempotent; a session that never held one is a no-op."""
+        with self._lock:
+            self._leases.pop(str(sess.sid), None)
+        remove_lease(self.state_dir, sess.sid)
+
+    def _lease_beat_once(self, now: float | None = None) -> int:
+        """Refresh every held lease's heartbeat (and its conversation id, which a /clear or a fork
+        moves). Returns how many were held."""
+        now = time.time() if now is None else now
+        with self._lock:
+            items = list(self._leases.values())
+        for sess, lease in items:
+            lease["t"] = now
+            lease["fsid"] = str(sess.resume_sid or sess.sid)
+            try:
+                write_lease(self.state_dir, lease)
+            except Exception as e:
+                self._log("lease (%s): heartbeat write failed: %s" % (sess.name, e), problem=True)
+        return len(items)
+
+    def _lease_beat_loop(self) -> None:
+        """The heartbeat thread: one beat every LEASE_HEARTBEAT_S while any lease is held; exits when
+        none is (the next _lease_open starts a new one)."""
+        while True:
+            time.sleep(LEASE_HEARTBEAT_S)
+            if self._lease_beat_once() == 0:
+                with self._lock:
+                    if not self._leases:
+                        self._lease_thread = None
+                        return
+
+    def _lease_problem(self, prob: dict, sid_of: dict) -> None:
+        """File one lease_census anomaly as a problem row (the ring, the kernel log, the ledger)."""
+        sid = prob.get("sid") or sid_of.get(str(prob.get("fsid") or ""))
+        problem_row(self.state_dir, prob.get("text") or prob.get("kind"), prob["kind"], sid=sid, log=self._log,
+                    cliPid=prob.get("cliPid"), fsid=prob.get("fsid"))
+
     def _session_cli_pid(self, session) -> int | None:
-        """The live CLI pid for `session` — a child of THIS kernel resuming its sid (or lastSid, the
-        fork-tracking twin) — for the interrupt escalation's signal. ps-scan through the pure
-        find_session_cli matcher, so the signal can only ever land on our own child. None (logged by
+        """The live CLI pid for `session` — its LEASED CLI when the lease's pid is still that process
+        (T305: a re-parented CLI is reachable), else a child of THIS kernel resuming its sid (or lastSid,
+        the fork-tracking twin) — for the interrupt escalation's signal. ps-scan through the pure
+        find_session_cli matcher, so the signal can only ever land on our own CLI. None (logged by
         the caller) when no such process exists."""
         try:
             ps = subprocess.run(PS_ARGV, capture_output=True, text=True, timeout=10)
             reg = read_reg(self.state_dir, session.sid) or {}
             sids = [session.sid, str(reg.get("lastSid") or "")]
-            return find_session_cli(ps.stdout.splitlines(), sids, os.getpid())
+            return find_session_cli(ps.stdout.splitlines(), sids, os.getpid(), lease=read_lease(self.state_dir, session.sid))
         except Exception as e:
             self._log("session cli pid (%s): %s" % (session.name, e))
             return None
@@ -8440,8 +8764,10 @@ class SdkBackend:
         forced = signal_all(signal.SIGKILL, True) if any(alive(p) for p in targets) else 0
         return {"scope": unit if stopped else None, "signaled": signaled, "forced": forced, "tree": len(targets) - 1}
 
-    def _stop_leftover_scopes(self, lastsids: list[str], run=None) -> int:
-        """Stop the session scopes of OUR sessions whose CLI is not a live child of this kernel (T276):
+    def _stop_leftover_scopes(self, lastsids: list[str], run=None, owned=()) -> int:
+        """Stop the session scopes of OUR sessions whose CLI is not OWNED — `owned` is lease_census's
+        set of owned pids (a valid lease, or a live kernel's child; T305) — and not a live child of this
+        kernel (T276):
         a scope outlives its CLI when a tool's setsid children keep running — exactly the loops the
         pid-only reap left behind once their shells had died and re-parented. Every process in the
         scope belongs to that session by construction. A unit whose pid is this kernel's own child
@@ -8458,8 +8784,9 @@ class SdkBackend:
         stopped = 0
         for unit in session_scope_units(listing.splitlines(), lastsids):
             sp = scope_pid(unit)
-            if sp is not None and (sp == os.getpid() or (self._pid_alive(sp) and _read_ppid(sp) == os.getpid())):
-                continue            # this kernel's live session
+            if sp is not None and (sp in owned or sp == os.getpid()
+                                   or (self._pid_alive(sp) and _read_ppid(sp) == os.getpid())):
+                continue            # an owned CLI's scope, or this kernel's live session
             try:
                 run(["systemctl", "--user", "stop", unit], capture_output=True, text=True, timeout=SCOPE_STOP_TIMEOUT)
                 stopped += 1
@@ -8522,7 +8849,20 @@ class SdkBackend:
                                                                                  ", ".join(str(p) for p in pids)),
                                     "reconcile.duplicate-cli", log=self._log, sid=r0.get("sid"), name=r0.get("name"),
                                     fsid=fsid, pids=",".join(str(p) for p in pids), n=len(pids))
-                    for pid in find_orphan_clis(ps_lines, lastsids, os.getpid()):
+                    # Ownership by lease (T305): a CLI with a valid lease is owned whatever its parent; every
+                    # anomaly is a problem row (lease_census documents the rules and the kinds)
+                    leases = list_leases(self.state_dir)
+                    census = lease_census(ps_lines, lastsids, os.getpid(), leases, version=self.code_version)
+                    sid_of = {str(r.get("lastSid")): str(r.get("sid")) for r in alive if r.get("lastSid")}
+                    for prob in census["problems"]:
+                        self._lease_problem(prob, sid_of)
+                    lease_by_pid = {}
+                    for lease in leases:
+                        try:
+                            lease_by_pid.setdefault(int(lease.get("pid")), lease)
+                        except (TypeError, ValueError):
+                            pass
+                    for pid in census["orphans"]:
                         if pid == os.getpid():
                             continue
                         # the CLI AND its tree (T276): its scope unit, then every process still under it
@@ -8542,8 +8882,16 @@ class SdkBackend:
                                         signaled=res.get("signaled"), forced=res.get("forced"), tree=res.get("tree"))
                         except (ProcessLookupError, PermissionError):
                             pass
-                    # …and the scopes whose CLI already died but whose children live on
-                    scopes_stopped = self._stop_leftover_scopes(lastsids)
+                        if pid in lease_by_pid:            # the lease that did not hold goes with its CLI
+                            remove_lease(self.state_dir, lease_by_pid[pid]["sid"])
+                    for sid in census["dead_leases"]:      # a lease naming no live CLI is nobody's claim
+                        remove_lease(self.state_dir, sid)
+                    # …and the scopes whose CLI already died but whose children live on (an owned CLI's stays)
+                    scopes_stopped = self._stop_leftover_scopes(lastsids, owned=set(census["owned"]))
+                    if census["owned"] or census["problems"]:
+                        by_lease = sum(1 for why in census["owned"].values() if why == "lease")
+                        self._log("boot reconcile: %d CLI(s) owned (%d by lease), %d lease anomaly(ies) filed"
+                                  % (len(census["owned"]), by_lease, len(census["problems"])))
                 except Exception:
                     self._log("boot reconcile: orphan reap failed: %s" % traceback.format_exc())
             resumed, restored, notified = 0, 0, 0
@@ -8934,6 +9282,7 @@ class SdkBackend:
                     kill(pid, signal.SIGKILL)            # a wedged CLI still never outlives us
                 reaped.append("%s(pid %d)" % (s.name, pid))
                 reaped_sids.add(s.sid)
+                self._lease_close(s)                     # ended on purpose: the lease goes with it
             except ProcessLookupError:
                 pass                                     # exited between the join and the reap — fine
             except Exception:
@@ -9647,9 +9996,9 @@ class SdkBackend:
             with self._problem_lock:
                 hit = None
                 if key is not None:
-                    for row in reversed(self._problems):
-                        if row.get("key") == key:
-                            hit = row
+                    for entry in reversed(self._problems):
+                        if entry.get("key") == key:
+                            hit = entry
                             break
                 if hit is not None:
                     hit["count"] = int(hit.get("count") or 1) + 1

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3498,7 +3498,6 @@ def duplicate_clis(ps_lines: list[str], lastsids: list[str]) -> dict[str, list[i
 LEASE_DIR = "leases"
 LEASE_HEARTBEAT_S = 3.0      # the drain hold's poll cadence
 LEASE_TTL_S = 12.0           # DRAIN_HOLD_TTL: four beats, outlives a missed beat, not a dead holder
-LEASE_FIELDS = ("sid", "fsid", "pid", "start", "holder", "version", "t", "spawnedAt", "name")
 
 LEASE_ANOMALIES = ("lease.cli-without-lease",   # an SDK CLI of ours with no valid lease, kept because a live kernel parents it
                    "lease.no-live-process",     # a lease whose pid is gone, or now names another process
@@ -5912,7 +5911,6 @@ class SdkSession:
                 async with ClaudeSDKClient(options=opts) as client:
                     connected = True
                     self.client = client
-                    self.backend._lease_open(self, client)   # ownership by lease (T305): pid + start time, heartbeat
                     # The handshake IS the "this session is open" event (snapshot `connected`, the flip
                     # the kernel's opening chip stands down on) — push THIS session now. Left to the
                     # periodic cycle, a fresh session wore the opening dots seconds after its CLI was
@@ -5920,6 +5918,7 @@ class SdkSession:
                     # create, the ready chip landing at 5-12s with the cycle).
                     self.backend._push_session(self.sid)
                     self._connected.set()   # the control channel exists from here (move() waits on this)
+                    self.backend._lease_open(self, client)   # ownership by lease (T305): pid + start time, heartbeat
                     self._seed_spend_watermarks()   # a fresh CLI process starts its cumulative counters at
                     #   zero, or at what it restores from the resumed transcript's cost-state record
                     # The CLI is demonstrably up, so any recorded launch failure is HISTORY — clear it

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -391,13 +391,16 @@ class RealProcessTree(unittest.TestCase):
         the tester's own scope, which the reaper would refuse anyway), the scope listing is empty, and every
         process this test starts is killed by it."""
         d = tempfile.mkdtemp(); be = _backend(d)
-        for sid in (SID, OTHER):
+        # sids minted per run: the census is box-wide, so two checkouts running this test at once must never
+        # see each other's fake CLIs as theirs (the T305 review)
+        sid_a, sid_b = str(uuid.uuid4()), str(uuid.uuid4())
+        for sid in (sid_a, sid_b):
             _reg(d, sid)
-        (live, live_pg), (stale, stale_pg) = self._fake_cli(SID), self._fake_cli(OTHER)
+        (live, live_pg), (stale, stale_pg) = self._fake_cli(sid_a), self._fake_cli(sid_b)
         now = time.time()
-        sb.write_lease(d, {"sid": SID, "fsid": SID, "pid": live, "start": sb.proc_start(live),
+        sb.write_lease(d, {"sid": sid_a, "fsid": sid_a, "pid": live, "start": sb.proc_start(live),
                            "holder": {"pid": os.getpid(), "start": sb.proc_start(os.getpid())}, "version": "", "t": now})
-        sb.write_lease(d, {"sid": OTHER, "fsid": OTHER, "pid": stale, "start": sb.proc_start(stale),
+        sb.write_lease(d, {"sid": sid_b, "fsid": sid_b, "pid": stale, "start": sb.proc_start(stale),
                            "holder": {"pid": P + 80, "start": "1"}, "version": "", "t": now})
         real_run = subprocess.run
         def run(argv, **kw):
@@ -406,26 +409,26 @@ class RealProcessTree(unittest.TestCase):
         deadline = time.time() + 5
         while time.time() < deadline:
             ps = real_run(sb.PS_ARGV, capture_output=True, text=True, timeout=10).stdout.splitlines()
-            if set(sb.find_orphan_clis(ps, [SID, OTHER], os.getpid())) >= {live, stale}:
+            if set(sb.find_orphan_clis(ps, [sid_a, sid_b], os.getpid())) >= {live, stale}:
                 break
             time.sleep(0.05)
-        self.assertEqual(set(sb.find_orphan_clis(ps, [SID, OTHER], os.getpid())), {live, stale},
+        self.assertEqual(set(sb.find_orphan_clis(ps, [sid_a, sid_b], os.getpid())), {live, stale},
                          "by parentage alone both are orphans")
         with mock.patch.object(sb.subprocess, "run", side_effect=run), \
              mock.patch.object(sb, "_read_cgroup", lambda p: ""):
-            be._boot_reconcile([sb.read_reg(Path(d), s) for s in (SID, OTHER)])
+            be._boot_reconcile([sb.read_reg(Path(d), s) for s in (sid_a, sid_b)])
         deadline = time.time() + 5
         while time.time() < deadline and self._alive(stale):
             time.sleep(0.05)
         self.assertFalse(self._alive(stale), "the CLI whose lease did not hold is gone")
         self.assertTrue(self._alive(live), "the leased CLI survived the boot")
-        self.assertIsNotNone(sb.read_lease(d, SID))
-        self.assertIsNone(sb.read_lease(d, OTHER))
+        self.assertIsNotNone(sb.read_lease(d, sid_a))
+        self.assertIsNone(sb.read_lease(d, sid_b))
         rows = [r for r in (json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines())
                 if r["kind"].startswith("lease.")]
-        self.assertEqual([(r["kind"], r["sid"], r["cliPid"]) for r in rows], [("lease.holder-gone", OTHER, stale)])
+        self.assertEqual([(r["kind"], r["sid"], r["cliPid"]) for r in rows], [("lease.holder-gone", sid_b, stale)])
         # the escalation reaches the surviving, re-parented CLI through its lease
-        self.assertEqual(be._session_cli_pid(_Sess(SID)), live)
+        self.assertEqual(be._session_cli_pid(_Sess(sid_a)), live)
         os.killpg(live_pg, signal.SIGKILL)
 
 

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -285,7 +285,9 @@ class BootReconcileEndsTheTree(unittest.TestCase):
         self.assertIsNotNone(sb.read_lease(d, SID), "the valid lease stays")
         self.assertIsNone(sb.read_lease(d, OTHER), "the lease that did not hold went with its CLI")
         self.assertIsNone(sb.read_lease(d, DEADSID), "a lease naming no live CLI is dropped")
-        rows = [json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines()]
+        # the lease rows among the ledger's (the boot sweep files rows of its own there: reconcile.*)
+        rows = [r for r in (json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines())
+                if r["kind"].startswith("lease.")]
         self.assertEqual(sorted(r["kind"] for r in rows), ["lease.holder-gone", "lease.no-live-process"])
         self.assertEqual({r["sid"] for r in rows}, {OTHER, DEADSID})
         self.assertEqual({r["cliPid"] for r in rows}, {STALE, DEAD})
@@ -419,7 +421,8 @@ class RealProcessTree(unittest.TestCase):
         self.assertTrue(self._alive(live), "the leased CLI survived the boot")
         self.assertIsNotNone(sb.read_lease(d, SID))
         self.assertIsNone(sb.read_lease(d, OTHER))
-        rows = [json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines()]
+        rows = [r for r in (json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines())
+                if r["kind"].startswith("lease.")]
         self.assertEqual([(r["kind"], r["sid"], r["cliPid"]) for r in rows], [("lease.holder-gone", OTHER, stale)])
         # the escalation reaches the surviving, re-parented CLI through its lease
         self.assertEqual(be._session_cli_pid(_Sess(SID)), live)

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -30,6 +30,7 @@ import tempfile
 import time
 import unittest
 import uuid
+import json
 from pathlib import Path
 from unittest import mock
 from romp_load import load_source
@@ -60,6 +61,12 @@ CLI, TOOL, LOOP, BYSTANDER, MANAGER, KERNEL, TMUX, LIVE = (P + 42, P + 50, P + 6
 
 def _backend(d=None):
     return sb.SdkBackend(d or tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+
+
+class _Sess:
+    """The two attributes _session_cli_pid reads."""
+    def __init__(self, sid):
+        self.sid, self.name = sid, "s-" + sid[:4]
 
 
 def _reg(d, sid, **extra):
@@ -237,6 +244,55 @@ class BootReconcileEndsTheTree(unittest.TestCase):
         self.assertIn(["systemctl", "--user", "stop", "romp-session-11111111-%d-1757374800.scope" % CLI], runs,
                       "the dead CLI's scope is stopped: its children live on in the cgroup even after the CLI is gone")
 
+    def test_a_reparented_cli_with_a_valid_lease_survives_the_boot_and_a_stale_one_is_reaped(self):
+        """Ownership by lease (T305): three orphan-SHAPED CLIs (parent pid 1, no kernel), each a different case.
+        LEASED holds a valid lease (holder alive by pid and start time, fresh beat): it survives, its scope is
+        left alone, its lease stays. STALE's lease names a holder that is gone (a crashed kernel): its tree is
+        ended, its scope stopped, its lease dropped, and a holder-gone row is filed. A lease naming DEAD, a pid
+        no process wears, is dropped with a no-live-process row. The start-time reader is the seam: fake pids
+        above pid_max have no /proc entry, so identity comes from the fixture."""
+        LEASED, STALE, DEAD, HOLDER = P + 70, P + 71, P + 72, P + 80
+        d = tempfile.mkdtemp(); be = _backend(d)
+        for sid in (SID, OTHER):
+            _reg(d, sid)
+        now = time.time()
+        sb.write_lease(d, {"sid": SID, "fsid": SID, "pid": LEASED, "start": "1000", "holder": {"pid": HOLDER, "start": "500"},
+                           "version": "", "t": now})
+        sb.write_lease(d, {"sid": OTHER, "fsid": OTHER, "pid": STALE, "start": "1001", "holder": {"pid": P + 81, "start": "1"},
+                           "version": "", "t": now})
+        DEADSID = "33333333-cccc-0000-0000-00000000c305"
+        _reg(d, DEADSID)
+        sb.write_lease(d, {"sid": DEADSID, "fsid": DEADSID, "pid": DEAD, "start": "7", "holder": {"pid": HOLDER, "start": "500"},
+                           "version": "", "t": now})
+        starts = {LEASED: "1000", STALE: "1001", HOLDER: "500"}
+        ps = ("  %d 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              "  %d 1 /x/claude --output-format stream-json --resume %s --input-format stream-json\n"
+              ) % (LEASED, SID, STALE, OTHER)
+        listing = ("romp-session-%s-%d-1757374800.scope loaded active running claude\n"
+                   "romp-session-%s-%d-1757374801.scope loaded active running claude\n") % (SID[:8], LEASED, OTHER[:8], STALE)
+        killed, runs = [], []
+        def run(argv, **kw):
+            runs.append(list(argv)); return mock.Mock(stdout=ps if argv == sb.PS_ARGV else (listing if argv == sb.SCOPE_LIST_ARGV else ""), returncode=0)
+        regs = [sb.read_reg(Path(d), s) for s in (SID, OTHER, DEADSID)]
+        with mock.patch.object(sb.subprocess, "run", side_effect=run), \
+             mock.patch.object(sb.os, "kill", side_effect=lambda p, s: killed.append((p, s))), \
+             mock.patch.object(sb, "proc_start", lambda p, run=None: starts.get(p)), \
+             mock.patch.object(sb.SdkBackend, "_pid_alive", lambda self, p: False):
+            be._boot_reconcile(regs)
+        self.assertEqual([p for p, _ in killed], [STALE], "only the CLI whose lease did not hold is signaled")
+        stops = [a[-1] for a in runs if a[:3] == ["systemctl", "--user", "stop"]]
+        self.assertEqual(stops, ["romp-session-%s-%d-1757374801.scope" % (OTHER[:8], STALE)], "the leased CLI's scope is spared")
+        self.assertIsNotNone(sb.read_lease(d, SID), "the valid lease stays")
+        self.assertIsNone(sb.read_lease(d, OTHER), "the lease that did not hold went with its CLI")
+        self.assertIsNone(sb.read_lease(d, DEADSID), "a lease naming no live CLI is dropped")
+        rows = [json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines()]
+        self.assertEqual(sorted(r["kind"] for r in rows), ["lease.holder-gone", "lease.no-live-process"])
+        self.assertEqual({r["sid"] for r in rows}, {OTHER, DEADSID})
+        self.assertEqual({r["cliPid"] for r in rows}, {STALE, DEAD})
+        self.assertTrue(all(r["pid"] == os.getpid() for r in rows), "pid is the writing kernel's")
+        self.assertTrue({r["text"] for r in rows} <= {p["text"] for p in be.problems()}, "the ring carries the prose alone")
+        self.assertTrue(all(sb.PROBLEM_ROW_MARK not in p["text"] for p in be.problems()))
+
 
 @unittest.skipUnless(LINUX, "real processes on Linux with procfs")
 class RealProcessTree(unittest.TestCase):
@@ -301,6 +357,73 @@ class RealProcessTree(unittest.TestCase):
         self.assertIsNotNone(cli.poll(), "the CLI is gone")
         self.assertIsNone(by.poll(), "the bystander outside the tree was never signaled")
         self.assertGreaterEqual(out["tree"], 1)
+
+    def _fake_cli(self, sid):
+        """A process that LOOKS like an SDK CLI of ours to the ps scan (the stream-json mark and the sid in its argv)
+        and is a true ORPHAN shape: started by an intermediate shell that prints its pid and exits, so the fake CLI
+        re-parents to the subreaper (the user manager, or pid 1), never to this test — a child of the tester would be
+        the census's own-child case. Two commands in the fake CLI, so bash does not exec into the sleep and lose the
+        argv; the sleep is its descendant. The intermediate leads a new process group that the fake CLI and its
+        sleep inherit, so one killpg at cleanup ends whatever the reaper left. Returns (pid, pgid)."""
+        inter = subprocess.Popen(["bash", "-c", 'bash -c "sleep 300; :" romp-t305-fake-cli --input-format stream-json --resume "$1" '
+                                  '</dev/null >/dev/null 2>&1 & echo $!', "x", sid],
+                                 stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, start_new_session=True)
+        out, _ = inter.communicate(timeout=10)
+        pid = int(out.strip())
+        def sweep():
+            try:
+                os.killpg(inter.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        self.addCleanup(sweep)
+        return pid, inter.pid
+
+    @staticmethod
+    def _alive(pid):
+        return os.path.exists("/proc/%d" % pid) and "zombie" not in open("/proc/%d/status" % pid).read().split("State:")[1][:20]
+
+    def test_real_processes_a_leased_reparented_cli_survives_the_boot_and_a_stale_leased_one_is_reaped(self):
+        """The acceptance shape of T305 with real processes: two orphan-shaped CLIs; the one whose lease this test
+        HOLDS (the test process is the holder, alive by pid and start time) survives the boot reconcile, the one
+        whose lease names a holder that is gone is ended. The cgroup seam is pinned empty (the fake CLIs inherit
+        the tester's own scope, which the reaper would refuse anyway), the scope listing is empty, and every
+        process this test starts is killed by it."""
+        d = tempfile.mkdtemp(); be = _backend(d)
+        for sid in (SID, OTHER):
+            _reg(d, sid)
+        (live, live_pg), (stale, stale_pg) = self._fake_cli(SID), self._fake_cli(OTHER)
+        now = time.time()
+        sb.write_lease(d, {"sid": SID, "fsid": SID, "pid": live, "start": sb.proc_start(live),
+                           "holder": {"pid": os.getpid(), "start": sb.proc_start(os.getpid())}, "version": "", "t": now})
+        sb.write_lease(d, {"sid": OTHER, "fsid": OTHER, "pid": stale, "start": sb.proc_start(stale),
+                           "holder": {"pid": P + 80, "start": "1"}, "version": "", "t": now})
+        real_run = subprocess.run
+        def run(argv, **kw):
+            return mock.Mock(stdout="", returncode=0) if argv == sb.SCOPE_LIST_ARGV else real_run(argv, **kw)
+        # the ps scan must see both before the census reads it
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            ps = real_run(sb.PS_ARGV, capture_output=True, text=True, timeout=10).stdout.splitlines()
+            if set(sb.find_orphan_clis(ps, [SID, OTHER], os.getpid())) >= {live, stale}:
+                break
+            time.sleep(0.05)
+        self.assertEqual(set(sb.find_orphan_clis(ps, [SID, OTHER], os.getpid())), {live, stale},
+                         "by parentage alone both are orphans")
+        with mock.patch.object(sb.subprocess, "run", side_effect=run), \
+             mock.patch.object(sb, "_read_cgroup", lambda p: ""):
+            be._boot_reconcile([sb.read_reg(Path(d), s) for s in (SID, OTHER)])
+        deadline = time.time() + 5
+        while time.time() < deadline and self._alive(stale):
+            time.sleep(0.05)
+        self.assertFalse(self._alive(stale), "the CLI whose lease did not hold is gone")
+        self.assertTrue(self._alive(live), "the leased CLI survived the boot")
+        self.assertIsNotNone(sb.read_lease(d, SID))
+        self.assertIsNone(sb.read_lease(d, OTHER))
+        rows = [json.loads(l) for l in (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines()]
+        self.assertEqual([(r["kind"], r["sid"], r["cliPid"]) for r in rows], [("lease.holder-gone", OTHER, stale)])
+        # the escalation reaches the surviving, re-parented CLI through its lease
+        self.assertEqual(be._session_cli_pid(_Sess(SID)), live)
+        os.killpg(live_pg, signal.SIGKILL)
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -402,6 +402,58 @@ class LeaseRules(unittest.TestCase):
         self.assertEqual(len(be.problems()) - base, 1)
         self.assertIn("exposes no CLI pid", be.problems()[-1]["text"])
 
+    def test_two_sessions_opening_at_once_start_one_heartbeat_thread_and_neither_crashes(self):
+        # the T305 review: the beat thread used to be assigned under the lock and STARTED outside it; a second
+        # opener in the first's write window read the unstarted thread as not alive, replaced it, and both then
+        # started one Thread (RuntimeError out of the connect). Two opens held inside the write window at once.
+        d = tempfile.mkdtemp(); be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        gate, started, errors = threading.Event(), [], []
+        def loop(self_):
+            started.append(threading.current_thread().name); gate.wait(10)
+        barrier = threading.Barrier(2, timeout=10)
+        real_write = sb.write_lease
+        def write_inside_the_window(state_dir, lease):
+            barrier.wait()                                  # both opens are between the lock and the write
+            real_write(state_dir, lease)
+        client = types.SimpleNamespace(_transport=types.SimpleNamespace(_process=types.SimpleNamespace(pid=os.getpid())))
+        def open_(sid):
+            try:
+                be._lease_open(types.SimpleNamespace(sid=sid, name=sid[-2:], resume_sid=None), client)
+            except Exception as e:
+                errors.append(e)
+        sids = ("11111111-2222-3333-4444-0000000000a1", "11111111-2222-3333-4444-0000000000a2")
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", loop), mock.patch.object(sb, "write_lease", write_inside_the_window):
+            ts = [threading.Thread(target=open_, args=(s,)) for s in sids]
+            for t in ts: t.start()
+            for t in ts: t.join(15)
+        gate.set()
+        self.assertEqual(errors, [], "no open may raise")
+        self.assertEqual(len(started), 1, "one heartbeat thread per backend, started once")
+        self.assertEqual(sorted(l["sid"] for l in sb.list_leases(d)), sorted(sids))
+
+    def test_a_close_during_a_beat_leaves_no_lease_file_behind(self):
+        # the T305 review: a beat snapshot is taken under the lock but each write ran without it, so a beat could
+        # rewrite a lease that _lease_close had just popped and unlinked, and the next boot filed a false
+        # no-live-process row for a session that ended cleanly. The close lands mid-beat, from another thread.
+        d = tempfile.mkdtemp(); be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        client = types.SimpleNamespace(_transport=types.SimpleNamespace(_process=types.SimpleNamespace(pid=os.getpid())))
+        a = types.SimpleNamespace(sid="11111111-2222-3333-4444-0000000000b1", name="a", resume_sid=None)
+        b = types.SimpleNamespace(sid="11111111-2222-3333-4444-0000000000b2", name="b", resume_sid=None)
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self: None):
+            be._lease_open(a, client); be._lease_open(b, client)
+        real_write = sb.write_lease; closer = []
+        def write_then_close_b(state_dir, lease):
+            real_write(state_dir, lease)
+            if lease["sid"] == a.sid:                       # b ends cleanly while the beat is between a and b
+                t = threading.Thread(target=be._lease_close, args=(b,)); t.start(); closer.append(t)
+                time.sleep(0.2)
+        with mock.patch.object(sb, "write_lease", write_then_close_b):
+            be._lease_beat_once()
+        for t in closer: t.join(5)
+        self.assertIsNone(sb.read_lease(d, b.sid), "the beat must not rewrite a lease the close removed")
+        self.assertIsNotNone(sb.read_lease(d, a.sid))
+        self.assertEqual(be._lease_beat_once(), 1)
+
     def test_source_pins_the_connect_writes_the_close_drops_and_the_cadence_is_the_drain_holds(self):
         src = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
         self.assertIn("self.backend._lease_open(self, client)", src)

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -205,6 +205,212 @@ class FindOrphanClis(unittest.TestCase):
         self.assertEqual(sb.find_orphan_clis(lines, [self.SID], self.OWN), [5001, 5002, 5003])
 
 
+class LeaseRules(unittest.TestCase):
+    """Ownership by LEASE (T305, stage 1 of sessions surviving a kernel restart): a CLI with a valid lease —
+    fresh heartbeat, holder alive by pid and start time, CLI alive by pid and start time — is owned whatever
+    its parent; a CLI with no valid lease and no live kernel parent is an orphan. Every anomaly is a problem
+    row. Pure: lease_census takes the ps listing, the leases and a start-time reader, so no process, pid or
+    second is real here. Synthetic ids throughout."""
+    SID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"     # the conversation id (lastSid) the CLI's argv carries
+    RSID = "11111111-2222-3333-4444-555555555555"    # the romp sid the lease is filed under
+    OWN = 31337                                      # this kernel's pid in the fixtures
+    HOLDER = 777                                     # the lease holder's pid in the fixtures
+    NOW = 1_800_000_000.0
+
+    def _cli(self, pid, ppid, sid=None):
+        return " %d %d /x/claude --output-format stream-json --resume=%s --input-format stream-json" % (pid, ppid, sid or self.SID)
+
+    def _lease(self, pid, start="1000", holder=None, t=None, version="abc12345", sid=None):
+        return {"sid": sid or self.RSID, "fsid": self.SID, "pid": pid, "start": start,
+                "holder": holder if holder is not None else {"pid": self.HOLDER, "start": "50"},
+                "version": version, "t": self.NOW if t is None else t}
+
+    def _census(self, lines, leases, starts, version=""):
+        return sb.lease_census(lines, [self.SID], self.OWN, leases, now=self.NOW, start=lambda p: starts.get(p), version=version)
+
+    def test_a_reparented_cli_with_a_valid_lease_is_owned_whatever_its_parent(self):
+        # launchd and the `systemd --user` manager: the two orphan shapes the parentage rule reaped, each owned here
+        for parent in (" 1 0 /sbin/launchd", " 901 1 /usr/lib/systemd/systemd --user"):
+            ppid = int(parent.split()[0])
+            c = self._census([parent, self._cli(700, ppid)], [self._lease(700)], {700: "1000", self.HOLDER: "50"})
+            self.assertEqual((c["orphans"], c["owned"], c["problems"], c["dead_leases"]), ([], {700: "lease"}, [], []), parent)
+        # find_orphan_clis, handed the leases, gives the census's verdict
+        self.assertEqual(sb.find_orphan_clis([" 1 0 /sbin/launchd", self._cli(700, 1)], [self.SID], self.OWN,
+                                             [self._lease(700)], now=self.NOW, start={700: "1000", self.HOLDER: "50"}.get), [])
+        # …and without them, the parentage rule alone, unchanged
+        self.assertEqual(sb.find_orphan_clis([" 1 0 /sbin/launchd", self._cli(700, 1)], [self.SID], self.OWN), [700])
+
+    def test_a_holder_that_is_gone_makes_the_cli_an_orphan_with_a_row(self):
+        # the holder's pid has no start time (gone) — a crashed kernel's lease: reaped as before leases
+        c = self._census([self._cli(701, 1)], [self._lease(701)], {701: "1000"})
+        self.assertEqual(c["orphans"], [701])
+        self.assertEqual([(p["kind"], p["sid"], p["cliPid"]) for p in c["problems"]], [("lease.holder-gone", self.RSID, 701)])
+        # a holder pid worn by ANOTHER process now (start time differs) is gone too: pid alone is never identity
+        c = self._census([self._cli(701, 1)], [self._lease(701)], {701: "1000", self.HOLDER: "51"})
+        self.assertEqual((c["orphans"], [p["kind"] for p in c["problems"]]), ([701], ["lease.holder-gone"]))
+
+    def test_a_stale_heartbeat_makes_the_cli_an_orphan_and_the_boundary_is_the_ttl(self):
+        starts = {702: "1000", self.HOLDER: "50"}
+        c = self._census([self._cli(702, 1)], [self._lease(702, t=self.NOW - sb.LEASE_TTL_S - 0.5)], starts)
+        self.assertEqual((c["orphans"], [p["kind"] for p in c["problems"]]), ([702], ["lease.stale-heartbeat"]))
+        c = self._census([self._cli(702, 1)], [self._lease(702, t=self.NOW - sb.LEASE_TTL_S)], starts)
+        self.assertEqual((c["orphans"], c["owned"]), ([], {702: "lease"}), "a beat exactly TTL old still holds")
+
+    def test_a_lease_whose_pid_now_names_another_process_is_no_live_process(self):
+        # the lease's CLI died and its pid was reused — by an SDK CLI of ours here, the hardest case: the new
+        # process has no valid lease (identity differs), so it is judged on its own and the row says why
+        c = self._census([self._cli(703, 1)], [self._lease(703, start="1000")], {703: "2000", self.HOLDER: "50"})
+        self.assertEqual((c["orphans"], [p["kind"] for p in c["problems"]]), ([703], ["lease.no-live-process"]))
+        # …and by an unrelated process: no CLI to reap, the lease is dead and listed for removal
+        c = self._census([" 1 0 /sbin/launchd", " 704 1 sleep 300"], [self._lease(704)], {704: "1000", self.HOLDER: "50"})
+        self.assertEqual((c["orphans"], c["dead_leases"], [p["kind"] for p in c["problems"]]),
+                         ([], [self.RSID], ["lease.no-live-process"]))
+
+    def test_this_kernels_own_child_without_a_lease_is_owned_and_not_a_row(self):
+        # the window between this kernel's spawn and its connect-time lease write is by design
+        c = self._census([self._cli(705, self.OWN)], [], {})
+        self.assertEqual((c["orphans"], c["owned"], c["problems"]), ([], {705: "own-child"}, []))
+
+    def test_a_live_kernels_child_without_a_lease_is_kept_and_reported(self):
+        # the previous code version's kernel wrote no leases: its sessions survive the upgrade boot, with a row
+        lines = [" 901 1 /usr/lib/systemd/systemd --user", " 600 901 /usr/bin/python3.12 /x/romp/bin/romp-kernel", self._cli(706, 600)]
+        c = self._census(lines, [], {})
+        self.assertEqual((c["orphans"], c["owned"]), ([], {706: "kernel-child"}))
+        self.assertEqual([(p["kind"], p["cliPid"], p["fsid"]) for p in c["problems"]], [("lease.cli-without-lease", 706, self.SID)])
+
+    def test_no_lease_and_no_kernel_parent_is_todays_plain_orphan(self):
+        c = self._census([" 901 1 /usr/lib/systemd/systemd --user", self._cli(707, 901)], [], {})
+        self.assertEqual((c["orphans"], c["owned"], c["problems"]), ([707], {}, []))
+
+    def test_a_lease_from_another_code_version_is_owned_and_reported(self):
+        starts = {708: "1000", self.HOLDER: "50"}
+        c = self._census([self._cli(708, 1)], [self._lease(708, version="old00000")], starts, version="new00000")
+        self.assertEqual((c["orphans"], c["owned"], [p["kind"] for p in c["problems"]]), ([], {708: "lease"}, ["lease.version-skew"]))
+        c = self._census([self._cli(708, 1)], [self._lease(708, version="new00000")], starts, version="new00000")
+        self.assertEqual(c["problems"], [])
+        c = self._census([self._cli(708, 1)], [self._lease(708, version="old00000")], starts)   # no version to compare: no row
+        self.assertEqual(c["problems"], [])
+
+    def test_two_clis_on_one_conversation_are_reported_and_each_judged_alone(self):
+        c = self._census([self._cli(709, 1), self._cli(710, 1)], [self._lease(709)], {709: "1000", self.HOLDER: "50"})
+        self.assertEqual((c["owned"], c["orphans"]), ({709: "lease"}, [710]))
+        self.assertEqual([(p["kind"], p["fsid"]) for p in c["problems"]], [("lease.duplicate-cli", self.SID)])
+
+    def test_lease_state_names_the_first_failing_check(self):
+        st = lambda starts: (lambda p: starts.get(p))
+        L = self._lease(1)
+        self.assertEqual(sb.lease_state(L, self.NOW, st({1: "1000", self.HOLDER: "50"})), "valid")
+        self.assertEqual(sb.lease_state(L, self.NOW, st({self.HOLDER: "50"})), "no-live-process")
+        self.assertEqual(sb.lease_state(L, self.NOW, st({1: "1000"})), "holder-gone")
+        self.assertEqual(sb.lease_state(dict(L, t=self.NOW - sb.LEASE_TTL_S - 1), self.NOW, st({1: "1000", self.HOLDER: "50"})), "stale-heartbeat")
+        self.assertEqual(sb.lease_state({"sid": "x"}, self.NOW, st({})), "no-live-process", "a missing field fails its check")
+        self.assertEqual(sb.lease_state(dict(L, holder="junk"), self.NOW, st({1: "1000"})), "holder-gone")
+
+    def test_find_session_cli_reaches_the_leased_cli_first_then_the_child_scan(self):
+        lines = [" 1 0 /sbin/launchd", self._cli(711, 1), self._cli(712, self.OWN)]
+        lease = self._lease(711)
+        self.assertEqual(sb.find_session_cli(lines, [self.SID], self.OWN, lease=lease, start={711: "1000"}.get), 711,
+                         "the re-parented leased CLI is the escalation's target")
+        self.assertEqual(sb.find_session_cli(lines, [self.SID], self.OWN, lease=lease, start={711: "9999"}.get), 712,
+                         "the lease's pid now names another process: the child scan stands")
+        self.assertEqual(sb.find_session_cli(lines, [self.SID], self.OWN), 712)
+        # a lease naming a pid that is not an SDK CLI of ours never wins
+        self.assertEqual(sb.find_session_cli([" 713 1 sleep 300", self._cli(712, self.OWN)], [self.SID], self.OWN,
+                                             lease=self._lease(713), start={713: "1000"}.get), 712)
+
+    def test_lease_files_round_trip_list_and_skip_junk(self):
+        d = tempfile.mkdtemp()
+        self.assertEqual(sb.list_leases(d), [])
+        sb.write_lease(d, self._lease(5))
+        self.assertEqual(sb.read_lease(d, self.RSID)["pid"], 5)
+        self.assertEqual([l["sid"] for l in sb.list_leases(d)], [self.RSID])
+        (Path(d) / sb.LEASE_DIR / "junk.json").write_text("{not json")
+        (Path(d) / sb.LEASE_DIR / "x.json.1.abcd.tmp").write_text("{}")
+        self.assertEqual(len(sb.list_leases(d)), 1, "a corrupt lease and a temp file are nobody's claim")
+        self.assertTrue(sb.remove_lease(d, self.RSID))
+        self.assertFalse(sb.remove_lease(d, self.RSID))
+        self.assertIsNone(sb.read_lease(d, self.RSID))
+
+    def test_proc_start_names_a_live_process_and_not_a_fake_pid(self):
+        me = sb.proc_start(os.getpid())
+        self.assertTrue(me)
+        self.assertEqual(sb.proc_start(os.getpid()), me, "a stable identity")
+        self.assertIsNone(sb.proc_start(_P + 424242), "a pid above pid_max is nobody")
+        # the no-procfs path (macOS): `ps -o lstart=` through the run seam
+        ran = []
+        def run(argv, **kw):
+            ran.append(argv); return types.SimpleNamespace(stdout="Thu Sep 10 17:22:37 2026\n")
+        with mock.patch.object(sb.os.path, "isdir", lambda p: False if p == "/proc" else os.path.isdir(p)):
+            self.assertEqual(sb.proc_start(4242, run=run), "Thu Sep 10 17:22:37 2026")
+            self.assertEqual(ran, [["ps", "-o", "lstart=", "-p", "4242"]])
+            self.assertIsNone(sb.proc_start(4243, run=lambda *a, **k: types.SimpleNamespace(stdout="")))
+
+    def test_problem_row_is_the_log_line_the_ring_prose_and_the_ledger_row(self):
+        d = tempfile.mkdtemp(); logs = []
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=logs.append)
+        del logs[:]                                     # the construction's own setup lines are not the subject
+        base = len(be.problems())                       # …nor its own problem (the SDK is not importable here)
+        prose = "CLI pid 5 of session 11111111 has a lease that does not hold (holder gone); reaped as an orphan"
+        line = sb.problem_row(d, prose, "lease.holder-gone", sid=self.RSID, log=be._log, cliPid=5, t=1700000000, fsid=None)
+        row = sb.parse_problem_row(line)
+        self.assertEqual((row["kind"], row["t"], row["sid"], row["cliPid"], row["pid"], row["text"]),
+                         ("lease.holder-gone", 1700000000, self.RSID, 5, os.getpid(), prose))
+        self.assertNotIn("fsid", row, "a None field is dropped")
+        self.assertTrue(line.startswith(prose + sb.PROBLEM_ROW_MARK), line)
+        self.assertEqual(logs, [line], "the kernel log gets the whole line")
+        self.assertEqual([r["text"] for r in be.problems()[base:]], [prose], "the ring gets the prose alone")
+        ledger = (Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines()
+        self.assertEqual(json.loads(ledger[0]), row, "the ledger row is the same object")
+        self.assertIsNone(sb.parse_problem_row("a plain line"))
+        self.assertIsNone(sb.parse_problem_row("x" + sb.PROBLEM_ROW_MARK + "{not json"))
+        # a summary (ring=False): the ledger and the log, no ring entry
+        sb.problem_row(d, "boot summary", "reconcile.boot", log=be._log, ring=False)
+        self.assertEqual((len(be.problems()) - base, len(logs), len((Path(d) / sb.SESSION_EVENTS_FILE).read_text().splitlines())), (1, 2, 2))
+        # an unwritable ledger never raises
+        self.assertTrue(sb.problem_row(os.path.join(d, "no", "such", "dir"), "p", "k.x"))
+
+    def test_the_backend_writes_beats_and_drops_the_lease_of_a_connected_session(self):
+        d = tempfile.mkdtemp(); logs = []
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=logs.append, code_version="abc12345")
+        del logs[:]                                     # the construction's own setup lines are not the subject
+        base = len(be.problems())
+        sess = types.SimpleNamespace(sid=self.RSID, name="web", resume_sid=self.SID)
+        client = types.SimpleNamespace(_transport=types.SimpleNamespace(_process=types.SimpleNamespace(pid=os.getpid())))
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self: None):   # the thread exits at once here
+            be._lease_open(sess, client)
+        lease = sb.read_lease(d, self.RSID)
+        self.assertEqual((lease["pid"], lease["fsid"], lease["version"], lease["holder"]["pid"], lease["name"]),
+                         (os.getpid(), self.SID, "abc12345", os.getpid(), "web"))
+        self.assertEqual((lease["start"], lease["holder"]["start"]), (sb.proc_start(os.getpid()),) * 2)
+        self.assertEqual(sb.lease_state(lease, time.time()), "valid")
+        self.assertEqual(sb.lease_census([" %d %d /x/claude --resume=%s --input-format stream-json" % (os.getpid(), 1, self.SID)],
+                                         [self.SID], self.OWN, [lease])["owned"], {os.getpid(): "lease"})
+        # a beat refreshes the heartbeat and follows a conversation flip (a /clear, a fork)
+        sess.resume_sid = "99999999-8888-7777-6666-555555555555"
+        self.assertEqual(be._lease_beat_once(now=lease["t"] + 5), 1)
+        again = sb.read_lease(d, self.RSID)
+        self.assertEqual((again["t"], again["fsid"]), (lease["t"] + 5, sess.resume_sid))
+        be._lease_close(sess)
+        self.assertIsNone(sb.read_lease(d, self.RSID))
+        self.assertEqual(be._lease_beat_once(), 0)
+        be._lease_close(sess)                           # idempotent
+        self.assertEqual(logs, [])
+        # a transport with no pid: loud, and the session runs unleased
+        be._lease_open(sess, types.SimpleNamespace())
+        self.assertIsNone(sb.read_lease(d, self.RSID))
+        self.assertEqual(len(be.problems()) - base, 1)
+        self.assertIn("exposes no CLI pid", be.problems()[-1]["text"])
+
+    def test_source_pins_the_connect_writes_the_close_drops_and_the_cadence_is_the_drain_holds(self):
+        src = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
+        self.assertIn("self.backend._lease_open(self, client)", src)
+        self.assertIn("self.backend._lease_close(self)", src)
+        self.assertIn("self._lease_close(s)", src, "the drain's reap drops the lease it ends")
+        self.assertIn("code_version=_kernel_sha()", open(os.path.join(BIN, "romp-kernel")).read())
+        self.assertEqual(sb.LEASE_TTL_S, sb.SdkBackend.DRAIN_HOLD_TTL, "the drain hold's TTL, exactly")
+        self.assertEqual(sb.LEASE_TTL_S, 4 * sb.LEASE_HEARTBEAT_S, "four beats: outlives a missed beat, not a dead holder")
+
+
 class QueuePersistence(unittest.TestCase):
     def test_enqueue_and_unqueue_mirror_to_registry(self):
         d = tempfile.mkdtemp()

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -291,10 +291,11 @@ class LeaseRules(unittest.TestCase):
         c = self._census([self._cli(708, 1)], [self._lease(708, version="old00000")], starts)   # no version to compare: no row
         self.assertEqual(c["problems"], [])
 
-    def test_two_clis_on_one_conversation_are_reported_and_each_judged_alone(self):
+    def test_two_clis_on_one_conversation_are_each_judged_alone_with_no_row_of_their_own(self):
+        # the boot sweep files that event itself (reconcile.duplicate-cli, duplicate_clis); the census judges each
         c = self._census([self._cli(709, 1), self._cli(710, 1)], [self._lease(709)], {709: "1000", self.HOLDER: "50"})
-        self.assertEqual((c["owned"], c["orphans"]), ({709: "lease"}, [710]))
-        self.assertEqual([(p["kind"], p["fsid"]) for p in c["problems"]], [("lease.duplicate-cli", self.SID)])
+        self.assertEqual((c["owned"], c["orphans"], c["problems"]), ({709: "lease"}, [710], []))
+        self.assertEqual(sb.duplicate_clis([self._cli(709, 1), self._cli(710, 1)], [self.SID]), {self.SID: [709, 710]})
 
     def test_lease_state_names_the_first_failing_check(self):
         st = lambda starts: (lambda p: starts.get(p))

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -174,9 +174,12 @@ class BootReconcileRows(unittest.TestCase):
             be._boot_reconcile([sb.read_reg(Path(d), SID)])
         rows = _events(d)
         kinds = [r["kind"] for r in rows]
-        self.assertEqual(kinds, ["reconcile.duplicate-cli", "reconcile.orphan-reaped", "reconcile.scope-stopped",
-                                 "reconcile.boot"], kinds)
-        dup, orphan, scope, boot = rows
+        # the LIVE CLI is a live kernel's child with no lease: kept, and reported by the lease census (T305,
+        # the upgrade boot's transitional row) between the duplicate row and the reap
+        self.assertEqual(kinds, ["reconcile.duplicate-cli", "lease.cli-without-lease", "reconcile.orphan-reaped",
+                                 "reconcile.scope-stopped", "reconcile.boot"], kinds)
+        dup, unleased, orphan, scope, boot = rows
+        self.assertEqual((unleased["sid"], unleased["cliPid"], unleased["fsid"]), (SID, LIVE, SID))
         self.assertEqual((dup["sid"], dup["name"], dup["fsid"], dup["n"]), (SID, "web", SID, 2))
         self.assertEqual(dup["pids"], "%d,%d" % (CLI, LIVE), "listing order, before the reap")
         self.assertEqual((orphan["sid"], orphan["name"], orphan["cliPid"], orphan["fsid"]), (SID, "web", CLI, SID))
@@ -189,7 +192,7 @@ class BootReconcileRows(unittest.TestCase):
         self.assertIn("durationS", boot)
         # the problems reached the ring as prose (no json tail), the summary did not
         texts = [r["text"] for r in _ring(be)]
-        self.assertEqual(len(texts), 3, texts)
+        self.assertEqual(len(texts), 4, texts)
         self.assertTrue(all(sb.PROBLEM_ROW_MARK not in t for t in texts))
         self.assertTrue(texts[0].startswith("boot: 2 claude processes were holding session web's conversation"))
 


### PR DESCRIPTION
Part of #1317 (sessions that survive a kernel restart), stage 1 of the staged plan: ownership by lease and identity, no host yet.

## What changes

**A lease file per session** at `STATE/leases/<sid>.json`, written by the kernel the moment the SDK connect hands it the CLI, removed when the CLI's client closes (so only a kernel death leaves one behind). Fields: the romp sid and the conversation id the argv carries, the CLI's pid and start time, the holder's pid and start time (the kernel in this stage; the host in stage 4), the kernel's code version, a spawn stamp, a heartbeat.

**Heartbeat on the drain hold's cadence, exactly.** One backend thread beats every 3 s while any lease is held; a lease is fresh for 12 s (`LEASE_TTL_S == DRAIN_HOLD_TTL`: four beats, so it outlives a missed beat and not a dead holder). Holder identity is the primary check and the heartbeat the second line, against a holder that is alive but wedged.

**The reaper reads leases** (`lease_census`, wired into `find_orphan_clis` when given the leases). Per SDK CLI carrying one of our conversation ids:
- a valid lease (fresh beat, holder alive by pid and start time, CLI alive by pid and start time) means owned by its holder, whatever its parent; a lease from another code version is owned and reported;
- else a direct child of this kernel is owned (the spawn-to-lease-write window, by design, no row);
- else a child of a live kernel is kept and reported (`lease.cli-without-lease`): the previous code version's kernel wrote no leases, and its sessions survive the upgrade boot as they did before;
- everything else is an orphan and is ended with its tree, its lease removed.
Since the kernel is the holder, a crashed kernel's leases are invalid at the next boot and its CLIs are reaped as before, keeping one writer per transcript.

**Identity is pid plus start time, never pid alone**: `/proc/<pid>/stat` field 22 on Linux, `ps -o lstart=` elsewhere (`proc_start`).

**The scope sweep** spares an owned CLI's scope. **The interrupt escalation** (`find_session_cli`) signals the leased CLI first when its identity still matches, so a re-parented CLI is stoppable. **The drain** drops the lease of any CLI it reaps.

**Every anomaly is a problem row**: prose on the error center's ring, the same prose plus one JSON object on the kernel log line, one JSON line in `STATE/session-events.jsonl`. Kinds: `lease.cli-without-lease`, `lease.no-live-process`, `lease.holder-gone`, `lease.stale-heartbeat`, `lease.version-skew`. Two CLIs on one conversation is the boot sweep's own row (`reconcile.duplicate-cli`), filed once. The row shape and the `problem_row` helper come from the restart monitors' work (T304, branch `romp_metrics-t304`); the lease code carries no helper of its own. The CLI takes no lock on a transcript it resumes (the stage 3 probe), so the one writer per conversation is entirely the lease's to keep.

## Merge order

This layer was stacked on the restart monitors' work (T304, #1340) while that was open; #1340 has merged, so this pull request now targets `main` and its four commits are rebased onto it. That work owns the `problem_row` helper, the `session-events.jsonl` ledger and `_log`'s `ring_text` seam; the lease code carries no helper of its own. One of its tests (`test_session_events_ledger.py`, the boot reconcile rows) gains the `lease.cli-without-lease` row its live-kernel-child fixture now earns. Nothing here changes the reap signalling itself (`_end_cli_tree`) or the parentage rule when no leases exist: `find_orphan_clis` without `leases` is byte-for-byte the previous verdict.

## Review fixes (fourth commit)

The heartbeat thread starts under the lock (two sessions connecting at once could both adopt one unstarted thread and start it twice); a beat re-checks membership and writes under the lock (it could rewrite a lease a concurrent close had just removed and file a false row at the next boot); the real-process test mints its sids per run (two checkouts running it at once would reap each other's fake CLIs). Each with a pin.

## Tests

- `tests/test_sdk_lifecycle_hardening.py::LeaseRules`: every census rule as pure fixtures (valid lease owned whatever the parent, holder gone by absence and by pid reuse, stale heartbeat at the TTL boundary, pid reuse on the CLI, own child, a live kernel's unleased child kept and reported, version skew, two CLIs on one conversation), `lease_state`'s ordering, `find_session_cli` with a lease, the lease file round trip, `proc_start` on a live pid and a fake one above pid_max plus the no-procfs path, the problem row's three writes, the backend's lease open, beat and close with a fake transport, source pins for the connect write and the close drop.
- `tests/test_cut_turn_tree_kill.py`: the boot reconcile with a leased re-parented CLI spared (scope too), a stale one reaped with its scope and lease, a dead lease dropped, the rows filed; and real processes on Linux, re-parented through an exiting intermediate, one surviving the boot by its lease and one reaped, the escalation reaching the survivor through its lease.
- Hermetic: per-test state dirs, synthetic ids, fake pids above pid_max, the cgroup seam pinned empty, every process the tests start killed by them.

## Docs

`docs/reference.md`, "What survives a restart": the lease, the reaper's rule and the problem rows.

Tier: feature
