### PR TITLE
A feed card's reveal lands on its own turn again: segments opened by identical machine markers (restart notices, stop records) no longer alias under one lookup key (T318)

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -93,10 +93,6 @@ ROMP_INJECT_RE = re.compile(r"<!--\s*romp-injected\s*-->")
 # romp-injected; an atom carrying it gets atom["rompAuto"]=True for the timeline/chat to mark.
 # Comment form only, same reason as ROMP_INJECT_RE (content mentioning the marker must not match).
 ROMP_AUTO_RE = re.compile(r"<!--\s*romp-auto\s*-->")
-# romp-SYSTEM: a kernel STATUS notice romp injects on its own (a restart or crash resume notice) — untargeted, no
-# goal, and worded identically every time. Read here for SEGMENT IDENTITY (see _segment_id): a segment such a notice
-# opens must not key on its text, or every restart in a session would alias to one segment (T318, 2026-09-10).
-ROMP_SYSTEM_RE = re.compile(r"<!--\s*romp-system\s*-->")
 # A sender-declared RENDER HINT on an injected message (the user 2026-08-15): auto-generated text — a
 # kickoff template, a scripted brief — carries `<!-- romp-tag: <label> -->` (romp send --tag, or the
 # marker appended by hand) so the chat shows it as machine-sent under that label instead of posing it
@@ -2465,17 +2461,20 @@ def _segment_id(rompuuid, seg_t, atoms, trigger_uuid):
     atom-uuid key there would MISS its own echo. Hash the content, or — only when there is none — the
     anchor atom's identity.
 
-    A segment opened by a MACHINE MARKER is keyed by its anchor atom's uuid too (T318, 2026-09-10): romp's
-    own untargeted injections (a kernel restart or crash notice, romp-system; an auto-nudge, romp-auto) and
-    the CLI's own stop record ('[Request interrupted by user…]', is_interrupt_record). Each is worded
-    identically every time, so a content hash gave every such segment in a session the same hash and the
-    timestamp-invariant _seg_key aliased them all (one session held 19 restart-notice segments and 25 stop
-    records under three keys): a card whose recorded segments held one such segment resolved to whichever
-    the parse saw last, and its summary click landed hours away from the work it described. None of these
-    has a composer echo to drift against (romp and the CLI write them, not the composer), so the uuid is
-    stable across the judge and render parses, exactly as for a text-less seam. A follow-up the USER typed
-    into a card rides romp-injected too but not romp-system, and keeps its content hash: it does have an
-    echo."""
+    A segment opened by a MACHINE-WRITTEN trigger is keyed by its anchor atom's uuid too (T318, 2026-09-10):
+    anything romp injected itself (the romp-injected marker: a kernel restart or crash notice, an auto-nudge,
+    the retry message, the compaction suggestion, a Nudge-button follow-up) and the CLI's own stop record
+    ('[Request interrupted by user…]', is_interrupt_record). Most of these are worded identically every time,
+    so a content hash gave every such segment in a session the same hash and the timestamp-invariant _seg_key
+    aliased them all (one session held 19 restart-notice segments and 25 stop records under three keys): a
+    card whose recorded segments held one such segment resolved to whichever the parse saw last, and its
+    summary click landed hours away from the work it described. Keying them by uuid is safe on the echo
+    axis for a different reason than for typed prompts: every recorded key (a placement, a trail, a seam, a
+    caption) is written by the judge from the TRANSCRIPT parse and the kernel only looks up, and a romp
+    send's optimistic echo is hidden the moment its record lands, so the echo-time id and the landed id
+    never coexist in anything recorded. A follow-up the USER typed into a card carries no romp-injected
+    marker (only the Nudge button's does) and keeps its content hash, since its echo and its record must
+    share a key while both are on screen."""
     text = ""
     anchor = None
     if trigger_uuid:
@@ -2486,9 +2485,9 @@ def _segment_id(rompuuid, seg_t, atoms, trigger_uuid):
     if not text and atoms:
         anchor = anchor or atoms[0]
         text = _text_of(_content(atoms[0].get("message")))
-    machine_marker = bool(text) and bool(ROMP_SYSTEM_RE.search(text) or ROMP_AUTO_RE.search(text)
-                                        or (anchor is not None and is_interrupt_record(anchor)))
-    basis = (text if not machine_marker else "") or (anchor or {}).get("uuid") \
+    machine_written = bool(text) and bool(ROMP_INJECT_RE.search(text)
+                                         or (anchor is not None and is_interrupt_record(anchor)))
+    basis = (text if not machine_written else "") or (anchor or {}).get("uuid") \
         or next((a.get("uuid") for a in atoms if a.get("uuid")), "")   # first uuid-bearing atom if the anchor has none
     h = hashlib.sha1(basis.encode("utf-8", "replace")).hexdigest()[:8]
     return "%s:%d:%s" % (rompuuid, seg_t, h)

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -2463,8 +2463,10 @@ def _segment_id(rompuuid, seg_t, atoms, trigger_uuid):
 
     A segment opened by a MACHINE-WRITTEN trigger is keyed by its anchor atom's uuid too (T318, 2026-09-10):
     anything romp injected itself (the romp-injected marker: a kernel restart or crash notice, an auto-nudge,
-    the retry message, the compaction suggestion, a Nudge-button follow-up) and the CLI's own stop record
-    ('[Request interrupted by user…]', is_interrupt_record). Most of these are worded identically every time,
+    the retry message, the compaction suggestion, a Nudge-button follow-up), the CLI's own stop record
+    ('[Request interrupted by user…]', is_interrupt_record), and a SCHEDULED task's fired prompt (origin
+    subkind scheduled-trigger, or its preamble on an unstamped record: the CLI fires the stored prompt
+    verbatim every interval, with no time or task id interpolated). Most of these are worded identically every time,
     so a content hash gave every such segment in a session the same hash and the timestamp-invariant _seg_key
     aliased them all (one session held 19 restart-notice segments and 25 stop records under three keys): a
     card whose recorded segments held one such segment resolved to whichever the parse saw last, and its
@@ -2485,8 +2487,11 @@ def _segment_id(rompuuid, seg_t, atoms, trigger_uuid):
     if not text and atoms:
         anchor = anchor or atoms[0]
         text = _text_of(_content(atoms[0].get("message")))
-    machine_written = bool(text) and bool(ROMP_INJECT_RE.search(text)
-                                         or (anchor is not None and is_interrupt_record(anchor)))
+    origin = (anchor or {}).get("origin")
+    machine_written = bool(text) and bool(
+        ROMP_INJECT_RE.search(text) or SCHEDULED_PREAMBLE_RE.match(text)
+        or (isinstance(origin, dict) and origin.get("kind") == "task-notification" and origin.get("subkind") == "scheduled-trigger")
+        or (anchor is not None and is_interrupt_record(anchor)))
     basis = (text if not machine_written else "") or (anchor or {}).get("uuid") \
         or next((a.get("uuid") for a in atoms if a.get("uuid")), "")   # first uuid-bearing atom if the anchor has none
     h = hashlib.sha1(basis.encode("utf-8", "replace")).hexdigest()[:8]

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -93,6 +93,10 @@ ROMP_INJECT_RE = re.compile(r"<!--\s*romp-injected\s*-->")
 # romp-injected; an atom carrying it gets atom["rompAuto"]=True for the timeline/chat to mark.
 # Comment form only, same reason as ROMP_INJECT_RE (content mentioning the marker must not match).
 ROMP_AUTO_RE = re.compile(r"<!--\s*romp-auto\s*-->")
+# romp-SYSTEM: a kernel STATUS notice romp injects on its own (a restart or crash resume notice) — untargeted, no
+# goal, and worded identically every time. Read here for SEGMENT IDENTITY (see _segment_id): a segment such a notice
+# opens must not key on its text, or every restart in a session would alias to one segment (T318, 2026-09-10).
+ROMP_SYSTEM_RE = re.compile(r"<!--\s*romp-system\s*-->")
 # A sender-declared RENDER HINT on an injected message (the user 2026-08-15): auto-generated text — a
 # kickoff template, a scripted brief — carries `<!-- romp-tag: <label> -->` (romp send --tag, or the
 # marker appended by hand) so the chat shows it as machine-sent under that label instead of posing it
@@ -2459,7 +2463,19 @@ def _segment_id(rompuuid, seg_t, atoms, trigger_uuid):
     Text-BEARING segments keep the content hash: it is drift-invariant across the SDK optimistic echo
     (send time) and the real transcript atom (process time), which share text but NOT uuid — so an
     atom-uuid key there would MISS its own echo. Hash the content, or — only when there is none — the
-    anchor atom's identity."""
+    anchor atom's identity.
+
+    A segment opened by a MACHINE MARKER is keyed by its anchor atom's uuid too (T318, 2026-09-10): romp's
+    own untargeted injections (a kernel restart or crash notice, romp-system; an auto-nudge, romp-auto) and
+    the CLI's own stop record ('[Request interrupted by user…]', is_interrupt_record). Each is worded
+    identically every time, so a content hash gave every such segment in a session the same hash and the
+    timestamp-invariant _seg_key aliased them all (one session held 19 restart-notice segments and 25 stop
+    records under three keys): a card whose recorded segments held one such segment resolved to whichever
+    the parse saw last, and its summary click landed hours away from the work it described. None of these
+    has a composer echo to drift against (romp and the CLI write them, not the composer), so the uuid is
+    stable across the judge and render parses, exactly as for a text-less seam. A follow-up the USER typed
+    into a card rides romp-injected too but not romp-system, and keeps its content hash: it does have an
+    echo."""
     text = ""
     anchor = None
     if trigger_uuid:
@@ -2470,7 +2486,9 @@ def _segment_id(rompuuid, seg_t, atoms, trigger_uuid):
     if not text and atoms:
         anchor = anchor or atoms[0]
         text = _text_of(_content(atoms[0].get("message")))
-    basis = text or (anchor or {}).get("uuid") \
+    machine_marker = bool(text) and bool(ROMP_SYSTEM_RE.search(text) or ROMP_AUTO_RE.search(text)
+                                        or (anchor is not None and is_interrupt_record(anchor)))
+    basis = (text if not machine_marker else "") or (anchor or {}).get("uuid") \
         or next((a.get("uuid") for a in atoms if a.get("uuid")), "")   # first uuid-bearing atom if the anchor has none
     h = hashlib.sha1(basis.encode("utf-8", "replace")).hexdigest()[:8]
     return "%s:%d:%s" % (rompuuid, seg_t, h)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -474,7 +474,8 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          already had their own.
 PLACEMENTS_V = 13                        # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v13 (T318, 2026-09-10): a segment opened by a machine-written trigger (a romp
-#                                          injection, the CLI's stop record) keys on its anchor atom's uuid. Recorded
+#                                          injection, the CLI's stop record, a scheduled task's fired prompt) keys on its
+#                                          anchor atom's uuid; the tasks memo (tasks_for) steps to v7 with it. Recorded
 #                                          ids from before (trails, seam keys, caption rows into such segments) are NOT
 #                                          remapped: their lookups miss and the card falls to its fallback tiers, which
 #                                          is where those anchors already were wrong; a one-time remap by exact `t`
@@ -3222,7 +3223,8 @@ def tasks_for(fsid, leaf, files, now):
     cf = PCACHE / (fsid + ".json")
     try:
         o = json.loads(cf.read_text())
-        if o.get("key") == key and o.get("v") == 6:    # v6 = absorbed atoms placed at their landing time, so their seg ids moved (T252d, 2026-09-08);
+        if o.get("key") == key and o.get("v") == 7:    # v7 = machine-written triggers key their segment on the anchor uuid, so those seg ids moved (T318, 2026-09-10; with PLACEMENTS_V 13);
+            #                                             v6 = absorbed atoms placed at their landing time, so their seg ids moved (T252d, 2026-09-08);
             #                                             v5 = absorbed SDK-injection atoms carry real text (2026-07-06); older caches regenerate
             return o["tasks"]
     except Exception:
@@ -3242,7 +3244,7 @@ def tasks_for(fsid, leaf, files, now):
     try:
         PCACHE.mkdir(parents=True, exist_ok=True)
         tmp = cf.with_suffix(".tmp.%d" % os.getpid())
-        tmp.write_text(json.dumps({"key": key, "v": 6, "tasks": tasks}))
+        tmp.write_text(json.dumps({"key": key, "v": 7, "tasks": tasks}))
         tmp.rename(cf)
     except Exception:
         pass

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -472,7 +472,7 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          consolidator / courier; the
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
-PLACEMENTS_V = 12                        # placements-identity schema version (plan P2, the user 2026-07-06).
+PLACEMENTS_V = 13                        # placements-identity schema version (plan P2, the user 2026-07-06).
 #                                          v12 (2026-09-08, T252d): an ABSORBED atom (a mid-turn send the CLI
 #                                          spliced in) is placed at its LANDING time, not its send time, so
 #                                          every absorbed segment whose landing differs from its send changes

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -473,6 +473,12 @@ JUDGE_FAIL_CAP = 3                       # the same rule for every other retryin
 #                                          planner (PLAN_PARSE_RETRIES) and distiller/briefer (DISTILL_FAIL_CAP)
 #                                          already had their own.
 PLACEMENTS_V = 13                        # placements-identity schema version (plan P2, the user 2026-07-06).
+#                                          v13 (T318, 2026-09-10): a segment opened by a machine-written trigger (a romp
+#                                          injection, the CLI's stop record) keys on its anchor atom's uuid. Recorded
+#                                          ids from before (trails, seam keys, caption rows into such segments) are NOT
+#                                          remapped: their lookups miss and the card falls to its fallback tiers, which
+#                                          is where those anchors already were wrong; a one-time remap by exact `t`
+#                                          in _migrate_placements would be the follow-up if that ever matters.
 #                                          v12 (2026-09-08, T252d): an ABSORBED atom (a mid-turn send the CLI
 #                                          spliced in) is placed at its LANDING time, not its send time, so
 #                                          every absorbed segment whose landing differs from its send changes

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -129,7 +129,7 @@ RECORDS = [
 # boundary does not arm the replay dedup).
 EXPECTED_SEG_IDS = [
     SID + ":1780000000:ca8d36fd",
-    SID + ":1780000120:f03c5f4f",
+    SID + ":1780000120:b9c69e54",
     SID + ":1780000240:686c9d66",
     SID + ":1780000330:f3320ed1",
     SID + ":1780000350:26e8f145",   # att2: sent at T0+340, placed at its T0+350 landing (v12, T252d)
@@ -154,7 +154,7 @@ EXPECTED_ATOM_UUIDS = [
 # continuation work — a5 chains through the boundary — and predates this block.)
 EXPECTED_UNITS = [
     (SID + ":1780000000:ca8d36fd", "work", True),
-    (SID + ":1780000120:f03c5f4f", "nudge", False),
+    (SID + ":1780000120:b9c69e54", "nudge", False),
     (SID + ":1780000240:686c9d66", "work", True),
     (SID + ":1780000330:f3320ed1", "work", True),
     (SID + ":1780000350:26e8f145", "work", True),
@@ -222,10 +222,12 @@ class PlacementIdentityCanary(unittest.TestCase):
         # set again (tests/test_event_model_golden.py EclipsedChainSelection covers the pick).
         # v12 (2026-09-08, T252d): absorbed atoms placed at their landing time — att2's id and the atom set
         # above re-pinned with the bump.
-        # v13 (2026-09-10, T318): a segment opened by romp's own system notice or auto-nudge keys on its anchor
-        # atom's uuid, not its (identical every time) text; this fixture carries no such notice, so every pinned
-        # id is UNCHANGED — the bump seals sessions whose restart-notice segments aliased under one key
-        # (tests/test_restart_notice_segments.py covers the derivation and the card anchors it protects).
+        # v13 (2026-09-10, T318): a segment opened by a machine-written trigger (a romp injection: restart or
+        # crash notice, auto-nudge, retry, compaction suggestion, Nudge-button follow-up; or the CLI's stop record)
+        # keys on its anchor atom's uuid, not its (identical every time) text; this fixture's u2 is romp-injected
+        # but its id is pinned as it now derives, and the rest carry no such trigger — the bump seals sessions
+        # whose restart-notice and stop-record segments aliased under one key (tests/test_restart_notice_segments.py
+        # covers the derivation and the card anchors it protects).
         self.assertEqual(jd.PLACEMENTS_V, 13, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=13 — "
                          "re-pin the ids and this version together, in the same commit")
 

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -223,7 +223,8 @@ class PlacementIdentityCanary(unittest.TestCase):
         # v12 (2026-09-08, T252d): absorbed atoms placed at their landing time — att2's id and the atom set
         # above re-pinned with the bump.
         # v13 (2026-09-10, T318): a segment opened by a machine-written trigger (a romp injection: restart or
-        # crash notice, auto-nudge, retry, compaction suggestion, Nudge-button follow-up; or the CLI's stop record)
+        # crash notice, auto-nudge, retry, compaction suggestion, Nudge-button follow-up; the CLI's stop record; a
+        # scheduled task's fired prompt)
         # keys on its anchor atom's uuid, not its (identical every time) text; this fixture's u2 is romp-injected
         # but its id is pinned as it now derives, and the rest carry no such trigger — the bump seals sessions
         # whose restart-notice and stop-record segments aliased under one key (tests/test_restart_notice_segments.py

--- a/tests/test_placements_canary.py
+++ b/tests/test_placements_canary.py
@@ -222,7 +222,11 @@ class PlacementIdentityCanary(unittest.TestCase):
         # set again (tests/test_event_model_golden.py EclipsedChainSelection covers the pick).
         # v12 (2026-09-08, T252d): absorbed atoms placed at their landing time — att2's id and the atom set
         # above re-pinned with the bump.
-        self.assertEqual(jd.PLACEMENTS_V, 12, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=11 — "
+        # v13 (2026-09-10, T318): a segment opened by romp's own system notice or auto-nudge keys on its anchor
+        # atom's uuid, not its (identical every time) text; this fixture carries no such notice, so every pinned
+        # id is UNCHANGED — the bump seals sessions whose restart-notice segments aliased under one key
+        # (tests/test_restart_notice_segments.py covers the derivation and the card anchors it protects).
+        self.assertEqual(jd.PLACEMENTS_V, 13, "EXPECTED_SEG_IDS was pinned under PLACEMENTS_V=13 — "
                          "re-pin the ids and this version together, in the same commit")
 
 

--- a/tests/test_restart_notice_segments.py
+++ b/tests/test_restart_notice_segments.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Every kernel-restart notice romp injects has identical text, so the segment-id derivation (which hashes
+the segment's trigger text) gave every restart-notice segment in a session the same hash, and the kernel's
+timestamp-invariant lookup key (_seg_key = session id plus that hash) treated them all as ONE segment
+(T318, 2026-09-10: a card whose recorded segments included one restart-notice segment resolved, through
+that key, to whichever restart-notice segment the parse saw last, so its summary click landed on an
+assistant turn hours after the work the summary described). A romp system notice (or an auto-nudge)
+carries no user content and has no composer echo to drift against, so its segment is keyed by its anchor
+atom's uuid, exactly as a text-less seam already is. Two cut turns, two identical notices: distinct ids,
+distinct keys, and the card's anchors stay inside its own segments. SYNTHETIC fixtures only: a private
+synthetic sid, invented text, placeholder uuids."""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE the loads (a bare run has no conftest floor)
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_restart_segs", os.path.join(BIN, "romp-kernel"))
+jd = km.jd
+em = km.em
+
+NOW = 1_788_300_000
+T0 = NOW - 7200
+SID = "f318e001-1111-4222-8333-000000000001"    # private synthetic sid — never the shared placeholder
+NOTICE = ("<!-- romp-injected --><!-- romp-system -->[romp] The romp kernel restarted and cut this session's "
+          "in-flight turn; the session has been resumed with its history intact. Re-read the tail of the "
+          "conversation and pick the work back up where it stopped, without asking whether to continue.")
+ASK = "Please make the outline pane optional in the settings, and talk me through what turning it off breaks."
+WORK1 = "Read through the settings model: the outline pane is drawn by its own module, so an off switch is feasible without touching the feed."
+WORK2 = "Picking the settings work back up after the cut: the outline module has one entry point, and hiding it drops no state."
+WORK3 = "Resumed again: wrote the talk-through of the outline split and listed the three calls that are yours to make."
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None, ps="typed"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": ps, "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": "end_turn"}}
+
+
+RECORDS = [
+    uline(T0, ASK, "u1"),
+    aline(T0 + 60, WORK1, "a1", "u1"),
+    uline(T0 + 600, "[Request interrupted by user]", "c1", "a1", ps="sdk"),   # the first cut
+    uline(T0 + 610, NOTICE, "n1", "c1", ps="sdk"),                            # the restart notice, injected by romp
+    aline(T0 + 700, WORK2, "a2", "n1"),
+    uline(T0 + 1800, "[Request interrupted by user]", "c2", "a2", ps="sdk"),  # the second cut
+    uline(T0 + 1810, NOTICE, "n2", "c2", ps="sdk"),                           # the SAME notice text again
+    aline(T0 + 1900, WORK3, "a3", "n2"),
+]
+
+
+class RestartNoticeSegments(unittest.TestCase):
+    def setUp(self):
+        km._downtime[:] = []
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"
+        cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        self.tpath = pdir / (SID + ".jsonl")
+        self.tpath.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+        names = td / "names"
+        names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
+        jd.gist_llm = lambda p: ""
+        km._autonudge_cache.clear()
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        jd.STATE = td
+        km.NAMES = names
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
+                                           "effort": "", "context": None, "compactPct": None,
+                                           "color": None}}
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        s = jd.parsed_session(SID, [str(self.tpath)], NOW)
+        st0 = {"rompUuid": SID, "nodes": {}, "placements": {}, "status": {}}
+        self.segs = [sg for turn in s["turns"] for sg in jd._segs(turn, st0)]
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm) = self.saved
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _seg_of(self, uuid):
+        return next(sg for sg in self.segs if any(a.get("uuid") == uuid for a in sg["atoms"]))
+
+    def test_two_identical_restart_notices_open_two_segments_with_distinct_ids_and_keys(self):
+        n1, n2 = self._seg_of("n1"), self._seg_of("n2")
+        self.assertNotEqual(n1["id"], n2["id"])
+        self.assertNotEqual(jd._seg_key(n1["id"]), jd._seg_key(n2["id"]),
+                            "identical notice text must not collapse two segments into one lookup key: %s / %s" % (n1["id"], n2["id"]))
+        # the ask keeps a content-keyed id (drift-invariant across a composer echo), as every typed prompt does
+        u1 = self._seg_of("u1")
+        self.assertEqual(u1["id"].rsplit(":", 1)[1], __import__("hashlib").sha1(ASK.encode()).hexdigest()[:8])
+        # a notice segment is keyed by its anchor atom's uuid, like a text-less seam
+        self.assertEqual(n1["id"].rsplit(":", 1)[1], __import__("hashlib").sha1(b"n1").hexdigest()[:8])
+        # …and so is the CLI's own stop record, worded identically at every cut
+        c1, c2 = self._seg_of("c1"), self._seg_of("c2")
+        if c1["id"] != n1["id"] and c2["id"] != n2["id"]:   # the stop record opens its own segment in this parse
+            self.assertNotEqual(jd._seg_key(c1["id"]), jd._seg_key(c2["id"]), "two identical stop records must not share a key")
+
+    def test_the_cards_anchors_stay_inside_its_own_segments(self):
+        u1, n1, n2 = self._seg_of("u1"), self._seg_of("n1"), self._seg_of("n2")
+        g = SID + ":g1"
+        # the card's recorded segments: the ask and the FIRST notice segment (the planner placed the work after the
+        # first cut under it); no stored citation, so the summary click resolves through the segment walk
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "lastNode": g,
+            "nodes": {g: {"id": g, "text": "Outline pane optional in settings", "parentId": None,
+                          "nodeComplete": False, "blocked": True, "cleared": False,
+                          "trail": [u1["id"], n1["id"]], "promptUuid": "u1", "quote": ASK, "t": T0, "mt": NOW,
+                          "blockSummary": "Three calls are yours before anything is built.",
+                          "summaryAnchor": None, "briefedMt": NOW - 10, "log": []}},
+            "placements": {}, "status": {g: "blocked"}}))
+        km._parse(str(self.tpath), SID, NOW)           # warm the kernel parse cache, as the pusher would
+        card = next(a for a in km.build_feed(NOW)["asks"] if a.get("itemId") == g)
+        root = next(n for n in card["tree"] if n.get("id") == g)   # the root node carries the two deep-link uuids (feed.ts reads rootNode)
+        self.assertEqual(root.get("promptAnchorUuid"), "u1", "the title click lands on the ask itself")
+        self.assertEqual(root.get("anchorUuid"), "a2",
+                         "the work anchor is the newest recorded segment's reply: the work right after the FIRST cut, never the later notice's turn (%r)" % root.get("anchorUuid"))
+        self.assertIn(card.get("summaryAnchorUuid"), ("a1", "a2"),
+                      "the summary click stays inside the card's own segments, never the later notice's turn: %r" % card.get("summaryAnchorUuid"))
+        self.assertNotEqual(card.get("summaryAnchorUuid"), "a3", "the second notice's segment is not this card's")
+        # the hover glow lights exactly the recorded segments' rows
+        us = km._segment_atom_uuids(SID, [u1["id"], n1["id"]], NOW)
+        self.assertIn("a2", us); self.assertIn("u1", us); self.assertNotIn("a3", us)
+        self.assertEqual(km._segment_of_uuid(SID, "a3", NOW)[0], n2["id"], "the later turn belongs to the later notice's segment")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_notice_segments.py
+++ b/tests/test_restart_notice_segments.py
@@ -7,7 +7,8 @@ that key, to whichever restart-notice segment the parse saw last, so its summary
 assistant turn hours after the work the summary described). A romp system notice (or an auto-nudge)
 carries no user content and has no composer echo to drift against, so its segment is keyed by its anchor
 atom's uuid, exactly as a text-less seam already is; so is every other segment a machine wrote the trigger of
-(any romp injection: the retry message, an auto-nudge; the CLI's stop record). Two cut turns, two identical
+(any romp injection: the retry message, an auto-nudge; the CLI's stop record; a scheduled task's fired prompt,
+stamped by its origin or read from its preamble). Two cut turns, two identical
 notices: distinct ids, distinct keys, and the card's anchors stay inside its own segments. SYNTHETIC fixtures
 only: a private synthetic sid, invented text, placeholder uuids."""
 import json
@@ -45,9 +46,12 @@ def iso(t):
     return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
-def uline(t, text, uuid, parent=None, ps="typed"):
-    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
-            "promptSource": ps, "message": {"role": "user", "content": text}}
+def uline(t, text, uuid, parent=None, ps="typed", origin=None):
+    r = {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+         "promptSource": ps, "message": {"role": "user", "content": text}}
+    if origin:
+        r["origin"] = origin
+    return r
 
 
 def aline(t, text, uuid, parent=None):
@@ -58,6 +62,11 @@ def aline(t, text, uuid, parent=None):
 
 RETRY = "retry\n\n<!-- romp-injected -->"                                        # the kernel's fixed retry message
 AUTO = "<!-- romp-injected --><!-- romp-auto -->[romp] Where does the outline work stand? <!-- romp-goal-id: g1 -->"
+SCHEDULED = ("[SCHEDULED TASK - AUTOMATED FIRING OF A CONFIGURED PROMPT]\n"
+             "This turn was started automatically by a schedule, not typed live by the user.\n"
+             "The content below is the stored prompt of a scheduled task on this account.\n\n"
+             "Sweep the outline module for stale references and report.")          # the CLI fires it verbatim each interval
+SCHED_ORIGIN = {"kind": "task-notification", "subkind": "scheduled-trigger"}
 RECORDS = [
     uline(T0, ASK, "u1"),
     aline(T0 + 60, WORK1, "a1", "u1"),
@@ -76,6 +85,15 @@ RECORDS = [
     aline(T0 + 2710, "The outline work stands where the talk-through left it: three calls are still yours.", "a6", "an1"),
     uline(T0 + 2800, AUTO, "an2", "a6", ps="sdk"),
     aline(T0 + 2810, "Still standing where it was; nothing new to build until you decide the three calls.", "a7", "an2"),
+    # a scheduled task fired twice: stamped by the CLI's origin (s1, s2), and unstamped, read from the preamble (p1, p2)
+    uline(T0 + 3600, SCHEDULED, "s1", "a7", ps="sdk", origin=SCHED_ORIGIN),
+    aline(T0 + 3610, "Swept the outline module: two stale references, both in the talk-through section.", "a8", "s1"),
+    uline(T0 + 7200, SCHEDULED, "s2", "a8", ps="sdk", origin=SCHED_ORIGIN),
+    aline(T0 + 7210, "Swept again: the two stale references are still there; nothing new since the last sweep.", "a9", "s2"),
+    uline(T0 + 10800, SCHEDULED, "p1", "a9", ps="sdk"),
+    aline(T0 + 10810, "Swept once more without a stamp on the firing; the same two references remain.", "a10", "p1"),
+    uline(T0 + 14400, SCHEDULED, "p2", "a10", ps="sdk"),
+    aline(T0 + 14410, "The fourth sweep finds the two references fixed; the module reads clean now.", "a11", "p2"),
 ]
 
 
@@ -134,8 +152,9 @@ class RestartNoticeSegments(unittest.TestCase):
         c1, c2 = self._seg_of("c1"), self._seg_of("c2")
         self.assertEqual(c1["id"].rsplit(":", 1)[1], h("c1")); self.assertEqual(c2["id"].rsplit(":", 1)[1], h("c2"))
         self.assertNotEqual(jd._seg_key(c1["id"]), jd._seg_key(c2["id"]), "two identical stop records must not share a key")
-        # …and every other trigger romp wrote: the fixed retry message and an auto-nudge, each sent twice
-        for a, b in (("r1", "r2"), ("an1", "an2")):
+        # …and every other machine-written trigger: romp's fixed retry message and an auto-nudge, each sent twice, and
+        # a scheduled task's prompt fired twice, stamped by its origin (s1, s2) and unstamped, read from its preamble (p1, p2)
+        for a, b in (("r1", "r2"), ("an1", "an2"), ("s1", "s2"), ("p1", "p2")):
             sa, sb = self._seg_of(a), self._seg_of(b)
             self.assertEqual(sa["id"].rsplit(":", 1)[1], h(a), "%s keys on its own uuid" % a)
             self.assertNotEqual(jd._seg_key(sa["id"]), jd._seg_key(sb["id"]), "%s and %s must not share a key" % (a, b))

--- a/tests/test_restart_notice_segments.py
+++ b/tests/test_restart_notice_segments.py
@@ -6,9 +6,10 @@ timestamp-invariant lookup key (_seg_key = session id plus that hash) treated th
 that key, to whichever restart-notice segment the parse saw last, so its summary click landed on an
 assistant turn hours after the work the summary described). A romp system notice (or an auto-nudge)
 carries no user content and has no composer echo to drift against, so its segment is keyed by its anchor
-atom's uuid, exactly as a text-less seam already is. Two cut turns, two identical notices: distinct ids,
-distinct keys, and the card's anchors stay inside its own segments. SYNTHETIC fixtures only: a private
-synthetic sid, invented text, placeholder uuids."""
+atom's uuid, exactly as a text-less seam already is; so is every other segment a machine wrote the trigger of
+(any romp injection: the retry message, an auto-nudge; the CLI's stop record). Two cut turns, two identical
+notices: distinct ids, distinct keys, and the card's anchors stay inside its own segments. SYNTHETIC fixtures
+only: a private synthetic sid, invented text, placeholder uuids."""
 import json
 import os
 import re
@@ -55,6 +56,8 @@ def aline(t, text, uuid, parent=None):
                         "stop_reason": "end_turn"}}
 
 
+RETRY = "retry\n\n<!-- romp-injected -->"                                        # the kernel's fixed retry message
+AUTO = "<!-- romp-injected --><!-- romp-auto -->[romp] Where does the outline work stand? <!-- romp-goal-id: g1 -->"
 RECORDS = [
     uline(T0, ASK, "u1"),
     aline(T0 + 60, WORK1, "a1", "u1"),
@@ -64,6 +67,15 @@ RECORDS = [
     uline(T0 + 1800, "[Request interrupted by user]", "c2", "a2", ps="sdk"),  # the second cut
     uline(T0 + 1810, NOTICE, "n2", "c2", ps="sdk"),                           # the SAME notice text again
     aline(T0 + 1900, WORK3, "a3", "n2"),
+    # the other machine-written triggers, each worded identically twice: romp's retry and an auto-nudge
+    uline(T0 + 2500, RETRY, "r1", "a3", ps="sdk"),
+    aline(T0 + 2510, "Retrying the last step as asked; the outline module still builds clean.", "a4", "r1"),
+    uline(T0 + 2600, RETRY, "r2", "a4", ps="sdk"),
+    aline(T0 + 2610, "Retried once more; the same result, so the talk-through stands as written.", "a5", "r2"),
+    uline(T0 + 2700, AUTO, "an1", "a5", ps="sdk"),
+    aline(T0 + 2710, "The outline work stands where the talk-through left it: three calls are still yours.", "a6", "an1"),
+    uline(T0 + 2800, AUTO, "an2", "a6", ps="sdk"),
+    aline(T0 + 2810, "Still standing where it was; nothing new to build until you decide the three calls.", "a7", "an2"),
 ]
 
 
@@ -82,14 +94,12 @@ class RestartNoticeSegments(unittest.TestCase):
         names = td / "names"
         names.mkdir()
         (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
-        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-                      km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
+        self.saved = (jd.STATE, jd.PROJECTS, km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
         jd.gist_llm = lambda p: ""
         km._autonudge_cache.clear()
         km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
-        jd.NAMES, jd.PROJECTS = names, proj
-        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
-        jd.STATE = td
+        jd._rebind_state(td)          # STATE and every dir derived from it (names, captions, archive, goals…), the house way
+        jd.PROJECTS = proj
         km.NAMES = names
         km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "",
                                            "effort": "", "context": None, "compactPct": None,
@@ -100,8 +110,8 @@ class RestartNoticeSegments(unittest.TestCase):
         self.segs = [sg for turn in s["turns"] for sg in jd._segs(turn, st0)]
 
     def tearDown(self):
-        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
-         km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm) = self.saved
+        state, jd.PROJECTS, km.NAMES, km._tmux_sessions, km._GLOBAL_CLAUDE_MD, jd.gist_llm = self.saved
+        jd._rebind_state(state)
         km._autonudge_cache.clear()
         self.td.cleanup()
 
@@ -116,12 +126,19 @@ class RestartNoticeSegments(unittest.TestCase):
         # the ask keeps a content-keyed id (drift-invariant across a composer echo), as every typed prompt does
         u1 = self._seg_of("u1")
         self.assertEqual(u1["id"].rsplit(":", 1)[1], __import__("hashlib").sha1(ASK.encode()).hexdigest()[:8])
-        # a notice segment is keyed by its anchor atom's uuid, like a text-less seam
-        self.assertEqual(n1["id"].rsplit(":", 1)[1], __import__("hashlib").sha1(b"n1").hexdigest()[:8])
-        # …and so is the CLI's own stop record, worded identically at every cut
+        # a notice segment is keyed by its anchor atom's uuid, like a text-less seam…
+        h = lambda u: __import__("hashlib").sha1(u.encode()).hexdigest()[:8]
+        self.assertEqual(n1["id"].rsplit(":", 1)[1], h("n1"))
+        # …and so is the CLI's own stop record, worded identically at every cut (each opens its own segment: the
+        # assistant turn before it had ended, and the record ends the turn it opens)
         c1, c2 = self._seg_of("c1"), self._seg_of("c2")
-        if c1["id"] != n1["id"] and c2["id"] != n2["id"]:   # the stop record opens its own segment in this parse
-            self.assertNotEqual(jd._seg_key(c1["id"]), jd._seg_key(c2["id"]), "two identical stop records must not share a key")
+        self.assertEqual(c1["id"].rsplit(":", 1)[1], h("c1")); self.assertEqual(c2["id"].rsplit(":", 1)[1], h("c2"))
+        self.assertNotEqual(jd._seg_key(c1["id"]), jd._seg_key(c2["id"]), "two identical stop records must not share a key")
+        # …and every other trigger romp wrote: the fixed retry message and an auto-nudge, each sent twice
+        for a, b in (("r1", "r2"), ("an1", "an2")):
+            sa, sb = self._seg_of(a), self._seg_of(b)
+            self.assertEqual(sa["id"].rsplit(":", 1)[1], h(a), "%s keys on its own uuid" % a)
+            self.assertNotEqual(jd._seg_key(sa["id"]), jd._seg_key(sb["id"]), "%s and %s must not share a key" % (a, b))
 
     def test_the_cards_anchors_stay_inside_its_own_segments(self):
         u1, n1, n2 = self._seg_of("u1"), self._seg_of("n1"), self._seg_of("n2")


### PR DESCRIPTION
A feed card's summary click revealed the wrong chat turn (an assistant turn hours after the work the summary described) and hovering the card highlighted nothing (the user, today, reproduced by the feature-review session). Root cause, confirmed on a hermetic copy of the session (kernel module loaded against copied files, never the live state root or the kernel's process):

Every kernel-restart notice romp injects has identical text. The segment-id derivation (`kernel/event_model.py` `_segment_id`) hashes the segment's trigger text, so every restart-notice segment in a session got the same hash, and the timestamp-invariant lookup key (`_seg_key` = session id plus that hash) treated them all as ONE segment. The reproduced session had 19 such segments sharing one key. The card's own recorded segments included one restart-notice segment (the planner placed a restart notice under it as if it were the user's follow-up, the same collision), and the feed's summary-anchor walk resolves a recorded segment id through `_seg_key`, so it landed on whichever restart-notice segment the parse saw last: the assistant turn after a much later restart. The summary itself was written about the user's own message, which is never a citation target by construction (only assistant prose and peer reports carry citation labels), so the card leaned on that walk.

Fix: a segment opened by a MACHINE-WRITTEN trigger is keyed by its anchor atom's uuid, exactly as a text-less seam already is: anything romp injected itself (the `romp-injected` marker: a restart or crash notice, an auto-nudge, the retry message, the compaction suggestion, a Nudge-button follow-up) and the CLI's own stop record (`[Request interrupted by user…]`, which the reproduced session held 25 of under two keys), and a scheduled task's fired prompt (origin subkind `scheduled-trigger`, or its preamble on an unstamped record: the CLI fires the stored prompt verbatim every interval, so every firing hashed alike and a card whose newest trail segment was an earlier firing resolved its clicks to the latest one). Keying these by uuid is safe on the echo axis for a different reason than for typed prompts: every recorded key (a placement, a trail, a seam, a caption) is written by the judge from the transcript parse and the kernel only looks up, and a romp send's optimistic echo is hidden the moment its record lands, so the echo-time id and the landed id never coexist in anything recorded. A follow-up the user typed into a card carries no `romp-injected` marker and keeps its content hash, because its echo and its record must share a key while both are on screen. Recorded identity changes for these segments, so `PLACEMENTS_V` steps to 13 and the canary is re-pinned in the same commit (its romp-injected nudge segment now derives from its uuid; every other pinned id is unchanged). The bump seals older stores' ready-unplaced units at the next pass, the standard cost of a derivation change, so dormant sessions replay nothing. Residue, stated rather than migrated: ids recorded before v13 into such segments (trails, seam keys, caption rows) are not remapped; their lookups miss and the card falls to its fallback tiers, which is where those anchors already were wrong. A one-time remap by exact segment time in `_migrate_placements` is the follow-up if that ever matters. The tasks memo (`tasks_for`, the per-session cache of planned units) steps to v7 with the placements version, as the previous bump did: a cached unit list written under the old derivation would keep the old ids for a session whose transcript has not moved, and the one-time re-caption for the machine-written segments of touched sessions is bounded and cheap (their captions are the fixed notice, retry or stop texts).

Tests (red-first, both fail on the unfixed tree): `tests/test_restart_notice_segments.py` builds a synthetic transcript (private synthetic sid, invented text, placeholder uuids) with an ask, two cut turns each followed by the identical restart notice, the work after each, and then the retry message, an auto-nudge and a scheduled task's prompt each fired twice (the scheduled one both stamped by its origin and unstamped); it pins that the two notice segments, the two stop records, the two retries, the two auto-nudges and each pair of scheduled firings have distinct ids and distinct lookup keys while the typed ask keeps its content-keyed id, and that a blocked card recorded against the ask and the first notice segment gets its title anchor on the ask, its summary anchor inside its own segments (never the later notice's turn), its hover glow over exactly its own rows, and the later turn resolving to the later segment. `tests/test_placements_canary.py` pins the new version.

The click path in the browser (feed card to the chat's landing by uuid) is unchanged, so no served test is added. Hover on a card whose source turns sit outside the chat's loaded tail still paints nothing (the glow paints rendered rows only); marking those positions on the chat's overview ruler is T318b, a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


