### PR TITLE
The comment popup remembers its size and gains a maximize control

### DIFF
--- a/tests/test_comment_pop_size_browser.py
+++ b/tests/test_comment_pop_size_browser.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""The comment dialog remembers its size and has a maximize control, executed in a real browser (the user
+2026-09-10, who kept enlarging the box by hand on every open).
+
+The source pins in ui/webview/comment-pop-size.test.ts say the wiring exists; nothing there proves the box
+the user sees behaves — that a ResizeObserver actually fires for a native-grip-style inline resize and for
+the JS edge band, that the stored fraction survives a reload into BOTH dialogs, that a phone-sized window
+keeps the 8px margins, and above all that a double-click on the title bar reaches the toggle at all: the
+whole-box drag captures the pointer on every press, which retargets the click it ends in to the box, so this
+is the executed guard the task asked for rather than an assumption. A hermetic kernel serves the real /chat
+page with a synthetic session whose transcript carries one seeded thread (the comments store the kernel
+itself writes), and the driver walks:
+  fresh   — nothing stored: the thread dialog opens at 70% × 60% right-aligned at top 120 (today's geometry),
+            the create dialog opens content-sized with NO inline width/height;
+  resize  — an inline resize (what the native grip does) and a pull on the east edge band both write the
+            fraction; after a reload both dialogs open at the remembered size, in bounds;
+  tiny    — a full-size preference on a 480×360 window opens capped inside the 8px margins, reading Restore;
+  toggle  — the button maximizes (cap, centered, Restore, data-max, remembered) and restores (the size it had,
+            centered, Maximize); a double-click on the title does the same, twice; the create dialog's
+            restore drops the inline size and the preference, and a double-click on its name box is exempt.
+Skips LOUDLY without the extension deps or a playwright browser (CI installs none); it executes on any dev
+box with the extension installed. All fixtures synthetic (the notes-api demo world, session web)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TID = "cccccccc-1111-2222-3333-444444444444"     # the seeded thread (tid == its own session id, as the kernel mints them)
+U_UUID = "11111111-2222-3333-4444-555555555555"
+A_UUID = "22222222-3333-4444-5555-666666666666"
+REPLY = "The web session finished the notes-api login flow and every test passes now. Next up is the password reset path."
+EXACT = "finished the notes-api login flow"      # the passage the seeded thread highlights
+W, H = 1200, 800
+TINY_W, TINY_H = 480, 360
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const KEY = "romp:cmtPopSize";
+const page = await browser.newPage({ viewport: { width: cfg.W, height: cfg.H } });
+
+async function load() {
+  await page.goto(cfg.chat);
+  await page.waitForSelector("#content .turn p", { timeout: 20000 });
+  await page.waitForSelector("mark.cmt-hl[data-tid]", { timeout: 20000 });   // the seeded thread's highlight has landed
+  await page.waitForTimeout(300);
+}
+const geom = () => page.evaluate(() => {
+  const pop = document.getElementById("cmt-pop");
+  if (!pop) return null;
+  const r = pop.getBoundingClientRect();
+  const btn = pop.querySelector(".cmt-max"), x = pop.querySelector(".cmt-x");
+  return { mode: pop.dataset.mode, w: pop.offsetWidth, h: pop.offsetHeight,
+    left: Math.round(r.left), top: Math.round(r.top), right: Math.round(r.right), bottom: Math.round(r.bottom),
+    styleW: pop.style.width, styleH: pop.style.height, sized: pop.classList.contains("sized"), max: pop.dataset.max || null,
+    btn: btn ? { title: btn.title, aria: btn.getAttribute("aria-label"), inHead: !!btn.closest(".cmt-head"),
+                 beforeX: btn.nextElementSibling === x, svg: /<svg [^>]*viewBox="0 0 16 16"/.test(btn.innerHTML),
+                 frames: (btn.innerHTML.match(/<rect|<path/g) || []).length } : null,
+    stored: localStorage.getItem("romp:cmtPopSize"), W: innerWidth, H: innerHeight };
+});
+async function openThread() {
+  await page.click("mark.cmt-hl[data-tid]");
+  await page.waitForSelector('#cmt-pop[data-mode="thread"]', { timeout: 10000 });
+  await page.waitForTimeout(120);   // the observer's first delivery (a frame) before we read anything
+  return geom();
+}
+async function openCreate() {
+  const info = await page.evaluate((t) => {
+    const turn = Array.from(document.querySelectorAll(".turn")).find((n) => (n.textContent || "").includes(t));
+    const md = turn.querySelector(".md") || turn;
+    const walker = document.createTreeWalker(md, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node && !(node.textContent || "").includes("password")) node = walker.nextNode();
+    const i = node.textContent.indexOf("password");
+    const sel = window.getSelection(); sel.removeAllRanges();
+    const r = document.createRange(); r.setStart(node, i); r.setEnd(node, i + 8); sel.addRange(r);
+    const box = md.getBoundingClientRect();
+    md.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: box.left + 20, clientY: box.top + 10, button: 2 }));
+    return { selected: sel.toString(), items: Array.from(document.querySelectorAll(".ctx-menu .ctx-item")).map((i) => i.textContent) };
+  }, REPLY_PLACEHOLDER);
+  const comment = page.locator(".ctx-menu .ctx-item", { hasText: "Comment" }).first();
+  try { await comment.waitFor({ timeout: 5000 }); } catch (e) { console.error("no Comment item: " + JSON.stringify(info)); process.exit(1); }
+  await comment.click();
+  await page.waitForSelector('#cmt-pop[data-mode="create"]', { timeout: 10000 });
+  await page.waitForTimeout(120);
+  return geom();
+}
+async function closePop() {
+  await page.click("#cmt-pop .cmt-x");
+  await page.waitForSelector("#cmt-pop", { state: "detached", timeout: 5000 });
+}
+const storedChanged = async (before) => page.waitForFunction((b) => localStorage.getItem("romp:cmtPopSize") !== b, before, { timeout: 5000 });
+
+const out = {};
+// ── fresh: nothing stored ────────────────────────────────────────────────────────────────────────
+await load();
+out.freshThread = await openThread();
+await closePop();
+out.freshCreate = await openCreate();
+await closePop();
+// ── resize: the native grip's effect (an inline size) and the JS edge band both write the fraction ──
+const g0 = await openThread();
+await page.evaluate(() => { const p = document.getElementById("cmt-pop"); p.style.width = "600px"; p.style.height = "300px"; });
+await storedChanged(g0.stored);
+out.afterInline = await geom();
+// the east edge band: 3px inside the right edge, mid-height (well clear of the native grip's corner), pull +100
+const g1 = out.afterInline;
+await page.mouse.move(g1.right - 3, g1.top + Math.round(g1.h / 2));
+await page.mouse.down();
+await page.mouse.move(g1.right + 40, g1.top + Math.round(g1.h / 2), { steps: 4 });
+await page.mouse.move(g1.right + 97, g1.top + Math.round(g1.h / 2), { steps: 4 });
+await page.mouse.up();
+await storedChanged(g1.stored);
+out.afterEdge = await geom();
+await closePop();
+// ── reload: both dialogs open at the remembered fraction ─────────────────────────────────────────
+await load();
+out.rememberedThread = await openThread();
+await closePop();
+out.rememberedCreate = await openCreate();
+await closePop();
+// ── tiny: a full-size preference on a phone-sized window stays inside the 8px margins ────────────
+await page.evaluate(() => localStorage.setItem("romp:cmtPopSize", JSON.stringify({ w: 1, h: 1 })));
+await page.setViewportSize({ width: cfg.TINY_W, height: cfg.TINY_H });
+await load();
+out.tinyThread = await openThread();
+await closePop();
+// ── toggle: the button, then the title bar's double-click ────────────────────────────────────────
+await page.setViewportSize({ width: cfg.W, height: cfg.H });
+await page.evaluate(() => localStorage.removeItem("romp:cmtPopSize"));
+await load();
+out.beforeMax = await openThread();
+await page.click("#cmt-pop .cmt-max");
+await page.waitForTimeout(80);
+out.maxed = await geom();
+await page.click("#cmt-pop .cmt-max");
+await page.waitForTimeout(80);
+out.restored = await geom();
+await page.dblclick("#cmt-pop .cmt-title");
+await page.waitForTimeout(80);
+out.dblMaxed = await geom();
+await page.dblclick("#cmt-pop .cmt-title");
+await page.waitForTimeout(80);
+out.dblRestored = await geom();
+await closePop();
+// the create dialog: content-sized → maximize → (a double-click on its name box is exempt) → restore drops the size
+await page.evaluate(() => localStorage.removeItem("romp:cmtPopSize"));
+out.createBefore = await openCreate();
+await page.click("#cmt-pop .cmt-max");
+await page.waitForTimeout(80);
+out.createMaxed = await geom();
+await page.dblclick("#cmt-pop .cmt-name");
+await page.waitForTimeout(80);
+out.createAfterNameDbl = await geom();
+await page.click("#cmt-pop .cmt-max");
+await page.waitForTimeout(80);
+out.createRestored = await geom();
+await closePop();
+
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+""".replace("REPLY_PLACEHOLDER", json.dumps(REPLY))
+
+
+class ServedCommentPopSize(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served dialog needs them")
+        cls.lab = tempfile.mkdtemp(prefix="comment-pop-size-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            shutil.rmtree(cls.lab, ignore_errors=True)
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states", "comments"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        claude = os.path.join(cls.lab, "claude")
+        # the kernel finds a session's transcript under Claude's project dir: EVERY non-alphanumeric char of the
+        # realpath becomes '-' (jd._proj_dir)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # a CLOSED turn: an open one would invite the boot reconcile to resume it — no real CLI here
+        Path(proj, SID + ".jsonl").write_text(
+            json.dumps({"type": "user", "uuid": U_UUID, "parentUuid": None,
+                        "timestamp": "2026-09-05T00:00:00.000Z", "sessionId": SID,
+                        "message": {"role": "user", "content": "Where do we stand on the login flow?"}}) + "\n" +
+            json.dumps({"type": "assistant", "uuid": A_UUID, "parentUuid": U_UUID,
+                        "timestamp": "2026-09-05T00:00:05.000Z", "sessionId": SID,
+                        "message": {"role": "assistant", "model": "claude-fable-5-1",
+                                    "content": [{"type": "text", "text": REPLY}],
+                                    "stop_reason": "end_turn"}}) + "\n")
+        # ONE thread anchored on the reply — the store the kernel's own create writes (_comment_create's row shape),
+        # so the chat paints its highlight and a click on it opens the THREAD dialog. Its conversation never existed
+        # (no thread transcript here), which the kernel reports as an unreachable thread; the geometry is the same.
+        now = int(time.time())
+        Path(cls.state, "comments", SID + ".json").write_text(json.dumps({"threads": [
+            {"tid": TID, "sid": TID, "anchorUuid": A_UUID, "cutUuid": A_UUID, "anchorT": now - 900, "exact": EXACT,
+             "status": "open", "createdT": now - 600, "lastSeenT": now - 600, "name": "web-comment-1", "color": "#e8b220"}]}))
+        cls.port = _free_port()
+        cls.token = "testtok-cmtpopsize"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        cls.klog = open(os.path.join(cls.lab, "kernel.log"), "w")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=cls.klog, stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        if getattr(cls, "klog", None):
+            cls.klog.close()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token),
+                       "W": W, "H": H, "TINY_W": TINY_W, "TINY_H": TINY_H}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served dialog needs one (CI installs none)")
+        klog = open(os.path.join(self.lab, "kernel.log")).read()[-2000:]
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + klog)
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    @staticmethod
+    def _frac(g):
+        return json.loads(g["stored"]) if g["stored"] else None
+
+    def _button(self, g, label):
+        b = g["btn"]
+        self.assertIsNotNone(b, "the maximize button exists: %r" % g)
+        self.assertTrue(b["inHead"] and b["beforeX"], "in .cmt-head, right before the ×: %r" % b)
+        self.assertTrue(b["svg"], "a 16-unit line glyph: %r" % b)
+        self.assertEqual((b["title"], b["aria"]), (label, label), "its label reads %s: %r" % (label, b))
+        self.assertEqual(b["frames"], 1 if label == "Maximize" else 2, "one frame = maximize, two = restore: %r" % b)
+
+    def _inside(self, g, margin=8):
+        self.assertGreaterEqual(g["left"], margin, "left margin: %r" % g)
+        self.assertGreaterEqual(g["top"], margin, "top margin: %r" % g)
+        self.assertLessEqual(g["right"], g["W"] - margin, "right margin: %r" % g)
+        self.assertLessEqual(g["bottom"], g["H"] - margin, "bottom margin: %r" % g)
+
+    def test_the_dialog_remembers_its_size_and_maximizes_from_the_button_and_the_title_bar(self):
+        o = self._drive()
+        # ── fresh: today's geometry, byte for byte ──
+        g = o["freshThread"]
+        self.assertEqual(g["mode"], "thread")
+        self.assertIsNone(g["stored"], "nothing stored before any resize")
+        self.assertEqual((g["styleW"], g["styleH"]), ("%dpx" % round(W * 0.7), "%dpx" % round(H * 0.6)), "70%% × 60%% inline: %r" % g)
+        self.assertEqual((g["w"], g["h"]), (840, 480))
+        self.assertEqual((g["left"], g["top"]), (W - 840 - 8, 120), "right-aligned at top 120: %r" % g)
+        self.assertIsNone(g["max"]); self._button(g, "Maximize")
+        g = o["freshCreate"]
+        self.assertEqual(g["mode"], "create")
+        self.assertEqual((g["styleW"], g["styleH"]), ("", ""), "the create dialog carries NO inline size: %r" % g)
+        self.assertIsNone(g["stored"], "opening writes nothing")
+        self.assertFalse(g["sized"], "content-sized: the quote clamp still applies")
+        self.assertIsNone(g["max"]); self._button(g, "Maximize")
+        # ── resize: both paths write the fraction of the window ──
+        g = o["afterInline"]
+        self.assertEqual((g["w"], g["h"]), (600, 300))
+        self.assertEqual(self._frac(g), {"w": 0.5, "h": 0.375}, "an inline resize (the native grip's effect) is remembered: %r" % g)
+        g = o["afterEdge"]
+        self.assertEqual(g["h"], 300, "an east pull leaves the height: %r" % g)
+        self.assertEqual(g["w"], 700, "the edge band pulled +100: %r" % g)
+        self.assertEqual(g["left"], o["afterInline"]["left"], "east anchored west: %r" % g)
+        self.assertTrue(g["sized"])
+        f = self._frac(g)
+        self.assertAlmostEqual(f["w"], 700 / W, places=4, msg="the edge band's pull is remembered too: %r" % g)
+        self.assertAlmostEqual(f["h"], 0.375, places=4)
+        # ── reload: both dialogs open at the remembered fraction, in bounds ──
+        g = o["rememberedThread"]
+        self.assertEqual((g["w"], g["h"]), (700, 300), "the thread dialog opens at the remembered size: %r" % g)
+        self.assertEqual((g["left"], g["top"]), (W - 700 - 8, 120), "still right-aligned at top 120: %r" % g)
+        self.assertTrue(g["sized"], "an applied preference is an expressed size")
+        self._inside(g); self.assertIsNone(g["max"]); self._button(g, "Maximize")
+        g = o["rememberedCreate"]
+        self.assertEqual(g["mode"], "create")
+        self.assertEqual((g["w"], g["h"]), (700, 300), "the create dialog shares the preference: %r" % g)
+        self.assertTrue(g["sized"]); self._inside(g)
+        # ── tiny: a full-size preference stays inside the 8px margins, and reads as maximized ──
+        g = o["tinyThread"]
+        self.assertEqual((g["W"], g["H"]), (TINY_W, TINY_H))
+        self.assertEqual((g["w"], g["h"]), (round(TINY_W * 0.94), round(TINY_H * 0.9)), "capped at 94vw × 90vh: %r" % g)
+        self._inside(g)
+        self.assertEqual(g["max"], "1", "the cap IS maximized, computed at open: %r" % g)
+        self._button(g, "Restore")
+        # ── toggle: the button ──
+        g = o["beforeMax"]
+        self.assertEqual((g["w"], g["h"]), (840, 480), "the preference was cleared: today's default again: %r" % g)
+        g = o["maxed"]
+        self.assertEqual((g["w"], g["h"]), (1128, 720), "the cap: %r" % g)
+        self.assertEqual((g["left"], g["top"]), (36, 40), "centered: %r" % g)
+        self.assertEqual(g["max"], "1"); self.assertTrue(g["sized"]); self._button(g, "Restore")
+        self.assertEqual(self._frac(g), {"w": 0.94, "h": 0.9}, "maximize is remembered like any resize: %r" % g)
+        g = o["restored"]
+        self.assertEqual((g["w"], g["h"]), (840, 480), "back to the size it had: %r" % g)
+        self.assertEqual((g["left"], g["top"]), (180, 160), "kept centered: %r" % g)
+        self.assertIsNone(g["max"]); self._button(g, "Maximize")
+        self.assertEqual(self._frac(g), {"w": 0.7, "h": 0.6}, "the restored size is what is remembered: %r" % g)
+        # ── toggle: the title bar's double-click reaches the same toggle (the drag's pointer capture notwithstanding) ──
+        g = o["dblMaxed"]
+        self.assertEqual((g["w"], g["h"], g["max"]), (1128, 720, "1"), "a double-click on the title maximizes: %r" % g)
+        self._button(g, "Restore")
+        g = o["dblRestored"]
+        self.assertEqual((g["w"], g["h"], g["max"]), (840, 480, None), "a second double-click restores: %r" % g)
+        self._button(g, "Maximize")
+        # ── the create dialog: content-sized → cap → (name box exempt) → content-sized again, preference gone ──
+        g = o["createBefore"]
+        self.assertEqual((g["styleW"], g["styleH"]), ("", ""), "content-sized with the preference cleared: %r" % g)
+        g = o["createMaxed"]
+        self.assertEqual((g["w"], g["h"], g["max"]), (1128, 720, "1"), "the create dialog maximizes too: %r" % g)
+        self.assertEqual((g["left"], g["top"]), (36, 40))
+        g = o["createAfterNameDbl"]
+        self.assertEqual((g["w"], g["h"], g["max"]), (1128, 720, "1"), "a double-click on the name box is exempt: %r" % g)
+        g = o["createRestored"]
+        self.assertEqual((g["styleW"], g["styleH"]), ("", ""), "restore drops the inline size — content-sized again: %r" % g)
+        self.assertIsNone(g["stored"], "…and the preference with it: %r" % g)
+        self.assertFalse(g["sized"]); self.assertIsNone(g["max"]); self._button(g, "Maximize")
+        self._inside(g)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/comment-pop-size.test.ts
+++ b/ui/webview/comment-pop-size.test.ts
@@ -1,0 +1,195 @@
+// Remembered size + maximize for the comment popover (the user 2026-09-10, who kept enlarging the box by
+// hand on every open): the size the user last dragged it to is applied on every open, in the thread AND the
+// create dialog, as a fraction of the window re-clamped to the live one; a maximize control (the head's
+// button, or a double-click on the title bar) snaps it to the cap and back. Nothing stored → both modes open
+// exactly as before. Executed tests on the pure module + source pins for the wiring (no jsdom for the chat
+// renderer); the real-browser check is tests/test_comment_pop_size_browser.py.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CMT_POP_SIZE_KEY, CMT_POP_MIN_W, CMT_POP_MIN_H, CMT_POP_CAP_W, CMT_POP_CAP_H, CMT_POP_EDGE, CMT_POP_THREAD_DEFAULT,
+  CMT_POP_MAX_SLACK, cmtPopCapPx, clampCmtPopPx, toCmtPopFrac, parseCmtPopSize, isCmtPopMax, centerCmtPop } from "../../ui/webview/comment-pop-size";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const SETTINGS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "settings.ts"), "utf8");
+const MODULE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "comment-pop-size.ts"), "utf8");
+
+// ── the pure module ─────────────────────────────────────────────────────────────────────────────
+
+test("executed: a dragged size round-trips through the stored fraction, and means the same thing on a smaller window", () => {
+  const f = toCmtPopFrac(840, 480, 1200, 800);
+  assert.deepEqual(f, { w: 0.7, h: 0.6 });
+  assert.deepEqual(parseCmtPopSize(JSON.stringify(f)), f, "what is written reads back");
+  assert.deepEqual(clampCmtPopPx(f, 1200, 800), { w: 840, h: 480 }, "the same window: the same pixels");
+  assert.deepEqual(clampCmtPopPx(f, 600, 400), { w: 420, h: 240 }, "half the window: half the pixels — a fraction, not a px count");
+  assert.deepEqual(clampCmtPopPx({ w: 0.5, h: 0.5 }, 1001, 801), { w: 501, h: 401 }, "whole pixels");
+});
+
+test("executed: the floor is the CSS mins and the cap the CSS caps — and the box never comes nearer than 8px to an edge", () => {
+  assert.equal(CMT_POP_MIN_W, 300); assert.equal(CMT_POP_MIN_H, 120);
+  assert.equal(CMT_POP_CAP_W, 0.94); assert.equal(CMT_POP_CAP_H, 0.90); assert.equal(CMT_POP_EDGE, 8);
+  assert.deepEqual(clampCmtPopPx({ w: 0.01, h: 0.01 }, 1200, 800), { w: 300, h: 120 }, "a tiny stored fraction lands on the CSS mins");
+  assert.deepEqual(clampCmtPopPx({ w: 1, h: 1 }, 1200, 800), { w: 1128, h: 720 }, "a full stored fraction lands on 94vw × 90vh");
+  assert.deepEqual(cmtPopCapPx(1200, 800), { w: 1128, h: 720 }, "the maximize target is the same cap");
+  // the px-available rule: on a short window 90vh would leave less than 8px above and below — H−16 wins
+  assert.deepEqual(clampCmtPopPx({ w: 1, h: 1 }, 800, 150), { w: 752, h: 134 }, "150px tall: 0.9×150 = 135 > 150−16 = 134");
+  // a window too small for both: the floor wins over the cap, exactly as CSS resolves min-width over max-width
+  assert.deepEqual(clampCmtPopPx({ w: 1, h: 1 }, 200, 100), { w: 300, h: 120 });
+  // the phone case the browser test drives: 480×360 keeps the 8px margins with room to spare
+  const tiny = clampCmtPopPx({ w: 1, h: 1 }, 480, 360);
+  assert.deepEqual(tiny, { w: 451, h: 324 });
+  assert.ok(tiny.w <= 480 - 2 * CMT_POP_EDGE && tiny.h <= 360 - 2 * CMT_POP_EDGE);
+});
+
+test("executed: a live size becomes a fraction in (0, 1] — never 0, never over 1, never NaN into storage", () => {
+  assert.deepEqual(toCmtPopFrac(1128, 720, 1200, 800), { w: 0.94, h: 0.9 });
+  assert.deepEqual(toCmtPopFrac(5000, 5000, 1200, 800), { w: 1, h: 1 }, "wider than the window caps at 1");
+  assert.deepEqual(toCmtPopFrac(0, 0, 1200, 800), { w: 0.01, h: 0.01 }, "a 0×0 box never stores a zero");
+  assert.deepEqual(toCmtPopFrac(300, 120, 0, 0), { w: 1, h: 1 }, "a zero window (never in practice) stays finite");
+});
+
+test("executed: a stored entry parses to a fraction pair or null — garbage and partials never throw", () => {
+  assert.equal(parseCmtPopSize(null), null, "never stored");
+  assert.equal(parseCmtPopSize(""), null, "reset");
+  assert.equal(parseCmtPopSize("garbage"), null);
+  assert.equal(parseCmtPopSize("{"), null, "half a JSON object");
+  assert.equal(parseCmtPopSize("[]"), null);
+  assert.equal(parseCmtPopSize("null"), null);
+  assert.equal(parseCmtPopSize("42"), null);
+  assert.equal(parseCmtPopSize('{"w":0.5}'), null, "a partial pair");
+  assert.equal(parseCmtPopSize('{"w":0.5,"h":"x"}'), null, "a string where a number goes");
+  assert.equal(parseCmtPopSize('{"w":0,"h":0.5}'), null, "zero is not a size");
+  assert.equal(parseCmtPopSize('{"w":1.5,"h":0.5}'), null, "over the window is not a fraction");
+  assert.equal(parseCmtPopSize('{"w":-0.5,"h":0.5}'), null);
+  assert.deepEqual(parseCmtPopSize('{"w":0.5,"h":0.25}'), { w: 0.5, h: 0.25 });
+  assert.deepEqual(parseCmtPopSize('{"w":1,"h":1,"extra":true}'), { w: 1, h: 1 }, "unknown keys are ignored");
+});
+
+test("executed: maximized is the LIVE size within a few px of the cap — computed, not a stored bit", () => {
+  assert.equal(CMT_POP_MAX_SLACK, 4);
+  assert.equal(isCmtPopMax(1128, 720, 1200, 800), true, "exactly the cap");
+  assert.equal(isCmtPopMax(1125, 717, 1200, 800), true, "a few px short still reads maximized");
+  assert.equal(isCmtPopMax(1120, 720, 1200, 800), false, "8px short on one axis is a size of its own");
+  assert.equal(isCmtPopMax(1128, 700, 1200, 800), false);
+  assert.equal(isCmtPopMax(840, 480, 1200, 800), false, "the thread default is not maximized");
+  assert.equal(isCmtPopMax(1128, 720, 2400, 1600), false, "the same pixels on a bigger window are not the cap");
+});
+
+test("executed: centering, with the 8px margin as the floor", () => {
+  assert.deepEqual(centerCmtPop(1128, 720, 1200, 800), { left: 36, top: 40 });
+  assert.deepEqual(centerCmtPop(840, 480, 1200, 800), { left: 180, top: 160 });
+  assert.deepEqual(centerCmtPop(300, 120, 316, 130), { left: 8, top: 8 }, "a box that barely fits sits at the margin, never above it");
+  assert.deepEqual(centerCmtPop(301, 121, 1000, 1000), { left: 350, top: 440 }, "whole pixels");
+});
+
+// ── the wiring in render.ts / styles.css ────────────────────────────────────────────────────────
+
+test("the module restates the CSS mins/caps and wireEdgeResize's floor verbatim — one set of numbers", () => {
+  assert.match(CSS, /\.cmt-pop \{[^}]*max-width: 94vw/s);
+  assert.match(CSS, /\.cmt-pop \{[^}]*min-width: 300px; min-height: 120px; max-height: 90vh/s);
+  const fn = RENDER.split("function wireEdgeResize(")[1].split("\nfunction ")[0];
+  assert.ok(fn.includes("const MIN_W = 300, MIN_H = 120;"), "the edge bands' floor is the same floor");
+  assert.match(MODULE, /is per-viewer ARRANGEMENT, like the tab strip's dragged cap/, "the header says why localStorage");
+  assert.equal(CMT_POP_SIZE_KEY, "romp:cmtPopSize");
+  assert.ok(!SETTINGS.includes("cmtPop"), "not a kernel setting: settings.ts carries nothing of it");
+});
+
+test("a stored size is applied in BOTH modes, before the thread default — which stays verbatim, so nothing stored opens as before", () => {
+  const body = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
+  const pref = body.indexOf("const pref = readCmtPopSize();");
+  const thW = body.indexOf('if (th && !pop.style.width) { pop.style.width = Math.round(window.innerWidth * 0.7) + "px"; }');
+  const thH = body.indexOf('if (th && !pop.style.height) { pop.style.height = Math.round(window.innerHeight * 0.6) + "px"; }');
+  const applied = body.indexOf("cmtPopApplied = { w: pop.offsetWidth, h: pop.offsetHeight };   // whatever it measures now is ours");
+  const rect = body.indexOf("const r = pop.getBoundingClientRect();");
+  const sync = body.indexOf("syncCmtMaxState(pop);                              // a stored cap-sized preference opens reading");
+  assert.ok(pref > 0 && thW > pref && thH > thW && applied > thH && rect > applied && sync > rect,
+    "order: read the preference → apply it → the thread default fills what it left → baseline → position → paint the toggle");
+  const block = body.slice(pref, thW);
+  assert.match(block, /const sz = clampCmtPopPx\(pref, window\.innerWidth, window\.innerHeight\);/, "re-clamped to the LIVE window");
+  assert.match(block, /pop\.style\.width = sz\.w \+ "px";\s*\n\s*pop\.style\.height = sz\.h \+ "px";/);
+  assert.match(block, /pop\.classList\.add\("sized"\);/, "an expressed size: the reflow rules apply from open");
+  assert.ok(!block.includes("if (th"), "the preference branch is mode-blind: create and thread alike");
+  // the create dialog with nothing stored writes NO inline size (content-sized, as before)
+  assert.ok(!body.includes("if (create && !pop.style.width)"), "no create-mode default size was added");
+  // a denied or corrupt store costs the preference, never the popover
+  assert.match(RENDER, /function readCmtPopSize\(\): CmtPopFrac \| null \{\s*\n\s*try \{ return parseCmtPopSize\(localStorage\.getItem\(CMT_POP_SIZE_KEY\)\); \} catch \{ return null; \}/);
+  assert.match(RENDER, /try \{ localStorage\.setItem\(CMT_POP_SIZE_KEY, JSON\.stringify\(frac\)\); \} catch \{/);
+});
+
+test("every user resize is remembered through the ONE observer both grips fire — our own sizing, the window's caps and the close are not", () => {
+  const body = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
+  const ro = body.slice(body.indexOf("const ro = new ResizeObserver("), body.indexOf("ro.observe(pop);"));
+  assert.match(ro, /pop\.classList\.add\("sized"\)/, "the existing .sized arming stays");
+  assert.match(ro, /if \(!pop\.isConnected \|\| !pop\.offsetWidth \|\| !pop\.offsetHeight\) return;/, "a 0×0 box is a close, never a preference");
+  assert.match(ro, /if \(a && Math\.abs\(pop\.offsetWidth - a\.w\) <= 1 && Math\.abs\(pop\.offsetHeight - a\.h\) <= 1\) return;/, "the size WE applied is skipped");
+  assert.match(ro, /cmtPopApplied = \{ w: pop\.offsetWidth, h: pop\.offsetHeight \};\s*\n\s*saveCmtPopSize\(pop\);\s*\n\s*syncCmtMaxState\(pop\);/,
+    "then every observation writes the fraction and repaints the toggle");
+  assert.ok(!/setTimeout|debounce|Date\.now/.test(ro), "event-based: no timer between the pull and the write");
+  // the WINDOW moving the box through the vw/vh caps is re-baselined, not written back (the tab strip's rule)
+  assert.match(body, /const onWin = \(\) => \{\s*\n\s*if \(!pop\.isConnected\) \{ window\.removeEventListener\("resize", onWin\); return; \}\s*\n\s*cmtPopApplied = \{ w: pop\.offsetWidth, h: pop\.offsetHeight \};/);
+  assert.match(body, /window\.addEventListener\("resize", onWin\);/);
+  // the edge bands still write the style directly — a USER pull, so the observer sees it as one
+  const fn = RENDER.split("function wireEdgeResize(")[1].split("\nfunction ")[0];
+  assert.ok(fn.includes('pop.style.width = wpx + "px";') && !fn.includes("cmtPopApplied"), "an edge pull is never mistaken for ours");
+});
+
+test("the maximize button sits in .cmt-head right before the ×, delegated like it, and paints its own label", () => {
+  assert.match(RENDER, /const maxBtn = el\("button", "cmt-max"\) as HTMLButtonElement;\s*\n\s*maxBtn\.type = "button";\s*\n\s*maxBtn\.dataset\.act = "cmtmax";/);
+  assert.match(RENDER, /if \(nameBox\) head\.append\(title, nameBox, maxBtn, closeBtn\);\s*\n\s*else head\.append\(title, maxBtn, closeBtn\);/,
+    "before the × in both modes");
+  assert.match(RENDER, /cmtmax: \(\) => toggleCommentPopMax\(\),/, "delegated on the stable root: the popover rebuilds on status flips");
+  const sync = RENDER.split("function syncCmtMaxState(")[1].split("\nfunction ")[0];
+  assert.match(sync, /const max = isCmtPopMax\(pop\.offsetWidth, pop\.offsetHeight, window\.innerWidth, window\.innerHeight\);/, "computed from the live size");
+  assert.match(sync, /if \(max\) pop\.dataset\.max = "1"; else delete pop\.dataset\.max;/);
+  assert.match(sync, /btn\.title = max \? "Restore" : "Maximize";/);
+  assert.match(sync, /btn\.setAttribute\("aria-label", max \? "Restore" : "Maximize"\);/);
+  assert.match(sync, /viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" '\s*\n\s*\+ 'stroke-width="1\.4" stroke-linecap="round" stroke-linejoin="round">/,
+    "the house line-icon style");
+  assert.match(RENDER, /const CMT_MAX_GLYPH = '<rect x="2\.5" y="2\.5" width="11" height="11" rx="1\.5"\/>';/, "one frame: maximize");
+  assert.match(RENDER, /const CMT_RESTORE_GLYPH = '<path d="M5\.5 5\.5V3\.5a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-2"\/>'\s*\n\s*\+ '<rect x="2\.5" y="5\.5" width="8" height="8" rx="1"\/>';/,
+    "two offset frames: restore");
+  // CSS: click-safe (a transparent border at rest holds the box), the house accent hover, the ×'s push moves to it
+  assert.match(CSS, /\.cmt-max \{[^}]*border: 1px solid transparent;[^}]*\}/s);
+  assert.match(CSS, /\.cmt-max:hover \{ opacity: 1; border-color: var\(--accent\); color: var\(--accent\); background: var\(--accent-wash\); \}/);
+  assert.match(CSS, /\.cmt-max \{[^}]*margin-left: auto;/s);
+  assert.match(CSS, /\.cmt-max \+ \.cmt-x \{ margin-left: 0; \}/, "the × no longer pushes itself: the pair sits together at the right");
+  assert.match(CSS, /\.cmt-head \.cmt-x, \.cmt-head \.cmt-max \{ cursor: pointer; \}/);
+  // the whole-box drag exempts it (a `button`), so a press on it is a click, never a drag
+  assert.match(RENDER, /if \(t\.closest\("\.cmt-x, \.cmt-name, \.cmt-input, \.cmt-msgs, \.cmt-quote, button, input, textarea, \.meta-btn, \.meta-menu"\)\) return;/);
+});
+
+test("a double-click on the title bar routes to the SAME toggle; the head's interactive children keep theirs; the title selects nothing", () => {
+  assert.equal(RENDER.split("function toggleCommentPopMax(").length, 2, "one toggle function");
+  const body = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
+  const dbl = body.slice(body.indexOf('pop.addEventListener("dblclick"'), body.indexOf("toggleCommentPopMax();", body.indexOf('pop.addEventListener("dblclick"')));
+  assert.ok(dbl.length > 0, "the double-click listener exists");
+  assert.match(dbl, /const at = document\.elementFromPoint\(ev\.clientX, ev\.clientY\) as HTMLElement \| null;/,
+    "hit-tested at the pointer: the drag's pointer capture retargets the click to the box, so the head never hears it");
+  assert.match(dbl, /if \(!at \|\| !at\.closest\("\.cmt-head"\) \|\| at\.closest\("\.cmt-name, \.cmt-x, \.cmt-max, button, input"\)\) return;/,
+    "only the title bar's own surface; the name box and the two buttons are exempt");
+  assert.match(RENDER, /head\.title = "Drag to move · double-click to maximize or restore";/, "the head says so");
+  assert.match(CSS, /\.cmt-title \{ font-weight: 600; user-select: none; \}/);
+  assert.match(CSS, /\.cmt-head \{ display: flex; align-items: center; user-select: none; \}/, "the whole head already refused selection; the title says it too");
+});
+
+test("toggle: maximize = cap + centered + remembered + sized; restore = the pre-maximize size, else the mode's default (create drops the inline size AND the preference)", () => {
+  const fn = RENDER.split("function toggleCommentPopMax(")[1].split("\nfunction ")[0];
+  assert.match(fn, /if \(isCmtPopMax\(pop\.offsetWidth, pop\.offsetHeight, W, H\)\) \{/, "the branch reads the live size, never a stored flag");
+  // maximize
+  assert.match(fn, /cmtPopPreMax = pop\.style\.width \? toCmtPopFrac\(pop\.offsetWidth, pop\.offsetHeight, W, H\) : null;/, "an expressed size is what restore goes back to");
+  assert.match(fn, /const cap = cmtPopCapPx\(W, H\);\s*\n\s*sizeCommentPop\(pop, cap\.w, cap\.h\);\s*\n\s*saveCmtPopSize\(pop\);\s*\n\s*pop\.classList\.add\("sized"\);/);
+  // restore
+  assert.match(fn, /if \(cmtPopPreMax\) \{\s*\n\s*const px = clampCmtPopPx\(cmtPopPreMax, W, H\);\s*\n\s*sizeCommentPop\(pop, px\.w, px\.h\);\s*\n\s*saveCmtPopSize\(pop\);/);
+  assert.match(fn, /else if \(pop\.dataset\.mode === "thread"\) \{\s*\n\s*sizeCommentPop\(pop, Math\.round\(W \* CMT_POP_THREAD_DEFAULT\.w\), Math\.round\(H \* CMT_POP_THREAD_DEFAULT\.h\)\);/,
+    "the thread's default is today's 70%/60%");
+  assert.deepEqual(CMT_POP_THREAD_DEFAULT, { w: 0.7, h: 0.6 });
+  assert.match(fn, /pop\.style\.removeProperty\("width"\);\s*\n\s*pop\.style\.removeProperty\("height"\);[\s\S]*?pop\.classList\.remove\("sized"\);[\s\S]*?localStorage\.removeItem\(CMT_POP_SIZE_KEY\)/,
+    "the create dialog goes back to its content size and forgets the preference");
+  // both ends: centered, the position persisted like a drag's, the label repainted
+  assert.match(fn, /const c = centerCmtPop\(pop\.offsetWidth, pop\.offsetHeight, W, H\);\s*\n\s*pop\.style\.left = c\.left \+ "px";\s*\n\s*pop\.style\.top = c\.top \+ "px";\s*\n\s*commentPopPos = \{ x: c\.left, y: c\.top \};/);
+  assert.match(fn, /syncCmtMaxState\(pop\);\s*\n\}\s*$/, "the label is repainted last, on both ends");
+  // programmatic sizing records what it measures, so the observer never writes it back as the user's
+  assert.match(RENDER, /function sizeCommentPop\(pop: HTMLElement, w: number, h: number\): void \{\s*\n\s*pop\.style\.width = w \+ "px";\s*\n\s*pop\.style\.height = h \+ "px";\s*\n\s*cmtPopApplied = \{ w: pop\.offsetWidth, h: pop\.offsetHeight \};/);
+});

--- a/ui/webview/comment-pop-size.ts
+++ b/ui/webview/comment-pop-size.ts
@@ -1,0 +1,78 @@
+// Remembered size + maximize for the comment popover (the user 2026-09-10, who kept enlarging the box
+// by hand on every open): the size the user last dragged it to is applied on every open, in both the
+// thread and the create dialog, and a maximize control (the head's button, or a double-click on the
+// title bar) snaps it to the cap and back. Pure logic split out of render.ts so it can be unit-tested
+// without a DOM (the tabbar-resize.ts pattern); the wiring lives in renderCommentPopover.
+
+// localStorage key: the chosen size is per-viewer ARRANGEMENT, like the tab strip's dragged cap
+// (romp:tabbarH) and the tab order (romp:vieworder) — a property of how you are looking at your
+// sessions on THIS screen, not a setting the kernel should carry to every dashboard. Stored as
+// FRACTIONS of the window so the same entry means the same thing on a phone and a desktop.
+export const CMT_POP_SIZE_KEY = "romp:cmtPopSize";
+
+export type CmtPopFrac = { w: number; h: number };   // each in (0, 1]
+
+// The floor: the .cmt-pop CSS mins (min-width: 300px; min-height: 120px), restated for the math the
+// same way wireEdgeResize's MIN_W/MIN_H restate them.
+export const CMT_POP_MIN_W = 300;
+export const CMT_POP_MIN_H = 120;
+// The cap: the .cmt-pop CSS caps (max-width: 94vw; max-height: 90vh), as fractions.
+export const CMT_POP_CAP_W = 0.94;
+export const CMT_POP_CAP_H = 0.90;
+// The open geometry keeps 8px of window on every side (renderCommentPopover's left/top clamp), so an
+// applied size also stays 8px short of each edge — a stored fraction can never park the box off-screen.
+export const CMT_POP_EDGE = 8;
+// The thread dialog's default when nothing is stored (renderCommentPopover's 70%/60% open geometry).
+export const CMT_POP_THREAD_DEFAULT: CmtPopFrac = { w: 0.7, h: 0.6 };
+// "Maximized" is COMPUTED from the live size, never a stored bit that could drift: within this many px
+// of the cap on both axes.
+export const CMT_POP_MAX_SLACK = 4;
+
+/** The largest box the window allows: the CSS caps, and never closer than CMT_POP_EDGE to an edge. */
+export function cmtPopCapPx(innerW: number, innerH: number): { w: number; h: number } {
+  return {
+    w: Math.min(Math.round(innerW * CMT_POP_CAP_W), Math.round(innerW - 2 * CMT_POP_EDGE)),
+    h: Math.min(Math.round(innerH * CMT_POP_CAP_H), Math.round(innerH - 2 * CMT_POP_EDGE)),
+  };
+}
+
+/** A stored fraction as pixels for the LIVE window: capped by cmtPopCapPx, then floored by the CSS mins
+ *  (the floor wins on a window too small for both, exactly as CSS resolves min-width over max-width). */
+export function clampCmtPopPx(frac: CmtPopFrac, innerW: number, innerH: number): { w: number; h: number } {
+  const cap = cmtPopCapPx(innerW, innerH);
+  return {
+    w: Math.max(CMT_POP_MIN_W, Math.min(cap.w, Math.round(frac.w * innerW))),
+    h: Math.max(CMT_POP_MIN_H, Math.min(cap.h, Math.round(frac.h * innerH))),
+  };
+}
+
+/** A live pixel size as the fraction to store: of the window, clamped to (0, 1]. */
+export function toCmtPopFrac(wPx: number, hPx: number, innerW: number, innerH: number): CmtPopFrac {
+  const f = (px: number, win: number) => (win > 0 ? Math.min(1, Math.max(0.01, px / win)) : 1);
+  return { w: f(wPx, innerW), h: f(hPx, innerH) };
+}
+
+/** A stored entry: a fraction pair, or null for never stored / reset / garbage — never throws. */
+export function parseCmtPopSize(raw: string | null): CmtPopFrac | null {
+  if (!raw) return null;
+  let v: unknown;
+  try { v = JSON.parse(raw); } catch { return null; }
+  if (!v || typeof v !== "object") return null;
+  const { w, h } = v as { w?: unknown; h?: unknown };
+  const ok = (n: unknown): n is number => typeof n === "number" && Number.isFinite(n) && n > 0 && n <= 1;
+  return ok(w) && ok(h) ? { w, h } : null;
+}
+
+/** Whether a live size IS the cap (both axes within CMT_POP_MAX_SLACK px) — the maximize toggle's state. */
+export function isCmtPopMax(wPx: number, hPx: number, innerW: number, innerH: number): boolean {
+  const cap = cmtPopCapPx(innerW, innerH);
+  return Math.abs(wPx - cap.w) <= CMT_POP_MAX_SLACK && Math.abs(hPx - cap.h) <= CMT_POP_MAX_SLACK;
+}
+
+/** The position that centers a w×h box in the window, never nearer than CMT_POP_EDGE to the top-left. */
+export function centerCmtPop(w: number, h: number, innerW: number, innerH: number): { left: number; top: number } {
+  return {
+    left: Math.max(CMT_POP_EDGE, Math.round((innerW - w) / 2)),
+    top: Math.max(CMT_POP_EDGE, Math.round((innerH - h) / 2)),
+  };
+}

--- a/ui/webview/comment-popover-parity.test.ts
+++ b/ui/webview/comment-popover-parity.test.ts
@@ -186,6 +186,12 @@ test("the thread popover opens 70% wide right-aligned, 60% tall — and NEVER gr
   assert.ok(!opener.includes("commentPopPos = { x, y }"), "no click-coord seeding on thread open");
   // …and the CSS no longer hard-sizes the box (the inline open geometry owns it)
   assert.doesNotMatch(CSS, /\.cmt-pop \{[^}]*width: 440px/s);
+  // the remembered size (2026-09-10, comment-pop-size.test.ts) sits ABOVE these lines and only fills the
+  // inline size when a preference exists — so with nothing stored the two lines above still decide, byte
+  // for byte, and the create dialog still writes no inline size at all
+  const body = RENDER.split("function renderCommentPopover(")[1].split("\nfunction ")[0];
+  assert.ok(body.indexOf("const pref = readCmtPopSize();") < body.indexOf("if (th && !pop.style.width)"));
+  assert.match(body, /if \(pref\) \{[\s\S]*?pop\.style\.width = sz\.w \+ "px";[\s\S]*?\}\s*\n\s*\/\/ OPEN GEOMETRY/, "the preference branch, then the default");
 });
 
 test("the popover resizes from ANY edge or corner, macOS-style; the old grip keeps working", () => {

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -359,7 +359,7 @@ test("the create dialog names the thread right there: prefilled <session>-commen
   assert.match(UI, /const prefill = defaultCommentName\(sess0\?\.name, sid, \(commentThreads\.get\(sid\) \|\| \[\]\)\.length\);\s*\n\s*nameBox\.dataset\.prefill = prefill;\s*\n\s*nameBox\.value = commentDrafts\.get\(nk\) \|\| prefill;/);
   // the name lives IN the header ("New comment: <name>"), the button says Comment, and the picks ride along
   assert.match(UI, /"New comment:"/);
-  assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, closeBtn\);/);
+  assert.match(UI, /if \(nameBox\) head\.append\(title, nameBox, maxBtn, closeBtn\);/);   // the maximize button rides between (2026-09-10, comment-pop-size.test.ts)
   assert.match(UI, /send\.setAttribute\("aria-label", create \? "Comment" : "Send"\);/);   // the ➤ carries the word
   assert.match(UI, /const held = newCommentCreate\(create, text, nm\);\s*\n\s*vscodeApi\.postMessage\(commentCreateFrame\(held\)\);/);   // the anchor's picks ride the held create
   // the comment's own model/effort selectors reuse the statusline's /models-fed choices + menu skin

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13,6 +13,9 @@ import diff from "highlight.js/lib/languages/diff";
 import yaml from "highlight.js/lib/languages/yaml";
 import type { ParsedAsk } from "../ask-types";
 import { TABBAR_H_KEY, TABBAR_H_DEFAULT, clampTabbarH, parseTabbarH } from "./tabbar-resize";
+import type { CmtPopFrac } from "./comment-pop-size";
+import { CMT_POP_SIZE_KEY, CMT_POP_THREAD_DEFAULT, parseCmtPopSize, clampCmtPopPx, toCmtPopFrac, isCmtPopMax,
+         centerCmtPop, cmtPopCapPx } from "./comment-pop-size";
 import { ctxFallbackColor, pickTone, readableRgb } from "./ctx-color";
 import { applyTheme } from "./theme";
 import { applyDenseChrome } from "./dense-chrome";
@@ -8329,6 +8332,10 @@ let pendingCommentAnchor: { sid: string; uuid: string; exact: string;
   model?: string; effort?: string; fast?: string; color?: string } | null = null; // create mode (+ the thread's own picks)
 let pendingAdoptTid: string | null = null;                          // commentCreated ack that beat its frame
 let commentPopPos: { x: number; y: number } | null = null;
+// the size WE set on the open popover (its open geometry, a stored preference, maximize/restore) — the
+// ResizeObserver tells our own sizing from the user's pull by it, so only a pull is remembered (2026-09-10)
+let cmtPopApplied: { w: number; h: number } | null = null;
+let cmtPopPreMax: CmtPopFrac | null = null;     // the size the box had before the last maximize this page-load: restore's target
 
 // the popover's own file picker (the user 2026-08-17: the attach clip, like the chat's) — files
 // ship through the SAME dropFile flow; the droppedPath ack sees the open popover and lands there
@@ -9006,6 +9013,77 @@ function wireEdgeResize(pop: HTMLElement): void {
   });
 }
 
+// ── remembered size + maximize (the user 2026-09-10, who enlarged the box by hand on every open) ── the
+// rules are comment-pop-size.ts's; this is the DOM half. localStorage reads and writes are wrapped so a
+// denied or full store costs the preference, never the popover (file-view.ts's convention).
+function readCmtPopSize(): CmtPopFrac | null {
+  try { return parseCmtPopSize(localStorage.getItem(CMT_POP_SIZE_KEY)); } catch { return null; }
+}
+function saveCmtPopSize(pop: HTMLElement): void {
+  const frac = toCmtPopFrac(pop.offsetWidth, pop.offsetHeight, window.innerWidth, window.innerHeight);
+  try { localStorage.setItem(CMT_POP_SIZE_KEY, JSON.stringify(frac)); } catch { /* storage full or denied */ }
+}
+/** Size the box programmatically and record what it measures: the observer treats that size as ours. */
+function sizeCommentPop(pop: HTMLElement, w: number, h: number): void {
+  pop.style.width = w + "px";
+  pop.style.height = h + "px";
+  cmtPopApplied = { w: pop.offsetWidth, h: pop.offsetHeight };
+}
+// the house line-icon style (16-unit box, 1.4 stroke, round caps): one frame = maximize, two offset frames = restore
+const CMT_MAX_GLYPH = '<rect x="2.5" y="2.5" width="11" height="11" rx="1.5"/>';
+const CMT_RESTORE_GLYPH = '<path d="M5.5 5.5V3.5a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-2"/>'
+  + '<rect x="2.5" y="5.5" width="8" height="8" rx="1"/>';
+/** "Maximized" is COMPUTED from the live size (within a few px of the cap), never a stored bit that can
+ *  drift: the data-max mark and the button's glyph/title/aria-label follow it (a control changes its own
+ *  label on click — ui/CLAUDE.md). Called at open, after every toggle, and after every user resize. */
+function syncCmtMaxState(pop: HTMLElement): void {
+  const max = isCmtPopMax(pop.offsetWidth, pop.offsetHeight, window.innerWidth, window.innerHeight);
+  if (max) pop.dataset.max = "1"; else delete pop.dataset.max;
+  const btn = pop.querySelector(".cmt-max") as HTMLElement | null;
+  if (!btn) return;
+  btn.innerHTML = '<svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + (max ? CMT_RESTORE_GLYPH : CMT_MAX_GLYPH) + "</svg>";
+  btn.title = max ? "Restore" : "Maximize";
+  btn.setAttribute("aria-label", max ? "Restore" : "Maximize");
+}
+/** Maximize ⇄ restore — the head's button and a double-click on the title bar both land here. Maximize
+ *  sizes to the cap, centers, and remembers the fraction like any resize; restore goes back to the size
+ *  the box had before the maximize (this page-load), else the mode's own default — the thread's 70%/60%,
+ *  or the create dialog's content size (inline size AND preference dropped) — centered too. */
+function toggleCommentPopMax(): void {
+  const pop = document.getElementById("cmt-pop");
+  if (!pop) return;
+  const W = window.innerWidth, H = window.innerHeight;
+  if (isCmtPopMax(pop.offsetWidth, pop.offsetHeight, W, H)) {
+    if (cmtPopPreMax) {
+      const px = clampCmtPopPx(cmtPopPreMax, W, H);
+      sizeCommentPop(pop, px.w, px.h);
+      saveCmtPopSize(pop);
+    } else if (pop.dataset.mode === "thread") {
+      sizeCommentPop(pop, Math.round(W * CMT_POP_THREAD_DEFAULT.w), Math.round(H * CMT_POP_THREAD_DEFAULT.h));
+      saveCmtPopSize(pop);
+    } else {
+      pop.style.removeProperty("width");
+      pop.style.removeProperty("height");
+      pop.classList.remove("sized");                  // no expressed size any more: the quote clamp comes back…
+      cmtPopApplied = { w: pop.offsetWidth, h: pop.offsetHeight };   // …and reflows the content size, so measure AFTER it
+      try { localStorage.removeItem(CMT_POP_SIZE_KEY); } catch { /* storage denied */ }
+    }
+  } else {
+    // an expressed size only: a content-sized create dialog has nothing to go back to but its content
+    cmtPopPreMax = pop.style.width ? toCmtPopFrac(pop.offsetWidth, pop.offsetHeight, W, H) : null;
+    const cap = cmtPopCapPx(W, H);
+    sizeCommentPop(pop, cap.w, cap.h);
+    saveCmtPopSize(pop);
+    pop.classList.add("sized");
+  }
+  const c = centerCmtPop(pop.offsetWidth, pop.offsetHeight, W, H);
+  pop.style.left = c.left + "px";
+  pop.style.top = c.top + "px";
+  commentPopPos = { x: c.left, y: c.top };             // a later rebuild reopens where the toggle put it, like a drag
+  syncCmtMaxState(pop);
+}
+
 function commentPopTitle(create: boolean, th: CommentThread | null | undefined): string {
   const nm = th?.name || "Thread";
   return create ? "New comment:"
@@ -9131,18 +9209,34 @@ function renderCommentPopover(): void {
     const nb = nameBox;
     nb.addEventListener("input", () => { nb.classList.remove("bad"); commentDrafts.set(nk, nb.value); });
   }
+  // maximize ⇄ restore (the user 2026-09-10), right before the ×; delegated like the × (cmtmax), the
+  // glyph and label painted by syncCmtMaxState once the box has its open size
+  const maxBtn = el("button", "cmt-max") as HTMLButtonElement;
+  maxBtn.type = "button";
+  maxBtn.dataset.act = "cmtmax";
   const closeBtn = el("button", "cmt-x") as HTMLButtonElement;
   closeBtn.type = "button";
   closeBtn.textContent = "×";
   closeBtn.title = "Close (the thread stays on its highlight)";
   closeBtn.dataset.act = "cmtclose";
-  if (nameBox) head.append(title, nameBox, closeBtn);
-  else head.append(title, closeBtn);
+  if (nameBox) head.append(title, nameBox, maxBtn, closeBtn);
+  else head.append(title, maxBtn, closeBtn);
   // DRAG by the header (the user 2026-08-13, who found the popover's spot inconvenient): pointer
   // capture, viewport-clamped, and the position writes through to commentPopPos so a later full
   // rebuild (a status flip) reopens where the user parked it. The header survives in-place
   // refreshes, so a drag is never cut by a comments frame; a full rebuild mid-drag just ends it.
-  head.title = "Drag to move";
+  head.title = "Drag to move · double-click to maximize or restore";
+  // DOUBLE-CLICK on the title bar toggles maximize, a window's title bar (the user 2026-09-10) — the same
+  // toggle as the button. Listened on the BOX and hit-tested at the pointer: the drag below captures the
+  // pointer on every press, and a captured press retargets the click/dblclick it ends in to the box, so a
+  // listener on the head would never hear it. Interactive children of the head (the name box, the two
+  // buttons) keep their own double-click.
+  pop.addEventListener("dblclick", (ev: MouseEvent) => {
+    const at = document.elementFromPoint(ev.clientX, ev.clientY) as HTMLElement | null;
+    if (!at || !at.closest(".cmt-head") || at.closest(".cmt-name, .cmt-x, .cmt-max, button, input")) return;
+    ev.preventDefault();
+    toggleCommentPopMax();
+  });
   // the WHOLE box drags (the user 2026-08-17), not just the header — any grip that isn't an
   // interactive control or selectable text, and never the bottom-right resize corner
   pop.addEventListener("pointerdown", (ev: PointerEvent) => {
@@ -9408,10 +9502,38 @@ function renderCommentPopover(): void {
     // resizing the BOX (resize: both) hands the extra room to the quoted context: the .sized class
     // unlocks the quote's clamp; armed only after a real user resize, so the natural size stays tight
     const w0 = pop.offsetWidth, h0 = pop.offsetHeight;
+    // …and REMEMBERS the size (the user 2026-09-10): this observer sees the native grip and the edge
+    // bands alike, so it is the one event every user resize fires — each observation writes the fraction
+    // (comment-pop-size.ts) except the ones that are not the user's: the size WE set (cmtPopApplied —
+    // the open geometry, a stored preference, maximize/restore), a box the WINDOW moved through the
+    // vw/vh caps (re-baselined on resize below: a briefly-small window never rewrites the preference,
+    // the tab strip's rule), and the box leaving the page (a 0×0 box is a close, not a choice).
     const ro = new ResizeObserver(() => {
       if (Math.abs(pop.offsetWidth - w0) > 6 || Math.abs(pop.offsetHeight - h0) > 6) pop.classList.add("sized");
+      if (!pop.isConnected || !pop.offsetWidth || !pop.offsetHeight) return;
+      const a = cmtPopApplied;
+      if (a && Math.abs(pop.offsetWidth - a.w) <= 1 && Math.abs(pop.offsetHeight - a.h) <= 1) return;
+      cmtPopApplied = { w: pop.offsetWidth, h: pop.offsetHeight };
+      saveCmtPopSize(pop);
+      syncCmtMaxState(pop);                          // a pull onto or off the cap flips the toggle's label with it
     });
     ro.observe(pop);
+    const onWin = () => {
+      if (!pop.isConnected) { window.removeEventListener("resize", onWin); return; }
+      cmtPopApplied = { w: pop.offsetWidth, h: pop.offsetHeight };   // the resize event runs before the observer's frame
+    };
+    window.addEventListener("resize", onWin);
+  }
+  // REMEMBERED SIZE (the user 2026-09-10): the fraction of the window the user last dragged the box to,
+  // applied in BOTH modes and re-clamped to the live window (comment-pop-size.ts: the CSS mins as the
+  // floor, the CSS caps and an 8px margin as the cap). With nothing stored, both modes open exactly as
+  // before: the thread geometry below, the create dialog at its content size with no inline size at all.
+  const pref = readCmtPopSize();
+  if (pref) {
+    const sz = clampCmtPopPx(pref, window.innerWidth, window.innerHeight);
+    pop.style.width = sz.w + "px";
+    pop.style.height = sz.h + "px";
+    pop.classList.add("sized");                      // an expressed size: the quote/msgs reflow rules apply from open
   }
   // OPEN GEOMETRY (the user 2026-08-25), THREAD mode: 70% of the chat pane's width with the RIGHT
   // edge on the chat's right edge, 60% of the pane's height — and the size is FIXED from open:
@@ -9421,12 +9543,14 @@ function renderCommentPopover(): void {
   // The CREATE composer keeps its natural size at the selection point — a different gesture.
   if (th && !pop.style.width) { pop.style.width = Math.round(window.innerWidth * 0.7) + "px"; }
   if (th && !pop.style.height) { pop.style.height = Math.round(window.innerHeight * 0.6) + "px"; }
+  cmtPopApplied = { w: pop.offsetWidth, h: pop.offsetHeight };   // whatever it measures now is ours, the content size included
   const r = pop.getBoundingClientRect();
   const defaultX = th ? (window.innerWidth - r.width - 8) : (window.innerWidth - r.width) / 2;
   const px = Math.max(8, Math.min(commentPopPos?.x ?? defaultX, window.innerWidth - r.width - 8));
   const py = Math.max(8, Math.min(commentPopPos?.y ?? 120, window.innerHeight - r.height - 8));
   pop.style.left = px + "px";
   pop.style.top = py + "px";
+  syncCmtMaxState(pop);                              // a stored cap-sized preference opens reading "Restore"
   const msgs = pop.querySelector(".cmt-msgs") as HTMLElement | null;
   if (msgs) msgs.scrollTop = msgs.scrollHeight;
   if (create || hadFocus || !th || !th.msgs.length) (pop.querySelector(".cmt-input") as HTMLTextAreaElement | null)?.focus();
@@ -17641,6 +17765,7 @@ setupSettings();
       openCommentPopover(activeId, tid, Math.min(r.left, window.innerWidth - 380), r.bottom + 6);
     },
     cmtclose: () => closeCommentPop(),
+    cmtmax: () => toggleCommentPopMax(),   // maximize ⇄ restore; the head's double-click lands in the same function
     // Interrupt the THREAD's own turn (T138): the sid rides the button (the thread's session),
     // never activeId — the exact owner-scoping class queued-x/Retry were fixed for. The gesture
     // itself ENDS the exchange with no reply record coming, so the T102 send-latch clears on THIS

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3400,13 +3400,24 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    from open until the thread's REAL render (its events) is ready; a backstop falls back so it can
    never trap. Reuses the page's .rl-* pieces, centered in the list. */
 .cmt-boot { display: flex; align-items: center; justify-content: center; min-height: 90px; }
-.cmt-head .cmt-x { cursor: pointer; }
-.cmt-title { font-weight: 600; }
+.cmt-head .cmt-x, .cmt-head .cmt-max { cursor: pointer; }
+.cmt-title { font-weight: 600; user-select: none; }   /* a double-click here maximizes; it must select nothing */
 .cmt-x {
   margin-left: auto; padding: 0 4px; border: 0; background: none;
   color: inherit; opacity: 0.6; font-size: 14px; cursor: pointer;
 }
 .cmt-x:hover { opacity: 1; }
+/* maximize ⇄ restore (the user 2026-09-10): the line glyph right before the ×, so it takes the ×'s
+   push to the far right and the × loses its own. A transparent 1px border at rest holds the box, so
+   the hover's accent border + text + wash (the house button hover) shifts nothing — click-safe. */
+.cmt-max {
+  margin-left: auto; width: 20px; height: 20px; padding: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid transparent; border-radius: 4px; background: none;
+  color: inherit; opacity: 0.6; cursor: pointer;
+}
+.cmt-max:hover { opacity: 1; border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
+.cmt-max + .cmt-x { margin-left: 0; }
 .cmt-quote {
   padding: 4px 8px; border-left: 2px solid var(--cmt-hl); border-radius: 2px;
   background: rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
Tier: feature

The comment popup remembers the size you drag it to, and gets a maximize control. The user kept enlarging the box by hand on every open and asked for exactly these two things; today's default open sizes and today's maximum are unchanged.

## Design points

- **Remembered size, shared by every comment popup.** The chosen size is stored in localStorage under `romp:cmtPopSize` as fractions of the window (`{w, h}` in `(0, 1]`), so it means the same thing on a phone and a desktop. It is a per-viewer arrangement like the tab strip's dragged height (`romp:tabbarH`), not a kernel setting; `settings.ts` is untouched. On every open, in BOTH modes (thread and create), a stored preference is applied and re-clamped to the live window: floor = the existing CSS mins (300×120), cap = the existing CSS caps (0.94×innerWidth, 0.90×innerHeight) and never wider/taller than innerWidth−16 / innerHeight−16, so the existing 8px left/top clamp still holds on a tiny window. An applied preference adds `.sized` (an expressed size, so the quote/msgs reflow rules apply from open). Position rules are as before.
- **Nothing stored → byte-identical to today.** The preference branch sits above the thread's `70%/60%` lines, which stay verbatim and fill only what it left empty; the create dialog still gets no inline width/height at all.
- **Every user resize updates the preference.** The existing `ResizeObserver` sees the native `resize: both` grip and the JS edge bands alike, so it is the one event both fire. It skips observations that are not the user's: the size we applied ourselves (compared against `cmtPopApplied`), a box the window moved through the vw/vh caps (re-baselined on `resize`, so a briefly-small window never rewrites the preference), and the box leaving the page (a 0×0 observation). No timers or debounces; a localStorage write per observation during a drag. Storage access is wrapped in try/catch (`file-view.ts`'s convention): a corrupt or denied store costs the preference, never the popup.
- **Maximize button** in `.cmt-head`, right before the `×`, delegated (`data-act="cmtmax"`) like the close button so it survives the popup's rebuilds. House line-icon style (16-unit viewBox, `stroke="currentColor"`, 1.4 stroke, round caps): one frame = Maximize, two offset frames = Restore. Click → cap size, centered, persisted, `.sized`, `data-max="1"`, glyph + `title`/`aria-label` flip to "Restore". Click again → the size it had before the maximize this page-load, else the mode's default (thread: 70/60; create: inline size removed so it is content-sized again, and the stored preference removed), kept centered. "Maximized" is computed from the live size (within 4px of the cap), never a stored boolean. Click-safe: a transparent 1px border at rest, the accent border+text+wash hover.
- **Double-click on the title bar** toggles through the same function. Verified in a real browser: the whole-box drag captures the pointer on every press, which retargets the resulting `dblclick` to the box, so the listener sits on the box and hit-tests the point (`elementFromPoint`); the name input and the two buttons are exempt. `.cmt-title` gets `user-select: none`.
- Pure logic in `ui/webview/comment-pop-size.ts` (`tabbar-resize.ts`'s shape): `CMT_POP_SIZE_KEY`, the mins/caps/default constants, `parseCmtPopSize`, `clampCmtPopPx`, `toCmtPopFrac`, `isCmtPopMax`, `centerCmtPop`, `cmtPopCapPx`.

Unchanged by design: the never-grows-on-content contract, drag-to-move, the native grip corner deferral, the pane-local non-modal treatment, the wire protocol, `settings.ts`.

## Tests

- `ui/webview/comment-pop-size.test.ts` (new): executed tests on the pure module (round trip, both clamps, the tiny-window px-available rule, garbage/partial parse → null, maximize detection, centering) + source pins for the wiring (preference applied before the verbatim defaults, observer skips, button placement/label, delegate entry, dblclick routing, CSS).
- `ui/webview/comment-popover-parity.test.ts`: the geometry test additionally pins that the preference branch precedes the still-verbatim default lines.
- `ui/webview/comments.test.ts`: the head-order pin updated (`title, nameBox, maxBtn, closeBtn`).
- `tests/test_comment_pop_size_browser.py` (new, Playwright over a hermetic kernel, synthetic data): fresh geometry in both modes (thread 840×480 right-aligned at top 120 at 1200×800; create with no inline size); an inline resize and an east edge-band pull both write the fraction; after a reload both dialogs open at the remembered size; a full-size preference on a 480×360 window is capped inside the 8px margins and reads "Restore" at open; the button maximizes (1128×720 centered at 36,40, `data-max`, remembered as 0.94/0.9) and restores (840×480 centered); the title-bar double-click does the same twice; the create dialog's restore drops the inline size and the preference, and a double-click on its name box is exempt.

Runs: `npm run typecheck` clean; `npm test` 4286 pass / 1 fail — the one failure is `md-sanitize-postpass-browser.test.ts`'s KaTeX fraction-layout check, which fails identically on an untouched `main` checkout on this machine (pre-existing, unrelated); `npm run build` clean; full pytest suite (minus `test_no_personal_identifiers.py`, in three alphabetical chunks to fit a 10-minute cap): 11405 passed, 47 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
