### PR TITLE
One parse for the kernel and the judges (lazy transcripts, stage 2)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -974,9 +974,10 @@ display parse delegates to it, the tree the chat renders is the tree the
 judges walk, and the store keys on every fact either side keyed on (the
 transcript's and the states file's stat pair, the pending rollback cut, and
 whether a backend owns the session, which one owner hook answers for both).
-A session read under two different cuts keeps a slot per cut rather than one
-side reading the other's view; the store evicts the least recently used entry
-past 256 instead of clearing wholesale. The gain is one tree per session, about
+A session read under a new pending cut gets a slot of its own and the spent
+cut's slot is dropped with it, so one tree per session holds through a
+rollback; the store evicts the least recently used entry past 256 instead of
+clearing wholesale. The gain is one tree per session, about
 a quarter of the record cost the T311 report measured (0.25 GB of 6.6); the
 record cache itself, the bulk, is the checkpoint work's target.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -976,8 +976,10 @@ transcript's and the states file's stat pair, the pending rollback cut, and
 whether a backend owns the session, which one owner hook answers for both).
 A session read under a new pending cut gets a slot of its own and the spent
 cut's slot is dropped with it, so one tree per session holds through a
-rollback; the store evicts the least recently used entry past 256 instead of
-clearing wholesale. The gain is one tree per session, about
+rollback. A parse of another transcript under a session's id (a subagent
+viewer's agent file, an episode render) has a slot of its own beside the live
+leaf's, so the two never evict each other; the store evicts the least recently
+used entry past 256 instead of clearing wholesale. The gain is one tree per session, about
 a quarter of the record cost the T311 report measured (0.25 GB of 6.6); the
 record cache itself, the bulk, is the checkpoint work's target.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -978,8 +978,11 @@ A session read under a new pending cut gets a slot of its own and the spent
 cut's slot is dropped with it, so one tree per session holds through a
 rollback. A parse of another transcript under a session's id (a subagent
 viewer's agent file, an episode render) has a slot of its own beside the live
-leaf's, so the two never evict each other; the store evicts the least recently
-used entry past 256 instead of clearing wholesale. The gain is one tree per session, about
+leaf's, so the two never evict each other. When a `/clear` or a resume fork
+moves a session to a new transcript, the previous leaf's tree is dropped the
+moment discovery first hands out the new one, so it holds across clears too.
+The store evicts the least recently used entry past 256 instead of clearing
+wholesale. The gain is one tree per session, about
 a quarter of the record cost the T311 report measured (0.25 GB of 6.6); the
 record cache itself, the bulk, is the checkpoint work's target.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -966,6 +966,20 @@ enumerates, which the checkpoint work that follows removes. `/perf`'s `parses`
 counts the cold parses, and `scripts/bench_boot_parse.py` measures a boot's
 cost against transcript size on synthetic worlds.
 
+The kernel and the judges share one parse. Until 2026-09-11 each kept its own
+cache of parsed session trees (the kernel's keyed by transcript path, the
+judges' by session), so every live transcript was parsed twice per file
+version and held twice. The judges' cache is now the one store: the kernel's
+display parse delegates to it, the tree the chat renders is the tree the
+judges walk, and the store keys on every fact either side keyed on (the
+transcript's and the states file's stat pair, the pending rollback cut, and
+whether a backend owns the session, which one owner hook answers for both).
+A session read under two different cuts keeps a slot per cut rather than one
+side reading the other's view; the store evicts the least recently used entry
+past 256 instead of clearing wholesale. The gain is one tree per session, about
+a quarter of the record cost the T311 report measured (0.25 GB of 6.6); the
+record cache itself, the bulk, is the checkpoint work's target.
+
 What the CLI itself does when its parent goes quiet was measured on Claude Code
 2.1.257 (2026-09-10, the restart-surviving sessions program's stage 3 probe, run
 against a throwaway config directory): a permission request (`can_use_tool`)
@@ -1279,12 +1293,14 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   longer wait between cycles would have skipped; a conservative undercount,
   since a wake set by another thread or a periodic repost of an unchanged
   frame marks a cycle busy).
-- `parses`: the cold event-model parses this kernel ran, `total`, `bytes`
-  (the parsed files' sizes) and `bySid` (per session, by the first eight
-  characters of its id), plus `judge`, the judges' own cold parses through
-  their separate cache. The acceptance number of the lazy-transcript work: a
-  boot with no client connected reads zero here, and a connecting chat client
-  adds exactly its shown tabs.
+- `parses`: the cold event-model parses through the one parse store the
+  kernel and the judges share: `total` (every miss, whoever asked), `kernel`
+  (the display's asks among them, with `bytes`, the parsed files' sizes, and
+  `bySid`, per session by the first eight characters of its id), `judge` (the
+  rest), `hits` (the display's asks served from the store) and `sharedHits`
+  (every hit). The acceptance number of the lazy-transcript work: a boot with
+  no client connected reads `kernel` zero, and a connecting chat client adds
+  at most its shown tabs.
 - `stages_ms`: `jobs` (the cycle's tick jobs outside the push), `push`, and
   inside it `push.chat`, `push.feed`, `push.timeline`, `push.send`. The
   `push.*` stages count every push, including the one a connecting page gets,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -175,6 +175,7 @@ def _rebind_state(path):
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
     _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
     _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
+    parse_cache_clear()      # the parses belong to the old root too
     _COURIER_SEEN.clear()   # the courier gate keys on the old root's files
     _PLANNER_SEEN.clear()   # ...and the planner gate
     _BACKREF_MEMO["slot"] = None   # ...and so does the sender-board walk's map
@@ -1316,7 +1317,7 @@ def _sig_inputs(tier, fsid, path):
     if tier in ("group", "consolidate"):
         ident += [STATE / "cleared.jsonl"]
     if tier == "distill":
-        ident += [(STATE / "states") / (fsid + ".jsonl")]
+        ident += [STATESDIR / (fsid + ".jsonl")]
         value += [STATE / "auto-nudge.json"]
     return ident, value
 
@@ -2721,11 +2722,15 @@ class _ParseStore(collections.OrderedDict):
         return None
 
     def __getitem__(self, k):
-        if not isinstance(k, tuple):
+        if not isinstance(k, tuple):                     # a bare id: the newest slot's newest tree, as (key, session, leaf, flag)
             nk = self._newest(k)
             if nk is None:
                 raise KeyError(k)
-            return super().__getitem__(nk)
+            trees = super().__getitem__(nk)
+            ent = _newest_of(trees)
+            if ent is None:
+                raise KeyError(k)
+            return ent
         return super().__getitem__(k)
 
     def get(self, k, default=None):
@@ -2738,12 +2743,13 @@ class _ParseStore(collections.OrderedDict):
         return (self._newest(k) is not None) if not isinstance(k, tuple) else super().__contains__(k)
 
     def __setitem__(self, k, v):
-        if not isinstance(k, tuple):
-            k = (k, _pending_cut(k))
+        if not isinstance(k, tuple):                     # a bare id write (a test stand-in): one tree under the live cut
+            flag = bool(v[3]) if isinstance(v, tuple) and len(v) > 3 else False
+            k, v = (k, _pending_cut(k)), {flag: v}
         super().__setitem__(k, v)
 
 
-_PARSE_CACHE = _ParseStore()   # (fsid, cut) -> (key, session, leaf, sdk_human); a bare fsid reads the newest slot
+_PARSE_CACHE = _ParseStore()   # (fsid, cut) -> {sdk_human: (key, session, leaf, sdk_human)}; a bare fsid reads the newest slot
 _PARSE_CACHE_MAX = 256
 _PARSE_CACHE_LOCK = threading.Lock()
 _PARSE_HITS = [0]              # served from the cache (whoever asked); misses are _PARSE_MISSES
@@ -2767,29 +2773,50 @@ def _lru_touch(cache, k):
         touch(k)
 
 
-def _parse_slot(fsid, cut):
-    """The cache entry for (fsid, cut), marked most recently used; None when absent."""
+def _newest_of(trees):
+    return trees[next(reversed(trees))] if trees else None
+
+
+def _parse_slot(fsid, cut, human=None):
+    """The cache entry for (fsid, cut) under the sdk_human flag `human`, marked most recently used; None when absent.
+    A slot holds one tree per flag: a display parse and a judge parse that answer "is the composer input the human"
+    differently (a process with no owner hook: the kernel asks its backend, the judges the registry file) each keep
+    their own tree rather than one reading the other's; with the hook both answer alike and share one tree. `human`
+    None (a judge caller) takes the slot's only tree when it has exactly one and no hook is installed, so a hit reads
+    no registry file (the stage gate's signature lists none); otherwise the judges' own answer picks."""
     with _PARSE_CACHE_LOCK:
-        ent = _PARSE_CACHE.get((fsid, cut))
-        if ent is not None:
-            _lru_touch(_PARSE_CACHE, (fsid, cut))
-        return ent
+        trees = _PARSE_CACHE.get((fsid, cut))
+        if not trees:
+            return None
+        _lru_touch(_PARSE_CACHE, (fsid, cut))
+        if human is None and _SDK_OWNER_FN is None and len(trees) == 1:
+            return _newest_of(trees)
+    if human is None:
+        human = _sdk_owned(fsid)
+    with _PARSE_CACHE_LOCK:
+        trees = _PARSE_CACHE.get((fsid, cut)) or {}
+        return trees.get(bool(human))
 
 
 def _parse_store(fsid, cut, key, session, leaf, human):
     with _PARSE_CACHE_LOCK:
-        _PARSE_CACHE[(fsid, cut)] = (key, session, str(leaf), bool(human))
+        trees = _PARSE_CACHE.get((fsid, cut))
+        if trees is None:
+            trees = _PARSE_CACHE[(fsid, cut)] = {}
+        trees.pop(bool(human), None)
+        trees[bool(human)] = (key, session, str(leaf), bool(human))
         _lru_touch(_PARSE_CACHE, (fsid, cut))
         while len(_PARSE_CACHE) > _PARSE_CACHE_MAX:
             del _PARSE_CACHE[next(iter(_PARSE_CACHE))]   # the least recently used goes, never everything at once
 
 
 def _parse_entry(fsid):
-    """The newest cached entry for fsid across cuts (the chain and courier keys compare its session by identity)."""
+    """The newest cached entry for fsid across cuts and flags (the chain and courier keys compare its session by
+    identity)."""
     with _PARSE_CACHE_LOCK:
         for k in reversed(_PARSE_CACHE):
             if k[0] == fsid:
-                return _PARSE_CACHE[k]
+                return _newest_of(_PARSE_CACHE[k])
     return None
 
 
@@ -2798,15 +2825,16 @@ def parse_entry_for_leaf(leaf):
     leaf = str(leaf)
     with _PARSE_CACHE_LOCK:
         for k in reversed(_PARSE_CACHE):
-            if _PARSE_CACHE[k][2] == leaf:
-                return _PARSE_CACHE[k]
+            for ent in reversed(list(_PARSE_CACHE[k].values())):
+                if ent[2] == leaf:
+                    return ent
     return None
 
 
 def parse_cache_paths():
-    """The leaf paths of every cached parse, newest last (the kernel's view iterates these)."""
+    """The leaf paths of every cached parse, one per slot, newest last (the kernel's view iterates these)."""
     with _PARSE_CACHE_LOCK:
-        return [ent[2] for ent in _PARSE_CACHE.values()]
+        return [_newest_of(trees)[2] for trees in _PARSE_CACHE.values() if trees]
 
 
 def parse_cache_drop(fsid):
@@ -2827,16 +2855,17 @@ def parse_hits():
     return int(_PARSE_HITS[0])
 
 
-def parse_cached(fsid, files):
-    """The cached session for fsid under the LIVE key (files as they stand now, the live cut, sdk_human), or None:
-    NEVER parses, so the feed's cache-only read costs nothing cold (kernel._parse_cached)."""
+def parse_cached(fsid, files, states=None, sdk_human=None):
+    """The cached session for fsid under the LIVE key (files as they stand now, the live cut, the caller's
+    sdk_human or the judges' answer), or None: NEVER parses, so the feed's cache-only read costs nothing cold
+    (kernel._parse_cached)."""
     try:
-        cands, states, keyfiles = _parse_key_files(fsid, files)
+        cands, _states, keyfiles = _parse_key_files(fsid, files, states)
         pair = _fileset_key(keyfiles)
     except Exception:
         return None
     cut = _pending_cut(fsid)
-    ent = _parse_slot(fsid, cut)
+    ent = _parse_slot(fsid, cut, None if sdk_human is None else bool(sdk_human))
     if ent is not None and ent[0] == (pair, cut):
         return ent[1]
     return None
@@ -3049,7 +3078,7 @@ def _chain_membership(fsid, path, cut):
     from _CHAIN_MEMO when the inputs are unchanged. Returns the five-way dict with FROZENSET values,
     shared with the memo (immutable, so no per-hit copy; the dict itself is a fresh shallow copy).
     A build that raises propagates and leaves the memo untouched."""
-    states = (STATE / "states") / (fsid + ".jsonl")
+    states = STATESDIR / (fsid + ".jsonl")
     states_s = str(states) if states.exists() else None
     cands = _judge_candidates(fsid, [str(path)])
     try:
@@ -3213,18 +3242,19 @@ def _pass_frame():
     return _frame if getattr(_judge_ctx, "in_pass", False) else None
 
 
-def _parse_key_files(fsid, files):
+def _parse_key_files(fsid, files, states=None):
     """The files the judge parse of `fsid` reads, as the filesystem shows them now: the candidate
     transcripts (_judge_candidates over the RAW leaf list every caller hands in) plus states/<fsid>.jsonl
     when it exists. Takes the raw list on purpose: _judge_candidates over an already-expanded list would
     append a fork lane's anchor a second time, and a key computed that way would never equal the one the
     parse cache holds (one spurious parse per fork lane per pass)."""
     cands = _judge_candidates(fsid, files)
-    states = (STATE / "states") / (fsid + ".jsonl")
+    states = Path(states) if states else STATESDIR / (fsid + ".jsonl")   # the caller's states log (the kernel's display
+    #                                                                       parse names its own path) or the judges' default
     return cands, states, list(cands) + ([str(states)] if states.exists() else [])
 
 
-def _frame_parse_key(fsid, files):
+def _frame_parse_key(fsid, files, states=None):
     """The (fileset key, pending cut) pair this pass judges `fsid` under, pinned in the pass frame
     (2026-09-07).
 
@@ -3255,7 +3285,7 @@ def _frame_parse_key(fsid, files):
             hit = fr["keys"].get(("parse", fsid), _NO_PIN)
         if hit is not _NO_PIN:
             return hit, None, fr
-    _cands, _states, key_files = _parse_key_files(fsid, files)
+    _cands, _states, key_files = _parse_key_files(fsid, files, states)
     cut = _pending_cut(fsid)
     try:
         key = (_fileset_key(key_files), cut)
@@ -3278,7 +3308,7 @@ def _frame_pin_parse(fr, fsid, session, key):
     return won
 
 
-def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
+def parsed_session(fsid, files, now, asm_mode_out=None, stats=None, states=None, sdk_human=None):
     """ONE event-model parse per (transcript+states, mtime+size), reused across the captioner, planner,
     sweep, courier, and grouper — which all re-parsed the SAME leaf every pass (up to 4× per change, and
     once per pass even when nothing changed, which is what forced the PLAN_SESSIONS cap). In-memory: the
@@ -3311,8 +3341,8 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
     # The pass's (fileset key, cut) pair, pinned BEFORE this read: a gate that pinned first fixes the
     # fileset component for the pass; a first toucher pins the live one here. `fr` is the frame the pin
     # went into, and the parse below is pinned into that same frame.
-    pair, cut, fr = _frame_parse_key(fsid, files)
-    states = (STATE / "states") / (fsid + ".jsonl")
+    pair, cut, fr = _frame_parse_key(fsid, files, states)
+    states = Path(states) if states else STATESDIR / (fsid + ".jsonl")   # the same log the key was taken over
     # A FORKED leaf (SDK /clear: discover hands the lastSid file under the stable romp sid) parses with
     # the session's anchor transcript among the candidates, so a fork whose chain back-links across files
     # (a resume-style fork) keeps its history — the FileAdapter walk crosses files by design, and a /clear
@@ -3330,8 +3360,8 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
     # shows up as a served pair that differs from the pinned one, which withholds the gate's stamp.
     if cut is None:                        # a pin answered and read nothing: the live cut is ours to read
         cut = _pending_cut(fsid)
-    key = (pair[0], cut) if pair is not None else None   # the frame's pair shape; sdk_human rides the entry (stage 2)
-    hit = _parse_slot(fsid, cut)
+    key = (pair[0], cut) if pair is not None else None   # the frame's pair shape; sdk_human is the slot's tree pick (stage 2)
+    hit = _parse_slot(fsid, cut, None if sdk_human is None else bool(sdk_human))
     if key is not None and hit and hit[0] == key:
         _PARSE_HITS[0] += 1
         if stats is not None:
@@ -3342,7 +3372,7 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
         return hit[1]                      #  only - the two-worlds shape the frame exists to prevent
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
-                               sdk_human=(human := bool(_sdk_owned(fsid))),   # SDK session → the composer input is the human (one owner hook; read on a miss only)
+                               sdk_human=(human := bool(sdk_human) if sdk_human is not None else bool(_sdk_owned(fsid))),   # the caller's answer, else the judges', read on a miss
                                leaf_override=cut or None, asm_mode_out=asm_mode_out)
     if stats is not None:
         stats["miss"] = True
@@ -5889,7 +5919,7 @@ def reconcile_rewound_goals(fsid, path, now):
     either side moved, archiving only on a hit (one-way, identity-keyed, tombstone-idempotent: no
     flap, no store re-publish on a miss)."""
     files = _judge_candidates(fsid, [str(path)])
-    states = (STATE / "states") / (fsid + ".jsonl")
+    states = STATESDIR / (fsid + ".jsonl")
     epi = EPIDIR / (fsid + ".jsonl")
     key_files = (list(files) + ([str(states)] if states.exists() else [])
                  + ([str(epi)] if epi.exists() else []))
@@ -12991,7 +13021,7 @@ def _write_death_marker(fsid, m):
 def _newest_states_t(fsid):
     """The newest states-row t for a sid, any row shape — the finalize's supersession read."""
     try:
-        rows = ((STATE / "states") / (fsid + ".jsonl")).read_text().splitlines()
+        rows = (STATESDIR / (fsid + ".jsonl")).read_text().splitlines()
         for ln in reversed(rows):
             try:
                 r = json.loads(ln)
@@ -14325,7 +14355,7 @@ def _live_prompt_since(fsid):
     the running stage incomplete and logs a `states-unreadable` row (_read_failed): the distiller's
     signature carries this file by identity, and a stamp over an answer that never read it would skip the
     session until the file moved (a brief owed to a parked session would wait on an unrelated row)."""
-    path_s = str((STATE / "states") / (fsid + ".jsonl"))
+    path_s = str(STATESDIR / (fsid + ".jsonl"))
     try:
         st = os.stat(path_s)
     except OSError:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2698,18 +2698,22 @@ def _fileset_key(files):
     return out
 
 
-# THE parse cache (T323 stage 2, 2026-09-11): one parsed session tree per (fsid, pending cut), shared by the judges
-# and the kernel's display parse (kernel._parse delegates here), least-recently-used, _PARSE_CACHE_MAX entries.
-# Entry: (key, session, leaf_path, sdk_human) with key = (fileset stat pair over the candidates and the states file,
-# the pending cut), the pass frame's pair shape unchanged, and sdk_human beside it: every fact either caller keyed on
-# before the two caches were one. The cut is in the SLOT as well as the key, so a caller reading a different cut than
-# another (the kernel arming a bare rollback the judges do not see, or the reverse) gets an entry of its own rather
-# than the other's view: two trees are cheaper than one wrong tree.
+# THE parse cache (T323 stage 2, 2026-09-11): one parsed session tree per (fsid, pending cut, leaf transcript), shared
+# by the judges and the kernel's display parse (kernel._parse delegates here), least-recently-used, _PARSE_CACHE_MAX
+# slots. A slot holds {sdk_human: entry}; an entry is (key, session, leaf_path, sdk_human, fsid, asm_mode) with
+# key = (fileset stat pair over the candidates and the states file, the pending cut), the pass frame's pair shape
+# unchanged: every fact either caller keyed on before the two caches were one, plus the sid the parse ran under (the
+# kernel's path-keyed view never derives one from a filename) and the assembly mode of the parse that built the tree
+# (a hit reports it). The cut is in the SLOT as well as the key so a store under a new cut can drop the spent cut's
+# slot: one tree per session through a rollback. The LEAF is in the slot because the kernel parses OTHER transcripts
+# under a session's sid (a subagent viewer's agent file, an episode render, build_session's path_override) whose keys
+# can never equal the live leaf's: sharing the slot made each miss evict the other's tree every pusher cycle (review
+# find, 2026-09-11), so an override parse sits beside the live leaf's tree, never in its place.
 class _ParseStore(collections.OrderedDict):
-    """The shared store's dictionary: slots are (fsid, cut) tuples, least recently used first. A bare fsid string
+    """The shared store's dictionary: slots are (fsid, cut, leaf) tuples, least recently used first. A bare fsid string
     reads as that session's NEWEST slot (the pass-frame tests and the courier keys look a session up by id), and
     writes under a bare fsid land in the slot of the live cut, so a stand-in dict a test installs and the readers
-    that predate the (fsid, cut) slots keep working."""
+    that predate the (fsid, cut, leaf) slots keep working."""
 
     @staticmethod
     def _k(k):
@@ -2745,11 +2749,12 @@ class _ParseStore(collections.OrderedDict):
     def __setitem__(self, k, v):
         if not isinstance(k, tuple):                     # a bare id write (a test stand-in): one tree under the live cut
             flag = bool(v[3]) if isinstance(v, tuple) and len(v) > 3 else False
-            k, v = (k, _pending_cut(k)), {flag: v}
+            leaf = str(v[2]) if isinstance(v, tuple) and len(v) > 2 else ""
+            k, v = (k, _pending_cut(k), leaf), {flag: v}
         super().__setitem__(k, v)
 
 
-_PARSE_CACHE = _ParseStore()   # (fsid, cut) -> {sdk_human: (key, session, leaf, sdk_human, fsid, asm_mode)}; a bare fsid reads the newest slot
+_PARSE_CACHE = _ParseStore()   # (fsid, cut, leaf) -> {sdk_human: (key, session, leaf, sdk_human, fsid, asm_mode)}; a bare fsid reads the newest slot
 _PARSE_CACHE_MAX = 256
 _PARSE_CACHE_LOCK = threading.Lock()
 _PARSE_HITS = [0]              # served from the cache (whoever asked); misses are _PARSE_MISSES
@@ -2777,54 +2782,67 @@ def _newest_of(trees):
     return trees[next(reversed(trees))] if trees else None
 
 
-def _parse_slot(fsid, cut, human=None):
-    """The cache entry for (fsid, cut) under the sdk_human flag `human`, marked most recently used; None when absent.
+def _parse_slot(fsid, cut, leaf, human=None):
+    """The cache entry for (fsid, cut, leaf) under the sdk_human flag `human`, marked most recently used; None when absent.
     A slot holds one tree per flag: a display parse and a judge parse that answer "is the composer input the human"
     differently (a process with no owner hook: the kernel asks its backend, the judges the registry file) each keep
     their own tree rather than one reading the other's; with the hook both answer alike and share one tree. `human`
     None (a judge caller) takes the slot's only tree when it has exactly one and no hook is installed, so a hit reads
     no registry file (the stage gate's signature lists none); otherwise the judges' own answer picks."""
+    slot = (fsid, cut, str(leaf))
     with _PARSE_CACHE_LOCK:
-        trees = _PARSE_CACHE.get((fsid, cut))
+        trees = _PARSE_CACHE.get(slot)
         if not trees:
             return None
-        _lru_touch(_PARSE_CACHE, (fsid, cut))
+        _lru_touch(_PARSE_CACHE, slot)
         if human is None and _SDK_OWNER_FN is None and len(trees) == 1:
             return _newest_of(trees)
     if human is None:
         human = _sdk_owned(fsid)
     with _PARSE_CACHE_LOCK:
-        trees = _PARSE_CACHE.get((fsid, cut)) or {}
+        trees = _PARSE_CACHE.get(slot) or {}
         return trees.get(bool(human))
 
 
 def _parse_store(fsid, cut, key, session, leaf, human, mode="full"):
-    """Store a parse under (fsid, cut). A slot stored under a NEW cut drops the fsid's other cut slots: a bare
+    """Store a parse under (fsid, cut, leaf). A slot stored under a NEW cut drops the fsid's other cut slots: a bare
     rollback parses under its cut, the next record spends the cut and every caller parses under the plain one, and
     the spent cut's tree was staying resident until the store filled (review find, 2026-09-11); a cut is never read
     again once spent, so one tree per session holds. The entry carries the fsid (the kernel's path-keyed view must
     never derive a sid from a filename: a /clear's leaf is named after the CLI session, not the romp sid) and the
-    assembly mode of the parse that built it (a hit reports it, so the chat fold sees fold or serve, never a blank)."""
+    assembly mode of the parse that built it (a hit reports it, so the chat fold sees fold or serve, never a blank).
+    The leaf is part of the slot: a parse of another transcript under the same sid (a subagent viewer's agent file
+    while the live leaf is parsed by the lanes, the feed and the judges) keeps a slot of its own instead of evicting
+    the live leaf's tree and being evicted by it in turn, twice per cycle (review find, 2026-09-11). A leaf a /clear
+    rotated away keeps its slot until the least-recently-used eviction reaches it, as the kernel's path-keyed cache
+    always did."""
+    slot = (fsid, cut, str(leaf))
     with _PARSE_CACHE_LOCK:
         for k in [k for k in _PARSE_CACHE if k[0] == fsid and k[1] != cut]:
             del _PARSE_CACHE[k]
-        trees = _PARSE_CACHE.get((fsid, cut))
+        trees = _PARSE_CACHE.get(slot)
         if trees is None:
-            trees = _PARSE_CACHE[(fsid, cut)] = {}
+            trees = _PARSE_CACHE[slot] = {}
         trees.pop(bool(human), None)
         trees[bool(human)] = (key, session, str(leaf), bool(human), str(fsid), str(mode or "full"))
-        _lru_touch(_PARSE_CACHE, (fsid, cut))
+        _lru_touch(_PARSE_CACHE, slot)
         while len(_PARSE_CACHE) > _PARSE_CACHE_MAX:
             del _PARSE_CACHE[next(iter(_PARSE_CACHE))]   # the least recently used goes, never everything at once
 
 
-def _parse_entry(fsid):
-    """The newest cached entry for fsid across cuts and flags (the chain and courier keys compare its session by
-    identity)."""
+def _parse_entry(fsid, session=None):
+    """The newest cached entry for fsid across cuts, leaves and flags, or with `session` given the entry holding
+    that very tree (the chain and courier keys hold the judges' session object; the newest slot may be an override
+    parse of another transcript under the same sid). None when absent."""
     with _PARSE_CACHE_LOCK:
         for k in reversed(_PARSE_CACHE):
-            if k[0] == fsid:
+            if k[0] != fsid:
+                continue
+            if session is None:
                 return _newest_of(_PARSE_CACHE[k])
+            for ent in reversed(list(_PARSE_CACHE[k].values())):
+                if ent[1] is session:
+                    return ent
     return None
 
 
@@ -2883,7 +2901,7 @@ def parse_cached(fsid, files, states=None, sdk_human=None):
     except Exception:
         return None
     cut = _pending_cut(fsid)
-    ent = _parse_slot(fsid, cut, None if sdk_human is None else bool(sdk_human))
+    ent = _parse_slot(fsid, cut, str(files[0]), None if sdk_human is None else bool(sdk_human))
     if ent is not None and ent[0] == (pair, cut):
         return ent[1]
     return None
@@ -2957,7 +2975,7 @@ def _plan_key(fsid, path, session, now):
     session after a /clear), the captions file (the floor-title heal reads it), and each running background
     launch with whether it has crossed its deadline under the pass clock `now` (_bg_expiry_key: the settle
     reads that crossing and no file records it)."""
-    pk = _parse_entry(fsid)
+    pk = _parse_entry(fsid, session)
     if pk is None or pk[1] is not session:
         return None
     return (str(path), pk[0], _store_key(fsid), _file_key(str(EPIDIR / (fsid + ".jsonl"))),
@@ -2980,7 +2998,7 @@ def _courier_scan_key(fsid, path, session):
     """Every input run_courier's per-session scan reads, or None when the parse is not the cache's own
     (never skip what cannot be keyed). Taken before the store read, so a write landing during the scan
     moves the key the next pass takes."""
-    pk = _parse_entry(fsid)
+    pk = _parse_entry(fsid, session)
     if pk is None or pk[1] is not session:
         return None
     return (str(path), pk[0], _file_key(str(GOALDIR / (fsid + ".json"))), _journal_key(fsid), _archive_key(fsid),
@@ -3361,6 +3379,8 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None, states=None,
     # went into, and the parse below is pinned into that same frame.
     pair, cut, fr = _frame_parse_key(fsid, files, states)
     states = Path(states) if states else STATESDIR / (fsid + ".jsonl")   # the same log the key was taken over
+    leaf = str(files[0])                   # the transcript this parse is OF: part of the slot (an override parse of
+    #                                        another file under the same sid never takes the live leaf's slot)
     # A FORKED leaf (SDK /clear: discover hands the lastSid file under the stable romp sid) parses with
     # the session's anchor transcript among the candidates, so a fork whose chain back-links across files
     # (a resume-style fork) keeps its history — the FileAdapter walk crosses files by design, and a /clear
@@ -3379,7 +3399,7 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None, states=None,
     if cut is None:                        # a pin answered and read nothing: the live cut is ours to read
         cut = _pending_cut(fsid)
     key = (pair[0], cut) if pair is not None else None   # the frame's pair shape; sdk_human is the slot's tree pick (stage 2)
-    hit = _parse_slot(fsid, cut, None if sdk_human is None else bool(sdk_human))
+    hit = _parse_slot(fsid, cut, leaf, None if sdk_human is None else bool(sdk_human))
     if key is not None and hit and hit[0] == key:
         _PARSE_HITS[0] += 1
         if stats is not None:
@@ -3398,7 +3418,7 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None, states=None,
         stats["miss"] = True
     _PARSE_MISSES[0] += 1                                  # a cold parse (T323: /perf parses)
     if key is not None:
-        _parse_store(fsid, cut, key, session, files[0], human, (_am[-1] if _am else "full"))   # LRU, never a wholesale clear
+        _parse_store(fsid, cut, key, session, leaf, human, (_am[-1] if _am else "full"))   # LRU, never a wholesale clear
     if fr is not None:                     # pin under the frame the KEY went into (never a re-read _frame: a
         with _frame_lock:                  #  parse spanning a pass boundary must not land keyless in the next
             return _frame_pin_parse(fr, fsid, session, key)   # frame); a concurrent first toucher wins

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -173,6 +173,7 @@ def _rebind_state(path):
     CODEXDIR = STATE / "codex"
     EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
+    _LEAF_SEEN.clear()      # the leaves discover handed out belong to the old root
     _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
     _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
     parse_cache_clear()      # the parses belong to the old root too
@@ -2814,8 +2815,8 @@ def _parse_store(fsid, cut, key, session, leaf, human, mode="full"):
     The leaf is part of the slot: a parse of another transcript under the same sid (a subagent viewer's agent file
     while the live leaf is parsed by the lanes, the feed and the judges) keeps a slot of its own instead of evicting
     the live leaf's tree and being evicted by it in turn, twice per cycle (review find, 2026-09-11). A leaf a /clear
-    rotated away keeps its slot until the least-recently-used eviction reaches it, as the kernel's path-keyed cache
-    always did."""
+    or a resume fork rotated away is released at the event that rotates it: discover, on first handing out the
+    session's new leaf, drops the previous leaf's slots (_note_leaf), so one tree per session holds across clears."""
     slot = (fsid, cut, str(leaf))
     with _PARSE_CACHE_LOCK:
         for k in [k for k in _PARSE_CACHE if k[0] == fsid and k[1] != cut]:
@@ -2830,18 +2831,19 @@ def _parse_store(fsid, cut, key, session, leaf, human, mode="full"):
             del _PARSE_CACHE[next(iter(_PARSE_CACHE))]   # the least recently used goes, never everything at once
 
 
-def _parse_entry(fsid, session=None):
-    """The newest cached entry for fsid across cuts, leaves and flags, or with `session` given the entry holding
-    that very tree (the chain and courier keys hold the judges' session object; the newest slot may be an override
-    parse of another transcript under the same sid). None when absent."""
+def _parse_entry(fsid, session=None, turns=None):
+    """The newest cached entry for fsid across cuts, leaves and flags, or with `session` (or its `turns` list)
+    given the entry holding that very tree: the chain and courier keys hold the judges' session object and the
+    nudge gate its turns, and the newest slot may be an override parse of another transcript under the same sid
+    (a subagent viewer's agent file stored between the walk's parse and the gate's read). None when absent."""
     with _PARSE_CACHE_LOCK:
         for k in reversed(_PARSE_CACHE):
             if k[0] != fsid:
                 continue
-            if session is None:
+            if session is None and turns is None:
                 return _newest_of(_PARSE_CACHE[k])
             for ent in reversed(list(_PARSE_CACHE[k].values())):
-                if ent[1] is session:
+                if ent[1] is session or (turns is not None and isinstance(ent[1], dict) and ent[1].get("turns") is turns):
                     return ent
     return None
 
@@ -7711,6 +7713,22 @@ def _custom_title(p):
     return None
 
 
+_LEAF_SEEN = {}      # sid -> the leaf path discover last handed out for it: the parse store releases the previous
+
+
+def _note_leaf(sid, path_str):
+    """discover hands out `path_str` as sid's CURRENT leaf. When that differs from the leaf it handed out last (a
+    /clear minted a new fsid under the same romp sid, or a resume fork moved the head to a fresh file), the previous
+    leaf's parse slots are dropped: nothing reads them again (the anchor is a non-leaf candidate of the new parse,
+    read through the record cache, never through the parse store), and without this every clear left one more full
+    tree resident until restart (review find, 2026-09-11). The event is the flip itself, observed at the one read
+    that gives every caller the new leaf; a candidate-based drop would release only the first anchor."""
+    prev = _LEAF_SEEN.get(sid)
+    if prev is not None and prev != path_str:
+        parse_cache_drop_leaf(prev)
+    _LEAF_SEEN[sid] = path_str
+
+
 _lastsid_memo = {}   # sid -> (sdk-registry mtime, diverged lastSid or None) — the registry is rewritten
                      # constantly while a session works (ctx%, queue mirror), but lastSid flips only on a
                      # /clear-style fork, so an mtime memo keeps the fingerprint's per-push reads cheap
@@ -8149,11 +8167,13 @@ def _discover_impl(now, window=None, forks=True):
         fork = next(((p, m) for st, p, m in listing if st == last), None) if last else None
         if fork is not None:
             path_str, mt = fork
+            _note_leaf(sid, path_str)                    # the leaf flipped here: the previous leaf's trees go
             if mt >= cutoff and path_str not in seen:
                 seen.add(path_str); out.append((sid, Path(path_str), sid, name))
         else:
             for stem, path_str, mt in listing:           # anchor (<sid>.jsonl) first — mirrors the old exists()/stat() block
                 if stem == sid:
+                    _note_leaf(sid, path_str)
                     if mt >= cutoff and path_str not in seen:
                         seen.add(path_str); out.append((sid, Path(path_str), sid, name))
                     break

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1316,7 +1316,7 @@ def _sig_inputs(tier, fsid, path):
     if tier in ("group", "consolidate"):
         ident += [STATE / "cleared.jsonl"]
     if tier == "distill":
-        ident += [STATESDIR / (fsid + ".jsonl")]
+        ident += [(STATE / "states") / (fsid + ".jsonl")]
         value += [STATE / "auto-nudge.json"]
     return ident, value
 
@@ -2752,9 +2752,12 @@ _SDK_OWNER_FN = None           # kernel wiring: fn(fsid) -> whether an SDK or Co
 
 def set_sdk_owner_provider(fn):
     """Kernel wiring: the ONE answer to "is this session's composer input the human" (sdk_human), the backends'
-    owns(); without it _sdk_owned falls back to the SDK registry file, which misses Codex sessions."""
+    owns(); without it _sdk_owned falls back to the SDK registry file, which misses Codex sessions. Installing
+    the hook drops every cached parse: the flag rides each entry (read at parse time, never on a hit, so a hit
+    reads no registry file the stage gate's signature would have to list) and a new answer must re-parse."""
     global _SDK_OWNER_FN
     _SDK_OWNER_FN = fn
+    parse_cache_clear()
 
 
 def _lru_touch(cache, k):
@@ -2834,7 +2837,7 @@ def parse_cached(fsid, files):
         return None
     cut = _pending_cut(fsid)
     ent = _parse_slot(fsid, cut)
-    if ent is not None and ent[0] == (pair, cut) and ent[3] == bool(_sdk_owned(fsid)):
+    if ent is not None and ent[0] == (pair, cut):
         return ent[1]
     return None
 
@@ -3046,7 +3049,7 @@ def _chain_membership(fsid, path, cut):
     from _CHAIN_MEMO when the inputs are unchanged. Returns the five-way dict with FROZENSET values,
     shared with the memo (immutable, so no per-hit copy; the dict itself is a fresh shallow copy).
     A build that raises propagates and leaves the memo untouched."""
-    states = STATESDIR / (fsid + ".jsonl")
+    states = (STATE / "states") / (fsid + ".jsonl")
     states_s = str(states) if states.exists() else None
     cands = _judge_candidates(fsid, [str(path)])
     try:
@@ -3217,7 +3220,7 @@ def _parse_key_files(fsid, files):
     append a fork lane's anchor a second time, and a key computed that way would never equal the one the
     parse cache holds (one spurious parse per fork lane per pass)."""
     cands = _judge_candidates(fsid, files)
-    states = STATESDIR / (fsid + ".jsonl")
+    states = (STATE / "states") / (fsid + ".jsonl")
     return cands, states, list(cands) + ([str(states)] if states.exists() else [])
 
 
@@ -3309,7 +3312,7 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
     # fileset component for the pass; a first toucher pins the live one here. `fr` is the frame the pin
     # went into, and the parse below is pinned into that same frame.
     pair, cut, fr = _frame_parse_key(fsid, files)
-    states = STATESDIR / (fsid + ".jsonl")
+    states = (STATE / "states") / (fsid + ".jsonl")
     # A FORKED leaf (SDK /clear: discover hands the lastSid file under the stable romp sid) parses with
     # the session's anchor transcript among the candidates, so a fork whose chain back-links across files
     # (a resume-style fork) keeps its history — the FileAdapter walk crosses files by design, and a /clear
@@ -3327,10 +3330,9 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
     # shows up as a served pair that differs from the pinned one, which withholds the gate's stamp.
     if cut is None:                        # a pin answered and read nothing: the live cut is ours to read
         cut = _pending_cut(fsid)
-    human = bool(_sdk_owned(fsid))
     key = (pair[0], cut) if pair is not None else None   # the frame's pair shape; sdk_human rides the entry (stage 2)
     hit = _parse_slot(fsid, cut)
-    if key is not None and hit and hit[0] == key and hit[3] == human:
+    if key is not None and hit and hit[0] == key:
         _PARSE_HITS[0] += 1
         if stats is not None:
             stats["miss"] = False
@@ -3340,7 +3342,7 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
         return hit[1]                      #  only - the two-worlds shape the frame exists to prevent
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
-                               sdk_human=human,   # SDK session → composer input is promptSource "sdk" = the human (one owner hook)
+                               sdk_human=(human := bool(_sdk_owned(fsid))),   # SDK session → the composer input is the human (one owner hook; read on a miss only)
                                leaf_override=cut or None, asm_mode_out=asm_mode_out)
     if stats is not None:
         stats["miss"] = True
@@ -5887,7 +5889,7 @@ def reconcile_rewound_goals(fsid, path, now):
     either side moved, archiving only on a hit (one-way, identity-keyed, tombstone-idempotent: no
     flap, no store re-publish on a miss)."""
     files = _judge_candidates(fsid, [str(path)])
-    states = STATESDIR / (fsid + ".jsonl")
+    states = (STATE / "states") / (fsid + ".jsonl")
     epi = EPIDIR / (fsid + ".jsonl")
     key_files = (list(files) + ([str(states)] if states.exists() else [])
                  + ([str(epi)] if epi.exists() else []))
@@ -12989,7 +12991,7 @@ def _write_death_marker(fsid, m):
 def _newest_states_t(fsid):
     """The newest states-row t for a sid, any row shape — the finalize's supersession read."""
     try:
-        rows = (STATESDIR / (fsid + ".jsonl")).read_text().splitlines()
+        rows = ((STATE / "states") / (fsid + ".jsonl")).read_text().splitlines()
         for ln in reversed(rows):
             try:
                 r = json.loads(ln)
@@ -14323,7 +14325,7 @@ def _live_prompt_since(fsid):
     the running stage incomplete and logs a `states-unreadable` row (_read_failed): the distiller's
     signature carries this file by identity, and a stamp over an answer that never read it would skip the
     session until the file moved (a brief owed to a parked session would wait on an unrelated row)."""
-    path_s = str(STATESDIR / (fsid + ".jsonl"))
+    path_s = str((STATE / "states") / (fsid + ".jsonl"))
     try:
         st = os.stat(path_s)
     except OSError:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -173,7 +173,7 @@ def _rebind_state(path):
     CODEXDIR = STATE / "codex"
     EPIDIR = STATE / "episodes"
     _lastsid_memo.clear()   # sdk-registry reads are mtime-memoized per sid — a rebind must not serve the old root's values
-    _LEAF_SEEN.clear()      # the leaves discover handed out belong to the old root
+    _LEAF_SEEN.clear(); _LEAF_RETIRED.clear()   # the leaves discover handed out belong to the old root
     _STORE_FAULTS.clear()   # unreadable-store episodes belong to the old root's files
     _CHAIN_MEMO.clear()     # the write-moment chain memo keys on paths under STATESDIR; a new root is a new world
     parse_cache_clear()      # the parses belong to the old root too
@@ -2816,7 +2816,13 @@ def _parse_store(fsid, cut, key, session, leaf, human, mode="full"):
     while the live leaf is parsed by the lanes, the feed and the judges) keeps a slot of its own instead of evicting
     the live leaf's tree and being evicted by it in turn, twice per cycle (review find, 2026-09-11). A leaf a /clear
     or a resume fork rotated away is released at the event that rotates it: discover, on first handing out the
-    session's new leaf, drops the previous leaf's slots (_note_leaf), so one tree per session holds across clears."""
+    session's new leaf, drops the previous leaf's slots (_note_leaf), so one tree per session holds across clears;
+    a parse stored under that retired leaf afterwards (a pass working from rows it snapshotted before the flip, an
+    episode render of the pre-clear transcript) is handed back to its caller and not stored, since the release is
+    a one-shot and nothing would drop it again. A leaf discover never handed out (a subagent's agent file) is
+    never retired and stores as an override slot."""
+    if _leaf_retired(fsid, leaf):
+        return
     slot = (fsid, cut, str(leaf))
     with _PARSE_CACHE_LOCK:
         for k in [k for k in _PARSE_CACHE if k[0] == fsid and k[1] != cut]:
@@ -2874,11 +2880,14 @@ def parse_cache_drop(fsid):
     return len(gone)
 
 
-def parse_cache_drop_leaf(leaf):
-    """Drop every slot holding a parse of `leaf` (the kernel's view pops by path; a leaf's stem is not the sid)."""
+def parse_cache_drop_leaf(leaf, fsid=None):
+    """Drop every slot holding a parse of `leaf` (the kernel's view pops by path; a leaf's stem is not the sid), or
+    with `fsid` only that session's slots of it: a fork child's registry is born naming the PARENT's transcript until
+    its own init flips it, so the child's flip must not take the parent's live slot with it (review find)."""
     leaf = str(leaf)
     with _PARSE_CACHE_LOCK:
-        gone = [k for k, trees in _PARSE_CACHE.items() if any(ent[2] == leaf for ent in trees.values())]
+        gone = [k for k, trees in _PARSE_CACHE.items()
+                if (fsid is None or k[0] == fsid) and any(ent[2] == leaf for ent in trees.values())]
         for k in gone:
             del _PARSE_CACHE[k]
     return len(gone)
@@ -7714,19 +7723,36 @@ def _custom_title(p):
 
 
 _LEAF_SEEN = {}      # sid -> the leaf path discover last handed out for it: the parse store releases the previous
+_LEAF_RETIRED = {}   # sid -> the leaves discover handed out for it before the current one: never stored again
+_LEAF_LOCK = threading.Lock()
 
 
 def _note_leaf(sid, path_str):
     """discover hands out `path_str` as sid's CURRENT leaf. When that differs from the leaf it handed out last (a
     /clear minted a new fsid under the same romp sid, or a resume fork moved the head to a fresh file), the previous
-    leaf's parse slots are dropped: nothing reads them again (the anchor is a non-leaf candidate of the new parse,
-    read through the record cache, never through the parse store), and without this every clear left one more full
-    tree resident until restart (review find, 2026-09-11). The event is the flip itself, observed at the one read
-    that gives every caller the new leaf; a candidate-based drop would release only the first anchor."""
-    prev = _LEAF_SEEN.get(sid)
+    leaf's parse slots OF THIS SID are dropped: nothing reads them again (the anchor is a non-leaf candidate of the
+    new parse, read through the record cache, never through the parse store), and without this every clear left one
+    more full tree resident until restart (review find, 2026-09-11). The event is the flip itself, observed at the
+    one read that gives every caller the new leaf; a candidate-based drop would release only the first anchor. Only
+    this sid's slots go: a fork child's registry names the parent's transcript until its own init flips it, and the
+    parent's live slot is not the child's to drop. The retired leaf is remembered so a parse stored under it AFTER
+    the flip (a pass that snapshotted its rows before a mid-pass /clear) is refused by _parse_store rather than
+    kept as a live slot; a leaf handed out again (the anchor, while a fresh lastSid names a file not yet on disk)
+    is current again and stores as before."""
+    with _LEAF_LOCK:
+        prev = _LEAF_SEEN.get(sid)
+        _LEAF_SEEN[sid] = path_str
+        retired = _LEAF_RETIRED.setdefault(sid, set())
+        retired.discard(path_str)
+        if prev is not None and prev != path_str:
+            retired.add(prev)
     if prev is not None and prev != path_str:
-        parse_cache_drop_leaf(prev)
-    _LEAF_SEEN[sid] = path_str
+        parse_cache_drop_leaf(prev, sid)
+
+
+def _leaf_retired(sid, leaf):
+    with _LEAF_LOCK:
+        return str(leaf) in _LEAF_RETIRED.get(sid, ())
 
 
 _lastsid_memo = {}   # sid -> (sdk-registry mtime, diverged lastSid or None) — the registry is rewritten

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13,6 +13,7 @@ CLI:
   romp-judge --once               # one caption pass over the live fleet (writes captions/)
   romp-judge --test <transcript>  # caption one transcript's recent units, print them (no write)
 """
+import collections
 import contextlib, copy, hashlib, json, os, re, secrets, shutil, signal, stat, sys, time, subprocess, threading, traceback, importlib.util
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -2696,7 +2697,146 @@ def _fileset_key(files):
     return out
 
 
-_PARSE_CACHE = {}          # fsid -> (fileset_key, parsed_session)
+# THE parse cache (T323 stage 2, 2026-09-11): one parsed session tree per (fsid, pending cut), shared by the judges
+# and the kernel's display parse (kernel._parse delegates here), least-recently-used, _PARSE_CACHE_MAX entries.
+# Entry: (key, session, leaf_path, sdk_human) with key = (fileset stat pair over the candidates and the states file,
+# the pending cut), the pass frame's pair shape unchanged, and sdk_human beside it: every fact either caller keyed on
+# before the two caches were one. The cut is in the SLOT as well as the key, so a caller reading a different cut than
+# another (the kernel arming a bare rollback the judges do not see, or the reverse) gets an entry of its own rather
+# than the other's view: two trees are cheaper than one wrong tree.
+class _ParseStore(collections.OrderedDict):
+    """The shared store's dictionary: slots are (fsid, cut) tuples, least recently used first. A bare fsid string
+    reads as that session's NEWEST slot (the pass-frame tests and the courier keys look a session up by id), and
+    writes under a bare fsid land in the slot of the live cut, so a stand-in dict a test installs and the readers
+    that predate the (fsid, cut) slots keep working."""
+
+    @staticmethod
+    def _k(k):
+        return k if isinstance(k, tuple) else None
+
+    def _newest(self, fsid):
+        for k in reversed(list(self.keys())):
+            if isinstance(k, tuple) and k[0] == fsid:
+                return k
+        return None
+
+    def __getitem__(self, k):
+        if not isinstance(k, tuple):
+            nk = self._newest(k)
+            if nk is None:
+                raise KeyError(k)
+            return super().__getitem__(nk)
+        return super().__getitem__(k)
+
+    def get(self, k, default=None):
+        try:
+            return self[k]
+        except KeyError:
+            return default
+
+    def __contains__(self, k):
+        return (self._newest(k) is not None) if not isinstance(k, tuple) else super().__contains__(k)
+
+    def __setitem__(self, k, v):
+        if not isinstance(k, tuple):
+            k = (k, _pending_cut(k))
+        super().__setitem__(k, v)
+
+
+_PARSE_CACHE = _ParseStore()   # (fsid, cut) -> (key, session, leaf, sdk_human); a bare fsid reads the newest slot
+_PARSE_CACHE_MAX = 256
+_PARSE_CACHE_LOCK = threading.Lock()
+_PARSE_HITS = [0]              # served from the cache (whoever asked); misses are _PARSE_MISSES
+_SDK_OWNER_FN = None           # kernel wiring: fn(fsid) -> whether an SDK or Codex backend owns the session
+
+
+def set_sdk_owner_provider(fn):
+    """Kernel wiring: the ONE answer to "is this session's composer input the human" (sdk_human), the backends'
+    owns(); without it _sdk_owned falls back to the SDK registry file, which misses Codex sessions."""
+    global _SDK_OWNER_FN
+    _SDK_OWNER_FN = fn
+
+
+def _lru_touch(cache, k):
+    """Mark k most recently used; a plain dict standing in for the store (a test's raced cache) has no order."""
+    touch = getattr(cache, "move_to_end", None)
+    if touch is not None:
+        touch(k)
+
+
+def _parse_slot(fsid, cut):
+    """The cache entry for (fsid, cut), marked most recently used; None when absent."""
+    with _PARSE_CACHE_LOCK:
+        ent = _PARSE_CACHE.get((fsid, cut))
+        if ent is not None:
+            _lru_touch(_PARSE_CACHE, (fsid, cut))
+        return ent
+
+
+def _parse_store(fsid, cut, key, session, leaf, human):
+    with _PARSE_CACHE_LOCK:
+        _PARSE_CACHE[(fsid, cut)] = (key, session, str(leaf), bool(human))
+        _lru_touch(_PARSE_CACHE, (fsid, cut))
+        while len(_PARSE_CACHE) > _PARSE_CACHE_MAX:
+            del _PARSE_CACHE[next(iter(_PARSE_CACHE))]   # the least recently used goes, never everything at once
+
+
+def _parse_entry(fsid):
+    """The newest cached entry for fsid across cuts (the chain and courier keys compare its session by identity)."""
+    with _PARSE_CACHE_LOCK:
+        for k in reversed(_PARSE_CACHE):
+            if k[0] == fsid:
+                return _PARSE_CACHE[k]
+    return None
+
+
+def parse_entry_for_leaf(leaf):
+    """The newest cached entry whose parse read `leaf` as its leaf transcript (the kernel's path-keyed view)."""
+    leaf = str(leaf)
+    with _PARSE_CACHE_LOCK:
+        for k in reversed(_PARSE_CACHE):
+            if _PARSE_CACHE[k][2] == leaf:
+                return _PARSE_CACHE[k]
+    return None
+
+
+def parse_cache_paths():
+    """The leaf paths of every cached parse, newest last (the kernel's view iterates these)."""
+    with _PARSE_CACHE_LOCK:
+        return [ent[2] for ent in _PARSE_CACHE.values()]
+
+
+def parse_cache_drop(fsid):
+    """Drop every cut's entry for fsid (a dead timeline lane releasing its parse); returns how many went."""
+    with _PARSE_CACHE_LOCK:
+        gone = [k for k in _PARSE_CACHE if k[0] == fsid]
+        for k in gone:
+            del _PARSE_CACHE[k]
+    return len(gone)
+
+
+def parse_cache_clear():
+    with _PARSE_CACHE_LOCK:
+        _PARSE_CACHE.clear()
+
+
+def parse_hits():
+    return int(_PARSE_HITS[0])
+
+
+def parse_cached(fsid, files):
+    """The cached session for fsid under the LIVE key (files as they stand now, the live cut, sdk_human), or None:
+    NEVER parses, so the feed's cache-only read costs nothing cold (kernel._parse_cached)."""
+    try:
+        cands, states, keyfiles = _parse_key_files(fsid, files)
+        pair = _fileset_key(keyfiles)
+    except Exception:
+        return None
+    cut = _pending_cut(fsid)
+    ent = _parse_slot(fsid, cut)
+    if ent is not None and ent[0] == (pair, cut) and ent[3] == bool(_sdk_owned(fsid)):
+        return ent[1]
+    return None
 
 # ── the courier's change gate (2026-09-09) ──
 # run_courier scanned every session's transcript and goal store on every triage pass, loading the store
@@ -2767,7 +2907,7 @@ def _plan_key(fsid, path, session, now):
     session after a /clear), the captions file (the floor-title heal reads it), and each running background
     launch with whether it has crossed its deadline under the pass clock `now` (_bg_expiry_key: the settle
     reads that crossing and no file records it)."""
-    pk = _PARSE_CACHE.get(fsid)
+    pk = _parse_entry(fsid)
     if pk is None or pk[1] is not session:
         return None
     return (str(path), pk[0], _store_key(fsid), _file_key(str(EPIDIR / (fsid + ".jsonl"))),
@@ -2790,7 +2930,7 @@ def _courier_scan_key(fsid, path, session):
     """Every input run_courier's per-session scan reads, or None when the parse is not the cache's own
     (never skip what cannot be keyed). Taken before the store read, so a write landing during the scan
     moves the key the next pass takes."""
-    pk = _PARSE_CACHE.get(fsid)
+    pk = _parse_entry(fsid)
     if pk is None or pk[1] is not session:
         return None
     return (str(path), pk[0], _file_key(str(GOALDIR / (fsid + ".json"))), _journal_key(fsid), _archive_key(fsid),
@@ -3002,6 +3142,11 @@ def _sdk_owned(fsid):
     human (it parses with sdk_human=True), the dotted placeholder sticks for the whole open turn — forever if
     the turn reads as 'working' indefinitely — and each new message just re-renders a fresh one (the user
     2026-06-29). Computed from the live STATE global so it follows _rebind_state in tests."""
+    if _SDK_OWNER_FN is not None:
+        try:
+            return bool(_SDK_OWNER_FN(fsid))
+        except Exception:
+            pass
     return (STATE / "sdk" / (fsid + ".json")).exists()
 
 
@@ -3130,7 +3275,7 @@ def _frame_pin_parse(fr, fsid, session, key):
     return won
 
 
-def parsed_session(fsid, files, now):
+def parsed_session(fsid, files, now, asm_mode_out=None, stats=None):
     """ONE event-model parse per (transcript+states, mtime+size), reused across the captioner, planner,
     sweep, courier, and grouper — which all re-parsed the SAME leaf every pass (up to 4× per change, and
     once per pass even when nothing changed, which is what forced the PLAN_SESSIONS cap). In-memory: the
@@ -3182,22 +3327,26 @@ def parsed_session(fsid, files, now):
     # shows up as a served pair that differs from the pinned one, which withholds the gate's stamp.
     if cut is None:                        # a pin answered and read nothing: the live cut is ours to read
         cut = _pending_cut(fsid)
-    key = (pair[0], cut) if pair is not None else None
-    hit = _PARSE_CACHE.get(fsid)
-    if key is not None and hit and hit[0] == key:
+    human = bool(_sdk_owned(fsid))
+    key = (pair[0], cut) if pair is not None else None   # the frame's pair shape; sdk_human rides the entry (stage 2)
+    hit = _parse_slot(fsid, cut)
+    if key is not None and hit and hit[0] == key and hit[3] == human:
+        _PARSE_HITS[0] += 1
+        if stats is not None:
+            stats["miss"] = False
         if fr is not None:                 # a WARM first touch pins too (review 2026-09-06): this path used to
             with _frame_lock:              #  return unpinned, so a session already in the cache froze nothing
                 return _frame_pin_parse(fr, fsid, hit[1], key)   # and a mid-pass append reached a later stage
         return hit[1]                      #  only - the two-worlds shape the frame exists to prevent
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
-                               sdk_human=_sdk_owned(fsid),   # SDK session → composer input is promptSource "sdk" = the human (mirrors the kernel)
-                               leaf_override=cut or None)
+                               sdk_human=human,   # SDK session → composer input is promptSource "sdk" = the human (one owner hook)
+                               leaf_override=cut or None, asm_mode_out=asm_mode_out)
+    if stats is not None:
+        stats["miss"] = True
+    _PARSE_MISSES[0] += 1                                  # a cold parse (T323: /perf parses)
     if key is not None:
-        if len(_PARSE_CACHE) > 256:        # bounded by fleet size; a wholesale clear on overflow is fine
-            _PARSE_CACHE.clear()
-        _PARSE_MISSES[0] += 1                              # a cold parse (T323: /perf parses.judge)
-        _PARSE_CACHE[fsid] = (key, session)
+        _parse_store(fsid, cut, key, session, files[0], human)   # LRU, never a wholesale clear (T323 stage 2)
     if fr is not None:                     # pin under the frame the KEY went into (never a re-read _frame: a
         with _frame_lock:                  #  parse spanning a pass boundary must not land keyless in the next
             return _frame_pin_parse(fr, fsid, session, key)   # frame); a concurrent first toucher wins

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2749,7 +2749,7 @@ class _ParseStore(collections.OrderedDict):
         super().__setitem__(k, v)
 
 
-_PARSE_CACHE = _ParseStore()   # (fsid, cut) -> {sdk_human: (key, session, leaf, sdk_human)}; a bare fsid reads the newest slot
+_PARSE_CACHE = _ParseStore()   # (fsid, cut) -> {sdk_human: (key, session, leaf, sdk_human, fsid, asm_mode)}; a bare fsid reads the newest slot
 _PARSE_CACHE_MAX = 256
 _PARSE_CACHE_LOCK = threading.Lock()
 _PARSE_HITS = [0]              # served from the cache (whoever asked); misses are _PARSE_MISSES
@@ -2798,13 +2798,21 @@ def _parse_slot(fsid, cut, human=None):
         return trees.get(bool(human))
 
 
-def _parse_store(fsid, cut, key, session, leaf, human):
+def _parse_store(fsid, cut, key, session, leaf, human, mode="full"):
+    """Store a parse under (fsid, cut). A slot stored under a NEW cut drops the fsid's other cut slots: a bare
+    rollback parses under its cut, the next record spends the cut and every caller parses under the plain one, and
+    the spent cut's tree was staying resident until the store filled (review find, 2026-09-11); a cut is never read
+    again once spent, so one tree per session holds. The entry carries the fsid (the kernel's path-keyed view must
+    never derive a sid from a filename: a /clear's leaf is named after the CLI session, not the romp sid) and the
+    assembly mode of the parse that built it (a hit reports it, so the chat fold sees fold or serve, never a blank)."""
     with _PARSE_CACHE_LOCK:
+        for k in [k for k in _PARSE_CACHE if k[0] == fsid and k[1] != cut]:
+            del _PARSE_CACHE[k]
         trees = _PARSE_CACHE.get((fsid, cut))
         if trees is None:
             trees = _PARSE_CACHE[(fsid, cut)] = {}
         trees.pop(bool(human), None)
-        trees[bool(human)] = (key, session, str(leaf), bool(human))
+        trees[bool(human)] = (key, session, str(leaf), bool(human), str(fsid), str(mode or "full"))
         _lru_touch(_PARSE_CACHE, (fsid, cut))
         while len(_PARSE_CACHE) > _PARSE_CACHE_MAX:
             del _PARSE_CACHE[next(iter(_PARSE_CACHE))]   # the least recently used goes, never everything at once
@@ -2841,6 +2849,16 @@ def parse_cache_drop(fsid):
     """Drop every cut's entry for fsid (a dead timeline lane releasing its parse); returns how many went."""
     with _PARSE_CACHE_LOCK:
         gone = [k for k in _PARSE_CACHE if k[0] == fsid]
+        for k in gone:
+            del _PARSE_CACHE[k]
+    return len(gone)
+
+
+def parse_cache_drop_leaf(leaf):
+    """Drop every slot holding a parse of `leaf` (the kernel's view pops by path; a leaf's stem is not the sid)."""
+    leaf = str(leaf)
+    with _PARSE_CACHE_LOCK:
+        gone = [k for k, trees in _PARSE_CACHE.items() if any(ent[2] == leaf for ent in trees.values())]
         for k in gone:
             del _PARSE_CACHE[k]
     return len(gone)
@@ -3366,6 +3384,8 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None, states=None,
         _PARSE_HITS[0] += 1
         if stats is not None:
             stats["miss"] = False
+        if asm_mode_out is not None:
+            asm_mode_out.append(hit[5] if len(hit) > 5 else "full")   # the mode of the parse that built this tree (review find)
         if fr is not None:                 # a WARM first touch pins too (review 2026-09-06): this path used to
             with _frame_lock:              #  return unpinned, so a session already in the cache froze nothing
                 return _frame_pin_parse(fr, fsid, hit[1], key)   # and a mid-pass append reached a later stage
@@ -3373,12 +3393,12 @@ def parsed_session(fsid, files, now, asm_mode_out=None, stats=None, states=None,
     session = em.parse_session(files[0], rompuuid=fsid, candidate_files=list(files),
                                states=str(states), postal_log=str(MESSAGES), now=now,
                                sdk_human=(human := bool(sdk_human) if sdk_human is not None else bool(_sdk_owned(fsid))),   # the caller's answer, else the judges', read on a miss
-                               leaf_override=cut or None, asm_mode_out=asm_mode_out)
+                               leaf_override=cut or None, asm_mode_out=(_am := asm_mode_out if asm_mode_out is not None else []))
     if stats is not None:
         stats["miss"] = True
     _PARSE_MISSES[0] += 1                                  # a cold parse (T323: /perf parses)
     if key is not None:
-        _parse_store(fsid, cut, key, session, files[0], human)   # LRU, never a wholesale clear (T323 stage 2)
+        _parse_store(fsid, cut, key, session, files[0], human, (_am[-1] if _am else "full"))   # LRU, never a wholesale clear
     if fr is not None:                     # pin under the frame the KEY went into (never a re-read _frame: a
         with _frame_lock:                  #  parse spanning a pass boundary must not land keyless in the next
             return _frame_pin_parse(fr, fsid, session, key)   # frame); a concurrent first toucher wins

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27542,10 +27542,6 @@ class _SharedParseView:
     shape: `path in _parse_cache`, `_parse_cache.get(path)` → (key, session), iteration over leaf paths,
     `.pop(path)` (a dead lane releasing its parse) and `.clear()` (the perf bench's cold sample)."""
 
-    @staticmethod
-    def _fsid(path):
-        return os.path.splitext(os.path.basename(str(path)))[0]
-
     def get(self, path, default=None):
         ent = jd.parse_entry_for_leaf(str(path))
         return (ent[0], ent[1]) if ent is not None else default
@@ -27567,8 +27563,8 @@ class _SharedParseView:
 
     def pop(self, path, default=None):
         ent = self.get(path)
-        jd.parse_cache_drop(self._fsid(path))
-        return ent if ent is not None else default
+        jd.parse_cache_drop_leaf(str(path))          # by LEAF, never by a sid derived from the filename (a /clear's
+        return ent if ent is not None else default   # leaf is named after the CLI session, not the romp sid)
 
     def clear(self):
         jd.parse_cache_clear()
@@ -29084,7 +29080,10 @@ def _parse_cached(path):
     (which come from the goal store, cheap) paint AT ONCE on a cold kernel start; the dots/anchors fill in a
     beat later once _warm_fleet_bg has parsed the session in the background (the user 2026-06-26: the feed
     cards lagged the timeline lanes on startup, all of it the ~1s cold parse of the fleet)."""
-    fsid = _SharedParseView._fsid(path)
+    ent = jd.parse_entry_for_leaf(str(path))     # the entry names its romp sid: a leaf's stem is the CLI session's id
+    if ent is None or len(ent) < 5:               # after a /clear or a resume fork, never the romp sid (review find)
+        return None
+    fsid = ent[4]
     return jd.parse_cached(fsid, [str(path)], states=str(jd.STATE / "states" / (fsid + ".jsonl")),
                            sdk_human=_display_sdk_human(fsid))   # the store's live-key read, under the display's slot
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28560,7 +28560,9 @@ def _parse(path, sid, now):
     # session's anchor file), so the tree it returns is the tree the judges walk: parsed once per file version, held
     # once. The old per-path cache is a view over that store (_SharedParseView).
     _mode, stats = [], {}
-    session = jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats)
+    states = str(jd.STATE / "states" / (sid + ".jsonl"))   # the kernel's states log path (the judges default to the same file)
+    session = jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats, states=states,
+                                sdk_human=_display_sdk_human(sid))
     _parse_mode[path] = _mode[-1] if _mode else "full"
     try:
         if stats.get("miss"):
@@ -29068,13 +29070,23 @@ def _rewind_holds_boot():
             sys.stderr.write("rewind-hold boot: %s\n" % traceback.format_exc())
 
 
+def _display_sdk_human(sid):
+    """The display parse's answer to sdk_human: a backend (SDK or Codex) owns the session. The same answer the owner
+    hook gives the judges once a backend exists, so both sides share one slot; in a process without one (tests) the
+    judges fall back to the registry file and a differing answer keeps its own slot."""
+    _be = _sdk()
+    return bool((_be and _be.owns(sid)) or ((_cx := _codex()) and _cx.owns(sid)))
+
+
 def _parse_cached(path):
     """The CACHED parse for `path` (matching its (mtime,size)) or None — NEVER parses, so it adds no cold
     cost on the request path. build_feed reads it for the working-dots + deep-link anchors so its CARDS
     (which come from the goal store, cheap) paint AT ONCE on a cold kernel start; the dots/anchors fill in a
     beat later once _warm_fleet_bg has parsed the session in the background (the user 2026-06-26: the feed
     cards lagged the timeline lanes on startup, all of it the ~1s cold parse of the fleet)."""
-    return jd.parse_cached(_SharedParseView._fsid(path), [str(path)])   # the shared store's live-key read (stage 2)
+    fsid = _SharedParseView._fsid(path)
+    return jd.parse_cached(fsid, [str(path)], states=str(jd.STATE / "states" / (fsid + ".jsonl")),
+                           sdk_human=_display_sdk_human(fsid))   # the store's live-key read, under the display's slot
 
 
 _warm_lock = threading.Lock()

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11492,7 +11492,8 @@ def _nudge_placement_gate(sid, turns, store):
     A parse the cache does not hold, or a store that is not the current shared view, is derived every time
     and never cached. The exception path is unchanged: a gate that cannot be computed waves nothing through
     silently, and is never cached."""
-    pk = jd._PARSE_CACHE.get(sid)
+    pk = jd._parse_entry(sid, turns=turns)     # the entry holding THESE turns, never the sid's newest slot (an agent
+    #                                             view stored between the walk's parse and this read: review find)
     parse_key = pk[0] if (pk is not None and pk[1] is not None and pk[1].get("turns") is turns) else None
     epi = _stat_key(jd.EPIDIR / (sid + ".jsonl")) if parse_key is not None else None
     hit = _nudge_gate_memo.get(sid) if parse_key is not None else None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -28554,7 +28554,9 @@ def _parse(path, sid, now):
     # function keyed on (the transcript's and the states file's stat pair, the pending cut it reads through the provider
     # this kernel installs, sdk_human through the owner hook) and expands the same candidate set (the leaf plus the
     # session's anchor file), so the tree it returns is the tree the judges walk: parsed once per file version, held
-    # once. The old per-path cache is a view over that store (_SharedParseView).
+    # once. The old per-path cache is a view over that store (_SharedParseView). The store's slot carries the leaf, so
+    # a parse of another transcript under this sid (a subagent viewer's agent file, an episode's transcript: build_session
+    # with path_override hands it here as sess["path"]) sits beside the live leaf's tree rather than evicting it.
     _mode, stats = [], {}
     states = str(jd.STATE / "states" / (sid + ".jsonl"))   # the kernel's states log path (the judges default to the same file)
     session = jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats, states=states,

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -315,7 +315,7 @@ class _PerfStats:
             # cold event-model parses this kernel ran (T323 stage 1): the kernel's own _parse misses, per session
             # (sid8) and in total, plus the bytes of the files parsed; the judges' misses ride the snapshot from
             # jd.parse_misses(). The acceptance number of the lazy-transcript work: a boot with no client parses zero.
-            self.parses = {"total": 0, "bytes": 0, "bySid": {}}
+            self.parses = {"kernel": 0, "hits": 0, "bytes": 0, "bySid": {}}   # kernel-asked cold parses; total/judge from jd
             self.http = {}
 
     # ── writers (hot paths) ──
@@ -358,11 +358,16 @@ class _PerfStats:
         with self.lock:
             self.stages[name] = self.stages.get(name, 0.0) + dt * 1000.0
 
+    def parse_hit(self):
+        """The kernel's _parse served from the shared store (T323 stage 2)."""
+        with self.lock:
+            self.parses["hits"] += 1
+
     def parse(self, sid, nbytes=0):
-        """One COLD parse by the kernel's _parse (a cache miss that ran em.parse_session)."""
+        """One COLD parse the kernel's _parse asked for (a shared-store miss that ran em.parse_session)."""
         with self.lock:
             p = self.parses
-            p["total"] += 1
+            p["kernel"] += 1
             p["bytes"] += int(nbytes or 0)
             k = str(sid or "")[:8]
             if len(p["bySid"]) < 1024 or k in p["bySid"]:
@@ -466,7 +471,8 @@ class _PerfStats:
             stages = dict(self.stages)
             builds = {k: dict(v) for k, v in self.builds.items()}
             builds["chat"]["bg_miss"] = dict(self.builds["chat"]["bg_miss"])   # the nested map: a copy too
-            parses = {"total": self.parses["total"], "bytes": self.parses["bytes"], "bySid": dict(self.parses["bySid"])}
+            parses = {"kernel": self.parses["kernel"], "hits": self.parses["hits"], "bytes": self.parses["bytes"],
+                      "bySid": dict(self.parses["bySid"])}
             sends = {k: {sl: {"count": e[0], "bytes": e[1]} for sl, e in d.items()}
                      for k, d in self.sends.items()}
             judge = dict(self.judge)
@@ -514,7 +520,12 @@ class _PerfStats:
         return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF,
                 "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
                 "builds": builds, "sends": sends, "goals": goals, "memos": memos, "judge": judge, "http": http,
-                "parses": dict(parses, judge=int(getattr(jd, "parse_misses", lambda: 0)()))}   # T323: cold parses
+                # T323: cold parses through the ONE parse store (stage 2): total = every miss (whoever asked), kernel =
+                # the display's asks among them, judge = the rest, hits = the display's asks served from the store,
+                # sharedHits = every hit. A boot with no client reads kernel 0.
+                "parses": dict(parses, total=int(getattr(jd, "parse_misses", lambda: 0)()),
+                               judge=max(0, int(getattr(jd, "parse_misses", lambda: 0)()) - parses["kernel"]),
+                               sharedHits=int(getattr(jd, "parse_hits", lambda: 0)()))}
 
 
 _PERF_STATS = _PerfStats()
@@ -14962,6 +14973,11 @@ def _sdk_locked():
             _cut_fn = getattr(_sdk_backend, "pending_cut", None)
             if _cut_fn:
                 jd.set_pending_cut_provider(_cut_fn)
+            # ONE answer to sdk_human for the shared parse (T323 stage 2): the backends' owns(), SDK or Codex,
+            # so the judges and the display never key the same file under two flags
+            _owns = getattr(_sdk_backend, "owns", None)
+            if _owns:
+                jd.set_sdk_owner_provider(lambda fsid: bool(_owns(fsid)) or bool((_cx := _codex()) and _cx.owns(fsid)))
             # The backend's flag-consumption events resolve held rewinds (two-phase goal cleanup:
             # archive at the branch-take, restore on failure — _on_rewind_resolved).
             _sdk_backend.rewind_resolved_cb = _on_rewind_resolved
@@ -27519,7 +27535,46 @@ def _fold_tasks(session, sid=None):
             for t in ordered]
 
 
-_parse_cache = {}                                # realpath → ((mtime, size, pending-rollback cut), parsed session)
+class _SharedParseView:
+    """The kernel's parse cache as a PATH-keyed view over the ONE parse store, jd._PARSE_CACHE (T323 stage 2): the
+    kernel's _parse delegates to jd.parsed_session, so the tree the judges walk and the tree the chat renders are
+    the same object, parsed once per file version instead of twice. Readers that knew the old dict keep their
+    shape: `path in _parse_cache`, `_parse_cache.get(path)` → (key, session), iteration over leaf paths,
+    `.pop(path)` (a dead lane releasing its parse) and `.clear()` (the perf bench's cold sample)."""
+
+    @staticmethod
+    def _fsid(path):
+        return os.path.splitext(os.path.basename(str(path)))[0]
+
+    def get(self, path, default=None):
+        ent = jd.parse_entry_for_leaf(str(path))
+        return (ent[0], ent[1]) if ent is not None else default
+
+    def __getitem__(self, path):
+        v = self.get(path)
+        if v is None:
+            raise KeyError(path)
+        return v
+
+    def __contains__(self, path):
+        return self.get(path) is not None
+
+    def __iter__(self):
+        return iter(jd.parse_cache_paths())
+
+    def __len__(self):
+        return len(jd.parse_cache_paths())
+
+    def pop(self, path, default=None):
+        ent = self.get(path)
+        jd.parse_cache_drop(self._fsid(path))
+        return ent if ent is not None else default
+
+    def clear(self):
+        jd.parse_cache_clear()
+
+
+_parse_cache = _SharedParseView()                # path → (key, parsed session): a view over jd._PARSE_CACHE (stage 2)
 
 # Built-chat cache (the user 2026-06-24, who found the UI sluggish): the pusher rebuilt EVERY open chat tab on
 # every 0.5s poll — a full transcript reshape into ChatEvent[] AND a json.dumps of the whole chat, per tab,
@@ -28499,66 +28554,25 @@ def _parse(path, sid, now):
     to the transcript anyway, busting the cache.) The cut (a chat DELETE's bare rollback, backend
     pending_cut) rides the KEY because it changes the parse with no file change — arming and clearing
     both must bust the cache, and its own spend event (a record landing) moves mtime/size anyway."""
-    _be = _sdk()
-    # pending_cut is hot-path safe: a LIVE SDK session is a dict hit + attr checks (no I/O);
-    # tmux/dormant fall to one small reg read; the transcript-leaf read happens only while
-    # a rollback is actually pending.
-    cut = _be.pending_cut(sid) if _be else ""
-    # states/<sid>.jsonl → REAL idle transitions become idle atoms (the interrupt/settle write lands HERE,
-    # not the transcript). Mirrors jd.parsed_session, which has read states since 2026-06-17 — the kernel's
-    # DISPLAY parse was overlooked, so an SDK interrupt cleared 'working' for the judge/nudge (which read
-    # states) while the chip/card/timeline lane (which read this cache) stayed yellow. Without it the display
-    # only clears on a transcript write, which an SDK stop need not produce (the user 2026-07-22: "pressing
-    # interrupt doesn't clear working"). Safe: _session_working sorts atoms by their START time, so an idle
-    # span whose end runs to `now` never closes a genuinely-working turn — its fresh work atoms sort later.
-    states = jd.STATE / "states" / (sid + ".jsonl")
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size, cut)
-    except OSError:
-        key = None
-    if key is not None:
-        try:                                         # a states-ONLY change (an idle transition that never
-            sst = os.stat(states)                    # touches the transcript) must bust the cache too — else
-            key = key + (sst.st_mtime, sst.st_size)  # the fresh idle atom is invisible and 'working' latches
-        except OSError:
-            pass                                     # no states file yet → nothing to fold
-    hit = _parse_cache.get(path)
-    if hit is not None and key is not None and hit[0] == key:
-        return hit[1]
-    # A FORKED leaf (SDK /clear: discover hands the lastSid file under the stable romp sid) parses with
-    # the session's anchor transcript among the candidates — a resume-style fork's cross-file chain keeps
-    # its history via the FileAdapter walk (a RECORDED fresh-headed resume fork stitches through the
-    # states/ resumeFork lineage inside parse_session, 2026-08-14); a /clear fork (parentUuid null, no
-    # lineage) still starts fresh. Mirrors jd.parsed_session. Cache stays keyed on the LEAF alone plus
-    # the states file (folded above), which moves when a lineage row lands: the anchor file is dead
-    # once forked.
-    cands = [path]
-    anchor = os.path.join(os.path.dirname(path), sid + ".jsonl")
-    if os.path.basename(path) != sid + ".jsonl" and os.path.exists(anchor):
-        cands.append(anchor)
-    _mode = []
-    session = em.parse_session(path, rompuuid=sid, candidate_files=cands,
-                               postal_log=str(jd.MESSAGES), now=now, asm_mode_out=_mode,
-                               # SDK/Codex session: composer input arrives programmatic (promptSource "sdk"),
-                               # so the unmarked prompt is the HUMAN — same flag for both backends
-                               sdk_human=bool((_be and _be.owns(sid)) or ((_cx := _codex()) and _cx.owns(sid))),
-                               states=str(states) if states.exists() else None,   # idle transitions → idle atoms (see above)
-                               leaf_override=cut or None)   # pending bare rollback → render the cut conversation NOW
-    # the assembly path this parse took, read by the chat-payload fold (issue 903) right after the
-    # call: a serve/fold left every earlier atom in place, a full/bypass/fallback may have re-emitted
-    # history. Keyed by path, written by the thread that parsed; the fold reads it under the same
-    # parse it just made, so a racing parse of the same path can only make it MORE conservative
-    # (a "full" read where a "fold" happened) — never less.
+    # T323 stage 2 (2026-09-11): ONE parse for the kernel and the judges. jd.parsed_session keys on the same facts this
+    # function keyed on (the transcript's and the states file's stat pair, the pending cut it reads through the provider
+    # this kernel installs, sdk_human through the owner hook) and expands the same candidate set (the leaf plus the
+    # session's anchor file), so the tree it returns is the tree the judges walk: parsed once per file version, held
+    # once. The old per-path cache is a view over that store (_SharedParseView).
+    _mode, stats = [], {}
+    session = jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats)
     _parse_mode[path] = _mode[-1] if _mode else "full"
     try:
-        _PERF_STATS.parse(sid, key[1] if key is not None else 0)   # a cold parse ran (T323: /perf parses)
+        if stats.get("miss"):
+            try:
+                size = os.stat(path).st_size
+            except OSError:
+                size = 0
+            _PERF_STATS.parse(sid, size)             # a cold parse the KERNEL's ask ran (T323: /perf parses.kernel)
+        else:
+            _PERF_STATS.parse_hit()
     except Exception:
         pass
-    if key is not None:
-        if len(_parse_cache) > 256:              # backstop: bounded by fleet size, but never unbounded
-            _parse_cache.clear()
-        _parse_cache[path] = (key, session)
     return session
 
 
@@ -29060,15 +29074,7 @@ def _parse_cached(path):
     (which come from the goal store, cheap) paint AT ONCE on a cold kernel start; the dots/anchors fill in a
     beat later once _warm_fleet_bg has parsed the session in the background (the user 2026-06-26: the feed
     cards lagged the timeline lanes on startup, all of it the ~1s cold parse of the fleet)."""
-    try:
-        st = os.stat(path)
-        key = (st.st_mtime, st.st_size)
-    except OSError:
-        return None
-    hit = _parse_cache.get(path)
-    # prefix compare: _parse's key carries a third element (the pending-rollback cut) this NEVER-parsing
-    # reader can't cheaply recompute — dots/anchors from a cut parse are consistent with what chat shows
-    return hit[1] if (hit is not None and tuple(hit[0][:2]) == key) else None
+    return jd.parse_cached(_SharedParseView._fsid(path), [str(path)])   # the shared store's live-key read (stage 2)
 
 
 _warm_lock = threading.Lock()

--- a/scripts/bench_boot_parse.py
+++ b/scripts/bench_boot_parse.py
@@ -132,8 +132,11 @@ def boot_once(tree, dist, sessions, turns, settle_s):
             parses = {}
         row = {"tree": tree, "sessions": sessions, "turnsPerSession": turns, "worldBytes": total_bytes,
                "firstServeS": round(first_serve, 2), "settleS": settle_s, "readBytes": io.get("rchar"),
-               "rssKb": io.get("rssKb"), "parses": parses.get("total"), "parseBytes": parses.get("bytes"),
-               "judgeParses": parses.get("judge")}
+               "rssKb": io.get("rssKb"),
+               # /perf parses: since stage 2 `kernel` is the display's cold parses and `total` every miss through the
+               # shared store; a stage 1 tree reports `total` as the display's (no shared store yet)
+               "parses": parses.get("kernel", parses.get("total")), "parseBytes": parses.get("bytes"),
+               "judgeParses": parses.get("judge"), "totalParses": parses.get("total")}
         proc.terminate()
         try:
             proc.wait(timeout=15)

--- a/scripts/bench_shared_parse.py
+++ b/scripts/bench_shared_parse.py
@@ -108,7 +108,7 @@ def draw(rows, out):
              ylabel="Resident size added by the judges' parse\nafter the display had parsed (MB), zero is the goal")
     ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25); ax.set_yticks([0, round(top, 1) if top < 10 else round(top)])
     f.text(0.5, -0.04, "One measurement per point. A zero is the resident read's floor: a second tree that fits in pages\n"
-                       "the allocator already held adds nothing visible; the parse count in bench.json says whether one was built.",
+                       "the allocator already held adds nothing visible. The parse count in bench.json says whether one was built.",
            ha="center", va="top", fontsize=8, color="#555555", transform=f.transFigure)
     path = os.path.join(out, "trees_vs_size.png")
     f.savefig(path, dpi=150, bbox_inches="tight")

--- a/scripts/bench_shared_parse.py
+++ b/scripts/bench_shared_parse.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""bench_shared_parse: the memory the parsed session trees cost when BOTH the display and the judges parse the same
+transcripts, against transcript size (T323 stage 2's acceptance measurement).
+
+For each romp tree given, a child process loads that tree's event model, judge and kernel against a temporary state
+root (nothing against live state), builds N synthetic sessions whose transcripts are S times a base of invented text,
+then asks BOTH sides for every session (the kernel's _parse, the way the chat build asks, and jd.parsed_session, the
+way a judge pass asks) and reports the process's resident-size growth and the cold parses counted. One child per
+(tree, size), sequential, small worlds, under `capped`. Then a cleanplots figure of tree memory against size per tree:
+two trees per session before the shared store, one after.
+
+    capped bash -c 'uvx --with cleanplots --with matplotlib --with pandas python scripts/bench_shared_parse.py \\
+        --tree before=/path/to/stage1-tree --tree after=/path/to/stage2-tree --sizes 1,4,16 --sessions 6 --out DIR'
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+CHILD = r'''
+import json, os, resource, sys, tempfile, time, random
+tree, sessions, turns = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+root = tempfile.mkdtemp(prefix="romp-shared-bench-")
+os.environ["XDG_STATE_HOME"] = os.path.join(root, "state"); os.makedirs(os.environ["XDG_STATE_HOME"] + "/romp/states", exist_ok=True)
+os.environ.pop("ROMP_STATE_DIR", None); os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(root, "claude")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"; os.environ.setdefault("ROMP_SERVE_TOKEN", "bench"); os.environ["ROMP_MANAGER_PORT"] = "1"
+sys.path.insert(0, os.path.join(tree, "tests"))
+from romp_load import load_source
+load_source("romp_event_model", os.path.join(tree, "bin", "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(tree, "bin", "romp-judge"))
+km = load_source("romp_kernel_bench", os.path.join(tree, "bin", "romp-kernel"))
+WORDS = ("fixture", "suite", "backoff", "jitter", "cap", "retry", "review", "branch", "merge", "green", "README", "wire")
+def transcript(path, seed):
+    rnd = random.Random(seed); parent = None; t0 = int(time.time()) - 86400
+    with open(path, "w") as f:
+        for i in range(turns):
+            u, a = "u%06d" % i, "a%06d" % i
+            ts = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(t0 + i * 60))
+            f.write(json.dumps({"type": "user", "timestamp": ts, "uuid": u, "parentUuid": parent, "promptSource": "typed",
+                                "message": {"role": "user", "content": "please " + " ".join(rnd.choice(WORDS) for _ in range(40))}}) + "\n")
+            f.write(json.dumps({"type": "assistant", "timestamp": ts, "uuid": a, "parentUuid": u,
+                                "message": {"role": "assistant", "content": [{"type": "text", "text": " ".join(rnd.choice(WORDS) for _ in range(120))}], "stop_reason": "end_turn"}}) + "\n")
+            parent = a
+d = os.path.join(root, "tx"); os.makedirs(d)
+paths = []
+for i in range(sessions):
+    sid = "%08x-1111-2222-3333-444444444444" % (0xb0000000 + i)
+    p = os.path.join(d, sid + ".jsonl"); transcript(p, i); paths.append((sid, p))
+total = sum(os.path.getsize(p) for _, p in paths)
+def rss(): return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+now = int(time.time())
+r0 = rss()
+for sid, p in paths:
+    km._parse(p, sid, now)                 # the display's ask
+r1 = rss()
+for sid, p in paths:
+    jd.parsed_session(sid, [p], now)      # a judge pass's ask
+r2 = rss()
+misses = getattr(jd, "parse_misses", lambda: None)()
+print(json.dumps({"worldBytes": total, "afterKernelBytes": r1 - r0, "afterBothBytes": r2 - r0, "coldParses": misses,
+                  "sessions": sessions, "turns": turns}))
+import shutil; shutil.rmtree(root, ignore_errors=True)
+'''
+
+
+def run_child(tree, sessions, turns):
+    p = subprocess.run([sys.executable, "-c", CHILD, tree, str(sessions), str(turns)], capture_output=True, text=True, timeout=600)
+    line = [ln for ln in p.stdout.splitlines() if ln.startswith("{")]
+    if p.returncode != 0 or not line:
+        return {"error": (p.stderr or p.stdout)[-400:]}
+    return json.loads(line[-1])
+
+
+def draw(rows, out):
+    import cleanplots as cp
+    import matplotlib
+    matplotlib.use("Agg")
+    labels = sorted({r["label"] for r in rows})
+    cols = list(cp.colors)
+    f, ax = cp.fig(w=9, h=5)
+    top = 1.0
+    for i, label in enumerate(labels):
+        rs = sorted([r for r in rows if r["label"] == label and not r.get("error")], key=lambda r: r["worldBytes"])
+        if not rs:
+            sys.stderr.write("figure: every run of %r errored; the label is left out\n" % label); continue
+        xs = [r["worldBytes"] / 1048576 for r in rs]
+        ys = [r["afterBothBytes"] / 1048576 for r in rs]
+        top = max(top, max(ys))
+        ax.line(xs, ys, label=label, color=cols[i % len(cols)], marker="o")
+    ax.clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Resident growth after the display and the judges\nboth parsed every session (MB), lower is better")
+    ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25); ax.set_yticks([0, round(top)])
+    path = os.path.join(out, "trees_vs_size.png")
+    f.savefig(path, dpi=150, bbox_inches="tight")
+    return path
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--tree", action="append", required=True)
+    ap.add_argument("--sizes", default="1,4,16")
+    ap.add_argument("--base-turns", type=int, default=150)
+    ap.add_argument("--sessions", type=int, default=6)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--no-figure", action="store_true")
+    ap.add_argument("--figure-only", action="store_true")
+    a = ap.parse_args(argv)
+    os.makedirs(a.out, exist_ok=True)
+    if a.figure_only:
+        with open(os.path.join(a.out, "bench.json")) as f:
+            sys.stdout.write("figure " + draw(json.load(f)["rows"], a.out) + "\n")
+        return 0
+    rows = []
+    for spec in a.tree:
+        label, tree = spec.split("=", 1)
+        for s in (int(x) for x in a.sizes.split(",")):
+            row = run_child(os.path.abspath(tree), a.sessions, a.base_turns * s)
+            row.update(label=label, size=s, tree=os.path.abspath(tree))
+            rows.append(row); sys.stdout.write(json.dumps(row) + "\n"); sys.stdout.flush()
+    with open(os.path.join(a.out, "bench.json"), "w") as f:
+        json.dump({"rows": rows}, f, indent=1)
+    if not a.no_figure:
+        sys.stdout.write("figure " + draw(rows, a.out) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_shared_parse.py
+++ b/scripts/bench_shared_parse.py
@@ -6,10 +6,15 @@ For each romp tree given, a child process loads that tree's event model, judge a
 root (nothing against live state), builds N synthetic sessions whose transcripts are S times a base of invented text,
 then asks BOTH sides for every session (the kernel's _parse, the way the chat build asks, and jd.parsed_session, the
 way a judge pass asks) and reports the process's CURRENT resident size (VmRSS from /proc/self/statm, never the peak)
-after the display's parses and again after the judges', and the cold parses counted. One child per (tree, size),
-sequential, small worlds, under `capped`. The figure draws, per tree, the second side's resident delta (after both
-minus after the display alone) against size: the cost of the second tree, present before the shared store and gone
-after it. The bars are one measurement each, not a distribution.
+after the display's parses and again after the judges', and the event-model parses counted at em.parse_session
+itself (so the count reads the same on a tree where the kernel called the event model directly and on one where it
+goes through the judges' store; the judges' own miss counter is reported beside it and is NOT comparable across such
+trees). One child per (tree, size), sequential, small worlds, under `capped`. The figure draws, per tree, the second
+side's resident delta (after both minus after the display alone) against size: the cost of the second tree, present
+before the shared store and gone after it. Sizes are decimal megabytes (1e6 bytes) on both axes. The points are one
+measurement each, not a distribution, and the resident read has a FLOOR: a small second tree can land in pages the
+allocator already held, so a delta of zero means the read saw no new resident pages, not that no tree was built; the
+parse count says whether one was.
 
     capped bash -c 'uvx --with cleanplots --with matplotlib --with pandas python scripts/bench_shared_parse.py \\
         --tree before=/path/to/stage1-tree --tree after=/path/to/stage2-tree --sizes 1,4,16 --sessions 6 --out DIR'
@@ -56,6 +61,11 @@ def rss():
         return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
 now = int(time.time())
 r0 = rss()
+em_mod = sys.modules["romp_event_model"]; n_em = [0]; _orig_parse = em_mod.parse_session
+def _counted(*a, **k):
+    n_em[0] += 1
+    return _orig_parse(*a, **k)
+em_mod.parse_session = _counted             # both callers reach the event model here, on every tree
 for sid, p in paths:
     km._parse(p, sid, now)                 # the display's ask
 r1 = rss()
@@ -63,7 +73,8 @@ for sid, p in paths:
     jd.parsed_session(sid, [p], now)      # a judge pass's ask
 r2 = rss()
 misses = getattr(jd, "parse_misses", lambda: None)()
-print(json.dumps({"worldBytes": total, "afterKernelBytes": r1 - r0, "afterBothBytes": r2 - r0, "coldParses": misses,
+print(json.dumps({"worldBytes": total, "afterKernelBytes": r1 - r0, "afterBothBytes": r2 - r0, "coldParses": n_em[0],
+                  "judgeMisses": misses,
                   "sessions": sessions, "turns": turns}))
 import shutil; shutil.rmtree(root, ignore_errors=True)
 '''
@@ -89,13 +100,16 @@ def draw(rows, out):
         rs = sorted([r for r in rows if r["label"] == label and not r.get("error")], key=lambda r: r["worldBytes"])
         if not rs:
             sys.stderr.write("figure: every run of %r errored; the label is left out\n" % label); continue
-        xs = [r["worldBytes"] / 1048576 for r in rs]
-        ys = [max(0.0, r["afterBothBytes"] - r["afterKernelBytes"]) / 1048576 for r in rs]   # the SECOND tree's own cost
+        xs = [r["worldBytes"] / 1e6 for r in rs]                                          # decimal MB, as the axes say
+        ys = [max(0.0, r["afterBothBytes"] - r["afterKernelBytes"]) / 1e6 for r in rs]   # the SECOND tree's own cost
         top = max(top, max(ys))
         ax.line(xs, ys, label=label, color=cols[i % len(cols)], marker="o")
     ax.clean(xlabel="Transcripts on disk (MB), all sessions",
              ylabel="Resident size added by the judges' parse\nafter the display had parsed (MB), zero is the goal")
     ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25); ax.set_yticks([0, round(top, 1) if top < 10 else round(top)])
+    f.text(0.5, -0.04, "One measurement per point. A zero is the resident read's floor: a second tree that fits in pages\n"
+                       "the allocator already held adds nothing visible; the parse count in bench.json says whether one was built.",
+           ha="center", va="top", fontsize=8, color="#555555", transform=f.transFigure)
     path = os.path.join(out, "trees_vs_size.png")
     f.savefig(path, dpi=150, bbox_inches="tight")
     return path

--- a/scripts/bench_shared_parse.py
+++ b/scripts/bench_shared_parse.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
-"""bench_shared_parse: the memory the parsed session trees cost when BOTH the display and the judges parse the same
-transcripts, against transcript size (T323 stage 2's acceptance measurement).
+"""bench_shared_parse: the resident memory the SECOND parsed tree costs when both the display and the judges parse the
+same transcripts, against transcript size (T323 stage 2's acceptance measurement).
 
 For each romp tree given, a child process loads that tree's event model, judge and kernel against a temporary state
 root (nothing against live state), builds N synthetic sessions whose transcripts are S times a base of invented text,
 then asks BOTH sides for every session (the kernel's _parse, the way the chat build asks, and jd.parsed_session, the
-way a judge pass asks) and reports the process's resident-size growth and the cold parses counted. One child per
-(tree, size), sequential, small worlds, under `capped`. Then a cleanplots figure of tree memory against size per tree:
-two trees per session before the shared store, one after.
+way a judge pass asks) and reports the process's CURRENT resident size (VmRSS from /proc/self/statm, never the peak)
+after the display's parses and again after the judges', and the cold parses counted. One child per (tree, size),
+sequential, small worlds, under `capped`. The figure draws, per tree, the second side's resident delta (after both
+minus after the display alone) against size: the cost of the second tree, present before the shared store and gone
+after it. The bars are one measurement each, not a distribution.
 
     capped bash -c 'uvx --with cleanplots --with matplotlib --with pandas python scripts/bench_shared_parse.py \\
         --tree before=/path/to/stage1-tree --tree after=/path/to/stage2-tree --sizes 1,4,16 --sessions 6 --out DIR'
@@ -49,7 +51,9 @@ for i in range(sessions):
     sid = "%08x-1111-2222-3333-444444444444" % (0xb0000000 + i)
     p = os.path.join(d, sid + ".jsonl"); transcript(p, i); paths.append((sid, p))
 total = sum(os.path.getsize(p) for _, p in paths)
-def rss(): return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+def rss():
+    with open("/proc/self/statm") as f:                 # CURRENT resident pages, not ru_maxrss (a peak: differences of peaks are not growth)
+        return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
 now = int(time.time())
 r0 = rss()
 for sid, p in paths:
@@ -86,11 +90,12 @@ def draw(rows, out):
         if not rs:
             sys.stderr.write("figure: every run of %r errored; the label is left out\n" % label); continue
         xs = [r["worldBytes"] / 1048576 for r in rs]
-        ys = [r["afterBothBytes"] / 1048576 for r in rs]
+        ys = [max(0.0, r["afterBothBytes"] - r["afterKernelBytes"]) / 1048576 for r in rs]   # the SECOND tree's own cost
         top = max(top, max(ys))
         ax.line(xs, ys, label=label, color=cols[i % len(cols)], marker="o")
-    ax.clean(xlabel="Transcripts on disk (MB), all sessions", ylabel="Resident growth after the display and the judges\nboth parsed every session (MB), lower is better")
-    ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25); ax.set_yticks([0, round(top)])
+    ax.clean(xlabel="Transcripts on disk (MB), all sessions",
+             ylabel="Resident size added by the judges' parse\nafter the display had parsed (MB), zero is the goal")
+    ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25); ax.set_yticks([0, round(top, 1) if top < 10 else round(top)])
     path = os.path.join(out, "trees_vs_size.png")
     f.savefig(path, dpi=150, bbox_inches="tight")
     return path

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -285,7 +285,8 @@ class PerfCountsColdParses(unittest.TestCase):
         km._PERF_STATS.parse(SID_OLD, 10)
         km._PERF_STATS.parse(SID_NEW, 5)
         snap = km._PERF_STATS.snapshot()
-        self.assertEqual((snap["parses"]["total"], snap["parses"]["bytes"]), (3, 1249))
+        self.assertEqual((snap["parses"]["kernel"], snap["parses"]["bytes"]), (3, 1249), "the kernel's own asks (stage 2 splits the counters)")
+        self.assertIsInstance(snap["parses"]["total"], int)
         self.assertEqual(snap["parses"]["bySid"], {SID_OLD[:8]: 2, SID_NEW[:8]: 1})
         self.assertIsInstance(snap["parses"]["judge"], int)
 
@@ -297,7 +298,8 @@ class PerfCountsColdParses(unittest.TestCase):
         now = int(time.time())
         km._parse(r["path"], SID_NEW, now)
         km._parse(r["path"], SID_NEW, now)
-        self.assertEqual(km._PERF_STATS.snapshot()["parses"]["total"], 1, "the second call is a cache hit")
+        snap = km._PERF_STATS.snapshot()["parses"]
+        self.assertEqual((snap["kernel"], snap["hits"]), (1, 1), "the second call is served from the shared store")
 
     def test_judge_parse_misses(self):
         d = tempfile.mkdtemp()

--- a/tests/test_boot_parses_served.py
+++ b/tests/test_boot_parses_served.py
@@ -178,7 +178,7 @@ class ServedBootParses(unittest.TestCase):
     def test_1_a_boot_with_no_client_parses_nothing_and_the_blocked_card_comes_from_the_store(self):
         self._settled()
         p = self._parses()
-        self.assertEqual(p["total"], 0, "no client asked, so the kernel parsed no transcript at boot: %r" % p)
+        self.assertEqual(p["kernel"], 0, "no client asked, so the kernel parsed no transcript at boot: %r" % p)
         self.assertEqual(p["bySid"], {}, "per session: none")
         # the judges' first pass still parses what it enumerates (their checkpoint resume is stages 3 and 4); this
         # stage only orders it newest first; pin the count so a regression to double parsing shows
@@ -190,7 +190,7 @@ class ServedBootParses(unittest.TestCase):
         self.assertTrue(web, "web's card is in the feed: %r" % [c.get("sid") for c in cards][:10])
         self.assertTrue(any(c.get("column") == "needs_input" for c in web),
                         "web reads blocked (needs_input) from the store the previous kernel wrote: %r" % [c.get("column") for c in web])
-        self.assertEqual(self._parses()["total"], 0, "and the feed route parsed nothing to say so (it is cache-only)")
+        self.assertEqual(self._parses()["kernel"], 0, "and the feed route parsed nothing to say so (it is cache-only; the judges' own parses ride total)")
 
     def test_2_a_chat_client_parses_only_what_it_shows(self):
         if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
@@ -199,7 +199,7 @@ class ServedBootParses(unittest.TestCase):
                                 os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
         if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
             raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
-        before = self._parses()["total"]
+        before = self._parses()["kernel"]
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
             json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token)}, f)
@@ -210,8 +210,9 @@ class ServedBootParses(unittest.TestCase):
                            env=dict(os.environ, CFG=cfg, EXT_PKG=os.path.join(EXT, "package.json")))
         self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-2000:] + p.stderr[-2000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
         after = self._parses()
-        self.assertGreaterEqual(after["total"] - before, 1, "a connected chat client's own tabs are parsed on demand: %r" % after)
-        self.assertLessEqual(after["total"] - before, len(ALL), "and nothing beyond the shown tabs (every living session is a tab here): %r" % after)
+        asked = after["kernel"] + after["hits"]     # stage 2: the judges may have parsed a tab first, then the kernel's ask is a hit
+        self.assertGreaterEqual(asked, 1, "a connected chat client's own tabs are parsed or served on demand: %r" % after)
+        self.assertLessEqual(after["kernel"] - before, len(ALL), "and nothing beyond the shown tabs (every living session is a tab here): %r" % after)
         self.assertTrue(set(after["bySid"]) <= {s[:8] for s in ALL}, after["bySid"])
 
 

--- a/tests/test_interrupt_marks_memo.py
+++ b/tests/test_interrupt_marks_memo.py
@@ -337,7 +337,7 @@ class MemoAcrossTheCycle(_MemoHarness):
         km.build_feed(NOW, self.tmux)
         judge = km._intr_marks_memo[(SID, "judge")]
         disp = km._intr_marks_memo[(SID, "display")]
-        self.assertIsNot(judge[0], disp[0], "two distinct parse objects, one slot each")
+        self.assertIs(judge[0], disp[0], "ONE parse object since stage 2 (the kernel and the judges share the store); still one slot per family")
         km._interrupt_block_tick(NOW, self.tmux)
         self.assertIs(km._intr_marks_memo[(SID, "display")], disp, "the tick left the display slot alone")
         km.build_feed(NOW, self.tmux)

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -248,12 +248,16 @@ class ParseCut(unittest.TestCase):
 
     def test_kernel_parse_keys_the_cache_on_the_cut(self):
         # arming and clearing both change the parse with NO file change — the cut must ride the key
+        # stage 2 (2026-09-11): the kernel's parse is the judges' parsed_session; the cut rides ITS key and its slot
         src = inspect.getsource(km._parse)
-        self.assertIn("cut = _be.pending_cut(sid) if _be else \"\"", src)
-        self.assertIn("key = (st.st_mtime, st.st_size, cut)", src)
-        self.assertIn("leaf_override=cut or None", src)
-        # the never-parsing feed reader compares the file identity prefix only
-        self.assertIn("tuple(hit[0][:2]) == key", inspect.getsource(km._parse_cached))
+        self.assertIn("jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats)", src)
+        jsrc = inspect.getsource(km.jd.parsed_session)
+        self.assertIn("cut = _pending_cut(fsid)", jsrc)
+        self.assertIn("key = (pair[0], cut) if pair is not None else None", jsrc)
+        self.assertIn("hit = _parse_slot(fsid, cut)", jsrc, "the slot is per cut: two callers reading different cuts never share a tree")
+        self.assertIn("leaf_override=cut or None", jsrc)
+        # the never-parsing feed reader asks the shared store under the live key
+        self.assertIn("jd.parse_cached(", inspect.getsource(km._parse_cached))
 
     def test_the_built_chat_cache_sig_carries_the_cut_too(self):
         # same lesson one level up: the BUILT payload cache would otherwise keep pushing a

--- a/tests/test_kernel_rewind.py
+++ b/tests/test_kernel_rewind.py
@@ -250,11 +250,12 @@ class ParseCut(unittest.TestCase):
         # arming and clearing both change the parse with NO file change — the cut must ride the key
         # stage 2 (2026-09-11): the kernel's parse is the judges' parsed_session; the cut rides ITS key and its slot
         src = inspect.getsource(km._parse)
-        self.assertIn("jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats)", src)
+        self.assertIn("jd.parsed_session(sid, [path], now, asm_mode_out=_mode, stats=stats, states=states,", src)
+        self.assertIn("sdk_human=_display_sdk_human(sid))", src, "the display passes its own owner answer: a differing judge answer keeps its own slot")
         jsrc = inspect.getsource(km.jd.parsed_session)
         self.assertIn("cut = _pending_cut(fsid)", jsrc)
         self.assertIn("key = (pair[0], cut) if pair is not None else None", jsrc)
-        self.assertIn("hit = _parse_slot(fsid, cut)", jsrc, "the slot is per cut: two callers reading different cuts never share a tree")
+        self.assertIn("hit = _parse_slot(fsid, cut, ", jsrc, "the slot is per cut: two callers reading different cuts never share a tree")
         self.assertIn("leaf_override=cut or None", jsrc)
         # the never-parsing feed reader asks the shared store under the live key
         self.assertIn("jd.parse_cached(", inspect.getsource(km._parse_cached))

--- a/tests/test_nudge_gate_memo.py
+++ b/tests/test_nudge_gate_memo.py
@@ -238,6 +238,26 @@ class GateMemo(_Gate):
         self.assertEqual(snap["memos"]["nudgeGate"], {"served": 1, "derived": 1})
 
 
+    def test_served_by_the_turns_held_when_an_agent_view_is_the_newest_slot(self):
+        """Review find (2026-09-11): the gate read the sid's NEWEST parse slot; an openSubagent handler on a socket
+        thread can store the agent file's parse under the same sid between the walk's parse and the gate's read
+        (the store keeps a slot per leaf), and the newest slot then held another tree, so the memo missed and the
+        gate re-derived the whole session that cycle. The gate looks its entry up by the turns it holds."""
+        turns, store = self._turns(), self._view()
+        km._nudge_placement_gate(SID, turns, store)                         # derived once, memoized
+        agent = self.tpath.parent / "subagents" / "agent-aaaa.jsonl"
+        agent.parent.mkdir()
+        agent.write_text("\n".join(json.dumps(r) for r in [uline(T0 + 100, "check the width", "s1"),
+                                                             aline(T0 + 110, "checked", "s2", "s1")]) + "\n")
+        jd.parsed_session(SID, [str(agent)], NOW)                           # the agent view: the sid's newest slot now
+        self.assertEqual(jd._PARSE_CACHE[SID][2], str(agent), "the newest slot is the agent file's")
+        self.assertIsNot(jd._PARSE_CACHE[SID][1].get("turns"), turns)
+        with patch.object(jd, "plan_units", wraps=jd.plan_units) as pu:
+            km._nudge_placement_gate(SID, turns, store)
+        self.assertEqual(pu.call_count, 0, "served from the memo: the entry is found by the turns held, not the newest slot")
+        self.assertEqual(km._NUDGE_GATE_STATS, {"served": 1, "derived": 1})
+
+
 class WalkReadsTheSharedView(_Gate):
     def test_the_walk_reads_through_the_shared_view_and_never_a_fresh_load(self):
         """The walk's own read is the shared view; every writer downstream reloads at its write moment

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -44,6 +44,8 @@ def _transcript(d, sid, n=2):
 
 class OneParseForBoth(unittest.TestCase):
     def setUp(self):
+        km._display_sdk_human(A)                # builds the backend once: its setter installs the owner hook and
+        #                                          clears the store, which must never happen mid-test (review find D)
         jd.parse_cache_clear()
         km._PERF_STATS.reset()
         self.d = tempfile.mkdtemp()
@@ -84,6 +86,57 @@ class OneParseForBoth(unittest.TestCase):
         self.assertIs(s1, s2)
         self.assertEqual(self._misses() - m0, 1, "the grown file costs one parse, shared")
 
+    def test_a_leaf_named_after_the_cli_session_is_found_by_path(self):
+        """Review find (A): after a /clear or a resume fork the leaf is <lastSid>.jsonl while the romp sid is another
+        id; the cache-only read and the view's drop go by leaf path and the entry's own sid, never a filename stem."""
+        other = "55555555-6666-4777-8888-000000000777"
+        p = _transcript(self.d, other, n=3)                  # a leaf named after the CLI session id
+        km._parse(p, A, self.now)                            # parsed for romp sid A
+        self.assertIsNotNone(km._parse_cached(p), "the cache-only read finds the display's tree by leaf path")
+        self.assertIs(km._parse_cached(p), jd._PARSE_CACHE[A][1])
+        self.assertIn(p, km._parse_cache)
+        km._parse_cache.pop(p, None)
+        self.assertNotIn(p, km._parse_cache, "pop by path drops the tree parsed under the romp sid")
+        self.assertIsNone(km._parse_cached(p))
+        self.assertNotIn(A, jd._PARSE_CACHE)
+
+    def test_a_store_hit_reports_the_assembly_mode_so_the_chat_fold_can_fold(self):
+        """Review find (B): the judges parse an appended transcript first; the kernel's build hits the store and must
+        learn the mode of the parse that built the tree (fold or serve), else the fold gate rebuilds the whole chat."""
+        p = _transcript(self.d, B, n=2)
+        km._parse(p, B, self.now)
+        self.assertEqual(km._parse_mode[p], "full", "the first parse is a full assembly")
+        with open(p, "a") as f:
+            f.write(json.dumps({"type": "user", "uuid": "u9", "parentUuid": "a1", "timestamp": "2026-09-10T00:20:00.000Z",
+                                "message": {"role": "user", "content": "one more"}}) + "\n")
+        jd.parsed_session(B, [p], self.now + 1)              # a judge sees the append first (no asm_mode_out of its own)
+        m0 = self._misses()
+        km._parse(p, B, self.now + 1)                        # the kernel's build: a hit
+        self.assertEqual(self._misses() - m0, 0)
+        self.assertIn(km._parse_mode[p], ("fold", "serve"), "the hit carries the judges' assembly mode, never a blank read as full: %r" % km._parse_mode[p])
+        ent = jd._PARSE_CACHE[B]
+        self.assertEqual((ent[4], ent[5]), (B, km._parse_mode[p]), "the entry names its sid and the mode that built it")
+
+    def test_two_answers_in_one_slot_in_a_hookless_process(self):
+        """Review find (F), the case the per-flag trees exist for: with no owner hook, the display passes True (its
+        backend owns the session) while the judges compute False (no registry file); each keeps its own tree in the
+        slot and neither reads the other's."""
+        p = _transcript(self.d, A, n=2)
+        saved = jd._SDK_OWNER_FN
+        jd._SDK_OWNER_FN = None
+        try:
+            jd.parse_cache_clear()
+            judge_tree = jd.parsed_session(A, [p], self.now)                      # the judges: registry absent → False
+            disp_tree = jd.parsed_session(A, [p], self.now, sdk_human=True)      # the display: its backend owns → True
+            self.assertIsNot(judge_tree, disp_tree)
+            self.assertEqual(sorted(jd._PARSE_CACHE[(A, "")].keys()), [False, True], "one tree per answer in the slot")
+            m0 = self._misses()
+            self.assertIs(jd.parsed_session(A, [p], self.now), judge_tree, "the judges hit their own tree")
+            self.assertIs(jd.parsed_session(A, [p], self.now, sdk_human=True), disp_tree, "the display hits its own")
+            self.assertEqual(self._misses() - m0, 0, "no stale hit either way, no re-parse either")
+        finally:
+            jd._SDK_OWNER_FN = saved
+
     def test_different_pending_cuts_get_separate_slots(self):
         """The manager's rule: when the kernel and the judges would read different cuts, each gets its own entry
         rather than one reading the other's view."""
@@ -95,12 +148,15 @@ class OneParseForBoth(unittest.TestCase):
             jd.set_pending_cut_provider(lambda fsid: "a1")          # a bare rollback armed: the world cut at a1
             cut = jd.parsed_session(A, [p], self.now)
             self.assertIsNot(plain, cut)
-            self.assertIn((A, ""), jd._PARSE_CACHE); self.assertIn((A, "a1"), jd._PARSE_CACHE)   # a slot per cut, a tree per flag inside
+            self.assertIn((A, "a1"), jd._PARSE_CACHE)
+            self.assertNotIn((A, ""), jd._PARSE_CACHE, "a slot stored under a new cut drops the fsid's other cut slots: one tree per session (review find)")
+            jd.set_pending_cut_provider(lambda fsid: "")        # the cut is spent (the next record landed)
             m0 = self._misses()
-            jd.set_pending_cut_provider(lambda fsid: "")
-            self.assertIs(jd.parsed_session(A, [p], self.now), plain, "the un-cut slot is still there, not evicted by the cut one")
-            self.assertEqual(self._misses() - m0, 0)
-            self.assertIs(jd._PARSE_CACHE[A][1], plain, "a bare id reads the newest slot")
+            again = jd.parsed_session(A, [p], self.now)
+            self.assertEqual(self._misses() - m0, 1, "the spent cut's tree is gone, the plain world is parsed once more")
+            self.assertNotIn((A, "a1"), jd._PARSE_CACHE, "and the spent cut's slot went with it")
+            self.assertIs(jd._PARSE_CACHE[A][1], again, "a bare id reads the newest slot")
+            self.assertEqual(len([k for k in jd._PARSE_CACHE if k[0] == A]), 1)
         finally:
             jd.set_pending_cut_provider(saved)
 

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""T323 stage 2 (the user 2026-09-10; built 2026-09-11): ONE parse for the kernel and the judges. The judges' cache is
+the shared store: the kernel's _parse delegates to jd.parsed_session, so a transcript is parsed once per file version
+and its tree is held once, whichever side asked first. The store keys on every fact either side keyed on (the fileset
+stat pair over the candidates and the states file, the pending cut, sdk_human), keeps a slot per pending cut so two
+callers reading different cuts never share one wrong tree, evicts least recently used instead of clearing wholesale,
+and answers the kernel's path-keyed readers through a view. Hermetic: synthetic transcripts under a temp root."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel_t323s2", os.path.join(BIN, "romp-kernel"))
+
+A = "11111111-2222-4333-8444-000000000201"
+B = "22222222-2222-4333-8444-000000000202"
+
+
+def _transcript(d, sid, n=2):
+    p = Path(d) / (sid + ".jsonl")
+    recs, parent = [], None
+    for i in range(n):
+        u, a = "u%d" % i, "a%d" % i
+        recs.append({"type": "user", "uuid": u, "parentUuid": parent, "timestamp": "2026-09-10T00:%02d:00Z" % i,
+                     "promptSource": "typed", "message": {"role": "user", "content": "wire the fixtures %d" % i}})
+        recs.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": "2026-09-10T00:%02d:30Z" % i,
+                     "message": {"role": "assistant", "content": [{"type": "text", "text": "done %d" % i}], "stop_reason": "end_turn"}})
+        parent = a
+    p.write_text("".join(json.dumps(r) + "\n" for r in recs))
+    return str(p)
+
+
+class OneParseForBoth(unittest.TestCase):
+    def setUp(self):
+        jd.parse_cache_clear()
+        km._PERF_STATS.reset()
+        self.d = tempfile.mkdtemp()
+        self.now = int(time.time())
+
+    def _misses(self):
+        return jd.parse_misses()
+
+    def test_kernel_then_judges_share_one_cold_parse_and_one_object(self):
+        p = _transcript(self.d, A)
+        m0 = self._misses()
+        s1 = km._parse(p, A, self.now)
+        s2 = jd.parsed_session(A, [p], self.now)
+        self.assertIs(s1, s2, "the judges receive the very tree the kernel rendered")
+        self.assertEqual(self._misses() - m0, 1, "one cold parse for the pair")
+        snap = km._PERF_STATS.snapshot()["parses"]
+        self.assertEqual(snap["kernel"], 1, "the kernel's ask was the cold one")
+        self.assertGreaterEqual(snap["sharedHits"], 1, "the judges' ask was served from the store")
+
+    def test_judges_then_kernel_share_too(self):
+        p = _transcript(self.d, B)
+        m0 = self._misses()
+        s1 = jd.parsed_session(B, [p], self.now)
+        s2 = km._parse(p, B, self.now)
+        self.assertIs(s1, s2)
+        self.assertEqual(self._misses() - m0, 1)
+        snap = km._PERF_STATS.snapshot()["parses"]
+        self.assertEqual((snap["kernel"], snap["hits"]), (0, 1), "the kernel's ask was a hit on the judges' parse")
+
+    def test_an_appended_record_is_one_new_cold_parse_for_both(self):
+        p = _transcript(self.d, A)
+        km._parse(p, A, self.now); jd.parsed_session(A, [p], self.now)
+        m0 = self._misses()
+        with open(p, "a") as f:
+            f.write(json.dumps({"type": "user", "uuid": "u9", "parentUuid": "a1", "timestamp": "2026-09-10T01:00:00Z",
+                                "promptSource": "typed", "message": {"role": "user", "content": "one more"}}) + "\n")
+        s1 = jd.parsed_session(A, [p], self.now); s2 = km._parse(p, A, self.now)
+        self.assertIs(s1, s2)
+        self.assertEqual(self._misses() - m0, 1, "the grown file costs one parse, shared")
+
+    def test_different_pending_cuts_get_separate_slots(self):
+        """The manager's rule: when the kernel and the judges would read different cuts, each gets its own entry
+        rather than one reading the other's view."""
+        p = _transcript(self.d, A, n=3)
+        saved = jd._PENDING_CUT_FN
+        try:
+            jd.set_pending_cut_provider(lambda fsid: "")
+            plain = jd.parsed_session(A, [p], self.now)
+            jd.set_pending_cut_provider(lambda fsid: "a1")          # a bare rollback armed: the world cut at a1
+            cut = jd.parsed_session(A, [p], self.now)
+            self.assertIsNot(plain, cut)
+            self.assertIn((A, ""), jd._PARSE_CACHE); self.assertIn((A, "a1"), jd._PARSE_CACHE)
+            m0 = self._misses()
+            jd.set_pending_cut_provider(lambda fsid: "")
+            self.assertIs(jd.parsed_session(A, [p], self.now), plain, "the un-cut slot is still there, not evicted by the cut one")
+            self.assertEqual(self._misses() - m0, 0)
+            self.assertIs(jd._PARSE_CACHE[A][1], plain, "a bare id reads the newest slot")
+        finally:
+            jd.set_pending_cut_provider(saved)
+
+    def test_sdk_human_comes_from_the_owner_hook_and_is_part_of_the_match(self):
+        p = _transcript(self.d, B)
+        saved = jd._SDK_OWNER_FN
+        try:
+            jd.set_sdk_owner_provider(lambda fsid: False)
+            s_no = jd.parsed_session(B, [p], self.now)
+            self.assertFalse(jd._PARSE_CACHE[B][3])
+            jd.set_sdk_owner_provider(lambda fsid: True)
+            m0 = self._misses()
+            s_yes = jd.parsed_session(B, [p], self.now)
+            self.assertEqual(self._misses() - m0, 1, "a flipped owner answer is a different parse, never a stale hit")
+            self.assertIsNot(s_no, s_yes)
+            self.assertTrue(jd._sdk_owned(B))
+            jd.set_sdk_owner_provider(lambda fsid: (_ for _ in ()).throw(RuntimeError("boom")))
+            self.assertFalse(jd._sdk_owned(B), "a failing hook falls back to the registry file (absent here)")
+        finally:
+            jd._SDK_OWNER_FN = saved
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("jd.set_sdk_owner_provider(", src, "the kernel installs the backends' owns() as the one answer")
+
+    def test_the_kernel_view_reads_the_store(self):
+        p = _transcript(self.d, A)
+        self.assertNotIn(p, km._parse_cache)
+        self.assertIsNone(km._parse_cached(p), "cache-only read: nothing yet, and no parse ran")
+        s = km._parse(p, A, self.now)
+        self.assertIn(p, km._parse_cache)
+        self.assertIs(km._parse_cache.get(p)[1], s)
+        self.assertIs(km._parse_cache[p][1], s)
+        self.assertIs(km._parse_cached(p), s, "the live-key read answers from the store")
+        self.assertIn(p, list(km._parse_cache))
+        self.assertEqual(len(km._parse_cache), 1)
+        km._parse_cache.pop(p, None)
+        self.assertNotIn(p, km._parse_cache, "a dead lane's drop empties every cut's slot")
+        km._parse(p, A, self.now)
+        km._parse_cache.clear()
+        self.assertEqual(len(jd._PARSE_CACHE), 0)
+
+    def test_least_recently_used_eviction_never_clears_wholesale(self):
+        saved = jd._PARSE_CACHE_MAX
+        jd._PARSE_CACHE_MAX = 3
+        try:
+            paths = [_transcript(self.d, "3333333%d-2222-4333-8444-00000000030%d" % (i, i)) for i in range(4)]
+            sids = [os.path.splitext(os.path.basename(p))[0] for p in paths]
+            for p, sid in zip(paths[:3], sids[:3]):
+                jd.parsed_session(sid, [p], self.now)
+            jd.parsed_session(sids[0], [paths[0]], self.now)        # touch the oldest: it becomes newest
+            jd.parsed_session(sids[3], [paths[3]], self.now)        # a fourth: evicts ONE, the least recently used (sids[1])
+            self.assertEqual(len(jd._PARSE_CACHE), 3)
+            self.assertIn(sids[0], jd._PARSE_CACHE); self.assertNotIn(sids[1], jd._PARSE_CACHE)
+            self.assertIn(sids[2], jd._PARSE_CACHE); self.assertIn(sids[3], jd._PARSE_CACHE)
+        finally:
+            jd._PARSE_CACHE_MAX = saved
+
+    def test_parse_cached_never_parses_and_matches_the_live_key(self):
+        p = _transcript(self.d, B)
+        m0 = self._misses()
+        self.assertIsNone(jd.parse_cached(B, [p]))
+        self.assertEqual(self._misses() - m0, 0)
+        s = jd.parsed_session(B, [p], self.now)
+        self.assertIs(jd.parse_cached(B, [p]), s)
+        with open(p, "a") as f:
+            f.write(json.dumps({"type": "user", "uuid": "u7", "parentUuid": "a1", "timestamp": "2026-09-10T02:00:00Z",
+                                "promptSource": "typed", "message": {"role": "user", "content": "grown"}}) + "\n")
+        self.assertIsNone(jd.parse_cached(B, [p]), "a moved file is not the cached version")
+        self.assertEqual(self._misses() - m0, 1, "and the cache-only read still parsed nothing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -2,8 +2,9 @@
 """T323 stage 2 (the user 2026-09-10; built 2026-09-11): ONE parse for the kernel and the judges. The judges' cache is
 the shared store: the kernel's _parse delegates to jd.parsed_session, so a transcript is parsed once per file version
 and its tree is held once, whichever side asked first. The store keys on every fact either side keyed on (the fileset
-stat pair over the candidates and the states file, the pending cut, sdk_human), keeps a slot per pending cut so two
-callers reading different cuts never share one wrong tree, evicts least recently used instead of clearing wholesale,
+stat pair over the candidates and the states file, the pending cut, sdk_human), keeps a slot per pending cut and per
+leaf transcript so a spent cut's tree goes and an override render of another file under the same sid never evicts
+the live leaf's tree, evicts least recently used instead of clearing wholesale,
 and answers the kernel's path-keyed readers through a view. Hermetic: synthetic transcripts under a temp root."""
 import json
 import os
@@ -91,7 +92,12 @@ class OneParseForBoth(unittest.TestCase):
         id; the cache-only read and the view's drop go by leaf path and the entry's own sid, never a filename stem."""
         other = "55555555-6666-4777-8888-000000000777"
         p = _transcript(self.d, other, n=3)                  # a leaf named after the CLI session id
+        states = Path(jd.STATE) / "states" / (A + ".jsonl")  # the romp sid's states log: part of the key, so a read that
+        states.parent.mkdir(parents=True, exist_ok=True)     #  derived the states path from the leaf's stem would miss (review find)
+        states.write_text(json.dumps({"t": self.now, "state": "idle"}) + "\n")
+        self.addCleanup(lambda: states.unlink(missing_ok=True))
         km._parse(p, A, self.now)                            # parsed for romp sid A
+        self.assertIn(str(states), [f for f in jd._parse_key_files(A, [p], str(states))[2]], "the states log is in the key")
         self.assertIsNotNone(km._parse_cached(p), "the cache-only read finds the display's tree by leaf path")
         self.assertIs(km._parse_cached(p), jd._PARSE_CACHE[A][1])
         self.assertIn(p, km._parse_cache)
@@ -129,7 +135,7 @@ class OneParseForBoth(unittest.TestCase):
             judge_tree = jd.parsed_session(A, [p], self.now)                      # the judges: registry absent → False
             disp_tree = jd.parsed_session(A, [p], self.now, sdk_human=True)      # the display: its backend owns → True
             self.assertIsNot(judge_tree, disp_tree)
-            self.assertEqual(sorted(jd._PARSE_CACHE[(A, "")].keys()), [False, True], "one tree per answer in the slot")
+            self.assertEqual(sorted(jd._PARSE_CACHE[(A, "", p)].keys()), [False, True], "one tree per answer in the slot")
             m0 = self._misses()
             self.assertIs(jd.parsed_session(A, [p], self.now), judge_tree, "the judges hit their own tree")
             self.assertIs(jd.parsed_session(A, [p], self.now, sdk_human=True), disp_tree, "the display hits its own")
@@ -148,17 +154,46 @@ class OneParseForBoth(unittest.TestCase):
             jd.set_pending_cut_provider(lambda fsid: "a1")          # a bare rollback armed: the world cut at a1
             cut = jd.parsed_session(A, [p], self.now)
             self.assertIsNot(plain, cut)
-            self.assertIn((A, "a1"), jd._PARSE_CACHE)
-            self.assertNotIn((A, ""), jd._PARSE_CACHE, "a slot stored under a new cut drops the fsid's other cut slots: one tree per session (review find)")
+            self.assertIn((A, "a1", p), jd._PARSE_CACHE)
+            self.assertNotIn((A, "", p), jd._PARSE_CACHE, "a slot stored under a new cut drops the fsid's other cut slots: one tree per session (review find)")
             jd.set_pending_cut_provider(lambda fsid: "")        # the cut is spent (the next record landed)
             m0 = self._misses()
             again = jd.parsed_session(A, [p], self.now)
             self.assertEqual(self._misses() - m0, 1, "the spent cut's tree is gone, the plain world is parsed once more")
-            self.assertNotIn((A, "a1"), jd._PARSE_CACHE, "and the spent cut's slot went with it")
+            self.assertNotIn((A, "a1", p), jd._PARSE_CACHE, "and the spent cut's slot went with it")
             self.assertIs(jd._PARSE_CACHE[A][1], again, "a bare id reads the newest slot")
             self.assertEqual(len([k for k in jd._PARSE_CACHE if k[0] == A]), 1)
         finally:
             jd.set_pending_cut_provider(saved)
+
+    def test_an_override_render_keeps_its_own_slot_beside_the_live_leaf(self):
+        """Review find (2026-09-11): build_session(path_override=agent file) parses ANOTHER transcript under the parent
+        romp sid (a subagent viewer open on a running agent, an episode render). With a slot per (sid, cut) the two keys
+        never matched, so each miss stored over the other's tree: two builds per cycle for one session, the chat fold
+        seeing a new object every build, the feed's cache-only read flipping with build order. The leaf is in the slot:
+        both hit, one tree each, no eviction, in either order."""
+        p = _transcript(self.d, A, n=3)                                  # the live leaf
+        os.makedirs(os.path.join(self.d, "subagents"), exist_ok=True)
+        sub = _transcript(os.path.join(self.d, "subagents"), "agent-aaaa", n=2)   # an agent's own transcript
+        cut = jd._pending_cut(A)
+        for order in ((sub, p), (p, sub)):
+            jd.parse_cache_clear()
+            m0 = self._misses()
+            first = km._parse(order[0], A, self.now)
+            second = km._parse(order[1], A, self.now)
+            self.assertEqual(self._misses() - m0, 2, "two transcripts, two cold parses")
+            self.assertIs(km._parse(order[0], A, self.now), first, "the first still hits after the second parsed")
+            self.assertIs(km._parse(order[1], A, self.now), second)
+            self.assertEqual(self._misses() - m0, 2, "and neither evicted the other")
+            self.assertIn((A, cut, p), jd._PARSE_CACHE)
+            self.assertIn((A, cut, sub), jd._PARSE_CACHE)
+            leaf_tree = first if order[0] == p else second
+            self.assertIs(km._parse_cached(p), leaf_tree, "the feed's cache-only read sees the live leaf's tree while the agent's is held")
+            self.assertIs(jd.parsed_session(A, [p], self.now), leaf_tree, "a judge pass reads the live leaf's tree")
+            self.assertEqual(self._misses() - m0, 2)
+        self.assertEqual(len([k for k in jd._PARSE_CACHE if k[0] == A]), 2, "one slot per transcript under the sid")
+        self.assertEqual(km._parse_cache.pop(sub)[1], second if order[1] == sub else first)
+        self.assertIn(p, km._parse_cache, "dropping the agent's slot leaves the leaf's")
 
     def test_sdk_human_comes_from_the_owner_hook_and_is_part_of_the_match(self):
         p = _transcript(self.d, B)

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -97,7 +97,13 @@ class OneParseForBoth(unittest.TestCase):
         states.write_text(json.dumps({"t": self.now, "state": "idle"}) + "\n")
         self.addCleanup(lambda: states.unlink(missing_ok=True))
         km._parse(p, A, self.now)                            # parsed for romp sid A
-        self.assertIn(str(states), [f for f in jd._parse_key_files(A, [p], str(states))[2]], "the states log is in the key")
+        st = states.stat()
+        stored = jd._PARSE_CACHE[A][0]                       # the STORED key: (fileset pair, cut)
+        self.assertIn([st.st_mtime, st.st_size], stored[0], "the stored key carries states/<A>.jsonl's stat")
+        stem_states = Path(jd.STATE) / "states" / (other + ".jsonl")   # a states path derived from the leaf's stem
+        self.assertFalse(stem_states.exists())
+        self.assertNotEqual(jd._fileset_key(jd._parse_key_files(A, [p], str(stem_states))[2]), stored[0],
+                            "a key built over the stem-derived states path would not match the stored one")
         self.assertIsNotNone(km._parse_cached(p), "the cache-only read finds the display's tree by leaf path")
         self.assertIs(km._parse_cached(p), jd._PARSE_CACHE[A][1])
         self.assertIn(p, km._parse_cache)
@@ -214,6 +220,63 @@ class OneParseForBoth(unittest.TestCase):
             jd._SDK_OWNER_FN = saved
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("jd.set_sdk_owner_provider(", src, "the kernel installs the backends' owns() as the one answer")
+
+    def test_a_clear_releases_the_previous_leafs_tree(self):
+        """Review find (2026-09-11): with the leaf in the slot, a /clear (the SDK registry's lastSid flips to a new
+        fsid, discover hands out <lastSid>.jsonl) left the pre-clear leaf's full tree resident until restart: no cut
+        changed, the LRU is 256 deep, nothing popped it. discover drops the previous leaf's slots when it first hands
+        out the new one, so exactly one slot remains per session; twice, for two clears."""
+        import re
+        C = "33333333-2222-4333-8444-000000000303"
+        L1, L2 = "44444444-2222-4333-8444-000000000441", "44444444-2222-4333-8444-000000000442"
+        saved = (jd.STATE, jd.NAMES, jd.PROJECTS, os.environ.get("CLAUDE_CONFIG_DIR"))
+        td = Path(tempfile.mkdtemp())
+        try:
+            jd._rebind_state(td / "state")
+            cfg = td / "claude"; os.environ["CLAUDE_CONFIG_DIR"] = str(cfg)
+            cdir = td / "launchdir"; cdir.mkdir()
+            proj_dir = cfg / "projects" / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+            proj_dir.mkdir(parents=True)
+            names = td / "names"; names.mkdir()
+            (names / C).write_text("worker\t%s\t#abcdef\n" % cdir)
+            jd.NAMES, jd.PROJECTS = names, cfg / "projects"
+            jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+            reg = jd.SDKDIR / (C + ".json")
+            anchor_path = _transcript(str(proj_dir), C, n=2)
+            reg.write_text(json.dumps({"sid": C, "name": "worker", "cwd": str(cdir)}))
+            now = time.time()
+
+            def current_leaf():
+                rows = [r for r in jd.discover(now) if r[0] == C]
+                self.assertEqual(len(rows), 1, rows)
+                return str(rows[0][1])
+
+            def slots():
+                return [k for k in jd._PARSE_CACHE if k[0] == C]
+
+            self.assertEqual(current_leaf(), anchor_path)
+            t0 = km._parse(anchor_path, C, now)
+            jd.parsed_session(C, [anchor_path], now)
+            self.assertEqual(len(slots()), 1)
+            for i, L in enumerate((L1, L2), start=1):
+                time.sleep(0.02)                                   # the registry rewrite must move its mtime
+                leaf = _transcript(str(proj_dir), L, n=1)         # /clear: a fresh-headed transcript under a new fsid
+                reg.write_text(json.dumps({"sid": C, "name": "worker", "cwd": str(cdir), "lastSid": L}))
+                self.assertEqual(current_leaf(), leaf, "clear %d: discover hands out the new leaf" % i)
+                t = km._parse(leaf, C, now)
+                self.assertIsNot(t, t0)
+                jd.parsed_session(C, [leaf], now)                  # the judges read the same slot
+                self.assertEqual(slots(), [(C, jd._pending_cut(C), leaf)],
+                                 "clear %d: exactly one slot remains for the session, the new leaf's" % i)
+                self.assertIsNone(km._parse_cached(anchor_path if i == 1 else prev_leaf), "the previous leaf's tree is gone")
+                prev_leaf, t0 = leaf, t
+        finally:
+            jd.NAMES, jd.PROJECTS = saved[1], saved[2]
+            if saved[3] is None:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            else:
+                os.environ["CLAUDE_CONFIG_DIR"] = saved[3]
+            jd._rebind_state(saved[0])
 
     def test_the_kernel_view_reads_the_store(self):
         p = _transcript(self.d, A)

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -95,7 +95,7 @@ class OneParseForBoth(unittest.TestCase):
             jd.set_pending_cut_provider(lambda fsid: "a1")          # a bare rollback armed: the world cut at a1
             cut = jd.parsed_session(A, [p], self.now)
             self.assertIsNot(plain, cut)
-            self.assertIn((A, ""), jd._PARSE_CACHE); self.assertIn((A, "a1"), jd._PARSE_CACHE)
+            self.assertIn((A, ""), jd._PARSE_CACHE); self.assertIn((A, "a1"), jd._PARSE_CACHE)   # a slot per cut, a tree per flag inside
             m0 = self._misses()
             jd.set_pending_cut_provider(lambda fsid: "")
             self.assertIs(jd.parsed_session(A, [p], self.now), plain, "the un-cut slot is still there, not evicted by the cut one")

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -259,9 +259,10 @@ class OneParseForBoth(unittest.TestCase):
             jd.parsed_session(C, [anchor_path], now)
             self.assertEqual(len(slots()), 1)
             for i, L in enumerate((L1, L2), start=1):
-                time.sleep(0.02)                                   # the registry rewrite must move its mtime
                 leaf = _transcript(str(proj_dir), L, n=1)         # /clear: a fresh-headed transcript under a new fsid
                 reg.write_text(json.dumps({"sid": C, "name": "worker", "cwd": str(cdir), "lastSid": L}))
+                os.utime(reg, (now + i, now + i))                  # the registry read memoizes on mtime: move it
+                #                                                    explicitly, never by a sleep (coarse timestamps)
                 self.assertEqual(current_leaf(), leaf, "clear %d: discover hands out the new leaf" % i)
                 t = km._parse(leaf, C, now)
                 self.assertIsNot(t, t0)
@@ -270,6 +271,15 @@ class OneParseForBoth(unittest.TestCase):
                                  "clear %d: exactly one slot remains for the session, the new leaf's" % i)
                 self.assertIsNone(km._parse_cached(anchor_path if i == 1 else prev_leaf), "the previous leaf's tree is gone")
                 prev_leaf, t0 = leaf, t
+            # a pass that snapshotted its rows before the clear parses the retired leaf AFTER the flip: it gets its
+            # tree and the store keeps nothing, since the release was a one-shot and nothing would drop it again
+            m0 = self._misses()
+            late = jd.parsed_session(C, [anchor_path], now)
+            self.assertEqual(self._misses() - m0, 1)
+            self.assertTrue(late["turns"], "the late caller still gets a parse")
+            self.assertEqual(slots(), [(C, jd._pending_cut(C), prev_leaf)], "a store under a retired leaf is refused")
+            self.assertIsNone(km._parse_cached(anchor_path))
+            self.assertTrue(jd._leaf_retired(C, anchor_path)); self.assertFalse(jd._leaf_retired(C, prev_leaf))
         finally:
             jd.NAMES, jd.PROJECTS = saved[1], saved[2]
             if saved[3] is None:
@@ -277,6 +287,26 @@ class OneParseForBoth(unittest.TestCase):
             else:
                 os.environ["CLAUDE_CONFIG_DIR"] = saved[3]
             jd._rebind_state(saved[0])
+
+    def test_a_fork_childs_flip_leaves_the_parents_slot(self):
+        """Review find (2026-09-11): a fork child's SDK registry is born with lastSid = the PARENT's fsid until its
+        own init flips it, so discover hands the child the parent's transcript first; the child's flip to its own
+        file must drop the child's slots of that leaf only, never the parent's live tree."""
+        P, CH = A, "66666666-2222-4333-8444-000000000666"
+        parent_leaf = _transcript(self.d, P, n=2)
+        child_leaf = _transcript(self.d, CH, n=1)
+        jd._note_leaf(P, parent_leaf)
+        jd._note_leaf(CH, parent_leaf)                     # the child's registry still names the parent's file
+        parent_tree = km._parse(parent_leaf, P, self.now)
+        jd.parsed_session(CH, [parent_leaf], self.now)     # a pass parsed the child's row over the parent's file
+        m0 = self._misses()
+        jd._note_leaf(CH, child_leaf)                      # the child's init flipped its lastSid
+        self.assertIs(km._parse(parent_leaf, P, self.now), parent_tree, "the parent's live slot stands")
+        self.assertEqual(self._misses() - m0, 0, "the parent is not re-parsed cold by the child's flip")
+        self.assertEqual([k for k in jd._PARSE_CACHE if k[0] == CH], [], "the child's slot of the parent's file went")
+        self.assertTrue(jd._leaf_retired(CH, parent_leaf)); self.assertFalse(jd._leaf_retired(P, parent_leaf))
+        jd.parsed_session(CH, [child_leaf], self.now)
+        self.assertEqual(len([k for k in jd._PARSE_CACHE if k[0] == CH]), 1, "the child's own leaf stores")
 
     def test_the_kernel_view_reads_the_store(self):
         p = _transcript(self.d, A)

--- a/tools/perf-bench.py
+++ b/tools/perf-bench.py
@@ -1035,7 +1035,7 @@ def _bench(args, state, repo, out, shadow, rec, maps):
     bench = out["benchmarks"] = {}
     profiles = out["profiles"] = {}
     iters = max(1, args.iters)
-    out["cold_caches"] = {"kernel": [n for n in COLD_KERNEL_CACHES + ("_chat_fold",) if isinstance(getattr(km, n, None), dict)],
+    out["cold_caches"] = {"kernel": [n for n in COLD_KERNEL_CACHES + ("_chat_fold",) if callable(getattr(getattr(km, n, None), "clear", None))],
                           "event_model": [n for n, _lock in COLD_EM_CACHES if isinstance(getattr(em, n, None), dict)]}
 
     def now():
@@ -1064,7 +1064,7 @@ def _bench(args, state, repo, out, shadow, rec, maps):
         """The kernel-side caches a freshly started kernel lacks (build_session's inputs above the parse)."""
         for name in COLD_KERNEL_CACHES:
             d = getattr(km, name, None)
-            if isinstance(d, dict):
+            if callable(getattr(d, "clear", None)):   # a dict, or the kernel's view over the shared parse store (T323 stage 2)
                 d.clear()
         if hasattr(km, "_chat_fold"):
             lock = getattr(km, "_chat_fold_lock", None)
@@ -1080,7 +1080,7 @@ def _bench(args, state, repo, out, shadow, rec, maps):
         sample cold)."""
         for name, lock_name in COLD_EM_CACHES:
             d = getattr(em, name, None)
-            if not isinstance(d, dict):
+            if not callable(getattr(d, "clear", None)):
                 continue
             lock = getattr(em, lock_name, None)
             if lock is not None:


### PR DESCRIPTION
Stage 2 of the lazy-transcripts plan (T323, approved by the user 2026-09-10; the research report and stage 1 are on main). Until now the kernel and the judges each kept a cache of parsed session trees (the kernel's keyed by transcript path, the judges' by session), so every live transcript was parsed twice per file version and its tree held twice. This stage makes the judges' cache the one parse store.

**What changes**

- The kernel's display parse (`_parse`) delegates to `jd.parsed_session`: the tree the chat renders is the tree the judges walk. The store keys on every fact either side keyed on before: the transcript's and the states file's stat pair, the pending rollback cut (read through the provider the kernel installs), and the SDK-human flag, which one owner hook installed by the kernel answers for both (the backends' `owns()`, SDK or Codex; the judges used to read the SDK registry file, which missed Codex sessions). The flag is read on a miss only; installing the hook drops the store.
- One slot per (session, pending cut, leaf transcript). A session read under a new pending cut gets a slot of its own and the spent cut's slot is dropped with it, so one tree per session holds through a rollback. The leaf is in the slot because the kernel parses other transcripts under a session's id (a subagent viewer's agent file, an episode render: `build_session` with `path_override`): their keys can never equal the live leaf's, and with a slot per (session, cut) each miss evicted the other's tree every pusher cycle (two tree builds per cycle for one session, the chat fold seeing a new object every build, the feed's cache-only read flipping with build order). An override parse now sits beside the live leaf's tree; pinned in either order. When a `/clear` or a resume fork moves a session to a new transcript, discovery drops the previous leaf's slots the moment it first hands out the new one (the flip is the event; a candidate-based drop would release only the first anchor), so one tree per session holds across clears; a test clears a synthetic SDK session twice through discovery and checks one slot remains each time. The chain, courier and nudge-gate keys look their entry up by the tree they hold, never the session's newest slot. The release drops only that session's slots of the previous leaf (a fork child's registry names the parent's transcript until its own init flips it, and the parent's live tree is not the child's to drop), and a parse stored under a retired leaf after the flip (a pass working from rows snapshotted before a mid-pass `/clear`, an episode render of the pre-clear transcript) is handed to its caller and not stored: the release is a one-shot, so a late store would otherwise live as a long-lived slot. A leaf discovery never handed out (an agent file) is never retired and stores as an override slot.

**Carried to the next stage, not in this change**: in the `/clear` race window (the registry's lastSid rewritten before the new transcript exists on disk) discovery hands out the anchor again, so from the second clear on a build landing in that window re-parses the pre-clear anchor cold once, its tree having been released at the first clear. The cure is discovery not handing out the anchor while lastSid names a file not yet on disk. The entry carries its session id (the path-keyed view never derives one from a filename stem: a /clear's leaf is named after the CLI session) and the assembly mode of the parse that built it (a store hit reports it, so the chat fold folds instead of rebuilding).
- Least-recently-used eviction past 256 entries instead of the wholesale clear both caches had, so a box over 256 sessions does not thrash.
- The kernel's old cache is a path-keyed view over the store, so its readers keep their shape: a dead timeline lane's drop, the perf bench's cold sample, the feed's cache-only read, and the tests that look a session up by path. The judges' pass-frame pinning is unchanged.
- The judges' parse reads the states log under the live state root (it was bound at import), and `/perf`'s `parses` splits the cold parses by who asked: `total` (every miss), `kernel`, `judge`, `hits`, `sharedHits`.

**Complexity, per the user's scaling criterion**

| Cost | Before | After |
|---|---|---|
| Parsed trees held per session | 2 | 1 |
| Cold parses per file version, when both sides read | 2 | 1 |
| Per pusher cycle, per judge pass | cache hits | cache hits (one store) |

**Measured** (`scripts/bench_shared_parse.py`, six synthetic sessions at 1x, 4x and 16x of 150 invented turns; one process per tree loads the event model, judge and kernel against a temporary root, asks the display for every session, reads the CURRENT resident size from /proc, then asks the judges and reads it again; decimal megabytes throughout): the resident size the judges' parse adds after the display had parsed, the second tree's own cost, is 1.2, 4.5 and 18.1 MB at the three sizes on the stage 1 tree and 0.0 MB (45 KB, 4 KB, 0) at every size on this branch. Parses counted at the event model itself, the same on both trees: 12 versus 6 on stage 1 at every size, 6 versus 6 here. Figure: `T323-stage2-bench/trees_vs_size.png` under the research directory, one measurement per point, not a distribution. The resident read has a floor: a second tree that fits in pages the allocator already held adds nothing visible, so a zero means the read saw no new resident pages, not that no tree was built (an earlier run of this bench read 0.0 for stage 1 at 1x while its parse count showed the second tree was built; the count is the check). Said plainly: this is the second tree's share, about a quarter of the record cost the T311 report measured (0.25 GB of 6.6); the record cache itself is the bulk and is the checkpoint stages' target. A no-client boot shows no change from this stage (`boot_cost_vs_size.png`): stage 1 already left only the judges' tree there.

**Live, the T311 recipe on the first kernel booted after stage 1 merged** (sha ad189beb): 5.1 GB resident and 3.0 GB read from files at one minute of uptime; 6.55 GB resident, 8.3 GB read, 192 cold parses (179 the judges', 13 the display's) and 240 chats built for the connected dashboards at five minutes. Stage 1 removed the parses nobody asked for; the connected panes and the judges' first pass still fill the record cache, which is exactly what stages 3 and 4 checkpoint. The judges' whole-history walk becomes a checkpoint-plus-tail walk through this same store: a restored tree is handed to one place, and its key grows the checkpoint's offset and guard.

**Tests**: `tests/test_shared_parse.py` (one cold parse for the display then the judges and the reverse, the same object both ways; a slot per cut and the spent cut dropped; an override render beside the live leaf in either order; the leaf found by path with the states log in the key; the assembly mode on a hit; two answers in one slot in a hookless process; the owner hook; the cache-only read; the view's membership, iteration, drop and clear; least-recently-used eviction; the perf split), plus the existing parse-cache, pass-frame, stage-gate, rewind and memo pins moved to the shared store; the perf bench tool clears the view before a cold sample.

Part of the lazy-transcripts program (T323), stage 2 of 6.

**Live, the twelve-minute mark on the same kernel**: 6.95 GB resident, 19.8 GB read, 224 display parses and 313 judges' parses, 240 chats built. Identical to the T311 baseline (6.9 GB at 12 minutes): stage 1 removed the parses nobody asked for, and the connected dashboards plus the judges' first pass fill the record cache all the same. Stages 3 and 4 are where these numbers move; the table is in the research directory as `T323-live-after-stage1.md`.
