### PR TITLE
A terminal session's pane runs claude through env: an assignment-led exec is a command named ROMP_SID=… to every shell

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -3208,7 +3208,10 @@ fi
 # through the API and this var, never tmux). Mirrors the SDK backend's spawn env (sdk_backend
 # _options); both values are already sanitized above (sid: hex+hyphens, name: [A-Za-z0-9_-]),
 # so the interpolation into the respawn-pane exec line is injection-safe.
-claude_cmd="ROMP_SID=$sid ROMP_SESSION_NAME=\"$display\" $claude_cmd"
+# Through `env`: the pane runs this as `exec <cmd>` (respawn-pane below), and an assignment-led exec is a command
+# named ROMP_SID=… to every shell (zsh, bash and sh all answer "command not found", status 127), so from
+# 2026-08-16 to 2026-09-11 a terminal session's pane died the instant it was spawned (found by the T325 lab).
+claude_cmd="env ROMP_SID=$sid ROMP_SESSION_NAME=\"$display\" $claude_cmd"
 
 # Load the Romp Postal Service MCP server (tool-native messaging) into romp
 # sessions only (scoped via --mcp-config), when installed.

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -1058,12 +1058,15 @@ _stale_server_globals() {
     run "$ROMP_SCRIPT" new -t --detach myproject
     [ "$status" -eq 0 ]
     grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude ' "$MOCK_LOG"
-    ! grep -qE 'respawn-pane .* exec ROMP_SID=' "$MOCK_LOG"
-    # the rule itself, on the shells a tmux server may run the pane with
+    # (`run` and a status check: a bare `!`-inverted command is exempt from errexit and the ERR trap, so it
+    # would assert nothing here)
+    run grep -qE 'respawn-pane .* exec ROMP_SID=' "$MOCK_LOG"
+    [ "$status" -ne 0 ]
+    # the rule itself, on the shells a tmux server may run the pane with (`run -127`: the expected exit code,
+    # so bats files no command-not-found warning for the very status under test)
     for sh in sh bash zsh; do
         command -v "$sh" >/dev/null || continue
-        run "$sh" -c 'exec FOO=1 true'
-        [ "$status" -eq 127 ]
+        run -127 "$sh" -c 'exec FOO=1 true'
         run "$sh" -c 'exec env FOO=1 true'
         [ "$status" -eq 0 ]
     done

--- a/tests/romp.bats
+++ b/tests/romp.bats
@@ -992,7 +992,7 @@ MOCK
     # handed to the pane with respawn-pane (atomic), not typed with send-keys.
     # The romp identity rides the CLI's environment on this backend too (the user 2026-08-16):
     # external tools attribute authors env-first (ROMP_SESSION_NAME) instead of asking tmux.
-    grep -qE 'tmux respawn-pane -k -t myproject exec ROMP_SID=[0-9a-f-]{36} ROMP_SESSION_NAME="myproject" claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=[0-9a-f-]{36} ROMP_SESSION_NAME="myproject" claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
     grep -q 'tmux attach-session -t myproject' "$MOCK_LOG"
 }
 
@@ -1051,6 +1051,24 @@ _stale_server_globals() {
     [ "$status" -ne 0 ]
 }
 
+@test "the pane's exec line runs claude through env: an assignment-led exec is a command named ROMP_SID=… to every shell" {
+    # zsh, bash and sh all answer `exec FOO=1 cmd` with "command not found: FOO=1" (status 127): from 2026-08-16 to
+    # 2026-09-11 a terminal session's pane died the instant it was spawned (a hermetic kernel lab found it)
+    _stub_claude 9.9.9
+    run "$ROMP_SCRIPT" new -t --detach myproject
+    [ "$status" -eq 0 ]
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude ' "$MOCK_LOG"
+    ! grep -qE 'respawn-pane .* exec ROMP_SID=' "$MOCK_LOG"
+    # the rule itself, on the shells a tmux server may run the pane with
+    for sh in sh bash zsh; do
+        command -v "$sh" >/dev/null || continue
+        run "$sh" -c 'exec FOO=1 true'
+        [ "$status" -eq 127 ]
+        run "$sh" -c 'exec env FOO=1 true'
+        [ "$status" -eq 0 ]
+    done
+}
+
 @test "launch hands the exec line to respawn-pane, never typed via send-keys (dropped-char bug)" {
     # Regression: a fresh shell flushes its tty input on startup, so send-keys'd
     # keys are dropped — the launch once started `ec claude …` (the "ex" eaten).
@@ -1058,8 +1076,8 @@ _stale_server_globals() {
     # line must NEVER appear on a send-keys call.
     run run_romp new -t myproject
     [ "$status" -eq 0 ]
-    grep -qE 'tmux respawn-pane -k -t myproject exec ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude' "$MOCK_LOG"
-    ! grep -qE 'send-keys.*exec (ROMP_SID=\S+ ROMP_SESSION_NAME="[^"]*" )?claude' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude' "$MOCK_LOG"
+    ! grep -qE 'send-keys.*exec (env ROMP_SID=\S+ ROMP_SESSION_NAME="[^"]*" )?claude' "$MOCK_LOG"
 }
 
 @test "old tmux without copy-mode-position-style still launches claude (no set -e abort)" {
@@ -1071,7 +1089,7 @@ _stale_server_globals() {
     export MOCK_TMUX_FAIL_OPT="copy-mode-position-style"
     run run_romp new -t --detach myproject
     [ "$status" -eq 0 ]
-    grep -qE 'tmux respawn-pane -k -t myproject exec ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude' "$MOCK_LOG"
 }
 
 @test "append-system-prompt: omitted when no working-style prompt is installed" {
@@ -1090,7 +1108,7 @@ _stale_server_globals() {
     # stays OUT of the exec line, so the launch shell expands it at exec time.
     grep -F -- "--append-system-prompt \"\$(cat $HOME/.claude/romp-session-prompt.md)\"" "$MOCK_LOG"
     # Still the same single exec line, handed to the pane via respawn-pane.
-    grep -qE 'tmux respawn-pane -k -t myproject exec ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude --name "myproject" --session-id [0-9a-f-]{36} --append-system-prompt .*' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude --name "myproject" --session-id [0-9a-f-]{36} --append-system-prompt .*' "$MOCK_LOG"
 }
 
 @test "append-system-prompt: also appended on the resume path" {
@@ -1122,7 +1140,7 @@ _stale_server_globals() {
     run run_romp new -t "my.task:v2"
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s my-task-v2' "$MOCK_LOG"
-    grep -qE 'exec ROMP_SID=\S+ ROMP_SESSION_NAME="my-task-v2" claude --name "my-task-v2"' "$MOCK_LOG"
+    grep -qE 'exec env ROMP_SID=\S+ ROMP_SESSION_NAME="my-task-v2" claude --name "my-task-v2"' "$MOCK_LOG"
 }
 
 @test "session name sanitization: shell metacharacters folded to dashes (no command injection)" {
@@ -1229,14 +1247,14 @@ _stale_server_globals() {
     [ "$status" -eq 0 ]
     [[ "$output" != *"retired"* ]]
     grep -q 'tmux new-session -d -s web' "$MOCK_LOG"
-    grep -qE 'tmux respawn-pane -k -t web exec ROMP_SID=abc123-uuid ROMP_SESSION_NAME="web" claude --resume abc123-uuid --name "web"' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t web exec env ROMP_SID=abc123-uuid ROMP_SESSION_NAME="web" claude --resume abc123-uuid --name "web"' "$MOCK_LOG"
     ! grep -q 'tmux attach-session' "$MOCK_LOG"
 }
 
 @test "resume: explicit session id resumes that conversation" {
     run run_romp resume abc123-uuid
     [ "$status" -eq 0 ]
-    grep -q 'tmux respawn-pane -k -t myproject exec ROMP_SID=abc123-uuid ROMP_SESSION_NAME="myproject" claude --resume abc123-uuid --name "myproject"' "$MOCK_LOG"
+    grep -q 'tmux respawn-pane -k -t myproject exec env ROMP_SID=abc123-uuid ROMP_SESSION_NAME="myproject" claude --resume abc123-uuid --name "myproject"' "$MOCK_LOG"
 }
 
 @test "resume: name collision uniquifies instead of hijacking the session" {
@@ -1247,7 +1265,7 @@ _stale_server_globals() {
     run grep -qE 'tmux attach-session -t myproject$' "$MOCK_LOG"
     [ "$status" -ne 0 ]
     grep -q 'tmux new-session -d -s myproject-2' "$MOCK_LOG"
-    grep -qE 'tmux respawn-pane -k -t myproject-2 exec ROMP_SID=abc123-uuid ROMP_SESSION_NAME="myproject-2" claude --resume abc123-uuid --name "myproject-2"' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject-2 exec env ROMP_SID=abc123-uuid ROMP_SESSION_NAME="myproject-2" claude --resume abc123-uuid --name "myproject-2"' "$MOCK_LOG"
 }
 
 @test "resume: the background picker-check goes through ROMP_POSTAL_BIN, and the stand-in writes nothing" {
@@ -1276,7 +1294,7 @@ _stale_server_globals() {
     run run_romp new -t --detach myproject
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
-    grep -qE 'tmux respawn-pane -k -t myproject exec ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=\S+ ROMP_SESSION_NAME="myproject" claude --name "myproject" --session-id [0-9a-f-]{36}' "$MOCK_LOG"
     # $output is asserted BEFORE the `run grep` below overwrites it with grep's (empty) output.
     [[ "$output" == *"attach with: tmux attach -t myproject"* ]]
     run grep -q 'tmux attach-session' "$MOCK_LOG"
@@ -1287,7 +1305,7 @@ _stale_server_globals() {
     run run_romp --resume sess-xyz --detach
     [ "$status" -eq 0 ]
     grep -q 'tmux new-session -d -s myproject' "$MOCK_LOG"
-    grep -qE 'tmux respawn-pane -k -t myproject exec ROMP_SID=sess-xyz ROMP_SESSION_NAME="myproject" claude --resume sess-xyz --name "myproject"' "$MOCK_LOG"
+    grep -qE 'tmux respawn-pane -k -t myproject exec env ROMP_SID=sess-xyz ROMP_SESSION_NAME="myproject" claude --resume sess-xyz --name "myproject"' "$MOCK_LOG"
     # $output asserted before the `run grep` overwrites it.
     [[ "$output" == *"(detached)"* ]]
     run grep -q 'tmux attach-session' "$MOCK_LOG"

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -517,9 +517,12 @@ class SessionIdentityEnv(unittest.TestCase):
 
     def test_the_terminal_launcher_exports_the_same_identity(self):
         # both backends: the tmux launch line carries ROMP_SID + ROMP_SESSION_NAME into the CLI's
-        # environment (the user 2026-08-16 — external tools attribute env-first, never via tmux)
+        # environment (the user 2026-08-16 — external tools attribute env-first, never via tmux), through
+        # `env` since 2026-09-11: the pane runs the line as `exec <cmd>`, and an assignment-led exec is a
+        # command named ROMP_SID=… to every shell (status 127), which killed every terminal pane at spawn
         launcher = Path(os.path.join(os.path.dirname(HERE), "bin", "romp")).read_text()
-        self.assertIn('claude_cmd="ROMP_SID=$sid ROMP_SESSION_NAME=\\"$display\\" $claude_cmd"', launcher)
+        self.assertIn('claude_cmd="env ROMP_SID=$sid ROMP_SESSION_NAME=\\"$display\\" $claude_cmd"', launcher)
+        self.assertNotIn('claude_cmd="ROMP_SID=$sid', launcher, "the assignment-led form must not come back")
 
     def test_one_env_overlay_only(self):
         # both vars ride _options' single env= overlay (additive over os.environ via


### PR DESCRIPTION
Since 2026-08-16 ("terminal sessions carry the identity env too") `bin/romp` built the pane command as `exec ROMP_SID=<sid> ROMP_SESSION_NAME="<name>" claude …` and handed it to `respawn-pane -k`. An exec led by an assignment is a command named `ROMP_SID=…` to zsh, bash and sh alike (each answers "command not found", status 127), so every `romp new -t` pane died the instant it was spawned: the session existed, its name was on file, and its pane was dead. Latent in production because the tmux backend's offer is off by default; found by a hermetic kernel lab (the T325 work on the tmux socket directory) that created a terminal session through `POST /new` and read the pane's death status.

Fix: the variables ride `env`, which every shell execs; the pane shell's own `$(cat …)` substitution for the system prompt is untouched. The shell suite's pins follow the new line, and one new case pins the rule itself on each shell present (`exec FOO=1 true` is a 127, `exec env FOO=1 true` runs) and that the respawned line is led by `exec env`.

Verified: `tests/romp.bats` (151 tests) green under the cap.

Tier: fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)