### PR TITLE
The UI stops offering the tmux backend (T331, stage 2 of the removal)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -414,20 +414,12 @@ Sessions run on one of these backends, chosen per session:
 
 - **Claude Code (the default, strongly recommended).** The kernel runs the
   Claude Code session itself, through the Claude Agent SDK.
-- **Claude Code (tmux).** A Claude Code session running in a terminal inside
-  tmux. Run `romp new -t <name>` and that terminal session joins the interface
-  like any other, so you can work in the terminal directly and still see it in
-  Romp. The cost is that Romp has no direct connection to it: it reads what
-  appears in the terminal and on disk, and sends messages and nudges by
-  injecting keystrokes. That makes it less reliable and less responsive than
-  Claude Code itself, since scraping a terminal has edge cases a real API does
-  not, and updates wait on the transcript reaching disk. The new-session picker
-  and the gear's Default backend list offer it only while **Enable Claude Code
-  tmux backend** is on in the gear's Updates & debug section (off by default);
-  sessions already running on it keep working either way.
 - **Codex.** An OpenAI Codex agent; see [docs/codex.md](codex.md).
 
-The backends interleave freely, so terminal sessions and Claude Code sessions
+The terminal backend (a Claude Code session in a tmux pane that Romp followed by
+reading the terminal) is being removed: the new-session picker and the gear's
+Default backend list no longer offer it, and a saved default of it reads as
+Claude Code. The backends interleave freely, so Claude Code and Codex sessions
 sit side by side in the interface and message each other like any other pair.
 
 ## The Romp kernel (the back end)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -528,18 +528,14 @@ through to `install.sh`:
 
 ### Session backends
 
-- **Enable Claude Code tmux backend** (the gear's Updates & debug section; off
-  by default) decides whether the new-session picker and the gear's Default
-  backend list offer **Claude Code (tmux)**, a Claude Code session in a
-  terminal pane that Romp follows by reading the terminal. The setting gates
-  the offer alone: sessions already running on that backend keep working and
-  keep their label, `romp new -t` still works, and a saved default of Claude
-  Code (tmux) is set aside while the setting is off (new sessions use Claude
-  Code) and returns when it comes back. Like the judge settings, a change
-  applies at once, without a restart, and follows to every connected machine.
-  The backends read as **Claude Code** (the default), **Claude Code (tmux)**
-  and **Codex** everywhere: the picker, the gear, the tab tooltip's Backend
-  row.
+- The new-session picker and the gear's Default backend list offer **Claude
+  Code** (the default) and **Codex**; the backends read by those names
+  everywhere (the picker, the gear, the tab tooltip's Backend row). The
+  terminal backend, **Claude Code (tmux)**, is being removed: the dashboard no
+  longer offers it or its gear switch, a saved default of it reads as Claude
+  Code (never an undefined value), and every session's tab menu offers Move to
+  folder. The kernel still carries the setting and the backend until their
+  removal lands; a session already running on it keeps working meanwhile.
 
 ### Ports
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -48683,8 +48683,6 @@ var rows=m.sessions||[];
 if(rows.length){h+='<div class=ru-tip-win><div class=ru-tip-name><span>Sessions waiting</span></div>';
 rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}
 h+=histHTML();
-if(m.tmux>0)h+='<div class="ru-tip-win ah-line">'+(m.tmux===1?'1 tmux session is seen through its transcript only':m.tmux+' tmux sessions are seen through their transcripts only')
-+', so a retry in progress there shows only when it fails or recovers.</div>';
 if(full)h+='<div class="ru-tip-row ah-foot"><span class=ah-link role=button tabindex=0 data-act=usage>Usage and spend</span><span class=ah-link role=button tabindex=0 data-act=log>Log</span></div>';
 return h;}
 // The hover anchors above the rail, centered on the cursor, as the usage tip's showTip does; a re-render re-anchors

--- a/tests/test_api_health_hover.py
+++ b/tests/test_api_health_hover.py
@@ -747,8 +747,9 @@ class Script(unittest.TestCase):
         self.assertNotIn("headWords", JS, "no summary head line: the per-machine lines do the work")
         self.assertEqual(sb._AH_COUNTED, ("ok", "429", "529", "5xx", "other"),
                          "requests excludes 'none', so requests plus noStatus counts every attempt once")
-        self.assertIn("rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}\nh+=histHTML();\nif(m.tmux>0)h+=", JS,
-                      "the section sits after the sessions waiting and before the tmux line, in hover and detail alike")
+        self.assertIn("rows.forEach(function(r){h+=rowHTML(r,full);});h+='</div>';}\nh+=histHTML();\nif(full)h+=", JS,
+                      "the section sits after the sessions waiting and before the footer, in hover and detail alike")
+        self.assertNotIn("tmux session", JS, "T331: the terminal-coverage line is gone (the frame's count stays until the kernel side goes)")
 
     def test_the_card_names_every_machine_with_its_counts_in_their_colours_and_the_window_once(self):
         # T316: no head sentence; one line per machine (the dot in its state, the kernel's own name, the counts as coloured

--- a/tests/test_api_health_hover_browser.py
+++ b/tests/test_api_health_hover_browser.py
@@ -14,7 +14,7 @@ a browser (CI installs none).
 
 Executed here, beyond the rendering: the newest read wins a race, a fresh show drops the last answer, a pin
 after the hover reads once, the answer waits under a held pointer, the section's place between the sessions
-and the tmux line, the family-only bucket name, the dated stamp and the hour and day durations; Escape
+the family-only bucket name, the dated stamp and the hour and day durations; Escape
 dismisses the focus-shown hover, tooltip and dialog roles by mode, a window-refocus does not pop the hover,
 and the geometry at 830 px wide and on a short window. The window-refocus trigger itself cannot be produced
 headless (bringToFront fires no window focus in Playwright's chromium), so that case drives the mechanism with
@@ -467,8 +467,8 @@ await step("race", async () => {
   await variant("storm");
 });
 await step("order", async () => {
-  // 11. with a waiting session and a tmux session in the frame, the section sits after Sessions waiting and
-  //     before the tmux line
+  // 11. with a waiting session (and a terminal count the frame still carries), the section sits after Sessions
+  //     waiting, and no terminal-coverage line follows it (T331)
   await ev((f) => { window.__rompApiHealth(f); }, frame({ state: "degraded", cls: "429", text: "rate limited · 1 waiting", waiting: 1, retrying: 1, since: NOW_PLACEHOLDER, tmux: 1, seq: 1,
     sessions: [{ sid: "SID_PLACEHOLDER", name: "web", color: null, kind: "retrying", cls: "429", status: 429, since: NOW_PLACEHOLDER, suppressed: false }] }));
   await enter(); await waitRows();
@@ -933,10 +933,10 @@ class ServedHistory(unittest.TestCase):
         self.assertEqual(R["recovered"]["head"]["word"], '35 successful requests · 9 429s · 1 5xx', "the next successful read replaces the failure")
         self.assertIsNone(R["recovered"]["head"]["err"])
 
-    def test_the_section_sits_between_the_sessions_waiting_and_the_tmux_line(self):
+    def test_the_section_sits_after_the_sessions_waiting_and_no_terminal_coverage_line_follows(self):
         order = self.R["order"]
         self.assertEqual(order[:3], ["API health", "Sessions waiting", "History"])
-        self.assertTrue(order[3].startswith("1 tmux session is seen"), order)
+        self.assertFalse(any("tmux" in o for o in order), "T331: the frame's tmux count draws no line: %r" % order)
 
     def test_focus_shows_the_hover_and_blur_hides_it(self):
         R = self.R

--- a/tests/test_api_health_rail.py
+++ b/tests/test_api_health_rail.py
@@ -491,10 +491,12 @@ class Detail(unittest.TestCase):
         self.assertIn("data-act=reveal data-sid=", self.JS)
         self.assertIn("else{hint=NOTSENT;dirty=true;}", row, "a dead socket is said here too")
 
-    def test_the_coverage_line_appears_only_under_a_tmux_guard(self):
-        self.assertIn("if(m.tmux>0)h+=", self.JS)
-        self.assertIn("seen through their transcripts only", self.JS)
-        self.assertIn(", so a retry in progress there shows only when it fails or recovers.", self.JS)
+    def test_no_terminal_coverage_line_is_drawn(self):
+        # T331 (the user 2026-09-10: the tmux backend is being removed): the popup no longer says how many terminal
+        # sessions are seen through their transcripts; the frame's `tmux` count stays on the wire until the kernel
+        # side goes (a federation field older peers keep sending)
+        self.assertNotIn("m.tmux", self.JS)
+        self.assertNotIn("seen through their transcripts only", self.JS)
 
     def test_the_detail_renders_from_the_last_frame_and_the_history_is_the_one_read(self):
         # the cell and the frame's reading render from the last frame only; the History section is the one fetch,

--- a/tests/test_kernel_settings_sections.py
+++ b/tests/test_kernel_settings_sections.py
@@ -91,18 +91,23 @@ class SettingsSectionsTest(unittest.TestCase):
 
     def test_the_sdk_backend_is_labelled_plain_sdk(self):
         # the backends as the user reads them (T288, the user 2026-09-09): "Claude Code" (the default, no
-        # qualifier — never "SDK" in copy a person reads), "Claude Code (tmux)", "Codex"
+        # qualifier — never "SDK" in copy a person reads) and "Codex"; the terminal backend is no longer offered
+        # (T331, the user 2026-09-10: the tmux backend is being removed), and its gear switch is gone
         h = _gear_src()
-        self.assertIn("<option value=sdk>Claude Code</option><option value=tmux>Claude Code (tmux)</option><option value=codex>Codex</option>", h)
+        self.assertIn("<option value=sdk>Claude Code</option><option value=codex>Codex</option>", h)
+        self.assertNotIn("Claude Code (tmux)", h)
+        self.assertNotIn("rs-tmuxbackend", h)
         self.assertNotIn("headless", h)
         self.assertNotIn(">SDK<", h)
         self.assertNotIn("SDK runs via", h)
         self.assertNotIn("new SDK session", h)
-        # the tmux backend's offer: a checkbox in Updates & debug, off by default, stamped and propagated like the
-        # judge knobs; the Default backend list follows it in the same modal (paintBackendOffer)
-        self.assertTrue(h.index(">Updates & debug<") < h.index("id=rs-tmuxbackend") < h.index("id=rs-judges-index"))
-        self.assertIn("<b>Enable Claude Code tmux backend <span class=rs-mixed hidden></span></b>", h)
-        self.assertIn("id=rs-backend-note", h, "the sub-line that says a saved tmux default is set aside")
+        # T331: the terminal backend's offer switch and the set-aside note are gone from the gear; the Default backend
+        # select is static and painted from the saved preference through the shared rule (a retired value reads as
+        # Claude Code)
+        self.assertNotIn("Enable Claude Code tmux backend", h)
+        self.assertNotIn("id=rs-backend-note", h)
+        self.assertNotIn("paintBackendOffer", h)
+        self.assertIn("bk.value = BN.effectiveDefaultBackend(load().backend);", h)
 
     def test_judge_rows_are_one_line_label_plus_picker(self):
         # label + picker share the line (the user 2026-07-12): nine .rs-jrow rows — six judge rows

--- a/tests/test_tag_chips_everywhere_browser.py
+++ b/tests/test_tag_chips_everywhere_browser.py
@@ -17,7 +17,7 @@ The served guard drives the real /chat page from a hermetic kernel with two tagg
 holds, opens the picker with the strip's +, and reads the Tags row: one option per tag, each holding one chip whose
 border wears the tag's colour; the tags the ACTIVE tab holds are selected (the full chip), the rest unselected (the
 faded chip); no dot anywhere. A click flips one option: the state class the create reads (`sel`) and the chip's off
-class move together, and a second click puts them back. The tmux pick greys the row and leaves both looks readable
+class move together, and a second click puts them back. No backend pick greys the row (T331)
 (the off chip's fade is not stacked with the row's).
 
 Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
@@ -141,15 +141,9 @@ await page.waitForTimeout(150);
 const light = await survey();
 await page.evaluate(() => document.body.classList.remove("chat-theme-yatharth", "theme-light"));
 await page.waitForTimeout(100);
-// the tmux pick: the row greys behind its note
-const hasTmux = await page.evaluate(() => { const b = document.querySelector('#picker .picker-be-opt[data-be="tmux"]'); return !!b && getComputedStyle(b).display !== "none"; });
-let tmux = null;
-if (hasTmux) {
-  await page.click('#picker .picker-be-opt[data-be="tmux"]');
-  await page.waitForTimeout(150);
-  tmux = await survey();
-}
-fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, lensMenu, open, on, off, light, tmux, hasTmux }) + "\n");
+// T331: no backend pick disables the row any more (the terminal backend is no longer offered); the picker's toggles
+const backends = await page.evaluate(() => Array.from(document.querySelectorAll('#picker .picker-be-opt:not([data-tag])')).map((b) => b.getAttribute('data-be')).filter(Boolean));
+fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, lensMenu, open, on, off, light, backends }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -184,7 +178,6 @@ class ServedPickerTagChips(unittest.TestCase):
                      "message": {"role": "user", "content": "notes-api: check the %s service" % name}}]
             Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
-        Path(cls.state, "tmux-backend").write_text("on")   # the gear's tmux switch: the picker offers Claude Code (tmux), so the greyed row can be driven
         tags = [{"id": tid, "name": tname, "color": color, "members": [sid for (_n, sid, t) in SESSIONS if tname in (t or "").split()]}
                 for (tid, tname, color) in TAGS]
         Path(cls.state, "timeline-views.json").write_text(json.dumps({"tags": tags, "tagOrder": [t[1] for t in TAGS],
@@ -297,16 +290,9 @@ class ServedPickerTagChips(unittest.TestCase):
         off = {x["tag"]: x for x in out["off"]["opts"]}
         self.assertFalse(off["infra"]["sel"])
         self.assertEqual((off["infra"]["chipClass"], off["infra"]["chipOpacity"]), ("tag-chip-off", "0.45"), "clicked again: the off chip")
-        # the tmux pick: the row greys (not a second fade), every option disabled, both looks still distinct
-        self.assertTrue(out["hasTmux"], "the lab turns the gear's tmux switch on, so the picker offers the tmux backend")
-        if out["hasTmux"]:
-            t = {x["tag"]: x for x in out["tmux"]["opts"]}
-            self.assertTrue(out["tmux"]["rowDisabled"])
-            for x in t.values():
-                self.assertTrue(x["disabled"])
-                self.assertIn("grayscale", x["btnFilter"], "greyed: %r" % x)
-                self.assertEqual(x["btnOpacity"], "1", "grey is the whole disabled cue: no second fade over the off chip's own: %r" % x)
-            self.assertEqual(t["web"]["chipOpacity"], "1"); self.assertEqual(t["infra"]["chipOpacity"], "0.45")
+        # T331: the picker offers Claude Code and Codex, both of whose creates take tags: no pick greys the row
+        self.assertEqual(out["backends"], ["sdk", "codex"], "the terminal backend is no longer offered")
+        self.assertFalse(out["on"]["rowDisabled"], "the row is never disabled")
 
 
 if __name__ == "__main__":

--- a/ui/ask-types.ts
+++ b/ui/ask-types.ts
@@ -1,5 +1,5 @@
 // Shared shape for a parsed live AskUserQuestion picker. The PARSER now lives in Python
-// (bin/romp-askparse, scraping the tmux pane kernel-side); the webview only needs these TYPES to render
+// (the kernel pushes askLive from the SDK's own control request); the webview only needs these TYPES to render
 // the picker the kernel pushes (askLive). The kernel emits exactly this shape (camelCase keys).
 
 export interface AskOption {
@@ -9,7 +9,7 @@ export interface AskOption {
   selected: boolean;    // the ❯ cursor is currently on this row
   checked?: boolean;    // multi-select checkbox state ([✔]/[ ]); undefined for non-checkbox rows
   preview?: string;     // THIS option's own preview box (SDK backend carries one per option, so the webview
-                        // can swap previews on ↑/↓ locally — no terminal round-trip). undefined on the tmux
+                        // can swap previews on ↑/↓ locally — no round-trip). undefined only from an older
                         // path, which only scrapes ONE preview (the focused option) into ParsedAsk.preview.
 }
 
@@ -29,6 +29,6 @@ export interface ParsedAsk {
                         // focused option draws to the RIGHT of the option list — undefined when none.
   previewKind?: "diff" | "plan"; // how to render `preview`: "diff" → colorize +/- lines (Edit/Write
                         // permission on the SDK backend), "plan" → plain (ExitPlanMode). undefined → verbatim
-                        // monospace (the tmux side-by-side scrape). (the user 2026-06-27.)
+                        // monospace (a verbatim box). (the user 2026-06-27.)
   sig: string;          // change-signature, so the host only re-posts when it actually changed
 }

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -714,7 +714,7 @@ function badgeFor(s) {
   let m = null;
   if (s.state === 'working') {
     // Live Task-subagent count (SDK only) rides the WORKING badge —
-    // so "what's actually running" is glanceable, the transparency the tmux backend never had. Blank when none.
+    // so "what's actually running" is glanceable. Blank when none.
     const n = (s.subagents && s.subagents.length) || 0;
     m = { label: n ? 'Working · ' + n + (n === 1 ? ' subagent' : ' subagents') : 'Working', kind: 'working' };
   }
@@ -761,7 +761,7 @@ function ctxInfo(s) {
 }
 
 // Model + effort, e.g. "Opus 4.8 xhigh" — the SAME string the Claude status bar shows.
-// statusline.sh publishes @claude-model/@claude-effort to tmux; the data layer reads them onto the
+// the kernel publishes model and effort per lane from the session's own row; the data layer reads them onto the
 // session. Rendered as muted secondary text between the name and the state chip. '' when unknown
 // (historical/dead lanes never reported it, and some models carry no effort level).
 // ---- theme palette (the opt-in LIGHT theme, 2026-08-28) ----------------------------------------
@@ -877,7 +877,7 @@ function modelLabel(s) {
 
 // The model + effort labels are little drop-down pickers (mirror of the chat statusline's): on a
 // LIVE lane, clicking the model or effort word opens a menu whose pick injects the matching /model or
-// /effort slash command into that session's pane (see _sendCommand → tmux, like _compactSession). The
+// /effort setting to that session through the kernel (_sendCommand, like _compactSession). The
 // label refreshes on the next poll when the TUI republishes @claude-model/@claude-effort; _metaPending
 // dims the word in the gap. Values mirror the extension's allowlist (extension.ts META_VALUES) verbatim.
 // (META_HOVER_FG — brighten the word + reveal its caret on hover — is a palette binding, declared
@@ -1459,7 +1459,7 @@ class TimelinePanel {
     } catch (e) {}
 
     // model/effort drop-down pickers: the open menu element + per-lane optimistic "pending" cues
-    // ('sid:kind' → {was, until}) that dim a word until the tmux var actually flips (or 20s elapses).
+    // ('sid:kind' → {was, until}) that dim a word until the session republishes the value (or 20s elapses).
     // _laneMenu = the per-lane GEAR drop-down (feed/postal/notify toggles — the user 2026-07-28).
     this._metaMenu = null; this._metaPending = {}; this._laneMenu = null;
     this._onDocClick = () => { this._closeMetaMenu(); this._closeLaneMenu(); this._closeViewsMenu(); };
@@ -2196,7 +2196,7 @@ class TimelinePanel {
   }
 
   update(data) {
-    if (!data || data.unavailable || !data.sessions) { this.data = data; this.drawMessage(data && data.unavailable ? 'Timeline needs a desktop Obsidian with tmux.' : 'No romp activity.'); this._signalReady(); return; }
+    if (!data || data.unavailable || !data.sessions) { this.data = data; this.drawMessage('No romp activity.'); this._signalReady(); return; }
     const _only = _rompOnlyTag();   // demo/recording view filter: keep only matching-name lanes (the user 2026-07-14)
     if (_only) data = Object.assign({}, data, { sessions: data.sessions.filter((s) => _rompMatchesOnly(s.name, _only)) });
     // The kernel ships the timeline as TWO messages (the user 2026-06-25): {type:"data"} carries the LANES
@@ -2919,8 +2919,8 @@ class TimelinePanel {
   }
 
   // Click the context battery → send `/compact` to that session's terminal. VS Code: hand the session
-  // name to the extension host (no Node in the webview); Obsidian: shell tmux directly. Types the slash
-  // command literally then submits it. (Targets the tmux session by name, like romp-postal-service's inject.)
+  // name to the extension host (no Node in the webview); Obsidian: POST /compact to the kernel over HTTP
+  // (_kernelPost, the same door `romp compact` uses). The kernel owns the transport to the session.
   // (Removed _smilBegin: the working-badge breathe no longer uses an in-SVG SMIL <animate> — a phase resync
   // couldn't fix the CADENCE, so even phase-correct it stuttered/truncated at the irregular redraw rate. It's
   // now a persistent CSS-animated overlay div (see _positionWorkLabel), like the compacting sweep — the user
@@ -3033,46 +3033,29 @@ class TimelinePanel {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineCompact === 'function') {
         window.__rompTimelineCompact(name); return;
       }
-      const cp = require('child_process'), tmux = this._tmuxPath();
-      cp.execFile(tmux, ['send-keys', '-t', name, '-l', '/compact'], (err) => {
-        if (!err) cp.execFile(tmux, ['send-keys', '-t', name, 'Enter']);
-      });
-    } catch (e) { /* no host hook + no Node → can't send */ }
+      // bare Obsidian (no host hook): the kernel's compact route, which parks mid-turn like the click in the chat
+      // does; _kernelPost never rejects and names the refusal, and the lane's next poll shows the result
+      this._kernelPost('/compact', { name }).then((r) => { if (r && r.ok === false && r.error) console.warn('romp timeline: /compact ' + r.error); });
+    } catch (e) { /* no host hook + no Electron → can't send */ }
   }
-  // Inject a slash command into a session's pane (the model/effort pickers). VS Code surface: hand it
-  // to the host hook if present; Obsidian: shell tmux. We BRACKETED-PASTE the command (set-buffer +
-  // paste-buffer -p) rather than send-keys -l, then submit with a delayed Enter — mirroring the
-  // the extension's sendToSession. A literal type would feed "/model …" to Claude Code's slash-command
-  // AUTOCOMPLETE char-by-char and an immediate Enter would race the TUI; a bracketed paste lands the
-  // whole string atomically (no autocomplete), and the 250ms gap lets the paste arrive before Enter.
+  // Send a slash command to a session (the model/effort pickers). VS Code surface: hand it to the host hook
+  // if present (the shell socket's sendCommand op, which carries the op flags); Obsidian: POST /send to the
+  // kernel over HTTP (_kernelPost), the same door `romp send` uses: a typed /model, /effort or /fast takes
+  // the kernel's setters there too, and anything else parks like a composer send. The kernel owns the
+  // transport to the session, so the model switch's confirmation is the kernel's to handle.
   //
-  // confirm=true → send a SECOND Enter after the submit. /model doesn't switch on submit: it opens a
-  // "Switch model?" picker (cursor pre-seated on "Yes, switch …") that fires no hook and waits — so the
-  // one Enter only OPENS the dialog and the model never changes. The extra Enter accepts the default
-  // "Yes". /effort and /compact apply directly (no cache-invalidation confirmation), so they don't pass
-  // it. The extra Enter is harmless even if a build skips the dialog (an empty composer submit is a no-op).
+  // `confirm` is kept in the signature for the callers (the model pick passes it); the kernel needs no
+  // second keystroke. `extra` is op flags for the kernel bridge (the Latest row's `{ floating: true }`);
+  // the HTTP route carries the bare command, so a Latest pick through it applies the alias without forgetting
+  // the family's pin (the shell socket path does both).
   _sendCommand(name, cmd, confirm, extra) {
     if (!name || !cmd) return;
     try {
-      // `extra` is op flags for the kernel bridge (the Latest row's `{ floating: true }`); the direct
-      // tmux paste below has no kernel to carry them to, so it sends the bare command
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSendCommand === 'function') {
         window.__rompTimelineSendCommand(name, cmd, extra || undefined); return;
       }
-      const cp = require('child_process'), tmux = this._tmuxPath();
-      const env = Object.assign({}, process.env, { LANG: 'en_US.UTF-8', LC_ALL: 'en_US.UTF-8', LC_CTYPE: 'en_US.UTF-8' });
-      const run = (args, cb) => cp.execFile(tmux, args, { timeout: 4000, encoding: 'utf8', env }, (err, out) => { if (cb) cb(err, out); });
-      const enter = () => run(['send-keys', '-t', name, 'Enter']);
-      const BUF = 'romp-timeline';
-      const submit = () => { enter(); if (confirm) setTimeout(enter, 600); };   // 2nd Enter → accept "Switch model? Yes"
-      const paste = () => run(['set-buffer', '-b', BUF, cmd], () =>
-        run(['paste-buffer', '-b', BUF, '-d', '-p', '-t', name], () => setTimeout(submit, 250)));
-      // exit copy-mode first if the pane is scrolled, so the paste + Enter actually land
-      run(['display-message', '-p', '-t', name, '#{pane_in_mode}'], (err, out) => {
-        if (!err && String(out || '').trim() === '1') run(['send-keys', '-t', name, '-X', 'cancel'], paste);
-        else paste();
-      });
-    } catch (e) { /* no host hook + no Node → can't send */ }
+      this._kernelPost('/send', { name, text: cmd }).then((r) => { if (r && r.ok === false && r.error) console.warn('romp timeline: /send ' + r.error); });
+    } catch (e) { /* no host hook + no Electron → can't send */ }
   }
 
   _closeMetaMenu() { if (this._metaMenu) { if (this._metaMenu._sub) this._metaMenu._sub.remove(); this._metaMenu.remove(); this._metaMenu = null; } }
@@ -5310,8 +5293,8 @@ class TimelinePanel {
     // Electron (Obsidian) only: a bare-node run (the test runner) and a browser page (which has its host
     // hooks) have no kernel to post to from here — the guard the file writers wore (the user 2026-07-02)
     if (typeof process === 'undefined' || !process.versions || !process.versions.electron) return null;
-    // the requires sit INSIDE a try, like every Node require in this file (_tmuxPath, the shell-outs, the
-    // writers this replaced): this file is also bundled for the BROWSER (esbuild, platform browser, the
+    // the requires sit INSIDE a try, like every Node require in this file (the http posts, the writers this
+    // replaced): this file is also bundled for the BROWSER (esbuild, platform browser, the
     // webview's timeline-main.ts inlines it), and esbuild leaves an unresolvable require alone only when
     // a try/catch wraps it — a bare one fails the build (PR #1078's first CI run). The guard above keeps
     // the page from ever evaluating them.
@@ -5466,12 +5449,7 @@ class TimelinePanel {
     } catch (e) {}
   }
 
-  _tmuxPath() {
-    if (this._tmux) return this._tmux;
-    this._tmux = 'tmux';
-    try { const fs = require('fs'); for (const p of ['/opt/homebrew/bin/tmux', '/usr/local/bin/tmux', '/usr/bin/tmux', '/bin/tmux']) if (fs.existsSync(p)) { this._tmux = p; break; } } catch (e) {}
-    return this._tmux;
-  }
+
 
   // Items that aren't themselves a conversational line (awaiting/compaction spans, message
   // connectors) borrow the deep-link anchor of the session's nearest work period to `t`.

--- a/ui/romp-timeline-view.js
+++ b/ui/romp-timeline-view.js
@@ -3034,8 +3034,9 @@ class TimelinePanel {
         window.__rompTimelineCompact(name); return;
       }
       // bare Obsidian (no host hook): the kernel's compact route, which parks mid-turn like the click in the chat
-      // does; _kernelPost never rejects and names the refusal, and the lane's next poll shows the result
-      this._kernelPost('/compact', { name }).then((r) => { if (r && r.ok === false && r.error) console.warn('romp timeline: /compact ' + r.error); });
+      // does; _kernelPost never rejects and names the refusal, which the lane says (settingRefused) while the
+      // optimistic compacting cue is dropped (review find: a refusal to the console alone is a silent degrade)
+      this._kernelPost('/compact', { name }).then((r) => { if (r && r.ok === false) this._commandRefused(name, '', r); });
     } catch (e) { /* no host hook + no Electron → can't send */ }
   }
   // Send a slash command to a session (the model/effort pickers). VS Code surface: hand it to the host hook
@@ -3054,8 +3055,18 @@ class TimelinePanel {
       if (typeof window !== 'undefined' && typeof window.__rompTimelineSendCommand === 'function') {
         window.__rompTimelineSendCommand(name, cmd, extra || undefined); return;
       }
-      this._kernelPost('/send', { name, text: cmd }).then((r) => { if (r && r.ok === false && r.error) console.warn('romp timeline: /send ' + r.error); });
+      const kind = (/^\/(model|effort|fast)\b/.exec(cmd) || [])[1] || '';   // the pick's optimistic dim to drop on a refusal
+      this._kernelPost('/send', { name, text: cmd }).then((r) => { if (r && r.ok === false) this._commandRefused(name, kind, r); });
     } catch (e) { /* no host hook + no Electron → can't send */ }
+  }
+  // A refused /compact or slash send through the HTTP route: the kernel's words reach the lane (its gear, the same
+  // dismissible row a refused toggle gets; the shell's bell when a shell hosts the panel), and the optimistic cue
+  // (the compacting bar, the dimmed model/effort word) is dropped, never left to promise a change the kernel refused.
+  _commandRefused(name, kind, r) {
+    const s = ((this.data && this.data.sessions) || []).find((x) => x.name === name);
+    const sid = s ? s.id : '';
+    const text = r && r.refusal ? r.error : "couldn't send that — " + ((r && r.error) || 'no answer');
+    this.settingRefused({ gesture: 'command', sid, flag: kind || '', text });
   }
 
   _closeMetaMenu() { if (this._metaMenu) { if (this._metaMenu._sub) this._metaMenu._sub.remove(); this._metaMenu.remove(); this._metaMenu = null; } }
@@ -3391,6 +3402,10 @@ class TimelinePanel {
       this._laneRefusal = { sid, flag, text };
       if (this._laneMenu && this._laneMenu._sid === sid && this._laneMenuBuild) this._laneMenuBuild();
     }
+    if (m && m.gesture === 'command' && sid) {
+      // a refused /compact or slash send (the HTTP route): drop the optimistic cue the click stamped
+      if (flag) delete this._metaPending[sid + ':' + flag]; else delete this._compactClicked[sid];
+    }
     if (m && m.gesture === 'lane' && sid) {
       // the kernel could not record this Clear: release the sticky removal and put the row back in the slot
       // the click took it from, so the lane is visible again on THIS event (see _holdDismissed)
@@ -3406,6 +3421,11 @@ class TimelinePanel {
       shell = !!(typeof window !== 'undefined' && window.parent && window.parent !== window);
       if (shell) window.parent.postMessage({ romp: 'notify', kind: 'refused', text, sid }, '*');
     } catch (e) { /* no parent frame (Obsidian, headless) */ }
+    if (!shell && m && m.gesture === 'command' && sid) {
+      // no shell bell (the Obsidian panel): the lane's gear shows the kernel's words, the row a refused toggle gets
+      this._laneRefusal = { sid, flag: '', text };
+      if (this._laneMenu && this._laneMenu._sid === sid && this._laneMenuBuild) this._laneMenuBuild();
+    }
     if (!shell && m && m.gesture === 'order' && sid) {
       if (m.from === 'dialog') {
         // a row dragged INSIDE the tags dialog: the dialog's own row carries it, and only the dialog's —

--- a/ui/timeline-compact.test.ts
+++ b/ui/timeline-compact.test.ts
@@ -54,7 +54,7 @@ test("clicking the battery sends /compact on POINTERDOWN (not a click/down→up 
   assert.doesNotMatch(SRC, /hit\.addEventListener\('pointerup'/, "no pointerup pairing — a mid-press redraw would drop it");
   assert.match(SRC, /window\.__rompTimelineCompact === 'function'/);
   // bare Obsidian (no host hook): the kernel's /compact route over HTTP, the door `romp compact` uses (T331)
-  assert.match(SRC, /this\._kernelPost\('\/compact', \{ name \}\)/);
+  assert.match(SRC, /this\._kernelPost\('\/compact', \{ name \}\)\.then\(\(r\) => \{ if \(r && r\.ok === false\) this\._commandRefused\(name, '', r\); \}\);/, "a refusal drops the compacting cue and is said in the lane");
   assert.doesNotMatch(SRC, /send-keys/, "no tmux shell-out");
 });
 

--- a/ui/timeline-compact.test.ts
+++ b/ui/timeline-compact.test.ts
@@ -53,6 +53,9 @@ test("clicking the battery sends /compact on POINTERDOWN (not a click/down→up 
   assert.match(SRC, /this\._compactClicked\[s\.id\] = \(Date\.now \? Date\.now\(\) : 0\);\s*\n?\s*this\._compactSession\(s\.name\)/);
   assert.doesNotMatch(SRC, /hit\.addEventListener\('pointerup'/, "no pointerup pairing — a mid-press redraw would drop it");
   assert.match(SRC, /window\.__rompTimelineCompact === 'function'/);
+  // bare Obsidian (no host hook): the kernel's /compact route over HTTP, the door `romp compact` uses (T331)
+  assert.match(SRC, /this\._kernelPost\('\/compact', \{ name \}\)/);
+  assert.doesNotMatch(SRC, /send-keys/, "no tmux shell-out");
 });
 
 test("the compacting scan-bar mirrors the context colormap via the kernel's cmapGrad", () => {

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -672,6 +672,10 @@ test("the lane version submenu opens with a Latest row that clears the family's 
   // the bridge carries the flag in every host: the VS Code boot glue and the kernel's shell page
   assert.match(SRC, /_sendCommand\(name, cmd, confirm, extra\) \{/);
   assert.match(SRC, /window\.__rompTimelineSendCommand\(name, cmd, extra \|\| undefined\); return;/);
+  // bare Obsidian (no host hook): the kernel's /send route over HTTP is the transport (T331); no tmux shell-out remains
+  assert.match(SRC, /this\._kernelPost\('\/send', \{ name, text: cmd \}\)/);
+  assert.doesNotMatch(SRC, /_tmuxPath|send-keys|paste-buffer|set-buffer/, "the direct tmux path is gone");
+  assert.doesNotMatch(SRC, /require\('child_process'\), tmux/);
   assert.match(BOOT, /__rompTimelineSendCommand: \(name: string, cmd: string, extra\?: Record<string, unknown>\) => post\(\{ type: "sendCommand", name, cmd, \.\.\.\(extra \|\| \{\}\) \}\)/);
   assert.match(KERNEL, /window\.__rompTimelineSendCommand=function\(name,cmd,extra\)\{post\(Object\.assign\(\{type:"sendCommand",name:name,cmd:cmd\},extra\|\|\{\}\)\);\};/);
   assert.match(KERNEL, /_route_meta_command\(be, sid, cmd, client, floating=bool\(msg\.get\("floating"\)\)\)/);

--- a/ui/timeline-views-panel.test.ts
+++ b/ui/timeline-views-panel.test.ts
@@ -673,7 +673,11 @@ test("the lane version submenu opens with a Latest row that clears the family's 
   assert.match(SRC, /_sendCommand\(name, cmd, confirm, extra\) \{/);
   assert.match(SRC, /window\.__rompTimelineSendCommand\(name, cmd, extra \|\| undefined\); return;/);
   // bare Obsidian (no host hook): the kernel's /send route over HTTP is the transport (T331); no tmux shell-out remains
-  assert.match(SRC, /this\._kernelPost\('\/send', \{ name, text: cmd \}\)/);
+  assert.match(SRC, /this\._kernelPost\('\/send', \{ name, text: cmd \}\)\.then\(\(r\) => \{ if \(r && r\.ok === false\) this\._commandRefused\(name, kind, r\); \}\);/,
+    "a refusal reaches the lane, never the console alone (review find)");
+  assert.match(SRC, /_commandRefused\(name, kind, r\) \{[\s\S]{0,400}this\.settingRefused\(\{ gesture: 'command', sid, flag: kind \|\| '', text \}\);/);
+  assert.match(SRC, /if \(m && m\.gesture === 'command' && sid\) \{\s*\n[^\n]*\n\s*if \(flag\) delete this\._metaPending\[sid \+ ':' \+ flag\]; else delete this\._compactClicked\[sid\];/, "the optimistic cue is dropped");
+  assert.doesNotMatch(SRC, /console\.warn\('romp timeline: \/(send|compact)/);
   assert.doesNotMatch(SRC, /_tmuxPath|send-keys|paste-buffer|set-buffer/, "the direct tmux path is gone");
   assert.doesNotMatch(SRC, /require\('child_process'\), tmux/);
   assert.match(BOOT, /__rompTimelineSendCommand: \(name: string, cmd: string, extra\?: Record<string, unknown>\) => post\(\{ type: "sendCommand", name, cmd, \.\.\.\(extra \|\| \{\}\) \}\)/);

--- a/ui/webview/apierror-refusal.test.ts
+++ b/ui/webview/apierror-refusal.test.ts
@@ -40,9 +40,8 @@ test("the chat error card drops Retry on a refusal and names the real fix in pla
   // remedy string, so this write and the tick's re-assert below cannot drift into different words
   assert.match(R, /const REFUSAL_REMEDY = "the model's safeguards refused this prompt — rewrite it or drop this thread";/);
   assert.match(apiErr, /if \(refusal\) countdown\.textContent = REFUSAL_REMEDY;/);
-  // no Dismiss-dialog dead button either: the Esc-sender is for the CLI's spend-limit menu, which a
-  // refusal never parks
-  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{/);
+  // no dead button either: a refusal (like every no-Retry class) appends nothing after the Retry arm
+  assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?\n  \}\s*\n\s*\/\/ Global auto-retry pause/);
 });
 
 test("the 1s countdown tick RE-ASSERTS the refusal remedy — it must never write \"retrying soon…\" over it", () => {

--- a/ui/webview/apierror-refusal.test.ts
+++ b/ui/webview/apierror-refusal.test.ts
@@ -40,8 +40,10 @@ test("the chat error card drops Retry on a refusal and names the real fix in pla
   // remedy string, so this write and the tick's re-assert below cannot drift into different words
   assert.match(R, /const REFUSAL_REMEDY = "the model's safeguards refused this prompt — rewrite it or drop this thread";/);
   assert.match(apiErr, /if \(refusal\) countdown\.textContent = REFUSAL_REMEDY;/);
-  // no dead button either: a refusal (like every no-Retry class) appends nothing after the Retry arm
-  assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?\n  \}\s*\n\s*\/\/ Global auto-retry pause/);
+  // no dead button either: a refusal (like every no-Retry class) appends nothing after the Retry arm. Anchored with no
+  // wildcard (review find): the Retry push, its closing brace and the next comment are adjacent lines, so a re-added
+  // `else if` arm under any label fails this pin
+  assert.match(apiErr, /if \(!spendCap\) \{\n    acts\.push\(noticeAct\("Retry now", "apiRetryNow"[^\n]*\n  \}\n  \/\/ Global auto-retry pause/);
 });
 
 test("the 1s countdown tick RE-ASSERTS the refusal remedy — it must never write \"retrying soon…\" over it", () => {

--- a/ui/webview/apierror-retry-now.test.ts
+++ b/ui/webview/apierror-retry-now.test.ts
@@ -11,7 +11,7 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 // isolate the Retry button's click handler — since 2026-09-08 (the notice-vocabulary pass) it lives on the
 // document.body delegate (apiRetryNow), not on a per-node listener the tail rebuild destroyed mid-press
-const H = (RENDER.match(/apiRetryNow: \(el\) => \{[\s\S]*?\},\n    dismissDialog:/) || [""])[0];
+const H = (RENDER.match(/apiRetryNow: \(el\) => \{[\s\S]*?\},\n    stopAllRetries:/) || [""])[0];   // the next delegate act (Dismiss dialog went with the terminal backend, T331)
 
 test("Retry now posts an explicit MANUAL override so it fires even when auto-retry is paused/suppressed", () => {
   assert.ok(H, "found the Retry button block");

--- a/ui/webview/ask-keyboard.test.ts
+++ b/ui/webview/ask-keyboard.test.ts
@@ -14,20 +14,14 @@ test("an option can carry its own preview (the SDK backend sends one per option)
   assert.match(TYPES, /preview\?: string;/);
 });
 
-test("single-select ↑/↓ steps the preview to the focused option (instant for per-option, cursor-driven for tmux)", () => {
+test("single-select ↑/↓ steps the preview to the focused option instantly: every option carries its own preview", () => {
   // paint moves the highlight AND re-renders the preview for the new focus
   assert.match(RENDER, /function paintLiveAskFocus\(\) \{[\s\S]*?renderAskPreview\(\);/);
-  // when the focused option has NO preview of its own but the ask has a scraped one (tmux), nudge the TUI
-  // cursor so the next scrape captures THIS option's preview — without selecting
-  assert.match(RENDER, /if \(o && !o\.preview && ask\.preview\) navLiveAsk\(o\.n\);/);
+  // no cursor nudge round trip (T331): the terminal scrape that needed one is gone, and nothing posts navAsk
+  assert.doesNotMatch(RENDER, /navLiveAsk|navAsk|navTimer/, "no cursor-driven preview path");
+  assert.doesNotMatch(RENDER, /answer it in the terminal|renderUnknownCard/, "no unreadable-screen card: the kernel pushes a typed ask or clears");
   // Enter still confirms; ↑/↓ never select
   assert.match(RENDER, /e\.key === "Enter"[^}]*answerLiveAsk\(opts\[liveAskFocus\]\.n\)/);
-});
-
-test("navLiveAsk posts a navAsk (move cursor, no select) and is debounced", () => {
-  assert.match(RENDER, /function navLiveAsk\(target: number\)/);
-  assert.match(RENDER, /if \(navTimer\) clearTimeout\(navTimer\);/);
-  assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "navAsk", id, target \}\)/);
 });
 
 test("multi-select keyboard: ↑/↓ walk checkboxes + Submit/Cancel; Enter TOGGLES (the user 2026-06-27)", () => {

--- a/ui/webview/auth-selector.test.ts
+++ b/ui/webview/auth-selector.test.ts
@@ -24,12 +24,12 @@ const INTENT = fs.readFileSync(path.join(ROOT, "vscode-extension", "src", "pipe-
 
 test("the picker's Billing row shows for SDK whenever availability is known", () => {
   // one known choice is enough to SHOW the row (the user 2026-08-09) — the both-test only decides
-  // buttons vs written-out text; the backend toggle still re-decides the row (tmux CLIs live in the
-  // tmux server's env, which the kernel doesn't control)
+  // buttons vs written-out text; the backend toggle still re-decides the row (Billing is a Claude Code
+  // matter, so the Codex pick hides it)
   // (pickerBackendChoice reads the Backend row's chip alone since tab groups, 2026-09-04 — the Tags
   // row wears the same chip grammar, and a selected tag must never read as the backend)
   assert.match(RENDER, /const show = !pickMode && !!\(a && \(a\.login \|\| a\.key\)\) && pickerBackendChoice\(\) === "sdk";/);
-  assert.match(RENDER, /function pickerBackendChoice\(\): string \{\s*\n\s*const beSel = document\.querySelector\("#picker \.picker-backend:not\(\.picker-host\):not\(\.picker-auth\):not\(\.picker-tags\) \.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*return beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);
+  assert.match(RENDER, /function pickerBackendChoice\(\): string \{\s*\n\s*const beSel = document\.querySelector\("#picker \.picker-backend:not\(\.picker-host\):not\(\.picker-auth\):not\(\.picker-tags\) \.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*return beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend\);/);
   assert.match(RENDER, /const both = !!\(a!\.login && a!\.key\);/);
   assert.match(RENDER, /auWrap\.style\.display = "none";\s*\/\/ hidden until a sessionList reply carries authAvail/);
   assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => \{ syncPickerAuth\(\); syncPickerTags\(\); \}\);/);   // the Tags row follows the backend pick too (tab groups)
@@ -93,8 +93,7 @@ test("no key material reaches the webview — no tail plumbing survives anywhere
 });
 
 test("the chat tab hover says Billing whenever the backend reports it, naming the login", () => {
-  // ungated on machine shape (the user 2026-08-09: one-auth machines included; only a tmux session,
-  // whose CLI env romp does not control, reports nothing) — and 'Login (account)' when known
+  // ungated on machine shape (the user 2026-08-09: one-auth machines included) — and 'Login (account)' when known
   assert.match(RENDER, /s\.status\.auth === "key" \? "API key"\s*\n\s*: \(s\.status\.authAcct \? `Login \(\$\{s\.status\.authAcct\}\)` : "Login"\)\]\);/);
   assert.match(RENDER, /: s\.status\.authPickUnavailable === s\.status\.auth\s*\n(?:\s*\/\/[^\n]*\n)*\s*\? `⚠ /);   // 2026-09-08: a pick this box cannot bill is said on the hover too
   // …and the row tells the TRUTH in every landing shape (T124, superseding the quiet-parenthetical
@@ -102,8 +101,8 @@ test("the chat tab hover says Billing whenever the backend reports it, naming th
   // window, and a wrong-side landing read as an aside). A PENDING pick says "applying — not
   // confirmed yet"; a CONFIRMED contradiction (authLive on the other side — a key found via
   // apiKeyHelper on a login launch) LEADS with the warning and names what is actually billed.
-  // Anchored at the gate + label: a no-auth session (tmux — the exclusion above) must never grow a
-  // fabricated Billing row, so the `if (s.status.auth)` guard is part of the pinned behavior.
+  // Anchored at the gate + label: a session reporting no auth must never grow a fabricated Billing row,
+  // so the `if (s.status.auth)` guard is part of the pinned behavior.
   assert.match(RENDER, /if \(s\.status\.auth\) rows\.push\(\["Billing",\s*\n\s*s\.status\.authPending\s*\n\s*\? \(s\.status\.auth === "key" \? "API key" : "Login"\) \+ " \(applying — not confirmed yet\)"/,
     "the reconnect window renders as pending intent, never as applied fact");
   assert.match(RENDER, /⚠ \$\{s\.status\.auth === "key" \? "API key" : "Login"\} picked, but the CLI reports `\s*\n\s*\+ `\$\{s\.status\.authLive === "key" \? "the API key" : "the login"\} — this session bills that`/,

--- a/ui/webview/backend-names.test.ts
+++ b/ui/webview/backend-names.test.ts
@@ -1,6 +1,7 @@
-// The backends as the user reads them (T288, the user 2026-09-09): "Claude Code" (the default, no qualifier),
-// "Claude Code (tmux)" (offered only while the kernel setting is on) and "Codex"; the ids and the protocol are
-// unchanged. One module names them for the picker, the gear and the tooltip, so the surfaces cannot drift apart.
+// The backends as the user reads them (T288, the user 2026-09-09): "Claude Code" (the default, no qualifier) and
+// "Codex"; the ids and the protocol are unchanged. One module names them for the picker, the gear and the tooltip,
+// so the surfaces cannot drift apart. The terminal backend is no longer offered (T331, the user 2026-09-10: the
+// tmux backend is being removed), and a saved default of it reads as Claude Code, never as an undefined value.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -11,40 +12,41 @@ const read = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..
 const RENDER = read("ui", "webview", "render.ts");
 const GEAR = read("ui", "webview", "gear.js");
 
-test("the three names, and an unknown id reads as itself", () => {
-  assert.deepEqual(BACKEND_LABEL, { sdk: "Claude Code", tmux: "Claude Code (tmux)", codex: "Codex" });
+test("the two names, and an unknown id reads as itself", () => {
+  assert.deepEqual(BACKEND_LABEL, { sdk: "Claude Code", codex: "Codex" });
   assert.equal(backendLabel("sdk"), "Claude Code");
-  assert.equal(backendLabel("tmux"), "Claude Code (tmux)");
   assert.equal(backendLabel("codex"), "Codex");
-  assert.equal(backendLabel("future"), "future", "never a lie, never blank");
+  assert.equal(backendLabel("tmux"), "tmux", "a retired id names itself, never a lie and never blank (an old session's row)");
+  assert.equal(backendLabel("future"), "future");
   assert.equal(backendLabel(null), "");
   for (const label of Object.values(BACKEND_LABEL)) assert.doesNotMatch(label, /\bSDK\b/, "the word never reaches the user");
 });
 
-test("the offer: Claude Code (tmux) only while the setting is on; the default falls back to Claude Code", () => {
-  assert.deepEqual(offeredBackends(false), ["sdk", "codex"]);
-  assert.deepEqual(offeredBackends(true), ["sdk", "tmux", "codex"]);
-  assert.equal(effectiveDefaultBackend("tmux", false), "sdk", "a saved tmux default is set aside while the backend is off");
-  assert.equal(effectiveDefaultBackend("tmux", true), "tmux", "…and returns with the setting");
-  assert.equal(effectiveDefaultBackend("codex", false), "codex");
-  assert.equal(effectiveDefaultBackend("sdk", false), "sdk");
-  assert.equal(effectiveDefaultBackend(undefined, false), "sdk", "no preference is the default");
-  assert.equal(effectiveDefaultBackend("", true), "sdk");
+test("the offer is Claude Code and Codex; a saved default no longer offered reads as Claude Code, never undefined", () => {
+  assert.deepEqual(offeredBackends(), ["sdk", "codex"]);
+  assert.equal(effectiveDefaultBackend("tmux"), "sdk", "the retired terminal backend's saved default migrates to Claude Code");
+  assert.equal(effectiveDefaultBackend("codex"), "codex");
+  assert.equal(effectiveDefaultBackend("sdk"), "sdk");
+  assert.equal(effectiveDefaultBackend(undefined), "sdk", "no preference is the default");
+  assert.equal(effectiveDefaultBackend(""), "sdk");
+  assert.equal(effectiveDefaultBackend("nonsense"), "sdk");
+  assert.equal(offeredBackends.length, 0, "no offer switch: the list takes no argument");
+  assert.equal(effectiveDefaultBackend.length, 1);
 });
 
 test("no user-facing copy in the picker, the tooltip or the gear says SDK; every label comes from the shared names", () => {
-  // the picker toggles and the tooltip row read backendLabel; the gear's select spells the same three names
+  // the picker toggles and the tooltip row read backendLabel; the gear's select spells the same two names
   assert.match(RENDER, /mkBe\("sdk", backendLabel\("sdk"\)/);
-  assert.match(RENDER, /mkBe\("tmux", backendLabel\("tmux"\)/);
   assert.match(RENDER, /mkBe\("codex", backendLabel\("codex"\)/);
   assert.match(RENDER, /rows\.push\(\["Backend", backendLabel\(be\)\]\)/, "the tab tooltip's Backend row");
-  assert.match(GEAR, /<option value=sdk>Claude Code<\/option><option value=tmux>Claude Code \(tmux\)<\/option><option value=codex>Codex<\/option>/);
+  assert.match(GEAR, /<option value=sdk>Claude Code<\/option><option value=codex>Codex<\/option>/);
+  assert.doesNotMatch(GEAR, /option value=tmux|rs-tmuxbackend|setTmuxBackend|paintBackendOffer/, "the gear offers no terminal backend and no switch for one");
   // the word "SDK" in a string a person reads: the picker tips, the tooltip row, the gear's HTML. Comments and
   // identifiers (status.backend === "sdk", sdkOnly) are not copy; only quoted strings count here.
   const pickerTips = [...RENDER.matchAll(/mkBe\("[a-z]+", backendLabel\("[a-z]+"\), "([^"]*)"\)/g)].map((m) => m[1]);
-  assert.equal(pickerTips.length, 3);
-  for (const tip of pickerTips) assert.doesNotMatch(tip, /\bSDK\b/, tip);
-  // …and every quoted string in the picker's builder (the Tags note among them, the review's find)
+  assert.equal(pickerTips.length, 2);
+  for (const tip of pickerTips) assert.doesNotMatch(tip, /\bSDK\b|tmux/, tip);
+  // …and every quoted string in the picker's builder
   const picker = RENDER.slice(RENDER.indexOf('const beWrap = el("div", "picker-backend")'), RENDER.indexOf("actions.appendChild(newSess)"));
   assert.ok(picker.length > 1000 && picker.length < 40000, "the picker's builder located");
   for (const m of picker.matchAll(/"([^"\n]*)"|`([^`\n]*)`/g)) assert.doesNotMatch(m[1] || m[2] || "", /\bSDK\b/, (m[1] || m[2] || "").slice(0, 80));
@@ -52,7 +54,12 @@ test("no user-facing copy in the picker, the tooltip or the gear says SDK; every
   const KERNEL = read("kernel", "kernel.py");
   for (const phrase of ["needs the SDK backend", "need an SDK or Codex session", "needs an SDK session", "runs on tmux, so there is nothing", "tmux sessions still work"])
     assert.ok(!KERNEL.includes(phrase), "kernel copy still says: " + phrase);
-  const gearHtml = GEAR.slice(0, GEAR.indexOf("var gclock") > 0 ? GEAR.length : GEAR.length);
-  const userStrings = [...gearHtml.matchAll(/'([^'\n]*<span class=rs-sub>[^'\n]*)'/g)].map((m) => m[1]);
+  const userStrings = [...GEAR.matchAll(/'([^'\n]*<span class=rs-sub>[^'\n]*)'/g)].map((m) => m[1]);
   for (const s of userStrings) assert.doesNotMatch(s, /\bSDK\b/, s.slice(0, 80));
+});
+
+test("the gear's Default backend select is static and painted from the saved preference once, through the shared rule", () => {
+  assert.match(GEAR, /if \(bk\) \{ bk\.value = BN\.effectiveDefaultBackend\(load\(\)\.backend\); \}\s*\n\s*repaintSelectPicks\(\);/,
+    "a saved default of the retired backend paints as Claude Code; the facade repaints once at init (the call paintBackendOffer used to make)");
+  assert.match(GEAR, /if \(bk\) bk\.addEventListener\('change', function \(\) \{ var s = load\(\); s\.backend = bk\.value; save\(s\); \}\);/, "a pick saves only what the select offers, so the retired value is gone on the next save");
 });

--- a/ui/webview/backend-names.ts
+++ b/ui/webview/backend-names.ts
@@ -1,25 +1,26 @@
-// The backends as the user reads them (T288, the user 2026-09-09): the internal ids ("sdk", "tmux", "codex") and
-// the kernel protocol are unchanged; every label a person sees comes from here, so the picker toggles, the
-// gear's Default backend list, the tab tooltip's Backend row and any chip agree. The default needs no
-// qualifier, so the word "SDK" appears in no user-facing copy: it is "Claude Code"; the terminal-driven
-// variant is "Claude Code (tmux)"; the OpenAI agent is "Codex".
-export type BackendId = "sdk" | "tmux" | "codex";
-export const BACKEND_LABEL: Readonly<Record<BackendId, string>> = { sdk: "Claude Code", tmux: "Claude Code (tmux)", codex: "Codex" };
+// The backends as the user reads them (T288, the user 2026-09-09): the internal ids ("sdk", "codex") and the
+// kernel protocol are unchanged; every label a person sees comes from here, so the picker toggles, the gear's
+// Default backend list, the tab tooltip's Backend row and any chip agree. The default needs no qualifier, so
+// the word "SDK" appears in no user-facing copy: it is "Claude Code"; the OpenAI agent is "Codex". The terminal
+// backend ("Claude Code (tmux)") is being removed (the user 2026-09-10, T331 the UI stage): nothing offers it
+// any more, and a saved default of it reads as Claude Code.
+export type BackendId = "sdk" | "codex";
+export const BACKEND_LABEL: Readonly<Record<BackendId, string>> = { sdk: "Claude Code", codex: "Codex" };
 
 /** The label for a backend id; an unknown id reads as itself (never a lie, never blank). */
 export function backendLabel(be: string | null | undefined): string {
   return (be && (BACKEND_LABEL as Record<string, string>)[be]) || String(be || "");
 }
 
-/** What the picker OFFERS: "Claude Code (tmux)" only while the kernel setting says so (off by default). The
- *  setting gates the offer alone; an existing tmux session keeps working and keeps its label whatever it says. */
-export function offeredBackends(tmuxOn: boolean): BackendId[] {
-  return tmuxOn ? ["sdk", "tmux", "codex"] : ["sdk", "codex"];
+/** What the picker OFFERS: Claude Code and Codex, always. */
+export function offeredBackends(): BackendId[] {
+  return ["sdk", "codex"];
 }
 
 /** The default a new session starts from: the saved preference when it is on offer, else Claude Code. A saved
- *  default of tmux while the tmux backend is off is set aside, not erased: it returns when the setting comes back. */
-export function effectiveDefaultBackend(pref: string | null | undefined, tmuxOn: boolean): BackendId {
+ *  default that is no longer offered (the retired terminal backend, an unknown value) reads as Claude Code,
+ *  never as an undefined value. */
+export function effectiveDefaultBackend(pref: string | null | undefined): BackendId {
   const p = (pref || "sdk") as BackendId;
-  return (offeredBackends(tmuxOn) as string[]).includes(p) ? p : "sdk";
+  return (offeredBackends() as string[]).includes(p) ? p : "sdk";
 }

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -660,7 +660,7 @@ test("the parity bundle (2026-08-26): dividers, owner-scoped in-turn controls, t
   assert.match(UI, /function owningSidOf\(el0: HTMLElement \| null\): string \| null \{/);
   assert.match(UI, /const sidQ = owningSidOf\(el\) \|\| activeId;/);   // resolved once — the optimistic arm reuses it
   assert.match(UI, /\{ type: "cancelQueued", id: sidQ, md: qmd \}/);
-  assert.match(UI, /\{ type: "dismissDialog", id: owningSidOf\(b\) \}/);   // the delegate's handler (2026-09-08), still owner-scoped
+  assert.match(UI, /const own = owningSidOf\(b\);\s*\n\s*if \(vscodeApi\) vscodeApi\.postMessage\(\{ type: "apiRetry", id: own, manual: true \}\);/);   // the api-error card's delegate handler (2026-09-08), still owner-scoped
 });
 
 test("the thread's running turn offers the chat's stop affordance, owner-scoped to the THREAD (T138)", () => {

--- a/ui/webview/dismiss-dialog.test.ts
+++ b/ui/webview/dismiss-dialog.test.ts
@@ -1,15 +1,13 @@
-// Dismiss-dialog action (the user 2026-07-16): a tmux session parked on the CLI's spend-cap modal can't
-// be unblocked by Retry — the menu eats the injected "retry" as keystrokes. The chat's spend-cap error
-// card therefore drops Retry and, on tmux, offers "Dismiss dialog" (→ dismissDialog drive op → the kernel
-// verifies the menu is up, then sends Esc; cancel, never a billing change). An SDK spend-cap card shows
-// no dead button, just the raise-your-cap line. render.ts has import-time DOM side effects → source pins.
+// The chat's spend-cap error card (the user 2026-07-16): a billing cap cannot be lifted by a retry, so the card drops
+// Retry and names the fix (raise the cap) with no dead button. The "Dismiss dialog" button that once served a
+// terminal session parked on the CLI's spend-limit menu went with the terminal backend (T331, the user 2026-09-10).
+// render.ts has import-time DOM side effects → source pins.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const R = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
-const K = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 // isolate renderApiError's body so the pins can't accidentally match elsewhere in the file
 const apiErr = R.slice(R.indexOf("function renderApiError"), R.indexOf("// ── API-error auto-retry"));
@@ -21,29 +19,12 @@ test("a spend cap suppresses the Retry button entirely", () => {
   assert.match(apiErr, /if \(!spendCap\) \{\s*\n\s*acts\.push\(noticeAct\("Retry now", "apiRetryNow",/);
 });
 
-test("a tmux spend cap offers Dismiss dialog, posting the dismissDialog op", () => {
-  // refusal-gated: the Esc-sender is for the CLI's spend-limit dialog — a refusal parks no menu
-  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{/);
-  assert.match(apiErr, /acts\.push\(noticeAct\("Dismiss dialog", "dismissDialog",/);
-  // the handler on the body delegate (2026-09-08), owner-scoped (the parity bundle, 2026-08-26)
-  assert.match(R, /dismissDialog: \(el\) => \{[\s\S]{0,200}?vscodeApi\.postMessage\(\{ type: "dismissDialog", id: owningSidOf\(b\) \}\)/);
-  // acknowledges the click at once (disable + "Dismissing…"), like every other card control
-  assert.match(R, /dismissDialog: \(el\) => \{[\s\S]{0,400}?b\.textContent = "Dismissing…";/);
-});
-
-test("an SDK spend cap shows neither Retry nor a Dismiss button (raise-the-cap line only)", () => {
-  // the Dismiss branch is tmux-gated, so an SDK spend cap falls through with no button appended
-  assert.match(apiErr, /\} else if \(st\?\.backend === "tmux" && !refusal\) \{[\s\S]*?acts\.push\(noticeAct\("Dismiss dialog"[\s\S]*?\n  \}/);
+test("a spend cap shows neither Retry nor a Dismiss button: the raise-the-cap line alone", () => {
+  assert.doesNotMatch(apiErr, /Dismiss dialog|dismissDialog|backend === "tmux"/, "no terminal-only branch");
+  assert.doesNotMatch(R, /dismissDialog/, "no delegate handler and no op posted for it");
+  assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?\n  \}\s*\n\s*\/\/ Global auto-retry pause/, "the spend-cap arm appends no button");
 });
 
 test("the countdown reads the spend-cap message, never a fake retry countdown", () => {
   assert.match(apiErr, /else if \(spendCap\) countdown\.textContent = "spend limit reached — raise it at claude\.ai\/settings\/usage";/);
-});
-
-// kernel contract this card codes against (node-tests-pin-kernel-source precedent)
-test("kernel: dismissDialog is a drive op backed by TmuxBackend.dismiss_dialog verifying the modal", () => {
-  assert.match(K, /elif t == "dismissDialog":/);
-  assert.match(K, /def dismiss_dialog\(self, sid\):/);
-  assert.match(K, /def _spend_dialog_showing\(pane\):/);
-  assert.match(K, /self\.send_keys\(name, "Escape"\)/);   // Esc, never Enter
 });

--- a/ui/webview/dismiss-dialog.test.ts
+++ b/ui/webview/dismiss-dialog.test.ts
@@ -22,7 +22,9 @@ test("a spend cap suppresses the Retry button entirely", () => {
 test("a spend cap shows neither Retry nor a Dismiss button: the raise-the-cap line alone", () => {
   assert.doesNotMatch(apiErr, /Dismiss dialog|dismissDialog|backend === "tmux"/, "no terminal-only branch");
   assert.doesNotMatch(R, /dismissDialog/, "no delegate handler and no op posted for it");
-  assert.match(apiErr, /if \(!spendCap\) \{[\s\S]*?\n  \}\s*\n\s*\/\/ Global auto-retry pause/, "the spend-cap arm appends no button");
+  // anchored with no wildcard (review find): the Retry push, its closing brace and the next comment are adjacent
+  // lines, so a re-added `else if` arm under any label fails this pin
+  assert.match(apiErr, /if \(!spendCap\) \{\n    acts\.push\(noticeAct\("Retry now", "apiRetryNow"[^\n]*\n  \}\n  \/\/ Global auto-retry pause/, "the spend-cap arm appends no button");
 });
 
 test("the countdown reads the spend-cap message, never a fake retry countdown", () => {

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -82,7 +82,6 @@ const KERNEL_SETTING = new Set(["setAutoNudge", "setJudgeModel", "setIndexModel"
                                 "setDistillModel", "setDistillEffort", "setFileEditing",
                                 "setCompactSuggest",
                                 "setCommentModel", "setCommentEffort", "setCommentFast",
-                                "setTmuxBackend",   // T288: the tmux backend's offer, one value across machines
                                 "setJudgeFast", "setDistillFast", "setIndexFast"]);   // Fast mode per judge tier, one value across machines
 
 // ── what a send to a host whose relay socket is NOT open does, by message class (2026-09-10) ─────────

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1053,7 +1053,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* ---------- liveness anomaly rings (2026-06-11) ---------- */
 /* The OUTLINE ring marks a card whose LIVE state disagrees with the column it's
    filed in (agreement = no ring; the user's simplification). Host-computed from
-   live tmux state + open handoffs; colors only, decides nothing. The border
+   live session state + open handoffs; colors only, decides nothing. The border
    keeps the recency tint; focus/pin keep box-shadow.
    green  = settled-but-in-Asks (nothing can move it without you — likely done)
    dashed = stalled-in-Asks (unfinished handoff, nobody working)

--- a/ui/webview/gear-judge-fast-browser.test.ts
+++ b/ui/webview/gear-judge-fast-browser.test.ts
@@ -46,7 +46,7 @@ const MODELS = { models: [{ value: "opus", label: "Opus", versions: [] }, { valu
 // Haiku with its box on too (a kept value on a tier that cannot run fast: greyed, not lost); the CLI declined the
 // distilling tier's last fast ask
 const VERSION = { judgeModel: "opus", judgeEffort: "", indexModel: "haiku", indexEffort: "low", distillModel: "triage", distillEffort: "triage",
-  judgeConcurrency: "", commentModel: "session", commentEffort: "session", commentFast: "session", tmuxBackend: "off",
+  judgeConcurrency: "", commentModel: "session", commentEffort: "session", commentFast: "session",
   judgeFast: "on", distillFast: "on", indexFast: "on", fastRefused: { distill: { reason: "sdk_opt_in_required", model: "opus", t: 1 } },
   autoNudge: true, settingsGt: {}, updateMode: "off" };
 

--- a/ui/webview/gear.js
+++ b/ui/webview/gear.js
@@ -81,10 +81,10 @@ var GEAR_HTML =
   "<button id=rs-defaultdir-browse type=button style='flex:0 0 auto;cursor:pointer;background:var(--btn-bg, #2a2a2a);color:var(--fg, #ccc);border:1px solid var(--hairline, #3a3a3a);border-radius:5px;padding:3px 8px'>Browse…</button>" +
   '</div></span></div>' +
   "<div class='rs-row rs-sep' style='cursor:default'><span style='flex:1 1 auto'><b>Default backend</b>" +
-  '<span class=rs-sub>What the + button uses for a NEW session. Claude Code runs the session through romp itself; Claude Code (tmux) drives a terminal pane and is on offer only while the tmux backend is enabled (Updates & debug); Codex runs an OpenAI Codex agent (docs/codex.md). All kinds run side by side; this only sets the default.</span>' +
+  '<span class=rs-sub>What the + button uses for a NEW session. Claude Code runs the session through romp itself; Codex runs an OpenAI Codex agent (docs/codex.md).</span>' +
   "<select id=rs-backend style='display:none'>" +
-  '<option value=sdk>Claude Code</option><option value=tmux>Claude Code (tmux)</option><option value=codex>Codex</option>' +
-  '</select><span id=rs-backend-note class=rs-sub hidden></span></span></div>' +
+  '<option value=sdk>Claude Code</option><option value=codex>Codex</option>' +
+  '</select></span></div>' +
   "<label class='rs-row rs-sep'><input type=checkbox id=rs-autonudge>" +
   '<span><b>Auto Nudge</b><span class=rs-mixed id=rs-autonudge-split hidden></span>' +
   '<span class=rs-sub id=rs-autonudge-sub>' + AUTONUDGE_SUB + '</span>' +
@@ -239,10 +239,6 @@ var GEAR_HTML =
   "<select id=rs-updates style='display:none'>" +
   '<option value=ask>Check and ask</option><option value=auto>Install automatically</option><option value=off>Off</option>' +
   '</select></span></div>' +
-  "<label class=rs-row><input type=checkbox id=rs-tmuxbackend>" +
-  '<span><b>Enable Claude Code tmux backend <span class=rs-mixed hidden></span></b>' +
-  '<span class=rs-sub>Offers Claude Code (tmux) in the + picker and the Default backend list: a Claude Code session in a terminal pane that romp follows by reading the terminal, less reliable than Claude Code itself. Off by default. Sessions already running on it keep working either way; this only sets what the picker offers. Follows to every connected machine\'s kernel.</span>' +
-  '</span></label>' +
   
   '<div class=rs-judges>' +
   '<label class=rs-row rs-half><input type=checkbox id=rs-judges-index>' +
@@ -321,7 +317,6 @@ function initGear(post, opts) {
     cmm = document.getElementById('rs-cmtmodel'), cme = document.getElementById('rs-cmteffort'),
     cmf = document.getElementById('rs-cmtfast'),
     jf = document.getElementById('rs-judgefast'), df = document.getElementById('rs-distillfast'), xf = document.getElementById('rs-indexfast'),   // T300: one per tier
-    tb = document.getElementById('rs-tmuxbackend'), bkn = document.getElementById('rs-backend-note'),
     fe = document.getElementById('rs-fileedit'),
     pn = { timeline: document.getElementById('rs-pane-timeline'), fleet: document.getElementById('rs-pane-fleet'), feed: document.getElementById('rs-pane-feed') },
     ths = document.getElementById('rs-thinksum'),
@@ -829,9 +824,6 @@ function initGear(post, opts) {
   if (cmm) cmm.addEventListener('change', function () { post({ type: 'setCommentModel', model: cmm.value, gt: gclock.stamp('comment-model') }); cmtFastGate(true); });
   if (cme) cme.addEventListener('change', function () { post({ type: 'setCommentEffort', effort: cme.value, gt: gclock.stamp('comment-effort') }); });
   if (cmf) cmf.addEventListener('change', function () { post({ type: 'setCommentFast', fast: cmf.checked ? 'on' : 'session', gt: gclock.stamp('comment-fast') }); });
-  // the tmux backend's offer (T288): a kernel setting like the judge knobs (stamped, propagated); the Default
-  // backend list repaints at once so the pick and the offer never disagree in the same modal
-  if (tb) tb.addEventListener('change', function () { post({ type: 'setTmuxBackend', enabled: tb.checked, gt: gclock.stamp('tmux-backend') }); paintBackendOffer(tb.checked); });
   // Fast mode for the judges, one box per tier (T300, the user 2026-09-10): a kernel setting per tier like the
   // judge knobs (stamped, propagated); the judges read each tier's flag per call
   if (jf) jf.addEventListener('change', function () { post({ type: 'setJudgeFast', enabled: jf.checked, gt: gclock.stamp('judge-fast') }); judgeFastGate(); });   // the hint follows the box (a refusal reads only on a checked box)
@@ -865,20 +857,10 @@ function initGear(post, opts) {
       if (sub) sub.textContent = !can ? JUDGEFAST_SUB_OFF : (r ? judgeFastSubRefused(t.word, r) : JUDGEFAST_SUB);
     });
   }
-  // "Claude Code (tmux)" is in the Default backend list only while the setting is on; a saved default of tmux
-  // while it is off is set aside (the select shows Claude Code and the note says so), never erased: it returns
-  // with the setting. The option is removed rather than hidden: the facade paints from sel.options.
-  function paintBackendOffer(on) {
-    if (!bk) return;
-    var opt = bk.querySelector('option[value=tmux]');
-    if (on && !opt) { opt = document.createElement('option'); opt.value = 'tmux'; opt.textContent = BN.backendLabel('tmux'); bk.insertBefore(opt, bk.querySelector('option[value=codex]')); }
-    else if (!on && opt) opt.remove();
-    var pref = load().backend || 'sdk', eff = BN.effectiveDefaultBackend(pref, on);
-    bk.value = eff;
-    if (bkn) { bkn.hidden = eff === pref; bkn.textContent = eff === pref ? '' : 'Your saved default, ' + BN.backendLabel(pref) + ', is set aside while the tmux backend is off; new sessions use ' + BN.backendLabel(eff) + '.'; }
-    repaintSelectPicks();
-  }
-  paintBackendOffer(tb ? tb.checked : false);   // the list assumes OFF until a kernel says on (the picker's rule), so the two never disagree on the offer
+  // the Default backend list is static (Claude Code, Codex); a saved default no longer offered (the retired terminal
+  // backend) reads as Claude Code (effectiveDefaultBackend), and the facade paints from the select once at init
+  if (bk) { bk.value = BN.effectiveDefaultBackend(load().backend); }
+  repaintSelectPicks();
   // feed-colormap preview bar: a horizontal gradient of the SELECTED map's stops (mirrors render.ts COLORMAPS).
   var CMAPS = { aurora: [[84, 178, 4], [0, 180, 115], [35, 175, 156], [66, 169, 176], [25, 168, 201], [14, 164, 227], [74, 155, 241], [113, 145, 244], [144, 136, 240]],
     hawaii: [[140, 2, 115], [146, 46, 85], [151, 78, 62], [155, 111, 40], [156, 150, 28], [137, 189, 74], [107, 212, 142], [103, 233, 213], [179, 242, 253]],
@@ -916,7 +898,7 @@ function initGear(post, opts) {
   if (plBtn) plBtn.addEventListener('click', function (e) { e.stopPropagation(); plBuild(); if (plList) plList.hidden = !plList.hidden; });
   document.addEventListener('click', function (e) { var w = document.getElementById('rs-pal');
     if (plList && !plList.hidden && w && !w.contains(e.target)) plList.hidden = true; });
-  if (bk) bk.addEventListener('change', function () { var s = load(); s.backend = bk.value; save(s); paintBackendOffer(tb ? tb.checked : false); });   // webview-local pref read at createSession time; the set-aside note follows the new pick (T288)
+  if (bk) bk.addEventListener('change', function () { var s = load(); s.backend = bk.value; save(s); });   // webview-local pref read at createSession time
   if (dd) dd.addEventListener('change', function () { var v = dd.value.trim(); var s = load(); s.defaultDir = v; save(s);
     post({ type: 'setDefaultDir', value: v }); });   // persist kernel-side: _default_create_dir reads this file FIRST
   var ddb = document.getElementById('rs-defaultdir-browse');
@@ -942,7 +924,7 @@ function initGear(post, opts) {
     'index-model': 'Indexing model', 'index-effort': 'Indexing effort', 'judge-concurrency': 'Judge concurrency',
     'distill-model': 'Distilling model', 'distill-effort': 'Distilling effort',
     'comment-model': 'Comment model', 'comment-effort': 'Comment effort',
-    'comment-fast': 'Fast comment threads', 'tmux-backend': 'Claude Code tmux backend',
+    'comment-fast': 'Fast comment threads',
     'judge-fast': 'Fast mode (triage judges)', 'distill-fast': 'Fast mode (distilling judges)', 'index-fast': 'Fast mode (indexing judges)',
     'thinking-summaries': 'Thinking summaries' };
   // store name → the message type that sets it: the whitelist for the toast's Apply anyway (a frame
@@ -954,7 +936,7 @@ function initGear(post, opts) {
     'index-model': 'setIndexModel', 'index-effort': 'setIndexEffort', 'judge-concurrency': 'setJudgeConcurrency',
     'distill-model': 'setDistillModel', 'distill-effort': 'setDistillEffort',
     'comment-model': 'setCommentModel', 'comment-effort': 'setCommentEffort', 'comment-fast': 'setCommentFast',
-    'tmux-backend': 'setTmuxBackend', 'judge-fast': 'setJudgeFast', 'distill-fast': 'setDistillFast', 'index-fast': 'setIndexFast' };
+    'judge-fast': 'setJudgeFast', 'distill-fast': 'setDistillFast', 'index-fast': 'setIndexFast' };
   // store name → the words its select shows for the sentinel options whose value is not the word. The
   // effort selects' Default is the EMPTY value (no effort flag), which read as no value at all, so a
   // refused Default pick drew the value-less copy and a plain Apply anyway — in the frozen-tab case, the
@@ -1228,7 +1210,7 @@ function initGear(post, opts) {
     [['updateMode', upm], ['judgeModel', jm], ['judgeEffort', je], ['indexModel', im],
      ['indexEffort', ie], ['judgeConcurrency', jc], ['distillModel', dm], ['distillEffort', de], ['fileEditing', fe],
      ['compactSuggest', csg],
-     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf], ['tmuxBackend', tb],
+     ['commentModel', cmm], ['commentEffort', cme], ['commentFast', cmf],
      ['judgeFast', jf], ['distillFast', df], ['indexFast', xf]].forEach(function (pair) {
       var key = pair[0], el = pair[1];
       if (!el) return;
@@ -1276,7 +1258,6 @@ function initGear(post, opts) {
     if (typeof v.commentModel === 'string') setShow(cmm, v.commentModel);   // RAW: "session" selects Same as the session
     if (typeof v.commentEffort === 'string') setShow(cme, v.commentEffort);
     if (cmf && typeof v.commentFast === 'string') cmf.checked = v.commentFast === 'on';
-    if (tb && typeof v.tmuxBackend === 'string') { tb.checked = v.tmuxBackend === 'on'; paintBackendOffer(tb.checked); }   // T288: the offer, then the list follows it
     if (jf && typeof v.judgeFast === 'string') jf.checked = v.judgeFast === 'on';   // RAW on/off: the kernel's persisted answer
     if (df && typeof v.distillFast === 'string') df.checked = v.distillFast === 'on';
     if (xf && typeof v.indexFast === 'string') xf.checked = v.indexFast === 'on';
@@ -1331,7 +1312,7 @@ function initGear(post, opts) {
     // burned the whole 5-frame retry against a display:none pane, latched rs-pane-gone, and the
     // full-viewport fallback box blacked out every pane behind the modal.
     try { if (window.parent !== window) window.parent.postMessage({ romp: 'logUnseenQuery' }, '*'); } catch (e) { /* no shell to ask */ }   // T290: the Open log count
-    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sbg) sbg.checked = s.showSessionBadge === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.showFilesControl === true); (function (p) { Object.keys(pn).forEach(function (k) { if (pn[k]) pn[k].checked = p[k]; }); })(panesOf(s)); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); paintBackendOffer(tb ? tb.checked : false); if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
+    p.hidden = false; feedFull(true); setModalCls(true); var s = load(); cc.checked = !!s.compact; jix.checked = (s.showIndexJudges !== undefined ? !!s.showIndexJudges : !!s.debug); jtr.checked = (s.showTriageJudges !== undefined ? !!s.showTriageJudges : !!s.debug); if (gb) gb.checked = s.showBranch === true; if (sbg) sbg.checked = s.showSessionBadge === true; if (sr) sr.checked = s.stripGroupRows !== false; if (dn) dn.checked = s.denseChrome === true; if (fl) fl.value = s.fileLinkPane === 'pane' ? 'pane' : 'chat'; if (fsc) fsc.checked = (s.showFilesControl === true); (function (p) { Object.keys(pn).forEach(function (k) { if (pn[k]) pn[k].checked = p[k]; }); })(panesOf(s)); if (tc) tc.value = tabCtxMode(s.tabCtx); tcPaint(); csPaint(); ttPaint(); if (cg) cg.checked = s.collapseGaps !== false; if (ao) ao.checked = s.activeOnly !== false; if (fc) fc.checked = s.collapsed === true; cmBuild(); cmPaint(s.colormap || 'aurora'); if (bk) { bk.value = BN.effectiveDefaultBackend(s.backend); repaintSelectPicks(); } if (dd) dd.value = s.defaultDir || ''; plFill(); fill(); }
   if (g) g.onclick = function (e) { e.stopPropagation(); openSettings(); };   // hidden anchor; hosts open via the message below
   window.addEventListener('message', function (e) { if (e.data && e.data.romp === 'openSettings') openSettings(); });
   // Escape, relayed by the web shell's Escape chain (_LANDING_ESC_JS captures keydown in this same-origin

--- a/ui/webview/gear.test.ts
+++ b/ui/webview/gear.test.ts
@@ -47,7 +47,7 @@ test("every gear fetch routes through the kernel base + token (VS Code's webview
 test("the gear posts kernel ops through ONE shared channel (never re-acquires the VS Code API)", () => {
   assert.ok(!GEAR.includes("acquireVsCodeApi"), "a second acquire throws in a real webview");
   for (const op of ["setAutoNudge", "setJudgeModel", "setIndexModel", "setJudgeEffort", "setIndexEffort", "setJudgeConcurrency",
-    "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast", "setTmuxBackend",
+    "setDistillModel", "setDistillEffort", "setCommentModel", "setCommentEffort", "setCommentFast",
     "setJudgeFast", "setDistillFast", "setIndexFast", "setFileEditing", "setColormap", "setPalette", "setDefaultDir", "browseDir"])
     assert.ok(GEAR.includes(`'${op}'`), `gear must post ${op}`);
 });

--- a/ui/webview/hover-wiring.test.ts
+++ b/ui/webview/hover-wiring.test.ts
@@ -50,7 +50,7 @@ test("landOn top-aligns the target (block:'start'), never centers", () => {
 
 // Ask preview — the live picker card reproduces the FOCUSED option's side-by-side TUI box (the user
 // 2026-06-13), now FOCUS-AWARE so ↑/↓ swaps it (the user 2026-06-22): the focused option's OWN preview
-// (SDK per-option) or ParsedAsk.preview (the single tmux scrape). Rendered as a monospace <pre> via
+// (per option; ParsedAsk.preview only from an older kernel). Rendered as a monospace <pre> via
 // textContent (NEVER innerHTML: the pane text is untrusted terminal output), and REPLACED not appended.
 test("the live ask card renders the focused option's preview as a monospace pre via textContent", () => {
   assert.match(RENDER, /renderAskPreview\(\);/);

--- a/ui/webview/mcp-panel.test.ts
+++ b/ui/webview/mcp-panel.test.ts
@@ -2,7 +2,7 @@
 // interactive TUI an SDK-driven session cannot render, so it replied "use a terminal". The SDK exposes
 // the same facts and repairs as designed control requests — get_mcp_status, toggle_mcp_server,
 // reconnect_mcp_server — so romp intercepts the command and renders its own panel from them. Fails
-// LOUDLY: a tmux session or a disconnected CLI is NAMED, never an empty list that reads as
+// LOUDLY: a disconnected-CLI session or a disconnected CLI is NAMED, never an empty list that reads as
 // "no servers configured". No jsdom harness → source pins (the repo convention).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
@@ -36,7 +36,7 @@ test("the panel reads the SDK's designed control requests through the kernel", (
   assert.ok(KERNEL.includes('json.dumps({"servers": servers, "error": err})'));
   assert.ok(KERNEL.includes('elif t == "mcpAction" and msg.get("server"):'));
   assert.ok(KERNEL.includes('"mcpAction"'), "routes by session id like every session op (ID_OPS)");
-  // tmux says so explicitly rather than returning a misleading empty list
+  // disconnected-CLI says so explicitly rather than returning a misleading empty list
   assert.ok(ABC.includes("def mcp_status(self, sid: str):"));
   assert.ok(ABC.includes("use /mcp there"));
 });

--- a/ui/webview/mode-selector.test.ts
+++ b/ui/webview/mode-selector.test.ts
@@ -22,8 +22,8 @@ test("the mode button renders FIRST (left of model) and the picker posts setMode
 
 test("Bypass is offered, and offered ONLY on an SDK session", () => {
   // The SDK sets the mode outright (set_permission_mode), so bypassPermissions is reachable there; a
-  // tmux session has nothing but the shift+tab cycle, which cannot express it. Listing it on tmux would
-  // be a menu entry that silently does nothing — the state this same change made the kernel refuse.
+  // Codex session has its own vocabulary and cannot express it. Listing it there would be a menu entry
+  // that silently does nothing.
   assert.match(RENDER, /value: "bypassPermissions", sdkOnly: true/);
   assert.match(RENDER, /\.filter\(\(c\) => !c\.sdkOnly \|\| s\.status\.backend === "sdk"\)/);
 });
@@ -49,7 +49,7 @@ test("every mode wears a tagline, and 'Accept edits' reads 'Accept' everywhere (
   // the rename holds everywhere the mode name renders: the chip/badge…
   assert.match(RENDER, /case "acceptedits": return "Accept";/);
   assert.ok(!RENDER.includes('"Accept edits"'), "no surface still says the two-word label");
-  // …and the kernel's tmux-cycle refusal names the same four modes with the same word
+  // …and the kernel's cycle refusal (its terminal leg, until the backend's removal lands) names the same four modes with the same word
   const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
   assert.match(KERNEL, /shift\+tab cycle — Normal, Accept, Auto, Plan\./);
 });

--- a/ui/webview/notice.test.ts
+++ b/ui/webview/notice.test.ts
@@ -97,7 +97,7 @@ test("actions are data-act word buttons on the button vocabulary (noticeAct); th
   assert.match(RENDER, /function noticeAct\(label: string, act: string, tip\?: string\): HTMLButtonElement \{\s*\n\s*const b = el\("button", "notice-act"\) as HTMLButtonElement;/);
   assert.match(RENDER, /b\.dataset\.act = act;\s*\n\s*if \(tip\) setTip\(b, tip\);/);
   assert.match(CSS, /\.notice-act \{[^}]*font-size: var\(--btn-fs-sm\);[^}]*padding: var\(--btn-pad-sm\);/);
-  for (const act of ["apiRetryNow", "dismissDialog", "stopAllRetries", "stopRetrying", "echorestore", "echodismiss", "todofold", "futoggle", "composerNoteX"]) {
+  for (const act of ["apiRetryNow", "stopAllRetries", "stopRetrying", "echorestore", "echodismiss", "todofold", "futoggle", "composerNoteX"]) {   // dismissDialog went with the terminal backend (T331)
     assert.match(RENDER, new RegExp("\\n    " + act + ": \\("), act + " is handled on the body delegate");
   }
 });

--- a/ui/webview/opening-state.test.ts
+++ b/ui/webview/opening-state.test.ts
@@ -24,7 +24,8 @@ test("the kernel reports OPENING while the transcript doesn't exist and the spaw
 // running): a fresh session of EITHER backend writes NO transcript until its first turn, so keying the
 // chip on the file alone held a fully-up idle session on the opening dots until the user typed.
 // SDK: the backend's live `spawning` report (session thread up, client not yet; the handshake closes
-// it). tmux: the CLI's statusline hook publishing its first @claude-state (2026-08-10). The SDK leg
+// it). The kernel's terminal leg (the statusline hook's first @claude-state) stays pinned until the backend's
+// removal lands (T331 is the UI stage). The SDK leg
 // must key on `spawning`, NOT on `connected` being falsy — a DORMANT created session (kernel restarts
 // kill idle CLIs; boot reconcile leaves them lazy) also reports no `connected`, and reading that as
 // "still opening" kept the dots up for hours on a session one message from answering (the user

--- a/ui/webview/picker-backend.test.ts
+++ b/ui/webview/picker-backend.test.ts
@@ -1,8 +1,7 @@
 // A per-session backend picker on the + dialog (the user 2026-06-23): a segmented toggle, defaulting to the
-// gear's Default backend but overridable for THIS new session. Since T288 (the user 2026-09-09) the toggles
-// read "Claude Code", "Claude Code (tmux)" and "Codex" from backend-names.ts, and "Claude Code (tmux)" is on
-// offer only while the kernel setting says so (off by default; the local sessionList reply carries it).
-// Source-pin over render.ts.
+// gear's Default backend but overridable for THIS new session. The toggles read "Claude Code" and "Codex" from
+// backend-names.ts (T288); the terminal backend is no longer offered (T331, the user 2026-09-10: the tmux backend
+// is being removed), and a saved default of it reads as Claude Code. Source-pin over render.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -11,44 +10,35 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("the + dialog builds a Claude Code | Claude Code (tmux) | Codex backend toggle from the shared names, hidden in pick-mode", () => {
+test("the + dialog builds a Claude Code | Codex backend toggle from the shared names, hidden in pick-mode", () => {
   assert.match(RENDER, /import \{ backendLabel, effectiveDefaultBackend \} from "\.\/backend-names";/);
   assert.match(RENDER, /const beWrap = el\("div", "picker-backend"\)/);
   assert.match(RENDER, /mkBe\("sdk", backendLabel\("sdk"\)/);
-  assert.match(RENDER, /mkBe\("tmux", backendLabel\("tmux"\)/);
   assert.match(RENDER, /mkBe\("codex", backendLabel\("codex"\)/);
+  assert.doesNotMatch(RENDER, /mkBe\("tmux"/, "the terminal backend is not offered");
+  assert.doesNotMatch(RENDER, /kernelTmuxBackend|tmuxBackend/, "no offer switch rides the sessionList reply any more");
+  assert.equal([...RENDER.matchAll(/mkBe\("[a-z]+", backendLabel/g)].length, 2, "two options");
   assert.match(RENDER, /box\.appendChild\(beWrap\)/);
-  // hidden + reset to the EFFECTIVE default each open (a saved tmux default while the backend is off → Claude Code)
+  // hidden + reset to the EFFECTIVE default each open (a saved default no longer offered → Claude Code)
   assert.match(RENDER, /beWrapEl\.style\.display = pick \? "none" : ""/);
-  assert.match(RENDER, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);
-  assert.match(RENDER, /\.classList\.toggle\("sel", \(x as HTMLElement\)\.dataset\.be === def\)\);\s*\n\s*syncPickerBackends\(\);/, "the offer is applied on every open");
+  assert.match(RENDER, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend\);/);
+  assert.match(RENDER, /\.classList\.toggle\("sel", \(x as HTMLElement\)\.dataset\.be === def\)\);\s*\n\s*syncPickerBackends\(\);/, "the default is applied on every open");
 });
 
-test("the tmux toggle is on offer only while the kernel setting is on: absent when off, present when on (T288)", () => {
-  // the setting rides the LOCAL sessionList reply; assumed off until a kernel says on
-  assert.match(RENDER, /let kernelTmuxBackend = false;/);
-  assert.match(RENDER, /if \(typeof m\.tmuxBackend === "boolean" && !from\) \{ kernelTmuxBackend = m\.tmuxBackend; syncPickerBackends\(\); \}/);
-  const sync = RENDER.slice(RENDER.indexOf("function syncPickerBackends(): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function syncPickerBackends(): void {")));
-  assert.match(sync, /const tmuxBtn = wrap\.querySelector\('\.picker-be-opt\[data-be="tmux"\]'\) as HTMLElement \| null;/);
-  assert.match(sync, /tmuxBtn\.style\.display = kernelTmuxBackend \? "" : "none";/, "off → the toggle is not shown; on → it is");
-  // the reply lands AFTER the open reset the row: the effective default is re-applied while the user has not
-  // picked this open (a saved tmux default lands once the toggle is on offer), and a selected toggle that went
-  // off offer always hands the selection back, so the create never sends a backend the picker does not show;
-  // an explicit pick made this open is never undone
+test("the selected toggle follows the effective default until the user picks this open, and a pick is never undone", () => {
   assert.match(RENDER, /let pickerBackendPicked = false;/);
   assert.match(RENDER, /b\.addEventListener\("click", \(\) => \{ pickerBackendPicked = true; beWrap\.querySelectorAll/, "a click is an explicit pick");
   assert.match(RENDER, /pickerBackendPicked = false;   \/\/ a fresh open/, "each open forgets the last pick");
-  assert.match(sync, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);\s*\n\s*const cur = wrap\.querySelector\("\.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*if \(!pickerBackendPicked \|\| \(!kernelTmuxBackend && cur\?\.dataset\.be === "tmux"\)\) \{/);
+  const sync = RENDER.slice(RENDER.indexOf("function syncPickerBackends(): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function syncPickerBackends(): void {")));
+  assert.match(sync, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend\);\s*\n\s*const cur = wrap\.querySelector\("\.picker-be-opt\.sel"\) as HTMLElement \| null;\s*\n\s*if \(!pickerBackendPicked && cur\?\.dataset\.be !== def\) \{/);
   assert.match(sync, /syncPickerAuth\(\); syncPickerTags\(\);/, "the Billing and Tags rows follow the new choice");
-  // the kernel's reply carries the setting as a boolean, off by default
-  const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
-  assert.match(KERNEL, /"tmuxBackend": jd\._state_str\("tmux-backend", "off"\) == "on",/, "the sessionList reply");
+  assert.doesNotMatch(sync, /display/, "nothing is hidden or shown: both options are always on offer");
 });
 
 test("createSession uses the picked backend, falling back to the EFFECTIVE gear default", () => {
   assert.match(RENDER, /const beSel = beWrap\.querySelector\("\.picker-be-opt\.sel"\)/);
-  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);
-  assert.match(RENDER, /return beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/, "pickerBackendChoice too");
+  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend\);/);
+  assert.match(RENDER, /return beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend\);/, "pickerBackendChoice too");
   assert.match(RENDER, /startCreate\(\{ name, backend,/);
 });
 

--- a/ui/webview/picker-dir.test.ts
+++ b/ui/webview/picker-dir.test.ts
@@ -32,7 +32,7 @@ test("createSession carries the chosen dir, alongside name + backend", () => {
   // 2026-06-23). The whole request goes through startCreate, which remembers it so a missing directory
   // can be created and the SAME create re-sent (the user 2026-07-28).
   // (…and the Tags row's picks since tab groups, 2026-09-04 — omitted like auth when nothing is picked)
-  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);   // the EFFECTIVE default since T288
+  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend\);/);   // the EFFECTIVE default since T288
   assert.match(RENDER, /startCreate\(\{ name, backend,\s*\n\s*dir: dirInput\.value\.trim\(\), host: hostSel, \.\.\.\(auth \? \{ auth \} : \{\}\), \.\.\.\(tags\.length \? \{ tags \} : \{\}\) \}\)/);
   assert.match(RENDER, /vscodeApi\.postMessage\(\{ type: "createSession", \.\.\.req/);
 });

--- a/ui/webview/picker-tag-chips.test.ts
+++ b/ui/webview/picker-tag-chips.test.ts
@@ -36,21 +36,15 @@ test("the option wears no button chrome around the chip, selected or hovered, so
   assert.ok(CSS.indexOf(".picker-be-opt.sel { background: var(--accent)") < CSS.indexOf(".picker-tags .picker-be-opt.sel {"), "the tag rule follows the generic one in the sheet");
 });
 
-test("the tmux pick greys the row without stacking a second fade on the off chips, so on and off still read", () => {
-  assert.match(CSS, /\n\.picker-tags\.disabled \.picker-be-opt \{ filter: grayscale\(1\); cursor: default; pointer-events: none; \}\n/,
-    "grey says disabled; the off chip's 0.45 stays the only fade");
-  assert.doesNotMatch(CSS, /\.picker-tags\.disabled \.picker-be-opt \{ opacity: 0\.45;/, "the old 0.45 over 0.45 left an off chip at a fifth");
-});
-
 test("the off visual is the one the tag toggles use: TAG_CHIP_OFF_CLASS at the inline opacity, defined on both sheets", () => {
   assert.match(MENU, /export const TAG_CHIP_OFF_CLASS = "tag-chip-off";/);
   assert.match(MENU, /export const TAG_CHIP_OFF_OPACITY = "0\.45";/);
   for (const [name, sheet] of [["styles.css", CSS], ["feed.css", FEED_CSS]] as const) assert.match(sheet, /\n\.tag-chip-off \{ opacity: 0\.45; \}\n/, name);
 });
 
-test("what the create reads is unchanged: the selected options' data-tag, only when the backend takes tags", () => {
-  assert.match(RENDER, /const tags = backendTakesTags\(backend\)\s*\n\s*\? Array\.from\(tgWrap\.querySelectorAll<HTMLElement>\("\.picker-be-opt\.sel"\)\)\.map\(\(x\) => x\.dataset\.tag \|\| ""\)\.filter\(Boolean\)/);
+test("what the create reads is unchanged: the selected options' data-tag (every offered backend takes tags)", () => {
+  assert.match(RENDER, /const tags = Array\.from\(tgWrap\.querySelectorAll<HTMLElement>\("\.picker-be-opt\.sel"\)\)\.map\(\(x\) => x\.dataset\.tag \|\| ""\)\.filter\(Boolean\)/);
   assert.match(REBUILD, /b\.type = "button"; b\.dataset\.tag = u\.name;/);
   const sync = RENDER.slice(RENDER.indexOf("function syncPickerTags("), RENDER.indexOf("function syncPickerAuth("));
-  assert.match(sync, /\.forEach\(\(b\) => \{ b\.disabled = !takes; \}\);/, "the tmux pick still disables the buttons themselves");
+  assert.match(sync, /\.forEach\(\(b\) => \{ b\.disabled = false; \}\);/, "every chip stays live: no pick disables the buttons (T331)");
 });

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -1,7 +1,7 @@
 // A new session shows its chat box immediately and starts behind it (the user 2026-07-30).
 //
 // Creating a session used to raise an "Opening session…" modal over the pane: the kernel resolved the
-// directory, spawned tmux or connected the SDK, and the first transcript poll came back — seconds you
+// directory, connected the session, and the first transcript poll came back — seconds you
 // could do nothing with, watching three bouncing dots. Now the tab is there from the first click with a
 // live composer; anything typed is HELD and flushed the moment the real session lands; and a create that
 // fails says so in a dialog carrying the kernel's own words, instead of the cue silently timing out.

--- a/ui/webview/provisional.ts
+++ b/ui/webview/provisional.ts
@@ -1,7 +1,7 @@
 // A new session shows its chat box IMMEDIATELY, and starts behind it (the user 2026-07-30).
 //
 // Creating a session used to raise a modal "Opening session…" over the whole pane, and you waited: the
-// kernel resolves the directory, spawns tmux or connects the SDK, and the first transcript poll comes
+// kernel resolves the directory, connects the session, and the first transcript poll comes
 // back — seconds, sometimes many. Nothing could be typed in that gap, and the only thing on screen was a
 // dialog with three dots. So the tab appears at once in the OPENING state with a live composer; anything
 // typed is held and flushed the moment the real session lands, and a create that FAILS says so in a

--- a/ui/webview/queued-held.ts
+++ b/ui/webview/queued-held.ts
@@ -5,7 +5,7 @@
 // reader within that height of the bottom, and the landed card then grows the tail back below them: a card above
 // the bottom, follow mode off, the jump chip shown. So a vanished copy is HELD in place, marked landing, until the
 // atom that carries its identity arrives (T252c: the queued copy's `qid` is the landed atom's `qid`, or one of its
-// `qids`), and the atom then takes the copy's slot in the same frame. A copy with no id (an older kernel, the tmux
+// `qids`), and the atom then takes the copy's slot in the same frame. A copy with no id (an older kernel
 // route, a copy the backend queued itself) is held by TEXT for the one push it vanished on, and dropped at the
 // next push that carries the queue if nothing claimed it — never a phantom. A held identified copy is dropped the
 // moment a LATER landing shows the CLI has passed it (the queue is first-in-first-out: had the copy landed, its

--- a/ui/webview/queued-indicator.test.ts
+++ b/ui/webview/queued-indicator.test.ts
@@ -1,6 +1,6 @@
 // The "queued" indicator (the user's messages submitted while a session is still working). It's the SAME
 // generic {kind:"queued"} ChatEvent for BOTH backends — the kernel feeds it from the transcript queue-ops
-// for tmux and from SdkBackend.pending_queued for SDK (business 2026-06-23). So pinning the one render path
+// from SdkBackend.pending_queued (business 2026-06-23). So pinning the one render path
 // confirms the dot shows for either backend. The renderer has no jsdom harness, so pin the wiring at source.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";

--- a/ui/webview/render-settings.test.ts
+++ b/ui/webview/render-settings.test.ts
@@ -43,6 +43,6 @@ test("the chat has NO gear of its own — it only consumes the shared setting (g
 
 test("the + New session button sends the picker's backend toggle, defaulting to the gear's (the user 2026-06-23)", () => {
   // the per-session toggle wins; it RESETS to the gear default (read fresh via loadSettings()) on each open
-  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);\s*\n[\s\S]{0,400}startCreate\(\{ name, backend,/);
-  assert.match(RENDER, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend, kernelTmuxBackend\);/);   // toggle defaults to the gear setting, as offered (T288)
+  assert.match(RENDER, /const backend = beSel\?\.dataset\.be \|\| effectiveDefaultBackend\(loadSettings\(\)\.backend\);\s*\n[\s\S]{0,400}startCreate\(\{ name, backend,/);
+  assert.match(RENDER, /const def = effectiveDefaultBackend\(loadSettings\(\)\.backend\);/);   // toggle defaults to the gear setting, as offered (T288; a retired saved default reads as Claude Code, T331)
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -298,7 +298,7 @@ type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: stri
 // which billing sides this box can bill, and why not for the other (kernel _auth_avail, 2026-09-08): the
 // Billing submenu lists both and greys the unavailable one with the reason in its hover
 interface AuthAvail { login?: boolean; key?: boolean; loginWhy?: string; keyWhy?: string; acct?: string; default?: string }
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "tmux" | "sdk"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "sdk" | "codex"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 
 // The side a pick this box cannot bill actually fell to ("login" | "key"), "" when nothing did: the kernel's
 // authPickFell (the launch's own decision, 2026-09-09). An older kernel without the field is read the way the
@@ -1149,9 +1149,9 @@ interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: bo
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
-// live ONLY in the session's tmux pane (Claude Code doesn't write a pending
-// prompt to the transcript until it's answered), so the host captures+parses the
-// pane and pushes them here. Kept OUT of the transcript `events` list so syncView
+// never reach the transcript (Claude Code doesn't write a pending prompt to it until
+// it's answered): the SDK pushes the pending question over the control channel and
+// the kernel forwards it here as askLive. Kept OUT of the transcript `events` list so syncView
 // never clobbers them; rendered into the dedicated #live-ask region instead.
 // The pending prompt per session (its `kind` selects the widget). Kept OUT of the
 // transcript events so syncView can't clobber it. A stored null = awaiting an
@@ -3323,10 +3323,9 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         bubble.classList.add("undelivered-bubble");
         const note = el("div", "undelivered-note");
         // covers BOTH dropped-echo populations (the copy predated the 2026-08-26 widening and claimed a
-        // process death for every loss): an SDK echo really is a send its CLI died holding, but a tmux
-        // echo settles dropped when the session simply moved past it — a keystroke the pane dropped, or
-        // a delivery the transcript recorded under different text. Say what is KNOWN (it never made the
-        // conversation), not a cause that is only sometimes true.
+        // process death for every loss): an echo really is a send its CLI died holding, or the session simply
+        // moved past it (a delivery the transcript recorded under different text). Say what is KNOWN (it never
+        // made the conversation), not a cause that is only sometimes true.
         setTip(note, "This message never made it into the conversation: the session moved on without recording it (a dropped keystroke, a process that died holding it, or a delivery recorded under different text).");
         const label = el("span", "undelivered-label");
         label.textContent = "never delivered";
@@ -3375,7 +3374,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         // RESTORE-FILES affordance (the user 2026-08-04): put the WORKSPACE back the way it was just
         // before this message — the SDK's file-checkpoint rewind (rewind_files). The conversation is
         // untouched; edit/delete cover that. Same two-click arm as delete (destructive — every miss
-        // fails toward "not restored"); the kernel warns on a refusal (tmux, disconnected).
+        // fails toward "not restored"); the kernel warns on a refusal (disconnected).
         const rf = el("button", "msg-restorefiles") as HTMLButtonElement;
         rf.type = "button";
         rf.textContent = "restore files";
@@ -4324,7 +4323,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     else if (t.landing) { bubble.classList.add("landing"); bubble.title = "the session has taken this — it joins the conversation as soon as its record lands"; }
     // a queued entry with NO ✕ (the user 2026-07-20): the queue lives inside the session's own CLI —
     // there is no recall — so instead of a cancel that would only ever say "too late", the tooltip says
-    // where the message actually is. (SDK mid-turn forwards and every tmux queued message land here.)
+    // where the message actually is. (SDK mid-turn forwards land here.)
     else if (!t.cancelable && t.idx !== undefined)
       bubble.title = "queued in the session — it can't be recalled, and joins the conversation at the session's next step";
     const isCmd = renderSlashCmd(bubble, t.md);
@@ -4408,7 +4407,7 @@ function renderQueued(ev: Extract<ChatEvent, { kind: "queued" }>): HTMLElement {
     // undiscoverable AND hung on a node every push rebuilds, so mid-press rebuilds silently ate the
     // click). The ✕ carries data-act="qx" → the ONE document.body delegate (click-safe per CLAUDE.md);
     // a MESSAGE returns to the composer to re-edit, a slash COMMAND just cancels. Covers both queues:
-    // the backend's own (idx; SDK only — tmux's queue lives inside Claude Code, no recall) and ops
+    // the backend's own (idx; the SDK's) and ops
     // PARKED during compaction/model switches (park; romp-owned on every backend).
     if (t.cancelable && (t.idx !== undefined || t.park !== undefined || t.optimistic)) {
       const x = el("button", "queued-x");
@@ -4496,11 +4495,7 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
   const countdown = el("span", "notice-meta api-countdown");
   countdown.textContent = "retrying soon…";
   // A SPEND-CAP block gets no Retry (the user 2026-07-16, mirroring the feed card's 2026-07-14 call):
-  // retrying can't lift a billing cap, and on a tmux session it's worse than useless — the CLI is parked
-  // on an interactive menu that eats the injected "retry" as navigation keystrokes. There the real
-  // unblock is dismissing that dialog, so the tmux card offers exactly that (the kernel verifies the
-  // menu is up, then sends Esc — cancel, never a billing change). An SDK spend-cap card names the fix
-  // (raise the cap) with no dead button at all.
+  // retrying can't lift a billing cap. The card names the fix (raise the cap) with no dead button at all.
   const st = activeId ? liveSession(activeId)?.status : undefined;
   // A spent MODEL allowance gets no Retry either (the user 2026-08-01): "retry" re-fails until the model
   // changes or its own window resets, so the card names the fix instead of offering a button that cannot work.
@@ -4513,13 +4508,10 @@ function renderApiError(ev: Extract<ChatEvent, { kind: "apiError" }>): HTMLEleme
   const spendCap = !!st?.apiSpendLimit || !!st?.apiModelLimit || !!st?.apiAuthErr || refusal;
   const acts: HTMLElement[] = [];
   // every action is a data-act word button on the button vocabulary; the document.body delegate acts
-  // (apiRetryNow / dismissDialog / stopAllRetries) and acknowledges at once — the tail rebuilds on every
+  // (apiRetryNow / stopAllRetries) and acknowledges at once — the tail rebuilds on every
   // push, and the per-node listeners this replaced ate mid-press clicks (CLAUDE.md click-safety)
   if (!spendCap) {
     acts.push(noticeAct("Retry now", "apiRetryNow", "send “retry” into this session right now (also resets the auto-retry countdown)"));
-  } else if (st?.backend === "tmux" && !refusal) {
-    // (a refusal parks no menu — the Esc-sender is for the CLI's spend-limit dialog only)
-    acts.push(noticeAct("Dismiss dialog", "dismissDialog", "the terminal is showing the spend-limit menu — send Esc to close it (cancels; changes no billing setting)"));
   }
   // Global auto-retry pause (the user 2026-06-30) — no per-session off-switch. "Retry now" + sending a message still work.
   const paused = globalRetryPaused;
@@ -5285,10 +5277,9 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   if (s.status.effort) rows.push(["Effort", s.status.effort]);
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
-  if (be === "sdk" || be === "tmux" || be === "codex") rows.push(["Backend", backendLabel(be)]);   // the shared names (T288); a tmux session keeps its label whatever the offer setting says
+  if (be === "sdk" || be === "codex") rows.push(["Backend", backendLabel(be)]);   // the shared names (T288)
   // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
-  // user 2026-08-09: shown whenever the backend reports it, one-auth machines included; only a tmux
-  // session, whose CLI env romp does not control, reports nothing). No key material, ever.
+  // user 2026-08-09: shown whenever the backend reports it, one-auth machines included). No key material, ever.
   // When the CLI's own init landed on the OTHER side (authLive — say, a key found via apiKeyHelper
   // on a session launched for the login), the row carries the live truth beside the intent instead
   // of wearing the lie (the user 2026-08-15). The account name yields its parenthetical then: it is
@@ -6331,21 +6322,18 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
   }
   // Move to folder… sits with Rename (the user 2026-09-01: a subproject became its own repo and the
   // session should follow it) — the same dress, the sub-line saying what a move KEEPS. The dialog does
-  // the rest (showMovePrompt); the kernel wraps the CLI's own relocation. SDK sessions only: a terminal
-  // session has no relocation primitive, so its row says so rather than failing after a click.
+  // the rest (showMovePrompt); the kernel wraps the CLI's own relocation. Every session moves (T331: the
+  // terminal backend, which had no relocation primitive, is no longer offered).
   {
-    const sTm = sessions.get(id);
-    const isTmux = !!(sTm && sTm.status && sTm.status.backend === "tmux");
-    const mv = el("div", "ctx-item ctx-item-toggle" + (isTmux ? " ctx-item-off" : ""));
-    mv.appendChild(ctxIcon("folder", isTmux));
+    const mv = el("div", "ctx-item ctx-item-toggle");
+    mv.appendChild(ctxIcon("folder", false));
     const bodyEl = el("span", "ctx-item-body");
     const l = el("span", "ctx-item-label"); l.textContent = "Move to folder…"; bodyEl.appendChild(l);
     const sb = el("span", "ctx-item-sub");
-    sb.textContent = isTmux ? "terminal sessions can't move — start a new one in that folder"
-                            : "the conversation, mail, goals and history stay with the session";
+    sb.textContent = "the conversation, mail, goals and history stay with the session";
     bodyEl.appendChild(sb);
     mv.appendChild(bodyEl);
-    if (!isTmux) mv.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); showMovePrompt(id); });
+    mv.addEventListener("click", (ev) => { ev.stopPropagation(); dismissTabMenu(); showMovePrompt(id); });
     menu.appendChild(mv);
   }
   // Colors join Rename in the AESTHETIC section (the user 2026-08-24, the final by-kind grouping:
@@ -6799,7 +6787,7 @@ window.addEventListener("scroll", dismissTabMenu, true);
 window.addEventListener("blur", () => dismissTabMenu());
 
 // "Rename" (tab context menu): swap the tab's label for an inline input. Enter
-// or clicking away commits (the host renames the tmux session and confirms with
+// or clicking away commits (the kernel renames the session and confirms with
 // a "renamed" message — the label only changes once that lands), Esc cancels.
 function startTabRename(id: string, copy?: string) {   // `copy`: which copy of a multi-tag session to edit in place (T264b); the first one when it is gone
   const s = sessions.get(id);
@@ -7124,7 +7112,7 @@ let pickAllowNew = false;
 
 // The session you just created gets its TAB AND COMPOSER IMMEDIATELY, and starts behind them (the user
 // 2026-07-30). This replaced an "Opening session…" modal that covered the pane while the kernel resolved
-// the directory, spawned tmux or connected the SDK, and the first transcript poll came back — seconds you
+// the directory, connected the session, and the first transcript poll came back — seconds you
 // could do nothing with, watching three dots. See ./provisional.ts for why the id carries no colon.
 //
 // `pendingNewSession` is the NAME the created session will arrive under; it is the only join available,
@@ -7402,14 +7390,9 @@ function dirPrefill(host: string): string {
 // The capability rides in on the local sessionList; assume yes until a kernel says otherwise, so an older
 // kernel that doesn't send it keeps the button it always had.
 let kernelNativeDialogs = true;
-// Whether the + picker OFFERS "Claude Code (tmux)" (T288, the user 2026-09-09): a kernel setting, off by default,
-// carried on the local sessionList reply. It gates the offer alone: an existing tmux session keeps working and
-// keeps its tooltip label whatever it says. Assumed off until a kernel says on (an older kernel sends none).
-let kernelTmuxBackend = false;
 // whether the user clicked a Backend toggle during THIS open of the picker: the sessionList reply, which lands after
-// the open reset the row, re-applies the effective default only while no explicit pick stands (the review's find:
-// a saved tmux default with the setting on landed on Claude Code on the first open, since the reset ran before
-// the reply said the toggle was on offer), and never undoes a pick the user made
+// the open reset the row, re-applies the effective default only while no explicit pick stands, and never undoes a
+// pick the user made
 let pickerBackendPicked = false;
 
 // The two cases are shown differently, because one of them can change and the other cannot. A REMOTE host
@@ -7445,48 +7428,34 @@ function requestSessionList(host: string): void {
 // manager environment carries. The row is ALWAYS there for an SDK session (the user 2026-08-09):
 // segmented BUTTONS when the selected host offers both, and when it offers ONE, the same spot just
 // writes out which it is — informative, never a one-option selector (what the earlier disappearing
-// rule was really against). The row still disappears when the backend toggle says tmux (that CLI
-// lives in the tmux server's environment, which the kernel does not control) and until the host's
-// sessionList reply carries authAvail (an older kernel never answers with one).
+// rule was really against). The row still disappears until the host's sessionList reply carries authAvail
+// (an older kernel never answers with one), and on the Codex pick (Billing is a Claude Code matter).
 let pickerAuthAvail: AuthAvail | null = null;
 
 // the picker's selected Backend chip — the Backend row alone (the Billing, Host and Tags rows wear the
 // same chip grammar, and a selected tag chip must never read as a backend)
 function pickerBackendChoice(): string {
   const beSel = document.querySelector("#picker .picker-backend:not(.picker-host):not(.picker-auth):not(.picker-tags) .picker-be-opt.sel") as HTMLElement | null;
-  return beSel?.dataset.be || effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);
+  return beSel?.dataset.be || effectiveDefaultBackend(loadSettings().backend);
 }
 
-// The Backend row offers "Claude Code (tmux)" only while the kernel setting is on (T288): the toggle hides
-// otherwise, and a hidden toggle that was selected hands the selection to the effective default, so the create
-// can never send a backend the picker does not show. Re-run on every open and on the local sessionList reply.
+// The Backend row offers Claude Code and Codex. Until the user picks this open, the selected toggle follows the
+// effective default (a saved default that is no longer offered reads as Claude Code, effectiveDefaultBackend), so
+// the create can never send a backend the picker does not show. Re-run on every open and on the local sessionList reply.
 function syncPickerBackends(): void {
   const wrap = document.querySelector("#picker .picker-backend:not(.picker-host):not(.picker-auth):not(.picker-tags)") as HTMLElement | null;
   if (!wrap) return;
-  const tmuxBtn = wrap.querySelector('.picker-be-opt[data-be="tmux"]') as HTMLElement | null;
-  if (tmuxBtn) tmuxBtn.style.display = kernelTmuxBackend ? "" : "none";
-  // the effective default is re-applied while the user has not picked this open (so a saved tmux default lands
-  // once the reply says the toggle is on offer), and always when the selected toggle went off offer
-  const def = effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);
+  const def = effectiveDefaultBackend(loadSettings().backend);
   const cur = wrap.querySelector(".picker-be-opt.sel") as HTMLElement | null;
-  if (!pickerBackendPicked || (!kernelTmuxBackend && cur?.dataset.be === "tmux")) {
-    if (cur?.dataset.be !== def) {
-      wrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
-      syncPickerAuth(); syncPickerTags();
-    }
+  if (!pickerBackendPicked && cur?.dataset.be !== def) {
+    wrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
+    syncPickerAuth(); syncPickerTags();
   }
 }
 
-// the backends whose create takes `tags`: the kernel applies parent/tags on an SDK or a Codex create
-// (the tag store keys on the registry sid, not the backend), and a tmux create takes none — a
-// terminal session's id is unknown until it starts, so the kernel refuses tags on one. One predicate
-// for the Tags row's state and for the create handler's payload, so the two cannot disagree about
-// which backend a chip is for.
-function backendTakesTags(be: string): boolean { return be === "sdk" || be === "codex"; }
-
-// the Tags row is for SDK and Codex sessions (tab groups, 2026-09-04): on the tmux pick the row stays
-// in place but disabled behind a short note, and the create handler sends no `tags`. Without this a
-// chip prefilled from a tagged active tab turns every terminal create into a refusal.
+// the Tags row (tab groups, 2026-09-04): every offered backend's create takes `tags` (the kernel applies parent/tags
+// on a Claude Code or a Codex create; the tag store keys on the registry sid, not the backend), so the row is never
+// disabled and the create handler always sends the selected chips.
 // The Tags row's option paints as the tag chip itself (T321, the user 2026-09-10): the thin border in the tag's own
 // colour that the tab strip, the feed and the outline draw, and on versus off by the visual the tag toggles already
 // use, the faded chip (tagChip's `off`, TAG_CHIP_OFF_CLASS at 0.45), never a dot and never the Backend row's accent
@@ -7498,11 +7467,9 @@ function paintPickerTagChip(b: HTMLButtonElement, u: { name: string; color?: str
 function syncPickerTags(): void {
   const wrap = document.querySelector("#picker .picker-tags") as HTMLElement | null;
   if (!wrap) return;
-  const takes = backendTakesTags(pickerBackendChoice());
-  wrap.classList.toggle("disabled", !takes);
-  wrap.querySelectorAll<HTMLButtonElement>(".picker-be-opt").forEach((b) => { b.disabled = !takes; });
-  const note = wrap.querySelector(".picker-tags-note") as HTMLElement | null;
-  if (note) note.style.display = takes ? "none" : "";
+  // every offered backend takes tags: the chips are always live (the disabled state and its note went with the
+  // terminal backend, T331)
+  wrap.querySelectorAll<HTMLButtonElement>(".picker-be-opt").forEach((b) => { b.disabled = false; });
 }
 
 function syncPickerAuth(): void {
@@ -7789,7 +7756,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     dirField.appendChild(dirInput); dirField.appendChild(dirHint);
     dirWrap.appendChild(dirField); dirWrap.appendChild(browseBtn);
     dirWrap.appendChild(dirMenu);
-    // per-session BACKEND picker (the user 2026-06-23): a tmux | SDK segmented toggle, defaulting to the
+    // per-session BACKEND picker (the user 2026-06-23): a Claude Code | Codex segmented toggle, defaulting to the
     // gear's Default backend but overridable for THIS new session. Hidden in pick-mode (like dirWrap).
     const beWrap = el("div", "picker-backend");
     const beLabel = el("span", "picker-backend-label"); beLabel.textContent = "Backend";
@@ -7799,13 +7766,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       b.addEventListener("click", () => { pickerBackendPicked = true; beWrap.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", x === b)); });
       return b;
     };
-    // the labels come from backend-names.ts (T288): "Claude Code" (the default, no qualifier), "Claude Code (tmux)"
-    // (offered only while the kernel setting is on — syncPickerBackends), "Codex"; the ids are unchanged
+    // the labels come from backend-names.ts (T288): "Claude Code" (the default, no qualifier) and "Codex"; the ids
+    // are unchanged
     beWrap.append(beLabel, mkBe("sdk", backendLabel("sdk"), "The default: romp runs the Claude Code session itself, with the same full chat."),   // first — the de-facto default (the user 2026-07-02)
-                  mkBe("tmux", backendLabel("tmux"), "Drives a Claude Code session in a real terminal pane (tmux); offered while the tmux backend is enabled in the gear."),
                   mkBe("codex", backendLabel("codex"), "Runs an OpenAI Codex agent (the host needs romp-codex-setup + codex login)."));
-    // the billing row exists only for SDK sessions, the Tags row only for backends whose create takes
-    // tags (backendTakesTags) — re-decide both on every backend toggle
+    // the billing row exists only for Claude Code sessions — re-decide it (and the Tags row's paint) on every backend toggle
     beWrap.addEventListener("click", () => { syncPickerAuth(); syncPickerTags(); });
     // per-session BILLING row (the user 2026-08-08): Login | API key buttons when the selected host
     // offers both; with ONE real choice the same spot writes it out as plain text (the user
@@ -7829,17 +7794,11 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
     // VISIBLE and editable, never a silent inherit (the user's ruling): a session started beside the
     // one you are looking at joins its group unless you unpick it. Chips in the Backend row's
     // grammar, each toggling on its own (a session may hold several tags); rebuilt per open
-    // (openPicker below), hidden with no tags to offer and in pick-mode. SDK and Codex sessions
-    // (backendTakesTags): on the tmux pick the chips disable behind a note and no `tags` ride the
-    // create (syncPickerTags) — the kernel refuses tags on a terminal create, and a prefilled chip
-    // would turn one into a refusal.
+    // (openPicker below), hidden with no tags to offer and in pick-mode. Every offered backend's create takes
+    // the chips (syncPickerTags paints them).
     const tgWrap = el("div", "picker-backend picker-tags");
     const tgLabel = el("span", "picker-backend-label"); tgLabel.textContent = "Tags";
     tgWrap.appendChild(tgLabel);
-    const tgNote = el("span", "picker-auth-fixed picker-tags-note");   // the Billing row's written-out text style
-    tgNote.textContent = `Tags apply to ${backendLabel("sdk")} and ${backendLabel("codex")} sessions`;   // the shared names (T288)
-    tgNote.style.display = "none";
-    tgWrap.appendChild(tgNote);
     // per-session HOST picker (federation, the user 2026-07-02): local | each attached SSH host — the new
     // session is created BY that host's kernel (over its tunnel) and appears prefixed `host:name`. The
     // options are rebuilt on every open (hosts attach/detach live); the row hides with no hosts attached.
@@ -7879,12 +7838,9 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
       const auth = pickerAuthChoice();
       // tags: the Tags row's selected chips (prefilled from the active tab, edited or not) ride the
       // create as names; the owning kernel resolves them by name, minting a missing one like POST /tag.
-      // SDK and Codex creates (backendTakesTags) — a tmux create carries none (the row is disabled for
-      // it, and the kernel refuses tags on a terminal create)
-      const backend = beSel?.dataset.be || effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);
-      const tags = backendTakesTags(backend)
-        ? Array.from(tgWrap.querySelectorAll<HTMLElement>(".picker-be-opt.sel")).map((x) => x.dataset.tag || "").filter(Boolean)
-        : [];
+      // Every offered backend's create takes them (the kernel applies parent/tags on a Claude Code or a Codex create).
+      const backend = beSel?.dataset.be || effectiveDefaultBackend(loadSettings().backend);
+      const tags = Array.from(tgWrap.querySelectorAll<HTMLElement>(".picker-be-opt.sel")).map((x) => x.dataset.tag || "").filter(Boolean);
       startCreate({ name, backend,
                     dir: dirInput.value.trim(), host: hostSel, ...(auth ? { auth } : {}), ...(tags.length ? { tags } : {}) });
     });
@@ -7941,7 +7897,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
   if (beWrapEl) {   // reset the backend toggle to the gear default each open (overridable for this session)
     beWrapEl.style.display = pick ? "none" : "";
     pickerBackendPicked = false;   // a fresh open: the row follows the effective default until the user picks
-    const def = effectiveDefaultBackend(loadSettings().backend, kernelTmuxBackend);   // a saved tmux default while it is off → Claude Code
+    const def = effectiveDefaultBackend(loadSettings().backend);   // a saved default no longer offered → Claude Code
     beWrapEl.querySelectorAll(".picker-be-opt").forEach((x) => x.classList.toggle("sel", (x as HTMLElement).dataset.be === def));
     syncPickerBackends();
   }
@@ -8002,7 +7958,7 @@ function openPicker(pick = false, prompt?: string, allowNew = false) {
         ? `the session you are looking at is in ${u.name} — the new one joins it too unless you unpick this`
         : `put the new session in ${u.name}`;
       b.addEventListener("click", () => { b.classList.toggle("sel"); paintPickerTagChip(b, u); });   // multi-select: each chip on its own
-      tgWrapEl.insertBefore(b, tgWrapEl.querySelector(".picker-tags-note"));   // chips before the tmux note
+      tgWrapEl.appendChild(b);
     }
     syncPickerTags();   // the backend toggle was just reset to the gear default above
   }
@@ -9847,7 +9803,7 @@ function loadMcpPanel(sid: string, body: HTMLElement): void {
       if (mcpPanelSid !== sid) return;   // panel closed (or reopened for another tab) while loading
       body.textContent = "";
       const servers: any[] = Array.isArray(d?.servers) ? d.servers : [];
-      // FAIL LOUDLY: a refusal (tmux session, disconnected CLI) is named, never an empty list that
+      // FAIL LOUDLY: a refusal (a disconnected CLI) is named, never an empty list that
       // reads as "no servers configured".
       if (d?.error) {
         const e = el("div", "mcp-err"); e.textContent = String(d.error); body.appendChild(e);
@@ -10040,7 +9996,7 @@ function renderPicker(items: any[]) {
     if (it.hiddenTab) {   // open as a tab but filtered out of the CURRENT view (tagged) → picking jumps to its view
       time.textContent = "other view";
       time.style.opacity = "0.7";
-    } else if (it.running) {   // a live session (SDK/tmux backend) whose tab is closed → a green "running" badge
+    } else if (it.running) {   // a live session whose tab is closed → a green "running" badge
       time.classList.add("picker-running-badge");
       time.append(el("span", "picker-run-dot"), document.createTextNode("running"));
     } else {
@@ -13191,11 +13147,11 @@ function renderLiveAsk() {
   host.style.display = "";
   const ask = liveAsks.get(activeId) ?? null;
   setComposerAskMode();   // picker with a free-text path → the composer becomes "add your own answer…"
-  if (!ask) renderUnknownCard();
-  else if (ask.kind === "multi") renderMultiCard(ask);
+  if (!ask) { host.style.display = "none"; setComposerAskMode(); return; }   // no typed ask (the kernel clears instead): nothing to draw
+  if (ask.kind === "multi") renderMultiCard(ask);
   else if (ask.kind === "submit") renderSubmitCard(ask);
   else renderSingleCard(ask);
-  renderAskPreview();   // focus-aware: the FOCUSED option's own preview (SDK) or the single scraped one (tmux)
+  renderAskPreview();   // focus-aware: the FOCUSED option's own preview
   // Reveal the picker if the user is parked at the bottom — it's part of the scroll flow now, so new/taller
   // pickers would otherwise land below the fold. Never yank a user who has scrolled UP to read context.
   const v = activeId ? views.get(activeId) : undefined;
@@ -13206,10 +13162,9 @@ function renderLiveAsk() {
 // 2026-06-13). The TUI draws it to the RIGHT of the options; the chat rail is narrow, so it sits BELOW the
 // card and scrolls sideways if wider than the rail. FOCUS-AWARE (the user 2026-06-22): on a single-select
 // card it shows the CURRENTLY-FOCUSED option's preview, so ↑/↓ swaps the picture like the terminal —
-// instantly when the option carries its OWN preview (the SDK backend sends one per option), else from
-// ParsedAsk.preview (the one the tmux scrape captured for the focused row, which paintLiveAskFocus keeps
-// current by nudging the terminal cursor). REPLACES rather than appends, so stepping never stacks
-// duplicates. textContent, never innerHTML: the pane text is untrusted terminal output.
+// instantly, from the option's OWN preview (the SDK sends one per option; ParsedAsk.preview stands in only
+// for an older kernel's single preview). REPLACES rather than appends, so stepping never stacks
+// duplicates. textContent, never innerHTML: the preview is untrusted tool output.
 function renderAskPreview() {
   const host = document.getElementById("live-ask"); if (!host) return;
   const card = host.querySelector(".ask-card") as HTMLElement | null; if (!card) return;
@@ -13462,46 +13417,10 @@ function insertClipboardText(text: string) {
   inp.dispatchEvent(new Event("input", { bubbles: true })); // keep liveTextValue/draft sync
   inp.focus();
 }
-// Safeguard: the session is awaiting input but the parser can't map the screen to
-// a known widget (an unrecognized prompt, a free-text editor, etc.). Warn loudly
-// so a prompt is never silently missed — and offer a best-effort text input in
-// case it IS a plain text prompt.
-function renderUnknownCard() {
-  const card = askCard("ask-live-unknown");
-  const warn = el("div", "ask-warn");
-  warn.textContent = "⚠ Waiting on a prompt the panel can’t read — answer it in the terminal.";
-  card.appendChild(warn);
-  // Free text goes through the NORMAL message box below now (composerAnswersAsk → "text" → askText); no
-  // separate inline input (the user 2026-07-09).
-  const hint = el("div", "ask-custom-hint-text");
-  hint.textContent = "…or, if it’s a text prompt, type it in the message box below + ⏎.";
-  card.appendChild(hint);
-}
-
 function paintLiveAskFocus() {
   const rows = document.querySelectorAll("#live-ask .ask-live-opt");
   rows.forEach((r, i) => r.classList.toggle("focus", i === liveAskFocus));
-  renderAskPreview();   // step the preview to the newly-focused option (instant for per-option SDK previews)
-  // tmux scrape path: the focused option has no preview of its own, but the ask carries the one scraped for
-  // the cursor row — so nudge the TERMINAL cursor onto this option, and the next scrape captures ITS preview.
-  // That's the only way to "see the other ones" without selecting (the user 2026-06-22). Debounced in
-  // navLiveAsk so a fast ↑↑↑ only drives the final option. SDK options carry their own preview → no nudge.
-  const ask = activeId ? liveAsks.get(activeId) : null;
-  if (ask && ask.kind === "single") {
-    const opts = singleOptions(ask);
-    const o = opts[Math.max(0, Math.min(liveAskFocus, opts.length - 1))];
-    if (o && !o.preview && ask.preview) navLiveAsk(o.n);
-  }
-}
-
-// Move the TUI cursor to `target` WITHOUT selecting, so the tmux-scraped preview follows ↑/↓. Debounced so
-// a fast keyboard sweep drives only the final option; NOT sendingGuard'd (it's navigation, not a commit).
-let navTimer: ReturnType<typeof setTimeout> | undefined;
-function navLiveAsk(target: number) {
-  if (!activeId || !vscodeApi) return;
-  const id = activeId;
-  if (navTimer) clearTimeout(navTimer);
-  navTimer = setTimeout(() => { navTimer = undefined; vscodeApi?.postMessage({ type: "navAsk", id, target }); }, 110);
+  renderAskPreview();   // step the preview to the newly-focused option (instant: every option carries its own)
 }
 
 // Single-select keyboard: ↑/↓ highlight (preview follows), Enter confirms, number jumps to + confirms.
@@ -13567,14 +13486,14 @@ function elapsedMs(sinceMs: number | null): string {
 }
 
 // Right side of the status line: "Opus 4.8 xhigh" (model + effort) — the context %
-// is shown separately as a battery bar (ctxBar). Sourced from the @claude-model /
-// @claude-effort / @claude-context tmux vars. Shown in EVERY state, not just working.
-// Each value is a little dropdown: picking an entry has the host inject the matching
-// /model or /effort slash command into the session's pane; the label then updates
-// when the TUI's statusline republishes the tmux vars (meta-pending bridges the gap).
+// is shown separately as a battery bar (ctxBar). Sourced from the session's own row
+// (the kernel publishes model, effort and context per session). Shown in EVERY state, not just working.
+// Each value is a little dropdown: picking an entry has the kernel apply the matching
+// /model or /effort setting to the session; the label then updates
+// when the session republishes the value (meta-pending bridges the gap).
 type MetaKind = "mode" | "model" | "effort" | "fast";
 // One dropdown entry. `sub` is the second line for a choice whose consequence is not obvious from its
-// label; `sdkOnly` drops the entry on a tmux session, whose backend cannot apply it.
+// label; `sdkOnly` drops the entry on a backend that cannot apply it (Codex).
 interface MetaChoice { label: string; value: string; sub?: string; sdkOnly?: boolean; color?: number[] | null;
   versions?: { label: string; value: string; learned?: boolean }[]; default?: string }   // model families only (the
   // user 2026-08-25). `default` is the family's remembered version pin, else the family ALIAS; `learned`
@@ -13655,11 +13574,9 @@ function modelChoiceLabel(value: string): { label: string; color?: number[] | nu
   }
   return { label: value };
 }
-// Permission mode. A tmux session has no slash command for it — the host cycles shift+tab the right
-// number of times (the user 2026-06-16) — so the four CYCLE modes are all that backend can reach.
-// An SDK session sets it outright over the control channel (set_permission_mode), which is what makes
-// Bypass offerable there and only there: on tmux the click would land on a mode the cycle cannot
-// express, and _cycle_mode would drop it. `sdkOnly` is the filter, applied in toggleMetaMenu.
+// Permission mode. A Claude Code session sets it outright over the control channel (set_permission_mode),
+// which is what makes Bypass offerable there and only there (a Codex session has its own vocabulary and
+// cannot express it). `sdkOnly` is the filter, applied in toggleMetaMenu.
 // Permission-mode GLYPHS (the user 2026-08-28): each mode gets a small line icon beside its text —
 // the statusline badge and the picker rows carry it, always WITH the label (an icon alone is a
 // riddle). House icon style (the tag-glyph convention): 16-unit viewBox, stroke currentColor 1.4,
@@ -13707,8 +13624,8 @@ const MODE_CHOICES: MetaChoice[] = [
 ];
 // Fast mode (the CLI's /fast — Opus-only research preview): a two-state toggle offered as the same
 // dropdown shape as the other badges. The badge exists only when the session REPORTS a fast state
-// (st.fast, from the SDK init's fast_mode_state) — a session that can't run it, or a tmux session
-// whose statusline doesn't publish it yet, shows no dead control. The options speak the BADGE's two
+// (st.fast, from the SDK init's fast_mode_state) — a session that doesn't report a fast state shows no
+// dead control. The options speak the BADGE's two
 // words — Fast/Slow, never On/Off (the user 2026-08-11: a badge reading "Slow" opened a menu of
 // "On"/"Off", two vocabularies for one toggle; prettyFast is the one wording, the values stay the
 // wire's on/off).
@@ -13791,8 +13708,8 @@ function isCurrentMeta(kind: MetaKind, st: Status, value: string): boolean {
   return (st.model || "").toLowerCase().startsWith(value);
 }
 
-// "<sessionId>:<kind>" → set when the user picks a value, cleared when the tmux
-// var actually changes (or after 20s, if the TUI rejected/ignored the command).
+// "<sessionId>:<kind>" → set when the user picks a value, cleared when the session
+// republishes the value (or after 20s, if the CLI rejected/ignored the command).
 const metaPending = new Map<string, { was: string; until: number }>();
 function isMetaPending(kind: MetaKind, st: Status): boolean {
   if (!activeId) return false;
@@ -13960,7 +13877,7 @@ function toggleMetaMenu(kind: MetaKind, btn: HTMLElement, forSid?: string | null
   };
   let subEl: HTMLElement | null = null;
   const closeSub = () => { subEl?.remove(); subEl = null; };
-  // An sdkOnly entry is dropped on tmux rather than shown-and-refused: the backend cannot apply it,
+  // An sdkOnly entry is dropped on Codex rather than shown-and-refused: the backend cannot apply it,
   // and a menu that lists a mode you can't have is worse than one that doesn't. Codex sessions read
   // their own vocabulary via metaChoices (docs/codex.md) before the same filter.
   const rows = metaChoices(kind, s.status).filter((c) => !c.sdkOnly || s.status.backend === "sdk");
@@ -16572,9 +16489,6 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
       kernelNativeDialogs = m.nativeDialogs;
       applyBrowseState(pickerHost());
     }
-    // the tmux backend's offer (T288): the LOCAL kernel's setting; the Backend row follows it while the picker
-    // is on screen (the reply lands after the open), and an older kernel that sends none leaves the row as it was
-    if (typeof m.tmuxBackend === "boolean" && !from) { kernelTmuxBackend = m.tmuxBackend; syncPickerBackends(); }
     // the selected host's billing choices ride its own list reply — this is what arms (or hides) the
     // picker's Billing row (the user 2026-08-08); an older kernel sends none and the row stays away
     pickerAuthAvail = (m.authAvail && typeof m.authAvail === "object") ? m.authAvail : null;
@@ -17315,7 +17229,7 @@ function setupComposer() {
 
   // ── slash-command autocomplete (the user 2026-06-29) ── a "/" at the START of the box opens a filterable,
   // arrow-navigable menu of THIS session's slash commands (name + description + arg hint), sourced from the
-  // kernel's /commands (the Agent SDK's get_server_info, per-cwd — works for tmux + SDK alike). Enter/Tab/click
+  // kernel's /commands (the Agent SDK's get_server_info, per-cwd, for every backend). Enter/Tab/click
   // FILLS "/name " so you add arguments then send yourself; Esc closes. The list is fetched per active session
   // and cached; while the kernel warms its (slow) probe the menu shows the romp loader. Modeled on the VS Code
   // client's command palette + the terminal UI.
@@ -18401,13 +18315,6 @@ setupSettings();
       b.disabled = true;
       b.textContent = "Retrying…";
       setTimeout(() => { if (b.isConnected) { b.disabled = false; b.textContent = "Retry now"; } }, 2500);
-    },
-    dismissDialog: (el) => {
-      const b = el as HTMLButtonElement;
-      if (vscodeApi) vscodeApi.postMessage({ type: "dismissDialog", id: owningSidOf(b) });
-      b.disabled = true;
-      b.textContent = "Dismissing…";
-      setTimeout(() => { if (b.isConnected) { b.disabled = false; b.textContent = "Dismiss dialog"; } }, 2500);
     },
     stopAllRetries: () => {
       globalRetryPaused = !globalRetryPaused;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5277,7 +5277,7 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   if (s.status.effort) rows.push(["Effort", s.status.effort]);
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
-  if (be === "sdk" || be === "codex") rows.push(["Backend", backendLabel(be)]);   // the shared names (T288)
+  if (be) rows.push(["Backend", backendLabel(be)]);   // the shared names (T288); a session still running on the retired terminal backend (until stage 3) reads its id, never blank (review find)
   // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
   // user 2026-08-09: shown whenever the backend reports it, one-auth machines included). No key material, ever.
   // When the CLI's own init landed on the OTHER side (authLive — say, a key found via apiKeyHelper

--- a/ui/webview/rewind-edit.test.ts
+++ b/ui/webview/rewind-edit.test.ts
@@ -18,7 +18,7 @@ test("the edit affordance renders only on bubbles the backend can address", () =
   // SDK backend only, newer than the last compaction, not an optimistic echo)
   assert.match(RENDER, /if \(!romp && !injected && ev\.uuid && editSid\s*\n\s*&& \(sessions\.get\(editSid\) as any\)\?\._editable\?\.has\(ev\.uuid\)\)/);
   // the set is computed by rewind-reconcile.ts (executed there); render.ts hands it the backend and the echo prefix
-  assert.match(RENDER, /sdk: s\.status\?\.backend === "sdk", now: Date\.now\(\), ttlMs: REWIND_TTL_MS, optPrefix: OPT_PREFIX/);   // tmux sessions get no edit affordance; echoes are excluded
+  assert.match(RENDER, /sdk: s\.status\?\.backend === "sdk", now: Date\.now\(\), ttlMs: REWIND_TTL_MS, optPrefix: OPT_PREFIX/);   // a Codex session gets no edit affordance; echoes are excluded
   const PASS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "rewind-reconcile.ts"), "utf8");
   assert.match(PASS, /if \(events\[i\]\.kind === "compact"\) lastCompact = i;/);   // pre-compaction bubbles excluded
   assert.match(PASS, /!e\.uuid\.startsWith\(opts\.optPrefix\)/);              // optimistic echoes excluded

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -40,7 +40,7 @@ import { markerLabel } from "./time-marker";
 // position: a send parked in the kernel's own queue (compaction, a usage-limit hold) had no id at all until
 // the drain, and text cannot tell a press-time copy from a same-text copy another client queued later. Where
 // the frame shows the id NOWHERE (the kernel has not received the send yet; a kernel that mints its own; the
-// tmux route, whose copies carry none), text and order decide for that push, exactly as before ids existed.
+// whose copies carry none), text and order decide for that push, exactly as before ids existed.
 //
 // THE ANCHOR (2026-09-06 review): every decision is read from the events AFTER the send, never from a
 // count of tail events. At the first reconcile after the press the entry records the uuid of the last
@@ -82,7 +82,7 @@ export type PendingSend = {
                        //   queued copy, its echo atom (whose uuid IS the id) and the landed atom's qid/qids wear it, so
                        //   the landing, the cover and the hidden copy are decided by id wherever the frame shows it (an
                        //   event that carries an id is ours only if it carries THIS one); an event without an id (an
-                       //   older kernel, tmux) and a push in which the frame carries this id nowhere decide by text
+                       //   older kernel) and a push in which the frame carries this id nowhere decide by text
   cover?: string;      // the id of the kernel's queued copy that covered this send BY TEXT on the last push: the kernel
                        //   identifies that copy otherwise (an older kernel minted its own id for it), so a ✕ on that copy
                        //   is a ✕ on this send (dropPending). Re-read every push and cleared where the cover is by id
@@ -285,7 +285,7 @@ const namesSend = (e: TailEvent, qid: string | undefined): boolean =>
  *  read this send's own echo as background (our dashed bubble beside the kernel's echo until the landing;
  *  a never-delivered verdict that never ended the bubble) and its own landing as its anchor (a bubble
  *  that never ended). Below the first event that names the send, and throughout a frame that names it
- *  nowhere, the stamp bound decides as before for records that carry no id (an older kernel, the tmux
+ *  nowhere, the stamp bound decides as before for records that carry no id (an older kernel
  *  route) or another send's id. The bound is confined to the late stamp because that is the only stamp
  *  that can meet the send's own records, and because at a press-time stamp it could only misfire (an
  *  identical message that landed within the press's second would read as this send's). */
@@ -360,7 +360,7 @@ export type Reconciled = {
  *  Identity first (T252c): every send carries the id it was pressed with (newPending), and the kernel's copies
  *  of it wear that id (the queued copy's `qid`, the echo's uuid, the landed atom's `qid`/`qids`), so landing,
  *  cover and loss are decided by the id wherever the frame shows it. Text and order remain the reading for
- *  copies the kernel gave no id (an older kernel, the tmux route, a notice it queued itself) and for a push
+ *  copies the kernel gave no id (an older kernel, a notice it queued itself) and for a push
  *  in which the frame carries the send's id nowhere (the kernel has not received it yet, or minted its own);
  *  the COUNT of confirmed sends is then what the kernel's records support. Nothing latches: an id a kernel
  *  copy wears that is not this send's is another send's, whatever its text says.
@@ -547,7 +547,7 @@ export function dropPending(list: PendingSend[], text: string, ts?: number, qid?
 /** Which copy of `text` in a kernel queued group the caller hides for a send drawn at its own slot: the NEWEST
  *  copy not already hidden (the group lists the queue in order; ours is the latest press with that text), or -1
  *  when there is none — including when the only copies are ones the kernel marked cancelable:false (no recall
- *  exists there: a tmux queue). That copy stays the one bubble shown, with its honest tooltip, and ours is
+ *  exists there: the session's own queue). That copy stays the one bubble shown, with its honest tooltip, and ours is
  *  suppressed as before: hidden behind our bubble's ✕ it offered a cancel the kernel would refuse (review of the
  *  first cut). */
 export function queuedCopyToHide(texts: { md?: string; cancelable?: boolean; hiddenByPending?: boolean; optimistic?: boolean; qid?: string }[], text: string, qid?: string): number {

--- a/ui/webview/settings.test.ts
+++ b/ui/webview/settings.test.ts
@@ -25,8 +25,18 @@ test("both judge-set toggles default OFF (the user 2026-06-29): the timeline's j
   assert.equal(DEFAULT_SETTINGS.showTriageJudges, false);
 });
 
-test("Default backend defaults to sdk (the user 2026-07-13, superseding the 06-22 tmux default); both backends coexist", () => {
+test("Default backend defaults to sdk (the user 2026-07-13); Claude Code and Codex coexist", () => {
   assert.equal(DEFAULT_SETTINGS.backend, "sdk");
+});
+
+test("a saved default of the retired terminal backend reads as sdk, never an undefined value (T331)", () => {
+  localStorage.setItem("romp:settings", JSON.stringify({ ...DEFAULT_SETTINGS, backend: "tmux" }));
+  assert.equal(loadSettings().backend, "sdk");
+  localStorage.setItem("romp:settings", JSON.stringify({ ...DEFAULT_SETTINGS, backend: "nonsense" }));
+  assert.equal(loadSettings().backend, "sdk", "any value no longer offered reads as the default");
+  localStorage.setItem("romp:settings", JSON.stringify({ ...DEFAULT_SETTINGS, backend: "codex" }));
+  assert.equal(loadSettings().backend, "codex", "an offered pick stands");
+  saveSettings({ backend: "sdk" });
 });
 
 test("Compact transcript defaults ON (the user 2026-07-14): fresh installs read the tidy transcript", () => {

--- a/ui/webview/settings.ts
+++ b/ui/webview/settings.ts
@@ -1,3 +1,4 @@
+import { effectiveDefaultBackend } from "./backend-names";
 // Shared, persisted webview settings (the user 2026-06-14): one global settings store, surfaced via a
 // gear → modal. localStorage-backed so same-origin views (the browser's /chat, /feed, /timeline tabs)
 // share ONE setting, and a `storage` event live-syncs a change across the other open tabs. Keep this
@@ -13,7 +14,7 @@ export interface RompSettings {
   showIndexJudges: boolean;
   showTriageJudges: boolean;
   debug?: boolean;    // LEGACY (the user 2026-06-17): the old single judging-band toggle; read as the migration fallback for the two judge-set toggles when those are unset. The ↻ restart button is always-visible (decoupled).
-  backend: "tmux" | "sdk" | "codex";   // which backend a NEWLY-created session uses (the user 2026-06-22): "tmux" (terminal), "sdk" (Agent SDK), "codex" (OpenAI Codex, docs/codex.md). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
+  backend: "sdk" | "codex";   // which backend a NEWLY-created session uses (the user 2026-06-22): "sdk" (Claude Code through the Agent SDK), "codex" (OpenAI Codex, docs/codex.md); a stored value of the retired terminal backend reads as sdk (loadSettings). Both coexist; this is only the default for the + button. Read at createSession time (render.ts). Default sdk (the user 2026-07-13).
   defaultDir: string;        // default working directory PREFILLED in the new-session field (the user 2026-06-22). A session starts there; the tab menu's "Move to folder…" can change it later. Empty → the kernel's serve dir. ~ / $VAR expanded server-side.
   showBranch: boolean;       // chat bottom-bar: show the session's git branch (if any) beside the dir (the user 2026-06-23). OFF by default (the user 2026-08-10, trimming the statusline for narrow panes; an explicit stored true keeps showing it).
   showSessionBadge: boolean; // chat bottom-bar: a small badge with the session's NAME on its identity colour before Awaiting / Ready / Working (session-badge.ts). OFF by default (the maintainers via the user, 2026-09-10: the composer's placeholder already names the session; the badge is an opt-in second reading of it where the state shows).
@@ -87,6 +88,7 @@ export function loadSettings(): RompSettings {
       delete (s as Record<string, unknown>).filesControl;   // the T317-era key (merged in by that gear's whole-object save): never read, gone on the next save
       s.chatScheme = chatScheme(s.chatScheme);   // unknown/legacy values normalize to "default"
       s.panes = paneSet(s.panes);   // every optional pane present; only an explicit false hides one
+      s.backend = effectiveDefaultBackend(s.backend);   // a saved default of the retired terminal backend (or any unknown value) reads as Claude Code, never undefined (T331)
       // theme migration (2026-08-28): a store from before `theme` existed seeds it from the old
       // tab-strip pick, so a yatharth strip stays a yatharth strip. chatTabTheme itself is DERIVED
       // from theme ever after (one axis of truth; older readers keep working off the alias).

--- a/ui/webview/slash-commands.test.ts
+++ b/ui/webview/slash-commands.test.ts
@@ -1,6 +1,6 @@
 // Slash-command autocomplete (the user 2026-06-29): typing "/" at the start of the composer opens a
 // filterable, arrow-navigable menu of the session's slash commands (name + description + arg hint), sourced
-// from the kernel's /commands (the Agent SDK's get_server_info — works for tmux + SDK alike). Enter/Tab/click
+// from the kernel's /commands (the Agent SDK's get_server_info — for every backend). Enter/Tab/click
 // FILLS "/name " so the user adds args then sends. Source-level pins (no jsdom for the chat renderer).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -735,8 +735,8 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 
 .tab-close { opacity: 0; font-size: 1.1em; line-height: 1; padding: 0 2px; border-radius: 3px; color: var(--dim); }
 .tab:hover .tab-close { opacity: 0.7; }
-/* Rich tab hover tooltip (the user 2026-06-23): backend BOLD in its own colour (sdk=blue, tmux=green), the
-   full directory path, then mode / model / effort / context, each on its own line. Custom DOM (a native
+/* Rich tab hover tooltip (the user 2026-06-23): the backend a plain labelled field row (no per-backend colour),
+   the full directory path, then mode / model / effort / context, each on its own line. Custom DOM (a native
    title can't colour/bold). */
 .tab-tip {
   position: fixed; z-index: 70; display: none; pointer-events: none;
@@ -1516,7 +1516,7 @@ button.chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 1p
 }
 .meta-btn:hover { background: rgba(255, 255, 255, 0.08); color: var(--fg); }
 .meta-caret { font-size: 0.82em; opacity: 0.65; }
-/* waiting for the TUI to confirm the change (tmux var not republished yet) */
+/* waiting for the session to republish the value after a pick */
 .meta-pending .meta-label { opacity: 0.5; animation: meta-pulse 1.1s ease-in-out infinite; }
 @keyframes meta-pulse { 50% { opacity: 1; } }
 /* a /model switch resolving: three accent-blue dots IN the badge until the new name lands (the user
@@ -2931,7 +2931,7 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-dir-row:hover { background: rgba(255, 255, 255, 0.08); }
 .picker-dir-row.active { background: var(--accent-wash); color: var(--accent); }
 .picker-dir-more { padding: 4px 10px; color: var(--dim); font-size: 0.82em; }
-/* per-session backend toggle in the + dialog (the user 2026-06-23): a tmux | SDK segmented control */
+/* per-session backend toggle in the + dialog (the user 2026-06-23): a Claude Code | Codex segmented control */
 .picker-backend { display: flex; align-items: center; gap: 6px; padding: 6px 14px 8px; }
 .picker-backend-label { flex: 0 0 auto; color: var(--dim); font-size: 0.82em; margin-right: 2px; }
 .picker-be-opt {
@@ -2952,9 +2952,6 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-tags .picker-be-opt { padding: 0; border: none; background: transparent; font-family: inherit; }
 .picker-tags .picker-be-opt:hover, .picker-tags .picker-be-opt.sel { background: transparent; border-color: transparent; color: inherit; }
 .picker-tags .picker-be-opt:hover { filter: brightness(1.3); }
-/* the tmux pick: the chips stay in place, disabled, behind the note (tags apply to SDK and Codex sessions). Greyed
-   and nothing else: the off chip's own 0.45 stays the only fade, so on and off still read in both themes */
-.picker-tags.disabled .picker-be-opt { filter: grayscale(1); cursor: default; pointer-events: none; }
 .picker-list { overflow-y: auto; }
 /* The resume list's heading (the user 2026-08-12): the list sits LAST in the dialog — typing in the
    name box re-filters it, and its changing height used to jump every control below it — so this line

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -29,8 +29,8 @@ test("the tab tooltip is a custom DOM tooltip shown on hover, not a native title
 });
 
 test("backend is a plain labelled FIELD ROW under the others — no coloured top badge (the user 2026-07-08)", () => {
-  // it's just another "Backend: Claude Code | Claude Code (tmux) | Codex" row alongside Branch/Mode/Model/Effort, not a
-  // bold coloured badge; the names come from backend-names.ts (T288), so a tmux session keeps its label whatever the offer says
+  // it's just another "Backend: Claude Code | Codex" row alongside Branch/Mode/Model/Effort, not a
+  // bold coloured badge; the names come from backend-names.ts (T288)
   assert.match(RENDER, /rows\.push\(\["Backend", backendLabel\(be\)\]\)/);
   assert.doesNotMatch(RENDER, /"tab-tip-be"/, "no dedicated backend-badge element");
   assert.doesNotMatch(RENDER, /be === "tmux" \? "#54B204" : "#1EA1EB"/, "no per-backend colour on the tooltip");

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -31,7 +31,7 @@ test("the tab tooltip is a custom DOM tooltip shown on hover, not a native title
 test("backend is a plain labelled FIELD ROW under the others — no coloured top badge (the user 2026-07-08)", () => {
   // it's just another "Backend: Claude Code | Codex" row alongside Branch/Mode/Model/Effort, not a
   // bold coloured badge; the names come from backend-names.ts (T288)
-  assert.match(RENDER, /rows\.push\(\["Backend", backendLabel\(be\)\]\)/);
+  assert.match(RENDER, /if \(be\) rows\.push\(\["Backend", backendLabel\(be\)\]\);/, "every backend the kernel names gets its row: a session still running on the retired terminal backend reads its id (T331 review)");
   assert.doesNotMatch(RENDER, /"tab-tip-be"/, "no dedicated backend-badge element");
   assert.doesNotMatch(RENDER, /be === "tmux" \? "#54B204" : "#1EA1EB"/, "no per-backend colour on the tooltip");
   assert.doesNotMatch(CSS, /\.tab-tip-be \b/, "the badge's CSS rule is gone");

--- a/ui/webview/tab-groups.test.ts
+++ b/ui/webview/tab-groups.test.ts
@@ -315,34 +315,19 @@ test("row hairlines count section headers as row members (T134's floating look m
   assert.doesNotMatch(painter, /tab-group-sep|tab-group-break/);
 });
 
-test("the picker's Tags row is for SDK and Codex sessions: disabled behind a note on the tmux pick, and no `tags` ride a tmux create", () => {
-  // the kernel refuses tags on a tmux create (a terminal session's id is unknown until it starts);
-  // the row, prefilled from a tagged active tab, used to turn every terminal create into a refusal.
-  // A Codex create takes them (the kernel applies parent/tags on one since the upstream fold's round
-  // 2), so the row and the payload follow ONE predicate — executed here on each backend name
-  const pred = RENDER.match(/function backendTakesTags\(be: string\): boolean \{ (return [^}]*); \}/);
-  assert.ok(pred, "one predicate decides which backend a chip is for");
-  const takes = new Function("be", pred![1]) as (be: string) => boolean;
-  assert.equal(takes("sdk"), true);
-  assert.equal(takes("codex"), true, "a Codex create takes tags");
-  assert.equal(takes("tmux"), false, "a terminal session's id is unknown until it starts");
-  assert.equal(takes(""), false);
+test("the picker's Tags row is live for every offered backend, and the create always carries the selected chips (T331)", () => {
+  // the terminal backend, whose create took no tags, is no longer offered: no disabled state, no note, one payload
+  assert.doesNotMatch(RENDER, /backendTakesTags|picker-tags-note/, "the predicate and the note went with the tmux pick");
+  const sync = RENDER.slice(RENDER.indexOf("function syncPickerTags("), RENDER.indexOf("function syncPickerAuth("));
+  assert.match(sync, /\.forEach\(\(b\) => \{ b\.disabled = false; \}\);/, "every chip stays live");
+  assert.doesNotMatch(sync, /classList\.toggle\("disabled"/);
+  assert.match(RENDER, /const tags = Array\.from\(tgWrap\.querySelectorAll<HTMLElement>\("\.picker-be-opt\.sel"\)\)\.map\(\(x\) => x\.dataset\.tag \|\| ""\)\.filter\(Boolean\);/,
+    "the create handler sends the selected chips for every backend");
   assert.match(KERNEL, /_create_codex_session\(nm, cwd, client=client,\s+parent=psid or "", tags=ctags\)/,
     "the premise: the kernel's createSession op applies tags on a Codex create");
-  const sync = RENDER.slice(RENDER.indexOf("function syncPickerTags("), RENDER.indexOf("function syncPickerAuth("));
-  assert.match(sync, /const takes = backendTakesTags\(pickerBackendChoice\(\)\);/);
-  assert.match(sync, /wrap\.classList\.toggle\("disabled", !takes\);/);
-  assert.match(sync, /\.forEach\(\(b\) => \{ b\.disabled = !takes; \}\);/);
-  assert.match(sync, /note\.style\.display = takes \? "none" : "";/);
-  assert.match(RENDER, /tgNote\.textContent = `Tags apply to \$\{backendLabel\("sdk"\)\} and \$\{backendLabel\("codex"\)\} sessions`;/, "the shared names (T288)");
-  assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => \{ syncPickerAuth\(\); syncPickerTags\(\); \}\);/, "re-decided on every backend toggle");
-  assert.match(RENDER, /syncPickerTags\(\);\s+\/\/ the backend toggle was just reset/, "…and on every open, after the backend reset");
-  assert.match(RENDER, /const tags = backendTakesTags\(backend\)\s*\n\s*\? Array\.from\(tgWrap\.querySelectorAll<HTMLElement>\("\.picker-be-opt\.sel"\)\)/,
-    "the create handler sends none for tmux, through the same predicate");
-  assert.doesNotMatch(RENDER, /const tags = backend === "sdk"/, "no second, SDK-only copy of the rule");
+  assert.match(RENDER, /beWrap\.addEventListener\("click", \(\) => \{ syncPickerAuth\(\); syncPickerTags\(\); \}\);/, "re-painted on every backend toggle");
   assert.match(RENDER, /:not\(\.picker-host\):not\(\.picker-auth\):not\(\.picker-tags\) \.picker-be-opt\.sel/, "a selected tag chip never reads as the backend pick");
-  assert.match(CSS, /\.picker-tags\.disabled \.picker-be-opt \{ filter: grayscale\(1\); cursor: default; pointer-events: none; \}/,
-    "greyed, not faded: the off chip keeps its own 0.45 as the only fade (T321)");
+  assert.doesNotMatch(CSS, /\.picker-tags\.disabled/, "the greyed-row rule is gone with the state");
 });
 
 test("headers are click-safe: data-act on the node, the action on the stable #tabs delegate, one render path via the event", () => {

--- a/ui/webview/tab-move.test.ts
+++ b/ui/webview/tab-move.test.ts
@@ -17,10 +17,9 @@ test("the tab menu carries a Move to folder… row beside Rename that opens the 
   assert.match(menu, /l\.textContent = "Rename"/);
   assert.match(menu, /l\.textContent = "Move to folder…"/);
   assert.match(menu, /dismissTabMenu\(\); showMovePrompt\(id\);/);
-  // a terminal session has no relocation primitive: the row says so and takes no click
-  assert.match(menu, /const isTmux = !!\(sTm && sTm\.status && sTm\.status\.backend === "tmux"\);/);
-  assert.match(menu, /if \(!isTmux\) mv\.addEventListener\("click"/);
-  assert.match(menu, /terminal sessions can't move/);
+  // every session moves (T331: the terminal backend, which had no relocation primitive, is no longer offered)
+  assert.match(menu, /mv\.addEventListener\("click", \(ev\) => \{ ev\.stopPropagation\(\); dismissTabMenu\(\); showMovePrompt\(id\); \}\);/);
+  assert.doesNotMatch(menu, /isTmux|terminal sessions can't move|ctx-item-off/, "no greyed state, no note");
 });
 
 test("the dialog posts moveSession with the typed folder and acknowledges before the round trip", () => {

--- a/ui/webview/undelivered-err.test.ts
+++ b/ui/webview/undelivered-err.test.ts
@@ -1,5 +1,5 @@
 // The kernel's LOUD channel (the user 2026-07-29). An op naming a session this kernel doesn't have used to
-// degrade into a no-op — the tmux backend typed at a pane that wasn't there — so typed messages vanished with
+// degrade into a no-op — a send with nothing behind it — so typed messages vanished with
 // no bubble, no error and no record. The kernel now refuses and emits `err`; this pins the two panes that can
 // fire such an op rendering it as a DIALOG rather than a fading toast, and handing the text back.
 //

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,6 +1,6 @@
 // The romp VS Code extension — a THIN CLIENT of the romp web kernel.
 //
-// All host logic (transcript parsing, session mirroring, the feed fold, tmux
+// All host logic (transcript parsing, session mirroring, the feed fold,
 // driving, record-file IO) lives in the kernel (bin/romp-kernel, spawned via
 // bin/romp-serve). This extension only:
 //   1. ensures a kernel is running (spawn-or-attach on the default port,

--- a/vscode-extension/src/fleet-status.test.ts
+++ b/vscode-extension/src/fleet-status.test.ts
@@ -1,5 +1,5 @@
 // The status bar / needs-you notification decision core: derived from the
-// kernel's {type:"feed"} frames only (no polling, no tmux heuristics).
+// kernel's {type:"feed"} frames only (no polling).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import { deriveStatus, freshNeedsYou, needsYouAsks, renderStatusBar, statusTooltipLines } from "./fleet-status";

--- a/vscode-extension/src/pipe-intent.ts
+++ b/vscode-extension/src/pipe-intent.ts
@@ -15,7 +15,7 @@ export const INTENT_OPS: ReadonlySet<string> = new Set([
   "setModel", "setEffort", "setMode", "setFast", "setAuth",
   "renameSession", "moveSession", "endSession", "reviveSession",
   "nodeOverride", "askClear", "undoClear", "cardMove", "cardNotify", "redistill",
-  "answerAsk", "submitAsk", "toggleAsk", "navAsk", "cancelAsk",
+  "answerAsk", "submitAsk", "toggleAsk", "cancelAsk",
   "setSessionFlag", "setSessionColor", "setGlobalRetryPaused", "setTimelineViews", "tagEdit", "openTagsDialog",
   // the REMOTE-tag edit (a tag homed on another kernel). Dropped with the view chatter it was simply
   // lost: the reconnect's reload wipes the pane's optimistic mirror too, and the resynced pane showed


### PR DESCRIPTION
## Summary

Stage 2 of the tmux backend's removal (the user's ruling, 2026-09-10): the dashboard stops offering the terminal backend. The kernel side (the backend itself, its setting and the wire fields) goes in stage 3; this change is UI-only and touches no SDK file.

## What changes

**The + picker.** The Backend row offers Claude Code and Codex; the third toggle and its tooltip are gone, and no offer switch rides the sessionList reply any more (the reply's field is ignored until stage 3 stops sending it). The Tags row is never disabled: both offered backends' creates take tags, so the note, the greyed state and its CSS rule go, and the create handler always sends the selected chips.

**The gear.** The "Enable Claude Code tmux backend" row and its paragraph are gone from Updates and debug, with the set-aside note, the offer painter, the two map entries and the paint-list tuple. The Default backend select is static (Claude Code, Codex) and painted from the saved preference through the shared rule once at init and on every open, where the facade repaint that the offer painter used to make now lives.

**A saved default of tmux reads as Claude Code, never undefined.** `effectiveDefaultBackend` maps any value no longer offered to `sdk`; `loadSettings` applies it, so every reader sees a valid value, and the gear's next save drops the retired one.

**The chat.** The tab menu's Move to folder row is enabled for every session (the terminal note goes); the API-error card's spend-cap arm appends no Dismiss dialog button (the raise-the-cap line stays), and the body delegate's handler for it goes; the live-ask picker loses the cursor-nudge round trip (every option carries its own preview) and the "answer it in the terminal" card (the kernel pushes a typed ask or clears); the tab tooltip's Backend row names Claude Code or Codex. The extension's piped-intent list drops `navAsk`.

**The API-health hover** no longer draws the "N tmux sessions are seen through their transcripts only" line; the frame's count stays on the wire until the kernel side goes.

**The timeline view.** The empty state reads "No romp activity." without the tmux clause. The direct tmux shell fallbacks (`_compactSession`, `_sendCommand`, `_tmuxPath`) are replaced by the kernel's own HTTP routes through the panel's existing `_kernelPost`: `POST /compact` and `POST /send`, the doors `romp compact` and `romp send` use, where a typed /model, /effort or /fast takes the kernel's setters. Bare Obsidian keeps a transport for /compact and the slash sends; the VS Code host hook path is unchanged. The bare-command limit of the HTTP route is documented in the function's comment.

**Kept until stage 3:** federation.ts's `setTmuxBackend` fan-out entry is removed from the UI op list (the gear no longer posts it), while the kernel's setting, `tmuxBackend` on the sessionList reply and the `tmux` count on the frame stay on the kernel side.

## Tests

- Deleted: the picker's tmux-offer test, the offer half of backend-names, the two tmux tests of dismiss-dialog, the Tags-row disabled test in tab-groups, the tmux-pick test in picker-tag-chips, the cursor-nudge test in ask-keyboard.
- Re-pinned: picker-backend (two options, no offer switch), backend-names (two names, the saved-default migration incl. `nonsense` and the retired id, the gear's static select painted through the shared rule), dismiss-dialog (no button, no handler), tab-groups and picker-tag-chips (the row always live), ask-keyboard (no nudge, no card), auth-selector, render-settings, picker-dir, tab-move (an always-clickable row), apierror-refusal, gear, settings (the migration case), tab-backend-tooltip, gear-judge-fast-browser, notice, apierror-retry-now, comments (the parity bundle re-anchored on the Retry handler), timeline-views-panel and timeline-compact (the kernel routes, no shell-out).
- Python: `tests/test_kernel_settings_sections.py` (two options, no switch, the init paint), `tests/test_tag_chips_everywhere_browser.py` (the picker offers two backends, the row is never disabled), `tests/test_api_health_hover.py`, `tests/test_api_health_rail.py` and `tests/test_api_health_hover_browser.py` (no coverage line).

## SDK boundary

`git diff --stat upstream/main | grep -c 'kernel/sdk_backend.py'` reads 0, and the same for `bin/romp_sdk_backend.py`.

## Docs

`docs/guide.md` (the backends list) and `docs/reference.md` (the Session backends setting) say the dashboard no longer offers the terminal backend and that a saved default of it reads as Claude Code.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
