### PR TITLE
A notification tap lands on its session even when the chat pane's ready beats the shell's reveal: a boot reveal is delivered to the same-window pane with a copy kept parked (T312)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -45009,11 +45009,13 @@ def _reveal_request(sid, wid, boot=False, via=""):
     2026-09-06, whose tap on the phone did nothing — the phone is where sockets die without a
     close: a suspended app, a VPN link that dropped with the screen):
       boot  — the shell says the page is BOOTING (the deep-link arrival: iOS opens the installed
-              app's one window on the link, or the app comes back from a kill). Its own chat pane
-              cannot be connected yet, so a socket wearing its wid is the PREVIOUS page's
-              (sessionStorage keeps the wid across a reload) — dead, and the ping timeout has up to
-              WS_DEAD_S to say so. Park only; "delivering" there parked nothing and the new pane's
-              ready found nothing to consume.
+              app's one window on the link, or the app comes back from a kill). A socket wearing its
+              wid is usually the PREVIOUS page's (sessionStorage keeps the wid across a reload) —
+              dead, and the ping timeout has up to WS_DEAD_S to say so — but it can also be this
+              page's own chat pane, when the pane's ready beat the shell's fetch (T312: a slow
+              machine). So a boot reveal is delivered AND kept parked, the unproven rule below, never
+              parked alone: 2026-09-06 to 2026-09-10 it was park-only, and a pane already ready found
+              it parked after its ready had passed, so the tap never landed.
       unproven — a live tap, but the target has a ping on the wire nobody has answered (pingAt set:
               the peer is unproven since the last heartbeat). Deliver as before AND keep a copy
               parked, tagged with who it went to: the pong that proves that socket alive retires it
@@ -45030,13 +45032,21 @@ def _reveal_request(sid, wid, boot=False, via=""):
     the pane's ready never came for that wid; consumed — the pane got it. Ids clipped: enough to
     match rows, not a transcript of anything."""
     with _clients_lock:
-        targets = [] if boot else [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid]
+        targets = [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid]
     delivered, sent = False, []
     for c in targets:
         try:
             c["send"](json.dumps(_reveal_msg(sid)))
             delivered = True
-            if c.get("pingAt") is not None:
+            # A booting page's same-wid socket may be the PREVIOUS page's (dead, its pong never coming) — or
+            # this very page's chat pane, whose ready beat the shell's fetch (T312, 2026-09-10: a slow machine
+            # put the pane's ready first, the boot reveal was parked after it with nothing left to consume it,
+            # and the tap landed on whichever session frame the pane adopted first). Both wear the same wid and
+            # nothing here can tell them apart, so a boot reveal is delivered like an unproven live tap: sent to
+            # every same-wid pane AND kept parked until one of them answers (its pong or next message retires
+            # the copy, _reveal_proven) or a new pane's ready consumes it. A dead socket swallows its send; a
+            # live pane lands the focus; the one thing that no longer happens is a park nobody consumes.
+            if boot or c.get("pingAt") is not None:
                 sent.append(c)
         except Exception:
             pass
@@ -45044,7 +45054,7 @@ def _reveal_request(sid, wid, boot=False, via=""):
         _PENDING_REVEAL[0] = {"sid": str(sid), "wid": str(wid or "")}
     elif sent:
         _PENDING_REVEAL[0] = {"sid": str(sid), "wid": str(wid or ""), "sent": sent}
-    outcome = ("delivered, copy parked (target unproven)" if sent else "delivered") if delivered else "parked"
+    outcome = ("delivered, copy parked (%s)" % ("booting page" if boot else "target unproven") if sent else "delivered") if delivered else "parked"
     print("[reveal] %s sid=%s wid=%s%s: %s" % (via or "shell", str(sid)[:8], str(wid or "")[:8],
                                              " boot" if boot else "", outcome), file=sys.stderr)
     return delivered

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -44967,8 +44967,9 @@ def _sw_js():
 
 # ── landing a push tap on the session that fired ─────────────────────────────────────────────────
 # The cold-start half of a tap: the app was closed, the page opened on the deep link (the worker's
-# openWindow, or iOS's own navigate), and the shell POSTs /reveal {sid, wid} at boot — necessarily
-# BEFORE its chat pane's WS exists, so the focus cannot be sent yet. It parks here and is delivered on the exact event it was waiting
+# openWindow, or iOS's own navigate), and the shell POSTs /reveal {sid, wid} at boot — usually BEFORE
+# its chat pane's WS exists (on a slow machine the pane's ready comes first, T312, and the reveal is
+# then delivered to it at once with a copy kept here). Otherwise it parks here and is delivered on the exact event it was waiting
 # for: that window's chat pane saying "ready" (matched by wid — the per-dashboard id the shell
 # mints and every same-window pane shares — so a second dashboard's reload cannot steal it). One
 # slot, latest wins: two taps before a boot completes should land on the newer notification.
@@ -45013,16 +45014,20 @@ def _reveal_request(sid, wid, boot=False, via=""):
               wid is usually the PREVIOUS page's (sessionStorage keeps the wid across a reload) —
               dead, and the ping timeout has up to WS_DEAD_S to say so — but it can also be this
               page's own chat pane, when the pane's ready beat the shell's fetch (T312: a slow
-              machine). So a boot reveal is delivered AND kept parked, the unproven rule below, never
-              parked alone: 2026-09-06 to 2026-09-10 it was park-only, and a pane already ready found
-              it parked after its ready had passed, so the tap never landed.
+              machine). So a boot reveal is delivered to every same-wid pane that has said READY and
+              kept parked too, the unproven rule below, never parked alone: 2026-09-06 to 2026-09-10 it
+              was park-only, and a pane already ready found it parked after its ready had passed, so
+              the tap never landed. A same-wid socket that has NOT said ready is no target on any
+              road: its bundle cannot hear a frame yet, and its ready would count as the answer that
+              retires the copy; the park stands for it and its ready consumes.
       unproven — a live tap, but the target has a ping on the wire nobody has answered (pingAt set:
               the peer is unproven since the last heartbeat). Deliver as before AND keep a copy
               parked, tagged with who it went to: the pong that proves that socket alive retires it
               (_note_ws_inbound — the focus frame is ordered behind the ping it answers); a dead
               socket never pongs, the pane redials, and its ready consumes the copy instead of
               finding nothing. A socket with no ping outstanding is proven: nothing parked, so a
-              later ready never replays a landed tap.
+              later ready never replays a landed tap — except on the boot road, where the copy is
+              kept whatever the ping state (above) and the pane's own answer retires it.
 
     One stderr line per tap, whatever became of it (2026-09-08: a phone's tap "did nothing" and
     nothing anywhere recorded whether it had even reached the kernel). `via` is the road the shell
@@ -45032,20 +45037,26 @@ def _reveal_request(sid, wid, boot=False, via=""):
     the pane's ready never came for that wid; consumed — the pane got it. Ids clipped: enough to
     match rows, not a transcript of anything."""
     with _clients_lock:
-        targets = [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid]
+        # Only a pane that has said READY is a target (client["ready"], stamped by the ready handler): a
+        # same-wid chat socket exists from its handshake, but until its bundle posts ready it has no message
+        # listener, so a focus sent to it vanishes — and its ready message, counted as an answer by
+        # _note_ws_inbound, would retire the parked copy before the ready handler could consume it (the
+        # review find on T312). Such a socket is left alone: the park stands and its ready consumes.
+        targets = [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid and c.get("ready")]
     delivered, sent = False, []
     for c in targets:
         try:
             c["send"](json.dumps(_reveal_msg(sid)))
             delivered = True
-            # A booting page's same-wid socket may be the PREVIOUS page's (dead, its pong never coming) — or
-            # this very page's chat pane, whose ready beat the shell's fetch (T312, 2026-09-10: a slow machine
+            # A booting page's same-wid ready socket may be the PREVIOUS page's (dead, its pong never coming) —
+            # or this very page's chat pane, whose ready beat the shell's fetch (T312, 2026-09-10: a slow machine
             # put the pane's ready first, the boot reveal was parked after it with nothing left to consume it,
             # and the tap landed on whichever session frame the pane adopted first). Both wear the same wid and
             # nothing here can tell them apart, so a boot reveal is delivered like an unproven live tap: sent to
-            # every same-wid pane AND kept parked until one of them answers (its pong or next message retires
-            # the copy, _reveal_proven) or a new pane's ready consumes it. A dead socket swallows its send; a
-            # live pane lands the focus; the one thing that no longer happens is a park nobody consumes.
+            # every ready same-wid pane AND kept parked until one of them answers (its pong or next message
+            # retires the copy, _reveal_proven) or a new pane's ready consumes it. A dead socket's send lands
+            # in its queue and nobody reads it; a live pane lands the focus; the one thing that no longer
+            # happens is a park nobody consumes.
             if boot or c.get("pingAt") is not None:
                 sent.append(c)
         except Exception:
@@ -52224,9 +52235,11 @@ class Handler(BaseHTTPRequestHandler):
                 # The cold-start half of a push tap (see _PENDING_REVEAL): the freshly opened
                 # shell asks for the focus its ?push-reveal= URL named, aimed by its own wid so
                 # no other open dashboard gets dragged along (the 2026-07-29 rule).
-                # `boot` (2026-09-06): the deep-link arrival — the page is booting, so its own chat
-                # pane is not connected yet; the kernel parks for it and never counts a same-wid
-                # socket the previous page left behind as delivery (_reveal_request has the why).
+                # `boot` (2026-09-06, widened 2026-09-10 T312): the deep-link arrival — the page is
+                # booting; a same-wid chat socket that has said ready is told (it may be this page's own
+                # pane, whose ready beat this fetch) and a copy stays parked for the pane that is still
+                # to come, so the previous page's dead socket never counts as the only delivery
+                # (_reveal_request has the why).
                 try:
                     body = json.loads(raw_body or b"{}")
                     sid = str(body.get("sid") or "")
@@ -53425,6 +53438,11 @@ class Handler(BaseHTTPRequestHandler):
             # because cached bundles win the race). Same repair as needFull above, client-wide;
             # ready is posted once per renderer life, so this cannot loop.
             _client_reset_chat_base(client)
+            # From here the pane's bundle LISTENS: a frame sent before this point landed in a document with
+            # no message listener and vanished (the paragraph above). _reveal_request delivers a tap only to
+            # a pane that has said ready and parks for the rest (T312), so the socket's own `ready` message,
+            # which _note_ws_inbound counts as an answer, can never retire a focus this pane never heard.
+            client["ready"] = True
             # Capture the seq of the views blob the pushes below serve — from the frames THIS thread
             # enqueues, so a pusher-thread frame landing meanwhile is not mistaken for the connect push's
             # (the caps frame's viewsSeq, see KERNEL_WS_CAPS)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -53438,11 +53438,6 @@ class Handler(BaseHTTPRequestHandler):
             # because cached bundles win the race). Same repair as needFull above, client-wide;
             # ready is posted once per renderer life, so this cannot loop.
             _client_reset_chat_base(client)
-            # From here the pane's bundle LISTENS: a frame sent before this point landed in a document with
-            # no message listener and vanished (the paragraph above). _reveal_request delivers a tap only to
-            # a pane that has said ready and parks for the rest (T312), so the socket's own `ready` message,
-            # which _note_ws_inbound counts as an answer, can never retire a focus this pane never heard.
-            client["ready"] = True
             # Capture the seq of the views blob the pushes below serve — from the frames THIS thread
             # enqueues, so a pusher-thread frame landing meanwhile is not mistaken for the connect push's
             # (the caps frame's viewsSeq, see KERNEL_WS_CAPS)
@@ -53473,6 +53468,12 @@ class Handler(BaseHTTPRequestHandler):
                 except Exception:
                     views_seq = None
             _send_caps(client, views_seq=views_seq)
+            # From here the pane LISTENS and holds its frames (the push above): a tap that arrives now is sent
+            # to it directly (_reveal_request targets panes with this stamp only, T312: a socket registered at
+            # its handshake but still loading its bundle has no listener, and its own `ready` message counts
+            # as an answer to _note_ws_inbound, so a frame sent to it earlier was lost and its copy retired);
+            # one that arrived before this point parked, and is consumed right below.
+            client["ready"] = True
             # a push tap parked a reveal for this window's chat pane → deliver it now, AFTER the
             # ready push, so the tab it names already exists on the client (ordered socket)
             _consume_pending_reveal(client)

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -1310,6 +1310,36 @@ class RevealAiming(unittest.TestCase):
             km._consume_pending_reveal(mine)
             self.assertEqual(len(mine_got), 1, "consumed means consumed")
 
+    def test_a_boot_reveal_reaches_a_pane_whose_ready_beat_the_fetch_and_keeps_a_copy(self):
+        """T312 (2026-09-10): on a slow machine the page's chat pane can say ready BEFORE the shell's boot fetch
+        parks the reveal, and a park nobody consumes lands the tap on whichever session frame the pane adopted
+        first. A boot reveal therefore goes to every same-wid chat pane like an unproven live tap: delivered
+        AND kept parked (the same-wid socket may be the previous page's, dead), retired by the pane's answer
+        or consumed by a new pane's ready. Before the fix a boot reveal was parked alone."""
+        mine, mine_got = self._register("chat", "W-phone")   # ready already, no ping outstanding
+        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
+            self.assertTrue(km._reveal_request("SID-live", "W-phone", boot=True, via="link"), "delivered to the ready pane")
+        self.assertEqual(mine_got, [{"type": "focus", "id": "SID-live", "live": True}])
+        parked = km._PENDING_REVEAL[0]
+        self.assertEqual((parked["sid"], parked["wid"]), ("SID-live", "W-phone"))
+        self.assertEqual(parked.get("sent"), [mine], "…and a copy stays parked, tagged with who got it")
+        # the pane answers (a pong, any message): the copy is retired, so a later ready never replays the tap
+        km._reveal_proven(mine)
+        self.assertIsNone(km._PENDING_REVEAL[0])
+        # the previous page's DEAD socket wears the same wid: its send fails, nothing is delivered, the park
+        # stands for the real pane's ready — the cold-start norm, unchanged
+        dead, _ = self._register("chat", "W-tablet")
+        dead["send"] = lambda s: (_ for _ in ()).throw(OSError("socket closed"))
+        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
+            self.assertFalse(km._reveal_request("SID-live", "W-tablet", boot=True, via="link"))
+        self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-live", "wid": "W-tablet"})
+        real, real_got = _fake_ws_client("chat", "W-tablet")
+        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
+            km._consume_pending_reveal(real)
+        self.assertEqual(real_got, [{"type": "focus", "id": "SID-live", "live": True}])
+        self.assertIsNone(km._PENDING_REVEAL[0])
+
+
     def test_a_widless_park_matches_the_first_chat_pane(self):
         # sessionStorage blocked → the shell has no wid; better the first chat pane than a dropped tap
         with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
@@ -1318,17 +1348,21 @@ class RevealAiming(unittest.TestCase):
             km._consume_pending_reveal(c)
         self.assertEqual(got[0]["id"], "S")
 
-    def test_a_booting_page_parks_past_the_previous_pages_socket(self):
-        # the deep-link arrival (2026-09-06, the phone): the page is BOOTING, so its own chat pane
-        # cannot be connected yet — a same-wid chat socket the kernel still holds is the PREVIOUS
-        # page's (sessionStorage keeps the wid across a reload; a suspended phone never sent its
-        # close, and the ping timeout has up to WS_DEAD_S to notice). "Delivering" there parked
-        # nothing, and the new pane's ready found nothing to consume.
+    def test_a_booting_page_reaches_a_same_wid_socket_and_still_parks_for_the_fresh_panes_ready(self):
+        # the deep-link arrival (2026-09-06, the phone): the page is BOOTING, and a same-wid chat socket the
+        # kernel still holds is usually the PREVIOUS page's (sessionStorage keeps the wid across a reload; a
+        # suspended phone never sent its close, and the ping timeout has up to WS_DEAD_S to notice). From
+        # 2026-09-06 to 2026-09-10 a boot reveal was therefore parked ALONE — until T312 found the other owner
+        # of that wid: this page's own chat pane, whose ready beat the shell's fetch on a slow machine, so the
+        # park had nothing left to consume it and the tap never landed. Now the boot reveal is delivered to
+        # the same-wid socket like an unproven live tap AND a copy stays parked: a dead twin swallows its
+        # frame and the fresh pane's ready consumes the copy; a live pane lands it and its answer retires it.
         twin, twin_got = self._register("chat", "W-phone")
         with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
-            self.assertFalse(km._reveal_request("S", "W-phone", boot=True))
-            self.assertEqual(twin_got, [], "a booting page's tap is never aimed at a socket that predates it")
-            self.assertEqual(km._PENDING_REVEAL[0], {"sid": "S", "wid": "W-phone"})
+            self.assertTrue(km._reveal_request("S", "W-phone", boot=True))
+            self.assertEqual(twin_got, [{"type": "focus", "id": "S", "live": True}], "the same-wid socket is told: it may be the page's own pane")
+            parked = km._PENDING_REVEAL[0]
+            self.assertEqual((parked["sid"], parked["wid"], parked.get("sent")), ("S", "W-phone", [twin]), "…and the copy stays for the fresh pane")
             fresh, fresh_got = _fake_ws_client("chat", "W-phone")
             km._consume_pending_reveal(fresh)
         self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True}])
@@ -1411,21 +1445,24 @@ class RevealRoute(unittest.TestCase):
         self.assertEqual(code, 400)
         self.assertIsNone(km._PENDING_REVEAL[0])
 
-    def test_a_boot_flagged_reveal_parks_even_past_a_connected_same_wid_pane(self):
-        # the deep-link arrival says it is booting; the kernel parks for the pane that is about to
-        # connect and never counts the previous page's socket as delivery (RevealAiming has the why)
+    def test_a_boot_flagged_reveal_reaches_a_connected_same_wid_pane_and_keeps_a_copy_parked(self):
+        # the deep-link arrival says it is booting; a connected same-wid pane may be the previous page's dead
+        # socket OR this page's own pane whose ready beat the fetch (T312), so the route delivers to it AND keeps
+        # the copy parked for the pane that is about to connect (RevealAiming has the why)
         twin, twin_got = _fake_ws_client("chat", "W-x")
         with km._clients_lock:
             km._clients.append(twin)
         try:
-            code, body = self._post("/reveal", {"sid": "SID-x", "wid": "W-x", "boot": True})
+            with mock.patch.object(km, "_tmux_sessions", return_value={"SID-x": {}}):
+                code, body = self._post("/reveal", {"sid": "SID-x", "wid": "W-x", "boot": True})
         finally:
             with km._clients_lock:
                 km._clients.remove(twin)
         self.assertEqual(code, 200)
-        self.assertFalse(json.loads(body)["delivered"])
-        self.assertEqual(twin_got, [])
-        self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-x", "wid": "W-x"})
+        self.assertTrue(json.loads(body)["delivered"])
+        self.assertEqual(twin_got, [{"type": "focus", "id": "SID-x", "live": True}])
+        parked = km._PENDING_REVEAL[0]
+        self.assertEqual((parked["sid"], parked["wid"], parked.get("sent")), ("SID-x", "W-x", [twin]))
 
     def test_every_tap_leaves_a_line_in_the_kernel_log(self):
         # 2026-09-08: a phone's tap "did nothing" and nothing recorded whether it had reached the kernel.

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -1248,7 +1248,7 @@ class PushLedger(unittest.TestCase):
 def _fake_ws_client(app, wid):
     """Just enough of a _clients row for the reveal/badge paths: send() records the parsed JSON."""
     got = []
-    return {"app": app, "wid": wid, "alive": True,
+    return {"app": app, "wid": wid, "alive": True, "ready": True,   # ready: its bundle listens (the ready handler's stamp)
             "send": lambda s: got.append(json.loads(s))}, got
 
 
@@ -1322,22 +1322,41 @@ class RevealAiming(unittest.TestCase):
         self.assertEqual(mine_got, [{"type": "focus", "id": "SID-live", "live": True}])
         parked = km._PENDING_REVEAL[0]
         self.assertEqual((parked["sid"], parked["wid"]), ("SID-live", "W-phone"))
-        self.assertEqual(parked.get("sent"), [mine], "…and a copy stays parked, tagged with who got it")
+        self.assertEqual(len(parked.get("sent") or []), 1); self.assertIs(parked["sent"][0], mine, "…and a copy stays parked, tagged with who got it")
         # the pane answers (a pong, any message): the copy is retired, so a later ready never replays the tap
         km._reveal_proven(mine)
         self.assertIsNone(km._PENDING_REVEAL[0])
-        # the previous page's DEAD socket wears the same wid: its send fails, nothing is delivered, the park
-        # stands for the real pane's ready — the cold-start norm, unchanged
-        dead, _ = self._register("chat", "W-tablet")
-        dead["send"] = lambda s: (_ for _ in ()).throw(OSError("socket closed"))
+
+    def test_a_same_wid_socket_that_has_not_said_ready_is_no_target_and_its_ready_still_consumes(self):
+        """The review find on T312: a chat socket exists from its handshake, but until its bundle posts `ready`
+        it has no message listener (the ready handler's own paragraph: frames sent before it vanish), and the
+        kernel counts that ready message as an answer (_note_ws_inbound → _reveal_proven). Delivering a boot
+        reveal to such a socket lost the tap twice over: the frame vanished, and the ready retired the parked
+        copy before the handler could consume it. So a not-yet-ready socket is no target on any road: the park
+        stands, and the ready handler stamps the client and consumes."""
+        booting, heard = self._register("chat", "W-boot")
+        dropped = []
+        booting["ready"] = False          # registered at its handshake; the bundle is still loading
+        booting["send"] = lambda s: (heard if booting.get("ready") else dropped).append(json.loads(s))   # a frame before ready vanishes
         with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
-            self.assertFalse(km._reveal_request("SID-live", "W-tablet", boot=True, via="link"))
-        self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-live", "wid": "W-tablet"})
-        real, real_got = _fake_ws_client("chat", "W-tablet")
-        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
-            km._consume_pending_reveal(real)
-        self.assertEqual(real_got, [{"type": "focus", "id": "SID-live", "live": True}])
+            self.assertFalse(km._reveal_request("SID-live", "W-boot", boot=True, via="link"), "parked: nothing can hear it yet")
+            self.assertEqual(dropped, [], "nothing is sent to a pane that cannot listen")
+            self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-live", "wid": "W-boot"})
+            # the pane's ready message arrives: _ws notes the inbound (an answer) BEFORE dispatching the handler…
+            km._note_ws_inbound(booting)
+            self.assertIsNotNone(km._PENDING_REVEAL[0], "…which must not retire a copy this pane never heard")
+            # …then the ready handler stamps the client and consumes the park
+            booting["ready"] = True
+            km._consume_pending_reveal(booting)
+        self.assertEqual(heard, [{"type": "focus", "id": "SID-live", "live": True}])
         self.assertIsNone(km._PENDING_REVEAL[0])
+        # a live (non-boot) tap to that same not-yet-ready socket parks too: the sw / ack / vanish roads had the
+        # same hole once the shell saw the socket up but before the bundle listened
+        with mock.patch.object(km, "_tmux_sessions", return_value={"SID-live": {}}):
+            booting["ready"] = False
+            self.assertFalse(km._reveal_request("SID-live", "W-boot", via="sw"))
+            self.assertEqual(dropped, [])
+            self.assertEqual(km._PENDING_REVEAL[0], {"sid": "SID-live", "wid": "W-boot"})
 
 
     def test_a_widless_park_matches_the_first_chat_pane(self):

--- a/tests/test_notification_tap_resume_browser.py
+++ b/tests/test_notification_tap_resume_browser.py
@@ -153,8 +153,11 @@ try { browser = await chromium.launch(); }
 catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
 const out = { reveals: [], ledger: [] };
 const context = await browser.newContext({ viewport: { width: 1100, height: 720 } });
-// T312 trace: in every frame, wrap the federation layer's inbound the moment it is published, so the order of
-// frames the chat pane processed at boot (tabOrder, sessions, the focus) and the active tab after each is on record
+// T312 trace: in every frame, wrap the federation layer's inbound the moment it is published (federation.ts assigns
+// window.__rompFed once, by plain assignment; every reader goes through the getter by truthiness, and before the
+// manager starts the getter answers undefined, so a page that never publishes reads as before). The order of frames
+// the chat pane processed at boot (tabOrder, sessions, the focus) and the active tab after each is on record; the
+// list grows for the page's life, which is seconds here
 await context.addInitScript(() => {
   const w = window; w.__frames = [];
   let fed = undefined;

--- a/tests/test_notification_tap_resume_browser.py
+++ b/tests/test_notification_tap_resume_browser.py
@@ -28,7 +28,8 @@ Three scenarios against the REAL shell, the REAL worker and the REAL kernel (her
      granted the way a real click grants it.)
   2. THE LINK ROAD (what an iOS tap produces): the page is navigated to the deep link the declarative message's
      `navigate` names — '/?push-reveal=<api>&push-pid=<pid>' — as iOS does on a tap. The page must land it at boot:
-     ONE /reveal via 'link' with boot:true, parked by the kernel and consumed on the chat pane's ready (the tab
+     ONE /reveal via 'link' with boot:true, parked by the kernel and consumed on the chat pane's ready, or delivered
+     at once when that pane's ready beat the fetch (T312: a copy stays parked until the pane answers) (the tab
      becomes `api`), /push/landed for the pid, the params stripped from the URL (and the ?token= it was opened
      with, which the shell drops once the cookie is set), the 'deeplink' row on file. Then the open page GAINS the
      params without a load (history.pushState + pageshow, the window iOS navigates in place) for a second push:
@@ -152,6 +153,19 @@ try { browser = await chromium.launch(); }
 catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
 const out = { reveals: [], ledger: [] };
 const context = await browser.newContext({ viewport: { width: 1100, height: 720 } });
+// T312 trace: in every frame, wrap the federation layer's inbound the moment it is published, so the order of
+// frames the chat pane processed at boot (tabOrder, sessions, the focus) and the active tab after each is on record
+await context.addInitScript(() => {
+  const w = window; w.__frames = [];
+  let fed = undefined;
+  Object.defineProperty(w, "__rompFed", { configurable: true, get() { return fed; }, set(v) {
+    fed = v;
+    if (v && typeof v.inbound === "function" && !v.__traced) {
+      const orig = v.inbound.bind(v); v.__traced = true;
+      v.inbound = (h, m) => { try { w.__frames.push([Math.round(performance.now()), h, m && m.type, m && (m.id || (Array.isArray(m.order) ? "order:" + m.order.length : "")), (document.querySelector("#tabs .tab.active") || {}).dataset?.id || null]); } catch {} return orig(h, m); };
+    }
+  } });
+});
 const page = await context.newPage();
 page.on("request", (r) => { const u = r.url();
   if (r.method() === "POST" && /\/reveal$/.test(u)) out.reveals.push(JSON.parse(r.postData() || "{}"));
@@ -163,6 +177,7 @@ if (!chat) { console.error("no chat iframe in the shell"); process.exit(1); }
 const active = () => chat.evaluate(() => (document.querySelector("#tabs .tab.active") || { dataset: {} }).dataset.id || null);
 out.landed = await chat.waitForFunction((sid) => (document.querySelector("#tabs .tab.active") || {}).dataset?.id === sid, cfg.sidB, { timeout: 20000 }).then(() => true).catch(() => false);
 out.after = await active();
+out.frames = await chat.evaluate(() => (window.__frames || []).slice(0, 60));   // T312 trace
 out.urlAfterBoot = page.url();
 out.cookies = (await context.cookies(cfg.origin)).map((c) => ({ name: c.name, value: c.value }));   // the token's home once the address drops it
 for (let i = 0; i < 40 && !out.ledger.length; i++) await page.waitForTimeout(50);
@@ -475,18 +490,8 @@ class ServedTapLanding(unittest.TestCase):
         link2 = "/?push-reveal=%s&push-pid=%s" % (SID_B, pid2)
         out = self._drive(DRIVER_LINK, link=link, link2=link2)
         # THE OUTCOME first: the page booted on the link and the chat pane is on api
-        if not out["landed"] and os.environ.get("ROMP_SERVED_TESTS_REQUIRE") == "1":
-            # Optional under the CI switch, and ONLY this assertion, until T312 lands: a boot race in the chat pane
-            # flips the landed tab on a slow machine (seen once on the CI runner, 2026-09-10: the kernel parked the
-            # boot reveal and delivered it on the pane's ready, yet the active tab ended on another session, so a
-            # default-active pick, or the tab set arriving after the focus, won over the reveal's own delivery).
-            # T312 keys the landing on the reveal's delivery, restores this line to required red-first, and pins
-            # it. Locally the assertion below still fails, so a developer sees the race; the `optional:` prefix is
-            # what tests/conftest.py leaves as a skip when the switch is on.
-            self.skipTest("optional: the boot race T312 flipped the landed tab to %r on this runner; the page posted %d /reveal(s); kernel: %s"
-                          % (out["after"], len(out["boot"]["reveals"]), self._reveal_lines()))
-        self.assertTrue(out["landed"], "the chat pane's active tab must become the session the link names; it is %r, the page posted %d /reveal(s)\n  kernel: %s\n  reveals: %r"
-                        % (out["after"], len(out["boot"]["reveals"]), self._reveal_lines(), out["boot"]["reveals"]))
+        self.assertTrue(out["landed"], "the chat pane's active tab must become the session the link names; it is %r, the page posted %d /reveal(s)\n  kernel: %s\n  reveals: %r\n  frames (t, host, type, id, active-after): %r"
+                        % (out["after"], len(out["boot"]["reveals"]), self._reveal_lines(), out["boot"]["reveals"], out.get("frames")))
         self.assertEqual(out["after"], SID_B)
         b = out["boot"]
         self.assertEqual(len(b["reveals"]), 1, "exactly one /reveal at boot: %r" % b["reveals"])
@@ -516,9 +521,10 @@ class ServedTapLanding(unittest.TestCase):
                 break
             time.sleep(0.1)
         self.assertTrue((self._row(pid) or {}).get("landedAt") and (self._row(pid2) or {}).get("landedAt"), "both rows landed on the kernel: %r %r" % (self._row(pid), self._row(pid2)))
-        # the kernel's trail: the boot's park consumed on the pane's ready; the later one delivered live; both settled
+        # the kernel's trail: the boot reveal parked (the pane not yet up) or delivered with a copy parked (the pane's
+        # ready beat the fetch, T312) — either road lands; the later one delivered live; both settled
         klog = self._klog()
-        self.assertRegex(klog, r"\[reveal\] link sid=%s wid=\S+ boot: parked" % re.escape(SID_B[:8]), "the boot parked: %s" % self._reveal_lines())
+        self.assertRegex(klog, r"\[reveal\] link sid=%s wid=\S+ boot: (parked|delivered, copy parked \(booting page\))" % re.escape(SID_B[:8]), "the boot reveal: %s" % self._reveal_lines())
         self.assertRegex(klog, r"\[reveal\] link sid=%s wid=\S+: delivered" % re.escape(SID_B[:8]), "the in-place arrival delivered live: %s" % self._reveal_lines())
         self.assertEqual(len(re.findall(r"\[push\] landed sid=%s endpoint=web.push.apple.com" % re.escape(SID_B[:8]), klog)), 2)
         # the shell's trail: the deeplink rows, boot then pageshow, structure only


### PR DESCRIPTION
A notification tap could land the chat on the wrong session (the tap-landing browser test's deep-link scenario failed once on the CI runner and once on the devbox): the kernel parked the boot reveal for the chat pane's ready, but on a slow machine that pane's ready had already passed, so nothing consumed the park, no focus frame ever reached the pane, and the pane adopted whichever session frame arrived first (the frame trace the test now records shows exactly that: tab order, four session frames with the first adopted, no focus).

Cause: `_reveal_request` treated a `boot` reveal as park-only, on the reasoning that a same-wid chat socket during a boot must be the previous page's dead socket. The other owner of that wid is the page's own chat pane when its ready beats the shell's fetch. Fix, event-keyed and without a timer: a boot reveal is delivered to every same-wid chat pane that has said `ready` like an unproven live tap, and a copy stays parked; the pane's answer retires the copy (`_reveal_proven`), a dead previous-page socket queues its frame unread and the fresh pane's ready consumes the copy as before. The ready gate came out of the lean review: a same-wid socket exists from its WebSocket handshake, but until its bundle posts `ready` it has no message listener (a frame sent to it vanishes) and the kernel counts that ready message as an answer, so delivering to it would have lost the tap twice over. The ready handler now stamps `client["ready"]`, and `_reveal_request` targets only stamped panes on every road (the worker, ack and vanish roads had the same hole once the shell saw the socket up but before the bundle listened), parking for the rest. The one thing that no longer happens is a park nobody consumes.

Tests (red-first): `tests/test_kernel_webpush.py` gains the boot-beats-fetch pin (a ready same-wid pane gets the focus and a copy stays parked until the pane answers) and the not-yet-ready pin (a registered socket whose bundle has not said ready gets nothing, its ready message does not retire the park, and the ready handler's consume lands the focus; the same for a live tap), and its two boot-parks-only pins are re-anchored to the new rule; the served deep-link landing assertion in `tests/test_notification_tap_resume_browser.py` is required again under the CI switch (it was made optional with this task named when the CI gap closed), its kernel-trail pin accepts both roads, and its driver records the frames the chat pane processed at boot so the next such failure names its order. The whole tap file ran six times in a row behind a slot without a failure; the webpush pins pass.

On the other timing failure seen in this file today (the click scenario's "the push settled before the click was dispatched", reported from a full run under two concurrent suites): that assertion compared the positions of the worker's two ack lines in the kernel log, whose requests ride separate connections the kernel serves on separate threads, so their order was never a fact of the design. It was dropped when the served-page tests joined CI earlier today (the ack-order commit of that PR), so a checkout at or after that merge no longer has it; no other order or clock compare remains in the file (the vanish scenario's remaining count is an event count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


