### PR TITLE
A tap after the chat pane redialed lands again: the redial's first tab strip stamps the pane ready and consumes the parked reveal

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40410,7 +40410,19 @@ def _resolve_reconnect(c, chat_list):
     it (the pusher, the connect push a `ready` triggers included, _push_session_now, _confirm_close_now), so no
     strip can reach a reconnecting client before its set exists: a close confirmation landing in the gap before
     the pusher's first pass would otherwise paint the page's stale sessions as loaded tabs. No active hint (no
-    localStorage) → the kernel cannot know what the page shows → no set → today's full push (fail safe)."""
+    localStorage) → the kernel cannot know what the page shows → no set → today's full push (fail safe).
+    Returns whether the flag was popped HERE, so the caller knows the strip it is about to send is the redial's
+    first. That strip stands in for the `ready` a redial never posts: the bundle posted its one ready on an
+    earlier socket of this page, so no ready arm runs for this socket, and the pop stamps the client `ready` in
+    the arm's place (the target filter of _reveal_request reads the stamp); the caller then consumes a reveal
+    parked for the page's window right behind the strip (_consume_pending_reveal): strip, then focus, the order
+    the ready arm sends them in. The stamp itself lands earlier than the arm's (the arm stamps after its push;
+    this stamps before the caller's strip is enqueued), so a tap that reaches _reveal_request between this lock's
+    release and the strip's enqueue is sent ahead of the strip. Accepted: a redial is not a reload, so the page
+    still shows every tab it had, and a focus naming a session created during the outage arrives ahead of the
+    strip that lists it only the way a live tap outruns the pusher today (the bundle's focus handler acts by id
+    and treats the session's presence as optional). A client that declared no redial is left as it was, and the
+    caller does nothing more."""
     # ATOMIC under the client's slot lock, flag to set (review find 2026-09-07): with the pop and the stats outside
     # it, a second strip sender racing this one popped False, sent a keyless strip and a FULL for some sid, and
     # this sender then wrote a set still naming that sid — held whole by the client yet served only status frames
@@ -40418,14 +40430,19 @@ def _resolve_reconnect(c, chat_list):
     # holds whole (echat) is excluded outright, so a full that won the race can never be re-listed.
     with _client_lock(c):
         if not c.pop("reconnect", False):
-            return
+            return False
+        # The redial's stamp (2026-09-10): the page listens (the shim dials ?reconnect=1 only once the kernel's caps
+        # frame has answered its bundle's ready), and the bundle posts ready once, so nothing else would ever stamp
+        # this socket; without the stamp a tap for this window parked for the rest of the page's life.
+        c["ready"] = True
         act = c.get("active")
         if not act:
-            return
+            return True
         held = c.get("echat") or {}
         skel = [sid for sid in _skeleton_for(c, str(act), chat_list) if sid not in held]
         c["skeleton"] = set(skel)
         c["skeletonOrder"] = skel
+    return True
 
 
 def _send_tab_order(c, tab_order, tab_meta, live):
@@ -42883,8 +42900,10 @@ def _push(targets, connect=False, tmux=None):
                 _send_client(c, ("globalRetryPaused",), {"type": "globalRetryPaused", "value": _retry_paused_on(),
                                                          "resumeAt": _retry_resume_at(),   # limit reset epoch → the card counts down to the real retry
                                                          "reason": _retry_pause_reason()})   # "spend" → the card says 'raise your cap', no countdown
-                _resolve_reconnect(c, chat_list)         # a redialing page: fix its skeleton set BEFORE any strip
+                redialed = _resolve_reconnect(c, chat_list)   # a redialing page: fix its skeleton set BEFORE any strip
                 _send_tab_order(c, tab_order, tab_meta, tmux)
+                if redialed:                             # the redial's first strip stands in for the ready it never posts:
+                    _consume_pending_reveal(c, why="the pane's redial")   # a reveal parked for its window lands behind the strip
             active = {c.get("active") for c in chat_clients if c.get("active")}
             # Stable: active tabs first — and TRANSCRIPT-LESS sessions with them. A just-created session
             # has no transcript, so its build is near-free, and its creator is guaranteed to be staring
@@ -43388,8 +43407,10 @@ def _push_session_now(sid):
             return                                   # the periodic pusher owns the sid until content returns
         ms = None                                    # lazy: the first full send materializes it, the rest reuse
         for c in targets:
-            _resolve_reconnect(c, chat_list)         # a redialing page must never see a strip before its set exists
+            redialed = _resolve_reconnect(c, chat_list)   # a redialing page must never see a strip before its set exists
             _send_tab_order(c, tab_order, tab_meta, tmux)
+            if redialed:                             # this strip is the redial's first: a reveal parked for its window lands behind it
+                _consume_pending_reveal(c, why="the pane's redial")
             ms = _send_chat(c, m, ms, 0, True)       # change_from 0 → always the full-session form (…and releases a skeleton)
     except Exception:
         sys.stderr.write("push-session-now (%s): %s\n" % (sid, traceback.format_exc()))
@@ -43438,8 +43459,10 @@ def _confirm_close_now(sid):
             targets = [c for c in _clients if c["app"] == "chat"]
         for c in targets:
             try:
-                _resolve_reconnect(c, chat_list)     # a confirmation may be the FIRST strip a redialing page sees
+                redialed = _resolve_reconnect(c, chat_list)   # a confirmation may be the FIRST strip a redialing page sees
                 _send_tab_order(c, tab_order, tab_meta, tmux)
+                if redialed:                         # ...and then the sender that lands a reveal parked for its window
+                    _consume_pending_reveal(c, why="the pane's redial")
             except Exception:
                 c["alive"] = False
         return sid not in tab_order
@@ -45352,7 +45375,8 @@ def _sw_js():
 # mints and every same-window pane shares — so a second dashboard's reload cannot steal it). One
 # slot, latest wins: two taps before a boot completes should land on the newer notification.
 # `sent` (2026-09-06): the clients a LIVE tap was already handed to while unproven — see
-# _reveal_request; a pong from one of them retires the slot, a redial's ready consumes it.
+# _reveal_request; a pong from one of them retires the slot, a redial's first tab strip consumes it (a
+# redialed socket carries no ready, so _resolve_reconnect stamps it and its strip sender consumes).
 _PENDING_REVEAL = [None]                     # {"sid": ..., "wid": ...[, "sent": [clients]]} or None
 # The roads a shell may name in /reveal's `via`, the log line's first word (the ledger block above _push_ledger has
 # the design): the worker's message to a live window ('sw'), the deep link the page opened on or was navigated to
@@ -45402,8 +45426,12 @@ def _reveal_request(sid, wid, boot=False, via=""):
               the peer is unproven since the last heartbeat). Deliver as before AND keep a copy
               parked, tagged with who it went to: the pong that proves that socket alive retires it
               (_note_ws_inbound — the focus frame is ordered behind the ping it answers); a dead
-              socket never pongs, the pane redials, and its ready consumes the copy instead of
-              finding nothing. A socket with no ping outstanding is proven: nothing parked, so a
+              socket never pongs, the pane redials, and the redial's first tab strip consumes the
+              copy instead of finding nothing: a redialed socket carries no ready (the bundle posted
+              its one ready on the socket that died), so _resolve_reconnect stamps the client when
+              the first strip sender pops the flag, and that sender consumes behind its strip. A tap
+              in the gap between the redial's handshake and that strip parks like any other and is
+              landed by the same strip. A socket with no ping outstanding is proven: nothing parked, so a
               later ready never replays a landed tap — except on the boot road, where the copy is
               kept whatever the ping state (above) and the pane's own answer retires it.
 
@@ -45419,7 +45447,9 @@ def _reveal_request(sid, wid, boot=False, via=""):
         # same-wid chat socket exists from its handshake, but until its bundle posts ready it has no message
         # listener, so a focus sent to it vanishes — and its ready message, counted as an answer by
         # _note_ws_inbound, would retire the parked copy before the ready handler could consume it (the
-        # review find on T312). Such a socket is left alone: the park stands and its ready consumes.
+        # review find on T312). Such a socket is left alone: the park stands and its ready consumes. A
+        # redial (?reconnect=1) never posts a ready: _resolve_reconnect stamps it at its first tab strip,
+        # and that strip's sender consumes the park.
         targets = [c for c in _clients if c["app"] == "chat" and (c.get("wid") or "") == wid and c.get("ready")]
     delivered, sent = False, []
     for c in targets:
@@ -45458,18 +45488,23 @@ def _reveal_proven(client):
         print("[reveal] sid=%s: copy retired — its target answered" % str(p["sid"])[:8], file=sys.stderr)
 
 
-def _consume_pending_reveal(client):
+def _consume_pending_reveal(client, why="the pane's ready"):
     """Called from the WS 'ready' handler: if this is the chat pane the parked reveal was aimed
     at, deliver and clear. Runs AFTER the ready push, so the session tabs this focus names are
     already on the client (same socket, ordered delivery). An empty parked wid matches the first
-    chat pane to arrive — the no-sessionStorage fallback, better than dropping the tap."""
+    chat pane to arrive — the no-sessionStorage fallback, better than dropping the tap.
+    Also called by each tab-strip sender right after a redial's FIRST strip (_resolve_reconnect
+    popped the flag): a redialed socket never carries a ready, so that strip is the event that
+    consumes; the strip is sent first, for the same reason the ready push precedes the arm's
+    consume. `why` names the event on the journal line, so a park's end says which of the two
+    landed it."""
     p = _PENDING_REVEAL[0]
     if not p or client.get("app") != "chat":
         return
     if p["wid"] and (client.get("wid") or "") != p["wid"]:
         return
     _PENDING_REVEAL[0] = None
-    print("[reveal] sid=%s wid=%s: consumed — the pane's ready" % (str(p["sid"])[:8], str(p["wid"] or "")[:8]), file=sys.stderr)
+    print("[reveal] sid=%s wid=%s: consumed — %s" % (str(p["sid"])[:8], str(p["wid"] or "")[:8], why), file=sys.stderr)
     try:
         client["send"](json.dumps(_reveal_msg(p["sid"])))
     except Exception:

--- a/tests/test_chat_skeleton_reconnect.py
+++ b/tests/test_chat_skeleton_reconnect.py
@@ -49,6 +49,8 @@ GONE = "11111111-2222-3333-4444-555555555559"  # an ended session, listed nowher
 NAMES = {S1: "web", S2: "api", S3: "tests", S4: "docs"}
 TAB_ORDER = [S2, S1, S3, S4]                  # big, mid, small — the tab order is NOT the size order
 SIZES = {S2: 3000, S1: 2000, S3: 1000}        # transcript bytes; S4 has none
+# the journal of a tap that parked on the named road and was landed by the redial's first strip (item 12)
+REDIAL_TRAIL = r"\[reveal\] %s sid=\S+ wid=W1: parked[\s\S]*\[reveal\] sid=\S+ wid=W1: consumed \S+ the pane's redial"
 
 
 def _sess(sid, n, state):
@@ -388,6 +390,9 @@ class SkeletonReconnect(unittest.TestCase):
             self.assertIn("_send_tab_order(c, tab_order, tab_meta, tmux)", s, fn.__name__)
             self.assertLess(s.index("_resolve_reconnect(c, chat_list)"), s.index("_send_tab_order(c, tab_order, tab_meta, tmux)"),
                             fn.__name__ + ": resolve BEFORE the strip")
+            self.assertIn("_consume_pending_reveal(c", s, fn.__name__ + ": a redial's first strip consumes a parked reveal")
+            self.assertLess(s.index("_send_tab_order(c, tab_order, tab_meta, tmux)"), s.index("_consume_pending_reveal(c"),
+                            fn.__name__ + ": the strip BEFORE the focus it names a tab of")
         i = src.find('msg.get("type") == "ready"')
         body = src[i:i + 2600]
         self.assertNotIn("_send_tab_order(client", body,
@@ -483,6 +488,117 @@ class SkeletonReconnect(unittest.TestCase):
         for name in ("_send_chat", "_send_chat_or_status"):
             s = inspect.getsource(getattr(km, name))
             self.assertLess(s.index("with _client_lock("), s.index("_send_chat_locked("), name)
+
+    # ── item 12 ──
+    def test_12_a_reveal_parked_while_the_page_had_no_socket_lands_behind_the_redials_first_strip(self):
+        # A push tap (or a deep link, or a vanished notification) reached the kernel while the page's socket was
+        # dead: /reveal found no ready chat pane for the window and parked. The page redials with ?reconnect=1 and
+        # its bundle, which posted ready once, never posts another, so no ready arm runs for the new socket. The
+        # pusher's first strip for the redial is the event that stands in: it stamps the client, sends the strip,
+        # then delivers the parked focus, so the focus names a tab the strip has already listed.
+        km._PENDING_REVEAL[0] = None
+        km._tmux_sessions = lambda: {S1: {}}       # the tapped session is live, so the reveal is a focus, not a revive
+        try:
+            trail = io.StringIO()
+            with contextlib.redirect_stderr(trail):
+                self.assertFalse(km._reveal_request(S1, "W1", via="vanish"), "no socket for the window: parked")
+                self.assertEqual(km._PENDING_REVEAL[0], {"sid": S1, "wid": "W1"})
+                c = self._client(active=S1, reconnect=True, wid="W1")
+                km._push([c])
+            self.assertIs(c.get("ready"), True, "the redial's first strip stamps the client as the ready arm would")
+            self.assertIsNone(km._PENDING_REVEAL[0], "the park was consumed")
+            types = [f["type"] for f in c["_frames"]]
+            self.assertIn("focus", types, "the parked focus landed on the redialed socket")
+            self.assertLess(types.index("tabOrder"), types.index("focus"), "behind the strip that names its tab")
+            self.assertLess(types.index("focus"), types.index("session"), "and ahead of the cycle's session frames")
+            focus = self._frames(c, "focus")
+            self.assertEqual(len(focus), 1)
+            self.assertEqual((focus[0]["id"], focus[0]["live"]), (S1, True))
+            self.assertEqual(self._tab_orders(c)[0]["skeleton"], [S3, S2], "the redial is still served as a skeleton set")
+            self.assertRegex(trail.getvalue(), REDIAL_TRAIL % "vanish", "the journal says which event landed the park")
+            # the next cycle consumes nothing: the flag is gone, and there is nothing parked
+            c["_frames"].clear()
+            with contextlib.redirect_stderr(io.StringIO()):
+                km._push([c])
+            self.assertEqual(self._frames(c, "focus"), [])
+            # a fresh page (no redial) with a park for its window is left to its own ready, as before
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertFalse(km._reveal_request(S1, "W2", via="sw"))
+                fresh = self._client(active=S1, wid="W2")
+                km._push([fresh])
+            self.assertEqual(self._frames(fresh, "focus"), [], "no redial: the strip consumes nothing")
+            self.assertNotIn("ready", fresh)
+            self.assertEqual(km._PENDING_REVEAL[0], {"sid": S1, "wid": "W2"}, "the park stands for the ready arm")
+        finally:
+            km._PENDING_REVEAL[0] = None
+
+    def _park_for_a_redialing_page(self, via):
+        """A tap parked while the window had no socket, then the page's redial registered at its handshake:
+        the client is in _clients with the flag and no stamp, exactly as _ws leaves it before any strip."""
+        km._PENDING_REVEAL[0] = None
+        km._tmux_sessions = lambda: {S1: {}}       # the tapped session is live, so the reveal is a focus, not a revive
+        trail = io.StringIO()
+        with contextlib.redirect_stderr(trail):
+            self.assertFalse(km._reveal_request(S1, "W1", via=via), "no socket for the window: parked")
+        c = self._client(active=S1, reconnect=True, wid="W1")
+        km._clients.append(c)
+        return c, trail
+
+    def _assert_landed_behind_the_first_strip(self, c, trail, via):
+        self.assertIs(c.get("ready"), True, "stamped by the strip sender that popped the flag")
+        self.assertIsNone(c.get("reconnect"))
+        self.assertIsNone(km._PENDING_REVEAL[0], "the park was consumed")
+        types = [f["type"] for f in c["_frames"]]
+        self.assertIn("focus", types)
+        self.assertLess(types.index("tabOrder"), types.index("focus"), "behind the strip that names its tab")
+        self.assertEqual([(f["id"], f["live"]) for f in self._frames(c, "focus")], [(S1, True)])
+        self.assertEqual(self._tab_orders(c)[0]["skeleton"], [S3, S2], "the strip is still the redial's skeleton strip")
+        self.assertRegex(trail.getvalue(), REDIAL_TRAIL % via)
+
+    def test_12b_a_close_confirmation_as_the_redials_first_strip_lands_the_park_too(self):
+        # the off-cycle sender that can be the FIRST strip a redialing page sees (test_10b): it stamps and consumes
+        # like the pusher's pass does, so a park does not wait for the next cycle
+        c, trail = self._park_for_a_redialing_page("sw")
+        try:
+            with contextlib.redirect_stderr(trail):
+                self.assertTrue(km._confirm_close_now(GONE))
+            self._assert_landed_behind_the_first_strip(c, trail, "sw")
+        finally:
+            km._PENDING_REVEAL[0] = None
+
+    def test_12c_a_session_push_as_the_redials_first_strip_lands_the_park_too(self):
+        # the other off-cycle sender (a create or a handshake for one tab, test_05), as the redial's first strip
+        c, trail = self._park_for_a_redialing_page("link")
+        try:
+            with contextlib.redirect_stderr(trail):
+                km._push_session_now(S3)
+            self._assert_landed_behind_the_first_strip(c, trail, "link")
+            self.assertEqual(self._sessions(c), [S3], "the push's own full still follows")
+        finally:
+            km._PENDING_REVEAL[0] = None
+
+    def test_12d_the_ready_arm_over_a_still_flagged_client_lands_the_park_once_as_the_ready(self):
+        # the arm's path and the strip's cannot both land one park: _client_reset_chat_base pops the flag before the
+        # connect push, so that push's strip resolves nothing, and the arm's own consume (after the push) is the one;
+        # the journal names the ready, not the redial, and there is one focus (green before and after the change)
+        c, trail = self._park_for_a_redialing_page("sw")
+        try:
+            h = _Self(lambda cl: km._push([cl], connect=True))   # the real _push_one body
+            with contextlib.redirect_stderr(trail):
+                km.Handler._dispatch_ws(h, {"type": "ready"}, c)
+            self.assertEqual(h.calls, [c])
+            self.assertIs(c.get("ready"), True)
+            self.assertIsNone(km._PENDING_REVEAL[0])
+            for k in ("skeleton", "skeletonOrder", "reconnect"):
+                self.assertNotIn(k, c, k)
+            types = [f["type"] for f in c["_frames"]]
+            self.assertEqual(types.count("focus"), 1, "one focus: the arm's")
+            self.assertLess(types.index("tabOrder"), types.index("focus"))
+            self.assertEqual(sorted(self._sessions(c)), sorted(TAB_ORDER), "the arm's push is every full, no set")
+            self.assertRegex(trail.getvalue(), r"consumed \S+ the pane's ready")
+            self.assertNotIn("the pane's redial", trail.getvalue(), "the strip inside the arm's push resolved no flag")
+        finally:
+            km._PENDING_REVEAL[0] = None
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_webpush.py
+++ b/tests/test_kernel_webpush.py
@@ -1392,7 +1392,8 @@ class RevealAiming(unittest.TestCase):
         # answered yet (pingAt set — the peer is unproven since the last heartbeat). The focus goes
         # out as before, AND stays parked: the pong that proves the socket alive retires the copy
         # (the frame is ordered behind the ping it answers); a dead socket never pongs, the pane
-        # redials, and its ready consumes the copy instead of finding nothing.
+        # redials, and the redial's first tab strip consumes the copy instead of finding nothing
+        # (_resolve_reconnect stamps the client, its strip sender consumes; the redial posts no ready).
         c, got = self._register("chat", "W1")
         c["pingAt"] = 100.0
         with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
@@ -1411,7 +1412,7 @@ class RevealAiming(unittest.TestCase):
         with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
             self.assertTrue(km._reveal_request("S", "W1"))
         self.assertIsNone(km._PENDING_REVEAL[0], "a socket with no ping outstanding is proven — nothing parked")
-        # the dead case: never pongs; the pane's redial says ready and takes the copy
+        # the dead case: never pongs; the redial's first strip takes the copy (its sender's consume, called here)
         c["pingAt"] = 100.0
         with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
             km._reveal_request("S", "W1")
@@ -1419,6 +1420,40 @@ class RevealAiming(unittest.TestCase):
             km._consume_pending_reveal(fresh)
         self.assertEqual(fresh_got, [{"type": "focus", "id": "S", "live": True}])
         self.assertIsNone(km._PENDING_REVEAL[0])
+
+    def test_a_redialed_pane_is_a_target_and_its_first_strip_consumes_the_park(self):
+        """A pane whose socket died in the SAME kernel process redials (the shim's ?reconnect=1), and its
+        bundle posts ready once per page life, so no ready ever arrives on the new socket: nothing stamped
+        the redial, so it was never a target and nothing consumed a park aimed at its window. The tap after
+        a phone suspend or a dropped link parked for good, until the page reloaded. The redial's first tab
+        strip is the event that stands in for the ready: _resolve_reconnect stamps the client when it pops
+        the flag and says so, and the strip sender consumes the park right behind the strip it just sent."""
+        with mock.patch.object(km, "_tmux_sessions", return_value={"S": {}}):
+            self.assertFalse(km._reveal_request("S", "W1", via="vanish"), "the socket died: the tap parks")
+            self.assertEqual(km._PENDING_REVEAL[0], {"sid": "S", "wid": "W1"})
+            c, got = self._register("chat", "W1")
+            del c["ready"]                    # registered at its handshake; no ready will follow on this socket
+            c["reconnect"] = True             # the shim's own statement: this page held the sessions before
+            self.assertFalse(km._reveal_request("S", "W1", via="sw"), "before its first strip the redial is no target")
+            self.assertEqual(got, [], "nothing is sent to a pane whose strip has not gone yet")
+            self.assertEqual(km._PENDING_REVEAL[0], {"sid": "S", "wid": "W1"}, "the park stands")
+            # the first strip sender pops the flag: the client is stamped, and the sender is told to consume
+            self.assertTrue(km._resolve_reconnect(c, []), "a popped redial flag says so")
+            self.assertIs(c.get("ready"), True, "the redial is stamped like a pane whose ready was heard")
+            self.assertIsNone(c.get("reconnect"))
+            km._consume_pending_reveal(c, why="the pane's redial")
+            self.assertEqual(len(got), 1)
+            self.assertEqual((got[0]["type"], got[0]["id"], got[0]["live"]), ("focus", "S", True))
+            self.assertIsNone(km._PENDING_REVEAL[0], "consumed")
+            # from here the redialed pane is an ordinary target: the next tap lands at once
+            self.assertTrue(km._reveal_request("S", "W1", via="sw"))
+            self.assertEqual((got[-1]["type"], got[-1]["id"]), ("focus", "S"))
+            self.assertEqual(len(got), 2)
+            # a client that declared no redial is left as it was: not stamped, and its sender told nothing
+            fresh, fresh_got = self._register("chat", "W2")
+            del fresh["ready"]
+            self.assertFalse(km._resolve_reconnect(fresh, []))
+            self.assertNotIn("ready", fresh)
 
 
 class RevealRoute(unittest.TestCase):


### PR DESCRIPTION
## Symptom

A notification tap, a deep link or a vanished notification does nothing when it reaches the kernel after the chat pane's socket died in the same kernel process (a phone suspend, a dropped link, a frozen tab) and the pane redialed. The journal shows `[reveal] <road> sid=... wid=...: parked` and no `consumed` line, and the tap lands only after a page reload. A redial against a new kernel process is unaffected: the page reloads itself (T265) and the fresh bundle's ready consumes.

## Cause

Since the ready gate from T312 (#1355), `_reveal_request` targets only a same-wid chat socket stamped `ready`, and the one consumer of a park was the WS ready arm, which stamps the client and calls `_consume_pending_reveal`. A redial (`?reconnect=1`) never posts a ready: the bundle posts `{type: "ready"}` once per page life (the last line of render.ts), on the socket that died, and the shim dials the reconnect term only once that ready was answered by the caps frame. So a redialed socket was never stamped, never a target, and never consumed anything, and every reveal for its window parked for the rest of the page's life. `_reveal_proven` never retired such a park either, since a redialed socket is never in a park's `sent` list. Before the gate a same-wid socket was a target and the tap landed directly.

The comments at the slot and in `_reveal_request`'s docstring ("a redial's ready consumes it") described a ready a redialed socket has not carried since the reconnect redial (#1017), and the RevealAiming test modelled the redial by calling `_consume_pending_reveal` on a fresh fake client directly. The shell socket re-sends its own ready on every open, but it is a different app: `_consume_pending_reveal` returns for a non-chat client and `_push_one` pushes to the given client only, so it can neither consume a chat park nor run a chat client's `_resolve_reconnect`.

## Fix

The redial's first tab strip is the event that stands in for the ready: the shim's `reconnect=1` states that the bundle posted ready and the caps frame answered it, so the page listens.

- `_resolve_reconnect` stamps `c["ready"] = True` when it pops a truthy `reconnect`, under the client lock it already holds (the pop stays first), and returns True from both the no-`active` return and the skeleton path; False when the flag is absent.
- The three strip senders (`_push`, `_push_session_now`, `_confirm_close_now`) keep `_resolve_reconnect` before `_send_tab_order` and, when it returned True, call `_consume_pending_reveal(c, why="the pane's redial")` right after the strip: strip, then focus, the order the ready arm sends them in. In `_push` that is before the same cycle's session frames; the bundle's focus handler acts on strip tabs by id and treats the session's presence as optional, and a redialed page still holds every session it had.
- The stamp itself lands earlier than the arm's: the arm stamps after its push, this stamps before the sender's strip is enqueued, so a tap that reaches `_reveal_request` between the resolve's lock release and the strip's enqueue is sent ahead of the strip. Accepted and said in the docstring: a redial is not a reload, the page still shows every tab it had, and a focus naming a session created during the outage arrives ahead of the strip that lists it only the way a live tap outruns the pusher today.
- `_consume_pending_reveal` gains an optional `why`, used on the journal line only. The default is byte-identical to today's line, so the RevealRoute exact-line pin and the browser tap test's `consumed \S+ the pane's ready` regex stay matched. For this case the journal reads `parked` and then `consumed ... the pane's redial`.
- A tap arriving between the redial's handshake and its first strip parks (no stamp yet) and is landed by that same strip. The ready arm cannot double-consume: `_client_reset_chat_base` pops `reconnect` before `_push_one`, so `_resolve_reconnect` returns False there.
- The comments that said a redial's ready consumes now say the redial's first strip does, in the kernel and in the two RevealAiming comments that repeated the sentence.

Rejected: a shim-side re-posted ready would run `_client_reset_chat_base` and a whole-page full push, the cost the skeleton redial exists to avoid, and would fight the shim's redial gate; stamping `ready` in `_ws` at the handshake would let a tap in the handshake-to-strip gap be delivered ahead of the strip.

`_consume_pending_reveal` now also runs on the pusher thread and the two event-push threads. `_PENDING_REVEAL` is a lock-free single slot, the pattern the /reveal handler and the ready arm already share, so a race yields at worst a duplicate focus (idempotent on the page) or one lost slot, the class of hazard that exists today.

Adjacent and pre-existing, not changed here: between a redial's registration and the superseded twin's handler `finally`, both clients sit in `_clients` and the twin keeps `ready=True` with `alive=False`, so `_reveal_request` can hand a proven live tap to the dead twin and park nothing; `and c.get("alive")` in the targets filter would close it. Also pre-existing: a proven delivery with no copy does not clear an older park for the same wid, so a stale park could be consumed by the redial's first strip and replay an old focus; the new consume makes that slightly more reachable.

Neighbours: the ready gate and the RevealAiming pins in tests/test_kernel_webpush.py came in with T312 (#1355); every pin there stays green and the new test joins that class. tests/test_chat_skeleton_reconnect.py was introduced by lczh's #1017 (the reconnect skeletons) and is extended here. Open PR #1126 (chat-split) rewrites `_consume_pending_reveal`'s send to add `own: True` and pins that text, and changes four RevealAiming expected frames; this change keeps its hunk in that function to the def line, the docstring and the journal line, and the new tests assert on the focus frame's `type`, `id` and `live` rather than exact lists, so they hold with or without `own`. Whichever of the two lands second rebases that function.

## Tests

Every new test runs in-process over the fake ws client: no browser, no processes.

- tests/test_kernel_webpush.py, RevealAiming, `test_a_redialed_pane_is_a_target_and_its_first_strip_consumes_the_park`: a tap parks with no socket; a redialed client (`ready` absent, `reconnect` set) is no target and nothing is sent to it; `_resolve_reconnect` returns True and stamps it; `_consume_pending_reveal` lands the focus (`type`, `id`, `live`) and clears the slot; the next tap lands at once; a client with no flag is left unstamped. Before the change it fails at `assertTrue(km._resolve_reconnect(c, []))`: `None is not true`.
- tests/test_chat_skeleton_reconnect.py, SkeletonReconnect, `test_12_a_reveal_parked_while_the_page_had_no_socket_lands_behind_the_redials_first_strip`: drives the real `_push` over a redialing client with a park for its window. The client is stamped, the park is consumed, `tabOrder` precedes the `focus` whose id is the tapped session and the focus precedes the cycle's session frames, the strip still carries the skeleton set, the journal reads `parked` then `consumed ... the pane's redial`, the next cycle consumes nothing, and a fresh page with a park for its window is left to its ready arm. Before the change it fails at `assertIs(c.get("ready"), True)`: `None is not True`. Removing `why=` from `_push`'s call fails its journal assertion.
- `test_12b_a_close_confirmation_as_the_redials_first_strip_lands_the_park_too` and `test_12c_a_session_push_as_the_redials_first_strip_lands_the_park_too`: the same over `_confirm_close_now(GONE)` and `_push_session_now(S3)` as the redial's first strip (the client in `_clients`, as test_10b and test_05 drive them): stamped, consumed, `tabOrder` before the focus, the skeleton strip intact, the journal line names the redial. Each fails before the change on the missing stamp, and each fails alone when its sender's consume is removed (the test_10 source pin is no longer the only guard on those two sites).
- `test_12d_the_ready_arm_over_a_still_flagged_client_lands_the_park_once_as_the_ready`: dispatches `{"type": "ready"}` through the real `_push_one` body over a client still carrying `reconnect` with a park for its window: one focus frame, the arm's, behind the strip; the journal names the ready and not the redial; the set and the flag are gone and every full is sent. Green before and after the change: it pins that the arm's path is untouched and that the two consumers cannot both land one park.
- `test_10_source_pins_every_strip_sender_resolves_and_uses_the_one_builder` now also requires `_consume_pending_reveal(c` after `_send_tab_order(c, tab_order, tab_meta, tmux)` in each of the three senders; before the change it fails on `_push`.

Targeted: tests/test_kernel_webpush.py and tests/test_chat_skeleton_reconnect.py, 131 passed; tests/test_kernel_tabs_first.py, tests/test_timeline_views.py and tests/test_notification_tap_resume_browser.py, 54 passed. Full suite (`pytest -n 6 tests/`, with the extension's node_modules installed so the served-page legs run): 11726 passed, 45 skipped, 1746 subtests passed in 191 s, no failures.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)