### PR TITLE
Judges: a Fast mode box per tier, greyed where the tier cannot run fast, and the first cut's four review concerns fixed

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -459,9 +459,16 @@ permission/API-error floors: one interrupt at a time, the present event first.
 
 - Toggles: `CLOSER_ON`, `GROUPER_ON`, `DISTILLER_ON`, `CONSOLIDATE_ON`.
   Models: `STATE/judge-model` (triage), `STATE/index-model`.
-  Fast mode for the judges (the gear's Fast mode box beside the Triage model
-  picker): `STATE/judge-fast` (`on` | `off`, off by default; read per call, and
-  the fast-mode opt-in rides only a call whose model is Opus).
+  Fast mode per judge tier (the gear's Fast mode box beside each tier's model
+  picker): `STATE/judge-fast` (triage), `STATE/distill-fast`, `STATE/index-fast`
+  (`on` | `off`, off by default; read per call for the call's tier, and the
+  fast-mode opt-in rides only a call whose model is Opus: `_tier_fast`). A flag
+  on for a tier whose model cannot run fast is kept and asks nothing. The CLI's
+  refusal of a fast ask is recorded per tier in `STATE/fast-refused.json` (one
+  `fast-refused` judge-errors row per change of reason) and cleared by the next
+  fast call that engages; a key-billed fast call carries the sessions' org-check
+  env (`_fast_org_env`, asked once per process). The one-time carry-over from
+  the single flag is `_migrate_judge_fast_tiers` in the kernel's boot sweep.
   Pool width: `STATE/judge-concurrency` (the gear's Judge concurrency, 1..16,
   read fresh each pass; empty = `ROMP_JUDGE_CONCURRENCY` as read at load,
   else 6). Every pool reads it at call time (`_conc`, or `_judge_concurrency()`
@@ -489,8 +496,10 @@ permission/API-error floors: one interrupt at a time, the present event first.
   the sessions the evidence gate ran. Outside
   a pass frame (`romp-judge --plan`) the evidence gate stamps nothing, and
   the inner gate does the skipping.
-- Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt, and
-  the CLI's `fast_mode_state` as `fast`),
+- Logs: `STATE/judge-usage.jsonl` (per-call cost, one name per prompt, the
+  CLI's `fast_mode_state` as `fast` and its `fast_mode_disabled_reason` as
+  `fastReason`; an error envelope that carried the readback leaves a zero-cost
+  row marked `err`, which the cost rollup skips),
   `STATE/judge-errors.jsonl` (the row contract above; kinds are parse,
   call, give-up, sweep-cut, cite-miss, rate-limited, task-store, history-unreadable,
   task-key-collision (a duplicated to-do mirror key, reconciled per node

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -487,22 +487,38 @@ through to `install.sh`:
 
 ### Fast mode for the judges
 
-- **Fast mode** (the checkbox beside the gear's Triage model picker; off by
-  default) runs the judges in Claude Code's fast mode, the same Opus-only
-  research preview the chat statusline's Fast badge toggles for a session,
-  billed at a premium over standard Opus rates. The setting is read per call: a
-  judge call whose model is Opus, by the bare alias or a pinned Opus version,
-  carries the CLI's fast-mode opt-in in its per-call settings; a call on any
-  other model runs exactly as before, so with every tier on Sonnet and Haiku the
-  setting changes nothing until a tier is pinned to Opus. The gear says so: while
-  no judge tier (triage, distilling, or indexing) is on Opus, the box is greyed
-  and its hint names the reason. Fast requests draw on fast mode's own rate
-  limits, the pool your sessions' fast toggles share. Whether fast engaged is
-  the CLI's answer, per account (an account with extra usage turned off, or an
-  organisation with fast mode disabled, reports it off with the setting on):
-  each row of `judge-usage.jsonl` keeps that answer in its `fast` field (`on`,
-  `off` or `cooldown`; `null` when the CLI reported none), so a checkbox that
-  reads on beside rows that read off names the account, not the setting. Like
+- **Fast mode** (a checkbox beside each of the gear's judge model pickers:
+  Triage, Distilling, Indexing; off by default) runs that tier's judges in
+  Claude Code's fast mode, the same Opus-only research preview the chat
+  statusline's Fast badge toggles for a session, billed at a premium (about
+  twice the standard Opus rate). One flag per tier: the setting is read per
+  call, for the tier the call runs in, and a call whose tier is on and whose
+  model is Opus, by the bare alias or a pinned Opus version, carries the CLI's
+  fast-mode opt-in in its per-call settings; every other call runs exactly as
+  before. The gear says so per tier: when a tier's effective model cannot run
+  fast (a Distilling pick of Follow triage takes the triage model), its box is
+  greyed and its hint names the reason; the value is kept, not cleared, so
+  pinning Opus for the tier later brings the box back live with no second
+  click. An install that had the earlier single box on gets the same behaviour
+  once: on its first start the kernel turns the new tiers' flags on where the
+  tier's model can run fast and off where it cannot. Fast requests draw on fast
+  mode's own rate limits, the pool your sessions' fast toggles share. Whether
+  fast engaged is the CLI's answer, per account (an account with extra usage
+  turned off, or an organisation with fast mode disabled, reports it off with
+  the setting on): each row of `judge-usage.jsonl` keeps that answer in its
+  `fast` field (`on`, `off` or `cooldown`; `null` when the CLI reported none)
+  and the CLI's reason in `fastReason`, so a checkbox that reads on beside rows
+  that read off names the account, not the setting. A declined ask is loud: the
+  kernel records it per tier (`STATE/fast-refused.json`), the tier's box hint
+  names the reason, and `judge-errors.jsonl` gets one `fast-refused` row per
+  change of reason (never one per call); the next fast call that engages clears
+  the record. A key-billed judge call that asks for fast carries the same
+  org-check switch a key-billed session gets (the CLI's own probe would ask the
+  saved login, not the paying account), asked once per kernel start and again
+  after any refusal the CLI reports. The cost view needs no fast price
+  table: the CLI's own per-call cost, which every usage row carries, already
+  includes the fast premium (measured: the same prompt costs twice as much
+  fast), so a fast row is priced at the fast rate. Like
   the other judge settings, a change applies on the judges' next pass with no
   restart and follows to every connected machine.
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -166,6 +166,8 @@ def _rebind_state(path):
     MESSAGES, ERRORS, USAGE = STATE / "timeline" / "messages.jsonl", STATE / "judge-errors.jsonl", STATE / "judge-usage.jsonl"
     global JUDGE_LIMIT
     JUDGE_LIMIT = STATE / "judge-limit.json"
+    global FAST_REFUSED
+    FAST_REFUSED = STATE / "fast-refused.json"   # the judges' per-tier fast refusal record (T300) rebinds with the rest
     SDKDIR = STATE / "sdk"
     CODEXDIR = STATE / "codex"
     EPIDIR = STATE / "episodes"
@@ -243,8 +245,30 @@ def _index_effort():  return _state_str("index-effort", "")
 def _judge_engine():  return _state_str("judge-engine", "claude")   # "claude" | "codex" — which model
 #   harness runs the judges (docs/codex.md §judges). "codex" lets a machine with no Claude login keep
 #   the board thinking: every judge becomes a one-shot `codex exec` billing the machine's codex login.
-def _judge_fast():    return _state_str("judge-fast", "off") == "on"   # the gear's Fast mode box (Triage model row): the CLI's fast-mode
-#   opt-in rides every judge call whose model is Opus (_judge_cmd); off by default. Read per call, like the tiers.
+def _judge_fast():    return _state_str("judge-fast", "off") == "on"   # the gear's Fast mode box beside the TRIAGE model
+#   (T300, the user 2026-09-10: one flag per tier, since one box for every tier ticked three at once and sat greyed
+#   where it could not act). STATE/judge-fast is the triage tier's flag (it was the one flag of the first cut;
+#   _migrate_judge_fast_tiers in the kernel carries an existing "on" over once), distill-fast and index-fast the
+#   other two. Read per call, like the tiers' models.
+def _distill_fast():  return _state_str("distill-fast", "off") == "on"
+def _index_fast():    return _state_str("index-fast", "off") == "on"
+_TIER_FAST = {"triage": _judge_fast, "distill": _distill_fast, "index": _index_fast}
+
+
+def fast_capable(model):
+    """Whether the CLI would run fast mode on `model`: the opus family, by the bare alias or a pinned version id
+    (fast mode is an Opus-only research preview). One rule for the judges, the gear's per-tier gate and the
+    kernel's migration, so the three never disagree about a model."""
+    return _model_family_version(model)[0] == "opus"
+
+
+def _tier_fast(tier, model):
+    """Whether THIS call asks for fast mode: the tier's flag is on AND the model the call runs on can run it. The
+    model is the RESOLVED one (a fallback onto a non-Opus model never asks); an unknown tier reads the triage flag,
+    the long-standing default tier. A flag left on for a tier whose model cannot run fast is kept, not cleared
+    (the gear greys its box and says why): it simply asks nothing until the tier is back on a model that can."""
+    on = _TIER_FAST.get(tier or "triage", _judge_fast)()
+    return bool(on and fast_capable(model))
 INDEX_EFFORT_DEFAULT = "low"   # the index tier's cost lever on models that take --effort (2026-09-01; see _judge_env)
 
 
@@ -841,7 +865,7 @@ UNTRUSTED_SYS = (
     "prompt and from text outside the marked sections.")
 
 
-def _judge_cmd(model, sys_prompt, effort=None, auth=None):
+def _judge_cmd(model, sys_prompt, effort=None, auth=None, tier="triage"):
     """The `claude -p` argv for ONE judge call, isolated so the model sees ONLY its own prompt. Three
     flags do it (verified by token count: a probe call drops 8334 -> ~165 input tokens):
       --system-prompt (REPLACE, not --append) — drops Claude Code's static base prompt (~6k tokens);
@@ -860,13 +884,14 @@ def _judge_cmd(model, sys_prompt, effort=None, auth=None):
     # call needs rides one overlay; --safe-mode drops only the auto-discovered settings, an explicit
     # --settings still loads. Two keys can ride it:
     overlay = {}
-    if _judge_fast() and _model_family_version(model)[0] == "opus":
-        # Fast mode for the judges (the gear's box beside the Triage model picker, off by default): the CLI refuses fast mode to a
-        # non-interactive client unless the flag-settings layer carries this exact key, the same opt-in a
-        # fast-picked session's launch uses (sdk_backend.flag_settings_path), and fast mode is an Opus-only
-        # preview, so the key rides only a call whose model reads as the opus family: the bare alias or a
-        # pinned version id (a tier pinned to a version id reaches here with that id). Whether fast then
-        # engaged is the CLI's answer, per account: the envelope's fast_mode_state, kept on the usage row.
+    if _tier_fast(tier, model):
+        # Fast mode for this call's TIER (the gear's box beside the tier's model picker, off by default): the CLI
+        # refuses fast mode to a non-interactive client unless the flag-settings layer carries this exact key, the
+        # same opt-in a fast-picked session's launch uses (sdk_backend.flag_settings_path), and fast mode is an
+        # Opus-only preview, so the key rides only a call whose model reads as the opus family: the bare alias or
+        # a pinned version id (a tier pinned to a version id reaches here with that id). Whether fast then
+        # engaged is the CLI's answer, per account: the envelope's fast_mode_state, kept on the usage row and
+        # read back by _note_fast_readback.
         overlay["fastMode"] = True
     if auth == "login":
         # A login-billed call must not bill the key (2026-09-08): in the CLI's precedence apiKeyHelper outranks
@@ -1482,7 +1507,7 @@ def _prune_usage_log():
         pass
 
 
-def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
+def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None, err=False):
     """Append ONE per-call usage line to USAGE for the kernel/UI cost rollup (judge_ui 2026-06-17).
     `wrap` is the claude -p JSON envelope. `sent`/`recv` are the LITERAL wall-clock floats bracketing the
     actual API call — when the judge's prompt went out and when its response came back (the user
@@ -1502,9 +1527,104 @@ def _log_judge_usage(judge, tier, model, fsid, wrap, sent=None, recv=None):
                                 "cache_r": u.get("cache_read_input_tokens"),
                                 "fast": wrap.get("fast_mode_state"),   # the CLI's word on whether fast mode engaged
                                 #   ("on" | "off" | "cooldown"; null when the envelope carries none): the judges' fast-mode readback
+                                "fastReason": wrap.get("fast_mode_disabled_reason"),   # why not, when the CLI says
+                                **({"err": True} if err else {}),   # an error envelope's row: kept for its readback,
+                                #   zero cost, skipped by the cost rollup's call and cost counts
                                 "cost": wrap.get("total_cost_usd")}) + "\n")
     except Exception:
         pass
+
+
+FAST_REFUSED = STATE / "fast-refused.json"   # tier -> {"reason", "model", "t"}: the CLI's last refusal of a fast
+#   ask, per tier; absent or empty when the last fast call engaged. /version lifts it so the gear's box says why.
+
+
+def _fast_refused():
+    """The per-tier refusal record, {} when none stands. Read fresh: the judges write it, the kernel reads it."""
+    try:
+        d = json.loads(FAST_REFUSED.read_text())
+        return d if isinstance(d, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+_FAST_REFUSED_LOCK = threading.Lock()   # the record is one file written from every judge pool's threads
+
+
+def _note_fast_readback(tier, model, wrap, judge, fsid):
+    """After a call that ASKED for fast: the envelope's fast_mode_state is the CLI's answer. "on" clears the tier's
+    refusal record (the box's hint goes with it on the gear's next read); a refusal records itself under the tier
+    with the CLI's reason and writes ONE judge-errors row per reason change (the fast-refused kind), so a refused
+    pick is loud where every judge fault is, and never once per call. Two answers are NOT refusals: an envelope
+    without the field says nothing (the sessions' rule for the same field: never fabricate a verdict), and
+    "cooldown" means fast is allowed and rate-limited for now (the statusline's third state), so neither records
+    nor clears. Any refusal drops the org-check memo, so the next key-billed fast call asks the paying account
+    again (the event that says the earlier answer may have been wrong). The read-check-write holds a lock: the
+    index and triage pools refuse on parallel threads. Best-effort, never raises."""
+    try:
+        if not isinstance(wrap, dict) or "fast_mode_state" not in wrap:
+            return
+        state = wrap.get("fast_mode_state")
+        if state == "cooldown":
+            return
+        reason = wrap.get("fast_mode_disabled_reason") or ("the CLI reported %r" % state)
+        tier = tier or "triage"
+        with _FAST_REFUSED_LOCK:
+            rec = _fast_refused()
+            if state == "on":
+                if tier in rec:
+                    del rec[tier]
+                    _atomic_write_json(FAST_REFUSED, rec)
+                return
+            _FAST_ORG_MEMO["env"] = None
+            if (rec.get(tier) or {}).get("reason") == reason:
+                return                               # the same refusal standing: said already
+            rec[tier] = {"reason": reason, "model": str(model), "t": int(time.time())}
+            _atomic_write_json(FAST_REFUSED, rec)
+        _log_judge_error(judge, fsid, "fast-refused",
+                         note="%s tier asked for fast mode on %s; the CLI ran it %s: %s" % (tier, model, state or "without saying", reason))
+    except Exception:
+        pass
+
+
+def _atomic_write_json(path, obj):
+    tmp = Path("%s.%d.%x.tmp" % (path, os.getpid(), threading.get_ident()))   # per writer: two threads never share one
+    tmp.write_text(json.dumps(obj))
+    os.replace(tmp, path)
+
+
+_FAST_ORG_MEMO = {"env": None}   # the org-check env for key-billed fast calls: None = not asked; a dict (maybe {})
+#                                  = asked. Filled once per process under _FAST_ORG_LOCK; dropped by any refusal the
+#                                  CLI reports (_note_fast_readback), never re-asked per call
+_FAST_ORG_LOCK = threading.Lock()
+
+
+def _fast_org_env():
+    """The sessions' rule for a KEY-billed fast call (sdk_backend.helper_fast_org_env): the CLI's fast-mode
+    availability probe asks the saved claude.ai login even when the call bills the key, so the kernel asks the
+    paying account (the configured apiKeyHelper's key) and hands the CLI its own switch. Asked once per process,
+    since a judge call is not a connect (hundreds an hour) and the helper may cost the operator a prompt: the
+    first caller asks under a lock and the pool's other callers wait for its answer instead of each running the
+    helper. An answer with nothing to say ({}: no helper, or the probe unreachable) is kept too, so a dead network
+    does not cost a probe per call; the CLI's next refusal of a fast ask, whatever its reason, drops the memo and
+    the next call asks again."""
+    env = _FAST_ORG_MEMO["env"]
+    if env is not None:
+        return env
+    with _FAST_ORG_LOCK:
+        env = _FAST_ORG_MEMO["env"]
+        if env is not None:
+            return env                               # another caller asked first
+        try:
+            sb = sys.modules.get("romp_sdk_backend") or load_source("romp_sdk_backend", HERE / "sdk_backend.py")
+            def log(msg, problem=False):
+                sys.stderr.write("judges: %s\n" % msg)
+            env = dict(sb.helper_fast_org_env(log, None) or {})
+        except Exception as e:
+            sys.stderr.write("judges: fast-mode org check failed (%s); the CLI's own check stands\n" % e)
+            env = {}
+        _FAST_ORG_MEMO["env"] = env
+        return env
 
 
 _LOGIN_AUTH_ENV_FN = None      # login tokens claimed out of the manager's ambient environment: the kernel
@@ -1784,6 +1904,10 @@ def _judge_env(tier, auth="login", model=None):
     env = dict(os.environ)
     for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
         env.pop(k, None)                             # billing is an explicit choice per call
+    for k in ("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", "CLAUDE_CODE_DISABLE_FAST_MODE"):
+        env.pop(k, None)                             # the fast-mode org verdict is per call too (_fast_org_env for a
+        #                                              key-billed ask; a session's own verdict in this process's
+        #                                              environment says nothing about the judge's account)
     for k in list(env):                              # the 1Password CLI's own names never ride a judge child
         if k in _cred.OP_ENV_NAMES or k.startswith(_cred.OP_ENV_PREFIX):
             env.pop(k, None)
@@ -2071,7 +2195,10 @@ def _judge_run_impl(model, sys_prompt, user, effort=None, judge=None, tier="tria
             _judge_ctx.paused = True
             return ""
         try:
-            p = subprocess.run(_judge_cmd(model, sys_prompt, effort, auth=auth), input=user,
+            fast_asked = _tier_fast(tier, model)
+            if fast_asked and auth != "login":
+                env = dict(env, **_fast_org_env())    # permission follows billing (the sessions' rule, T300)
+            p = subprocess.run(_judge_cmd(model, sys_prompt, effort, auth=auth, tier=tier), input=user,
                                capture_output=True, text=True, cwd=JUDGE_SCRATCH, env=env,
                                timeout=CALL_ALARM_S + 5)
         except Exception as e:
@@ -2106,6 +2233,11 @@ def _judge_run_impl(model, sys_prompt, user, effort=None, judge=None, tier="tria
                     _mark_call_failed(model, msg[:160])
                 _log_judge_error(judge or tier, fsid, "call",
                                  note="error envelope: %r" % msg[:160])
+                if fast_asked and "fast_mode_state" in wrap:
+                    # the call asked for fast and the CLI's refusal envelope still says whether fast engaged: keep
+                    # that readback (a zero-cost row marked err, which the cost rollup skips) and judge it below
+                    _log_judge_usage(judge or tier, tier, model, fsid, dict(wrap, total_cost_usd=0), sent, recv, err=True)
+                    _note_fast_readback(tier, model, wrap, judge or tier, fsid)
                 if _LIMIT_ENVELOPE_RE.search(msg):
                     # a limit-shaped envelope is the EVENT that says usage.json is stale (get_usage
                     # rides turn ends; an idle fleet refreshes nothing): latch the loud banner NOW
@@ -2130,6 +2262,8 @@ def _judge_run_impl(model, sys_prompt, user, effort=None, judge=None, tier="tria
             if isinstance(wrap, dict) and isinstance(wrap.get("result"), str):
                 _judge_ctx.last["reply"] = _mid_elide(wrap["result"])
                 _log_judge_usage(judge or tier, tier, model, fsid, wrap, sent, recv)
+                if fast_asked and "fast_mode_state" in wrap:   # no answer is no information (never a fabricated refusal)
+                    _note_fast_readback(tier, model, wrap, judge or tier, fsid)
                 _note_served_model(model, wrap)       # the envelope names the model a bare alias resolved to;
                                                       # the alias table is checked against it (one line per drift)
                 _auth_down_clear(fsid)                # billing works → unlatch (cheap no-op when unlatched)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1904,10 +1904,10 @@ def _judge_env(tier, auth="login", model=None):
     env = dict(os.environ)
     for k in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
         env.pop(k, None)                             # billing is an explicit choice per call
-    for k in ("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", "CLAUDE_CODE_DISABLE_FAST_MODE"):
-        env.pop(k, None)                             # the fast-mode org verdict is per call too (_fast_org_env for a
-        #                                              key-billed ask; a session's own verdict in this process's
-        #                                              environment says nothing about the judge's account)
+    env.pop("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", None)   # the fast-mode org verdict is per call too (_fast_org_env
+    #   for a key-billed ask): a session's skip in this process's environment says nothing about the judge's account.
+    #   CLAUDE_CODE_DISABLE_FAST_MODE stays: set in service.env it is the OPERATOR's kill switch, which every judge
+    #   child honoured before and every session still does (a review finding on the add-on's first head).
     for k in list(env):                              # the 1Password CLI's own names never ride a judge child
         if k in _cred.OP_ENV_NAMES or k.startswith(_cred.OP_ENV_PREFIX):
             env.pop(k, None)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40583,26 +40583,37 @@ _JUDGE_FAST_TIERS = (("judgeFast", "judge-fast", "triage", _set_judge_fast, lamb
                      ("indexFast", "index-fast", "indexing", _set_index_fast, lambda: jd._index_model()))           # follow resolves
 
 
+_JUDGE_FAST_MIGRATED = "judge-fast-tiers.migrated"   # STATE marker: the carry-over below ran to completion (epoch seconds)
+
+
 def _migrate_judge_fast_tiers():
     """One-time carry-over from the single fast-mode flag (STATE/judge-fast alone, which ran every Opus call fast
-    whichever tier) to a flag per tier. On the first boot on this code, the boot that finds NEITHER new file, both
-    are written: when judge-fast is "on", each new tier gets "on" where its effective model can run fast and "off"
-    where it cannot, so an existing on keeps the behaviour it had; otherwise both get "off", the default they
-    already read as. The two files' existence is the done marker, so a Triage box ticked later never spreads to
-    the other tiers at the next restart (a review finding on the first cut, whose marker was the carried value).
-    The writes carry stamp 1, a value older than any gesture: a pick made on any machine, before or after this
-    boot, outranks them (a peer's propagated on/off is never stood down by a migration default)."""
+    whichever tier) to a flag per tier. On the first boot on this code, every new-tier file that is not yet written
+    gets a value: when judge-fast is "on", "on" where the tier's effective model can run fast and "off" where it
+    cannot, so an existing on keeps the behaviour it had; otherwise "off", the default it already read as. An
+    explicit marker (STATE/judge-fast-tiers.migrated) is written LAST and is the only done signal: a boot that
+    finds it does nothing, a boot that finds a file already written leaves that file alone and completes the rest
+    (a write that failed half-way completes on the next boot; a review finding on the add-on's first head, whose
+    marker was either file's existence, so a failed second write lost that tier's carry for good). A Triage box
+    ticked after the marker never spreads to the other tiers. The value writes carry stamp 1, older than any
+    gesture: a pick made on any machine, before or after this boot, outranks them."""
     try:
-        if (jd.STATE / "distill-fast").exists() or (jd.STATE / "index-fast").exists():
+        marker = jd.STATE / _JUDGE_FAST_MIGRATED
+        if marker.exists():
             return 0
         carry = jd._state_str("judge-fast", "off") == "on"
         n = 0
         for field, fname, word, setter, model_of in _JUDGE_FAST_TIERS[1:]:
+            if (jd.STATE / fname).exists():
+                continue                             # written already (a half-applied earlier boot): left as it is
             v = "on" if carry and jd.fast_capable(model_of()) else "off"
-            if setter(v, gt=1) is not None:
-                n += 1
-                if carry:
-                    sys.stderr.write("judges: fast mode carried over to the %s tier as %s (its model: %s)\n" % (word, v, model_of()))
+            if setter(v, gt=1) is None:
+                return n                             # the write failed (said by the setter): no marker, the next boot completes
+            n += 1
+            if carry:
+                sys.stderr.write("judges: fast mode carried over to the %s tier as %s (its model: %s)\n" % (word, v, model_of()))
+        jd.STATE.mkdir(parents=True, exist_ok=True)
+        _atomic_write(marker, str(int(time.time())))
         return n
     except Exception:
         sys.stderr.write("judge-fast migration: %s\n" % traceback.format_exc())

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1137,7 +1137,9 @@ def _version_info():
             "commentEffort": jd._state_str("comment-effort", "session"),
             "commentFast": jd._state_str("comment-fast", "session"),
             "tmuxBackend": jd._state_str("tmux-backend", "off"),   # T288: "on" offers Claude Code (tmux) in the picker and the gear
-            "judgeFast": jd._state_str("judge-fast", "off"),   # RAW "on" | "off": the judges' Fast mode box, the fast-mode opt-in on Opus judge calls
+            "judgeFast": jd._state_str("judge-fast", "off"),   # RAW "on" | "off": the TRIAGE tier's Fast mode box (T300: one per tier)
+            "distillFast": jd._state_str("distill-fast", "off"), "indexFast": jd._state_str("index-fast", "off"),
+            "fastRefused": jd._fast_refused(),   # tier -> {reason, model, t}: the CLI declined a fast ask; the gear's box says why
             # One dict with every kernel-side setting, lifted by a PEER kernel's /version poll onto its
             # /tunnels row so its gear can mark controls where machines disagree (the user 2026-08-14).
             # The top-level fields above stay: this tab's own gear and older kernels read those.
@@ -1158,7 +1160,8 @@ def _version_info():
                          "commentEffort": jd._state_str("comment-effort", "session"),
                          "commentFast": jd._state_str("comment-fast", "session"),
                          "tmuxBackend": jd._state_str("tmux-backend", "off"),
-                         "judgeFast": jd._state_str("judge-fast", "off")},
+                         "judgeFast": jd._state_str("judge-fast", "off"),
+                         "distillFast": jd._state_str("distill-fast", "off"), "indexFast": jd._state_str("index-fast", "off")},
             # every gt-gated store's last-applied gesture stamp (epoch-ms ints, nothing path-shaped):
             # the gear stamps its next gesture above these instead of trusting the device clock.
             # Top-level, not lifted into /tunnels rows — a remote's newer stamp reaches the dashboard
@@ -38215,8 +38218,8 @@ def _judge_usage(t0):
         return {"calls": 0, "in": 0, "out": 0, "cost": 0.0, "ms": 0}
     total, by_judge, by_tier = blank(), {}, {}
     for o in _judge_usage_rows():
-        if (o.get("t") or 0) < t0:
-            continue
+        if (o.get("t") or 0) < t0 or o.get("err"):     # err: an error envelope's row, kept for its fast readback
+            continue                                    # only (zero cost, no model call to count)
         for b in (total, by_judge.setdefault(o.get("judge") or "?", blank()),
                   by_tier.setdefault(o.get("tier") or "?", blank())):
             b["calls"] += 1
@@ -40570,6 +40573,40 @@ def _set_tmux_backend(v, gt=None):   return _set_judge_state("tmux-backend", v, 
 # default. Fast mode bills Opus at a premium and draws on fast mode's own rate limits, so it is a deliberate
 # pick. Rides the judge-knob machinery: validated, stamped, propagated to every linked kernel.
 def _set_judge_fast(v, gt=None):     return _set_judge_state("judge-fast", v, {"on", "off"}, gt=gt)
+# One flag per tier (T300, the user 2026-09-10): judge-fast above is the TRIAGE tier's, these two the distilling and
+# indexing tiers'. A box beside each tier's model picker in the gear, greyed with the reason when the tier's effective
+# model cannot run fast (jd.fast_capable); the value is kept then, and the judges simply ask nothing (jd._tier_fast).
+def _set_distill_fast(v, gt=None):   return _set_judge_state("distill-fast", v, {"on", "off"}, gt=gt)
+def _set_index_fast(v, gt=None):     return _set_judge_state("index-fast", v, {"on", "off"}, gt=gt)
+_JUDGE_FAST_TIERS = (("judgeFast", "judge-fast", "triage", _set_judge_fast, lambda: jd._triage_model()),
+                     ("distillFast", "distill-fast", "distilling", _set_distill_fast, lambda: jd._distill_model()),   # EFFECTIVE:
+                     ("indexFast", "index-fast", "indexing", _set_index_fast, lambda: jd._index_model()))           # follow resolves
+
+
+def _migrate_judge_fast_tiers():
+    """One-time carry-over from the single fast-mode flag (STATE/judge-fast alone, which ran every Opus call fast
+    whichever tier) to a flag per tier. On the first boot on this code, the boot that finds NEITHER new file, both
+    are written: when judge-fast is "on", each new tier gets "on" where its effective model can run fast and "off"
+    where it cannot, so an existing on keeps the behaviour it had; otherwise both get "off", the default they
+    already read as. The two files' existence is the done marker, so a Triage box ticked later never spreads to
+    the other tiers at the next restart (a review finding on the first cut, whose marker was the carried value).
+    The writes carry stamp 1, a value older than any gesture: a pick made on any machine, before or after this
+    boot, outranks them (a peer's propagated on/off is never stood down by a migration default)."""
+    try:
+        if (jd.STATE / "distill-fast").exists() or (jd.STATE / "index-fast").exists():
+            return 0
+        carry = jd._state_str("judge-fast", "off") == "on"
+        n = 0
+        for field, fname, word, setter, model_of in _JUDGE_FAST_TIERS[1:]:
+            v = "on" if carry and jd.fast_capable(model_of()) else "off"
+            if setter(v, gt=1) is not None:
+                n += 1
+                if carry:
+                    sys.stderr.write("judges: fast mode carried over to the %s tier as %s (its model: %s)\n" % (word, v, model_of()))
+        return n
+    except Exception:
+        sys.stderr.write("judge-fast migration: %s\n" % traceback.format_exc())
+        return 0
 
 
 # The four judge-tier settings PROPAGATE: a pick made here follows to every linked kernel (the user
@@ -40595,7 +40632,8 @@ _JUDGE_SETTING_FIELDS = (("judgeModel", _set_judge_model), ("indexModel", _set_i
                          ("commentModel", _set_comment_model), ("commentEffort", _set_comment_effort),
                          ("commentFast", _set_comment_fast),
                          ("tmuxBackend", _set_tmux_backend),   # T288: the tmux backend's offer, "on" | "off"
-                         ("judgeFast", _set_judge_fast))       # the judges' Fast mode, "on" | "off"
+                         ("judgeFast", _set_judge_fast),       # fast mode per tier, "on" | "off" (T300)
+                         ("distillFast", _set_distill_fast), ("indexFast", _set_index_fast))
 
 # The per-field PICK STAMPS this leg carried from 2026-08-30 (each field's STATE-file mtime in a
 # body "stamps" dict, preserved by utime at the receiver — the distill-pick stomp fix) are
@@ -40648,7 +40686,8 @@ def _apply_judge_settings(body):
             "commentEffort": jd._state_str("comment-effort", "session"),
             "commentFast": jd._state_str("comment-fast", "session"),
             "tmuxBackend": jd._state_str("tmux-backend", "off"),
-            "judgeFast": jd._state_str("judge-fast", "off")}
+            "judgeFast": jd._state_str("judge-fast", "off"),
+            "distillFast": jd._state_str("distill-fast", "off"), "indexFast": jd._state_str("index-fast", "off")}
 
 
 def _propagate_judge_settings(body):
@@ -40859,7 +40898,7 @@ def _adopt_peer_settings(host, rver):
 _GT_STORES = ("auto-nudge", "compact-suggest", "file-editing", "update-mode", "thinking-summaries",
               "judge-model", "index-model", "judge-effort", "index-effort", "judge-concurrency",
               "distill-model", "distill-effort", "comment-model", "comment-effort", "comment-fast",
-              "tmux-backend", "judge-fast")
+              "tmux-backend", "judge-fast", "distill-fast", "index-fast")
 
 
 def _setting_stored_gt(name):
@@ -53744,19 +53783,22 @@ class Handler(BaseHTTPRequestHandler):
                                  args=({"tmuxBackend": _tbv, "gt": _jgt},), daemon=True).start()
             else:
                 _tell_stale_gesture(client, msg)
-        elif msg and msg.get("type") == "setJudgeFast" and msg.get("enabled") is not None:
-            # the gear's Fast mode box on the Triage model row: a checkbox, stored as on/off and read by the judges per call (jd._judge_fast).
-            # The boolean is checked like its siblings' (_as_bool), and a malformed frame is refused with a
-            # warn, unwritten; an applied pick fans out to every linked kernel under its gesture stamp.
+        elif msg and msg.get("type") in ("setJudgeFast", "setDistillFast", "setIndexFast") and msg.get("enabled") is not None:
+            # the gear's Fast mode box beside a tier's model picker (T300: one per tier): a checkbox, stored as on/off
+            # and read by the judges per call (jd._tier_fast). The boolean is checked like its siblings' (_as_bool),
+            # and a malformed frame is refused with a warn, unwritten; an applied pick fans out to every linked
+            # kernel under its gesture stamp.
+            _ffield, _fset = {"setJudgeFast": ("judgeFast", _set_judge_fast), "setDistillFast": ("distillFast", _set_distill_fast),
+                              "setIndexFast": ("indexFast", _set_index_fast)}[msg["type"]]
             _jfe, ferr = _as_bool(msg.get("enabled"), "enabled")
             if ferr:
                 _refuse_ws_flag(client, msg["type"], ferr, "enabled", msg.get("enabled"))
                 return
             _jfv = "on" if _jfe else "off"
-            _jgt = _set_judge_fast(_jfv, gt=_gesture_ms(msg))
+            _jgt = _fset(_jfv, gt=_gesture_ms(msg))
             if _jgt is not None:
                 threading.Thread(target=_propagate_judge_settings,
-                                 args=({"judgeFast": _jfv, "gt": _jgt},), daemon=True).start()
+                                 args=({_ffield: _jfv, "gt": _jgt},), daemon=True).start()
             else:
                 _tell_stale_gesture(client, msg)
         else:
@@ -54377,6 +54419,7 @@ def main():
         _n = jd.migrate_all_stores()                          # goal store/archive BEFORE any judge pass runs —
         if _n:                                                # the hot paths carry no migration logic anymore
             sys.stderr.write("romp-kernel: diary sweep migrated %d store file(s)\n" % _n)
+        _migrate_judge_fast_tiers()                           # the one fast-mode flag -> one per tier (T300), once
     except Exception:
         sys.stderr.write("diary sweep: %s\n" % traceback.format_exc())
     try:                                                      # judge scratch transcripts are one-shot junk

--- a/tests/fixtures/claude-p-result-envelope-fast.json
+++ b/tests/fixtures/claude-p-result-envelope-fast.json
@@ -1,0 +1,58 @@
+{
+ "type": "result",
+ "subtype": "success",
+ "is_error": false,
+ "duration_ms": 1800,
+ "duration_api_ms": 1500,
+ "num_turns": 1,
+ "result": "ok",
+ "stop_reason": "end_turn",
+ "terminal_reason": null,
+ "session_id": "11111111-2222-4333-8444-555555555555",
+ "uuid": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+ "total_cost_usd": 0.27,
+ "api_error_status": null,
+ "permission_denials": [],
+ "queued_turn_count": 0,
+ "time_to_request_ms": 300,
+ "ttft_ms": 900,
+ "ttft_stream_ms": 950,
+ "subagent_stats": {},
+ "usage": {
+  "input_tokens": 2,
+  "cache_creation_input_tokens": 21600,
+  "cache_read_input_tokens": 0,
+  "output_tokens": 4,
+  "output_tokens_details": {
+   "thinking_tokens": 0
+  },
+  "server_tool_use": {
+   "web_search_requests": 0,
+   "web_fetch_requests": 0
+  },
+  "service_tier": "standard",
+  "cache_creation": {
+   "ephemeral_1h_input_tokens": 0,
+   "ephemeral_5m_input_tokens": 21600
+  },
+  "inference_geo": "global",
+  "speed": "fast"
+ },
+ "modelUsage": {
+  "claude-opus-5": {
+   "inputTokens": 2,
+   "outputTokens": 4,
+   "cacheReadInputTokens": 0,
+   "cacheCreationInputTokens": 21600,
+   "webSearchRequests": 0,
+   "costUSD": 0.27,
+   "maxOutputTokens": 64000,
+   "thinkingTokens": 0,
+   "canonicalModel": "claude-opus-5",
+   "provider": "firstParty",
+   "costBasis": "list"
+  }
+ },
+ "fast_mode_state": "on",
+ "fast_mode_disabled_reason": null
+}

--- a/tests/fixtures/claude-p-result-envelope-standard.json
+++ b/tests/fixtures/claude-p-result-envelope-standard.json
@@ -1,0 +1,58 @@
+{
+ "type": "result",
+ "subtype": "success",
+ "is_error": false,
+ "duration_ms": 1800,
+ "duration_api_ms": 1500,
+ "num_turns": 1,
+ "result": "ok",
+ "stop_reason": "end_turn",
+ "terminal_reason": null,
+ "session_id": "11111111-2222-4333-8444-555555555555",
+ "uuid": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+ "total_cost_usd": 0.135,
+ "api_error_status": null,
+ "permission_denials": [],
+ "queued_turn_count": 0,
+ "time_to_request_ms": 300,
+ "ttft_ms": 900,
+ "ttft_stream_ms": 950,
+ "subagent_stats": {},
+ "usage": {
+  "input_tokens": 2,
+  "cache_creation_input_tokens": 21600,
+  "cache_read_input_tokens": 0,
+  "output_tokens": 4,
+  "output_tokens_details": {
+   "thinking_tokens": 0
+  },
+  "server_tool_use": {
+   "web_search_requests": 0,
+   "web_fetch_requests": 0
+  },
+  "service_tier": "standard",
+  "cache_creation": {
+   "ephemeral_1h_input_tokens": 0,
+   "ephemeral_5m_input_tokens": 21600
+  },
+  "inference_geo": "global",
+  "speed": "standard"
+ },
+ "modelUsage": {
+  "claude-opus-5": {
+   "inputTokens": 2,
+   "outputTokens": 4,
+   "cacheReadInputTokens": 0,
+   "cacheCreationInputTokens": 21600,
+   "webSearchRequests": 0,
+   "costUSD": 0.135,
+   "maxOutputTokens": 64000,
+   "thinkingTokens": 0,
+   "canonicalModel": "claude-opus-5",
+   "provider": "firstParty",
+   "costBasis": "list"
+  }
+ },
+ "fast_mode_state": "off",
+ "fast_mode_disabled_reason": "sdk_opt_in_required"
+}

--- a/tests/test_judge_fast_tiers.py
+++ b/tests/test_judge_fast_tiers.py
@@ -58,7 +58,7 @@ def _clear_state():
                 (jd.STATE / name).unlink()
             except OSError:
                 pass
-    for name in ("fast-refused.json",):
+    for name in ("fast-refused.json", "judge-fast-tiers.migrated"):
         try:
             (jd.STATE / name).unlink()
         except OSError:
@@ -229,7 +229,8 @@ class CarryOver(_Base):
         self.assertEqual((jd.STATE / "index-fast").read_text(), "off")
         self.assertEqual((jd.STATE / "judge-fast").read_text(), "on", "the triage flag is the old flag, untouched")
         self.assertEqual(err.getvalue().count("fast mode carried over"), 2)
-        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "done once: the files' existence is the marker")
+        self.assertTrue((jd.STATE / "judge-fast-tiers.migrated").exists(), "the marker, written last")
+        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "done once: the marker says so")
         self.assertEqual(km._setting_stored_gt("distill-fast"), 1, "a carried value is older than any gesture")
         self.assertEqual(km._set_distill_fast("off", gt=T_OLD), T_OLD, "a peer's earlier explicit off is not stood down by it")
 
@@ -244,7 +245,7 @@ class CarryOver(_Base):
         self.assertEqual(((jd.STATE / "distill-fast").read_text(), (jd.STATE / "index-fast").read_text()), ("off", "off"))
         self.assertEqual((km._setting_stored_gt("distill-fast"), km._setting_stored_gt("index-fast")), (1, 1), "older than any gesture")
         km._set_judge_fast("on")           # the user ticks only the Triage box...
-        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "...and a restart carries nothing")
+        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "...and a restart carries nothing: the marker stands")
         self.assertEqual((jd.STATE / "distill-fast").read_text(), "off")
         self.assertFalse(jd._tier_fast("distill", jd._distill_model()))
         # a real gesture from any machine, even one stamped before this boot, outranks the migration default
@@ -256,11 +257,31 @@ class CarryOver(_Base):
         self.assertEqual(km._migrate_judge_fast_tiers(), 2)
         self.assertEqual(((jd.STATE / "distill-fast").read_text(), (jd.STATE / "index-fast").read_text()), ("off", "off"))
 
-    def test_a_tier_already_written_stops_the_carry_over(self):
-        km._set_judge_fast("on"); km._set_index_fast("off")
-        self._pick("judgeModel", "opus")
-        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "someone already chose per tier: nothing to carry")
-        self.assertFalse((jd.STATE / "distill-fast").exists())
+    def test_a_half_applied_carry_over_completes_on_the_next_boot(self):
+        # the first boot wrote distill-fast and died before index-fast and the marker (an OSError on the second
+        # write, a crash): the next boot leaves the written file alone, writes the missing one, then the marker
+        self._pick("judgeModel", "opus"); self._pick("indexModel", "opus")
+        km._set_judge_fast("on")
+        km._set_distill_fast("off", gt=1)          # what the failed boot left: written, no marker
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._migrate_judge_fast_tiers(), 1, "only the missing tier is written")
+        self.assertEqual((jd.STATE / "distill-fast").read_text(), "off", "the written file is left as it was")
+        self.assertEqual((jd.STATE / "index-fast").read_text(), "on", "the missing tier gets its carry")
+        self.assertTrue((jd.STATE / "judge-fast-tiers.migrated").exists())
+        self.assertEqual(km._migrate_judge_fast_tiers(), 0)
+
+    def test_a_failed_write_leaves_no_marker_so_the_next_boot_retries(self):
+        km._set_judge_fast("on")
+        with patch.object(km, "_set_index_fast", return_value=None), contextlib.redirect_stderr(io.StringIO()):
+            # the tier table binds the setters at import: patch the table's entry, not the module name
+            tiers = tuple((f, n, w, (km._set_distill_fast if n == "distill-fast" else (lambda v, gt=None: None)), m) for f, n, w, _s, m in km._JUDGE_FAST_TIERS)
+            with patch.object(km, "_JUDGE_FAST_TIERS", tiers):
+                self.assertEqual(km._migrate_judge_fast_tiers(), 1, "distill landed, index failed")
+        self.assertFalse((jd.STATE / "judge-fast-tiers.migrated").exists(), "no marker: not done")
+        self.assertFalse((jd.STATE / "index-fast").exists())
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._migrate_judge_fast_tiers(), 1, "the next boot completes the rest")
+        self.assertTrue((jd.STATE / "judge-fast-tiers.migrated").exists())
 
     def test_the_kernel_boots_through_it(self):
         with open(os.path.join(BIN, "romp-kernel")) as f:
@@ -458,12 +479,18 @@ class RunEndToEnd(_Base):
         self._run(fast, auth="key")
         self.assertEqual(self.asked, [None], "memoised: a judge call is not a connect")
         out, seen = self._run(fast, auth="login")
-        # ...and never from this process's own environment either: a session's verdict is not the judge's
+        # ...and never from this process's own environment either: a session's skip is not the judge's verdict. The
+        # operator's kill switch (CLAUDE_CODE_DISABLE_FAST_MODE in service.env) is another matter: it reaches every
+        # judge child, as it did before the per-tier boxes and as it reaches every session
         with patch.dict(os.environ, {"CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK": "1", "CLAUDE_CODE_DISABLE_FAST_MODE": "1"}):
             out, seen = self._run(fast, auth="login")
         self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", seen["env"], "a login-billed call: the CLI's probe already asks the paying account")
-        self.assertNotIn("CLAUDE_CODE_DISABLE_FAST_MODE", seen["env"])
+        self.assertEqual(seen["env"].get("CLAUDE_CODE_DISABLE_FAST_MODE"), "1", "the operator's kill switch reaches the judge child")
         self.assertEqual(json.loads(seen["cmd"][seen["cmd"].index("--settings") + 1]), {"fastMode": True, "apiKeyHelper": ""})
+        with patch.dict(os.environ, {"CLAUDE_CODE_DISABLE_FAST_MODE": "1"}):
+            out, seen = self._run(fast, auth="key")
+        self.assertEqual(seen["env"].get("CLAUDE_CODE_DISABLE_FAST_MODE"), "1", "...on a key-billed call too, beside the org-check switch")
+        self.assertEqual(seen["env"].get("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK"), "1")
         # fast off for the tier, or a model that cannot run it: no probe, no opt-in
         out, seen = self._run(fast, auth="key", model="sonnet")
         self.assertNotIn("--settings", seen["cmd"])

--- a/tests/test_judge_fast_tiers.py
+++ b/tests/test_judge_fast_tiers.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""Fast mode per judge tier (T300, the user 2026-09-10), the add-on over the judges' one Fast mode flag: a box
+beside EACH tier's model picker, one flag per tier (STATE/judge-fast is the triage tier's, distill-fast and
+index-fast the other two), read by the judges at call time for the tier the call runs in. The gear greys a
+tier's box and says why when the tier's effective model cannot run fast; the value is kept, and the judges ask
+nothing for that tier. Also here: the one-time carry-over from the single flag, and the four review concerns on
+the first cut, each with a test:
+  - a key-billed fast call carries the sessions' org-check env (permission follows billing), memoised, never a
+    login-billed call;
+  - a refused fast ask is loud: the CLI's readback records the refusal per tier (fast-refused.json, lifted by
+    /version for the gear's hint) and writes ONE judge-errors row per reason change; an error envelope that
+    carries the readback still writes a usage row (zero cost, marked err, skipped by the cost rollup);
+  - the readback's field names are the CLI's own: two fixtures carry the result envelope's shape as claude
+    2.1.257 prints it (captured 2026-09-10; synthetic values);
+  - the cost rollup adds the CLI's own total_cost_usd, which the CLI already doubles for a fast call (measured:
+    the same prompt cost twice as much fast), so a fast row is priced at the fast rate with no table of its own.
+Hermetic state dir; synthetic values; no sockets; the CLI is a fake where a call runs.
+"""
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import threading as _real_threading
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+FIX = os.path.join(HERE, "fixtures")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+km = load_source("romp_kernel_judgefasttiers", os.path.join(BIN, "romp-kernel"))
+jd = km.jd
+
+FLAGS = ("judge-fast", "distill-fast", "index-fast")
+MODELS = ("judge-model", "distill-model", "index-model")
+HELPER_OFF = ["--settings", '{"apiKeyHelper": ""}']   # the login-billed call's helper suppression, verbatim
+T_OLD, T_NEW = 1_700_000_000_000, 1_700_000_360_000
+
+
+def _fixture(name):
+    with open(os.path.join(FIX, name)) as f:
+        return json.load(f)
+
+
+def _clear_state():
+    for f in FLAGS + MODELS:
+        for name in (f, f + ".gt"):
+            try:
+                (jd.STATE / name).unlink()
+            except OSError:
+                pass
+    for name in ("fast-refused.json",):
+        try:
+            (jd.STATE / name).unlink()
+        except OSError:
+            pass
+    jd._state_cache.clear()
+    jd._FAST_ORG_MEMO["env"] = None
+
+
+class _InlineThread:
+    """threading.Thread stand-in: the propagation fan-out runs inline, so a test sees every call at once."""
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+        self._target, self._args, self._kwargs = target, args, (kwargs or {})
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        _clear_state()
+
+    def tearDown(self):
+        _clear_state()
+
+    def _pick(self, field, model):
+        res = km._apply_judge_settings({field: model})
+        self.assertEqual(res[field], model, "the pick must be accepted for the scenario to mean anything")
+        return res
+
+
+class PerTierAsk(_Base):
+    def test_fast_capable_is_the_opus_family(self):
+        for m in ("opus", "claude-opus-4-6", "claude-opus-5", "Opus"):
+            self.assertTrue(jd.fast_capable(m), repr(m))
+        for m in ("sonnet", "haiku", "fable", "claude-sonnet-5", "claude-haiku-4-5-20251001", "", None):
+            self.assertFalse(jd.fast_capable(m), repr(m))
+
+    def test_each_tier_reads_its_own_flag_and_its_own_model(self):
+        self.assertFalse(jd._tier_fast("triage", "opus"), "off by default")
+        self.assertIsNotNone(km._set_judge_fast("on"))
+        self.assertTrue(jd._tier_fast("triage", "opus"))
+        self.assertTrue(jd._judge_fast(), "the first cut's reader is the triage tier's flag")
+        self.assertFalse(jd._tier_fast("triage", "sonnet"), "a model that cannot run fast asks nothing; the flag is kept")
+        self.assertEqual((jd.STATE / "judge-fast").read_text(), "on")
+        self.assertFalse(jd._tier_fast("index", "opus"), "each tier has its own flag")
+        self.assertFalse(jd._tier_fast("distill", "opus"))
+        self.assertIsNotNone(km._set_index_fast("on"))
+        self.assertIsNotNone(km._set_distill_fast("on"))
+        self.assertTrue(jd._tier_fast("index", "opus"))
+        self.assertTrue(jd._tier_fast("distill", "opus"))
+        self.assertTrue(jd._tier_fast(None, "opus"), "no tier = the triage tier, the long-standing default")
+
+    def test_the_argv_carries_the_opt_in_for_the_calls_tier_only(self):
+        km._set_distill_fast("on")
+        off = jd._judge_cmd("opus", "SYS")
+        self.assertNotIn("--settings", off, "the triage tier's flag is off: nothing added")
+        self.assertNotIn("--settings", jd._judge_cmd("opus", "SYS", tier="index"))
+        cmd = jd._judge_cmd("opus", "SYS", tier="distill")
+        self.assertEqual(cmd.count("--settings"), 1)
+        self.assertEqual(json.loads(cmd[-1]), {"fastMode": True})
+        self.assertEqual(cmd[:-2], off, "the opt-in is appended and nothing else moves")
+        self.assertEqual(jd._judge_cmd("sonnet", "SYS", tier="distill"), jd._judge_cmd("sonnet", "SYS"), "a non-Opus distill model: the plain argv")
+        # a login-billed call: ONE overlay with both keys; fast off keeps the helper pin byte for byte
+        cmd = jd._judge_cmd("opus", "SYS", None, auth="login", tier="distill")
+        self.assertEqual(cmd.count("--settings"), 1)
+        self.assertEqual(json.loads(cmd[-1]), {"fastMode": True, "apiKeyHelper": ""})
+        self.assertEqual(jd._judge_cmd("opus", "SYS", None, auth="login", tier="index")[-2:], HELPER_OFF)
+
+    def test_the_run_passes_its_tier_and_resolved_model(self):
+        # the call site is inline in _judge_run_impl: pinned at the source (the end-to-end run is exercised below)
+        with open(os.path.join(ROOT, "kernel", "judge.py")) as f:
+            src = f.read()
+        self.assertIn("fast_asked = _tier_fast(tier, model)", src)
+        self.assertIn("_judge_cmd(model, sys_prompt, effort, auth=auth, tier=tier)", src)
+
+    def test_only_on_and_off_are_storable(self):
+        for bad in ("yes", "true", "1", "", "session", "ON"):
+            self.assertIsNone(km._set_distill_fast(bad), repr(bad))
+            self.assertIsNone(km._set_index_fast(bad), repr(bad))
+        self.assertFalse((jd.STATE / "distill-fast").exists(), "a refused value never lands")
+        self.assertFalse((jd.STATE / "index-fast").exists())
+
+
+class KernelSetting(_Base):
+    def test_the_settings_door_applies_and_reports_the_raw_flags(self):
+        res = km._apply_judge_settings({})
+        self.assertEqual((res["judgeFast"], res["distillFast"], res["indexFast"]), ("off", "off", "off"))
+        res = km._apply_judge_settings({"distillFast": "on", "indexFast": "on"})
+        self.assertEqual((jd.STATE / "distill-fast").read_text(), "on")
+        self.assertEqual((jd.STATE / "index-fast").read_text(), "on")
+        self.assertFalse((jd.STATE / "judge-fast").exists(), "fields not in the body are untouched")
+        self.assertEqual((res["judgeFast"], res["distillFast"], res["indexFast"]), ("off", "on", "on"))
+        res = km._apply_judge_settings({"distillFast": "maybe"})
+        self.assertEqual(res["distillFast"], "on", "an invalid value is ignored and the ack shows what holds")
+
+    def test_a_model_pick_that_cannot_run_fast_keeps_the_flag(self):
+        # the gear greys the box and says why; the kernel clears nothing (the user's session's rule, 2026-09-10)
+        self._pick("judgeModel", "opus")
+        km._set_judge_fast("on"); km._set_distill_fast("on")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            res = self._pick("judgeModel", "sonnet")
+        self.assertEqual((res["judgeFast"], res["distillFast"]), ("on", "on"), "the values stand")
+        self.assertEqual(err.getvalue(), "")
+        self.assertFalse(jd._tier_fast("triage", jd._triage_model()), "...and the tier asks nothing on Sonnet")
+        self.assertFalse(jd._tier_fast("distill", jd._distill_model()), "a Distilling pick of Follow triage follows the triage model")
+
+    def test_the_flags_are_stamp_stores_and_ride_version(self):
+        self.assertTrue({"judge-fast", "distill-fast", "index-fast"} <= set(km._GT_STORES))
+        self.assertTrue({"judge-fast", "distill-fast", "index-fast"} <= set(km._settings_gt()))
+        self.assertTrue({"judgeFast", "distillFast", "indexFast"} <= dict(km._JUDGE_SETTING_FIELDS).keys())
+        km._set_index_fast("on")
+        v = km._version_info()
+        self.assertEqual((v["judgeFast"], v["distillFast"], v["indexFast"]), ("off", "off", "on"), "/version top level, RAW")
+        self.assertEqual((v["settings"]["judgeFast"], v["settings"]["distillFast"], v["settings"]["indexFast"]), ("off", "off", "on"),
+                         "the cross-machine settings dict (the gear's mixed marks)")
+        self.assertEqual(v["fastRefused"], {}, "no refusal recorded: an empty record")
+        for store in ("judge-fast", "distill-fast", "index-fast"):
+            self.assertIn(store, v["settingsGt"])
+
+    def _ws(self, msg):
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s)), "alive": True}
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(types.SimpleNamespace(), msg, client)
+        jd._state_cache.clear()
+        return sent
+
+    def test_the_two_new_socket_ops_store_propagate_and_order_by_gesture(self):
+        propagated = []
+        saved_threading, saved_prop = km.threading, km._propagate_judge_settings
+        ns = {k: getattr(_real_threading, k) for k in dir(_real_threading) if not k.startswith("__")}
+        ns["Thread"] = _InlineThread
+        km.threading = types.SimpleNamespace(**ns)
+        km._propagate_judge_settings = lambda body: propagated.append(body)
+        try:
+            self.assertEqual(self._ws({"type": "setDistillFast", "enabled": True, "gt": T_NEW}), [])
+            self.assertTrue(jd._distill_fast())
+            self.assertFalse(jd._judge_fast(), "the triage flag is another store")
+            self.assertEqual(propagated, [{"distillFast": "on", "gt": T_NEW}])
+            self.assertEqual(self._ws({"type": "setIndexFast", "enabled": True, "gt": T_NEW}), [])
+            self.assertTrue(jd._index_fast())
+            self.assertEqual(propagated[-1], {"indexFast": "on", "gt": T_NEW})
+            # an OLDER gesture stands down: nothing applied, nothing propagated, the delivering socket hears it
+            sent = self._ws({"type": "setIndexFast", "enabled": False, "gt": T_OLD})
+            self.assertTrue(jd._index_fast())
+            self.assertEqual(len(propagated), 2)
+            self.assertEqual([m["setting"] for m in sent if m.get("type") == "settingStale"], ["index-fast"])
+            # a flag that is not a boolean is refused unwritten, with a warn on the delivering socket
+            sent = self._ws({"type": "setDistillFast", "enabled": "on", "gt": T_NEW + 2})
+            self.assertTrue(jd._distill_fast())
+            self.assertEqual([m["type"] for m in sent], ["warn"])
+            self.assertEqual(len(propagated), 2)
+        finally:
+            km.threading, km._propagate_judge_settings = saved_threading, saved_prop
+
+
+class CarryOver(_Base):
+    def test_an_existing_on_is_carried_to_the_tiers_that_can_run_fast(self):
+        # the first cut's one flag ran every Opus call fast, whichever tier: a triage flag on with distilling on
+        # Opus (following triage) and indexing on Haiku becomes triage on, distilling on, indexing off
+        self._pick("judgeModel", "opus"); self._pick("indexModel", "haiku")
+        km._set_judge_fast("on")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._migrate_judge_fast_tiers(), 2)
+        self.assertEqual((jd.STATE / "distill-fast").read_text(), "on")
+        self.assertEqual((jd.STATE / "index-fast").read_text(), "off")
+        self.assertEqual((jd.STATE / "judge-fast").read_text(), "on", "the triage flag is the old flag, untouched")
+        self.assertEqual(err.getvalue().count("fast mode carried over"), 2)
+        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "done once: the files' existence is the marker")
+        self.assertEqual(km._setting_stored_gt("distill-fast"), 1, "a carried value is older than any gesture")
+        self.assertEqual(km._set_distill_fast("off", gt=T_OLD), T_OLD, "a peer's earlier explicit off is not stood down by it")
+
+    def test_a_fresh_install_writes_both_off_and_a_later_triage_tick_never_spreads(self):
+        # the review finding on the first cut: with the carried value as the marker, a Triage box ticked on a fresh
+        # install spread to the distilling tier at the next restart. The marker is the files' existence now.
+        self._pick("judgeModel", "opus")
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._migrate_judge_fast_tiers(), 2, "both files written, as off")
+        self.assertEqual(err.getvalue(), "", "nothing carried: nothing said")
+        self.assertEqual(((jd.STATE / "distill-fast").read_text(), (jd.STATE / "index-fast").read_text()), ("off", "off"))
+        self.assertEqual((km._setting_stored_gt("distill-fast"), km._setting_stored_gt("index-fast")), (1, 1), "older than any gesture")
+        km._set_judge_fast("on")           # the user ticks only the Triage box...
+        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "...and a restart carries nothing")
+        self.assertEqual((jd.STATE / "distill-fast").read_text(), "off")
+        self.assertFalse(jd._tier_fast("distill", jd._distill_model()))
+        # a real gesture from any machine, even one stamped before this boot, outranks the migration default
+        self.assertEqual(km._set_distill_fast("on", gt=T_OLD), T_OLD)
+        self.assertTrue(jd._distill_fast())
+
+    def test_an_off_flag_writes_both_off_too(self):
+        km._set_judge_fast("off")
+        self.assertEqual(km._migrate_judge_fast_tiers(), 2)
+        self.assertEqual(((jd.STATE / "distill-fast").read_text(), (jd.STATE / "index-fast").read_text()), ("off", "off"))
+
+    def test_a_tier_already_written_stops_the_carry_over(self):
+        km._set_judge_fast("on"); km._set_index_fast("off")
+        self._pick("judgeModel", "opus")
+        self.assertEqual(km._migrate_judge_fast_tiers(), 0, "someone already chose per tier: nothing to carry")
+        self.assertFalse((jd.STATE / "distill-fast").exists())
+
+    def test_the_kernel_boots_through_it(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            src = f.read()
+        i = src.index("_n = jd.migrate_all_stores()")
+        self.assertIn("_migrate_judge_fast_tiers()", src[i:i + 600], "right after the store migration, before any judge pass")
+
+
+class Readback(_Base):
+    """The CLI's answer to a fast ask, in the shape claude 2.1.257 prints (two fixtures captured 2026-09-10 with
+    synthetic values): fast_mode_state and fast_mode_disabled_reason on the RESULT envelope, usage.speed beside."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_usage, self._saved_errors = jd.USAGE, jd.ERRORS
+        jd.USAGE = jd.STATE / ("judge-usage-%s.jsonl" % os.getpid())
+        jd.ERRORS = jd.STATE / ("judge-errors-%s.jsonl" % os.getpid())
+
+    def tearDown(self):
+        for p in (jd.USAGE, jd.ERRORS):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+        jd.USAGE, jd.ERRORS = self._saved_usage, self._saved_errors
+        super().tearDown()
+
+    def _rows(self, p):
+        try:
+            return [json.loads(ln) for ln in p.read_text().splitlines() if ln.strip()]
+        except OSError:
+            return []
+
+    def test_the_fixtures_carry_the_fields_the_readback_reads(self):
+        fast, std = _fixture("claude-p-result-envelope-fast.json"), _fixture("claude-p-result-envelope-standard.json")
+        for env in (fast, std):
+            self.assertEqual(env["type"], "result")
+            for k in ("fast_mode_state", "fast_mode_disabled_reason", "total_cost_usd", "usage", "is_error"):
+                self.assertIn(k, env, k)
+        self.assertEqual((fast["fast_mode_state"], fast["fast_mode_disabled_reason"], fast["usage"]["speed"]), ("on", None, "fast"))
+        self.assertEqual((std["fast_mode_state"], std["fast_mode_disabled_reason"], std["usage"]["speed"]), ("off", "sdk_opt_in_required", "standard"))
+        # the usage row keeps the state and the reason from those very names
+        jd._log_judge_usage("planner", "triage", "opus", None, fast, 1.0, 2.0)
+        jd._log_judge_usage("planner", "triage", "opus", None, std, 3.0, 4.0)
+        rows = self._rows(jd.USAGE)
+        self.assertEqual([(r["fast"], r["fastReason"]) for r in rows], [("on", None), ("off", "sdk_opt_in_required")])
+        self.assertNotIn("err", rows[0])
+
+    def test_the_cost_rollup_adds_the_cli_s_own_figure_which_is_fast_priced(self):
+        # the same one-word prompt cost 0.270 fast and 0.135 standard on 2026-09-10: the CLI's total_cost_usd already
+        # carries the fast premium, so the band that sums it prices a fast row right with no table of its own
+        fast, std = _fixture("claude-p-result-envelope-fast.json"), _fixture("claude-p-result-envelope-standard.json")
+        self.assertAlmostEqual(fast["total_cost_usd"] / std["total_cost_usd"], 2.0, places=6)
+        saved = dict(km._JUDGE_USAGE_CACHE) if hasattr(km, "_JUDGE_USAGE_CACHE") else None
+        jd._log_judge_usage("planner", "triage", "opus", None, dict(fast, duration_ms=5), 1.0, 2.0)
+        jd._log_judge_usage("captioner", "index", "opus", None, dict(std, duration_ms=5), 3.0, 4.0)
+        jd._log_judge_usage("planner", "triage", "opus", None, dict(std, total_cost_usd=0, duration_ms=5), 5.0, 6.0, err=True)
+        with patch.object(jd, "STATE", jd.STATE), patch.object(km, "_judge_usage_rows", lambda: self._rows(jd.USAGE)):
+            band = km._judge_usage(0)
+        self.assertEqual(band["total"]["calls"], 2, "the error envelope's row is not a call")
+        self.assertAlmostEqual(band["total"]["cost"], fast["total_cost_usd"] + std["total_cost_usd"], places=9)
+        self.assertAlmostEqual(band["byTier"]["triage"]["cost"], fast["total_cost_usd"], places=9)
+        if saved is not None:
+            km._JUDGE_USAGE_CACHE.update(saved)
+
+    def test_a_refusal_is_recorded_once_per_reason_and_cleared_by_an_on(self):
+        std = _fixture("claude-p-result-envelope-standard.json")
+        jd._note_fast_readback("distill", "opus", std, "distiller", None)
+        rec = jd._fast_refused()
+        self.assertEqual(rec["distill"]["reason"], "sdk_opt_in_required")
+        self.assertEqual(rec["distill"]["model"], "opus")
+        self.assertEqual(km._version_info()["fastRefused"]["distill"]["reason"], "sdk_opt_in_required", "/version lifts it for the gear")
+        errs = self._rows(jd.ERRORS)
+        self.assertEqual([(r["err"], r["judge"]) for r in errs], [("fast-refused", "distiller")])
+        self.assertIn("distill tier asked for fast mode on opus", errs[0]["note"])
+        jd._note_fast_readback("distill", "opus", std, "briefer", None)
+        self.assertEqual(len(self._rows(jd.ERRORS)), 1, "the same refusal standing: said once")
+        other = dict(std, fast_mode_disabled_reason="org_disabled")
+        jd._FAST_ORG_MEMO["env"] = {"X": "1"}
+        jd._note_fast_readback("distill", "opus", other, "distiller", None)
+        self.assertEqual(len(self._rows(jd.ERRORS)), 2, "a new reason is a new row")
+        self.assertIsNone(jd._FAST_ORG_MEMO["env"], "an org-shaped refusal drops the org-check memo")
+        jd._note_fast_readback("distill", "opus", _fixture("claude-p-result-envelope-fast.json"), "distiller", None)
+        self.assertEqual(jd._fast_refused(), {}, "an on clears the tier's record")
+        self.assertEqual(len(self._rows(jd.ERRORS)), 2)
+
+
+class ReadbackEdges(Readback):
+    def test_cooldown_is_not_a_refusal_and_clears_nothing(self):
+        std = _fixture("claude-p-result-envelope-standard.json")
+        jd._note_fast_readback("index", "opus", std, "captioner", None)
+        cool = dict(std, fast_mode_state="cooldown", fast_mode_disabled_reason=None)
+        jd._note_fast_readback("index", "opus", cool, "captioner", None)
+        self.assertEqual(jd._fast_refused()["index"]["reason"], "sdk_opt_in_required", "the standing record is untouched")
+        self.assertEqual(len(self._rows(jd.ERRORS)), 1, "no row for a cooldown")
+        jd._note_fast_readback("distill", "opus", cool, "distiller", None)
+        self.assertNotIn("distill", jd._fast_refused(), "a cooldown on a clean tier records nothing")
+        # on/cooldown alternation at caption volume: no flapping rows
+        for _ in range(3):
+            jd._note_fast_readback("index", "opus", _fixture("claude-p-result-envelope-fast.json"), "captioner", None)
+            jd._note_fast_readback("index", "opus", cool, "captioner", None)
+        self.assertEqual(len(self._rows(jd.ERRORS)), 1)
+
+    def test_an_envelope_without_the_field_says_nothing(self):
+        bare = {k: v for k, v in _fixture("claude-p-result-envelope-fast.json").items() if not k.startswith("fast_mode")}
+        jd._note_fast_readback("triage", "opus", bare, "planner", None)
+        self.assertEqual(jd._fast_refused(), {})
+        self.assertEqual(self._rows(jd.ERRORS), [])
+        std = _fixture("claude-p-result-envelope-standard.json")
+        jd._note_fast_readback("triage", "opus", std, "planner", None)
+        jd._note_fast_readback("triage", "opus", bare, "planner", None)
+        self.assertIn("triage", jd._fast_refused(), "...and clears nothing either: no answer is no information")
+
+    def test_any_refusal_drops_the_org_check_memo(self):
+        jd._FAST_ORG_MEMO["env"] = {}
+        std = dict(_fixture("claude-p-result-envelope-standard.json"), fast_mode_disabled_reason="extra_usage_disabled")
+        jd._note_fast_readback("triage", "opus", std, "planner", None)
+        self.assertIsNone(jd._FAST_ORG_MEMO["env"], "the paying account is asked again after any refusal")
+        jd._FAST_ORG_MEMO["env"] = {"X": "1"}
+        jd._note_fast_readback("triage", "opus", std, "planner", None)
+        self.assertIsNone(jd._FAST_ORG_MEMO["env"], "a standing same-reason refusal drops it too (no row, but the ask stands)")
+
+    def test_concurrent_refusals_of_two_tiers_both_stand(self):
+        import threading
+        std = _fixture("claude-p-result-envelope-standard.json")
+        gate = threading.Barrier(2)
+        def refuse(tier, judge):
+            gate.wait()
+            jd._note_fast_readback(tier, "opus", std, judge, None)
+        ts = [threading.Thread(target=refuse, args=("distill", "distiller")), threading.Thread(target=refuse, args=("index", "captioner"))]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+        self.assertEqual(set(jd._fast_refused()), {"distill", "index"}, "neither record lost to the other's write")
+        self.assertEqual(sorted(r["judge"] for r in self._rows(jd.ERRORS)), ["captioner", "distiller"], "exactly one row each")
+        self.assertEqual([p.name for p in jd.STATE.glob("fast-refused.json.*")], [], "no temp file left behind")
+
+
+class RunEndToEnd(_Base):
+    """_judge_run with a fake CLI: the env a key-billed fast call carries, and what an error envelope leaves."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved_usage, self._saved_errors = jd.USAGE, jd.ERRORS
+        jd.USAGE = jd.STATE / ("judge-usage-e2e-%s.jsonl" % os.getpid())
+        jd.ERRORS = jd.STATE / ("judge-errors-e2e-%s.jsonl" % os.getpid())
+        self._saved_sb = sys.modules.get("romp_sdk_backend")
+        self.asked = []
+        fake_sb = types.SimpleNamespace(helper_fast_org_env=lambda log, cwd: (self.asked.append(cwd) or {"CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK": "1"}))
+        sys.modules["romp_sdk_backend"] = fake_sb
+
+    def tearDown(self):
+        if self._saved_sb is not None:
+            sys.modules["romp_sdk_backend"] = self._saved_sb
+        else:
+            sys.modules.pop("romp_sdk_backend", None)
+        for p in (jd.USAGE, jd.ERRORS):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+        jd.USAGE, jd.ERRORS = self._saved_usage, self._saved_errors
+        super().tearDown()
+
+    def _run(self, envelope, auth, model="opus", tier="triage"):
+        seen = {}
+        def fake_run(cmd, input=None, capture_output=None, text=None, cwd=None, env=None, timeout=None):
+            seen["cmd"], seen["env"] = list(cmd), dict(env or {})
+            return types.SimpleNamespace(returncode=0, stdout=json.dumps(envelope), stderr="")
+        saved = jd.subprocess.run
+        jd.subprocess.run = fake_run
+        try:
+            with patch.object(jd, "_judge_engine", return_value="claude"), patch.object(jd, "_judge_auth", return_value=auth), \
+                 patch.object(jd, "_login_auth_env", return_value={}), contextlib.redirect_stderr(io.StringIO()):
+                out = jd._judge_run(model, "SYS", "u", judge="planner", tier=tier)
+        finally:
+            jd.subprocess.run = saved
+        return out, seen
+
+    def _rows(self, p):
+        try:
+            return [json.loads(ln) for ln in p.read_text().splitlines() if ln.strip()]
+        except OSError:
+            return []
+
+    def test_a_key_billed_fast_call_carries_the_org_check_env_once_and_a_login_call_never(self):
+        km._set_judge_fast("on")
+        fast = _fixture("claude-p-result-envelope-fast.json")
+        out, seen = self._run(fast, auth="key")
+        self.assertEqual(out, "ok")
+        self.assertEqual(seen["env"].get("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK"), "1", "permission follows billing")
+        self.assertEqual(json.loads(seen["cmd"][seen["cmd"].index("--settings") + 1]), {"fastMode": True})
+        self.assertEqual(self.asked, [None], "asked once, with no project cwd (the judges bill the operator's helper)")
+        self._run(fast, auth="key")
+        self.assertEqual(self.asked, [None], "memoised: a judge call is not a connect")
+        out, seen = self._run(fast, auth="login")
+        # ...and never from this process's own environment either: a session's verdict is not the judge's
+        with patch.dict(os.environ, {"CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK": "1", "CLAUDE_CODE_DISABLE_FAST_MODE": "1"}):
+            out, seen = self._run(fast, auth="login")
+        self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", seen["env"], "a login-billed call: the CLI's probe already asks the paying account")
+        self.assertNotIn("CLAUDE_CODE_DISABLE_FAST_MODE", seen["env"])
+        self.assertEqual(json.loads(seen["cmd"][seen["cmd"].index("--settings") + 1]), {"fastMode": True, "apiKeyHelper": ""})
+        # fast off for the tier, or a model that cannot run it: no probe, no opt-in
+        out, seen = self._run(fast, auth="key", model="sonnet")
+        self.assertNotIn("--settings", seen["cmd"])
+        self.assertNotIn("CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK", seen["env"])
+        km._set_judge_fast("off")
+        out, seen = self._run(fast, auth="key")
+        self.assertNotIn("--settings", seen["cmd"])
+
+    def test_an_error_envelope_keeps_its_readback_as_a_zero_cost_row_and_the_refusal_is_recorded(self):
+        km._set_judge_fast("on")
+        env = dict(_fixture("claude-p-result-envelope-standard.json"), is_error=True, subtype="error_during_execution",
+                   result="Fast mode is not available for this organization")
+        out, seen = self._run(env, auth="key")
+        self.assertEqual(out, "", "an error envelope is a failed call to the callers")
+        rows = self._rows(jd.USAGE)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual((rows[0]["fast"], rows[0]["fastReason"], rows[0]["cost"], rows[0].get("err")), ("off", "sdk_opt_in_required", 0, True))
+        errs = self._rows(jd.ERRORS)
+        self.assertEqual([r["err"] for r in errs], ["call", "fast-refused"], "the call failure and the refusal, each once")
+        self.assertEqual(jd._fast_refused()["triage"]["reason"], "sdk_opt_in_required")
+        # the same envelope again: no second refusal row; a success with fast on clears the record
+        self._run(env, auth="key")
+        self.assertEqual([r["err"] for r in self._rows(jd.ERRORS)], ["call", "fast-refused", "call"], "no second refusal row")
+        self._run(_fixture("claude-p-result-envelope-fast.json"), auth="key")
+        self.assertEqual(jd._fast_refused(), {})
+        rows = self._rows(jd.USAGE)
+        self.assertEqual([r.get("err") for r in rows], [True, True, None])
+
+    def test_the_org_check_is_asked_once_across_concurrent_callers(self):
+        import threading
+        gate = threading.Barrier(4)
+        def ask():
+            gate.wait()
+            jd._fast_org_env()
+        ts = [threading.Thread(target=ask) for _ in range(4)]
+        for t in ts:
+            t.start()
+        for t in ts:
+            t.join()
+        self.assertEqual(self.asked, [None], "one helper run for the pool: the others wait for its answer")
+        self.assertEqual(jd._fast_org_env(), {"CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK": "1"})
+
+    def test_a_probe_with_nothing_to_say_is_kept_until_a_refusal(self):
+        sys.modules["romp_sdk_backend"] = types.SimpleNamespace(helper_fast_org_env=lambda log, cwd: (self.asked.append(cwd) or {}))
+        self.assertEqual(jd._fast_org_env(), {})
+        self.assertEqual(jd._fast_org_env(), {})
+        self.assertEqual(self.asked, [None], "a dead network does not cost a probe per call")
+        km._set_judge_fast("on")
+        out, seen = self._run(_fixture("claude-p-result-envelope-standard.json"), auth="key")   # the CLI refuses: re-ask
+        self.assertIsNone(jd._FAST_ORG_MEMO["env"])
+        jd._fast_org_env()
+        self.assertEqual(self.asked, [None, None])
+
+    def test_a_success_without_the_field_is_not_a_refusal(self):
+        km._set_judge_fast("on")
+        bare = {k: v for k, v in _fixture("claude-p-result-envelope-fast.json").items() if not k.startswith("fast_mode")}
+        out, seen = self._run(bare, auth="key")
+        self.assertEqual(out, "ok")
+        self.assertEqual(jd._fast_refused(), {})
+        self.assertEqual(self._rows(jd.ERRORS), [])
+        rows = self._rows(jd.USAGE)
+        self.assertEqual([(r["fast"], r["fastReason"]) for r in rows], [(None, None)], "the row says the CLI said nothing")
+
+    def test_a_call_that_asked_nothing_records_no_readback(self):
+        # fast off: the standard envelope's "off" is not a refusal of anything
+        out, seen = self._run(_fixture("claude-p-result-envelope-standard.json"), auth="key")
+        self.assertEqual(out, "ok")
+        self.assertEqual(jd._fast_refused(), {})
+        self.assertEqual(self._rows(jd.ERRORS), [])
+
+
+class WiredInline(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(BIN, "romp-kernel")) as f:
+            self.src = f.read()
+
+    def test_the_three_ops_share_one_arm_and_propagate_their_own_field(self):
+        self.assertIn('msg.get("type") in ("setJudgeFast", "setDistillFast", "setIndexFast") and msg.get("enabled") is not None', self.src)
+        self.assertIn('args=({_ffield: _jfv, "gt": _jgt},)', self.src)
+
+    def test_the_cost_rollup_skips_error_rows(self):
+        self.assertIn('if (o.get("t") or 0) < t0 or o.get("err"):', self.src)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -241,7 +241,7 @@ class OneHopNeverALoop(unittest.TestCase):
                      'args=({"commentEffort": str(msg["effort"]), "gt": _jgt},)',
                      'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)',
                      'args=({"tmuxBackend": _tbv, "gt": _jgt},)',   # T288
-                     'args=({"judgeFast": _jfv, "gt": _jgt},)'):    # Fast judging
+                     'args=({_ffield: _jfv, "gt": _jgt},)'):    # Fast judging
             self.assertIn(frag, self.src, frag)
         self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 12,
                                 "every judge-tier fan-out is gated on the pick actually applying")

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -856,6 +856,8 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
             ("setConserve", "enabled", {}, km._conserve_on, warn),
             ("setTmuxBackend", "enabled", {}, lambda: km.jd._state_str("tmux-backend", "off") == "on", warn),   # T288
             ("setJudgeFast", "enabled", {}, lambda: km.jd._state_str("judge-fast", "off") == "on", warn),   # Fast judging
+            ("setDistillFast", "enabled", {}, lambda: km.jd._state_str("distill-fast", "off") == "on", warn),   # T300: a box per tier
+            ("setIndexFast", "enabled", {}, lambda: km.jd._state_str("index-fast", "off") == "on", warn),
             ("setGlobalRetryPaused", "value", {}, km._retry_paused_on, warn),
             ("setSessionFlag", "value", {"id": self.SID, "flag": "hideFromFeed"},
              lambda: km._session_flag(self.SID, "hideFromFeed"), lane),

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -125,7 +125,13 @@ class SettingsSectionsTest(unittest.TestCase):
         self.assertIn("connected machine's kernel", hint, "the copy says the pick follows to the other machines")
         # greyed with the reason while no judge tier is on Opus (the box is inert then: the opt-in rides only Opus calls)
         self.assertIn("function judgeFastGate", h)
-        self.assertIn("var JUDGEFAST_SUB_OFF = \"Fast mode is Opus-only, and no judge tier is on Opus.", h)
+        self.assertIn("var JUDGEFAST_SUB_OFF = \"Fast mode is Opus-only, and this tier is not on Opus.", h)
+        # T300: the same box follows the Distilling and Indexing pickers, each greyed on ITS tier's effective model
+        for sel, tier in (("rs-distillmodel", "distillfast"), ("rs-indexmodel", "indexfast")):
+            row = h[h.index("<select id=%s></select>" % sel):]
+            row = row[:row.index("</div>")]
+            self.assertIn("<label class=rs-fastin id=rs-%s-wrap><input type=checkbox id=rs-%s>Fast mode<span class=rs-mixed hidden></span>" % (tier, tier), row)
+            self.assertIn("<span class=rs-sub id=rs-%s-sub>" % tier, row)
         self.assertIn("#rsettings .rs-fastin.rs-off {", _gear_css_src())
 
     def test_collapse_gaps_is_wired_to_the_shared_collapseGaps_setting(self):

--- a/tests/test_setting_gesture_order.py
+++ b/tests/test_setting_gesture_order.py
@@ -795,7 +795,7 @@ class VersionReportsEveryStoredStamp(_Base):
     def test_a_fresh_install_reports_every_store_at_zero(self):
         gts = km._version_info()["settingsGt"]
         self.assertEqual(set(gts), set(km._GT_STORES), "one key per gt-gated store, no more, no less")
-        self.assertEqual(len(km._GT_STORES), 17, "five toggles/modes + twelve kernel-side stores (judge-concurrency since T277, tmux-backend since T288, judge-fast with Fast judging)")
+        self.assertEqual(len(km._GT_STORES), 19, "five toggles/modes + fourteen kernel-side stores (judge-concurrency since T277, tmux-backend since T288, judge-fast with the judges' fast mode, distill-fast and index-fast with T300's box per tier)")
         self.assertEqual(set(gts.values()), {0}, "nothing applied yet reads 0 — nothing to outrank")
         self.assertEqual(json.loads(json.dumps(gts)), gts, "plain JSON — ints, no paths, nothing to redact")
 
@@ -808,10 +808,12 @@ class VersionReportsEveryStoredStamp(_Base):
         self.assertEqual(km._set_thinking_summaries(True, gt=T_NEW + 8), T_NEW + 8)
         self.assertEqual(km._set_comment_fast("on", gt=T_NEW + 9), T_NEW + 9)
         self.assertEqual(km._set_judge_fast("on", gt=T_NEW + 10), T_NEW + 10)
+        self.assertEqual(km._set_distill_fast("on", gt=T_NEW + 11), T_NEW + 11)
+        self.assertEqual(km._set_index_fast("on", gt=T_NEW + 12), T_NEW + 12)
         gts = km._version_info()["settingsGt"]
         want = {"judge-model": T_NEW, "auto-nudge": T_OLD, "compact-suggest": T_NEW + 5,
                 "file-editing": T_NEW + 6, "update-mode": T_NEW + 7, "thinking-summaries": T_NEW + 8,
-                "comment-fast": T_NEW + 9, "judge-fast": T_NEW + 10}
+                "comment-fast": T_NEW + 9, "judge-fast": T_NEW + 10, "distill-fast": T_NEW + 11, "index-fast": T_NEW + 12}
         for store, gt in want.items():
             self.assertEqual(gts[store], gt, store)
         for store in set(km._GT_STORES) - set(want):
@@ -838,7 +840,8 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setDistillModel", "model": "haiku"},
                  {"type": "setDistillEffort", "effort": "high"}, {"type": "setCommentModel", "model": "haiku"},
                  {"type": "setCommentEffort", "effort": "high"}, {"type": "setCommentFast", "fast": "on"},
-                 {"type": "setTmuxBackend", "enabled": True}, {"type": "setJudgeFast", "enabled": True}]
+                 {"type": "setTmuxBackend", "enabled": True}, {"type": "setJudgeFast", "enabled": True},
+                 {"type": "setDistillFast", "enabled": True}, {"type": "setIndexFast", "enabled": True}]
         older = [{"type": "setAutoNudge", "enabled": True}, {"type": "setCompactSuggest", "enabled": False},
                  {"type": "setFileEditing", "enabled": False}, {"type": "setUpdateMode", "mode": "off"},
                  {"type": "setThinkingSummaries", "enabled": False}, {"type": "setJudgeModel", "model": "opus"},
@@ -847,14 +850,15 @@ class VersionReportsEveryStoredStamp(_Base):
                  {"type": "setDistillModel", "model": "triage"},
                  {"type": "setDistillEffort", "effort": "low"}, {"type": "setCommentModel", "model": "session"},
                  {"type": "setCommentEffort", "effort": "session"}, {"type": "setCommentFast", "fast": "session"},
-                 {"type": "setTmuxBackend", "enabled": False}, {"type": "setJudgeFast", "enabled": False}]
+                 {"type": "setTmuxBackend", "enabled": False}, {"type": "setJudgeFast", "enabled": False},
+                 {"type": "setDistillFast", "enabled": False}, {"type": "setIndexFast", "enabled": False}]
         with contextlib.redirect_stderr(io.StringIO()):
             for n, o in zip(newer, older):
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(n, gt=T_NEW), client)
                 km.Handler._dispatch_ws(types.SimpleNamespace(), dict(o, gt=T_OLD), client)
         named = {m["setting"] for m in sent if m.get("type") == "settingStale"}
         self.assertEqual(named, set(km._version_info()["settingsGt"]), "frames and the report share one vocabulary")
-        self.assertEqual(len(named), 17)   # twelve kernel-side stores since Fast judging
+        self.assertEqual(len(named), 19)   # fourteen kernel-side stores since T300's box per judge tier
 
 
 class ASkewedClockCannotLockTheStore(_Base):

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -83,7 +83,7 @@ const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel"
                                 "setCompactSuggest",
                                 "setCommentModel", "setCommentEffort", "setCommentFast",
                                 "setTmuxBackend",   // T288: the tmux backend's offer, one value across machines
-                                "setJudgeFast"]);   // Fast mode for the judges: their fast-mode opt-in, one value across machines
+                                "setJudgeFast", "setDistillFast", "setIndexFast"]);   // Fast mode per judge tier, one value across machines
 
 // ── what a send to a host whose relay socket is NOT open does, by message class (2026-09-10) ─────────
 // Three classes, decided by an EXPLICIT list — never guessed from the type's spelling at run time:

--- a/ui/webview/gear-judge-fast-browser.test.ts
+++ b/ui/webview/gear-judge-fast-browser.test.ts
@@ -1,0 +1,170 @@
+// The per-tier Fast mode boxes (T300), driven in headless Chromium over the REAL gear module (gear.js) and its
+// stylesheet. gear-judge-fast.test.ts pins the source; a pin cannot see a box that fails to grey, a hint that
+// never changes, or a gate that reads an unfilled select (a painted select reads its first option before /version
+// answers). So the gear is opened against a fake kernel (the /models, /version, /tunnels, /palette routes answered
+// with synthetic payloads), and the DOM is read after each gesture: a fill with triage on Opus, distilling following
+// triage and indexing on Haiku greys only the indexing box, with the flags shown as stored; a Triage pick of Sonnet
+// greys the triage and distilling boxes, keeps them checked, swaps their hints, and posts nothing for them; picking
+// Opus again ungreys them with the hints back; a checked box on a capable model whose last fast ask the CLI declined
+// shows the refusal; ticking a box posts its op; pinning Distilling to Opus keeps its box live under a Sonnet triage.
+// Skips with a stated reason without a playwright browser (CI installs none), the md-sanitize-browser.test.ts
+// pattern. Synthetic values only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const EXT = process.cwd();                                        // npm test runs in vscode-extension
+const requireCjs = createRequire(path.join(EXT, "package.json"));
+const UI = path.resolve(EXT, "..", "ui", "webview");
+const GEAR_CSS = fs.readFileSync(path.join(UI, "gear.css"), "utf8");
+
+const ENTRY = `
+const { initGear } = require("./gear.js");
+(window as any).__posts = [];
+initGear((m: any) => { (window as any).__posts.push(m); });
+`;
+
+function bundle(): string {
+  const esbuild = requireCjs("esbuild");
+  const r = esbuild.buildSync({
+    stdin: { contents: ENTRY, resolveDir: UI, loader: "ts", sourcefile: "gear-judge-fast-entry.ts" },
+    bundle: true, write: false, format: "iife", platform: "browser", target: "es2020",
+    nodePaths: [path.join(EXT, "node_modules")], logLevel: "silent",
+  });
+  return r.outputFiles[0].text;
+}
+
+const PAGE_HTML = `<!DOCTYPE html><html><head><meta charset=utf-8><style>${GEAR_CSS}</style></head><body>
+<script src=/dist/gear.js></script></body></html>`;
+const MODELS = { models: [{ value: "opus", label: "Opus", versions: [] }, { value: "sonnet", label: "Sonnet", versions: [] }, { value: "haiku", label: "Haiku", versions: [] }],
+  efforts: [{ value: "", label: "Default" }, { value: "low", label: "Low" }] };
+// the kernel's raw picks: triage on Opus with its box on, distilling following triage with its box on, indexing on
+// Haiku with its box on too (a kept value on a tier that cannot run fast: greyed, not lost); the CLI declined the
+// distilling tier's last fast ask
+const VERSION = { judgeModel: "opus", judgeEffort: "", indexModel: "haiku", indexEffort: "low", distillModel: "triage", distillEffort: "triage",
+  judgeConcurrency: "", commentModel: "session", commentEffort: "session", commentFast: "session", tmuxBackend: "off",
+  judgeFast: "on", distillFast: "on", indexFast: "on", fastRefused: { distill: { reason: "sdk_opt_in_required", model: "opus", t: 1 } },
+  autoNudge: true, settingsGt: {}, updateMode: "off" };
+
+let pw: any = null;
+try { pw = requireCjs("playwright"); } catch { pw = null; }
+
+type Snap = { disabled: Record<string, boolean>; off: Record<string, boolean>; opacity: Record<string, string>;
+  checked: Record<string, boolean>; hint: Record<string, string> };
+
+async function withGear(t: any, body: (page: any, errors: string[]) => Promise<void>): Promise<void> {
+  if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser leg needs it (CI installs no browsers)"); return; }
+  let browser: any;
+  try { browser = await pw.chromium.launch(); }
+  catch (e) { t.skip("no playwright browser on this machine; the browser leg needs one (CI installs none): " + String((e as Error).message).split("\n")[0]); return; }
+  const errors: string[] = [];
+  try {
+    const js = bundle();
+    const page = await browser.newPage({ viewport: { width: 1000, height: 900 } });
+    page.on("pageerror", (e: Error) => { errors.push(e.message); });
+    await page.route("**/*", (route: any) => {
+      const u = new URL(route.request().url());
+      const json = (o: unknown) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(o) });
+      if (u.hostname !== "romp.test") return route.fulfill({ status: 404, body: "" });
+      if (u.pathname === "/gear") return route.fulfill({ status: 200, contentType: "text/html; charset=utf-8", body: PAGE_HTML });
+      if (u.pathname === "/dist/gear.js") return route.fulfill({ status: 200, contentType: "application/javascript", body: js });
+      if (u.pathname === "/models") return json(MODELS);
+      if (u.pathname === "/version") return json(VERSION);
+      if (u.pathname === "/tunnels") return json({ tunnels: [] });
+      return json({});   // /palette, /analytics and the rest: empty answers, nothing under test
+    });
+    await page.goto("http://romp.test/gear");
+    await page.waitForFunction(() => Array.isArray((window as any).__posts) && !!document.getElementById("rs-judgemodel"), null, { timeout: 10000 });
+    await page.evaluate(() => { window.postMessage({ romp: "openSettings" }, "*"); });
+    // the fill has run once a box holds the kernel's flag: only fill() writes it, and the gate runs in the same
+    // callback right after (the triage select's value is no signal: a painted select reads its first option,
+    // "opus" here, before /version has answered)
+    await page.waitForFunction(() => (document.getElementById("rs-indexfast") as HTMLInputElement).checked === true, null, { timeout: 10000 });
+    await body(page, errors);
+  } finally {
+    await browser.close();
+  }
+}
+
+const snap = (page: any): Promise<Snap> => page.evaluate(() => {
+  const disabled: Record<string, boolean> = {}, off: Record<string, boolean> = {}, opacity: Record<string, string> = {};
+  const checked: Record<string, boolean> = {}, hint: Record<string, string> = {};
+  for (const tier of ["judgefast", "distillfast", "indexfast"]) {
+    const box = document.getElementById("rs-" + tier) as HTMLInputElement;
+    const wrap = document.getElementById("rs-" + tier + "-wrap") as HTMLElement;
+    const sub = document.getElementById("rs-" + tier + "-sub") as HTMLElement;
+    disabled[tier] = box.disabled; off[tier] = wrap.classList.contains("rs-off"); opacity[tier] = getComputedStyle(wrap).opacity;
+    checked[tier] = box.checked; hint[tier] = sub.textContent || "";
+  }
+  return { disabled, off, opacity, checked, hint };
+});
+const posts = (page: any, type: string): Promise<any[]> => page.evaluate((ty: string) => (window as any).__posts.filter((m: any) => m && m.type === ty), type);
+// the judge selects are display:none behind versionMenu's button; a pick is what the user does: open the menu
+// after the select, click the family row (a family with one version or none commits on the row itself)
+async function pickModel(page: any, selId: string, label: string): Promise<void> {
+  await page.click(`#${selId} + button.rs-vermenu-btn`);
+  // the menu is a body-level div the facade positions (its inline style re-serializes, so no attribute match);
+  // its rows are the focusable direct children, labelled by family
+  await page.locator('body > div > div[tabindex="0"]', { hasText: label }).first().click();
+  await page.waitForFunction(([id, want]: [string, string]) => {
+    const sel = document.getElementById(id) as HTMLSelectElement;
+    return sel && Array.from(sel.options).some((o) => o.textContent === want && o.value === sel.value);
+  }, [selId, label] as [string, string], { timeout: 5000 });
+}
+
+test("each tier's box greys on its own effective model, keeps its value, says why, and posts only its own clicks", { timeout: 90000 }, async (t) => {
+  await withGear(t, async (page, errors) => {
+    // 1. filled: triage Opus (live), distilling follows triage (live, but the CLI declined its last ask), indexing Haiku (greyed, value kept)
+    let s = await snap(page);
+    assert.deepEqual(s.disabled, { judgefast: false, distillfast: false, indexfast: true }, "greyed for the Haiku tier only");
+    assert.deepEqual(s.off, { judgefast: false, distillfast: false, indexfast: true });
+    assert.equal(s.opacity.indexfast, "0.4", "the greyed look renders"); assert.equal(s.opacity.judgefast, "1");
+    assert.deepEqual(s.checked, { judgefast: true, distillfast: true, indexfast: true }, "the boxes reflect the kernel's raw flags, greyed or not");
+    assert.match(s.hint.judgefast, /^This tier's judge calls run in Claude Code's fast mode/, "a live box: the description");
+    assert.match(s.hint.distillfast, /^Fast mode was declined by Claude Code for the last distilling call \(sdk_opt_in_required\)/, "a declined ask: the CLI's reason");
+    assert.match(s.hint.indexfast, /^Fast mode is Opus-only, and this tier is not on Opus\./, "a greyed box: why");
+    for (const ty of ["setJudgeFast", "setDistillFast", "setIndexFast"]) assert.deepEqual(await posts(page, ty), [], `${ty}: a fill posts nothing`);
+
+    // 2. the user picks Sonnet for triage: the model post, both dependent boxes grey and KEEP their value, hints swap, no box post
+    await pickModel(page, "rs-judgemodel", "Sonnet");
+    s = await snap(page);
+    assert.deepEqual(s.disabled, { judgefast: true, distillfast: true, indexfast: true }, "no tier can run fast now");
+    assert.deepEqual(s.checked, { judgefast: true, distillfast: true, indexfast: true }, "the values are kept: nothing was unchecked");
+    for (const tier of ["judgefast", "distillfast"]) assert.match(s.hint[tier], /^Fast mode is Opus-only, and this tier is not on Opus\./, `${tier}: greyed, says why`);
+    const model = await posts(page, "setJudgeModel");
+    assert.equal(model.length, 1); assert.equal(model[0].model, "sonnet"); assert.equal(typeof model[0].gt, "number");
+    for (const ty of ["setJudgeFast", "setDistillFast", "setIndexFast"]) assert.deepEqual(await posts(page, ty), [], `${ty}: a model pick posts nothing for the boxes`);
+
+    // 3. Opus again: live again, still checked, the hints back (the declined one included: the record stands until the kernel clears it)
+    await pickModel(page, "rs-judgemodel", "Opus");
+    s = await snap(page);
+    assert.deepEqual(s.disabled, { judgefast: false, distillfast: false, indexfast: true });
+    assert.deepEqual(s.checked, { judgefast: true, distillfast: true, indexfast: true });
+    assert.match(s.hint.judgefast, /^This tier's judge calls/); assert.match(s.hint.distillfast, /^Fast mode was declined/);
+
+    // 4. clicking the triage box posts its own stamped op, and only it
+    await page.uncheck("#rs-judgefast");
+    const jOff = await posts(page, "setJudgeFast");
+    assert.deepEqual(jOff.map((m: any) => m.enabled), [false]); assert.equal(typeof jOff[0].gt, "number");
+    assert.deepEqual(await posts(page, "setDistillFast"), []);
+    // ...and the hint follows the box: unticking the distilling box (a standing refusal) drops the refusal wording for a
+    // tier that no longer asks; ticking it again brings it back (the record stands until the kernel clears it)
+    await page.uncheck("#rs-distillfast");
+    s = await snap(page);
+    assert.match(s.hint.distillfast, /^This tier's judge calls/, "unticked: the plain description");
+    await page.check("#rs-distillfast");
+    s = await snap(page);
+    assert.match(s.hint.distillfast, /^Fast mode was declined/, "ticked again: the refusal is said again");
+    assert.deepEqual((await posts(page, "setDistillFast")).map((m: any) => m.enabled), [false, true]);
+
+    // 5. distilling pinned to Opus stays live under a Sonnet triage; a greyed box refuses the click (disabled)
+    await pickModel(page, "rs-distillmodel", "Opus");
+    await pickModel(page, "rs-judgemodel", "Sonnet");
+    s = await snap(page);
+    assert.deepEqual(s.disabled, { judgefast: true, distillfast: false, indexfast: true }, "a pinned Opus distilling tier stays fast-capable");
+    assert.equal(await page.evaluate(() => (document.getElementById("rs-indexfast") as HTMLInputElement).disabled), true);
+    assert.deepEqual(errors, [], "no page errors");
+  });
+});

--- a/ui/webview/gear-judge-fast.test.ts
+++ b/ui/webview/gear-judge-fast.test.ts
@@ -1,0 +1,75 @@
+// Fast mode per judge tier (T300, the user 2026-09-10), the add-on over the box the user's session put on the
+// Triage model row: the same compact box follows the Distilling and Indexing pickers, each tier greys its own
+// box with the hint saying why when THAT tier's effective model cannot run fast (Follow triage resolves to the
+// triage pick), the value is kept, and each box posts its own stamped op under its own store. These pins hold
+// the gear's side; tests/test_judge_fast_tiers.py holds the kernel's; gear-judge-fast-browser.test.ts drives
+// the real gear in Chromium.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const read = (...p: string[]) => fs.readFileSync(path.join(ROOT, ...p), "utf8");
+const GEAR = read("ui", "webview", "gear.js");
+const FED = read("ui", "webview", "federation.ts");
+
+test("each tier's model row carries the same compact Fast mode box after its picker", () => {
+  for (const [sel, tier] of [["rs-judgemodel", "judgefast"], ["rs-distillmodel", "distillfast"], ["rs-indexmodel", "indexfast"]]) {
+    const row = GEAR.slice(GEAR.indexOf(`<select id=${sel}></select>`));
+    const end = row.indexOf("</div>");
+    const seg = row.slice(0, end);
+    assert.ok(seg.includes(`<label class=rs-fastin id=rs-${tier}-wrap><input type=checkbox id=rs-${tier}>Fast mode<span class=rs-mixed hidden></span>`),
+      `${tier}: the box follows the picker inside the same row, with its own mixed mark`);
+    assert.ok(seg.includes(`<span class=rs-sub id=rs-${tier}-sub>`), `${tier}: a row hint the gate swaps`);
+  }
+  assert.ok(!GEAR.includes("Fast judging"), "the old label stays gone");
+});
+
+test("the gate greys each tier's box on ITS effective model and keeps the value", () => {
+  assert.ok(GEAR.includes("function judgeFastTiers"), "one table of tiers");
+  assert.ok(GEAR.includes("function judgeFastGate"), "the gate");
+  assert.ok(GEAR.includes("t.box.disabled = !can;"), "greyed, not hidden, not unchecked");
+  assert.ok(GEAR.includes("wrap.classList.toggle('rs-off', !can);"), "the greyed look per box");
+  assert.ok(GEAR.includes("v === 'triage' ? (jm ? (jm.value || '') : '') : v"), "Follow triage resolves to the triage pick");
+  assert.ok(GEAR.includes("can = !v || v.toLowerCase().indexOf('opus') !== -1"), "the Opus-only rule; an unloaded value is unknown, not a refusal");
+  assert.ok(!GEAR.includes("t.box.checked = false"), "no gesture unchecks a box: the setting is the user's to keep");
+  assert.match(GEAR, /var JUDGEFAST_SUB_OFF = "Fast mode is Opus-only, and this tier is not on Opus\./, "the hint says why, per tier");
+  assert.ok(GEAR.includes("sub.textContent = !can ? JUDGEFAST_SUB_OFF : (r ? judgeFastSubRefused(t.word, r) : JUDGEFAST_SUB)"),
+    "the hint: the greyed reason, else the CLI's refusal of this tier's last fast ask, else the description");
+  for (const store of ["judge-model", "index-model", "distill-model"])
+    assert.match(GEAR, new RegExp("gclock\\.stamp\\('" + store + "'\\) \\}\\); judgeFastGate\\(\\);"), `a ${store} pick re-runs the gate`);
+  assert.match(GEAR, /cmtFastGate\(false\);\n\s*judgeFastGate\(\);/, "fill() re-checks after the tiers and the flags are set");
+});
+
+test("the CLI's refusal reaches the box's hint from /version", () => {
+  assert.ok(GEAR.includes("fastRefused = (v.fastRefused && typeof v.fastRefused === 'object') ? v.fastRefused : {};"), "fill() reads the record");
+  assert.ok(GEAR.includes("var r = can && t.box.checked ? fastRefused[t.tier] : null;"), "only a checked box on a capable model can have been refused");
+  assert.ok(GEAR.includes("function judgeFastSubRefused"), "the refusal wording");
+  for (const [el, ty, clock] of [["jf", "setJudgeFast", "judge-fast"], ["df", "setDistillFast", "distill-fast"], ["xf", "setIndexFast", "index-fast"]])
+    assert.ok(GEAR.includes(`post({ type: '${ty}', enabled: ${el}.checked, gt: gclock.stamp('${clock}') }); judgeFastGate();`),
+      `${ty}: the box's own toggle re-runs the gate, so a standing refusal's hint leaves with the tick and returns with it`);
+  assert.match(GEAR, /tier: 'triage'[\s\S]*?tier: 'distill'[\s\S]*?tier: 'index'/, "the record's keys are the judge tiers' names");
+});
+
+test("each box posts its own stamped op under its own store, and fills from the raw flag", () => {
+  for (const [type, clock, el] of [["setJudgeFast", "judge-fast", "jf"], ["setDistillFast", "distill-fast", "df"], ["setIndexFast", "index-fast", "xf"]]) {
+    assert.ok(GEAR.includes(`post({ type: '${type}', enabled: ${el}.checked, gt: gclock.stamp('${clock}') })`), `${type}: the boolean, stamped in the literal`);
+  }
+  for (const [field, el] of [["judgeFast", "jf"], ["distillFast", "df"], ["indexFast", "xf"]])
+    assert.ok(GEAR.includes(`${el}.checked = v.${field} === 'on'`), `fill() reads the RAW ${field} flag`);
+  const typeSrc = GEAR.match(/var STALE_TYPE = \{([\s\S]*?)\};/);
+  assert.ok(typeSrc, "STALE_TYPE located");
+  for (const [clock, type] of [["judge-fast", "setJudgeFast"], ["distill-fast", "setDistillFast"], ["index-fast", "setIndexFast"]])
+    assert.ok(typeSrc![1].includes(`'${clock}': '${type}'`), `the stale toast knows ${clock}`);
+  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'judge-fast': 'Fast mode \(triage judges\)', 'distill-fast': 'Fast mode \(distilling judges\)', 'index-fast': 'Fast mode \(indexing judges\)'/,
+    "a stood-down gesture toasts under its tier's name");
+  assert.ok(GEAR.includes("['judgeFast', jf], ['distillFast', df], ['indexFast', xf]"), "the mixed-mark reconcile covers the three boxes");
+});
+
+test("the three ops are kernel settings federation broadcasts to every host", () => {
+  const setSrc = FED.match(/const KERNEL_SETTING = new Set\(\[([\s\S]*?)\]\)/);
+  assert.ok(setSrc, "federation's KERNEL_SETTING set must exist");
+  for (const op of ["setJudgeFast", "setDistillFast", "setIndexFast"])
+    assert.ok(setSrc![1].includes(`"${op}"`), `${op} must be a KERNEL_SETTING (one pick sets every machine)`);
+});

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -46,9 +46,13 @@ var AUTONUDGE_SUB = "When a session goes idle but its goal still shows working (
   + "you), automatically nudge it once for a status update. Applies to every connected machine's kernel.";
 // Fast mode's one-line hint, in a var because judgeFastGate() swaps it for the greyed-out reason when no
 // judge tier is on Opus (the opt-in rides only a call whose model is Opus, so the box is inert then).
-var JUDGEFAST_SUB = "Judge calls on Opus run in Claude Code's fast mode (an Opus-only research preview, billed at a premium). "
-  + "Off by default. Follows to every connected machine's kernel.";
-var JUDGEFAST_SUB_OFF = "Fast mode is Opus-only, and no judge tier is on Opus. Pick Opus for triage, distilling or indexing to use it.";
+var JUDGEFAST_SUB = "This tier's judge calls run in Claude Code's fast mode (an Opus-only research preview, billed at a premium, "
+  + "about twice the standard Opus rate). Off by default. Follows to every connected machine's kernel.";
+var JUDGEFAST_SUB_OFF = "Fast mode is Opus-only, and this tier is not on Opus. Pick Opus for it to use fast mode; the setting is kept.";
+function judgeFastSubRefused(word, r) {
+  return "Fast mode was declined by Claude Code for the last " + word + " call (" + ((r && r.reason) || "no reason given")
+    + "); the judges run at normal speed. The setting is kept.";
+}
 
 // The modal markup — ported verbatim from the kernel's _gear_html; the model/
 // effort selects start empty and are filled from /models (see fill()).
@@ -181,9 +185,13 @@ var GEAR_HTML =
   "<label class=rs-fastin id=rs-judgefast-wrap><input type=checkbox id=rs-judgefast>Fast mode<span class=rs-mixed hidden></span>" +
   "<span class=rs-sub id=rs-judgefast-sub>" + JUDGEFAST_SUB + "</span></label></div>" +
   "<div class='rs-row rs-jrow'><b>Triage effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the triage judges. Default = no effort flag (the judges' standard behavior). Not every model accepts every level. Follows to every connected machine's kernel.</span><select id=rs-judgeeffort></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Distilling model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model for the judges that write the prose you read on cards — distiller, briefer, staller. Follow triage (the default) keeps them on the triage pick; pinning a model here lets the copy you read run richer than the placement judges. Follows to every connected machine's kernel.</span><select id=rs-distillmodel></select>" +
+  "<label class=rs-fastin id=rs-distillfast-wrap><input type=checkbox id=rs-distillfast>Fast mode<span class=rs-mixed hidden></span>" +
+  "<span class=rs-sub id=rs-distillfast-sub>" + JUDGEFAST_SUB + "</span></label></div>" +
   "<div class='rs-row rs-jrow'><b>Distilling effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the distilling judges. Follow triage (the default) rides the triage effort; Default pins no effort flag. Follows to every connected machine's kernel.</span><select id=rs-distilleffort></select></div>" +
-  "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select></div>" +
+  "<div class='rs-row rs-jrow'><b>Indexing model <span class=rs-mixed hidden></span></b><span class=rs-sub>The model the indexing judges use — captioner + archiver (high-volume, low-stakes summarization). Haiku by default for cost. Follows to every connected machine's kernel.</span><select id=rs-indexmodel></select>" +
+  "<label class=rs-fastin id=rs-indexfast-wrap><input type=checkbox id=rs-indexfast>Fast mode<span class=rs-mixed hidden></span>" +
+  "<span class=rs-sub id=rs-indexfast-sub>" + JUDGEFAST_SUB + "</span></label></div>" +
   "<div class='rs-row rs-jrow'><b>Indexing effort <span class=rs-mixed hidden></span></b><span class=rs-sub>Thinking effort for the indexing judges. Default keeps this high-volume work cheap: effort low on models with adaptive thinking (Fable, Opus 4.6 and later, Sonnet 4.6 and later); Haiku, Sonnet 4.5 and Opus 4.5 have none, so they run with thinking off and no flag. Follows to every connected machine's kernel.</span><select id=rs-indexeffort></select></div>" +
   "<div class='rs-row rs-jrow'><b>Judge concurrency <span class=rs-mixed hidden></span></b><span class=rs-sub>How many judge calls run at once, across every tier. Default is 6, or the ROMP_JUDGE_CONCURRENCY the kernel's service environment sets. Applies on the judges' next pass; no restart. Follows to every connected machine's kernel.</span><select id=rs-judgeconc></select></div>" +
   '<div class=rs-sec>Updates & debug</div>' +
@@ -269,7 +277,7 @@ function initGear(post) {
     dm = document.getElementById('rs-distillmodel'), de = document.getElementById('rs-distilleffort'),
     cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
     cmf = document.getElementById('rs-cmtfast'),
-    jf = document.getElementById('rs-judgefast'),
+    jf = document.getElementById('rs-judgefast'), df = document.getElementById('rs-distillfast'), xf = document.getElementById('rs-indexfast'),   // T300: one per tier
     tb = document.getElementById('rs-tmuxbackend'), bkn = document.getElementById('rs-backend-note'),
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
@@ -772,8 +780,11 @@ function initGear(post) {
   // the tmux backend's offer (T288): a kernel setting like the judge knobs (stamped, propagated); the Default
   // backend list repaints at once so the pick and the offer never disagree in the same modal
   if (tb) tb.addEventListener('change', function () { post({ type: 'setTmuxBackend', enabled: tb.checked, gt: gclock.stamp('tmux-backend') }); paintBackendOffer(tb.checked); });
-  // Fast mode for the judges: a kernel setting like the judge knobs (stamped, propagated); the judges read it per call
-  if (jf) jf.addEventListener('change', function () { post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') }); });
+  // Fast mode for the judges, one box per tier (T300, the user 2026-09-10): a kernel setting per tier like the
+  // judge knobs (stamped, propagated); the judges read each tier's flag per call
+  if (jf) jf.addEventListener('change', function () { post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') }); judgeFastGate(); });   // the hint follows the box (a refusal reads only on a checked box)
+  if (df) df.addEventListener('change', function () { post({ type: 'setDistillFast', enabled: df.checked, gt: gclock.stamp('distill-fast') }); judgeFastGate(); });   // the hint follows the box (a refusal reads only on a checked box)
+  if (xf) xf.addEventListener('change', function () { post({ type: 'setIndexFast', enabled: xf.checked, gt: gclock.stamp('index-fast') }); judgeFastGate(); });   // the hint follows the box (a refusal reads only on a checked box)
   // Fast mode is an Opus-only research preview (render.ts fastAvailable and cmtFastGate above, the same rule),
   // and the judges' opt-in rides only a call whose model is Opus: with no tier on Opus the box is inert, so it
   // greys and its hint says why (a review finding on the setting's first cut: with the default tiers the box
@@ -781,16 +792,26 @@ function initGear(post) {
   // nothing fires or toasts while it is inert, and a tier pinned to Opus later brings it back without a
   // second click. Distilling on Follow triage resolves to the triage pick; a tier whose value has not
   // loaded is unknown, never a refusal (the benefit of the doubt fastAvailable gives an unknown model).
+  var fastRefused = {};   // /version's record: judge tier ("triage" | "distill" | "index") -> { reason, model, t }
+  function judgeFastTiers() {
+    return [
+      { box: jf, wrap: 'rs-judgefast-wrap', sub: 'rs-judgefast-sub', tier: 'triage', word: 'triage',
+        model: function () { return jm ? (jm.value || '') : ''; } },
+      { box: df, wrap: 'rs-distillfast-wrap', sub: 'rs-distillfast-sub', tier: 'distill', word: 'distilling',
+        model: function () { var v = dm ? (dm.value || '') : ''; return v === 'triage' ? (jm ? (jm.value || '') : '') : v; } },   // Follow triage resolves
+      { box: xf, wrap: 'rs-indexfast-wrap', sub: 'rs-indexfast-sub', tier: 'index', word: 'indexing',
+        model: function () { return im ? (im.value || '') : ''; } }];
+  }
   function judgeFastGate() {
-    if (!jf) return;
-    var wrap = document.getElementById('rs-judgefast-wrap'), sub = document.getElementById('rs-judgefast-sub');
-    var tri = jm ? (jm.value || '') : '', dis = dm ? (dm.value || '') : '', idx = im ? (im.value || '') : '';
-    if (dis === 'triage') dis = tri;
-    var picks = [tri, dis, idx].filter(function (v) { return !!v; });
-    var can = !picks.length || picks.some(function (v) { return v.toLowerCase().indexOf('opus') !== -1; });
-    jf.disabled = !can;
-    if (wrap) wrap.classList.toggle('rs-off', !can);
-    if (sub) sub.textContent = can ? JUDGEFAST_SUB : JUDGEFAST_SUB_OFF;
+    judgeFastTiers().forEach(function (t) {
+      if (!t.box) return;
+      var wrap = document.getElementById(t.wrap), sub = document.getElementById(t.sub);
+      var v = t.model(), can = !v || v.toLowerCase().indexOf('opus') !== -1;   // unknown (not loaded) = the benefit of the doubt
+      t.box.disabled = !can;
+      if (wrap) wrap.classList.toggle('rs-off', !can);
+      var r = can && t.box.checked ? fastRefused[t.tier] : null;   // the CLI declined this tier's last fast ask: say why
+      if (sub) sub.textContent = !can ? JUDGEFAST_SUB_OFF : (r ? judgeFastSubRefused(t.word, r) : JUDGEFAST_SUB);
+    });
   }
   // "Claude Code (tmux)" is in the Default backend list only while the setting is on; a saved default of tmux
   // while it is off is set aside (the select shows Claude Code and the note says so), never erased: it returns
@@ -869,7 +890,8 @@ function initGear(post) {
     'index-model': 'Indexing model', 'index-effort': 'Indexing effort', 'judge-concurrency': 'Judge concurrency',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
-    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend', 'judge-fast': 'Fast mode (judges)',
+    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend',
+    'judge-fast': 'Fast mode (triage judges)', 'distill-fast': 'Fast mode (distilling judges)', 'index-fast': 'Fast mode (indexing judges)',
     'thinking-summaries': 'Thinking summaries' };
   // store name → the message type that sets it: the whitelist for the toast's Apply anyway (a frame
   // may re-issue the one setting it names, nothing else) and the completeness pin's map
@@ -880,7 +902,7 @@ function initGear(post) {
     'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort', 'judge-concurrency': 'setJudgeConcurrency',
     'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
     'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast',
-    'tmux-backend': 'setTmuxBackend', 'judge-fast': 'setJudgeFast' };
+    'tmux-backend': 'setTmuxBackend', 'judge-fast': 'setJudgeFast', 'distill-fast': 'setDistillFast', 'index-fast': 'setIndexFast' };
   // store name → the words its select shows for the sentinel options whose value is not the word. The
   // effort selects' Default is the EMPTY value (no effort flag), which read as no value at all, so a
   // refused Default pick drew the value-less copy and a plain Apply anyway — in the frozen-tab case, the
@@ -1155,7 +1177,7 @@ function initGear(post) {
      ['indexEffort', ie], ['judgeConcurrency', jc], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
      ['compactSuggest', csg],
      ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf], ['tmuxBackend', tb],
-     ['judgeFast', jf]].forEach(function (pair) {
+     ['judgeFast', jf], ['distillFast', df], ['indexFast', xf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
       // the mark nearest the control: a checkbox's own <label> (the fast-mode box shares the Triage model
@@ -1204,8 +1226,11 @@ function initGear(post) {
     if (cmf && typeof v.commentFast === 'string') cmf.checked = v.commentFast === 'on';
     if (tb && typeof v.tmuxBackend === 'string') { tb.checked = v.tmuxBackend === 'on'; paintBackendOffer(tb.checked); }   // T288: the offer, then the list follows it
     if (jf && typeof v.judgeFast === 'string') jf.checked = v.judgeFast === 'on';   // RAW on/off: the kernel's persisted answer
+    if (df && typeof v.distillFast === 'string') df.checked = v.distillFast === 'on';
+    if (xf && typeof v.indexFast === 'string') xf.checked = v.indexFast === 'on';
+    fastRefused = (v.fastRefused && typeof v.fastRefused === 'object') ? v.fastRefused : {};
     cmtFastGate(false);
-    judgeFastGate();   // the tiers are set above; the box follows them
+    judgeFastGate();   // the tiers are set above; the boxes follow them
     if (dd && typeof v.defaultDir === 'string') dd.value = v.defaultDir;   // the kernel's persisted default is authoritative
     // Browse… draws on the KERNEL's screen, and a kernel with no desktop has none — the click used to
     // vanish into a macOS-only dialog. Drop the button rather than offer one that cannot work; the

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -46,7 +46,7 @@ test("the gear posts kernel ops through ONE shared channel (never re-acquires th
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort", "setJudgeConcurrency",
     "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast", "setTmuxBackend",
-    "setJudgeFast", "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
+    "setJudgeFast", "setDistillFast", "setIndexFast", "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });
 
@@ -55,8 +55,8 @@ test("Fast mode for the judges is a kernel setting: a stamped emitter under its 
     "the click posts the kernel's designed message with the gesture stamp minted in the literal");
   assert.ok(GEAR.includes("jf.checked = v.judgeFast === 'on'"),
     "the checkbox shows the kernel's persisted answer (RAW on/off), never a page default");
-  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'judge-fast': 'Fast mode \(judges\)'/,
-    "a stood-down gesture toasts under the control's own name");
+  assert.match(GEAR, /STALE_LABELS = \{[\s\S]*?'judge-fast': 'Fast mode \(triage judges\)'/,
+    "a stood-down gesture toasts under the control's own name (T300: one box per tier, named by its tier)");
   assert.match(GEAR, /STALE_TYPE = \{[\s\S]*?'judge-fast': 'setJudgeFast'/,
     "the store maps to its message type (the toast's Apply anyway whitelist)");
   assert.match(GEAR, /\['judgeFast', jf\]/, "the row carries the mixed mark where machines disagree");
@@ -79,9 +79,10 @@ test("the judges' fast-mode box sits on the Triage model row in the chat's words
   // the gate, mirroring cmtFastGate: the opt-in rides only a call whose model is Opus, so with no tier on
   // Opus the box is inert; the gear greys it and the hint says why, instead of a dead control
   assert.ok(GEAR.includes("function judgeFastGate"), "the availability gate must exist");
-  assert.ok(GEAR.includes("jf.disabled = !can"), "the box disables when no tier is on Opus");
-  assert.ok(GEAR.includes("sub.textContent = can ? JUDGEFAST_SUB : JUDGEFAST_SUB_OFF"), "the hint says why while greyed");
-  assert.ok(GEAR.includes("if (dis === 'triage') dis = tri;"), "distilling on Follow triage counts as the triage pick");
+  // T300: one box per tier, each greyed on ITS tier's effective model (gear-judge-fast.test.ts holds the rest)
+  assert.ok(GEAR.includes("t.box.disabled = !can;"), "a box disables when its tier is not on Opus");
+  assert.ok(GEAR.includes("sub.textContent = !can ? JUDGEFAST_SUB_OFF : (r ? judgeFastSubRefused(t.word, r) : JUDGEFAST_SUB)"), "the hint says why while greyed");
+  assert.ok(GEAR.includes("v === 'triage' ? (jm ? (jm.value || '') : '') : v"), "distilling on Follow triage counts as the triage pick");
   for (const store of ["judge-model", "index-model", "distill-model"])
     assert.match(GEAR, new RegExp("gclock\\.stamp\\('" + store + "'\\) \\}\\); judgeFastGate\\(\\);"), `a ${store} pick re-runs the gate`);
   assert.match(GEAR, /cmtFastGate\(false\);\n\s*judgeFastGate\(\);/, "fill() re-checks availability after the tiers are set");

--- a/ui/webview/multi-kernel-merge.test.ts
+++ b/ui/webview/multi-kernel-merge.test.ts
@@ -509,6 +509,8 @@ test("routeOutbound: the gear's kernel-side settings reach EVERY attached kernel
                      { type: "setCommentEffort", effort: "high" },
                      { type: "setCommentFast", fast: "on" },
                      { type: "setJudgeFast", enabled: true },
+                     { type: "setDistillFast", enabled: true },
+                     { type: "setIndexFast", enabled: true },
                      { type: "setFileEditing", enabled: true },
                      { type: "setCompactSuggest", enabled: true }]) {   // T248: no longer per-install
     const routes = routeOutbound(msg, new Set(["TESTHOST", "gpu1"]));


### PR DESCRIPTION
Part of the fast judging work, follows PR 1292 and extends PR 1324: one Fast mode box per judge tier, greyed with the reason where the tier cannot run fast, plus the four review concerns on the first cut, each with a test.

## What it does

The Fast mode checkbox that PR 1324 put after the Triage model picker now also follows the Distilling and Indexing pickers, in the same compact shape. Each box is its own kernel setting, read by the judges per call for the tier the call runs in. A box greys with a hint saying why when THAT tier's effective model cannot run fast (a Distilling pick of Follow triage takes the triage model); the value is kept, not cleared, so pinning Opus for the tier later brings the box back live with no second click. The gear posts nothing on a model pick for the boxes, so no second writer races the kernel and no stale toast fires.

## Storage: one flag per tier, and why

`STATE/judge-fast` stays the triage tier's flag; `distill-fast` and `index-fast` join it through the same setter family (validated, gesture-stamped, in `_GT_STORES`, propagated to every linked kernel, reported raw in `/version` at the top level and in the settings dict, applied and acked by `/judge-settings`). The ops `setDistillFast` and `setIndexFast` take the same boolean `enabled` as `setJudgeFast`. The alternative, one setting rendered per tier where it applies, would tick three tiers at once from one box and grey where it cannot act, which is the surprise to avoid: the user's ask was a box beside each tier's model that means that tier.

**One-time carry-over.** On the first kernel start on this code (the one that finds neither new file), both files are written: when `judge-fast` is on, each new tier gets on where its effective model can run fast and off where it cannot, so an install that had the single box on keeps the behaviour it had; otherwise both get off. An explicit marker (`STATE/judge-fast-tiers.migrated`), written last, is the only done signal: a boot that finds a file already written leaves it alone and completes the rest, so a write that failed half-way completes on the next boot, and a Triage box ticked after the marker never spreads to the other tiers at a restart. The writes carry stamp 1, older than any gesture, so a pick made on any machine outranks them.

## The four concerns from the first cut

- **A key-billed judge's fast permission followed the login account.** A key-billed call that asks for fast now carries the sessions' own switch (`sdk_backend.helper_fast_org_env`, the same rule a key-billed session gets), memoised per kernel process since a judge call is not a connect and the helper may cost a prompt (one ask per pool under a lock), and asked again after any refusal the CLI reports. Login-billed calls never carry it, and `_judge_env` strips the skip variable from the inherited environment so a session's skip never reaches a judge child; the operator's kill switch (`CLAUDE_CODE_DISABLE_FAST_MODE` in the service environment) still does, as it did before. Test: `RunEndToEnd.test_a_key_billed_fast_call_carries_the_org_check_env_once_and_a_login_call_never`.
- **A refused pick stayed armed silently; an error envelope logged no usage row.** `_note_fast_readback` records the CLI's refusal per tier in `STATE/fast-refused.json`, lifted by `/version` as `fastRefused` so the tier's box hint names the reason, and writes one `fast-refused` row in `judge-errors.jsonl` per change of reason, never per call; the next fast call that engages clears the record. An error envelope that carries `fast_mode_state` now writes a usage row with the readback, zero cost and `err: true`, which the cost rollup skips. Tests: `Readback.test_a_refusal_is_recorded_once_per_reason_and_cleared_by_an_on`, `RunEndToEnd.test_an_error_envelope_keeps_its_readback_as_a_zero_cost_row_and_the_refusal_is_recorded`.
- **The readback's field name was unverified.** Two real calls on 2026-09-10 (claude 2.1.257, one-word prompt on opus, with and without the opt-in) show the RESULT envelope carrying `fast_mode_state` (`on`, or `off` with `fast_mode_disabled_reason` `sdk_opt_in_required`) and `usage.speed` (`fast` or `standard`). Two fixtures carry that exact shape with synthetic values, and the usage row now keeps the reason as `fastReason`. Test: `Readback.test_the_fixtures_carry_the_fields_the_readback_reads`.
- **The cost view might under-report a fast row by half.** Measured: the identical prompt cost 0.270 fast and 0.135 standard, so the CLI's own `total_cost_usd` already carries the fast premium, and the judging band sums that figure per row with no price table. No pricing change; the band is pinned to add the fixture's fast cost as given and to skip error rows. Test: `Readback.test_the_cost_rollup_adds_the_cli_s_own_figure_which_is_fast_priced`.

## Review

An adversarial review over the diff (four lenses, each finding verified by a skeptic) found six things, all fixed here with tests: the carry-over marker above (it was the carried value, so a fresh install's single Triage tick spread at the next restart); the refusal record's read-modify-write now holds a lock and uses per-writer temp names (the index and triage pools refuse on parallel threads); `cooldown` and an envelope without the field are not refusals (the sessions' rule for the same field; on/cooldown alternation at caption volume no longer writes a row per flip); the org-check memo fills under a lock so a pool's first fast pass runs the helper once, keeps an empty answer so a dead network does not cost a probe per call, and is dropped by any refusal, not only an organisation-shaped one; the box's own toggle re-runs the gate so a standing refusal's hint leaves with the tick.

## Gear

`judgeFastTiers` and `judgeFastGate` grey each box on its own tier (the `cmtFastGate` and `render.ts fastAvailable` rule), swap its hint between the description, the greyed reason and the CLI's refusal, and run on every model pick and on fill. Three literal stamped emitters, `STALE_LABELS` and `STALE_TYPE` entries named by tier, the mixed marks per box, `KERNEL_SETTING` membership. A Chromium-driven test (`gear-judge-fast-browser.test.ts`) opens the real gear against a fake kernel and drives the version-menu facade like a user: it checks the greyed states, the kept values, the hint texts and the posts after each pick.

## Tests and docs

- New: `tests/test_judge_fast_tiers.py`, `ui/webview/gear-judge-fast.test.ts`, `ui/webview/gear-judge-fast-browser.test.ts`, two fixtures under `tests/fixtures/`.
- Updated: `test_kernel_settings_sections`, `gear.test.ts`, `test_setting_gesture_order` (nineteen stamp stores), `test_kernel_session_flags`, `multi-kernel-merge.test.ts`, `test_judge_settings_sync`.
- Docs: `docs/reference.md` (the Fast mode section, per tier), `docs/judges.md` (knobs and logs).

Tier: feature

