### PR TITLE
SDK echo: a send the transcript has overtaken is flagged never-delivered, live and at boot, never re-sent

### DIFF
--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -240,8 +240,17 @@ lose it) from `send()` until the transcript carries the same text. For a message
 into a running turn that record is the `queued_command` attachment the CLI writes
 when it splices the message in at its next tool boundary. On the SDK route no floor
 retires an echo: it retires when its text lands in a record stamped at or after the
-send (a user record or that attachment), or when the CLI dies holding it (`dropped`,
-which the chat shows as never delivered, with restore and dismiss). The chat's own
+send (a user record or that attachment), or it is flagged `dropped` (which the chat
+shows as never delivered, with restore and dismiss) on one of two events: the CLI dies
+holding it, or the transcript OVERTAKES it — a later genuine-human turn lands, in a
+later second, while the send's text has landed nowhere and no queue still owes it
+(the backend's own, or the CLI's queue ledger). The composer's messages travel one
+channel in order, so a later one going through means the CLI skipped this one: lost,
+not waiting (`settle_echoes`, the SDK twin of the tmux settle; before 2026-09-11 a
+CLI that wedged, swallowed a send and carried on left a solid bubble nothing could
+clear). At boot the same evidence turns the re-delivery of an unlanded human send
+into the flag: a message the conversation has moved past is not re-sent behind the
+newer ones. The chat's own
 pending bubble, painted at the press, has no lifetime either: it ends on the same
 events, read from the events after the send (a landing of the text, the kernel's
 never-delivered verdict, or the user's ✕), and a record the CLI wrote from several

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -23909,6 +23909,36 @@ def _pending_queued(path):
     return [m["md"] for m in _pending_queued_meta(path)]
 
 
+def _queue_ledger_step(pending, o):
+    """One transcript record folded onto the CLI queue ledger's pending list — _pending_queued's rules (its
+    docstring): enqueue appends, a content-bearing remove discards exactly that entry, an anonymous remove
+    or a dequeue resolves the oldest, popAll clears. Shared by the display fold (_pending_queued_meta) and
+    the SDK echo settle's owed read (_pending_ledger), so the two read one ledger the same way."""
+    if o.get("type") != "queue-operation":
+        return pending
+    op = o.get("operation")
+    content = o.get("content") if isinstance(o.get("content"), str) else None
+    if op == "enqueue":
+        pending.append((content or "", o.get("timestamp")))
+    elif op == "popAll":                                 # the whole queue recalled — nothing is left owed
+        pending.clear()
+    elif op == "remove" and content is not None and any(c == content for c, _ts in pending):
+        pending.pop(next(i for i, (c, _ts) in enumerate(pending) if c == content))   # that entry only; the rest keep their places
+    elif op in ("dequeue", "remove") and pending:
+        del pending[0]                                   # anonymous resolution: the oldest is the one taken
+    return pending
+
+
+def _pending_ledger(path):
+    """Every text the CLI's queue ledger still lists as pending, UNFILTERED — _pending_queued's fold without
+    its _genuine_queued cut. The "still owed" read the SDK echo settle takes (sdk_backend.settle_echoes,
+    2026-09-11): there a romp-authored echo (a nudge) waiting in the CLI's queue must count as waiting like
+    any other, where the display fold drops it on purpose (it is not the user's queued input). Same cache
+    as the display fold, so the read is free on a quiet transcript."""
+    return [c.strip() for c, _ts in _fold_records(_queued_parse_cache, path, list, _queue_ledger_step)
+            if isinstance(c, str) and c.strip()]
+
+
 def _pending_queued_meta(path):
     """_pending_queued's copies with what the CLI's ledger knows about each (T252c): the enqueue record's
     stamp (`qts`, epoch ms) and NO id. The ledger carries none, the kernel's tmux echo is minted before the
@@ -23916,21 +23946,7 @@ def _pending_queued_meta(path):
     chain could share an id the ledger copy wore, and an id the chat latched from it would make it reject
     the echo and the landing as another send's (the review of the first cut). The chat reads this route
     by text; `qid` is None on every copy."""
-    def step(pending, o):
-        if o.get("type") != "queue-operation":
-            return pending
-        op = o.get("operation")
-        content = o.get("content") if isinstance(o.get("content"), str) else None
-        if op == "enqueue":
-            pending.append((content or "", o.get("timestamp")))
-        elif op == "popAll":                                 # the whole queue recalled — nothing is left owed
-            pending.clear()
-        elif op == "remove" and content is not None and any(c == content for c, _ts in pending):
-            pending.pop(next(i for i, (c, _ts) in enumerate(pending) if c == content))   # that entry only; the rest keep their places
-        elif op in ("dequeue", "remove") and pending:
-            del pending[0]                                   # anonymous resolution: the oldest is the one taken
-        return pending
-    pending = _fold_records(_queued_parse_cache, path, list, step)
+    pending = _fold_records(_queued_parse_cache, path, list, _queue_ledger_step)
     out = []
     for text, ts in pending:
         if not _genuine_queued(text):
@@ -31808,6 +31824,21 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     if withheld:
         tx_uuids = tx_uuids - withheld           # a NEW set: the memoized one is shared with every later build
     be.prune_live(sid, tx_uuids, tx_text_t, human_floor)
+    # An SDK input echo the transcript has OVERTAKEN — a genuine-human turn stamped strictly later than its
+    # send (_echo_overtaken), its text landed nowhere — is a LOSS, and the backend flags it `dropped` so the
+    # chat draws "never delivered" with its ✕ instead of a sent bubble riding above every newer message
+    # (sdk_backend.settle_echoes, 2026-09-11; TmuxBackend.prune_live settles its own echoes the same way).
+    # Guarded on a pure pass over the snapshot, so the CLI's queue ledger is read only when there is
+    # something to rule on. The ledger is handed over here because the two backends keep their queues in
+    # different places: the tmux settle reads the transcript's queue-operation fold AS its queue, while an
+    # SDK session's queue view is the backend's in-memory list and the CLI's ledger is the second place a
+    # fed message can wait (a message fed into a running turn sits there until the splice) — a send still
+    # listed in either is waiting, not lost.
+    settle = getattr(be, "settle_echoes", None)
+    if settle is not None and any(_echo_overtaken(a, human_floor) and not a.get("dropped") and not a.get("_landed")
+                                  for a in live):
+        p = _path_of(sid)
+        settle(sid, human_floor, still_queued=_pending_ledger(p) if p else ())
     hide = tx_texts | {sb.echo_text_key(t) for t in shown_texts if t}    # transcript dups + already-shown queued msgs
     # `live` was snapshotted before the prune, so each of prune_live's three exits has its paint-side twin
     # here: by uuid (tx_uuids), by text (hide), and the recorded landing (`_landed`: the backend's boot/spawn

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -68,6 +68,12 @@ _keys = (sys.modules.get("romp_session_backend")
          or load_source("romp_session_backend_keys", _HERE / "session_backend.py"))
 echo_text_key = _keys.echo_text_key
 command_text_key = _keys.command_text_key
+# The event model's AUTHOR rule (author_of, is_interrupt_record), for the boot scan that asks whether a
+# LATER human turn went through after a send (_input_landed_after, 2026-09-11): a transcript record is read
+# there exactly the way the kernel's parse authors its atom, so "a genuine-human turn" means one thing on
+# both sides of the restart. The kernel's own copy when it is loaded (the _cred idiom); standalone, the file
+# under its own name.
+_em = sys.modules.get("romp_event_model") or load_source("romp_event_model_echo", _HERE / "event_model.py")
 echo_keys = _keys.echo_keys                  # both keys of a text, the "either key" rule written once
 
 
@@ -5378,8 +5384,10 @@ class SdkSession:
         """The texts FED to the current client whose ResultMessage has not landed (`_inflight_texts`,
         oldest first); thread-safe. A mid-turn send lives here from the inputs() pop until the turn
         settles: the CLI holds it, queued behind the running turn, to splice at the next tool boundary.
-        The observable twin of `inflight`, for diagnostics and tests; nothing gates on it (prune_live
-        floors no echo, so there is nothing to shield a fed echo from — its docstring)."""
+        The observable twin of `inflight`, for diagnostics and tests, and since 2026-09-11 one of the
+        settle's "still owed" reads (SdkBackend.settle_echoes): an echo whose text is fed and unsettled is
+        waiting on the CLI, never a loss, however the transcript's floor has moved (prune_live itself still
+        floors no echo — its docstring)."""
         with self._lock:
             return list(self._inflight_texts)
 
@@ -8335,6 +8343,110 @@ def _path_bearing(text: str) -> bool:
     """True when `text` carries an image path the CLI's composer paste hook would extract (_IMG_PATH_RE).
     Read by kernel._tmux_echo_settle through sys.modules — the tmux route's floor; keep the name."""
     return bool(_IMG_PATH_RE.search(text or ""))
+
+
+def _records_from_mark(state_dir, sid: str, off, fsid, literals):
+    """The sid's transcript records from an echo's send-time mark to EOF, parsed, for the boot scans
+    (SdkBackend._text_landed, _input_landed_after): the file is the registry's current transcript (lastSid), the
+    start is the mark when it was measured on that file and fits it (else the file's start), lines are
+    streamed and pre-filtered on the record-type `literals` only — never on a text, which JSON
+    escaping can split — and a line that does not parse (a fragment the mark cut) is skipped. Raises
+    when the transcript cannot be read; each caller turns that into its None. Module functions over the
+    backend's state dir, not methods: the boot marker is bound onto bare stubs in tests, and a helper a stub
+    lacks would read as an unreadable transcript."""
+    reg = read_reg(state_dir, sid) or {}
+    cur = str(reg.get("lastSid") or sid)
+    path = transcript_path(reg.get("cwd") or "", cur)
+    start = 0
+    if (isinstance(off, int) and not isinstance(off, bool) and fsid is not None
+            and str(fsid) == cur and 0 <= off <= os.path.getsize(path)):
+        start = off
+    with open(path, "rb") as f:
+        f.seek(start)
+        for raw in f:
+            if not any(lit in raw for lit in literals):
+                continue
+            try:
+                rec = json.loads(raw.decode(errors="replace"))
+            except ValueError:
+                continue
+            if isinstance(rec, dict):
+                yield rec
+
+def _input_landed_after(state_dir, sid: str, t, off=None, fsid=None):
+    """Did a GENUINE HUMAN input land in the sid's transcript STRICTLY AFTER the send stamped `t`? The
+    boot marker's second question about a send whose text never landed (SdkBackend._mark_dropped_echoes): the
+    composer's messages travel one channel in order, so a later one recorded means the CLI took it
+    while this one was owed — this send is not waiting anywhere, and re-feeding it would run it after
+    the conversation has moved on. Three answers, like _text_landed's: True (found), False (readable,
+    none), None (unreadable — no evidence either way). Reads from the echo's mark, since anything
+    that could outrun the send was written after it; a record without a readable stamp cannot prove
+    "later" and is skipped; the human rule is the parse's (_human_input_record). Both record shapes a
+    message lands as are read: the native user record, and the queued_command ATTACHMENT a message fed
+    into a running turn gets as its only record (the parse authors that absorbed atom the same way and
+    it raises the live floor; a scan of user records alone re-fed a send the most common SDK landing had
+    already outrun — the review of the first cut). 2026-09-11."""
+    try:
+        floor = int(t or 0)
+        for rec in _records_from_mark(state_dir, sid, off, fsid, (b'"user"', b'"queued_command"')):
+            if not _human_input_record(rec):
+                continue
+            ts = _record_epoch(rec.get("timestamp"))
+            if ts is None or ts <= floor:
+                continue
+            return True
+        return False
+    except Exception:
+        return None
+
+
+def _human_input_record(rec: dict) -> bool:
+    """Is this transcript record a GENUINE HUMAN input — a message the person sent through the same channel a
+    composer send travels (stream-json on an SDK session) — as the kernel's parse would author it? Read by
+    _input_landed_after (2026-09-11). Two record shapes carry an input: the native USER record, and the
+    queued_command ATTACHMENT a message fed into a running turn is spliced in as (its only record —
+    event_model._absorbed authors it from the prompt with the attachment's own origin stamp). The verdict is
+    the event model's author_of with sdk_human on (an unmarked "sdk" prompt is the composer's), after the
+    same pre-reads the parse applies to a user record, in its order (event_model.atoms): a slash-command
+    WRAPPER is the human's command atom BEFORE any isMeta skip (some CLI versions mark it isMeta); the
+    command's own stdout is an assistant atom, the other wrappers and a Skill's instructions payload are
+    harness noise; an isMeta record (a skill payload, a postal delivery) and a compaction summary are
+    skipped; a tool_result line and the CLI's interrupt record (a STOP event, which _human_turn_floor
+    excludes too) are not messages the CLI took; a whitespace-only content yields no atom at all. Everything
+    the CLI or romp injects on its own — a task notification, a scheduled trigger, a teammate's message, a
+    nudge, relayed mail — reads as not-human here, exactly as it does in the chat. Mirrored rather than
+    shared: the parse's reading is inline in its record walk, so this stays in step with it the way
+    _landed_texts stays in step with the kernel's _atom_user_texts."""
+    typ = rec.get("type")
+    if typ == "attachment":
+        att = rec.get("attachment") or {}
+        if att.get("type") != "queued_command":
+            return False
+        c = att.get("prompt")
+    elif typ == "user":
+        c = (rec.get("message") or {}).get("content")
+    else:
+        return False
+    if isinstance(c, str):
+        blocks = [{"type": "text", "text": c}] if c.strip() else []
+    elif isinstance(c, list):
+        blocks = [b for b in c if isinstance(b, dict)]
+    else:
+        return False
+    if not blocks or any(b.get("type") == "tool_result" for b in blocks):
+        return False
+    text = _em._text_of(blocks)
+    if typ == "user":
+        if _em.COMMAND_NAME_RE.match(text) or (_em.CMD_WRAP_RE.match(text) and _em.COMMAND_NAME_ANY_RE.search(text)):
+            return True                                    # the slash command the person typed, however marked
+        if _em.CMD_WRAP_RE.match(text) or _em.SKILL_CONTENT_RE.match(text) or rec.get("sourceToolUseID"):
+            return False                                   # its stdout, the other wrappers, a skill's payload
+        if rec.get("isMeta") or rec.get("isCompactSummary") or _em.is_interrupt_record(rec):
+            return False
+    if not text.strip():
+        return False
+    return _em.author_of(blocks, rec.get("promptSource") if typ == "user" else None, {}, True,
+                         _em._record_origin(rec)) == "human"
 
 
 def _landed_texts(rec: dict) -> set:
@@ -11301,6 +11413,12 @@ class SdkBackend:
         is not flagged in the first place (2026-09-06). The flag rides the registry mirror
         (_persist_echoes), so it survives further restarts.
 
+        A HUMAN send the transcript has OUTRUN — its text never landed, and a later genuine-human input
+        did (_input_landed_after) — takes the flag path even under refeed (2026-09-11): the composer's
+        messages travel one channel in order, so a later one recorded means the CLI took it while this
+        one was owed; the send is lost, not waiting, and a re-feed would run it after the conversation
+        moved on. The same event settles a live echo at every build (settle_echoes).
+
         `refeed=False` (2026-08-26, honoring _reconcile_stranded's documented policy): the RESUMABLE-
         reconnect caller takes the flag path ONLY — the abandoned client may still be flushing the record
         the redeliver arm's _text_landed scan looks for, so a miss there is not proof of loss, and a
@@ -11349,7 +11467,7 @@ class SdkBackend:
         # romp-authored echoes (nudges) keep the flag path: re-delivering one could double-nudge,
         # and its content is regenerable machinery, not the user's words. A refeed=False caller
         # (the resumable reconnect — docstring above) keeps EVERY echo on the flag path.
-        redeliver, landed = [], set()
+        redeliver, landed, outrun = [], set(), set()
         if refeed:
             for a in sorted(newly, key=lambda x: x.get("t") or 0):
                 if a.get("author") != "human":
@@ -11357,7 +11475,18 @@ class SdkBackend:
                 seen = self._text_landed(sid, a["_echo_text"], a.get("t"),
                                          a.get("_echo_off"), a.get("_echo_fsid"))
                 if seen is False:
-                    redeliver.append(a)
+                    # A send the transcript has OUTRUN is flagged, not re-fed (2026-09-11): a later human
+                    # message landed after it, and the composer's messages travel one channel in order, so
+                    # the CLI took that one while still owing this — the send is not waiting anywhere, and
+                    # a re-feed now would run it AFTER the conversation moved on, minutes or days later,
+                    # unasked (the user 2026-09-11, whose CLI wedged for five minutes and swallowed a send;
+                    # they kept working through it, and a restart would have re-sent the swallowed message
+                    # under the newer ones). Live, sdk_backend.settle_echoes rules on the same event at
+                    # every build; here the transcript is read directly, the way the landing is.
+                    if _input_landed_after(self.state_dir, sid, a.get("t"), a.get("_echo_off"), a.get("_echo_fsid")):
+                        outrun.add(a["_echo_text"])
+                    else:
+                        redeliver.append(a)
                 elif seen:
                     a["_landed"] = True                    # the verdict, for prune_live and the next boot
                     landed.add(a["_echo_text"])
@@ -11418,8 +11547,13 @@ class SdkBackend:
                 self.forget_fed(sid, a.get("uuid"))   # its landing will never come (T252c)
             with self._live_lock:
                 self._touch_live(sid)                  # a flag write outside the lock: still a change to the tail
-            self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
-                      "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
+            if a["_echo_text"] in outrun:
+                self._log("%s: a send never reached its conversation (the CLI took a later message while "
+                          "still holding it) — kept in the chat as never-delivered, not re-sent: %.80r"
+                          % (sid[:8], a["_echo_text"]), problem=True)
+            else:
+                self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
+                          "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
         self._persist_echoes(sid)
         self._wake_push()
 
@@ -11458,32 +11592,17 @@ class SdkBackend:
         one) as never landed. A mark taken while the CLI was mid-write leaves a line fragment first; it
         fails to parse and is skipped like any other non-record line."""
         try:
-            reg = read_reg(self.state_dir, sid) or {}
-            cur = str(reg.get("lastSid") or sid)
-            path = transcript_path(reg.get("cwd") or "", cur)
             # the plain key and, for a slash send, its words (echo_keys): the send's own record is the
             # CLI's wrapper, which _landed_texts reads as "/name args" the way the kernel's prune does
             want = set(echo_keys(text))
             floor = int(t or 0)
-            start = 0
-            if (isinstance(off, int) and not isinstance(off, bool) and fsid is not None
-                    and str(fsid) == cur and 0 <= off <= os.path.getsize(path)):
-                start = off
-            with open(path, "rb") as f:
-                f.seek(start)
-                for raw in f:
-                    if b'"user"' not in raw and b'"queued_command"' not in raw:
-                        continue
-                    try:
-                        rec = json.loads(raw.decode(errors="replace"))
-                    except ValueError:
-                        continue
-                    if not isinstance(rec, dict) or not (want & _landed_texts(rec)):
-                        continue
-                    ts = _record_epoch(rec.get("timestamp"))
-                    if floor and ts is not None and ts < floor:
-                        continue                       # an earlier record wearing the same words
-                    return True
+            for rec in _records_from_mark(self.state_dir, sid, off, fsid, (b'"user"', b'"queued_command"')):
+                if not (want & _landed_texts(rec)):
+                    continue
+                ts = _record_epoch(rec.get("timestamp"))
+                if floor and ts is not None and ts < floor:
+                    continue                           # an earlier record wearing the same words
+                return True
             return False
         except Exception:
             return None
@@ -13125,7 +13244,8 @@ class SdkBackend:
         THE RULE: every site that adds, replaces, pops, flags or REWORDS an atom in `_live` calls this,
         once per call that changed something: _stash_live, _forward (its eviction included), unqueue (the
         cancelled copy's echo), edit_queued (the echo's new words), dismiss_echo, prune_live,
-        retire_live_work, and the two flag writes _mark_dropped_echoes makes outside the lock (each takes
+        retire_live_work, settle_echoes (the overtaken flags, one bump per call that flagged), and the two
+        flag writes _mark_dropped_echoes makes outside the lock (each takes
         the lock for its bump). tests/test_live_tail_rev.py pins the set by source, so a new queue or echo
         mutator that touches `_live` fails that census until it bumps. Only a CHANGE bumps: a prune that
         retired nothing, a settle over echoes already marked, a queue miss and every read leave the
@@ -13238,6 +13358,79 @@ class SdkBackend:
             self._note_live_tail_race("prune_live")
         if echo_removed:
             self._persist_echoes(sid)   # keep the restart mirror in step (empty once everything landed)
+
+    def settle_echoes(self, sid: str, human_floor, still_queued=()) -> None:
+        """Mark every OVERTAKEN input echo `dropped` — the SDK twin of the kernel's _tmux_echo_settle, and
+        the LIVE half of the loss rule _mark_dropped_echoes applies at boot (2026-09-11). An echo is
+        overtaken when the transcript holds a genuine-human turn stamped STRICTLY LATER than its send
+        (`human_floor`, the kernel's _human_turn_floor; strictly and in whole seconds, so a send made in
+        the same second as another turn's record keeps its pending treatment) while its own text has
+        landed nowhere: the composer's
+        messages travel one channel in order, so the later one going through means the CLI took it while
+        still owing this one — a send that will never land, however alive the process holding it looked.
+        Until this rule an SDK echo was flagged only when its holder DIED (a spawn, a boot, a reconnect):
+        a CLI that wedged for five minutes, swallowed a send and then carried on (the user 2026-09-11)
+        left the echo painted as an ordinary sent bubble that resurfaced above every newer message, with
+        no way to clear it — dismiss_echo takes DROPPED echoes only, by design.
+
+        MARKING, never pruning: a dropped send's echo is the only visible record of the loss and stays
+        until the user dismisses it (prune_live's contract). Self-correcting like the boot flag: should
+        the text land after all, prune_live retires the echo, flag and all.
+
+        STANDS DOWN for a send still OWED somewhere: the backend's own queue (pending_queued_meta — the
+        copies by identity, so the lost first of two identical sends is not hidden by its queued twin);
+        the CLI's queue ledger (`still_queued`, the transcript's queue-operation fold the kernel hands
+        over, unfiltered so a queued nudge counts as waiting too); and the texts FED to the current client
+        whose turn has not settled (SdkSession.fed_texts): a message fed into a running turn is the CLI's
+        to record at its next boundary, and until the ResultMessage the order the floor stands in for is
+        still being written — the moments between the feed and the CLI's ledger record, and between its
+        dequeue and its user record, where the text is owed by nothing on disk (the review of the first
+        cut). The floor is a per-session clock: an OLDER queued sibling delivering stamps its record after
+        a younger send that is still genuinely waiting, overtaken but not lost — the queues outrank the
+        floor, and once they release the text the next build rules normally. Already-dropped and
+        already-landed echoes are left alone, so a quiet tail costs one pass and no write."""
+        # Whole seconds: an echo is stamped to the second (send: int(time.time())), a record to the
+        # millisecond, so a float compare read a record written in the SAME second as the send — the
+        # previous message's, landing as the user pressed enter twice in one second — as later than it,
+        # and flagged a send the CLI was taking. A later turn is a later second.
+        floor = int(float(human_floor or 0))
+        if not floor:
+            return
+        with self._live_lock:
+            d = self._live.get(sid)
+            if not d:
+                return
+            cands = [a for a in list(d.values())
+                     if a.get("_echo_text") and not a.get("command") and not a.get("dropped")
+                     and not a.get("_landed") and floor > int(float(a.get("t") or 0))]
+        if not cands:
+            return
+        own = self.pending_queued_meta(sid)
+        if own is None:
+            own = self.pending_queued(sid)             # identities untrusted: by text, the side that never flags a waiting send
+        owed = {echo_text_key(m.get("md") if isinstance(m, dict) else m) for m in (still_queued or [])}
+        with self._lock:
+            s = self.sessions.get(sid)
+        if s is not None and hasattr(s, "fed_texts"):
+            owed |= {echo_text_key(t) for t in s.fed_texts() if isinstance(t, str)}   # fed, its turn not yet settled
+        owed.discard("")
+        flagged = []
+        for a in cands:
+            if _echo_queued_in(a, own) or any(k in owed for k in echo_keys(a["_echo_text"])):
+                continue                               # still owed somewhere → waiting, not lost
+            a["dropped"] = True
+            flagged.append(a)
+        if not flagged:
+            return
+        with self._live_lock:
+            self._touch_live(sid)                      # the flag writes above: one change to the tail
+        for a in flagged:
+            self.forget_fed(sid, a.get("uuid"))        # its landing will never come (T252c)
+            self._log("%s: a send never reached its conversation (the CLI took a later message while still "
+                      "holding it) — kept in the chat as never-delivered: %.80r"
+                      % (sid[:8], a["_echo_text"]), problem=True)
+        self._persist_echoes(sid)                      # the flag rides the mirror across a restart
+        self._wake_push()
 
     def retire_live_work(self, sid: str) -> None:
         """Drop the sid's live-tail WORK atoms (stream messages — not input echoes, not command feedback)

--- a/tests/test_live_tail_rev.py
+++ b/tests/test_live_tail_rev.py
@@ -188,7 +188,7 @@ class SdkLiveTailRevision(unittest.TestCase):
         flag-writing lines in _mark_dropped_echoes are each followed by one, and _stash_live and _forward are
         the only sites that stash into _live, so a new mutator fails here until it is classified."""
         for name in ("_stash_live", "_forward", "unqueue", "edit_queued", "dismiss_echo", "prune_live",
-                     "retire_live_work", "_mark_dropped_echoes"):
+                     "retire_live_work", "_mark_dropped_echoes", "settle_echoes"):
             src = inspect.getsource(getattr(sb.SdkBackend, name))
             self.assertIn("self._touch_live(", src, "%s changes the tail without advancing its revision" % name)
         mde = inspect.getsource(sb.SdkBackend._mark_dropped_echoes)

--- a/tests/test_queued_copy_identity.py
+++ b/tests/test_queued_copy_identity.py
@@ -53,6 +53,18 @@ def iso(t):
     return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
+def at_clock(now):
+    """The shift that puts RUNNING just BEFORE the clock and a splice or landing written at T0+85 half a
+    minute after it: a message is fed INTO a turn already running, so the turn's records (through T0+50)
+    precede the feed made during the test, and the record that lands the fed text follows it by a margin a
+    slow machine cannot eat (the CLI's enqueue stamp is never earlier than the feed; a landing stamped before
+    the echo would leave it unpaired). Until 2026-09-11 these tests wrote the turn AT the clock (shift
+    now-T0), which stamped its opener 39 s after the feed — a shape no session produces, and one the SDK
+    echo settle (sdk_backend.settle_echoes) rightly reads as the feed having been overtaken by a later human
+    turn."""
+    return (now - T0) - 52
+
+
 class _World:
     """A real SdkBackend bound as the kernel's backend, owning SID, with a thread-less SdkSession, plus the
     discovery a build_session needs (names/ + projects/<cdir>/<SID>.jsonl under a hermetic state root)."""
@@ -114,8 +126,9 @@ class _World:
 
     def write(self, recs, shift=None):
         # discovery keys on the real clock: shift the fixture to "just now"; a landing that must pair with a
-        # feed made during the test is written AT the clock (shift=now-T0), since the CLI's enqueue stamp is
-        # never earlier than the feed that handed it the text
+        # feed made during the test is written just after the clock and the running turn just before it
+        # (shift=at_clock(now)), since the CLI's enqueue stamp is never earlier than the feed that handed it
+        # the text, and the turn the text is fed into was running before the feed
         shift = (self.now - 600) - T0 if shift is None else shift
         out = []
         for r in recs:
@@ -253,7 +266,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
         km._pending_ops.pop(SID, None)
 
     def test_the_queued_group_and_the_landed_atom_share_the_copys_id(self):
-        live = self.w.now - T0            # this test's records sit at the clock: the landing follows the feed in time
+        live = at_clock(self.w.now)       # the turn precedes the feed, the landing follows it (at_clock)
         self.w.write(RUNNING, shift=live)
         fed_text = "and also update the docstring"
         self.assertTrue(self.w.be.send(SID, fed_text))
@@ -267,7 +280,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
         # the CLI takes the first copy at the boundary: the feed pops it, the splice record lands it
         with self.w.s._lock:
             self.w.s._pop_for_feed_locked()
-        recs = RUNNING + [attline(T0 + 55, fed_text, "att1", "tr1"), aline(T0 + 75, "Updated.", "a3", "att1", tools=("Bash",), stop="tool_use")]
+        recs = RUNNING + [attline(T0 + 85, fed_text, "att1", "tr1"), aline(T0 + 105, "Updated.", "a3", "att1", tools=("Bash",), stop="tool_use")]
         self.w.write(recs, shift=live)
         m = self.w.build()
         landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == fed_text]
@@ -278,7 +291,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
         self.assertEqual([t.get("qid") for t in q[0]["texts"]], [qid_later], "the queue now holds the other copy only")
 
     def test_an_intermediate_build_between_the_feed_and_the_landing_keeps_the_pairing(self):
-        live = self.w.now - T0
+        live = at_clock(self.w.now)
         self.w.write(RUNNING, shift=live)
         fed_text = "and also update the docstring"
         self.w.be.send(SID, fed_text)
@@ -288,7 +301,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
         mid = self.w.build()                    # the echo is the visible copy now: a build here must not pair it
         echoes = [e for e in mid["events"] if e.get("kind") == "user" and str(e.get("uuid", "")).startswith("echo:")]
         self.assertEqual([e.get("qid") for e in echoes], [None] * len(echoes), "an echo event carries no landing id (its uuid IS the copy's id)")
-        self.w.write(RUNNING + [attline(T0 + 55, fed_text, "att1", "tr1"), aline(T0 + 75, "Updated.", "a3", "att1", tools=("Bash",), stop="tool_use")], shift=live)
+        self.w.write(RUNNING + [attline(T0 + 85, fed_text, "att1", "tr1"), aline(T0 + 105, "Updated.", "a3", "att1", tools=("Bash",), stop="tool_use")], shift=live)
         m = self.w.build()
         landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == fed_text and not str(e.get("uuid", "")).startswith("echo:")]
         self.assertEqual([e.get("qid") for e in landed], [qid])
@@ -299,7 +312,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
         # as "/deploy staging now" with one space. The chat's own pending bubble retires by id once it has
         # latched the copy's, so the landed event must carry it although the texts differ in whitespace;
         # and the kernel's echo, the other visible copy, retires on the same record (2026-09-10).
-        live = self.w.now - T0
+        live = at_clock(self.w.now)
         self.w.write(RUNNING, shift=live)
         typed = "/deploy \n\nstaging now"
         self.assertTrue(self.w.be.send(SID, typed))
@@ -308,10 +321,10 @@ class TheChatCarriesTheIds(unittest.TestCase):
             self.w.s._pop_for_feed_locked()
         wrap = ("<command-message>deploy</command-message>\n<command-name>/deploy</command-name>\n"
                 "<command-args>staging now</command-args>\n<skill-format>true</skill-format>")
-        recs = RUNNING + [dict(uline(T0 + 55, wrap, "c1", "tr1"), isMeta=True, promptId="p1"),
-                          dict(uline(T0 + 55, "Base directory for this skill: /tmp/notes-api/.claude/skills/deploy\n\nDeploy the service.",
+        recs = RUNNING + [dict(uline(T0 + 85, wrap, "c1", "tr1"), isMeta=True, promptId="p1"),
+                          dict(uline(T0 + 85, "Base directory for this skill: /tmp/notes-api/.claude/skills/deploy\n\nDeploy the service.",
                                      "c2", "c1"), isMeta=True, promptId="p1"),
-                          aline(T0 + 75, "Deploying staging now.", "a3", "c2")]
+                          aline(T0 + 105, "Deploying staging now.", "a3", "c2")]
         self.w.write(recs, shift=live)
         m = self.w.build()
         landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("md") == "/deploy staging now"
@@ -322,7 +335,7 @@ class TheChatCarriesTheIds(unittest.TestCase):
         self.assertNotIn(SID, self.w.be._live, "…and left the live store")
 
     def test_a_two_block_record_carries_both_copies_ids(self):
-        live = self.w.now - T0
+        live = at_clock(self.w.now)
         self.w.write(RUNNING, shift=live)
         self.w.be.send(SID, "first of two"); self.w.be.send(SID, "second of two")
         [q1, q2] = [m["qid"] for m in self.w.be.pending_queued_meta(SID)]
@@ -510,7 +523,7 @@ class IdentitySurvivesTheKernelsDeath(unittest.TestCase):
 
     def setUp(self):
         self.w = _World()
-        self.w.write(RUNNING, shift=self.w.now - T0)   # at the clock: a landing must follow the feed in time
+        self.w.write(RUNNING, shift=at_clock(self.w.now))   # the turn before the feed, the landing after it (at_clock)
         self._parks = []
 
     def tearDown(self):
@@ -542,7 +555,7 @@ class IdentitySurvivesTheKernelsDeath(unittest.TestCase):
                          "the reseeded echo keeps its uuid, which IS the id")
         with s2._lock:
             s2._pop_for_feed_locked()
-        self.w.write(RUNNING + [uline(T0 + 55, "rename it", "u3", "tr1")], shift=self.w.now - T0)
+        self.w.write(RUNNING + [uline(T0 + 85, "rename it", "u3", "tr1")], shift=at_clock(self.w.now))
         m = self.w.build()
         landed = [e for e in m["events"] if e.get("kind") == "user" and e.get("uuid") == "u3"]
         self.assertEqual([e.get("qid") for e in landed], [qid], "the landing pairs with the same id in the new life")

--- a/tests/test_sdk_echo_overtaken.py
+++ b/tests/test_sdk_echo_overtaken.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""A send the transcript has OUTRUN is a loss, and reads as one (2026-09-11). An SDK input echo used to be
+flagged `dropped` (the chat's "never delivered" bubble with its ✕) only when the process HOLDING the send
+died: a spawn, a boot, a reconnect. A CLI that wedged for five minutes, swallowed a send and then carried on
+left the echo painted as an ordinary sent bubble — solid, stamped with its send time, resurfacing above
+every newer message as they landed — with no way to clear it: dismiss_echo takes dropped echoes only, by
+design, and a kernel restart would have RE-SENT the swallowed message behind the newer ones (the boot
+marker's re-delivery arm). The event that settles it: a GENUINE-HUMAN turn stamped strictly later than the
+send, its own text landed nowhere and owed by no queue. The composer's messages travel one channel in
+order, so the later one going through means the CLI took it while still holding this one.
+
+Three surfaces, each pinned here:
+  1. live — sdk_backend.settle_echoes marks the overtaken echo dropped at the build (the SDK twin of the
+     kernel's _tmux_echo_settle): whole seconds, never pruning, standing down for a text the backend's own
+     queue or the CLI's queue ledger still lists, self-correcting on a landing;
+  2. the kernel's _merge_live_atoms hands the settle the CLI's UNFILTERED ledger (_pending_ledger), and
+     only when an unflagged, unlanded echo is actually overtaken;
+  3. boot — _mark_dropped_echoes flags instead of re-feeding when a later human input landed after the
+     send (_input_landed_after), reading the record the way the parse authors it (_human_input_record).
+SYNTHETIC fixtures only; a private synthetic sid; the notes-api demo domain."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_echo_overtaken", os.path.join(BIN, "romp-kernel"))
+sb = load_source("romp_sdk_backend_overtaken", os.path.join(BIN, "romp_sdk_backend.py"))
+
+SID = "6c6c6c6c-7d7d-4e8e-9f9f-0a0a0a0a0a0a"      # private synthetic sid (goal-store fixtures rule)
+SENT = "now name the full evaluation plan for the notes-api search"
+T = 1_800_000_100                                  # the send (the echo's stamp)
+KEY = "echo:0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _echo_atom(text=SENT, t=T, key=KEY, author="human", **extra):
+    a = {"type": "user", "uuid": key, "session_id": SID, "t": t, "parentUuid": None, "author": author,
+         "_echo_text": text, "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+    a.update(extra)
+    return a
+
+
+class _Queue:
+    """A stand-in SdkSession holding a queue: what settle_echoes asks the live session for."""
+
+    def __init__(self, metas, fed=()):
+        self.metas = list(metas)
+        self.fed = list(fed)
+        self.forgotten = []
+
+    def pending(self):
+        return [m["md"] for m in self.metas]
+
+    def fed_texts(self):
+        return list(self.fed)
+
+    def pending_meta(self):
+        return [dict(m, qts=None, held=False, holder=None) for m in self.metas]
+
+    def forget_fed(self, qid):
+        self.forgotten.append(qid)
+
+
+class _World(unittest.TestCase):
+    """A registry + transcript for one SDK session under a hermetic state root, with the CLI's record shapes."""
+
+    def setUp(self):
+        self.state = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.state, "sdk"))
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.state, "claude")
+        self.cwd = os.path.join(self.state, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        self.tpath = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(self.tpath), exist_ok=True)
+        open(self.tpath, "w").close()
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    # -- the CLI's record shapes (keys real, content invented) --
+    def _user(self, t, text, uuid, parent, **extra):
+        rec = {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "sdk",
+               "userType": "external", "isSidechain": False, "message": {"role": "user", "content": text}}
+        rec.update(extra)
+        return rec
+
+    def _assistant(self, t, uuid, parent, text="Done.", tool=False):
+        content = ([{"type": "tool_use", "id": "tu_" + uuid, "name": "Bash", "input": {"command": "true"}}]
+                   if tool else [{"type": "text", "text": text}])
+        return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+                "message": {"role": "assistant", "content": content, "stop_reason": "tool_use" if tool else "end_turn"}}
+
+    def _tool_result(self, t, uuid, parent, tool_uuid):
+        return {"type": "user", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
+                "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu_" + tool_uuid, "content": "ok"}]}}
+
+    def _att(self, t, prompt, uuid, parent, **extra):
+        # the CLI's shape for a mid-turn splice's record (keys real, content invented): no '"user"' literal
+        # anywhere, and the prompt a plain string or a content-block list
+        rec = {"type": "attachment", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent, "isSidechain": False,
+               "userType": "external", "attachment": {"type": "queued_command", "prompt": prompt, "commandMode": "prompt",
+                                                      "timestamp": int(t) * 1000}}
+        rec["attachment"].update(extra)
+        return rec
+
+    def _qop(self, t, op, content=None):
+        return {"type": "queue-operation", "timestamp": _iso(t), "operation": op, "content": content}
+
+    def _running_turn(self):
+        # the turn the send was fed into: an opener 38 s before the send, a tool call still out
+        return [self._user(T - 38, "tighten the notes-api search", "u1", None),
+                self._assistant(T - 28, "a1", "u1", tool=True)]
+
+    def _write(self, recs):
+        with open(self.tpath, "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + "\n")
+
+    def _size(self):
+        return os.path.getsize(self.tpath)
+
+    def _reg(self, **fields):
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits", "alive": True, "cwd": self.cwd, "lastSid": SID,
+               "queue": [], "echoes": []}
+        reg.update(fields)
+        sb.write_reg(self.state, SID, reg)
+
+    def _backend(self):
+        return sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None)   # __init__ runs the boot reseed
+
+    def _mirror_echo(self, text=SENT, t=T, **mark):
+        e = {"t": t, "text": text, "author": "human", "rompAuto": False, "dropped": False, "uuid": KEY}
+        e.update(mark)
+        return e
+
+    def _queue(self):
+        return (sb.read_reg(self.state, SID) or {}).get("queue") or []
+
+    def _mirror(self):
+        return (sb.read_reg(self.state, SID) or {}).get("echoes") or []
+
+    @staticmethod
+    def _live(be):
+        return list((be._live.get(SID) or {}).values())
+
+
+class LiveSettleFlagsAnOvertakenSend(_World):
+    """Surface 1: settle_echoes at the build, on a running backend with one unlanded echo."""
+
+    def _be(self, atom=None):
+        self._reg()
+        be = self._backend()
+        be._live[SID] = {KEY: atom or _echo_atom()}
+        be._persist_echoes(SID)
+        self.assertFalse(self._mirror()[0].get("dropped"), "the fixture starts as a pending send")
+        return be
+
+    def test_a_later_human_turn_flags_the_echo_and_the_x_can_then_clear_it(self):
+        be = self._be()
+        be.settle_echoes(SID, T + 60)
+        [a] = self._live(be)
+        self.assertTrue(a.get("dropped"), "overtaken by a later human turn, landed nowhere: never delivered")
+        self.assertTrue(self._mirror()[0].get("dropped"), "the verdict rides the mirror across a restart")
+        self.assertEqual(be.dismiss_echo(SID, uuid=KEY), SENT, "a dropped echo is the user's to clear")
+        self.assertEqual(self._live(be), [], "…and it is gone")
+        self.assertEqual(self._mirror(), [])
+
+    def test_a_pending_echo_cannot_be_dismissed_which_is_why_the_flag_matters(self):
+        be = self._be()
+        self.assertIsNone(be.dismiss_echo(SID, uuid=KEY), "dismiss_echo takes DROPPED echoes only, by design")
+        self.assertEqual(len(self._live(be)), 1)
+
+    def test_the_turn_must_fall_in_a_later_second(self):
+        be = self._be()
+        be.settle_echoes(SID, 0)
+        self.assertFalse(self._live(be)[0].get("dropped"), "no floor, no verdict")
+        be.settle_echoes(SID, T)
+        self.assertFalse(self._live(be)[0].get("dropped"), "the same second is not later")
+        be.settle_echoes(SID, T + 0.9)
+        self.assertFalse(self._live(be)[0].get("dropped"),
+                         "a record written in the send's second (the previous message landing as the user pressed "
+                         "enter twice) is not a later turn: the echo is stamped to the second, the record to the ms")
+        be.settle_echoes(SID, T + 1)
+        self.assertTrue(self._live(be)[0].get("dropped"), "the next second is")
+
+    def test_a_text_the_cli_ledger_still_owes_is_waiting_not_lost(self):
+        be = self._be()
+        be.settle_echoes(SID, T + 60, still_queued=[SENT])
+        self.assertFalse(self._live(be)[0].get("dropped"),
+                         "an older queued sibling delivering raises the floor past a send still in the CLI's queue")
+        be.settle_echoes(SID, T + 60, still_queued=[{"md": SENT + "\n", "qid": None}])
+        self.assertFalse(self._live(be)[0].get("dropped"), "ledger copies as dicts, under the shared text key")
+        be.settle_echoes(SID, T + 60, still_queued=[])
+        self.assertTrue(self._live(be)[0].get("dropped"), "once the ledger releases the text, the next build rules")
+
+    def test_a_text_the_backends_own_queue_holds_is_waiting_not_lost(self):
+        be = self._be()
+        be.sessions[SID] = _Queue([{"md": SENT, "qid": KEY}])
+        be.settle_echoes(SID, T + 60)
+        self.assertFalse(self._live(be)[0].get("dropped"), "held in the kernel's queue (an editor open on it): waiting")
+        # the same text queued under ANOTHER copy's id does not hide this copy's loss (T252c's identity reading)
+        be.sessions[SID] = _Queue([{"md": SENT, "qid": "echo:ffffffffffffffffffffffffffffffff"}])
+        be.settle_echoes(SID, T + 60)
+        self.assertTrue(self._live(be)[0].get("dropped"), "the second of two identical sends does not hide the first's loss")
+        self.assertEqual(be.sessions[SID].forgotten, [KEY], "its fed copy leaves the ledger: the landing will never come")
+
+    def test_a_text_fed_into_the_running_turn_is_waiting_until_that_turn_settles(self):
+        be = self._be()
+        q = _Queue([], fed=[SENT])                    # fed to the CLI, its ResultMessage not yet landed
+        be.sessions[SID] = q
+        be.settle_echoes(SID, T + 60)
+        self.assertFalse(self._live(be)[0].get("dropped"),
+                         "between the feed and the CLI's own record nothing on disk owes the text: the fed ledger does")
+        q.fed = []                                    # the turn settled without recording it
+        be.settle_echoes(SID, T + 60)
+        self.assertTrue(self._live(be)[0].get("dropped"))
+
+    def test_the_flag_advances_the_live_revision_once(self):
+        be = self._be()
+        rev = be.live_rev(SID)
+        be.settle_echoes(SID, T + 60)
+        self.assertEqual(be.live_rev(SID), rev + 1, "a flag is a change to the tail: the chat's signature must move")
+
+    def test_untrusted_identities_fall_back_to_the_text(self):
+        be = self._be()
+        q = _Queue([{"md": SENT, "qid": KEY}])
+        q.pending_meta = lambda: None                 # the two lists disagree: identities cannot be trusted
+        be.sessions[SID] = q
+        be.settle_echoes(SID, T + 60)
+        self.assertFalse(self._live(be)[0].get("dropped"), "by text, the side that never flags a waiting send")
+
+    def test_a_landing_still_prunes_a_flagged_echo(self):
+        be = self._be()
+        be.settle_echoes(SID, T + 60)
+        self.assertTrue(self._live(be)[0].get("dropped"))
+        be.prune_live(SID, tx_uuids=set(), tx_user_texts={sb.echo_text_key(SENT): T + 5}, human_floor=T + 60)
+        self.assertNotIn(SID, be._live, "self-correcting: a text that lands after all retires the echo, flag and all")
+        self.assertEqual(self._mirror(), [])
+
+    def test_marking_is_never_pruning(self):
+        be = self._be()
+        be.settle_echoes(SID, T + 60)
+        for _ in range(3):
+            be.prune_live(SID, tx_uuids=set(), tx_user_texts={}, human_floor=T + 600)
+        self.assertEqual(len(self._live(be)), 1, "a dropped send's echo stays until the user dismisses it")
+
+    def test_a_settled_or_landed_echo_is_left_alone(self):
+        be = self._be()
+        be.settle_echoes(SID, T + 60)
+        rev = be.live_rev(SID)
+        writes = []
+        be._persist_echoes = lambda sid: writes.append(sid)
+        be.settle_echoes(SID, T + 120)
+        self.assertEqual((be.live_rev(SID), writes), (rev, []), "a mark already made is no change: no revision, no reg write")
+        be2 = self._be(_echo_atom(_landed=True))
+        be2.settle_echoes(SID, T + 60)
+        self.assertFalse(self._live(be2)[0].get("dropped"), "a recorded landing is never a loss (prune_live retires it)")
+
+    def test_a_romp_authored_echo_is_flagged_too(self):
+        be = self._be(_echo_atom(text="<!-- romp-injected --> where does this stand?", author="romp", rompAuto=True))
+        be.settle_echoes(SID, T + 60)
+        self.assertTrue(self._live(be)[0].get("dropped"), "a lost nudge is a loss as well; nothing is re-sent here")
+
+    def test_the_loss_is_reported_as_a_problem_once(self):
+        be = self._be()
+        lines = []
+        be._log = lambda m, problem=None, **k: lines.append((m, problem))
+        be.settle_echoes(SID, T + 60)
+        be.settle_echoes(SID, T + 61)
+        self.assertEqual(len(lines), 1, lines)
+        self.assertTrue(lines[0][1], "a lost send reaches the error center")
+        self.assertIn("never reached its conversation", lines[0][0])
+        self.assertNotIn(SENT, lines[0][0][:20], "the sid prefix leads; the text is a capped repr")
+
+
+class TheKernelHandsTheSettleTheLedger(unittest.TestCase):
+    """Surface 2: _merge_live_atoms calls settle_echoes with the floor and the CLI's unfiltered ledger, and
+    only when an unflagged, unlanded echo is overtaken."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.path = os.path.join(self.td, SID + ".jsonl")
+        self._saved = (km.Sessions.__dict__["backend_for"], km.__dict__["_path_of"], dict(km._merge_sets_memo))
+        km._merge_sets_memo.clear()
+        self.calls, self.prunes, self.live = [], [], []
+        test = self
+
+        class Fake:
+            def live_atoms(self, sid):
+                return list(test.live)
+
+            def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
+                test.prunes.append(human_floor)
+
+            def settle_echoes(self, sid, human_floor, still_queued=()):
+                test.calls.append((sid, human_floor, list(still_queued)))
+        self.Fake = Fake
+        km.Sessions.backend_for = staticmethod(lambda sid: Fake())
+        km._path_of = lambda sid, now=None: test.path
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved[0]
+        km._path_of = self._saved[1]
+        km._merge_sets_memo.clear(); km._merge_sets_memo.update(self._saved[2])
+
+    @staticmethod
+    def _user(text, uid, t, author="human"):
+        return {"type": "user", "uuid": uid, "t": t, "author": author,
+                "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+    @staticmethod
+    def _assistant(uid, t):
+        return {"type": "assistant", "uuid": uid, "t": t, "message": {"role": "assistant", "content": [{"type": "text", "text": "Done."}]}}
+
+    def _session(self, newest_human_t):
+        return {"turns": [
+            {"id": "t1", "trigger": "u1", "t": T - 38, "end": T - 20, "ended": True,
+             "atoms": [self._user("tighten the notes-api search", "u1", T - 38), self._assistant("a1", T - 20)]},
+            {"id": "t2", "trigger": "u2", "t": newest_human_t, "end": newest_human_t + 9, "ended": True,
+             "atoms": [self._user("the newer message", "u2", newest_human_t), self._assistant("a2", newest_human_t + 9)]}]}
+
+    def _ledger(self, ops):
+        with open(self.path, "w") as f:
+            for op, content in ops:
+                f.write(json.dumps({"type": "queue-operation", "timestamp": _iso(T + 5), "operation": op, "content": content}) + "\n")
+
+    def test_an_overtaken_echo_brings_one_settle_call_with_the_unfiltered_ledger(self):
+        mail = "<!-- romp-msg-id: m1 -->hello from web"          # a delivery the display fold drops as not the user's
+        self._ledger([("enqueue", "still waiting"), ("enqueue", mail), ("enqueue", "taken"), ("remove", "taken")])
+        self.live = [_echo_atom()]
+        km._merge_live_atoms(self._session(T + 60), SID)
+        self.assertEqual(self.prunes, [T + 60], "the prune runs first, with the same floor")
+        self.assertEqual(self.calls, [(SID, T + 60, ["still waiting", mail])])
+        self.assertEqual(km._pending_queued(self.path), ["still waiting"], "the display fold keeps only the user's queued input")
+        self.assertEqual(km._pending_ledger(self.path), ["still waiting", mail], "the settle's owed read keeps every pending text")
+
+    def test_no_settle_without_something_to_rule_on(self):
+        self._ledger([])
+        for label, live, floor_t in [
+                ("nothing overtaken", [_echo_atom()], T - 10),
+                ("the same second", [_echo_atom()], T),
+                ("already dropped", [_echo_atom(dropped=True)], T + 60),
+                ("already landed", [_echo_atom(_landed=True)], T + 60),
+                ("no echo at all", [self._assistant("w1", T + 70)], T + 60)]:
+            self.calls.clear(); self.live = live
+            km._merge_live_atoms(self._session(floor_t), SID)
+            self.assertEqual(self.calls, [], label)
+
+    def test_a_missing_path_settles_with_no_ledger_and_a_backend_without_a_settle_is_left_alone(self):
+        km._path_of = lambda sid, now=None: None
+        self.live = [_echo_atom()]
+        km._merge_live_atoms(self._session(T + 60), SID)
+        self.assertEqual(self.calls, [(SID, T + 60, [])], "no transcript path: nothing owed by a ledger")
+        Tmuxish = type("Tmuxish", (), {"live_atoms": self.Fake.live_atoms, "prune_live": self.Fake.prune_live})
+        km.Sessions.backend_for = staticmethod(lambda sid: Tmuxish())
+        self.calls.clear()
+        km._merge_live_atoms(self._session(T + 60), SID)        # the tmux backend settles inside its own prune_live
+        self.assertEqual(self.calls, [])
+
+
+class BootFlagsAnOutrunSendInsteadOfRefeeding(_World):
+    """Surface 3: the boot reseed's marker. A human send whose text never landed used to be RE-FED at boot
+    (restarts never lose typed input); when a later human input has landed after it, the send is not waiting
+    anywhere and a re-feed would run it after the conversation moved on — it is flagged instead."""
+
+    def _after_the_send(self, later):
+        """The transcript: the running turn, the send's mark taken, no record of the send ever, then `later`."""
+        self._write(self._running_turn())
+        off = self._size()
+        with open(self.tpath, "a") as f:
+            for r in later:
+                f.write(json.dumps(r) + "\n")
+        return off
+
+    def _closing(self, t0=T + 12):
+        # the running turn closes without the send: its tool result, then the reply
+        return [self._tool_result(t0, "tr1", "a1", "a1"), self._assistant(t0 + 8, "a2", "tr1", "Tightened.")]
+
+    def test_a_later_human_turn_means_flag_not_refeed(self):
+        off = self._after_the_send(self._closing() + [self._user(T + 357, "the newer message", "u2", "a2"),
+                                                       self._assistant(T + 380, "a3", "u2", "On it.")])
+        self._reg(echoes=[self._mirror_echo(off=off, fsid=SID)])
+        be = self._backend()
+        self.assertEqual(self._queue(), [], "never re-fed: the CLI took a later message while holding this one")
+        [a] = self._live(be)
+        self.assertTrue(a.get("dropped"), "flagged, so the chat says never delivered and offers the ✕")
+        self.assertTrue(self._mirror()[0].get("dropped"))
+        self.assertEqual(be.dismiss_echo(SID, uuid=KEY), SENT)
+
+    def test_a_later_message_spliced_in_as_an_attachment_counts_too(self):
+        # the most common SDK landing: the later message was fed into a running turn and the CLI spliced it in at
+        # a tool boundary — an attachment stamped with its enqueue time, no user record for it ever
+        later = [self._qop(T + 300, "enqueue", None), self._tool_result(T + 312, "tr1", "a1", "a1"),
+                 self._qop(T + 312, "remove"), self._att(T + 300, "the newer message", "att1", "tr1"),
+                 self._assistant(T + 330, "a2", "att1", "On it.")]
+        off = self._after_the_send(later)
+        self._reg(echoes=[self._mirror_echo(off=off, fsid=SID)])
+        be = self._backend()
+        self.assertEqual(self._queue(), [], "the spliced message outran the send exactly as a native record would")
+        self.assertTrue(self._live(be)[0].get("dropped"))
+
+    def test_only_non_human_records_after_the_send_keep_the_refeed(self):
+        later = self._closing() + [
+            self._att(T + 38, "<!-- romp-injected --><!-- romp-auto -->Where does this stand?", "att8", "a2"),
+            self._att(T + 39, "<task-notification>done</task-notification>", "att9", "att8", commandMode="task-notification"),
+            self._user(T + 40, "<task-notification>done</task-notification>", "n1", "a2"),
+            self._user(T + 41, "<!-- romp-injected --><!-- romp-auto -->Where does this stand?", "n2", "n1"),
+            self._user(T + 42, "[SYSTEM NOTIFICATION - NOT USER INPUT] a hook fired", "n3", "n2"),
+            self._user(T + 43, "a skill's markdown payload", "n4", "n3", isMeta=True),
+            self._user(T + 44, "<!-- romp-msg-id: m9 -->mail from another session", "n5", "n4", isMeta=True),
+            self._user(T + 45, "background task finished", "n6", "n5", origin={"kind": "task-notification"}),
+            self._user(T + 46, "[Request interrupted by user]", "n7", "n6"),
+            self._tool_result(T + 47, "tr9", "n7", "a1")]
+        off = self._after_the_send(later)
+        self._reg(echoes=[self._mirror_echo(off=off, fsid=SID)])
+        be = self._backend()
+        self.assertEqual(self._queue(), [SENT], "nothing the person sent went through: the send is re-fed, as before")
+        self.assertFalse(self._live(be)[0].get("dropped"), "a re-queued send renders as queued, never as lost")
+
+    def test_a_human_record_in_the_sends_second_or_before_it_keeps_the_refeed(self):
+        off = self._after_the_send(self._closing(t0=T - 5) + [self._user(T, "the same-second message", "u2", "a2")])
+        self._reg(echoes=[self._mirror_echo(off=off, fsid=SID)])
+        self._backend()
+        self.assertEqual(self._queue(), [SENT], "not strictly later: this is not evidence the send was skipped")
+
+    def test_the_scan_starts_at_the_mark_and_a_missing_transcript_answers_none(self):
+        # a human record BEFORE the mark, however stamped, is not read: everything that could outrun the send was written after it
+        self._write(self._running_turn() + [self._user(T + 300, "an oddly stamped earlier line", "u0", "a1")])
+        off = self._size()
+        self._reg()
+        self.assertIs(sb._input_landed_after(self.state, SID, T, off, SID), False)
+        self.assertIs(sb._input_landed_after(self.state, SID, T, None, None), True, "no mark: the whole file is read")
+        self.assertIs(sb._input_landed_after(self.state, SID, T, off, "some-other-file"), True, "a mark from another file reads from the start")
+        os.remove(self.tpath)
+        self.assertIsNone(sb._input_landed_after(self.state, SID, T, None, None), "unreadable: no evidence either way")
+
+    def test_the_human_input_rule_is_the_parses(self):
+        def rec(content, **extra):
+            r = {"type": "user", "message": {"role": "user", "content": content}}
+            r.update(extra)
+            return r
+        human = sb._human_input_record
+        self.assertTrue(human(rec("plain words", promptSource="sdk")), "an unmarked sdk prompt is the composer's")
+        self.assertTrue(human(rec("plain words", promptSource="typed")))
+        self.assertTrue(human(rec("plain words")), "no promptSource: presumed human, as the parse does")
+        self.assertTrue(human(rec([{"type": "text", "text": "in a block"}], promptSource="sdk")))
+        self.assertTrue(human(rec("/model opus", promptSource="sdk")), "a typed slash command travelled the same channel")
+        wrap = "<command-name>/deploy</command-name>\n<command-message>deploy</command-message>\n<command-args>staging</command-args>"
+        self.assertTrue(human(rec(wrap, promptSource="sdk")), "the CLI's wrapper for a typed slash command is the human's command atom")
+        self.assertTrue(human(rec(wrap, promptSource="sdk", isMeta=True)), "…before any isMeta skip, as the parse reads it")
+        att = {"type": "attachment", "attachment": {"type": "queued_command", "prompt": "spliced words"}}
+        self.assertTrue(human(att), "a mid-turn splice's attachment is the message's only record")
+        self.assertTrue(human({"type": "attachment", "attachment": {"type": "queued_command",
+                                                                     "prompt": [{"type": "text", "text": "in a block"}]}}))
+        for label, r in [
+                ("tool_result", rec([{"type": "tool_result", "tool_use_id": "tu1", "content": "ok"}], promptSource="sdk")),
+                ("tool_result with text", rec([{"type": "tool_result", "tool_use_id": "tu1", "content": "ok"},
+                                               {"type": "text", "text": "and a note"}], promptSource="sdk")),
+                ("command stdout", rec("<local-command-stdout>ok</local-command-stdout>")),
+                ("command caveat", rec("<local-command-caveat>Caveat: …</local-command-caveat>", promptSource="sdk")),
+                ("skill payload", rec("Base directory for this skill: /tmp/notes-api/.claude/skills/deploy\n# Deploy", promptSource="sdk")),
+                ("skill payload by link", rec("# Deploy", promptSource="sdk", sourceToolUseID="tu_skill")),
+                ("injected attachment", {"type": "attachment", "attachment": {"type": "queued_command",
+                                                                                 "prompt": "<!-- romp-injected -->Where does this stand?"}}),
+                ("task attachment", {"type": "attachment", "attachment": {"type": "queued_command", "prompt": "done",
+                                                                             "commandMode": "task-notification"}}),
+                ("stamped attachment", {"type": "attachment", "attachment": {"type": "queued_command", "prompt": "hi",
+                                                                                "origin": {"kind": "peer"}}}),
+                ("other attachment", {"type": "attachment", "attachment": {"type": "image", "prompt": "x"}}),
+                ("empty attachment", {"type": "attachment", "attachment": {"type": "queued_command", "prompt": "  "}}),
+                ("isMeta", rec("a skill payload", isMeta=True)),
+                ("compact summary", rec("summary", isCompactSummary=True)),
+                ("interrupt", rec("[Request interrupted by user for tool use]")),
+                ("system wrapper", rec("<system-reminder>note</system-reminder>", promptSource="sdk")),
+                ("romp-injected", rec("<!-- romp-injected -->Where does this stand?", promptSource="sdk")),
+                ("postal", rec("<!-- romp-msg-id: m1 -->hi", promptSource="sdk")),
+                ("origin stamped", rec("done", promptSource="sdk", origin={"kind": "task-notification"})),
+                ("peer origin", rec("hi", promptSource="sdk", origin={"kind": "peer"})),
+                ("teammate", rec("Another Claude session sent a message: hi", promptSource="sdk")),
+                ("empty", rec("   ")),
+                ("no content", {"type": "user", "message": {}}),
+                ("not a user record", {"type": "assistant", "message": {"content": "x"}})]:
+            self.assertFalse(human(r), label)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was wrong

A composer send on an SDK session is painted as an optimistic **input echo** until the transcript records the text. The echo is flagged `dropped` (the chat's "never delivered" bubble, with its ✕) only when the process holding the send **died**: a spawn, a boot, a resumable reconnect. A CLI that stayed alive but swallowed a send had no such event. Seen 2026-09-10: a CLI's control channel timed out for about five minutes and the message sent at the start of that window was never recorded; the user kept working through it. The echo stayed a solid, sent-looking bubble stamped with its send time, resurfaced above every newer message as they landed, and could not be cleared, since `dismiss_echo` takes dropped echoes only, by design. Worse, a kernel restart would have **re-sent** the swallowed text: the boot marker's re-delivery arm re-queues an unlanded human send, under the messages the user had typed since.

## The fix

The loss has an exact event. The composer's messages travel one channel in order, so a **later genuine-human turn recorded** while the send's text has landed nowhere and no queue still owes it means the CLI took the later message while still holding this one: the send is lost, not waiting. That is the rule the kernel already applies to tmux echoes (`_tmux_echo_settle`); the SDK route now has its twin.

- `sdk_backend.settle_echoes(sid, human_floor, still_queued)`: marks an unlanded, unflagged echo `dropped` when the transcript's newest genuine-human turn falls in a strictly later **whole second** than the send (the echo is stamped to the second, a record to the millisecond, so a float compare read the previous message landing in the same second as later). It stands down while anything still owes the text: the backend's own queue (by copy identity, so the second of two identical sends does not hide the first's loss), the CLI's queue ledger, or the fed-but-unsettled list (`SdkSession.fed_texts`: a message fed into a running turn is the CLI's to record at its next boundary, and until the turn's result nothing on disk owes it). Marking, never pruning: the echo stays until the user dismisses it, and a text that lands after all still retires it, flag and all.
- `kernel._merge_live_atoms` calls the settle after the prune, only when a live echo is actually overtaken and not yet flagged or landed, handing over the CLI's ledger through the new `_pending_ledger(path)`: the display fold without its "the user's own input" filter, so a queued nudge counts as waiting too. Same cache as the display fold.
- Boot: `_mark_dropped_echoes` asks a second question about a send whose text never landed, `_input_landed_after`: did a genuine-human input land strictly after it? If so the send is flagged, not re-fed. Both landing shapes are read, the native user record and the `queued_command` attachment a message fed mid-turn gets as its only record. The record is read the way the kernel's parse authors it (`_human_input_record` over `event_model.author_of` with the SDK's human reading, after the parse's own pre-reads in its order: the slash wrapper is the human's command even when marked isMeta, the command's stdout and the other wrappers are noise, tool results and the interrupt record are no message). Only-machine records after the send (task notifications, nudges, mail, system wrappers, tool results) keep the re-delivery.
- `_text_landed`'s file-and-offset resolution is now the shared `_records_from_mark`; its behaviour is unchanged (pinned by the existing durability and re-delivery tests).

## Tests

- `tests/test_sdk_echo_overtaken.py` (22): the live settle (flag, then ✕ clears it; a pending echo cannot be dismissed, which is why the flag matters; the whole-second rule; the ledger, own-queue and fed-list guards, including the identity reading and the untrusted-identities fallback; a landing still prunes a flagged echo; marking is never pruning; the flag advances the live revision once, and a settled or landed echo is left alone with no revision and no reg write; a romp-authored echo is flagged too; one problem line to the error center). The kernel hand-off (one settle call with the unfiltered ledger; no call when nothing is overtaken, already dropped, already landed, or no echo; no path means no ledger; a backend without a settle is left alone). The boot rule (flag instead of re-feed after a later human turn, as a native record or as a mid-turn attachment; only-machine records keep the re-feed; a same-second record keeps it; the scan starts at the mark and answers None on an unreadable transcript; the human-input rule case by case against the parse's shapes). `test_live_tail_rev`'s writer census gains the new mutator.
- `tests/test_queued_copy_identity.py`: the fixture wrote the running turn AT the clock, which stamped the turn's opener 39 s after a feed made during the test, a shape no session produces and one the settle rightly reads as overtaken. `at_clock(now)` now places the turn just before the feed and the landing half a minute after it.

An adversarial review pass ran over the first cut; it found the attachment gap in the boot scan, the fed-list window in the live settle, and the parse-mirroring shapes above, each now pinned. Known residual, accepted: two chat builds racing on one session can both flag the same echo (two identical problem lines, two identical registry writes; the flag itself is idempotent).

Fail-before check: the new file reports 3 failures and 12 errors on main.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
