### PR TITLE
Lease heartbeat: the beat loop is stepped by a test through sleep and clock seams; a refused heartbeat thread leaves the session unleased instead of crashing its connect

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -8742,14 +8742,30 @@ class SdkBackend:
         lease = {"sid": str(sess.sid), "fsid": str(sess.resume_sid or sess.sid), "name": str(sess.name),
                  "pid": int(pid), "start": start, "holder": self._lease_holder(), "version": self.code_version,
                  "spawnedAt": int(now), "t": now}
+        refused = None
         with self._lock:
             self._leases[str(sess.sid)] = (sess, lease)
             if self._lease_thread is None or not self._lease_thread.is_alive():
                 # started UNDER the lock: an unstarted thread reads as not alive, so a second session
                 # connecting in the first's write window would otherwise adopt it too and both would call
                 # start() on one Thread (RuntimeError out of the connect; the review of T305, 2026-09-10)
-                self._lease_thread = threading.Thread(target=self._lease_beat_loop, name="sdk-lease-beat", daemon=True)
-                self._lease_thread.start()
+                t = threading.Thread(target=self._lease_beat_loop, name="sdk-lease-beat", daemon=True)
+                try:
+                    t.start()
+                except (RuntimeError, OSError) as e:   # the OS refused a thread ("can't start new thread")
+                    # Raised from here, inside the connect and after the handshake, the connect's handler
+                    # would crash-heal a CLI that is up and answering. This session runs unleased instead,
+                    # the missing-pid posture above: its entry goes, so no beat ever claims it, and the
+                    # slot stays empty so the next open tries the start again. Said outside the lock.
+                    self._leases.pop(str(sess.sid), None)
+                    self._lease_thread = None
+                    refused = e
+                else:
+                    self._lease_thread = t
+        if refused is not None:
+            self._log("lease (%s): the heartbeat thread could not start (%s); the session runs unleased and a boot "
+                      "judges it by parentage" % (sess.name, refused), problem=True)
+            return
         try:
             write_lease(self.state_dir, lease)
         except Exception as e:
@@ -8785,12 +8801,16 @@ class SdkBackend:
                 self._log("lease (%s): heartbeat write failed: %s" % (sess.name, err), problem=True)
         return len(items)
 
-    def _lease_beat_loop(self) -> None:
+    def _lease_beat_loop(self, sleep=None, now=None) -> None:
         """The heartbeat thread: one beat every LEASE_HEARTBEAT_S while any lease is held; exits when
-        none is (the next _lease_open starts a new one)."""
+        none is (the next _lease_open starts a new one). `sleep` and `now` are the test seams, resolved
+        at call time as _end_cli_tree's are, so a test steps a beat, the empty exit and the restart with
+        no second behind them; the thread target passes neither, so the kernel beats on the real clock."""
+        sleep = sleep or time.sleep
+        now = now or time.time
         while True:
-            time.sleep(LEASE_HEARTBEAT_S)
-            if self._lease_beat_once() == 0:
+            sleep(LEASE_HEARTBEAT_S)
+            if self._lease_beat_once(now=now()) == 0:
                 with self._lock:
                     if not self._leases:
                         self._lease_thread = None

--- a/tests/test_sdk_lifecycle_hardening.py
+++ b/tests/test_sdk_lifecycle_hardening.py
@@ -454,6 +454,141 @@ class LeaseRules(unittest.TestCase):
         self.assertIsNotNone(sb.read_lease(d, a.sid))
         self.assertEqual(be._lease_beat_once(), 1)
 
+    def test_the_heartbeat_loop_beats_on_its_cadence_exits_on_an_empty_census_and_restarts_at_the_next_open(self):
+        # The loop itself, executed: every other test here patches it away, because the real one sleeps a
+        # beat (3 s) before anything happens. Its sleep and clock are seams (the _end_cli_tree shape), so
+        # a beat, the exit on an empty census and the restart at the next open are stepped on this thread
+        # with no second behind them; the only real thread is the recorder the restart runs, joined.
+        # Whether the loop returns never rests on which sleep it called: the close that empties the census
+        # sits on the BEAT side, and every beat checks that one recorded sleep preceded it, so a loop that
+        # slept elsewhere (the seam bypassed, a default bound at the definition) fails at its first beat,
+        # one real beat later at worst, instead of hanging the run. The recorder counts this thread only
+        # and hands any other thread the real sleep (test_kernel_update's T230b: a process-global
+        # time.sleep patch that a foreign thread consumed hung five CI jobs).
+        real_loop, real_sleep = sb.SdkBackend._lease_beat_loop, time.sleep    # kept before any patch
+        d = tempfile.mkdtemp(); self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sess = types.SimpleNamespace(sid=self.RSID, name="web", resume_sid=self.SID)
+        client = types.SimpleNamespace(_transport=types.SimpleNamespace(_process=types.SimpleNamespace(pid=os.getpid())))
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self_: None):  # that thread exits at once
+            be._lease_open(sess, client)
+        be._lease_thread.join(5)
+        lease0 = sb.read_lease(d, self.RSID)
+        clock, slept, struck, main = [lease0["t"] + 100.0], [], [], threading.get_ident()
+        def sleep(s):
+            if threading.get_ident() != main:
+                return real_sleep(s)                  # a foreign thread never feeds the recorder
+            slept.append(s); clock[0] += s
+            if len(slept) > 5:
+                raise AssertionError("the loop did not exit on an empty census")
+        real_beat = be._lease_beat_once
+        def beat(now, then):
+            # the loop's beat: one recorded sleep before it, the real beat, then the stage's step
+            struck.append(now)
+            if len(slept) != len(struck):
+                raise AssertionError("the loop slept on something other than its seam")
+            n = real_beat(now=now)
+            then(n)
+            return n
+        # a beat on the cadence, stamped from the loop's clock, then the exit: the loop is "this thread"
+        stamps = []
+        def close_after_the_first(n):
+            if len(struck) == 1:                      # the first beat has landed: the session ends mid-loop
+                stamps.append(sb.read_lease(d, self.RSID)["t"]); be._lease_close(sess)
+        be._lease_thread = threading.current_thread()
+        with mock.patch.object(be, "_lease_beat_once", lambda now=None: beat(now, close_after_the_first)):
+            real_loop(be, sleep=sleep, now=lambda: clock[0])
+        self.assertEqual(slept, [sb.LEASE_HEARTBEAT_S, sb.LEASE_HEARTBEAT_S])
+        self.assertEqual(struck, [lease0["t"] + 100.0 + sb.LEASE_HEARTBEAT_S, lease0["t"] + 100.0 + 2 * sb.LEASE_HEARTBEAT_S],
+                         "each beat reads the loop's clock after its sleep")
+        self.assertEqual(stamps, struck[:1], "the beat stamps the loop's clock, not time.time()")
+        self.assertIsNone(be._lease_thread, "the exit hands the thread slot back")
+        self.assertEqual(be._lease_beat_once(), 0)
+        # the exit handshake: a census that reads 0 is re-checked under the lock, so an open landing between
+        # the beat and the check keeps the loop alive (its thread is this one, alive, so that open starts
+        # none); the beat after it ends that session first, so its census reads 0 again and the loop exits
+        sess2 = types.SimpleNamespace(sid="11111111-2222-3333-4444-0000000000c1", name="api", resume_sid=None)
+        opened, started = [], []
+        def open_at_the_zero(n):
+            if n == 0 and not opened:
+                opened.append(True); be._lease_open(sess2, client)
+        def beat_around_the_open(now=None):
+            if opened:
+                be._lease_close(sess2)
+            return beat(now, open_at_the_zero)
+        del slept[:]; del struck[:]
+        be._lease_thread = threading.current_thread()
+        with mock.patch.object(be, "_lease_beat_once", beat_around_the_open), \
+             mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self_: started.append(1)):
+            real_loop(be, sleep=sleep, now=lambda: clock[0])
+        self.assertEqual(slept, [sb.LEASE_HEARTBEAT_S, sb.LEASE_HEARTBEAT_S], "alive past the 0: the re-check saw the open")
+        self.assertEqual((opened, started), ([True], []), "the open adopted the live loop and started no thread")
+        self.assertIsNone(be._lease_thread)
+        self.assertIsNone(sb.read_lease(d, sess2.sid))
+        # the restart: with the slot empty, the next open starts a new heartbeat thread, under its name
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self_: started.append(threading.current_thread().name)):
+            be._lease_open(sess, client)
+            be._lease_thread.join(5)
+        self.assertEqual(started, ["sdk-lease-beat"])
+        self.assertIsNotNone(sb.read_lease(d, self.RSID))
+        # the seams default to time.sleep and time.time, resolved at the call and not at the definition (the
+        # thread target passes neither): a stand-in for the module's `time` name, this module only and never
+        # the process-global functions, is what the loop called with no seams then runs on
+        clockwork = types.SimpleNamespace(**{k: getattr(time, k) for k in dir(time) if not k.startswith("_")})
+        clockwork.sleep, clockwork.time = sleep, lambda: clock[0]
+        del slept[:]; del struck[:]; del stamps[:]
+        be._lease_thread = threading.current_thread()
+        with mock.patch.object(be, "_lease_beat_once", lambda now=None: beat(now, close_after_the_first)), \
+             mock.patch.object(sb, "time", clockwork):
+            real_loop(be)
+        self.assertEqual(slept, [sb.LEASE_HEARTBEAT_S, sb.LEASE_HEARTBEAT_S])
+        self.assertEqual(struck, [clock[0] - sb.LEASE_HEARTBEAT_S, clock[0]], "the default clock is time.time, read at the call")
+        self.assertEqual(stamps, struck[:1])
+        self.assertIsNone(be._lease_thread)
+        self.assertEqual(sb.list_leases(d), [])
+
+    def test_a_heartbeat_thread_the_os_refuses_leaves_the_session_unleased_with_a_problem_and_no_raise(self):
+        # The heartbeat's Thread.start() runs inside the connect, after the handshake; an OS that refuses
+        # a thread (CPython's RuntimeError "can't start new thread") used to raise out of _lease_open,
+        # and the connect's handler then crash-healed a CLI that was up and answering. The session runs
+        # unleased instead, said once as a problem (the missing-pid posture), and the next open tries again.
+        # A second session holds a lease throughout, its heartbeat thread finished (the no-op loop), so the
+        # refusal is seen to drop this session's entry alone and to empty a slot that held a thread.
+        d = tempfile.mkdtemp(); self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
+        sess = types.SimpleNamespace(sid=self.RSID, name="web", resume_sid=self.SID)
+        held = types.SimpleNamespace(sid="11111111-2222-3333-4444-0000000000c2", name="api", resume_sid=None)
+        client = types.SimpleNamespace(_transport=types.SimpleNamespace(_process=types.SimpleNamespace(pid=os.getpid())))
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self_: None):  # that thread exits at once
+            be._lease_open(held, client)
+        be._lease_thread.join(5)
+        self.assertFalse(be._lease_thread.is_alive(), "a finished thread sits in the slot: the next open must start one")
+        base = len(be.problems())
+        refusals = (RuntimeError("can't start new thread"), OSError(11, "Resource temporarily unavailable"))
+        for n, err in enumerate(refusals, 1):
+            class Refused(threading.Thread):
+                def start(self_):
+                    raise err
+            with mock.patch.object(sb.threading, "Thread", Refused):    # the window is this one call
+                be._lease_open(sess, client)                             # and it must not raise
+            self.assertIsNone(sb.read_lease(d, self.RSID), "no file: the session runs unleased")
+            self.assertEqual((set(be._leases), be._lease_thread), ({held.sid}, None),
+                             "this session's entry alone goes, and the slot is empty for the next open")
+            self.assertIsNotNone(sb.read_lease(d, held.sid), "the other session's lease stands")
+            self.assertEqual(len(be.problems()) - base, n)
+            text = be.problems()[-1]["text"]
+            self.assertIn("runs unleased", text); self.assertIn(str(err), text)
+        # not latched: the next open starts the heartbeat and writes the lease
+        started = []
+        with mock.patch.object(sb.SdkBackend, "_lease_beat_loop", lambda self_: started.append(threading.current_thread().name)):
+            be._lease_open(sess, client)
+            be._lease_thread.join(5)
+        self.assertEqual(started, ["sdk-lease-beat"])
+        self.assertIsNotNone(sb.read_lease(d, self.RSID))
+        self.assertEqual(len(be.problems()) - base, len(refusals), "a start that worked says nothing")
+        be._lease_close(sess); be._lease_close(held)
+        self.assertEqual(sb.list_leases(d), [])
+
     def test_source_pins_the_connect_writes_the_close_drops_and_the_cadence_is_the_drain_holds(self):
         src = open(os.path.join(BIN, "romp_sdk_backend.py")).read()
         self.assertIn("self.backend._lease_open(self, client)", src)


### PR DESCRIPTION
Two changes in the lease heartbeat: the beat loop takes sleep and clock seams and is executed by a test, and a heartbeat thread the OS refuses no longer crashes the session's connect.

## Symptom

A session whose lease heartbeat thread the OS refuses to start dies at its connect. `Thread.start()` runs in `_lease_open`, inside the connect and after the handshake (`connected = True`), with no guard. CPython reports the refusal as `RuntimeError("can't start new thread")`; the connect's handler re-raises it, `_run` logs "sdk session X crashed", and `_on_session_gone` heals away a CLI that was up and answering. Rare (an OS thread limit), but the cost is a working session.

Separately, the heartbeat loop `_lease_beat_loop` was executed by no test. It called `time.sleep(LEASE_HEARTBEAT_S)` directly, so the three tests that reach it all patch it away, and its exit handshake (a census of 0, then the re-check of the held leases under the lock before the thread slot is cleared) had no pin. The post-merge review of #1342 named both as follow-ups.

## Cause

- `_lease_open` started the heartbeat thread under the lock with nothing around `start()`, and the connect path has no handler between that call and the one that crash-heals.
- `_lease_beat_loop` had no seams: the sleep and the clock were the module's `time.sleep` and `time.time` by name, so the loop could not be stepped without three real seconds per beat.

## Fix

`kernel/sdk_backend.py`, two hunks:

- `_lease_beat_loop(self, sleep=None, now=None)`: the seams resolve at call time (`sleep = sleep or time.sleep`, `now = now or time.time`), the shape `_end_cli_tree` uses, and the beat is `self._lease_beat_once(now=now())`. The thread target still passes nothing, so the kernel beats on the real clock; the exit handshake is unchanged.
- `_lease_open`: the Thread is created into a local and `start()` sits in a `try`. On `RuntimeError` or `OSError` this session's entry is popped from the held leases and the thread slot is set to None, both under the lock; after the lock is released a problem row says the heartbeat thread could not start and the session runs unleased and a boot judges it by parentage, and `_lease_open` returns before `write_lease`, so no file is written. That is the posture the missing-pid branch already takes, reused rather than a new `lease.*` anomaly kind (which would need a `LEASE_ANOMALIES` entry and a line in the reference's lease paragraph). On success `_lease_thread = t`, as before.

A choice to weigh: after a refusal only this session's entry is dropped. Other held leases stay in `_leases` with no heartbeat until the next `_lease_open` retries the start (the slot is None, so it does). Today nothing reads a beat while the kernel lives (`lease_state` runs from `_boot_reconcile`, when this kernel as holder is gone anyway; `find_session_cli` checks pid and start identity only), so this costs nothing now; a per-session host that reads beats in-life may prefer every held lease dropped, or the start retried on its own. Said here so the choice is visible.

## Tests

`tests/test_sdk_lifecycle_hardening.py::LeaseRules`, two tests. Neither sleeps for real, signals a process or spawns a CLI: the client is a `SimpleNamespace` whose pid is the test's own, and the only real threads are no-op recorders joined with a timeout.

- `test_the_heartbeat_loop_beats_on_its_cadence_exits_on_an_empty_census_and_restarts_at_the_next_open` runs the real loop on the test thread through the seams: a beat on the cadence stamped from the loop's clock (not `time.time()`), the exit on an empty census handing the thread slot back, an open landing between the beat's 0 and the lock's re-check keeping the loop alive and starting no thread, the restart at the next open under the thread's name, and the defaults resolving at the call to the module's `time.sleep` and `time.time` (a stand-in for the module's `time` name is patched, this module only, never the process-global functions; the recorder counts the test thread only and hands any other thread the real sleep). Whether the loop returns never rests on which sleep it called: the close that empties the census sits on the beat side, and every beat checks that one recorded sleep preceded it, so a loop that slept elsewhere (the seam bypassed, a default bound at the definition) fails at its first beat, one real beat later at worst, instead of hanging the run; a loop that never exits fails on the recorder's count. Before the change: `TypeError: _lease_beat_loop() got an unexpected keyword argument 'sleep'`.
- `test_a_heartbeat_thread_the_os_refuses_leaves_the_session_unleased_with_a_problem_and_no_raise` opens a second session under the no-op loop and joins its thread, so a lease is held and a finished thread sits in the slot, then patches `threading.Thread` for one `_lease_open` call with a subclass whose `start()` raises, once `RuntimeError("can't start new thread")` and once an `OSError`: no raise, no lease file for this session, the other session's entry and file untouched, the slot emptied, one problem row each naming the refusal and "runs unleased"; then the real Thread starts at the next open and the lease is written (the refusal is not latched). Before the change: the `RuntimeError` escapes `_lease_open` and the test errors.

Both fail before the change and pass after; the module (63 tests) is green alone and under pytest-xdist. Checked by mutation, each read in seconds: the slot reset or the pop dropped from the refusal branch (a `clear()` in its place), the guard or the early return removed, either default bound at the definition, either seam bypassed, the re-check under the lock dropped, and a loop that never exits. Full suite on this head (`pytest -n 6 tests/`, the served-page modules executing): 11672 passed, 45 skipped, 1744 subtests passed, 1 failed. The failure is `tests/test_paste_to_focus_browser.py::ServedPaste::test_a_trusted_paste_after_selecting_transcript_text_lands_in_the_box`, a served-page browser test of the chat pane's paste that reads none of the two files this change touches; run alone right after, it passes (1 passed in 9 s).

## Tier

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)