### PR TITLE
The composer's placeholder paints the session's name at an inactive tab label's fade, its host prefix fading with it

### DIFF
--- a/tests/test_composer_placeholder_remote_served.py
+++ b/tests/test_composer_placeholder_remote_served.py
@@ -80,13 +80,17 @@ const measure = () => page.evaluate(() => {
   return { active: tab ? tab.dataset.id : null, tabLabel: tab ? (tab.querySelector(".tab-label") || tab).textContent : null,
            tabHost: dress(tab && tab.querySelector(".tab-label .host-prefix")), tabBg: tab ? tab.style.getPropertyValue("--chip-bg") : null,
            phText: ph ? ph.textContent : null, phHost: dress(ph && ph.querySelector(".host-prefix")), phHostInsideName: !!(nm && nm.querySelector(".host-prefix")),
-           phName: dress(nm), phNameColor: nm ? nm.style.color : null, nativePlaceholder: ta ? ta.placeholder : null,
+           phName: dress(nm), phNameColor: nm ? nm.style.color : null, phFaded: !!ph && ph.classList.contains("name-faded"),
+           bodyBg: getComputedStyle(document.body).backgroundColor, nativePlaceholder: ta ? ta.placeholder : null,
            theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
 });
 const out = {};
 out.dark = await measure();
 if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-composer-remote-host-dark.png", fullPage: false }); }
 await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(300);
+// the overlay's name colour is computed against the page background at paint time (T335): a keystroke and its undo repaint
+// it under the light theme, as any edit of the box would
+await page.focus("#composer-input"); await page.keyboard.type("x"); await page.keyboard.press("Backspace"); await page.waitForTimeout(300);
 out.light = await measure();
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-composer-remote-host-light.png", fullPage: false });
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
@@ -237,7 +241,20 @@ class ServedComposerPlaceholderRemoteHost(unittest.TestCase):
             self.assertEqual(m["phHost"]["style"], "italic"); self.assertEqual(m["phHost"]["weight"], "400", "the host is quiet, not bold")
             self.assertEqual(m["phName"]["text"], "api", "only the name is the bold run: %r" % m["phName"])
             self.assertEqual(m["phName"]["weight"], "600")
-            self.assertEqual(m["phNameColor"], "rgb(100, 181, 246)", "…in the session's identity colour (the tab's --chip-bg): %r / %r" % (m["phNameColor"], m["tabBg"]))
+            # …in the session's identity colour at an at-rest tab label's fade (T335): every channel moved from the identity
+            # colour toward the page background, never the full colour, and the overlay carries the strip's at-rest class so
+            # the host span fades with the name (the exact level is proven against a real at-rest label in
+            # tests/test_session_name_served.py)
+            rgb = lambda c: tuple(int(x) for x in re.findall(r"\d+", c or "")[:3])
+            ident, name, bg = (100, 181, 246), rgb(m["phNameColor"]), rgb(m["bodyBg"])
+            if theme == "dark":
+                self.assertNotEqual(name, ident, "faded, not the full identity colour: %r" % m["phNameColor"])
+            else:
+                self.assertEqual(name, ident, "the light theme: the strip's fade is a no-op on a light page, so the name keeps its colour: %r" % m["phNameColor"])
+            for i in range(3):
+                lo, hi = sorted((ident[i], bg[i]))
+                self.assertTrue(lo <= name[i] <= hi, "channel %d of the name lies between the identity colour and the page background in %s: %r %r %r" % (i, theme, ident, name, bg))
+            self.assertTrue(m["phFaded"], "the overlay carries the strip's at-rest class")
             self.assertNotEqual(m["phHost"]["color"], m["phNameColor"], "the host does not wear the identity colour")
             self.assertTrue((m["nativePlaceholder"] or "").startswith("Message this session"), "the native placeholder beneath stays the plain resting text for assistive tech")
 

--- a/tests/test_session_name_served.py
+++ b/tests/test_session_name_served.py
@@ -1,5 +1,9 @@
 """The chat names the session it messages (the user 2026-09-09), in a real browser against a hermetic kernel: the composer's
 resting placeholder reads "Message <name>…" with the name bold in the session's identity colour and follows the active tab;
+since T335 (the user 2026-09-10) the name is painted at an INACTIVE tab label's level: the strip's own perceptual fade of the
+identity colour, so it sits with the faded placeholder text; this test reads the same session's at-rest label colour once the
+tab is inactive and requires the placeholder's name colour to equal it, dark and light (PH_SHOTS=<dir> writes screenshots of
+the box under the strip; PH_BEFORE_DIST=<dist> serves another tree's bundle for the before shots and skips the fade checks);
 the statusline badge (the name in black on that colour) is a SETTING, off by default (the maintainers via the user,
 2026-09-10), and a flip of the setting shows it and hides it again without a reload. Skips LOUDLY when the extension deps
 or a playwright browser are absent (CI installs none). Synthetic sessions and text only."""
@@ -83,10 +87,17 @@ const naming = () => page.evaluate(() => {
   const tab = d.querySelector("#tabs .tab.active[data-id]"); const tabBg = tab ? tab.style.getPropertyValue("--chip-bg") : null;
   const ta = d.getElementById("composer-input"); const ph = d.getElementById("composer-ph"); const nm = ph && ph.querySelector(".composer-ph-name");
   const badge = d.querySelector("#statusline .chip-session");
+  // every tab's label as painted: the inline colour (the at-rest fade, fadedColor, or none while active) and the at-rest class
+  const tabs = Array.from(d.querySelectorAll("#tabs .tab[data-id]")).map((t) => { const l = t.querySelector(".tab-label");
+    return { id: t.dataset.id, active: t.classList.contains("active"), labelColor: l ? l.style.color : null, labelComputed: l ? getComputedStyle(l).color : null, faded: !!l && l.classList.contains("name-faded") }; });
   return { active: tab ? tab.dataset.id : null, tabBg, phShown: !!ph && getComputedStyle(ph).display !== "none", phName: nm ? nm.textContent : null,
-           phColor: nm ? nm.style.color : null, phBold: nm ? getComputedStyle(nm).fontWeight : null, nativeHidden: !!ta && ta.classList.contains("ph-on"),
+           phColor: nm ? nm.style.color : null, phComputed: nm ? getComputedStyle(nm).color : null, phBold: nm ? getComputedStyle(nm).fontWeight : null,
+           phFaded: !!ph && ph.classList.contains("name-faded"), nativeHidden: !!ta && ta.classList.contains("ph-on"), tabs,
+           theme: d.body.classList.contains("theme-light") ? "light" : "dark",
            badgeText: badge ? badge.textContent : null, badgeBg: badge ? badge.style.background : null, badgeFg: badge ? getComputedStyle(badge).color : null };
 });
+const shot = async (name) => { if (!cfg.shots) return; fs.mkdirSync(cfg.shots, { recursive: true }); const box = await (await page.$("#f-chat")).boundingBox();
+  await page.screenshot({ path: cfg.shots + "/" + name + (cfg.shotSuffix || "") + ".png", clip: { x: box.x, y: box.y, width: box.width, height: box.height } }); };
 const setBadge = (on) => page.evaluate((on) => { const s = JSON.parse(localStorage.getItem("romp:settings") || "{}"); s.showSessionBadge = on; localStorage.setItem("romp:settings", JSON.stringify(s)); }, on);
 const badgeIs = (want, why) => waitFn((want) => !!document.getElementById("f-chat").contentDocument.querySelector("#statusline .chip-session") === want, want, why);
 
@@ -96,10 +107,26 @@ const fr = await (await page.$("#f-chat")).contentFrame();
 await fr.click('#tabs .tab[data-id="' + cfg.sidA + '"]'); await waitActive(cfg.sidA);
 await waitFn(() => { const d = document.getElementById("f-chat").contentDocument; const ph = d.getElementById("composer-ph"); return !!(ph && ph.querySelector(".composer-ph-name")); }, null, "the placeholder overlay never named the session");
 out.a = await naming();
+await page.mouse.move(700, 500); await page.waitForTimeout(300);   // off the strip: no hover un-fade, no tooltip in the shot
+await shot("romp_chat-composer-name-fade-dark");
 // the other tab: the placeholder follows the active session
 await fr.click('#tabs .tab[data-id="' + cfg.sidB + '"]'); await waitActive(cfg.sidB);
 await waitFn((b) => { const d = document.getElementById("f-chat").contentDocument; const nm = d.querySelector("#composer-ph .composer-ph-name"); return !!nm && nm.textContent !== b; }, out.a.phName, "the placeholder never followed the tab switch");
 out.b = await naming();
+// the light theme (T335): the fade blends toward the page background, so both the strip and the overlay repaint under it on
+// the next tab pick; A read again while active (its name in the box) and while inactive (its label), as in the dark pass
+await page.evaluate(() => { document.getElementById("f-chat").contentDocument.body.classList.add("theme-light"); });
+await fr.click('#tabs .tab[data-id="' + cfg.sidA + '"]'); await waitActive(cfg.sidA);
+await waitFn((a) => { const d = document.getElementById("f-chat").contentDocument; const nm = d.querySelector("#composer-ph .composer-ph-name"); return !!nm && nm.textContent === a; }, out.a.phName, "the placeholder never named A again under the light theme");
+await page.mouse.move(700, 500); await page.waitForTimeout(300);
+out.aLight = await naming();
+await shot("romp_chat-composer-name-fade-light");
+await fr.click('#tabs .tab[data-id="' + cfg.sidB + '"]'); await waitActive(cfg.sidB);
+await waitFn((b) => { const d = document.getElementById("f-chat").contentDocument; const nm = d.querySelector("#composer-ph .composer-ph-name"); return !!nm && nm.textContent === b; }, out.b.phName, "the placeholder never followed to B under the light theme");
+out.bLight = await naming();
+await page.evaluate(() => { document.getElementById("f-chat").contentDocument.body.classList.remove("theme-light"); });
+await fr.click('#tabs .tab[data-id="' + cfg.sidA + '"]'); await waitActive(cfg.sidA);
+await fr.click('#tabs .tab[data-id="' + cfg.sidB + '"]'); await waitActive(cfg.sidB);   // back to B, dark, for the badge legs below
 // the badge: off by default; a flip of the setting (from the shell, as a gear save in another pane lands) shows it, and back
 await setBadge(true);
 await badgeIs(true, "the badge never came up after the setting was switched on");
@@ -133,14 +160,25 @@ class ServedSessionName(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:          # a skip OR a failure: never leave a kernel or a lab behind
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
         if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
             raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served leg needs them")
         cls.lab = tempfile.mkdtemp(prefix="session-name-")
-        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
-        if b.returncode != 0:
-            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        # PH_BEFORE_DIST=<dir>: a dist built from another tree (the screenshots' "before"); the fade checks are skipped for that run
+        cls.before = os.environ.get("PH_BEFORE_DIST", "")
+        if not cls.before:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
         dist = os.path.join(cls.lab, "dist")
-        copy_dist(os.path.join(EXT, "dist"), dist)
+        copy_dist(cls.before or os.path.join(EXT, "dist"), dist)
         state = os.path.join(cls.lab, "xdg", "romp")
         cwd = os.path.join(cls.lab, "proj")
         os.makedirs(os.path.join(state, "names"), exist_ok=True)
@@ -151,8 +189,12 @@ class ServedSessionName(unittest.TestCase):
         os.makedirs(proj, exist_ok=True)
         # two synthetic SDK sessions with closed-turn transcripts (nothing is ever resumed or spawned), each with an identity
         # colour in the registry (the third field): the name in the placeholder and on the badge wears it
+        os.makedirs(os.path.join(state, "states"), exist_ok=True)
         for sid, name, color in ((SID_A, "web", "#e57373"), (SID_B, "api", "#64b5f6")):
             Path(state, "names", sid).write_text("%s\t%s\t%s\t\n" % (name, cwd, color))
+            # idle for two hours (the last states row's time is a dormant session's idle-since): past the faded threshold, so
+            # an INACTIVE tab's label wears the strip's at-rest fade, the level the placeholder's name is measured against (T335)
+            Path(state, "states", sid + ".jsonl").write_text(json.dumps({"t": int(time.time()) - 7200, "state": "waiting"}) + "\n")
             Path(state, "sdk", sid + ".json").write_text(json.dumps(
                 {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True}))
             Path(proj, sid + ".jsonl").write_text(_transcript(sid, cwd, 3))
@@ -192,7 +234,8 @@ class ServedSessionName(unittest.TestCase):
     def _drive(cls):
         cfg = os.path.join(cls.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (cls.port, cls.token), "sidA": SID_A, "sidB": SID_B}, f)
+            json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (cls.port, cls.token), "sidA": SID_A, "sidB": SID_B,
+                       "shots": os.environ.get("PH_SHOTS", ""), "shotSuffix": "-before" if cls.before else ""}, f)
         driver = os.path.join(cls.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)
@@ -249,7 +292,7 @@ class ServedSessionName(unittest.TestCase):
             return "rgb(%d,%d,%d)" % tuple(int(c[i:i + 2], 16) for i in (1, 3, 5))
         return c
 
-    def test_1_the_placeholder_names_the_active_session_bold_in_its_colour_and_follows_the_tab(self):
+    def test_1_the_placeholder_names_the_active_session_bold_at_an_inactive_labels_fade_and_follows_the_tab(self):
         r = self._r(); a, b = r["a"], r["b"]
         self.assertEqual((a["active"], a["phName"]), (SID_A, "web"))
         self.assertEqual((b["active"], b["phName"]), (SID_B, "api"), "the placeholder follows the active tab")
@@ -257,9 +300,26 @@ class ServedSessionName(unittest.TestCase):
             self.assertTrue(c["phShown"], "an empty box shows the overlay")
             self.assertTrue(c["nativeHidden"], "…and the native placeholder is transparent beneath it")
             self.assertTrue(c["tabBg"], "the active tab wears the identity colour")
-            self.assertEqual(self._rgb(c["phColor"]), self._rgb(c["tabBg"]), "the name wears the tab's colour")
-            self.assertIn(c["phBold"], ("600", "700", "bold"))
+            self.assertIn(c["phBold"], ("600", "700", "bold"), "the weight stays")
         self.assertNotEqual(a["tabBg"], b["tabBg"], "two sessions, two colours")
+        if self.before:
+            self.skipTest("a before-the-change dist: screenshots only, the fade checks describe the change")
+        # T335: the name's colour is the SAME session's at-rest label colour (the strip's perceptual fade), read off A's label
+        # once B is active, dark and light; not the full identity colour it wore before
+        for act, rest, theme in ((a, b, "dark"), (r["aLight"], r["bLight"], "light")):
+            self.assertEqual((act["theme"], rest["theme"]), (theme, theme))
+            restA = next(t for t in rest["tabs"] if t["id"] == SID_A)
+            self.assertFalse(restA["active"]); self.assertTrue(restA["faded"], "A's tab is at rest and faded in %s: %r" % (theme, restA))
+            self.assertTrue(restA["labelColor"], "the at-rest label carries the computed fade inline: %r" % restA)
+            self.assertEqual(self._rgb(act["phColor"]), self._rgb(restA["labelColor"]), "the box names A at A's inactive label colour in %s: %r vs %r" % (theme, act["phColor"], restA))
+            self.assertEqual(act["phComputed"], restA["labelComputed"], "…and the computed inks agree")
+            self.assertTrue(act["phFaded"], "the overlay carries the strip's at-rest class, so a remote host's prefix would fade with the name")
+            if theme == "dark":
+                self.assertNotEqual(self._rgb(act["phColor"]), self._rgb(act["tabBg"]), "faded, not the full identity colour, in the dark theme")
+            else:
+                # the strip's fade blends toward a LOW luminance target (fadedColor), which a light page already exceeds, so an
+                # at-rest label keeps its full colour there by the strip's own rule; the box matches that, whatever it is
+                self.assertEqual(self._rgb(act["phColor"]), self._rgb(act["tabBg"]), "the light theme: the strip's at-rest label is unfaded, and so is the box's name")
 
     def test_2_the_badge_is_off_by_default_and_a_flip_of_the_setting_shows_it_and_hides_it_live(self):
         r = self._r(); a, b, on, off = r["a"], r["b"], r["bOn"], r["bOff"]

--- a/ui/webview/composer-placeholder.test.ts
+++ b/ui/webview/composer-placeholder.test.ts
@@ -50,7 +50,7 @@ test("render.ts: the overlay mirrors the placeholder, wears the identity colour,
   assert.match(fn, /const parts = phParts\(ta\.placeholder, live\?\.name \|\| meta\?\.name \|\| "", activeId\);/, "the sid rides along: a remote host's prefix is told from the name by the sid (host-prefix.ts)");
   // T328: the host is the tab label's own quiet span (hostNameNodes: .host-prefix, marked when the host is down), a
   // sibling of the bold name, never inside it
-  assert.match(fn, /if \(parts\.host\) \{[\s\S]*?ph\.appendChild\(hostNameNodes\(parts\.host \+ parts\.name, activeId\)\[0\]\);\s*\n\s*\}\s*\n\s*const nm = el\("b", "composer-ph-name"\); nm\.textContent = parts\.name;/);
+  assert.match(fn, /if \(parts\.host\) \{[\s\S]*?ph\.appendChild\(hostNameNodes\(parts\.host \+ parts\.name, activeId\)\[0\]\);\s*\n\s*\}\s*\n(\s*\/\/[^\n]*\n)*\s*const nm = el\("b", "composer-ph-name"\); nm\.textContent = parts\.name;/);
   assert.doesNotMatch(CSS, /#composer-ph \.host-prefix/, "no dress of the overlay's own for the host: the global .host-prefix rule, the tab label's, is the one");
   // the host's link dropping or returning flips the span's .off mark on the tab (the romp-hosts event, host-offline.test.ts);
   // the overlay's span is repainted on the same event, so the two never disagree until the next keystroke
@@ -58,7 +58,16 @@ test("render.ts: the overlay mirrors the placeholder, wears the identity colour,
   assert.match(fn, /parts\.kind === "named" && !ta\.value/, "the styled form only for the resting placeholder, only while the box is empty");
   assert.match(fn, /ta\.classList\.toggle\("ph-on", show\);/, "the native placeholder goes transparent beneath the overlay");
   assert.match(fn, /const colorBg = \(live\?\.color\?\.bg \|\| meta\?\.color\?\.bg\) \|\| null;/, "the identity colour: the live session's, else the strip's own word on the tab (a skeleton's), never a stale session (skeleton-tabs-wiring)");
-  assert.match(fn, /if \(colorBg\) nm\.style\.color = colorBg; else nm\.style\.removeProperty\("color"\);/, "the name wears the session's identity colour — the tab label's");
+  // T335 (the user 2026-09-10): the name is painted at an INACTIVE tab label's level, the strip's own perceptual fade of the
+  // identity colour (fadedColor, what an at-rest tab wears), so it sits with the faded placeholder text instead of outshining
+  // it; the weight stays; the host span fades in tandem through the strip's .name-faded class carried by the overlay
+  assert.match(fn, /if \(colorBg\) nm\.style\.color = fadedColor\(colorBg\); else nm\.style\.removeProperty\("color"\);/, "the name wears the session's identity colour at the at-rest tab label's fade");
+  assert.match(fn, /ph\.classList\.add\("name-faded"\);/, "the overlay carries the strip's at-rest class, once, at its making");
+  assert.match(RENDER, /^function fadedColor\(hex: string\): string \{/m, "…the one fade rule, the strip's (bright hues fade as far as dim ones)");
+  // the fade reads the page background live, so the overlay re-syncs on the strip's REBUILD (the event that repaints every
+  // at-rest label's fade), beside the tip hide: a host-rewritten background reaches the box when it reaches the strip
+  const tabs = RENDER.slice(RENDER.indexOf("function renderTabs() {"), RENDER.indexOf("function stripAftermath("));
+  assert.match(tabs, /tabStripSig = stripSig;\s*\n(\s*\/\/[^\n]*\n)*\s*hideTabTip\(\);\s*\n(\s*\/\/[^\n]*\n)*\s*syncComposerPh\(\);/, "the strip's rebuild re-syncs the overlay");
   assert.match(fn, /el\("b", "composer-ph-name"\)/, "…bold");
   // re-synced by the value and placeholder writers: growth after a value write, the active-tab show, a rename or
   // a recolour of the active session, the ask-mode placeholder swap, the width refit and every keystroke
@@ -81,6 +90,8 @@ test("render.ts: the overlay mirrors the placeholder, wears the identity colour,
 test("styles.css: the overlay sits over the box, dim like a placeholder, the name bold; the native placeholder is transparent while it shows", () => {
   assert.match(CSS, /#composer-ph \{ position: absolute; pointer-events: none; color: var\(--dim\);/);
   assert.match(CSS, /#composer-ph \.composer-ph-name \{ font-weight: 600; \}/);
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: 0\.5; \}/m, "the host prefix fades by the strip's own rule wherever the class is carried (T335)");
+  assert.doesNotMatch(CSS, /#composer-ph[^\n]*opacity/, "no opacity of the overlay's own: the fade is the colour the strip computes");
   assert.match(CSS, /#composer-input\.ph-on::placeholder \{ color: transparent; \}/);
   // the question flow (the user 2026-09-10): the answering tint rule sits at that rule's specificity and came later, so
   // both texts showed — the overlay takes the tint, the native placeholder stays transparent under it

--- a/ui/webview/host-offline.test.ts
+++ b/ui/webview/host-offline.test.ts
@@ -85,6 +85,11 @@ test("the mark goes on the HOST token, never on the session name", () => {
   // (2026-07-30: the cue became the STALE treatment — dim italic, dotted underline — because
   // strikethrough claimed the session was gone when it is the LINK that is down. See host-offline-ux.)
   assert.match(CSS, /\.host-prefix\.off \{[\s\S]*?text-decoration: underline dotted 1px/);
+  // the two rules that both set the token's opacity (T335 review): the at-rest fade (0.5) and this cue (0.75). The fade wins
+  // by SPECIFICITY through its compound selector, whatever their order in the sheet: an at-rest label on a down host fades
+  // with its name and still wears the cue's italic and dotted underline
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: 0\.5; \}/m, "the fade names the .off token too");
+  assert.match(CSS, /^\.host-prefix\.off \{\s*\n\s*opacity: 0\.75;/m, "the cue keeps its own opacity for an active label's token");
   assert.match(FEEDCSS, /\.host-prefix\.off \{[\s\S]*?text-decoration: underline dotted 1px/,
     "the feed page loads only feed.css");
 });

--- a/ui/webview/host-prefix.test.ts
+++ b/ui/webview/host-prefix.test.ts
@@ -68,7 +68,7 @@ test("the host prefix FADES in tandem with the name it precedes (the user 2026-0
   assert.match(RENDER, /label\.classList\.add\("name-faded"\)/);
   assert.match(RENDER, /mouseenter", \(\) => \{ label\.style\.color = full; label\.classList\.remove\("name-faded"\); \}/);
   assert.match(RENDER, /mouseleave", \(\) => \{ label\.style\.color = fadedColor\(full\); label\.classList\.add\("name-faded"\); \}/);
-  assert.match(CSS, /\.tab-label\.name-faded \.host-prefix \{ opacity: 0\.5; \}/);
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: 0\.5; \}/m, "one rule for both carriers of the class: the tab label and the composer's name overlay (T335)");
   // TIMELINE: the SVG twin — a tspan's own fill beats the parent <text>, so fade it explicitly and
   // register it for the same hover un-fade the name uses
   assert.match(TL, /hostTsp = el\('tspan', \{ fill: F\(MODEL_FG\)/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5967,6 +5967,10 @@ function renderTabs() {
   // 2026-09-10: its screenshots caught the tip after every pick). The rebuild is the event: hide it here, once, before
   // the nodes go.
   hideTabTip();
+  // the rebuild repaints every at-rest label's fade against the page background as it stands (fadedColor reads it live),
+  // and the composer's name overlay wears that same fade (T335): re-sync it on the same event, so a background the host
+  // rewrote (a VS Code colour-theme switch, which fires no romp event) reaches the box when it reaches the strip
+  syncComposerPh();
   // Preserve TAB-MODE keyboard focus across the rebuild (the user 2026-06-29). renderTabs runs on EVERY kernel
   // push (0.5–3s), and replaceChildren() destroys the focused tab — dropping focus out of the strip (often out
   // of the chat iframe entirely), which silently killed ←/→/Enter nav after a send or any push: you were left
@@ -13046,6 +13050,7 @@ function syncComposerPh(): void {
   let ph = document.getElementById("composer-ph");
   if (!ph) {
     ph = el("div", ""); ph.id = "composer-ph"; ph.setAttribute("aria-hidden", "true"); box.appendChild(ph);
+    ph.classList.add("name-faded");   // the strip's at-rest class: a remote host's prefix fades with the name it precedes (styles.css .name-faded .host-prefix; T335)
     // The box's LAYOUT moves the textarea too, not only its value: a quote chip seeded by a highlight, a dropped
     // file or a staged note adds a row above it (the user 2026-09-10: the name overlay sat on top of the chip
     // row). Every such change resizes #composer, so its ResizeObserver re-places the overlay — event-based,
@@ -13071,8 +13076,11 @@ function syncComposerPh(): void {
     // the quiet .host-prefix span, marked when the host's link is down, and only the name below is bold and coloured
     ph.appendChild(hostNameNodes(parts.host + parts.name, activeId)[0]);
   }
+  // the name at an INACTIVE tab label's level (T335, the user 2026-09-10: it stood out brighter than every other word of
+  // the faded placeholder): the strip's own perceptual fade of the identity colour (fadedColor, what an at-rest tab's
+  // label wears), the weight kept; the host span fades in tandem through the strip's own class on the overlay
   const nm = el("b", "composer-ph-name"); nm.textContent = parts.name;
-  if (colorBg) nm.style.color = colorBg; else nm.style.removeProperty("color");
+  if (colorBg) nm.style.color = fadedColor(colorBg); else nm.style.removeProperty("color");
   ph.appendChild(nm);
   ph.appendChild(document.createTextNode(parts.after));
   // where the box's own first line sits: inside its border and padding, in its font (offsets are relative to

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3338,8 +3338,13 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 /* ...but it must FADE with the name it precedes. Because the rule above is a declaration on the child,
    the at-rest tab's inline faded color can't inherit into it, so a remote session's "host:" stayed bright
    while its name dimmed (the user 2026-07-22). renderTabs adds .name-faded whenever it applies the faded
-   name color, and drops it on hover, so the two always move together. */
-.tab-label.name-faded .host-prefix { opacity: 0.5; }
+   name color, and drops it on hover, so the two always move together. The composer's name overlay wears the
+   class too (#composer-ph, T335): its name is painted at the at-rest label's faded colour, so its host fades
+   by this same rule; one selector for both carriers, never two values. The compound second selector keeps the
+   fade WINNING over the stale-link cue below (.host-prefix.off, opacity 0.75) by specificity, as the scoped
+   rule did before: an at-rest label on a down host fades with its name, and the cue's italic and dotted
+   underline still show. A state rule wins the cascade by construction, never by order. */
+.name-faded .host-prefix, .name-faded .host-prefix.off { opacity: 0.5; }
 /* DISCONNECTED host (the user 2026-07-29): its sessions keep their tabs, lanes and cards — dropping them
    would lose the thread — but the "host:" token says the link is down, so nobody reads a frozen transcript
    thinking it is live. Struck + dimmed, the strike on the HOST only: a struck WHOLE name already means a

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -124,7 +124,7 @@ function lift(): (hooks: Hooks) => Api {
       H.heads.push({ name: sec.name, color: sec.color, ids: sec.ids.slice(), folded, active, hidden: hidden.slice() });
       return h;
     }
-    const onTabKey = () => {}; const dragImageBlank = () => el("div"); const hideTabTip = () => {}; const snapshotDragGeometry = () => {};
+    const onTabKey = () => {}; const dragImageBlank = () => el("div"); const hideTabTip = () => {}; const syncComposerPh = () => {}; const snapshotDragGeometry = () => {};   // syncComposerPh: the rebuild re-syncs the composer's name overlay (T335), inert here
     const flipTabs = (f) => f(); const applyCompactSweep = () => {};
     const hostNameNodes = (name) => [document.createTextNode(name)]; const fadedColor = (h) => h;
     const tabCtxGauge = () => el("span", "tab-ctx"); const pickTone = (a, b) => b ?? a;


### PR DESCRIPTION
The user (2026-09-10, screenshot): in the message box the session's name stood out at full brightness in its identity colour, and a remote session's host prefix bright too, beside the faded grey hint around them; the name should sit at the level an inactive tab's label has in the tab strip.

**Root cause.** `syncComposerPh` painted the bold name in the raw identity colour, while the strip paints an at-rest tab's label through `fadedColor` (its perceptual blend of the identity colour toward the page background) and fades the label's host prefix through the `.name-faded` class.

**Fix.** The overlay uses the strip's own two rules: the name's inline colour is `fadedColor(identity)`, the weight kept, and the overlay carries the `name-faded` class, so its host span fades by the same declaration as a tab label's; that declaration loses its `.tab-label` scoping (`.name-faded .host-prefix`), one selector for both carriers, never two values. Nothing else in the placeholder changes.

**Manager's review.** Unscoping alone had left the fade rule tied with the stale-link cue (`.host-prefix.off`, opacity 0.75) and the cue winning by order on a down host; the fade now wins by specificity through a compound second selector (`.name-faded .host-prefix.off`), as the scoped rule did, so an at-rest label on a down host fades with its name and still wears the cue's italic and dotted underline; `host-offline.test.ts` pins both competing rules. The session-name served test's boot is wrapped so a skip or a failure tears the lab down.

**Lean review.** The overlay's fade reads the page background live, so `renderTabs` re-syncs the overlay at the strip's rebuild (the event that repaints every at-rest label's fade), beside the tip hide: a background the host rewrote (a VS Code colour-theme switch, which fires no romp event) reaches the box when it reaches the strip; pinned in `composer-placeholder.test.ts`.

**Light theme.** By the strip's own rule the fade is a no-op on a light page (it blends toward a low luminance target a light page already exceeds), so there an at-rest label and the box's name both keep the full colour; the light screenshots are unchanged by design.

**Tests.** `composer-placeholder.test.ts` pins the faded colour, the class on the overlay, the shared rule and no opacity of the overlay's own; `host-prefix.test.ts` follows the rule's new selector. `tests/test_session_name_served.py` gives the lab's sessions an idle-since two hours old (so an inactive tab is faded, as the user's are), reads every tab label's painted colour and requires the placeholder's name colour to equal the same session's at-rest label colour once its tab is inactive, dark and light (fails with the fade removed), with screenshots and a before-dist hook. `tests/test_composer_placeholder_remote_served.py` checks the name lies between the identity colour and the page background and that the overlay carries the class.

Locally: typecheck clean; the placeholder, host-prefix, host-offline, strip and stylesheet tests green (69); the served pair green (4). Full suites running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
