### PR TITLE
Feed: a card only for work the user asked for; a session's own workflows, review rounds and agents nest under the goal they ran in

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -134,6 +134,28 @@ coordinate/question mail, a bookkeeping record): the anchor substitutes the
 segment's first assistant atom. The clear wrap-up is exempt: its one
 blocked card is the designed needs-you escape.
 
+A card appears only for work that traces to something the user asked for (the
+user 2026-09-10, whose feed filled with cards titled after the workflows their
+sessions ran on their own). The origin rule at minting time, event first, text
+second: in a segment whose trigger is not a human ask (a seam tail a completion
+notification woke, an autonomous stretch), every top-level `mint` the planner
+files demotes to a step under the goal the turn ran in (the seam's own top, the
+segment's placement, else the open top nearest in words to the work); in a
+human-triggered segment the mints demote when the segment's assistant turns
+started background work by the event model's own criterion (a Workflow run, or an
+Agent or Task with `run_in_background` or an asynchronous ack; a foreground
+subagent the turn waited on is no launch), whatever they are called, and the ask
+itself keeps its card
+(the segment's placement, or the reply's first mint when the segment was planned
+in one work-run). Word overlap never decides top versus step: it only picks which
+launch supplies the step's one-line why, and which open goal is the parent when
+the turn ran in none. A demoted step carries `born` (`{kind: session, via:
+workflow | agent | work, why}`); with nothing the user asked for to nest under,
+the mint files nothing. A harness report (a background task's completion, a
+system reminder) or a teammate's line never appears under USER ASKED in the text
+the judges read and never roots a mint. `_demote_session_mints`,
+`_seg_launches`.
+
 **placer.** The second, scoped call, only when the chosen card already has
 open sub-goals: it sees just that card's subtree and picks the spot, biased
 to the highest level that makes sense. Most cards have no open sub-goals,

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -136,27 +136,27 @@ blocked card is the designed needs-you escape.
 
 A card appears only for work that traces to something the user asked for (the
 user 2026-09-10, whose feed filled with cards titled after the workflows their
-sessions ran on their own). The origin rule at minting time, event first, text
-second: in a segment whose trigger is not a human ask (a seam tail a completion
-notification woke, an autonomous stretch), every top-level `mint` the planner
-files demotes to a step under the goal the turn ran in (the seam's own top, the
-segment's placement, else the open top nearest in words to the work); in a
-human-triggered segment the mints demote when the segment's assistant turns
-started background work by the event model's own criterion (a Workflow run, or an
-Agent or Task with `run_in_background` or an asynchronous ack; a foreground
-subagent the turn waited on is no launch), whatever they are called, and the ask
-itself keeps its card:
-the mint the planner marks `"ask": true` (the deliverable the user's own message
-asked for), else the mint nearest the user's words, never one a launch's words
-fit better; a scheduled or programmatic prompt's mints are never demoted. Word
-overlap otherwise never decides top versus step: it only picks which
-launch supplies the step's one-line why, and which open goal is the parent when
-the turn ran in none. A demoted step carries `born` (`{kind: session, via:
-workflow | agent | work, why}`); with nothing the user asked for to nest under,
-the mint files nothing. A harness report (a background task's completion, a
-system reminder) or a teammate's line never appears under USER ASKED in the text
-the judges read and never roots a mint. `_demote_session_mints`,
-`_seg_launches`.
+sessions ran on their own). The planner labels every mint `kind`: `ask` (a
+deliverable the user's message asked for) or `process` (work the session started
+for itself: a review round, an audit, a workflow or agent it launched), and the
+rule at minting time trusts the labels: an ask keeps its card, on both the
+unplaced and the already-placed path; a process mint nests as a step under the
+goal the turn ran in (the seam's own top, the segment's placement, this reply's
+ask, else the open top nearest in words), carrying `born` (`{kind: session, via:
+workflow | agent | work, why, parentText}`), with the matching background launch
+(a Workflow run, or an Agent or Task with `run_in_background` or an asynchronous
+ack; a foreground subagent is no launch) supplying `via` and the why; with
+nothing to nest under it files nothing and the ops chained onto it go with it. A
+segment whose trigger is not a human ask (a seam tail a completion notification
+woke, an autonomous stretch) treats every mint as process; a scheduled or
+programmatic prompt is left untouched. A missing label is filled by the words
+alone: without a launch a mint is an ask; with one, every unlabelled mint is
+process except the one nearest the user's own words (its text against the
+message, never its why or its position), and only among the mints no launch
+fits better; when all read like a launch and a top exists, all nest. A harness
+report (a background task's completion, a system reminder) or a teammate's line
+never appears under USER ASKED in the text the judges read and never roots a
+mint. `_demote_session_mints`, `_seg_launches`.
 
 **placer.** The second, scoped call, only when the chosen card already has
 open sub-goals: it sees just that card's subtree and picks the spot, biased

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -145,9 +145,11 @@ human-triggered segment the mints demote when the segment's assistant turns
 started background work by the event model's own criterion (a Workflow run, or an
 Agent or Task with `run_in_background` or an asynchronous ack; a foreground
 subagent the turn waited on is no launch), whatever they are called, and the ask
-itself keeps its card
-(the segment's placement, or the reply's first mint when the segment was planned
-in one work-run). Word overlap never decides top versus step: it only picks which
+itself keeps its card:
+the mint the planner marks `"ask": true` (the deliverable the user's own message
+asked for), else the mint nearest the user's words, never one a launch's words
+fit better; a scheduled or programmatic prompt's mints are never demoted. Word
+overlap otherwise never decides top versus step: it only picks which
 launch supplies the step's one-line why, and which open goal is the parent when
 the turn ran in none. A demoted step carries `born` (`{kind: session, via:
 workflow | agent | work, why}`); with nothing the user asked for to nest under,

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -330,11 +330,13 @@ verdict: a peer's line, the agent's own record, romp bookkeeping; never a top th
 merely lacks an anchor) is rendered inside the session's human-asked top that was current
 when it was minted; word overlap with the transcript's recorded background
 launches only picks which launch supplies the why and, among several open tops,
-the parent. Hosts are the session's human-asked tops only, never a cleared one
-(completed ones still hold their rows). A blocked top keeps its card until the
-block lifts (needs-you breaks through) and still wears the face that says what
-it is; a live prompt or error floor that lands on a nested top shows on its
-host's card. Deterministic on the same store and stream
+the parent. Hosts are the asks that trace to the user: human-anchored tops and
+courier-planted delegated goals, never a handoff tracker; a completed host still
+holds its rows and a cleared host hides them with it. A blocked top keeps its
+card until the block lifts (needs-you breaks through) and still wears the face
+that says what it is; the top a live prompt or error floor stands on keeps its
+card too. The launch match reads the dispatch's own description, kept on the
+task record from launch time, never the completion's summary or the brief. Deterministic on the same store and stream
 (nothing moves between builds without a new record), never written back, and
 said once per rise on stderr. A tree row born
 of the session carries `born` with its why; a session-started root that still

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -330,10 +330,11 @@ verdict: a peer's line, the agent's own record, romp bookkeeping; never a top th
 merely lacks an anchor) is rendered inside the session's human-asked top that was current
 when it was minted; word overlap with the transcript's recorded background
 launches only picks which launch supplies the why and, among several open tops,
-the parent. A blocked top keeps its card until the block lifts (needs-you breaks
-through), a live prompt or error floor that lands on a nested top shows on its
-host's card, and a nested row stays with its host when the ask completes and
-goes with it when the user clears it. Deterministic on the same store and stream
+the parent. Hosts are the session's human-asked tops only, never a cleared one
+(completed ones still hold their rows). A blocked top keeps its card until the
+block lifts (needs-you breaks through) and still wears the face that says what
+it is; a live prompt or error floor that lands on a nested top shows on its
+host's card. Deterministic on the same store and stream
 (nothing moves between builds without a new record), never written back, and
 said once per rise on stderr. A tree row born
 of the session carries `born` with its why; a session-started root that still

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -327,7 +327,8 @@ Work a session started on its own is never a card of its own (the user
 judges' origin rule); for stores written before that rule, `build_feed` heals
 read-side: a top rooted in a machine record (the judge's latched `askAnchor`
 verdict: a peer's line, the agent's own record, romp bookkeeping; never a top that
-merely lacks an anchor) is rendered inside the session's human-asked top that was current
+merely lacks an anchor, and never a scheduled prompt's top, which the latch marks
+`scheduled` as the user's configured work) is rendered inside the session's human-asked top that was current
 when it was minted; word overlap with the transcript's recorded background
 launches only picks which launch supplies the why and, among several open tops,
 the parent. Hosts are the asks that trace to the user: human-anchored tops and

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -322,6 +322,26 @@ tree rolls UP, so the *top-level card* moves to BLOCKED and its modal shows whic
 leaf is blocking; likewise a completed step shows inside the modal, not as its own
 Completed card. No read-time DAG rebuild, no status derivation, no handoff repair.
 
+Work a session started on its own is never a card of its own (the user
+2026-09-10). At mint time the planner nests it under the goal it ran in (see the
+judges' origin rule); for stores written before that rule, `build_feed` heals
+read-side: a top rooted in a machine record (the judge's latched `askAnchor`
+verdict: a peer's line, the agent's own record, romp bookkeeping; never a top that
+merely lacks an anchor) is rendered inside the session's human-asked top that was current
+when it was minted; word overlap with the transcript's recorded background
+launches only picks which launch supplies the why and, among several open tops,
+the parent. A blocked top keeps its card until the block lifts (needs-you breaks
+through), a live prompt or error floor that lands on a nested top shows on its
+host's card, and a nested row stays with its host when the ask completes and
+goes with it when the user clears it. Deterministic on the same store and stream
+(nothing moves between builds without a new record), never written back, and
+said once per rise on stderr. A tree row born
+of the session carries `born` with its why; a session-started root that still
+shows (its parent gone, or no top to nest under) carries `sessionStarted` and
+its face says in one line what it is and, when known, the request it served.
+The awaiting panel's `local_workflow` / `local_agent` rows are the run's own
+place in the parent card.
+
 - A card's modal shows the goal's trail (its filed segments + sub-goal tree,
   interleaved).
 - **No caption stream.** Turn/segment captions are NOT feed cards — they live in the

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -220,6 +220,24 @@ def _result_text(content):
     return ""
 
 
+_WF_META_DESC_RE = re.compile(r"\b(description|name)\s*:\s*(['\"])(.*?)\2", re.S)
+
+
+def _launch_desc(name, inp):
+    """The dispatch's OWN words at launch time: an Agent/Task's description, a Workflow's meta description
+    (else its meta name) read off the script, else ''. Kept on the task row as `launchDesc` and never
+    overwritten by the completion notification, whose summary replaces `summary` when the run ends (T319: the
+    feed matches a session-started goal to the launch that produced it on these words)."""
+    inp = inp if isinstance(inp, dict) else {}
+    d = str(inp.get("description") or "").strip()
+    if not d and name == "Workflow":
+        meta = {m.group(1): m.group(3) for m in _WF_META_DESC_RE.finditer(str(inp.get("script") or "")[:4000])}
+        d = str(meta.get("description") or meta.get("name") or "").strip()
+        if not d and inp.get("scriptPath"):
+            d = os.path.splitext(os.path.basename(str(inp["scriptPath"])))[0]
+    return " ".join(d.split())[:200]
+
+
 def _parse_task_notification(txt):
     """Parse a <task-notification> block's fields, or None if it isn't one. Keys on the exact tags the
     harness emits (status / summary / output-file / tool-use-id), not a guess. tool_use_id is the join
@@ -376,6 +394,7 @@ def _bg_step(state, o):
                 # never be consumed (both creation paths refuse the id), so it is not captured.
                 dispatch[b["id"]] = {
                     "desc": str(inp.get("description") or "").strip(),
+                    "launchDesc": _launch_desc(b.get("name"), inp),
                     "detail": _clip_detail(inp.get("prompt") or inp.get("script")
                                            or ("script: " + str(inp["scriptPath"])
                                                if inp.get("scriptPath") else "")),
@@ -395,6 +414,7 @@ def _bg_step(state, o):
             if tid and tid not in tasks and tid not in done:
                 tasks[tid] = {"id": tid, "status": "running", "t": parse_z(o.get("timestamp")),
                               "summary": (inp.get("description") or b.get("name") or "Background task"),
+                              "launchDesc": _launch_desc(b.get("name"), inp),
                               "command": inp.get("command") or (inp.get("ws") or {}).get("url", ""),
                               "outputFile": ""}
                 d = dispatch.pop(tid, None)
@@ -434,6 +454,8 @@ def _bg_step(state, o):
                                   "summary": (tur.get("description") or tur.get("summary")
                                               or d.get("desc")
                                               or ("workflow " + str(wf) if wf else "Background agent")),
+                                  "launchDesc": (d.get("launchDesc") or str(tur.get("description") or "").strip()
+                                                 or ("workflow " + str(wf) if wf else "")),
                                   "command": d.get("detail")
                                              or _clip_detail(tur.get("prompt")
                                                              or ("script: " + str(tur["scriptPath"])
@@ -452,6 +474,8 @@ def _bg_step(state, o):
                     # the launch row lacks, never overwrite what it has
                     tk = tasks[tid]
                     tk["outputFile"] = tk["outputFile"] or tur.get("outputFile") or ""
+                    if not tk.get("launchDesc") and tur.get("description"):
+                        tk["launchDesc"] = str(tur["description"]).strip()[:200]
                     if tur.get("taskType"):
                         tk["type"] = tur["taskType"]
                     if tur.get("agentId") and not tk.get("agentId"):

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -221,20 +221,38 @@ def _result_text(content):
 
 
 _WF_META_DESC_RE = re.compile(r"\b(description|name)\s*:\s*(['\"])(.*?)\2", re.S)
-_WF_META_LITERAL_RE = re.compile(r"export\s+const\s+meta\s*=\s*\{(.*?)\}", re.S)   # the meta object only, never a schema field
+
+
+def _meta_literal(script):
+    """The text inside a Workflow script's FIRST `export const meta = {...}` literal, matched by brace depth (a
+    nested object or array inside meta never ends the scan early); '' when none."""
+    src = str(script or "")[:8000]
+    m = re.search(r"export\s+const\s+meta\s*=\s*\{", src)
+    if not m:
+        return ""
+    depth, i = 1, m.end()
+    while i < len(src) and depth:
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    return src[m.end():i - 1] if depth == 0 else src[m.end():]
 
 
 def _launch_desc(name, inp):
     """The dispatch's OWN words at launch time: an Agent/Task's description, a Workflow's meta description
-    (else its meta name) read off the script, else ''. Kept on the task row as `launchDesc` and never
-    overwritten by the completion notification, whose summary replaces `summary` when the run ends (T319: the
-    feed matches a session-started goal to the launch that produced it on these words)."""
+    (else its meta name) read off the script's meta literal alone (never a schema field's or a prompt's quoted
+    description later in the script), else ''. Kept on the task row as `launchDesc` and never overwritten by
+    the completion notification, whose summary replaces `summary` when the run ends (T319: the feed matches a
+    session-started goal to the launch that produced it on these words)."""
     inp = inp if isinstance(inp, dict) else {}
     d = str(inp.get("description") or "").strip()
     if not d and name == "Workflow":
-        lit = _WF_META_LITERAL_RE.search(str(inp.get("script") or "")[:6000])   # the FIRST meta literal: a later quoted
-        meta = {m.group(1): m.group(3) for m in _WF_META_DESC_RE.finditer(lit.group(1))} if lit else {}   # description is a
-        d = str(meta.get("description") or meta.get("name") or "").strip()                                 # schema field's
+        lit = _meta_literal(inp.get("script"))
+        meta = {m.group(1): m.group(3) for m in _WF_META_DESC_RE.finditer(lit)} if lit else {}
+        d = str(meta.get("description") or meta.get("name") or "").strip()
         if not d and inp.get("scriptPath"):
             d = os.path.splitext(os.path.basename(str(inp["scriptPath"])))[0]
     return " ".join(d.split())[:200]

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -221,6 +221,7 @@ def _result_text(content):
 
 
 _WF_META_DESC_RE = re.compile(r"\b(description|name)\s*:\s*(['\"])(.*?)\2", re.S)
+_WF_META_LITERAL_RE = re.compile(r"export\s+const\s+meta\s*=\s*\{(.*?)\}", re.S)   # the meta object only, never a schema field
 
 
 def _launch_desc(name, inp):
@@ -231,8 +232,9 @@ def _launch_desc(name, inp):
     inp = inp if isinstance(inp, dict) else {}
     d = str(inp.get("description") or "").strip()
     if not d and name == "Workflow":
-        meta = {m.group(1): m.group(3) for m in _WF_META_DESC_RE.finditer(str(inp.get("script") or "")[:4000])}
-        d = str(meta.get("description") or meta.get("name") or "").strip()
+        lit = _WF_META_LITERAL_RE.search(str(inp.get("script") or "")[:6000])   # the FIRST meta literal: a later quoted
+        meta = {m.group(1): m.group(3) for m in _WF_META_DESC_RE.finditer(lit.group(1))} if lit else {}   # description is a
+        d = str(meta.get("description") or meta.get("name") or "").strip()                                 # schema field's
         if not d and inp.get("scriptPath"):
             d = os.path.splitext(os.path.basename(str(inp["scriptPath"])))[0]
     return " ".join(d.split())[:200]

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6327,6 +6327,16 @@ def _restrict_retitle(ops, allowed):
 
 _LAUNCH_TOOLS = {"Workflow": "workflow", "Agent": "agent", "Task": "agent"}
 _WF_META_RE = re.compile(r"\b(name|description)\s*:\s*(['\"])(.*?)\2", re.S)
+_WF_META_LITERAL_RE = re.compile(r"export\s+const\s+meta\s*=\s*\{(.*?)\}", re.S)   # the meta object only, never a schema field
+
+
+def _wf_meta(script):
+    """{name, description} read off a Workflow script's `export const meta = {...}` literal (the FIRST one), {} when
+    none: a later quoted description (a schema field's, an agent prompt's) is never the run's own words."""
+    m = _WF_META_LITERAL_RE.search(str(script or "")[:6000])
+    if not m:
+        return {}
+    return {mm.group(1): mm.group(3) for mm in _WF_META_RE.finditer(m.group(1))}
 
 
 def _seg_launches(seg):
@@ -6362,7 +6372,7 @@ def _seg_launches(seg):
                 continue                                   # a foreground subagent: the turn waited on it, no launch
             desc = ""
             if via == "workflow":
-                meta = {m.group(1): m.group(3) for m in _WF_META_RE.finditer(str(inp.get("script") or "")[:4000])}
+                meta = _wf_meta(inp.get("script"))
                 desc = meta.get("description") or meta.get("name") or ""
                 if not desc and inp.get("scriptPath"):
                     desc = os.path.splitext(os.path.basename(str(inp["scriptPath"])))[0]
@@ -6444,17 +6454,20 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
         return max([_overlap(l["desc"], o.get("text")) for l in launches] + [_overlap(l["desc"], o.get("why")) for l in launches] + [0.0])
     prompt = _prompt_text(seg.get("atoms") or []) if human else ""
     def prompt_match(o):
-        return _overlap(prompt, o.get("text")) if prompt else 0.0
+        return max(_overlap(prompt, o.get("text")), _overlap(prompt, o.get("why"))) if prompt else 0.0
     mints = [o for o in ops if o.get("do") == "mint"]
     ask_op = None
     if human and parent is None:
-        # the ask's own placement: the mint the planner MARKED as the user's ask, else the mint nearest the user's
-        # words (a paraphrased title shares no words; a tie by position is no evidence), and never a mint a launch's
-        # words fit better than the user's (that one is the session's process, whatever its position)
-        pool = [o for o in mints if launch_match(o) <= prompt_match(o)]
-        marked = [o for o in pool if o.get("ask") is True]
-        pool = marked or pool
-        if pool:
+        # the ask's own placement, ALWAYS one for a human segment (the user's message never files nothing here):
+        # the mint the planner MARKED as the user's ask, before any word test (a short approval like "yes, go
+        # ahead" shares no word with any mint, and the mark is the planner's own knowledge); else the mint nearest
+        # the user's words among those no launch fits better (that one is the session's process, whatever its
+        # position); else the mint nearest the user's words at all; else the first mint.
+        marked = [o for o in mints if o.get("ask") is True]
+        if marked:
+            ask_op = marked[0]
+        else:
+            pool = [o for o in mints if launch_match(o) <= prompt_match(o)] or mints
             ask_op = max(pool, key=lambda o: (prompt_match(o), -mints.index(o)))
     # `ref` indexes the reply's CREATED nodes (mints and subs) in the reply's own order. The ask's mint is processed
     # FIRST so a demoted mint can nest under it wherever the planner listed it; every op keeps its original created
@@ -6513,6 +6526,8 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
         created_new += 1; newpos[orig[id(o)]] = created_new
         born["parentText"] = str(nodes[p].get("text") or "")[:120]
         out.append({"do": "sub", "why": str(o.get("why") or why), "parentId": p, "text": text, "born": born})
+    if human and not out:
+        return ops                                     # a human segment never files nothing through this rule
     return out
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6394,24 +6394,36 @@ def _top_of(nodes, nid):
     return nid if nid in nodes else None
 
 
+def _seg_trigger_author(seg):
+    atoms = seg.get("atoms") or []
+    trig = next((a for a in atoms if a.get("uuid") == seg.get("trigger")), None) or (atoms[0] if atoms else None)
+    return trig.get("author") if trig else None
+
+
 def _demote_session_mints(ops, seg, store, menu, p_target, human):
     """The origin rule at minting time (T319, the user 2026-09-10: a card appears only for work that traces to
     something they asked for; the sessions' own process, a Workflow run, a review round, an agent, never
-    stands as a top-level card). EVENT FIRST, TEXT SECOND (the manager's amendment): in a segment whose trigger
-    is not a human ask (a seam tail, an autonomous stretch, a sender-less delivery), EVERY top mint demotes to a
-    step under the goal the turn ran in; in a human-triggered segment the mints demote when the segment's
-    assistant turns started background work (_seg_launches: an Agent/Task/Workflow tool_use, the event model's
-    own launch record), whatever their words. The ask itself keeps its card: when the segment already has a
-    placement (its prompt-run placed the message when it landed) that goal is the parent and every mint
-    demotes; when it has none (an ended segment planned in one work-run), the reply's FIRST mint is the ask's
-    placement and stays a top, the rest nest under it. Token overlap never decides top versus step: it only
-    picks WHICH launch supplies the step's one-line why and, when the turn ran in no goal and several are open,
-    which open goal is the parent (ties: the newest). With nothing to nest under, a demoted mint files nothing
-    (the bookkeeping floor's shape: our own process is never an ask). Demoted steps carry born {kind: session,
-    via: workflow|agent|work, why}; same-reply refs stay valid since a mint and a sub both create a node in
-    order."""
+    stands as a top-level card). EVENT FIRST, TEXT SECOND (the manager's amendment):
+    - a segment whose trigger is not a human ask (a seam tail a notification woke, an autonomous stretch, a
+      sender-less delivery): EVERY top mint demotes to a step under the goal the turn ran in (the seam's own
+      top, the segment's prompt-run placement, its standing placement, else the open top nearest in words to
+      the work, ties the newest); with nothing to nest under it files nothing, the bookkeeping floor's shape;
+    - a human-triggered segment that started background work (_seg_launches, the event model's own criterion):
+      the ask's own mint keeps its card, chosen by its WORDS against the user's message (never by position: the
+      planner's op order is unspecified), and of the other mints only those nearer a launch's words (in the
+      mint's text or its why) than the user's own demote under the ask; a second deliverable the user asked for
+      in the same message stays a top. With a placement already (the prompt run placed the message) the launch-matching
+      mints nest under it.
+    - a scheduled or programmatic prompt (trigger author "sdk") traces to the user's earlier setup: its mints are
+      never demoted or dropped.
+    Word overlap otherwise only picks WHICH launch supplies the step's one-line why and, when the turn ran in no
+    goal and several are open, which open goal is the parent. Demoted steps carry born {kind: session, via:
+    workflow|agent|work, why, parentText}; a dropped mint takes the ops chained onto it and surviving refs are
+    remapped (a demoted mint still creates a node, so positions hold)."""
     if not any(o.get("do") == "mint" for o in ops):
         return ops
+    if _seg_trigger_author(seg) == "sdk":
+        return ops                                     # a scheduled firing is the user's, set up earlier
     launches = _seg_launches(seg)
     if human and not launches:
         return ops
@@ -6424,44 +6436,60 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
             break
     open_tops = [m["id"] for m in menu if m.get("id") in nodes and nodes[m["id"]].get("parentId") is None
                  and not nodes[m["id"]].get("nodeComplete") and not nodes[m["id"]].get("cleared")]
-    # `ref` indexes the reply's CREATED nodes in order (mints and subs). A demoted mint still creates a node, so
-    # positions hold; a DROPPED mint shifts every later one and orphans the ops chained onto it, which apply_plan
-    # would then place as tops (the hole _strip_top_mints closes for bookkeeping segments). newpos[i] is created
-    # node i's new 1-based position, None when dropped; chained ops on a dropped node are dropped with it.
-    out, newpos, created_new = [], [], 0
+    def launch_match(o):
+        return max([_overlap(l["desc"], o.get("text")) for l in launches] + [_overlap(l["desc"], o.get("why")) for l in launches] + [0.0])
+    prompt = _prompt_text(seg.get("atoms") or []) if human else ""
+    def prompt_match(o):
+        return _overlap(prompt, o.get("text")) if prompt else 0.0
+    mints = [o for o in ops if o.get("do") == "mint"]
+    ask_op = None
+    if human and parent is None:
+        # the ask's own placement: the mint nearest the user's words (the first mint when none is near)
+        ask_op = max(mints, key=lambda o: (prompt_match(o), -mints.index(o)))
+    # `ref` indexes the reply's CREATED nodes (mints and subs) in the reply's own order. The ask's mint is processed
+    # FIRST so a demoted mint can nest under it wherever the planner listed it; every op keeps its original created
+    # position for ref resolution (orig -> new), and a dropped mint takes the ops chained onto it.
+    orig = {}
+    for o in ops:
+        if o.get("do") in ("mint", "sub"):
+            orig[id(o)] = len(orig) + 1
+    order = ([ask_op] if ask_op is not None else []) + [o for o in ops if o is not ask_op]
+    out, newpos, created_new = [], {}, 0
     ask_ref, ask_text = None, ""
     def dead(o):
         r = o.get("ref")
-        return bool(r) and (r > len(newpos) or newpos[r - 1] is None)
+        return bool(r) and newpos.get(r) is None
     def remap(o):
         r = o.get("ref")
-        return dict(o, ref=newpos[r - 1]) if r else o
-    for o in ops:
+        return dict(o, ref=newpos[r]) if r else o
+    for o in order:
         do = o.get("do")
         if do == "sub":
             if dead(o):
-                newpos.append(None)                    # its parent died with a dropped mint: dropped with it
+                newpos[orig[id(o)]] = None            # its parent died with a dropped mint: dropped with it
                 continue
-            created_new += 1; newpos.append(created_new); out.append(remap(o))
+            created_new += 1; newpos[orig[id(o)]] = created_new; out.append(remap(o))
             continue
         if do != "mint":
             if dead(o):
                 continue                               # a verdict aimed at a dropped node
             out.append(remap(o))
             continue
-        if human and parent is None and ask_ref is None:
-            created_new += 1; newpos.append(created_new)
-            ask_ref, ask_text = created_new, str(o.get("text") or "")
-            out.append(o)                              # the ask's own placement: the first mint of an unplaced human segment
+        keep = o is ask_op or (human and (launch_match(o) <= 0.0 or prompt_match(o) >= launch_match(o)))
+        if keep:                                       # the user's own ask, or a deliverable nearer their words than any launch's
+            created_new += 1; newpos[orig[id(o)]] = created_new
+            if o is ask_op:
+                ask_ref, ask_text = created_new, str(o.get("text") or "")
+            out.append(o)
             continue
         text = str(o.get("text") or "")
-        launch = max(launches, key=lambda l: _overlap(l["desc"], text)) if launches else None
+        launch = max(launches, key=lambda l: max(_overlap(l["desc"], text), _overlap(l["desc"], o.get("why")))) if launches else None
         via = launch["via"] if launch else "work"
         why = ("started a background %s (%s)" % (via, launch["desc"]) if launch and launch["desc"]
                else str(o.get("why") or "the session started this on its own"))
         born = {"kind": "session", "via": via, "why": " ".join(why.split())[:200]}
         if ask_ref is not None:
-            created_new += 1; newpos.append(created_new)
+            created_new += 1; newpos[orig[id(o)]] = created_new
             born["parentText"] = ask_text[:120]
             out.append({"do": "sub", "why": str(o.get("why") or why), "ref": ask_ref, "text": text, "born": born})
             continue
@@ -6470,9 +6498,9 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
             p = max(open_tops, key=lambda nid: (_overlap(nodes[nid].get("text"), (launch or {}).get("desc") or text),
                                                 nodes[nid].get("t") or 0))
         if p is None:
-            newpos.append(None)                        # nothing the user asked for to nest under: files nothing
+            newpos[orig[id(o)]] = None                 # nothing the user asked for to nest under: files nothing
             continue
-        created_new += 1; newpos.append(created_new)
+        created_new += 1; newpos[orig[id(o)]] = created_new
         born["parentText"] = str(nodes[p].get("text") or "")[:120]
         out.append({"do": "sub", "why": str(o.get("why") or why), "parentId": p, "text": text, "born": born})
     return out
@@ -6708,7 +6736,8 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
                     nodes[dup]["mt"] = seg_t
                     if not o.get("coerced"):           # a coerced landing is bookkeeping, not re-engagement
                         _unblock_branch(dup)           #  (the user 2026-07-21) — blocks on the branch stand
-                    focus = touched = dup
+                    created.append(dup)                # the reply's created-node positions hold: a later `ref` to this
+                    focus = touched = dup              #   sub lands on the twin, never on a neighbour (T319 review)
                     continue
                 nid = new_node(o["text"] or "(step)", parent, o["why"], born=o.get("born"))
             # A _coerce_place sub is the never-vanish floor, not the user re-engaging this branch: it must

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10230,7 +10230,8 @@ def _latch_ask_anchors(fsid, session, store):
     shown→hidden on every restart/cache-cold beat: cache temperature, not new information (the
     cards-move-on-new-information rule). The verdict is a fact about a record that never changes
     once readable, so resolve it ONCE from the judge's own WARM parse and stamp `askAnchor` on the
-    node: 'human' (the dictated ask), 'machine' (a peer mail, the agent's own atom, romp
+    node: 'human' (the dictated ask), 'scheduled' (a scheduled or programmatic prompt, author
+    sdk: the user's configured work, which the feed's heal never nests), 'machine' (a peer mail, the agent's own atom, romp
     bookkeeping — _human_prompt_record, the one definition of 'dictated'), or 'absent' (the
     stitched chain no longer holds the uuid: rewound/compacted/pre-/clear — durable doubt, which
     keeps failing open exactly as the per-beat read did, just stably). The write rides the planner
@@ -10260,7 +10261,9 @@ def _latch_ask_anchors(fsid, session, store):
         if a is None:
             nd["askAnchor"] = "absent"
         else:
-            nd["askAnchor"] = "human" if _human_prompt_record(a, fsid) else "machine"
+            nd["askAnchor"] = ("human" if _human_prompt_record(a, fsid)
+                               else "scheduled" if a.get("author") == "sdk"   # a scheduled or programmatic prompt: the
+                               else "machine")                                #   user's configured work, never machine (T319)
         n += 1
     return n
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3583,8 +3583,10 @@ PLAN_SYS = (
     "diagnosing, a follow-up it volunteers) is not an ask, so block the goal that surfaced the offer, "
     "with the offer as the why, and mint nothing. It earns a card of its own once the user says go. "
     "The session's own background workflows, review rounds and agents are its process, not deliverables: "
-    "file them as steps under the goal they serve, never as a new top-level goal. Put \"ask\": true on the one "
-    "mint that is the deliverable the user's own message asked for, never on work the session started.\n"
+    "file them as steps under the goal they serve, never as a new top-level goal. Every mint carries "
+    "\"kind\": \"ask\" (a deliverable the user's message asked for, e.g. \"Add retries to the client\") or "
+    "\"kind\": \"process\" (work the session started for itself: a review round, an audit, a workflow or agent it "
+    "launched, e.g. \"Adversarial review of the retry diff\").\n"
     '- {\"why\",\"do\":\"sub\",\"under\":<n>,\"text\":\"<step ≤10 words>\"}: a step or progress under '
     "card #n, where #n must be a **top-level card** (a flush-left line in <open-goals>; the indented "
     "sub-goals are context and done/block targets, not filing spots — where inside the card the step "
@@ -3807,8 +3809,11 @@ def _parse_plan(raw, menu_len, allow_extend=False):
         elif do == "mint":
             if _has_alpha(text):
                 op = {"do": "mint", "why": why, "text": text}
-                if o.get("ask") is True:
-                    op["ask"] = True                   # the planner's mark: this mint is the user's own ask (T319)
+                kind = str(o.get("kind") or "").strip().lower()
+                if kind in ("ask", "process"):
+                    op["kind"] = kind                  # the planner's label: the user's deliverable, or the session's own process (T319)
+                elif o.get("ask") is True:
+                    op["kind"] = "ask"                 # the earlier mark's spelling
                 ops.append(op)
         elif do == "sub":
             n, r = _int(o, "under"), _int(o, "ref")
@@ -6330,13 +6335,32 @@ _WF_META_RE = re.compile(r"\b(name|description)\s*:\s*(['\"])(.*?)\2", re.S)
 _WF_META_LITERAL_RE = re.compile(r"export\s+const\s+meta\s*=\s*\{(.*?)\}", re.S)   # the meta object only, never a schema field
 
 
-def _wf_meta(script):
-    """{name, description} read off a Workflow script's `export const meta = {...}` literal (the FIRST one), {} when
-    none: a later quoted description (a schema field's, an agent prompt's) is never the run's own words."""
-    m = _WF_META_LITERAL_RE.search(str(script or "")[:6000])
+def _meta_literal(script):
+    """The text inside a Workflow script's FIRST `export const meta = {...}` literal, matched by brace depth (a
+    nested object or array inside meta, phases: [{...}], never ends the scan early); '' when none."""
+    src = str(script or "")[:8000]
+    m = re.search(r"export\s+const\s+meta\s*=\s*\{", src)
     if not m:
+        return ""
+    depth, i = 1, m.end()
+    while i < len(src) and depth:
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    return src[m.end():i - 1] if depth == 0 else src[m.end():]
+
+
+def _wf_meta(script):
+    """{name, description} read off a Workflow script's meta literal (the FIRST one, by brace depth), {} when none:
+    a quoted description elsewhere in the script (a schema field's, an agent prompt's) is never the run's own
+    words."""
+    lit = _meta_literal(script)
+    if not lit:
         return {}
-    return {mm.group(1): mm.group(3) for mm in _WF_META_RE.finditer(m.group(1))}
+    return {mm.group(1): mm.group(3) for mm in _WF_META_RE.finditer(lit)}
 
 
 def _seg_launches(seg):
@@ -6417,30 +6441,31 @@ def _seg_trigger_author(seg):
 def _demote_session_mints(ops, seg, store, menu, p_target, human):
     """The origin rule at minting time (T319, the user 2026-09-10: a card appears only for work that traces to
     something they asked for; the sessions' own process, a Workflow run, a review round, an agent, never
-    stands as a top-level card). EVENT FIRST, TEXT SECOND (the manager's amendment):
-    - a segment whose trigger is not a human ask (a seam tail a notification woke, an autonomous stretch, a
-      sender-less delivery): EVERY top mint demotes to a step under the goal the turn ran in (the seam's own
-      top, the segment's prompt-run placement, its standing placement, else the open top nearest in words to
-      the work, ties the newest); with nothing to nest under it files nothing, the bookkeeping floor's shape;
-    - a human-triggered segment that started background work (_seg_launches, the event model's own criterion):
-      the ask's own mint keeps its card, chosen by its WORDS against the user's message (never by position: the
-      planner's op order is unspecified), and of the other mints only those nearer a launch's words (in the
-      mint's text or its why) than the user's own demote under the ask; a second deliverable the user asked for
-      in the same message stays a top. With a placement already (the prompt run placed the message) the launch-matching
-      mints nest under it.
-    - a scheduled or programmatic prompt (trigger author "sdk") traces to the user's earlier setup: its mints are
-      never demoted or dropped.
-    Word overlap otherwise only picks WHICH launch supplies the step's one-line why and, when the turn ran in no
-    goal and several are open, which open goal is the parent. Demoted steps carry born {kind: session, via:
-    workflow|agent|work, why, parentText}; a dropped mint takes the ops chained onto it and surviving refs are
-    remapped (a demoted mint still creates a node, so positions hold)."""
-    if not any(o.get("do") == "mint" for o in ops):
+    stands as a top-level card). The PLANNER labels every mint `kind`: "ask" (a deliverable the user's message
+    asked for) or "process" (work the session started for itself), and this rule TRUSTS the labels (the fourth
+    review round: four rounds of word-overlap edge cases ended by asking the model, which knows):
+    - kind ask keeps its card, on both paths (an unplaced human segment and one whose prompt run already placed
+      the message);
+    - kind process nests as a step under the ask's top: the goal the turn ran in (the seam's own top, the
+      segment's placement), else this reply's ask, else the open top nearest in words to the launch or the step,
+      else nothing (files nothing; the chained ops go with it); born.via is the matching launch's kind when one
+      exists (workflow | agent, its words the why), else "work" with the planner's own why;
+    - a segment whose trigger is not a human ask (a seam tail, an autonomous stretch) treats every mint as process
+      whatever its label; a scheduled or programmatic prompt (trigger author "sdk") traces to the user's earlier
+      setup and is left untouched.
+    A MISSING label is filled by the words, and only then: in a human segment with no background launch a mint is
+    an ask; with a launch it is process, except exactly ONE unlabelled mint, the one nearest the user's own words
+    (its text against the message, never its why, never its position), which is an ask, and only among the mints
+    no launch's words fit better; when every unlabelled mint reads like a launch and a top exists to nest under,
+    all of them nest; when none exists (the message must place somewhere), the one least like a launch keeps the
+    card. Demoted steps carry born {kind: session, via, why, parentText}; a dropped mint takes the ops chained
+    onto it and surviving refs are remapped (a demoted mint still creates a node, so positions hold)."""
+    mints = [o for o in ops if o.get("do") == "mint"]
+    if not mints:
         return ops
     if _seg_trigger_author(seg) == "sdk":
         return ops                                     # a scheduled firing is the user's, set up earlier
     launches = _seg_launches(seg)
-    if human and not launches:
-        return ops
     nodes = store.get("nodes", {})
     parent = None
     seam_top = (seg.get("seamOf") or {}).get("top") if isinstance(seg.get("seamOf"), dict) else None
@@ -6450,28 +6475,45 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
             break
     open_tops = [m["id"] for m in menu if m.get("id") in nodes and nodes[m["id"]].get("parentId") is None
                  and not nodes[m["id"]].get("nodeComplete") and not nodes[m["id"]].get("cleared")]
-    def launch_match(o):
-        return max([_overlap(l["desc"], o.get("text")) for l in launches] + [_overlap(l["desc"], o.get("why")) for l in launches] + [0.0])
+    def launch_match(o):                               # the launch's words in the mint's TEXT only
+        return max([_overlap(l["desc"], o.get("text")) for l in launches] + [0.0])
     prompt = _prompt_text(seg.get("atoms") or []) if human else ""
-    def prompt_match(o):
-        return max(_overlap(prompt, o.get("text")), _overlap(prompt, o.get("why"))) if prompt else 0.0
-    mints = [o for o in ops if o.get("do") == "mint"]
+    def prompt_match(o):                               # the user's words in the mint's TEXT only, never its why
+        return _overlap(prompt, o.get("text")) if prompt else 0.0
+    # the label of every mint: the planner's, else filled by the words
+    kind = {}
+    for o in mints:
+        k = str(o.get("kind") or "").strip().lower()
+        kind[id(o)] = k if k in ("ask", "process") else None
+    if not human:
+        for o in mints:
+            kind[id(o)] = "process"                    # the trigger is the event: no label can make this an ask
+    else:
+        unlabeled = [o for o in mints if kind[id(o)] is None]
+        if unlabeled and not launches:
+            for o in unlabeled:
+                kind[id(o)] = "ask"                    # no background work started: the words are the user's
+        elif unlabeled:
+            for o in unlabeled:
+                kind[id(o)] = "process"
+            if not any(kind[id(o)] == "ask" for o in mints):
+                fits_user = [o for o in unlabeled if launch_match(o) <= prompt_match(o)]
+                if fits_user:
+                    crown = max(fits_user, key=lambda o: prompt_match(o))
+                    kind[id(crown)] = "ask"
+                elif parent is None and not open_tops:  # nothing to nest under: the message must place somewhere
+                    crown = min(unlabeled, key=lambda o: launch_match(o))
+                    kind[id(crown)] = "ask"
+    if all(kind[id(o)] == "ask" for o in mints):
+        return ops
+    asks = [o for o in mints if kind[id(o)] == "ask"]
     ask_op = None
-    if human and parent is None:
-        # the ask's own placement, ALWAYS one for a human segment (the user's message never files nothing here):
-        # the mint the planner MARKED as the user's ask, before any word test (a short approval like "yes, go
-        # ahead" shares no word with any mint, and the mark is the planner's own knowledge); else the mint nearest
-        # the user's words among those no launch fits better (that one is the session's process, whatever its
-        # position); else the mint nearest the user's words at all; else the first mint.
-        marked = [o for o in mints if o.get("ask") is True]
-        if marked:
-            ask_op = marked[0]
-        else:
-            pool = [o for o in mints if launch_match(o) <= prompt_match(o)] or mints
-            ask_op = max(pool, key=lambda o: (prompt_match(o), -mints.index(o)))
-    # `ref` indexes the reply's CREATED nodes (mints and subs) in the reply's own order. The ask's mint is processed
-    # FIRST so a demoted mint can nest under it wherever the planner listed it; every op keeps its original created
-    # position for ref resolution (orig -> new), and a dropped mint takes the ops chained onto it.
+    if asks and parent is None:
+        # the reply's own ask hosts its process steps: the ask nearest the user's words, processed FIRST so a step
+        # can reference it wherever the planner listed it
+        ask_op = max(asks, key=lambda o: prompt_match(o))
+    # `ref` indexes the reply's CREATED nodes (mints and subs) in the reply's own order. Every op keeps its
+    # original created position for ref resolution (orig -> new); a dropped mint takes the ops chained onto it.
     orig = {}
     for o in ops:
         if o.get("do") in ("mint", "sub"):
@@ -6498,15 +6540,16 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
                 continue                               # a verdict aimed at a dropped node
             out.append(remap(o))
             continue
-        keep = o is ask_op or (human and (launch_match(o) <= 0.0 or prompt_match(o) >= launch_match(o)))
-        if keep:                                       # the user's own ask, or a deliverable nearer their words than any launch's
+        if kind[id(o)] == "ask":
             created_new += 1; newpos[orig[id(o)]] = created_new
             if o is ask_op:
                 ask_ref, ask_text = created_new, str(o.get("text") or "")
             out.append(o)
             continue
         text = str(o.get("text") or "")
-        launch = max(launches, key=lambda l: max(_overlap(l["desc"], text), _overlap(l["desc"], o.get("why")))) if launches else None
+        launch = max(launches, key=lambda l: _overlap(l["desc"], text)) if launches else None
+        if launch is not None and _overlap(launch["desc"], text) <= 0.0:
+            launch = launches[0] if len(launches) == 1 else None   # one launch in the segment: the step is its work
         via = launch["via"] if launch else "work"
         why = ("started a background %s (%s)" % (via, launch["desc"]) if launch and launch["desc"]
                else str(o.get("why") or "the session started this on its own"))

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2544,10 +2544,16 @@ def _unit_text(atoms, marker=None):
     ([m3]) so the model can CITE the one message its takeaway is grounded in (see _split_source).
     Sub-floor stubs (< CITE_MIN_CHARS) still ride along as context, just unlabeled — uncitable by
     construction."""
-    user_said, asst_said, tools, results = [], [], [], []
+    user_said, asst_said, tools, results, reported = [], [], [], [], []
     for a in atoms:
         if a["type"] == "user" and a.get("author") is not None:
             t = _FOLLOWUP_MARKER_RE.sub("", _atom_text(a)).strip()   # the follow-up marker is plumbing, not user text
+            if t and a.get("author") in ("system", "teammate"):
+                # T319: a harness report (a background task's completion, a system reminder) or a teammate's
+                # line folds into the unit, but it is NOT what the user asked: under USER ASKED it read as a
+                # request, and the planner minted the session's own review round as the user's deliverable
+                reported.append(t)
+                continue
             if t:
                 # a PEER's postal report is SUBSTANCE, not just context (T218, the study's postal class:
                 # the summary's evidence was the peer's ready-report, but only assistant prose could be
@@ -2587,6 +2593,8 @@ def _unit_text(atoms, marker=None):
     out = []
     if user_said:
         out.append("USER ASKED: " + _shape(" | ".join(user_said), 1200, 1800))
+    if reported:
+        out.append("BACKGROUND REPORTED (not the user): " + _shape(" | ".join(reported), 600, 900))
     if asst_said:
         out.append("ASSISTANT SAID: " + _shape(" ".join(asst_said), 2500, 5500))
     if tools:
@@ -3573,7 +3581,9 @@ PLAN_SYS = (
     "A card born **blocked** is the tell: when all a new goal would hold is a question about work that "
     "has not started, it is not a goal. Work the assistant merely **offers** (a fix it proposes after "
     "diagnosing, a follow-up it volunteers) is not an ask, so block the goal that surfaced the offer, "
-    "with the offer as the why, and mint nothing. It earns a card of its own once the user says go.\n"
+    "with the offer as the why, and mint nothing. It earns a card of its own once the user says go. "
+    "The session's own background workflows, review rounds and agents are its process, not deliverables: "
+    "file them as steps under the goal they serve, never as a new top-level goal.\n"
     '- {\"why\",\"do\":\"sub\",\"under\":<n>,\"text\":\"<step ≤10 words>\"}: a step or progress under '
     "card #n, where #n must be a **top-level card** (a flush-left line in <open-goals>; the indented "
     "sub-goals are context and done/block targets, not filing spots — where inside the card the step "
@@ -6311,6 +6321,163 @@ def _restrict_retitle(ops, allowed):
     return [o for o in ops if o["do"] != "retitle" or o.get("goal") == allowed]
 
 
+_LAUNCH_TOOLS = {"Workflow": "workflow", "Agent": "agent", "Task": "agent"}
+_WF_META_RE = re.compile(r"\b(name|description)\s*:\s*(['\"])(.*?)\2", re.S)
+
+
+def _seg_launches(seg):
+    """The BACKGROUND work this segment's assistant turns started, as [{"via": "workflow"|"agent", "desc": <the
+    dispatch's own words>}] in transcript order. The criterion is the event model's own (event_model._bg_step
+    registers a task on exactly these): a Workflow run (the tool only ever runs in the background), or an
+    Agent/Task tool_use whose input carries run_in_background or whose tool_result in this segment acked
+    asynchronously (toolUseResult.isAsync, or status "async_launched"). A FOREGROUND subagent (an Explore or a
+    review agent the turn waited on) is not a launch: counting it demoted a user's second ask under the first
+    (a review finding on this change). A Workflow's words come from its script's meta (description, else name)
+    or its scriptPath's file name; an agent's from its description, else the first line of its prompt."""
+    atoms = seg.get("atoms") or []
+    acks = {}
+    for a in atoms:
+        if a.get("type") != "user":
+            continue
+        tur = a.get("toolUseResult")
+        tur = tur if isinstance(tur, dict) else {}
+        is_async = bool(tur.get("isAsync")) or tur.get("status") == "async_launched"
+        for b in (a.get("message") or {}).get("content", []) or []:
+            if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("tool_use_id"):
+                acks[b["tool_use_id"]] = acks.get(b["tool_use_id"], False) or is_async
+    out = []
+    for a in atoms:
+        if a.get("type") != "assistant" or a.get("isApiError"):
+            continue
+        for b in (a.get("message") or {}).get("content", []) or []:
+            if not (isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name") in _LAUNCH_TOOLS):
+                continue
+            inp = b.get("input") if isinstance(b.get("input"), dict) else {}
+            via = _LAUNCH_TOOLS[b["name"]]
+            if via != "workflow" and not inp.get("run_in_background") and acks.get(b.get("id")) is not True:
+                continue                                   # a foreground subagent: the turn waited on it, no launch
+            desc = ""
+            if via == "workflow":
+                meta = {m.group(1): m.group(3) for m in _WF_META_RE.finditer(str(inp.get("script") or "")[:4000])}
+                desc = meta.get("description") or meta.get("name") or ""
+                if not desc and inp.get("scriptPath"):
+                    desc = os.path.splitext(os.path.basename(str(inp["scriptPath"])))[0]
+            if not desc:
+                desc = str(inp.get("description") or "").strip()
+            if not desc:
+                first = str(inp.get("prompt") or "").strip().splitlines()
+                desc = first[0] if first else ""
+            out.append({"via": via, "desc": " ".join(str(desc).split())[:160]})
+    return out
+
+
+_TOKEN_STOP = {"the", "and", "for", "with", "over", "into", "from", "that", "this", "each", "then", "them", "they", "their", "your", "onto", "about"}   # function words: never a shared word
+
+
+def _tokens(text):
+    return {w for w in re.findall(r"[a-z0-9]+", str(text or "").lower()) if len(w) > 3 and w not in _TOKEN_STOP}
+
+
+def _overlap(a, b):
+    """Token overlap of two texts as a share of the smaller set (0..1); 0 when either is empty."""
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / float(min(len(ta), len(tb)))
+
+
+def _top_of(nodes, nid):
+    seen = set()
+    while nid in nodes and nodes[nid].get("parentId") and nid not in seen:
+        seen.add(nid)
+        nid = nodes[nid]["parentId"]
+    return nid if nid in nodes else None
+
+
+def _demote_session_mints(ops, seg, store, menu, p_target, human):
+    """The origin rule at minting time (T319, the user 2026-09-10: a card appears only for work that traces to
+    something they asked for; the sessions' own process, a Workflow run, a review round, an agent, never
+    stands as a top-level card). EVENT FIRST, TEXT SECOND (the manager's amendment): in a segment whose trigger
+    is not a human ask (a seam tail, an autonomous stretch, a sender-less delivery), EVERY top mint demotes to a
+    step under the goal the turn ran in; in a human-triggered segment the mints demote when the segment's
+    assistant turns started background work (_seg_launches: an Agent/Task/Workflow tool_use, the event model's
+    own launch record), whatever their words. The ask itself keeps its card: when the segment already has a
+    placement (its prompt-run placed the message when it landed) that goal is the parent and every mint
+    demotes; when it has none (an ended segment planned in one work-run), the reply's FIRST mint is the ask's
+    placement and stays a top, the rest nest under it. Token overlap never decides top versus step: it only
+    picks WHICH launch supplies the step's one-line why and, when the turn ran in no goal and several are open,
+    which open goal is the parent (ties: the newest). With nothing to nest under, a demoted mint files nothing
+    (the bookkeeping floor's shape: our own process is never an ask). Demoted steps carry born {kind: session,
+    via: workflow|agent|work, why}; same-reply refs stay valid since a mint and a sub both create a node in
+    order."""
+    if not any(o.get("do") == "mint" for o in ops):
+        return ops
+    launches = _seg_launches(seg)
+    if human and not launches:
+        return ops
+    nodes = store.get("nodes", {})
+    parent = None
+    seam_top = (seg.get("seamOf") or {}).get("top") if isinstance(seg.get("seamOf"), dict) else None
+    for cand in (seam_top, p_target, (store.get("placements") or {}).get(seg.get("id") or "")):
+        if isinstance(cand, str) and cand in nodes:
+            parent = _top_of(nodes, cand)
+            break
+    open_tops = [m["id"] for m in menu if m.get("id") in nodes and nodes[m["id"]].get("parentId") is None
+                 and not nodes[m["id"]].get("nodeComplete") and not nodes[m["id"]].get("cleared")]
+    # `ref` indexes the reply's CREATED nodes in order (mints and subs). A demoted mint still creates a node, so
+    # positions hold; a DROPPED mint shifts every later one and orphans the ops chained onto it, which apply_plan
+    # would then place as tops (the hole _strip_top_mints closes for bookkeeping segments). newpos[i] is created
+    # node i's new 1-based position, None when dropped; chained ops on a dropped node are dropped with it.
+    out, newpos, created_new = [], [], 0
+    ask_ref, ask_text = None, ""
+    def dead(o):
+        r = o.get("ref")
+        return bool(r) and (r > len(newpos) or newpos[r - 1] is None)
+    def remap(o):
+        r = o.get("ref")
+        return dict(o, ref=newpos[r - 1]) if r else o
+    for o in ops:
+        do = o.get("do")
+        if do == "sub":
+            if dead(o):
+                newpos.append(None)                    # its parent died with a dropped mint: dropped with it
+                continue
+            created_new += 1; newpos.append(created_new); out.append(remap(o))
+            continue
+        if do != "mint":
+            if dead(o):
+                continue                               # a verdict aimed at a dropped node
+            out.append(remap(o))
+            continue
+        if human and parent is None and ask_ref is None:
+            created_new += 1; newpos.append(created_new)
+            ask_ref, ask_text = created_new, str(o.get("text") or "")
+            out.append(o)                              # the ask's own placement: the first mint of an unplaced human segment
+            continue
+        text = str(o.get("text") or "")
+        launch = max(launches, key=lambda l: _overlap(l["desc"], text)) if launches else None
+        via = launch["via"] if launch else "work"
+        why = ("started a background %s (%s)" % (via, launch["desc"]) if launch and launch["desc"]
+               else str(o.get("why") or "the session started this on its own"))
+        born = {"kind": "session", "via": via, "why": " ".join(why.split())[:200]}
+        if ask_ref is not None:
+            created_new += 1; newpos.append(created_new)
+            born["parentText"] = ask_text[:120]
+            out.append({"do": "sub", "why": str(o.get("why") or why), "ref": ask_ref, "text": text, "born": born})
+            continue
+        p = parent
+        if p is None and open_tops:
+            p = max(open_tops, key=lambda nid: (_overlap(nodes[nid].get("text"), (launch or {}).get("desc") or text),
+                                                nodes[nid].get("t") or 0))
+        if p is None:
+            newpos.append(None)                        # nothing the user asked for to nest under: files nothing
+            continue
+        created_new += 1; newpos.append(created_new)
+        born["parentText"] = str(nodes[p].get("text") or "")[:120]
+        out.append({"do": "sub", "why": str(o.get("why") or why), "parentId": p, "text": text, "born": born})
+    return out
+
+
 def _strip_top_mints(ops):
     """Drop every top-level `mint` op — and every op chained onto a dropped node — remapping the
     surviving same-reply refs. The deterministic half of the bookkeeping-root gate (the user
@@ -6466,7 +6633,7 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
     place_key = place_key if place_key is not None else seg_id
     created = []                                       # nodes minted/subbed in THIS reply, in order (for "ref")
 
-    def new_node(text, parent, why):
+    def new_node(text, parent, why, born=None):
         store["seq"] = store.get("seq", 0) + 1
         while "%s:g%d" % (store["rompUuid"], store["seq"]) in nodes:
             # a stale/absent seq must never mint OVER a live node: the overwrite is silent data
@@ -6480,6 +6647,9 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
                    "t": seg_t, "mt": seg_t, "why": why, "log": []}  # an empty diary at birth = diary-era node (2026-07-07)
         if clear_wrap:
             payload["clearWrap"] = True                # born from a clear wrap-up → clearing it is final (no second round)
+        if isinstance(born, dict) and born.get("kind"):
+            payload["born"] = dict(born)               # T319: work the SESSION started (a workflow, an agent, its own
+            #                                            thread), demoted under the goal it ran in; the card says so
         nodes[nid] = GuardedNode(payload)
         created.append(nid)
         return nid
@@ -6509,6 +6679,8 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
         return created[r - 1] if (r and 1 <= r <= len(created)) else None
 
     def _parent_of(o):                                # a sub parent: a menu node OR a same-reply mint ("ref")
+        if o.get("parentId") in nodes:                # ...or a node named outright (the T319 demotion's form:
+            return o["parentId"]                      #    the goal the turn ran in, menu member or not)
         if "under" in o:
             return menu[o["under"] - 1]["id"]
         r = o.get("ref")
@@ -6520,7 +6692,7 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
         if do == "skip":
             continue
         if do == "mint":
-            nid = new_node(o["text"] or "(untitled goal)", None, o["why"])
+            nid = new_node(o["text"] or "(untitled goal)", None, o["why"], born=o.get("born"))
             _unblock_branch(nid); focus = touched = nid
         elif do == "sub":
             parent = _parent_of(o)                     # menu goal, or a "ref" to an umbrella minted this reply
@@ -6538,7 +6710,7 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
                         _unblock_branch(dup)           #  (the user 2026-07-21) — blocks on the branch stand
                     focus = touched = dup
                     continue
-                nid = new_node(o["text"] or "(step)", parent, o["why"])
+                nid = new_node(o["text"] or "(step)", parent, o["why"], born=o.get("born"))
             # A _coerce_place sub is the never-vanish floor, not the user re-engaging this branch: it must
             # not clear blocks above it (the user 2026-07-21: an unrelated aside quietly pulled the lone
             # blocked card back to working). A planner-chosen sub keeps the newest-wins unblock.
@@ -8298,8 +8470,8 @@ def _mint_anchor_uuid(seg):
     author = ta.get("author")
     files_nothing = (isinstance(author, dict)
                      and (author.get("kind") or "") in ("coordinate", "question"))
-    if not files_nothing and not (author == "romp" or em.is_interrupt_record(ta)):
-        return t
+    if not files_nothing and not (author in ("romp", "system", "teammate") or em.is_interrupt_record(ta)):
+        return t                                       # system/teammate (T319): a harness report is never a root either
     for a in atoms:
         if a.get("type") == "assistant" and a.get("uuid"):
             return a["uuid"]
@@ -10461,6 +10633,11 @@ def _plan_session(fsid, path, now):
                 store["placements"][seg_id] = None
                 save_goals(fsid, store)
                 continue
+        ops = _demote_session_mints(ops, seg_by_id.get(seg_id) or {}, store, menu, p_target, human)   # T319: the
+        if not ops:                                    # session's own process never stands as a top card; with
+            store["placements"][seg_id] = None         # nothing the user asked for to nest under, it files nothing
+            save_goals(fsid, store)
+            continue
         ops = _restrict_retitle(ops, pgi)              # only the segment's own prompt-run node is retitle-eligible
         ops = _card_route_subs(store, ops, menu)       # card-first: route subs to the card, then the placer
         if apply_plan_guarded(fsid, path, store, seg_id, seg_t, ops, menu, prompt_uuid=trig, quote=vq,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3583,7 +3583,8 @@ PLAN_SYS = (
     "diagnosing, a follow-up it volunteers) is not an ask, so block the goal that surfaced the offer, "
     "with the offer as the why, and mint nothing. It earns a card of its own once the user says go. "
     "The session's own background workflows, review rounds and agents are its process, not deliverables: "
-    "file them as steps under the goal they serve, never as a new top-level goal.\n"
+    "file them as steps under the goal they serve, never as a new top-level goal. Put \"ask\": true on the one "
+    "mint that is the deliverable the user's own message asked for, never on work the session started.\n"
     '- {\"why\",\"do\":\"sub\",\"under\":<n>,\"text\":\"<step ≤10 words>\"}: a step or progress under '
     "card #n, where #n must be a **top-level card** (a flush-left line in <open-goals>; the indented "
     "sub-goals are context and done/block targets, not filing spots — where inside the card the step "
@@ -3805,7 +3806,10 @@ def _parse_plan(raw, menu_len, allow_extend=False):
             ops.append({"do": "skip", "why": why})
         elif do == "mint":
             if _has_alpha(text):
-                ops.append({"do": "mint", "why": why, "text": text})
+                op = {"do": "mint", "why": why, "text": text}
+                if o.get("ask") is True:
+                    op["ask"] = True                   # the planner's mark: this mint is the user's own ask (T319)
+                ops.append(op)
         elif do == "sub":
             n, r = _int(o, "under"), _int(o, "ref")
             if not _has_alpha(text):
@@ -6444,8 +6448,14 @@ def _demote_session_mints(ops, seg, store, menu, p_target, human):
     mints = [o for o in ops if o.get("do") == "mint"]
     ask_op = None
     if human and parent is None:
-        # the ask's own placement: the mint nearest the user's words (the first mint when none is near)
-        ask_op = max(mints, key=lambda o: (prompt_match(o), -mints.index(o)))
+        # the ask's own placement: the mint the planner MARKED as the user's ask, else the mint nearest the user's
+        # words (a paraphrased title shares no words; a tie by position is no evidence), and never a mint a launch's
+        # words fit better than the user's (that one is the session's process, whatever its position)
+        pool = [o for o in mints if launch_match(o) <= prompt_match(o)]
+        marked = [o for o in pool if o.get("ask") is True]
+        pool = marked or pool
+        if pool:
+            ask_op = max(pool, key=lambda o: (prompt_match(o), -mints.index(o)))
     # `ref` indexes the reply's CREATED nodes (mints and subs) in the reply's own order. The ask's mint is processed
     # FIRST so a demoted mint can nest under it wherever the planner listed it; every op keeps its original created
     # position for ref resolution (orig -> new), and a dropped mint takes the ops chained onto it.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25635,17 +25635,18 @@ def _heal_session_tops(path, nodes, status=None, keep=()):
     "machine": the node's prompt anchor resolved to a peer mail, the agent's own record or romp bookkeeping,
     _latch_ask_anchors); never a word match, and never a top that merely lacks an anchor (older stores hold
     plain tops without one). Excluded: cleared tops, handoff trackers, delegate-rooted tops (origin.peer: a
-    chain the courier traced) and steps born of a session (never tops). A top in `keep` (the top a live floor
-    stands on: a permission prompt, an API error or a judge-auth refusal keys the card on it) is not nested: it
-    keeps its card and still gets the face record, like a blocked one. HOSTS are the asks that trace to the user: human-anchored
-    prompt tops and courier-planted delegated goals (origin.peer, a chain the courier proved), never a handoff
+    chain the courier traced) and steps born of a session (never tops). A top a live floor RESOLVES to (a
+    permission prompt, an API error or a judge-auth refusal keys the card on it) is un-nested by build_feed once
+    the floors are known: it keeps its card and its face record, like a blocked one. HOSTS are the asks that trace to the user: human-anchored
+    prompt tops and courier-planted delegated goals whose chain the courier proved to a human (origin.peer with
+    userAsk), never a handoff
     tracker (the delegation fold hides those) and never a session-born step; a completed host still holds its
     rows and a cleared host hides them with it (what a real step does; a cleared ask never resurfaces its rows
     as root cards). NEEDS-YOU BREAKS THROUGH: a candidate that is blocked (its own flag or its exported status)
     or a clear wrap-up's decision card is not nested, keeps its card, and still gets the face record so it
     never poses as an ask. The launch match reads the launch record's OWN description (`launchDesc`, kept from
     the dispatch and never overwritten by the completion's summary; never the brief or script) and shares by
-    the TITLE's word count, more than half and at least two, so one stray word never carries it; it only picks
+    the smaller word set, more than half and at least two, so one stray word never carries it; it only picks
     WHICH launch supplies the why and, when several hosts are open, which is the parent; with no matching
     launch the parent is the newest host minted before the node (else the oldest) and the why says the record
     it is rooted in. Returns {nid: (parent nid or None, born)}; None for a top not nested (blocked, or no
@@ -25666,8 +25667,9 @@ def _heal_session_tops(path, nodes, status=None, keep=()):
     except Exception:
         tasks = []
     launches = [t for t in tasks if isinstance(t, dict) and _bg_is_agent(t.get("type")) and (t.get("launchDesc") or t.get("summary"))]
-    def planted(hd):
-        return isinstance(hd.get("origin"), dict) and hd["origin"].get("peer")
+    def planted(hd):                                  # a courier-planted goal whose chain the courier PROVED reaches the
+        return (isinstance(hd.get("origin"), dict) and hd["origin"].get("peer")   # user (userAsk); a mid-chain coordination
+                and isinstance(hd.get("userAsk"), dict))                          # top the feed folds away never hosts
     hosts = sorted(((hid, hd) for hid, hd in nodes.items()
                     if hd.get("parentId") is None and not hd.get("born") and not isinstance(hd.get("handoff"), dict)
                     and hd.get("askAnchor") != "machine" and (hd.get("promptUuid") or planted(hd))),
@@ -25678,7 +25680,7 @@ def _heal_session_tops(path, nodes, status=None, keep=()):
         for l in launches:
             lt = toks(l.get("launchDesc") or l.get("summary"))    # the dispatch's own words, never the brief
             shared = len(tt & lt)
-            share = shared / float(len(tt)) if tt and lt and shared >= 2 else 0.0
+            share = shared / float(min(len(tt), len(lt))) if tt and lt and shared >= 2 else 0.0
             if share > 0.5 and share > best:
                 best, hit = share, l
         via = ("workflow" if hit.get("type") == "local_workflow" else "agent") if hit else "work"
@@ -34990,15 +34992,7 @@ def build_feed(now, tmux=None):
                             cite_uuids.add(_a["uuid"])
         except Exception:
             pass
-        _floor_keep = set()                          # T319: the top a live floor will stand on keeps its card (see the heal)
-        if (tm and str(tm.get("state")) in _NEEDS_INPUT_STATES) or _jauth_map.get(fsid) \
-                or (ps is not None and _api_error(s["path"])):
-            _f = store.get("lastNode")
-            while _f and nodes.get(_f, {}).get("parentId") is not None:
-                _f = nodes[_f]["parentId"]
-            if _f in nodes:
-                _floor_keep.add(_f)
-        healed = _heal_session_tops(s.get("path"), nodes, status, _floor_keep)   # T319: machine-rooted tops nest (read-side)
+        healed = _heal_session_tops(s.get("path"), nodes, status)   # T319: machine-rooted tops nest (read-side)
         heal_total += sum(1 for v in healed.values() if v[0])
         children = {}
         for nid, nd in nodes.items():
@@ -35241,10 +35235,13 @@ def build_feed(now, tmux=None):
                 f = nodes[f]["parentId"]
             if f in nodes and status.get(f) not in ("completed", "cleared"):
                 jauth_top = f
-        def _host_top(x):                            # T319: a floor landing on a healed top belongs to its host card (the
-            _h = healed.get(x) if x else None        #   healed top is no longer a card, and the placeholder keys on the floor)
-            return _h[0] if (_h and _h[0]) else x
-        perm_top, api_top, jauth_top = _host_top(perm_top), _host_top(api_top), _host_top(jauth_top)
+        for _f in (perm_top, api_top, jauth_top):    # T319: a floor that RESOLVES to a healed top un-nests exactly that top:
+            _h = healed.get(_f) if _f else None      #   it keeps its card (the floor keys the card on it) and its face; the
+            if _h and _h[0] and _f in children.get(_h[0], []):   #   host's other rows are untouched
+                children[_h[0]].remove(_f)
+                children.setdefault(None, []).append(_f)
+                healed[_f] = (None, _h[1])
+                heal_total -= 1
         plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
         had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
         had_awaiting = False                         # …and does any of them read AWAITING? → the session's await-green dot (below)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9182,8 +9182,8 @@ def _pure_delegation_top(nodes, top_id, sid=None, path=None):
         pu = root.get("promptUuid")
         if pu and not isinstance(root.get("origin"), dict):
             latch = root.get("askAnchor")
-            if latch in ("human", "absent"):
-                return False                          # the dictated ask (or durable doubt) — stable
+            if latch in ("human", "absent", "scheduled"):
+                return False                          # the dictated ask, a scheduled prompt's, or durable doubt: stable
             if latch != "machine" and _dictated_prompt_uuid(sid, path, pu) is not False:
                 return False                          # unlatched → the cached-parse read, fail-open
     children = {}
@@ -25659,7 +25659,8 @@ def _heal_session_tops(path, nodes, status=None, keep=()):
         return isinstance(nd.get("handoff"), dict) or (isinstance(nd.get("origin"), dict) and nd["origin"].get("peer"))
     cands = [(nid, nd) for nid, nd in nodes.items()
              if nd.get("parentId") is None and not nd.get("cleared") and not nd.get("born") and not delegate(nd)
-             and nd.get("askAnchor") == "machine"]
+             and nd.get("askAnchor") == "machine"]      # never "scheduled": a scheduled prompt's top is the user's
+             #                                           configured work (the mint-time rule's sdk carve-out)
     if not cands:
         return out
     try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25628,25 +25628,28 @@ _HEAL_LOG = {"n": 0}          # tops the feed has nested as session-started this
 _HEAL_STOP = {"the", "and", "for", "with", "over", "into", "from", "that", "this", "each", "then", "them", "they", "their", "your", "onto", "about"}   # function words: never a shared word
 
 
-def _heal_session_tops(path, nodes, status=None):
+def _heal_session_tops(path, nodes, status=None, keep=()):
     """READ-SIDE heal for stores written before the minting-time rule (T319): a top-level goal rooted in a
     MACHINE record, not in anything the user asked for, is rendered inside the session's human-asked top that
     was current when it was minted. The deciding fact is the judge's own latched anchor verdict (askAnchor
     "machine": the node's prompt anchor resolved to a peer mail, the agent's own record or romp bookkeeping,
     _latch_ask_anchors); never a word match, and never a top that merely lacks an anchor (older stores hold
     plain tops without one). Excluded: cleared tops, handoff trackers, delegate-rooted tops (origin.peer: a
-    chain the courier traced), and steps born of a session (never tops). HOSTS are human-asked tops only
-    (promptUuid with no machine verdict, not a tracker, not born), never cleared (a row under a cleared host
-    would vanish with it, and a live floor resolved to the row with it), completed allowed (the row stays in
-    the completed card). NEEDS-YOU BREAKS THROUGH: a candidate that is blocked (its own flag or its exported
-    status) or a clear wrap-up's decision card is not nested, keeps its card, and still gets the face record so
-    it never poses as an ask. Word overlap with the transcript's recorded launches, on the LAUNCH record's words
-    (the dispatch's description and detail, not the completion's summary, which overwrites it when the run
-    ends) only picks WHICH launch supplies the why and, when several human tops are open, which is the parent;
-    with no overlapping launch the parent is the newest human top minted before the node (else the oldest)
-    and the why says the record it is rooted in. Returns {nid: (parent nid or None, born)}; None for a top not
-    nested (blocked, or no host). Deterministic: a pure function of the store and the task stream (sorted
-    hosts, first-match launches). Never writes the store."""
+    chain the courier traced) and steps born of a session (never tops). A top in `keep` (the top a live floor
+    stands on: a permission prompt, an API error or a judge-auth refusal keys the card on it) is not nested: it
+    keeps its card and still gets the face record, like a blocked one. HOSTS are the asks that trace to the user: human-anchored
+    prompt tops and courier-planted delegated goals (origin.peer, a chain the courier proved), never a handoff
+    tracker (the delegation fold hides those) and never a session-born step; a completed host still holds its
+    rows and a cleared host hides them with it (what a real step does; a cleared ask never resurfaces its rows
+    as root cards). NEEDS-YOU BREAKS THROUGH: a candidate that is blocked (its own flag or its exported status)
+    or a clear wrap-up's decision card is not nested, keeps its card, and still gets the face record so it
+    never poses as an ask. The launch match reads the launch record's OWN description (`launchDesc`, kept from
+    the dispatch and never overwritten by the completion's summary; never the brief or script) and shares by
+    the TITLE's word count, more than half and at least two, so one stray word never carries it; it only picks
+    WHICH launch supplies the why and, when several hosts are open, which is the parent; with no matching
+    launch the parent is the newest host minted before the node (else the oldest) and the why says the record
+    it is rooted in. Returns {nid: (parent nid or None, born)}; None for a top not nested (blocked, or no
+    host). Deterministic: a pure function of the store and the task stream. Never writes the store."""
     out = {}
     status = status or {}
     def toks(x):
@@ -25662,24 +25665,27 @@ def _heal_session_tops(path, nodes, status=None):
         tasks = _bg_scan_all_cached(path) if path else []
     except Exception:
         tasks = []
-    launches = [t for t in tasks if isinstance(t, dict) and _bg_is_agent(t.get("type")) and (t.get("summary") or t.get("command"))]
+    launches = [t for t in tasks if isinstance(t, dict) and _bg_is_agent(t.get("type")) and (t.get("launchDesc") or t.get("summary"))]
+    def planted(hd):
+        return isinstance(hd.get("origin"), dict) and hd["origin"].get("peer")
     hosts = sorted(((hid, hd) for hid, hd in nodes.items()
-                    if hd.get("parentId") is None and not hd.get("born") and not hd.get("cleared")
-                    and not delegate(hd) and hd.get("askAnchor") != "machine" and hd.get("promptUuid")),
+                    if hd.get("parentId") is None and not hd.get("born") and not isinstance(hd.get("handoff"), dict)
+                    and hd.get("askAnchor") != "machine" and (hd.get("promptUuid") or planted(hd))),
                    key=lambda h: (h[1].get("t") or 0, h[0]))      # keyed by the store's own ids, never a node's "id" field
     for nid, nd in sorted(cands, key=lambda c: (c[1].get("t") or 0, c[0])):
         tt = toks(nd.get("text"))
         best, hit = 0.0, None
         for l in launches:
-            lt = toks(l.get("command")) | toks(l.get("summary"))   # the launch's own words first; the summary rides along
-            share = len(tt & lt) / float(min(len(tt), len(lt))) if tt and lt else 0.0
-            if share > best:
+            lt = toks(l.get("launchDesc") or l.get("summary"))    # the dispatch's own words, never the brief
+            shared = len(tt & lt)
+            share = shared / float(len(tt)) if tt and lt and shared >= 2 else 0.0
+            if share > 0.5 and share > best:
                 best, hit = share, l
         via = ("workflow" if hit.get("type") == "local_workflow" else "agent") if hit else "work"
-        why = ("matched a background %s the session started (%s)" % (via, " ".join(str(hit.get("summary") or hit.get("command")).split())[:120])
+        why = ("matched a background %s the session started (%s)" % (via, " ".join(str(hit.get("launchDesc") or hit.get("summary")).split())[:120])
                if hit else "rooted in the session's own record (a peer's line, a report, its own turn), not in a request")
         born = {"kind": "session", "via": via, "why": why, "healed": True}
-        nest = not (nd.get("blocked") or status.get(nid) == "blocked" or nd.get("clearWrap"))
+        nest = not (nd.get("blocked") or status.get(nid) == "blocked" or nd.get("clearWrap") or nid in set(keep or ()))
         host = None
         if nest:
             before = [h for h in hosts if (h[1].get("t") or 0) <= (nd.get("t") or 0) and h[0] != nid]
@@ -25687,7 +25693,7 @@ def _heal_session_tops(path, nodes, status=None):
             if pool:
                 host = pool[-1]
                 if hit and len(pool) > 1:            # several open: the launch's words pick the parent, ties the newest
-                    ht = toks(hit.get("command")) | toks(hit.get("summary"))
+                    ht = toks(hit.get("launchDesc") or hit.get("summary"))
                     host = max(pool, key=lambda h: (len(toks(h[1].get("text")) & ht), h[1].get("t") or 0))
         if host:
             born["parentText"] = str(host[1].get("text") or "")[:120]
@@ -34984,7 +34990,15 @@ def build_feed(now, tmux=None):
                             cite_uuids.add(_a["uuid"])
         except Exception:
             pass
-        healed = _heal_session_tops(s.get("path"), nodes, status)   # T319: pre-rule stores' machine-rooted tops nest (read-side)
+        _floor_keep = set()                          # T319: the top a live floor will stand on keeps its card (see the heal)
+        if (tm and str(tm.get("state")) in _NEEDS_INPUT_STATES) or _jauth_map.get(fsid) \
+                or (ps is not None and _api_error(s["path"])):
+            _f = store.get("lastNode")
+            while _f and nodes.get(_f, {}).get("parentId") is not None:
+                _f = nodes[_f]["parentId"]
+            if _f in nodes:
+                _floor_keep.add(_f)
+        healed = _heal_session_tops(s.get("path"), nodes, status, _floor_keep)   # T319: machine-rooted tops nest (read-side)
         heal_total += sum(1 for v in healed.values() if v[0])
         children = {}
         for nid, nd in nodes.items():

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25609,6 +25609,95 @@ def _bg_scan_all_cached(path):
     return em.scan_bg_tasks_cached(path, _bgall_cache, want_all=True)
 
 
+def _session_started_face(nodes, nid, healed):
+    """The one-line story for a session-started ROOT card: {why, parent} or None for an ordinary ask."""
+    nd = nodes.get(nid) or {}
+    born = nd.get("born") if isinstance(nd.get("born"), dict) else None
+    if born is None and nid in healed:
+        born = healed[nid][1]
+    if not born:
+        return None
+    parent = str(born.get("parentText") or "") or None   # recorded at demotion / heal time: names the request
+    pid = nd.get("parentId")                              # even after the parent node itself is gone
+    if not parent and pid and pid in nodes:
+        parent = str(nodes[pid].get("text") or "") or None
+    return {"why": str(born.get("why") or ""), "parent": parent}
+
+
+_HEAL_LOG = {"n": 0}          # tops the feed has nested as session-started this boot (logged once per rise)
+_HEAL_STOP = {"the", "and", "for", "with", "over", "into", "from", "that", "this", "each", "then", "them", "they", "their", "your", "onto", "about"}   # function words: never a shared word
+
+
+def _heal_session_tops(path, nodes, status=None):
+    """READ-SIDE heal for stores written before the minting-time rule (T319): a top-level goal rooted in a
+    MACHINE record, not in anything the user asked for, is rendered inside the session's human-asked top that
+    was current when it was minted. The deciding fact is the judge's own latched anchor verdict (askAnchor
+    "machine": the node's prompt anchor resolved to a peer mail, the agent's own record or romp bookkeeping,
+    _latch_ask_anchors); never a word match, and never a top that merely lacks an anchor (older stores hold
+    plain tops without one). Excluded: cleared tops, handoff
+    trackers, delegate-rooted tops (origin.peer: a chain the courier traced), and steps born of a session
+    (never tops). Word overlap with the transcript's recorded background launches (every Agent/Task/Workflow
+    row, _bg_scan_all_cached) only picks WHICH launch supplies the why line and, when several human tops are
+    open, which is the parent; with no overlapping launch the parent is the newest human top minted before
+    the node (else the oldest) and the why says the record it is rooted in. Returns {nid: (parent nid or
+    None, born)}, None for a machine top with no human top to nest under (rendered as a card that says what
+    it is). Deterministic: a pure function of the store and the task stream (sorted hosts, first-match
+    launches), so the same inputs nest the same way on every build and nothing moves without a new record.
+    NEEDS-YOU BREAKS THROUGH (the serving fold's rule): a candidate whose exported status is blocked, or that
+    is itself blocked, keeps its card until the block lifts, and a clear wrap-up's decision card is never a
+    candidate; the heal only rewrites the feed's children map, so a nested node's block would otherwise leave
+    the Needs-You column with its host still reading working. Hosts include completed and cleared human tops:
+    a healed row stays with its host when the ask completes (the row renders in the completed card) and goes
+    with it when the user clears it (what a real step does), never resurfacing as a root card. Never writes
+    the store."""
+    out = {}
+    status = status or {}
+    def toks(x):
+        return {w for w in re.findall(r"[a-z0-9]+", str(x or "").lower()) if len(w) > 3 and w not in _HEAL_STOP}
+    def delegate(nd):
+        return isinstance(nd.get("handoff"), dict) or (isinstance(nd.get("origin"), dict) and nd["origin"].get("peer"))
+    cands = [(nid, nd) for nid, nd in nodes.items()
+             if nd.get("parentId") is None and not nd.get("cleared") and not nd.get("born") and not delegate(nd)
+             and not nd.get("blocked") and status.get(nid) != "blocked" and not nd.get("clearWrap")
+             and nd.get("askAnchor") == "machine"]      # the latched verdict only: an anchorless top is older
+             #                                           data, not evidence (a review finding on this change)
+    if not cands:
+        return out
+    try:
+        tasks = _bg_scan_all_cached(path) if path else []
+    except Exception:
+        tasks = []
+    launches = [t for t in tasks if isinstance(t, dict) and _bg_is_agent(t.get("type")) and t.get("summary")]
+    hosts = sorted(((hid, hd) for hid, hd in nodes.items()
+                    if hd.get("parentId") is None and not hd.get("born") and hd.get("askAnchor") != "machine"
+                    and (hd.get("promptUuid") or delegate(hd))),
+                   key=lambda h: (h[1].get("t") or 0, h[0]))      # keyed by the store's own ids, never a node's "id" field
+    for nid, nd in sorted(cands, key=lambda c: (c[1].get("t") or 0, c[0])):
+        tt = toks(nd.get("text"))
+        best, hit = 0.0, None
+        for l in launches:
+            lt = toks(l.get("summary"))
+            share = len(tt & lt) / float(min(len(tt), len(lt))) if tt and lt else 0.0
+            if share > best:
+                best, hit = share, l
+        before = [h for h in hosts if (h[1].get("t") or 0) <= (nd.get("t") or 0) and h[0] != nid]
+        pool = before or [h for h in hosts if h[0] != nid][:1]
+        host = None
+        if pool:
+            host = pool[-1]
+            if hit and len(pool) > 1:            # several open: the launch's words pick the parent, ties the newest
+                ht = toks(hit.get("summary"))
+                host = max(pool, key=lambda h: (len(toks(h[1].get("text")) & ht), h[1].get("t") or 0))
+        via = ("workflow" if hit.get("type") == "local_workflow" else "agent") if hit else "work"
+        why = ("matched a background %s the session started (%s)" % (via, " ".join(str(hit.get("summary")).split())[:120])
+               if hit else "rooted in the session's own record (a peer's line, a report, its own turn), not in a request")
+        born = {"kind": "session", "via": via, "why": why, "healed": True}
+        if host:
+            born["parentText"] = str(host[1].get("text") or "")[:120]
+        out[nid] = (host[0] if host else None, born)
+    return out
+
+
 def _bg_tasks(path, spawned_at=None, live=None):
     """The chat's background-task box payload: {count, tasks}. count = how many tasks to surface (drives the
     'N background tasks' header); tasks = up to 16 of them (newest first) enriched with each one's output tail
@@ -34778,6 +34867,7 @@ def build_feed(now, tmux=None):
     dbg_rows = _judge_error_rows(now) if jd._debug_mode() else None
     asks, working, awaiting = [], [], []
     serving_folds = []                                # T137: worker mirror cards awaiting the view-side fold
+    heal_total = 0                                    # T319: session-started tops nested this build (logged once per rise)
     bg_services = {}          # session name -> live SERVICE descs (judge-classified, _bg_split) → the neutral chip
     alive = _alive_sessions(now, tmux)               # hard filter: living sessions only
     wmap = _wait_for_graph(now, {s["sid"] for s in alive})   # per-session 'waiting on a live peer' (the user 2026-06-22)
@@ -34897,9 +34987,15 @@ def build_feed(now, tmux=None):
                             cite_uuids.add(_a["uuid"])
         except Exception:
             pass
+        healed = _heal_session_tops(s.get("path"), nodes, status)   # T319: pre-rule stores' machine-rooted tops nest (read-side)
+        heal_total += sum(1 for v in healed.values() if v[0])
         children = {}
         for nid, nd in nodes.items():
-            children.setdefault(nd.get("parentId"), []).append(nid)
+            _hp = healed.get(nid)
+            _pk = _hp[0] if (_hp and _hp[0]) else nd.get("parentId")
+            if _pk is not None and _pk not in nodes and isinstance(nd.get("born"), dict):
+                _pk = None                           # T319: a born step whose parent is gone renders as a root that says so
+            children.setdefault(_pk, []).append(nid)
         agent_open = _agent_open_set(nodes, children)   # authoritative-open subtree → never rendered 'done' (see helper)
         parked_rows = _parked_rows(nodes, children)     # leapfrogged open rows → the quiet "parked" row cue (see helper)
 
@@ -35013,7 +35109,9 @@ def build_feed(now, tmux=None):
             # courier-recorded handoff.peer, never inferred.
             _ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
             _ho_sid = str(_ho.get("peer") or "") if _ho else ""
+            _born = nd.get("born") if isinstance(nd.get("born"), dict) else (healed.get(nid) or (None, None))[1]
             out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
+                        "born": _born or None,   # T319: a step the session started on its own (why it sits here)
                         "who": (_name_of(_ho_sid) or _ho_sid[:8]) if _ho_sid else name,
                         "whoSid": _ho_sid or fsid,
                         "whoColor": _name_color(_ho_sid) if _ho_sid else color,
@@ -35132,6 +35230,10 @@ def build_feed(now, tmux=None):
                 f = nodes[f]["parentId"]
             if f in nodes and status.get(f) not in ("completed", "cleared"):
                 jauth_top = f
+        def _host_top(x):                            # T319: a floor landing on a healed top belongs to its host card (the
+            _h = healed.get(x) if x else None        #   healed top is no longer a card, and the placeholder keys on the floor)
+            return _h[0] if (_h and _h[0]) else x
+        perm_top, api_top, jauth_top = _host_top(perm_top), _host_top(api_top), _host_top(jauth_top)
         plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
         had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
         had_awaiting = False                         # …and does any of them read AWAITING? → the session's await-green dot (below)
@@ -35674,6 +35776,10 @@ def build_feed(now, tmux=None):
                 "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
                                              store.get("placements") or {}) or None)
                             if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section
+                # T319: this root is work the SESSION started (a planner-born step whose parent is gone, or a
+                # pre-rule machine-rooted top the heal found no request to nest under): the face names the
+                # parent request when one is known and says why the work exists, in one line
+                "sessionStarted": _session_started_face(nodes, nid, healed),
                 "tree": flatten(nid, [], boundary=jd.review_boundary(nodes[nid]))}
             # THE SERVING FOLD, candidate side (the user 2026-08-28, T137: fan-out lives inside the
             # ask card — the T101 ruling applied to the mirror, view-side): a to-do mirror top the
@@ -35733,6 +35839,10 @@ def build_feed(now, tmux=None):
     # globally unique, so the tracker id is the whole key). A candidate whose tracker row is not
     # on this build's board keeps its own card — suppression without a rendered home would
     # silently hide live work.
+    if heal_total > _HEAL_LOG["n"]:                   # T319: said once per boot, and again only when the count rises
+        _HEAL_LOG["n"] = heal_total
+        sys.stderr.write("feed: %d session-started top(s) nested under the goal they ran in "
+                         "(no request behind them; the planner nests new ones at mint time)\n" % heal_total)
     if serving_folds:
         _byrow = {}
         for _c in asks:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25634,22 +25634,19 @@ def _heal_session_tops(path, nodes, status=None):
     was current when it was minted. The deciding fact is the judge's own latched anchor verdict (askAnchor
     "machine": the node's prompt anchor resolved to a peer mail, the agent's own record or romp bookkeeping,
     _latch_ask_anchors); never a word match, and never a top that merely lacks an anchor (older stores hold
-    plain tops without one). Excluded: cleared tops, handoff
-    trackers, delegate-rooted tops (origin.peer: a chain the courier traced), and steps born of a session
-    (never tops). Word overlap with the transcript's recorded background launches (every Agent/Task/Workflow
-    row, _bg_scan_all_cached) only picks WHICH launch supplies the why line and, when several human tops are
-    open, which is the parent; with no overlapping launch the parent is the newest human top minted before
-    the node (else the oldest) and the why says the record it is rooted in. Returns {nid: (parent nid or
-    None, born)}, None for a machine top with no human top to nest under (rendered as a card that says what
-    it is). Deterministic: a pure function of the store and the task stream (sorted hosts, first-match
-    launches), so the same inputs nest the same way on every build and nothing moves without a new record.
-    NEEDS-YOU BREAKS THROUGH (the serving fold's rule): a candidate whose exported status is blocked, or that
-    is itself blocked, keeps its card until the block lifts, and a clear wrap-up's decision card is never a
-    candidate; the heal only rewrites the feed's children map, so a nested node's block would otherwise leave
-    the Needs-You column with its host still reading working. Hosts include completed and cleared human tops:
-    a healed row stays with its host when the ask completes (the row renders in the completed card) and goes
-    with it when the user clears it (what a real step does), never resurfacing as a root card. Never writes
-    the store."""
+    plain tops without one). Excluded: cleared tops, handoff trackers, delegate-rooted tops (origin.peer: a
+    chain the courier traced), and steps born of a session (never tops). HOSTS are human-asked tops only
+    (promptUuid with no machine verdict, not a tracker, not born), never cleared (a row under a cleared host
+    would vanish with it, and a live floor resolved to the row with it), completed allowed (the row stays in
+    the completed card). NEEDS-YOU BREAKS THROUGH: a candidate that is blocked (its own flag or its exported
+    status) or a clear wrap-up's decision card is not nested, keeps its card, and still gets the face record so
+    it never poses as an ask. Word overlap with the transcript's recorded launches, on the LAUNCH record's words
+    (the dispatch's description and detail, not the completion's summary, which overwrites it when the run
+    ends) only picks WHICH launch supplies the why and, when several human tops are open, which is the parent;
+    with no overlapping launch the parent is the newest human top minted before the node (else the oldest)
+    and the why says the record it is rooted in. Returns {nid: (parent nid or None, born)}; None for a top not
+    nested (blocked, or no host). Deterministic: a pure function of the store and the task stream (sorted
+    hosts, first-match launches). Never writes the store."""
     out = {}
     status = status or {}
     def toks(x):
@@ -25658,40 +25655,40 @@ def _heal_session_tops(path, nodes, status=None):
         return isinstance(nd.get("handoff"), dict) or (isinstance(nd.get("origin"), dict) and nd["origin"].get("peer"))
     cands = [(nid, nd) for nid, nd in nodes.items()
              if nd.get("parentId") is None and not nd.get("cleared") and not nd.get("born") and not delegate(nd)
-             and not nd.get("blocked") and status.get(nid) != "blocked" and not nd.get("clearWrap")
-             and nd.get("askAnchor") == "machine"]      # the latched verdict only: an anchorless top is older
-             #                                           data, not evidence (a review finding on this change)
+             and nd.get("askAnchor") == "machine"]
     if not cands:
         return out
     try:
         tasks = _bg_scan_all_cached(path) if path else []
     except Exception:
         tasks = []
-    launches = [t for t in tasks if isinstance(t, dict) and _bg_is_agent(t.get("type")) and t.get("summary")]
+    launches = [t for t in tasks if isinstance(t, dict) and _bg_is_agent(t.get("type")) and (t.get("summary") or t.get("command"))]
     hosts = sorted(((hid, hd) for hid, hd in nodes.items()
-                    if hd.get("parentId") is None and not hd.get("born") and hd.get("askAnchor") != "machine"
-                    and (hd.get("promptUuid") or delegate(hd))),
+                    if hd.get("parentId") is None and not hd.get("born") and not hd.get("cleared")
+                    and not delegate(hd) and hd.get("askAnchor") != "machine" and hd.get("promptUuid")),
                    key=lambda h: (h[1].get("t") or 0, h[0]))      # keyed by the store's own ids, never a node's "id" field
     for nid, nd in sorted(cands, key=lambda c: (c[1].get("t") or 0, c[0])):
         tt = toks(nd.get("text"))
         best, hit = 0.0, None
         for l in launches:
-            lt = toks(l.get("summary"))
+            lt = toks(l.get("command")) | toks(l.get("summary"))   # the launch's own words first; the summary rides along
             share = len(tt & lt) / float(min(len(tt), len(lt))) if tt and lt else 0.0
             if share > best:
                 best, hit = share, l
-        before = [h for h in hosts if (h[1].get("t") or 0) <= (nd.get("t") or 0) and h[0] != nid]
-        pool = before or [h for h in hosts if h[0] != nid][:1]
-        host = None
-        if pool:
-            host = pool[-1]
-            if hit and len(pool) > 1:            # several open: the launch's words pick the parent, ties the newest
-                ht = toks(hit.get("summary"))
-                host = max(pool, key=lambda h: (len(toks(h[1].get("text")) & ht), h[1].get("t") or 0))
         via = ("workflow" if hit.get("type") == "local_workflow" else "agent") if hit else "work"
-        why = ("matched a background %s the session started (%s)" % (via, " ".join(str(hit.get("summary")).split())[:120])
+        why = ("matched a background %s the session started (%s)" % (via, " ".join(str(hit.get("summary") or hit.get("command")).split())[:120])
                if hit else "rooted in the session's own record (a peer's line, a report, its own turn), not in a request")
         born = {"kind": "session", "via": via, "why": why, "healed": True}
+        nest = not (nd.get("blocked") or status.get(nid) == "blocked" or nd.get("clearWrap"))
+        host = None
+        if nest:
+            before = [h for h in hosts if (h[1].get("t") or 0) <= (nd.get("t") or 0) and h[0] != nid]
+            pool = before or [h for h in hosts if h[0] != nid][:1]
+            if pool:
+                host = pool[-1]
+                if hit and len(pool) > 1:            # several open: the launch's words pick the parent, ties the newest
+                    ht = toks(hit.get("command")) | toks(hit.get("summary"))
+                    host = max(pool, key=lambda h: (len(toks(h[1].get("text")) & ht), h[1].get("t") or 0))
         if host:
             born["parentText"] = str(host[1].get("text") or "")[:120]
         out[nid] = (host[0] if host else None, born)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -35235,6 +35235,7 @@ def build_feed(now, tmux=None):
                 f = nodes[f]["parentId"]
             if f in nodes and status.get(f) not in ("completed", "cleared"):
                 jauth_top = f
+        _unnested = False
         for _f in (perm_top, api_top, jauth_top):    # T319: a floor that RESOLVES to a healed top un-nests exactly that top:
             _h = healed.get(_f) if _f else None      #   it keeps its card (the floor keys the card on it) and its face; the
             if _h and _h[0] and _f in children.get(_h[0], []):   #   host's other rows are untouched
@@ -35242,6 +35243,10 @@ def build_feed(now, tmux=None):
                 children.setdefault(None, []).append(_f)
                 healed[_f] = (None, _h[1])
                 heal_total -= 1
+                _unnested = True
+        if _unnested:                                # the derivations below read the tree the card SHOWS (item 8 of the
+            agent_open = _agent_open_set(nodes, children)   #   fourth review): recomputed over the un-nested layout
+            parked_rows = _parked_rows(nodes, children)
         plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
         had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
         had_awaiting = False                         # …and does any of them read AWAITING? → the session's await-green dot (below)

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -289,6 +289,35 @@ class HealOlderStores(_Feed):
         self.assertEqual(asks[wf]["column"], "needs_input")
         self.assertIn("matched a background workflow", asks[wf]["sessionStarted"]["why"])
 
+    def test_a_floor_that_resolves_to_the_ask_leaves_the_machine_top_nested(self):
+        # the session is stopped on a permission prompt whose focus is UNDER the ask: the floor resolves to the ask,
+        # so the machine top stays a row in the ask's tree (a broader keep on the session's state would pop it out)
+        ask, step, wf = SID + ":g1", SID + ":g3", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     step: self._node(step, "Wrote the retry loop", parent=ask, t=T0 + 100),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")}, last=step)
+        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None}}
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask}, "the floor is the ask's; the machine top stays nested")
+        self.assertEqual(asks[ask]["column"], "needs_input")
+        self.assertIn(wf, {r["id"] for r in asks[ask]["tree"]})
+
+    def test_a_needs_input_state_whose_floor_does_not_set_leaves_the_nesting_alone(self):
+        # the focus top is the machine top but its exported status is completed, so the permission floor does not
+        # set on it: no floor resolves there, and the top stays nested (a keep on the session state alone would not)
+        ask, wf = SID + ":g1", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine", nodeComplete=True)},
+                    status={wf: "completed"}, last=wf)
+        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None}}
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask})
+        self.assertIn(wf, {r["id"] for r in asks[ask]["tree"]})
+
     def test_the_launch_match_reads_the_dispatch_not_the_completion_summary(self):
         # the run completes and its notification's summary overwrites the task's summary; the heal still matches on
         # the words the dispatch carried at launch (launchDesc), so the why and the parent do not change when a run ends

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -318,6 +318,38 @@ class HealOlderStores(_Feed):
         self.assertEqual(set(asks), {ask})
         self.assertIn(wf, {r["id"] for r in asks[ask]["tree"]})
 
+    def test_a_scheduled_prompts_top_keeps_its_card_with_no_face(self):
+        # the latch marks a scheduled (sdk) prompt's top "scheduled": the user's configured work, never nested, no face
+        ask, night = SID + ":g1", SID + ":g6"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     night: self._node(night, "Nightly guard review of the tree", t=T0 + 500, promptUuid="c1", askAnchor="scheduled")})
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask, night})
+        self.assertIsNone(asks[night]["sessionStarted"])
+        self.assertEqual(err, "")
+
+    def test_an_unnest_recomputes_the_hosts_row_state_and_the_parked_cue(self):
+        # W (machine top) nests under the completed ask A; W holds an open agent step and a handoff edge. A permission
+        # floor on W un-nests it: A must then render done and its leaf R must lose the parked cue (both derived rows)
+        A, R, W, H, G = SID + ":g1", SID + ":g3", SID + ":g2", SID + ":g4", SID + ":g5"
+        self._store({A: self._node(A, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human", nodeComplete=True),
+                     R: self._node(R, "Write the changelog entry", parent=A, t=T0 + 100),
+                     W: self._node(W, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine"),
+                     H: self._node(H, "delegated: check the diff", parent=W, t=T0 + 600, handoff={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m1"}),
+                     G: self._node(G, "Lens pass two", parent=W, t=T0 + 650, agentTask={"status": "open"})},
+                    status={A: "completed"}, last=W)
+        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None}}
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {A, W}, "the floor resolves to W: it un-nests and keeps its card")
+        rows = {r["id"]: r for r in asks[A]["tree"]}
+        self.assertNotIn(W, rows, "W left the tree the card shows")
+        self.assertEqual(rows[A]["status"], "done", "no open agent step under A any more: the row reads done (agent_open recomputed)")
+        self.assertIsNone(rows[R]["parked"], "no younger sibling with a handoff edge under A any more (parked_rows recomputed)")
+        self.assertEqual(asks[W]["column"], "needs_input")
+
     def test_the_launch_match_reads_the_dispatch_not_the_completion_summary(self):
         # the run completes and its notification's summary overwrites the task's summary; the heal still matches on
         # the words the dispatch carried at launch (launchDesc), so the why and the parent do not change when a run ends

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -220,56 +220,68 @@ class HealOlderStores(_Feed):
         self.assertIsNone(asks[wf]["sessionStarted"]["parent"], "not nested: no parent named")
         self.assertEqual(err, "", "nothing nested, nothing counted")
 
-    def test_a_cleared_ask_never_hosts_and_a_tracker_never_hosts(self):
-        # a row under a cleared host would vanish with it (and a live floor resolved to the row with it); a delegate's
-        # tracker is hidden by the delegation fold, taking any row along: neither is a host, so the machine top keeps
-        # its card and says what it is
+    def test_a_cleared_host_hides_its_row_and_a_tracker_never_hosts(self):
+        # a cleared ask keeps hosting (its row hides with it, never resurfacing as a root card); a delegate's tracker
+        # is no host (the delegation fold hides those), so with only a tracker the machine top keeps its card
         ask, wf, tracker = SID + ":g1", SID + ":g2", SID + ":g5"
         self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human", cleared=True),
-                     tracker: self._node(tracker, "delegated: review the retry diff", t=T0 + 100, handoff={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m1"}),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")},
+                    status={ask: "cleared"})           # a top is cleared through the ledger; the export reads cleared
+        feed, err = self._feed()
+        self.assertEqual([a["itemId"] for a in feed["asks"] if a["sid"] == SID], [], "hidden with its cleared host, no root card")
+        self._store({tracker: self._node(tracker, "delegated: review the retry diff", t=T0 + 100, handoff={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m1"}),
                      wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
         feed, err = self._feed()
         asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
         self.assertIn(wf, asks, "no host: still a card")
         self.assertEqual(asks[wf]["sessionStarted"]["parent"], None)
-        self.assertEqual(err, "")
 
-    def test_a_completed_host_keeps_its_healed_row(self):
-        # the ask completes: the row stays in the completed card's tree instead of resurfacing as a root card
-        # (a cleared host hides the same way: cards are built per root, and the row's root is the host)
-        ask, wf = SID + ":g1", SID + ":g2"
-        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human", nodeComplete=True),
-                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")},
-                    status={ask: "completed"})
+    def test_a_delegated_goal_the_courier_planted_is_a_host(self):
+        planted, wf = SID + ":g7", SID + ":g2"
+        self._store({planted: self._node(planted, "Review the retry diff for the manager", origin={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m2"}),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
         feed, err = self._feed()
         asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
-        self.assertEqual(set(asks), {ask}, "the completed ask still hosts the row; the row is no root")
-        self.assertEqual(asks[ask]["column"], "completed")
-        self.assertIn(wf, {r["id"] for r in asks[ask]["tree"]})
+        self.assertEqual(set(asks), {planted}, "the worker's process top nests under the delegated goal")
+        self.assertIn(wf, {r["id"] for r in asks[planted]["tree"]})
 
-    def test_an_anchorless_top_is_older_data_not_evidence_and_keeps_its_card(self):
-        # a top with no promptUuid and no latched verdict (an older store's plain mint) is never healed, even
-        # when its words match a recorded run: only the judge's machine verdict is the event
-        ask = SID + ":g1"; odd = SID + ":g9"; old = SID + ":g8"
-        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1"),
-                     odd: self._node(odd, "Rename the widget colours", t=T0 + 500),
-                     old: self._node(old, "Lens review of the retry diff", t=T0 + 600)})
-        feed, err = self._feed()
-        self.assertEqual({a["itemId"] for a in feed["asks"] if a["sid"] == SID}, {ask, odd, old})
-        self.assertEqual(err, "")
-
-    def test_a_permission_floor_on_a_healed_top_reaches_its_host_card(self):
+    def test_the_top_a_live_floor_stands_on_keeps_its_card(self):
+        # the session is stopped on a permission prompt whose focus is a machine top whose host is cleared: nesting
+        # would lose the needs-you floor with the hidden host, so the top keeps its card and the floor
         ask, wf = SID + ":g1", SID + ":g2"
-        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human", cleared=True),
                      wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")},
-                    last=wf)
+                    status={ask: "cleared"}, last=wf)
         km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "", "effort": "",
                                            "context": None, "compactPct": None, "color": None}}
         feed, err = self._feed()
         asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
-        self.assertEqual(set(asks), {ask}, "the healed top is no card")
-        self.assertEqual(asks[ask]["column"], "needs_input", "the live prompt's floor lands on the host")
-        self.assertEqual((asks[ask].get("blocked") or {}).get("state"), "permission")
+        self.assertEqual(set(asks), {wf})
+        self.assertEqual(asks[wf]["column"], "needs_input")
+        self.assertIn("matched a background workflow", asks[wf]["sessionStarted"]["why"])
+
+    def test_the_launch_match_reads_the_dispatch_not_the_completion_summary(self):
+        # the run completes and its notification's summary overwrites the task's summary; the heal still matches on
+        # the words the dispatch carried at launch (launchDesc), so the why and the parent do not change when a run ends
+        done_recs = json.loads("[" + ",".join(l for l in self.tpath.read_text().splitlines() if l.strip()) + "]")
+        done_recs.append({"type": "user", "timestamp": iso(T0 + 900), "uuid": "u9", "parentUuid": "a2",
+                          "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_a1",
+                                      "content": "<task-notification><task-id>w1</task-id><tool-use-id>toolu_a1</tool-use-id><status>completed</status>"
+                                                 "<summary>Findings: two nits on the colour names</summary></task-notification>"}]}})
+        self.tpath.write_text("\n".join(json.dumps(r) for r in done_recs) + "\n")
+        km._bgall_cache.clear()
+        tasks = km._bg_scan_all_cached(str(self.tpath))
+        wf_task = next(t for t in tasks if t.get("type") == "local_workflow")
+        self.assertIn("two nits", wf_task["summary"], "the completion overwrote the summary")
+        self.assertEqual(wf_task["launchDesc"], "Lens reviewers over the retry diff", "the dispatch's words stay")
+        ask, wf = SID + ":g1", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
+        nodes = json.loads((jd.GOALDIR / (SID + ".json")).read_text())["nodes"]
+        h = km._heal_session_tops(str(self.tpath), nodes, {})
+        self.assertEqual(h[wf][0], ask)
+        self.assertIn("Lens reviewers over the retry diff", h[wf][1]["why"], "matched on the launch, not the completion")
+        self.assertEqual(h[wf][1]["via"], "workflow")
 
     def test_a_machine_top_with_no_human_top_to_nest_under_shows_as_a_card_that_says_so(self):
         wf = SID + ":g2"

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -205,8 +205,9 @@ class HealOlderStores(_Feed):
         self.assertNotIn(fresh, nested)
         self.assertEqual(err, "")
 
-    def test_a_blocked_machine_top_keeps_its_needs_you_card(self):
-        # needs-you breaks through: the heal never takes a pending question off the board
+    def test_a_blocked_machine_top_keeps_its_needs_you_card_and_wears_the_face(self):
+        # needs-you breaks through: the heal never takes a pending question off the board, and the card still says
+        # what it is instead of posing as an ask
         ask, wf = SID + ":g1", SID + ":g2"
         self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
                      wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine", blocked=True)},
@@ -215,6 +216,22 @@ class HealOlderStores(_Feed):
         asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
         self.assertIn(wf, asks, "still a card")
         self.assertEqual(asks[wf]["column"], "needs_input")
+        self.assertIn("matched a background workflow", asks[wf]["sessionStarted"]["why"])
+        self.assertIsNone(asks[wf]["sessionStarted"]["parent"], "not nested: no parent named")
+        self.assertEqual(err, "", "nothing nested, nothing counted")
+
+    def test_a_cleared_ask_never_hosts_and_a_tracker_never_hosts(self):
+        # a row under a cleared host would vanish with it (and a live floor resolved to the row with it); a delegate's
+        # tracker is hidden by the delegation fold, taking any row along: neither is a host, so the machine top keeps
+        # its card and says what it is
+        ask, wf, tracker = SID + ":g1", SID + ":g2", SID + ":g5"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human", cleared=True),
+                     tracker: self._node(tracker, "delegated: review the retry diff", t=T0 + 100, handoff={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m1"}),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertIn(wf, asks, "no host: still a card")
+        self.assertEqual(asks[wf]["sessionStarted"]["parent"], None)
         self.assertEqual(err, "")
 
     def test_a_completed_host_keeps_its_healed_row(self):

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""The feed's side of T319 (the user 2026-09-10: no card for work a session started on its own). Three rules,
+each pinned here on a hermetic build_feed over synthetic stores and transcripts:
+- a Workflow or Agent run the session launched shows only inside the parent card's awaiting panel (the
+  local_workflow / local_agent rows), never as a card of its own;
+- a step the planner demoted (born {kind: session}) renders in its parent's tree with its why, and a
+  session-started ROOT that still shows (its parent gone) carries a one-line face naming what it is;
+- older stores are healed read-side: a top with no human prompt whose title matches a background run the
+  transcript records nests under the session's human-prompted top, the same way on every build, with a top
+  that has a human prompt never touched; the heal logs once how many it nested.
+Placeholder uuids, invented text, an invented project."""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_session_started", os.path.join(BIN, "romp-kernel"))
+jd = km.jd
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+WF_SCRIPT = "export const meta = { name: 'review-notes-api-retry', description: 'Lens reviewers over the retry diff' }\nreturn 1"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn", launch=None):
+    content = [{"type": "text", "text": text}]
+    if launch:
+        content.append({"type": "tool_use", "id": "toolu_" + uuid, "name": launch[0], "input": launch[1]})
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": content, "stop_reason": stop}}
+
+
+def tack(t, uuid, parent, tool_use_id, desc):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "toolUseResult": {"isAsync": True, "status": "async_launched", "description": desc, "taskType": "local_workflow"},
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": "Workflow launched in background. Task ID: w1"}]}}
+
+
+class _Feed(unittest.TestCase):
+    def setUp(self):
+        km._downtime[:] = []
+        km._HEAL_LOG["n"] = 0
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"; cdir.mkdir()
+        proj = td / "projects"
+        pdir = proj / jd.re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        recs = [uline(T0, "Add retries to the notes-api client", "u1"),
+                aline(T0 + 60, "Adding the retry loop.", "a1", "u1", stop="tool_use",
+                      launch=("Workflow", {"script": WF_SCRIPT})),
+                tack(T0 + 61, "u2", "a1", "toolu_a1", "Lens reviewers over the retry diff"),
+                aline(T0 + 400, "Wrote the retry loop; the review runs in the background.", "a2", "u2")]
+        self.tpath = pdir / (SID + ".jsonl")
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        names = td / "names"; names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE, km.NAMES, km._tmux_sessions)
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        jd.STATE = td
+        km.NAMES = names
+        km._tmux_sessions = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None}}
+        jd.GOALDIR.mkdir(parents=True)
+        km._bgall_cache.clear()
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE, km.NAMES, km._tmux_sessions) = self.saved
+        self.td.cleanup()
+
+    def _store(self, nodes, status=None, last=None):
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps(
+            {"rompUuid": SID, "seq": len(nodes), "lastNode": last, "nodes": nodes, "placements": {}, "status": status or {}}))
+
+    def _feed(self):
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            f = km.build_feed(NOW)
+        return f, err.getvalue()
+
+    @staticmethod
+    def _node(nid, text, parent=None, t=T0, **kw):
+        d = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False, "blocked": False, "cleared": False,
+             "trail": [], "t": t, "mt": t}
+        d.update(kw)
+        return d
+
+
+class BornSteps(_Feed):
+    def test_a_demoted_step_renders_in_its_parents_tree_with_its_why(self):
+        top, step = SID + ":g1", SID + ":g2"
+        self._store({top: self._node(top, "Add retries to the notes-api client", promptUuid="u1"),
+                     step: self._node(step, "Adversarial review of the retry diff", parent=top, t=T0 + 400,
+                                      born={"kind": "session", "via": "workflow", "why": "started a background workflow (Lens reviewers over the retry diff)"})})
+        feed, err = self._feed()
+        asks = [a for a in feed["asks"] if a["sid"] == SID]
+        self.assertEqual([a["text"] for a in asks], ["Add retries to the notes-api client"], "one card: the ask")
+        self.assertIsNone(asks[0]["sessionStarted"], "an ask's own card carries no session-started face")
+        rows = {r["id"]: r for r in asks[0]["tree"]}
+        self.assertEqual(rows[step]["born"]["via"], "workflow")
+        self.assertIn("Lens reviewers", rows[step]["born"]["why"])
+        self.assertIsNone(rows[top]["born"])
+
+    def test_an_orphaned_born_step_is_a_root_that_names_the_request_it_served(self):
+        # the parent node is gone (popped by a later reconcile): the step still has a parentId, pointing nowhere.
+        # It renders as a root, and its face names the request from the record made at demotion time
+        step = SID + ":g2"
+        self._store({step: self._node(step, "Adversarial review of the retry diff", parent=SID + ":g1", t=T0 + 400,
+                                      born={"kind": "session", "via": "workflow", "parentText": "Add retries to the notes-api client",
+                                            "why": "started a background workflow (Lens reviewers over the retry diff)"})})
+        feed, err = self._feed()
+        card = next(a for a in feed["asks"] if a["sid"] == SID)
+        self.assertEqual(card["sessionStarted"], {"why": "started a background workflow (Lens reviewers over the retry diff)",
+                                                  "parent": "Add retries to the notes-api client"})
+
+
+class HealOlderStores(_Feed):
+    def _pre_rule_store(self):
+        ask, wf, other, plain = SID + ":g1", SID + ":g2", SID + ":g3", SID + ":g4"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     # minted by the old planner off the session's narration: its anchor resolved to the session's own
+                     # record (the judge latched "machine"), and its words match the recorded run
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine"),
+                     # a top with a human anchor whose words also match the run: never touched
+                     other: self._node(other, "Review the retry diff with fresh eyes", t=T0 + 600, promptUuid="u7", askAnchor="human"),
+                     # machine-rooted with words unlike any run: the event decides, it nests too
+                     plain: self._node(plain, "Tidy the colour names", t=T0 + 700, promptUuid="a9", askAnchor="machine")})
+        return ask, wf, other, plain
+
+    def test_machine_rooted_tops_nest_under_the_human_top_and_stay_there(self):
+        ask, wf, other, plain = self._pre_rule_store()
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask, other}, "the machine-rooted tops are no cards")
+        rows = {r["id"]: r for r in asks[ask]["tree"]}
+        self.assertIn(wf, rows, "the one whose words match the run sits in the retry top's tree")
+        self.assertEqual(rows[wf]["born"]["via"], "workflow")
+        self.assertTrue(rows[wf]["born"]["healed"])
+        self.assertIn("matched a background workflow the session started", rows[wf]["born"]["why"])
+        # the one unlike any run: nested by the event alone, under the newest human top minted before it
+        rows_other = {r["id"]: r for r in asks[other]["tree"]}
+        self.assertIn(plain, rows_other)
+        self.assertEqual(rows_other[plain]["born"]["via"], "work")
+        self.assertIn("rooted in the session's own record", rows_other[plain]["born"]["why"])
+        self.assertIn("feed: 2 session-started top(s) nested", err, "said once, on stderr")
+        # the second build: the same nesting, nothing said again
+        feed2, err2 = self._feed()
+        asks2 = {a["itemId"]: a for a in feed2["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks2), {ask, other})
+        self.assertIn(wf, {r["id"] for r in asks2[ask]["tree"]})
+        self.assertIn(plain, {r["id"] for r in asks2[other]["tree"]})
+        self.assertEqual(err2, "")
+
+    def test_a_top_with_a_human_anchor_is_never_healed_away(self):
+        ask, wf, other, plain = self._pre_rule_store()
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertIn(other, asks, "its words match the run, but a human asked for it")
+        self.assertIsNone(asks[other]["sessionStarted"])
+        self.assertIn(ask, asks)
+
+    def test_the_heal_is_a_pure_function_of_store_and_transcript(self):
+        ask, wf, other, plain = self._pre_rule_store()
+        nodes = json.loads((jd.GOALDIR / (SID + ".json")).read_text())["nodes"]
+        a = km._heal_session_tops(str(self.tpath), nodes)
+        b = km._heal_session_tops(str(self.tpath), nodes)
+        self.assertEqual(a, b)
+        self.assertEqual(set(a), {wf, plain})
+        self.assertEqual(a[wf][0], ask)
+        self.assertEqual(a[plain][0], other, "the newest human top minted before it")
+        self.assertEqual(km._heal_session_tops(str(self.tpath), {k: v for k, v in nodes.items() if k in (ask, other)}), {})
+
+    def test_an_unlatched_or_human_top_and_a_delegate_tracker_are_not_candidates(self):
+        ask, tracker, fresh = SID + ":g1", SID + ":g5", SID + ":g6"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     tracker: self._node(tracker, "delegated: review the retry diff", t=T0 + 500, handoff={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m1"}),
+                     fresh: self._node(fresh, "Lens review of the retry diff", t=T0 + 600, promptUuid="u8")})
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertIn(fresh, asks, "a not-yet-latched prompt top keeps its card")
+        self.assertIsNone(asks[fresh]["sessionStarted"])
+        nested = {r["id"] for a in asks.values() for r in a["tree"] if r["id"] != a["itemId"]}
+        self.assertNotIn(tracker, nested, "a delegate's tracker is never healed into another card")
+        self.assertNotIn(fresh, nested)
+        self.assertEqual(err, "")
+
+    def test_a_blocked_machine_top_keeps_its_needs_you_card(self):
+        # needs-you breaks through: the heal never takes a pending question off the board
+        ask, wf = SID + ":g1", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine", blocked=True)},
+                    status={wf: "blocked", ask: "working"})
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertIn(wf, asks, "still a card")
+        self.assertEqual(asks[wf]["column"], "needs_input")
+        self.assertEqual(err, "")
+
+    def test_a_completed_host_keeps_its_healed_row(self):
+        # the ask completes: the row stays in the completed card's tree instead of resurfacing as a root card
+        # (a cleared host hides the same way: cards are built per root, and the row's root is the host)
+        ask, wf = SID + ":g1", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human", nodeComplete=True),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")},
+                    status={ask: "completed"})
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask}, "the completed ask still hosts the row; the row is no root")
+        self.assertEqual(asks[ask]["column"], "completed")
+        self.assertIn(wf, {r["id"] for r in asks[ask]["tree"]})
+
+    def test_an_anchorless_top_is_older_data_not_evidence_and_keeps_its_card(self):
+        # a top with no promptUuid and no latched verdict (an older store's plain mint) is never healed, even
+        # when its words match a recorded run: only the judge's machine verdict is the event
+        ask = SID + ":g1"; odd = SID + ":g9"; old = SID + ":g8"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1"),
+                     odd: self._node(odd, "Rename the widget colours", t=T0 + 500),
+                     old: self._node(old, "Lens review of the retry diff", t=T0 + 600)})
+        feed, err = self._feed()
+        self.assertEqual({a["itemId"] for a in feed["asks"] if a["sid"] == SID}, {ask, odd, old})
+        self.assertEqual(err, "")
+
+    def test_a_permission_floor_on_a_healed_top_reaches_its_host_card(self):
+        ask, wf = SID + ":g1", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")},
+                    last=wf)
+        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None}}
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask}, "the healed top is no card")
+        self.assertEqual(asks[ask]["column"], "needs_input", "the live prompt's floor lands on the host")
+        self.assertEqual((asks[ask].get("blocked") or {}).get("state"), "permission")
+
+    def test_a_machine_top_with_no_human_top_to_nest_under_shows_as_a_card_that_says_so(self):
+        wf = SID + ":g2"
+        self._store({wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
+        feed, err = self._feed()
+        card = next(a for a in feed["asks"] if a["sid"] == SID)
+        self.assertEqual(card["sessionStarted"]["parent"], None)
+        self.assertIn("matched a background workflow", card["sessionStarted"]["why"])
+        self.assertEqual(err, "", "nothing nested: nothing counted")
+
+
+class AwaitingPanel(unittest.TestCase):
+    def test_workflow_and_agent_rows_are_agents_for_the_awaiting_panel_never_cards(self):
+        self.assertTrue(km._bg_is_agent("local_workflow"))
+        self.assertTrue(km._bg_is_agent("local_agent"))
+        self.assertFalse(km._bg_is_agent("local_bash"))
+        # the feed's cards are goal nodes only: the card loop reads children[None], nothing else
+        import inspect
+        src = inspect.getsource(km.build_feed)
+        self.assertIn("for nid in children.get(None, [])", src)
+        self.assertNotIn("local_workflow", src.split("for nid in children.get(None, [])")[0].split("healed = _heal_session_tops")[0][-4000:],
+                         "no card is built from a workflow row")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -236,14 +236,43 @@ class HealOlderStores(_Feed):
         self.assertIn(wf, asks, "no host: still a card")
         self.assertEqual(asks[wf]["sessionStarted"]["parent"], None)
 
-    def test_a_delegated_goal_the_courier_planted_is_a_host(self):
+    def test_a_delegated_goal_hosts_only_when_its_chain_is_proven_to_a_human(self):
         planted, wf = SID + ":g7", SID + ":g2"
-        self._store({planted: self._node(planted, "Review the retry diff for the manager", origin={"peer": "22222222-3333-4444-5555-666666666666", "msgId": "m2"}),
+        peer = "22222222-3333-4444-5555-666666666666"
+        self._store({planted: self._node(planted, "Review the retry diff for the manager", origin={"peer": peer, "msgId": "m2"},
+                                         userAsk={"text": "please review the retry diff", "sid": peer}),
                      wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
         feed, err = self._feed()
         asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
-        self.assertEqual(set(asks), {planted}, "the worker's process top nests under the delegated goal")
+        self.assertEqual(set(asks), {planted}, "the worker's process top nests under the proven delegated goal")
         self.assertIn(wf, {r["id"] for r in asks[planted]["tree"]})
+        # a mid-chain coordination top with no proven ask never hosts: the machine top keeps its card and its face
+        self._store({planted: self._node(planted, "Review the retry diff for the manager", origin={"peer": peer, "msgId": "m2"}),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")})
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertIn(wf, asks)
+        self.assertIsNotNone(asks[wf]["sessionStarted"])
+
+    def test_a_permission_prompt_elsewhere_leaves_the_nesting_alone(self):
+        # the session is on a permission prompt, but the floor resolves to the HUMAN top (lastNode under it): the
+        # machine top stays nested, no root card pops out
+        ask, wf = SID + ":g1", SID + ":g2"
+        self._store({ask: self._node(ask, "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                     wf: self._node(wf, "Lens review of the retry diff", t=T0 + 500, promptUuid="a2", askAnchor="machine")}, last=ask)
+        km._tmux_sessions = lambda: {SID: {"state": "permission", "since": NOW - 10, "model": "", "effort": "",
+                                           "context": None, "compactPct": None, "color": None}}
+        feed, err = self._feed()
+        asks = {a["itemId"]: a for a in feed["asks"] if a["sid"] == SID}
+        self.assertEqual(set(asks), {ask})
+        self.assertEqual(asks[ask]["column"], "needs_input")
+        self.assertIn(wf, {r["id"] for r in asks[ask]["tree"]})
+
+    def test_a_long_title_holding_every_word_of_a_short_description_matches(self):
+        nodes = {SID + ":g1": self._node(SID + ":g1", "Add retries to the notes-api client", promptUuid="u1", askAnchor="human"),
+                 SID + ":g2": self._node(SID + ":g2", "Lens reviewers over the retry diff of the notes-api client, round two, with findings", t=T0 + 500, promptUuid="a2", askAnchor="machine")}
+        h = km._heal_session_tops(str(self.tpath), nodes, {})
+        self.assertEqual(h[SID + ":g2"][1]["via"], "workflow", "shared by the smaller set: the short description's words all appear")
 
     def test_the_top_a_live_floor_stands_on_keeps_its_card(self):
         # the session is stopped on a permission prompt whose focus is a machine top whose host is cleared: nesting

--- a/tests/test_session_started_work.py
+++ b/tests/test_session_started_work.py
@@ -194,27 +194,40 @@ class WorkflowMidGoal(_Harness):
         step = self._by_text(store, "Wrote the retry loop")
         self.assertEqual(step["parentId"], tops[0]["id"], "the same-reply ref followed the ask's remapped position")
 
-    def test_the_planners_ask_mark_wins_over_words_a_paraphrased_title_keeps_the_card(self):
-        # the planner marks the ask's mint ("ask": true); a paraphrased title shares no word with the user's message,
-        # and the review-first order would once have crowned the review. The mark crowns the paraphrase.
+    def test_the_planners_ask_mark_alone_decides_against_a_better_worded_rival(self):
+        # the marked title shares NO word with the user's message; the rival mint repeats the user's words and would
+        # win on overlap; the review-first order would once have crowned the review. The mark alone decides.
         marked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
-                  '{"why":"the user asked for resilience","do":"mint","ask":true,"text":"Make the client resilient to flaky networks"}]}')
+                  '{"why":"what was asked","do":"mint","text":"Add retries to the notes-api client"},'
+                  '{"why":"the shape the user wants","do":"mint","ask":true,"text":"Harden outbound calls against dropped packets"}]}')
         calls, store = self._run(self._records(), [("adversarial review workflow", marked), (ASK[:40], PLACE_ASK)])
-        tops = self._tops(store)
-        self.assertEqual([nd["text"] for nd in tops], ["Make the client resilient to flaky networks"])
+        tops = sorted(nd["text"] for nd in self._tops(store))
+        self.assertIn("Harden outbound calls against dropped packets", tops, "the mark crowns the paraphrase")
+        self.assertIn("Add retries to the notes-api client", tops, "the rival, nearer the user's words than any launch, stays a card too")
         rev = self._by_text(store, "Adversarial review")
-        self.assertEqual(rev["parentId"], tops[0]["id"])
-        self.assertEqual(rev["born"]["parentText"], "Make the client resilient to flaky networks")
+        self.assertEqual(rev["parentId"], self._by_text(store, "Harden outbound")["id"], "the review nests under the marked ask")
 
-    def test_a_launch_favoured_mint_is_never_crowned_even_when_marked_or_tied(self):
-        # every mint shares no word with the user's message (a tie); the review's words fit the launch, so it is
-        # never the ask, whatever its position or a stray mark; the other mint is crowned
-        tied = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","ask":true,"text":"Adversarial review of the retry diff"},'
-                '{"why":"the user asked for resilience","do":"mint","text":"Make the client resilient to flaky networks"}]}')
-        calls, store = self._run(self._records(), [("adversarial review workflow", tied), (ASK[:40], PLACE_ASK)])
-        tops = self._tops(store)
-        self.assertEqual([nd["text"] for nd in tops], ["Make the client resilient to flaky networks"])
-        self.assertEqual(self._by_text(store, "Adversarial review")["parentId"], tops[0]["id"])
+    def test_a_short_approval_still_keeps_a_top_and_the_mark_beats_a_launch_word_in_its_why(self):
+        # "yes, go ahead": every mint shares no word with the message. The marked mint's why shares a word with the
+        # launch; before this fold the filter excluded it, no ask was crowned, every mint demoted, and with no open
+        # top the user's approved deliverable never reached the board
+        recs = [
+            uline(T0, "yes, go ahead", "u1"),
+            aline(T0 + 60, "Going ahead with the retry loop.", "a1", "u1", stop="tool_use", launch=("Workflow", {"script": WF_SCRIPT})),
+            tresult(T0 + 61, "u2", "a1", "toolu_a1"),
+            aline(T0 + 400, "Wrote the retry loop and launched an adversarial review workflow over the diff.", "a2", "u2"),
+        ]
+        marked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
+                  '{"why":"the retry diff the user approved","do":"mint","ask":true,"text":"Harden outbound calls against dropped packets"}]}')
+        calls, store = self._run(recs, [("adversarial review workflow", marked)])
+        tops = [nd["text"] for nd in self._tops(store)]
+        self.assertEqual(tops, ["Harden outbound calls against dropped packets"], "the marked deliverable reaches the board")
+        self.assertEqual(self._by_text(store, "Adversarial review")["parentId"], self._tops(store)[0]["id"])
+        # ...and with no mark at all, a human segment still keeps one top (the first mint, when no words help)
+        unmarked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
+                    '{"why":"the approved work","do":"mint","text":"Harden outbound calls against dropped packets"}]}')
+        calls, store = self._run(recs, [("adversarial review workflow", unmarked)])
+        self.assertEqual(len(self._tops(store)), 1, "never nothing for a human segment")
 
     def test_the_parser_carries_the_ask_mark_and_the_prompt_asks_for_it(self):
         ops = jd._parse_plan('{"ops":[{"why":"w","do":"mint","ask":true,"text":"Add retries"},{"why":"w","do":"mint","text":"Other"}]}', 0)
@@ -392,6 +405,13 @@ class TriggerlessSegments(unittest.TestCase):
 
 
 class LaunchReader(unittest.TestCase):
+    def test_a_workflow_description_comes_from_the_meta_literal_not_a_later_schema_field(self):
+        script = ("export const meta = { name: 'review-notes-api-retry', description: 'Lens reviewers over the retry diff' }\n"
+                  "const FINDINGS = { type: 'object', properties: { title: { type: 'string', description: 'a finding title' } } }\n")
+        seg = {"atoms": [{"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t1", "name": "Workflow", "input": {"script": script}}]}}]}
+        self.assertEqual(jd._seg_launches(seg)[0]["desc"], "Lens reviewers over the retry diff")
+        self.assertEqual(jd._wf_meta("const x = 1"), {}, "no meta literal: nothing")
+
     def test_reads_background_launches_only_with_the_event_models_criterion(self):
         seg = {"atoms": [
             {"type": "assistant", "message": {"content": [

--- a/tests/test_session_started_work.py
+++ b/tests/test_session_started_work.py
@@ -417,6 +417,18 @@ class TriggerlessSegments(unittest.TestCase):
         ops = jd._demote_session_mints([dict(self.MINT, kind="ask")], seg, store, self._menu(store), None, False)
         self.assertEqual(ops[0]["do"], "sub", "no human asked: the label does not stand")
 
+    def test_the_latch_marks_a_scheduled_prompts_top_scheduled_not_machine(self):
+        g1, g2 = SID + ":g1", SID + ":g2"
+        store = {"rompUuid": SID, "nodes": {
+            g1: {"id": g1, "text": "Nightly guard review", "parentId": None, "promptUuid": "c1"},
+            g2: {"id": g2, "text": "Lens review of the diff", "parentId": None, "promptUuid": "s1"}}}
+        txt = lambda t: {"content": [{"type": "text", "text": t}]}
+        atoms = [{"uuid": "c1", "type": "user", "author": "sdk", "message": txt("nightly review")},
+                 {"uuid": "s1", "type": "user", "author": "system", "message": txt("<task-notification>done</task-notification>")}]
+        self.assertEqual(jd._latch_ask_anchors(SID, {"turns": [{"atoms": atoms}]}, store), 2)
+        self.assertEqual(store["nodes"][g1]["askAnchor"], "scheduled", "the user's configured work, never machine")
+        self.assertEqual(store["nodes"][g2]["askAnchor"], "machine")
+
     def test_a_scheduled_prompt_is_the_users_and_its_mints_are_never_demoted(self):
         store = self._store()
         seg = {"id": "s1", "trigger": "c1", "atoms": [

--- a/tests/test_session_started_work.py
+++ b/tests/test_session_started_work.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""A card appears only for work that traces to something the user asked for (T319, the user 2026-09-10,
+whose feed filled with cards titled after the workflows their sessions ran on their own: adversarial-review
+rounds, pull-request audits, guard reviews, each attributed to the authoring session and leading nowhere the
+user had asked to go). The planner had minted those as top-level goals off the session's narration of its
+own process. The rule at minting time is EVENT FIRST, TEXT SECOND: in a segment whose trigger is not a human
+ask, every top mint demotes to a step under the goal the turn ran in; in a human-triggered segment a mint
+demotes when the segment's assistant turns started background work (an Agent/Task/Workflow tool_use, the
+event model's own launch record), whatever the words; token overlap only picks which launch supplies the
+step's why and, with no goal the turn ran in, which open goal is the parent. Demoted steps carry
+born {kind: session, via, why}. With nothing the user asked for to nest under, the mint files nothing.
+
+Synthetic fixtures only: placeholder uuids, invented workflow names, an invented project."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+jd = load_source("romp_judge_session_started", os.path.join(BIN, "romp-judge"))
+
+NOW = 1781100000
+SID = "11111111-2222-3333-4444-555555555555"
+T0 = NOW - 3600
+ASK = "Add retries to the notes-api client so a flaky network does not drop a note"
+WF_SCRIPT = ("export const meta = { name: 'review-notes-api-retry', description: 'Lens reviewers over the retry diff, "
+             "each finding verified' }\nconst r = await agent('review')\nreturn r")
+WF_UNRELATED = "export const meta = { name: 'orchard-count', description: 'Count the apples in the orchard by row' }\nreturn 1"
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn", launch=None):
+    content = [{"type": "text", "text": text}]
+    if launch:
+        content.append({"type": "tool_use", "id": "toolu_" + uuid, "name": launch[0], "input": launch[1]})
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": content, "stop_reason": stop}}
+
+
+def tresult(t, uuid, parent, tool_use_id, text="Workflow launched in background. Task ID: w1"):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "toolUseResult": {"isAsync": True, "status": "async_launched", "workflowName": "review-notes-api-retry"},
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": text}]}}
+
+
+PLACE_ASK = '{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"}]}'
+# the planner's realistic reply for an ENDED segment planned in one work-run: the ask's placement first, the
+# step under it, then the review as what the prompt calls a distinct deliverable
+REVIEW_AS_TOP = ('{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+                 '{"why":"progress on the retries","do":"sub","ref":1,"text":"Wrote the retry loop"},'
+                 '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
+# ...and for a segment whose ask the prompt-run already placed (the live case): the step and the review only
+REVIEW_LATER = ('{"ops":[{"why":"progress on the retries","do":"sub","under":1,"text":"Wrote the retry loop"},'
+                '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
+
+
+SKIP = '{"ops":[{"why":"skip","do":"skip"}]}'
+
+
+class _Harness(unittest.TestCase):
+    def _run(self, records, replies):
+        """replies: [(needle, reply), ...]: the planner (and the opener) answer by what the call's text carries,
+        the first matching needle wins; a call matching none is a skip."""
+        calls = []
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            def fake(text, *a, **k):
+                calls.append(text)
+                for needle, reply in replies:
+                    if needle in text:
+                        return reply
+                return SKIP
+            jd.plan_llm = jd.opener_llm = fake
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+            return calls, store
+
+    @staticmethod
+    def _tops(store):
+        return [nd for nd in store["nodes"].values() if nd.get("parentId") is None]
+
+    @staticmethod
+    def _by_text(store, frag):
+        return next((nd for nd in store["nodes"].values() if frag.lower() in (nd.get("text") or "").lower()), None)
+
+
+class WorkflowMidGoal(_Harness):
+    def _records(self, script=WF_SCRIPT):
+        return [
+            uline(T0, ASK, "u1"),
+            aline(T0 + 60, "Adding the retry loop now.", "a1", "u1", stop="tool_use",
+                  launch=("Workflow", {"script": script, "description": "ignored by the tool"})),
+            tresult(T0 + 61, "u2", "a1", "toolu_a1"),
+            aline(T0 + 400, "Wrote the retry loop and launched an adversarial review workflow over the diff; its findings come back in the background.", "a2", "u2"),
+            uline(T0 + 900, "thanks, carry on", "u3", "a2"),
+            aline(T0 + 910, "Carrying on.", "a3", "u3"),
+        ]
+
+    def test_a_workflow_the_session_started_nests_under_the_ask_with_its_why(self):
+        calls, store = self._run(self._records(), [("adversarial review workflow", REVIEW_AS_TOP), (ASK[:40], PLACE_ASK)])
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Add retries to the notes-api client"], "no new top for the session's own review")
+        self.assertIsNone(tops[0].get("born"), "the ask's own mint is the user's")
+        step = self._by_text(store, "Wrote the retry loop")
+        self.assertEqual(step["parentId"], tops[0]["id"], "the same-reply ref still lands on the ask")
+        rev = self._by_text(store, "Adversarial review")
+        self.assertIsNotNone(rev, "the review still exists, as a step")
+        self.assertEqual(rev["parentId"], tops[0]["id"], "under the goal the turn ran in")
+        self.assertEqual(rev["born"]["parentText"], "Add retries to the notes-api client", "the face can name the request even if the parent goes")
+        self.assertEqual(rev["born"]["kind"], "session")
+        self.assertEqual(rev["born"]["via"], "workflow")
+        self.assertIn("Lens reviewers over the retry diff", rev["born"]["why"], "the launch's own words supply the why")
+        self.assertIn("workflow", rev["born"]["why"])
+
+    def test_the_live_case_places_the_ask_first_and_nests_everything_the_work_run_mints(self):
+        # pass 1: the turn is open (the launch went out, no end yet) → the prompt-run places the ask alone
+        open_recs = self._records()[:3]
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            calls = []
+            def fake(text, *a, **k):
+                calls.append(text)
+                if "adversarial review workflow" in text:
+                    return REVIEW_LATER
+                return PLACE_ASK if ASK[:40] in text else SKIP
+            jd.plan_llm = jd.opener_llm = fake
+            jd._group_store = lambda *a, **k: None
+            try:
+                tpath.write_text("\n".join(json.dumps(r) for r in open_recs) + "\n")
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                mid = jd.load_goals(SID)
+                self.assertEqual([nd["text"] for nd in self._tops(mid)], ["Add retries to the notes-api client"], "placed on landing")
+                # pass 2: the turn ended with the review narration → the work-run's mint nests under the placed ask
+                tpath.write_text("\n".join(json.dumps(r) for r in self._records()) + "\n")
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Add retries to the notes-api client"])
+        rev = self._by_text(store, "Adversarial review")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev["parentId"], tops[0]["id"])
+        self.assertEqual(rev["born"]["via"], "workflow")
+
+    def test_a_launch_with_unrelated_words_still_demotes_the_mint(self):
+        # the event decides: the session started background work in this segment, so the narration's mint is a
+        # step whatever the launch was called; the unrelated launch's words still supply the why (the only one)
+        calls, store = self._run(self._records(script=WF_UNRELATED), [("adversarial review workflow", REVIEW_AS_TOP), (ASK[:40], PLACE_ASK)])
+        self.assertEqual(len(self._tops(store)), 1, "no new top")
+        rev = self._by_text(store, "Adversarial review")
+        self.assertIsNotNone(rev)
+        self.assertEqual(rev["parentId"], self._tops(store)[0]["id"])
+        self.assertIn("Count the apples", rev["born"]["why"])
+
+    def test_the_planner_prompt_names_the_rule_in_one_sentence(self):
+        self.assertIn("The session's own background workflows, review rounds and agents are its process, not deliverables: "
+                      "file them as steps under the goal they serve, never as a new top-level goal.", jd.PLAN_SYS)
+
+    def test_a_harness_report_is_not_what_the_user_asked_in_the_text_the_judges_read(self):
+        # the completion notification folds into the unit as a report, never under USER ASKED (the synthesis's
+        # route b: the planner read the notification's summary as the ask and minted the review as a deliverable)
+        atoms = [
+            {"type": "user", "author": "human", "message": {"content": [{"type": "text", "text": ASK}]}},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Wrote the retry loop."}]}},
+            {"type": "user", "author": "system", "message": {"content": [{"type": "text", "text": "<task-notification><summary>Workflow review-notes-api-retry completed</summary></task-notification>"}]}},
+        ]
+        text = jd._unit_text(atoms)
+        self.assertIn("USER ASKED: " + ASK, text)
+        self.assertNotIn("review-notes-api-retry", text.split("\n")[0], "the notification is not part of the ask line")
+        self.assertIn("BACKGROUND REPORTED (not the user): <task-notification>", text)
+
+    def test_a_foreground_agent_is_no_launch_so_a_second_ask_keeps_its_card(self):
+        # the turn WAITED on an Explore agent (no run_in_background, a synchronous result): the event model records
+        # no task for it, and neither does the rule; the user's second ask in the same message stays a card
+        records = [
+            uline(T0, ASK + " and also write me a comparison of the two retry libraries", "u1"),
+            aline(T0 + 60, "Reading the client first.", "a1", "u1", stop="tool_use",
+                  launch=("Agent", {"description": "Explore the retry code", "prompt": "Read the client"})),
+            {"type": "user", "timestamp": iso(T0 + 120), "uuid": "u2", "parentUuid": "a1",
+             "toolUseResult": {"status": "completed"},
+             "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_a1", "content": "the client has no retry"}]}},
+            aline(T0 + 400, "Wrote the retry loop and the comparison of the two libraries.", "a2", "u2"),
+        ]
+        two = ('{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+               '{"why":"a write-up the user asked to read","do":"mint","text":"Compare the two retry libraries"}]}')
+        calls, store = self._run(records, [("comparison of the two", two)])
+        self.assertEqual(sorted(nd["text"] for nd in self._tops(store)),
+                         ["Add retries to the notes-api client", "Compare the two retry libraries"], "two asks, two cards")
+        self.assertTrue(all(nd.get("born") is None for nd in store["nodes"].values()))
+
+    def test_a_human_segment_without_a_launch_still_mints_its_top(self):
+        # the user's own second ask in a turn with no background launch keeps the old behaviour: a new top
+        records = [
+            uline(T0, ASK, "u1"),
+            aline(T0 + 60, "Wrote the retry loop.", "a1", "u1"),
+            uline(T0 + 900, "also write me a comparison of the two retry libraries", "u2", "a1"),
+            aline(T0 + 950, "Here is the comparison of the two libraries.", "a2", "u2"),
+        ]
+        calls, store = self._run(records, [("comparison of the two", '{"ops":[{"why":"a write-up the user asked to read","do":"mint","text":"Compare the two retry libraries"}]}'), (ASK[:40], PLACE_ASK)])
+        self.assertEqual(len(self._tops(store)), 2, "a real second ask is a second card")
+        cmp_ = self._by_text(store, "Compare the two")
+        self.assertIsNone(cmp_.get("born"), "a user's ask is not session-started")
+
+
+class TriggerlessSegments(unittest.TestCase):
+    """A segment with no human trigger: the seam tail a completion notification wakes (seamOf names the settled
+    top), or an autonomous stretch. The trigger is the event: every mint demotes, no launch needed."""
+
+    def _store(self):
+        t1, t2 = SID + ":g1", SID + ":g2"
+        return {"rompUuid": SID, "seq": 2, "placements": {}, "nodes": {
+            t1: {"id": t1, "text": "Add retries to the notes-api client", "parentId": None, "nodeComplete": False, "cleared": False, "t": T0, "promptUuid": "u1"},
+            t2: {"id": t2, "text": "Rename the widget colours", "parentId": None, "nodeComplete": False, "cleared": False, "t": T0 + 100, "promptUuid": "u9"}}}
+
+    def _menu(self, store):
+        return [{"id": nid} for nid in store["nodes"]]
+
+    MINT = {"do": "mint", "why": "a nightly review round", "text": "Guard review of the notes-api retry loop"}
+
+    def test_a_seam_tail_nests_under_the_top_it_ran_in(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": None, "atoms": [], "seamOf": {"top": SID + ":g2", "text": "..."}}
+        ops = jd._demote_session_mints([dict(self.MINT), {"do": "skip", "why": ""}], seg, store, self._menu(store), None, False)
+        self.assertEqual([o["do"] for o in ops], ["sub", "skip"])
+        self.assertEqual(ops[0]["parentId"], SID + ":g2", "the seam's own top, whatever the words say")
+        self.assertEqual(ops[0]["born"], {"kind": "session", "via": "work", "why": "a nightly review round", "parentText": "Rename the widget colours"})
+
+    def test_without_a_placement_the_open_top_nearest_in_words_is_the_parent(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": None, "atoms": []}
+        ops = jd._demote_session_mints([dict(self.MINT)], seg, store, self._menu(store), None, False)
+        self.assertEqual(ops[0]["parentId"], SID + ":g1", "retries and notes-api: the retry goal")
+
+    def test_a_launch_in_the_segment_supplies_the_why_and_picks_the_parent(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": None, "atoms": [{"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Workflow", "input": {"script": "export const meta = { name: 'colour-audit', description: 'Audit the widget colours rename' }"}}]}}]}
+        ops = jd._demote_session_mints([dict(self.MINT)], seg, store, self._menu(store), None, False)
+        self.assertEqual(ops[0]["parentId"], SID + ":g2", "the launch's words pick the parent among open tops")
+        self.assertEqual(ops[0]["born"]["via"], "workflow")
+        self.assertIn("Audit the widget colours rename", ops[0]["born"]["why"])
+
+    def test_with_nothing_the_user_asked_for_the_mint_files_nothing(self):
+        store = {"rompUuid": SID, "seq": 0, "placements": {}, "nodes": {}}
+        seg = {"id": "s1", "trigger": None, "atoms": []}
+        self.assertEqual(jd._demote_session_mints([dict(self.MINT)], seg, store, [], None, False), [], "no card, no node")
+        # ...and the ops chained onto the dropped mint go with it: a sub by ref would otherwise land as a top
+        chained = [dict(self.MINT), {"do": "sub", "ref": 1, "why": "ran it", "text": "Ran the lens reviewers"}, {"do": "done", "ref": 1, "why": "finished"}]
+        self.assertEqual(jd._demote_session_mints(chained, seg, store, [], None, False), [])
+
+    def test_a_demoted_mint_keeps_its_refs_and_a_later_mint_shifts_none(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": None, "atoms": [], "seamOf": {"top": SID + ":g2", "text": "..."}}
+        ops = [dict(self.MINT), {"do": "sub", "ref": 1, "why": "ran it", "text": "Ran the lens reviewers"},
+               {"do": "done", "ref": 1, "why": "finished"}, {"do": "sub", "under": 1, "why": "aside", "text": "Noted a flake"}]
+        got = jd._demote_session_mints(ops, seg, store, self._menu(store), None, False)
+        self.assertEqual([o["do"] for o in got], ["sub", "sub", "done", "sub"])
+        self.assertEqual(got[0]["parentId"], SID + ":g2")
+        self.assertEqual(got[0]["born"]["parentText"], "Rename the widget colours")
+        self.assertEqual(got[1]["ref"], 1, "the demoted mint still created node 1")
+        self.assertEqual(got[2]["ref"], 1)
+        self.assertEqual(got[3]["under"], 1, "a menu-targeted sub is untouched")
+
+    def test_a_human_segment_without_a_launch_is_left_alone(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": "u1", "atoms": []}
+        ops = [dict(self.MINT)]
+        self.assertEqual(jd._demote_session_mints(ops, seg, store, self._menu(store), None, True), ops)
+
+    def test_a_notification_never_roots_a_mint(self):
+        seg = {"trigger": "n1", "atoms": [
+            {"type": "user", "uuid": "n1", "author": "system", "message": {"content": [{"type": "text", "text": "<task-notification>done</task-notification>"}]}},
+            {"type": "assistant", "uuid": "a1", "message": {"content": [{"type": "text", "text": "Folding the findings in."}]}}]}
+        self.assertEqual(jd._mint_anchor_uuid(seg), "a1", "the root claim moves to the session's own first record")
+
+
+class LaunchReader(unittest.TestCase):
+    def test_reads_background_launches_only_with_the_event_models_criterion(self):
+        seg = {"atoms": [
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": "t1", "name": "Workflow", "input": {"script": WF_SCRIPT}},
+                {"type": "tool_use", "id": "t2", "name": "Agent", "input": {"description": "Audit the open pull requests", "prompt": "...", "run_in_background": True}},
+                {"type": "tool_use", "id": "t3", "name": "Task", "input": {"prompt": "Guard review of the tree\nsecond line"}},
+                {"type": "tool_use", "id": "t4", "name": "Workflow", "input": {"scriptPath": "/tmp/TESTHOST/scripts/pr-audit-round.js"}},
+                {"type": "tool_use", "id": "t5", "name": "Agent", "input": {"description": "Explore the retry code (foreground)", "prompt": "read"}},
+                {"type": "tool_use", "id": "t6", "name": "Bash", "input": {"command": "ls"}}]}},
+            # t3's ack is asynchronous: a launch; t5's result is synchronous: the turn waited, no launch
+            {"type": "user", "toolUseResult": {"isAsync": True, "status": "async_launched"},
+             "message": {"content": [{"type": "tool_result", "tool_use_id": "t3", "content": "Agent launched in background"}]}},
+            {"type": "user", "toolUseResult": {"status": "completed"},
+             "message": {"content": [{"type": "tool_result", "tool_use_id": "t5", "content": "the client has no retry"}]}},
+            {"type": "assistant", "isApiError": True, "message": {"content": [{"type": "tool_use", "id": "t7", "name": "Agent", "input": {"description": "never counted", "run_in_background": True}}]}},
+        ]}
+        got = jd._seg_launches(seg)
+        self.assertEqual([l["via"] for l in got], ["workflow", "agent", "agent", "workflow"])
+        self.assertEqual(got[0]["desc"], "Lens reviewers over the retry diff, each finding verified")
+        self.assertEqual(got[1]["desc"], "Audit the open pull requests", "run_in_background on the input")
+        self.assertEqual(got[2]["desc"], "Guard review of the tree", "an asynchronous ack; the prompt's first line names it")
+        self.assertEqual(got[3]["desc"], "pr-audit-round", "a script file: its name")
+        self.assertFalse(any("foreground" in l["desc"] for l in got), "the agent the turn waited on is no launch")
+
+    def test_overlap_is_a_share_of_the_smaller_set(self):
+        self.assertEqual(jd._overlap("review the retry diff", "the retry diff review"), 1.0)
+        self.assertEqual(jd._overlap("", "anything"), 0.0)
+        self.assertLess(jd._overlap("count the apples in the orchard", "review the retry diff"), 0.34)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_session_started_work.py
+++ b/tests/test_session_started_work.py
@@ -171,15 +171,45 @@ class WorkflowMidGoal(_Harness):
         self.assertEqual(rev["parentId"], tops[0]["id"])
         self.assertEqual(rev["born"]["via"], "workflow")
 
-    def test_a_launch_with_unrelated_words_still_demotes_the_mint(self):
-        # the event decides: the session started background work in this segment, so the narration's mint is a
-        # step whatever the launch was called; the unrelated launch's words still supply the why (the only one)
+    def test_in_a_human_segment_a_mint_matching_no_launch_keeps_its_card(self):
+        # the manager's second ruling: in a human-triggered segment only a mint that matches a launch (its words in
+        # the mint's text or why) is the session's process; a mint like no launch may be a second thing the user
+        # asked for, so it stays a card (the trigger-less rule below still demotes everything)
         calls, store = self._run(self._records(script=WF_UNRELATED), [("adversarial review workflow", REVIEW_AS_TOP), (ASK[:40], PLACE_ASK)])
-        self.assertEqual(len(self._tops(store)), 1, "no new top")
+        self.assertEqual(sorted(nd["text"] for nd in self._tops(store)),
+                         ["Add retries to the notes-api client", "Adversarial review of the retry diff"])
+        self.assertIsNone(self._by_text(store, "Adversarial review").get("born"))
+
+    def test_the_asks_own_mint_is_chosen_by_its_words_not_its_position(self):
+        # a review-first reply: the mint nearest the user's words is the ask and keeps the card; the review nests
+        swapped = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
+                   '{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+                   '{"why":"progress on the retries","do":"sub","ref":2,"text":"Wrote the retry loop"}]}')
+        calls, store = self._run(self._records(), [("adversarial review workflow", swapped), (ASK[:40], PLACE_ASK)])
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Add retries to the notes-api client"])
         rev = self._by_text(store, "Adversarial review")
-        self.assertIsNotNone(rev)
-        self.assertEqual(rev["parentId"], self._tops(store)[0]["id"])
-        self.assertIn("Count the apples", rev["born"]["why"])
+        self.assertEqual(rev["parentId"], tops[0]["id"])
+        self.assertEqual(rev["born"]["via"], "workflow")
+        step = self._by_text(store, "Wrote the retry loop")
+        self.assertEqual(step["parentId"], tops[0]["id"], "the same-reply ref followed the ask's remapped position")
+
+    def test_a_two_ask_message_with_a_launch_keeps_both_asks_and_nests_the_review(self):
+        records = [
+            uline(T0, ASK + " and also write me a comparison of the two retry libraries", "u1"),
+            aline(T0 + 60, "Adding the retry loop now.", "a1", "u1", stop="tool_use", launch=("Workflow", {"script": WF_SCRIPT})),
+            tresult(T0 + 61, "u2", "a1", "toolu_a1"),
+            aline(T0 + 400, "Wrote the retry loop, the comparison, and launched an adversarial review workflow over the diff.", "a2", "u2"),
+        ]
+        three = ('{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+                 '{"why":"a write-up the user asked to read","do":"mint","text":"Compare the two retry libraries"},'
+                 '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
+        calls, store = self._run(records, [("adversarial review workflow", three)])
+        self.assertEqual(sorted(nd["text"] for nd in self._tops(store)),
+                         ["Add retries to the notes-api client", "Compare the two retry libraries"], "two asks, two cards")
+        rev = self._by_text(store, "Adversarial review")
+        self.assertEqual(rev["parentId"], self._by_text(store, "Add retries")["id"])
+        self.assertIsNone(self._by_text(store, "Compare the two").get("born"))
 
     def test_the_planner_prompt_names_the_rule_in_one_sentence(self):
         self.assertIn("The session's own background workflows, review rounds and agents are its process, not deliverables: "
@@ -289,6 +319,37 @@ class TriggerlessSegments(unittest.TestCase):
         self.assertEqual(got[1]["ref"], 1, "the demoted mint still created node 1")
         self.assertEqual(got[2]["ref"], 1)
         self.assertEqual(got[3]["under"], 1, "a menu-targeted sub is untouched")
+
+    def test_a_scheduled_prompt_is_the_users_and_its_mints_are_never_demoted(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": "c1", "atoms": [
+            {"type": "user", "uuid": "c1", "author": "sdk", "message": {"content": [{"type": "text", "text": "[SCHEDULED TASK - AUTOMATED FIRING OF A CONFIGURED PROMPT] nightly review"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "w1", "name": "Workflow", "input": {"script": "export const meta = { name: 'nightly', description: 'Nightly guard review' }"}}]}}]}
+        ops = [dict(self.MINT)]
+        self.assertEqual(jd._demote_session_mints(ops, seg, store, self._menu(store), None, False), ops, "user-chained: kept as a top, never dropped")
+
+    def test_a_trigger_less_segment_demotes_even_a_mint_unlike_its_launch(self):
+        # the trigger is the event: no launch words needed; the unrelated launch still supplies the why
+        store = self._store()
+        seg = {"id": "s1", "trigger": None, "atoms": [{"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "w1", "name": "Workflow", "input": {"script": WF_UNRELATED}}]}}], "seamOf": {"top": SID + ":g1", "text": "..."}}
+        ops = jd._demote_session_mints([dict(self.MINT)], seg, store, self._menu(store), None, False)
+        self.assertEqual(ops[0]["do"], "sub"); self.assertEqual(ops[0]["parentId"], SID + ":g1")
+        self.assertIn("Count the apples", ops[0]["born"]["why"])
+
+    def test_a_demoted_mint_that_lands_on_a_twin_keeps_every_later_ref_in_place(self):
+        # the demoted step's title matches an open sibling under the parent: apply_plan lands on the twin (no new node)
+        # and the reply's created positions must still hold, so `sub ref 1` nests under the twin, never as a fresh top
+        store = self._store()
+        parent = SID + ":g1"; twin = SID + ":g5"
+        store["nodes"][twin] = {"id": twin, "text": "Guard review of the notes-api retry loop", "parentId": parent, "nodeComplete": False, "cleared": False, "t": T0 + 50}
+        ops = [{"do": "sub", "parentId": parent, "why": "round two", "text": "Guard review of the notes-api retry loop", "born": {"kind": "session", "via": "work", "why": "round two"}},
+               {"do": "sub", "ref": 1, "why": "ran it", "text": "Ran the lens reviewers"}]
+        jd.apply_plan(store, "s9", T0 + 900, ops, self._menu(store), prompt_uuid=None, quote=None)
+        tops = [nd for nd in store["nodes"].values() if nd.get("parentId") is None]
+        self.assertEqual(len(tops), 2, "no fresh top")
+        ran = next(nd for nd in store["nodes"].values() if nd["text"] == "Ran the lens reviewers")
+        self.assertEqual(ran["parentId"], twin, "the ref followed the twin the demoted step landed on")
 
     def test_a_human_segment_without_a_launch_is_left_alone(self):
         store = self._store()

--- a/tests/test_session_started_work.py
+++ b/tests/test_session_started_work.py
@@ -194,6 +194,33 @@ class WorkflowMidGoal(_Harness):
         step = self._by_text(store, "Wrote the retry loop")
         self.assertEqual(step["parentId"], tops[0]["id"], "the same-reply ref followed the ask's remapped position")
 
+    def test_the_planners_ask_mark_wins_over_words_a_paraphrased_title_keeps_the_card(self):
+        # the planner marks the ask's mint ("ask": true); a paraphrased title shares no word with the user's message,
+        # and the review-first order would once have crowned the review. The mark crowns the paraphrase.
+        marked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
+                  '{"why":"the user asked for resilience","do":"mint","ask":true,"text":"Make the client resilient to flaky networks"}]}')
+        calls, store = self._run(self._records(), [("adversarial review workflow", marked), (ASK[:40], PLACE_ASK)])
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Make the client resilient to flaky networks"])
+        rev = self._by_text(store, "Adversarial review")
+        self.assertEqual(rev["parentId"], tops[0]["id"])
+        self.assertEqual(rev["born"]["parentText"], "Make the client resilient to flaky networks")
+
+    def test_a_launch_favoured_mint_is_never_crowned_even_when_marked_or_tied(self):
+        # every mint shares no word with the user's message (a tie); the review's words fit the launch, so it is
+        # never the ask, whatever its position or a stray mark; the other mint is crowned
+        tied = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","ask":true,"text":"Adversarial review of the retry diff"},'
+                '{"why":"the user asked for resilience","do":"mint","text":"Make the client resilient to flaky networks"}]}')
+        calls, store = self._run(self._records(), [("adversarial review workflow", tied), (ASK[:40], PLACE_ASK)])
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Make the client resilient to flaky networks"])
+        self.assertEqual(self._by_text(store, "Adversarial review")["parentId"], tops[0]["id"])
+
+    def test_the_parser_carries_the_ask_mark_and_the_prompt_asks_for_it(self):
+        ops = jd._parse_plan('{"ops":[{"why":"w","do":"mint","ask":true,"text":"Add retries"},{"why":"w","do":"mint","text":"Other"}]}', 0)
+        self.assertEqual([o.get("ask") for o in ops], [True, None])
+        self.assertIn('Put "ask": true on the one mint that is the deliverable the user\'s own message asked for', jd.PLAN_SYS)
+
     def test_a_two_ask_message_with_a_launch_keeps_both_asks_and_nests_the_review(self):
         records = [
             uline(T0, ASK + " and also write me a comparison of the two retry libraries", "u1"),

--- a/tests/test_session_started_work.py
+++ b/tests/test_session_started_work.py
@@ -60,12 +60,16 @@ def tresult(t, uuid, parent, tool_use_id, text="Workflow launched in background.
 PLACE_ASK = '{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"}]}'
 # the planner's realistic reply for an ENDED segment planned in one work-run: the ask's placement first, the
 # step under it, then the review as what the prompt calls a distinct deliverable
-REVIEW_AS_TOP = ('{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+REVIEW_AS_TOP = ('{"ops":[{"why":"the user asked for retries","do":"mint","kind":"ask","text":"Add retries to the notes-api client"},'
                  '{"why":"progress on the retries","do":"sub","ref":1,"text":"Wrote the retry loop"},'
-                 '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
+                 '{"why":"a distinct review deliverable","do":"mint","kind":"process","text":"Adversarial review of the retry diff"}]}')
+# the same reply with NO labels: the words fill them in (exactly one ask, the one nearest the user's message)
+REVIEW_UNLABELED = ('{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+                    '{"why":"progress on the retries","do":"sub","ref":1,"text":"Wrote the retry loop"},'
+                    '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
 # ...and for a segment whose ask the prompt-run already placed (the live case): the step and the review only
 REVIEW_LATER = ('{"ops":[{"why":"progress on the retries","do":"sub","under":1,"text":"Wrote the retry loop"},'
-                '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
+                '{"why":"a distinct review deliverable","do":"mint","kind":"process","text":"Adversarial review of the retry diff"}]}')
 
 
 SKIP = '{"ops":[{"why":"skip","do":"skip"}]}'
@@ -171,68 +175,115 @@ class WorkflowMidGoal(_Harness):
         self.assertEqual(rev["parentId"], tops[0]["id"])
         self.assertEqual(rev["born"]["via"], "workflow")
 
-    def test_in_a_human_segment_a_mint_matching_no_launch_keeps_its_card(self):
-        # the manager's second ruling: in a human-triggered segment only a mint that matches a launch (its words in
-        # the mint's text or why) is the session's process; a mint like no launch may be a second thing the user
-        # asked for, so it stays a card (the trigger-less rule below still demotes everything)
-        calls, store = self._run(self._records(script=WF_UNRELATED), [("adversarial review workflow", REVIEW_AS_TOP), (ASK[:40], PLACE_ASK)])
-        self.assertEqual(sorted(nd["text"] for nd in self._tops(store)),
-                         ["Add retries to the notes-api client", "Adversarial review of the retry diff"])
-        self.assertIsNone(self._by_text(store, "Adversarial review").get("born"))
+    def test_labels_are_trusted_a_process_mint_nests_even_with_no_launch_and_an_ask_stays(self):
+        # the planner knows: a review round it labelled process nests under the ask (via work: no launch in the
+        # segment), and a second deliverable labelled ask keeps its card
+        records = [
+            uline(T0, ASK, "u1"),
+            aline(T0 + 60, "Wrote the retry loop and reviewed it myself; also compared the two libraries.", "a1", "u1"),
+        ]
+        reply = ('{"ops":[{"why":"the user asked for retries","do":"mint","kind":"ask","text":"Add retries to the notes-api client"},'
+                 '{"why":"my own review round","do":"mint","kind":"process","text":"Self-review of the retry loop"},'
+                 '{"why":"a write-up the user asked to read","do":"mint","kind":"ask","text":"Compare the two retry libraries"}]}')
+        calls, store = self._run(records, [("reviewed it myself", reply)])
+        self.assertEqual(sorted(nd["text"] for nd in self._tops(store)), ["Add retries to the notes-api client", "Compare the two retry libraries"])
+        rev = self._by_text(store, "Self-review")
+        self.assertEqual(rev["parentId"], self._by_text(store, "Add retries")["id"])
+        self.assertEqual(rev["born"]["via"], "work")
+        self.assertEqual(rev["born"]["why"], "my own review round", "no launch: the planner's own why")
 
-    def test_the_asks_own_mint_is_chosen_by_its_words_not_its_position(self):
-        # a review-first reply: the mint nearest the user's words is the ask and keeps the card; the review nests
-        swapped = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
-                   '{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
+    def test_unlabelled_mints_with_a_launch_keep_exactly_one_the_nearest_the_users_words(self):
+        calls, store = self._run(self._records(), [("adversarial review workflow", REVIEW_UNLABELED), (ASK[:40], PLACE_ASK)])
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Add retries to the notes-api client"])
+        rev = self._by_text(store, "Adversarial review")
+        self.assertEqual(rev["parentId"], tops[0]["id"])
+        self.assertEqual(rev["born"]["via"], "workflow")
+
+    def test_the_crown_reads_the_text_never_the_why_or_the_position(self):
+        # review first, and its why names the project's nouns; the ask's text is nearest the user's words
+        swapped = ('{"ops":[{"why":"the retries for the notes-api client the user wanted","do":"mint","text":"Adversarial review of the retry diff"},'
+                   '{"why":"a distinct deliverable","do":"mint","text":"Add retries to the notes-api client"},'
                    '{"why":"progress on the retries","do":"sub","ref":2,"text":"Wrote the retry loop"}]}')
         calls, store = self._run(self._records(), [("adversarial review workflow", swapped), (ASK[:40], PLACE_ASK)])
         tops = self._tops(store)
         self.assertEqual([nd["text"] for nd in tops], ["Add retries to the notes-api client"])
         rev = self._by_text(store, "Adversarial review")
         self.assertEqual(rev["parentId"], tops[0]["id"])
-        self.assertEqual(rev["born"]["via"], "workflow")
-        step = self._by_text(store, "Wrote the retry loop")
-        self.assertEqual(step["parentId"], tops[0]["id"], "the same-reply ref followed the ask's remapped position")
+        self.assertEqual(self._by_text(store, "Wrote the retry loop")["parentId"], tops[0]["id"], "the same-reply ref followed the ask")
 
-    def test_the_planners_ask_mark_alone_decides_against_a_better_worded_rival(self):
-        # the marked title shares NO word with the user's message; the rival mint repeats the user's words and would
-        # win on overlap; the review-first order would once have crowned the review. The mark alone decides.
-        marked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
-                  '{"why":"what was asked","do":"mint","text":"Add retries to the notes-api client"},'
-                  '{"why":"the shape the user wants","do":"mint","ask":true,"text":"Harden outbound calls against dropped packets"}]}')
-        calls, store = self._run(self._records(), [("adversarial review workflow", marked), (ASK[:40], PLACE_ASK)])
-        tops = sorted(nd["text"] for nd in self._tops(store))
-        self.assertIn("Harden outbound calls against dropped packets", tops, "the mark crowns the paraphrase")
-        self.assertIn("Add retries to the notes-api client", tops, "the rival, nearer the user's words than any launch, stays a card too")
+    def test_a_process_label_on_the_placed_path_nests_and_an_ask_label_there_keeps_its_card(self):
+        # the live case: the prompt run placed the message; the work run's mints carry labels, and both are honoured
+        open_recs = self._records()[:3]
+        reply = ('{"ops":[{"why":"progress","do":"sub","under":1,"text":"Wrote the retry loop"},'
+                 '{"why":"the review round","do":"mint","kind":"process","text":"Adversarial review of the retry diff"},'
+                 '{"why":"the user also asked to read this","do":"mint","kind":"ask","text":"Compare the two retry libraries"}]}')
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td)
+            tpath = td / (SID + ".jsonl")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            def fake(text, *a, **k):
+                if "adversarial review workflow" in text:
+                    return reply
+                return PLACE_ASK if ASK[:40] in text else SKIP
+            jd.plan_llm = jd.opener_llm = fake
+            jd._group_store = lambda *a, **k: None
+            try:
+                tpath.write_text("\n".join(json.dumps(r) for r in open_recs) + "\n")
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                tpath.write_text("\n".join(json.dumps(r) for r in self._records()) + "\n")
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+                jd._plan_session(SID, str(tpath), NOW)
+                store = jd.load_goals(SID)
+            finally:
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store) = saved
+        self.assertEqual(sorted(nd["text"] for nd in self._tops(store)), ["Add retries to the notes-api client", "Compare the two retry libraries"])
         rev = self._by_text(store, "Adversarial review")
-        self.assertEqual(rev["parentId"], self._by_text(store, "Harden outbound")["id"], "the review nests under the marked ask")
+        self.assertEqual(rev["parentId"], self._by_text(store, "Add retries")["id"])
+        self.assertIsNone(self._by_text(store, "Compare the two").get("born"))
 
-    def test_a_short_approval_still_keeps_a_top_and_the_mark_beats_a_launch_word_in_its_why(self):
-        # "yes, go ahead": every mint shares no word with the message. The marked mint's why shares a word with the
-        # launch; before this fold the filter excluded it, no ask was crowned, every mint demoted, and with no open
-        # top the user's approved deliverable never reached the board
-        recs = [
-            uline(T0, "yes, go ahead", "u1"),
-            aline(T0 + 60, "Going ahead with the retry loop.", "a1", "u1", stop="tool_use", launch=("Workflow", {"script": WF_SCRIPT})),
-            tresult(T0 + 61, "u2", "a1", "toolu_a1"),
-            aline(T0 + 400, "Wrote the retry loop and launched an adversarial review workflow over the diff.", "a2", "u2"),
+    def test_unlabelled_mints_that_all_read_like_the_launch_nest_when_a_top_exists(self):
+        # two unlabelled mints, both fitting the launch's words better than the user's short approval; the ask was
+        # placed by the prompt run, so both nest under it: nothing is crowned by position
+        records = [
+            uline(T0, ASK, "u0"),
+            aline(T0 + 30, "Wrote the retry loop.", "a0", "u0"),
+            uline(T0 + 900, "yes, go ahead", "u1", "a0"),
+            aline(T0 + 960, "Going ahead.", "a1", "u1", stop="tool_use", launch=("Workflow", {"script": WF_SCRIPT})),
+            tresult(T0 + 961, "u2", "a1", "toolu_a1"),
+            aline(T0 + 1400, "Launched an adversarial review workflow over the retry diff and its lens reviewers.", "a2", "u2"),
         ]
-        marked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
-                  '{"why":"the retry diff the user approved","do":"mint","ask":true,"text":"Harden outbound calls against dropped packets"}]}')
-        calls, store = self._run(recs, [("adversarial review workflow", marked)])
-        tops = [nd["text"] for nd in self._tops(store)]
-        self.assertEqual(tops, ["Harden outbound calls against dropped packets"], "the marked deliverable reaches the board")
-        self.assertEqual(self._by_text(store, "Adversarial review")["parentId"], self._tops(store)[0]["id"])
-        # ...and with no mark at all, a human segment still keeps one top (the first mint, when no words help)
-        unmarked = ('{"ops":[{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"},'
-                    '{"why":"the approved work","do":"mint","text":"Harden outbound calls against dropped packets"}]}')
-        calls, store = self._run(recs, [("adversarial review workflow", unmarked)])
-        self.assertEqual(len(self._tops(store)), 1, "never nothing for a human segment")
+        two = ('{"ops":[{"why":"a","do":"mint","text":"Lens reviewers over the diff"},'
+               '{"why":"b","do":"mint","text":"Adversarial review of the retry diff"}]}')
+        calls, store = self._run(records, [("adversarial review workflow", two), (ASK[:40], PLACE_ASK)])
+        tops = self._tops(store)
+        self.assertEqual([nd["text"] for nd in tops], ["Add retries to the notes-api client"], "the open ask hosts; nothing is crowned")
+        for frag in ("Lens reviewers", "Adversarial review"):
+            self.assertEqual(self._by_text(store, frag)["parentId"], tops[0]["id"], frag)
 
-    def test_the_parser_carries_the_ask_mark_and_the_prompt_asks_for_it(self):
-        ops = jd._parse_plan('{"ops":[{"why":"w","do":"mint","ask":true,"text":"Add retries"},{"why":"w","do":"mint","text":"Other"}]}', 0)
-        self.assertEqual([o.get("ask") for o in ops], [True, None])
-        self.assertIn('Put "ask": true on the one mint that is the deliverable the user\'s own message asked for', jd.PLAN_SYS)
+    def test_with_no_top_at_all_the_mint_least_like_the_launch_keeps_the_card(self):
+        # the last resort: no label, every mint shares a word with the launch, no top to nest under; the message must
+        # place somewhere, so the least launch-like mint keeps the card (never the first by position)
+        store = {"rompUuid": SID, "seq": 0, "placements": {}, "nodes": {}}
+        seg = {"id": "s1", "trigger": "u1", "atoms": [
+            {"type": "user", "uuid": "u1", "author": "human", "message": {"content": [{"type": "text", "text": "yes, go ahead"}]}},
+            {"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "w1", "name": "Workflow", "input": {"script": WF_SCRIPT}}]}}]}
+        ops = [{"do": "mint", "why": "a", "text": "Lens reviewers over the retry diff"},
+               {"do": "mint", "why": "b", "text": "Harden the outbound retry calls"}]
+        got = jd._demote_session_mints(ops, seg, store, [], None, True)
+        self.assertEqual([o["do"] for o in got], ["mint", "sub"])
+        self.assertEqual(got[0]["text"], "Harden the outbound retry calls")
+        self.assertEqual(got[1]["ref"], 1)
+
+    def test_the_parser_carries_the_label_and_the_earlier_mark_and_the_prompt_asks_for_it(self):
+        ops = jd._parse_plan('{"ops":[{"why":"w","do":"mint","kind":"ask","text":"Add retries"},{"why":"w","do":"mint","kind":"process","text":"Review"},'
+                             '{"why":"w","do":"mint","ask":true,"text":"Old mark"},{"why":"w","do":"mint","kind":"other","text":"Junk"}]}', 0)
+        self.assertEqual([o.get("kind") for o in ops], ["ask", "process", "ask", None])
+        self.assertIn('Every mint carries "kind": "ask" (a deliverable the user\'s message asked for, e.g. "Add retries to the client") or '
+                      '"kind": "process" (work the session started for itself: a review round, an audit, a workflow or agent it launched, '
+                      'e.g. "Adversarial review of the retry diff").', jd.PLAN_SYS)
 
     def test_a_two_ask_message_with_a_launch_keeps_both_asks_and_nests_the_review(self):
         records = [
@@ -241,9 +292,9 @@ class WorkflowMidGoal(_Harness):
             tresult(T0 + 61, "u2", "a1", "toolu_a1"),
             aline(T0 + 400, "Wrote the retry loop, the comparison, and launched an adversarial review workflow over the diff.", "a2", "u2"),
         ]
-        three = ('{"ops":[{"why":"the user asked for retries","do":"mint","text":"Add retries to the notes-api client"},'
-                 '{"why":"a write-up the user asked to read","do":"mint","text":"Compare the two retry libraries"},'
-                 '{"why":"a distinct review deliverable","do":"mint","text":"Adversarial review of the retry diff"}]}')
+        three = ('{"ops":[{"why":"the user asked for retries","do":"mint","kind":"ask","text":"Add retries to the notes-api client"},'
+                 '{"why":"a write-up the user asked to read","do":"mint","kind":"ask","text":"Compare the two retry libraries"},'
+                 '{"why":"the review round","do":"mint","kind":"process","text":"Adversarial review of the retry diff"}]}')
         calls, store = self._run(records, [("adversarial review workflow", three)])
         self.assertEqual(sorted(nd["text"] for nd in self._tops(store)),
                          ["Add retries to the notes-api client", "Compare the two retry libraries"], "two asks, two cards")
@@ -360,6 +411,12 @@ class TriggerlessSegments(unittest.TestCase):
         self.assertEqual(got[2]["ref"], 1)
         self.assertEqual(got[3]["under"], 1, "a menu-targeted sub is untouched")
 
+    def test_a_label_cannot_make_a_trigger_less_mint_an_ask(self):
+        store = self._store()
+        seg = {"id": "s1", "trigger": None, "atoms": [], "seamOf": {"top": SID + ":g2", "text": "..."}}
+        ops = jd._demote_session_mints([dict(self.MINT, kind="ask")], seg, store, self._menu(store), None, False)
+        self.assertEqual(ops[0]["do"], "sub", "no human asked: the label does not stand")
+
     def test_a_scheduled_prompt_is_the_users_and_its_mints_are_never_demoted(self):
         store = self._store()
         seg = {"id": "s1", "trigger": "c1", "atoms": [
@@ -411,6 +468,13 @@ class LaunchReader(unittest.TestCase):
         seg = {"atoms": [{"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t1", "name": "Workflow", "input": {"script": script}}]}}]}
         self.assertEqual(jd._seg_launches(seg)[0]["desc"], "Lens reviewers over the retry diff")
         self.assertEqual(jd._wf_meta("const x = 1"), {}, "no meta literal: nothing")
+
+    def test_a_nested_object_before_the_description_does_not_end_the_meta_scan(self):
+        script = ("export const meta = { name: 'guard', phases: [{ title: 'Scan', detail: 'grep' }], description: 'Nightly guard review' }\n"
+                  "const S = { type: 'object', description: 'a schema field' }")
+        self.assertEqual(jd._wf_meta(script).get("description"), "Nightly guard review")
+        self.assertEqual(jd.em._launch_desc("Workflow", {"script": script}), "Nightly guard review", "the event model reads the same literal")
+        self.assertEqual(jd.em._launch_desc("Workflow", {"script": "export const meta = { name: 'only-name' }\nconst S = { description: 'schema words' }"}), "only-name")
 
     def test_reads_background_launches_only_with_the_event_models_criterion(self):
         seg = {"atoms": [

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -53,6 +53,8 @@ interface AskQuestion { reply_id: string; sid: string; name: string; t: number; 
 // One node of the ask's request DAG (flat list, root first; nest via children ids;
 // a node under two parents appears in both → render twice, dim the repeat).
 interface AskTreeNode {
+  born?: { kind: string; via: string; why: string; healed?: boolean } | null;   // T319: a step the session started on its own
+                                                                                //   (via: workflow | agent | work); why it sits under this goal
   id: string; kind: "ask" | "handoff"; text: string; who: string;
   whoSid: string; whoColor: { bg: string; fg: string } | null;   // agent → colored session link
   whoWorking?: boolean;                                          // that agent is currently WORKING → yellow dot before its name
@@ -80,6 +82,9 @@ interface NodeLogRow {
   at?: number | null; evT?: number | null; anchorUuid?: string | null;
 }
 interface AskItem {
+  sessionStarted?: { why: string; parent: string | null } | null;   // T319: the root is work the SESSION started (a workflow, an
+                                                                    //   agent, its own thread) with no request of the user's to nest
+                                                                    //   under; the face says so in one line instead of posing as an ask
   itemId: string; sid: string; name: string; color: { bg: string; fg: string } | null;
   text: string; t: number; live: boolean;
   turnId: string;
@@ -2272,6 +2277,16 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // TWO collapsible distiller sections (the user 2026-07-02): BACKGROUND (re-orientation for a reader who
   // forgot the thread, collapsed by default) above the takeaway (expanded by default), each with a +/−.
   applySections(a, it, !!distillShown);   // bg/summary/sub-goals (mutually exclusive) — applyDistillLine returns the line's TEXT (string), coerce to "has content"
+  // A SESSION-STARTED root (T319): work the session began on its own (a Workflow run, an agent, a thread of
+  // its own) that stands as a card only because its parent is gone or no request could host it. The face
+  // says what it is and why in one line, so it never reads as something the user asked for. AFTER
+  // applySections: with no takeaway that logic hides the distill line, and the face borrows that line.
+  if (it.sessionStarted && !distillShown && !(isJudgeAuth && it.blocked)) {
+    const dle = a._distill as HTMLElement;
+    const ss = it.sessionStarted;
+    dle.textContent = (ss.parent ? "Started by the session while working on \u201c" + ss.parent + "\u201d: " : "Started by the session on its own: ") + (ss.why || "");
+    dle.style.display = "";
+  }
   // API error → a red "API error" badge + a Retry button that pastes "retry" into the session to resume
   // the stalled turn (the user 2026-06-16). The card STAYS in Working (the user 2026-06-29) — an API error is
   // a transient stall, not a block — so this badge + Retry are the only API-error cue; no column move.

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -2278,14 +2278,27 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
   // forgot the thread, collapsed by default) above the takeaway (expanded by default), each with a +/−.
   applySections(a, it, !!distillShown);   // bg/summary/sub-goals (mutually exclusive) — applyDistillLine returns the line's TEXT (string), coerce to "has content"
   // A SESSION-STARTED root (T319): work the session began on its own (a Workflow run, an agent, a thread of
-  // its own) that stands as a card only because its parent is gone or no request could host it. The face
-  // says what it is and why in one line, so it never reads as something the user asked for. AFTER
-  // applySections: with no takeaway that logic hides the distill line, and the face borrows that line.
-  if (it.sessionStarted && !distillShown && !(isJudgeAuth && it.blocked)) {
-    const dle = a._distill as HTMLElement;
+  // its own) that stands as a card only because its parent is gone, no request could host it, or it is
+  // blocked (needs-you breaks through). The face says what it is and why in one line, so it never reads as
+  // something the user asked for. Its OWN line, created once beside the sections and kept outside them: the
+  // distill line lives inside the collapsible sections, whose logic hides it without a takeaway and whose
+  // decision brief would otherwise displace the face; both show.
+  {
+    let fe = a._face as HTMLElement | undefined;
+    if (!fe) {
+      fe = el("div", "fask-distill fask-face");
+      const secs = a._secs as HTMLElement;
+      secs.parentNode!.insertBefore(fe, secs.nextSibling);
+      a._face = fe;
+    }
     const ss = it.sessionStarted;
-    dle.textContent = (ss.parent ? "Started by the session while working on \u201c" + ss.parent + "\u201d: " : "Started by the session on its own: ") + (ss.why || "");
-    dle.style.display = "";
+    if (ss) {
+      fe.textContent = (ss.parent ? "Started by the session while working on \u201c" + ss.parent + "\u201d: " : "Started by the session on its own: ") + (ss.why || "");
+      fe.style.display = "";
+    } else {
+      fe.textContent = "";
+      fe.style.display = "none";
+    }
   }
   // API error → a red "API error" badge + a Retry button that pastes "retry" into the session to resume
   // the stalled turn (the user 2026-06-16). The card STAYS in Working (the user 2026-06-29) — an API error is

--- a/ui/webview/session-started-face.test.ts
+++ b/ui/webview/session-started-face.test.ts
@@ -15,11 +15,13 @@ test("the card item and the tree node carry the session-started records the kern
   assert.match(FEED, /interface AskTreeNode \{\n  born\?: \{ kind: string; via: string; why: string; healed\?: boolean \} \| null;/, "the tree row's why");
 });
 
-test("a session-started root says so in one line on the distill line, yielding to a real takeaway", () => {
-  const face = FEED.indexOf("if (it.sessionStarted && !distillShown && !(isJudgeAuth && it.blocked)) {");
-  assert.ok(face > 0, "shown only when no takeaway or decision brief occupies the line, and never over a judge-auth explanation");
+test("a session-started root says so on its own line beside the sections, shown with or without a takeaway", () => {
+  const face = FEED.indexOf('fe = el("div", "fask-distill fask-face");');
+  assert.ok(face > 0, "the face has its own element (the distill line's look), created once");
+  assert.ok(FEED.includes("secs.parentNode!.insertBefore(fe, secs.nextSibling);"), "kept OUTSIDE the collapsible sections, whose logic hides the distill line");
   const sections = FEED.indexOf("applySections(a, it, !!distillShown);");
-  assert.ok(sections > 0 && face > sections, "set AFTER applySections, whose no-takeaway branch hides the distill line the face borrows");
+  assert.ok(sections > 0 && face > sections, "set after the section logic runs");
   assert.ok(FEED.includes('"Started by the session while working on \\u201c" + ss.parent + "\\u201d: "'), "names the parent request when known");
   assert.ok(FEED.includes('"Started by the session on its own: "'), "and says so plainly when none is known");
+  assert.ok(FEED.includes('fe.style.display = "none";'), "and clears on a later push when the record is gone");
 });

--- a/ui/webview/session-started-face.test.ts
+++ b/ui/webview/session-started-face.test.ts
@@ -1,0 +1,25 @@
+// The card face for work a session started on its own (T319, the user 2026-09-10): such work is nested under
+// the goal it ran in at mint time and by the feed's read-side heal, so a root card for it is the exception (its
+// parent gone); when one shows, the face says what it is and why in one line, never posing as something the
+// user asked for. The rule lives in feed.ts's updateAskCard; these pins hold its shape.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(process.cwd(), "..");
+const FEED = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.ts"), "utf8");
+
+test("the card item and the tree node carry the session-started records the kernel ships", () => {
+  assert.match(FEED, /interface AskItem \{\n  sessionStarted\?: \{ why: string; parent: string \| null \} \| null;/, "the card's face record");
+  assert.match(FEED, /interface AskTreeNode \{\n  born\?: \{ kind: string; via: string; why: string; healed\?: boolean \} \| null;/, "the tree row's why");
+});
+
+test("a session-started root says so in one line on the distill line, yielding to a real takeaway", () => {
+  const face = FEED.indexOf("if (it.sessionStarted && !distillShown && !(isJudgeAuth && it.blocked)) {");
+  assert.ok(face > 0, "shown only when no takeaway or decision brief occupies the line, and never over a judge-auth explanation");
+  const sections = FEED.indexOf("applySections(a, it, !!distillShown);");
+  assert.ok(sections > 0 && face > sections, "set AFTER applySections, whose no-takeaway branch hides the distill line the face borrows");
+  assert.ok(FEED.includes('"Started by the session while working on \\u201c" + ss.parent + "\\u201d: "'), "names the parent request when known");
+  assert.ok(FEED.includes('"Started by the session on its own: "'), "and says so plainly when none is known");
+});


### PR DESCRIPTION
A card appears only for work that traces to something the user asked for (the user 2026-09-10, whose feed filled with top-level cards titled after the workflows their sessions ran on their own: adversarial-review rounds, pull-request audits, guard reviews, each attributed to the authoring session and leading to the session's run rather than to anything they asked for). Session-initiated work now stays inside the goal it ran in; when a card for such work still shows, its face names the parent request and says in one line why the session started it.

## Where the cards came from

Scouted on the code and on today's live feed, read through the kernel's own feed route. The event model's `local_workflow` and `local_agent` items are not the source: they reach the feed only as rows inside the parent card's awaiting panel, and no card is built from them. The cards are goal nodes the planner minted from a work run: the session's narration of starting or finishing a Workflow read as a "distinct deliverable", which the planner's rule says always mints. Two roads feed that: the harness's completion notification is authored `system` and folds into the previous turn's tail, which the planner later sees as a trigger-less seam segment with no human ask; and inside a human turn the notification's summary was joined into the `USER ASKED` line of the text the judges read. Today's stores hold three such tops, all with a prompt uuid the judge's own anchor latch already marks as pointing at a machine record; there are no anchorless tops.

## The origin rule at minting time (kernel/judge.py)

The planner labels every mint `kind`: `ask` (a deliverable the user's message asked for) or `process` (work the session started for itself: a review round, an audit, a workflow or agent it launched), one sentence in its prompt with an example of each, and the rule trusts the labels (the fourth review round: four rounds of word-overlap edge cases ended by asking the model, which knows). In the planner's work run, after the existing bookkeeping floor:
- `kind: ask` keeps its card, on both paths: an unplaced human segment, and one whose prompt run already placed the message.
- `kind: process` nests as a step under the ask's top: the goal the turn ran in (the seam's own top, the segment's placement), else this reply's ask (the one nearest the user's words hosts), else the open top nearest in words to the launch or the step, else nothing, with the ops chained onto it dropped and surviving references remapped. `born.via` is the matching background launch's kind (a Workflow run, or an Agent or Task with `run_in_background` or an asynchronous ack; a foreground subagent is no launch), its words the why; with no matching launch, `work` and the planner's own why.
- A segment whose trigger is not a human ask (a seam tail a notification woke, an autonomous stretch) treats every mint as process, whatever its label; a scheduled or programmatic prompt traces to the user's earlier setup and is left untouched.
- A missing label is filled by the words, and only then: in a human segment with no launch a mint is an ask; with a launch every unlabelled mint is process except exactly one, the one nearest the user's own words (its text against the message, never its why, never its position), and only among the mints no launch fits better; when every unlabelled mint reads like a launch and a top exists to nest under, all of them nest; when none exists, the one least like a launch keeps the card, since the message must place somewhere.
- A demoted step carries `born` (`{kind: session, via, why, parentText}`), persisted by `apply_plan`; a sub may name its parent by node id; a sub that lands on a same-titled twin keeps its created position. `born` is a new field rather than `origin`, which the store already uses for postal-delegate frames.
- A harness report (a background task's completion, a system reminder) or a teammate's line goes under `BACKGROUND REPORTED (not the user):` in the text the judges read, never under `USER ASKED`, and never roots a mint.

## The feed (kernel/kernel.py, ui/webview/feed.ts)

- Read-side heal for stores written before the rule: a top rooted in a machine record (the judge's latched `askAnchor` verdict: a peer's line, the agent's own record, romp bookkeeping) is rendered inside the session's human-asked top that was current when it was minted. Only that latched verdict qualifies: a top that merely lacks an anchor is older data, not evidence, and keeps its card. Handoff trackers, delegate-rooted tops and session-born steps are never candidates; a human-anchored top is never touched. A blocked top or a clear wrap-up card keeps its card (needs-you breaks through) and still wears the face that says what it is. Hosts are the asks that trace to the user: human-anchored tops and courier-planted delegated goals whose chain the courier proved to a human (`userAsk`), never a handoff tracker or a mid-chain coordination top (the delegation fold hides those); a completed host still holds its rows and a cleared host hides them with it, so a cleared ask never resurfaces its rows as root cards. The top a live prompt, API-error or judge-auth floor actually resolves to is un-nested once the floors are known: it keeps its card and its face, and nothing else moves. The launch match reads the dispatch's own description, kept on the task record from launch time (`launchDesc`, new in the event model) and never overwritten by the completion's summary, read from the script's `export const meta` literal alone for a Workflow, and shares by the smaller word set (more than half, at least two), so one stray word never carries it and a long title holding a short description's every word still matches. The face has its own line beside the sections, shown with or without a decision brief. Word overlap with the transcript's recorded launches only picks the why and, among several open human tops, the parent. Deterministic on the same store and task stream (sorted hosts, first-match launches; nothing moves between builds without a new record), never written back, and said once per boot on stderr with the build's total, again only when it rises. It rewrites only the feed's children map, so a healed top leaves the card list and joins its parent's tree.
- A tree row carries `born` with its why. The parent's name is recorded on `born` at demotion and heal time, so a session-started root that still shows (a born step whose parent node is gone renders as a root; a machine top with no human top to nest under) carries `sessionStarted` `{why, parent}`, and the card face says on the distill line, after the section logic and only when no takeaway occupies it, "Started by the session while working on <parent>: <why>" or "Started by the session on its own: <why>".
- The awaiting panel's `local_workflow` and `local_agent` rows stay where they were: the run's own place inside the parent card.

## Review

Two adversarial reviews. The first (four lenses, each finding verified by a skeptic) found ten things, folded before opening: the launch reader counted foreground subagents (a synchronous Explore agent would have demoted a user's second ask), so it now follows the event model's own criterion; a dropped mint left its chained sub to land as a top, so chained ops go with it and surviving references are remapped; the heal would have hidden a blocked top's needs-you state and a live prompt floor landing on a nested top, so blocked tops keep their cards and floors follow the host; hosts excluded completed and cleared tops, so a nested row could resurface as a root; the face could never name the parent since a root has none, so the name is recorded on the born record; and the face was written before the section logic that hides the distill line. The manager's review of the open PR confirmed eight more, folded on the branch: a demoted mint landing on a same-titled twin shifted every later reference; the ask's mint was assumed first in the reply; a two-ask message with any launch lost its second deliverable; scheduled prompts were treated as the session's own; a cleared ask or a tracker could host a row and hide it; a blocked machine top kept its card without the face; and the heal matched the completion summary rather than the launch record. Their verification of that fold found six more, folded again: the ask picker leaned on word overlap alone (now the planner's mark, then words, never a launch-favoured mint); the heal matched the whole brief (now the launch description, shared by the title's word count); a completion-overwrite test was missing; courier-planted goals were not hosts; cleared hosts were excluded (now they host and hide their rows); and the blocked top's face was displaced by the decision brief (now its own line). A third verification found six more, folded: the ask mark honoured before any filter with a human segment always keeping a top, delegated hosts only with a proven chain, floors un-nesting exactly their own top, the Workflow description read from the meta literal alone, the share divided by the smaller word set. The fourth inverted the design to the planner's labels (above) and folded eight: the keep decision reads text only, no fallback crowns a launch's mint while a top exists, the label is honoured on the placed path, the floor un-nesting has revert-failing tests and recomputes the row derivations it changes, the meta literal is read by brace depth with a schema-field test, and the short-approval test discriminates. A third verification found six, folded again: the mark filtered out by a launch word in its why with a short approval as the message (now the mark comes first and a human segment always keeps a top); picker tests that passed without the fold (now the mark alone decides); any delegated top hosting (now only a proven chain); the floor keep un-nesting on broader conditions than the floors (now only the top a floor resolves to); the Workflow description scraped from any quoted literal (now the meta literal alone); and the share divided by the title's word count (now the smaller set).

## Acceptance

Today's feed rebuilt hermetically from a copy of the live goal stores and names under a temporary state root (the kernel loaded against an empty root, then pointed at the copies; transcripts read where they live), with the live feed's session set as the registry: the heal recognises four machine-rooted tops, all with a human top to nest under; none stands as a top-level card under the new code; the log names four.

## Tests

- `tests/test_session_started_work.py`: a synthetic transcript (placeholder uuids, invented workflow names) running a Workflow mid-goal, planned in one work run and in the live two-pass shape: no new top, the review a step under the ask with `born.via` workflow and the launch's words as the why; the no-overlap case; a human second ask without a launch still mints its card; the trigger-less rule on seam tails, the open-top choice by overlap, the launch picking parent and why, the files-nothing case; the launch reader over Workflow scripts, Agent and Task inputs and a script path; the unit text's report label; the anchor refusal; the prompt sentence.
- `tests/test_feed_session_started.py`: a born step renders in its parent's tree with its why; a session-started root carries the face; machine-rooted tops nest under the human top current at their mint (with and without a matching launch) and stay nested on a second build with nothing said again; a human-anchored top is never healed; the heal is a pure function of store and transcript; trackers and unlatched prompt tops are not candidates; a machine top with no human top shows as a card that says so; the awaiting-panel rows stay agents.
- `ui/webview/session-started-face.test.ts`: the interfaces and the render's shape.

## Left as follow-ups, not in this change

- The to-do mirror mints an agent's own to-do items parentless; a session that lists "run review round 2" gets a top by construction. Same rule, separate contract (agent-asserted nodes).
- A GitHub issue only on the user's word; this body carries the design.

Tier: feature




