### PR TITLE
The bus refuses the machine's fixed port under a test: a belt against hermetic leaks, the trio on the in-process tunnel module, the spawn guard widened

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17557,8 +17557,10 @@ def _ensure_postal_bus():
     no-ops when the bus is already up, so the kernel can insist at every boot. Absolute paths: a
     bootstrap-started kernel's non-login shell has neither the repo's bin/ nor a guaranteed PATH."""
     try:
-        subprocess.run([sys.executable, str(BIN / "romp-postal-service"), "ensure"],
-                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30)
+        r = subprocess.run([sys.executable, str(BIN / "romp-postal-service"), "ensure"],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, timeout=30)
+        if r.returncode != 0:   # the bus said no (2026-09-10: it refuses the machine's fixed port under a test): say so here, where the kernel's log is
+            sys.stderr.write("postal bus ensure refused (exit %d): %s\n" % (r.returncode, (r.stderr or "").strip()[-2000:]))
     except Exception:
         sys.stderr.write("postal bus ensure failed:\n%s" % traceback.format_exc())
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2799,7 +2799,42 @@ def _sweep_unfinished_writes():
     if parts:
         _refused_notice("mail service start: %s (the log names each)" % "; ".join(parts))
 
+TESTS_ROOT_MARK = "romp-tests-"   # the test runner's temporary roots (/tmp/romp-tests-*): a state root under one belongs to a test
+
+
+def _fixed_port_refusal():
+    """Why this process must NOT bind the machine's fixed bus port, or None (2026-09-10). A hermetic kernel, a test's
+    lab process or the kernel module loaded inside a test process, runs `ensure` at boot and again whenever a bus
+    call is refused; with ROMP_POSTAL_PORT unset that started a bus on the FIXED port the moment the machine's real
+    bus was down for a restart (three leaks in one afternoon, two spawn shapes, three worktrees), and every real
+    session's mail then failed against the lab's token. Fixture hygiene (kernel_env's trio, tests/test_hermetic_
+    kernel_postal.py) covers the spawn sites it can see; this is the belt for the rest: under a test
+    (PYTEST_CURRENT_TEST set) or with the state root under a test runner's temporary directory, the fixed port is
+    refused unless ROMP_POSTAL_PORT names a port explicitly. Loud: the reason goes to stderr and the bus log."""
+    if os.environ.get("ROMP_POSTAL_PORT"):
+        return None
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return ("under a test (PYTEST_CURRENT_TEST is set) with no ROMP_POSTAL_PORT: refusing to bind the machine's fixed bus "
+                "port %d; a hermetic bus names its own port (ROMP_POSTAL_PORT) or runs client-only (ROMP_POSTAL_CLIENT_ONLY=1)" % PORT)
+    if TESTS_ROOT_MARK in str(STATE):
+        return ("the state root %s is a test runner's temporary directory and ROMP_POSTAL_PORT is unset: refusing to bind the "
+                "machine's fixed bus port %d; a hermetic bus names its own port or runs client-only" % (STATE, PORT))
+    return None
+
+
+def _refuse_loudly(why):
+    sys.stderr.write("romp-postal-service: " + why + "\n")
+    try:
+        _log("refused: " + why)
+    except Exception:
+        pass
+
+
 def serve():
+    why = _fixed_port_refusal()
+    if why:
+        _refuse_loudly(why)
+        return 2
     STATE.mkdir(parents=True, exist_ok=True)
     MAILROOT.mkdir(parents=True, exist_ok=True)
     _reconcile_markers()
@@ -4501,6 +4536,10 @@ def ensure():
         return True
     if is_client_only():
         return ping()
+    why = _fixed_port_refusal()   # the belt (2026-09-10): a hermetic kernel's ensure never takes the shared port
+    if why:
+        _refuse_loudly(why)
+        return False
     STATE.mkdir(parents=True, exist_ok=True)
     logf = open(LOG, "a")
     subprocess.Popen([sys.executable, os.path.abspath(__file__), "serve"],

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2808,26 +2808,33 @@ def _fixed_port_refusal():
     call is refused; with ROMP_POSTAL_PORT unset that started a bus on the FIXED port the moment the machine's real
     bus was down for a restart (three leaks in one afternoon, two spawn shapes, three worktrees), and every real
     session's mail then failed against the lab's token. Fixture hygiene (kernel_env's trio, tests/test_hermetic_
-    kernel_postal.py) covers the spawn sites it can see; this is the belt for the rest: under a test
-    (PYTEST_CURRENT_TEST set) or with the state root under a test runner's temporary directory, the fixed port is
-    refused unless ROMP_POSTAL_PORT names a port explicitly. Loud: the reason goes to stderr and the bus log."""
-    if os.environ.get("ROMP_POSTAL_PORT"):
+    kernel_postal.py) covers the spawn sites it can see; this refusal, in the bus itself, covers every shape: under a
+    test (PYTEST_CURRENT_TEST set) or with the state root under a temporary directory (a test runner's romp-tests-
+    root, or the system's temporary directory at all, which is where a bare unittest run puts its state), the fixed
+    port is refused unless ROMP_POSTAL_PORT names the port this process bound at import. The reason goes to stderr,
+    which a detached serve's log carries and which the kernel's ensure runner copies into its own log."""
+    import tempfile
+    named = (os.environ.get("ROMP_POSTAL_PORT") or "").strip()
+    if named and named == str(PORT):
         return None
+    root = str(STATE)
+    tmp = tempfile.gettempdir().rstrip("/") + "/"
     if os.environ.get("PYTEST_CURRENT_TEST"):
-        return ("under a test (PYTEST_CURRENT_TEST is set) with no ROMP_POSTAL_PORT: refusing to bind the machine's fixed bus "
-                "port %d; a hermetic bus names its own port (ROMP_POSTAL_PORT) or runs client-only (ROMP_POSTAL_CLIENT_ONLY=1)" % PORT)
-    if TESTS_ROOT_MARK in str(STATE):
-        return ("the state root %s is a test runner's temporary directory and ROMP_POSTAL_PORT is unset: refusing to bind the "
-                "machine's fixed bus port %d; a hermetic bus names its own port or runs client-only" % (STATE, PORT))
-    return None
+        why = "under a test (PYTEST_CURRENT_TEST is set)"
+    elif TESTS_ROOT_MARK in root:
+        why = "the state root %s is under a test runner's temporary directory" % STATE
+    elif root.startswith(tmp) or root.startswith("/tmp/"):
+        why = "the state root %s is under the temporary directory" % STATE
+    else:
+        return None
+    return ("%s and no ROMP_POSTAL_PORT names this process's port%s: refusing to bind the machine's fixed bus port %d; a "
+            "hermetic bus names its own port (ROMP_POSTAL_PORT), or runs client-only with peers off (ROMP_POSTAL_CLIENT_ONLY=1 "
+            "and ROMP_POSTAL_PEERS=0) so it never starts one"
+            % (why, (" (it names %s, this process bound %d at import)" % (named, PORT)) if named else "", PORT))
 
 
 def _refuse_loudly(why):
     sys.stderr.write("romp-postal-service: " + why + "\n")
-    try:
-        _log("refused: " + why)
-    except Exception:
-        pass
 
 
 def serve():
@@ -4536,7 +4543,7 @@ def ensure():
         return True
     if is_client_only():
         return ping()
-    why = _fixed_port_refusal()   # the belt (2026-09-10): a hermetic kernel's ensure never takes the shared port
+    why = _fixed_port_refusal()   # 2026-09-10: a hermetic kernel's ensure never takes the shared port
     if why:
         _refuse_loudly(why)
         return False

--- a/tests/test_hermetic_kernel_postal.py
+++ b/tests/test_hermetic_kernel_postal.py
@@ -9,15 +9,18 @@ FIXED port whenever nothing listens there. During a kernel restart the machine's
 lab bus took the port, the test's teardown killed the kernel and not the bus, and every session's mail then failed
 against the lab's token until someone found the process.
 
-The third leak of that day came by a shape no spawn scan can see: a test module that loads the kernel module
-IN-PROCESS (load_source of bin/romp-kernel, no subprocess at all) drove an attach whose bus call was refused, and the
-kernel's revive path ran `ensure` from inside the test process, with the test's environment and no trio. So the rule
+The later leaks of that day came by a shape no spawn scan can see: a test module that loads the kernel module
+IN-PROCESS (load_source of bin/romp-kernel, no subprocess at all) makes a bus call that is refused, and the kernel's
+revive path runs `ensure` from inside the test process, with the test's environment and no trio. Three sites, one
+afternoon: tests/test_federation_missing_served.py (a lab kernel started as a process, its environment built by hand),
+tests/test_kernel_tunnels.py (an in-process kernel, an attach whose bus call was refused) and tests/test_kernel.py's
+PostalPeerTunnels.test_notify_bus_peer_is_guarded (an in-process kernel, a peer notify forced to fail). So the rule
 here scans every process spawn whose argv names the kernel (Popen, run, check_output, check_call, call; the argument
 span read across lines, whatever spells the path, a path held in a name included), and the in-process shape is met in
 the bus itself: `romp-postal-service serve` and `ensure` refuse the fixed port under a test (PYTEST_CURRENT_TEST set, or the
 state root under a temporary directory) unless ROMP_POSTAL_PORT names the port, pinned by tests/test_postal_fixed_port_belt.py.
-A module that loads the kernel in-process and exercises the bus should still carry the trio before its load (the tunnel
-tests do), so its kernel never even asks.
+A module that loads the kernel in-process and exercises the bus still carries the trio, before its load (the tunnel
+tests) or around the call that provokes the revive (the peer-notify test), so its kernel never even asks.
 
 The fixture rule below is static, so it holds for tests that skip here (no browser, no extension deps) and fails at
 the spawn site, naming the file.
@@ -104,6 +107,14 @@ class HermeticKernelPostal(unittest.TestCase):
         load = src.index('load_source("romp_kernel"')
         for k in TRIO:
             self.assertIn(k, src[:load], "%s is set before the kernel module loads (it reads the port at import)" % k)
+
+    def test_the_peer_notify_guard_test_carries_the_trio_around_the_call_it_forces_to_fail(self):
+        src = open(os.path.join(HERE, "test_kernel.py"), encoding="utf-8", errors="replace").read()
+        body = src[src.index("def test_notify_bus_peer_is_guarded"):src.index("class CheckinMechanics")]
+        self.assertIn('os.environ.update(ROMP_POSTAL_CLIENT_ONLY="1", ROMP_POSTAL_PEERS="0", ROMP_POSTAL_PORT="1")', body,
+                      "client-only with peers off and a port nothing can bind, for the call the refusal revives the bus from")
+        self.assertLess(body.index("os.environ.update("), body.index("km._notify_bus_peer("), "…set before the call")
+        self.assertIn("os.environ.pop(k, None)", body, "…and restored after it")
 
 
 if __name__ == "__main__":

--- a/tests/test_hermetic_kernel_postal.py
+++ b/tests/test_hermetic_kernel_postal.py
@@ -13,9 +13,9 @@ The third leak of that day came by a shape no spawn scan can see: a test module 
 IN-PROCESS (load_source of bin/romp-kernel, no subprocess at all) drove an attach whose bus call was refused, and the
 kernel's revive path ran `ensure` from inside the test process, with the test's environment and no trio. So the rule
 here scans every process spawn whose argv names the kernel (Popen, run, check_output, check_call, call; the argument
-span read across lines, whatever spells the path), and the BELT for the in-process shape lives in the bus itself:
-`romp-postal-service serve` and `ensure` refuse the fixed port under a test (PYTEST_CURRENT_TEST set, or the state root
-under a test runner's temporary directory) unless ROMP_POSTAL_PORT names a port, pinned by tests/test_postal_fixed_port_belt.py.
+span read across lines, whatever spells the path, a path held in a name included), and the in-process shape is met in
+the bus itself: `romp-postal-service serve` and `ensure` refuse the fixed port under a test (PYTEST_CURRENT_TEST set, or the
+state root under a temporary directory) unless ROMP_POSTAL_PORT names the port, pinned by tests/test_postal_fixed_port_belt.py.
 A module that loads the kernel in-process and exercises the bus should still carry the trio before its load (the tunnel
 tests do), so its kernel never even asks.
 
@@ -32,7 +32,10 @@ sys.path.insert(0, HERE)
 import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
 
 CALL = re.compile(r"(?:subprocess\.(?:Popen|run|check_output|check_call|call)|(?<![\w.])Popen)\s*\(")
-KERNEL_ARGV = re.compile(r"""romp-kernel|bin/romp\b|\bBIN\b[^\]\n]*?["']romp["']""")   # a joined path: BIN, "romp"
+# the kernel's path as an argv spells it: the script's name, the bare CLI (not the other bin/romp-* scripts), a path
+# joined from BIN with "romp"
+KERNEL_ARGV = re.compile(r"""romp-kernel|bin/romp(?![\w-])|\bBIN\b[^\]\n]*?["']romp["']""")
+KERNEL_NAME = re.compile(r"^[ \t]*([A-Za-z_]\w*)\s*=\s*[^\n]*romp-kernel", re.M)   # a name bound to the kernel's path
 TRIO = ("ROMP_POSTAL_PORT", "ROMP_POSTAL_PEERS", "ROMP_POSTAL_CLIENT_ONLY")
 
 
@@ -51,7 +54,8 @@ def _call_spans(src):
 
 
 def _spawns_kernel(src):
-    return any(KERNEL_ARGV.search(span) for span in _call_spans(src))
+    names = [re.compile(r"\b%s\b" % re.escape(n)) for n in KERNEL_NAME.findall(src)]
+    return any(KERNEL_ARGV.search(span) or any(n.search(span) for n in names) for span in _call_spans(src))
 
 
 def _hermetic(src):
@@ -86,16 +90,20 @@ class HermeticKernelPostal(unittest.TestCase):
         for src in ('subprocess.Popen([os.path.join(BIN, "romp-kernel")], env=env)',
                     'subprocess.run(\n    [sys.executable, str(BIN / "romp-kernel")],\n    capture_output=True)',
                     'Popen(["python3", "bin/romp-kernel"])',
-                    'subprocess.check_output([os.path.join(BIN, "romp"), "kernel", "--serve"])'):
+                    'subprocess.check_output([os.path.join(BIN, "romp"), "kernel", "--serve"])',
+                    'KERNEL = os.path.join(BIN, "romp-kernel")\nproc = subprocess.Popen([sys.executable, KERNEL], env=env)'):
             self.assertTrue(_spawns_kernel(src), src)
-        self.assertFalse(_spawns_kernel('subprocess.run(["node", "esbuild.js"], cwd=EXT)'), "a build is not a kernel")
-        self.assertFalse(_spawns_kernel('load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))'), "an in-process load is not a spawn: the bus's belt covers it")
+        for src in ('subprocess.run(["node", "esbuild.js"], cwd=EXT)',
+                    'subprocess.run(["bin/romp-postal-service", "ensure"])',
+                    'subprocess.run([os.path.join(BIN, "romp-judge"), "--once"])',
+                    'load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))'):
+            self.assertFalse(_spawns_kernel(src), "not a kernel spawn (a build, the other scripts, an in-process load): " + src)
 
     def test_the_module_that_loads_the_kernel_in_process_and_attaches_carries_the_trio_before_its_load(self):
         src = open(os.path.join(HERE, "test_kernel_tunnels.py"), encoding="utf-8", errors="replace").read()
         load = src.index('load_source("romp_kernel"')
         for k in TRIO:
-            self.assertIn(k, src[:load], "%s is set before the kernel module loads (it binds the port at import)" % k)
+            self.assertIn(k, src[:load], "%s is set before the kernel module loads (it reads the port at import)" % k)
 
 
 if __name__ == "__main__":

--- a/tests/test_hermetic_kernel_postal.py
+++ b/tests/test_hermetic_kernel_postal.py
@@ -7,8 +7,20 @@ Why a guard: one served test built its kernel environment by hand without the tr
 service's `ensure`, which starts the bus detached (its own session, so the kernel's death never reaches it) on the
 FIXED port whenever nothing listens there. During a kernel restart the machine's real bus was down for a moment, the
 lab bus took the port, the test's teardown killed the kernel and not the bus, and every session's mail then failed
-against the lab's token until someone found the process. The fixture rule below is static, so it holds for tests that
-skip here (no browser, no extension deps) and fails at the spawn site, naming the file.
+against the lab's token until someone found the process.
+
+The third leak of that day came by a shape no spawn scan can see: a test module that loads the kernel module
+IN-PROCESS (load_source of bin/romp-kernel, no subprocess at all) drove an attach whose bus call was refused, and the
+kernel's revive path ran `ensure` from inside the test process, with the test's environment and no trio. So the rule
+here scans every process spawn whose argv names the kernel (Popen, run, check_output, check_call, call; the argument
+span read across lines, whatever spells the path), and the BELT for the in-process shape lives in the bus itself:
+`romp-postal-service serve` and `ensure` refuse the fixed port under a test (PYTEST_CURRENT_TEST set, or the state root
+under a test runner's temporary directory) unless ROMP_POSTAL_PORT names a port, pinned by tests/test_postal_fixed_port_belt.py.
+A module that loads the kernel in-process and exercises the bus should still carry the trio before its load (the tunnel
+tests do), so its kernel never even asks.
+
+The fixture rule below is static, so it holds for tests that skip here (no browser, no extension deps) and fails at
+the spawn site, naming the file.
 """
 import os
 import re
@@ -19,8 +31,31 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
 import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
 
-SPAWN = re.compile(r"""Popen\(\s*\[[^\]]*["']romp-kernel["']""")
+CALL = re.compile(r"(?:subprocess\.(?:Popen|run|check_output|check_call|call)|(?<![\w.])Popen)\s*\(")
+KERNEL_ARGV = re.compile(r"""romp-kernel|bin/romp\b|\bBIN\b[^\]\n]*?["']romp["']""")   # a joined path: BIN, "romp"
 TRIO = ("ROMP_POSTAL_PORT", "ROMP_POSTAL_PEERS", "ROMP_POSTAL_CLIENT_ONLY")
+
+
+def _call_spans(src):
+    """The argument span of every subprocess call in `src`, read across lines to the matching parenthesis."""
+    for m in CALL.finditer(src):
+        i = m.end(); depth = 1; j = i
+        while j < len(src) and depth:   # loop-ok: a bounded scan of one call's argument span
+            c = src[j]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+            j += 1
+        yield src[i:j]
+
+
+def _spawns_kernel(src):
+    return any(KERNEL_ARGV.search(span) for span in _call_spans(src))
+
+
+def _hermetic(src):
+    return "kernel_env(" in src or all(k in src for k in TRIO)
 
 
 class HermeticKernelPostal(unittest.TestCase):
@@ -37,19 +72,30 @@ class HermeticKernelPostal(unittest.TestCase):
             if not name.endswith(".py") or name == os.path.basename(__file__):
                 continue
             src = open(os.path.join(HERE, name), encoding="utf-8", errors="replace").read()
-            if not SPAWN.search(src):
-                continue
-            hermetic = "kernel_env(" in src or all(k in src for k in TRIO)
-            if not hermetic:
+            if _spawns_kernel(src) and not _hermetic(src):
                 offenders.append(name)
         self.assertEqual(offenders, [], "these tests start a kernel process without the postal trio (use kernel_env, or set "
                                         "ROMP_POSTAL_PORT to a free port, ROMP_POSTAL_PEERS=0 and ROMP_POSTAL_CLIENT_ONLY=1): %r" % offenders)
 
     def test_the_guard_itself_sees_the_spawn_sites(self):
-        """the regex must match the spawn idiom the labs use, else the rule above would pass vacuously"""
-        hits = [n for n in os.listdir(HERE) if n.endswith(".py") and SPAWN.search(open(os.path.join(HERE, n), encoding="utf-8", errors="replace").read())]
+        """the scan must match the spawn idioms the labs use, else the rule above would pass vacuously"""
+        hits = [n for n in os.listdir(HERE) if n.endswith(".py") and _spawns_kernel(open(os.path.join(HERE, n), encoding="utf-8", errors="replace").read())]
         self.assertIn("test_federation_missing_served.py", hits)
         self.assertIn("test_notification_tap_resume_browser.py", hits)
+        # the shapes the scan must read: a list literal, a path joined or divided, a call split across lines, run as well as Popen
+        for src in ('subprocess.Popen([os.path.join(BIN, "romp-kernel")], env=env)',
+                    'subprocess.run(\n    [sys.executable, str(BIN / "romp-kernel")],\n    capture_output=True)',
+                    'Popen(["python3", "bin/romp-kernel"])',
+                    'subprocess.check_output([os.path.join(BIN, "romp"), "kernel", "--serve"])'):
+            self.assertTrue(_spawns_kernel(src), src)
+        self.assertFalse(_spawns_kernel('subprocess.run(["node", "esbuild.js"], cwd=EXT)'), "a build is not a kernel")
+        self.assertFalse(_spawns_kernel('load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))'), "an in-process load is not a spawn: the bus's belt covers it")
+
+    def test_the_module_that_loads_the_kernel_in_process_and_attaches_carries_the_trio_before_its_load(self):
+        src = open(os.path.join(HERE, "test_kernel_tunnels.py"), encoding="utf-8", errors="replace").read()
+        load = src.index('load_source("romp_kernel"')
+        for k in TRIO:
+            self.assertIn(k, src[:load], "%s is set before the kernel module loads (it binds the port at import)" % k)
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -8926,11 +8926,22 @@ class PostalPeerTunnels(unittest.TestCase):
     def test_notify_bus_peer_is_guarded(self):
         saved = km.BUS_PORT
         km.BUS_PORT = 1                    # nothing listens here → refused instantly
+        # the refusal kicks the bus revive, which runs the postal service's ensure with THIS process's environment: for
+        # the call's duration the process is client-only with peers off and names a port nothing can bind, so no bus is
+        # ever started (2026-09-10: a hermetic bus reached the machine's fixed port from exactly this test while the real
+        # bus was down for a restart); restored after, whatever the outcome
+        env_saved = {k: os.environ.get(k) for k in ("ROMP_POSTAL_CLIENT_ONLY", "ROMP_POSTAL_PEERS", "ROMP_POSTAL_PORT")}
+        os.environ.update(ROMP_POSTAL_CLIENT_ONLY="1", ROMP_POSTAL_PEERS="0", ROMP_POSTAL_PORT="1")
         try:
             self.assertFalse(km._notify_bus_peer("TESTHOST", 50002, True),
                              "postal down → False, never an exception (the supervisor must survive)")
         finally:
             km.BUS_PORT = saved
+            for k, v in env_saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
 
 
 class CheckinMechanics(unittest.TestCase):

--- a/tests/test_kernel_tunnels.py
+++ b/tests/test_kernel_tunnels.py
@@ -26,6 +26,13 @@ os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# the postal trio (2026-09-10): this kernel runs IN-PROCESS, and an attach whose bus call is refused revives the bus;
+# without these it started one on the machine's fixed port while the real bus was down for a restart. Client-only, so
+# ensure starts nothing; its own port and no peers, read at load (the kernel binds them at import)
+import socket as _socket
+_s = _socket.socket(); _s.bind(("127.0.0.1", 0)); os.environ.setdefault("ROMP_POSTAL_PORT", str(_s.getsockname()[1])); _s.close()
+os.environ["ROMP_POSTAL_PEERS"] = "0"
+os.environ["ROMP_POSTAL_CLIENT_ONLY"] = "1"
 load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
 load_source("romp_judge", os.path.join(BIN, "romp-judge"))
 km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))

--- a/tests/test_kernel_tunnels.py
+++ b/tests/test_kernel_tunnels.py
@@ -28,9 +28,10 @@ os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
 os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
 # the postal trio (2026-09-10): this kernel runs IN-PROCESS, and an attach whose bus call is refused revives the bus;
 # without these it started one on the machine's fixed port while the real bus was down for a restart. Client-only, so
-# ensure starts nothing; its own port and no peers, read at load (the kernel binds them at import)
+# ensure starts nothing; its own port (never one inherited from a shell that names the machine's) and no peers, read at
+# load (the kernel reads them at import)
 import socket as _socket
-_s = _socket.socket(); _s.bind(("127.0.0.1", 0)); os.environ.setdefault("ROMP_POSTAL_PORT", str(_s.getsockname()[1])); _s.close()
+_s = _socket.socket(); _s.bind(("127.0.0.1", 0)); os.environ["ROMP_POSTAL_PORT"] = str(_s.getsockname()[1]); _s.close()
 os.environ["ROMP_POSTAL_PEERS"] = "0"
 os.environ["ROMP_POSTAL_CLIENT_ONLY"] = "1"
 load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))

--- a/tests/test_postal_fixed_port_belt.py
+++ b/tests/test_postal_fixed_port_belt.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""The bus's belt against hermetic leaks (2026-09-10): `romp-postal-service serve` and `ensure` refuse to bind the
+machine's fixed bus port under a test (PYTEST_CURRENT_TEST set, or the state root under a test runner's temporary
+directory, the /tmp/romp-tests-* shape) unless ROMP_POSTAL_PORT names a port explicitly, and say why on stderr.
+
+Three leaks in one afternoon put a hermetic bus on the shared port while the real bus was down for a restart: two lab
+kernels started as processes without kernel_env's trio, and one kernel module loaded inside a test process whose
+revive path ran `ensure`. The fixture guard (tests/test_hermetic_kernel_postal.py) sees the spawns; this belt holds
+for every shape, because it is the bus that refuses.
+
+Every case here runs the real script in a subprocess with a hermetic environment: the refusal happens before any bind,
+so nothing listens anywhere, and the allowed case is read from the helper, never by starting a bus.
+"""
+import os
+import subprocess
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BUS = os.path.join(ROOT, "bin", "romp-postal-service")
+PROBE = ("import importlib.machinery as m, sys; p = m.SourceFileLoader('romp_postal_probe', sys.argv[1]).load_module(); "
+         "print(repr(p._fixed_port_refusal()))")
+
+
+# state roots that are NEVER created: the refusal precedes every mkdir and the probe only imports the module, so these are
+# strings the belt reads, not directories; one outside any test runner's root (no romp-tests- segment, the machine's own
+# case) and one inside the runner's root shape (the case the belt refuses). No temp API, nothing written outside the run.
+OUTSIDE_ROOT = "/nonexistent/belt-home"
+TESTS_ROOT = "/nonexistent/romp-tests-belt/lab"
+
+
+def _env(**over):
+    """a bare environment: the path, a home and state root that never come to exist, no postal port unless the case sets
+    one, and no PYTEST_CURRENT_TEST unless the case sets one (the runner exports it into ours)"""
+    env = {"PATH": os.environ.get("PATH", ""), "HOME": OUTSIDE_ROOT, "XDG_STATE_HOME": OUTSIDE_ROOT + "/xdg", "ROMP_KERNEL_NO_OPEN": "1",
+           "ROMP_SERVE_TOKEN": "testtok-belt"}   # given, so the module mints none under a root that never exists
+    env.update(over)
+    return env
+
+
+def _refusal(env):
+    p = subprocess.run([sys.executable, "-c", PROBE, BUS], env=env, capture_output=True, text=True, timeout=60)
+    assert p.returncode == 0, p.stderr[-800:]
+    return eval(p.stdout.strip())   # repr of a str or None
+
+
+class FixedPortBelt(unittest.TestCase):
+    def test_under_a_test_the_fixed_port_is_refused_with_the_reason(self):
+        why = _refusal(_env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)"))
+        self.assertIsNotNone(why)
+        self.assertIn("refusing to bind the machine's fixed bus port 25302", why)
+        self.assertIn("PYTEST_CURRENT_TEST", why)
+
+    def test_a_state_root_under_the_test_runners_temporary_directory_is_refused_too(self):
+        why = _refusal(_env(XDG_STATE_HOME=TESTS_ROOT + "/xdg"))   # the runner's root shape, no PYTEST_CURRENT_TEST at all
+        self.assertIsNotNone(why)
+        self.assertIn("test runner's temporary directory", why)
+        self.assertIn("25302", why)
+
+    def test_an_explicit_port_is_allowed_under_a_test(self):
+        self.assertIsNone(_refusal(_env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)", ROMP_POSTAL_PORT="45678")),
+                          "a hermetic bus that names its own port is what the labs run")
+
+    def test_outside_a_test_nothing_is_refused(self):
+        self.assertIsNone(_refusal(_env()), "the machine's own bus binds the fixed port as ever")
+
+    def test_serve_exits_loudly_before_binding(self):
+        env = _env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)")
+        p = subprocess.run([sys.executable, BUS, "serve"], env=env, capture_output=True, text=True, timeout=60)
+        self.assertEqual(p.returncode, 2, p.stderr[-800:])
+        self.assertIn("romp-postal-service: under a test", p.stderr)
+        self.assertIn("refusing to bind the machine's fixed bus port", p.stderr)
+        self.assertFalse(os.path.exists(env["XDG_STATE_HOME"]), "no bus came up and nothing was written: the refusal precedes every mkdir")
+
+    def test_ensure_refuses_before_it_spawns(self):
+        src = open(BUS, encoding="utf-8").read()
+        ens = src[src.index("def ensure():"):src.index("def restart():")]
+        self.assertLess(ens.index("_fixed_port_refusal()"), ens.index("subprocess.Popen("), "the belt sits before the spawn")
+        self.assertIn("_refuse_loudly(why)", ens)
+        srv = src[src.index("def serve():"):src.index("def serve():") + 400]
+        self.assertLess(srv.index("_fixed_port_refusal()"), srv.index("STATE.mkdir"), "serve refuses before it touches anything")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_fixed_port_belt.py
+++ b/tests/test_postal_fixed_port_belt.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
-"""The bus's belt against hermetic leaks (2026-09-10): `romp-postal-service serve` and `ensure` refuse to bind the
-machine's fixed bus port under a test (PYTEST_CURRENT_TEST set, or the state root under a test runner's temporary
-directory, the /tmp/romp-tests-* shape) unless ROMP_POSTAL_PORT names a port explicitly, and say why on stderr.
+"""The bus refuses the machine's fixed port under a test (2026-09-10): `romp-postal-service serve` and `ensure` will not
+bind it when PYTEST_CURRENT_TEST is set, or when the state root sits under a temporary directory (a test runner's
+romp-tests- root, or the system's temporary directory at all, where a bare unittest run puts its state), unless
+ROMP_POSTAL_PORT names the port this process bound at import; they say why on stderr, and the kernel's ensure runner
+copies a refusal into its own log.
 
 Three leaks in one afternoon put a hermetic bus on the shared port while the real bus was down for a restart: two lab
 kernels started as processes without kernel_env's trio, and one kernel module loaded inside a test process whose
-revive path ran `ensure`. The fixture guard (tests/test_hermetic_kernel_postal.py) sees the spawns; this belt holds
-for every shape, because it is the bus that refuses.
+revive path ran `ensure`. The fixture guard (tests/test_hermetic_kernel_postal.py) sees the spawns; the refusal in the
+bus holds for every shape.
 
-Every case here runs the real script in a subprocess with a hermetic environment: the refusal happens before any bind,
-so nothing listens anywhere, and the allowed case is read from the helper, never by starting a bus.
+Every case here runs the real script in a subprocess with a bare environment: the refusal happens before any bind, so
+nothing listens anywhere, and the allowed cases are read from the helper, never by starting a bus.
 """
 import os
 import subprocess
@@ -19,15 +21,16 @@ import unittest
 HERE = os.path.dirname(os.path.realpath(__file__))
 ROOT = os.path.dirname(HERE)
 BUS = os.path.join(ROOT, "bin", "romp-postal-service")
-PROBE = ("import importlib.machinery as m, sys; p = m.SourceFileLoader('romp_postal_probe', sys.argv[1]).load_module(); "
-         "print(repr(p._fixed_port_refusal()))")
+PROBE = ("import importlib.util as u, importlib.machinery as m, sys; s = u.spec_from_loader('romp_postal_probe', m.SourceFileLoader('romp_postal_probe', sys.argv[1])); "
+         "p = u.module_from_spec(s); s.loader.exec_module(p); print(repr(p._fixed_port_refusal()))")
 
 
 # state roots that are NEVER created: the refusal precedes every mkdir and the probe only imports the module, so these are
-# strings the belt reads, not directories; one outside any test runner's root (no romp-tests- segment, the machine's own
-# case) and one inside the runner's root shape (the case the belt refuses). No temp API, nothing written outside the run.
+# strings the bus reads, not directories; one outside any temporary directory (the machine's own case), one under a test
+# runner's root shape, one under the system's temporary directory. No temp API, nothing written outside the run.
 OUTSIDE_ROOT = "/nonexistent/belt-home"
 TESTS_ROOT = "/nonexistent/romp-tests-belt/lab"
+TEMP_ROOT = "/tmp/tmpbelt-never-made"
 
 
 def _env(**over):
@@ -58,9 +61,33 @@ class FixedPortBelt(unittest.TestCase):
         self.assertIn("test runner's temporary directory", why)
         self.assertIn("25302", why)
 
+    def test_a_state_root_under_the_systems_temporary_directory_is_refused_too(self):
+        why = _refusal(_env(XDG_STATE_HOME=TEMP_ROOT + "/xdg"))   # a bare unittest run's state, no runner root, no PYTEST_CURRENT_TEST
+        self.assertIsNotNone(why)
+        self.assertIn("under the temporary directory", why)
+
     def test_an_explicit_port_is_allowed_under_a_test(self):
         self.assertIsNone(_refusal(_env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)", ROMP_POSTAL_PORT="45678")),
                           "a hermetic bus that names its own port is what the labs run")
+
+    def test_the_named_port_must_be_the_one_this_process_bound(self):
+        """a port named AFTER the module read its own (PORT is frozen at import) does not license the fixed one: the
+        message says both numbers"""
+        probe = PROBE.replace("print(repr(p._fixed_port_refusal()))", "import os; os.environ['ROMP_POSTAL_PORT'] = '45678'; print(repr(p._fixed_port_refusal()))")
+        p = subprocess.run([sys.executable, "-c", probe, BUS], env=_env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)"), capture_output=True, text=True, timeout=60)
+        self.assertEqual(p.returncode, 0, p.stderr[-800:])
+        why = eval(p.stdout.strip())
+        self.assertIsNotNone(why); self.assertIn("it names 45678, this process bound 25302", why)
+
+    def test_the_message_names_the_whole_trio_not_client_only_alone(self):
+        why = _refusal(_env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)"))
+        self.assertIn("ROMP_POSTAL_CLIENT_ONLY=1 and ROMP_POSTAL_PEERS=0", why, "client-only alone is inert while peers are on")
+
+    def test_the_kernels_ensure_runner_copies_a_refusal_into_its_own_log(self):
+        src = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+        fn = src[src.index("def _ensure_postal_bus():"):src.index("def _revive_postal_bus():")]
+        self.assertIn('stderr=subprocess.PIPE, text=True', fn, "the bus's stderr is read, not discarded")
+        self.assertIn('sys.stderr.write("postal bus ensure refused (exit %d): %s\\n"', fn, "a non-zero exit is said in the kernel's log")
 
     def test_outside_a_test_nothing_is_refused(self):
         self.assertIsNone(_refusal(_env()), "the machine's own bus binds the fixed port as ever")
@@ -69,14 +96,14 @@ class FixedPortBelt(unittest.TestCase):
         env = _env(PYTEST_CURRENT_TEST="tests/test_x.py::T::t (call)")
         p = subprocess.run([sys.executable, BUS, "serve"], env=env, capture_output=True, text=True, timeout=60)
         self.assertEqual(p.returncode, 2, p.stderr[-800:])
-        self.assertIn("romp-postal-service: under a test", p.stderr)
+        self.assertIn("romp-postal-service: under a test (PYTEST_CURRENT_TEST is set)", p.stderr)
         self.assertIn("refusing to bind the machine's fixed bus port", p.stderr)
         self.assertFalse(os.path.exists(env["XDG_STATE_HOME"]), "no bus came up and nothing was written: the refusal precedes every mkdir")
 
     def test_ensure_refuses_before_it_spawns(self):
         src = open(BUS, encoding="utf-8").read()
         ens = src[src.index("def ensure():"):src.index("def restart():")]
-        self.assertLess(ens.index("_fixed_port_refusal()"), ens.index("subprocess.Popen("), "the belt sits before the spawn")
+        self.assertLess(ens.index("_fixed_port_refusal()"), ens.index("subprocess.Popen("), "the refusal sits before the spawn")
         self.assertIn("_refuse_loudly(why)", ens)
         srv = src[src.index("def serve():"):src.index("def serve():") + 400]
         self.assertLess(srv.index("_fixed_port_refusal()"), srv.index("STATE.mkdir"), "serve refuses before it touches anything")


### PR DESCRIPTION
The bus refuses the machine's fixed port under a test: a belt against hermetic leaks, the trio on the in-process tunnel module, the spawn guard widened

Three times on 2026-09-10 a hermetic test put a postal bus on the machine's fixed port while the real bus was down
for a kernel restart, and every real session's mail then failed against the lab's token. Two leaks came from lab
kernels started as processes without kernel_env's trio; the third came by a shape no spawn scan can see: a test
module that loads the kernel module in-process drove an attach whose bus call was refused, and the kernel's revive
path ran the bus's ensure from inside the test process, with the test's environment and no trio.

The belt, in the bus itself: `romp-postal-service serve` and `ensure` refuse the fixed port when ROMP_POSTAL_PORT is
unset and either PYTEST_CURRENT_TEST is set or the state root sits under a test runner's temporary directory (the
romp-tests- shape), saying why on stderr and in the bus log; a hermetic kernel's boot-time or revive-time ensure
then cannot take the shared port whatever its environment, and a bus that names its own port runs as before.

The fixture: tests/test_kernel_tunnels.py sets the trio before its kernel loads (the kernel binds the port at
import), so its kernel never even asks. The guard (tests/test_hermetic_kernel_postal.py) now reads every subprocess
call whose argument span names the kernel, across lines and whatever spells the path, requires the trio in that
file, checks its own reach against the spawn shapes the labs use, pins the tunnel module's preamble, and carries
the lesson in its docstring. tests/test_postal_fixed_port_belt.py runs the real script in subprocesses with bare
environments: refused under a test, refused under a test runner's root, allowed with an explicit port, allowed
outside a test, serve exits loudly before it touches anything, ensure checks before it spawns.


**Review fold** (an adversarial pass, three lenses, read-only). The kernel's ensure runner discarded the bus's stderr and exit status, so the refusal built for its own revive path vanished; it now copies a non-zero exit and the reason into the kernel's log. A bare unittest run puts its state under the system's temporary directory with no runner root and no PYTEST_CURRENT_TEST; a state root under the temporary directory at all is refused now. A port named after the module froze its own at import licensed the fixed one; the named port must equal the one this process bound, and the message says both numbers when they differ. The message named client-only alone, which is inert while peers are on; it names the trio. The tunnel module takes its own port rather than an inherited one. The guard's bare-CLI alternative matched every other bin/romp-* script and missed a kernel path held in a name; both are fixed and in its self-check. Left as is, noted: `ensure` still answers a live machine bus before the refusal (a test process would then address the real bus, no leak); `restart` against a pidfile that names the machine's bus is a separate misuse; the tunnel module's peers-off setting stays in the process environment for later modules, and the full suite passes with it.


**A third site.** tests/test_kernel.py's peer-notify guard test forces a refused bus call, and the kernel's revive path ran the postal service's ensure with the test process's environment, which named no port; the fourth leak of the day came from there. For the call's duration that process is now client-only with peers off and names a port nothing can bind, restored after; the guard's docstring names the three sites and pins this one's trio around its call.
