### PR TITLE
Postal cards: the kind word at prose weight, its colours one ranked ramp

### DIFF
--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -212,13 +212,27 @@ const measure = () => page.evaluate(() => {
   // the page colour under the text, and the two kind colours, for a contrast check per theme
   const pg = document.createElement("div"); pg.style.background = "var(--bg)"; document.body.appendChild(pg);
   const pageBg = getComputedStyle(pg).backgroundColor; pg.remove();
-  const kinds = {}; const kindWeight = {};
-  for (const k of ["delegate", "coordinate", "question"]) { const e = document.querySelector(".postal-kind-" + k); if (e) { kinds[k] = getComputedStyle(e).color; kindWeight[k] = getComputedStyle(e).fontWeight; } }
-  return { boxBg, pageBg, kinds, kindWeight, theme: document.body.classList.contains("theme-light") ? "light" : "dark", cards, pendingBubbleClass: !!document.querySelector(".queued-bubble") };
+  const kinds = {}; const kindWeight = {}; const kindBoxed = {};
+  for (const k of ["delegate", "coordinate", "question"]) {
+    const e = document.querySelector(".postal-kind-" + k);
+    if (e) {
+      kinds[k] = getComputedStyle(e).color; kindWeight[k] = getComputedStyle(e).fontWeight;
+      const card = e.closest(".turn-postal-service");   // the FIRST word of each kind: measured against the card it sits on
+      kindBoxed[k] = !!(card && card.classList.contains("notice-boxed"));
+    }
+  }
+  return { boxBg, pageBg, kinds, kindWeight, kindBoxed, theme: document.body.classList.contains("theme-light") ? "light" : "dark", cards, pendingBubbleClass: !!document.querySelector(".queued-bubble") };
 });
 const contrast = (a, b) => {
   const lum = (css) => { const m = css.match(/\d+(\.\d+)?/g).slice(0, 3).map(Number).map((v) => v / 255).map((c) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)); return 0.2126 * m[0] + 0.7152 * m[1] + 0.0722 * m[2]; };
   const la = lum(a), lb = lum(b); return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+};
+// a boxed card paints --box-bg, an rgba WASH, over the page: the colour the word actually sits on is the composite (the
+// review of 2026-09-10 found the light coordination step at 4.33:1 there while the page read 4.6:1)
+const composite = (washCss, pageCss) => {
+  const nums = (css) => css.match(/\d+(\.\d+)?/g).map(Number);
+  const w = nums(washCss), p = nums(pageCss), a = w.length > 3 ? w[3] : 1;
+  return "rgb(" + [0, 1, 2].map((i) => Math.round(w[i] * a + p[i] * (1 - a))).join(", ") + ")";
 };
 const results = {};
 let page;
@@ -241,7 +255,14 @@ for (const pass of [{ width: 1000, theme: "dark" }, { width: 520, theme: "dark" 
   await page.evaluate(() => { const c = document.getElementById("content"); if (c) c.scrollTop = c.scrollHeight; });
   await page.waitForTimeout(300);
   const m = await measure();
-  m.contrast = { delegate: m.kinds.delegate ? contrast(m.kinds.delegate, m.pageBg) : null, coordinate: m.kinds.coordinate ? contrast(m.kinds.coordinate, m.pageBg) : null, question: m.kinds.question ? contrast(m.kinds.question, m.pageBg) : null };
+  const boxOnPage = composite(m.boxBg, m.pageBg);
+  m.contrast = {}; m.contrastOn = {}; m.contrastPage = {};
+  for (const k of ["delegate", "coordinate", "question"]) {
+    if (!m.kinds[k]) { m.contrast[k] = null; continue; }
+    m.contrastOn[k] = m.kindBoxed[k] ? "box" : "page";
+    m.contrast[k] = contrast(m.kinds[k], m.kindBoxed[k] ? boxOnPage : m.pageBg);   // against the card the word sits on
+    m.contrastPage[k] = contrast(m.kinds[k], m.pageBg);
+  }
   results[pass.theme === "light" ? (width === 1000 ? "light" : "light" + width) : String(width)] = m;
   if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-postal-cards-" + pass.theme + "-" + width + ".png", fullPage: false }); }
   await page.close();
@@ -433,11 +454,15 @@ class ServedPostalCards(unittest.TestCase):
         # at 520 px and above the head is one line: the ends, the gist and the kind side by side (no wrap)
         for c in wide["cards"] + narrow["cards"]:
             self.assertEqual(c["headWrap"], "nowrap", "wider than the query the head stays one line: %r" % c)
-        # (light theme) the kind colours re-ink for the cream page: text contrast at or above 4.5:1 in both themes
+        # the kind colours read at or above 4.5:1 on the card each word actually sits on, in both themes: a boxed
+        # incoming card paints --box-bg over the page (the review of 2026-09-10 caught the light coordination step at
+        # 4.33:1 there while the bare page read 4.6:1), a slim card is the page itself
         self.assertEqual(light["theme"], "light")
         for k in ("delegate", "coordinate", "question"):
-            self.assertGreaterEqual(light["contrast"][k] or 0, 4.5, "%s reads on the light page: %r" % (k, light["contrast"]))
-            self.assertGreaterEqual(wide["contrast"][k] or 0, 4.5, "%s reads on the dark page: %r" % (k, wide["contrast"]))
+            self.assertGreaterEqual(light["contrast"][k] or 0, 4.5, "%s reads on its light card (%s): %r" % (k, light["contrastOn"].get(k), light["contrast"]))
+            self.assertGreaterEqual(wide["contrast"][k] or 0, 4.5, "%s reads on its dark card (%s): %r" % (k, wide["contrastOn"].get(k), wide["contrast"]))
+            self.assertGreaterEqual(light["contrastPage"][k] or 0, 4.5, "%s reads on the bare light page too" % k)
+        self.assertEqual(light["contrastOn"]["coordinate"], "box", "the first coordination word is on a boxed incoming card: the measurement that matters")
         # T320 (the user 2026-09-10): the kind word wears the prose weight, not bold, in both themes, and its three
         # colours are ONE sequential ramp ranked coordination < delegation < question: monotone in luminance against
         # the page (brighter with rank on the dark page, darker with rank on the light one), as the browser computes them

--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -9,7 +9,7 @@ files (the send-time stamp, and the postal ledger's exec / relayed / bounced / r
 both ENDS wear their sessions' colours (the peer's chip, then this session's own chip); no card wears a background
 wash; incoming cards are boxed, sent ones slim; a sent card whose message has not landed wears the pending
 send's own provisional dress (the queued bubble's class). With POSTAL_SHOTS=<dir> the driver also writes
-screenshots at 1000 px, 520 px, 340 px (the phone width: the head wraps, the ends first, the kind word and the icon on
+screenshots at 1000 px, 520 px, 340 px dark and 1000 px, 340 px light, named romp_chat-postal-cards-<theme>-<width>.png (the phone width: the head wraps, the ends first, the kind word and the icon on
 that line or the next as one unit, the gist last on its own full-width line, T313) and the light theme. Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC
 fixtures only (the notes-api demo world: web / api / tests; host TESTHOST)."""
 import json
@@ -212,9 +212,9 @@ const measure = () => page.evaluate(() => {
   // the page colour under the text, and the two kind colours, for a contrast check per theme
   const pg = document.createElement("div"); pg.style.background = "var(--bg)"; document.body.appendChild(pg);
   const pageBg = getComputedStyle(pg).backgroundColor; pg.remove();
-  const kinds = {};
-  for (const k of ["delegate", "coordinate", "question"]) { const e = document.querySelector(".postal-kind-" + k); if (e) kinds[k] = getComputedStyle(e).color; }
-  return { boxBg, pageBg, kinds, theme: document.body.classList.contains("theme-light") ? "light" : "dark", cards, pendingBubbleClass: !!document.querySelector(".queued-bubble") };
+  const kinds = {}; const kindWeight = {};
+  for (const k of ["delegate", "coordinate", "question"]) { const e = document.querySelector(".postal-kind-" + k); if (e) { kinds[k] = getComputedStyle(e).color; kindWeight[k] = getComputedStyle(e).fontWeight; } }
+  return { boxBg, pageBg, kinds, kindWeight, theme: document.body.classList.contains("theme-light") ? "light" : "dark", cards, pendingBubbleClass: !!document.querySelector(".queued-bubble") };
 });
 const contrast = (a, b) => {
   const lum = (css) => { const m = css.match(/\d+(\.\d+)?/g).slice(0, 3).map(Number).map((v) => v / 255).map((c) => c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)); return 0.2126 * m[0] + 0.7152 * m[1] + 0.0722 * m[2]; };
@@ -222,7 +222,7 @@ const contrast = (a, b) => {
 };
 const results = {};
 let page;
-for (const pass of [{ width: 1000, theme: "dark" }, { width: 520, theme: "dark" }, { width: 340, theme: "dark" }, { width: 1000, theme: "light" }]) {
+for (const pass of [{ width: 1000, theme: "dark" }, { width: 520, theme: "dark" }, { width: 340, theme: "dark" }, { width: 1000, theme: "light" }, { width: 340, theme: "light" }]) {
   const width = pass.width;
   page = await browser.newPage({ viewport: { width, height: 1000 }, deviceScaleFactor: 2 });
   await page.goto(cfg.chat);
@@ -242,8 +242,8 @@ for (const pass of [{ width: 1000, theme: "dark" }, { width: 520, theme: "dark" 
   await page.waitForTimeout(300);
   const m = await measure();
   m.contrast = { delegate: m.kinds.delegate ? contrast(m.kinds.delegate, m.pageBg) : null, coordinate: m.kinds.coordinate ? contrast(m.kinds.coordinate, m.pageBg) : null, question: m.kinds.question ? contrast(m.kinds.question, m.pageBg) : null };
-  results[pass.theme === "light" ? "light" : String(width)] = m;
-  if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-postal-cards-" + (pass.theme === "light" ? "light" : width) + ".png", fullPage: false }); }
+  results[pass.theme === "light" ? (width === 1000 ? "light" : "light" + width) : String(width)] = m;
+  if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-postal-cards-" + pass.theme + "-" + width + ".png", fullPage: false }); }
   await page.close();
 }
 fs.writeSync(1, "RESULT:" + JSON.stringify(results) + "\n");
@@ -349,8 +349,8 @@ class ServedPostalCards(unittest.TestCase):
             else:
                 self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
             self.assertFalse(c["chip"], "no chip: %r" % c)
-        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(176, 140, 255)", "delegation violet")
-        self.assertEqual(card("Heads-up")["kindColor"], "rgb(20, 184, 166)", "coordination teal")
+        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(127, 184, 231)", "delegation: the ramp's middle step (T320)")
+        self.assertEqual(card("Heads-up")["kindColor"], "rgb(121, 150, 175)", "coordination: the ramp's low step (T320)")
         # (2) the delivery icon per state, at the head's right edge, with a worded title
         states = {c["gist"][:20]: c["state"] for c in cards}
         self.assertIsNone(card("Take the retry-loop")["state"], "an incoming message in hand: no icon")
@@ -433,11 +433,28 @@ class ServedPostalCards(unittest.TestCase):
         # at 520 px and above the head is one line: the ends, the gist and the kind side by side (no wrap)
         for c in wide["cards"] + narrow["cards"]:
             self.assertEqual(c["headWrap"], "nowrap", "wider than the query the head stays one line: %r" % c)
-        # (light theme) the two raw kind colours re-ink for the cream page: text contrast at or above 4.5:1
+        # (light theme) the kind colours re-ink for the cream page: text contrast at or above 4.5:1 in both themes
         self.assertEqual(light["theme"], "light")
         for k in ("delegate", "coordinate", "question"):
             self.assertGreaterEqual(light["contrast"][k] or 0, 4.5, "%s reads on the light page: %r" % (k, light["contrast"]))
             self.assertGreaterEqual(wide["contrast"][k] or 0, 4.5, "%s reads on the dark page: %r" % (k, wide["contrast"]))
+        # T320 (the user 2026-09-10): the kind word wears the prose weight, not bold, in both themes, and its three
+        # colours are ONE sequential ramp ranked coordination < delegation < question: monotone in luminance against
+        # the page (brighter with rank on the dark page, darker with rank on the light one), as the browser computes them
+        for m in (wide, light, r["light340"]):
+            self.assertEqual({k: m["kindWeight"][k] for k in ("delegate", "coordinate", "question")},
+                             {"delegate": "400", "coordinate": "400", "question": "400"}, "prose weight: %r" % m["kindWeight"])
+        def _lum(css):
+            r, g, b = [int(x) for x in re.findall(r"\d+", css)[:3]]
+            ch = lambda c: (c / 255) / 12.92 if (c / 255) <= 0.03928 else (((c / 255) + 0.055) / 1.055) ** 2.4
+            return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b)
+        d = [_lum(wide["kinds"][k]) for k in ("coordinate", "delegate", "question")]
+        self.assertTrue(d[0] < d[1] < d[2], "dark page: the ramp brightens with rank: %r" % wide["kinds"])
+        lt = [_lum(light["kinds"][k]) for k in ("coordinate", "delegate", "question")]
+        self.assertTrue(lt[0] > lt[1] > lt[2], "light page: the ramp deepens with rank: %r" % light["kinds"])
+        # the phone-width light pass reads too (the fourth screenshot the user looks at)
+        for k in ("delegate", "coordinate", "question"):
+            self.assertGreaterEqual(r["light340"]["contrast"][k] or 0, 4.5, "%s reads on the light page at 340 px" % k)
 
 
 if __name__ == "__main__":

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -17,19 +17,29 @@ function fn(name: string): string {
 }
 const CARD = fn("renderPostalService");
 
-test("the kind is coloured text in the meta slot, never a chip, in the old chip colours", () => {
+test("the kind is coloured text in the meta slot, never a chip, at prose weight, on one ranked ramp", () => {
   assert.match(RENDER, /import \{ kindLabel, deliveryOf, deliveryTitle[^}]*\} from "\.\/postal-state";/);
   assert.match(CARD, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
   assert.match(CARD, /meta = el\("span", "postal-kind postal-kind-" \+ intent\.cls\); meta\.textContent = kind;/);
   assert.doesNotMatch(CARD, /postal-service-intent|notice-chip/, "no chip");
-  // the two raw colours are TOKENS with light-theme values (2.2:1 and 2.1:1 on the cream page otherwise; review):
-  // 5.4:1 and 5.3:1 there, 6.4:1 and 6.7:1 on the dark page (WCAG text contrast 4.5:1)
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #b08cff\); \}/);
-  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #14b8a6\); \}/);
-  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, var\(--st-working-bg\)\); \}/);
-  assert.match(CSS, /\n  --postal-delegate: #b08cff;\s+--postal-coordinate: #14b8a6;\s+--postal-question: var\(--st-working-bg\);/, "the dark tokens (the old chip colours)");
+  // T320 (the user 2026-09-10): the word is NOT bold (the prose weight), and the three colours are TOKENS on ONE
+  // sequential ramp in the accent's hue, ranked coordination < delegation < question by how much each asks of the
+  // reader, each with a light-theme re-ink (the parity test holds every one at 4.5:1 on its page)
+  assert.match(CSS, /\.postal-kind \{ font-weight: 400; \}/, "prose weight, not bold");
+  assert.doesNotMatch(CSS, /\.postal-kind \{ font-weight: (600|700|bold)/);
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7fb8e7\); \}/);
+  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #7996af\); \}/);
+  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #91d9ff\); \}/);
+  assert.match(CSS, /\n  --postal-coordinate: #7996af;\s+--postal-delegate: #7fb8e7;\s+--postal-question: #91d9ff;/, "the dark ramp, low to high");
   const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
-  assert.match(light, /--postal-delegate: #6e3fd0;\s+--postal-coordinate: #0d6b64;\s+--postal-question: #7d5600;/, "the light tokens re-ink the three kinds (the working amber alone measured 4.26:1 on cream)");
+  assert.match(light, /--postal-coordinate: #a1533a;\s+--postal-delegate: #962b00;\s+--postal-question: #751000;/, "the light ramp, low to high, deepening");
+  // the ramp IS a ramp: in each theme the three steps are monotone in luminance in rank order (brighter with rank on
+  // the dark page, darker with rank on the light one), so the eye reads one scale, not three tags
+  const lumOf = (hex: string) => { const c = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255).map((v) => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)); return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]; };
+  const dark = ["#7996af", "#7fb8e7", "#91d9ff"].map(lumOf), lightRamp = ["#a1533a", "#962b00", "#751000"].map(lumOf);
+  assert.ok(dark[0] < dark[1] && dark[1] < dark[2], "dark: coordination < delegation < question in luminance");
+  assert.ok(lightRamp[0] > lightRamp[1] && lightRamp[1] > lightRamp[2], "light: coordination > delegation > question in luminance");
+  assert.match(CSS, /coordination lowest \(an FYI\), delegation\s+next \(work handed over\), question highest \(an answer owed\)/, "the ranking sits beside the tokens");
   // under the narrow container query the head WRAPS: the gist takes its own full-width line, word-wise, and the kind
   // word keeps the first line whole and inside the card (T313; the 4ch floor that squeezed the gist into a letter
   // column beside the ends is gone)

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -32,11 +32,11 @@ test("the kind is coloured text in the meta slot, never a chip, at prose weight,
   assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #91d9ff\); \}/);
   assert.match(CSS, /\n  --postal-coordinate: #7996af;\s+--postal-delegate: #7fb8e7;\s+--postal-question: #91d9ff;/, "the dark ramp, low to high");
   const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
-  assert.match(light, /--postal-coordinate: #a1533a;\s+--postal-delegate: #962b00;\s+--postal-question: #751000;/, "the light ramp, low to high, deepening");
+  assert.match(light, /--postal-coordinate: #974a32;\s+--postal-delegate: #962b00;\s+--postal-question: #751000;/, "the light ramp, low to high, deepening");
   // the ramp IS a ramp: in each theme the three steps are monotone in luminance in rank order (brighter with rank on
   // the dark page, darker with rank on the light one), so the eye reads one scale, not three tags
   const lumOf = (hex: string) => { const c = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255).map((v) => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)); return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]; };
-  const dark = ["#7996af", "#7fb8e7", "#91d9ff"].map(lumOf), lightRamp = ["#a1533a", "#962b00", "#751000"].map(lumOf);
+  const dark = ["#7996af", "#7fb8e7", "#91d9ff"].map(lumOf), lightRamp = ["#974a32", "#962b00", "#751000"].map(lumOf);
   assert.ok(dark[0] < dark[1] && dark[1] < dark[2], "dark: coordination < delegation < question in luminance");
   assert.ok(lightRamp[0] > lightRamp[1] && lightRamp[1] > lightRamp[2], "light: coordination > delegation > question in luminance");
   assert.match(CSS, /coordination lowest \(an FYI\), delegation\s+next \(work handed over\), question highest \(an answer owed\)/, "the ranking sits beside the tokens");

--- a/ui/webview/postal-intent.test.ts
+++ b/ui/webview/postal-intent.test.ts
@@ -40,5 +40,5 @@ test("the intent reads as coloured TEXT in the postal head's meta slot — no ch
   assert.match(RENDER, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
   assert.doesNotMatch(RENDER, /meta\.push\("delivered"\)/);
   assert.doesNotMatch(CSS, /\.postal-service-intent/);
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #b08cff\); \}/);
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7fb8e7\); \}/);   // the ramp's middle step (T320)
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -94,7 +94,8 @@ body.scheme-solarized-dark {
      three unrelated hues, ranked by how much the kind asks of the reader: coordination lowest (an FYI), delegation
      next (work handed over), question highest (an answer owed). More asking = more intense against the page: on the
      dark page the ramp climbs toward the accent's brightness (OKLCH hue 244, L .66 / .76 / .86; 5.4:1, 7.8:1 and
-     10.8:1 on it); the light theme re-inks the same three ranks toward the deep end of its clay accent (below). */
+     10.8:1 on the page, 5.0:1, 7.3:1 and 9.9:1 on a boxed card, whose --box-bg wash the word also sits on); the light
+     theme re-inks the same three ranks toward the deep end of its clay accent (below). */
   --postal-coordinate: #7996af;  --postal-delegate: #7fb8e7;  --postal-question: #91d9ff;
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
@@ -229,11 +230,14 @@ body.theme-light {
   --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
-  --postal-coordinate: #a1533a;  --postal-delegate: #962b00;  --postal-question: #751000;   /* the kind ramp (T320): the
+  --postal-coordinate: #974a32;  --postal-delegate: #962b00;  --postal-question: #751000;   /* the kind ramp (T320): the
                                                                                             accent's clay hue (OKLCH 38)
-                                                                                            deepening with rank, L .53 /
-                                                                                            .45 / .36; 4.6:1, 6.7:1 and
-                                                                                            9.7:1 on the cream page */
+                                                                                            deepening with rank, L .50 /
+                                                                                            .45 / .36; 5.3:1, 6.7:1 and
+                                                                                            9.6:1 on the cream page and
+                                                                                            5.0:1, 6.2:1 and 9.0:1 on a
+                                                                                            boxed card (the review's
+                                                                                            floor is the box, 4.5:1) */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -90,9 +90,12 @@ body.scheme-solarized-dark {
   --err: #c0392b;   /* unified with the awaiting/blocked red (the user 2026-06-24): one "needs you" red. API-error (--st-blocked-bg #e5484d) stays distinct. */
   --warn: #d7a23a;  /* the heads-up amber — "attention, not an error". Was referenced with fallbacks but never
                        defined (a phantom token) until 2026-08-26; mirrored in feed.css (own :root). */
-  /* the postal card's two KIND colours (T302): the pre-rewrite chip colours as text on the dark page (6.4:1 and
-     6.7:1); the light theme re-inks both (they read 2.2:1 and 2.1:1 on cream otherwise) */
-  --postal-delegate: #b08cff;  --postal-coordinate: #14b8a6;  --postal-question: var(--st-working-bg);
+  /* the postal card's three KIND colours (T320, the user 2026-09-10): one SEQUENTIAL ramp in the accent's hue, not
+     three unrelated hues, ranked by how much the kind asks of the reader: coordination lowest (an FYI), delegation
+     next (work handed over), question highest (an answer owed). More asking = more intense against the page: on the
+     dark page the ramp climbs toward the accent's brightness (OKLCH hue 244, L .66 / .76 / .86; 5.4:1, 7.8:1 and
+     10.8:1 on it); the light theme re-inks the same three ranks toward the deep end of its clay accent (below). */
+  --postal-coordinate: #7996af;  --postal-delegate: #7fb8e7;  --postal-question: #91d9ff;
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
@@ -226,9 +229,11 @@ body.theme-light {
   --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
-  --postal-delegate: #6e3fd0;  --postal-coordinate: #0d6b64;  --postal-question: #7d5600;   /* 5.4:1, 5.3:1 and 5.5:1 on the
-                                                                                            cream page (T302); the working
-                                                                                            amber alone read 4.26:1 there */
+  --postal-coordinate: #a1533a;  --postal-delegate: #962b00;  --postal-question: #751000;   /* the kind ramp (T320): the
+                                                                                            accent's clay hue (OKLCH 38)
+                                                                                            deepening with rank, L .53 /
+                                                                                            .45 / .36; 4.6:1, 6.7:1 and
+                                                                                            9.7:1 on the cream page */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
@@ -2427,12 +2432,13 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   .turn-postal-service .notice-head > .notice-gist { flex: 1 0 100%; order: 1; min-width: 0;
     white-space: normal; overflow: visible; text-overflow: clip; overflow-wrap: break-word; }
 }
-/* T302 (the user 2026-09-10): the interaction KIND is coloured TEXT in the meta slot — a chip reads as a tag now — in
-   the colours the old chips wore: delegation violet, coordination teal, question the working amber. */
-.postal-kind { font-weight: 600; }
-.postal-kind-delegate { color: var(--postal-delegate, #b08cff); }
-.postal-kind-coordinate { color: var(--postal-coordinate, #14b8a6); }
-.postal-kind-question { color: var(--postal-question, var(--st-working-bg)); }
+/* T302 (the user 2026-09-10): the interaction KIND is coloured TEXT in the meta slot — a chip reads as a tag now.
+   T320 (the user, later that day): the word wears the prose weight, not bold, and its three colours are one
+   sequential ramp ranked by how much the kind asks of the reader (the tokens' comment has the ranking). */
+.postal-kind { font-weight: 400; }
+.postal-kind-delegate { color: var(--postal-delegate, #7fb8e7); }
+.postal-kind-coordinate { color: var(--postal-coordinate, #7996af); }
+.postal-kind-question { color: var(--postal-question, #91d9ff); }
 /* BOTH ENDS of a postal card in the head, each in its session's identity colour (the peer's chip as before, and this
    session's own chip after it); a narrow head collapses this session's chip to its coloured dot, so both colours
    still show where the words would not fit */

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -61,9 +61,12 @@ const PAIRS: Array<[string, string, number]> = [
   ["--green", "--bg", 3],
   ["--code-fg", "--bg", 4.5],
   ["--text-muted", "--surface-raised", 4.5],
-  ["--postal-coordinate", "--bg", 4.5],   // the postal kind word's three-step ramp (T320): text, so 4.5:1 on the page in both themes
+  ["--postal-coordinate", "--bg", 4.5],   // the postal kind word's three-step ramp (T320): text, so 4.5:1 on the page in both themes...
   ["--postal-delegate", "--bg", 4.5],
   ["--postal-question", "--bg", 4.5],
+  ["--postal-coordinate", "--box-bg", 4.5],   // ...and on a BOXED card (an incoming message paints --box-bg over --bg), where the
+  ["--postal-delegate", "--box-bg", 4.5],     // review found the light coordination step at 4.33:1 (2026-09-10)
+  ["--postal-question", "--box-bg", 4.5],
   ["--st-working-fg", "--st-working-bg", 3],
   ["--st-ready-fg", "--st-ready-bg", 3],
   ["--st-blocked-fg", "--st-blocked-bg", 3],

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -61,6 +61,9 @@ const PAIRS: Array<[string, string, number]> = [
   ["--green", "--bg", 3],
   ["--code-fg", "--bg", 4.5],
   ["--text-muted", "--surface-raised", 4.5],
+  ["--postal-coordinate", "--bg", 4.5],   // the postal kind word's three-step ramp (T320): text, so 4.5:1 on the page in both themes
+  ["--postal-delegate", "--bg", 4.5],
+  ["--postal-question", "--bg", 4.5],
   ["--st-working-fg", "--st-working-bg", 3],
   ["--st-ready-fg", "--st-ready-bg", 3],
   ["--st-blocked-fg", "--st-blocked-bg", 3],


### PR DESCRIPTION
The user's tweak to the postal cards' kind word (2026-09-10, T320): the word (Coordination, Delegation, Question) renders at the prose weight, not bold, and its three colours come from one sequential ramp rather than three unrelated hues, ranked by how much each kind asks of the reader: coordination lowest (an FYI), delegation next (work handed over), question highest (an answer owed).

Design points:
- The three tokens are three steps in the theme's accent hue. Dark page: they climb toward the accent's brightness (contrast 5.4:1, 7.8:1, 10.8:1). Light page: they deepen toward the clay accent's dark end (4.6:1, 6.7:1, 9.7:1). The ranking sits as a comment beside the tokens.
- Not the recency colormap, deliberately: the age labels in the same chat already carry that map, so a kind word in its hues would read as recency.
- Pins: the card test holds the weight, the tokens and the monotone luminance order per theme; the theme-parity test holds every step at 4.5:1 on its page in both themes; the served guard measures the computed weight and the luminance order in the browser and gains a phone-width light pass (screenshots named by theme and width).

Checked by eye at 1000 px and 340 px, dark and light (screenshots in the user's drops folder).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)