### PR TITLE
Comment threads: one solid outline in the notch's yellow around the whole unread passage

### DIFF
--- a/tests/test_comment_outline_served.py
+++ b/tests/test_comment_outline_served.py
@@ -3,10 +3,13 @@
 scroll notch's yellow around the WHOLE highlighted passage — never a dashed box per line.
 
 A hermetic kernel serves a synthetic chat (the notes-api demo world: session web) whose one answer carries two open
-comment threads with a landed, unseen reply each: a passage that wraps over two lines and one over five. Asserted on
+comment threads with a landed, unseen reply each: a passage that wraps over two lines and one over five
+(on a 640 px page; the kernel ships a thread's exact text capped at 500 characters, so the mark covers at most that),
+plus an incoming question card whose long body scrolls, with a third thread on its last sentence: that box exists only
+while its passage shows inside the body (cut to the scrolling container, repainted when the body scrolls). Asserted on
 the page: every unread thread has EXACTLY one outline box, positioned (the text under it never moves) and transparent
 to the pointer, whose rect covers every line fragment of the thread's marks; the box's outline is solid and its
-colour is byte-equal to the thread's scroll tick, in the dark theme and the light one; no mark fragment wears an
+colour is byte-equal to the thread's scroll tick and reads at 3:1 or better against the page, in the dark theme and the light one; no mark fragment wears an
 outline of its own; opening a thread (a click on its mark) removes ITS box on the same pass and leaves the other's.
 With COMMENT_SHOTS=<dir> the driver also writes a dark and a light screenshot. Skips LOUDLY without the extension
 deps or a Playwright browser. SYNTHETIC fixtures only (placeholder UUIDs, invented prose, host TESTHOST)."""
@@ -36,13 +39,39 @@ THREAD5 = "cccccccc-1111-2222-3333-444444444444"   # the five-line passage's thr
 
 # the answer: two paragraphs, each the exact text of one thread's highlight
 P2 = ("Use exponential backoff with a jitter of ten percent on every retry of the notes-api sync loop, and cap the "
-      "delay at two minutes so a long outage never turns into an hour-long silence between attempts.")
+      "delay at two minutes.")
 P5 = ("The retry budget itself should live in one place: a small table keyed by the failing endpoint, holding the "
       "attempt count, the next allowed time and the last error text, so the dashboard can show at a glance which "
       "endpoints are struggling and the operator can reset one row without touching the others. Persist that table "
       "with the notes themselves, never in memory alone, because a restart in the middle of an outage would otherwise "
-      "forget every backoff and hammer the endpoint the moment the process comes back, which is exactly the storm the "
-      "backoff exists to prevent in the first place.")
+      "forget every backoff and hammer the endpoint when it comes back.")
+assert len(P5) <= 500, "the kernel ships a thread's exact text capped at 500 chars; the mark covers what ships"
+THREADQ = "dddddddd-1111-2222-3333-444444444444"   # the thread on the question card's LAST sentence (a scrolled notice body)
+API = "eeeeeeee-1111-2222-3333-444444444444"
+BAR = "#" * 44
+PQ_LAST = "Which of the two caps do you want written into the README, two minutes or five?"
+# an incoming QUESTION card opens by default and its body scrolls at the notice body's 420 px max height: forty short
+# paragraphs, then the sentence the third thread anchors to, so that passage starts scrolled OUT of the body's view
+PQ = "\n\n".join("Point %d: the retry table needs a row for endpoint number %d, with its own attempt count and next allowed time." % (i, i)
+                 for i in range(1, 41)) + "\n\n" + PQ_LAST
+
+
+def banner(frm, kind, mid, body, t):
+    """The delivered banner the postal service injects (bin/romp-postal-service format_push), as a user record."""
+    hhmm = datetime.fromtimestamp(t).strftime("%H:%M")
+    return "\n".join([BAR, "## \U0001F4EC from %s \u00b7 %s" % (frm, hhmm), BAR, body, "<!-- romp-msg-id: %s -->" % mid,
+                      "<!-- romp-msg-kind: %s -->" % kind, BAR,
+                      "(to reply, only if substantive: romp mail send --kind delegate|coordinate|question %s \"...\")" % frm])
+
+
+def _contrast(a, b):
+    """WCAG contrast of two "rgb(r, g, b)" strings."""
+    def lum(c):
+        ch = [int(x) / 255 for x in c[c.index("(") + 1:c.index(")")].split(",")[:3]]
+        f = lambda v: v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4
+        return 0.2126 * f(ch[0]) + 0.7152 * f(ch[1]) + 0.0722 * f(ch[2])
+    la, lb = lum(a), lum(b)
+    return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
 
 
 def _free_port():
@@ -77,7 +106,7 @@ const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
 let browser;
 try { browser = await chromium.launch(); }
 catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
-const page = await browser.newPage({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
+const page = await browser.newPage({ viewport: { width: 640, height: 900 }, deviceScaleFactor: 2 });
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
 await page.waitForFunction((n) => document.querySelectorAll("mark.cmt-hl.unread").length >= n, cfg.minMarks, { timeout: 30000 });
@@ -104,11 +133,24 @@ const measure = () => page.evaluate(() => {
                      boxes };
   }
   const tick = document.querySelector(".cmt-tick.unread");
-  return { threads, tickColor: tick ? getComputedStyle(tick).backgroundColor : null,
+  const nb = document.querySelector(".turn-postal-service .notice-body");
+  const nbr = nb ? nb.getBoundingClientRect() : null;
+  const solid = (c) => c && !/^rgba\(.*,\s*0\)$/.test(c) && c !== "transparent";
+  const pageBg = [document.getElementById("content"), document.body, document.documentElement]
+    .map((n) => n && getComputedStyle(n).backgroundColor).find(solid) || "rgb(30, 30, 30)";
+  return { threads, tickColor: tick ? getComputedStyle(tick).backgroundColor : null, pageBg,
+           noticeBody: nb ? { l: nbr.left, t: nbr.top, r: nbr.right, b: nbr.bottom, scrollTop: nb.scrollTop, scrollHeight: nb.scrollHeight, clientHeight: nb.clientHeight } : null,
            boxCount: document.querySelectorAll(".cmt-outline").length,
            theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
 });
 const dark = await measure();
+// the question card's body scrolls: its last sentence (the third thread) starts out of view — scroll the body to its end
+// (a real scroll event inside the pane, which does not bubble) and let the rail's rAF pass repaint
+await page.evaluate(() => { const nb = document.querySelector(".turn-postal-service .notice-body"); nb.scrollTop = nb.scrollHeight; });
+await page.waitForTimeout(400);
+const scrolled = await measure();
+await page.evaluate(() => { const nb = document.querySelector(".turn-postal-service .notice-body"); nb.scrollTop = 0; });
+await page.waitForTimeout(400);
 if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-comment-outline-dark.png", fullPage: false }); }
 await page.evaluate(() => document.body.classList.add("theme-light"));
 await page.waitForTimeout(300);
@@ -122,7 +164,7 @@ await page.waitForFunction((tid) => !document.querySelector(`.cmt-outline[data-t
 await page.waitForTimeout(300);
 const afterRead = await measure();
 afterRead.popover = await page.evaluate(() => !!document.querySelector("#cmt-pop"));
-fs.writeSync(1, "RESULT:" + JSON.stringify({ dark, light, afterRead }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ dark, scrolled, light, afterRead }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -165,28 +207,34 @@ class ServedCommentOutline(unittest.TestCase):
              "model": "claude-opus-5", "liveModel": "Opus 5"}))
         Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         t0 = int(time.time()) - 1800
+        Path(state, "names", API).write_text("api\t%s\t#1EA1EB\t#ffffff\n" % cwd)
+        os.makedirs(os.path.join(state, "timeline"), exist_ok=True)
+        Path(state, "timeline", "messages.jsonl").write_text(json.dumps(
+            {"t": t0 + 30, "ev": "sent", "id": "q-cap", "from": "api", "from_id": API, "to_id": WEB, "body": PQ, "kind": "question", "from_host": ""}) + "\n")
         parent = [user(t0, "u1", None, "how should the notes-api retry loop back off, and where does its budget live?", WEB),
-                  agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5, WEB)]
+                  agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5, WEB),
+                  user(t0 + 31, "m1", "a1", banner("api", "question", "q-cap", PQ, t0 + 30), WEB)]
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in parent))
         # two threads, each a fork cut at the answer (the copied history, then the exchange), a reply landed and
         # never seen (no lastSeenT) — the kernel's unread bit; no names/ entry (a thread is never on the board)
         rows = []
-        for i, (tsid, exact, ask, reply) in enumerate([
-                (THREAD2, P2, "why jitter at all?", "Jitter spreads simultaneous retries apart so they do not arrive as one wave."),
-                (THREAD5, P5, "why persist the budget?", "A restart mid-outage would otherwise forget every backoff and storm the endpoint.")]):
+        for i, (tsid, anchor, exact, ask, reply) in enumerate([
+                (THREAD2, "a1", P2, "why jitter at all?", "Jitter spreads simultaneous retries apart so they do not arrive as one wave."),
+                (THREAD5, "a1", P5, "why persist the budget?", "A restart mid-outage would otherwise forget every backoff and storm the endpoint."),
+                (THREADQ, "m1", PQ_LAST, "is five too long?", "Five minutes is too long for a notes sync; two keeps the user waiting under a coffee.")]):
             t = t0 + 60 * (i + 1)
-            thread = [user(t0, "u1", None, "how should the notes-api retry loop back off, and where does its budget live?", tsid),
-                      agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5, tsid),
-                      user(t, "c%d" % i, "a1", ask, tsid),
-                      agent(t + 20, "r%d" % i, "c%d" % i, reply, tsid)]
+            thread = [r for r in parent if r["uuid"] in ("u1", "a1") or anchor == "m1"]   # the copied history, up to the cut
+            thread = [dict(r, sessionId=tsid) for r in thread]
+            thread += [user(t, "c%d" % i, anchor, ask, tsid),
+                       agent(t + 20, "r%d" % i, "c%d" % i, reply, tsid)]
             Path(proj, tsid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in thread))
             Path(state, "sdk", tsid + ".json").write_text(json.dumps(
-                {"sid": tsid, "name": "web-comment-%d" % (i + 1), "cwd": cwd, "lastSid": tsid, "threadOf": WEB, "forkAt": "a1",
+                {"sid": tsid, "name": "web-comment-%d" % (i + 1), "cwd": cwd, "lastSid": tsid, "threadOf": WEB, "forkAt": anchor,
                  "alive": False, "mode": "auto", "effort": "high", "model": "claude-opus-5"}))
-            rows.append({"tid": "tid-%d" % (i + 1), "sid": tsid, "name": "web-comment-%d" % (i + 1), "anchorUuid": "a1",
-                         "cutUuid": "a1", "exact": exact, "status": "open", "createdT": t})
+            rows.append({"tid": "tid-%d" % (i + 1), "sid": tsid, "name": "web-comment-%d" % (i + 1), "anchorUuid": anchor,
+                         "cutUuid": anchor, "exact": exact, "status": "open", "createdT": t})
         Path(state, "comments", WEB + ".json").write_text(json.dumps({"threads": rows}))
         cls.port, cls.token = _free_port(), "testtok-outline"
         env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
@@ -216,7 +264,7 @@ class ServedCommentOutline(unittest.TestCase):
     def test_one_solid_box_around_the_whole_passage_in_the_ticks_yellow_gone_once_read(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "minMarks": 2, "read": "tid-1",
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "minMarks": 3, "read": "tid-1",
                        "shots": os.environ.get("COMMENT_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -229,12 +277,20 @@ class ServedCommentOutline(unittest.TestCase):
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
         r = json.loads(line[len("RESULT:"):])
-        for theme, want in (("dark", "rgb(255, 213, 74)"), ("light", "rgb(255, 223, 112)")):
+        for theme, want in (("dark", "rgb(255, 213, 74)"), ("light", "rgb(143, 106, 0)")):
             m = r[theme]
             self.assertEqual(m["theme"], theme)
-            self.assertEqual(set(m["threads"]), {"tid-1", "tid-2"}, m)
-            self.assertEqual(m["boxCount"], 2, "exactly one box per unread thread: %r" % m)
-            self.assertEqual(m["tickColor"], want, "the scroll tick's yellow in this theme: %r" % m)
+            self.assertEqual(set(m["threads"]), {"tid-1", "tid-2", "tid-3"}, m)
+            self.assertEqual(m["tickColor"], want, "the scroll tick's ink in this theme: %r" % m)
+            self.assertGreaterEqual(_contrast(want, m["pageBg"]), 3.0, "the ink reads as a LINE against the page: %r on %r" % (want, m["pageBg"]))
+            # the third thread's passage sits below the question card's scrolled body: no box for it until it shows
+            q = m["threads"]["tid-3"]
+            self.assertTrue(q["unread"], q)
+            self.assertEqual(m["noticeBody"]["scrollTop"], 0, m["noticeBody"])
+            self.assertGreater(m["noticeBody"]["scrollHeight"], m["noticeBody"]["clientHeight"] + 200, "the body scrolls: %r" % m["noticeBody"])
+            self.assertGreater(q["union"]["t"], m["noticeBody"]["b"], "the passage starts scrolled out of the body's view: %r vs %r" % (q["union"], m["noticeBody"]))
+            self.assertEqual(q["boxes"], [], "a fragment scrolled out of its container draws no box over the content below: %r" % q)
+            self.assertEqual(m["boxCount"], 2, "one box per VISIBLE unread thread: %r" % m)
             two, five = m["threads"]["tid-1"], m["threads"]["tid-2"]
             self.assertGreaterEqual(two["lines"], 2, "the first passage wraps over at least two lines: %r" % two)
             self.assertGreaterEqual(five["lines"], 5, "the second passage wraps over at least five lines: %r" % five)
@@ -243,7 +299,9 @@ class ServedCommentOutline(unittest.TestCase):
                 self.assertEqual(th["markOutlines"], ["none"], "no fragment wears an outline of its own: %r" % th)
                 self.assertEqual(len(th["boxes"]), 1, "ONE box for the whole passage: %r" % th)
                 box, u = th["boxes"][0], th["union"]
-                self.assertEqual(box["outline"], "solid 1.5px " + want, "solid, in the tick's exact colour: %r" % box)
+                style, width, colour = box["outline"].split(" ", 2)
+                self.assertEqual((style, colour), ("solid", want), "solid, in the tick's exact colour: %r" % box)
+                self.assertTrue(1 <= float(width.rstrip("px")) <= 2, "the 1.5px rule, as the engine snaps it: %r" % box)
                 self.assertEqual(box["position"], "absolute", "positioned: the text never moves")
                 self.assertEqual(box["pointer"], "none", "hover and click land on the marks beneath")
                 self.assertTrue(box["parentIsTurn"] and box["sameTurn"], "a child of the anchor turn: %r" % box)
@@ -252,12 +310,24 @@ class ServedCommentOutline(unittest.TestCase):
                 self.assertGreaterEqual(box["r"], u["r"] + 0.5); self.assertGreaterEqual(box["b"], u["b"] + 0.5)
                 for side in ("l", "t", "r", "b"):
                     self.assertLess(abs(box[side] - u[side]), 4, "the box hugs the union on the %s side: %r vs %r" % (side, box, u))
+        # scrolled to the body's end (a scroll inside the pane, captured by the rail scheduler): the third thread's box
+        # appears on its passage, inside the body's rect, hugging the visible fragments
+        sc = r["scrolled"]
+        q, nb = sc["threads"]["tid-3"], sc["noticeBody"]
+        self.assertGreater(nb["scrollTop"], 0, nb)
+        self.assertEqual(len(q["boxes"]), 1, "the box follows the scrolled marks: %r" % q)
+        box = q["boxes"][0]
+        self.assertGreaterEqual(box["t"], nb["t"] - 1.5); self.assertLessEqual(box["b"], nb["b"] + 1.5)
+        self.assertGreaterEqual(box["l"], nb["l"] - 1.5); self.assertLessEqual(box["r"], nb["r"] + 1.5)
+        for side in ("l", "t", "r", "b"):
+            self.assertLess(abs(box[side] - q["union"][side]), 4, "the box hugs the now-visible passage on the %s side: %r vs %r" % (side, box, q["union"]))
+        self.assertEqual(sc["boxCount"], 3)
         a = r["afterRead"]
         self.assertTrue(a["popover"], "the click opened the thread: %r" % a)
         self.assertFalse(a["threads"]["tid-1"]["unread"], "read: the unread bit dropped on the click")
         self.assertEqual(a["threads"]["tid-1"]["boxes"], [], "…and its box went on the same pass: %r" % a["threads"]["tid-1"])
         self.assertEqual(len(a["threads"]["tid-2"]["boxes"]), 1, "the other thread keeps its box: %r" % a["threads"]["tid-2"])
-        self.assertEqual(a["boxCount"], 1)
+        self.assertEqual(a["boxCount"], 1, "the read thread's box gone, the scrolled-out one still clipped away: %r" % a)
 
 
 if __name__ == "__main__":

--- a/tests/test_comment_outline_served.py
+++ b/tests/test_comment_outline_served.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -32,6 +33,8 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
 
 WEB = "aaaaaaaa-1111-2222-3333-444444444444"
 THREAD2 = "bbbbbbbb-1111-2222-3333-444444444444"   # the two-line passage's thread
@@ -237,12 +240,7 @@ class ServedCommentOutline(unittest.TestCase):
                          "cutUuid": anchor, "exact": exact, "status": "open", "createdT": t})
         Path(state, "comments", WEB + ".json").write_text(json.dumps({"threads": rows}))
         cls.port, cls.token = _free_port(), "testtok-outline"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
-                   ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
-        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-            env.pop(k, None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
         for _ in range(120):

--- a/tests/test_comment_outline_served.py
+++ b/tests/test_comment_outline_served.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""T310 (the user 2026-09-10): an unread comment thread's cue on the real /chat page is ONE solid outline in the
+scroll notch's yellow around the WHOLE highlighted passage — never a dashed box per line.
+
+A hermetic kernel serves a synthetic chat (the notes-api demo world: session web) whose one answer carries two open
+comment threads with a landed, unseen reply each: a passage that wraps over two lines and one over five. Asserted on
+the page: every unread thread has EXACTLY one outline box, positioned (the text under it never moves) and transparent
+to the pointer, whose rect covers every line fragment of the thread's marks; the box's outline is solid and its
+colour is byte-equal to the thread's scroll tick, in the dark theme and the light one; no mark fragment wears an
+outline of its own; opening a thread (a click on its mark) removes ITS box on the same pass and leaves the other's.
+With COMMENT_SHOTS=<dir> the driver also writes a dark and a light screenshot. Skips LOUDLY without the extension
+deps or a Playwright browser. SYNTHETIC fixtures only (placeholder UUIDs, invented prose, host TESTHOST)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+
+WEB = "aaaaaaaa-1111-2222-3333-444444444444"
+THREAD2 = "bbbbbbbb-1111-2222-3333-444444444444"   # the two-line passage's thread
+THREAD5 = "cccccccc-1111-2222-3333-444444444444"   # the five-line passage's thread
+
+# the answer: two paragraphs, each the exact text of one thread's highlight
+P2 = ("Use exponential backoff with a jitter of ten percent on every retry of the notes-api sync loop, and cap the "
+      "delay at two minutes so a long outage never turns into an hour-long silence between attempts.")
+P5 = ("The retry budget itself should live in one place: a small table keyed by the failing endpoint, holding the "
+      "attempt count, the next allowed time and the last error text, so the dashboard can show at a glance which "
+      "endpoints are struggling and the operator can reset one row without touching the others. Persist that table "
+      "with the notes themselves, never in memory alone, because a restart in the middle of an outage would otherwise "
+      "forget every backoff and hammer the endpoint the moment the process comes back, which is exactly the storm the "
+      "backoff exists to prevent in the first place.")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def user(t, uuid, parent, text, sid):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed",
+            "sessionId": sid, "message": {"role": "user", "content": text}}
+
+
+def agent(t, uuid, parent, text, sid):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "sessionId": sid,
+            "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                        "content": [{"type": "text", "text": text}]}}
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 900, height: 900 }, deviceScaleFactor: 2 });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction((n) => document.querySelectorAll("mark.cmt-hl.unread").length >= n, cfg.minMarks, { timeout: 30000 });
+await page.waitForTimeout(400);   // the rail's rAF pass after the marks landed
+const measure = () => page.evaluate(() => {
+  const tids = Array.from(new Set(Array.from(document.querySelectorAll("mark.cmt-hl")).map((m) => m.dataset.tid)));
+  const threads = {};
+  for (const tid of tids) {
+    const marks = Array.from(document.querySelectorAll(`mark.cmt-hl[data-tid="${tid}"]`));
+    const rects = marks.flatMap((m) => Array.from(m.getClientRects()).filter((q) => q.width || q.height))
+      .map((q) => ({ l: q.left, t: q.top, r: q.right, b: q.bottom }));
+    const lines = new Set(rects.map((q) => Math.round(q.t))).size;
+    const boxes = Array.from(document.querySelectorAll(`.cmt-outline[data-tid="${tid}"]`)).map((box) => {
+      const q = box.getBoundingClientRect();
+      const cs = getComputedStyle(box);
+      return { l: q.left, t: q.top, r: q.right, b: q.bottom, outline: cs.outlineStyle + " " + cs.outlineWidth + " " + cs.outlineColor,
+               position: cs.position, pointer: cs.pointerEvents, parentIsTurn: box.parentElement.classList.contains("turn"),
+               sameTurn: box.parentElement === marks[0].closest(".turn") };
+    });
+    threads[tid] = { unread: marks.some((m) => m.classList.contains("unread")), fragments: rects.length, lines,
+                     markOutlines: Array.from(new Set(marks.map((m) => getComputedStyle(m).outlineStyle))),
+                     union: rects.length ? { l: Math.min(...rects.map((q) => q.l)), t: Math.min(...rects.map((q) => q.t)),
+                                             r: Math.max(...rects.map((q) => q.r)), b: Math.max(...rects.map((q) => q.b)) } : null,
+                     boxes };
+  }
+  const tick = document.querySelector(".cmt-tick.unread");
+  return { threads, tickColor: tick ? getComputedStyle(tick).backgroundColor : null,
+           boxCount: document.querySelectorAll(".cmt-outline").length,
+           theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const dark = await measure();
+if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-comment-outline-dark.png", fullPage: false }); }
+await page.evaluate(() => document.body.classList.add("theme-light"));
+await page.waitForTimeout(300);
+const light = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-comment-outline-light.png", fullPage: false });
+await page.evaluate(() => document.body.classList.remove("theme-light"));
+await page.waitForTimeout(200);
+// read the two-line thread: a click on its mark opens the popover, which drops the unread bit and re-runs the marks pass
+await page.click(`mark.cmt-hl[data-tid="${cfg.read}"]`);
+await page.waitForFunction((tid) => !document.querySelector(`.cmt-outline[data-tid="${tid}"]`), cfg.read, { timeout: 10000 }).catch(() => {});
+await page.waitForTimeout(300);
+const afterRead = await measure();
+afterRead.popover = await page.evaluate(() => !!document.querySelector("#cmt-pop"));
+fs.writeSync(1, "RESULT:" + JSON.stringify({ dark, light, afterRead }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedCommentOutline(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="comment-outline-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)   # tests/dist_copy: skips the bundler's staging files
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states", "comments"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(state, "names", WEB).write_text("web\t%s\t#9cd2ff\t#0c1a2e\n" % cwd)
+        Path(state, "sdk", WEB + ".json").write_text(json.dumps(
+            {"sid": WEB, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": WEB, "alive": True,
+             "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        t0 = int(time.time()) - 1800
+        parent = [user(t0, "u1", None, "how should the notes-api retry loop back off, and where does its budget live?", WEB),
+                  agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5, WEB)]
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in parent))
+        # two threads, each a fork cut at the answer (the copied history, then the exchange), a reply landed and
+        # never seen (no lastSeenT) — the kernel's unread bit; no names/ entry (a thread is never on the board)
+        rows = []
+        for i, (tsid, exact, ask, reply) in enumerate([
+                (THREAD2, P2, "why jitter at all?", "Jitter spreads simultaneous retries apart so they do not arrive as one wave."),
+                (THREAD5, P5, "why persist the budget?", "A restart mid-outage would otherwise forget every backoff and storm the endpoint.")]):
+            t = t0 + 60 * (i + 1)
+            thread = [user(t0, "u1", None, "how should the notes-api retry loop back off, and where does its budget live?", tsid),
+                      agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5, tsid),
+                      user(t, "c%d" % i, "a1", ask, tsid),
+                      agent(t + 20, "r%d" % i, "c%d" % i, reply, tsid)]
+            Path(proj, tsid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in thread))
+            Path(state, "sdk", tsid + ".json").write_text(json.dumps(
+                {"sid": tsid, "name": "web-comment-%d" % (i + 1), "cwd": cwd, "lastSid": tsid, "threadOf": WEB, "forkAt": "a1",
+                 "alive": False, "mode": "auto", "effort": "high", "model": "claude-opus-5"}))
+            rows.append({"tid": "tid-%d" % (i + 1), "sid": tsid, "name": "web-comment-%d" % (i + 1), "anchorUuid": "a1",
+                         "cutUuid": "a1", "exact": exact, "status": "open", "createdT": t})
+        Path(state, "comments", WEB + ".json").write_text(json.dumps({"threads": rows}))
+        cls.port, cls.token = _free_port(), "testtok-outline"
+        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
+                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
+                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
+                   ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
+        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
+            env.pop(k, None)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_one_solid_box_around_the_whole_passage_in_the_ticks_yellow_gone_once_read(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "minMarks": 2, "read": "tid-1",
+                       "shots": os.environ.get("COMMENT_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        for theme, want in (("dark", "rgb(255, 213, 74)"), ("light", "rgb(255, 223, 112)")):
+            m = r[theme]
+            self.assertEqual(m["theme"], theme)
+            self.assertEqual(set(m["threads"]), {"tid-1", "tid-2"}, m)
+            self.assertEqual(m["boxCount"], 2, "exactly one box per unread thread: %r" % m)
+            self.assertEqual(m["tickColor"], want, "the scroll tick's yellow in this theme: %r" % m)
+            two, five = m["threads"]["tid-1"], m["threads"]["tid-2"]
+            self.assertGreaterEqual(two["lines"], 2, "the first passage wraps over at least two lines: %r" % two)
+            self.assertGreaterEqual(five["lines"], 5, "the second passage wraps over at least five lines: %r" % five)
+            for th in (two, five):
+                self.assertTrue(th["unread"], th)
+                self.assertEqual(th["markOutlines"], ["none"], "no fragment wears an outline of its own: %r" % th)
+                self.assertEqual(len(th["boxes"]), 1, "ONE box for the whole passage: %r" % th)
+                box, u = th["boxes"][0], th["union"]
+                self.assertEqual(box["outline"], "solid 1.5px " + want, "solid, in the tick's exact colour: %r" % box)
+                self.assertEqual(box["position"], "absolute", "positioned: the text never moves")
+                self.assertEqual(box["pointer"], "none", "hover and click land on the marks beneath")
+                self.assertTrue(box["parentIsTurn"] and box["sameTurn"], "a child of the anchor turn: %r" % box)
+                # the box covers every fragment (1px clear of the glyphs) and hugs the union, not the whole line
+                self.assertLessEqual(box["l"], u["l"] - 0.5); self.assertLessEqual(box["t"], u["t"] - 0.5)
+                self.assertGreaterEqual(box["r"], u["r"] + 0.5); self.assertGreaterEqual(box["b"], u["b"] + 0.5)
+                for side in ("l", "t", "r", "b"):
+                    self.assertLess(abs(box[side] - u[side]), 4, "the box hugs the union on the %s side: %r vs %r" % (side, box, u))
+        a = r["afterRead"]
+        self.assertTrue(a["popover"], "the click opened the thread: %r" % a)
+        self.assertFalse(a["threads"]["tid-1"]["unread"], "read: the unread bit dropped on the click")
+        self.assertEqual(a["threads"]["tid-1"]["boxes"], [], "…and its box went on the same pass: %r" % a["threads"]["tid-1"])
+        self.assertEqual(len(a["threads"]["tid-2"]["boxes"]), 1, "the other thread keeps its box: %r" % a["threads"]["tid-2"])
+        self.assertEqual(a["boxCount"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/comment-mark.test.ts
+++ b/ui/webview/comment-mark.test.ts
@@ -1,8 +1,10 @@
-// The comment mark's UNREAD ring (the user 2026-09-08): a landed reply you have not opened wears the SAME
-// dashed ring the tab strip puts on a session that needs you — one idiom for "this waits on you" — in
-// place of the 2026-08-23 yellow corner dot. The fill keeps saying pending vs landed exactly as before
-// (T237: the green .busy wash = a reply still being written, the 45% yellow .unread tier = landed); the
-// ring is the only new element, and only on unread. Source pins (no jsdom harness for the renderers).
+// The comment mark's UNREAD cue (the user 2026-09-10): a landed reply you have not opened draws ONE solid outline
+// in the scroll notch's yellow around the WHOLE highlighted passage — in place of the 2026-09-08 dashed ring, which
+// was an outline on the inline mark and so painted once per line fragment (a wrapped passage wore a stack of dashed
+// boxes). The fill keeps saying pending vs landed exactly as before (T237: the green .busy wash = a reply still
+// being written, the 45% yellow .unread tier = landed); the box is the only cue for unread, and only on unread.
+// Source pins (no jsdom harness for the renderers); the union geometry itself is measured on the served page by
+// tests/test_comment_outline_served.py.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -11,30 +13,24 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-const RING = /mark\.cmt-hl\.unread \{ outline: 1\.5px dashed var\(--st-awaiting-bg\); outline-offset: 1px; \}/;
-
-test("an unread mark wears the tab strip's needs-you ring: the same token, the same dash, scaled to a text run", () => {
-  assert.match(CSS, RING);
-  // the tab's ring: --state resolves to --st-awaiting-bg for a session waiting on you, drawn as a dashed outline
-  assert.match(CSS, /\.tab\.tab-awaiting \{ --state: var\(--st-awaiting-bg\); \}/);
-  assert.match(CSS, /\.tab\.tab-awaiting, \.tab\.tab-blocked, \.tab\.tab-retrying \{ outline: 2px dashed var\(--state\); outline-offset: -2px; \}/);
-  // scaled: thinner (the dash and gap shorten with the width) and offset OUTWARD so it never crosses the glyphs
-  const ring = CSS.match(RING)![0];
-  assert.match(ring, /outline: 1\.5px dashed/);
-  assert.match(ring, /outline-offset: 1px/);
-  assert.doesNotMatch(ring, /#[0-9a-fA-F]{3,6}\b|border|box-shadow/, "the token, as an outline — nothing reflows when it comes and goes");
+test("the per-fragment dashed ring is gone: no outline on the mark itself, in any state", () => {
+  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/);
+  assert.doesNotMatch(CSS, /dashed var\(--st-awaiting-bg\); outline-offset: 1px/);
+  const marks = CSS.match(/^mark\.cmt-hl[^{]*\{[^}]*\}/gms) || [];
+  assert.ok(marks.length >= 6, "the mark rules are found");
+  for (const rule of marks) assert.doesNotMatch(rule, /outline/, "an outline on an inline mark paints per line fragment: " + rule);
 });
 
-test("read marks wear no ring, and the fill tiers are byte-untouched — the colour still says pending vs landed", () => {
-  const base = CSS.slice(CSS.indexOf("mark.cmt-hl {"), CSS.indexOf("mark.cmt-hl.unread {"));
-  assert.doesNotMatch(base, /outline/, "the base (read) mark: no ring");
+test("read marks wear no box, and the fill tiers are byte-untouched — the colour still says pending vs landed", () => {
   assert.match(CSS, /mark\.cmt-hl\.unread \{ background: color-mix\(in srgb, var\(--cmt-hl\) 45%, transparent\); \}/, "landed = the 45% yellow tier (T237's pin)");
   assert.match(CSS, /mark\.cmt-hl\.busy \{\s*\n\s*background-color: color-mix\(in srgb, var\(--st-awaitbg-bg\) 24%, transparent\);/, "pending = the green wash");
   assert.match(CSS, /mark\.cmt-hl\.resolved \{ background: rgba\(255, 255, 255, 0\.08\); \}/);
   assert.match(CSS, /mark\.cmt-hl:hover \{ background: color-mix\(in srgb, var\(--cmt-hl\) 58%, transparent\); \}/);
+  // the painter draws a box for UNREAD marks only: a read mark has no box to wear
+  assert.match(RENDER, /v\.el\.querySelectorAll\("mark\.cmt-hl\.unread"\)/);
 });
 
-test("the yellow corner dot is gone root and branch", () => {
+test("the yellow corner dot stays gone root and branch", () => {
   assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread\.hl-last::after/);
   assert.doesNotMatch(CSS, /mark\.cmt-hl \{[^}]*position: relative;/s, "nothing left for the mark to anchor");
   // the segment classes stay: the radius still sits only on the run's outer ends
@@ -43,7 +39,7 @@ test("the yellow corner dot is gone root and branch", () => {
   assert.match(RENDER, /segs\[i\]\.classList\.toggle\("hl-last", i === segs\.length - 1\);/);
 });
 
-test("unread is the kernel's bit on an open thread, cleared by opening the thread — the ring follows it, nothing else", () => {
+test("unread is the kernel's bit on an open thread, cleared by opening the thread — the box follows it, nothing else", () => {
   assert.match(RENDER, /m\.classList\.toggle\("unread", !!th\.unread && th\.status === "open"\);/);
   assert.match(RENDER, /if \(th\) th\.unread = false;\s*\/\/ optimistic; the kernel's watermark reconciles/);
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "commentSeen", id: sid, tid \}\);/);
@@ -52,11 +48,4 @@ test("unread is the kernel's bit on an open thread, cleared by opening the threa
   assert.ok(at > 0, "the chip's click handler exists");
   const click = RENDER.slice(at, RENDER.indexOf("new ResizeObserver(updateReplyChips)", at));
   assert.doesNotMatch(click, /"commentSeen"|\.unread = false/);
-});
-
-test("both themes define the ring's token, in the red that means 'waiting on you' in each", () => {
-  const dark = CSS.split("body.theme-light {")[0];
-  const light = CSS.split("body.theme-light {")[1].split("\n}")[0];
-  assert.match(dark, /--st-awaiting-bg: #c0392b;/);
-  assert.match(light, /--st-awaiting-bg: #c0392b;/);
 });

--- a/ui/webview/comment-outline.test.ts
+++ b/ui/webview/comment-outline.test.ts
@@ -68,8 +68,13 @@ test("the box follows the marks: repainted after every marks pass, on the rail's
   const pass = RENDER.slice(at, RENDER.indexOf("\n}\n", at));
   assert.match(pass, /if \(!threads\.length\) \{ paintCommentOutlines\(sid\);/, "the last thread gone: its box goes on the same pass");
   assert.match(pass, /for \(const th of list\) ensureCommentMark\(turn, th\);[\s\S]*paintCommentOutlines\(sid\);/, "after the marks are placed");
-  assert.match(RENDER, /requestAnimationFrame\(\(\) => \{ railStickyPending = false; paintRailSticky\(\); paintScrollMarks\(\); updateCommentRail\(\); if \(activeId\) paintCommentOutlines\(activeId\); \}\);/,
-    "the notches' and ticks' own repaint path (a re-render, the view's resize observer)");
-  assert.match(RENDER, /window\.addEventListener\("resize", \(\) => \{ updateCommentRail\(\); if \(activeId\) paintCommentOutlines\(activeId\); \}\);/);
+  assert.match(RENDER, /requestAnimationFrame\(\(\) => \{ railStickyPending = false; paintRailSticky\(\); paintScrollMarks\(\); updateCommentRail\(\); if \(activeId && hasUnreadOpenThread\(activeId\)\) paintCommentOutlines\(activeId\); \}\);/,
+    "the notches' and ticks' own repaint path (a re-render, the view's resize observer, every scroll frame) — gated");
+  assert.match(RENDER, /window\.addEventListener\("resize", \(\) => \{ updateCommentRail\(\); if \(activeId && hasUnreadOpenThread\(activeId\)\) paintCommentOutlines\(activeId\); \}\);/);
+  // the gate is a store read, never a DOM walk: a scroll frame on a session with nothing unread costs a Map lookup
+  assert.match(RENDER, /function hasUnreadOpenThread\(sid: string\): boolean \{\s*\n\s*return \(commentThreads\.get\(sid\) \|\| \[\]\)\.some\(\(t\) => !!t\.unread && t\.status === "open"\);\s*\n\}/);
+  // …while the marks pass stays ungated: it is the removal path (the last unread thread gone takes its box with it)
+  const pass2 = RENDER.slice(RENDER.indexOf("function applyCommentMarks(sid: string): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function applyCommentMarks(sid: string): void {")));
+  assert.doesNotMatch(pass2, /hasUnreadOpenThread/);
   assert.doesNotMatch(RENDER.slice(RENDER.indexOf("function paintCommentOutlines"), RENDER.indexOf("\n}\n", RENDER.indexOf("function paintCommentOutlines"))), /setTimeout|setInterval/);
 });

--- a/ui/webview/comment-outline.test.ts
+++ b/ui/webview/comment-outline.test.ts
@@ -10,21 +10,40 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-const RULE = /\.cmt-outline \{ position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;\s*\n\s*outline: 1\.5px solid var\(--cmt-hl\); border-radius: 3px; \}/;
+const RULE = /\.cmt-outline \{ position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;\s*\n\s*outline: 1\.5px solid var\(--cmt-hl-outline\); border-radius: 3px; \}/;
 
 test("one solid outline in the notch's yellow: the same token the tick wears, as an outline on a positioned box", () => {
   assert.match(CSS, RULE);
   const rule = CSS.match(RULE)![0];
-  assert.match(rule, /outline: 1\.5px solid var\(--cmt-hl\)/, "solid, not dashed; the token, never a hex");
+  assert.match(rule, /outline: 1\.5px solid var\(--cmt-hl-outline\)/, "solid, not dashed; the token, never a hex");
   assert.doesNotMatch(rule, /#[0-9a-fA-F]{3,6}\b|border(?!-radius)[-\w]*:|box-shadow|background/, "an outline on an empty box: nothing reflows, nothing tints");
   assert.match(rule, /position: absolute/, "positioned: the text under it never moves");
   assert.match(rule, /pointer-events: none/, "hover and click land on the marks beneath");
-  // the notch for the same thread: .cmt-tick's fill is the very same token, in both themes
-  assert.match(CSS, /\.cmt-tick \{[^}]*background: var\(--cmt-hl\);/s);
+  // the notch for the same thread: .cmt-tick's fill is the very same token, in both themes — the INK, which is the
+  // highlighter yellow itself in the dark theme and a darker amber on the cream page (the review measured the yellow
+  // at 1.1:1 there: a fill reads, a line does not); the fill tokens stay the highlighter yellow in both
+  assert.match(CSS, /\.cmt-tick \{[^}]*background: var\(--cmt-hl-outline\);/s);
+  assert.match(CSS, /\.cmt-tick\.unread \{[^}]*color-mix\(in srgb, var\(--cmt-hl-outline\) 85%, transparent\)/s, "the unread tick's ring, the same ink");
   const dark = CSS.split("body.theme-light {")[0];
   const light = CSS.split("body.theme-light {")[1].split("\n}")[0];
   assert.match(dark, /--cmt-hl: #ffd54a;/);
+  assert.match(dark, /--cmt-hl-outline: #ffd54a;/, "dark: the ink IS the fill's yellow");
   assert.match(light, /--cmt-hl: #FFDF70;/);
+  assert.match(light, /--cmt-hl-outline: #8f6a00;/, "light: amber ink, 4.2:1 on the cream page (theme-parity pins the ratio)");
+  assert.match(fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "theme-parity.test.ts"), "utf8"), /\["--cmt-hl-outline", "--bg", 3\]/);
+});
+
+test("a fragment inside a scrolling container counts only where it shows: cut to every scrolling ancestor, and the pane's scroll listener captures inner scrolls", () => {
+  const at = RENDER.indexOf("function paintCommentOutlines(sid: string): void {");
+  const fn = RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+  assert.match(fn, /for \(let a = m\.parentElement; a && a !== turn; a = a\.parentElement\) \{\s*\n\s*const cs = getComputedStyle\(a\);\s*\n\s*if \(cs\.overflowX === "visible" && cs\.overflowY === "visible"\) continue;/, "every ancestor that clips, up to the turn");
+  assert.match(fn, /cl = Math\.max\(cl, ar\.left\); ct = Math\.max\(ct, ar\.top\); cr = Math\.min\(cr, ar\.right\); cb = Math\.min\(cb, ar\.bottom\);/, "the intersection of their rects");
+  assert.match(fn, /if \(qr <= ql \|\| qb <= qt\) continue;\s*\/\/ clipped away by a scrolling ancestor/, "a fragment scrolled out adds nothing");
+  // a notice body is such a container; so is a wide display formula
+  assert.match(CSS, /\.notice-body \{ margin-top: 7px; max-height: 420px; overflow: auto;/);
+  assert.match(CSS, /\.katex-display \{ overflow-x: auto; overflow-y: hidden; \}/);
+  // scroll events do not bubble: the rail scheduler's listener on #content captures them, so the boxes follow
+  assert.match(RENDER, /c\.addEventListener\("scroll", scheduleRailSticky, \{ passive: true, capture: true \}\);/);
 });
 
 test("the painter: one box per unread thread, a child of the turn, sized to the union of the fragments' client rects", () => {
@@ -34,7 +53,7 @@ test("the painter: one box per unread thread, a child of the turn, sized to the 
   assert.match(fn, /querySelectorAll\("mark\.cmt-hl\.unread"\)/, "unread marks only");
   assert.match(fn, /want\.get\(tid\)/, "grouped by thread: one box per tid");
   assert.match(fn, /m\.getClientRects\(\)/, "every line fragment of every mark of the thread");
-  assert.match(fn, /l = Math\.min\(l, q\.left\); t = Math\.min\(t, q\.top\); r = Math\.max\(r, q\.right\); b = Math\.max\(b, q\.bottom\);/, "the union");
+  assert.match(fn, /l = Math\.min\(l, ql\); t = Math\.min\(t, qt\); r = Math\.max\(r, qr\); b = Math\.max\(b, qb\);/, "the union of the CLIPPED fragments");
   assert.match(fn, /marks\[0\]\.closest\("\.turn"\)/, "the box lives on the anchor turn (position: relative): it scrolls with the text");
   assert.match(fn, /box = el\("div", "cmt-outline"\); box\.dataset\.tid = tid; turn\.appendChild\(box\);/);
   assert.match(fn, /turn\.getBoundingClientRect\(\)/, "turn-relative coordinates");

--- a/ui/webview/comment-outline.test.ts
+++ b/ui/webview/comment-outline.test.ts
@@ -1,0 +1,56 @@
+// T310 (the user 2026-09-10): an unread comment thread's cue is ONE solid outline in the scroll notch's yellow around
+// the WHOLE highlighted area — never a box per line. Source pins for the rule, the painter and its hooks; the
+// geometry (exactly one box per unread thread, covering every fragment; gone once read) is measured on the served
+// page by tests/test_comment_outline_served.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+const RULE = /\.cmt-outline \{ position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;\s*\n\s*outline: 1\.5px solid var\(--cmt-hl\); border-radius: 3px; \}/;
+
+test("one solid outline in the notch's yellow: the same token the tick wears, as an outline on a positioned box", () => {
+  assert.match(CSS, RULE);
+  const rule = CSS.match(RULE)![0];
+  assert.match(rule, /outline: 1\.5px solid var\(--cmt-hl\)/, "solid, not dashed; the token, never a hex");
+  assert.doesNotMatch(rule, /#[0-9a-fA-F]{3,6}\b|border(?!-radius)[-\w]*:|box-shadow|background/, "an outline on an empty box: nothing reflows, nothing tints");
+  assert.match(rule, /position: absolute/, "positioned: the text under it never moves");
+  assert.match(rule, /pointer-events: none/, "hover and click land on the marks beneath");
+  // the notch for the same thread: .cmt-tick's fill is the very same token, in both themes
+  assert.match(CSS, /\.cmt-tick \{[^}]*background: var\(--cmt-hl\);/s);
+  const dark = CSS.split("body.theme-light {")[0];
+  const light = CSS.split("body.theme-light {")[1].split("\n}")[0];
+  assert.match(dark, /--cmt-hl: #ffd54a;/);
+  assert.match(light, /--cmt-hl: #FFDF70;/);
+});
+
+test("the painter: one box per unread thread, a child of the turn, sized to the union of the fragments' client rects", () => {
+  const at = RENDER.indexOf("function paintCommentOutlines(sid: string): void {");
+  assert.ok(at > 0, "the painter exists");
+  const fn = RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+  assert.match(fn, /querySelectorAll\("mark\.cmt-hl\.unread"\)/, "unread marks only");
+  assert.match(fn, /want\.get\(tid\)/, "grouped by thread: one box per tid");
+  assert.match(fn, /m\.getClientRects\(\)/, "every line fragment of every mark of the thread");
+  assert.match(fn, /l = Math\.min\(l, q\.left\); t = Math\.min\(t, q\.top\); r = Math\.max\(r, q\.right\); b = Math\.max\(b, q\.bottom\);/, "the union");
+  assert.match(fn, /marks\[0\]\.closest\("\.turn"\)/, "the box lives on the anchor turn (position: relative): it scrolls with the text");
+  assert.match(fn, /box = el\("div", "cmt-outline"\); box\.dataset\.tid = tid; turn\.appendChild\(box\);/);
+  assert.match(fn, /turn\.getBoundingClientRect\(\)/, "turn-relative coordinates");
+  assert.match(fn, /if \(!marks \|\| marks\[0\]\.closest\("\.turn"\) !== box\.parentElement\) box\.remove\(\);/, "a box whose thread is read, resolved or gone is removed");
+  assert.match(fn, /if \(!isFinite\(l\)\) \{ box\?\.remove\(\); continue; \}/, "no fragment has a box (hidden) → no outline");
+  assert.match(fn, /if \(box\.style\[k\] !== css\[k\]\) box\.style\[k\] = css\[k\];/, "writes only what changed: the rAF path is a measure pass most frames");
+  assert.match(CSS, /^\.turn \{ position: relative;/m, "the turn is the positioning context the box relies on");
+});
+
+test("the box follows the marks: repainted after every marks pass, on the rail's rAF scheduler and on window resize — no timers", () => {
+  const at = RENDER.indexOf("function applyCommentMarks(sid: string): void {");
+  const pass = RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+  assert.match(pass, /if \(!threads\.length\) \{ paintCommentOutlines\(sid\);/, "the last thread gone: its box goes on the same pass");
+  assert.match(pass, /for \(const th of list\) ensureCommentMark\(turn, th\);[\s\S]*paintCommentOutlines\(sid\);/, "after the marks are placed");
+  assert.match(RENDER, /requestAnimationFrame\(\(\) => \{ railStickyPending = false; paintRailSticky\(\); paintScrollMarks\(\); updateCommentRail\(\); if \(activeId\) paintCommentOutlines\(activeId\); \}\);/,
+    "the notches' and ticks' own repaint path (a re-render, the view's resize observer)");
+  assert.match(RENDER, /window\.addEventListener\("resize", \(\) => \{ updateCommentRail\(\); if \(activeId\) paintCommentOutlines\(activeId\); \}\);/);
+  assert.doesNotMatch(RENDER.slice(RENDER.indexOf("function paintCommentOutlines"), RENDER.indexOf("\n}\n", RENDER.indexOf("function paintCommentOutlines"))), /setTimeout|setInterval/);
+});

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -106,7 +106,7 @@ test("an unread thread wears ONE outline box around its whole passage and a shou
   // flag on open.
   assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread\.hl-last::after/, "the corner dot is gone");
   assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/, "no outline on the mark itself: it would paint per line fragment");
-  assert.match(CSS, /\.cmt-outline \{ position: absolute; pointer-events: none;[^}]*outline: 1\.5px solid var\(--cmt-hl\);/s, "one box, the notch's token");
+  assert.match(CSS, /\.cmt-outline \{ position: absolute; pointer-events: none;[^}]*outline: 1\.5px solid var\(--cmt-hl-outline\);/s, "one box, the notch's ink");
   assert.match(UI, /function paintCommentOutlines\(sid: string\): void \{/);
   assert.doesNotMatch(CSS, /mark\.cmt-hl \{[^}]*position: relative;/s, "nothing left for the mark to anchor");
   assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1;/);

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -95,16 +95,19 @@ test("the popover keeps the chat renderer but sheds its transcript-coupled hover
     "no rail time-markers on gutterless popover turns");
 });
 
-test("an unread thread wears the needs-you RING on its mark and a shouting rail tick", () => {
+test("an unread thread wears ONE outline box around its whole passage and a shouting rail tick", () => {
   // the user 2026-08-23: the 45% unread tint alone was too subtle — a thread that replied while the
   // box was closed needs a visible element. That element was a yellow corner dot on the run's last
-  // segment until 2026-09-08, when the user asked for the tab strip's needs-you idiom instead: the
-  // SAME dashed ring a tab wears while its session waits on you (.tab.tab-awaiting, --st-awaiting-bg),
-  // scaled to a text run — one idiom for "this waits on you" across the surface. The dot pins below
-  // were rewritten deliberately for that; the ring's pins live in comment-mark.test.ts. The rail tick
-  // still grows and double-rings. Both clear with the unread flag on open.
-  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread\.hl-last::after/, "the corner dot is gone — the ring replaced it");
-  assert.match(CSS, /mark\.cmt-hl\.unread \{ outline: 1\.5px dashed var\(--st-awaiting-bg\); outline-offset: 1px; \}/);
+  // segment until 2026-09-08 (then the tab strip's dashed needs-you ring on the mark), and since
+  // 2026-09-10 it is ONE solid outline in the notch's yellow around the WHOLE highlighted area: the
+  // ring was an outline on the inline mark and painted once per line fragment, a dashed box per line.
+  // The box is a positioned child of the turn that render.ts measures from the marks (its pins live in
+  // comment-outline.test.ts). The rail tick still grows and double-rings. Both clear with the unread
+  // flag on open.
+  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread\.hl-last::after/, "the corner dot is gone");
+  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/, "no outline on the mark itself: it would paint per line fragment");
+  assert.match(CSS, /\.cmt-outline \{ position: absolute; pointer-events: none;[^}]*outline: 1\.5px solid var\(--cmt-hl\);/s, "one box, the notch's token");
+  assert.match(UI, /function paintCommentOutlines\(sid: string\): void \{/);
   assert.doesNotMatch(CSS, /mark\.cmt-hl \{[^}]*position: relative;/s, "nothing left for the mark to anchor");
   assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1;/);
   // the clearing story is the existing machinery, untouched: optimistic on open + kernel watermark

--- a/ui/webview/rail-sticky-stamp.test.ts
+++ b/ui/webview/rail-sticky-stamp.test.ts
@@ -50,8 +50,10 @@ test("the hand-off happens at the buffer line, with the crossed marker hidden", 
 
 test("scroll drives it (passive, rAF-coalesced) and a resize re-measures it", () => {
   assert.match(SRC, /function scheduleRailSticky\(\): void \{[^}]*railStickyPending[^}]*requestAnimationFrame/s);
-  assert.match(SRC, /addEventListener\("scroll", scheduleRailSticky, \{ passive: true \}\)/,
-    "passive: it measures, never blocks the scroll it annotates");
+  // passive: it measures, never blocks the scroll it annotates; CAPTURE (T310): a scroll inside the pane — a notice body
+  // at its max height, a wide formula — does not bubble, and the unread comment boxes on this scheduler must follow it
+  assert.match(SRC, /addEventListener\("scroll", scheduleRailSticky, \{ passive: true, capture: true \}\)/,
+    "passive: it measures, never blocks the scroll it annotates; capture: inner scrolls reach it too");
   assert.match(SRC, /window\.addEventListener\("resize", scheduleRailSticky\)/);
   // one scheduler, not two: with the spacing pass gone there is nothing to re-run on render but the sticky
   assert.doesNotMatch(SRC, /scheduleRestamp/, "the old restamp scheduler is gone");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3009,7 +3009,7 @@ let railStickyPending = false;
 function scheduleRailSticky(): void {
   if (railStickyPending) return;
   railStickyPending = true;
-  requestAnimationFrame(() => { railStickyPending = false; paintRailSticky(); paintScrollMarks(); updateCommentRail(); if (activeId) paintCommentOutlines(activeId); });
+  requestAnimationFrame(() => { railStickyPending = false; paintRailSticky(); paintScrollMarks(); updateCommentRail(); if (activeId && hasUnreadOpenThread(activeId)) paintCommentOutlines(activeId); });
 }
 
 function renderEventInner(ev: ChatEvent): HTMLElement {
@@ -8404,10 +8404,19 @@ function applyCommentMarks(sid: string): void {
  *  the box sits outside those containers, so an unclipped fragment scrolled out of one would draw over the content
  *  below. Repainted where the geometry can move — after every marks pass (each transcript rebuild and comments frame),
  *  on the rail's rAF scheduler (a re-render, the view's resize observer, every scroll in the pane, inner containers'
- *  included through the capture-phase listener) and on window resize; the same measure-then-write
+ *  included through the capture-phase listener) and on window resize — those two only while the session has an unread
+ *  open thread (hasUnreadOpenThread: a store read, so a scroll frame with nothing to move walks no DOM); the same measure-then-write
  *  pass either way, writing only what changed. pointer-events: none, so hover and click land on the marks beneath.
  *  A box goes with its unread bit (styleCommentMark drops the class when the popover opens or the thread resolves)
  *  and with its marks (a windowed-out turn, a deleted thread); a hidden view has no boxes to measure and keeps none. */
+/** The cheap gate for the geometry hooks (the rail scheduler fires on every scroll frame, the resize listener on every
+ *  resize): a session with no unread open thread has no box to move, so those paths never walk its DOM (review find,
+ *  T310). Read from the thread store, no DOM. The marks pass calls the painter unconditionally: it is the removal path
+ *  (the last unread thread read, resolved or deleted takes its box with it on that pass). */
+function hasUnreadOpenThread(sid: string): boolean {
+  return (commentThreads.get(sid) || []).some((t) => !!t.unread && t.status === "open");
+}
+
 function paintCommentOutlines(sid: string): void {
   const v = views.get(sid);
   if (!v) return;
@@ -8595,7 +8604,7 @@ function updateCommentRail(): void {
     return tick;
   }));
 }
-window.addEventListener("resize", () => { updateCommentRail(); if (activeId) paintCommentOutlines(activeId); });
+window.addEventListener("resize", () => { updateCommentRail(); if (activeId && hasUnreadOpenThread(activeId)) paintCommentOutlines(activeId); });
 
 // (The per-turn count badge is GONE — the user 2026-08-17: the highlight does the speaking, and
 // the scroll-rail tick already covers a thread whose rendered text drifted beyond re-matching.)

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -8400,8 +8400,11 @@ function applyCommentMarks(sid: string): void {
  *  mark paints per fragment, so a wrapped passage read as a stack of dashed boxes). CSS cannot merge the fragments,
  *  so the box is an absolutely positioned child of the TURN (.cmt-outline, one per thread), sized to the union of the
  *  thread's mark fragments' client rects, turn-relative: it scrolls with the text and needs no repaint on scroll.
- *  Repainted where the geometry can move — after every marks pass (each transcript rebuild and comments frame), on
- *  the rail's rAF scheduler (a re-render, the view's resize observer) and on window resize; the same measure-then-write
+ *  Each fragment is first cut to every scrolling ancestor between its mark and the turn (a notice body, a wide formula):
+ *  the box sits outside those containers, so an unclipped fragment scrolled out of one would draw over the content
+ *  below. Repainted where the geometry can move — after every marks pass (each transcript rebuild and comments frame),
+ *  on the rail's rAF scheduler (a re-render, the view's resize observer, every scroll in the pane, inner containers'
+ *  included through the capture-phase listener) and on window resize; the same measure-then-write
  *  pass either way, writing only what changed. pointer-events: none, so hover and click land on the marks beneath.
  *  A box goes with its unread bit (styleCommentMark drops the class when the popover opens or the thread resolves)
  *  and with its marks (a windowed-out turn, a deleted thread); a hidden view has no boxes to measure and keeps none. */
@@ -8428,13 +8431,26 @@ function paintCommentOutlines(sid: string): void {
     if (!turn) continue;
     let l = Infinity, t = Infinity, r = -Infinity, b = -Infinity;
     for (const m of marks) {
+      // a fragment counts only where it can be SEEN: the box lives on the turn, outside any scrolling container between
+      // the mark and the turn (a notice body at its max height, a wide formula), whose clip the fragment's own rect
+      // ignores — so each fragment is cut to every such ancestor first, and a fragment scrolled out of view adds nothing
+      // (review find, T310). The union of what remains is the box; nothing left → no box.
+      let cl = -Infinity, ct = -Infinity, cr = Infinity, cb = Infinity;
+      for (let a = m.parentElement; a && a !== turn; a = a.parentElement) {
+        const cs = getComputedStyle(a);
+        if (cs.overflowX === "visible" && cs.overflowY === "visible") continue;
+        const ar = a.getBoundingClientRect();
+        cl = Math.max(cl, ar.left); ct = Math.max(ct, ar.top); cr = Math.min(cr, ar.right); cb = Math.min(cb, ar.bottom);
+      }
       for (const q of Array.from(m.getClientRects())) {
         if (!q.width && !q.height) continue;
-        l = Math.min(l, q.left); t = Math.min(t, q.top); r = Math.max(r, q.right); b = Math.max(b, q.bottom);
+        const ql = Math.max(q.left, cl), qt = Math.max(q.top, ct), qr = Math.min(q.right, cr), qb = Math.min(q.bottom, cb);
+        if (qr <= ql || qb <= qt) continue;              // clipped away by a scrolling ancestor
+        l = Math.min(l, ql); t = Math.min(t, qt); r = Math.max(r, qr); b = Math.max(b, qb);
       }
     }
     let box = turn.querySelector(`:scope > .cmt-outline[data-tid="${cssEscape(tid)}"]`) as HTMLElement | null;
-    if (!isFinite(l)) { box?.remove(); continue; }        // no fragment has a box (a display:none ancestor)
+    if (!isFinite(l)) { box?.remove(); continue; }        // no visible fragment (a display:none ancestor, or all scrolled out)
     if (!box) { box = el("div", "cmt-outline"); box.dataset.tid = tid; turn.appendChild(box); }
     const tr = turn.getBoundingClientRect();
     const css = { left: (l - tr.left - PAD) + "px", top: (t - tr.top - PAD) + "px", width: (r - l + 2 * PAD) + "px", height: (b - t + 2 * PAD) + "px" };
@@ -11626,10 +11642,13 @@ if (typeof ResizeObserver === "function") {
   const c = document.getElementById("content");
   if (c) ro.observe(c);
 }
-// the sticky rail stamp tracks the scroll it annotates (passive: it only measures, never blocks the scroll)
+// the sticky rail stamp tracks the scroll it annotates (passive: it only measures, never blocks the scroll). CAPTURE,
+// so a scroll INSIDE the pane reaches it too — a notice body at its max height, a wide formula: scroll events do not
+// bubble, and the unread comment boxes (paintCommentOutlines, on this same scheduler) must follow marks that move
+// inside such a container and be cut to it (review find, T310). The other painters here are signature-guarded.
 {
   const c = document.getElementById("content");
-  if (c) c.addEventListener("scroll", scheduleRailSticky, { passive: true });
+  if (c) c.addEventListener("scroll", scheduleRailSticky, { passive: true, capture: true });
 }
 // ── jump to newest (the user 2026-08-31) ─────────────────────────────────────────────────────────
 // Scrolled-up reading leaves follow mode, and the send gate keeps it that way — this chip is the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -3009,7 +3009,7 @@ let railStickyPending = false;
 function scheduleRailSticky(): void {
   if (railStickyPending) return;
   railStickyPending = true;
-  requestAnimationFrame(() => { railStickyPending = false; paintRailSticky(); paintScrollMarks(); updateCommentRail(); });
+  requestAnimationFrame(() => { railStickyPending = false; paintRailSticky(); paintScrollMarks(); updateCommentRail(); if (activeId) paintCommentOutlines(activeId); });
 }
 
 function renderEventInner(ev: ChatEvent): HTMLElement {
@@ -8378,7 +8378,7 @@ function applyCommentMarks(sid: string): void {
   // the rail cue clears first (idempotent re-apply): a thread viewed, resolved, or removed must
   // drop its turn's tint on this very pass, not linger until the next anchor match
   for (const t of Array.from(v.el.querySelectorAll(".turn.cmt-rail-unread"))) t.classList.remove("cmt-rail-unread");
-  if (!threads.length) { if (sid === activeId) updateReplyChips(); return; }   // no threads → no chips (the last one resolved/deleted)
+  if (!threads.length) { paintCommentOutlines(sid); if (sid === activeId) updateReplyChips(); return; }   // no threads → no boxes, no chips (the last one resolved/deleted)
   for (const [uuid, list] of threadsByAnchor(threads)) {
     const turn = v.el.querySelector(`.turn[data-uuid="${cssEscape(uuid)}"]`) as HTMLElement | null;
     if (!turn) continue;                       // windowed out — the mark returns when the turn does
@@ -8389,9 +8389,57 @@ function applyCommentMarks(sid: string): void {
     // openCommentPopover drops the unread flag and re-runs this pass.
     turn.classList.toggle("cmt-rail-unread", list.some((t) => !!t.unread && t.status === "open"));
   }
+  paintCommentOutlines(sid);                   // the unread boxes follow the marks this pass just placed (or unwrapped)
   // the reply chips MEASURE the marks (above/below the viewport), so they recount after this pass has the
   // highlights back in the DOM — this is the comments frame's and every transcript rebuild's hook for them
   if (sid === activeId) updateReplyChips();
+}
+
+/** ONE outline around the WHOLE highlighted passage of an unread open thread (the user 2026-09-10), in the scroll
+ *  notch's yellow (var(--cmt-hl)) — in place of the dashed ring each line fragment wore (an outline on the inline
+ *  mark paints per fragment, so a wrapped passage read as a stack of dashed boxes). CSS cannot merge the fragments,
+ *  so the box is an absolutely positioned child of the TURN (.cmt-outline, one per thread), sized to the union of the
+ *  thread's mark fragments' client rects, turn-relative: it scrolls with the text and needs no repaint on scroll.
+ *  Repainted where the geometry can move — after every marks pass (each transcript rebuild and comments frame), on
+ *  the rail's rAF scheduler (a re-render, the view's resize observer) and on window resize; the same measure-then-write
+ *  pass either way, writing only what changed. pointer-events: none, so hover and click land on the marks beneath.
+ *  A box goes with its unread bit (styleCommentMark drops the class when the popover opens or the thread resolves)
+ *  and with its marks (a windowed-out turn, a deleted thread); a hidden view has no boxes to measure and keeps none. */
+function paintCommentOutlines(sid: string): void {
+  const v = views.get(sid);
+  if (!v) return;
+  const want = new Map<string, HTMLElement[]>();          // tid -> its unread fragments, document order
+  if (v.el.style.display !== "none") {
+    for (const m of Array.from(v.el.querySelectorAll("mark.cmt-hl.unread")) as HTMLElement[]) {
+      const tid = m.dataset.tid || "";
+      const list = want.get(tid);
+      if (list) list.push(m); else want.set(tid, [m]);
+    }
+  }
+  for (const box of Array.from(v.el.querySelectorAll(".cmt-outline")) as HTMLElement[]) {
+    const tid = box.dataset.tid || "";
+    const marks = want.get(tid);
+    // a box whose thread is no longer unread, or that sits on a turn its marks have left, goes
+    if (!marks || marks[0].closest(".turn") !== box.parentElement) box.remove();
+  }
+  const PAD = 1;                                          // the box sits 1px clear of the glyphs (outline-offset's role)
+  for (const [tid, marks] of want) {
+    const turn = marks[0].closest(".turn") as HTMLElement | null;
+    if (!turn) continue;
+    let l = Infinity, t = Infinity, r = -Infinity, b = -Infinity;
+    for (const m of marks) {
+      for (const q of Array.from(m.getClientRects())) {
+        if (!q.width && !q.height) continue;
+        l = Math.min(l, q.left); t = Math.min(t, q.top); r = Math.max(r, q.right); b = Math.max(b, q.bottom);
+      }
+    }
+    let box = turn.querySelector(`:scope > .cmt-outline[data-tid="${cssEscape(tid)}"]`) as HTMLElement | null;
+    if (!isFinite(l)) { box?.remove(); continue; }        // no fragment has a box (a display:none ancestor)
+    if (!box) { box = el("div", "cmt-outline"); box.dataset.tid = tid; turn.appendChild(box); }
+    const tr = turn.getBoundingClientRect();
+    const css = { left: (l - tr.left - PAD) + "px", top: (t - tr.top - PAD) + "px", width: (r - l + 2 * PAD) + "px", height: (b - t + 2 * PAD) + "px" };
+    for (const k of ["left", "top", "width", "height"] as const) if (box.style[k] !== css[k]) box.style[k] = css[k];
+  }
 }
 
 /** The parent side of a branch (the user 2026-08-13): a small "↳ <name>" chip on the turn a fork
@@ -8531,7 +8579,7 @@ function updateCommentRail(): void {
     return tick;
   }));
 }
-window.addEventListener("resize", () => updateCommentRail());
+window.addEventListener("resize", () => { updateCommentRail(); if (activeId) paintCommentOutlines(activeId); });
 
 // (The per-turn count badge is GONE — the user 2026-08-17: the highlight does the speaking, and
 // the scroll-rail tick already covers a thread whose rendered text drifted beyond re-matching.)

--- a/ui/webview/reply-ready.test.ts
+++ b/ui/webview/reply-ready.test.ts
@@ -162,8 +162,9 @@ test("every input is an event the chat already listens for — no timers, no pol
   assert.match(RENDER, /if \(off\) jumpBtn\.style\.bottom = [^\n]*\n\s*updateReplyChips\(\);/, "updateJumpBtn's tail");
   assert.match(RENDER, /c\.addEventListener\("scroll", updateJumpBtn, \{ passive: true \}\);/, "…and that update rides the passive scroll listener");
   // the comments frame and every transcript rebuild re-anchor the marks, then recount (the marks are what gets measured)
-  assert.match(RENDER, /turn\.classList\.toggle\("cmt-rail-unread", [^\n]*\n\s*\}\s*\n[^\n]*\n[^\n]*\n\s*if \(sid === activeId\) updateReplyChips\(\);\s*\n\}/, "applyCommentMarks' tail");
-  assert.match(RENDER, /if \(!threads\.length\) \{ if \(sid === activeId\) updateReplyChips\(\); return; \}/, "…and its no-threads early return drops the chips");
+  // (the unread outline boxes are painted between the marks and the recount — T310 — the chips still close the pass)
+  assert.match(RENDER, /turn\.classList\.toggle\("cmt-rail-unread", [^\n]*\n\s*\}\s*\n\s*paintCommentOutlines\(sid\);[^\n]*\n[^\n]*\n[^\n]*\n\s*if \(sid === activeId\) updateReplyChips\(\);\s*\n\}/, "applyCommentMarks' tail");
+  assert.match(RENDER, /if \(!threads\.length\) \{ paintCommentOutlines\(sid\); if \(sid === activeId\) updateReplyChips\(\); return; \}/, "…and its no-threads early return drops the boxes and the chips");
   assert.match(BLOCK, /new ResizeObserver\(updateReplyChips\)\.observe\(c\);/, "a pane measuring 0 drops the chips like the jump chip");
   assert.match(UPDATE, /if \(sig === replyChipSig\) return;/, "a signature skips unchanged paints (pure scrolls do no DOM work)");
 });

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -206,8 +206,10 @@ test("a reply dot sits at its anchor's position in the notches' own frame, over 
 });
 
 test("the dot is the comment's landed colour; UNREAD shouts; keyed on the kernel's bit on an open thread", () => {
-  assert.match(CSS, /\.cmt-tick \{\s*\n\s*position: absolute; right: 1px; width: 8px; height: 4px;[\s\S]{0,120}background: var\(--cmt-hl\);/, "the landed token, never a raw hex");
-  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;\s*\n\s*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px color-mix\(in srgb, var\(--cmt-hl\) 85%, transparent\); \}/,
+  // the tick's fill is the comment INK (T310): the highlighter yellow itself in the dark theme, a darker amber on the cream
+  // page, the same token the unread passage's outline box wears — never a raw hex
+  assert.match(CSS, /\.cmt-tick \{\s*\n\s*position: absolute; right: 1px; width: 8px; height: 4px;[\s\S]{0,120}background: var\(--cmt-hl-outline\);/, "the ink token, never a raw hex");
+  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;\s*\n\s*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px color-mix\(in srgb, var\(--cmt-hl-outline\) 85%, transparent\); \}/,
     "…and lifted above a read sibling at the same top (nested-marks.test.ts)");
   assert.match(RAIL, /\+ \(th\.unread && th\.status === "open" \? " unread" : ""\)/, "the same predicate the mark's ring and the reply chips read");
   assert.match(RAIL, /\+ ":" \+ \(t\.th\.unread \? 1 : 0\)/, "the unread bit rides the signature: a reply landing repaints the dot");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3313,17 +3313,19 @@ mark.cmt-hl {
   cursor: pointer;
 }
 mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
-/* UNREAD = the needs-you ring (the user 2026-09-08): a landed reply you have not opened wears the SAME
-   dashed ring the tab strip puts on a session that needs you (.tab.tab-awaiting: `2px dashed
-   var(--st-awaiting-bg)`, inset) — one idiom for "something here waits on you", scaled to a text run:
-   1.5px so the dash/gap (Chromium scales them with the width) shortens with it, offset OUTWARD so the
-   ring never crosses the glyphs. An outline, so nothing reflows when it comes and goes; on a run that
-   wraps, every line fragment is ringed. It replaces the 2026-08-23 corner dot (a yellow dot on yellow
-   read as decoration, not as an ask). Its OWN rule, apart from the fill line above: the fill still says
-   pending vs landed exactly as before — the 45% yellow tier is the landed reply, .busy's green wash below
-   the reply still being written — and T237's tests pin that line byte for byte. Read marks wear no ring.
-   Clears with the unread flag the moment the popover opens (optimistic + kernel watermark). */
-mark.cmt-hl.unread { outline: 1.5px dashed var(--st-awaiting-bg); outline-offset: 1px; }
+/* UNREAD = ONE outline around the WHOLE passage (the user 2026-09-10): a landed reply you have not opened draws a
+   single solid box in the scroll notch's yellow — var(--cmt-hl), the colour .cmt-tick wears for the same thread —
+   around the union of the highlight's line fragments. The 2026-09-08 dashed ring was an outline on the inline
+   mark, which Chromium paints once per line fragment, so a wrapped passage wore a stack of dashed boxes. CSS
+   cannot merge a mark's fragments (box-decoration-break: clone keeps them apart), so the box is a positioned
+   child of the TURN that render.ts's paintCommentOutlines measures from the marks' client rects — turn-relative,
+   so it scrolls with the text and needs no repaint on scroll; repainted after every marks pass, on the rail's
+   rAF scheduler (a re-render, the view's resize) and on window resize. An OUTLINE on an empty box, so nothing
+   reflows when it comes and goes; 1px clear of the glyphs; transparent to the pointer, so hover and click land
+   on the marks beneath. The fill still says pending vs landed exactly as before (the 45% tier above, .busy's
+   green below); read marks have no box. */
+.cmt-outline { position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;
+  outline: 1.5px solid var(--cmt-hl); border-radius: 3px; }
 /* the turn's rail segment shouts an unread thread (the user 2026-08-23): the identity line's own
    segment tints the comment yellow — wider and fully opaque so it reads from across the pane — and
    the rail-hit strip over it opens the thread on click. applyCommentMarks clears the class the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -164,6 +164,7 @@ body.scheme-solarized-dark {
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
   --cmt-hl: #ffd54a;
+  --cmt-hl-outline: #ffd54a;   /* the ink of the comment notch and the unread box: the fill's yellow here, darker on cream (T310) */
   /* fast mode ON — the CLI's own fastMode orange, a STATUS color (means "this session runs fast
      mode"), so the badge reads the same here as in the Claude Code TUI. Not the accent. */
   --fast: #ff6a00;
@@ -232,6 +233,7 @@ body.theme-light {
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
   --cmt-hl: #FFDF70;
+  --cmt-hl-outline: #8f6a00;   /* amber ink: 4.2:1 on the cream page — the fill's yellow measures 1.1:1 there, invisible as a line (T310) */
   --fast: #D45500;
   --warn: #9A6A00;
   /* the WORKING gold and the COMPACTING teal are re-inked for cream (the user 2026-09-08, decision 3 of the
@@ -3314,8 +3316,10 @@ mark.cmt-hl {
 }
 mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
 /* UNREAD = ONE outline around the WHOLE passage (the user 2026-09-10): a landed reply you have not opened draws a
-   single solid box in the scroll notch's yellow — var(--cmt-hl), the colour .cmt-tick wears for the same thread —
-   around the union of the highlight's line fragments. The 2026-09-08 dashed ring was an outline on the inline
+   single solid box in the scroll notch's ink — var(--cmt-hl-outline), the colour .cmt-tick wears for the same thread:
+   the highlighter yellow itself in the dark theme, a darker amber on the cream page, where the yellow reads as a fill
+   but not as a line — around the union of the highlight's line fragments, clipped to any scrolling container between
+   the marks and the turn (a notice body, a wide formula). The 2026-09-08 dashed ring was an outline on the inline
    mark, which Chromium paints once per line fragment, so a wrapped passage wore a stack of dashed boxes. CSS
    cannot merge a mark's fragments (box-decoration-break: clone keeps them apart), so the box is a positioned
    child of the TURN that render.ts's paintCommentOutlines measures from the marks' client rects — turn-relative,
@@ -3325,7 +3329,7 @@ mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transpare
    on the marks beneath. The fill still says pending vs landed exactly as before (the 45% tier above, .busy's
    green below); read marks have no box. */
 .cmt-outline { position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;
-  outline: 1.5px solid var(--cmt-hl); border-radius: 3px; }
+  outline: 1.5px solid var(--cmt-hl-outline); border-radius: 3px; }
 /* the turn's rail segment shouts an unread thread (the user 2026-08-23): the identity line's own
    segment tints the comment yellow — wider and fully opaque so it reads from across the pane — and
    the rail-hit strip over it opens the thread on click. applyCommentMarks clears the class the
@@ -3526,7 +3530,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-tick {
   position: absolute; right: 1px; width: 8px; height: 4px;
   border: 0; border-radius: 2px; padding: 0;
-  background: var(--cmt-hl); opacity: 0.75; pointer-events: auto; cursor: pointer;
+  background: var(--cmt-hl-outline); opacity: 0.75; pointer-events: auto; cursor: pointer;   /* the ink the unread box shares (T310) */
 }
 .cmt-tick:hover { opacity: 1; }
 .cmt-tick.resolved { opacity: 0.3; }
@@ -3535,7 +3539,7 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    two threads on one passage share a `top`, and the later-painted read tick covered the unread one
    (the user 2026-09-10) */
 .cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;
-  box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl) 85%, transparent); }
+  box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl-outline) 85%, transparent); }
 /* a WRITING thread's tick wears the same await-green as the passage (the user 2026-08-24: the
    marching-ants crawl — the "spinning dots" — is retired; the state COLOR is the in-flight cue,
    here as everywhere on the rail) */

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -54,6 +54,7 @@ const PAIRS: Array<[string, string, number]> = [
   ["--dim", "--bg", 4.5],
   ["--fg", "--surface-raised", 4.5],
   ["--accent", "--bg", 3],
+  ["--cmt-hl-outline", "--bg", 3],   // the comment notch and the unread box: a LINE, so it must read against the page (T310)
   ["--accent-fg", "--accent", 3],
   ["--warn", "--bg", 3],
   ["--err", "--bg", 3],


### PR DESCRIPTION
An unread comment thread (a landed reply the user has not opened) wore a dashed outline on its highlight mark. An outline on an inline mark paints once per line fragment, so a wrapped passage read as a stack of dashed boxes, one per line. The user's ruling (2026-09-10): ONE outline around the WHOLE highlighted area, in the same yellow the scroll rail's notch uses for that thread, never a per-line treatment.

## Design

- **One box per unread thread, drawn from the marks.** CSS cannot merge a mark's line fragments (`box-decoration-break: clone` keeps them apart), so the cue is an absolutely positioned child of the anchor turn, `.cmt-outline`, sized by `paintCommentOutlines` in render.ts to the union of the thread's mark fragments' client rects. Turn-relative coordinates: the box scrolls with the text and needs no repaint on scroll.
- **Nothing moves, nothing tints.** An outline on an empty box (nothing reflows when it comes and goes), 1px clear of the glyphs, `pointer-events: none` so hover and click land on the marks beneath. The fill tiers are untouched: 45% yellow still says landed, the green wash still says a reply is being written.
- **The notch's colour, exactly.** Solid 1.5px in `var(--cmt-hl)`, the token `.cmt-tick` wears, so box and notch agree in both themes.
- **Event-driven repaint, no timers.** After every marks pass (each transcript rebuild and comments frame), on the rail's rAF scheduler (a re-render, the view's resize observer) and on window resize, writing only what changed. The box goes with the unread bit (the popover opening, a resolve) and with the marks (a windowed-out turn, a deleted thread).

## Tests

- `ui/webview/comment-outline.test.ts`: the rule (solid, the tick's token, positioned, pointer-transparent, no hex), the painter's shape (unread marks only, grouped by thread, union of `getClientRects`, a child of the turn, stale boxes removed, hidden view keeps none) and its three hooks.
- `ui/webview/comment-mark.test.ts`: no mark rule carries an outline any more; the fill tiers and the unread bit's one clearer stay pinned.
- `tests/test_comment_outline_served.py`: the real /chat page of a hermetic kernel with a two-line and a five-line unread passage. Exactly one box per thread covering every fragment, hugging the union; outline colour byte-equal to the thread's scroll tick in the dark and the light theme; no fragment with an outline of its own; opening one thread removes its box on the same pass and leaves the other's. With `COMMENT_SHOTS=<dir>` it writes the dark and light screenshots.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
