### PR TITLE
The Files control in the dashboard bar is off by default; the gear setting adds it

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -284,10 +284,12 @@ find past work: the search box reaches every session, live or closed.
 
 The Files pane holds the file viewer in a column of its own, beside the chat
 and the feed, so an open file covers neither. While the pane is open, a file
-link clicked in the chat opens in it. When it is closed, the gear's **File
-links open in** setting decides where a link opens: over the pane you clicked
-(the default), or in the Files pane, which then opens and stays open; on a
-phone, closing the file takes you back to the tab you came from. The folder
+link clicked in the chat opens in it. When it is closed and the Files control
+is on, the gear's **File links open in** setting decides where a link opens:
+over the pane you clicked (the default), or in the Files pane, which then
+opens and stays open; with the control off (the default), a link always opens
+over the pane you clicked. On a phone, closing the file takes you back to the
+tab you came from. The folder
 shown under the chat (the session's working directory), the **Directory** row
 of the **System context** card and **Browse files** on a tab's right-click menu
 open a listing of that folder by the same rule: in this pane while it is open
@@ -295,8 +297,10 @@ or when the setting names it, otherwise over the chat. Pick a file in the
 listing and it opens where the listing is. Selecting a passage in the viewer
 puts the quote in the chat's composer, as it does from the viewer over the
 chat. When no file is open, the pane lists the files most recently opened in
-it; click one to open it again. The pane is off by default; the bottom bar
-turns it on, and on a phone it is a tab like the others.
+it; click one to open it again. The pane and its control are both off by
+default: the gear's **Files control in the dashboard bar** setting adds a
+Files toggle to the bottom bar (on a phone, a Files tab like the others), and
+that toggle turns the pane on.
 
 ## Automatic nudges
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -49566,7 +49566,7 @@ var F={chat:document.getElementById('f-chat'),fleet:document.getElementById('f-f
 // bell's `.on`, the class _LANDING_PUSH_JS paints from the master + this device's subscription and the
 // slash rule keys on, until the next paint event. A tab or a reveal decides which pane shows, nothing else.
 var B=bar.querySelectorAll('button[data-pane]'),KT='romp-mobile-tab';
-function filesCtlM(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}   // the gear's Files-control setting (T317): the same read the pane controller makes, which parses after this script
+function filesCtlM(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !!(st&&st.showFilesControl===true);}catch(e){return false;}}   // the gear's Files-control setting (T317; off by default since T317b: shown only when the store holds the literal true under the fresh key, never the T317-era filesControl a whole-object save merged in): the same read the pane controller makes, which parses after this script
 function show(p){if(p==='files'&&!filesCtlM())p='chat';   // the Files tab is hidden while its control is off: the chat shows instead
 if(!F[p])return;document.body.setAttribute('data-tab',p);for(var k in F)if(F[k])F[k].classList.toggle('m-on',k===p);   // a pane this shell lacks is skipped, never a TypeError
 for(var i=0;i<B.length;i++)B[i].classList.toggle('on',B[i].getAttribute('data-pane')===p);
@@ -50054,13 +50054,16 @@ _LANDING_COLLAPSE_JS = """
   function saveP(){try{localStorage.setItem(PK,JSON.stringify(po));}catch(e){}}
   var LBL={chat:'chat',fleet:'fleet',feed:'feed',timeline:'timeline',files:'files pane'};
   // THE FILES CONTROL'S OWN SETTING (T317, the user 2026-09-10): the gear's "Files control in the dashboard bar"
-  // (romp:settings.filesControl, gear.js; shown unless the store holds the literal false). Off: the rail's Files
+  // (romp:settings.showFilesControl, gear.js; hidden unless the store holds the literal true: OFF by default since T317b,
+  // the user 2026-09-10, who wants the control asked for, not shipped. A FRESH key: the T317-era gear saved its merged-in
+  // filesControl: true on any settings change, so that key cannot tell a chosen on from a merged-in one and is never read).
+  // Off: the rail's Files
   // toggle and the phone's Files tab are hidden (body.no-files-control), an open Files pane closes on the same
   // apply, the pane cannot be brought forward (togglePane refuses 'files': the palette command, a stale relay),
   // and the panes are told the pane is unavailable (avail.files below), so a file link set to open there opens
   // over the pane clicked (ui/webview/file-route.ts). The gear writes the store from the feed iframe, another
   // document, so the storage listener below is the event that re-applies it here.
-  function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}
+  function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !!(st&&st.showFilesControl===true);}catch(e){return false;}}
   // The pane KEYS, from _PANE_ORDER (the one list of panes), so a pane added there is broadcast below without
   // anyone remembering this block. The panes learn which panes are ON SCREEN from the shell, which holds that
   // state: {romp:'panes',on:{key:bool}} goes to every pane iframe on every apply(), a toggle being the event

--- a/tests/test_files_pane.py
+++ b/tests/test_files_pane.py
@@ -239,28 +239,34 @@ class Shell(unittest.TestCase):
                       "c.contains('po-fleet')?'fleet-pane':'chat-pane';},'files-pane');", self.html)
 
     def test_the_files_controls_own_setting_hides_it_in_both_layouts(self):
-        # T317 (the user 2026-09-10): the gear's "Files control in the dashboard bar" (romp:settings.filesControl,
-        # shown unless the store holds the literal false). The shell reads the gear's store key itself, hides the
+        # T317 (the user 2026-09-10): the gear's "Files control in the dashboard bar" (romp:settings.showFilesControl,
+        # hidden unless the store holds the literal true: OFF by default since T317b; a FRESH key, since the T317-era gear's
+        # whole-object save left filesControl: true in any profile that touched a setting). The shell reads the gear's store key itself, hides the
         # rail's toggle and the phone's tab by one body class, closes an open pane on the same apply, refuses to
         # bring the pane forward, tells the panes it is unavailable, and the phone's switcher never shows a hidden
         # tab (a stored romp-mobile-tab, a relay). Executed under node in tests/test_pane_state_broadcast.py.
         _has(self, "body.no-files-control .rail-btn[data-pane=files],body.no-files-control #mtabs button[data-pane=files]{display:none}", self.html)
         js = km._LANDING_COLLAPSE_JS
-        _has(self, "function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !(st&&st.filesControl===false);}catch(e){return true;}}", js)
+        _has(self, "function filesCtl(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !!(st&&st.showFilesControl===true);}catch(e){return false;}}", js)
+        _has(self, "function filesCtlM(){try{var st=JSON.parse(localStorage.getItem('romp:settings')||'null');return !!(st&&st.showFilesControl===true);}catch(e){return false;}}", km._LANDING_MOBILE_JS)   # the phone's read agrees: only the literal true
+        self.assertNotIn("st.filesControl", js + km._LANDING_MOBILE_JS, "the T317-era key is never read: a whole-object save merged its true into profiles that never touched the box")
         _has(self, "document.body.classList.toggle('no-files-control',!ctl);", js)
         _has(self, "if(k==='files'&&!filesCtl())return;", js)
         _has(self, "return {romp:'panes',on:on,avail:{files:filesCtl()}};", js)
         _has(self, "window.addEventListener('storage',apply);", js)   # the gear writes from another document: this is the event
         mob = km._LANDING_MOBILE_JS
         _has(self, "function show(p){if(p==='files'&&!filesCtlM())p='chat';", mob)
-        # the gear's row, in the panes section beside "File links open in", shown by default; the chat's route reads the word
+        # the gear's row, in the panes section beside "File links open in", UNCHECKED by default (T317b); the chat's route reads the word
         gear = (UI / "gear.js").read_text()
-        _has(self, "<input type=checkbox id=rs-filesctl checked>", gear)
+        _has(self, "<input type=checkbox id=rs-filesctl>", gear)
+        self.assertNotIn("id=rs-filesctl checked", gear, "off by default: the box is not pre-checked")
+        self.assertEqual(gear.count("showFilesControl: false, stripGroupRows"), 2, "the gear's load defaults (the assign and its catch) say off")
+        _has(self, "delete o.filesControl; return o; } catch (e) {", gear)   # load() drops the T317-era key, so the next save leaves it behind
         # the box has a NAME OF ITS OWN in the gear's one var list (review find: a second `fc` shadowed the feed's
         # collapsed box, so the new row was dead and the feed box wrote this setting)
         _has(self, "fsc = document.getElementById('rs-filesctl')", gear)
-        _has(self, "if (fsc) fsc.addEventListener('change', function () { var s = load(); s.filesControl = fsc.checked; save(s); });", gear)
-        _has(self, "if (fsc) fsc.checked = (s.filesControl !== false);", gear)
+        _has(self, "if (fsc) fsc.addEventListener('change', function () { var s = load(); s.showFilesControl = fsc.checked; save(s); });", gear)
+        _has(self, "if (fsc) fsc.checked = (s.showFilesControl === true);", gear)
         self.assertEqual(gear.count("fc = document.getElementById("), 1, "fc is the feed's collapsed box alone")
         self.assertEqual(gear.count("fsc = document.getElementById("), 1)
         # the palette's entry for the pane is not listed while the control is hidden (re-read at every open)
@@ -274,7 +280,7 @@ class Shell(unittest.TestCase):
         _has(self, "fileLinkRoute(settings.fileLinkPane, window.parent !== window, panesOn.files === true, panesAvail.files !== false)", render)
         # the hint in the pane stays true: it speaks of the pane being open or closed, never of the control
         files = (UI / "files.ts").read_text()
-        _has(self, "To open them here while it is closed, set File links open in to The Files pane in the gear.", files)
+        _has(self, "To open them here while it is closed, turn on the Files control in the dashboard bar and set File links open in to The Files pane in the gear.", files)
 
     def test_mobile_tab_and_the_palette_command(self):
         _has(self, "#chat-pane,#fleet-pane,#feed-pane,#files-pane,#tl-pane{display:contents!important}", self.html)

--- a/tests/test_files_pane_toggle_served.py
+++ b/tests/test_files_pane_toggle_served.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """T317 (the user 2026-09-10): clicking the dashboard's Files control opened the timeline in a side pane instead of
 the Files pane. Reproduction and guard on the real shell page (`/`) of a hermetic kernel: the desktop rail's Files
-toggle and the phone layout's Files tab open the Files pane, and the gear's "Files control in the dashboard bar"
-setting (T317 add-on) hides both, closes an open pane and refuses a bring-forward. With FILES_SHOTS=<dir> the driver
-writes screenshots (the control shown, and hidden). Skips LOUDLY without
+toggle and the phone layout's Files tab open the Files pane once the gear's "Files control in the dashboard bar"
+setting (T317 add-on) is on; OFF by default since T317b (the user 2026-09-10): a fresh store hides both, closes a pane
+an earlier session left open and refuses a bring-forward, and the gear's write (heard through the storage event) shows
+the control without a reload. With FILES_SHOTS=<dir> the driver writes screenshots (the control shown, and hidden; the
+bottom bar with the control hidden by default and shown after the toggle, dark and light). Skips LOUDLY without
 the extension deps or a Playwright browser. SYNTHETIC fixtures only (the notes-api demo world: session web)."""
 import json
 import os
@@ -82,7 +84,25 @@ for (const pass of cfg.passes) {
   const before = await measure();
   if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_shell-files-" + pass.name + "-before.png", fullPage: false }); }
   let after = null;
-  if (pass.hidden) {
+  if (pass.toggle) {
+    // the bottom bar, hidden by default: shots in both themes (the shell's light theme is body.theme-light), clipped to the bar
+    const barClip = () => page.evaluate(() => { const rs = Array.from(document.querySelectorAll(".rail-btn")).map((b) => b.getBoundingClientRect()).filter((r) => r.width > 0);   // a hidden button's box is empty: not the bar's
+      const top = Math.min(...rs.map((r) => r.top)), bottom = Math.max(...rs.map((r) => r.bottom)); return { x: 0, y: Math.max(0, Math.floor(top) - 8), width: 1400, height: Math.ceil(bottom - top) + 16 }; });
+    if (cfg.shots) { const c = await barClip(); await page.screenshot({ path: cfg.shots + "/romp_shell-files-control-default-hidden-dark.png", clip: c });
+      await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(200);
+      await page.screenshot({ path: cfg.shots + "/romp_shell-files-control-default-hidden-light.png", clip: c });
+      await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(100); }
+    // the gear's write, from the feed iframe (the gear's own document): the shell hears it through its storage listener
+    const feed = page.frames().find((f) => f.url().includes("/feed"));
+    if (!feed) { console.error("no feed frame: " + page.frames().map((f) => f.url()).join(" ")); process.exit(1); }
+    await feed.evaluate(() => { const s = JSON.parse(localStorage.getItem("romp:settings") || "{}"); s.showFilesControl = true; localStorage.setItem("romp:settings", JSON.stringify(s)); });
+    await page.waitForTimeout(800);
+    after = await measure();
+    if (cfg.shots) { const c = await barClip(); await page.screenshot({ path: cfg.shots + "/romp_shell-files-control-shown-dark.png", clip: c });
+      await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(200);
+      await page.screenshot({ path: cfg.shots + "/romp_shell-files-control-shown-light.png", clip: c });
+      await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(100); }
+  } else if (pass.hidden) {
     // the control hidden by the gear's setting: nothing to click; the palette's command and a relay are refused
     await page.evaluate(() => { window.__rompPaneToggle && window.__rompPaneToggle("files", true); });
     await page.waitForTimeout(600);
@@ -176,14 +196,18 @@ class ServedFilesPaneToggle(unittest.TestCase):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
             json.dump({"shell": "http://127.0.0.1:%d/?token=%s" % (self.port, self.token),
-                       "passes": [{"name": "desktop", "width": 1400, "height": 900, "mobile": False},
-                                  {"name": "phone", "width": 390, "height": 844, "mobile": True, "touch": True},
-                                  # the control hidden by the gear's setting, with the pane left OPEN by an earlier session
+                       # the control is OFF by default (T317b): the two clicking passes turn it on through the gear's store key
+                       "passes": [{"name": "desktop", "width": 1400, "height": 900, "mobile": False, "storage": {"romp:settings": json.dumps({"showFilesControl": True})}},
+                                  {"name": "phone", "width": 390, "height": 844, "mobile": True, "touch": True, "storage": {"romp:settings": json.dumps({"showFilesControl": True})}},
+                                  # the control hidden: a store the T317-era gear wrote (its whole-object save merged filesControl: true into any
+                                  # profile that touched a setting; the key is never read), with the pane left OPEN by that earlier session
                                   {"name": "desktop-hidden", "width": 1400, "height": 900, "mobile": False, "hidden": True,
-                                   "storage": {"romp:settings": json.dumps({"filesControl": False}),
+                                   "storage": {"romp:settings": json.dumps({"compact": True, "filesControl": True}),
                                                "romp-panes": json.dumps({"chat": True, "fleet": False, "feed": True, "timeline": True, "files": True})}},
                                   {"name": "phone-hidden", "width": 390, "height": 844, "mobile": True, "touch": True, "hidden": True,
-                                   "storage": {"romp:settings": json.dumps({"filesControl": False}), "romp-mobile-tab": "files"}}],
+                                   "storage": {"romp-mobile-tab": "files"}},
+                                  # the default, then the gear's toggle: its write from the feed's document reaches the shell as a storage event
+                                  {"name": "desktop-toggle", "width": 1400, "height": 900, "mobile": False, "toggle": True}],
                        "shots": os.environ.get("FILES_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -212,10 +236,11 @@ class ServedFilesPaneToggle(unittest.TestCase):
         # the timeline band stays exactly as it was: the Files toggle never touches it
         self.assertEqual(after["panes"]["tl-pane"]["display"], d["before"]["panes"]["tl-pane"]["display"], "the Files toggle leaves the timeline as it was")
         self.assertEqual("po-timeline" in after["body"].split(), "po-timeline" in d["before"]["body"].split())
-        # the control shown (the default): both layouts offer it
-        self.assertTrue(next(b for b in after["rail"] if b["pane"] == "files")["shown"], "the rail's Files toggle shows by default: %r" % after["rail"])
-        self.assertTrue(next(b for b in r["phone"]["after"]["tabs"] if b["pane"] == "files")["shown"], "the phone's Files tab shows by default")
-        # the control HIDDEN by the gear's setting (T317): the toggle and the tab are gone in both layouts, the pane an
+        # the control shown, by the gear's setting (on in these passes' store): both layouts offer it
+        self.assertTrue(next(b for b in after["rail"] if b["pane"] == "files")["shown"], "the rail's Files toggle shows with the setting on: %r" % after["rail"])
+        self.assertTrue(next(b for b in r["phone"]["after"]["tabs"] if b["pane"] == "files")["shown"], "the phone's Files tab shows with the setting on")
+        # the control hidden (T317b): the desktop store is the T317-era gear's, filesControl: true merged in by a whole-object
+        # save (never read); the phone store has no settings at all. The toggle and the tab are gone in both layouts, the pane an
         # earlier session left open is closed, a bring-forward is refused, and a phone left on the Files tab shows the chat
         h = r["desktop-hidden"]
         for k in ("before", "after"):
@@ -230,6 +255,15 @@ class ServedFilesPaneToggle(unittest.TestCase):
         self.assertFalse(next(b for b in ph["tabs"] if b["pane"] == "files")["shown"], "the phone's Files tab is hidden: %r" % ph["tabs"])
         self.assertEqual(ph["tab"], "chat", "a stored Files tab falls to the chat: %r" % ph["tab"])
         self.assertTrue(ph["panes"]["chat-pane"]["iframe"]["mOn"] and not ph["panes"]["files-pane"]["iframe"]["mOn"])
+        # the default, then the gear's toggle (T317b): a fresh shell hides the control; the gear's write from the feed's
+        # document shows it without a reload, and the panes are told the pane is available again
+        t = r["desktop-toggle"]
+        self.assertIn("no-files-control", t["before"]["body"].split(), "a fresh store hides the control: %r" % t["before"]["body"])
+        self.assertFalse(next(b for b in t["before"]["rail"] if b["pane"] == "files")["shown"], "the rail's Files toggle is hidden by default: %r" % t["before"]["rail"])
+        self.assertEqual(len([b for b in t["before"]["rail"] if b["shown"]]), 4, "the four other toggles show: %r" % t["before"]["rail"])
+        self.assertNotIn("no-files-control", t["after"]["body"].split(), "the gear's write shows the control: %r" % t["after"]["body"])
+        self.assertTrue(next(b for b in t["after"]["rail"] if b["pane"] == "files")["shown"], "the rail's Files toggle appears after the toggle: %r" % t["after"]["rail"])
+        self.assertEqual(len([b for b in t["after"]["rail"] if b["shown"]]), 5)
         m = r["phone"]["after"]
         self.assertTrue(m["mobile"], "the phone pass is the one-pane layout: %r" % m)
         self.assertEqual(m["tab"], "files", "the Files tab is the one showing: %r" % m)

--- a/tests/test_pane_state_broadcast.py
+++ b/tests/test_pane_state_broadcast.py
@@ -105,7 +105,8 @@ console.log(JSON.stringify(out));
 
 
 # ── the Files control hidden by its gear setting (T317) ─────────────────────────────────────────────────
-# The store holds romp:settings.filesControl false and the Files pane is ON (a desktop session left it open):
+# The store holds NO romp:settings at all (a fresh install: the control is OFF by default since T317b, the user
+# 2026-09-10) and the Files pane is ON (a desktop session of the shown-by-default era left it open):
 # the boot apply hides the control (body.no-files-control), closes the pane and saves that, tells the panes the
 # pane is unavailable (avail.files false), and refuses to bring it forward; a phone left on the Files tab is
 # switched to the chat. Flipping the store back on (the gear's write, heard through the storage listener) shows
@@ -120,7 +121,7 @@ out.refused = { poFiles: CLS.has('po-files'), chat: last('chat'), counts: counts
 MOBILE = true; TAB = 'files'; SWITCHED.length = 0; window.__rompPaneToggle('feed');   // any apply (here a feed flip) on a phone left on the Files tab
 out.phone = { switched: SWITCHED.slice() };
 MOBILE = false;
-STORE['romp:settings'] = JSON.stringify({ filesControl: true }); STORAGE_LISTENERS.forEach((f) => f());   // the gear turns it back on
+STORE['romp:settings'] = JSON.stringify({ showFilesControl: true }); STORAGE_LISTENERS.forEach((f) => f());   // the gear turns it back on
 out.shown = { cls: CLS.has('no-files-control'), chat: last('chat') };
 window.__rompPaneToggle('files', true);
 out.reopened = { poFiles: CLS.has('po-files'), chat: last('chat') };
@@ -146,7 +147,7 @@ class HiddenControlBookmark(unittest.TestCase):
         harness = (_COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(keys))
                    .replace("const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {};",
                             "const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {"
-                            "'romp:settings': JSON.stringify({ filesControl: false }), 'romp-panes': " + json.dumps(stored) + " };")
+                            "'romp:settings': JSON.stringify({ filesControl: true }), 'romp-panes': " + json.dumps(stored) + " };")   # the T317-era key's true (a whole-object save merged it in): never read, the control stays hidden (T317b)
                    .replace("global.location = { search: '' };", "global.location = { search: '?panes=chat,files' };")
                    .replace("global.URLSearchParams = class { get() { return null; } };", "global.URLSearchParams = class { get(k) { return k === 'panes' ? 'chat,files' : null; } };"))
         cls.stored = stored
@@ -167,7 +168,7 @@ class HiddenControl(unittest.TestCase):
         harness = (_COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(keys))
                    .replace("const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {};",
                             "const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {"
-                            "'romp:settings': JSON.stringify({ filesControl: false }), 'romp-panes': JSON.stringify({ chat: true, fleet: false, feed: true, timeline: true, files: true }) };"
+                            "'romp-panes': JSON.stringify({ chat: true, fleet: false, feed: true, timeline: true, files: true }) };"   # no romp:settings: the default hides (T317b)
                             "const STORAGE_LISTENERS = [], SWITCHED = [];")
                    .replace("global.addEventListener = () => {};", "global.addEventListener = (ev, f) => { if (ev === 'storage') STORAGE_LISTENERS.push(f); };")
                    + "window.__rompMobileTab = (p) => { SWITCHED.push(p); TAB = p; };\n")
@@ -203,12 +204,17 @@ class Broadcast(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.keys = [k for k, _ in km._PANE_ORDER]
-        cls.out = _run(_COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(cls.keys)) + km._LANDING_COLLAPSE_JS + _COLLAPSE_DRIVER)
+        # the control turned ON by its gear setting (off by default since T317b): the toggles the driver makes are the
+        # user's clicks on a control they asked for
+        harness = _COLLAPSE_HARNESS.replace("__KEYS__", json.dumps(cls.keys)).replace(
+            "const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = {};",
+            "const POSTED = {}, LOADS = {}, CLS = new Set(['po-chat', 'po-feed', 'po-timeline']), STORE = { 'romp:settings': JSON.stringify({ showFilesControl: true }) };")
+        cls.out = _run(harness + km._LANDING_COLLAPSE_JS + _COLLAPSE_DRIVER)
 
     def test_the_boot_apply_tells_every_pane_the_set_as_the_flags_stand(self):
         self.assertEqual(self.out["boot"]["counts"], {k: 1 for k in self.keys}, "one message per pane at boot")
         self.assertEqual(self.out["boot"]["chat"], {"romp": "panes", "on": {"chat": True, "timeline": True, "fleet": False, "feed": True, "files": False},
-                                                     "avail": {"files": True}})   # avail: the Files control's setting rides every tell (T317)
+                                                     "avail": {"files": True}})   # avail: the Files control's setting rides every tell (T317); on here by the store (off by default since T317b)
         self.assertEqual(self.out["boot"]["files"], self.out["boot"]["chat"], "every pane hears the same set")
 
     def test_a_toggle_is_the_event_and_a_no_change_toggle_is_silent(self):
@@ -316,10 +322,35 @@ console.log(JSON.stringify(out));
 """
 
 
+class MobileScriptDefault(unittest.TestCase):
+    """The phone script with NO settings store (a fresh install): the Files control is off by default (T317b, the user
+    2026-09-10), so its tab is hidden and a switch aimed at it (a relay, a stored tab) shows the chat instead."""
+    @classmethod
+    def setUpClass(cls):
+        driver = r"""
+const out = {};
+out.boot = { tab: TAB };
+window.__rompMobileTab('files');
+out.files = { tab: TAB, store: STORE['romp-mobile-tab'] || null };
+window.__rompMobileTab('feed');
+out.feed = { tab: TAB };
+console.log(JSON.stringify(out));
+"""
+        cls.out = _run(_MOBILE_HARNESS + km._LANDING_MOBILE_JS + driver)
+
+    def test_a_switch_to_the_hidden_files_tab_shows_the_chat(self):
+        self.assertEqual(self.out["files"]["tab"], "chat", "the Files tab is hidden by default: the chat shows instead")
+        self.assertEqual(self.out["feed"]["tab"], "feed", "every other tab switches as ever")
+
+
 class MobileScript(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.out = _run(_MOBILE_HARNESS + km._LANDING_MOBILE_JS + _MOBILE_DRIVER)
+        # the Files control turned ON by its gear setting (off by default since T317b): the taps below land on a tab
+        # the person asked for
+        harness = _MOBILE_HARNESS.replace('const TOGGLES = [], TELLS = [], MQL = [], MSGS = [], STORE = {};', "const TOGGLES = [], TELLS = [], MQL = [], MSGS = [], STORE = { 'romp:settings': JSON.stringify({ showFilesControl: true }) };")
+        assert harness != _MOBILE_HARNESS
+        cls.out = _run(harness + km._LANDING_MOBILE_JS + _MOBILE_DRIVER)
 
     def test_the_layout_probe_answers_the_stylesheets_own_media_query(self):
         # one constant lays out the grid AND answers the JS, never two strings that can drift

--- a/ui/webview/file-route.ts
+++ b/ui/webview/file-route.ts
@@ -8,7 +8,7 @@
 //   filesOpen  the shell's Files-pane bit (render.ts panesOn.files, cached from the shell's own broadcast):
 //              the pane is ON SCREEN, a desktop column toggled on or the tab showing on a phone.
 //   filesAvail the shell's word that the Files control exists (render.ts panesAvail.files, the same broadcast):
-//              the gear's "Files control in the dashboard bar" is on (the default). Off, there is no pane to
+//              the gear's "Files control in the dashboard bar" is on (off by default since T317b). Off, there is no pane to
 //              bring forward, so a click that would have gone there opens here (T317).
 // A verdict names the TARGET: "pane" is the Files pane (the shell brings a closed one forward; the click is
 // the gesture), "here" is this document, the viewer or the file browser as a modal over the pane that was

--- a/ui/webview/files.ts
+++ b/ui/webview/files.ts
@@ -73,7 +73,7 @@ function paint(): void {
   if (open) return;
   const title = el("div", "fs-title"); title.textContent = "No file open";
   const hint = el("div", "fs-hint");
-  hint.textContent = "While this pane is open, a file or folder clicked in the chat opens here. To open them here while it is closed, set File links open in to The Files pane in the gear.";
+  hint.textContent = "While this pane is open, a file or folder clicked in the chat opens here. To open them here while it is closed, turn on the Files control in the dashboard bar and set File links open in to The Files pane in the gear.";
   const out: HTMLElement[] = [title, hint];
   if (recent.length) {
     const list = el("div", "fs-recent");

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -140,18 +140,23 @@ var GEAR_HTML =
   // the hidden select is
   // the value holder, selectPick below dresses it as a house menu like the other selects
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>File links open in</b>" +
-  '<span class=rs-sub>Where a file or folder clicked in the chat opens. While the Files pane is open, both open there. When the pane is closed, this setting decides: over the pane you clicked, or in the Files pane, which then opens and stays open. Browser dashboard only: in VS Code file links open in the editor, and a chat tab opened on its own has no Files pane.</span>' +
+  '<span class=rs-sub>Where a file or folder clicked in the chat opens. While the Files pane is open, both open there. When the pane is closed, this setting decides: over the pane you clicked, or in the Files pane, which then opens and stays open. Needs the Files control below to be on; with it off (the default), links open over the pane you clicked. Browser dashboard only: in VS Code file links open in the editor, and a chat tab opened on its own has no Files pane.</span>' +
   "<select id=rs-filelink style='display:none'>" +
   '<option value=chat>The pane you clicked</option><option value=pane>The Files pane</option>' +
   '</select>' +
   '</span></div>' +
   // the Files control itself (T317, the user 2026-09-10, who recalled a setting for it): the toggle at the bottom of
-  // the dashboard and the Files tab on a phone. Shown by default (today's behaviour). Off hides both, closes an open
-  // Files pane, and a file link set to open in the Files pane opens over the pane you clicked instead (the shell
-  // reads this store key and tells the panes: kernel.py _LANDING_COLLAPSE_JS, render.ts panesAvail).
-  '<label class=rs-row><input type=checkbox id=rs-filesctl checked>' +
+  // the dashboard and the Files tab on a phone. OFF by default (T317b, the user the same day: the control is asked for,
+  // not shipped): on shows both; off hides both, closes an open Files pane, and a file link set to open in the Files
+  // pane opens over the pane you clicked instead (the shell reads this store key and tells the panes: kernel.py
+  // _LANDING_COLLAPSE_JS, render.ts panesAvail). Only the literal true shows it, so the box is unchecked until read.
+  // The key is showFilesControl, a FRESH one (T317b review): the T317-era load() merged its default filesControl: true
+  // into the object and save() wrote the whole object on ANY change, so a profile that touched any setting in that
+  // window carries filesControl: true without ever touching this box; the old key is never read and load() drops it,
+  // so the next save leaves it behind.
+  '<label class=rs-row><input type=checkbox id=rs-filesctl>' +
   '<span><b>Files control in the dashboard bar</b>' +
-  '<span class=rs-sub>The Files toggle at the bottom of the dashboard, and the Files tab on a phone. Off hides them and closes the Files pane if it is open; file links set to open in the Files pane then open over the pane you clicked.</span>' +
+  '<span class=rs-sub>Adds the Files toggle to the bottom of the dashboard, and the Files tab on a phone. Off (the default) hides them and closes the Files pane if it is open; file links set to open in the Files pane then open over the pane you clicked.</span>' +
   '</span></label>' +
   "<div class='rs-row' style='cursor:default'><span style='flex:1 1 auto;min-width:0'><b>Text scheme</b>" +
   "<span class=rs-sub>Chat text colors only. Each option previews its own tiers — prose, the dimmer tool text, code. (Solarized Light is omitted — its tiers are made for a light page and turn muddy here.)</span>" +
@@ -296,7 +301,7 @@ function initGear(post) {
     fe = document.getElementById('rs-fileedit'),
     ths = document.getElementById('rs-thinksum'),
     ans = document.getElementById('rs-autonudge-split'), asub = document.getElementById('rs-autonudge-sub');
-  function load() { try { return Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, showSessionBadge: false, tabCtx: 'over50', fileLinkPane: 'chat', filesControl: true, stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, showSessionBadge: false, tabCtx: 'over50', fileLinkPane: 'chat', filesControl: true, stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
+  function load() { try { var o = Object.assign({ compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, showSessionBadge: false, tabCtx: 'over50', fileLinkPane: 'chat', showFilesControl: false, stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }, JSON.parse(localStorage.getItem('romp:settings') || 'null')); delete o.filesControl; return o; } catch (e) { return { compact: true, colormap: 'aurora', subgoals: true, debug: false, backend: 'sdk', defaultDir: '', showBranch: false, showSessionBadge: false, tabCtx: 'over50', fileLinkPane: 'chat', showFilesControl: false, stripGroupRows: true, denseChrome: false, collapseGaps: true, activeOnly: true }; } }
   // mirrors settings.ts tabCtxMode (this file can't import the TS module): the gauge shipped for a
   // few hours as a boolean toggle — false was an explicit hide, true the default nobody chose.
   function tabCtxMode(v) { return (v === 'always' || v === 'never') ? v : (v === false ? 'never' : 'over50'); }
@@ -322,7 +327,7 @@ function initGear(post) {
   if (dn) dn.addEventListener('change', function () { var s = load(); s.denseChrome = dn.checked; save(s); });
   if (tc) tc.addEventListener('change', function () { var s = load(); s.tabCtx = tc.value; save(s); });
   if (fl) fl.addEventListener('change', function () { var s = load(); s.fileLinkPane = fl.value; save(s); });   // webview-local pref read at click time (render.ts openPath)
-  if (fsc) fsc.addEventListener('change', function () { var s = load(); s.filesControl = fsc.checked; save(s); });   // the shell hears the store change (its storage listener) and hides or shows the control (T317)
+  if (fsc) fsc.addEventListener('change', function () { var s = load(); s.showFilesControl = fsc.checked; save(s); });   // the shell hears the store change (its storage listener) and hides or shows the control (T317)
   // ── the settings' value-picker DROPDOWNS (T117, the user 2026-08-27, screenshot: the Chat
   // tabs and Text scheme pickers rendered every option always-expanded, and the description spans
   // ran off the card's right edge). Progressive disclosure: the CLOSED state is ONE row — the
@@ -1294,7 +1299,7 @@ function initGear(post) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sbg) sbg.checked = s.showSessionBadge === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.filesControl !== false); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sbg) sbg.checked = s.showSessionBadge === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.showFilesControl === true); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // The shortcuts row: the web shell (same-origin parent) gets the customize link — it opens the

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -130,19 +130,31 @@ test("File links open in defaults to the pane you clicked; the Files pane opt-in
 });
 
 // The Files CONTROL's own setting (T317, the user 2026-09-10): whether the dashboard bar's Files toggle and the
-// phone's Files tab show at all. Shown by default (today's behaviour); only the literal false hides them, so a
-// corrupt entry may cost the preference, never the control. The shell reads the store key itself
-// (kernel.py _LANDING_COLLAPSE_JS filesCtl), so the key and the false-only rule are the contract.
-test("the Files control shows by default; hiding it round-trips, and only the literal false hides it", () => {
-  assert.equal(DEFAULT_SETTINGS.filesControl, true);
+// phone's Files tab show at all. OFF by default (T317b, the user the same day: the control is asked for, not
+// shipped); only the literal true shows them, so a corrupt entry may cost the preference, never surprise the user
+// with a control. The shell reads the store key itself (kernel.py _LANDING_COLLAPSE_JS filesCtl), so the key and
+// the true-only rule are the contract.
+test("the Files control is hidden by default; showing it round-trips, and only the literal true under the fresh key shows it", () => {
+  assert.equal(DEFAULT_SETTINGS.showFilesControl, false);
   delete store["romp:settings"];
-  assert.equal(loadSettings().filesControl, true, "a fresh install shows the control");
-  saveSettings({ filesControl: false });
-  assert.equal(loadSettings().filesControl, false, "hiding it survives a reload (localStorage)");
-  assert.equal(JSON.parse(store["romp:settings"]).filesControl, false, "the key the shell reads, the literal false");
+  assert.equal(loadSettings().showFilesControl, false, "a fresh install hides the control");
+  saveSettings({ showFilesControl: true });
+  assert.equal(loadSettings().showFilesControl, true, "showing it survives a reload (localStorage)");
+  assert.equal(JSON.parse(store["romp:settings"]).showFilesControl, true, "the key the shell reads, the literal true");
+  saveSettings({ showFilesControl: false });
+  assert.equal(loadSettings().showFilesControl, false, "turning it off again round-trips too");
+  assert.equal(JSON.parse(store["romp:settings"]).showFilesControl, false, "on-then-off leaves the literal false");
   store["romp:settings"] = JSON.stringify({ compact: true });
-  assert.equal(loadSettings().filesControl, true, "a store written before the key shows the control");
-  store["romp:settings"] = JSON.stringify({ filesControl: "no" });
-  assert.equal(loadSettings().filesControl, true, "a foreign stored value shows it: only false hides");
+  assert.equal(loadSettings().showFilesControl, false, "a store written before the key hides the control");
+  store["romp:settings"] = JSON.stringify({ showFilesControl: "yes" });
+  assert.equal(loadSettings().showFilesControl, false, "a foreign stored value hides it: only true shows");
+  // the T317-era key: that gear merged its default filesControl: true into the object and saved the whole object on
+  // ANY change, so a profile that touched any setting in that window carries filesControl: true without touching the
+  // Files box. It is never read, and the next save drops it.
+  store["romp:settings"] = JSON.stringify({ compact: true, filesControl: true });
+  assert.equal(loadSettings().showFilesControl, false, "the old key's true is a merged-in default, not an opt-in: hidden");
+  assert.equal("filesControl" in loadSettings(), false, "the old key is dropped from the loaded object");
+  saveSettings({ compact: false });
+  assert.deepEqual(Object.keys(JSON.parse(store["romp:settings"])).filter((k) => /filesControl/i.test(k)), ["showFilesControl"], "the next save leaves the old key behind and writes the fresh one");
   delete store["romp:settings"];
 });

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -20,7 +20,7 @@ export interface RompSettings {
   tabCtx: TabCtxMode;        // chat tabs: WHEN the context gauge shows beside each session name (the user 2026-08-08) — "over50" (default: only once half full, so quiet tabs stay clean), "always", or "never".
   fileLinkPane: FileLinkPane;   // where a chat file-link click opens on the WEB while the Files pane is CLOSED: "chat" (the default: the viewer over the pane you clicked) or "pane" (the Files pane, a column of its own that comes forward and stays up). An OPEN Files pane takes the click whatever this says (file-route.ts). Read at click time (render.ts openPath, and openBrowse for a folder click, which walks the same ladder); VS Code (the host editor) and standalone /chat (no shell to relay to) are unaffected.
   stripGroupRows: boolean;   // chat tabs, grouped by tag: start EVERY tag group on its own row (T264, the row breaks in render.ts). ON by default; off, the groups follow one another across the strip and wrap as they need, the untagged trail behind its divider. Per browser profile, like every setting here. Read by renderTabs and part of the strip's rebuild signature, so a gear flip repaints at once.
-  filesControl: boolean;   // the Files control (the dashboard bar's toggle, the phone's tab) shows; off hides it and closes the pane (T317)
+  showFilesControl: boolean;   // the Files control (the dashboard bar's toggle, the phone's tab) shows when on; off, the default since T317b (the user 2026-09-10), hides it and closes the pane (T317). A FRESH key: the T317-era gear merged its default `filesControl: true` into the object and saved it whole on any change, so that key cannot tell a chosen on from a merged-in one; it is never read and is dropped on the next save
   chatScheme: ChatScheme;    // chat TEXT scheme (the user 2026-08-24): raises body-text contrast without collapsing the tool-dimmer-than-prose hierarchy. A scheme = a text-tier variable set (styles.css body.scheme-*); "default" applies nothing — today's values exactly.
   chatTabTheme: ChatTabTheme;   // LEGACY, derived (2026-08-28): the chat TAB STRIP's appearance (T113). Now computed from `theme` on every load/save ("classic" -> classic strip, anything else -> the yatharth strip) so older panes/extension builds keep working; never set it directly.
   theme: Theme;   // the OVERALL dashboard theme (the user 2026-08-27, promoting the tab-strip setting): "classic" = the pre-720 dark look; "yatharth" = dark + the contributed strip aesthetic (what chatTabTheme:"yatharth" was); "yatharth-light" = the warm light theme (body.theme-light + the yatharth strip). Migration: a store written before `theme` existed seeds it from chatTabTheme.
@@ -62,7 +62,7 @@ export function tabCtxMode(v: unknown): TabCtxMode {
 // hand-written "why" as their line; they show the distiller's summary instead (the why demotes to a hover).
 // compact defaults ON (the user 2026-07-14): a fresh install reads the tidy transcript
 // (thinking hidden, tool runs folded); the gear opts back into the full stream.
-export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, showSessionBadge: false, tabCtx: "over50", fileLinkPane: "chat", stripGroupRows: true, filesControl: true, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
+export const DEFAULT_SETTINGS: RompSettings = { compact: true, colormap: "aurora", subgoals: true, showIndexJudges: false, showTriageJudges: false, backend: "sdk", defaultDir: "", showBranch: false, showSessionBadge: false, tabCtx: "over50", fileLinkPane: "chat", stripGroupRows: true, showFilesControl: false, chatScheme: "default", chatTabTheme: "classic", theme: "classic", denseChrome: false };
 const KEY = "romp:settings";
 
 export function loadSettings(): RompSettings {
@@ -73,7 +73,8 @@ export function loadSettings(): RompSettings {
       const s = { ...DEFAULT_SETTINGS, ...parsed };
       s.tabCtx = tabCtxMode(s.tabCtx);   // a store written by the boolean-era gear holds true/false
       s.fileLinkPane = fileLinkPane(s.fileLinkPane);   // only "pane" opts in; anything else reads as the default
-      s.filesControl = s.filesControl !== false;   // only the literal false hides the control; anything else shows it (the default)
+      s.showFilesControl = s.showFilesControl === true;   // only the literal true shows the control; anything else hides it (the default since T317b)
+      delete (s as Record<string, unknown>).filesControl;   // the T317-era key (merged in by that gear's whole-object save): never read, gone on the next save
       s.chatScheme = chatScheme(s.chatScheme);   // unknown/legacy values normalize to "default"
       // theme migration (2026-08-28): a store from before `theme` existed seeds it from the old
       // tab-strip pick, so a yatharth strip stays a yatharth strip. chatTabTheme itself is DERIVED


### PR DESCRIPTION
The user (2026-09-10): the Files toggle in the dashboard's bottom bar (and the Files tab on a phone) should not ship shown; the gear's **Files control in the dashboard bar** setting (the T317 add-on) turns it on.

**Change.** The default flips, and the opt-in moves to a **fresh key**, `showFilesControl`: the T317-era gear merged its default `filesControl: true` into the settings object and saved the whole object on any change, so a profile that touched any gear setting between that change's landing and this one carries `filesControl: true` without anyone touching the Files box, and the old key cannot tell a chosen on from a merged-in one. `DEFAULT_SETTINGS.showFilesControl` is `false`; `loadSettings` keeps only the literal `true` and drops the old key from the loaded object (the next save leaves it behind); the gear's load defaults and its checkbox start off, its `load()` drops the old key too, and its change handler writes the new one; both shell reads (`filesCtl` in the pane controller, `filesCtlM` in the phone script) answer true only for the new key's literal `true`, false on any failure, and never read the old key. The guide's Files paragraph says the pane and its control are both off by default and what the setting adds; the file-route comment no longer calls the control on by default; the "File links open in" copy (the gear row's sub, the guide's sentence, the Files page's empty-state line) says the Files-pane choice needs the control on, since with it off a link always opens over the pane clicked.

**Tests.** `settings.test.ts` pins the default, the true-only rule both ways, on-then-off leaving the literal false, and the migration (a store with the old key true and no new key is hidden; the old key is dropped from the loaded object and left behind by the next save). `tests/test_files_pane.py` pins both shell reads, the unchecked box and the gear's load defaults. `tests/test_pane_state_broadcast.py`'s toggle harnesses turn the control on through the store (the taps are on a control the person asked for); its bookmark class runs with the old key's true (hidden); its hidden-control class runs with no settings store at all (the default hides, closes a pane an earlier session left open, refuses a bring-forward, switches a phone off the Files tab); a new phone case shows a switch to the hidden Files tab landing on the chat. The served shell test's clicking passes turn the control on through the new key, its desktop-hidden pass carries the T317-era store (old key true: hidden, the pane closed), its phone-hidden pass no store, and a new pass boots a fresh shell (the control hidden), writes the setting from the feed's document and sees the storage event show the control without a reload, with screenshots of the bottom bar hidden and shown, dark and light.

Locally: typecheck clean; the settings and file-route tests green; the three Python modules green (55 passed). Full suites running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
