### PR TITLE
A feed card's hover marks its source turns outside the chat's resident tail on the overview ruler's history strip, instead of highlighting nothing

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40068,6 +40068,29 @@ def _cards_for_segments(sid, seg_ids):
     return tops
 
 
+def _glow_groups(sid, uuids):
+    """The chat glow's group for one session (glowTurns): its atom uuids plus, for the pane's overview ruler, each
+    uuid's GLOBAL index in the chat payload (`idx`) and the payload's length (`total`) (T318b, 2026-09-10). The pane
+    holds only the newest WIRE_TAIL events, so a hovered card whose source turns are older has no row to light; with
+    the positions it marks them on the ruler's history strip instead of painting nothing. Read from the pusher's
+    built payload (_built_chat, the same events the pane was sent, in wire order: an event's index there IS the
+    global index the pane maps through headFrom); a session with no built payload gets a group without positions,
+    and no uuids means no group."""
+    if not uuids:
+        return []
+    g = {"sid": sid, "uuids": uuids}
+    hit = _built_chat.get(sid)
+    evs = (hit[1].get("events") if hit is not None and isinstance(hit[1], dict) else None) or []
+    if evs:
+        want, idx = set(uuids), {}
+        for i, e in enumerate(evs):
+            u = e.get("uuid") if isinstance(e, dict) else None
+            if u in want and u not in idx:
+                idx[u] = i                      # a multi-block atom's FIRST event is where its row sits
+        g["idx"], g["total"] = idx, len(evs)
+    return [g]
+
+
 def _segment_atom_uuids(sid, seg_ids, now):
     """The chat .turn[data-uuid]s inside the given segments — for the timeline->chat glow, so a bar hover
     lights EXACTLY that segment's chat rows BY ID instead of a +/-2s time window (the user 2026-06-19). Each
@@ -54589,7 +54612,7 @@ class Handler(BaseHTTPRequestHandler):
             _send_to_app("timeline", {"type": "hover", "ids": seg_ids, "nonce": _next_nonce()})
             gsid = item_id.rsplit(":", 1)[0] if (item_id and not msg.get("off")) else ""
             uuids = _segment_atom_uuids(gsid, seg_ids, time.time()) if gsid else []
-            groups = [{"sid": gsid, "uuids": uuids}] if uuids else []
+            groups = _glow_groups(gsid, uuids)   # with each uuid's global index, for turns outside the pane's tail (T318b)
             _send_to_app("chat", {"type": "glowTurns", "groups": groups, "mids": []})
         elif msg and msg.get("type") == "dotOpen":
             # chat rail CLICK → NAVIGATE the other two panes (the user 2026-07-23): the timeline pans to
@@ -54621,7 +54644,7 @@ class Handler(BaseHTTPRequestHandler):
                 _send_to_app("feed", {"type": "hoverCards",
                                       "keys": _cards_for_segments(hsid, [seg_id]) if seg_id else [],
                                       "eid": None})
-                groups = [{"sid": hsid, "uuids": seg_uuids}] if seg_uuids else []
+                groups = _glow_groups(hsid, seg_uuids)
                 _send_to_app("chat", {"type": "glowTurns", "groups": groups, "mids": []})
         elif msg and msg.get("type") == "timelineHover":
             # the REVERSE of the feed/chat→timeline hovers: a timeline bar hover lights the feed
@@ -54637,7 +54660,7 @@ class Handler(BaseHTTPRequestHandler):
                 _send_to_app("feed", {"type": "hoverCards",
                                       "keys": _cards_for_segments(hsid, seg_ids), "eid": None})
                 uuids = _segment_atom_uuids(hsid, seg_ids, time.time())
-                groups = [{"sid": hsid, "uuids": uuids}] if uuids else []
+                groups = _glow_groups(hsid, uuids)
                 _send_to_app("chat", {"type": "glowTurns", "groups": groups, "mids": []})
         # ---- pasted-image hydration + dropped-file handling (ported from the old TS kernel) ----
         elif msg and msg.get("type") == "imgRequest" and msg.get("path"):

--- a/tests/test_glow_history_positions.py
+++ b/tests/test_glow_history_positions.py
@@ -1,0 +1,55 @@
+"""A feed card's hover lights its source turns in the chat (glowTurns), but a turn outside the chat's resident
+tail has no row to light: the chat ships only the newest WIRE_TAIL events and streams older history in on
+demand. So the glow's group also carries each uuid's GLOBAL index in the chat payload and the payload's length
+(T318b, 2026-09-10), and the pane marks the unloaded ones on its overview ruler's history strip. Pinned here:
+the group builder reads the pusher's built payload, and every glow site in the socket handler goes through it.
+SYNTHETIC fixtures only: a private synthetic sid, placeholder uuids."""
+import inspect
+import os
+import unittest
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+km = load_source("romp_kernel_glow_hist", os.path.join(BIN, "romp-kernel"))
+
+SID = "f318b001-1111-4222-8333-000000000001"
+
+
+class GlowGroupsCarryPositions(unittest.TestCase):
+    def setUp(self):
+        self.saved = km._built_chat.pop(SID, None)
+
+    def tearDown(self):
+        km._built_chat.pop(SID, None)
+        if self.saved is not None:
+            km._built_chat[SID] = self.saved
+
+    def test_a_group_carries_each_uuid_s_global_index_and_the_payload_length(self):
+        evs = [{"uuid": "u%d" % i} for i in range(400)]
+        evs[7] = {"uuid": "u6"}          # a multi-block atom: two events share one uuid; the FIRST is the row's position
+        km._built_chat[SID] = ("sig", {"events": evs}, "", None)
+        groups = km._glow_groups(SID, ["u6", "u380", "zz"])
+        self.assertEqual(len(groups), 1)
+        g = groups[0]
+        self.assertEqual((g["sid"], g["uuids"]), (SID, ["u6", "u380", "zz"]))
+        self.assertEqual(g["idx"], {"u6": 6, "u380": 380}, "an unknown uuid has no position; a repeated one keeps its first")
+        self.assertEqual(g["total"], 400)
+
+    def test_no_built_payload_means_a_group_without_positions(self):
+        self.assertEqual(km._glow_groups(SID, ["u1"]), [{"sid": SID, "uuids": ["u1"]}])
+
+    def test_no_uuids_means_no_group(self):
+        self.assertEqual(km._glow_groups(SID, []), [])
+
+    def test_every_glow_site_in_the_socket_handler_builds_its_groups_here(self):
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        self.assertEqual(src.count("_glow_groups("), 3, "the feed-card hover, the chat-dot hover and the timeline-bar hover")
+        self.assertNotIn('{"sid": gsid, "uuids": uuids}', src)
+        self.assertNotIn('{"sid": hsid, "uuids": uuids}', src)
+        self.assertNotIn('{"sid": hsid, "uuids": seg_uuids}', src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_glow_history_positions.py
+++ b/tests/test_glow_history_positions.py
@@ -6,9 +6,15 @@ the group builder reads the pusher's built payload, and every glow site in the s
 SYNTHETIC fixtures only: a private synthetic sid, placeholder uuids."""
 import inspect
 import os
+import tempfile
 import unittest
 
-from romp_load import load_source
+# the state root is hermetic BEFORE any romp code loads (tests/test_state_isolation_order.py): under a bare unittest
+# or script run the kernel would otherwise operate on the real state directory
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+
+from romp_load import load_source   # noqa: E402
 
 HERE = os.path.dirname(os.path.realpath(__file__))
 BIN = os.path.join(os.path.dirname(HERE), "bin")

--- a/tests/test_ledger_anchors.py
+++ b/tests/test_ledger_anchors.py
@@ -196,8 +196,9 @@ class ChatAndFeedHoverRouting(unittest.TestCase):
         self.assertIn('_send_to_app("feed", {"type": "hoverCards"', self.SRC)
 
     def test_chat_dot_hover_glows_its_whole_segment(self):
-        # #3: the same branch glows EVERY atom uuid in the hovered segment (the sibling dots), by id
-        self.assertIn('"sid": hsid, "uuids": seg_uuids', self.SRC)
+        # #3: the same branch glows EVERY atom uuid in the hovered segment (the sibling dots), by id; the group is
+        # built by _glow_groups, which adds each uuid's global index for the ruler's history strip (T318b)
+        self.assertIn("_glow_groups(hsid, seg_uuids)", self.SRC)
 
     def test_ledger_bullet_hover_stays_timeline_only(self):
         # the feed/chat extension is gated to dotHover; a ledgerHover (TOC bullet) must not stomp the glow

--- a/ui/webview/glow-history.test.ts
+++ b/ui/webview/glow-history.test.ts
@@ -7,7 +7,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { historyMarks, historyBands, HIST_H, HIST_GAP, HIST_MIN_H } from "./glow-history";
+import { historyMarks, historyBands, windowSpans, HIST_H, HIST_GAP, HIST_MIN_H } from "./glow-history";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
@@ -25,7 +25,7 @@ test("a resident turn is the ruler proper's, never the strip's; a lit row and an
   const idx = { u100: 100, u450: 450, u500: 500 };
   const lit = new Set(["u500"]);                    // its row is on the page and already glows
   assert.deepEqual(historyMarks(["u100", "u450", "u500", "u999"], idx, lit, 400), [0.25],
-    "u450 is resident (at or past headFrom) even without a lit row: folded or off the active path, not unloaded");
+    "u450 is resident (at or past headFrom) even without a lit row: the ruler proper's business (windowSpans), never the strip's");
   assert.deepEqual(historyMarks(["u100"], idx, lit, 0), [], "headFrom 0: the whole transcript is resident, no strip");
   assert.deepEqual(historyMarks(["u100"], undefined, lit, 400), [], "a group without positions (no built payload) marks nothing");
 });
@@ -41,17 +41,38 @@ test("marks are sorted, touching marks coalesce into one band, and the last mark
   assert.deepEqual(historyBands([], HIST_H), []);
 });
 
+test("a hover on a turn that is RESIDENT but outside the render window lands on the ruler proper by its spacer slice, not the strip", () => {
+  // a fresh tab of a long session: 250 resident events [400, 650), the last 80 units rendered, units [0, 170) folded
+  // into one top spacer of 170 × 60 px; the card's source turn is unit 85 (global 485): no row, and not history
+  const lit = new Set<string>();
+  assert.deepEqual(historyMarks(["u485"], { u485: 485 }, lit, 400), [], "resident: nothing on the strip");
+  const w = { winStart: 170, winEnd: 250, unitTotal: 250, topY: 0, topH: 170 * 60, botY: 0, botH: 0, avg: 60 };
+  assert.deepEqual(windowSpans([85], w), [{ top: 85 * 60, bot: 86 * 60 }], "halfway down the top spacer, one row tall");
+  assert.deepEqual(windowSpans([200], w), [], "inside the window: its row is lit by applyGlow, or folded and placeless");
+  assert.equal(lit.size, 0, "no row lit: none is on the page");
+  // a window rendered around a deep link, with a bottom spacer of 30 units below it starting at content y 9000
+  const w2 = { winStart: 100, winEnd: 220, unitTotal: 250, topY: 0, topH: 6000, botY: 9000, botH: 1800, avg: 60 };
+  assert.deepEqual(windowSpans([235], w2), [{ top: 9000 + 15 * 60, bot: 9000 + 16 * 60 }], "the bottom spacer's slice for a newer unit");
+  assert.deepEqual(windowSpans([50, 235], w2).map((s) => s.top), [3000, 9900]);
+  // the hover's units are looked up by uuid in the resident events and placed at paint time from the live spacers
+  assert.match(RENDER, /function residentUnits\(s: Session, uuids: string\[\]\): number\[\]/);
+  assert.match(RENDER, /const idx = s\.events\.findIndex\(\(e\) => e\.uuid === uuid\);\s*if \(idx < 0\) continue;/);
+  assert.match(RENDER, /glowUnits = s \? residentUnits\(s, \(g\.uuids \|\| \[\]\)\.filter\(\(u\) => !lit\.has\(u\)\)\) : \[\];/);
+  assert.match(RENDER, /segs\.push\(\.\.\.windowSpans\(units, \{ winStart: v\.winStart \?\? 0, winEnd: v\.winEnd \?\? \(v\.unitTotal \?\? 0\), unitTotal: v\.unitTotal \?\? 0,/);
+  assert.match(RENDER, /topY: yOf\(topSp\), topH: topSp \? topSp\.offsetHeight : 0, botY: yOf\(botSp\), botH: botSp \? botSp\.offsetHeight : 0,/);
+});
+
 test("applyGlow records which uuids lit a row and hands the rest to the strip, for the active view only", () => {
   // the lit set is filled inside the ONE query that adds .ext-glow, so a uuid with no rendered row can never glow
   assert.match(RENDER, /const lit = new Set<string>\(\);\s*v\.el\.querySelectorAll<HTMLElement>\("\.turn\[data-uuid\]"\)\.forEach\(\(n\) => \{\s*const u = n\.dataset\.uuid \|\| "";\s*if \(uset\.has\(u\)\) \{ n\.classList\.add\("ext-glow"\); lit\.add\(u\); \}/);
-  assert.match(RENDER, /if \(g\.sid === activeId\) glowHistory = historyMarks\(g\.uuids \|\| \[\], g\.idx, lit, liveSession\(g\.sid\)\?\.headFrom \?\? 0\);/);
-  assert.match(RENDER, /glowHistory = \[\];\s*const midSet = new Set\(mids\);/, "a fresh hover (or a clear) starts with no history marks");
-  assert.match(RENDER, /import \{ historyMarks, historyBands, HIST_H, HIST_GAP \} from "\.\/glow-history";/);
+  assert.match(RENDER, /if \(g\.sid === activeId\) \{\s*const s = liveSession\(g\.sid\);\s*glowHistory = historyMarks\(g\.uuids \|\| \[\], g\.idx, lit, s\?\.headFrom \?\? 0\);/);
+  assert.match(RENDER, /glowHistory = \[\]; glowUnits = \[\];\s*const midSet = new Set\(mids\);/, "a fresh hover (or a clear) starts with no history marks and no spacer units");
+  assert.match(RENDER, /import \{ historyMarks, historyBands, windowSpans, HIST_H, HIST_GAP \} from "\.\/glow-history";/);
 });
 
 test("the ruler shows for history marks alone, caps its top with the strip, and maps the resident scroll below it", () => {
-  assert.match(RENDER, /const hist = \(content && v\) \? glowHistory : \[\];/);
-  assert.match(RENDER, /if \(!content \|\| \(!glows\.length && !hist\.length\)\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
+  assert.match(RENDER, /const hist = \(content && v\) \? glowHistory : \[\];\s*const units = \(content && v\) \? glowUnits : \[\];/);
+  assert.match(RENDER, /if \(!content \|\| !v \|\| \(!glows\.length && !hist\.length && !units\.length\)\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
   assert.match(RENDER, /const capH = hist\.length \? HIST_H \+ HIST_GAP : 0;/);
   assert.match(RENDER, /const mapH = Math\.max\(1, rulerH - capH\);/);
   assert.match(RENDER, /band\.style\.top = \(capH \+ b\.top \/ scrollH \* mapH\) \+ "px";/);

--- a/ui/webview/glow-history.test.ts
+++ b/ui/webview/glow-history.test.ts
@@ -1,0 +1,71 @@
+// The ruler's history strip (T318b, the user 2026-09-10): a hovered feed card whose source turns sit outside the
+// chat's resident tail used to light nothing (applyGlow paints rendered rows only, and the ruler maps the resident
+// scroll height). Now the glow group carries each uuid's global event index and the pane marks the unloaded turns
+// in a strip at the top of the ruler. The pure half executes for real here; the DOM half is pinned to source, as
+// the other webview tests do (render.ts has import-time DOM side effects).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { historyMarks, historyBands, HIST_H, HIST_GAP, HIST_MIN_H } from "./glow-history";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+
+test("a hover on turns outside the resident tail marks them on the strip by global index, and lights no row", () => {
+  // the chat holds [400, 650) of 650 events; the card's source turns are events 100, 101 and 380 — none resident
+  const idx = { u100: 100, u101: 101, u380: 380 };
+  const lit = new Set<string>();                   // applyGlow found no .turn for any of them
+  const marks = historyMarks(["u100", "u101", "u380"], idx, lit, 400);
+  assert.deepEqual(marks, [0.25, 0.2525, 0.95]);
+  assert.equal(lit.size, 0, "nothing lit: the rows are not on the page to light");
+});
+
+test("a resident turn is the ruler proper's, never the strip's; a lit row and an unknown uuid stay off it too", () => {
+  const idx = { u100: 100, u450: 450, u500: 500 };
+  const lit = new Set(["u500"]);                    // its row is on the page and already glows
+  assert.deepEqual(historyMarks(["u100", "u450", "u500", "u999"], idx, lit, 400), [0.25],
+    "u450 is resident (at or past headFrom) even without a lit row: folded or off the active path, not unloaded");
+  assert.deepEqual(historyMarks(["u100"], idx, lit, 0), [], "headFrom 0: the whole transcript is resident, no strip");
+  assert.deepEqual(historyMarks(["u100"], undefined, lit, 400), [], "a group without positions (no built payload) marks nothing");
+});
+
+test("marks are sorted, touching marks coalesce into one band, and the last mark stays inside the strip", () => {
+  assert.deepEqual(historyMarks(["b", "a"], { a: 10, b: 200 }, new Set(), 400), [0.025, 0.5]);
+  const bands = historyBands([0.25, 0.2525, 0.95], HIST_H);
+  assert.equal(bands.length, 2, "the two adjacent turns are one band, the far one another");
+  assert.equal(bands[0].top, 0.25 * HIST_H);
+  assert.ok(bands[0].height >= HIST_MIN_H && bands[0].height < 2 * HIST_MIN_H);
+  assert.equal(bands[1].top, Math.min(0.95 * HIST_H, HIST_H - HIST_MIN_H), "clamped so the band ends inside the strip");
+  assert.deepEqual(historyBands([1], HIST_H), [{ top: HIST_H - HIST_MIN_H, height: HIST_MIN_H }]);
+  assert.deepEqual(historyBands([], HIST_H), []);
+});
+
+test("applyGlow records which uuids lit a row and hands the rest to the strip, for the active view only", () => {
+  // the lit set is filled inside the ONE query that adds .ext-glow, so a uuid with no rendered row can never glow
+  assert.match(RENDER, /const lit = new Set<string>\(\);\s*v\.el\.querySelectorAll<HTMLElement>\("\.turn\[data-uuid\]"\)\.forEach\(\(n\) => \{\s*const u = n\.dataset\.uuid \|\| "";\s*if \(uset\.has\(u\)\) \{ n\.classList\.add\("ext-glow"\); lit\.add\(u\); \}/);
+  assert.match(RENDER, /if \(g\.sid === activeId\) glowHistory = historyMarks\(g\.uuids \|\| \[\], g\.idx, lit, liveSession\(g\.sid\)\?\.headFrom \?\? 0\);/);
+  assert.match(RENDER, /glowHistory = \[\];\s*const midSet = new Set\(mids\);/, "a fresh hover (or a clear) starts with no history marks");
+  assert.match(RENDER, /import \{ historyMarks, historyBands, HIST_H, HIST_GAP \} from "\.\/glow-history";/);
+});
+
+test("the ruler shows for history marks alone, caps its top with the strip, and maps the resident scroll below it", () => {
+  assert.match(RENDER, /const hist = \(content && v\) \? glowHistory : \[\];/);
+  assert.match(RENDER, /if \(!content \|\| \(!glows\.length && !hist\.length\)\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
+  assert.match(RENDER, /const capH = hist\.length \? HIST_H \+ HIST_GAP : 0;/);
+  assert.match(RENDER, /const mapH = Math\.max\(1, rulerH - capH\);/);
+  assert.match(RENDER, /band\.style\.top = \(capH \+ b\.top \/ scrollH \* mapH\) \+ "px";/);
+  assert.match(RENDER, /const strip = el\("div", "glow-ruler-hist"\);[\s\S]*?for \(const hb of historyBands\(hist, HIST_H\)\) \{[\s\S]*?band\.classList\.add\("hist"\);[\s\S]*?strip\.appendChild\(band\);[\s\S]*?ruler\.appendChild\(strip\);/);
+  assert.equal(HIST_GAP, 2);
+});
+
+test("the strip wears the same ink as the bands, with a hairline under it, and stays a pure indicator", () => {
+  assert.match(CSS, /\.glow-ruler-hist \{[^}]*position: absolute;[^}]*top: 0;[^}]*border-bottom: 1px solid color-mix\(in srgb, var\(--active-accent, #fff\) 35%, transparent\)/);
+  assert.match(CSS, /\.glow-ruler-band\.hist \{[^}]*border-radius: 2px/);
+  assert.match(CSS, /\.glow-ruler \{[^}]*pointer-events: none/, "the strip inherits it: no click is swallowed over the scrollbar");
+});
+
+test("a click on the card still lands on an unloaded turn: the reveal fetches older chunks until the uuid is resident", () => {
+  assert.match(RENDER, /if \(fetchOlderForAnchor\(activeId, uuid\) \|\| loadingOlder\.has\(activeId\)\) \{/);
+  assert.match(RENDER, /pendingAnchor = uuid; anchorPendingOlder = true; landTrail\.push\("pointer-fetch-older"\); return false;/);
+});

--- a/ui/webview/glow-history.ts
+++ b/ui/webview/glow-history.ts
@@ -11,8 +11,9 @@ export const HIST_GAP = 2;     // px: the hairline between the strip and the res
 export const HIST_MIN_H = 3;   // px: a mark's minimum height, so one turn still reads
 
 /** Fractions in [0, 1) of the unloaded prefix for the hovered uuids with NO lit row and a known global index
- *  before the resident head. A lit row is banded by the ruler proper; a uuid at or past headFrom is resident (its
- *  row is folded or off the active path, not unloaded) and stays off the strip; an unknown uuid has no place. */
+ *  before the resident head. A lit row is banded by the ruler proper; a uuid at or past headFrom is resident and
+ *  stays off the strip (outside the render window it is placed on the ruler proper by windowSpans; inside it
+ *  without a row it is folded or off the active path and has no place); an unknown uuid has no place. */
 export function historyMarks(uuids: readonly string[], idx: Readonly<Record<string, number>> | undefined,
                              lit: { has(u: string): boolean }, headFrom: number): number[] {
   if (!(headFrom > 0) || !idx) return [];
@@ -37,4 +38,31 @@ export function historyBands(marks: readonly number[], stripH: number): Array<{ 
     else bands.push({ top, height: HIST_MIN_H });
   }
   return bands;
+}
+
+/** The render window's geometry, read off the active view when the ruler paints (render.ts sizeSpacers): the hidden
+ *  head [0, winStart) is one top spacer of topH px starting at content-space topY; the hidden tail [winEnd, unitTotal)
+ *  one bottom spacer of botH px at botY; avg is the measured row height the spacers were sized by. */
+export interface WindowGeometry { winStart: number; winEnd: number; unitTotal: number; topY: number; topH: number; botY: number; botH: number; avg: number }
+
+/** Content-space spans for hovered turns that are RESIDENT but outside the render window (review find on the first
+ *  cut: a fresh tab of a long session holds 250 events and renders the last 80 units, so a source turn 81 to 250 back
+ *  had no row and was not history either, and the hover lit nothing). Such a turn sits inside a spacer, which is its
+ *  place in the scroll, sized by unit count; its span is the spacer's slice for its unit, and the ruler proper bands
+ *  it exactly as it would a rendered row. A unit inside the window has no span here: its row exists (lit by
+ *  applyGlow) or is folded away, and neither is a spacer's. */
+export function windowSpans(units: readonly number[], w: WindowGeometry): Array<{ top: number; bot: number }> {
+  const out: Array<{ top: number; bot: number }> = [];
+  for (const u of units) {
+    if (u < w.winStart && w.winStart > 0 && w.topH > 0) {
+      const slot = w.topH / w.winStart;
+      const top = w.topY + u * slot;
+      out.push({ top, bot: top + Math.min(slot, w.avg) });
+    } else if (u >= w.winEnd && w.unitTotal > w.winEnd && w.botH > 0) {
+      const slot = w.botH / (w.unitTotal - w.winEnd);
+      const top = w.botY + (u - w.winEnd) * slot;
+      out.push({ top, bot: top + Math.min(slot, w.avg) });
+    }
+  }
+  return out;
 }

--- a/ui/webview/glow-history.ts
+++ b/ui/webview/glow-history.ts
@@ -1,0 +1,40 @@
+// The overview ruler's HISTORY STRIP (T318b, the user 2026-09-10): a hovered feed card's source turns can sit
+// OUTSIDE the chat's resident tail (the kernel ships only the newest WIRE_TAIL events and streams older history
+// in on scroll-back or a deep link), so applyGlow finds no .turn to light and the ruler, which maps the RESIDENT
+// scroll height, has nowhere to band them. The glow's group therefore carries each uuid's GLOBAL event index
+// (`idx`, read from the kernel's built chat payload) and the pane marks the unloaded ones in a short strip at the
+// top of the ruler, positioned by index over the unloaded prefix [0, headFrom). A click on the card still lands
+// there by the existing road (scrollToAnchor fetches older chunks until the uuid is resident). This module is the
+// DOM-free half, so it runs for real under node; render.ts has import-time DOM side effects.
+export const HIST_H = 14;      // px: the strip's height at the top of the ruler
+export const HIST_GAP = 2;     // px: the hairline between the strip and the resident scroll map
+export const HIST_MIN_H = 3;   // px: a mark's minimum height, so one turn still reads
+
+/** Fractions in [0, 1) of the unloaded prefix for the hovered uuids with NO lit row and a known global index
+ *  before the resident head. A lit row is banded by the ruler proper; a uuid at or past headFrom is resident (its
+ *  row is folded or off the active path, not unloaded) and stays off the strip; an unknown uuid has no place. */
+export function historyMarks(uuids: readonly string[], idx: Readonly<Record<string, number>> | undefined,
+                             lit: { has(u: string): boolean }, headFrom: number): number[] {
+  if (!(headFrom > 0) || !idx) return [];
+  const out: number[] = [];
+  for (const u of uuids) {
+    if (lit.has(u)) continue;
+    const i = idx[u];
+    if (typeof i !== "number" || !(i >= 0) || i >= headFrom) continue;
+    out.push(i / headFrom);
+  }
+  return out.sort((a, b) => a - b);
+}
+
+/** Marks → bands inside a strip `stripH` px tall: each mark is HIST_MIN_H tall, marks that touch coalesce (a
+ *  segment's run of turns is one band, as on the ruler proper), and a mark at the very end stays inside. */
+export function historyBands(marks: readonly number[], stripH: number): Array<{ top: number; height: number }> {
+  const bands: Array<{ top: number; height: number }> = [];
+  for (const f of marks) {
+    const top = Math.min(Math.max(0, f) * stripH, Math.max(0, stripH - HIST_MIN_H));
+    const last = bands[bands.length - 1];
+    if (last && top <= last.top + last.height + 1) last.height = Math.max(last.height, top + HIST_MIN_H - last.top);
+    else bands.push({ top, height: HIST_MIN_H });
+  }
+  return bands;
+}

--- a/ui/webview/glow-ruler.test.ts
+++ b/ui/webview/glow-ruler.test.ts
@@ -25,7 +25,8 @@ test("the ruler observes ONLY the active view's .ext-glow turns and hides when t
   // other views are display:none (zero rects), so only the active view's glows map onto its #content scroll
   assert.match(RENDER, /const v = activeId \? views\.get\(activeId\) : null;/);
   assert.match(RENDER, /v\.el\.querySelectorAll<HTMLElement>\("\.turn\.ext-glow"\)/);
-  assert.match(RENDER, /if \(!content \|\| !glows\.length\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
+  // …or history marks (T318b): a hover on turns outside the resident tail shows the strip with no glowing row
+  assert.match(RENDER, /if \(!content \|\| \(!glows\.length && !hist\.length\)\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
 });
 
 test("bands are CONTENT-space (scroll-independent), mapped to ruler space by scrollHeight", () => {
@@ -34,8 +35,10 @@ test("bands are CONTENT-space (scroll-independent), mapped to ruler space by scr
   assert.match(RENDER, /const top = turn\.getBoundingClientRect\(\)\.top - rect\.top \+ content\.scrollTop;/);
   assert.match(RENDER, /const rulerH = content\.clientHeight;/);
   assert.match(RENDER, /const scrollH = content\.scrollHeight \|\| 1;/);
-  assert.match(RENDER, /band\.style\.top = \(b\.top \/ scrollH \* rulerH\) \+ "px";/);
-  assert.match(RENDER, /band\.style\.height = Math\.max\(3, \(b\.bot - b\.top\) \/ scrollH \* rulerH\) \+ "px";/);
+  // the resident map sits under the history cap (0 px when nothing unloaded is hovered, T318b): capH + span / scrollH * mapH
+  assert.match(RENDER, /band\.style\.top = \(capH \+ b\.top \/ scrollH \* mapH\) \+ "px";/);
+  assert.match(RENDER, /band\.style\.height = Math\.max\(3, \(b\.bot - b\.top\) \/ scrollH \* mapH\) \+ "px";/);
+  assert.match(RENDER, /const mapH = Math\.max\(1, rulerH - capH\);/);
 });
 
 test("contiguous glowing turns coalesce into ONE band; gaps make separate bands (link_audit spec)", () => {

--- a/ui/webview/glow-ruler.test.ts
+++ b/ui/webview/glow-ruler.test.ts
@@ -25,8 +25,9 @@ test("the ruler observes ONLY the active view's .ext-glow turns and hides when t
   // other views are display:none (zero rects), so only the active view's glows map onto its #content scroll
   assert.match(RENDER, /const v = activeId \? views\.get\(activeId\) : null;/);
   assert.match(RENDER, /v\.el\.querySelectorAll<HTMLElement>\("\.turn\.ext-glow"\)/);
-  // …or history marks (T318b): a hover on turns outside the resident tail shows the strip with no glowing row
-  assert.match(RENDER, /if \(!content \|\| \(!glows\.length && !hist\.length\)\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
+  // …or history marks or spacer units (T318b): a hover on turns outside the resident tail shows the strip, one on
+  // turns outside the render window bands their spacer slice, each with no glowing row
+  assert.match(RENDER, /if \(!content \|\| !v \|\| \(!glows\.length && !hist\.length && !units\.length\)\) \{ ruler\.style\.display = "none"; ruler\.replaceChildren\(\); return; \}/);
 });
 
 test("bands are CONTENT-space (scroll-independent), mapped to ruler space by scrollHeight", () => {

--- a/ui/webview/render-scroll.test.ts
+++ b/ui/webview/render-scroll.test.ts
@@ -173,8 +173,9 @@ test("a deep-link to an anchor OLDER than the resident tail fetches older histor
 test("timeline→chat glow matches turns BY UUID, not a ±2s time window (the user 2026-06-19)", () => {
   // applyGlow lights .turn[data-uuid] against the segment's atom uuids the kernel sends (kernel
   // _segment_atom_uuids); the old data-t range match was a flaky time heuristic and is gone.
-  assert.match(RENDER, /function applyGlow\(groups: Array<\{ sid: string; uuids: string\[\] \}>/);
-  assert.match(RENDER, /uset\.has\(n\.dataset\.uuid \|\| ""\)/, "glow matches by uuid set");
+  // (the group also carries idx/total since T318b, for the ruler's history strip; the uuid match is unchanged)
+  assert.match(RENDER, /function applyGlow\(groups: Array<\{ sid: string; uuids: string\[\]; idx\?: Record<string, number>; total\?: number \}>/);
+  assert.match(RENDER, /const u = n\.dataset\.uuid \|\| "";\s*if \(uset\.has\(u\)\)/, "glow matches by uuid set");
   assert.doesNotMatch(RENDER, /t >= s - 2 && t <= e \+ 2/, "the old ±2s data-t window match is gone");
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -34,7 +34,7 @@ import { flash } from "./actions";   // its own line: the import above is pinned
 import { awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
-import { historyMarks, historyBands, HIST_H, HIST_GAP } from "./glow-history";
+import { historyMarks, historyBands, windowSpans, HIST_H, HIST_GAP } from "./glow-history";
 import { newSkeletonState, applyTabOrderSkeleton, onStatus, onFull, onDismiss, onSocketUp, nextPrefetch, renderKind } from "./skeleton-tabs";
 import { reconcileTabOrder, adoptArrival } from "./tab-order";
 import { writeViewOrder } from "./view-order";
@@ -2406,9 +2406,26 @@ function railLastDotFrom(turn: HTMLElement, hostR: DOMRect): number | null {
 // payload) so a source turn OUTSIDE the resident tail, which has no row here to light, is marked on the ruler's
 // history strip by its position in the unloaded prefix [0, headFrom) instead of painting nothing (glow-history.ts).
 let glowHistory: number[] = [];   // the active view's unloaded glow turns, as fractions of its unloaded prefix
+let glowUnits: number[] = [];     // …and its RESIDENT glow turns with no rendered row, as display units (a spacer's)
+// The display units of hovered uuids that are RESIDENT (in s.events) but have no rendered row: outside the render
+// window they sit inside a spacer, and paintGlowRuler places them by windowSpans; inside the window without a row
+// (folded, off the active path) they have no place and paintGlowRuler drops them. Same lookup as scrollToAnchor's.
+function residentUnits(s: Session, uuids: string[]): number[] {
+  if (!uuids.length) return [];
+  const items = displayItems(s);
+  const out: number[] = [];
+  for (const uuid of uuids) {
+    const idx = s.events.findIndex((e) => e.uuid === uuid);
+    if (idx < 0) continue;
+    let u = items.findIndex((it) => it.kind === "toolgroup" || it.kind === "noticegroup" ? it.indices.includes(idx) : it.index === idx);
+    if (u < 0) u = items.findIndex((it) => itemFirstEvent(it) >= idx);
+    if (u >= 0) out.push(u);
+  }
+  return out;
+}
 function applyGlow(groups: Array<{ sid: string; uuids: string[]; idx?: Record<string, number>; total?: number }>, mids: string[]) {
   document.querySelectorAll(".ext-glow").forEach((n) => n.classList.remove("ext-glow"));
-  glowHistory = [];
+  glowHistory = []; glowUnits = [];
   const midSet = new Set(mids);
   if (midSet.size) {
     document.querySelectorAll<HTMLElement>(".turn[data-mid]").forEach((n) => {
@@ -2425,9 +2442,14 @@ function applyGlow(groups: Array<{ sid: string; uuids: string[]; idx?: Record<st
       const u = n.dataset.uuid || "";
       if (uset.has(u)) { n.classList.add("ext-glow"); lit.add(u); }   // every row of a matched atom lights
     });
-    // the rest sit outside the resident tail: mark them on the ruler's history strip (the active view's only,
-    // whose #content the ruler mirrors; other views are display:none)
-    if (g.sid === activeId) glowHistory = historyMarks(g.uuids || [], g.idx, lit, liveSession(g.sid)?.headFrom ?? 0);
+    // the rest have no row: outside the resident tail they go on the ruler's history strip, resident but outside
+    // the render window on the ruler proper at their spacer's slice (the active view's only, whose #content the
+    // ruler mirrors; other views are display:none)
+    if (g.sid === activeId) {
+      const s = liveSession(g.sid);
+      glowHistory = historyMarks(g.uuids || [], g.idx, lit, s?.headFrom ?? 0);
+      glowUnits = s ? residentUnits(s, (g.uuids || []).filter((u) => !lit.has(u))) : [];
+    }
   }
   paintGlowRuler();   // mirror the glow as bands on the overview ruler (link_audit's #4)
   paintRailBand();    // one continuous measured band over the rail line (the user 2026-07-02)
@@ -2562,7 +2584,8 @@ function paintGlowRuler(): void {
   // only the ACTIVE view's glows map onto its #content scroll (other views are display:none → zero rects)
   const glows = (content && v) ? Array.from(v.el.querySelectorAll<HTMLElement>(".turn.ext-glow")) : [];
   const hist = (content && v) ? glowHistory : [];
-  if (!content || (!glows.length && !hist.length)) { ruler.style.display = "none"; ruler.replaceChildren(); return; }
+  const units = (content && v) ? glowUnits : [];
+  if (!content || !v || (!glows.length && !hist.length && !units.length)) { ruler.style.display = "none"; ruler.replaceChildren(); return; }
   const rect = content.getBoundingClientRect();
   const scrollH = content.scrollHeight || 1;
   const rulerH = content.clientHeight;          // the strip spans #content's VISIBLE height
@@ -2572,7 +2595,18 @@ function paintGlowRuler(): void {
   const segs = glows.map((turn) => {
     const top = turn.getBoundingClientRect().top - rect.top + content.scrollTop;
     return { top, bot: top + turn.offsetHeight };
-  }).sort((a, b) => a.top - b.top);
+  });
+  // T318b: a hovered turn that is resident but outside the render window sits inside a spacer; its span is the
+  // spacer's slice for its unit, so the ruler bands it like a row it cannot see (windowSpans; the geometry is read
+  // here, at paint time, so a window that moved since the hover is placed as it stands now)
+  if (units.length) {
+    const yOf = (e: HTMLElement | null) => e ? e.getBoundingClientRect().top - rect.top + content.scrollTop : 0;
+    const topSp = v.el.querySelector<HTMLElement>(".tx-spacer-top"), botSp = v.el.querySelector<HTMLElement>(".tx-spacer-bot");
+    segs.push(...windowSpans(units, { winStart: v.winStart ?? 0, winEnd: v.winEnd ?? (v.unitTotal ?? 0), unitTotal: v.unitTotal ?? 0,
+                                      topY: yOf(topSp), topH: topSp ? topSp.offsetHeight : 0, botY: yOf(botSp), botH: botSp ? botSp.offsetHeight : 0,
+                                      avg: v.avgTurnH ?? 60 }));
+  }
+  segs.sort((a, b) => a.top - b.top);
   // coalesce contiguous / overlapping turns into ONE band; a multi-segment goal hover → a few disjoint bands
   const bands: Array<{ top: number; bot: number }> = [];
   for (const s of segs) {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -34,6 +34,7 @@ import { flash } from "./actions";   // its own line: the import above is pinned
 import { awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
+import { historyMarks, historyBands, HIST_H, HIST_GAP } from "./glow-history";
 import { newSkeletonState, applyTabOrderSkeleton, onStatus, onFull, onDismiss, onSocketUp, nextPrefetch, renderKind } from "./skeleton-tabs";
 import { reconcileTabOrder, adoptArrival } from "./tab-order";
 import { writeViewOrder } from "./view-order";
@@ -2401,8 +2402,13 @@ function railLastDotFrom(turn: HTMLElement, hostR: DOMRect): number | null {
 // time window — plus any postal card carrying a hovered message id. Empty
 // groups+mids = clear. Glow is hover-transient, so a re-render that drops it
 // mid-hover self-heals on the next hover tick (the user 2026-06-19).
-function applyGlow(groups: Array<{ sid: string; uuids: string[] }>, mids: string[]) {
+// T318b (the user 2026-09-10): a group also carries `idx` (each uuid's GLOBAL event index in the kernel's chat
+// payload) so a source turn OUTSIDE the resident tail, which has no row here to light, is marked on the ruler's
+// history strip by its position in the unloaded prefix [0, headFrom) instead of painting nothing (glow-history.ts).
+let glowHistory: number[] = [];   // the active view's unloaded glow turns, as fractions of its unloaded prefix
+function applyGlow(groups: Array<{ sid: string; uuids: string[]; idx?: Record<string, number>; total?: number }>, mids: string[]) {
   document.querySelectorAll(".ext-glow").forEach((n) => n.classList.remove("ext-glow"));
+  glowHistory = [];
   const midSet = new Set(mids);
   if (midSet.size) {
     document.querySelectorAll<HTMLElement>(".turn[data-mid]").forEach((n) => {
@@ -2414,9 +2420,14 @@ function applyGlow(groups: Array<{ sid: string; uuids: string[] }>, mids: string
     if (!v) continue;
     const uset = new Set(g.uuids || []);
     if (!uset.size) continue;
+    const lit = new Set<string>();
     v.el.querySelectorAll<HTMLElement>(".turn[data-uuid]").forEach((n) => {
-      if (uset.has(n.dataset.uuid || "")) n.classList.add("ext-glow");   // every row of a matched atom lights
+      const u = n.dataset.uuid || "";
+      if (uset.has(u)) { n.classList.add("ext-glow"); lit.add(u); }   // every row of a matched atom lights
     });
+    // the rest sit outside the resident tail: mark them on the ruler's history strip (the active view's only,
+    // whose #content the ruler mirrors; other views are display:none)
+    if (g.sid === activeId) glowHistory = historyMarks(g.uuids || [], g.idx, lit, liveSession(g.sid)?.headFrom ?? 0);
   }
   paintGlowRuler();   // mirror the glow as bands on the overview ruler (link_audit's #4)
   paintRailBand();    // one continuous measured band over the rail line (the user 2026-07-02)
@@ -2532,7 +2543,9 @@ function paintRailBand(): void {
 // map CONTENT space → ruler space, so a plain scroll never moves them (they mark absolute transcript
 // position); only a glow change or a #content relayout repaints. v1 is a pure indicator (pointer-events:none
 // so the native scrollbar still works underneath) — the optional click-a-band-to-scroll is intentionally
-// skipped so it can't swallow scrollbar clicks.
+// skipped so it can't swallow scrollbar clicks. T318b (the user 2026-09-10): when the hovered turns include some
+// OUTSIDE the resident tail, the top of the strip is a HISTORY cap marking them by global event index over the
+// unloaded prefix (applyGlow → glowHistory), and the resident scroll maps into what is left below a hairline gap.
 const RULER_W = 10;   // == the webkit scrollbar width (styles.css ::-webkit-scrollbar) so bands sit in its gutter
 let glowRuler: HTMLElement | null = null;
 function ensureGlowRuler(): HTMLElement {
@@ -2548,10 +2561,13 @@ function paintGlowRuler(): void {
   const v = activeId ? views.get(activeId) : null;
   // only the ACTIVE view's glows map onto its #content scroll (other views are display:none → zero rects)
   const glows = (content && v) ? Array.from(v.el.querySelectorAll<HTMLElement>(".turn.ext-glow")) : [];
-  if (!content || !glows.length) { ruler.style.display = "none"; ruler.replaceChildren(); return; }
+  const hist = (content && v) ? glowHistory : [];
+  if (!content || (!glows.length && !hist.length)) { ruler.style.display = "none"; ruler.replaceChildren(); return; }
   const rect = content.getBoundingClientRect();
   const scrollH = content.scrollHeight || 1;
   const rulerH = content.clientHeight;          // the strip spans #content's VISIBLE height
+  const capH = hist.length ? HIST_H + HIST_GAP : 0;   // the history cap, when there is history to mark
+  const mapH = Math.max(1, rulerH - capH);            // …and the resident scroll maps into the rest
   // each glowing turn → a [top, bot] span in CONTENT space (scroll-independent: + scrollTop, − content top)
   const segs = glows.map((turn) => {
     const top = turn.getBoundingClientRect().top - rect.top + content.scrollTop;
@@ -2572,9 +2588,21 @@ function paintGlowRuler(): void {
   ruler.replaceChildren();
   for (const b of bands) {
     const band = el("div", "glow-ruler-band");
-    band.style.top = (b.top / scrollH * rulerH) + "px";
-    band.style.height = Math.max(3, (b.bot - b.top) / scrollH * rulerH) + "px";   // min 3px so a short turn still reads
+    band.style.top = (capH + b.top / scrollH * mapH) + "px";
+    band.style.height = Math.max(3, (b.bot - b.top) / scrollH * mapH) + "px";   // min 3px so a short turn still reads
     ruler.appendChild(band);
+  }
+  if (hist.length) {
+    const strip = el("div", "glow-ruler-hist");
+    strip.style.height = HIST_H + "px";
+    for (const hb of historyBands(hist, HIST_H)) {
+      const band = el("div", "glow-ruler-band");
+      band.classList.add("hist");
+      band.style.top = hb.top + "px";
+      band.style.height = hb.height + "px";
+      strip.appendChild(band);
+    }
+    ruler.appendChild(strip);
   }
   ruler.style.display = "";
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3154,6 +3154,12 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .glow-ruler-band { position: absolute; left: 1px; right: 1px; border-radius: 3px;
   background: color-mix(in srgb, var(--active-accent, #fff) 50%, transparent);
   box-shadow: 0 0 3px color-mix(in srgb, var(--active-accent, #fff) 40%, transparent); }
+/* The ruler's HISTORY strip (T318b, the user 2026-09-10): a hovered card's source turns outside the resident tail are
+   marked at the top of the ruler by global event index; a hairline under the strip separates the unloaded prefix
+   from the resident scroll map below. The same ink as the bands, so it reads as the same hover. */
+.glow-ruler-hist { position: absolute; left: 0; right: 0; top: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--active-accent, #fff) 35%, transparent); }
+.glow-ruler-band.hist { border-radius: 2px; }
 
 /* Fleet inbox-zero (the user 2026-06-29): when the fleet has loaded but has no open work, show the romp
    tri-color WORDMARK centered + faded in — the SAME calm at-rest mark as the feed's .feed-empty, mirrored


### PR DESCRIPTION
Follow-up to the summary-click fix (T318): the second half of that report was that hovering the card highlighted nothing. Root cause: the chat holds only the newest WIRE_TAIL events and streams older history in on scroll-back or a deep link, so when a hovered card's source turns were older than the resident tail, `applyGlow` found no row to light and the overview ruler, which maps the resident scroll height, had nowhere to band them. The hover painted nothing, with no sign that the turns existed off the loaded end.

Fix: the kernel's glow group now carries each uuid's global event index in the built chat payload (`_glow_groups` in `kernel/kernel.py`, read from the pusher's memo, the same events the pane was sent in wire order; used by the feed-card, chat-dot and timeline-bar hover sites), and the pane marks the unloaded turns in a short strip at the top of the overview ruler, positioned by index over the unloaded prefix `[0, headFrom)`, in the same ink as the bands, with a hairline under it; the resident scroll maps into the rest of the ruler (`ui/webview/glow-history.ts`, the pure half; `applyGlow`/`paintGlowRuler` in `render.ts`; two rules in `styles.css`). A turn that is resident but outside the RENDER window (a fresh tab of a long session holds 250 events and renders the last 80 units, the older head folded into one measured spacer; a review find on the first cut, which lit nothing for 81 to 250 events back) is placed where it sits in the scroll: inside the spacer, at the spacer's slice for its display unit (`windowSpans`, `residentUnits`; the geometry is read at paint time), and the ruler proper bands it like a rendered row; both spacers are handled, so a window rendered around a deep link places newer unrendered turns too. A turn inside the window without a row (folded, or off the active path) has no place and is dropped. A click on the card still lands on such a turn by the existing road: the reveal fetches older chunks until the uuid is resident. The ruler stays a pure indicator (pointer-events none), so nothing over the scrollbar is swallowed.

Tests (red before the change): `ui/webview/glow-history.test.ts` executes the pure half (a hover on three unloaded turns yields their marks and lights no row; a resident, a lit and an unknown uuid stay off the strip; touching marks coalesce; the last mark stays inside the strip), and the spacer placement (a top-spacer unit, a bottom-spacer unit, an in-window unit) and pins the DOM half to source, as the other webview tests do (the lit set is filled inside the one query that adds `.ext-glow`; the ruler shows for history marks alone; the cap offsets the resident map; the strip's styles; the reveal's fetch-older road). `tests/test_glow_history_positions.py` pins the kernel group builder (a repeated uuid keeps its first index, an unknown uuid has none, no built payload means a group without positions) and that every glow site in the socket handler goes through it. The ruler's existing pins are re-pinned to the capped map; the chat-dot hover's source pin and the applyGlow signature pin follow the new shapes.

Verified: the whole node suite (4322 tests, the one pin that named the old signature re-pinned), `tsc --noEmit`, and the kernel tests touching the hover graph (532 passed), each in one capped slot. No served screenshot: the strip needs a session longer than the wire tail with a card whose source turns are older than it; the geometry is pinned and the pure half is executed.

Tier: fix (the reported hover painted nothing; the tests fail before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

