### PR TITLE
The host-down notice's swirl spins only while romp is dialing the host, keyed on the kernel's tunnel row and the relay socket, never a timer (T309)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -18911,6 +18911,35 @@ def _expected_restart_status(r, st, rsha, now):
     return st
 
 
+def _row_dialing(r):
+    """Is romp trying to reach this host RIGHT NOW? True while an ssh dial is spawned and not yet confirmed
+    (status "starting"; "connecting" is the checked-in row's birth state) or while the supervisor's health
+    request to the host is in flight (_dialing, set around the poll below). False while the row waits out
+    its backoff (status "down" until nextTry). The dashboard's host-down notice spins
+    its swirl on exactly this (the user 2026-09-10, who wanted a spinner that means romp is trying right
+    now, never one that spins whatever happens); federation reads it from the /tunnels row every few
+    seconds and repaints on a change. The mark is on for ANY polled row during its pass's requests, an up
+    row included (milliseconds against an answering host); the notice only ever shows for a down one."""
+    return bool(r.get("_dialing")) or (r.get("status") or "") in ("starting", "connecting")
+
+
+@contextlib.contextmanager
+def _dialing_mark(r):
+    """The row wears the in-flight mark (_dialing, read by _row_dialing) for the supervisor pass's health
+    requests to its host: on from the first round-trip until the last returns, HOWEVER the block ends. The
+    clear is the context manager's exit, a finally by construction, because a mark left on by an exception
+    (a socket the port check could not build) would read as dialing through the row's whole next backoff, the
+    one state the mark exists to distinguish (review find, 2026-09-10). The polls themselves stay inline in
+    _tunnel_supervisor, whose source a dozen tests pin line by line."""
+    with _remotes_lock:
+        r["_dialing"] = True
+    try:
+        yield
+    finally:
+        with _remotes_lock:
+            r["_dialing"] = False
+
+
 def _remote_public(r):
     """The API view of a remote row — everything the browser needs, minus the Popen and minus the remote's
     credential. The browser reaches a remote through /remote/<host>/ws, where _remote_ws injects that
@@ -18981,6 +19010,9 @@ def _remote_public(r):
             # forever-retry must never look identical to a healthy idle row, so the popover can say how
             # many dials have failed and when the next one lands.
             "fails": int(r.get("fails") or 0), "nextTry": int(r.get("next_try") or 0),
+            # a dial or health request to the host in flight at this moment (_row_dialing): the host-down
+            # notice's swirl spins on it as of the dashboard's last poll, sits still between attempts
+            "dialing": _row_dialing(r),
             # not live: everything above derived from kernel_sha / the peer's declared tier is a memory of
             # the last successful exchange. lastOk is when that was (0 = never seen up this process).
             "stale": stale, "lastOk": int(r.get("last_ok") or 0),
@@ -18993,6 +19025,8 @@ _remotes_saved_sig = None   # signature of the last blob written — lets the su
 
 
 _NOT_SAVED = ("proc",       # the live Popen
+              "_dialing",   # a health request to the host in flight right now (_row_dialing): this pass's
+              #               mark, meaningless to the next boot
               "usage",      # a remote's rate-limit snapshot: re-polled a minute after any boot, and
               "_usage_at",  # persisting it would rewrite this 0600 credential file every minute forever
               "_views_at",  # the /views poll's stamp, restamped once a minute per up host (REMOTE_VIEWS_EVERY):
@@ -22459,16 +22493,17 @@ def _tunnel_supervisor():
                         _mark_known_unreachable(r["host"])
                 if skip:
                     continue
-                up = _port_open(r["local_port"])              # outside the lock (socket round-trip)
-                rows = _poll_remote_sessions(r) if up else None   # its session rows: ids for the wake-router, names for notifications
-                sids = None if rows is None else [x.get("id") for x in rows]
-                rver = _poll_remote_version(r) if up else None   # the code the remote is running (drift check)
-                rsha = (rver or {}).get("sha")
-                # …and which Claude account it burns, so the rail can draw a second set of bars when it is
-                # a different one (self-rate-limited to a minute — these windows are hours wide)
-                ruse = _poll_remote_usage(r) if up else None
-                rviews = _poll_remote_views(r) if up else None   # tag federation v0: the read half
-                rapih = _poll_remote_api_health(r) if up else None   # its API-health frame, for the shell's per-host map (T301)
+                with _dialing_mark(r):   # the pass's health requests: the row reads dialing meanwhile (_row_dialing)
+                    up = _port_open(r["local_port"])              # outside the lock (socket round-trip)
+                    rows = _poll_remote_sessions(r) if up else None   # its session rows: ids for the wake-router, names for notifications
+                    sids = None if rows is None else [x.get("id") for x in rows]
+                    rver = _poll_remote_version(r) if up else None   # the code the remote is running (drift check)
+                    rsha = (rver or {}).get("sha")
+                    # …and which Claude account it burns, so the rail can draw a second set of bars when it is
+                    # a different one (self-rate-limited to a minute — these windows are hours wide)
+                    ruse = _poll_remote_usage(r) if up else None
+                    rviews = _poll_remote_views(r) if up else None   # tag federation v0: the read half
+                    rapih = _poll_remote_api_health(r) if up else None   # its API-health frame, for the shell's per-host map (T301)
                 with _remotes_lock:
                     if r["host"] not in _remotes:
                         continue

--- a/tests/test_kernel_tunnel_truth.py
+++ b/tests/test_kernel_tunnel_truth.py
@@ -8,6 +8,7 @@ popover with the next step. The /send remote forward reports a dead far kernel i
 Synthetic fixtures only."""
 import json
 import os
+import inspect
 import unittest
 from unittest import mock
 from romp_load import load_source
@@ -208,6 +209,39 @@ class RecoveryCounter(unittest.TestCase):
                         "noted before the pass overwrites the status")
         self.assertIn('r["_poll_miss"] = True', src, "a real silent poll leaves its mark")
         self.assertEqual(src.count('r["_demand_miss"] = True'), 2, "both the ssh row's and the checked-in peer's timeout preload")
+
+    def test_the_row_says_when_romp_is_dialing_the_host_right_now(self):
+        """The host-down notice's swirl spins on `dialing` (the user 2026-09-10, who wanted a spinner that means
+        romp is trying right now): true while an ssh dial is spawned and unconfirmed ("starting"; "connecting"
+        is a checked-in row's birth state) or while the pass's health requests to the host are in flight, false
+        while the row waits out its backoff. The in-flight mark is set around the requests, cleared however
+        they end, and never saved: it describes this pass, not the host."""
+        row = lambda **kw: dict({"host": "TESTHOST", "kernel_port": 1, "local_port": 1}, **kw)
+        self.assertTrue(km._row_dialing(row(status="starting")), "an ssh dial spawned, not yet confirmed")
+        self.assertTrue(km._row_dialing(row(status="connecting")), "a checked-in row before its first poll")
+        self.assertTrue(km._row_dialing(row(status="down", _dialing=True)), "the health request is in flight")
+        self.assertFalse(km._row_dialing(row(status="down")), "waiting out the backoff: still")
+        self.assertFalse(km._row_dialing(row(status="down", _dialing=False)))
+        self.assertFalse(km._row_dialing(row(status="up")), "an up row between passes: nothing in flight")
+        self.assertFalse(km._row_dialing(row(status="error")))
+        self.assertIn("_dialing", km._NOT_SAVED, "a per-pass mark, never written to the remotes file")
+        src = open(os.path.join(BIN, "romp-kernel"), encoding="utf-8").read()
+        self.assertIn('"dialing": _row_dialing(r),', src, "_remote_public serves it on the /tunnels row")
+        sup = inspect.getsource(km._tunnel_supervisor)
+        self.assertIn("with _dialing_mark(r):", sup, "the pass's health requests run under the mark")
+        self.assertLess(sup.index("with _dialing_mark(r):"), sup.index('up = _port_open(r["local_port"])'), "…entered before the first round-trip")
+        # the mark's lifetime, behaviourally: on inside the block, off once it ends…
+        r = row(status="down")
+        with km._dialing_mark(r):
+            self.assertTrue(r["_dialing"], "on while the round-trips run")
+        self.assertFalse(r["_dialing"], "…and off once they returned")
+        # …and off when the block RAISES (the port check builds its socket outside its own try: fd exhaustion
+        # unwinds through here), so a row never reads dialing through its next backoff
+        with self.assertRaises(OSError):
+            with km._dialing_mark(r):
+                raise OSError("out of file descriptors")
+        self.assertFalse(r["_dialing"], "a raise clears the mark too")
+
 
 
 class ExpectedRestart(unittest.TestCase):

--- a/ui/webview/federation-single-instance.test.ts
+++ b/ui/webview/federation-single-instance.test.ts
@@ -30,7 +30,9 @@ test("hostOf/bareId live in host-prefix.ts (side-effect-free) and federation re-
   assert.match(hp, /export function bareId\(id: string\): string \{/);
   assert.doesNotMatch(hp, /import /, "host-prefix.ts must stay import-free — it is the safe home");
   const fed = fs.readFileSync(path.join(UI, "federation.ts"), "utf8");
-  assert.match(fed, /import \{ hostOf, bareId \} from "\.\/host-prefix";/);
+  // hostDialLive (2026-09-10) is the third pure helper federation takes from the safe home: the host-down
+  // notice's "is romp dialing right now" rule, over the row and socket state federation publishes
+  assert.match(fed, /import \{ hostOf, bareId, hostDialLive \} from "\.\/host-prefix";/);
   assert.match(fed, /export \{ hostOf, bareId \};/);
   const pv = fs.readFileSync(path.join(UI, "preview.ts"), "utf8");
   assert.match(pv, /import \{ hostOf, bareId \} from "\.\/host-prefix";/);

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -14,7 +14,7 @@
 import { adoptArrivals, applyViewOrder, applyViewOrderTo, churnSwaps, healOrder, pruneViewOrder,
          readViewOrder, writeViewOrder, VIEW_ORDER_KEY, VIEW_ORDER_EVENT } from "./view-order";
 import { adoptViews, capsAdopts, announcedSeq, announcedAfter } from "./views-writes";
-import { hostOf, bareId } from "./host-prefix";
+import { hostOf, bareId, hostDialLive } from "./host-prefix";
 import { installPerfTelemetry, classifyFrame, type RompPerf } from "./perf-telemetry";
 
 export const SEP = ":";
@@ -877,6 +877,7 @@ export class FederationManager {
   private perHostTlBars: Record<string, any> = {}; // last timeline {type:"bars"} detail per host
   private hostSeq: string[] = [LOCAL]; // local first, then attach order — fixes the group order in the strip
   private downHosts = new Set<string>(); // attached, but its tunnel isn't up: what's on screen is a memory
+  private dialingHosts = new Set<string>(); // the kernel is dialing or health-checking these right now (the row's `dialing`)
   // each host's recovery counter as last seen (/tunnels upSeq, T291b): the kernel bumps it when a row that had
   // missed polls answers again, so a link that failed a request while its status never left "up" still has a
   // recovery event; a change is treated as that host coming back (hostUp). A first observation is not a bump.
@@ -953,6 +954,10 @@ export class FederationManager {
       // panel says "loading sessions…" from the same set
       pending: () => this.pendingFor(),
       lastSeen: (h: string) => this.lastSeen[h] || 0,
+      // is a dial attempt to this host in flight right now? The host-down notice's swirl spins on exactly
+      // this (host-prefix.ts hostDialLive: the socket's CONNECTING state), and romp:hostDial below says
+      // when it changes — on the dial, the open and the close, never on a timer
+      dialing: (h: string) => { const c = this.conns.get(h); return hostDialLive(this.dialingHosts.has(h), c && c.ws ? c.ws.readyState : null); },
     };
     // A drag in ANY pane rewrites the arrangement; every other pane hears it through `storage` (which fires
     // only in other same-origin contexts) and this one through the writer's own CustomEvent. Both land here,
@@ -1048,6 +1053,7 @@ export class FederationManager {
         dead.onopen = dead.onmessage = dead.onclose = dead.onerror = null;
         try { dead.close(); } catch (e) { /* already dying */ }
         c.ws = null;
+        this.dialEvent(c.host, false);   // its onclose is detached above, so the attempt's end is said HERE (the swirl must not spin on a dead dial)
         this.connect(c);   // settings queued on the conn meanwhile ride the fresh socket's open (flushPending)
       } else if (v === "redial") {
         this.connect(c);
@@ -1528,6 +1534,12 @@ export class FederationManager {
     if (recovered.length) window.dispatchEvent(new MessageEvent("message", { data: { type: "hostUp", hosts: recovered } }));
     this.downHosts = down;
     if (changed) window.dispatchEvent(new Event("romp-hosts"));   // panes repaint their disconnected marks
+    // …and whether the kernel is TRYING right now (the row's `dialing`, kernel.py _row_dialing): the host-down
+    // notice's swirl spins on it. Published on a change only, through the same event the relay socket's own
+    // dial transitions use, so one listener sees every reason the state can move
+    const dialing = new Set([...want.keys()].filter((h) => want.get(h).dialing === true));
+    for (const h of new Set([...dialing, ...this.dialingHosts])) if (dialing.has(h) !== this.dialingHosts.has(h)) this.dialEvent(h, dialing.has(h));
+    this.dialingHosts = dialing;
   }
 
   private openRemote(host: string, live: boolean): void {
@@ -1574,7 +1586,9 @@ export class FederationManager {
       return;
     }
     conn.ws = ws;
+    this.dialEvent(conn.host, true);   // a dial attempt is in flight: the host-down notice's swirl spins
     ws.onopen = () => {
+      this.dialEvent(conn.host, false);
       // settings queued while the socket was down go out FIRST — on the open event itself, never a
       // timer — so nothing sent after the reconnect can overtake them (see flushPending). That is
       // also why the relay-up dispatch below comes AFTER the flush: the chat's upload re-ship rides
@@ -1605,6 +1619,7 @@ export class FederationManager {
       this.inbound(conn.host, msg);
     };
     ws.onclose = (ev: CloseEvent) => {
+      this.dialEvent(conn.host, false);   // the attempt ended (refused, or the socket dropped): still until the redial
       this.diag("hostconn", { host: conn.host, ev: "close", code: ev.code, clean: ev.wasClean, detached: conn.closed });
       if (!conn.closed) setTimeout(() => this.connect(conn), 2000); // reconnect a dropped remote
     };
@@ -1613,6 +1628,17 @@ export class FederationManager {
         ws.close();
       } catch (e) {}
     };
+  }
+
+  /** One host's dial state changed: its relay socket's dial began (CONNECTING) or ended (open, closed, or
+   *  abandoned by the watchdog), or the kernel's /tunnels poll reported its `dialing` flipping. The chat's
+   *  host-down notice repaints its swirl on this event alone (render.ts syncHostOfflineFoot); the state
+   *  itself is read back through __rompFed.dialing, so a listener that missed an event still paints the
+   *  truth. Dispatch must never break the relay. */
+  private dialEvent(host: string, dialing: boolean): void {
+    try {
+      window.dispatchEvent(new CustomEvent("romp:hostDial", { detail: { host, dialing } }));
+    } catch (e) { /* nothing to do */ }
   }
 
   private closeRemote(host: string): void {

--- a/ui/webview/host-dial-live.test.ts
+++ b/ui/webview/host-dial-live.test.ts
@@ -1,0 +1,91 @@
+// The host-down notice at a disconnected remote's transcript tail ("<host> is disconnected — this is the
+// last romp got from it. Reconnecting.") wears the romp swirl AFTER "Reconnecting", spinning only while
+// a dial attempt to that host is actually in flight (the user 2026-09-10, who wanted it dynamic and honest:
+// romp trying right now, never a spinner that spins whatever happens). The rule is pure over the relay
+// socket's state federation publishes (hostDialLive: CONNECTING), the repaint is keyed on federation's
+// dial events (romp:hostDial on the dial, the open and the close), never on a timer, and the sentence
+// stays the one wording it had. The pure rule and its reader are executed here against a stub manager;
+// the per-surface wiring is pinned at source, the way host-offline.test.ts pins the mark.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { hostDialLive, hostIsDialing } from "./host-prefix";
+
+const UI = path.resolve(process.cwd(), "..", "ui", "webview");
+const read = (f: string) => fs.readFileSync(path.join(UI, f), "utf8");
+const RENDER = read("render.ts");
+const FED = read("federation.ts");
+const CSS = read("styles.css");
+
+const withFed = (fed: any, fn: () => void) => {
+  const g = globalThis as any;
+  const prev = g.__rompFed;
+  g.__rompFed = fed;
+  try { fn(); } finally { if (prev === undefined) delete g.__rompFed; else g.__rompFed = prev; }
+};
+
+test("the notice is live while the kernel says it is dialing, or the relay socket is CONNECTING; still otherwise", () => {
+  // the kernel's row: an ssh dial spawned and unconfirmed, or a health request in flight (kernel.py _row_dialing)
+  assert.equal(hostDialLive(true, null), true, "the kernel is trying right now: a down host has no socket, and this is the case that matters");
+  assert.equal(hostDialLive(false, null), false, "the kernel waits out its backoff: still");
+  assert.equal(hostDialLive(undefined, null), false, "a kernel too old to publish the flag: never live on its account");
+  // this page's own relay socket (the case the kernel reports up but the socket is down: a remote kernel restart)
+  assert.equal(hostDialLive(false, 0), true, "WebSocket.CONNECTING: a dial attempt is in flight");
+  assert.equal(hostDialLive(false, 1), false, "OPEN: connected, nothing to spin for");
+  assert.equal(hostDialLive(false, 2), false, "CLOSING");
+  assert.equal(hostDialLive(false, 3), false, "CLOSED: waiting between attempts — the swirl sits still");
+  assert.equal(hostDialLive(false, undefined), false);
+});
+
+test("hostIsDialing reads the manager's published dial state for the sid's host, and nothing else", () => {
+  withFed({ down: () => ["TESTHOST"], lastSeen: () => 0, dialing: (h: string) => h === "TESTHOST" }, () => {
+    assert.equal(hostIsDialing("TESTHOST:1111-2222"), true);
+    assert.equal(hostIsDialing("otherhost:1111-2222"), false);
+    assert.equal(hostIsDialing("11111111-2222-3333-4444-555555555555"), false, "a local session has no host to dial");
+    assert.equal(hostIsDialing(""), false);
+    assert.equal(hostIsDialing(null), false);
+  });
+  // a manager too old to publish the state, or none at all: never live
+  withFed({ down: () => ["TESTHOST"], lastSeen: () => 0 }, () => assert.equal(hostIsDialing("TESTHOST:1111"), false));
+  const g = globalThis as any;
+  const prev = g.__rompFed;
+  delete g.__rompFed;
+  try { assert.equal(hostIsDialing("TESTHOST:1111"), false); } finally { if (prev !== undefined) g.__rompFed = prev; }
+});
+
+test("federation publishes the dial state through the pure rule and says when it changes, on the socket's events and the kernel's poll", () => {
+  assert.match(FED, /dialing: \(h: string\) => \{ const c = this\.conns\.get\(h\); return hostDialLive\(this\.dialingHosts\.has\(h\), c && c\.ws \? c\.ws\.readyState : null\); \}/);
+  // the kernel's word, read in the same /tunnels poll that publishes the down set, an event only on a change
+  assert.match(FED, /const dialing = new Set\(\[\.\.\.want\.keys\(\)\]\.filter\(\(h\) => want\.get\(h\)\.dialing === true\)\);/);
+  assert.match(FED, /for \(const h of new Set\(\[\.\.\.dialing, \.\.\.this\.dialingHosts\]\)\) if \(dialing\.has\(h\) !== this\.dialingHosts\.has\(h\)\) this\.dialEvent\(h, dialing\.has\(h\)\);/,
+    "one event per host whose state changed, carrying its true value: a repaint per change, not per poll");
+  // the three transitions, in the connect path: the dial itself, the open, the close — no timer anywhere
+  assert.match(FED, /conn\.ws = ws;\n\s*this\.dialEvent\(conn\.host, true\);/, "a dial began the moment the socket exists");
+  assert.match(FED, /ws\.onopen = \(\) => \{\n\s*this\.dialEvent\(conn\.host, false\);/, "…and ended on open");
+  assert.match(FED, /ws\.onclose = \(ev: CloseEvent\) => \{\n\s*this\.dialEvent\(conn\.host, false\);/, "…or on close");
+  assert.match(FED, /new CustomEvent\("romp:hostDial", \{ detail: \{ host, dialing \} \}\)/);
+  // the watchdog's abandon detaches the dying socket's onclose, so it must say the attempt ended itself
+  assert.match(FED, /c\.ws = null;\n\s*this\.dialEvent\(c\.host, false\);[^\n]*\n\s*this\.connect\(c\);/, "an abandoned dial ends the live state before the fresh dial begins");
+  assert.ok((FED.match(/this\.dialEvent\(/g) || []).length >= 5, "the three socket transitions, the watchdog's abandon and the poll's change dispatch it, nothing timed");
+});
+
+test("the foot's swirl sits after the sentence as the gist's flex sibling, only while dialing, and the sentence is unchanged", () => {
+  assert.match(RENDER, /const text = host \+ " is disconnected — this is the last romp got from it\. Reconnecting\.";/,
+    "no new copy: the one sentence");
+  assert.match(RENDER, /const dialing = hostIsDialing\(activeId\);/);
+  assert.match(RENDER, /const key = text \+ \(dialing \? " \|dialing" : ""\);/, "the rebuild is keyed on the state");
+  assert.match(RENDER, /glyph: "api", sev: "warn", gist: text, nested: true, live: dialing,/, "the sentence is the gist as before; the row is live exactly when it spins");
+  assert.match(RENDER, /if \(dialing\) \{\n\s*const swirl = el\("img", "host-dial-swirl"\)/, "the swirl exists only when dialing");
+  assert.match(RENDER, /swirl\.src = mediaSrc\("romp-swirl-glyph\.svg"\); swirl\.alt = ""; swirl\.onerror = \(\) => swirl\.remove\(\);/);
+  assert.match(RENDER, /const gistEl = card\.querySelector\("\.notice-head \.notice-gist"\);\n\s*if \(gistEl\) gistEl\.after\(swirl\);/,
+    "a flex SIBLING right after the gist, never inside it (the gist ellipsizes on a narrow pane and would clip the swirl first)");
+  assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); \}\);/,
+    "repainted on federation's dial event, and on nothing timed");
+});
+
+test("the swirl is a flex item of the head that spins with the placeholder tab's motif and rests under reduced motion", () => {
+  assert.match(CSS, /\.notice-head \.host-dial-swirl \{[^}]*flex: 0 0 auto;[^}]*animation: tab-ph-swirl-spin 7s linear infinite; \}/,
+    "flex: 0 0 auto, so the ellipsizing gist beside it gives way first");
+  assert.match(CSS, /@media \(prefers-reduced-motion: reduce\) \{ \.notice-head \.host-dial-swirl \{ animation: none; \} \}/);
+});

--- a/ui/webview/host-offline-ux.test.ts
+++ b/ui/webview/host-offline-ux.test.ts
@@ -41,7 +41,9 @@ test("the transcript says why it ends, at the END, where the eye lands", () => {
   // 2026-09-08 (the notice-vocabulary pass): a slim SESSION notice in the warn severity — the one row that sat
   // outside the vocabulary (centred italic); .notice-foot gives it the prose column's indent off the rail
   assert.match(RENDER, /foot\.id = "host-offline-foot";/);
-  assert.match(RENDER, /notice\(\{ src: "session", glyph: "api", sev: "warn", gist: text, nested: true,/);
+  // `live` since 2026-09-10: the row is live while a dial to the host is in flight, and the romp swirl sits after
+  // the gist as its flex sibling (host-dial-live.test.ts pins that rule) — the wording itself unchanged
+  assert.match(RENDER, /notice\(\{ src: "session", glyph: "api", sev: "warn", gist: text, nested: true, live: dialing,/);
   assert.match(CSS, /\.notice-foot \{/);
   assert.doesNotMatch(CSS, /\.tx-hostoff/);
 });

--- a/ui/webview/host-prefix.ts
+++ b/ui/webview/host-prefix.ts
@@ -67,6 +67,31 @@ export function hostIsDown(sid: string | null | undefined): boolean {
   } catch { return false; }
 }
 
+/** The host-down notice is LIVE (the romp swirl after "Reconnecting" spins) only while romp is actually
+ *  trying to reach the host: the kernel's /tunnels row says `dialing` (an ssh dial spawned and not yet
+ *  confirmed, or the supervisor's health request to the host in flight; kernel.py _row_dialing), or this
+ *  page's relay socket to the host is in its CONNECTING state (readyState 0, from `new WebSocket` until
+ *  the open or close event). Between attempts (the row waiting out its backoff, the socket closed and
+ *  waiting on the redial timer) and while open it is still. Pure over the two states federation
+ *  publishes, so the spinner is keyed on the dial EVENTS, never on a timer (the user 2026-09-10, who
+ *  wanted to see romp actually trying, not a spinner that spins whatever happens). The kernel's row is
+ *  the one that matters for a DOWN host: the browser does not dial a host the kernel reports down. */
+export function hostDialLive(rowDialing: boolean | null | undefined, readyState: number | null | undefined): boolean {
+  return !!rowDialing || readyState === 0;
+}
+
+/** Is a dial to this (prefixed) sid's host in flight right now? Reads the federation manager's published
+ *  state (`dialing`, hostDialLive over the host's socket); false wherever no manager is loaded, for a
+ *  local session, and with a manager too old to publish it. */
+export function hostIsDialing(sid: string | null | undefined): boolean {
+  const i = typeof sid === "string" ? sid.indexOf(":") : -1;
+  if (i <= 0) return false;
+  try {
+    const fed = (globalThis as any).__rompFed;
+    return !!fed && typeof fed.dialing === "function" && !!fed.dialing((sid as string).slice(0, i));
+  } catch { return false; }
+}
+
 /** The tooltip a marked host wears: what is wrong, when it was last reached, and that romp is still on it. */
 export function hostDownNote(sid: string | null | undefined): string {
   const i = typeof sid === "string" ? sid.indexOf(":") : -1;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -64,7 +64,7 @@ import { openPathLink, linkifyPathTokens, selectionOpenIn } from "./path-links";
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
-import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostDownNote } from "./host-prefix";
+import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostIsDialing, hostDownNote } from "./host-prefix";
 import { MENTION_MAX_ROWS, mentionQuery, rankMentions, mentionMoreNote, mentionToken, insertMention, mentionKeyAction, mentionSegments } from "./composer-mention";   // the @-mention card's rules, pure; the DOM is setupComposer's mention block and markMentions
 import type { MentionCandidate, MentionQuery } from "./composer-mention";
 import { defaultCommentName, defaultBreakoutName, defaultForkName, nameToSend } from "./comment-name";
@@ -6690,6 +6690,9 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
 // this only when the reachable set actually CHANGES (its own /tunnels poll is the event), so this is a
 // repaint per connect/drop, not per poll (the user 2026-07-29).
 window.addEventListener("romp-hosts", () => { renderTabs(); });
+// a dial attempt to a remote host began or ended (federation.ts dialEvent): the host-down foot's swirl
+// spins while one is in flight, as of the last /tunnels poll, so it repaints on this event and on nothing else
+window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); });
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
 // (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it
@@ -11620,15 +11623,35 @@ function syncHostOfflineFoot(): void {
   if (!activeId || !hostIsDown(activeId)) { existing?.remove(); return; }
   const host = String(activeId).slice(0, String(activeId).indexOf(":"));
   const text = host + " is disconnected — this is the last romp got from it. Reconnecting.";
-  if (existing && existing.dataset.text === text) return;
+  // The swirl after "Reconnecting" spins only while romp is actually trying to reach the host (the user
+  // 2026-09-10, who wanted it dynamic and honest: trying right now, not a spinner because something is wrong).
+  // hostIsDialing reads what federation publishes (host-prefix.ts hostDialLive): the kernel's /tunnels row
+  // saying `dialing` (an ssh dial spawned and unconfirmed, or its health request to the host in flight;
+  // the browser never dials a host the kernel reports down, so the kernel's word is the one that matters
+  // here) or this page's relay socket in its CONNECTING state. Federation's romp:hostDial event, on the
+  // row's change and on the socket's dial, open and close, is what repaints this foot; between attempts
+  // (the kernel waiting out its backoff) the swirl sits still. It sits AFTER the sentence as the gist's flex
+  // SIBLING in the head (the postal delivery icon's convention), never inside the gist: that span ellipsizes
+  // on a narrow pane and would clip the swirl first, the one dynamic cue. The rebuild is keyed on the state
+  // too, so a repaint with nothing changed leaves the DOM alone.
+  const dialing = hostIsDialing(activeId);
+  const key = text + (dialing ? " |dialing" : "");
+  if (existing && existing.dataset.text === key) return;
   existing?.remove();
   // a slim SESSION notice in the warn severity at the transcript's tail (the audit's row 35 — it was a
   // centred italic line, the one row outside the vocabulary); off the rail, so the prose-column indent
   const foot = el("div", "notice-foot");
   foot.id = "host-offline-foot";
-  foot.dataset.text = text;
-  foot.appendChild(notice({ src: "session", glyph: "api", sev: "warn", gist: text, nested: true,
-                            tip: hostDownNote(activeId) }));   // the one place that note is worded — host-prefix.ts
+  foot.dataset.text = key;
+  const card = notice({ src: "session", glyph: "api", sev: "warn", gist: text, nested: true, live: dialing,
+                        tip: hostDownNote(activeId) });   // the one place that note is worded — host-prefix.ts
+  if (dialing) {
+    const swirl = el("img", "host-dial-swirl") as HTMLImageElement;   // the romp-loader motif (the placeholder tab's mini swirl)
+    swirl.src = mediaSrc("romp-swirl-glyph.svg"); swirl.alt = ""; swirl.onerror = () => swirl.remove();
+    const gistEl = card.querySelector(".notice-head .notice-gist");
+    if (gistEl) gistEl.after(swirl); else card.querySelector(".notice-head")?.appendChild(swirl);
+  }
+  foot.appendChild(card);
   content.appendChild(foot);
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -585,6 +585,13 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-ph-swirl { width: 12px; height: 12px; border-radius: 2px; flex: none;
   animation: tab-ph-swirl-spin 7s linear infinite; }   /* .tab is flex with its own gap, so no margin needed */
 @keyframes tab-ph-swirl-spin { to { transform: rotate(-360deg); } }
+/* the host-down foot's swirl, after "Reconnecting": present only while a dial to the host is in flight as of
+   the last /tunnels poll (render.ts syncHostOfflineFoot), so the spin follows the state; the same motif as the
+   placeholder tab's. A flex item of the head right after the gist (the postal delivery icon's convention), so an
+   ellipsized sentence on a phone-wide pane clips its own tail and never the swirl, the one dynamic cue */
+.notice-head .host-dial-swirl { width: 12px; height: 12px; border-radius: 2px; flex: 0 0 auto; align-self: center;
+  margin-left: -2px; animation: tab-ph-swirl-spin 7s linear infinite; }
+@media (prefers-reduced-motion: reduce) { .notice-head .host-dial-swirl { animation: none; } }
 /* CLASSIC (the default; T113, tightened by T115, tuned by T118 — the user 2026-08-27): the tab
    strip is the PRE-720 strip — verified by pixel-diffing a real pre-720 build — modulo exactly
    four sanctioned deltas: typography (the strip inherits the global Inter/type ladder), the 1px


### PR DESCRIPTION
Design points (feature tier: a self-contained capability inside romp's existing model).

The host-down notice at a disconnected remote's transcript tail ("<host> is disconnected — this is the last romp got from it. Reconnecting.") now carries the romp swirl after "Reconnecting", spinning only while romp is actually trying to reach the host, still between attempts. The sentence is unchanged; the swirl sits after it so the words read first; the notice resolves as before when the host returns.

What "trying right now" means, and why the kernel says it: the browser never dials a host the kernel reports down (federation connects a relay socket only while the /tunnels row reads up, and the notice shows exactly when it does not), so a spinner keyed on the relay socket alone would never spin while the notice is on screen. The honest signal is the kernel's own retry. The tunnel supervisor already marks a row `starting` while an ssh dial is spawned and not yet healthy and `down` while it backs off until `nextTry`; for a checked-in peer the attempt is its health poll of the peer's port. So:
- `kernel/kernel.py`: the /tunnels row gains `dialing` (`_row_dialing`): true while the status is `starting` (or a checked-in row's birth state `connecting`) or while the pass's health request to the host is in flight (a per-pass mark set around the request, never saved to the remotes file). The four supervisor round-trips to a silent host take their timeouts, so the mark is on for seconds per pass and off between passes; against a refused port it is on for milliseconds.
- `ui/webview/federation.ts`: the same /tunnels poll that publishes the down set now publishes the dialing set and fires `romp:hostDial` only when it changes; the relay socket's own dial, open and close fire the same event (three transitions, no timer anywhere). `__rompFed.dialing(host)` answers from both states.
- `ui/webview/host-prefix.ts`: `hostDialLive(rowDialing, readyState)` is the pure rule (the kernel's word, or the socket in CONNECTING), and `hostIsDialing(sid)` its reader, false with no manager, for a local session and for a manager too old to publish the state.
- `ui/webview/render.ts`: the foot rebuilds on `romp:hostDial`, keyed on the state, appends the swirl inside the gist after the text only when dialing, and passes `live` for the same state.
- `ui/webview/styles.css`: the swirl spins with the placeholder tab's motif (same keyframes, 12 px) and rests under reduced motion.

Tests: `ui/webview/host-dial-live.test.ts` executes the pure rule and its reader against a stub manager and pins the wiring at source (federation's publish and its four dispatch sites, the foot's order of words then swirl, the CSS); `tests/test_kernel_tunnel_truth.py` pins `_row_dialing`, the unsaved mark and where the pass sets and clears it; two existing pins re-anchored (the single-instance import line now names the third pure helper; the host-offline notice's gist is an element). Suite runs stayed behind the machine's test lock in capped scopes: the extension suite, the tunnel-row Python tests, and the focused re-run of the re-anchored pins.

Seen by eye from a hermetic served page with a fake checked-in host (a checkin_peer row pointing at a stub server that answers the kernel's polls and pushes one `api` session over the relay): pausing the stub makes the kernel's health request hang to its timeout, the row reads `no-kernel` with `dialing` true and the notice shows the swirl (`~/.local/state/romp/drops/romp_feed-reconnecting-spinning.png`, with a tight crop `-spinning-foot.png`); killing the stub makes the port refuse at once and the notice sits still (`-still.png`, `-still-foot.png`). Same sentence, same place, in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
