### PR TITLE
Billing is reachable from a terminal: POST /auth and `romp billing` read or switch what a session bills, and a session never picked says so

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -677,6 +677,7 @@ EOF
     _romp_cmd "romp perf client [--minutes <n>|--json]" - "Browser-side performance of the open dashboards (client-diag.jsonl, surface perf): handler ms/min by frame type with window p50/p90/p99 and max, main-thread-free p90, long animation frames and their attributed callbacks, the worst minute, heap and DOM, the slowest frames — per dashboard and pane over the last <n> minutes (default 10)"
     _romp_cmd "romp api-health"            -            "The API-health signal across your sessions (GET /api-health as JSON: per-key/family retry rates and a thrash state)"
     _romp_cmd "romp fork <parent> <name>"  -            "Branch a session into a new parallel one (parent untouched; --at <uuid> picks the cut)"
+    _romp_cmd "romp billing <session> [login|key]" -    "Which account an SDK session bills (login or API key): bare reads it, a value switches it (mid-turn it waits for the turn to end)"
     _romp_cmd "romp rename <session> <name>" -          "Rename a session (uuid-keyed: mailboxes, goals and history all follow)"
     _romp_cmd "romp move <session> <dir>"   -           "Move an SDK session's working directory (its conversation follows; mid-turn it waits for the turn to end)"
     _romp_cmd "romp color <session> [<#hex|slot>]" -    "Recolor a session's identity swatch (palette hex or slot number; no color arg reads bg/fg)"
@@ -1439,6 +1440,81 @@ if [[ "${1:-}" == "fork" ]]; then
     _err="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]).get("error") or sys.argv[1])' "$_resp" 2>/dev/null || printf '%s' "$_resp")"
     echo "romp fork: refused — $_err" >&2
     exit 1
+fi
+
+# Which account an SDK session bills (the user 2026-09-11, who wants the switch reachable from a
+# terminal and a script, not only from the tab menu): the kernel's /auth route, the tab menu's Billing
+# pick as a one-shot route beside /fork. Bare, it READS (GET /auth?id=): one line naming the side the
+# session bills, whether a switch is still applying, the login account, and whether the session was
+# ever picked (an unpicked one bills the machine's default). With `login` or `key` it SWITCHES (POST
+# /auth) and prints the kernel's answer the same way: a quiet session reconnects to apply; a mid-turn
+# one parks the switch and the line says so. The kernel refuses a side this machine cannot bill and
+# names why. No key material is ever printed: the key is the label "API key". A kernel that answers
+# with a refusal is reported AS ITSELF (a refused token, a kernel without the route), never as "not
+# reachable" — the api-health shape.
+if [[ "${1:-}" == "billing" ]]; then
+    shift
+    _bl_usage="usage: romp billing <session> [login|key]"
+    if [[ $# -lt 1 || $# -gt 2 || -z "$1" || "$1" == -* ]]; then echo "$_bl_usage" >&2; exit 2; fi
+    _bl_who="$1"; _bl_val="${2:-}"
+    if [[ -n "$_bl_val" && "$_bl_val" != "login" && "$_bl_val" != "key" ]]; then echo "$_bl_usage" >&2; exit 2; fi
+    _tok="$(_romp_token)"
+    _kport="${ROMP_KERNEL_PORT:-29855}"
+    if [[ -z "$_tok" ]]; then
+        echo "romp billing: the kernel isn't running (no serve token). Start romp (the login service, or \`romp up\`) first." >&2
+        exit 1
+    fi
+    # The HTTP status rides the reply's last line (-w), so a refusal is reported as itself: a refused
+    # token (401/403) and a kernel that predates the route (404) are not "kernel not reachable".
+    if [[ -n "$_bl_val" ]]; then
+        _payload="$(python3 -c 'import json,sys; print(json.dumps({"id": sys.argv[1], "value": sys.argv[2]}))' "$_bl_who" "$_bl_val")"
+        _raw="$(_romp_token_cfg | curl -s -m 30 --config - -w '\n%{http_code}' -X POST "http://127.0.0.1:$_kport/auth" \
+                    -H 'Content-Type: application/json' -d "$_payload")" \
+            || { echo "romp billing: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    else
+        _bl_q="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$_bl_who")"
+        _raw="$(_romp_token_cfg | curl -s -m 10 --config - -w '\n%{http_code}' "http://127.0.0.1:$_kport/auth?id=$_bl_q")" \
+            || { echo "romp billing: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    fi
+    _code="${_raw##*$'\n'}"
+    _body="${_raw%$'\n'*}"; _body="${_body%$'\n'}"
+    case "$_code" in
+        2??|400) ;;
+        401|403) echo "romp billing: the kernel refused the serve token (HTTP $_code): a stale ROMP_SERVE_TOKEN, or a state dir that is not this kernel's" >&2; exit 1 ;;
+        404) echo "romp billing: this kernel has no /auth route (HTTP 404): it predates this command, restart romp" >&2; exit 1 ;;
+        *)   echo "romp billing: the kernel answered HTTP $_code on :$_kport" >&2; exit 1 ;;
+    esac
+    # The kernel's answer as one line. ok:false (a refusal, a 400) prints its reason and exits 1. The
+    # fields are the tab hover's (auth, authLive, authPending, authPicked, acct); nothing here is a key.
+    printf '%s' "$_body" | python3 -c '
+import json, sys
+try:
+    r = json.load(sys.stdin)
+except ValueError:
+    sys.stderr.write("romp billing: the kernel answered something that is not JSON\n"); sys.exit(1)
+if not isinstance(r, dict) or not r.get("ok"):
+    why = (r.get("error") if isinstance(r, dict) else None) or "no reason given"
+    sys.stderr.write("romp billing: refused — %s\n" % why); sys.exit(1)
+word = {"login": "the login", "key": "the API key"}.get(r.get("auth") or "", "")
+name = r.get("name") or r.get("id") or sys.argv[1]
+if r.get("queued"):
+    want = "the login" if sys.argv[2] == "login" else "the API key"
+    line = "%s: queued — the switch to %s applies once the session can take it: it is mid-turn, compacting, being moved, held back by a usage limit, or has changes queued ahead" % (name, want)
+    if word:
+        line += " (bills %s until then)" % word
+elif not word:
+    sys.stderr.write("romp billing: billing unknown for %s — not an SDK session, or the kernel has not reported it yet\n" % name); sys.exit(1)
+elif not r.get("authPicked"):
+    line = "%s: unpicked (bills %s, the default for this machine)" % (name, word)
+else:
+    line = "%s: bills %s" % (name, word)
+    if r.get("authPending"):
+        line += " (applying — not confirmed yet)"
+    if r.get("auth") == "login" and r.get("acct"):
+        line += " · login account %s" % r["acct"]
+print(line)
+' "$_bl_who" "$_bl_val"
+    exit $?
 fi
 
 # Rename a session (the user 2026-08-23, via the SynthProbe fleet restructuring): the kernel's

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -387,6 +387,49 @@ the same with the sides swapped. The tab menu's Billing sub-line says the same
 in fewer words: `API key` or `Login (name@example.com)`, `applying…`, `⚠ login
 unavailable, billing API key`, and `⚠ CLI reports API key`.
 
+An unpicked session is one whose record carries no pick: a session from
+before the picker existed, or one created when no remembered default stood
+(the picker seeds a new session from the remembered default when this box can
+bill it). It bills the machine's default, the API key when a helper is
+configured and the login otherwise. The status says so as `authPicked: false`, and the surfaces
+read it as such rather than wearing the default as a pick: the Billing
+sub-line says `unpicked (bills the API key)` and the flyout check-marks
+neither choice, and the hover row reads `API key (unpicked)` or `Login
+(name@example.com, unpicked)`. Picking a side from the flyout makes it an
+explicit pick. An older kernel sends no `authPicked`, and the surfaces read
+that as picked, the rendering they always had.
+
+The pick is reachable without a browser. `POST /auth` is the tab menu's pick
+as a one-shot token-gated route beside `/fork`, so a terminal, a script or
+another machine's plugin can set a live session's billing: body `{"id"` or
+`"name": <live name or sid>, "value": "login"|"key"}`. A body without
+`value` reads without changing anything, and `GET /auth?id=<name or sid>` is
+the same read. The reply is `{ok, queued, id, name, auth, authLive,
+authPending, authPicked, acct}`, the fields the tab hover reads; no fragment of
+a key ever rides it. A quiet session reconnects to apply and answers with
+`authPending: true`; a dormant session takes the pick into its record and
+applies it on its next resume; a session that cannot take the switch now
+(mid-turn, compacting, being moved, held back by a usage limit, or with
+changes queued ahead) parks it, exactly as the menu's pick does, and the reply
+says `queued: true` with `auth` still
+the old side. Refusals come before any park or write, as `ok: false` with the
+reason the toast carries: a side this machine cannot bill; a terminal (tmux)
+or Codex session, which has no such control; a session that has ended (a read
+of one is refused the same way, never answered with an empty side); an
+unknown name or a value other than the two sides, naming it. A malformed body
+is a 400. A
+session that lives on an attached kernel is forwarded over its tunnel with
+the body, and that kernel's reply is the answer; when it does not answer, the
+reply says so by host. `romp billing <session>` prints the read as one line,
+`web: bills the API key`, `web: bills the login · login account
+name@example.com`, or `web: unpicked (bills the API key, the default for this
+machine)`, with `(applying — not confirmed yet)` while a switch reconnects;
+`romp billing <session> login|key` posts the switch and prints the same line,
+or that it is queued until the session can take it. A reply with no side (a
+terminal session, or a kernel that has not reported one) is an error on
+stderr and exit 1, never a quiet success. A kernel that predates the route
+answers 404, and the command says to restart romp.
+
 Failures are loud rather than silent: a session that lands on the other auth
 than it was launched for is flagged in the Log panel, and a dead credential
 ("Not logged in", an invalid or expired key) blocks the session's card with the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16133,13 +16133,9 @@ def _drive(msg, client):
         if not _set_auth_or_park(be, sid, str(msg["value"])):
             # the backend names the reason it refused (no login signed in / no apiKeyHelper / a managed
             # helper: auth_unavailable_why) when it had one; the generic text covers the rest (a tmux
-            # session, an unknown sid)
-            why = str(getattr(be, "auth_unavailable_why", lambda v: "")(str(msg["value"])) or "")
+            # session, an unknown sid). One sentence with POST /auth (_auth_refusal).
             client["send"](json.dumps({"type": "warn",
-                                       "text": ("Couldn't switch the account this session bills: %s." % why) if why
-                                       else "Couldn't switch the account this session bills — "
-                                            "it isn't an SDK session, no API key is configured, "
-                                            "or this machine has no Claude login to switch to."}))
+                                       "text": _auth_refusal(be, sid, str(msg["value"])) or _AUTH_REFUSAL_GENERIC}))
         _push_soon()
     elif t == "stopTask" and msg.get("taskId"):
         # the SDK's designed stop_task control request, addressed by the id the bg-task box shows.
@@ -17307,6 +17303,8 @@ class Sessions:
                                 # the explicit pick this box cannot bill ("login"|"key"|""): the launch
                                 # fell to the other side, the Billing menu says so (2026-09-08)
                                 "authPickUnavailable": st.get("authPickUnavailable", ""),
+                                # an EXPLICIT pick stands behind `auth` (False: the box's default, said as "unpicked")
+                                "authPicked": bool(st.get("authPicked")),
                                 "authPending": bool(st.get("authPending")),   # an /auth switch reconnecting → badge dots
                                 "color": (st.get("color") or None), "mode": st.get("mode", ""), "backend": "sdk",
                                 "subagents": st.get("subagents") or [],   # live Task subagents (SDK only) → lane pill
@@ -30743,15 +30741,121 @@ def _set_env_or_park(be, sid, value):
         be.set_env(sid, value)
 
 
-def _set_auth_or_park(be, sid, value):
+def _set_auth_or_park(be, sid, value, state=None):
     """Apply a billing-account change now — or park it while the session compacts, in the same FIFO as
     /model and /effort (it reconnects the session, which mid-compaction would derail the compaction
-    exactly the way a model switch would). Returns the backend's verdict so the caller can be loud."""
+    exactly the way a model switch would). Returns the backend's verdict so the caller can be loud.
+    `state`, when given, receives {"queued": bool}: whether the change PARKED, from this setter's own
+    decision, so POST /auth answers `queued` truthfully (the _route_meta_command shape, 2026-09-11)."""
     if value not in ("login", "key"):
         return False
+    if _auth_refusal(be, sid, value):
+        return False                  # capability and side BEFORE the park: a parked op nobody can apply is a silent drop
     if _gate_or_park(sid, ("auth", value)):
+        if state is not None:
+            state["queued"] = True
         return True
     return be.set_auth(sid, value)
+
+
+# the residual refusal, when the backend was asked and said no without a reason of its own (a record that
+# vanished between the check and the write): the toast and the route both fall to it
+_AUTH_REFUSAL_GENERIC = ("Couldn't switch the account this session bills — it isn't an SDK session, no API key is "
+                         "configured, or this machine has no Claude login to switch to.")
+
+
+def _auth_refusal(be, sid, value):
+    """Why a billing pick cannot apply, as the one sentence the person reads — or "" when it can. Asked BEFORE
+    the park (review of 178968e6: _ops_gate parks whenever the backend is busy, so a mid-turn tmux or Codex
+    session's pick queued behind its turn and the drain then handed a backend with no switch an op it could
+    not apply — the switch never happened and nobody was told), and shared by both doors, the WS setAuth toast
+    and POST /auth, so they tell one truth (the tab menu hides the pick for tmux, so nothing visible changes
+    there). A backend with no such control (tmux, Codex: SessionBackend.set_auth's default False) is refused
+    outright; the SDK backend names its own reason (auth_pick_refusal: the side this box cannot bill, an ended
+    session, no record); "" hands over."""
+    fn = getattr(be, "auth_pick_refusal", None)
+    if fn is None:
+        return ("Couldn't switch the account this session bills — a terminal (tmux) or Codex session has no such "
+                "control; only a Claude Code (SDK) session's billing is picked here.")
+    why = str(fn(str(sid), str(value)) or "")
+    return ("Couldn't switch the account this session bills: %s." % why) if why else ""
+
+
+def _auth_status(sid):
+    """One session's billing as the tab hover reads it: {id, name, auth, authLive, authPending, authPicked,
+    acct}, off the SAME merged liveness row the status push builds from (Sessions.live: the SDK backend's
+    snapshot for a running session, its registry row for a dormant one; a tmux row carries no auth and
+    reads ""), plus the login's display name. No fragment of a key: the key is the word 'key'."""
+    row = Sessions.live().get(str(sid)) or {}
+    return {"id": str(sid), "name": _name_of(sid) or str(sid)[:8],
+            "auth": str(row.get("auth") or ""), "authLive": str(row.get("authLive") or ""),
+            "authPending": bool(row.get("authPending")), "authPicked": bool(row.get("authPicked")),
+            "acct": _claude_account_label()}
+
+
+def _auth_request(who, value):
+    """POST /auth's brain (`romp billing`): which account a session bills, read or switched, as the route's
+    reply dict (with `_status` when not 200). The tab menu's Billing pick — the setAuth WS op — as a one-shot
+    token-gated route beside /fork, so a terminal, a script or another machine's plugin can set a live
+    session's billing without hand-driving the WS (the user 2026-09-11; the long-running sessions created
+    before the pick existed carry none, and the only door was the tab menu). `who` is a live name or a sid
+    (/fork's resolution: a dormant SDK session by sid); `value` is "login", "key", or "" for a READ that
+    changes nothing. A session on an attached kernel is forwarded over its tunnel the way /send forwards:
+    the body crosses, a far kernel that does not answer is said so by host, and its reply is the reply. The
+    local switch is _set_auth_or_park, so the gear pick's semantics hold exactly: parked while the session
+    cannot take it (mid-turn, compacting, being moved, held back by a usage limit, or with changes queued
+    ahead — _ops_gate's five reasons; `queued`
+    says so, and `auth` is still the old side until it fires), refused BEFORE any park with the sentence the
+    toast carries when the box cannot bill the side (the T124 login gate, the managed-helper gate), the
+    session has no such control (tmux, Codex) or has ended. The reply reads the status fields the tab hover
+    reads (_auth_status)."""
+    who = str(who or "").strip()
+    value = str(value or "").strip()
+    if not who:
+        return {"ok": False, "error": "id or name required", "_status": 400}
+    if value and value not in ("login", "key"):
+        return {"ok": False, "error": 'value must be "login" or "key"'}
+    live = _live_names(_tmux_sessions())
+    sid = live.get(who) or ""
+    if not sid and re.fullmatch(r"[0-9a-fA-F-]{32,36}", who):
+        sid = who                                  # a sid: a dormant SDK session is reached by sid, as /fork's is
+    if not sid:
+        return {"ok": False, "error": 'no live session named "%s" (a dormant one can be reached by sid)' % who}
+    r = _host_for_sid(sid)
+    if r is not None:                              # remote session → its own kernel decides, over the -L tunnel
+        fwd = {"id": sid}
+        if value:
+            fwd["value"] = value
+        res = _remote_forward(r, "/auth", fwd)
+        if res is None:                            # the far kernel didn't answer — say so, never pretend it switched
+            return {"ok": False, "error": "the remote kernel for this session (%s) isn't answering, or has no "
+                    "/auth route yet — billing not %s" % (r.get("host", "?"), "switched" if value else "read")}
+        if not isinstance(res, dict):
+            return {"ok": False, "error": "the remote kernel for this session (%s) answered with something "
+                    "that is not a reply" % r.get("host", "?")}
+        return res                                 # its answer verbatim — a refusal, a read, a queued switch
+    if not _kernel_knows(sid):
+        return {"ok": False, "error": 'no session with id "%s" on this kernel' % sid}
+    be = Sessions.backend_for(sid)
+    out = {"ok": True, "queued": False}
+    if value:
+        why = _auth_refusal(be, sid, value)        # asked ONCE here, before any park or write; the setter's own
+        if why:                                    # guard re-asks only on the way to applying (its door's truth)
+            return {"ok": False, "error": why}
+        meta = {}
+        if not _set_auth_or_park(be, sid, value, state=meta):
+            return {"ok": False, "error": _AUTH_REFUSAL_GENERIC}   # asked and said no without a reason: the residual
+        out["queued"] = bool(meta.get("queued"))
+        _push_soon()                               # the badge dots and the sub-line follow now, not at the backstop
+    else:
+        # a READ: only the record's own state can refuse it — an ENDED session (alive: false) is not "billing
+        # unknown", it is gone, and the reply says so instead of an empty auth (review of 178968e6)
+        fn = getattr(be, "auth_pick_refusal", None)
+        why = str(fn(sid, "") or "") if fn else ""
+        if why:
+            return {"ok": False, "error": why}
+    out.update(_auth_status(sid))
+    return out
 
 
 def _set_fast_or_park(be, sid, value):
@@ -33696,6 +33800,10 @@ def build_session(sid, now, tmux=None, path_override=None, tail_cap_t=None, side
                   # the explicit pick this box cannot bill ("login"|"key"|"") — the launch fell to the
                   # other side (sdk_backend._options) and the menu's sub-line says so under the pick
                   "authPickUnavailable": tm.get("authPickUnavailable", ""),
+                  # whether an explicit pick stands behind `auth` (the user 2026-09-11): an unpicked SDK
+                  # session's `auth` is the box's fallback, and the Billing menu used to check-mark it as
+                  # though picked; False now renders as "unpicked (bills the …)" with no check mark
+                  "authPicked": bool(tm.get("authPicked")),
                   # the login's display name, shown beside 'Login' (the user 2026-08-09); "" when no login
                   "authAcct": _claude_account_label(),
                   "authPending": bool(tm.get("authPending")),   # an /auth reconnect applying → badge dots
@@ -52202,6 +52310,12 @@ class Handler(BaseHTTPRequestHandler):
                 if f is None:
                     return self._send(503, json.dumps({"error": "no API-health frame yet"}), "application/json", cache="no-cache")
                 return self._send(200, json.dumps(f), "application/json", cache="no-cache")
+            if p == "/auth":
+                # `romp billing <session>` bare: which account a session bills, read without acting — POST
+                # /auth's brain with no value (_auth_request); a session on an attached kernel is answered
+                # by that kernel. Token-gated like its POST twin: the reply names a login account.
+                res = _auth_request((q.get("id") or q.get("name") or [""])[0], "")
+                return self._send(res.pop("_status", 200), json.dumps(res), "application/json", cache="no-cache")
             if p == "/api-health":
                 # The API-health signal (docs/reference.md): per-(auth label, model family) attempt /
                 # response / give-up counts over rolling windows and a thrash/degraded/recovering state
@@ -53251,6 +53365,18 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(409, json.dumps({"ok": False, "error": refusal}), "application/json")
                 return self._send(200, json.dumps({"ok": True, "pending": True, "dir": cwd}),
                                   "application/json")
+            if u.path == "/auth":
+                # Headless billing pick (`romp billing`, the user 2026-09-11): the setAuth WS op as a
+                # one-shot POST beside /fork — see _auth_request. Body: {"id"|"name": <live name or sid>,
+                # "value": "login"|"key"}; without `value` it READS and changes nothing (GET /auth?id= is
+                # the same read). Reply: {ok, queued, id, name, auth, authLive, authPending, authPicked,
+                # acct} — the tab hover's fields, never a fragment of a key. Refusals are 200 ok:false
+                # with the plain reason; a malformed body is a 400.
+                b, berr = _json_object_body(raw_body)
+                if berr:
+                    return self._send(400, json.dumps({"ok": False, "error": berr}), "application/json")
+                res = _auth_request((b or {}).get("id") or (b or {}).get("name"), (b or {}).get("value"))
+                return self._send(res.pop("_status", 200), json.dumps(res), "application/json")
             if u.path == "/fork":
                 # Headless session fork (`romp fork`, the user 2026-08-19 via lab_manager): the WS
                 # forkSession op as a one-shot POST beside /new and /send, so a terminal or another

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -8270,6 +8270,10 @@ class SdkSession:
                 # the fall carried explicitly 2026-09-09)
                 "authPickUnavailable": self.backend.pick_unavailable(self.auth),
                 "authPickFell": self.backend.pick_fall(self.auth),
+                # whether an EXPLICIT pick stands behind `auth` (the user 2026-09-11): False means the side
+                # above is the box's default (effective_auth's fallback), which the Billing menu says as
+                # "unpicked" and check-marks nothing, instead of wearing the fallback as a pick
+                "authPicked": self.auth in ("login", "key"),
                 "authLive": self.auth_live,   # what the CLI's init actually reported ("" until one
                 #   lands) — the Billing row says so when it disagrees with the launch intent above
                 #   (a key found via apiKeyHelper bills the key while `auth` still reads login)
@@ -12654,6 +12658,25 @@ class SdkBackend:
             return _cred.WHY_NO_HELPER if self.key_state() == "missing" else ""   # "unknown" is cannot tell
         return ""
 
+    def auth_pick_refusal(self, sid: str, side: str) -> str:
+        """Why a billing pick for `sid` cannot apply, as ONE plain sentence, or "" when it can — asked by the kernel
+        BEFORE it parks or applies the pick (review of the /auth route, 2026-09-11), and by a read (`side` ""),
+        which only the record's own state can refuse. Three reasons: the side this box cannot bill
+        (auth_unavailable_why); a session this backend has no record of; and a session that has ENDED (its
+        record says alive: false, the kill path). A dormant session, alive but not running, takes the pick into
+        its record and applies it on its next resume; an ended one would take a write nobody reads and reseed
+        the box's default from a dead session. Parked instead of refused, the op would wait in the FIFO for a
+        switch that never comes, and nobody would be told."""
+        why = self.auth_unavailable_why(side) if side else ""
+        if why:
+            return why
+        reg = read_reg(self.state_dir, sid)
+        if reg is None:
+            return "this kernel has no record of that session"
+        if not reg.get("alive"):
+            return "that session has ended; a dormant one, still alive but not running, can be reached by sid"
+        return ""
+
     def auth_avail(self) -> dict:
         """The Billing availability the status push carries per session (`authAvail`): {login, key, loginWhy?,
         keyWhy?}. The webview lists BOTH options always and greys the unavailable one with its reason in
@@ -12959,6 +12982,7 @@ class SdkBackend:
                     "auth": self.default_auth(reg),
                     "authPickUnavailable": self.pick_unavailable(reg.get("auth") or ""),   # same as snapshot()
                     "authPickFell": self.pick_fall(reg.get("auth") or ""),
+                    "authPicked": reg.get("auth") in ("login", "key"),   # same as snapshot(): the reg's own pick
                     # the persisted CLI truth (apiKeyAuth, the liveModel pattern) so a dormant
                     # session's Billing row keeps telling it; absent = no init ever landed
                     "authLive": ("key" if reg.get("apiKeyAuth") else "login")

--- a/tests/romp-billing.bats
+++ b/tests/romp-billing.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+
+# `romp billing <session> [login|key]` (the user 2026-09-11): which account an SDK session bills, read
+# or switched from a terminal — the kernel's /auth route, the tab menu's Billing pick as a one-shot
+# route. Bare it reads (GET /auth?id=) and prints one line; with a value it posts the switch and prints
+# the kernel's answer the same way. The api-health contract: the token travels on stdin (never argv), a
+# dead kernel fails LOUDLY, a kernel that ANSWERS with a refusal is reported as what it said (a refused
+# token, a kernel without the route), never as "not reachable", and a bad value is a usage error. No
+# key material is ever printed: the key is the label "API key". On origin/main `romp billing` is not
+# a command at all, so every case here fails the wrapper's unknown-command path.
+
+ROMP_SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../bin" && pwd)/romp"
+
+setup() {
+    unset ROMP_STATE_DIR ROMP_SERVE_TOKEN
+    TEST_DIR="$(mktemp -d)"
+    export XDG_STATE_HOME="$TEST_DIR/state"
+    mkdir -p "$XDG_STATE_HOME/romp"
+    printf 'TESTTOKEN123\n' > "$XDG_STATE_HOME/romp/serve-token"
+    export ROMP_KERNEL_PORT=29855
+
+    # Stub curl: records argv AND stdin (the auth header rides stdin as a curl config), replies with
+    # the synthetic /auth answer in AUTH_JSON. It honours -w the way curl does (the format after the
+    # body, with the status filled in), so the script's status split runs for real. CURL_FAIL: no
+    # reply at all (curl's exit 7). CURL_CODE + CURL_BODY: a reply with that status and body.
+    MOCK="$TEST_DIR/mock"; mkdir -p "$MOCK"
+    export CURL_LOG="$TEST_DIR/curl.log"
+    export CURL_STDIN="$TEST_DIR/curl.stdin"
+    export AUTH_JSON="$TEST_DIR/auth.json"
+    _reply '{"ok": true, "queued": false, "id": "11111111-2222-3333-4444-555555555555", "name": "web", "auth": "key", "authLive": "key", "authPending": false, "authPicked": true, "acct": "someone@example.com"}'
+    cat > "$MOCK/curl" <<'MOCK'
+#!/usr/bin/env bash
+echo "$*" >> "$CURL_LOG"
+cat >> "$CURL_STDIN" 2>/dev/null
+[ -n "${CURL_FAIL:-}" ] && exit 7
+_w=""
+while [ $# -gt 0 ]; do [ "$1" = "-w" ] && _w="$2"; shift; done
+if [ -n "${CURL_CODE:-}" ]; then printf '%s' "${CURL_BODY:-}"; else cat "$AUTH_JSON"; fi
+if [ -n "$_w" ]; then printf '%b' "$(printf '%s' "$_w" | sed "s/%{http_code}/${CURL_CODE:-200}/")"; fi
+exit 0
+MOCK
+    chmod +x "$MOCK/curl"
+    export PATH="$MOCK:$PATH"
+}
+
+_reply() { printf '%s' "$1" > "$AUTH_JSON"; }
+
+teardown() { rm -rf "$TEST_DIR"; }
+
+@test "romp billing: bare reads GET /auth?id= and prints one line naming the side" {
+    run "$ROMP_SCRIPT" billing web
+    [ "$status" -eq 0 ]
+    [ "$output" = "web: bills the API key" ]
+    grep -q "127.0.0.1:29855/auth?id=web" "$CURL_LOG"
+    run grep -q -- '-X POST' "$CURL_LOG"
+    [ "$status" -ne 0 ]
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+    # never in argv: /proc/<pid>/cmdline is world-readable
+    run grep -q "TESTTOKEN123" "$CURL_LOG"
+    [ "$status" -ne 0 ]
+}
+
+@test "romp billing: a login-billed session names its account; an applying switch says so" {
+    _reply '{"ok": true, "queued": false, "id": "x", "name": "web", "auth": "login", "authLive": "", "authPending": true, "authPicked": true, "acct": "someone@example.com"}'
+    run "$ROMP_SCRIPT" billing web
+    [ "$status" -eq 0 ]
+    [ "$output" = "web: bills the login (applying — not confirmed yet) · login account someone@example.com" ]
+}
+
+@test "romp billing: a session never picked is said to be unpicked, billing the machine's default" {
+    _reply '{"ok": true, "queued": false, "id": "x", "name": "web", "auth": "key", "authLive": "key", "authPending": false, "authPicked": false, "acct": ""}'
+    run "$ROMP_SCRIPT" billing web
+    [ "$status" -eq 0 ]
+    [ "$output" = "web: unpicked (bills the API key, the default for this machine)" ]
+}
+
+@test "romp billing: a value posts the switch with id and value, and prints the kernel's answer" {
+    _reply '{"ok": true, "queued": false, "id": "x", "name": "web", "auth": "login", "authLive": "", "authPending": true, "authPicked": true, "acct": ""}'
+    run "$ROMP_SCRIPT" billing web login
+    [ "$status" -eq 0 ]
+    [ "$output" = "web: bills the login (applying — not confirmed yet)" ]
+    grep -q -- '-X POST' "$CURL_LOG"
+    grep -q "127.0.0.1:29855/auth " "$CURL_LOG"
+    grep -q '"id": *"web"' "$CURL_LOG"
+    grep -q '"value": *"login"' "$CURL_LOG"
+    grep -q "X-Romp-Token: TESTTOKEN123" "$CURL_STDIN"
+}
+
+@test "romp billing: a parked switch is reported as queued, neutrally about why, with the side billed until then" {
+    # the kernel parks for more than an open turn (compaction, a hold, changes queued ahead): the line names
+    # the possibilities rather than claiming one
+    _reply '{"ok": true, "queued": true, "id": "x", "name": "web", "auth": "login", "authLive": "login", "authPending": false, "authPicked": true, "acct": ""}'
+    run "$ROMP_SCRIPT" billing web key
+    [ "$status" -eq 0 ]
+    [ "$output" = "web: queued — the switch to the API key applies once the session can take it: it is mid-turn, compacting, being moved, held back by a usage limit, or has changes queued ahead (bills the login until then)" ]
+}
+
+@test "romp billing: a reply with no side is an error, never a quiet exit 0" {
+    _reply '{"ok": true, "queued": false, "id": "x", "name": "web", "auth": "", "authLive": "", "authPending": false, "authPicked": false, "acct": ""}'
+    run "$ROMP_SCRIPT" billing web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"billing unknown for web"* ]]
+}
+
+@test "romp billing: the kernel's refusal is printed as its own reason, exit 1" {
+    _reply '{"ok": false, "error": "Couldn'"'"'t switch the account this session bills: no Claude login signed in on this machine."}'
+    run "$ROMP_SCRIPT" billing web login
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused — Couldn't switch the account this session bills: no Claude login signed in on this machine."* ]]
+}
+
+@test "romp billing: usage errors exit 2 — no session, a value outside login|key, too many arguments" {
+    run "$ROMP_SCRIPT" billing
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp billing <session> [login|key]"* ]]
+    run "$ROMP_SCRIPT" billing web credit-card
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp billing"* ]]
+    run "$ROMP_SCRIPT" billing web key extra
+    [ "$status" -eq 2 ]
+    [ ! -e "$CURL_LOG" ]
+}
+
+@test "romp billing: a dead kernel fails LOUDLY" {
+    CURL_FAIL=1 run "$ROMP_SCRIPT" billing web
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+}
+
+@test "romp billing: a 404 says the kernel predates the command and wants a restart" {
+    CURL_CODE=404 CURL_BODY='' run "$ROMP_SCRIPT" billing web key
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"has no /auth route (HTTP 404)"* ]]
+    [[ "$output" == *"restart romp"* ]]
+    [[ "$output" != *"kernel not reachable"* ]]
+}
+
+@test "romp billing: a refused token is reported as that, not as a dead kernel" {
+    CURL_CODE=403 CURL_BODY='forbidden' run "$ROMP_SCRIPT" billing web
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"refused the serve token (HTTP 403)"* ]]
+    [[ "$output" != *"kernel not reachable"* ]]
+}
+
+@test "romp billing: no serve token means no kernel, said plainly" {
+    rm -f "$XDG_STATE_HOME/romp/serve-token"
+    run "$ROMP_SCRIPT" billing web key
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"the kernel isn't running (no serve token)"* ]]
+    [ ! -e "$CURL_LOG" ]
+}
+
+@test "romp billing: listed in help, under the scripting group" {
+    run "$ROMP_SCRIPT" help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"romp billing <session> [login|key]"* ]]
+}

--- a/tests/test_auth_route.py
+++ b/tests/test_auth_route.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""POST /auth and GET /auth (the user 2026-09-11): the tab menu's per-session Billing pick — the setAuth WS
+op — as a one-shot token-gated route beside /fork, so a terminal, a script or another machine's plugin can
+read or switch what a live session bills without hand-driving the WS, and `romp billing` has a door. Until
+this route the pick existed only as the WS message, so the long-running sessions created before the picker
+existed could not be given one from outside a browser.
+
+Drives the REAL Handler over HTTP (the test_rename_route.py pattern). Only the named seams are stubbed: the
+backend is a fake that records the setter call and answers like SdkBackend.set_auth (a verdict, a reason
+through auth_unavailable_why), the liveness merge is a fixed row shaped like Sessions.live's, the remote
+seams (_host_for_sid, _remote_forward) are stubbed the way test_kernel_remote_end_interrupt.py stubs them,
+and the park gate (_ops_gate) is forced for the mid-turn case. On origin/main every request here is a 404
+"not found" in text/plain: the route does not exist. Synthetic only: session `web`, a placeholder sid, host
+TESTHOST, an invented account label."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_auth_route", os.path.join(BIN, "romp-kernel"))
+
+SID = "11111111-2222-3333-4444-555555555555"
+FAR = {"host": "TESTHOST", "local_port": 1, "token": "t"}
+ACCT = "someone@example.com"
+REPLY_KEYS = {"ok", "queued", "id", "name", "auth", "authLive", "authPending", "authPicked", "acct"}
+
+
+class _BE:
+    """SdkBackend's contract: auth_pick_refusal names why a pick cannot apply ("" when it can) and is asked
+    BEFORE any park; set_auth is the verdict. A taken pick lands on the liveness row the way the real
+    setter's does (auth = the pick, authPending until the reconnect confirms), so the reply is shown to be
+    read AFTER the setter, not before."""
+
+    def __init__(self, row, ok=True, why=""):
+        self.row, self.ok, self.why, self.calls, self.asked = row, ok, why, [], []
+
+    def set_auth(self, sid, value):
+        self.calls.append((sid, value))
+        if self.ok:
+            self.row.update(auth=value, authPending=True, authPicked=True)
+        return self.ok
+
+    def auth_pick_refusal(self, sid, side):
+        self.asked.append((sid, side))
+        return self.why
+
+
+class _CodexLike:
+    """A backend with no billing switch (CodexBackend: auth is machine-global) that is BUSY: set_auth's
+    default False and no auth_pick_refusal, a turn in flight."""
+
+    def set_auth(self, sid, value):
+        return False
+
+    def busy(self, sid):
+        return True
+
+
+class AuthRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def setUp(self):
+        # the liveness row the status push builds from, for an SDK session picked onto the key
+        self.row = {"state": "waiting", "backend": "sdk", "auth": "key", "authLive": "key",
+                    "authPending": False, "authPicked": True}
+        self.be = _BE(self.row)
+        names = ("_tmux_sessions", "_live_names", "_kernel_knows", "_name_of", "_claude_account_label",
+                 "_push_soon", "_host_for_sid", "_ops_gate", "_mark_views_dirty")
+        self._saved = {k: getattr(km, k) for k in names}
+        self._saved_live, self._saved_backend = km.Sessions.live, km.Sessions.backend_for
+        km._tmux_sessions = lambda: {}
+        km._live_names = lambda tm: {"web": SID}
+        km._kernel_knows = lambda sid: str(sid) == SID
+        km._name_of = lambda sid: "web" if str(sid) == SID else ""
+        km._claude_account_label = lambda: ACCT
+        km._push_soon = lambda: None
+        km._host_for_sid = lambda sid: None
+        km._ops_gate = lambda sid: False                 # quiet: nothing parks unless a test says so
+        km._mark_views_dirty = lambda: None
+        km.Sessions.live = staticmethod(lambda: {SID: self.row})
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+        km._pending_ops.clear()
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(km, k, v)
+        km.Sessions.live, km.Sessions.backend_for = self._saved_live, self._saved_backend
+        km._pending_ops.clear()
+
+    def _req(self, method, path, body=None, token=True, raw=None):
+        data = raw if raw is not None else (json.dumps(body).encode() if body is not None else None)
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["X-Romp-Token"] = os.environ["ROMP_SERVE_TOKEN"]
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method=method,
+                                     data=data, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as r:
+                text = r.read().decode()
+                return r.status, (json.loads(text) if text.startswith("{") else text)
+        except urllib.error.HTTPError as e:
+            text = e.read().decode()
+            return e.code, (json.loads(text) if text.startswith("{") else text)
+
+    def _post(self, body, **kw):
+        return self._req("POST", "/auth", body, **kw)
+
+    # ---- the switch, by name and by sid ----
+    def test_a_live_name_switches_through_the_setter_and_answers_the_hover_fields(self):
+        st, r = self._post({"name": "web", "value": "login"})
+        self.assertEqual(st, 200)
+        self.assertEqual(self.be.calls, [(SID, "login")], "one setter call, the WS op's own door")
+        self.assertEqual(set(r), REPLY_KEYS, "the tab hover's fields and nothing else — no key material")
+        self.assertEqual((r["ok"], r["queued"], r["id"], r["name"]), (True, False, SID, "web"))
+        self.assertEqual((r["auth"], r["authPending"], r["authPicked"], r["acct"]), ("login", True, True, ACCT),
+                         "read AFTER the setter: the pick, applying, now an explicit pick")
+
+    def test_a_sid_target_reaches_the_setter_directly(self):
+        st, r = self._post({"id": SID, "value": "key"})
+        self.assertEqual((st, r["ok"], r["id"], r["name"]), (200, True, SID, "web"))
+        self.assertEqual(self.be.calls, [(SID, "key")])
+
+    # ---- refusals ----
+    def test_a_bad_value_is_refused_without_acting(self):
+        st, r = self._post({"id": SID, "value": "credit-card"})
+        self.assertEqual(st, 200)
+        self.assertIs(r["ok"], False)
+        self.assertEqual(r["error"], 'value must be "login" or "key"')
+        self.assertEqual(self.be.calls, [], "nothing reached the backend")
+
+    def test_missing_fields_are_a_400(self):
+        st, r = self._post({})
+        self.assertEqual((st, r["ok"], r["error"]), (400, False, "id or name required"))
+        st, r = self._post({"value": "key"})
+        self.assertEqual(st, 400)
+        self.assertEqual(self.be.calls, [])
+
+    def test_a_malformed_body_is_a_400_naming_what_arrived(self):
+        st, r = self._post(None, raw=b"[]")
+        self.assertEqual((st, r["error"]), (400, "body must be a JSON object, got []"))
+        st, r = self._post(None, raw=b"{not json")
+        self.assertEqual((st, r["error"]), (400, "body is not JSON"))
+
+    def test_an_unknown_name_is_a_plain_refusal(self):
+        st, r = self._post({"name": "nope", "value": "key"})
+        self.assertEqual(st, 200)
+        self.assertIs(r["ok"], False)
+        self.assertEqual(r["error"], 'no live session named "nope" (a dormant one can be reached by sid)')
+        self.assertEqual(self.be.calls, [])
+
+    def test_the_backends_refusal_carries_its_own_reason_before_any_write(self):
+        # the T124 login gate / the managed-helper gate: auth_pick_refusal names why, and the setter is never
+        # reached — the reason is asked BEFORE the park or the write (review of 178968e6)
+        self.be.why = "no Claude login signed in on this machine"
+        st, r = self._post({"id": SID, "value": "login"})
+        self.assertEqual(st, 200)
+        self.assertIs(r["ok"], False)
+        self.assertEqual(r["error"], "Couldn't switch the account this session bills: no Claude login signed in on this machine.")
+        self.assertEqual(self.be.asked, [(SID, "login")], "the backend was asked for its reason")
+        self.assertEqual(self.be.calls, [], "and the setter was never reached")
+
+    def test_a_tmux_session_has_no_such_control(self):
+        # the real tmux backend: SessionBackend.set_auth's default False, and no auth_pick_refusal
+        km.Sessions.backend_for = staticmethod(lambda sid: km._TMUX)
+        st, r = self._post({"id": SID, "value": "key"})
+        self.assertEqual(st, 200)
+        self.assertIs(r["ok"], False)
+        self.assertIn("a terminal (tmux) or Codex session has no such control", r["error"])
+
+    def test_a_busy_session_without_the_switch_is_refused_not_parked(self):
+        # review of 178968e6: _ops_gate parks whenever the backend is busy, so a mid-turn tmux or Codex pick
+        # used to answer queued:true and sit in the FIFO until the drain handed it to a backend with nothing
+        # to apply — the switch never happened and nobody was told. Capability is checked BEFORE the park.
+        km._ops_gate = lambda sid: True                  # busy: the gate would park
+        for be, label in ((km._TMUX, "tmux"), (_CodexLike(), "codex")):
+            km.Sessions.backend_for = staticmethod(lambda sid, be=be: be)
+            st, r = self._post({"id": SID, "value": "key"})
+            self.assertEqual(st, 200, label)
+            self.assertIs(r["ok"], False, label)
+            self.assertNotIn("queued", r, label)
+            self.assertIn("has no such control", r["error"], label)
+            self.assertEqual(km._pending_ops.get(SID), None, "%s: nothing parked" % label)
+
+    def test_the_ws_door_refuses_a_busy_session_without_the_switch_and_parks_nothing(self):
+        # the same guard through _drive's setAuth arm (the tab menu's door): the toast names the refusal and the
+        # FIFO stays empty — before, the pick parked behind the turn and was dropped at the drain, silently
+        km._ops_gate = lambda sid: True
+        for be, label in ((km._TMUX, "tmux"), (_CodexLike(), "codex")):
+            km.Sessions.backend_for = staticmethod(lambda sid, be=be: be)
+            out = []
+            self.assertTrue(km._drive({"type": "setAuth", "id": SID, "value": "key"}, {"send": out.append}), label)
+            frames = [json.loads(x) for x in out]
+            warns = [f for f in frames if f.get("type") == "warn"]
+            self.assertEqual(len(warns), 1, "%s: one refusal toast: %r" % (label, frames))
+            self.assertIn("a terminal (tmux) or Codex session has no such control", warns[0]["text"], label)
+            self.assertEqual(km._pending_ops.get(SID), None, "%s: nothing parked" % label)
+
+    def test_a_side_the_box_cannot_bill_is_refused_before_the_park_too(self):
+        km._ops_gate = lambda sid: True                  # busy SDK session, but the pick names a side it cannot bill
+        self.be.why = "no apiKeyHelper configured"
+        st, r = self._post({"id": SID, "value": "key"})
+        self.assertEqual((st, r["ok"]), (200, False))
+        self.assertEqual(r["error"], "Couldn't switch the account this session bills: no apiKeyHelper configured.")
+        self.assertEqual(km._pending_ops.get(SID), None, "refused now, never parked for a turn end that changes nothing")
+        self.assertEqual(self.be.calls, [])
+
+    def test_an_ended_session_is_refused_for_a_switch_and_a_read(self):
+        # review of 178968e6: an ended SDK session (its record says alive: false) was admitted by sid — the
+        # names registry still knows it and owns() only stats the record — so the pick was persisted and the
+        # box's default reseeded from a dead session, and the reply carried an empty auth. The backend's
+        # predicate names it, before any write; the read is refused the same way, never "billing unknown".
+        ended = "that session has ended; a dormant one, still alive but not running, can be reached by sid"
+        self.be.why = ended
+        st, r = self._post({"id": SID, "value": "login"})
+        self.assertEqual((st, r["ok"]), (200, False))
+        self.assertEqual(r["error"], "Couldn't switch the account this session bills: %s." % ended)
+        self.assertEqual(self.be.calls, [], "nothing written for a dead session")
+        self.assertEqual(km._pending_ops.get(SID), None)
+        st, r = self._req("GET", "/auth?id=%s" % SID)
+        self.assertEqual((st, r["ok"], r["error"]), (200, False, ended))
+        self.assertEqual(self.be.asked[-1], (SID, ""), "a read asks with no side: only the record can refuse it")
+
+    def test_a_token_less_request_is_refused_before_the_body_is_read(self):
+        st, body = self._post({"id": SID, "value": "key"}, token=False)
+        self.assertEqual(st, 403)
+        self.assertEqual(self.be.calls, [], "the gate holds: a co-tenant cannot switch what a session bills")
+
+    # ---- parked mid-turn / compacting ----
+    def test_a_mid_turn_pick_parks_and_says_so_truthfully(self):
+        km._ops_gate = lambda sid: True                  # the session is mid-turn or compacting
+        self.row.update(auth="login", authLive="login")
+        st, r = self._post({"name": "web", "value": "key"})
+        self.assertEqual(st, 200)
+        self.assertEqual((r["ok"], r["queued"]), (True, True))
+        self.assertEqual(self.be.calls, [], "parked: the setter runs when the turn ends, not now")
+        self.assertEqual(km._pending_ops.get(SID), [("auth", "key")], "the same FIFO the menu's pick parks in")
+        self.assertEqual((r["auth"], r["authPending"]), ("login", False), "still the old side until it fires")
+
+    # ---- the read ----
+    def test_get_reads_the_billing_without_acting(self):
+        self.row.update(auth="login", authLive="login", authPicked=True)
+        st, r = self._req("GET", "/auth?id=web")
+        self.assertEqual(st, 200)
+        self.assertEqual(set(r), REPLY_KEYS)
+        self.assertEqual((r["ok"], r["queued"], r["auth"], r["authLive"], r["authPending"], r["authPicked"], r["acct"]),
+                         (True, False, "login", "login", False, True, ACCT))
+        self.assertEqual(self.be.calls, [], "a read changes nothing")
+        st, r = self._post({"id": SID})                  # a value-less POST is the same read
+        self.assertEqual((st, r["ok"], r["auth"]), (200, True, "login"))
+        self.assertEqual(self.be.calls, [])
+
+    def test_an_unpicked_session_reads_unpicked(self):
+        # the long-running sessions created before the pick existed: auth is the box's fallback, and
+        # authPicked says no pick stands behind it (the surfaces render "unpicked" off this field)
+        self.row.update(authPicked=False)
+        st, r = self._req("GET", "/auth?id=%s" % SID)
+        self.assertEqual((st, r["ok"], r["auth"], r["authPicked"]), (200, True, "key", False))
+
+    def test_get_without_an_id_is_a_400(self):
+        st, r = self._req("GET", "/auth")
+        self.assertEqual((st, r["ok"], r["error"]), (400, False, "id or name required"))
+
+    def test_get_is_token_gated_too(self):
+        st, body = self._req("GET", "/auth?id=web", token=False)
+        self.assertEqual(st, 403, "the reply names a login account: never for a token-less reader")
+
+
+class RemoteAuthRoute(unittest.TestCase):
+    """A sid _host_for_sid places on TESTHOST: forwarded over its tunnel with the body, the /send arm's shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), km.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown()
+        cls.srv.server_close()
+
+    def _forward(self, method, path, body, far_reply):
+        crossed = []
+
+        def rec(r, p, b):
+            crossed.append((r, p, b))
+            return far_reply
+
+        def no_local(sid):
+            self.fail("a remote session's billing must not touch the local backend")
+
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (self.port, path), method=method, data=data,
+                                     headers={"Content-Type": "application/json",
+                                              "X-Romp-Token": os.environ["ROMP_SERVE_TOKEN"]})
+        with mock.patch.object(km, "_tmux_sessions", lambda: {}), \
+             mock.patch.object(km, "_live_names", lambda tm: {}), \
+             mock.patch.object(km, "_host_for_sid", lambda sid: dict(FAR)), \
+             mock.patch.object(km, "_remote_forward", rec), \
+             mock.patch.object(km.Sessions, "backend_for", staticmethod(no_local)), \
+             mock.patch.object(km.Sessions, "live", staticmethod(no_local)):
+            with urllib.request.urlopen(req, timeout=10) as r:
+                code, resp = r.status, json.loads(r.read().decode())
+        self.assertEqual(len(crossed), 1, "exactly one forward over the tunnel")
+        return code, resp, crossed[0]
+
+    def test_the_switch_crosses_with_its_value_and_a_dead_tunnel_is_not_an_ok(self):
+        code, resp, (r, path, body) = self._forward("POST", "/auth", {"id": SID, "value": "login"}, None)
+        self.assertEqual((r["host"], path), ("TESTHOST", "/auth"))
+        self.assertEqual(body, {"id": SID, "value": "login"}, "the pick rides to the far kernel")
+        self.assertEqual(code, 200)
+        self.assertIs(resp.get("ok"), False, "a dead tunnel is not an ok — nothing was switched")
+        self.assertIn("TESTHOST", resp["error"], "the reply names the host that isn't answering")
+        self.assertIn("billing not switched", resp["error"])
+
+    def test_the_far_reply_rides_back_verbatim(self):
+        far = {"ok": True, "queued": True, "id": SID, "name": "api", "auth": "key", "authLive": "",
+               "authPending": False, "authPicked": True, "acct": ""}
+        code, resp, _ = self._forward("POST", "/auth", {"id": SID, "value": "login"}, dict(far))
+        self.assertEqual((code, resp), (200, far), "the far kernel's answer, queued flag and all, never rewritten")
+        refusal = {"ok": False, "error": "x"}
+        code, resp, _ = self._forward("POST", "/auth", {"id": SID, "value": "key"}, dict(refusal))
+        self.assertEqual((code, resp), (200, refusal), "its refusal comes back as itself")
+
+    def test_a_read_crosses_without_a_value(self):
+        code, resp, (_, path, body) = self._forward("GET", "/auth?id=%s" % SID, None, None)
+        self.assertEqual((path, body), ("/auth", {"id": SID}), "a read carries no value: the far kernel reads")
+        self.assertIs(resp.get("ok"), False)
+        self.assertIn("billing not read", resp["error"])
+
+
+class StatusCarriesAuthPicked(unittest.TestCase):
+    """The liveness merge and the status push carry `authPicked` beside `auth` (source-level: the merge is a
+    static method over the SDK backend's rows, the push a per-session dict deep in the pusher)."""
+
+    def test_the_merge_carries_the_backend_rows_flag(self):
+        class FakeSdk:
+            def live_sessions(self):
+                return {SID: {"state": "waiting", "auth": "key", "authPicked": False}}
+        with mock.patch.object(km, "_sdk", lambda: FakeSdk()), \
+             mock.patch.object(km._TMUX, "live_sessions", lambda: {}):
+            row = km.Sessions.live()[SID]
+        self.assertEqual((row["auth"], row["authPicked"]), ("key", False))
+
+    def test_the_status_push_reads_it_off_the_merged_row(self):
+        import inspect
+        src = inspect.getsource(km)
+        i = src.index('"auth": tm.get("auth", ""),')
+        self.assertIn('"authPicked": bool(tm.get("authPicked")),', src[i:i + 3000],
+                      "the status dict carries authPicked beside auth")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rename_route.py
+++ b/tests/test_rename_route.py
@@ -101,7 +101,7 @@ class NonObjectBodies(unittest.TestCase):
     `or`) and raise AttributeError into do_POST's catch-all: a 500 whose body was a Python traceback
     naming absolute paths. Now every one of them answers 400 in the route family's JSON shape, naming
     what arrived, and acts on nothing."""
-    ROUTES = ("/new", "/fork", "/rename", "/move", "/color", "/watch-pr", "/watch", "/tag", "/group",
+    ROUTES = ("/new", "/fork", "/auth", "/rename", "/move", "/color", "/watch-pr", "/watch", "/tag", "/group",
               "/update-dismiss", "/working", "/deliver", "/picker-check", "/walk-root", "/redial")
 
     @classmethod

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -1022,9 +1022,15 @@ class Availability(unittest.TestCase):
     def test_the_refusal_toast_names_the_backend_reason(self):
         # a refused setAuth tells the user WHY (no login signed in / no apiKeyHelper / a managed helper)
         # from the backend's own sentence, and keeps the generic text for the cases without one
+        # one sentence for both doors since POST /auth (2026-09-11): the WS arm and the route read it
+        # from _auth_refusal, which asks the backend first and keeps the generic text for the rest
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn('why = str(getattr(be, "auth_unavailable_why", lambda v: "")(str(msg["value"])) or "")', src)
-        self.assertIn('("Couldn\'t switch the account this session bills: %s." % why) if why', src)
+        self.assertIn('"text": _auth_refusal(be, sid, str(msg["value"])) or _AUTH_REFUSAL_GENERIC}))', src)
+        self.assertIn('fn = getattr(be, "auth_pick_refusal", None)', src)
+        self.assertIn('return ("Couldn\'t switch the account this session bills: %s." % why) if why else ""', src)
+        self.assertIn("or this machine has no Claude login to switch to.", src)
+        # …and it is asked BEFORE the park (review of 178968e6): a busy tmux/Codex pick used to queue for nothing
+        self.assertIn("    if _auth_refusal(be, sid, value):\n        return False", src)
 
 
 class SwitchCycleTruthTable(_Keyed):
@@ -1088,7 +1094,7 @@ class DrivePlumbing(unittest.TestCase):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('"setAuth", "endSession"', src.replace("\n", " "), "an ID_OPS member")
         self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src)
-        self.assertIn("def _set_auth_or_park(be, sid, value):", src)
+        self.assertIn("def _set_auth_or_park(be, sid, value, state=None):", src)   # state: POST /auth reads the park (2026-09-11)
         self.assertIn('_gate_or_park(sid, ("auth", value))', src)   # parks on the gate, or hands over (2026-09-05)
         self.assertIn('elif op[0] == "auth":', src)
         self.assertIn("be.set_auth(sid, op[1])", src)
@@ -1104,6 +1110,41 @@ class DrivePlumbing(unittest.TestCase):
         sbc = open(os.path.join(os.path.dirname(HERE), "kernel", "session_backend.py")).read()
         self.assertIn("def set_auth(self, sid: str, value: str) -> bool:", sbc)
         self.assertIn("return False", sbc.split("def set_auth", 1)[1][:900])
+
+
+class AuthPicked(_Keyed):
+    """`authPicked` (the user 2026-09-11): whether an EXPLICIT pick stands behind a row's `auth`. An unpicked
+    session's `auth` is the box's fallback (default_auth / effective_auth), and the Billing menu used to
+    check-mark it as though picked; both rows now say which it is, so the menu can say "unpicked"."""
+
+    def test_the_rows_say_whether_a_pick_stands_behind_auth(self):
+        sid = self.be.spawn("n", "/tmp")                      # no pick: the reg carries no auth
+        row = self.be.live_sessions()[sid]
+        self.assertEqual((row["auth"], row["authPicked"]), ("key", False), "the fallback, and said to be one")
+        s = sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, sid))
+        self.assertEqual((s.snapshot()["auth"], s.snapshot()["authPicked"]), ("key", False), "the live twin agrees")
+        picked = self.be.spawn("m", "/tmp", auth="key")       # the SAME side, picked explicitly
+        self.assertEqual((self.be.live_sessions()[picked]["auth"], self.be.live_sessions()[picked]["authPicked"]),
+                         ("key", True))
+        self.assertTrue(sb.SdkSession(self.be, sb.read_reg(self.be.state_dir, picked)).snapshot()["authPicked"])
+
+    def test_an_ended_session_refuses_a_pick_before_any_write_a_dormant_one_takes_it(self):
+        # review of 178968e6: an ended session (kill: alive False, the record kept) was admitted by sid, so the
+        # pick was persisted and sdk-defaults reseeded from a dead session
+        sid = self.be.spawn("n", "/tmp", auth="key")
+        self.assertEqual(self.be.auth_pick_refusal(sid, "login"), "", "dormant: alive, not running — takes the pick")
+        self.be.kill(sid)
+        why = self.be.auth_pick_refusal(sid, "login")
+        self.assertEqual(why, "that session has ended; a dormant one, still alive but not running, can be reached by sid")
+        self.assertEqual(self.be.auth_pick_refusal(sid, ""), why, "a read of an ended session is refused the same way")
+        reg = sb.read_reg(self.be.state_dir, sid)
+        self.assertEqual((reg.get("auth"), reg.get("alive")), ("key", False), "the record is untouched")
+        self.assertFalse((Path(self.d) / "sdk-defaults.json").exists(), "the box's default was not reseeded")
+        self.assertEqual(self.be.auth_pick_refusal("11111111-2222-3333-4444-000000000000", "key"),
+                         "this kernel has no record of that session")
+        # the side this box cannot bill comes first, whatever the record says
+        self.be.login_ok = lambda: False
+        self.assertEqual(self.be.auth_pick_refusal(sid, "login"), sb._cred.WHY_NO_LOGIN)
 
 
 if __name__ == "__main__":

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -76,9 +76,10 @@ test("the switching CONTROL is the tab menu's Billing submenu, both sides listed
   // with the session's current choice check-marked
   assert.match(RENDER, /\{ label: st\.authAcct \? `Login \(\$\{st\.authAcct\}\)` : "Login", value: "login", why: avail\.login \? "" : /);   // 2026-09-08: each option carries the reason it is greyed, or ""
   assert.match(RENDER, /\{ label: "API key", value: "key", why: avail\.key \? "" : /);   // 2026-09-08: reason field, see above
-  assert.match(RENDER, /el\("div", "ctx-item" \+ \(st\.auth === c\.value \? " current" : ""\) \+ \(c\.why \? " disabled" : ""\)\)/);   // 2026-09-08: the unavailable side is greyed, never hidden
-  // a pick posts the same setAuth the badge used, and only a CHANGE posts (current = dismiss)
-  assert.match(RENDER, /if \(st\.auth !== c\.value && vscodeApi\) vscodeApi\.postMessage\(\{ type: "setAuth", id, value: c\.value \}\);/);
+  assert.match(RENDER, /el\("div", "ctx-item" \+ \(st\.auth === c\.value && st\.authPicked !== false \? " current" : ""\) \+ \(c\.why \? " disabled" : ""\)\)/);   // 2026-09-08: the unavailable side is greyed, never hidden; 2026-09-11: an unpicked session check-marks nothing
+  // a pick posts the same setAuth the badge used: a CHANGE posts, and so does an unpicked session's own fallback
+  // side (2026-09-11) — a picked session's current option only dismisses
+  assert.match(RENDER, /if \(\(st\.auth !== c\.value \|\| st\.authPicked === false\) && vscodeApi\) vscodeApi\.postMessage\(\{ type: "setAuth", id, value: c\.value \}\);/);
   // the item's sub-line names the current billing, or the applying reconnect
   assert.match(RENDER, /st\.authPending \? "applying…"/);
   assert.match(RENDER, /auth\?: string; authLive\?: string; authPending\?: boolean; authBoth\?: boolean; authAvail\?: AuthAvail; authPickUnavailable\?: string; authPickFell\?: string; authAcct\?: string;/);   // 2026-09-09: the fall the launch took rides beside the unavailable pick
@@ -104,13 +105,13 @@ test("the chat tab hover says Billing whenever the backend reports it, naming th
   // apiKeyHelper on a login launch) LEADS with the warning and names what is actually billed.
   // Anchored at the gate + label: a no-auth session (tmux — the exclusion above) must never grow a
   // fabricated Billing row, so the `if (s.status.auth)` guard is part of the pinned behavior.
-  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing",\s*\n\s*s\.status\.authPending\s*\n\s*\? \(s\.status\.auth === "key" \? "API key" : "Login"\) \+ " \(applying — not confirmed yet\)"/,
-    "the reconnect window renders as pending intent, never as applied fact");
+  assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing",\s*\n\s*s\.status\.authPicked === false\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? \(s\.status\.authLive && s\.status\.authLive !== s\.status\.auth\s*\n\s*\? `unpicked \(the CLI reports \$\{s\.status\.authLive === "key" \? "the API key" : "the login"\}\) — this session bills that`\s*\n\s*: s\.status\.auth === "key" \? "API key \(unpicked\)"\s*\n\s*: \(s\.status\.authAcct \? `Login \(\$\{s\.status\.authAcct\}, unpicked\)` : "Login \(unpicked\)"\)\)\s*\n\s*: s\.status\.authPending\s*\n\s*\? \(s\.status\.auth === "key" \? "API key" : "Login"\) \+ " \(applying — not confirmed yet\)"/,
+    "unpicked is decided first (2026-09-11), then the reconnect window renders as pending intent, never as applied fact");
   assert.match(RENDER, /⚠ \$\{s\.status\.auth === "key" \? "API key" : "Login"\} picked, but the CLI reports `\s*\n\s*\+ `\$\{s\.status\.authLive === "key" \? "the API key" : "the login"\} — this session bills that`/,
     "a confirmed contradiction leads with the warning");
   // the SWITCH CONTROL (the Billing submenu) carries the same truth where the pick lives
-  assert.match(RENDER, /sb\.textContent = st\.authPending \? "applying…"\s*\n\s*: st\.authPickUnavailable === st\.auth\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? `⚠ \$\{wordOf\(st\.auth\)\} unavailable`[^\n]*\n\s*: st\.authLive && st\.authLive !== st\.auth\s*\n\s*\? `⚠ CLI reports \$\{st\.authLive === "key" \? "API key" : "login"\}`/,
-    "the submenu sub-line shows the contradiction, not the unapplied pick");
+  assert.match(RENDER, /sb\.textContent = st\.authPicked === false\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? `unpicked \(\$\{st\.authLive && st\.authLive !== st\.auth \? `the CLI reports the \$\{wordOf\(st\.authLive\)\}` : `bills the \$\{wordOf\(st\.auth\)\}`\}\)`\s*\n\s*: st\.authPending \? "applying…"\s*\n\s*: st\.authPickUnavailable === st\.auth\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? `⚠ \$\{wordOf\(st\.auth\)\} unavailable`[^\n]*\n\s*: st\.authLive && st\.authLive !== st\.auth\s*\n\s*\? `⚠ CLI reports \$\{st\.authLive === "key" \? "API key" : "login"\}`/,
+    "the submenu sub-line shows the contradiction, not the unapplied pick (after the unpicked case, 2026-09-11)");
 });
 
 test("set_auth refuses a login pick on a box with no login — the same bar the key side always had (T124)", () => {
@@ -126,4 +127,38 @@ test("set_auth refuses a login pick on a box with no login — the same bar the 
 
 test("setAuth is an intent op — held through a kernel-restart window, never dropped", () => {
   assert.match(INTENT, /"setModel", "setEffort", "setMode", "setFast", "setAuth",/);
+});
+
+test("an unpicked session is said to be unpicked: the sub-line names the box's default, the flyout check-marks nothing, the hover appends (unpicked)", () => {
+  // the kernel's authPicked (the user 2026-09-11): true iff the registry carries an explicit pick. Before
+  // it, an unpicked SDK session's `auth` carried the box's fallback (effective_auth / default_auth) and the
+  // Billing menu showed and check-marked that side as though it had been picked. An older kernel sends no
+  // authPicked, and `=== false` reads that as picked — today's rendering, unchanged.
+  assert.match(RENDER, /authPickFell\?: string; authAcct\?: string; authPicked\?: boolean;/);
+  assert.match(RENDER, /sb\.textContent = st\.authPicked === false\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? `unpicked \(\$\{st\.authLive && st\.authLive !== st\.auth \? `the CLI reports the \$\{wordOf\(st\.authLive\)\}` : `bills the \$\{wordOf\(st\.auth\)\}`\}\)`/,
+    "the submenu sub-line says unpicked FIRST, naming the default it bills — or, when the CLI landed elsewhere, what the CLI reports (one line)");
+  assert.match(RENDER, /el\("div", "ctx-item" \+ \(st\.auth === c\.value && st\.authPicked !== false \? " current" : ""\)/,
+    "no check mark on the fallback: nothing was picked");
+  assert.match(RENDER, /s\.status\.authPicked === false\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? \(s\.status\.authLive && s\.status\.authLive !== s\.status\.auth\s*\n\s*\? `unpicked \(the CLI reports /,
+    "the hover row says the same: an unpicked fact, not a pick contradicted");
+  // ordering (review of 178968e6): the unpicked case is decided BEFORE the pick-contradiction branch in both spots
+  assert.ok(RENDER.indexOf("sb.textContent = st.authPicked === false") < RENDER.indexOf("? `⚠ CLI reports ${st.authLive"), "sub-line: unpicked before the contradiction");
+  assert.ok(RENDER.indexOf("s.status.authPicked === false") < RENDER.indexOf("picked, but the CLI reports `"), "hover: unpicked before the contradiction");
+  // the flyout's post rule, DRIVEN from the source expression (review of 60aa0a64): an unpicked session's own
+  // fallback side must become an explicit pick, while a picked session's current option still only dismisses
+  const rule = RENDER.match(/if \(\((st\.auth !== c\.value \|\| st\.authPicked === false)\) && vscodeApi\) vscodeApi\.postMessage\(\{ type: "setAuth", id, value: c\.value \}\);/);
+  assert.ok(rule, "the post rule is the one the pin above names");
+  const posts = new Function("st", "c", "return " + rule![1] + ";") as (st: unknown, c: unknown) => boolean;
+  assert.equal(posts({ auth: "key", authPicked: false }, { value: "key" }), true, "unpicked: clicking the fallback side posts, making it a pick");
+  assert.equal(posts({ auth: "key", authPicked: false }, { value: "login" }), true, "unpicked: the other side posts too");
+  assert.equal(posts({ auth: "key", authPicked: true }, { value: "key" }), false, "picked: the current option only dismisses");
+  assert.equal(posts({ auth: "key", authPicked: true }, { value: "login" }), true, "picked: a change posts");
+  assert.equal(posts({ auth: "key" }, { value: "key" }), false, "an older kernel sends no authPicked: current only dismisses, as before");
+  // the kernel side: the flag rides the running snapshot, the dormant row, the liveness merge and the status push
+  const BACKEND = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "sdk_backend.py"), "utf8");
+  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+  assert.ok(BACKEND.includes('"authPicked": self.auth in ("login", "key"),'), "SdkSession.snapshot");
+  assert.ok(BACKEND.includes('"authPicked": reg.get("auth") in ("login", "key"),'), "the dormant registry row");
+  assert.ok(KERNEL.includes('"authPicked": bool(st.get("authPicked")),'), "Sessions.live merge");
+  assert.ok(KERNEL.includes('"authPicked": bool(tm.get("authPicked")),'), "the status push");
 });

--- a/ui/webview/billing-one-auth.test.ts
+++ b/ui/webview/billing-one-auth.test.ts
@@ -20,7 +20,7 @@ test("the Billing submenu renders on availability, not only when both sides exis
 test("both options are listed; the unavailable one is greyed, titled with its reason, and inert", () => {
   assert.match(RENDER, /value: "login", why: avail\.login \? "" : \(avail\.loginWhy \|\| "no Claude login signed in on this machine"\)/);
   assert.match(RENDER, /value: "key", why: avail\.key \? "" : \(avail\.keyWhy \|\| "no apiKeyHelper configured"\)/);
-  assert.match(RENDER, /\(st\.auth === c\.value \? " current" : ""\) \+ \(c\.why \? " disabled" : ""\)/);
+  assert.match(RENDER, /\(st\.auth === c\.value && st\.authPicked !== false \? " current" : ""\) \+ \(c\.why \? " disabled" : ""\)/);   // 2026-09-11: an unpicked session (authPicked false) check-marks neither side
   assert.match(RENDER, /opt\.title = c\.why;\s*\n\s*opt\.setAttribute\("aria-disabled", "true"\);/);
   assert.match(RENDER, /if \(c\.why\) return;\s*\/\/ a disabled option posts nothing/);
   // the click handler posts setAuth only past that guard

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -295,7 +295,7 @@ type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: stri
 // which billing sides this box can bill, and why not for the other (kernel _auth_avail, 2026-09-08): the
 // Billing submenu lists both and greys the unavailable one with the reason in its hover
 interface AuthAvail { login?: boolean; key?: boolean; loginWhy?: string; keyWhy?: string; acct?: string; default?: string }
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; authPicked?: boolean; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 
 // The side a pick this box cannot bill actually fell to ("login" | "key"), "" when nothing did: the kernel's
 // authPickFell (the launch's own decision, 2026-09-09). An older kernel without the field is read the way the
@@ -5294,8 +5294,15 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   // applied fact through the whole reconnect window, and a wrong-side landing read as a quiet
   // parenthetical): a pending pick says so, a confirmed contradiction leads with the warning.
   if (s.status.auth) rows.push(["Billing",
-    s.status.authPending
-      ? (s.status.auth === "key" ? "API key" : "Login") + " (applying — not confirmed yet)"
+    s.status.authPicked === false
+      // never picked: the side is the box's default, said FIRST (a CLI that landed on the other side is an
+      // unpicked fact, not a pick contradicted) rather than worn as a pick
+      ? (s.status.authLive && s.status.authLive !== s.status.auth
+           ? `unpicked (the CLI reports ${s.status.authLive === "key" ? "the API key" : "the login"}) — this session bills that`
+           : s.status.auth === "key" ? "API key (unpicked)"
+             : (s.status.authAcct ? `Login (${s.status.authAcct}, unpicked)` : "Login (unpicked)"))
+      : s.status.authPending
+        ? (s.status.auth === "key" ? "API key" : "Login") + " (applying — not confirmed yet)"
       // the pick names a side this box cannot bill (the kernel's authPickUnavailable, with the reason
       // in authAvail): the launch went to the other side, and the row says so (the user 2026-09-08)
       : s.status.authPickUnavailable === s.status.auth
@@ -6418,7 +6425,12 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
     const bodyEl = el("span", "ctx-item-body");
     const l = el("span", "ctx-item-label"); l.textContent = "Billing"; bodyEl.appendChild(l);
     const sb = el("span", "ctx-item-sub");
-    sb.textContent = st.authPending ? "applying…"
+    sb.textContent = st.authPicked === false
+      // never picked (the kernel's authPicked): `auth` is the box's default, said as such and FIRST — a CLI that
+      // landed on the other side is then an unpicked fact, not a pick contradicted — and the flyout check-marks
+      // nothing, since nothing was picked (an older kernel sends no authPicked: read as picked, today's rendering)
+      ? `unpicked (${st.authLive && st.authLive !== st.auth ? `the CLI reports the ${wordOf(st.authLive)}` : `bills the ${wordOf(st.auth)}`})`
+      : st.authPending ? "applying…"
       : st.authPickUnavailable === st.auth
         // the pick names a side this box cannot bill — the launch went to the other one when it exists
         ? `⚠ ${wordOf(st.auth)} unavailable` + (authFellTo(st) ? `, billing ${wordOf(authFellTo(st))}` : "")
@@ -6435,7 +6447,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       const sub = el("div", "ctx-menu ctx-sub");
       for (const c of [{ label: st.authAcct ? `Login (${st.authAcct})` : "Login", value: "login", why: avail.login ? "" : (avail.loginWhy || "no Claude login signed in on this machine") },
                        { label: "API key", value: "key", why: avail.key ? "" : (avail.keyWhy || "no apiKeyHelper configured") }]) {
-        const opt = el("div", "ctx-item" + (st.auth === c.value ? " current" : "") + (c.why ? " disabled" : ""));
+        const opt = el("div", "ctx-item" + (st.auth === c.value && st.authPicked !== false ? " current" : "") + (c.why ? " disabled" : ""));
         opt.textContent = c.label;
         if (c.why) {   // unavailable here: greyed, the reason on hover, inert (the user 2026-09-08)
           opt.title = c.why;
@@ -6445,7 +6457,10 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
           ev2.stopPropagation();
           if (c.why) return;                                       // a disabled option posts nothing, and the menu stays
           dismissTabMenu();
-          if (st.auth !== c.value && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value });
+          // a CHANGE posts — and so does an unpicked session's own fallback side (review of 60aa0a64: `auth` IS
+          // that side, so the natural click posted nothing and the record stayed unpicked); a picked session's
+          // current option only dismisses
+          if ((st.auth !== c.value || st.authPicked === false) && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value });
         });
         sub.appendChild(opt);
       }


### PR DESCRIPTION
Tier: feature

## What this adds
A way to set which account a live session bills, login or API key, from outside the dashboard, and an honest word for sessions that never picked.

## Why
The per-session billing pick exists today only as a WebSocket message the tab menu sends. A terminal, a script, or another machine's plugin has no way to set it, and no way to ask. Long-running sessions created before the pick existed carry no pick at all; their tab menu shows the machine's default checked as if someone had chosen it. On a box with both a login and an API key, that means several managers have been billing the key with no control to move them and no sign that nobody decided.

## Design points
- **One route, the gear pick's semantics exactly.** `POST /auth` with `{"id"|"name", "value": "login"|"key"}` sits beside `/fork` under the same token gate and goes through the same helper the tab menu uses. A switch that cannot apply yet is parked in the same queue as a model or effort change and answered as queued, truthfully, from the park's own decision: the session is mid-turn, compacting, being moved, held back by a usage limit, or has changes queued ahead. Before anything is parked, the route asks whether the switch can apply at all, and refuses at once with the backend's own sentence when it cannot: no login signed in, a managed helper in the way, no API key configured, not an SDK session, or a session that has ended. Only a switch that could apply is parked when the session is mid-turn, compacting, held, or has changes queued ahead, and the answer says queued. A dormant session, alive but not running, takes the pick into its record and applies it on its next resume. A remote session is forwarded the way `/send` is, and a dead tunnel answers with the host named rather than a false ok. Without a value, or as `GET /auth?id=`, the route only reads. Nothing in any answer, log line or CLI line carries a fragment of a key.
- **`romp billing <session> [login|key]`.** Bare, it prints one line: which account the session bills, whether a switch is still applying, which login account, or that the session is unpicked and bills the machine's default. With a value, it posts the switch and echoes the kernel's answer. A refusal prints the reason and exits 1, an unknown billing state exits 1 rather than pretending, and a kernel that predates the route is named as such, the way `romp api-health` does it.
- **Unpicked is said, not implied.** Status gains one field, whether the session's record carries an explicit pick. The tab menu's Billing submenu shows "unpicked (bills the API key)" with no current mark for such a session, or "unpicked (the CLI reports the login)" when the CLI's own report differs, and the hover row says the same in one line. An unpicked session is one whose record carries no pick: created before the picker existed, or when no remembered default stood. Clicking either side of the flyout on such a session makes it an explicit pick, including the side it already bills; a picked session's current option still only dismisses. What a pick does is unchanged; only how it is reached and how its absence is described.

## Deliberately left out
A remote session addressed by name still resolves locally, as the send and end routes do today. The sessions listing is unchanged. No row was added to the docs' command table, which open PRs are editing; the billing section itself gains the route, the command and the unpicked case.

## Tests
Twenty-two route cases drive the real request handler over loopback with only the host lookup and the remote forward stubbed: a quiet switch, a parked one through the real queue, a read with no side effect, a bad value, an unknown name, a malformed body, a missing id, a token-less request, a busy tmux target and a busy Codex-shaped backend refused with nothing parked, an unbillable side refused before parking, an ended session refused for both switch and read with its record and the defaults untouched, a backend refusal, a remote forward and a dead tunnel. Thirteen bats cases drive the real `romp billing` against a stub kernel: bare status in each state, a switch, usage, the token refusal, the stale-kernel line and the unknown-state exit. The menu case renders the unpicked sub-line through the real builder. On `main` the route answers 404, the command is unknown, and the sub-line is absent. Three existing pins were updated where their text moved. The modules pass 22, 8, 73, 7, 13 and 150; the extension suite passes except one layout case that fails identically on `main`.

Screenshot: the tab menu's Billing submenu for an unpicked session, posted alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
