### PR TITLE
Tags render as one chip everywhere, never bold: one renderer for the strip's rows and filters, the feed's and outline's filters, the menus, the spend panel, the Obsidian view and the picker

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -47291,6 +47291,10 @@ function spMany(d){return spHosts(d).length>1;}
 // .tab-label with the identity color as --chip-bg (styles.css keys the color and weight on the SAME
 // rule the strip uses, so the two cannot drift) and the quiet .host-prefix — no swatch
 function spTitle(s,many){return '<span class="tab-label colored" style="--chip-bg:'+spColor(s)+'">'+(many&&s.host?'<span class=host-prefix>'+esc(s.host)+':</span>':'')+esc(spName(s))+'</span>';}
+// a merge-by-tag row names its TAG, and a tag is the one tag chip everywhere (T321): the landing page loads no module,
+// so this is tagChip's pill inlined (ui/webview/tag-menu.ts; the row's size, weight 400, normal tracking), never the
+// session title's bold. tests/test_spend_detail.py pins it against the renderer.
+function spTagChip(s){var c=spColor(s);return '<span class=rsp-tag-chip style="display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;border:1px solid '+c+';color:'+c+';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;">'+esc(s.name)+'</span>';}
 // ── T247g (the user 2026-09-08): three ranges, and "merge by tag"
 // the series for the range: "1 day" is the hourly series' last 24 buckets and "7 days" its last 168 (T293, the
 // user 2026-09-09; the ledger holds 192 hours, a day of slack past the view, and 90 days; a range is a slice of
@@ -47377,7 +47381,7 @@ var h='<table class=rsp-tbl><thead><tr><th>session</th><th class=n>dollars</th>'
 var many=spMany(d);
 var model=spRows(d);
 model.rows.forEach(function(s){h+='<tr data-sid="'+esc(s.sid||'')+'"'+(s.live?' class=rsp-live':' class=rsp-dead')+(s.kind==='tag'?' data-tag="'+esc(s.name)+'"':'')+'>'
-+'<td class=rsp-name>'+(s.kind==='tag'?('<span class="tab-label colored" style="--chip-bg:'+spColor(s)+'">'+esc(s.name)+'</span><span class=ru-tip-reset> \u00b7 '+s.members.length+' session'+(s.members.length===1?'':'s')+'</span>'):spTitle(s.s,many))+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
++'<td class=rsp-name>'+(s.kind==='tag'?(spTagChip(s)+'<span class=ru-tip-reset> \u00b7 '+s.members.length+' session'+(s.members.length===1?'':'s')+'</span>'):spTitle(s.s,many))+(s.live?'':'<span class=ru-tip-reset> \u00b7 not running</span>')+'</td>'
 +'<td class=n>'+fmtUsd(s.usd)+'</td>'+(keyCol?'<td class=n>'+(s.key?fmtUsd(s.key.usd):'\u2014')+'</td>':'')
 +'<td class=n>'+(s.turns||0)+'</td><td class=n>'+fmtTok(s.tok||0)+'</td></tr>';});
 // spend recorded before per-session attribution existed (T100, 2026-08-24), or the part of a bucket no

--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -194,8 +194,9 @@ const { chromium } = require('playwright');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="merge:toggle"]').classList.contains('on'), null, { timeout: 5000 });
   const merge = await pg.evaluate(() => {
     const rows = Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent.trim());
-    const tagRow = document.querySelector('#rsp-panel .rsp-tbl tbody tr[data-tag] .tab-label');
-    return { rows, tagColor: tagRow ? getComputedStyle(tagRow).color : null,
+    const tagRow = document.querySelector('#rsp-panel .rsp-tbl tbody tr[data-tag] .rsp-tag-chip');
+    return { rows, tagColor: tagRow ? getComputedStyle(tagRow).color : null, tagWeight: tagRow ? getComputedStyle(tagRow).fontWeight : null,
+      tagBorder: tagRow ? getComputedStyle(tagRow).borderTopColor : null,
       notes: Array.from(document.querySelectorAll('#rsp-panel .rsp-note')).map((e) => e.textContent),
       stackNames: (() => { const names = new Set(); document.querySelectorAll('#rsp-chart .rsp-seg').forEach((p) => { names.add(p.getAttribute('data-s')); }); return Array.from(names).map((i) => (window.__rompSpendStackNames || [])[+i] || ''); })(),
       prefs: JSON.parse(localStorage.getItem('romp:spendModal') || '{}') };

--- a/tests/test_spend_detail.py
+++ b/tests/test_spend_detail.py
@@ -9,6 +9,7 @@ root, synthetic ledger, the notes-api demo sessions (web/api/tests), placeholder
 import inspect
 import json
 import os
+import re
 import tempfile
 import time
 import unittest
@@ -625,6 +626,16 @@ class SpendDetail(unittest.TestCase):
         self.assertIn(".rsp-tbl thead th{position:sticky;top:0;background:#252526;z-index:1}", js)
         self.assertIn("body.theme-light .rsp-tbl thead th{background:#FFFFFF}", js)
         self.assertIn('<span class="tab-label colored" style="--chip-bg:\'+spColor(s)+\'">', js, "a row's title wears the tab strip's classes")
+        # a merge-by-tag row names its TAG as the one tag chip (T321): tagChip's pill inlined, never the title's bold
+        self.assertIn("(s.kind==='tag'?(spTagChip(s)+", js, "the tag row's name is the chip, not the session title")
+        self.assertEqual(js.count('<span class="tab-label colored"'), 1, "the session-title markup stays the title's alone (spTitle)")
+        menu = open(os.path.join(os.path.dirname(HERE), "ui", "webview", "tag-menu.ts")).read()
+        shared = re.search(r'chip\.setAttribute\("style", "([^"]+)"\s*\n\s*\+ "border-radius:9px;"', menu)
+        self.assertTrue(shared, "the shared tagChip's style is where the pin expects it")
+        twin = re.search(r"function spTagChip\(s\)\{var c=spColor\(s\);return '<span class=rsp-tag-chip style=\"([^\"]+)\"", js)
+        self.assertTrue(twin, "the landing page inlines the chip")
+        self.assertTrue(twin.group(1).startswith(shared.group(1) + "border-radius:9px;border:1px solid "), "the pill, byte for byte up to the colour (the row's size: no font-size)")
+        self.assertIn(";background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;", twin.group(1), "the tail after the colour: the shared weight and tracking")
         # T247f: the order chips beside the measure chips; the choice persists with the other toggles
         self.assertIn('data-act=order:spend>by spend</button>', js)
         self.assertIn('data-act=order:yours>your order</button>', js)

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -193,6 +193,7 @@ class SpendModalServed(unittest.TestCase):
         self.assertIn("$1200", mg["rows"][0].replace(",", ""), "team = web 960 + api 240")
         self.assertIn("$540", mg["rows"][1].replace(",", ""), "ops = api 240 + worker 300")
         self.assertEqual(mg["tagColor"], "rgb(194, 65, 12)", "the tag row wears the tag store's color")
+        self.assertEqual((mg["tagBorder"], mg["tagWeight"]), ("rgb(194, 65, 12)", "400"), "…as the one tag chip: its colour on a thin border, never bold (T321)")
         self.assertTrue(any("1 session carries several tags" in n for n in mg["notes"]), mg["notes"])
         self.assertIn("team", mg["stackNames"]); self.assertIn("ops", mg["stackNames"])
         self.assertLessEqual(mg["dayBuckets"], 24, "1 day · by hour = the last 24 hourly buckets")

--- a/tests/test_tag_chips_everywhere_browser.py
+++ b/tests/test_tag_chips_everywhere_browser.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""T321 (the user 2026-09-10): tags render the same everywhere, and never in bold. One renderer (tagChip in
+ui/webview/tag-menu.ts) builds every tag chip: the tab strip's group rows and its filter chips at the strip's right,
+the feed's and the outline's filter chips, the tag-lens menu, the tab menu's Tags flyout, the feed's session dialog,
+and the new-session picker's Tags row, where each tag shows as the chip (a thin border in the tag's own colour) and on
+versus off by the visual the tag toggles already use: the faded chip (TAG_CHIP_OFF_CLASS at 0.45). No identity dot.
+
+The strip guard reads the LIVE computed style of a group row's chip and of the same tag's filter chip at the strip's
+right (a chat lens seeded with two tags, so both rows and both filter chips show) and asserts they are one rendering:
+the same font size, weight 400, normal tracking, the same border width and radius, the same padding, and the tag's
+colour on both border and text.
+
+The served guard drives the real /chat page from a hermetic kernel with two tagged sessions and a third tag nobody
+holds, opens the picker with the strip's +, and reads the Tags row: one option per tag, each holding one chip whose
+border wears the tag's colour; the tags the ACTIVE tab holds are selected (the full chip), the rest unselected (the
+faded chip); no dot anywhere. A click flips one option: the state class the create reads (`sel`) and the chip's off
+class move together, and a second click puts them back. The tmux pick greys the row and leaves both looks readable
+(the off chip's fade is not stacked with the row's).
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
+ui/webview/tag-chip-everywhere.test.ts, picker-tag-chips.test.ts and tab-groups.test.ts. All fixtures synthetic (the
+notes-api demo world)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+# name → (sid, tags): the active tab (web) holds one tag; a second session holds another; a third tag has no member
+SESSIONS = [
+    ("web", "aaaaaaaa-1111-2222-3333-000000000001", "web"),
+    ("api", "aaaaaaaa-1111-2222-3333-000000000002", "infra"),
+]
+TAGS = [("t-web", "web", "#1EA1EB"), ("t-infra", "infra", "#54B204"), ("t-docs", "docs", "#B9770E")]
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _rgb(hex6):
+    h = hex6.lstrip("#")
+    return "rgb(%d, %d, %d)" % (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 700 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab[data-id]", { timeout: 20000 });
+// the web tab active: its tag is what the picker pre-selects
+await page.click(`#tabs .tab[data-id="${cfg.activeSid}"]`);
+await page.waitForFunction((id) => (document.querySelector("#tabs .tab.active") || {}).dataset?.id === id, cfg.activeSid, { timeout: 8000 });
+await page.waitForSelector("#tabs .tab-tagchips > span", { timeout: 10000 });
+await page.waitForTimeout(200);
+const look = (e) => { const cs = getComputedStyle(e); return { text: (e.childNodes[0] && e.childNodes[0].textContent) || "", fontSize: cs.fontSize, fontWeight: cs.fontWeight, fontFamily: cs.fontFamily,
+  letterSpacing: cs.letterSpacing, borderW: cs.borderTopWidth, borderColor: cs.borderTopColor, color: cs.color, radius: cs.borderTopLeftRadius,
+  padding: cs.paddingTop + " " + cs.paddingLeft, bg: cs.backgroundColor, display: cs.display }; };
+const strip = await page.evaluate((lookSrc) => {
+  const look = eval("(" + lookSrc + ")");
+  return { rows: Array.from(document.querySelectorAll("#tabs .tab-group-chip")).map(look),
+           filters: Array.from(document.querySelectorAll("#tabs .tab-tagchips > span")).map(look),
+           names: Array.from(document.querySelectorAll("#tabs .tab-label")).map((e) => getComputedStyle(e).fontWeight) };
+}, look.toString());
+await page.click("#tabs .tab-add");
+await page.waitForSelector("#picker .picker-tags .picker-be-opt", { timeout: 10000 });
+await page.waitForTimeout(200);
+const survey = () => page.evaluate(() => {
+  const row = document.querySelector("#picker .picker-tags");
+  const opts = Array.from(row.querySelectorAll(".picker-be-opt"));
+  return {
+    rowDisabled: row.classList.contains("disabled"),
+    rowOpacity: getComputedStyle(row).opacity,
+    dots: document.querySelectorAll("#picker .picker-tag-dot").length,
+    opts: opts.map((b) => {
+      const chip = b.firstElementChild;
+      const cs = chip ? getComputedStyle(chip) : null;
+      const bs = getComputedStyle(b);
+      return { tag: b.dataset.tag, sel: b.classList.contains("sel"), disabled: b.disabled,
+               children: b.children.length, chipTag: chip ? chip.tagName : null, chipClass: chip ? chip.getAttribute("class") || "" : null,
+               chipText: chip ? chip.textContent : null,
+               chipBorder: cs ? cs.borderTopColor : null, chipBorderW: cs ? cs.borderTopWidth : null, chipColor: cs ? cs.color : null,
+               chipOpacity: cs ? cs.opacity : null, chipBg: cs ? cs.backgroundColor : null, chipFont: cs ? cs.fontFamily : null,
+               btnBg: bs.backgroundColor, btnBorder: bs.borderTopStyle, btnOpacity: bs.opacity, btnFilter: bs.filter, btnPad: bs.paddingLeft };
+    }),
+  };
+});
+const open = await survey();
+// flip the unselected infra tag on, then off again
+await page.click('#picker .picker-tags .picker-be-opt[data-tag="infra"]');
+await page.waitForTimeout(100);
+const on = await survey();
+await page.click('#picker .picker-tags .picker-be-opt[data-tag="infra"]');
+await page.waitForTimeout(100);
+const off = await survey();
+// the tmux pick: the row greys behind its note
+const hasTmux = await page.evaluate(() => { const b = document.querySelector('#picker .picker-be-opt[data-be="tmux"]'); return !!b && getComputedStyle(b).display !== "none"; });
+let tmux = null;
+if (hasTmux) {
+  await page.click('#picker .picker-be-opt[data-be="tmux"]');
+  await page.waitForTimeout(150);
+  tmux = await survey();
+}
+fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, open, on, off, tmux, hasTmux }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedPickerTagChips(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps not installed here (npm ci in vscode-extension)")
+        cls.lab = tempfile.mkdtemp(prefix="picker-tag-chips-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        for k, (name, sid, _tag) in enumerate(SESSIONS):
+            Path(cls.state, "names", sid).write_text("%s\t%s\t\t\n" % (name, cwd))
+            Path(cls.state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high",
+                 "lastSid": sid, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+            u = "11111111-2222-3333-4444-%012d" % k
+            recs = [{"type": "user", "uuid": u, "parentUuid": None, "timestamp": "2026-09-10T10:%02d:00.000Z" % k, "sessionId": sid,
+                     "message": {"role": "user", "content": "notes-api: check the %s service" % name}}]
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        Path(cls.state, "tmux-backend").write_text("on")   # the gear's tmux switch: the picker offers Claude Code (tmux), so the greyed row can be driven
+        tags = [{"id": tid, "name": tname, "color": color, "members": [sid for (_n, sid, t) in SESSIONS if tname in (t or "").split()]}
+                for (tid, tname, color) in TAGS]
+        Path(cls.state, "timeline-views.json").write_text(json.dumps({"tags": tags, "tagOrder": [t[1] for t in TAGS],
+                                                                     "actives": {"chat": {"tags": ["web", "infra"]}}}))
+        cls.port = _free_port()
+        cls.token = "testtok-pickertags"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "activeSid": SESSIONS[0][1]}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box, and the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    _out = None
+
+    def _once(self):
+        if type(self)._out is None:
+            type(self)._out = self._drive()
+        return type(self)._out
+
+    def test_the_strip_s_group_row_chip_and_its_filter_chip_are_one_rendering_and_never_bold(self):
+        strip = self._once()["strip"]
+        rows = {r["text"]: r for r in strip["rows"]}
+        filters = {f["text"]: f for f in strip["filters"]}
+        self.assertEqual(sorted(rows), ["infra", "web"], "two group rows: %r" % strip["rows"])
+        self.assertEqual(sorted(filters), ["infra", "web"], "two filter chips at the strip's right: %r" % strip["filters"])
+        colors = {name: color for (_i, name, color) in TAGS}
+        for name in ("web", "infra"):
+            r, f = rows[name], filters[name]
+            for key in ("fontSize", "fontWeight", "fontFamily", "letterSpacing", "borderW", "radius", "padding", "bg", "display"):
+                self.assertEqual(r[key], f[key], "%s: the row chip and the filter chip differ in %s: %r vs %r" % (name, key, r, f))
+            self.assertEqual(r["fontWeight"], "400", "never bold: %r" % r)
+            self.assertEqual(r["letterSpacing"], "normal", "the header's tracking does not reach the chip: %r" % r)
+            self.assertEqual((r["borderColor"], r["color"]), (_rgb(colors[name]), _rgb(colors[name])), "the tag's colour on border and text: %r" % r)
+            self.assertEqual((f["borderColor"], f["color"]), (_rgb(colors[name]), _rgb(colors[name])), "…on the filter chip too: %r" % f)
+            self.assertEqual(r["borderW"], "1px")
+
+    def test_each_tag_is_the_shared_chip_and_a_click_flips_the_faded_look_with_the_state_class(self):
+        out = self._once()
+        o = out["open"]
+        by = {x["tag"]: x for x in o["opts"]}
+        self.assertEqual(sorted(by), sorted(t[1] for t in TAGS), "one option per tag: %r" % o)
+        self.assertEqual(o["dots"], 0, "no identity dot in the row")
+        colors = {name: color for (_i, name, color) in TAGS}
+        for name, x in by.items():
+            self.assertEqual((x["children"], x["chipTag"], x["chipText"]), (1, "SPAN", name), "one chip per option, the tag's name as its text: %r" % x)
+            self.assertEqual(x["chipBorder"], _rgb(colors[name]), "the chip's border is the tag's colour: %r" % x)
+            self.assertEqual(x["chipColor"], _rgb(colors[name]), "…and so is its text")
+            self.assertEqual(x["chipBorderW"], "1px", "a thin border")
+            self.assertEqual(x["chipBg"], "rgba(0, 0, 0, 0)", "the chip stays transparent: no fill says selected")
+            self.assertEqual(x["btnBg"], "rgba(0, 0, 0, 0)", "no button chrome behind the chip, selected or not: %r" % x)
+            self.assertEqual(x["btnBorder"], "none", "no button border around the chip's own")
+            self.assertEqual(x["btnPad"], "0px", "the chip's own padding is the whole footprint")
+            self.assertEqual(x["chipFont"], out["strip"]["rows"][0]["fontFamily"], "the page's typeface, as the strip's chip: a bare button wears the browser's control face (review find): %r" % x)
+        # the active tab's tag is selected: the full chip; the others unselected: the faded chip
+        self.assertTrue(by["web"]["sel"]); self.assertFalse(by["infra"]["sel"]); self.assertFalse(by["docs"]["sel"])
+        self.assertEqual((by["web"]["chipClass"], by["web"]["chipOpacity"]), ("", "1"), "selected = the full chip")
+        for name in ("infra", "docs"):
+            self.assertEqual((by[name]["chipClass"], by[name]["chipOpacity"]), ("tag-chip-off", "0.45"), "unselected = the off chip (the tag toggles' look): %r" % by[name])
+        # the flip: the state class and the chip's look move together, and back
+        on = {x["tag"]: x for x in out["on"]["opts"]}
+        self.assertTrue(on["infra"]["sel"])
+        self.assertEqual((on["infra"]["chipClass"], on["infra"]["chipOpacity"]), ("", "1"), "clicked on: the full chip")
+        self.assertTrue(on["web"]["sel"], "multi-select: the other stays")
+        off = {x["tag"]: x for x in out["off"]["opts"]}
+        self.assertFalse(off["infra"]["sel"])
+        self.assertEqual((off["infra"]["chipClass"], off["infra"]["chipOpacity"]), ("tag-chip-off", "0.45"), "clicked again: the off chip")
+        # the tmux pick: the row greys (not a second fade), every option disabled, both looks still distinct
+        self.assertTrue(out["hasTmux"], "the lab turns the gear's tmux switch on, so the picker offers the tmux backend")
+        if out["hasTmux"]:
+            t = {x["tag"]: x for x in out["tmux"]["opts"]}
+            self.assertTrue(out["tmux"]["rowDisabled"])
+            for x in t.values():
+                self.assertTrue(x["disabled"])
+                self.assertIn("grayscale", x["btnFilter"], "greyed: %r" % x)
+                self.assertEqual(x["btnOpacity"], "1", "grey is the whole disabled cue: no second fade over the off chip's own: %r" % x)
+            self.assertEqual(t["web"]["chipOpacity"], "1"); self.assertEqual(t["infra"]["chipOpacity"], "0.45")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -142,3 +142,13 @@ and a five-pane matrix of every tag filled the page and left two session rows sh
 A change to a tag or session surface is checked against a fixture of thirty tags (the
 dialog's is `ui/timeline-tags-scale.test.ts`, with the measured layout in
 `ui/timeline-tags-scale-browser.test.ts`).
+
+**Tags render as ONE chip everywhere** (the user 2026-09-10): `tagChip` in
+`ui/webview/tag-menu.ts` builds every tag the UI shows (the strip's group rows and filter
+chips, the feed's and outline's filter chips, the tag-lens menu, the tab menu's Tags flyout,
+the picker's Tags row), a thin border and the text in the tag's colour, weight 400, the
+context's size, faded when off; never bold, which is the session names' weight
+(`ui/webview/tag-chip-everywhere.test.ts` pins the sites and the sheets; the two documents
+that load no module, the landing page's spend panel and the Obsidian timeline view, inline
+the same bytes under drift pins in `tests/test_spend_detail.py` and
+`ui/timeline-tag-chips.test.ts`).

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -417,7 +417,8 @@ let MENU_STYLE = null, MENU_CHECK_STYLE = null;   // set by applyPal() below (da
 // THE TAG CHIP in the views menu (T283b, the user 2026-09-09: menus wear one vocabulary): the shared tag-lens
 // menu renders each tag as the tag chip itself acting as a toggle (ui/webview/tag-menu.ts tagChip + T283's
 // loop); this pane inlines the RESOLVED twin, since it may live in a foreign document that loads no module.
-// TAG_CHIP_STYLE is tagChip's pill byte for byte up to the colour (a drift test compares); the fade is the
+// TAG_CHIP_STYLE is tagChip's pill byte for byte up to the colour (a drift test compares), and the tail after the
+// colour carries tagChip's weight 400 and normal tracking (T321: a tag is never bold, on any surface); the fade is the
 // shared TAG_CHIP_OFF_OPACITY, and the class names the state for a host that does load the sheets.
 const TAG_CHIP_STYLE = 'display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0.82em;border:1px solid ';
 const TAG_CHIP_OFF_OPACITY = '0.45';
@@ -1271,7 +1272,7 @@ class TimelinePanel {
           + '.romp-tl-cbtn:hover{border-color:var(--accent,#9cd2ff);color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12)}'
           + '.romp-tl-cbtn.on{color:var(--accent,#9cd2ff);border-color:var(--accent,#9cd2ff);background:rgba(156,210,255,0.12);opacity:1}'
           + '.romp-tl-chip{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;'
-          + 'font-size:0.82em;border:1px solid;background:transparent;white-space:nowrap}'
+          + 'font-size:0.82em;border:1px solid;background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal}'
           + '.romp-tl-chipx{cursor:pointer;opacity:0.75;color:#9aa0a6;font-size:0.9em}'
           + '.romp-tl-ctail{color:#9aa0a6;opacity:0.7;font-size:12px;cursor:pointer;user-select:none;white-space:nowrap}'
           // LIGHT theme re-skin, scoped so the sheet is theme-flip-safe without re-injection: muted ink,
@@ -3524,7 +3525,7 @@ class TimelinePanel {
       const ch = box.createSpan();
       ch.setAttribute('style', 'display:inline-flex;align-items:center;gap:5px;'
         + 'padding:2px 7px;border-radius:9px;font-size:0.82em;cursor:pointer;white-space:nowrap;'
-        + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
+        + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;font-weight:400;letter-spacing:normal;');   // the one tag chip (T321)
       ch.addEventListener('mouseenter', () => { ch.style.background = HOVER_BG; });
       ch.addEventListener('mouseleave', () => { ch.style.background = 'transparent'; });
       ch.createSpan({ text: g.name });
@@ -3567,8 +3568,8 @@ class TimelinePanel {
       if (!rowIds.some((id) => g.members.indexOf(id) < 0)) continue;
       const tc = g.color || MENU_FG;
       const opt = box.createSpan({ text: g.name });
-      opt.setAttribute('style', 'padding:1px 8px;border-radius:9px;font-size:0.82em;cursor:pointer;'
-        + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;');
+      opt.setAttribute('style', 'display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0.82em;cursor:pointer;white-space:nowrap;'
+        + 'color:' + tc + ';border:1px solid ' + tc + ';background:transparent;font-weight:400;letter-spacing:normal;');   // the one tag chip (T321): the join option is the tag
       opt.addEventListener('mouseenter', () => { opt.style.background = HOVER_BG; });
       opt.addEventListener('mouseleave', () => { opt.style.background = 'transparent'; });
       opt.addEventListener('click', () => {
@@ -4233,7 +4234,7 @@ class TimelinePanel {
       row.setAttribute('style', TAG_CHIP_ROW_STYLE);
       const col = color || MODEL_FG;
       const chip = row.createSpan({ text: name });
-      chip.setAttribute('style', TAG_CHIP_STYLE + col + ';color:' + col + ';background:transparent;white-space:nowrap;'
+      chip.setAttribute('style', TAG_CHIP_STYLE + col + ';color:' + col + ';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;'
         + (on ? '' : 'opacity:' + TAG_CHIP_OFF_OPACITY + ';'));
       if (!on) chip.classList.add(TAG_CHIP_OFF_CLASS);
       chip.setAttribute('role', 'button');
@@ -4654,7 +4655,7 @@ class TimelinePanel {
           } else {
             const pill = pillCell.createSpan({ text: tg.name });
             pill.setAttribute('style', 'display:inline-flex;align-items:center;padding:2px 9px;'
-              + 'border-radius:10px;border:1px solid ' + tc + ';color:' + tc + ';background:transparent;font-weight:650;'
+              + 'border-radius:10px;border:1px solid ' + tc + ';color:' + tc + ';background:transparent;font-weight:400;'   // a tag is never bold (T321)
               + (gid && tg.ids.indexOf(gid) >= 0 ? 'outline:1px solid ' + OUTLINE_FG + ';outline-offset:2px;' : ''));
             // tag federation v2: a queued edit for an unreachable home is VISIBLE, never
             // gone-but-not-gone — the kernel stamps the cached remote entry with `pending`
@@ -4871,9 +4872,9 @@ class TimelinePanel {
             const pill = (text, selected, color, apply) => {
               const c2 = color || MODEL_FG;
               const s2 = cell.createSpan({ text });
-              s2.setAttribute('style', 'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;'
+              s2.setAttribute('style', 'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;font-weight:400;'   // a tag is never bold (T321): selected is the wash and the full opacity
                 + 'border:1px solid ' + c2 + ';color:' + c2 + ';'
-                + (selected ? 'background:' + SEL_BG + ';opacity:1;font-weight:650;' : 'background:transparent;opacity:0.6;'));
+                + (selected ? 'background:' + SEL_BG + ';opacity:1;' : 'background:transparent;opacity:0.6;'));
               s2.addEventListener('mouseenter', () => { s2.style.opacity = '1'; });
               s2.addEventListener('mouseleave', () => { if (!selected) s2.style.opacity = '0.6'; });
               s2.addEventListener('click', apply);

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -4665,8 +4665,9 @@ class TimelinePanel {
             }, 0);
           } else {
             const pill = pillCell.createSpan({ text: tg.name });
-            pill.setAttribute('style', 'display:inline-flex;align-items:center;padding:2px 9px;'
-              + 'border-radius:10px;border:1px solid ' + tc + ';color:' + tc + ';background:transparent;font-weight:400;'   // a tag is never bold (T321)
+            // the one tag chip (T321): the shared pill's bytes at the ROW's size (the inherit case: a row that sizes its chip
+            // drops the chip's own 0.82em, as the strip's group row does), so the table's row height is the row's own
+            pill.setAttribute('style', TAG_CHIP_STYLE.replace('font-size:0.82em;', '') + tc + ';color:' + tc + ';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;'
               + (gid && tg.ids.indexOf(gid) >= 0 ? 'outline:1px solid ' + OUTLINE_FG + ';outline-offset:2px;' : ''));
             // tag federation v2: a queued edit for an unreachable home is VISIBLE, never
             // gone-but-not-gone — the kernel stamps the cached remote entry with `pending`
@@ -4883,11 +4884,13 @@ class TimelinePanel {
             const pill = (text, selected, color, apply) => {
               const c2 = color || MODEL_FG;
               const s2 = cell.createSpan({ text });
-              s2.setAttribute('style', 'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;font-weight:400;'   // a tag is never bold (T321): selected is the wash and the full opacity
-                + 'border:1px solid ' + c2 + ';color:' + c2 + ';'
-                + (selected ? 'background:' + SEL_BG + ';opacity:1;' : 'background:transparent;opacity:0.6;'));
+              // the one tag chip (T321): selected = the full chip, unselected = the faded chip (the shared off fade and class),
+              // never a fill or a weight; the pointer is the only addition, this pill being a toggle
+              s2.setAttribute('style', TAG_CHIP_STYLE + c2 + ';color:' + c2 + ';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;cursor:pointer;'
+                + (selected ? '' : 'opacity:' + TAG_CHIP_OFF_OPACITY + ';'));
+              if (!selected) s2.classList.add(TAG_CHIP_OFF_CLASS);
               s2.addEventListener('mouseenter', () => { s2.style.opacity = '1'; });
-              s2.addEventListener('mouseleave', () => { if (!selected) s2.style.opacity = '0.6'; });
+              s2.addEventListener('mouseleave', () => { if (!selected) s2.style.opacity = TAG_CHIP_OFF_OPACITY; });
               s2.addEventListener('click', apply);
               return s2;
             };

--- a/ui/timeline-tag-chips.test.ts
+++ b/ui/timeline-tag-chips.test.ts
@@ -133,9 +133,11 @@ test("drift pins: the inlined chip is the shared tagChip's pill up to the colour
     "…and the tail after the colour carries the shared weight and tracking (T321: never bold)");
   assert.match(MENU, /\+ "font-weight:400;letter-spacing:normal;"/, "the shared pill's own tail, the same bytes");
   // the dialog's two other tag pills (its own signatures: the drag cell's pill, the per-pane filter pills): never bold either (T321)
-  assert.match(SRC, /'border-radius:10px;border:1px solid ' \+ tc \+ ';color:' \+ tc \+ ';background:transparent;font-weight:400;'/, "the tag row's pill");
-  assert.match(SRC, /'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;font-weight:400;'/, "the filter pills");
-  assert.match(SRC, /\(selected \? 'background:' \+ SEL_BG \+ ';opacity:1;' : 'background:transparent;opacity:0\.6;'\)/, "selected is the wash and the full opacity, not a weight");
+  assert.match(SRC, /pill\.setAttribute\('style', TAG_CHIP_STYLE\.replace\('font-size:0\.82em;', ''\) \+ tc \+ ';color:' \+ tc \+ ';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;'/,
+    "the tag row's pill: the shared pill's bytes at the row's size (the inherit case)");
+  assert.match(SRC, /s2\.setAttribute\('style', TAG_CHIP_STYLE \+ c2 \+ ';color:' \+ c2 \+ ';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;cursor:pointer;'\s*\n\s*\+ \(selected \? '' : 'opacity:' \+ TAG_CHIP_OFF_OPACITY \+ ';'\)\);\s*\n\s*if \(!selected\) s2\.classList\.add\(TAG_CHIP_OFF_CLASS\);/,
+    "the filter pills: the shared pill plus the pointer; selected = the full chip, unselected = the shared fade and class, never a fill");
+  assert.doesNotMatch(SRC, /SEL_BG \+ ';opacity:1;'|padding:2px 9px|padding:1px 8px;border-radius:9px/, "no third or fourth pill shape in the pane");
   assert.doesNotMatch(SRC, /font-weight:650;'\s*\n?[^\n]*(tc|c2)\b/, "no bold left on a tag-coloured pill");
   // the view's other inlined chips carry the same tail: the dialog rows' lane chips, the [+] join options, the corner filter chips
   assert.match(SRC, /'color:' \+ tc \+ ';border:1px solid ' \+ tc \+ ';background:transparent;font-weight:400;letter-spacing:normal;'\);\s+\/\/ the one tag chip \(T321\)\n/, "the lane chips");

--- a/ui/timeline-tag-chips.test.ts
+++ b/ui/timeline-tag-chips.test.ts
@@ -129,6 +129,18 @@ test("drift pins: the inlined chip is the shared tagChip's pill up to the colour
   const shared = /chip\.setAttribute\("style", "([^"]+)"\s*\n\s*\+ "border-radius:9px;" \+ \(opts && opts\.inheritSize \? "" : "font-size:0\.82em;"\)\s*\n\s*\+ "border:1px solid "/.exec(MENU);
   assert.ok(shared, "the shared tagChip's style is where the pin expects it");
   assert.equal(chipStyle, shared![1] + "border-radius:9px;font-size:0.82em;border:1px solid ", "the pill, byte for byte up to the colour");
+  assert.match(SRC, /TAG_CHIP_STYLE \+ col \+ ';color:' \+ col \+ ';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;'/,
+    "…and the tail after the colour carries the shared weight and tracking (T321: never bold)");
+  assert.match(MENU, /\+ "font-weight:400;letter-spacing:normal;"/, "the shared pill's own tail, the same bytes");
+  // the dialog's two other tag pills (its own signatures: the drag cell's pill, the per-pane filter pills): never bold either (T321)
+  assert.match(SRC, /'border-radius:10px;border:1px solid ' \+ tc \+ ';color:' \+ tc \+ ';background:transparent;font-weight:400;'/, "the tag row's pill");
+  assert.match(SRC, /'cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;font-weight:400;'/, "the filter pills");
+  assert.match(SRC, /\(selected \? 'background:' \+ SEL_BG \+ ';opacity:1;' : 'background:transparent;opacity:0\.6;'\)/, "selected is the wash and the full opacity, not a weight");
+  assert.doesNotMatch(SRC, /font-weight:650;'\s*\n?[^\n]*(tc|c2)\b/, "no bold left on a tag-coloured pill");
+  // the view's other inlined chips carry the same tail: the dialog rows' lane chips, the [+] join options, the corner filter chips
+  assert.match(SRC, /'color:' \+ tc \+ ';border:1px solid ' \+ tc \+ ';background:transparent;font-weight:400;letter-spacing:normal;'\);\s+\/\/ the one tag chip \(T321\)\n/, "the lane chips");
+  assert.match(SRC, /'display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0\.82em;cursor:pointer;white-space:nowrap;'\s*\n\s*\+ 'color:' \+ tc \+ ';border:1px solid ' \+ tc \+ ';background:transparent;font-weight:400;letter-spacing:normal;'\);\s+\/\/ the one tag chip \(T321\): the join option/, "the join options, the chip's shape");
+  assert.match(SRC, /\.romp-tl-chip\{display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;'\s*\n\s*\+ 'font-size:0\.82em;border:1px solid;background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal\}/, "the corner filter chips");
   assert.match(SRC, /const TAG_CHIP_OFF_OPACITY = '0\.45';/);
   assert.match(SRC, /const TAG_CHIP_OFF_CLASS = 'tag-chip-off';/);
   // the shared menu's own constants and chip row (T283, on main): each pin fails LOUDLY when its anchor moves,

--- a/ui/timeline-tags-scale-browser.test.ts
+++ b/ui/timeline-tags-scale-browser.test.ts
@@ -172,7 +172,7 @@ const toggleFilters = (page: any) => page.evaluate(() => {
 // (review find, 2026-09-09: the assertions read the cell's scrollHeight, which overflow of any kind grows)
 const matrix = (page: any) => page.evaluate(() => {
   const card = ((window as any).panel._viewsDialog as HTMLElement).firstElementChild as HTMLElement;
-  const chips = Array.from(card.querySelectorAll("span")).filter((n) => (n.getAttribute("style") || "").startsWith("cursor:pointer;padding:1px 8px;border-radius:9px;"));
+  const chips = Array.from(card.querySelectorAll("span")).filter((n) => { const s = n.getAttribute("style") || ""; return s.startsWith("display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0.82em;border:1px solid ") && s.includes("cursor:pointer;"); });   // the shared chip plus the pointer (T321)
   const cb = card.getBoundingClientRect();
   const rows = new Set(chips.map((n) => Math.round(n.getBoundingClientRect().top)));
   const allLabel = Array.from(card.querySelectorAll("span")).find((n) => n.textContent === "All surfaces" && (n.getAttribute("style") || "").includes("flex:0 0 88px"));

--- a/ui/timeline-tags-scale.test.ts
+++ b/ui/timeline-tags-scale.test.ts
@@ -168,8 +168,10 @@ const caption = (panel: any) => walk(panel._viewsDialog).find((n) => String(n.te
 const TGRID_PRE = "display:grid;grid-template-columns:max-content max-content max-content 1fr;";
 const tgridOf = (panel: any) => walk(panel._viewsDialog).find((n) => styleOf(n).startsWith(TGRID_PRE));
 const cardOf = (panel: any) => panel._viewsDialog.children[0];
-// the filter pills by their own style signature (the session rows' tag chips share the radius, not the padding)
-const chips = (panel: any) => walk(panel._viewsDialog).filter((n) => styleOf(n).startsWith("cursor:pointer;padding:1px 8px;border-radius:9px;font-size:0.82em;"));
+// the filter pills: the shared tag chip's signature (T321) plus the pointer they alone carry (the tag row's pill is the
+// same chip without it; the lane chips diverge after the size)
+const CHIP_PRE = "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;font-size:0.82em;border:1px solid ";
+const chips = (panel: any) => walk(panel._viewsDialog).filter((n) => styleOf(n).startsWith(CHIP_PRE) && styleOf(n).includes("cursor:pointer;"));
 // the folded summary: the pane label's row, [label, summary]
 const paneLines = (panel: any) => {
   const out: Record<string, any> = {};
@@ -1045,7 +1047,7 @@ test("executed: the folded summary names only tags that exist; a lens left with 
   // open, the matrix shows the same: no chip for zeta, alpha selected on Chat, nothing selected on Sessions
   caption(panel)._listeners.click();
   const open = paneLines(panel);
-  const sel = (k: string) => open[k].children[1].children.filter((c: any) => styleOf(c).includes("opacity:1;")).map((c: any) => c.textContent);   // selected = the wash and full opacity, never a weight (T321)
+  const sel = (k: string) => open[k].children[1].children.filter((c: any) => !styleOf(c).includes("opacity:")).map((c: any) => c.textContent);   // selected = the full chip; unselected wears the shared fade (T321)
   assert.deepEqual(sel("Chat"), ["alpha"]);
   assert.deepEqual(sel("Sessions"), [], "nothing selected: the same emptiness the folded line reports");
   assert.ok(!walk(panel._viewsDialog).some((n) => n.textContent === "zeta"), "no chip anywhere for the gone name");

--- a/ui/timeline-tags-scale.test.ts
+++ b/ui/timeline-tags-scale.test.ts
@@ -1045,7 +1045,7 @@ test("executed: the folded summary names only tags that exist; a lens left with 
   // open, the matrix shows the same: no chip for zeta, alpha selected on Chat, nothing selected on Sessions
   caption(panel)._listeners.click();
   const open = paneLines(panel);
-  const sel = (k: string) => open[k].children[1].children.filter((c: any) => styleOf(c).includes("font-weight:650;")).map((c: any) => c.textContent);
+  const sel = (k: string) => open[k].children[1].children.filter((c: any) => styleOf(c).includes("opacity:1;")).map((c: any) => c.textContent);   // selected = the wash and full opacity, never a weight (T321)
   assert.deepEqual(sel("Chat"), ["alpha"]);
   assert.deepEqual(sel("Sessions"), [], "nothing selected: the same emptiness the folded line reports");
   assert.ok(!walk(panel._viewsDialog).some((n) => n.textContent === "zeta"), "no chip anywhere for the gone name");

--- a/ui/webview/dense-chrome-layout.test.ts
+++ b/ui/webview/dense-chrome-layout.test.ts
@@ -15,7 +15,7 @@ const CSS_PATH = path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"
 // the markup render.ts builds, reduced to the nodes the dense rules touch. The chip's inline style is tagChip's
 // (tag-menu.ts, inheritSize), the tag button's is tagMenuButton's, the arrow is agentOpenButton's svg.
 const ARROW = '<span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/></svg></span>';
-const CHIP = '<span class="tab-group-chip" style="display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;border:1px solid var(--dim);color:var(--dim);background:transparent;white-space:nowrap;">web</span>';
+const CHIP = '<span class="tab-group-chip" style="display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;border:1px solid var(--dim);color:var(--dim);background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;">web</span>';
 const TAGBTN = '<button type="button" style="background:transparent;border:1px solid #3c3c3c;border-radius:6px;padding:4px 6px;cursor:pointer;color:#9aa0a6;display:inline-flex;align-items:center;"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M2 7.5 L7.5 2.5 H14 V9 L8.5 14 Z" stroke="currentColor" stroke-width="1.4"/></svg></button>';
 const tab = (id: string, label: string, cls = "") =>
   `<div class="tab${cls}" id="${id}"><span class="tab-label">${label}</span><span class="tab-close">×</span></div>`;

--- a/ui/webview/feed-session-filter.test.ts
+++ b/ui/webview/feed-session-filter.test.ts
@@ -84,12 +84,13 @@ test("session rows carry their tag chips — grouping visible, the pick untouche
   // non-interactive, ellipsizing in the row's leftover space
   assert.match(FEED, /if \(!g\.members\.includes\(pick\)\) continue;/);
   assert.match(FEED, /if \(chips\.childElementCount\) r\.appendChild\(chips\);/);
-  assert.match(FEED, /if \(g\.color\) \{ c\.style\.color = g\.color; c\.style\.borderColor = g\.color; \}/,
-    "the tag's own colour, outline-pill like the dialog");
+  assert.match(FEED, /const c = tagChip\(g\.name, g\.color \|\| null\);/,
+    "the tag's own colour on the one tag chip every surface draws (T321)");
+  assert.match(FEED, /c\.classList\.add\("fsm-chip-tag"\);/, "the dialog's layout hook stays on it");
   const CSS2 = fs.readFileSync(path.join(ROOT, "ui", "webview", "feed.css"), "utf8");
   assert.match(CSS2, /\.fsm-chips \{ flex: 1 1 auto; min-width: 0; margin-left: 8px; text-align: right;\s*\n\s*overflow: hidden; text-overflow: ellipsis; white-space: nowrap; pointer-events: none; \}/,
     "ellipsizes, never wraps the row; never a click target — the pick stays byte-identical");
-  assert.match(CSS2, /\.fsm-chip-tag \{ display: inline-block; font-style: normal; padding: 0 6px; margin-left: 4px;/,
+  assert.match(CSS2, /\.fsm-chip-tag \{ margin-left: 4px; \}/,
     "compact at the row's scale");
 });
 

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1184,8 +1184,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
    stay primary and rows never wrap. */
 .fsm-chips { flex: 1 1 auto; min-width: 0; margin-left: 8px; text-align: right;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; pointer-events: none; }
-.fsm-chip-tag { display: inline-block; font-style: normal; padding: 0 6px; margin-left: 4px;
-  border: 1px solid var(--dim); border-radius: 9px; font-size: 0.82em; color: var(--dim); }
+.fsm-chip-tag { margin-left: 4px; }   /* the chip's look is tagChip's own (T321); the sheet spaces it */
 /* the VIEW MENU (the user 2026-08-24): the sort + layout controls live behind one monochrome ordering
    glyph now (NOT a gear — the strip's ⛭ sits right below this footer on the kernel page). The popup
    wears the shared .ctx-menu vocabulary (chrome defined with the card menus below); these rules add

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -19,7 +19,7 @@ import { spinFor, awaitWord, groupRows, waitsNote, GROUP_TITLE, ROW_KIND_OF_LEGA
 import { onlyTag, matchesOnly } from "./only-filter";
 import { searchMatches, searchSids } from "./feed-search";
 import { TagLens, lensAll, lensLabel, lensVisible, lensUnions } from "./tag-lens";
-import { openTagMenu, tagMenuButton, syncTagFilter } from "./tag-menu";
+import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
 import { SessionViews } from "./session-views";
 import { freezeDiff, contentSig } from "./feed-freeze";
 import { hostNameNodes, hostPartsNodes, hostIsDown, hostDownNote, hostOf } from "./host-prefix";
@@ -4013,9 +4013,8 @@ function openSessList(): void {
       const chips = el("span", "fsm-chips");
       for (const g of lensUnions(feedTagViews)) {
         if (!g.members.includes(pick)) continue;
-        const c = el("i", "fsm-chip-tag");
-        c.textContent = g.name;
-        if (g.color) { c.style.color = g.color; c.style.borderColor = g.color; }
+        const c = tagChip(g.name, g.color || null);   // the one tag chip (T321); the class is the dialog's layout hook
+        c.classList.add("fsm-chip-tag");
         chips.appendChild(c);
       }
       if (chips.childElementCount) r.appendChild(chips);

--- a/ui/webview/picker-tag-chips.test.ts
+++ b/ui/webview/picker-tag-chips.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+// The picker's Tags row shows each tag AS THE TAG CHIP (T321, the user 2026-09-10): the thin border in the tag's own
+// colour that the tab strip, the feed and the outline draw, and on versus off by the visual the tag toggles already
+// use, the faded chip (TAG_CHIP_OFF_CLASS at 0.45), never a dot. The `sel` class on the option stays the state the
+// create reads and the tests pin; the chip inside is repainted from it on every click.
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const CSS = ui("webview", "styles.css");
+const FEED_CSS = ui("webview", "feed.css");
+const MENU = ui("webview", "tag-menu.ts");
+const REBUILD = RENDER.slice(RENDER.indexOf('const tgWrapEl = overlay.querySelector(".picker-tags")'), RENDER.indexOf('applyBrowseState("");'));
+
+test("each option is the shared tag chip: the tag's colour on a thin border, the faded chip for off, no dot", () => {
+  assert.match(RENDER, /import \{[^}]*\btagChip\b[^}]*\} from "\.\/tag-menu";/, "the one chip helper every surface shares");
+  assert.match(REBUILD, /const b = el\("button", "picker-be-opt" \+ \(preset\.has\(u\.name\) \? " sel" : ""\)\) as HTMLButtonElement;/, "the option and its state class stay");
+  assert.match(REBUILD, /paintPickerTagChip\(b, u\);/, "painted from the state class, on build…");
+  assert.match(REBUILD, /b\.addEventListener\("click", \(\) => \{ b\.classList\.toggle\("sel"\); paintPickerTagChip\(b, u\); \}\);/, "…and on every click (multi-select: each chip on its own)");
+  assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, off: !b\.classList\.contains\("sel"\) \}\)\);/,
+    "selected = the full chip, unselected = the off chip; the button's size, not a second 0.82em");
+  assert.doesNotMatch(RENDER, /picker-tag-dot/, "the dot is gone from the pane");
+  assert.doesNotMatch(CSS, /picker-tag-dot/, "…and from the sheet");
+  assert.doesNotMatch(RENDER, /ctx-tag-dot/, "the tab menu's Tags flyout wears the chip too: no dot anywhere a tag shows (T321)");
+});
+
+test("the option wears no button chrome around the chip, selected or hovered, so the chip's border is the whole look", () => {
+  assert.match(CSS, /\n\.picker-tags \.picker-be-opt \{ padding: 0; border: none; background: transparent; font-family: inherit; \}\n/,
+    "no weight on the host (the chip carries 400) and the page's typeface: a bare button wears the browser's control face (review find, T321)");
+  assert.match(CSS, /\n\.picker-tags \.picker-be-opt:hover \{ filter: brightness\(1\.3\); \}\n/, "the hover cue is the strip's own: the chip brightened, a property the chip never sets inline");
+  assert.match(CSS, /\n\.picker-tags \.picker-be-opt:hover, \.picker-tags \.picker-be-opt\.sel \{ background: transparent; border-color: transparent; color: inherit; \}\n/,
+    "the Backend row's accent fill and hover wash never reach a tag option");
+  // the specificity that makes the override stick without !important: two classes beat one
+  assert.ok(CSS.indexOf(".picker-be-opt.sel { background: var(--accent)") < CSS.indexOf(".picker-tags .picker-be-opt.sel {"), "the tag rule follows the generic one in the sheet");
+});
+
+test("the tmux pick greys the row without stacking a second fade on the off chips, so on and off still read", () => {
+  assert.match(CSS, /\n\.picker-tags\.disabled \.picker-be-opt \{ filter: grayscale\(1\); cursor: default; pointer-events: none; \}\n/,
+    "grey says disabled; the off chip's 0.45 stays the only fade");
+  assert.doesNotMatch(CSS, /\.picker-tags\.disabled \.picker-be-opt \{ opacity: 0\.45;/, "the old 0.45 over 0.45 left an off chip at a fifth");
+});
+
+test("the off visual is the one the tag toggles use: TAG_CHIP_OFF_CLASS at the inline opacity, defined on both sheets", () => {
+  assert.match(MENU, /export const TAG_CHIP_OFF_CLASS = "tag-chip-off";/);
+  assert.match(MENU, /export const TAG_CHIP_OFF_OPACITY = "0\.45";/);
+  for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const) assert.match(sheet, /\n\.tag-chip-off \{ opacity: 0\.45; \}\n/, name);
+});
+
+test("what the create reads is unchanged: the selected options' data-tag, only when the backend takes tags", () => {
+  assert.match(RENDER, /const tags = backendTakesTags\(backend\)\s*\n\s*\? Array\.from\(tgWrap\.querySelectorAll<HTMLElement>\("\.picker-be-opt\.sel"\)\)\.map\(\(x\) => x\.dataset\.tag \|\| ""\)\.filter\(Boolean\)/);
+  assert.match(REBUILD, /b\.type = "button"; b\.dataset\.tag = u\.name;/);
+  const sync = RENDER.slice(RENDER.indexOf("function syncPickerTags("), RENDER.indexOf("function syncPickerAuth("));
+  assert.match(sync, /\.forEach\(\(b\) => \{ b\.disabled = !takes; \}\);/, "the tmux pick still disables the buttons themselves");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6499,9 +6499,11 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
         sub.replaceChildren();
         for (const g of holding()) {                             // one chip per NAME — never a host prefix
           const row = el("div", "ctx-item ctx-item-toggle");
-          const chip = el("span", "ctx-tag-dot"); chip.style.background = g.color || "var(--dim)"; row.appendChild(chip);
           const bodyE = el("span", "ctx-item-body");
-          const lb = el("span", "ctx-item-label"); lb.textContent = g.name; bodyE.appendChild(lb);
+          const lb = el("span", "ctx-item-label");
+          const chip = tagChip(g.name, g.color || null, { inheritSize: true });   // the one tag chip (T321): the row's label IS the tag, at the label's size
+          chip.classList.add("ctx-tag-chip");
+          lb.appendChild(chip); bodyE.appendChild(lb);
           row.appendChild(bodyE);
           if (g.pending) {
             // a create still in flight: the row shows, and takes no gesture until the ack names the
@@ -6532,11 +6534,12 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
         const home = home0 && !home0.pending ? home0 : undefined;
         for (const g of others) {
           const row = el("div", "ctx-item ctx-item-toggle");
-          const chip = el("span", "ctx-tag-dot"); chip.style.background = g.color || "var(--dim)"; row.appendChild(chip);
           const bodyE = el("span", "ctx-item-body");
           const lb = el("span", "ctx-item-label");
+          // the tag inside the sentence is the chip (T321): no swatch-and-name pair anywhere a tag shows
+          const named = () => { const c = tagChip(g.name, g.color || null, { inheritSize: true }); c.classList.add("ctx-tag-chip"); return c; };
           if (home) {
-            lb.textContent = "Move to " + g.name; bodyE.appendChild(lb);
+            lb.append("Move to ", named()); bodyE.appendChild(lb);
             row.appendChild(bodyE);
             const plus = el("button", "ctx-tag-x ctx-tag-plus") as HTMLButtonElement;
             plus.type = "button"; plus.textContent = "+"; plus.title = "add this tag too — the session keeps its other tags";
@@ -6544,7 +6547,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
             row.appendChild(plus);
             row.addEventListener("click", (e2) => { e2.stopPropagation(); moveUnion(home, g); build(); sb.textContent = subText(); });
           } else {
-            lb.textContent = "+ " + g.name; bodyE.appendChild(lb);
+            lb.append("+ ", named()); bodyE.appendChild(lb);
             row.appendChild(bodyE);
             row.addEventListener("click", (e2) => { e2.stopPropagation(); editUnion(g, { add: [id] }); build(); sb.textContent = subText(); });
           }
@@ -6570,8 +6573,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
           const on = isPinned(tabGroups(), sec, id);
           sub.appendChild(el("div", "ctx-sep"));
           const row = el("div", "ctx-item ctx-item-toggle ctx-item-pin" + (on ? " current" : ""));
-          const chip = el("span", "ctx-tag-dot"); chip.style.background = home.color || "var(--dim)"; row.appendChild(chip);
-          const bodyE = el("span", "ctx-item-body");
+          const bodyE = el("span", "ctx-item-body");   // no swatch (T321): the sub-line names the home tag in words
           const lb = el("span", "ctx-item-label"); lb.textContent = "Show when folded"; bodyE.appendChild(lb);
           const sb2 = el("span", "ctx-item-sub");
           sb2.textContent = on ? `stays on the strip while ${home.name} is folded` : `keep this tab on the strip while ${home.name} is folded`;
@@ -7391,6 +7393,14 @@ function backendTakesTags(be: string): boolean { return be === "sdk" || be === "
 // the Tags row is for SDK and Codex sessions (tab groups, 2026-09-04): on the tmux pick the row stays
 // in place but disabled behind a short note, and the create handler sends no `tags`. Without this a
 // chip prefilled from a tagged active tab turns every terminal create into a refusal.
+// The Tags row's option paints as the tag chip itself (T321, the user 2026-09-10): the thin border in the tag's own
+// colour that the tab strip, the feed and the outline draw, and on versus off by the visual the tag toggles already
+// use, the faded chip (tagChip's `off`, TAG_CHIP_OFF_CLASS at 0.45), never a dot and never the Backend row's accent
+// fill. The `sel` class on the button stays the state the create reads; the chip is repainted from it on each click.
+function paintPickerTagChip(b: HTMLButtonElement, u: { name: string; color?: string | null }): void {
+  b.replaceChildren(tagChip(u.name, u.color, { inheritSize: true, off: !b.classList.contains("sel") }));
+}
+
 function syncPickerTags(): void {
   const wrap = document.querySelector("#picker .picker-tags") as HTMLElement | null;
   if (!wrap) return;
@@ -7893,12 +7903,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     for (const u of unions) {
       const b = el("button", "picker-be-opt" + (preset.has(u.name) ? " sel" : "")) as HTMLButtonElement;
       b.type = "button"; b.dataset.tag = u.name;
-      const d = el("span", "picker-tag-dot"); d.style.background = u.color || "var(--dim)"; b.appendChild(d);
-      b.appendChild(document.createTextNode(u.name));
+      paintPickerTagChip(b, u);   // the tag chip every surface draws, full when selected, faded when not (T321)
       b.title = preset.has(u.name)
         ? `the session you are looking at is in ${u.name} — the new one joins it too unless you unpick this`
         : `put the new session in ${u.name}`;
-      b.addEventListener("click", () => b.classList.toggle("sel"));   // multi-select: each chip on its own
+      b.addEventListener("click", () => { b.classList.toggle("sel"); paintPickerTagChip(b, u); });   // multi-select: each chip on its own
       tgWrapEl.insertBefore(b, tgWrapEl.querySelector(".picker-tags-note"));   // chips before the tmux note
     }
     syncPickerTags();   // the backend toggle was just reset to the gear default above

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -423,8 +423,9 @@ body.tabbar-resizing { cursor: ns-resize; user-select: none; }
 .tab-group-head:not(.collapsed) .tab-group-caret { transform: rotate(90deg); }
 /* the tag's color as a short bar, not a dot: a dot beside a name is a session pip */
 /* the tag's CHIP (T251) — the shared tag-menu builder's pill, sized by the header (no nested em); flex-none
-   so a wrapping strip never squeezes it, and a tab's own vertical rhythm stays the ceiling */
-.tab-group-chip { flex: 0 0 auto; font-weight: 600; line-height: 1.2; }
+   so a wrapping strip never squeezes it, and a tab's own vertical rhythm stays the ceiling. No weight here:
+   the chip is weight 400 everywhere (T321), bold is the session names' */
+.tab-group-chip { flex: 0 0 auto; line-height: 1.2; }
 .tab-group-count { opacity: 0.7; }
 /* the folded header's member-state pip (after the count, small — subordinate to the label): the tab's
    status colors by the tab's own rule (tab-state.ts) — working gold, blocked/waiting red, retrying the
@@ -680,9 +681,9 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    gray + slashed. So the same blue marks "enabled" in both the menu and the timeline. */
 .ctx-item-toggle .ctx-icon { flex: 0 0 auto; margin-top: 1px; color: var(--accent); display: flex; }
 .ctx-item-toggle .ctx-icon.off { color: var(--dim); }
-/* the tab menu's Tags flyout (the user 2026-08-24): identity dot per union tag, ✕ = remove-
-   everywhere, an inline New tag… input — all in the menu vocabulary, no new font sizes */
-.ctx-tag-dot { flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; }
+/* the tab menu's Tags flyout (the user 2026-08-24): the tag chip per union tag (T321: the one chip, in the
+   label slot at the label's size, no identity dot), ✕ = remove-everywhere, an inline New tag… input, all in
+   the menu vocabulary, no new font sizes */
 /* a tag chip standing for an UNSELECTED toggle (the tag-lens menu, T283): faded, its colour kept —
    the state class; tag-menu.ts paints the same opacity inline for a sheet-less host (TAG_CHIP_OFF_OPACITY) */
 .tag-chip-off { opacity: 0.45; }
@@ -2870,12 +2871,18 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* the Billing row's single-choice text: written out where the buttons would sit (the user 2026-08-09) —
    the buttons' 0.82em, plain, no button chrome (it is a fact, not a control) */
 .picker-auth-fixed { flex: 0 0 auto; color: var(--fg); font-size: 0.82em; padding: 4px 0; }
-/* the picker's Tags row (tab groups, the user 2026-09-04): the Backend row's chips, each with its
-   tag's identity dot; several may be selected — a session can hold several tags */
+/* the picker's Tags row (tab groups, the user 2026-09-04): one option per tag; several may be selected, a session
+   can hold several tags. Each option IS the tag chip every surface draws (T321, the user 2026-09-10): the thin
+   border in the tag's colour, the faded chip (.tag-chip-off) for unselected, so the button around it carries no
+   chrome: no border, no padding, the page's typeface (a bare button wears the browser's control face), and never
+   the Backend row's accent fill or hover wash; the hover cue is the strip's own, the chip brightened */
 .picker-tags { flex-wrap: wrap; }
-.picker-tag-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 5px; vertical-align: middle; }
-/* the tmux pick: the chips stay in place, disabled, behind the note (tags apply to SDK and Codex sessions) */
-.picker-tags.disabled .picker-be-opt { opacity: 0.45; cursor: default; pointer-events: none; }
+.picker-tags .picker-be-opt { padding: 0; border: none; background: transparent; font-family: inherit; }
+.picker-tags .picker-be-opt:hover, .picker-tags .picker-be-opt.sel { background: transparent; border-color: transparent; color: inherit; }
+.picker-tags .picker-be-opt:hover { filter: brightness(1.3); }
+/* the tmux pick: the chips stay in place, disabled, behind the note (tags apply to SDK and Codex sessions). Greyed
+   and nothing else: the off chip's own 0.45 stays the only fade, so on and off still read in both themes */
+.picker-tags.disabled .picker-be-opt { filter: grayscale(1); cursor: default; pointer-events: none; }
 .picker-list { overflow-y: auto; }
 /* The resume list's heading (the user 2026-08-12): the list sits LAST in the dialog — typing in the
    name box re-filters it, and its changing height used to jump every control below it — so this line

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -338,7 +338,8 @@ test("the picker's Tags row is for SDK and Codex sessions: disabled behind a not
     "the create handler sends none for tmux, through the same predicate");
   assert.doesNotMatch(RENDER, /const tags = backend === "sdk"/, "no second, SDK-only copy of the rule");
   assert.match(RENDER, /:not\(\.picker-host\):not\(\.picker-auth\):not\(\.picker-tags\) \.picker-be-opt\.sel/, "a selected tag chip never reads as the backend pick");
-  assert.match(CSS, /\.picker-tags\.disabled \.picker-be-opt \{ opacity: 0\.45; cursor: default; pointer-events: none; \}/);
+  assert.match(CSS, /\.picker-tags\.disabled \.picker-be-opt \{ filter: grayscale\(1\); cursor: default; pointer-events: none; \}/,
+    "greyed, not faded: the off chip keeps its own 0.45 as the only fade (T321)");
 });
 
 test("headers are click-safe: data-act on the node, the action on the stable #tabs delegate, one render path via the event", () => {
@@ -380,7 +381,7 @@ test("the picker's Tags row: prefilled from the ACTIVE tab, visible and editable
   assert.match(RENDER, /const tgWrap = el\("div", "picker-backend picker-tags"\);/);
   assert.match(RENDER, /const preset = new Set\(activeId \? unions\.filter\(\(u\) => u\.members\.includes\(activeId!\)\)\.map\(\(u\) => u\.name\) : \[\]\);/,
     "the active tab's tags pre-select — never a silent inherit");
-  assert.match(RENDER, /b\.addEventListener\("click", \(\) => b\.classList\.toggle\("sel"\)\);/, "multi-select: each chip on its own");
+  assert.match(RENDER, /b\.addEventListener\("click", \(\) => \{ b\.classList\.toggle\("sel"\); paintPickerTagChip\(b, u\); \}\);/, "multi-select: each chip on its own, repainted as the shared chip (T321)");
   assert.match(RENDER, /\.\.\.\(tags\.length \? \{ tags \} : \{\}\) \}\);/, "absent when nothing is picked (the kernel's not-asked contract)");
   assert.match(RENDER, /tgWrapEl\.style\.display = pick \|\| !unions\.length \? "none" : "";/, "hidden with no tags to offer, and in pick-mode");
 });
@@ -393,7 +394,7 @@ test("the section chrome is a LABEL's (the user 2026-09-06): the surface's sub-l
   assert.match(CSS, /\.tab-group-count \{ opacity: 0\.7; \}/, "the count inherits the header's size — no em nested inside an em");
   // T251 (the user 2026-09-07): the swatch+name pair retired for THE CHIP the tag wears everywhere —
   // the shared tag-menu builder's pill, bold like the name it replaces, sized by the header
-  assert.match(CSS, /\.tab-group-chip \{ flex: 0 0 auto; font-weight: 600; line-height: 1\.2; \}/);
+  assert.match(CSS, /\.tab-group-chip \{ flex: 0 0 auto; line-height: 1\.2; \}/, "no weight on the host: the chip is 400 everywhere (T321)");
   assert.doesNotMatch(CSS, /\.tab-group-swatch|\.tab-group-name \{/, "the bar and the plain name are gone");
   assert.doesNotMatch(CSS, /\.tab-group-dot/, "the dot is gone");
   const sizes = new Set(Array.from(CSS.matchAll(/\n\.tab-group-[^{\n]*\{[^}]*font-size: ([^;]+);/g)).map((m) => m[1]));
@@ -1665,13 +1666,13 @@ test("executed: the pin persists with the fold state under romp:tabgroups, survi
 test("the toggle is a row in the tab menu's Tags flyout beside the Move-to rows: the home tag's chip, ✓ when on, per-section copy, the fold's own write and render path; the views adoption carries the pins across a rename (source pins)", () => {
   const fly = RENDER.slice(RENDER.indexOf('const sub = el("div", "ctx-menu ctx-sub ctx-sub-tags");'), RENDER.indexOf("// New tag… — an inline input"));
   const pin = fly.slice(fly.indexOf("// SHOW WHEN FOLDED"));
-  assert.ok(fly.indexOf('lb.textContent = "Move to " + g.name') < fly.indexOf("// SHOW WHEN FOLDED"), "after the Move-to rows, before New tag…");
+  assert.ok(fly.indexOf('lb.append("Move to ", named())') < fly.indexOf("// SHOW WHEN FOLDED"), "after the Move-to rows, before New tag…");
   assert.match(pin, /if \(home\) \{\s*\n\s*const sec = sectionRef\(home\);\s*\n\s*const on = isPinned\(tabGroups\(\), sec, id\);/,
     "only with a home tag (there is no fold to show through otherwise); the section as the plan keys it (sectionRef: name and local id); the store read with the unions (the migration)");
   assert.doesNotMatch(pin, /isPinned\(tabGroups\(\), home\.name|togglePinned\(tabGroups\(\), home\.name|home\.localId, id\)|readTabGroups\(\)/,
     "never the bare name or the bare id, and never a store read without the unions on a path that writes");
   assert.match(pin, /const row = el\("div", "ctx-item ctx-item-toggle ctx-item-pin" \+ \(on \? " current" : ""\)\);/, "the menus' ✓ mark when on");
-  assert.match(pin, /chip\.style\.background = home\.color \|\| "var\(--dim\)"; row\.appendChild\(chip\);/, "the home tag's chip, like its neighbors");
+  assert.doesNotMatch(pin, /ctx-tag-dot|chip\.style\.background/, "no swatch on the row (T321): the sub-line names the home tag in words, and a tag shows only as the one chip");
   assert.match(pin, /lb\.textContent = "Show when folded";/);
   assert.match(pin, /sb2\.textContent = on \? `stays on the strip while \$\{home\.name\} is folded` : `keep this tab on the strip while \$\{home\.name\} is folded`;/,
     "the copy speaks of the home section alone — and the write is per section, so it is the whole truth");

--- a/ui/webview/tab-tags.test.ts
+++ b/ui/webview/tab-tags.test.ts
@@ -74,10 +74,11 @@ test("New tag… is an inline input (menu vocabulary, no native prompt) that cre
   assert.match(RENDER, /const existing = unionFor\(\)\.find\(\(g\) => g\.name === name\);/);
 });
 
-test("presentation: one chip per NAME, identity dot, ✕ — and never a host prefix in the flyout", () => {
-  assert.match(RENDER, /lb\.textContent = g\.name; bodyE\.appendChild\(lb\);/);
-  assert.match(RENDER, /lb\.textContent = "\+ " \+ g\.name; bodyE\.appendChild\(lb\);/);
-  assert.match(CSS, /\.ctx-tag-dot \{ flex: 0 0 auto; width: 9px; height: 9px; border-radius: 50%; \}/);
+test("presentation: one chip per NAME (the shared tag chip, T321), the action rows' identity dot, ✕, and never a host prefix in the flyout", () => {
+  assert.match(RENDER, /const chip = tagChip\(g\.name, g\.color \|\| null, \{ inheritSize: true \}\);\s+\/\/ the one tag chip \(T321\)/, "a row that names a tag IS the tag chip, at the label's size");
+  assert.match(RENDER, /chip\.classList\.add\("ctx-tag-chip"\);\s*\n\s*lb\.appendChild\(chip\); bodyE\.appendChild\(lb\);/, "in the label slot");
+  assert.match(RENDER, /lb\.append\("\+ ", named\(\)\); bodyE\.appendChild\(lb\);/, "the + row names its tag as the chip inside the sentence");
+  assert.doesNotMatch(RENDER + CSS, /ctx-tag-dot/, "no swatch-and-name pair is left in the flyout (T321)");
   const fly = RENDER.slice(RENDER.indexOf("const sub = el(\"div\", \"ctx-menu ctx-sub ctx-sub-tags\");"));
   assert.doesNotMatch(fly.slice(0, 2500), /host-prefix|hostNameNodes/, "kernels are plumbing — no host chrome in the flyout");
 });
@@ -86,10 +87,10 @@ test("one-click MOVE between groups (tab groups, 2026-09-04): 'Move to <name>' a
   const fly = RENDER.slice(RENDER.indexOf('const sub = el("div", "ctx-menu ctx-sub ctx-sub-tags");'), RENDER.indexOf("// New tag… — an inline input"));
   assert.match(fly, /const home0 = readTabGroups\(\)\.on \? \(\(copy !== undefined \? holding\(\)\.find\(\(g\) => g\.name === copy\) : undefined\) \?\? holding\(\)\[0\]\) : undefined;\s*\n\s*const home = home0 && !home0\.pending \? home0 : undefined;/,
     "the group THIS COPY sits in (T264b: a session under several tags has a copy per group, and the menu speaks for the right-clicked copy's group), else the first holder; only while the strip is sectioned, and never a tag whose create is still in flight");
-  assert.match(fly, /lb\.textContent = "Move to " \+ g\.name; bodyE\.appendChild\(lb\);/);
+  assert.match(fly, /lb\.append\("Move to ", named\(\)\); bodyE\.appendChild\(lb\);/, "the tag inside the sentence is the chip (T321)");
   assert.match(fly, /moveUnion\(home, g\); build\(\); sb\.textContent = subText\(\);/, "the row IS the move");
   assert.match(fly, /plus\.title = "add this tag too — the session keeps its other tags";/, "…and multi-tag stays one click away");
-  assert.match(fly, /lb\.textContent = "\+ " \+ g\.name; bodyE\.appendChild\(lb\);/, "with no home tag, + <name> is the move");
+  assert.match(fly, /lb\.append\("\+ ", named\(\)\); bodyE\.appendChild\(lb\);/, "with no home tag, + <name> is the move");
   const mv = RENDER.slice(RENDER.indexOf("const moveUnion = (from: TagUnion, to: TagUnion)"), RENDER.indexOf("// HOVER-INTENT open"));
   assert.match(mv, /const a = applyUnionEdit\(nv, to, \{ add: \[id\] \}\);\s*\n\s*const r = applyUnionEdit\(nv, from, \{ remove: \[id\] \}\);/,
     "two edits on ONE blob shown — the strip never shows the half-moved state");

--- a/ui/webview/tag-chip-everywhere.test.ts
+++ b/ui/webview/tag-chip-everywhere.test.ts
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+// ONE tag chip everywhere (T321, the user 2026-09-10: the strip's filter chips rendered unlike the tag rows above them,
+// and a tag must never be bold, the session names' weight). tagChip in tag-menu.ts is the one renderer; every surface
+// that shows a tag builds through it, the sheets add layout and state cues but never a weight, and the standard is
+// stated once beside the renderer and once in ui/CLAUDE.md.
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const FEED = ui("webview", "feed.ts");
+const OUTLINE = ui("webview", "fleet.ts");   // the outline pane's module
+const MENU = ui("webview", "tag-menu.ts");
+const CSS = ui("webview", "styles.css");
+const FEED_CSS = ui("webview", "feed.css");
+const RULES = ui("CLAUDE.md");
+
+test("the renderer pins the standard inline: thin border and text in the tag's colour, weight 400, normal tracking, faded when off", () => {
+  assert.match(MENU, /\/\*\* THE ONE TAG CHIP \(T321/, "the standard is written once, beside the renderer");
+  assert.match(MENU, /\+ "border:1px solid " \+ col \+ ";color:" \+ col \+ ";background:transparent;white-space:nowrap;"\s*\n\s*\+ "font-weight:400;letter-spacing:normal;"/,
+    "weight and tracking ride inline, so a bold or letter-spaced host (the strip's header) cannot restyle the chip");
+  // the real builder against a stub document: what it writes is what every surface gets
+  const created: { tag: string; attrs: Record<string, string>; kids: unknown[] }[] = [];
+  const g = globalThis as any;
+  const saved = g.document, savedWin = g.window;
+  g.document = {
+    createElement: (tag: string) => { const n = { tag, attrs: {} as Record<string, string>, kids: [] as unknown[],
+      setAttribute(k: string, v: string) { this.attrs[k] = v; }, appendChild(c: unknown) { this.kids.push(c); },
+      addEventListener() { /* unused by tagChip */ } }; created.push(n); return n; },
+    createTextNode: (t: string) => ({ text: t }),
+    addEventListener() { /* the module wires its closers at load */ },
+  };
+  g.window = { addEventListener() { /* the storage listener at load */ } };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { tagChip } = require("./tag-menu");
+    const on = tagChip("infra", "#54B204");
+    assert.match(on.attrs.style, /border:1px solid #54B204;color:#54B204;background:transparent;/);
+    assert.match(on.attrs.style, /font-weight:400;letter-spacing:normal;/);
+    assert.match(on.attrs.style, /font-size:0\.82em;/, "its own size where no host sizes it…");
+    assert.equal(on.attrs["class"], undefined);
+    const hosted = tagChip("infra", "#54B204", { inheritSize: true });
+    assert.doesNotMatch(hosted.attrs.style, /font-size/, "…the host's where a row sizes it");
+    const off = tagChip("qa", "#3355aa", { off: true });
+    assert.equal(off.attrs["class"], "tag-chip-off");
+    assert.match(off.attrs.style, /opacity:0\.45;/);
+    assert.match(off.attrs.style, /border:1px solid #3355aa;color:#3355aa;/, "faded, never recoloured");
+  } finally { g.document = saved; g.window = savedWin; }
+});
+
+test("every tag surface builds through tagChip", () => {
+  const head = RENDER.slice(RENDER.indexOf("function makeGroupHead("), RENDER.indexOf("\n}", RENDER.indexOf("function makeGroupHead(")));
+  assert.match(head, /const chip = tagChip\(name, sec\.color, \{ inheritSize: true \}\);/, "the strip's group row");
+  const filt = MENU.slice(MENU.indexOf("export function syncTagFilter("));
+  assert.match(filt, /const chip = tagChip\(c\.label, c\.color\);/, "the filter chips: the strip's, the feed's and the outline's, one builder");
+  assert.match(RENDER, /syncTagFilter\(tagBtn, tagChipsHost, surfaceLens\(v, "chat"\)/, "the strip's filter mount goes through it");
+  assert.match(FEED, /syncTagFilter\(b, ch, feedLens, lensUnions\(feedTagViews\) as never/, "the feed's");
+  assert.match(OUTLINE, /syncTagFilter\(tagBtn, chipsHost, surfaceLens\(fleetViews, "outline"\)/, "the outline's");
+  const lensMenu = MENU.slice(MENU.indexOf("export function openTagMenu("), MENU.indexOf("export const TAG_CHIP_OFF_CLASS"));
+  assert.match(lensMenu, /const chip = tagChip\(u\.name, u\.color \|\| null, \{ off: !on \}\);/, "the tag-lens menu's rows");
+  const fly = RENDER.slice(RENDER.indexOf('const sub = el("div", "ctx-menu ctx-sub ctx-sub-tags");'), RENDER.indexOf("// New tag… — an inline input"));
+  assert.match(fly, /const chip = tagChip\(g\.name, g\.color \|\| null, \{ inheritSize: true \}\);\s+\/\/ the one tag chip \(T321\)/, "the tab menu's Tags flyout: a row that names a tag, at the label's size");
+  assert.match(fly, /chip\.classList\.add\("ctx-tag-chip"\);/);
+  assert.match(fly, /const named = \(\) => \{ const c = tagChip\(g\.name, g\.color \|\| null, \{ inheritSize: true \}\); c\.classList\.add\("ctx-tag-chip"\); return c; \};/, "the action rows name their tag as the chip inside the sentence");
+  assert.match(fly, /lb\.append\("Move to ", named\(\)\);/); assert.match(fly, /lb\.append\("\+ ", named\(\)\);/);
+  assert.doesNotMatch(RENDER + CSS, /ctx-tag-dot/, "no swatch-and-name pair anywhere a tag shows");
+  const spend = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.match(spend, /function spTagChip\(s\)\{var c=spColor\(s\);return '<span class=rsp-tag-chip style="display:inline-flex;align-items:center;gap:5px;padding:2px 7px;border-radius:9px;border:1px solid '\+c\+';color:'\+c\+';background:transparent;white-space:nowrap;font-weight:400;letter-spacing:normal;">'/,
+    "the landing page's spend panel: a merge-by-tag row names its tag as the chip's inlined twin, at the row's size");
+  assert.match(spend, /\(s\.kind==='tag'\?\(spTagChip\(s\)\+/, "…in place of the session title's bold");
+  const dialog = FEED.slice(FEED.indexOf('const chips = el("span", "fsm-chips");'), FEED.indexOf("if (chips.childElementCount) r.appendChild(chips);"));
+  assert.match(dialog, /const c = tagChip\(g\.name, g\.color \|\| null\);/, "the feed's session dialog");
+  assert.match(dialog, /c\.classList\.add\("fsm-chip-tag"\);/);
+  assert.doesNotMatch(FEED, /c\.style\.borderColor = g\.color/, "no hand-painted tag border remains");
+  assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, off: !b\.classList\.contains\("sel"\) \}\)\);/,
+    "the new-session picker's Tags row");
+  assert.doesNotMatch(RENDER + CSS, /picker-tag-dot/, "the picker's dot is gone");
+});
+
+test("no sheet sets a weight on a tag chip class: the sheets add layout and state cues only", () => {
+  // every rule of the sheet (selector { body }, across line breaks; comments stripped) whose selector names a chip class
+  const rule = /([^{}]+)\{([^{}]*)\}/g;
+  const chipSel = /(tab-group-chip|tag-chip|fsm-chip-tag|ctx-tag-chip|picker-tags \.picker-be-opt)/;
+  for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const) {
+    const bare = sheet.replace(/\/\*[\s\S]*?\*\//g, "");
+    let m: RegExpExecArray | null; let seen = 0;
+    while ((m = rule.exec(bare))) {   // loop-ok: a bounded scan of one file's rules
+      const sel = m[1].trim(), body = m[2];
+      if (!chipSel.test(sel)) continue;
+      seen++;
+      assert.doesNotMatch(body, /font-weight\s*:\s*(bold|bolder|[5-9]00)/, `${name}: "${sel}" must not bold a tag chip`);
+      assert.doesNotMatch(body, /(^|[^-\w])font\s*:\s*[^;]*\b(bold|bolder|[5-9]00)\b/, `${name}: "${sel}" must not bold a tag chip through the font shorthand`);
+      if (!/picker-tags \.picker-be-opt/.test(sel))   // the picker's HOST button strips its own chrome; the chip inside is the renderer's
+        assert.doesNotMatch(body, /(^|[^-\w])(border(-color|-width|-style)?|color|font-size)\s*:/, `${name}: "${sel}" must not restyle the chip's border, colour or size (the renderer's); a state cue such as an underline's colour is fine`);
+    }
+    assert.ok(seen > 0, name + " has chip rules to check");
+  }
+  assert.match(CSS, /\n\.tab-group-chip \{ flex: 0 0 auto; line-height: 1\.2; \}\n/, "the strip's row chip lost its bold");
+  assert.match(FEED_CSS, /\n\.fsm-chip-tag \{ margin-left: 4px; \}/, "the dialog's chip keeps only its spacing");
+  for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const) assert.match(sheet, /\n\.tag-chip-off \{ opacity: 0\.45; \}\n/, name + ": the off state");
+});
+
+test("the standard is written in ui/CLAUDE.md, one sentence", () => {
+  assert.match(RULES, /\*\*Tags render as ONE chip everywhere\*\* \(the user 2026-09-10\): `tagChip` in\s*\n`ui\/webview\/tag-menu\.ts` builds every tag the UI shows/);
+  assert.match(RULES, /weight 400, the\s*\ncontext's size, faded when off; never bold, which is the session names' weight/);
+});

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -194,12 +194,23 @@ export const TAG_BTN_WASH = "rgba(156,210,255,0.12)";     // the feed .on's fain
  *  paints it on a sheet-less host, the two equal by construction. */
 export const TAG_CHIP_OFF_CLASS = "tag-chip-off";
 export const TAG_CHIP_OFF_OPACITY = "0.45";   // pinned equal to .tag-chip-off in styles.css / feed.css
+/** THE ONE TAG CHIP (T321, the user 2026-09-10: tags render the same everywhere, and never in bold, which is the
+ *  session names' weight). Every surface that shows a tag builds it here: the tab strip's group rows and its filter
+ *  chips, the feed's and the outline's filter chips, the tag-lens menu's rows, the tab menu's Tags flyout, the feed's
+ *  session dialog, the new-session picker's Tags row; the two documents that load no module, the landing page's spend
+ *  panel (kernel.py spTagChip) and the Obsidian timeline view, inline the same bytes under drift pins. The standard: a
+ *  thin 1px border and the text in the tag's own
+ *  colour on a transparent ground, weight 400 and normal tracking (inline, so a bold or letter-spaced host cannot
+ *  restyle it), one size per context (the chip's own 0.82em, or the host's with `inheritSize` where a row sizes it),
+ *  and off = the faded chip (`off`: TAG_CHIP_OFF_CLASS at TAG_CHIP_OFF_OPACITY). A host adds layout (flex, margins)
+ *  and state cues the chip never sets inline (a filter, an underline), never a weight, size, border or colour. */
 export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean; off?: boolean }): HTMLElement {
   const col = color || ("var(--dim, " + TAG_BTN_GRAY + ")");
   const chip = document.createElement("span");
   chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;"
     + "border-radius:9px;" + (opts && opts.inheritSize ? "" : "font-size:0.82em;")
     + "border:1px solid " + col + ";color:" + col + ";background:transparent;white-space:nowrap;"
+    + "font-weight:400;letter-spacing:normal;"
     + (opts && opts.off ? "opacity:" + TAG_CHIP_OFF_OPACITY + ";" : ""));
   if (opts && opts.off) chip.setAttribute("class", TAG_CHIP_OFF_CLASS);
   chip.appendChild(document.createTextNode(label));


### PR DESCRIPTION
Tags render as one chip everywhere, and never in bold (T321, the user 2026-09-10: the strip's filter chips at its right rendered unlike the tag rows above them; bold is the session names' weight; the new-session picker's Tags row showed a coloured dot beside each name instead of the tag chip).

**The standard, in one renderer.** `tagChip` (`ui/webview/tag-menu.ts`) builds every tag the UI shows: a thin 1px border and the text in the tag's own colour on a transparent ground, weight 400 and normal tracking (pinned inline, so a bold or letter-spaced host cannot restyle a chip), one size per context (the chip's own 0.82em, or the host's with `inheritSize` where a row sizes it), off = the faded chip (`tag-chip-off`, 0.45). It is written once beside the renderer and once in `ui/CLAUDE.md`. A host adds layout and state cues the chip never sets inline (a filter, an underline), never a weight, size, border or colour.

**The sites.**
- The tab strip's group row chip: already the shared chip; its sheet rule drops `font-weight: 600`, and the header's letter-spacing no longer reaches it. Measured on the served page: the row chip was 10.66px at weight 600 with 0.43px tracking beside filter chips at 400 and normal; both now read 10.66px, 400, normal.
- The strip's filter chips with the ×, the feed's and the outline's filter chips: one builder (`syncTagFilter`), unchanged in shape, now weight 400 by the renderer.
- The tag-lens menu's rows: already the shared chip, faded when off.
- The tab menu's Tags flyout: a row that names a tag IS the chip, in the label slot at the label's size (class `ctx-tag-chip` as its hook), and the action rows name their tag as the chip inside their sentence ("Move to [infra]", "+ [infra]"); the identity dot and its rule are gone (the review found the swatch-and-name pair was the retired vocabulary), and the Show-when-folded row names the home tag in its sub-line's words.
- The landing page's spend panel, which loads no module: a merge-by-tag row names its tag with the chip's inlined twin at the row's size, in place of the session title's bold; pinned against the renderer in the spend tests, and the headless spend pass reads the row's border colour and weight.
- The feed's session dialog: its outline chips come from the renderer (`fsm-chip-tag` stays as the dialog's spacing hook; the sheet rule is reduced to that).
- The new-session picker's Tags row: each option is the chip inside a chrome-less button that inherits the page's typeface (a bare button wears the browser's control face; a review find) and brightens on hover like the strip's row chip, the full chip when selected and the faded chip when not; the dot and its rule are gone; the `sel` state class the create reads is unchanged; the tmux pick greys the row (grayscale alone) rather than fading it, so an off chip is not stacked into a fifth and both looks read in both themes.
- The Obsidian timeline view, which loads no module, inlines the chip's bytes: its views-menu twin, the dialog rows' lane chips, the [+] join options and the corner filter chips carry the same weight and tracking after the colour, and its Sessions and tags dialog's own pills (the tag row's and the per-pane filter pills) take the shared pill byte for byte and the shared off fade, selected being the full chip and unselected the faded chip, never a fill or a weight, so one tag is dressed one way in that pane; all pinned by the drift test. The section-at-a-glance heading's swatch-and-name pair is left to the change stacked behind this one, which replaces that heading.

**Tests.** `ui/webview/tag-chip-everywhere.test.ts`: the renderer through a stub document (border, colour, weight, tracking, size, the off class and opacity), every site's builder including the spend panel's twin, a scan of every rule of both sheets that refuses a weight (the shorthand too), border, colour or size on a chip class, the sentence in `ui/CLAUDE.md`. `ui/webview/picker-tag-chips.test.ts`: the picker's option, chrome and greyed row. Updated pins in the tab-groups, tab-tags, dense-chrome-layout, feed-session-filter, timeline-tag-chips, timeline-tags-scale and spend-detail tests. `tests/test_tag_chips_everywhere_browser.py` drives the served page with a seeded chat filter: the row chip and the same tag's filter chip have identical computed size, weight 400, tracking, border width, radius, padding and colours; the picker's chips wear the strip's typeface, the click flips `sel` and the off class together and back; the greyed row keeps both looks. Extension suite and full Python suite green.

**Screenshots** (hermetic served page, synthetic sessions and tags, dark and light): the grouped strip with the filter chips at its right, before and after, `~/.local/state/romp/drops/romp_timeline-tag-chips-strip-{before,after}-{dark,light}.png`; the picker before, `romp_timeline-picker-tags-before-desktop-{dark,light}.png`, and after at desktop and phone width, `romp_timeline-picker-tags-after-{desktop,phone}-{dark,light}.png`, plus the greyed row, `romp_timeline-picker-tags-after-desktop-{dark,light}-tmux.png`.

**Review.** Two adversarial passes here (four and three lenses, two skeptics per finding, read-only) and the manager's on the pull request (the dialog pills' third and fourth shapes, now the shared one): the picker's host button inherited the browser's control typeface (now the page's), the picker lost its hover cue (the strip's brightening), the greyed row stacked two fades (grey alone now), the spend panel's merge-by-tag rows and the Obsidian view's dialog pills and three inlined chips were still bold or unpinned (all in the standard now), the flyout's action rows kept the swatch-and-name pair (chips in the sentence now), the sheet scan read only single-line rules (every rule now), and prose slips (em-dashes, an added word, a wrong comment) are fixed.
