### PR TITLE
The composer's resting placeholder shows a remote session's host as the quiet host prefix, only the name bold

### DIFF
--- a/tests/test_composer_placeholder_remote_served.py
+++ b/tests/test_composer_placeholder_remote_served.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""T328 (the user 2026-09-10): the composer's resting placeholder painted a REMOTE session's whole "host:name" bold in the
+identity colour, where every other surface shows the host as the quiet .host-prefix span (host-prefix.ts). On the real
+/chat page of a hub kernel with a SECOND hermetic kernel checked in as host TESTHOST (the mobile handshake, no ssh),
+the remote session's tab is picked and the composer's overlay is read: it says "Message TESTHOST:api…" with the host
+in a .host-prefix span whose computed dress (class, italic, colour, weight) equals the tab label's own host span, and
+only the name bold in the identity colour; the host span is not bold. Red with the split removed: the overlay holds no
+.host-prefix span and the bold name reads the whole "TESTHOST:api". With PH_SHOTS=<dir> the driver writes screenshots
+of the message box beside its tab, dark and light. Skips LOUDLY without the extension deps or a Playwright browser.
+SYNTHETIC fixtures only (host TESTHOST, session api, the notes-api demo world)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SID = "bbbbbbbb-1111-2222-3333-444444444444"
+COLOR = ("#64b5f6", "#0c1a2e")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+// the remote host's tab appears once the hub reports the check-in up and the relay socket is open
+const remoteTab = page.locator("#tabs .tab", { hasText: "TESTHOST" }).first();
+try { await remoteTab.waitFor({ timeout: 45000 }); }
+catch (e) {
+  const st = await page.evaluate(() => ({ tabs: (document.getElementById("tabs") || {}).textContent }));
+  console.error("no remote tab: " + JSON.stringify(st)); process.exit(1);
+}
+await remoteTab.click();
+await page.waitForFunction(() => { const ph = document.getElementById("composer-ph"); return !!(ph && getComputedStyle(ph).display !== "none" && ph.querySelector(".composer-ph-name")); }, null, { timeout: 30000 });
+await page.mouse.move(700, 400);   // off the strip: no tab tooltip in the shots
+await page.waitForTimeout(600);
+// the dress of a host span: the class, the italic, the ink, the weight (the four the tab label's rule sets), and its words
+// (defined inside the page's evaluate, where getComputedStyle lives)
+const measure = () => page.evaluate(() => {
+  const dress = (n) => { if (!n) return null; const cs = getComputedStyle(n); return { cls: n.className, text: n.textContent, style: cs.fontStyle, color: cs.color, weight: cs.fontWeight, size: cs.fontSize }; };
+  const tab = document.querySelector("#tabs .tab.active[data-id]");
+  const ph = document.getElementById("composer-ph"); const nm = ph && ph.querySelector(".composer-ph-name");
+  const ta = document.getElementById("composer-input");
+  return { active: tab ? tab.dataset.id : null, tabLabel: tab ? (tab.querySelector(".tab-label") || tab).textContent : null,
+           tabHost: dress(tab && tab.querySelector(".tab-label .host-prefix")), tabBg: tab ? tab.style.getPropertyValue("--chip-bg") : null,
+           phText: ph ? ph.textContent : null, phHost: dress(ph && ph.querySelector(".host-prefix")), phHostInsideName: !!(nm && nm.querySelector(".host-prefix")),
+           phName: dress(nm), phNameColor: nm ? nm.style.color : null, nativePlaceholder: ta ? ta.placeholder : null,
+           theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const out = {};
+out.dark = await measure();
+if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-composer-remote-host-dark.png", fullPage: false }); }
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(300);
+out.light = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-composer-remote-host-light.png", fullPage: false });
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+def _kernel(lab, name, port, token, records=None, sid=None):
+    """Boot one hermetic kernel: its own state root, dist, and (optionally) one session with a transcript and a colour."""
+    state = os.path.join(lab, name, "xdg", "romp")
+    claude = os.path.join(lab, name, "claude")
+    cwd = os.path.join(lab, name, "proj")
+    for d in ("names", "sdk", "states"):
+        os.makedirs(os.path.join(state, d), exist_ok=True)
+    os.makedirs(cwd, exist_ok=True)
+    Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+    if records is not None:
+        Path(state, "names", sid).write_text("api\t%s\t%s\t%s\n" % (cwd, COLOR[0], COLOR[1]))
+        Path(state, "sdk", sid + ".json").write_text(json.dumps(
+            {"sid": sid, "name": "api", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": sid, "alive": True, "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in records))
+    env = _lab.kernel_env(os.path.join(lab, name), claude, os.path.join(lab, "dist"), port, token,
+                          ROMP_HOST_NAME=name.upper())
+    log = os.path.join(lab, name + "-kernel.log")
+    proc = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(log, "w"), stderr=subprocess.STDOUT, env=env)
+    for _ in range(120):
+        try:
+            urllib.request.urlopen("http://127.0.0.1:%d/healthz" % port, timeout=1)
+            return proc, log
+        except Exception:
+            time.sleep(0.5)
+    proc.kill(); proc.wait()
+    raise unittest.SkipTest("hermetic kernel %s never served /healthz here" % name)
+
+
+class ServedComposerPlaceholderRemoteHost(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:          # a skip OR a failure: never leave a kernel or a lab behind
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="composer-ph-remote-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            shutil.rmtree(cls.lab, ignore_errors=True)
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        copy_dist(os.path.join(EXT, "dist"), os.path.join(cls.lab, "dist"))
+        cls.procs = []
+        t0 = int(time.time()) - 900
+        recs = [
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": SID,
+             "message": {"role": "user", "content": "how should the notes-api retry loop back off?"}},
+            {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": "Use exponential backoff with a jitter of ten percent."}]}},
+        ]
+        # the REMOTE kernel owns the session; the HUB has none of its own and shows the remote's through the relay
+        cls.rport, cls.rtoken = _free_port(), "testtok-remote-ph"
+        cls.hport, cls.htoken = _free_port(), "testtok-hub-ph"
+        try:
+            rp, cls.rlog = _kernel(cls.lab, "testhost", cls.rport, cls.rtoken, records=recs, sid=SID)
+            cls.procs.append(rp)
+            hp, cls.hlog = _kernel(cls.lab, "hub", cls.hport, cls.htoken)
+            cls.procs.append(hp)
+        except unittest.SkipTest:
+            cls.tearDownClass()
+            raise
+        # the check-in handshake a mobile machine makes through its reverse forward: the hub records the peer like an
+        # attached remote (no ssh of its own) and probes it on the port given, here the remote's own
+        body = json.dumps({"host": "TESTHOST", "kernelPort": cls.rport, "busPort": _free_port(), "token": cls.rtoken}).encode()
+        req = urllib.request.Request("http://127.0.0.1:%d/checkin?token=%s" % (cls.hport, cls.htoken), data=body,
+                                     headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            ans = json.loads(resp.read().decode())
+        if not ans.get("ok"):
+            cls.tearDownClass()
+            raise unittest.SkipTest("the hub refused the check-in: %r" % ans)
+        for _ in range(60):   # the hub's supervisor probes the peer and reports it up; the browser dials only then
+            try:
+                with urllib.request.urlopen("http://127.0.0.1:%d/tunnels?token=%s" % (cls.hport, cls.htoken), timeout=3) as r2:
+                    rows = json.loads(r2.read().decode()).get("tunnels") or []
+            except Exception:
+                rows = []
+            row = next((t for t in rows if t.get("host") == "TESTHOST"), None)
+            if row and row.get("status") == "up" and row.get("hasToken"):
+                break
+            time.sleep(0.5)
+        else:
+            cls.tearDownClass()
+            raise unittest.SkipTest("the hub never reported the checked-in peer up: %r" % (rows,))
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in getattr(cls, "procs", []):
+            try:
+                p.kill(); p.wait()
+            except Exception:
+                pass
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_placeholder_shows_the_remote_host_as_the_tab_label_does(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.hport, self.htoken), "shots": os.environ.get("PH_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:]
+                         + "\nhub:\n" + open(self.hlog).read()[-1500:] + "\nremote:\n" + open(self.rlog).read()[-800:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        for theme in ("dark", "light"):
+            m = r[theme]
+            self.assertEqual(m["theme"], theme)
+            self.assertEqual(m["active"], "TESTHOST:" + SID, "the remote session's tab is the active one: %r" % m)
+            self.assertEqual(m["tabLabel"], "TESTHOST:api", "the tab label reads host:name: %r" % m)
+            self.assertIsNotNone(m["tabHost"], "the tab label's host is its own span: %r" % m)
+            self.assertEqual(m["tabHost"]["text"], "TESTHOST:")
+            # the overlay: "Message TESTHOST:api…", the host as the SAME quiet span the tab wears, the name alone bold in the colour
+            self.assertTrue((m["phText"] or "").startswith("Message TESTHOST:api"), "the overlay names the session with its host: %r" % m["phText"])
+            self.assertIsNotNone(m["phHost"], "the overlay's host is a .host-prefix span (the split): %r" % m)
+            self.assertEqual(m["phHost"]["text"], "TESTHOST:")
+            self.assertFalse(m["phHostInsideName"], "the host span is a sibling of the bold name, never inside it")
+            for k in ("cls", "style", "color", "weight"):
+                self.assertEqual(m["phHost"][k], m["tabHost"][k], "the overlay's host wears the tab label's %s in %s: %r vs %r" % (k, theme, m["phHost"], m["tabHost"]))
+            self.assertEqual(m["phHost"]["style"], "italic"); self.assertEqual(m["phHost"]["weight"], "400", "the host is quiet, not bold")
+            self.assertEqual(m["phName"]["text"], "api", "only the name is the bold run: %r" % m["phName"])
+            self.assertEqual(m["phName"]["weight"], "600")
+            self.assertEqual(m["phNameColor"], "rgb(100, 181, 246)", "…in the session's identity colour (the tab's --chip-bg): %r / %r" % (m["phNameColor"], m["tabBg"]))
+            self.assertNotEqual(m["phHost"]["color"], m["phNameColor"], "the host does not wear the identity colour")
+            self.assertTrue((m["nativePlaceholder"] or "").startswith("Message this session"), "the native placeholder beneath stays the plain resting text for assistive tech")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/composer-placeholder.test.ts
+++ b/ui/webview/composer-placeholder.test.ts
@@ -16,15 +16,23 @@ const SHORT = "Message this session…  (/ for commands)";
 const PHONE = "Message this session…";
 
 test("every resting form takes the session's name in place of 'this session', keeping the ellipsis and the hint", () => {
-  assert.deepEqual(phParts(FULL, "web"), { kind: "named", before: "Message ", name: "web", after: "…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)" });
-  assert.deepEqual(phParts(SHORT, "api"), { kind: "named", before: "Message ", name: "api", after: "…  (/ for commands)" });
-  assert.deepEqual(phParts(PHONE, "tests"), { kind: "named", before: "Message ", name: "tests", after: "…" });
+  assert.deepEqual(phParts(FULL, "web"), { kind: "named", before: "Message ", host: null, name: "web", after: "…  (⏎ send · ⇧⏎ newline · ⌘⏎ stage · ↑ history · / for commands)" });
+  assert.deepEqual(phParts(SHORT, "api"), { kind: "named", before: "Message ", host: null, name: "api", after: "…  (/ for commands)" });
+  assert.deepEqual(phParts(PHONE, "tests"), { kind: "named", before: "Message ", host: null, name: "tests", after: "…" });
   assert.equal(RESTING_PREFIX, "Message this session", "the prefix the resting forms share (composerRestingPlaceholder)");
 });
 
-test("the name is trimmed and a remote session's host prefix rides along as the tab shows it", () => {
+test("the name is trimmed; a remote session's host is split off as the tab label splits it (T328): the host quiet, only the name bold", () => {
   assert.equal((phParts(FULL, "  web ") as any).name, "web");
-  assert.equal((phParts(FULL, "TESTHOST:api") as any).name, "TESTHOST:api");
+  const LOCAL = "aaaaaaaa-1111-2222-3333-444444444444", REMOTE = "TESTHOST:" + LOCAL;
+  // the split is the sid's own prefix (host-prefix.ts hostPrefix): federation prefixes both the name and the sid
+  assert.deepEqual(phParts(PHONE, "TESTHOST:api", REMOTE), { kind: "named", before: "Message ", host: "TESTHOST:", name: "api", after: "…" });
+  assert.deepEqual(phParts(FULL, "TESTHOST:api", REMOTE).kind === "named" && (phParts(FULL, "TESTHOST:api", REMOTE) as any).host, "TESTHOST:");
+  // a LOCAL session with a colon in its name is not a remote one: the sid carries no prefix, so the name stays whole
+  assert.deepEqual(phParts(PHONE, "TESTHOST:api", LOCAL), { kind: "named", before: "Message ", host: null, name: "TESTHOST:api", after: "…" });
+  assert.deepEqual(phParts(PHONE, "api", LOCAL), { kind: "named", before: "Message ", host: null, name: "api", after: "…" }, "a local session: unchanged");
+  assert.deepEqual(phParts(PHONE, "api", REMOTE), { kind: "named", before: "Message ", host: null, name: "api", after: "…" }, "a remote sid whose name lacks the prefix (an older frame): whole, never a false host");
+  assert.deepEqual(phParts(PHONE, "web"), { kind: "named", before: "Message ", host: null, name: "web", after: "…" }, "no sid at all (the pure callers): a local form");
 });
 
 test("other placeholders show as they are, and a session with no name yet keeps the plain resting text", () => {
@@ -39,7 +47,14 @@ test("render.ts: the overlay mirrors the placeholder, wears the identity colour,
   assert.match(RENDER, /import \{ phParts \} from "\.\/composer-placeholder";/);
   const fn = RENDER.slice(RENDER.indexOf("function syncComposerPh(): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function syncComposerPh(): void {")));
   assert.ok(fn.length > 0, "syncComposerPh exists");
-  assert.match(fn, /const parts = phParts\(ta\.placeholder, live\?\.name \|\| meta\?\.name \|\| ""\);/);
+  assert.match(fn, /const parts = phParts\(ta\.placeholder, live\?\.name \|\| meta\?\.name \|\| "", activeId\);/, "the sid rides along: a remote host's prefix is told from the name by the sid (host-prefix.ts)");
+  // T328: the host is the tab label's own quiet span (hostNameNodes: .host-prefix, marked when the host is down), a
+  // sibling of the bold name, never inside it
+  assert.match(fn, /if \(parts\.host\) \{[\s\S]*?ph\.appendChild\(hostNameNodes\(parts\.host \+ parts\.name, activeId\)\[0\]\);\s*\n\s*\}\s*\n\s*const nm = el\("b", "composer-ph-name"\); nm\.textContent = parts\.name;/);
+  assert.doesNotMatch(CSS, /#composer-ph \.host-prefix/, "no dress of the overlay's own for the host: the global .host-prefix rule, the tab label's, is the one");
+  // the host's link dropping or returning flips the span's .off mark on the tab (the romp-hosts event, host-offline.test.ts);
+  // the overlay's span is repainted on the same event, so the two never disagree until the next keystroke
+  assert.match(RENDER, /window\.addEventListener\("romp-hosts", \(\) => \{ renderTabs\(\); syncComposerPh\(\); \}\)/);
   assert.match(fn, /parts\.kind === "named" && !ta\.value/, "the styled form only for the resting placeholder, only while the box is empty");
   assert.match(fn, /ta\.classList\.toggle\("ph-on", show\);/, "the native placeholder goes transparent beneath the overlay");
   assert.match(fn, /const colorBg = \(live\?\.color\?\.bg \|\| meta\?\.color\?\.bg\) \|\| null;/, "the identity colour: the live session's, else the strip's own word on the tab (a skeleton's), never a stale session (skeleton-tabs-wiring)");

--- a/ui/webview/composer-placeholder.ts
+++ b/ui/webview/composer-placeholder.ts
@@ -6,20 +6,27 @@
 // the empty box (syncComposerPh) and keeps the native placeholder beneath it, transparent, for assistive tech.
 // The split is pure so node executes it: the resting forms (full hint, short hint, the phone's bare prompt)
 // take the name; every other placeholder (the closed-session notice, a picker's "add your own answer…") shows
-// as it is, and a session with no name yet keeps the plain resting text.
+// as it is, and a session with no name yet keeps the plain resting text. A REMOTE session's "host:" is metadata,
+// not part of the name (host-prefix.ts, the one rule every surface follows): the split hands it back apart, so the
+// overlay paints it as the quiet .host-prefix span the tab label wears and only the name bold in the identity
+// colour (T328, the user 2026-09-10: the box read the whole "host:name" bold in the colour).
+import { hostPrefix } from "./host-prefix";
 
 export const RESTING_PREFIX = "Message this session";
 
 export type PhParts =
-  | { kind: "named"; before: string; name: string; after: string }
+  | { kind: "named"; before: string; host: string | null; name: string; after: string }
   | { kind: "plain"; text: string };
 
-/** How the overlay renders `placeholder` for a session called `name`: the resting form with the name in place
- *  of "this session" (kept: the leading "Message ", the trailing "…" and hint), else the text as it is. */
-export function phParts(placeholder: string, name: string | null | undefined): PhParts {
+/** How the overlay renders `placeholder` for a session called `name` with id `sid`: the resting form with the name
+ *  in place of "this session" (kept: the leading "Message ", the trailing "…" and hint), the remote host split off
+ *  as `host` ("TESTHOST:", by the sid's own prefix, hostPrefix) with `name` the rest; a local session has host null
+ *  and its name whole; else the text as it is. */
+export function phParts(placeholder: string, name: string | null | undefined, sid?: string | null): PhParts {
   const nm = (name || "").trim();
   if (nm && placeholder.startsWith(RESTING_PREFIX)) {
-    return { kind: "named", before: "Message ", name: nm, after: placeholder.slice(RESTING_PREFIX.length) };
+    const p = hostPrefix(nm, sid);
+    return { kind: "named", before: "Message ", host: p ? p.host : null, name: p ? p.rest : nm, after: placeholder.slice(RESTING_PREFIX.length) };
   }
   return { kind: "plain", text: placeholder };
 }

--- a/ui/webview/host-offline.test.ts
+++ b/ui/webview/host-offline.test.ts
@@ -125,7 +125,7 @@ test("the note the tab carries on hover is still the one wording of it", () => {
 });
 
 test("both surfaces repaint on the reachability event", () => {
-  assert.match(RENDER, /window\.addEventListener\("romp-hosts", \(\) => \{ renderTabs\(\); \}\)/);
+  assert.match(RENDER, /window\.addEventListener\("romp-hosts", \(\) => \{ renderTabs\(\); syncComposerPh\(\); \}\)/, "the strip and the composer's name overlay (its host span wears the same mark, T328) repaint together");
   assert.match(TL, /window\.addEventListener\('romp-hosts', this\._onHosts\)/);
   assert.match(TL, /window\.removeEventListener\('romp-hosts', this\._onHosts\)/, "and let go on teardown");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6786,8 +6786,10 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
 }
 // A remote host coming or going flips the disconnected marks on its tabs. The federation manager fires
 // this only when the reachable set actually CHANGES (its own /tunnels poll is the event), so this is a
-// repaint per connect/drop, not per poll (the user 2026-07-29).
-window.addEventListener("romp-hosts", () => { renderTabs(); });
+// repaint per connect/drop, not per poll (the user 2026-07-29). The composer's overlay names the active session
+// with the same host span (T328), so it re-syncs on the same event: its mark would otherwise lag the tab's until
+// the next keystroke, resize, rename or tab switch.
+window.addEventListener("romp-hosts", () => { renderTabs(); syncComposerPh(); });
 // a dial attempt to a remote host began or ended (federation.ts dialEvent): the host-down foot's swirl
 // spins while one is in flight, as of the last /tunnels poll, so it repaints on this event and on nothing else
 window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); });
@@ -13096,13 +13098,19 @@ function syncComposerPh(): void {
   const live = liveSession(activeId);
   const meta = activeId ? tabMeta.get(activeId) : undefined;
   const colorBg = (live?.color?.bg || meta?.color?.bg) || null;
-  const parts = phParts(ta.placeholder, live?.name || meta?.name || "");
+  const parts = phParts(ta.placeholder, live?.name || meta?.name || "", activeId);   // the sid tells a remote host's prefix from a name (host-prefix.ts)
   const show = parts.kind === "named" && !ta.value && !ta.disabled && ta.offsetParent !== null;
   ph.style.display = show ? "" : "none";
   ta.classList.toggle("ph-on", show);
   if (!show || parts.kind !== "named") return;
   ph.replaceChildren();
   ph.appendChild(document.createTextNode(parts.before));
+  if (parts.host) {
+    // a remote session's "host:" is metadata, not part of the name (T328, the user 2026-09-10: the box read the whole
+    // "host:name" bold in the identity colour): the tab label's own renderer paints it (host-prefix.ts hostNameNodes),
+    // the quiet .host-prefix span, marked when the host's link is down, and only the name below is bold and coloured
+    ph.appendChild(hostNameNodes(parts.host + parts.name, activeId)[0]);
+  }
   const nm = el("b", "composer-ph-name"); nm.textContent = parts.name;
   if (colorBg) nm.style.color = colorBg; else nm.style.removeProperty("color");
   ph.appendChild(nm);


### PR DESCRIPTION
The user (2026-09-10, screenshot): in the message box the session name is right, but a remote session's host is not the grey italic every other surface shows; the whole "host:name" read bold in the identity colour.

**Root cause.** `composer-placeholder.ts` handed the whole "host:name" string as the name and `render.ts` painted it as one bold coloured run. The tab label, the chips and the cards split the host off through `host-prefix.ts` (`hostPrefix`, `hostNameNodes`) into the `.host-prefix` span.

**Fix.** `phParts` takes the sid too and splits the remote host by the sid's own prefix (`hostPrefix`): the named form carries `host` ("TESTHOST:") and `name` ("api"); a local session, a colon in a local name, and a remote sid whose name lacks the prefix keep the name whole and `host` null. `syncComposerPh` passes the active id and, for a remote host, appends the tab label's own host span (`hostNameNodes`: `.host-prefix`, marked when the host's link is down) as a sibling before the bold name, so the host wears the global `.host-prefix` rule (dim, italic, weight 400) and only the name is bold in the identity colour. No stylesheet change.

**Manager's review.** The hosts-state listener (the `romp-hosts` event a remote host's link drop or return fires) re-syncs the overlay beside the strip's repaint, so the overlay's host span gains or loses the `.off` mark with the tab's instead of lagging until the next keystroke, resize, rename or tab switch; pinned in `host-offline.test.ts` and `composer-placeholder.test.ts`.

**Tests.** `composer-placeholder.test.ts` executes the split (remote, local, colon-in-name, prefix-less) and pins the painter. `tests/test_composer_placeholder_remote_served.py` drives the real `/chat` page of a hub kernel with a second hermetic kernel checked in as host TESTHOST, picks the remote tab and compares the overlay's host span with the tab label's (class, italic, colour, weight), checks the host is neither bold nor inside the name and the name alone bold in the identity colour, dark and light; red with the split removed.

Locally: typecheck clean; the placeholder, host-prefix and skeleton-tabs tests green (28); the served pair green (3). Full suites running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
