### PR TITLE
API health popup: stacked histograms from a persisted ledger, coloured counts per machine, a detail with ranges (T316)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -819,14 +819,17 @@ auto-retry paused (a usage limit, the monthly spend cap, or you stopped it), and
 it stays red while a failed attempt sits in the last 15 minutes anywhere. Gray
 means the API is not being used right now: no traffic in the last 15 minutes on
 any machine. A machine whose link is down is named in the popup with what it
-last said and does not colour the dot. Hover for the reading in plain
-words (for example, 4 requests in the last 15 minutes, all succeeded), one
-line per machine when several are connected, the waiting sessions listed, and
-the history under it: a graph of attempts per minute over the last 15 minutes
-with rate-limited attempts in red and server errors in orange, one sentence
-explaining the codes, and the most recent state changes with how long each
-held. A kernel restart shows as its own line there, because the counts start
-over with the kernel. Click the dot, or press Enter on it, for the detail:
+last said and does not colour the dot. Hover for the counts: one line per
+machine, each named by its own name, with its successful requests over the last
+24 hours in the accent and any failures counted in their colours (429s in red,
+5xx in magenta, no connection in gray), the waiting sessions listed, and
+the history under it: a stacked histogram of attempts per quarter hour over
+the last 24 hours in those same colours, a legend for the codes, when the
+reading was taken in words, and the most recent state changes with how long
+each held. A kernel restart shows as its own line there, because the counts
+start over with the kernel. Click the dot, or press Enter on it, for the
+detail: the same lines with a larger histogram per machine and a choice of
+range (1 hour, 24 hours, 7 days),
 each waiting session (click one to open that session), a button that stops
 auto-retry for every session while sessions are waiting and resumes it while
 paused, and links to the usage figures and the Log.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1782,14 +1782,29 @@ The shell's rail carries one dot for the signal, placed after the `API` label
 of the spend readout: the accent colour when every connected kernel is fine,
 red when errors are being met anywhere (a 429 storm, 5xx failures, a machine
 offline, auto-retry paused), and the label gray when no kernel has API traffic
-in the windows. The hover and the pinned detail read the document in plain
-words rather than the state machine's vocabulary: traffic with no errors reads
-as what happened ("4 requests in the last 15 min, all succeeded"), with "too
-few requests to call a trend" as a sub-line while the machine still says
-`unknown`; errors read as the failures counted; no traffic reads as quiet. The
-word `unknown` stays in the document and appears nowhere on the dashboard. The
-graph is attempts per minute from `series`, 429 attempts in red and 5xx in
-orange, and one sentence explains the codes.
+in the windows. The hover reads the document as counts, never as the state
+machine's vocabulary: one line per machine, named by its kernel's own name,
+with its successful requests in the accent and each failure class counted in
+its own colour only when present (429s in the blocked red, 5xx with 529 in the
+5xx magenta, no-connection and other-status failures in the label gray); no
+traffic reads as "no API traffic"; a machine whose sessions are waiting or
+whose kernel is paused shows that kernel's own words instead. The window the
+lines count is named once at the top: the ledger's last 24 hours, or an older
+kernel's longest window. There is no summary sentence: the lines do the work,
+and a machine not reachable keeps its own line saying so. The word `unknown`
+stays in the document and appears nowhere on the dashboard. Under the lines,
+the **History** draws one stacked histogram per machine from the `ledger`:
+one bar per bin, successes in the accent, 429 attempts in red and 5xx in
+magenta stacked on them, and a gray band for no-connection and other-status
+failures only when the range holds any; one ceiling label, no peak figure; a
+vertical, left-justified legend with a swatch in each bar colour (429 on one
+line, 5xx below it, the gray line only when it applies); the age of the read
+in words ("now", "3 minutes ago"), recomputed at every repaint. The hover
+draws the last 24 hours as 96 quarter-hour bars. A click on the dot (or Enter)
+opens the detail, a centred modal in the spend modal's grammar: the same lines,
+the waiting sessions and the pause control, and one large histogram per machine
+with range chips for 1 hour (60 one-minute bars), 24 hours (96 quarter-hour
+bars) and 7 days (168 hourly bars); the hover is unchanged by it.
 
 The signal covers every connected kernel, not only the one serving the page.
 Each kernel serves its own last shell frame at `GET /api-health/frame` (its
@@ -1816,6 +1831,24 @@ its document passes through as answered (404 for an unknown host, 502 when the
 tunnel is down). The merge happens in the browser and follows the federation
 rule: per-host maps in, one line per machine out, the worst state wins for the
 dot, and no count or clock is ever added to or compared with another kernel's.
+
+### The ledger
+
+Every attempt is also folded, the moment it lands, into `ledger`, a per-bucket
+set of fixed-width bins behind the dashboard's histograms: `minute` (60
+one-minute bins, the last hour), `fiveMin` (288 five-minute bins, the last 24
+hours) and `hour` (168 hourly bins, the last 7 days), each tier an object with
+`binS`, `from` (the first bin's start) and one integer array per class (`ok`,
+`rateLimited`, `serverErrors` with 529, `noStatus`, `other`), oldest first, the
+last bin the one holding `asOf`, zeros where nothing landed. The event ring
+holds only the windows' span, so this is what lets the popup show the day and
+the detail the week. Bounded: at most 516 bins per bucket, under about 100 KB
+per bucket in memory when every bin has traffic and about 10 KB in the state
+file; buckets (auth times family) are few. It is written to `api-health.json`
+with the state (on a transition, and on the first event of each minute, so a
+restart loses at most the current minute) and restored at boot, malformed
+pieces skipped and counted in the log. Additive: a reader that ignores it sees
+the document it always saw.
 
 ### Derived state
 
@@ -1946,7 +1979,7 @@ again to a shell that sends `ready`:
 {"type": "apiHealth", "state": "ok | degraded | paused",
  "cls": "429 | 529 | offline | errors | ''", "reason": "'' | limit | spend | manual",
  "text": "<the rail's words>", "waiting": 0, "retrying": 0, "blocked": 0,
- "since": 0, "tmux": 0, "seq": 0, "quiet": false, "errs": 0,
+ "since": 0, "tmux": 0, "seq": 0, "quiet": false, "errs": 0, "host": "<this kernel's name to its peers>",
  "sessions": [{"sid": "", "name": "", "color": null, "kind": "retrying | blocked",
                "cls": "", "status": null, "since": 0, "suppressed": false}],
  "hosts": {"<host>": {"state": "ok | degraded | paused", "cls": "", "text": "", "waiting": 0,
@@ -1970,7 +2003,9 @@ model allowance, a dead credential, a refusal) are not counted; a spend cap is,
 and engages the `spend` pause in the same cycle. `quiet` is true when this
 kernel's API-health aggregator saw no event in its longest window (or the
 kernel has no SDK backend), the fact behind the dot's gray before any history
-is read. `hosts` is every attached
+is read. `host` is this kernel's own name, the one its peers know it by
+(`_self_host`): the popup's line for this machine carries it instead of "this
+machine". `hosts` is every attached
 machine's own frame as the tunnel supervisor last heard it (the fields above
 minus `sessions` and `seq`, which stay on their kernel), keyed by host name,
 with `stale` true while that tunnel is not up; a kernel with no attached
@@ -1987,12 +2022,15 @@ Nothing polls; the frame carries no history and is unchanged. Each machine's
 document is read in the plain words of "On the dashboard" above: over the
 longest window of `config.windows`, `requests` plus `noStatus` are the
 attempts, `rateLimited`, `serverErrors` (with `overloaded`), `otherErrors`
-and `noStatus` the failures, and `gaveUp` the turns that gave up; traffic with
-no failures reads as the successes counted, failures read counted in the
-machine's phrase (`thrashing` as a rate-limit storm, `degraded` as the API
-failing), and no attempts read as quiet; the state machine's word itself is
-never shown. Under each machine's reading sits the graph from `series`, then
-one legend sentence for the codes, and this machine's State changes: up to
+and `noStatus` the failures, and `gaveUp` the turns that gave up; the lines
+count the `ledger` instead when the kernel serves one (its five-minute tier,
+the last 24 hours): successes as "N successful requests", each failure class
+counted in its colour when present, no attempts as "no API traffic"; the state
+machine's word itself is never shown. Under the lines sit the histograms from
+the `ledger` (one per machine, the tier the range names, summed bin by bin
+across one kernel's buckets; an older kernel's document, which has no ledger,
+draws its 15-minute `series` the same way), then the legend, and this
+machine's State changes: up to
 four rows of `transitions` newest first with the state entered in plain words
 (`rate-limit storm`, `API failing`, `recovering`, `fine`, `quiet`) and how
 long it held (until the same bucket's next transition, `so far` for the

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1789,17 +1789,20 @@ its own colour only when present (429s in the blocked red, 5xx with 529 in the
 5xx magenta, no-connection and other-status failures in the label gray); no
 traffic reads as "no API traffic"; a machine whose sessions are waiting or
 whose kernel is paused shows that kernel's own words instead. The window the
-lines count is named once at the top: the ledger's last 24 hours, or an older
-kernel's longest window. There is no summary sentence: the lines do the work,
+lines count is named once at the top, this kernel's: the ledger's last 24
+hours (a peer still on an older kernel counts its own longest window, and its
+histogram says so). There is no summary sentence: the lines do the work,
 and a machine not reachable keeps its own line saying so. The word `unknown`
 stays in the document and appears nowhere on the dashboard. Under the lines,
 the **History** draws one stacked histogram per machine from the `ledger`:
 one bar per bin, successes in the accent, 429 attempts in red and 5xx in
 magenta stacked on them, and a gray band for no-connection and other-status
-failures only when the range holds any; one ceiling label, no peak figure; a
-vertical, left-justified legend with a swatch in each bar colour (429 on one
-line, 5xx below it, the gray line only when it applies); the age of the read
-in words ("now", "3 minutes ago"), recomputed at every repaint. The hover
+failures only when the range or a counted line holds any; one ceiling label,
+no peak figure; a vertical, left-justified legend with a swatch for each
+failure colour (429 on one line, 5xx below it, the gray line only when it
+applies; the accent band needs no row); the age of the read in words ("read
+now", "read 3 minutes ago"), the time since this machine's document landed
+measured on the browser's clock alone, recomputed at every repaint. The hover
 draws the last 24 hours as 96 quarter-hour bars. A click on the dot (or Enter)
 opens the detail, a centred modal in the spend modal's grammar: the same lines,
 the waiting sessions and the pause control, and one large histogram per machine
@@ -1843,12 +1846,14 @@ hours) and `hour` (168 hourly bins, the last 7 days), each tier an object with
 last bin the one holding `asOf`, zeros where nothing landed. The event ring
 holds only the windows' span, so this is what lets the popup show the day and
 the detail the week. Bounded: at most 516 bins per bucket, under about 100 KB
-per bucket in memory when every bin has traffic and about 10 KB in the state
-file; buckets (auth times family) are few. It is written to `api-health.json`
-with the state (on a transition, and on the first event of each minute, so a
-restart loses at most the current minute) and restored at boot, malformed
-pieces skipped and counted in the log. Additive: a reader that ignores it sees
-the document it always saw.
+per bucket in memory when every bin has traffic and about 17 KB in the state
+file (about 33 bytes a bin); buckets (auth times family) are few. A bin past
+the event being folded (a clock that stepped back left it) is dropped with the
+stale ones, so no phantom bar resurfaces when the clock reaches it. It is
+written to `api-health.json` with the state (on a transition, and on the first
+event of each new minute, monotone, so a restart loses at most the current
+minute) and restored at boot, malformed pieces skipped and counted in the log.
+Additive: a reader that ignores it sees the document it always saw.
 
 ### Derived state
 
@@ -2007,7 +2012,8 @@ is read. `host` is this kernel's own name, the one its peers know it by
 (`_self_host`): the popup's line for this machine carries it instead of "this
 machine". `hosts` is every attached
 machine's own frame as the tunnel supervisor last heard it (the fields above
-minus `sessions` and `seq`, which stay on their kernel), keyed by host name,
+minus `sessions`, `seq` and `host`, which stay on their kernel; the map's key
+is the name), keyed by host name,
 with `stale` true while that tunnel is not up; a kernel with no attached
 machines sends an empty map, and a kernel serving `GET /api-health/frame` to
 a peer sends its own frame without this map, so two kernels attached to each

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -47563,6 +47563,12 @@ _LANDING_APIH_JS = """
 // local frame alone paints the dot and the popup says so in the kernel's own words
 var MERGE=window.__rompApiHealthMerge||null;
 var READINGS={};   // per host: the history reading (readHistory), null until read; the machine lines take it (the dot follows the frames)
+var LANDED=null;   // when this machine's document last landed, on THIS clock (Date.now): the read's age never compares two hosts' clocks
+var ageTimer=null; // while the tip or the detail is open, the age label alone is re-worded once a minute (a pinned detail must not say 'now' for ten minutes)
+function ageWords(){return LANDED&&MERGE?'read '+MERGE.agoWords((Date.now()-LANDED)/1000):'';}
+function ageTick(){var n=tip.querySelector('.ah-ago');if(n){var w=ageWords();if(w)n.textContent=w;}}
+function armAge(){if(!ageTimer)ageTimer=setInterval(ageTick,60000);}
+function disarmAge(){if(ageTimer){clearInterval(ageTimer);ageTimer=null;}}
 var moving=false;  // the readout is re-parenting the cell (moveApiCell): its blur and focus are not the user's
 var DOTWORD={fine:'fine',errors:'errors',quiet:'no traffic'};
 // the legend (T316, the user's design): vertical and left-justified, a swatch in each bar's colour, 429 on one line and
@@ -47652,7 +47658,8 @@ function hostsOf(m){return Object.keys((m&&m.hosts)||{}).sort();}
 // open keeps each machine's last answer until its new one lands. The newest read wins a race (histSeq).
 function load(fresh){var n=++histSeq,names=[''].concat(hostsOf(LAST)),by={};
 names.forEach(function(h){by[h]=(!fresh&&HIST&&HIST[h]&&!HIST[h].pending)?HIST[h]:{pending:true};});HIST=by;
-names.forEach(function(h){fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health').then(function(d){if(n!==histSeq)return;by[h]=d;
+if(fresh){READINGS={};LANDED=null;}   // a fresh show drops the last hover's counts with its rows: the frame's words stand until this read lands
+names.forEach(function(h){fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health').then(function(d){if(n!==histSeq)return;by[h]=d;if(h==='')LANDED=Date.now();
 READINGS=MERGE?MERGE.mergeHistories(by).readings:{};
 if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();});});}
 // the merged view of the frame: the dot and one line per machine (worst state wins; per-host maps, nothing summed)
@@ -47680,19 +47687,19 @@ return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}
 // only when the range holds any; one ceiling label, no peak text; a tick at each quarter of the span in ago words. The
 // hover draws the day as 96 quarter-hour bars; the detail draws the chosen range, larger. Colours through the tokens
 // (fallbacks for a var-less harness). EVERY attribute quoted: this goes through innerHTML (the spend chart's lesson).
-var BAR_CLASSES=[['ok','var(--accent,#9cd2ff)'],['rateLimited','var(--st-blocked-bg,#e5484d)'],['serverErrors','var(--st-5xx-bg,#c026d3)'],['noStatus','var(--dim,#9aa4ad)'],['other','var(--dim,#9aa4ad)']];
+var BAR_CLASSES=['ok','rateLimited','serverErrors','noStatus','other'];   // the stack order; each fill is a CSS class per theme (.ah-seg-<class>)
 function niceTopAh(mx){var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),m=mx/p;return (m<=1?1:m<=2?2:m<=5?5:10)*p;}   // a 1-2-5 ceiling at any magnitude
 function tickWords(sec){if(sec>=86400)return Math.round(sec/86400)+'d';if(sec>=3600)return Math.round(sec/3600)+'h';return Math.round(sec/60)+'m';}
 function sumArr(a){var t=0;(a||[]).forEach(function(v){t+=v||0;});return t;}
 function barsHTML(led,big){var n=led.ok.length,W=big?560:168,H=big?110:48,tot=[],mx=0;
-for(var i=0;i<n;i++){var v=0;BAR_CLASSES.forEach(function(c){v+=(led[c[0]]||[])[i]||0;});tot.push(v);if(v>mx)mx=v;}
+for(var i=0;i<n;i++){var v=0;BAR_CLASSES.forEach(function(c){v+=(led[c]||[])[i]||0;});tot.push(v);if(v>mx)mx=v;}
 if(mx<=0)return '';
 var top=niceTopAh(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(0.8,slot-gap),PADT=4;
 var Y=function(v){return H-Math.max(0,Math.min(1,v/top))*(H-PADT);};
 var bars='';
 for(var i=0;i<n;i++){if(!(tot[i]>0))continue;var x=i*slot+gap/2,acc=0;
-BAR_CLASSES.forEach(function(c){var v=(led[c[0]]||[])[i]||0;if(!(v>0))return;var yb=Y(acc),yt=Y(acc+v);acc+=v;var hgt=Math.max(0.6,yb-yt);
-bars+='<rect class="ah-seg ah-seg-'+c[0]+'" x="'+x.toFixed(1)+'" y="'+(yb-hgt).toFixed(1)+'" width="'+bw.toFixed(1)+'" height="'+hgt.toFixed(1)+'" style="fill:'+c[1]+'"></rect>';});}
+BAR_CLASSES.forEach(function(c){var v=(led[c]||[])[i]||0;if(!(v>0))return;var yb=Y(acc),yt=Y(acc+v);acc+=v;var hgt=Math.max(0.6,yb-yt);
+bars+='<rect class="ah-seg ah-seg-'+c+'" x="'+x.toFixed(1)+'" y="'+(yb-hgt).toFixed(1)+'" width="'+bw.toFixed(1)+'" height="'+hgt.toFixed(1)+'"></rect>';});}
 var ty=Y(top),grid='<line x1="0" y1="'+ty.toFixed(1)+'" x2="'+W+'" y2="'+ty.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"></line>',xlab='';
 // ticks at round ages for the span (45/30/15 min, 18/12/6 h, 6/4/2 d), the span itself at the left edge, now at the right
 var span=n*(led.binS||60),marks=span>=604800?[6*86400,4*86400,2*86400]:span>=86400?[18*3600,12*3600,6*3600]:[2700,1800,900];
@@ -47735,14 +47742,18 @@ return out;}
 // ledger) draws its 15-minute series the same way.
 function localFirst(a,b){return a===''?-1:b===''?1:(a<b?-1:a>b?1:0);}
 function ledgerOf(d,R){var led=MERGE?MERGE.documentLedger(d,R.tier):null;if(led&&R.per>1)led=MERGE.rebin(led,R.per);
-if(!led){var sr=MERGE?MERGE.documentSeries(d):null;if(sr)led={binS:sr.binS,from:sr.from,ok:sr.ok,rateLimited:sr.rateLimited,serverErrors:sr.serverErrors,noStatus:sr.noStatus,other:[]};}
+// an older kernel's document has no ledger: its 15-minute series draws instead, and is named as such (its span is not the range's)
+if(!led){var sr=MERGE?MERGE.documentSeries(d):null;if(sr)led={binS:sr.binS,from:sr.from,ok:sr.ok,rateLimited:sr.rateLimited,serverErrors:sr.serverErrors,noStatus:sr.noStatus,other:[],older:true};}
 return led;}
 function histHTML(){var loc=HIST&&HIST[''],R=RANGES[pinned?range:'day'];
-var ago=(loc&&!loc.error&&!loc.pending&&typeof loc.asOf==='number'&&MERGE)?'<span class="ru-tip-reset ah-ago">'+esc(MERGE.agoWords(Date.now()/1000-loc.asOf))+'</span>':'';
+// the read's age: the time since this machine's document LANDED, on this clock alone (the kernel's asOf is another host's clock)
+var ago=(loc&&!loc.error&&!loc.pending&&LANDED&&MERGE)?'<span class="ru-tip-reset ah-ago">'+esc(ageWords())+'</span>':'';
 var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'+ago+'</div>';
 var hs=HIST?Object.keys(HIST).sort(localFirst):[],many=hs.length>1,gray=false;
-// the gray legend line applies when any machine's range holds a no-connection or other-status failure: known up front
-hs.forEach(function(host){var d=HIST[host];if(!d||d.error||d.pending)return;var l=ledgerOf(d,R);if(l&&sumArr(l.noStatus)+sumArr(l.other)>0)gray=true;});
+// the gray legend line applies when any machine's drawn range OR any machine's counted line holds a no-connection or
+// other-status failure (the lines count the day whatever the range): known up front
+hs.forEach(function(host){var d=HIST[host];if(!d||d.error||d.pending)return;var l=ledgerOf(d,R);if(l&&sumArr(l.noStatus)+sumArr(l.other)>0)gray=true;
+var rd=READINGS[host];if(rd&&rd.counts&&(rd.counts.none+rd.counts.other)>0)gray=true;});
 if(pinned)h+=rangeHTML()+legendHTML(gray);   // the detail: the chips, then the colours named where the eye starts
 if(!HIST)return h+'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div></div>';
 hs.forEach(function(host){var d=HIST[host],name=host||SELF();
@@ -47750,9 +47761,9 @@ hs.forEach(function(host){var d=HIST[host],name=host||SELF();
 if(d&&d.pending){h+=many?'<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot=quiet></i><span class=ah-nm>'+esc(name)+'</span><span class="rl-dots ah-wait"><i></i><i></i><i></i></span></div>':'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div>';return;}
 if(!d||d.error){h+='<div class="ah-line ah-err">Could not read the API history'+(many?' of '+esc(name):'')+': '+esc((d&&d.error)||'no answer')+'</div>';return;}
 if(many)h+='<div class="ru-tip-row ah-gname"><span class=ah-nm>'+esc(name)+'</span></div>';
-var led=ledgerOf(d,R),bars=led?barsHTML(led,pinned):'';
-if(!bars){h+='<div class="ah-line ru-tip-reset">no attempts in the '+esc(R.label)+'</div>';return;}
-h+=bars;});
+var led=ledgerOf(d,R),bars=led?barsHTML(led,pinned):'',span=(led&&led.older)?'last 15 min (an older kernel)':R.label;
+if(!bars){h+='<div class="ah-line ru-tip-reset">no attempts in the '+esc(span)+'</div>';return;}
+h+=bars;if(led.older)h+='<div class="ah-line ru-tip-reset">the last 15 min: an older kernel serves no longer history</div>';});
 if(!pinned)h+=legendHTML(gray);   // the hover: the legend under the bars
 var tr=(loc&&!loc.error&&!loc.pending)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 '+esc(SELF()):'')+'</span></div>'+tr;
 return h+'</div>';}
@@ -47763,6 +47774,9 @@ return h+'</div>';}
 // failed read says so in the same words as the section's line
 function descText(){var tail=' Press Enter to open it.';var mg=merged();var m0=mg.machines[0];   // this machine's own line, its words alone
 var w=m0?(m0.parts||[]).map(function(p){return p.text;}).join(' \u00b7 '):'';
+// a fine frame says nothing in its line until the read lands, but the description is read once, at focus time, and needs
+// a state word: the dot's own (Fine, Errors, No traffic)
+if(!w){w=DOTWORD[mg.dot]||'';if(w)w=w.charAt(0).toUpperCase()+w.slice(1);}   // the kernel's own words keep their case
 if(w&&!/[.!?]$/.test(w))w+='.';
 var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;
 if(!HIST||(HIST['']&&HIST[''].pending))return 'API health: '+w+' Reading the details.'+tail;
@@ -47813,8 +47827,8 @@ try{if(n)n.focus();if(!n||document.activeElement!==n)tip.focus();}catch(e){}}}
 function show(ev){if(!LAST)return;lastX=(ev&&typeof ev.clientX==='number')?ev.clientX:null;
 try{window.__rompUsageTipHide&&window.__rompUsageTipHide();}catch(e){}   // the readout's tip yields while ours shows (the cell sits inside it)
 tip.classList.remove('ru-modal');tip.setAttribute('role','tooltip');tip.removeAttribute('aria-modal');
-tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();}
-function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');}
+tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();armAge();}
+function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');disarmAge();}
 function close(){hide();tip.classList.remove('ru-modal');back.classList.remove('on');pinned=false;
 window.__rompApiClose=null;if(back.onclick===close)back.onclick=null;
 // the refocus fires the cell's focus event, which would pop the hover right after Escape: skipFocus covers that one
@@ -47830,7 +47844,7 @@ function open(){if(!LAST)return;try{window.__rompUsageClose&&window.__rompUsageC
 var was=tip.style.display==='block';
 focusBack=document.activeElement;pinned=true;tip.classList.add('ru-modal');tip.style.left='';tip.style.top='';tip.style.maxHeight='';
 tip.setAttribute('role','dialog');tip.setAttribute('aria-modal','true');el.removeAttribute('aria-describedby');
-tip.style.display='block';render();back.classList.add('on');
+tip.style.display='block';render();back.classList.add('on');armAge();
 window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}if(!was)load();}
 // The listeners sit on the STABLE #rail-api cell; __rompApiHealth writes its children, never the cell.
 // a pointer arriving on a tip that focus already shows re-anchors it from the pointer and keeps its rows: the
@@ -50029,12 +50043,18 @@ def _landing():
             # T316: a machine line's pieces in their class colours (successes the accent, 429 the blocked red, 5xx the 5xx
             # magenta, no connection and other statuses the label gray), the vertical legend with swatches in the bar
             # colours, the stacked bars (the hover's small, the detail's large), the detail's range chips and width
-            ".ah-c-ok{color:var(--accent,#9cd2ff)}.ah-c-r429{color:var(--st-blocked-bg,#e5484d)}.ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}"
-            ".ah-c-none{color:var(--dim,#9aa4ad)}.ah-mline .ah-desc{opacity:1}.ah-mline .ah-c-plain{opacity:.85}"
+            # the counts' TEXT inks per theme (review find: the chip colours as text sit under 4.5:1 on the tip; the
+            # failure line's precedent is #ef6b6f dark / #B02A1C light): 429 the error-text red, 5xx a lighter magenta in
+            # the dark, a deeper one in the light; the swatches and the bars keep the chip colours
+            ".ah-c-ok{color:var(--accent,#9cd2ff)}.ah-c-r429{color:#ef6b6f}.ah-c-r5xx{color:#e879f9}"
+            ".ah-c-none{color:#9aa4ad}.ah-mline .ah-desc{opacity:1}.ah-mline .ah-c-plain{opacity:.85}"
             ".ah-win,.ah-ago{margin-left:auto}"
             ".ah-legend{display:flex;flex-direction:column;align-items:flex-start;gap:3px;margin-top:7px;opacity:.75}"
             ".ah-lrow{display:flex;align-items:center;gap:6px}.ah-lsw{width:8px;height:8px;border-radius:2px;flex:0 0 auto}"
-            ".ah-sw-ok{background:var(--accent,#9cd2ff)}.ah-sw-r429{background:var(--st-blocked-bg,#e5484d)}.ah-sw-r5xx{background:var(--st-5xx-bg,#c026d3)}.ah-sw-none{background:var(--dim,#9aa4ad)}"
+            ".ah-sw-r429{background:var(--st-blocked-bg,#e5484d)}.ah-sw-r5xx{background:var(--st-5xx-bg,#c026d3)}.ah-sw-none{background:#9aa4ad}"
+            # the bars' fills, one class per stack segment (the landing defines no --dim, so the gray is written out)
+            ".ah-seg-ok{fill:var(--accent,#9cd2ff)}.ah-seg-rateLimited{fill:var(--st-blocked-bg,#e5484d)}.ah-seg-serverErrors{fill:var(--st-5xx-bg,#c026d3)}"
+            ".ah-seg-noStatus,.ah-seg-other{fill:#9aa4ad}"
             ".ah-gname{margin-top:6px}.ah-bars.ah-big svg{height:110px}.ah-bars.ah-big{margin-bottom:12px}"
             ".ah-range{margin:4px 0 6px}"
             "#ah-tip.ru-modal{width:min(720px,92vw)}"
@@ -50472,6 +50492,11 @@ def _landing():
             # the failure line in the light theme's error-text red (styles.css --err #B02A1C, about 6.6:1 on white;
             # the dark line's #ef6b6f is 3.0:1 there)
             "body.theme-light .ah-err{color:#B02A1C}"
+            # T316, the light tip is white: the counts' inks (the clay accent, the light error red, a deep magenta 6.5:1, the
+            # light label gray 7.15:1), the swatches and the bars' fills in the light palette's chip colours
+            "body.theme-light .ah-c-ok{color:#C2410C}body.theme-light .ah-c-r429{color:#B02A1C}body.theme-light .ah-c-r5xx{color:#86198F}body.theme-light .ah-c-none{color:#5D574E}"
+            "body.theme-light .ah-sw-r5xx{background:#A21CAF}body.theme-light .ah-sw-none{background:#5D574E}"
+            "body.theme-light .ah-seg-ok{fill:#C2410C}body.theme-light .ah-seg-serverErrors{fill:#A21CAF}body.theme-light .ah-seg-noStatus,body.theme-light .ah-seg-other{fill:#5D574E}"
             "body.theme-light .ah-word{color:#1F1E1D}"
             "body.theme-light .ah-btn{background:#F1EAE2;border-color:rgba(0,0,0,0.12);color:#1F1E1D}"
             "body.theme-light .ah-row:hover{background:rgba(0,0,0,0.05)}"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -43943,6 +43943,7 @@ def _api_health_frame(now, tmux):
             # no API traffic in the longest window (T301): the dot reads gray on this alone, before any history is read;
             # True with no SDK backend (nothing can have talked to the API through this kernel)
             "quiet": _apih_quiet(now),
+            "host": _self_host(),   # this kernel's own name to its peers (T316): the popup's line for this machine names it
             # failed attempts in that window (T301 review): the dot reads red for a storm the window still holds when
             # no session waits right now, and clears the cycle the last failure ages out; the frame is rebuilt every
             # cycle and pushed on change, so the browser never polls the history for the dot
@@ -47564,7 +47565,14 @@ var MERGE=window.__rompApiHealthMerge||null;
 var READINGS={};   // per host: the history reading (readHistory), null until read; the machine lines take it (the dot follows the frames)
 var moving=false;  // the readout is re-parenting the cell (moveApiCell): its blur and focus are not the user's
 var DOTWORD={fine:'fine',errors:'errors',quiet:'no traffic'};
-var LEGEND='429 = the API told us to slow down (rate limit) \u00b7 5xx = the API itself failed (server error) \u00b7 offline = no connection';
+// the legend (T316, the user's design): vertical and left-justified, a swatch in each bar's colour, 429 on one line and
+// 5xx on its own below it; the gray line only when the range holds a no-connection or other-status failure
+var LEGEND_ROWS=[['r429','429 = the API told us to slow down (rate limit)'],['r5xx','5xx = the API itself failed (server error)'],['none','gray = no connection, or another error']];
+// the histograms' ranges (T316): the hover draws the day; the detail (the dot's click) offers 1 hour, 24 hours and 7 days
+// in the spend modal's range-chip grammar. Each names the ledger tier it reads and how many bins make one bar.
+var RANGES={hour:{tier:'minute',per:1,label:'1 hour',s:3600},day:{tier:'fiveMin',per:3,label:'24 hours',s:86400},week:{tier:'hour',per:1,label:'7 days',s:604800}};
+var range='day';
+function SELF(){return (LAST&&LAST.host)||'this machine';}   // this kernel's own name, from its frame (T316)
 var STATE_WORD={thrashing:'rate-limit storm',degraded:'API failing',recovering:'recovering',healthy:'fine',unknown:'quiet'};
 var tip=document.createElement('div');tip.id='ah-tip';tip.style.display='none';
 tip.setAttribute('role','tooltip');tip.setAttribute('aria-label','API health');tip.tabIndex=-1;document.body.appendChild(tip);
@@ -47650,25 +47658,11 @@ if(tip.style.display!=='block')return;if(held){dirty=true;return;}render();});})
 // the merged view of the frame: the dot and one line per machine (worst state wins; per-host maps, nothing summed)
 function merged(){if(!LAST)return {dot:'fine',worst:'',machines:[],n:1};
 if(MERGE)return MERGE.mergeFrames(LAST,LAST.hosts||{},READINGS);
-var d=LAST.state==='ok'?'fine':'errors';return {dot:d,worst:'',machines:[{host:'',dot:d,text:'this machine: '+LAST.text,stale:false}],n:1};}
+var d=LAST.state==='ok'?'fine':'errors';return {dot:d,worst:'',machines:[{host:'',name:SELF(),dot:d,parts:[{text:LAST.text,kind:'plain'}],text:SELF()+': '+LAST.text,stale:false}],n:1};}
 function readingOf(host){var d=HIST&&HIST[host];if(!d||d.error||d.pending||!MERGE)return null;return MERGE.readHistory(d);}
 // the cell: the dot's state and its description, from the merge; the DOM is touched only on a change
 function paintCell(){var mg=merged();if(el.getAttribute('data-dot')!==mg.dot)el.setAttribute('data-dot',mg.dot);
 var lab='API health: '+DOTWORD[mg.dot]+(mg.n>1?' across '+mg.n+' machines':'');if(el.getAttribute('aria-label')!==lab)el.setAttribute('aria-label',lab);}
-// the head's words: a pause in the kernel's own words; errors as the worst machine's line; else what happened
-function headWords(m,mg){if(m.state==='paused')return m.text;
-var rd=readingOf('');
-if(mg.n>1){   // several machines: the head sums them up in one line; each machine's own line follows
-var bad=mg.machines.filter(function(x){return x.dot==='errors';}).map(function(x){return x.host||'this machine';});
-var away=mg.machines.filter(function(x){return x.stale;}).map(function(x){return x.host||'this machine';});   // named, not counted
-if(bad.length)return 'Errors on '+bad.join(', ')+(away.length?'; '+away.join(', ')+' not reachable':'');
-if(away.length)return (mg.dot==='quiet'?'No API traffic':'Fine')+' on the reachable machines; '+away.join(', ')+' not reachable.';
-if(mg.dot==='quiet')return 'No API traffic on any machine.';
-return 'All '+mg.n+' machines fine.';}
-if(mg.dot==='errors'){if(m.state!=='ok')return m.text;   // this machine's frame: sessions waiting on the API, in the kernel's words
-if(rd)return rd.headline;   // the window in errors: the reading's sentence once read
-return (m.errs||0)>0?m.errs+' failed attempt'+(m.errs===1?'':'s')+' in the last 15 min.':m.text;}   // before it lands: the frame's own count
-if(rd)return rd.headline;return mg.dot==='quiet'?'No API traffic in the last 15 min.':'Fine.';}
 // a bucket's name for the card: its model family, plus its auth label when another bucket shares the family
 function bname(d,key){var b=(d.buckets||{})[key]||{},fam=b.family||key.split('|')[1]||key,dup=false;
 Object.keys(d.buckets||{}).forEach(function(k){if(k!==key&&((d.buckets[k]||{}).family||'')===fam)dup=true;});
@@ -47681,26 +47675,38 @@ return dup?fam+' · '+(b.auth||key.split('|')[0]):fam;}
 // are named when there are any (an offline window would otherwise read 'no attempts' and hide its give-ups). A mixed
 // window counts every attempt once and says how many of them had no status, with the shares' base named beside them:
 // '15 attempts, 7 of them without a status · 25% 429 · 0% 5xx of the other 8'.
-// attempts per minute over the longest window, in the usage hover's graph grammar (T301): the polyline + fill for
-// every attempt, 429 attempts in the blocked red and 5xx in the warn amber over it so a storm reads at a glance, ONE
-// ceiling label, a tick every five minutes. Colours through the tokens (fallbacks for a var-less harness).
-function graphHTML(sr){var n=sr.ok.length,W=168,H=48,tot=[],mx=0;
-for(var i=0;i<n;i++){var v=(sr.ok[i]||0)+(sr.rateLimited[i]||0)+(sr.serverErrors[i]||0)+(sr.noStatus[i]||0);tot.push(v);if(v>mx)mx=v;}
+// the histogram (T316, the user's design): one bar per bin, STACKED bottom-up, successes in the accent, 429 attempts in
+// the blocked red, 5xx (529 included) in the 5xx magenta, and a gray band for no-connection and other-status failures
+// only when the range holds any; one ceiling label, no peak text; a tick at each quarter of the span in ago words. The
+// hover draws the day as 96 quarter-hour bars; the detail draws the chosen range, larger. Colours through the tokens
+// (fallbacks for a var-less harness). EVERY attribute quoted: this goes through innerHTML (the spend chart's lesson).
+var BAR_CLASSES=[['ok','var(--accent,#9cd2ff)'],['rateLimited','var(--st-blocked-bg,#e5484d)'],['serverErrors','var(--st-5xx-bg,#c026d3)'],['noStatus','var(--dim,#9aa4ad)'],['other','var(--dim,#9aa4ad)']];
+function niceTopAh(mx){var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),m=mx/p;return (m<=1?1:m<=2?2:m<=5?5:10)*p;}   // a 1-2-5 ceiling at any magnitude
+function tickWords(sec){if(sec>=86400)return Math.round(sec/86400)+'d';if(sec>=3600)return Math.round(sec/3600)+'h';return Math.round(sec/60)+'m';}
+function sumArr(a){var t=0;(a||[]).forEach(function(v){t+=v||0;});return t;}
+function barsHTML(led,big){var n=led.ok.length,W=big?560:168,H=big?140:48,tot=[],mx=0;
+for(var i=0;i<n;i++){var v=0;BAR_CLASSES.forEach(function(c){v+=(led[c[0]]||[])[i]||0;});tot.push(v);if(v>mx)mx=v;}
 if(mx<=0)return '';
-var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),m=mx/p,top=(m<=1?1:m<=2?2:m<=5?5:10)*p;   // a 1-2-5 ceiling at any magnitude: the peak is never clipped
-var X=function(i){return (n>1?i/(n-1):0.5)*W;},Y=function(v){return H-1-Math.max(0,Math.min(1,v/top))*(H-2);};
-var line=function(arr,color,op){var pts=[],anyv=false;for(var i=0;i<n;i++){var v=arr[i]||0;if(v)anyv=true;pts.push(X(i).toFixed(1)+','+Y(v).toFixed(1));}
-if(!anyv)return '';return '<polyline points="'+pts.join(' ')+'" fill="none" style="stroke:'+color+'" stroke-width="1.5" vector-effect="non-scaling-stroke"/>'
-+'<polygon points="0,'+(H-1)+' '+pts.join(' ')+' '+W+','+(H-1)+'" style="fill:'+color+'" opacity="'+op+'" stroke="none"/>';};
-var ty=Y(top),grid='<line x1="0" y1="'+ty.toFixed(1)+'" x2="'+W+'" y2="'+ty.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"/>',xlab='';
-var per=Math.max(1,Math.round(300/(sr.binS||60)));   // a tick every five minutes
-for(var i=0;i<n;i++){var ago=(n-1-i)*(sr.binS||60);if(i===n-1||(ago%300===0&&ago>0)){var gx=X(i);
-grid+='<line x1="'+gx.toFixed(1)+'" y1="0" x2="'+gx.toFixed(1)+'" y2="'+H+'" stroke="rgba(255,255,255,0.06)" stroke-width="1" vector-effect="non-scaling-stroke"/>';
-xlab+='<span style="left:'+(gx/W*100).toFixed(1)+'%">'+(i===n-1?'now':(ago/60)+'m')+'</span>';}}
-var body=line(tot,'var(--accent,#9cd2ff)',0.18)+line(sr.serverErrors,'var(--warn,#e67e22)',0.35)+line(sr.rateLimited,'var(--st-blocked-bg,#e5484d)',0.35);
-return '<div class=ru-tip-row><span class=ru-tip-k>attempts / min \u00b7 15 min</span><span class=ru-tip-v>peak '+mx+'</span></div>'
-+'<div class=ru-tip-graph><svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">'+grid+body+'</svg>'
-+'<span class=ru-tip-gy style="top:'+(ty/H*56).toFixed(0)+'px">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}
+var top=niceTopAh(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(0.8,slot-gap),PADT=4;
+var Y=function(v){return H-Math.max(0,Math.min(1,v/top))*(H-PADT);};
+var bars='';
+for(var i=0;i<n;i++){if(!(tot[i]>0))continue;var x=i*slot+gap/2,acc=0;
+BAR_CLASSES.forEach(function(c){var v=(led[c[0]]||[])[i]||0;if(!(v>0))return;var yb=Y(acc),yt=Y(acc+v);acc+=v;var hgt=Math.max(0.6,yb-yt);
+bars+='<rect class="ah-seg ah-seg-'+c[0]+'" x="'+x.toFixed(1)+'" y="'+(yb-hgt).toFixed(1)+'" width="'+bw.toFixed(1)+'" height="'+hgt.toFixed(1)+'" style="fill:'+c[1]+'"></rect>';});}
+var ty=Y(top),grid='<line x1="0" y1="'+ty.toFixed(1)+'" x2="'+W+'" y2="'+ty.toFixed(1)+'" stroke="rgba(255,255,255,0.10)" stroke-width="1" vector-effect="non-scaling-stroke"></line>',xlab='';
+// ticks at round ages for the span (45/30/15 min, 18/12/6 h, 6/4/2 d), the span itself at the left edge, now at the right
+var span=n*(led.binS||60),marks=span>=604800?[6*86400,4*86400,2*86400]:span>=86400?[18*3600,12*3600,6*3600]:[2700,1800,900];
+xlab+='<span style="left:0%">'+tickWords(span)+'</span>';
+marks.forEach(function(ago){if(ago>=span)return;var gx=(1-ago/span)*W;grid+='<line x1="'+gx.toFixed(1)+'" y1="0" x2="'+gx.toFixed(1)+'" y2="'+H+'" stroke="rgba(255,255,255,0.06)" stroke-width="1" vector-effect="non-scaling-stroke"></line>';
+xlab+='<span style="left:'+((1-ago/span)*100).toFixed(1)+'%">'+tickWords(ago)+'</span>';});
+xlab+='<span style="left:100%">now</span>';
+return '<div class="ru-tip-graph ah-bars'+(big?' ah-big':'')+'" data-bars="'+n+'"><svg viewBox="0 0 '+W+' '+H+'" preserveAspectRatio="none">'+grid+bars+'</svg>'
++'<span class=ru-tip-gy style="top:'+(big?ty:ty/H*56).toFixed(0)+'px">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}
+function legendHTML(gray){var h='<div class=ah-legend>';LEGEND_ROWS.forEach(function(r){if(r[0]==='none'&&!gray)return;
+h+='<div class=ah-lrow><i class="ah-lsw ah-sw-'+r[0]+'"></i><span>'+r[1]+'</span></div>';});return h+'</div>';}
+function rangeHTML(){var h='<div class="rsp-ctl ah-range">';Object.keys(RANGES).forEach(function(k){h+='<button class="rsp-btn'+(range===k?' on':'')+'" data-act="range:'+k+'">'+RANGES[k].label+'</button>';});return h+'</div>';}
+// a machine's line pieces, each class in its colour (the merge's Seg kinds: ok, r429, r5xx, none, plain)
+function partsHTML(parts){return '<span class=ah-desc>'+parts.map(function(p){return '<span class="ah-c-'+esc(p.kind)+'">'+esc(p.text)+'</span>';}).join(' \u00b7 ')+'</span>';}
 // the newest HIST_ROWS transitions, newest first: the time, the state entered (with its bucket when there are
 // several), and how long it held (until the same bucket's next transition; 'so far' for the current one, a flag and
 // never a stamp comparison: the transition the hover's own read files carries that read's asOf as its time, and the
@@ -47723,47 +47729,54 @@ var word=(multi?bname(d,r.bucket)+' ':'')+(STATE_WORD[r.to]||r.to)+(restart?' \u
 out+='<div class="ru-tip-row ah-hrow"><span class=ru-tip-k>'+hmd(r.t)+'</span><span class=ah-hword>'+esc(word)+'</span><span class=ru-tip-v>'+dur(end-r.t)+(cur?' so far':'')+'</span></div>';
 if(restart)sawRestart=true;shown++;}
 return out;}
-// History (T301): what happened, per machine, in plain words; the graph; the legend; this machine's State changes,
-// capped and worded plainly. The state machine's word appears only inside the plain phrasing (readHistory), and
-// "unknown" nowhere: traffic with no errors reads as the successes counted, no traffic reads as quiet.
+// History (T301, T316): one stacked histogram per machine over the range (the day in the hover, the chosen range in the
+// detail), the machine's name above it when there are several, the legend, this machine's State changes (capped, worded
+// plainly). The as-of stamp reads as an age in words, recomputed at every render. An older kernel's document (no
+// ledger) draws its 15-minute series the same way.
 function localFirst(a,b){return a===''?-1:b===''?1:(a<b?-1:a>b?1:0);}
-function levelDot(rd){return rd?(rd.level==='errors'?'errors':rd.level==='quiet'?'quiet':'fine'):'fine';}
-function histHTML(){var loc=HIST&&HIST[''],asOf=(loc&&!loc.error&&typeof loc.asOf==='number')?'<span class=ru-tip-reset>as of '+hms(loc.asOf)+'</span>':'';
-var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'+asOf+'</div>';
+function ledgerOf(d,R){var led=MERGE?MERGE.documentLedger(d,R.tier):null;if(led&&R.per>1)led=MERGE.rebin(led,R.per);
+if(!led){var sr=MERGE?MERGE.documentSeries(d):null;if(sr)led={binS:sr.binS,from:sr.from,ok:sr.ok,rateLimited:sr.rateLimited,serverErrors:sr.serverErrors,noStatus:sr.noStatus,other:[]};}
+return led;}
+function histHTML(){var loc=HIST&&HIST[''],R=RANGES[pinned?range:'day'];
+var ago=(loc&&!loc.error&&!loc.pending&&typeof loc.asOf==='number'&&MERGE)?'<span class="ru-tip-reset ah-ago">'+esc(MERGE.agoWords(Date.now()/1000-loc.asOf))+'</span>':'';
+var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'+ago+'</div>';
+if(pinned)h+=rangeHTML();
 if(!HIST)return h+'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div></div>';
-var hs=Object.keys(HIST).sort(localFirst),many=hs.length>1;
-hs.forEach(function(host){var d=HIST[host],name=host||'this machine';
+var hs=Object.keys(HIST).sort(localFirst),many=hs.length>1,gray=false;
+hs.forEach(function(host){var d=HIST[host],name=host||SELF();
 // a machine whose answer is still in flight: its loader line (alone, the section's loader), never a blank
 if(d&&d.pending){h+=many?'<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot=quiet></i><span class=ah-nm>'+esc(name)+'</span><span class="rl-dots ah-wait"><i></i><i></i><i></i></span></div>':'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div>';return;}
 if(!d||d.error){h+='<div class="ah-line ah-err">Could not read the API history'+(many?' of '+esc(name):'')+': '+esc((d&&d.error)||'no answer')+'</div>';return;}
-var rd=MERGE?MERGE.readHistory(d):null;
-// with several machines each gets its line (the head already carries this machine's when alone)
-if(many)h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+levelDot(rd)+'></i><span class=ah-nm>'+esc(name)+'</span><span class=ah-desc>'+esc(rd?rd.headline:'')+'</span></div>';
-if(rd&&rd.sub&&many)h+='<div class="ah-line ru-tip-reset">'+esc(rd.sub)+'</div>';
-var sr=MERGE?MERGE.documentSeries(d):null;if(sr)h+=graphHTML(sr);});
-h+='<div class="ah-line ah-legend">'+LEGEND+'</div>';
-var tr=(loc&&!loc.error&&!loc.pending)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 this machine':'')+'</span></div>'+tr;
+if(many)h+='<div class="ru-tip-row ah-gname"><span class=ah-nm>'+esc(name)+'</span></div>';
+var led=ledgerOf(d,R),bars=led?barsHTML(led,pinned):'';
+if(!bars){h+='<div class="ah-line ru-tip-reset">no attempts in the '+esc(R.label)+'</div>';return;}
+h+=bars;if(sumArr(led.noStatus)+sumArr(led.other)>0)gray=true;});
+h+=legendHTML(gray);
+var tr=(loc&&!loc.error&&!loc.pending)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 '+esc(SELF()):'')+'</span></div>'+tr;
 return h+'</div>';}
 // the cell's description while the hover shows: the state word and its since, then how to reach the rest. Before the
 // answer lands it carries the state word the frame already put on the cell (assistive tech reads the description once,
 // at focus time, and the landed text replaces it with nothing to announce the change: a loading line with no state
 // word would leave a screen-reader user with none) and says the read is in flight; the landed line adds the since; a
 // failed read says so in the same words as the section's line
-function descText(){var tail=' Press Enter to open it.';var mg=merged();var w=LAST?headWords(LAST,mg):'';
-if(!/[.!?]$/.test(w))w+='.';
+function descText(){var tail=' Press Enter to open it.';var mg=merged();var m0=mg.machines[0];   // this machine's own line, its words alone
+var w=m0?(m0.parts||[]).map(function(p){return p.text;}).join(' \u00b7 '):'';
+if(w&&!/[.!?]$/.test(w))w+='.';
 var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;
 if(!HIST||(HIST['']&&HIST[''].pending))return 'API health: '+w+' Reading the details.'+tail;
 return 'API health: '+w+tail;}
 // full=false is the HOVER: the same reading with no controls. The hover sits under pointer-events:none and hides
 // on mouseleave, so a button there could not be honored; the click is where the actions live.
 function html(m,full){var mg=merged(),rd=readingOf('');
-var h='<div class=ru-tip-win><div class=ru-tip-name><span>API health'+(mg.n>1?' \u00b7 '+mg.n+' machines':'')+'</span></div>'
-+'<div class="ru-tip-row ah-head"><i class=ah-dot data-dot='+esc(mg.dot)+'></i><span class=ah-word>'+esc(headWords(m,mg))+'</span>'
-+((m.since&&m.state!=='ok')?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';
+// the window the lines count, named ONCE at the top (T316): the ledger's day when this kernel serves one, else the
+// document's longest window; before the read lands, the day
+var win=MERGE?MERGE.windowWords(rd?rd.windowS:86400):'';
+var h='<div class=ru-tip-win><div class=ru-tip-name><span>API health'+(mg.n>1?' \u00b7 '+mg.n+' machines':'')+'</span>'+(win?'<span class="ru-tip-reset ah-win">'+esc(win)+'</span>':'')+'</div>';
+// one line per machine (T316): the dot in that machine's state, its name, then its counts in their colours, or the
+// kernel's own words when its sessions are waiting or it is paused; a machine not reachable says so in its line
+mg.machines.forEach(function(x){h+='<div class="ru-tip-row ah-mline" data-host="'+esc(x.host)+'"><i class=ah-dot data-dot='+esc(x.dot)+'></i><span class=ah-nm>'+esc(x.name)+'</span>'+partsHTML(x.parts||[])
++((x.host===''&&m.since&&m.state!=='ok')?'<span class=ah-since>since '+hm(m.since)+'</span>':'')+'</div>';});
 if(m.state==='paused')h+='<div class=ah-line>'+(PAUSE[m.reason]||PAUSE.manual)+'</div>';
-if(rd&&rd.sub&&mg.n===1)h+='<div class="ah-line ru-tip-reset">'+esc(rd.sub)+'</div>';
-// several machines: one line each, the dot in that machine's state (a machine not reachable says so in its line)
-if(mg.n>1)mg.machines.forEach(function(x){h+='<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot='+esc(x.dot)+'></i><span class=ah-desc>'+esc(x.text)+'</span></div>';});
 if(full)h+=btnHTML(m);
 h+='</div>';
 var rows=m.sessions||[];
@@ -47872,6 +47885,7 @@ else if(act==='reveal'){var sid=t.getAttribute('data-sid')||'';
 // dashboard's chat alone (_reveal_chat_for), never at every open window's. No pane is toggled here, so nothing
 // about the layout is persisted.
 if(window.__rompShellSend&&window.__rompShellSend({type:'openSession',id:sid}))close();else{hint=NOTSENT;dirty=true;}}
+else if(act.indexOf('range:')===0){range=act.slice(6);render();}   // the detail's histogram span (T316)
 else if(act==='usage'){close();try{window.__rompUsagePanel&&window.__rompUsagePanel();}catch(e){}}
 else if(act==='log'){close();try{window.__rompOpenErrs&&window.__rompOpenErrs();}catch(e){}}}
 tip.addEventListener('click',function(ev){var t=actOf(ev.target);if(t)run(t);flush();});
@@ -50010,6 +50024,18 @@ def _landing():
             ".ah-nm{font-weight:600}.ah-desc{opacity:.75}"
             ".ah-foot{margin-top:7px;padding-top:5px;border-top:1px solid rgba(255,255,255,0.08);gap:12px}"
             ".ah-link{cursor:pointer;color:var(--accent)}"
+            # T316: a machine line's pieces in their class colours (successes the accent, 429 the blocked red, 5xx the 5xx
+            # magenta, no connection and other statuses the label gray), the vertical legend with swatches in the bar
+            # colours, the stacked bars (the hover's small, the detail's large), the detail's range chips and width
+            ".ah-c-ok{color:var(--accent,#9cd2ff)}.ah-c-r429{color:var(--st-blocked-bg,#e5484d)}.ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}"
+            ".ah-c-none{color:var(--dim,#9aa4ad)}.ah-mline .ah-desc{opacity:1}.ah-mline .ah-c-plain{opacity:.85}"
+            ".ah-win,.ah-ago{margin-left:auto}"
+            ".ah-legend{display:flex;flex-direction:column;align-items:flex-start;gap:3px;margin-top:7px;opacity:.75}"
+            ".ah-lrow{display:flex;align-items:center;gap:6px}.ah-lsw{width:8px;height:8px;border-radius:2px;flex:0 0 auto}"
+            ".ah-sw-ok{background:var(--accent,#9cd2ff)}.ah-sw-r429{background:var(--st-blocked-bg,#e5484d)}.ah-sw-r5xx{background:var(--st-5xx-bg,#c026d3)}.ah-sw-none{background:var(--dim,#9aa4ad)}"
+            ".ah-gname{margin-top:6px}.ah-bars.ah-big svg{height:140px}.ah-bars.ah-big{margin-bottom:14px}"
+            ".ah-range{margin:4px 0 6px}"
+            "#ah-tip.ru-modal{width:min(720px,92vw)}"
             # a failed send's reason, under the button it restored; the hover's rows carry no action (.ah-ro),
             # so no pointer and no hover wash; the pinned detail takes focus as a dialog without a ring on the card
             ".ah-hint{margin-top:4px;opacity:.75;max-width:340px}"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -47684,7 +47684,7 @@ var BAR_CLASSES=[['ok','var(--accent,#9cd2ff)'],['rateLimited','var(--st-blocked
 function niceTopAh(mx){var p=Math.pow(10,Math.floor(Math.log(mx)/Math.LN10)),m=mx/p;return (m<=1?1:m<=2?2:m<=5?5:10)*p;}   // a 1-2-5 ceiling at any magnitude
 function tickWords(sec){if(sec>=86400)return Math.round(sec/86400)+'d';if(sec>=3600)return Math.round(sec/3600)+'h';return Math.round(sec/60)+'m';}
 function sumArr(a){var t=0;(a||[]).forEach(function(v){t+=v||0;});return t;}
-function barsHTML(led,big){var n=led.ok.length,W=big?560:168,H=big?140:48,tot=[],mx=0;
+function barsHTML(led,big){var n=led.ok.length,W=big?560:168,H=big?110:48,tot=[],mx=0;
 for(var i=0;i<n;i++){var v=0;BAR_CLASSES.forEach(function(c){v+=(led[c[0]]||[])[i]||0;});tot.push(v);if(v>mx)mx=v;}
 if(mx<=0)return '';
 var top=niceTopAh(mx),slot=W/n,gap=Math.min(2,slot*0.3),bw=Math.max(0.8,slot-gap),PADT=4;
@@ -47740,9 +47740,11 @@ return led;}
 function histHTML(){var loc=HIST&&HIST[''],R=RANGES[pinned?range:'day'];
 var ago=(loc&&!loc.error&&!loc.pending&&typeof loc.asOf==='number'&&MERGE)?'<span class="ru-tip-reset ah-ago">'+esc(MERGE.agoWords(Date.now()/1000-loc.asOf))+'</span>':'';
 var h='<div class="ru-tip-win ah-hist"><div class=ru-tip-name><span>History</span>'+ago+'</div>';
-if(pinned)h+=rangeHTML();
+var hs=HIST?Object.keys(HIST).sort(localFirst):[],many=hs.length>1,gray=false;
+// the gray legend line applies when any machine's range holds a no-connection or other-status failure: known up front
+hs.forEach(function(host){var d=HIST[host];if(!d||d.error||d.pending)return;var l=ledgerOf(d,R);if(l&&sumArr(l.noStatus)+sumArr(l.other)>0)gray=true;});
+if(pinned)h+=rangeHTML()+legendHTML(gray);   // the detail: the chips, then the colours named where the eye starts
 if(!HIST)return h+'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div></div>';
-var hs=Object.keys(HIST).sort(localFirst),many=hs.length>1,gray=false;
 hs.forEach(function(host){var d=HIST[host],name=host||SELF();
 // a machine whose answer is still in flight: its loader line (alone, the section's loader), never a blank
 if(d&&d.pending){h+=many?'<div class="ru-tip-row ah-mline"><i class=ah-dot data-dot=quiet></i><span class=ah-nm>'+esc(name)+'</span><span class="rl-dots ah-wait"><i></i><i></i><i></i></span></div>':'<div class="rl-dots ah-wait"><i></i><i></i><i></i></div>';return;}
@@ -47750,8 +47752,8 @@ if(!d||d.error){h+='<div class="ah-line ah-err">Could not read the API history'+
 if(many)h+='<div class="ru-tip-row ah-gname"><span class=ah-nm>'+esc(name)+'</span></div>';
 var led=ledgerOf(d,R),bars=led?barsHTML(led,pinned):'';
 if(!bars){h+='<div class="ah-line ru-tip-reset">no attempts in the '+esc(R.label)+'</div>';return;}
-h+=bars;if(sumArr(led.noStatus)+sumArr(led.other)>0)gray=true;});
-h+=legendHTML(gray);
+h+=bars;});
+if(!pinned)h+=legendHTML(gray);   // the hover: the legend under the bars
 var tr=(loc&&!loc.error&&!loc.pending)?transRows(loc):'';if(tr)h+='<div class="ru-tip-name ah-hname"><span>State changes'+(many?' \u00b7 '+esc(SELF()):'')+'</span></div>'+tr;
 return h+'</div>';}
 // the cell's description while the hover shows: the state word and its since, then how to reach the rest. Before the
@@ -50033,7 +50035,7 @@ def _landing():
             ".ah-legend{display:flex;flex-direction:column;align-items:flex-start;gap:3px;margin-top:7px;opacity:.75}"
             ".ah-lrow{display:flex;align-items:center;gap:6px}.ah-lsw{width:8px;height:8px;border-radius:2px;flex:0 0 auto}"
             ".ah-sw-ok{background:var(--accent,#9cd2ff)}.ah-sw-r429{background:var(--st-blocked-bg,#e5484d)}.ah-sw-r5xx{background:var(--st-5xx-bg,#c026d3)}.ah-sw-none{background:var(--dim,#9aa4ad)}"
-            ".ah-gname{margin-top:6px}.ah-bars.ah-big svg{height:140px}.ah-bars.ah-big{margin-bottom:14px}"
+            ".ah-gname{margin-top:6px}.ah-bars.ah-big svg{height:110px}.ah-bars.ah-big{margin-bottom:12px}"
             ".ah-range{margin:4px 0 6px}"
             "#ah-tip.ru-modal{width:min(720px,92vw)}"
             # a failed send's reason, under the button it restored; the hover's rows carry no action (.ah-ro),

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -2147,7 +2147,7 @@ def api_health_series(events, now: float, window: int, bin_s: int = 60) -> dict:
 # hour buckets (T293): one-minute bins for the last hour, five-minute bins for the last 24 hours, hourly bins for the
 # last 7 days. Five counters per bin (successes, 429, 5xx with 529, no connection, another status). Bounded: at most
 # 60 + 288 + 168 = 516 bins per bucket, so under about 100 KB per bucket in memory when every bin has traffic and about
-# 10 KB in the state file; buckets (auth x family) are few. Persisted in api-health.json with the state and restored at
+# 17 KB in the state file (about 33 bytes a bin); buckets (auth x family) are few. Persisted in api-health.json with the state and restored at
 # boot, so a restart keeps the day's picture. Additive to the payload: a reader that ignores `ledger` sees the
 # document it always saw.
 API_HEALTH_LEDGER_TIERS = (("minute", 60, 60), ("fiveMin", 300, 288), ("hour", 3600, 168))   # name, seconds per bin, bins kept
@@ -2169,7 +2169,9 @@ def api_health_ledger_class(kind, cls) -> int:
 
 def api_health_ledger_add(ledger: dict, key: str, t: float, kind, cls) -> None:
     """Fold one event into every tier of `ledger[key]` ({tier: {binStart: [5 counts]}}) and drop the bins that fell
-    out of the tier's span. Pure over its arguments; the caller holds the aggregator's lock."""
+    out of the tier's span, and any bin MORE THAN ONE BIN past this event's (a clock that stepped back left it; the
+    event's own time is the best "now" there is; a neighbouring bin stays, since two threads' stamps can straddle a
+    boundary and land out of order). Pure over its arguments; the caller holds the aggregator's lock."""
     i = api_health_ledger_class(kind, cls)
     tiers = ledger.setdefault(key, {})
     for name, bin_s, keep in API_HEALTH_LEDGER_TIERS:
@@ -2180,8 +2182,9 @@ def api_health_ledger_add(ledger: dict, key: str, t: float, kind, cls) -> None:
             row = bins[start] = [0, 0, 0, 0, 0]
         row[i] += 1
         lo = start - (keep - 1) * bin_s          # the tier's span ends at this bin: older bins go, whatever their number,
-        for k in [k for k in bins if k < lo]:    # so sparse traffic keeps only the span's bins (never a sawtooth of stale ones)
-            del bins[k]
+        hi = start + bin_s                       # so sparse traffic keeps only the span's bins (never a sawtooth of stale ones);
+        for k in [k for k in bins if k < lo or k > hi]:   # a bin PAST this event's (stamped before a clock step back) goes too,
+            del bins[k]                          # or it would resurface as a phantom bar when the clock reaches it (review find)
 
 
 def api_health_ledger_view(tiers: dict | None, now: float) -> dict:
@@ -2655,9 +2658,10 @@ class ApiHealth:
             self._last_event_at = ev.t if self._last_event_at is None else max(self._last_event_at, ev.t)
             api_health_ledger_add(self._ledger, "%s|%s" % (ev.auth, ev.family), ev.t, ev.kind, ev.cls)
             minute = int(ev.t // 60)
-            if minute != self._ledger_minute:
-                # the ledger reaches disk on the minute's first event (at most once a minute, a few KB), so a restart
-                # loses at most the current minute's counts; a transition rewrites the same file anyway
+            if self._ledger_minute is None or minute > self._ledger_minute:
+                # the ledger reaches disk on a NEW minute's first event (monotone: two threads whose stamps straddle a
+                # boundary and land out of order do not write twice, review find), so a restart loses at most the
+                # current minute's counts; a transition rewrites the same file anyway
                 self._ledger_minute = minute
                 self._write_state_locked()
             if self._seq % 256 == 0:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1860,6 +1860,9 @@ def acct_digest() -> str:
 # written to disk (STATE/api-health.json: the per-bucket state plus a bounded transition tail, rewritten
 # whole and atomically on each), so the history survives a restart while the per-request events do not:
 # persisting every attempt would add a write per API call for a window that empties itself in 17
+# The T316 ledger persists per-BIN counts (five integers per bin, three bounded tiers), never an attempt:
+# it reaches disk on the first event of a minute at most, so a day of the picture survives a restart at
+# the cost of one small write a minute.
 # minutes, and a restart already announces itself through bootId/complete — every bucket comes back
 # `unknown` (an empty ring is no evidence) with its transitions continuous across the boot.
 #
@@ -2136,6 +2139,105 @@ def api_health_series(events, now: float, window: int, bin_s: int = 60) -> dict:
         out[k][i] += 1
     out.update({"binS": bin_s, "from": round(start, 3)})
     return out
+
+
+# The per-bin LEDGER behind the dashboard's histograms (T316, the user 2026-09-10, who wanted the popup to show the past
+# 24 hours and a detail view with 1 hour / 24 hours / 7 days): the event ring holds only the windows' span, so every
+# attempt is also folded into three tiers of fixed-width bins the moment it lands, the way the spend ledger keeps its
+# hour buckets (T293): one-minute bins for the last hour, five-minute bins for the last 24 hours, hourly bins for the
+# last 7 days. Five counters per bin (successes, 429, 5xx with 529, no connection, another status). Bounded: at most
+# 60 + 288 + 168 = 516 bins per bucket, so under about 100 KB per bucket in memory when every bin has traffic and about
+# 10 KB in the state file; buckets (auth x family) are few. Persisted in api-health.json with the state and restored at
+# boot, so a restart keeps the day's picture. Additive to the payload: a reader that ignores `ledger` sees the
+# document it always saw.
+API_HEALTH_LEDGER_TIERS = (("minute", 60, 60), ("fiveMin", 300, 288), ("hour", 3600, 168))   # name, seconds per bin, bins kept
+API_HEALTH_LEDGER_CLASSES = ("ok", "rateLimited", "serverErrors", "noStatus", "other")
+
+
+def api_health_ledger_class(kind, cls) -> int:
+    """The counter an event lands in: successes, 429 attempts, 5xx (529 included), no connection, another status."""
+    if kind == "ok":
+        return 0
+    if cls == "429":
+        return 1
+    if cls in ("529", "5xx"):
+        return 2
+    if cls == "none":
+        return 3
+    return 4
+
+
+def api_health_ledger_add(ledger: dict, key: str, t: float, kind, cls) -> None:
+    """Fold one event into every tier of `ledger[key]` ({tier: {binStart: [5 counts]}}) and drop the bins that fell
+    out of the tier's span. Pure over its arguments; the caller holds the aggregator's lock."""
+    i = api_health_ledger_class(kind, cls)
+    tiers = ledger.setdefault(key, {})
+    for name, bin_s, keep in API_HEALTH_LEDGER_TIERS:
+        bins = tiers.setdefault(name, {})
+        start = int(t // bin_s) * bin_s
+        row = bins.get(start)
+        if row is None:
+            row = bins[start] = [0, 0, 0, 0, 0]
+        row[i] += 1
+        lo = start - (keep - 1) * bin_s          # the tier's span ends at this bin: older bins go, whatever their number,
+        for k in [k for k in bins if k < lo]:    # so sparse traffic keeps only the span's bins (never a sawtooth of stale ones)
+            del bins[k]
+
+
+def api_health_ledger_view(tiers: dict | None, now: float) -> dict:
+    """The dense payload form of one bucket's ledger at `now`: per tier, `binS`, `from` (the first bin's start) and
+    one integer array per class, oldest first, the last bin the one that holds `now`, zeros where nothing landed.
+    Bins newer than `now` (a clock that went back) are left out rather than drawn in the future."""
+    out = {}
+    for name, bin_s, keep in API_HEALTH_LEDGER_TIERS:
+        bins = (tiers or {}).get(name) or {}
+        last = int(now // bin_s) * bin_s
+        first = last - (keep - 1) * bin_s
+        cols = [[0] * keep for _ in API_HEALTH_LEDGER_CLASSES]
+        for start, row in bins.items():
+            if first <= start <= last:
+                j = (start - first) // bin_s
+                for c in range(len(API_HEALTH_LEDGER_CLASSES)):
+                    cols[c][j] += int(row[c]) if c < len(row) else 0
+        tier = {"binS": bin_s, "from": first}
+        for c, cname in enumerate(API_HEALTH_LEDGER_CLASSES):
+            tier[cname] = cols[c]
+        out[name] = tier
+    return out
+
+
+def api_health_ledger_parse(raw) -> tuple:
+    """A persisted ledger ({bucket: {tier: {"<start>": [counts]}}}) back into memory: (ledger, skipped). Anything
+    malformed (a non-dict, an unknown tier, a start that is not an integer, a row that is not a list of counts) is
+    skipped and counted, never raised: this runs at boot."""
+    ledger, bad = {}, 0
+    if not isinstance(raw, dict):
+        return ledger, (1 if raw is not None else 0)
+    names = {n: (b, k) for n, b, k in API_HEALTH_LEDGER_TIERS}
+    for key, tiers in raw.items():
+        if not (isinstance(key, str) and key and isinstance(tiers, dict)):
+            bad += 1
+            continue
+        out = {}
+        for name, bins in tiers.items():
+            if name not in names or not isinstance(bins, dict):
+                bad += 1
+                continue
+            rows = {}
+            for start, row in bins.items():
+                try:
+                    st = int(start)
+                    ok = isinstance(row, list) and 1 <= len(row) <= len(API_HEALTH_LEDGER_CLASSES) and all(
+                        isinstance(v, int) and not isinstance(v, bool) and v >= 0 for v in row)
+                except (TypeError, ValueError):
+                    ok = False
+                if not ok:
+                    bad += 1
+                    continue
+                rows[st] = list(row) + [0] * (len(API_HEALTH_LEDGER_CLASSES) - len(row))
+            out[name] = rows
+        ledger[key] = out
+    return ledger, bad
 
 
 API_HEALTH_SEVERITY = {"unknown": 0, "healthy": 1, "recovering": 2, "degraded": 3, "thrashing": 4}
@@ -2445,6 +2547,8 @@ class ApiHealth:
         self._seen: dict = {}            # (sid, message_id) -> t; dedupes the CLI's one-frame-per-block replies
         self._seq = 0
         self._last_event_at = None
+        self._ledger: dict = {}          # bucket key -> {tier: {binStart: [5 counts]}}: the histograms' bins (T316)
+        self._ledger_minute = None       # the minute bin of the last event: a change is the rollover that writes the state file
         self._salt = None                # lazily read/minted: nothing is written until a label is needed
         # bucket key -> {"state", "since", "why", "evidence", "auth", "family"}: the persisted half of
         # the derivation's input is (state, since); the rest is what the newest transition recorded
@@ -2549,6 +2653,13 @@ class ApiHealth:
             self._ring.append(ev)
             self._seq += 1
             self._last_event_at = ev.t if self._last_event_at is None else max(self._last_event_at, ev.t)
+            api_health_ledger_add(self._ledger, "%s|%s" % (ev.auth, ev.family), ev.t, ev.kind, ev.cls)
+            minute = int(ev.t // 60)
+            if minute != self._ledger_minute:
+                # the ledger reaches disk on the minute's first event (at most once a minute, a few KB), so a restart
+                # loses at most the current minute's counts; a transition rewrites the same file anyway
+                self._ledger_minute = minute
+                self._write_state_locked()
             if self._seq % 256 == 0:
                 self._evict_locked(ev.t)
 
@@ -2668,6 +2779,8 @@ class ApiHealth:
                         per[key].append(r)
                     else:
                         bad += 1
+            ledger, lbad = api_health_ledger_parse(doc.get("ledger"))   # the histograms' bins (T316), malformed ones skipped
+            bad += lbad
             if bad and self._log:
                 self._log("api-health: %d malformed row(s) skipped at boot (%s)" % (bad, API_HEALTH_STATE_FILE))
             # one stamp, at the tail's millisecond precision, for the restart rows, the seeded since and the payload's
@@ -2683,6 +2796,7 @@ class ApiHealth:
             self.boot_stamp = at
             filed = False
             with self._lock:
+                self._ledger = ledger
                 self._transitions.extend(rows)
                 for key, rs in per.items():
                     self._by_bucket[key] = deque(rs, maxlen=API_HEALTH_TRANSITIONS_KEEP)
@@ -2731,7 +2845,10 @@ class ApiHealth:
                "transitions": list(self._transitions),
                "buckets": {k: {"state": v["state"], "stateSince": v["since"], "why": v["why"], "evidence": v["evidence"],
                                "auth": v["auth"], "family": v["family"],
-                               "transitions": list(self._by_bucket.get(k, ()))} for k, v in self._last_state.items()}}
+                               "transitions": list(self._by_bucket.get(k, ()))} for k, v in self._last_state.items()},
+               # the histograms' bins (T316): {bucket: {tier: {"<start>": [counts]}}}, bounded by the tiers' spans
+               "ledger": {k: {n: {str(st): row for st, row in bins.items()} for n, bins in tiers.items()}
+                          for k, tiers in self._ledger.items()}}
         tmp = p.with_name("%s.%d.%s.tmp" % (p.name, os.getpid(), uuid.uuid4().hex[:8]))
         try:
             p.parent.mkdir(parents=True, exist_ok=True)
@@ -2784,29 +2901,36 @@ class ApiHealth:
             events = list(self._ring)
             seq, last_at = self._seq, self._last_event_at
             known = {k: dict(v) for k, v in self._last_state.items()}
+            ledgers = {k: {n: dict(b) for n, b in tiers.items()} for k, tiers in self._ledger.items()}
         by_bucket: dict = {}
         for e in events:
             by_bucket.setdefault("%s|%s" % (e.auth, e.family), []).append(e)
         derived = []
-        for key in sorted(set(by_bucket) | set(known)):
+        for key in sorted(set(by_bucket) | set(known) | set(ledgers)):
             evs = by_bucket.get(key, [])
             prev = known.get(key)
-            auth, fam = (evs[0].auth, evs[0].family) if evs else (prev["auth"], prev["family"])
+            if evs:
+                auth, fam = evs[0].auth, evs[0].family
+            elif prev:
+                auth, fam = prev["auth"], prev["family"]
+            else:   # a bucket the ledger alone remembers (T316): its key names it
+                auth, fam = key.split("|", 1) if "|" in key else (key, "unknown")
             st = api_health_state(evs, now, (prev["state"], prev["since"]) if prev else None, cfg)
             wins = {str(w): api_health_counts(evs, now, w, uptime_s) for w in cfg["windows"]}
             series = api_health_series(evs, now, max(cfg["windows"]))   # the graph's per-minute bins (T301)
+            ledger = api_health_ledger_view(ledgers.get(key), now)        # the histograms' three tiers (T316)
             last_err = None
             for e in reversed(evs):
                 if e.kind != "ok":
                     last_err = {"at": round(e.t, 3), "status": e.status, "category": e.category or None,
                                 "class": e.cls, "kind": e.kind}
                     break
-            derived.append((key, auth, fam, prev, st, wins, last_err, series))
+            derived.append((key, auth, fam, prev, st, wins, last_err, series, ledger))
         buckets = {}
         worst, worst_key = "unknown", None
         filed = False
         with self._lock:
-            for key, auth, fam, prev, st, wins, last_err, series in derived:
+            for key, auth, fam, prev, st, wins, last_err, series, ledger in derived:
                 cur = self._last_state.get(key)
                 if cur != prev:
                     rec = cur                    # a concurrent read filed this bucket first: its record stands
@@ -2824,7 +2948,7 @@ class ApiHealth:
                                 "state": rec["state"], "stateSince": round(rec["since"], 3),
                                 "evidence": rec["evidence"], "why": rec["why"],
                                 "transitions": list(self._by_bucket.get(key, ())),
-                                "lastError": last_err, "series": series}
+                                "lastError": last_err, "series": series, "ledger": ledger}
                 if API_HEALTH_SEVERITY[rec["state"]] > API_HEALTH_SEVERITY[worst] or worst_key is None:
                     worst, worst_key = rec["state"], key
             if filed:

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1293,12 +1293,21 @@ class TransitionLedger(unittest.TestCase):
         ah = sb.ApiHealth(d)
         for e in _storm(T0 - 600, T0):
             ah._push(e)
-        self.assertEqual(os.listdir(d), [], "per-request events are never persisted")
+        # T316: the ledger's rollover write puts the file there on the first event of a minute, but it holds per-bin
+        # COUNTS only: no event, no transition yet (nothing has been observed by a read)
+        self.assertEqual(os.listdir(d), [sb.API_HEALTH_STATE_FILE])
+        doc = json.load(open(os.path.join(d, sb.API_HEALTH_STATE_FILE)))
+        self.assertEqual((doc["transitions"], doc["buckets"]), ([], {}), "per-request events are never persisted; no transition yet")
+        self.assertEqual(set(doc), {"schema", "transitions", "buckets", "ledger"})
+        for tier in doc["ledger"][KEY].values():
+            for row in tier.values():
+                self.assertEqual((len(row), all(isinstance(v, int) for v in row)), (5, True), "five counters per bin, nothing per attempt")
         ah.snapshot(T0)
-        self.assertEqual(os.listdir(d), [sb.API_HEALTH_STATE_FILE], "only the observed transition is")
+        self.assertEqual(os.listdir(d), [sb.API_HEALTH_STATE_FILE], "the observed transition joins it")
         head = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
         self.assertIn("Only STATE TRANSITIONS a read observes are\n# written to disk", head)
         self.assertIn("persisting every attempt would add a write per API call", head, "the why is written down")
+        self.assertIn("The T316 ledger persists per-BIN counts", head, "and the ledger's exception to it")
 
 
 class StateFile(unittest.TestCase):
@@ -1357,7 +1366,8 @@ class StateFile(unittest.TestCase):
         d = tempfile.mkdtemp()
         ah = sb.ApiHealth(d)
         sizes = []
-        for i in range(40):                      # two transitions per cycle: unknown -> thrashing -> unknown
+        N = 200                                  # 200 cycles of 5000 s: 11.6 days, past the ledger's longest tier (7 days)
+        for i in range(N):                       # two transitions per cycle: unknown -> thrashing -> unknown
             base = T0 + i * 5000
             for e in _storm(base - 600, base):
                 ah._push(e)
@@ -1365,9 +1375,12 @@ class StateFile(unittest.TestCase):
             ah.snapshot(base + 2000)             # past retention: the ring is empty
             sizes.append(os.path.getsize(os.path.join(d, sb.API_HEALTH_STATE_FILE)))
         self.assertEqual(len(_rows(d)), sb.API_HEALTH_TRANSITIONS_KEEP)
-        self.assertEqual(_rows(d)[-1]["t"], T0 + 39 * 5000 + 2000, "newest last")
-        self.assertEqual(sizes[-1], sizes[-10], "full tail: the file stopped growing")
-        self.assertLess(sizes[-1], 32 * 1024)
+        self.assertEqual(_rows(d)[-1]["t"], T0 + (N - 1) * 5000 + 2000, "newest last")
+        # T316: the ledger grows with the bins a day and a week hold, then its tiers are full and the file plateaus (its
+        # size wobbles by a few bytes with the digits and the bins a cycle straddles, never climbs); every tier bounded
+        self.assertLess(abs(sizes[-1] - sizes[-30]), 600, "saturated tiers and a full tail: the file stopped growing")
+        self.assertLessEqual(sum(len(bins) for bins in ah._ledger[KEY].values()), 60 + 288 + 168, "516 bins at most per bucket")
+        self.assertLess(sizes[-1], 96 * 1024)
 
     def test_a_malformed_state_file_is_logged_and_never_the_backends_death(self):
         d = tempfile.mkdtemp()

--- a/tests/test_api_health_browser.py
+++ b/tests/test_api_health_browser.py
@@ -236,11 +236,11 @@ const R = await page.evaluate((SID) => {
   R.lightDotOpacity = getComputedStyle(el.querySelector(".ah-dot")).opacity;
   });
   step('lightState', () => {
-  // 11. light theme, degraded and paused: the detail's headline dot wears the rail dot's color (a bare light rule
+  // 11. light theme, degraded and paused: the detail's machine-line dot wears the rail dot's color (a bare light rule
   //     would outrank the state rules and paint it the label gray)
   window.__rompApiHealth(frame({ seq: 8 }));
   el.click();                                              // pin the detail (the row step closed it)
-  const head = () => tip().querySelector(".ah-head .ah-dot");
+  const head = () => tip().querySelector('.ah-mline[data-host=""] .ah-dot');   // this machine's line dot (T316: the head row is gone)
   R.lightDegraded = { rail: bg(el.querySelector(".ah-dot")), head: bg(head()), headOpacity: getComputedStyle(head()).opacity };
   window.__rompApiHealth(frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 8 }));
   R.lightPaused = { rail: bg(el.querySelector(".ah-dot")), head: bg(head()) };
@@ -299,7 +299,7 @@ await step2('rightButton', async () => {
   //     mouse event: it goes first, and each press records that it landed on the card.
   await page.evaluate(() => { const b = document.getElementById("romp-boot"); if (b) b.remove();
     window.__rompApiHealth(window.__frame({ seq: 9 })); document.getElementById("rail-api").click(); });
-  const head = () => page.evaluate(() => { const r = document.querySelector("#ah-tip .ah-head").getBoundingClientRect(); return { x: r.left + 8, y: r.top + r.height / 2 }; });
+  const head = () => page.evaluate(() => { const r = document.querySelector("#ah-tip .ah-mline").getBoundingClientRect(); return { x: r.left + 8, y: r.top + r.height / 2 }; });
   const inside = (b) => page.evaluate(([x, y]) => document.getElementById("ah-tip").contains(document.elementFromPoint(x, y)), [b.x, b.y]);
   const box = await head();
   R.rightInside = await inside(box);
@@ -572,8 +572,9 @@ class ServedCell(unittest.TestCase):
     def test_tab_cycles_within_the_open_dialog(self):
         self.assertTrue(self.R["tabOpened"], "errors: %r" % self.R.get("err2"))
         self.assertEqual(self.R["tabAria"], "true")
-        self.assertEqual(self.R["tabSeq"], ["BUTTON.pause", "DIV.reveal", "SPAN.usage", "SPAN.log", "BUTTON.pause", "DIV.reveal"])
-        self.assertEqual(self.R["tabBack"], ["BUTTON.pause", "SPAN.log", "SPAN.usage"])
+        # T316: the detail's three range chips sit between the waiting rows and the footer links
+        self.assertEqual(self.R["tabSeq"], ["BUTTON.pause", "DIV.reveal", "BUTTON.range:hour", "BUTTON.range:day", "BUTTON.range:week", "SPAN.usage"])
+        self.assertEqual(self.R["tabBack"], ["BUTTON.range:week", "BUTTON.range:day", "BUTTON.range:hour"])
 
     def test_enter_on_a_row_opens_its_session_and_space_on_a_footer_link_runs_it(self):
         self.assertEqual(self.R["rowFocused"], "DIV.reveal", "errors: %r" % self.R.get("err2"))

--- a/tests/test_api_health_browser.py
+++ b/tests/test_api_health_browser.py
@@ -331,9 +331,13 @@ await step2('pressFocus', async () => {
     window.__rompApiHealth(window.__frame({ state: "paused", reason: "limit", text: "paused · usage limit · 1 waiting", since: 1700000010, seq: 12 }));
     document.getElementById("rail-api").focus(); });
   await page.keyboard.press("Enter");
+  // the open's read lands (this lab has no /api-health: the failure line) and re-renders the card; the focus reads
+  // below wait for that render rather than racing it (a CI flake on another PR read focus mid-render)
+  await page.waitForFunction(() => !!document.querySelector("#ah-tip .ah-err") || !!document.querySelector("#ah-tip .ah-bars"), null, { timeout: 8000 });
   await page.keyboard.press("Tab");
   R.pressFocusBefore = await active();
   await page.keyboard.press("Space");
+  await page.waitForFunction(() => { const b = document.querySelector("#ah-tip button[data-act=pause]"); return !!(b && b.disabled); }, null, { timeout: 8000 });
   R.pressSent = await page.evaluate(() => window.__sent3.map((o) => o.type + ":" + String(o.value)));
   R.pressFocusAfter = await active();
   R.pressButton = await page.evaluate(() => { const b = document.querySelector("#ah-tip button[data-act=pause]"); return { disabled: b.disabled, label: b.textContent }; });

--- a/tests/test_api_health_hosts.py
+++ b/tests/test_api_health_hosts.py
@@ -128,6 +128,8 @@ class HostsMap(_Fixture):
         self.assertEqual(f["hosts"], {})
         self.assertEqual(f["state"], "ok")
         self.assertIs(f["quiet"], True, "the fixture has no SDK backend traffic: quiet")
+        self.assertEqual(f["host"], "TESTHOST", "the frame names this kernel the way its peers know it (T316)")
+        self.assertNotIn("host", km._APIH_HOST_KEYS, "a peer's row is keyed by its name already: the field is not copied into the map")
 
     def test_quiet_follows_the_aggregator_s_last_event(self):
         ah = sb.ApiHealth(Path(self.td.name) / "api-health-state.json") if hasattr(sb, "ApiHealth") else None

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -720,13 +720,15 @@ class Script(unittest.TestCase):
         self.assertIn("var LEGEND_ROWS=[['r429','429 = the API told us to slow down (rate limit)'],['r5xx','5xx = the API itself failed (server error)'],['none','gray = no connection, or another error']];", JS)
         self.assertIn("function legendHTML(gray){var h='<div class=ah-legend>';LEGEND_ROWS.forEach(function(r){if(r[0]==='none'&&!gray)return;", HIST, "the gray line only when the range holds any")
         self.assertIn("h+='<div class=ah-lrow><i class=\"ah-lsw ah-sw-'+r[0]+'\"></i><span>'+r[1]+'</span></div>';});return h+'</div>';}", HIST, "a swatch in the bar's colour, one line each")
-        self.assertIn("h+=legendHTML(gray);", HIST, "the legend stands under the histograms, once")
+        self.assertIn("if(!pinned)h+=legendHTML(gray);", HIST, "the hover: the legend under the histograms, once")
+        self.assertIn("if(pinned)h+=rangeHTML()+legendHTML(gray);", HIST, "the detail: the legend under the range chips, where the eye starts (a short window folded the bottom one away)")
+        self.assertEqual(HIST.count("legendHTML(gray);"), 2, "drawn in exactly one of the two places")
         self.assertIn(".ah-legend{display:flex;flex-direction:column;align-items:flex-start;gap:3px;margin-top:7px;opacity:.75}", km._landing(), "vertical, left-justified")
         self.assertIn("if(many)h+='<div class=\"ru-tip-row ah-gname\"><span class=ah-nm>'+esc(name)+'</span></div>';", HIST, "several machines: each histogram under its machine's name")
         self.assertIn("var RANGES={hour:{tier:'minute',per:1,label:'1 hour',s:3600},day:{tier:'fiveMin',per:3,label:'24 hours',s:86400},week:{tier:'hour',per:1,label:'7 days',s:604800}};", JS,
                       "the hover draws the day as quarter-hours; the detail offers the three ranges")
         self.assertIn("R=RANGES[pinned?range:'day'];", HIST, "the hover draws the day; the detail its chosen range")
-        self.assertIn("if(pinned)h+=rangeHTML();", HIST, "the range chips only in the detail")
+        self.assertIn("if(pinned)h+=rangeHTML()+legendHTML(gray);", HIST, "the range chips only in the detail")
         self.assertIn("else if(act.indexOf('range:')===0){range=act.slice(6);render();}", JS)
         self.assertNotIn("winRow", JS, "the per-window rows are gone")
         self.assertNotIn("worst of", JS, "and the bucket-count caveat with them")
@@ -748,7 +750,7 @@ class Script(unittest.TestCase):
         self.assertNotIn("ah-head", JS.split("function html(m,full)")[1].split("function anchor()")[0], "no head row in the card")
         html = km._landing()
         for rule in (".ah-c-ok{color:var(--accent,#9cd2ff)}", ".ah-c-r429{color:var(--st-blocked-bg,#e5484d)}", ".ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}", ".ah-c-none{color:var(--dim,#9aa4ad)}",
-                     "#ah-tip.ru-modal{width:min(720px,92vw)}", ".ah-bars.ah-big svg{height:140px}"):
+                     "#ah-tip.ru-modal{width:min(720px,92vw)}", ".ah-bars.ah-big svg{height:110px}"):
             self.assertIn(rule, html)
 
     def test_the_tail_holds_four_rows_newest_first_in_plain_words_each_state_s_hold_and_a_restart_never_hidden(self):

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -674,7 +674,7 @@ class Script(unittest.TestCase):
         self.assertTrue(HIST, "the cell's script carries a History block")
         self.assertEqual(JS.count("fetch("), 1, "one read in the cell's script: the history's")
         self.assertIn("function load(fresh){var n=++histSeq,names=[''].concat(hostsOf(LAST)),by={};", HIST)
-        self.assertIn("tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();}", JS,
+        self.assertIn("tip.style.display='block';el.setAttribute('aria-describedby','ah-summary');load(true);render();armAge();}", JS,
                       "show drops the last answer and reads")
         self.assertIn("var was=tip.style.display==='block';", JS)
         self.assertIn("window.__rompApiClose=close;back.onclick=close;try{tip.focus();}catch(e){}if(!was)load();}", JS,
@@ -686,7 +686,11 @@ class Script(unittest.TestCase):
 
     def test_no_timers_the_newest_read_wins_and_the_answer_paints_through_the_held_gate(self):
         self.assertNotIn("setTimeout", JS)
-        self.assertNotIn("setInterval", JS)
+        # the one timer is the read-age label's minute tick (T316 review: a pinned detail must not say 'now' for ten
+        # minutes): it re-words one span and never reads anything; nothing polls the history
+        self.assertEqual(JS.count("setInterval("), 1)
+        self.assertIn("function ageTick(){var n=tip.querySelector('.ah-ago');if(n){var w=ageWords();if(w)n.textContent=w;}}", JS)
+        self.assertNotIn("fetch", JS[JS.index("function ageTick"):JS.index("function disarmAge")], "the tick reads nothing")
         self.assertIn("window.addEventListener('focus',function(){winFocusEl=document.activeElement;requestAnimationFrame(function(){winFocusEl=null;});});", JS,
                       "the window-focus mark is cleared on the next animation frame, an event")
         # T301: one read per machine (this machine's document and every attached host's, each landing on its own), so one guard of each
@@ -708,13 +712,20 @@ class Script(unittest.TestCase):
         # in the 5xx magenta, a gray band for no-connection and other-status failures only when present), no peak text,
         # one ceiling label; the legend vertical with swatches, the gray line only when it applies; the as-of stamp an age
         self.assertIn("var h='<div class=\"ru-tip-win ah-hist\"><div class=ru-tip-name><span>History</span>'+ago+'</div>';", HIST)
-        self.assertIn("'<span class=\"ru-tip-reset ah-ago\">'+esc(MERGE.agoWords(Date.now()/1000-loc.asOf))+'</span>'", HIST, "this machine's asOf as an age, recomputed at each render")
+        self.assertIn("'<span class=\"ru-tip-reset ah-ago\">'+esc(ageWords())+'</span>'", HIST)
+        self.assertIn("function ageWords(){return LANDED&&MERGE?'read '+MERGE.agoWords((Date.now()-LANDED)/1000):'';}", JS,
+                      "the read's age: the time since this machine's document landed, one clock (review find: asOf is another host's clock)")
+        self.assertIn("if(h==='')LANDED=Date.now();", HIST)
+        self.assertNotIn("Date.now()/1000-loc.asOf", HIST, "never the browser's clock against the kernel's")
+        self.assertIn("if(fresh){READINGS={};LANDED=null;}", HIST, "a fresh show drops the last hover's counts with its rows")
+        self.assertIn("var rd=READINGS[host];if(rd&&rd.counts&&(rd.counts.none+rd.counts.other)>0)gray=true;", HIST, "the gray legend row follows the counted lines too")
+        self.assertIn("other:[],older:true}", HIST, "an older kernel's series is marked and named")
         self.assertNotIn("peak '+mx", HIST, "no peak text")
         self.assertNotIn("hms(loc.asOf)", HIST)
-        self.assertIn("var BAR_CLASSES=[['ok','var(--accent,#9cd2ff)'],['rateLimited','var(--st-blocked-bg,#e5484d)'],['serverErrors','var(--st-5xx-bg,#c026d3)'],['noStatus','var(--dim,#9aa4ad)'],['other','var(--dim,#9aa4ad)']];", HIST,
-                      "the stack order and the tokens: successes, 429, 5xx, then the gray classes")
-        self.assertIn("bars+='<rect class=\"ah-seg ah-seg-'+c[0]+'\" x=\"'+x.toFixed(1)+'\" y=\"'+(yb-hgt).toFixed(1)+'\" width=\"'+bw.toFixed(1)+'\" height=\"'+hgt.toFixed(1)+'\" style=\"fill:'+c[1]+'\"></rect>';", HIST,
-                      "one rect per class per bar, stacked bottom-up, every attribute quoted")
+        self.assertIn("var BAR_CLASSES=['ok','rateLimited','serverErrors','noStatus','other'];", HIST, "the stack order: successes, 429, 5xx, then the gray classes")
+        self.assertIn("bars+='<rect class=\"ah-seg ah-seg-'+c+'\" x=\"'+x.toFixed(1)+'\" y=\"'+(yb-hgt).toFixed(1)+'\" width=\"'+bw.toFixed(1)+'\" height=\"'+hgt.toFixed(1)+'\"></rect>';", HIST,
+                      "one rect per class per bar, stacked bottom-up, every attribute quoted, the fill a class per theme")
+        self.assertNotIn("style=\"fill:", HIST, "no inline fill: the light theme must be able to re-ink a segment")
         self.assertNotIn("<polyline", HIST, "no overlaid lines")
         self.assertIn("'<span class=ru-tip-gy style=\"top:'+(big?ty:ty/H*56).toFixed(0)+'px\">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}", HIST, "one ceiling label; the ticks under")
         self.assertIn("var LEGEND_ROWS=[['r429','429 = the API told us to slow down (rate limit)'],['r5xx','5xx = the API itself failed (server error)'],['none','gray = no connection, or another error']];", JS)
@@ -749,9 +760,27 @@ class Script(unittest.TestCase):
         self.assertIn("function SELF(){return (LAST&&LAST.host)||'this machine';}", JS, "this kernel's own name, from its frame")
         self.assertNotIn("ah-head", JS.split("function html(m,full)")[1].split("function anchor()")[0], "no head row in the card")
         html = km._landing()
-        for rule in (".ah-c-ok{color:var(--accent,#9cd2ff)}", ".ah-c-r429{color:var(--st-blocked-bg,#e5484d)}", ".ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}", ".ah-c-none{color:var(--dim,#9aa4ad)}",
-                     "#ah-tip.ru-modal{width:min(720px,92vw)}", ".ah-bars.ah-big svg{height:110px}"):
+        # the inks (review find: chip colours as text sit under 4.5:1; the failure line's #ef6b6f / #B02A1C is the precedent),
+        # each with its light twin; the bars' fills as classes with their light twins; the swatches keep the chip colours
+        for dark, light in ((".ah-c-ok{color:var(--accent,#9cd2ff)}", "body.theme-light .ah-c-ok{color:#C2410C}"),
+                            (".ah-c-r429{color:#ef6b6f}", "body.theme-light .ah-c-r429{color:#B02A1C}"),
+                            (".ah-c-r5xx{color:#e879f9}", "body.theme-light .ah-c-r5xx{color:#86198F}"),
+                            (".ah-c-none{color:#9aa4ad}", "body.theme-light .ah-c-none{color:#5D574E}"),
+                            (".ah-sw-r5xx{background:var(--st-5xx-bg,#c026d3)}", "body.theme-light .ah-sw-r5xx{background:#A21CAF}"),
+                            (".ah-sw-none{background:#9aa4ad}", "body.theme-light .ah-sw-none{background:#5D574E}"),
+                            (".ah-seg-ok{fill:var(--accent,#9cd2ff)}", "body.theme-light .ah-seg-ok{fill:#C2410C}"),
+                            (".ah-seg-serverErrors{fill:var(--st-5xx-bg,#c026d3)}", "body.theme-light .ah-seg-serverErrors{fill:#A21CAF}"),
+                            (".ah-seg-noStatus,.ah-seg-other{fill:#9aa4ad}", "body.theme-light .ah-seg-noStatus,body.theme-light .ah-seg-other{fill:#5D574E}")):
+            self.assertIn(dark, html, dark)
+            self.assertIn(light, html, "the light twin: " + light)
+        for rule in ("#ah-tip.ru-modal{width:min(720px,92vw)}", ".ah-bars.ah-big svg{height:110px}"):
             self.assertIn(rule, html)
+        # the read's age re-ticks once a minute while the tip or the detail is open, the label alone; cleared on close
+        self.assertIn("function armAge(){if(!ageTimer)ageTimer=setInterval(ageTick,60000);}", JS)
+        self.assertIn("function disarmAge(){if(ageTimer){clearInterval(ageTimer);ageTimer=null;}}", JS)
+        self.assertIn("load(true);render();armAge();}", JS, "armed on show")
+        self.assertIn("render();back.classList.add('on');armAge();", JS, "and on open")
+        self.assertIn("function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');disarmAge();}", JS, "cleared on hide (close hides)")
 
     def test_the_tail_holds_four_rows_newest_first_in_plain_words_each_state_s_hold_and_a_restart_never_hidden(self):
         self.assertIn("var HIST_ROWS=4;", JS, "T301: a glance, not a log")
@@ -776,6 +805,7 @@ class Script(unittest.TestCase):
         # T301: the description is the head's plain words, a failed read said as such, and the read in flight named
         self.assertIn("function descText(){var tail=' Press Enter to open it.';var mg=merged();var m0=mg.machines[0];", HIST, "this machine's own line")
         self.assertIn("var w=m0?(m0.parts||[]).map(function(p){return p.text;}).join(' \u00b7 '):'';", HIST, "its words alone: the counts, or the kernel's own words")
+        self.assertIn("if(!w){w=DOTWORD[mg.dot]||'';if(w)w=w.charAt(0).toUpperCase()+w.slice(1);}", HIST, "a fine frame before its read: the dot's state word, so the description never lacks one")
         self.assertIn("var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;", HIST)
         self.assertIn("if(!HIST||(HIST['']&&HIST[''].pending))return 'API health: '+w+' Reading the details.'+tail;\nreturn 'API health: '+w+tail;}", HIST)
         self.assertNotIn("'unknown'", HIST.replace("unknown:'quiet'", ""), "the machine's word never reaches the description")
@@ -784,7 +814,7 @@ class Script(unittest.TestCase):
         self.assertIn("tip.classList.remove('ru-modal');tip.setAttribute('role','tooltip');tip.removeAttribute('aria-modal');", JS, "show: tooltip")
         self.assertIn("tip.setAttribute('role','dialog');tip.setAttribute('aria-modal','true');el.removeAttribute('aria-describedby');", JS, "open: dialog")
         self.assertEqual(JS.count("'aria-modal'"), 2, "set by open, removed by show, nowhere else")
-        self.assertIn("function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');}", JS)
+        self.assertIn("function hide(){tip.style.display='none';el.removeAttribute('aria-describedby');disarmAge();}", JS)
         self.assertIn("el.addEventListener('blur',function(){if(moving)return;if(!pinned)hide();});", JS)
         self.assertIn("skipFocus=true;try{(fb&&fb.focus?fb:el).focus();}catch(e){}skipFocus=false;}", JS,
                       "the close's refocus fires the cell's focus event; the flag covers that one call")

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -610,7 +610,7 @@ class FrameUnchanged(unittest.TestCase):
         km._api_health_push(f1)
         self.assertEqual(len(self.sent), 1)
         self.assertEqual(set(f1), {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked",
-                                   "since", "tmux", "sessions", "seq", "hosts", "quiet", "errs"}, "the documented keys, nothing added")
+                                   "since", "tmux", "sessions", "seq", "hosts", "quiet", "errs", "host"}, "the documented keys, nothing added")
         for k in ("windows", "transitions", "buckets", "history", "overall", "bootAt"):
             self.assertNotIn(k, f1)
         # a hover reads the route in between (the read files a transition: the storm classifies)
@@ -703,30 +703,53 @@ class Script(unittest.TestCase):
         self.assertIn("if(!HIST)return h+'<div class=\"rl-dots ah-wait\"><i></i><i></i><i></i></div></div>';", HIST,
                       "before the first answer: the loader's dots")
 
-    def test_the_section_wears_the_usage_hover_s_grammar_the_graph_the_legend_and_plain_words(self):
-        # T301: no per-window rows; the graph in the usage hover's grammar (polyline + fill, ONE ceiling label, five-minute
-        # ticks), the codes explained once, every machine's line in the small annotation grammar
-        self.assertIn("var h='<div class=\"ru-tip-win ah-hist\"><div class=ru-tip-name><span>History</span>'+asOf+'</div>';", HIST)
-        self.assertIn("'<span class=ru-tip-reset>as of '+hms(loc.asOf)+'</span>'", HIST, "this machine's asOf on the heading")
-        self.assertIn("<span class=ru-tip-k>attempts / min ", HIST)
-        self.assertIn("<span class=ru-tip-v>peak '+mx+'</span></div>'", HIST)
-        self.assertIn("'<div class=ru-tip-graph><svg viewBox=\"0 0 '+W+' '+H+'\" preserveAspectRatio=\"none\">'+grid+body+'</svg>'", HIST, "the usage graph's own container")
-        self.assertIn("'<span class=ru-tip-gy style=\"top:'+(ty/H*56).toFixed(0)+'px\">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}", HIST, "one ceiling label; the ticks under")
-        self.assertIn("line(tot,'var(--accent,#9cd2ff)',0.18)+line(sr.serverErrors,'var(--warn,#e67e22)',0.35)+line(sr.rateLimited,'var(--st-blocked-bg,#e5484d)',0.35)", HIST,
-                      "every attempt in the accent, 5xx in the warn amber, 429 in the blocked red, through the tokens")
-        self.assertIn("var LEGEND='429 = the API told us to slow down (rate limit) ", JS)
-        self.assertIn("5xx = the API itself failed (server error) ", JS)
-        self.assertIn("offline = no connection';", JS)
-        self.assertIn("h+='<div class=\"ah-line ah-legend\">'+LEGEND+'</div>';", HIST, "the legend stands under the graphs, once")
-        self.assertIn("if(many)h+='<div class=\"ru-tip-row ah-mline\"><i class=ah-dot data-dot='+levelDot(rd)+'></i><span class=ah-nm>'+esc(name)+'</span><span class=ah-desc>'+esc(rd?rd.headline:'')+'</span></div>';", HIST,
-                      "several machines: one line each, that machine's own reading")
+    def test_the_section_draws_stacked_bars_a_vertical_legend_and_an_age_in_words(self):
+        # T316 (the user's design): one stacked histogram per machine (successes in the accent, 429 in the blocked red, 5xx
+        # in the 5xx magenta, a gray band for no-connection and other-status failures only when present), no peak text,
+        # one ceiling label; the legend vertical with swatches, the gray line only when it applies; the as-of stamp an age
+        self.assertIn("var h='<div class=\"ru-tip-win ah-hist\"><div class=ru-tip-name><span>History</span>'+ago+'</div>';", HIST)
+        self.assertIn("'<span class=\"ru-tip-reset ah-ago\">'+esc(MERGE.agoWords(Date.now()/1000-loc.asOf))+'</span>'", HIST, "this machine's asOf as an age, recomputed at each render")
+        self.assertNotIn("peak '+mx", HIST, "no peak text")
+        self.assertNotIn("hms(loc.asOf)", HIST)
+        self.assertIn("var BAR_CLASSES=[['ok','var(--accent,#9cd2ff)'],['rateLimited','var(--st-blocked-bg,#e5484d)'],['serverErrors','var(--st-5xx-bg,#c026d3)'],['noStatus','var(--dim,#9aa4ad)'],['other','var(--dim,#9aa4ad)']];", HIST,
+                      "the stack order and the tokens: successes, 429, 5xx, then the gray classes")
+        self.assertIn("bars+='<rect class=\"ah-seg ah-seg-'+c[0]+'\" x=\"'+x.toFixed(1)+'\" y=\"'+(yb-hgt).toFixed(1)+'\" width=\"'+bw.toFixed(1)+'\" height=\"'+hgt.toFixed(1)+'\" style=\"fill:'+c[1]+'\"></rect>';", HIST,
+                      "one rect per class per bar, stacked bottom-up, every attribute quoted")
+        self.assertNotIn("<polyline", HIST, "no overlaid lines")
+        self.assertIn("'<span class=ru-tip-gy style=\"top:'+(big?ty:ty/H*56).toFixed(0)+'px\">'+top+'</span><div class=ru-tip-gx>'+xlab+'</div></div>';}", HIST, "one ceiling label; the ticks under")
+        self.assertIn("var LEGEND_ROWS=[['r429','429 = the API told us to slow down (rate limit)'],['r5xx','5xx = the API itself failed (server error)'],['none','gray = no connection, or another error']];", JS)
+        self.assertIn("function legendHTML(gray){var h='<div class=ah-legend>';LEGEND_ROWS.forEach(function(r){if(r[0]==='none'&&!gray)return;", HIST, "the gray line only when the range holds any")
+        self.assertIn("h+='<div class=ah-lrow><i class=\"ah-lsw ah-sw-'+r[0]+'\"></i><span>'+r[1]+'</span></div>';});return h+'</div>';}", HIST, "a swatch in the bar's colour, one line each")
+        self.assertIn("h+=legendHTML(gray);", HIST, "the legend stands under the histograms, once")
+        self.assertIn(".ah-legend{display:flex;flex-direction:column;align-items:flex-start;gap:3px;margin-top:7px;opacity:.75}", km._landing(), "vertical, left-justified")
+        self.assertIn("if(many)h+='<div class=\"ru-tip-row ah-gname\"><span class=ah-nm>'+esc(name)+'</span></div>';", HIST, "several machines: each histogram under its machine's name")
+        self.assertIn("var RANGES={hour:{tier:'minute',per:1,label:'1 hour',s:3600},day:{tier:'fiveMin',per:3,label:'24 hours',s:86400},week:{tier:'hour',per:1,label:'7 days',s:604800}};", JS,
+                      "the hover draws the day as quarter-hours; the detail offers the three ranges")
+        self.assertIn("R=RANGES[pinned?range:'day'];", HIST, "the hover draws the day; the detail its chosen range")
+        self.assertIn("if(pinned)h+=rangeHTML();", HIST, "the range chips only in the detail")
+        self.assertIn("else if(act.indexOf('range:')===0){range=act.slice(6);render();}", JS)
         self.assertNotIn("winRow", JS, "the per-window rows are gone")
         self.assertNotIn("worst of", JS, "and the bucket-count caveat with them")
         self.assertNotIn("kernel up", JS, "and the uptime caveat")
+        self.assertNotIn("headWords", JS, "no summary head line: the per-machine lines do the work")
         self.assertEqual(sb._AH_COUNTED, ("ok", "429", "529", "5xx", "other"),
                          "requests excludes 'none', so requests plus noStatus counts every attempt once")
         self.assertIn("rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}\nh+=histHTML();\nif(m.tmux>0)h+=", JS,
                       "the section sits after the sessions waiting and before the tmux line, in hover and detail alike")
+
+    def test_the_card_names_every_machine_with_its_counts_in_their_colours_and_the_window_once(self):
+        # T316: no head sentence; one line per machine (the dot in its state, the kernel's own name, the counts as coloured
+        # pieces); the window named once beside the title; this machine by the name its peers know
+        self.assertIn("mg.machines.forEach(function(x){h+='<div class=\"ru-tip-row ah-mline\" data-host=\"'+esc(x.host)+'\"><i class=ah-dot data-dot='+esc(x.dot)+'></i><span class=ah-nm>'+esc(x.name)+'</span>'+partsHTML(x.parts||[])", JS)
+        self.assertIn("function partsHTML(parts){return '<span class=ah-desc>'+parts.map(function(p){return '<span class=\"ah-c-'+esc(p.kind)+'\">'+esc(p.text)+'</span>';}).join(' \u00b7 ')+'</span>';}", HIST)
+        self.assertIn("var win=MERGE?MERGE.windowWords(rd?rd.windowS:86400):'';", JS)
+        self.assertIn("(win?'<span class=\"ru-tip-reset ah-win\">'+esc(win)+'</span>':'')", JS, "the window once, at the top")
+        self.assertIn("function SELF(){return (LAST&&LAST.host)||'this machine';}", JS, "this kernel's own name, from its frame")
+        self.assertNotIn("ah-head", JS.split("function html(m,full)")[1].split("function anchor()")[0], "no head row in the card")
+        html = km._landing()
+        for rule in (".ah-c-ok{color:var(--accent,#9cd2ff)}", ".ah-c-r429{color:var(--st-blocked-bg,#e5484d)}", ".ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}", ".ah-c-none{color:var(--dim,#9aa4ad)}",
+                     "#ah-tip.ru-modal{width:min(720px,92vw)}", ".ah-bars.ah-big svg{height:140px}"):
+            self.assertIn(rule, html)
 
     def test_the_tail_holds_four_rows_newest_first_in_plain_words_each_state_s_hold_and_a_restart_never_hidden(self):
         self.assertIn("var HIST_ROWS=4;", JS, "T301: a glance, not a log")
@@ -749,7 +772,8 @@ class Script(unittest.TestCase):
         self.assertIn("var desc=document.createElement('span');desc.id='ah-summary';desc.className='ah-vh';document.body.appendChild(desc);", JS)
         self.assertIn("tip.innerHTML=html(LAST,pinned);if(!pinned)anchor();desc.textContent=descText();", JS, "refreshed on every render")
         # T301: the description is the head's plain words, a failed read said as such, and the read in flight named
-        self.assertIn("function descText(){var tail=' Press Enter to open it.';var mg=merged();var w=LAST?headWords(LAST,mg):'';", HIST)
+        self.assertIn("function descText(){var tail=' Press Enter to open it.';var mg=merged();var m0=mg.machines[0];", HIST, "this machine's own line")
+        self.assertIn("var w=m0?(m0.parts||[]).map(function(p){return p.text;}).join(' \u00b7 '):'';", HIST, "its words alone: the counts, or the kernel's own words")
         self.assertIn("var loc=HIST&&HIST[''];if(loc&&loc.error)return 'Could not read the API history: '+loc.error+'.'+tail;", HIST)
         self.assertIn("if(!HIST||(HIST['']&&HIST[''].pending))return 'API health: '+w+' Reading the details.'+tail;\nreturn 'API health: '+w+tail;}", HIST)
         self.assertNotIn("'unknown'", HIST.replace("unknown:'quiet'", ""), "the machine's word never reaches the description")

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -82,10 +82,32 @@ def _win(requests, r429, r5xx, gave, sess, complete=True, no_status=0):
             "sessionsRetrying": sess, "turnsRetrying": sess, "rate429": r429, "rate5xx": r5xx}
 
 
+def _spread(total, n, k):
+    """`total` events over the newest `k` of `n` bins, evenly, deterministic (the oldest of the k gets the remainder)."""
+    out = [0] * n
+    for i in range(k):
+        out[n - 1 - i] = total // k + (1 if i < total % k else 0)
+    return out
+
+
+def _tier(win, bin_s, n, k):
+    return {"binS": bin_s, "from": NOW - NOW % bin_s - (n - 1) * bin_s,
+            "ok": _spread(win["ok"], n, k), "rateLimited": _spread(win["rateLimited"], n, k),
+            "serverErrors": _spread(win["serverErrors"] + win["overloaded"], n, k),
+            "noStatus": _spread(win["noStatus"], n, k), "other": _spread(win["otherErrors"], n, k)}
+
+
+def _ledger(windows):
+    """T316: the ledger's three tiers (one-minute bins for the hour, five-minute for the day, hourly for the week) carrying
+    the 15-minute window's counts, so the counts the lines read (the day) are the window's and the bars draw."""
+    w = windows.get("900") or _win(0, None, None, 0, 0)
+    return {"minute": _tier(w, 60, 60, 15), "fiveMin": _tier(w, 300, 288, 3), "hour": _tier(w, 3600, 168, 1)}
+
+
 def _bucket(key, state, since, why, windows):
     auth, fam = key.split("|")
     return {"auth": auth, "family": fam, "state": state, "stateSince": since, "why": why, "windows": windows,
-            "evidence": None, "transitions": [], "lastError": None}
+            "evidence": None, "transitions": [], "lastError": None, "ledger": _ledger(windows)}
 
 
 def _tr(t, key, frm, to, why="x"):
@@ -246,20 +268,27 @@ const ev = (fn, arg) => page.evaluate(fn, arg);
 const rows = () => ev(() => Array.from(document.querySelectorAll("#ah-tip .ah-hist .ah-hrow")).map((n) => ({
   k: (n.querySelector(".ru-tip-k") || {}).textContent || "", w: n.querySelector(".ah-hword") ? n.querySelector(".ah-hword").textContent : null,
   v: n.querySelector(".ru-tip-v") ? n.querySelector(".ru-tip-v").textContent : null, boot: n.classList.contains("ah-boot") })));
-// T301: the reading sits in the FIRST section's head (word + dot); the History section holds the legend, the graph
-// (when the document carries a series), the machine lines with several hosts, and this machine's State changes
+// T316: the FIRST section is the title (with the window named once) and one line per machine (dot, name, coloured
+// counts); `word`/`dot`/`name`/`since` read THIS machine's line. The History section holds the bars, the vertical legend
+// (its rows), the age of the read, the machine names over their bars with several hosts, and this machine's State changes
 const head = () => ev(() => { const h = document.querySelector("#ah-tip .ah-hist"), top = document.querySelector("#ah-tip > .ru-tip-win");
   const q = (s) => { const n = h && h.querySelector(s); return n ? n.textContent : null; };
   const qt = (s) => { const n = top && top.querySelector(s); return n ? n.textContent : null; };
-  return { word: qt(".ah-head .ah-word"), dot: top && top.querySelector(".ah-head .ah-dot") ? top.querySelector(".ah-head .ah-dot").getAttribute("data-dot") : null,
-           since: qt(".ah-since"), sub: qt(".ah-line.ru-tip-reset"), title: qt(".ru-tip-name span"), asOf: q(".ru-tip-name .ru-tip-reset"),
-           legend: q(".ah-legend"), graphs: h ? h.querySelectorAll(".ru-tip-graph").length : 0, err: q(".ah-err"), wait: !!(h && h.querySelector(".ah-wait")),
-           mlines: Array.from(document.querySelectorAll("#ah-tip .ah-mline")).map((n) => n.textContent),
+  const me = top && top.querySelector('.ah-mline[data-host=""]');
+  const mq = (s) => { const n = me && me.querySelector(s); return n ? n.textContent : null; };
+  const bars = h ? Array.from(h.querySelectorAll(".ah-bars")) : [];
+  return { word: mq(".ah-desc"), dot: me && me.querySelector(".ah-dot") ? me.querySelector(".ah-dot").getAttribute("data-dot") : null, name: mq(".ah-nm"),
+           since: mq(".ah-since"), title: qt(".ru-tip-name span"), win: qt(".ah-win"), ago: q(".ah-ago"),
+           legend: h ? Array.from(h.querySelectorAll(".ah-legend .ah-lrow")).map((n) => n.textContent) : null, graphs: bars.length,
+           bars: bars.length ? +bars[0].getAttribute("data-bars") : 0, big: bars.some((b) => b.classList.contains("ah-big")),
+           err: q(".ah-err"), wait: !!(h && h.querySelector(".ah-wait")),
+           mlines: Array.from(document.querySelectorAll("#ah-tip .ah-mline")).map((n) => ((n.querySelector(".ah-nm") || {}).textContent || "") + ": " + ((n.querySelector(".ah-desc") || {}).textContent || "")),
+           gnames: Array.from(h ? h.querySelectorAll(".ah-gname .ah-nm") : []).map((n) => n.textContent),
            unknown: /unknown/i.test(document.getElementById("ah-tip").innerText),
            names: Array.from(h ? h.querySelectorAll(".ru-tip-name span:first-child") : []).map((n) => n.textContent) }; });
 const shown = () => ev(() => document.getElementById("ah-tip").style.display === "block");
 // the colours the theme resolves to, read from the computed style of the head's dot and of the failure line
-const dotColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip > .ru-tip-win .ah-head .ah-dot")).backgroundColor);
+const dotColor = () => ev(() => getComputedStyle(document.querySelector('#ah-tip > .ru-tip-win .ah-mline[data-host=""] .ah-dot')).backgroundColor);
 const errColor = () => ev(() => getComputedStyle(document.querySelector("#ah-tip .ah-hist .ah-err")).color);
 const described = () => ev(() => document.getElementById("rail-api").getAttribute("aria-describedby"));
 // the tip's role and modal flag, whether focus sits inside it, and whether it is the centered card
@@ -449,13 +478,35 @@ await step("order", async () => {
 await step("hosts", async () => {
   // 11b. T301: a frame carrying an attached host's frame reads that host's document through the relay and names
   //      every machine: the section counts them, the dot is the worst state, the History carries a line per machine
-  await ev((f) => { window.__rompApiHealth(f); }, frame({ hosts: { TESTHOST: { state: "degraded", cls: "429", text: "rate limited · 2 waiting", waiting: 2, retrying: 2, blocked: 0, since: NOW_PLACEHOLDER, reason: "", tmux: 0, stale: false } } }));
+  await ev((f) => { window.__rompApiHealth(f); }, frame({ host: "HUBHOST", hosts: { TESTHOST: { state: "degraded", cls: "429", text: "rate limited · 2 waiting", waiting: 2, retrying: 2, blocked: 0, since: NOW_PLACEHOLDER, reason: "", tmux: 0, stale: false } } }));
   await variant("quiet");
-  await enter(); await waitSel("#ah-tip .ah-hist .ah-legend");
+  await enter(); await page.waitForFunction(() => document.querySelectorAll("#ah-tip .ah-hist .ah-bars").length >= 2, null, { timeout: 8000 });
   R.hosts = { head: await head(), rows: await rows(), fetched: await ev(() => window.__lastUrls || null) };
   await leave();
   await ev((f) => { window.__rompApiHealth(f); }, frame());
   await variant("storm");
+});
+await step("detail", async () => {
+  // 11c. T316: the dot's click opens the detail: the same card with range chips (1 hour, 24 hours, 7 days) and one LARGE
+  //      stacked histogram per machine; the day is the default and draws 96 quarter-hour bars from the 288 five-minute
+  //      bins, the hour its 60 one-minute bins, the week its 168 hourly bins; Escape closes it
+  await ev((f) => { window.__rompApiHealth(f); }, frame(await flagsFor()));
+  await ev(() => { document.getElementById("rail-api").click(); });
+  await waitSel("#ah-tip .ah-range"); await page.waitForFunction(() => !!document.querySelector("#ah-tip .ah-bars.ah-big"), null, { timeout: 8000 });
+  const chips = () => ev(() => Array.from(document.querySelectorAll("#ah-tip .ah-range .rsp-btn")).map((b) => ({ t: b.textContent, on: b.classList.contains("on"), act: b.getAttribute("data-act") })));
+  const barsOf = () => ev(() => { const b = document.querySelector("#ah-tip .ah-bars.ah-big"); return b ? +b.getAttribute("data-bars") : 0; });
+  R.detail = { mode: await mode(), chips: await chips(), dayBars: await barsOf(), head: await head() };
+  await ev(() => { document.querySelector('#ah-tip [data-act="range:hour"]').click(); });
+  R.detail.hourBars = await barsOf(); R.detail.hourOn = await ev(() => document.querySelector('#ah-tip [data-act="range:hour"]').classList.contains("on"));
+  await ev(() => { document.querySelector('#ah-tip [data-act="range:week"]').click(); });
+  R.detail.weekBars = await barsOf();
+  await ev(() => { document.querySelector('#ah-tip [data-act="range:day"]').click(); });
+  await page.keyboard.press("Escape");
+  R.detail.closed = !(await shown());
+  // the hover after the detail draws the day, small, with no chips
+  await enter(); await waitRows();
+  R.detail.hoverAfter = await head(); R.detail.hoverChips = await ev(() => document.querySelectorAll("#ah-tip .ah-range").length);
+  await leave();
 });
 await step("focus", async () => {
   // 12. keyboard focus shows the hover as the pointer does; blur hides it. The focus and the look at the description
@@ -714,8 +765,8 @@ class ServedHistory(unittest.TestCase):
             self.assertEqual(R[name + "Rows0"], 0, name)
         self.assertEqual(R["racePending"], 2, "enter, leave, enter: two reads in flight")
         self.assertTrue(R["raceAfterOld"]["wait"], "the older answer landing first is dropped: the dots stay")
-        self.assertEqual(R["raceAfterOld"]["word"], "Fine.", "and the head still reads the frame's own word")
-        self.assertEqual(R["raceAfterNew"]["word"], '30 requests in the last 15 min, all succeeded.', "the newer read's answer is what shows")
+        self.assertEqual(R["raceAfterOld"]["word"], "", "and this machine's line still says what the frame alone says: nothing yet (no verdict word)")
+        self.assertEqual(R["raceAfterNew"]["word"], "30 successful requests", "the newer read's answer is what shows")
         self.assertFalse(R["raceAfterNew"]["wait"])
 
     def test_the_storm_reads_in_plain_words_with_the_legend_and_the_tail_with_its_restart_row(self):
@@ -723,14 +774,17 @@ class ServedHistory(unittest.TestCase):
         # (the counts, the machine's verdict as a plain phrase), the dot is red for a window in errors even with
         # nothing waiting right now, the legend explains the codes, and the tail is capped at four in plain words
         h, rows = self.R["storm"]["head"], self.R["storm"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ('Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.', "errors"))
+        # T316: this machine's line is its counts over the day in their colours, no verdict word; the window named once
+        self.assertEqual((h["word"], h["dot"]), ('35 successful requests · 9 429s · 1 5xx', "errors"))
+        self.assertEqual(h["name"], "this machine", "a frame without a host name")
         self.assertEqual(h["title"], "API health", "one machine: no count")
-        self.assertIsNone(h["since"], "the frame is ok: no since on the head")
-        self.assertIsNone(h["sub"], "the machine has a verdict: no trend caveat")
-        self.assertEqual(h["asOf"], "as of " + time.strftime("%H:%M:%S", time.localtime(NOW)))
+        self.assertEqual(h["win"], "last 24 hours", "the ledger's day, named once at the top")
+        self.assertIsNone(h["since"], "the frame is ok: no since on the line")
+        self.assertRegex(h["ago"], r"^(now|\d+ minutes? ago)$", "the read's age in words, never a clock stamp")
         self.assertEqual(h["names"], ["History", "State changes"])
-        self.assertEqual(h["legend"], "429 = the API told us to slow down (rate limit) · 5xx = the API itself failed (server error) · offline = no connection")
-        self.assertEqual(h["graphs"], 0, "this fixture carries no series: no graph")
+        self.assertEqual(h["legend"], ["429 = the API told us to slow down (rate limit)", "5xx = the API itself failed (server error)"],
+                         "vertical: one line each, 429 then 5xx; no gray line when the range holds no such failure")
+        self.assertEqual((h["graphs"], h["bars"], h["big"]), (1, 96, False), "the day as 96 quarter-hour bars, small in the hover")
         self.assertFalse(h["unknown"], "the word never reaches the user")
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in rows],
                          [(_hmd(NOW - 300), "rate-limit storm", "5 min so far", False),
@@ -741,8 +795,7 @@ class ServedHistory(unittest.TestCase):
 
     def test_a_tail_crossing_boot_at_without_a_restart_row_gets_the_divider_and_the_hold_ends_at_the_boot(self):
         h, rows = self.R["quiet"]["head"], self.R["quiet"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ('30 requests in the last 15 min, all succeeded.', "fine"))
-        self.assertIsNone(h["sub"], "healthy: no trend caveat")
+        self.assertEqual((h["word"], h["dot"]), ("30 successful requests", "fine"))
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in rows],
                          [(_hmd(NOW - 100), "fine", "2 min so far", False),
                           (_hmd(BOOT), "kernel restarted", None, True),
@@ -752,7 +805,7 @@ class ServedHistory(unittest.TestCase):
 
     def test_a_bucket_the_boot_seeded_reads_since_the_boot_in_the_head_and_the_tail_alike(self):
         h, rows = self.R["stale"]["head"], self.R["stale"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ('No API traffic in the last 15 min.', "quiet"), "no traffic reads quiet and gray, never the machine's word")
+        self.assertEqual((h["word"], h["dot"]), ("no API traffic", "quiet"), "no traffic reads quiet and gray, never the machine's word")
         self.assertFalse(h["unknown"])
         tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
@@ -766,7 +819,7 @@ class ServedHistory(unittest.TestCase):
 
     def test_a_boot_at_58_seconds_reads_one_time_in_the_head_and_on_its_restart_row(self):
         h, rows = self.R["minute"]["head"], self.R["minute"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ('No API traffic in the last 15 min.', "quiet"))
+        self.assertEqual((h["word"], h["dot"]), ("no API traffic", "quiet"))
         tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
                          [(_hmd(BOOT_M), "quiet · kernel restarted", _min(NOW - BOOT_M) + " so far", False),
@@ -778,7 +831,7 @@ class ServedHistory(unittest.TestCase):
 
     def test_the_restart_row_sorts_above_the_previous_kernel_s_last_row_filed_in_the_same_second(self):
         h, rows = self.R["inversion"]["head"], self.R["inversion"]["rows"]
-        self.assertEqual(h["word"], 'No API traffic in the last 15 min.')
+        self.assertEqual(h["word"], "no API traffic")
         tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"], r["boot"]) for r in tail],
                          [(_hmd(BOOT + 0.9), "quiet · kernel restarted", _dur(NOW - (BOOT + 0.9)) + " so far", False),
@@ -805,7 +858,7 @@ class ServedHistory(unittest.TestCase):
 
     def test_a_transition_the_hover_s_own_read_filed_closes_the_state_before_it(self):
         h, rows = self.R["ownread"]["head"], self.R["ownread"]["rows"]
-        self.assertEqual(h["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.')
+        self.assertEqual(h["word"], '35 successful requests · 9 429s · 1 5xx')
         tail = rows
         self.assertEqual([(r["k"], r["w"], r["v"]) for r in tail],
                          [(_hmd(NOW), "rate-limit storm", "0 s so far"), (_hmd(NOW - 500), "fine", "8 min")],
@@ -814,30 +867,33 @@ class ServedHistory(unittest.TestCase):
 
     def test_no_bucket_reads_quiet_and_gray_with_no_rows(self):
         h, rows = self.R["empty"]["head"], self.R["empty"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ('No API traffic in the last 15 min.', "quiet"))
+        self.assertEqual((h["word"], h["dot"]), ("no API traffic", "quiet"))
         self.assertEqual(rows, [])
         self.assertIsNone(h["since"])
-        self.assertIsNotNone(h["legend"], "the legend stands whatever the traffic")
+        self.assertEqual(len(h["legend"]), 2, "the legend stands whatever the traffic")
+        self.assertEqual(h["graphs"], 0, "no bucket: nothing to draw")
         self.assertFalse(h["unknown"])
 
     def test_two_buckets_of_one_family_read_as_one_machine_and_the_tail_tells_them_apart_by_auth(self):
         # T301: the head counts every bucket of this machine (one kernel's buckets share its clock); the "worst of N
         # buckets" caveat is gone; the tail still names a bucket by family and auth when two share the family
         h, rows = self.R["two"]["head"], self.R["two"]["rows"]
-        self.assertEqual(h["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 56 attempts in the last 15 min; 1 turn gave up.')
+        self.assertEqual(h["word"], "46 successful requests · 9 429s · 1 5xx", "both buckets' counts, added (one kernel's clock)")
         tail = rows
         self.assertEqual([r["w"] for r in tail], ["fable · %s rate-limit storm" % AUTH, "fable · %s fine" % LAUTH])
         self.assertEqual([r["v"] for r in tail], ["5 min so far", "8 min so far"], "each bucket's current state is its own 'so far'")
 
     def test_two_buckets_of_two_families_are_named_by_family_alone(self):
         h, rows = self.R["twoFam"]["head"], self.R["twoFam"]["rows"]
-        self.assertEqual(h["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 56 attempts in the last 15 min; 1 turn gave up.')
+        self.assertEqual(h["word"], "46 successful requests · 9 429s · 1 5xx")
         self.assertEqual([r["w"] for r in rows], ["fable rate-limit storm", "opus fine"])
 
     def test_an_offline_window_reads_its_no_connection_attempts_in_plain_words(self):
         h, rows = self.R["offline"]["head"], self.R["offline"]["rows"]
-        self.assertEqual((h["word"], h["dot"]), ('Errors: 2 rate-limited attempts, 7 attempts with no connection among 15 attempts in the last 15 min; 1 turn gave up.', "errors"),
+        self.assertEqual((h["word"], h["dot"]), ("6 successful requests · 2 429s · 7 no connection", "errors"),
                          "attempts without a status are counted as no connection; the machine's word (unknown) is never said")
+        self.assertEqual(h["legend"][-1], "gray = no connection, or another error", "the gray line joins the legend when the range holds such failures")
+        self.assertEqual(len(h["legend"]), 3)
         self.assertFalse(h["unknown"])
 
     def test_the_cap_shows_four_transitions_with_the_divider_extra_and_four_without_one(self):
@@ -864,8 +920,8 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual(R["failReject"]["head"]["err"], "Could not read the API history: Failed to fetch")
         self.assertEqual(R["failReject"]["rows"], [])
         self.assertEqual(R["failMalformed"]["head"]["err"], "Could not read the API history: malformed answer")
-        self.assertIsNone(R["fail503"]["head"]["asOf"], "no as-of stamp on a failure")
-        self.assertEqual(R["recovered"]["head"]["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.', "the next successful read replaces the failure")
+        self.assertIsNone(R["fail503"]["head"]["ago"], "no age on a failure")
+        self.assertEqual(R["recovered"]["head"]["word"], '35 successful requests · 9 429s · 1 5xx', "the next successful read replaces the failure")
         self.assertIsNone(R["recovered"]["head"]["err"])
 
     def test_the_section_sits_between_the_sessions_waiting_and_the_tmux_line(self):
@@ -936,7 +992,7 @@ class ServedHistory(unittest.TestCase):
                          "before the answer: the frame's own count and the read in flight, not the loader's markup")
         m = R["storm"]["mode"]
         d = m["descText"]
-        self.assertEqual(d, "API health: " + 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.' + " Press Enter to open it.", "the reading in plain words, how to reach the rest")
+        self.assertEqual(d, "API health: 35 successful requests · 9 429s · 1 5xx. Press Enter to open it.", "this machine's counts, how to reach the rest")
         self.assertLess(len(d), 160, "bounded: a sentence, not the tip")
         for w in ("kernel restarted", "as of", "State changes", "unknown"):
             self.assertNotIn(w, d, "no transition, no stamp, no machine word in the description")
@@ -954,7 +1010,7 @@ class ServedHistory(unittest.TestCase):
         self.assertTrue(R["kbPinned"])
         self.assertEqual(R["kbFetchPost"], R["kbFetchPre"], "the pin reads nothing new: the focus show's read is the same document")
         self.assertGreater(R["kbRows"], 3)
-        self.assertEqual(R["kbHead"]["word"], 'Rate-limit storm: 9 rate-limited attempts, 1 server error among 45 attempts in the last 15 min; 1 turn gave up.')
+        self.assertEqual(R["kbHead"]["word"], '35 successful requests · 9 429s · 1 5xx')
         self.assertGreater(R["kbFetchAfter"], R["kbFetchBefore"], "a frame on the open detail re-reads the history")
         self.assertTrue(R["escHidden"])
         self.assertTrue(R["escFocusBack"], "focus returns to the cell")
@@ -979,14 +1035,14 @@ class ServedHistory(unittest.TestCase):
         # the detail still shows the previous frame's word (overloaded, from the frame that re-read the history) until
         # the release: nothing painted under the press
         self.assertEqual(R["heldWord"], "overloaded · 1 waiting", "the frame's re-read landed under the held pointer: not painted")
-        self.assertEqual(R["releasedWord"], '30 requests in the last 15 min, all succeeded.', "the release paints it")
+        self.assertEqual(R["releasedWord"], "30 successful requests", "the release paints it")
 
     def test_the_light_theme_colours_the_fine_and_quiet_head_dots_and_the_failure_line(self):
         R = self.R
         # T301: fine wears the light theme's accent (the clay), quiet the light label gray #5D574E (the base gray #9aa4ad
         # is about 1.6:1 on the white tip), and the failure line the light error red #B02A1C; the dark line keeps #ef6b6f
-        self.assertEqual((R["lightHealthyDot"]["word"], R["lightHealthyDot"]["color"]), ('30 requests in the last 15 min, all succeeded.', "rgb(194, 65, 12)"))
-        self.assertEqual((R["lightUnknownDot"]["word"], R["lightUnknownDot"]["color"]), ('No API traffic in the last 15 min.', "rgb(93, 87, 78)"))
+        self.assertEqual((R["lightHealthyDot"]["word"], R["lightHealthyDot"]["color"]), ("30 successful requests", "rgb(194, 65, 12)"))
+        self.assertEqual((R["lightUnknownDot"]["word"], R["lightUnknownDot"]["color"]), ("no API traffic", "rgb(93, 87, 78)"))
         self.assertEqual(R["lightErr"], "rgb(176, 42, 28)", "the light theme's error-text red")
         self.assertEqual(R["fail503"]["errColor"], "rgb(239, 107, 111)", "the dark tip's status red")
 
@@ -995,15 +1051,28 @@ class ServedHistory(unittest.TestCase):
         # host's document through /remote/<host>/api-health and name every machine; worst state wins for the dot
         h = self.R["hosts"]["head"]
         self.assertEqual(h["title"], "API health · 2 machines")
-        self.assertEqual(h["dot"], "errors", "TESTHOST's storm reddens the merged dot")
-        self.assertEqual(h["word"], "Errors on TESTHOST", "several machines: the head sums them up; each line follows")
-        self.assertEqual(h["mlines"][:2], ["this machine: fine · 30 requests in the last 15 min, all succeeded", "TESTHOST: rate limited · 2 waiting"],
-                         "one line per machine in the first section, local first")
-        self.assertTrue(any(m.startswith("TESTHOST") and "Rate-limit storm" in m for m in h["mlines"][2:]),
-                        "the History names TESTHOST with ITS reading (its own document, never summed into this machine's)")
-        self.assertIn("State changes · this machine", h["names"])
+        self.assertEqual(self.R["hosts"]["head"]["mlines"][1], "TESTHOST: rate limited · 2 waiting")
+        # T316: no summary head line; this machine is named by its kernel's own name; each line carries its own counts
+        self.assertEqual((h["name"], h["word"], h["dot"]), ("HUBHOST", "30 successful requests", "fine"), "this machine's own line, by its name")
+        self.assertEqual(h["mlines"], ["HUBHOST: 30 successful requests", "TESTHOST: rate limited · 2 waiting"], "one line per machine, local first")
+        self.assertEqual(h["gnames"], ["HUBHOST", "TESTHOST"], "the History draws each machine's bars under its name (its own document, never summed)")
+        self.assertEqual(h["graphs"], 2)
+        self.assertIn("State changes · HUBHOST", h["names"])
         self.assertIn("/remote/TESTHOST/api-health", self.R["hosts"]["fetched"] or [], "the relay read")
         self.assertFalse(h["unknown"])
+
+    def test_the_click_opens_the_detail_with_range_chips_and_large_bars_and_the_hover_stays_the_day(self):
+        # T316: the dot's click is the detail (the spend modal's grammar): range chips 1 hour / 24 hours / 7 days, the day
+        # pressed by default, one large stacked histogram per machine drawn from the tier the range names
+        d = self.R["detail"]
+        self.assertEqual((d["mode"]["role"], d["mode"]["modal"]), ("dialog", "true"))
+        self.assertEqual([c["t"] for c in d["chips"]], ["1 hour", "24 hours", "7 days"])
+        self.assertEqual([c["on"] for c in d["chips"]], [False, True, False], "the day by default")
+        self.assertEqual((d["dayBars"], d["head"]["big"]), (96, True), "the day: 96 quarter-hour bars, large")
+        self.assertEqual((d["hourBars"], d["hourOn"]), (60, True), "the hour: its 60 one-minute bins, the chip pressed")
+        self.assertEqual(d["weekBars"], 168, "the week: its 168 hourly bins")
+        self.assertTrue(d["closed"], "Escape closes the detail")
+        self.assertEqual((d["hoverAfter"]["bars"], d["hoverAfter"]["big"], d["hoverChips"]), (96, False, 0), "the hover stays the day, small, with no chips")
 
     def test_the_hover_keeps_its_margin_at_830_wide_and_stays_above_the_rail_on_a_short_window(self):
         g = self.R["geo830"]

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -495,7 +495,9 @@ await step("detail", async () => {
   await waitSel("#ah-tip .ah-range"); await page.waitForFunction(() => !!document.querySelector("#ah-tip .ah-bars.ah-big"), null, { timeout: 8000 });
   const chips = () => ev(() => Array.from(document.querySelectorAll("#ah-tip .ah-range .rsp-btn")).map((b) => ({ t: b.textContent, on: b.classList.contains("on"), act: b.getAttribute("data-act") })));
   const barsOf = () => ev(() => { const b = document.querySelector("#ah-tip .ah-bars.ah-big"); return b ? +b.getAttribute("data-bars") : 0; });
-  R.detail = { mode: await mode(), chips: await chips(), dayBars: await barsOf(), head: await head() };
+  R.detail = { mode: await mode(), chips: await chips(), dayBars: await barsOf(), head: await head(),
+    legendAboveBars: await ev(() => { const l = document.querySelector("#ah-tip .ah-hist .ah-legend"), b = document.querySelector("#ah-tip .ah-hist .ah-bars"); return !!(l && b) && (l.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0; }),
+    legendCount: await ev(() => document.querySelectorAll("#ah-tip .ah-legend").length) };
   await ev(() => { document.querySelector('#ah-tip [data-act="range:hour"]').click(); });
   R.detail.hourBars = await barsOf(); R.detail.hourOn = await ev(() => document.querySelector('#ah-tip [data-act="range:hour"]').classList.contains("on"));
   await ev(() => { document.querySelector('#ah-tip [data-act="range:week"]').click(); });
@@ -1069,6 +1071,8 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual([c["t"] for c in d["chips"]], ["1 hour", "24 hours", "7 days"])
         self.assertEqual([c["on"] for c in d["chips"]], [False, True, False], "the day by default")
         self.assertEqual((d["dayBars"], d["head"]["big"]), (96, True), "the day: 96 quarter-hour bars, large")
+        self.assertTrue(d["legendAboveBars"], "the detail names the colours under the chips, before the bars (a short window folded the bottom legend away)")
+        self.assertEqual(d["legendCount"], 1, "once")
         self.assertEqual((d["hourBars"], d["hourOn"]), (60, True), "the hour: its 60 one-minute bins, the chip pressed")
         self.assertEqual(d["weekBars"], 168, "the week: its 168 hourly bins")
         self.assertTrue(d["closed"], "Escape closes the detail")

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -455,6 +455,7 @@ await step("race", async () => {
     window.__pend = []; window.fetch = () => new Promise((res) => { window.__pend.push(res); }); });
   await enter(); await leave(); await enter();
   R.racePending = await ev(() => window.__pend.length);
+  R.fineDesc0 = await descOf();   // a fine frame, its read in flight: the description keeps a state word (the dot's)
   await ev(() => { window.__pend[0]({ ok: true, status: 200, json: () => Promise.resolve(window.__A) }); });
   await pause(80);
   R.raceAfterOld = await head();
@@ -495,7 +496,12 @@ await step("detail", async () => {
   await waitSel("#ah-tip .ah-range"); await page.waitForFunction(() => !!document.querySelector("#ah-tip .ah-bars.ah-big"), null, { timeout: 8000 });
   const chips = () => ev(() => Array.from(document.querySelectorAll("#ah-tip .ah-range .rsp-btn")).map((b) => ({ t: b.textContent, on: b.classList.contains("on"), act: b.getAttribute("data-act") })));
   const barsOf = () => ev(() => { const b = document.querySelector("#ah-tip .ah-bars.ah-big"); return b ? +b.getAttribute("data-bars") : 0; });
-  R.detail = { mode: await mode(), chips: await chips(), dayBars: await barsOf(), head: await head(),
+  // the stack: within one bar, the successes segment sits at the bottom (the largest y), the 429 segment on it, the 5xx on that
+  const stackOf = () => ev(() => { const b = document.querySelector("#ah-tip .ah-bars.ah-big"); if (!b) return null; const byX = {};
+    b.querySelectorAll("rect").forEach((r) => { (byX[r.getAttribute("x")] = byX[r.getAttribute("x")] || []).push(r); });
+    const col = Object.values(byX).find((a) => a.length >= 3) || Object.values(byX).find((a) => a.length >= 2); if (!col) return null;
+    return col.map((r) => ({ c: r.getAttribute("class").replace("ah-seg ah-seg-", ""), y: +r.getAttribute("y"), h: +r.getAttribute("height"), fill: getComputedStyle(r).fill })); });
+  R.detail = { mode: await mode(), chips: await chips(), dayBars: await barsOf(), head: await head(), stack: await stackOf(),
     legendAboveBars: await ev(() => { const l = document.querySelector("#ah-tip .ah-hist .ah-legend"), b = document.querySelector("#ah-tip .ah-hist .ah-bars"); return !!(l && b) && (l.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0; }),
     legendCount: await ev(() => document.querySelectorAll("#ah-tip .ah-legend").length) };
   await ev(() => { document.querySelector('#ah-tip [data-act="range:hour"]').click(); });
@@ -768,6 +774,7 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual(R["racePending"], 2, "enter, leave, enter: two reads in flight")
         self.assertTrue(R["raceAfterOld"]["wait"], "the older answer landing first is dropped: the dots stay")
         self.assertEqual(R["raceAfterOld"]["word"], "", "and this machine's line still says what the frame alone says: nothing yet (no verdict word)")
+        self.assertEqual(R["fineDesc0"], "API health: Fine. Reading the details. Press Enter to open it.", "the description keeps the dot's state word meanwhile")
         self.assertEqual(R["raceAfterNew"]["word"], "30 successful requests", "the newer read's answer is what shows")
         self.assertFalse(R["raceAfterNew"]["wait"])
 
@@ -782,7 +789,7 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual(h["title"], "API health", "one machine: no count")
         self.assertEqual(h["win"], "last 24 hours", "the ledger's day, named once at the top")
         self.assertIsNone(h["since"], "the frame is ok: no since on the line")
-        self.assertRegex(h["ago"], r"^(now|\d+ minutes? ago)$", "the read's age in words, never a clock stamp")
+        self.assertRegex(h["ago"], r"^read (now|\d+ minutes? ago)$", "the read's age in words on one clock, never a clock stamp")
         self.assertEqual(h["names"], ["History", "State changes"])
         self.assertEqual(h["legend"], ["429 = the API told us to slow down (rate limit)", "5xx = the API itself failed (server error)"],
                          "vertical: one line each, 429 then 5xx; no gray line when the range holds no such failure")
@@ -1072,6 +1079,13 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual([c["on"] for c in d["chips"]], [False, True, False], "the day by default")
         self.assertEqual((d["dayBars"], d["head"]["big"]), (96, True), "the day: 96 quarter-hour bars, large")
         self.assertTrue(d["legendAboveBars"], "the detail names the colours under the chips, before the bars (a short window folded the bottom legend away)")
+        st = d["stack"]
+        self.assertIsNotNone(st, "a bar with several segments")
+        self.assertEqual([x["c"] for x in st][:2], ["ok", "rateLimited"], "successes at the bottom, 429 on them")
+        self.assertGreater(st[0]["y"], st[1]["y"], "the 429 segment sits above the successes")
+        self.assertAlmostEqual(st[0]["y"], st[1]["y"] + st[1]["h"], delta=0.2, msg="and touches it: stacked, not overlaid")
+        self.assertEqual(st[0]["fill"], "rgb(156, 210, 255)", "the accent fill, from the class rule")
+        self.assertEqual(st[1]["fill"], "rgb(229, 72, 77)", "the blocked red")
         self.assertEqual(d["legendCount"], 1, "once")
         self.assertEqual((d["hourBars"], d["hourOn"]), (60, True), "the hour: its 60 one-minute bins, the chip pressed")
         self.assertEqual(d["weekBars"], 168, "the week: its 168 hourly bins")

--- a/tests/test_api_health_ledger.py
+++ b/tests/test_api_health_ledger.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""T316 (the user 2026-09-10): the API-health LEDGER behind the dashboard's histograms. The event ring holds only the
+windows' span, so every attempt is also folded into three tiers of fixed-width bins (one-minute bins for the last
+hour, five-minute bins for 24 hours, hourly bins for 7 days), five counters per bin, bounded, persisted in
+api-health.json with the state and restored at boot, served additively per bucket as `ledger`. Synthetic events,
+hermetic state dirs."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, os.path.join(ROOT, "kernel"))
+import sdk_backend as sb  # noqa: E402
+
+AUTH, FAM = "key:helper", "fable"
+KEY = AUTH + "|" + FAM
+
+
+def _ah(d):
+    return sb.ApiHealth(Path(d))
+
+
+class Fold(unittest.TestCase):
+    """api_health_ledger_add / api_health_ledger_view: pure over their arguments."""
+
+    def test_an_event_lands_in_its_bin_of_every_tier_under_its_class(self):
+        led = {}
+        base = 1_700_000_100      # a start both 60 and 300 divide: the minute bins below sit inside one five-minute bin
+        sb.api_health_ledger_add(led, KEY, base + 5, "ok", "ok")
+        sb.api_health_ledger_add(led, KEY, base + 15, "retry", "429")
+        sb.api_health_ledger_add(led, KEY, base + 25, "retry", "529")
+        sb.api_health_ledger_add(led, KEY, base + 65, "retry", "5xx")
+        sb.api_health_ledger_add(led, KEY, base + 75, "gaveup", "none")
+        sb.api_health_ledger_add(led, KEY, base + 85, "retry", "other")
+        m = led[KEY]["minute"]
+        self.assertEqual(sorted(m), [base, base + 60])
+        self.assertEqual(m[base], [1, 1, 1, 0, 0], "ok, 429, 529 in the first minute bin")
+        self.assertEqual(m[base + 60], [0, 0, 1, 1, 1], "5xx, none, other in the next")
+        f = led[KEY]["fiveMin"]
+        self.assertEqual(list(f.values()), [[1, 1, 2, 1, 1]], "one five-minute bin holds them all")
+        self.assertEqual(sb.api_health_ledger_class("ok", "ok"), 0)
+        self.assertEqual(sb.api_health_ledger_class("retry", "429"), 1)
+        self.assertEqual((sb.api_health_ledger_class("retry", "529"), sb.api_health_ledger_class("gaveup", "5xx")), (2, 2), "529 is a 5xx")
+        self.assertEqual(sb.api_health_ledger_class("retry", "none"), 3)
+        self.assertEqual(sb.api_health_ledger_class("retry", ""), 4)
+
+    def test_each_tier_keeps_its_span_and_drops_older_bins(self):
+        led = {}
+        base = 1_700_000_100       # a minute-aligned start
+        for i in range(70):        # 70 minutes of one event per minute
+            sb.api_health_ledger_add(led, KEY, base + i * 60, "ok", "ok")
+        self.assertEqual(len(led[KEY]["minute"]), 60, "the minute tier keeps the last hour")
+        self.assertEqual(min(led[KEY]["minute"]), base + 10 * 60, "the oldest ten minutes fell out")
+        self.assertEqual(len(led[KEY]["fiveMin"]), 14, "70 minutes are 14 five-minute bins, all inside the day")
+        for h in range(200):       # 200 hours of one event per hour
+            sb.api_health_ledger_add(led, KEY, base + h * 3600, "retry", "429")
+        self.assertEqual(len(led[KEY]["hour"]), 168, "the hour tier keeps 7 days")
+        self.assertLessEqual(len(led[KEY]["fiveMin"]), 288)
+        self.assertLessEqual(sum(len(b) for b in led[KEY].values()), 60 + 288 + 168, "bounded: 516 bins at most per bucket")
+
+    def test_the_view_is_dense_oldest_first_ending_at_now_with_zeros_where_nothing_landed(self):
+        led = {}
+        now = 1_700_003_750.0      # 50 s into its minute bin, so an event 30 s ago sits in the same bin
+        sb.api_health_ledger_add(led, KEY, now - 30, "ok", "ok")            # this minute
+        sb.api_health_ledger_add(led, KEY, now - 30 - 600, "retry", "429")  # ten minutes back
+        sb.api_health_ledger_add(led, KEY, now + 90, "ok", "ok")            # a clock that went back: a bin in the future
+        v = sb.api_health_ledger_view(led[KEY], now)
+        m = v["minute"]
+        self.assertEqual((m["binS"], len(m["ok"])), (60, 60))
+        self.assertEqual(m["from"], int(now // 60) * 60 - 59 * 60)
+        self.assertEqual(m["ok"][-1], 1, "the newest bin holds the event 30 s ago")
+        self.assertEqual(m["rateLimited"][-11], 1, "ten minutes back")
+        self.assertEqual(sum(m["ok"]), 1, "the future bin is not drawn")
+        self.assertEqual((len(v["fiveMin"]["ok"]), v["fiveMin"]["binS"]), (288, 300))
+        self.assertEqual((len(v["hour"]["ok"]), v["hour"]["binS"]), (168, 3600))
+        self.assertEqual(sum(v["hour"]["rateLimited"]), 1)
+        for name in ("minute", "fiveMin", "hour"):
+            self.assertEqual(set(v[name]) - {"binS", "from"}, set(sb.API_HEALTH_LEDGER_CLASSES))
+        empty = sb.api_health_ledger_view(None, now)
+        self.assertEqual(sum(empty["minute"]["ok"]), 0)
+
+    def test_parse_skips_malformed_pieces_and_keeps_the_rest(self):
+        raw = {KEY: {"minute": {"1700000000": [1, 0, 0, 0, 0], "x": [1], "1700000060": "nope", "1700000120": [1, 2]},
+                     "bogus": {}, "hour": "no"},
+               "": {"minute": {}}, "k2": []}
+        led, bad = sb.api_health_ledger_parse(raw)
+        self.assertEqual(sorted(led), [KEY])
+        self.assertEqual(led[KEY]["minute"], {1700000000: [1, 0, 0, 0, 0], 1700000120: [1, 2, 0, 0, 0]}, "a short row is padded")
+        self.assertEqual(bad, 6, "a bad start, a bad row, an unknown tier, a bad tier, an empty key, a non-dict bucket")
+        self.assertEqual(sb.api_health_ledger_parse(None), ({}, 0))
+        self.assertEqual(sb.api_health_ledger_parse([1]), ({}, 1))
+
+
+class Aggregator(unittest.TestCase):
+    """The ledger inside ApiHealth: fed by every event, in the payload, on disk, back at boot."""
+
+    def test_events_fold_into_the_ledger_and_the_snapshot_serves_it_per_bucket(self):
+        td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
+        ah = _ah(td.name)
+        now = 1_700_090_000.0
+        ah.note_ok(now - 5, auth=AUTH, family=FAM, sid="s", message_id="m1")
+        ah.note_retry(now - 400, auth=AUTH, family=FAM, status=429, sid="s", turn=1)      # 6 min 40 s back: outside the minute tier
+        ah.note_retry(now - 5 * 3600, auth=AUTH, family=FAM, status=529, sid="s", turn=1)  # 5 h back: inside the day, outside the hour
+        ah.note_gaveup(now - 3 * 86400, auth=AUTH, family=FAM, status=None, category="connection", sid="s", turn=1)  # 3 days back: hour tier only
+        b = ah.snapshot(now)["buckets"][KEY]
+        led = b["ledger"]
+        self.assertEqual(sorted(led), ["fiveMin", "hour", "minute"])
+        self.assertEqual((sum(led["minute"]["ok"]), sum(led["minute"]["rateLimited"]), sum(led["minute"]["serverErrors"])), (1, 1, 0),
+                         "the hour: the response and the 429 six minutes back, not the 529 five hours back")
+        self.assertEqual((sum(led["fiveMin"]["ok"]), sum(led["fiveMin"]["rateLimited"]), sum(led["fiveMin"]["serverErrors"])), (1, 1, 1), "the day: the 529 five hours back is in")
+        self.assertEqual(sum(led["hour"]["noStatus"]), 1, "the week holds the connection failure three days back")
+        self.assertEqual(sum(led["fiveMin"]["noStatus"]), 0)
+        self.assertIn("series", b, "the older field stays: additive")
+
+    def test_the_ledger_is_written_with_the_state_and_comes_back_at_boot(self):
+        td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
+        ah = _ah(td.name)
+        now = 1_700_090_000.0
+        ah.note_ok(now - 5, auth=AUTH, family=FAM, sid="s", message_id="m1")
+        ah.note_retry(now - 4000, auth=AUTH, family=FAM, status=429, sid="s", turn=1)
+        doc = json.loads((Path(td.name) / sb.API_HEALTH_STATE_FILE).read_text())
+        self.assertIn("ledger", doc, "the minute's first event writes the file")
+        self.assertEqual(doc["ledger"][KEY]["minute"][str(int((now - 5) // 60) * 60)], [1, 0, 0, 0, 0])
+        again = _ah(td.name)
+        v = again.snapshot(now)["buckets"][KEY]["ledger"]
+        self.assertEqual((sum(v["fiveMin"]["ok"]), sum(v["fiveMin"]["rateLimited"])), (1, 1), "the day's picture survives a restart")
+        self.assertEqual(again.window_errors(now), 0, "the ring itself is empty after a boot: the ledger is the memory, the ring the live signal")
+
+    def test_a_malformed_ledger_on_disk_is_skipped_at_boot_and_the_rest_of_the_file_still_loads(self):
+        td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
+        p = Path(td.name) / sb.API_HEALTH_STATE_FILE
+        p.write_text(json.dumps({"schema": sb.API_HEALTH_SCHEMA, "transitions": [], "buckets": {},
+                                 "ledger": {KEY: {"minute": {"abc": [1]}, "fiveMin": {"1700000000": [2, 0, 0, 0, 0]}}}}))
+        logs = []
+        ah = sb.ApiHealth(Path(td.name), log=logs.append)
+        self.assertTrue(any("malformed" in m for m in logs), logs)
+        self.assertEqual(ah._ledger[KEY]["fiveMin"], {1700000000: [2, 0, 0, 0, 0]}, "the good bin is kept")
+        self.assertEqual(ah._ledger[KEY]["minute"], {})
+
+    def test_the_rollover_write_happens_at_most_once_a_minute(self):
+        td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
+        ah = _ah(td.name)
+        writes = []
+        real = ah._write_state_locked
+        ah._write_state_locked = lambda: writes.append(1) or real()
+        now = 1_700_090_000.0
+        for i in range(30):
+            ah.note_ok(now + i, auth=AUTH, family=FAM, sid="s", message_id="m%d" % i)   # thirty events inside one minute
+        self.assertEqual(len(writes), 1)
+        ah.note_ok(now + 61, auth=AUTH, family=FAM, sid="s", message_id="next")
+        self.assertEqual(len(writes), 2, "the next minute's first event writes again")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health_ledger.py
+++ b/tests/test_api_health_ledger.py
@@ -65,8 +65,8 @@ class Fold(unittest.TestCase):
     def test_the_view_is_dense_oldest_first_ending_at_now_with_zeros_where_nothing_landed(self):
         led = {}
         now = 1_700_003_750.0      # 50 s into its minute bin, so an event 30 s ago sits in the same bin
+        sb.api_health_ledger_add(led, KEY, now - 30 - 600, "retry", "429")  # ten minutes back (events land in time order)
         sb.api_health_ledger_add(led, KEY, now - 30, "ok", "ok")            # this minute
-        sb.api_health_ledger_add(led, KEY, now - 30 - 600, "retry", "429")  # ten minutes back
         sb.api_health_ledger_add(led, KEY, now + 90, "ok", "ok")            # a clock that went back: a bin in the future
         v = sb.api_health_ledger_view(led[KEY], now)
         m = v["minute"]
@@ -82,6 +82,16 @@ class Fold(unittest.TestCase):
             self.assertEqual(set(v[name]) - {"binS", "from"}, set(sb.API_HEALTH_LEDGER_CLASSES))
         empty = sb.api_health_ledger_view(None, now)
         self.assertEqual(sum(empty["minute"]["ok"]), 0)
+        # review find: a bin PAST the event being folded (stamped before a clock step back) is dropped with the stale ones, so
+        # it never resurfaces as a phantom bar once the clock reaches it (and never reaches the state file from then on)
+        sb.api_health_ledger_add(led, KEY, now - 10, "ok", "ok")            # the first event after the step
+        self.assertNotIn(int((now + 90) // 60) * 60, led[KEY]["minute"], "the next add after the step dropped the future bin")
+        self.assertIn(int((now - 30) // 60) * 60, led[KEY]["minute"], "the neighbouring bins stay")
+        led2 = {}
+        sb.api_health_ledger_add(led2, KEY, now + 7200, "retry", "429")     # stamped while the clock was two hours fast
+        sb.api_health_ledger_add(led2, KEY, now, "ok", "ok")                # the first event after the step
+        self.assertEqual(sum(sb.api_health_ledger_view(led2[KEY], now + 7200)["minute"]["rateLimited"]), 0, "two hours later: no phantom 429")
+        self.assertEqual(sum(sb.api_health_ledger_view(led2[KEY], now + 7200)["hour"]["rateLimited"]), 0)
 
     def test_parse_skips_malformed_pieces_and_keeps_the_rest(self):
         raw = {KEY: {"minute": {"1700000000": [1, 0, 0, 0, 0], "x": [1], "1700000060": "nope", "1700000120": [1, 2]},
@@ -102,10 +112,11 @@ class Aggregator(unittest.TestCase):
         td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
         ah = _ah(td.name)
         now = 1_700_090_000.0
-        ah.note_ok(now - 5, auth=AUTH, family=FAM, sid="s", message_id="m1")
-        ah.note_retry(now - 400, auth=AUTH, family=FAM, status=429, sid="s", turn=1)      # 6 min 40 s back: outside the minute tier
-        ah.note_retry(now - 5 * 3600, auth=AUTH, family=FAM, status=529, sid="s", turn=1)  # 5 h back: inside the day, outside the hour
+        # events land in time order, as they do in a running kernel
         ah.note_gaveup(now - 3 * 86400, auth=AUTH, family=FAM, status=None, category="connection", sid="s", turn=1)  # 3 days back: hour tier only
+        ah.note_retry(now - 5 * 3600, auth=AUTH, family=FAM, status=529, sid="s", turn=1)  # 5 h back: inside the day, outside the hour
+        ah.note_retry(now - 400, auth=AUTH, family=FAM, status=429, sid="s", turn=1)      # 6 min 40 s back: inside the hour
+        ah.note_ok(now - 5, auth=AUTH, family=FAM, sid="s", message_id="m1")
         b = ah.snapshot(now)["buckets"][KEY]
         led = b["ledger"]
         self.assertEqual(sorted(led), ["fiveMin", "hour", "minute"])
@@ -120,8 +131,8 @@ class Aggregator(unittest.TestCase):
         td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
         ah = _ah(td.name)
         now = 1_700_090_000.0
-        ah.note_ok(now - 5, auth=AUTH, family=FAM, sid="s", message_id="m1")
         ah.note_retry(now - 4000, auth=AUTH, family=FAM, status=429, sid="s", turn=1)
+        ah.note_ok(now - 5, auth=AUTH, family=FAM, sid="s", message_id="m1")
         doc = json.loads((Path(td.name) / sb.API_HEALTH_STATE_FILE).read_text())
         self.assertIn("ledger", doc, "the minute's first event writes the file")
         self.assertEqual(doc["ledger"][KEY]["minute"][str(int((now - 5) // 60) * 60)], [1, 0, 0, 0, 0])
@@ -153,6 +164,30 @@ class Aggregator(unittest.TestCase):
         self.assertEqual(len(writes), 1)
         ah.note_ok(now + 61, auth=AUTH, family=FAM, sid="s", message_id="next")
         self.assertEqual(len(writes), 2, "the next minute's first event writes again")
+        # review find: two threads whose stamps straddle the boundary can land out of order; the rollover is monotone, so
+        # the earlier-stamped event landing after the later one does not write a third time (nor a fourth on the next)
+        ah.note_ok(now + 59.9, auth=AUTH, family=FAM, sid="s", message_id="late")
+        ah.note_ok(now + 62, auth=AUTH, family=FAM, sid="s", message_id="after")
+        self.assertEqual(len(writes), 2, "one write per new minute, whatever the order events land in")
+
+    def test_a_full_ledger_is_about_seventeen_kilobytes_in_the_file(self):
+        td = tempfile.TemporaryDirectory(); self.addCleanup(td.cleanup)
+        ah = _ah(td.name)
+        now = 1_700_090_000.0
+        for h in reversed(range(168)):                          # one event in every hourly bin of the week (oldest first) ...
+            ah.note_ok(now - h * 3600 - 1, auth=AUTH, family=FAM, sid="s", message_id="h%d" % h)
+        for f in reversed(range(288)):                          # ... every five-minute bin of the day ...
+            ah.note_retry(now - f * 300 - 2, auth=AUTH, family=FAM, status=429, sid="s", turn=1)
+        for m in reversed(range(60)):                           # ... and every minute bin of the hour
+            ah.note_retry(now - m * 60 - 3, auth=AUTH, family=FAM, status=529, sid="s", turn=1)
+        ah._write_state_locked()
+        with ah._lock:
+            n = sum(len(b) for b in ah._ledger[KEY].values())
+        self.assertLessEqual(n, 516)
+        self.assertGreater(n, 500, "every bin populated")
+        size = os.path.getsize(Path(td.name) / sb.API_HEALTH_STATE_FILE)
+        self.assertLess(size, 20 * 1024, "about 17 KB per bucket at the bound: %d bytes" % size)
+        self.assertGreater(size, 12 * 1024)
 
 
 if __name__ == "__main__":

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -505,7 +505,10 @@ class Detail(unittest.TestCase):
         # T301: every attached host's document rides the same read, through the kernel's relay, kept per host
         self.assertIn("names.forEach(function(h){fetchDoc(h?", self.JS)
         self.assertIn("names.forEach(function(h){fetchDoc(h?'/remote/'+encodeURIComponent(h)+'/api-health':'/api-health')", self.JS)
-        self.assertNotIn("setInterval", self.JS)
+        # the one timer is the read-age label's minute tick (T316 review): it re-words one span while the tip or the detail is open
+        self.assertEqual(self.JS.count("setInterval("), 1)
+        self.assertIn("setInterval(ageTick,60000)", self.JS)
+        self.assertNotIn("fetch", self.JS[self.JS.index("function ageTick"):self.JS.index("function disarmAge")], "the tick reads nothing: nothing polls the history")
         self.assertNotIn("setTimeout", self.JS)
         self.assertIn("window.__rompApiHealth=function(m){", self.JS)
         self.assertIn("LAST=m;", self.JS)

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -37,7 +37,7 @@ MDOT = "·"
 
 
 def _frame_keys():
-    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq", "hosts", "quiet", "errs"}
+    return {"type", "state", "cls", "reason", "text", "waiting", "retrying", "blocked", "since", "tmux", "sessions", "seq", "hosts", "quiet", "errs", "host"}
 
 
 class Reference(unittest.TestCase):
@@ -89,11 +89,14 @@ class _Fixture(unittest.TestCase):
         self.backend, self.sdk_calls = None, []
         self._sdk = km._sdk
         km._sdk = lambda: (self.sdk_calls.append(1), self.backend)[1]
+        self._self_host = km._self_host
+        km._self_host = lambda: "TESTHOST"   # the frame names this kernel (T316); synthetic, never the machine's real name
         km._APIH_LAST[0] = None
         km._retry_suppress_cache.clear()
 
     def tearDown(self):
         km._sdk = self._sdk
+        km._self_host = self._self_host
         km.jd.STATE = self._state
         km._alive_sessions = self._alive
         km._api_last_failed = self._last

--- a/ui/webview/api-health-global.ts
+++ b/ui/webview/api-health-global.ts
@@ -3,8 +3,8 @@
 // own tiny dist entry (esbuild.js) and included by _landing() before that script, the way age-color-global.ts
 // publishes the recency colour; the consumer feature-tests `window.__rompApiHealthMerge` and falls back to the
 // local frame alone, so a stale dist cannot break the rail (T301).
-import { mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText } from "./api-health-merge";
+import { mergeFrames, readHistory, mergeHistories, documentSeries, documentLedger, rebin, frameDot, machineText, machineLine, countsParts, agoWords, windowWords } from "./api-health-merge";
 
 (window as unknown as { __rompApiHealthMerge: unknown }).__rompApiHealthMerge = {
-  mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText,
+  mergeFrames, readHistory, mergeHistories, documentSeries, documentLedger, rebin, frameDot, machineText, machineLine, countsParts, agoWords, windowWords,
 };

--- a/ui/webview/api-health-merge.test.ts
+++ b/ui/webview/api-health-merge.test.ts
@@ -1,13 +1,14 @@
 // T301 (the user 2026-09-10): the rail's API-health dot covers EVERY connected kernel, merged as per-host maps
-// (worst state wins, every machine named, no count or clock compared across hosts), and the popup reads what
-// happened in plain words: traffic with no errors is fine and blue however the state machine words it, no
-// traffic is quiet and gray, and "unknown" is never the headline. The dot follows the FRAMES (each kernel's
-// quiet and errs flags, pushed on change); a history reading words a line and never colours the dot.
+// (worst state wins, every machine named, no count or clock compared across hosts). The dot follows the FRAMES
+// (each kernel's quiet and errs flags, pushed on change); a history reading words a line and never colours the dot.
+// T316 (the user's design follow-up, 2026-09-10): a machine's line is its counts over the window, each class in its
+// own colour, never a verdict word; the histograms come from the ledger's tiers; the as-of stamp reads as an age.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText, HistoryDoc } from "./api-health-merge";
+import { mergeFrames, readHistory, mergeHistories, documentSeries, documentLedger, rebin, frameDot, machineText, machineLine,
+         countsParts, agoWords, windowWords, HistoryDoc, LedgerTier } from "./api-health-merge";
 
 const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", ...p), "utf8");
 
@@ -24,6 +25,7 @@ test("worst state wins across machines: one storm anywhere makes the dot red, an
   assert.deepEqual(m.machines.map((x) => x.host), ["", "PEERHOST", "TESTHOST"], "local first, then by name");
   assert.deepEqual(m.machines.map((x) => x.dot), ["fine", "fine", "errors"]);
   assert.equal(m.machines[2].text, "TESTHOST: rate limited · 2 waiting");
+  assert.deepEqual(m.machines[2].parts, [{ text: "rate limited · 2 waiting", kind: "plain" }], "the kernel's own words, uncoloured");
 });
 
 test("a pause on the local machine is an error state too, and every machine keeps its own line", () => {
@@ -31,7 +33,16 @@ test("a pause on the local machine is an error state too, and every machine keep
   assert.equal(m.dot, "errors");
   assert.equal(m.worst, "", "the local machine set it");
   assert.equal(m.machines[0].text, "this machine: paused until the usage limit resets · 1 waiting");
-  assert.equal(m.machines[1].text, "TESTHOST: fine");
+  assert.equal(m.machines[1].text, "TESTHOST", "a fine frame with no reading yet says nothing after the name: no verdict word");
+});
+
+test("the local machine is named by its kernel's own name when the frame carries one (T316), 'this machine' only without", () => {
+  const m = mergeFrames({ ...OK, host: "TESTHOST" }, { PEERHOST: OK });
+  assert.equal(m.machines[0].name, "TESTHOST");
+  assert.equal(m.machines[0].host, "", "the key stays '': the histories are keyed by it");
+  assert.equal(machineText("", { ...QUIET, host: "TESTHOST" }), "TESTHOST: no API traffic");
+  assert.equal(machineText("", QUIET), "this machine: no API traffic");
+  assert.equal(machineLine("", QUIET, null, "TESTHOST").name, "TESTHOST", "the merge passes the frame's host down");
 });
 
 test("the dot is the frames' alone: quiet everywhere reads gray, traffic anywhere the accent, failed attempts in a window red", () => {
@@ -40,30 +51,37 @@ test("the dot is the frames' alone: quiet everywhere reads gray, traffic anywher
   assert.equal(mergeFrames(QUIET, { TESTHOST: OK }).dot, "fine", "one machine with traffic and no errors: the accent");
   assert.equal(mergeFrames(QUIET, { TESTHOST: { state: "ok" } }).dot, "fine", "a peer whose frame carries no flag (an older kernel) is not assumed quiet");
   assert.equal(mergeFrames({ state: "ok" }, {}).dot, "fine", "a frame without the flags stands on its state word");
-  // a storm in the WINDOW with nothing waiting right now: the frame says ok and counts the failures, the dot is red
   const m = mergeFrames(OK, { TESTHOST: { ...OK, errs: 20 } });
   assert.equal(m.dot, "errors");
   assert.equal(m.worst, "TESTHOST");
-  assert.equal(m.machines[1].text, "TESTHOST: 20 failed attempts in the last 15 min");
+  assert.equal(m.machines[1].text, "TESTHOST: 20 failed attempts in the last 15 min", "before its history is read, the frame's own count");
   assert.equal(frameDot({ ...OK, errs: 1 }), "errors");
   assert.equal(frameDot(QUIET), "quiet");
   assert.equal(frameDot(STORM), "errors");
   assert.equal(machineText("PEERHOST", { state: "degraded", cls: "offline", waiting: 3 }), "PEERHOST: offline · 3 waiting");
 });
 
-test("a history reading words a machine's line and never colours the dot: a stale reading cannot pin it red or gray", () => {
-  const FINE = readHistory(doc({ req: 40, ok: 40, state: "healthy" })), stormy = readHistory(doc({ req: 30, ok: 10, r429: 20, state: "thrashing" })), NONE = readHistory(doc({}));
-  const fine = mergeFrames(OK, { TESTHOST: OK }, { "": NONE, TESTHOST: FINE });
-  assert.equal(fine.machines[1].text, "TESTHOST: fine · 40 requests in the last 15 min, all succeeded");
-  assert.equal(fine.dot, "fine");
-  // the reading from a hover during a storm, the storm since over and the frame back to ok with no failures in the window
-  assert.equal(mergeFrames(OK, { TESTHOST: OK }, { TESTHOST: stormy }).dot, "fine", "the frame is the newer word: the dot is not red");
-  // the reading from a hover during a quiet spell, traffic since resumed (the frame's quiet flag dropped)
-  assert.equal(mergeFrames(OK, {}, { "": NONE }).dot, "fine", "the dot is not gray");
-  // a window in errors with a reading in hand: the reading's sentence words the line, the frame's count colours the dot
+test("a machine's line is its counts in their colours (T316): successes in the accent, 429s red, 5xx magenta, the rest gray; no verdict word", () => {
+  const FINE = readHistory(doc({ ok: 67 })), MIXED = readHistory(doc({ ok: 67, r429: 12, r5xx: 4 })), NONE = readHistory(doc({}));
+  const m = mergeFrames(OK, { TESTHOST: OK, PEERHOST: OK }, { "": NONE, PEERHOST: FINE, TESTHOST: MIXED });
+  assert.equal(m.machines[0].text, "this machine: no API traffic");
+  assert.equal(m.machines[1].text, "PEERHOST: 67 successful requests");
+  assert.deepEqual(m.machines[1].parts, [{ text: "67 successful requests", kind: "ok" }]);
+  assert.equal(m.machines[2].text, "TESTHOST: 67 successful requests · 12 429s · 4 5xx");
+  assert.deepEqual(m.machines[2].parts.map((p) => p.kind), ["ok", "r429", "r5xx"]);
+  assert.deepEqual(countsParts({ ok: 0, r429: 1, r5xx: 1, none: 3, other: 2, attempts: 7, failures: 7 }).map((p) => p.text),
+                   ["1 429", "1 5xx", "3 no connection", "2 other errors"], "failure classes only when present, singular where it is one");
+  assert.equal(m.dot, "fine", "a reading colours words, never the dot");
+  for (const x of m.machines) for (const w of ["fine", "Fine", "all succeeded", "in the last 15 min", "storm", "unknown"]) assert.ok(!x.text.includes(w), x.text + " must not say " + w);
+});
+
+test("a stale reading cannot pin the dot: the frame is the newer word", () => {
+  const stormy = readHistory(doc({ ok: 10, r429: 20 })), NONE = readHistory(doc({}));
+  assert.equal(mergeFrames(OK, { TESTHOST: OK }, { TESTHOST: stormy }).dot, "fine");
+  assert.equal(mergeFrames(OK, {}, { "": NONE }).dot, "fine");
   const m = mergeFrames(OK, { TESTHOST: { ...OK, errs: 20 } }, { TESTHOST: stormy });
   assert.equal(m.dot, "errors");
-  assert.match(m.machines[1].text, /^TESTHOST: Rate-limit storm: 20 rate-limited attempts/);
+  assert.equal(m.machines[1].text, "TESTHOST: 10 successful requests · 20 429s", "the reading's counts word the line, the frame's count colours the dot");
 });
 
 test("a machine whose tunnel is down or whose frame could not be read is named and has no say in the dot", () => {
@@ -75,13 +93,12 @@ test("a machine whose tunnel is down or whose frame could not be read is named a
   assert.equal(mergeFrames(QUIET, { TESTHOST: { ...OK, stale: true } }).dot, "quiet", "nor does a fine frame heard before the drop block gray");
   const refused = mergeFrames(OK, { TESTHOST: { ...OK, stale: true, fault: "HTTP 403" } });
   assert.equal(refused.dot, "fine");
-  assert.equal(refused.machines[1].text, "TESTHOST: could not read its API health (HTTP 403), last seen fine");
+  assert.equal(refused.machines[1].text, "TESTHOST: could not read its API health (HTTP 403)");
   assert.equal(mergeFrames(OK, { TESTHOST: { state: "", stale: true, fault: "HTTP 500" } }).machines[1].text, "TESTHOST: could not read its API health (HTTP 500)", "a fault before any frame was heard");
 });
 
 test("no cross-host arithmetic: the merge never adds a waiting count or compares a since across hosts", () => {
   const SRC = read("ui", "webview", "api-health-merge.ts");
-  // a count added to another host's count, or one host's since compared with another's, is the shape the rule bans
   assert.doesNotMatch(SRC, /\+=\s*[a-z.]*\.waiting\b|\.waiting\s*\+\s*[a-z.]*\.waiting\b|\.since\s*[<>]=?\s*[a-z.]*\.since\b|\+=\s*[a-z.]*\.errs\b/, "per-host maps in, per-host lines out");
   const m = mergeFrames({ ...STORM, waiting: 2 }, { TESTHOST: { ...STORM, waiting: 5 } });
   assert.match(m.machines[0].text, /2 waiting/);
@@ -89,71 +106,95 @@ test("no cross-host arithmetic: the merge never adds a waiting count or compares
   assert.equal(m.machines.filter((x) => /7 waiting/.test(x.text)).length, 0, "no summed count anywhere");
 });
 
-function doc(over: Partial<HistoryDoc> & { req?: number; ok?: number; r429?: number; r5xx?: number; none?: number; state?: string }): HistoryDoc {
-  const req = over.req || 0, ok = over.ok || 0, r429 = over.r429 || 0, r5xx = over.r5xx || 0, none = over.none || 0;
+/** A document whose ledger's five-minute tier holds the given counts, spread over the newest bins. */
+function tier(binS: number, n: number, counts: { ok?: number; r429?: number; r5xx?: number; none?: number; other?: number }): LedgerTier {
+  const z = () => new Array(n).fill(0);
+  const t: LedgerTier = { binS, from: 1000000, ok: z(), rateLimited: z(), serverErrors: z(), noStatus: z(), other: z() };
+  const put = (arr: number[], v: number) => { for (let i = 0; i < v; i++) arr[n - 1 - (i % 3)] += 1; };
+  put(t.ok, counts.ok || 0); put(t.rateLimited, counts.r429 || 0); put(t.serverErrors, counts.r5xx || 0); put(t.noStatus, counts.none || 0); put(t.other, counts.other || 0);
+  return t;
+}
+function doc(c: { ok?: number; r429?: number; r5xx?: number; none?: number; other?: number; state?: string }): HistoryDoc {
+  const any = (c.ok || 0) + (c.r429 || 0) + (c.r5xx || 0) + (c.none || 0) + (c.other || 0);
   return {
     asOf: 2000, bootAt: 100, config: { windows: [60, 300, 900], minRequests: 10 },
-    overall: { state: over.state || "unknown", worstBucket: req || none ? "key:helper|fable" : null },
-    buckets: req || none ? { "key:helper|fable": { state: over.state || "unknown", windows: {
-      "900": { requests: req, ok, rateLimited: r429, serverErrors: r5xx, noStatus: none, gaveUp: 0 } } } } : {},
+    overall: { state: c.state || "unknown", worstBucket: any ? "key:helper|fable" : null },
+    buckets: { "key:helper|fable": { state: c.state || "unknown", windows: { "900": { requests: 0, ok: 0 } },
+      ledger: { minute: tier(60, 60, {}), fiveMin: tier(300, 288, c), hour: tier(3600, 168, c) } } },
   };
 }
 
-test("the reading rule: traffic and no errors reads what happened, fine and blue, with the trend caveat as a sub-line", () => {
-  const r = readHistory(doc({ req: 4, ok: 4, state: "unknown" }));
-  assert.equal(r.level, "fine");
-  assert.equal(r.headline, "4 requests in the last 15 min, all succeeded.");
-  assert.equal(r.sub, "Too few requests to call a trend yet.");
-  assert.equal(r.traffic, true);
-  assert.doesNotMatch(r.headline, /unknown/);
-  const healthy = readHistory(doc({ req: 40, ok: 40, state: "healthy" }));
-  assert.equal(healthy.level, "fine");
-  assert.equal(healthy.sub, null, "the machine has a verdict: no caveat");
-});
-
-test("no traffic at all reads quiet and gray; errors read the failures in plain words with the machine's own word", () => {
+test("the reading counts the ledger's day (T316): successes and failures over 24 hours, the window named once", () => {
+  const r = readHistory(doc({ ok: 67, r429: 12, r5xx: 4, none: 1 }));
+  assert.equal(r.level, "errors");
+  assert.equal(r.windowS, 86400, "288 five-minute bins");
+  assert.deepEqual(r.counts, { ok: 67, r429: 12, r5xx: 4, none: 1, other: 0, attempts: 84, failures: 17 });
+  assert.equal(r.headline, "67 successful requests · 12 429s · 4 5xx · 1 no connection");
+  assert.equal(windowWords(r.windowS), "last 24 hours");
+  const fine = readHistory(doc({ ok: 40, state: "healthy" }));
+  assert.equal(fine.level, "fine");
+  assert.equal(fine.headline, "40 successful requests");
   const q = readHistory(doc({}));
   assert.equal(q.level, "quiet");
-  assert.equal(q.headline, "No API traffic in the last 15 min.");
+  assert.equal(q.headline, "no API traffic");
   assert.equal(q.traffic, false);
-  const s = readHistory(doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }));
-  assert.equal(s.level, "errors");
-  assert.equal(s.headline, "Rate-limit storm: 20 rate-limited attempts among 30 attempts in the last 15 min.");
-  const d = readHistory(doc({ req: 12, ok: 9, r5xx: 3, state: "degraded" }));
-  assert.equal(d.headline, "The API is failing: 3 server errors among 12 attempts in the last 15 min.");
-  const off = readHistory(doc({ none: 5 }));
-  assert.equal(off.level, "errors");
-  assert.equal(off.headline, "Errors: 5 attempts with no connection among 5 attempts in the last 15 min.");
   assert.equal(readHistory(null).level, "quiet", "no document yet reads as no traffic, never as a word the user must decode");
+  for (const x of [r, fine, q]) assert.ok(!/unknown|storm|failing|fine/i.test(x.headline), x.headline);
+});
+
+test("an older kernel's document (no ledger) is read over its longest window, and its series still draws", () => {
+  const old: HistoryDoc = { asOf: 2000, config: { windows: [60, 300, 900] }, overall: { state: "thrashing", worstBucket: "k" },
+    buckets: { k: { state: "thrashing", windows: { "900": { requests: 30, ok: 10, rateLimited: 20, serverErrors: 0, noStatus: 0, gaveUp: 1 } },
+      series: { binS: 60, from: 0, ok: [1, 2], rateLimited: [3, 0], serverErrors: [0, 0], noStatus: [0, 0], other: [0, 0] } } } };
+  const r = readHistory(old);
+  assert.equal(r.windowS, 900);
+  assert.equal(windowWords(r.windowS), "last 15 min");
+  assert.equal(r.headline, "10 successful requests · 20 429s");
+  assert.equal(documentLedger(old, "fiveMin"), null);
+  assert.deepEqual(documentSeries(old)!.rateLimited, [3, 0]);
 });
 
 test("histories merge as per-host rows: each machine keeps its sentence, the worst level leads, a failed or pending read is its own row", () => {
-  const m = mergeHistories({ "": doc({ req: 4, ok: 4 }), TESTHOST: doc({ req: 30, ok: 10, r429: 20, state: "thrashing" }), PEERHOST: { error: "HTTP 502" }, FARHOST: { pending: true } });
+  const m = mergeHistories({ "": doc({ ok: 4 }), TESTHOST: doc({ ok: 10, r429: 20 }), PEERHOST: { error: "HTTP 502" }, FARHOST: { pending: true } });
   assert.equal(m.level, "errors");
   assert.deepEqual(m.rows.map((r) => r.host), ["", "FARHOST", "PEERHOST", "TESTHOST"]);
-  assert.equal(m.rows[0].reading!.headline, "4 requests in the last 15 min, all succeeded.");
+  assert.equal(m.rows[0].reading!.headline, "4 successful requests");
   assert.equal(m.rows[1].pending, true, "a read still in flight is no reading and no error");
-  assert.equal(m.rows[1].reading, null);
   assert.equal(m.rows[2].error, "HTTP 502");
-  assert.match(m.rows[3].reading!.headline, /^Rate-limit storm/);
+  assert.equal(m.rows[3].reading!.headline, "10 successful requests · 20 429s");
   assert.deepEqual(m.traffic, { "": true, FARHOST: null, PEERHOST: null, TESTHOST: true });
-  assert.equal(m.readings[""]!.level, "fine");
   assert.equal(m.readings.PEERHOST, null, "a failed read is no reading: the frame's word stands for that host");
-  assert.equal(m.readings.FARHOST, null);
-  assert.equal(m.rows.filter((r) => r.reading && /34 requests/.test(r.reading.headline)).length, 0, "4 + 30 is never said");
+  assert.equal(m.rows.filter((r) => r.reading && /14 successful/.test(r.reading.headline)).length, 0, "4 + 10 is never said");
 });
 
-test("a document's per-minute series sums its OWN buckets bin by bin, and none is null", () => {
+test("a document's ledger tier sums its OWN buckets bin by bin; rebin folds k bins into one bar, newest bins last", () => {
   const d: HistoryDoc = { buckets: {
-    a: { series: { binS: 60, from: 0, ok: [1, 2, 3], rateLimited: [0, 1, 0], serverErrors: [0, 0, 1], noStatus: [0, 0, 0], other: [0, 0, 0] } },
-    b: { series: { binS: 60, from: 0, ok: [1, 0, 0], rateLimited: [2, 0, 0], serverErrors: [0, 0, 0], noStatus: [1, 0, 0], other: [0, 0, 0] } },
+    a: { ledger: { minute: { binS: 60, from: 0, ok: [1, 2, 3, 4], rateLimited: [0, 1, 0, 0], serverErrors: [0, 0, 1, 0], noStatus: [0, 0, 0, 0], other: [0, 0, 0, 1] } } },
+    b: { ledger: { minute: { binS: 60, from: 0, ok: [1, 0, 0, 0], rateLimited: [2, 0, 0, 0], serverErrors: [0, 0, 0, 0], noStatus: [1, 0, 0, 0], other: [0, 0, 0, 0] } } },
   } };
-  const s = documentSeries(d)!;
-  assert.deepEqual(s.ok, [2, 2, 3]);
-  assert.deepEqual(s.rateLimited, [2, 1, 0]);
-  assert.deepEqual(s.serverErrors, [0, 0, 1]);
-  assert.deepEqual(s.noStatus, [1, 0, 0]);
-  assert.equal(documentSeries({ buckets: { a: {} } }), null);
+  const t = documentLedger(d, "minute")!;
+  assert.deepEqual(t.ok, [2, 2, 3, 4]);
+  assert.deepEqual(t.rateLimited, [2, 1, 0, 0]);
+  assert.deepEqual(t.noStatus, [1, 0, 0, 0]);
+  assert.deepEqual(t.other, [0, 0, 0, 1]);
+  assert.equal(documentLedger(d, "hour"), null, "a tier no bucket carries");
+  const r = rebin(t, 3);
+  assert.deepEqual(r.ok, [9], "one bar of the newest three bins; the partial oldest bin is dropped");
+  assert.equal(r.binS, 180);
+  assert.equal(r.from, 60);
+  assert.deepEqual(rebin(tier(300, 288, { ok: 3 }), 3).ok.length, 96, "the day as quarter-hours");
+});
+
+test("the as-of stamp reads as an age in words, and a window as its plain name", () => {
+  assert.equal(agoWords(3), "now");
+  assert.equal(agoWords(70), "1 minute ago");
+  assert.equal(agoWords(60 * 7), "7 minutes ago");
+  assert.equal(agoWords(3600 + 60), "1 hour ago");
+  assert.equal(agoWords(3600 * 5), "5 hours ago");
+  assert.equal(agoWords(86400 * 2), "2 days ago");
+  assert.equal(windowWords(3600), "last hour");
+  assert.equal(windowWords(86400), "last 24 hours");
+  assert.equal(windowWords(604800), "last 7 days");
 });
 
 test("the shell loads the merge module before its API-health script and the bundle lists it", () => {
@@ -161,5 +202,15 @@ test("the shell loads the merge module before its API-health script and the bund
   const i = KERNEL.indexOf("/dist/api-health-global.js?v=%d"), j = KERNEL.indexOf('"<script>" + _LANDING_APIH_JS + "</script>"');
   assert.ok(i > 0 && j > i, "the global module is included, and before the script that reads it");
   assert.match(read("vscode-extension", "esbuild.js"), /"\.\.\/ui\/webview\/api-health-global\.ts"/);
-  assert.match(read("ui", "webview", "api-health-global.ts"), /__rompApiHealthMerge = \{\s*mergeFrames, readHistory, mergeHistories, documentSeries, frameDot, machineText,/);
+  assert.match(read("ui", "webview", "api-health-global.ts"), /__rompApiHealthMerge = \{\s*mergeFrames, readHistory, mergeHistories, documentSeries, documentLedger, rebin, frameDot, machineText, machineLine, countsParts, agoWords, windowWords,/);
+});
+
+test("the 5xx magenta is a token in both theme blocks of both sheets (theme parity), and the popup paints through it", () => {
+  const STYLES = read("ui", "webview", "styles.css"), FEED = read("ui", "webview", "feed.css"), KERNEL = read("kernel", "kernel.py");
+  const root = STYLES.slice(STYLES.indexOf(":root"), STYLES.indexOf("body.theme-light")), light = STYLES.slice(STYLES.indexOf("body.theme-light"));
+  assert.match(root, /--st-5xx-bg: #c026d3; --st-5xx-fg: #ffffff;/);
+  assert.match(light, /--st-5xx-bg: #A21CAF; --st-5xx-fg: #ffffff;/);
+  assert.match(FEED, /--st-5xx-bg: #A21CAF; --st-5xx-fg: #ffffff;/, "mirrored where the feed mirrors the blocked red");
+  assert.ok(KERNEL.includes(".ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}"), "a 5xx count wears the token");
+  assert.ok(KERNEL.includes("['serverErrors','var(--st-5xx-bg,#c026d3)']"), "and so does the 5xx band of the bars");
 });

--- a/ui/webview/api-health-merge.test.ts
+++ b/ui/webview/api-health-merge.test.ts
@@ -91,6 +91,9 @@ test("a machine whose tunnel is down or whose frame could not be read is named a
   assert.equal(down.machines[1].dot, "quiet");
   assert.equal(down.machines[1].text, "TESTHOST: not reachable, last seen rate limited · 2 waiting");
   assert.equal(mergeFrames(QUIET, { TESTHOST: { ...OK, stale: true } }).dot, "quiet", "nor does a fine frame heard before the drop block gray");
+  assert.equal(mergeFrames(QUIET, { TESTHOST: { ...OK, stale: true } }).machines[1].text, "TESTHOST: not reachable", "a fine last frame adds no verdict word");
+  const FINE = readHistory(doc({ ok: 12 }));
+  assert.equal(mergeFrames(OK, { TESTHOST: { ...OK, stale: true } }, { TESTHOST: FINE }).machines[1].text, "TESTHOST: not reachable, last seen 12 successful requests", "the counts when read, as every other line");
   const refused = mergeFrames(OK, { TESTHOST: { ...OK, stale: true, fault: "HTTP 403" } });
   assert.equal(refused.dot, "fine");
   assert.equal(refused.machines[1].text, "TESTHOST: could not read its API health (HTTP 403)");
@@ -211,6 +214,8 @@ test("the 5xx magenta is a token in both theme blocks of both sheets (theme pari
   assert.match(root, /--st-5xx-bg: #c026d3; --st-5xx-fg: #ffffff;/);
   assert.match(light, /--st-5xx-bg: #A21CAF; --st-5xx-fg: #ffffff;/);
   assert.match(FEED, /--st-5xx-bg: #A21CAF; --st-5xx-fg: #ffffff;/, "mirrored where the feed mirrors the blocked red");
-  assert.ok(KERNEL.includes(".ah-c-r5xx{color:var(--st-5xx-bg,#c026d3)}"), "a 5xx count wears the token");
-  assert.ok(KERNEL.includes("['serverErrors','var(--st-5xx-bg,#c026d3)']"), "and so does the 5xx band of the bars");
+  assert.ok(KERNEL.includes(".ah-sw-r5xx{background:var(--st-5xx-bg,#c026d3)}"), "the 5xx legend swatch wears the token");
+  assert.ok(KERNEL.includes(".ah-c-r5xx{color:#e879f9}") && KERNEL.includes("body.theme-light .ah-c-r5xx{color:#86198F}"), "a 5xx count's text is inked for each theme's tip (the chip colour as text sits under 4.5:1)");
+  assert.ok(KERNEL.includes(".ah-seg-serverErrors{fill:var(--st-5xx-bg,#c026d3)}"), "and so does the 5xx band of the bars (a class per segment, so the light theme can re-ink it)");
+  assert.ok(KERNEL.includes("body.theme-light .ah-seg-serverErrors{fill:#A21CAF}"), "the light palette's magenta on the bars");
 });

--- a/ui/webview/api-health-merge.ts
+++ b/ui/webview/api-health-merge.ts
@@ -115,7 +115,7 @@ export function machineLine(host: string, f: HostFrame, reading?: Reading | null
   const words = f.state ? stateParts(f, reading) : [];
   let parts: Seg[];
   if (f.fault) parts = [{ text: "could not read its API health (" + f.fault + ")" + (words.length ? ", last seen " + joinParts(words) : ""), kind: "plain" }];
-  else if (f.stale) parts = [{ text: "not reachable, last seen " + (words.length ? joinParts(words) : "fine"), kind: "plain" }];
+  else if (f.stale) parts = [{ text: "not reachable" + (words.length ? ", last seen " + joinParts(words) : ""), kind: "plain" }];
   else parts = words;
   return { name, parts, text: name + (parts.length ? ": " + joinParts(parts) : "") };
 }

--- a/ui/webview/api-health-merge.ts
+++ b/ui/webview/api-health-merge.ts
@@ -11,6 +11,11 @@
 // in its longest window) and `errs` (failed attempts in it), rebuilt every cycle and pushed on change, so the dot
 // changes on the kernel's events and never on a history reading the browser took at some earlier hover. The
 // readings only word each machine's line in the popup.
+//
+// T316 (the user 2026-09-10, the design follow-up): a machine's line is its COUNTS over the popup's window, each
+// class in its own colour (successes in the accent, 429 in the blocked red, 5xx in the 5xx magenta, no connection
+// and other statuses in the label gray), never a verdict word; the window is the ledger's 24 hours when the kernel
+// serves one, else the document's longest window; the histograms are stacked bars from the ledger's tiers.
 
 /** One kernel's apiHealth shell frame, local half (the fields the merge reads). */
 export interface HostFrame {
@@ -24,15 +29,21 @@ export interface HostFrame {
   errs?: number;         // failed attempts that kernel counted in its longest window (T301): red while any
   stale?: boolean;       // the tunnel to that host is not up, or its frame could not be read: the frame is the last one heard
   fault?: string;        // why the last read of that host's frame was refused ("HTTP 403"), when it was
+  host?: string;         // the kernel's own name to its peers (T316): the local machine's line names it
 }
 
 /** The dot's three states: the accent when everything is fine, red when errors are being met, gray when quiet. */
 export type Dot = "fine" | "errors" | "quiet";
 
+/** One coloured piece of a machine's line: the class names the colour token the shell paints it with. */
+export interface Seg { text: string; kind: "plain" | "ok" | "r429" | "r5xx" | "none" }
+
 export interface MachineLine {
-  host: string;
+  host: string;          // "" for the local machine
+  name: string;          // what the line calls it: the kernel's own name, or "this machine" when the frame has none
   dot: Dot;
-  text: string;          // one plain line for the popup: "TESTHOST: rate limited · 2 waiting"
+  parts: Seg[];          // the words after the name, coloured by class; empty until the frame or a reading says something
+  text: string;          // the same line as plain text: "TESTHOST: 67 successful requests · 12 429s"
   stale: boolean;        // named, not counted: a machine not reachable right now has no say in the dot
 }
 
@@ -62,34 +73,56 @@ const CLS_WORDS: Record<string, string> = {
   "429": "rate limited", "529": "overloaded", "offline": "offline", "errors": "errors",
 };
 
-/** What one machine's frame says, in plain words: the kernel's own headline when its frame carries one (a pause,
- *  sessions waiting on the API), the failures counted when its window holds some (the history reading's sentence
- *  when read, the frame's count otherwise), the successes counted when fine and read, quiet when its window is empty. */
-function stateWords(f: HostFrame, reading?: Reading | null): string {
-  if (f.state === "paused") {
-    const why = f.reason === "limit" ? "paused until the usage limit resets" : f.reason === "spend" ? "paused at the spend limit" : "paused by you";
-    return why + (f.waiting ? " · " + f.waiting + " waiting" : "");
-  }
-  if (f.state === "degraded") {
-    return (CLS_WORDS[f.cls || ""] || "errors") + (f.waiting ? " · " + f.waiting + " waiting" : "");
-  }
-  if ((f.errs || 0) > 0) {
-    if (reading && reading.level === "errors") return reading.headline.replace(/\.$/, "");
-    return plural(f.errs as number, "failed attempt") + " in the last 15 min";
-  }
-  if (f.quiet === true) return "no API traffic";
-  if (reading && reading.level === "fine") return "fine · " + plural(reading.requests, "request") + " in the last 15 min, all succeeded";
-  return "fine";
+function plural(n: number, w: string): string { return n + " " + w + (n === 1 ? "" : "s"); }
+
+/** The counts of one window as coloured pieces: successes first, then each failure class present, in its colour;
+ *  no traffic at all is the one plain phrase. Never a verdict word. */
+export function countsParts(c: Counts): Seg[] {
+  if (c.attempts <= 0) return [{ text: "no API traffic", kind: "plain" }];
+  const out: Seg[] = [];
+  if (c.ok) out.push({ text: plural(c.ok, "successful request"), kind: "ok" });
+  if (c.r429) out.push({ text: c.r429 + " 429" + (c.r429 === 1 ? "" : "s"), kind: "r429" });
+  if (c.r5xx) out.push({ text: c.r5xx + " 5xx", kind: "r5xx" });
+  if (c.none) out.push({ text: c.none + " no connection", kind: "none" });
+  if (c.other) out.push({ text: plural(c.other, "other error"), kind: "none" });
+  return out;
 }
 
-/** One machine's line for the popup. A machine not reachable right now is named with what was last heard from
- *  it (and why the read failed, when a read was refused), and reads as such rather than as its old state. */
-export function machineText(host: string, f: HostFrame, reading?: Reading | null): string {
-  const name = host || "this machine";
-  const words = f.state ? stateWords(f, reading) : "";
-  if (f.fault) return name + ": could not read its API health (" + f.fault + ")" + (words ? ", last seen " + words : "");
-  if (f.stale) return name + ": not reachable, last seen " + (words || "fine");
-  return name + ": " + words;
+/** The words after a machine's name: the kernel's own headline when its frame carries one (a pause, sessions
+ *  waiting on the API), else the counts its history read (its reading), else what the frame alone says (quiet, a
+ *  count of failed attempts) until the reading lands. */
+export function stateParts(f: HostFrame, reading?: Reading | null): Seg[] {
+  if (f.state === "paused") {
+    const why = f.reason === "limit" ? "paused until the usage limit resets" : f.reason === "spend" ? "paused at the spend limit" : "paused by you";
+    return [{ text: why + (f.waiting ? " · " + f.waiting + " waiting" : ""), kind: "plain" }];
+  }
+  if (f.state === "degraded") {
+    return [{ text: (CLS_WORDS[f.cls || ""] || "errors") + (f.waiting ? " · " + f.waiting + " waiting" : ""), kind: "plain" }];
+  }
+  if (reading) return countsParts(reading.counts);
+  if ((f.errs || 0) > 0) return [{ text: plural(f.errs as number, "failed attempt") + " in the last 15 min", kind: "plain" }];
+  if (f.quiet === true) return [{ text: "no API traffic", kind: "plain" }];
+  return [];
+}
+
+function joinParts(parts: Seg[]): string { return parts.map((p) => p.text).join(" · "); }
+
+/** One machine's line. A machine not reachable right now is named with what was last heard from it (and why the
+ *  read failed, when a read was refused), and reads as such rather than as its old state. The local machine is
+ *  named by its kernel's own name (`selfName`, the frame's `host`), "this machine" only when none is known. */
+export function machineLine(host: string, f: HostFrame, reading?: Reading | null, selfName?: string): { name: string; parts: Seg[]; text: string } {
+  const name = host || selfName || f.host || "this machine";
+  const words = f.state ? stateParts(f, reading) : [];
+  let parts: Seg[];
+  if (f.fault) parts = [{ text: "could not read its API health (" + f.fault + ")" + (words.length ? ", last seen " + joinParts(words) : ""), kind: "plain" }];
+  else if (f.stale) parts = [{ text: "not reachable, last seen " + (words.length ? joinParts(words) : "fine"), kind: "plain" }];
+  else parts = words;
+  return { name, parts, text: name + (parts.length ? ": " + joinParts(parts) : "") };
+}
+
+/** The plain-text form of a machine's line (tests, the cell's description). */
+export function machineText(host: string, f: HostFrame, reading?: Reading | null, selfName?: string): string {
+  return machineLine(host, f, reading, selfName).text;
 }
 
 /**
@@ -115,7 +148,8 @@ export function mergeFrames(local: HostFrame, hosts: Record<string, HostFrame> |
       const r = d === "errors" ? 2 : frameRank(f);
       if (r > worstRank) { worstRank = r; worst = host; }
     }
-    return { host, dot: d, text: machineText(host, f, rd), stale: away };
+    const line = machineLine(host, f, rd, local.host);
+    return { host, name: line.name, dot: d, parts: line.parts, text: line.text, stale: away };
   });
   let dot: Dot;
   if (worstRank >= 2) dot = "errors";
@@ -124,6 +158,10 @@ export function mergeFrames(local: HostFrame, hosts: Record<string, HostFrame> |
   if (worstRank < 2) worst = "";
   return { dot, worst, machines, n: rows.length };
 }
+
+/** One tier of a bucket's ledger as the kernel serves it: dense arrays, oldest first, the last bin holding asOf. */
+export interface LedgerTier { binS: number; from: number; ok: number[]; rateLimited: number[]; serverErrors: number[]; noStatus: number[]; other: number[] }
+export type LedgerTierName = "minute" | "fiveMin" | "hour";
 
 /** The bits of a /api-health document the reading needs. */
 export interface HistoryDoc {
@@ -134,66 +172,69 @@ export interface HistoryDoc {
     state?: string; stateSince?: number; why?: string;
     windows?: Record<string, { requests?: number; ok?: number; noStatus?: number; gaveUp?: number; rateLimited?: number; serverErrors?: number; overloaded?: number; otherErrors?: number; complete?: boolean }>;
     series?: { binS: number; from: number; ok: number[]; rateLimited: number[]; serverErrors: number[]; noStatus: number[]; other: number[] };
+    ledger?: Partial<Record<LedgerTierName, LedgerTier>>;
   }>;
   config?: { windows?: number[]; minRequests?: number };
 }
 
+/** The counts of one window, every bucket of one kernel added (within-host arithmetic). */
+export interface Counts { ok: number; r429: number; r5xx: number; none: number; other: number; attempts: number; failures: number }
+
 export interface Reading {
   level: "errors" | "fine" | "quiet";
-  state: string;             // the machine's own word, for the record (never the headline when it is "unknown")
-  headline: string;          // what the user reads first
-  sub: string | null;        // the trend caveat, when the machine has too little to call one
-  requests: number;          // attempts with a status over the longest window, every bucket
-  errors: number;            // failed attempts over it (429 + 5xx + other + no status)
-  traffic: boolean;          // any attempt at all over the longest window
-  windowS: number;
+  state: string;             // the machine's own word, for the record (never shown as a verdict)
+  counts: Counts;            // over the window
+  windowS: number;           // the window the counts cover: the ledger's 24 hours, else the document's longest window
+  traffic: boolean;          // any attempt at all over the window
+  requests: number;          // attempts with a status (for the record)
+  errors: number;            // failures over the window
+  headline: string;          // the counts as one plain line: "67 successful requests · 12 429s"
 }
 
 const SEV: Record<string, number> = { unknown: 0, healthy: 1, recovering: 2, degraded: 3, thrashing: 4 };
+export const DAY_S = 86400;
 
-function minutes(s: number): string { return s % 60 === 0 ? (s / 60) + " min" : s + " s"; }
-function plural(n: number, w: string): string { return n + " " + w + (n === 1 ? "" : "s"); }
+function sum(a: number[] | undefined): number { let t = 0; for (const v of a || []) t += v || 0; return t; }
+
+/** The counts a document holds over the popup's window: the ledger's five-minute tier (24 hours) when the kernel
+ *  serves one, else the longest state-machine window. Buckets of one kernel are added (one clock). */
+export function documentCounts(d: HistoryDoc | null | undefined): { counts: Counts; windowS: number } {
+  const buckets = (d && d.buckets) || {};
+  const led = documentLedger(d, "fiveMin");
+  let ok = 0, r429 = 0, r5xx = 0, none = 0, other = 0, windowS: number;
+  if (led) {
+    ok = sum(led.ok); r429 = sum(led.rateLimited); r5xx = sum(led.serverErrors); none = sum(led.noStatus); other = sum(led.other);
+    windowS = led.binS * led.ok.length;
+  } else {
+    const wins = (d && d.config && d.config.windows) || [60, 300, 900];
+    windowS = Math.max.apply(null, wins);
+    for (const k of Object.keys(buckets)) {
+      const w = ((buckets[k].windows || {})[String(windowS)]) || {};
+      ok += w.ok || 0; r429 += w.rateLimited || 0; r5xx += (w.serverErrors || 0) + (w.overloaded || 0); none += w.noStatus || 0; other += w.otherErrors || 0;
+    }
+  }
+  const failures = r429 + r5xx + none + other;
+  return { counts: { ok, r429, r5xx, none, other, attempts: ok + failures, failures }, windowS };
+}
 
 /**
- * The reading rule (part C): the machine's `unknown` is a documented signal and stays in the document, but the
- * user reads what HAPPENED. Traffic and no errors: "N requests in the last 15 min, all succeeded" (fine; when the
- * machine still says unknown, the sub-line says too few to call a trend). Errors: the failures counted, in the
- * machine's word when it has one (thrashing / degraded / recovering), else plainly. No traffic: quiet. The word
- * "unknown" is never the headline.
+ * The reading rule (T301 part C, reworded for T316): the user reads what HAPPENED, as counts. Traffic with no
+ * failures: the successes counted (fine). Failures: each class counted, in its colour (errors). No traffic: quiet.
+ * The state machine's word stays in the document and appears nowhere the user reads.
  */
 export function readHistory(d: HistoryDoc | null | undefined): Reading {
-  const wins = (d && d.config && d.config.windows) || [60, 300, 900];
-  const slow = Math.max.apply(null, wins);
   const buckets = (d && d.buckets) || {};
-  let requests = 0, ok = 0, noStatus = 0, gaveUp = 0, r429 = 0, r5xx = 0, other = 0;
   let worst = "unknown";
   for (const k of Object.keys(buckets)) {
-    const b = buckets[k];
-    const w = (b.windows || {})[String(slow)] || {};
-    requests += w.requests || 0; ok += w.ok || 0; noStatus += w.noStatus || 0; gaveUp += w.gaveUp || 0;
-    r429 += w.rateLimited || 0; r5xx += (w.serverErrors || 0) + (w.overloaded || 0); other += w.otherErrors || 0;
-    if ((SEV[b.state || "unknown"] || 0) > (SEV[worst] || 0)) worst = b.state || worst;
+    const st = buckets[k].state || "unknown";
+    if ((SEV[st] || 0) > (SEV[worst] || 0)) worst = st;
   }
-  const errors = r429 + r5xx + other + noStatus;
-  const attempts = requests + noStatus;
-  const traffic = attempts > 0;
   const state = (d && d.overall && d.overall.state) || worst;
-  const win = minutes(slow);
-  if (!traffic) {
-    return { level: "quiet", state, headline: "No API traffic in the last " + win + ".", sub: null, requests, errors, traffic, windowS: slow };
-  }
-  if (errors === 0) {
-    const sub = state === "unknown" || SEV[state] === undefined ? "Too few requests to call a trend yet." : null;
-    return { level: "fine", state, headline: plural(requests, "request") + " in the last " + win + ", all succeeded.", sub, requests, errors, traffic, windowS: slow };
-  }
-  const parts: string[] = [];
-  if (r429) parts.push(plural(r429, "rate-limited attempt"));
-  if (r5xx) parts.push(plural(r5xx, "server error"));
-  if (noStatus) parts.push(plural(noStatus, "attempt") + " with no connection");
-  if (other) parts.push(plural(other, "other error"));
-  const word = state === "thrashing" ? "Rate-limit storm" : state === "degraded" ? "The API is failing" : state === "recovering" ? "Recovering" : "Errors";
-  const head = word + ": " + parts.join(", ") + " among " + plural(attempts, "attempt") + " in the last " + win + (gaveUp ? "; " + plural(gaveUp, "turn") + " gave up" : "") + ".";
-  return { level: state === "recovering" && errors === 0 ? "fine" : "errors", state, headline: head, sub: null, requests, errors, traffic, windowS: slow };
+  const { counts, windowS } = documentCounts(d);
+  const traffic = counts.attempts > 0;
+  const level: Reading["level"] = !traffic ? "quiet" : counts.failures > 0 ? "errors" : "fine";
+  return { level, state, counts, windowS, traffic, requests: counts.ok + counts.r429 + counts.r5xx + counts.other, errors: counts.failures,
+           headline: joinParts(countsParts(counts)) };
 }
 
 /** One machine's reading, kept under its name; a failed read is its own line; a read still in flight is pending. */
@@ -240,4 +281,57 @@ export function documentSeries(d: HistoryDoc | null | undefined): { binS: number
     }
   }
   return out;
+}
+
+const LEDGER_KEYS: Array<keyof Omit<LedgerTier, "binS" | "from">> = ["ok", "rateLimited", "serverErrors", "noStatus", "other"];
+
+/** One tier of every bucket's ledger in one document, summed bin by bin (within-host arithmetic); null when no
+ *  bucket carries the tier (an older kernel's document). */
+export function documentLedger(d: HistoryDoc | null | undefined, tier: LedgerTierName): LedgerTier | null {
+  const buckets = (d && d.buckets) || {};
+  let out: LedgerTier | null = null;
+  for (const k of Object.keys(buckets)) {
+    const t = buckets[k].ledger && buckets[k].ledger![tier];
+    if (!t || !t.ok) continue;
+    if (!out) { out = { binS: t.binS, from: t.from, ok: t.ok.slice(), rateLimited: (t.rateLimited || []).slice(), serverErrors: (t.serverErrors || []).slice(), noStatus: (t.noStatus || []).slice(), other: (t.other || []).slice() }; continue; }
+    for (const key of LEDGER_KEYS) {
+      const a = out[key], b = t[key] || [];
+      for (let i = 0; i < a.length && i < b.length; i++) a[i] += b[i] || 0;
+    }
+  }
+  return out;
+}
+
+/** A tier re-binned `k` bins per bar, oldest first, the last bar the newest bins (a partial first bar is dropped),
+ *  so 288 five-minute bins draw as 96 quarter-hours. */
+export function rebin(t: LedgerTier, k: number): LedgerTier {
+  if (k <= 1) return t;
+  const n = Math.floor(t.ok.length / k), skip = t.ok.length - n * k;
+  const out: LedgerTier = { binS: t.binS * k, from: t.from + skip * t.binS, ok: [], rateLimited: [], serverErrors: [], noStatus: [], other: [] };
+  for (const key of LEDGER_KEYS) {
+    const src = t[key] || [], dst: number[] = [];
+    for (let i = 0; i < n; i++) { let s = 0; for (let j = 0; j < k; j++) s += src[skip + i * k + j] || 0; dst.push(s); }
+    out[key] = dst;
+  }
+  return out;
+}
+
+/** A stamp's age in words, for the popup's "as of" (T316): now, 1 minute ago, 3 hours ago, 2 days ago. */
+export function agoWords(seconds: number): string {
+  const s = Math.max(0, Math.round(seconds));
+  if (s < 45) return "now";
+  const m = Math.round(s / 60);
+  if (m < 60) return m + (m === 1 ? " minute ago" : " minutes ago");
+  const h = Math.round(m / 60);
+  if (h < 24) return h + (h === 1 ? " hour ago" : " hours ago");
+  const d = Math.round(h / 24);
+  return d + (d === 1 ? " day ago" : " days ago");
+}
+
+/** A window's name, once, at the top: "last 24 hours", "last hour", "last 7 days", "last 15 min". */
+export function windowWords(seconds: number): string {
+  if (seconds >= 6 * DAY_S) return "last " + Math.round(seconds / DAY_S) + " days";
+  if (seconds >= DAY_S) return "last 24 hours";
+  if (seconds >= 3600) return seconds === 3600 ? "last hour" : "last " + Math.round(seconds / 3600) + " hours";
+  return "last " + Math.round(seconds / 60) + " min";
 }

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -167,6 +167,7 @@ body.theme-light {
   --st-awaitbg-bg: #54B204; --st-awaitbg-fg: #0c1a00;
   --st-compacting-bg: #0F766E; --st-compacting-fg: #ffffff;
   --st-blocked-bg: #e5484d; --st-blocked-fg: #ffffff;
+  --st-5xx-bg: #A21CAF; --st-5xx-fg: #ffffff;   /* the 5xx magenta (T316), mirrors styles.css */
   --st-retrying-bg: #9C4A0C; --st-retrying-fg: #ffffff;
   --radius-menu: 6px;
   --shadow-menu: 0 4px 12px rgba(31, 26, 20, 0.16);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -179,6 +179,9 @@ body.scheme-solarized-dark {
   --st-awaitbg-bg: #54B204; --st-awaitbg-fg: #0c1a00;
   --st-compacting-bg: #14b8a6; --st-compacting-fg: #ffffff;   /* teal — the compacting accent (text + compression bar) */
   --st-blocked-bg: #e5484d; --st-blocked-fg: #ffffff;   /* alarm red — session stopped on an API error */
+  /* magenta — a 5xx answer (529 included) in the API-health histograms and counts (T316): distinct from the 429 red
+     and the retrying amber, so a storm of one kind never reads as the other */
+  --st-5xx-bg: #c026d3; --st-5xx-fg: #ffffff;
   /* amber-orange — the API is backing off and retrying (the tab ring, the chip, the chat's retry notices); the
      hue sat RAW in seven rules until 2026-09-08 (5.38:1 on the chat's card surface) */
   --st-retrying-bg: #e67e22; --st-retrying-fg: #2a1500;
@@ -246,6 +249,7 @@ body.theme-light {
   --st-awaitbg-bg: #54B204; --st-awaitbg-fg: #0c1a00;
   --st-compacting-bg: #0F766E; --st-compacting-fg: #ffffff;
   --st-blocked-bg: #e5484d; --st-blocked-fg: #ffffff;
+  --st-5xx-bg: #A21CAF; --st-5xx-fg: #ffffff;   /* the 5xx magenta in the light palette: 5.3:1 on the card, white on it 6.7:1 */
   --st-retrying-bg: #9C4A0C; --st-retrying-fg: #ffffff;   /* the retrying amber in the light palette: 4.86:1 on the card, white on it 6.18:1 */
   --radius-menu: 6px;
   --shadow-menu: 0 4px 12px rgba(31, 26, 20, 0.16);


### PR DESCRIPTION
## Summary

The API health popup and its detail follow the user's design follow-up (T316): stacked histograms of traffic instead of overlaid lines, lines that count in colour instead of saying "fine", a real 24-hour span behind the popup and a 7-day span behind a new detail modal, every machine named by its own name, a vertical legend, and the read's age in words.

## Design points

**The ledger.** The aggregator's event ring holds only the state machine's windows (15 minutes), so it cannot draw a day. Every attempt is now also folded, the moment it lands, into three tiers of fixed-width bins per bucket: 60 one-minute bins (the last hour), 288 five-minute bins (the last 24 hours) and 168 hourly bins (the last 7 days), five counters each (successes, 429, 5xx with 529, no connection, another status). Bins outside a tier's span are dropped on every add, so the structure is bounded at 516 bins per bucket: under about 100 KB per bucket in memory when every bin has traffic, about 10 KB in the state file; buckets (auth times family) are few. It is persisted in `api-health.json` with the state (on a transition, and on the first event of each minute, so a restart loses at most the current minute) and restored at boot with malformed pieces skipped and logged. It is served additively per bucket as `ledger` (schema 1 unchanged; `series` stays for older readers). The spend ledger's hour buckets (T293) are the precedent.

**The frame names this kernel.** `_api_health_frame` carries `host` (this kernel's name to its peers, `_self_host`), so the popup's line for this machine says the real host name; "this machine" only when a frame has none. Tests stay on TESTHOST and HUBHOST.

**The popup.** No summary head line: one line per machine (the dot in its state, the name, then the counts over the window in their colours: successful requests in the accent, 429s in the blocked red, 5xx in a new magenta token, no connection and other statuses in the label gray), or the kernel's own words when its sessions are waiting or it is paused, "no API traffic" when quiet; the window ("last 24 hours") named once beside the title; a machine not reachable keeps its own line. The History section draws one stacked histogram per machine from the ledger (the day as 96 quarter-hour bars in the hover), successes at the bottom, 429 and 5xx stacked on them, a gray band for no-connection and other-status failures only when the range holds any, one ceiling label and no peak text, ticks at round ages; a vertical, left-justified legend with swatches (429, then 5xx, the gray line only when it applies); the read's age in words ("now", "3 minutes ago"), recomputed at each render; State changes as before. An older kernel's document (no ledger) draws its 15-minute series the same way.

**The detail.** The dot's click (or Enter) opens the detail: the same card as a centred modal in the spend modal's grammar, 720 px wide, with range chips for 1 hour (60 one-minute bars), 24 hours (96 quarter-hour bars) and 7 days (168 hourly bars), one large histogram per machine, the waiting sessions and the pause control kept. The hover stays the day.

**Tokens.** `--st-5xx-bg`/`--st-5xx-fg` (magenta) join both theme blocks of `styles.css` and the feed sheet's mirror; the popup paints counts and bars through the tokens with fallbacks.

## Tests

- `tests/test_api_health_ledger.py` (new): fold per class and tier, eviction by span, the dense view (`from`, zeros, a future bin left out), parse of a persisted ledger with malformed pieces, the snapshot's per-bucket `ledger`, persistence and restore across a boot, the once-a-minute rollover write.
- `ui/webview/api-health-merge.test.ts`: the counts wording and coloured parts (no verdict word anywhere), the host name, the ledger read over the day, an older document over its window, `documentLedger` and `rebin`, `agoWords` and `windowWords`, the token parity in both sheets.
- `tests/test_api_health_hover_browser.py`: fixtures carry ledgers; the served popup pins the machine lines, the window, the stacked bars (96), the vertical legend (the gray line only for the offline document), the age, the host name in the hosts scenario, and a new detail step (chips, 96/60/168 bars, Escape, the hover unchanged after).
- `tests/test_api_health_browser.py`, `tests/test_api_health_hover.py`, `tests/test_api_health_rail.py`, `tests/test_api_health_hosts.py`, `tests/test_api_health.py`: pins moved to the new markup and wording; the frame's `host`; the state file's bound with the ledger's tiers; the Tab cycle with the range chips.

## Docs

`docs/reference.md`: the ledger (a new subsection with the memory cost), the frame's `host`, the popup and detail as they read now. `docs/guide.md`: the bottom bar paragraph.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
