### PR TITLE
Tests: the git floor's trace pins match git's maintenance spawn line, not a bare word the fixture paths carry

### DIFF
--- a/tests/git-hermetic.bats
+++ b/tests/git-hermetic.bats
@@ -21,7 +21,10 @@ git_at_least_2_32() {
 
 setup() {
     git_at_least_2_32 || skip "GIT_CONFIG_GLOBAL needs git >= 2.32"
-    TEST_DIR="$(mktemp -d)"
+    # The scratch root's name carries `maintenance` on purpose: every fixture path then does, so the
+    # push test's trace pin below goes red if it ever matches a path instead of a spawn line (a
+    # commit's trace names no path; that test carries the word in its commit message instead).
+    TEST_DIR="$(mktemp -d "${BATS_TEST_TMPDIR:?}/maintenance-XXXXXX")"
     # A stand-in for the developer's global config: a hooks directory whose pre-commit refuses
     # every commit and leaves a marker, wired in through core.hooksPath.
     export HOME="$TEST_DIR/home"
@@ -111,15 +114,18 @@ teardown() { rm -rf "${TEST_DIR:-}"; }
 
 @test "with git_hermetic a commit spawns no maintenance or gc child" {
     # A smoke check on the git running the suite, read off git's own trace the way
-    # tests/test_git_fixture.py reads it (the same substrings: a bare `maintenance` also catches
-    # the --detach argument recent git appends); the config pin above is the deterministic half.
-    # Without the keys, `git commit` spawns `git maintenance run --auto`, the child that can still
-    # be writing under .git when a teardown's rm -rf runs.
+    # tests/test_git_fixture.py reads it: the spawn lines `run_command: git maintenance` and
+    # `run_command: git gc` (the --detach or --no-detach argument recent git appends rides the same
+    # line, so the prefix catches it). The config pin above is the deterministic half. Without the
+    # keys, `git commit` spawns `git maintenance run --auto`, the child that can still be writing
+    # under .git when a teardown's rm -rf runs.
     git_hermetic
-    GIT_TRACE="$TEST_DIR/trace" git -C "$REPO" commit -qm seed
+    GIT_TRACE="$TEST_DIR/trace" git -C "$REPO" commit -qm maintenance-traced
     [ -s "$TEST_DIR/trace" ]
     grep -q 'built-in: git commit' "$TEST_DIR/trace"
-    run grep 'maintenance' "$TEST_DIR/trace"
+    # The trace names the commit's argv, so the pin below cannot be a bare `maintenance`.
+    grep -q 'maintenance-traced' "$TEST_DIR/trace"
+    run grep 'run_command: git maintenance' "$TEST_DIR/trace"
     [ "$status" -ne 0 ]
     run grep 'run_command: git gc' "$TEST_DIR/trace"
     [ "$status" -ne 0 ]
@@ -144,6 +150,10 @@ teardown() { rm -rf "${TEST_DIR:-}"; }
     [ "$(git -C "$TEST_DIR/remote.git" rev-parse refs/heads/main)" = "$(git -C "$REPO" rev-parse HEAD)" ]
     [ "$(cat "$TEST_DIR/remote-saw")" = "$(printf 'false\n0')" ]
     grep -q 'built-in: git receive-pack' "$TEST_DIR/trace"
-    run grep 'maintenance' "$TEST_DIR/trace"
+    # The trace names the fixture paths on several lines (the push's argv, the stand-in's command
+    # line, receive-pack's own line and its quarantine object directory), and every one carries the
+    # scratch root's `maintenance-` prefix, so the pin below is the spawn line, not a bare word.
+    grep -q 'maintenance-' "$TEST_DIR/trace"
+    run grep 'run_command: git maintenance' "$TEST_DIR/trace"
     [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Symptom

`bats tests/git-hermetic.bats` under a TMPDIR whose path contains the word `maintenance` fails test 8 ("a push's receive-pack reads the no-background keys in the receiving repository") on every run: 7 passed, test 8 failed at its trace pin, with no maintenance child anywhere in the trace (the reproduction recorded on #1329). Test 7 has the same shape: a commit message carrying the word turns its pin red.

## Cause

Both trace pins were `grep 'maintenance'` over the GIT_TRACE output. The push trace names the fixture paths on several lines (the push's argv, the stand-in's command line, receive-pack's own line, and the quarantine object directory the unpack-objects and rev-list children carry), and the commit trace names the commit's argv, so a path or a commit message carrying the word matched the pin without any spawn. The comment justified the bare word as needed to catch the `--detach` argument recent git appends, but run-command.c puts that argument on the same `run_command: git maintenance run --auto ...` line, so the spawn prefix catches it. The comment also said the pin used the same substrings as tests/test_git_fixture.py; since #1327 that file pins `run_command: git maintenance`, so the cross-reference was stale.

## Fix

One file, tests/git-hermetic.bats:

- Both pins become `run grep 'run_command: git maintenance' "$TEST_DIR/trace"`, the spawn line, the form tests/test_git_fixture.py reads; the comment says so and drops the `--detach` sentence.
- Three carriers make the bare form red on every run, mirroring the python side of #1327: setup makes the scratch root with `mktemp -d "${BATS_TEST_TMPDIR:?}/maintenance-XXXXXX"`, so every fixture path (the repo, the bare remote, the stand-in, the quarantine directory) carries the word, with a comment saying this guards the push test's pin (a commit's trace names no path); the commit test commits with `-qm maintenance-traced` and asserts `grep -q 'maintenance-traced'` on the trace before its negative pin; the push test asserts `grep -q 'maintenance-'` on the trace before its negative pin, with a comment saying the trace names the fixture paths on several lines, which is why the pin is the spawn form.

No production code, no other test file, no README change (tests/README.md names the pins but not the grep form).

## Tests

All executing under bats 1.10.0; the git >= 2.32 skip guard is unchanged. Every run below was made under git 2.43.0 and repeated under git 2.55.0, whose receive-pack goes through maintenance rather than spawning `gc --auto` directly.

- Red first, with the carriers in place and the pins still the bare word: test 7 fails at `[ "$status" -ne 0 ]` after its pin, on the argv line `built-in: git commit -qm maintenance-traced`; test 8 fails at the same assertion after its pin, on the path lines. Neither trace has a maintenance child. With the spawn form, 8/8 pass on both gits.
- The recorded reproduction holds on the unchanged file on both gits: a TMPDIR under a directory named `maintenance-probe`, 7 passed, test 8 failed at line 148.
- Each carrier's positive grep reds when its carrier is removed: a plain `mktemp -d` fails test 8 at `grep -q 'maintenance-'`; a `-qm seed` message fails test 7 at `grep -q 'maintenance-traced'`.
- The pins keep their teeth. In a copy with the GIT_CONFIG_COUNT pairs unset and the floor's file emptied after `git_hermetic`, test 7 goes red at its pin on `run_command: git maintenance run --auto --quiet` under 2.43 and on `run_command: git maintenance run --auto --quiet --detach` under 2.55. Test 8 in the same copy goes red first at its assertion on the stand-in's reads; with that assertion dropped so the run reaches the pin, under 2.55 the pin goes red on `run_command: git maintenance run --auto --quiet --detach`, the real child from receive-pack. Under 2.43 that trace has `run_command: git gc --auto --quiet` and no maintenance line, so there the push pin rests on its carrier.
- The sibling bats suites that commit or push into fixture repos pass at the changed head: pre-push-hook, gitleaks-config and docs-serve (37 tests), release-sh, bootstrap-sh and install-sh (89 tests), with stdin from /dev/null and a TMPDIR outside the system temp dir. No python changed; the two python tests that read bats sources, the literal-pin scan in tests/test_tempdir_hygiene.py (which classifies every mktemp shape, this template included) and tests/test_bats_bare_negation.py, pass on the changed file.

The `--receive-pack="$TEST_DIR/receive-pack"` word in the push test stays unquoted. git's contract for that option is a shell command string (the local transport appends the value verbatim and sq-quotes only the repository path), so a TMPDIR with a space fails the push at that line with exit 128 and the shell's not-found message before any pin reads: a loud failure, not a silent false red, and no bats suite here declares support for a TMPDIR with spaces. Quoting the value as `--receive-pack="'$TEST_DIR/receive-pack'"` works, but it trades the space hazard for a single-quote hazard and needs its own comment, so it is left out of this change.

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)