### PR TITLE
Restart metrics: a turn the CLI opened itself measures no latency, and the feed stamps get driven tests

### DIFF
--- a/cli/restart_metrics.py
+++ b/cli/restart_metrics.py
@@ -260,12 +260,20 @@ def parse_events(rows: list[dict]) -> list[dict]:
 
 
 def parse_turns(rows: list[dict]) -> list[dict]:
-    """turns.jsonl rows with the derived seconds: feedToResultS, feedToFirstOutS (when both stamps exist)."""
+    """turns.jsonl rows with the derived seconds: feedToResultS, feedToFirstOutS (when both stamps exist and
+    the row says the turn was fed: a kernel before the 2026-09-10 writer fix stamped a turn the CLI opened
+    itself, fedTexts 0, with the previous fed turn's fedT and firstOutT, which read as hours of feed-to-result
+    and a duplicated first output; such a row is a turn and measures no feed latency). The gate is the count 0
+    alone: a row without a fedTexts key is read by its stamps, and a bool is not a count."""
     out = []
     for r in rows:
         if not isinstance(r.get("t"), (int, float)):
             continue
         rec = dict(r)
+        n = r.get("fedTexts")
+        if isinstance(n, int) and not isinstance(n, bool) and n == 0:
+            out.append(rec)          # nothing fed: the stamps, if any, are another turn's
+            continue
         fed, res, fo = r.get("fedT"), r.get("resultT"), r.get("firstOutT")
         if isinstance(fed, (int, float)) and fed > 0 and isinstance(res, (int, float)) and res >= fed:
             rec["feedToResultS"] = round(float(res) - float(fed), 3)

--- a/tests/test_restart_metrics.py
+++ b/tests/test_restart_metrics.py
@@ -83,6 +83,10 @@ def _fixture(state: Path):
         {"t": t1 + 100, "sid": SID2, "name": "api", "fedT": t1 + 90, "firstOutT": t1 + 91.0, "resultT": t1 + 100.0,
          "durationMs": 10000, "apiMs": 8000, "usd": 0.1, "opener": "human", "resumeNotice": False, "fedTexts": 1},
         {"t": t2 + 50, "sid": SID2, "name": "api", "fedT": 0, "resultT": t2 + 50.0, "opener": "", "resumeNotice": False},
+        # a turn the CLI opened itself at 02:01, written by a kernel before the 2026-09-10 writer fix: nothing fed
+        # (fedTexts 0), and the stamps still in memory were the 01:00 turn's (its fedT and firstOutT)
+        {"t": t2 + 60, "sid": SID, "name": "web", "fedT": t1 + 3, "firstOutT": t1 + 5.5, "resultT": t2 + 60.0,
+         "opener": "injected", "resumeNotice": False, "fedTexts": 0},
     ])
     _write(state, "states/%s.jsonl" % SID, [
         {"t": int(t1 - 100), "state": "working"}, {"t": int(t1 - 70), "state": "waiting"},
@@ -136,11 +140,27 @@ class Parsers(unittest.TestCase):
         self.assertEqual(turns[0]["feedToResultS"], 37.0)
         self.assertEqual(turns[0]["feedToFirstOutS"], 2.5)
         self.assertNotIn("feedToResultS", turns[2], "fedT 0 (no feed stamp) → no interval, never a bogus one")
+        # the self-opened turn (fedTexts 0) carries the previous fed turn's stamps: an hour of feed-to-result and
+        # a duplicated first-output interval if read; it counts as a turn and measures nothing
+        self.assertEqual(turns[3]["fedTexts"], 0)
+        self.assertNotIn("feedToResultS", turns[3], "nothing fed: the stamps are another turn's, never an interval")
+        self.assertNotIn("feedToFirstOutS", turns[3])
         lines = (self.state / "states" / (SID + ".jsonl")).read_text().splitlines()
         sl, cuts = rm.state_log_turns(lines)
         self.assertEqual([x["feedToResultS"] for x in sl], [30.0, 37.0],
                          "working→waiting pairs; an interrupt's by-marked settle and an idle close are not turns")
         self.assertEqual(cuts, {"restart": 1, "crash": 1})
+        self.assertEqual(rm.spend_by_day(json.loads((self.state / "spend.json").read_text())), {"2026-09-10": 12.5, "2026-09-12": 3.0})
+
+    def test_parse_turns_gates_on_a_zero_count_alone(self):
+        """The fedTexts gate keys on the count 0 and nothing else: a row without the key is read by its stamps
+        (a writer that never wrote the key), and a bool is not a count. Direct rows, so the fixture's turn
+        count and buckets stay as they are."""
+        stamped = {"t": 100, "sid": SID, "fedT": 10, "firstOutT": 12.0, "resultT": 15.0}
+        rows = [dict(stamped), dict(stamped, fedTexts=0), dict(stamped, fedTexts=False), dict(stamped, fedTexts=1)]
+        got = [(r.get("feedToResultS"), r.get("feedToFirstOutS")) for r in rm.parse_turns(rows)]
+        self.assertEqual(got, [(5.0, 2.0), (None, None), (5.0, 2.0), (5.0, 2.0)],
+                         "no key: read by its stamps; the count 0: unmeasured; a bool: not a count; a count: measured")
 
     def test_state_log_pair_breaks_at_a_machine_cut(self):
         """Review find (2026-09-10): a cut turn's `working` row was closed by the RESUMED turn's `waiting`, so
@@ -151,7 +171,6 @@ class Parsers(unittest.TestCase):
         sl, cuts = rm.state_log_turns(lines)
         self.assertEqual([(x["fedT"], x["feedToResultS"]) for x in sl], [(1400, 10.0)])
         self.assertEqual(cuts, {"restart": 1})
-        self.assertEqual(rm.spend_by_day(json.loads((self.state / "spend.json").read_text())), {"2026-09-10": 12.5, "2026-09-12": 3.0})
 
 
 class BootJoin(unittest.TestCase):
@@ -232,7 +251,7 @@ class Document(unittest.TestCase):
                           b["drainLeftClosing"], b["leaseProblems"]), (1, 1, 1, 1, 1, 1, 1))
         self.assertEqual((b["drainUnjoinedCount"], b["drainReapedCount"]), (1, 1))
         self.assertEqual(b["redo"], {"turns": 1, "usd": 0.5, "tokens": 3700})
-        self.assertEqual(b["turns"], 3)
+        self.assertEqual(b["turns"], 4, "the self-opened turn counts as a turn; only its latency is unmeasured")
         self.assertEqual((b["latency"]["feedToResultS"]["n"], b["latency"]["feedToResultS"]["max"]), (2, 37.0))
         self.assertEqual(b["latency"]["feedToFirstOutS"]["p50"], 1.0)
         self.assertEqual(b["latency"]["apiS"]["max"], 30.0)

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -37,6 +37,7 @@ Every id here is synthetic (the placeholder uuid family); no message content is 
 """
 import asyncio
 import inspect
+import json
 import os
 import re
 import shutil
@@ -1082,6 +1083,33 @@ class TheDeferredReconnectTakesTheHeldQueueWithIt(unittest.TestCase):
         c1 = self._Client.instances[0]
         self.assertEqual(c1.writes, [("first turn", "before-result")])
         return c1
+
+    def test_a_fed_turn_gets_the_pop_stamp_and_its_row_carries_both_event_stamps(self):
+        """The two event stamps the latency figures read: the feeder's pop stamps fedT as it hands the
+        fresh turn's text to the client, the first streamed work atom stamps firstOutT, and the settle's
+        row carries both (rounded to the millisecond) and then spends them. Driven through the real
+        _amain on the stand-in SDK; every cross-thread read waits on its event, and what is asserted is
+        presence and order, never a duration."""
+        t0 = time.time()
+        c1 = self._first_turn()
+        s = self.s
+        self._wait(lambda: s._fed_t is not None, "the pop stamp")
+        self.assertIsInstance(s._fed_t, float)
+        self.assertTrue(t0 <= s._fed_t <= time.time(), "the pop's own clock reading")
+        self._wait(lambda: s._first_out_t is not None, "the first work atom")
+        fed_seen, first_seen = s._fed_t, s._first_out_t
+        self.assertLessEqual(fed_seen, first_seen, "fed, then the first output")
+        s.loop.call_soon_threadsafe(c1.release.set)          # the turn's ResultMessage: the settle runs
+        self._wait(lambda: s.inflight == 0, "the settle")
+        rows = [json.loads(ln) for ln in (self.be.state_dir / sb.TURNS_FILE).read_text().splitlines()]
+        self.assertEqual(len(rows), 1, "one row for the settled turn")
+        row = rows[0]
+        self.assertEqual((row["fedT"], row["firstOutT"]), (round(fed_seen, 3), round(first_seen, 3)))
+        self.assertTrue(row["fedT"] <= row["firstOutT"] <= row["resultT"])
+        self.assertEqual((row["fedTexts"], row["opener"]), (1, "human"))
+        self.assertIn("usd", row, "the spend accounting's figure rode along")
+        self.assertTrue(s._fed_t is None and s._first_out_t is None and s._turn_spend is None,
+                        "spent with the row")
 
     def test_a_head_held_behind_an_interrupted_turn_is_fed_to_the_new_client_and_never_flagged(self):
         s = self.s

--- a/tests/test_session_events_ledger.py
+++ b/tests/test_session_events_ledger.py
@@ -8,6 +8,7 @@ the backend's problem ring as its prose (the shape agreed with the lease work, w
 kinds through the same helper). turns.jsonl gets one row per settled turn with the event stamps the latency
 and redo-cost figures read. Synthetic fixtures only: placeholder uuids, fake pids above pid_max, scripted
 `run` / `kill` seams, no real CLI."""
+import asyncio
 import json
 import os
 import tempfile
@@ -356,21 +357,20 @@ class TurnLedgerRow(unittest.TestCase):
         s.since = 1700000000   # `since` stays whole seconds for its other readers and is not what the row reads
         self.assertEqual(s._turn_ledger_row(types.SimpleNamespace(), now=1700000012.5)["fedT"], 1700000000.125)
 
-    def test_feed_stamps_are_spent_at_the_settle(self):
-        """The ResultMessage branch resets _fed_t and _first_out_t right after the row, in the finally, ahead of
-        the settle; and the row is written from the finally, so a bookkeeping fault (a spend-fold exception)
-        still leaves it. Pinned on the source, which is where the ordering lives."""
+    def test_the_result_branch_stays_one_try(self):
+        """The ResultMessage branch is ONE try: its body is the bookkeeping, its finally the settle. Two things
+        about its shape stay pinned on the source, where they live: the one try itself (the branch's own
+        contract, and why the spend accounting hands its figures to the finally by attribute), and the feed
+        stamps spent ahead of the settle inside that finally (an order nothing outside it can observe: the two
+        are plain assignments with no await between them). What the finally DOES is driven in TurnLedgerDriven:
+        the row written with the accounting's figures whatever the bookkeeping did (so the figures were handed
+        over before the spend write), the stamps None afterwards, and the settle run."""
         import inspect
         src = inspect.getsource(sb.SdkSession._on_message)
-        i_fin = src.index("finally:\n                # T304: one durable row per settled turn")
-        i_row = src.index("append_turn_row(self.backend.state_dir, self._turn_ledger_row(msg, _sp[0], _sp[1]))")
-        i_reset = src.index("self._fed_t = None               # the turn's feed stamps are spent")
-        i_settle = src.index("everything that makes the turn over for the kernel")   # the finally's own comment
-        self.assertTrue(i_fin < i_row < i_reset < i_settle, "row, then the reset, then the settle, all inside the finally")
         self.assertIn("elif isinstance(msg, ResultMessage):\n            try:", src,
                       "the branch stays ONE try (the settle pins), so the fold hands its figures over by attribute")
-        self.assertIn("self._turn_spend = (delta, turn_u)", src[src.index("turn_u = self._turn_usage(msg)"):i_fin])
-        self.assertIn("self._turn_spend = None", src[i_row:i_settle], "spent with the row")
+        self.assertLess(src.index("self._fed_t = None"), src.index("self.inflight = 0"),
+                        "the feed stamps are spent ahead of the settle, both inside the finally")
 
     def test_row_fields_and_stamps(self):
         s = self._sess(["do the thing"], first_out=1700000004.25, fed_t=1700000000)
@@ -403,6 +403,108 @@ class TurnLedgerRow(unittest.TestCase):
         sb.append_turn_row(Path(d), {})            # nothing to write
         rows = [json.loads(ln) for ln in (Path(d) / sb.TURNS_FILE).read_text().splitlines()]
         self.assertEqual(rows, [{"t": 1, "sid": SID}])
+
+
+# ---- message doubles for the driven tests: the SDK's shapes by class name (msg_to_atom and _on_message key on it) ----
+class _TextBlock:
+    def __init__(self, text): self.text = text
+class _AssistantMessage:
+    def __init__(self, content, uuid="a1"):
+        self.content, self.model, self.uuid, self.stop_reason, self.error = content, "claude-x", uuid, "end_turn", None
+class _UserMessage:
+    def __init__(self, content, uuid="u1"):
+        self.content, self.uuid, self.parent_tool_use_id, self.tool_use_result = content, uuid, None, None
+class _ResultMessage:
+    uuid = "r1"
+    num_turns = 1
+def _result(**fields):
+    """A ResultMessage double carrying result fields (total_cost_usd, usage, ...): a subclass, so the
+    handler's isinstance and the failure report's class-name read both see a ResultMessage."""
+    return type("ResultMessage", (_ResultMessage,), dict(fields))()
+class _SystemMessage:
+    def __init__(self, subtype, data=None, uuid=None):
+        self.subtype, self.data, self.uuid = subtype, (data or {}), uuid
+_TextBlock.__name__ = "TextBlock"; _AssistantMessage.__name__ = "AssistantMessage"
+_UserMessage.__name__ = "UserMessage"; _ResultMessage.__name__ = "ResultMessage"; _SystemMessage.__name__ = "SystemMessage"
+
+
+async def _noop_coro(*a, **k):
+    return None
+
+
+class TurnLedgerDriven(unittest.TestCase):
+    """The stamps and the row, driven through the real code paths on a real SdkSession (never started: no
+    CLI, no thread) over a hermetic backend. TurnLedgerRow above reads the row off a preset double; these
+    reach the two writers of the stamps it presets, and the finally that writes the row and spends them."""
+
+    def _session(self, be, sid=SID, name="web"):
+        s = sb.SdkSession(be, {"sid": sid, "name": name, "cwd": "/tmp"})
+        s._do_refresh_context = _noop_coro    # the settle schedules both; there is no client to ask
+        s._do_refresh_usage = _noop_coro
+        return s
+
+    def test_forward_stamps_the_first_work_atom_once(self):
+        """firstOutT is the turn's FIRST streamed work atom while a fed turn is in flight: a second atom keeps
+        the first's stamp, nothing in flight stamps nothing, and a command line (a streamed /model
+        confirmation) is not work."""
+        be = _backend(tempfile.mkdtemp())
+        s = self._session(be)
+        s.inflight = 1
+        self.assertIsNone(s._first_out_t)
+        be._forward(s, _AssistantMessage([_TextBlock("working on it")], uuid="w1"))
+        first = s._first_out_t
+        self.assertIsInstance(first, float)
+        be._forward(s, _AssistantMessage([_TextBlock("still at it")], uuid="w2"))
+        self.assertEqual(s._first_out_t, first, "the first atom's stamp holds for the turn")
+        other = self._session(be, sid=SID2, name="api")
+        be._forward(other, _AssistantMessage([_TextBlock("idle chatter")], uuid="w3"))
+        self.assertIsNone(other._first_out_t, "nothing in flight: not a fed turn's first output")
+        other.inflight = 1
+        cmd = _UserMessage([_TextBlock("<command-name>/model</command-name>\n"
+                                       "<command-message>model</command-message>\n"
+                                       "<command-args>sonnet</command-args>")], uuid="c1")
+        be._forward(other, cmd)
+        self.assertIsNone(other._first_out_t, "a command line is not the turn's output")
+        be._forward(other, _AssistantMessage([_TextBlock("now working")], uuid="w4"))
+        self.assertIsInstance(other._first_out_t, float, "the next work atom is")
+
+    def test_the_settle_writes_the_row_and_spends_the_stamps_when_the_spend_write_raises(self):
+        """The ResultMessage branch's finally writes the turn's row and then spends the feed stamps, ahead of
+        the settle, whatever the bookkeeping did: here the spend write raises (the anomalous turn is exactly
+        the one the row must keep), the row still lands with the accounting's figures (the spend tuple is
+        set before the raising write), the stamps are None afterwards, and the settle ran. The fault itself is
+        contained by _handle_stream_message, which reports it and returns False."""
+        d = tempfile.mkdtemp()
+        be = _backend(d)
+        s = self._session(be)
+        s.inflight = 1
+        s._inflight_texts.append("do the thing")
+        s._fed_t = 1700000000.125
+        s._first_out_t = 1700000004.25
+
+        def boom(*a, **k):
+            raise RuntimeError("boom")
+        be._record_spend = boom
+        msg = _result(total_cost_usd=0.5, usage={"input_tokens": 1, "output_tokens": 2},
+                      duration_ms=10, duration_api_ms=8, num_turns=1, is_error=False)
+
+        async def run():
+            ok = s._handle_stream_message(msg, _AssistantMessage, _ResultMessage, _SystemMessage)
+            await asyncio.sleep(0)
+            return ok
+        ok = asyncio.run(run())
+        self.assertFalse(ok, "the spend write's fault is contained and reported, not swallowed")
+        rows = [json.loads(ln) for ln in (Path(be.state_dir) / sb.TURNS_FILE).read_text().splitlines()]
+        self.assertEqual(len(rows), 1, "one row for the settled turn, written from the finally")
+        row = rows[0]
+        self.assertEqual((row["fedT"], row["firstOutT"], row["fedTexts"]), (1700000000.125, 1700000004.25, 1))
+        self.assertEqual((row["usd"], row["durationMs"], row["apiMs"], row["tokIn"], row["tokOut"]), (0.5, 10, 8, 1, 2),
+                         "the accounting's figures reached the row although the spend write raised")
+        self.assertIsNone(s._fed_t, "the feed stamps are spent with the row")
+        self.assertIsNone(s._first_out_t)
+        self.assertIsNone(s._turn_spend)
+        self.assertEqual((s.inflight, list(s._inflight_texts)), (0, []), "the settle ran")
+        self.assertEqual(sb.last_state_value(Path(be.state_dir), SID), "waiting")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Symptom

`romp restart-metrics` reports an hours-long feed-to-result and a duplicated feed-to-first-output sample wherever turns.jsonl holds a row that a kernel before the 2026-09-10 writer fix wrote for a turn the CLI opened by itself (a channel message, a task notification, a scheduled prompt). The summary's "feed to result" line, the day and week buckets and the report's latency frames all carry the sample. The current kernel no longer writes that row shape (a fedT now implies fedTexts >= 1), so only rows recorded under the earlier writer are affected, and a baseline read over them is wrong.

The post-merge review of #1340, the PR that added restart metrics, named this reader check and two test gaps; the gaps are closed here as well. The two writers of the stamps the latency figures depend on, the pop's `_fed_t` in inputs() and the first work atom's `_first_out_t` in _forward, had no executing test: deleting either line left the suite green and the reader reporting n 0 with no error. The finally that writes the turn's row and spends the stamps was pinned by source-text indices only. And in tests/test_restart_metrics.py the spend_by_day assertion ran under test_state_log_pair_breaks_at_a_machine_cut, whose docstring never claimed it, so a spend_by_day regression would have reported under the machine-cut test's name.

## Cause

parse_turns derived the seconds from any row with fedT > 0 and resultT >= fedT. The earlier writer set fedT from `since` and firstOutT from `_first_out_t` unconditionally, and both were reset only at a fresh feed, so a self-opened turn's row carried the previous fed turn's stamps with fedTexts 0, and the reader took the interval from one turn's feed to another turn's result. The misplaced assertion dates from the commit that inserted the machine-cut test between test_events_turns_and_state_log's last two statements.

## Fix

- cli/restart_metrics.py: parse_turns keeps a row whose fedTexts is 0 as a turn and derives no seconds from it. The gate is the count 0 alone: a row without the key is read by its stamps as before, and a bool is not a count. The bucket count still takes the row as a turn; only its feed latency is unmeasured.
- tests/test_restart_metrics.py: the spend_by_day assertion is back as the last statement of test_events_turns_and_state_log, and the machine-cut test ends at its cuts assertion, as its docstring says.
- tests/test_session_events_ledger.py: the index-arithmetic pin (now test_the_result_branch_stays_one_try) keeps two assertions that are checkable on the source alone: the branch's one-try shape, and the feed stamps reset ahead of the settle inside the finally (plain assignments with no await between them, so the order is not observable from outside the finally). The row's content under a raising spend write, the spend tuple set before that write, and the stamps spent afterwards are driven by the new tests below.

## Tests

- tests/test_restart_metrics.py: a fourth turns row with the self-opened shape (fedTexts 0, the 01:00 turn's fedT and firstOutT, a 02:01 resultT). Before the gate, Parsers.test_events_turns_and_state_log fails on turns[3] carrying feedToResultS 3657.0 and feedToFirstOutS 2.5; Document.test_week_buckets_carry_every_metric fails on feedToResultS n 3 and max 3657.0; Document.test_summary_text_names_the_numbers fails on the summary's feed-to-result count (3 for 2); tests/test_restart_metrics_report.py Frames.test_frames_from_two_documents fails on latencySamples [37.0, 10.0, 3657.0]. The week bucket's turns count moves from 3 to 4.
- tests/test_restart_metrics.py, Parsers.test_parse_turns_gates_on_a_zero_count_alone: parse_turns over four direct rows with the same stamps and no fedTexts key, fedTexts 0, fedTexts false and fedTexts 1 derives (5.0, 2.0), nothing, (5.0, 2.0) and (5.0, 2.0). It fails without the gate (the 0 row derives), with a gate keyed on falsiness (`if not n:`, the keyless row derives nothing), with a gate that also takes a missing key (`n is None or ...`), and with the bool exclusion dropped (the false row derives nothing).
- The spend_by_day move, shown executing: with rm.spend_by_day replaced by a function returning {}, the machine-cut test fails before the move and test_events_turns_and_state_log fails after it, read from those two tests alone; a deliberate wrong expected value (99.0 for 12.5) fails test_events_turns_and_state_log at the moved line.
- tests/test_sdk_stream_survives_handler_errors.py, TheDeferredReconnectTakesTheHeldQueueWithIt.test_a_fed_turn_gets_the_pop_stamp_and_its_row_carries_both_event_stamps: the real _amain on the stand-in SDK runs a fed turn; the pop stamp, the first-output stamp and the settled row carrying both (fedT <= firstOutT <= resultT, fedTexts 1, opener human, usd present) are read through the class's _wait, and the stamps are None afterwards. Removing the `self._fed_t = time.time()` line in inputs() fails it (timed out waiting for the pop stamp); removing the `sess._first_out_t = time.time()` line in _forward fails it too.
- tests/test_session_events_ledger.py, TurnLedgerDriven.test_forward_stamps_the_first_work_atom_once: a real SdkSession with inflight 1; the first work atom stamps, the second keeps the first's stamp, nothing in flight stamps nothing, a command line never stamps. Removing the _forward stamp fails it (None is not a float).
- tests/test_session_events_ledger.py, TurnLedgerDriven.test_the_settle_writes_the_row_and_spends_the_stamps_when_the_spend_write_raises: a real SdkSession travels the ResultMessage branch through _handle_stream_message with _record_spend raising. The row lands with fedT, firstOutT, fedTexts 1, usd 0.5, durationMs 10, apiMs 8 and the token counts; the stamps and _turn_spend are None afterwards; inflight is 0 and the state log reads waiting; the handler returns False. Removing the three reset lines fails it (_fed_t still 1700000000.125); moving the append out of the finally to after the spend write fails it (no turns.jsonl); setting the spend tuple after the raising write fails it (no usd on the row).
- tests/test_session_events_ledger.py, TurnLedgerRow.test_the_result_branch_stays_one_try: the source pin. Moving the three resets after `self.inflight = 0` fails it and no driven test, since the order is not observable from outside the finally.
- Full pytest suite on this branch: 11719 passed, 45 skipped, 1746 subtests passed (pytest -n 6 over tests/ on the final tree, the served-page legs included).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
