### PR TITLE
Gear: a greyed Fast mode box fades the checkbox alone, so its hint stays legible

### DIFF
--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -264,7 +264,7 @@ class JudgeArgvBilling(_JudgeAuthBase):
         self.assertNotIn("--settings", jd._judge_cmd("sonnet", "SYS", None), "the default: no auth argument")
 
     def test_a_fast_login_billed_call_rides_one_overlay_with_both_keys(self):
-        # `--settings` takes ONE value. With Fast judging on (STATE/judge-fast "on"), an Opus login-billed call
+        # `--settings` takes ONE value. With the triage tier's Fast mode on (STATE/judge-fast "on"), an Opus login-billed call
         # carries the fastMode opt-in and the helper suppression in one JSON overlay; a login-billed call on a
         # model that cannot run fast keeps HELPER_OFF byte for byte; a key-billed or unpicked Opus call carries
         # the opt-in alone, and the helper key never appears in it.
@@ -490,7 +490,7 @@ class JudgeRunBilling(_JudgeAuthBase):
         self.assertEqual(seen["cmd"][i:i + 2], HELPER_OFF)
 
     def test_a_fast_login_pick_on_opus_launches_with_one_overlay_and_logs_the_readback(self):
-        # end to end through _judge_run: Fast judging on, a login pick, an Opus model. The child gets ONE
+        # end to end through _judge_run: the triage tier's Fast mode on, a login pick, an Opus model. The child gets ONE
         # --settings overlay carrying both keys, the login tokens, no key; the usage row keeps the envelope's
         # fast_mode_state, the CLI's own word on whether fast engaged.
         jd._LOGIN_AUTH_ENV_FN = lambda: {"CLAUDE_CODE_OAUTH_TOKEN": "synthetic-login-token"}

--- a/tests/test_judge_settings_sync.py
+++ b/tests/test_judge_settings_sync.py
@@ -74,7 +74,7 @@ class ApplySettings(unittest.TestCase):
                          "garbage never reaches the files or `claude --model`")
 
     def test_judge_fast_applies_and_reports_raw(self):
-        # Fast judging rides the same cross-kernel door as the judge tiers: "on" | "off", off by default,
+        # the judges' Fast mode rides the same cross-kernel door as the judge tiers: "on" | "off", off by default,
         # answered RAW, a value outside the pair ignored and visible in the ack
         self.assertEqual(km._apply_judge_settings({})["judgeFast"], "off")
         res = km._apply_judge_settings({"judgeFast": "on"})
@@ -241,7 +241,7 @@ class OneHopNeverALoop(unittest.TestCase):
                      'args=({"commentEffort": str(msg["effort"]), "gt": _jgt},)',
                      'args=({"commentFast": str(msg["fast"]), "gt": _jgt},)',
                      'args=({"tmuxBackend": _tbv, "gt": _jgt},)',   # T288
-                     'args=({_ffield: _jfv, "gt": _jgt},)'):    # Fast judging
+                     'args=({_ffield: _jfv, "gt": _jgt},)'):    # Fast mode, one field per judge tier
             self.assertIn(frag, self.src, frag)
         self.assertGreaterEqual(self.src.count("if _jgt is not None:"), 12,
                                 "every judge-tier fan-out is gated on the pick actually applying")

--- a/tests/test_kernel_judge_model.py
+++ b/tests/test_kernel_judge_model.py
@@ -177,7 +177,7 @@ class _InlineThread:
 
 
 class FastJudging(unittest.TestCase):
-    """Fast judging: STATE/judge-fast ("on" | "off", off by default) adds the CLI's fastMode opt-in to
+    """Fast mode for the judges: STATE/judge-fast ("on" | "off", off by default) adds the CLI's fastMode opt-in to
     judge calls whose model is Opus. The CLI refuses fast mode to a non-interactive client unless the
     flag-settings layer carries that exact key (sdk_backend.flag_settings_path is the sessions' twin),
     and fast mode is an Opus-only preview, so the key rides only a call whose model reads as the opus

--- a/tests/test_kernel_session_flags.py
+++ b/tests/test_kernel_session_flags.py
@@ -855,7 +855,7 @@ class WsFlagsMustBeBooleans(unittest.TestCase):
             ("setThinkingSummaries", "enabled", {}, km._thinking_summaries_on, warn),
             ("setConserve", "enabled", {}, km._conserve_on, warn),
             ("setTmuxBackend", "enabled", {}, lambda: km.jd._state_str("tmux-backend", "off") == "on", warn),   # T288
-            ("setJudgeFast", "enabled", {}, lambda: km.jd._state_str("judge-fast", "off") == "on", warn),   # Fast judging
+            ("setJudgeFast", "enabled", {}, lambda: km.jd._state_str("judge-fast", "off") == "on", warn),   # Fast mode, the triage tier's box
             ("setDistillFast", "enabled", {}, lambda: km.jd._state_str("distill-fast", "off") == "on", warn),   # T300: a box per tier
             ("setIndexFast", "enabled", {}, lambda: km.jd._state_str("index-fast", "off") == "on", warn),
             ("setGlobalRetryPaused", "value", {}, km._retry_paused_on, warn),

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -132,7 +132,13 @@ class SettingsSectionsTest(unittest.TestCase):
             row = row[:row.index("</div>")]
             self.assertIn("<label class=rs-fastin id=rs-%s-wrap><input type=checkbox id=rs-%s>Fast mode<span class=rs-mixed hidden></span>" % (tier, tier), row)
             self.assertIn("<span class=rs-sub id=rs-%s-sub>" % tier, row)
-        self.assertIn("#rsettings .rs-fastin.rs-off {", _gear_css_src())
+        css = _gear_css_src()
+        self.assertIn("#rsettings .rs-fastin.rs-off {", css)
+        # the greyed look fades the BOX alone: opacity on the whole label faded the hint span inside it too, and made
+        # the label a stacking context the rows beneath paint over, so the reason the box was greyed read dim and overdrawn
+        self.assertIn("#rsettings .rs-fastin.rs-off input { opacity: .4;", css)
+        self.assertNotRegex(css, r"\.rs-fastin\.rs-off \{[^}]*opacity", "no opacity on the label: the hint inside it would fade with it")
+        self.assertRegex(css, r"\.rs-fastin\.rs-off \{[^}]*color: var\(--text-faint", "the word greys by token, not by fading")
 
     def test_collapse_gaps_is_wired_to_the_shared_collapseGaps_setting(self):
         # the gear JS persists/loads romp:settings.collapseGaps; the timeline reads it (see romp-timeline-view.js)

--- a/ui/webview/gear-judge-fast-browser.test.ts
+++ b/ui/webview/gear-judge-fast-browser.test.ts
@@ -3,10 +3,12 @@
 // never changes, or a gate that reads an unfilled select (a painted select reads its first option before /version
 // answers). So the gear is opened against a fake kernel (the /models, /version, /tunnels, /palette routes answered
 // with synthetic payloads), and the DOM is read after each gesture: a fill with triage on Opus, distilling following
-// triage and indexing on Haiku greys only the indexing box, with the flags shown as stored; a Triage pick of Sonnet
-// greys the triage and distilling boxes, keeps them checked, swaps their hints, and posts nothing for them; picking
-// Opus again ungreys them with the hints back; a checked box on a capable model whose last fast ask the CLI declined
-// shows the refusal; ticking a box posts its op; pinning Distilling to Opus keeps its box live under a Sonnet triage.
+// triage and indexing on Haiku greys only the indexing box, with the flags shown as stored, the greyed look on the
+// box alone (its hint's ancestors all opaque, its word in the section grey, its hint unfaded and in the colour a live
+// box's hint shows); a Triage pick of Sonnet greys the triage and distilling boxes, keeps them checked, swaps their
+// hints, and posts nothing for them; picking Opus again ungreys them with the hints back; a checked box on a capable
+// model whose last fast ask the CLI declined shows the refusal; ticking a box posts its op; pinning Distilling to
+// Opus keeps its box live under a Sonnet triage.
 // Skips with a stated reason without a playwright browser (CI installs none), the md-sanitize-browser.test.ts
 // pattern. Synthetic values only.
 import { test } from "node:test";
@@ -52,7 +54,7 @@ let pw: any = null;
 try { pw = requireCjs("playwright"); } catch { pw = null; }
 
 type Snap = { disabled: Record<string, boolean>; off: Record<string, boolean>; opacity: Record<string, string>;
-  checked: Record<string, boolean>; hint: Record<string, string> };
+  hintFade: Record<string, string>; wordColor: Record<string, string>; checked: Record<string, boolean>; hint: Record<string, string> };
 
 async function withGear(t: any, body: (page: any, errors: string[]) => Promise<void>): Promise<void> {
   if (!pw) { t.skip("playwright is not installed under vscode-extension; the browser leg needs it (CI installs no browsers)"); return; }
@@ -90,15 +92,23 @@ async function withGear(t: any, body: (page: any, errors: string[]) => Promise<v
 
 const snap = (page: any): Promise<Snap> => page.evaluate(() => {
   const disabled: Record<string, boolean> = {}, off: Record<string, boolean> = {}, opacity: Record<string, string> = {};
+  const hintFade: Record<string, string> = {}, wordColor: Record<string, string> = {};
   const checked: Record<string, boolean> = {}, hint: Record<string, string> = {};
   for (const tier of ["judgefast", "distillfast", "indexfast"]) {
     const box = document.getElementById("rs-" + tier) as HTMLInputElement;
     const wrap = document.getElementById("rs-" + tier + "-wrap") as HTMLElement;
     const sub = document.getElementById("rs-" + tier + "-sub") as HTMLElement;
-    disabled[tier] = box.disabled; off[tier] = wrap.classList.contains("rs-off"); opacity[tier] = getComputedStyle(wrap).opacity;
+    disabled[tier] = box.disabled; off[tier] = wrap.classList.contains("rs-off");
+    opacity[tier] = getComputedStyle(box).opacity;   // the box's own: the greyed look fades the box alone
+    // the fade the hint is seen through: opacity is not inherited, so the hint's own computed value reads 1 whatever
+    // its ancestors do; the most faded ancestor below the settings backdrop is the one the eye sees the hint through
+    let fade = 1;
+    for (let el = sub.parentElement; el && el.id !== "rsettings"; el = el.parentElement) fade = Math.min(fade, parseFloat(getComputedStyle(el).opacity));
+    hintFade[tier] = String(fade);
+    wordColor[tier] = getComputedStyle(wrap).color;   // the label's colour is the word's: "Fast mode" is a bare text node
     checked[tier] = box.checked; hint[tier] = sub.textContent || "";
   }
-  return { disabled, off, opacity, checked, hint };
+  return { disabled, off, opacity, hintFade, wordColor, checked, hint };
 });
 const posts = (page: any, type: string): Promise<any[]> => page.evaluate((ty: string) => (window as any).__posts.filter((m: any) => m && m.type === ty), type);
 // the judge selects are display:none behind versionMenu's button; a pick is what the user does: open the menu
@@ -120,12 +130,28 @@ test("each tier's box greys on its own effective model, keeps its value, says wh
     let s = await snap(page);
     assert.deepEqual(s.disabled, { judgefast: false, distillfast: false, indexfast: true }, "greyed for the Haiku tier only");
     assert.deepEqual(s.off, { judgefast: false, distillfast: false, indexfast: true });
-    assert.equal(s.opacity.indexfast, "0.4", "the greyed look renders"); assert.equal(s.opacity.judgefast, "1");
+    assert.equal(s.opacity.indexfast, "0.4", "the greyed look renders on the box"); assert.equal(s.opacity.judgefast, "1");
+    assert.deepEqual(s.hintFade, { judgefast: "1", distillfast: "1", indexfast: "1" }, "the hint's ancestors are all opaque: the greyed reason stays legible");
+    assert.notEqual(s.wordColor.indexfast, s.wordColor.judgefast, "the greyed word takes the section grey; the live word keeps the row's colour");
     assert.deepEqual(s.checked, { judgefast: true, distillfast: true, indexfast: true }, "the boxes reflect the kernel's raw flags, greyed or not");
     assert.match(s.hint.judgefast, /^This tier's judge calls run in Claude Code's fast mode/, "a live box: the description");
     assert.match(s.hint.distillfast, /^Fast mode was declined by Claude Code for the last distilling call \(sdk_opt_in_required\)/, "a declined ask: the CLI's reason");
     assert.match(s.hint.indexfast, /^Fast mode is Opus-only, and this tier is not on Opus\./, "a greyed box: why");
     for (const ty of ["setJudgeFast", "setDistillFast", "setIndexFast"]) assert.deepEqual(await posts(page, ty), [], `${ty}: a fill posts nothing`);
+    // hovering the greyed box shows its hint unfaded, in the colour a live box's hint shows: the label's grey stops at
+    // the word, and no rule fades the hint itself (its own opacity reads 1 before the fix too, so this is a guard)
+    const hovered = (tier: string) => page.evaluate((id: string) => {
+      const sub = document.getElementById("rs-" + id + "-sub") as HTMLElement, wrap = document.getElementById("rs-" + id + "-wrap") as HTMLElement;
+      return { display: getComputedStyle(sub).display, color: getComputedStyle(sub).color, opacity: getComputedStyle(sub).opacity, word: getComputedStyle(wrap).color };
+    }, tier);
+    await page.hover("#rs-indexfast-wrap");
+    const shown = await hovered("indexfast");
+    await page.hover("#rs-judgefast-wrap");
+    const live = await hovered("judgefast");
+    assert.equal(shown.display, "block", "hovering the greyed box shows its hint");
+    assert.equal(shown.opacity, "1", "the hint itself is not faded");
+    assert.notEqual(shown.color, shown.word, "the hint keeps its own colour, not the greyed word's");
+    assert.equal(live.display, "block"); assert.equal(shown.color, live.color, "the greyed box's hint shows in the colour a live box's hint does");
 
     // 2. the user picks Sonnet for triage: the model post, both dependent boxes grey and KEEP their value, hints swap, no box post
     await pickModel(page, "rs-judgemodel", "Sonnet");

--- a/ui/webview/gear.css
+++ b/ui/webview/gear.css
@@ -83,8 +83,11 @@ body.rs-lifted.rs-pane-gone::before { display: none; }
    no judge tier is on Opus. Hover shows ONE description: the box's own over the box, the row's elsewhere. */
 #rsettings .rs-fastin { display: inline-flex; align-items: center; gap: 5px; margin-left: 10px; flex: 0 0 auto; white-space: nowrap; cursor: pointer; }
 #rsettings .rs-fastin input { margin: 0; }
-#rsettings .rs-fastin.rs-off { opacity: .4; cursor: default; }
-#rsettings .rs-fastin.rs-off input { cursor: default; }
+/* the greyed look fades the BOX alone (the #rrefresh:disabled look) and greys the word by token: opacity on the whole
+   label faded the hint span inside it too, and made the label a stacking context that the rows beneath painted over,
+   so the reason the box was greyed read dim and overdrawn. The hint keeps the colour the hover rule above gives it. */
+#rsettings .rs-fastin.rs-off { color: var(--text-faint, #6e7681); cursor: default; }
+#rsettings .rs-fastin.rs-off input { opacity: .4; cursor: default; }
 #rsettings .rs-row:hover .rs-fastin .rs-sub { display: none; }
 #rsettings .rs-row:has(.rs-fastin:hover) > .rs-sub { display: none; }
 #rsettings .rs-row:has(.rs-fastin:hover) .rs-fastin .rs-sub { display: block; }

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -89,7 +89,12 @@ test("the judges' fast-mode box sits on the Triage model row in the chat's words
   // the mixed mark is the one inside the box's own label, not the picker's (both share the row now)
   assert.ok(GEAR.includes("el.closest('label') || el.closest('.rs-row')"), "fillMixedMarks scopes to the control's own label first");
   const CSS = read("ui", "webview", "gear.css");
-  assert.ok(CSS.includes("#rsettings .rs-fastin.rs-off { opacity: .4;"), "the greyed look");
+  // the greyed look fades the BOX alone: opacity on the whole label faded the hint span inside it too, and made the
+  // label a stacking context the rows beneath paint over, so the reason the box was greyed read dim and overdrawn
+  assert.ok(CSS.includes("#rsettings .rs-fastin.rs-off input { opacity: .4;"), "the greyed look fades the box alone");
+  assert.doesNotMatch(CSS, /#rsettings \.rs-fastin\.rs-off \{[^}]*opacity/,
+    "no opacity on the label: the hint span lives inside it and would fade with it, and the label would become a stacking context the rows beneath paint over");
+  assert.match(CSS, /#rsettings \.rs-fastin\.rs-off \{[^}]*color: var\(--text-faint/, "the word greys by token, not by fading");
   assert.ok(CSS.includes("#rsettings .rs-row:has(.rs-fastin:hover) > .rs-sub { display: none; }"), "one hover description at a time");
   assert.ok(CSS.includes("#rsettings .rs-fastin .rs-sub { white-space: normal; }"), "the hint wraps: the label's nowrap (box + word on one line) must not reach the hint, or it runs off the card");
   assert.ok(CSS.includes("#rsettings .rs-row:has(.rs-fastin .rs-mixed:hover) .rs-fastin .rs-sub { display: none; }"), "the box's mixed mark keeps its title alone: no hint under it");


### PR DESCRIPTION
## Symptom
With a judge tier off Opus (the defaults: Sonnet for triage, Haiku for indexing), that tier's Fast mode box in the gear's Judges section greys, and hovering the box shows why. The hint is hard to read: it renders at 40% opacity, with the rows below it (the effort picker, the next model row) drawn across it.

## Cause
`gear.css` put `opacity: .4` on the whole `.rs-fastin.rs-off` label. The hint `<span class=rs-sub>` is a child of that label, so it faded with the checkbox. Opacity below 1 also makes the label a stacking context: the hint's `z-index: 10` became local to the label, and the following `.rs-row` siblings, painted later in tree order in the same step, drew over the translucent group.

## Fix
`ui/webview/gear.css`: the label no longer carries opacity. The checkbox alone fades (`#rsettings .rs-fastin.rs-off input { opacity: .4; }`, the `#rrefresh:disabled` look), and the word takes the section grey by token (`color: var(--text-faint, #6e7681)`; the fallback is the dark value, like every other fallback in this sheet, and the light theme resolves the token to its own). The hint keeps the colour the `.rs-row:hover .rs-sub` rule sets. No markup, id or gate changes: the hints stay inside the labels, so the one-hint hover rules and `fillMixedMarks`'s label scoping are untouched, and the three tiers' boxes share the rule.

Token choice: `--text-faint` is the token nearest the raw `#6f747c` that `.rs-sec` and `.rs-mixed` use for the section grey; `--text-muted` is lighter and reads as live text.

## Tests
- `ui/webview/gear.test.ts`, the Triage-row test: the label-opacity pin becomes three pins. The input rule carries `opacity: .4`; the label rule carries no `opacity`; the label rule colours by `var(--text-faint`. Before the change all three fail (node reports the first: the input rule carried no opacity; the label held the opacity and had no colour rule).
- `tests/test_kernel_settings_sections.py::SettingsSectionsTest::test_fast_mode_for_the_judges_sits_on_the_triage_model_row`: the same three pins beside the existing selector pin. Before the change all three fail (unittest reports the first: `'#rsettings .rs-fastin.rs-off input { opacity: .4;' not found`).
- `ui/webview/gear-judge-fast-browser.test.ts`, headless Chromium over the real `gear.js` and `gear.css`: `snap()` now reads the checkbox's own computed opacity instead of the label's (0.4 greyed, 1 live), the most faded ancestor of each hint up to `#rsettings` (`hintFade`, all 1), and each label's computed colour (the greyed word's differs from a live word's). After the first snapshot it hovers the greyed box and then a live one, and checks the greyed hint shows (display block) with its own opacity at 1, in a colour other than the greyed word's and equal to the live hint's. Before the change, with Playwright's Chromium installed: the checkbox opacity reads 1 on all three tiers (the assertion expecting 0.4 fails first), `hintFade` reads 0.4 on the greyed tier, and the three word colours are equal. The hover checks pass before and after the change; they are guards: the label's colour must not reach the hint, and no rule may fade the hint itself (opacity is not inherited, so the hint's own value reads 1 either way otherwise; a rule such as `.rs-fastin.rs-off .rs-sub { opacity: .4; }` passes every source pin and fails only this check). The test skips without a Playwright browser as before; on CI the extension job runs `npm test` before it installs Playwright's Chromium, so the leg skips there and the source pins carry the gate.
- Second commit, text only: six comments and docstrings in `tests/test_judge_auth_billing.py`, `tests/test_judge_settings_sync.py`, `tests/test_kernel_judge_model.py` and `tests/test_kernel_session_flags.py` still said Fast judging, the name the gear dropped; they say Fast mode now. No assertion, count or behaviour changes.
- Full runs on this head, both with the served-page modules executing: `pytest tests/` (`-n 6`) 11675 passed, 45 skipped, 1744 subtests passed, 0 failed; `npm test` 4315 passed, 0 failed (4293 in the main run plus the 22 of `ui/timeline-tags-scale.test.ts`, run on its own); `npm run typecheck` clean.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)