### PR TITLE
Session events: the default since is the boot's whole second, and a drain row is a problem row

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2133,12 +2133,16 @@ sweep summary of every boot that had a session to reconcile: `sessions`, `resume
 as the boot's process listing stood: `fsid`, `pids`, `n`), `crash.heal` and
 `crash.loop` (`attempt`), `drain.unjoined` (a session the drain's bound left
 closing: `inflight`, `reaped`), and the lease work's `lease.*` kinds. Every kind
-but the boot summary is also a problem-ring entry (the bell and error center
-show its prose) and a kernel-log line of the form `<prose> ;; problem-row
-{json}`, the same object after the marker, so a log reader parses it with a
-split on the marker. `GET /session-events?since=<epoch s>&limit=<n>`
-(token-gated) returns the rows newest first since the stamp (default this
-kernel's boot; at most 1000), each with `host`, and `count`, this kernel's
+but the boot summary carries `text` and is also a kernel-log line of the form
+`<prose> ;; problem-row {json}`, the same object after the marker, so a log
+reader parses it with a split on the marker; every kind but the boot summary
+and `drain.unjoined` (written as the kernel exits, when the bell has no reader)
+is a problem-ring entry too (the bell and error center show its prose).
+`GET /session-events?since=<epoch s>&limit=<n>` (token-gated) returns the rows
+newest first since the stamp (default this kernel's boot in whole seconds, the
+resolution every row's `t` has and the `bootAt` the response names, so the
+default rows and `count` are one predicate but for the boot summary and the
+`limit` cap; at most 1000), each with `host`, and `count`, this kernel's
 problems since its boot, never a sum across kernels. `turns.jsonl` gets one
 row per settled turn: `t`, `sid`, `name`, `fedT` (the feed pop, when the text
 left the queue for the CLI's stdin, at millisecond resolution), `firstOutT`

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15109,9 +15109,14 @@ def _session_event_rows(since=0.0, limit=200, tail=SESSION_EVENTS_TAIL):
     CLIs holding one conversation, a crash heal or loop, a session the drain left closing, and the boot
     sweep's summary), newest first, rows with t >= `since`, at most `limit`, each carrying `host` (this
     kernel's own name, _self_host) so a federated shell merges per-host maps and never sums across kernels.
-    `count` is the problems since THIS kernel's boot on THIS host: every row at or after _STARTED except the
-    boot summary (reconcile.boot, which every boot writes). Reads the file's tail only; a missing or
-    unreadable ledger is ([], 0)."""
+    `count` is the problems since THIS kernel's boot on THIS host: every row at or after int(_STARTED) except
+    the boot summary (reconcile.boot, which every boot writes). The route's default `since` is that same whole
+    second, the resolution every row's `t` has (append_session_event stamps it to the second), so the default
+    rows and `count` are one predicate but for the boot summary and the `limit` cap (`count` is uncapped). A
+    row the previous kernel stamped in this kernel's boot second (its drain rows are written as it exits, and
+    the manager spawns the next kernel on that exit) is therefore both listed and counted here: whole seconds
+    are what the rows have, and /version's `started` and the response's `bootAt` name that same second. Reads
+    the file's tail only; a missing or unreadable ledger is ([], 0)."""
     path = jd.STATE / "session-events.jsonl"
     try:
         lines = path.read_text(encoding="utf-8").splitlines()[-int(tail):]
@@ -51616,14 +51621,19 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send(200, json.dumps(out), "application/json", cache="no-cache")
             if p == "/session-events":
                 # T304: the session-event ledger for the dashboard's "sessions gone wrong" cue and `romp
-                # restart-metrics` (_session_event_rows): ?since=<epoch s> (default this kernel's boot),
+                # restart-metrics` (_session_event_rows): ?since=<epoch s> (default this kernel's boot in
+                # whole seconds, int(_STARTED), for a missing and for an unparseable value alike: every row's
+                # `t` is stamped to the second, and `count` and `bootAt` below use that same second, so the
+                # default rows and `count` are one predicate but for the boot summary and the `limit` cap;
+                # the float _STARTED here left a row stamped in the boot second counted and unlisted),
                 # ?limit=<n> (default 200, at most 1000). AUTHED like /api-health, by the plain _authorize:
-                # session names ride it. `count` is this kernel's alone, never a cross-kernel sum (a federated
-                # shell keeps per-host maps; every row names its host for that merge).
+                # session names ride it. `count` is this kernel's alone, never a cross-kernel sum (a
+                # federated shell keeps per-host maps; every row names its host for that merge).
+                raw_since = (q.get("since") or [""])[0]
                 try:
-                    since = float((q.get("since") or [""])[0] or _STARTED)
+                    since = float(raw_since) if raw_since else int(_STARTED)
                 except ValueError:
-                    since = float(_STARTED)
+                    since = int(_STARTED)
                 try:
                     limit = max(1, min(1000, int((q.get("limit") or [""])[0] or 200)))
                 except ValueError:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -1515,10 +1515,12 @@ def append_resume_fork(state_dir: Path, sid: str, from_fsid: str, to_fsid: str, 
 #                          "sid": romp sid when about a session, "name": its name then, ...flat fields}.
 #                         Kinds this file writes: reconcile.boot (the sweep's summary, every boot, ledger only),
 #                         reconcile.orphan-reaped, reconcile.scope-stopped, reconcile.duplicate-cli, crash.heal,
-#                         crash.loop, drain.unjoined. Every kind that IS a problem also lands on the backend's
-#                         problem ring (the dashboard's bell and error center) as its prose, and on the kernel
-#                         log as `<prose> ;; problem-row {json}` so a log reader parses the same object with
-#                         `line.rsplit(PROBLEM_ROW_MARK, 1)[1]`.
+#                         crash.loop, drain.unjoined. Every kind but the boot summary is written through
+#                         problem_row: its row carries the prose as `text`, and the kernel log gets
+#                         `<prose> ;; problem-row {json}` so a log reader parses the same object with
+#                         `line.rsplit(PROBLEM_ROW_MARK, 1)[1]`. Every one of those but drain.unjoined also
+#                         lands on the backend's problem ring (the dashboard's bell and error center) as its
+#                         prose; the drain rows are written as the kernel exits, when the ring has no reader.
 #   turns.jsonl           one row per settled turn (SdkSession._turn_ledger_row): the event stamps the latency
 #                         and redo-cost figures read. Every stamp is an EVENT's time: fedT is the feed pop
 #                         (the turn left the queue for the CLI's stdin), firstOutT the first streamed work atom,
@@ -9346,10 +9348,15 @@ class SdkBackend:
                 pass                                     # exited between the join and the reap — fine
             except Exception:
                 self._log("drain: reap failed for %s: %s" % (s.name, traceback.format_exc()))
-        for s in unjoined:   # T304: the sessions the bound left closing, one ledger row each (the cut row's
-            #                 `unjoined` is the count alone); the process is exiting, so the ring is not asked
-            append_session_event(self.state_dir, "drain.unjoined", sid=s.sid, name=s.name,
-                                 inflight=int(bool(getattr(s, "inflight", 0))), reaped=(s.sid in reaped_sids))
+        for s in unjoined:   # T304: the sessions the bound left closing, one problem row each (the cut row's
+            #                 `unjoined` is the count alone): the row with its prose as `text` and the
+            #                 kernel-log line a reader parses, like every kind but the boot summary. ring=False:
+            #                 the process is exiting, so the bell has no reader left for the ring entry
+            problem_row(self.state_dir,
+                        "drain: session %s was still closing when the shutdown's wait ran out%s"
+                        % (s.name, "; its claude process was ended" if s.sid in reaped_sids else ""),
+                        "drain.unjoined", sid=s.sid, name=s.name, log=self._log, ring=False,
+                        inflight=int(bool(getattr(s, "inflight", 0))), reaped=(s.sid in reaped_sids))
         if sessions:
             names = [s.name for s in unjoined]
             self._log("drain: stopped %d session(s), %d in-flight turn(s) interrupted%s%s"

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -3,10 +3,11 @@
 read. session-events.jsonl gets one flat row per thing that went wrong with a session's process (an orphaned
 CLI ended at boot, a leftover scope stopped, two CLIs holding one conversation, a crash heal or crash loop, a
 session the drain's bound left closing) and one summary row per boot sweep; every problem also lands on the
-backend's problem ring as its prose and on the kernel log as `<prose> ;; problem-row {json}` (the shape agreed
-with the lease work, which writes its `lease.*` kinds through the same helper). turns.jsonl gets one row per
-settled turn with the event stamps the latency and redo-cost figures read. Synthetic fixtures only: placeholder
-uuids, fake pids above pid_max, scripted `run` / `kill` seams, no real CLI."""
+kernel log as `<prose> ;; problem-row {json}`, and every one but a drain row (written as the kernel exits) on
+the backend's problem ring as its prose (the shape agreed with the lease work, which writes its `lease.*`
+kinds through the same helper). turns.jsonl gets one row per settled turn with the event stamps the latency
+and redo-cost figures read. Synthetic fixtures only: placeholder uuids, fake pids above pid_max, scripted
+`run` / `kill` seams, no real CLI."""
 import json
 import os
 import tempfile
@@ -235,8 +236,10 @@ class CrashRows(unittest.TestCase):
 
 
 class DrainRows(unittest.TestCase):
-    def test_unjoined_sessions_get_a_row_each(self):
-        d = tempfile.mkdtemp(); be = _backend(d)
+    def _drain(self, be, cli_pid=None):
+        """Drain two doubles: `web` still closing with a turn in flight, `api` joined clean. `cli_pid` is
+        what the CLI-pid seam answers for the stuck one; a stub `kill` (nothing real is signalled) reports the
+        process gone at the first existence poll."""
         class Thr:
             def __init__(self, alive): self._alive = alive
             def join(self, *_): pass
@@ -247,12 +250,50 @@ class DrainRows(unittest.TestCase):
         stuck = sess(SID, "web", True, 1)
         clean = sess(SID2, "api", False, 0)
         be.sessions = {SID: stuck, SID2: clean}
-        with mock.patch.object(sb.SdkBackend, "_session_cli_pid", lambda self, s: None):
-            res = be.drain(0.01)
+        def kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError()
+        with mock.patch.object(sb.SdkBackend, "_session_cli_pid", lambda self, s: cli_pid):
+            return be.drain(0.01, kill=kill)
+
+    def test_unjoined_sessions_get_a_row_each(self):
+        d = tempfile.mkdtemp(); be = _backend(d)
+        res = self._drain(be)
         self.assertEqual((res["stopped"], res["unjoined"], res["reaped"]), (2, 1, 0))
         rows = _events(d)
         self.assertEqual([(r["kind"], r["sid"], r["name"], r["inflight"], r["reaped"]) for r in rows],
                          [("drain.unjoined", SID, "web", 1, False)])
+
+    def test_unjoined_row_is_a_problem_row_without_the_ring(self):
+        """A drain.unjoined row is a problem row like every kind but the boot summary: it carries `text` and
+        the kernel log gets `<prose> ;; problem-row {json}`. The ring alone is not asked, since the kernel is
+        exiting and the bell has no reader for it."""
+        d = tempfile.mkdtemp(); lines = []
+        be = _backend(d, log=lambda m: lines.append(m))
+        self._drain(be)
+        (row,) = _events(d)
+        self.assertEqual(row["kind"], "drain.unjoined")
+        self.assertIsInstance(row.get("text"), str)
+        self.assertIn("web", row["text"])
+        self.assertNotIn("ended", row["text"], "not reaped: the prose does not say its process was ended")
+        marked = [m for m in lines if sb.PROBLEM_ROW_MARK in m]
+        self.assertEqual(len(marked), 1, lines)
+        self.assertEqual(sb.parse_problem_row(marked[0]), row, "the log line carries the same object")
+        self.assertTrue(marked[0].startswith(row["text"] + sb.PROBLEM_ROW_MARK))
+        self.assertTrue(any(m.startswith("drain: stopped 2 session(s)") for m in lines),
+                        "the drain's own summary still logs")
+        self.assertEqual(_ring(be), [])
+
+    def test_reaped_row_says_so_in_its_prose(self):
+        d = tempfile.mkdtemp(); lines = []
+        be = _backend(d, log=lambda m: lines.append(m))
+        res = self._drain(be, cli_pid=CLI)
+        self.assertEqual((res["unjoined"], res["reaped"]), (1, 1))
+        (row,) = _events(d)
+        self.assertEqual((row["kind"], row["reaped"]), ("drain.unjoined", True))
+        self.assertIn("ended", row["text"])
+        self.assertEqual(sb.parse_problem_row([m for m in lines if sb.PROBLEM_ROW_MARK in m][0]), row)
+        self.assertEqual(_ring(be), [])
 
 
 class LedgerRotation(unittest.TestCase):

--- a/tests/test_session_events_route.py
+++ b/tests/test_session_events_route.py
@@ -89,6 +89,27 @@ class SessionEventsRoute(unittest.TestCase):
         self.assertEqual(code, 200, "bad parameters fall back to the defaults")
         self.assertEqual(len(d["rows"]), 3)
 
+    def test_a_row_in_the_boot_second_is_counted_and_listed(self):
+        """The default `since` is the boot's whole second, the resolution every row's `t` has, the same stamp
+        `bootAt` reports and `count` filters by. A real _STARTED is fractional, so a row stamped in the boot
+        second (the previous kernel's drain row, written as it exited and this kernel was spawned) sits at
+        t == int(_STARTED) < _STARTED: with a float default it was counted and not listed. Both defaults, the
+        one a missing ?since= gets and the one an unparseable ?since= falls back to, are that whole second."""
+        km._STARTED = BOOT + 0.6
+        with open(self.tmp / "session-events.jsonl", "a") as f:
+            f.write(json.dumps({"t": BOOT, "pid": 1, "kind": "drain.unjoined", "sid": SID, "name": "web",
+                                "inflight": 1, "reaped": True}) + "\n")
+        for qs in ("", "?since=garbage"):
+            with self.subTest(query=qs or "none"):
+                code, d = self._get(qs)
+                self.assertEqual(code, 200)
+                kinds = [r["kind"] for r in d["rows"]]
+                self.assertIn("drain.unjoined", kinds, "the boot-second row is listed with this boot's rows")
+                self.assertEqual(d["count"], len([k for k in kinds if k != "reconcile.boot"]),
+                                 "count and rows are one predicate but for the boot summary: %s" % kinds)
+                self.assertEqual(d["since"], BOOT, "the default since is the boot's whole second")
+                self.assertEqual(d["since"], d["bootAt"])
+
     def test_missing_ledger_is_empty_not_an_error(self):
         (self.tmp / "session-events.jsonl").unlink()
         code, d = self._get()


### PR DESCRIPTION
## Symptom

`GET /session-events` with no `?since=` can answer a `count` larger than the number of problem rows it lists: a row stamped in this kernel's boot second is counted and missing from `rows`, and the echoed `since` names a fraction of a second while `bootAt` names the whole second. The realistic case is the previous kernel's `drain.unjoined` row: it is written as that kernel exits, the manager spawns the next kernel on that exit, and `_STARTED` often lands in the same wall second. An unparseable `?since=` falls back to the same fraction.

A `drain.unjoined` row itself has no `text` and no `<prose> ;; problem-row {json}` kernel-log line, although the header comment in `kernel/sdk_backend.py` and `docs/reference.md` promise both for every kind but the boot summary. A log reader parsing on the marker never sees a drain row.

## Cause

The handler defaulted `since` to `_STARTED`, a float, both when the parameter is missing and when it does not parse, while `_session_event_rows` counts with `int(_STARTED)` and every row's `t` is a whole second (`append_session_event` stamps `int(time.time())`). A row with `t == int(_STARTED)` passes the count's `t >= boot_t` and fails the listing's `t >= since`.

The drain loop appended its rows with `append_session_event` directly instead of `problem_row`, which is what gives a row its `text` and the marker line.

## Fix

- `kernel/kernel.py`: the default `since` is `int(_STARTED)` for a missing and for an unparseable `?since=` alike, the same whole second `count` filters by and `bootAt` reports, so the default rows and `count` are one predicate but for the boot summary and the `limit` cap (`count` is uncapped). An explicit `?since=` still parses as a float. The helper's docstring and the handler's comment say why the whole second, and that a previous kernel's row stamped in this kernel's boot second is therefore both listed and counted (the resolution the row stamps have). Switching only `count` to a pid compare would reopen the disagreement the other way (a previous kernel's boot-second row listed but not counted).
- `kernel/sdk_backend.py`: the drain writes each unjoined session's row through `problem_row(..., log=self._log, ring=False, ...)`, so the row carries its prose as `text` and the kernel log gets the parseable line. `ring=False` stays: the kernel is exiting and the bell has no reader for a ring entry. The prose reads `drain: session <name> was still closing when the shutdown's wait ran out`, with `; its claude process was ended` when the reap ran. The header comment names the one exception, the ring.
- `docs/reference.md`: the `session-events.jsonl` paragraph says every kind but the boot summary carries `text` and the log line, every kind but the boot summary and `drain.unjoined` is a ring entry too, and the route's default `since` is the boot in whole seconds.

The echoed `since` changes from a float to an int by default; no reader consumes it today (`cli/restart_metrics.py` reads the file, not the route), and it now equals `bootAt`.

## Tests

- `tests/test_session_events_route.py::SessionEventsRoute::test_a_row_in_the_boot_second_is_counted_and_listed`: `_STARTED = BOOT + 0.6` and a previous kernel's `drain.unjoined` row at `t == BOOT`; for a GET with no query and for `?since=garbage` (two subtests), asserts the row is listed, `count` equals the number of non-summary rows, and `since == bootAt == BOOT`. Before the fix both subtests fail with `'drain.unjoined' not found in ['crash.heal', 'reconcile.boot', 'reconcile.orphan-reaped']` (count 3 against 2 listed); with only one of the two handler defaults changed, the other subtest still fails.
- `tests/test_session_events_ledger.py::DrainRows::test_unjoined_row_is_a_problem_row_without_the_ring`: drains the two doubles with a logging backend; asserts the row has a `text` naming the session, exactly one log line carries `PROBLEM_ROW_MARK` and parses to the same row, the drain's own summary still logs, and the ring is empty. Before the fix: the row has no `text`.
- `tests/test_session_events_ledger.py::DrainRows::test_reaped_row_says_so_in_its_prose`: the CLI-pid seam answers a pid above pid_max and a stub `kill` reports it gone at the first existence poll (nothing real is signalled); asserts `reaped` is true and the prose says the process was ended. Before the fix: `KeyError: 'text'`.
- The existing `test_unjoined_sessions_get_a_row_each` keeps its assertions, on a drain helper the three tests share.

Full suite on this head: 11650 passed, 45 skipped, 1746 subtests passed, 1 failed. The failure is `tests/test_notification_tap_resume_browser.py::ServedTapLanding::test_a_click_the_worker_saw_lands_the_page_via_the_message_and_settles_the_row`, a served-page browser test of the notification tap landing that reads none of the code this change touches; run alone right after, it and its module pass (1 passed; 3 passed).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)