### PR TITLE
A block addressed to a peer is a peer wait, not the user's needs-you: the judges read the addressee from evidence and file the awaiting-a-peer stamp in its place, the kernel relays a never-mailed question to the delegating peer (T334)

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -247,7 +247,13 @@ pending relay whose wait ended another way is withdrawn from the far host's
 outbox, and one the judge retired while it was parked is recalled the same
 way (the recall rides its own queue entry beside the marker's, the boot pass
 re-queues a node that owes one, and a recall nobody answers is asked once per
-hold for a while and then once per half hour, said both times); a parked
+hold for a while and then once per half hour, said both times; every queue
+entry carries a token of its own that the spend's re-read compares, so a
+fresh entry flushed over the path during a pass is never taken for the spent
+one; a question the far host carried on before it could be withdrawn, or one
+the host could not be reached to withdraw, leaves a note on the node that the
+brief, the card and the modal show beside the block until a later relay
+reaches the peer); a parked
 question completes only on the far
 host's delivered row, never on a later message; a refused relay's note reaches
 the card's brief beside the question it could not carry; a dead worker's block is not relayed; each record lands

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -215,19 +215,36 @@ reply the lift); an already-blocked node is unblocked by romp first. When the
 worker never mailed that peer, nothing could end the wait, so the kernel RELAYS
 it: the block's why goes to the delegating peer as the worker's own question
 (kind question, from the worker, "<worker> cannot move further: <why>", marked
-relayed in the row, the header and the inbox's bookkeeping comment), once per
-block off a marker the judge
-leaves on the node and an entry the judge writes to a queue directory once the
-store is saved (one file per entry, so the two writers never rewrite each
-other's list), so the reply lifts the stamp and the reminder ladder covers it;
-a wait that ended before the tick is never relayed, a far-host relay stays
-pending until it lands or comes back, and a refusal the bus cannot retry (no
-live recipient, a bounced parked message) reverts the node to your block with
-the refusal in its why, since nobody can be asked. A block filed again after
-the peer's reply ended the wait relays again; a block re-asserted on a
-standing wait never does. A top is attributed to the delegate mail its anchor
-names, so a worker two managers dispatched relays each block to the manager
-that asked.
+relayed in the row, the header and the inbox's bookkeeping comment, on a far
+host too), once per block off a marker the judge leaves on the node (each
+marker has an identity that its queue entry and the record settling it name,
+and the node remembers the markers it settled, so a block filed again with
+the same words after a lift is a new marker nothing older can settle, and a
+holder stale across two relays never re-mints the first; two holders that
+mint a marker for one wait converge on the published one) and an entry the
+saver holding the store writes to a queue directory once its own publish
+carried the marker (one file per entry, so the two writers never rewrite
+each other's list; another holder's save of the same session flushes nothing
+of it; an entry whose node carries a newer marker is rewritten for it; an
+entry whose marker is gone with no record is spent once the store's
+published revision passed the entry's; the boot pass re-queues a marker that
+lost its entry; a pass that changed nothing is not repeated until the store,
+the log or the entries move), so the reply lifts the stamp and the reminder
+ladder covers it; a wait that ended before the tick is never relayed, a relay
+the bus handed to a far host (parked, or in flight to a host that is up)
+stays pending by its id up to the far host's delivered row or the peer's
+answer (the pending stamp survives every holder's save), and a refusal the
+bus cannot retry (no live recipient, a message that came back, with the far
+host's reason) reverts the node to your block with the refusal in its why,
+since nobody can be asked; each record lands before its entry is spent. A
+block filed again after the peer's reply ended the wait relays again; a block
+re-asserted on a standing wait never does. A top is attributed to the
+delegate mail its anchor names (the delegate-kind marker of the delivery that
+is a dispatch to this session, never one quoted from another session's, so a
+batched inbox whose first mail is a peer's heads-up still belongs to the
+manager whose dispatch follows it; a stamp naming no such dispatch leaves the
+latest delegate as the fallback), so a worker two managers dispatched relays
+each block to the manager that asked.
 An open question to a peer the block never names does not capture a block in
 the delegator's work: that block goes to the delegator, relayed. Rows filed before the rule convert once per boot. The debt ladder judges a debtor's
 reminder only at an idle turn end (the nudge walk's own gates); for a manager

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -245,8 +245,10 @@ bounce's own time, so a follow-up of yours between the bounce and the tick
 outranks it; the refusal is noted beside the block, never in its words); a
 pending relay whose wait ended another way is withdrawn from the far host's
 outbox, and one the judge retired while it was parked is recalled the same
-way (its entry is never spent while the recall is owed, and the boot pass
-re-queues a node that owes one); a parked question completes only on the far
+way (the recall rides its own queue entry beside the marker's, the boot pass
+re-queues a node that owes one, and a recall nobody answers is asked once per
+hold for a while and then once per half hour, said both times); a parked
+question completes only on the far
 host's delivered row, never on a later message; a refused relay's note reaches
 the card's brief beside the question it could not carry; a dead worker's block is not relayed; each record lands
 before its entry is spent; a send the bus answered late is never repeated

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -194,6 +194,48 @@ turn. Its diary events carry src `closer`, so planner and closer verdicts
 stay distinguishable, and both defer to the user floor: a verdict computed
 from evidence at or before your last reply loses.
 
+A block addressed to a peer is a peer wait, not your needs-you (the user
+2026-09-10, via the philosophy: waiting on a peer or another session is not
+you being the bottleneck). Both judges file blocks through one writer that
+reads the addressee from evidence, never from words alone: the session's own
+open question to a live peer (the wait graph's source), failing that the peer
+that delegated the work the block sits under (the courier-planted top's
+origin when present; else the sender of the delegate mail the session received
+before the goal was minted, the primary record, and only for a top the latch
+has read as a machine record: a goal you typed keeps its blocks, and a script
+mailer's pseudo-sid is never a peer), and words only to pick among
+several open asks; a block on a
+"delegated to <peer>" tracker waits on that peer, whose report ends the
+delegate edge. A block in a
+delegated goal whose text names you still goes to the delegating manager, who
+relays; a worker's card reaches you only through the debt ladder's escalation
+event. The write is the existing awaiting-a-peer stamp in place of the block
+(the "Awaiting <peer>" chip in Working, the auto-nudge skipping it, the peer's
+reply the lift); an already-blocked node is unblocked by romp first. When the
+worker never mailed that peer, nothing could end the wait, so the kernel RELAYS
+it: the block's why goes to the delegating peer as the worker's own question
+(kind question, from the worker, "<worker> cannot move further: <why>", marked
+relayed in the row, the header and the inbox's bookkeeping comment), once per
+block off a marker the judge
+leaves on the node and an entry the judge writes to a queue directory once the
+store is saved (one file per entry, so the two writers never rewrite each
+other's list), so the reply lifts the stamp and the reminder ladder covers it;
+a wait that ended before the tick is never relayed, a far-host relay stays
+pending until it lands or comes back, and a refusal the bus cannot retry (no
+live recipient, a bounced parked message) reverts the node to your block with
+the refusal in its why, since nobody can be asked. A block filed again after
+the peer's reply ended the wait relays again; a block re-asserted on a
+standing wait never does. A top is attributed to the delegate mail its anchor
+names, so a worker two managers dispatched relays each block to the manager
+that asked.
+An open question to a peer the block never names does not capture a block in
+the delegator's work: that block goes to the delegator, relayed. Rows filed before the rule convert once per boot. The debt ladder judges a debtor's
+reminder only at an idle turn end (the nudge walk's own gates); for a manager
+debtor the record also stands while delivered mail waits unread in its inbox,
+so a manager with worker mail queued is not yet failing to answer. Any other
+peer keeps the ladder as it was, and the dead-man backstop still applies. A block nothing
+resolves to a peer stays yours, exactly as before.
+
 **unblocker.** The stale-block backstop; it exists because answers arrive
 in passing and work overtakes asks. A goal blocked on a question is only
 ever unblocked by work filed on that exact node, but the answer usually

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -215,13 +215,16 @@ reply the lift); an already-blocked node is unblocked by romp first. When the
 worker never mailed that peer, nothing could end the wait, so the kernel RELAYS
 it: the block's why goes to the delegating peer as the worker's own question
 (kind question, from the worker, "<worker> cannot move further: <why>", marked
-relayed in the row, the header and the inbox's bookkeeping comment, on a far
-host too), once per block off a marker the judge leaves on the node (each
-marker has an identity that its queue entry and the record settling it name,
-and the node remembers the markers it settled, so a block filed again with
-the same words after a lift is a new marker nothing older can settle, and a
-holder stale across two relays never re-mints the first; two holders that
-mint a marker for one wait converge on the published one) and an entry the
+relayed in the row and the header, on a far host too, the row naming the
+marker so a send whose record was lost is adopted and never repeated; a why
+that speaks romp is scrubbed to the question, and romp's own procedural whys
+ride as the plain lead-in alone), once per block off a marker the judge
+leaves on the node (each marker has an identity, the block's evidence time
+and the peer, that its queue entry and the record settling it name, and the
+node remembers the markers it settled, so a block filed again after a lift is
+a new marker nothing older can settle, an ended wait's unsent marker is never
+reused for a new wait, a holder stale across two relays never re-mints the
+first, and two holders filing one wait mint one marker) and an entry the
 saver holding the store writes to a queue directory once its own publish
 carried the marker (one file per entry, so the two writers never rewrite
 each other's list; another holder's save of the same session flushes nothing
@@ -236,9 +239,13 @@ stays pending by its id up to the far host's delivered row or the peer's
 answer (the pending stamp survives every holder's save), and a refusal the
 bus cannot retry (no live recipient, a message that came back, with the far
 host's reason) reverts the node to your block with the refusal in its why,
-since nobody can be asked; each record lands before its entry is spent. A
-block filed again after the peer's reply ended the wait relays again; a block
-re-asserted on a standing wait never does. A top is attributed to the
+since nobody can be asked (filed at the bounce's own time, so a lift that
+landed after it outranks it); a pending relay whose wait ended another way is
+withdrawn from the far host's outbox; a dead worker's block is not relayed;
+each record lands before its entry is spent. A block filed again after the
+peer's reply ended the wait relays again; a block re-asserted on a standing
+wait never does. Your own follow-up on a delegated card, newer than the
+delegation and the standing wait, keeps its block yours. A top is attributed to the
 delegate mail its anchor names (the delegate-kind marker of the delivery that
 is a dispatch to this session, never one quoted from another session's, so a
 batched inbox whose first mail is a peer's heads-up still belongs to the

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -239,13 +239,21 @@ stays pending by its id up to the far host's delivered row or the peer's
 answer (the pending stamp survives every holder's save), and a refusal the
 bus cannot retry (no live recipient, a message that came back, with the far
 host's reason) reverts the node to your block with the refusal in its why,
-since nobody can be asked (filed at the bounce's own time, so a lift that
-landed after it outranks it); a pending relay whose wait ended another way is
-withdrawn from the far host's outbox; a dead worker's block is not relayed;
-each record lands before its entry is spent. A block filed again after the
+since nobody can be asked (the node is read again first, so a wait another
+holder ended meanwhile stands down instead, and the block is filed at the
+bounce's own time, so a follow-up of yours between the bounce and the tick
+outranks it; the refusal is noted beside the block, never in its words); a
+pending relay whose wait ended another way is withdrawn from the far host's
+outbox, and one the judge retired while it was parked is recalled the same
+way; a parked question completes only on the far host's delivered row, never
+on a later message; a dead worker's block is not relayed; each record lands
+before its entry is spent; a send the bus answered late is never repeated
+(the bus answers the send it holds, and the tick holds off after an unknown
+outcome and reads the bus's row). A block filed again after the
 peer's reply ended the wait relays again; a block re-asserted on a standing
-wait never does. Your own follow-up on a delegated card, newer than the
-delegation and the standing wait, keeps its block yours. A top is attributed to the
+wait never does. Your own follow-up on a delegated card, newer than every edge the block
+could wait on (the delegation, a standing wait up the card, the worker's own
+open question, a handoff), keeps its block yours. A top is attributed to the
 delegate mail its anchor names (the delegate-kind marker of the delivery that
 is a dispatch to this session, never one quoted from another session's, so a
 batched inbox whose first mail is a peer's heads-up still belongs to the

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -245,8 +245,10 @@ bounce's own time, so a follow-up of yours between the bounce and the tick
 outranks it; the refusal is noted beside the block, never in its words); a
 pending relay whose wait ended another way is withdrawn from the far host's
 outbox, and one the judge retired while it was parked is recalled the same
-way; a parked question completes only on the far host's delivered row, never
-on a later message; a dead worker's block is not relayed; each record lands
+way (its entry is never spent while the recall is owed, and the boot pass
+re-queues a node that owes one); a parked question completes only on the far
+host's delivered row, never on a later message; a refused relay's note reaches
+the card's brief beside the question it could not carry; a dead worker's block is not relayed; each record lands
 before its entry is spent; a send the bus answered late is never repeated
 (the bus answers the send it holds, and the tick holds off after an unknown
 outcome and reads the bus's row). A block filed again after the

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -130,6 +130,20 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   (open, nothing for you to do — including delegated work and waiting on a
   non-user trigger), **blocked** (needs *you*), **completed**. They map 1:1 onto
   the three feed columns.
+- **A block addressed to a peer is a peer wait, in working** (2026-09-11): the
+  judges read a block's addressee from the session's own open question to a live
+  peer, else from the peer that delegated the work it sits under (the planted
+  origin, or the delegate mail the session received before the goal was minted;
+  never a goal you typed), and file the
+  awaiting-a-peer stamp instead of the block, so the card shows the "Awaiting
+  <peer>" chip in working and never a needs-you; when the worker never mailed
+  that peer, the kernel relays the block's why to it as the worker's own question,
+  once per block, so the reply can end the wait; a refusal the bus cannot retry
+  reverts the block to yours. A block in a delegated goal that
+  names you still goes to the delegating manager; a worker's card reaches you only
+  when the debt ladder escalates, and for a manager debtor only at an idle turn end
+  with no unread mail waiting for it. Your own sessions' blocks are untouched,
+  whatever questions they have out.
 - **`blocked` has a deterministic floor the judge cannot override.** A live
   permission / decision prompt is a fact, not a judgment. `blocked = hard OR soft`,
   hard wins: the planner's output can never clear a hard block. This is a merge

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -138,8 +138,10 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   awaiting-a-peer stamp instead of the block, so the card shows the "Awaiting
   <peer>" chip in working and never a needs-you; when the worker never mailed
   that peer, the kernel relays the block's why to it as the worker's own question,
-  once per block, so the reply can end the wait; a refusal the bus cannot retry
-  reverts the block to yours. A block in a delegated goal that
+  once per block (each marker has an identity its queue entry and its record
+  name), so the reply can end the wait; a relay handed to a far host stays
+  pending by its id up to the far host's delivered row or the peer's answer; a
+  refusal the bus cannot retry reverts the block to yours. A block in a delegated goal that
   names you still goes to the delegating manager; a worker's card reaches you only
   when the debt ladder escalates, and for a manager debtor only at an idle turn end
   with no unread mail waiting for it. Your own sessions' blocks are untouched,

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -141,7 +141,8 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   once per block (each marker has an identity its queue entry and its record
   name), so the reply can end the wait; a relay handed to a far host stays
   pending by its id up to the far host's delivered row or the peer's answer; a
-  refusal the bus cannot retry reverts the block to yours. A block in a delegated goal that
+  refusal the bus cannot retry reverts the block to yours; your own follow-up on a
+  delegated card, newer than the delegation, keeps its block yours. A block in a delegated goal that
   names you still goes to the delegating manager; a worker's card reaches you only
   when the debt ladder escalates, and for a manager debtor only at an idle turn end
   with no unread mail waiting for it. Your own sessions' blocks are untouched,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4565,16 +4565,21 @@ def _rebase_onto_disk(fsid, store):
             mnd["relaySettled"] = (ms + [x for x in dnd["relaySettled"]           #   remembers, so a holder stale
                                          if isinstance(x, str) and x not in ms])[-RELAY_SETTLED_CAP:]   # across two relays
         #                                                                                never re-mints the first)
-        if isinstance(dnd.get("relayRecalled"), list):   # the recalls done: the union
-            ms = [x for x in (mnd.get("relayRecalled") or []) if isinstance(x, str)]
-            mnd["relayRecalled"] = (ms + [x for x in dnd["relayRecalled"] if isinstance(x, str) and x not in ms])[-RELAY_SETTLED_CAP:]
-        if isinstance(dnd.get("relayRecall"), list):     # the recalls owed: the union, minus the ones done on either side
-            done = set(mnd.get("relayRecalled") or [])
+        if isinstance(dnd.get("relayRecalled"), list):   # the recalls done ({mid, outcome, t}): the union, by mid
+            have = _relay_recalled_mids(mnd.get("relayRecalled"))
+            mnd["relayRecalled"] = ([x for x in (mnd.get("relayRecalled") or [])]
+                                    + [x for x in dnd["relayRecalled"] if _relay_recalled_mid(x) not in have])[-RELAY_SETTLED_CAP:]
+        if isinstance(mnd.get("relayRecall"), list) or isinstance(dnd.get("relayRecall"), list):
+            done = _relay_recalled_mids(mnd.get("relayRecalled"))   # the recalls owed: the union, minus the ones done on
             mine = {str(r.get("pendingMid") or ""): r for r in (mnd.get("relayRecall") or []) if isinstance(r, dict)}
-            for r in dnd["relayRecall"]:
-                if isinstance(r, dict) and str(r.get("pendingMid") or "") not in mine:
-                    mine[str(r.get("pendingMid") or "")] = r
-            mnd["relayRecall"] = [r for r in mine.values() if str(r.get("pendingMid") or "") not in done][-RELAY_SETTLED_CAP:]
+            for r in (dnd.get("relayRecall") if isinstance(dnd.get("relayRecall"), list) else []):   #   either side, whether
+                if isinstance(r, dict) and str(r.get("pendingMid") or "") not in mine:           #   or not the disk still
+                    mine[str(r.get("pendingMid") or "")] = r                                     #   owes any
+            owed = [r for r in mine.values() if str(r.get("pendingMid") or "") not in done][-RELAY_SETTLED_CAP:]
+            if owed:
+                mnd["relayRecall"] = owed
+            else:
+                mnd.pop("relayRecall", None)
         if isinstance(mnd.get("relayWanted"), dict) and _relay_settled(mnd, mnd["relayWanted"]):
             mnd.pop("relayWanted", None)               # ours is settled: popped FIRST, so the disk's live marker is adopted
         d_rw, m_rw = dnd.get("relayWanted"), mnd.get("relayWanted")
@@ -4582,9 +4587,9 @@ def _rebase_onto_disk(fsid, store):
             if not isinstance(m_rw, dict):
                 mnd["relayWanted"] = d_rw                  # the other writer's live marker
             elif d_rw.get("id") == m_rw.get("id"):
-                for k in ("pendingMid", "pendingAt", "pendingHost"):   # the SAME marker on both sides: the kernel's pending
-                    if k in d_rw and k not in m_rw:        #   stamp (a relay handed to a far host) is a fact a marker only
-                        m_rw[k] = d_rw[k]                  #   gains; a stale copy without it would send the question again
+                _relay_carry_tick_keys(m_rw, d_rw)         # the SAME marker on both sides: the kernel's fields on it (the
+                                                           #   pending stamp, the hold after a stalled bus) are facts a stale
+                                                           #   copy without them would undo, and the question would go again
             elif d_rw.get("pendingMid") or not m_rw.get("pendingMid"):
                 mnd["relayWanted"] = d_rw                  # two holders minted a marker for one wait: the one already handed
                                                            #   to a far host wins, else the published one (its entry is
@@ -12965,6 +12970,29 @@ def _relay_retire_marker(store, nd):
 
 
 RELAY_SETTLED_CAP = 8        # settled marker ids a node remembers (relaySettled), newest last
+RELAY_TICK_KEYS = ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts")   # the kernel's tick owns these
+#                                                                                        on a marker; the judge never writes them
+
+
+def _relay_recalled_mid(x):
+    """The message id a done-recall record names (a dict since the seventh review; a bare id before)."""
+    return str(x.get("mid") or "") if isinstance(x, dict) else str(x)
+
+
+def _relay_recalled_mids(lst):
+    return {_relay_recalled_mid(x) for x in (lst or [])}
+
+
+def _relay_carry_tick_keys(mine, theirs):
+    """Carry the tick-owned fields of the same marker from `theirs` onto `mine` (the store merge, in whichever process
+    runs it): a field absent here is taken, and a counter or a clock (attempts, unknownAt) takes the newer value, so a
+    judge's copy loaded before the tick wrote them never drops the pending stamp or the hold after a stalled bus, and
+    the kernel's own copy never loses its own (the manager's seventh review)."""
+    for k in RELAY_TICK_KEYS:
+        if k not in theirs:
+            continue
+        if k not in mine or (k in ("attempts", "unknownAt") and int(theirs.get(k) or 0) > int(mine.get(k) or 0)):
+            mine[k] = theirs[k]
 
 
 def _relay_mark_settled(nd, marker):

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4565,6 +4565,16 @@ def _rebase_onto_disk(fsid, store):
             mnd["relaySettled"] = (ms + [x for x in dnd["relaySettled"]           #   remembers, so a holder stale
                                          if isinstance(x, str) and x not in ms])[-RELAY_SETTLED_CAP:]   # across two relays
         #                                                                                never re-mints the first)
+        if isinstance(dnd.get("relayRecalled"), list):   # the recalls done: the union
+            ms = [x for x in (mnd.get("relayRecalled") or []) if isinstance(x, str)]
+            mnd["relayRecalled"] = (ms + [x for x in dnd["relayRecalled"] if isinstance(x, str) and x not in ms])[-RELAY_SETTLED_CAP:]
+        if isinstance(dnd.get("relayRecall"), list):     # the recalls owed: the union, minus the ones done on either side
+            done = set(mnd.get("relayRecalled") or [])
+            mine = {str(r.get("pendingMid") or ""): r for r in (mnd.get("relayRecall") or []) if isinstance(r, dict)}
+            for r in dnd["relayRecall"]:
+                if isinstance(r, dict) and str(r.get("pendingMid") or "") not in mine:
+                    mine[str(r.get("pendingMid") or "")] = r
+            mnd["relayRecall"] = [r for r in mine.values() if str(r.get("pendingMid") or "") not in done][-RELAY_SETTLED_CAP:]
         if isinstance(mnd.get("relayWanted"), dict) and _relay_settled(mnd, mnd["relayWanted"]):
             mnd.pop("relayWanted", None)               # ours is settled: popped FIRST, so the disk's live marker is adopted
         d_rw, m_rw = dnd.get("relayWanted"), mnd.get("relayWanted")
@@ -12825,21 +12835,41 @@ def block_addressee_via(store, nd, why):
     or (None, None) when the block is the user's (T334, the rule above). Only a node
     under a DELEGATED goal (a courier-planted top) is ever redirected: a managed session's block is the case, and the
     user's own session, however many open questions it has out, keeps its blocks as its own decisions (an unrelated
-    open ask must never hide the user's own call behind "Awaiting <peer>"). An empty why is never redirected."""
+    open ask must never hide the user's own call behind "Awaiting <peer>"). An empty why is never redirected. The
+    USER's own follow-up on the delegated card (the reopen floor, _floor_of: the node's and its ancestors') newer than
+    every edge the block could wait on (the top's mint, a standing peer wait up the same chain, the open ask it would
+    name, the handoff) makes the block theirs: their decision, never relayed (the manager's fifth and sixth reviews)."""
     if not str(why or "").strip():
         return None, None
     if not _delegator_of(store, str(nd.get("id") or "")):
         return None, None
+    peer, via, edge_t = _block_peer_edge(store, nd, why)
+    if not peer:
+        return None, None
     nodes = store.get("nodes", {})
     tn = nodes.get(_top_of(nodes, str(nd.get("id") or "")) or "") or {}
-    since = max(int(tn.get("t") or 0), int(nd.get("awaitingAt") or 0) if nd.get("awaitingKind") == "peer" else 0)
+    since = max(int(tn.get("t") or 0), int(edge_t or 0))
+    seen, cur = set(), str(nd.get("id") or "")
+    while cur and cur in nodes and cur not in seen:             # loop-ok: the ancestor walk, cycle-guarded
+        seen.add(cur)
+        n_ = nodes[cur]
+        if n_.get("awaitingKind") == "peer":
+            since = max(since, int(n_.get("awaitingAt") or 0))
+        cur = n_.get("parentId")
     if int(_floor_of(store, nd) or 0) > since:
-        return None, None                              # the USER's own follow-up on the delegated card (the floor, newer than
-                                                       #   the delegation and the standing wait): their decision, never relayed
+        return None, None
+    return peer, via
+
+
+def _block_peer_edge(store, nd, why):
+    """The addressee of a block under a delegated goal, before the follow-up gate: (peer, via, edge_t), where edge_t is
+    the time of the edge the block would wait on (the open ask's send time, the handoff's time, 0 for the delegator's
+    relay), or (None, None, 0)."""
     ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
     if ho and ho.get("peer") and ":" not in str(ho["peer"]):
-        return str(ho["peer"]), "ask"                 # a block on a "delegated to <peer>" tracker under a delegated goal waits
-                                                       #   on that peer: the delegate is a reply-expecting send its report ends
+        return str(ho["peer"]), "ask", int(ho.get("t") or 0)   # a block on a "delegated to <peer>" tracker under a delegated
+                                                       #   goal waits on that peer: the delegate is a reply-expecting send
+                                                       #   its report ends
     sid = str(store.get("rompUuid") or str(nd.get("id") or "").rsplit(":", 1)[0])
     nodes = store.get("nodes", {})
     delegator = _delegator_of(store, str(nd.get("id") or ""))
@@ -12850,17 +12880,18 @@ def block_addressee_via(store, nd, why):
     def named(p):
         return bool(_peer_name(p)) and bool(re.search(r"\b%s\b" % re.escape(_peer_name(p).lower()), text))
     if peers:
+        _la, last_ask, _al = _postal_ask_maps()
         if delegator in peers and not any(named(p) for p in peers if p != delegator):
-            return delegator, "ask"                    # the open ask to the delegator IS the edge
+            return delegator, "ask", int(last_ask.get((sid, delegator), 0))   # the open ask to the delegator IS the edge
         hits = [p for p in peers if named(p)]
         if len(hits) == 1:
-            return hits[0], "ask"                      # the words pick among the open asks
+            return hits[0], "ask", int(last_ask.get((sid, hits[0]), 0))   # the words pick among the open asks
         if delegator and not hits:
-            return delegator, "delegator"              # an open ask to a peer the block never names does not capture a
+            return delegator, "delegator", 0           # an open ask to a peer the block never names does not capture a
                                                        #   block in the delegator's work: the delegator, relayed
-        _la, last_ask, _al = _postal_ask_maps()
-        return max(peers, key=lambda p: last_ask.get((sid, p), 0)), "ask"   # else the latest ask, the wait graph's rule
-    return delegator, "delegator"
+        best = max(peers, key=lambda p: last_ask.get((sid, p), 0))
+        return best, "ask", int(last_ask.get((sid, best), 0))   # else the latest ask, the wait graph's rule
+    return delegator, "delegator", 0
 
 
 def file_block(store, nd, src, why, ev_t, t=None, seg=None):
@@ -12870,9 +12901,9 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
     kind "peer" or "block"; landed True when a verdict was written."""
     peer, via = block_addressee_via(store, nd, why)
     if not peer:
-        if isinstance(nd.get("relayWanted"), dict):        # the block is the user's: a peer wait's unsent marker on this
-            _relay_mark_settled(nd, nd.pop("relayWanted").get("id") or "")   #   node (the wait ended, or the user's
-        #                                                    follow-up reclaimed the card) is settled, never relayed
+        _relay_retire_marker(store, nd)                    # the block is the user's: a peer wait's marker on this node (the
+        #                                                    wait ended, or the user's follow-up reclaimed the card) is
+        #                                                    retired: settled, and recalled when it was handed to a far host
         return "block", bool(record_verdict(store, nd, src, "block", ev_t, why=why, seg=seg))
     if any(e.get("kind") in ("awaiting", "done") and (e.get("lift") or e.get("kind") == "done")
            and _wait_end_ev(e) > (ev_t or 0) for e in nd.get("log") or []):
@@ -12885,11 +12916,11 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
                                                        #   own once-ever record: a re-asserted judge block never lifts it
     prior_standing = nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())   # read BEFORE any write:
     #                                                   record_verdict materializes awaitingKind at once (the manager's third review)
-    if not prior_standing and isinstance(nd.get("relayWanted"), dict):
-        old = nd.pop("relayWanted")                    # the ENDED wait's marker, still unsent: a new wait never reuses it (the
-        _relay_mark_settled(nd, old.get("id") or "")   #   tick would relay the old words for the new question, or its stand-down
-        #                                                of the old id would leave a wait with nothing to end it; the manager's
-        #                                                fifth review); its entry, if one exists, is spent as settled
+    if not prior_standing:
+        _relay_retire_marker(store, nd)                # the ENDED wait's marker: a new wait never reuses it (the tick would relay
+        #                                                the old words for the new question, or its stand-down of the old id
+        #                                                would leave a wait with nothing to end it; the manager's fifth review);
+        #                                                one handed to a far host is recalled (the sixth)
     landed = False
     if nd.get("blocked"):
         landed = bool(record_verdict(store, nd, "romp", "unblock", ev_t)) or landed
@@ -12900,19 +12931,37 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
     # its since-time, so the relay sent after it (and the peer's reply after that) end exactly this wait
     if via == "delegator" and not prior_standing:  # a fresh marker for every new wait (the ended wait's went above)
         nd["relayWanted"] = {"peer": peer, "why": str(why), "t": int(t if t is not None else ev_t),
-                             "id": _relay_marker_id(t if t is not None else ev_t, peer)}   # its identity: the records
+                             "id": _relay_marker_id(t if t is not None else ev_t, peer, nd.get("id"))}   # its identity:
         _relay_enqueue(store, nd)                  #   that settle it name it. The kernel's relay tick sends it as the
         landed = True                              #   worker's question, once per block: a re-asserted block on a
                                                    #   standing relayed wait never relays twice
     return "peer", landed
 
 
-def _relay_marker_id(ev_t, peer=""):
-    """A relay marker's identity: the block's evidence time and the peer. The records that settle a marker (relayed,
-    relayDone) name it and the queue entry carries it, so a re-block after a lift (later evidence) is a new marker
-    nothing older can settle (the manager's fourth review), while two holders filing ONE wait (the same evidence, the
-    same peer) mint the same id and each other's records settle it (the fifth review)."""
-    return "%d-%s" % (int(ev_t or 0), str(peer or "")[:8] or "peer")
+def _relay_marker_id(ev_t, peer="", nid=""):
+    """A relay marker's identity: the block's evidence time, the peer and the node. The records that settle a marker
+    (relayed, relayDone), the queue entry and the bus's sent row name it, so a re-block after a lift (later evidence)
+    is a new marker nothing older can settle (the manager's fourth review), two holders filing ONE wait (the same
+    evidence, peer and node) mint the same id and each other's records settle it (the fifth), and two nodes blocked
+    toward one peer in one pass (one evidence time) keep two markers and two questions (the sixth)."""
+    return "%d-%s-%s" % (int(ev_t or 0), str(peer or "")[:8] or "peer", str(nid or "").rsplit(":", 1)[-1] or "node")
+
+
+def _relay_retire_marker(store, nd):
+    """Retire the node's marker for a wait that ended (a new wait replaces it, or the block became the user's): it is
+    settled (relaySettled), and when it had already been handed to a far host (pendingMid: parked or unacked) it is
+    remembered on the node (relayRecall) for the kernel's tick to RECALL, so the far host never delivers a stale
+    question with no record; an entry brings the tick to the node (the manager's sixth review)."""
+    old = nd.pop("relayWanted", None)
+    if not isinstance(old, dict):
+        return
+    _relay_mark_settled(nd, old.get("id") or "")
+    if old.get("pendingMid"):
+        lst = [r for r in (nd.get("relayRecall") or []) if isinstance(r, dict)
+               and str(r.get("pendingMid") or "") != str(old.get("pendingMid"))]
+        lst.append({k: old.get(k) for k in ("id", "peer", "pendingMid", "pendingHost", "pendingAt") if old.get(k) is not None})
+        nd["relayRecall"] = lst[-RELAY_SETTLED_CAP:]
+        _relay_enqueue(store, nd)
 
 
 RELAY_SETTLED_CAP = 8        # settled marker ids a node remembers (relaySettled), newest last
@@ -12991,6 +13040,8 @@ def _relay_flush(fsid, store, pending):
         rw = nd.get("relayWanted") if isinstance(nd, dict) else None
         if isinstance(rw, dict):
             n += 1 if _relay_write_entry(str(fsid), str(nid), rw.get("id") or "", store.get("rev") or 0) else 0
+        elif isinstance(nd, dict) and nd.get("relayRecall"):
+            n += 1 if _relay_write_entry(str(fsid), str(nid), "recall", store.get("rev") or 0) else 0   # recalls owed
     return n
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4573,8 +4573,15 @@ def _rebase_onto_disk(fsid, store):
             done = _relay_recalled_mids(mnd.get("relayRecalled"))   # the recalls owed: the union, minus the ones done on
             mine = {str(r.get("pendingMid") or ""): r for r in (mnd.get("relayRecall") or []) if isinstance(r, dict)}
             for r in (dnd.get("relayRecall") if isinstance(dnd.get("relayRecall"), list) else []):   #   either side, whether
-                if isinstance(r, dict) and str(r.get("pendingMid") or "") not in mine:           #   or not the disk still
-                    mine[str(r.get("pendingMid") or "")] = r                                     #   owes any
+                if not isinstance(r, dict):                                                      #   or not the disk still
+                    continue                                                                     #   owes any
+                mid = str(r.get("pendingMid") or "")
+                if mid not in mine:
+                    mine[mid] = r
+                else:                                      # the same recall on both sides: the tick's hold and count newer-wins
+                    for k in ("unknownAt", "attempts"):
+                        if int(r.get(k) or 0) > int(mine[mid].get(k) or 0):
+                            mine[mid][k] = r[k]
             owed = [r for r in mine.values() if str(r.get("pendingMid") or "") not in done][-RELAY_SETTLED_CAP:]
             if owed:
                 mnd["relayRecall"] = owed
@@ -12970,7 +12977,8 @@ def _relay_retire_marker(store, nd):
 
 
 RELAY_SETTLED_CAP = 8        # settled marker ids a node remembers (relaySettled), newest last
-RELAY_TICK_KEYS = ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts", "recallUnknownAt")   # the tick owns these
+RELAY_TICK_KEYS = ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts", "recallUnknownAt", "recallAttempts")
+#                                                                                        the tick owns these on a marker
 #                                                                                        on a marker; the judge never writes them
 
 
@@ -12991,7 +12999,8 @@ def _relay_carry_tick_keys(mine, theirs):
     for k in RELAY_TICK_KEYS:
         if k not in theirs:
             continue
-        if k not in mine or (k in ("attempts", "unknownAt") and int(theirs.get(k) or 0) > int(mine.get(k) or 0)):
+        if k not in mine or (k in ("attempts", "unknownAt", "recallUnknownAt", "recallAttempts")
+                             and int(theirs.get(k) or 0) > int(mine.get(k) or 0)):
             mine[k] = theirs[k]
 
 
@@ -13024,6 +13033,12 @@ def _relay_entry_path(sid, nid):
     return _relay_queue_dir() / ("%s__%s.json" % (str(sid), re.sub(r"[^A-Za-z0-9_.-]", "_", str(nid))))
 
 
+def _relay_recall_entry_path(sid, nid):
+    """The recalls a node owes ride their OWN entry file beside the marker's (the ninth review): the two are written by
+    different hands at different times, and a rewrite of one path by the other's writer lost whichever entry was there."""
+    return _relay_queue_dir() / ("%s__%s.recall.json" % (str(sid), re.sub(r"[^A-Za-z0-9_.-]", "_", str(nid))))
+
+
 def _relay_enqueue(store, nd):
     """Remember `nd` on the STORE OBJECT for the kernel's relay tick. save_goals writes the entry (one file per entry
     in a queue directory: append = create, consume = unlink, so the judge's thread and the kernel's tick never rewrite
@@ -13043,7 +13058,8 @@ def _relay_enqueue(store, nd):
 def _relay_write_entry(sid, nid, marker="", rev=0):
     """One queue entry: the node, the marker it was written for (its id) and the store revision whose publish carried
     the marker, so the tick can tell a spent entry (a record names the marker; the node moved on to a newer marker; a
-    published revision at or past this one lacks the marker) from one whose publish it has not read yet."""
+    published revision at or past this one lacks the marker) from one whose publish it has not read yet. The marker
+    "recall" names the node's recall entry, its own file beside the marker's."""
     try:
         d = _relay_queue_dir()
         d.mkdir(parents=True, exist_ok=True)
@@ -13051,7 +13067,7 @@ def _relay_write_entry(sid, nid, marker="", rev=0):
         #             the judge's flush and the tick's rewrite share one process: a private name each
         tmp.write_text(json.dumps({"sid": sid, "nid": nid, "t": int(time.time()), "marker": str(marker or ""),
                                    "rev": int(rev or 0)}))
-        tmp.rename(_relay_entry_path(sid, nid))
+        tmp.rename(_relay_recall_entry_path(sid, nid) if marker == "recall" else _relay_entry_path(sid, nid))
         return True
     except OSError as e:
         _log_judge_error("relay-queue", sid, "relay queue entry not written (%r)" % (e,))
@@ -13068,8 +13084,8 @@ def _relay_flush(fsid, store, pending):
         rw = nd.get("relayWanted") if isinstance(nd, dict) else None
         if isinstance(rw, dict):
             n += 1 if _relay_write_entry(str(fsid), str(nid), rw.get("id") or "", store.get("rev") or 0) else 0
-        elif isinstance(nd, dict) and nd.get("relayRecall"):
-            n += 1 if _relay_write_entry(str(fsid), str(nid), "recall", store.get("rev") or 0) else 0   # recalls owed
+        if isinstance(nd, dict) and nd.get("relayRecall"):   # recalls owed ride their own entry, beside the marker's
+            n += 1 if _relay_write_entry(str(fsid), str(nid), "recall", store.get("rev") or 0) else 0
     return n
 
 
@@ -13085,11 +13101,11 @@ def _requeue_relays_all():
         except Exception:
             continue
         for nid, nd in ((raw or {}).get("nodes") or {}).items():
-            if not isinstance(nd, dict) or _relay_entry_path(p.stem, nid).exists():
+            if not isinstance(nd, dict):
                 continue
-            if isinstance(nd.get("relayWanted"), dict):
+            if isinstance(nd.get("relayWanted"), dict) and not _relay_entry_path(p.stem, nid).exists():
                 n += 1 if _relay_write_entry(p.stem, nid, nd["relayWanted"].get("id") or "", (raw or {}).get("rev") or 0) else 0
-            elif nd.get("relayRecall"):                 # recalls owed with no marker: an entry brings the tick to them
+            if nd.get("relayRecall") and not _relay_recall_entry_path(p.stem, nid).exists():   # recalls owed: their own entry
                 n += 1 if _relay_write_entry(p.stem, nid, "recall", (raw or {}).get("rev") or 0) else 0
     return n
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -12970,7 +12970,7 @@ def _relay_retire_marker(store, nd):
 
 
 RELAY_SETTLED_CAP = 8        # settled marker ids a node remembers (relaySettled), newest last
-RELAY_TICK_KEYS = ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts")   # the kernel's tick owns these
+RELAY_TICK_KEYS = ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts", "recallUnknownAt")   # the tick owns these
 #                                                                                        on a marker; the judge never writes them
 
 
@@ -13075,8 +13075,9 @@ def _relay_flush(fsid, store, pending):
 
 def _requeue_relays_all():
     """Once per boot: every node carrying relayWanted with no queue entry gets one (a marker whose entry was lost to a
-    failed write, a kernel restart between the publish and the flush, or a stale merge would otherwise wait forever).
-    Returns the number re-queued."""
+    failed write, a kernel restart between the publish and the flush, or a stale merge would otherwise wait forever),
+    and so does every node that owes recalls (relayRecall) with no entry, so a parked question retired by the judge is
+    withdrawn whatever became of its entry (the manager's eighth review). Returns the number re-queued."""
     n = 0
     for p in (sorted(GOALDIR.glob("*.json")) if GOALDIR.is_dir() else []):
         try:
@@ -13084,8 +13085,12 @@ def _requeue_relays_all():
         except Exception:
             continue
         for nid, nd in ((raw or {}).get("nodes") or {}).items():
-            if isinstance(nd, dict) and isinstance(nd.get("relayWanted"), dict) and not _relay_entry_path(p.stem, nid).exists():
+            if not isinstance(nd, dict) or _relay_entry_path(p.stem, nid).exists():
+                continue
+            if isinstance(nd.get("relayWanted"), dict):
                 n += 1 if _relay_write_entry(p.stem, nid, nd["relayWanted"].get("id") or "", (raw or {}).get("rev") or 0) else 0
+            elif nd.get("relayRecall"):                 # recalls owed with no marker: an entry brings the tick to them
+                n += 1 if _relay_write_entry(p.stem, nid, "recall", (raw or {}).get("rev") or 0) else 0
     return n
 
 
@@ -15812,6 +15817,16 @@ def review_boundary(nd):
     return b
 
 
+def _owed_why(nd):
+    """The owed question the block brief is fed for a blocked node: its blockWhy, and, when a relay of that question to
+    the peer that delegated the work was refused (relayRefusal, the kernel's note beside the block: nobody could be
+    asked), that note in brackets after it, so the brief can say why the decision came back to the user (the manager's
+    eighth review: the note was written and read by nothing)."""
+    why = str((nd or {}).get("blockWhy") or "")
+    ref = str((nd or {}).get("relayRefusal") or "").strip()
+    return "%s (%s)" % (why, ref) if ref else why
+
+
 def _distill_session(fsid, path, now):
     """Distill each newly-(re)resolved TOP goal of ONE session, COMPLETED and BLOCKED alike (the user
     2026-06-18). Gather the goal's full WORK history — the text of every segment in its trail and its whole
@@ -15998,8 +16013,8 @@ def _distill_session(fsid, path, now):
             proc_whys = [d.get("blockWhy") for d in blkd if procedural_block_why(d.get("blockWhy"))]
             proc_only = bool(blkd) and len(proc_whys) == len(blkd)
             blkd = [d for d in blkd if not procedural_block_why(d.get("blockWhy"))]
-            owed = ([(d.get("text", ""), d.get("blockWhy", "")) for d in blkd] if len(blkd) > 1
-                    else blkd[0]["blockWhy"] if blkd else "")
+            owed = ([(d.get("text", ""), _owed_why(d)) for d in blkd] if len(blkd) > 1
+                    else _owed_why(blkd[0]) if blkd else "")
             if proc_only:                              # no SUBSTANTIVE decision is owed — but a card in Blocked
                 # must still say where things stand (the user 2026-07-23: every blocked card presents a
                 # distilled summary; the bare red chip over silence left look-alike cards inconsistent). A

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4552,17 +4552,33 @@ def _rebase_onto_disk(fsid, store):
                 mnd["log"] = sorted((mnd.get("log") or []) + add,
                                     key=lambda e: (int(e.get("ev_t") or 0), int(e.get("at") or 0)))
         # T334: the relay's record rides plain node keys two writers touch (the judge marks relayWanted; the kernel's tick
-        # replaces it with relayed): the newer fact on disk wins over a stale in-memory copy, in either direction
+        # replaces it with relayed): the NEWER record wins in either direction (by its t, the tick's clock, so a stale
+        # holder never republishes an older record over a newer one), and a marker is settled only by a record that
+        # NAMES it (its id): a re-block with the same words after a lift is a new marker, never popped by the record
+        # that settled the earlier one (the manager's fourth review)
         for key in ("relayed", "relayDone"):        # the kernel's records of a relay sent, stood down or refused
-            if isinstance(dnd.get(key), dict) and not isinstance(mnd.get(key), dict):
-                mnd[key] = dnd[key]
-        def _settled(node, want):                    # a record at or after the marker settles it
-            return any(isinstance(node.get(k), dict) and int(node[k].get("t") or 0) >= int((want or {}).get("t") or 0)
-                       and node[k].get("why") == (want or {}).get("why") for k in ("relayed", "relayDone"))
-        if isinstance(dnd.get("relayWanted"), dict) and "relayWanted" not in mnd and not _settled(mnd, dnd["relayWanted"]):
-            mnd["relayWanted"] = dnd["relayWanted"]
-        if isinstance(mnd.get("relayWanted"), dict) and _settled(mnd, mnd["relayWanted"]):
-            mnd.pop("relayWanted", None)
+            d_, m_ = dnd.get(key), mnd.get(key)
+            if isinstance(d_, dict) and (not isinstance(m_, dict) or int(d_.get("t") or 0) > int(m_.get("t") or 0)):
+                mnd[key] = d_
+        if isinstance(dnd.get("relaySettled"), list):   # the settled markers: the union (each record slot is overwritten
+            ms = [x for x in (mnd.get("relaySettled") or []) if isinstance(x, str)]   #   by the next marker's; the list
+            mnd["relaySettled"] = (ms + [x for x in dnd["relaySettled"]           #   remembers, so a holder stale
+                                         if isinstance(x, str) and x not in ms])[-RELAY_SETTLED_CAP:]   # across two relays
+        #                                                                                never re-mints the first)
+        if isinstance(mnd.get("relayWanted"), dict) and _relay_settled(mnd, mnd["relayWanted"]):
+            mnd.pop("relayWanted", None)               # ours is settled: popped FIRST, so the disk's live marker is adopted
+        d_rw, m_rw = dnd.get("relayWanted"), mnd.get("relayWanted")
+        if isinstance(d_rw, dict) and not _relay_settled(mnd, d_rw):
+            if not isinstance(m_rw, dict):
+                mnd["relayWanted"] = d_rw                  # the other writer's live marker
+            elif d_rw.get("id") == m_rw.get("id"):
+                for k in ("pendingMid", "pendingAt", "pendingHost"):   # the SAME marker on both sides: the kernel's pending
+                    if k in d_rw and k not in m_rw:        #   stamp (a relay handed to a far host) is a fact a marker only
+                        m_rw[k] = d_rw[k]                  #   gains; a stale copy without it would send the question again
+            elif d_rw.get("pendingMid") or not m_rw.get("pendingMid"):
+                mnd["relayWanted"] = d_rw                  # two holders minted a marker for one wait: the one already handed
+                                                           #   to a far host wins, else the published one (its entry is
+                                                           #   flushed); the loser never reaches the queue
         # `mt` is a monotonic last-touched stamp the read side orders and anchors on (a block's mt feeds the
         # card's disp_t), so it must not regress to our older snapshot — take the newer of the two. The
         # verdict FLAGS need no such care: rollup_status below re-derives them all from the merged log.
@@ -4922,8 +4938,9 @@ def _replay_overrides(fsid, store, lines=None):
     return applied
 
 
-_NONCONTENT_KEYS = ("rev", "_baseRev", "_unread")   # the revision counter + the transient CAS base and
-#                                                      unread-journal mark (_replay_overrides): not store CONTENT
+_NONCONTENT_KEYS = ("rev", "_baseRev", "_unread", "_relayPending")   # the revision counter + the transient CAS base,
+#                                                      unread-journal mark (_replay_overrides) and the relay entries
+#                                                      awaiting this holder's publish (_relay_enqueue): not store CONTENT
 
 
 def _store_content(store):
@@ -5600,9 +5617,12 @@ def save_goals(fsid, store):
     GOALDIR.mkdir(parents=True, exist_ok=True)
     mine = _own_hash(store) if "_baseRev" in store else None
     if mine is not None and _matches_disk(fsid, store, mine):
+        if store.get("_relayPending"):               # the file already holds our markers: their entries go out now
+            _relay_flush(fsid, store, store.pop("_relayPending", None))
         return                                       # nothing of ours to publish → leave the file (and its
     base = store.pop("_baseRev", None)               # mtime) alone.  transient: never serialized
     unread = store.pop("_unread", None)              # likewise transient (_replay_overrides' unread-journal mark)
+    pending = store.pop("_relayPending", None)       # likewise: the relay entries this publish carries (_relay_enqueue)
     rebased = published = False
     try:
         if base is not None:
@@ -5625,8 +5645,9 @@ def save_goals(fsid, store):
         tmp.rename(GOALDIR / (fsid + ".json"))        # atomic publish
         published = True
         _shared_forget(str(GOALDIR / (fsid + ".json")))   # the shared read-only view of the old version goes
-        _relay_flush(fsid)                            # T334: the relay entries of markers this save just published
         #                                               with it (its identity check would miss anyway; this frees the bytes)
+        if pending:
+            _relay_flush(fsid, store, pending)        # T334: the relay entries of the markers this publish carried
     finally:
         if base is not None:
             # published: the file holds exactly this content at this revision, so the holder's NEXT save
@@ -5636,6 +5657,8 @@ def save_goals(fsid, store):
             store["_baseRev"] = store["rev"] if published else base
         if not published and unread is not None:
             store["_unread"] = unread                # the mark describes the object still held
+        if not published and pending:
+            store["_relayPending"] = pending         # the holder's retry publishes the markers, then flushes
 
 
 def load_goal_archive(fsid):
@@ -10607,22 +10630,28 @@ def _asks_user(nodes, nid):
 
 
 def _latch_prompt_msg_ids(session, store):
-    """Stamp promptMsgId on every parentless promptUuid-bearing top whose anchor atom the parse holds: the postal message
-    id its delivery text carries (em.postal_pairs, the first marker), or "" when it carries none (checked). The
-    delegating peer of a top is then the sender of THAT mail (_delegator_of), never merely the latest delegate the
-    session received (a worker dispatched by two managers relays each block to the manager that asked, T334)."""
+    """Stamp promptMsgId on every parentless promptUuid-bearing top whose anchor atom the parse holds: the id of the
+    DELEGATE-kind postal marker its delivery text carries (em.postal_pairs pairs each id with the kind declared after
+    it; the last delegate when a drained inbox holds several, the rule author_of applies to the delivery's peer), or ""
+    when it carries no delegate (checked: a batched inbox whose first mail is a peer's coordinate and whose second the
+    manager's dispatch is the manager's, and a delivery with no dispatch in it leaves _delegator_of its fallback, the
+    latest delegate at or before the mint; the manager's fourth review). The delegating peer of a top is then the
+    sender of THAT mail (_delegator_of), never merely the latest delegate the session received (a worker dispatched by
+    two managers relays each block to the manager that asked, T334)."""
     cands = [nd for nd in store.get("nodes", {}).values()
              if isinstance(nd, dict) and nd.get("parentId") is None and nd.get("promptUuid") and "promptMsgId" not in nd]
     if not cands:
         return 0
     by_uuid = {a["uuid"]: a for turn in session.get("turns") or [] for a in turn.get("atoms") or [] if a.get("uuid")}
+    sid = str(store.get("rompUuid") or "")
     n = 0
     for nd in cands:
         a = by_uuid.get(nd["promptUuid"])
         if a is None:
             continue                                    # not in this parse: left for a parse that holds it
-        pairs = em.postal_pairs(_atom_text(a))
-        nd["promptMsgId"] = str(pairs[0][0]) if pairs else ""
+        dels = [m for m, k in em.postal_pairs(_atom_text(a)) if k == "delegate" and _delegate_sender(m, sid)]
+        nd["promptMsgId"] = str(dels[-1]) if dels else ""   # a delegate marker QUOTED in a body (another session's
+        #                                                       dispatch) is no dispatch to this session: not the anchor
         n += 1
     return n
 
@@ -12705,7 +12734,7 @@ def _peer_name(sid):
 
 
 _DELEG_CACHE = [None, {}]    # (mtime_ns, size), {to_sid: [(t, from_id), ...] ascending}: one scan per log change
-_DELEG_BY_MID = {}           # message id -> from_id of that delegate row (filled by the same scan)
+_DELEG_BY_MID = {}           # message id -> (from_id, to_sid) of that delegate row (filled by the same scan)
 
 
 def _delegates_to():
@@ -12738,7 +12767,7 @@ def _delegates_to():
                 continue
             out.setdefault(str(t_), []).append((int(ts), str(f)))
             if o.get("id"):
-                by_mid[str(o["id"])] = str(f)
+                by_mid[str(o["id"])] = (str(f), str(t_))
         for v in out.values():
             v.sort()
     except OSError:
@@ -12748,10 +12777,15 @@ def _delegates_to():
     return out
 
 
-def _delegate_sender(mid):
-    """The from_id of the DELEGATE row with message id `mid` (the mail a top's anchor record names), or None."""
+def _delegate_sender(mid, sid=None):
+    """The from_id of the DELEGATE row with message id `mid` (the mail a top's anchor record names), or None; with `sid`,
+    only when that row was addressed TO `sid` (a dispatch to another session, quoted in a body, names nobody here)."""
     _delegates_to()
-    return _DELEG_BY_MID.get(str(mid))
+    ent = _DELEG_BY_MID.get(str(mid))
+    if not ent:
+        return None
+    frm, to = ent
+    return frm if sid is None or str(to) == str(sid) else None
 
 
 def _delegator_of(store, nid):
@@ -12770,10 +12804,11 @@ def _delegator_of(store, nid):
     if not top or tn.get("askAnchor") != "machine":
         return None
     sid = str(store.get("rompUuid") or str(nid).rsplit(":", 1)[0])
-    peer = _delegate_sender(tn["promptMsgId"]) if tn.get("promptMsgId") else None   # the mail the anchor names, first
-    if not peer and not tn.get("promptMsgId"):    # no mail id on the anchor: the latest delegate at or before the mint
-        before = [r for r in _delegates_to().get(sid, []) if r[0] <= int(tn.get("t") or 0)]
-        peer = before[-1][1] if before else None
+    peer = _delegate_sender(tn["promptMsgId"], sid) if tn.get("promptMsgId") else None   # the mail the anchor names, first
+    if not peer:                                  # no mail id on the anchor, or one that is no dispatch to this session (a
+        before = [r for r in _delegates_to().get(sid, []) if r[0] <= int(tn.get("t") or 0)]   # stamp from before the
+        peer = before[-1][1] if before else None  #   delegate-kind rule, a quoted marker): the latest delegate at or
+                                                  #   before the mint, as for an anchor that names none
     return None if not peer or ":" in peer else peer   # an ext: mailer or an unresolved cross-host key is no session that
                                                        #   could ever be asked (judge _presumed_closed: closed by construction)
 
@@ -12851,13 +12886,43 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
     # a peer wait on the same peer already standing is not re-filed, whatever the re-asserted words: the stamp keeps
     # its since-time, so the relay sent after it (and the peer's reply after that) end exactly this wait
     if via == "delegator" and not prior_standing and not isinstance(nd.get("relayWanted"), dict):
-        nd["relayWanted"] = {"peer": peer, "why": str(why), "t": int(t if t is not None else ev_t)}   # the kernel's
-        _relay_enqueue(store, nd)                  #   relay tick sends it as the worker's question, once per block: a
-        landed = True                              #   re-asserted block on a standing relayed wait never relays twice
+        nd["relayWanted"] = {"peer": peer, "why": str(why), "t": int(t if t is not None else ev_t),
+                             "id": _relay_marker_id(t if t is not None else ev_t)}   # its identity: the records that
+        _relay_enqueue(store, nd)                  #   settle it name it. The kernel's relay tick sends it as the worker's
+        landed = True                              #   question, once per block: a re-asserted block on a standing
+                                                   #   relayed wait never relays twice
     return "peer", landed
 
 
-_RELAY_PENDING = []          # (sid, nid) marked this pass, written to the queue only once the store is SAVED (save_goals)
+def _relay_marker_id(ev_t):
+    """A relay marker's identity: the block's evidence time and a nonce. The records that settle a marker (relayed,
+    relayDone) name it and the queue entry carries it, so a re-block with the same words after a lift is a new marker
+    nothing older can settle (the manager's fourth review)."""
+    return "%d-%s" % (int(ev_t or 0), secrets.token_hex(4))
+
+
+RELAY_SETTLED_CAP = 8        # settled marker ids a node remembers (relaySettled), newest last
+
+
+def _relay_mark_settled(nd, marker):
+    """Remember `marker` as settled on the node: the kernel's record slots (relayed, relayDone) hold one record each and
+    the next marker's record overwrites them, so a holder stale across two relays would find nothing naming the first
+    marker and republish it; the capped list remembers what the slots forgot."""
+    if not marker:
+        return
+    lst = [x for x in (nd.get("relaySettled") or []) if isinstance(x, str) and x != str(marker)]
+    nd["relaySettled"] = (lst + [str(marker)])[-RELAY_SETTLED_CAP:]
+
+
+def _relay_settled(node, want):
+    """True when the marker `want` is settled on `node`: a record (relayed, relayDone) or the settled list NAMES its id.
+    Words and times never settle a marker. A marker with no id (none is written today) is settled by any record, the
+    reading the kernel's tick gives such an entry, so the two rules agree."""
+    mk = str((want or {}).get("id") or "")
+    recs = [node.get(k) for k in ("relayed", "relayDone") if isinstance(node.get(k), dict)]
+    if not mk:
+        return bool(recs)
+    return mk in (node.get("relaySettled") or []) or any(str(r.get("marker") or "") == mk for r in recs)
 
 
 def _relay_queue_dir():
@@ -12869,21 +12934,31 @@ def _relay_entry_path(sid, nid):
 
 
 def _relay_enqueue(store, nd):
-    """Remember (sid, nid) for the kernel's relay tick. The queue is a DIRECTORY of one file per entry (append = create,
-    consume = unlink: two writers, the judge's thread and the kernel's tick, never rewrite each other's list), and the
-    entry is written only after the store carrying the marker is saved (_relay_flush from save_goals), so the tick
-    never reads a store that lacks the marker and drops the entry. A failed write is said; the boot pass re-queues
-    every marker without an entry (_requeue_relays_all)."""
-    sid = str(store.get("rompUuid") or str(nd.get("id") or "").rsplit(":", 1)[0])
-    _RELAY_PENDING.append((sid, str(nd.get("id") or "")))
+    """Remember `nd` on the STORE OBJECT for the kernel's relay tick. save_goals writes the entry (one file per entry
+    in a queue directory: append = create, consume = unlink, so the judge's thread and the kernel's tick never rewrite
+    each other's list) once THIS object is published, and only the saver holding the object flushes its own entries:
+    a save of the same sid by another holder, whose copy may not carry the marker yet, flushes nothing of ours (the
+    manager's fourth review; a module-level list shared by every tier and thread needed a lock and still flushed on
+    any save of the sid). The list is transient, a non-content key never serialized. A failed write is said; the
+    boot pass re-queues every marker without an entry (_requeue_relays_all)."""
+    pend = store.get("_relayPending")
+    if not isinstance(pend, list):
+        pend = store["_relayPending"] = []
+    nid = str(nd.get("id") or "")
+    if nid not in pend:
+        pend.append(nid)
 
 
-def _relay_write_entry(sid, nid):
+def _relay_write_entry(sid, nid, marker="", rev=0):
+    """One queue entry: the node, the marker it was written for (its id) and the store revision whose publish carried
+    the marker, so the tick can tell a spent entry (a record names the marker; the node moved on to a newer marker; a
+    published revision at or past this one lacks the marker) from one whose publish it has not read yet."""
     try:
         d = _relay_queue_dir()
         d.mkdir(parents=True, exist_ok=True)
         tmp = d / (".tmp-%s-%d" % (re.sub(r"[^A-Za-z0-9_.-]", "_", nid), os.getpid()))
-        tmp.write_text(json.dumps({"sid": sid, "nid": nid, "t": int(time.time())}))
+        tmp.write_text(json.dumps({"sid": sid, "nid": nid, "t": int(time.time()), "marker": str(marker or ""),
+                                   "rev": int(rev or 0)}))
         tmp.rename(_relay_entry_path(sid, nid))
         return True
     except OSError as e:
@@ -12891,18 +12966,23 @@ def _relay_write_entry(sid, nid):
         return False
 
 
-def _relay_flush(fsid):
-    """Write the queue entries of the store just saved (save_goals calls this after its publish)."""
-    mine = [(s_, n_) for s_, n_ in _RELAY_PENDING if s_ == str(fsid)]
-    if not mine:
-        return 0
-    _RELAY_PENDING[:] = [e for e in _RELAY_PENDING if e[0] != str(fsid)]
-    return sum(1 for s_, n_ in mine if _relay_write_entry(s_, n_))
+def _relay_flush(fsid, store, pending):
+    """Write the queue entries of the nodes in `pending` (the store object's own list, popped by save_goals) now that
+    `store` is on disk at store["rev"]. A node whose marker the publish's rebase settled and popped gets none (nothing
+    is left to relay). Returns the number written."""
+    n = 0
+    for nid in pending or []:
+        nd = (store.get("nodes") or {}).get(nid)
+        rw = nd.get("relayWanted") if isinstance(nd, dict) else None
+        if isinstance(rw, dict):
+            n += 1 if _relay_write_entry(str(fsid), str(nid), rw.get("id") or "", store.get("rev") or 0) else 0
+    return n
 
 
 def _requeue_relays_all():
     """Once per boot: every node carrying relayWanted with no queue entry gets one (a marker whose entry was lost to a
-    failed write or a stale merge would otherwise wait forever). Returns the number re-queued."""
+    failed write, a kernel restart between the publish and the flush, or a stale merge would otherwise wait forever).
+    Returns the number re-queued."""
     n = 0
     for p in (sorted(GOALDIR.glob("*.json")) if GOALDIR.is_dir() else []):
         try:
@@ -12911,7 +12991,7 @@ def _requeue_relays_all():
             continue
         for nid, nd in ((raw or {}).get("nodes") or {}).items():
             if isinstance(nd, dict) and isinstance(nd.get("relayWanted"), dict) and not _relay_entry_path(p.stem, nid).exists():
-                n += 1 if _relay_write_entry(p.stem, nid) else 0
+                n += 1 if _relay_write_entry(p.stem, nid, nd["relayWanted"].get("id") or "", (raw or {}).get("rev") or 0) else 0
     return n
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -4551,6 +4551,18 @@ def _rebase_onto_disk(fsid, store):
             with _authority():
                 mnd["log"] = sorted((mnd.get("log") or []) + add,
                                     key=lambda e: (int(e.get("ev_t") or 0), int(e.get("at") or 0)))
+        # T334: the relay's record rides plain node keys two writers touch (the judge marks relayWanted; the kernel's tick
+        # replaces it with relayed): the newer fact on disk wins over a stale in-memory copy, in either direction
+        for key in ("relayed", "relayDone"):        # the kernel's records of a relay sent, stood down or refused
+            if isinstance(dnd.get(key), dict) and not isinstance(mnd.get(key), dict):
+                mnd[key] = dnd[key]
+        def _settled(node, want):                    # a record at or after the marker settles it
+            return any(isinstance(node.get(k), dict) and int(node[k].get("t") or 0) >= int((want or {}).get("t") or 0)
+                       and node[k].get("why") == (want or {}).get("why") for k in ("relayed", "relayDone"))
+        if isinstance(dnd.get("relayWanted"), dict) and "relayWanted" not in mnd and not _settled(mnd, dnd["relayWanted"]):
+            mnd["relayWanted"] = dnd["relayWanted"]
+        if isinstance(mnd.get("relayWanted"), dict) and _settled(mnd, mnd["relayWanted"]):
+            mnd.pop("relayWanted", None)
         # `mt` is a monotonic last-touched stamp the read side orders and anchors on (a block's mt feeds the
         # card's disp_t), so it must not regress to our older snapshot — take the newer of the two. The
         # verdict FLAGS need no such care: rollup_status below re-derives them all from the merged log.
@@ -5613,6 +5625,7 @@ def save_goals(fsid, store):
         tmp.rename(GOALDIR / (fsid + ".json"))        # atomic publish
         published = True
         _shared_forget(str(GOALDIR / (fsid + ".json")))   # the shared read-only view of the old version goes
+        _relay_flush(fsid)                            # T334: the relay entries of markers this save just published
         #                                               with it (its identity check would miss anyway; this frees the bytes)
     finally:
         if base is not None:
@@ -7080,7 +7093,8 @@ def apply_plan(store, seg_id, seg_t, ops, menu, place_key=None, prompt_uuid=None
                     nodes[t].setdefault("trail", []).append(seg_id)
         elif do == "block":
             t = _target(o)
-            if t and record_verdict(store, nodes[t], "planner", "block", seg_t, why=o["why"], seg=seg_id):
+            _fb = file_block(store, nodes[t], "planner", o["why"], seg_t, seg=seg_id) if t else ("block", False)   # T334: a peer's
+            if _fb[1] and _fb[0] == "block":         #   block is a peer wait; an annotation, so no mt bump and no trail
                 nodes[t]["mt"] = seg_t; touched = t   # the event materialized the flags (blockWhy = why)
                 if seg_id and seg_id not in (nodes[t].get("trail") or []):
                     nodes[t].setdefault("trail", []).append(seg_id)   # same: the blocking segment is history
@@ -10592,6 +10606,27 @@ def _asks_user(nodes, nid):
     return False
 
 
+def _latch_prompt_msg_ids(session, store):
+    """Stamp promptMsgId on every parentless promptUuid-bearing top whose anchor atom the parse holds: the postal message
+    id its delivery text carries (em.postal_pairs, the first marker), or "" when it carries none (checked). The
+    delegating peer of a top is then the sender of THAT mail (_delegator_of), never merely the latest delegate the
+    session received (a worker dispatched by two managers relays each block to the manager that asked, T334)."""
+    cands = [nd for nd in store.get("nodes", {}).values()
+             if isinstance(nd, dict) and nd.get("parentId") is None and nd.get("promptUuid") and "promptMsgId" not in nd]
+    if not cands:
+        return 0
+    by_uuid = {a["uuid"]: a for turn in session.get("turns") or [] for a in turn.get("atoms") or [] if a.get("uuid")}
+    n = 0
+    for nd in cands:
+        a = by_uuid.get(nd["promptUuid"])
+        if a is None:
+            continue                                    # not in this parse: left for a parse that holds it
+        pairs = em.postal_pairs(_atom_text(a))
+        nd["promptMsgId"] = str(pairs[0][0]) if pairs else ""
+        n += 1
+    return n
+
+
 def _latch_skill_load_anchors(store, loads, now=None):
     """Stamp every parentless, promptUuid-bearing, origin-less top anchored on one of `loads` (T333, 2026-09-11:
     {record uuid: skill name} of the harness's own skill-load wrappers, the parse's own report of the records
@@ -11418,6 +11453,7 @@ def _plan_session(fsid, path, now):
         _group_store(store, fsid, now)
         save_goals(fsid, store)
     _note_checked(store, {a.get("uuid") for turn in session.get("turns") or [] for a in turn.get("atoms") or [] if a.get("uuid")})
+    _latch_prompt_msg_ids(session, store)             # T334: the mail a top's anchor names, for its delegating peer
     _latch_skill_load_anchors(store, session.get("skillLoads") or {}, now)   # the parse's own report of the wrappers its
     #                                                   emit skipped: a top the harness's skill load minted (T333)
     _latch_ask_anchors(fsid, session, store)          # durable ask-unit anchor verdicts — no LLM,
@@ -11472,6 +11508,17 @@ def run_plan(now=None, sessions_cap=PLAN_SESSIONS, concurrency=None, verbose=Fal
                                                                               len(_WRAP_INDEX), time.time() - _t0, _sw_tops, _sw_stores))
         except Exception as e:
             _log_judge_error("skill-load-sweep", "-", "the store-side skill-load pass raised: %r" % (e,))
+    if not _PEER_SWEEP["done"]:                       # T334: blocks already filed toward a peer become peer waits, once per boot
+        _PEER_SWEEP["done"] = True
+        try:
+            _pw_stores, _pw_nodes = restamp_peer_wait_blocks_all(now)
+            _rq = _requeue_relays_all()
+            if _rq:
+                sys.stderr.write("judge: %d relay marker(s) re-queued at boot\n" % _rq)
+            if _pw_nodes:
+                sys.stderr.write("judge: %d block(s) in %d store(s) addressed to a peer became peer waits\n" % (_pw_nodes, _pw_stores))
+        except Exception as e:
+            _log_judge_error("peer-wait-sweep", "-", "the store-side peer-wait pass raised: %r" % (e,))
     fleet = [s for s in discover(now) if not _hidden_from_feed(s[0])][:sessions_cap]   # muted sessions are out of task tracking
     for _gone in [f for f in _PLANNER_SEEN if f not in {s[0] for s in fleet}]:
         _PLANNER_SEEN.pop(_gone, None)                # the planner gate, bounded by the sessions this pass discovered
@@ -12630,6 +12677,284 @@ def _open_peer_asks(sid, since=0):
     return bool(_open_ask_peers(sid, since))
 
 
+# ── T334 (2026-09-11): a block addressed to a PEER is a peer wait, not the user's needs-you ──────────
+# CLAUDE.md: interrupt only when the human is the bottleneck; waiting on a peer, a build or another session is
+# not that. A worker session that ends its turn asking its manager (or any peer it has an open question to)
+# used to get the closer's or planner's BLOCK, which the feed shows as the user's needs-you card. The block's
+# ADDRESSEE is read from evidence, never from words alone: (a) the session's own open ask (a kind=question it
+# sent to a live peer with no record back since, the wait graph's and the peer-kind awaiting gate's one
+# source), (b) failing that, the peer that DELEGATED the goal the block sits under (the courier-planted top's
+# origin.peer: the team relation as recorded), and (c) words only to pick AMONG open asks (a peer's session
+# name in the block's text), never to invent a peer. A block in a managed session whose text names the user
+# explicitly still resolves to the delegating peer: the manager relays, and a worker's card reaches the user
+# only through the debt ladder's escalation event. The write is the existing awaiting/peer verdict in place
+# of the block (the chip "Awaiting <peer>" in Working, the auto-nudge already skipping peer waits, the peer's
+# reply the lift). Nothing resolves: the user, the block exactly as before.
+
+
+def _peer_name(sid):
+    """The session name NAMES records for `sid` ("" when none), or the name a cross-host key carries itself
+    ("peer:<host>:<name>" or "peer:<name>"): words pick among peers by this."""
+    key = str(sid)
+    if key.startswith("peer:"):
+        return key.rsplit(":", 1)[-1].strip()
+    try:
+        return (NAMES / key).read_text().split("\t", 1)[0].strip()
+    except Exception:
+        return ""
+
+
+_DELEG_CACHE = [None, {}]    # (mtime_ns, size), {to_sid: [(t, from_id), ...] ascending}: one scan per log change
+_DELEG_BY_MID = {}           # message id -> from_id of that delegate row (filled by the same scan)
+
+
+def _delegates_to():
+    """{recipient sid: [(t, from_id), ...] ascending} for every DELEGATE row in the postal log that reached its recipient
+    (a returned or withdrawn send, _learn_return, makes no entry): the team relation as the mail recorded it. The
+    courier's planted origin, when present, is derived from these rows; today's stores hold none, so this is the
+    primary record (T334). Cross-host rows key on the resolved to_sid like _postal_ask_maps."""
+    try:
+        st = MESSAGES.stat()
+        key = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return {}
+    if _DELEG_CACHE[0] == key:
+        return _DELEG_CACHE[1]
+    out, rows, returned, by_mid = {}, [], {}, {}
+    try:
+        for line in MESSAGES.read_text(errors="replace").splitlines():
+            try:
+                o = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(o, dict):
+                rows.append(o)
+                _learn_return(returned, o)
+        for o in rows:
+            if o.get("kind") != "delegate" or o.get("ev") not in (None, "sent"):
+                continue
+            f, t_, ts = o.get("from_id"), o.get("to_sid") or o.get("to_id"), o.get("t")
+            if not (f and t_ and ts) or str(o.get("id") or "") in returned or str(t_).startswith("peer:"):
+                continue
+            out.setdefault(str(t_), []).append((int(ts), str(f)))
+            if o.get("id"):
+                by_mid[str(o["id"])] = str(f)
+        for v in out.values():
+            v.sort()
+    except OSError:
+        return {}
+    _DELEG_BY_MID.clear(); _DELEG_BY_MID.update(by_mid)
+    _DELEG_CACHE[0], _DELEG_CACHE[1] = key, out
+    return out
+
+
+def _delegate_sender(mid):
+    """The from_id of the DELEGATE row with message id `mid` (the mail a top's anchor record names), or None."""
+    _delegates_to()
+    return _DELEG_BY_MID.get(str(mid))
+
+
+def _delegator_of(store, nid):
+    """The peer that delegated the work `nid` sits under, or None when the goal is the user's own. Two records, the
+    courier's first: the top's planted origin.peer; else the sender of the latest DELEGATE mail this session received
+    at or before the top was minted (_delegates_to), provided the latch has POSITIVELY read the top's anchor as a
+    machine record (askAnchor "machine": the dispatch mail, never a prompt the user typed). An unlatched top, one
+    whose anchor is gone ("absent") or a scheduled prompt's top is left to the user (fail open to the block), whatever
+    mail the session got before. A top minted before any delegate reached the session predates the relation."""
+    nodes = store.get("nodes", {})
+    top = _top_of(nodes, nid) if nid in nodes else None
+    tn = nodes.get(top) or {}
+    o = tn.get("origin")
+    if isinstance(o, dict) and o.get("peer"):
+        return None if ":" in str(o["peer"]) else str(o["peer"])   # same rule for a planted ext: origin
+    if not top or tn.get("askAnchor") != "machine":
+        return None
+    sid = str(store.get("rompUuid") or str(nid).rsplit(":", 1)[0])
+    peer = _delegate_sender(tn["promptMsgId"]) if tn.get("promptMsgId") else None   # the mail the anchor names, first
+    if not peer and not tn.get("promptMsgId"):    # no mail id on the anchor: the latest delegate at or before the mint
+        before = [r for r in _delegates_to().get(sid, []) if r[0] <= int(tn.get("t") or 0)]
+        peer = before[-1][1] if before else None
+    return None if not peer or ":" in peer else peer   # an ext: mailer or an unresolved cross-host key is no session that
+                                                       #   could ever be asked (judge _presumed_closed: closed by construction)
+
+
+def block_addressee(store, nd, why):
+    """The peer a block on `nd` is addressed to, else None: block_addressee_via without the how."""
+    return block_addressee_via(store, nd, why)[0]
+
+
+def block_addressee_via(store, nd, why):
+    """(peer, via) for a block on `nd`: via "ask" when the session's own open question names the peer (an ending
+    exists: the reply), "delegator" when only the courier's origin does (no question was ever sent, so the kernel
+    RELAYS the block's why to that peer as a question on the worker's behalf, once per block: relayWanted below),
+    or (None, None) when the block is the user's (T334, the rule above). Only a node
+    under a DELEGATED goal (a courier-planted top) is ever redirected: a managed session's block is the case, and the
+    user's own session, however many open questions it has out, keeps its blocks as its own decisions (an unrelated
+    open ask must never hide the user's own call behind "Awaiting <peer>"). An empty why is never redirected."""
+    if not str(why or "").strip():
+        return None, None
+    if not _delegator_of(store, str(nd.get("id") or "")):
+        return None, None
+    ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
+    if ho and ho.get("peer") and ":" not in str(ho["peer"]):
+        return str(ho["peer"]), "ask"                 # a block on a "delegated to <peer>" tracker under a delegated goal waits
+                                                       #   on that peer: the delegate is a reply-expecting send its report ends
+    sid = str(store.get("rompUuid") or str(nd.get("id") or "").rsplit(":", 1)[0])
+    nodes = store.get("nodes", {})
+    delegator = _delegator_of(store, str(nd.get("id") or ""))
+    top = _top_of(nodes, str(nd.get("id") or "")) if str(nd.get("id") or "") in nodes else None
+    since = int((nodes.get(top) or {}).get("t") or nd.get("t") or 0)   # an ask sent once the GOAL existed counts, even
+    peers = _open_ask_peers(sid, since=since)                          #   for a step minted after the worker asked
+    text = str(why or "").lower()
+    def named(p):
+        return bool(_peer_name(p)) and bool(re.search(r"\b%s\b" % re.escape(_peer_name(p).lower()), text))
+    if peers:
+        if delegator in peers and not any(named(p) for p in peers if p != delegator):
+            return delegator, "ask"                    # the open ask to the delegator IS the edge
+        hits = [p for p in peers if named(p)]
+        if len(hits) == 1:
+            return hits[0], "ask"                      # the words pick among the open asks
+        if delegator and not hits:
+            return delegator, "delegator"              # an open ask to a peer the block never names does not capture a
+                                                       #   block in the delegator's work: the delegator, relayed
+        _la, last_ask, _al = _postal_ask_maps()
+        return max(peers, key=lambda p: last_ask.get((sid, p), 0)), "ask"   # else the latest ask, the wait graph's rule
+    return delegator, "delegator"
+
+
+def file_block(store, nd, src, why, ev_t, t=None, seg=None):
+    """The one block writer for the judges (closer, planner): a block addressed to a peer (block_addressee) is
+    filed as the awaiting/peer stamp instead (an already-blocked node is unblocked by romp first, so the card
+    leaves Blocked), and only a block addressed to the user is filed as a block. Returns (kind, landed):
+    kind "peer" or "block"; landed True when a verdict was written."""
+    peer, via = block_addressee_via(store, nd, why)
+    if not peer:
+        return "block", bool(record_verdict(store, nd, src, "block", ev_t, why=why, seg=seg))
+    if any(e.get("kind") in ("awaiting", "done") and (e.get("lift") or e.get("kind") == "done")
+           and _wait_end_ev(e) > (ev_t or 0) for e in nd.get("log") or []):
+        return "peer", False                           # the wait this block describes already ENDED in the diary after
+                                                       #   this turn's evidence (the awaiting branch's own stand-down):
+                                                       #   a late closer neither re-stamps nor re-relays it
+    if nd.get("blocked") and next((e.get("src") for e in reversed(nd.get("log") or []) if e.get("kind") == "block"), None) \
+            not in ("closer", "planner"):
+        return "peer", False                           # the standing block is the ladder's escalation or an interrupt, romp's
+                                                       #   own once-ever record: a re-asserted judge block never lifts it
+    prior_standing = nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())   # read BEFORE any write:
+    if not prior_standing:                            #   record_verdict materializes awaitingKind at once (the manager's
+        nd.pop("relayed", None)                       #   third review); a wait that ended takes its relay record with it
+    landed = False
+    if nd.get("blocked"):
+        landed = bool(record_verdict(store, nd, "romp", "unblock", ev_t)) or landed
+    if not prior_standing:
+        landed = bool(record_verdict(store, nd, src, "awaiting", t if t is not None else ev_t, why=why,
+                                     await_kind="peer", await_peers=[peer], seg=seg)) or landed
+    # a peer wait on the same peer already standing is not re-filed, whatever the re-asserted words: the stamp keeps
+    # its since-time, so the relay sent after it (and the peer's reply after that) end exactly this wait
+    if via == "delegator" and not prior_standing and not isinstance(nd.get("relayWanted"), dict):
+        nd["relayWanted"] = {"peer": peer, "why": str(why), "t": int(t if t is not None else ev_t)}   # the kernel's
+        _relay_enqueue(store, nd)                  #   relay tick sends it as the worker's question, once per block: a
+        landed = True                              #   re-asserted block on a standing relayed wait never relays twice
+    return "peer", landed
+
+
+_RELAY_PENDING = []          # (sid, nid) marked this pass, written to the queue only once the store is SAVED (save_goals)
+
+
+def _relay_queue_dir():
+    return STATE / "relay-queue"
+
+
+def _relay_entry_path(sid, nid):
+    return _relay_queue_dir() / ("%s__%s.json" % (str(sid), re.sub(r"[^A-Za-z0-9_.-]", "_", str(nid))))
+
+
+def _relay_enqueue(store, nd):
+    """Remember (sid, nid) for the kernel's relay tick. The queue is a DIRECTORY of one file per entry (append = create,
+    consume = unlink: two writers, the judge's thread and the kernel's tick, never rewrite each other's list), and the
+    entry is written only after the store carrying the marker is saved (_relay_flush from save_goals), so the tick
+    never reads a store that lacks the marker and drops the entry. A failed write is said; the boot pass re-queues
+    every marker without an entry (_requeue_relays_all)."""
+    sid = str(store.get("rompUuid") or str(nd.get("id") or "").rsplit(":", 1)[0])
+    _RELAY_PENDING.append((sid, str(nd.get("id") or "")))
+
+
+def _relay_write_entry(sid, nid):
+    try:
+        d = _relay_queue_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        tmp = d / (".tmp-%s-%d" % (re.sub(r"[^A-Za-z0-9_.-]", "_", nid), os.getpid()))
+        tmp.write_text(json.dumps({"sid": sid, "nid": nid, "t": int(time.time())}))
+        tmp.rename(_relay_entry_path(sid, nid))
+        return True
+    except OSError as e:
+        _log_judge_error("relay-queue", sid, "relay queue entry not written (%r)" % (e,))
+        return False
+
+
+def _relay_flush(fsid):
+    """Write the queue entries of the store just saved (save_goals calls this after its publish)."""
+    mine = [(s_, n_) for s_, n_ in _RELAY_PENDING if s_ == str(fsid)]
+    if not mine:
+        return 0
+    _RELAY_PENDING[:] = [e for e in _RELAY_PENDING if e[0] != str(fsid)]
+    return sum(1 for s_, n_ in mine if _relay_write_entry(s_, n_))
+
+
+def _requeue_relays_all():
+    """Once per boot: every node carrying relayWanted with no queue entry gets one (a marker whose entry was lost to a
+    failed write or a stale merge would otherwise wait forever). Returns the number re-queued."""
+    n = 0
+    for p in (sorted(GOALDIR.glob("*.json")) if GOALDIR.is_dir() else []):
+        try:
+            raw = json.loads(p.read_text())
+        except Exception:
+            continue
+        for nid, nd in ((raw or {}).get("nodes") or {}).items():
+            if isinstance(nd, dict) and isinstance(nd.get("relayWanted"), dict) and not _relay_entry_path(p.stem, nid).exists():
+                n += 1 if _relay_write_entry(p.stem, nid) else 0
+    return n
+
+
+_PEER_SWEEP = {"done": False}
+
+
+def restamp_peer_wait_blocks_all(now=None):
+    """Rows already filed before T334: once per boot, every store's nodes blocked by the closer or the planner
+    (the newest block row's src) whose block resolves to a peer today are converted the way file_block does
+    (romp's unblock, then the awaiting/peer stamp with the block's own why), rolled up and saved. Idempotent: a
+    converted node is no longer blocked. Returns (stores, nodes)."""
+    now = now or int(time.time())
+    stores = nodes_n = 0
+    for p in (sorted(GOALDIR.glob("*.json")) if GOALDIR.is_dir() else []):
+        try:
+            raw = json.loads(p.read_text())
+        except Exception:
+            continue
+        if not isinstance(raw, dict):
+            continue
+        hits = [nid for nid, nd in (raw.get("nodes") or {}).items()
+                if isinstance(nd, dict) and nd.get("blocked") and not nd.get("cleared")
+                and next((e.get("src") for e in reversed(nd.get("log") or []) if e.get("kind") == "block"), None)
+                in ("closer", "planner")]
+        if not hits:
+            continue
+        store = load_goals(p.stem)
+        n = 0
+        for nid in hits:
+            nd = store["nodes"].get(nid)
+            if not isinstance(nd, dict) or not nd.get("blocked"):
+                continue
+            if block_addressee(store, nd, nd.get("blockWhy")):
+                kind, landed = file_block(store, nd, "romp", nd.get("blockWhy"), now)
+                n += 1 if landed else 0
+        if n:
+            rollup_status(store, False)
+            save_goals(p.stem, store)
+            stores += 1
+            nodes_n += n
+    return stores, nodes_n
+
+
 def _parse_close(raw, menu_len):
     """Parse the closer's {"done":[{goal,why}], "block":[{goal,why}], "awaiting":[{goal,why,kind}]} reply
     into {"done": {1-based idx: doneWhy}, "block": {1-based idx: blockWhy}, "awaiting": {1-based idx:
@@ -13136,10 +13461,11 @@ def apply_close(store, menu, verdicts, t=None, touched=None, t_overrides=None, t
                 nd["mt"] = ev
             newly.append(nd["id"])
         elif i in block:
-            if not record_verdict(store, nd, "closer", "block", ev, why=block[i] or None):   # the user's follow-up postdates this turn's evidence —
-                continue                               # their reply owns the verdict now, not this stale close
-            if ev is not None:                        # (the event materialized the flags + blockWhy)
-                nd["mt"] = ev
+            kind, landed = file_block(store, nd, "closer", block[i] or None, ev, t)   # T334: a peer's block is a peer wait
+            if not landed:                            # the user's follow-up postdates this turn's evidence: their reply
+                continue                              #   owns the verdict now, not this stale close (or a same stamp)
+            if ev is not None and kind == "block":    # (the event materialized the flags + blockWhy; a peer wait is an
+                nd["mt"] = ev                         #   annotation and never bumps mt)
         elif i in awaiting:
             aw_why = (awaiting[i] or {}).get("why") or None
             aw_kind = (awaiting[i] or {}).get("kind")

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -12830,6 +12830,12 @@ def block_addressee_via(store, nd, why):
         return None, None
     if not _delegator_of(store, str(nd.get("id") or "")):
         return None, None
+    nodes = store.get("nodes", {})
+    tn = nodes.get(_top_of(nodes, str(nd.get("id") or "")) or "") or {}
+    since = max(int(tn.get("t") or 0), int(nd.get("awaitingAt") or 0) if nd.get("awaitingKind") == "peer" else 0)
+    if int(_floor_of(store, nd) or 0) > since:
+        return None, None                              # the USER's own follow-up on the delegated card (the floor, newer than
+                                                       #   the delegation and the standing wait): their decision, never relayed
     ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
     if ho and ho.get("peer") and ":" not in str(ho["peer"]):
         return str(ho["peer"]), "ask"                 # a block on a "delegated to <peer>" tracker under a delegated goal waits
@@ -12864,6 +12870,9 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
     kind "peer" or "block"; landed True when a verdict was written."""
     peer, via = block_addressee_via(store, nd, why)
     if not peer:
+        if isinstance(nd.get("relayWanted"), dict):        # the block is the user's: a peer wait's unsent marker on this
+            _relay_mark_settled(nd, nd.pop("relayWanted").get("id") or "")   #   node (the wait ended, or the user's
+        #                                                    follow-up reclaimed the card) is settled, never relayed
         return "block", bool(record_verdict(store, nd, src, "block", ev_t, why=why, seg=seg))
     if any(e.get("kind") in ("awaiting", "done") and (e.get("lift") or e.get("kind") == "done")
            and _wait_end_ev(e) > (ev_t or 0) for e in nd.get("log") or []):
@@ -12875,8 +12884,12 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
         return "peer", False                           # the standing block is the ladder's escalation or an interrupt, romp's
                                                        #   own once-ever record: a re-asserted judge block never lifts it
     prior_standing = nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())   # read BEFORE any write:
-    if not prior_standing:                            #   record_verdict materializes awaitingKind at once (the manager's
-        nd.pop("relayed", None)                       #   third review); a wait that ended takes its relay record with it
+    #                                                   record_verdict materializes awaitingKind at once (the manager's third review)
+    if not prior_standing and isinstance(nd.get("relayWanted"), dict):
+        old = nd.pop("relayWanted")                    # the ENDED wait's marker, still unsent: a new wait never reuses it (the
+        _relay_mark_settled(nd, old.get("id") or "")   #   tick would relay the old words for the new question, or its stand-down
+        #                                                of the old id would leave a wait with nothing to end it; the manager's
+        #                                                fifth review); its entry, if one exists, is spent as settled
     landed = False
     if nd.get("blocked"):
         landed = bool(record_verdict(store, nd, "romp", "unblock", ev_t)) or landed
@@ -12885,20 +12898,21 @@ def file_block(store, nd, src, why, ev_t, t=None, seg=None):
                                      await_kind="peer", await_peers=[peer], seg=seg)) or landed
     # a peer wait on the same peer already standing is not re-filed, whatever the re-asserted words: the stamp keeps
     # its since-time, so the relay sent after it (and the peer's reply after that) end exactly this wait
-    if via == "delegator" and not prior_standing and not isinstance(nd.get("relayWanted"), dict):
+    if via == "delegator" and not prior_standing:  # a fresh marker for every new wait (the ended wait's went above)
         nd["relayWanted"] = {"peer": peer, "why": str(why), "t": int(t if t is not None else ev_t),
-                             "id": _relay_marker_id(t if t is not None else ev_t)}   # its identity: the records that
-        _relay_enqueue(store, nd)                  #   settle it name it. The kernel's relay tick sends it as the worker's
-        landed = True                              #   question, once per block: a re-asserted block on a standing
-                                                   #   relayed wait never relays twice
+                             "id": _relay_marker_id(t if t is not None else ev_t, peer)}   # its identity: the records
+        _relay_enqueue(store, nd)                  #   that settle it name it. The kernel's relay tick sends it as the
+        landed = True                              #   worker's question, once per block: a re-asserted block on a
+                                                   #   standing relayed wait never relays twice
     return "peer", landed
 
 
-def _relay_marker_id(ev_t):
-    """A relay marker's identity: the block's evidence time and a nonce. The records that settle a marker (relayed,
-    relayDone) name it and the queue entry carries it, so a re-block with the same words after a lift is a new marker
-    nothing older can settle (the manager's fourth review)."""
-    return "%d-%s" % (int(ev_t or 0), secrets.token_hex(4))
+def _relay_marker_id(ev_t, peer=""):
+    """A relay marker's identity: the block's evidence time and the peer. The records that settle a marker (relayed,
+    relayDone) name it and the queue entry carries it, so a re-block after a lift (later evidence) is a new marker
+    nothing older can settle (the manager's fourth review), while two holders filing ONE wait (the same evidence, the
+    same peer) mint the same id and each other's records settle it (the fifth review)."""
+    return "%d-%s" % (int(ev_t or 0), str(peer or "")[:8] or "peer")
 
 
 RELAY_SETTLED_CAP = 8        # settled marker ids a node remembers (relaySettled), newest last
@@ -12956,7 +12970,8 @@ def _relay_write_entry(sid, nid, marker="", rev=0):
     try:
         d = _relay_queue_dir()
         d.mkdir(parents=True, exist_ok=True)
-        tmp = d / (".tmp-%s-%d" % (re.sub(r"[^A-Za-z0-9_.-]", "_", nid), os.getpid()))
+        tmp = d / (".tmp-%s-%d-%s" % (re.sub(r"[^A-Za-z0-9_.-]", "_", nid), os.getpid(), secrets.token_hex(3)))
+        #             the judge's flush and the tick's rewrite share one process: a private name each
         tmp.write_text(json.dumps({"sid": sid, "nid": nid, "t": int(time.time()), "marker": str(marker or ""),
                                    "rev": int(rev or 0)}))
         tmp.rename(_relay_entry_path(sid, nid))

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13059,14 +13059,18 @@ def _relay_write_entry(sid, nid, marker="", rev=0):
     """One queue entry: the node, the marker it was written for (its id) and the store revision whose publish carried
     the marker, so the tick can tell a spent entry (a record names the marker; the node moved on to a newer marker; a
     published revision at or past this one lacks the marker) from one whose publish it has not read yet. The marker
-    "recall" names the node's recall entry, its own file beside the marker's."""
+    "recall" names the node's recall entry, its own file beside the marker's. Every entry carries a token of its own,
+    so the spend's re-read tells a fresh entry flushed over the path from the one it read (see _relay_spend)."""
     try:
         d = _relay_queue_dir()
         d.mkdir(parents=True, exist_ok=True)
         tmp = d / (".tmp-%s-%d-%s" % (re.sub(r"[^A-Za-z0-9_.-]", "_", nid), os.getpid(), secrets.token_hex(3)))
         #             the judge's flush and the tick's rewrite share one process: a private name each
         tmp.write_text(json.dumps({"sid": sid, "nid": nid, "t": int(time.time()), "marker": str(marker or ""),
-                                   "rev": int(rev or 0)}))
+                                   "rev": int(rev or 0), "token": secrets.token_hex(4)}))
+        #   token: the entry's own identity, compared by the tick's spend on its re-read (the third verdict: every
+        #   recall entry's marker is the constant "recall", so a fresh one the judge flushed over the path DURING a
+        #   pass read as the spent one and was unlinked with it; the marker id told marker entries apart, nothing did recalls)
         tmp.rename(_relay_recall_entry_path(sid, nid) if marker == "recall" else _relay_entry_path(sid, nid))
         return True
     except OSError as e:
@@ -15837,10 +15841,12 @@ def _owed_why(nd):
     """The owed question the block brief is fed for a blocked node: its blockWhy, and, when a relay of that question to
     the peer that delegated the work was refused (relayRefusal, the kernel's note beside the block: nobody could be
     asked), that note in brackets after it, so the brief can say why the decision came back to the user (the manager's
-    eighth review: the note was written and read by nothing)."""
+    eighth review: the note was written and read by nothing); the same for the kernel's note on a question a far
+    host still holds after the wait ended (relayCarried: carried on before it could be withdrawn, or the host
+    unreachable; the third verdict)."""
     why = str((nd or {}).get("blockWhy") or "")
-    ref = str((nd or {}).get("relayRefusal") or "").strip()
-    return "%s (%s)" % (why, ref) if ref else why
+    notes = [s for s in (str((nd or {}).get(k) or "").strip() for k in ("relayRefusal", "relayCarried")) if s]
+    return "%s (%s)" % (why, "; ".join(notes)) if notes else why
 
 
 def _distill_session(fsid, path, now):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2940,6 +2940,196 @@ def _debt_escalate(asker, debtor, ask_ts, now):
     return False
 
 
+def _delegated_to(manager, worker):
+    """True when `manager` delegated a goal to `worker` (a courier-planted top in the worker's store with origin.peer
+    naming the manager): the team relation as recorded, read from the shared store view (T334)."""
+    try:
+        store, _fault = jd.load_goals_shared_or_fault(worker)
+    except (OSError, ValueError, KeyError, TypeError) as e:
+        sys.stderr.write("delegated-to (%s -> %s): %r\n" % (manager, worker, e))
+        return False
+    for nd in (store or {}).get("nodes", {}).values():
+        o = nd.get("origin") if isinstance(nd, dict) else None
+        if nd.get("parentId") is None and isinstance(o, dict) and str(o.get("peer") or "") == str(manager):
+            return True
+    try:                                               # the primary record: a delegate mail from the manager to the worker
+        return any(f == str(manager) for _t, f in jd._delegates_to().get(str(worker), []))
+    except Exception as e:
+        sys.stderr.write("delegated-to (%s -> %s): %r\n" % (manager, worker, e))
+        return False
+
+
+def _bus_send_relay(payload):
+    """POST one relayed question to the bus's /send as the worker (from_id the worker's sid, kind question, relayed):
+    the bus resolves the recipient, writes the maildir and the log row every ending keys on. Returns (ok, error,
+    definitive, response): definitive when the bus REFUSED the send (a 4xx: no such live recipient, an isolated
+    mailbox), so a retry cannot help; a bus that could not be reached or failed (a 5xx) is not definitive. The
+    response carries the bus's id and, for a far host, "parked"."""
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=12)
+        conn.request("POST", "/send", json.dumps(payload), {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        try:
+            body = json.loads(data.decode("utf-8", "replace") or "{}")
+        except Exception:
+            body = {}
+        if resp.status != 200:
+            return False, "bus /send %d: %s" % (resp.status, data[:200].decode("utf-8", "replace")), 400 <= resp.status < 500, body
+        return True, "", False, body if isinstance(body, dict) else {}
+    except Exception as e:
+        return False, repr(e), False, {}
+
+
+_RELAY_SAID = set()           # (sid, nid) whose relay failed and was said once this boot
+_RELAY_BAD = {"n": 0}         # malformed queue entries dropped this boot (said once each)
+
+
+def _relay_parked_status(sid, peer, mid, at):
+    """A parked relay's outcome so far: "bounced" when a terminal row names its id (the far host refused, the mail was
+    destroyed or withdrawn), "answered" when the peer wrote to the worker after the park, else None (still pending)."""
+    try:
+        for r in _messages_rows():
+            if str(r.get("id") or "") == str(mid) and r.get("ev") in ("bounced", "recall"):
+                return "bounced"
+        last_any, _la, _aw = _postal_wait_maps()
+        if last_any.get((str(peer), str(sid)), 0) >= int(at or 0):
+            return "answered"
+    except Exception as e:
+        sys.stderr.write("relay parked status (%s): %r\n" % (str(mid)[:12], e))
+    return None
+
+
+def _relay_revert(store, nd, rw, err, now):
+    """Nobody can be asked: the block is the user's after all, filed with the refusal in its why, the node's mt bumped
+    and the views woken like every other block writer."""
+    peer = str(rw.get("peer") or "")
+    why = "%s (a relay to %s was refused: %s)" % (str(rw.get("why") or "").strip(), _name_of(peer) or peer[:8], str(err)[:160])
+    if jd.record_verdict(store, nd, "romp", "block", int(now), why=why):
+        nd["mt"] = int(now)
+    nd["relayDone"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "outcome": "refused"}
+    nd.pop("relayWanted", None)
+    _mark_views_dirty()
+
+
+def _relay_store(sid, ents, now):
+    """One store's queued relays (see _relay_tick): returns the number sent. Per entry (a file in the queue directory):
+    a node with no marker is consumed when a record (relayed, relayDone) settled it and KEPT when neither exists (the
+    save carrying the marker has not landed yet, never dropped); a node no longer waiting on that peer stands down
+    (relayDone stood-down); a parked relay is watched by its id until the peer answers (relayed) or the mail comes back
+    (a revert); a fresh one is sent, recorded relayed, or reverted on a definitive refusal, or kept on a transient one."""
+    store = jd.load_goals(sid)
+    n = 0
+    dirty = False
+    for f, e in ents:
+        nid = str(e["nid"])
+        nd = store["nodes"].get(nid)
+        rw = nd.get("relayWanted") if isinstance(nd, dict) else None
+        if not isinstance(rw, dict):
+            if nd is None or isinstance(nd.get("relayed"), dict) or isinstance(nd.get("relayDone"), dict):
+                f.unlink(missing_ok=True)                  # settled (or the node is gone): the entry is spent
+            continue                                       # else the marker's save has not landed yet: keep the entry
+        peer = str(rw.get("peer") or "")
+        standing = (nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())
+                    and not nd.get("nodeComplete") and not nd.get("cleared") and not nd.get("blocked"))
+        if not standing:
+            nd["relayDone"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "outcome": "stood-down"}
+            del nd["relayWanted"]                          # the wait ended or moved on before the relay: stand down
+            f.unlink(missing_ok=True)
+            dirty = True
+            continue
+        if rw.get("parkedMid"):                            # a far-host relay: pending until it lands or comes back
+            status = _relay_parked_status(sid, peer, rw["parkedMid"], rw.get("parkedAt"))
+            if status == "bounced":
+                _relay_revert(store, nd, rw, "the parked message came back", now)
+                f.unlink(missing_ok=True)
+                dirty = True
+            elif status == "answered":
+                nd["relayed"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "mid": rw["parkedMid"]}
+                del nd["relayWanted"]
+                f.unlink(missing_ok=True)
+                dirty = True
+                n += 1
+            continue
+        who = _name_of(sid) or sid[:8]
+        body = "%s cannot move further: %s" % (who, str(rw.get("why") or "").strip())
+        ok, err, definitive, resp = _bus_send_relay({"to": peer, "from": who, "from_id": sid, "body": body,
+                                                     "kind": "question", "relayed": True})
+        if ok and resp.get("parked"):
+            rw["parkedMid"] = str(resp.get("id") or "")   # the sent row is there; the entry watches for a bounce
+            rw["parkedAt"] = int(now)
+            dirty = True
+            continue
+        if ok:
+            nd["relayed"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "mid": str(resp.get("id") or "")}
+            del nd["relayWanted"]
+            f.unlink(missing_ok=True)
+            _RELAY_SAID.discard((sid, nid))
+            dirty = True
+            n += 1
+            continue
+        if definitive:                                     # nobody can be asked: the block is the user's after all
+            _relay_revert(store, nd, rw, err, now)
+            f.unlink(missing_ok=True)
+            _RELAY_SAID.discard((sid, nid))
+            dirty = True
+            sys.stderr.write("relay (%s, %s -> %s) refused for good: %s; the block stands as the user's\n"
+                             % (sid[:8], nid, peer[:8], err))
+            continue
+        if (sid, nid) not in _RELAY_SAID:
+            _RELAY_SAID.add((sid, nid))
+            sys.stderr.write("relay (%s, %s -> %s): %s; retried next tick\n" % (sid[:8], nid, peer[:8], err))
+    if dirty:
+        jd.rollup_status(store, False)
+        jd.save_goals(sid, store)
+    return n
+
+
+def _relay_tick(now):
+    """The RELAY (T334, the manager's ruling 2026-09-11): a block the judges addressed to the peer that DELEGATED the
+    work, with no question ever sent to that peer, would be a wait nothing can end (every ending keys on a reply-
+    expecting message the worker itself sent). So the judge leaves relayWanted on the node and, once the store is
+    saved, one entry file in STATE/relay-queue/ (a directory: append is a create, consume an unlink, so the judge's
+    thread and this tick never rewrite each other's list), and this tick sends the block's why to that peer as the
+    worker's own question, once per block: kind question, from the worker, body "<worker> cannot move further:
+    <why>", marked relayed (the row, the header and the inbox's comment say so, for the recipient and the courier).
+    That creates the edge: the peer's reply lifts the stamp, the reminder ladder covers it, and the idle-manager
+    escalation is the only door to the user. The recipient is always the delegating peer the record names, never
+    anyone else. A malformed entry is dropped and counted, never the others. Returns the number relayed."""
+    d = jd._relay_queue_dir()
+    if not d.is_dir():
+        return 0
+    by_sid = {}
+    for f in sorted(d.glob("*.json")):
+        try:
+            e = json.loads(f.read_text())
+            if not (isinstance(e, dict) and e.get("sid") and e.get("nid")):
+                raise ValueError("not an entry")
+        except Exception as ex:
+            _RELAY_BAD["n"] += 1
+            sys.stderr.write("relay queue: entry %s malformed (%r); dropped, the others stand\n" % (f.name, ex))
+            f.unlink(missing_ok=True)
+            continue
+        by_sid.setdefault(str(e["sid"]), []).append((f, e))
+    n = 0
+    for sid, ents in by_sid.items():
+        try:
+            n += _relay_store(sid, ents, now)
+        except Exception:
+            sys.stderr.write("relay (%s): %s\n" % (sid[:8], traceback.format_exc()))   # one store's fault never skips the others
+    return n
+
+
+def _postal_unread(sid):
+    """How many delivered postal messages `sid` has not read yet (its maildir new/): the one queued signal the
+    nudge walk's gates do not see (_backend_queued counts composer turns only). Best-effort 0."""
+    try:
+        return sum(1 for _ in (jd.STATE / "postal" / "mail" / str(sid) / "new").iterdir())
+    except OSError:
+        return 0
+
+
 def _debt_reminder_outcomes(sid, lt, now):
     """Judge this DEBTOR's past reminders at their exact outcome events, both once-ever: an ANSWERED ask
     retires its record silently (the reminder worked), and an ask still unanswered after a turn of the
@@ -2969,6 +3159,14 @@ def _debt_reminder_outcomes(sid, lt, now):
             drop.append(key)                           # return is the outcome, the bus told the asker
             continue
         if isinstance(fire_t, (int, float)) and lt_end > fire_t:
+            if _delegated_to(sid, asker) and _postal_unread(sid):
+                continue                               # T334: the asker's MANAGER runs many threads and its turns end
+                                                       #   constantly. This walk already reaches here only for an idle
+                                                       #   debtor (no composer turn queued, no turn in flight, no
+                                                       #   progressing state); the one queue those gates miss is
+                                                       #   delivered mail it has not read, so with worker mail waiting
+                                                       #   the manager is not yet failing to answer and the record stands.
+                                                       #   A peer that is not the asker's manager keeps the ladder as it was.
             _debt_escalate(asker, sid, ts, now)        # moved on without replying → the user's turn
             drop.append(key)
     if drop:
@@ -9911,6 +10109,12 @@ def _auto_nudge_pass(now, live_map, run_dead_wait):
         except Exception:
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
+    try:
+        _relay_tick(now)                               # T334: a worker's block toward its delegating peer goes out as its
+        #                                                question, once per block (mail, not an injected message: the toggle
+        #                                                below governs injected follow-ups, not the postal service)
+    except Exception:
+        sys.stderr.write("relay tick: %s\n" % traceback.format_exc())   # its own failure never skips the sweeps below
     try:
         if on:
             _debt_backstop_tick(now)                   # reminder outcomes for debtors the walk can't reach

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3012,6 +3012,8 @@ ROMP_VOICE_WORDS = ("romp", "card", "board", "goal", "cleared", "dismissal", "st
 #   tests/test_injected_voice.py's list of the same words, with the why of each, is pinned to this one
 RELAY_GENERIC_BODY = "%s cannot move further on this and needs your call."
 RELAY_UNKNOWN_HOLD = 30        # seconds a send or a recall with an unknown outcome is not repeated (the bus's own timeout, twice)
+RELAY_RECALL_TRIES = 8         # unanswered recall attempts before the hold stretches (about four minutes of asking)...
+RELAY_RECALL_BACKOFF = 60      # ...to thirty minutes between asks: a parked question nobody can withdraw is said, not hammered
 _ROMP_VOICE_RES = [re.compile(r"\b%s(?:s|es|ed|ing)?\b" % re.escape(w).replace(r"\ ", r"[ -]")) for w in ROMP_VOICE_WORDS]
 
 
@@ -3167,13 +3169,26 @@ def _relay_recall_sweep(sid, nd, now):
     if not owed:
         return False
     keep, done, changed = [], list(nd.get("relayRecalled") or []), False
+    next_at = 0                                            # when the earliest hold ends: the tick looks again then
     for r in owed:
-        if r.get("unknownAt") and int(now) - int(r["unknownAt"]) < RELAY_UNKNOWN_HOLD:
+        hold = RELAY_UNKNOWN_HOLD * (RELAY_RECALL_BACKOFF if int(r.get("attempts") or 0) >= RELAY_RECALL_TRIES else 1)
+        if r.get("unknownAt") and int(now) - int(r["unknownAt"]) < hold:
             keep.append(r)                                 # the bus could not be asked a moment ago: held, not hammered
+            next_at = min(next_at or 10**12, int(r["unknownAt"]) + hold)
             continue
         got = _bus_recall_relay(sid, r.get("pendingMid"))
         if got == "unknown":
             r["unknownAt"] = int(now)
+            r["attempts"] = int(r.get("attempts") or 0) + 1
+            next_at = min(next_at or 10**12, int(now) + (RELAY_UNKNOWN_HOLD * (RELAY_RECALL_BACKOFF if r["attempts"] >= RELAY_RECALL_TRIES else 1)))
+            key = (sid, str(r.get("pendingMid") or ""), "recall")
+            if r["attempts"] == 1 and key not in _RELAY_SAID:
+                _RELAY_SAID.add(key)
+                sys.stderr.write("relay recall (%s, %s): the bus could not be asked; asked again every %d s\n"
+                                 % (sid[:8], str(r.get("pendingMid") or "")[:12], RELAY_UNKNOWN_HOLD))
+            if r["attempts"] == RELAY_RECALL_TRIES:
+                sys.stderr.write("relay recall (%s, %s): %d tries unanswered; asked again every %d s from here\n"
+                                 % (sid[:8], str(r.get("pendingMid") or "")[:12], RELAY_RECALL_TRIES, RELAY_UNKNOWN_HOLD * RELAY_RECALL_BACKOFF))
             keep.append(r)
             changed = True
             continue
@@ -3186,7 +3201,7 @@ def _relay_recall_sweep(sid, nd, now):
     else:
         nd.pop("relayRecall", None)
     nd["relayRecalled"] = done[-jd.RELAY_SETTLED_CAP:]
-    return changed
+    return changed, (next_at or 0)
 
 
 def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
@@ -3200,11 +3215,12 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
     nid = str(e["nid"])
     marker = str(e.get("marker") or "")
     nd = store["nodes"].get(nid)
-    changed = False
+    changed, recall_next = False, 0
     if isinstance(nd, dict) and nd.get("relayRecall"):
-        changed = _relay_recall_sweep(sid, nd, now) or changed
-    if marker == "recall":                                 # an entry for recalls owed alone
-        return 0, changed, not (isinstance(nd, dict) and nd.get("relayRecall")), False
+        changed, recall_next = _relay_recall_sweep(sid, nd, now)
+    if marker == "recall":                                 # the node's recall entry (its own file beside the marker's)
+        owed = isinstance(nd, dict) and bool(nd.get("relayRecall"))
+        return 0, changed, not owed, (False if changed else (recall_next or True))
     rw = nd.get("relayWanted") if isinstance(nd, dict) else None
     if not isinstance(rw, dict) or (marker and str(rw.get("id") or "") != marker):
         if nd is None or _relay_record_names(nd, marker):
@@ -3251,11 +3267,17 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
             _RELAY_SAID.discard(said)
             return 0, True, True, False
         if not standing:                                   # the wait ended another way: the parked question is withdrawn
-            if rw.get("recallUnknownAt") and int(now) - int(rw["recallUnknownAt"]) < RELAY_UNKNOWN_HOLD:
-                return 0, changed, False, False            # the bus could not be asked a moment ago: held, not hammered
+            hold = RELAY_UNKNOWN_HOLD * (RELAY_RECALL_BACKOFF if int(rw.get("recallAttempts") or 0) >= RELAY_RECALL_TRIES else 1)
+            if rw.get("recallUnknownAt") and int(now) - int(rw["recallUnknownAt"]) < hold:
+                return 0, changed, False, int(rw["recallUnknownAt"]) + hold   # held: quiet until the hold ends
             got = _bus_recall_relay(sid, rw["pendingMid"])  #   so the far host never delivers a stale one
             if got == "unknown":
                 rw["recallUnknownAt"] = int(now)
+                rw["recallAttempts"] = int(rw.get("recallAttempts") or 0) + 1
+                if rw["recallAttempts"] in (1, RELAY_RECALL_TRIES):
+                    sys.stderr.write("relay recall (%s, %s): the bus could not be asked (%d tries); asked again every %d s\n"
+                                     % (sid[:8], nid, rw["recallAttempts"],
+                                        RELAY_UNKNOWN_HOLD * (RELAY_RECALL_BACKOFF if rw["recallAttempts"] >= RELAY_RECALL_TRIES else 1)))
                 return 0, True, False, False               # the bus could not be asked: the entry stays, asked again later
             _relay_settle(nd, rw, now, "relayDone", outcome="stood-down",
                           recall=("withdrawn" if got == "withdrawn" else "carried: could not be withdrawn"))
@@ -3267,8 +3289,8 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
         _RELAY_SAID.discard(said)
         return 0, True, True, False
     if rw.get("unknownAt") and int(now) - int(rw["unknownAt"]) < RELAY_UNKNOWN_HOLD:
-        return 0, changed, False, False                    # a send the bus may still be processing: the log is re-read
-                                                           #   each tick (above) and nothing is sent again meanwhile
+        return 0, changed, False, int(rw["unknownAt"]) + RELAY_UNKNOWN_HOLD   # a send the bus may still be processing:
+                                                           #   quiet until the hold ends or the log moves (its row lands)
     if alive_ids is not None and sid not in alive_ids:
         return 0, changed, False, not changed              # a dead worker asks nothing: the entry waits, quiet, for the
                                                            #   sweep's block to stand the marker down or the session to live
@@ -3337,7 +3359,7 @@ def _relay_store(sid, ents, now, alive_ids=None):
     others."""
     store = jd.load_goals(sid)
     n = 0
-    quiet = True
+    quiet, until = True, 0                                 # quiet: nothing to do until the key moves; until: or this time
     for f, e in ents:
         try:
             sent, changed, spent, q = _relay_entry(store, sid, f, e, int(store.get("rev") or 0), now, alive_ids)
@@ -3346,18 +3368,20 @@ def _relay_store(sid, ents, now, alive_ids=None):
             quiet = False
             continue
         n += sent
-        quiet = quiet and q
+        if q is False or q is None:
+            quiet = False
+        elif q is not True:                                # a time: a hold that ends on the clock, not on a file moving
+            until = min(until or 10**12, int(q))
         if changed:
             jd.rollup_status(store, False)
             jd.save_goals(sid, store)                      # the record lands first; a raise here keeps the entry
         if spent:
             nd = store["nodes"].get(str(e["nid"]))
-            if isinstance(nd, dict) and nd.get("relayRecall"):   # a recall still owed on this node (the bus could not be asked):
-                jd._relay_write_entry(sid, str(e["nid"]), "recall", int(store.get("rev") or 0))   # the entry becomes the
-                quiet = False                              #   recall's own, never spent with the marker's send (eighth review)
-            else:
-                _relay_spend(f, e)
-    return n, quiet
+            if isinstance(nd, dict) and nd.get("relayRecall") and not jd._relay_recall_entry_path(sid, str(e["nid"])).exists():
+                jd._relay_write_entry(sid, str(e["nid"]), "recall", int(store.get("rev") or 0))   # a recall still owed:
+                quiet = False                              #   its OWN entry beside the marker's (never a rewrite of the
+            _relay_spend(f, e)                             #   marker's file, which the judge may have renamed a newer
+    return n, (quiet and (until or True))                  #   marker's entry over meanwhile; the ninth review)
 
 
 def _relay_quiet_key(sid, ents, alive_ids=None):
@@ -3416,12 +3440,14 @@ def _relay_tick(now, alive_ids=None):
     for sid, ents in by_sid.items():
         try:
             key = _relay_quiet_key(sid, ents, alive_ids)
-            if key is not None and _RELAY_QUIET.get(sid) == key:
-                continue                                   # nothing it reads has moved since a pass that changed nothing
+            held = _RELAY_QUIET.get(sid)
+            if key is not None and held and held[0] == key and (held[1] is True or int(now) < int(held[1])):
+                continue                                   # nothing it reads has moved since a pass that changed nothing,
+                                                           #   and no hold of its has ended
             sent, quiet = _relay_store(sid, ents, now, alive_ids)
             n += sent
             if quiet and key is not None:
-                _RELAY_QUIET[sid] = key
+                _RELAY_QUIET[sid] = (key, quiet)           # quiet: True (until the key moves) or the time a hold ends
             else:
                 _RELAY_QUIET.pop(sid, None)
         except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2967,10 +2967,16 @@ def _bus_send_relay(payload):
     response carries the bus's id and, for a far host, "parked"."""
     try:
         conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=12)
-        conn.request("POST", "/send", json.dumps(payload), {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
-        resp = conn.getresponse()
-        data = resp.read()
-        conn.close()
+        try:
+            conn.request("POST", "/send", json.dumps(payload), {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
+        except Exception as e:
+            return False, repr(e), False, {}           # never written: a plain retry
+        try:
+            resp = conn.getresponse()
+            data = resp.read()
+            conn.close()
+        except Exception as e:                         # WRITTEN, no answer (a timeout, a dropped socket): the bus may have
+            return False, repr(e), False, {"unknown": True}   # delivered; unknown, not transient (the log decides next tick)
         try:
             body = json.loads(data.decode("utf-8", "replace") or "{}")
         except Exception:
@@ -2982,42 +2988,103 @@ def _bus_send_relay(payload):
         return False, repr(e), False, {}
 
 
+def _bus_recall_relay(sid, mid):
+    """POST /recall for a relayed question the worker no longer waits on (its wait ended another way before the far
+    host delivered): as the worker, by id. Returns "withdrawn" (the unread message is gone), "carried" (it left with an
+    exchange and can no longer be withdrawn, or was read), or "unknown" (the bus could not be asked)."""
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=12)
+        conn.request("POST", "/recall", json.dumps({"from_id": sid, "to": "", "id": mid}),
+                     {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
+        resp = conn.getresponse()
+        data = resp.read()
+        conn.close()
+        body = json.loads(data.decode("utf-8", "replace") or "{}") if resp.status == 200 else {}
+        if not isinstance(body, dict) or not body.get("ok"):
+            return "unknown"
+        return "withdrawn" if body.get("removed") else "carried"
+    except Exception:
+        return "unknown"
+
+
+RELAY_SCRUB_WORDS = ("romp", "card", "board", "goal", "cleared", "dismissal", "status check", "nudge")
+RELAY_GENERIC_BODY = "%s cannot move further on this and needs your call."
+
+
+def _relay_body(who, why):
+    """The relayed question's body, in the worker's voice to a peer that has never heard of romp: the plain lead-in and
+    the block's why, minus any clause that speaks romp (the judges' card-facing prose: "the goal is blocked", "card held
+    open"), and the lead-in alone for romp's own procedural whys (jd.procedural_block_why) or a why nothing survives
+    of (the injected-voice rule; tests/test_injected_voice.py renders this template)."""
+    who = str(who or "").strip() or "a session"
+    text = " ".join(str(why or "").split())
+    if not text or jd.procedural_block_why(text):
+        return RELAY_GENERIC_BODY % who
+    kept = [c.strip() for c in re.split(r"(?<=[.;:])\s+", text)
+            if c.strip() and not any(re.search(r"\b%s\b" % re.escape(w), c.lower()) for w in RELAY_SCRUB_WORDS)]
+    text = " ".join(kept).strip()
+    return "%s cannot move further: %s" % (who, text) if text else RELAY_GENERIC_BODY % who
+
+
 _RELAY_SAID = set()           # (sid, nid, marker) whose relay failed and was said once this boot
 _RELAY_BAD = {"n": 0}         # malformed queue entries dropped this boot (said once each)
 _RELAY_QUIET = {}             # sid -> what a pass that changed nothing read (_relay_quiet_key): not repeated until it moves
 
 
 def _relay_pending_status(sid, peer, mid, at):
-    """A pending relay's outcome so far, as (status, detail): ("bounced", where and why) when a bounced row names its
-    id (the far host refused it, or it was destroyed), ("withdrawn", "") when a recall row does, ("delivered", "")
-    when the far host's end-to-end ack names it (the postal log's `relayed` row), ("answered", "") when the peer wrote
-    to the worker AFTER the send (strictly after its second: a message in the send's own second is not its answer),
-    else (None, ""). Every row about the id was appended after the send, so the scan walks the log's tail down to
-    the send time (a margin for clock skew), never the whole log per pending entry per tick."""
+    """A pending relay's outcome so far, as (status, detail, t): ("bounced", where and why, row t) when a bounced row
+    names its id (the far host refused it, or it was destroyed), ("withdrawn", "", row t) when a recall row does,
+    ("delivered", "", row t) when the far host's end-to-end ack names it (the postal log's `relayed` row), ("answered",
+    "", 0) when the peer wrote to the worker AFTER the send (strictly after its second: a message in the send's own
+    second is not its answer), else (None, "", 0). Every row about the id was appended after the send, so the scan
+    walks the log's tail down to the send's own row, or to the send time with a margin for clock skew; a recovered
+    row (the rowless rebuild's, timed by the mail's Date header) never ends the walk."""
     try:
-        delivered = False
+        delivered = 0
         floor = int(at or 0) - 600
         for r in reversed(_messages_rows()):
-            if int(r.get("t") or 0) < floor:
-                break
-            if str(r.get("id") or "") != str(mid):
-                continue
+            same = str(r.get("id") or "") == str(mid)
             ev = r.get("ev")
+            if same and ev in (None, "sent"):
+                break                                  # the send's own row: nothing about the id lies below it
+            if not r.get("recovered") and int(r.get("t") or 0) < floor:
+                break
+            if not same:
+                continue
             if ev == "bounced":
                 host, why = str(r.get("host") or ""), str(r.get("why") or "").strip()
-                return "bounced", ("%s: %s" % (host, why) if host and why else (why or host))
+                return "bounced", ("%s: %s" % (host, why) if host and why else (why or host)), int(r.get("t") or 0)
             if ev == "recall":
-                return "withdrawn", ""
+                return "withdrawn", "", int(r.get("t") or 0)
             if ev == "relayed":
-                delivered = True
+                delivered = int(r.get("t") or 0) or 1
         if delivered:
-            return "delivered", ""
+            return "delivered", "", delivered
         last_any, _la, _aw = _postal_wait_maps()
         if last_any.get((str(peer), str(sid)), 0) > int(at or 0):
-            return "answered", ""
+            return "answered", "", 0
     except Exception as e:
         sys.stderr.write("relay pending status (%s): %r\n" % (str(mid)[:12], e))
-    return None, ""
+    return None, "", 0
+
+
+def _relay_sent_row(sid, peer, marker, since):
+    """The sent row of a relayed question for the marker `marker` from `sid`, if the bus wrote one (the authoritative
+    record: the row carries relayMarker as wire metadata), walking the log's tail down to the marker's time. A send
+    whose answer was lost, or whose record the tick could not save, is found here and adopted, never repeated."""
+    try:
+        floor = int(since or 0) - 600
+        for r in reversed(_messages_rows()):
+            if not r.get("recovered") and int(r.get("t") or 0) < floor:
+                break
+            if (r.get("ev") in (None, "sent") and r.get("relayed") and str(r.get("from_id") or "") == str(sid)
+                    and str(r.get("relayMarker") or "") == str(marker)
+                    and (str(r.get("to_id") or "") == str(peer) or str(r.get("to_id") or "").startswith("peer:")
+                         or str(r.get("to_sid") or "") == str(peer))):
+                return r
+    except Exception as e:
+        sys.stderr.write("relay sent row (%s): %r\n" % (str(marker)[:16], e))
+    return None
 
 
 def _relay_record(rw, now, **more):
@@ -3048,21 +3115,25 @@ def _relay_settle(nd, rw, now, key, **more):
     nd.pop("relayWanted", None)
 
 
-def _relay_revert(store, nd, rw, err, now):
+def _relay_revert(store, nd, rw, err, now, ev_t=None):
     """Nobody can be asked: the block is the user's after all, filed with the refusal in its why, the node's mt bumped
-    and the views woken like every other block writer."""
+    and the views woken like every other block writer. `ev_t` is the refusal's evidence time (a bounce row's t): a lift
+    another holder filed after it outranks this block in the fold, so an answered wait never comes back as needs-you."""
     peer = str(rw.get("peer") or "")
     why = "%s (a relay to %s was refused: %s)" % (str(rw.get("why") or "").strip(), _name_of(peer) or peer[:8], str(err)[:160])
-    if jd.record_verdict(store, nd, "romp", "block", int(now), why=why):
+    if jd.record_verdict(store, nd, "romp", "block", int(ev_t or now), why=why):
         nd["mt"] = int(now)
     _relay_settle(nd, rw, now, "relayDone", outcome="refused")
     _mark_views_dirty()
 
 
-def _relay_entry(store, sid, f, e, rev, now):
+def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
     """One queue entry against the loaded store: (sent, changed, spent, quiet). `changed` means the store must be saved,
     `spent` that the entry file is done once that save landed, `quiet` that nothing here needs another look until the
-    store, the log or the entries move (a pending relay, a kept entry); a transient failure is never quiet."""
+    store, the log or the entries move (a pending relay, a kept entry, a dead worker's); a transient failure is never
+    quiet. Order: a pending relay's outcome is read FIRST (delivered or answered settles it whatever the wait did), then
+    the wait's standing (a pending relay whose wait ended another way is recalled), then the fresh send, which adopts
+    the bus's own record of an earlier send for this marker before it sends anything."""
     nid = str(e["nid"])
     marker = str(e.get("marker") or "")
     nd = store["nodes"].get(nid)
@@ -3082,27 +3153,50 @@ def _relay_entry(store, sid, f, e, rev, now):
     said = (sid, nid, str(rw.get("id") or ""))
     standing = (nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())
                 and not nd.get("nodeComplete") and not nd.get("cleared") and not nd.get("blocked"))
-    if not standing:
-        _relay_settle(nd, rw, now, "relayDone", outcome="stood-down")   # the wait ended or moved on before the relay
-        _RELAY_SAID.discard(said)
-        return 0, True, True, False
-    if rw.get("pendingMid"):                               # handed to a far host: pending up to its landing or its return
-        status, detail = _relay_pending_status(sid, peer, rw["pendingMid"], rw.get("pendingAt"))
-        if status in ("bounced", "withdrawn"):
-            err = ("the message was withdrawn" if status == "withdrawn"
-                   else "the message came back from %s" % (detail or rw.get("pendingHost") or "the far host"))
-            _relay_revert(store, nd, rw, err, now)
-            _RELAY_SAID.discard(said)
-            return 0, True, True, False
+    if rw.get("pendingMid"):                               # handed to a far host: its outcome first, whatever the wait did
+        status, detail, row_t = _relay_pending_status(sid, peer, rw["pendingMid"], rw.get("pendingAt"))
         if status in ("delivered", "answered"):
             _relay_settle(nd, rw, now, "relayed", mid=str(rw["pendingMid"]))
             _RELAY_SAID.discard(said)
             return 1, True, True, False
+        if status in ("bounced", "withdrawn"):
+            if standing:                                   # nobody was asked after all: the user's block, at the row's time
+                err = ("the relayed question was withdrawn by %s" % (_name_of(sid) or sid[:8]) if status == "withdrawn"
+                       else "the message came back from %s" % (detail or rw.get("pendingHost") or "the far host"))
+                _relay_revert(store, nd, rw, err, now, ev_t=row_t or None)
+            else:                                          # the wait ended another way: nothing to revert to
+                _relay_settle(nd, rw, now, "relayDone", outcome="stood-down", pending=status)
+            _RELAY_SAID.discard(said)
+            return 0, True, True, False
+        if not standing:                                   # the wait ended another way: the parked question is withdrawn
+            got = _bus_recall_relay(sid, rw["pendingMid"])  #   so the far host never delivers a stale one
+            _relay_settle(nd, rw, now, "relayDone", outcome="stood-down",
+                          recall=("withdrawn" if got == "withdrawn" else "carried: could not be withdrawn"))
+            _RELAY_SAID.discard(said)
+            return 0, True, True, False
         return 0, False, False, True
+    if not standing:
+        _relay_settle(nd, rw, now, "relayDone", outcome="stood-down")   # the wait ended or moved on before the relay
+        _RELAY_SAID.discard(said)
+        return 0, True, True, False
+    prior = _relay_sent_row(sid, peer, str(rw.get("id") or ""), rw.get("t"))
+    if prior is not None:                                  # the bus already holds a send for this marker (its record was
+        to_id = str(prior.get("to_id") or "")              #   lost to a failed save, a restart or a dropped answer): adopt
+        if to_id.startswith("peer:"):                      #   it, never send it twice
+            rw["pendingMid"] = str(prior.get("id") or "")
+            rw["pendingAt"] = int(prior.get("t") or now)
+            rw["pendingHost"] = to_id[5:]
+            return 0, True, False, False
+        _relay_settle(nd, rw, now, "relayed", mid=str(prior.get("id") or ""))
+        _RELAY_SAID.discard(said)
+        return 1, True, True, False
+    if alive_ids is not None and sid not in alive_ids:
+        return 0, False, False, True                       # a dead worker asks nothing: the entry waits, quiet, for the
+                                                           #   sweep's block to stand the marker down or the session to live
     who = _name_of(sid) or sid[:8]
-    body = "%s cannot move further: %s" % (who, str(rw.get("why") or "").strip())
+    body = _relay_body(who, rw.get("why"))
     ok, err, definitive, resp = _bus_send_relay({"to": peer, "from": who, "from_id": sid, "body": body,
-                                                 "kind": "question", "relayed": True})
+                                                 "kind": "question", "relayed": True, "relayMarker": str(rw.get("id") or "")})
     if ok and (resp.get("parked") or ("to" not in resp and resp.get("id"))):
         rw["pendingMid"] = str(resp.get("id") or "")       # the relay leg answered (parked, or in flight to a host that
         rw["pendingAt"] = int(now)                         #   is up): the sent row is there, and the relay completes only
@@ -3118,13 +3212,17 @@ def _relay_entry(store, sid, f, e, rev, now):
         sys.stderr.write("relay (%s, %s -> %s) refused for good: %s; the block stands as the user's\n"
                          % (sid[:8], nid, peer[:8], err))
         return 0, True, True, False
+    if resp.get("unknown"):                                # written, unanswered: the bus's row decides next tick
+        sys.stderr.write("relay (%s, %s -> %s): %s; the outcome is unknown, the log decides next tick\n"
+                         % (sid[:8], nid, peer[:8], err))
+        return 0, False, False, False
     if said not in _RELAY_SAID:
         _RELAY_SAID.add(said)
         sys.stderr.write("relay (%s, %s -> %s): %s; retried next tick\n" % (sid[:8], nid, peer[:8], err))
     return 0, False, False, False
 
 
-def _relay_store(sid, ents, now):
+def _relay_store(sid, ents, now, alive_ids=None):
     """One store's queued relays (see _relay_tick): (sent, quiet). Per entry (a file in the queue directory naming
     the node, the marker it was written for and the store revision whose publish carried the marker): an entry whose
     node carries no marker is SPENT when a record names its marker, when the node is gone, or when the store's
@@ -3143,7 +3241,7 @@ def _relay_store(sid, ents, now):
     quiet = True
     for f, e in ents:
         try:
-            sent, changed, spent, q = _relay_entry(store, sid, f, e, int(store.get("rev") or 0), now)
+            sent, changed, spent, q = _relay_entry(store, sid, f, e, int(store.get("rev") or 0), now, alive_ids)
         except Exception:
             sys.stderr.write("relay (%s, %s): %s\n" % (sid[:8], str(e.get("nid"))[:32], traceback.format_exc()))
             quiet = False
@@ -3158,7 +3256,7 @@ def _relay_store(sid, ents, now):
     return n, quiet
 
 
-def _relay_quiet_key(sid, ents):
+def _relay_quiet_key(sid, ents, alive_ids=None):
     """What a pass over `sid`'s entries reads, by identity: the store file, the postal log and the entries themselves
     (mtime and size). A pass that changed nothing (every entry pending or kept) is not repeated until one moves, so
     a relay parked for a host that is down costs no store parse per tick. None when a stat fails (never quiet)."""
@@ -3166,24 +3264,27 @@ def _relay_quiet_key(sid, ents):
         s1 = (jd.GOALDIR / (sid + ".json")).stat()
         s2 = jd.MESSAGES.stat() if jd.MESSAGES.exists() else None
         ek = tuple(sorted((f.name, f.stat().st_mtime_ns, f.stat().st_size) for f, _e in ents))
-        return ((s1.st_mtime_ns, s1.st_size), (s2.st_mtime_ns, s2.st_size) if s2 else None, ek)
+        alive = True if alive_ids is None else (sid in alive_ids)   # a worker coming to life is a change too
+        return ((s1.st_mtime_ns, s1.st_size), (s2.st_mtime_ns, s2.st_size) if s2 else None, ek, alive)
     except OSError:
         return None
 
 
-def _relay_tick(now):
+def _relay_tick(now, alive_ids=None):
     """The RELAY (T334, the manager's ruling 2026-09-11): a block the judges addressed to the peer that DELEGATED the
     work, with no question ever sent to that peer, would be a wait nothing can end (every ending keys on a reply-
     expecting message the worker itself sent). So the judge leaves relayWanted on the node and, once the store is
     saved, one entry file in STATE/relay-queue/ (a directory: append is a create, consume an unlink, so the judge's
     thread and this tick never rewrite each other's list), and this tick sends the block's why to that peer as the
     worker's own question, once per block: kind question, from the worker, body "<worker> cannot move further:
-    <why>", marked relayed (the row, the header and the inbox's comment say so, for the recipient and the courier).
-    That creates the edge: the peer's reply lifts the stamp, the reminder ladder covers it, and the idle-manager
-    escalation is the only door to the user. The recipient is always the delegating peer the record names, never
-    anyone else. Every marker has an identity (its id) that its entry and the record settling it name. A malformed
-    entry is dropped and counted, never the others. A store whose pass changed nothing is not read again until the
-    store, the log or its entries move. Returns the number relayed."""
+    <why>" with any clause that speaks romp scrubbed (_relay_body), marked relayed in the row and the header, the
+    row naming the marker. That creates the edge: the peer's reply lifts the stamp, the reminder ladder covers it, and
+    the idle-manager escalation is the only door to the user. The recipient is always the delegating peer the record
+    names, never anyone else. Every marker has an identity (its id) that its entry, the sent row and the record
+    settling it name, so a send whose record was lost is adopted, never repeated. A dead worker's entry (`alive_ids`,
+    the pusher's live set; None gates nothing) waits quiet. A malformed entry is dropped and counted, never the others.
+    A store whose pass changed nothing is not read again until the store, the log or its entries move. Returns the
+    number relayed."""
     d = jd._relay_queue_dir()
     if not d.is_dir():
         return 0
@@ -3204,10 +3305,10 @@ def _relay_tick(now):
     n = 0
     for sid, ents in by_sid.items():
         try:
-            key = _relay_quiet_key(sid, ents)
+            key = _relay_quiet_key(sid, ents, alive_ids)
             if key is not None and _RELAY_QUIET.get(sid) == key:
                 continue                                   # nothing it reads has moved since a pass that changed nothing
-            sent, quiet = _relay_store(sid, ents, now)
+            sent, quiet = _relay_store(sid, ents, now, alive_ids)
             n += sent
             if quiet and key is not None:
                 _RELAY_QUIET[sid] = key
@@ -10208,7 +10309,7 @@ def _auto_nudge_pass(now, live_map, run_dead_wait):
             sys.stderr.write("auto-nudge (session %s): %s\n"
                              % (s.get("sid") or "?", traceback.format_exc()))
     try:
-        _relay_tick(now)                               # T334: a worker's block toward its delegating peer goes out as its
+        _relay_tick(now, alive_ids)                    # T334: a worker's block toward its delegating peer goes out as its
         #                                                question, once per block (mail, not an injected message: the toggle
         #                                                below governs injected follow-ups, not the postal service)
     except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3007,26 +3007,33 @@ def _bus_recall_relay(sid, mid):
         return "unknown"
 
 
-RELAY_SCRUB_WORDS = ("romp", "card", "board", "goal", "cleared", "dismissal", "status check", "nudge")
+ROMP_VOICE_WORDS = ("romp", "card", "board", "goal", "cleared", "dismissal", "status check", "nudge")
+#   the vocabulary an injected body must never speak to a session (CLAUDE.md, "Messages we inject into a session");
+#   tests/test_injected_voice.py's list of the same words, with the why of each, is pinned to this one
 RELAY_GENERIC_BODY = "%s cannot move further on this and needs your call."
+RELAY_UNKNOWN_HOLD = 30        # seconds a send with an unknown outcome is not repeated (the bus's own timeout, twice)
+_ROMP_VOICE_RES = [re.compile(r"\b%s(?:s|es|ed|ing)?\b" % re.escape(w).replace(r"\ ", r"[ -]")) for w in ROMP_VOICE_WORDS]
 
 
 def _relay_body(who, why):
     """The relayed question's body, in the worker's voice to a peer that has never heard of romp: the plain lead-in and
-    the block's why, minus any clause that speaks romp (the judges' card-facing prose: "the goal is blocked", "card held
-    open"), and the lead-in alone for romp's own procedural whys (jd.procedural_block_why) or a why nothing survives
-    of (the injected-voice rule; tests/test_injected_voice.py renders this template)."""
+    the block's why, minus any clause that reads as romp's (a romp word, an inflection included, and no question in
+    it: the judges' card-facing prose, "the goal is blocked", "card held open"); a clause with a question is always
+    kept, whatever it names. Romp's own procedural whys (the nudge's, the interrupt's, the wake's exactly; the debt
+    ladder's prefix only with no question in it) and a why nothing survives of ride as the lead-in alone
+    (tests/test_injected_voice.py renders both templates)."""
     who = str(who or "").strip() or "a session"
     text = " ".join(str(why or "").split())
-    if not text or jd.procedural_block_why(text):
+    procedural = text in jd._PROCEDURAL_BLOCK_WHYS or (text.startswith(jd.DEBT_BLOCK_WHY_PREFIX) and "?" not in text)
+    if not text or procedural:
         return RELAY_GENERIC_BODY % who
-    kept = [c.strip() for c in re.split(r"(?<=[.;:])\s+", text)
-            if c.strip() and not any(re.search(r"\b%s\b" % re.escape(w), c.lower()) for w in RELAY_SCRUB_WORDS)]
+    kept = [c.strip() for c in re.split(r"(?<=[.;:?])\s+", text)
+            if c.strip() and ("?" in c or not any(rx.search(c.lower()) for rx in _ROMP_VOICE_RES))]
     text = " ".join(kept).strip()
     return "%s cannot move further: %s" % (who, text) if text else RELAY_GENERIC_BODY % who
 
 
-_RELAY_SAID = set()           # (sid, nid, marker) whose relay failed and was said once this boot
+_RELAY_SAID = set()           # (sid, nid, marker[, "unknown"]) whose relay failed or stalled and was said once this boot
 _RELAY_BAD = {"n": 0}         # malformed queue entries dropped this boot (said once each)
 _RELAY_QUIET = {}             # sid -> what a pass that changed nothing read (_relay_quiet_key): not repeated until it moves
 
@@ -3034,11 +3041,11 @@ _RELAY_QUIET = {}             # sid -> what a pass that changed nothing read (_r
 def _relay_pending_status(sid, peer, mid, at):
     """A pending relay's outcome so far, as (status, detail, t): ("bounced", where and why, row t) when a bounced row
     names its id (the far host refused it, or it was destroyed), ("withdrawn", "", row t) when a recall row does,
-    ("delivered", "", row t) when the far host's end-to-end ack names it (the postal log's `relayed` row), ("answered",
-    "", 0) when the peer wrote to the worker AFTER the send (strictly after its second: a message in the send's own
-    second is not its answer), else (None, "", 0). Every row about the id was appended after the send, so the scan
-    walks the log's tail down to the send's own row, or to the send time with a margin for clock skew; a recovered
-    row (the rowless rebuild's, timed by the mail's Date header) never ends the walk."""
+    ("delivered", "", row t) when the far host's end-to-end ack names it (the postal log's `relayed` row), else
+    (None, "", 0). Delivery PROOF is required: a message parked or in flight cannot have been read, so a later message
+    from the peer is not its answer (the manager's sixth review). Every row about the id was appended after the send,
+    so the scan walks the log's tail down to the send's own row, or to the send time with a margin for clock skew; a
+    recovered row (the rowless rebuild's, timed by the mail's Date header) never ends the walk."""
     try:
         delivered = 0
         floor = int(at or 0) - 600
@@ -3060,9 +3067,6 @@ def _relay_pending_status(sid, peer, mid, at):
                 delivered = int(r.get("t") or 0) or 1
         if delivered:
             return "delivered", "", delivered
-        last_any, _la, _aw = _postal_wait_maps()
-        if last_any.get((str(peer), str(sid)), 0) > int(at or 0):
-            return "answered", "", 0
     except Exception as e:
         sys.stderr.write("relay pending status (%s): %r\n" % (str(mid)[:12], e))
     return None, "", 0
@@ -3071,14 +3075,21 @@ def _relay_pending_status(sid, peer, mid, at):
 def _relay_sent_row(sid, peer, marker, since):
     """The sent row of a relayed question for the marker `marker` from `sid`, if the bus wrote one (the authoritative
     record: the row carries relayMarker as wire metadata), walking the log's tail down to the marker's time. A send
-    whose answer was lost, or whose record the tick could not save, is found here and adopted, never repeated."""
+    whose answer was lost, or whose record the tick could not save, is found here and adopted, never repeated. A row
+    whose id the bus bounced as NOT PARKED (the relay leg's 503: the outbox record could not be written, nothing left)
+    was never sent and is skipped."""
     try:
         floor = int(since or 0) - 600
+        tail = []
         for r in reversed(_messages_rows()):
             if not r.get("recovered") and int(r.get("t") or 0) < floor:
                 break
+            tail.append(r)
+        unsent = {str(r.get("id") or "") for r in tail
+                  if r.get("ev") == "bounced" and (r.get("notParked") or "not parked" in str(r.get("why") or "").lower())}
+        for r in tail:
             if (r.get("ev") in (None, "sent") and r.get("relayed") and str(r.get("from_id") or "") == str(sid)
-                    and str(r.get("relayMarker") or "") == str(marker)
+                    and str(r.get("relayMarker") or "") == str(marker) and str(r.get("id") or "") not in unsent
                     and (str(r.get("to_id") or "") == str(peer) or str(r.get("to_id") or "").startswith("peer:")
                          or str(r.get("to_sid") or "") == str(peer))):
                 return r
@@ -3116,51 +3127,113 @@ def _relay_settle(nd, rw, now, key, **more):
 
 
 def _relay_revert(store, nd, rw, err, now, ev_t=None):
-    """Nobody can be asked: the block is the user's after all, filed with the refusal in its why, the node's mt bumped
-    and the views woken like every other block writer. `ev_t` is the refusal's evidence time (a bounce row's t): a lift
-    another holder filed after it outranks this block in the fold, so an answered wait never comes back as needs-you."""
+    """Nobody can be asked: the block is the user's after all, filed with the block's own why (the mechanism's note
+    goes to relayRefusal, never into a why the nudge and the follow-up quote), the node's mt bumped and the views
+    woken like every other block writer. `ev_t` is the refusal's evidence time (a bounce row's t), so a user reopen
+    filed between the bounce and this tick outranks the block; a lift another holder saved meanwhile is read by the
+    caller before the revert (_relay_ended_since)."""
     peer = str(rw.get("peer") or "")
-    why = "%s (a relay to %s was refused: %s)" % (str(rw.get("why") or "").strip(), _name_of(peer) or peer[:8], str(err)[:160])
-    if jd.record_verdict(store, nd, "romp", "block", int(ev_t or now), why=why):
+    if jd.record_verdict(store, nd, "romp", "block", int(ev_t or now), why=str(rw.get("why") or "").strip()):
         nd["mt"] = int(now)
+    nd["relayRefusal"] = "a relay to %s was refused: %s" % (_name_of(peer) or peer[:8], str(err)[:160])
     _relay_settle(nd, rw, now, "relayDone", outcome="refused")
     _mark_views_dirty()
+
+
+def _relay_ended_since(sid, nid, t):
+    """True when the node ON DISK (a fresh read: another holder may have saved since this pass loaded the store) ended
+    the wait at or after `t`: a lift or a done whose evidence horizon is at or past it, or a node complete or cleared.
+    The bounce revert asks this first, so an answered wait never comes back as needs-you (the manager's sixth review)."""
+    try:
+        fresh = jd.load_goals(sid)["nodes"].get(nid)
+    except Exception:
+        return False
+    if not isinstance(fresh, dict):
+        return True
+    if fresh.get("nodeComplete") or fresh.get("cleared"):
+        return True
+    return any(e.get("kind") in ("awaiting", "done") and (e.get("lift") or e.get("kind") == "done")
+               and int(jd._wait_end_ev(e) or 0) >= int(t or 0) for e in fresh.get("log") or [])
+
+
+def _relay_recall_sweep(sid, nd, now):
+    """Recall every relayed question the node owes a recall for (relayRecall: markers retired by the judge after they
+    were handed to a far host). A recall the bus answered (withdrawn, or carried and so beyond withdrawal) is done and
+    remembered (relayRecalled); one the bus could not be asked for stays owed for the next tick. Returns True when the
+    node changed."""
+    owed = [r for r in (nd.get("relayRecall") or []) if isinstance(r, dict)]
+    if not owed:
+        return False
+    keep, done = [], [x for x in (nd.get("relayRecalled") or []) if isinstance(x, str)]
+    for r in owed:
+        got = _bus_recall_relay(sid, r.get("pendingMid"))
+        if got == "unknown":
+            keep.append(r)
+            continue
+        done.append(str(r.get("pendingMid") or ""))
+        jd._relay_mark_settled(nd, r.get("id") or "")
+    if keep:
+        nd["relayRecall"] = keep
+    else:
+        nd.pop("relayRecall", None)
+    nd["relayRecalled"] = done[-jd.RELAY_SETTLED_CAP:]
+    return len(keep) != len(owed)
 
 
 def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
     """One queue entry against the loaded store: (sent, changed, spent, quiet). `changed` means the store must be saved,
     `spent` that the entry file is done once that save landed, `quiet` that nothing here needs another look until the
     store, the log or the entries move (a pending relay, a kept entry, a dead worker's); a transient failure is never
-    quiet. Order: a pending relay's outcome is read FIRST (delivered or answered settles it whatever the wait did), then
-    the wait's standing (a pending relay whose wait ended another way is recalled), then the fresh send, which adopts
-    the bus's own record of an earlier send for this marker before it sends anything."""
+    quiet. Order: the recalls the node owes, then the bus's own record of an earlier send for this marker (adopted:
+    a local row settles relayed, a relay-leg row becomes pending), then a pending relay's outcome (delivered settles
+    it whatever the wait did; a bounce on an ended wait stands down), then the wait's standing (an ended wait's
+    pending relay is recalled), then the fresh send, held for RELAY_UNKNOWN_HOLD after an unknown outcome."""
     nid = str(e["nid"])
     marker = str(e.get("marker") or "")
     nd = store["nodes"].get(nid)
+    changed = False
+    if isinstance(nd, dict) and nd.get("relayRecall"):
+        changed = _relay_recall_sweep(sid, nd, now) or changed
+    if marker == "recall":                                 # an entry for recalls owed alone
+        return 0, changed, not (isinstance(nd, dict) and nd.get("relayRecall")), False
     rw = nd.get("relayWanted") if isinstance(nd, dict) else None
     if not isinstance(rw, dict) or (marker and str(rw.get("id") or "") != marker):
         if nd is None or _relay_record_names(nd, marker):
-            return 0, False, True, False                   # spent: the node is gone, or a record names the marker
+            return 0, changed, True, False                 # spent: the node is gone, or a record names the marker
         if isinstance(rw, dict):                           # the node carries another marker: the entry is REWRITTEN for
             jd._relay_write_entry(sid, nid, rw.get("id") or "", rev)   #   the live one, never unlinked (the path may
-            return 0, False, False, False                  #   already be that newer flush); the next tick sends it
+            return 0, changed, False, False                #   already be that newer flush); the next tick sends it
         if rev >= int(e.get("rev") or 0):
             sys.stderr.write("relay (%s, %s): marker %s gone with no record at rev %d; the entry is dropped\n"
                              % (sid[:8], nid, marker[:16] or "?", rev))
-            return 0, False, True, False                   # the publish that wrote the entry (or a later one) is on disk
-        return 0, False, False, True                       # the store on disk predates the entry's publish: kept
+            return 0, changed, True, False                 # the publish that wrote the entry (or a later one) is on disk
+        return 0, changed, False, not changed              # the store on disk predates the entry's publish: kept
     peer = str(rw.get("peer") or "")
     said = (sid, nid, str(rw.get("id") or ""))
     standing = (nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())
                 and not nd.get("nodeComplete") and not nd.get("cleared") and not nd.get("blocked"))
+    if not rw.get("pendingMid"):
+        prior = _relay_sent_row(sid, peer, str(rw.get("id") or ""), rw.get("t"))
+        if prior is not None:                              # the bus already holds a send for this marker (its record was
+            to_id = str(prior.get("to_id") or "")          #   lost to a failed save, a restart, a stalled bus or a dropped
+            if to_id.startswith("peer:"):                  #   answer): adopt it, never send it twice
+                rw["pendingMid"] = str(prior.get("id") or "")
+                rw["pendingAt"] = int(prior.get("t") or now)
+                rw["pendingHost"] = to_id[5:]
+                rw.pop("unknownAt", None)
+                changed = True
+            else:
+                _relay_settle(nd, rw, now, "relayed", mid=str(prior.get("id") or ""))
+                _RELAY_SAID.discard(said)
+                return 1, True, True, False
     if rw.get("pendingMid"):                               # handed to a far host: its outcome first, whatever the wait did
         status, detail, row_t = _relay_pending_status(sid, peer, rw["pendingMid"], rw.get("pendingAt"))
-        if status in ("delivered", "answered"):
+        if status == "delivered":
             _relay_settle(nd, rw, now, "relayed", mid=str(rw["pendingMid"]))
             _RELAY_SAID.discard(said)
             return 1, True, True, False
         if status in ("bounced", "withdrawn"):
-            if standing:                                   # nobody was asked after all: the user's block, at the row's time
+            if standing and not _relay_ended_since(sid, nid, row_t):   # nobody was asked after all: the user's block
                 err = ("the relayed question was withdrawn by %s" % (_name_of(sid) or sid[:8]) if status == "withdrawn"
                        else "the message came back from %s" % (detail or rw.get("pendingHost") or "the far host"))
                 _relay_revert(store, nd, rw, err, now, ev_t=row_t or None)
@@ -3170,38 +3243,33 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
             return 0, True, True, False
         if not standing:                                   # the wait ended another way: the parked question is withdrawn
             got = _bus_recall_relay(sid, rw["pendingMid"])  #   so the far host never delivers a stale one
+            if got == "unknown":
+                return 0, changed, False, False            # the bus could not be asked: the entry stays, asked again
             _relay_settle(nd, rw, now, "relayDone", outcome="stood-down",
                           recall=("withdrawn" if got == "withdrawn" else "carried: could not be withdrawn"))
             _RELAY_SAID.discard(said)
             return 0, True, True, False
-        return 0, False, False, True
+        return 0, changed, False, not changed
     if not standing:
         _relay_settle(nd, rw, now, "relayDone", outcome="stood-down")   # the wait ended or moved on before the relay
         _RELAY_SAID.discard(said)
         return 0, True, True, False
-    prior = _relay_sent_row(sid, peer, str(rw.get("id") or ""), rw.get("t"))
-    if prior is not None:                                  # the bus already holds a send for this marker (its record was
-        to_id = str(prior.get("to_id") or "")              #   lost to a failed save, a restart or a dropped answer): adopt
-        if to_id.startswith("peer:"):                      #   it, never send it twice
-            rw["pendingMid"] = str(prior.get("id") or "")
-            rw["pendingAt"] = int(prior.get("t") or now)
-            rw["pendingHost"] = to_id[5:]
-            return 0, True, False, False
-        _relay_settle(nd, rw, now, "relayed", mid=str(prior.get("id") or ""))
-        _RELAY_SAID.discard(said)
-        return 1, True, True, False
+    if rw.get("unknownAt") and int(now) - int(rw["unknownAt"]) < RELAY_UNKNOWN_HOLD:
+        return 0, changed, False, False                    # a send the bus may still be processing: the log is re-read
+                                                           #   each tick (above) and nothing is sent again meanwhile
     if alive_ids is not None and sid not in alive_ids:
-        return 0, False, False, True                       # a dead worker asks nothing: the entry waits, quiet, for the
+        return 0, changed, False, not changed              # a dead worker asks nothing: the entry waits, quiet, for the
                                                            #   sweep's block to stand the marker down or the session to live
     who = _name_of(sid) or sid[:8]
     body = _relay_body(who, rw.get("why"))
     ok, err, definitive, resp = _bus_send_relay({"to": peer, "from": who, "from_id": sid, "body": body,
                                                  "kind": "question", "relayed": True, "relayMarker": str(rw.get("id") or "")})
+    rw.pop("unknownAt", None)
     if ok and (resp.get("parked") or ("to" not in resp and resp.get("id"))):
         rw["pendingMid"] = str(resp.get("id") or "")       # the relay leg answered (parked, or in flight to a host that
         rw["pendingAt"] = int(now)                         #   is up): the sent row is there, and the relay completes only
-        rw["pendingHost"] = str(resp.get("parked") or "")  #   when the far host's delivered row or the peer's answer
-        return 0, True, False, False                       #   names it; a bounce reverts it (a local send answers `to`)
+        rw["pendingHost"] = str(resp.get("parked") or "")  #   when the far host's delivered row names it; a bounce
+        return 0, True, False, False                       #   reverts it (a local send answers `to`)
     if ok:
         _relay_settle(nd, rw, now, "relayed", mid=str(resp.get("id") or ""))
         _RELAY_SAID.discard(said)
@@ -3212,14 +3280,33 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
         sys.stderr.write("relay (%s, %s -> %s) refused for good: %s; the block stands as the user's\n"
                          % (sid[:8], nid, peer[:8], err))
         return 0, True, True, False
-    if resp.get("unknown"):                                # written, unanswered: the bus's row decides next tick
-        sys.stderr.write("relay (%s, %s -> %s): %s; the outcome is unknown, the log decides next tick\n"
-                         % (sid[:8], nid, peer[:8], err))
-        return 0, False, False, False
+    if resp.get("unknown"):                                # written, unanswered: held, and the bus's row decides
+        rw["unknownAt"] = int(now)
+        rw["attempts"] = int(rw.get("attempts") or 0) + 1
+        if said + ("unknown",) not in _RELAY_SAID:
+            _RELAY_SAID.add(said + ("unknown",))
+            sys.stderr.write("relay (%s, %s -> %s): %s; the outcome is unknown, the log decides, nothing is sent again "
+                             "for %d s\n" % (sid[:8], nid, peer[:8], err, RELAY_UNKNOWN_HOLD))
+        return 0, True, False, False
     if said not in _RELAY_SAID:
         _RELAY_SAID.add(said)
         sys.stderr.write("relay (%s, %s -> %s): %s; retried next tick\n" % (sid[:8], nid, peer[:8], err))
-    return 0, False, False, False
+    return 0, changed, False, False
+
+
+def _relay_spend(f, e):
+    """Unlink the entry file `f` only when it still holds the entry `e` that was read: the judge's flush renames a newer
+    marker's entry over the same path, and an unlink after that read would take the new wait's entry with the old one
+    (the manager's sixth review). A file that changed stays for the next tick."""
+    try:
+        cur = json.loads(f.read_text())
+    except FileNotFoundError:
+        return
+    except Exception:
+        cur = None
+    if isinstance(cur, dict) and (str(cur.get("marker") or ""), str(cur.get("nid") or "")) != (str(e.get("marker") or ""), str(e.get("nid") or "")):
+        return
+    f.unlink(missing_ok=True)
 
 
 def _relay_store(sid, ents, now, alive_ids=None):
@@ -3252,7 +3339,7 @@ def _relay_store(sid, ents, now, alive_ids=None):
             jd.rollup_status(store, False)
             jd.save_goals(sid, store)                      # the record lands first; a raise here keeps the entry
         if spent:
-            f.unlink(missing_ok=True)
+            _relay_spend(f, e)
     return n, quiet
 
 
@@ -3288,6 +3375,12 @@ def _relay_tick(now, alive_ids=None):
     d = jd._relay_queue_dir()
     if not d.is_dir():
         return 0
+    for f in d.glob(".tmp-*"):                             # a writer's temp file left by a crash: swept after a minute
+        try:
+            if int(now) - int(f.stat().st_mtime) > 60:
+                f.unlink(missing_ok=True)
+        except OSError:
+            pass
     by_sid = {}
     for f in sorted(d.glob("*.json")):
         try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3128,6 +3128,7 @@ def _relay_settle(nd, rw, now, key, **more):
     nd.pop("relayWanted", None)
     if key == "relayed":
         nd.pop("relayRefusal", None)                       # a later relay on the node succeeded: the old refusal's note goes
+        nd.pop("relayCarried", None)                       #   and so does the note on a stale question a far host still held
 
 
 def _relay_revert(store, nd, rw, err, now, ev_t=None):
@@ -3160,14 +3161,37 @@ def _relay_ended_since(sid, nid, t):
                and int(jd._wait_end_ev(e) or 0) >= int(t or 0) for e in fresh.get("log") or [])
 
 
+def _relay_carried_note(r, how):
+    """The note a node carries when a far host still holds a relayed question after its wait ended: who it was for,
+    where it sits, why it stands. Read by jd._owed_why (the brief's owed why), _brief_with_relay_note (the card and
+    the modal) and dropped when a later relay on the node reaches the peer (_relay_settle)."""
+    peer = str(r.get("peer") or "")
+    return "a question to %s is still parked on %s: %s" % (_name_of(peer) or peer[:8] or "the peer",
+                                                          str(r.get("pendingHost") or "a far host"), how)
+
+
+def _brief_with_relay_note(nd):
+    """The node's decision brief as the card and the modal show it, with the kernel's note on a question a far host
+    still holds after the wait ended (relayCarried) as a closing line. The brief was distilled when the block was
+    filed and the recall's outcome comes ticks later, so the note rides beside it at read time and vanishes with it."""
+    brief = (nd or {}).get("blockSummary")
+    note = str((nd or {}).get("relayCarried") or "").strip()
+    if not note:
+        return brief
+    return ("%s\n\n%s" % (str(brief).rstrip(), note)) if brief else note
+
+
 def _relay_recall_sweep(sid, nd, now):
     """Recall every relayed question the node owes a recall for (relayRecall: markers retired by the judge after they
     were handed to a far host). A recall the bus answered (withdrawn, or carried and so beyond withdrawal) is done and
-    remembered (relayRecalled); one the bus could not be asked for stays owed for the next tick. Returns True when the
-    node changed."""
+    remembered (relayRecalled); one the bus could not be asked for stays owed for the next tick. Returns (changed,
+    when the earliest hold ends) on every path, 0 for no hold. A question the far host carried on before it could be
+    withdrawn, or one the host could not be reached to withdraw for RELAY_RECALL_TRIES tries, leaves a note on the
+    node (relayCarried) that the brief's owed why, the card and the modal show beside the block: before, only stderr
+    said a far host still held a question after its wait ended (the third verdict)."""
     owed = [r for r in (nd.get("relayRecall") or []) if isinstance(r, dict)]
     if not owed:
-        return False
+        return False, 0
     keep, done, changed = [], list(nd.get("relayRecalled") or []), False
     next_at = 0                                            # when the earliest hold ends: the tick looks again then
     for r in owed:
@@ -3189,11 +3213,14 @@ def _relay_recall_sweep(sid, nd, now):
             if r["attempts"] == RELAY_RECALL_TRIES:
                 sys.stderr.write("relay recall (%s, %s): %d tries unanswered; asked again every %d s from here\n"
                                  % (sid[:8], str(r.get("pendingMid") or "")[:12], RELAY_RECALL_TRIES, RELAY_UNKNOWN_HOLD * RELAY_RECALL_BACKOFF))
+                nd["relayCarried"] = _relay_carried_note(r, "the host could not be reached to withdraw it")
             keep.append(r)
             changed = True
             continue
         done.append({"mid": str(r.get("pendingMid") or ""), "t": int(now),
                      "outcome": "withdrawn" if got == "withdrawn" else "carried: could not be withdrawn"})
+        if got != "withdrawn":
+            nd["relayCarried"] = _relay_carried_note(r, "it went on before it could be withdrawn")
         jd._relay_mark_settled(nd, r.get("id") or "")
         changed = True
     if keep:
@@ -3216,8 +3243,9 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
     marker = str(e.get("marker") or "")
     nd = store["nodes"].get(nid)
     changed, recall_next = False, 0
-    if isinstance(nd, dict) and nd.get("relayRecall"):
-        changed, recall_next = _relay_recall_sweep(sid, nd, now)
+    if isinstance(nd, dict) and isinstance(nd.get("relayRecall"), list) and nd["relayRecall"]:
+        got = _relay_recall_sweep(sid, nd, now)          # (changed, when the earliest hold ends) on every path; a
+        changed, recall_next = got if isinstance(got, tuple) and len(got) == 2 else (bool(got), 0)   # bare flag tolerated
     if marker == "recall":                                 # the node's recall entry (its own file beside the marker's)
         owed = isinstance(nd, dict) and bool(nd.get("relayRecall"))
         return 0, changed, not owed, (False if changed else (recall_next or True))
@@ -3331,14 +3359,17 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
 def _relay_spend(f, e):
     """Unlink the entry file `f` only when it still holds the entry `e` that was read: the judge's flush renames a newer
     marker's entry over the same path, and an unlink after that read would take the new wait's entry with the old one
-    (the manager's sixth review). A file that changed stays for the next tick."""
+    (the manager's sixth review). The comparison is the entry's marker, node AND its own token: a recall entry's
+    marker is the constant "recall", so the judge's fresh recall entry (a second far-host marker retired while the
+    tick withdrew the first) read as the one just spent and was unlinked, leaving the store owing a recall no tick
+    asked for until a boot (the third verdict). A file that changed in any of the three stays for the next tick."""
     try:
         cur = json.loads(f.read_text())
     except FileNotFoundError:
         return
     except Exception:
         cur = None
-    if isinstance(cur, dict) and (str(cur.get("marker") or ""), str(cur.get("nid") or "")) != (str(e.get("marker") or ""), str(e.get("nid") or "")):
+    if isinstance(cur, dict) and any(str(cur.get(k) or "") != str(e.get(k) or "") for k in ("marker", "nid", "token")):
         return
     f.unlink(missing_ok=True)
 
@@ -35703,7 +35734,7 @@ def build_feed(now, live_map=None):
                         "anchorUuid": _wa,
                         "promptAnchorUuid": _pa,
                         "summary": nd.get("summary"),                   # distiller's key takeaway — shown in the MODAL only — the user 2026-06-17
-                        "blockSummary": nd.get("blockSummary"),         # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18
+                        "blockSummary": _brief_with_relay_note(nd),     # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18; a far host's parked question noted under it
                         "followupPending": nd.get("followupPending"),   # per-node "Followed up" chip in the modal tree (business 2026-06-17)
                         # the per-item story (MODAL, non-done only): newest block/unblock/verdict rows with
                         # anchors, so an open sub answers 'is this still active?' in place (the user 2026-07-20)
@@ -36251,7 +36282,7 @@ def build_feed(now, live_map=None):
                               "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
-                "blockSummary": nodes[nid].get("blockSummary"),    # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18
+                "blockSummary": _brief_with_relay_note(nodes[nid]),   # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18; a far host's parked question noted under it
                 "briefParts": nodes[nid].get("briefParts") or None,   # MULTI-item brief: [{id, since}] one per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null for single-item briefs, whose stamp is the card header's age (the user 2026-07-24)
                 "summaryParts": nodes[nid].get("summaryParts") or None,
                 # the user FOLLOWED UP after the takeaway they read (followupAt postdates what the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3011,7 +3011,7 @@ ROMP_VOICE_WORDS = ("romp", "card", "board", "goal", "cleared", "dismissal", "st
 #   the vocabulary an injected body must never speak to a session (CLAUDE.md, "Messages we inject into a session");
 #   tests/test_injected_voice.py's list of the same words, with the why of each, is pinned to this one
 RELAY_GENERIC_BODY = "%s cannot move further on this and needs your call."
-RELAY_UNKNOWN_HOLD = 30        # seconds a send with an unknown outcome is not repeated (the bus's own timeout, twice)
+RELAY_UNKNOWN_HOLD = 30        # seconds a send or a recall with an unknown outcome is not repeated (the bus's own timeout, twice)
 _ROMP_VOICE_RES = [re.compile(r"\b%s(?:s|es|ed|ing)?\b" % re.escape(w).replace(r"\ ", r"[ -]")) for w in ROMP_VOICE_WORDS]
 
 
@@ -3124,6 +3124,8 @@ def _relay_settle(nd, rw, now, key, **more):
     nd[key] = _relay_record(rw, now, **more)
     jd._relay_mark_settled(nd, rw.get("id") or "")
     nd.pop("relayWanted", None)
+    if key == "relayed":
+        nd.pop("relayRefusal", None)                       # a later relay on the node succeeded: the old refusal's note goes
 
 
 def _relay_revert(store, nd, rw, err, now, ev_t=None):
@@ -3164,20 +3166,27 @@ def _relay_recall_sweep(sid, nd, now):
     owed = [r for r in (nd.get("relayRecall") or []) if isinstance(r, dict)]
     if not owed:
         return False
-    keep, done = [], [x for x in (nd.get("relayRecalled") or []) if isinstance(x, str)]
+    keep, done, changed = [], list(nd.get("relayRecalled") or []), False
     for r in owed:
+        if r.get("unknownAt") and int(now) - int(r["unknownAt"]) < RELAY_UNKNOWN_HOLD:
+            keep.append(r)                                 # the bus could not be asked a moment ago: held, not hammered
+            continue
         got = _bus_recall_relay(sid, r.get("pendingMid"))
         if got == "unknown":
+            r["unknownAt"] = int(now)
             keep.append(r)
+            changed = True
             continue
-        done.append(str(r.get("pendingMid") or ""))
+        done.append({"mid": str(r.get("pendingMid") or ""), "t": int(now),
+                     "outcome": "withdrawn" if got == "withdrawn" else "carried: could not be withdrawn"})
         jd._relay_mark_settled(nd, r.get("id") or "")
+        changed = True
     if keep:
         nd["relayRecall"] = keep
     else:
         nd.pop("relayRecall", None)
     nd["relayRecalled"] = done[-jd.RELAY_SETTLED_CAP:]
-    return len(keep) != len(owed)
+    return changed
 
 
 def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
@@ -3242,9 +3251,12 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
             _RELAY_SAID.discard(said)
             return 0, True, True, False
         if not standing:                                   # the wait ended another way: the parked question is withdrawn
+            if rw.get("recallUnknownAt") and int(now) - int(rw["recallUnknownAt"]) < RELAY_UNKNOWN_HOLD:
+                return 0, changed, False, False            # the bus could not be asked a moment ago: held, not hammered
             got = _bus_recall_relay(sid, rw["pendingMid"])  #   so the far host never delivers a stale one
             if got == "unknown":
-                return 0, changed, False, False            # the bus could not be asked: the entry stays, asked again
+                rw["recallUnknownAt"] = int(now)
+                return 0, True, False, False               # the bus could not be asked: the entry stays, asked again later
             _relay_settle(nd, rw, now, "relayDone", outcome="stood-down",
                           recall=("withdrawn" if got == "withdrawn" else "carried: could not be withdrawn"))
             _RELAY_SAID.discard(said)
@@ -3268,7 +3280,7 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
     if ok and (resp.get("parked") or ("to" not in resp and resp.get("id"))):
         rw["pendingMid"] = str(resp.get("id") or "")       # the relay leg answered (parked, or in flight to a host that
         rw["pendingAt"] = int(now)                         #   is up): the sent row is there, and the relay completes only
-        rw["pendingHost"] = str(resp.get("parked") or "")  #   when the far host's delivered row names it; a bounce
+        rw["pendingHost"] = str(resp.get("parked") or resp.get("host") or "")   # when the far host's delivered row names
         return 0, True, False, False                       #   reverts it (a local send answers `to`)
     if ok:
         _relay_settle(nd, rw, now, "relayed", mid=str(resp.get("id") or ""))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -2982,23 +2982,70 @@ def _bus_send_relay(payload):
         return False, repr(e), False, {}
 
 
-_RELAY_SAID = set()           # (sid, nid) whose relay failed and was said once this boot
+_RELAY_SAID = set()           # (sid, nid, marker) whose relay failed and was said once this boot
 _RELAY_BAD = {"n": 0}         # malformed queue entries dropped this boot (said once each)
+_RELAY_QUIET = {}             # sid -> what a pass that changed nothing read (_relay_quiet_key): not repeated until it moves
 
 
-def _relay_parked_status(sid, peer, mid, at):
-    """A parked relay's outcome so far: "bounced" when a terminal row names its id (the far host refused, the mail was
-    destroyed or withdrawn), "answered" when the peer wrote to the worker after the park, else None (still pending)."""
+def _relay_pending_status(sid, peer, mid, at):
+    """A pending relay's outcome so far, as (status, detail): ("bounced", where and why) when a bounced row names its
+    id (the far host refused it, or it was destroyed), ("withdrawn", "") when a recall row does, ("delivered", "")
+    when the far host's end-to-end ack names it (the postal log's `relayed` row), ("answered", "") when the peer wrote
+    to the worker AFTER the send (strictly after its second: a message in the send's own second is not its answer),
+    else (None, ""). Every row about the id was appended after the send, so the scan walks the log's tail down to
+    the send time (a margin for clock skew), never the whole log per pending entry per tick."""
     try:
-        for r in _messages_rows():
-            if str(r.get("id") or "") == str(mid) and r.get("ev") in ("bounced", "recall"):
-                return "bounced"
+        delivered = False
+        floor = int(at or 0) - 600
+        for r in reversed(_messages_rows()):
+            if int(r.get("t") or 0) < floor:
+                break
+            if str(r.get("id") or "") != str(mid):
+                continue
+            ev = r.get("ev")
+            if ev == "bounced":
+                host, why = str(r.get("host") or ""), str(r.get("why") or "").strip()
+                return "bounced", ("%s: %s" % (host, why) if host and why else (why or host))
+            if ev == "recall":
+                return "withdrawn", ""
+            if ev == "relayed":
+                delivered = True
+        if delivered:
+            return "delivered", ""
         last_any, _la, _aw = _postal_wait_maps()
-        if last_any.get((str(peer), str(sid)), 0) >= int(at or 0):
-            return "answered"
+        if last_any.get((str(peer), str(sid)), 0) > int(at or 0):
+            return "answered", ""
     except Exception as e:
-        sys.stderr.write("relay parked status (%s): %r\n" % (str(mid)[:12], e))
-    return None
+        sys.stderr.write("relay pending status (%s): %r\n" % (str(mid)[:12], e))
+    return None, ""
+
+
+def _relay_record(rw, now, **more):
+    """A relay record (relayed, relayDone) for the marker `rw`: names the peer, the words and the MARKER it settles."""
+    return dict({"peer": str(rw.get("peer") or ""), "why": str(rw.get("why") or ""), "t": int(now),
+                 "marker": str(rw.get("id") or "")}, **more)
+
+
+def _relay_record_names(nd, marker):
+    """True when a record on the node (relayed, relayDone) or its settled list names the marker `marker`; an entry
+    with no marker id (none is written today) is settled by any record."""
+    if not isinstance(nd, dict):
+        return False
+    if marker and str(marker) in (nd.get("relaySettled") or []):
+        return True
+    for k in ("relayed", "relayDone"):
+        r = nd.get(k)
+        if isinstance(r, dict) and (not marker or str(r.get("marker") or "") == str(marker)):
+            return True
+    return False
+
+
+def _relay_settle(nd, rw, now, key, **more):
+    """Write the record `key` (relayed or relayDone) for the marker `rw`, remember the marker as settled (the record
+    slot is overwritten by the next marker's; jd._relay_mark_settled's list is not) and drop the marker."""
+    nd[key] = _relay_record(rw, now, **more)
+    jd._relay_mark_settled(nd, rw.get("id") or "")
+    nd.pop("relayWanted", None)
 
 
 def _relay_revert(store, nd, rw, err, now):
@@ -3008,82 +3055,120 @@ def _relay_revert(store, nd, rw, err, now):
     why = "%s (a relay to %s was refused: %s)" % (str(rw.get("why") or "").strip(), _name_of(peer) or peer[:8], str(err)[:160])
     if jd.record_verdict(store, nd, "romp", "block", int(now), why=why):
         nd["mt"] = int(now)
-    nd["relayDone"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "outcome": "refused"}
-    nd.pop("relayWanted", None)
+    _relay_settle(nd, rw, now, "relayDone", outcome="refused")
     _mark_views_dirty()
 
 
+def _relay_entry(store, sid, f, e, rev, now):
+    """One queue entry against the loaded store: (sent, changed, spent, quiet). `changed` means the store must be saved,
+    `spent` that the entry file is done once that save landed, `quiet` that nothing here needs another look until the
+    store, the log or the entries move (a pending relay, a kept entry); a transient failure is never quiet."""
+    nid = str(e["nid"])
+    marker = str(e.get("marker") or "")
+    nd = store["nodes"].get(nid)
+    rw = nd.get("relayWanted") if isinstance(nd, dict) else None
+    if not isinstance(rw, dict) or (marker and str(rw.get("id") or "") != marker):
+        if nd is None or _relay_record_names(nd, marker):
+            return 0, False, True, False                   # spent: the node is gone, or a record names the marker
+        if isinstance(rw, dict):                           # the node carries another marker: the entry is REWRITTEN for
+            jd._relay_write_entry(sid, nid, rw.get("id") or "", rev)   #   the live one, never unlinked (the path may
+            return 0, False, False, False                  #   already be that newer flush); the next tick sends it
+        if rev >= int(e.get("rev") or 0):
+            sys.stderr.write("relay (%s, %s): marker %s gone with no record at rev %d; the entry is dropped\n"
+                             % (sid[:8], nid, marker[:16] or "?", rev))
+            return 0, False, True, False                   # the publish that wrote the entry (or a later one) is on disk
+        return 0, False, False, True                       # the store on disk predates the entry's publish: kept
+    peer = str(rw.get("peer") or "")
+    said = (sid, nid, str(rw.get("id") or ""))
+    standing = (nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())
+                and not nd.get("nodeComplete") and not nd.get("cleared") and not nd.get("blocked"))
+    if not standing:
+        _relay_settle(nd, rw, now, "relayDone", outcome="stood-down")   # the wait ended or moved on before the relay
+        _RELAY_SAID.discard(said)
+        return 0, True, True, False
+    if rw.get("pendingMid"):                               # handed to a far host: pending up to its landing or its return
+        status, detail = _relay_pending_status(sid, peer, rw["pendingMid"], rw.get("pendingAt"))
+        if status in ("bounced", "withdrawn"):
+            err = ("the message was withdrawn" if status == "withdrawn"
+                   else "the message came back from %s" % (detail or rw.get("pendingHost") or "the far host"))
+            _relay_revert(store, nd, rw, err, now)
+            _RELAY_SAID.discard(said)
+            return 0, True, True, False
+        if status in ("delivered", "answered"):
+            _relay_settle(nd, rw, now, "relayed", mid=str(rw["pendingMid"]))
+            _RELAY_SAID.discard(said)
+            return 1, True, True, False
+        return 0, False, False, True
+    who = _name_of(sid) or sid[:8]
+    body = "%s cannot move further: %s" % (who, str(rw.get("why") or "").strip())
+    ok, err, definitive, resp = _bus_send_relay({"to": peer, "from": who, "from_id": sid, "body": body,
+                                                 "kind": "question", "relayed": True})
+    if ok and (resp.get("parked") or ("to" not in resp and resp.get("id"))):
+        rw["pendingMid"] = str(resp.get("id") or "")       # the relay leg answered (parked, or in flight to a host that
+        rw["pendingAt"] = int(now)                         #   is up): the sent row is there, and the relay completes only
+        rw["pendingHost"] = str(resp.get("parked") or "")  #   when the far host's delivered row or the peer's answer
+        return 0, True, False, False                       #   names it; a bounce reverts it (a local send answers `to`)
+    if ok:
+        _relay_settle(nd, rw, now, "relayed", mid=str(resp.get("id") or ""))
+        _RELAY_SAID.discard(said)
+        return 1, True, True, False
+    if definitive:                                         # nobody can be asked: the block is the user's after all
+        _relay_revert(store, nd, rw, err, now)
+        _RELAY_SAID.discard(said)
+        sys.stderr.write("relay (%s, %s -> %s) refused for good: %s; the block stands as the user's\n"
+                         % (sid[:8], nid, peer[:8], err))
+        return 0, True, True, False
+    if said not in _RELAY_SAID:
+        _RELAY_SAID.add(said)
+        sys.stderr.write("relay (%s, %s -> %s): %s; retried next tick\n" % (sid[:8], nid, peer[:8], err))
+    return 0, False, False, False
+
+
 def _relay_store(sid, ents, now):
-    """One store's queued relays (see _relay_tick): returns the number sent. Per entry (a file in the queue directory):
-    a node with no marker is consumed when a record (relayed, relayDone) settled it and KEPT when neither exists (the
-    save carrying the marker has not landed yet, never dropped); a node no longer waiting on that peer stands down
-    (relayDone stood-down); a parked relay is watched by its id until the peer answers (relayed) or the mail comes back
-    (a revert); a fresh one is sent, recorded relayed, or reverted on a definitive refusal, or kept on a transient one."""
+    """One store's queued relays (see _relay_tick): (sent, quiet). Per entry (a file in the queue directory naming
+    the node, the marker it was written for and the store revision whose publish carried the marker): an entry whose
+    node carries no marker is SPENT when a record names its marker, when the node is gone, or when the store's
+    published revision is at or past the entry's without the marker (the marker was lost with no record: said, and
+    the boot pass re-queues what it finds), and kept only when the store on disk predates the publish that wrote it;
+    an entry whose node carries a DIFFERENT marker is rewritten for that one. A node no longer waiting on that peer
+    stands down (relayDone stood-down). A pending relay (the bus's relay leg answered with an id, parked or in flight
+    to a far host) is watched by its id: the far host's delivered row or the peer's answer completes it (relayed),
+    the mail coming back reverts it. A fresh one is sent: a local delivery is complete at once, a relay-leg answer is
+    pending, a definitive refusal reverts, a transient failure keeps the entry and is said once. Every record names
+    the marker it settled and the node remembers it. Each entry's change is SAVED before its entry is spent (a save
+    that raises keeps the entry, and the next tick reads the marker again), and one entry's fault never skips the
+    others."""
     store = jd.load_goals(sid)
     n = 0
-    dirty = False
+    quiet = True
     for f, e in ents:
-        nid = str(e["nid"])
-        nd = store["nodes"].get(nid)
-        rw = nd.get("relayWanted") if isinstance(nd, dict) else None
-        if not isinstance(rw, dict):
-            if nd is None or isinstance(nd.get("relayed"), dict) or isinstance(nd.get("relayDone"), dict):
-                f.unlink(missing_ok=True)                  # settled (or the node is gone): the entry is spent
-            continue                                       # else the marker's save has not landed yet: keep the entry
-        peer = str(rw.get("peer") or "")
-        standing = (nd.get("awaitingKind") == "peer" and peer in (nd.get("awaitingPeers") or ())
-                    and not nd.get("nodeComplete") and not nd.get("cleared") and not nd.get("blocked"))
-        if not standing:
-            nd["relayDone"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "outcome": "stood-down"}
-            del nd["relayWanted"]                          # the wait ended or moved on before the relay: stand down
+        try:
+            sent, changed, spent, q = _relay_entry(store, sid, f, e, int(store.get("rev") or 0), now)
+        except Exception:
+            sys.stderr.write("relay (%s, %s): %s\n" % (sid[:8], str(e.get("nid"))[:32], traceback.format_exc()))
+            quiet = False
+            continue
+        n += sent
+        quiet = quiet and q
+        if changed:
+            jd.rollup_status(store, False)
+            jd.save_goals(sid, store)                      # the record lands first; a raise here keeps the entry
+        if spent:
             f.unlink(missing_ok=True)
-            dirty = True
-            continue
-        if rw.get("parkedMid"):                            # a far-host relay: pending until it lands or comes back
-            status = _relay_parked_status(sid, peer, rw["parkedMid"], rw.get("parkedAt"))
-            if status == "bounced":
-                _relay_revert(store, nd, rw, "the parked message came back", now)
-                f.unlink(missing_ok=True)
-                dirty = True
-            elif status == "answered":
-                nd["relayed"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "mid": rw["parkedMid"]}
-                del nd["relayWanted"]
-                f.unlink(missing_ok=True)
-                dirty = True
-                n += 1
-            continue
-        who = _name_of(sid) or sid[:8]
-        body = "%s cannot move further: %s" % (who, str(rw.get("why") or "").strip())
-        ok, err, definitive, resp = _bus_send_relay({"to": peer, "from": who, "from_id": sid, "body": body,
-                                                     "kind": "question", "relayed": True})
-        if ok and resp.get("parked"):
-            rw["parkedMid"] = str(resp.get("id") or "")   # the sent row is there; the entry watches for a bounce
-            rw["parkedAt"] = int(now)
-            dirty = True
-            continue
-        if ok:
-            nd["relayed"] = {"peer": peer, "why": str(rw.get("why") or ""), "t": int(now), "mid": str(resp.get("id") or "")}
-            del nd["relayWanted"]
-            f.unlink(missing_ok=True)
-            _RELAY_SAID.discard((sid, nid))
-            dirty = True
-            n += 1
-            continue
-        if definitive:                                     # nobody can be asked: the block is the user's after all
-            _relay_revert(store, nd, rw, err, now)
-            f.unlink(missing_ok=True)
-            _RELAY_SAID.discard((sid, nid))
-            dirty = True
-            sys.stderr.write("relay (%s, %s -> %s) refused for good: %s; the block stands as the user's\n"
-                             % (sid[:8], nid, peer[:8], err))
-            continue
-        if (sid, nid) not in _RELAY_SAID:
-            _RELAY_SAID.add((sid, nid))
-            sys.stderr.write("relay (%s, %s -> %s): %s; retried next tick\n" % (sid[:8], nid, peer[:8], err))
-    if dirty:
-        jd.rollup_status(store, False)
-        jd.save_goals(sid, store)
-    return n
+    return n, quiet
+
+
+def _relay_quiet_key(sid, ents):
+    """What a pass over `sid`'s entries reads, by identity: the store file, the postal log and the entries themselves
+    (mtime and size). A pass that changed nothing (every entry pending or kept) is not repeated until one moves, so
+    a relay parked for a host that is down costs no store parse per tick. None when a stat fails (never quiet)."""
+    try:
+        s1 = (jd.GOALDIR / (sid + ".json")).stat()
+        s2 = jd.MESSAGES.stat() if jd.MESSAGES.exists() else None
+        ek = tuple(sorted((f.name, f.stat().st_mtime_ns, f.stat().st_size) for f, _e in ents))
+        return ((s1.st_mtime_ns, s1.st_size), (s2.st_mtime_ns, s2.st_size) if s2 else None, ek)
+    except OSError:
+        return None
 
 
 def _relay_tick(now):
@@ -3096,7 +3181,9 @@ def _relay_tick(now):
     <why>", marked relayed (the row, the header and the inbox's comment say so, for the recipient and the courier).
     That creates the edge: the peer's reply lifts the stamp, the reminder ladder covers it, and the idle-manager
     escalation is the only door to the user. The recipient is always the delegating peer the record names, never
-    anyone else. A malformed entry is dropped and counted, never the others. Returns the number relayed."""
+    anyone else. Every marker has an identity (its id) that its entry and the record settling it name. A malformed
+    entry is dropped and counted, never the others. A store whose pass changed nothing is not read again until the
+    store, the log or its entries move. Returns the number relayed."""
     d = jd._relay_queue_dir()
     if not d.is_dir():
         return 0
@@ -3112,11 +3199,22 @@ def _relay_tick(now):
             f.unlink(missing_ok=True)
             continue
         by_sid.setdefault(str(e["sid"]), []).append((f, e))
+    for sid in [s for s in _RELAY_QUIET if s not in by_sid]:
+        _RELAY_QUIET.pop(sid, None)
     n = 0
     for sid, ents in by_sid.items():
         try:
-            n += _relay_store(sid, ents, now)
+            key = _relay_quiet_key(sid, ents)
+            if key is not None and _RELAY_QUIET.get(sid) == key:
+                continue                                   # nothing it reads has moved since a pass that changed nothing
+            sent, quiet = _relay_store(sid, ents, now)
+            n += sent
+            if quiet and key is not None:
+                _RELAY_QUIET[sid] = key
+            else:
+                _RELAY_QUIET.pop(sid, None)
         except Exception:
+            _RELAY_QUIET.pop(sid, None)
             sys.stderr.write("relay (%s): %s\n" % (sid[:8], traceback.format_exc()))   # one store's fault never skips the others
     return n
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3137,7 +3137,7 @@ def _relay_revert(store, nd, rw, err, now, ev_t=None):
     peer = str(rw.get("peer") or "")
     if jd.record_verdict(store, nd, "romp", "block", int(ev_t or now), why=str(rw.get("why") or "").strip()):
         nd["mt"] = int(now)
-    nd["relayRefusal"] = "a relay to %s was refused: %s" % (_name_of(peer) or peer[:8], str(err)[:160])
+    nd["relayRefusal"] = "%s could not be asked: %s" % (_name_of(peer) or peer[:8], str(err)[:160])
     _relay_settle(nd, rw, now, "relayDone", outcome="refused")
     _mark_views_dirty()
 
@@ -3351,7 +3351,12 @@ def _relay_store(sid, ents, now, alive_ids=None):
             jd.rollup_status(store, False)
             jd.save_goals(sid, store)                      # the record lands first; a raise here keeps the entry
         if spent:
-            _relay_spend(f, e)
+            nd = store["nodes"].get(str(e["nid"]))
+            if isinstance(nd, dict) and nd.get("relayRecall"):   # a recall still owed on this node (the bus could not be asked):
+                jd._relay_write_entry(sid, str(e["nid"]), "recall", int(store.get("rev") or 0))   # the entry becomes the
+                quiet = False                              #   recall's own, never spent with the marker's send (eighth review)
+            else:
+                _relay_spend(f, e)
     return n, quiet
 
 

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -552,7 +552,7 @@ def _walk_root_record(frm_id):
 
 
 def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
-            relay_mid="", relay_via="", tracked=False, user_ask=None, relayed=False):
+            relay_mid="", relay_via="", tracked=False, user_ask=None, relayed=False, relay_marker=""):
     # relayed=True (T334, 2026-09-11): romp sent this on the SENDER's behalf (the kernel relaying a worker's block
     # toward the peer that delegated its goal, as the worker's own question). The header and the row say so, so
     # the recipient and the courier can tell it from a typed ask; the message is otherwise ordinary mail.
@@ -570,7 +570,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     # it (read_box/restore queue it into the readbox). The maildir file is the durable record: the
     # receipt route survives a bus restart exactly as long as the unread mail does.
     relayed = bool(relayed) and kind == "question"   # the invariant every path shares (the /send gate, the far side's
-    mb = _mailbox(to_id)                             #   deliver, a held message's approve): only a question is relayed
+    relay_marker = str(relay_marker or "")[:64] if relayed else ""   # deliver, a held message's approve): only a question
+    mb = _mailbox(to_id)                             #   is relayed; the marker (the kernel's relay identity) rides with it
     name = _unique()
     tmp = mb / "tmp" / name
     # THE header write point — every value that lands in a header line goes through _hdr_val
@@ -600,6 +601,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         hdr += "X-Peer-Mid: %s\nX-Peer-Via: %s\n" % (h["relay_mid"], h["relay_via"])
     if relayed:
         hdr += "X-Relayed: romp\n"                  # sent by romp on the sender's behalf (T334)
+    if relay_marker:
+        hdr += "X-Relay-Marker: %s\n" % relay_marker   # the kernel's marker id: the row is its authoritative record
     tmp.write_text(hdr + "\n" + body + "\n")
     # Timeline log: a message was SENT (the matching exec event is logged when
     # the recipient consumes it in read_box). id = maildir filename joins the two.
@@ -611,6 +614,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         ev["kind"] = kind                            # additive (consumer contract above)
     if relayed:
         ev["relayed"] = True                         # additive (consumer contract above): romp relayed it (T334)
+    if relay_marker:
+        ev["relayMarker"] = relay_marker             # additive: the kernel finds a send it lost the record of by this
     if tracked:
         ev["tracked"] = True                         # additive (consumer contract above): report-back
         #                                              delegation — the row is the flag's ONE record;
@@ -899,8 +904,6 @@ def format_inbox(msgs, me_id=""):
         mid = ("\n<!-- romp-msg-id: %s -->" % m["id"]) if m.get("id") else ""   # exact id for the timeline join
         if m.get("kind"):
             mid += "\n<!-- romp-msg-kind: %s -->" % m["kind"]   # sender-declared kind, read by the courier
-        if m.get("relayed"):
-            mid += "\n<!-- romp-msg-relayed -->"               # romp sent it on the sender's behalf (T334)
         out.append("\n— from %s%s%s:\n%s%s" % (_from_disp(m), d, pk, m.get("body", ""), mid))
     out.append("\n" + REPLY_HINT)
     return "\n".join(out)
@@ -988,7 +991,8 @@ def format_receipts(recs):
             st = "delivered %s (not read yet) · id %s" % (_hhmm_epoch(r["relayed"]), r.get("id", "?"))
         else:                                  # still unread -> recallable; show the id to target it
             st = "pending (not read yet) · id %s" % r.get("id", "?")
-        out.append("  → %-18s sent %s · %s" % (r.get("to", "?"), _hhmm_epoch(r["sent"]), st))
+        out.append("  → %-18s sent %s · %s%s" % (r.get("to", "?"), _hhmm_epoch(r["sent"]), st,
+                                                  " · sent on your behalf" if r.get("onBehalf") else ""))
     return "\n".join(out)
 
 # ───────────────────────── the bus (server) ─────────────────────────
@@ -1604,6 +1608,8 @@ def _sent_receipts(mid):
         r = {"to": e.get("toName") or _name(e.get("to_id", "")), "id": i, "sent": e["t"],
              "exec": execs.get(i), "recalled": recalls.get(i),
              "relayed": relays.get(i), "bounced": bounced.get(i), "parked": h}
+        if e.get("relayed"):
+            r["onBehalf"] = True                     # romp sent it on this session's behalf (T334): the receipt says so
         if r["bounced"]:
             r["bouncedWhy"] = bounced_why.get(i, "")   # additive: an older client ignores it
         if h:
@@ -1842,8 +1848,6 @@ def format_push(msgs):
             out.append("<!-- romp-msg-id: %s -->" % m["id"])   # exact id for the timeline join
         if m.get("kind"):
             out.append("<!-- romp-msg-kind: %s -->" % m["kind"])   # sender-declared kind, read by the courier
-        if m.get("relayed"):
-            out.append("<!-- romp-msg-relayed -->")               # romp sent it on the sender's behalf (T334)
         out.append(bar)
     out.append('(to reply, only if substantive: romp mail send --kind delegate|coordinate|question %s "...")'
                % msgs[0].get("from", ""))
@@ -2325,6 +2329,7 @@ class Handler(BaseHTTPRequestHandler):
             if rerr:
                 return self._send({"error": rerr}, 400)
             relayed = relayed and kind == "question"
+            relay_marker = str(data.get("relayMarker") or "")[:64] if relayed else ""   # the kernel's marker id (T334)
             #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing
             #   about the flag ever appears in message prose (the injected-voice rule)
             if _postal_off(frm_id):                # the sender is in isolation → sending is disabled
@@ -2373,6 +2378,8 @@ class Handler(BaseHTTPRequestHandler):
                 if relayed:
                     relay_msg["relayed"] = True    # the far side's deliver marks it (T334): a relayed question
                     #                                reaches a far-host manager marked, exactly as a local one does
+                    if relay_marker:
+                        relay_msg["relayMarker"] = relay_marker
                 # `to_sid` (2026-09-08): the recipient's STABLE id, the same value the wire's toId
                 # carries. The row used to name the recipient only ("<host>:<name>"), so every
                 # reader of the wait (the kernel's wait maps, the judge's ask maps) had to join it
@@ -2392,7 +2399,8 @@ class Handler(BaseHTTPRequestHandler):
                                                      "toName": "%s:%s" % (phost, hit.get("name") or to),
                                                      "to_sid": str(hit.get("id") or ""),
                                                      "body": body, "kind": kind,
-                                                     **({"relayed": True} if relayed else {})}):   # as deliver's row (T334)
+                                                     **({"relayed": True} if relayed else {}),   # as deliver's row (T334)
+                                                     **({"relayMarker": relay_marker} if relay_marker else {})}):
                     return self._send({"ok": False, "error": NOT_RECORDED_TEXT}, 503)
                 if not outbox_put(phost, relay_msg):
                     _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
@@ -2411,7 +2419,8 @@ class Handler(BaseHTTPRequestHandler):
                                    "note": _parked_note(phost, frm_id) + tnote})
             a0 = res["agent"]
             try:
-                mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed)
+                mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed,
+                              relay_marker=relay_marker)
             except DeliveryNotRecorded as e:
                 # 503 + ok:false (see the relay leg): nothing was published; the sender retries.
                 return self._send({"ok": False, "error": str(e)}, 503)
@@ -2669,6 +2678,8 @@ def _rebuild_rows_for_rowless_mail(box, sent, ended):
             row["kind"] = meta["x-kind"]
         if meta.get("x-relayed"):
             row["relayed"] = True                    # romp sent it on the sender's behalf (T334)
+        if meta.get("x-relay-marker"):
+            row["relayMarker"] = str(meta.get("x-relay-marker"))[:64]
         row["from_host"] = meta.get("x-from-host", "")
         if meta.get("x-peer-mid"):
             row["originMid"] = meta["x-peer-mid"]
@@ -3786,6 +3797,8 @@ def _quarantine_put(origin, m, to_id, via="", wire_id=None):
         rec["userAsk"] = m["userAsk"]                # held with its provenance; approve replays it (T126)
     if m.get("relayed"):
         rec["relayed"] = True                        # held with its mark; approve replays it (T334)
+        if m.get("relayMarker"):
+            rec["relayMarker"] = str(m.get("relayMarker"))[:64]
     try:
         QUARANTINE.mkdir(parents=True, exist_ok=True)
         tmp = QUARANTINE / (mid + ".tmp")
@@ -3918,7 +3931,8 @@ def quarantine_decide(mid, action, text=None, feedback=None):
             deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
                     from_host=rec.get("origin") or "",
                     relay_mid=rec.get("mid") or "", relay_via=rec.get("via") or rec.get("origin") or "",
-                    user_ask=rec.get("userAsk"), relayed=bool(rec.get("relayed")))
+                    user_ask=rec.get("userAsk"), relayed=bool(rec.get("relayed")),
+                    relay_marker=str(rec.get("relayMarker") or ""))
         except DeliveryNotRecorded as e:
             return False, "%s — the held message is untouched" % e
         quarantine_del(mid)
@@ -3993,7 +4007,8 @@ def _relay_in(host, m, token_proven=False):
                         kind=m.get("kind") or "", from_host=origin,
                         relay_mid=mid, relay_via=host,       # read-receipt route: back through the direct peer
                         user_ask=m.get("userAsk"),           # origin-kernel walked record rides through (T126)
-                        relayed=bool(m.get("relayed")))      # romp sent it on the sender's behalf (T334)
+                        relayed=bool(m.get("relayed")),      # romp sent it on the sender's behalf (T334)
+                        relay_marker=str(m.get("relayMarker") or ""))
             except DeliveryNotRecorded as e:
                 # nothing landed → NOT acked and not marked seen: silence crosses the wire as
                 # 'retry', the sender's outbox keeps it parked and re-relays it next exchange

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -569,7 +569,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     # from — stamped into headers so the read receipt can flow back when the recipient actually reads
     # it (read_box/restore queue it into the readbox). The maildir file is the durable record: the
     # receipt route survives a bus restart exactly as long as the unread mail does.
-    mb = _mailbox(to_id)
+    relayed = bool(relayed) and kind == "question"   # the invariant every path shares (the /send gate, the far side's
+    mb = _mailbox(to_id)                             #   deliver, a held message's approve): only a question is relayed
     name = _unique()
     tmp = mb / "tmp" / name
     # THE header write point — every value that lands in a header line goes through _hdr_val
@@ -1920,7 +1921,7 @@ def _bounce_oversize(sid, m):
         return
     if not restore(sid, mid):
         deliver(sid, m.get("from", "?"), frm_id, m.get("body", ""), park=m.get("park", False),
-                kind=m.get("kind", ""), from_host=m.get("from_host", ""))
+                kind=m.get("kind", ""), from_host=m.get("from_host", ""), relayed=bool(m.get("relayed")))
     if mid not in _OVERSIZE_NAMED:
         _OVERSIZE_NAMED.add(mid)
         _log("push to %s: message %s is %d bytes, over the %d-byte /deliver limit, and has no local sender "
@@ -1985,7 +1986,7 @@ def _push(sid, agent):
             if not restore(sid, m.get("id", "")):
                 deliver(sid, m.get("from", "?"), m.get("from_id", ""), m.get("body", ""),
                         park=m.get("park", False), kind=m.get("kind", ""),
-                        from_host=m.get("from_host", ""))
+                        from_host=m.get("from_host", ""), relayed=bool(m.get("relayed")))
         _log("push to %s deferred (%s); %d msg(s) restored for the drain backstop%s"
              % (sid, cause, len(held), (" after %d landed" % landed) if landed else ""))
         return False
@@ -2369,6 +2370,9 @@ class Handler(BaseHTTPRequestHandler):
                     ua = _walk_root_record(frm_id)
                     if ua:
                         relay_msg["userAsk"] = ua
+                if relayed:
+                    relay_msg["relayed"] = True    # the far side's deliver marks it (T334): a relayed question
+                    #                                reaches a far-host manager marked, exactly as a local one does
                 # `to_sid` (2026-09-08): the recipient's STABLE id, the same value the wire's toId
                 # carries. The row used to name the recipient only ("<host>:<name>"), so every
                 # reader of the wait (the kernel's wait maps, the judge's ask maps) had to join it
@@ -2387,7 +2391,8 @@ class Handler(BaseHTTPRequestHandler):
                                                      "to_id": "peer:%s" % phost,
                                                      "toName": "%s:%s" % (phost, hit.get("name") or to),
                                                      "to_sid": str(hit.get("id") or ""),
-                                                     "body": body, "kind": kind}):
+                                                     "body": body, "kind": kind,
+                                                     **({"relayed": True} if relayed else {})}):   # as deliver's row (T334)
                     return self._send({"ok": False, "error": NOT_RECORDED_TEXT}, 503)
                 if not outbox_put(phost, relay_msg):
                     _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
@@ -3779,6 +3784,8 @@ def _quarantine_put(origin, m, to_id, via="", wire_id=None):
         rec["toWireId"] = wire
     if isinstance(m.get("userAsk"), dict):
         rec["userAsk"] = m["userAsk"]                # held with its provenance; approve replays it (T126)
+    if m.get("relayed"):
+        rec["relayed"] = True                        # held with its mark; approve replays it (T334)
     try:
         QUARANTINE.mkdir(parents=True, exist_ok=True)
         tmp = QUARANTINE / (mid + ".tmp")
@@ -3911,7 +3918,7 @@ def quarantine_decide(mid, action, text=None, feedback=None):
             deliver(to_id, rec.get("frm") or "?", rec.get("frmId") or "", body, kind=rec.get("kind") or "",
                     from_host=rec.get("origin") or "",
                     relay_mid=rec.get("mid") or "", relay_via=rec.get("via") or rec.get("origin") or "",
-                    user_ask=rec.get("userAsk"))
+                    user_ask=rec.get("userAsk"), relayed=bool(rec.get("relayed")))
         except DeliveryNotRecorded as e:
             return False, "%s — the held message is untouched" % e
         quarantine_del(mid)
@@ -3985,7 +3992,8 @@ def _relay_in(host, m, token_proven=False):
                 deliver(match[0]["id"], m.get("frm") or "?", m.get("frm_id") or "", m.get("body") or "",
                         kind=m.get("kind") or "", from_host=origin,
                         relay_mid=mid, relay_via=host,       # read-receipt route: back through the direct peer
-                        user_ask=m.get("userAsk"))           # origin-kernel walked record rides through (T126)
+                        user_ask=m.get("userAsk"),           # origin-kernel walked record rides through (T126)
+                        relayed=bool(m.get("relayed")))      # romp sent it on the sender's behalf (T334)
             except DeliveryNotRecorded as e:
                 # nothing landed → NOT acked and not marked seen: silence crosses the wire as
                 # 'retry', the sender's outbox keeps it parked and re-relays it next exchange

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -552,7 +552,10 @@ def _walk_root_record(frm_id):
 
 
 def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
-            relay_mid="", relay_via="", tracked=False, user_ask=None):
+            relay_mid="", relay_via="", tracked=False, user_ask=None, relayed=False):
+    # relayed=True (T334, 2026-09-11): romp sent this on the SENDER's behalf (the kernel relaying a worker's block
+    # toward the peer that delegated its goal, as the worker's own question). The header and the row say so, so
+    # the recipient and the courier can tell it from a typed ask; the message is otherwise ordinary mail.
     # park=True marks a HANDOFF parked for a session that's currently dead. The
     # maildir is keyed by the session UUID (which `romp resume` reuses), so the
     # message simply waits on disk until that session is revived — delivered then,
@@ -594,6 +597,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         hdr += "X-From-Host: %s\n" % h["from_host"]
     if h["relay_mid"] and h["relay_via"]:
         hdr += "X-Peer-Mid: %s\nX-Peer-Via: %s\n" % (h["relay_mid"], h["relay_via"])
+    if relayed:
+        hdr += "X-Relayed: romp\n"                  # sent by romp on the sender's behalf (T334)
     tmp.write_text(hdr + "\n" + body + "\n")
     # Timeline log: a message was SENT (the matching exec event is logged when
     # the recipient consumes it in read_box). id = maildir filename joins the two.
@@ -603,6 +608,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
         ev["park"] = True
     if kind:
         ev["kind"] = kind                            # additive (consumer contract above)
+    if relayed:
+        ev["relayed"] = True                         # additive (consumer contract above): romp relayed it (T334)
     if tracked:
         ev["tracked"] = True                         # additive (consumer contract above): report-back
         #                                              delegation — the row is the flag's ONE record;
@@ -790,6 +797,7 @@ def read_box(sid, consume):
         out.append({"from": meta.get("from", "?"), "from_id": meta.get("from-id", ""),
                     "date": meta.get("date", ""), "body": body.rstrip("\n"), "id": f.name,
                     "park": bool(meta.get("x-park")), "kind": meta.get("x-kind", ""),
+                    "relayed": bool(meta.get("x-relayed")),   # romp sent it on the sender's behalf (T334)
                     "from_host": meta.get("x-from-host", "")})
     if consume:
         _mark_pending(sid)         # cleared the box -> drop the marker (no-op if more arrived)
@@ -890,6 +898,8 @@ def format_inbox(msgs, me_id=""):
         mid = ("\n<!-- romp-msg-id: %s -->" % m["id"]) if m.get("id") else ""   # exact id for the timeline join
         if m.get("kind"):
             mid += "\n<!-- romp-msg-kind: %s -->" % m["kind"]   # sender-declared kind, read by the courier
+        if m.get("relayed"):
+            mid += "\n<!-- romp-msg-relayed -->"               # romp sent it on the sender's behalf (T334)
         out.append("\n— from %s%s%s:\n%s%s" % (_from_disp(m), d, pk, m.get("body", ""), mid))
     out.append("\n" + REPLY_HINT)
     return "\n".join(out)
@@ -1831,6 +1841,8 @@ def format_push(msgs):
             out.append("<!-- romp-msg-id: %s -->" % m["id"])   # exact id for the timeline join
         if m.get("kind"):
             out.append("<!-- romp-msg-kind: %s -->" % m["kind"])   # sender-declared kind, read by the courier
+        if m.get("relayed"):
+            out.append("<!-- romp-msg-relayed -->")               # romp sent it on the sender's behalf (T334)
         out.append(bar)
     out.append('(to reply, only if substantive: romp mail send --kind delegate|coordinate|question %s "...")'
                % msgs[0].get("from", ""))
@@ -2308,6 +2320,10 @@ class Handler(BaseHTTPRequestHandler):
             if terr:                                   # a string here armed tracking on a plain send
                 return self._send({"error": terr}, 400)
             tracked = tracked and kind == "delegate"
+            relayed, rerr = _as_bool(data.get("relayed"), "relayed")   # the kernel relaying a worker's question (T334)
+            if rerr:
+                return self._send({"error": rerr}, 400)
+            relayed = relayed and kind == "question"
             #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing
             #   about the flag ever appears in message prose (the injected-voice rule)
             if _postal_off(frm_id):                # the sender is in isolation → sending is disabled
@@ -2390,7 +2406,7 @@ class Handler(BaseHTTPRequestHandler):
                                    "note": _parked_note(phost, frm_id) + tnote})
             a0 = res["agent"]
             try:
-                mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)
+                mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed)
             except DeliveryNotRecorded as e:
                 # 503 + ok:false (see the relay leg): nothing was published; the sender retries.
                 return self._send({"ok": False, "error": str(e)}, 503)
@@ -2646,6 +2662,8 @@ def _rebuild_rows_for_rowless_mail(box, sent, ended):
             row["park"] = True
         if meta.get("x-kind"):
             row["kind"] = meta["x-kind"]
+        if meta.get("x-relayed"):
+            row["relayed"] = True                    # romp sent it on the sender's behalf (T334)
         row["from_host"] = meta.get("x-from-host", "")
         if meta.get("x-peer-mid"):
             row["originMid"] = meta["x-peer-mid"]

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -2372,7 +2372,7 @@ class Handler(BaseHTTPRequestHandler):
                 if prior is not None:                  # the same relayed question was sent already (a stalled answer had
                     to_prior = str(prior.get("to_id") or "")   # the kernel ask again): answer THAT send, deliver nothing
                     if to_prior.startswith("peer:"):
-                        return self._send({"ok": True, "id": prior.get("id"), "duplicate": True,
+                        return self._send({"ok": True, "id": prior.get("id"), "duplicate": True, "host": to_prior[5:],
                                            "note": "already relayed to %s" % to_prior[5:]})
                     return self._send({"ok": True, "to": to, "id": prior.get("id"), "duplicate": True})
             #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -343,6 +343,13 @@ def _safe_id(s):
 # printable is in here: spaces, punctuation, accents, CJK and emoji all live outside it.
 _HDR_BREAK_RE = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
 
+def _marker_val(v):
+    """A relay marker as the wire may carry it: the kernel's own alphabet (digits, letters, ':' '_' '.' '-'), at most 64
+    characters; anything else is dropped, so a value from a tokened client, a far host or a held record can carry
+    no header line and forge nothing."""
+    return re.sub(r"[^A-Za-z0-9:_.-]", "", str(v or ""))[:64]
+
+
 def _hdr_val(v):
     """One value, made safe to write into a maildir header line (see deliver).
 
@@ -555,7 +562,9 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
             relay_mid="", relay_via="", tracked=False, user_ask=None, relayed=False, relay_marker=""):
     # relayed=True (T334, 2026-09-11): romp sent this on the SENDER's behalf (the kernel relaying a worker's block
     # toward the peer that delegated its goal, as the worker's own question). The header and the row say so, so
-    # the recipient and the courier can tell it from a typed ask; the message is otherwise ordinary mail.
+    # the courier and the sender's own receipts can tell it from a typed ask (the recipient reads ordinary mail);
+    # relay_marker is the kernel's identity for the relay, written on the row so a send whose answer was lost is
+    # found again and never repeated.
     # park=True marks a HANDOFF parked for a session that's currently dead. The
     # maildir is keyed by the session UUID (which `romp resume` reuses), so the
     # message simply waits on disk until that session is revived — delivered then,
@@ -570,8 +579,9 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     # it (read_box/restore queue it into the readbox). The maildir file is the durable record: the
     # receipt route survives a bus restart exactly as long as the unread mail does.
     relayed = bool(relayed) and kind == "question"   # the invariant every path shares (the /send gate, the far side's
-    relay_marker = str(relay_marker or "")[:64] if relayed else ""   # deliver, a held message's approve): only a question
-    mb = _mailbox(to_id)                             #   is relayed; the marker (the kernel's relay identity) rides with it
+    relay_marker = _marker_val(relay_marker) if relayed else ""   # deliver, a held message's approve): only a question is
+    mb = _mailbox(to_id)                             #   relayed; the marker (the kernel's relay identity) rides with it,
+    #                                                  clamped to a marker's own alphabet (a wire value forges nothing)
     name = _unique()
     tmp = mb / "tmp" / name
     # THE header write point — every value that lands in a header line goes through _hdr_val
@@ -602,7 +612,8 @@ def deliver(to_id, from_name, from_id, body, park=False, kind="", from_host="",
     if relayed:
         hdr += "X-Relayed: romp\n"                  # sent by romp on the sender's behalf (T334)
     if relay_marker:
-        hdr += "X-Relay-Marker: %s\n" % relay_marker   # the kernel's marker id: the row is its authoritative record
+        hdr += "X-Relay-Marker: %s\n" % _hdr_val(relay_marker)   # the kernel's marker id (clamped above; the one
+        #                                                          sanitizer every header value passes, as well)
     tmp.write_text(hdr + "\n" + body + "\n")
     # Timeline log: a message was SENT (the matching exec event is logged when
     # the recipient consumes it in read_box). id = maildir filename joins the two.
@@ -1561,6 +1572,32 @@ def _recall(from_id, to, mid, kept=None):
                                               "box": "outbox", "host": hostdir.name})
     return removed
 
+def _relay_marker_sent_row(from_id, marker):
+    """The sent row of a relayed question `from_id` sent under the kernel's relay marker `marker`, if any: the bus's own
+    record that makes /send idempotent for a relay (a stalled answer has the kernel POST again; the manager must hold
+    the question once). A row whose id was bounced as NOT PARKED never went anywhere and does not count. Reads the
+    log's tail, newest first."""
+    log = TLDIR / "messages.jsonl"
+    if not (from_id and marker) or not log.exists():
+        return None
+    try:
+        lines = log.read_text(errors="replace").splitlines()
+    except OSError:
+        return None
+    unsent = set()
+    for line in reversed(lines):
+        try:
+            e = json.loads(line)
+        except Exception:
+            continue
+        if e.get("ev") == "bounced" and e.get("notParked"):
+            unsent.add(str(e.get("id") or ""))
+        elif (e.get("ev") == "sent" and e.get("from_id") == from_id and e.get("relayed")
+              and str(e.get("relayMarker") or "") == str(marker) and str(e.get("id") or "") not in unsent):
+            return e
+    return None
+
+
 def _sent_receipts(mid):
     """[{to, id, sent, exec, recalled}] for messages SENT by `mid`, joined by id,
     oldest first. exec is None until the recipient reads it; recalled is set if the
@@ -2329,7 +2366,15 @@ class Handler(BaseHTTPRequestHandler):
             if rerr:
                 return self._send({"error": rerr}, 400)
             relayed = relayed and kind == "question"
-            relay_marker = str(data.get("relayMarker") or "")[:64] if relayed else ""   # the kernel's marker id (T334)
+            relay_marker = _marker_val(data.get("relayMarker")) if relayed else ""   # the kernel's marker id (T334)
+            if relay_marker:
+                prior = _relay_marker_sent_row(frm_id, relay_marker)
+                if prior is not None:                  # the same relayed question was sent already (a stalled answer had
+                    to_prior = str(prior.get("to_id") or "")   # the kernel ask again): answer THAT send, deliver nothing
+                    if to_prior.startswith("peer:"):
+                        return self._send({"ok": True, "id": prior.get("id"), "duplicate": True,
+                                           "note": "already relayed to %s" % to_prior[5:]})
+                    return self._send({"ok": True, "to": to, "id": prior.get("id"), "duplicate": True})
             #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing
             #   about the flag ever appears in message prose (the injected-voice rule)
             if _postal_off(frm_id):                # the sender is in isolation → sending is disabled
@@ -2405,7 +2450,7 @@ class Handler(BaseHTTPRequestHandler):
                 if not outbox_put(phost, relay_msg):
                     _tl_append("messages.jsonl", {"t": int(time.time()), "ev": "bounced", "id": mid,
                                                   "to": hit.get("name") or to, "host": phost,
-                                                  "why": WHY_NOT_PARKED})
+                                                  "why": WHY_NOT_PARKED, "notParked": True})   # never left (T334 reads it)
                     return self._send({"ok": False, "error": "the message could not be parked for %s "
                                        "(the outbox could not be written), so it was not sent — "
                                        "nothing is lost; retry" % phost}, 503)

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -160,6 +160,10 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             bodies["fork nudge variant %d" % i] = v
         return bodies
 
+    def test_the_relay_scrub_speaks_this_lists_words(self):
+        # the kernel scrubs a relayed question's why by the same vocabulary this file scans for (T334): one list
+        self.assertEqual(tuple(w for w, _why in ROMP_WORDS), km.ROMP_VOICE_WORDS)
+
     def test_no_romp_vocabulary_reaches_the_session(self):
         for name, body in self._bodies().items():
             # THE ONE ALLOWANCE, deliberate and ruling-backed (T212, the user 2026-09-01): a

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -135,6 +135,10 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # index, so it shipped saying "goal" twice and announcing "(Automated re-check…)" until
             # 2026-08-11 — exactly the drift this index exists to catch
             "awaiting backstop": km.AWAITING_BACKSTOP_TEXT,
+            # the relayed question (T334): a worker's block toward the peer that delegated its work, sent as the
+            # worker's own words; the why is the closer's prose, scrubbed of any clause that speaks romp
+            "relayed question": km._relay_body("api", "which client should the exporter target?"),
+            "relayed question (procedural why)": km._relay_body("api", jd.NUDGE_BLOCK_WHY),
             # a comment thread's opening message (the user 2026-08-13): the highlight + comment are
             # the user's own words; the quoting frame around them is romp-authored and scanned here
             "comment thread opener": km._comment_first_message(
@@ -269,8 +273,11 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             if name in ("typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
                         "debt reminder (several)", "comment thread opener", "edit trace",
-                        "comment-thread merge", "compaction suggestion"):
-                #        ^ a housekeeping suggestion, not a progress ask — it elicits nothing
+                        "comment-thread merge", "compaction suggestion",
+                        "relayed question", "relayed question (procedural why)"):
+                #        ^ a housekeeping suggestion, not a progress ask: it elicits nothing; and the relayed
+                #          question is a WORKER's question to the peer that delegated its work, in the worker's
+                #          words, never a progress ask to the user (T334)
                 continue
             text = prose(body).lower()
             with self.subTest(message=name):

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -8527,8 +8527,10 @@ class StaleBlockGuard(unittest.TestCase):
         # this pin just keeps the planner on the one seam.
         import inspect
         src = inspect.getsource(jd)
-        self.assertIn('if t and record_verdict(store, nodes[t], "planner", "block", seg_t', src,
-                      "the planner's block op must go through record_verdict exactly like the closer")
+        self.assertIn('file_block(store, nodes[t], "planner", o["why"], seg_t, seg=seg_id) if t else', src,
+                      "the planner's block op goes through the one block writer, like the closer (T334)")
+        self.assertIn('record_verdict(store, nd, src, "block", ev_t, why=why, seg=seg)', inspect.getsource(jd.file_block),
+                      "…and that writer files a user's block through record_verdict, the fused gate+recorder")
 
 
 class FollowupContinuationCarry(unittest.TestCase):

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -1699,6 +1699,89 @@ class SaverFlushesItsOwn(_RelayFixture):
         with contextlib.redirect_stderr(io.StringIO()):
             self.assertEqual(km._relay_tick(NOW + 71), 1, "M3's question goes out on the next tick, no boot needed")
 
+    def test_a_recall_entry_flushed_during_the_ticks_pass_survives_the_spend(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)           # M1 handed to the far host
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "second question", NOW + 60)   # M1 retired (px-1 owed), M2 minted
+        self._save(st)
+        km._bus_recall_relay = lambda sid, mid: "unknown"  # px-1's recall held
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-2", "parked": "TESTHOST"})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 70), 0)   # M2 handed to the far host too (pending px-2)
+        jd._relay_entry_path(WORKER, step).unlink()        # M2's entry lost to a failed write (the boot pass would re-queue it): the recall entry is alone in the queue
+        asked = []
+        def recall_while_judge_retires_m2(sid, mid):       # WHILE the tick withdraws px-1, the judge retires M2 (px-2 owed) and flushes the recall entry over the same path
+            asked.append(mid)
+            st3 = jd.load_goals(WORKER)
+            jd.record_verdict(st3, st3["nodes"][step], "romp", "awaiting", NOW + 71, why="", lift=True, end_ev=NOW + 71)
+            self._close(st3, step, "third question", NOW + 72)
+            jd.save_goals(WORKER, st3)
+            return "withdrawn"
+        km._bus_recall_relay = recall_while_judge_retires_m2
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._relay_tick(NOW + 70 + km.RELAY_UNKNOWN_HOLD)
+        self.assertEqual(asked, ["px-1"])
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual([r["pendingMid"] for r in nd["relayRecall"]], ["px-2"], "the store owes px-2 (the tick's save folded it in)")
+        self.assertTrue(jd._relay_recall_entry_path(WORKER, step).exists(), "the judge's fresh recall entry survived the tick's spend: its token moved")
+        asked.clear()
+        km._bus_recall_relay = lambda sid, mid: asked.append(mid) or "withdrawn"
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._relay_tick(NOW + 71 + km.RELAY_UNKNOWN_HOLD)
+        self.assertEqual(asked, ["px-2"], "the next tick asks for px-2, no boot needed")
+        self.assertEqual(self._queue(), [], "both entries spent once done")
+
+    def test_a_recall_list_holding_no_dict_never_raises_in_the_tick(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        st = jd.load_goals(WORKER)
+        st["nodes"][step]["relayRecall"] = ["not a recall row"]   # a hand-edited or corrupted store, or a future writer's shape
+        jd._relay_write_entry(WORKER, step, "recall", st.get("rev") or 0)
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(st))   # written past the merge, which would drop the junk
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(km._relay_tick(NOW), 1, "the question goes out; the junk list is skipped, never raised on")
+        self.assertNotIn("Traceback", err.getvalue())
+
+    def test_a_question_a_far_host_still_holds_is_noted_beside_the_block(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-car-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "still stuck", NOW + 60)     # M1 retired while parked (a recall owed), M2 minted
+        self._save(st)
+        km._bus_recall_relay = lambda sid, mid: "carried"  # the far host carried it on before it could be withdrawn
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-car-2", "parked": "TESTHOST"})
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._relay_tick(NOW + 70)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertIn("still parked on TESTHOST", nd["relayCarried"])
+        self.assertIn("before it could be withdrawn", nd["relayCarried"])
+        self.assertTrue(jd._owed_why(nd).endswith("(%s)" % nd["relayCarried"]), "the brief's owed why carries the note in brackets")
+        nd["blockSummary"] = "Decide the retry policy."
+        self.assertEqual(km._brief_with_relay_note(nd), "Decide the retry policy.\n\n" + nd["relayCarried"], "the card and the modal show it under the brief")
+        self.assertEqual(km._brief_with_relay_note({"relayCarried": nd["relayCarried"]}), nd["relayCarried"], "and alone before the brief is distilled")
+        self.assertIsNone(km._brief_with_relay_note({}), "no note, no brief: null as before")
+        st = jd.load_goals(WORKER)                         # a later relay that reaches the peer drops the note
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 75, why="", lift=True, end_ev=NOW + 75)
+        self._close(st, step, "a fresh question", NOW + 80)
+        self._save(st)
+        km._bus_recall_relay = lambda sid, mid: "withdrawn"
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 90), 1)
+        self.assertNotIn("relayCarried", jd.load_goals(WORKER)["nodes"][step])
+
     def test_an_unanswerable_recall_is_said_once_and_backs_off(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "first question", T0 + 400)
@@ -1719,6 +1802,7 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertEqual(len(calls), km.RELAY_RECALL_TRIES, "one ask per hold up to the tries")
         self.assertEqual(err.getvalue().count("could not be asked"), 1, "said once")
         self.assertEqual(err.getvalue().count("tries unanswered"), 1, "the back-off said once")
+        self.assertIn("could not be reached to withdraw it", jd.load_goals(WORKER)["nodes"][step]["relayCarried"], "the eighth try leaves the note the brief and the card show")
         with contextlib.redirect_stderr(io.StringIO()):
             self.assertEqual(km._relay_tick(t + km.RELAY_UNKNOWN_HOLD), 0)
         self.assertEqual(len(calls), km.RELAY_RECALL_TRIES, "inside the stretched hold: not asked")

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -1,0 +1,751 @@
+#!/usr/bin/env python3
+"""A block addressed to a PEER is a peer wait, not the user's needs-you (T334, the user 2026-09-10 via the
+philosophy in CLAUDE.md: waiting on a peer or another session is not the human being the bottleneck). Pinned
+here on synthetic stores, postal logs and names (placeholder uuids, the notes-api demo's session names):
+- the closer's and the planner's block on a node whose session has an open question to a live peer files the
+  awaiting/peer stamp naming that peer, in place of the block; with several open asks the block's words pick
+  among them, never invent one;
+- with no open ask, a block under a courier-planted goal is addressed to the peer that delegated it, even when
+  the text names the user (the manager relays); a standalone session's block stays the user's, exactly as before;
+- rows already filed convert once per boot; the manager debtor's escalation waits for its idle turn."""
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_peer_wait", os.path.join(BIN, "romp-kernel"))
+jd = km.jd
+
+NOW = 1781300000
+T0 = NOW - 3600
+WORKER = "11111111-2222-3333-4444-aaaaaaaaaaaa"     # the session whose block is judged
+MANAGER = "11111111-2222-3333-4444-bbbbbbbbbbbb"    # the peer that delegated its goal
+OTHER = "11111111-2222-3333-4444-cccccccccccc"      # another peer it asked something
+
+
+def mail(from_id, to_id, t, kind="question", mid=None):
+    return {"id": mid or "m-%s-%s-%d" % (from_id[-4:], to_id[-4:], t), "from_id": from_id, "to_id": to_id,
+            "from": "api", "to": "web", "t": t, "kind": kind}
+
+
+def node(nid, text, parent=None, t=T0, **kw):
+    d = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False, "blocked": False, "cleared": False,
+         "trail": [], "t": t, "mt": t, "log": []}
+    d.update(kw)
+    return d
+
+
+class _Peer(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        self.saved = (jd.NAMES, jd.GOALDIR, jd.MESSAGES, jd.STATE, km.NAMES)
+        jd.NAMES = td / "names"; jd.NAMES.mkdir()
+        jd.GOALDIR = td / "goals"; jd.GOALDIR.mkdir()
+        jd.MESSAGES = td / "messages.jsonl"
+        jd.STATE = td
+        km.NAMES = jd.NAMES
+        for sid, name in ((WORKER, "api"), (MANAGER, "web"), (OTHER, "tests")):
+            (jd.NAMES / sid).write_text("%s\t/TESTDIR\t#abcdef\n" % name)
+        self.rows = []
+        self._write_mail()
+
+    def tearDown(self):
+        (jd.NAMES, jd.GOALDIR, jd.MESSAGES, jd.STATE, km.NAMES) = self.saved
+        jd._PEER_ASK_CACHE[0] = None
+        jd._DELEG_CACHE[0] = None
+        jd._RELAY_PENDING[:] = []
+        self.td.cleanup()
+
+    def _write_mail(self):
+        jd.MESSAGES.write_text("".join(json.dumps(r) + "\n" for r in self.rows))
+        jd._PEER_ASK_CACHE[0] = None
+        jd._DELEG_CACHE[0] = None
+
+    def ask(self, from_id, to_id, t, kind="question"):
+        self.rows.append(mail(from_id, to_id, t, kind))
+        self._write_mail()
+
+    def store(self, delegated=False, blocked=False):
+        top = WORKER + ":g1"; step = WORKER + ":g2"
+        kw = {"origin": {"peer": MANAGER, "goalId": MANAGER + ":g7", "msgId": "m-deleg"}} if delegated else {}
+        st = {"rompUuid": WORKER, "seq": 2, "placements": {}, "status": {top: "working"}, "confirming": [],
+              "nodes": {top: node(top, "Ship the exporter", **kw),
+                        step: node(step, "Ask which client to change", parent=top, t=T0 + 60)}}
+        if blocked:
+            st["nodes"][step]["blocked"] = True
+            st["nodes"][step]["blockWhy"] = "asked the manager which client"
+            st["nodes"][step]["log"] = [{"kind": "block", "src": "closer", "ev_t": T0 + 400, "why": "asked the manager which client"}]
+        return st, top, step
+
+
+class CloserBlocks(_Peer):
+    def _close(self, st, step, why):
+        menu = [st["nodes"][step]]
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, menu, {"done": {}, "block": {1: why}, "awaiting": {}}, t=T0 + 400)
+        return st["nodes"][step]
+
+    def test_an_open_question_to_a_live_peer_makes_the_block_a_peer_wait(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, MANAGER, T0 + 300)
+        nd = self._close(st, step, "cannot move further without an answer")
+        self.assertFalse(nd["blocked"], "no needs-you")
+        self.assertEqual(nd.get("awaitingKind"), "peer")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        self.assertNotIn("relayWanted", nd, "the open ask to the delegator is the edge: nothing to relay")
+        rows = [e for e in nd["log"] if e.get("kind") in ("block", "awaiting")]
+        self.assertEqual([(e["kind"], e["src"]) for e in rows], [("awaiting", "closer")])
+
+    def test_an_unrelated_open_ask_does_not_capture_a_block_in_the_delegators_work(self):
+        # the worker asked another peer about ports; its block toward its manager names nobody: the manager, relayed
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, OTHER, T0 + 300)
+        nd = self._close(st, step, "cannot move further without an answer")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        self.assertEqual(nd["relayWanted"]["peer"], MANAGER)
+        st2, top2, step2 = self.store(delegated=True)
+        self.ask(WORKER, OTHER, T0 + 300)
+        nd2 = self._close(st2, step2, "waiting on tests for the port")      # names the peer it asked: that peer
+        self.assertEqual(list(nd2.get("awaitingPeers") or ()), [OTHER])
+        self.assertNotIn("relayWanted", nd2)
+
+    def test_words_pick_among_several_open_asks_and_never_invent_a_peer(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, OTHER, T0 + 300)
+        self.ask(WORKER, MANAGER, T0 + 310)
+        nd = self._close(st, step, "waiting on tests to say which fixture")   # "tests" is OTHER's session name
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [OTHER])
+        st2, top2, step2 = self.store(delegated=True)
+        nd2 = self._close(st2, step2, "waiting on an answer")                  # no name: the latest ask
+        self.assertEqual(list(nd2.get("awaitingPeers") or ()), [MANAGER])
+        st3, top3, step3 = self.store(delegated=True)
+        nd3 = self._close(st3, step3, "the user or the contest judge must say")   # names nobody who asked: the latest
+        self.assertEqual(list(nd3.get("awaitingPeers") or ()), [MANAGER], "words never invent a peer")
+        st4, top4, step4 = self.store(delegated=True)
+        nd4 = self._close(st4, step4, "the apitests harness is red")            # "tests" inside a longer word: no match
+        self.assertEqual(list(nd4.get("awaitingPeers") or ()), [MANAGER])
+
+    def test_with_no_open_ask_a_delegated_goals_block_goes_to_the_peer_that_delegated_it(self):
+        st, top, step = self.store(delegated=True)
+        nd = self._close(st, step, "PR is green and cannot move further without you")
+        self.assertFalse(nd["blocked"])
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        self.assertEqual(nd["relayWanted"], {"peer": MANAGER, "why": "PR is green and cannot move further without you", "t": T0 + 400},
+                         "no question was ever sent: the kernel relays it as the worker's own")
+        st2, top2, step2 = self.store(delegated=True)
+        self.ask(WORKER, MANAGER, T0 + 300)
+        nd2 = self._close(st2, step2, "cannot move further without an answer")
+        self.assertNotIn("relayWanted", nd2, "the open ask already is the edge: nothing to relay")
+
+    def test_a_block_naming_the_user_in_a_delegated_goal_still_goes_to_the_manager(self):
+        # the requirement: a worker's card never reaches the user except through the escalation event
+        st, top, step = self.store(delegated=True)
+        nd = self._close(st, step, "only the user can decide this; please relay the question to them")
+        self.assertFalse(nd["blocked"], "the manager relays")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+
+    def test_a_standalone_sessions_block_is_the_users_exactly_as_before(self):
+        st, top, step = self.store()
+        nd = self._close(st, step, "which client should change?")
+        self.assertTrue(nd["blocked"])
+        self.assertIsNone(nd.get("awaitingKind"))
+        self.assertEqual([e["src"] for e in nd["log"] if e.get("kind") == "block"], ["closer"])
+
+    def test_the_users_own_session_keeps_its_block_whatever_questions_it_has_out(self):
+        # a standalone session with an unrelated open question: its decision must never hide behind "Awaiting <peer>"
+        st, top, step = self.store()
+        self.ask(WORKER, OTHER, T0 + 300)
+        nd = self._close(st, step, "need your call on breaking the v1 API")
+        self.assertTrue(nd["blocked"])
+        self.assertIsNone(nd.get("awaitingKind"))
+
+    def test_an_empty_why_is_never_redirected(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, OTHER, T0 + 300)
+        nd = self._close(st, step, "")
+        self.assertTrue(nd["blocked"], "a block with nothing to relay stays a block")
+
+    def test_the_ladders_own_escalation_block_is_never_lifted_by_a_re_asserted_judge_block(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, MANAGER, T0 + 300)
+        st["nodes"][top]["blocked"] = True
+        st["nodes"][top]["log"] = [{"kind": "block", "src": "nudge", "ev_t": T0 + 500, "why": "web has not answered"}]
+        menu = [st["nodes"][top]]
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, menu, {"done": {}, "block": {1: "still waiting on the manager"}, "awaiting": {}}, t=T0 + 900)
+        self.assertTrue(st["nodes"][top]["blocked"], "the once-ever escalation stands")
+        self.assertEqual([e["kind"] for e in st["nodes"][top]["log"]], ["block"], "nothing filed over it")
+
+    def test_a_delegate_or_coordinate_row_is_no_open_ask(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, OTHER, T0 + 300, kind="coordinate")
+        self.ask(WORKER, OTHER, T0 + 301, kind="delegate")
+        nd = self._close(st, step, "which client should change?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "a heads-up or a handoff asks nothing back: the delegator")
+
+    def test_an_answered_question_is_no_open_ask(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, OTHER, T0 + 300)
+        self.ask(OTHER, WORKER, T0 + 350, kind="coordinate")                    # any reply answers
+        nd = self._close(st, step, "which client should change?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the answered ask is gone; the delegator remains")
+
+    def test_a_re_asserted_block_on_an_already_blocked_node_unblocks_it_into_the_wait(self):
+        st, top, step = self.store(delegated=True, blocked=True)
+        nd = self._close(st, step, "still waiting on the manager")
+        self.assertFalse(nd["blocked"], "romp's unblock lifts the old block, the peer wait replaces it")
+        kinds = [(e["kind"], e["src"]) for e in nd["log"] if e.get("kind") in ("block", "unblock", "awaiting")]
+        self.assertEqual(kinds, [("block", "closer"), ("unblock", "romp"), ("awaiting", "closer")])
+
+    def test_the_delegate_mail_is_the_relation_when_the_courier_planted_nothing(self):
+        # today's stores hold no planted origin; the DELEGATE row the manager sent is the primary record. A top anchored
+        # on a machine record (the dispatch mail) minted after that delegate belongs to the relation; a top the user
+        # typed (askAnchor human) never does, whatever mail the session received; a top minted before any delegate
+        # predates it
+        self.ask(MANAGER, WORKER, T0 - 100, kind="delegate")
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"
+        nd = self._close(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        self.assertEqual(nd["relayWanted"]["peer"], MANAGER)
+        for anchor in ("human", None, "absent", "scheduled"):        # only the latch's positive machine verdict qualifies
+            st2, top2, step2 = self.store()
+            if anchor is None:
+                st2["nodes"][top2].pop("askAnchor", None)
+            else:
+                st2["nodes"][top2]["askAnchor"] = anchor
+            nd2 = self._close(st2, step2, "cannot move further without you")
+            self.assertTrue(nd2["blocked"], "anchor %r: the user's, fail open" % anchor)
+        st3, top3, step3 = self.store()
+        st3["nodes"][top3]["askAnchor"] = "machine"; st3["nodes"][top3]["t"] = T0 - 500
+        nd3 = self._close(st3, step3, "cannot move further without you")
+        self.assertTrue(nd3["blocked"], "minted before any delegate reached the session: not the relation")
+        self.assertTrue(km._delegated_to(MANAGER, WORKER), "the kernel reads the same record for the ladder")
+
+    def test_a_script_mailers_pseudo_sid_is_never_the_delegating_peer(self):
+        # a cron mailer delegates as ext:<label>: no session behind it could ever be asked, so the block stays the user's
+        self.ask("ext:morning", WORKER, T0 - 100, kind="delegate")
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"
+        nd = self._close(st, step, "cannot move further without you")
+        self.assertTrue(nd["blocked"])
+        st2, top2, step2 = self.store(delegated=True)
+        st2["nodes"][top2]["origin"]["peer"] = "ext:morning"
+        nd2 = self._close(st2, step2, "cannot move further without you")
+        self.assertTrue(nd2["blocked"], "a planted ext: origin is no session either")
+
+    def test_a_block_on_a_handoff_tracker_waits_on_the_peer_it_was_handed_to(self):
+        # a manager blocked on its own "delegated to <worker>" tracker waits on that worker (the delegate edge the
+        # worker's report ends), never on whoever delegated to the manager
+        st, top, step = self.store(delegated=True)
+        st["nodes"][step]["handoff"] = {"peer": OTHER, "goalId": OTHER + ":g3"}
+        nd = self._close(st, step, "waiting on their report")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [OTHER])
+        self.assertNotIn("relayWanted", nd, "the delegate already is the edge: nothing to relay")
+
+    def test_an_ask_sent_once_the_goal_existed_counts_for_a_step_minted_later(self):
+        # the worker asked its manager after the goal was minted but before this step: still the edge, no relay
+        st, top, step = self.store(delegated=True)
+        st["nodes"][step]["t"] = T0 + 500
+        self.ask(WORKER, MANAGER, T0 + 300)
+        nd = self._close(st, step, "cannot move further without an answer")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        self.assertNotIn("relayWanted", nd, "the earlier question is the edge: nothing to relay twice")
+
+    def test_a_late_closer_never_re_stamps_or_re_relays_a_wait_the_diary_already_ended(self):
+        st, top, step = self.store(delegated=True)
+        nd = self._close(st, step, "cannot move further without you")          # stamped and relay wanted, at T0 + 400
+        self.assertIn("relayWanted", nd)
+        del nd["relayWanted"]
+        jd.record_verdict(st, nd, "romp", "awaiting", T0 + 900, why="", lift=True, end_ev=T0 + 900)   # the reply lifted it
+        self.assertIsNone(nd.get("awaitingKind"))
+        menu = [nd]
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, menu, {"done": {}, "block": {1: "still cannot move further without you"}, "awaiting": {}}, t=T0 + 400)
+        self.assertIsNone(nd.get("awaitingKind"), "a closer auditing the OLD turn stands down before the newer lift")
+        self.assertNotIn("relayWanted", nd)
+        self.assertFalse(nd.get("blocked"))
+
+    def test_the_planners_block_op_files_a_peer_wait_with_no_mt_bump_and_a_users_block_with_one(self):
+        st, top, step = self.store(delegated=True)
+        mt0, trail0 = st["nodes"][step]["mt"], list(st["nodes"][step]["trail"])
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_plan(st, "seg-9", T0 + 900, [{"do": "block", "why": "needs the manager's call", "goal": 1}], [st["nodes"][step]])
+        nd = st["nodes"][step]
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        self.assertFalse(nd["blocked"])
+        self.assertEqual((nd["mt"], nd["trail"]), (mt0, trail0), "an annotation: no mt bump, no trail entry")
+        st2, top2, step2 = self.store()                                          # standalone: the user's block, as before
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_plan(st2, "seg-9", T0 + 900, [{"do": "block", "why": "needs your call", "goal": 1}], [st2["nodes"][step2]])
+        nd2 = st2["nodes"][step2]
+        self.assertTrue(nd2["blocked"])
+        self.assertEqual(nd2["mt"], T0 + 900)
+        self.assertIn("seg-9", nd2["trail"])
+
+    def test_the_planner_shares_the_one_block_writer(self):
+        import inspect
+        src = inspect.getsource(jd.apply_plan)
+        self.assertIn('file_block(store, nodes[t], "planner", o["why"], seg_t, seg=seg_id)', src)
+        st, top, step = self.store(delegated=True)
+        kind, landed = jd.file_block(st, st["nodes"][step], "planner", "needs the manager's call", T0 + 400)
+        self.assertEqual((kind, landed), ("peer", True))
+        self.assertEqual(list(st["nodes"][step]["awaitingPeers"] or ()), [MANAGER])
+
+
+class RowsAlreadyFiled(_Peer):
+    def test_the_boot_pass_converts_a_closer_block_addressed_to_a_peer_once(self):
+        st, top, step = self.store(delegated=True, blocked=True)
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(st))
+        self.assertEqual(jd.restamp_peer_wait_blocks_all(NOW), (1, 1))
+        got = json.loads((jd.GOALDIR / (WORKER + ".json")).read_text())["nodes"][step]
+        self.assertFalse(got["blocked"])
+        self.assertEqual(got.get("awaitingKind"), "peer")
+        self.assertEqual(list(got.get("awaitingPeers") or ()), [MANAGER])
+        self.assertEqual(jd.restamp_peer_wait_blocks_all(NOW + 1), (0, 0), "idempotent")
+
+    def test_the_boot_pass_leaves_a_users_block_and_a_nudge_block_alone(self):
+        st, top, step = self.store(blocked=True)                                # standalone: the user's
+        st["nodes"][top]["blocked"] = True
+        st["nodes"][top]["log"] = [{"kind": "block", "src": "nudge", "ev_t": T0 + 500}]
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(st))
+        self.assertEqual(jd.restamp_peer_wait_blocks_all(NOW), (0, 0))
+        got = json.loads((jd.GOALDIR / (WORKER + ".json")).read_text())["nodes"]
+        self.assertTrue(got[step]["blocked"] and got[top]["blocked"])
+
+
+class RelayEndToEnd(_Peer):
+    """A worker's closer block under a delegated goal with no open ask: one relayed question in the manager's inbox,
+    the manager's reply lifts the wait, and a re-asserted block never relays twice."""
+
+    def setUp(self):
+        super().setUp()
+        self._orig_send = km._bus_send_relay
+        self.sent = []
+        self.inbox = jd.STATE / "postal" / "mail" / MANAGER / "new"
+        self.inbox.mkdir(parents=True)
+        test = self
+
+        def fake_bus(payload):                       # the bus's own outcome: the maildir file and the log row
+            test.sent.append(payload)
+            mid = "relay-%d" % len(test.sent)
+            (test.inbox / mid).write_text("X-Relayed: romp\n\n" + payload["body"])
+            test.rows.append({"id": mid, "from_id": payload["from_id"], "to_id": payload["to"], "from": payload["from"],
+                              "t": NOW, "kind": payload["kind"], "relayed": True})
+            test._write_mail()
+            return True, "", False, {"ok": True, "id": mid}
+        km._bus_send_relay = fake_bus
+
+    def tearDown(self):
+        km._bus_send_relay = self._orig_send
+        km._RELAY_SAID.clear()
+        km._RELAY_BAD["n"] = 0
+        super().tearDown()
+
+    def _save(self, st):
+        jd.save_goals(WORKER, st)                   # the real path: the entry is written once the store is published
+
+    def _queue(self):
+        d = jd._relay_queue_dir()
+        return sorted(f.name for f in d.glob("*.json")) if d.is_dir() else []
+
+    def _close(self, st, step, why, t):
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, [st["nodes"][step]], {"done": {}, "block": {1: why}, "awaiting": {}}, t=t)
+
+    def test_the_relay_creates_the_edge_the_reply_lifts_and_a_re_asserted_block_never_relays_twice(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "PR is green and cannot move further without you", T0 + 400)
+        self.assertEqual(self._queue(), [], "nothing queued before the store is saved")
+        self._save(st)
+        self.assertEqual(len(self._queue()), 1, "the judge queued the node once its store was published")
+        self.assertEqual(km._relay_tick(NOW), 1)
+        self.assertEqual(self._queue(), [], "consumed")
+        self.assertEqual(self.sent, [{"to": MANAGER, "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+                                      "body": "api cannot move further: PR is green and cannot move further without you"}],
+                         "the worker's own words with a plain lead-in, as the worker, marked relayed")
+        self.assertEqual(len(list(self.inbox.iterdir())), 1, "one question in the manager's inbox")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertNotIn("relayWanted", nd)
+        self.assertEqual(nd["relayed"]["peer"], MANAGER)
+        self.assertEqual(jd._open_ask_peers(WORKER), [MANAGER], "the edge every ending keys on now exists")
+        self.assertEqual(km._relay_tick(NOW + 1), 0, "once")
+        # the closer re-asserts the block on the standing wait: no second relay
+        st2 = jd.load_goals(WORKER)
+        self._close(st2, step, "still cannot move further without you", NOW + 5)
+        self.assertNotIn("relayWanted", st2["nodes"][step])
+        self.assertEqual(list(st2["nodes"][step]["awaitingPeers"]), [MANAGER])
+        # the manager replies: the pair-aware supersede lifts the wait (the stamp's WRITE time is the wall clock, so
+        # the reply must postdate it: a reply the gate had already weighed never supersedes)
+        import time as _time
+        self.rows.append(mail(MANAGER, WORKER, int(_time.time()) + 60, kind="coordinate"))
+        self._write_mail()
+        self.assertTrue(km._peer_stamp_superseded(st2["nodes"][step], km._peer_answered(WORKER)), "the reply ends the wait")
+        self.assertEqual(jd._open_ask_peers(WORKER), [], "answered: no open ask")
+
+    def test_a_transient_failure_keeps_the_entry_and_is_said_once(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (False, "ConnectionRefusedError", False, {})
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            self.assertEqual(km._relay_tick(NOW), 0)
+            self.assertEqual(km._relay_tick(NOW + 1), 0)
+        self.assertEqual(err.getvalue().count("retried next tick"), 1, "said once")
+        self.assertIn("relayWanted", jd.load_goals(WORKER)["nodes"][step], "the marker stands for the next tick")
+        self.assertEqual(len(self._queue()), 1, "the entry stays queued")
+
+    def test_a_definitive_refusal_reverts_to_the_users_block(self):
+        # the delegating peer is dead or not a session: nobody can be asked, so the block is the user's after all
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (False, "bus /send 404: no live session answers to that id", True, {})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 0)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertTrue(nd["blocked"], "the needs-you is back")
+        self.assertIn("cannot move further without you", nd["blockWhy"])
+        self.assertIn("relay to web was refused", nd["blockWhy"])
+        self.assertNotIn("relayWanted", nd)
+        self.assertEqual(nd["mt"], NOW, "bumped like every other block writer")
+        self.assertEqual(nd["relayDone"]["outcome"], "refused", "the removal is a record the merge honours")
+        self.assertEqual(self._queue(), [])
+
+    def test_a_wait_that_ended_before_the_tick_is_never_relayed(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        jd.record_verdict(st, st["nodes"][step], "romp", "done", T0 + 500)         # resolved before the tick ran
+        self._save(st)
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertEqual(self.sent, [], "nothing sent")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertNotIn("relayWanted", nd, "the marker stood down")
+        self.assertEqual(nd["relayDone"]["outcome"], "stood-down")
+
+
+class RelayEdges(RelayEndToEnd):
+    """The manager's third review: the guard reads the state before the write, two writers never lose an entry, an
+    unsaved marker keeps its entry, a parked relay is pending until it lands or comes back, malformed entries drop alone."""
+
+    def test_a_block_after_the_lift_relays_again(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        self.assertEqual(km._relay_tick(NOW), 1)
+        st = jd.load_goals(WORKER)
+        self.rows.append(mail(MANAGER, WORKER, NOW + 5, kind="coordinate"))    # the manager answers the relayed question...
+        self._write_mail()
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)   # ...and the wait lifts
+        self.assertIsNone(st["nodes"][step].get("awaitingKind"))
+        self._close(st, step, "now stuck on the second question", NOW + 60)   # a NEW block on the same node
+        self.assertEqual(st["nodes"][step]["relayWanted"]["why"], "now stuck on the second question", "a second relay")
+        self.assertNotIn("relayed", st["nodes"][step], "the ended wait took its relay record with it")
+
+    def test_an_entry_whose_marker_is_not_saved_yet_is_kept_not_dropped(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)                                     # the store on disk carries no marker...
+        jd._relay_write_entry(WORKER, step)                # ...but an entry exists (the save carrying it has not landed)
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertEqual(len(self._queue()), 1, "kept for the save to land, never dropped")
+        st2, top2, step2 = self.store(delegated=True)
+        st2["nodes"][step2]["relayed"] = {"peer": MANAGER, "why": "x", "t": NOW}
+        self._save(st2)
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertEqual(self._queue(), [], "a settled node's entry is spent")
+
+    def test_two_writers_never_lose_an_entry(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        other = WORKER + ":g9"
+        st["nodes"][other] = node(other, "Another question", parent=top, t=T0 + 700, relayWanted={"peer": MANAGER, "why": "q", "t": T0 + 700})
+        self._save(st)
+        real = km._bus_send_relay
+        def slow_bus(payload):                            # the judge appends an entry WHILE the tick is mid-send
+            jd._relay_write_entry(WORKER, other)
+            return real(payload)
+        km._bus_send_relay = slow_bus
+        self.assertGreaterEqual(km._relay_tick(NOW), 1)
+        self.assertIn(jd._relay_entry_path(WORKER, other).name, self._queue(),
+                      "the entry appended mid-tick survives for the next tick: two writers never rewrite one list")
+
+    def test_a_parked_relay_is_pending_until_it_lands_or_comes_back(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "relay-far-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0, "parked is not sent")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual(nd["relayWanted"]["parkedMid"], "relay-far-1")
+        self.assertEqual(len(self._queue()), 1, "pending")
+        self.rows.append({"id": "relay-far-1", "ev": "bounced", "t": NOW + 30, "to_id": MANAGER, "from_id": WORKER})
+        self._write_mail()
+        self.assertEqual(km._relay_tick(NOW + 60), 0)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertTrue(nd["blocked"], "the bounce is the definitive refusal: the user's block")
+        self.assertEqual(self._queue(), [])
+
+    def test_a_parked_relay_the_peer_answers_completes(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "relay-far-2", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.rows.append(mail(MANAGER, WORKER, NOW + 40, kind="coordinate"))
+        self._write_mail()
+        self.assertEqual(km._relay_tick(NOW + 60), 1, "the peer answered: the relay stands as sent")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual(nd["relayed"]["mid"], "relay-far-2")
+        self.assertEqual(self._queue(), [])
+
+    def test_a_malformed_entry_drops_alone(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        (jd._relay_queue_dir() / "garbage.json").write_text("{not json")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 1, "the good entry was relayed")
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(km._RELAY_BAD["n"], 1)
+
+    def test_the_boot_pass_requeues_an_orphaned_marker(self):
+        st, top, step = self.store(delegated=True)
+        st["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(st))   # a marker on disk with no entry
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(jd._requeue_relays_all(), 1)
+        self.assertEqual(len(self._queue()), 1)
+        self.assertEqual(jd._requeue_relays_all(), 0, "idempotent")
+
+
+class TwoDelegators(_Peer):
+    def test_a_top_is_attributed_to_the_mail_its_anchor_names(self):
+        # two managers dispatched this worker; each goal's block goes to the manager whose mail anchored it
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self.rows.append(mail(OTHER, WORKER, T0 - 100, kind="delegate", mid="m-tests-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"; st["nodes"][top]["promptMsgId"] = "m-web-1"
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "web's mail anchored it, though tests wrote later")
+        st2, top2, step2 = self.store()
+        st2["nodes"][top2]["askAnchor"] = "machine"; st2["nodes"][top2]["promptMsgId"] = ""
+        nd2 = self._close_block(st2, step2, "cannot move further without you")
+        self.assertEqual(list(nd2.get("awaitingPeers") or ()), [OTHER], "no mail id on the anchor: the latest delegate")
+
+    def test_the_planner_pass_latches_the_anchors_mail_id_from_the_parse(self):
+        st, top, step = self.store()
+        session = {"turns": [{"atoms": [{"uuid": "u1", "type": "user", "message": {"role": "user", "content": [{"type": "text",
+                   "text": "Ship the exporter\n<!-- romp-msg-id: m-web-1 -->\n<!-- romp-msg-kind: delegate -->"}]}}]}]}
+        st["nodes"][top]["promptUuid"] = "u1"
+        self.assertEqual(jd._latch_prompt_msg_ids(session, st), 1)
+        self.assertEqual(st["nodes"][top]["promptMsgId"], "m-web-1")
+        self.assertEqual(jd._latch_prompt_msg_ids(session, st), 0, "latched once")
+
+    def _close_block(self, st, step, why):
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, [st["nodes"][step]], {"done": {}, "block": {1: why}, "awaiting": {}}, t=T0 + 400)
+        return st["nodes"][step]
+
+
+class MoreRules(_Peer):
+    def _close_block(self, st, step, why, t=T0 + 400):
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, [st["nodes"][step]], {"done": {}, "block": {1: why}, "awaiting": {}}, t=t)
+        return st["nodes"][step]
+
+    def test_a_tracker_in_the_users_own_session_keeps_its_block(self):
+        st, top, step = self.store()                                          # no delegation: the user's own session
+        st["nodes"][step]["handoff"] = {"peer": OTHER, "goalId": OTHER + ":g3"}
+        nd = self._close_block(st, step, "need your call before I hand more over")
+        self.assertTrue(nd["blocked"], "a decision only the user can make")
+
+    def test_one_stamp_per_standing_wait_whatever_the_words(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, MANAGER, T0 + 300)
+        nd = self._close_block(st, step, "cannot move further without an answer")
+        nd = self._close_block(st, step, "still waiting, now on the second point too", T0 + 900)
+        rows = [e for e in nd["log"] if e.get("kind") == "awaiting"]
+        self.assertEqual(len(rows), 1, "the standing wait keeps its since-time; no second stamp")
+        self.assertEqual(nd["awaitingWhy"], "cannot move further without an answer")
+
+    def test_a_cross_host_open_ask_is_a_peer_wait_with_no_relay(self):
+        st, top, step = self.store(delegated=True)
+        self.rows.append({"id": "m-x", "from_id": WORKER, "to_id": "peer:TESTHOST", "toName": "far", "from": "api", "t": T0 + 300, "kind": "question"})
+        self._write_mail()
+        nd = self._close_block(st, step, "waiting on far")
+        self.assertEqual(len(nd.get("awaitingPeers") or ()), 1)
+        self.assertTrue(str(nd["awaitingPeers"][0]).startswith("peer:"), "the wait maps' own key for an unresolved far recipient")
+        self.assertNotIn("relayWanted", nd, "the ask exists: nothing to relay")
+
+    def test_a_host_qualified_sender_is_never_the_delegating_peer(self):
+        self.ask("TESTHOST:" + OTHER, WORKER, T0 - 100, kind="delegate")
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertTrue(nd["blocked"])
+
+    def test_an_interrupt_block_is_never_lifted_into_a_wait(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, MANAGER, T0 + 300)
+        st["nodes"][step]["blocked"] = True
+        st["nodes"][step]["log"] = [{"kind": "block", "src": "interrupt", "ev_t": T0 + 350, "why": "stopped by the user"}]
+        nd = self._close_block(st, step, "still waiting on the manager")
+        self.assertTrue(nd["blocked"], "the interrupt stands")
+        self.assertEqual([e["kind"] for e in nd["log"]], ["block"])
+
+    def test_the_planners_block_row_carries_its_segment(self):
+        st, top, step = self.store()
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_plan(st, "seg-7", T0 + 900, [{"do": "block", "why": "needs your call", "goal": 1}], [st["nodes"][step]])
+        row = [e for e in st["nodes"][step]["log"] if e.get("kind") == "block"][0]
+        self.assertEqual(row.get("seg"), "seg-7")
+
+
+class SendRouteRelayed(unittest.TestCase):
+    """The bus's /send carries relayed into deliver: the maildir header, the row and the inbox read all say so."""
+
+    def test_the_send_route_relays_end_to_end(self):
+        ps = load_source("romp_postal_service_pw_route", os.path.join(os.path.dirname(HERE), "postal", "postal_service.py"))
+        live = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False); json.dump([{"id": MANAGER, "name": "web"}], live); live.close()
+        prior = os.environ.get("ROMP_SESSIONS_FILE"); os.environ["ROMP_SESSIONS_FILE"] = live.name
+        try:
+            h = object.__new__(ps.Handler)
+            raw = json.dumps({"to": MANAGER, "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+                              "body": "api cannot move further: which client?"}).encode()
+            h.path = "/send"; h.headers = {"Content-Length": str(len(raw)), "X-Romp-Token": ps.SERVE_TOKEN}; h.rfile = io.BytesIO(raw)
+            out = []; h._send = lambda obj, code=200: out.append((obj, code))
+            h.do_POST()
+        finally:
+            if prior is None: os.environ.pop("ROMP_SESSIONS_FILE", None)
+            else: os.environ["ROMP_SESSIONS_FILE"] = prior
+            os.unlink(live.name)
+        obj, code = out[0]
+        self.assertEqual(code, 200, obj)
+        got = [m for m in ps.read_box(MANAGER, False) if m.get("from_id") == WORKER]
+        self.assertTrue(got and got[-1].get("relayed"), "the recipient's inbox read carries the mark")
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        self.assertTrue(any(r.get("relayed") and r.get("from_id") == WORKER and r.get("kind") == "question" for r in rows))
+
+
+class MergeCarriesTheRelay(_Peer):
+    """Two writers touch the relay keys (the judge marks relayWanted, the kernel's tick replaces it with relayed): the
+    store merge on save carries the newer fact, so a stale copy never resurrects a relay or loses its record."""
+
+    def test_a_stale_judge_copy_does_not_resurrect_a_relay_the_kernel_sent(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400}
+        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "cannot move further", "t": NOW}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayed"]["peer"], MANAGER)
+        self.assertNotIn("relayWanted", mem["nodes"][step])
+
+    def test_a_stale_kernel_copy_keeps_a_relay_the_judge_just_asked_for(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayWanted"]["peer"], MANAGER)
+
+    def test_a_removal_the_kernel_recorded_is_never_resurrected(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400}
+        disk["nodes"][step]["relayDone"] = {"peer": MANAGER, "why": "q", "t": NOW, "outcome": "stood-down"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertNotIn("relayWanted", mem["nodes"][step], "the stand-down stands")
+        self.assertEqual(mem["nodes"][step]["relayDone"]["outcome"], "stood-down")
+
+
+class PostalRelayedFlag(unittest.TestCase):
+    """The postal deliver and its row carry the relayed mark, so the recipient and the courier can tell a relayed
+    question from a typed ask."""
+
+    def test_deliver_marks_a_relayed_question_in_the_header_and_the_row(self):
+        ps = load_source("romp_postal_service_pw", os.path.join(os.path.dirname(HERE), "postal", "postal_service.py"))
+        mid = ps.deliver(MANAGER, "api", WORKER, "api cannot move further: which client?", kind="question", relayed=True)
+        text = (ps._mailbox(MANAGER) / "new" / mid).read_text()
+        self.assertIn("X-Relayed: romp\n", text)
+        self.assertIn("X-Kind: question\n", text)
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        row = next(r for r in rows if r.get("id") == mid)
+        self.assertEqual((row.get("relayed"), row.get("kind"), row.get("from_id"), row.get("to_id")), (True, "question", WORKER, MANAGER))
+        got = [m for m in ps.read_box(MANAGER, False) if m.get("from_id") == WORKER]
+        self.assertTrue(got and all(m.get("relayed") for m in got), "the inbox read carries the mark to the recipient")
+        plain = ps.deliver(MANAGER, "api", WORKER, "a typed question", kind="question")
+        self.assertNotIn("X-Relayed", (ps._mailbox(MANAGER) / "new" / plain).read_text())
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        self.assertNotIn("relayed", next(r for r in rows if r.get("id") == plain))
+
+
+class ManagerEscalation(_Peer):
+    """The debt ladder's escalation for a MANAGER debtor waits until nothing is queued for it: the nudge walk already
+    runs the outcomes only for an idle debtor, and the one queue its gates miss is delivered mail the manager has not
+    read, so with worker mail waiting the record stands. A peer that is not the asker's manager keeps the ladder."""
+
+    def setUp(self):
+        super().setUp()
+        self._orig = {n: getattr(km, n) for n in ("_mark_views_dirty",)}
+        self.inbox = jd.STATE / "postal" / "mail" / MANAGER / "new"
+        self.inbox.mkdir(parents=True)
+        km._autonudge_cache.clear()
+        self.asker, self.debtor, self.ts, self.fire = WORKER, MANAGER, T0 + 300, T0 + 600
+        self.ask(self.asker, self.debtor, self.ts)                                     # the unanswered ask
+        st, top, step = self.store(delegated=True)                                     # the manager delegated the goal
+        (jd.GOALDIR / (self.asker + ".json")).write_text(json.dumps(st))
+        (jd.STATE / "auto-nudge.json").write_text(json.dumps(
+            {"enabled": True, "nudged": {}, "debtNudged": {"%s>%s:%d" % (self.asker, self.debtor, self.ts): self.fire}}))
+        km._autonudge_cache.clear()
+        km._mark_views_dirty = lambda *a, **k: None
+
+    def tearDown(self):
+        for n, v in self._orig.items():
+            setattr(km, n, v)
+        km._autonudge_cache.clear()
+        super().tearDown()
+
+    def _outcomes(self, unread):
+        for f in self.inbox.iterdir():
+            f.unlink()
+        for i in range(unread):
+            (self.inbox / ("m%d" % i)).write_text("{}")
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._debt_reminder_outcomes(self.debtor, {"id": "t9", "t": self.fire + 100, "end": self.fire + 160, "ended": True}, NOW)
+        keys = list((km._auto_nudge_data().get("debtNudged") or {}).keys())
+        top = json.loads((jd.GOALDIR / (self.asker + ".json")).read_text())["nodes"][self.asker + ":g1"]
+        return keys, top.get("blocked", False)
+
+    def test_a_manager_with_unread_mail_is_not_yet_failing_to_answer(self):
+        keys, blocked = self._outcomes(unread=3)
+        self.assertEqual(len(keys), 1, "the record stands: mail waits for the manager")
+        self.assertFalse(blocked)
+
+    def test_an_idle_managers_turn_ending_without_an_answer_escalates(self):
+        keys, blocked = self._outcomes(unread=0)
+        self.assertEqual(keys, [], "the record retires on the event")
+        self.assertTrue(blocked, "the asker's card reaches the user, through the ladder alone")
+
+    def test_a_peer_that_is_not_the_managers_keeps_the_ladder_as_it_was(self):
+        st, top, step = self.store()                                                   # no delegation from the debtor
+        (jd.GOALDIR / (self.asker + ".json")).write_text(json.dumps(st))
+        (jd.STATE / "postal" / "mail" / OTHER / "new").mkdir(parents=True)
+        keys, blocked = self._outcomes(unread=3)
+        self.assertEqual(keys, [], "an ordinary peer with mail waiting that moved on still escalates")
+        self.assertTrue(blocked)

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -305,6 +305,40 @@ class CloserBlocks(_Peer):
         self.assertEqual(list(st["nodes"][step]["awaitingPeers"] or ()), [MANAGER])
 
 
+class UsersFollowUp(_Peer):
+    """The user's own follow-up on a delegated card (follow up pressed on the worker's card): a block after it is theirs,
+    never a peer wait, never relayed; a follow-up older than the delegation changes nothing."""
+
+    def _close(self, st, step, why, t=T0 + 400):
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, [st["nodes"][step]], {"done": {}, "block": {1: why}, "awaiting": {}}, t=t)
+        return st["nodes"][step]
+
+    def test_a_follow_up_newer_than_the_delegation_keeps_the_block_the_users(self):
+        st, top, step = self.store(delegated=True)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", T0 + 300, msg=True)   # follow up pressed on the card after the mint
+        nd = self._close(st, step, "cannot move further without you")
+        self.assertTrue(nd["blocked"])
+        self.assertIsNone(nd.get("awaitingKind"))
+        self.assertNotIn("relayWanted", nd)
+
+    def test_a_follow_up_older_than_the_delegation_changes_nothing(self):
+        st, top, step = self.store(delegated=True)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", T0 - 100, msg=True)   # before the mint
+        nd = self._close(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+
+    def test_a_follow_up_after_a_standing_wait_reclaims_it(self):
+        st, top, step = self.store(delegated=True)
+        nd = self._close(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+        jd.record_verdict(st, nd, "user", "reopen", T0 + 900, msg=True)   # the user follows up on the waiting card...
+        jd.record_verdict(st, nd, "romp", "awaiting", T0 + 900, why="", lift=True, end_ev=T0 + 900)
+        nd = self._close(st, step, "still cannot move further", T0 + 1000)   # ...and the next block is theirs
+        self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
+
+
 class RowsAlreadyFiled(_Peer):
     def test_the_boot_pass_converts_a_closer_block_addressed_to_a_peer_once(self):
         st, top, step = self.store(delegated=True, blocked=True)
@@ -344,7 +378,7 @@ class _RelayFixture(_Peer):
             mid = "relay-%d" % len(test.sent)
             (test.inbox / mid).write_text("X-Relayed: romp\n\n" + payload["body"])
             test.rows.append({"id": mid, "from_id": payload["from_id"], "to_id": payload["to"], "from": payload["from"],
-                              "t": NOW, "kind": payload["kind"], "relayed": True})
+                              "t": NOW, "kind": payload["kind"], "relayed": True, "relayMarker": payload.get("relayMarker")})
             test._write_mail()
             return True, "", False, {"ok": True, "to": payload["to"]}   # the local route's answer (no id)
         km._bus_send_relay = fake_bus
@@ -380,7 +414,7 @@ class RelayEndToEnd(_RelayFixture):
         self.assertEqual(len(self._queue()), 1, "the judge queued the node once its store was published")
         self.assertEqual(km._relay_tick(NOW), 1)
         self.assertEqual(self._queue(), [], "consumed")
-        self.assertEqual(self.sent, [{"to": MANAGER, "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+        self.assertEqual([{k: v for k, v in s.items() if k != "relayMarker"} for s in self.sent], [{"to": MANAGER, "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
                                       "body": "api cannot move further: PR is green and cannot move further without you"}],
                          "the worker's own words with a plain lead-in, as the worker, marked relayed")
         self.assertEqual(len(list(self.inbox.iterdir())), 1, "one question in the manager's inbox")
@@ -460,7 +494,6 @@ class RelayEdges(_RelayFixture):
         self.assertIsNone(st["nodes"][step].get("awaitingKind"))
         self._close(st, step, "now stuck on the second question", NOW + 60)   # a NEW block on the same node
         self.assertEqual(st["nodes"][step]["relayWanted"]["why"], "now stuck on the second question", "a second relay")
-        self.assertNotIn("relayed", st["nodes"][step], "the ended wait took its relay record with it")
         self._save(st)
         entry = json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())
         self.assertEqual(entry["marker"], st["nodes"][step]["relayWanted"]["id"], "the entry names the new marker")
@@ -468,6 +501,35 @@ class RelayEdges(_RelayFixture):
         self.assertEqual(km._relay_tick(NOW + 90), 1, "the second question goes out")
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertEqual(nd["relayed"]["marker"], entry["marker"], "the record names the marker it settled")
+
+    def test_a_lift_before_any_tick_then_a_new_block_relays_the_new_words_once(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)   # block...
+        first = st["nodes"][step]["relayWanted"]["id"]
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", T0 + 500, why="", lift=True, end_ev=T0 + 500)   # ...lift...
+        self._close(st, step, "second question", T0 + 600)  # ...re-block, all on one loaded store, no tick between
+        rw = st["nodes"][step]["relayWanted"]
+        self.assertEqual((rw["why"], rw["id"] != first), ("second question", True), "a fresh marker for the new wait")
+        self.assertIn(first, st["nodes"][step]["relaySettled"], "the ended wait's unsent marker is settled")
+        self._save(st)
+        self.assertEqual(km._relay_tick(NOW), 1)
+        self.assertEqual([p["body"] for p in self.sent], ["api cannot move further: second question"], "the NEW words")
+        self.assertEqual(km._relay_tick(NOW + 1), 0, "once")
+
+    def test_two_holders_filing_one_wait_mint_one_marker(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)
+        a = jd.load_goals(WORKER)
+        b = jd.load_goals(WORKER)
+        self._close(a, step, "cannot move further without you", T0 + 400)
+        self._save(a)
+        self._close(b, step, "cannot move further without you", T0 + 400)   # the same evidence, the same peer
+        self._save(b)
+        self.assertEqual(a["nodes"][step]["relayWanted"]["id"], b["nodes"][step]["relayWanted"]["id"], "one id")
+        self.assertEqual(len(self._queue()), 1)
+        self.assertEqual(km._relay_tick(NOW), 1)
+        self.assertEqual(len(self.sent), 1, "one question")
+        self.assertEqual(km._relay_tick(NOW + 1), 0)
 
     def test_a_re_block_with_the_same_words_after_a_lift_is_a_new_marker(self):
         st, top, step = self.store(delegated=True)
@@ -625,7 +687,7 @@ class RelayEdges(_RelayFixture):
             self.assertEqual(km._relay_tick(NOW + 60), 0)
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertTrue(nd["blocked"])
-        self.assertIn("the message was withdrawn", nd["log"][-1]["why"])
+        self.assertIn("was withdrawn by api", nd["log"][-1]["why"])
 
     def test_a_bounce_carries_the_far_hosts_reason_into_the_users_block(self):
         st, top, step = self.store(delegated=True)
@@ -639,6 +701,7 @@ class RelayEdges(_RelayFixture):
             km._relay_tick(NOW + 60)
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertIn("came back from TESTHOST: no live session named web", nd["log"][-1]["why"])
+        self.assertEqual(nd["log"][-1]["ev_t"], NOW + 30, "filed at the bounce row's time: a later lift outranks it")
 
     def test_an_answer_in_the_sends_own_second_is_not_the_answer(self):
         st, top, step = self.store(delegated=True)
@@ -685,11 +748,48 @@ class RelayEdges(_RelayFixture):
             self.assertEqual(len(self._queue()), 1, "the entry is kept for the next tick")
             self.assertEqual(len(self.sent), 1)
             with contextlib.redirect_stderr(io.StringIO()):
-                self.assertEqual(km._relay_tick(NOW + 1), 1)
+                self.assertEqual(km._relay_tick(NOW + 1), 1, "the bus's own row of the first send is adopted")
         finally:
             jd.save_goals = real
+        self.assertEqual(len(self.sent), 1, "never a second send: the manager holds the question once")
         self.assertEqual(self._queue(), [])
-        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayed"]["peer"], MANAGER)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual((nd["relayed"]["peer"], nd["relayed"]["mid"]), (MANAGER, "relay-1"))
+
+    def test_a_send_with_an_unknown_outcome_is_settled_by_the_bus_row_next_tick(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        real = km._bus_send_relay
+        def lossy_bus(payload):                            # the bus delivered, the answer never came back
+            real(payload)
+            return False, "timed out", False, {"unknown": True}
+        km._bus_send_relay = lossy_bus
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertIn("outcome is unknown", err.getvalue())
+        self.assertEqual(len(self._queue()), 1)
+        self.assertEqual(km._relay_tick(NOW + 1), 1, "the row names the marker: adopted")
+        self.assertEqual(len(self.sent), 1)
+        self.assertEqual(self._queue(), [])
+
+    def test_a_relay_leg_send_with_a_lost_answer_is_adopted_as_pending(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        marker = st["nodes"][step]["relayWanted"]["id"]
+        def lossy_relay_leg(payload):                      # the relay leg wrote its sent row, then the answer was lost
+            self.rows.append({"t": NOW, "ev": "sent", "id": "px-lost-1", "from_id": WORKER, "to_id": "peer:TESTHOST",
+                              "to_sid": MANAGER, "kind": "question", "relayed": True, "relayMarker": payload["relayMarker"]})
+            self._write_mail()
+            return False, "timed out", False, {"unknown": True}
+        km._bus_send_relay = lossy_relay_leg
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 0)
+        km._bus_send_relay = lambda payload: self.fail("a second send")
+        self.assertEqual(km._relay_tick(NOW + 1), 0)
+        rw = jd.load_goals(WORKER)["nodes"][step]["relayWanted"]
+        self.assertEqual((rw["id"], rw["pendingMid"], rw["pendingHost"]), (marker, "px-lost-1", "TESTHOST"))
 
     def test_a_later_markers_transient_failure_is_said_after_an_earlier_one_stood_down(self):
         st, top, step = self.store(delegated=True)
@@ -732,6 +832,73 @@ class RelayEdges(_RelayFixture):
             self.assertEqual(loads, [WORKER, WORKER])
         finally:
             jd.load_goals = real
+
+    def test_a_pending_relay_whose_wait_ended_is_recalled(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-r1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        recalls = []
+        real = km._bus_recall_relay
+        km._bus_recall_relay = lambda sid, mid: recalls.append((sid, mid)) or "withdrawn"
+        try:
+            st = jd.load_goals(WORKER)
+            jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)   # ended another way
+            self._save(st)
+            self.assertEqual(km._relay_tick(NOW + 10), 0)
+        finally:
+            km._bus_recall_relay = real
+        self.assertEqual(recalls, [(WORKER, "px-r1")], "the parked question is withdrawn from the far host's outbox")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual((nd["relayDone"]["outcome"], nd["relayDone"]["recall"]), ("stood-down", "withdrawn"))
+        self.assertEqual(self._queue(), [])
+
+    def test_a_pending_relay_the_far_host_delivered_settles_though_the_wait_ended(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-r2", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._save(st)
+        self.rows.append({"t": NOW + 30, "ev": "relayed", "id": "px-r2", "host": "TESTHOST"})
+        self._write_mail()
+        km._bus_recall_relay = lambda sid, mid: self.fail("nothing to recall: it was delivered")
+        self.assertEqual(km._relay_tick(NOW + 60), 1, "delivered settles it, whatever the wait did")
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayed"]["mid"], "px-r2")
+
+    def test_a_recovered_row_behind_the_ack_never_ends_the_walk(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-r3", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.rows.append({"t": NOW + 30, "ev": "relayed", "id": "px-r3", "host": "TESTHOST"})
+        self.rows.append({"t": NOW - 5000, "ev": "sent", "id": "old-mail", "from_id": WORKER, "to_id": MANAGER, "recovered": True})
+        self._write_mail()                                 # the rowless rebuild appended an old row behind the ack
+        self.assertEqual(km._relay_tick(NOW + 60), 1, "the ack is found past the recovered row")
+
+    def test_a_dead_workers_block_is_not_relayed(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        self.assertEqual(km._relay_tick(NOW, alive_ids={MANAGER}), 0, "the worker is not alive: nobody asks")
+        self.assertEqual(self.sent, [])
+        self.assertEqual(len(self._queue()), 1, "the entry waits")
+        self.assertEqual(km._relay_tick(NOW + 1, alive_ids={MANAGER}), 0)
+        self.assertEqual(km._relay_tick(NOW + 2, alive_ids={MANAGER, WORKER}), 1, "alive again: sent")
+
+    def test_the_relayed_body_speaks_no_romp_and_drops_a_procedural_why(self):
+        self.assertEqual(km._relay_body("api", jd.NUDGE_BLOCK_WHY), "api cannot move further on this and needs your call.")
+        self.assertEqual(km._relay_body("api", ""), "api cannot move further on this and needs your call.")
+        body = km._relay_body("api", "the goal is blocked until the user approves the schema; card held open; which schema version should ship?")
+        self.assertEqual(body, "api cannot move further: which schema version should ship?")
+        self.assertEqual(km._relay_body("api", "the dashboard keyboard shortcut collides with discard; which key?"),
+                         "api cannot move further: the dashboard keyboard shortcut collides with discard; which key?",
+                         "words, not substrings")
+        self.assertEqual(km._relay_body("api", "the card is held open."), "api cannot move further on this and needs your call.")
 
     def test_a_malformed_entry_drops_alone(self):
         st, top, step = self.store(delegated=True)
@@ -1064,6 +1231,8 @@ class PostalRelayedFlag(unittest.TestCase):
         self.assertEqual((row.get("relayed"), row.get("kind"), row.get("from_id"), row.get("to_id")), (True, "question", WORKER, MANAGER))
         got = [m for m in ps.read_box(MANAGER, False) if m.get("from_id") == WORKER]
         self.assertTrue(got and all(m.get("relayed") for m in got), "the inbox read carries the mark to the recipient")
+        recs = ps.format_receipts(ps._sent_receipts(WORKER))
+        self.assertIn("sent on your behalf", recs, "the worker's own receipts say romp sent it")
         plain = ps.deliver(MANAGER, "api", WORKER, "a typed question", kind="question")
         self.assertNotIn("X-Relayed", (ps._mailbox(MANAGER) / "new" / plain).read_text())
         rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -482,6 +482,23 @@ class RelayEndToEnd(_RelayFixture):
         self.assertEqual(nd["relayDone"]["outcome"], "refused", "the removal is a record the merge honours")
         self.assertEqual(self._queue(), [])
 
+    def test_a_later_relay_on_the_node_clears_the_refusals_note(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        fake = km._bus_send_relay
+        km._bus_send_relay = lambda payload: (False, "bus /send 404: no live recipient", True, {})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        self.assertIn("relayRefusal", st["nodes"][step])
+        jd.record_verdict(st, st["nodes"][step], "romp", "unblock", NOW + 5)          # the block lifts (the manager is live again)...
+        self._close(st, step, "a new question", NOW + 60)                              # ...and the next block relays
+        self._save(st)
+        km._bus_send_relay = fake
+        self.assertEqual(km._relay_tick(NOW + 70), 1)
+        self.assertNotIn("relayRefusal", jd.load_goals(WORKER)["nodes"][step], "the old note is gone with the new relay")
+
     def test_a_wait_that_ended_before_the_tick_is_never_relayed(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
@@ -846,6 +863,23 @@ class RelayEdges(_RelayFixture):
         self.assertEqual(len(calls), 1)
         self.assertEqual(len(self.sent), 1)
 
+    def test_a_judges_save_inside_the_hold_keeps_the_hold(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        holder = jd.load_goals(WORKER)                     # a judge pass loads before the tick...
+        calls = []
+        km._bus_send_relay = lambda payload: calls.append(payload) or (False, "timed out", False, {"unknown": True})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 0)     # ...the bus stalls: the marker carries the hold...
+        holder["nodes"][top]["text"] = "Ship the exporter (renamed)"
+        self._save(holder)                                 # ...and the judge saves inside the hold
+        rw = jd.load_goals(WORKER)["nodes"][step]["relayWanted"]
+        self.assertEqual((rw["unknownAt"], rw["attempts"]), (NOW, 1), "the merge carried the tick's fields")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 2), 0)
+        self.assertEqual(len(calls), 1, "the stalled bus is not asked again")
+
     def test_a_stalled_bus_that_never_wrote_is_asked_again_after_the_hold(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
@@ -859,6 +893,16 @@ class RelayEdges(_RelayFixture):
             self.assertEqual(km._relay_tick(NOW + km.RELAY_UNKNOWN_HOLD), 0)
         self.assertEqual(len(calls), 2, "the hold passed with no row: asked again")
         self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayWanted"]["attempts"], 2)
+
+    def test_a_far_route_duplicate_answer_is_pending_on_the_named_host(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-dup-1", "duplicate": True, "host": "TESTHOST",
+                                                                "note": "already relayed to TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        rw = jd.load_goals(WORKER)["nodes"][step]["relayWanted"]
+        self.assertEqual((rw["pendingMid"], rw["pendingHost"]), ("px-dup-1", "TESTHOST"), "a later bounce names the host")
 
     def test_a_relay_leg_send_with_a_lost_answer_is_adopted_as_pending(self):
         st, top, step = self.store(delegated=True)
@@ -1019,6 +1063,8 @@ class RelayEdges(_RelayFixture):
         self.assertEqual(len(self._queue()), 1, "the bus could not be asked: kept")
         self.assertIn("relayWanted", jd.load_goals(WORKER)["nodes"][step])
         self.assertEqual(km._relay_tick(NOW + 11), 0)
+        self.assertEqual(len(answers), 1, "held: not asked again inside the hold")
+        self.assertEqual(km._relay_tick(NOW + 10 + km.RELAY_UNKNOWN_HOLD), 0)
         self.assertEqual(self._queue(), [])
         self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayDone"]["recall"], "carried: could not be withdrawn")
 
@@ -1311,6 +1357,29 @@ class MergeCarriesTheRelay(_Peer):
         jd._rebase_onto_disk(WORKER, mem2)
         self.assertEqual(mem2["nodes"][step]["relayWanted"]["pendingMid"], "px-1", "the kernel's own copy keeps it")
 
+    def test_the_ticks_fields_on_a_same_id_marker_are_carried_whole(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "attempts": 1, "unknownAt": NOW}
+        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "attempts": 2,
+                                              "unknownAt": NOW + 40, "pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        rw = mem["nodes"][step]["relayWanted"]
+        self.assertEqual({k: rw[k] for k in jd.RELAY_TICK_KEYS},
+                         {"pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST", "unknownAt": NOW + 40, "attempts": 2})
+        self.assertEqual(jd.RELAY_TICK_KEYS, ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts"), "named once")
+
+    def test_a_recall_done_on_the_disk_filters_the_holders_owed_list_though_the_disk_owes_none(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayRecall"] = [{"id": "mk-a", "peer": MANAGER, "pendingMid": "px-1"}]
+        disk["nodes"][step]["relayRecalled"] = [{"mid": "px-1", "outcome": "withdrawn", "t": NOW}]   # the sweep's save: done, none owed
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertNotIn("relayRecall", mem["nodes"][step], "a recall done on the disk is not re-owed by a stale holder")
+        self.assertEqual([d["mid"] for d in mem["nodes"][step]["relayRecalled"]], ["px-1"])
+
     def test_a_settled_marker_is_popped_before_the_disks_live_marker_is_adopted(self):
         st, top, step = self.store(delegated=True)
         mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
@@ -1527,7 +1596,7 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertEqual(recalls, ["px-ret-1"], "and the stale one is withdrawn from the far host's outbox")
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertNotIn("relayRecall", nd)
-        self.assertEqual(nd["relayRecalled"], ["px-ret-1"])
+        self.assertEqual([(d["mid"], d["outcome"]) for d in nd["relayRecalled"]], [("px-ret-1", "withdrawn")])
 
     def test_a_retired_marker_on_the_users_block_is_recalled_too(self):
         st, top, step = self.store(delegated=True)
@@ -1548,6 +1617,29 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertEqual(km._relay_tick(NOW + 70), 0)
         self.assertEqual(recalls, ["px-ret-2"])
         self.assertEqual(self._queue(), [], "the recall entry is spent")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual([(d["mid"], d["outcome"]) for d in nd["relayRecalled"]],
+                         [("px-ret-2", "carried: could not be withdrawn")], "a carried recall says so: the stale question reached the manager")
+
+    def test_an_unknown_recall_owed_is_held_like_a_send(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-ret-3", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", NOW + 5, msg=True)
+        self._close(st, step, "still stuck", NOW + 60)
+        self._save(st)
+        calls = []
+        km._bus_recall_relay = lambda sid, mid: calls.append(mid) or "unknown"
+        self.assertEqual(km._relay_tick(NOW + 70), 0)
+        self.assertEqual(km._relay_tick(NOW + 71), 0)
+        self.assertEqual(km._relay_tick(NOW + 70 + km.RELAY_UNKNOWN_HOLD - 1), 0)
+        self.assertEqual(len(calls), 1, "a hung bus is asked once per hold, not once per tick")
+        self.assertEqual(km._relay_tick(NOW + 70 + km.RELAY_UNKNOWN_HOLD), 0)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(len(self._queue()), 1, "still owed")
 
     def test_a_failed_publish_keeps_the_pending_list_for_the_retry(self):
         st, top, step = self.store(delegated=True)
@@ -1596,6 +1688,30 @@ class FarHostRelayMark(unittest.TestCase):
         self.assertTrue(obj.get("id") and "to" not in obj and not obj.get("parked"), "the relay leg's answer: an id, no to")
         self.assertEqual(len(parked), 1)
         self.assertEqual((parked[0][0], parked[0][1]["relayed"], parked[0][1]["kind"]), ("TESTHOST", True, "question"))
+
+    def test_the_far_route_duplicate_answer_names_the_host(self):
+        ps = self._postal()
+        saved = (ps.resolve_recipient, ps.outbox_put, dict(ps.PEERS))
+        ps.resolve_recipient = lambda to, frm_id="": {"kind": "relay", "host": "TESTHOST", "agent": {"name": "web", "id": MANAGER}}
+        ps.outbox_put = lambda host, msg: True
+        ps.PEERS["TESTHOST"] = {"up": True}
+        try:
+            def post():
+                h = object.__new__(ps.Handler)
+                raw = json.dumps({"to": "web", "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+                                  "relayMarker": "1781296800-11111111-g9", "body": "api cannot move further: far?"}).encode()
+                h.path = "/send"; h.headers = {"Content-Length": str(len(raw)), "X-Romp-Token": ps.SERVE_TOKEN}; h.rfile = io.BytesIO(raw)
+                out = []; h._send = lambda obj, code=200: out.append((obj, code))
+                h.do_POST()
+                return out[0]
+            first, c1 = post()
+            second, c2 = post()
+        finally:
+            ps.resolve_recipient, ps.outbox_put = saved[0], saved[1]
+            ps.PEERS.clear(); ps.PEERS.update(saved[2])
+        self.assertEqual((c1, c2), (200, 200))
+        self.assertEqual((second.get("duplicate"), second.get("id"), second.get("host"), "to" in second),
+                         (True, first["id"], "TESTHOST", False), "the far-route duplicate: the id, the host, no to")
 
     def test_the_far_side_delivers_a_relayed_question_marked(self):
         ps = self._postal()
@@ -1675,7 +1791,8 @@ class FarHostRelayMark(unittest.TestCase):
             self.assertIn("X-Relay-Marker: 1781296800-11111111-g2\n", text, "the header, for the rowless rebuild")
             obj2, code2 = post("1781296800-11111111-g2")   # the kernel asks again after a stalled answer
             self.assertEqual(code2, 200, obj2)
-            self.assertEqual((obj2.get("duplicate"), obj2.get("id")), (True, row["id"]), "the bus answers the send it holds")
+            self.assertEqual((obj2.get("duplicate"), obj2.get("id"), obj2.get("to")), (True, row["id"], MANAGER),
+                             "the bus answers the send it holds, a local one with `to`")
             self.assertEqual(len([r for r in [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
                                   if r.get("relayMarker") == "1781296800-11111111-g2"]), 1, "one row, one message")
             # the rowless rebuild recovers the marker from the header

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -1380,10 +1380,21 @@ class MergeCarriesTheRelay(_Peer):
         (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
         jd._rebase_onto_disk(WORKER, mem)
         rw = mem["nodes"][step]["relayWanted"]
-        self.assertEqual({k: rw[k] for k in jd.RELAY_TICK_KEYS},
+        self.assertEqual({k: rw.get(k) for k in jd.RELAY_TICK_KEYS},
                          {"pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST", "unknownAt": NOW + 40, "attempts": 2,
-                          "recallUnknownAt": NOW + 42})
-        self.assertEqual(jd.RELAY_TICK_KEYS, ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts", "recallUnknownAt"), "named once")
+                          "recallUnknownAt": NOW + 42, "recallAttempts": None})
+        self.assertEqual(jd.RELAY_TICK_KEYS, ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts", "recallUnknownAt", "recallAttempts"), "named once")
+        mem3 = json.loads(json.dumps(st)); disk3 = json.loads(json.dumps(st))
+        mem3["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "recallUnknownAt": NOW, "recallAttempts": 1}
+        disk3["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "recallUnknownAt": NOW + 90, "recallAttempts": 3}
+        mem3["nodes"][step]["relayRecall"] = [{"id": "mk-0", "pendingMid": "px-r", "unknownAt": NOW, "attempts": 1}]
+        disk3["nodes"][step]["relayRecall"] = [{"id": "mk-0", "pendingMid": "px-r", "unknownAt": NOW + 90, "attempts": 4}]
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk3))
+        jd._rebase_onto_disk(WORKER, mem3)
+        rw3 = mem3["nodes"][step]["relayWanted"]
+        self.assertEqual((rw3["recallUnknownAt"], rw3["recallAttempts"]), (NOW + 90, 3), "the recall hold newer-wins, like the send's")
+        self.assertEqual((mem3["nodes"][step]["relayRecall"][0]["unknownAt"], mem3["nodes"][step]["relayRecall"][0]["attempts"]), (NOW + 90, 4),
+                         "the per-recall hold and count newer-wins too")
 
     def test_a_recall_done_on_the_disk_filters_the_holders_owed_list_though_the_disk_owes_none(self):
         st, top, step = self.store(delegated=True)
@@ -1626,7 +1637,7 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertTrue(nd["blocked"])
         self.assertEqual([r["pendingMid"] for r in nd["relayRecall"]], ["px-ret-2"])
         self._save(st)
-        self.assertEqual(len(self._queue()), 1, "an entry brings the tick to the node though no marker stands")
+        self.assertEqual(len(self._queue()), 2, "the retired marker's entry (spent on the tick) and the recall's own")
         recalls = []
         km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "carried"
         self.assertEqual(km._relay_tick(NOW + 70), 0)
@@ -1649,13 +1660,71 @@ class SaverFlushesItsOwn(_RelayFixture):
         km._bus_recall_relay = lambda sid, mid: "unknown"  # the bus is restarting: the recall cannot be asked
         km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
         self.assertEqual(km._relay_tick(NOW + 70), 1, "M2's question goes out")
-        self.assertEqual(len(self._queue()), 1, "the entry is not spent while a recall is owed")
-        self.assertEqual(json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())["marker"], "recall", "it became the recall's own")
+        self.assertEqual(self._queue(), [jd._relay_recall_entry_path(WORKER, step).name], "the marker's entry is spent; the recall keeps its own")
         recalls = []
         km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "withdrawn"
         self.assertEqual(km._relay_tick(NOW + 70 + km.RELAY_UNKNOWN_HOLD), 0)
         self.assertEqual(recalls, ["px-owe-1"], "the recall is asked again once the hold passed")
         self.assertEqual(self._queue(), [], "and the recall's entry is spent once done")
+
+    def test_a_recall_owed_never_touches_the_live_markers_entry_even_mid_send(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-mid-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)           # M1 handed to the far host
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "second question", NOW + 60)   # M1 retired (a recall owed), M2 minted
+        self._save(st)                                     # the marker's entry (M2) and the recall's own entry
+        names = self._queue()
+        self.assertEqual(len(names), 2, names)
+        self.assertTrue(any(n.endswith(".recall.json") for n in names), "the recall rides its own file")
+        km._bus_recall_relay = lambda sid, mid: "unknown"
+        marker_path = jd._relay_entry_path(WORKER, step)
+        def send_while_judge_moves_on(payload):            # WHILE the tick sends M2, the judge retires it and mints M3 over the path
+            st3 = jd.load_goals(WORKER)
+            jd.record_verdict(st3, st3["nodes"][step], "romp", "awaiting", NOW + 61, why="", lift=True, end_ev=NOW + 61)
+            self._close(st3, step, "third question", NOW + 62)
+            jd.save_goals(WORKER, st3)
+            return True, "", False, {"ok": True, "to": payload["to"]}
+        km._bus_send_relay = send_while_judge_moves_on
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 70), 1, "M2 went out")
+        entry = json.loads(marker_path.read_text())
+        st = jd.load_goals(WORKER)
+        self.assertEqual(entry["marker"], st["nodes"][step]["relayWanted"]["id"], "M3's entry survived the tick: never rewritten")
+        self.assertTrue(jd._relay_recall_entry_path(WORKER, step).exists(), "the recall keeps its own entry")
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 71), 1, "M3's question goes out on the next tick, no boot needed")
+
+    def test_an_unanswerable_recall_is_said_once_and_backs_off(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-bo-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", NOW + 5, msg=True)   # the user's block: the marker retires
+        self._close(st, step, "still stuck", NOW + 60)
+        self._save(st)
+        calls = []
+        km._bus_recall_relay = lambda sid, mid: calls.append(mid) or "unknown"
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            t = NOW + 70
+            for i in range(km.RELAY_RECALL_TRIES):
+                self.assertEqual(km._relay_tick(t), 0)
+                t += km.RELAY_UNKNOWN_HOLD
+        self.assertEqual(len(calls), km.RELAY_RECALL_TRIES, "one ask per hold up to the tries")
+        self.assertEqual(err.getvalue().count("could not be asked"), 1, "said once")
+        self.assertEqual(err.getvalue().count("tries unanswered"), 1, "the back-off said once")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(t + km.RELAY_UNKNOWN_HOLD), 0)
+        self.assertEqual(len(calls), km.RELAY_RECALL_TRIES, "inside the stretched hold: not asked")
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(t + km.RELAY_UNKNOWN_HOLD * km.RELAY_RECALL_BACKOFF), 0)
+        self.assertEqual(len(calls), km.RELAY_RECALL_TRIES + 1, "asked again once the stretched hold passed")
 
     def test_the_boot_pass_requeues_a_node_that_owes_recalls(self):
         st, top, step = self.store(delegated=True)

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -64,7 +64,6 @@ class _Peer(unittest.TestCase):
         (jd.NAMES, jd.GOALDIR, jd.MESSAGES, jd.STATE, km.NAMES) = self.saved
         jd._PEER_ASK_CACHE[0] = None
         jd._DELEG_CACHE[0] = None
-        jd._RELAY_PENDING[:] = []
         self.td.cleanup()
 
     def _write_mail(self):
@@ -141,7 +140,9 @@ class CloserBlocks(_Peer):
         nd = self._close(st, step, "PR is green and cannot move further without you")
         self.assertFalse(nd["blocked"])
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
-        self.assertEqual(nd["relayWanted"], {"peer": MANAGER, "why": "PR is green and cannot move further without you", "t": T0 + 400},
+        rw = dict(nd["relayWanted"])
+        self.assertTrue(rw.pop("id", "").startswith("%d-" % (T0 + 400)), "the marker's identity: the block's evidence time and a nonce")
+        self.assertEqual(rw, {"peer": MANAGER, "why": "PR is green and cannot move further without you", "t": T0 + 400},
                          "no question was ever sent: the kernel relays it as the worker's own")
         st2, top2, step2 = self.store(delegated=True)
         self.ask(WORKER, MANAGER, T0 + 300)
@@ -325,9 +326,10 @@ class RowsAlreadyFiled(_Peer):
         self.assertTrue(got[step]["blocked"] and got[top]["blocked"])
 
 
-class RelayEndToEnd(_Peer):
-    """A worker's closer block under a delegated goal with no open ask: one relayed question in the manager's inbox,
-    the manager's reply lifts the wait, and a re-asserted block never relays twice."""
+class _RelayFixture(_Peer):
+    """The relay harness: a fake bus that answers as the local /send does and lands the mail in the manager's maildir
+    and the postal log; the real save path (the entry is written once the store is published); the queue directory.
+    No tests of its own: the classes below inherit it, each running only its own cases."""
 
     def setUp(self):
         super().setUp()
@@ -344,12 +346,13 @@ class RelayEndToEnd(_Peer):
             test.rows.append({"id": mid, "from_id": payload["from_id"], "to_id": payload["to"], "from": payload["from"],
                               "t": NOW, "kind": payload["kind"], "relayed": True})
             test._write_mail()
-            return True, "", False, {"ok": True, "id": mid}
+            return True, "", False, {"ok": True, "to": payload["to"]}   # the local route's answer (no id)
         km._bus_send_relay = fake_bus
 
     def tearDown(self):
         km._bus_send_relay = self._orig_send
         km._RELAY_SAID.clear()
+        km._RELAY_QUIET.clear()
         km._RELAY_BAD["n"] = 0
         super().tearDown()
 
@@ -363,6 +366,11 @@ class RelayEndToEnd(_Peer):
     def _close(self, st, step, why, t):
         with contextlib.redirect_stderr(io.StringIO()):
             jd.apply_close(st, [st["nodes"][step]], {"done": {}, "block": {1: why}, "awaiting": {}}, t=t)
+
+
+class RelayEndToEnd(_RelayFixture):
+    """A worker's closer block under a delegated goal with no open ask: one relayed question in the manager's inbox,
+    the manager's reply lifts the wait, and a re-asserted block never relays twice."""
 
     def test_the_relay_creates_the_edge_the_reply_lifts_and_a_re_asserted_block_never_relays_twice(self):
         st, top, step = self.store(delegated=True)
@@ -436,7 +444,7 @@ class RelayEndToEnd(_Peer):
         self.assertEqual(nd["relayDone"]["outcome"], "stood-down")
 
 
-class RelayEdges(RelayEndToEnd):
+class RelayEdges(_RelayFixture):
     """The manager's third review: the guard reads the state before the write, two writers never lose an entry, an
     unsaved marker keeps its entry, a parked relay is pending until it lands or comes back, malformed entries drop alone."""
 
@@ -453,29 +461,83 @@ class RelayEdges(RelayEndToEnd):
         self._close(st, step, "now stuck on the second question", NOW + 60)   # a NEW block on the same node
         self.assertEqual(st["nodes"][step]["relayWanted"]["why"], "now stuck on the second question", "a second relay")
         self.assertNotIn("relayed", st["nodes"][step], "the ended wait took its relay record with it")
+        self._save(st)
+        entry = json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())
+        self.assertEqual(entry["marker"], st["nodes"][step]["relayWanted"]["id"], "the entry names the new marker")
+        self.assertEqual(entry["rev"], st["rev"], "and the revision whose publish carried it")
+        self.assertEqual(km._relay_tick(NOW + 90), 1, "the second question goes out")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual(nd["relayed"]["marker"], entry["marker"], "the record names the marker it settled")
 
-    def test_an_entry_whose_marker_is_not_saved_yet_is_kept_not_dropped(self):
+    def test_a_re_block_with_the_same_words_after_a_lift_is_a_new_marker(self):
         st, top, step = self.store(delegated=True)
-        self._save(st)                                     # the store on disk carries no marker...
-        jd._relay_write_entry(WORKER, step)                # ...but an entry exists (the save carrying it has not landed)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        self.assertEqual(km._relay_tick(NOW), 1)
+        st = jd.load_goals(WORKER)
+        first = st["nodes"][step]["relayed"]
+        self.rows.append(mail(MANAGER, WORKER, NOW + 5, kind="coordinate"))
+        self._write_mail()
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "cannot move further without you", NOW + 60)     # the SAME words, a new block
+        rw = st["nodes"][step]["relayWanted"]
+        self.assertNotEqual(rw["id"], first["marker"], "its own identity")
+        theirs = jd.load_goals(WORKER)                     # another holder publishes in between...
+        theirs["nodes"][top]["text"] = "Ship the exporter (renamed)"
+        base = st["_baseRev"]
+        self._save(theirs)
+        self._save(st)                                     # ...so this publish REBASES onto the disk holding the first record
+        st2 = jd.load_goals(WORKER)
+        self.assertEqual(st2["rev"], base + 2, "the rebase happened")
+        self.assertIn("relayWanted", st2["nodes"][step], "the earlier record settles only the marker it names")
+        self.assertEqual(km._relay_tick(NOW + 90), 1, "relayed again")
+
+    def test_an_entry_is_kept_only_when_the_disk_predates_its_publish_and_bounded_after(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)                                     # the store on disk (rev 1) carries no marker...
+        rev = jd.load_goals(WORKER)["rev"]
+        jd._relay_write_entry(WORKER, step, "mk-1", rev + 1)   # ...and an entry names a publish the disk does not show yet
         self.assertEqual(km._relay_tick(NOW), 0)
-        self.assertEqual(len(self._queue()), 1, "kept for the save to land, never dropped")
-        st2, top2, step2 = self.store(delegated=True)
-        st2["nodes"][step2]["relayed"] = {"peer": MANAGER, "why": "x", "t": NOW}
-        self._save(st2)
+        self.assertEqual(len(self._queue()), 1, "kept: the publish that wrote it is not on disk")
+        st = jd.load_goals(WORKER)
+        st["nodes"][step]["text"] = "Ask which client to change (edited)"
+        self._save(st)                                     # rev 2 published, still no marker and no record
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertEqual(self._queue(), [], "bounded: the revision passed without the marker, the entry is spent")
+        self.assertIn("gone with no record", err.getvalue())
+
+    def test_an_entry_is_spent_by_a_record_naming_its_marker_or_a_newer_marker(self):
+        st, top, step = self.store(delegated=True)
+        st["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "x", "t": NOW, "marker": "mk-1"}
+        self._save(st)
+        jd._relay_write_entry(WORKER, step, "mk-1", 1)
         self.assertEqual(km._relay_tick(NOW), 0)
-        self.assertEqual(self._queue(), [], "a settled node's entry is spent")
+        self.assertEqual(self._queue(), [], "the record names the marker: spent")
+        st = jd.load_goals(WORKER)
+        st["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-3"}
+        self._save(st)
+        jd._relay_write_entry(WORKER, step, "mk-2", 1)     # an older marker's entry: the node moved on to mk-3
+        self.assertEqual(km._relay_tick(NOW), 0, "nothing is sent for the stale entry")
+        entry = json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())
+        self.assertEqual(entry["marker"], "mk-3", "the entry is REWRITTEN for the live marker, never unlinked (the path may "
+                                                  "already be the newer flush)")
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayWanted"]["id"], "mk-3", "the newer marker stands")
+        self.assertEqual(km._relay_tick(NOW + 1), 0)       # mk-3 has no standing stamp here: the next tick stands it down
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayDone"]["marker"], "mk-3")
 
     def test_two_writers_never_lose_an_entry(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
         self._save(st)
         other = WORKER + ":g9"
-        st["nodes"][other] = node(other, "Another question", parent=top, t=T0 + 700, relayWanted={"peer": MANAGER, "why": "q", "t": T0 + 700})
+        st["nodes"][other] = node(other, "Another question", parent=top, t=T0 + 700,
+                                  relayWanted={"peer": MANAGER, "why": "q", "t": T0 + 700, "id": "mk-other"})
         self._save(st)
         real = km._bus_send_relay
         def slow_bus(payload):                            # the judge appends an entry WHILE the tick is mid-send
-            jd._relay_write_entry(WORKER, other)
+            jd._relay_write_entry(WORKER, other, "mk-other", st["rev"])
             return real(payload)
         km._bus_send_relay = slow_bus
         self.assertGreaterEqual(km._relay_tick(NOW), 1)
@@ -489,7 +551,7 @@ class RelayEdges(RelayEndToEnd):
         km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "relay-far-1", "parked": "TESTHOST"})
         self.assertEqual(km._relay_tick(NOW), 0, "parked is not sent")
         nd = jd.load_goals(WORKER)["nodes"][step]
-        self.assertEqual(nd["relayWanted"]["parkedMid"], "relay-far-1")
+        self.assertEqual((nd["relayWanted"]["pendingMid"], nd["relayWanted"]["pendingHost"]), ("relay-far-1", "TESTHOST"))
         self.assertEqual(len(self._queue()), 1, "pending")
         self.rows.append({"id": "relay-far-1", "ev": "bounced", "t": NOW + 30, "to_id": MANAGER, "from_id": WORKER})
         self._write_mail()
@@ -511,6 +573,166 @@ class RelayEdges(RelayEndToEnd):
         self.assertEqual(nd["relayed"]["mid"], "relay-far-2")
         self.assertEqual(self._queue(), [])
 
+    def test_a_relay_in_flight_to_a_host_that_is_up_is_pending_until_the_far_host_delivers(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-3", "note": "relaying to 'web' on TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0, "the relay leg's answer is pending, host up or not")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual(nd["relayWanted"]["pendingMid"], "px-far-3")
+        self.assertEqual(km._relay_tick(NOW + 10), 0, "still pending: no delivered row, no answer")
+        self.rows.append({"t": NOW + 30, "ev": "relayed", "id": "px-far-3", "host": "TESTHOST"})   # the far host's ack
+        self._write_mail()
+        self.assertEqual(km._relay_tick(NOW + 60), 1, "delivered: the relay stands as sent")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual((nd["relayed"]["mid"], nd["relayed"]["marker"]), ("px-far-3", st["nodes"][step]["relayWanted"]["id"]))
+        self.assertNotIn("relayWanted", nd)
+        self.assertEqual(self._queue(), [])
+
+    def test_a_relay_in_flight_that_bounces_reverts_to_the_users_block(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-4", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.rows.append({"t": NOW + 30, "ev": "bounced", "id": "px-far-4", "host": "TESTHOST", "why": "no live session"})
+        self._write_mail()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 60), 0)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertTrue(nd["blocked"], "the bounce is the definitive refusal: the user's block")
+        self.assertEqual((nd["relayDone"]["outcome"], nd["relayDone"]["marker"]), ("refused", st["nodes"][step]["relayWanted"]["id"]))
+        self.assertEqual(self._queue(), [])
+
+    def test_an_entry_whose_node_is_gone_is_spent(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)
+        jd._relay_write_entry(WORKER, WORKER + ":gone", "mk-x", 1)
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertEqual(self._queue(), [], "a rewound or archived node's entry is spent, nothing sent")
+        self.assertEqual(self.sent, [])
+
+    def test_a_pending_relay_the_worker_withdrew_reverts_as_withdrawn(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-5", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.rows.append({"t": NOW + 30, "ev": "recall", "id": "px-far-5"})
+        self._write_mail()
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 60), 0)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertTrue(nd["blocked"])
+        self.assertIn("the message was withdrawn", nd["log"][-1]["why"])
+
+    def test_a_bounce_carries_the_far_hosts_reason_into_the_users_block(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-6", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.rows.append({"t": NOW + 30, "ev": "bounced", "id": "px-far-6", "host": "TESTHOST", "why": "no live session named web"})
+        self._write_mail()
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._relay_tick(NOW + 60)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertIn("came back from TESTHOST: no live session named web", nd["log"][-1]["why"])
+
+    def test_an_answer_in_the_sends_own_second_is_not_the_answer(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-7", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.rows.append(mail(MANAGER, WORKER, NOW, kind="coordinate"))        # the same second as the send
+        self._write_mail()
+        self.assertEqual(km._relay_tick(NOW + 1), 0, "still pending")
+        self.rows.append(mail(MANAGER, WORKER, NOW + 2, kind="coordinate"))
+        self._write_mail()
+        self.assertEqual(km._relay_tick(NOW + 3), 1, "a later message is the answer")
+
+    def test_the_pending_stamp_survives_a_holders_save_so_the_question_is_sent_once(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        holder = jd.load_goals(WORKER)                     # a judge holder loads before the tick...
+        calls = []
+        km._bus_send_relay = lambda payload: calls.append(payload) or (True, "", False, {"ok": True, "id": "px-far-8", "note": "relaying"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        holder["nodes"][top]["text"] = "Ship the exporter (renamed)"
+        self._save(holder)                                 # ...and saves after it: its copy lacked the pending stamp
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayWanted"]["pendingMid"], "px-far-8", "the merge kept the stamp")
+        self.assertEqual(km._relay_tick(NOW + 10), 0)
+        self.assertEqual(len(calls), 1, "the far-host manager gets the question once")
+
+    def test_a_record_lands_before_its_entry_is_spent(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        real = jd.save_goals
+        state = {"raised": False}
+        def failing_save(fsid, store):
+            if not state["raised"]:
+                state["raised"] = True
+                raise OSError("disk full")
+            return real(fsid, store)
+        jd.save_goals = failing_save
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(km._relay_tick(NOW), 0, "the save raised: nothing counted")
+            self.assertEqual(len(self._queue()), 1, "the entry is kept for the next tick")
+            self.assertEqual(len(self.sent), 1)
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(km._relay_tick(NOW + 1), 1)
+        finally:
+            jd.save_goals = real
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayed"]["peer"], MANAGER)
+
+    def test_a_later_markers_transient_failure_is_said_after_an_earlier_one_stood_down(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (False, "bus down", False, {})
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertIn("retried next tick", err.getvalue())
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)   # the wait ends
+        self._save(st)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW + 6), 0)   # stood down
+        st = jd.load_goals(WORKER)                         # a fresh holder files the next block
+        self._close(st, step, "now stuck again", NOW + 60)
+        self._save(st)
+        with contextlib.redirect_stderr(io.StringIO()) as err2:
+            self.assertEqual(km._relay_tick(NOW + 61), 0)
+        self.assertIn("retried next tick", err2.getvalue(), "the new marker's failure is said once too")
+
+    def test_a_quiet_pass_is_not_repeated_until_something_moves(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-9", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)           # pending, parked
+        real = jd.load_goals
+        loads = []
+        jd.load_goals = lambda sid: loads.append(sid) or real(sid)
+        try:
+            self.assertEqual(km._relay_tick(NOW + 1), 0)
+            self.assertEqual(loads, [WORKER], "the first pass reads the store and finds nothing to do")
+            self.assertEqual(km._relay_tick(NOW + 2), 0)
+            self.assertEqual(km._relay_tick(NOW + 3), 0)
+            self.assertEqual(loads, [WORKER], "nothing moved: no store parse per tick for a parked relay")
+            self.rows.append({"t": NOW + 30, "ev": "relayed", "id": "px-far-9", "host": "TESTHOST"})
+            self._write_mail()                             # the log moved: the far host delivered
+            self.assertEqual(km._relay_tick(NOW + 60), 1)
+            self.assertEqual(loads, [WORKER, WORKER])
+        finally:
+            jd.load_goals = real
+
     def test_a_malformed_entry_drops_alone(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
@@ -523,11 +745,14 @@ class RelayEdges(RelayEndToEnd):
 
     def test_the_boot_pass_requeues_an_orphaned_marker(self):
         st, top, step = self.store(delegated=True)
-        st["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400}
+        st["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-boot"}
+        st["rev"] = 7
         (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(st))   # a marker on disk with no entry
         self.assertEqual(self._queue(), [])
         self.assertEqual(jd._requeue_relays_all(), 1)
         self.assertEqual(len(self._queue()), 1)
+        entry = json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())
+        self.assertEqual((entry["marker"], entry["rev"]), ("mk-boot", 7))
         self.assertEqual(jd._requeue_relays_all(), 0, "idempotent")
 
 
@@ -547,6 +772,8 @@ class TwoDelegators(_Peer):
         self.assertEqual(list(nd2.get("awaitingPeers") or ()), [OTHER], "no mail id on the anchor: the latest delegate")
 
     def test_the_planner_pass_latches_the_anchors_mail_id_from_the_parse(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
         st, top, step = self.store()
         session = {"turns": [{"atoms": [{"uuid": "u1", "type": "user", "message": {"role": "user", "content": [{"type": "text",
                    "text": "Ship the exporter\n<!-- romp-msg-id: m-web-1 -->\n<!-- romp-msg-kind: delegate -->"}]}}]}]}
@@ -555,10 +782,73 @@ class TwoDelegators(_Peer):
         self.assertEqual(st["nodes"][top]["promptMsgId"], "m-web-1")
         self.assertEqual(jd._latch_prompt_msg_ids(session, st), 0, "latched once")
 
+    def test_a_batched_inbox_is_attributed_to_its_delegate_marker_not_its_first(self):
+        self.rows.append(mail(OTHER, WORKER, T0 - 300, kind="coordinate", mid="m-tests-c"))
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        text = ("Heads up, the tests are flaky today\n<!-- romp-msg-id: m-tests-c -->\n<!-- romp-msg-kind: coordinate -->\n"
+                "Ship the exporter\n<!-- romp-msg-id: m-web-1 -->\n<!-- romp-msg-kind: delegate -->")
+        session = {"turns": [{"atoms": [{"uuid": "u1", "type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}]}]}
+        st["nodes"][top]["promptUuid"] = "u1"; st["nodes"][top]["askAnchor"] = "machine"
+        self.assertEqual(jd._latch_prompt_msg_ids(session, st), 1)
+        self.assertEqual(st["nodes"][top]["promptMsgId"], "m-web-1", "the delegate marker, though a peer's coordinate came first")
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
+
+    def test_a_delivery_with_no_delegate_marker_leaves_the_fallback_to_the_latest_delegate(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        text = "Heads up\n<!-- romp-msg-id: m-tests-c -->\n<!-- romp-msg-kind: coordinate -->"
+        session = {"turns": [{"atoms": [{"uuid": "u1", "type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}]}]}
+        st["nodes"][top]["promptUuid"] = "u1"; st["nodes"][top]["askAnchor"] = "machine"
+        jd._latch_prompt_msg_ids(session, st)
+        self.assertEqual(st["nodes"][top]["promptMsgId"], "", "no delegate in the delivery")
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the latest delegate at or before the mint")
+
     def _close_block(self, st, step, why):
         with contextlib.redirect_stderr(io.StringIO()):
             jd.apply_close(st, [st["nodes"][step]], {"done": {}, "block": {1: why}, "awaiting": {}}, t=T0 + 400)
         return st["nodes"][step]
+
+    def _session(self, text):
+        return {"turns": [{"atoms": [{"uuid": "u1", "type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}]}]}
+
+    def test_two_delegates_in_one_delivery_attribute_to_the_last(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 300, kind="delegate", mid="m-web-1"))
+        self.rows.append(mail(OTHER, WORKER, T0 - 200, kind="delegate", mid="m-tests-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        st["nodes"][top]["promptUuid"] = "u1"; st["nodes"][top]["askAnchor"] = "machine"
+        jd._latch_prompt_msg_ids(self._session("A\n<!-- romp-msg-id: m-web-1 -->\n<!-- romp-msg-kind: delegate -->\n"
+                                               "B\n<!-- romp-msg-id: m-tests-1 -->\n<!-- romp-msg-kind: delegate -->"), st)
+        self.assertEqual(st["nodes"][top]["promptMsgId"], "m-tests-1", "the last dispatch of a drained inbox, the delivery's own peer")
+        self.assertEqual(list(self._close_block(st, step, "stuck").get("awaitingPeers") or ()), [OTHER])
+
+    def test_a_delegate_marker_quoted_from_another_sessions_dispatch_names_nobody_here(self):
+        third = "11111111-2222-3333-4444-dddddddddddd"
+        self.rows.append(mail(OTHER, third, T0 - 400, kind="delegate", mid="m-foreign"))    # a dispatch to a THIRD session
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="", mid="m-web-plain"))      # the manager's plain mail quoting it
+        self._write_mail()
+        st, top, step = self.store()
+        st["nodes"][top]["promptUuid"] = "u1"; st["nodes"][top]["askAnchor"] = "machine"
+        jd._latch_prompt_msg_ids(self._session("FYI, here is what I got:\n<!-- romp-msg-id: m-foreign -->\n<!-- romp-msg-kind: delegate -->\n"
+                                               "<!-- romp-msg-id: m-web-plain -->"), st)
+        self.assertEqual(st["nodes"][top]["promptMsgId"], "", "a quoted foreign dispatch is no dispatch to this session")
+        self.assertIsNone(jd._delegate_sender("m-foreign", WORKER))
+        self.assertEqual(jd._delegate_sender("m-foreign"), OTHER, "without a recipient, the row's sender as before")
+        self.assertEqual(self._close_block(st, step, "stuck").get("awaitingPeers"), None, "no delegate at all: the user's block")
+
+    def test_a_stamp_naming_no_dispatch_to_this_session_leaves_the_fallback(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self.rows.append(mail(OTHER, WORKER, T0 - 100, kind="coordinate", mid="m-tests-c"))
+        self._write_mail()
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"; st["nodes"][top]["promptMsgId"] = "m-tests-c"   # an older stamp (the first-marker rule)
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "as for an anchor that names none: the latest delegate")
 
 
 class MoreRules(_Peer):
@@ -648,17 +938,102 @@ class MergeCarriesTheRelay(_Peer):
     def test_a_stale_judge_copy_does_not_resurrect_a_relay_the_kernel_sent(self):
         st, top, step = self.store(delegated=True)
         mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
-        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400}
-        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "cannot move further", "t": NOW}
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400, "id": "mk-a"}
+        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "cannot move further", "t": NOW, "marker": "mk-a"}
         (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
         jd._rebase_onto_disk(WORKER, mem)
         self.assertEqual(mem["nodes"][step]["relayed"]["peer"], MANAGER)
         self.assertNotIn("relayWanted", mem["nodes"][step])
 
+    def test_a_record_settles_only_the_marker_it_names(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400, "id": "mk-b"}
+        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "cannot move further", "t": NOW, "marker": "mk-a"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayWanted"]["id"], "mk-b", "same words, later clock: a NEW marker stands")
+
+    def test_the_newer_record_wins_in_either_direction(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "a", "t": NOW + 50, "marker": "mk-b"}
+        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "a", "t": NOW, "marker": "mk-a"}
+        mem["nodes"][step]["relayDone"] = {"peer": MANAGER, "why": "a", "t": NOW, "marker": "mk-a", "outcome": "stood-down"}
+        disk["nodes"][step]["relayDone"] = {"peer": MANAGER, "why": "a", "t": NOW + 50, "marker": "mk-c", "outcome": "refused"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayed"]["marker"], "mk-b", "memory's newer record stays")
+        self.assertEqual(mem["nodes"][step]["relayDone"]["marker"], "mk-c", "disk's newer record is adopted")
+
+    def test_the_same_marker_on_both_sides_keeps_the_kernels_pending_stamp_either_way(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a"}
+        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a",
+                                              "pendingMid": "px-1", "pendingAt": NOW, "pendingHost": "TESTHOST"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayWanted"]["pendingMid"], "px-1", "a holder's stale copy gains the tick's stamp")
+        mem2 = json.loads(json.dumps(st)); disk2 = json.loads(json.dumps(st))
+        mem2["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "pendingMid": "px-1", "pendingAt": NOW}
+        disk2["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk2))
+        jd._rebase_onto_disk(WORKER, mem2)
+        self.assertEqual(mem2["nodes"][step]["relayWanted"]["pendingMid"], "px-1", "the kernel's own copy keeps it")
+
+    def test_a_settled_marker_is_popped_before_the_disks_live_marker_is_adopted(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-1"}
+        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "q", "t": NOW, "marker": "mk-1"}
+        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q2", "t": NOW + 50, "id": "mk-2"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayWanted"]["id"], "mk-2", "ours was settled and popped; the live one is adopted")
+
+    def test_two_holders_markers_for_one_wait_converge(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-mine"}
+        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-theirs"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertEqual(mem["nodes"][step]["relayWanted"]["id"], "mk-theirs", "the published one wins: its entry is flushed")
+        mem2 = json.loads(json.dumps(st)); disk2 = json.loads(json.dumps(st))
+        mem2["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-mine", "pendingMid": "px-9", "pendingAt": NOW}
+        disk2["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-theirs"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk2))
+        jd._rebase_onto_disk(WORKER, mem2)
+        self.assertEqual(mem2["nodes"][step]["relayWanted"]["id"], "mk-mine", "the one already handed to a far host wins")
+
+    def test_the_settled_list_survives_the_record_slot_and_merges_as_a_union(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-1"}
+        mem["nodes"][step]["relaySettled"] = ["mk-0"]
+        disk["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "q2", "t": NOW + 50, "marker": "mk-2"}   # the slot moved on
+        disk["nodes"][step]["relaySettled"] = ["mk-1", "mk-2"]
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertNotIn("relayWanted", mem["nodes"][step], "the list remembers what the slot forgot: mk-1 is settled")
+        self.assertEqual(mem["nodes"][step]["relaySettled"], ["mk-0", "mk-1", "mk-2"])
+
+    def test_a_stale_holder_never_re_mints_a_retired_marker(self):
+        st, top, step = self.store(delegated=True)
+        mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a"}
+        mem["nodes"][step]["relayed"] = {"peer": MANAGER, "why": "old", "t": NOW - 500, "marker": "mk-0"}
+        disk["nodes"][step]["relayDone"] = {"peer": MANAGER, "why": "q", "t": NOW, "marker": "mk-a", "outcome": "stood-down"}
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
+        jd._rebase_onto_disk(WORKER, mem)
+        self.assertNotIn("relayWanted", mem["nodes"][step], "the kernel retired mk-a; the holder's copy follows")
+        self.assertEqual(mem["nodes"][step]["relayed"]["marker"], "mk-0", "an unrelated older record is untouched")
+
     def test_a_stale_kernel_copy_keeps_a_relay_the_judge_just_asked_for(self):
         st, top, step = self.store(delegated=True)
         mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
-        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400}
+        disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "cannot move further", "t": T0 + 400, "id": "mk-a"}
         (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
         jd._rebase_onto_disk(WORKER, mem)
         self.assertEqual(mem["nodes"][step]["relayWanted"]["peer"], MANAGER)
@@ -666,8 +1041,8 @@ class MergeCarriesTheRelay(_Peer):
     def test_a_removal_the_kernel_recorded_is_never_resurrected(self):
         st, top, step = self.store(delegated=True)
         mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
-        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400}
-        disk["nodes"][step]["relayDone"] = {"peer": MANAGER, "why": "q", "t": NOW, "outcome": "stood-down"}
+        mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a"}
+        disk["nodes"][step]["relayDone"] = {"peer": MANAGER, "why": "q", "t": NOW, "outcome": "stood-down", "marker": "mk-a"}
         (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
         jd._rebase_onto_disk(WORKER, mem)
         self.assertNotIn("relayWanted", mem["nodes"][step], "the stand-down stands")
@@ -749,3 +1124,164 @@ class ManagerEscalation(_Peer):
         keys, blocked = self._outcomes(unread=3)
         self.assertEqual(keys, [], "an ordinary peer with mail waiting that moved on still escalates")
         self.assertTrue(blocked)
+
+
+class SaverFlushesItsOwn(_RelayFixture):
+    """The pending relay entries ride the STORE OBJECT: only the saver holding the object writes them, once its own
+    publish (which carries the marker) is on disk; another holder's save of the same sid flushes nothing, and the
+    list never reaches the file (the manager's fourth review)."""
+
+    def test_another_holders_save_flushes_nothing_of_ours(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)
+        mine = jd.load_goals(WORKER)                       # the closer's copy
+        theirs = jd.load_goals(WORKER)                     # the planner's copy of the same store
+        self._close(mine, step, "cannot move further without you", T0 + 400)
+        self.assertEqual(mine["_relayPending"], [step], "remembered on the object that holds the marker")
+        theirs["nodes"][top]["text"] = "Ship the exporter (renamed)"
+        self._save(theirs)                                 # a save of the sid by another holder, no marker in it
+        self.assertEqual(self._queue(), [], "nothing of ours flushed by their save")
+        self.assertNotIn("relayWanted", jd.load_goals(WORKER)["nodes"][step])
+        self._save(mine)                                   # our publish rebases onto theirs and carries the marker
+        self.assertEqual(len(self._queue()), 1)
+        raw = json.loads((jd.GOALDIR / (WORKER + ".json")).read_text())
+        self.assertEqual(raw["nodes"][step]["relayWanted"]["id"], mine["nodes"][step]["relayWanted"]["id"])
+        self.assertEqual(raw["rev"], theirs["rev"] + 1, "our publish rebased onto theirs")
+        self.assertNotIn("_relayPending", raw, "transient: never serialized")
+        self.assertNotIn("_relayPending", mine, "popped by the publish")
+        self.assertEqual(km._relay_tick(NOW), 1)
+
+    def test_a_no_op_save_still_flushes_when_the_file_already_holds_the_marker(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        self.assertEqual(len(self._queue()), 1)
+        (jd._relay_queue_dir() / self._queue()[0]).unlink()   # the entry is lost (a failed write, say)
+        st["_relayPending"] = [step]                       # the holder still remembers it and saves nothing new
+        self._save(st)
+        self.assertEqual(len(self._queue()), 1, "the file holds the marker: its entry goes out on the no-op save")
+
+    def test_a_marker_the_publishs_rebase_settled_gets_no_entry(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)
+        a = jd.load_goals(WORKER)
+        self._close(a, step, "cannot move further without you", T0 + 400)
+        self._save(a)                                      # holder A publishes the marker and its entry
+        self.assertEqual(km._relay_tick(NOW), 1)           # the tick relays it: relayed names the marker on disk
+        self.assertEqual(self._queue(), [])
+        a["_relayPending"] = [step]                        # A still remembers it (a second flush attempt, say)
+        a["nodes"][top]["text"] = "Ship the exporter (renamed)"
+        self._save(a)                                      # A's publish rebases: the marker is settled and popped
+        self.assertNotIn("relayWanted", jd.load_goals(WORKER)["nodes"][step])
+        self.assertEqual(self._queue(), [], "nothing left to relay: no entry")
+
+    def test_a_failed_publish_keeps_the_pending_list_for_the_retry(self):
+        st, top, step = self.store(delegated=True)
+        self._save(st)
+        st = jd.load_goals(WORKER)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        real = jd._publish_tmp
+        jd._publish_tmp = lambda d, f: (_ for _ in ()).throw(OSError("disk full"))
+        try:
+            with self.assertRaises(OSError):
+                self._save(st)
+        finally:
+            jd._publish_tmp = real
+        self.assertEqual(st["_relayPending"], [step], "kept on the object: the retry publishes and flushes")
+        self.assertEqual(self._queue(), [])
+        self._save(st)
+        self.assertEqual(len(self._queue()), 1)
+
+
+class FarHostRelayMark(unittest.TestCase):
+    """The relayed mark rides the bus's relay leg to a far host and the far side's deliver (trusted, or held and
+    approved), so a far-host manager's inbox says a relayed question is one, as a local one does."""
+
+    def _postal(self):
+        return load_source("romp_postal_service_pw_far", os.path.join(os.path.dirname(HERE), "postal", "postal_service.py"))
+
+    def test_the_relay_leg_carries_the_mark_and_answers_with_an_id_and_no_to(self):
+        ps = self._postal()
+        parked = []
+        saved = (ps.resolve_recipient, ps.outbox_put, dict(ps.PEERS))
+        ps.resolve_recipient = lambda to, frm_id="": {"kind": "relay", "host": "TESTHOST", "agent": {"name": "web", "id": MANAGER}}
+        ps.outbox_put = lambda host, msg: parked.append((host, msg)) or True
+        ps.PEERS["TESTHOST"] = {"up": True}
+        try:
+            h = object.__new__(ps.Handler)
+            raw = json.dumps({"to": "web", "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+                              "body": "api cannot move further: which client?"}).encode()
+            h.path = "/send"; h.headers = {"Content-Length": str(len(raw)), "X-Romp-Token": ps.SERVE_TOKEN}; h.rfile = io.BytesIO(raw)
+            out = []; h._send = lambda obj, code=200: out.append((obj, code))
+            h.do_POST()
+        finally:
+            ps.resolve_recipient, ps.outbox_put = saved[0], saved[1]
+            ps.PEERS.clear(); ps.PEERS.update(saved[2])
+        obj, code = out[0]
+        self.assertEqual(code, 200, obj)
+        self.assertTrue(obj.get("id") and "to" not in obj and not obj.get("parked"), "the relay leg's answer: an id, no to")
+        self.assertEqual(len(parked), 1)
+        self.assertEqual((parked[0][0], parked[0][1]["relayed"], parked[0][1]["kind"]), ("TESTHOST", True, "question"))
+
+    def test_the_far_side_delivers_a_relayed_question_marked(self):
+        ps = self._postal()
+        saved = ps.local_agents_checked
+        ps.local_agents_checked = lambda threads=False: ([{"id": MANAGER, "name": "web"}], True)
+        try:
+            verdict, bounce = ps._relay_in("TESTHOST", {"mid": "px-far-9", "to": "web", "toId": MANAGER, "frm": "api", "frm_id": WORKER,
+                                                        "body": "api cannot move further: which client?", "kind": "question",
+                                                        "relayed": True, "t": NOW}, token_proven=True)
+        finally:
+            ps.local_agents_checked = saved
+        self.assertEqual(verdict, "ack", bounce)
+        box = ps._mailbox(MANAGER) / "new"
+        texts = [p.read_text() for p in box.iterdir()]
+        self.assertTrue(texts and any("X-Relayed: romp\n" in t and "which client?" in t for t in texts), texts)
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        self.assertTrue(any(r.get("relayed") and r.get("from_id") == WORKER for r in rows))
+
+    def test_a_held_relayed_question_keeps_its_mark_through_the_approve(self):
+        ps = self._postal()
+        m = {"mid": "px-held-1", "to": "web", "toId": MANAGER, "frm": "api", "frm_id": WORKER, "body": "api cannot move further: x",
+             "kind": "question", "relayed": True}
+        self.assertTrue(ps._quarantine_put("TESTHOST", m, MANAGER, via="TESTHOST", wire_id=MANAGER))
+        rec = json.loads((ps.QUARANTINE / "px-held-1.json").read_text())
+        self.assertTrue(rec.get("relayed"), "held with its mark")
+        saved = ps.local_agents_checked
+        ps.local_agents_checked = lambda threads=False: ([{"id": MANAGER, "name": "web"}], True)
+        try:
+            ok, err = ps.quarantine_decide("px-held-1", "approve")
+        finally:
+            ps.local_agents_checked = saved
+        self.assertTrue(ok, err)
+        texts = [p.read_text() for p in (ps._mailbox(MANAGER) / "new").iterdir()]
+        self.assertTrue(any("X-Relayed: romp\n" in t and "cannot move further: x" in t for t in texts), "approved: delivered marked")
+
+    def test_the_relay_legs_sent_row_carries_the_mark(self):
+        ps = self._postal()
+        saved = (ps.resolve_recipient, ps.outbox_put, dict(ps.PEERS))
+        ps.resolve_recipient = lambda to, frm_id="": {"kind": "relay", "host": "TESTHOST", "agent": {"name": "web", "id": MANAGER}}
+        ps.outbox_put = lambda host, msg: True
+        ps.PEERS["TESTHOST"] = {"up": True}
+        try:
+            h = object.__new__(ps.Handler)
+            raw = json.dumps({"to": "web", "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+                              "body": "api cannot move further: the row"}).encode()
+            h.path = "/send"; h.headers = {"Content-Length": str(len(raw)), "X-Romp-Token": ps.SERVE_TOKEN}; h.rfile = io.BytesIO(raw)
+            out = []; h._send = lambda obj, code=200: out.append((obj, code))
+            h.do_POST()
+        finally:
+            ps.resolve_recipient, ps.outbox_put = saved[0], saved[1]
+            ps.PEERS.clear(); ps.PEERS.update(saved[2])
+        obj, code = out[0]
+        self.assertEqual(code, 200, obj)
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        row = next(r for r in rows if r.get("id") == obj["id"])
+        self.assertEqual((row.get("ev"), row.get("relayed"), row.get("kind")), ("sent", True, "question"), "the sender's ledger says relayed")
+
+    def test_deliver_holds_the_invariant_only_a_question_is_relayed(self):
+        ps = self._postal()
+        mid = ps.deliver(MANAGER, "api", WORKER, "a dispatch that claims the mark", kind="delegate", relayed=True)
+        self.assertNotIn("X-Relayed", (ps._mailbox(MANAGER) / "new" / mid).read_text())
+        rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+        self.assertNotIn("relayed", next(r for r in rows if r.get("id") == mid))

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -49,11 +49,9 @@ class _Peer(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         td = Path(self.td.name)
-        self.saved = (jd.NAMES, jd.GOALDIR, jd.MESSAGES, jd.STATE, km.NAMES)
-        jd.NAMES = td / "names"; jd.NAMES.mkdir()
-        jd.GOALDIR = td / "goals"; jd.GOALDIR.mkdir()
-        jd.MESSAGES = td / "messages.jsonl"
-        jd.STATE = td
+        self.saved = (jd.STATE, km.NAMES)
+        jd._rebind_state(td)                             # STATE and every dir derived from it, the repo's rule for tests
+        jd.NAMES.mkdir(); jd.GOALDIR.mkdir(); jd.MESSAGES.parent.mkdir(parents=True)
         km.NAMES = jd.NAMES
         for sid, name in ((WORKER, "api"), (MANAGER, "web"), (OTHER, "tests")):
             (jd.NAMES / sid).write_text("%s\t/TESTDIR\t#abcdef\n" % name)
@@ -61,7 +59,7 @@ class _Peer(unittest.TestCase):
         self._write_mail()
 
     def tearDown(self):
-        (jd.NAMES, jd.GOALDIR, jd.MESSAGES, jd.STATE, km.NAMES) = self.saved
+        jd._rebind_state(self.saved[0]); km.NAMES = self.saved[1]
         jd._PEER_ASK_CACHE[0] = None
         jd._DELEG_CACHE[0] = None
         self.td.cleanup()
@@ -328,6 +326,22 @@ class UsersFollowUp(_Peer):
         nd = self._close(st, step, "cannot move further without you")
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
 
+    def test_the_workers_own_ask_after_the_follow_up_is_the_newer_edge(self):
+        st, top, step = self.store(delegated=True)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", T0 + 300, msg=True)   # the user follows up...
+        self.ask(WORKER, MANAGER, T0 + 350)                                             # ...the worker asks the manager after it...
+        nd = self._close(st, step, "cannot move further without you")                  # ...and blocks at T0 + 400
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the ask is the newer edge: a peer wait")
+        self.assertNotIn("relayWanted", nd, "the ask is the edge: nothing to relay")
+
+    def test_a_follow_up_after_the_workers_ask_is_the_users(self):
+        st, top, step = self.store(delegated=True)
+        self.ask(WORKER, MANAGER, T0 + 300)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", T0 + 350, msg=True)
+        nd = self._close(st, step, "cannot move further without you")
+        self.assertTrue(nd["blocked"])
+        self.assertIsNone(nd.get("awaitingKind"))
+
     def test_a_follow_up_after_a_standing_wait_reclaims_it(self):
         st, top, step = self.store(delegated=True)
         nd = self._close(st, step, "cannot move further without you")
@@ -368,6 +382,7 @@ class _RelayFixture(_Peer):
     def setUp(self):
         super().setUp()
         self._orig_send = km._bus_send_relay
+        self._orig_recall = km._bus_recall_relay
         self.sent = []
         self.inbox = jd.STATE / "postal" / "mail" / MANAGER / "new"
         self.inbox.mkdir(parents=True)
@@ -385,6 +400,7 @@ class _RelayFixture(_Peer):
 
     def tearDown(self):
         km._bus_send_relay = self._orig_send
+        km._bus_recall_relay = self._orig_recall
         km._RELAY_SAID.clear()
         km._RELAY_QUIET.clear()
         km._RELAY_BAD["n"] = 0
@@ -460,7 +476,7 @@ class RelayEndToEnd(_RelayFixture):
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertTrue(nd["blocked"], "the needs-you is back")
         self.assertIn("cannot move further without you", nd["blockWhy"])
-        self.assertIn("relay to web was refused", nd["blockWhy"])
+        self.assertIn("relay to web was refused", nd["relayRefusal"])
         self.assertNotIn("relayWanted", nd)
         self.assertEqual(nd["mt"], NOW, "bumped like every other block writer")
         self.assertEqual(nd["relayDone"]["outcome"], "refused", "the removal is a record the merge honours")
@@ -515,6 +531,21 @@ class RelayEdges(_RelayFixture):
         self.assertEqual(km._relay_tick(NOW), 1)
         self.assertEqual([p["body"] for p in self.sent], ["api cannot move further: second question"], "the NEW words")
         self.assertEqual(km._relay_tick(NOW + 1), 0, "once")
+
+    def test_two_nodes_blocked_in_one_pass_toward_one_peer_get_two_questions(self):
+        st, top, step = self.store(delegated=True)
+        other = WORKER + ":g3"
+        st["nodes"][other] = node(other, "Ask which port to use", parent=top, t=T0 + 70)
+        with contextlib.redirect_stderr(io.StringIO()):
+            jd.apply_close(st, [st["nodes"][step], st["nodes"][other]],
+                           {"done": {}, "block": {1: "which client?", 2: "which port?"}, "awaiting": {}}, t=T0 + 400)
+        ids = (st["nodes"][step]["relayWanted"]["id"], st["nodes"][other]["relayWanted"]["id"])
+        self.assertNotEqual(ids[0], ids[1], "one evidence time, one peer, two nodes: two markers")
+        self._save(st)
+        self.assertEqual(len(self._queue()), 2)
+        self.assertEqual(km._relay_tick(NOW), 2)
+        self.assertEqual(sorted(p["body"] for p in self.sent),
+                         ["api cannot move further: which client?", "api cannot move further: which port?"])
 
     def test_two_holders_filing_one_wait_mint_one_marker(self):
         st, top, step = self.store(delegated=True)
@@ -622,17 +653,19 @@ class RelayEdges(_RelayFixture):
         self.assertTrue(nd["blocked"], "the bounce is the definitive refusal: the user's block")
         self.assertEqual(self._queue(), [])
 
-    def test_a_parked_relay_the_peer_answers_completes(self):
+    def test_a_parked_relay_needs_delivery_proof_a_later_message_is_not_its_answer(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
         self._save(st)
         km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "relay-far-2", "parked": "TESTHOST"})
         self.assertEqual(km._relay_tick(NOW), 0)
-        self.rows.append(mail(MANAGER, WORKER, NOW + 40, kind="coordinate"))
+        self.rows.append(mail(MANAGER, WORKER, NOW + 40, kind="coordinate"))   # the peer writes, but the parked question
+        self._write_mail()                                                     #   cannot have been read
+        self.assertEqual(km._relay_tick(NOW + 60), 0, "still pending: no delivery proof")
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayWanted"]["pendingMid"], "relay-far-2")
+        self.rows.append({"t": NOW + 70, "ev": "relayed", "id": "relay-far-2", "host": "TESTHOST"})
         self._write_mail()
-        self.assertEqual(km._relay_tick(NOW + 60), 1, "the peer answered: the relay stands as sent")
-        nd = jd.load_goals(WORKER)["nodes"][step]
-        self.assertEqual(nd["relayed"]["mid"], "relay-far-2")
+        self.assertEqual(km._relay_tick(NOW + 90), 1, "the far host's ack completes it")
         self.assertEqual(self._queue(), [])
 
     def test_a_relay_in_flight_to_a_host_that_is_up_is_pending_until_the_far_host_delivers(self):
@@ -687,7 +720,8 @@ class RelayEdges(_RelayFixture):
             self.assertEqual(km._relay_tick(NOW + 60), 0)
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertTrue(nd["blocked"])
-        self.assertIn("was withdrawn by api", nd["log"][-1]["why"])
+        self.assertIn("was withdrawn by api", nd["relayRefusal"])
+        self.assertEqual(nd["log"][-1]["why"], "cannot move further without you", "the block keeps its own why")
 
     def test_a_bounce_carries_the_far_hosts_reason_into_the_users_block(self):
         st, top, step = self.store(delegated=True)
@@ -700,21 +734,39 @@ class RelayEdges(_RelayFixture):
         with contextlib.redirect_stderr(io.StringIO()):
             km._relay_tick(NOW + 60)
         nd = jd.load_goals(WORKER)["nodes"][step]
-        self.assertIn("came back from TESTHOST: no live session named web", nd["log"][-1]["why"])
-        self.assertEqual(nd["log"][-1]["ev_t"], NOW + 30, "filed at the bounce row's time: a later lift outranks it")
+        self.assertIn("came back from TESTHOST: no live session named web", nd["relayRefusal"])
+        self.assertEqual(nd["log"][-1]["why"], "cannot move further without you", "the mechanism's note stays out of the why")
+        self.assertEqual(nd["log"][-1]["ev_t"], NOW + 30, "filed at the bounce row's time: a user reopen after it outranks it")
 
-    def test_an_answer_in_the_sends_own_second_is_not_the_answer(self):
+    def test_a_bounce_on_a_wait_another_holder_ended_stands_down(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
         self._save(st)
-        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-7", "note": "relaying"})
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-far-6b", "note": "relaying"})
         self.assertEqual(km._relay_tick(NOW), 0)
-        self.rows.append(mail(MANAGER, WORKER, NOW, kind="coordinate"))        # the same second as the send
+        self.rows.append({"t": NOW + 30, "ev": "bounced", "id": "px-far-6b", "host": "TESTHOST", "why": "no live session"})
         self._write_mail()
-        self.assertEqual(km._relay_tick(NOW + 1), 0, "still pending")
-        self.rows.append(mail(MANAGER, WORKER, NOW + 2, kind="coordinate"))
-        self._write_mail()
-        self.assertEqual(km._relay_tick(NOW + 3), 1, "a later message is the answer")
+        real = km._relay_ended_since
+        km._relay_ended_since = lambda sid, nid, t: True   # the fresh read finds the wait ended at or after the bounce
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.assertEqual(km._relay_tick(NOW + 60), 0)
+        finally:
+            km._relay_ended_since = real
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertFalse(nd["blocked"], "nothing to revert to")
+        self.assertEqual((nd["relayDone"]["outcome"], nd["relayDone"]["pending"]), ("stood-down", "bounced"))
+
+    def test_ended_since_reads_the_node_on_disk(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        self.assertFalse(km._relay_ended_since(WORKER, step, NOW))
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._save(st)
+        self.assertTrue(km._relay_ended_since(WORKER, step, NOW), "a lift at or after the bounce's time")
+        self.assertFalse(km._relay_ended_since(WORKER, step, NOW + 10), "a lift before it is not an ending since")
 
     def test_the_pending_stamp_survives_a_holders_save_so_the_question_is_sent_once(self):
         st, top, step = self.store(delegated=True)
@@ -772,6 +824,41 @@ class RelayEdges(_RelayFixture):
         self.assertEqual(km._relay_tick(NOW + 1), 1, "the row names the marker: adopted")
         self.assertEqual(len(self.sent), 1)
         self.assertEqual(self._queue(), [])
+
+    def test_a_stalled_bus_is_not_asked_again_before_its_timeout_and_the_row_settles_it(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        real = km._bus_send_relay
+        calls = []
+        def stalled_bus(payload):                          # the request went in; no answer within the read timeout
+            calls.append(payload)
+            return False, "timed out", False, {"unknown": True}
+        km._bus_send_relay = stalled_bus
+        with contextlib.redirect_stderr(io.StringIO()) as err:
+            self.assertEqual(km._relay_tick(NOW), 0)
+            self.assertEqual(km._relay_tick(NOW + 1), 0)
+            self.assertEqual(km._relay_tick(NOW + 12), 0)
+        self.assertEqual(len(calls), 1, "held: nothing is sent again inside the bus's own timeout")
+        self.assertEqual(err.getvalue().count("outcome is unknown"), 1, "said once")
+        real(calls[0])                                     # the bus drains: its row lands, the manager holds one question
+        self.assertEqual(km._relay_tick(NOW + 13), 1, "the row names the marker: adopted")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(len(self.sent), 1)
+
+    def test_a_stalled_bus_that_never_wrote_is_asked_again_after_the_hold(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        calls = []
+        km._bus_send_relay = lambda payload: calls.append(payload) or (False, "timed out", False, {"unknown": True})
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 0)
+            self.assertEqual(km._relay_tick(NOW + km.RELAY_UNKNOWN_HOLD - 1), 0)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(km._relay_tick(NOW + km.RELAY_UNKNOWN_HOLD), 0)
+        self.assertEqual(len(calls), 2, "the hold passed with no row: asked again")
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayWanted"]["attempts"], 2)
 
     def test_a_relay_leg_send_with_a_lost_answer_is_adopted_as_pending(self):
         st, top, step = self.store(delegated=True)
@@ -880,6 +967,72 @@ class RelayEdges(_RelayFixture):
         self._write_mail()                                 # the rowless rebuild appended an old row behind the ack
         self.assertEqual(km._relay_tick(NOW + 60), 1, "the ack is found past the recovered row")
 
+    def test_a_lost_relay_leg_send_whose_wait_ended_is_adopted_then_recalled(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        marker = st["nodes"][step]["relayWanted"]["id"]
+        def lossy_relay_leg(payload):
+            self.rows.append({"t": NOW, "ev": "sent", "id": "px-lost-2", "from_id": WORKER, "to_id": "peer:TESTHOST",
+                              "to_sid": MANAGER, "kind": "question", "relayed": True, "relayMarker": payload["relayMarker"]})
+            self._write_mail()
+            return False, "timed out", False, {"unknown": True}
+        km._bus_send_relay = lossy_relay_leg
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)   # the wait ends
+        self._save(st)
+        recalls = []
+        km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "withdrawn"
+        km._bus_send_relay = lambda payload: self.fail("a second send")
+        self.assertEqual(km._relay_tick(NOW + 10), 0)
+        self.assertEqual(recalls, ["px-lost-2"], "adopted as pending, then recalled: the far host never delivers it")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertEqual((nd["relayDone"]["outcome"], nd["relayDone"]["recall"], nd["relayDone"]["marker"]), ("stood-down", "withdrawn", marker))
+
+    def test_a_row_the_bus_bounced_as_not_parked_was_never_sent(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        marker = st["nodes"][step]["relayWanted"]["id"]
+        self.rows.append({"t": NOW - 5, "ev": "sent", "id": "px-np", "from_id": WORKER, "to_id": "peer:TESTHOST",
+                          "to_sid": MANAGER, "kind": "question", "relayed": True, "relayMarker": marker})
+        self.rows.append({"t": NOW - 5, "ev": "bounced", "id": "px-np", "host": "TESTHOST",
+                          "why": "not parked: the outbox record could not be written", "notParked": True})
+        self._write_mail()
+        self.assertEqual(km._relay_tick(NOW), 1, "the not-parked row is no send: a fresh one goes out")
+        self.assertEqual(len(self.sent), 1)
+
+    def test_an_unknown_recall_keeps_the_entry_for_the_next_tick(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "cannot move further without you", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-ur", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._save(st)
+        answers = ["unknown", "carried"]
+        km._bus_recall_relay = lambda sid, mid: answers.pop(0)
+        self.assertEqual(km._relay_tick(NOW + 10), 0)
+        self.assertEqual(len(self._queue()), 1, "the bus could not be asked: kept")
+        self.assertIn("relayWanted", jd.load_goals(WORKER)["nodes"][step])
+        self.assertEqual(km._relay_tick(NOW + 11), 0)
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(jd.load_goals(WORKER)["nodes"][step]["relayDone"]["recall"], "carried: could not be withdrawn")
+
+    def test_an_entry_is_spent_only_when_the_file_still_holds_what_was_read(self):
+        jd._relay_write_entry(WORKER, WORKER + ":g2", "mk-a", 3)
+        f = jd._relay_entry_path(WORKER, WORKER + ":g2")
+        e = json.loads(f.read_text())
+        jd._relay_write_entry(WORKER, WORKER + ":g2", "mk-b", 4)   # the judge's flush renamed a newer marker's entry over it
+        km._relay_spend(f, e)
+        self.assertTrue(f.exists(), "the newer entry stays")
+        self.assertEqual(json.loads(f.read_text())["marker"], "mk-b")
+        km._relay_spend(f, json.loads(f.read_text()))
+        self.assertFalse(f.exists(), "spent once it is the one read")
+
     def test_a_dead_workers_block_is_not_relayed(self):
         st, top, step = self.store(delegated=True)
         self._close(st, step, "cannot move further without you", T0 + 400)
@@ -899,6 +1052,15 @@ class RelayEdges(_RelayFixture):
                          "api cannot move further: the dashboard keyboard shortcut collides with discard; which key?",
                          "words, not substrings")
         self.assertEqual(km._relay_body("api", "the card is held open."), "api cannot move further on this and needs your call.")
+        self.assertEqual(km._relay_body("api", "the cards are nudged and the goals cleared; which port?"),
+                         "api cannot move further: which port?", "inflections are the same words")
+        self.assertEqual(km._relay_body("api", "the goal is blocked; which goal should ship first?"),
+                         "api cannot move further: which goal should ship first?", "a question is always kept")
+        self.assertEqual(km._relay_body("api", "No answer from the payments vendor yet; should I switch providers?"),
+                         "api cannot move further: No answer from the payments vendor yet; should I switch providers?",
+                         "a real question under the debt ladder's prefix is not procedural")
+        self.assertEqual(km._relay_body("api", jd.DEBT_BLOCK_WHY_PREFIX + "web after two reminders"),
+                         "api cannot move further on this and needs your call.")
 
     def test_a_malformed_entry_drops_alone(self):
         st, top, step = self.store(delegated=True)
@@ -1233,6 +1395,7 @@ class PostalRelayedFlag(unittest.TestCase):
         self.assertTrue(got and all(m.get("relayed") for m in got), "the inbox read carries the mark to the recipient")
         recs = ps.format_receipts(ps._sent_receipts(WORKER))
         self.assertIn("sent on your behalf", recs, "the worker's own receipts say romp sent it")
+        self.assertNotIn("romp-msg-relayed", ps.format_inbox(got, MANAGER) + ps.format_push(got), "no comment nobody reads")
         plain = ps.deliver(MANAGER, "api", WORKER, "a typed question", kind="question")
         self.assertNotIn("X-Relayed", (ps._mailbox(MANAGER) / "new" / plain).read_text())
         rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
@@ -1344,6 +1507,48 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertNotIn("relayWanted", jd.load_goals(WORKER)["nodes"][step])
         self.assertEqual(self._queue(), [], "nothing left to relay: no entry")
 
+    def test_a_retired_marker_handed_to_a_far_host_is_recalled_by_the_tick(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-ret-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)           # handed to the far host, pending
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "second question", NOW + 60)   # the judge retires the pending marker for a new wait
+        nd = st["nodes"][step]
+        self.assertEqual([r["pendingMid"] for r in nd["relayRecall"]], ["px-ret-1"], "remembered for the recall")
+        self.assertEqual(nd["relayWanted"]["why"], "second question")
+        self._save(st)
+        recalls = []
+        km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "withdrawn"
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
+        self.assertEqual(km._relay_tick(NOW + 70), 1, "the new question goes out")
+        self.assertEqual(recalls, ["px-ret-1"], "and the stale one is withdrawn from the far host's outbox")
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertNotIn("relayRecall", nd)
+        self.assertEqual(nd["relayRecalled"], ["px-ret-1"])
+
+    def test_a_retired_marker_on_the_users_block_is_recalled_too(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-ret-2", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", NOW + 5, msg=True)   # the user follows up: the block is theirs
+        self._close(st, step, "still stuck", NOW + 60)
+        nd = st["nodes"][step]
+        self.assertTrue(nd["blocked"])
+        self.assertEqual([r["pendingMid"] for r in nd["relayRecall"]], ["px-ret-2"])
+        self._save(st)
+        self.assertEqual(len(self._queue()), 1, "an entry brings the tick to the node though no marker stands")
+        recalls = []
+        km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "carried"
+        self.assertEqual(km._relay_tick(NOW + 70), 0)
+        self.assertEqual(recalls, ["px-ret-2"])
+        self.assertEqual(self._queue(), [], "the recall entry is spent")
+
     def test_a_failed_publish_keeps_the_pending_list_for_the_retry(self):
         st, top, step = self.store(delegated=True)
         self._save(st)
@@ -1447,6 +1652,49 @@ class FarHostRelayMark(unittest.TestCase):
         rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
         row = next(r for r in rows if r.get("id") == obj["id"])
         self.assertEqual((row.get("ev"), row.get("relayed"), row.get("kind")), ("sent", True, "question"), "the sender's ledger says relayed")
+
+    def test_the_marker_rides_the_row_the_header_and_the_rebuild_and_forges_nothing(self):
+        ps = self._postal()
+        live = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False); json.dump([{"id": MANAGER, "name": "web"}], live); live.close()
+        prior = os.environ.get("ROMP_SESSIONS_FILE"); os.environ["ROMP_SESSIONS_FILE"] = live.name
+        try:
+            def post(marker):
+                h = object.__new__(ps.Handler)
+                raw = json.dumps({"to": MANAGER, "from": "api", "from_id": WORKER, "kind": "question", "relayed": True,
+                                  "relayMarker": marker, "body": "api cannot move further: which client?"}).encode()
+                h.path = "/send"; h.headers = {"Content-Length": str(len(raw)), "X-Romp-Token": ps.SERVE_TOKEN}; h.rfile = io.BytesIO(raw)
+                out = []; h._send = lambda obj, code=200: out.append((obj, code))
+                h.do_POST()
+                return out[0]
+            obj, code = post("1781296800-11111111-g2")
+            self.assertEqual(code, 200, obj)
+            rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+            row = next(r for r in rows if r.get("relayMarker") == "1781296800-11111111-g2")
+            self.assertEqual((row["ev"], row["from_id"], row["relayed"]), ("sent", WORKER, True))
+            text = (ps._mailbox(MANAGER) / "new" / row["id"]).read_text()
+            self.assertIn("X-Relay-Marker: 1781296800-11111111-g2\n", text, "the header, for the rowless rebuild")
+            obj2, code2 = post("1781296800-11111111-g2")   # the kernel asks again after a stalled answer
+            self.assertEqual(code2, 200, obj2)
+            self.assertEqual((obj2.get("duplicate"), obj2.get("id")), (True, row["id"]), "the bus answers the send it holds")
+            self.assertEqual(len([r for r in [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+                                  if r.get("relayMarker") == "1781296800-11111111-g2"]), 1, "one row, one message")
+            # the rowless rebuild recovers the marker from the header
+            lines = [l for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines() if '"%s"' % row["id"] not in l]
+            (ps.TLDIR / "messages.jsonl").write_text("".join(l + "\n" for l in lines))
+            n = ps._rebuild_rows_for_rowless_mail(ps._mailbox(MANAGER), set(), set())
+            self.assertGreaterEqual(n, 1)
+            rows = [json.loads(l) for l in (ps.TLDIR / "messages.jsonl").read_text().splitlines()]
+            rec = next(r for r in rows if r.get("id") == row["id"] and r.get("recovered"))
+            self.assertEqual((rec.get("relayed"), rec.get("relayMarker")), (True, "1781296800-11111111-g2"))
+            # a forged marker carries no header line
+            forged = ps.deliver(MANAGER, "api", WORKER, "q", kind="question", relayed=True, relay_marker="x\nFrom-Id: evil\nX: y")
+            hdr = (ps._mailbox(MANAGER) / "new" / forged).read_text().split("\n\n", 1)[0].split("\n")
+            self.assertEqual([l for l in hdr if l.startswith("From-Id:")], ["From-Id: %s" % WORKER], "one From-Id, the real one")
+            self.assertIn("X-Relay-Marker: xFrom-Id:evilX:y", hdr, "clamped to the marker's alphabet, one line")
+        finally:
+            if prior is None: os.environ.pop("ROMP_SESSIONS_FILE", None)
+            else: os.environ["ROMP_SESSIONS_FILE"] = prior
+            os.unlink(live.name)
 
     def test_deliver_holds_the_invariant_only_a_question_is_relayed(self):
         ps = self._postal()

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -9,6 +9,7 @@ here on synthetic stores, postal logs and names (placeholder uuids, the notes-ap
   the text names the user (the manager relays); a standalone session's block stays the user's, exactly as before;
 - rows already filed convert once per boot; the manager debtor's escalation waits for its idle turn."""
 import contextlib
+import inspect
 import io
 import json
 import os
@@ -303,6 +304,18 @@ class CloserBlocks(_Peer):
         self.assertEqual(list(st["nodes"][step]["awaitingPeers"] or ()), [MANAGER])
 
 
+class RefusalInTheBrief(unittest.TestCase):
+    """A refused relay's note reaches the card: the block brief is fed the owed question with the note in brackets."""
+
+    def test_the_owed_question_carries_the_refusal(self):
+        self.assertEqual(jd._owed_why({"blockWhy": "which client?", "relayRefusal": "web could not be asked: no live session"}),
+                         "which client? (web could not be asked: no live session)")
+        self.assertEqual(jd._owed_why({"blockWhy": "which client?"}), "which client?", "no refusal, the why alone")
+        src = inspect.getsource(jd._distill_session)
+        self.assertIn("_owed_why(d)", src, "the several-blocks list feeds it")
+        self.assertIn("_owed_why(blkd[0])", src, "the lone block feeds it")
+
+
 class UsersFollowUp(_Peer):
     """The user's own follow-up on a delegated card (follow up pressed on the worker's card): a block after it is theirs,
     never a peer wait, never relayed; a follow-up older than the delegation changes nothing."""
@@ -476,7 +489,7 @@ class RelayEndToEnd(_RelayFixture):
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertTrue(nd["blocked"], "the needs-you is back")
         self.assertIn("cannot move further without you", nd["blockWhy"])
-        self.assertIn("relay to web was refused", nd["relayRefusal"])
+        self.assertIn("web could not be asked", nd["relayRefusal"])
         self.assertNotIn("relayWanted", nd)
         self.assertEqual(nd["mt"], NOW, "bumped like every other block writer")
         self.assertEqual(nd["relayDone"]["outcome"], "refused", "the removal is a record the merge honours")
@@ -1362,13 +1375,15 @@ class MergeCarriesTheRelay(_Peer):
         mem = json.loads(json.dumps(st)); disk = json.loads(json.dumps(st))
         mem["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "attempts": 1, "unknownAt": NOW}
         disk["nodes"][step]["relayWanted"] = {"peer": MANAGER, "why": "q", "t": T0 + 400, "id": "mk-a", "attempts": 2,
-                                              "unknownAt": NOW + 40, "pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST"}
+                                              "unknownAt": NOW + 40, "pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST",
+                                              "recallUnknownAt": NOW + 42}
         (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(disk))
         jd._rebase_onto_disk(WORKER, mem)
         rw = mem["nodes"][step]["relayWanted"]
         self.assertEqual({k: rw[k] for k in jd.RELAY_TICK_KEYS},
-                         {"pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST", "unknownAt": NOW + 40, "attempts": 2})
-        self.assertEqual(jd.RELAY_TICK_KEYS, ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts"), "named once")
+                         {"pendingMid": "px-1", "pendingAt": NOW + 41, "pendingHost": "TESTHOST", "unknownAt": NOW + 40, "attempts": 2,
+                          "recallUnknownAt": NOW + 42})
+        self.assertEqual(jd.RELAY_TICK_KEYS, ("pendingMid", "pendingAt", "pendingHost", "unknownAt", "attempts", "recallUnknownAt"), "named once")
 
     def test_a_recall_done_on_the_disk_filters_the_holders_owed_list_though_the_disk_owes_none(self):
         st, top, step = self.store(delegated=True)
@@ -1620,6 +1635,42 @@ class SaverFlushesItsOwn(_RelayFixture):
         nd = jd.load_goals(WORKER)["nodes"][step]
         self.assertEqual([(d["mid"], d["outcome"]) for d in nd["relayRecalled"]],
                          [("px-ret-2", "carried: could not be withdrawn")], "a carried recall says so: the stale question reached the manager")
+
+    def test_an_owed_recall_never_loses_its_entry_to_the_live_markers_send(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-owe-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)           # M1 handed to the far host
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "second question", NOW + 60)   # M1 retired (a recall owed), M2 minted, one entry file
+        self._save(st)
+        km._bus_recall_relay = lambda sid, mid: "unknown"  # the bus is restarting: the recall cannot be asked
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "to": payload["to"]})
+        self.assertEqual(km._relay_tick(NOW + 70), 1, "M2's question goes out")
+        self.assertEqual(len(self._queue()), 1, "the entry is not spent while a recall is owed")
+        self.assertEqual(json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())["marker"], "recall", "it became the recall's own")
+        recalls = []
+        km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "withdrawn"
+        self.assertEqual(km._relay_tick(NOW + 70 + km.RELAY_UNKNOWN_HOLD), 0)
+        self.assertEqual(recalls, ["px-owe-1"], "the recall is asked again once the hold passed")
+        self.assertEqual(self._queue(), [], "and the recall's entry is spent once done")
+
+    def test_the_boot_pass_requeues_a_node_that_owes_recalls(self):
+        st, top, step = self.store(delegated=True)
+        st["nodes"][step]["relayRecall"] = [{"id": "mk-old", "peer": MANAGER, "pendingMid": "px-boot", "pendingHost": "TESTHOST"}]
+        st["rev"] = 3
+        (jd.GOALDIR / (WORKER + ".json")).write_text(json.dumps(st))   # recalls owed, no marker, no entry (a lost entry)
+        self.assertEqual(jd._requeue_relays_all(), 1)
+        entry = json.loads((jd._relay_queue_dir() / self._queue()[0]).read_text())
+        self.assertEqual((entry["marker"], entry["rev"]), ("recall", 3))
+        self.assertEqual(jd._requeue_relays_all(), 0, "idempotent")
+        recalls = []
+        km._bus_recall_relay = lambda sid, mid: recalls.append(mid) or "carried"
+        self.assertEqual(km._relay_tick(NOW), 0)
+        self.assertEqual(recalls, ["px-boot"])
+        self.assertEqual(self._queue(), [])
 
     def test_an_unknown_recall_owed_is_held_like_a_send(self):
         st, top, step = self.store(delegated=True)

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -92,7 +92,7 @@ class PostalTrackedWire(unittest.TestCase):
                       "a checked boolean: the string \"false\" used to arm tracking")
         self.assertIn('tracked = tracked and kind == "delegate"', PSRC)
         self.assertIn("`tracked` deliberately does NOT ride the relay", PSRC)
-        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed)', PSRC)   # T334: relayed rides too
+        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed,', PSRC)   # T334: relayed rides too
 
     def test_mcp_and_cli_expose_the_flag(self):
         self.assertIn('"tracked": {"type": "boolean"', PSRC, "the send_message schema offers it")

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -92,7 +92,7 @@ class PostalTrackedWire(unittest.TestCase):
                       "a checked boolean: the string \"false\" used to arm tracking")
         self.assertIn('tracked = tracked and kind == "delegate"', PSRC)
         self.assertIn("`tracked` deliberately does NOT ride the relay", PSRC)
-        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked)', PSRC)
+        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed)', PSRC)   # T334: relayed rides too
 
     def test_mcp_and_cli_expose_the_flag(self):
         self.assertIn('"tracked": {"type": "boolean"', PSRC, "the send_message schema offers it")

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -92,7 +92,8 @@ class PostalTrackedWire(unittest.TestCase):
                       "a checked boolean: the string \"false\" used to arm tracking")
         self.assertIn('tracked = tracked and kind == "delegate"', PSRC)
         self.assertIn("`tracked` deliberately does NOT ride the relay", PSRC)
-        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed,', PSRC)   # T334: relayed rides too
+        self.assertIn('mid = deliver(a0["id"], frm, frm_id, body, kind=kind, tracked=tracked, relayed=relayed,\n'
+                      '                              relay_marker=relay_marker)', PSRC)   # T334: relayed and its marker ride too
 
     def test_mcp_and_cli_expose_the_flag(self):
         self.assertIn('"tracked": {"type": "boolean"', PSRC, "the send_message schema offers it")


### PR DESCRIPTION
## What

A block addressed to a peer is a peer wait, not the user's needs-you. The repository's philosophy (interrupt only when the human is the bottleneck; waiting on a peer, a build or another session is not that) said so; the judges did not. A worker session that ended its turn asking its manager got the closer's block, and the feed showed it as a needs-you card for the user.

## Design

- **Addressee, from evidence, never words alone.** `block_addressee` reads (a) the session's own open question to a live peer (the same postal read the wait graph and the awaiting-a-peer write gate use), (b) failing that, the peer that delegated the work the block sits under: the courier-planted top's `origin.peer` when present, else the sender of the delegate mail the top's anchor record names (`promptMsgId`, latched from the parse's postal markers as the delegate-kind marker of the delivery, so a batched inbox whose first mail is a peer's coordinate and whose second the manager's dispatch is the manager's; a worker two managers dispatched relays each block to the manager that asked), else the latest delegate the session received at or before the top's mint (today's live stores hold no planted origin at all, so the mail row is the primary record); only a top the latch has positively read as a machine record qualifies; an unlatched, absent, scheduled or human anchor stays the user's, and a script mailer's `ext:` pseudo-sid is never the delegating peer (no session behind it could be asked), and (c) words only to pick among several open asks (a peer's session name in the block's text, on word boundaries), never to invent a peer; an open ask to a peer the block never names does not capture a block in the delegator's work. A block on a "delegated to <peer>" tracker under a delegated goal waits on that peer, whose report ends the delegate edge; the same tracker in the user's own session keeps its block. Nothing resolves: the user, the block exactly as before.
- **A worker's card never reaches the user directly.** A block in a delegated goal whose text names the user explicitly still resolves to the delegating manager, who relays; the user sees the card only through the debt ladder's escalation event.
- **Only a delegated goal is redirected.** A node not under a delegated top keeps its block whatever open questions its session has out: the user's own decision never hides behind "Awaiting <peer>". An empty why is never redirected.
- **What the card shows.** The existing awaiting-a-peer stamp is filed in place of the block by the one block writer both judges now share (`file_block`), an already-blocked closer or planner block unblocked by romp first, one stamp per standing wait (the standing state read before any write), with the awaiting branch's own stand-down (a wait the diary already ended after this turn's evidence is neither re-stamped nor re-relayed) and the open-ask window starting at the goal's mint: the "Awaiting <peer>" chip in Working, never a needs-you face; the auto-nudge already skips peer waits; the peer's reply is the lift. A standing nudge or interrupt block (the ladder's own once-ever escalation) is never lifted by a re-asserted judge block.
- **The relay.** When the addressee came from the delegator alone, no question was ever sent, so nothing could end the wait (every ending keys on a reply-expecting message the worker itself sent). The judge leaves `relayWanted` on the node, a marker with an identity (the block's evidence time and the peer) that its queue entry, the bus's sent row and the record settling it name, so a block filed again after a lift is a new marker nothing older can settle, an ended wait's unsent marker is never reused for a new wait (it is popped and marked settled, on the peer path and the user path alike), and two holders filing one wait mint one marker. The pending entries ride the store object: the saver holding it writes them, one file per entry in a queue directory (two writers never rewrite each other's list; a malformed entry drops alone), once its own publish carried the marker; another holder's save of the same session flushes nothing of it, and a failed publish keeps them for the retry. The kernel's tick sends the block's why to that peer as the worker's own question through the bus (`kind` question, from the worker, "<worker> cannot move further: <why>" with any clause that speaks romp scrubbed and the plain lead-in alone for romp's own procedural whys, marked `relayed` in the row and an `X-Relayed` header the rowless rebuild recovers, the row naming the marker; the mark and the marker ride the relay leg to a far host, through a hold and its approve too), once per block: before a fresh send the tick adopts the bus's own sent row for the marker when one exists (a send whose record was lost to a failed save, a restart or a dropped answer is never repeated; a row the bus bounced as not parked never counts; a request written but unanswered is unknown, not transient: the tick sends nothing for thirty seconds and reads the row, and the bus itself answers a repeated marker with the send it holds); the marker names the node as well as the evidence time and the peer, so two nodes blocked in one pass keep two questions; the kernel's fields on a marker (the pending stamp, the hold, the attempt count) survive every holder's save; a marker the judge retires while it is parked on a far host is recalled by the tick (`relayRecall`), a recall the bus could not be asked for is held like a send, rides its own queue entry beside the marker's (never a rewrite of the marker's file, which the judge may rename a newer marker's entry over meanwhile; the boot pass re-queues a node that owes one), is asked once per hold for eight tries and then once per half hour, said both times, and a done recall records whether the question was withdrawn or had already been carried; a quiet pass carries the time its earliest hold ends, so a held send or recall is asked again on the clock even when nothing on disk moved; a refused relay's note reaches the card's brief in brackets after the owed question, and a later relay that succeeds clears it; a question a far host carried on before it could be withdrawn, or one the host could not be reached to withdraw for eight tries, leaves a note beside the block that the brief's owed why, the card and the modal show under the brief, cleared the same way (before, only stderr said a far host still held a question after its wait ended); the parked question completes only on the far host's delivered row, never on a later message; an entry file is spent only while it still holds the entry that was read, its own token included, so a fresh recall entry the judge flushed over the same path during the pass (every recall entry's marker is the constant "recall") survives the spend and the next tick asks for what it owes; the recall sweep returns its pair on every path and never raises on a recall list holding no dict; the user's own follow-up on a delegated card, newer than the delegation and the standing wait, keeps the block theirs; a dead worker's entry waits quiet; the worker's own receipts say the question was sent on its behalf; a re-asserted block on a standing relayed wait never relays twice; a wait that ended before the tick stands down unsent; a relay the bus handed to a far host (parked, or in flight to a host that is up) stays pending by its id up to the far host's delivered row or the peer's answer, read before the wait's standing so a delivery settles it whatever the wait did, and a pending relay whose wait ended another way is recalled from the far host's outbox; a definitive refusal (no live recipient, a message that came back, with the far host's reason) reverts the node to the user's block with the refusal in its why, mt bumped and views woken, filed at the bounce's own time so a lift that landed after it outranks it; a transient failure keeps the entry and is said once; an entry whose marker is gone with no record is spent once the store's published revision passed the entry's, never kept forever; an entry whose node carries a newer marker is rewritten for it; each record lands before its entry is spent; a pass that changed nothing is not repeated until the store, the log or the entries move, so a relay parked for a host that is down costs no store parse per tick. Removals are records (`relayDone`) that name their marker, and the node keeps a capped list of the markers it settled (`relaySettled`), so a holder stale across two relays never re-mints the first; the store merge adopts the newer record in either direction, pops a settled marker before adopting the disk's live one, keeps the kernel's pending stamp on a marker both sides hold, converges two holders' markers for one wait on the one already handed to a far host or else the published one, and settles a marker only by a record or the list that names it; the boot pass re-queues a marker that lost its entry. Only a question is ever relayed: `deliver` holds that invariant for every path. A block filed after the peer's reply ended the wait relays again. That creates the edge: the reply lifts the stamp, the reminder ladder covers it, and the idle-manager escalation is the only door to the user.
- **When the peer never answers.** The existing debt reminder ladder; no timer. The nudge walk already judges a debtor's reminders only at an idle turn end; for a manager debtor (it delegated to the asker) the record also stands while delivered mail waits unread in its inbox, the one queue those gates miss. Any other peer keeps the ladder as it was; the dead-man backstop still applies.
- **Rows already filed** convert once per boot (the planner's first pass), idempotently.
- **The user's own sessions** are untouched: no open ask and no delegating peer means the block stays theirs.

## Tests

`tests/test_peer_wait_blocks.py` (synthetic stores, postal rows, maildirs and names): 121 tests in 13 classes, 121 collected (the relay classes share a test-less fixture base, so no class re-runs another's cases). Covered: a recall entry the judge flushed over the path during the tick's pass survives the spend and the next tick asks for the second question with no boot (fails on the old marker-and-node comparison), a recall list holding no dict is skipped without a traceback, a carried recall and an eighth unanswered try leave the note in the owed why, under the brief, alone before a brief exists, and a later relay drops it; a judge's save inside the hold keeps the hold, the tick's fields on a marker are carried whole with the newer counter and clock winning, an unknown recall is held like a send, a done recall records its outcome, a recall done on the disk filters a holder's owed list, the far-route duplicate answer names its host and the tick keeps it, a later relay clears the refusal's note; a stalled bus is asked once inside its timeout and the row settles it, a bus that never wrote is asked again after the hold, the bus answers a repeated marker with the send it holds, two nodes blocked in one pass toward one peer get two questions, a retired far-host marker is recalled on the next question or through its own entry, an entry file is spent only while it holds what was read, a lost relay-leg send whose wait ended is adopted then recalled, a not-parked row was never sent, an unknown recall keeps the entry, a bounce on a wait another holder ended stands down, the fresh read of the node on disk, a parked relay needs delivery proof, the worker's own ask after the follow-up is the newer edge and a follow-up after the ask is the user's, the scrub matches inflections and keeps every question, the marker rides the row, the header and the rebuild and forges nothing, the inbox and push carry no relayed comment; a lift before any tick then a new block relays the new words once, two holders filing one wait mint one marker, a send whose save raised is adopted from the bus's row and never repeated, an unknown outcome is settled by the row next tick, a lost relay-leg answer is adopted as pending, the user's follow-up newer than the delegation keeps the block theirs (and one older changes nothing, and one on a standing wait reclaims the next block), a bounce's revert carries the far host's reason at the row's time, a pending relay whose wait ended is recalled, a delivered one settles though the wait ended, a recovered row behind the ack never ends the walk, a dead worker's block is not relayed, the relayed body speaks no romp and drops a procedural why, the worker's receipts say sent on your behalf; the same marker on both sides of a merge keeps the kernel's pending stamp either way, a settled marker is popped before the disk's live one is adopted, two holders' markers for one wait converge, the settled list survives the record slot and merges as a union; two delegates in one delivery attribute to the last, a delegate marker quoted from another session's dispatch names nobody here, a stamp naming no dispatch to the session leaves the fallback; an entry whose node is gone is spent, a withdrawn pending relay reverts as withdrawn, a bounce carries the far host's reason into the block, a same-second message is not the answer, the pending stamp survives a holder's save so the question is sent once, a record lands before its entry is spent, a later marker's transient failure is said after an earlier one stood down, a quiet pass is not repeated until something moves; a marker the publish's rebase settled gets no entry; a held relayed question keeps its mark through the approve, the relay leg's sent row carries the mark, deliver relays only a question; an open question makes the closer's block a peer wait; words pick among several asks and never invent a peer; a delegated goal's block goes to its delegator, even when the text names the user; a standalone session's block is unchanged, whatever questions it has out; an empty why stays a block; the ladder's own escalation and an interrupt block are never lifted; a delegate or coordinate row is no open ask, an answered question neither; a re-asserted block on an already-blocked node unblocks it into the wait; the planner shares the writer, its block row carries the segment, and its block op through the real entry files a peer wait with no mt bump on a delegated step and the user's block with the bump on a standalone one; a script mailer's pseudo-sid and a host-qualified sender are never the delegating peer, a `peer:host` recipient key is a peer wait with no relay; a block on a handoff tracker under a delegated goal waits on the peer it was handed to, the same tracker in the user's own session keeps its block; a top is attributed to the mail its anchor names, two managers each get the block their mail anchored, the planner pass latches the delegate-kind marker of a batched delivery and leaves the fallback when the delivery holds no delegate; the boot pass converts a closer block once and leaves the user's and a nudge block alone; the relay end to end: one relayed question in the manager's inbox as the worker's own words, the edge exists, no second relay on a re-asserted block, the manager's reply lifts the wait, a block after the lift relays again as a new marker, a re-block with the same words is a new marker the earlier record never settles, a transient failure keeps the queued entry and is said once, a definitive refusal reverts to the user's block with mt bumped and a record, a wait that ended before the tick stands down; an entry is kept only when the store on disk predates its publish and is spent once the revision passed without the marker, by a record naming its marker, or by a newer marker; an entry appended mid-tick survives; a parked relay and a relay in flight to a host that is up are pending up to the far host's delivered row, the peer's answer or a bounce; a malformed entry drops alone; the boot pass re-queues an orphaned marker with its marker and revision; the saver flushes only its own entries after its own publish, a no-op save still flushes, a failed publish keeps the list; the merge carries the newer record in either direction, settles a marker only by the record that names it and never re-mints a retired one; the bus's /send relayed path end to end through the handler with a fake request (header, row, inbox read); the relay leg carries the mark and answers with an id and no `to`, the far side delivers it marked, a held one keeps its mark; the postal deliver marks a relayed question in the header and the row; a manager with unread mail is not yet failing to answer, an idle manager's turn ending without an answer escalates, an ordinary peer keeps the ladder. On the base, every test fails or errors at setUp (the fixture reads the new delegate map and the postal flag).

Acceptance on read-only copies of the live stores, at the time of the last count: of 4 standing closer or planner blocks, 1 resolves to a delegating peer through the delegate mail and would relay (a session's toward the triage session that delegated to it); the other 3 stay the user's. Earlier counts the same day read 5 standing with 3 relaying and 3 with 1, as sessions cleared their waits; every relaying block reached the peer only through the delegate mail, none through a planted origin.

Tier: feature
