### PR TITLE
Test-root sweep: the chmod retry re-modes only directories inside the tombstone, never its parent or a symlink's target

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2341,16 +2341,24 @@ def _rmtree_stubborn(root: str) -> None:
     """rmtree that gets past a child with its permission bits cleared (a 000-mode directory some suite
     tests create and restore only in a finally that an os._exit skipped): on the first failure at a
     path, restore owner rwx on it and its parent and retry that step once. Raises on a second failure
-    so the caller can leave the tombstone standing and say so."""
+    so the caller can leave the tombstone standing and say so. Only `root` and directories inside it
+    are re-moded: the root's parent is not ours, and a chmod of a symlink would land on its target."""
     def onexc(func, path, exc):
         # `func` is whichever os call failed (3.12's fd-based rmtree hands over os.open, os.scandir,
         # os.rmdir, os.unlink with their own signatures), so it is not called back: the subtree at
         # `path` is removed again plainly after the chmod, and a second failure raises.
-        try:
-            os.chmod(os.path.dirname(path), 0o700)
-            os.chmod(path, 0o700)
-        except OSError:
-            pass
+        # Re-mode only directories of the tombstone's own tree. rmtree hands over the root or a
+        # descendant, so the parent is outside the tree exactly when `path` is the root (a failed
+        # rmdir of the root, or a root a peer already removed, must not chmod the system temp dir);
+        # and os.chmod follows a symlink, so a link inside a read-only child is left alone (its
+        # target may be anywhere). Unlink needs the parent's write bit, never the entry's own mode,
+        # so a non-directory never needed the chmod.
+        for p in ([os.path.dirname(path)] if path != root else []) + [path]:
+            if os.path.isdir(p) and not os.path.islink(p):
+                try:
+                    os.chmod(p, 0o700)
+                except OSError:
+                    pass
         if os.path.isdir(path) and not os.path.islink(path):
             shutil.rmtree(path)
         elif os.path.lexists(path):

--- a/tests/README.md
+++ b/tests/README.md
@@ -102,7 +102,15 @@ child processes (kernels, git, a shell's `mktemp -d`), `mkstemp` files,
 `os.mkdir` paths — by pointing the process temp dir (`tempfile.tempdir` and
 `TMPDIR`, so every child inherits it) at one private `romp-tests-*` root under
 the system temp dir and removing the root when the run ends (before both, a
-full run left ~5,600 entries in `/tmp` and over a million had piled up). Still
+full run left ~5,600 entries in `/tmp` and over a million had piled up). A run
+that dies before that removal (pytest-timeout's `os._exit`, a killed shell)
+leaves the root standing, so conftest also writes an owner marker,
+`romp-tests-owner.json` naming the run's pid, into the root at mint time. The
+kernel's boot reconcile (`sweep_dead_test_roots` in `kernel/sdk_backend.py`)
+removes `romp-tests-*` roots under the system temp dir whose marker names a
+dead pid, renaming each to `<name>.sweeping` before deleting it so a partial
+delete leaves a tombstone the next boot finishes. A root without a marker (a
+foreign directory, a pre-marker root) is never touched by the sweep. Still
 clean up what you create — `with tempfile.TemporaryDirectory()`,
 `self.addCleanup(shutil.rmtree, ...)`, a `tearDownClass` for a class-level
 fixture — so a fixture is gone when its test is, not at exit; bats suites use

--- a/tests/test_test_root_sweep.py
+++ b/tests/test_test_root_sweep.py
@@ -11,12 +11,16 @@ reconcile sweeps roots under the system temp dir whose marker names a dead pid.
 Pinned: a root whose owner is dead goes; a root whose owner is alive stays (this process is the
 owner); a root with no marker, an unreadable marker or a foreign name stays — refusing is the safe
 direction; the running suite's own root carries a marker naming this process; the marker file name
-agrees between conftest and the kernel; and _boot_reconcile calls the sweep. Everything is built
-under this test's own temp dir (itself inside the run's root), never in the real system temp dir.
+agrees between conftest and the kernel; the chmod retry re-modes only directories of the tombstone's
+own tree (never its parent, never a symlink's target, never a hard-linked file); and _boot_reconcile
+calls the sweep.
+Everything is built under this test's own temp dir (itself inside the run's root), never in the
+real system temp dir.
 """
 import inspect
 import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -122,6 +126,92 @@ class DeadOwnerSweep(unittest.TestCase):
             if os.path.isdir(locked):
                 os.chmod(locked, 0o700)
         self.assertFalse(os.path.exists(dead))
+
+    def _read_only_children(self, dead: str, names):
+        """One read-only child of `dead` per name, restored (wherever the sweep left it: under the root
+        or under the tombstone) once the test is over, so the run's own temp root can go at run end."""
+        children = {n: os.path.join(dead, "deep", n) for n in names}
+        for c in children.values():
+            os.makedirs(c)
+
+        def restore():
+            for base in (dead, dead + sb.TEST_ROOT_TOMBSTONE):
+                for n in names:
+                    c = os.path.join(base, "deep", n)
+                    if os.path.isdir(c) and not os.path.islink(c):
+                        os.chmod(c, 0o700)
+        self.addCleanup(restore)
+        return children
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores the read-only bit; the retry never runs")
+    def test_chmod_retry_never_follows_a_symlink_out_of_the_root(self):
+        # A symlink inside a read-only child: unlinking it fails once (the parent lacks the write
+        # bit), the retry re-modes the parent, and the link itself is left alone. os.chmod follows
+        # a symlink, so a chmod of the link would land on its target, which can be anywhere. One
+        # link per read-only child, because the first failure re-modes that child and the rest of
+        # its entries then go without a retry: a link to a file and a link to a directory each get
+        # their own (a directory target is the one os.path.isdir follows).
+        outside_file = os.path.join(self.tmp, "outside.txt")
+        with open(outside_file, "w") as fh:
+            fh.write("x")
+        os.chmod(outside_file, 0o644)
+        outside_dir = os.path.join(self.tmp, "outside-dir")
+        os.makedirs(outside_dir)
+        os.chmod(outside_dir, 0o755)
+        dead = _root(self.tmp, "romp-tests-linky", {"pid": _dead_pid()})
+        ro = self._read_only_children(dead, ("ro-file", "ro-dir"))
+        os.symlink(outside_file, os.path.join(ro["ro-file"], "link"))
+        os.symlink(outside_dir, os.path.join(ro["ro-dir"], "link"))
+        for c in ro.values():
+            os.chmod(c, 0o555)
+        self.assertEqual(sb.sweep_dead_test_roots(self.tmp), 1)
+        self.assertFalse(os.path.exists(dead))
+        self.assertEqual(stat.S_IMODE(os.stat(outside_file).st_mode), 0o644)
+        self.assertEqual(stat.S_IMODE(os.stat(outside_dir).st_mode), 0o755)
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores the read-only bit; the retry never runs")
+    def test_chmod_retry_leaves_a_hard_linked_file_alone(self):
+        # A hard link inside a read-only child shares its inode, and so its mode, with a file
+        # outside the root: the retry re-modes the read-only child and never the entry.
+        outside = os.path.join(self.tmp, "shared.txt")
+        with open(outside, "w") as fh:
+            fh.write("x")
+        os.chmod(outside, 0o644)
+        dead = _root(self.tmp, "romp-tests-hardy", {"pid": _dead_pid()})
+        ro = self._read_only_children(dead, ("ro",))["ro"]
+        os.link(outside, os.path.join(ro, "hard"))
+        os.chmod(ro, 0o555)
+        self.assertEqual(sb.sweep_dead_test_roots(self.tmp), 1)
+        self.assertFalse(os.path.exists(dead))
+        self.assertEqual(stat.S_IMODE(os.stat(outside).st_mode), 0o644)
+
+    @unittest.skipIf(os.geteuid() == 0, "root ignores the read-only bit; the retry never runs")
+    def test_a_failure_at_the_tombstone_itself_leaves_the_temp_dir_mode_alone(self):
+        # The final rmdir of the tombstone fails because its PARENT (the temp dir, which is not
+        # ours) is not writable: the parent keeps its mode, the tombstone stands for the next boot,
+        # and the sweep says so.
+        arena = os.path.join(self.tmp, "arena")
+        os.makedirs(arena)
+        tomb = _root(arena, "romp-tests-old" + sb.TEST_ROOT_TOMBSTONE)
+        os.chmod(arena, 0o555)
+        logs = []
+        try:
+            n = sb.sweep_dead_test_roots(arena, log=logs.append)
+            self.assertEqual(stat.S_IMODE(os.stat(arena).st_mode), 0o555)
+        finally:
+            os.chmod(arena, 0o700)
+        self.assertEqual(n, 0)
+        self.assertTrue(os.path.isdir(tomb))
+        self.assertTrue(any("not removed" in line for line in logs), logs)
+
+    def test_a_tombstone_a_peer_already_removed_does_not_re_mode_its_parent(self):
+        # rmtree reports a root that is already gone through the same handler; nothing outside the
+        # root changes.
+        arena = os.path.join(self.tmp, "arena2")
+        os.makedirs(arena)
+        os.chmod(arena, 0o755)
+        sb._rmtree_stubborn(os.path.join(arena, "romp-tests-gone" + sb.TEST_ROOT_TOMBSTONE))
+        self.assertEqual(stat.S_IMODE(os.stat(arena).st_mode), 0o755)
 
     def test_a_leftover_tombstone_is_removed_without_a_marker(self):
         # A previous boot renamed the root and died before finishing: the tombstone is ours by name.


### PR DESCRIPTION
## Symptom

The boot-time removal of a dead test run's `romp-tests-*` root (`sweep_dead_test_roots`, added in #1335) can change the mode of directories and files that are not the root's. Two cases:

- A tombstone whose final `rmdir` fails (the temp dir is not writable, or a straggler of the dead run is still writing under it), or a tombstone another kernel already removed: the system temp dir itself is chmod'ed to 0o700. On a root-owned 1777 `/tmp` a user kernel gets EPERM and the call is swallowed, which is why this went unnoticed; a user-owned `TMPDIR`, or a kernel running as root, has its temp dir silently re-moded, and since the retry then succeeds the sweep counts the root as removed.
- A symlink inside a read-only child of the root: the file or directory the link points to, anywhere on the filesystem, becomes 0o700 before the link is unlinked, and the sweep reports success. A hard link inside such a child re-modes the shared inode the same way. This case is live for every user.

## Cause

`_rmtree_stubborn`'s `onexc` handler (`kernel/sdk_backend.py`) chmod'ed the failing path and its parent with no check that either was inside the tombstone. `shutil.rmtree` hands the handler the root itself when `lstat`, `open` or the final `rmdir` of the root fails, so `dirname(path)` is the system temp dir in those cases. For a child whose `unlink` fails because its parent lacks the write bit, the handler chmod'ed the entry, and `os.chmod` follows a symlink, so the chmod landed on the target. A no-follow chmod is not available here: on Linux, `os.chmod` is outside `os.supports_follow_symlinks` for the interpreter the kernel runs on, and `os.lchmod` does not exist.

## Fix

The handler re-modes only directories of the tombstone's own tree:

- the parent is skipped when `path == root` (`rmtree` only ever hands over the root or a descendant, so the parent is outside the tree only in that case);
- a candidate is chmod'ed only when `os.path.isdir(p) and not os.path.islink(p)`, the idiom the handler already used to choose between `rmtree` and `unlink`.

Restricting the chmod to directories loses nothing the function was written for. Removing an entry needs the write bit on its parent directory, never the entry's own mode, so a regular file, a hard link or a symlink never needed the chmod; the 000-mode directory (a suite fixture restored only in a `finally` that `os._exit` skipped) is a non-link directory inside the tree and is still re-moded and removed.

Behaviour change on the parent case: a tombstone whose final `rmdir` fails on a non-writable parent is now left standing for the next boot, and `sweep_dead_test_roots` logs `dead test root not removed (will retry next boot)` through the branch it already had, instead of the temp dir being re-moded to force the delete through. The line repeats on every boot until the survivor is removed by hand; the parent is not the sweep's to change. A root a peer already removed still returns silently, now without touching the parent. The docstring gains one sentence saying so.

A second commit adds three sentences to the hermetic-temp paragraph of `tests/README.md`, which described only the run-end removal: conftest's owner marker, the boot reconcile that removes roots whose marker names a dead pid, and the `.sweeping` tombstone a partial delete leaves for the next boot.

## Tests

Four tests in `tests/test_test_root_sweep.py` (class `DeadOwnerSweep`), each running the real handler over a private arena inside the run's own temp root. Each is red on the unchanged handler, and together they go red when any one clause of the guard is dropped:

- `test_chmod_retry_never_follows_a_symlink_out_of_the_root`: a 0o644 file and a 0o755 directory outside the root, each the target of a symlink in its own 0o555 child of the root (one link per child, because the first retry re-modes that child and its other entries then go without one). Before: the file reads 0o700 after the sweep (`AssertionError: 448 != 420`). After: the file stays 0o644, the directory 0o755, and the root is still removed (count 1). The directory target is the one `os.path.isdir` follows, so it pins the `islink` clause: with that clause alone dropped, this test fails on the directory (`448 != 493`).
- `test_chmod_retry_leaves_a_hard_linked_file_alone`: a hard link from a 0o555 child of the root to a 0o644 file outside it. Before: the file reads 0o700 (`448 != 420`). After: 0o644, and the root is removed. This pins the `isdir` clause.
- `test_a_failure_at_the_tombstone_itself_leaves_the_temp_dir_mode_alone`: a tombstone under a 0o555 arena. Before: the arena reads 0o700 and the count is 1 (`448 != 365`). After: the arena stays 0o555, the count is 0, the tombstone stands, and the log carries `not removed`.
- `test_a_tombstone_a_peer_already_removed_does_not_re_mode_its_parent`: `_rmtree_stubborn` on a path that is already gone, under a 0o755 arena. Before: the arena reads 0o700 (`448 != 493`). After: 0o755.

The three tests that need the read-only bit enforced skip under euid 0. Each restores what it made read-only once it is over (the two link tests through a cleanup that looks under the root and under the tombstone, wherever a failed removal left the child), so the run's own temp root can still be removed at run end. The existing `test_a_stubborn_child_is_chmoded_and_removed` stays green; the module is 18 passed.

Full pytest suite on this head (six workers): 11608 passed, 45 skipped, 1744 subtests passed, 0 failed, 170 s.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
