### PR TITLE
Tab strip grouped by tag: the overview is a mode, the rows are not tabs, one selection on the strip

### DIFF
--- a/tests/test_tab_overview_mode_served.py
+++ b/tests/test_tab_overview_mode_served.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""T322 (the user 2026-09-10): the tab strip grouped by tag, one tag per row, and a tag's overview, on the real /chat page
+of a hermetic kernel with four sessions under two tags. Asserted: with a session active inside an expanded row, the
+row's tag chip wears no underline; a click on the row shows the overview whose heading reads "Overview of", the tag's
+ordinary chip and the count; while it shows the message box (the whole footer) is gone, no tab renders as selected
+(the active tab's fill is transparent) and the row wears the selected tab's box (the tab's fill token, the identity
+ring); selecting a tab clears it and brings the footer and the tab's fill back. With SNAP_SHOTS=<dir> the driver writes
+screenshots (the grouped strip with one row expanded and a session active, dark and light; the overview shown, dark).
+Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC fixtures only (the notes-api demo world)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
+
+SIDS = {"web": "aaaaaaaa-1111-2222-3333-444444444444", "api": "bbbbbbbb-1111-2222-3333-444444444444",
+        "tests": "cccccccc-1111-2222-3333-444444444444", "docs": "dddddddd-1111-2222-3333-444444444444"}
+COLORS = {"web": ("#9cd2ff", "#0c1a2e"), "api": ("#1EA1EB", "#ffffff"), "tests": ("#54B204", "#ffffff"), "docs": ("#c98cff", "#1a0c2e")}
+TAGS = [{"id": "tag-infra", "name": "infra", "color": "#4EC9B0", "members": [SIDS["web"], SIDS["api"]]},
+        {"id": "tag-ui", "name": "ui", "color": "#e5a50a", "members": [SIDS["tests"]]}]
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab-group-head", { timeout: 30000 });
+await page.waitForTimeout(800);
+const measure = () => page.evaluate(() => {
+  const rows = Array.from(document.querySelectorAll("#tabs .tab-group-head")).map((h) => {
+    const chip = h.querySelector(".tab-group-chip"); const cs = getComputedStyle(h);
+    return { group: h.dataset.group, folded: h.dataset.folded, holdsActive: h.classList.contains("holds-active"), shown: h.classList.contains("snap-shown"),
+             chipUnderline: chip ? getComputedStyle(chip).textDecorationLine : null, bg: cs.backgroundColor, shadow: cs.boxShadow, color: cs.color,
+             padding: cs.padding, border: cs.borderTopWidth + " " + cs.borderTopStyle + " " + cs.borderTopColor, chipBg: h.style.getPropertyValue("--chip-bg") };
+  });
+  const tabs = Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => {
+    const cs = getComputedStyle(t);
+    return { id: t.dataset.id, active: t.classList.contains("active"), bg: cs.backgroundColor, shadow: cs.boxShadow, color: cs.color, name: (t.querySelector(".tab-label") || t).textContent.trim() };
+  });
+  const tab = document.querySelector("#tabs .tab.active"); const tcs = tab ? getComputedStyle(tab) : null;
+  const probe = document.createElement("div"); probe.style.background = "var(--tab-active-bg)"; document.body.appendChild(probe);
+  const activeFill = getComputedStyle(probe).backgroundColor; probe.remove();
+  const footer = document.getElementById("footer"); const composer = document.getElementById("composer");
+  const host = document.getElementById("tab-snapshot"); const head = host ? host.querySelector(".snap-head") : null;
+  return { body: document.body.className, rows, tabs, activeFill,
+           footer: footer ? getComputedStyle(footer).display : null, composer: composer ? getComputedStyle(composer).display : null,
+           composerVisible: composer ? composer.getBoundingClientRect().height > 0 : null,
+           snap: host ? { display: getComputedStyle(host).display, heading: head ? Array.from(head.children).map((c) => ({ cls: c.className, text: c.textContent.trim(), style: c.getAttribute("style") || (c.firstElementChild && c.firstElementChild.getAttribute("style")) || "" })) : null,
+                         rows: host.querySelectorAll(".snap-row").length, label: host.getAttribute("aria-label") } : null,
+           theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const out = {};
+// a session inside the infra row is active (the strip's default pick is the first tab; make it explicit)
+await page.click('#tabs .tab[data-id="' + cfg.web + '"]');
+await page.mouse.move(700, 600);   // off the strip: no tab tooltip in the shots
+await page.waitForTimeout(500);
+out.active = await measure();
+if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-tab-groups-active-dark.png", clip: { x: 0, y: 0, width: 1100, height: 260 } }); }
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(250);
+out.activeLight = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-tab-groups-active-light.png", clip: { x: 0, y: 0, width: 1100, height: 260 } });
+await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(250);
+// the OTHER tag's row: the overview of ui, while web (in the still-expanded infra row) stays the active session — so the
+// strip shows an active tab whose selected dress must be gone (a click on infra's own row would fold web away instead)
+await page.click('#tabs .tab-group-head[data-group="ui"]');
+await page.mouse.move(700, 600);
+await page.waitForTimeout(600);
+out.overview = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-tab-overview-dark.png", fullPage: false });
+// a tab pick clears the overview: the docs tab, in the untagged trail (the row's click folded infra's tabs away)
+await page.click('#tabs .tab[data-id="' + cfg.docs + '"]');
+await page.waitForTimeout(500);
+out.picked = await measure();
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedTabOverviewMode(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="tab-overview-")
+        # SNAP_BEFORE_DIST=<dir>: a dist built from another tree (the screenshots' "before"); the test's assertions are
+        # skipped for that run, since they describe the change
+        before = os.environ.get("SNAP_BEFORE_DIST", "")
+        if before:
+            src = before
+        else:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+            src = os.path.join(EXT, "dist")
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(src, dist)   # tests/dist_copy: skips the bundler's staging files
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        for i, (name, sid) in enumerate(SIDS.items()):
+            bg, fg = COLORS[name]
+            Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, bg, fg))
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                 "model": "claude-opus-5", "liveModel": "Opus 5"}))
+            recs = [{"type": "user", "timestamp": iso(t0 + i), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": sid,
+                     "message": {"role": "user", "content": "what does the %s session do in notes-api?" % name}},
+                    {"type": "assistant", "timestamp": iso(t0 + i + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": sid,
+                     "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                                 "content": [{"type": "text", "text": "It keeps the %s side of the notes-api tidy." % name}]}}]
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        # the tags: two, holding three of the four sessions; the fourth is the untagged trail
+        Path(state, "timeline-views.json").write_text(json.dumps({"active": "all", "tags": TAGS}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.port, cls.token = _free_port(), "testtok-overview"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_overview_is_a_mode_and_the_rows_are_not_tabs(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "web": SIDS["web"], "docs": SIDS["docs"],
+                       "shots": os.environ.get("SNAP_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        if os.environ.get("SNAP_BEFORE_DIST"):
+            self.skipTest("a before-the-change dist: screenshots only, the assertions describe the change")
+        a = r["active"]
+        infra = next(row for row in a["rows"] if row["group"] == "infra")
+        self.assertTrue(infra["holdsActive"], "the web tab is active inside the infra row: %r" % a["rows"])
+        # 1. no underline on the holding row's chip
+        self.assertEqual(infra["chipUnderline"], "none", "the tag chip wears no underline for holding the active tab: %r" % infra)
+        # 4. the row is not dressed as a tab: transparent, no ring; a tab's box of space
+        self.assertEqual(infra["bg"], "rgba(0, 0, 0, 0)", "no wash on a row at rest: %r" % infra)
+        self.assertEqual(infra["shadow"], "none")
+        self.assertEqual(infra["padding"], "6px 7px", "a tab's padding: %r" % infra)
+        self.assertIn("0px", infra["border"], "no border of its own: %r" % infra)
+        self.assertEqual(infra["chipBg"].strip(), "#4EC9B0", "the tag's colour rides the row as --chip-bg for its selected box")
+        active = next(t for t in a["tabs"] if t["active"])
+        self.assertEqual(active["bg"], a["activeFill"], "the active tab wears the fill token: %r" % active)
+        self.assertNotEqual(a["footer"], "none", "the message box shows while a session is read")
+        self.assertTrue(a["composerVisible"])
+        self.assertEqual(r["activeLight"]["theme"], "light")
+        self.assertEqual(next(row for row in r["activeLight"]["rows"] if row["group"] == "infra")["chipUnderline"], "none", "light theme: no underline either")
+        # 2, 3, 5, 6. the overview
+        o = r["overview"]
+        self.assertIn("snap-mode", o["body"].split(), "the mode class: %r" % o["body"])
+        self.assertIsNotNone(o["snap"]); self.assertNotEqual(o["snap"]["display"], "none")
+        heading = o["snap"]["heading"]
+        self.assertEqual([h["cls"] for h in heading], ["snap-of", "snap-chip-slot", "snap-count"], heading)
+        self.assertEqual(heading[0]["text"], "Overview of")
+        self.assertEqual(heading[1]["text"], "ui", "the tag's chip carries the name: %r" % heading)
+        self.assertIn("#e5a50a", heading[1]["style"], "…in the tag's colour, tagChip's pill: %r" % heading)
+        self.assertEqual(heading[2]["text"], "1 session")
+        self.assertEqual(o["snap"]["rows"], 1)
+        self.assertEqual(o["snap"]["label"], "Overview of ui: 1 session; click one to open it")
+        self.assertEqual(o["footer"], "none", "the message box disappears entirely: it is a mode, not a session")
+        self.assertFalse(o["composerVisible"])
+        shown = next(row for row in o["rows"] if row["group"] == "ui")
+        self.assertTrue(shown["shown"])
+        self.assertFalse(next(row for row in o["rows"] if row["group"] == "infra")["shown"], "one selection on the strip: the row whose overview shows")
+        self.assertEqual(shown["bg"], o["activeFill"], "the row wears the selected tab's fill: %r" % shown)
+        self.assertIn("inset", shown["shadow"], "…and the selected tab's inset identity ring: %r" % shown)
+        for t in o["tabs"]:
+            self.assertNotEqual(t["bg"], o["activeFill"], "no tab wears the selected fill while the overview shows: %r" % t)
+            self.assertEqual(t["shadow"], "none", "no identity ring on any tab either: %r" % t)
+        web = next(t for t in o["tabs"] if t["id"] == SIDS["web"])
+        self.assertTrue(web["active"], "the active tab keeps its class (the way back), only its dress is neutralised: %r" % web)
+        self.assertEqual(web["bg"], "rgba(0, 0, 0, 0)", "…transparent like a resting tab: %r" % web)
+        # a tab pick clears the overview: the footer and the fill are back
+        pk = r["picked"]
+        self.assertNotIn("snap-mode", pk["body"].split())
+        self.assertNotEqual(pk["footer"], "none")
+        self.assertEqual(next(t for t in pk["tabs"] if t["active"])["id"], SIDS["docs"])
+        self.assertEqual(next(t for t in pk["tabs"] if t["active"])["bg"], pk["activeFill"])
+        self.assertFalse(any(row["shown"] for row in pk["rows"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tab_overview_mode_served.py
+++ b/tests/test_tab_overview_mode_served.py
@@ -103,6 +103,20 @@ await page.mouse.move(700, 600);
 await page.waitForTimeout(600);
 out.overview = await measure();
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-tab-overview-dark.png", fullPage: false });
+// the cascade's two exceptions, probed in the mode: a hard-blocked active tab keeps its red fill (the class the tab
+// state paints, added here since a hermetic kernel has no blocked session), and under the Yatharth theme the active
+// tab wears that theme's resting wash with no selection border
+const probe = (fn) => page.evaluate(fn, cfg.web);
+await probe((id) => { document.querySelector('#tabs .tab[data-id="' + id + '"]').classList.add("tab-blocked"); });
+await page.waitForTimeout(100);
+out.blocked = await probe((id) => { const t = document.querySelector('#tabs .tab[data-id="' + id + '"]'); const cs = getComputedStyle(t); return { bg: cs.backgroundColor, active: t.classList.contains("active") }; });
+await probe((id) => { document.querySelector('#tabs .tab[data-id="' + id + '"]').classList.remove("tab-blocked"); document.body.classList.add("chat-theme-yatharth"); });
+await page.waitForTimeout(150);
+out.yatharth = await probe((id) => { const t = document.querySelector('#tabs .tab[data-id="' + id + '"]'); const cs = getComputedStyle(t);
+  const rest = Array.from(document.querySelectorAll('#tabs .tab.colored:not(.active)')).map((r) => getComputedStyle(r).backgroundColor);
+  return { border: cs.borderTopColor, bg: cs.backgroundColor, restBgs: rest, snap: document.body.classList.contains("snap-mode") }; });
+await probe(() => document.body.classList.remove("chat-theme-yatharth"));
+await page.waitForTimeout(150);
 // a tab pick clears the overview: the docs tab, in the untagged trail (the row's click folded infra's tabs away)
 await page.click('#tabs .tab[data-id="' + cfg.docs + '"]');
 await page.waitForTimeout(500);
@@ -249,6 +263,17 @@ class ServedTabOverviewMode(unittest.TestCase):
         web = next(t for t in o["tabs"] if t["id"] == SIDS["web"])
         self.assertTrue(web["active"], "the active tab keeps its class (the way back), only its dress is neutralised: %r" % web)
         self.assertEqual(web["bg"], "rgba(0, 0, 0, 0)", "…transparent like a resting tab: %r" % web)
+        # the two exceptions: a blocked active tab keeps the red fill; Yatharth's active tab wears the resting wash, no border
+        b = r["blocked"]
+        self.assertTrue(b["active"])
+        self.assertTrue(b["bg"].startswith("rgba(229, 72, 77, 0."), "a hard-blocked active tab keeps its red fill in the mode (the active-blocked tier): %r" % b)
+        y = r["yatharth"]
+        self.assertTrue(y["snap"])
+        self.assertEqual(y["border"], "rgba(0, 0, 0, 0)", "Yatharth: no 55%% selection border on the active tab in the mode: %r" % y)
+        # the resting wash is each tab's own identity colour at the theme's resting alpha: the active tab's alpha matches its siblings'
+        alpha = lambda c: c.rsplit("/", 1)[-1].strip(" )") if "/" in c else None
+        self.assertEqual(alpha(y["bg"]), "0.09", "…and the theme's resting wash (its 9 percent tint, not the 22 percent selected one): %r" % y)
+        self.assertTrue(y["restBgs"] and all(alpha(bg) == alpha(y["bg"]) for bg in y["restBgs"]), "…the same alpha as the other coloured tabs: %r" % y)
         # a tab pick clears the overview: the footer and the fill are back
         pk = r["picked"]
         self.assertNotIn("snap-mode", pk["body"].split())

--- a/ui/webview/dense-chrome.test.ts
+++ b/ui/webview/dense-chrome.test.ts
@@ -99,7 +99,7 @@ test("the dense rules exist under the class, with these exact values", () => {
   assert.match(add, /font-size: 1\.1em;/, "the + keeps its glyph size: the dense .tab rule outranks .tab-add's own 1.1em, so it is restated");
   assert.match(denseRule(".tab-tagbox"), /min-height: 25px;/, "the tag control's floor follows the dense + tab's rendered height (the arithmetic test below)");
   const head = denseRule(".tab-group-head");
-  assert.match(head, /gap: 4px;/); assert.match(head, /padding: 3px 5px 3px 4px;/);
+  assert.match(head, /gap: 4px;/); assert.match(head, /padding: 3px 5px;/, 'the dense tab\'s own padding: the row keeps a tab\'s box (T322)');
   assert.doesNotMatch(head, /font-size/, "the group header keeps the surface's one sub-line size (0.82em); its count inherits it and stays legible");
   const sep = denseRule(".tab-group-sep:not(.tab-group-break)");
   assert.match(sep, /padding: 6px 6px;/, "the trail divider's gutters scale with the row, so its line keeps the default's half-row proportion");
@@ -182,7 +182,8 @@ test("every dense rule is scoped to the body class, and the sheet's defaults are
   assert.match(defaultRule(".tab-tagbox"), /min-height: 31px;/);
   assert.match(defaultRule(".tab-group-sep:not(.tab-group-break)"), /width: 13px; padding: 8px 6px;/);
   const head = defaultRule(".tab-group-head");
-  assert.match(head, /gap: 5px; padding: 6px 7px;/);   // a tab's box of space (T322) assert.match(head, /font-size: 0\.82em;/);
+  assert.match(head, /gap: 5px; padding: 6px 7px;/);   // a tab's box of space (T322)
+  assert.match(head, /font-size: 0\.82em;/);
   assert.match(defaultRule("#bg-tasks"), /margin: 8px 10px 6px;/);
   assert.match(defaultRule(".bg-fold-head"), /padding: 7px 11px;/);
   assert.match(defaultRule(".bg-list"), /padding: 4px 2px;/);

--- a/ui/webview/dense-chrome.test.ts
+++ b/ui/webview/dense-chrome.test.ts
@@ -182,7 +182,7 @@ test("every dense rule is scoped to the body class, and the sheet's defaults are
   assert.match(defaultRule(".tab-tagbox"), /min-height: 31px;/);
   assert.match(defaultRule(".tab-group-sep:not(.tab-group-break)"), /width: 13px; padding: 8px 6px;/);
   const head = defaultRule(".tab-group-head");
-  assert.match(head, /gap: 5px; padding: 6px 7px 6px 6px;/); assert.match(head, /font-size: 0\.82em;/);
+  assert.match(head, /gap: 5px; padding: 6px 7px;/);   // a tab's box of space (T322) assert.match(head, /font-size: 0\.82em;/);
   assert.match(defaultRule("#bg-tasks"), /margin: 8px 10px 6px;/);
   assert.match(defaultRule(".bg-fold-head"), /padding: 7px 11px;/);
   assert.match(defaultRule(".bg-list"), /padding: 4px 2px;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5375,6 +5375,9 @@ function makeGroupHead(sec: TabSection, collapsed: boolean, holdsActive: boolean
   // (headWords) and its own way back are derived from
   const shown = snapView === name;
   if (shown) head.classList.add("snap-shown");
+  // the tag's colour as the row's --chip-bg (the tab sets the same variable from its identity colour): the shown
+  // row's box wears the selected tab's inset ring in it (styles.css .tab-group-head.snap-shown, T322)
+  if (sec.color) head.style.setProperty("--chip-bg", sec.color);
   // THE WAY BACK: the header whose section the pane shows, OPEN, holding the tab being read, is the click that
   // put the section in the pane; a second click puts the transcript back (show-transcript, leaveSnapshot)
   // instead of folding the section under its reader. Derived from the rendered state, as the fold is, and
@@ -11241,6 +11244,7 @@ function snapshotHost(): HTMLElement | null {
 function hideSnapshot(): void {
   const host = document.getElementById("tab-snapshot");
   if (host) host.style.display = "none";
+  document.body.classList.remove("snap-mode");
   snapModel = null;
   // the transcript comes back where the reader left it, not where the view's scrolls put the spot (snapKeep)
   if (snapKeep) { snapKeep.v.scrollTop = snapKeep.scrollTop; snapKeep.v.stick = snapKeep.stick; snapKeep = null; }
@@ -11324,16 +11328,18 @@ function renderSnapshot(): boolean {
   let list = host.querySelector<HTMLElement>(":scope > .snap-list");
   if (!list) {
     const h = document.createElement("h2"); h.className = "snap-head";
-    // the heading's own bar (snap-swatch) and the name: the strip's header wears the tag chip; this heading
-    // keeps a bar + name pair, whose parts the patch below rewrites in place (the rows' rule: nothing is remade)
-    const sw = el("span", "snap-swatch"); sw.setAttribute("aria-hidden", "true");
-    h.append(sw, el("span", "snap-name"), el("span", "snap-count"));
+    // the heading reads "Overview of <the tag's ordinary chip> <count>" (T322, the user 2026-09-10: a name beside a
+    // little colour bar was not it): the words, a slot the tag chip is placed in (tagChip, the same builder the
+    // strip's row and the tag menu use — never a chip rule of its own), and the count; the patch below rewrites
+    // the slot's chip and the count in place (the rows' rule: nothing else is remade)
+    const of = el("span", "snap-of"); of.textContent = "Overview of";
+    h.append(of, el("span", "snap-chip-slot"), el("span", "snap-count"));
     list = el("div", "snap-list"); list.setAttribute("role", "list");
     host.replaceChildren(h, list);
   }
   const part = (cls: string) => host.querySelector<HTMLElement>(".snap-head > ." + cls)!;
-  part("snap-swatch").style.background = next.color || "";
-  part("snap-name").textContent = next.name;
+  const chip = tagChip(next.name, next.color, { inheritSize: true }); chip.classList.add("snap-chip");
+  part("snap-chip-slot").replaceChildren(chip);
   part("snap-count").textContent = words.count;
   // a MOVED row: insertBefore detaches and re-attaches its node, which blurs it (the browser's focus fixup); the
   // same event puts focus back on it (the strip's refocus rule, by node instead of by id). A row GONE from under
@@ -11413,6 +11419,7 @@ function showActive(keep?: { uuid: string; y: number } | null) {
   // the mark. renderSnapshot answers false when the section is gone from the strip (a tag deleted, its last
   // member hidden): then the transcript.
   if (snapView && renderSnapshot()) {
+    document.body.classList.add("snap-mode");   // the overview is a mode: the message box goes, no tab is selected (styles.css, T322)
     for (const v of views.values()) v.el.style.display = "none";
     // the reader's place (snapKeep; once per visit): the hide above only queues the clamp's scroll event, so the
     // view's fields still hold what the reader's last scroll recorded
@@ -11435,6 +11442,7 @@ function showActive(keep?: { uuid: string; y: number } | null) {
     updateStatusline();
     return;
   }
+  document.body.classList.remove("snap-mode");   // a session's transcript: the message box and the selected tab are back
   hideSnapshot();
   const s = activeId ? liveSession(activeId) : null;
   if (!s) {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5969,7 +5969,7 @@ function renderTabs() {
     // ...and the whole tab dims when that host is unreachable, so a disconnected session reads as one at
     // a glance rather than only on inspection (the user 2026-07-29). The marked "host:" carries the why.
     if (hostIsDown(id)) { tab.classList.add("host-off"); tab.title = hostDownNote(id); }
-    if (s.status.faded && id !== activeId && s.color) {
+    if (s.status.faded && (id !== activeId || snapView) && s.color) {   // in the overview mode the active tab fades like any other (no residual selection cue, T322)
       const full = s.color.bg;
       label.style.color = fadedColor(full);
       // The "host:" prefix declares its OWN color (quiet gray), so the parent's faded color can't inherit
@@ -11241,10 +11241,17 @@ function snapshotHost(): HTMLElement | null {
   host.addEventListener("pointerdown", () => { tabPointerHeld = true; });
   return host;
 }
+/** The overview MODE's one switch (T322): the body carries the class (the footer hides by it, the Classic strip's active
+ *  tab is neutralised by it) and so does the strip itself, because the Yatharth theme's neutraliser is a tint rule and
+ *  every tint rule starts with the theme's body class (tab-theme.test.ts), so that rule reads the mode off #tabs. */
+function setSnapMode(on: boolean): void {
+  document.body.classList.toggle("snap-mode", on);
+  document.getElementById("tabs")?.classList.toggle("snap-mode", on);
+}
 function hideSnapshot(): void {
   const host = document.getElementById("tab-snapshot");
   if (host) host.style.display = "none";
-  document.body.classList.remove("snap-mode");
+  setSnapMode(false);
   snapModel = null;
   // the transcript comes back where the reader left it, not where the view's scrolls put the spot (snapKeep)
   if (snapKeep) { snapKeep.v.scrollTop = snapKeep.scrollTop; snapKeep.v.stick = snapKeep.stick; snapKeep = null; }
@@ -11418,8 +11425,9 @@ function showActive(keep?: { uuid: string; y: number } | null) {
   // kernel's active hint, the MRU and the drafts still point at the session being read, and its header wears
   // the mark. renderSnapshot answers false when the section is gone from the strip (a tag deleted, its last
   // member hidden): then the transcript.
+  const wasSnap = document.body.classList.contains("snap-mode");   // read before renderSnapshot's gone-section path can clear it
   if (snapView && renderSnapshot()) {
-    document.body.classList.add("snap-mode");   // the overview is a mode: the message box goes, no tab is selected (styles.css, T322)
+    setSnapMode(true);   // the overview is a mode: the message box goes, no tab is selected (styles.css, T322)
     for (const v of views.values()) v.el.style.display = "none";
     // the reader's place (snapKeep; once per visit): the hide above only queues the clamp's scroll event, so the
     // view's fields still hold what the reader's last scroll recorded
@@ -11442,7 +11450,11 @@ function showActive(keep?: { uuid: string; y: number } | null) {
     updateStatusline();
     return;
   }
-  document.body.classList.remove("snap-mode");   // a session's transcript: the message box and the selected tab are back
+  setSnapMode(false);   // a session's transcript: the message box and the selected tab are back
+  if (wasSnap) {   // the box was measured while the footer was display:none (a pick's draft swap): measure it now it has a layout box
+    const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+    if (ta) growComposer(ta);
+  }
   hideSnapshot();
   const s = activeId ? liveSession(activeId) : null;
   if (!s) {
@@ -12193,7 +12205,7 @@ if (typeof ResizeObserver === "function") {
       const h = entries[0]?.contentRect?.height ?? 0;
       const content = document.getElementById("content");
       const v = activeId ? views.get(activeId) : null;
-      if (content && lastH >= 0 && content.clientHeight > 0 && v && v.shown && followBoxBelow(v.stick, h - lastH)) {
+      if (content && !snapView && lastH >= 0 && content.clientHeight > 0 && v && v.shown && followBoxBelow(v.stick, h - lastH)) {   // a transcript rule: it stands down while the overview owns #content (the footer's hide is not a box below the reader, T322)
         writeScroll(content, content.scrollHeight, "box-below", true);
         v.scrollTop = content.scrollTop;                      // keep the per-view saved position in sync
       }

--- a/ui/webview/skeleton-tabs-wiring.test.ts
+++ b/ui/webview/skeleton-tabs-wiring.test.ts
@@ -322,6 +322,7 @@ function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript
     // the section-at-a-glance view, inert: no section shows (snapView null), so showActive's branch is not taken
     let snapView = null, snapKeep = null;
     const renderSnapshot = () => false, hideSnapshot = () => {}, composerRestingPlaceholder = () => "";
+    const setSnapMode = () => {}, growComposer = () => {};   // the overview mode's switch and the box re-measure on leaving it (T322)
     const requestFullSession = (id, why) => { HOOKS.fulls.push(why + ":" + id); };
   `;
   const epilogue = `

--- a/ui/webview/skeleton-tabs-wiring.test.ts
+++ b/ui/webview/skeleton-tabs-wiring.test.ts
@@ -291,7 +291,8 @@ function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript
   const pane = new ChipPane(opts.clientHeight, opts.innerHeight - 40);
   const win = { innerHeight: opts.innerHeight };
   const doc = { getElementById: (id: string): ChipEl | null => id === "content" ? pane : (pane.children.find((c) => c.id === id) ?? null),
-                body: { style: { removeProperty(_k: string): void {} } } };
+                body: { style: { removeProperty(_k: string): void {} },
+                        classList: { add(..._c: string[]): void {}, remove(..._c: string[]): void {}, toggle(_c: string, _on?: boolean): void {}, contains(_c: string): boolean { return false; } } } };   // body.snap-mode (T322): showActive toggles the mode class
   const viewA = new ChipEl("session", opts.transcript);
   pane.appendChild(viewA);
   const viewB = new ChipEl("session", 900); viewB.style.display = "none";   // the stale copy's view, hidden as a non-active view is

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -402,8 +402,7 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    2026-09-06): a disclosure chevron that flips with the fold, the tag as THE CHIP it wears everywhere
    (T251), and the member count (the folded-away count while folded). No state class, no close, no pip
    of its own — none of a tab's dress; folded, one small MEMBER-derived mark follows the count (the
-   state pip below), and hover/focus brighten the label and color the chevron in the accent (a fold
-   cue), never a row wash (a "select me" cue). The chip is coloured by IDENTITY, so it brightens by a
+   state pip below), The chip is coloured by IDENTITY, so it brightens by a
    filter rather than to --fg (T251b: --fg would erase the tag; the chip's inline colour is what the
    header's colour rule cannot reach) — the same lift the plain name used to get, on the tag's own hue. The header is focusable (Enter or Space fold),
    drags to reorder the groups (tagOrder), and the header under a dragged group wears the accent
@@ -1024,8 +1023,16 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    one selection on the strip. The active tab's classes stay (activeId is the way back; focus and the arrows key
    on them), only its dress is neutralised to a resting tab's. Selecting any tab clears the mode (setActive). */
 body.snap-mode #footer { display: none; }
-body.snap-mode #tabs .tab.active { color: var(--dim); background: transparent; box-shadow: none; }
+/* the neutralised active tab is a RESTING tab of its theme (review finds): a hard-blocked tab keeps its red fill (the
+   user's standing rule: the blocked fill survives on the active tab), hover still lifts it, and under the Yatharth theme
+   it wears that theme's resting wash with no border (Yatharth's selection mark IS the 55% identity border). The strip
+   (#tabs) carries the mode class beside the body (setSnapMode, one switch): a tint rule must start with the theme's
+   body class (tab-theme.test.ts: every identity wash lives under it), so the mode is read off the strip there. */
+body.snap-mode #tabs .tab.active:not(.tab-blocked) { color: var(--dim); background: transparent; box-shadow: none; }
+body.snap-mode #tabs .tab.active:not(.tab-blocked):hover { color: var(--fg); background: rgba(255, 255, 255, 0.06); }
 body.snap-mode:not(.chat-theme-yatharth) #tabs .tab.active:not(.tab-blocked):not(.tab-add) { border-color: rgba(255, 255, 255, 0.06); }
+body.chat-theme-yatharth #tabs.snap-mode .tab.active.colored:not(.tab-blocked) { background: color-mix(in srgb, var(--chip-bg) 9%, transparent); border-color: transparent; }
+body.chat-theme-yatharth #tabs.snap-mode .tab.active.colored:not(.tab-blocked):hover { background: color-mix(in srgb, var(--chip-bg) 15%, transparent); }
 #footer {
   position: relative;   /* anchors #composer-resize on the top-edge divider */
   flex: 0 0 auto;
@@ -4108,7 +4115,7 @@ body.dense-chrome .tab-add { padding: 3px 8px; font-size: 1.1em; }              
    the 18px line + 2 x 3px dense padding + the 1px border; #tabs stretches every item on a row to the tallest, so
    without this the row holding the + and the tag control would stay 31px beside 25px rows */
 body.dense-chrome .tab-tagbox { min-height: 25px; }                                     /* 31px */
-body.dense-chrome .tab-group-head { gap: 4px; padding: 3px 5px 3px 4px; }               /* 5px; 6px 7px 6px 6px */
+body.dense-chrome .tab-group-head { gap: 4px; padding: 3px 5px; }                       /* 5px; 6px 7px — the dense tab's own padding, so the row keeps a tab's box here too (T322) */
 /* the untagged trail's divider (the inline layout, stripGroupRows off): its 1px line is the content area under fixed
    gutters, so the 8px gutters sized for the 32px row would leave a 9px line in the 25px row; 6px keeps the default's
    half-row proportion (about 13px). Scoped off the row break, which must keep no footprint; the width stays 13px,

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -104,6 +104,7 @@ body.scheme-solarized-dark {
   /* THE faint accent wash — the one alpha behind every selected/hovered accent chrome (0.10 and 0.14
      variants drifted in before 2026-08-26). Mirrored in feed.css (own :root). */
   --accent-wash: rgba(156, 210, 255, 0.12);
+  --tab-active-bg: rgba(255, 255, 255, 0.14);   /* the selected tab's fill, and the tag row's while its overview shows (T322) */
   /* the menu vocabulary (CLAUDE.md "Menus and dropdowns wear ONE vocabulary") — every dropdown's
      radius and shadow resolve through these; two menus had drifted onto their own shadows before
      2026-08-26. Mirrored in feed.css (own :root). */
@@ -244,6 +245,7 @@ body.theme-light {
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
+  --tab-active-bg: rgba(255, 255, 255, 0.14);   /* the same fill the dark tab wears: a whiter sheet over cream (T322) */
   --cmt-hl: #FFDF70;
   --cmt-hl-outline: #8f6a00;   /* amber ink: 4.2:1 on the cream page — the fill's yellow measures 1.1:1 there, invisible as a line (T310) */
   --fast: #D45500;
@@ -408,25 +410,23 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    insertion cue. 0.82em is the surface's sub-line size (the menus' sub-lines) — labels match labels,
    and nothing here nests an em inside it. Tokens only, so the header reads in every theme without a
    light override. */
-.tab-group-head { display: flex; flex: 0 0 auto; align-items: center; gap: 5px; padding: 6px 7px 6px 6px;
+.tab-group-head { display: flex; flex: 0 0 auto; align-items: center; gap: 5px; padding: 6px 7px;
   font-size: 0.82em; letter-spacing: 0.04em; color: var(--dim); cursor: pointer; white-space: nowrap;
   user-select: none; border-radius: 6px 6px 0 0; outline: none; }
-.tab-group-head:hover, .tab-group-head:focus-visible { color: var(--fg); }
-.tab-group-head:hover .tab-group-caret, .tab-group-head:focus-visible .tab-group-caret { color: var(--accent); }
-/* the chip's fold cue (T251b): a brightness lift keeps the tag's identity colour (a --fg swap would erase
-   it) and, unlike a background wash, is a property the chip's inline style never sets — so the rule wins
-   by construction; the uncoloured "(no tags)" chip lifts from --dim toward --fg, the old label's exact cue */
-.tab-group-head:hover .tab-group-chip, .tab-group-head:focus-visible .tab-group-chip { filter: brightness(1.3); }
+/* A tag row is NOT a tab (T322, the user 2026-09-10): it takes a tab's allotment of space (the same 6px 7px padding
+   as .tab around the chip, the caret and the count; no border of its own, so a row never sets the strip's height,
+   a tab does — dense-chrome-layout.test.ts measures that) but wears none of a tab's dress — no hover lift of the
+   words, the caret or the chip, no wash, no rest outline. The keyboard's focus ring stays: it is not a dress, it
+   is where the focus is. */
 .tab-group-head:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
-/* the section holding the tab being read, open or folded: it folds like any other (its cursor promises the
-   click), and its header says whose it is by the tag's chip, accent-underlined (the chip is coloured by
-   identity inline, which a colour rule cannot reach; the underline is a property it never sets), so the
-   header that stands in for a folded-away tab is found by the same mark it wore while open. Distinct from
-   the hover lift (a fold cue) and from .snap-shown (the pane shows the section). */
-.tab-group-head.holds-active .tab-group-chip { text-decoration: underline; text-decoration-color: var(--accent); text-underline-offset: 2px; }
-/* the section whose sessions the pane is SHOWING at a glance (render.ts sets .snap-shown on its header): the
-   accent wash the picker's active row wears, on the header the chip's inline style never reaches */
-.tab-group-head.snap-shown { background: var(--accent-wash); }
+/* the section holding the tab being read wears NO mark of its own any more (T322, the user 2026-09-10: the
+   accent underline on the tag's chip read as a second selection): the highlight on the tab itself says which
+   session is active. The class stays (aria-current, the folded stand-in's focus and arrows key on it). */
+/* the section whose sessions the pane is SHOWING at a glance (render.ts sets .snap-shown on its header) wears
+   the SELECTED TAB's box (T322): the same fill token .tab.active wears and the same inset identity ring
+   .tab.active.colored wears (--chip-bg, set inline from the tag's colour by makeGroupHead), so the one selected
+   thing on the strip, tab or row, always looks the same; no tab is selected while it shows (body.snap-mode). */
+.tab-group-head.snap-shown { color: var(--fg); background: var(--tab-active-bg); box-shadow: inset 0 0 0 1.5px var(--chip-bg, transparent); }
 .tab-group-head.dragging { opacity: 0.45; }
 .tab-group-head.drop-target { box-shadow: inset 2px 0 0 var(--accent); }
 /* the disclosure chevron: ▸ folded, turned down while open — the fold-caret idiom (a CSS transition on
@@ -614,7 +614,7 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
    background everywhere). No identity tint at any state, the
    thick 1.5px inset identity ring on the selected tab, the neutral line under the strip. The
    Yatharth theme below is the opt-in restoration of the contributor's merged strip aesthetic. */
-.tab.active { color: var(--fg); background: rgba(255, 255, 255, 0.14); }
+.tab.active { color: var(--fg); background: var(--tab-active-bg); }
 /* T123 (the user 2026-08-27, redirecting T118's resting-tab distinction — the merged 2% fill
    came out for this): resting tabs wear a SUPER-THIN outline at all times, no fill — the tab body
    stays the dark background, ringed by 1px in EXACTLY the gray the hover fill uses
@@ -1018,6 +1018,14 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .bg-deeper { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); white-space: nowrap; }
 .sub-head-waits { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }   /* the viewer header's "· waiting on …" tail */
 
+/* THE OVERVIEW IS A MODE, NOT A SESSION (T322, the user 2026-09-10, twice): while a tag's overview shows
+   (body.snap-mode, set by showActive), the message box and the bottom bar go entirely — a message typed here
+   has no session to go to — and no tab renders as selected: the row's box (.tab-group-head.snap-shown) is the
+   one selection on the strip. The active tab's classes stay (activeId is the way back; focus and the arrows key
+   on them), only its dress is neutralised to a resting tab's. Selecting any tab clears the mode (setActive). */
+body.snap-mode #footer { display: none; }
+body.snap-mode #tabs .tab.active { color: var(--dim); background: transparent; box-shadow: none; }
+body.snap-mode:not(.chat-theme-yatharth) #tabs .tab.active:not(.tab-blocked):not(.tab-add) { border-color: rgba(255, 255, 255, 0.06); }
 #footer {
   position: relative;   /* anchors #composer-resize on the top-edge divider */
   flex: 0 0 auto;
@@ -1272,7 +1280,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
    identity color inline. Tokens only, so it reads in every theme without a light override. */
 #tab-snapshot { padding: 6px 14px 14px; }
 .snap-head { display: flex; align-items: center; gap: 6px; margin: 4px 0 8px; font-size: 0.82em; font-weight: 600; letter-spacing: 0.04em; color: var(--dim); }
-.snap-swatch { flex: 0 0 auto; width: 3px; height: 12px; border-radius: 1px; background: var(--dim); }
+/* (the heading's colour bar is gone, T322: the tag's ordinary chip carries the colour, between the words "Overview of" and the count) */
 .snap-count { font-weight: 400; opacity: 0.7; }
 .snap-list { display: flex; flex-direction: column; gap: 2px; }
 .snap-row { display: flex; flex-wrap: wrap; align-items: center; gap: 2px 8px; width: 100%; min-width: 0; padding: 5px 8px; border: 1px solid transparent; border-radius: 6px;

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -228,7 +228,10 @@ test("executed + pinned: the section holding the ACTIVE tab folds like any other
   assert.match(head, /const words = headWords\(name, total, hidden\.length, collapsed, holdsActive, back, shown\);\s*\n\s*head\.title = words\.title;/, "the words are the pure module's");
   assert.ok(!RENDER.includes('"group-active"'), "no delegate handler for a no-op either");
   assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active \{ cursor: default; \}/, "the header folds, so its cursor promises the click");
-  assert.match(CSS, /\.tab-group-head\.holds-active \.tab-group-chip \{ text-decoration: underline; text-decoration-color: var\(--accent\);/, "the mark: the tag's chip accent-underlined");
+  // the holding row wears no mark of its own (T322, the user 2026-09-10: the chip's accent underline read as a second
+  // selection); the class stays for aria-current and the folded stand-in's focus and arrows
+  assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active \.tab-group-chip \{ text-decoration: underline/, "no underline on the holding row's chip");
+  assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active[^\n]*\{[^}]*(background|border|outline|text-decoration)/, "no dress of any kind on the holding row");
   // the hidden active tab's stand-in in render.ts: focus lands on the header, the arrows step from it, and a
   // pick of a folded-away session opens its section (tab-snapshot-pane.test.ts runs these)
   assert.match(RENDER, /const home = activeId \? homeSectionOf\(lastStripItems, activeId\) : null;\s*\n\s*if \(!home \|\| home\.name === null \|\| !bar\) return;\s*\n\s*Array\.from\(bar\.querySelectorAll<HTMLElement>\("\.tab-group-head"\)\)\.find\(\(h\) => h\.dataset\.group === home\.name\)\?\.focus\(\);/,
@@ -571,8 +574,8 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
     "…falling back to the active tab when the group is gone or now holds it");
   // hover/focus: the count brightens to --fg, the chevron takes the accent, and the CHIP brightens by a
   // filter on its own identity colour (T251b — a --fg swap would erase the tag) — no row wash ("select me")
-  assert.match(CSS, /\.tab-group-head:hover, \.tab-group-head:focus-visible \{ color: var\(--fg\); \}/);
-  assert.match(CSS, /\.tab-group-head:hover \.tab-group-chip, \.tab-group-head:focus-visible \.tab-group-chip \{ filter: brightness\(1\.3\); \}/);
+  assert.doesNotMatch(CSS, /\.tab-group-head:hover/, "no hover lift on a tag row: it is not a tab (T322)");
+  assert.doesNotMatch(CSS, /\.tab-group-head:hover \.tab-group-chip/, "no brightness lift on hover either (T322)");
   {
     // the RENDERED outcome, not the sheet's text: the chip's inline style is what the header's colour rule
     // cannot reach (inline beats class), so the cue must be a property the chip never sets inline. Run the
@@ -599,8 +602,12 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
       assert.ok(!/font-size/.test(style), "and the header-hosted chip inherits the header's size");
     } finally { g.document = saved; g.window = savedWin; }
   }
-  assert.match(CSS, /\.tab-group-head:hover \.tab-group-caret, \.tab-group-head:focus-visible \.tab-group-caret \{ color: var\(--accent\); \}/);
-  for (const m of CSS.matchAll(/\n\.tab-group-head:hover[^{\n]*\{([^}]*)\}/g)) assert.doesNotMatch(m[1], /background/, "no wash on hover");
+  // a tag row is not a tab (T322): no hover dress at all — no lift of the words, the caret or the chip, no wash — only
+  // the keyboard's focus ring; and it takes a tab's box of space (the same padding and transparent border as .tab)
+  assert.doesNotMatch(CSS, /\n\.tab-group-head:hover/, "no hover rule on the row");
+  assert.match(CSS, /\n\.tab-group-head \{[^}]*padding: 6px 7px;[^}]*border-radius: 6px 6px 0 0;/s, "a tab's allotment: .tab's padding around the chip, the caret and the count");
+  assert.match(CSS, /\n\.tab \{[^}]*padding: 6px 7px;/s, "…the tab's own");
+  assert.doesNotMatch(CSS.match(/\n\.tab-group-head \{([^}]*)\}/)![1], /border:|background/, "no border, no fill: empty around the parts");
   assert.match(CSS, /\.tab-group-head:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/);
   assert.match(head, /head\.draggable = true;/, "still drags to reorder the groups");
   assert.match(head, /head\.dataset\.act = "toggle-group";/, "…and still folds through the delegate");
@@ -609,7 +616,7 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
   // --accent against --bg in both themes); --accent-wash is the shown section's header (the pane shows it:
   // .snap-shown), the wash the picker's active row already wears
   const rules = Array.from(CSS.matchAll(/\n(\.tab-group-[^{\n]*)\{([^}]*)\}/g));
-  assert.ok(rules.length >= 15, "the section rules were found: " + rules.length);
+  assert.ok(rules.length >= 12, "the section rules were found: " + rules.length);   // the hover dress rules left with T322
   for (const [, sel, body] of rules) {
     // no exception any more (2026-09-08): the retrying amber is a token, --st-retrying-bg, on the pip AND the tab
     assert.doesNotMatch(body.replace(/var\([^)]*\)/g, "V"), /#[0-9a-fA-F]{3,8}\b|rgba?\(/, "a raw color in " + sel.trim());
@@ -617,7 +624,7 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
   assert.equal(CSS.match(/\.tab-group-pip\.retrying \{ background: (var\(--st-retrying-bg\)); \}/)![1], CSS.match(/\.tab\.tab-retrying \{ --state: (var\(--st-retrying-bg\)); \}/)![1],
     "the pip's retrying amber IS the tab's — the same status token");
   const toks = new Set((rules.map((m) => m[2]).join(" ").match(/var\((--[a-z-]+)/g) || []).map((m) => m.slice(4)));
-  for (const t of toks) assert.ok(["--fg", "--dim", "--accent", "--accent-wash", "--box-border", "--st-working-bg", "--st-blocked-bg", "--st-retrying-bg"].includes(t), "a token the strip does not already wear: " + t);
+  for (const t of toks) assert.ok(["--fg", "--dim", "--accent", "--accent-wash", "--box-border", "--st-working-bg", "--st-blocked-bg", "--st-retrying-bg", "--tab-active-bg", "--chip-bg"].includes(t), "a token the strip does not already wear: " + t);
 });
 
 // SHOW WHEN FOLDED (the user 2026-09-06): a member pinned to its section keeps its tab on the strip

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -572,14 +572,12 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
     "captured before the tab rule (chat-focus-model.test pins that rule's two-line shape)");
   assert.match(RENDER, /if \(h && h\.tabIndex >= 0\) h\.focus\(\); else focusActiveTab\(\);/,
     "…falling back to the active tab when the group is gone or now holds it");
-  // hover/focus: the count brightens to --fg, the chevron takes the accent, and the CHIP brightens by a
-  // filter on its own identity colour (T251b — a --fg swap would erase the tag) — no row wash ("select me")
   assert.doesNotMatch(CSS, /\.tab-group-head:hover/, "no hover lift on a tag row: it is not a tab (T322)");
   assert.doesNotMatch(CSS, /\.tab-group-head:hover \.tab-group-chip/, "no brightness lift on hover either (T322)");
   {
-    // the RENDERED outcome, not the sheet's text: the chip's inline style is what the header's colour rule
-    // cannot reach (inline beats class), so the cue must be a property the chip never sets inline. Run the
-    // real builder against a stub document and read the style it writes.
+    // the RENDERED outcome, not the sheet's text: the chip's inline style is what the shown row's colour rule
+    // cannot reach (inline beats class), and the row-hosted chip takes the row's size. Run the real builder
+    // against a stub document and read the style it writes.
     const created: { tag: string; attrs: Record<string, string>; kids: unknown[] }[] = [];
     const g = globalThis as any;
     const saved = g.document;
@@ -597,8 +595,7 @@ test("the header's structure and gestures read as a label: the tag's chip, then 
       const { tagChip } = require("./tag-menu");
       const chip = tagChip("infra", "#54B204", { inheritSize: true });
       const style: string = chip.attrs.style;
-      assert.match(style, /color:#54B204;/, "the identity colour rides inline — the header's --fg rule cannot recolour it…");
-      assert.ok(!/filter\s*:/.test(style), "…so the fold cue is a FILTER, a property the chip never sets inline: the class rule wins by construction");
+      assert.match(style, /color:#54B204;/, "the identity colour rides inline — the shown row's --fg rule cannot recolour it");
       assert.ok(!/font-size/.test(style), "and the header-hosted chip inherits the header's size");
     } finally { g.document = saved; g.window = savedWin; }
   }

--- a/ui/webview/tab-overview-mode.test.ts
+++ b/ui/webview/tab-overview-mode.test.ts
@@ -46,9 +46,12 @@ test("2. the overview's title: 'Overview of', the tag's ordinary chip from tagCh
 test("3 and 6. the overview is a mode: the message box and the bottom bar are gone while it shows", () => {
   assert.match(CSS, /body\.snap-mode #footer \{ display: none; \}/, "the whole footer: the message box and the session's bottom bar");
   const show = fn("function showActive(");
-  assert.match(show, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*document\.body\.classList\.add\("snap-mode"\);/, "set as the overview paints");
-  assert.match(show, /return;\s*\n\s*\}\s*\n\s*document\.body\.classList\.remove\("snap-mode"\);/, "cleared on the transcript path of the same function");
-  assert.match(fn("function hideSnapshot(): void {"), /document\.body\.classList\.remove\("snap-mode"\);/, "and on every exit that hides the view");
+  assert.match(show, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*setSnapMode\(true\);/, "set as the overview paints");
+  assert.match(show, /return;\s*\n\s*\}\s*\n\s*setSnapMode\(false\);/, "cleared on the transcript path of the same function");
+  assert.match(fn("function hideSnapshot(): void {"), /setSnapMode\(false\);/, "and on every exit that hides the view");
+  // one switch, two carriers: the body (the footer, the Classic neutraliser) and the strip (the Yatharth tint rule must
+  // start with the theme's body class, so it reads the mode off #tabs)
+  assert.match(fn("function setSnapMode(on: boolean): void {"), /document\.body\.classList\.toggle\("snap-mode", on\);\s*\n\s*document\.getElementById\("tabs"\)\?\.classList\.toggle\("snap-mode", on\);/);
   // the keyboard agrees: Enter on a folded stand-in drops into the message box only while no overview shows
   assert.match(RENDER, /if \(e\.key === "Enter" && standIn && !snapView && focusComposerOrAsk\(\)\)/);
 });
@@ -74,8 +77,23 @@ test("4. a tag row is not a tab: a tab's box of space, no dress; its overview sh
 });
 
 test("5. no tab renders as selected while the overview shows; selecting any tab clears it", () => {
-  assert.match(CSS, /body\.snap-mode #tabs \.tab\.active \{ color: var\(--dim\); background: transparent; box-shadow: none; \}/, "the active tab's dress neutralised to a resting tab's");
+  // the neutralised active tab is a RESTING tab of its theme: a hard-blocked tab keeps its red fill (the standing rule),
+  // hover still lifts it, and Yatharth's resting wash replaces that theme's 55% selection border
+  assert.match(CSS, /body\.snap-mode #tabs \.tab\.active:not\(\.tab-blocked\) \{ color: var\(--dim\); background: transparent; box-shadow: none; \}/, "the active tab's dress neutralised to a resting tab's, the blocked fill excepted");
+  assert.match(CSS, /body\.snap-mode #tabs \.tab\.active:not\(\.tab-blocked\):hover \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.06\); \}/, "hover lifts it like any resting tab");
   assert.match(CSS, /body\.snap-mode:not\(\.chat-theme-yatharth\) #tabs \.tab\.active:not\(\.tab-blocked\):not\(\.tab-add\) \{ border-color: rgba\(255, 255, 255, 0\.06\); \}/, "…rest outline included, the tab rule's own gray");
+  const rest = CSS.match(/body\.chat-theme-yatharth \.tab\.colored:not\(\.tab-blocked\) \{[^}]*background: ([^;]+);/)![1];
+  assert.match(CSS, new RegExp("body\\.chat-theme-yatharth #tabs\\.snap-mode \\.tab\\.active\\.colored:not\\(\\.tab-blocked\\) \\{ background: " + rest.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "; border-color: transparent; \\}"), "Yatharth: the theme's own resting wash, no selection border");
+  assert.doesNotMatch(CSS, /body\.snap-mode #tabs \.tab\.active \{/, "no rule neutralises a blocked tab's fill");
+  // the faded-label exemption for the active tab stands down in the mode: no residual selection cue among faded siblings
+  assert.match(RENDER, /if \(s\.status\.faded && \(id !== activeId \|\| snapView\) && s\.color\) \{/);
+  // the footer's hide is not a box below the reader: the boxes-below follow rule stands down while the overview owns #content
+  assert.match(RENDER, /if \(content && !snapView && lastH >= 0 && content\.clientHeight > 0 && v && v\.shown && followBoxBelow\(v\.stick, h - lastH\)\) \{/);
+  // leaving the overview re-measures the message box, which a pick's draft swap measured under display:none
+  assert.match(fn("function showActive("), /const wasSnap = document\.body\.classList\.contains\("snap-mode"\);[\s\S]*if \(wasSnap\) \{[^}]*growComposer\(ta\);/);
+  // dense chrome mirrors the row's tab box too
+  assert.match(CSS, /body\.dense-chrome \.tab-group-head \{ gap: 4px; padding: 3px 5px; \}/);
+  assert.match(CSS, /body\.dense-chrome \.tab \{ gap: 3px; padding: 3px 5px;/);
   // the class itself stays on the tab: activeId is the way back, focus and the arrows key on it
   assert.match(RENDER, /const tab = el\("div", "tab" \+ \(id === activeId \? " active" : ""\)\);/);
   // a pick clears the view (setActive), as before

--- a/ui/webview/tab-overview-mode.test.ts
+++ b/ui/webview/tab-overview-mode.test.ts
@@ -1,0 +1,84 @@
+// T322 (the user 2026-09-10): the tab strip grouped by tag, one tag per row, and the section-at-a-glance view.
+// Six points, pinned at the source (the executed harnesses live in tab-groups.test.ts and tab-snapshot-pane.test.ts):
+//   1. a session picked inside an expanded tag row no longer underlines the row's tag chip: the tab's own
+//      highlight says which is active;
+//   2. the overview's title is the words "Overview of", the tag as its ordinary chip (tagChip, tag-menu.ts) and the
+//      session count, not the tag's name beside a little colour bar;
+//   3 and 6. while the overview shows, the message box disappears entirely: it is a mode, not a session;
+//   4. a tag row is not a tab: a tab's box of space around the chip, the caret and the count, no hover dress, no
+//      wash, no borders; and while its overview shows, the row wears the selected tab's box;
+//   5. no tab renders as selected while the overview shows; selecting any tab clears the overview.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = read("render.ts");
+const CSS = read("styles.css");
+const SNAP = read("tab-snapshot.ts");
+
+function fn(name: string): string {
+  const at = RENDER.indexOf(name);
+  assert.ok(at > 0, name + " exists");
+  return RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+}
+
+test("1. the holding row's chip wears no underline; the class stays for the stand-in's focus and aria-current", () => {
+  assert.doesNotMatch(CSS, /\.holds-active[^\n{]*\{[^}]*text-decoration/, "no underline rule keyed on holds-active");
+  const head = fn("function makeGroupHead(");
+  assert.match(head, /\+ \(holdsActive \? " holds-active" : ""\)\);/, "the class is still set…");
+  assert.match(head, /if \(holdsActive\) head\.setAttribute\("aria-current", "true"\);/, "…for assistive tech and the folded stand-in");
+});
+
+test("2. the overview's title: 'Overview of', the tag's ordinary chip from tagChip, the count; no colour bar", () => {
+  const rs = fn("function renderSnapshot(): boolean {");
+  assert.match(rs, /const of = el\("span", "snap-of"\); of\.textContent = "Overview of";/);
+  assert.match(rs, /h\.append\(of, el\("span", "snap-chip-slot"\), el\("span", "snap-count"\)\);/, "words, chip slot, count — in that order");
+  assert.match(rs, /const chip = tagChip\(next\.name, next\.color, \{ inheritSize: true \}\); chip\.classList\.add\("snap-chip"\);/, "the shared tag chip builder, sized by the heading");
+  assert.match(rs, /part\("snap-chip-slot"\)\.replaceChildren\(chip\);/, "patched in place on every paint, like the count");
+  assert.doesNotMatch(rs, /snap-swatch|snap-name/, "the colour bar and the bare name are gone");
+  assert.doesNotMatch(CSS, /\n\.snap-swatch \{/, "no bar rule left");
+  assert.doesNotMatch(CSS, /\n\.snap-chip \{/, "no chip rule of the view's own: the chip's dress is tagChip's alone");
+  assert.match(SNAP, /label: `Overview of \$\{name\}: \$\{count\}; click one to open it`/, "the spoken label says the same words");
+});
+
+test("3 and 6. the overview is a mode: the message box and the bottom bar are gone while it shows", () => {
+  assert.match(CSS, /body\.snap-mode #footer \{ display: none; \}/, "the whole footer: the message box and the session's bottom bar");
+  const show = fn("function showActive(");
+  assert.match(show, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*document\.body\.classList\.add\("snap-mode"\);/, "set as the overview paints");
+  assert.match(show, /return;\s*\n\s*\}\s*\n\s*document\.body\.classList\.remove\("snap-mode"\);/, "cleared on the transcript path of the same function");
+  assert.match(fn("function hideSnapshot(): void {"), /document\.body\.classList\.remove\("snap-mode"\);/, "and on every exit that hides the view");
+  // the keyboard agrees: Enter on a folded stand-in drops into the message box only while no overview shows
+  assert.match(RENDER, /if \(e\.key === "Enter" && standIn && !snapView && focusComposerOrAsk\(\)\)/);
+});
+
+test("4. a tag row is not a tab: a tab's box of space, no dress; its overview shown, the selected tab's box", () => {
+  const row = CSS.match(/\n\.tab-group-head \{([^}]*)\}/)![1];
+  const tab = CSS.match(/\n\.tab \{([^}]*)\}/)![1];
+  for (const prop of ["padding: 6px 7px;", "border-radius: 6px 6px 0 0;"]) {
+    assert.ok(row.includes(prop), "the row has a tab's " + prop); assert.ok(tab.includes(prop), "…as the tab does: " + prop);
+  }
+  assert.doesNotMatch(row, /background|border:/, "empty around the chip, the caret and the count: no fill, no border of its own (a tab sets the strip's height)");
+  assert.doesNotMatch(CSS, /\n\.tab-group-head:hover/, "no hover lift, wash or border");
+  assert.match(CSS, /\.tab-group-head:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/, "the keyboard's focus ring is not a dress");
+  // the shown row wears exactly the selected tab's box: the same fill token and the same inset identity ring
+  assert.match(CSS, /\.tab-group-head\.snap-shown \{ color: var\(--fg\); background: var\(--tab-active-bg\); box-shadow: inset 0 0 0 1\.5px var\(--chip-bg, transparent\); \}/);
+  assert.match(CSS, /\.tab\.active \{ color: var\(--fg\); background: var\(--tab-active-bg\); \}/);
+  assert.match(CSS, /\.tab\.active\.colored \{ box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\); \}/);
+  assert.match(fn("function makeGroupHead("), /if \(sec\.color\) head\.style\.setProperty\("--chip-bg", sec\.color\);/, "the tag's colour as the row's --chip-bg, the tab's own variable");
+  // the token in both themes (theme-parity.test.ts checks every :root token has a light twin)
+  const dark = CSS.split("body.theme-light {")[0], light = CSS.split("body.theme-light {")[1].split("\n}")[0];
+  assert.match(dark, /--tab-active-bg: rgba\(255, 255, 255, 0\.14\);/); assert.match(light, /--tab-active-bg: /);
+  assert.doesNotMatch(CSS, /\.tab-group-head\.snap-shown \{ background: var\(--accent-wash\); \}/, "the accent wash is gone");
+});
+
+test("5. no tab renders as selected while the overview shows; selecting any tab clears it", () => {
+  assert.match(CSS, /body\.snap-mode #tabs \.tab\.active \{ color: var\(--dim\); background: transparent; box-shadow: none; \}/, "the active tab's dress neutralised to a resting tab's");
+  assert.match(CSS, /body\.snap-mode:not\(\.chat-theme-yatharth\) #tabs \.tab\.active:not\(\.tab-blocked\):not\(\.tab-add\) \{ border-color: rgba\(255, 255, 255, 0\.06\); \}/, "…rest outline included, the tab rule's own gray");
+  // the class itself stays on the tab: activeId is the way back, focus and the arrows key on it
+  assert.match(RENDER, /const tab = el\("div", "tab" \+ \(id === activeId \? " active" : ""\)\);/);
+  // a pick clears the view (setActive), as before
+  const sa = fn("function setActive(");
+  assert.match(sa, /const leavingSnap = snapView !== null;\s*\n\s*snapView = null;/);
+});

--- a/ui/webview/tab-snapshot-pane.test.ts
+++ b/ui/webview/tab-snapshot-pane.test.ts
@@ -604,7 +604,7 @@ test("executed: the nav trail records the reader's spot while the view shows: th
 test("pinned: the wiring the lifted slices cannot reach: showActive's branch, the exits, setActive's pick, the strip's follow", () => {
   // showActive: while a section shows, every transcript is hidden, the reader's place held, the composer disabled with a
   // placeholder that says what to do; the transcript path hides the host first
-  assert.match(SHOW, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*document\.body\.classList\.add\("snap-mode"\);[^\n]*\n\s*for \(const v of views\.values\(\)\) v\.el\.style\.display = "none";/, "the mode class first (the message box goes, no tab selected), then the views hide");
+  assert.match(SHOW, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*setSnapMode\(true\);[^\n]*\n\s*for \(const v of views\.values\(\)\) v\.el\.style\.display = "none";/, "the mode switch first (the message box goes, no tab selected), then the views hide");
   assert.match(SHOW, /const av = activeId \? views\.get\(activeId\) : null;\s*\n\s*if \(av && !snapKeep\) snapKeep = \{ v: av, scrollTop: av\.scrollTop, stick: av\.stick \};/, "the reader's place, once per visit");
   assert.match(SHOW, /if \(av && snapKeep && snapKeep\.v !== av\) \{\s*\n\s*snapKeep\.v\.scrollTop = snapKeep\.scrollTop; snapKeep\.v\.stick = snapKeep\.stick;\s*\n\s*snapKeep = \{ v: av, scrollTop: av\.scrollTop, stick: av\.stick \};\s*\n\s*\}/, "the active changed under the view (the session being read closed): the survivor's place is held instead");
   assert.match(SHOW, /if \(ta\) \{ ta\.disabled = true; ta\.placeholder = "Pick a session above to write to it"; \}/);

--- a/ui/webview/tab-snapshot-pane.test.ts
+++ b/ui/webview/tab-snapshot-pane.test.ts
@@ -62,7 +62,7 @@ class FakeEl {
   tag: string; id = ""; className: string; children: FakeEl[] = []; parent: FakeEl | null = null;
   dataset: Record<string, string> = {}; attrs: Record<string, string> = {}; listeners: Record<string, Function[]> = {};
   textContent = ""; title = ""; tabIndex = -1; type = ""; disabled = false; scrollTop = 0; draggable = false;
-  style: Record<string, string> = { display: "", background: "", color: "" };
+  style: Record<string, any> = { display: "", background: "", color: "", setProperty(k: string, v: string) { (this as Record<string, string>)[k] = v; } };   // setProperty: the row's --chip-bg (T322)
   classList: { add: (...c: string[]) => void; remove: (...c: string[]) => void; contains: (c: string) => boolean; toggle: (c: string, on?: boolean) => void };
   constructor(tag: string, cls = "") {
     this.tag = tag; this.className = cls;
@@ -265,10 +265,15 @@ test("executed: the view paints one row per member from the model: heading, keye
   const host = content.byId("tab-snapshot")!;
   assert.ok(host, "the host hangs off #content");
   assert.equal(host.getAttribute("role"), "region"); assert.equal(host.style.display, "");
-  assert.equal(host.getAttribute("aria-label"), "infra: 2 sessions; click one to open it");
+  assert.equal(host.getAttribute("aria-label"), "Overview of infra: 2 sessions; click one to open it");
   const head = host.children[0];
-  assert.deepEqual([head.tag, head.className, head.children.map((c) => c.className)], ["h2", "snap-head", ["snap-swatch", "snap-name", "snap-count"]]);
-  assert.equal(head.children[0].style.background, "#4EC9B0"); assert.equal(head.children[1].textContent, "infra"); assert.equal(head.children[2].textContent, "2 sessions");
+  // "Overview of <the tag's ordinary chip> <count>" (T322): the words, the chip slot holding tagChip's pill, the count
+  assert.deepEqual([head.tag, head.className, head.children.map((c) => c.className)], ["h2", "snap-head", ["snap-of", "snap-chip-slot", "snap-count"]]);
+  assert.equal(head.children[0].textContent, "Overview of");
+  const chip = head.children[1].children[0];
+  assert.ok(chip.has("snap-chip"), "the chip carries the view's class: " + chip.className); assert.equal(chip.text(), "infra", "the tag's name in the chip");
+  assert.ok(chip.has("tag-chip"), "built by tagChip (the world's stub marks its pills): " + chip.className);
+  assert.equal(head.children[2].textContent, "2 sessions");
   const items = rowsOf(host);
   assert.deepEqual(items.map((i) => [i.getAttribute("role"), i.dataset.id]), [["listitem", "web"], ["listitem", "api"]], "keyed by the session id, in strip order");
   const [web, api_] = items.map((i) => i.children[0]);
@@ -322,7 +327,7 @@ test("executed: a push that changes nothing a row shows moves nothing: the same 
   assert.equal(after[0], webItem, "web's node stands");
   assert.deepEqual([after[1].children[0].className, after[1].children[0].getAttribute("aria-label")], ["snap-row loading", "tests; opening"], "a placeholder tab (its meta alone) is a loading row");
   assert.equal(after[1].children[0].querySelector(".snap-now")!.textContent, "opening…");
-  assert.equal(host.getAttribute("aria-label"), "infra: 2 sessions; click one to open it");
+  assert.equal(host.getAttribute("aria-label"), "Overview of infra: 2 sessions; click one to open it");
 });
 
 test("executed: focus survives the push that changes the rows: a moved row is re-focused on its own node, a removed row hands focus to the row in its place", () => {
@@ -599,7 +604,7 @@ test("executed: the nav trail records the reader's spot while the view shows: th
 test("pinned: the wiring the lifted slices cannot reach: showActive's branch, the exits, setActive's pick, the strip's follow", () => {
   // showActive: while a section shows, every transcript is hidden, the reader's place held, the composer disabled with a
   // placeholder that says what to do; the transcript path hides the host first
-  assert.match(SHOW, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*for \(const v of views\.values\(\)\) v\.el\.style\.display = "none";/);
+  assert.match(SHOW, /if \(snapView && renderSnapshot\(\)\) \{\s*\n\s*document\.body\.classList\.add\("snap-mode"\);[^\n]*\n\s*for \(const v of views\.values\(\)\) v\.el\.style\.display = "none";/, "the mode class first (the message box goes, no tab selected), then the views hide");
   assert.match(SHOW, /const av = activeId \? views\.get\(activeId\) : null;\s*\n\s*if \(av && !snapKeep\) snapKeep = \{ v: av, scrollTop: av\.scrollTop, stick: av\.stick \};/, "the reader's place, once per visit");
   assert.match(SHOW, /if \(av && snapKeep && snapKeep\.v !== av\) \{\s*\n\s*snapKeep\.v\.scrollTop = snapKeep\.scrollTop; snapKeep\.v\.stick = snapKeep\.stick;\s*\n\s*snapKeep = \{ v: av, scrollTop: av\.scrollTop, stick: av\.stick \};\s*\n\s*\}/, "the active changed under the view (the session being read closed): the survivor's place is held instead");
   assert.match(SHOW, /if \(ta\) \{ ta\.disabled = true; ta\.placeholder = "Pick a session above to write to it"; \}/);
@@ -631,9 +636,9 @@ test("pinned: the wiring the lifted slices cannot reach: showActive's branch, th
 });
 
 test("pinned: the sheet: the shown header's wash and the stand-in's mark on the tab-group rules; the view's two sizes, tokens only, the tab's state colors on the pip", () => {
-  assert.match(CSS, /\.tab-group-head\.snap-shown \{ background: var\(--accent-wash\); \}/, "the shown section's header wears the accent wash");
+  assert.match(CSS, /\.tab-group-head\.snap-shown \{ color: var\(--fg\); background: var\(--tab-active-bg\); box-shadow: inset 0 0 0 1\.5px var\(--chip-bg, transparent\); \}/, "the shown section's row wears the SELECTED TAB's box (T322): its fill token and its inset identity ring");
   assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active \{ cursor: default; \}/, "the header folds, so its cursor promises the click");
-  assert.match(CSS, /\.tab-group-head\.holds-active \.tab-group-chip \{ text-decoration: underline; text-decoration-color: var\(--accent\);/, "the stand-in's mark: the tag's chip accent-underlined");
+  assert.doesNotMatch(CSS, /\.tab-group-head\.holds-active \.tab-group-chip \{ text-decoration: underline/, "the stand-in wears no mark of its own (T322): the tab's highlight says which session is active");
   const block = CSS.slice(CSS.indexOf("#tab-snapshot {"), CSS.indexOf(".snap-when {") + 200);
   assert.ok(block.length > 200, "the sheet was found");
   assert.deepEqual([...new Set(block.match(/font-size: [^;]+/g))], ["font-size: 0.82em"], "one sub-line size, the header's; the rest inherit the body");

--- a/ui/webview/tab-snapshot.test.ts
+++ b/ui/webview/tab-snapshot.test.ts
@@ -192,7 +192,7 @@ test("executed: new information yields a NEW model: a state change, a new event,
 });
 
 test("executed: the words: the heading's count and label, the row's spoken label and hover title", () => {
-  assert.deepEqual(snapshotHeading("infra", 3), { count: "3 sessions", label: "infra: 3 sessions; click one to open it" });
+  assert.deepEqual(snapshotHeading("infra", 3), { count: "3 sessions", label: "Overview of infra: 3 sessions; click one to open it" });
   assert.equal(snapshotHeading("qa", 1).count, "1 session");
   const m = snapshotModel(sec, look(sessions), look(ledgers), null);
   assert.equal(rowWords(m.rows[0]).label, "web; working; Add the notes list page; its note: editing the list page template", "the task first, the note last, named as the session's own");

--- a/ui/webview/tab-snapshot.ts
+++ b/ui/webview/tab-snapshot.ts
@@ -226,10 +226,11 @@ export function snapshotModel(sec: SnapSectionLike, session: (id: string) => Sna
   return prev && sameModel(prev, next) ? prev : next;
 }
 
-/** The heading's words: the section's name and its count, and the spoken label for the region. */
+/** The heading's words: the count, and the spoken label for the region — "Overview of <tag>: N sessions", the
+ *  words the heading shows (T322: "Overview of", the tag's chip, the count). */
 export function snapshotHeading(name: string, n: number): { count: string; label: string } {
   const count = `${n} session${n === 1 ? "" : "s"}`;
-  return { count, label: `${name}: ${count}; click one to open it` };
+  return { count, label: `Overview of ${name}: ${count}; click one to open it` };
 }
 
 /** A row's spoken label (name, needs you, state, what it is doing, its own note) and its hover title.

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -41,7 +41,8 @@ test("the theme applies LIVE through the scheme plumbing — a body class, no re
 test("Classic: the pre-720 strip verbatim — line, gap 0, gray active fill, ring, stand-down", () => {
   assert.match(CSS, /border-bottom: 1px solid var\(--box-border\);/);
   assert.match(CSS, /#tabs \{ display: flex; flex: 1 1 auto; flex-wrap: wrap; align-items: stretch; gap: 0; position: relative; \}/);
-  assert.match(CSS, /\.tab\.active \{ color: var\(--fg\); background: rgba\(255, 255, 255, 0\.14\); \}/);
+  assert.match(CSS, /\.tab\.active \{ color: var\(--fg\); background: var\(--tab-active-bg\); \}/, "the gray active fill, as the token the tag row's selected box shares (T322)");
+  assert.match(CSS, /--tab-active-bg: rgba\(255, 255, 255, 0\.14\);/, "…which IS the pre-720 gray");
   assert.match(CSS, /\.tab\.active\.colored \{ box-shadow: inset 0 0 0 1\.5px var\(--chip-bg\); \}/);
   assert.match(CSS, /\.tab\.tab-blocked\.active\.colored \{ box-shadow: none; \}/, "blocked outranks the ring (2026-07-24)");
 });


### PR DESCRIPTION
Six points of the user's feedback (2026-09-10) on the tab strip grouped by tag, one tag per row, and a tag's overview.

## Design

- **No underline on the holding row's chip.** A session picked inside an expanded tag row used to accent-underline the row's tag chip; the tab's own highlight already says which session is active. The `holds-active` class stays for the folded stand-in's focus, arrows and `aria-current`.
- **The overview's title** is the words "Overview of", the tag as its ordinary chip (`tagChip` from tag-menu.ts, the same builder the strip's row and the tag menu use; no chip rule of the view's own) and the session count, in place of the name beside a little colour bar. The spoken label says the same words.
- **The overview is a mode, not a session.** While it shows, the message box disappears entirely: `body.snap-mode` is set as the overview paints and cleared on every path back to a transcript, and the whole footer goes with it (the session chip, the asks and the spend readout were already suppressed).
- **A tag row is not a tab.** It takes a tab's allotment of space around the chip, the caret and the count (the tab's own padding; no border of its own, so a tab still sets the strip's height under dense chrome) and wears none of a tab's dress: no hover lift of the words, the caret or the chip, no wash, no rest outline. While its overview shows, the row wears the selected tab's box: the same fill token and the same inset identity ring (`--chip-bg` set inline from the tag's colour, as a tab sets it from its identity colour).
- **One selection on the strip.** No tab renders as selected while the overview shows: the active tab keeps its class (`activeId` is the way back; focus and the arrows key on it) but its dress is neutralised to a resting tab's. Selecting any tab clears the overview, as before.
- The selected tab's fill becomes a token, `--tab-active-bg`, declared in both themes, so the tab and the row have one source (the value is the pre-existing gray).

The tag chip's own rendering (weight, border, size, the off state) is untouched here: it belongs to T321.

## Tests

- `ui/webview/tab-overview-mode.test.ts`: the six points pinned at the source.
- `tab-groups`, `tab-snapshot-pane`, `tab-theme`, `dense-chrome` pins follow the changed rules; the executed snapshot heading now reads "Overview of", chip, count.
- `tests/test_tab_overview_mode_served.py`: the real `/chat` page of a hermetic kernel with four sessions under two tags. Measured: the holding chip's underline is none (dark and light), the row's box at rest is transparent with a tab's padding, the overview heading's three parts and the chip's colour, the footer gone and the active tab's fill transparent while the other tag's overview shows, the shown row wearing the fill token and the ring, and both back on a tab pick. With `SNAP_SHOTS` it writes the screenshots; with `SNAP_BEFORE_DIST` it drives the same page from another build for the before shots.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
