### PR TITLE
Postal cards: at phone width the head wraps, the gist on its own full-width line

### DIFF
--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -9,7 +9,8 @@ files (the send-time stamp, and the postal ledger's exec / relayed / bounced / r
 both ENDS wear their sessions' colours (the peer's chip, then this session's own chip); no card wears a background
 wash; incoming cards are boxed, sent ones slim; a sent card whose message has not landed wears the pending
 send's own provisional dress (the queued bubble's class). With POSTAL_SHOTS=<dir> the driver also writes
-screenshots at 1000 px and 520 px. Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC
+screenshots at 1000 px, 520 px, 340 px (the phone width: the head wraps, the ends first, the kind word and the icon on
+that line or the next as one unit, the gist last on its own full-width line, T313) and the light theme. Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC
 fixtures only (the notes-api demo world: web / api / tests; host TESTHOST)."""
 import json
 import os
@@ -17,6 +18,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -30,6 +32,8 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BIN = os.path.join(ROOT, "bin")
 EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
 
 WEB = "aaaaaaaa-1111-2222-3333-444444444444"
 API = "bbbbbbbb-1111-2222-3333-444444444444"
@@ -71,7 +75,7 @@ def send_pair(t, uuid, parent, to, kind, body, result, is_error=False):
         {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "sessionId": WEB,
          "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "tool_use",
                      "content": [{"type": "tool_use", "id": tu, "name": "mcp__romp-postal-service__send_message",
-                                  "input": {"to": to, "body": body, "kind": kind}}]}},
+                                  "input": ({"to": to, "body": body, "kind": kind} if kind else {"to": to, "body": body})}]}},
         {"type": "user", "timestamp": iso(t + 1), "uuid": uuid + "r", "parentUuid": uuid, "sessionId": WEB,
          "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tu, "content": result, "is_error": is_error}]}},
     ]
@@ -79,12 +83,19 @@ def send_pair(t, uuid, parent, to, kind, body, result, is_error=False):
 
 def sent_row(mid, frm, frm_id, to_id, body, t, kind, park=False):
     r = {"t": t, "ev": "sent", "id": mid, "from": frm, "from_id": frm_id, "to_id": to_id, "body": body, "kind": kind, "from_host": ""}
+    if not kind:
+        del r["kind"]                      # a legacy row: sent without --kind, before the marker existed
     if park:
         r["park"] = True
     return r
 
 
-# The world: nine cards, every kind and every state. Bodies are invented notes-api chatter.
+# a sent one-liner under the 90-char clip with NO kind (no declared kind, no leading token): the card has no kind word,
+# only a delivery icon — the meta slot must still exist so the icon rides in it like every other (T313 review find)
+KINDLESS = "Merged the fixtures branch; nothing else is pending on my side."
+
+
+# The world: ten cards, every kind and every state, plus one legacy card with no kind. Bodies are invented notes-api chatter.
 def world(t0):
     msgs = {
         "in-deleg": ("api", API, "delegate", "Take the retry-loop rewrite in notes-api: exponential backoff with jitter, cap at two minutes, tests included."),
@@ -96,6 +107,7 @@ def world(t0):
         "out-queued": ("web", WEB, "coordinate", "The remote build is green; merging in an hour unless you object."),
         "out-bounced": ("web", WEB, "delegate", "Take the cap decision and write it down in the README."),
         "out-recalled": ("web", WEB, "coordinate", "Ignore my last note, wrong thread."),
+        "out-nokind": ("web", WEB, None, KINDLESS),
     }
     log, recs = [], []
     t = t0
@@ -121,6 +133,7 @@ def world(t0):
          [lambda t: {"t": t + 30, "ev": "bounced", "id": "out-bounced", "why": "refused: the mailbox is isolated"}]),
         ("out-recalled", "tests", TESTS, "Delivered to 'tests'.", False,
          [lambda t: {"t": t + 40, "ev": "recall", "id": "out-recalled"}]),
+        ("out-nokind", "api", API, "Delivered to 'api'.", False, []),   # a legacy send: no kind anywhere, an icon all the same
     ]
     for i, (mid, to_name, to_id, result, err, later) in enumerate(outs):
         t += 60
@@ -153,11 +166,36 @@ const measure = () => page.evaluate(() => {
     const self = t.querySelector(".notice-src-self");
     const peer = t.querySelector(".notice-src-chip:not(.notice-src-self)");
     const cs = getComputedStyle(n);
+    const glyph = t.querySelector(".notice-glyph");
+    const ends = t.querySelector(".notice-src-ends");
+    // the kind WORD's own box (the meta element also holds the icon now), from a Range over its text node
+    const kw = kind && kind.firstChild && kind.firstChild.nodeType === 3 ? (() => { const r = document.createRange(); r.selectNodeContents(kind.firstChild); return r.getBoundingClientRect(); })() : null;
+    // the gist's real LINE boxes: the element is a blockified flex item and reports one rect, a Range over its text
+    // reports one per line fragment — the count of distinct tops is the line count, the first row's span the first line
+    const gl = (() => { const g = t.querySelector(".notice-gist"); if (!g) return { lines: null, first: null };
+      const r = document.createRange(); r.selectNodeContents(g); const rs = Array.from(r.getClientRects()).filter((q) => q.width > 0);
+      if (!rs.length) return { lines: 0, first: 0 };
+      const tops = []; for (const q of rs) if (!tops.some((y) => Math.abs(y - q.top) < 4)) tops.push(q.top);
+      const top = Math.min(...tops); const row = rs.filter((q) => Math.abs(q.top - top) < 4);
+      return { lines: tops.length, first: Math.max(...row.map((q) => q.right)) - Math.min(...row.map((q) => q.left)) }; })();
     return {
       dir: t.classList.contains("postal-service-in") ? "in" : "out",
       boxed: t.classList.contains("notice-boxed"), slim: n.classList.contains("notice-slim"),
       kind: kind ? kind.textContent : null, kindColor: kind ? getComputedStyle(kind).color : null,
       kindClipped: kind ? kind.scrollWidth > kind.clientWidth + 1 : null,
+      // the phone-width head (T313): the kind word and the icon inside the card, the gist on its own full-width line
+      kindInside: kind && n ? Math.round(n.getBoundingClientRect().right - kind.getBoundingClientRect().right) : null,
+      iconInside: icon && n ? Math.round(n.getBoundingClientRect().right - icon.getBoundingClientRect().right) : null,
+      gistRatio: t.querySelector(".notice-gist") ? t.querySelector(".notice-gist").getBoundingClientRect().width / t.querySelector(".notice-head").getBoundingClientRect().width : null,
+      headWidth: t.querySelector(".notice-head") ? t.querySelector(".notice-head").getBoundingClientRect().width : null,
+      gistLines: gl.lines, gistFirstLine: gl.first,
+      gistBelowEnds: (() => { const g = t.querySelector(".notice-gist"), e = t.querySelector(".notice-src-ends"); return g && e ? g.getBoundingClientRect().top >= e.getBoundingClientRect().bottom - 2 : null; })(),
+      headWrap: t.querySelector(".notice-head") ? getComputedStyle(t.querySelector(".notice-head")).flexWrap : null,
+      iconWithKind: icon && kw ? Math.abs(icon.getBoundingClientRect().top + icon.getBoundingClientRect().height / 2 - (kw.top + kw.height / 2)) < 8 : null,
+      iconInMeta: icon ? !!icon.closest(".notice-meta") : null,
+      iconGlyphDelta: icon && glyph ? Math.abs(icon.getBoundingClientRect().top - glyph.getBoundingClientRect().top) : null,
+      kindWithOrBelowEnds: kw && ends ? kw.top >= ends.getBoundingClientRect().top - 2 : null,
+      gistBelowKind: kw && t.querySelector(".notice-gist") ? t.querySelector(".notice-gist").getBoundingClientRect().top >= kw.bottom - 2 : null,
       chip: !!t.querySelector(".notice-chip, .postal-service-intent"),
       state: icon ? icon.dataset.state : null, title: icon ? (icon.getAttribute("aria-label") || "") : null,
       iconRight: icon && n ? Math.round(n.getBoundingClientRect().right - icon.getBoundingClientRect().right) : null,
@@ -259,14 +297,9 @@ class ServedPostalCards(unittest.TestCase):
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
-        cls.count = 9
+        cls.count = 10
         cls.port, cls.token = _free_port(), "testtok-postal"
-        env = dict(os.environ, XDG_STATE_HOME=os.path.join(cls.lab, "xdg"), CLAUDE_CONFIG_DIR=claude,
-                   ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1", ROMP_SERVE_TOKEN=cls.token,
-                   ROMP_KERNEL_PORT=str(cls.port), ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
-                   ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
-        for k in ("ROMP_STATE_DIR", "ROMP_API_KEY_CMD", "ANTHROPIC_API_KEY"):
-            env.pop(k, None)
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
         for _ in range(120):
@@ -303,7 +336,7 @@ class ServedPostalCards(unittest.TestCase):
         r = json.loads(line[len("RESULT:"):])
         wide, narrow, phone, light = r["1000"], r["520"], r["340"], r["light"]
         cards = wide["cards"]
-        self.assertEqual(len(cards), 9, cards)
+        self.assertEqual(len(cards), 10, cards)
         by = {c["gist"][:24]: c for c in cards}
         def card(prefix):
             m = [c for c in cards if c["gist"].startswith(prefix)]
@@ -311,7 +344,10 @@ class ServedPostalCards(unittest.TestCase):
             return m[0]
         # (1) the kind: coloured text, never a chip
         for c in cards:
-            self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
+            if c["gist"].startswith(KINDLESS[:20]):
+                self.assertIsNone(c["kind"], "a legacy card with no kind shows no kind word: %r" % c)
+            else:
+                self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
             self.assertFalse(c["chip"], "no chip: %r" % c)
         self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(176, 140, 255)", "delegation violet")
         self.assertEqual(card("Heads-up")["kindColor"], "rgb(20, 184, 166)", "coordination teal")
@@ -328,8 +364,14 @@ class ServedPostalCards(unittest.TestCase):
         self.assertEqual(card("Ignore my last note")["state"], "recalled")
         for c in cards:
             if c["state"]:
+                self.assertTrue(c["iconInMeta"], "the icon rides in the meta slot (T313), a kind-less card's empty slot included: %r" % c)
+                if c["kind"]:
+                    self.assertTrue(c["iconWithKind"], "…beside the kind word, on its line: %r" % c)
+                self.assertLess(c["iconGlyphDelta"], 8, "…on the head's first line, where the glyph is: %r" % c)
                 self.assertTrue(c["title"] and c["title"].split(" ")[0] in ("Delivered", "Read", "Parked", "Sent", "Bounced", "Recalled"), c)
                 self.assertLessEqual(c["iconRight"], 16, "the icon sits at the head's right edge: %r" % c)
+        kindless = card(KINDLESS[:20])
+        self.assertEqual(kindless["state"], "delivered", "the legacy card still shows its delivery state: %r" % kindless)
         self.assertIn("isolated", card("Take the cap decision")["title"], "a bounce carries its reason")
         # (3) both ends, each in its session's colour; no wash; boxed vs slim
         for c in cards:
@@ -357,10 +399,40 @@ class ServedPostalCards(unittest.TestCase):
         for c in narrow["cards"]:
             self.assertTrue(c["selfBg"] == "rgb(156, 210, 255)" and c["selfWidth"] is not None and c["selfWidth"] <= 12,
                             "at 520 px the own chip is its coloured dot: %r" % c)
-            self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), "the kind is never truncated: %r" % c)
-        # (phone) under the 360 px container query the GIST yields; the kind word is never clipped
+            if c["kind"]:
+                self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), "the kind is never truncated: %r" % c)
+        # (phone) under the 360 px container query the head WRAPS (T313): the two ends keep the first line; the kind word
+        # and the icon stay on it when they fit and otherwise move to the next line as one unit; the gist comes last on its
+        # own full-width line and breaks by words, never into a letter column — every card, slim, boxed and provisional
+        self.assertEqual(len(phone["cards"]), 10, phone["cards"])
         for c in phone["cards"]:
             self.assertFalse(c["kindClipped"], "at 340 px the kind word is whole: %r" % c)
+            self.assertEqual(c["headWrap"], "wrap", "the head wraps at phone width: %r" % c)
+            if c["kind"]:
+                self.assertGreaterEqual(c["kindInside"], 0, "the kind word's right edge sits inside the card: %r" % c)
+            if c["state"]:
+                self.assertGreaterEqual(c["iconInside"], 0, "the delivery icon sits inside the card: %r" % c)
+                if c["kind"]:
+                    self.assertTrue(c["iconWithKind"], "the icon shares the kind word's line: they wrap as one unit, never an icon alone on a line: %r" % c)
+                else:
+                    self.assertLess(c["iconGlyphDelta"], 8, "a kind-less card's icon sits on the first line with the glyph: %r" % c)
+            if c["kind"]:
+                self.assertTrue(c["kindWithOrBelowEnds"], "the kind word is on the ends' line or the next, never above: %r" % c)
+                self.assertTrue(c["gistBelowKind"], "the gist comes after the kind word: %r" % c)
+            self.assertTrue(c["gistBelowEnds"], "the gist sits on its own line under the ends: %r" % c)
+            self.assertGreaterEqual(c["gistRatio"], 0.9, "the gist line spans the card's width: %r" % c)
+            # word-wise breaks, never a letter column: a wrapped gist's FIRST line fills most of the head (a column two to
+            # four letters wide filled a tenth of it), and a short gist is one line — measured on the text's line boxes
+            self.assertTrue(c["gistLines"] == 1 or (c["gistFirstLine"] >= 0.6 * c["headWidth"] and c["gistFirstLine"] >= 150),
+                            "the first gist line spans the head (at least 60%% of it, 150 px), no letter column: %r" % c)
+        self.assertTrue(any(c["gistLines"] >= 2 for c in phone["cards"]), "at least one gist wraps at 340 px, so the wrapped branch is exercised: %r" % [c["gistLines"] for c in phone["cards"]])
+        prov = [c for c in phone["cards"] if c["provisional"]]
+        self.assertEqual(len(prov), 2, "the two provisional cards (parked, relayed) are boxed at phone width too: %r" % prov)
+        slim = [c for c in phone["cards"] if c["slim"]]
+        self.assertGreaterEqual(len(slim), 3, "and slim cards are covered: %r" % [c["gist"][:20] for c in slim])
+        # at 520 px and above the head is one line: the ends, the gist and the kind side by side (no wrap)
+        for c in wide["cards"] + narrow["cards"]:
+            self.assertEqual(c["headWrap"], "nowrap", "wider than the query the head stays one line: %r" % c)
         # (light theme) the two raw kind colours re-ink for the cream page: text contrast at or above 4.5:1
         self.assertEqual(light["theme"], "light")
         for k in ("delegate", "coordinate", "question"):

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -30,11 +30,15 @@ test("the kind is coloured text in the meta slot, never a chip, in the old chip 
   assert.match(CSS, /\n  --postal-delegate: #b08cff;\s+--postal-coordinate: #14b8a6;\s+--postal-question: var\(--st-working-bg\);/, "the dark tokens (the old chip colours)");
   const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
   assert.match(light, /--postal-delegate: #6e3fd0;\s+--postal-coordinate: #0d6b64;\s+--postal-question: #7d5600;/, "the light tokens re-ink the three kinds (the working amber alone measured 4.26:1 on cream)");
-  // under the narrow container query the GIST yields, never the kind word (the ruling: the kind never truncates)
-  assert.match(CSS, /@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-gist \{ min-width: min\(100%, 4ch\); \}\n\}/);
+  // under the narrow container query the head WRAPS: the gist takes its own full-width line, word-wise, and the kind
+  // word keeps the first line whole and inside the card (T313; the 4ch floor that squeezed the gist into a letter
+  // column beside the ends is gone)
+  assert.match(CSS, /@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-head \{ flex-wrap: wrap; \}\n  \.turn-postal-service \.notice-head > \.notice-gist \{ flex: 1 0 100%; order: 1; min-width: 0;\n    white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: break-word; \}\n\}/);
+  assert.doesNotMatch(CSS, /min-width: min\(100%, 4ch\)/, "no character-wide gist column anywhere");
   assert.doesNotMatch(CSS, /@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-meta/, "the meta no longer shrinks under it");
   // never truncated: the postal meta stays rigid
-  assert.match(CSS, /\.turn-postal-service \.notice-meta \{ flex: 0 0 auto; \}/);
+  assert.match(CSS, /\.turn-postal-service \.notice-meta \{ flex: 1 0 auto; display: inline-flex; align-items: baseline; gap: 7px; min-width: 0; \}/,
+    "the postal meta never shrinks (the kind word stays whole) and grows to the head's edge to carry the icon (T313)");
 });
 
 test("the delivery state is one icon per state at the head's right edge, each with a worded title", () => {
@@ -46,10 +50,17 @@ test("the delivery state is one icon per state at the head's right edge, each wi
   assert.match(fn("deliveryIcon"), /span\.setAttribute\("role", "img"\);/, "a labelled span is announced only with an image role");
   assert.match(fn("deliveryIcon"), /const title = deliveryTitle\(d, clockOf\);[^\n]*\n\s*setTip\(span, title\);[^\n]*\n\s*span\.setAttribute\("role", "img"\);[^\n]*\n\s*span\.setAttribute\("aria-label", title\);/);
   assert.match(CARD, /const delivery = deliveryOf\(ev\);/);
-  assert.match(CARD, /turn\.querySelector\("\.notice-head"\)\?\.appendChild\(deliveryIcon\(delivery\)\);/);
+  assert.match(CARD, /turn\.querySelector\("\.notice-meta"\)\?\.appendChild\(deliveryIcon\(delivery\)\);/);
   assert.match(CSS, /\.postal-delivery \{ flex: 0 0 auto; margin-left: auto;/, "the right edge");
   // on a fold-less card whose one line wraps, the icon sits on the FIRST line like the glyph, not centred over the block
-  assert.match(CSS, /\.turn-postal-service \.notice:not\(\.notice-collapsible\) \.postal-delivery \{ align-self: flex-start; margin-top: 4px; \}/);
+  // the icon rides inside the META slot (T313): a one-line flex box the head aligns by baseline, so it sits on the kind
+  // word's line, the first, however the gist wraps — and on a phone-width head the two wrap as one unit
+  assert.match(RENDER, /turn\.querySelector\("\.notice-meta"\)\?\.appendChild\(deliveryIcon\(delivery\)\);/);
+  // …and the meta always exists when there is an icon: a kind-less legacy card (no declared kind, no leading token) with
+  // a delivery state gets an EMPTY meta slot, so no icon is ever appended straight to the head (T313 review find)
+  assert.match(RENDER, /if \(!meta && delivery\) meta = el\("span", "postal-meta-empty"\);/);
+  assert.doesNotMatch(RENDER, /notice-head"\)\?\.appendChild\(deliveryIcon/, "no second path for the icon");
+  assert.doesNotMatch(CSS, /\.postal-delivery \{ align-self: flex-start; margin-top: 4px; \}/, "no first-line nudge left: the meta's line IS the first line");
   assert.match(CSS, /\.postal-delivery-read \{ color: var\(--accent\); \}/);
   assert.match(CSS, /\.postal-delivery-parked \{ color: var\(--warn\); \}/);
   assert.match(CSS, /\.postal-delivery-bounced \{ color: var\(--st-blocked-bg\); \}/);

--- a/ui/webview/postal-head.test.ts
+++ b/ui/webview/postal-head.test.ts
@@ -79,8 +79,9 @@ test("render.ts builds the postal card's head through postalHead and the shared 
 
 test("the head's meta never shrinks to a letter, and a head-only postal line wraps instead of truncating", () => {
   const CSS = read("ui", "webview", "styles.css");
-  assert.match(CSS, /\.turn-postal-service \.notice-head \{ container-type: inline-size; \}\n\.turn-postal-service \.notice-meta \{ flex: 0 0 auto; \}\n@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-gist \{ min-width: min\(100%, 4ch\); \}\n\}/,
-               "the head is the size container and the postal meta is rigid at every width; under 360px the GIST yields to a smaller floor, never the kind word (T302)");
+  assert.match(CSS, /\.turn-postal-service \.notice \{ container-type: inline-size; \}\n(?:\/\*[\s\S]*?\*\/\n)?\.turn-postal-service \.notice-meta \{ flex: 1 0 auto; display: inline-flex; align-items: baseline; gap: 7px; min-width: 0; \}\n@container \(max-width: 360px\) \{\n  \.turn-postal-service \.notice-head \{ flex-wrap: wrap; \}\n  \.turn-postal-service \.notice-head > \.notice-gist \{ flex: 1 0 100%; order: 1; min-width: 0;/,
+               "the CARD is the size container (a query resolves against ancestors: a rule on the head cannot query the head itself) and the postal meta is rigid at every width; under 360px the head wraps and the GIST takes its own full-width line, never a letter column beside the kind word (T313)");
+  assert.doesNotMatch(CSS, /\.notice-head \{ container-type/, "never the head as its own container: its wrap rule would never match");
   // scoped to the postal card: every other notice head's meta still yields (an API-error meta is a sentence, a compact
   // group head's meta is a whole gist, and both sit beside actions that must stay on the pane)
   assert.match(CSS, /\n\.notice-meta \{ flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4844,6 +4844,12 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
   const kind = kindLabel(intent ? intent.cls : null);
   let meta: HTMLElement | undefined;
   if (kind && intent) { meta = el("span", "postal-kind postal-kind-" + intent.cls); meta.textContent = kind; }
+  // the delivery state, read once here: it decides the meta below and the icon + dress after the card is built
+  const delivery = deliveryOf(ev);
+  // no recognised kind (a legacy row with neither a declared kind nor a leading token) but a delivery state to show:
+  // an EMPTY meta slot, so the icon always rides in the meta (T313 review find) — one geometry for every card, and
+  // the CSS needs no second path for an icon appended straight to the head
+  if (!meta && delivery) meta = el("span", "postal-meta-empty");
   // Gist: ALWAYS a one-line summary, the incoming caption, else the first line of the message CLIPPED (gist.ts
   // postalHead), with the full message one click deeper whenever the gist does not carry all of it (the user
   // 2026-06-16; T294, the user 2026-09-10, whose one-paragraph sent card had no fold at all). KEYED (the user
@@ -4861,9 +4867,11 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
   // relay, or parked for an unreachable host) — the SAME provisional dress the user's own pending send wears
   // (the queued bubble's class and tokens, the T302 amendment): solid again once the receipt says delivered,
   // relayed or read; bounced keeps its red mark. Incoming: only a parked clock (it waited while you were offline).
-  const delivery = deliveryOf(ev);
   if (delivery) {
-    turn.querySelector(".notice-head")?.appendChild(deliveryIcon(delivery));
+    // the icon rides INSIDE the meta slot, after the kind word (T313): the meta grows to the head's right edge, so the
+    // icon still sits at that edge, and on a phone-width head the kind word and the icon wrap as ONE unit (an icon
+    // alone on a line of its own was the alternative); the meta always exists when there is an icon (above)
+    turn.querySelector(".notice-meta")?.appendChild(deliveryIcon(delivery));
     if (ev.direction === "out" && (delivery.state === "sent" || delivery.state === "parked")) {
       turn.querySelector(".notice")?.classList.add("queued-bubble");
       turn.classList.add("postal-provisional");   // the bubble's border + padding move the head line: the rail dot follows

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2399,12 +2399,24 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    itself and never the word beside it down to a letter (T294, the user 2026-09-10, whose card's "question" had
    become "q…"). Scoped to the postal card: an API-error head carries a sentence-long meta and a compact notice-group
    head carries a whole gist there, and those must still yield to the actions beside them on a narrow pane. The head is
-   the size container: on a phone-width one (under 360px) even the short words do not fit beside the gist's floor, and
-   there the GIST yields further, to a smaller floor, and the kind word stays whole (T302: the kind never truncates). */
-.turn-postal-service .notice-head { container-type: inline-size; }
-.turn-postal-service .notice-meta { flex: 0 0 auto; }
+   the size container: on a phone-width one (under 360px) the two ends, the kind word and the icon leave the gist no
+   room on their line, and a floor there only squeezed it into a column two to four letters wide beside them while the
+   kind word ran off a boxed card (T313, the user 2026-09-10, who reads over the tailnet at phone width). So at that
+   width the head WRAPS: the ends keep the first line, the kind word and the delivery icon stay on it when they fit and
+   otherwise move to the next line as ONE unit (they share the meta slot), and the gist takes its own full-width line
+   last, breaking word-wise (overflow-wrap only for an unbroken token, a bare link), every card, boxed or slim; the kind
+   word never truncates (T302) and now never leaves the card either. The CARD is the size
+   container, not the head: a container query resolves against an element's ANCESTORS, so a rule on the head could
+   never query the head's own size (the head-as-container of T302 served only the gist, its child). */
+.turn-postal-service .notice { container-type: inline-size; }
+/* the postal meta never shrinks, and it GROWS to the head's right edge: it holds the kind word and, after it, the
+   delivery icon (margin-left auto inside it), so the icon sits at the edge as before and, when a phone-width head
+   wraps, the kind word and the icon move to the next line as ONE unit (T313) */
+.turn-postal-service .notice-meta { flex: 1 0 auto; display: inline-flex; align-items: baseline; gap: 7px; min-width: 0; }
 @container (max-width: 360px) {
-  .turn-postal-service .notice-gist { min-width: min(100%, 4ch); }
+  .turn-postal-service .notice-head { flex-wrap: wrap; }
+  .turn-postal-service .notice-head > .notice-gist { flex: 1 0 100%; order: 1; min-width: 0;
+    white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: break-word; }
 }
 /* T302 (the user 2026-09-10): the interaction KIND is coloured TEXT in the meta slot — a chip reads as a tag now — in
    the colours the old chips wore: delegation violet, coordination teal, question the working amber. */
@@ -2433,8 +2445,8 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 /* and its glyph sits on the FIRST line of the wrapped head (the centred glyph of a one-line head drifts to the
    middle of a three-line block otherwise); 4px is the centred offset within the head's own line */
 .turn-postal-service .notice:not(.notice-collapsible) .notice-glyph { align-self: flex-start; margin-top: 4px; }
-/* …and so does the delivery icon at the right edge: on the first line, not centred over the wrapped block */
-.turn-postal-service .notice:not(.notice-collapsible) .postal-delivery { align-self: flex-start; margin-top: 4px; }
+/* (the delivery icon needs no such rule since T313: it rides inside the meta slot, a one-line flex box the head
+   aligns by baseline, so it sits on the kind word's line, the first, however the gist wraps) */
 /* a sent card in the provisional dress wears the bubble's border + padding: its rail dot and time marker sit where a
    boxed card's do (T302 review) */
 .turn-postal-service.postal-provisional > .dot, .turn-postal-service.postal-provisional > .time-marker { top: 18px; }


### PR DESCRIPTION
On a pane narrower than 360px the postal card's head row held the two ends, the kind word and the delivery icon beside the gist, and a floor on the gist only squeezed it into a column two to four letters wide ("remo / te / build / is / gree / n"), while on a boxed provisional card the kind word and its icon ran past the card's right edge and the viewport cut them. The user reads over the tailnet at phone width, so this is a supported case (the user 2026-09-10, on the 340px screenshot of the postal cards).

## Fix

Under the 360px container query the head wraps: the ends keep the first line with the kind word and the delivery icon when they fit; the icon now rides inside the meta slot after the kind word (the meta grows to the head's right edge, so the icon sits there as before), so when they do not fit the two move to the next line as one unit, never an icon alone on a line; the gist takes its own full-width line below them, breaking by words (`overflow-wrap: break-word`, so only an unbroken token such as a bare link ever splits). Every card, boxed or slim. The 4ch floor is gone, and so is the icon's first-line nudge (the meta's line is the first line). The card, not the head, is the query's container: a container query resolves against an element's ancestors, so a rule on the head could never query the head's own size (the head-as-container served only the gist, its child). Wider than the query nothing changes: the head stays one line.

## Tests

- `ui/webview/postal-card.test.ts`, `ui/webview/postal-head.test.ts`: the query's rule (wrap, the gist's full-width line with `order`), no character-wide floor anywhere.
- `tests/test_postal_cards_served.py` (the real /chat page of a hermetic kernel, nine cards): the 340px pass asserts on every card that the head wraps, the kind word's and the icon's right edges sit inside the card, the gist sits under the ends and spans the card, its first line fills the card (no letter column), and the icon shares the kind word's line, with the two provisional cards and the slim cards among them; the 520px and 1000px passes assert the head is still one line. Red before the fix on the kind-inside and gist-width assertions.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
