### PR TITLE
A lab kernel never starts a postal bus on the machine's port: the postal trio on the one bare lab, and a guard for every kernel-spawning test

### DIFF
--- a/tests/test_federation_missing_served.py
+++ b/tests/test_federation_missing_served.py
@@ -246,7 +246,11 @@ class ServedFederationMissing(unittest.TestCase):
                        ROMP_MANAGER_PORT="1", ROMP_KERNEL_NO_OPEN="1",
                        ROMP_SERVE_TOKEN=cls.token, ROMP_KERNEL_PORT=str(cls.port),
                        ROMP_DIST_DIR=dist, ROMP_MODEL_CATALOG="off",
-                       ROMP_TMUX_SOCKET="romp-fedmissing-%d" % cls.port)
+                       ROMP_TMUX_SOCKET="romp-fedmissing-%d" % cls.port,
+                       # a postal bus of its own that is never started (the trio kernel_env gives every lab kernel):
+                       # without it the kernel's boot-time ensure started a detached bus on the FIXED port, which
+                       # outlived this kernel and held the machine's shared bus port after a restart (2026-09-10)
+                       ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1")
         cls.env.pop("ROMP_STATE_DIR", None)
         for k in [k for k in cls.env if k in _cred.RETIRED_VARS or _cred.is_op_env_name(k)]:   # the kernel's own boot rule (module top)
             cls.env.pop(k, None)

--- a/tests/test_hermetic_kernel_postal.py
+++ b/tests/test_hermetic_kernel_postal.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Every lab kernel a test starts as a PROCESS is hermetic about the postal bus (2026-09-10): its environment carries
+ROMP_POSTAL_CLIENT_ONLY=1 (the kernel's boot-time ensure then starts no bus) and its own ROMP_POSTAL_PORT (an ephemeral
+port, never the machine's fixed one) and ROMP_POSTAL_PEERS=0, the trio tests/test_ship_reship.py kernel_env gives.
+
+Why a guard: one served test built its kernel environment by hand without the trio. Its kernel ran the postal
+service's `ensure`, which starts the bus detached (its own session, so the kernel's death never reaches it) on the
+FIXED port whenever nothing listens there. During a kernel restart the machine's real bus was down for a moment, the
+lab bus took the port, the test's teardown killed the kernel and not the bus, and every session's mail then failed
+against the lab's token until someone found the process. The fixture rule below is static, so it holds for tests that
+skip here (no browser, no extension deps) and fails at the spawn site, naming the file.
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SPAWN = re.compile(r"""Popen\(\s*\[[^\]]*["']romp-kernel["']""")
+TRIO = ("ROMP_POSTAL_PORT", "ROMP_POSTAL_PEERS", "ROMP_POSTAL_CLIENT_ONLY")
+
+
+class HermeticKernelPostal(unittest.TestCase):
+    def test_kernel_env_gives_every_lab_kernel_its_own_never_started_bus(self):
+        env = _lab.kernel_env("/tmp/lab", "/tmp/lab/claude", "/tmp/lab/dist", 1, "tok")
+        self.assertEqual(env.get("ROMP_POSTAL_CLIENT_ONLY"), "1", "the kernel's ensure starts no bus")
+        self.assertEqual(env.get("ROMP_POSTAL_PEERS"), "0")
+        port = int(env.get("ROMP_POSTAL_PORT") or 0)
+        self.assertTrue(port and port != 25302, "an ephemeral port, never the machine's fixed bus port: %r" % env.get("ROMP_POSTAL_PORT"))
+
+    def test_every_test_that_starts_a_kernel_process_carries_the_trio(self):
+        offenders = []
+        for name in sorted(os.listdir(HERE)):
+            if not name.endswith(".py") or name == os.path.basename(__file__):
+                continue
+            src = open(os.path.join(HERE, name), encoding="utf-8", errors="replace").read()
+            if not SPAWN.search(src):
+                continue
+            hermetic = "kernel_env(" in src or all(k in src for k in TRIO)
+            if not hermetic:
+                offenders.append(name)
+        self.assertEqual(offenders, [], "these tests start a kernel process without the postal trio (use kernel_env, or set "
+                                        "ROMP_POSTAL_PORT to a free port, ROMP_POSTAL_PEERS=0 and ROMP_POSTAL_CLIENT_ONLY=1): %r" % offenders)
+
+    def test_the_guard_itself_sees_the_spawn_sites(self):
+        """the regex must match the spawn idiom the labs use, else the rule above would pass vacuously"""
+        hits = [n for n in os.listdir(HERE) if n.endswith(".py") and SPAWN.search(open(os.path.join(HERE, n), encoding="utf-8", errors="replace").read())]
+        self.assertIn("test_federation_missing_served.py", hits)
+        self.assertIn("test_notification_tap_resume_browser.py", hits)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notification_tap_resume_browser.py
+++ b/tests/test_notification_tap_resume_browser.py
@@ -466,7 +466,10 @@ class ServedTapLanding(unittest.TestCase):
         ep_host = "push.example.net"
         for line in (r"\[push\] ack stage=shown sid=%s endpoint=%s" % (re.escape(SID_B[:8]), ep_host),
                      r"\[push\] ack stage=clicked sid=%s endpoint=%s" % (re.escape(SID_B[:8]), ep_host),
-                     r"\[reveal\] sw sid=%s wid=\S+: delivered" % re.escape(SID_B[:8]),
+                     # since the readiness gate (2026-09-10) a live tap reaches a pane that has said ready at once, and a tap
+                     # that arrives while the pane's ready push is still being built parks and is consumed when that ready
+                     # finishes: both roads land it, and the trail says which
+                     r"\[reveal\] sw sid=%s wid=\S+: (?:delivered|parked[\s\S]*?\[reveal\] sid=%s wid=\S+: consumed \S+ the pane's ready)" % (re.escape(SID_B[:8]), re.escape(SID_B[:8])),
                      r"\[push\] landed sid=%s endpoint=%s" % (re.escape(SID_B[:8]), ep_host)):
             self.assertRegex(klog, line, "the kernel logged it: %s" % klog[-2000:])
         # (the worker STARTS the shown ack before the click and the clicked ack before it tells the page, but every one


### PR DESCRIPTION
A lab kernel never starts a postal bus on the machine's port: the federation-missing served test carries the postal trio, and a guard keeps every kernel-spawning test hermetic

The federation-missing served test built its lab kernel's environment by hand, without the trio kernel_env gives
every lab kernel (ROMP_POSTAL_CLIENT_ONLY=1, its own ROMP_POSTAL_PORT, ROMP_POSTAL_PEERS=0). Its kernel ran the
postal service's boot-time ensure, which starts the bus detached (its own session) on the FIXED port whenever
nothing listens there. During a kernel restart the machine's real bus was down for a moment, the lab bus took the
port, the test's teardown killed the kernel and not the bus, and every session's mail failed against the lab's
token until the process was found (2026-09-10, about 3:28 PM PT).

The fix at the source: that lab's environment carries the trio, so its kernel starts no bus at all. The guard
(tests/test_hermetic_kernel_postal.py) pins kernel_env's trio and scans every test that starts a kernel process
for it, naming the offender; it is static, so it holds for the served tests that skip without a browser.


**Also, the push-tap test's click road.** Since the readiness gate of the boot-race fix, both roads land a tap: a live tap is delivered at once to a pane that has said ready, and a tap that arrives while the pane's ready push is still being built parks and is consumed when that ready finishes. The click-road test pinned only the delivered wording and was red under load on any change, this one included; its regex now accepts either trail and still requires all four kernel lines. The rest of that test's hardening (event waits for landedAt, the trail printed on failure) is romp_feed's follow-up.
