### PR TITLE
Tests: the CLI probe hands its child no ANTHROPIC_* name and runs the --bg refusal with no prompt, stdin at /dev/null, in a process group tearDown kills; the reference scopes the hook-timeout sentence to the tool hook it measured and counts three pinned facts

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -951,21 +951,30 @@ What the CLI itself does when its parent goes quiet was measured on Claude Code
 2.1.257 (2026-09-10, the restart-surviving sessions program's stage 3 probe, run
 against a throwaway config directory): a permission request (`can_use_tool`)
 waits for its answer with no expiry within ten minutes and the turn continues
-normally on a late answer; a hook callback waits 600 seconds by default, or the
+normally on a late answer; a tool hook callback (a `PreToolUse` hook on Bash,
+the kind the probe module registers) waits 600 seconds by default, or the
 matcher's `timeout` seconds when one is set, then the CLI cancels the request
 (`control_cancel_request`), records a hook-timeout error as the tool's result
-and goes on with the turn; a second `initialize` on the same stdin is accepted
-and its hook table replaces the first; stdin end-of-file ends an idle CLI at
-once (0.02 s) and a busy one after its turn (a 30 s tool call ran to completion
-first); an unread stdout does not stall the CLI (the pipe's 64 kilobytes fill,
-the rest buffers inside the process, the turn completes); `--resume` takes no
-lock, and two processes on one session id both append to the one transcript;
-`claude --bg` runs an interactive session on a pseudo-terminal under a daemon
-that stays in the launcher's cgroup, and refuses `--print`, so a background
-session has no stream-json channel. `tests/test_cli_control_protocol_probe.py`
-re-checks the two facts that need no model call (the second initialize, the
-`--bg` refusal) when run with `ROMP_CLI_PROBE_LIVE=1` and a `claude` on PATH; it
-skips otherwise, as every test that would reach the live CLI must.
+and goes on with the turn; the CLI instead treats a timed-out `UserPromptSubmit`
+callback as a blocking decision and suppresses the prompt (Claude Code 2.1.266,
+read from the CLI's hook dispatch rather than measured: that dispatch converts a
+timed-out prompt-hook callback into a block and hands every other event's
+timeout to that event's own handler; romp registers that hook and sets no
+`timeout` on any matcher); what a timed-out `Stop`, `SubagentStart`,
+`SubagentStop`, `PostToolUse` or `PostToolUseFailure` callback does is
+unmeasured; a second `initialize` on the same stdin is accepted and its hook
+table replaces the first; stdin end-of-file ends an idle CLI at once (0.02 s)
+and a busy one after its turn (a 30 s tool call ran to completion first); an
+unread stdout does not stall the CLI (the pipe's 64 kilobytes fill, the rest
+buffers inside the process, the turn completes); `--resume` takes no lock, and
+two processes on one session id both append to the one transcript; `claude --bg`
+runs an interactive session on a pseudo-terminal under a daemon that stays in
+the launcher's cgroup, and refuses `--print`, so a background session has no
+stream-json channel. `tests/test_cli_control_protocol_probe.py` re-checks the
+three facts that need no model call (the second initialize, the idle exit on
+stdin end-of-file, the `--bg` refusal) when run with `ROMP_CLI_PROBE_LIVE=1` and
+a `claude` on PATH; it skips otherwise, as every test that would reach the live
+CLI must.
 
 Who owns a running CLI is a lease, not its parent process. The kernel writes
 `leases/<sid>.json` under the state directory the moment the SDK connect hands

--- a/tests/test_cli_control_protocol_probe.py
+++ b/tests/test_cli_control_protocol_probe.py
@@ -11,13 +11,20 @@ with the probe described in docs/reference.md ("What survives a restart"):
   * `--bg` (a background session) and `--print` (the only mode that takes `--input-format
     stream-json`) are refused together, so a background session has no structured channel.
 
-Every test here runs the REAL CLI, so the suite's standing rule applies (tests/conftest.py floors
-ROMP_CLAUDE_BIN at /bin/false: no test reaches the live CLI unasked). These run only when the
-developer opts in with ROMP_CLI_PROBE_LIVE=1 and a `claude` is on PATH (or named in
-ROMP_CLI_PROBE_CLAUDE); otherwise they skip, on CI too. They never touch the developer's own
-Claude Code state: a throwaway CLAUDE_CONFIG_DIR and XDG_STATE_HOME per test, an empty settings
-file, no key, every CLAUDE_* and ROMP_* variable scrubbed from the child's environment, and the
-child killed with its process group in tearDown. Synthetic fixtures only.
+The pins in ControlProtocolPins run the REAL CLI, so the suite's standing rule applies
+(tests/conftest.py floors ROMP_CLAUDE_BIN at /bin/false: no test reaches the live CLI unasked). They
+run only when the developer opts in with ROMP_CLI_PROBE_LIVE=1 and a `claude` is on PATH (or named
+in ROMP_CLI_PROBE_CLAUDE); otherwise they skip, on CI too. They never touch the developer's own
+Claude Code state: a throwaway CLAUDE_CONFIG_DIR and XDG_STATE_HOME per test with an empty settings
+file, and a child environment with every ANTHROPIC_*, CLAUDE_* and ROMP_* variable scrubbed, which
+are the two channels the test controls (managed settings outside the config directory are not the
+test's to control). The scrub is the module's own, so a bare
+`python3 tests/test_cli_control_protocol_probe.py` run, which loads no conftest, hands the CLI no
+key either. Every CLI the module starts runs in a process group of its own that tearDown kills, and
+the one started without a stdin pipe reads /dev/null; a daemon that leaves its group is out of the
+kill's reach, which is one more reason the child carries no credential. The two classes after the
+pins start no CLI and run everywhere: they check the scrub and the runner over /bin/sh. Synthetic
+fixtures only.
 """
 import json
 import os
@@ -29,6 +36,7 @@ import tempfile
 import time
 import unittest
 import uuid
+from unittest import mock
 
 LIVE = os.environ.get("ROMP_CLI_PROBE_LIVE") == "1"
 CLAUDE = os.environ.get("ROMP_CLI_PROBE_CLAUDE") or shutil.which("claude") or ""
@@ -40,9 +48,13 @@ STREAM_ARGV = ["--print", "--output-format", "stream-json", "--verbose", "--inpu
 
 
 def hermetic_env(root):
-    """A child environment that reaches none of the developer's Claude Code or romp state."""
+    """A child environment that reaches none of the developer's Claude Code or romp state, and carries no
+    credential the test can see: every ANTHROPIC_* name goes (a key, a login token, a proxy base URL and
+    the header that usually carries the proxy's credential), by prefix rather than by list, as the
+    kernel's codex judge does, because the CLI grows names and the harmless ones may go too."""
     env = {k: v for k, v in os.environ.items()
-           if not (k == "CLAUDECODE" or k.startswith("CLAUDE_") or k.startswith("ROMP_") or k.startswith("XDG_"))}
+           if not (k == "CLAUDECODE" or k.startswith("ANTHROPIC_") or k.startswith("CLAUDE_")
+                   or k.startswith("ROMP_") or k.startswith("XDG_"))}
     cfg = os.path.join(root, "cfg"); xdg = os.path.join(root, "xdg")
     os.makedirs(cfg); os.makedirs(xdg)
     with open(os.path.join(cfg, "settings.json"), "w") as f:
@@ -51,6 +63,43 @@ def hermetic_env(root):
                 "XDG_CACHE_HOME": os.path.join(xdg, "cache"), "DISABLE_AUTOUPDATER": "1",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1", "CLAUDE_CODE_ENTRYPOINT": "sdk-py"})
     return cfg, env
+
+
+def kill_group(p):
+    """SIGKILL the process group `p` leads (start_new_session made it a leader), reap `p` and close its
+    pipes. A group that is already empty is fine; a member that left the group (a daemon's setsid) is
+    not reached, and it may still hold the pipes' write ends, so the read ends are closed, never drained."""
+    try:
+        os.killpg(p.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    try:
+        p.wait(timeout=5)
+    except Exception:
+        pass
+    for f in (p.stdin, p.stdout, p.stderr):
+        if f is not None:
+            try:
+                f.close()
+            except Exception:
+                pass
+
+
+def run_probe(exe, argv, env, cwd, timeout, procs):
+    """Run `exe` with `argv` to completion the way a probe needs: stdin at /dev/null (a CLI that wants a
+    prompt from stdin sees end-of-file at once, never the test's own stdin), a process group of its
+    own, and the Popen appended to `procs` BEFORE the wait, so tearDown's group kill reaches whatever
+    the run left behind however it ended. Returns (returncode, stdout, stderr); a run still going at
+    `timeout` seconds is killed with its group and TimeoutExpired re-raised."""
+    p = subprocess.Popen([exe, *argv], stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         text=True, env=env, cwd=cwd, start_new_session=True)
+    procs.append(p)
+    try:
+        out, err = p.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        kill_group(p)
+        raise
+    return p.returncode, out, err
 
 
 class StreamCli:
@@ -115,14 +164,7 @@ class StreamCli:
         return None
 
     def kill(self):
-        try:
-            os.killpg(self.p.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        try:
-            self.p.wait(timeout=5)
-        except Exception:
-            pass
+        kill_group(self.p)
 
 
 @unittest.skipUnless(LIVE and CLAUDE, SKIP_WHY)
@@ -131,10 +173,13 @@ class ControlProtocolPins(unittest.TestCase):
         self.root = tempfile.mkdtemp(prefix="romp-cli-probe-")
         self.cfg, self.env = hermetic_env(self.root)
         self.cli = None
+        self.procs = []
 
     def tearDown(self):
         if self.cli is not None:
             self.cli.kill()
+        for p in self.procs:
+            kill_group(p)
         shutil.rmtree(self.root, ignore_errors=True)
 
     def test_second_initialize_is_accepted_and_idle_eof_exits_at_once(self):
@@ -158,14 +203,17 @@ class ControlProtocolPins(unittest.TestCase):
         self.assertEqual(self.cli.p.returncode, 0, self._stderr())
 
     def test_background_session_refuses_print_and_so_has_no_stream_json_channel(self):
-        p = subprocess.run([CLAUDE, "--bg", "--print", "--input-format", "stream-json", "--output-format", "stream-json",
-                            "Reply with the single word: ok"],
-                           env=self.env, cwd=self.cfg, capture_output=True, text=True, timeout=60)
-        self.assertNotEqual(p.returncode, 0, "`--bg --print` was accepted: a background session may now take stream-json; re-measure")
-        err = p.stderr.lower()
-        self.assertIn("--bg", err, p.stderr)
-        self.assertIn("--print", err, p.stderr)
-        self.assertIn("conflict", err, p.stderr)
+        # No prompt (the assertions read the exit status and stderr only), stdin at /dev/null, no
+        # credential in the environment, and a process group tearDown kills: a CLI that accepted the pair
+        # (the regression the first assertion exists to catch) has nothing to run and no key to run it
+        # with, and its launcher and any daemon that stays in the group are killed.
+        argv = ["--bg", "--print", "--input-format", "stream-json", "--output-format", "stream-json"]
+        rc, _out, stderr = run_probe(CLAUDE, argv, self.env, self.cfg, 60, self.procs)
+        self.assertNotEqual(rc, 0, "`--bg --print` was accepted: a background session may now take stream-json; re-measure")
+        err = stderr.lower()
+        self.assertIn("--bg", err, stderr)
+        self.assertIn("--print", err, stderr)
+        self.assertIn("conflict", err, stderr)
 
     def _stderr(self):
         """Whatever the CLI has written to stderr so far, without blocking on an open pipe (the message
@@ -181,6 +229,126 @@ class ControlProtocolPins(unittest.TestCase):
         except Exception:
             pass
         return out[-2000:]
+
+
+class HermeticEnvPins(unittest.TestCase):
+    """What hermetic_env drops from the child's environment. No CLI is started, so these run on CI and
+    under a bare unittest run alike. The scrub is the module's own: tests/conftest.py pops a fixed list of
+    credential names, only under pytest, and a bare `python3 tests/test_cli_control_protocol_probe.py`
+    run loads no conftest."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="romp-cli-probe-unit-")
+
+    def tearDown(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_drops_every_anthropic_claude_romp_and_xdg_name(self):
+        # Planted values are three plain words and a loopback URL, all short, so nothing credential-shaped
+        # sits in the repo or in a failure report; the assertions render names only, never the mapping.
+        planted = {"ANTHROPIC_API_KEY": "planted-anthropic-api-key",
+                   "ANTHROPIC_AUTH_TOKEN": "planted-anthropic-auth-token",
+                   "ANTHROPIC_BASE_URL": "http://127.0.0.1:1",
+                   "ANTHROPIC_CUSTOM_HEADERS": "planted-header",
+                   "CLAUDECODE": "1", "CLAUDE_PLANTED": "1", "ROMP_PLANTED": "1", "XDG_DATA_HOME": "/nonexistent"}
+        with mock.patch.dict(os.environ, planted):
+            cfg, env = hermetic_env(self.root)
+        self.assertEqual(sorted(k for k in env if k.startswith("ANTHROPIC_")), [],
+                         "ANTHROPIC_* names reached the child's environment")
+        self.assertEqual(sorted(k for k in env if k in planted and not k.startswith("ANTHROPIC_")), [])
+        self.assertEqual(env["CLAUDE_CONFIG_DIR"], cfg)
+        self.assertTrue(cfg.startswith(self.root + os.sep), cfg)
+        self.assertTrue(env["XDG_STATE_HOME"].startswith(self.root + os.sep), env["XDG_STATE_HOME"])
+        self.assertTrue(os.path.isfile(os.path.join(cfg, "settings.json")))
+
+
+def _gone(pid, timeout):
+    """Whether `pid` is dead within `timeout` seconds: reaped (no such process), or a zombie its new
+    parent has not collected yet (/proc/<pid>/stat state Z, which is the usual sight on Linux right
+    after the kill; where /proc is absent only the reaped case counts)."""
+    end = time.monotonic() + timeout
+    while True:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        try:
+            with open("/proc/%d/stat" % pid) as f:
+                if f.read().rsplit(")", 1)[1].split()[0] == "Z":
+                    return True
+        except OSError:
+            pass
+        if time.monotonic() >= end:
+            return False
+        time.sleep(0.05)
+
+
+# A background sleep the sh leaves behind stands in for a daemon a CLI would leave behind. Its three
+# descriptors are redirected on purpose: with the pipes inherited, communicate() would wait for their
+# end-of-file until the sleep ended.
+LEAVE_A_SLEEPER = "sleep 30 </dev/null >/dev/null 2>&1 & echo $!"
+
+
+class ProbeRunPins(unittest.TestCase):
+    """run_probe, kill_group and the class's own tearDown over /bin/sh, with no CLI: these run on CI."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="romp-cli-probe-unit-")
+        self.procs = []
+
+    def tearDown(self):
+        for p in self.procs:
+            kill_group(p)
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def test_run_probe_takes_its_own_group_and_kill_group_reaches_an_orphan(self):
+        rc, out, err = run_probe("/bin/sh", ["-c", LEAVE_A_SLEEPER], dict(os.environ), self.root, 10, self.procs)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(len(self.procs), 1)
+        sleeper = int(out.strip())
+        # start_new_session made the sh the leader of a new group (pgid == its pid); a non-interactive sh
+        # has no job control, so its background child stays in that group, which outlives the sh.
+        self.assertEqual(os.getpgid(sleeper), self.procs[0].pid)
+        kill_group(self.procs[0])
+        self.assertTrue(_gone(sleeper, 5), "the orphaned sleeper survived the group kill")
+
+    def test_run_probe_kills_the_group_when_the_timeout_expires(self):
+        # The sh records its sleeper's pid, then waits on it, so the run outlives the timeout.
+        with self.assertRaises(subprocess.TimeoutExpired):
+            run_probe("/bin/sh", ["-c", "sleep 30 </dev/null >/dev/null 2>&1 & echo $! > pid; wait"],
+                      dict(os.environ), self.root, 3, self.procs)
+        self.assertEqual(len(self.procs), 1)
+        p = self.procs[0]
+        self.assertIsNotNone(p.returncode, "the sh outlived its timeout")
+        self.assertTrue(p.stdout.closed and p.stderr.closed, "the timeout's group kill left the pipes open")
+        pid_path = os.path.join(self.root, "pid")
+        self.assertTrue(os.path.exists(pid_path), "the sh never recorded its sleeper")
+        with open(pid_path) as f:
+            sleeper = int(f.read().strip())
+        self.assertTrue(_gone(sleeper, 5), "the sleeper survived the timeout's group kill")
+
+    def test_teardown_kills_a_group_the_test_left_running(self):
+        # Nothing here kills the sleeper. A cleanup runs after tearDown, so the check reads tearDown's kill.
+        rc, out, err = run_probe("/bin/sh", ["-c", LEAVE_A_SLEEPER], dict(os.environ), self.root, 10, self.procs)
+        self.assertEqual(rc, 0, err)
+        self.addCleanup(self._assert_gone, int(out.strip()), "tearDown left the sleeper running")
+
+    def _assert_gone(self, pid, why):
+        self.assertTrue(_gone(pid, 5), why)
+
+    def test_run_probe_reads_stdin_from_dev_null(self):
+        # The test's own fd 0 carries bytes for the duration of the run: pytest's capture puts /dev/null
+        # on fd 0 during a test, so a run_probe that inherited stdin would otherwise look the same as one
+        # reading /dev/null. `cat` on an inherited stdin would echo the bytes before `eof`.
+        r, w = os.pipe()
+        os.write(w, b"inherited\n"); os.close(w)
+        saved = os.dup(0)
+        try:
+            os.dup2(r, 0)
+            rc, out, err = run_probe("/bin/sh", ["-c", "cat; echo eof"], dict(os.environ), self.root, 10, self.procs)
+        finally:
+            os.dup2(saved, 0); os.close(saved); os.close(r)
+        self.assertEqual((rc, out.strip()), (0, "eof"), err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Symptom

`tests/test_cli_control_protocol_probe.py`, the opt-in probe behind `ROMP_CLI_PROBE_LIVE=1`, hands the Claude Code CLI every `ANTHROPIC_*` variable the developer's shell exports, while its docstring says the child has no key. Its `--bg` refusal test runs a real prompt with the test's stdin inherited, no process group and nothing for tearDown to kill: had the CLI accepted `--bg --print` (the regression the test exists to catch), the prompt would have run under a daemon, on that credential, beyond the 60 s timeout's reach. In `docs/reference.md`, the paragraph on what the CLI does when its parent goes quiet says a hook callback's timeout ends with a tool-result error and the turn going on, which does not hold for the `UserPromptSubmit` hook romp registers; the same paragraph says the module pins two facts where it pins three.

## Cause

`hermetic_env` filtered `CLAUDECODE`, `CLAUDE_*`, `ROMP_*` and `XDG_*` only. Under pytest, `tests/conftest.py` pops `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN`, which hid the gap; a proxy's `ANTHROPIC_BASE_URL` and `ANTHROPIC_CUSTOM_HEADERS` still passed, and the module's own `__main__` loads no conftest. The `--bg` test used `subprocess.run` with a prompt argument no assertion reads. The hook-timeout sentence records a `PreToolUse` measurement (the only hook kind the module registers) without naming the kind; in the 2.1.266 CLI the hook dispatch converts a timed-out `UserPromptSubmit` or `UserPromptExpansion` callback into a blocking decision that suppresses the prompt, and hands every other event's timeout to that event's own handler. The count of two predates the module's third pinned fact, the idle exit on stdin end-of-file.

## Fix

- `hermetic_env` drops every `ANTHROPIC_*` name, by prefix as `kernel/judge.py` does for the codex judge: the CLI grows names, and the harmless ones may go too. The docstrings say what the scrub controls (the environment and the config directory; managed settings outside the config directory are not the test's to control) and that a group kill does not reach a daemon that left its group.
- Two module-level helpers. `kill_group(p)` is the group SIGKILL `StreamCli.kill` did, then a reap and a close of the pipes (never a drain: a daemon that left the group can hold the write ends). `run_probe(exe, argv, env, cwd, timeout, procs)` runs a command with stdin at `/dev/null` in a process group of its own, appends the Popen to `procs` before waiting, and on timeout kills the group and re-raises `TimeoutExpired`.
- `ControlProtocolPins.setUp` starts `self.procs`; `tearDown` kills every recorded group. The `--bg` test drops the prompt and runs through `run_probe`; its assertions are unchanged.
- `docs/reference.md`: the hook-timeout sentence names the measured kind, states the `UserPromptSubmit` outcome with its version (2.1.266) and source (read from the CLI's hook dispatch, not measured), notes that romp registers that hook and sets no matcher `timeout`, and marks the other hook kinds unmeasured; the probe sentence counts three facts. The rest of the paragraph is rewrapped at 80 columns with its words unchanged (`git diff --word-diff` shows the two sentences alone).

## Tests

Two new classes in the module, outside the live gate, so they run on CI and start no CLI:

- `HermeticEnvPins.test_drops_every_anthropic_claude_romp_and_xdg_name` plants four `ANTHROPIC_*` names (a key, a token, a base URL, a custom header; the values are three plain words and a loopback URL, all short, none credential-shaped) plus `CLAUDECODE`, a `CLAUDE_*`, a `ROMP_*` and `XDG_DATA_HOME`, calls `hermetic_env`, and asserts none reaches the child and that `CLAUDE_CONFIG_DIR` and `XDG_STATE_HOME` point under the test root; assertions render names, never the mapping. Before the change it fails listing the `ANTHROPIC_*` names kept.
- `ProbeRunPins.test_run_probe_takes_its_own_group_and_kill_group_reaches_an_orphan`: `/bin/sh -c` starts a background `sleep` with its descriptors redirected (so `communicate` sees end-of-file) and prints its pid; the sleeper's pgid is the sh's pid, and after `kill_group` the sleeper is gone (reaped, or a zombie per `/proc/<pid>/stat`, polled up to 5 s). Fails without `start_new_session` (the pgid is the test runner's).
- `ProbeRunPins.test_run_probe_kills_the_group_when_the_timeout_expires`: the sh records its sleeper's pid and waits on it; `run_probe` raises `TimeoutExpired` at 3 s, the sh has exited, its pipes are closed and the sleeper is gone. Fails when `kill_group` stops closing the pipes, and without `start_new_session`.
- `ProbeRunPins.test_teardown_kills_a_group_the_test_left_running`: the test leaves the sleeper running and asserts from a cleanup, which runs after tearDown, that it is gone. Fails when tearDown stops killing the recorded groups.
- `ProbeRunPins.test_run_probe_reads_stdin_from_dev_null`: for the duration of the run the test's own fd 0 is a pipe carrying bytes (pytest's capture otherwise puts `/dev/null` on fd 0, which would make an inherited stdin look the same as `/dev/null`); `cat; echo eof` prints `eof` alone at once. With `run_probe` inheriting stdin it fails with `inherited` echoed first, under pytest and under a bare unittest run alike.
- Before the change the four `ProbeRunPins` tests fail with `NameError` on `run_probe`. Module before: 5 failed, 2 skipped; after: 5 passed, 2 skipped (the live pair skips with the gate unset), the same under `-n 2`, under `-s` with a pipe on the runner's stdin, and as a bare `python3 tests/test_cli_control_protocol_probe.py` run (7 tests, 2 skipped).
- The live pair keeps its assertions and was not run here. Dropping the prompt changes the argv the CLI validates; the `--bg`/`--print` conflict is a flag check and `--input-format stream-json` takes its prompt from stdin, so the refusal text should not change, but one live run with a `claude` on PATH would confirm it.
- Full suite (`pytest -n 6 tests/`, extension dependencies installed so the served-page tests run): 11691 passed, 45 skipped, 1744 subtests passed, 1 failed. The failure is `tests/test_dashboard_reload_served.py::ServedAutoReload::test_build_drift_reloads_after_the_gesture_ends_and_a_restart_reloads_too`, a served-page browser test of the dashboard's reload that reads none of the two files this change touches; run alone right after, it passes (1 passed in 23 s).

Tier: docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)