### PR TITLE
Files control: a gear setting hides it, and a served guard that the control opens the Files pane

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -48807,7 +48807,9 @@ var F={chat:document.getElementById('f-chat'),fleet:document.getElementById('f-f
 // bell's `.on`, the class _LANDING_PUSH_JS paints from the master + this device's subscription and the
 // slash rule keys on, until the next paint event. A tab or a reveal decides which pane shows, nothing else.
 var B=bar.querySelectorAll('button[data-pane]'),KT='romp-mobile-tab';
-function show(p){if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)if(F[k])F[k].classList.toggle('m-on',k===p);   // a pane this shell lacks is skipped, never a TypeError
+function filesCtlM(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}   // the gear's Files-control setting (T317): the same read the pane controller makes, which parses after this script
+function show(p){if(p==='files'&&!filesCtlM())p='chat';   // the Files tab is hidden while its control is off: the chat shows instead
+if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)if(F[k])F[k].classList.toggle('m-on',k===p);   // a pane this shell lacks is skipped, never a TypeError
 for(var i=0;i<B.length;i++)B[i].classList.toggle('on',B[i].getAttribute('data-pane')===p);
 try{localStorage.setItem(KT,p);}catch(e){}
 // a tab switch changes what is on screen: re-tell the panes (the collapse script's broadcast; absent only
@@ -49292,6 +49294,14 @@ _LANDING_COLLAPSE_JS = """
   if(qp!==null){po={chat:false,fleet:false,feed:false,timeline:false,files:false};qp.split(',').forEach(function(k){k=k.trim();if(k in po)po[k]=true;});}
   function saveP(){try{localStorage.setItem(PK,JSON.stringify(po));}catch(e){}}
   var LBL={chat:'chat',fleet:'fleet',feed:'feed',timeline:'timeline',files:'files pane'};
+  // THE FILES CONTROL'S OWN SETTING (T317, the user 2026-09-10): the gear's "Files control in the dashboard bar"
+  // (romp:settings.filesControl, gear.js; shown unless the store holds the literal false). Off: the rail's Files
+  // toggle and the phone's Files tab are hidden (body.no-files-control), an open Files pane closes on the same
+  // apply, the pane cannot be brought forward (togglePane refuses 'files': the palette command, a stale relay),
+  // and the panes are told the pane is unavailable (avail.files below), so a file link set to open there opens
+  // over the pane clicked (ui/webview/file-route.ts). The gear writes the store from the feed iframe, another
+  // document, so the storage listener below is the event that re-applies it here.
+  function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}
   // The pane KEYS, from _PANE_ORDER (the one list of panes), so a pane added there is broadcast below without
   // anyone remembering this block. The panes learn which panes are ON SCREEN from the shell, which holds that
   // state: {romp:'panes',on:{key:bool}} goes to every pane iframe on every apply(), a toggle being the event
@@ -49307,11 +49317,16 @@ _LANDING_COLLAPSE_JS = """
   // classes ignored, _LANDING_MOBILE_JS) it is the current tab, so a po.files left true by a desktop session
   // or an earlier bring-forward cannot silently steer a phone's file links into a tab nobody is looking at
   function panesMsg(){var mob=!!(window.__rompMobileOn&&window.__rompMobileOn()),tab=mob?document.body.getAttribute('data-tab'):null;
-    var on={};KEYS.forEach(function(k){on[k]=mob?(k===tab):!!po[k];});return {romp:'panes',on:on};}
+    var on={};KEYS.forEach(function(k){on[k]=mob?(k===tab):!!po[k];});return {romp:'panes',on:on,avail:{files:filesCtl()}};}
   function tell(f,m){try{f&&f.contentWindow&&f.contentWindow.postMessage(m,'*');}catch(e){}}
   function broadcast(){var m=panesMsg();KEYS.forEach(function(k){tell(document.getElementById('f-'+k),m);});}
   window.__rompPanesTell=broadcast;   // the mobile script re-tells on a tab switch / layout flip
   function apply(){
+    var ctl=filesCtl();
+    document.body.classList.toggle('no-files-control',!ctl);
+    if(!ctl&&po.files){po.files=false;saveP();}   // the control gone, its pane closes cleanly on the same apply
+    // a phone left on the Files tab when the control goes: the tab bar's button is hidden, so the chat comes forward
+    if(!ctl&&window.__rompMobileOn&&window.__rompMobileOn()&&document.body.getAttribute('data-tab')==='files'){try{window.__rompMobileTab&&window.__rompMobileTab('chat');}catch(e){}}
     document.body.classList.toggle('po-chat',!!po.chat);
     document.body.classList.toggle('po-fleet',!!po.fleet);
     document.body.classList.toggle('po-feed',!!po.feed);
@@ -49326,7 +49341,7 @@ _LANDING_COLLAPSE_JS = """
     try{window.dispatchEvent(new Event('romp-panes'));}catch(e){}   // nudge the timeline band to auto-fit when toggled
     broadcast();
   }
-  function togglePane(k,to){if(!(k in po))return;var nv=(to===undefined)?!po[k]:!!to;
+  function togglePane(k,to){if(!(k in po))return;if(k==='files'&&!filesCtl())return;var nv=(to===undefined)?!po[k]:!!to;
     if(nv===!!po[k])return;   // already so (a relay's bring-forward on an open pane): nothing changed, so no re-apply and no broadcast claiming one
     if(nv&&!po[k]&&window.__rompGrowFair)window.__rompGrowFair(k);   // newly shown → fair width, not a sliver
     po[k]=nv;apply();saveP();}
@@ -49747,6 +49762,8 @@ def _landing():
             "justify-content:center;transition:color .1s,background .1s,border-color .1s}"
             ".rail-btn:hover{color:#cfe6ff;background:rgba(255,255,255,0.06)}"
             ".rail-btn.on{color:var(--accent);background:rgba(156,210,255,0.12);border-color:rgba(156,210,255,0.35)}"
+            # the Files control hidden by its gear setting (T317): the rail's toggle and the phone's tab both go
+            "body.no-files-control .rail-btn[data-pane=files],body.no-files-control #mtabs button[data-pane=files]{display:none}"
             # the ↻ refresh + ⛭ settings actions sit in .rail-acts, pinned to the RIGHT (margin-left:auto on the
             # wrapper) of the bottom bar and ALWAYS visible — settings (⛭, last in the DOM) at the far right.
             ".rail-act{flex:0 0 auto;display:flex;align-items:center;justify-content:center;margin:1px 4px;padding:4px 0;"

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -49324,7 +49324,7 @@ _LANDING_COLLAPSE_JS = """
   function apply(){
     var ctl=filesCtl();
     document.body.classList.toggle('no-files-control',!ctl);
-    if(!ctl&&po.files){po.files=false;saveP();}   // the control gone, its pane closes cleanly on the same apply
+    if(!ctl&&po.files){po.files=false;if(qp===null)saveP();}   // the control gone, its pane closes cleanly on the same apply; a ?panes= bookmark stays a view (never written over the stored set)
     // a phone left on the Files tab when the control goes: the tab bar's button is hidden, so the chat comes forward
     if(!ctl&&window.__rompMobileOn&&window.__rompMobileOn()&&document.body.getAttribute('data-tab')==='files'){try{window.__rompMobileTab&&window.__rompMobileTab('chat');}catch(e){}}
     document.body.classList.toggle('po-chat',!!po.chat);

--- a/tests/test_files_pane.py
+++ b/tests/test_files_pane.py
@@ -248,7 +248,6 @@ class Shell(unittest.TestCase):
         js = km._LANDING_COLLAPSE_JS
         _has(self, "function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}", js)
         _has(self, "document.body.classList.toggle('no-files-control',!ctl);", js)
-        _has(self, "if(!ctl&&po.files){po.files=false;saveP();}", js)
         _has(self, "if(k==='files'&&!filesCtl())return;", js)
         _has(self, "return {romp:'panes',on:on,avail:{files:filesCtl()}};", js)
         _has(self, "window.addEventListener('storage',apply);", js)   # the gear writes from another document: this is the event
@@ -257,7 +256,19 @@ class Shell(unittest.TestCase):
         # the gear's row, in the panes section beside "File links open in", shown by default; the chat's route reads the word
         gear = (UI / "gear.js").read_text()
         _has(self, "<input type=checkbox id=rs-filesctl checked>", gear)
-        _has(self, "s.filesControl = fc.checked; save(s);", gear)
+        # the box has a NAME OF ITS OWN in the gear's one var list (review find: a second `fc` shadowed the feed's
+        # collapsed box, so the new row was dead and the feed box wrote this setting)
+        _has(self, "fsc = document.getElementById('rs-filesctl')", gear)
+        _has(self, "if (fsc) fsc.addEventListener('change', function () { var s = load(); s.filesControl = fsc.checked; save(s); });", gear)
+        _has(self, "if (fsc) fsc.checked = (s.filesControl !== false);", gear)
+        self.assertEqual(gear.count("fc = document.getElementById("), 1, "fc is the feed's collapsed box alone")
+        self.assertEqual(gear.count("fsc = document.getElementById("), 1)
+        # the palette's entry for the pane is not listed while the control is hidden (re-read at every open)
+        pal = (UI / "palette-main.ts").read_text()
+        _has(self, 'when: key === "files" ? () => !document.body.classList.contains("no-files-control") : undefined,', pal)
+        _has(self, "filter((c) => !c.hidden && (!c.when || c.when()))", (UI / "palette.ts").read_text())
+        # a ?panes= bookmark stays a view: the forced close is never written over the stored set
+        _has(self, "if(!ctl&&po.files){po.files=false;if(qp===null)saveP();}", js)
         self.assertLess(gear.index("id=rs-filelink"), gear.index("id=rs-filesctl"), "the row follows the file-link setting it qualifies")
         render = (UI / "render.ts").read_text()
         _has(self, "fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false)", render)

--- a/tests/test_files_pane.py
+++ b/tests/test_files_pane.py
@@ -238,6 +238,33 @@ class Shell(unittest.TestCase):
         _has(self, "gutter('gv-c',function(){var c=document.body.classList;return c.contains('po-feed')?'feed-pane':"
                       "c.contains('po-fleet')?'fleet-pane':'chat-pane';},'files-pane');", self.html)
 
+    def test_the_files_controls_own_setting_hides_it_in_both_layouts(self):
+        # T317 (the user 2026-09-10): the gear's "Files control in the dashboard bar" (romp:settings.filesControl,
+        # shown unless the store holds the literal false). The shell reads the gear's store key itself, hides the
+        # rail's toggle and the phone's tab by one body class, closes an open pane on the same apply, refuses to
+        # bring the pane forward, tells the panes it is unavailable, and the phone's switcher never shows a hidden
+        # tab (a stored romp-mobile-tab, a relay). Executed under node in tests/test_pane_state_broadcast.py.
+        _has(self, "body.no-files-control .rail-btn[data-pane=files],body.no-files-control #mtabs button[data-pane=files]{display:none}", self.html)
+        js = km._LANDING_COLLAPSE_JS
+        _has(self, "function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}", js)
+        _has(self, "document.body.classList.toggle('no-files-control',!ctl);", js)
+        _has(self, "if(!ctl&&po.files){po.files=false;saveP();}", js)
+        _has(self, "if(k==='files'&&!filesCtl())return;", js)
+        _has(self, "return {romp:'panes',on:on,avail:{files:filesCtl()}};", js)
+        _has(self, "window.addEventListener('storage',apply);", js)   # the gear writes from another document: this is the event
+        mob = km._LANDING_MOBILE_JS
+        _has(self, "function show(p){if(p==='files'&&!filesCtlM())p='chat';", mob)
+        # the gear's row, in the panes section beside "File links open in", shown by default; the chat's route reads the word
+        gear = (UI / "gear.js").read_text()
+        _has(self, "<input type=checkbox id=rs-filesctl checked>", gear)
+        _has(self, "s.filesControl = fc.checked; save(s);", gear)
+        self.assertLess(gear.index("id=rs-filelink"), gear.index("id=rs-filesctl"), "the row follows the file-link setting it qualifies")
+        render = (UI / "render.ts").read_text()
+        _has(self, "fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false)", render)
+        # the hint in the pane stays true: it speaks of the pane being open or closed, never of the control
+        files = (UI / "files.ts").read_text()
+        _has(self, "To open them here while it is closed, set File links open in to The Files pane in the gear.", files)
+
     def test_mobile_tab_and_the_palette_command(self):
         _has(self, "#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}", self.html)
         _has(self, "#f-chat.m-on,#f-fleet.m-on,#f-feed.m-on,#f-files.m-on{display:block}", self.html)
@@ -294,11 +321,11 @@ class Relay(unittest.TestCase):
         # gesture reader); the pane validates the identity and caches it per sid (files.ts)
         render = (UI / "render.ts").read_text()
         _has(self, 'window.parent.postMessage({ romp: "viewFile", path, sid: to, pane: "pane",', render)
-        _has(self, "fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true)", render)
+        _has(self, "fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false)", render)
         files = (UI / "files.ts").read_text()
         _has(self, "asIdentity(m.identity)", files)
         route = (UI / "file-route.ts").read_text()
-        _has(self, "export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean): FileRoute {", route)
+        _has(self, "export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean, filesAvail: boolean = true): FileRoute {", route)
 
     def test_the_gear_and_the_guide_say_the_open_pane_wins(self):
         gear = (UI / "gear.js").read_text()
@@ -516,7 +543,7 @@ class BrowseRelay(unittest.TestCase):
         # identity, opens the browser, routes a pick through its own open, and owes the shell no browseClosed
         render = (UI / "render.ts").read_text()
         _has(self, 'window.parent.postMessage({ romp: "browseFiles", path: path || ".", sid: to, pane: "pane",', render)
-        _has(self, "browseRoute(web, settings.fileLinkPane, window.parent !== window, panesOn.files === true)", render)
+        _has(self, "browseRoute(web, settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false)", render)
         files = (UI / "files.ts").read_text()
         _has(self, "shellRestore: false,", files)
         _has(self, "if (sid && id) identities.set(sid, id);", files)
@@ -525,7 +552,7 @@ class BrowseRelay(unittest.TestCase):
         browse = (UI / "file-browse.ts").read_text()
         _has(self, "if (!shellRestore) return;", browse)
         route = (UI / "file-route.ts").read_text()
-        _has(self, "export function browseRoute(web: boolean, pane: unknown, framed: boolean, filesOpen: boolean): BrowseRoute {", route)
+        _has(self, "export function browseRoute(web: boolean, pane: unknown, framed: boolean, filesOpen: boolean, filesAvail: boolean = true): BrowseRoute {", route)
         _has(self, 'export type BrowseRoute = FileRoute | "editor";', route)
 
     def test_the_gear_and_the_guide_name_the_folder(self):

--- a/tests/test_files_pane_toggle_served.py
+++ b/tests/test_files_pane_toggle_served.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""T317 (the user 2026-09-10): clicking the dashboard's Files control opened the timeline in a side pane instead of
+the Files pane. Reproduction and guard on the real shell page (`/`) of a hermetic kernel: the desktop rail's Files
+toggle and the phone layout's Files tab open the Files pane, and the gear's "Files control in the dashboard bar"
+setting (T317 add-on) hides both, closes an open pane and refuses a bring-forward. With FILES_SHOTS=<dir> the driver
+writes screenshots (the control shown, and hidden). Skips LOUDLY without
+the extension deps or a Playwright browser. SYNTHETIC fixtures only (the notes-api demo world: session web)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
+
+WEB = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+// what is on screen: the body's pane classes, every pane's box and display, every pane iframe's src and title
+const measure = () => page.evaluate(() => {
+  const panes = {};
+  for (const id of ["chat-pane", "fleet-pane", "feed-pane", "files-pane", "tl-pane"]) {
+    const p = document.getElementById(id);
+    if (!p) { panes[id] = null; continue; }
+    const r = p.getBoundingClientRect(); const cs = getComputedStyle(p);
+    const f = p.querySelector("iframe");
+    let title = null, url = null;
+    try { title = f && f.contentDocument ? f.contentDocument.title : null; url = f && f.contentWindow ? f.contentWindow.location.pathname : null; } catch (e) { title = "cross-origin"; }
+    panes[id] = { display: cs.display, x: Math.round(r.left), y: Math.round(r.top), w: Math.round(r.width), h: Math.round(r.height),
+                  iframe: f ? { id: f.id, src: f.getAttribute("src"), url, title, mOn: f.classList.contains("m-on") } : null };
+  }
+  const vis = (b) => { const cs = getComputedStyle(b); const r = b.getBoundingClientRect(); return cs.display !== "none" && r.width > 0; };
+  const rail = Array.from(document.querySelectorAll(".rail-btn[data-pane]")).map((b) => ({ pane: b.dataset.pane, label: b.textContent, on: b.classList.contains("on"), shown: vis(b) }));
+  const tabs = Array.from(document.querySelectorAll("#mtabs button[data-pane]")).map((b) => ({ pane: b.dataset.pane, label: b.textContent, on: b.classList.contains("on"), shown: vis(b) }));
+  return { body: document.body.className, tab: document.body.getAttribute("data-tab"), mobile: !!(window.__rompMobileOn && window.__rompMobileOn()),
+           panes, rail, tabs, panesStored: localStorage.getItem("romp-panes") };
+});
+const results = {};
+let page;
+for (const pass of cfg.passes) {
+  page = await browser.newPage({ viewport: { width: pass.width, height: pass.height }, deviceScaleFactor: 2, hasTouch: !!pass.touch });
+  if (pass.storage) await page.addInitScript((st) => { for (const k in st) localStorage.setItem(k, st[k]); }, pass.storage);
+  await page.goto(cfg.shell);
+  await page.waitForSelector("#f-chat", { timeout: 20000 });
+  await page.waitForTimeout(1500);   // the panes' boots
+  const before = await measure();
+  if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_shell-files-" + pass.name + "-before.png", fullPage: false }); }
+  let after = null;
+  if (pass.hidden) {
+    // the control hidden by the gear's setting: nothing to click; the palette's command and a relay are refused
+    await page.evaluate(() => { window.__rompPaneToggle && window.__rompPaneToggle("files", true); });
+    await page.waitForTimeout(600);
+    after = await measure();
+  } else {
+    // the click the user makes: the rail's Files toggle on desktop, the bottom bar's Files tab on a phone
+    const sel = pass.mobile ? "#mtabs button[data-pane=files]" : ".rail-btn[data-pane=files]";
+    const target = await page.$(sel);
+    if (!target) { console.error("no Files control for " + sel + ": " + JSON.stringify(before)); process.exit(1); }
+    await target.click();
+    await page.waitForTimeout(1200);
+    after = await measure();
+  }
+  if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_shell-files-" + pass.name + "-after.png", fullPage: false });
+  results[pass.name] = { before, after };
+  await page.close();
+}
+fs.writeSync(1, "RESULT:" + JSON.stringify(results) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedFilesPaneToggle(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="files-pane-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)   # tests/dist_copy: skips the bundler's staging files
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cwd, "README.md").write_text("# notes-api\n\nA demo project for the Files pane.\n")
+        Path(state, "names", WEB).write_text("web\t%s\t#9cd2ff\t#0c1a2e\n" % cwd)
+        Path(state, "sdk", WEB + ".json").write_text(json.dumps(
+            {"sid": WEB, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": WEB, "alive": True,
+             "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        t0 = int(time.time()) - 600
+        recs = [{"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": WEB,
+                 "message": {"role": "user", "content": "how should the notes-api retry loop back off?"}},
+                {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": WEB,
+                 "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                             "content": [{"type": "text", "text": "Use exponential backoff with a jitter of ten percent."}]}}]
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.port, cls.token = _free_port(), "testtok-files"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"shell": "http://127.0.0.1:%d/?token=%s" % (self.port, self.token),
+                       "passes": [{"name": "desktop", "width": 1400, "height": 900, "mobile": False},
+                                  {"name": "phone", "width": 390, "height": 844, "mobile": True, "touch": True},
+                                  # the control hidden by the gear's setting, with the pane left OPEN by an earlier session
+                                  {"name": "desktop-hidden", "width": 1400, "height": 900, "mobile": False, "hidden": True,
+                                   "storage": {"romp:settings": json.dumps({"filesControl": False}),
+                                               "romp-panes": json.dumps({"chat": True, "fleet": False, "feed": True, "timeline": True, "files": True})}},
+                                  {"name": "phone-hidden", "width": 390, "height": 844, "mobile": True, "touch": True, "hidden": True,
+                                   "storage": {"romp:settings": json.dumps({"filesControl": False}), "romp-mobile-tab": "files"}}],
+                       "shots": os.environ.get("FILES_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    def test_the_files_control_opens_the_files_pane(self):
+        r = self._drive()
+        if os.environ.get("FILES_SHOTS"):
+            print("\nRESULT:" + json.dumps(r, indent=1)[:6000])
+        d = r["desktop"]
+        after = d["after"]
+        self.assertIn("po-files", after["body"].split(), "the Files toggle turns the Files pane on: %r" % after["body"])
+        fp = after["panes"]["files-pane"]
+        self.assertIsNotNone(fp, "the shell has a Files pane")
+        self.assertNotEqual(fp["display"], "none", "the Files pane shows: %r" % fp)
+        self.assertGreater(fp["w"], 200, "the Files pane has a real width: %r" % fp)
+        self.assertEqual(fp["iframe"]["src"], "/files", "the Files pane holds the Files page: %r" % fp)
+        # the timeline band stays exactly as it was: the Files toggle never touches it
+        self.assertEqual(after["panes"]["tl-pane"]["display"], d["before"]["panes"]["tl-pane"]["display"], "the Files toggle leaves the timeline as it was")
+        self.assertEqual("po-timeline" in after["body"].split(), "po-timeline" in d["before"]["body"].split())
+        # the control shown (the default): both layouts offer it
+        self.assertTrue(next(b for b in after["rail"] if b["pane"] == "files")["shown"], "the rail's Files toggle shows by default: %r" % after["rail"])
+        self.assertTrue(next(b for b in r["phone"]["after"]["tabs"] if b["pane"] == "files")["shown"], "the phone's Files tab shows by default")
+        # the control HIDDEN by the gear's setting (T317): the toggle and the tab are gone in both layouts, the pane an
+        # earlier session left open is closed, a bring-forward is refused, and a phone left on the Files tab shows the chat
+        h = r["desktop-hidden"]
+        for k in ("before", "after"):
+            self.assertFalse(next(b for b in h[k]["rail"] if b["pane"] == "files")["shown"], "the rail's Files toggle is hidden: %r" % h[k]["rail"])
+            self.assertNotIn("po-files", h[k]["body"].split(), "the pane left open closes: %r" % h[k]["body"])
+            self.assertEqual(h[k]["panes"]["files-pane"]["display"], "none")
+            self.assertIn("no-files-control", h[k]["body"].split())
+        self.assertEqual(json.loads(h["before"]["panesStored"])["files"], False, "the close is saved")
+        self.assertEqual(len([b for b in h["after"]["rail"] if b["shown"]]), 4, "the four other toggles still show: %r" % h["after"]["rail"])
+        ph = r["phone-hidden"]["after"]
+        self.assertTrue(ph["mobile"])
+        self.assertFalse(next(b for b in ph["tabs"] if b["pane"] == "files")["shown"], "the phone's Files tab is hidden: %r" % ph["tabs"])
+        self.assertEqual(ph["tab"], "chat", "a stored Files tab falls to the chat: %r" % ph["tab"])
+        self.assertTrue(ph["panes"]["chat-pane"]["iframe"]["mOn"] and not ph["panes"]["files-pane"]["iframe"]["mOn"])
+        m = r["phone"]["after"]
+        self.assertTrue(m["mobile"], "the phone pass is the one-pane layout: %r" % m)
+        self.assertEqual(m["tab"], "files", "the Files tab is the one showing: %r" % m)
+        self.assertTrue(m["panes"]["files-pane"]["iframe"]["mOn"], "the Files iframe is the one on: %r" % m["panes"])
+        self.assertFalse(m["panes"]["tl-pane"]["iframe"]["mOn"], "the timeline is not: %r" % m["panes"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pane_state_broadcast.py
+++ b/tests/test_pane_state_broadcast.py
@@ -104,6 +104,67 @@ console.log(JSON.stringify(out));
 """
 
 
+# ── the Files control hidden by its gear setting (T317) ─────────────────────────────────────────────────
+# The store holds romp:settings.filesControl false and the Files pane is ON (a desktop session left it open):
+# the boot apply hides the control (body.no-files-control), closes the pane and saves that, tells the panes the
+# pane is unavailable (avail.files false), and refuses to bring it forward; a phone left on the Files tab is
+# switched to the chat. Flipping the store back on (the gear's write, heard through the storage listener) shows
+# the control again and the pane can open.
+_HIDDEN_DRIVER = r"""
+const last = (k) => (POSTED[k] || []).slice(-1)[0];
+const out = {};
+out.boot = { cls: CLS.has('no-files-control'), poFiles: CLS.has('po-files'), store: JSON.parse(STORE['romp-panes'] || 'null'), chat: last('chat') };
+window.__rompPaneToggle('files', true);          // a relay's bring-forward, the palette's command: refused
+out.refused = { poFiles: CLS.has('po-files'), chat: last('chat') };
+MOBILE = true; TAB = 'files'; SWITCHED.length = 0; window.__rompPaneToggle('feed');   // any apply (here a feed flip) on a phone left on the Files tab
+out.phone = { switched: SWITCHED.slice() };
+MOBILE = false;
+STORE['romp:settings'] = JSON.stringify({ filesControl: true }); STORAGE_LISTENERS.forEach((f) => f());   // the gear turns it back on
+out.shown = { cls: CLS.has('no-files-control'), chat: last('chat') };
+window.__rompPaneToggle('files', true);
+out.reopened = { poFiles: CLS.has('po-files'), chat: last('chat') };
+console.log(JSON.stringify(out));
+"""
+
+
+class HiddenControl(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        keys = [k for k, _ in km._PANE_ORDER]
+        harness = (_COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(keys))
+                   .replace("const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {};",
+                            "const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {"
+                            "'romp:settings': JSON.stringify({ filesControl: false }), 'romp-panes': JSON.stringify({ chat: true, fleet: false, feed: true, timeline: true, files: true }) };"
+                            "const STORAGE_LISTENERS = [], SWITCHED = [];")
+                   .replace("global.addEventListener = () => {};", "global.addEventListener = (ev, f) => { if (ev === 'storage') STORAGE_LISTENERS.push(f); };")
+                   + "window.__rompMobileTab = (p) => { SWITCHED.push(p); TAB = p; };\n")
+        cls.out = _run(harness + km._LANDING_COLLAPSE_JS + _HIDDEN_DRIVER)
+
+    def test_the_boot_apply_hides_the_control_and_closes_the_open_pane(self):
+        b = self.out["boot"]
+        self.assertTrue(b["cls"], "body.no-files-control: the rail's toggle and the phone's tab are hidden by CSS")
+        self.assertFalse(b["poFiles"], "the pane a desktop session left open closes on the same apply")
+        self.assertEqual(b["store"]["files"], False, "…and the close is saved, so a reload stays closed")
+        self.assertEqual(b["chat"]["avail"], {"files": False}, "the panes are told the pane is unavailable: file links open over the pane clicked")
+        self.assertEqual(b["chat"]["on"]["files"], False)
+
+    def test_the_pane_cannot_be_brought_forward_while_the_control_is_hidden(self):
+        r = self.out["refused"]
+        self.assertFalse(r["poFiles"], "a relay's bring-forward or the palette's command is refused")
+        self.assertEqual(r["chat"]["avail"], {"files": False})
+
+    def test_a_phone_left_on_the_files_tab_is_switched_to_the_chat(self):
+        self.assertEqual(self.out["phone"]["switched"], ["chat"])
+
+    def test_the_gears_write_shows_the_control_again_and_the_pane_can_open(self):
+        s = self.out["shown"]
+        self.assertFalse(s["cls"], "the storage event re-applies: the control shows")
+        self.assertEqual(s["chat"]["avail"], {"files": True})
+        r = self.out["reopened"]
+        self.assertTrue(r["poFiles"], "and the pane opens again")
+        self.assertEqual(r["chat"]["on"]["files"], True)
+
+
 class Broadcast(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -112,7 +173,8 @@ class Broadcast(unittest.TestCase):
 
     def test_the_boot_apply_tells_every_pane_the_set_as_the_flags_stand(self):
         self.assertEqual(self.out["boot"]["counts"], {k: 1 for k in self.keys}, "one message per pane at boot")
-        self.assertEqual(self.out["boot"]["chat"], {"romp": "panes", "on": {"chat": True, "timeline": True, "fleet": False, "feed": True, "files": False}})
+        self.assertEqual(self.out["boot"]["chat"], {"romp": "panes", "on": {"chat": True, "timeline": True, "fleet": False, "feed": True, "files": False},
+                                                     "avail": {"files": True}})   # avail: the Files control's setting rides every tell (T317)
         self.assertEqual(self.out["boot"]["files"], self.out["boot"]["chat"], "every pane hears the same set")
 
     def test_a_toggle_is_the_event_and_a_no_change_toggle_is_silent(self):

--- a/tests/test_pane_state_broadcast.py
+++ b/tests/test_pane_state_broadcast.py
@@ -112,10 +112,11 @@ console.log(JSON.stringify(out));
 # the control again and the pane can open.
 _HIDDEN_DRIVER = r"""
 const last = (k) => (POSTED[k] || []).slice(-1)[0];
+const counts = () => Object.fromEntries(KEYS.map((k) => [k, (POSTED[k] || []).length]));
 const out = {};
-out.boot = { cls: CLS.has('no-files-control'), poFiles: CLS.has('po-files'), store: JSON.parse(STORE['romp-panes'] || 'null'), chat: last('chat') };
+out.boot = { cls: CLS.has('no-files-control'), poFiles: CLS.has('po-files'), store: JSON.parse(STORE['romp-panes'] || 'null'), chat: last('chat'), counts: counts() };
 window.__rompPaneToggle('files', true);          // a relay's bring-forward, the palette's command: refused
-out.refused = { poFiles: CLS.has('po-files'), chat: last('chat') };
+out.refused = { poFiles: CLS.has('po-files'), chat: last('chat'), counts: counts() };
 MOBILE = true; TAB = 'files'; SWITCHED.length = 0; window.__rompPaneToggle('feed');   // any apply (here a feed flip) on a phone left on the Files tab
 out.phone = { switched: SWITCHED.slice() };
 MOBILE = false;
@@ -125,6 +126,38 @@ window.__rompPaneToggle('files', true);
 out.reopened = { poFiles: CLS.has('po-files'), chat: last('chat') };
 console.log(JSON.stringify(out));
 """
+
+
+_BOOKMARK_DRIVER = r"""
+const out = { poFiles: CLS.has('po-files'), cls: CLS.has('no-files-control'), store: STORE['romp-panes'], chat: (POSTED.chat || []).slice(-1)[0] };
+console.log(JSON.stringify(out));
+"""
+
+
+class HiddenControlBookmark(unittest.TestCase):
+    """A ?panes=chat,files bookmark opened with the control hidden: the view shows the chat alone (the pane is closed
+    on the boot apply), but the stored pane set is NOT rewritten with the bookmark's — a bookmark was always a view,
+    never a write (review find: the forced close's save would have replaced the person's stored set)."""
+
+    @classmethod
+    def setUpClass(cls):
+        keys = [k for k, _ in km._PANE_ORDER]
+        stored = json.dumps({"chat": True, "fleet": False, "feed": True, "timeline": True, "files": False})
+        harness = (_COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(keys))
+                   .replace("const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {};",
+                            "const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {"
+                            "'romp:settings': JSON.stringify({ filesControl: false }), 'romp-panes': " + json.dumps(stored) + " };")
+                   .replace("global.location = { search: '' };", "global.location = { search: '?panes=chat,files' };")
+                   .replace("global.URLSearchParams = class { get() { return null; } };", "global.URLSearchParams = class { get(k) { return k === 'panes' ? 'chat,files' : null; } };"))
+        cls.stored = stored
+        cls.out = _run(harness + km._LANDING_COLLAPSE_JS + _BOOKMARK_DRIVER)
+
+    def test_the_bookmark_shows_the_chat_alone_and_writes_nothing(self):
+        self.assertFalse(self.out["poFiles"], "the bookmark's files pane is closed: the control is hidden")
+        self.assertTrue(self.out["cls"])
+        self.assertEqual(self.out["store"], self.stored, "the stored pane set is untouched: a bookmark is a view")
+        self.assertEqual(self.out["chat"]["on"], {"chat": True, "timeline": False, "fleet": False, "feed": False, "files": False})
+        self.assertEqual(self.out["chat"]["avail"], {"files": False})
 
 
 class HiddenControl(unittest.TestCase):
@@ -151,7 +184,8 @@ class HiddenControl(unittest.TestCase):
     def test_the_pane_cannot_be_brought_forward_while_the_control_is_hidden(self):
         r = self.out["refused"]
         self.assertFalse(r["poFiles"], "a relay's bring-forward or the palette's command is refused")
-        self.assertEqual(r["chat"]["avail"], {"files": False})
+        self.assertEqual(r["counts"], self.out["boot"]["counts"], "…silently: no message claiming a change")
+        self.assertEqual(self.out["boot"]["counts"], {k: 1 for k in [k for k, _ in km._PANE_ORDER]}, "the boot apply told each pane once")
 
     def test_a_phone_left_on_the_files_tab_is_switched_to_the_chat(self):
         self.assertEqual(self.out["phone"]["switched"], ["chat"])

--- a/ui/webview/browse-route.test.ts
+++ b/ui/webview/browse-route.test.ts
@@ -102,6 +102,7 @@ function liftChat(over: Partial<ChatHooks> = {}): { H: ChatHooks; api: ChatApi }
     window.parent = H.framed ? { postMessage: (m, origin) => { H.up.push([m, origin]); } } : window;
     const settings = H.settings;
     let panesOn = H.panes;
+    let panesAvail = H.avail || {};   // the Files control's setting as the shell last told it (T317); absent = available
     let activeId = H.activeId;
     const sessions = new Map([[${JSON.stringify(SID)}, { id: ${JSON.stringify(SID)}, name: "web", color: ${JSON.stringify(COLOR)} }]]);
     const tabMeta = new Map([[${JSON.stringify(SID_TAB)}, { name: "api", color: null }]]);
@@ -109,7 +110,7 @@ function liftChat(over: Partial<ChatHooks> = {}): { H: ChatHooks; api: ChatApi }
     const openFileBrowse = (p, sid) => { H.here.push([p, sid]); };
     const initFileBrowse = (poster, host) => { H.poster = poster; H.host = host; };
   `;
-  const epilogue = "return { openBrowse, browseRouteNow, setPanes: (on) => { panesOn = on; } };";
+  const epilogue = "return { openBrowse, browseRouteNow, setPanes: (on) => { panesOn = on; }, setAvail: (a) => { panesAvail = a; } };";
   const api = (new Function("HOOKS", "browseRoute", prelude + code + epilogue) as (h: ChatHooks, r: typeof browseRoute) => ChatApi)(H, browseRoute);
   return { H, api };
 }

--- a/ui/webview/commands.ts
+++ b/ui/webview/commands.ts
@@ -10,6 +10,7 @@ export type PaletteCommand = {
                     // actually answers to is effectiveChord(), and the palette's hotkey chip shows
                     // that, so a rebound command never advertises a stale default (the user 2026-08-09).
   hidden?: boolean; // bindable but not listed in the palette (palette.toggle: running "toggle the
+  when?: () => boolean;   // listed only while true, re-read at every open (a pane whose control the gear hid; T317)
                     // palette" FROM the palette would just blink it)
   run: () => void;
 };

--- a/ui/webview/file-route.test.ts
+++ b/ui/webview/file-route.test.ts
@@ -7,7 +7,7 @@
 // modal over the pane that was clicked, the default and the only route where no shell exists.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { fileLinkRoute } from "./file-route";
+import { fileLinkRoute, browseRoute } from "./file-route";
 
 const SETTINGS = ["chat", "pane", undefined, null, "purple", 42];   // the gear's two values, an unset store, foreign values
 
@@ -28,6 +28,20 @@ test("fileLinkRoute: Files pane CLOSED, the setting decides; only the literal 'p
   assert.equal(fileLinkRoute(null, true, false), "here");
   assert.equal(fileLinkRoute("purple", true, false), "here", "a foreign stored value falls to the default");
   assert.equal(fileLinkRoute(42, true, false), "here");
+});
+
+// The Files CONTROL hidden by its gear setting (T317): there is no pane to bring forward, so the "pane" setting
+// reads as the default and the click opens here — the closed-pane road. An OPEN pane still takes the click (the
+// shell closes the pane when the control goes, so the two cannot disagree for long); no shell still means here.
+test("fileLinkRoute: the Files control hidden, the pane setting falls back to the pane you clicked", () => {
+  assert.equal(fileLinkRoute("pane", true, false, false), "here", "no control, no pane to open: over the pane clicked");
+  assert.equal(fileLinkRoute("chat", true, false, false), "here");
+  assert.equal(fileLinkRoute("pane", true, false, true), "pane", "the control shown: the setting still opts in");
+  assert.equal(fileLinkRoute("pane", true, false), "pane", "the argument defaults to shown (a shell that never said)");
+  assert.equal(fileLinkRoute("pane", true, true, false), "pane", "an OPEN pane takes the click whatever else is said");
+  assert.equal(fileLinkRoute("pane", false, false, false), "here");
+  assert.equal(browseRoute(true, "pane", true, false, false), "here", "a folder walks the same ladder");
+  assert.equal(browseRoute(false, "pane", true, false, false), "editor", "VS Code keeps the editor's opener");
 });
 
 test("fileLinkRoute names only the two targets this chat can open", () => {

--- a/ui/webview/file-route.ts
+++ b/ui/webview/file-route.ts
@@ -7,6 +7,9 @@
 //              other pane, so everything opens in place there.
 //   filesOpen  the shell's Files-pane bit (render.ts panesOn.files, cached from the shell's own broadcast):
 //              the pane is ON SCREEN, a desktop column toggled on or the tab showing on a phone.
+//   filesAvail the shell's word that the Files control exists (render.ts panesAvail.files, the same broadcast):
+//              the gear's "Files control in the dashboard bar" is on (the default). Off, there is no pane to
+//              bring forward, so a click that would have gone there opens here (T317).
 // A verdict names the TARGET: "pane" is the Files pane (the shell brings a closed one forward; the click is
 // the gesture), "here" is this document, the viewer or the file browser as a modal over the pane that was
 // clicked, and "editor" (a folder in VS Code) is the host editor's own opener.
@@ -17,9 +20,10 @@ export type BrowseRoute = FileRoute | "editor";
 /** A FILE link. An OPEN Files pane takes the click whatever the setting says: the pane being open IS the
  *  intent, and a file that opened as a modal over the chat while the pane sat there empty was the bug.
  *  Closed, the setting decides; "here" is the default. */
-export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean): FileRoute {
+export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean, filesAvail: boolean = true): FileRoute {
   if (!framed) return "here";
   if (filesOpen) return "pane";
+  if (!filesAvail) return "here";   // the Files control is hidden by its setting (T317): no pane to bring forward, so the pane clicked
   return pane === "pane" ? "pane" : "here";
 }
 
@@ -28,7 +32,7 @@ export function fileLinkRoute(pane: unknown, framed: boolean, filesOpen: boolean
  *  file link: an open Files pane takes the listing, a closed one only when the setting names it, and
  *  otherwise the browser opens over the chat as it always has. Web only: in VS Code the folder link keeps
  *  the editor's own opener (asFolderLink's openFolder act), so the ladder is never asked. */
-export function browseRoute(web: boolean, pane: unknown, framed: boolean, filesOpen: boolean): BrowseRoute {
+export function browseRoute(web: boolean, pane: unknown, framed: boolean, filesOpen: boolean, filesAvail: boolean = true): BrowseRoute {
   if (!web) return "editor";
-  return fileLinkRoute(pane, framed, filesOpen);
+  return fileLinkRoute(pane, framed, filesOpen, filesAvail);
 }

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -24,7 +24,8 @@ test("openPath routes by HOST: the in-pane viewer modal on the web (or the Files
   assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null\): void/);   // ev: the click, for a PDF's modified-click tab
   // web → the ladder decides at the click (file-route.ts fileLinkRoute, its table in file-route.test.ts): "here" opens
   // the viewer in THIS document through the gesture reader; "pane" hands a plain click to the shell for the Files pane
-  assert.match(RENDER, /const route = fileLinkRoute\(settings\.fileLinkPane, window\.parent !== window, panesOn\.files === true\);/);
+  assert.match(RENDER, /const route = fileLinkRoute\(settings\.fileLinkPane, window\.parent !== window, panesOn\.files === true, panesAvail\.files !== false\);/,
+    "…and whether the Files control exists at all (its gear setting, T317): hidden, the pane road falls back to here");
   assert.match(RENDER, /openFileClick\(ev, path, to, route === "pane" \? \(\) => \{/);   // via the gesture reader: a plain click is openFileView or the relay (pdf-new-tab.test.ts)
   assert.match(RENDER, /import \{ openFileClick \} from "\.\/file-view";/);   // the gesture reader is the chat's only way in; openFileView is not imported
   assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "viewFile", path, sid: to, pane: "pane",\n\s*identity: s && s\.name \? \{ name: s\.name, color: s\.color \?\? null \} : null \}, "\*"\);/);

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -139,6 +139,14 @@ var GEAR_HTML =
   '<option value=chat>The pane you clicked</option><option value=pane>The Files pane</option>' +
   '</select>' +
   '</span></div>' +
+  // the Files control itself (T317, the user 2026-09-10, who recalled a setting for it): the toggle at the bottom of
+  // the dashboard and the Files tab on a phone. Shown by default (today's behaviour). Off hides both, closes an open
+  // Files pane, and a file link set to open in the Files pane opens over the pane you clicked instead (the shell
+  // reads this store key and tells the panes: kernel.py _LANDING_COLLAPSE_JS, render.ts panesAvail).
+  '<label class=rs-row><input type=checkbox id=rs-filesctl checked>' +
+  '<span><b>Files control in the dashboard bar</b>' +
+  '<span class=rs-sub>The Files toggle at the bottom of the dashboard, and the Files tab on a phone. Off hides them and closes the Files pane if it is open; file links set to open in the Files pane then open over the pane you clicked.</span>' +
+  '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>Text scheme</b>" +
   "<span class=rs-sub>Chat text colors only. Each option previews its own tiers — prose, the dimmer tool text, code. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
   "<div id=rs-chatscheme style='position:relative;margin-top:5px'></div>" +
@@ -263,7 +271,7 @@ function initGear(post) {
     cvm = document.getElementById('rs-conserve'),
     csg = document.getElementById('rs-suggestcompact'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
-    tc = document.getElementById('rs-tabctx'), fl = document.getElementById('rs-filelink'),
+    tc = document.getElementById('rs-tabctx'), fl = document.getElementById('rs-filelink'), fc = document.getElementById('rs-filesctl'),
     sr = document.getElementById('rs-striprows'),
     dn = document.getElementById('rs-dense'),
     cs = document.getElementById('rs-chatscheme'),
@@ -282,7 +290,7 @@ function initGear(post) {
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', fileLinkPane: 'chat', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', fileLinkPane: 'chat', stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
+  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', fileLinkPane: 'chat', filesControl: true, stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, tabCtx: 'over50', fileLinkPane: 'chat', filesControl: true, stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -307,6 +315,7 @@ function initGear(post) {
   if (dn) dn.addEventListener('change', function () { var s = load(); s.denseChrome = dn.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
   if (fl) fl.addEventListener('change', function () { var s = load(); s.fileLinkPane = fl.value; save(s); });   // webview-local pref read at click time (render.ts openPath)
+  if (fc) fc.addEventListener('change', function () { var s = load(); s.filesControl = fc.checked; save(s); });   // the shell hears the store change (its storage listener) and hides or shows the control (T317)
   // ── the settings' value-picker DROPDOWNS (T117, the user 2026-08-27, screenshot: the Chat
   // tabs and Text scheme pickers rendered every option always-expanded, and the description spans
   // ran off the card's right edge). Progressive disclosure: the CLOSED state is ONE row — the
@@ -1278,7 +1287,7 @@ function initGear(post) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fc) fc.checked = (s.filesControl !== false); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -271,7 +271,7 @@ function initGear(post) {
     cvm = document.getElementById('rs-conserve'),
     csg = document.getElementById('rs-suggestcompact'),
     dd = document.getElementById('rs-defaultdir'), gb = document.getElementById('rs-branch'),
-    tc = document.getElementById('rs-tabctx'), fl = document.getElementById('rs-filelink'), fc = document.getElementById('rs-filesctl'),
+    tc = document.getElementById('rs-tabctx'), fl = document.getElementById('rs-filelink'), fsc = document.getElementById('rs-filesctl'),
     sr = document.getElementById('rs-striprows'),
     dn = document.getElementById('rs-dense'),
     cs = document.getElementById('rs-chatscheme'),
@@ -315,7 +315,7 @@ function initGear(post) {
   if (dn) dn.addEventListener('change', function () { var s = load(); s.denseChrome = dn.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
   if (fl) fl.addEventListener('change', function () { var s = load(); s.fileLinkPane = fl.value; save(s); });   // webview-local pref read at click time (render.ts openPath)
-  if (fc) fc.addEventListener('change', function () { var s = load(); s.filesControl = fc.checked; save(s); });   // the shell hears the store change (its storage listener) and hides or shows the control (T317)
+  if (fsc) fsc.addEventListener('change', function () { var s = load(); s.filesControl = fsc.checked; save(s); });   // the shell hears the store change (its storage listener) and hides or shows the control (T317)
   // ── the settings' value-picker DROPDOWNS (T117, the user 2026-08-27, screenshot: the Chat
   // tabs and Text scheme pickers rendered every option always-expanded, and the description spans
   // ran off the card's right edge). Progressive disclosure: the CLOSED state is ONE row — the
@@ -1287,7 +1287,7 @@ function initGear(post) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fc) fc.checked = (s.filesControl !== false); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.filesControl !== false); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/palette-main.ts
+++ b/ui/webview/palette-main.ts
@@ -141,6 +141,9 @@ installMenuEcho();
     registerCommand({
       id: "pane." + label, title: "Show or hide the " + label + " pane",
       run: () => { if (w.__rompPaneToggle) w.__rompPaneToggle(key); },
+      // the Files control hidden by its gear setting (T317): the shell's body wears no-files-control, the toggle refuses,
+      // so the entry is not listed either (re-read at every open: the gear's change reaches the body class live)
+      when: key === "files" ? () => !document.body.classList.contains("no-files-control") : undefined,
     });
   }
 

--- a/ui/webview/palette.test.ts
+++ b/ui/webview/palette.test.ts
@@ -77,7 +77,7 @@ test("the defaults hold — Mod+O jump, Mod+Shift+O picker, Mod+P palette — th
   assert.match(MAIN, /window\.addEventListener\("storage", invalidate\);/);
   // …and the palette chips show the EFFECTIVE binding, never a stale default
   assert.match(MAIN, /kbdFor: \(c\) => \{ const ch = effectiveChord\(c\.id, c\.chord, loadOverrides\(\), mac\); return ch \? displayChord\(ch, mac\) : undefined; \}/);
-  assert.match(PALETTE, /commandList\(\)\.filter\(\(c\) => !c\.hidden\)/);
+  assert.match(PALETTE, /commandList\(\)\.filter\(\(c\) => !c\.hidden && \(!c\.when \|\| c\.when\(\)\)\)/);
 });
 
 test("key wiring mirrors the Alt+Arrow pane nav: capture on the shell doc AND every pane doc, re-wired on load", () => {
@@ -202,4 +202,13 @@ test("the gear links the shortcuts dialog instead of carrying its own stale list
   assert.match(GEAR, /\{ romp: 'openKeys' \}/);
   assert.doesNotMatch(GEAR, /quick switcher/);
   assert.doesNotMatch(GEAR, /<kbd>⌘\/Ctrl<\/kbd>/);
+});
+
+// The Files control hidden by its gear setting (T317): the shell's body wears no-files-control and __rompPaneToggle
+// refuses 'files', so the palette's "Show or hide the files pane" entry is not listed either — a `when` predicate on
+// the command, re-read at every open (the gear's change in the feed iframe reaches the body class through the
+// shell's storage listener), so the list never offers a visible no-op.
+test("the Files pane command is listed only while its control shows: a `when` predicate the list re-reads at every open", () => {
+  assert.match(MAIN, /when: key === "files" \? \(\) => !document\.body\.classList\.contains\("no-files-control"\) : undefined,/);
+  assert.match(PALETTE, /filter\(\(c\) => !c\.hidden && \(!c\.when \|\| c\.when\(\)\)\)/, "the list filters on it beside `hidden`");
 });

--- a/ui/webview/palette.ts
+++ b/ui/webview/palette.ts
@@ -239,7 +239,7 @@ export function initPalette(opts?: { onClose?: () => void; kbdFor?: (c: PaletteC
     openPick({
       placeholder: "Type a command…",
       // hidden commands are bindable but not listed (palette.toggle from the palette just blinks it)
-      items: commandList().filter((c) => !c.hidden)
+      items: commandList().filter((c) => !c.hidden && (!c.when || c.when()))
         .map((c) => ({ title: c.title, kbd: opts && opts.kbdFor ? opts.kbdFor(c) : undefined, run: c.run })),
     });
   }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1425,11 +1425,12 @@ document.addEventListener("click", (e) => {
 // own event, never a per-click guess (no reading the parent's DOM, no polling). Standalone /chat never
 // hears one and reads as all-off, which the framed gate makes moot anyway.
 let panesOn: Record<string, boolean> = {};
+let panesAvail: Record<string, boolean> = {};   // …and which panes EXIST to bring forward (avail: the Files control's setting, T317); absent = available
 function openPath(path: string, sid?: string | null, ev?: MouseEvent | null): void {
   if (!vscodeApi) return;
   if (location.protocol === "http:" || location.protocol === "https:") {
     const to = sid || activeId || null;
-    const route = fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true);
+    const route = fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false);
     // with its gesture, read first: a Cmd/Ctrl- or middle-click on a PDF takes the browser's own tab wherever
     // the plain click would have landed; a plain click routed to the Files pane is handed to the shell
     openFileClick(ev, path, to, route === "pane" ? () => {
@@ -1462,7 +1463,7 @@ function onMiddleClick(a: HTMLElement, fn: (e: MouseEvent) => void): void {
 // tells the person where Browse files will land, so the two cannot disagree.
 function browseRouteNow(): BrowseRoute {
   const web = location.protocol === "http:" || location.protocol === "https:";
-  return browseRoute(web, settings.fileLinkPane, window.parent !== window, panesOn.files === true);
+  return browseRoute(web, settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false);
 }
 // Surface the FILE BROWSER at `path` for the session: the folder shown under the chat, the system context
 // card's Directory row, a tab menu's Browse files, a chat-hosted viewer's directory link. The listing goes
@@ -16008,6 +16009,10 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
       for (const k of Object.keys(m.on)) on[k] = m.on[k] === true;
       panesOn = on;
     }
+    // which panes exist to bring forward (the Files control's setting): whole-set replace as well
+    const avail: Record<string, boolean> = {};
+    if (m.avail && typeof m.avail === "object") for (const k of Object.keys(m.avail)) avail[k] = m.avail[k] !== false;
+    panesAvail = avail;
     return;
   }
   // the pipe's down edge is the VS Code twin of the shim's romp:wsdown: unconfirmed sends say so (markPendingLost)

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -125,6 +125,8 @@ test("File links open in defaults to the pane you clicked; the Files pane opt-in
   assert.equal(loadSettings().fileLinkPane, "chat", "a foreign stored value normalizes to the default");
   assert.equal(fileLinkPane("pane"), "pane");
   assert.equal(fileLinkPane("feed"), "chat", "no other target exists here");
+  assert.equal(fileLinkPane(undefined), "chat");
+  delete store["romp:settings"];
 });
 
 // The Files CONTROL's own setting (T317, the user 2026-09-10): whether the dashboard bar's Files toggle and the
@@ -142,6 +144,5 @@ test("the Files control shows by default; hiding it round-trips, and only the li
   assert.equal(loadSettings().filesControl, true, "a store written before the key shows the control");
   store["romp:settings"] = JSON.stringify({ filesControl: "no" });
   assert.equal(loadSettings().filesControl, true, "a foreign stored value shows it: only false hides");
-  assert.equal(fileLinkPane(undefined), "chat");
   delete store["romp:settings"];
 });

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -125,6 +125,23 @@ test("File links open in defaults to the pane you clicked; the Files pane opt-in
   assert.equal(loadSettings().fileLinkPane, "chat", "a foreign stored value normalizes to the default");
   assert.equal(fileLinkPane("pane"), "pane");
   assert.equal(fileLinkPane("feed"), "chat", "no other target exists here");
+});
+
+// The Files CONTROL's own setting (T317, the user 2026-09-10): whether the dashboard bar's Files toggle and the
+// phone's Files tab show at all. Shown by default (today's behaviour); only the literal false hides them, so a
+// corrupt entry may cost the preference, never the control. The shell reads the store key itself
+// (kernel.py _LANDING_COLLAPSE_JS filesCtl), so the key and the false-only rule are the contract.
+test("the Files control shows by default; hiding it round-trips, and only the literal false hides it", () => {
+  assert.equal(DEFAULT_SETTINGS.filesControl, true);
+  delete store["romp:settings"];
+  assert.equal(loadSettings().filesControl, true, "a fresh install shows the control");
+  saveSettings({ filesControl: false });
+  assert.equal(loadSettings().filesControl, false, "hiding it survives a reload (localStorage)");
+  assert.equal(JSON.parse(store["romp:settings"]).filesControl, false, "the key the shell reads, the literal false");
+  store["romp:settings"] = JSON.stringify({ compact: true });
+  assert.equal(loadSettings().filesControl, true, "a store written before the key shows the control");
+  store["romp:settings"] = JSON.stringify({ filesControl: "no" });
+  assert.equal(loadSettings().filesControl, true, "a foreign stored value shows it: only false hides");
   assert.equal(fileLinkPane(undefined), "chat");
   delete store["romp:settings"];
 });

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -19,6 +19,7 @@ export interface RompSettings {
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
   fileLinkPane: FileLinkPane;   // where a chat file-link click opens on the WEB while the Files pane is CLOSED: "chat" (the default: the viewer over the pane you clicked) or "pane" (the Files pane, a column of its own that comes forward and stays up). An OPEN Files pane takes the click whatever this says (file-route.ts). Read at click time (render.ts openPath, and openBrowse for a folder click, which walks the same ladder); VS Code (the host editor) and standalone /chat (no shell to relay to) are unaffected.
   stripGroupRows: boolean;   // chat tabs, grouped by tag: start EVERY tag group on its own row (T264, the row breaks in render.ts). ON by default; off, the groups follow one another across the strip and wrap as they need, the untagged trail behind its divider. Per browser profile, like every setting here. Read by renderTabs and part of the strip's rebuild signature, so a gear flip repaints at once.
+  filesControl: boolean;   // the Files control (the dashboard bar's toggle, the phone's tab) shows; off hides it and closes the pane (T317)
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
   chatTabTheme: ChatTabTheme;   // LEGACY, derived (2026-08-28): the chat TAB STRIP's appearance (T113). Now computed from `theme` on every load/save ("classic" -> classic strip, anything else -> the yatharth strip) so older panes/extension builds keep working; never set it directly.
   theme: Theme;   // the OVERALL dashboard theme (the user 2026-08-27, promoting the tab-strip setting): "classic" = the pre-720 dark look; "yatharth" = dark + the contributed strip aesthetic (what chatTabTheme:"yatharth" was); "yatharth-light" = the warm light theme (body.theme-light + the yatharth strip). Migration: a store written before `theme` existed seeds it from chatTabTheme.
@@ -60,7 +61,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", fileLinkPane: "chat", stripGroupRows: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, tabCtx: "over50", fileLinkPane: "chat", stripGroupRows: true, filesControl: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {
@@ -71,6 +72,7 @@ export function loadSettings(): RompSettings {
       const s = { ...DEFAULT_SETTINGS, ...parsed };
       s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
       s.fileLinkPane = fileLinkPane(s.fileLinkPane);   // only "pane" opts in; anything else reads as the default
+      s.filesControl = s.filesControl !== false;   // only the literal false hides the control; anything else shows it (the default)
       s.chatScheme = chatScheme(s.chatScheme);   // unknown/legacy values normalize to "default"
       // theme migration (2026-08-28): a store from before `theme` existed seeds it from the old
       // tab-strip pick, so a yatharth strip stays a yatharth strip. chatTabTheme itself is DERIVED


### PR DESCRIPTION
The user reported the dashboard's Files control opening the timeline in a side pane instead of the Files pane (2026-09-10). On a served hermetic dashboard and on a live one, the rail's Files toggle and the phone's Files tab open the Files pane at every width tried (1400, 1100, 900, 390 px; stored pane sets, bookmarks and a stored phone tab included), so what lands here is the guard for that behaviour plus the setting the user recalled.

## The guard

`tests/test_files_pane_toggle_served.py` drives the real shell page of a hermetic kernel, clicks the Files control in both layouts and asserts the Files pane shows with its own page (`/files`) while the timeline band stays exactly as it was; on the phone the Files iframe is the one showing and the timeline's is not.

## The setting

The gear's panes section gains **Files control in the dashboard bar**, shown by default (today's behaviour), stored with the other gear settings (`romp:settings.filesControl`, per browser). The shell reads the store key itself (`_LANDING_COLLAPSE_JS`): off, the rail's toggle and the phone's tab are hidden by one body class, an open Files pane closes on the same apply and the close is saved, the pane cannot be brought forward (the palette's command, a stale relay), a phone left on the Files tab shows the chat, and the panes are told the pane is unavailable (`avail.files` on the existing pane-set broadcast), so a file link set to open in the Files pane opens over the pane clicked (`fileLinkRoute`'s closed-pane road). The gear writes from the feed iframe, another document, so the shell's storage listener is the event that re-applies it live. Only the literal `false` hides the control.

## Tests

- `ui/webview/settings.test.ts`: the default, the round-trip, false-only.
- `ui/webview/file-route.test.ts` and the executed `browse-route` slices: the fallback with the control hidden; an open pane still takes the click.
- `tests/test_pane_state_broadcast.py`: the controller under node with the store holding `false` and the pane left open: the class, the forced close saved, the refused bring-forward, the phone switch, the storage event showing it again.
- `tests/test_files_pane.py`: the CSS rule, the gear row after the file-link setting, the mobile guard, the hint unchanged.
- `tests/test_files_pane_toggle_served.py`: the served page at 1400 and 390 px with the control shown and hidden, with screenshots.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
