### PR TITLE
The tag overview rows wear the shared status chip ("Awaiting 3 agents", Blocked); the grey "waiting" pill is gone

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -194,17 +194,19 @@ tags stays short.
 **A section at a glance.** Clicking a header also shows the section in the transcript's place: one
 row per session, with its color, a dot for its state (yellow working, red stopped on a prompt or an
 API error only you can clear, amber retrying an API error on its own, teal compacting, green waiting
-on background work, none while it is idle), a **needs you** or **waiting** word, what it is doing
-now in a few words, and how long ago it last did anything. **Needs you** appears when the feed shows
-one of the session's cards under Blocked, or when the session is stopped on a prompt or an API error
-only you can clear; **waiting**, when it is waiting on background work. A session that asked a
-question and went quiet shows the word with no dot: the dot follows the session's own state, the
-word follows the feed. What it is doing now comes from its current task, else from the headline of
+on background work, none while it is idle), a state chip when the state is worth a word, what it is
+doing now in a few words, and how long ago it last did anything. The chip is the one the bar under
+the transcript wears for the session you are reading, with the same words and colours: **Blocked**
+when the feed shows one of the session's cards under Blocked or the session is stopped on a prompt
+(**API error** when it is stopped on one only you can clear), and **Awaiting** with what is awaited
+(**Awaiting 3 agents**, **Awaiting watch**, the peer's name) when it is waiting on background work.
+A session that asked a question and went quiet shows the chip with no dot: the dot follows the
+session's own state, the chip follows the feed. What it is doing now comes from its current task, else from the headline of
 its work so far, else from the last task it had; a session that has published a note of what it is
 working on shows the note as a quieter second line. Hover a row for its last message, shown without
 its formatting; click one to open that session, which also opens its section if the section is
 folded (with several tags, the first folded group of them). The rows update as the sessions work and
-change only when something about a session changes; the **needs you** word follows the feed, one
+change only when something about a session changes; the **Blocked** chip follows the feed, one
 refresh behind it at most. The transcript comes back when you pick a session, press Escape, or click
 that header again while its section is open and holds the tab you are reading.
 

--- a/tests/test_awaiting_box_sync.py
+++ b/tests/test_awaiting_box_sync.py
@@ -65,7 +65,10 @@ class SourcePins(unittest.TestCase):
     def test_the_chip_and_the_gist_agree_in_number_from_one_count(self):
         # since slice 2 (plans/subagent-transcripts.md, 2026-09-05) the ONE rule is awaitWord: the kernel's
         # kind + count + the awaited ROWS word the chip and the gist alike ("agent", "3 agents", "4" for mixed)
-        self.assertIn("const chipWord = awaitWord(s.status.awaitingKind, s.status.awaitingCount, chipItems);", RENDER)
+        # the bar's chip is the SHARED status chip since T322b (ui/webview/status-chip.ts, which the tag overview's rows
+        # build from too): the bar asks the module for the button form, and the module's one awaitWord call words it
+        self.assertIn('const chip = statusChip(chipWords(s.status), "button") as HTMLButtonElement;', RENDER)
+        self.assertIn("const word = awaitWord(st.awaitingKind, st.awaitingCount, items);", open(os.path.join(ROOT, "ui", "webview", "status-chip.ts")).read())
         self.assertIn("const word = awaitWord(s.status.awaitingKind, s.status.awaitingCount, items);", RENDER)   # `s` narrowed by the one renderer's gate (2026-09-06)
 
 

--- a/tests/test_tab_overview_mode_served.py
+++ b/tests/test_tab_overview_mode_served.py
@@ -4,8 +4,13 @@ of a hermetic kernel with four sessions under two tags. Asserted: with a session
 row's tag chip wears no underline; a click on the row shows the overview whose heading reads "Overview of", the tag's
 ordinary chip and the count; while it shows the message box (the whole footer) is gone, no tab renders as selected
 (the active tab's fill is transparent) and the row wears the selected tab's box (the tab's fill token, the identity
-ring); selecting a tab clears it and brings the footer and the tab's fill back. With SNAP_SHOTS=<dir> the driver writes
-screenshots (the grouped strip with one row expanded and a session active, dark and light; the overview shown, dark).
+ring); selecting a tab clears it and brings the footer and the tab's fill back. T322b: a row's state words are the SHARED
+status chip: the ui tag's session is idle awaiting three background agents (a tmux-backed session a fake tmux lists, its
+wait the states overlay row), and its overview row wears `chip chip-awaitingBg` reading "Awaiting 3 agents" in the same
+computed dress (fill, ink, weight,
+spacing, radius, padding, line height, rendered height, the 0.7em rule) the bar under the transcript wore for it a moment earlier; no pill of the row's
+own, the green pip beside it. With SNAP_SHOTS=<dir> the driver writes screenshots (the grouped strip with one row expanded
+and a session active, dark and light; the overview shown, dark; the overview with the awaiting row, dark).
 Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC fixtures only (the notes-api demo world)."""
 import json
 import os
@@ -78,7 +83,15 @@ const measure = () => page.evaluate(() => {
   const activeFill = getComputedStyle(probe).backgroundColor; probe.remove();
   const footer = document.getElementById("footer"); const composer = document.getElementById("composer");
   const host = document.getElementById("tab-snapshot"); const head = host ? host.querySelector(".snap-head") : null;
-  return { body: document.body.className, rows, tabs, activeFill,
+  // a status chip's computed dress, and its parent's font size (the chip is 0.7em of whatever it sits in)
+  const dress = (c) => { const cs = getComputedStyle(c); const pcs = getComputedStyle(c.parentElement);
+    return { tag: c.tagName.toLowerCase(), cls: c.className, text: c.textContent.trim(), bg: cs.backgroundColor, color: cs.color, weight: cs.fontWeight,
+             spacing: cs.letterSpacing, radius: cs.borderRadius, padding: cs.padding, size: cs.fontSize, parentSize: pcs.fontSize,
+             lineHeight: cs.lineHeight, height: Math.round(c.getBoundingClientRect().height * 10) / 10 }; };
+  const barChip = document.querySelector("#statusline .chip");
+  const chips = host ? Array.from(host.querySelectorAll(".snap-row")).map((r) => { const c = r.querySelector(".chip"); const pip = r.querySelector(".snap-pip");
+    return { id: r.dataset.id, pip: pip ? pip.className : null, flag: !!r.querySelector(".snap-flag"), chip: c ? dress(c) : null }; }) : [];
+  return { body: document.body.className, rows, tabs, activeFill, bar: barChip ? dress(barChip) : null, chips,
            footer: footer ? getComputedStyle(footer).display : null, composer: composer ? getComputedStyle(composer).display : null,
            composerVisible: composer ? composer.getBoundingClientRect().height > 0 : null,
            snap: host ? { display: getComputedStyle(host).display, heading: head ? Array.from(head.children).map((c) => ({ cls: c.className, text: c.textContent.trim(), style: c.getAttribute("style") || (c.firstElementChild && c.firstElementChild.getAttribute("style")) || "" })) : null,
@@ -86,8 +99,15 @@ const measure = () => page.evaluate(() => {
            theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
 });
 const out = {};
+// the awaiting session read first: the bar under the transcript wears its Awaiting chip (the dress the row's must match)
+await page.click('#tabs .tab[data-id="' + cfg.tests + '"]');
+await page.hover('#tabs .tab[data-id="' + cfg.docs + '"]');   // a tab pick rebuilds the strip under the pointer, and nothing hides the clicked tab's hover tip (render.ts renderTabs): hover-and-leave another tab dismisses it so the shots stay clean
+await page.mouse.move(700, 600);
+await page.waitForTimeout(700);
+out.barAwaiting = await measure();
 // a session inside the infra row is active (the strip's default pick is the first tab; make it explicit)
 await page.click('#tabs .tab[data-id="' + cfg.web + '"]');
+await page.hover('#tabs .tab[data-id="' + cfg.docs + '"]');
 await page.mouse.move(700, 600);   // off the strip: no tab tooltip in the shots
 await page.waitForTimeout(500);
 out.active = await measure();
@@ -103,6 +123,7 @@ await page.mouse.move(700, 600);
 await page.waitForTimeout(600);
 out.overview = await measure();
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-tab-overview-dark.png", fullPage: false });
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-tab-overview-awaiting-dark.png", clip: { x: 0, y: 0, width: 1100, height: 360 } });   // T322b: the awaiting row's chip
 // the cascade's two exceptions, probed in the mode: a hard-blocked active tab keeps its red fill (the class the tab
 // state paints, added here since a hermetic kernel has no blocked session), and under the Yatharth theme the active
 // tab wears that theme's resting wash with no selection border
@@ -171,20 +192,45 @@ class ServedTabOverviewMode(unittest.TestCase):
         for i, (name, sid) in enumerate(SIDS.items()):
             bg, fg = COLORS[name]
             Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, bg, fg))
-            Path(state, "sdk", sid + ".json").write_text(json.dumps(
-                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
-                 "model": "claude-opus-5", "liveModel": "Opus 5"}))
+            if name != "tests":   # tests is the tmux-backed session below: the fake tmux lists it, the SDK backend never does
+                Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                    {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                     "model": "claude-opus-5", "liveModel": "Opus 5"}))
             recs = [{"type": "user", "timestamp": iso(t0 + i), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": sid,
                      "message": {"role": "user", "content": "what does the %s session do in notes-api?" % name}},
                     {"type": "assistant", "timestamp": iso(t0 + i + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": sid,
                      "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
                                  "content": [{"type": "text", "text": "It keeps the %s side of the notes-api tidy." % name}]}}]
             Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        # the tests session is idle awaiting background work it dispatched. Only a LIVE session can be awaiting (every
+        # source of _session_awaiting is live evidence, and the kernel's audit lifts a durable stamp no live source
+        # backs), and a lab has no running process, so tests is a tmux-backed session a FAKE tmux on the lab kernel's
+        # PATH lists (one idle romp pane, the lane format's fields; every other tmux command answers nothing), and its
+        # wait is the states overlay row the tmux Stop hook writes (source 1), carrying the kind and the count the chips
+        # word. (An SDK registration would not do: the SDK backend heals an awaiting:true row of a not-running session to
+        # false on its next look.) The state root and the fake live in the lab, so the real tmux server is never reached.
+        Path(state, "states", SIDS["tests"] + ".jsonl").write_text(json.dumps(
+            {"t": t0 + 20, "awaiting": True, "why": "waiting on 3 background agents", "kind": "agents", "count": 3}) + "\n")
+        fake_bin = os.path.join(cls.lab, "bin")
+        os.makedirs(fake_bin, exist_ok=True)
+        lane = "1|%s|waiting|%d|Opus 5|high|||%s|auto" % (SIDS["tests"], t0 + 10, COLORS["tests"][0])
+        Path(fake_bin, "tmux").write_text("#!/bin/sh\n"
+            "# the lab's tmux: one romp session (tests), idle; list-sessions answers the format it is asked for, all else is silent\n"
+            "fmt=''; while [ $# -gt 0 ]; do case \"$1\" in -F) fmt=\"$2\"; shift;; esac; shift; done\n"   # loop-ok: a finite argv walk
+            "case \"$fmt\" in\n"
+            "  '') exit 0;;\n"
+            "  *'#{@claude-state}'*) printf '%s\\n' '" + lane + "';;\n"
+            "  *'#{session_name}'*) printf '%s\\t%s\\n' '" + SIDS["tests"] + "' tests;;\n"
+            "  *'#{@romp-session-id}'*) printf '%s\\n' '" + SIDS["tests"] + "';;\n"
+            "esac\n")
+        os.chmod(os.path.join(fake_bin, "tmux"), 0o755)
+        cls.fake_path = fake_bin + os.pathsep + os.environ.get("PATH", "")
         # the tags: two, holding three of the four sessions; the fourth is the untagged trail
         Path(state, "timeline-views.json").write_text(json.dumps({"active": "all", "tags": TAGS}))
         Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         cls.port, cls.token = _free_port(), "testtok-overview"
-        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST",
+                              PATH=cls.fake_path, ROMP_TMUX_AVAILABLE="1")   # the fake tmux above lists the tests session
         cls.klog = os.path.join(cls.lab, "kernel.log")
         cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
         for _ in range(120):
@@ -206,7 +252,7 @@ class ServedTabOverviewMode(unittest.TestCase):
     def test_the_overview_is_a_mode_and_the_rows_are_not_tabs(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "web": SIDS["web"], "docs": SIDS["docs"],
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "web": SIDS["web"], "docs": SIDS["docs"], "tests": SIDS["tests"],
                        "shots": os.environ.get("SNAP_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -263,6 +309,23 @@ class ServedTabOverviewMode(unittest.TestCase):
         web = next(t for t in o["tabs"] if t["id"] == SIDS["web"])
         self.assertTrue(web["active"], "the active tab keeps its class (the way back), only its dress is neutralised: %r" % web)
         self.assertEqual(web["bg"], "rgba(0, 0, 0, 0)", "…transparent like a resting tab: %r" % web)
+        # T322b: the row's state words are the SHARED status chip: the same class, words and computed dress the bar under the
+        # transcript wore for the same session a moment earlier; no pill of the row's own; the green pip stays beside it
+        bar = r["barAwaiting"]["bar"]
+        self.assertIsNotNone(bar, "the bar wears a chip while the awaiting session is read: %r" % r["barAwaiting"])
+        self.assertEqual((bar["cls"].split()[:2], bar["text"]), (["chip", "chip-awaitingBg"], "Awaiting 3 agents"), "the bar's chip: %r" % bar)
+        trow = next(x for x in o["chips"] if x["id"] == SIDS["tests"])
+        self.assertFalse(trow["flag"], "no pill of the row's own: %r" % trow)
+        self.assertEqual(trow["pip"], "snap-pip waiting", "the green pip stays: %r" % trow)
+        chip = trow["chip"]
+        self.assertIsNotNone(chip, "the row wears the chip: %r" % trow)
+        self.assertEqual((chip["tag"], chip["cls"], chip["text"]), ("span", "chip chip-awaitingBg", "Awaiting 3 agents"),
+                         "the bar's class and words, as a span inside the row's button: %r" % chip)
+        for k in ("bg", "color", "weight", "spacing", "radius", "padding", "lineHeight", "height"):   # height: a span chip beside a button chip
+            self.assertEqual(chip[k], bar[k], "the chip's %s in the row equals the bar's: %r vs %r" % (k, chip, bar))
+        self.assertEqual(chip["bg"], "rgb(84, 178, 4)", "await-green, the status token: %r" % chip)
+        ratio = lambda d: round(float(d["size"].rstrip("px")) / float(d["parentSize"].rstrip("px")), 2)
+        self.assertEqual((ratio(chip), ratio(bar)), (0.7, 0.7), "the chip's em rule holds in both: %r %r" % (chip, bar))
         # the two exceptions: a blocked active tab keeps the red fill; Yatharth's active tab wears the resting wash, no border
         b = r["blocked"]
         self.assertTrue(b["active"])

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -79,8 +79,11 @@ test("the chip and the box gist take the kind word from ONE count (T225 rider)",
   assert.match(RENDER, /import \{ awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow \} from "\.\/spin-caption";/);   // + the nested-wait helpers (2026-09-10)
   assert.match(RENDER, /awaitingCount\?: number \| null;/, "the Status shape carries the kernel's count");
   assert.match(RENDER, /awaitingItems\?: AwaitRow\[\];/, "…and the rows (slice 2)");
-  assert.match(RENDER, /const chipWord = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, chipItems\);/);
-  assert.match(RENDER, /chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(chipWord \? " " \+ chipWord : ""\);/);
+  // the bar's chip is built by status-chip.ts since T322b: ONE awaitWord call words it for the bar and the tag overview's rows
+  assert.match(RENDER, /const chip = statusChip\(chipWords\(s\.status\), "button"\) as HTMLButtonElement;/);
+  const CHIP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "status-chip.ts"), "utf8");
+  assert.match(CHIP, /const word = awaitWord\(st\.awaitingKind, st\.awaitingCount, items\);/);
+  assert.match(CHIP, /return \{ state, text: head \+ \(word \? " " \+ word : ""\), peer: null \};/);
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/);   // `s` is narrowed by the one renderer's gate since 2026-09-06 (no `s!`)
   assert.match(RENDER, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace/);
   // the feed pill and the spin caption derive their word the same way

--- a/ui/webview/awaiting-peer-name.test.ts
+++ b/ui/webview/awaiting-peer-name.test.ts
@@ -38,15 +38,17 @@ test("the chat pane names the peer: box in identity colour, pill with the colour
   assert.match(box, /el\("span", "bg-await-peer"\)/);
   assert.match(box, /\(pr\.host \? pr\.host \+ ":" : ""\) \+ pr\.name/, "host-prefixed when cross-host");
   assert.match(box, /nm\.style\.color = pr\.color\.bg/);
-  const chipAt = RENDER.indexOf("const chipPeers = s.status.awaitingPeers");
-  const chip = RENDER.slice(chipAt, RENDER.indexOf("chip.title =", chipAt));
+  // the bar's chip is the SHARED status chip since T322b (status-chip.ts): the peer name's treatment lives in its builder
+  const CHIP = ui("webview", "status-chip.ts");
+  const chip = CHIP.slice(CHIP.indexOf("export function statusChip("));
   assert.ok(!chip.includes("chip-peer-dot"), "the dot retired (the user 2026-08-26, round two) — the name wears the colour");
-  assert.match(chip, /el\("span", "chip-peer-name"\)/, "'Awaiting <name>' — the NAME itself in identity colour");
-  assert.match(chip, /nm\.replaceChildren\(\.\.\.hostPartsNodes\(chipPeers\[0\]\.host, chipPeers\[0\]\.name\)\)/,
+  assert.match(chip, /nm\.className = "chip-peer-name";/, "'Awaiting <name>' — the NAME itself in identity colour");
+  assert.match(chip, /nm\.replaceChildren\(\.\.\.hostPartsNodes\(w\.peer\.host, w\.peer\.name, doc\)\)/,
     "the HOUSE idiom via the SHARED renderer (the user 2026-08-26, round three) — host in .host-prefix italic gray, never a restyled copy");
-  assert.match(chip, /nm\.style\.color = chipPeers\[0\]\.color\.bg/);
+  assert.match(chip, /nm\.style\.color = w\.peer\.color\.bg/);
   assert.ok(!/nm\.textContent = .*host/.test(chip), "no one-string concatenation of host and name");
-  assert.match(chip, /chipPeers\.length \+ " peers"/, "several peers keep the one-line rule as a count");
+  assert.match(CHIP, /peers\.length \+ " peers"/, "several peers keep the one-line rule as a count");
+  assert.match(RENDER, /const chip = statusChip\(chipWords\(s\.status\), "button"\) as HTMLButtonElement;/, "the bar builds from it");
   // the backing is ONE rule shared with the transcript's mention chip since 2026-09-10 (the user, who wanted a
   // typed @name to wear this chip's look); the peer name keeps its own #fff default beside it
   assert.match(CSS, /^\.chip-peer-name, \.mention-chip \{ background: rgba\(0, 0, 0, 0\.85\); border-radius: 7px; padding: 0 5px; \}/m,

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -108,7 +108,9 @@ test("the card caption stands down under rows of ANY kind, and still speaks when
 // --- the chat statusline chip -------------------------------------------------------------------------
 test("the Awaiting chip is a BUTTON on the stable statusline delegate, acknowledged, that opens the box", () => {
   const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
-  assert.match(branch, /const chip = el\("button", "chip chip-awaitingBg chip-btn"\) as HTMLButtonElement;/);
+  // the chip itself is the SHARED status chip since T322b (status-chip.ts): the bar asks for the button form and adds its own class
+  assert.match(branch, /const chip = statusChip\(chipWords\(s\.status\), "button"\) as HTMLButtonElement;/);
+  assert.match(branch, /chip\.classList\.add\("chip-btn"\);/);
   assert.match(branch, /chip\.type = "button";/);
   assert.match(branch, /chip\.dataset\.act = "awaitingChip";/, "keyed for the delegate — never a listener on the rebuilt node");
   // the tooltip: the per-kind breakdown, the kernel's why, and what the click does (setTip, one line each)
@@ -124,10 +126,13 @@ test("the Awaiting chip is a BUTTON on the stable statusline delegate, acknowled
 });
 
 test("the chip's label: a single named peer keeps its coloured name; every other wait wears awaitWord", () => {
-  const branch = RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0];
-  assert.match(branch, /if \(chipPeers\.length && groupRows\(chipItems\)\.every\(\(g\) => g\.kind === "peer"\)\) \{/, "the name path only when every row is a peer — a peer beside an agent is a mixed wait");
-  assert.match(branch, /\} else chip\.append\(chipWord \|\| chipPeers\.length \+ " peers"\);/);
-  assert.match(branch, /\} else chip\.textContent = CHIP_LABEL\.awaitingBg \+ \(chipWord \? " " \+ chipWord : ""\);/);
+  // the rule moved to status-chip.ts with T322b (the tag overview's rows wear the same chip); the bar builds from it
+  const CHIP = W("status-chip.ts");
+  assert.match(CHIP, /const word = awaitWord\(st\.awaitingKind, st\.awaitingCount, items\);/);
+  assert.match(CHIP, /if \(peers\.length && groupRows\(items\)\.every\(\(g\) => g\.kind === "peer"\)\) \{/, "the name path only when every row is a peer — a peer beside an agent is a mixed wait");
+  assert.match(CHIP, /return \{ state, text: head \+ " " \+ \(word \|\| peers\.length \+ " peers"\), peer: null \};/);
+  assert.match(CHIP, /return \{ state, text: head \+ \(word \? " " \+ word : ""\), peer: null \};/);
+  assert.match(RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0], /statusChip\(chipWords\(s\.status\), "button"\)/);
 });
 
 // --- the box: rows grouped by kind, per-kind affordances ------------------------------------------------

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -19,10 +19,12 @@ const FED = W("federation.ts");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp-kernel"), "utf8");
 
 test("the chat chip knows awaitingBg: its own await-green chip, label 'Awaiting', with the elapsed timer", () => {
-  assert.match(RENDER, /"awaiting" \| "awaitingBg" \|/);           // the ChipState union carries both meanings
-  assert.match(RENDER, /awaitingBg: "Awaiting",/);                 // CHIP_LABEL
-  // its own statusline branch: await-green chip + the wait's clock — but NO pulse (nothing computing here)
-  assert.match(RENDER, /\} else if \(s\.status\.state === "awaitingBg"\) \{[\s\S]*?chip chip-awaitingBg[\s\S]*?timer\.id = "work-timer";/);
+  assert.match(W("status-chip.ts"), /"awaiting" \| "awaitingBg" \|/);   // the ChipState union carries both meanings (status-chip.ts since T322b, beside its labels)
+  assert.match(W("status-chip.ts"), /awaitingBg: "Awaiting",/);   // CHIP_LABEL (status-chip.ts since T322b: the bar and the tag overview's rows import one map)
+  assert.match(RENDER, /import \{ CHIP_LABEL, chipWords, statusChip, type ChipState \} from "\.\/status-chip";/);
+  // its own statusline branch: the shared await-green chip (`chip chip-` + the state) + the wait's clock — but NO pulse (nothing computing here)
+  assert.match(RENDER, /\} else if \(s\.status\.state === "awaitingBg"\) \{[\s\S]*?statusChip\(chipWords\(s\.status\), "button"\)[\s\S]*?timer\.id = "work-timer";/);
+  assert.match(W("status-chip.ts"), /chip\.className = "chip chip-" \+ w\.state;/);
   assert.doesNotMatch(RENDER.split('state === "awaitingBg") {')[1].split("} else if")[0], /chip-pulse/);
   // the ticking clock covers it, same as working
   assert.match(RENDER, /if \(s\.status\.state === "working" \|\| s\.status\.state === "awaitingBg"\) \{\s*\n\s*const timer = document\.getElementById\("work-timer"\);/);

--- a/ui/webview/chip-label-case.test.ts
+++ b/ui/webview/chip-label-case.test.ts
@@ -1,15 +1,18 @@
 // Status chips read as sentence case, not ALL CAPS (the user 2026-07-03): "Working", "Ready",
 // "Blocked", "Compacting", … — first letter capitalized, the rest lowercase (acronyms like "API"
-// stay). Pins the statusline CHIP_LABEL map + its fallback in render.ts.
+// stay). Pins the CHIP_LABEL map + its fallback, which live in status-chip.ts since T322b (the bar under the
+// transcript and the tag overview's rows import the one map), and that render.ts keeps no map of its own.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-const R = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const W = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const R = W("render.ts");
+const C = W("status-chip.ts");
 
 test("CHIP_LABEL uses sentence case, never ALL-CAPS status words", () => {
-  const m = R.match(/const CHIP_LABEL[\s\S]*?\};/);
+  const m = C.match(/export const CHIP_LABEL[\s\S]*?\};/);
   assert.ok(m, "CHIP_LABEL exists");
   const map = m![0];
   assert.match(map, /working: "Working"/);
@@ -20,8 +23,11 @@ test("CHIP_LABEL uses sentence case, never ALL-CAPS status words", () => {
   assert.match(map, /closed: "Closed"/);
   // no bare ALL-CAPS status word survives (the acronym "API" is allowed)
   assert.doesNotMatch(map, /"WORKING"|"READY"|"BLOCKED"|"COMPACTING"|"IDLE"|"CLOSED"/);
+  assert.doesNotMatch(R, /const CHIP_LABEL/, "one map: render.ts imports it");
+  assert.match(R, /import \{ CHIP_LABEL, chipWords, statusChip, type ChipState \} from "\.\/status-chip";/);
 });
 
 test("the unknown-state fallback is sentence case too (not toUpperCase)", () => {
-  assert.match(R, /s\.status\.state\[0\]\.toUpperCase\(\) \+ s\.status\.state\.slice\(1\)\.toLowerCase\(\)/);
+  assert.match(C, /st\[0\]\.toUpperCase\(\) \+ st\.slice\(1\)\.toLowerCase\(\)/);
+  assert.doesNotMatch(R, /toUpperCase\(\) \+ s\.status\.state\.slice\(1\)/, "the bar's plain states go through the shared builder");
 });

--- a/ui/webview/clear-divider.test.ts
+++ b/ui/webview/clear-divider.test.ts
@@ -55,7 +55,7 @@ test("the pre-clear history lazy-loads once per boundary and renders through the
 test("renderClearing is the loader-dots in-progress element, and the chip family knows 'clearing'", () => {
   // 2026-09-08: a slim live SESSION notice with the loader dots in its glyph slot (the romp severity: accent)
   assert.match(RENDER, /function renderClearing\(\): HTMLElement \{[\s\S]{0,200}?notice\(\{ src: "session", glyph: noticeLiveGlyph\(metaDots\(\)\), sev: "romp", gist: "Clearing conversation…", live: true,/);
-  assert.match(RENDER, /"clearing" \| "blocked"|clearing: "Clearing"/);   // ChipState + CHIP_LABEL entries
+  assert.match(fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "status-chip.ts"), "utf8"), /"clearing" \| "blocked"|clearing: "Clearing"/);   // ChipState + CHIP_LABEL entries (status-chip.ts since T322b)
   assert.match(RENDER, /⟳ Clearing conversation…/);                       // statusline line, like compacting's
   assert.match(TL, /label: 'Clearing'/);                                  // timeline lane badge
 });

--- a/ui/webview/host-prefix.test.ts
+++ b/ui/webview/host-prefix.test.ts
@@ -40,7 +40,7 @@ test("every surface renders the prefix through the shared treatment", () => {
   // bare uuid), rendered through the same .host-prefix treatment (the user 2026-07-26)
   assert.match(FEED, /peer\.replaceChildren\(\.\.\.hostPartsNodes\(it\.origin\.peerHost, it\.origin\.peer\)\)/);
   const HP = read("host-prefix.ts");
-  assert.match(HP, /export function hostPartsNodes\(host: string \| null \| undefined, name: string\): Node\[\]/);
+  assert.match(HP, /export function hostPartsNodes\(host: string \| null \| undefined, name: string,\s*\n\s*doc: Pick<Document, "createElement" \| "createTextNode"> = document\): Node\[\]/, "builds in the document it is handed (T322b: a fake's chip carries a fake's name node); the page's by default");
   // fleet: the prefix stays OUT of the search highlight (metadata never highlights)
   assert.match(FLEET, /function nameInto\(elm: HTMLElement, name: string, sid: string, q: string\)/);
   assert.match(FLEET, /nameInto\(tnm, s\.name, s\.sid, curSearch\)/);

--- a/ui/webview/host-prefix.ts
+++ b/ui/webview/host-prefix.ts
@@ -110,10 +110,11 @@ export function hostDownNote(sid: string | null | undefined): string {
 /** Same rendering when the host rides its OWN field instead of a sid prefix — the feed card's
  *  "↪ from" chip, whose peerSid stays a bare uuid (the sender may live on a third host neither
  *  the viewer nor the card's kernel can address). No host → plain text, identical to a local name. */
-export function hostPartsNodes(host: string | null | undefined, name: string): Node[] {
-  if (!host) return [document.createTextNode(name)];
-  const h = document.createElement("span");
+export function hostPartsNodes(host: string | null | undefined, name: string,
+                               doc: Pick<Document, "createElement" | "createTextNode"> = document): Node[] {   // `doc`: the document to build in (a test's fake through status-chip.ts statusChip); the page's by default
+  if (!host) return [doc.createTextNode(name)];
+  const h = doc.createElement("span");
   h.className = "host-prefix";
   h.textContent = host + ":";
-  return [h, document.createTextNode(name)];
+  return [h, doc.createTextNode(name)];
 }

--- a/ui/webview/interrupt-ux.test.ts
+++ b/ui/webview/interrupt-ux.test.ts
@@ -11,6 +11,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const SRC = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CHIP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "status-chip.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("the stop button acknowledges its click instantly: chip flips, button + timer vanish", () => {
@@ -28,8 +29,8 @@ test("the stop button acknowledges its click instantly: chip flips, button + tim
 });
 
 test("INTERRUPTING is a first-class chip state: labeled, styled, timerless, buttonless", () => {
-  assert.match(SRC, /"interrupting" \| "opening";/, "in the ChipState union (opening joined it 2026-08-05)");
-  assert.match(SRC, /interrupting: "Interrupting…",/);
+  assert.match(CHIP, /"interrupting" \| "opening";/, "in the ChipState union (opening joined it 2026-08-05; the union lives in status-chip.ts since T322b)");
+  assert.match(CHIP, /interrupting: "Interrupting…",/);   // CHIP_LABEL lives in status-chip.ts since T322b
   // the generic chip branch renders it; the stop button is drawn for working/compacting AND the stuck
   // retrying/blocked states — but NEVER for interrupting (the stop is already in flight)
   assert.match(SRC, /state === "working" \|\| s\.status\.state === "compacting"\s*\n\s*\|\| s\.status\.state === "retrying" \|\| s\.status\.state === "blocked"\) right\.appendChild\(stopButton\(s\.status\.state\)\)/);

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -62,7 +62,7 @@ test("the statusline shows Opening + dots for BOTH the pre-payload tab and the k
   // kernel-reported opening rides the same line
   assert.match(RENDER, /s\.status\.state === "opening"/);
   assert.match(RENDER, /"opening"/);
-  assert.ok(RENDER.includes('opening: "Opening…",'), "the chip vocabulary knows the state");
+  assert.ok(fs.readFileSync(path.join(ROOT, "ui", "webview", "status-chip.ts"), "utf8").includes('opening: "Opening…",'), "the chip vocabulary knows the state (CHIP_LABEL lives in status-chip.ts since T322b)");
   // three staggered accent dots — the loader idiom's smallest form, no new fonts
   assert.match(CSS, /\.opening-line-dots span \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);/);
   assert.match(CSS, /@keyframes opening-line-pulse/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -32,6 +32,7 @@ import { backendLabel, effectiveDefaultBackend } from "./backend-names";
 import { delegate } from "./actions";
 import { flash } from "./actions";   // its own line: the import above is pinned verbatim by click-safe.test.ts (the file-view precedent)
 import { awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
+import { CHIP_LABEL, chipWords, statusChip, type ChipState } from "./status-chip";   // the session status chip: its words and its classes, the one builder the bar and the tag overview's rows share (T322b)
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
 import { historyMarks, historyBands, windowSpans, HIST_H, HIST_GAP } from "./glow-history";
@@ -288,7 +289,9 @@ type ChatEvent = (
 
 interface TodoTask { id: string; subject: string; activeForm?: string; status: string }
 
-type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";   // needsInput = a live permission/picker prompt (on YOU) — renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13)
+// ChipState, the kernel's chip states, lives in status-chip.ts since T322b beside its labels (imported above), so the label
+// map is checked exhaustive over it: needsInput = a live permission/picker prompt (on YOU), the legacy "awaiting" accepted
+// for older remote kernels; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13).
 type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
 // which billing sides this box can bill, and why not for the other (kernel _auth_avail, 2026-09-08): the
 // Billing submenu lists both and greys the unavailable one with the reason in its hover
@@ -11453,8 +11456,12 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
   const name = el("span", "snap-sess"); name.replaceChildren(...hostNameNodes(r.name, r.id));
   if (r.color) name.style.color = r.color.bg;
   btn.appendChild(name);
-  if (r.needsYou) { const f = el("span", "snap-flag needs"); f.textContent = "needs you"; btn.appendChild(f); }
-  else if (r.waiting) { const f = el("span", "snap-flag"); f.textContent = "waiting"; btn.appendChild(f); }
+  // the state in words, when the row says one: the SHARED status chip (status-chip.ts), the same words and dress the
+  // bar under the transcript wears for the session you are reading — Blocked (API error when that is the state) on
+  // you, "Awaiting 3 agents" / "Awaiting watch" / the peer's name for background work (T322b, the user 2026-09-10:
+  // a grey outlined pill of the row's own reading "waiting" was not it). The model picks the chip (tab-snapshot.ts
+  // snapshotRow); the pip stays beside it: the strip's colour language says the state, the chip says what.
+  if (r.chip) btn.appendChild(statusChip(r.chip));
   const nowEl = el("span", "snap-now"); nowEl.textContent = r.loading ? "opening…" : r.now; btn.appendChild(nowEl);
   if (r.lastT) {
     const when = el("span", "snap-when"); when.dataset.t = String(r.lastT);
@@ -14117,15 +14124,8 @@ function setCtxBar(bar: HTMLElement, ctxStr: string | undefined, compacting = fa
     : `context ${pct}% used — click to /compact`;
 }
 
-const CHIP_LABEL: Record<ChipState, string> = {
-  working: "Working", ready: "Ready", needsInput: "Blocked",
-  awaiting: "Blocked",   // the legacy name for needsInput — an older remote kernel still sends it
-  awaitingBg: "Awaiting",   // idle, waiting on background work it dispatched — the romp await-green, not working-yellow (the user 2026-07-13; recolored from straw 2026-07-22)
-  idle: "Idle", closed: "Closed", compacting: "Compacting", clearing: "Clearing", blocked: "API error",
-  retrying: "API retrying…",   // a live session stalled on an API rate-limit/overload auto-retry (api 2026-06-23)
-  interrupting: "Interrupting…",   // stop sent, turn not yet settled (the user 2026-07-02) — clears to READY on its own
-  opening: "Opening…",             // spawned, transcript not on disk yet — the first record clears it (the user 2026-08-05)
-};
+// CHIP_LABEL, the state words, lives in status-chip.ts since T322b (the user 2026-09-10): the tag overview's rows wear
+// the same chip as this bar, so the words and the classes have one home the two import (imported above).
 
 // A stop/interrupt button that lives beside the state badge in the statusline (the user 2026-06-19):
 // it sends the SAME interrupt the composer's Ctrl+C does (host → Esc into the pane) — a less fiddly way
@@ -14219,37 +14219,20 @@ function updateStatusline() {
     // #bg-tasks box below and scrolls it into view — the chip used to be the one status word on the
     // pane you could not click through. data-act on the stable #statusline delegate (click-safe across
     // the per-push rebuild); the delegate's .romp-acted pulse acknowledges the press.
-    const chip = el("button", "chip chip-awaitingBg chip-btn") as HTMLButtonElement;
+    // the chip itself is the SHARED status chip (status-chip.ts chipWords + statusChip, T322b): `chip chip-awaitingBg`
+    // wearing "Awaiting <word>" — the KIND rides the label so a glance says WHAT is awaited (the user 2026-08-15;
+    // tooltips are dead on the touch PWA), by ONE rule (awaitWord, agreeing in number, T225): "Awaiting agent" /
+    // "Awaiting command" / "Awaiting watch" for one, "Awaiting 3 agents" for several of a kind, "Awaiting 4" when
+    // the kinds are mixed; a single named peer's NAME in its identity colour on the .chip-peer-name backing (the
+    // user 2026-08-26). The tag overview's rows build theirs from the same two calls, so the two cannot drift. This
+    // bar adds what only it has: the button, the per-kind hook and the tip (the breakdown "2 agents · 1 command ·
+    // 1 watch" rides there).
+    const chip = statusChip(chipWords(s.status), "button") as HTMLButtonElement;
+    chip.classList.add("chip-btn");
     chip.type = "button";
     chip.dataset.act = "awaitingChip";
-    // the KIND rides the label so a glance says WHAT is awaited (the user 2026-08-15) — tooltips are
-    // dead on the touch PWA, so the word must be visible; the subject stays in the #bg-tasks box. ONE
-    // rule words it (awaitWord): "Awaiting agent" / "Awaiting command" / "Awaiting watch" for one,
-    // "Awaiting 3 agents" for several of a kind, "Awaiting 4" when the kinds are mixed — the
-    // breakdown ("2 agents · 1 command · 1 watch") rides the tooltip.
     const chipItems = s.status.awaitingItems || [];
     chip.classList.add("chip-awaiting-" + (s.status.awaitingKind || "untyped"));   // per-kind hook, one hue today
-    const chipPeers = s.status.awaitingPeers || [];
-    const chipWord = awaitWord(s.status.awaitingKind, s.status.awaitingCount, chipItems);
-    if (chipPeers.length && groupRows(chipItems).every((g) => g.kind === "peer")) {
-      // the pill names the actual session (the user 2026-08-26): "Awaiting <name>", the NAME itself
-      // in the peer's identity colour — the dot it launched with retired the same day (round two:
-      // it read stupid). The name sits on an always-on ~85% black backing (.chip-peer-name), mostly
-      // opaque so ANY identity colour reads against any chip hue (their green-on-green example),
-      // translucent enough that the chip's own colour still glows through around it. Several peers
-      // keep the one-line rule as a count, names on the tooltip.
-      chip.append(CHIP_LABEL.awaitingBg + " ");
-      if (chipPeers.length === 1) {
-        const nm = el("span", "chip-peer-name");
-        // the HOUSE session-reference idiom (the user 2026-08-26, round three — one undifferentiated
-        // string read wrong): the shared renderer, so the host prefix wears .host-prefix (italic
-        // gray) and the NAME text takes the identity colour — the card headers' own treatment,
-        // never a restyled copy
-        nm.replaceChildren(...hostPartsNodes(chipPeers[0].host, chipPeers[0].name));
-        if (chipPeers[0].color && chipPeers[0].color.bg) nm.style.color = chipPeers[0].color.bg;
-        chip.appendChild(nm);
-      } else chip.append(chipWord || chipPeers.length + " peers");
-    } else chip.textContent = CHIP_LABEL.awaitingBg + (chipWord ? " " + chipWord : "");   // agrees in number (T225); the plain words of slice 2
     // the tip: the per-kind breakdown when there are rows, the kernel's why, and what the click does
     setTip(chip, [awaitBreakdown(chipItems), s.status.awaitingWhy || "idle, waiting on background work it dispatched",
                   "click to see what it's waiting on"].filter(Boolean).join("\n"));
@@ -14272,9 +14255,7 @@ function updateStatusline() {
   } else if (s.status.state === "opening") {
     sl.appendChild(openingLine());             // spawned, transcript not on disk yet — dots until the first record
   } else {
-    const chip = el("span", `chip chip-${s.status.state}`);
-    chip.textContent = CHIP_LABEL[s.status.state] ?? (s.status.state[0].toUpperCase() + s.status.state.slice(1).toLowerCase());
-    sl.appendChild(chip);
+    sl.appendChild(statusChip(chipWords(s.status)));   // the shared chip (status-chip.ts): `chip chip-<state>`, the state's words in sentence case
   }
 
   // The right-side cluster — dir · branch · mode/model/effort/fast badges · ctx battery — grouped in ONE

--- a/ui/webview/retrying-state.test.ts
+++ b/ui/webview/retrying-state.test.ts
@@ -11,8 +11,8 @@ const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "
 const TL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "romp-timeline-view.js"), "utf8");
 
 test("chat: 'retrying' is a ChipState with an 'API retrying…' label, an amber chip, and a tab ring", () => {
-  assert.match(RENDER, /type ChipState =[^;]*\| "retrying"/);
-  assert.match(RENDER, /retrying: "API retrying…"/);
+  assert.match(fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "status-chip.ts"), "utf8"), /type ChipState =[^;]*\| "retrying"/);   // the union lives in status-chip.ts since T322b
+  assert.match(fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "status-chip.ts"), "utf8"), /retrying: "API retrying…"/);   // CHIP_LABEL lives in status-chip.ts since T322b
   // the state → class rule lives in tab-state.ts since tab groups (2026-09-04); render.ts wears its result
   const S = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "tab-state.ts"), "utf8");
   assert.match(S, /if \(st === "retrying"\) return "tab-retrying";/);

--- a/ui/webview/status-chip.test.ts
+++ b/ui/webview/status-chip.test.ts
@@ -1,0 +1,112 @@
+// THE SESSION STATUS CHIP (status-chip.ts; T322b, the user 2026-09-10): one vocabulary and one dress for every surface
+// that says a session's state in a pill. The user saw the tag overview's rows wearing a grey outlined pill of their own
+// reading "waiting" beside the bar's await-green "Awaiting agents" for the same session. Executed here: the pure words
+// (stateLabel, chipWords) and the builder over a small fake document. Pinned: the two consumers build from this module
+// (the bar under the transcript, render.ts updateStatusline; the overview's rows, fillSnapshotRow), no second label map
+// and no pill of the view's own survive, and the stylesheet dresses the chip once. Synthetic names only (the notes-api
+// world, TESTHOST).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { CHIP_LABEL, stateLabel, chipWords, statusChip } from "./status-chip";
+
+const read = (f: string) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", f), "utf8");
+const RENDER = read("render.ts");
+const CSS = read("styles.css");
+const SNAP = read("tab-snapshot.ts");
+
+class FakeNode {
+  tag: string; className = ""; textContent = ""; children: any[] = []; style: Record<string, string> = {};
+  constructor(tag: string) { this.tag = tag; }
+  append(...cs: any[]): void { for (const c of cs) this.children.push(typeof c === "string" ? { tag: "#text", textContent: c } : c); }
+  appendChild(c: any): any { this.children.push(c); return c; }
+  replaceChildren(...cs: any[]): void { this.children = []; this.append(...cs); }
+  text(): string { return this.children.length ? this.children.map((c) => (c.text ? c.text() : c.textContent)).join("") : this.textContent; }
+}
+const doc = { createElement: (tag: string) => new FakeNode(tag), createTextNode: (t: string) => ({ tag: "#text", textContent: t }) } as unknown as Pick<Document, "createElement" | "createTextNode">;   // the builder's document: the fake stands in for both node makers
+
+test("the label map is exhaustive over the chip states at compile time, and the union lives beside it", () => {
+  const CHIP = read("status-chip.ts");
+  assert.match(CHIP, /^export type ChipState = "working" \| "ready" \| "needsInput" \| "awaiting" \| "awaitingBg" \| "idle" \| "closed" \| "compacting" \| "clearing" \| "blocked" \| "retrying" \| "interrupting" \| "opening";/m);
+  assert.match(CHIP, /\} satisfies Record<ChipState, string>;/, "a state added to the union without a word fails to compile (main's exhaustiveness, kept)");
+  assert.doesNotMatch(RENDER, /^type ChipState =/m, "render.ts imports the union");
+  assert.match(CHIP, /export function hostPartsNodes|hostPartsNodes\(w\.peer\.host, w\.peer\.name, doc\)/, "the peer's name node is built in the same document as the chip");
+});
+
+test("stateLabel: the map's word in sentence case, a state the map lacks in sentence case, nothing for none", () => {
+  assert.deepEqual(["working", "ready", "needsInput", "awaiting", "awaitingBg", "blocked", "retrying", "closed"].map(stateLabel),
+    ["Working", "Ready", "Blocked", "Blocked", "Awaiting", "API error", "API retrying…", "Closed"]);
+  assert.equal(stateLabel("frobnicating"), "Frobnicating", "an unknown state: its own name, first letter up, the rest down");
+  assert.equal(stateLabel("SHOUTING"), "Shouting"); assert.equal(stateLabel(""), ""); assert.equal(stateLabel(null), ""); assert.equal(stateLabel(undefined), "");
+  assert.equal(CHIP_LABEL.awaitingBg, "Awaiting");
+});
+
+test("chipWords: every state but awaitingBg is its label; the Awaiting chip words WHAT is awaited by the one rule, and names a single peer", () => {
+  assert.deepEqual(chipWords({ state: "working" }), { state: "working", text: "Working", peer: null });
+  assert.deepEqual(chipWords({ state: "needsInput" }), { state: "needsInput", text: "Blocked", peer: null });
+  assert.deepEqual(chipWords({ state: "blocked" }), { state: "blocked", text: "API error", peer: null });
+  assert.deepEqual(chipWords({}), { state: "", text: "", peer: null }, "no state: an empty chip, never a throw");
+  assert.deepEqual(chipWords({ state: "awaitingBg" }), { state: "awaitingBg", text: "Awaiting agents", peer: null }, "kindless, countless: the historic default word");
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "agents", awaitingCount: 1 }), { state: "awaitingBg", text: "Awaiting agent", peer: null }, "agrees in number (T225)");
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "agents", awaitingCount: 3 }), { state: "awaitingBg", text: "Awaiting 3 agents", peer: null });
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "task", awaitingCount: 2 }), { state: "awaitingBg", text: "Awaiting 2 commands", peer: null }, "the plain words: a task is a command");
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "job", awaitingCount: 1 }), { state: "awaitingBg", text: "Awaiting watch", peer: null }, "…a job is a watch");
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "mixed", awaitingCount: 4 }), { state: "awaitingBg", text: "Awaiting 4", peer: null }, "mixed kinds: the number alone");
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "mixed" }), { state: "awaitingBg", text: "Awaiting", peer: null }, "mixed with no count: the bare head");
+  // the awaited ROWS decide before the legacy kind + count (slice 2)
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "agents", awaitingCount: 9, awaitingItems: [{ kind: "watches", id: "w1" }] }), { state: "awaitingBg", text: "Awaiting watch", peer: null });
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingItems: [{ kind: "agents", id: "a1" }, { kind: "commands", id: "c1" }] }), { state: "awaitingBg", text: "Awaiting 2", peer: null });
+  // peers: one → the chip names it (the text is the spoken form, host-prefixed when remote); several → the count; a peer beside an agent is a mixed wait
+  const api = { name: "api", host: "TESTHOST", color: { bg: "#d53a3a", fg: "#ffffff" } };
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "peer", awaitingCount: 1, awaitingPeers: [api] }), { state: "awaitingBg", text: "Awaiting TESTHOST:api", peer: api });
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "peer", awaitingCount: 1, awaitingPeers: [{ name: "web" }], awaitingItems: [{ kind: "peer", id: "p1" }] }), { state: "awaitingBg", text: "Awaiting web", peer: { name: "web" } }, "a local peer: the bare name; a peer row keeps the name path");
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingKind: "peer", awaitingCount: 2, awaitingPeers: [api, { name: "web" }] }), { state: "awaitingBg", text: "Awaiting 2 peers", peer: null });
+  assert.deepEqual(chipWords({ state: "awaitingBg", awaitingPeers: [api], awaitingItems: [{ kind: "peer", id: "p1" }, { kind: "agents", id: "a1" }] }), { state: "awaitingBg", text: "Awaiting 2", peer: null }, "a peer beside an agent: mixed, no name");
+});
+
+test("statusChip: `chip chip-<state>` wearing the words; a span by default, a button on request; the one peer's name on its own coloured node through the shared host renderer", () => {
+  const blocked = statusChip(chipWords({ state: "needsInput" }), "span", doc) as unknown as FakeNode;
+  assert.deepEqual([blocked.tag, blocked.className, blocked.textContent, blocked.children.length], ["span", "chip chip-needsInput", "Blocked", 0]);
+  const bar = statusChip(chipWords({ state: "awaitingBg", awaitingKind: "agents", awaitingCount: 3 }), "button", doc) as unknown as FakeNode;
+  assert.deepEqual([bar.tag, bar.className, bar.textContent], ["button", "chip chip-awaitingBg", "Awaiting 3 agents"]);
+  const plain = statusChip(chipWords({ state: "ready" }), undefined, doc) as unknown as FakeNode;
+  assert.deepEqual([plain.tag, plain.className, plain.textContent], ["span", "chip chip-ready", "Ready"]);
+  // the peer path builds the name through host-prefix.ts's renderer, in the SAME document the chip is built in (doc passes through)
+  const named = statusChip(chipWords({ state: "awaitingBg", awaitingKind: "peer", awaitingCount: 1, awaitingPeers: [{ name: "api", host: "TESTHOST", color: { bg: "#d53a3a", fg: "#ffffff" } }] }), "span", doc) as unknown as FakeNode;
+  assert.equal(named.className, "chip chip-awaitingBg");
+  assert.equal(named.children.length, 2, "the head and the name node");
+  assert.equal(named.children[0].textContent, "Awaiting ");
+  const nm = named.children[1] as FakeNode;
+  assert.deepEqual([nm.tag, nm.className, nm.style.color], ["span", "chip-peer-name", "#d53a3a"], "the NAME wears the identity colour on the backing");
+  assert.deepEqual(nm.children.map((c) => [c.tag, c.className || "", c.textContent]), [["span", "host-prefix", "TESTHOST:"], ["#text", "", "api"]], "the host as quiet metadata, the shared renderer's shape");
+  const local = statusChip(chipWords({ state: "awaitingBg", awaitingPeers: [{ name: "web" }] }), "span", doc) as unknown as FakeNode;
+  assert.deepEqual([(local.children[1] as FakeNode).text(), (local.children[1] as FakeNode).style.color], ["web", undefined], "no host, no colour: the bare name in the backing's default ink");
+});
+
+test("pinned: the bar and the tag overview's rows both build from this module; no second map, no pill of the view's own", () => {
+  assert.match(RENDER, /import \{ CHIP_LABEL, chipWords, statusChip, type ChipState \} from "\.\/status-chip";/);
+  assert.doesNotMatch(RENDER, /const CHIP_LABEL/, "the map has one home");
+  const bar = RENDER.split("function updateStatusline() {")[1].split("\nfunction ")[0];
+  assert.match(bar, /const chip = statusChip\(chipWords\(s\.status\), "button"\) as HTMLButtonElement;/, "the Awaiting chip, as the bar's button");
+  assert.match(bar, /sl\.appendChild\(statusChip\(chipWords\(s\.status\)\)\);/, "every plain state's chip");
+  assert.doesNotMatch(bar, /el\("span", `chip chip-\$\{/, "no chip class assembled by hand");
+  const row = RENDER.split("function fillSnapshotRow(")[1].split("\n}\n")[0];
+  assert.match(row, /if \(r\.chip\) btn\.appendChild\(statusChip\(r\.chip\)\);/, "the overview row: the model's chip, painted by the shared builder, a span inside the row's button");
+  const rowCode = row.split("\n").map((l) => l.replace(/\s*\/\/.*$/, "")).join("\n");   // the code alone: the comment recalls the old pill by name
+  assert.doesNotMatch(rowCode, /snap-flag|"waiting"|"needs you"/, "the bespoke pill and its lowercase words are gone");
+  assert.doesNotMatch(RENDER, /snap-flag/); assert.doesNotMatch(CSS, /snap-flag \{|snap-flag\.needs/, "…and its rules");
+  // the model picks the chip: on you → the bar's word for the session's own state, else the feed's column word; awaiting → the status's kind, count, rows, peers
+  assert.match(SNAP, /import \{ chipWords, type ChipStatusLike, type ChipWords \} from "\.\/status-chip";/);
+  assert.match(SNAP, /const chip = \(feedBlock \|\| st\.needsYou\) \? chipWords\(\{ state: s\?\.status && tabStateClass\(s\.status\) === "tab-blocked" \? "blocked" : "needsInput" \}\)\s*\n\s*: st\.waiting \? chipWords\(s\?\.status \|\| \{\}\) : null;/, "API error only for the tab's own on-you API error (the flags), else the feed's column word");
+  assert.match(SNAP, /if \(r\.chip && r\.chip\.text && stateWord !== r\.chip\.text\) parts\.push\(r\.chip\.text\);/, "the spoken label says the chip's words once");
+  assert.match(CSS, /\.chip \{[^}]*line-height: normal;/s, "a span chip and a button chip stand the same height");
+  assert.match(SNAP, /if \(s === "awaitingBg"\) return \{ pip: "waiting", state: chipWords\(st\)\.text, needsYou: false, waiting: true, closed: false \};/, "the spoken state is the chip's words");
+  assert.match(SNAP, /&& a\.needsYou === b\.needsYou && a\.waiting === b\.waiting && sameChip\(a\.chip, b\.chip\) && a\.now === b\.now/, "a chip change is a model change");
+  // the dress is the chip's, once: the size rule and the per-state fills in the one sheet
+  assert.equal((CSS.match(/^\.chip \{/gm) || []).length, 1);
+  assert.match(CSS, /\.chip-awaitingBg \{ background: var\(--st-awaitbg-bg\); color: var\(--st-awaitbg-fg\); \}/);
+  assert.match(CSS, /\.chip-needsInput \{ background: var\(--st-awaiting-bg\); color: var\(--st-awaiting-fg\); \}/);
+  assert.match(CSS, /\.chip-blocked \{ background: var\(--st-blocked-bg\); color: var\(--st-blocked-fg\); \}/);
+  assert.doesNotMatch(CSS, /\.snap-row \.chip|\.snap-item \.chip|#tab-snapshot \.chip/, "the overview adds no rule of its own for the chip");
+});

--- a/ui/webview/status-chip.ts
+++ b/ui/webview/status-chip.ts
@@ -1,0 +1,92 @@
+// THE SESSION STATUS CHIP: one vocabulary (the words) and one dress (the classes) for every surface that says a
+// session's state in a pill. The bar under the transcript wears it for the session you are reading (render.ts
+// updateStatusline), the comment popover's statusline mirrors its anatomy (cmtStateChip), and the tag overview's
+// rows wear it beside a session's name (fillSnapshotRow) for the two states a row says in words: on you (Blocked,
+// the feed's column word; API error when that is the state) and awaiting background work ("Awaiting 3 agents",
+// "Awaiting watch", the one peer's name). T322b (the user 2026-09-10, screenshot): the overview had grown a grey
+// outlined pill of its own reading "waiting" while the bar said "Awaiting agents" in await-green for the same
+// session: two renderers, two vocabularies. The words live here and nowhere else, and the classes are
+// `chip chip-<state>` wherever a chip is assembled: the bar's plain states and the overview's rows build through
+// statusChip; the bar's pulsing working chip, its interrupt flip and the comment popover's statusline assemble the
+// same classes by hand around these words.
+import { awaitWord, groupRows, type AwaitRow } from "./spin-caption";
+import { hostPartsNodes } from "./host-prefix";
+
+/** The kernel's chip states (its shared _session_chip derivation; render.ts imports the union from here since T322b, so
+ *  the labels below are checked exhaustive over it at compile time). needsInput = a live permission/picker prompt (on
+ *  YOU), renamed from the legacy "awaiting" (2026-08-15), which stays accepted for OLDER REMOTE KERNELS across
+ *  federation; awaitingBg = idle main thread waiting on background work it dispatched (the user 2026-07-13). */
+export type ChipState = "working" | "ready" | "needsInput" | "awaiting" | "awaitingBg" | "idle" | "closed" | "compacting" | "clearing" | "blocked" | "retrying" | "interrupting" | "opening";
+
+/** The state words, sentence case (the user 2026-07-03: never ALL CAPS), one per chip state: a state added to the union
+ *  without a word here fails to compile (the exhaustiveness main's render.ts map had, kept). */
+export const CHIP_LABEL = {
+  working: "Working", ready: "Ready", needsInput: "Blocked",
+  awaiting: "Blocked",   // the legacy name for needsInput — an older remote kernel still sends it
+  awaitingBg: "Awaiting",   // idle, waiting on background work it dispatched — the romp await-green, not working-yellow (the user 2026-07-13; recolored from straw 2026-07-22)
+  idle: "Idle", closed: "Closed", compacting: "Compacting", clearing: "Clearing", blocked: "API error",
+  retrying: "API retrying…",   // a live session stalled on an API rate-limit/overload auto-retry (api 2026-06-23)
+  interrupting: "Interrupting…",   // stop sent, turn not yet settled (the user 2026-07-02) — clears to READY on its own
+  opening: "Opening…",             // spawned, transcript not on disk yet — the first record clears it (the user 2026-08-05)
+} satisfies Record<ChipState, string>;
+
+/** A named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26): the name, its host when remote, its
+ *  identity colour. Structural: render.ts's PeerIdent and any payload shape fit. */
+export interface ChipPeer { name: string; host?: string | null; color?: { bg: string; fg?: string } | null }
+
+/** The status fields the chip reads — structural, so the chat's Status, a snapshot row's frame and a test's plain
+ *  object all fit. */
+export interface ChipStatusLike {
+  state?: string; awaitingKind?: string | null; awaitingCount?: number | null;
+  awaitingItems?: readonly AwaitRow[] | null; awaitingPeers?: readonly ChipPeer[] | null;
+}
+
+/** The chip's content as data: its state (the class), the words, and the one named peer when the wait is on a
+ *  single session (the name itself is the label then, in its identity colour). Pure, so a model can carry it and
+ *  compare it; statusChip paints it. */
+export interface ChipWords { state: string; text: string; peer: ChipPeer | null }
+
+/** The words for a state: the map's, else the state's own name in sentence case (the user 2026-07-03). */
+export function stateLabel(state: string | null | undefined): string {
+  const st = state || "";
+  return (CHIP_LABEL as Record<string, string>)[st] ?? (st ? st[0].toUpperCase() + st.slice(1).toLowerCase() : "");   // the one indexed read: a state the union lacks (an older remote kernel's) falls to its own name
+}
+
+/** The chip's words for a status. Every state but awaitingBg is its label alone. The Awaiting chip carries the KIND
+ *  so a glance says WHAT is awaited (the user 2026-08-15; tooltips are dead on the touch PWA), by ONE rule
+ *  (awaitWord, which agrees in number, T225): "Awaiting agent" / "Awaiting command" / "Awaiting watch" for one,
+ *  "Awaiting 3 agents" for several of a kind, "Awaiting 4" when the kinds are mixed. When every awaited row is a
+ *  peer and there is one, the chip names the actual session (the user 2026-08-26): `peer` carries it and `text`
+ *  holds the spoken form; several peers keep the one-line rule as a count. A peer beside an agent is a mixed wait. */
+export function chipWords(st: ChipStatusLike): ChipWords {
+  const state = st.state || "";
+  if (state !== "awaitingBg") return { state, text: stateLabel(state), peer: null };
+  const items = st.awaitingItems || [];
+  const peers = st.awaitingPeers || [];
+  const word = awaitWord(st.awaitingKind, st.awaitingCount, items);
+  const head = CHIP_LABEL.awaitingBg;
+  if (peers.length && groupRows(items).every((g) => g.kind === "peer")) {
+    if (peers.length === 1) return { state, text: head + " " + (peers[0].host ? peers[0].host + ":" : "") + peers[0].name, peer: peers[0] };
+    return { state, text: head + " " + (word || peers.length + " peers"), peer: null };
+  }
+  return { state, text: head + (word ? " " + word : ""), peer: null };
+}
+
+/** The chip element: `chip chip-<state>` wearing the words. A single peer's NAME renders on its own node in the
+ *  peer's identity colour on the always-on backing (.chip-peer-name) through the house session-reference renderer,
+ *  so a remote "host:" wears .host-prefix (the user 2026-08-26, round three). `tag`: a span, or a button for the
+ *  bar's clickable Awaiting chip (an overview row is itself a button, so its chip is a span). `doc` is the document
+ *  to build in — a test's fake; the page's by default. */
+export function statusChip(w: ChipWords, tag: "span" | "button" = "span", doc: Pick<Document, "createElement" | "createTextNode"> = document): HTMLElement {
+  const chip = doc.createElement(tag);
+  chip.className = "chip chip-" + w.state;
+  if (w.peer) {
+    chip.append(CHIP_LABEL.awaitingBg + " ");
+    const nm = doc.createElement("span");
+    nm.className = "chip-peer-name";
+    nm.replaceChildren(...hostPartsNodes(w.peer.host, w.peer.name, doc));   // the same document: a fake's chip carries a fake's name node
+    if (w.peer.color && w.peer.color.bg) nm.style.color = w.peer.color.bg;
+    chip.appendChild(nm);
+  } else chip.textContent = w.text;
+  return chip;
+}

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1286,9 +1286,10 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .mention-chip { display: inline-block; line-height: 1.35; font-weight: 600; color: var(--chip-bg, #fff); }
 
 /* A SECTION AT A GLANCE (tab-snapshot.ts, render.ts renderSnapshot): one row per session of a tab-strip
-   section, in the transcript's place. Two sizes only: the body size for the name and the now line, and
-   0.82em, the header's label size, for the heading, the flag word, the time and the note (labels match
-   labels, times match the strip's sub-lines). The heading wears the header's own dress (letter-spaced dim
+   section, in the transcript's place. Two sizes of its own: the body size for the name and the now line, and
+   0.82em, the header's label size, for the heading, the time and the note (labels match
+   labels, times match the strip's sub-lines); the state chip keeps the shared .chip rule's 0.7em, the bar's
+   own size (T322b). The heading wears the header's own dress (letter-spaced dim
    label + the tag's swatch bar); a row is a real button with the one action hover (accent border + accent
    wash) and the accent focus ring; the pip wears the tab's state colors by the tab's rule (the retrying
    amber is the same status token the tab and the folded header's pip use); the name takes the session's
@@ -1313,8 +1314,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 .snap-sess { flex: 0 0 auto; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
 .snap-row.closed .snap-sess { text-decoration: line-through; opacity: 0.6; }
 .snap-row.loading .snap-sess { opacity: 0.6; }
-.snap-flag { flex: 0 0 auto; padding: 0 6px; border: 1px solid var(--box-border); border-radius: var(--radius-pill); font-size: 0.82em; color: var(--dim); }
-.snap-flag.needs { border-color: transparent; background: var(--st-blocked-bg); color: var(--st-blocked-fg); }
+/* (the row's state words are the SHARED status chip, .chip / .chip-<state> below, the same the bar under the transcript
+   wears — the row adds no rule of its own for it; its grey "waiting" pill is gone, T322b) */
 .snap-now { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--dim); }
 /* the row's second line: the session's own working note (render.ts fillSnapshotRow), the header's 0.82em in
    the dim token a step quieter, one line, indented past the pip and its gap so it sits under the name */
@@ -1397,6 +1398,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   display: inline-flex; align-items: center;
   font-size: 0.7em; font-weight: 700; letter-spacing: 0.07em;
   padding: 3px 10px; border-radius: 11px;
+  line-height: normal;   /* a span chip and a button chip stand the same height: the UA gives a button normal, a span would inherit the body's 1.6 (T322b: the overview row's span beside the bar's button) */
 }
 .chip-working { background: var(--st-working-bg); color: var(--st-working-fg); }
 /* blocked = API error: red chip; the TAB itself goes dashed-red (above), no dot — it isn't working. */

--- a/ui/webview/tab-snapshot-pane.test.ts
+++ b/ui/webview/tab-snapshot-pane.test.ts
@@ -17,6 +17,7 @@ import { viewTagUnion } from "./session-views";
 import { parseTabGroups, planStrip, setSectionCollapsed, homeSectionOf, neighborOfFolded, headWords, type StripItem, type TabSection } from "./tab-groups";
 import { sectionPip, sectionPipMembers, sectionPipTitle } from "./tab-state";
 import { snapshotModel, snapshotHeading, rowWords, type SnapModel } from "./tab-snapshot";
+import { statusChip } from "./status-chip";
 import { rowStillOpen, installSnapshotEscape, reconcileRows } from "./tab-snapshot-view";
 
 const requireCjs = createRequire(__filename);
@@ -130,7 +131,7 @@ type Hooks = {
   calls: string[]; delegates: Array<{ root: FakeEl; handlers: Record<string, (node: FakeEl, ev: Event) => void> }>;
   winCap: Function[]; winBub: Function[]; writes: any[];
   FakeEl: typeof FakeEl; doc: FakeDoc;
-  snapshotModel: typeof snapshotModel; snapshotHeading: typeof snapshotHeading; rowWords: typeof rowWords;
+  snapshotModel: typeof snapshotModel; snapshotHeading: typeof snapshotHeading; rowWords: typeof rowWords; statusChip: typeof statusChip;
   rowStillOpen: typeof rowStillOpen; installSnapshotEscape: typeof installSnapshotEscape; reconcileRows: typeof reconcileRows;
   homeSectionOf: typeof homeSectionOf; neighborOfFolded: typeof neighborOfFolded; setSectionCollapsed: typeof setSectionCollapsed;
   headWords: typeof headWords; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
@@ -182,6 +183,7 @@ function lift(): (H: Hooks) => Api {
     const ageColorReadable = (s) => "age-" + Math.floor(s);
     const hostNameNodes = (name) => [document.createTextNode(name)];
     const snapshotModel = H.snapshotModel, snapshotHeading = H.snapshotHeading, rowWords = H.rowWords;
+    const statusChip = (w, tag) => H.statusChip(w, tag, document);   // the shared status chip, built in the fake document (T322b)
     const rowStillOpen = H.rowStillOpen, installSnapshotEscape = H.installSnapshotEscape, reconcileRows = H.reconcileRows;
     const homeSectionOf = H.homeSectionOf, neighborOfFolded = H.neighborOfFolded, setSectionCollapsed = H.setSectionCollapsed;
     const tabGroups = () => H.groups;
@@ -234,7 +236,7 @@ function world(active = "web", groups = parseTabGroups(null), ids = ["web", "api
   const H: Hooks = { content, bar, composer, sendBtn: new FakeEl("button"), sessions, ledgers, tabMeta: new Map([["tests", { name: "tests", color: null }]]),
     closingTabs: new Map(), views: new Map(), lastStripItems: plan.items, order: ids, collapsed: plan.folded, nowMs: T0 * 1000, pickerOpen: false,
     calls: [], delegates: [], winCap: [], winBub: [], writes: [], FakeEl, doc: DOC,
-    snapshotModel, snapshotHeading, rowWords, rowStillOpen, installSnapshotEscape, reconcileRows, homeSectionOf, neighborOfFolded, setSectionCollapsed,
+    snapshotModel, snapshotHeading, rowWords, statusChip, rowStillOpen, installSnapshotEscape, reconcileRows, homeSectionOf, neighborOfFolded, setSectionCollapsed,
     headWords, sectionPip, sectionPipMembers, sectionPipTitle, groups, navDeps: null };
   const api = lift()(H);
   api.set({ activeId: active });
@@ -287,8 +289,8 @@ test("executed: the view paints one row per member from the model: heading, keye
   assert.equal(web.children[2].textContent, "Add the notes list page");
   assert.deepEqual([web.children[3].dataset.t, web.children[3].textContent, web.children[3].style.color], [String(T0 - 40), "40s ago", "age-40"], "the model carries the epoch; the renderer formats it");
   assert.equal(web.children[4].textContent, "editing the list page");
-  assert.deepEqual(api_.children.map((c) => c.className), ["snap-pip", "snap-sess", "snap-flag needs", "snap-now", "snap-when"], "an idle session the feed files under needs-you: no pip, the word");
-  assert.equal(api_.children[2].textContent, "needs you");
+  assert.deepEqual(api_.children.map((c) => c.className), ["snap-pip", "snap-sess", "chip chip-needsInput", "snap-now", "snap-when"], "an idle session the feed files under needs-you: no pip, the bar's Blocked chip (T322b)");
+  assert.deepEqual([api_.children[2].tag, api_.children[2].textContent], ["span", "Blocked"], "the shared status chip, a span inside the row's button");
   assert.equal(H.delegates.length, 1, "one delegate, on the stable host, installed with it");
   assert.equal(H.delegates[0].root, host);
 });
@@ -649,9 +651,32 @@ test("pinned: the sheet: the shown header's wash and the stand-in's mark on the 
   assert.match(block, /\.snap-pip\.retrying \{ background: var\(--st-retrying-bg\); \}/, "the same status token the tab and the folded header's pip use");
   assert.match(block, /\.snap-row:hover \{ border-color: var\(--accent\); background: var\(--accent-wash\); \}/);
   assert.match(block, /\.snap-row:focus-visible \{ outline: 1px solid var\(--accent\); outline-offset: -1px; \}/);
-  assert.match(block, /\.snap-flag\.needs \{ border-color: transparent; background: var\(--st-blocked-bg\); color: var\(--st-blocked-fg\); \}/, "needs you in the status red, not the accent");
+  assert.doesNotMatch(block, /\.snap-flag/, "no pill of the view's own (T322b): the state words are the shared status chip, .chip / .chip-<state>");
   const stripped = block.replace(/\/\*[\s\S]*?\*\//g, "").replace(/var\([^)]*\)/g, "V");
   assert.equal(stripped.match(/#[0-9a-fA-F]{3,8}\b/g), null, "no raw color: the light theme needs no override");
+});
+
+test("executed: the row's state words are the SHARED status chip (T322b): the awaiting row wears chip-awaitingBg with 'Awaiting <word>' from the status's kind and count, the needs-you row the bar's Blocked; the pip stays; a count change re-texts the chip", () => {
+  const { api, content, sessions } = world();
+  sessions.set("tests", { name: "tests", color: null, status: { state: "awaitingBg", sinceEpoch: (T0 - 900) * 1000, awaitingKind: "agents", awaitingCount: 3, awaitingItems: [] }, events: [] });
+  api.set({ lastStripItems: [{ head: { name: "infra", localId: "g2", color: "#4EC9B0", ids: ["web", "api", "tests"] }, folded: false, active: true, hidden: [] }, { id: "web" }, { id: "api" }, { id: "tests" }], snapView: "infra" });
+  api.renderSnapshot();
+  const host = content.byId("tab-snapshot")!;
+  const [web, api_, tests] = rowsOf(host).map((i) => i.children[0]);
+  assert.deepEqual(tests.children.map((c) => c.className), ["snap-pip waiting", "snap-sess", "chip chip-awaitingBg", "snap-now", "snap-when"], "the green pip stays; the chip beside the name");
+  assert.deepEqual([tests.children[2].tag, tests.children[2].textContent], ["span", "Awaiting 3 agents"], "the bar's words: the kind, agreeing in number");
+  assert.equal(tests.getAttribute("aria-label"), "tests; Awaiting 3 agents", "spoken as shown");
+  assert.deepEqual([api_.children[2].className, api_.children[2].textContent], ["chip chip-needsInput", "Blocked"], "on you: the feed's column word, the bar's chip");
+  assert.equal(web.querySelector(".chip"), null, "a working row says it with the pip alone");
+  assert.equal(host.querySelector(".snap-flag"), null, "no pill of the view's own");
+  // new information: the kind and count change → the button stands, the chip re-texts
+  const m1 = api.get().snapModel;
+  sessions.set("tests", { ...sessions.get("tests"), status: { ...sessions.get("tests").status, awaitingKind: "job", awaitingCount: 1 } });
+  api.renderSnapshot();
+  assert.notEqual(api.get().snapModel, m1, "a chip change is a model change");
+  assert.equal(rowsOf(host)[2].children[0], tests, "the button stands");
+  assert.equal(tests.querySelector(".chip")!.textContent, "Awaiting watch");
+  assert.equal(tests.getAttribute("aria-label"), "tests; Awaiting watch");
 });
 
 test("executed: the guide describes the fold rule and the view", () => {

--- a/ui/webview/tab-snapshot.test.ts
+++ b/ui/webview/tab-snapshot.test.ts
@@ -6,7 +6,7 @@
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import { snapshotModel, snapshotRow, snapshotHeading, rowWords, rowState, nowLine, noteLine, lastActivity, lastMessage,
-         plainText, sameModel, FEED_BLOCK_STATE, type SnapSessionLike, type SnapLedgerLike } from "./tab-snapshot";
+         plainText, sameModel, type SnapSessionLike, type SnapLedgerLike } from "./tab-snapshot";
 
 const T0 = 1781100000;
 const iso = (t: number) => new Date(t * 1000).toISOString();
@@ -42,7 +42,7 @@ test("executed: one row per member in strip order, from what the client already 
   assert.deepEqual([api.pip, api.state, api.needsYou], ["awaiting", "needs you: waiting on your answer", true], "a live prompt is on you: the tab's red");
   assert.equal(api.now, "Pick a database", "the current task");
   assert.equal(api.note, "", "no note, no second line");
-  assert.deepEqual([tests.pip, tests.state, tests.waiting, tests.needsYou], ["waiting", "waiting on background work", true, false], "awaitingBg: waiting, not on you");
+  assert.deepEqual([tests.pip, tests.state, tests.waiting, tests.needsYou], ["waiting", "Awaiting agents", true, false], "awaitingBg: waiting, not on you; the state in the chip's own words (no kind, no count: the historic default word)");
   assert.equal(tests.now, "Run the notes-api suite", "no current task, no summary: the most recent top");
   assert.equal(tests.lastT, T0 - 900, "an empty tail: the state's start, converted from the wire's milliseconds");
   assert.equal(tests.lastMsg, "");
@@ -63,9 +63,9 @@ test("executed: the now line's precedence (current task, summary, recent top, no
 test("executed: needs you follows the FEED's column, not the tab's chip: a judge-filed block flags the row whether the session is idle or active", () => {
   // the common case the tab's rule misses: the agent asked a question and went idle; the feed files its card under needs-you
   const idle = snapshotRow("web", { name: "web", status: { state: "idle" } }, { needsInput: true, tree: [{ text: "Pick a database", current: true }] });
-  assert.deepEqual([idle.pip, idle.needsYou, idle.state], ["", true, FEED_BLOCK_STATE], "idle + feed needs-you: flagged, with the feed's word; the pip stays the tab's (none)");
+  assert.deepEqual([idle.pip, idle.needsYou, idle.state, idle.chip], ["", true, "", { state: "needsInput", text: "Blocked", peer: null }], "idle + feed needs-you: flagged; the chip is the feed's column word and the row's only word for it; the pip stays the tab's (none)");
   const ready = snapshotRow("web", { name: "web", status: { state: "ready" } }, { needsInput: true });
-  assert.deepEqual([ready.pip, ready.needsYou, ready.state], ["", true, FEED_BLOCK_STATE]);
+  assert.deepEqual([ready.pip, ready.needsYou, ready.state, ready.chip && ready.chip.text], ["", true, "", "Blocked"]);
   // blocked while active: the feed's verdict stands until the judges rule again, even with a turn open (a rejudge in flight)
   const active = snapshotRow("web", { name: "web", status: { state: "working" } }, { needsInput: true });
   assert.deepEqual([active.pip, active.needsYou, active.state], ["working", true, "working"], "active + feed needs-you: flagged; the tab's own state word and pip stay");
@@ -76,27 +76,30 @@ test("executed: needs you follows the FEED's column, not the tab's chip: a judge
   assert.equal(snapshotRow("web", { name: "web", status: { state: "needsInput" } }, { needsInput: null }).needsYou, true, "the tab's live prompt still counts (the feed trails the chip by a push)");
   assert.equal(snapshotRow("web", { name: "web", status: { state: "blocked", apiTooLong: true } }, { needsInput: false }).needsYou, true, "the tab's on-you API error too");
   assert.equal(snapshotRow("web", { name: "web", status: { state: "closed" } }, { needsInput: true }).state, "closed", "a closed session keeps its own word");
-  assert.equal(rowWords(idle).label, "web; needs you; Pick a database", "the spoken label carries the feed's word, once");
+  assert.equal(rowWords(idle).label, "web; Blocked; Pick a database", "the spoken label says the chip's words, once (T322b: what is heard is what is shown)");
 });
 
-test("executed: the feed's word claims only what is true of every card in its column: needs you, nothing about being stopped", () => {
-  // the column also holds a peer's held message waiting for approval (the session idle, taking input); the
-  // feed's own word for a goal in that column is the one every card there deserves
-  assert.equal(FEED_BLOCK_STATE, "needs you");
-  assert.doesNotMatch(FEED_BLOCK_STATE, /stop|answer/);
+test("executed: the on-you chip's words: Blocked for the feed's column and a live prompt; API error only for the tab's own on-you API error, never for a flagless auto-retried one", () => {
+  const chipOf = (status: any, lg: any = { needsInput: false }) => snapshotRow("api", { name: "api", status, events: [] }, lg).chip;
+  assert.deepEqual(chipOf({ state: "needsInput" }), { state: "needsInput", text: "Blocked", peer: null }, "a live prompt");
+  assert.deepEqual(chipOf({ state: "blocked", apiTooLong: true }), { state: "blocked", text: "API error", peer: null }, "an API error only you can clear: the flags say so");
+  assert.deepEqual(chipOf({ state: "blocked", apiSpendLimit: true }, { needsInput: true }), { state: "blocked", text: "API error", peer: null });
+  assert.deepEqual(chipOf({ state: "blocked" }, { needsInput: true }), { state: "needsInput", text: "Blocked", peer: null }, "a flagless API error is the kernel's transient, auto-retried one: with a feed-filed block the row reads Blocked like any other on-you row");
+  assert.deepEqual(chipOf({ state: "retrying" }, { needsInput: true }), { state: "needsInput", text: "Blocked", peer: null }, "…the same as its retrying twin");
+  assert.equal(chipOf({ state: "blocked" }), null, "a flagless API error with no feed verdict is not on you: the amber pip alone");
 });
 
-test("executed: the spoken label carries NEEDS YOU whenever the row wears it, whatever the state word, and never twice", () => {
+test("executed: the spoken label says the chip's words whenever the row wears one, once, then the tab's own phrase", () => {
   const prompt = snapshotRow("api", { name: "api", status: { state: "needsInput" } }, { needsInput: true });
-  assert.equal(rowWords(prompt).label, "api; needs you: waiting on your answer");
+  assert.equal(rowWords(prompt).label, "api; Blocked; needs you: waiting on your answer");
   const apiErr = snapshotRow("api", { name: "api", status: { state: "blocked", apiTooLong: true } }, null);
-  assert.equal(rowWords(apiErr).label, "api; needs you: stopped on an API error");
+  assert.equal(rowWords(apiErr).label, "api; API error; needs you: stopped on an API error");
   const rejudge = snapshotRow("web", { name: "web", status: { state: "working" } }, { needsInput: true, tree: [{ text: "Pick a database", current: true }] });
-  assert.equal(rowWords(rejudge).label, "web; needs you; working; Pick a database");
-  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "closed" } }, { needsInput: true })).label, "web; needs you; closed");
+  assert.equal(rowWords(rejudge).label, "web; Blocked; working; Pick a database");
+  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "closed" } }, { needsInput: true })).label, "web; Blocked; closed");
   assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "working" } }, { needsInput: false })).label, "web; working");
-  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "awaitingBg" } }, { needsInput: null })).label, "web; waiting on background work");
-  assert.equal(rowWords(snapshotRow("new1", null, { needsInput: true })).label, "(unnamed); needs you; opening", "a loading row can wear the flag only through a ledger the client has no session for; spoken all the same");
+  assert.equal(rowWords(snapshotRow("web", { name: "web", status: { state: "awaitingBg" } }, { needsInput: null })).label, "web; Awaiting agents", "an awaiting row's phrase IS the chip's words: said once");
+  assert.equal(rowWords(snapshotRow("new1", null, { needsInput: true })).label, "(unnamed); Blocked; opening", "a loading row can wear the chip only through a ledger the client has no session for; spoken all the same");
 });
 
 test("executed: the pip and the state word follow tab-state.ts: on-you red, transient amber, closed struck, idle none", () => {
@@ -197,6 +200,43 @@ test("executed: the words: the heading's count and label, the row's spoken label
   const m = snapshotModel(sec, look(sessions), look(ledgers), null);
   assert.equal(rowWords(m.rows[0]).label, "web; working; Add the notes list page; its note: editing the list page template", "the task first, the note last, named as the session's own");
   assert.equal(rowWords(m.rows[0]).title, "Last message: Adding the list page now: the route and the template.\nClick to open this session.");
-  assert.equal(rowWords(m.rows[1]).label, "api; needs you: waiting on your answer; Pick a database");
+  assert.equal(rowWords(m.rows[1]).label, "api; Blocked; needs you: waiting on your answer; Pick a database");
   assert.equal(rowWords(m.rows[2]).title, "No messages yet.\nClick to open this session.");
+});
+
+test("executed: the row's chip is the SHARED status chip's words (T322b): Blocked for the feed's column and a live prompt, API error for an on-you API error, 'Awaiting <word>' from the kind, count and rows, the one peer's name; none for working, ready and retrying; a change in it is a model change", () => {
+  const m = snapshotModel(sec, look(sessions), look(ledgers), null);
+  const [web, api, tests] = m.rows;
+  assert.equal(web.chip, null, "working: the pip alone");
+  assert.deepEqual(api.chip, { state: "needsInput", text: "Blocked", peer: null }, "a live prompt: the bar's Blocked");
+  assert.deepEqual(tests.chip, { state: "awaitingBg", text: "Awaiting agents", peer: null }, "no kind, no count: the historic default word");
+  const chipOf = (status: any, lg: any = { needsInput: false }) => snapshotRow("tests", { name: "tests", status, events: [] }, lg).chip;
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingKind: "agents", awaitingCount: 3 }), { state: "awaitingBg", text: "Awaiting 3 agents", peer: null });
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingKind: "job", awaitingCount: 1 }), { state: "awaitingBg", text: "Awaiting watch", peer: null }, "the plain words: a job is a watch");
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingKind: "mixed", awaitingCount: 4 }), { state: "awaitingBg", text: "Awaiting 4", peer: null }, "mixed kinds: the number alone");
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingItems: [{ kind: "agents", id: "a1" }, { kind: "commands", id: "c1" }] }), { state: "awaitingBg", text: "Awaiting 2", peer: null }, "rows of two kinds: the number alone");
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingItems: [{ kind: "watches", id: "w1" }, { kind: "watches", id: "w2" }] }), { state: "awaitingBg", text: "Awaiting 2 watches", peer: null });
+  const peer = { name: "api", host: "TESTHOST", color: { bg: "#d53a3a", fg: "#ffffff" } };
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingKind: "peer", awaitingCount: 1, awaitingPeers: [peer] }), { state: "awaitingBg", text: "Awaiting TESTHOST:api", peer }, "one peer: the chip names it");
+  assert.deepEqual(chipOf({ state: "awaitingBg", awaitingKind: "peer", awaitingCount: 2, awaitingPeers: [peer, { name: "web" }] }), { state: "awaitingBg", text: "Awaiting 2 peers", peer: null }, "several peers: the count");
+  assert.deepEqual(chipOf({ state: "blocked", apiTooLong: true }), { state: "blocked", text: "API error", peer: null }, "the tab's on-you API error: the bar's word for it");
+  assert.deepEqual(chipOf({ state: "needsInput" }), { state: "needsInput", text: "Blocked", peer: null }, "a live prompt");
+  assert.deepEqual(chipOf({ state: "idle" }, { needsInput: true }), { state: "needsInput", text: "Blocked", peer: null }, "a judge-filed block on an idle session: the feed's column word");
+  assert.deepEqual(chipOf({ state: "working" }, { needsInput: true }), { state: "needsInput", text: "Blocked", peer: null }, "…and on an active one");
+  assert.equal(chipOf({ state: "ready" }), null); assert.equal(chipOf({ state: "idle" }), null); assert.equal(chipOf({ state: "retrying" }), null, "retrying rides the pip alone");
+  assert.equal(chipOf({ state: "closed" }), null, "closed: the struck name says it");
+  assert.equal(snapshotRow("tests", null, null, { name: "tests" }).chip, null, "a placeholder tab: no chip");
+  // the spoken label says the chip's words, once
+  assert.equal(rowWords(snapshotRow("tests", { name: "tests", status: { state: "awaitingBg", awaitingKind: "job", awaitingCount: 1 }, events: [] }, null)).label, "tests; Awaiting watch");
+  // a change in the chip alone is a model change; nothing changed is the same object
+  const s2 = new Map(sessions); s2.set("tests", { ...sessions.get("tests")!, status: { state: "awaitingBg", sinceEpoch: ms(T0 - 900), awaitingKind: "agents", awaitingCount: 3 } });
+  assert.notEqual(snapshotModel(sec, look(s2), look(ledgers), m), m, "the count came: a new model");
+  // …and a change the chip alone carries (the state phrase unchanged): the one peer's identity colour
+  const peerA = { name: "api", color: { bg: "#d53a3a", fg: "#ffffff" } }, peerB = { name: "api", color: { bg: "#3a7bd5", fg: "#ffffff" } };
+  const s3 = new Map(sessions); s3.set("tests", { ...sessions.get("tests")!, status: { state: "awaitingBg", sinceEpoch: ms(T0 - 900), awaitingKind: "peer", awaitingCount: 1, awaitingPeers: [peerA] } });
+  const m3 = snapshotModel(sec, look(s3), look(ledgers), null);
+  const s4 = new Map(s3); s4.set("tests", { ...s3.get("tests")!, status: { ...s3.get("tests")!.status, awaitingPeers: [peerB] } });
+  assert.equal(snapshotModel(sec, look(s3), look(ledgers), m3), m3, "the same peer: the same object");
+  assert.notEqual(snapshotModel(sec, look(s4), look(ledgers), m3), m3, "the peer's colour changed and nothing else the row says: a new model (sameChip)");
+  assert.equal(snapshotModel(sec, look(sessions), look(ledgers), m), m, "nothing changed: the same object");
 });

--- a/ui/webview/tab-snapshot.ts
+++ b/ui/webview/tab-snapshot.ts
@@ -14,9 +14,11 @@
 // paints it; the shapes below are the minimal "Like" views of render.ts's types (the tab-state.ts idiom),
 // so the rule runs in node tests without a DOM.
 import { tabStateClass, type TabStateLike } from "./tab-state";
+import { chipWords, type ChipStatusLike, type ChipWords } from "./status-chip";
 import { stripInline } from "./docreview";
 
-export interface SnapStatusLike extends TabStateLike { sinceEpoch?: number | null }
+/** The tab's state fields, the chip's awaiting fields (kind, count, rows, peers: what an awaiting session waits on), the clock. */
+export interface SnapStatusLike extends TabStateLike, ChipStatusLike { sinceEpoch?: number | null }
 export interface SnapEventLike { kind?: string; md?: string; text?: string; ts?: string; t?: number }
 export interface SnapColor { bg: string; fg: string }
 export interface SnapSessionLike {
@@ -55,6 +57,13 @@ export interface SnapRow {
   needsYou: boolean;
   /** waiting on something that is not you: dispatched background work */
   waiting: boolean;
+  /** the state chip the row wears beside the name, or null for none: the SHARED status chip's words and class
+   *  (status-chip.ts chipWords), the same the bar under the transcript shows for the session you are reading.
+   *  Only the states a row says in words: on you (needsInput's "Blocked", the feed's column word; the tab's own
+   *  "API error" when its rule sees an API error only you can clear) and awaiting background work ("Awaiting 3 agents", "Awaiting watch", the
+   *  one peer's name). Working, ready and the rest ride the pip alone: a blank beside the name means alive and
+   *  quiet, the Sessions pane's rule (T322b, the user 2026-09-10). */
+  chip: ChipWords | null;
   /** what it is doing now, in the user's terms: the judges' current task, else the archiver's headline,
    *  else the most recent top task; "" when nothing is known */
   now: string;
@@ -157,18 +166,11 @@ export function rowState(st: SnapStatusLike | null | undefined): { pip: SnapPip;
   if (cls === "tab-compacting") return { pip: "compacting", state: s === "clearing" ? "clearing" : "compacting", needsYou: false, waiting: false, closed: false };
   if (cls === "tab-closed") return { pip: "", state: "closed", needsYou: false, waiting: false, closed: true };
   if (cls === "tab-working") return { pip: "working", state: "working", needsYou: false, waiting: false, closed: false };
-  if (s === "awaitingBg") return { pip: "waiting", state: "waiting on background work", needsYou: false, waiting: true, closed: false };
+  if (s === "awaitingBg") return { pip: "waiting", state: chipWords(st).text, needsYou: false, waiting: true, closed: false };   // the chip's own words ("Awaiting 3 agents"), spoken as shown (T322b)
   if (s === "interrupting") return { pip: "", state: "interrupting", needsYou: false, waiting: false, closed: false };
   if (s === "opening") return { pip: "unknown", state: "opening", needsYou: false, waiting: false, closed: false };
   return { pip: "", state: "", needsYou: false, waiting: false, closed: false };
 }
-
-/** The state word for a session the feed files under needs-you while the tab's own rule sees nothing (an
- *  idle session that asked a question and stopped, the common case): the feed's own word for that column,
- *  and nothing more. The column also holds cards that stop nothing (a peer's held message waiting for your
- *  approval), so a claim like "stopped until you answer" would be false for some rows the word reaches;
- *  "needs you" is true of every card there. */
-export const FEED_BLOCK_STATE = "needs you";
 
 /** A member's name as its tab shows it; "(unnamed)" for a blank one (the tab-state.ts rule). */
 const memberName = (s: { name?: string } | null | undefined): string => String(s?.name || "").trim() || "(unnamed)";
@@ -186,14 +188,21 @@ export function snapshotRow(id: string, s: SnapSessionLike | null | undefined, l
   // column, per session, from the kernel's last feed build (build_session); the tab's own cases stay as a
   // floor because the feed build trails the chip by one push.
   const feedBlock = lg?.needsInput === true;
+  // the chip: on you → "API error" when the tab's own rule sees an API error only you can clear (tab-blocked: the
+  // flags ride beside the state; a flagless API error is the kernel's transient, auto-retried one, and with a feed-filed
+  // block it reads "Blocked" like every other on-you row), else the feed's column word ("Blocked", needsInput's chip);
+  // awaiting → the awaiting chip's words from the status's kind, count, rows and peers; otherwise none
+  const chip = (feedBlock || st.needsYou) ? chipWords({ state: s?.status && tabStateClass(s.status) === "tab-blocked" ? "blocked" : "needsInput" })
+    : st.waiting ? chipWords(s?.status || {}) : null;
   return {
     id,
     name: memberName(src),
     color: src?.color && src.color.bg && src.color.fg ? { bg: src.color.bg, fg: src.color.fg } : null,
     pip: s ? st.pip : "unknown",
-    state: st.state || (feedBlock && !st.closed ? FEED_BLOCK_STATE : ""),
+    state: st.state,   // the tab's own phrase; a feed-filed block on a quiet session has none, its chip ("Blocked") is the word (T322b)
     needsYou: feedBlock || st.needsYou,
     waiting: st.waiting,
+    chip,
     now: nowLine(lg),
     note: noteLine(lg),
     lastT: s ? lastActivity(s) : null,
@@ -203,9 +212,13 @@ export function snapshotRow(id: string, s: SnapSessionLike | null | undefined, l
   };
 }
 
+const sameChip = (a: ChipWords | null, b: ChipWords | null): boolean =>
+  a === b || (!!a && !!b && a.state === b.state && a.text === b.text
+    && (a.peer === b.peer || (!!a.peer && !!b.peer && a.peer.name === b.peer.name && (a.peer.host || "") === (b.peer.host || "")
+                              && (a.peer.color?.bg || "") === (b.peer.color?.bg || ""))));
 const sameRow = (a: SnapRow, b: SnapRow): boolean =>
   a.id === b.id && a.name === b.name && a.pip === b.pip && a.state === b.state
-  && a.needsYou === b.needsYou && a.waiting === b.waiting && a.now === b.now && a.note === b.note
+  && a.needsYou === b.needsYou && a.waiting === b.waiting && sameChip(a.chip, b.chip) && a.now === b.now && a.note === b.note
   && a.lastT === b.lastT && a.lastMsg === b.lastMsg && a.closed === b.closed && a.loading === b.loading
   && (a.color === b.color || (!!a.color && !!b.color && a.color.bg === b.color.bg && a.color.fg === b.color.fg));
 
@@ -233,15 +246,16 @@ export function snapshotHeading(name: string, n: number): { count: string; label
   return { count, label: `Overview of ${name}: ${count}; click one to open it` };
 }
 
-/** A row's spoken label (name, needs you, state, what it is doing, its own note) and its hover title.
- *  NEEDS YOU is spoken whenever the row wears it: the tab's own state words carry it in their text; every
- *  other state word (working, closed, compacting) gets the word in front of it, where the painted chip sits
- *  beside the pip. The button's aria-label replaces its content for a reader, so a word only the chip
- *  carried would never be spoken. */
+/** A row's spoken label (name, the chip's words, the state phrase, what it is doing, its own note) and its hover
+ *  title. The CHIP's words are spoken whenever the row wears one ("Blocked", "API error", "Awaiting 3 agents"),
+ *  once, where the painted chip sits beside the pip: an awaiting row's state phrase IS the chip's words, so it is
+ *  not repeated; an on-you row's tab phrase ("needs you: waiting on your answer") follows the word. The button's
+ *  aria-label replaces its content for a reader, so a word only the chip carried would never be spoken, and a
+ *  word the chip does not show would be heard and not seen (T322b: the label says what is shown). */
 export function rowWords(r: SnapRow): { label: string; title: string } {
   const parts = [r.name];
   const stateWord = r.loading ? "opening" : r.state;
-  if (r.needsYou && !stateWord.startsWith(FEED_BLOCK_STATE)) parts.push(FEED_BLOCK_STATE);
+  if (r.chip && r.chip.text && stateWord !== r.chip.text) parts.push(r.chip.text);
   if (stateWord) parts.push(stateWord);
   if (r.now) parts.push(r.now);
   if (r.note) parts.push(`its note: ${r.note}`);


### PR DESCRIPTION
The user (2026-09-10, screenshot): in a tag's overview, sessions waiting on background work showed a plain grey outlined pill reading "waiting", while the bar under the transcript says "Awaiting agents" in await-green for the same session.

**Root cause.** The overview row built a pill of its own (`.snap-flag`) with its own words, beside the bar's chip, whose words (`CHIP_LABEL`, `awaitWord`) lived in `render.ts` alone. Two renderers, two vocabularies.

**Fix.** The chip's words and classes move to one module, `ui/webview/status-chip.ts` (`CHIP_LABEL`, `stateLabel`, `chipWords`, `statusChip`), which the bar and the overview row both build from. The bar's Awaiting chip is `statusChip(chipWords(status), "button")` plus what only the bar has (the button, the per-kind hook, the tip); every plain state's chip is the same builder. The row's model (`tab-snapshot.ts` `snapshotRow`) picks the chip: on you, needsInput's "Blocked" (the feed's column word) or the tab's own "API error" when that is the state; awaiting, the status's kind, count, rows and peers ("Awaiting 3 agents", "Awaiting watch", "Awaiting 4" for mixed kinds, a single peer's name in its identity colour); working, ready and the rest ride the pip alone (the Sessions pane's rule: a blank beside the name means alive and quiet). The pip stays. The row's spoken state is the chip's words. The guide's paragraph follows.

**Tests.** `status-chip.test.ts` executes the words and the builder and pins both consumers, no second map and no pill. `tab-snapshot.test.ts` and `tab-snapshot-pane.test.ts` cover the model's chip choice per state, the row's chip class and words, and a count change re-texting the chip in place. The served overview test's tag session is idle awaiting three background agents (a tmux-backed session a fake tmux on the lab kernel's PATH lists, its wait the states overlay row: only a live session can be awaiting, and an SDK-registered lab session's overlay row is healed to false while a hand-written judge stamp is lifted by the boot audit) and the row's chip must equal the bar's in class, words and computed dress (fill, ink, weight, spacing, radius, padding, the 0.7em rule), with the green pip beside it and no pill. The pins on the bar's chip follow it into the module (awaiting-rows, awaiting-box-sync and its Python twin, awaiting-state, awaiting-peer-name, chip-label-case, interrupt-ux, opening-state, retrying-state).

Locally: typecheck clean; extension suite 4354 pass / 0 fail; full pytest 11739 passed, 49 skipped, with the one Python pin then re-pointed and its module green.

**Review fixes (four lenses, two skeptics per finding).** The row's spoken label says the chip's words once before the tab's own phrase (it said "needs you" while the chip showed "Blocked"); the "API error" chip is keyed on the tab's own on-you rule (the flags), so a flagless, auto-retried API error with a feed-filed block reads "Blocked" like every other on-you row; `.chip` sets `line-height: normal` so the row's span chip and the bar's button chip stand the same height (the served test compares rendered height too): this reaches every span chip in the bar and the comment popover, which now stand level with the button chip, about 4 to 5 px shorter than before at the 13 px base; the stylesheet's size note and the module's header say only what holds; a test case where only the chip changes (a peer's colour) proves the model comparison reads it.

**Manager's review.** `ChipState` moves into `status-chip.ts` beside its labels and the label map is `satisfies Record<ChipState, string>`, keeping main's compile-time exhaustiveness (a state added without a word fails to compile); `statusChip`'s `doc` parameter now reaches the peer's name node too (`hostPartsNodes` builds in the document it is handed), so a fake document's chip carries a fake document's name node and the module test needs no global swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
