### PR TITLE
Fold checkpoints: a restarted kernel folds the tails of its files, not the files (T323 stage 3)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -982,7 +982,28 @@ leaf's, so the two never evict each other. When a `/clear` or a resume fork
 moves a session to a new transcript, the previous leaf's tree is dropped the
 moment discovery first hands out the new one, so it holds across clears too.
 The store evicts the least recently used entry past 256 instead of clearing
-wholesale. The gain is one tree per session, about
+wholesale.
+
+The folds' checkpoints survive a restart. Every append-incremental fold over a
+JSONL file (the states overlay and the last-state readers, the background-task
+pairing, the agent gists and launches, the postal log, the queue ledger, the
+wake tail, the machine cut, the states notes, the state intervals, the session
+meta) used to re-read its whole file from record zero after a kernel restart:
+its cursor lived in the process. Since 2026-09-11 one small JSON file per
+folded file under the state root's `checkpoints/` directory records the
+reader's prefix witness (the byte offset past the last complete line, the up
+to 64 bytes before it, the record count) and the state of every fold whose
+cursor stood at that count. A fresh kernel verifies the guard bytes on disk,
+reads only the bytes past the offset and resumes each fold from its recorded
+state; a checkpoint that does not verify (its version, its path, a file that
+shrank, a rewrite under the guard, a corrupt document) falls back to a whole
+read, is counted per reason in `/perf` and said once on stderr. Checkpoints
+are written when a session's turn settles or its states log moves, and all of
+them at exit; checkpoints of files that no longer exist are swept at boot. A
+compaction appends records and changes nothing here. The parse trees and the
+record cache the parse reads through are unchanged by this: a restart still
+parses a session's leaf transcript whole (the checkpoint work that follows
+addresses the parse itself). The gain is one tree per session, about
 a quarter of the record cost the T311 report measured (0.25 GB of 6.6); the
 record cache itself, the bulk, is the checkpoint work's target.
 
@@ -1299,6 +1320,13 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   longer wait between cycles would have skipped; a conservative undercount,
   since a wake set by another thread or a periodic repost of an unchanged
   frame marks a cycle busy).
+- `checkpoints`: the folds' checkpoints since boot: `restored` (files whose
+  folds resumed from one), `writes`, `swept` (checkpoints of vanished files
+  removed at boot), `skippedFolds` (fold states the codec could not encode),
+  `fallbacks` per reason (`version`, `path`, `shrunk`, `guard`, `rewrite`,
+  `corrupt`), `dirty` (files whose folds moved since their last write),
+  `readBytes` and `readByPath` (what the JSONL reader pulled off disk since
+  boot, in total and per file).
 - `parses`: the cold event-model parses through the one parse store the
   kernel and the judges share: `total` (every miss, whoever asked), `kernel`
   (the display's asks among them, with `bytes`, the parsed files' sizes, and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -997,7 +997,11 @@ cursor stood at that count. A fresh kernel verifies the guard bytes on disk,
 reads only the bytes past the offset and resumes each fold from its recorded
 state; a checkpoint that does not verify (its version, its path, a file that
 shrank, a rewrite under the guard, a corrupt document) falls back to a whole
-read, is counted per reason in `/perf` and said once on stderr. Checkpoints
+read, is counted per reason in `/perf` and said once on stderr. A fold whose
+encoded state would exceed 64 KB is left out of the document and counted (a
+state that grows with its file, such as the postal log fold's map of every
+sent row, would make the document a second copy of the file); it cold-folds
+at first touch, while the bounded folds beside it restore. Checkpoints
 are written when a session's turn settles or its states log moves, and all of
 them at exit; checkpoints of files that no longer exist are swept at boot. A
 compaction appends records and changes nothing here. The parse trees and the
@@ -1323,7 +1327,11 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
 - `checkpoints`: the folds' checkpoints since boot: `restored` (files whose
   folds resumed from one), `restoredFolds` (restores per fold name), `writes`,
   `swept` (checkpoints of vanished files removed at boot), `skippedFolds`
-  (fold states the codec could not encode),
+  (fold states the codec could not encode), `oversizeFolds` (per fold name,
+  states over the 64 KB cap left out of a document), `droppedRestores` (a
+  restore lost to a read that replaced the entry under it; the reader
+  serializes reads per path, so this should stay at zero), `documentBytes`
+  (what reading the checkpoint documents themselves cost since boot),
   `fallbacks` per reason (`version`, `path`, `shrunk`, `guard`, `rewrite`,
   `corrupt`), `dirty` (files whose folds moved since their last write),
   `readBytes` and `readByPath` (what the JSONL reader pulled off disk since

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1321,8 +1321,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   since a wake set by another thread or a periodic repost of an unchanged
   frame marks a cycle busy).
 - `checkpoints`: the folds' checkpoints since boot: `restored` (files whose
-  folds resumed from one), `writes`, `swept` (checkpoints of vanished files
-  removed at boot), `skippedFolds` (fold states the codec could not encode),
+  folds resumed from one), `restoredFolds` (restores per fold name), `writes`,
+  `swept` (checkpoints of vanished files removed at boot), `skippedFolds`
+  (fold states the codec could not encode),
   `fallbacks` per reason (`version`, `path`, `shrunk`, `guard`, `rewrite`,
   `corrupt`), `dirty` (files whose folds moved since their last write),
   `readBytes` and `readByPath` (what the JSONL reader pulled off disk since

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -656,6 +656,15 @@ _CKPT_PENDING = {}                # path -> {"count": N, "gen": g, "folds": {nam
 _CKPT_SEQ = {}                    # path -> the seq of the last checkpoint read or written for it
 _FOLD_DIRTY = set()               # paths whose fold cursors moved since their checkpoint was last written
 _FOLD_REG = {}                    # checkpoint name -> the fold's cursor dict (fold_records registers at first call)
+_FOLD_NAME_OF = {}                # id(cursor dict) -> checkpoint name, for callers that name their cache once (name_fold_cache)
+
+
+def name_fold_cache(cache, name):
+    """Give a fold's cursor dict its checkpoint name once, so every fold_records call over it is resumable without
+    a `ckpt` argument at the call (a caller whose call shape other code stubs, such as the judge's background-task
+    scan, keeps its signature)."""
+    _FOLD_NAME_OF[id(cache)] = name
+    _FOLD_REG[name] = cache
 
 
 def set_checkpoint_dir(fn):
@@ -1074,6 +1083,8 @@ def fold_records(cache, path, init, step, on=None, ckpt=None):
     Lives here (moved from the kernel, 2026-09-03) so the judge's readers can fold too — the
     background-task pairing below is shared by both."""
     key = str(path)
+    if ckpt is None:
+        ckpt = _FOLD_NAME_OF.get(id(cache))               # a cache named once (name_fold_cache)
     if ckpt is not None:
         _FOLD_REG[ckpt] = cache                           # the newest caller's cursor dict (a test process loads the kernel
         #                                                   several times over one event model; production loads it once)

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -651,7 +651,15 @@ def read_bytes_report():
 # settle, its states log moving, exit), never by a timer.
 _CKPT_V = 1
 _CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None = checkpoints off
-_CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}}
+_CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}, "droppedRestores": 0,
+               "oversizeFolds": {}}
+_CKPT_FOLD_CAP = 64 * 1024        # bytes of encoded state a fold may put in a checkpoint. A state that grows with its file (the postal
+#                                   log fold's map of every sent row, the state intervals' list of every transition, the every-task
+#                                   background view on a long transcript) would make the document a second copy of the file: reading
+#                                   it at boot costs what the checkpoint exists to save (measured 2026-09-11: 11 MB of documents in a
+#                                   44 MB world). Such a fold is left out, counted per name, and cold-folds at first touch; the folds
+#                                   whose state is bounded (the gist's capped steps, the running tasks, the newest rows) are the ones
+#                                   the checkpoint pays for. A bounded projection for the growing ones is a later stage's item.
 _CKPT_LOCK = threading.Lock()
 _CKPT_PENDING = {}                # path -> {"count": N, "gen": g, "folds": {name: {"count", "state"}}} restores not yet taken
 _CKPT_SEQ = {}                    # path -> the seq of the last checkpoint read or written for it
@@ -758,7 +766,9 @@ def _ckpt_load(path):
     if cp is None or not cp.exists():
         return None
     try:
-        doc = json.loads(cp.read_text())
+        text = cp.read_bytes()
+        _count_read(str(cp), len(text))                   # the document is a read of the boot too (/perf, the bench)
+        doc = json.loads(text.decode("utf-8"))
     except (OSError, ValueError) as e:
         _ckpt_fallback(path, "corrupt", str(e)[:80]); return None
     if not isinstance(doc, dict) or doc.get("v") != _CKPT_V:
@@ -859,7 +869,15 @@ def _restored_cursor(key, name, ent):
     base = ent[5]
     try:
         count = int(f["count"])
-        if count != pend["count"] or count < base or count > base + len(ent[4]) or pend["gen"] != ent[6]:
+        if pend["gen"] != ent[6]:                          # the entry is not the one the restore was taken for: another
+            with _CKPT_LOCK:                              # read replaced it (the stripe lock makes this a residual)
+                _CKPT_STATS["droppedRestores"] += 1
+            try:
+                sys.stderr.write("checkpoint restore dropped for fold %s of %s: the reader's entry moved under it\n" % (name, key))
+            except Exception:
+                pass
+            return None
+        if count != pend["count"] or count < base or count > base + len(ent[4]):
             return None
         state = _ckpt_decode(f["state"])
         with _CKPT_LOCK:
@@ -888,7 +906,12 @@ def checkpoint_write(path, force=False):
         if cur is None or cur[0] != count or cur[1] != gen:
             continue
         try:
-            folds[name] = {"count": count, "state": _ckpt_encode(cur[2])}
+            enc = _ckpt_encode(cur[2])
+            if len(json.dumps(enc, separators=(",", ":"))) > _CKPT_FOLD_CAP:
+                with _CKPT_LOCK:                          # a state the size of its file: the document must not become the file
+                    _CKPT_STATS["oversizeFolds"][name] = _CKPT_STATS["oversizeFolds"].get(name, 0) + 1
+                continue
+            folds[name] = {"count": count, "state": enc}
         except TypeError:
             with _CKPT_LOCK:
                 _CKPT_STATS["skippedFolds"] += 1
@@ -939,7 +962,9 @@ def checkpoint_sweep():
     for cp in Path(d).glob("*.json"):
         keep = False
         try:
-            doc = json.loads(cp.read_text())
+            text = cp.read_bytes()
+            _count_read(str(cp), len(text))
+            doc = json.loads(text.decode("utf-8"))
             keep = isinstance(doc, dict) and isinstance(doc.get("path"), str) and os.path.exists(doc["path"])
         except (OSError, ValueError):
             keep = False
@@ -956,6 +981,10 @@ def checkpoint_sweep():
 def checkpoint_stats():
     with _CKPT_LOCK:
         out = dict(_CKPT_STATS); out["fallbacks"] = dict(_CKPT_STATS["fallbacks"]); out["restoredFolds"] = dict(_CKPT_STATS["restoredFolds"])
+        out["oversizeFolds"] = dict(_CKPT_STATS["oversizeFolds"])
+    d = _ckpt_dir()
+    with _READ_BYTES_LOCK:
+        out["documentBytes"] = sum(n for p_, n in _READ_BYTES.items() if d is not None and p_.startswith(str(d) + os.sep))
         out["dirty"] = len(_FOLD_DIRTY)
     rb = read_bytes_report()
     out["readBytes"] = rb.pop("total")
@@ -999,7 +1028,42 @@ _READER_TRACE = bool(os.environ.get("ROMP_READER_TRACE"))   # one stderr line pe
 _LAST_ENTRY = threading.local()   # .ent: the entry the last _read_jsonl_incremental on this thread served
 
 
+_READ_STRIPES = [threading.RLock() for _ in range(64)]   # per-path serialization of the reads that pull bytes: two threads
+#                                                            meeting a file's first read at once (the judges' parse and the pusher's
+#                                                            folds at boot) used to read it twice and, with a checkpoint in play, the
+#                                                            later store's generation orphaned the earlier restore's pending fold
+#                                                            states (review find, 2026-09-11); the second thread now waits and hits.
+#                                                            Striped by path hash, so at most one in 64 unrelated files waits behind another.
+
+
+def _read_stripe(path):
+    return _READ_STRIPES[hash(path) % len(_READ_STRIPES)]
+
+
 def _read_jsonl_entry(path, on_fail=None, tail_ok=False):
+    """The reader's cache entry for `path`, current as of this call (the contract at _read_jsonl_entry_unlocked). A hit
+    is served under the cache lock alone; a read that would pull bytes runs under the path's stripe lock and re-checks
+    the cache first, so concurrent first reads of one file cost one read and one generation."""
+    path = str(path)
+    try:
+        st = os.stat(path)
+    except OSError as e:
+        with _JSONL_CACHE_LOCK:
+            _JSONL_CACHE.pop(path, None)
+        if on_fail is not None and not isinstance(e, FileNotFoundError):
+            on_fail(e)
+        return None
+    with _JSONL_CACHE_LOCK:
+        hit = _JSONL_CACHE.get(path)
+        if hit is not None and hit[0] == st.st_mtime and hit[1] == st.st_size and (tail_ok or hit[5] == 0):
+            _JSONL_CACHE.pop(path, None)  # reinsert at the LRU tail: a served entry is a USED entry
+            _JSONL_CACHE[path] = hit
+            return hit
+    with _read_stripe(path):
+        return _read_jsonl_entry_unlocked(path, on_fail=on_fail, tail_ok=tail_ok)
+
+
+def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False):
     """The reader's cache entry for `path`, (mtime, size, offset, tail, records, base, gen), current as of this call,
     or None when the file is absent or unreadable (`on_fail` as in _read_jsonl_incremental). With `tail_ok` a caller
     accepts a TAIL entry (base > 0: records[0] is the file's record number base), and a first touch with no entry

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -548,7 +548,7 @@ def _bg_finish(state, want_all=False):
     return keep[:60]
 
 
-def scan_bg_tasks_cached(path, cache, want_all=False):
+def scan_bg_tasks_cached(path, cache, want_all=False, ckpt=None):
     """_scan_bg_tasks folded append-incrementally through `cache` (fold_records): a changed transcript
     steps only its appended records instead of re-pairing the whole file — the kernel's chat box, awaiting
     source and awaiting-stamp lift, and the judge's settled gate, all asked per push per session, and
@@ -556,7 +556,7 @@ def scan_bg_tasks_cached(path, cache, want_all=False):
     2026-09-02: four such readers over one 180 MB transcript held the push loop at a full core). `cache`
     is the caller's dict (the kernel keeps a running-only and an every-task cache; the judge its own), so
     the two views never invalidate each other and a test's `.clear()` still forces a re-fold."""
-    state = fold_records(cache, path, lambda: _bg_fresh(want_all), _bg_step)
+    state = fold_records(cache, path, lambda: _bg_fresh(want_all), _bg_step, ckpt=ckpt)
     if state["all"] != bool(want_all):                    # the view is baked into the state at init: a cache handed to
         raise ValueError("bg fold cache for %s is shaped for want_all=%r, asked for %r"   # both views would answer
                          % (path, state["all"], bool(want_all)))                          # one of them wrong
@@ -593,7 +593,11 @@ def _read_jsonl(path):
 # (FileAdapter builds fresh atom dicts; nothing writes into a record), matching the kernel's existing
 # whole-parse cache contract. The cached list itself is never extended in place — a grown file stores a
 # NEW list — so a concurrent reader holding the old list is never surprised mid-iteration.
-_JSONL_CACHE = {}                 # path -> (mtime, size, offset, tail_bytes, records); dict order = LRU, hits reinsert
+_JSONL_CACHE = {}                 # path -> (mtime, size, offset, tail_bytes, records, base, gen); dict order = LRU, hits reinsert
+#                                   base: how many records of the file precede records[0] (0 = the whole file is held; > 0 = a
+#                                   TAIL entry restored from a checkpoint, T323 stage 3); gen: bumped on every from-zero read
+#                                   caused by a mismatch (a rewrite, a shrink, a same-size-new-mtime), never by an upgrade
+#                                   from a tail entry to a whole one, so a fold cursor keyed on it survives the upgrade
 _JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-03: the per-session states,
                                   # captions and the postal/nudge logs became tenants — a few KB each — and
                                   # must never evict a live transcript's slot) — past the cap, evict the least-recently-USED entry, one per
@@ -613,6 +617,308 @@ _JSONL_CACHE_LOCK = threading.Lock()   # the cache has cross-thread callers (the
                                        # lock covers only the cheap dict ops — the parse runs outside it —
                                        # and pops stay guarded so a lost race degrades to a re-parse, never
                                        # a raise
+
+
+_READ_BYTES = {}                  # path -> bytes this process read from it through the reader (the exit-then-boot witness; /perf)
+_READ_BYTES_LOCK = threading.Lock()
+
+
+def _count_read(path, n):
+    with _READ_BYTES_LOCK:
+        _READ_BYTES[path] = _READ_BYTES.get(path, 0) + int(n)
+
+
+def read_bytes_report():
+    """{path: bytes read since this process began} plus "total": what the reader itself pulled off disk, file by
+    file, so a test or /perf can say how much of a boot was tails and how much whole files."""
+    with _READ_BYTES_LOCK:
+        out = dict(_READ_BYTES)
+    out["total"] = sum(out.values())
+    return out
+
+
+# ───────────────────────── fold checkpoints (T323 stage 3, 2026-09-11) ─────────────────────────
+# A checkpoint is one small JSON file per folded JSONL file, under the state root's checkpoints/ directory, named by
+# the sha1 of the file's realpath. It records the reader's PREFIX WITNESS (the byte offset past the last complete
+# line, the up-to-64 bytes before it, the record count before it) and, for every fold_records fold whose cursor stood
+# at that count, the fold's state (through _ckpt_encode: sets and tuples survive the JSON). A fresh process that folds
+# the file restores the witness, verifies the guard bytes on disk and reads only offset..EOF; the folds resume from
+# their recorded states over the tail. Anything that does not verify (version, path, a shrunk file, a rewrite under the
+# guard, a same-size-new-mtime, a corrupt document) falls back to a whole read from zero, is counted per reason and
+# says so on stderr. The directory is asked of a provider the kernel/judge install (it follows _rebind_state); with no
+# provider, checkpoints are off and every fold behaves as before. Writes are event-keyed by the kernel (a session's
+# settle, its states log moving, exit), never by a timer.
+_CKPT_V = 1
+_CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None = checkpoints off
+_CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}}
+_CKPT_LOCK = threading.Lock()
+_CKPT_PENDING = {}                # path -> {"count": N, "gen": g, "folds": {name: {"count", "state"}}} restores not yet taken
+_CKPT_SEQ = {}                    # path -> the seq of the last checkpoint read or written for it
+_FOLD_DIRTY = set()               # paths whose fold cursors moved since their checkpoint was last written
+_FOLD_REG = {}                    # checkpoint name -> the fold's cursor dict (fold_records registers at first call)
+
+
+def set_checkpoint_dir(fn):
+    """Kernel/judge wiring: `fn()` names the checkpoint directory (a Path) at CALL time, so a rebound state root
+    moves it. None turns checkpoints off."""
+    global _CKPT_DIR_FN
+    _CKPT_DIR_FN = fn
+    with _CKPT_LOCK:
+        _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear()
+
+
+def _ckpt_dir():
+    fn = _CKPT_DIR_FN
+    return None if fn is None else fn()
+
+
+def _ckpt_file(path):
+    d = _ckpt_dir()
+    if d is None:
+        return None
+    return Path(d) / (hashlib.sha1(os.path.realpath(str(path)).encode("utf-8")).hexdigest()[:20] + ".json")
+
+
+def _ckpt_fallback(path, reason, detail=""):
+    """A checkpoint that did not verify: counted per reason, said once on stderr, and its file removed so the next
+    write starts clean. The caller reads the whole file from zero."""
+    with _CKPT_LOCK:
+        _CKPT_STATS["fallbacks"][reason] = _CKPT_STATS["fallbacks"].get(reason, 0) + 1
+        _CKPT_PENDING.pop(str(path), None)
+    try:
+        sys.stderr.write("checkpoint fallback (%s) for %s%s\n" % (reason, path, (": " + detail) if detail else ""))
+    except Exception:
+        pass
+    cp = _ckpt_file(path)
+    if cp is not None:
+        try:
+            cp.unlink()
+        except OSError:
+            pass
+
+
+def _ckpt_encode(o):
+    """The fold states are plain data (dict, list, set, tuple, str, int, float, bool, None); JSON keeps dicts with
+    string keys and lists, so sets, tuples and non-string-keyed dicts are tagged. Raises TypeError on anything else,
+    which the writer treats as a fold that cannot be checkpointed (counted, never a torn state)."""
+    if o is None or isinstance(o, (bool, int, float, str)):
+        return o
+    if isinstance(o, list):
+        return [_ckpt_encode(x) for x in o]
+    if isinstance(o, tuple):
+        return {"~tuple": [_ckpt_encode(x) for x in o]}
+    if isinstance(o, (set, frozenset)):
+        return {"~set": sorted((_ckpt_encode(x) for x in o), key=lambda x: json.dumps(x, sort_keys=True))}
+    if isinstance(o, dict):
+        if all(isinstance(k, str) and not k.startswith("~") for k in o):
+            return {k: _ckpt_encode(v) for k, v in o.items()}
+        return {"~dict": [[_ckpt_encode(k), _ckpt_encode(v)] for k, v in o.items()]}
+    raise TypeError("not checkpointable: %s" % type(o).__name__)
+
+
+def _ckpt_decode(o):
+    if isinstance(o, list):
+        return [_ckpt_decode(x) for x in o]
+    if isinstance(o, dict):
+        if len(o) == 1:
+            (k, v), = o.items()
+            if k == "~tuple":
+                return tuple(_ckpt_decode(x) for x in v)
+            if k == "~set":
+                return set(_ckpt_decode(x) for x in v)
+            if k == "~dict":
+                return {_ckpt_decode(a): _ckpt_decode(b) for a, b in v}
+        return {k: _ckpt_decode(v) for k, v in o.items()}
+    return o
+
+
+def _ckpt_load(path):
+    """The verified-by-shape checkpoint document for `path`, or None (absent, or a fallback was counted)."""
+    cp = _ckpt_file(path)
+    if cp is None or not cp.exists():
+        return None
+    try:
+        doc = json.loads(cp.read_text())
+    except (OSError, ValueError) as e:
+        _ckpt_fallback(path, "corrupt", str(e)[:80]); return None
+    if not isinstance(doc, dict) or doc.get("v") != _CKPT_V:
+        _ckpt_fallback(path, "version", repr(doc.get("v")) if isinstance(doc, dict) else "not a document"); return None
+    if doc.get("path") != os.path.realpath(str(path)):
+        _ckpt_fallback(path, "path", str(doc.get("path"))[:80]); return None
+    try:
+        offset, count, size = int(doc["offset"]), int(doc["count"]), int(doc["size"])
+        guard = bytes.fromhex(doc.get("guard") or "")
+        folds = doc.get("folds") or {}
+        if offset < 0 or count < 0 or len(guard) > _JSONL_TAIL_GUARD or not isinstance(folds, dict):
+            raise ValueError("shape")
+    except (KeyError, TypeError, ValueError) as e:
+        _ckpt_fallback(path, "corrupt", "shape: %s" % e); return None
+    return doc
+
+
+def _checkpoint_entry(path, st):
+    """A TAIL reader entry restored from `path`'s checkpoint, (mtime, size, offset, guard, [], count, 0), or None. The
+    guard bytes are verified by the reader against the file; here the document and the size are: a file shorter than
+    the recorded offset is a shrink."""
+    doc = _ckpt_load(path)
+    if doc is None:
+        return None
+    offset, count = int(doc["offset"]), int(doc["count"])
+    if st.st_size < offset:
+        _ckpt_fallback(path, "shrunk", "%d < %d" % (st.st_size, offset)); return None
+    with _CKPT_LOCK:
+        _CKPT_PENDING[str(path)] = {"count": count, "gen": 0, "folds": dict(doc.get("folds") or {})}
+        _CKPT_SEQ[str(path)] = int(doc.get("seq") or 0)
+    return (float(doc.get("mtime") or 0), int(doc["size"]), offset, bytes.fromhex(doc.get("guard") or ""), [], count, 0)
+
+
+def _ckpt_pending(path, ent):
+    """The restores waiting for `path`'s folds, given the reader's current entry: the ones a tail restore left, or,
+    when a whole reader read the file first (the entry holds every record and no restore happened), the checkpoint's
+    fold states after its guard is verified on disk by one 64-byte read. None when there is nothing to resume."""
+    key = str(path)
+    with _CKPT_LOCK:
+        pend = _CKPT_PENDING.get(key)
+    if pend is not None or ent is None or ent[5] != 0 or _CKPT_DIR_FN is None:
+        return pend
+    with _CKPT_LOCK:
+        if key in _CKPT_SEQ:                          # already consulted (or written) in this process: nothing new
+            return None
+    doc = _ckpt_load(path)
+    if doc is None:
+        with _CKPT_LOCK:
+            _CKPT_SEQ.setdefault(key, 0)
+        return None
+    offset, count, guard = int(doc["offset"]), int(doc["count"]), bytes.fromhex(doc.get("guard") or "")
+    ok = False
+    try:
+        with open(path, "rb") as fh:
+            fh.seek(max(0, offset - len(guard)))
+            ok = fh.read(len(guard)) == guard and ent[1] >= offset
+        _count_read(key, len(guard))
+    except OSError:
+        ok = False
+    if not ok or count > ent[5] + len(ent[4]):
+        _ckpt_fallback(path, "guard"); return None
+    pend = {"count": count, "gen": ent[6], "folds": dict(doc.get("folds") or {})}
+    with _CKPT_LOCK:
+        _CKPT_PENDING[key] = pend
+        _CKPT_SEQ[key] = int(doc.get("seq") or 0)
+        _CKPT_STATS["restored"] += 1
+    return pend
+
+
+def _restored_cursor(key, name, ent):
+    """The fold cursor (count, gen, state) a checkpoint carries for fold `name` of `key`, when it stands at a count
+    the current entry can resume from; None otherwise. Each fold's restore is taken once."""
+    pend = _ckpt_pending(key, ent)
+    if pend is None:
+        return None
+    f = pend["folds"].pop(name, None)
+    if not isinstance(f, dict):
+        return None
+    base = ent[5]
+    try:
+        count = int(f["count"])
+        if count != pend["count"] or count < base or count > base + len(ent[4]) or pend["gen"] != ent[6]:
+            return None
+        return (count, ent[6], _ckpt_decode(f["state"]))
+    except (KeyError, TypeError, ValueError) as e:
+        _ckpt_fallback(key, "corrupt", "fold %s: %s" % (name, e)); return None
+
+
+def checkpoint_write(path, force=False):
+    """Write `path`'s checkpoint from the reader's entry and every registered fold whose cursor stands at the entry's
+    record count. False when there is nothing to write (no entry, or no fold at the witness and not `force`)."""
+    key = str(path)
+    cp = _ckpt_file(key)
+    if cp is None:
+        return False
+    with _JSONL_CACHE_LOCK:
+        ent = _JSONL_CACHE.get(key)
+    if ent is None:
+        return False
+    mtime, size, offset, tail, records, base, gen = ent
+    count = base + len(records)
+    folds = {}
+    for name, cache in list(_FOLD_REG.items()):
+        cur = cache.get(key)
+        if cur is None or cur[0] != count or cur[1] != gen:
+            continue
+        try:
+            folds[name] = {"count": count, "state": _ckpt_encode(cur[2])}
+        except TypeError:
+            with _CKPT_LOCK:
+                _CKPT_STATS["skippedFolds"] += 1
+    if not folds and not force:
+        return False
+    last = records[-1] if records else None
+    with _CKPT_LOCK:
+        seq = _CKPT_SEQ.get(key, 0) + 1
+    doc = {"v": _CKPT_V, "path": os.path.realpath(key), "size": int(size), "mtime": float(mtime), "offset": int(offset),
+           "guard": tail.hex(), "count": int(count), "lastUuid": (last.get("uuid") if isinstance(last, dict) else None),
+           "seq": seq, "t": time.time(), "folds": folds}
+    try:
+        cp.parent.mkdir(parents=True, exist_ok=True)
+        tmp = cp.with_name("%s.%d.%x.tmp" % (cp.name, os.getpid(), threading.get_ident()))
+        tmp.write_text(json.dumps(doc, separators=(",", ":")))
+        os.replace(tmp, cp)
+    except OSError:
+        return False
+    with _CKPT_LOCK:
+        _CKPT_SEQ[key] = seq
+        _CKPT_STATS["writes"] += 1
+        _FOLD_DIRTY.discard(key)
+    return True
+
+
+def checkpoint_dirty():
+    """The paths whose fold cursors moved since their checkpoint was last written."""
+    with _CKPT_LOCK:
+        return sorted(_FOLD_DIRTY)
+
+
+def checkpoint_write_dirty(paths=None):
+    """Write the checkpoints of `paths` (default: every dirty path); returns how many were written."""
+    n = 0
+    for p in (checkpoint_dirty() if paths is None else [str(p) for p in paths]):
+        if checkpoint_write(p):
+            n += 1
+    return n
+
+
+def checkpoint_sweep():
+    """One pass over the checkpoint directory at boot: a document whose recorded file no longer exists, or that does
+    not parse, is removed (counted as swept), so cleared and removed sessions do not grow the directory forever."""
+    d = _ckpt_dir()
+    if d is None or not Path(d).is_dir():
+        return 0
+    gone = 0
+    for cp in Path(d).glob("*.json"):
+        keep = False
+        try:
+            doc = json.loads(cp.read_text())
+            keep = isinstance(doc, dict) and isinstance(doc.get("path"), str) and os.path.exists(doc["path"])
+        except (OSError, ValueError):
+            keep = False
+        if not keep:
+            try:
+                cp.unlink(); gone += 1
+            except OSError:
+                pass
+    with _CKPT_LOCK:
+        _CKPT_STATS["swept"] += gone
+    return gone
+
+
+def checkpoint_stats():
+    with _CKPT_LOCK:
+        out = dict(_CKPT_STATS); out["fallbacks"] = dict(_CKPT_STATS["fallbacks"])
+        out["dirty"] = len(_FOLD_DIRTY)
+    rb = read_bytes_report()
+    out["readBytes"] = rb.pop("total")
+    out["readByPath"] = rb                            # per file, so a boot can be read as tails versus whole files
+    return out
 
 
 def _scan_jsonl_bytes(data, base_offset):
@@ -639,7 +945,25 @@ def _read_jsonl_incremental(path, on_fail=None):
     when given, is called with the exception for a stat, open or read that raised on a file that EXISTS (any
     OSError but FileNotFoundError): an absent file is a state and answers [] quietly, an unreadable one is a
     failure the caller may count and log (fold_records passes it through as on("fail")). The answer is []
-    either way."""
+    either way. This is the WHOLE-file read: a tail entry a checkpoint restored is upgraded to the whole file
+    first (T323 stage 3); fold_records reads the entry itself through _read_jsonl_entry with tail_ok."""
+    ent = _read_jsonl_entry(path, on_fail=on_fail, tail_ok=bool(getattr(_TAIL_OK, "flag", False)))
+    _LAST_ENTRY.ent = ent
+    return ent[4] if ent is not None else []
+
+
+_TAIL_OK = threading.local()      # .flag: the calling fold accepts a tail entry (set by fold_records around its read)
+_LAST_ENTRY = threading.local()   # .ent: the entry the last _read_jsonl_incremental on this thread served
+
+
+def _read_jsonl_entry(path, on_fail=None, tail_ok=False):
+    """The reader's cache entry for `path`, (mtime, size, offset, tail, records, base, gen), current as of this call,
+    or None when the file is absent or unreadable (`on_fail` as in _read_jsonl_incremental). With `tail_ok` a caller
+    accepts a TAIL entry (base > 0: records[0] is the file's record number base), and a first touch with no entry
+    consults the file's checkpoint (T323 stage 3): the recorded offset's guard bytes are verified on disk and only
+    offset..EOF is read. Without it a tail entry is upgraded to the whole file from zero (same gen: the prefix stood).
+    A mismatch anywhere (the guard, a shrink, a same-size-new-mtime) reads from zero and bumps gen; when the entry
+    came from a checkpoint that is a counted fallback."""
     path = str(path)
     try:
         st = os.stat(path)
@@ -648,26 +972,57 @@ def _read_jsonl_incremental(path, on_fail=None):
             _JSONL_CACHE.pop(path, None)
         if on_fail is not None and not isinstance(e, FileNotFoundError):
             on_fail(e)
-        return []
+        return None
     with _JSONL_CACHE_LOCK:
         hit = _JSONL_CACHE.get(path)
-        if hit is not None and hit[0] == st.st_mtime and hit[1] == st.st_size:
+        if hit is not None and hit[0] == st.st_mtime and hit[1] == st.st_size and (tail_ok or hit[5] == 0):
             _JSONL_CACHE.pop(path, None)  # reinsert at the LRU tail: a served entry is a USED entry
             _JSONL_CACHE[path] = hit
-            return hit[4]
+            return hit
+    restored = None
+    if hit is None and tail_ok and _CKPT_DIR_FN is not None:
+        hit = restored = _checkpoint_entry(path, st)
     try:
         with open(path, "rb") as fh:
-            if hit is not None and st.st_size > hit[1]:
-                _, _, offset, tail, records = hit
+            base, gen, done = 0, (hit[6] if hit is not None else 0), False
+            grown = hit is not None and (st.st_size > hit[1] or (restored is not None and st.st_size == hit[1]
+                                                                    and st.st_mtime == hit[0]))
+            unchanged_tail = (hit is not None and not tail_ok and hit[5] > 0 and st.st_size == hit[1]
+                              and st.st_mtime == hit[0])            # a whole reader meets an unchanged tail entry
+            if grown or unchanged_tail:
+                _, _, offset, tail, records, base0, gen0 = hit
                 fh.seek(max(0, offset - len(tail)))
+                _count_read(path, len(tail))
                 if fh.read(len(tail)) == tail:            # the file really is our cached prefix + more
-                    new, offset = _scan_jsonl_bytes(fh.read(), offset)
-                    records = records + new               # a NEW list — never extend the served one in place
+                    if tail_ok or base0 == 0:
+                        data = fh.read()
+                        _count_read(path, len(data))
+                        new, offset = _scan_jsonl_bytes(data, offset)
+                        records = (records + new) if records else new   # a NEW list — never extend the served one in place
+                        base, gen, done = base0, gen0, True
+                        if restored is not None:
+                            with _CKPT_LOCK:
+                                _CKPT_STATS["restored"] += 1
+                    else:                                 # a whole reader over a tail entry: the whole file, same gen
+                        fh.seek(0)
+                        data = fh.read()
+                        _count_read(path, len(data))
+                        records, offset = _scan_jsonl_bytes(data, 0)
+                        base, gen, done = 0, gen0, True
                 else:
-                    fh.seek(0)                            # prefix changed → a rewrite → full re-read
-                    records, offset = _scan_jsonl_bytes(fh.read(), 0)
-            else:
-                records, offset = _scan_jsonl_bytes(fh.read(), 0)
+                    gen = gen0 + 1                        # prefix changed → a rewrite → full re-read
+                    if restored is not None:
+                        _ckpt_fallback(path, "guard")
+            elif hit is not None:
+                gen = hit[6] + 1                          # shrank, or same size under a new mtime: a rewrite
+                if restored is not None:
+                    _ckpt_fallback(path, "shrunk" if st.st_size < hit[2] else "rewrite")
+            if not done:
+                fh.seek(0)
+                data = fh.read()
+                _count_read(path, len(data))
+                records, offset = _scan_jsonl_bytes(data, 0)
+                base = 0
             tail_from = max(0, offset - _JSONL_TAIL_GUARD)
             fh.seek(tail_from)
             tail = fh.read(offset - tail_from)
@@ -676,72 +1031,111 @@ def _read_jsonl_incremental(path, on_fail=None):
             _JSONL_CACHE.pop(path, None)
         if on_fail is not None and not isinstance(e, FileNotFoundError):
             on_fail(e)
-        return []
+        return None
+    ent = (st.st_mtime, st.st_size, offset, tail, records, base, gen)
     with _JSONL_CACHE_LOCK:
         _JSONL_CACHE.pop(path, None)
         while len(_JSONL_CACHE) >= _JSONL_CACHE_MAX:
             _JSONL_CACHE.pop(next(iter(_JSONL_CACHE)))   # oldest-used first; hot entries survive any cold flood
-        _JSONL_CACHE[path] = (st.st_mtime, st.st_size, offset, tail, records)
-    return records
+        _JSONL_CACHE[path] = ent
+    return ent
 
 
-def fold_records(cache, path, init, step, on=None):
+def fold_records(cache, path, init, step, on=None, ckpt=None):
     """Fold a JSONL file's records into a carried state, APPEND-INCREMENTALLY (issue 903, 2026-09-03):
     the states/transcript readers re-read their whole file behind an (mtime,size) key that every append
-    invalidates — O(file) per push for every working session. _read_jsonl_incremental already serves the
-    parsed records of a growing file incrementally (the parse reads the same list, so this adds no I/O),
-    and its contract — a grown file returns a NEW list whose prefix objects are the SAME — is the
-    identity gate here: when the cached prefix is intact, only the appended records run through `step`;
-    a rewrite (prefix identity lost, a shrink, a same-size-new-mtime) re-folds from record 0. `init()`
-    makes a fresh state; `step(state, record)` returns the next state (mutate-and-return is fine: the
-    cached state is deep-copied before folding onto it, so a state a caller was handed never changes
-    under it). Returns the state; [] records (a missing or unreadable file) fold to init().
+    invalidates — O(file) per push for every working session. The reader serves the parsed records of a
+    growing file incrementally (the parse reads the same list, so this adds no I/O), and only the appended
+    records run through `step`; a rewrite (a shrink, a same-size-new-mtime, a changed prefix under the
+    reader's guard) re-folds from record 0. `init()` makes a fresh state; `step(state, record)` returns the
+    next state (mutate-and-return is fine: the cached state is deep-copied before folding onto it, so a
+    state a caller was handed never changes under it). Returns the state; [] records (a missing or
+    unreadable file) fold to init().
+
+    The cursor in `cache` is (count, gen, state): the record count folded and the reader entry's generation
+    (T323 stage 3, 2026-09-11; it was (count, last record object, state) gated on the identity of the
+    records list's objects, which no checkpoint can carry; the count stays first, as every reader of the
+    cursor knew it). A same-gen entry whose count grew is an append;
+    a bumped gen is a rewrite and refolds. `ckpt`, a name, makes the fold RESUMABLE across processes: its
+    cursor is written into the file's checkpoint (checkpoint_write, when it stands at the reader's witness)
+    and restored from it at the first fold of the file in a new process, over a TAIL entry that read only the
+    bytes past the checkpoint's offset; the fold then steps the tail alone. A refold over a tail entry reads
+    the whole file first. Folds without `ckpt` behave as before, over whatever entry the reader holds.
 
     `on`, when given, is called once per call with the path the fold took: "hit" (the records are the
     cached ones; nothing stepped), "append" (only the records past the cached prefix stepped), "refold"
-    (every record stepped: a rewrite, a shrink, or the first fold of this file) or "fail" (the file exists
-    and its stat, open or read raised: the answer is init(), the cache entry for the path is dropped and
-    nothing is memoized, so the next call reads again; an ABSENT file is not a failure and folds to init()
-    through the normal path). A caller's counters ride it (the kernel's `_states_awaiting_overlay`); the
-    fold itself keeps no counters, since one cache dict serves many readers and a caller's counters are
-    locked per reader.
+    (every record stepped: a rewrite, a shrink, or the first fold of this file), "restore" (the cursor came
+    from the checkpoint and only the tail past it was stepped) or "fail" (the file exists and its stat, open
+    or read raised: the answer is init(), the cache entry for the path is dropped and nothing is memoized, so
+    the next call reads again; an ABSENT file is not a failure and folds to init() through the normal path).
+    A caller's counters ride it (the kernel's `_states_awaiting_overlay`); the fold itself keeps no counters,
+    since one cache dict serves many readers and a caller's counters are locked per reader.
 
     Lives here (moved from the kernel, 2026-09-03) so the judge's readers can fold too — the
     background-task pairing below is shared by both."""
     key = str(path)
+    if ckpt is not None:
+        _FOLD_REG[ckpt] = cache                           # the newest caller's cursor dict (a test process loads the kernel
+        #                                                   several times over one event model; production loads it once)
     failed = []                                           # the reader's failures: a stat, open or read that raised on a
-    recs = _read_jsonl_incremental(path, on_fail=failed.append)   # file that exists (an absent file is [] and no failure)
+    recs = _tail_read(path, failed)                       # file that exists (an absent file is [] and no failure)
     ent = _pinned_entry(key, recs)                        # the reader's entry for THIS read, pinned by identity: another
     if ent is _UNPINNED:                                  # thread (the judge pool, a handler) may advance the shared entry
         del failed[:]                                     # past our records before we look at its tail, and a newer tail
-        recs = _read_jsonl_incremental(path, on_fail=failed.append)   # folded onto an older prefix would skip the
-        ent = _pinned_entry(key, recs)                    # records between. A lost pin re-reads once: the newer entry
-        if ent is _UNPINNED:                              # pins cleanly, so the answer is current, not a poll behind;
-            ent = None                                    # lost twice, the fold answers without the tail, never with
-    if failed:                                            # the wrong one. The re-read's verdict is the one that counts.
+        recs = _tail_read(path, failed)                   # folded onto an older prefix would skip the records between. A
+        ent = _pinned_entry(key, recs)                    # lost pin re-reads once: the newer entry pins cleanly, so the
+        if ent is _UNPINNED:                              # answer is current, not a poll behind; lost twice, the fold
+            ent = None                                    # answers its own records without a tail, never with the wrong
+    if failed:                                            # one. The re-read's verdict is the one that counts.
         cache.pop(key, None)                              # A failed read is never memoized: the next call reads again
         if on is not None:
             on("fail")
         return init()
+    base = ent[5] if ent is not None else 0               # no entry (lost twice): the records in hand, whole, no tail
+
+    gen = ent[6] if ent is not None else 0
+    total = base + len(recs)
     hit = cache.get(key)
+    kind = None
+    if hit is None and ckpt is not None and ent is not None:
+        hit = _restored_cursor(key, ckpt, ent)
+        if hit is not None:
+            kind = "restore"
     if hit is not None:
-        n0, last0, state0 = hit
-        if n0 == len(recs) and (n0 == 0 or recs[-1] is last0):
+        n0, g0, state0 = hit
+        if g0 == gen and n0 == total:
             if on is not None:
-                on("hit")
+                on("hit" if kind is None else kind)
+            if kind is not None:
+                cache[key] = hit                          # a restore at the witness: the cursor stands, nothing stepped
             return _fold_eof_fragment(key, ent, state0, step)   # unchanged records; a newline-less tail may still sit past them
-        if 0 < n0 < len(recs) and recs[n0 - 1] is last0:
-            state, start, kind = copy.deepcopy(state0), n0, "append"
+        if g0 == gen and base <= n0 < total:
+            state, start = copy.deepcopy(state0), n0 - base
+            kind = kind or "append"
         else:
-            state, start, kind = init(), 0, "refold"
-    else:
+            kind = None
+    if kind is None:
+        if base > 0:                                      # a refold needs every record: the entry is a tail, so read whole
+            del failed[:]
+            ent = _read_jsonl_entry(path, on_fail=failed.append, tail_ok=False)
+            if failed:
+                cache.pop(key, None)
+                if on is not None:
+                    on("fail")
+                return init()
+            recs = ent[4] if ent is not None else []
+            gen = ent[6] if ent is not None else 0
+            total = len(recs)
         state, start, kind = init(), 0, "refold"
     for r in recs[start:]:
         if isinstance(r, dict):
             state = step(state, r)
     if len(cache) > 256:                                  # bounded by the session count; never unbounded
         cache.clear()
-    cache[key] = (len(recs), recs[-1] if recs else None, state)
+    cache[key] = (total, gen, state)
+    if ckpt is not None:
+        with _CKPT_LOCK:
+            _FOLD_DIRTY.add(key)
     if on is not None:
         on(kind)
     return _fold_eof_fragment(key, ent, state, step)
@@ -750,10 +1144,25 @@ def fold_records(cache, path, init, step, on=None):
 _UNPINNED = object()
 
 
+def _tail_read(path, failed):
+    """fold_records' read: the whole-list reader (the seam every fold shares, so a test's stub or counter on
+    _read_jsonl_incremental still sees every fold read) with the tail flag raised, so a checkpoint-restored tail
+    entry is served instead of upgraded to the whole file."""
+    _TAIL_OK.flag = True
+    try:
+        return _read_jsonl_incremental(path, on_fail=failed.append)
+    finally:
+        _TAIL_OK.flag = False
+
+
 def _pinned_entry(key, recs):
     """The shared reader's cache entry for `key` if it still describes the read that returned `recs` (its
     records list IS `recs`), None when the reader holds nothing for the path, _UNPINNED when another thread
-    has advanced the entry past that read."""
+    has advanced the entry past that read. The entry the reader served on this thread is checked first
+    (T323 stage 3: an entry evicted from the cache between the read and the pin still describes the read)."""
+    last = getattr(_LAST_ENTRY, "ent", None)
+    if last is not None and last[4] is recs:
+        return last
     with _JSONL_CACHE_LOCK:
         ent = _JSONL_CACHE.get(key)
     if ent is not None and ent[4] is recs:

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -595,9 +595,10 @@ def _read_jsonl(path):
 # NEW list — so a concurrent reader holding the old list is never surprised mid-iteration.
 _JSONL_CACHE = {}                 # path -> (mtime, size, offset, tail_bytes, records, base, gen); dict order = LRU, hits reinsert
 #                                   base: how many records of the file precede records[0] (0 = the whole file is held; > 0 = a
-#                                   TAIL entry restored from a checkpoint, T323 stage 3); gen: bumped on every from-zero read
-#                                   caused by a mismatch (a rewrite, a shrink, a same-size-new-mtime), never by an upgrade
-#                                   from a tail entry to a whole one, so a fold cursor keyed on it survives the upgrade
+#                                   TAIL entry restored from a checkpoint, T323 stage 3); gen: a process-wide counter's value,
+#                                   fresh for every from-zero read and every restored entry (a mismatch, an eviction, a first
+#                                   read), kept across an upgrade from a tail entry to a whole one and across appends, so a
+#                                   fold cursor keyed on it survives those and nothing else
 _JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-03: the per-session states,
                                   # captions and the postal/nudge logs became tenants — a few KB each — and
                                   # must never evict a live transcript's slot) — past the cap, evict the least-recently-USED entry, one per
@@ -650,12 +651,22 @@ def read_bytes_report():
 # settle, its states log moving, exit), never by a timer.
 _CKPT_V = 1
 _CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None = checkpoints off
-_CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}}
+_CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}}
 _CKPT_LOCK = threading.Lock()
 _CKPT_PENDING = {}                # path -> {"count": N, "gen": g, "folds": {name: {"count", "state"}}} restores not yet taken
 _CKPT_SEQ = {}                    # path -> the seq of the last checkpoint read or written for it
 _FOLD_DIRTY = set()               # paths whose fold cursors moved since their checkpoint was last written
 _FOLD_REG = {}                    # checkpoint name -> the fold's cursor dict (fold_records registers at first call)
+_GEN = [0]                        # the reader's generation counter: every from-zero read and every restored entry takes the
+#                                   next value, process-wide, so no two entries of a path ever share one (a cursor left by an
+#                                   entry the cache evicted or a stat failure popped must never match a later read's, since
+#                                   the later read may be of a rewritten file with as many records; review find, 2026-09-11)
+
+
+def _next_gen():
+    with _JSONL_CACHE_LOCK:
+        _GEN[0] += 1
+        return _GEN[0]
 _FOLD_NAME_OF = {}                # id(cursor dict) -> checkpoint name, for callers that name their cache once (name_fold_cache)
 
 
@@ -765,6 +776,20 @@ def _ckpt_load(path):
     return doc
 
 
+def _ckpt_verdict(doc, st_size, st_mtime):
+    """What the file's stat says about a checkpoint document before its guard is read: "shrunk" (the file ends before
+    the recorded offset), "rewrite" (the same size under another mtime, or shorter than recorded while past the offset:
+    a rewrite the guard could miss), or None (grown, or the very file the document describes: the guard decides). Both
+    restore paths (the tail read and the whole-reader-first fold) ask this, so one rewrite gets one verdict and one
+    fallback reason whichever reader came first."""
+    offset, size, mtime = int(doc["offset"]), int(doc["size"]), float(doc.get("mtime") or 0)
+    if st_size < offset:
+        return "shrunk"
+    if st_size < size or (st_size == size and st_mtime != mtime):
+        return "rewrite"
+    return None
+
+
 def _checkpoint_entry(path, st):
     """A TAIL reader entry restored from `path`'s checkpoint, (mtime, size, offset, guard, [], count, 0), or None. The
     guard bytes are verified by the reader against the file; here the document and the size are: a file shorter than
@@ -773,12 +798,14 @@ def _checkpoint_entry(path, st):
     if doc is None:
         return None
     offset, count = int(doc["offset"]), int(doc["count"])
-    if st.st_size < offset:
-        _ckpt_fallback(path, "shrunk", "%d < %d" % (st.st_size, offset)); return None
+    verdict = _ckpt_verdict(doc, st.st_size, st.st_mtime)
+    if verdict is not None:
+        _ckpt_fallback(path, verdict, "size %d, recorded %d at offset %d" % (st.st_size, int(doc["size"]), offset)); return None
+    gen = _next_gen()
     with _CKPT_LOCK:
-        _CKPT_PENDING[str(path)] = {"count": count, "gen": 0, "folds": dict(doc.get("folds") or {})}
+        _CKPT_PENDING[str(path)] = {"count": count, "gen": gen, "folds": dict(doc.get("folds") or {})}
         _CKPT_SEQ[str(path)] = int(doc.get("seq") or 0)
-    return (float(doc.get("mtime") or 0), int(doc["size"]), offset, bytes.fromhex(doc.get("guard") or ""), [], count, 0)
+    return (float(doc.get("mtime") or 0), int(doc["size"]), offset, bytes.fromhex(doc.get("guard") or ""), [], count, gen)
 
 
 def _ckpt_pending(path, ent):
@@ -799,16 +826,19 @@ def _ckpt_pending(path, ent):
             _CKPT_SEQ.setdefault(key, 0)
         return None
     offset, count, guard = int(doc["offset"]), int(doc["count"]), bytes.fromhex(doc.get("guard") or "")
+    verdict = _ckpt_verdict(doc, ent[1], ent[0])          # the same facts the tail path checks: size, mtime, then the guard
+    if verdict is not None:
+        _ckpt_fallback(path, verdict, "whole reader first"); return None
     ok = False
     try:
         with open(path, "rb") as fh:
             fh.seek(max(0, offset - len(guard)))
-            ok = fh.read(len(guard)) == guard and ent[1] >= offset
+            ok = fh.read(len(guard)) == guard
         _count_read(key, len(guard))
     except OSError:
         ok = False
     if not ok or count > ent[5] + len(ent[4]):
-        _ckpt_fallback(path, "guard"); return None
+        _ckpt_fallback(path, "guard", "whole reader first"); return None
     pend = {"count": count, "gen": ent[6], "folds": dict(doc.get("folds") or {})}
     with _CKPT_LOCK:
         _CKPT_PENDING[key] = pend
@@ -831,7 +861,10 @@ def _restored_cursor(key, name, ent):
         count = int(f["count"])
         if count != pend["count"] or count < base or count > base + len(ent[4]) or pend["gen"] != ent[6]:
             return None
-        return (count, ent[6], _ckpt_decode(f["state"]))
+        state = _ckpt_decode(f["state"])
+        with _CKPT_LOCK:
+            _CKPT_STATS["restoredFolds"][name] = _CKPT_STATS["restoredFolds"].get(name, 0) + 1
+        return (count, ent[6], state)
     except (KeyError, TypeError, ValueError) as e:
         _ckpt_fallback(key, "corrupt", "fold %s: %s" % (name, e)); return None
 
@@ -922,7 +955,7 @@ def checkpoint_sweep():
 
 def checkpoint_stats():
     with _CKPT_LOCK:
-        out = dict(_CKPT_STATS); out["fallbacks"] = dict(_CKPT_STATS["fallbacks"])
+        out = dict(_CKPT_STATS); out["fallbacks"] = dict(_CKPT_STATS["fallbacks"]); out["restoredFolds"] = dict(_CKPT_STATS["restoredFolds"])
         out["dirty"] = len(_FOLD_DIRTY)
     rb = read_bytes_report()
     out["readBytes"] = rb.pop("total")
@@ -962,6 +995,7 @@ def _read_jsonl_incremental(path, on_fail=None):
 
 
 _TAIL_OK = threading.local()      # .flag: the calling fold accepts a tail entry (set by fold_records around its read)
+_READER_TRACE = bool(os.environ.get("ROMP_READER_TRACE"))   # one stderr line per read that pulled bytes (a diagnosis aid)
 _LAST_ENTRY = threading.local()   # .ent: the entry the last _read_jsonl_incremental on this thread served
 
 
@@ -993,7 +1027,7 @@ def _read_jsonl_entry(path, on_fail=None, tail_ok=False):
         hit = restored = _checkpoint_entry(path, st)
     try:
         with open(path, "rb") as fh:
-            base, gen, done = 0, (hit[6] if hit is not None else 0), False
+            base, gen, done, kind = 0, None, False, "zero"
             grown = hit is not None and (st.st_size > hit[1] or (restored is not None and st.st_size == hit[1]
                                                                     and st.st_mtime == hit[0]))
             unchanged_tail = (hit is not None and not tail_ok and hit[5] > 0 and st.st_size == hit[1]
@@ -1009,6 +1043,7 @@ def _read_jsonl_entry(path, on_fail=None, tail_ok=False):
                         new, offset = _scan_jsonl_bytes(data, offset)
                         records = (records + new) if records else new   # a NEW list — never extend the served one in place
                         base, gen, done = base0, gen0, True
+                        kind = "restore" if restored is not None else "grown"
                         if restored is not None:
                             with _CKPT_LOCK:
                                 _CKPT_STATS["restored"] += 1
@@ -1017,24 +1052,27 @@ def _read_jsonl_entry(path, on_fail=None, tail_ok=False):
                         data = fh.read()
                         _count_read(path, len(data))
                         records, offset = _scan_jsonl_bytes(data, 0)
-                        base, gen, done = 0, gen0, True
+                        base, gen, done, kind = 0, gen0, True, "upgrade"
                 else:
-                    gen = gen0 + 1                        # prefix changed → a rewrite → full re-read
+                    kind = "guard"                        # prefix changed → a rewrite → full re-read, a fresh generation
                     if restored is not None:
                         _ckpt_fallback(path, "guard")
             elif hit is not None:
-                gen = hit[6] + 1                          # shrank, or same size under a new mtime: a rewrite
+                kind = "shrunk" if st.st_size < hit[2] else "rewrite"   # shrank, or same size under a new mtime: a rewrite
                 if restored is not None:
-                    _ckpt_fallback(path, "shrunk" if st.st_size < hit[2] else "rewrite")
+                    _ckpt_fallback(path, kind)
             if not done:
                 fh.seek(0)
                 data = fh.read()
                 _count_read(path, len(data))
                 records, offset = _scan_jsonl_bytes(data, 0)
-                base = 0
+                base, gen = 0, _next_gen()                # a from-zero read: a generation no cursor of this path can hold
             tail_from = max(0, offset - _JSONL_TAIL_GUARD)
             fh.seek(tail_from)
             tail = fh.read(offset - tail_from)
+            _count_read(path, len(tail))                  # the guard capture is a read too (/perf's count is what was pulled)
+            if _READER_TRACE:
+                sys.stderr.write("reader: %s %s base=%d gen=%d size=%d\n" % (kind, path, base, gen, st.st_size))
     except OSError as e:
         with _JSONL_CACHE_LOCK:
             _JSONL_CACHE.pop(path, None)
@@ -1064,8 +1102,9 @@ def fold_records(cache, path, init, step, on=None, ckpt=None):
     The cursor in `cache` is (count, gen, state): the record count folded and the reader entry's generation
     (T323 stage 3, 2026-09-11; it was (count, last record object, state) gated on the identity of the
     records list's objects, which no checkpoint can carry; the count stays first, as every reader of the
-    cursor knew it). A same-gen entry whose count grew is an append;
-    a bumped gen is a rewrite and refolds. `ckpt`, a name, makes the fold RESUMABLE across processes: its
+    cursor knew it). A same-gen entry whose count grew is an append; any other gen (a rewrite, a shrink, an
+    entry the cache evicted or a failure popped and a later read replaced: every from-zero read takes a
+    fresh process-wide generation) refolds. `ckpt`, a name, makes the fold RESUMABLE across processes: its
     cursor is written into the file's checkpoint (checkpoint_write, when it stands at the reader's witness)
     and restored from it at the first fold of the file in a new process, over a TAIL entry that read only the
     bytes past the checkpoint's offset; the fold then steps the tail alone. A refold over a tail entry reads
@@ -1216,6 +1255,7 @@ def _trailing_record(path, ent):
         with open(path, "rb") as fh:
             fh.seek(ent[2])
             frag = fh.read(ent[1] - ent[2]).strip()
+        _count_read(path, ent[1] - ent[2])
         if frag and b"\n" not in frag:
             o = json.loads(frag.decode("utf-8", "replace"))
     except (OSError, ValueError):

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8662,6 +8662,7 @@ def _session_closed(session):
 
 
 _BG_SCAN_CACHE = {}                       # path -> em.fold_records entry (running tasks) — mirrors the kernel's _bg_scan_cached
+em.name_fold_cache(_BG_SCAN_CACHE, "bgJudge")   # resumable from the file's checkpoint (T323 stage 3); the call shape stays
 
 
 def _bg_unresolved(path, now=None):
@@ -8672,7 +8673,7 @@ def _bg_unresolved(path, now=None):
     planner key's expiry term and the gate's not-before, so none of them can disagree at the crossing);
     the wall clock otherwise."""
     # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records
-    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE, ckpt="bgJudge")
+    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
     # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
     # terminal record, and an idle transcript never busts the mtime key — a cached verdict would say
     # "running" forever (see em._bg_expired)
@@ -8695,7 +8696,7 @@ def _bg_expiry_key(path, now):
     computed is planned every pass; the settle's own call then raises as it does today."""
     try:
         return tuple(sorted((str(t.get("id") or ""), bool(em._bg_expired(t, now)))
-                            for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE, ckpt="bgJudge")))
+                            for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)))
     except Exception:
         return object()
 
@@ -8714,7 +8715,7 @@ def _settle_not_before(fsid, path, now):
     launch the judged world held (the transcript is append-only; a launch that landed after the pass's
     pin moves the parse pair anyway). Never recomputed on a skip: with an unchanged signature the task
     set is unchanged, so the stored instant is exact."""
-    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE, ckpt="bgJudge")
+    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
     sp = _cli_epoch(fsid)
     nb = None
     for t in tasks:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8662,7 +8662,15 @@ def _session_closed(session):
 
 
 _BG_SCAN_CACHE = {}                       # path -> em.fold_records entry (running tasks) — mirrors the kernel's _bg_scan_cached
-em.name_fold_cache(_BG_SCAN_CACHE, "bgJudge")   # resumable from the file's checkpoint (T323 stage 3); the call shape stays
+
+
+def _bg_scan(path):
+    """The judge's background-task pairing over `path`, resumable from the file's checkpoint (T323 stage 3). The name
+    rides the cursor dict and is registered at every call (em.name_fold_cache is idempotent): a test process
+    re-executes the event model under each kernel load, which resets its registry, and the scan's own call shape
+    stays the two arguments a test may stub."""
+    em.name_fold_cache(_BG_SCAN_CACHE, "bgJudge")
+    return em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
 
 
 def _bg_unresolved(path, now=None):
@@ -8673,7 +8681,7 @@ def _bg_unresolved(path, now=None):
     planner key's expiry term and the gate's not-before, so none of them can disagree at the crossing);
     the wall clock otherwise."""
     # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records
-    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
+    tasks = _bg_scan(path)
     # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
     # terminal record, and an idle transcript never busts the mtime key — a cached verdict would say
     # "running" forever (see em._bg_expired)
@@ -8696,7 +8704,7 @@ def _bg_expiry_key(path, now):
     computed is planned every pass; the settle's own call then raises as it does today."""
     try:
         return tuple(sorted((str(t.get("id") or ""), bool(em._bg_expired(t, now)))
-                            for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)))
+                            for t in _bg_scan(path)))
     except Exception:
         return object()
 
@@ -8715,7 +8723,7 @@ def _settle_not_before(fsid, path, now):
     launch the judged world held (the transcript is append-only; a launch that landed after the pass's
     pin moves the parse pair anyway). Never recomputed on a skip: with an unchanged signature the task
     set is unchanged, so the stored instant is exact."""
-    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
+    tasks = _bg_scan(path)
     sp = _cli_epoch(fsid)
     nb = None
     for t in tasks:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -67,6 +67,8 @@ _ls_mod = importlib.util.module_from_spec(_ls_spec)
 _ls_spec.loader.exec_module(_ls_mod)
 load_source = _ls_mod.load_source   # file-path imports with load_module()'s sys.modules semantics (kernel/loadsource.py)
 em = load_source("romp_event_model", HERE / "event_model.py")
+em.set_checkpoint_dir(lambda: STATE / "checkpoints")   # T323 stage 3: the fold checkpoints live under the state root, read at
+#                                                        call time so _rebind_state moves them with everything else
 _cred = sys.modules.get("romp_credentials") or load_source("romp_credentials", HERE / "credentials.py")
 
 HOME     = Path.home()
@@ -8670,7 +8672,7 @@ def _bg_unresolved(path, now=None):
     planner key's expiry term and the gate's not-before, so none of them can disagree at the crossing);
     the wall clock otherwise."""
     # folds append-incrementally since 2026-09-03: a changed transcript steps only its appended records
-    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
+    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE, ckpt="bgJudge")
     # expiry is applied OUTSIDE the cache with a fresh now: a monitor whose CLI died mid-watch has no
     # terminal record, and an idle transcript never busts the mtime key — a cached verdict would say
     # "running" forever (see em._bg_expired)
@@ -8693,7 +8695,7 @@ def _bg_expiry_key(path, now):
     computed is planned every pass; the settle's own call then raises as it does today."""
     try:
         return tuple(sorted((str(t.get("id") or ""), bool(em._bg_expired(t, now)))
-                            for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)))
+                            for t in em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE, ckpt="bgJudge")))
     except Exception:
         return object()
 
@@ -8712,7 +8714,7 @@ def _settle_not_before(fsid, path, now):
     launch the judged world held (the transcript is append-only; a launch that landed after the pass's
     pin moves the parse pair anyway). Never recomputed on a skip: with an unchanged signature the task
     set is unchanged, so the stored instant is exact."""
-    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE)
+    tasks = em.scan_bg_tasks_cached(path, _BG_SCAN_CACHE, ckpt="bgJudge")
     sp = _cli_epoch(fsid)
     nb = None
     for t in tasks:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -8460,6 +8460,16 @@ def _discover_impl(now, window=None, forks=True):
         # ever-growing work bar (the user 2026-07-10).
         last = _sdk_last_sid(sid)
         fork = next(((p, m) for st, p, m in listing if st == last), None) if last else None
+        if fork is None and last:
+            # The /clear race window: the registry's lastSid already names the new transcript but the CLI has not
+            # written its first record, so the file is not on disk yet. Handing out the ANCHOR here (the shape until
+            # 2026-09-11) made every build landing in the window parse the pre-clear anchor cold from the second clear
+            # on (its tree was released at the first clear) and flipped the noted leaf twice. The session's current
+            # transcript is the leaf discover handed out last, so that is what it hands out, when it still exists;
+            # only a fresh process, which noted nothing yet, falls to the anchor (review find carried from stage 2).
+            with _LEAF_LOCK:
+                prev = _LEAF_SEEN.get(sid)
+            fork = next(((p, m) for st, p, m in listing if p == prev), None) if prev else None
         if fork is not None:
             path_str, mt = fork
             _note_leaf(sid, path_str)                    # the leaf flipped here: the previous leaf's trees go

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9455,13 +9455,37 @@ def _last_state(sid):
     so this is the authoritative "properly stopped" signal. The TIME matters for auto-nudge: a progressing
     state recorded AFTER the parsed turn's end means the session is genuinely still working (a newer turn the
     parse hasn't caught up to); one recorded BEFORE it means the turn ended and the post-turn 'waiting' write
-    was lost (e.g. a kernel restart) — a stale record that must not block the nudge forever."""
-    val, vt = "", 0
-    for rec in _states_rows(sid):
-        if isinstance(rec, dict) and isinstance(rec.get("state"), str):
-            val = rec["state"]
-            vt = rec.get("t", vt)
-    return (val, vt)
+    was lost (e.g. a kernel restart) — a stale record that must not block the nudge forever. A fold_records
+    fold since T323 stage 3 (it walked every row of the shared record list per call): the newest row wins, the
+    cursor resumes from the file's checkpoint after a restart, so the log is read as a tail, not whole."""
+    return _fold_records(_last_state_cache, jd.STATE / "states" / ("%s.jsonl" % sid), lambda: ("", 0), _last_state_step,
+                         ckpt="lastState")
+
+
+_last_state_cache = {}            # states path -> fold cursor of _last_state
+_last_natural_state_cache = {}    # states path -> fold cursor of _last_natural_state
+_retrying_since_cache = {}        # states path -> fold cursor of the retrying-stretch start
+
+
+def _last_state_step(state, rec):
+    if isinstance(rec.get("state"), str):
+        return (rec["state"], rec.get("t", state[1]))
+    return state
+
+
+def _last_natural_state_step(state, rec):
+    if isinstance(rec.get("state"), str) and not rec.get("by"):
+        return (rec["state"], rec.get("t", state[1]))
+    return state
+
+
+def _retrying_since_step(since, o):
+    st = o.get("state")
+    if not st:
+        return since                                       # overlay/recovery rows don't bound a stretch
+    if st == "retrying":
+        return since if since is not None else o.get("t")  # first row of the current stretch
+    return None                                            # any real state transition ends the stretch
 
 
 def _last_natural_state(sid):
@@ -9469,13 +9493,10 @@ def _last_natural_state(sid):
     appended for a Stop press (`by` set: _record_idle and the SDK interrupt) skipped. A finished-turn
     signal reads this one: a Stop press is the user's own act, not a turn the session finished (review
     find on #937, 2026-09-07). Served from _states_rows, the append-incremental cache every other states
-    reader uses, so the turn tick's per-cycle ask is a stat while the log is quiet."""
-    val, vt = "", 0
-    for rec in _states_rows(sid):
-        if isinstance(rec, dict) and isinstance(rec.get("state"), str) and not rec.get("by"):
-            val = rec["state"]
-            vt = rec.get("t", vt)
-    return (val, vt)
+    reader uses, so the turn tick's per-cycle ask is a stat while the log is quiet; a fold_records fold since
+    T323 stage 3, resumed from the file's checkpoint after a restart."""
+    return _fold_records(_last_natural_state_cache, jd.STATE / "states" / ("%s.jsonl" % sid), lambda: ("", 0),
+                         _last_natural_state_step, ckpt="lastNaturalState")
 
 
 def _last_state_value(sid):
@@ -25681,19 +25702,11 @@ def _session_retrying(sid, tm):
     unchanged."""
     if not tm or tm.get("state") != "retrying":
         return None
-    since = None
-    try:
-        for o in _states_rows(sid):
-            st = o.get("state") if isinstance(o, dict) else None
-            if not st:
-                continue                                   # overlay/recovery rows don't bound a stretch
-            if st == "retrying":
-                if since is None:
-                    since = o.get("t")                     # first row of the current stretch
-            else:
-                since = None                               # any real state transition ends the stretch
+    try:                                                   # a fold since T323 stage 3 (it re-walked the whole log per call)
+        since = _fold_records(_retrying_since_cache, jd.STATE / "states" / ("%s.jsonl" % sid), lambda: None,
+                              _retrying_since_step, ckpt="retryingSince")
     except Exception:
-        pass
+        since = None
     try:
         count = int(tm.get("retryCount") or 0)
     except (TypeError, ValueError):
@@ -39577,7 +39590,7 @@ def _run_judging(t0, alive_sids, semantic):
     return out
 
 
-_nudge_times_cache = {}                       # path → ((mtime_ns, size), {gid: [t, ...]})
+_nudge_times_cache = {}                       # path → fold cursor (count, gen, {gid: [t, ...]}) (T323 stage 3)
 
 
 def _nudge_times():
@@ -39585,19 +39598,14 @@ def _nudge_times():
     auto-nudge fire) — the card-side nudge HISTORY behind the stalled chip (the user 2026-07-02: a chip
     that just says "stalled" reads like a state romp observed; the evidence that romp DID follow up,
     and when, must be one click away). mtime-cached like _auto_nudge_data; best-effort {}."""
-    p = jd.STATE / "nudge-events.jsonl"
-    try:
-        st = p.stat(); key = (st.st_mtime_ns, st.st_size)
-    except OSError:
-        return {}
-    hit = _nudge_times_cache.get(str(p))
-    if hit is not None and hit[0] == key:
-        return hit[1]
-    idx = {}
-    for o in em._read_jsonl_incremental(p):          # append-incremental (2026-09-03): the log grows on
-        if isinstance(o, dict) and o.get("gid") and o.get("t"):   # most nudge ticks; only new rows decode
-            idx.setdefault(o["gid"], []).append(int(o["t"]))
-    _nudge_times_cache[str(p)] = (key, idx)
+    return _fold_records(_nudge_times_cache, jd.STATE / "nudge-events.jsonl", dict, _nudge_times_step, ckpt="nudgeTimes")
+
+
+def _nudge_times_step(idx, o):
+    """One nudge-events row: the fire time under its goal id. A fold since T323 stage 3 (it re-walked the shared
+    record list on every log move); the cursor resumes from the file's checkpoint after a restart."""
+    if o.get("gid") and o.get("t"):
+        idx.setdefault(o["gid"], []).append(int(o["t"]))
     return idx
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -525,7 +525,10 @@ class _PerfStats:
                 # sharedHits = every hit. A boot with no client reads kernel 0.
                 "parses": dict(parses, total=int(getattr(jd, "parse_misses", lambda: 0)()),
                                judge=max(0, int(getattr(jd, "parse_misses", lambda: 0)()) - parses["kernel"]),
-                               sharedHits=int(getattr(jd, "parse_hits", lambda: 0)()))}
+                               sharedHits=int(getattr(jd, "parse_hits", lambda: 0)())),
+                # T323 stage 3: the folds' checkpoints: restored, written, swept at boot, folds skipped as unencodable,
+                # fallbacks per reason (version, path, shrunk, guard, rewrite, corrupt) and the bytes the reader read
+                "checkpoints": em.checkpoint_stats()}
 
 
 _PERF_STATS = _PerfStats()
@@ -729,7 +732,7 @@ def _last_machine_cut(sid):
         if o.get("machineCut"):
             return (float(o.get("t") or 0), str(o["machineCut"]))   # the NEWEST row decides
         return state
-    return _fold_records(_machine_cut_cache, p, lambda: (0.0, ""), step)
+    return _fold_records(_machine_cut_cache, p, lambda: (0.0, ""), step, ckpt="machineCut")
 
 
 def _machine_cut_cause(users, i, cut_t=0.0, cut_cause=""):
@@ -9043,6 +9046,53 @@ def _tick_job_skips(job, s):
 
 
 _load_tick_seen()               # the previous kernel's last evaluations, if it left them
+try:
+    em.checkpoint_sweep()       # checkpoints of files that are gone (cleared, removed sessions) leave with the boot (T323 stage 3)
+except Exception:
+    pass
+
+
+_CKPT_SETTLE_SEEN = {}          # sid -> (turn-end key, states-log stat) at the last checkpoint write of its files
+
+
+def _session_fold_files(sid, leaf):
+    """The files whose folds belong to session `sid` with leaf transcript `leaf`: the leaf, its states log, the agent
+    files under its subagents/ directory, and the shared postal log (written on any session's event)."""
+    out = {str(leaf), str(jd.STATE / "states" / (sid + ".jsonl")), str(jd.STATE / "timeline" / "messages.jsonl")}
+    try:
+        sd = Path(str(leaf)).with_suffix("") / "subagents"
+        if sd.is_dir():
+            out.update(str(p) for p in sd.glob("*.jsonl"))
+    except OSError:
+        pass
+    return out
+
+
+def _persist_checkpoints(now):
+    """Write the fold checkpoints whose files belong to a session with NEW settle evidence: its turn-end key (the
+    Stop hook's lastStopAt, else a stopped states transition) or its states log's stat moved since the last write for
+    it. A session whose turn runs for hours still writes at every states-log row (a working/awaiting transition is an
+    event; a timer is not). Only dirty checkpoints are written; a session with no evidence change writes nothing.
+    Exit writes everything dirty (_drain_and_exit). Returns how many files were written."""
+    dirty = set(em.checkpoint_dirty())
+    if not dirty:
+        return 0
+    written = 0
+    for s in _sessions(now):
+        sid, leaf = s.get("sid"), s.get("path")
+        if not sid or not leaf:
+            continue
+        key = (_turn_end_key(sid), _stat_key(jd.STATE / "states" / (sid + ".jsonl")))
+        if _CKPT_SETTLE_SEEN.get(sid) == key:
+            continue
+        mine = _session_fold_files(sid, leaf) & dirty
+        if mine:
+            written += em.checkpoint_write_dirty(sorted(mine))
+            dirty -= mine
+        _CKPT_SETTLE_SEEN[sid] = key
+    if len(_CKPT_SETTLE_SEEN) > 4096:
+        _CKPT_SETTLE_SEEN.clear()
+    return written
 
 
 def _interrupt_block_tick(now, tmux):
@@ -24120,7 +24170,7 @@ def _pending_ledger(path):
     2026-09-11): there a romp-authored echo (a nudge) waiting in the CLI's queue must count as waiting like
     any other, where the display fold drops it on purpose (it is not the user's queued input). Same cache
     as the display fold, so the read is free on a quiet transcript."""
-    return [c.strip() for c, _ts in _fold_records(_queued_parse_cache, path, list, _queue_ledger_step)
+    return [c.strip() for c, _ts in _fold_records(_queued_parse_cache, path, list, _queue_ledger_step, ckpt="queueLedger")
             if isinstance(c, str) and c.strip()]
 
 
@@ -24131,7 +24181,7 @@ def _pending_queued_meta(path):
     chain could share an id the ledger copy wore, and an id the chat latched from it would make it reject
     the echo and the landing as another send's (the review of the first cut). The chat reads this route
     by text; `qid` is None on every copy."""
-    pending = _fold_records(_queued_parse_cache, path, list, _queue_ledger_step)
+    pending = _fold_records(_queued_parse_cache, path, list, _queue_ledger_step, ckpt="queueLedger")
     out = []
     for text, ts in pending:
         if not _genuine_queued(text):
@@ -24275,7 +24325,7 @@ def _undelivered_wake_tail(path):
                     kept.append(e)
                 tail = kept
         return (tail, n)
-    tail, _n = _fold_records(_wake_tail_cache, path, lambda: ([], 0), step)
+    tail, _n = _fold_records(_wake_tail_cache, path, lambda: ([], 0), step, ckpt="wakeTail")
     tail = [dict(e) for e in tail]                           # callers get their own copies of the carried entries
     return (tail, (tail[-1]["pos"], tail[-1]["ts"]) if tail else None)
 
@@ -25514,7 +25564,7 @@ def _states_awaiting_overlay(sid):
     the fold's own cache clears whole above 256 entries, the shared idiom. Counters ride GET /perf under
     memos.statesOverlay."""
     p = jd.STATE / "states" / ("%s.jsonl" % sid)
-    last, working_after = _fold_records(_states_overlay_cache, p, _states_overlay_init, _states_overlay_step,
+    last, working_after = _fold_records(_states_overlay_cache, p, _states_overlay_init, _states_overlay_step, ckpt="statesOverlay",
                                         on=functools.partial(_states_overlay_on, str(p)))
     if last is not None and last.get("awaiting") and working_after:
         return {"awaiting": False, "why": None}            # stale true — superseded by a later work turn
@@ -25687,7 +25737,7 @@ def _states_notes(sid):
         if isinstance(v, str) and v:
             state["gestures"].append({"t": int(t), "cmd": v})
         return state
-    return _fold_records(_states_notes_cache, p, lambda: {k: [] for k in _NOTE_KEYS}, step)
+    return _fold_records(_states_notes_cache, p, lambda: {k: [] for k in _NOTE_KEYS}, step, ckpt="statesNotes")
 
 
 def _retry_recoveries(sid):
@@ -25839,7 +25889,7 @@ def _bg_scan_cached(path):
     Shared by the chat box (_bg_tasks) and the awaiting source (_session_awaiting source 0.75).
     Folds append-incrementally since 2026-09-03 (em.fold_records): a streaming session no longer re-
     pairs its whole transcript per record."""
-    return em.scan_bg_tasks_cached(path, _bgtasks_cache, want_all=False)
+    return em.scan_bg_tasks_cached(path, _bgtasks_cache, want_all=False, ckpt="bgRunning")
 
 
 _bgall_cache = {}             # path -> em.fold_records entry (every task, launch-ordered)
@@ -25851,7 +25901,7 @@ def _bg_scan_all_cached(path):
     push, this one only by the awaiting-stamp lift, and sharing one entry would make each invalidate the
     other's shape.
     Folds append-incrementally since 2026-09-03 (em.fold_records), like _bg_scan_cached."""
-    return em.scan_bg_tasks_cached(path, _bgall_cache, want_all=True)
+    return em.scan_bg_tasks_cached(path, _bgall_cache, want_all=True, ckpt="bgAll")
 
 
 def _session_started_face(nodes, nid, healed):
@@ -26159,7 +26209,7 @@ def _agent_launch_ids(agent_path):
     transcript half of _awaiting_nest's attribution: a background command whose tool_use id is in THIS
     file was launched by THIS agent. set() when unreadable."""
     try:
-        return em.fold_records(_AGENT_LAUNCH_IDS_CACHE, str(agent_path), _launch_ids_fresh, _launch_ids_step)
+        return em.fold_records(_AGENT_LAUNCH_IDS_CACHE, str(agent_path), _launch_ids_fresh, _launch_ids_step, ckpt="agentLaunchIds")
     except Exception:
         return set()
 
@@ -26173,7 +26223,7 @@ def _agent_steps(agent_path):
     either way); the running preview's clock (agentGist: calls/since/last) rides only while it runs."""
     _chat_dep_note_taskout(str(agent_path), _chat_stat_key(str(agent_path)))   # a growing agent file moves the key
     try:
-        st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step)
+        st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step, ckpt="agentGist")
     except Exception:
         return None
     if not st["since"]:
@@ -26215,7 +26265,7 @@ def _launch_step(state, o):
 
 
 def _agent_launch_state(path):
-    return em.fold_records(_AGENT_LAUNCH_CACHE, str(path), _launch_fresh, _launch_step)
+    return em.fold_records(_AGENT_LAUNCH_CACHE, str(path), _launch_fresh, _launch_step, ckpt="agentLaunches")
 
 
 def _agent_alive(row, agent_id, tm, spawned_at):
@@ -31257,7 +31307,7 @@ def _apply_pending_ops(now=None):
 # gitBranch / version on every user+assistant record and permissionMode on user records, and the model
 # rides each assistant message — it writes no system:init atom, so the event model never carries them.
 _GLOBAL_CLAUDE_MD = Path(os.path.expanduser("~/.claude/CLAUDE.md"))   # overridable in tests
-_session_meta_cache = {}   # path -> ((mtime,size), {...})
+_session_meta_cache = {}   # path -> fold_records cursor (count, gen, meta) (T323 stage 3)
 
 
 
@@ -31727,44 +31777,35 @@ def _session_meta(path):
     # contract — a grown file returns a NEW list whose prefix objects are the SAME — is the identity
     # gate here: newest-of-each-field wins, so folding only the appended records over the carried
     # meta is exact; a rewrite (prefix identity lost) re-folds from record 0.
-    recs = em._read_jsonl_incremental(path)
-    hit = _session_meta_cache.get(path)
-    start = 0
-    meta = {"cwd": "", "gitBranch": "", "version": "", "permissionMode": "", "lastEditPath": ""}
-    if hit is not None:
-        n0, last0, meta0 = hit
-        if n0 == len(recs) and (n0 == 0 or recs[-1] is last0):
-            return meta0
-        if 0 < n0 < len(recs) and recs[n0 - 1] is last0:
-            meta, start = dict(meta0), n0
+    return _fold_records(_session_meta_cache, str(path), _session_meta_fresh, _session_meta_step, ckpt="sessionMeta")
+
+
+def _session_meta_fresh():
+    return {"cwd": "", "gitBranch": "", "version": "", "permissionMode": "", "lastEditPath": ""}
+
+
+def _session_meta_step(meta, o):
+    """One record of _session_meta's fold (T323 stage 3: the hand-rolled cursor moved onto fold_records, so the meta
+    resumes from the checkpoint like every other fold): the newest of each field wins."""
     try:
-        for o in recs[start:]:
-                if not isinstance(o, dict):
-                    continue
-                if o.get("cwd"):
-                    meta["cwd"] = o["cwd"]
-                if o.get("gitBranch"):
-                    meta["gitBranch"] = o["gitBranch"]
-                if o.get("version"):
-                    meta["version"] = o["version"]
-                if o.get("type") == "user" and o.get("permissionMode"):
-                    meta["permissionMode"] = o["permissionMode"]
-                if o.get("type") == "assistant":
-                    try:
-                        for blk in (o.get("message") or {}).get("content") or []:
-                            if (isinstance(blk, dict) and blk.get("type") == "tool_use"
-                                    and blk.get("name") in _EDIT_TOOLS):
-                                fp = (blk.get("input") or {}).get("file_path") or \
-                                     (blk.get("input") or {}).get("notebook_path")
-                                if isinstance(fp, str) and fp.startswith("/"):
-                                    meta["lastEditPath"] = fp
-                    except Exception:
-                        pass
+        if o.get("cwd"):
+            meta["cwd"] = o["cwd"]
+        if o.get("gitBranch"):
+            meta["gitBranch"] = o["gitBranch"]
+        if o.get("version"):
+            meta["version"] = o["version"]
+        if o.get("type") == "user" and o.get("permissionMode"):
+            meta["permissionMode"] = o["permissionMode"]
+        if o.get("type") == "assistant":
+            for blk in (o.get("message") or {}).get("content") or []:
+                if (isinstance(blk, dict) and blk.get("type") == "tool_use"
+                        and blk.get("name") in _EDIT_TOOLS):
+                    fp = (blk.get("input") or {}).get("file_path") or \
+                         (blk.get("input") or {}).get("notebook_path")
+                    if isinstance(fp, str) and fp.startswith("/"):
+                        meta["lastEditPath"] = fp
     except Exception:
         pass
-    if len(_session_meta_cache) > 256:                       # bounded by fleet size; never unbounded
-        _session_meta_cache.clear()
-    _session_meta_cache[path] = (len(recs), recs[-1] if recs else None, meta)
     return meta
 
 
@@ -36567,7 +36608,7 @@ def _state_intervals(sid, want, now):
     rebuild used to re-read and re-parse the whole file, twice per session (once per `want`); the
     intervals themselves are cheap."""
     want = {want} if isinstance(want, str) else set(want)
-    ev = sorted(_fold_records(_state_ev_cache, jd.STATE / "states" / (sid + ".jsonl"), list, _state_ev_step))
+    ev = sorted(_fold_records(_state_ev_cache, jd.STATE / "states" / (sid + ".jsonl"), list, _state_ev_step, ckpt="stateIntervals"))
     cutoff, out = now - TL_HORIZON, []
     for i, (t, st) in enumerate(ev):
         if st not in want:
@@ -37869,7 +37910,7 @@ def _postal_messages(now, alive_sids, id2name, live_sids=None):
     host's lane by bare sid, and a connector whose far end matches nothing is dropped by the view's
     lane lookup, exactly like before. `live_sids` = the TRUE live set for the pending flag's
     recipient-liveness leg (alive_sids is the broader LANE set); None skips that leg."""
-    log = _fold_records(_postal_log_cache, jd.STATE / "timeline" / "messages.jsonl", _postal_log_fresh, _postal_log_step)
+    log = _fold_records(_postal_log_cache, jd.STATE / "timeline" / "messages.jsonl", _postal_log_fresh, _postal_log_step, ckpt="postalLog")
     sent, execd, ended = log["sent"], log["execd"], log["ended"]
     if not sent:
         return []
@@ -46147,6 +46188,10 @@ def _pusher_cycle_jobs(now, tmux, any_client):
         _persist_tick_seen()              # moved it (T323 stage 1): the next kernel's first look starts from here
     except Exception:
         sys.stderr.write("tick-seen: %s\n" % traceback.format_exc())
+    try:                                  # the folds' checkpoints, written for a session at its settle or a states-log
+        _persist_checkpoints(now)         # move (T323 stage 3): the next kernel folds the tails, not the files
+    except Exception:
+        sys.stderr.write("checkpoints: %s\n" % traceback.format_exc())
     try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
         _auto_pause_on_limit()
     except Exception:
@@ -56079,6 +56124,10 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     _exit_log("romp-kernel: %s, draining SDK sessions\n" % what)
     try:
         _persist_tick_seen(force=True)    # the tick jobs' memo for the next kernel's first look (T323 stage 1)
+    except Exception:
+        pass
+    try:
+        em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write (T323 stage 3)
     except Exception:
         pass
     try:

--- a/scripts/bench_fold_checkpoints.py
+++ b/scripts/bench_fold_checkpoints.py
@@ -15,10 +15,11 @@ and state root, each a fresh process loading the tree's event model, judge and k
 
 Bytes are counted at the reader itself (the event model's per-path counter on this branch; on a tree without it, a
 counting wrapper over the module's open() for .jsonl paths), so the count is what the reader pulled, not what the page
-cache served. The figure draws the second boot's total against transcript size per tree, and beside it the second
-boot's bytes per file class on the newest tree, so the residual that stays whole (the leaf transcript's parse, stage
-4's; the postal log's whole readers) is on the page, not left out. Decimal megabytes throughout; one measurement per
-point, not a distribution.
+cache served, and on this branch the checkpoint documents' own reads count too (they are a class of their own on the
+figure: a document carries every fold's state, and the postal log fold's state grows with the log). The figure draws
+the second boot's total against transcript size per tree, and beside it the second boot's bytes per file class on the
+newest tree, so the residual that stays whole (the leaf transcript's parse, stage 4's; the postal log's whole readers)
+is on the page, not left out. Decimal megabytes throughout; one measurement per point, not a distribution.
 
     capped bash -c 'uvx --with cleanplots --with matplotlib --with pandas python scripts/bench_fold_checkpoints.py \\
         --tree before=/path/to/main-tree --tree after=. --sizes 1,4,16 --sessions 6 --out DIR'
@@ -121,10 +122,11 @@ km._postal_index()
 km._fold_records(km._postal_log_cache, jd.STATE / "timeline" / "messages.jsonl", km._postal_log_fresh, km._postal_log_step,
                  **({"ckpt": "postalLog"} if hasattr(em, "checkpoint_write_dirty") else {}))
 rb = em.read_bytes_report() if hasattr(em, "read_bytes_report") else dict(counted, total=sum(counted.values()))
-by = {"leaf": 0, "agent": 0, "states": 0, "postal": 0, "other": 0}
+by = {"leaf": 0, "agent": 0, "states": 0, "postal": 0, "checkpoint": 0, "other": 0}
 for p, n in rb.items():
     if p == "total": continue
-    cls = "agent" if "/subagents/" in p else "states" if "/states/" in p else "postal" if p.endswith("messages.jsonl") else "leaf" if p.startswith(proj) else "other"
+    cls = ("checkpoint" if "/checkpoints/" in p else "agent" if "/subagents/" in p else "states" if "/states/" in p
+           else "postal" if p.endswith("messages.jsonl") else "leaf" if p.startswith(proj) else "other")
     by[cls] += n
 if phase == "first" and hasattr(em, "checkpoint_write_dirty"):
     em.checkpoint_write_dirty()                                # the exit path's write
@@ -181,8 +183,9 @@ def draw(rows, out):
     ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25)
     newest = labels[-1]
     rs = sorted([r for r in rows if r["label"] == newest and not r.get("error")], key=lambda r: r["worldBytes"])
-    classes = ["leaf", "postal", "states", "agent"]
-    names = {"leaf": "leaf transcripts (the parse, stage 4)", "postal": "postal log (whole readers)", "states": "states logs", "agent": "agent files"}
+    classes = ["leaf", "postal", "checkpoint", "states", "agent"]
+    names = {"leaf": "leaf transcripts (the parse, stage 4)", "postal": "postal log (whole readers)", "states": "states logs",
+             "agent": "agent files", "checkpoint": "checkpoint documents (the fold states, chiefly the postal fold's)"}
     for j, c in enumerate(classes):
         xs = [r["worldBytes"] / 1e6 for r in rs]
         ys = [r["second"]["byClass"][c] / 1e6 for r in rs]
@@ -190,8 +193,9 @@ def draw(rows, out):
     ax2.clean(xlabel="Same worlds (MB)", ylabel="Bytes read at the restart on %s,\nper file class (MB)" % newest)
     ax2.set_xlim(0, None); ax2.set_ylim(0, None)
     f.subplots_adjust(wspace=0.45)
-    f.text(0.5, -0.16, "One measurement per point. Bytes are counted at the reader, not the page cache. A checkpointed file still costs\n"
-                       "its guard bytes (up to 64) plus everything appended since the checkpoint; here nothing was appended between the two boots.",
+    f.text(0.5, -0.16, "One measurement per point. Bytes are counted at the reader, not the page cache, the checkpoint documents' own reads included.\n"
+                       "A checkpointed file still costs its document, its guard bytes twice (up to 64 each) and everything appended since the checkpoint;\n"
+                       "here nothing was appended between the two boots.",
            ha="center", va="top", fontsize=8, color="#555555", transform=f.transFigure)
     path = os.path.join(out, "boot_read_vs_size.png")
     f.savefig(path, dpi=150, bbox_inches="tight")

--- a/scripts/bench_fold_checkpoints.py
+++ b/scripts/bench_fold_checkpoints.py
@@ -184,15 +184,15 @@ def draw(rows, out):
     newest = labels[-1]
     rs = sorted([r for r in rows if r["label"] == newest and not r.get("error")], key=lambda r: r["worldBytes"])
     classes = ["leaf", "postal", "checkpoint", "states", "agent"]
-    names = {"leaf": "leaf transcripts (the parse, stage 4)", "postal": "postal log (whole readers)", "states": "states logs",
-             "agent": "agent files", "checkpoint": "checkpoint documents (the fold states, chiefly the postal fold's)"}
+    names = {"leaf": "leaf transcripts (parse, stage 4)", "postal": "postal log (whole readers)", "states": "states logs",
+             "agent": "agent files", "checkpoint": "checkpoint documents"}
     for j, c in enumerate(classes):
         xs = [r["worldBytes"] / 1e6 for r in rs]
         ys = [r["second"]["byClass"][c] / 1e6 for r in rs]
         ax2.line(xs, ys, label=names[c], color=cols[(j + 2) % len(cols)], marker="o")
     ax2.clean(xlabel="Same worlds (MB)", ylabel="Bytes read at the restart on %s,\nper file class (MB)" % newest)
     ax2.set_xlim(0, None); ax2.set_ylim(0, None)
-    f.subplots_adjust(wspace=0.45)
+    f.subplots_adjust(wspace=0.6)
     f.text(0.5, -0.16, "One measurement per point. Bytes are counted at the reader, not the page cache, the checkpoint documents' own reads included.\n"
                        "A checkpointed file still costs its document, its guard bytes twice (up to 64 each) and everything appended since the checkpoint;\n"
                        "here nothing was appended between the two boots.",

--- a/scripts/bench_fold_checkpoints.py
+++ b/scripts/bench_fold_checkpoints.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""bench_fold_checkpoints: the bytes a kernel BOOT reads for the folds' inputs, against transcript size, with and without
+the folds' checkpoints (T323 stage 3's acceptance measurement).
+
+For each romp tree given, and each size, a synthetic world is built under a temporary root: N sessions, each with a leaf
+transcript (S times a base of invented turns, with background launches and edits), an agent file under its subagents/
+directory, and a states log; one postal log shared by all. Then two child processes run in turn against the SAME world
+and state root, each a fresh process loading the tree's event model, judge and kernel (nothing against live state):
+
+  1. the first boot: every reader a kernel runs for a session at boot and at a client's first ask is called once per
+     session (the judges' parse of the leaf, the states readers, the background-task pairing, the session meta, the agent
+     gist and launches, the postal log), then the tree's exit path for checkpoints, when it has one, writes them;
+  2. the second boot: the same readers again in a new process. Its bytes read, per file class, are the measurement:
+     what a restart costs the folds' inputs. On a tree without checkpoints the second boot equals the first.
+
+Bytes are counted at the reader itself (the event model's per-path counter on this branch; on a tree without it, a
+counting wrapper over the module's open() for .jsonl paths), so the count is what the reader pulled, not what the page
+cache served. The figure draws the second boot's total against transcript size per tree, and beside it the second
+boot's bytes per file class on the newest tree, so the residual that stays whole (the leaf transcript's parse, stage
+4's; the postal log's whole readers) is on the page, not left out. Decimal megabytes throughout; one measurement per
+point, not a distribution.
+
+    capped bash -c 'uvx --with cleanplots --with matplotlib --with pandas python scripts/bench_fold_checkpoints.py \\
+        --tree before=/path/to/main-tree --tree after=. --sizes 1,4,16 --sessions 6 --out DIR'
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+WORLD = r'''
+import json, os, sys, random, time
+root, sessions, turns = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+state = os.path.join(root, "state", "romp"); proj = os.path.join(root, "claude", "projects", "-w-notes-api")
+for d in ("names", "sdk", "states", "timeline", "goals"): os.makedirs(os.path.join(state, d), exist_ok=True)
+os.makedirs(proj, exist_ok=True); os.makedirs(os.path.join(root, "w", "notes-api"), exist_ok=True)
+WORDS = ("fixture", "suite", "backoff", "jitter", "cap", "retry", "review", "branch", "merge", "green", "README", "wire")
+def iso(t): return time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(t))
+t0 = int(time.time()) - 86400; sids = []
+for i in range(sessions):
+    sid = "%08x-1111-4222-8333-%012d" % (i + 1, i + 1); sids.append(sid)
+    rnd = random.Random(i); parent = None; leaf = os.path.join(proj, sid + ".jsonl"); t = t0
+    with open(leaf, "w") as f:
+        for k in range(turns):
+            u, a, tid = "u%d" % k, "a%d" % k, "toolu_%d_%d" % (i, k)
+            f.write(json.dumps({"type": "user", "uuid": u, "parentUuid": parent, "timestamp": iso(t), "promptSource": "typed",
+                                "cwd": "/w/notes-api", "version": "2.1.0", "gitBranch": "web",
+                                "message": {"role": "user", "content": " ".join(rnd.choice(WORDS) for _ in range(40))}}) + "\n")
+            blocks = [{"type": "text", "text": " ".join(rnd.choice(WORDS) for _ in range(120))}]
+            if k % 7 == 3: blocks.append({"type": "tool_use", "id": tid, "name": "Bash", "input": {"command": "sleep 1", "run_in_background": True, "description": "lint"}})
+            if k % 5 == 1: blocks.append({"type": "tool_use", "id": tid + "e", "name": "Edit", "input": {"file_path": "/w/notes-api/web/app%d.ts" % k}})
+            f.write(json.dumps({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": iso(t + 20), "cwd": "/w/notes-api", "version": "2.1.0",
+                                "gitBranch": "web", "message": {"role": "assistant", "content": blocks, "stop_reason": "end_turn"}}) + "\n")
+            parent = a; t += 60
+    sub = os.path.join(proj, sid, "subagents"); os.makedirs(sub, exist_ok=True)
+    with open(os.path.join(sub, "agent-%08x.jsonl" % (i + 1)), "w") as f:
+        p2 = None
+        for k in range(turns):
+            s1, s2 = "s%d" % k, "r%d" % k
+            f.write(json.dumps({"type": "user", "uuid": s1, "parentUuid": p2, "timestamp": iso(t0 + 60 * k), "message": {"role": "user", "content": " ".join(rnd.choice(WORDS) for _ in range(30))}}) + "\n")
+            f.write(json.dumps({"type": "assistant", "uuid": s2, "parentUuid": s1, "timestamp": iso(t0 + 60 * k + 10), "message": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "toolu_s%d_%d" % (i, k), "name": "Read", "input": {"file_path": "/w/notes-api/web/app%d.ts" % k}},
+                {"type": "text", "text": " ".join(rnd.choice(WORDS) for _ in range(80))}]}}) + "\n")
+            p2 = s2
+    with open(os.path.join(state, "states", sid + ".jsonl"), "w") as f:
+        for k in range(turns):
+            f.write(json.dumps({"t": t0 + 60 * k, "state": "working"}) + "\n")
+            f.write(json.dumps({"t": t0 + 60 * k + 30, "state": "waiting"}) + "\n")
+    with open(os.path.join(state, "names", sid), "w") as f: f.write("worker%d\t%s\t#abcdef\n" % (i, os.path.join(root, "w", "notes-api")))
+    with open(os.path.join(state, "sdk", sid + ".json"), "w") as f:
+        json.dump({"sid": sid, "name": "worker%d" % i, "cwd": os.path.join(root, "w", "notes-api"), "lastSid": sid, "alive": False}, f)
+with open(os.path.join(state, "timeline", "messages.jsonl"), "w") as f:
+    for k in range(turns * sessions):
+        a, b = sids[k % sessions], sids[(k + 1) % sessions]
+        f.write(json.dumps({"ev": "sent", "id": "m%d" % k, "from_id": a, "to_id": b, "from": "worker", "body": " ".join(WORDS[:6]), "t": t0 + k, "kind": "coordinate"}) + "\n")
+        f.write(json.dumps({"ev": "exec", "id": "m%d" % k, "t": t0 + k + 1}) + "\n")
+print(json.dumps({"sids": sids, "proj": proj}))
+'''
+
+BOOT = r'''
+import json, os, sys, time, builtins
+tree, root, proj, phase = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+sids = json.loads(sys.argv[5])
+os.environ["XDG_STATE_HOME"] = os.path.join(root, "state"); os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(root, "claude"); os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "bench"); os.environ["ROMP_MANAGER_PORT"] = "1"
+sys.path.insert(0, os.path.join(tree, "tests"))
+from romp_load import load_source
+em = load_source("romp_event_model", os.path.join(tree, "bin", "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(tree, "bin", "romp-judge"))
+km = load_source("romp_kernel_bench", os.path.join(tree, "bin", "romp-kernel"))
+counted = {}
+if not hasattr(em, "read_bytes_report"):                         # a tree without the reader's counter: count at open()
+    _open = builtins.open
+    class _F:
+        def __init__(self, fh, path): self.fh, self.path = fh, path
+        def read(self, *a):
+            b = self.fh.read(*a); counted[self.path] = counted.get(self.path, 0) + len(b); return b
+        def __getattr__(self, k): return getattr(self.fh, k)
+        def __enter__(self): return self
+        def __exit__(self, *a): self.fh.close()
+        def __iter__(self): return iter(self.fh)
+    def counting_open(path, mode="r", *a, **k):
+        fh = _open(path, mode, *a, **k)
+        return _F(fh, str(path)) if "b" in mode and str(path).endswith(".jsonl") else fh
+    builtins.open = counting_open; em.open = counting_open
+now = time.time()
+for sid in sids:
+    leaf = os.path.join(proj, sid + ".jsonl")
+    jd.parsed_session(sid, [leaf], now)                        # the judges' pass: the leaf, whole (stage 4)
+    km._states_awaiting_overlay(sid); km._last_machine_cut(sid); km._last_state(sid)
+    km._state_intervals(sid, "working", now)
+    km._bg_scan_cached(leaf); km._bg_scan_all_cached(leaf); km._session_meta(leaf)
+    km._agent_launch_state(leaf)
+    sub = os.path.join(proj, sid, "subagents")
+    for a in sorted(os.listdir(sub)):
+        km._agent_steps(os.path.join(sub, a)); km._agent_launch_ids(os.path.join(sub, a))
+km._postal_index()
+km._fold_records(km._postal_log_cache, jd.STATE / "timeline" / "messages.jsonl", km._postal_log_fresh, km._postal_log_step,
+                 **({"ckpt": "postalLog"} if hasattr(em, "checkpoint_write_dirty") else {}))
+rb = em.read_bytes_report() if hasattr(em, "read_bytes_report") else dict(counted, total=sum(counted.values()))
+by = {"leaf": 0, "agent": 0, "states": 0, "postal": 0, "other": 0}
+for p, n in rb.items():
+    if p == "total": continue
+    cls = "agent" if "/subagents/" in p else "states" if "/states/" in p else "postal" if p.endswith("messages.jsonl") else "leaf" if p.startswith(proj) else "other"
+    by[cls] += n
+if phase == "first" and hasattr(em, "checkpoint_write_dirty"):
+    em.checkpoint_write_dirty()                                # the exit path's write
+stats = em.checkpoint_stats() if hasattr(em, "checkpoint_stats") else {}
+print(json.dumps({"phase": phase, "byClass": by, "total": sum(by.values()),
+                  "restored": stats.get("restored", 0), "fallbacks": stats.get("fallbacks", {})}))
+'''
+
+
+def run(args, timeout=900):
+    p = subprocess.run([sys.executable, "-c"] + args, capture_output=True, text=True, timeout=timeout)
+    line = [ln for ln in p.stdout.splitlines() if ln.startswith("{")]
+    if p.returncode != 0 or not line:
+        raise RuntimeError((p.stderr or p.stdout)[-600:])
+    return json.loads(line[-1])
+
+
+def measure(tree, sessions, turns):
+    root = tempfile.mkdtemp(prefix="romp-ckpt-bench-")
+    try:
+        world = run([WORLD, root, str(sessions), str(turns)])
+        sizes = {"leaf": 0, "agent": 0, "states": 0, "postal": 0}
+        for dp, _, fs in os.walk(root):
+            for f in fs:
+                if not f.endswith(".jsonl"):
+                    continue
+                p = os.path.join(dp, f); n = os.path.getsize(p)
+                sizes["agent" if "/subagents/" in p else "states" if "/states/" in p else "postal" if f == "messages.jsonl" else "leaf"] += n
+        first = run([BOOT, tree, root, world["proj"], "first", json.dumps(world["sids"])])
+        second = run([BOOT, tree, root, world["proj"], "second", json.dumps(world["sids"])])
+        return {"worldBytes": sum(sizes.values()), "sizes": sizes, "first": first, "second": second}
+    finally:
+        import shutil; shutil.rmtree(root, ignore_errors=True)
+
+
+def draw(rows, out):
+    import cleanplots as cp
+    import matplotlib
+    matplotlib.use("Agg")
+    labels = sorted({r["label"] for r in rows})
+    cols = list(cp.colors)
+    f, (ax, ax2) = cp.fig(w=12, h=5, cols=2)
+    top = 1.0
+    for i, label in enumerate(labels):
+        rs = sorted([r for r in rows if r["label"] == label and not r.get("error")], key=lambda r: r["worldBytes"])
+        if not rs:
+            sys.stderr.write("figure: every run of %r errored; the label is left out\n" % label); continue
+        xs = [r["worldBytes"] / 1e6 for r in rs]
+        ys = [r["second"]["total"] / 1e6 for r in rs]
+        top = max(top, max(ys))
+        ax.line(xs, ys, label=label, color=cols[i % len(cols)], marker="o")
+    ax.clean(xlabel="Files on disk (MB): transcripts, agent files,\nstates logs and the postal log",
+             ylabel="Bytes a restarted kernel reads\nfor the folds' inputs (MB)")
+    ax.set_xlim(0, None); ax.set_ylim(0, top * 1.25)
+    newest = labels[-1]
+    rs = sorted([r for r in rows if r["label"] == newest and not r.get("error")], key=lambda r: r["worldBytes"])
+    classes = ["leaf", "postal", "states", "agent"]
+    names = {"leaf": "leaf transcripts (the parse, stage 4)", "postal": "postal log (whole readers)", "states": "states logs", "agent": "agent files"}
+    for j, c in enumerate(classes):
+        xs = [r["worldBytes"] / 1e6 for r in rs]
+        ys = [r["second"]["byClass"][c] / 1e6 for r in rs]
+        ax2.line(xs, ys, label=names[c], color=cols[(j + 2) % len(cols)], marker="o")
+    ax2.clean(xlabel="Same worlds (MB)", ylabel="Bytes read at the restart on %s,\nper file class (MB)" % newest)
+    ax2.set_xlim(0, None); ax2.set_ylim(0, None)
+    f.subplots_adjust(wspace=0.45)
+    f.text(0.5, -0.16, "One measurement per point. Bytes are counted at the reader, not the page cache. A checkpointed file still costs\n"
+                       "its guard bytes (up to 64) plus everything appended since the checkpoint; here nothing was appended between the two boots.",
+           ha="center", va="top", fontsize=8, color="#555555", transform=f.transFigure)
+    path = os.path.join(out, "boot_read_vs_size.png")
+    f.savefig(path, dpi=150, bbox_inches="tight")
+    return path
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--tree", action="append", required=True)
+    ap.add_argument("--sizes", default="1,4,16")
+    ap.add_argument("--base-turns", type=int, default=150)
+    ap.add_argument("--sessions", type=int, default=6)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--no-figure", action="store_true")
+    ap.add_argument("--figure-only", action="store_true")
+    a = ap.parse_args(argv)
+    os.makedirs(a.out, exist_ok=True)
+    if a.figure_only:
+        with open(os.path.join(a.out, "bench.json")) as f:
+            sys.stdout.write("figure " + draw(json.load(f)["rows"], a.out) + "\n")
+        return 0
+    rows = []
+    for spec in a.tree:
+        label, tree = spec.split("=", 1)
+        for s in (int(x) for x in a.sizes.split(",")):
+            try:
+                row = measure(os.path.abspath(tree), a.sessions, a.base_turns * s)
+            except Exception as e:
+                row = {"error": str(e)[-400:], "worldBytes": 0}
+            row.update(label=label, size=s, tree=os.path.abspath(tree))
+            rows.append(row); sys.stdout.write(json.dumps(row) + "\n"); sys.stdout.flush()
+    with open(os.path.join(a.out, "bench.json"), "w") as f:
+        json.dump({"rows": rows}, f, indent=1)
+    if not a.no_figure:
+        sys.stdout.write("figure " + draw(rows, a.out) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bg_scan_fold.py
+++ b/tests/test_bg_scan_fold.py
@@ -483,10 +483,11 @@ class FoldTailSafety(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertLessEqual(len(em._TRAILING_CACHE), em._TRAILING_CACHE_MAX)
 
-    def test_f_a_pin_lost_to_eviction_re_reads_and_keeps_the_tail(self):
+    def test_f_a_pin_lost_to_eviction_keeps_the_tail_without_a_re_read(self):
         # the reader's entry can be evicted (its own LRU) between the read and the pin: a None entry with records in
-        # hand is a lost pin, not "the reader holds nothing" — it re-reads once and answers with the tail, as for a pin
-        # lost to a peer's advance
+        # hand is a lost pin, not "the reader holds nothing". It used to re-read once; since the reader remembers the
+        # entry it served on this thread (T323 stage 3), the pin holds through the eviction and the tail rides on the
+        # one read
         cache = {}
         _append(self.p, {"n": 1})
         with open(self.p, "a") as f:
@@ -502,8 +503,8 @@ class FoldTailSafety(unittest.TestCase):
                     em._JSONL_CACHE.pop(str(path), None)                       # gone from under the fold
             return recs
         with mock.patch.object(em, "_read_jsonl_incremental", evicted_once):
-            self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1, 2], "re-read once; the tail rides")
-        self.assertEqual(len(calls), 2)
+            self.assertEqual(em.fold_records(cache, self.p, list, self._step), [1, 2], "one read; the tail rides")
+        self.assertEqual(len(calls), 1, "the served entry is remembered: no re-read for a pin lost to eviction")
         self.assertEqual(cache[self.p][0], 1)
 
     def test_c_a_bg_cache_shaped_for_the_other_view_is_refused_loudly(self):

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -87,7 +87,7 @@ class Base(unittest.TestCase):
         (jd.STATE / "states").mkdir(parents=True, exist_ok=True)
         (jd.STATE / "timeline").mkdir(parents=True, exist_ok=True)
         self.fresh_process()
-        em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={})
+        em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={}, restoredFolds={})
 
     def tearDown(self):
         jd._rebind_state(self.saved_state)
@@ -157,8 +157,6 @@ class GenericFold(Base):
         return em.fold_records(cache if cache is not None else self.cache, self.p, list, self._step, on=self.kinds.append, ckpt=name)
 
     def cold(self):
-        with em._JSONL_CACHE_LOCK:
-            em._JSONL_CACHE.pop(self.p, None)
         saved = em._CKPT_DIR_FN
         em._CKPT_DIR_FN = None                                 # a plain whole fold, no checkpoint in play
         try:
@@ -186,7 +184,9 @@ class GenericFold(Base):
             ent = em._JSONL_CACHE[self.p]
         self.assertEqual((ent[5], len(ent[4])), (3, 2), "a TAIL entry: base 3, two records held")
         read = em.read_bytes_report()[self.p]
-        self.assertEqual(read, (os.stat(self.p).st_size - size0) + min(64, size0), "the tail plus the guard, nothing else")
+        size1 = os.stat(self.p).st_size
+        self.assertEqual(read, (size1 - size0) + min(64, size0) + min(64, size1),
+                         "the tail, the guard check before it and the guard captured after it: nothing of the prefix")
         self.assertEqual(em.checkpoint_stats()["restored"], 1)
         self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
         self.assertEqual(self.fold(), [0, 1, 2, 3, 4]); self.assertEqual(self.kinds[-1], "hit")
@@ -198,7 +198,7 @@ class GenericFold(Base):
         self.fold(); em.checkpoint_write(self.p)
         self.fresh_process()
         self.assertEqual(self.fold(), [0, 1]); self.assertEqual(self.kinds[-1], "restore")
-        self.assertEqual(em.read_bytes_report()[self.p], min(64, os.stat(self.p).st_size), "the guard only")
+        self.assertEqual(em.read_bytes_report()[self.p], 2 * min(64, os.stat(self.p).st_size), "the guard checked, then captured again: no content")
         _append(self.p, torn={"n": 2})
         self.assertEqual(self.fold(), [0, 1, 2], "the newline-less record is folded provisionally")
         self.assertEqual(self.cache[self.p][0], 2, "and not into the cursor")
@@ -215,7 +215,8 @@ class GenericFold(Base):
         self.assertEqual(self.kinds[-1], "restore", "the fold state came from the checkpoint after a guard check on disk")
         self.assertEqual(em.checkpoint_stats()["restored"], 1)
         self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
-        self.assertEqual(em.read_bytes_report()[self.p], os.stat(self.p).st_size + min(64, size0), "the whole file (the whole reader's) plus the guard check")
+        self.assertEqual(em.read_bytes_report()[self.p], os.stat(self.p).st_size + min(64, os.stat(self.p).st_size) + min(64, size0),
+                         "the whole file and its guard capture (the whole reader's) plus the restore's guard check")
 
     def test_a_rewrite_under_the_guard_falls_back_loudly_and_equals_cold(self):
         _write(self.p, [{"n": i} for i in range(4)])
@@ -266,6 +267,49 @@ class GenericFold(Base):
             self.assertEqual(em._JSONL_CACHE[self.p][5], 0, "the entry was upgraded to the whole file for it")
         self.assertEqual(self.fold(), [0, 1, 2, 3]); self.assertEqual(self.kinds[-1], "hit", "the restored fold still stands")
 
+    def test_an_evicted_reader_entry_never_lets_a_rewritten_file_pass_as_an_append(self):
+        """Review find (2026-09-11): a from-zero read after an eviction (the reader cache runs at its cap on a busy box) or
+        a failure pop restarted the generation at 0 while the fold's cursor still held (count, 0, state): a file rewritten
+        in place with as many records then read as a hit, one with more as an append of the NEW file's tail onto the OLD
+        state, and the checkpoint written afterwards carried the wrong state under a clean witness. Every from-zero read
+        takes a fresh process-wide generation now."""
+        _write(self.p, [{"n": i} for i in range(3)])
+        self.assertEqual(self.fold(), [0, 1, 2])
+        for rewrite in ([{"n": 7}, {"n": 8}, {"n": 9}], [{"n": 4}, {"n": 5}, {"n": 6}, {"n": 3}]):   # same size, then longer
+            with self.subTest(records=len(rewrite)):
+                with em._JSONL_CACHE_LOCK:
+                    em._JSONL_CACHE.pop(self.p, None)                 # evicted (or popped by a stat failure) under the fold
+                _write(self.p, rewrite)
+                self.assertEqual(self.fold(), [r["n"] for r in rewrite], "the rewritten file is folded from zero, never onto the old state")
+                self.assertEqual(self.kinds[-1], "refold")
+                self.assertTrue(em.checkpoint_write(self.p))
+                self.assertEqual(self.fold(), self.cold())
+                self.fresh_process()
+                self.assertEqual(self.fold(), [r["n"] for r in rewrite], "and the checkpoint written after it is right")
+                self.assertEqual(self.kinds[-1], "restore")
+
+    def test_a_whole_reader_first_then_a_rewritten_file_falls_back_like_the_tail_path(self):
+        """Review find (2026-09-11): the whole-reader-first restore checked the guard alone; the tail path also compared
+        the document's size and mtime. Both verdicts come from one helper now: the same rewrite gets the same reason
+        whichever reader came first, so /perf's fallback count is a witness."""
+        for reason, rewrite in (("guard", [{"n": 100 + i} for i in range(4)] + [{"n": 7}]),          # longer, other prefix
+                                ("rewrite", ([{"n": 5}, {"n": 6}, {"n": 7}], (TS0, TS0)))):         # same size, other mtime
+            with self.subTest(reason=reason):
+                _write(self.p, [{"n": i} for i in range(3)])
+                self.fresh_process(); em._CKPT_STATS["fallbacks"] = {}
+                self.fold(); em.checkpoint_write(self.p)
+                self.fresh_process()
+                if isinstance(rewrite, tuple):
+                    _write(self.p, rewrite[0]); os.utime(self.p, rewrite[1])
+                else:
+                    _write(self.p, rewrite)
+                recs = em._read_jsonl_incremental(self.p)          # the whole reader comes first
+                self.assertEqual(len(recs), len(rewrite[0] if isinstance(rewrite, tuple) else rewrite))
+                got = self.fold()
+                self.assertEqual(em.checkpoint_stats()["fallbacks"], {reason: 1}, reason)
+                self.assertEqual(got, self.cold()); self.assertEqual(self.kinds[-1], "refold")
+                self.assertFalse(em._ckpt_file(self.p).exists(), "the checkpoint that did not verify is gone")
+
     def test_nothing_is_written_when_no_fold_stands_at_the_witness_unless_forced(self):
         _write(self.p, [{"n": 0}])
         em._read_jsonl_incremental(self.p)                        # an entry with no fold on it
@@ -315,7 +359,8 @@ class KernelFolds(Base):
         self.states = str(jd.STATE / "states" / (SID + ".jsonl"))
         self.postal = str(jd.STATE / "timeline" / "messages.jsonl")
         self.queue_leaf = str(self.proj / "queue.jsonl")
-        self.files = (self.leaf, self.agent, self.states, self.postal, self.queue_leaf)
+        self.nudge = str(jd.STATE / "nudge-events.jsonl")
+        self.files = (self.leaf, self.agent, self.states, self.postal, self.queue_leaf, self.nudge)
 
     def leaf_recs(self, tail):
         head = [_user("wire the fixtures", "u1", None, TS0, permissionMode="acceptEdits"),
@@ -359,9 +404,14 @@ class KernelFolds(Base):
                 {"type": "queue-operation", "operation": "enqueue", "content": "third", "timestamp": _iso(TS0 + 3)}]
         return head + rest if tail else head
 
+    def nudge_recs(self, tail):
+        head = [{"gid": SID + ":g1", "t": TS0 + 1}, {"gid": SID + ":g1", "t": TS0 + 2}]
+        rest = [{"gid": SID + ":g2", "t": TS0 + 3}, {"gid": SID + ":g1", "t": TS0 + 4}]
+        return head + rest if tail else head
+
     def recs_of(self, p, tail):
         return {self.leaf: self.leaf_recs, self.agent: self.agent_recs, self.states: self.states_recs,
-                self.postal: self.postal_recs, self.queue_leaf: self.queue_recs}[p](tail)
+                self.postal: self.postal_recs, self.queue_leaf: self.queue_recs, self.nudge: self.nudge_recs}[p](tail)
 
     def answers(self):
         return {
@@ -380,6 +430,9 @@ class KernelFolds(Base):
             "retryingSince": km._fold_records(km._retrying_since_cache, jd.STATE / "states" / (SID + ".jsonl"), lambda: None,
                                               km._retrying_since_step, ckpt="retryingSince"),
             "queueLedger": km._pending_ledger(self.queue_leaf),
+            "wakeTail": km._undelivered_wake_tail(self.queue_leaf),
+            "nudgeTimes": km._nudge_times(),
+            "bgJudge": [dict(t) for t in jd._bg_unresolved(self.leaf, now=TS0 + 100)],
             "postalLog": {k: (dict(v) if isinstance(v, dict) else sorted(v)) for k, v in
                           km._fold_records(km._postal_log_cache, self.postal, km._postal_log_fresh, km._postal_log_step, ckpt="postalLog").items()},
         }
@@ -395,17 +448,22 @@ class KernelFolds(Base):
         for p in self.files:
             self.assertTrue(em.checkpoint_write(p), p)
             names |= set(self.doc(p)["folds"])
-        self.assertEqual(names, {"sessionMeta", "bgRunning", "bgAll", "agentLaunches", "agentGist", "agentLaunchIds", "statesOverlay",
-                                 "stateIntervals", "statesNotes", "machineCut", "queueLedger", "postalLog", "lastState",
-                                 "lastNaturalState", "retryingSince"},
-                         "every kernel fold this test drives left its state in the checkpoint")
+        ALL_NAMES = {"sessionMeta", "bgRunning", "bgAll", "bgJudge", "agentLaunches", "agentGist", "agentLaunchIds", "statesOverlay",
+                     "stateIntervals", "statesNotes", "machineCut", "queueLedger", "wakeTail", "postalLog", "lastState",
+                     "lastNaturalState", "retryingSince", "nudgeTimes"}
+        self.assertEqual(names, ALL_NAMES, "every kernel fold this test drives left its state in the checkpoint")
+        ksrc = open(os.path.join(BIN, "romp-kernel")).read(); jsrc = open(os.path.join(BIN, "romp-judge")).read()
+        import re as _re
+        named = set(_re.findall(r'ckpt="([A-Za-z]+)"', ksrc)) | set(_re.findall(r'name_fold_cache\([^,]+, "([A-Za-z]+)"\)', jsrc))
+        self.assertEqual(named, ALL_NAMES, "every checkpoint name the kernel and the judge give a fold is driven here")
         self.fresh_process()
         for p in self.files:
             full, head = self.recs_of(p, True), self.recs_of(p, False)
             _append(p, *full[len(head):])
         warm = self.answers()
         self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
-        self.assertEqual(em.checkpoint_stats()["restored"], 5, "one restore per file")
+        self.assertEqual(em.checkpoint_stats()["restored"], 6, "one restore per file")
+        self.assertEqual(set(em.checkpoint_stats()["restoredFolds"]), ALL_NAMES, "every fold restored from its recorded state")
         for p in self.files:
             with em._JSONL_CACHE_LOCK:
                 self.assertGreater(em._JSONL_CACHE[p][5], 0, "a tail entry: %s" % p)
@@ -425,6 +483,9 @@ class KernelFolds(Base):
         self.assertEqual(km._last_state(SID), ("waiting", TS0 + 12))
         self.assertEqual(km._last_natural_state(SID), ("retrying", TS0 + 9.5), "the session's own newest state skips rows with `by`")
         self.assertEqual(cold["queueLedger"], ["second", "third"])
+        self.assertEqual([e["text"] for e in cold["wakeTail"][0]], ["second", "third"])
+        self.assertEqual(cold["nudgeTimes"], {SID + ":g1": [TS0 + 1, TS0 + 2, TS0 + 4], SID + ":g2": [TS0 + 3]})
+        self.assertEqual([t["id"] for t in cold["bgJudge"]], ["toolu_bg2"], "the judge's settled gate reads the same pairing")
         self.assertEqual(cold["postalLog"]["ended"], ["m2"])
         self.assertNotIn("m1", cold["postalLog"]["execd"])
 
@@ -453,14 +514,14 @@ class KernelFolds(Base):
             self.assertEqual(km._persist_checkpoints(TS0 + 3), 0)
             _append(self.states, {"t": TS0 + 102, "state": "working"})   # a states row is an event, with no settle
             self.assertEqual(km._persist_checkpoints(TS0 + 4), 1, "the agent file rides the states-log move")
-            self.assertEqual(em.checkpoint_write_dirty(), 1, "exit writes what is left (the queue ledger's file)")
+            self.assertEqual(em.checkpoint_write_dirty(), 2, "exit writes what is left (the queue ledger's file and the nudge log)")
             self.assertEqual(em.checkpoint_dirty(), [])
         finally:
             km._sessions, km._turn_end_key = saved_sessions, saved_turn
 
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()
-        self.assertEqual(sorted(snap["checkpoints"]), ["dirty", "fallbacks", "readByPath", "readBytes", "restored", "skippedFolds", "swept", "writes"])
+        self.assertEqual(sorted(snap["checkpoints"]), ["dirty", "fallbacks", "readByPath", "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write", src,
                       "exit writes every dirty checkpoint in _drain_and_exit")

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -340,7 +340,8 @@ class KernelFolds(Base):
         head = [{"t": TS0, "state": "working"}, {"t": TS0 + 5, "awaiting": True, "state": "waiting"},
                 {"t": TS0 + 6, "machineCut": "restart", "state": "idle"},
                 {"t": TS0 + 7, "retriesRecovered": True, "retries": 2}]
-        rest = [{"t": TS0 + 8, "state": "working"}, {"t": TS0 + 9, "state": "waiting"},
+        rest = [{"t": TS0 + 8, "state": "working"}, {"t": TS0 + 8.5, "state": "idle", "by": "stop"},
+                {"t": TS0 + 9, "state": "retrying"}, {"t": TS0 + 9.5, "state": "retrying"},
                 {"t": TS0 + 10, "machineCut": "deploy"}, {"t": TS0 + 11, "retriesGaveUp": True, "retries": 5, "errorKind": "overloaded"}]
         return head + rest if tail else head
 
@@ -374,6 +375,10 @@ class KernelFolds(Base):
             "stateIntervals": km._state_intervals(SID, "working", TS0 + 200),
             "statesNotes": km._states_notes(SID),
             "machineCut": km._last_machine_cut(SID),
+            "lastState": km._last_state(SID),
+            "lastNaturalState": km._last_natural_state(SID),
+            "retryingSince": km._fold_records(km._retrying_since_cache, jd.STATE / "states" / (SID + ".jsonl"), lambda: None,
+                                              km._retrying_since_step, ckpt="retryingSince"),
             "queueLedger": km._pending_ledger(self.queue_leaf),
             "postalLog": {k: (dict(v) if isinstance(v, dict) else sorted(v)) for k, v in
                           km._fold_records(km._postal_log_cache, self.postal, km._postal_log_fresh, km._postal_log_step, ckpt="postalLog").items()},
@@ -391,7 +396,8 @@ class KernelFolds(Base):
             self.assertTrue(em.checkpoint_write(p), p)
             names |= set(self.doc(p)["folds"])
         self.assertEqual(names, {"sessionMeta", "bgRunning", "bgAll", "agentLaunches", "agentGist", "agentLaunchIds", "statesOverlay",
-                                 "stateIntervals", "statesNotes", "machineCut", "queueLedger", "postalLog"},
+                                 "stateIntervals", "statesNotes", "machineCut", "queueLedger", "postalLog", "lastState",
+                                 "lastNaturalState", "retryingSince"},
                          "every kernel fold this test drives left its state in the checkpoint")
         self.fresh_process()
         for p in self.files:
@@ -413,6 +419,11 @@ class KernelFolds(Base):
         self.assertEqual(len(cold["agentGist"]["steps"]), 3)
         self.assertEqual(cold["machineCut"], (float(TS0 + 10), "deploy"))
         self.assertEqual(len(cold["stateIntervals"]), 2, "two working stretches in the states rows")
+        self.assertEqual(cold["lastState"], ("retrying", TS0 + 9.5)); self.assertEqual(cold["lastNaturalState"], ("retrying", TS0 + 9.5))
+        self.assertEqual(cold["retryingSince"], TS0 + 9, "the current retrying stretch dates from its first row")
+        _append(self.states, {"t": TS0 + 12, "state": "waiting", "by": "stop"})       # a Stop press: romp's row, not the session's
+        self.assertEqual(km._last_state(SID), ("waiting", TS0 + 12))
+        self.assertEqual(km._last_natural_state(SID), ("retrying", TS0 + 9.5), "the session's own newest state skips rows with `by`")
         self.assertEqual(cold["queueLedger"], ["second", "third"])
         self.assertEqual(cold["postalLog"]["ended"], ["m2"])
         self.assertNotIn("m1", cold["postalLog"]["execd"])

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""T323 stage 3 (2026-09-11): the folds' checkpoints. One small JSON file per folded JSONL file records the reader's
+prefix witness (offset past the last complete line, the guard bytes before it, the record count) and the state of every
+fold_records fold whose cursor stood at that count; a fresh process verifies the guard on disk, reads only the tail
+past the offset and resumes each fold from its recorded state. Pinned here: the codec round-trips every fold state
+shape; fold-equals-full holds from the third start state (restore, then fold the tail) for the generic fold and for
+every kernel fold that carries a checkpoint name; a whole reader touching the file first still lets the folds resume;
+every fallback (rewrite under the guard, shrink, version, path, corrupt) reads whole, is counted per reason and equals
+a cold fold; the bytes the reader pulls after a restore are the tail plus the guard; a fold behind the witness is left
+out and cold-folds; the boot sweep removes checkpoints of vanished files; the kernel writes at a session's settle or
+states-log move and never otherwise; /perf carries the counters. Hermetic: synthetic records under a temp root."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+em = load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel_t323s3", os.path.join(BIN, "romp-kernel"))
+
+SID = "11111111-2222-4333-8444-000000000301"
+TS0 = 1_800_000_000
+
+
+def _iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _write(path, recs):
+    with open(path, "w") as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+
+
+def _append(path, *recs, torn=None):
+    with open(path, "a") as f:
+        for r in recs:
+            f.write(json.dumps(r) + "\n")
+        if torn is not None:
+            f.write(json.dumps(torn))                     # a final record without its newline
+    st = os.stat(path)
+    os.utime(path, (st.st_atime, st.st_mtime + 2))        # a new mtime even on a coarse-clock filesystem
+
+
+def _user(text, uuid, parent, t, **kw):
+    r = {"type": "user", "uuid": uuid, "parentUuid": parent, "timestamp": _iso(t), "promptSource": "typed",
+         "message": {"role": "user", "content": text}, "cwd": "/w/notes-api", "version": "2.1.0", "gitBranch": "web"}
+    r.update(kw)
+    return r
+
+
+def _assistant(blocks, uuid, parent, t):
+    return {"type": "assistant", "uuid": uuid, "parentUuid": parent, "timestamp": _iso(t), "cwd": "/w/notes-api",
+            "version": "2.1.0", "gitBranch": "web", "message": {"role": "assistant", "content": blocks, "stop_reason": "end_turn"}}
+
+
+def _tool_result(tid, uuid, parent, t, text="ok"):
+    return {"type": "user", "uuid": uuid, "parentUuid": parent, "timestamp": _iso(t),
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": tid, "content": text}]}}
+
+
+def _bg_launch(tid, desc, uuid, parent, t):
+    return _assistant([{"type": "tool_use", "id": tid, "name": "Bash",
+                        "input": {"command": "sleep 1", "run_in_background": True, "description": desc}}], uuid, parent, t)
+
+
+def _bg_note(tid, status, uuid, parent, t):
+    note = ("<task-notification>\n<task-id>b1</task-id>\n<tool-use-id>%s</tool-use-id>\n<status>%s</status>\n"
+            "<summary>%s</summary>\n</task-notification>" % (tid, status, status))
+    return _user(note, uuid, parent, t)
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.saved_state = jd.STATE
+        self.td = Path(tempfile.mkdtemp())
+        jd._rebind_state(self.td / "state")
+        (jd.STATE / "states").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "timeline").mkdir(parents=True, exist_ok=True)
+        self.fresh_process()
+        em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={})
+
+    def tearDown(self):
+        jd._rebind_state(self.saved_state)
+        em.set_checkpoint_dir(lambda: jd.STATE / "checkpoints")
+
+    def fresh_process(self):
+        """What a kernel restart does to the in-memory side: every reader entry, fold cursor, pending restore and
+        byte counter gone; the checkpoint files on disk stay."""
+        em.set_checkpoint_dir(lambda: jd.STATE / "checkpoints")   # the setter clears the pending restores and the seqs
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.clear()
+        em._TRAILING_CACHE.clear()
+        with em._READ_BYTES_LOCK:
+            em._READ_BYTES.clear()
+        for c in list(em._FOLD_REG.values()):
+            c.clear()
+        km._CKPT_SETTLE_SEEN.clear()
+
+    def ckpt_files(self):
+        d = jd.STATE / "checkpoints"
+        return sorted(d.glob("*.json")) if d.is_dir() else []
+
+    def doc(self, path):
+        return json.loads(em._ckpt_file(path).read_text())
+
+
+class Codec(Base):
+    def test_every_fold_state_shape_round_trips(self):
+        shapes = [
+            {"tasks": {"toolu_1": {"status": "running", "desc": "x"}}, "order": ["toolu_1"], "dispatch": {}, "all": False, "done": {"toolu_0", "toolu_9"}},
+            {"steps": [{"tool": "Bash", "desc": "ls", "ts": "2026-09-10T00:00:00.000Z"}], "calls": 1, "since": None, "last": "t"},
+            {"launched": {"toolu_a": 1.5}, "settled": {"toolu_a"}},
+            {"sent": {"m1": {"ev": "sent", "id": "m1"}}, "execd": {"m1": (1.0, None)}, "ended": {"m2"}},
+            (12.5, "restart"), (None, False), ({"awaiting": True, "t": 3}, True),
+            {"recoveries": [{"t": 1, "retries": 2}], "gaveups": [], "orphans": [], "efforts": [], "gestures": []},
+            ([("hello", "2026-09-10T00:00:00Z"), ("", None)], 7),
+            [(1, "working"), (2, "idle")],
+            {1: "int keyed", (2, 3): "tuple keyed"},
+            {"~set": "a plain key that looks like a tag"},
+            set(), (), [], {}, None, True, 0, 1.25, "s",
+        ]
+        for st in shapes:
+            enc = em._ckpt_encode(st)
+            json.dumps(enc)                                       # JSON-able
+            self.assertEqual(em._ckpt_decode(json.loads(json.dumps(enc))), st, repr(st))
+            self.assertIs(type(em._ckpt_decode(enc)), type(st), repr(st))
+
+    def test_an_unencodable_state_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            em._ckpt_encode({"x": object()})
+
+
+class GenericFold(Base):
+    """em.fold_records with a checkpoint name over a plain JSONL file of {"n": i} records."""
+
+    def setUp(self):
+        super().setUp()
+        self.p = str(self.td / "t.jsonl")
+        self.cache = {}
+        self.kinds = []
+
+    @staticmethod
+    def _step(st, o):
+        return st + [o["n"]]
+
+    def fold(self, name="t", cache=None):
+        return em.fold_records(cache if cache is not None else self.cache, self.p, list, self._step, on=self.kinds.append, ckpt=name)
+
+    def cold(self):
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.pop(self.p, None)
+        saved = em._CKPT_DIR_FN
+        em._CKPT_DIR_FN = None                                 # a plain whole fold, no checkpoint in play
+        try:
+            return em.fold_records({}, self.p, list, self._step)
+        finally:
+            em._CKPT_DIR_FN = saved
+
+    def test_write_restore_fold_the_tail_equals_a_cold_fold_and_reads_only_the_tail(self):
+        _write(self.p, [{"n": i} for i in range(3)])
+        self.assertEqual(self.fold(), [0, 1, 2])
+        self.assertEqual(self.kinds, ["refold"])
+        self.assertIn(self.p, em.checkpoint_dirty())
+        self.assertTrue(em.checkpoint_write(self.p))
+        self.assertNotIn(self.p, em.checkpoint_dirty(), "a write clears the dirty mark")
+        d = self.doc(self.p)
+        size0 = os.stat(self.p).st_size
+        self.assertEqual((d["v"], d["count"], d["offset"], d["size"], d["seq"]), (1, 3, size0, size0, 1))
+        self.assertEqual(d["folds"]["t"]["count"], 3)
+        self.assertEqual(bytes.fromhex(d["guard"]), open(self.p, "rb").read()[-64:])
+        self.fresh_process()
+        _append(self.p, {"n": 3}, {"n": 4})
+        self.assertEqual(self.fold(), [0, 1, 2, 3, 4], "restored state plus the tail equals a cold fold of the file")
+        self.assertEqual(self.kinds[-1], "restore")
+        with em._JSONL_CACHE_LOCK:
+            ent = em._JSONL_CACHE[self.p]
+        self.assertEqual((ent[5], len(ent[4])), (3, 2), "a TAIL entry: base 3, two records held")
+        read = em.read_bytes_report()[self.p]
+        self.assertEqual(read, (os.stat(self.p).st_size - size0) + min(64, size0), "the tail plus the guard, nothing else")
+        self.assertEqual(em.checkpoint_stats()["restored"], 1)
+        self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
+        self.assertEqual(self.fold(), [0, 1, 2, 3, 4]); self.assertEqual(self.kinds[-1], "hit")
+        self.assertEqual(self.cache[self.p][0], 5, "the cursor's count is first, as every reader of it knew")
+        self.assertEqual(self.cold(), [0, 1, 2, 3, 4])
+
+    def test_an_unchanged_file_restores_with_no_tail_and_a_torn_tail_folds_provisionally(self):
+        _write(self.p, [{"n": 0}, {"n": 1}])
+        self.fold(); em.checkpoint_write(self.p)
+        self.fresh_process()
+        self.assertEqual(self.fold(), [0, 1]); self.assertEqual(self.kinds[-1], "restore")
+        self.assertEqual(em.read_bytes_report()[self.p], min(64, os.stat(self.p).st_size), "the guard only")
+        _append(self.p, torn={"n": 2})
+        self.assertEqual(self.fold(), [0, 1, 2], "the newline-less record is folded provisionally")
+        self.assertEqual(self.cache[self.p][0], 2, "and not into the cursor")
+
+    def test_a_whole_reader_first_then_the_fold_still_restores(self):
+        _write(self.p, [{"n": 0}, {"n": 1}, {"n": 2}])
+        self.fold(); em.checkpoint_write(self.p)
+        size0 = os.stat(self.p).st_size
+        self.fresh_process()
+        _append(self.p, {"n": 3})
+        recs = em._read_jsonl_incremental(self.p)                 # a whole reader (the parse) touches the file first
+        self.assertEqual(len(recs), 4)
+        self.assertEqual(self.fold(), [0, 1, 2, 3])
+        self.assertEqual(self.kinds[-1], "restore", "the fold state came from the checkpoint after a guard check on disk")
+        self.assertEqual(em.checkpoint_stats()["restored"], 1)
+        self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
+        self.assertEqual(em.read_bytes_report()[self.p], os.stat(self.p).st_size + min(64, size0), "the whole file (the whole reader's) plus the guard check")
+
+    def test_a_rewrite_under_the_guard_falls_back_loudly_and_equals_cold(self):
+        _write(self.p, [{"n": i} for i in range(4)])
+        self.fold(); em.checkpoint_write(self.p)
+        self.fresh_process()
+        _write(self.p, [{"n": 100 + i} for i in range(4)] + [{"n": 7}])   # same shape, other content, longer
+        self.assertEqual(self.fold(), [100, 101, 102, 103, 7])
+        self.assertEqual(self.kinds[-1], "refold")
+        self.assertEqual(em.checkpoint_stats()["fallbacks"], {"guard": 1})
+        self.assertFalse(em._ckpt_file(self.p).exists(), "the bad checkpoint is removed")
+        self.assertEqual(self.fold(), self.cold())
+
+    def test_a_shrunk_file_a_wrong_version_a_wrong_path_and_a_corrupt_document_each_fall_back(self):
+        for reason, spoil in (
+            ("shrunk", lambda: _write(self.p, [{"n": 0}])),
+            ("version", lambda: em._ckpt_file(self.p).write_text(json.dumps(dict(self.doc(self.p), v=99)))),
+            ("path", lambda: em._ckpt_file(self.p).write_text(json.dumps(dict(self.doc(self.p), path="/elsewhere/t.jsonl")))),
+            ("corrupt", lambda: em._ckpt_file(self.p).write_text("{not json")),
+            ("corrupt", lambda: em._ckpt_file(self.p).write_text(json.dumps(dict(self.doc(self.p), offset="x")))),
+            ("rewrite", lambda: (_write(self.p, [{"n": 5}, {"n": 6}, {"n": 7}]), os.utime(self.p, (TS0, TS0)))),
+        ):
+            with self.subTest(reason=reason):
+                _write(self.p, [{"n": i} for i in range(3)])
+                self.fresh_process()
+                em._CKPT_STATS["fallbacks"] = {}
+                self.fold(); em.checkpoint_write(self.p)
+                self.fresh_process()
+                spoil()
+                got = self.fold()
+                self.assertEqual(em.checkpoint_stats()["fallbacks"], {reason: 1}, reason)
+                self.assertEqual(got, self.cold(), reason)
+                self.assertEqual(self.kinds[-1], "refold")
+
+    def test_a_fold_behind_the_witness_is_left_out_and_cold_folds_while_the_other_restores(self):
+        _write(self.p, [{"n": 0}, {"n": 1}])
+        other = {}
+        self.fold(); self.fold("u", other)
+        _append(self.p, {"n": 2})
+        self.fold()                                               # "t" stands at 3, "u" still at 2
+        self.assertTrue(em.checkpoint_write(self.p))
+        self.assertEqual(sorted(self.doc(self.p)["folds"]), ["t"], "only the fold at the witness is recorded")
+        self.fresh_process()
+        _append(self.p, {"n": 3})
+        self.assertEqual(self.fold(), [0, 1, 2, 3]); self.assertEqual(self.kinds[-1], "restore")
+        self.assertEqual(em.fold_records({}, self.p, list, self._step, on=self.kinds.append, ckpt="u"), [0, 1, 2, 3])
+        self.assertEqual(self.kinds[-1], "refold", "a fold with no recorded state reads the whole file")
+        with em._JSONL_CACHE_LOCK:
+            self.assertEqual(em._JSONL_CACHE[self.p][5], 0, "the entry was upgraded to the whole file for it")
+        self.assertEqual(self.fold(), [0, 1, 2, 3]); self.assertEqual(self.kinds[-1], "hit", "the restored fold still stands")
+
+    def test_nothing_is_written_when_no_fold_stands_at_the_witness_unless_forced(self):
+        _write(self.p, [{"n": 0}])
+        em._read_jsonl_incremental(self.p)                        # an entry with no fold on it
+        self.assertFalse(em.checkpoint_write(self.p))
+        self.assertTrue(em.checkpoint_write(self.p, force=True))
+        self.assertEqual(self.doc(self.p)["folds"], {})
+
+    def test_checkpoints_off_fold_as_before_and_write_nothing(self):
+        em.set_checkpoint_dir(None)
+        _write(self.p, [{"n": 0}])
+        self.assertEqual(self.fold(), [0])
+        self.assertFalse(em.checkpoint_write(self.p))
+        self.assertEqual(self.ckpt_files(), [])
+
+    def test_the_boot_sweep_removes_checkpoints_of_files_that_are_gone(self):
+        q = str(self.td / "q.jsonl")
+        _write(self.p, [{"n": 0}]); _write(q, [{"n": 1}])
+        self.fold(); em.fold_records({}, q, list, self._step, ckpt="q")
+        em.checkpoint_write_dirty()
+        self.assertEqual(len(self.ckpt_files()), 2)
+        os.unlink(q)
+        (jd.STATE / "checkpoints" / "junk.json").write_text("{")
+        self.assertEqual(em.checkpoint_sweep(), 2)
+        self.assertEqual([f.name for f in self.ckpt_files()], [em._ckpt_file(self.p).name])
+        self.assertEqual(em.checkpoint_stats()["swept"], 2)
+
+    def test_the_seq_counts_writes_per_file_and_survives_a_restore(self):
+        _write(self.p, [{"n": 0}])
+        self.fold(); em.checkpoint_write(self.p)
+        _append(self.p, {"n": 1}); self.fold(); em.checkpoint_write(self.p)
+        self.assertEqual(self.doc(self.p)["seq"], 2)
+        self.fresh_process()
+        self.fold(); _append(self.p, {"n": 2}); self.fold(); em.checkpoint_write(self.p)
+        self.assertEqual(self.doc(self.p)["seq"], 3)
+
+
+class KernelFolds(Base):
+    """Every kernel fold that carries a checkpoint name: the answer after (checkpoint at a prefix, a fresh process,
+    the tail appended, the fold) equals the answer of a cold fold over the whole file."""
+
+    def setUp(self):
+        super().setUp()
+        self.proj = self.td / "proj"; self.proj.mkdir()
+        self.leaf = str(self.proj / (SID + ".jsonl"))
+        sub = self.proj / SID / "subagents"; sub.mkdir(parents=True)
+        self.agent = str(sub / "agent-aaaa.jsonl")
+        self.states = str(jd.STATE / "states" / (SID + ".jsonl"))
+        self.postal = str(jd.STATE / "timeline" / "messages.jsonl")
+        self.queue_leaf = str(self.proj / "queue.jsonl")
+        self.files = (self.leaf, self.agent, self.states, self.postal, self.queue_leaf)
+
+    def leaf_recs(self, tail):
+        head = [_user("wire the fixtures", "u1", None, TS0, permissionMode="acceptEdits"),
+                _bg_launch("toolu_bg1", "run the suite", "a1", "u1", TS0 + 10),
+                _assistant([{"type": "tool_use", "id": "toolu_ag1", "name": "Agent", "input": {"prompt": "check the width"}}], "a2", "a1", TS0 + 20),
+                _assistant([{"type": "tool_use", "id": "toolu_ed1", "name": "Edit", "input": {"file_path": "/w/notes-api/web/app.ts"}}], "a3", "a2", TS0 + 30)]
+        rest = [_bg_note("toolu_bg1", "completed", "u2", "a3", TS0 + 40),
+                _tool_result("toolu_ag1", "u3", "u2", TS0 + 50, text="done"),
+                _bg_launch("toolu_bg2", "lint", "a4", "u3", TS0 + 60),
+                dict(_user("and the cap?", "u4", "a4", TS0 + 70), gitBranch="api"),
+                dict(_assistant([{"type": "tool_use", "id": "toolu_ed2", "name": "Write", "input": {"file_path": "/w/notes-api/api/cap.py"}}], "a5", "u4", TS0 + 80), gitBranch="api")]
+        return head + rest if tail else head
+
+    def agent_recs(self, tail):
+        head = [_user("check the width", "s1", None, TS0 + 21),
+                _assistant([{"type": "tool_use", "id": "toolu_s1", "name": "Bash", "input": {"command": "ls web", "description": "list"}}], "s2", "s1", TS0 + 22)]
+        rest = [_assistant([{"type": "tool_use", "id": "toolu_s2", "name": "Read", "input": {"file_path": "/w/notes-api/web/app.ts"}}], "s3", "s2", TS0 + 23),
+                _assistant([{"type": "tool_use", "id": "toolu_s3", "name": "Agent", "input": {"prompt": "deeper"}}], "s4", "s3", TS0 + 24)]
+        return head + rest if tail else head
+
+    def states_recs(self, tail):
+        head = [{"t": TS0, "state": "working"}, {"t": TS0 + 5, "awaiting": True, "state": "waiting"},
+                {"t": TS0 + 6, "machineCut": "restart", "state": "idle"},
+                {"t": TS0 + 7, "retriesRecovered": True, "retries": 2}]
+        rest = [{"t": TS0 + 8, "state": "working"}, {"t": TS0 + 9, "state": "waiting"},
+                {"t": TS0 + 10, "machineCut": "deploy"}, {"t": TS0 + 11, "retriesGaveUp": True, "retries": 5, "errorKind": "overloaded"}]
+        return head + rest if tail else head
+
+    def postal_recs(self, tail):
+        head = [{"ev": "sent", "id": "m1", "from_id": SID, "to_id": "22222222-2222-4333-8444-000000000302", "body": "ping", "t": TS0, "kind": "coordinate"},
+                {"ev": "exec", "id": "m1", "t": TS0 + 1, "dmid": None}]
+        rest = [{"ev": "sent", "id": "m2", "from_id": SID, "to_id": SID, "body": "note", "t": TS0 + 2},
+                {"ev": "recall", "id": "m2", "t": TS0 + 3}, {"ev": "unexec", "id": "m1", "t": TS0 + 4}]
+        return head + rest if tail else head
+
+    def queue_recs(self, tail):
+        head = [{"type": "queue-operation", "operation": "enqueue", "content": "first", "timestamp": _iso(TS0)},
+                {"type": "queue-operation", "operation": "enqueue", "content": "second", "timestamp": _iso(TS0 + 1)}]
+        rest = [{"type": "queue-operation", "operation": "remove", "content": "first", "timestamp": _iso(TS0 + 2)},
+                {"type": "queue-operation", "operation": "enqueue", "content": "third", "timestamp": _iso(TS0 + 3)}]
+        return head + rest if tail else head
+
+    def recs_of(self, p, tail):
+        return {self.leaf: self.leaf_recs, self.agent: self.agent_recs, self.states: self.states_recs,
+                self.postal: self.postal_recs, self.queue_leaf: self.queue_recs}[p](tail)
+
+    def answers(self):
+        return {
+            "sessionMeta": dict(km._session_meta(self.leaf)),
+            "bgRunning": km._bg_scan_cached(self.leaf),
+            "bgAll": km._bg_scan_all_cached(self.leaf),
+            "agentLaunches": {k: (dict(v) if isinstance(v, dict) else sorted(v)) for k, v in km._agent_launch_state(self.leaf).items()},
+            "agentGist": km._agent_steps(self.agent),
+            "agentLaunchIds": sorted(km._agent_launch_ids(self.agent)),
+            "statesOverlay": km._states_awaiting_overlay(SID),
+            "stateIntervals": km._state_intervals(SID, "working", TS0 + 200),
+            "statesNotes": km._states_notes(SID),
+            "machineCut": km._last_machine_cut(SID),
+            "queueLedger": km._pending_ledger(self.queue_leaf),
+            "postalLog": {k: (dict(v) if isinstance(v, dict) else sorted(v)) for k, v in
+                          km._fold_records(km._postal_log_cache, self.postal, km._postal_log_fresh, km._postal_log_step, ckpt="postalLog").items()},
+        }
+
+    def write_all(self, tail):
+        for p in self.files:
+            _write(p, self.recs_of(p, tail))
+
+    def test_every_named_fold_resumes_from_its_checkpoint_and_equals_a_cold_fold(self):
+        self.write_all(tail=False)
+        self.answers()                                            # every fold at the prefix
+        names = set()
+        for p in self.files:
+            self.assertTrue(em.checkpoint_write(p), p)
+            names |= set(self.doc(p)["folds"])
+        self.assertEqual(names, {"sessionMeta", "bgRunning", "bgAll", "agentLaunches", "agentGist", "agentLaunchIds", "statesOverlay",
+                                 "stateIntervals", "statesNotes", "machineCut", "queueLedger", "postalLog"},
+                         "every kernel fold this test drives left its state in the checkpoint")
+        self.fresh_process()
+        for p in self.files:
+            full, head = self.recs_of(p, True), self.recs_of(p, False)
+            _append(p, *full[len(head):])
+        warm = self.answers()
+        self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
+        self.assertEqual(em.checkpoint_stats()["restored"], 5, "one restore per file")
+        for p in self.files:
+            with em._JSONL_CACHE_LOCK:
+                self.assertGreater(em._JSONL_CACHE[p][5], 0, "a tail entry: %s" % p)
+        self.fresh_process(); em.set_checkpoint_dir(None)       # the cold answer: a fresh process with no checkpoints at all
+        cold = self.answers()
+        self.assertEqual(warm, cold)
+        self.assertEqual(cold["sessionMeta"]["lastEditPath"], "/w/notes-api/api/cap.py", "the fixtures drive the folds")
+        self.assertEqual(cold["sessionMeta"]["gitBranch"], "api")
+        self.assertEqual([t["id"] for t in cold["bgRunning"]], ["toolu_bg2"])
+        self.assertEqual(cold["agentLaunches"]["settled"], ["toolu_ag1"])
+        self.assertEqual(len(cold["agentGist"]["steps"]), 3)
+        self.assertEqual(cold["machineCut"], (float(TS0 + 10), "deploy"))
+        self.assertEqual(len(cold["stateIntervals"]), 2, "two working stretches in the states rows")
+        self.assertEqual(cold["queueLedger"], ["second", "third"])
+        self.assertEqual(cold["postalLog"]["ended"], ["m2"])
+        self.assertNotIn("m1", cold["postalLog"]["execd"])
+
+    def test_the_kernel_writes_at_a_settle_or_a_states_log_move_and_not_otherwise(self):
+        self.write_all(tail=False)
+        self.answers()
+        rows = [{"sid": SID, "path": self.leaf}]
+        saved_sessions, saved_turn = km._sessions, km._turn_end_key
+        turn_end = [0]
+        km._sessions = lambda now: rows
+        km._turn_end_key = lambda sid, reg=None: turn_end[0]
+        try:
+            self.assertGreater(len(em.checkpoint_dirty()), 0)
+            km._persist_checkpoints(TS0)                          # the first sight of a session is new evidence
+            self.assertEqual(sorted(set(em.checkpoint_dirty()) & {self.leaf, self.agent, self.states, self.postal}), [])
+            self.assertIn(self.queue_leaf, em.checkpoint_dirty(), "a file of no session waits for exit")
+            _append(self.leaf, _user("more", "u9", "a3", TS0 + 100))
+            km._session_meta(self.leaf)
+            self.assertIn(self.leaf, em.checkpoint_dirty())
+            self.assertEqual(km._persist_checkpoints(TS0 + 1), 0, "no settle, no states move: nothing written")
+            turn_end[0] = TS0 + 100                                # the Stop hook stamped the settle
+            self.assertEqual(km._persist_checkpoints(TS0 + 2), 1)
+            self.assertNotIn(self.leaf, em.checkpoint_dirty())
+            _append(self.agent, _assistant([{"type": "tool_use", "id": "toolu_s9", "name": "Bash", "input": {"command": "true"}}], "s9", "s2", TS0 + 101))
+            km._agent_steps(self.agent)
+            self.assertEqual(km._persist_checkpoints(TS0 + 3), 0)
+            _append(self.states, {"t": TS0 + 102, "state": "working"})   # a states row is an event, with no settle
+            self.assertEqual(km._persist_checkpoints(TS0 + 4), 1, "the agent file rides the states-log move")
+            self.assertEqual(em.checkpoint_write_dirty(), 1, "exit writes what is left (the queue ledger's file)")
+            self.assertEqual(em.checkpoint_dirty(), [])
+        finally:
+            km._sessions, km._turn_end_key = saved_sessions, saved_turn
+
+    def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
+        snap = km._PERF_STATS.snapshot()
+        self.assertEqual(sorted(snap["checkpoints"]), ["dirty", "fallbacks", "readByPath", "readBytes", "restored", "skippedFolds", "swept", "writes"])
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write", src,
+                      "exit writes every dirty checkpoint in _drain_and_exit")
+        self.assertIn("_persist_checkpoints(now)", src)
+        self.assertIn("em.checkpoint_sweep()", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -12,6 +12,7 @@ states-log move and never otherwise; /perf carries the counters. Hermetic: synth
 import json
 import os
 import tempfile
+import threading
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -87,7 +88,7 @@ class Base(unittest.TestCase):
         (jd.STATE / "states").mkdir(parents=True, exist_ok=True)
         (jd.STATE / "timeline").mkdir(parents=True, exist_ok=True)
         self.fresh_process()
-        em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={}, restoredFolds={})
+        em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={}, restoredFolds={}, droppedRestores=0, oversizeFolds={})
 
     def tearDown(self):
         jd._rebind_state(self.saved_state)
@@ -189,6 +190,9 @@ class GenericFold(Base):
                          "the tail, the guard check before it and the guard captured after it: nothing of the prefix")
         self.assertEqual(em.checkpoint_stats()["restored"], 1)
         self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
+        cp = em._ckpt_file(self.p)
+        self.assertEqual(em.read_bytes_report()[str(cp)], cp.stat().st_size, "the checkpoint document's own read is counted")
+        self.assertEqual(em.checkpoint_stats()["documentBytes"], cp.stat().st_size)
         self.assertEqual(self.fold(), [0, 1, 2, 3, 4]); self.assertEqual(self.kinds[-1], "hit")
         self.assertEqual(self.cache[self.p][0], 5, "the cursor's count is first, as every reader of it knew")
         self.assertEqual(self.cold(), [0, 1, 2, 3, 4])
@@ -309,6 +313,70 @@ class GenericFold(Base):
                 self.assertEqual(em.checkpoint_stats()["fallbacks"], {reason: 1}, reason)
                 self.assertEqual(got, self.cold()); self.assertEqual(self.kinds[-1], "refold")
                 self.assertFalse(em._ckpt_file(self.p).exists(), "the checkpoint that did not verify is gone")
+
+    def test_two_threads_meeting_a_checkpointed_files_first_read_cost_one_read_and_lose_no_restore(self):
+        """Review find (2026-09-11): the reader held its lock for the lookup and the store only, so a fold's tail restore
+        (generation N, pending fold states under N) and a concurrent whole read (generation N+1, stored last) left the
+        pending states orphaned: every other fold of the file refolded over a whole read, silently. Reads that pull bytes
+        are serialized per path now and re-check the cache under the lock: the second thread waits and hits."""
+        _write(self.p, [{"n": i} for i in range(200)])
+        other = {}
+        self.fold(); self.fold("u", other); em.checkpoint_write(self.p)
+        size = os.stat(self.p).st_size
+        for trial in range(8):
+            with self.subTest(trial=trial):
+                self.fresh_process(); other.clear()
+                em._CKPT_STATS.update(restored=0, restoredFolds={}, droppedRestores=0, fallbacks={})
+                gate = threading.Barrier(2)
+                results, errors = {}, []
+
+                def fold_first():
+                    try:
+                        gate.wait(5); results["fold"] = self.fold()
+                    except Exception as e:                                # noqa: BLE001
+                        errors.append(e)
+
+                def whole_first():
+                    try:
+                        gate.wait(5); results["whole"] = len(em._read_jsonl_incremental(self.p))
+                    except Exception as e:                                # noqa: BLE001
+                        errors.append(e)
+                ts = [threading.Thread(target=fold_first), threading.Thread(target=whole_first)]
+                for th in ts:
+                    th.start()
+                for th in ts:
+                    th.join(10)
+                self.assertEqual(errors, [])
+                self.assertEqual((results["fold"], results["whole"]), (list(range(200)), 200))
+                self.assertEqual(em.fold_records(other, self.p, list, self._step, on=self.kinds.append, ckpt="u"), list(range(200)))
+                self.assertEqual(self.kinds[-1], "restore", "the second fold of the file restores too: no orphaned pending states")
+                st = em.checkpoint_stats()
+                self.assertEqual((st["droppedRestores"], st["fallbacks"]), (0, {}))
+                self.assertEqual(sorted(st["restoredFolds"]), ["t", "u"])
+                read = em.read_bytes_report()[self.p]
+                self.assertLessEqual(read, size + 4 * 64, "the file's content was read once, whichever thread went first (%d bytes for a %d-byte file)" % (read, size))
+
+    def test_a_fold_whose_state_is_the_size_of_its_file_is_left_out_of_the_document(self):
+        """Review find (2026-09-11): a checkpoint carried every fold's state, and a state that grows with its file (the postal
+        fold's map of every sent row) made the document a second copy of the file, read at every boot. A fold's encoded
+        state past the cap is left out, counted per name, and cold-folds; the bounded folds beside it restore."""
+        _write(self.p, [{"n": i, "pad": "x" * 400} for i in range(400)])           # ~170 KB of records
+        big = {}
+        self.fold()                                                               # "t": a list of 400 ints, small
+        em.fold_records(big, self.p, list, lambda st, o: st + [o], ckpt="big")    # "big": every record whole, over the cap
+        self.assertTrue(em.checkpoint_write(self.p))
+        d = self.doc(self.p)
+        self.assertEqual(sorted(d["folds"]), ["t"], "the oversize fold is not in the document")
+        self.assertLess(em._ckpt_file(self.p).stat().st_size, em._CKPT_FOLD_CAP, "and the document stays small")
+        self.assertEqual(em.checkpoint_stats()["oversizeFolds"], {"big": 1})
+        self.fresh_process(); big.clear()
+        self.assertEqual(self.fold(), list(range(400))); self.assertEqual(self.kinds[-1], "restore")
+        got = em.fold_records(big, self.p, self.__class__._noop_init, lambda st, o: st + [o], on=self.kinds.append, ckpt="big")
+        self.assertEqual(len(got), 400); self.assertEqual(self.kinds[-1], "refold", "the oversize fold cold-folds over the whole file")
+
+    @staticmethod
+    def _noop_init():
+        return []
 
     def test_nothing_is_written_when_no_fold_stands_at_the_witness_unless_forced(self):
         _write(self.p, [{"n": 0}])
@@ -521,7 +589,8 @@ class KernelFolds(Base):
 
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()
-        self.assertEqual(sorted(snap["checkpoints"]), ["dirty", "fallbacks", "readByPath", "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
+        self.assertEqual(sorted(snap["checkpoints"]), ["dirty", "documentBytes", "droppedRestores", "fallbacks", "oversizeFolds", "readByPath",
+                                                        "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write", src,
                       "exit writes every dirty checkpoint in _drain_and_exit")

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -301,9 +301,10 @@ class ExitThenBoot(unittest.TestCase):
             # what stays whole is asserted, not hidden: the leaf transcripts and their states logs, which the parse
             # reads (stage 4's), cost their whole size plus the guard check the folds' restore made on each
             for sid, sp in self.states_files.items():
-                got = by.get(os.path.realpath(sp), by.get(sp))
-                self.assertEqual(got, sizes[sid] + min(64, sizes[sid]),
-                                 "%s's states log: whole (the parse's read) plus the restore's guard check (bytes by class: %s)" % (sid, report))
+                got = by.get(os.path.realpath(sp), by.get(sp)) or 0
+                now_size = os.path.getsize(sp)                      # the second kernel appends states rows of its own
+                self.assertGreaterEqual(got, sizes[sid], "%s's states log: whole, the parse's read (bytes by class: %s)" % (sid, report))
+                self.assertLessEqual(got, now_size + 64, "%s's states log: at most whole plus the restore's guard check" % sid)
             for sid, lp in self.leaf_files.items():
                 got = by.get(os.path.realpath(lp), by.get(lp)) or 0
                 self.assertGreaterEqual(got, os.path.getsize(lp), "%s's leaf transcript: whole, the parse's read (stage 4)" % sid)

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -297,10 +297,10 @@ class ExitThenBoot(unittest.TestCase):
             self._drive(p2)
             perf = self._get(p2, "/perf")["checkpoints"]
             by = perf["readByPath"]
-            report = {"agent": 0, "states": 0, "leaf": 0, "postal": 0, "other": 0}
+            report = {"agent": 0, "states": 0, "leaf": 0, "postal": 0, "checkpoint": 0, "other": 0}
             for path, n in by.items():
-                cls_ = ("agent" if "/subagents/" in path else "states" if "/states/" in path else "postal" if path.endswith("messages.jsonl")
-                        else "leaf" if path.endswith(".jsonl") and "/projects/" in path else "other")
+                cls_ = ("checkpoint" if "/checkpoints/" in path else "agent" if "/subagents/" in path else "states" if "/states/" in path
+                        else "postal" if path.endswith("messages.jsonl") else "leaf" if path.endswith(".jsonl") and "/projects/" in path else "other")
                 report[cls_] += n
             self.assertEqual(perf["fallbacks"], {}, "every checkpoint verified: %s" % perf)
             self.assertGreaterEqual(perf["restored"], len(ALL), "one restore per states log at least: %s" % perf)

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -210,11 +210,18 @@ class ExitThenBoot(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        keep = os.environ.get("ROMP_T323S3_KEEP_LOGS")
+        if keep:                                                # a diagnosis aid: the two kernels' logs, kept where asked
+            os.makedirs(keep, exist_ok=True)
+            for f in os.listdir(cls.lab):
+                if f.startswith("kernel-") and f.endswith(".log"):
+                    shutil.copy(os.path.join(cls.lab, f), os.path.join(keep, f))
         shutil.rmtree(cls.lab, ignore_errors=True)
 
     def _boot(self):
         port = _free_port()
-        env = _lab.kernel_env(self.lab, self.claude, self.dist, port, self.token, ROMP_HOST_NAME="TESTHOST")
+        env = _lab.kernel_env(self.lab, self.claude, self.dist, port, self.token, ROMP_HOST_NAME="TESTHOST",
+                              ROMP_READER_TRACE=os.environ.get("ROMP_READER_TRACE", ""))   # a diagnosis aid: one stderr line per read
         log = open(os.path.join(self.lab, "kernel-%d.log" % port), "w")
         k = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=log, stderr=subprocess.STDOUT, env=env)
         for _ in range(200):
@@ -296,17 +303,21 @@ class ExitThenBoot(unittest.TestCase):
             self.assertEqual(perf["fallbacks"], {}, "every checkpoint verified: %s" % perf)
             self.assertGreaterEqual(perf["restored"], len(ALL), "one restore per states log at least: %s" % perf)
             got = by.get(os.path.realpath(self.agent_file), by.get(self.agent_file))
-            self.assertEqual(got, 64, "the agent file was read as a TAIL: the 64 guard bytes only, since nothing was appended "
-                                      "(its size %d; bytes by class in this boot: %s)" % (agent_size, report))
+            self.assertEqual(got, 128, "the agent file was read as a TAIL: its 64 guard bytes checked and captured again, nothing of its "
+                                       "content, since nothing was appended (its size %d; bytes by class in this boot: %s)" % (agent_size, report))
+            self.assertGreaterEqual(perf["restoredFolds"].get("agentGist", 0), 1, "the gist fold resumed from its recorded state: %s" % perf["restoredFolds"])
+            for name in ("statesOverlay", "lastState", "machineCut"):   # the folds the feed and the busy hint run per session
+                self.assertGreaterEqual(perf["restoredFolds"].get(name, 0), len(ALL),
+                                        "the %s fold resumed for every session's states log: %s" % (name, perf["restoredFolds"]))
             # what stays whole is asserted, not hidden: the leaf transcripts and their states logs, which the parse
             # reads (stage 4's), cost their whole size plus the guard check the folds' restore made on each
             for sid, sp in self.states_files.items():
                 got = by.get(os.path.realpath(sp), by.get(sp)) or 0
                 now_size = os.path.getsize(sp)                      # the second kernel appends states rows of its own
                 self.assertGreaterEqual(got, sizes[sid], "%s's states log: whole, the parse's read (bytes by class: %s)" % (sid, report))
-                self.assertLessEqual(got, 2 * now_size + 4 * 64,
-                                     "%s's states log: whole once for the parse, at most once more when the kernel rewrites "
-                                     "the log in place (a healed overlay row moves the guard), plus a few guard reads" % sid)
+                self.assertLessEqual(got, now_size + 8 * 64,
+                                     "%s's states log: the parse's whole read plus guard reads and captures (a tail restore, its "
+                                     "upgrade to the whole file, the whole-reader-first check), never its content twice" % sid)
             for sid, lp in self.leaf_files.items():
                 got = by.get(os.path.realpath(lp), by.get(lp)) or 0
                 self.assertGreaterEqual(got, os.path.getsize(lp), "%s's leaf transcript: whole, the parse's read (stage 4)" % sid)

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""T323 stage 3, served: a REAL hermetic kernel boots over synthetic sessions, a chat client (a minimal websocket
+client in this file) looks at a session whose transcript launched an agent, so the chat build folds the agent's own
+transcript for its gist; the kernel is stopped the way the manager stops it (SIGTERM) and its exit writes the folds'
+checkpoints; a SECOND kernel boots over the same state root with the same client and reads the AGENT FILE as a tail
+(per file: the guard bytes, nothing more, since nothing was appended between the two boots), restores its checkpoints
+and falls back on none. What stays whole is asserted too, not left out: the leaf transcripts and their states logs,
+which the parse reads (stage 4's), read their whole size plus the guard check the folds' restore made. Synthetic only:
+invented text, placeholder uuids, TESTHOST."""
+import base64
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment
+
+WEB = "aaaaaaaa-3333-4222-8333-444444444444"
+API = "bbbbbbbb-3333-4222-8333-444444444444"
+TESTS = "cccccccc-3333-4222-8333-444444444444"
+ALL = (WEB, API, TESTS)
+
+
+def _free_port():
+    import socket
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); p = s.getsockname()[1]; s.close(); return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "cwd": "/w/notes-api",
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "cwd": "/w/notes-api",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+AGENT_ID = "a0123456789abcdef"                             # the shape the kernel's agent-id pattern admits
+
+
+def agent_launch(t, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "cwd": "/w/notes-api",
+            "message": {"role": "assistant", "stop_reason": "tool_use", "content": [
+                {"type": "tool_use", "id": "toolu_agent1", "name": "Agent", "input": {"prompt": "check the tab width on narrow screens"}}]}}
+
+
+def agent_result(t, uuid, parent):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "cwd": "/w/notes-api",
+            "toolUseResult": {"agentId": AGENT_ID, "status": "completed"},
+            "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_agent1", "content": "the tabs wrap at 480px"}]}}
+
+
+def agent_transcript(t0, n=60):
+    recs, parent = [], None
+    for k in range(n):
+        u, a = "s%d" % k, "r%d" % k
+        recs.append({"type": "user", "timestamp": iso(t0 + 2 * k), "uuid": u, "parentUuid": parent,
+                     "message": {"role": "user", "content": "look at screen %d" % k}})
+        recs.append({"type": "assistant", "timestamp": iso(t0 + 2 * k + 1), "uuid": a, "parentUuid": u,
+                     "message": {"role": "assistant", "stop_reason": "tool_use", "content": [
+                         {"type": "tool_use", "id": "toolu_s%d" % k, "name": "Read", "input": {"file_path": "/w/notes-api/web/tab%d.ts" % k}}]}})
+        parent = a
+    return recs
+
+
+class ChatClient:
+    """A minimal websocket client (RFC 6455 text frames, masked on the way out) that opens the chat pane on one
+    session the way the dashboard's shim does: the upgrade with app=chat and the active tab, then a ready frame,
+    then it reads frames until the session's frame arrives or the wait runs out."""
+
+    def __init__(self, port, token, active):
+        self.sock = socket.create_connection(("127.0.0.1", port), timeout=20)
+        key = base64.b64encode(os.urandom(16)).decode()
+        req = ("GET /ws?app=chat&wid=t323s3&active=%s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nUpgrade: websocket\r\n"
+               "Connection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\nX-Romp-Token: %s\r\n\r\n"
+               % (active, port, key, token))
+        self.sock.sendall(req.encode())
+        head = b""
+        while b"\r\n\r\n" not in head:
+            chunk = self.sock.recv(4096)
+            if not chunk:
+                raise RuntimeError("the websocket upgrade closed")
+            head += chunk
+        if b" 101 " not in head.split(b"\r\n", 1)[0]:
+            raise RuntimeError("upgrade refused: %r" % head[:120])
+        self.buf = head.split(b"\r\n\r\n", 1)[1]
+
+    def send(self, obj):
+        data = json.dumps(obj).encode()
+        mask = os.urandom(4)
+        hdr = bytes([0x81])
+        n = len(data)
+        if n < 126:
+            hdr += bytes([0x80 | n])
+        elif n < 65536:
+            hdr += bytes([0x80 | 126]) + struct.pack(">H", n)
+        else:
+            hdr += bytes([0x80 | 127]) + struct.pack(">Q", n)
+        self.sock.sendall(hdr + mask + bytes(b ^ mask[i % 4] for i, b in enumerate(data)))
+
+    def _need(self, n):
+        while len(self.buf) < n:
+            chunk = self.sock.recv(65536)
+            if not chunk:
+                raise EOFError
+            self.buf += chunk
+
+    def frames(self, seconds):
+        """Yield the text frames the kernel sends within `seconds` (pings are answered, other opcodes skipped)."""
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            self.sock.settimeout(max(0.1, deadline - time.time()))
+            try:
+                self._need(2)
+            except (socket.timeout, EOFError):
+                return
+            b0, b1 = self.buf[0], self.buf[1]
+            op, n, i = b0 & 0x0F, b1 & 0x7F, 2
+            if n == 126:
+                self._need(4); n = struct.unpack(">H", self.buf[2:4])[0]; i = 4
+            elif n == 127:
+                self._need(10); n = struct.unpack(">Q", self.buf[2:10])[0]; i = 10
+            try:
+                self._need(i + n)
+            except (socket.timeout, EOFError):
+                return
+            payload, self.buf = self.buf[i:i + n], self.buf[i + n:]
+            if op == 0x9:                                       # ping: answer with a pong
+                self.sock.sendall(bytes([0x8A, 0x80 | len(payload)]) + b"\0\0\0\0" + payload)
+            elif op == 0x1:
+                try:
+                    yield json.loads(payload.decode())
+                except ValueError:
+                    continue
+            elif op == 0x8:
+                return
+
+    def close(self):
+        try:
+            self.sock.sendall(bytes([0x88, 0x80]) + b"\0\0\0\0")
+        except OSError:
+            pass
+        self.sock.close()
+
+
+class ExitThenBoot(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lab = tempfile.mkdtemp(prefix="romp-t323s3-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        cls.dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), cls.dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cls.claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states", "goals", "timeline"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        proj = os.path.join(cls.claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 3600
+        for i, (sid, name) in enumerate(((WEB, "web"), (API, "api"), (TESTS, "tests"))):
+            Path(cls.state, "names", sid).write_text("%s\t%s\t#9cd2ff\t#0c1a2e\n" % (name, cwd))
+            Path(cls.state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                 "model": "claude-opus-5", "liveModel": "Opus 5", "lastStopAt": t0 + 90}))
+            rows = [{"t": t0 + 10 * k, "state": "working" if k % 2 == 0 else "waiting"} for k in range(1, 40)]
+            rows.append({"t": t0 + 70, "awaiting": True, "state": "waiting"} if i == 1 else {"t": t0 + 71, "state": "idle"})
+            Path(cls.state, "states", sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in rows))
+            recs = [uline(t0, "wire the fixtures directory into the integration suite", "u1"),
+                    aline(t0 + 20, "done: the suite reads the fixtures", "a1", "u1")]
+            if sid == WEB:                                     # web launched an agent whose own transcript is the gist's input
+                recs += [uline(t0 + 30, "check the tab width", "u2", "a1"), agent_launch(t0 + 31, "a2", "u2"),
+                         agent_result(t0 + 80, "u3", "a2"), aline(t0 + 85, "the tabs wrap at 480px; fixed", "a3", "u3")]
+                sub = Path(proj, sid, "subagents"); sub.mkdir(parents=True, exist_ok=True)
+                cls.agent_file = str(sub / ("agent-%s.jsonl" % AGENT_ID))
+                Path(cls.agent_file).write_text("".join(json.dumps(r) + "\n" for r in agent_transcript(t0 + 32)))
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+            cls.leaf_files = getattr(cls, "leaf_files", {}); cls.leaf_files[sid] = os.path.join(proj, sid + ".jsonl")
+        Path(cls.state, "timeline", "messages.jsonl").write_text("".join(json.dumps(r) + "\n" for r in (
+            {"ev": "sent", "id": "m1", "from_id": WEB, "to_id": API, "from": "web", "body": "ping", "t": t0 + 5, "kind": "coordinate"},
+            {"ev": "exec", "id": "m1", "t": t0 + 6})))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.states_files = {sid: os.path.join(cls.state, "states", sid + ".jsonl") for sid in ALL}
+        cls.token = "testtok-t323s3"
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.lab, ignore_errors=True)
+
+    def _boot(self):
+        port = _free_port()
+        env = _lab.kernel_env(self.lab, self.claude, self.dist, port, self.token, ROMP_HOST_NAME="TESTHOST")
+        log = open(os.path.join(self.lab, "kernel-%d.log" % port), "w")
+        k = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=log, stderr=subprocess.STDOUT, env=env)
+        for _ in range(200):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            k.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+        for _ in range(40):                                     # the boot reconcile and a few pusher cycles
+            try:
+                if self._get(port, "/version").get("uptime_s", 0) >= 4:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.5)
+        return k, port
+
+    def _get(self, port, path):
+        req = urllib.request.Request("http://127.0.0.1:%d%s" % (port, path), headers={"X-Romp-Token": self.token})
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return json.loads(r.read().decode())
+
+    def _drive(self, port):
+        """What a dashboard does: a chat client looks at web (the chat build folds the session meta, the queue ledger,
+        the background tasks, the agent launches and the agent's gist), plus the feed and the busy hint (the states
+        folds). The session frame for web is awaited so the build has run before the kernel is stopped."""
+        client = ChatClient(port, self.token, WEB)
+        try:
+            client.send({"type": "ready"})
+            seen = []
+            for fr in client.frames(20):
+                seen.append(fr.get("type"))
+                if fr.get("type") == "session" and (fr.get("id") == WEB or fr.get("sid") == WEB):
+                    break
+            self.assertIn("session", seen, "the chat client received web's frame; frames seen: %s" % seen[:20])
+            self._get(port, "/feed.json")
+            try:
+                self._get(port, "/busy")
+            except Exception:
+                pass
+            time.sleep(2.0)                                     # a few pusher cycles: the settle-keyed writer runs
+        finally:
+            client.close()
+
+    def _stop(self, k):
+        k.send_signal(signal.SIGTERM)                           # the manager's stop: _graceful_term, then _drain_and_exit
+        k.wait(timeout=30)
+
+    def test_the_second_kernel_reads_the_states_logs_as_tails_from_the_checkpoints_the_first_left_at_exit(self):
+        k1, p1 = self._boot()
+        try:
+            self._drive(p1)
+            perf1 = self._get(p1, "/perf")["checkpoints"]
+            self.assertEqual(perf1["fallbacks"], {}, "a first boot has nothing to fall back from")
+        finally:
+            self._stop(k1)
+        ck = os.path.join(self.state, "checkpoints")
+        files = sorted(os.listdir(ck)) if os.path.isdir(ck) else []
+        docs = [json.loads(open(os.path.join(ck, f)).read()) for f in files]
+        recorded = {d["path"] for d in docs}
+        for sid, sp in self.states_files.items():
+            self.assertIn(os.path.realpath(sp), recorded, "the exit wrote a checkpoint for %s's states log; wrote: %s" % (sid, sorted(recorded)))
+        self.assertIn(os.path.realpath(self.agent_file), recorded, "the exit wrote a checkpoint for the agent file the gist folded; wrote: %s" % sorted(recorded))
+        agent_size = os.path.getsize(self.agent_file)
+        sizes = {sid: os.path.getsize(sp) for sid, sp in self.states_files.items()}
+        k2, p2 = self._boot()
+        try:
+            self._drive(p2)
+            perf = self._get(p2, "/perf")["checkpoints"]
+            by = perf["readByPath"]
+            report = {"agent": 0, "states": 0, "leaf": 0, "postal": 0, "other": 0}
+            for path, n in by.items():
+                cls_ = ("agent" if "/subagents/" in path else "states" if "/states/" in path else "postal" if path.endswith("messages.jsonl")
+                        else "leaf" if path.endswith(".jsonl") and "/projects/" in path else "other")
+                report[cls_] += n
+            self.assertEqual(perf["fallbacks"], {}, "every checkpoint verified: %s" % perf)
+            self.assertGreaterEqual(perf["restored"], len(ALL), "one restore per states log at least: %s" % perf)
+            got = by.get(os.path.realpath(self.agent_file), by.get(self.agent_file))
+            self.assertEqual(got, 64, "the agent file was read as a TAIL: the 64 guard bytes only, since nothing was appended "
+                                      "(its size %d; bytes by class in this boot: %s)" % (agent_size, report))
+            # what stays whole is asserted, not hidden: the leaf transcripts and their states logs, which the parse
+            # reads (stage 4's), cost their whole size plus the guard check the folds' restore made on each
+            for sid, sp in self.states_files.items():
+                got = by.get(os.path.realpath(sp), by.get(sp))
+                self.assertEqual(got, sizes[sid] + min(64, sizes[sid]),
+                                 "%s's states log: whole (the parse's read) plus the restore's guard check (bytes by class: %s)" % (sid, report))
+            for sid, lp in self.leaf_files.items():
+                got = by.get(os.path.realpath(lp), by.get(lp)) or 0
+                self.assertGreaterEqual(got, os.path.getsize(lp), "%s's leaf transcript: whole, the parse's read (stage 4)" % sid)
+            sys.stderr.write("t323s3 served: second boot bytes by class %s, restored %d, writes %d\n"
+                             % (report, perf["restored"], perf["writes"]))
+        finally:
+            self._stop(k2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -304,7 +304,8 @@ class ExitThenBoot(unittest.TestCase):
                 got = by.get(os.path.realpath(sp), by.get(sp)) or 0
                 now_size = os.path.getsize(sp)                      # the second kernel appends states rows of its own
                 self.assertGreaterEqual(got, sizes[sid], "%s's states log: whole, the parse's read (bytes by class: %s)" % (sid, report))
-                self.assertLessEqual(got, now_size + 64, "%s's states log: at most whole plus the restore's guard check" % sid)
+                self.assertLessEqual(got, now_size + 4 * 64, "%s's states log: at most whole plus a few guard reads (the restore's "
+                                     "check, the upgrade's, an append's)" % sid)
             for sid, lp in self.leaf_files.items():
                 got = by.get(os.path.realpath(lp), by.get(lp)) or 0
                 self.assertGreaterEqual(got, os.path.getsize(lp), "%s's leaf transcript: whole, the parse's read (stage 4)" % sid)

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -304,8 +304,9 @@ class ExitThenBoot(unittest.TestCase):
                 got = by.get(os.path.realpath(sp), by.get(sp)) or 0
                 now_size = os.path.getsize(sp)                      # the second kernel appends states rows of its own
                 self.assertGreaterEqual(got, sizes[sid], "%s's states log: whole, the parse's read (bytes by class: %s)" % (sid, report))
-                self.assertLessEqual(got, now_size + 4 * 64, "%s's states log: at most whole plus a few guard reads (the restore's "
-                                     "check, the upgrade's, an append's)" % sid)
+                self.assertLessEqual(got, 2 * now_size + 4 * 64,
+                                     "%s's states log: whole once for the parse, at most once more when the kernel rewrites "
+                                     "the log in place (a healed overlay row moves the guard), plus a few guard reads" % sid)
             for sid, lp in self.leaf_files.items():
                 got = by.get(os.path.realpath(lp), by.get(lp)) or 0
                 self.assertGreaterEqual(got, os.path.getsize(lp), "%s's leaf transcript: whole, the parse's read (stage 4)" % sid)

--- a/tests/test_fold_checkpoints_served.py
+++ b/tests/test_fold_checkpoints_served.py
@@ -5,8 +5,10 @@ transcript for its gist; the kernel is stopped the way the manager stops it (SIG
 checkpoints; a SECOND kernel boots over the same state root with the same client and reads the AGENT FILE as a tail
 (per file: the guard bytes, nothing more, since nothing was appended between the two boots), restores its checkpoints
 and falls back on none. What stays whole is asserted too, not left out: the leaf transcripts and their states logs,
-which the parse reads (stage 4's), read their whole size plus the guard check the folds' restore made. Synthetic only:
-invented text, placeholder uuids, TESTHOST."""
+which the parse reads (stage 4's), read their whole size plus the guard reads the folds' restore made, and at most one
+more whole read: the reader serializes no reads, so two threads meeting a file's first read at the same instant (the
+judges' parse and the pusher's folds, at boot) both read it, which the reader trace showed as two from-zero reads of
+one states log back to back. Synthetic only: invented text, placeholder uuids, TESTHOST."""
 import base64
 import json
 import os
@@ -315,9 +317,11 @@ class ExitThenBoot(unittest.TestCase):
                 got = by.get(os.path.realpath(sp), by.get(sp)) or 0
                 now_size = os.path.getsize(sp)                      # the second kernel appends states rows of its own
                 self.assertGreaterEqual(got, sizes[sid], "%s's states log: whole, the parse's read (bytes by class: %s)" % (sid, report))
-                self.assertLessEqual(got, now_size + 8 * 64,
-                                     "%s's states log: the parse's whole read plus guard reads and captures (a tail restore, its "
-                                     "upgrade to the whole file, the whole-reader-first check), never its content twice" % sid)
+                self.assertLessEqual(got, 2 * now_size + 8 * 64,
+                                     "%s's states log: the parse's whole read, at most one more whole read when two threads meet "
+                                     "the file's first read at once (the reader serializes no reads; at boot the judges' parse and "
+                                     "the pusher's folds both ask, and the trace showed two from-zero reads of one log back to back), "
+                                     "plus guard reads and captures" % sid)
             for sid, lp in self.leaf_files.items():
                 got = by.get(os.path.realpath(lp), by.get(lp)) or 0
                 self.assertGreaterEqual(got, os.path.getsize(lp), "%s's leaf transcript: whole, the parse's read (stage 4)" % sid)

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -47,7 +47,8 @@ SID = "11111111-2222-3333-4444-555555555555"
 # and node ids collide across test modules under the shared placeholder (CLAUDE.md, goal-store fixtures).
 GOAL_SID = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
 TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms", "builds", "sends",
-            "goals", "memos", "judge", "http", "parses"}   # parses: cold event-model parses (T323 stage 1)
+            "goals", "memos", "judge", "http", "parses",   # parses: cold event-model parses (T323 stage 1)
+            "checkpoints"}                                 # checkpoints: the folds' checkpoints (T323 stage 3)
 
 
 def _burn_cpu(seconds):

--- a/tests/test_shared_parse.py
+++ b/tests/test_shared_parse.py
@@ -288,6 +288,57 @@ class OneParseForBoth(unittest.TestCase):
                 os.environ["CLAUDE_CONFIG_DIR"] = saved[3]
             jd._rebind_state(saved[0])
 
+    def test_the_clear_race_window_hands_out_the_previous_leaf_not_the_anchor(self):
+        """Carried from the stage 2 review (2026-09-11): between the registry's lastSid rewrite and the new transcript's
+        first record, discover handed out the ANCHOR, so from the second clear on a build landing in the window parsed
+        the pre-clear anchor cold (its tree released at the first clear) and the noted leaf flipped twice. discover
+        hands out the leaf it handed out last until the named file exists."""
+        import re
+        C = "33333333-2222-4333-8444-000000000304"
+        L1, L2 = "44444444-2222-4333-8444-000000000451", "44444444-2222-4333-8444-000000000452"
+        saved = (jd.STATE, jd.NAMES, jd.PROJECTS, os.environ.get("CLAUDE_CONFIG_DIR"))
+        td = Path(tempfile.mkdtemp())
+        try:
+            jd._rebind_state(td / "state")
+            cfg = td / "claude"; os.environ["CLAUDE_CONFIG_DIR"] = str(cfg)
+            cdir = td / "launchdir"; cdir.mkdir()
+            proj_dir = cfg / "projects" / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+            proj_dir.mkdir(parents=True)
+            names = td / "names"; names.mkdir()
+            (names / C).write_text("worker\t%s\t#abcdef\n" % cdir)
+            jd.NAMES, jd.PROJECTS = names, cfg / "projects"
+            jd.SDKDIR.mkdir(parents=True, exist_ok=True)
+            reg = jd.SDKDIR / (C + ".json")
+            anchor_path = _transcript(str(proj_dir), C, n=2)
+            leaf1 = _transcript(str(proj_dir), L1, n=1)
+            reg.write_text(json.dumps({"sid": C, "name": "worker", "cwd": str(cdir), "lastSid": L1}))
+            now = time.time()
+
+            def current_leaf():
+                rows = [r for r in jd.discover(now) if r[0] == C]
+                self.assertEqual(len(rows), 1, rows)
+                return str(rows[0][1])
+
+            self.assertEqual(current_leaf(), leaf1)                       # after the first clear
+            km._parse(leaf1, C, now)
+            reg.write_text(json.dumps({"sid": C, "name": "worker", "cwd": str(cdir), "lastSid": L2}))
+            os.utime(reg, (now + 1, now + 1))                             # the second clear's registry write lands first
+            m0 = self._misses()
+            self.assertEqual(current_leaf(), leaf1, "the window: lastSid names a file not on disk, the previous leaf stands")
+            self.assertEqual(self._misses() - m0, 0)
+            self.assertFalse(jd._leaf_retired(C, leaf1), "no flip was noted in the window")
+            self.assertEqual([k for k in jd._PARSE_CACHE if k[0] == C], [(C, jd._pending_cut(C), leaf1)], "the anchor was never parsed")
+            leaf2 = _transcript(str(proj_dir), L2, n=1)                  # the CLI writes the new transcript's first record
+            self.assertEqual(current_leaf(), leaf2, "the file exists: discover hands out the new leaf")
+            self.assertTrue(jd._leaf_retired(C, leaf1)); self.assertFalse(jd._leaf_retired(C, anchor_path))
+        finally:
+            jd.NAMES, jd.PROJECTS = saved[1], saved[2]
+            if saved[3] is None:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            else:
+                os.environ["CLAUDE_CONFIG_DIR"] = saved[3]
+            jd._rebind_state(saved[0])
+
     def test_a_fork_childs_flip_leaves_the_parents_slot(self):
         """Review find (2026-09-11): a fork child's SDK registry is born with lastSid = the PARENT's fsid until its
         own init flips it, so discover hands the child the parent's transcript first; the child's flip to its own


### PR DESCRIPTION
T323 stage 3 of the restart-surviving sessions program: the folds' checkpoints. After a kernel restart every append-incremental fold over a JSONL file read its whole file from record zero, because its cursor lived in the process and was gated on the identity of the record objects, which nothing on disk can carry. This change persists the reader's prefix witness and the folds' states per file, so a fresh kernel reads only the tail past the checkpoint and resumes each fold from its recorded state. The parse trees and the record cache the parse reads through are unchanged (stage 4).

**Design points**
- One small JSON file per folded file under the state root's `checkpoints/` directory, named by the sha1 of the file's realpath, written by temp-and-replace. It records the reader's witness (the byte offset past the last complete line, the up to 64 guard bytes before it, the record count, the last record's uuid when it has one), a per-file write counter, and `folds`: the state of every fold whose cursor stood at that count, through a tagged codec (sets, tuples and non-string-keyed dicts round-trip). A fold behind the witness is left out and cold-folds at first touch, and so is a fold whose encoded state would exceed 64 KB (counted per name under `oversizeFolds`): a state that grows with its file, such as the postal log fold's map of every sent row, the state intervals' list of every transition or the every-task background view on a long transcript, would make the document a second copy of the file and its boot read would cost what the checkpoint exists to save (measured before the cap: 11.2 MB of documents in a 44 MB world). The bounded folds (the gist's capped steps, the running tasks, the newest rows, the launches) are the ones the checkpoint pays for; a bounded projection for the growing ones is a later stage's item.
- The reader's cache entry gains `base` (records before the held list; a tail entry restored from a checkpoint holds only the tail) and `gen`, the value of a process-wide counter taken fresh by every from-zero read and every restored entry (a mismatch, an eviction, a failure pop, a first read) and kept across an upgrade from a tail entry to the whole file and across appends, so no two entries of a path ever share one and a cursor left by an evicted entry can never match a later read's. Fold cursors are `(count, gen, state)`, the count first as every reader of the cursor knew it; the object-identity gates are gone. `fold_records(..., ckpt=name)` makes a fold resumable (the judge names its cache once per call through `name_fold_cache`, keeping its two-argument call shape); folds without a name behave as before. Reads that pull bytes are serialized per path (64 striped locks) and re-check the cache under the lock, so two threads meeting a file's first read at boot (the judges' parse and the pusher's folds) cost one read and one generation, and a restore taken under one generation is never orphaned by a concurrent read's; a dropped restore, should one still happen, is counted (`droppedRestores`) and said on stderr.
- A first fold of a file in a new process consults the checkpoint: version, path and size are checked, then the guard bytes on disk, and only `offset..EOF` is read. A whole reader (the parse, the postal index) that meets a tail entry upgrades it to the whole file under the same generation, so the folds keep their cursors; a whole reader that came first still lets the folds resume after one guard read, and both restore paths ask one helper for the size and mtime verdict before the guard, so one rewrite gets one reason whichever reader came first. Anything that does not verify (`version`, `path`, `shrunk`, `guard` for a rewrite, `rewrite` for a same-size-new-mtime, `corrupt`) falls back to a whole read, is counted per reason under `/perf` `checkpoints.fallbacks`, said once on stderr, and its file is removed. `/perf` also carries `restoredFolds` (restores per fold name), `readBytes` and `readByPath` (every byte the reader pulled, guard captures and torn-fragment reads included).
- Writes are event-keyed: at the end of a pusher cycle, a session whose turn-end key (the Stop hook's `lastStopAt`, else a stopped states transition) or whose states log moved since its last write gets the dirty checkpoints of its files written (its leaf, its states log, its agent files, the shared postal log); everything dirty is written at exit in the drain every exit path shares (SIGTERM from the manager and the parent watch both reach it). No timer. A session whose turn runs for hours still writes at every states row.
- Checkpoints of files that no longer exist are swept at boot, counted. The directory is asked of the judge at call time, so a rebound state root moves it. A compaction appends records and changes nothing here.
- The four readers that still walked their whole log per call (the last state, the session's own last state, the retrying-stretch start, the nudge fire times) are folds with checkpoint names now, and `_session_meta` moved onto `fold_records`.
- The `/clear` race window carried from stage 2 is its own commit: discovery keeps handing out the previous leaf while a fresh lastSid names a file not yet on disk, instead of the anchor.

**Measured** (`scripts/bench_fold_checkpoints.py`: synthetic worlds of six sessions, each a leaf transcript, an agent file and a states log, one postal log; two boots per tree in fresh processes over the same world, the second boot's bytes counted at the reader per file class; decimal MB; one measurement per point): at 1x / 4x / 16x of 150 invented turns the restarted kernel reads 2.74 / 11.01 / 44.15 MB on main and 2.10 / 7.96 / 29.27 MB on this branch, the checkpoint documents' own reads included (0.37 / 1.04 / 1.53 MB: each document is read twice at boot, once by the sweep and once at the first fold; folds over the 64 KB cap are not in them). The agent files fall from 1.02 / 4.09 / 16.40 MB to 0.001 MB at every size (128 bytes per file: the guard checked, then captured again; nothing of their content). Bytes are counted the same way on both arms, at the reader on this branch and at a counting open() on main, guard captures included. What stays whole is on the figure's second panel and is stage 4's or named: the leaf transcripts (1.40 / 5.63 / 22.55 MB, the parse), their states logs (0.07 / 0.27 / 1.09 MB, read by the parse as well as by the folds, so the folds' restore saves them nothing at boot until the parse is checkpointed), and the postal log (0.25 / 1.02 / 4.10 MB, whose readers besides the timeline fold walk it whole: the postal index, the feed's parked-handoff scan, the park tail). Floor: a checkpointed file still costs its document (twice, sweep and load), its guard bytes twice (checked, then captured, up to 64 each) and whatever was appended since the checkpoint. Figure: `T323-stage3-bench/boot_read_vs_size.png` under the research directory.

**Tests**: `tests/test_fold_checkpoints.py` (the codec over every fold state shape; write, restore and fold-the-tail equals a cold fold, with the bytes read asserted as tail plus guard; the whole-reader-first restore; a rewrite under the guard, a shrink, a wrong version, a wrong path, a corrupt document and a same-size-new-mtime each fall back, are counted and equal cold; a fold behind the witness is left out and cold-folds while the other restores; an evicted reader entry never lets a rewritten file pass as a hit or an append, and the checkpoint written after is right; a whole reader first and then a rewrite falls back with the tail path's reason; the boot sweep; all eighteen checkpoint names the kernel and the judge give are pinned against the source and every one resumes equal to a cold fold over realistic rows; the kernel writes at a settle or a states-log move and not otherwise, and exit writes the rest; `/perf` carries the counters). `tests/test_fold_checkpoints_served.py` (a real hermetic kernel, a minimal websocket chat client looking at a session that launched an agent, SIGTERM, a second kernel: the agent file is read as 128 bytes, the gist and the states folds' restores pinned by name through `restoredFolds`, the states logs and leaves asserted whole as the parse's read with a bound of a few guard reads, no fallbacks). The `/clear` race window test in `tests/test_shared_parse.py`. The existing fold-equals-full pins (incremental reader, scanner folds, states overlay, background tasks, JSONL cache, assembly) pass unchanged but for one whose premise moved: a pin lost to eviction no longer costs a re-read, since the reader remembers the entry it served.

**Carried to stage 4, not in this change**: the task-checklist fold (`_fold_tasks`) folds parsed atoms per turn, not records; its input is the parse, which stays whole until the parse is checkpointed, and its natural checkpoint is that stage's turn-id anchored one. The postal log's whole readers named above stay whole here.

Tier: feature.
