### PR TITLE
The picker's off tag is struck through: a diagonal in the chip's colour, an off variant of the shared tag chip

### DIFF
--- a/tests/test_tag_chips_everywhere_browser.py
+++ b/tests/test_tag_chips_everywhere_browser.py
@@ -107,6 +107,8 @@ const survey = () => page.evaluate(() => {
                chipText: chip ? chip.textContent : null,
                chipBorder: cs ? cs.borderTopColor : null, chipBorderW: cs ? cs.borderTopWidth : null, chipColor: cs ? cs.color : null,
                chipOpacity: cs ? cs.opacity : null, chipBg: cs ? cs.backgroundColor : null, chipFont: cs ? cs.fontFamily : null,
+               chipPos: cs ? cs.position : null, chipW: chip ? chip.clientWidth : null, chipH: chip ? chip.clientHeight : null,   // the padding box: an absolute child spans it, so the line ends short of the border stroke
+               after: chip ? (() => { const a = getComputedStyle(chip, "::after"); return { content: a.content, pos: a.position, w: a.width, h: a.height, bg: a.backgroundImage, events: a.pointerEvents }; })() : null,
                btnBg: bs.backgroundColor, btnBorder: bs.borderTopStyle, btnOpacity: bs.opacity, btnFilter: bs.filter, btnPad: bs.paddingLeft };
     }),
   };
@@ -119,6 +121,12 @@ const on = await survey();
 await page.click('#picker .picker-tags .picker-be-opt[data-tag="infra"]');
 await page.waitForTimeout(100);
 const off = await survey();
+// the light theme: the diagonal is drawn in currentColor, so it follows the chip's colour on either theme
+await page.evaluate(() => document.body.classList.add("chat-theme-yatharth", "theme-light"));
+await page.waitForTimeout(150);
+const light = await survey();
+await page.evaluate(() => document.body.classList.remove("chat-theme-yatharth", "theme-light"));
+await page.waitForTimeout(100);
 // the tmux pick: the row greys behind its note
 const hasTmux = await page.evaluate(() => { const b = document.querySelector('#picker .picker-be-opt[data-be="tmux"]'); return !!b && getComputedStyle(b).display !== "none"; });
 let tmux = null;
@@ -127,7 +135,7 @@ if (hasTmux) {
   await page.waitForTimeout(150);
   tmux = await survey();
 }
-fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, open, on, off, tmux, hasTmux }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, open, on, off, light, tmux, hasTmux }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -251,16 +259,29 @@ class ServedPickerTagChips(unittest.TestCase):
         # the active tab's tag is selected: the full chip; the others unselected: the faded chip
         self.assertTrue(by["web"]["sel"]); self.assertFalse(by["infra"]["sel"]); self.assertFalse(by["docs"]["sel"])
         self.assertEqual((by["web"]["chipClass"], by["web"]["chipOpacity"]), ("", "1"), "selected = the full chip")
+        self.assertEqual(by["web"]["after"]["content"], "none", "…with no diagonal")
         for name in ("infra", "docs"):
-            self.assertEqual((by[name]["chipClass"], by[name]["chipOpacity"]), ("tag-chip-off", "0.45"), "unselected = the off chip (the tag toggles' look): %r" % by[name])
+            x = by[name]
+            self.assertEqual((x["chipClass"], x["chipOpacity"], x["chipPos"]), ("tag-chip-struck", "0.7", "relative"), "unselected = the STRUCK chip (T321b): %r" % x)
+            a = x["after"]
+            self.assertEqual((a["content"], a["pos"], a["events"]), ('""', "absolute", "none"), "the diagonal is a pseudo-element over the chip: %r" % a)
+            self.assertEqual((a["w"], a["h"]), ("%gpx" % x["chipW"], "%gpx" % x["chipH"]), "…covering the chip's padding box, so the gradient's line runs corner to corner inside the border: %r vs %r" % (a, x))
+            self.assertIn("linear-gradient", a["bg"]); self.assertIn("0.5px", a["bg"])
+            self.assertEqual(x["chipColor"], _rgb(colors[name]), "the line is currentColor, the tag's colour: %r" % x)
         # the flip: the state class and the chip's look move together, and back
         on = {x["tag"]: x for x in out["on"]["opts"]}
         self.assertTrue(on["infra"]["sel"])
-        self.assertEqual((on["infra"]["chipClass"], on["infra"]["chipOpacity"]), ("", "1"), "clicked on: the full chip")
+        self.assertEqual((on["infra"]["chipClass"], on["infra"]["chipOpacity"], on["infra"]["after"]["content"]), ("", "1", "none"), "clicked on: the full chip, no diagonal")
         self.assertTrue(on["web"]["sel"], "multi-select: the other stays")
         off = {x["tag"]: x for x in out["off"]["opts"]}
         self.assertFalse(off["infra"]["sel"])
-        self.assertEqual((off["infra"]["chipClass"], off["infra"]["chipOpacity"]), ("tag-chip-off", "0.45"), "clicked again: the off chip")
+        self.assertEqual((off["infra"]["chipClass"], off["infra"]["chipOpacity"], off["infra"]["after"]["content"]), ("tag-chip-struck", "0.7", '""'), "clicked again: struck")
+        # the light theme: the same classes, the same tag colours on border, text and (as currentColor) the line
+        light = {x["tag"]: x for x in out["light"]["opts"]}
+        for name in ("web", "infra", "docs"):
+            self.assertEqual((light[name]["chipBorder"], light[name]["chipColor"]), (_rgb(colors[name]), _rgb(colors[name])), "theme parity: %r" % light[name])
+        self.assertEqual(light["infra"]["after"]["content"], '""'); self.assertIn("linear-gradient", light["infra"]["after"]["bg"])
+        self.assertEqual(light["web"]["after"]["content"], "none")
         # the tmux pick: the row greys (not a second fade), every option disabled, both looks still distinct
         self.assertTrue(out["hasTmux"], "the lab turns the gear's tmux switch on, so the picker offers the tmux backend")
         if out["hasTmux"]:
@@ -270,7 +291,8 @@ class ServedPickerTagChips(unittest.TestCase):
                 self.assertTrue(x["disabled"])
                 self.assertIn("grayscale", x["btnFilter"], "greyed: %r" % x)
                 self.assertEqual(x["btnOpacity"], "1", "grey is the whole disabled cue: no second fade over the off chip's own: %r" % x)
-            self.assertEqual(t["web"]["chipOpacity"], "1"); self.assertEqual(t["infra"]["chipOpacity"], "0.45")
+            self.assertEqual(t["web"]["chipOpacity"], "1"); self.assertEqual(t["infra"]["chipOpacity"], "0.7")
+            self.assertEqual(t["infra"]["after"]["content"], '""', "the greyed row keeps the strike (grey) on its off chips")
 
 
 if __name__ == "__main__":

--- a/tests/test_tag_chips_everywhere_browser.py
+++ b/tests/test_tag_chips_everywhere_browser.py
@@ -3,7 +3,8 @@
 ui/webview/tag-menu.ts) builds every tag chip: the tab strip's group rows and its filter chips at the strip's right,
 the feed's and the outline's filter chips, the tag-lens menu, the tab menu's Tags flyout, the feed's session dialog,
 and the new-session picker's Tags row, where each tag shows as the chip (a thin border in the tag's own colour) and on
-versus off by the visual the tag toggles already use: the faded chip (TAG_CHIP_OFF_CLASS at 0.45). No identity dot.
+versus off as the full chip against the STRUCK chip (T321b: a diagonal in the chip's colour over a lighter fade, since
+the fade alone did not read as off there). No identity dot.
 
 The strip guard reads the LIVE computed style of a group row's chip and of the same tag's filter chip at the strip's
 right (a chat lens seeded with two tags, so both rows and both filter chips show) and asserts they are one rendering:
@@ -239,7 +240,7 @@ class ServedPickerTagChips(unittest.TestCase):
             self.assertEqual((f["borderColor"], f["color"]), (_rgb(colors[name]), _rgb(colors[name])), "…on the filter chip too: %r" % f)
             self.assertEqual(r["borderW"], "1px")
 
-    def test_each_tag_is_the_shared_chip_and_a_click_flips_the_faded_look_with_the_state_class(self):
+    def test_each_tag_is_the_shared_chip_and_a_click_flips_the_struck_look_with_the_state_class(self):
         out = self._once()
         o = out["open"]
         by = {x["tag"]: x for x in o["opts"]}
@@ -265,8 +266,11 @@ class ServedPickerTagChips(unittest.TestCase):
             self.assertEqual((x["chipClass"], x["chipOpacity"], x["chipPos"]), ("tag-chip-struck", "0.7", "relative"), "unselected = the STRUCK chip (T321b): %r" % x)
             a = x["after"]
             self.assertEqual((a["content"], a["pos"], a["events"]), ('""', "absolute", "none"), "the diagonal is a pseudo-element over the chip: %r" % a)
-            self.assertEqual((a["w"], a["h"]), ("%gpx" % x["chipW"], "%gpx" % x["chipH"]), "…covering the chip's padding box, so the gradient's line runs corner to corner inside the border: %r vs %r" % (a, x))
+            # the padding box may be fractional where glyphs advance by subpixels; clientWidth rounds, the computed width does not
+            self.assertLess(abs(float(a["w"].rstrip("px")) - x["chipW"]) + abs(float(a["h"].rstrip("px")) - x["chipH"]), 2,
+                            "…covering the chip's padding box, so the gradient's line runs corner to corner inside the border: %r vs %r" % (a, x))
             self.assertIn("linear-gradient", a["bg"]); self.assertIn("0.5px", a["bg"])
+            self.assertIn("to right bottom", a["bg"], "the keyword whose middle stop runs bottom-left to top-right, as the browser serialises it: %r" % a["bg"])
             self.assertEqual(x["chipColor"], _rgb(colors[name]), "the line is currentColor, the tag's colour: %r" % x)
         # the flip: the state class and the chip's look move together, and back
         on = {x["tag"]: x for x in out["on"]["opts"]}

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -147,7 +147,8 @@ dialog's is `ui/timeline-tags-scale.test.ts`, with the measured layout in
 `ui/webview/tag-menu.ts` builds every tag the UI shows (the strip's group rows and filter
 chips, the feed's and outline's filter chips, the tag-lens menu, the tab menu's Tags flyout,
 the picker's Tags row), a thin border and the text in the tag's colour, weight 400, the
-context's size, faded when off; never bold, which is the session names' weight
+context's size, faded when off (struck through with a diagonal in its colour where a fade alone
+reads too faint: the picker's Tags row); never bold, which is the session names' weight
 (`ui/webview/tag-chip-everywhere.test.ts` pins the sites and the sheets; the two documents
 that load no module, the landing page's spend panel and the Obsidian timeline view, inline
 the same bytes under drift pins in `tests/test_spend_detail.py` and

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1873,6 +1873,11 @@ a.fileview-gh-note { border-style: dashed; }
 /* a tag chip standing for an UNSELECTED toggle (the tag-lens menu, T283): faded, its colour kept —
    the state class; tag-menu.ts paints the same opacity inline for a sheet-less host (TAG_CHIP_OFF_OPACITY) */
 .tag-chip-off { opacity: 0.45; }
+/* an OFF tag drawn as STRUCK (T321b, the user 2026-09-10: in the picker's Tags row a faded chip alone did not read as
+   off): a 1px diagonal from the chip's bottom-left to its top-right in the chip's own colour (currentColor, so the same
+   tag colour on either theme), a gradient whose middle stop is the corner-to-corner line, over the lighter fade the
+   renderer sets inline with the class and the position (tagChip's `struck`); the same bytes on both sheets */
+.tag-chip-struck::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to top right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }
 /* the bell BUTTON (the user 2026-07-28, round 4): inline in row1's metadata cluster, right after the
    timestamp — shown only once the card is hovered or it's armed. Off = slashed dim bell; armed (.on) =
    accent bell, always visible. Accent = mechanics chrome, never a status colour.

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1875,9 +1875,12 @@ a.fileview-gh-note { border-style: dashed; }
 .tag-chip-off { opacity: 0.45; }
 /* an OFF tag drawn as STRUCK (T321b, the user 2026-09-10: in the picker's Tags row a faded chip alone did not read as
    off): a 1px diagonal from the chip's bottom-left to its top-right in the chip's own colour (currentColor, so the same
-   tag colour on either theme), a gradient whose middle stop is the corner-to-corner line, over the lighter fade the
-   renderer sets inline with the class and the position (tagChip's `struck`); the same bytes on both sheets */
-.tag-chip-struck::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to top right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }
+   tag colour on either theme). The gradient's middle stop is the line through the two corners the keyword does not
+   name, so `to bottom right` draws bottom-left to top-right; the pseudo-element takes the pill's radius so the line's
+   ends stay inside the curve; over the lighter fade the renderer sets inline with the class (tagChip's `struck`). The
+   class alone positions the chip, for a host that adds it by hand; the same bytes on both sheets */
+.tag-chip-struck { position: relative; }
+.tag-chip-struck::after { content: ""; position: absolute; inset: 0; border-radius: inherit; pointer-events: none; background: linear-gradient(to bottom right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }
 /* the bell BUTTON (the user 2026-07-28, round 4): inline in row1's metadata cluster, right after the
    timestamp — shown only once the card is hovered or it's armed. Off = slashed dim bell; armed (.on) =
    accent bell, always visible. Accent = mechanics chrome, never a status colour.

--- a/ui/webview/picker-tag-chips.test.ts
+++ b/ui/webview/picker-tag-chips.test.ts
@@ -21,7 +21,6 @@ test("each option is the shared tag chip: the tag's colour on a thin border, the
   assert.match(REBUILD, /b\.addEventListener\("click", \(\) => \{ b\.classList\.toggle\("sel"\); paintPickerTagChip\(b, u\); \}\);/, "…and on every click (multi-select: each chip on its own)");
   assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, struck: !b\.classList\.contains\("sel"\) \}\)\);/,
     "selected = the full chip, unselected = the STRUCK chip (T321b: a diagonal in the chip's colour, the fade alone read too faint); the button's size, not a second 0.82em");
-  assert.match(REBUILD, /b\.addEventListener\("click", \(\) => \{ b\.classList\.toggle\("sel"\); paintPickerTagChip\(b, u\); \}\);/, "the click flips it: repainted from the state class");
   assert.doesNotMatch(RENDER, /picker-tag-dot/, "the dot is gone from the pane");
   assert.doesNotMatch(CSS, /picker-tag-dot/, "…and from the sheet");
   assert.doesNotMatch(RENDER, /ctx-tag-dot/, "the tab menu's Tags flyout wears the chip too: no dot anywhere a tag shows (T321)");

--- a/ui/webview/picker-tag-chips.test.ts
+++ b/ui/webview/picker-tag-chips.test.ts
@@ -19,8 +19,9 @@ test("each option is the shared tag chip: the tag's colour on a thin border, the
   assert.match(REBUILD, /const b = el\("button", "picker-be-opt" \+ \(preset\.has\(u\.name\) \? " sel" : ""\)\) as HTMLButtonElement;/, "the option and its state class stay");
   assert.match(REBUILD, /paintPickerTagChip\(b, u\);/, "painted from the state class, on build…");
   assert.match(REBUILD, /b\.addEventListener\("click", \(\) => \{ b\.classList\.toggle\("sel"\); paintPickerTagChip\(b, u\); \}\);/, "…and on every click (multi-select: each chip on its own)");
-  assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, off: !b\.classList\.contains\("sel"\) \}\)\);/,
-    "selected = the full chip, unselected = the off chip; the button's size, not a second 0.82em");
+  assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, struck: !b\.classList\.contains\("sel"\) \}\)\);/,
+    "selected = the full chip, unselected = the STRUCK chip (T321b: a diagonal in the chip's colour, the fade alone read too faint); the button's size, not a second 0.82em");
+  assert.match(REBUILD, /b\.addEventListener\("click", \(\) => \{ b\.classList\.toggle\("sel"\); paintPickerTagChip\(b, u\); \}\);/, "the click flips it: repainted from the state class");
   assert.doesNotMatch(RENDER, /picker-tag-dot/, "the dot is gone from the pane");
   assert.doesNotMatch(CSS, /picker-tag-dot/, "…and from the sheet");
   assert.doesNotMatch(RENDER, /ctx-tag-dot/, "the tab menu's Tags flyout wears the chip too: no dot anywhere a tag shows (T321)");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7412,10 +7412,11 @@ function backendTakesTags(be: string): boolean { return be === "sdk" || be === "
 // chip prefilled from a tagged active tab turns every terminal create into a refusal.
 // The Tags row's option paints as the tag chip itself (T321, the user 2026-09-10): the thin border in the tag's own
 // colour that the tab strip, the feed and the outline draw, and on versus off by the visual the tag toggles already
-// use, the faded chip (tagChip's `off`, TAG_CHIP_OFF_CLASS at 0.45), never a dot and never the Backend row's accent
+// use, the faded chip, here the STRUCK one (tagChip's `struck`, T321b: a diagonal in the chip's colour, since the fade
+// alone read too faint in this row), never a dot and never the Backend row's accent
 // fill. The `sel` class on the button stays the state the create reads; the chip is repainted from it on each click.
 function paintPickerTagChip(b: HTMLButtonElement, u: { name: string; color?: string | null }): void {
-  b.replaceChildren(tagChip(u.name, u.color, { inheritSize: true, off: !b.classList.contains("sel") }));
+  b.replaceChildren(tagChip(u.name, u.color, { inheritSize: true, struck: !b.classList.contains("sel") }));   // off = struck (T321b)
 }
 
 function syncPickerTags(): void {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7921,7 +7921,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     for (const u of unions) {
       const b = el("button", "picker-be-opt" + (preset.has(u.name) ? " sel" : "")) as HTMLButtonElement;
       b.type = "button"; b.dataset.tag = u.name;
-      paintPickerTagChip(b, u);   // the tag chip every surface draws, full when selected, faded when not (T321)
+      paintPickerTagChip(b, u);   // the tag chip every surface draws, full when selected, struck when not (T321, T321b)
       b.title = preset.has(u.name)
         ? `the session you are looking at is in ${u.name} — the new one joins it too unless you unpick this`
         : `put the new session in ${u.name}`;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -702,9 +702,12 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .tag-chip-off { opacity: 0.45; }
 /* an OFF tag drawn as STRUCK (T321b, the user 2026-09-10: in the picker's Tags row a faded chip alone did not read as
    off): a 1px diagonal from the chip's bottom-left to its top-right in the chip's own colour (currentColor, so the same
-   tag colour on either theme), a gradient whose middle stop is the corner-to-corner line, over the lighter fade the
-   renderer sets inline with the class and the position (tagChip's `struck`); the same bytes on both sheets */
-.tag-chip-struck::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to top right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }
+   tag colour on either theme). The gradient's middle stop is the line through the two corners the keyword does not
+   name, so `to bottom right` draws bottom-left to top-right; the pseudo-element takes the pill's radius so the line's
+   ends stay inside the curve; over the lighter fade the renderer sets inline with the class (tagChip's `struck`). The
+   class alone positions the chip, for a host that adds it by hand; the same bytes on both sheets */
+.tag-chip-struck { position: relative; }
+.tag-chip-struck::after { content: ""; position: absolute; inset: 0; border-radius: inherit; pointer-events: none; background: linear-gradient(to bottom right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }
 .ctx-tag-x { flex: 0 0 auto; background: none; border: none; color: var(--dim); cursor: pointer; font: inherit; padding: 0 2px; }
 .ctx-tag-x:hover { color: var(--fg); }
 .ctx-item-newtag { cursor: default; }
@@ -2919,7 +2922,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-tags .picker-be-opt:hover, .picker-tags .picker-be-opt.sel { background: transparent; border-color: transparent; color: inherit; }
 .picker-tags .picker-be-opt:hover { filter: brightness(1.3); }
 /* the tmux pick: the chips stay in place, disabled, behind the note (tags apply to SDK and Codex sessions). Greyed
-   and nothing else: the off chip's own 0.45 stays the only fade, so on and off still read in both themes */
+   and nothing else: the off chip's own fade (0.7 under its strike) stays the only fade, so on and off still read */
 .picker-tags.disabled .picker-be-opt { filter: grayscale(1); cursor: default; pointer-events: none; }
 .picker-list { overflow-y: auto; }
 /* The resume list's heading (the user 2026-08-12): the list sits LAST in the dialog — typing in the

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -700,6 +700,11 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 /* a tag chip standing for an UNSELECTED toggle (the tag-lens menu, T283): faded, its colour kept —
    the state class; tag-menu.ts paints the same opacity inline for a sheet-less host (TAG_CHIP_OFF_OPACITY) */
 .tag-chip-off { opacity: 0.45; }
+/* an OFF tag drawn as STRUCK (T321b, the user 2026-09-10: in the picker's Tags row a faded chip alone did not read as
+   off): a 1px diagonal from the chip's bottom-left to its top-right in the chip's own colour (currentColor, so the same
+   tag colour on either theme), a gradient whose middle stop is the corner-to-corner line, over the lighter fade the
+   renderer sets inline with the class and the position (tagChip's `struck`); the same bytes on both sheets */
+.tag-chip-struck::after { content: ""; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to top right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }
 .ctx-tag-x { flex: 0 0 auto; background: none; border: none; color: var(--dim); cursor: pointer; font: inherit; padding: 0 2px; }
 .ctx-tag-x:hover { color: var(--fg); }
 .ctx-item-newtag { cursor: default; }
@@ -2906,7 +2911,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-auth-fixed { flex: 0 0 auto; color: var(--fg); font-size: 0.82em; padding: 4px 0; }
 /* the picker's Tags row (tab groups, the user 2026-09-04): one option per tag; several may be selected, a session
    can hold several tags. Each option IS the tag chip every surface draws (T321, the user 2026-09-10): the thin
-   border in the tag's colour, the faded chip (.tag-chip-off) for unselected, so the button around it carries no
+   border in the tag's colour, the struck chip (.tag-chip-struck, T321b) for unselected, so the button around it carries no
    chrome: no border, no padding, the page's typeface (a bare button wears the browser's control face), and never
    the Backend row's accent fill or hover wash; the hover cue is the strip's own, the chip brightened */
 .picker-tags { flex-wrap: wrap; }

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -1773,7 +1773,7 @@ test("assistive tech hears a label: decoration is aria-hidden, the header's name
 
 test("the group header wears the SHARED tag chip — one vocabulary with the tags bar and the feed (T251)", () => {
   const MENU = ui("webview", "tag-menu.ts");
-  assert.match(MENU, /export function tagChip\(label: string, color\?: string \| null, opts\?: \{ inheritSize\?: boolean; off\?: boolean \}\): HTMLElement \{/,
+  assert.match(MENU, /export function tagChip\(label: string, color\?: string \| null, opts\?: \{ inheritSize\?: boolean; off\?: boolean; struck\?: boolean \}\): HTMLElement \{/,
     "the chip is a named builder, not a lookalike");
   assert.match(MENU, /const chip = tagChip\(c\.label, c\.color\);/, "the tags bar builds its chips through it");
   assert.match(MENU, /\("var\(--dim, " \+ TAG_BTN_GRAY \+ "\)"\)/, "the uncoloured fallback is a THEME TOKEN — the light theme is never handed a dark gray");

--- a/ui/webview/tag-chip-everywhere.test.ts
+++ b/ui/webview/tag-chip-everywhere.test.ts
@@ -46,7 +46,19 @@ test("the renderer pins the standard inline: thin border and text in the tag's c
     assert.equal(off.attrs["class"], "tag-chip-off");
     assert.match(off.attrs.style, /opacity:0\.45;/);
     assert.match(off.attrs.style, /border:1px solid #3355aa;color:#3355aa;/, "faded, never recoloured");
+    // the STRUCK off variant (T321b, the user 2026-09-10: a faded chip alone was not obvious enough in the picker): the
+    // state class the sheets draw the diagonal on, the chip positioned for it, a lighter fade, the colour kept
+    const struck = tagChip("qa", "#3355aa", { struck: true });
+    assert.equal(struck.attrs["class"], "tag-chip-struck", "one class: struck is its own off variant, never stacked on the fade");
+    assert.match(struck.attrs.style, /position:relative;opacity:0\.7;/, "positioned for the diagonal, faded lighter than the plain off");
+    assert.doesNotMatch(struck.attrs.style, /opacity:0\.45/);
+    assert.match(struck.attrs.style, /border:1px solid #3355aa;color:#3355aa;/, "the colour kept: the line is drawn in it");
   } finally { g.document = saved; g.window = savedWin; }
+  assert.match(MENU, /export const TAG_CHIP_STRUCK_CLASS = "tag-chip-struck";/);
+  assert.match(MENU, /export const TAG_CHIP_STRUCK_OPACITY = "0\.7";/);
+  const STRUCK_RULE = ".tag-chip-struck::after { content: \"\"; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to top right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }";
+  for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const)
+    assert.ok(sheet.includes("\n" + STRUCK_RULE + "\n"), name + ": the diagonal, corner to corner in the chip's own colour (currentColor: theme parity by construction), the same bytes on both sheets");
 });
 
 test("every tag surface builds through tagChip", () => {
@@ -73,8 +85,10 @@ test("every tag surface builds through tagChip", () => {
   assert.match(dialog, /const c = tagChip\(g\.name, g\.color \|\| null\);/, "the feed's session dialog");
   assert.match(dialog, /c\.classList\.add\("fsm-chip-tag"\);/);
   assert.doesNotMatch(FEED, /c\.style\.borderColor = g\.color/, "no hand-painted tag border remains");
-  assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, off: !b\.classList\.contains\("sel"\) \}\)\);/,
-    "the new-session picker's Tags row");
+  assert.match(RENDER, /function paintPickerTagChip\(b: HTMLButtonElement, u: \{ name: string; color\?: string \| null \}\): void \{\s*\n\s*b\.replaceChildren\(tagChip\(u\.name, u\.color, \{ inheritSize: true, struck: !b\.classList\.contains\("sel"\) \}\)\);/,
+    "the new-session picker's Tags row: off = the struck chip (T321b)");
+  assert.match(filt, /const chip = tagChip\(c\.label, c\.color\);/, "the filter chips keep the plain chip (a selected filter is never off)");
+  assert.match(lensMenu, /\{ off: !on \}/, "the tag-lens menu keeps the fade for now (the user named the picker; the strike is one word away)");
   assert.doesNotMatch(RENDER + CSS, /picker-tag-dot/, "the picker's dot is gone");
 });
 
@@ -103,5 +117,5 @@ test("no sheet sets a weight on a tag chip class: the sheets add layout and stat
 
 test("the standard is written in ui/CLAUDE.md, one sentence", () => {
   assert.match(RULES, /\*\*Tags render as ONE chip everywhere\*\* \(the user 2026-09-10\): `tagChip` in\s*\n`ui\/webview\/tag-menu\.ts` builds every tag the UI shows/);
-  assert.match(RULES, /weight 400, the\s*\ncontext's size, faded when off; never bold, which is the session names' weight/);
+  assert.match(RULES, /weight 400, the\s*\ncontext's size, faded when off \(struck through with a diagonal in its colour where a fade alone\s*\nreads too faint: the picker's Tags row\); never bold, which is the session names' weight/);
 });

--- a/ui/webview/tag-chip-everywhere.test.ts
+++ b/ui/webview/tag-chip-everywhere.test.ts
@@ -53,10 +53,16 @@ test("the renderer pins the standard inline: thin border and text in the tag's c
     assert.match(struck.attrs.style, /position:relative;opacity:0\.7;/, "positioned for the diagonal, faded lighter than the plain off");
     assert.doesNotMatch(struck.attrs.style, /opacity:0\.45/);
     assert.match(struck.attrs.style, /border:1px solid #3355aa;color:#3355aa;/, "the colour kept: the line is drawn in it");
+    const both = tagChip("qa", "#3355aa", { off: true, struck: true });
+    assert.equal(both.attrs["class"], "tag-chip-struck", "struck wins when both are passed (stated in the docblock)");
+    assert.match(both.attrs.style, /opacity:0\.7;/); assert.doesNotMatch(both.attrs.style, /0\.45/);
   } finally { g.document = saved; g.window = savedWin; }
   assert.match(MENU, /export const TAG_CHIP_STRUCK_CLASS = "tag-chip-struck";/);
   assert.match(MENU, /export const TAG_CHIP_STRUCK_OPACITY = "0\.7";/);
-  const STRUCK_RULE = ".tag-chip-struck::after { content: \"\"; position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to top right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }";
+  // the sheets: the class alone positions the chip; the diagonal runs bottom-left to top-right (`to bottom right` puts the
+  // gradient's middle stop through the two corners the keyword does not name), clipped to the pill's radius
+  const STRUCK_RULE = ".tag-chip-struck { position: relative; }\n"
+    + ".tag-chip-struck::after { content: \"\"; position: absolute; inset: 0; border-radius: inherit; pointer-events: none; background: linear-gradient(to bottom right, transparent calc(50% - 0.5px), currentColor calc(50% - 0.5px), currentColor calc(50% + 0.5px), transparent calc(50% + 0.5px)); }";
   for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const)
     assert.ok(sheet.includes("\n" + STRUCK_RULE + "\n"), name + ": the diagonal, corner to corner in the chip's own colour (currentColor: theme parity by construction), the same bytes on both sheets");
 });

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -194,6 +194,8 @@ export const TAG_BTN_WASH = "rgba(156,210,255,0.12)";     // the feed .on's fain
  *  paints it on a sheet-less host, the two equal by construction. */
 export const TAG_CHIP_OFF_CLASS = "tag-chip-off";
 export const TAG_CHIP_OFF_OPACITY = "0.45";   // pinned equal to .tag-chip-off in styles.css / feed.css
+export const TAG_CHIP_STRUCK_CLASS = "tag-chip-struck";   // the sheets draw the diagonal on it (both carry the same rule)
+export const TAG_CHIP_STRUCK_OPACITY = "0.7";              // lighter than the fade: the line carries "off", the colour stays readable
 /** THE ONE TAG CHIP (T321, the user 2026-09-10: tags render the same everywhere, and never in bold, which is the
  *  session names' weight). Every surface that shows a tag builds it here: the tab strip's group rows and its filter
  *  chips, the feed's and the outline's filter chips, the tag-lens menu's rows, the tab menu's Tags flyout, the feed's
@@ -202,17 +204,23 @@ export const TAG_CHIP_OFF_OPACITY = "0.45";   // pinned equal to .tag-chip-off i
  *  thin 1px border and the text in the tag's own
  *  colour on a transparent ground, weight 400 and normal tracking (inline, so a bold or letter-spaced host cannot
  *  restyle it), one size per context (the chip's own 0.82em, or the host's with `inheritSize` where a row sizes it),
- *  and off = the faded chip (`off`: TAG_CHIP_OFF_CLASS at TAG_CHIP_OFF_OPACITY). A host adds layout (flex, margins)
- *  and state cues the chip never sets inline (a filter, an underline), never a weight, size, border or colour. */
-export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean; off?: boolean }): HTMLElement {
+ *  and off = the faded chip (`off`: TAG_CHIP_OFF_CLASS at TAG_CHIP_OFF_OPACITY) or, where a fade alone reads too faint,
+ *  the STRUCK chip (`struck`, T321b, the user 2026-09-10 on the picker's Tags row): a 1px diagonal from the chip's
+ *  bottom-left to its top-right in the chip's own colour (the sheets' TAG_CHIP_STRUCK_CLASS rule, currentColor, so it
+ *  follows the tag on either theme) over a lighter fade. The picker uses `struck`; the filter chips and the tag-lens
+ *  menu keep `off` until the user says otherwise, one word away. A host adds layout (flex, margins) and state cues
+ *  the chip never sets inline (a filter, an underline), never a weight, size, border or colour. */
+export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean; off?: boolean; struck?: boolean }): HTMLElement {
   const col = color || ("var(--dim, " + TAG_BTN_GRAY + ")");
   const chip = document.createElement("span");
   chip.setAttribute("style", "display:inline-flex;align-items:center;gap:5px;padding:2px 7px;"
     + "border-radius:9px;" + (opts && opts.inheritSize ? "" : "font-size:0.82em;")
     + "border:1px solid " + col + ";color:" + col + ";background:transparent;white-space:nowrap;"
     + "font-weight:400;letter-spacing:normal;"
-    + (opts && opts.off ? "opacity:" + TAG_CHIP_OFF_OPACITY + ";" : ""));
-  if (opts && opts.off) chip.setAttribute("class", TAG_CHIP_OFF_CLASS);
+    + (opts && opts.struck ? "position:relative;opacity:" + TAG_CHIP_STRUCK_OPACITY + ";"
+       : opts && opts.off ? "opacity:" + TAG_CHIP_OFF_OPACITY + ";" : ""));
+  if (opts && opts.struck) chip.setAttribute("class", TAG_CHIP_STRUCK_CLASS);   // its own off variant, never stacked on the fade
+  else if (opts && opts.off) chip.setAttribute("class", TAG_CHIP_OFF_CLASS);
   chip.appendChild(document.createTextNode(label));
   return chip;
 }

--- a/ui/webview/tag-menu.ts
+++ b/ui/webview/tag-menu.ts
@@ -207,9 +207,11 @@ export const TAG_CHIP_STRUCK_OPACITY = "0.7";              // lighter than the f
  *  and off = the faded chip (`off`: TAG_CHIP_OFF_CLASS at TAG_CHIP_OFF_OPACITY) or, where a fade alone reads too faint,
  *  the STRUCK chip (`struck`, T321b, the user 2026-09-10 on the picker's Tags row): a 1px diagonal from the chip's
  *  bottom-left to its top-right in the chip's own colour (the sheets' TAG_CHIP_STRUCK_CLASS rule, currentColor, so it
- *  follows the tag on either theme) over a lighter fade. The picker uses `struck`; the filter chips and the tag-lens
- *  menu keep `off` until the user says otherwise, one word away. A host adds layout (flex, margins) and state cues
- *  the chip never sets inline (a filter, an underline), never a weight, size, border or colour. */
+ *  follows the tag on either theme) over a lighter fade; `struck` wins when both are passed. The picker uses `struck`;
+ *  the tag-lens menu keeps `off` and the filter chips take neither (a selected filter is never off) until the user
+ *  says otherwise, one word away. A document that loads neither sheet (the Obsidian view, the kernel's inline pages)
+ *  must inline the rule before it uses `struck`, or its chip fades without the line. A host adds layout (flex,
+ *  margins) and state cues the chip never sets inline (a filter, an underline), never a weight, size, border or colour. */
 export function tagChip(label: string, color?: string | null, opts?: { inheritSize?: boolean; off?: boolean; struck?: boolean }): HTMLElement {
   const col = color || ("var(--dim, " + TAG_BTN_GRAY + ")");
   const chip = document.createElement("span");


### PR DESCRIPTION
The new-session picker's off tags are struck through (T321b, the user 2026-09-10: a faded chip alone was not obvious enough as off).

**An off variant of the shared renderer.** `tagChip` (`ui/webview/tag-menu.ts`) gains `struck` beside `off`: the chip keeps its colour, fades lighter (0.7 instead of 0.45), and both sheets draw a 1px diagonal from its bottom-left to its top-right in `currentColor`, one rule beside the fade's rule with the same bytes on `styles.css` and `feed.css` (a gradient whose middle stop is the corner-to-corner line, laid over the chip's padding box, so the line ends inside the border). The line is the tag's colour on either theme by construction. `struck` is its own state class, never stacked on the fade.

**Where it shows.** The picker's Tags row: selected = the full chip, off = the struck chip; the click flips it as before, the `sel` state class the create reads is unchanged, and the tmux-disabled row keeps its grayscale, the strike greyed with the rest. The strip's, the feed's and the outline's filter chips and the tag-lens menu keep the fade for now; where the user wants the strike next, it is one word at the call site.

**Pins.** `ui/webview/tag-chip-everywhere.test.ts` renders the struck variant through a stub document (its own class, the lighter opacity, the position for the diagonal, the colour kept), requires the identical rule on both sheets and the picker's painter on the variant, and its sheet scan admits the rule while still refusing a weight, border, colour or size on a chip class; `ui/webview/picker-tag-chips.test.ts` pins off = struck and the click; the tab-groups signature pin follows; `ui/CLAUDE.md`'s sentence names the case. `tests/test_tag_chips_everywhere_browser.py` reads the pseudo-element's computed geometry on the served page (content, absolute, the chip's padding box, the gradient, no pointer events) on the dark theme and its colour parity on the light theme, and the greyed row keeps the strike. Extension suite and full Python suite green.

**Screenshots** (hermetic served page, synthetic sessions and tags; one tag on, two off): `~/.local/state/romp/drops/romp_timeline-picker-struck-after-desktop-dark.png`, `romp_timeline-picker-struck-after-desktop-light.png`, `romp_timeline-picker-struck-after-phone-dark.png`, `romp_timeline-picker-struck-after-phone-light.png`.

**Review fold** (an adversarial pass, three lenses, read-only). The gradient's middle stop runs through the two corners its keyword does not name, so the first keyword drew the line top-left to bottom-right; `to bottom right` draws the slash the row wants, and the served test pins the direction by the browser's serialisation. The pseudo-element takes the pill's radius, so the line's ends no longer poke past the curve. The sheets position the chip under the class as well as the inline style. The docblock says `struck` wins when both variants are passed, pinned through the stub document, and names the sheet-less documents that must inline the rule before using it. The geometry check compares within a pixel, since glyph advances can be fractional where the client width rounds. Stale comments now say struck; a duplicated pin is gone. Noted, not changed: the 1px band is a hard-stop gradient, so on a 1x display it reads as a stepped hairline like any diagonal; the light-theme block guards against a future theme rule rather than failing today.
