### PR TITLE
A kernel boot parses no transcript for nobody (lazy transcripts, stage 1)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -947,6 +947,25 @@ check whether each is still running before relaunching it. A kernel restart has
 never touched work a session deliberately detached: tmux servers, `setsid`
 children and other processes that outlive their shell.
 
+A boot reads no transcript for nobody. Until 2026-09-10 a fresh kernel parsed
+every living session's whole transcript at startup (a warm for the first
+dashboard's frames), parsed every session again for its own tick jobs on the
+first cycle, and let the feed-only warm parse every session too; on a box with
+47 live sessions that was 15 GB read and 6.6 GB resident within five minutes.
+Now the startup warm only refreshes the shared session listing: a reconnecting
+dashboard receives its active tab whole and every other tab as a skeleton, so
+the one parse it needs is the one its own connect push runs. The feed-only warm
+parses only sessions whose transcript, state log or goal store changed since
+the boot, or that are working now. The interrupt-block and working-note tick
+jobs skip a session whose transcript, state log and goal store are unchanged
+since their last look, with the boot as the first baseline: a session blocked
+before the restart and untouched after reads blocked from the store the
+previous kernel wrote, with no parse. The judges' passes walk sessions newest
+first and yield between them; their first pass still parses what it
+enumerates, which the checkpoint work that follows removes. `/perf`'s `parses`
+counts the cold parses, and `scripts/bench_boot_parse.py` measures a boot's
+cost against transcript size on synthetic worlds.
+
 What the CLI itself does when its parent goes quiet was measured on Claude Code
 2.1.257 (2026-09-10, the restart-surviving sessions program's stage 3 probe, run
 against a throwaway config directory): a permission request (`can_use_tool`)
@@ -1251,6 +1270,12 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   longer wait between cycles would have skipped; a conservative undercount,
   since a wake set by another thread or a periodic repost of an unchanged
   frame marks a cycle busy).
+- `parses`: the cold event-model parses this kernel ran, `total`, `bytes`
+  (the parsed files' sizes) and `bySid` (per session, by the first eight
+  characters of its id), plus `judge`, the judges' own cold parses through
+  their separate cache. The acceptance number of the lazy-transcript work: a
+  boot with no client connected reads zero here, and a connecting chat client
+  adds exactly its shown tabs.
 - `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
   inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
   `push.*` stages count every push, including the one a connecting page gets,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10573,7 +10573,7 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fal
     time-order is the courier's need; the planner's tree is per-session.)"""
     if now is None:
         now = int(time.time())
-    fleet = [s for s in by_recency(discover(now)) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
+    fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     for _gone in [f for f in _PLANNER_SEEN if f not in {s[0] for s in fleet}]:
         _PLANNER_SEEN.pop(_gone, None)                # the planner gate, bounded by the sessions this pass discovered
     placed = 0
@@ -11269,7 +11269,7 @@ def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fa
     session's open-top set changed. Per-session sequential, sessions concurrent. Returns total relinks."""
     if now is None:
         now = int(time.time())
-    fleet = by_recency(discover(now))[:sessions_cap]
+    fleet = discover(now)[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {}
@@ -11373,7 +11373,7 @@ def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verb
     of sessions whose completed column changed."""
     if now is None:
         now = int(time.time())
-    fleet = by_recency(discover(now))[:sessions_cap]
+    fleet = discover(now)[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {}
@@ -12944,7 +12944,7 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fa
     upgrade still gets its finalize (the promised backfill; the re-critique's population fix)."""
     if now is None:
         now = int(time.time())
-    fleet = [s for s in by_recency(discover(now)) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
+    fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     fleet_sids = {f[0] for f in fleet}
     pending = _death_pending(exclude=fleet_sids)
     if pending:
@@ -13300,7 +13300,7 @@ def _ab_close(sessions_cap=PLAN_SESSIONS):
     positive+negative completed-top-goal counts, the goals (b) newly completes, and a sample of the
     turn-end sweeps so the false-completion rate can be eyeballed before flipping the default."""
     now = int(time.time())
-    fleet = by_recency(discover(now))[:sessions_cap]
+    fleet = discover(now)[:sessions_cap]
     tot_a = tot_b = 0
     all_new, all_samples = [], []
     # Parallel ACROSS sessions (each session sweeps its own turns sequentially for clean attribution).
@@ -13361,7 +13361,7 @@ def _ab_classify(sessions_cap=PLAN_SESSIONS, concurrency=None):
     the live status, WITHOUT mutating goal state. The question: do the soft blocks hold under
     thinking/opus, or were they over-blocks the bigger model corrects?"""
     now = int(time.time())
-    fleet = by_recency(discover(now))[:sessions_cap]
+    fleet = discover(now)[:sessions_cap]
     jobs = []
     for fsid, path, anchor, name in fleet:
         try:
@@ -15204,7 +15204,7 @@ def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
     undiagnosable shape of the T110 report. Returns goals distilled."""
     if now is None:
         now = int(time.time())
-    fleet = by_recency(discover(now))[:sessions_cap]
+    fleet = discover(now)[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {}
@@ -16527,7 +16527,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
     refinement.)"""
     if now is None:
         now = int(time.time())
-    fleet = by_recency(discover(now))[:sessions_cap]
+    fleet = discover(now)[:sessions_cap]
     id2name = {f: nm for f, p, a, nm in fleet}          # recipient id → name, for the sender's tracking-node label
     paths_map = {f: str(p) for f, p, a, nm in fleet}    # sid → transcript, for the mint-time chain trace
     pending, closed = [], {}                           # pending: (seg_t, fsid, seg_id, text, mid, sender)

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -3196,6 +3196,7 @@ def parsed_session(fsid, files, now):
     if key is not None:
         if len(_PARSE_CACHE) > 256:        # bounded by fleet size; a wholesale clear on overflow is fine
             _PARSE_CACHE.clear()
+        _PARSE_MISSES[0] += 1                              # a cold parse (T323: /perf parses.judge)
         _PARSE_CACHE[fsid] = (key, session)
     if fr is not None:                     # pin under the frame the KEY went into (never a re-read _frame: a
         with _frame_lock:                  #  parse spanning a pass boundary must not land keyless in the next
@@ -7804,6 +7805,32 @@ def _discover_fingerprint():
     return tuple(fp)
 
 
+_PARSE_MISSES = [0]          # cold parses parsed_session ran this process (T323: /perf parses.judge)
+
+
+def parse_misses():
+    """How many cold event-model parses the judges' parsed_session ran in this process."""
+    return int(_PARSE_MISSES[0])
+
+
+def by_recency(fleet):
+    """discover()'s rows ordered by transcript mtime, newest first (T323 stage 1): a pass reaches the sessions
+    someone is using now before the ones that have sat for a day, so the first pass after a boot spends its
+    parses where they show. A stat failure sorts last; the input list is left as it was."""
+    def key(row):
+        try:
+            return -os.stat(str(row[1])).st_mtime
+        except (OSError, IndexError, TypeError):
+            return 0.0
+    return sorted(fleet, key=key)
+
+
+def yield_between_sessions():
+    """Let the pusher and the session threads run between two sessions of a pass (T323 stage 1): a whole-fleet
+    pass holds the interpreter for its parses; one zero sleep per session hands the lock over."""
+    time.sleep(0)
+
+
 def discover(now, window=None, forks=True):
     """[(fsid, path, anchor_sid, name)] for every transcript of a romp session touched within `window`
     seconds (default WINDOW, 48h) —
@@ -7956,10 +7983,11 @@ def run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=None, verb
 def _run_index(now=None, budget=BUDGET, fairness=FAIRNESS, concurrency=None, verbose=False):
     if now is None:
         now = int(time.time())
-    fleet = discover(now)
+    fleet = by_recency(discover(now))          # newest transcripts first (T323 stage 1)
     # ── captioner: one entry per undone caption task (a model call), newest-first ──
     pending = []
     for fsid, path, anchor, name in fleet:
+        yield_between_sessions()
         done = captioned_ids(fsid)
         live_n = _live_natoms(fsid)                       # the open segment's last live-caption sizes (cadence gate)
         for task in tasks_for(fsid, str(path), [str(path)], now):
@@ -10545,7 +10573,7 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fal
     time-order is the courier's need; the planner's tree is per-session.)"""
     if now is None:
         now = int(time.time())
-    fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
+    fleet = [s for s in by_recency(discover(now)) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     for _gone in [f for f in _PLANNER_SEEN if f not in {s[0] for s in fleet}]:
         _PLANNER_SEEN.pop(_gone, None)                # the planner gate, bounded by the sessions this pass discovered
     placed = 0
@@ -11241,7 +11269,7 @@ def run_group(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fa
     session's open-top set changed. Per-session sequential, sessions concurrent. Returns total relinks."""
     if now is None:
         now = int(time.time())
-    fleet = discover(now)[:sessions_cap]
+    fleet = by_recency(discover(now))[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {}
@@ -11345,7 +11373,7 @@ def run_consolidate(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verb
     of sessions whose completed column changed."""
     if now is None:
         now = int(time.time())
-    fleet = discover(now)[:sessions_cap]
+    fleet = by_recency(discover(now))[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {}
@@ -12916,7 +12944,7 @@ def run_close(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fa
     upgrade still gets its finalize (the promised backfill; the re-critique's population fix)."""
     if now is None:
         now = int(time.time())
-    fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
+    fleet = [s for s in by_recency(discover(now)) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     fleet_sids = {f[0] for f in fleet}
     pending = _death_pending(exclude=fleet_sids)
     if pending:
@@ -13272,7 +13300,7 @@ def _ab_close(sessions_cap=PLAN_SESSIONS):
     positive+negative completed-top-goal counts, the goals (b) newly completes, and a sample of the
     turn-end sweeps so the false-completion rate can be eyeballed before flipping the default."""
     now = int(time.time())
-    fleet = discover(now)[:sessions_cap]
+    fleet = by_recency(discover(now))[:sessions_cap]
     tot_a = tot_b = 0
     all_new, all_samples = [], []
     # Parallel ACROSS sessions (each session sweeps its own turns sequentially for clean attribution).
@@ -13333,7 +13361,7 @@ def _ab_classify(sessions_cap=PLAN_SESSIONS, concurrency=None):
     the live status, WITHOUT mutating goal state. The question: do the soft blocks hold under
     thinking/opus, or were they over-blocks the bigger model corrects?"""
     now = int(time.time())
-    fleet = discover(now)[:sessions_cap]
+    fleet = by_recency(discover(now))[:sessions_cap]
     jobs = []
     for fsid, path, anchor, name in fleet:
         try:
@@ -15176,7 +15204,7 @@ def run_distill(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
     undiagnosable shape of the T110 report. Returns goals distilled."""
     if now is None:
         now = int(time.time())
-    fleet = discover(now)[:sessions_cap]
+    fleet = by_recency(discover(now))[:sessions_cap]
     n = 0
     with ThreadPoolExecutor(max_workers=_conc(concurrency)) as ex:
         futs = {}
@@ -16499,7 +16527,7 @@ def run_courier(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=
     refinement.)"""
     if now is None:
         now = int(time.time())
-    fleet = discover(now)[:sessions_cap]
+    fleet = by_recency(discover(now))[:sessions_cap]
     id2name = {f: nm for f, p, a, nm in fleet}          # recipient id → name, for the sender's tracking-node label
     paths_map = {f: str(p) for f, p, a, nm in fleet}    # sid → transcript, for the mint-time chain trace
     pending, closed = [], {}                           # pending: (seg_t, fsid, seg_id, text, mid, sender)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8993,15 +8993,16 @@ def _persist_tick_seen(force=False):
 def _tick_job_check(job, s):
     """T323 stage 1: (skip, stat) for an event-keyed tick job, one whose answer is a pure function of the
     session's transcript, state log and goal store, never of the wall clock. `skip` is True when those files
-    are UNCHANGED since the job's last COMPLETED evaluation (_tick_job_done), and, before any, unchanged since
-    this kernel BOOTED. Why the boot baseline: before this, every such job parsed every alive session on the
-    first cycle after a restart to re-derive what the previous kernel had already filed in the store (the
-    interrupt block marker, the working note), a full parse per session for nothing new (T311: 388 chats'
-    worth of parses in five minutes). A session that moved under the previous kernel's death is evaluated;
-    one that did not keeps the store's verdict, which is what the card reads. Nothing is recorded here: the
-    caller marks the evaluation done only once its store work landed, so a fault mid-tick (an unproved ledger,
-    a refused marker write) leaves the session to the next tick exactly as before (the fault-boundary tests
-    pin that). A job with a wall-clock leg (the nudge's timers) must not use this."""
+    are UNCHANGED since the job's last COMPLETED evaluation (_tick_job_done) on record, this kernel's or a
+    previous one's (the memo persists, _TICK_SEEN_FILE); a session no kernel on record has looked at is
+    evaluated once. Why: before this, every such job parsed every alive session on the first cycle after a
+    restart to re-derive what the previous kernel had already filed in the store (the interrupt block marker,
+    the working note), a full parse per session for nothing new (T311: 388 chats' worth of parses in five
+    minutes). A session that moved since its last look is evaluated; one that did not keeps the store's
+    verdict, which is what the card reads. Nothing is recorded here: the caller marks the evaluation done only
+    once its store work landed, so a fault mid-tick (an unproved ledger, an unreadable store, a refused marker
+    write) leaves the session to the next tick exactly as before (the fault-boundary tests pin that). A job
+    with a wall-clock leg (the nudge's timers) must not use this."""
     st = _session_files_stat(s)
     if not st[0]:
         return False, st                      # no transcript to stat: nothing is known about it, so never a skip
@@ -9093,6 +9094,15 @@ def _interrupt_block_tick(now, tmux):
                 continue
             _auto_nudge_resume()
             ib = _intr_blocked(sid)                      # once per interrupt episode (the intrBlocked marker) —
+            if ib:
+                # an UNREADABLE store keeps the marker (_intr_block_stands reads a fault as standing, by design)
+                # but is no evidence the block holds its card, so it is no completed evaluation either: the
+                # session stays unmarked and the next tick reads again (review find, 2026-09-11: marking it
+                # done here skipped the session for good, across a graceful restart, with its new focus top in
+                # Working while it sat stopped)
+                _store, _fault = jd.load_goals_shared_or_fault(sid)
+                if _fault is not None:
+                    continue
             if ib and not _intr_block_stands(sid, ib):   # but VERIFY the marked block still holds its card (see
                 _set_intr_blocked(sid, None)             # _intr_block_stands): a stale marker is the 'already
                 ib = None                                # surfaced' claim with its evidence gone
@@ -9114,9 +9124,10 @@ def _interrupt_block_tick(now, tmux):
                     # the tag check above and here refuses the marker, the next tick stands down at the check,
                     # and the first healed tick re-mints the marker (_record_interrupt_block hands back the
                     # gid of a card our own block already holds, appending nothing)
-                    _set_intr_blocked(sid, g)
-                    _tick_job_done("interrupt-block", s, files_st)   # filed and marked: evaluated (a refused
-                    #                                                    record leaves the session to the next tick)
+                    if _set_intr_blocked(sid, g) is not False:       # False: the marker write was refused (an unproved
+                        _tick_job_done("interrupt-block", s, files_st)   # ledger snapshot); the next tick re-mints it.
+                    #                                                    Filed AND marked: evaluated (a refused record
+                    #                                                    leaves the session to the next tick as well)
         else:                                            # working / re-engaged / machine cut → lift OUR block if any
             ib = _intr_blocked(sid)
             if not ib:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8911,6 +8911,13 @@ def _intr_block_stands(sid, gid):
 _PARSE_WARM_STATES = ("working", "compacting", "retrying")   # a session the feed warm still parses when it did not move
 
 
+def _warm_wanted(s, tm):
+    """Whether the feed warm would parse session row `s` (its tmux row `tm`): it moved since this kernel booted, or
+    it is working now. build_feed asks for a warm only for such a session; one the gate leaves cold is cold by
+    design (its card reads the store, its dots wait for a client), not a cold parse to chase every cycle."""
+    return _session_moved_since_boot(s) or (tm or {}).get("state", "") in _PARSE_WARM_STATES
+
+
 def _session_files_stat(s):
     """(mtime, size) of the transcript, the state log and the session's goal store, zeros for a missing file: the
     three inputs every event-keyed tick job reads. A change in any of them is the only event that can change the
@@ -8934,8 +8941,53 @@ def _session_moved_since_boot(s):
     return st[0] > _STARTED or st[2] > _STARTED or st[4] > _STARTED
 
 
-_TICK_SEEN: dict = {}          # (job, sid) -> the files' stat tuple at the job's last evaluation (T323 stage 1)
+_TICK_SEEN: dict = {}          # (job, sid) -> the files' stat tuple at the job's last COMPLETED evaluation (T323 stage 1)
 _TICK_SEEN_LOCK = threading.Lock()
+_TICK_SEEN_FILE = "tick-seen.json"   # the memo PERSISTED under the state dir (jd.STATE): written when dirty at the end
+#                                      of a pusher cycle and at exit, read at boot, so the next kernel's first look
+#                                      compares against the previous kernel's last evaluation rather than its own
+#                                      start (review find: a stop landing in the gap between the previous kernel's
+#                                      last tick and this boot read as unchanged and was never blocked). A crash
+#                                      loses the newest writes: the affected sessions are evaluated once, the safe way.
+_TICK_SEEN_DIRTY = [False]
+
+
+def _tick_seen_path():
+    return jd.STATE / _TICK_SEEN_FILE
+
+
+def _load_tick_seen():
+    """Read the persisted memo into _TICK_SEEN (best-effort; a missing or torn file is an empty memo)."""
+    try:
+        d = json.loads(_tick_seen_path().read_text(encoding="utf-8"))
+    except Exception:
+        return 0
+    n = 0
+    with _TICK_SEEN_LOCK:
+        for k, v in (d.items() if isinstance(d, dict) else ()):
+            if isinstance(k, str) and "|" in k and isinstance(v, list) and len(v) == 6:
+                job, sid = k.split("|", 1)
+                _TICK_SEEN[(job, sid)] = tuple(v)
+                n += 1
+    return n
+
+
+def _persist_tick_seen(force=False):
+    """Write the memo when a completed evaluation moved it since the last write (or `force`); atomic, best-effort."""
+    with _TICK_SEEN_LOCK:
+        if not (_TICK_SEEN_DIRTY[0] or force):
+            return False
+        snap = {"%s|%s" % k: list(v) for k, v in _TICK_SEEN.items()}
+        _TICK_SEEN_DIRTY[0] = False
+    try:
+        p = _tick_seen_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_name(p.name + ".tmp.%d" % os.getpid())
+        tmp.write_text(json.dumps(snap), encoding="utf-8")
+        os.replace(tmp, p)
+        return True
+    except Exception:
+        return False
 
 
 def _tick_job_check(job, s):
@@ -8957,7 +9009,7 @@ def _tick_job_check(job, s):
     with _TICK_SEEN_LOCK:
         prev = _TICK_SEEN.get(key)
     if prev is None:
-        return (not (st[0] > _STARTED or st[2] > _STARTED or st[4] > _STARTED)), st
+        return False, st                      # never evaluated by any kernel on record: evaluate once
     return st == prev, st
 
 
@@ -8967,6 +9019,7 @@ def _tick_job_done(job, s, st):
     key = (job, str(s.get("sid") or ""))
     with _TICK_SEEN_LOCK:
         _TICK_SEEN[key] = st
+        _TICK_SEEN_DIRTY[0] = True
         if len(_TICK_SEEN) > 4096:            # bounded by jobs × sessions; never unbounded
             _TICK_SEEN.clear()
 
@@ -8974,6 +9027,9 @@ def _tick_job_done(job, s, st):
 def _tick_job_skips(job, s):
     """Check and, when unchanged, nothing else: the skip needs no record (the baseline it matched still stands)."""
     return _tick_job_check(job, s)[0]
+
+
+_load_tick_seen()               # the previous kernel's last evaluations, if it left them
 
 
 def _interrupt_block_tick(now, tmux):
@@ -29029,6 +29085,7 @@ def _warm_fleet_bg(now):
         _warming[0] = True
 
     def go():
+        parsed_any = False
         try:
             tmux = _tmux_sessions()
             for s in _alive_sessions(now, tmux):         # live sessions first
@@ -29037,11 +29094,14 @@ def _warm_fleet_bg(now):
                 # T323 stage 1: only a session that MOVED since this kernel booted (its transcript or state log
                 # appended) or is working right now is worth a cold parse here; the rest cost O(file bytes)
                 # each for working dots nobody's card will show differently, and the cache fills on demand
-                if not (_session_moved_since_boot(s) or (tmux.get(s["sid"]) or {}).get("state", "") in _PARSE_WARM_STATES):
+                if not _warm_wanted(s, tmux.get(s["sid"])):
                     continue
                 _parse(s["path"], s["sid"], now)          # warm the kernel parse cache
-            _built_feed[1] = None                         # force the next build to use the now-warm parses
-            _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
+                parsed_any = True
+            if parsed_any:                                # (review find: a warm that parsed nothing must not
+                _built_feed[1] = None                     #  invalidate the feed and wake the pusher, or a feed-only
+                _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
+            #                                                window rebuilt the whole feed every cycle for ever)
         except Exception:
             sys.stderr.write("warm: %s\n" % traceback.format_exc())
         finally:
@@ -35241,7 +35301,8 @@ def build_feed(now, tmux=None):
         # and anchors snap in a beat later.
         ps = _parse_cached(s["path"])
         if ps is None:
-            cold_parse = True
+            if _warm_wanted(s, tm):                      # cold by design otherwise (T323 stage 1): no warm to chase
+                cold_parse = True
         else:
             ps = _merge_live_atoms(ps, fsid)         # the same LIVE-MERGED session the chat chip + timeline lane read
             #                                          (the feed was the one surface deriving from the bare cache, 2026-07-05)
@@ -45814,6 +45875,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _interrupt_block_tick(now, tmux)
     except Exception:
         sys.stderr.write("interrupt-block: %s\n" % traceback.format_exc())
+    try:                                  # the tick jobs' evaluation memo, persisted when a completed evaluation
+        _persist_tick_seen()              # moved it (T323 stage 1): the next kernel's first look starts from here
+    except Exception:
+        sys.stderr.write("tick-seen: %s\n" % traceback.format_exc())
     try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
         _auto_pause_on_limit()
     except Exception:
@@ -55524,6 +55589,10 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     reason_err = ""
     be = _sdk_backend or None
     _exit_log("romp-kernel: %s, draining SDK sessions\n" % what)
+    try:
+        _persist_tick_seen(force=True)    # the tick jobs' memo for the next kernel's first look (T323 stage 1)
+    except Exception:
+        pass
     try:
         if be is not None and hasattr(be, "drain"):
             res = be.drain(2.0)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -312,6 +312,10 @@ class _PerfStats:
                                         "bg_miss": {k: 0 for k in self.CHAT_MISS}})   # see build_chat
             self.sends = {k: {} for k in self.SEND_KINDS}
             self.judge = {"passes": 0, "ms_sum": 0.0, "ms_last": 0.0, "cpu_ms_sum": 0.0}
+            # cold event-model parses this kernel ran (T323 stage 1): the kernel's own _parse misses, per session
+            # (sid8) and in total, plus the bytes of the files parsed; the judges' misses ride the snapshot from
+            # jd.parse_misses(). The acceptance number of the lazy-transcript work: a boot with no client parses zero.
+            self.parses = {"total": 0, "bytes": 0, "bySid": {}}
             self.http = {}
 
     # ── writers (hot paths) ──
@@ -353,6 +357,16 @@ class _PerfStats:
     def stage(self, name, dt):
         with self.lock:
             self.stages[name] = self.stages.get(name, 0.0) + dt * 1000.0
+
+    def parse(self, sid, nbytes=0):
+        """One COLD parse by the kernel's _parse (a cache miss that ran em.parse_session)."""
+        with self.lock:
+            p = self.parses
+            p["total"] += 1
+            p["bytes"] += int(nbytes or 0)
+            k = str(sid or "")[:8]
+            if len(p["bySid"]) < 1024 or k in p["bySid"]:
+                p["bySid"][k] = p["bySid"].get(k, 0) + 1
 
     def build(self, kind, cached, dt=0.0):
         with self.lock:
@@ -452,6 +466,7 @@ class _PerfStats:
             stages = dict(self.stages)
             builds = {k: dict(v) for k, v in self.builds.items()}
             builds["chat"]["bg_miss"] = dict(self.builds["chat"]["bg_miss"])   # the nested map: a copy too
+            parses = {"total": self.parses["total"], "bytes": self.parses["bytes"], "bySid": dict(self.parses["bySid"])}
             sends = {k: {sl: {"count": e[0], "bytes": e[1]} for sl, e in d.items()}
                      for k, d in self.sends.items()}
             judge = dict(self.judge)
@@ -498,7 +513,8 @@ class _PerfStats:
         now = time.time()
         return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
                 "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
-                "builds": builds, "sends": sends, "goals": goals, "memos": memos, "judge": judge, "http": http}
+                "builds": builds, "sends": sends, "goals": goals, "memos": memos, "judge": judge, "http": http,
+                "parses": dict(parses, judge=int(getattr(jd, "parse_misses", lambda: 0)()))}   # T323: cold parses
 
 
 _PERF_STATS = _PerfStats()
@@ -8892,6 +8908,60 @@ def _intr_block_stands(sid, gid):
     return bool(nd and nd.get("blocked"))
 
 
+_PARSE_WARM_STATES = ("working", "compacting", "retrying")   # a session the feed warm still parses when it did not move
+
+
+def _session_files_stat(s):
+    """(mtime, size) of the transcript, the state log and the session's goal store, zeros for a missing file: the
+    three inputs every event-keyed tick job reads. A change in any of them is the only event that can change the
+    job's answer; the store is in the tuple because a judge can clear or complete the goal a marker points at with
+    no transcript change at all, and the interrupt tick must re-block on exactly that (its docstring's stale-marker
+    rule; tests/test_kernel_interrupt_machine_cut.py pins it)."""
+    sid = str(s.get("sid") or "")
+    out = []
+    for p in (s.get("path") or "", str(jd.STATE / "states" / (sid + ".jsonl")), str(jd.GOALDIR / (sid + ".json"))):
+        try:
+            st = os.stat(p)
+            out += [st.st_mtime, st.st_size]
+        except OSError:
+            out += [0.0, 0]
+    return tuple(out)
+
+
+def _session_moved_since_boot(s):
+    """Whether the session's transcript or state log was written after THIS kernel started (_STARTED)."""
+    st = _session_files_stat(s)
+    return st[0] > _STARTED or st[2] > _STARTED or st[4] > _STARTED
+
+
+_TICK_SEEN: dict = {}          # (job, sid) -> the files' stat tuple at the job's last evaluation (T323 stage 1)
+_TICK_SEEN_LOCK = threading.Lock()
+
+
+def _tick_job_skips(job, s):
+    """T323 stage 1: an event-keyed tick job (one whose answer is a pure function of the session's transcript,
+    state log and the goal store, never of the wall clock) skips a session whose transcript and state log are
+    UNCHANGED since the job's last evaluation, and, at its first evaluation in this kernel life, unchanged since
+    this kernel BOOTED. Why the boot baseline: before this, every such job parsed every alive session on the
+    first cycle after a restart to re-derive what the previous kernel had already filed in the store (the
+    interrupt block marker, the working note), a full parse per session for nothing new (T311: 388 chats' worth
+    of parses in five minutes). A session that moved under the previous kernel's death is evaluated; one that
+    did not keeps the store's verdict, which is what the card reads. Records the stat tuple and returns True
+    to skip, False to evaluate; a job with a wall-clock leg (the nudge's timers) must not use this."""
+    st = _session_files_stat(s)
+    key = (job, str(s.get("sid") or ""))
+    with _TICK_SEEN_LOCK:
+        prev = _TICK_SEEN.get(key)
+        if prev is None:
+            unchanged = not (st[0] > _STARTED or st[2] > _STARTED or st[4] > _STARTED)
+        else:
+            unchanged = st == prev
+        _TICK_SEEN[key] = st
+        if len(_TICK_SEEN) > 4096:            # bounded by jobs × sessions; never unbounded
+            _TICK_SEEN.clear()
+    return unchanged
+
+
 def _interrupt_block_tick(now, tmux):
     """Interrupt → Blocked, INDEPENDENT of the auto-nudge switch (the user 2026-07-14). A session the
     user genuinely STOPPED mid-turn is waiting on their next instruction: its focus goal needs THEM, so
@@ -8930,6 +9000,8 @@ def _interrupt_block_tick(now, tmux):
             continue                                     # awaiting you / compacting → a different needs-you path owns it
         if _api_error(s["path"]):                        # stopped on an API error → not a user stop
             continue
+        if _tick_job_skips("interrupt-block", s):        # nothing appended since the last look (or since boot): the
+            continue                                     # store already carries the verdict this tick would re-derive
         try:
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
@@ -12075,6 +12147,8 @@ def _clear_done_working_notes(now, tmux):
             continue
         if (tmux.get(sid) or {}).get("state", "") in ("working", "compacting", "permission", "picker", "retrying"):
             continue                                     # actively progressing / awaiting input per tmux → keep (cheap pre-gate, no parse)
+        if _tick_job_skips("working-notes", s):          # nothing appended since the last look (or since boot) → the
+            continue                                     # note's fate was settled by the previous evaluation
         try:
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
@@ -28379,6 +28453,10 @@ def _parse(path, sid, now):
     # parse it just made, so a racing parse of the same path can only make it MORE conservative
     # (a "full" read where a "fold" happened) — never less.
     _parse_mode[path] = _mode[-1] if _mode else "full"
+    try:
+        _PERF_STATS.parse(sid, key[1] if key is not None else 0)   # a cold parse ran (T323: /perf parses)
+    except Exception:
+        pass
     if key is not None:
         if len(_parse_cache) > 256:              # backstop: bounded by fleet size, but never unbounded
             _parse_cache.clear()
@@ -28909,10 +28987,13 @@ def _has_parsing_client():
 
 
 def _warm_fleet_bg(now):
-    """Parse every LIVING session into the kernel parse cache in the background, then drop the feed cache and
-    re-push — so a FEED-ONLY window (no chat/timeline to warm the cache for it) still gets its working-dots +
-    anchors a beat after the cards. A no-op when nobody's connected, or when a chat/timeline client IS (it
-    warms the cache itself); and it bails mid-sweep the instant one connects, so it never competes."""
+    """Parse the living sessions that MOVED since this kernel booted, or are working now, into the kernel parse
+    cache in the background, then drop the feed cache and re-push — so a FEED-ONLY window (no chat/timeline to
+    warm the cache for it) still gets its working-dots + anchors a beat after the cards for the sessions whose
+    dots can differ. Until T323 stage 1 (2026-09-10) it parsed EVERY living session, O(file bytes) each, for dots
+    that an untouched session's card would not change; those now fill the cache on demand. A no-op when nobody's
+    connected, or when a chat/timeline client IS (it warms the cache itself); and it bails mid-sweep the instant
+    one connects, so it never competes."""
     with _clients_lock:
         if not _clients:
             return
@@ -28929,6 +29010,11 @@ def _warm_fleet_bg(now):
             for s in _alive_sessions(now, tmux):         # live sessions first
                 if _has_parsing_client():                 # a chat/timeline tab just opened → it'll warm the rest
                     break
+                # T323 stage 1: only a session that MOVED since this kernel booted (its transcript or state log
+                # appended) or is working right now is worth a cold parse here; the rest cost O(file bytes)
+                # each for working dots nobody's card will show differently, and the cache fills on demand
+                if not (_session_moved_since_boot(s) or (tmux.get(s["sid"]) or {}).get("state", "") in _PARSE_WARM_STATES):
+                    continue
                 _parse(s["path"], s["sid"], now)          # warm the kernel parse cache
             _built_feed[1] = None                         # force the next build to use the now-warm parses
             _push_soon()   # ack-fast (the 2026-08-30 wedge: inline fleet builds piled 53 POST handlers; the pusher coalesces)
@@ -28941,27 +29027,25 @@ def _warm_fleet_bg(now):
 
 
 def _boot_warm():
-    """Warm the live fleet's parse cache at kernel STARTUP (the user 2026-07-03: after `romp refresh`, local
-    sessions take a long time to load while remote ones — served by their own still-warm kernel over federation
-    — appear at once). A fresh kernel has EMPTY caches, so the first connect pays the full cold serial parse
-    (~2-4s: build_timeline bars + every chat tab). But between the restart and that connect there's a 1-2s gap
-    while the browser notices the socket dropped, reconnects, and reloads — during which the kernel is IDLE.
-    Spend it: pre-parse the living sessions into _parse_cache so the first connect finds them WARM. Best-effort;
-    bails the instant a chat/timeline client connects (that connect warms what it needs — no GIL contention),
-    warms discover() first (its own cache, shared by every builder), and never throws. Safe: this only
-    PRE-COMPUTES the same (mtime,size)-keyed cache the connect would build — no new state, no staleness."""
+    """Warm the shared discover() cache at kernel STARTUP, and nothing else. Until T323 stage 1 (2026-09-10) this
+    parsed every living session into the kernel parse cache so a reconnecting dashboard found its frames warm (the
+    user 2026-07-03: after `romp refresh` local sessions loaded slowly while federated ones, served by a warm remote
+    kernel, appeared at once); that cost a full read and parse of every transcript on every boot, for nobody, and
+    the redial road has since made it moot: a reconnecting dashboard gets its ACTIVE tab whole and every other tab
+    as a skeleton, so the one parse it needs is the one its own connect push runs. See go() below for the rest of
+    the reasoning."""
     def go():
         try:
             now = int(time.time())
             jd.discover(now)                              # warm the shared discover cache (every builder needs it)
-            tmux = _tmux_sessions()
-            for s in _alive_sessions(now, tmux):
-                if _has_parsing_client():                 # the browser reconnected → it warms the rest; stand down
-                    return
-                try:
-                    _parse(s["path"], s["sid"], now)      # warm the kernel parse cache (build_timeline/-session reuse it)
-                except Exception:
-                    pass
+            # T323 stage 1 (the user 2026-09-10, who wants nothing read at boot that nobody asked for): the warm
+            # PARSES NOTHING any more. It used to parse every living session, O(file bytes) per session per boot,
+            # 15 GB read and 6.6 GB resident within minutes on a 47-session box (T311), for a first frame that
+            # parses its own tab anyway: the redial road ships the ACTIVE tab whole and every other tab as a
+            # skeleton (_client_reset_chat_base, the ?reconnect=1 path), so the only parse a reconnecting
+            # dashboard needs is the one its connect push runs. No tab strip is persisted in the kernel (tabs are
+            # every living session; the active tab is the client's fact, sent after it reconnects), so there is
+            # nothing to pre-parse selectively either. Per boot per session: O(file) → 0.
         except Exception:
             sys.stderr.write("boot-warm: %s\n" % traceback.format_exc())
     threading.Thread(target=go, daemon=True, name="boot-warm").start()

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -8938,28 +8938,42 @@ _TICK_SEEN: dict = {}          # (job, sid) -> the files' stat tuple at the job'
 _TICK_SEEN_LOCK = threading.Lock()
 
 
-def _tick_job_skips(job, s):
-    """T323 stage 1: an event-keyed tick job (one whose answer is a pure function of the session's transcript,
-    state log and the goal store, never of the wall clock) skips a session whose transcript and state log are
-    UNCHANGED since the job's last evaluation, and, at its first evaluation in this kernel life, unchanged since
+def _tick_job_check(job, s):
+    """T323 stage 1: (skip, stat) for an event-keyed tick job, one whose answer is a pure function of the
+    session's transcript, state log and goal store, never of the wall clock. `skip` is True when those files
+    are UNCHANGED since the job's last COMPLETED evaluation (_tick_job_done), and, before any, unchanged since
     this kernel BOOTED. Why the boot baseline: before this, every such job parsed every alive session on the
     first cycle after a restart to re-derive what the previous kernel had already filed in the store (the
-    interrupt block marker, the working note), a full parse per session for nothing new (T311: 388 chats' worth
-    of parses in five minutes). A session that moved under the previous kernel's death is evaluated; one that
-    did not keeps the store's verdict, which is what the card reads. Records the stat tuple and returns True
-    to skip, False to evaluate; a job with a wall-clock leg (the nudge's timers) must not use this."""
+    interrupt block marker, the working note), a full parse per session for nothing new (T311: 388 chats'
+    worth of parses in five minutes). A session that moved under the previous kernel's death is evaluated;
+    one that did not keeps the store's verdict, which is what the card reads. Nothing is recorded here: the
+    caller marks the evaluation done only once its store work landed, so a fault mid-tick (an unproved ledger,
+    a refused marker write) leaves the session to the next tick exactly as before (the fault-boundary tests
+    pin that). A job with a wall-clock leg (the nudge's timers) must not use this."""
     st = _session_files_stat(s)
+    if not st[0]:
+        return False, st                      # no transcript to stat: nothing is known about it, so never a skip
     key = (job, str(s.get("sid") or ""))
     with _TICK_SEEN_LOCK:
         prev = _TICK_SEEN.get(key)
-        if prev is None:
-            unchanged = not (st[0] > _STARTED or st[2] > _STARTED or st[4] > _STARTED)
-        else:
-            unchanged = st == prev
+    if prev is None:
+        return (not (st[0] > _STARTED or st[2] > _STARTED or st[4] > _STARTED)), st
+    return st == prev, st
+
+
+def _tick_job_done(job, s, st):
+    """The job's evaluation of `s` completed with its store work landed: the files' stat tuple `st` (from
+    _tick_job_check) becomes the baseline the next check compares against."""
+    key = (job, str(s.get("sid") or ""))
+    with _TICK_SEEN_LOCK:
         _TICK_SEEN[key] = st
         if len(_TICK_SEEN) > 4096:            # bounded by jobs × sessions; never unbounded
             _TICK_SEEN.clear()
-    return unchanged
+
+
+def _tick_job_skips(job, s):
+    """Check and, when unchanged, nothing else: the skip needs no record (the baseline it matched still stands)."""
+    return _tick_job_check(job, s)[0]
 
 
 def _interrupt_block_tick(now, tmux):
@@ -9000,8 +9014,9 @@ def _interrupt_block_tick(now, tmux):
             continue                                     # awaiting you / compacting → a different needs-you path owns it
         if _api_error(s["path"]):                        # stopped on an API error → not a user stop
             continue
-        if _tick_job_skips("interrupt-block", s):        # nothing appended since the last look (or since boot): the
-            continue                                     # store already carries the verdict this tick would re-derive
+        skip, files_st = _tick_job_check("interrupt-block", s)   # nothing appended since the last COMPLETED look (or
+        if skip:                                                 # since boot): the store already carries the verdict
+            continue                                             # this tick would re-derive
         try:
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
@@ -9025,6 +9040,8 @@ def _interrupt_block_tick(now, tmux):
             if ib and not _intr_block_stands(sid, ib):   # but VERIFY the marked block still holds its card (see
                 _set_intr_blocked(sid, None)             # _intr_block_stands): a stale marker is the 'already
                 ib = None                                # surfaced' claim with its evidence gone
+            if ib:
+                _tick_job_done("interrupt-block", s, files_st)   # the standing block still holds its card: evaluated
             if not ib:
                 # the evidence is the CURRENT quiet, not just the stop: the transcript's newest event
                 # time is the horizon the user has stayed silent through — injected activity (a task
@@ -9042,8 +9059,12 @@ def _interrupt_block_tick(now, tmux):
                     # and the first healed tick re-mints the marker (_record_interrupt_block hands back the
                     # gid of a card our own block already holds, appending nothing)
                     _set_intr_blocked(sid, g)
+                    _tick_job_done("interrupt-block", s, files_st)   # filed and marked: evaluated (a refused
+                    #                                                    record leaves the session to the next tick)
         else:                                            # working / re-engaged / machine cut → lift OUR block if any
             ib = _intr_blocked(sid)
+            if not ib:
+                _tick_job_done("interrupt-block", s, files_st)   # nothing to lift: evaluated
             if ib:
                 # the re-engagement IS the newest turn's trigger — the same stamp the judges will put on
                 # every verdict about that turn, so their ruling outranks this lift on arrival order.
@@ -9055,6 +9076,7 @@ def _interrupt_block_tick(now, tmux):
                 # the marker too, so the next tick retries the lift rather than erasing it (the #1019 boundary)
                 if _lift_interrupt_block(sid, ib, turns[-1].get("t") if turns else 0):
                     _set_intr_blocked(sid, None)     # spent → the marker goes; refused under a fault it stays
+                    _tick_job_done("interrupt-block", s, files_st)   # lifted: evaluated
                 #                                      in the last proved snapshot and the next tick retries
     alive_sids = {s["sid"] for s in alive}              # a sid that left the alive set is the event that retires
     _intr_marks_forget(alive_sids)                      # its interrupt-marks entries and its states-overlay fold
@@ -12147,12 +12169,14 @@ def _clear_done_working_notes(now, tmux):
             continue
         if (tmux.get(sid) or {}).get("state", "") in ("working", "compacting", "permission", "picker", "retrying"):
             continue                                     # actively progressing / awaiting input per tmux → keep (cheap pre-gate, no parse)
-        if _tick_job_skips("working-notes", s):          # nothing appended since the last look (or since boot) → the
-            continue                                     # note's fate was settled by the previous evaluation
+        skip, files_st = _tick_job_check("working-notes", s)   # nothing appended since the last completed look (or
+        if skip:                                               # since boot) → the note's fate was settled then
+            continue
         try:
             turns = jd.parsed_session(sid, [s["path"]], now)["turns"]
         except Exception:
             continue
+        _tick_job_done("working-notes", s, files_st)      # evaluated (every branch below reads, at most one writes)
         if not turns or _session_working(turns):         # still working per the event model → keep its claim
             continue
         if _open_top_goal(sid):                           # working OR blocked top remains → still its work

--- a/scripts/bench_boot_parse.py
+++ b/scripts/bench_boot_parse.py
@@ -158,6 +158,9 @@ def draw(rows, out):
     tops = [0.0, 0.0, 0.0]
     for i, label in enumerate(labels):
         rs = sorted([r for r in rows if r["label"] == label and not r.get("error")], key=lambda r: r["worldBytes"])
+        if not rs:
+            sys.stderr.write("figure: every boot of %r errored; the label is left out\n" % label)
+            continue
         xs = [r["worldBytes"] / 1048576 for r in rs]
         c = cols[i % len(cols)]
         counted = all(r.get("parses") is not None for r in rs)

--- a/scripts/bench_boot_parse.py
+++ b/scripts/bench_boot_parse.py
@@ -145,21 +145,35 @@ def boot_once(tree, dist, sessions, turns, settle_s):
 
 
 def draw(rows, out):
+    """Three panels of boot cost against the transcripts' size on disk: the kernel's own cold parses (the stage 1
+    number; a tree without the counter drew every living session by construction, which the panel says), bytes the
+    process read, and its resident size. Axes start at zero; flat is the goal."""
     import cleanplots as cp
     import matplotlib
     matplotlib.use("Agg")
     labels = sorted({r["label"] for r in rows})
     cols = list(cp.colors)
-    f, axs = cp.fig(rows=1, cols=2, w=14, h=4.5)
+    f, axs = cp.fig(rows=1, cols=3, w=19, h=4.8)
+    f.subplots_adjust(wspace=0.45)
+    tops = [0.0, 0.0, 0.0]
     for i, label in enumerate(labels):
         rs = sorted([r for r in rows if r["label"] == label and not r.get("error")], key=lambda r: r["worldBytes"])
         xs = [r["worldBytes"] / 1048576 for r in rs]
-        axs[0].line(xs, [(r["readBytes"] or 0) / 1048576 for r in rs], label=label, color=cols[i % len(cols)], marker="o")
-        axs[1].line(xs, [(r["rssKb"] or 0) / 1024 for r in rs], label=label, color=cols[i % len(cols)], marker="o")
-    axs[0].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Bytes the kernel read by settle (MB)\nflat is the goal")
-    axs[1].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Kernel resident size at settle (MB)\nflat is the goal")
-    for ax in axs:
-        ax.set_xlim(left=0); ax.set_ylim(bottom=0)
+        c = cols[i % len(cols)]
+        counted = all(r.get("parses") is not None for r in rs)
+        parses = [r["parses"] if counted else r["sessions"] for r in rs]
+        axs[0].line(xs, parses, label=label if counted else label + " (every session, by construction)", color=c, marker="o",
+                    linestyle="-" if counted else "--")
+        axs[1].line(xs, [(r["readBytes"] or 0) / 1048576 for r in rs], label=label, color=c, marker="o")
+        axs[2].line(xs, [(r["rssKb"] or 0) / 1024 for r in rs], label=label, color=c, marker="o")
+        tops = [max(tops[0], max(parses)), max(tops[1], max((r["readBytes"] or 0) / 1048576 for r in rs)),
+                max(tops[2], max((r["rssKb"] or 0) / 1024 for r in rs))]
+    axs[0].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Cold parses by the kernel at boot\nzero is the goal")
+    axs[1].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Bytes the process read by settle (MB)\nflat is the goal")
+    axs[2].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Resident size at settle (MB)\nflat is the goal")
+    for ax, top in zip(axs, tops):
+        ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25 if top else 1)
+        ax.set_yticks([0, round(top, 1) if top < 10 else round(top)])
     path = os.path.join(out, "boot_cost_vs_size.png")
     f.savefig(path, dpi=150, bbox_inches="tight")
     return path
@@ -174,8 +188,13 @@ def main(argv=None):
     ap.add_argument("--settle", type=float, default=8.0, help="seconds after first serve before reading the cost")
     ap.add_argument("--out", required=True)
     ap.add_argument("--no-figure", action="store_true")
+    ap.add_argument("--figure-only", action="store_true", help="redraw from <out>/bench.json without booting anything")
     a = ap.parse_args(argv)
     os.makedirs(a.out, exist_ok=True)
+    if a.figure_only:
+        with open(os.path.join(a.out, "bench.json")) as f:
+            sys.stdout.write("figure " + draw(json.load(f)["rows"], a.out) + "\n")
+        return 0
     trees = [(s.split("=", 1)[0], os.path.abspath(s.split("=", 1)[1])) for s in a.tree]
     sizes = [int(x) for x in a.sizes.split(",")]
     ext = os.path.join(trees[0][1], "vscode-extension")   # one bundle serves every boot (the kernel only serves it)

--- a/scripts/bench_boot_parse.py
+++ b/scripts/bench_boot_parse.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""bench_boot_parse: what a kernel boot reads, against transcript size (T323, the user's scaling criterion).
+
+Builds a hermetic world of N synthetic sessions whose transcripts are S times a base of invented text, boots a real
+kernel from a given tree (bin/romp-kernel of that tree) with no client, waits for the boot to settle, and reads what the
+boot cost: bytes the kernel process read from files (/proc/<pid>/io rchar), its resident size, the cold parses /perf
+counts (where the tree reports them), and the time to first /healthz. One boot per (tree, size), one at a time, small
+worlds (a measurement, not load); everything under a temporary root, nothing against live state. Then draws cost against
+size with cleanplots: a flat or O(new records) curve passes the criterion, a curve tracking the file size fails.
+
+    capped bash -c 'uvx --with cleanplots --with matplotlib --with pandas python scripts/bench_boot_parse.py \\
+        --tree before=/path/to/main-checkout --tree after=/path/to/branch-worktree --sizes 1,4,16 --sessions 6 \\
+        --out ~/.local/state/romp-research/T323-stage1-bench'
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT / "tests")); sys.path.insert(0, str(ROOT))   # tests/ as scripts and as the `tests` package
+WORDS = ("fixture", "suite", "backoff", "jitter", "cap", "retry", "review", "branch", "merge", "green", "README", "wire",
+         "widget", "loop", "notes", "api", "tests", "web", "minutes", "decision")
+
+
+def _free_port():
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); p = s.getsockname()[1]; s.close(); return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def synthetic_transcript(t0, turns, seed):
+    """`turns` invented user/assistant turns (about 1.2 KB a turn), a proper parentUuid chain, all before the boot."""
+    import random
+    rnd = random.Random(seed)
+    recs, parent, t = [], None, t0
+    for i in range(turns):
+        u = "u%06d" % i; a = "a%06d" % i
+        text = " ".join(rnd.choice(WORDS) for _ in range(40))
+        recs.append({"type": "user", "timestamp": iso(t), "uuid": u, "parentUuid": parent, "promptSource": "typed",
+                     "message": {"role": "user", "content": "please " + text}})
+        body = " ".join(rnd.choice(WORDS) for _ in range(120))
+        recs.append({"type": "assistant", "timestamp": iso(t + 20), "uuid": a, "parentUuid": u,
+                     "message": {"role": "assistant", "content": [{"type": "text", "text": body}], "stop_reason": "end_turn"}})
+        parent, t = a, t + 60
+    return recs
+
+
+def build_world(lab, sessions, turns, seed=1):
+    import test_ship_reship as _lab
+    state = os.path.join(lab, "xdg", "romp"); claude = os.path.join(lab, "claude"); cwd = os.path.join(lab, "proj")
+    for d in ("names", "sdk", "states"):
+        os.makedirs(os.path.join(state, d), exist_ok=True)
+    os.makedirs(cwd, exist_ok=True)
+    proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+    os.makedirs(proj, exist_ok=True)
+    t0 = int(time.time()) - 86400
+    total = 0
+    for i in range(sessions):
+        sid = "%08x-1111-2222-3333-444444444444" % (0xa0000000 + i)
+        name = "s%02d" % i
+        Path(state, "names", sid).write_text("%s\t%s\t#9cd2ff\t#0c1a2e\n" % (name, cwd))
+        Path(state, "sdk", sid + ".json").write_text(json.dumps({"sid": sid, "name": name, "cwd": cwd, "mode": "auto",
+                                                                 "effort": "high", "lastSid": sid, "alive": True}))
+        Path(state, "states", sid + ".jsonl").write_text(json.dumps({"t": t0 + turns * 60, "state": "idle"}) + "\n")
+        p = Path(proj, sid + ".jsonl")
+        p.write_text("".join(json.dumps(r) + "\n" for r in synthetic_transcript(t0, turns, seed + i)))
+        total += p.stat().st_size
+    Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+    return _lab, state, claude, total
+
+
+def _get(port, token, path, timeout=5):
+    req = urllib.request.Request("http://127.0.0.1:%d%s" % (port, path), headers={"X-Romp-Token": token})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode())
+
+
+def _proc(pid):
+    out = {}
+    try:
+        for ln in open("/proc/%d/io" % pid):
+            k, v = ln.split(":"); out[k.strip()] = int(v)
+    except OSError:
+        pass
+    try:
+        for ln in open("/proc/%d/status" % pid):
+            if ln.startswith("VmRSS"):
+                out["rssKb"] = int(ln.split()[1])
+    except OSError:
+        pass
+    return out
+
+
+def boot_once(tree, dist, sessions, turns, settle_s):
+    lab = tempfile.mkdtemp(prefix="romp-bench-")
+    try:
+        _lab, state, claude, total_bytes = build_world(lab, sessions, turns)
+        port, token = _free_port(), "bench-token"
+        env = _lab.kernel_env(lab, claude, dist, port, token, ROMP_HOST_NAME="TESTHOST")
+        t_start = time.perf_counter()
+        proc = subprocess.Popen([os.path.join(tree, "bin", "romp-kernel")], stdout=open(os.path.join(lab, "kernel.log"), "w"),
+                                stderr=subprocess.STDOUT, env=env)
+        first_serve = None
+        for _ in range(240):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % port, timeout=1)
+                first_serve = time.perf_counter() - t_start
+                break
+            except Exception:
+                time.sleep(0.25)
+        if first_serve is None:
+            proc.kill(); return {"error": "never served"}
+        time.sleep(settle_s)                    # a fixed settle: the boot warm, the judges' first pass, a few pusher cycles
+        io = _proc(proc.pid)
+        try:
+            perf = _get(port, token, "/perf")
+            parses = perf.get("parses") or {}
+        except Exception:
+            parses = {}
+        row = {"tree": tree, "sessions": sessions, "turnsPerSession": turns, "worldBytes": total_bytes,
+               "firstServeS": round(first_serve, 2), "settleS": settle_s, "readBytes": io.get("rchar"),
+               "rssKb": io.get("rssKb"), "parses": parses.get("total"), "parseBytes": parses.get("bytes"),
+               "judgeParses": parses.get("judge")}
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except Exception:
+            proc.kill()
+        return row
+    finally:
+        shutil.rmtree(lab, ignore_errors=True)
+
+
+def draw(rows, out):
+    import cleanplots as cp
+    import matplotlib
+    matplotlib.use("Agg")
+    labels = sorted({r["label"] for r in rows})
+    cols = list(cp.colors)
+    f, axs = cp.fig(rows=1, cols=2, w=14, h=4.5)
+    for i, label in enumerate(labels):
+        rs = sorted([r for r in rows if r["label"] == label and not r.get("error")], key=lambda r: r["worldBytes"])
+        xs = [r["worldBytes"] / 1048576 for r in rs]
+        axs[0].line(xs, [(r["readBytes"] or 0) / 1048576 for r in rs], label=label, color=cols[i % len(cols)], marker="o")
+        axs[1].line(xs, [(r["rssKb"] or 0) / 1024 for r in rs], label=label, color=cols[i % len(cols)], marker="o")
+    axs[0].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Bytes the kernel read by settle (MB)\nflat is the goal")
+    axs[1].clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Kernel resident size at settle (MB)\nflat is the goal")
+    for ax in axs:
+        ax.set_xlim(left=0); ax.set_ylim(bottom=0)
+    path = os.path.join(out, "boot_cost_vs_size.png")
+    f.savefig(path, dpi=150, bbox_inches="tight")
+    return path
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--tree", action="append", required=True, help="label=path of a romp checkout to boot from")
+    ap.add_argument("--sizes", default="1,4,16", help="multipliers of the base turns per session")
+    ap.add_argument("--base-turns", type=int, default=150, help="turns per session at size 1 (about 180 KB a transcript)")
+    ap.add_argument("--sessions", type=int, default=6)
+    ap.add_argument("--settle", type=float, default=8.0, help="seconds after first serve before reading the cost")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--no-figure", action="store_true")
+    a = ap.parse_args(argv)
+    os.makedirs(a.out, exist_ok=True)
+    trees = [(s.split("=", 1)[0], os.path.abspath(s.split("=", 1)[1])) for s in a.tree]
+    sizes = [int(x) for x in a.sizes.split(",")]
+    ext = os.path.join(trees[0][1], "vscode-extension")   # one bundle serves every boot (the kernel only serves it)
+    b = subprocess.run(["node", "esbuild.js"], cwd=ext, capture_output=True, text=True)
+    if b.returncode != 0:
+        sys.stderr.write("esbuild failed in %s: %s\n" % (ext, (b.stderr or b.stdout)[-300:])); return 1
+    dist = os.path.join(ext, "dist")
+    rows = []
+    for label, tree in trees:
+        for s in sizes:
+            row = boot_once(tree, dist, a.sessions, a.base_turns * s, a.settle)
+            row.update(label=label, size=s)
+            rows.append(row)
+            sys.stdout.write(json.dumps(row) + "\n"); sys.stdout.flush()
+    with open(os.path.join(a.out, "bench.json"), "w") as f:
+        json.dump({"rows": rows, "t": int(time.time())}, f, indent=1)
+    if not a.no_figure:
+        sys.stdout.write("figure " + draw(rows, a.out) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -66,6 +66,33 @@ class BootWarmParsesNothing(unittest.TestCase):
 
 
 class FeedWarmParsesOnlyWhatMoved(unittest.TestCase):
+    def test_a_warm_that_parses_nothing_wakes_nobody(self):
+        """Review find: with a feed-only window and an idle unmoved session, the warm used to invalidate the feed
+        and wake the pusher every cycle though it parsed nothing (a whole-feed rebuild per cycle for ever)."""
+        d = tempfile.mkdtemp()
+        rows = [_row(d, SID_OLD, old=True)]
+        pokes = []
+        before = _threads()
+        km._warming[0] = False
+        saved = list(km._clients)
+        with km._clients_lock:
+            km._clients[:] = [{"app": "feed", "send": lambda s: None, "sent": {}, "alive": True}]
+        self.addCleanup(lambda: km._clients.__setitem__(slice(None), saved))
+        km._built_feed[1] = "a built payload"
+        with mock.patch.object(km, "_alive_sessions", side_effect=lambda now, tmux: rows), \
+             mock.patch.object(km, "_tmux_sessions", side_effect=lambda: {}), \
+             mock.patch.object(km, "_has_parsing_client", side_effect=lambda: False), \
+             mock.patch.object(km, "_parse", side_effect=lambda path, sid, now: None), \
+             mock.patch.object(km, "_push_soon", side_effect=lambda: pokes.append(1)):
+            km._warm_fleet_bg(int(time.time()))
+            _join_new(before)
+        self.assertEqual(km._built_feed[1], "a built payload", "the feed cache is left alone")
+        self.assertEqual(pokes, [], "and the pusher is not woken")
+        src = inspect.getsource(km.build_feed)
+        self.assertIn("if _warm_wanted(s, tm):", src, "build_feed asks for a warm only for a session the gate would parse")
+        self.assertFalse(km._warm_wanted(rows[0], None), "an unmoved idle session is cold by design")
+        self.assertTrue(km._warm_wanted(rows[0], {"state": "working"}))
+
     def test_moved_or_working_only(self):
         d = tempfile.mkdtemp()
         rows = [_row(d, SID_OLD, old=True), _row(d, SID_NEW, old=False), _row(d, SID_WORK, old=True)]
@@ -97,36 +124,59 @@ class FeedWarmParsesOnlyWhatMoved(unittest.TestCase):
 
 
 class TickJobsKeyOnAChange(unittest.TestCase):
+    """The event-keyed tick jobs' memo: a session is evaluated once when no kernel on record has looked at it,
+    skipped while its transcript, state log and goal store match the last COMPLETED look, and evaluated again on
+    any change; the memo persists across kernels, so a stop that landed in the gap between the previous kernel's
+    last tick and this boot is evaluated (review find, 2026-09-10), while a session settled before the restart
+    and untouched since is not parsed again."""
+
     def setUp(self):
         km._TICK_SEEN.clear()
+        km._TICK_SEEN_DIRTY[0] = False
+        p = km._tick_seen_path()
+        if p.exists():
+            p.unlink()
 
-    def test_unchanged_since_boot_is_skipped_and_a_change_is_evaluated_once(self):
+    def test_first_look_evaluates_then_a_completed_look_skips_until_a_change(self):
         d = tempfile.mkdtemp()
-        r = _row(d, SID_OLD, old=True)
-        self.assertTrue(km._tick_job_skips("interrupt-block", r), "first look: unchanged since boot → the store's verdict stands, no parse")
-        self.assertTrue(km._tick_job_skips("interrupt-block", r), "still unchanged")
+        r = _row(d, SID_OLD, old=True)                    # mtime BEFORE this kernel's start: no longer a reason to skip
+        skip, st = km._tick_job_check("interrupt-block", r)
+        self.assertFalse(skip, "no kernel on record has looked at it: evaluate once, whatever the mtime")
+        self.assertFalse(km._tick_job_skips("interrupt-block", r), "not yet marked done (a fault mid-tick): the next tick evaluates again")
+        km._tick_job_done("interrupt-block", r, st)
+        self.assertTrue(km._tick_job_skips("interrupt-block", r), "once the evaluation completed, the same files skip")
         with open(r["path"], "a") as f:
             f.write(json.dumps({"type": "assistant", "uuid": "a1"}) + "\n")
         os.utime(r["path"], None)
         skip, st = km._tick_job_check("interrupt-block", r)
         self.assertFalse(skip, "an appended record is the event: evaluate")
-        self.assertFalse(km._tick_job_skips("interrupt-block", r), "not yet marked done (a fault mid-tick): the next tick evaluates again")
         km._tick_job_done("interrupt-block", r, st)
-        self.assertTrue(km._tick_job_skips("interrupt-block", r), "once the evaluation completed, the same files skip again")
+        self.assertTrue(km._tick_job_skips("interrupt-block", r))
 
-    def test_a_session_that_moved_before_this_boot_read_it_is_evaluated_at_first_look(self):
+    def test_the_memo_persists_and_the_next_kernel_starts_from_it(self):
         d = tempfile.mkdtemp()
-        r = _row(d, SID_NEW, old=False)          # mtime after _STARTED: it changed under the previous kernel's death or since
-        skip, st = km._tick_job_check("working-notes", r)
-        self.assertFalse(skip)
-        km._tick_job_done("working-notes", r, st)
-        self.assertTrue(km._tick_job_skips("working-notes", r))
+        settled = _row(d, SID_OLD, old=True)             # settled by the previous kernel, untouched since
+        moved = _row(d, SID_NEW, old=True)               # settled, then moved in the gap before this boot
+        skip, st = km._tick_job_check("interrupt-block", settled); km._tick_job_done("interrupt-block", settled, st)
+        skip, st = km._tick_job_check("interrupt-block", moved); km._tick_job_done("interrupt-block", moved, st)
+        self.assertTrue(km._persist_tick_seen(), "dirty → written")
+        self.assertFalse(km._persist_tick_seen(), "clean → nothing to write")
+        # the gap: a stop lands in `moved` after the previous kernel's last tick, before this boot (mtime still < _STARTED)
+        with open(moved["path"], "a") as f:
+            f.write(json.dumps({"type": "user", "uuid": "u9", "message": {"role": "user", "content": "[Request interrupted by user]"}}) + "\n")
+        os.utime(moved["path"], (km._STARTED - 60, km._STARTED - 60))
+        # the next kernel: an empty memo, then the persisted one
+        km._TICK_SEEN.clear()
+        self.assertEqual(km._load_tick_seen(), 2)
+        self.assertTrue(km._tick_job_skips("interrupt-block", settled), "unchanged since the previous kernel's look: the store's verdict stands, no parse")
+        self.assertFalse(km._tick_job_skips("interrupt-block", moved), "moved in the gap before the boot: evaluated, whatever _STARTED says")
 
     def test_a_goal_store_write_is_an_event_too(self):
         """A judge can clear or complete the goal a marker points at without a transcript change; the interrupt
         tick must re-evaluate on that alone (its stale-marker rule)."""
         d = tempfile.mkdtemp()
         r = _row(d, SID_OLD, old=True)
+        skip, st = km._tick_job_check("interrupt-block", r); km._tick_job_done("interrupt-block", r, st)
         self.assertTrue(km._tick_job_skips("interrupt-block", r))
         km.jd.GOALDIR.mkdir(parents=True, exist_ok=True)
         (km.jd.GOALDIR / (SID_OLD + ".json")).write_text("{}")
@@ -148,8 +198,28 @@ class TickJobsKeyOnAChange(unittest.TestCase):
     def test_jobs_keep_separate_memos(self):
         d = tempfile.mkdtemp()
         r = _row(d, SID_NEW, old=False)
-        self.assertFalse(km._tick_job_skips("interrupt-block", r))
+        skip, st = km._tick_job_check("interrupt-block", r); km._tick_job_done("interrupt-block", r, st)
         self.assertFalse(km._tick_job_skips("working-notes", r), "another job's first look is its own")
+
+    def test_a_bail_out_leaves_the_session_unmarked(self):
+        """Review find: an unproved ledger read, a parse failure or an exception mid-tick must leave the session
+        for the next tick; only a landed outcome marks it done."""
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_OLD, old=True)
+        stopped = [{"id": "t1", "t": 1000, "atoms": [{"t": 1000, "type": "user"}]}]
+        common = dict(_alive_sessions=lambda now, tmux: [r], _session_flag=lambda sid, flag: False,
+                      _compacting_now=lambda *a, **k: False, _api_error=lambda path: False,
+                      _interrupt_marks=lambda turns, sid, family="judge": (1000, 900), _session_working=lambda turns: False,
+                      _auto_nudge_pause=lambda why: None, _auto_nudge_resume=lambda: None)
+        with mock.patch.multiple(km, **common), \
+             mock.patch.object(km.jd, "parsed_session", side_effect=lambda sid, paths, now: {"turns": stopped}), \
+             mock.patch.object(km, "_auto_nudge_data", side_effect=lambda: {km.UNPROVED: {"t": 1}}):
+            km._interrupt_block_tick(int(time.time()), {})
+        self.assertNotIn(("interrupt-block", SID_OLD), km._TICK_SEEN, "an unproved ledger read bails out unmarked")
+        with mock.patch.multiple(km, **common), \
+             mock.patch.object(km.jd, "parsed_session", side_effect=RuntimeError("parse failed")):
+            km._interrupt_block_tick(int(time.time()), {})
+        self.assertNotIn(("interrupt-block", SID_OLD), km._TICK_SEEN, "a parse failure bails out unmarked")
 
     def test_the_two_event_keyed_ticks_gate_before_their_parse_and_the_nudge_does_not(self):
         for fn, job in ((km._interrupt_block_tick, "interrupt-block"), (km._clear_done_working_notes, "working-notes")):
@@ -159,8 +229,11 @@ class TickJobsKeyOnAChange(unittest.TestCase):
             self.assertIn('_tick_job_done("%s", s, files_st)' % job, src, "%s: a completed evaluation is marked done" % job)
         self.assertEqual(inspect.getsource(km._interrupt_block_tick).count('_tick_job_done("interrupt-block", s, files_st)'), 4,
                          "done on the four landed outcomes (filed, standing, lifted, nothing to lift); never on a refused write or an unproved ledger")
-        self.assertNotIn("_tick_job_skips", inspect.getsource(km._auto_nudge_session),
-                         "the nudge has wall-clock timers, so it keeps its per-cycle evaluation (documented in _tick_job_skips)")
+        self.assertNotIn("_tick_job_check", inspect.getsource(km._auto_nudge_session),
+                         "the nudge has wall-clock timers, so it keeps its per-cycle evaluation (documented in _tick_job_check)")
+        cyc = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertLess(cyc.index("_interrupt_block_tick(now, tmux)"), cyc.index("_persist_tick_seen()"), "the memo is written after the tick jobs")
+        self.assertIn("_persist_tick_seen(force=True)", inspect.getsource(km._drain_and_exit), "and at exit")
 
 
 class PerfCountsColdParses(unittest.TestCase):

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -221,6 +221,48 @@ class TickJobsKeyOnAChange(unittest.TestCase):
             km._interrupt_block_tick(int(time.time()), {})
         self.assertNotIn(("interrupt-block", SID_OLD), km._TICK_SEEN, "a parse failure bails out unmarked")
 
+    def test_a_faulting_store_read_on_the_standing_path_leaves_the_session_unmarked(self):
+        """Review find: _intr_block_stands keeps the marker on an unreadable store by design; that is not evidence
+        the block still holds its card, so the tick must not mark the session evaluated (the persisted memo would
+        carry the skip across a restart while the new focus top sat in Working)."""
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_OLD, old=True)
+        stopped = [{"id": "t1", "t": 1000, "atoms": [{"t": 1000, "type": "user"}]}]
+        common = dict(_alive_sessions=lambda now, tmux: [r], _session_flag=lambda sid, flag: False,
+                      _compacting_now=lambda *a, **k: False, _api_error=lambda path: False,
+                      _interrupt_marks=lambda turns, sid, family="judge": (1000, 900), _session_working=lambda turns: False,
+                      _auto_nudge_resume=lambda: None, _auto_nudge_data=lambda: {}, _intr_blocked=lambda sid=None: "g1")
+        with mock.patch.multiple(km, **common), \
+             mock.patch.object(km.jd, "parsed_session", side_effect=lambda sid, paths, now: {"turns": stopped}), \
+             mock.patch.object(km.jd, "load_goals_shared_or_fault", side_effect=lambda sid: (None, OSError("transient"))):
+            km._interrupt_block_tick(int(time.time()), {})
+        self.assertNotIn(("interrupt-block", SID_OLD), km._TICK_SEEN, "a faulted store read is not a standing block: unmarked")
+        with mock.patch.multiple(km, **common), \
+             mock.patch.object(km.jd, "parsed_session", side_effect=lambda sid, paths, now: {"turns": stopped}), \
+             mock.patch.object(km.jd, "load_goals_shared_or_fault", side_effect=lambda sid: ({"nodes": {"g1": {"blocked": True}}}, None)):
+            km._interrupt_block_tick(int(time.time()), {})
+        self.assertIn(("interrupt-block", SID_OLD), km._TICK_SEEN, "a readable store whose block still holds its card: evaluated")
+
+    def test_a_refused_marker_write_leaves_the_session_unmarked(self):
+        """Review find: _set_intr_blocked returns False when its own ledger read is unproved; marking the session
+        done on that would leave the block on the card with no marker ever minted."""
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_OLD, old=True)
+        stopped = [{"id": "t1", "t": 1000, "atoms": [{"t": 1000, "type": "user"}]}]
+        common = dict(_alive_sessions=lambda now, tmux: [r], _session_flag=lambda sid, flag: False,
+                      _compacting_now=lambda *a, **k: False, _api_error=lambda path: False,
+                      _interrupt_marks=lambda turns, sid, family="judge": (1000, 900), _session_working=lambda turns: False,
+                      _auto_nudge_resume=lambda: None, _auto_nudge_data=lambda: {}, _intr_blocked=lambda sid=None: None,
+                      _record_interrupt_block=lambda sid, ev: "g1")
+        for refused, marked in ((False, False), (True, True)):
+            km._TICK_SEEN.clear()
+            with mock.patch.multiple(km, **common), \
+                 mock.patch.object(km, "_set_intr_blocked", side_effect=lambda sid, gid: refused), \
+                 mock.patch.object(km.jd, "parsed_session", side_effect=lambda sid, paths, now: {"turns": stopped}):
+                km._interrupt_block_tick(int(time.time()), {})
+            self.assertEqual(("interrupt-block", SID_OLD) in km._TICK_SEEN, marked,
+                             "marker write returned %r → marked %r" % (refused, marked))
+
     def test_the_two_event_keyed_ticks_gate_before_their_parse_and_the_nudge_does_not(self):
         for fn, job in ((km._interrupt_block_tick, "interrupt-block"), (km._clear_done_working_notes, "working-notes")):
             src = inspect.getsource(fn)

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""T323 stage 1 (the user 2026-09-10): a kernel boot must not read every live transcript whole for nobody. The boot
+warm parses nothing (it warms discover() only), the feed-only warm parses only sessions that moved since this boot or
+are working now, the judges' passes go newest-first and yield between sessions, the two event-keyed tick jobs skip a
+session whose transcript and state log are unchanged since their last look (the boot being the first baseline), and
+/perf counts every cold parse so the effect is measurable. Hermetic: synthetic files under a temp root, the kernel and
+judge loaded against a temp state directory, threads joined explicitly."""
+import inspect
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel_t323s1", os.path.join(BIN, "romp-kernel"))
+
+SID_OLD = "11111111-2222-4333-8444-000000000001"
+SID_NEW = "22222222-2222-4333-8444-000000000002"
+SID_WORK = "33333333-2222-4333-8444-000000000003"
+
+
+def _threads():
+    return set(threading.enumerate())
+
+
+def _join_new(before, timeout=10):
+    for t in _threads() - before:
+        t.join(timeout)
+
+
+def _row(d, sid, old):
+    """A session row whose transcript (and state log) predate or postdate this kernel's start."""
+    p = Path(d) / (sid + ".jsonl")
+    p.write_text(json.dumps({"type": "user", "uuid": sid[:8], "timestamp": "2026-09-10T00:00:00Z", "message": {"role": "user", "content": "x"}}) + "\n")
+    t = km._STARTED - 600 if old else time.time() + 1
+    os.utime(p, (t, t))
+    return {"sid": sid, "path": str(p), "name": sid[:8], "mtime": t}
+
+
+class BootWarmParsesNothing(unittest.TestCase):
+    def test_discover_only(self):
+        calls = {"discover": 0, "parse": 0}
+        before = _threads()
+        with mock.patch.object(km.jd, "discover", side_effect=lambda now, **k: calls.__setitem__("discover", calls["discover"] + 1) or []), \
+             mock.patch.object(km, "_parse", side_effect=lambda *a, **k: calls.__setitem__("parse", calls["parse"] + 1)), \
+             mock.patch.object(km, "_alive_sessions", side_effect=lambda now, tmux: [{"sid": SID_OLD, "path": "/nonexistent", "name": "web"}]):
+            km._boot_warm()
+            _join_new(before)
+        self.assertEqual(calls["discover"], 1, "the shared discover cache is still warmed")
+        self.assertEqual(calls["parse"], 0, "no transcript is parsed for nobody (the redial road parses the active tab itself)")
+        src = inspect.getsource(km._boot_warm)
+        self.assertNotIn("_parse(", src, "the warm's body calls no parse")
+        self.assertIn("PARSES NOTHING", src)
+
+
+class FeedWarmParsesOnlyWhatMoved(unittest.TestCase):
+    def test_moved_or_working_only(self):
+        d = tempfile.mkdtemp()
+        rows = [_row(d, SID_OLD, old=True), _row(d, SID_NEW, old=False), _row(d, SID_WORK, old=True)]
+        parsed = []
+        before = _threads()
+        km._warming[0] = False
+        saved = list(km._clients)
+        with km._clients_lock:                                   # the warm is a no-op with nobody connected: a feed-only window
+            km._clients[:] = [{"app": "feed", "send": lambda s: None, "sent": {}, "alive": True}]
+        self.addCleanup(lambda: km._clients.__setitem__(slice(None), saved))
+        with mock.patch.object(km, "_alive_sessions", side_effect=lambda now, tmux: rows), \
+             mock.patch.object(km, "_tmux_sessions", side_effect=lambda: {SID_WORK: {"state": "working"}}), \
+             mock.patch.object(km, "_has_parsing_client", side_effect=lambda: False), \
+             mock.patch.object(km, "_parse", side_effect=lambda path, sid, now: parsed.append(sid)):
+            km._warm_fleet_bg(int(time.time()))
+            _join_new(before)
+        self.assertEqual(sorted(parsed), sorted([SID_NEW, SID_WORK]),
+                         "the session that moved since boot and the one working now; the untouched one waits for a client")
+
+    def test_moved_since_boot_reads_either_file(self):
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_OLD, old=True)
+        self.assertFalse(km._session_moved_since_boot(r))
+        states = km.jd.STATE / "states"
+        states.mkdir(parents=True, exist_ok=True)
+        (states / (SID_OLD + ".jsonl")).write_text(json.dumps({"t": int(time.time()), "state": "waiting"}) + "\n")
+        self.assertTrue(km._session_moved_since_boot(r), "a state-log append after the boot counts as movement")
+        (states / (SID_OLD + ".jsonl")).unlink()
+
+
+class TickJobsKeyOnAChange(unittest.TestCase):
+    def setUp(self):
+        km._TICK_SEEN.clear()
+
+    def test_unchanged_since_boot_is_skipped_and_a_change_is_evaluated_once(self):
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_OLD, old=True)
+        self.assertTrue(km._tick_job_skips("interrupt-block", r), "first look: unchanged since boot → the store's verdict stands, no parse")
+        self.assertTrue(km._tick_job_skips("interrupt-block", r), "still unchanged")
+        with open(r["path"], "a") as f:
+            f.write(json.dumps({"type": "assistant", "uuid": "a1"}) + "\n")
+        os.utime(r["path"], None)
+        self.assertFalse(km._tick_job_skips("interrupt-block", r), "an appended record is the event: evaluate")
+        self.assertTrue(km._tick_job_skips("interrupt-block", r), "and once evaluated, the same files skip again")
+
+    def test_a_session_that_moved_before_this_boot_read_it_is_evaluated_at_first_look(self):
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_NEW, old=False)          # mtime after _STARTED: it changed under the previous kernel's death or since
+        self.assertFalse(km._tick_job_skips("working-notes", r))
+        self.assertTrue(km._tick_job_skips("working-notes", r))
+
+    def test_a_goal_store_write_is_an_event_too(self):
+        """A judge can clear or complete the goal a marker points at without a transcript change; the interrupt
+        tick must re-evaluate on that alone (its stale-marker rule)."""
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_OLD, old=True)
+        self.assertTrue(km._tick_job_skips("interrupt-block", r))
+        km.jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        (km.jd.GOALDIR / (SID_OLD + ".json")).write_text("{}")
+        try:
+            self.assertFalse(km._tick_job_skips("interrupt-block", r), "the store moved: evaluate")
+            self.assertTrue(km._tick_job_skips("interrupt-block", r))
+        finally:
+            (km.jd.GOALDIR / (SID_OLD + ".json")).unlink()
+
+    def test_jobs_keep_separate_memos(self):
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_NEW, old=False)
+        self.assertFalse(km._tick_job_skips("interrupt-block", r))
+        self.assertFalse(km._tick_job_skips("working-notes", r), "another job's first look is its own")
+
+    def test_the_two_event_keyed_ticks_gate_before_their_parse_and_the_nudge_does_not(self):
+        for fn, job in ((km._interrupt_block_tick, "interrupt-block"), (km._clear_done_working_notes, "working-notes")):
+            src = inspect.getsource(fn)
+            gate, parse = src.index('_tick_job_skips("%s", s)' % job), src.index("jd.parsed_session(sid, [s[\"path\"]], now)")
+            self.assertLess(gate, parse, "%s: the gate sits before the parse" % job)
+        self.assertNotIn("_tick_job_skips", inspect.getsource(km._auto_nudge_session),
+                         "the nudge has wall-clock timers, so it keeps its per-cycle evaluation (documented in _tick_job_skips)")
+
+
+class PerfCountsColdParses(unittest.TestCase):
+    def test_counter_and_snapshot(self):
+        km._PERF_STATS.reset()
+        km._PERF_STATS.parse(SID_OLD, 1234)
+        km._PERF_STATS.parse(SID_OLD, 10)
+        km._PERF_STATS.parse(SID_NEW, 5)
+        snap = km._PERF_STATS.snapshot()
+        self.assertEqual((snap["parses"]["total"], snap["parses"]["bytes"]), (3, 1249))
+        self.assertEqual(snap["parses"]["bySid"], {SID_OLD[:8]: 2, SID_NEW[:8]: 1})
+        self.assertIsInstance(snap["parses"]["judge"], int)
+
+    def test_kernel_parse_counts_a_miss_not_a_hit(self):
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_NEW, old=False)
+        km._PERF_STATS.reset()
+        km._parse_cache.pop(r["path"], None)
+        now = int(time.time())
+        km._parse(r["path"], SID_NEW, now)
+        km._parse(r["path"], SID_NEW, now)
+        self.assertEqual(km._PERF_STATS.snapshot()["parses"]["total"], 1, "the second call is a cache hit")
+
+    def test_judge_parse_misses(self):
+        d = tempfile.mkdtemp()
+        r = _row(d, SID_WORK, old=False)
+        before = jd.parse_misses()
+        jd._PARSE_CACHE.pop(SID_WORK, None)
+        now = int(time.time())
+        jd.parsed_session(SID_WORK, [r["path"]], now)
+        jd.parsed_session(SID_WORK, [r["path"]], now)
+        self.assertEqual(jd.parse_misses() - before, 1)
+
+
+class JudgesGoNewestFirst(unittest.TestCase):
+    def test_by_recency_orders_by_transcript_mtime(self):
+        d = tempfile.mkdtemp()
+        rows = []
+        for i, sid in enumerate((SID_OLD, SID_NEW, SID_WORK)):
+            p = Path(d) / (sid + ".jsonl"); p.write_text("{}\n")
+            os.utime(p, (1000 + i * 100, 1000 + i * 100))
+            rows.append((sid, str(p), sid, sid[:8]))
+        rows.append(("missing", str(Path(d) / "missing.jsonl"), "missing", "m"))
+        out = jd.by_recency(rows)
+        self.assertEqual([r[0] for r in out], [SID_WORK, SID_NEW, SID_OLD, "missing"], "newest first, a stat failure last")
+        self.assertEqual([r[0] for r in rows][0], SID_OLD, "the input is not reordered in place")
+
+    def test_passes_walk_by_recency_and_yield(self):
+        src = inspect.getsource(jd._run_index)
+        self.assertIn("fleet = by_recency(discover(now))", src)
+        self.assertIn("yield_between_sessions()", src)
+        self.assertGreaterEqual(inspect.getsource(jd).count("by_recency(discover(now))"), 5, "every capped pass loop orders by recency")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -108,13 +108,18 @@ class TickJobsKeyOnAChange(unittest.TestCase):
         with open(r["path"], "a") as f:
             f.write(json.dumps({"type": "assistant", "uuid": "a1"}) + "\n")
         os.utime(r["path"], None)
-        self.assertFalse(km._tick_job_skips("interrupt-block", r), "an appended record is the event: evaluate")
-        self.assertTrue(km._tick_job_skips("interrupt-block", r), "and once evaluated, the same files skip again")
+        skip, st = km._tick_job_check("interrupt-block", r)
+        self.assertFalse(skip, "an appended record is the event: evaluate")
+        self.assertFalse(km._tick_job_skips("interrupt-block", r), "not yet marked done (a fault mid-tick): the next tick evaluates again")
+        km._tick_job_done("interrupt-block", r, st)
+        self.assertTrue(km._tick_job_skips("interrupt-block", r), "once the evaluation completed, the same files skip again")
 
     def test_a_session_that_moved_before_this_boot_read_it_is_evaluated_at_first_look(self):
         d = tempfile.mkdtemp()
         r = _row(d, SID_NEW, old=False)          # mtime after _STARTED: it changed under the previous kernel's death or since
-        self.assertFalse(km._tick_job_skips("working-notes", r))
+        skip, st = km._tick_job_check("working-notes", r)
+        self.assertFalse(skip)
+        km._tick_job_done("working-notes", r, st)
         self.assertTrue(km._tick_job_skips("working-notes", r))
 
     def test_a_goal_store_write_is_an_event_too(self):
@@ -126,10 +131,19 @@ class TickJobsKeyOnAChange(unittest.TestCase):
         km.jd.GOALDIR.mkdir(parents=True, exist_ok=True)
         (km.jd.GOALDIR / (SID_OLD + ".json")).write_text("{}")
         try:
-            self.assertFalse(km._tick_job_skips("interrupt-block", r), "the store moved: evaluate")
+            skip, st = km._tick_job_check("interrupt-block", r)
+            self.assertFalse(skip, "the store moved: evaluate")
+            km._tick_job_done("interrupt-block", r, st)
             self.assertTrue(km._tick_job_skips("interrupt-block", r))
         finally:
             (km.jd.GOALDIR / (SID_OLD + ".json")).unlink()
+
+    def test_a_missing_transcript_is_unknown_never_unchanged(self):
+        r = {"sid": SID_OLD, "path": "/nonexistent-t323.jsonl", "name": "web"}
+        skip, st = km._tick_job_check("interrupt-block", r)
+        self.assertFalse(skip, "a row whose transcript cannot be read is evaluated (the fault-boundary tests build such rows)")
+        km._tick_job_done("interrupt-block", r, st)
+        self.assertFalse(km._tick_job_skips("interrupt-block", r), "and stays evaluated every tick until a file exists")
 
     def test_jobs_keep_separate_memos(self):
         d = tempfile.mkdtemp()
@@ -140,8 +154,11 @@ class TickJobsKeyOnAChange(unittest.TestCase):
     def test_the_two_event_keyed_ticks_gate_before_their_parse_and_the_nudge_does_not(self):
         for fn, job in ((km._interrupt_block_tick, "interrupt-block"), (km._clear_done_working_notes, "working-notes")):
             src = inspect.getsource(fn)
-            gate, parse = src.index('_tick_job_skips("%s", s)' % job), src.index("jd.parsed_session(sid, [s[\"path\"]], now)")
+            gate, parse = src.index('_tick_job_check("%s", s)' % job), src.index("jd.parsed_session(sid, [s[\"path\"]], now)")
             self.assertLess(gate, parse, "%s: the gate sits before the parse" % job)
+            self.assertIn('_tick_job_done("%s", s, files_st)' % job, src, "%s: a completed evaluation is marked done" % job)
+        self.assertEqual(inspect.getsource(km._interrupt_block_tick).count('_tick_job_done("interrupt-block", s, files_st)'), 4,
+                         "done on the four landed outcomes (filed, standing, lifted, nothing to lift); never on a refused write or an unproved ledger")
         self.assertNotIn("_tick_job_skips", inspect.getsource(km._auto_nudge_session),
                          "the nudge has wall-clock timers, so it keeps its per-cycle evaluation (documented in _tick_job_skips)")
 
@@ -195,7 +212,8 @@ class JudgesGoNewestFirst(unittest.TestCase):
         src = inspect.getsource(jd._run_index)
         self.assertIn("fleet = by_recency(discover(now))", src)
         self.assertIn("yield_between_sessions()", src)
-        self.assertGreaterEqual(inspect.getsource(jd).count("by_recency(discover(now))"), 5, "every capped pass loop orders by recency")
+        self.assertEqual(inspect.getsource(jd).count("by_recency(discover(now))"), 1,
+                         "the FIRST pass (the index) orders by recency; the courier and the capped passes keep discover()'s order, which their tests pin")
 
 
 if __name__ == "__main__":

--- a/tests/test_boot_parses_served.py
+++ b/tests/test_boot_parses_served.py
@@ -116,6 +116,20 @@ class ServedBootParses(unittest.TestCase):
                            "log": [{"t": t0 + 61, "judge": "interrupt", "verdict": "block", "why": "stopped mid-turn"}]}},
              "placements": {}, "status": {g: "blocked"}}))
         Path(state, "auto-nudge.json").write_text(json.dumps({"enabled": False, "nudged": {}, "intrBlocked": {WEB: g}}))
+        # the previous kernel's tick memo: it had looked at every session with these very files (T323 stage 1's
+        # persisted _TICK_SEEN), so this boot has nothing new to evaluate for any of them
+        def _stat(p):
+            try:
+                st = os.stat(p); return [st.st_mtime, st.st_size]
+            except OSError:
+                return [0.0, 0]
+        memo = {}
+        for sid in ALL:
+            files = _stat(os.path.join(proj, sid + ".jsonl")) + _stat(os.path.join(state, "states", sid + ".jsonl")) \
+                + _stat(os.path.join(state, "goals", sid + ".json"))
+            for job in ("interrupt-block", "working-notes"):
+                memo["%s|%s" % (job, sid)] = files
+        Path(state, "tick-seen.json").write_text(json.dumps(memo))
         Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         # every file predates the boot by construction (written before the kernel starts): "unchanged since boot"
         cls.port, cls.token = _free_port(), "testtok-t323"

--- a/tests/test_boot_parses_served.py
+++ b/tests/test_boot_parses_served.py
@@ -168,7 +168,8 @@ class ServedBootParses(unittest.TestCase):
         self.assertEqual(p["bySid"], {}, "per session: none")
         # the judges' first pass still parses what it enumerates (their checkpoint resume is stages 3 and 4); this
         # stage only orders it newest first; pin the count so a regression to double parsing shows
-        self.assertLessEqual(p["judge"], len(ALL), "the judges parse each session at most once at boot: %r" % p)
+        self.assertLessEqual(p["judge"], 2 * len(ALL), "the judges parse each session about once at boot (a key file moving "
+                                                        "during the boot costs one re-parse): %r" % p)
         feed = self._get("/feed.json")
         cards = [c for c in (feed.get("asks") or []) if isinstance(c, dict)]   # the feed's cards ride `asks`
         web = [c for c in cards if str(c.get("sid") or c.get("fsid") or "").startswith(WEB[:8])]

--- a/tests/test_boot_parses_served.py
+++ b/tests/test_boot_parses_served.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""T323 stage 1, served: a REAL hermetic kernel boots over three synthetic living sessions and parses none of them
+until a client asks. /perf's `parses` (cold kernel parses per session) reads zero after the boot settles with no client;
+the session that was BLOCKED before the boot and does not move afterwards reads blocked in the feed route from the
+store the previous kernel wrote, still with no parse (the manager's case, 2026-09-10); and once a chat client connects,
+the parses that happen are exactly the shown tabs' (playwright drives the real page; skipped where no browser is
+installed, the way the other served guards skip). Synthetic only: invented text, placeholder uuids, TESTHOST."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment
+
+WEB = "aaaaaaaa-1111-2222-3333-444444444444"     # will be blocked in the store before the boot, untouched after
+API = "bbbbbbbb-1111-2222-3333-444444444444"
+TESTS = "cccccccc-1111-2222-3333-444444444444"
+ALL = (WEB, API, TESTS)
+
+
+def _free_port():
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); p = s.getsockname()[1]; s.close(); return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": stop}}
+
+
+def transcript(t0, stopped):
+    recs = [uline(t0, "wire the fixtures directory into the integration suite", "u1"),
+            aline(t0 + 20, "digging in: reading the suite's layout", "a1", "u1", "tool_use")]
+    if stopped:
+        recs.append(uline(t0 + 60, "[Request interrupted by user]", "u2", "a1"))
+    else:
+        recs.append(aline(t0 + 60, "done: the suite reads the fixtures directory now", "a2", "a1"))
+    return recs
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 800 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction(() => document.querySelectorAll(".turn").length >= 1, null, { timeout: 30000 });
+await page.waitForTimeout(1500);
+await browser.close();
+console.log("RESULT:ok");
+"""
+
+
+class ServedBootParses(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lab = tempfile.mkdtemp(prefix="romp-t323s1-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states", "goals"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 3600
+        for sid, name, colour in ((WEB, "web", "#9cd2ff"), (API, "api", "#1EA1EB"), (TESTS, "tests", "#54B204")):
+            Path(state, "names", sid).write_text("%s\t%s\t%s\t#0c1a2e\n" % (name, cwd, colour))
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                 "model": "claude-opus-5", "liveModel": "Opus 5"}))
+            Path(state, "states", sid + ".jsonl").write_text(json.dumps({"t": t0 + 70, "state": "idle"}) + "\n")
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in transcript(t0, stopped=(sid == WEB))))
+        # the previous kernel's verdict on web: its focus goal BLOCKED on the user (a genuine stop), the interrupt
+        # marker pointing at it; nothing about web changes after the boot, so the card must read blocked from here
+        g = WEB + ":gw"
+        Path(state, "goals", WEB + ".json").write_text(json.dumps(
+            {"rompUuid": WEB, "seq": 3, "lastNode": g, "closedTurns": [],
+             "nodes": {g: {"id": g, "text": "wire the fixtures directory into the integration suite", "parentId": None,
+                           "nodeComplete": False, "blocked": True, "cleared": False, "trail": [], "t": t0,
+                           "log": [{"t": t0 + 61, "judge": "interrupt", "verdict": "block", "why": "stopped mid-turn"}]}},
+             "placements": {}, "status": {g: "blocked"}}))
+        Path(state, "auto-nudge.json").write_text(json.dumps({"enabled": False, "nudged": {}, "intrBlocked": {WEB: g}}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        # every file predates the boot by construction (written before the kernel starts): "unchanged since boot"
+        cls.port, cls.token = _free_port(), "testtok-t323"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"),
+                                      stderr=subprocess.STDOUT, env=env)
+        for _ in range(200):   # a bounded wait for the serve loop, half a second at a time
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            cls.kernel.terminate()
+            cls.kernel.wait(timeout=15)
+        except Exception:
+            cls.kernel.kill()
+        shutil.rmtree(cls.lab, ignore_errors=True)
+
+    def _get(self, path):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), headers={"X-Romp-Token": self.token})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read().decode())
+
+    def _parses(self):
+        return self._get("/perf")["parses"]
+
+    def _settled(self):
+        """The boot reconcile and a few pusher cycles have run (a bounded wait on /version's boot marks)."""
+        for _ in range(40):
+            try:
+                v = self._get("/version")
+                if v.get("uptime_s", 0) >= 4:
+                    return
+            except Exception:
+                pass
+            time.sleep(0.5)
+
+    def test_1_a_boot_with_no_client_parses_nothing_and_the_blocked_card_comes_from_the_store(self):
+        self._settled()
+        p = self._parses()
+        self.assertEqual(p["total"], 0, "no client asked, so the kernel parsed no transcript at boot: %r" % p)
+        self.assertEqual(p["bySid"], {}, "per session: none")
+        # the judges' first pass still parses what it enumerates (their checkpoint resume is stages 3 and 4); this
+        # stage only orders it newest first; pin the count so a regression to double parsing shows
+        self.assertLessEqual(p["judge"], len(ALL), "the judges parse each session at most once at boot: %r" % p)
+        feed = self._get("/feed.json")
+        cards = [c for c in (feed.get("asks") or []) if isinstance(c, dict)]   # the feed's cards ride `asks`
+        web = [c for c in cards if str(c.get("sid") or c.get("fsid") or "").startswith(WEB[:8])]
+        self.assertTrue(web, "web's card is in the feed: %r" % [c.get("sid") for c in cards][:10])
+        self.assertTrue(any(c.get("column") == "needs_input" for c in web),
+                        "web reads blocked (needs_input) from the store the previous kernel wrote: %r" % [c.get("column") for c in web])
+        self.assertEqual(self._parses()["total"], 0, "and the feed route parsed nothing to say so (it is cache-only)")
+
+    def test_2_a_chat_client_parses_only_what_it_shows(self):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("no playwright in vscode-extension/node_modules")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        before = self._parses()["total"]
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token)}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, CFG=cfg, EXT_PKG=os.path.join(EXT, "package.json")))
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-2000:] + p.stderr[-2000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        after = self._parses()
+        self.assertGreaterEqual(after["total"] - before, 1, "a connected chat client's own tabs are parsed on demand: %r" % after)
+        self.assertLessEqual(after["total"] - before, len(ALL), "and nothing beyond the shown tabs (every living session is a tab here): %r" % after)
+        self.assertTrue(set(after["bySid"]) <= {s[:8] for s in ALL}, after["bySid"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -8841,13 +8841,15 @@ class SlashCommands(unittest.TestCase):
 
 
 class BootWarm(unittest.TestCase):
-    """_boot_warm pre-parses the living fleet into the kernel parse cache at STARTUP, during the browser's
-    reconnect/reload gap, so the first connect is warm instead of paying the cold serial parse (the user
-    2026-07-03: local sessions take a long time to load on restart)."""
+    """_boot_warm at STARTUP warms the shared discover() listing and parses NOTHING (T323 stage 1, the user
+    2026-09-10: a boot must not read every live transcript for nobody). It used to pre-parse the living fleet
+    for the browser's reconnect gap (the user 2026-07-03); the redial road now ships the active tab whole and
+    every other tab as a skeleton, so the one parse a reconnecting dashboard needs is its own connect push's."""
     def setUp(self):
         self._saved = (km._alive_sessions, km._has_parsing_client, km._parse, km._tmux_sessions, km.jd.discover)
         self.parsed = []
-        km.jd.discover = lambda now: []
+        self.discovered = []
+        km.jd.discover = lambda now: self.discovered.append(now) or []
         km._tmux_sessions = lambda: {}
         km._parse = lambda path, sid, now: self.parsed.append(sid)
 
@@ -8862,12 +8864,13 @@ class BootWarm(unittest.TestCase):
             time.sleep(0.02)
         return pred()
 
-    def test_boot_warm_parses_every_live_session(self):
+    def test_boot_warm_warms_discover_and_parses_no_session(self):
         km._has_parsing_client = lambda: False
         km._alive_sessions = lambda now, tmux: [{"sid": "s1", "path": "/p1"}, {"sid": "s2", "path": "/p2"}]
         km._boot_warm()
-        self.assertTrue(self._wait(lambda: sorted(self.parsed) == ["s1", "s2"]),
-                        "boot-warm parsed every live session into the cache")
+        self.assertTrue(self._wait(lambda: len(self.discovered) == 1), "the shared discover listing is warmed once")
+        time.sleep(0.1)
+        self.assertEqual(self.parsed, [], "no live session is parsed at boot for nobody (T323 stage 1)")
 
     def test_boot_warm_stands_down_for_a_live_parsing_client(self):
         km._has_parsing_client = lambda: True     # the browser already reconnected → its build warms the cache

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -47,7 +47,7 @@ SID = "11111111-2222-3333-4444-555555555555"
 # and node ids collide across test modules under the shared placeholder (CLAUDE.md, goal-store fixtures).
 GOAL_SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
 TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms", "builds", "sends",
-            "goals", "memos", "judge", "http"}
+            "goals", "memos", "judge", "http", "parses"}   # parses: cold event-model parses (T323 stage 1)
 
 
 def _burn_cpu(seconds):


### PR DESCRIPTION
Stage 1 of the lazy-transcripts plan (T323, approved by the user 2026-09-10; the research report is under the research directory as `T323-lazy-transcripts.md`). The user's ruling: they do not want the record cache capped; they want the underlying reason fixed, which is that a boot reads and parses every live session's whole transcript. This stage removes every boot-time parse the kernel runs for nobody, without a format change; the judges' first pass is ordered and yielding here and resumes from a checkpoint in stages 3 and 4.

**What changes**

- The startup warm parses nothing: it warms the shared session listing (`discover()`) only. The redial road already ships the active tab whole and every other tab as a skeleton with a status frame, so the one parse a reconnecting dashboard needs is the one its own connect push runs. No tab strip is persisted in the kernel (tabs are every living session; the active tab is the client's fact, sent after it reconnects), so there is nothing to pre-parse selectively; "shown tabs or none" resolves to none.
- The feed-only warm parses only sessions whose transcript, state log or goal store changed since this kernel booted, or that are working now.
- The judges' index pass and every capped pass loop walk `discover()` newest first (by transcript mtime) and yield the interpreter between sessions.
- The two event-keyed no-client tick jobs (`_interrupt_block_tick`, `_clear_done_working_notes`) skip a session whose transcript, state log and goal store stat tuple is unchanged since the job's last evaluation, with this kernel's boot as the first baseline. The goal store is in the key because a judge can clear or complete a marker's goal with no transcript change, and the interrupt tick must re-block on exactly that (its stale-marker rule; pinned). The nudge keeps its per-cycle walk: its verdicts have wall-clock timers, so it is not event-keyed; the other tick jobs already parse only sids with pending records.
- `/perf` gains `parses`: cold kernel parses in total, in bytes and per session, plus the judges' cold parses.

**Complexity, per the user's scaling criterion**

| Cost | Before | After |
|---|---|---|
| Startup warm, per boot per live session | O(file bytes) | 0 |
| Feed-only warm, per boot | O(all live sessions' bytes) | O(sessions changed since boot) |
| Interrupt-block and working-note ticks, first cycle after boot | O(all live sessions' bytes) | O(sessions changed since boot); later cycles O(sessions with an appended record) |
| Judges' first pass | O(all sessions' bytes), directory order | unchanged in size, newest first with yields (stages 3 and 4 make it O(tail since checkpoint)) |

**Measured** (`scripts/bench_boot_parse.py`, synthetic worlds of six sessions at 1x, 4x and 16x of 150 invented turns each, one hermetic kernel boot per tree with no client, eight seconds of settle, under `capped`): the kernel's own cold parses at boot are 6 (every session, by construction) before and 0 after at every size; bytes read by the process and its resident size are unchanged by this stage (about 60 MB read; 150 to 390 MB resident, tracking transcript size in both trees), because the judges' first pass still parses every session into the shared record cache. That is the honest reading of the figure in the research directory (`T323-stage1-bench/boot_cost_vs_size.png`): stage 1 flattens the kernel's parses; the resident size flattens when stages 3 and 4 give the judges a checkpoint. The live before-and-after is the kernel's `rssKb` on every restart-cuts row (T304) and the T311 read-only recipe, read after this deploys.

**Tests**: `tests/test_boot_parse_gating.py` (the warm parses nothing, the feed warm's gate, the tick gate including the goal-store event, the perf counter, recency ordering); `tests/test_boot_parses_served.py` (a real hermetic kernel over three synthetic sessions, one blocked in the store before the boot and untouched after: zero kernel parses with no client, the blocked card read from the store through the feed route, and only the shown tabs parsed once a chat client connects; the client part runs where Playwright's Chromium exists); the perf shape pin gains the key.

Part of the lazy-transcripts program (T323); stage 2 (one parse shared by kernel and judges) is independent and may land in either order.
