### PR TITLE
Pane shim: declare a redial only once the kernel's caps frame has answered the bundle's ready

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -93,13 +93,16 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   for a reload or a tab the browser discarded; a `resent: true` copy of the
   `return` row means the kept socket proved dead and the row was re-filed onto
   the redial.
-  A redial declares itself (`reconnect=1` on the `/ws` URL) once the bundle's
-  ready has left on a socket; before that, or with the ready still queued, it
-  dials as a fresh page. The kernel then sends the active tab in full and lists
-  every other session as a `skeleton` on the tab strip with one small `status`
-  frame each, and the chat pane loads a skeleton on click or one at a time in
-  idle, never while the tab is hidden; one `skeleton` client-diag row (count,
-  active) records the regime.
+  A redial declares itself (`reconnect=1` on the `/ws` URL) once the kernel's
+  caps frame has answered the bundle's ready; before that, with the ready still
+  queued, or after a socket that died before the caps frame came back, it dials
+  as a fresh page. A page whose ready was never answered dials fresh for its
+  life (the bundle posts ready once), so each of its redials is served whole.
+  On a declared redial the kernel sends the active tab in full and lists every
+  other session as a `skeleton` on the tab strip with one small `status` frame
+  each, and the chat pane loads a skeleton on click or one at a time in idle,
+  never while the tab is hidden; one `skeleton` client-diag row (count, active)
+  records the regime.
 - **The Outline pane's ages run on the kernel's clock.** Its timestamps are the
   kernel's, so the pane never reads the browser's clock against them: it anchors
   on the frame's `now` paired with the moment that frame arrived from the wire
@@ -611,12 +614,19 @@ once per distinct error, and stops retrying until the file changes or a
 write succeeds.
 
 The kernel announces what it can do in a `{type: "caps", caps, viewsSeq}` frame
-in reply to every `ready` and lists the caps on `/version`; `tagEdit` covers the
-targeted op, the acks and the `seq`. A client uses the targeted op only when the
-cap is present and posts the whole blob otherwise. A message no handler takes is
-answered `{type: "unknownOp", op, writeId}`, which the client treats as a refusal
-of that write and as withdrawing the cap. The caps frame is also the reconnect
-signal, and the `ready` handler sends it after its own connect push. `viewsSeq`
+in reply to every `ready` (a pane's bundle posts one per page life; the shell
+page's own socket posts one at every open) and lists the caps on `/version`;
+`tagEdit` covers the targeted op, the acks and the `seq`. A client uses the
+targeted op only when the cap is present and posts the whole blob otherwise. A
+message no handler takes is answered `{type: "unknownOp", op, writeId}`, which
+the client treats as a refusal of that write and as withdrawing the cap. The
+`ready` handler sends the caps frame after its own connect push, and the pane
+shim latches on it as the kernel's word that the ready was processed and the
+page served whole: a redial declares itself only once the frame has arrived.
+It is not a reconnect signal for a pane: a pane's shim re-sends no `ready` on a
+reconnect, so a reconnected pane socket gets a caps frame only when the
+bundle's ready queued across the drop and flushed onto it; the shell's socket,
+which posts `ready` at every open, learns the caps again each time. `viewsSeq`
 is the write seq of the views blob that push put on the socket: the tabOrder
 frame's, the timeline skeleton's or the feed frame's, the highest when the push
 carried more than one. When the push carried no views frame (a chat page that
@@ -673,6 +683,13 @@ same rule. Until the
 2026-09-05 review any adoption cleared the slot, so a re-emit in that window
 cleared the pane's; the pane turned the restored store away while the router
 held it, and the two diverged until the next write.
+
+The adoption on the caps frame and the drop of writes still in flight, above,
+wait on a caps frame, and the kernel sends one only in answer to a `ready` on
+that socket: the shell page's socket, which posts `ready` at every open, gets
+one on every reconnect; a pane's socket gets one at page load and, on a
+reconnect, only when the bundle's ready queued across the drop and flushed onto
+it. A reconnected pane socket that flushed no `ready` gets no caps frame.
 
 The Outline pane's tag filter posts its lens the same way: the frame copy it
 holds with only the outline lens changed, with a `writeId` and `edited: []`, so

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -39883,7 +39883,7 @@ def _client_reset_chat_base(client):
 # a laptop sleep, a network change) redials, and the kernel used to serve the new socket as a client that
 # holds nothing: a full session frame for EVERY tab — 17 frames, ~9 MB on the measured board — for ONE tab on
 # screen. The page still holds every session it had; it only needs the one it shows. So the shim declares the
-# redial (?reconnect=1: its bundle's ready has left on a socket), and the kernel sends that client the tab strip
+# redial (?reconnect=1: the caps frame answered its ready), and the kernel sends that client the tab strip
 # with a `skeleton` list — every listed tab except the active one, cheapest transcript first — the active
 # tab's full session, and a small status frame per skeleton tab so its chip stays honest. A skeleton tab
 # loads on the user's click (activeTab / needFull) or on the client's idle prefetch (needFull), and any full
@@ -40332,7 +40332,9 @@ def _send_slot_delta(c, key, ftype, payload, pre, sig, parts=None):
 
 
 # What THIS kernel can do for a dashboard beyond the base protocol, announced on the socket in reply to
-# every `ready` (the page's own at load, and the shim's re-send on a reconnected socket) as
+# every `ready` (a pane's bundle posts one per renderer life through the shim, so a reconnected pane socket
+# carries one only when it queued across the drop; the shell page's own socket, shellWS, posts one at every
+# open, the one reconnected socket that learns the caps again) as
 # {type: "caps", caps: [...]} and listed on /version. Until 2026-09-05 nothing told a dashboard what its
 # kernel could take, and a dashboard newer than its kernel posted ops the kernel silently dropped. A
 # client uses a targeted op only when the cap is present and takes the pre-cap path otherwise.
@@ -40376,10 +40378,13 @@ def _views_seq_of(msg):
 
 def _send_caps(client, views_seq=None):
     """The caps frame, on the client's own socket: {type: "caps", caps, viewsSeq} (the comment on
-    KERNEL_WS_CAPS has the field). Sent AFTER the ready handler's pushes: the shim clears its stale banner
-    on the first non-keepalive frame after a reconnect, which must stay the resync frame itself and not
-    this one. `views_seq` is the seq of the views blob those pushes served, else the store's current seq
-    (the comment on KERNEL_WS_CAPS), None only with no store."""
+    KERNEL_WS_CAPS has the field). Sent by the ready handler alone, AFTER its pushes, and both matter: the pane
+    shim's redial gate latches on this frame (readyAcked in _shim) as the kernel's word that it processed the
+    bundle's ready and served the page whole ahead of it, so no other path may send it and nothing may send it
+    before the pushes; and the shim retires the stale prompt a reconnect arms on the first non-keepalive frame,
+    which must be a resync frame and not this one (a reconnected pane socket carries a ready, and so earns this
+    frame, only when the bundle's ready queued across the drop). `views_seq` is the seq of the views blob those
+    pushes served, else the store's current seq (the comment on KERNEL_WS_CAPS), None only with no store."""
     try:
         client["send"](json.dumps({"type": "caps", "caps": list(KERNEL_WS_CAPS),
                                    "viewsSeq": views_seq if isinstance(views_seq, int) else None}))
@@ -45300,7 +45305,7 @@ def _shim(app, v=0, no_stale=False):
     return """
 %s
 (function(){/*shim-core*/var queue=[],ws=null,everConnected=false;
-var bundleReady=false,readyQueued=false;   // the BUNDLE's own {type:"ready"} has passed through send() on this page / is waiting in `queue` for an open (onopen clears it once the flush has carried it); the dial's reconnect term (connect) keys on both
+var bundleReady=false,readyQueued=false,readyAcked=false;   // the BUNDLE's own {type:"ready"} has passed through send() on this page / is waiting in `queue` for an open (onopen clears it once the flush has carried it) / has been ANSWERED: the kernel's caps frame has arrived on a socket of this page (onmessage), the ready arm's own statement (_send_caps, sent after that arm's pushes) that it processed the bundle's ready and served the page whole ahead of it; the dial's reconnect term (connect) keys on all three
 var queuedDiag=0,DIAG_QUEUE_MAX=20;   // clientDiag rows waiting in `queue` for a reconnect, capped (an outage must not pile up breadcrumbs); other queued messages are untouched
 var failedConnects=0,firstFailT=0;   // handshakes that never OPENED since the last open: reported as ONE wsconnfail row on the next open, never one wsclose per redial
 // This pane's DASHBOARD id. ?wid= when the host supplies one (the VS Code extension builds its own pane
@@ -45455,7 +45460,7 @@ function connect(){if(ws&&(ws.readyState===0||ws.readyState===1))return;   // on
 if(returnAt)returnRedialed=true;   // a dial inside a return window (whatever path led here) → the return-fresh row says so
 connT=Date.now();var proto=location.protocol==="https:"?"wss://":"ws://";
 var active="";try{var st0=JSON.parse(localStorage.getItem(SK)||"null");active=(st0&&st0.activeId)||"";}catch(e){}
-ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):"")+((everConnected&&bundleReady&&!readyQueued)?"&reconnect=1":""));   // reconnect=1: this page has held a socket before AND its bundle has said ready AND that ready is not still waiting in the queue for this open, so it may already hold sessions; the kernel skeletons the tabs it is not looking at (2026-09-07). A socket that opened and died before the bundle said ready held nothing for the page, and neither did one whose bundle said ready only after it died (the ready queued, and flushes onto this socket as the bundle's own): both redials dial as a fresh page (2026-09-10)
+ws=new WebSocket(proto+location.host+"/ws?app=%s&delta=1&iid="+encodeURIComponent(IID)+(wid?"&wid="+encodeURIComponent(wid):"")+(active?"&active="+encodeURIComponent(active):"")+((everConnected&&bundleReady&&readyAcked&&!readyQueued)?"&reconnect=1":""));   // reconnect=1: this page has held a socket before AND its bundle has said ready AND the kernel's caps frame has answered that ready AND the ready is not still waiting in the queue for this open, so it holds the sessions the kernel served it; the kernel skeletons the tabs it is not looking at (2026-09-07). A socket that opened and died before the bundle said ready held nothing for the page, and neither did one whose bundle said ready only after it died (the ready queued, and flushes onto this socket as the bundle's own); a ready that left on an open socket the kernel never answered (the socket died before its caps frame came back) served the page nothing either: all three redials dial as a fresh page, the last for the page's life, since the bundle posts ready once and no later socket carries one for a caps frame to answer (2026-09-10)
 // onopen: flush the queue; a RECONNECT (after a drop) also PROMPTS a reload — the fresh socket resyncs live via
 // the kernel's next push, and the banner offers a full reload for anything a live push doesn't cover. This
 // replaced the old silent location.reload() (the user 2026-07-05: don't foist a reload; let me click). Narrowed by
@@ -45476,6 +45481,7 @@ if(!ann)armStale(pendingWhy||"reconnect");   // T217: an ANNOUNCED restart's rec
 pendingWhy="";freshPending=true;try{window.dispatchEvent(new Event("romp:wsup"));}catch(e){}
 enqueue({type:"wsup"});}};   // the flip as a FRAME too: frames of the dead socket may still be draining from the FIFO, and a bundle that scopes "loaded on this socket" must see the flip between them and the new socket's frames, not at onopen (review find 2026-09-07)
 ws.onmessage=function(ev){lastRecv=Date.now();resumeProvisional=0;if(returnAt)returnBytes+=(ev.data&&ev.data.length)||0;var msg;try{msg=JSON.parse(ev.data);}catch(e){return;}
+if(msg&&msg.type==="caps")readyAcked=true;   // the kernel's answer to a ready it processed: _send_caps, which the ready arm alone sends, after its own pushes. From here a redial may declare itself (the dial term in connect); the frame goes on to the bundle below like any other
 if(msg&&msg.type==="ka"){if(LOADEDV&&msg.dv&&msg.dv>LOADEDV)raiseBuild();
 if(stalePending&&++staleKa>=2){var sw=stalePending;stalePending="";raiseStale(sw);}   // the SECOND keepalive since the arm, no resync between: a full heartbeat period on THIS socket with the kernel alive, talking to it, and not resyncing it — the view IS stale. (One keepalive alone can be a beat queued at accept, ahead of the resync frame.)
 return;}   // keepalive: stamped lastRecv above and confirmed a resumed keep (resumeProvisional=0: any frame does); carries the build token (drift → reload banner); nothing for the bundle to render
@@ -53073,8 +53079,11 @@ class Handler(BaseHTTPRequestHandler):
             finally:
                 seqs, _VIEWS_SERVED.seqs = _VIEWS_SERVED.seqs, None
             # What this kernel can do for the page (KERNEL_WS_CAPS), after the pushes above and on every
-            # `ready` — so a reconnected socket learns them again, and a page whose views writes were
-            # in flight across the drop learns, by this frame, that their answers may never come. It
+            # `ready`: the shell's socket, which re-sends ready at every open, learns them again; a page
+            # whose views writes were in flight across a drop learns, when a ready reaches its socket and
+            # this frame answers it, that their answers may never come; and the pane shim reads the frame
+            # as the kernel's word that this ready was processed and the page served whole ahead of it, the
+            # latch of its redial gate (readyAcked in _shim): the frame goes last and from this arm alone. It
             # carries the seq of the views blob those pushes served (viewsSeq), read above — or, when
             # they served none (a chat page on a sentinel cycle gets no tabOrder frame), the STORE's
             # current seq, the seq the next push serves (the 2026-09-05 review: with null here nothing
@@ -54060,10 +54069,15 @@ class Handler(BaseHTTPRequestHandler):
             # flag skeletons the tabs it is not looking at (_resolve_reconnect); a full push for one tab on
             # screen was 17 session frames / 9 MB on the measured board (2026-09-07).
             # The shim dials the term only once its bundle's ready has left on a socket with none still queued
-            # (everConnected&&bundleReady&&!readyQueued, 2026-09-10): a socket that died before the bundle said
-            # ready, or while its ready was queued, redials as a fresh page. What no shim bit sees: a ready that
-            # left on an open socket the kernel never processed, the socket dying before any frame came back,
-            # still redials with the term and is served skeletons that fill on click or the idle prefetch.
+            # AND the ready arm's caps frame has answered it (everConnected&&bundleReady&&readyAcked&&!readyQueued,
+            # 2026-09-10): a socket that died before the bundle said ready, while its ready was queued, or after
+            # the ready left but before the caps frame came back redials as a fresh page (_send_caps runs after the
+            # ready arm's pushes, so the frame is the kernel's word that the page was served whole). A caps frame
+            # that never arrives (the socket died between the pushes and the frame, the ready itself lost on a
+            # half-dead socket, or the ready arm raised into the dispatch loop's except below) leaves the page
+            # dialling fresh for its life: the bundle posts ready once, so no later socket carries one and no caps
+            # frame follows. Every redial of such a page is served whole, the cost before 2026-09-07, never a
+            # false skeleton.
             client["reconnect"] = True
         _register_ws_client(client)
         if client.get("reconnect"):

--- a/tests/test_chat_skeleton_reconnect.py
+++ b/tests/test_chat_skeleton_reconnect.py
@@ -411,8 +411,10 @@ class SkeletonReconnect(unittest.TestCase):
         self.assertIn("_send_chat_or_status(c, m, ms, change_from, led_changed)", s)
         self.assertNotIn("= _send_chat(c, m, ms, change_from, led_changed)", s,
                          "the pusher's per-client send goes through the skeleton-aware twin")
-        self.assertIn('+((everConnected&&bundleReady&&!readyQueued)?"&reconnect=1":"")', km._shim("chat", 1),
-                      "the shim declares the redial once its bundle's ready has left on a socket")
+        self.assertIn('+((everConnected&&bundleReady&&readyAcked&&!readyQueued)?"&reconnect=1":"")', km._shim("chat", 1),
+                      "the shim declares the redial once the kernel's caps frame has answered its bundle's ready")
+        self.assertIn('if(msg&&msg.type==="caps")readyAcked=true;', km._shim("chat", 1),
+                      "the latch is the caps frame, the ready arm's reply (_send_caps)")
         s = inspect.getsource(km.Handler._ws)
         self.assertIn('reconnect = (q.get("reconnect") or [""])[0] == "1"', s)
         self.assertIn('client["reconnect"] = True', s)

--- a/tests/test_pane_shim_return.py
+++ b/tests/test_pane_shim_return.py
@@ -570,7 +570,10 @@ class ReconnectFlag(unittest.TestCase):
     per tab into a document with no listener yet, all redone whole once the bundle's ready is processed (the kernel
     pops the set at `ready`). Nor does a redial whose bundle said ready while the socket was down:
     that ready sits in the queue (readyQueued) and flushes onto the redial socket as the bundle's own, so the dial
-    keys on the queue bit too. What no shim bit sees: a ready that left on an OPEN socket which then died before any
+    keys on the queue bit too. A ready posted while the FIRST socket is still CONNECTING (the bundle evaluated before
+    the handshake finished) queues the same way: send() sees readyState 0, sets the bit and queues the ready, that
+    socket's onopen flushes it exactly once and clears the bit, and the next redial declares itself. What no shim bit
+    sees: a ready that left on an OPEN socket which then died before any
     frame came back; that redial carries the flag and is served skeletons that fill on click or in idle (stated at
     the kernel's accept). The twin-retire at registration was rejected as the signal: it misses a socket the kernel
     already dropped."""
@@ -643,6 +646,42 @@ out({onDead:onDead,queued:queued,flushed:flushed,designed:designed,n:sockets.len
         self.assertEqual(r["flushed"], 1, "the queued ready goes out on the redial socket, once: the flush carries it")
         self.assertTrue(r["designed"].endswith("&active=S1&reconnect=1"),
                         "the ready has left on a socket: the next redial declares itself: " + r["designed"])
+
+    def test_a_ready_posted_while_the_first_socket_is_still_connecting_queues_flushes_once_at_its_open_and_the_next_redial_declares_itself(self):
+        # the bundle evaluates before the first socket's handshake finishes: the shim dialled during HTML parse, so
+        # the socket is CONNECTING (readyState 0) when the bundle posts ready. send() cannot put it on a socket that
+        # is not open, so the ready queues with readyQueued set; the first onopen flushes it exactly once and clears
+        # the bit (on the FIRST open too, not only on a reconnect's); the next redial then declares itself. The bits
+        # are read by name (readyQueued, bundleReady, queue: the shim's own variables at the harness's module scope,
+        # the way SocketFlipMarker reads FIFO), because while a socket is CONNECTING no dial runs, so no URL can show
+        # what the queue bit held at that moment.
+        r = _run(r"""
+function redial(){var live=timers.filter(function(t){return t.live&&t.fn.name==="connect";});live[live.length-1].fn();}
+function readys(s){return s.sent.filter(function(x){return JSON.parse(x).type==="ready";}).length;}
+function queuedReadys(){return queue.filter(function(x){return JSON.parse(x).type==="ready";}).length;}
+localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};
+var first=sockets[0].url,firstState=sockets[0].readyState;
+window.__rompLocalSend({type:"ready"});                                                    // the bundle says ready while the first socket is still connecting
+var connecting={sent:readys(sockets[0]),readyQueued:readyQueued,bundleReady:bundleReady,inQueue:queuedReadys()};
+open();                                                                                     // the first socket opens: the flush carries the ready
+var opened={sent:readys(sockets[0]),readyQueued:readyQueued,inQueue:queuedReadys()};
+recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var designed=sock().url;   // the ready has left on a socket: the designed redial
+open();                                                                                     // the redial opens: nothing left to flush
+out({first:first,firstState:firstState,connecting:connecting,opened:opened,designed:designed,onFirst:readys(sockets[0]),onRedial:readys(sockets[1]),n:sockets.length});""")
+        self.assertEqual(r["n"], 2)
+        self.assertEqual(r["firstState"], 0, "the harness's first socket is CONNECTING until open()")
+        self.assertNotIn("reconnect", r["first"], "the first dial never carries the flag: " + r["first"])
+        self.assertEqual(r["connecting"]["sent"], 0, "nothing goes out on a socket that has not opened")
+        self.assertTrue(r["connecting"]["bundleReady"], "send() has seen the bundle's ready (bundleReady, read by name)")
+        self.assertTrue(r["connecting"]["readyQueued"], "the ready waits for the open (readyQueued, read by name), on a CONNECTING socket as on a closed one")
+        self.assertEqual(r["connecting"]["inQueue"], 1, "the ready sits in the shim's queue (queue, read by name)")
+        self.assertEqual(r["opened"]["sent"], 1, "the first open flushes the queued ready onto its socket, once")
+        self.assertFalse(r["opened"]["readyQueued"], "the flush clears the queue bit on the FIRST open, not only on a reconnect's")
+        self.assertEqual(r["opened"]["inQueue"], 0, "the flush emptied the queue: no second copy waits for a later open")
+        self.assertTrue(r["designed"].endswith("&active=S1&reconnect=1"),
+                        "the ready has left on a socket and none is queued: the next redial declares itself: " + r["designed"])
+        self.assertEqual(r["designed"].count("&reconnect=1"), 1)
+        self.assertEqual((r["onFirst"], r["onRedial"]), (1, 0), "one ready on the first socket, none on the redial's: the bundle's ready went out exactly once")
 
 
 class SocketFlipMarker(unittest.TestCase):

--- a/tests/test_pane_shim_return.py
+++ b/tests/test_pane_shim_return.py
@@ -58,6 +58,7 @@ function runFlushes(){var f=flushes;flushes=[];for(var i=0;i<f.length;i++)f[i]()
 function sock(){return sockets[sockets.length-1];}
 function open(){var s=sock();s.readyState=1;s.onopen();return s;}
 function recv(m){sock().onmessage({data:JSON.stringify(m)});}
+function caps(){recv({type:"caps",caps:["tagEdit"],viewsSeq:null});}   // the kernel's answer to a ready it processed (_send_caps), in the shape it sends
 function tick(){for(var i=0;i<intervals.length;i++)intervals[i].fn();}
 function rows(s,what){return s.sent.map(function(x){return JSON.parse(x);}).filter(function(m){return m.type==="clientDiag"&&(!what||m.what===what);});}
 function hide(){document.visibilityState="hidden";fire("visibilitychange");}
@@ -561,9 +562,10 @@ out({got:delivered.map(function(m){return m.id;}),fifo:FIFO.length,armed:flushAr
 
 class ReconnectFlag(unittest.TestCase):
     """The redial declares itself (2026-09-07). A redial's URL ends with &reconnect=1 when THIS page has opened a
-    socket before AND its bundle has said ready AND that ready is not still waiting in the shim's queue for the
-    open (`everConnected&&bundleReady&&!readyQueued`): the one party that knows it may already hold sessions it can
-    reload lazily, so the kernel skeletons the tabs the page is not looking at (tests/test_chat_skeleton_reconnect.py).
+    socket before AND its bundle has said ready AND the kernel's caps frame has answered that ready AND the ready is
+    not still waiting in the shim's queue for the open (`everConnected&&bundleReady&&readyAcked&&!readyQueued`): the
+    one party that knows it holds the sessions the kernel served it, which it can reload lazily, so the kernel
+    skeletons the tabs the page is not looking at (tests/test_chat_skeleton_reconnect.py).
     The FIRST dial never carries it: a fresh page holds nothing and must get everything, as today. Nor does a redial
     after a first socket that opened and died before the bundle's ready (2026-09-10): the page held nothing on that
     socket, and with the flag the kernel would serve the skeleton strip, the active tab in full and a status frame
@@ -572,18 +574,22 @@ class ReconnectFlag(unittest.TestCase):
     that ready sits in the queue (readyQueued) and flushes onto the redial socket as the bundle's own, so the dial
     keys on the queue bit too. A ready posted while the FIRST socket is still CONNECTING (the bundle evaluated before
     the handshake finished) queues the same way: send() sees readyState 0, sets the bit and queues the ready, that
-    socket's onopen flushes it exactly once and clears the bit, and the next redial declares itself. What no shim bit
-    sees: a ready that left on an OPEN socket which then died before any
-    frame came back; that redial carries the flag and is served skeletons that fill on click or in idle (stated at
-    the kernel's accept). The twin-retire at registration was rejected as the signal: it misses a socket the kernel
-    already dropped."""
+    socket's onopen flushes it exactly once and clears the bit. Nor does a redial after a ready that left on an OPEN
+    socket which then died before the kernel answered it: the kernel's ready arm pops the skeleton set, serves the
+    page whole and only then sends its caps frame (_send_caps, the one sender), so that frame is the kernel's word
+    that the page was served, and the shim latches it (readyAcked) for the page's life. A keepalive back is no
+    answer, and neither is a pushed view frame: the pusher serves a socket from its registration at accept, ahead
+    of the ready's processing. A page whose caps frame never comes (the socket died between the pushes and the
+    frame) dials fresh for its life, since the bundle posts ready once and no later socket carries one: every
+    redial of it is served whole, the cost before 2026-09-07, never a false skeleton. The twin-retire at
+    registration was rejected as the signal: it misses a socket the kernel already dropped."""
 
-    def test_the_first_dial_has_no_flag_and_a_redial_after_the_bundles_ready_left_on_a_socket_carries_it_after_iid_and_active(self):
+    def test_the_first_dial_has_no_flag_and_a_redial_after_the_kernel_answered_the_bundles_ready_carries_it_after_iid_and_active(self):
         r = _run(r"""
 function redial(){var live=timers.filter(function(t){return t.live&&t.fn.name==="connect";});live[live.length-1].fn();}
 var first=sockets[0].url;
 localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};   // the page persisted its active tab before the drop
-open();window.__rompLocalSend({type:"ready"});recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var second=sock().url;   // the bundle said ready on the first socket: the page held sessions
+open();window.__rompLocalSend({type:"ready"});caps();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var second=sock().url;   // the bundle said ready on the first socket and the kernel answered it: the page holds sessions
 localStorage.getItem=function(){return null;};                              // a page with no hint still says it reconnected
 open();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var third=sock().url;
 out({first:first,second:second,third:third,n:sockets.length});""")
@@ -594,7 +600,7 @@ out({first:first,second:second,third:third,n:sockets.length});""")
         self.assertTrue(r["second"].endswith("&active=S1&reconnect=1"),
                         "the flag is APPENDED after the active hint, so the kernel's active-first build is untouched: " + r["second"])
         self.assertTrue(r["third"].endswith("&reconnect=1") and "active=" not in r["third"],
-                        "no hint → the kernel sends everything, but the page still names itself a reconnect: " + r["third"])
+                        "no hint → the kernel sends everything, but the page still names itself a reconnect (the kernel's answer stands for the page's life; no later socket carries a ready): " + r["third"])
         self.assertEqual(r["third"].count("&reconnect=1"), 1)
 
     def test_a_first_socket_that_died_before_the_bundles_ready_redials_without_the_flag(self):
@@ -610,7 +616,7 @@ function readys(s){return s.sent.filter(function(x){return JSON.parse(x).type===
 localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};
 open();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var midLoad=sock().url;    // opened, died, no bundle yet
 open();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var midLoad2=sock().url;   // and again: still no bundle
-open();window.__rompLocalSend({type:"ready"});recv({type:"ka"});                                // the bundle says ready on the third socket
+open();window.__rompLocalSend({type:"ready"});caps();recv({type:"ka"});                         // the bundle says ready on the third socket and the kernel answers it
 var readySent=readys(sock());
 sock().readyState=3;sock().onclose();redial();var designed=sock().url;                         // the designed redial: the page held sessions
 out({midLoad:midLoad,midLoad2:midLoad2,readySent:readySent,designed:designed,n:sockets.length});""")
@@ -620,7 +626,7 @@ out({midLoad:midLoad,midLoad2:midLoad2,readySent:readySent,designed:designed,n:s
         self.assertNotIn("reconnect", r["midLoad2"], "however many sockets died before the bundle: " + r["midLoad2"])
         self.assertEqual(r["readySent"], 1, "the bundle's own ready went out on the third socket")
         self.assertTrue(r["designed"].endswith("&active=S1&reconnect=1"),
-                        "once the bundle has said ready, a redial declares itself: " + r["designed"])
+                        "once the kernel has answered the bundle's ready, a redial declares itself: " + r["designed"])
 
     def test_a_ready_that_queued_while_the_socket_was_down_redials_without_the_flag_and_goes_out_once_on_the_redial(self):
         # the first socket opened and died before the bundle's ready; the bundle says ready WHILE the socket is down,
@@ -628,7 +634,7 @@ out({midLoad:midLoad,midLoad2:midLoad2,readySent:readySent,designed:designed,n:s
         # the redial would declare itself and the flushed ready, the bundle's first, would reach the kernel on a
         # socket flagged as a redial. The dial keys on !readyQueued too: no flag, and the queued ready is the ONE
         # ready on the redial socket (the flush carries it; onopen adds nothing). Once that ready has left on a
-        # socket, the next redial is the designed one and declares itself.
+        # socket and the kernel has answered it, the next redial is the designed one and declares itself.
         r = _run(r"""
 function redial(){var live=timers.filter(function(t){return t.live&&t.fn.name==="connect";});live[live.length-1].fn();}
 function readys(s){return s.sent.filter(function(x){return JSON.parse(x).type==="ready";}).length;}
@@ -636,8 +642,8 @@ localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};
 open();recv({type:"ka"});sock().readyState=3;sock().onclose();                 // opened, died, no bundle yet
 window.__rompLocalSend({type:"ready"});var onDead=readys(sockets[0]);           // the bundle says ready while the socket is down: queued
 redial();var queued=sock().url;
-open();var flushed=readys(sock());                                              // the redial opens: the flush carries the ready
-recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var designed=sock().url;   // the page held sessions on that socket: the designed redial
+open();var flushed=readys(sock());caps();                                       // the redial opens: the flush carries the ready, and the kernel answers it
+recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var designed=sock().url;   // the page holds what the kernel served on that socket: the designed redial
 out({onDead:onDead,queued:queued,flushed:flushed,designed:designed,n:sockets.length});""")
         self.assertEqual(r["n"], 3)
         self.assertEqual(r["onDead"], 0, "nothing goes out on a dead socket: the ready waits in the queue")
@@ -645,7 +651,7 @@ out({onDead:onDead,queued:queued,flushed:flushed,designed:designed,n:sockets.len
         self.assertTrue(r["queued"].endswith("&active=S1"), "the active hint still rides: " + r["queued"])
         self.assertEqual(r["flushed"], 1, "the queued ready goes out on the redial socket, once: the flush carries it")
         self.assertTrue(r["designed"].endswith("&active=S1&reconnect=1"),
-                        "the ready has left on a socket: the next redial declares itself: " + r["designed"])
+                        "the ready has left on a socket and the kernel answered it: the next redial declares itself: " + r["designed"])
 
     def test_a_ready_posted_while_the_first_socket_is_still_connecting_queues_flushes_once_at_its_open_and_the_next_redial_declares_itself(self):
         # the bundle evaluates before the first socket's handshake finishes: the shim dialled during HTML parse, so
@@ -665,7 +671,7 @@ window.__rompLocalSend({type:"ready"});                                         
 var connecting={sent:readys(sockets[0]),readyQueued:readyQueued,bundleReady:bundleReady,inQueue:queuedReadys()};
 open();                                                                                     // the first socket opens: the flush carries the ready
 var opened={sent:readys(sockets[0]),readyQueued:readyQueued,inQueue:queuedReadys()};
-recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var designed=sock().url;   // the ready has left on a socket: the designed redial
+caps();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var designed=sock().url;   // the kernel answered the flushed ready: the designed redial
 open();                                                                                     // the redial opens: nothing left to flush
 out({first:first,firstState:firstState,connecting:connecting,opened:opened,designed:designed,onFirst:readys(sockets[0]),onRedial:readys(sockets[1]),n:sockets.length});""")
         self.assertEqual(r["n"], 2)
@@ -679,9 +685,69 @@ out({first:first,firstState:firstState,connecting:connecting,opened:opened,desig
         self.assertFalse(r["opened"]["readyQueued"], "the flush clears the queue bit on the FIRST open, not only on a reconnect's")
         self.assertEqual(r["opened"]["inQueue"], 0, "the flush emptied the queue: no second copy waits for a later open")
         self.assertTrue(r["designed"].endswith("&active=S1&reconnect=1"),
-                        "the ready has left on a socket and none is queued: the next redial declares itself: " + r["designed"])
+                        "the ready has left on a socket, none is queued and the kernel answered it: the next redial declares itself: " + r["designed"])
         self.assertEqual(r["designed"].count("&reconnect=1"), 1)
         self.assertEqual((r["onFirst"], r["onRedial"]), (1, 0), "one ready on the first socket, none on the redial's: the bundle's ready went out exactly once")
+
+    def test_a_ready_the_kernel_never_answered_redials_without_the_flag_and_the_page_dials_fresh_until_a_caps_frame_arrives(self):
+        # the residual the queue bit left open: the bundle's ready left on an OPEN socket (bundleReady set, readyQueued
+        # not), and the socket died before the kernel processed it, a keepalive the only frame back. Keyed on
+        # everConnected&&bundleReady&&!readyQueued the redial declared itself and was served skeletons for sessions the
+        # page had never received. The kernel's ready arm answers every ready it processes with a caps frame, sent
+        # after its pushes (_send_caps, the one sender), so the shim latches on that frame (readyAcked): no caps, no
+        # flag. Once set the latch holds for the page's life; never set, it stays clear for the page's life, since
+        # the bundle posts ready once and no later socket carries one: every redial of such a page is served whole.
+        r = _run(r"""
+function redial(){var live=timers.filter(function(t){return t.live&&t.fn.name==="connect";});live[live.length-1].fn();}
+localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};
+open();window.__rompLocalSend({type:"ready"});recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var unanswered=sock().url;   // the ready left on an open socket; a keepalive came back, never the caps frame, and the socket died
+open();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var stillFresh=sock().url;                                    // no later socket carries a ready, so no caps frame comes: the page keeps dialling fresh
+open();caps();sock().readyState=3;sock().onclose();redial();var answered=sock().url;                                                 // harness only (a kernel answers no socket that carried no ready): the frame, and the frame alone, arms the gate
+out({unanswered:unanswered,stillFresh:stillFresh,answered:answered,n:sockets.length});""")
+        self.assertEqual(r["n"], 4)
+        self.assertNotIn("reconnect", r["unanswered"],
+                         "the kernel never answered the ready, so it never served the page: the redial dials as a fresh page: " + r["unanswered"])
+        self.assertTrue(r["unanswered"].endswith("&active=S1"), "the active hint still rides: " + r["unanswered"])
+        self.assertNotIn("reconnect", r["stillFresh"],
+                         "no later socket carries a ready and no caps frame comes: the page dials fresh for its life: " + r["stillFresh"])
+        self.assertTrue(r["answered"].endswith("&active=S1&reconnect=1"),
+                        "the caps frame is the latch, on whichever socket of the page it arrives: " + r["answered"])
+
+    def test_a_pushed_view_frame_after_the_ready_is_not_the_kernels_answer_only_the_caps_frame_is(self):
+        # the pusher serves a client from its registration at accept, on its own cycle or the reconnect wake, so a
+        # view frame can land after the bundle's ready left and before the ready arm processed it: the first frame
+        # after the ready is no evidence the ready was processed, and the latch is the caps frame alone.
+        r = _run(r"""
+function redial(){var live=timers.filter(function(t){return t.live&&t.fn.name==="connect";});live[live.length-1].fn();}
+localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};
+open();window.__rompLocalSend({type:"ready"});recv({type:"feed",asks:[]});recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var pushed=sock().url;
+out({pushed:pushed,n:sockets.length});""")
+        self.assertEqual(r["n"], 2)
+        self.assertNotIn("reconnect", r["pushed"], "a pushed view frame is the pusher's, not the ready arm's answer: no flag: " + r["pushed"])
+        self.assertTrue(r["pushed"].endswith("&active=S1"), r["pushed"])
+
+    def test_a_caps_frame_arms_nothing_on_its_own_neither_before_the_bundles_ready_nor_while_that_ready_is_still_queued(self):
+        # the kernel answers only a ready it processed, so in production a caps frame implies the bundle's ready has
+        # left and is not queued; the term keeps bundleReady and !readyQueued as the shim-local facts all the same
+        # (four events in order, no one bit standing in for the rest). Harness only, both legs: a caps frame before
+        # any ready from this bundle arms nothing, and with the frame on record a ready that then queues on a
+        # CONNECTING redial (send() sees readyState 0) holds the gate through that redial's failure until a later
+        # open's flush has carried it.
+        r = _run(r"""
+function redial(){var live=timers.filter(function(t){return t.live&&t.fn.name==="connect";});live[live.length-1].fn();}
+function readys(s){return s.sent.filter(function(x){return JSON.parse(x).type==="ready";}).length;}
+localStorage.getItem=function(){return JSON.stringify({activeId:"S1"});};
+open();caps();recv({type:"ka"});sock().readyState=3;sock().onclose();redial();var noReady=sock().url;   // a caps frame before any ready from this bundle
+window.__rompLocalSend({type:"ready"});var onConnecting=readys(sock());                                  // the bundle says ready while the redial is still connecting: queued
+sock().readyState=3;sock().onclose();redial();var queued=sock().url;                                    // that redial never opened (a failed connect): the next dials with the ready still queued
+open();var flushed=readys(sock());caps();sock().readyState=3;sock().onclose();redial();var designed=sock().url;
+out({noReady:noReady,onConnecting:onConnecting,queued:queued,flushed:flushed,designed:designed,n:sockets.length});""")
+        self.assertEqual(r["n"], 4)
+        self.assertNotIn("reconnect", r["noReady"], "no ready from this bundle: the frame alone arms nothing: " + r["noReady"])
+        self.assertEqual(r["onConnecting"], 0, "nothing goes out on a socket that has not opened")
+        self.assertNotIn("reconnect", r["queued"], "the ready is still queued: the frame on record does not stand in for its flush: " + r["queued"])
+        self.assertEqual(r["flushed"], 1, "the flush carries the queued ready onto the socket that opened, once")
+        self.assertTrue(r["designed"].endswith("&active=S1&reconnect=1"), "ready, flush and answer all on record: the redial declares itself: " + r["designed"])
 
 
 class SocketFlipMarker(unittest.TestCase):

--- a/ui/webview/skeleton-tabs.ts
+++ b/ui/webview/skeleton-tabs.ts
@@ -6,8 +6,9 @@
 // module owns the client's copy of that set — which tabs are resting, what the kernel last said about each,
 // and which one to fetch next in idle — as a pure, DOM-free state machine (the prebuild.ts / tab-meta.ts
 // pattern: executable in node, so the policy is pinned by skeleton-tabs.test.ts while render.ts only wires it).
-// A redial declares itself only once the bundle's ready has left on a socket; before that, or with the ready
-// still queued for the open, the shim dials as a fresh page and the kernel sends everything whole (2026-09-10).
+// A redial declares itself only once the kernel's caps frame has answered the bundle's ready; before that, with
+// the ready still queued for the open, or after a socket that died before its caps frame came back, the shim dials
+// as a fresh page and the kernel sends everything whole (2026-09-10).
 //
 // The page HELD every session before the outage, and render.ts deliberately keeps those `sessions` entries
 // (the eventual full then takes upsert's append path, so the DOM and the reader's scroll survive). What a


### PR DESCRIPTION
Follows #1325, which has merged; this branch is cut from main, and the change to review is its two commits: the test pin and the caps latch that #1325's review record named as follow-ups.

## Symptom

A pane whose bundle posted its `ready` on an open socket that then died before the kernel processed it (a keepalive the only frame back) dialled the next socket with `&reconnect=1`. The kernel served a page that had never received its sessions as one that held them: the skeleton strip, the active tab in full and a status frame per tab, with the withheld tabs filling on click or in idle. #1325's accept-time note stated this residual, and its review named the caps frame as the event to close it on.

The review also named a gap in the tests: no case covered the bundle's `ready` posted while the FIRST socket was still connecting.

## Cause

The dial term keyed on the ready having LEFT (`everConnected&&bundleReady&&!readyQueued`); nothing in the shim recorded whether the kernel had processed it. The kernel already says so on an exact event: the `ready` arm pops the skeleton set, serves the page whole (`_push_one`), and only then sends the caps frame (`_send_caps`, called from that arm alone), so the frame is the kernel's word that the page was served.

## Fix

Commit 1 (tests only): one ReconnectFlag case posts the ready before any `open()` while the first socket is CONNECTING, reads the shim's queue bits by name (no dial runs while a socket is connecting, so no URL could show them), and asserts the flush once at the first open, the cleared bit, and the next redial's flag. It is red under each of three shim mutations that every existing case survives (the clear moved into the reconnect branch; the queue bit set only for a closed socket; a ready dropped while connecting) and under a deleted clear (also red at the existing queued-ready case). One docstring sentence names the order.

Commit 2: `_shim` gains `readyAcked`, set in `ws.onmessage` on a `caps` frame (placed after the parse and before the keepalive line, so the heartbeat, disconnect-banner and auto-reload source pins stand). The dial term becomes `everConnected&&bundleReady&&readyAcked&&!readyQueued`: a fourth conjunct rather than a replacement, so the term reads as the four events in order and a frame with no prior ready from this bundle arms nothing. In production the caps frame implies the other three (ready is posted once per renderer life and the kernel answers only a ready it processed), so the extra conjuncts bite only on injected frames; for the same reason a latch gated on `bundleReady` would behave identically in production, and no test distinguishes the two. If you prefer the single bit, drop the conjuncts and the four-events test case goes with them.

Cost, stated in the accept-time note, `_send_caps`'s docstring and the ReconnectFlag docstring: a caps frame that never arrives (the socket died between the pushes and the frame, the ready lost on a half-dead socket, or the ready arm raised into the dispatch except) leaves the page dialling fresh for its LIFE, not for one redial: the bundle posts ready once, so no later socket carries one and no caps frame follows. Every redial of such a page is served whole, the cost before 2026-09-07, never a false skeleton.

Comments this change made stale, corrected here: the KERNEL_WS_CAPS comment's "the shim's re-send on a reconnected socket" (the socket that re-sends `ready` at every open is the shell page's own, `shellWS`; a pane's shim never re-sends, and a reconnected pane socket carries a ready only when it queued across the drop); `_send_caps`'s stale-banner sentence, which presumed a caps frame on every reconnect; the ready arm's comment; the reconnect-skeletons header; docs/read-side.md's redial sentence, its caps paragraph ("the caps frame is also the reconnect signal"), and a closing paragraph to its viewsSeq section scoping the restore adoption and the in-flight drop to a socket whose ready the frame answered (the shell's at every open, a pane's at load and, on a reconnect, only when the bundle's ready queued across the drop); ui/webview/skeleton-tabs.ts's header. Left for a separate comment-only change, since the UI files are outside this change: the same "re-send on a reconnected socket" claim in ui/webview/timeline-boot.ts:55, ui/webview/render.ts:853-854 and ui/romp-timeline-view.js:3674-3675. A reader of those still expects a caps frame on a pane's reconnect, which comes only when a queued ready flushed onto it, so the in-flight-write drop they describe fires for a pane only in that case; that is a latent issue of its own, not this change's.

## Tests

All in tests/test_pane_shim_return.py ReconnectFlag, running the real shim core under node; the harness gains `caps()`, the frame in the shape `_send_caps` sends.

- `test_a_ready_posted_while_the_first_socket_is_still_connecting_queues_flushes_once_at_its_open_and_the_next_redial_declares_itself` (commit 1): green on the unchanged shim; red under the mutations above.
- `test_a_ready_the_kernel_never_answered_redials_without_the_flag_and_the_page_dials_fresh_until_a_caps_frame_arrives`: fails before commit 2 at its first assertion, the redial URL ending `&active=S1&reconnect=1`. A second leg pins that a later socket with no ready earns no flag either; a third, harness-only leg pins that the frame, and the frame alone, arms the gate.
- `test_a_pushed_view_frame_after_the_ready_is_not_the_kernels_answer_only_the_caps_frame_is`: fails before commit 2 the same way. The pusher serves a socket from its registration at accept, ahead of the ready's processing, so a view frame after the ready is no evidence it was processed.
- `test_a_caps_frame_arms_nothing_on_its_own_neither_before_the_bundles_ready_nor_while_that_ready_is_still_queued`: harness only (a kernel sends no caps frame before a ready); green before and after; it pins the term's shape. Red if the term drops `bundleReady`, if it drops `!readyQueued`, or if the queue bit is set only for a closed socket.
- The four cases before commit 2 now feed a caps frame after the ready on the socket whose next redial must carry the flag: a bare ready plus a keepalive no longer earns it. The first is renamed to say the kernel answered; its third leg (a later redial with only keepalives still carries the flag) is the page-lifetime control, red if the latch is cleared at a reconnect open.
- tests/test_chat_skeleton_reconnect.py: the exact-string pin follows the new term and pins the latch line.

Mutations run against the finished class: the latch never setting fails six cases; the term without `readyAcked` fails the two cases above that are red before commit 2; the term without `bundleReady`, the term without `!readyQueued`, a latch on any non-keepalive frame, and a latch cleared at a reconnect open each fail one; the queue bit set only for a closed socket fails two (the connecting pin and the four-events case).

Red before commit 2 (its tests on the unchanged shim): 3 failed, 85 passed across tests/test_pane_shim_return.py, test_chat_skeleton_reconnect.py and test_dashboard_auto_reload.py (the two cases above at their URL assertions; the exact-string pin). At head: those three plus test_kernel_ws_heartbeat.py, test_kernel_disconnect_banner.py and test_new_session_dir.py (which reads docs/read-side.md), 158 passed; `npm run typecheck` clean (skeleton-tabs.ts is comment only). Full pytest at head, with the extension's node modules installed so the served-page browser legs run: 11505 passed, 43 skipped (environment-conditioned cases, among them the two ControlProtocolPins cases that need a live CLI), 1744 subtests passed, 0 failed. An earlier full run of the same two commits on the main of a few hours before (without #1326) had one failure, tests/test_notification_tap_resume_browser.py ServedTapLanding's deep-link landing, a Chromium-driven leg that had passed in the run before it on the same code, passed 4 of 5 times alone under a load average near 10, and reads nothing this change touches; it passed on the current head.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)