### PR TITLE
The tab strip's rebuild hides the hover tip; a clicked tab's tip no longer stands stranded

### DIFF
--- a/tests/test_tab_overview_mode_served.py
+++ b/tests/test_tab_overview_mode_served.py
@@ -91,7 +91,8 @@ const measure = () => page.evaluate(() => {
   const barChip = document.querySelector("#statusline .chip");
   const chips = host ? Array.from(host.querySelectorAll(".snap-row")).map((r) => { const c = r.querySelector(".chip"); const pip = r.querySelector(".snap-pip");
     return { id: r.dataset.id, pip: pip ? pip.className : null, flag: !!r.querySelector(".snap-flag"), chip: c ? dress(c) : null }; }) : [];
-  return { body: document.body.className, rows, tabs, activeFill, bar: barChip ? dress(barChip) : null, chips,
+  const tip = document.querySelector(".tab-tip"); const tipShown = !!tip && getComputedStyle(tip).display !== "none" && tip.getBoundingClientRect().width > 0;   // T327: no tip stands after a pick
+  return { body: document.body.className, rows, tabs, activeFill, bar: barChip ? dress(barChip) : null, chips, tipShown,
            footer: footer ? getComputedStyle(footer).display : null, composer: composer ? getComputedStyle(composer).display : null,
            composerVisible: composer ? composer.getBoundingClientRect().height > 0 : null,
            snap: host ? { display: getComputedStyle(host).display, heading: head ? Array.from(head.children).map((c) => ({ cls: c.className, text: c.textContent.trim(), style: c.getAttribute("style") || (c.firstElementChild && c.firstElementChild.getAttribute("style")) || "" })) : null,
@@ -100,14 +101,12 @@ const measure = () => page.evaluate(() => {
 });
 const out = {};
 // the awaiting session read first: the bar under the transcript wears its Awaiting chip (the dress the row's must match)
-await page.click('#tabs .tab[data-id="' + cfg.tests + '"]');
-await page.hover('#tabs .tab[data-id="' + cfg.docs + '"]');   // a tab pick rebuilds the strip under the pointer, and nothing hides the clicked tab's hover tip (render.ts renderTabs): hover-and-leave another tab dismisses it so the shots stay clean
+await page.click('#tabs .tab[data-id="' + cfg.tests + '"]');   // the pick rebuilds the strip under the pointer; renderTabs hides the clicked tab's hover tip as it rebuilds (T327)
 await page.mouse.move(700, 600);
 await page.waitForTimeout(700);
 out.barAwaiting = await measure();
 // a session inside the infra row is active (the strip's default pick is the first tab; make it explicit)
 await page.click('#tabs .tab[data-id="' + cfg.web + '"]');
-await page.hover('#tabs .tab[data-id="' + cfg.docs + '"]');
 await page.mouse.move(700, 600);   // off the strip: no tab tooltip in the shots
 await page.waitForTimeout(500);
 out.active = await measure();
@@ -268,6 +267,10 @@ class ServedTabOverviewMode(unittest.TestCase):
         if os.environ.get("SNAP_BEFORE_DIST"):
             self.skipTest("a before-the-change dist: screenshots only, the assertions describe the change")
         a = r["active"]
+        # T327: a tab pick rebuilds the strip under the pointer; the clicked tab's hover tip (shown by the pointer's arrival
+        # for the click) is hidden by the rebuild itself, so no tip stands over the page after either pick
+        self.assertFalse(r["barAwaiting"]["tipShown"], "no hover tip stands after the first pick (the strip rebuilt under the pointer)")
+        self.assertFalse(a["tipShown"], "…nor after the second")
         infra = next(row for row in a["rows"] if row["group"] == "infra")
         self.assertTrue(infra["holdsActive"], "the web tab is active inside the infra row: %r" % a["rows"])
         # 1. no underline on the holding row's chip

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5970,6 +5970,12 @@ function renderTabs() {
   const mslotEl = document.getElementById("mtag-slot");
   if (stripSig === tabStripSig && !(mslotEl && !mslotEl.firstChild)) { stripAftermath(visibleIds, ids); return; }
   tabStripSig = stripSig;
+  // the strip is about to be REBUILT: the hover tip belongs to a tab node this rebuild discards, and its mouseleave
+  // (the tip's only closer) never fires on a discarded node, so a tip shown for the tab the user just clicked stood
+  // stranded over the page until another tab was hovered and left (T327, found by the tag-overview served lab on
+  // 2026-09-10: its screenshots caught the tip after every pick). The rebuild is the event: hide it here, once, before
+  // the nodes go.
+  hideTabTip();
   // Preserve TAB-MODE keyboard focus across the rebuild (the user 2026-06-29). renderTabs runs on EVERY kernel
   // push (0.5–3s), and replaceChildren() destroys the focused tab — dropping focus out of the strip (often out
   // of the chat iframe entirely), which silently killed ←/→/Enter nav after a send or any push: you were left

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -20,6 +20,11 @@ test("the tab tooltip is a custom DOM tooltip shown on hover, not a native title
   // the tab node can outlive a frame that replaced the session object it was built from
   assert.match(RENDER, /tab\.addEventListener\("mouseenter", \(\) => showTabTip\(tab, sessions\.get\(id\) \?\? s\)\)/);
   assert.match(RENDER, /tab\.addEventListener\("mouseleave", hideTabTip\)/);
+  // T327: a strip REBUILD discards the hovered tab's node, and a discarded node never fires the mouseleave that closes
+  // the tip, so renderTabs hides it the moment it commits to rebuilding (after the unchanged-strip skip, before the nodes go)
+  const tabs = RENDER.slice(RENDER.indexOf("function renderTabs() {"), RENDER.indexOf("function stripAftermath("));
+  assert.match(tabs, /tabStripSig = stripSig;\s*\n(\s*\/\/[^\n]*\n)*\s*hideTabTip\(\);/, "the rebuild is the event that hides the tip");
+  assert.doesNotMatch(tabs.slice(0, tabs.indexOf("tabStripSig = stripSig;")), /hideTabTip\(\)/, "…not the unchanged-strip skip above it, which keeps the hovered node and its tip");
   assert.doesNotMatch(RENDER, /tab\.title = s\.name \+ " · " \+ beLabel/);
 });
 


### PR DESCRIPTION
Found by the tag-overview served lab on 2026-09-10 (its screenshots caught the tip after every pick; queued by the team's manager as T327, not a user report): clicking a tab left that tab's hover tip on screen.

**Root cause.** The tip is shown by a tab node's `mouseenter` and hidden by its `mouseleave`, and by nothing else. A pick rebuilds the strip (`renderTabs` replaces the bar's children once the strip's signature changes), the hovered node is discarded, and a discarded node never fires the `mouseleave` that would close its tip, so the tip stood until another tab was hovered and left.

**Fix.** The rebuild is the event: `renderTabs` calls `hideTabTip()` the moment it commits to rebuilding, after the unchanged-strip skip (which keeps the hovered node and its tip) and before the nodes go. A tip a kernel push interrupts mid-read closes with the rebuild; the pointer's next move shows the new node's.

**Tests.** `tab-backend-tooltip.test.ts` pins the hide at the rebuild and its absence above the skip. The served overview test (`tests/test_tab_overview_mode_served.py`) drops its hover-and-leave workaround and asserts no tip stands after either of its picks.

Locally: typecheck clean; the tab-strip and tip tests green (130); the served overview test green. Full suites running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
