### PR TITLE
Postal cards: evenly spread kind colours and the circled-check delivery marks

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -293,9 +293,9 @@
   font-weight: 400;
   white-space: nowrap;
 }
-.romp-kind-delegate   { color: #90badd; }   /* delegation: a peer handed off work */
-.romp-kind-coordinate { color: #5d92bc; }   /* coordination: a heads-up */
-.romp-kind-question   { color: #c3e3fd; }   /* question: an answer is needed */
+.romp-kind-delegate   { color: #7cb5e3; }   /* delegation: a peer handed off work */
+.romp-kind-coordinate { color: #5696c8; }   /* coordination: a heads-up */
+.romp-kind-question   { color: #a2d4fe; }   /* question: an answer is needed */
 
 /* ── Mermaid legibility ───────────────────────────────────────────────
    Every node in our diagrams carries an explicit LIGHT fill (the classDef

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -293,9 +293,9 @@
   font-weight: 400;
   white-space: nowrap;
 }
-.romp-kind-delegate   { color: #7fb8e7; }   /* delegation: a peer handed off work */
-.romp-kind-coordinate { color: #7996af; }   /* coordination: a heads-up */
-.romp-kind-question   { color: #91d9ff; }   /* question: an answer is needed */
+.romp-kind-delegate   { color: #90badd; }   /* delegation: a peer handed off work */
+.romp-kind-coordinate { color: #5d92bc; }   /* coordination: a heads-up */
+.romp-kind-question   { color: #c3e3fd; }   /* question: an answer is needed */
 
 /* ── Mermaid legibility ───────────────────────────────────────────────
    Every node in our diagrams carries an explicit LIGHT fill (the classDef

--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -2,9 +2,10 @@
 """T302 (the user 2026-09-10): the postal cards in the chat pane, rendered by the real /chat page of a hermetic
 kernel over a synthetic chat with web (the viewed session), api and tests (its peers) — every state at once.
 
-Asserted on the page: the interaction KIND is coloured text (Delegation / Coordination / Question in the old chip
-colours), never a chip; the DELIVERY STATE is one icon per state at the head's right edge with a worded title
-(delivered, read, parked, bounced, recalled, and sent for a message handed to the relay), from what the kernel
+Asserted on the page: the interaction KIND is coloured text (Delegation / Coordination / Question, three positions
+sampled evenly along one line in the accent's hue, T337), never a chip; the DELIVERY STATE is one icon per state at the
+head's right edge with a worded title (delivered, read, parked, bounced, recalled, and sent for a message handed to the
+relay; sent / delivered / read as the circled-check ladder, the read check cut out in the page colour, T337), from what the kernel
 files (the send-time stamp, and the postal ledger's exec / relayed / bounced / recall rows joined by message id);
 both ENDS wear their sessions' colours (the peer's chip, then this session's own chip); no card wears a background
 wash; incoming cards are boxed, sent ones slim unless a fold boxes them; a sent card whose message has not landed wears
@@ -207,6 +208,12 @@ const measure = () => page.evaluate(() => {
       kindWithOrBelowEnds: kw && ends ? kw.top >= ends.getBoundingClientRect().top - 2 : null,
       gistBelowKind: kw && t.querySelector(".notice-gist") ? t.querySelector(".notice-gist").getBoundingClientRect().top >= kw.bottom - 2 : null,
       chip: !!t.querySelector(".notice-chip, .postal-service-intent"),
+      // the mark's drawing as the browser computes it (T337): the circled-check ladder, its box, its stroke, its colours
+      mark: icon ? (() => { const svg = icon.querySelector("svg"), c = icon.querySelector("circle"), p = icon.querySelector("path");
+        return { size: svg ? Math.round(svg.getBoundingClientRect().width) : null, strokeWidth: svg ? svg.getAttribute("stroke-width") : null,
+                 circles: icon.querySelectorAll("circle").length, paths: icon.querySelectorAll("path").length,
+                 circleFill: c ? getComputedStyle(c).fill : null, checkStroke: p ? getComputedStyle(p).stroke : null,
+                 checkClass: p ? (p.getAttribute("class") || "") : null, colour: getComputedStyle(icon).color }; })() : null,
       state: icon ? icon.dataset.state : null, title: icon ? (icon.getAttribute("aria-label") || "") : null,
       iconRight: icon && n ? Math.round(n.getBoundingClientRect().right - icon.getBoundingClientRect().right) : null,
       peerText: peer ? peer.textContent : null, peerBg: peer ? getComputedStyle(peer).backgroundColor : null,
@@ -382,8 +389,9 @@ class ServedPostalCards(unittest.TestCase):
             else:
                 self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
             self.assertFalse(c["chip"], "no chip: %r" % c)
-        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(127, 184, 231)", "delegation: the ramp's middle step (T320)")
-        self.assertEqual(card("Heads-up")["kindColor"], "rgb(121, 150, 175)", "coordination: the ramp's low step (T320)")
+        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(144, 186, 221)", "delegation: the line's middle position (T320, re-sampled T337)")
+        self.assertEqual(card("Heads-up")["kindColor"], "rgb(93, 146, 188)", "coordination: the line's start (T320, re-sampled T337)")
+        self.assertEqual(card("Which cap")["kindColor"], "rgb(195, 227, 253)", "question: the line's end (T337)")
         # (2) the delivery icon per state, at the head's right edge, with a worded title
         states = {c["gist"][:20]: c["state"] for c in cards}
         self.assertIsNone(card("Take the retry-loop")["state"], "an incoming message in hand: no icon")
@@ -406,6 +414,27 @@ class ServedPostalCards(unittest.TestCase):
                 self.assertLessEqual(c["iconRight"], 16, "the icon sits at the head's right edge: %r" % c)
         kindless = card(KINDLESS[:20])
         self.assertEqual(kindless["state"], "delivered", "the legacy card still shows its delivery state: %r" % kindless)
+        # (2b) T337 (the user 2026-09-10, who wanted the circled check messaging apps draw): sent is the hollow circle,
+        # delivered the circle with the check, read the filled circle with the check cut out in the page colour, all three
+        # in the STATE colour (dim, dim, the accent), never the kind word's; one 14 px box, a 1.5 stroke, one circle
+        sent, deliv, read = card("The remote build")["mark"], card("The backoff branch")["mark"], card("Did the fixtures")["mark"]
+        for m in (sent, deliv, read):
+            self.assertEqual((m["size"], m["strokeWidth"], m["circles"]), (14, "1.5", 1), "one circle in a 14 px box with a 1.5 stroke: %r" % m)
+        self.assertEqual((sent["paths"], sent["circleFill"]), (0, "none"), "sent: the hollow circle alone: %r" % sent)
+        self.assertEqual((deliv["paths"], deliv["circleFill"], deliv["checkClass"]), (1, "none", "postal-mark-check"), "delivered: the hollow circle with the check: %r" % deliv)
+        self.assertEqual(deliv["checkStroke"], deliv["colour"], "delivered: the check in the mark's own colour: %r" % deliv)
+        self.assertEqual(sent["colour"], deliv["colour"], "sent and delivered share the dim colour: %r %r" % (sent, deliv))
+        self.assertEqual((read["paths"], read["checkClass"]), (1, "postal-mark-check"), "read: the check…: %r" % read)
+        self.assertEqual(read["circleFill"], read["colour"], "…on the circle filled in the state colour: %r" % read)
+        self.assertEqual(read["colour"], "rgb(156, 210, 255)", "the read colour is the accent, as before (the state colour, never the kind's): %r" % read)
+        self.assertEqual(read["checkStroke"], wide["pageBg"], "read: the check cut out in the page colour: %r" % read)
+        self.assertNotEqual(read["colour"], card("Did the fixtures")["kindColor"], "the mark's colour is not the kind word's")
+        lread = next(c for c in light["cards"] if c["gist"].startswith("Did the fixtures"))["mark"]
+        self.assertEqual(lread["circleFill"], "rgb(194, 65, 12)", "light: the read circle in the light accent: %r" % lread)
+        self.assertEqual(lread["checkStroke"], light["pageBg"], "light: the check cut out in the cream page: %r" % lread)
+        self.assertEqual((card("Please run the whole")["mark"]["circles"], card("Please run the whole")["mark"]["paths"]), (1, 1), "parked keeps the clock")
+        self.assertEqual(card("Take the cap decision")["mark"]["paths"], 2, "bounced keeps the cross")
+        self.assertEqual(card("Ignore my last note")["mark"]["paths"], 2, "recalled keeps the return arrow")
         self.assertIn("isolated", card("Take the cap decision")["title"], "a bounce carries its reason")
         # (3) both ends, each in its session's colour; no wash; boxed vs slim
         for c in cards:

--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -220,6 +220,7 @@ const measure = () => page.evaluate(() => {
       selfText: self ? self.textContent : null, selfBg: self ? getComputedStyle(self).backgroundColor : null,
       selfWidth: self ? Math.round(self.getBoundingClientRect().width) : null,
       bg: cs.backgroundColor, border: cs.borderTopStyle, provisional: n.classList.contains("queued-bubble"),
+      opacity: cs.opacity,   // T337: the provisional dress fades by its colours, never by an element opacity
       // the provisional dress at either density: the card's max-width as computed, and the box it actually takes
       maxWidth: cs.maxWidth, width: Math.round(n.getBoundingClientRect().width),
       gist: (t.querySelector(".notice-gist") || {}).textContent || "",
@@ -249,8 +250,11 @@ const contrast = (a, b) => {
 // a boxed card paints --box-bg, an rgba WASH, over the page: the colour the word actually sits on is the composite (the
 // review of 2026-09-10 found the light coordination step at 4.33:1 there while the page read 4.6:1)
 const composite = (washCss, pageCss) => {
-  const nums = (css) => css.match(/\d+(\.\d+)?/g).map(Number);
-  const w = nums(washCss), p = nums(pageCss), a = w.length > 3 ? w[3] : 1;
+  // a wash is rgba(...) or, for a color-mix() the browser resolved, color(srgb r g b / a) with channels in 0..1
+  const nums = (css) => { const m = css.match(/color\(srgb ([\d.]+) ([\d.]+) ([\d.]+)(?: \/ ([\d.]+))?\)/);
+    if (m) return [255 * +m[1], 255 * +m[2], 255 * +m[3], m[4] === undefined ? 1 : +m[4]];
+    const n = css.match(/\d+(\.\d+)?/g).map(Number); return [n[0], n[1], n[2], n.length > 3 ? n[3] : 1]; };
+  const w = nums(washCss), p = nums(pageCss), a = w[3];
   return "rgb(" + [0, 1, 2].map((i) => Math.round(w[i] * a + p[i] * (1 - a))).join(", ") + ")";
 };
 const results = {};
@@ -275,6 +279,8 @@ for (const pass of [{ width: 1000, theme: "dark" }, { width: 520, theme: "dark" 
   await page.waitForTimeout(300);
   const m = await measure();
   const boxOnPage = composite(m.boxBg, m.pageBg);
+  // every kind word against the ground it actually sits on: the page, the box, or the provisional wash (T337)
+  for (const c of m.cards) c.kindContrast = c.kind && c.kindColor ? contrast(c.kindColor, composite(c.bg, m.pageBg)) : null;
   m.contrast = {}; m.contrastOn = {}; m.contrastPage = {};
   for (const k of ["delegate", "coordinate", "question"]) {
     if (!m.kinds[k]) { m.contrast[k] = null; continue; }
@@ -389,9 +395,19 @@ class ServedPostalCards(unittest.TestCase):
             else:
                 self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
             self.assertFalse(c["chip"], "no chip: %r" % c)
-        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(144, 186, 221)", "delegation: the line's middle position (T320, re-sampled T337)")
-        self.assertEqual(card("Heads-up")["kindColor"], "rgb(93, 146, 188)", "coordination: the line's start (T320, re-sampled T337)")
-        self.assertEqual(card("Which cap")["kindColor"], "rgb(195, 227, 253)", "question: the line's end (T337)")
+        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(124, 181, 227)", "delegation: the line's middle position (T320, re-sampled T337)")
+        self.assertEqual(card("Heads-up")["kindColor"], "rgb(86, 150, 200)", "coordination: the line's start (T320, re-sampled T337)")
+        self.assertEqual(card("Which cap")["kindColor"], "rgb(162, 212, 254)", "question: the line's end (T337)")
+        # T337 (the review): the provisional dress fades by its colours, not by an element opacity that dimmed the kind
+        # word too, so every kind word reads at 4.5:1 on the ground it sits on, the provisional wash included, in both themes
+        for m, name in ((wide, "dark"), (light, "light")):
+            for c in m["cards"]:
+                if c["kind"]:
+                    self.assertGreaterEqual(c["kindContrast"] or 0, 4.5, "%s: %s reads on its own ground (%s): %r" % (
+                        name, c["kind"], "the provisional wash" if c["provisional"] else "the card", c))
+                if c["provisional"]:
+                    self.assertEqual(c["opacity"], "1", "no element opacity on the provisional card: %r" % c)
+        self.assertTrue(any(c["provisional"] and c["kind"] for c in wide["cards"]), "a provisional card with a kind word is in the world")
         # (2) the delivery icon per state, at the head's right edge, with a worded title
         states = {c["gist"][:20]: c["state"] for c in cards}
         self.assertIsNone(card("Take the retry-loop")["state"], "an incoming message in hand: no icon")

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -152,4 +152,12 @@ test("a sent card that has not landed wears the pending send's own provisional d
   assert.match(bubble, /color: var\(--prov-ink\);/);
   assert.match(CSS, /\.notice\.queued-bubble \.notice-gist, \.notice\.queued-bubble \.notice-body \{ color: var\(--prov-ink\); \}/, "the words fade with the dress");
   assert.doesNotMatch(CSS, /queued-bubble[^\n]*\.postal-kind/, "nothing re-colours the kind word on the provisional card: the token reads there as it is");
+  // the old opacity lifts are ink lifts now, and no queued-bubble rule carries an opacity at all: the hovered cancelable
+  // bubble and the bubble being edited bring the words to full ink, and a notice romp itself queued (T243) keeps its
+  // landed card's full ink under the wrapper
+  assert.match(CSS, /\.queued-bubble\.cancelable:hover \{ --prov-ink: var\(--fg\); border-color: var\(--accent\); \}/);
+  assert.match(CSS, /\.queued-bubble\.editing \{ --prov-ink: var\(--fg\);/);
+  assert.match(CSS, /\.queued-bubble\.queued-romp \{ background: transparent; border: 0; padding: 0; --prov-ink: var\(--fg\); \}/);
+  assert.doesNotMatch(CSS, /\.queued-bubble[^\n{]*\{[^}]*\bopacity:/, "no queued-bubble rule sets an opacity: the fade and its lifts are the ink");
+  assert.match(CSS, /\.queued-bubble\.cancelable \{ position: relative; padding-right: 30px; transition: color \.1s, border-color \.1s, background \.1s; \}/, "the transition names what changes");
 });

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -28,16 +28,16 @@ test("the kind is coloured text in the meta slot, never a chip, at prose weight,
   assert.match(CSS, /\.postal-kind \{ font-weight: 400; \}/, "prose weight, not bold");
   assert.doesNotMatch(CSS, /\.postal-kind \{ font-weight: (600|700|bold)/);
   // (T337: the three are re-sampled evenly along the line; postal-kind-ramp.test.ts holds the positions, these the values)
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #90badd\); \}/);
-  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #5d92bc\); \}/);
-  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #c3e3fd\); \}/);
-  assert.match(CSS, /\n  --postal-coordinate: #5d92bc;\s+--postal-delegate: #90badd;\s+--postal-question: #c3e3fd;/, "the dark ramp, low to high");
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7cb5e3\); \}/);
+  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #5696c8\); \}/);
+  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #a2d4fe\); \}/);
+  assert.match(CSS, /\n  --postal-coordinate: #5696c8;\s+--postal-delegate: #7cb5e3;\s+--postal-question: #a2d4fe;/, "the dark ramp, low to high");
   const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
-  assert.match(light, /--postal-coordinate: #974a32;\s+--postal-delegate: #6c2a14;\s+--postal-question: #430a00;/, "the light ramp, low to high, deepening");
+  assert.match(light, /--postal-coordinate: #974a32;\s+--postal-delegate: #752f18;\s+--postal-question: #551400;/, "the light ramp, low to high, deepening");
   // the ramp IS a ramp: in each theme the three steps are monotone in luminance in rank order (brighter with rank on
   // the dark page, darker with rank on the light one), so the eye reads one scale, not three tags
   const lumOf = (hex: string) => { const c = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255).map((v) => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)); return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]; };
-  const dark = ["#5d92bc", "#90badd", "#c3e3fd"].map(lumOf), lightRamp = ["#974a32", "#6c2a14", "#430a00"].map(lumOf);
+  const dark = ["#5696c8", "#7cb5e3", "#a2d4fe"].map(lumOf), lightRamp = ["#974a32", "#752f18", "#551400"].map(lumOf);
   assert.ok(dark[0] < dark[1] && dark[1] < dark[2], "dark: coordination < delegation < question in luminance");
   assert.ok(lightRamp[0] > lightRamp[1] && lightRamp[1] > lightRamp[2], "light: coordination > delegation > question in luminance");
   assert.match(CSS, /coordination lowest \(an FYI\), delegation\s+next \(work handed over\), question highest \(an answer owed\)/, "the ranking sits beside the tokens");
@@ -139,6 +139,17 @@ test("a sent card that has not landed wears the pending send's own provisional d
   // the bubble's border + padding move the head line down: the rail dot follows, as it does for a boxed card
   assert.match(CARD, /turn\.classList\.add\("postal-provisional"\)/);
   assert.match(CSS, /\.turn-postal-service\.postal-provisional > \.dot, \.turn-postal-service\.postal-provisional > \.time-marker \{ top: 18px; \}/);
-  assert.equal((CSS.match(/border: 1px dashed color-mix\(in srgb, var\(--you\) 65%, transparent\)/g) || []).length, 1,
+  assert.equal((CSS.match(/border: 1px dashed color-mix\(in srgb, var\(--you\) 55%, transparent\)/g) || []).length, 1,
                "one dashed --you border rule in the file: the bubble's");
+  // T337 (the review of the kind colours): the dress FADES BY ITS COLOURS, not by an element opacity that dimmed every
+  // colour inside (the kind word read below 4.5:1 on the wash): the old 10% / 65% / 0.85 are folded into 8.5% / 55% /
+  // an 85% --fg ink, the ink is a custom property the notice's gist and body read (their own rules set --fg back), and
+  // the head's own colours stay whole
+  const bubble = CSS.slice(CSS.indexOf(".queued-bubble, .notice.queued-bubble, .notice.notice-slim.queued-bubble {"), CSS.indexOf("\n}\n", CSS.indexOf(".queued-bubble, .notice.queued-bubble, .notice.notice-slim.queued-bubble {")));
+  assert.doesNotMatch(bubble, /opacity:/, "no element opacity on the provisional dress");
+  assert.match(bubble, /--prov-ink: color-mix\(in srgb, var\(--fg\) 85%, transparent\);/);
+  assert.match(bubble, /background: color-mix\(in srgb, var\(--you\) 8\.5%, transparent\);/);
+  assert.match(bubble, /color: var\(--prov-ink\);/);
+  assert.match(CSS, /\.notice\.queued-bubble \.notice-gist, \.notice\.queued-bubble \.notice-body \{ color: var\(--prov-ink\); \}/, "the words fade with the dress");
+  assert.doesNotMatch(CSS, /queued-bubble[^\n]*\.postal-kind/, "nothing re-colours the kind word on the provisional card: the token reads there as it is");
 });

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -51,11 +51,23 @@ test("the kind is coloured text in the meta slot, never a chip, at prose weight,
     "the postal meta never shrinks (the kind word stays whole) and grows to the head's edge to carry the icon (T313)");
 });
 
+const STATE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "postal-state.ts"), "utf8");
+
 test("the delivery state is one icon per state at the head's right edge, each with a worded title", () => {
+  // the glyph map lives in the pure module (postal-state.test.ts executes it: the T337 ladder); the renderer imports it
   for (const st of ["sent", "delivered", "read", "parked", "bounced", "recalled"]) {
-    assert.match(RENDER, new RegExp("^  " + st + ": '<", "m"), st + " has a glyph");
+    assert.match(STATE, new RegExp("^  " + st + ": '<", "m"), st + " has a glyph");
   }
-  assert.match(RENDER, /const DELIVERY_GLYPHS: Record<PostalDeliveryState, string>/);
+  assert.match(STATE, /export const DELIVERY_GLYPHS: Record<PostalDeliveryState, string>/);
+  assert.doesNotMatch(RENDER, /const DELIVERY_GLYPHS/, "one map, in the module");
+  assert.match(RENDER, /import \{ kindLabel, deliveryOf, deliveryTitle, DELIVERY_GLYPHS, type PostalDelivery, type PostalReceipt \} from "\.\/postal-state";/);
+  assert.doesNotMatch(RENDER, /type PostalDeliveryState/, "the state type left the renderer with the map");
+  // the mark's wrapper (T337, the user 2026-09-10 wanting the circled check): a 16-unit box drawn at 14 px, a 1.5 stroke,
+  // round caps and joins, no fill unless a rung says so; the read rung's check is knocked out in the page colour by the
+  // sheet (a presentation attribute cannot carry a var())
+  assert.match(fn("deliveryIcon"), /'<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '\s*\+ 'stroke-width="1\.5" stroke-linecap="round" stroke-linejoin="round">' \+ DELIVERY_GLYPHS\[d\.state\] \+ "<\/svg>"/);
+  assert.match(CSS, /\.postal-delivery-read \.postal-mark-check \{ stroke: var\(--bg\); \}/, "the read rung's check is cut out of the filled circle");
+  assert.match(STATE, /export const MARK_CHECK_CLASS = "postal-mark-check";/);
   assert.match(fn("deliveryIcon"), /span\.dataset\.state = d\.state;/);
   assert.match(fn("deliveryIcon"), /span\.setAttribute\("role", "img"\);/, "a labelled span is announced only with an image role");
   assert.match(fn("deliveryIcon"), /const title = deliveryTitle\(d, clockOf\);[^\n]*\n\s*setTip\(span, title\);[^\n]*\n\s*span\.setAttribute\("role", "img"\);[^\n]*\n\s*span\.setAttribute\("aria-label", title\);/);

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -27,16 +27,17 @@ test("the kind is coloured text in the meta slot, never a chip, at prose weight,
   // reader, each with a light-theme re-ink (the parity test holds every one at 4.5:1 on its page)
   assert.match(CSS, /\.postal-kind \{ font-weight: 400; \}/, "prose weight, not bold");
   assert.doesNotMatch(CSS, /\.postal-kind \{ font-weight: (600|700|bold)/);
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7fb8e7\); \}/);
-  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #7996af\); \}/);
-  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #91d9ff\); \}/);
-  assert.match(CSS, /\n  --postal-coordinate: #7996af;\s+--postal-delegate: #7fb8e7;\s+--postal-question: #91d9ff;/, "the dark ramp, low to high");
+  // (T337: the three are re-sampled evenly along the line; postal-kind-ramp.test.ts holds the positions, these the values)
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #90badd\); \}/);
+  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #5d92bc\); \}/);
+  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #c3e3fd\); \}/);
+  assert.match(CSS, /\n  --postal-coordinate: #5d92bc;\s+--postal-delegate: #90badd;\s+--postal-question: #c3e3fd;/, "the dark ramp, low to high");
   const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
-  assert.match(light, /--postal-coordinate: #974a32;\s+--postal-delegate: #962b00;\s+--postal-question: #751000;/, "the light ramp, low to high, deepening");
+  assert.match(light, /--postal-coordinate: #974a32;\s+--postal-delegate: #6c2a14;\s+--postal-question: #430a00;/, "the light ramp, low to high, deepening");
   // the ramp IS a ramp: in each theme the three steps are monotone in luminance in rank order (brighter with rank on
   // the dark page, darker with rank on the light one), so the eye reads one scale, not three tags
   const lumOf = (hex: string) => { const c = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255).map((v) => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)); return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]; };
-  const dark = ["#7996af", "#7fb8e7", "#91d9ff"].map(lumOf), lightRamp = ["#974a32", "#962b00", "#751000"].map(lumOf);
+  const dark = ["#5d92bc", "#90badd", "#c3e3fd"].map(lumOf), lightRamp = ["#974a32", "#6c2a14", "#430a00"].map(lumOf);
   assert.ok(dark[0] < dark[1] && dark[1] < dark[2], "dark: coordination < delegation < question in luminance");
   assert.ok(lightRamp[0] > lightRamp[1] && lightRamp[1] > lightRamp[2], "light: coordination > delegation > question in luminance");
   assert.match(CSS, /coordination lowest \(an FYI\), delegation\s+next \(work handed over\), question highest \(an answer owed\)/, "the ranking sits beside the tokens");

--- a/ui/webview/postal-intent.test.ts
+++ b/ui/webview/postal-intent.test.ts
@@ -40,5 +40,5 @@ test("the intent reads as coloured TEXT in the postal head's meta slot — no ch
   assert.match(RENDER, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
   assert.doesNotMatch(RENDER, /meta\.push\("delivered"\)/);
   assert.doesNotMatch(CSS, /\.postal-service-intent/);
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #90badd\); \}/);   // the ramp's middle step (T320; re-sampled T337)
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7cb5e3\); \}/);   // the ramp's middle step (T320; re-sampled T337)
 });

--- a/ui/webview/postal-intent.test.ts
+++ b/ui/webview/postal-intent.test.ts
@@ -40,5 +40,5 @@ test("the intent reads as coloured TEXT in the postal head's meta slot — no ch
   assert.match(RENDER, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
   assert.doesNotMatch(RENDER, /meta\.push\("delivered"\)/);
   assert.doesNotMatch(CSS, /\.postal-service-intent/);
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7fb8e7\); \}/);   // the ramp's middle step (T320)
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #90badd\); \}/);   // the ramp's middle step (T320; re-sampled T337)
 });

--- a/ui/webview/postal-kind-ramp.test.ts
+++ b/ui/webview/postal-kind-ramp.test.ts
@@ -1,8 +1,9 @@
 // T337 (the user 2026-09-10, who found the three kind colours of T320 too alike): each theme's three tokens sit at
 // positions 0, 1/2 and 1 of ONE straight line in OKLCH, hue pinned to the accent's, from the deepest step that still reads
 // on a boxed card to the far end of the tint the hue holds. The POSITIONS are the pin, not the hexes: a re-ink that keeps
-// the even spacing passes, one that bunches two steps (T320's spanned a fifth of the line) fails. The comment beside the
-// tokens in styles.css names the same knots.
+// the line, the even spacing and the span passes; one that narrows the span (T320's dark steps spanned .19 of lightness
+// against this line's .26, its light steps .14 against .25) or bunches two steps (T320's light steps were .05 then .09
+// apart) fails. The comment beside the tokens in styles.css names the same knots.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";

--- a/ui/webview/postal-kind-ramp.test.ts
+++ b/ui/webview/postal-kind-ramp.test.ts
@@ -1,9 +1,10 @@
 // T337 (the user 2026-09-10, who found the three kind colours of T320 too alike): each theme's three tokens sit at
-// positions 0, 1/2 and 1 of ONE straight line in OKLCH, hue pinned to the accent's, from the deepest step that still reads
-// on a boxed card to the far end of the tint the hue holds. The POSITIONS are the pin, not the hexes: a re-ink that keeps
-// the line, the even spacing and the span passes; one that narrows the span (T320's dark steps spanned .19 of lightness
-// against this line's .26, its light steps .14 against .25) or bunches two steps (T320's light steps were .05 then .09
-// apart) fails. The comment beside the tokens in styles.css names the same two endpoints.
+// positions 0, 1/2 and 1 of ONE straight line in OKLCH, hue pinned to the accent's. The line's two ends are two floors:
+// the deep end is the deepest step that still reads at 4.5:1 on the PROVISIONAL card's wash (theme-parity.test.ts holds
+// that contrast, and the box's and the page's), the far end stops short of the prose ink so a lone Question still reads
+// as a colour and not as body text (the distance is pinned here). The POSITIONS are the pin, not the hexes: a re-ink that
+// keeps the line and the even spacing passes; one that bunches two steps (T320's light steps were .05 then .09 apart),
+// drifts off the hue or runs into the ink fails. The comment beside the tokens in styles.css names the same two endpoints.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -16,33 +17,39 @@ function block(opener: string): string {
   return CSS.slice(at, CSS.indexOf("\n}", at)).replace(/\/\*[\s\S]*?\*\//g, "");   // comment-blind, like theme-parity
 }
 function token(blockText: string, name: string): string {
-  const m = new RegExp(name + ":\\s*(#[0-9a-f]{6});", "i").exec(blockText);
-  assert.ok(m, name + " declared as a hex");
+  // a bare hex, or the hex fallback of a var() (the dark --fg is var(--vscode-foreground, #cccccc))
+  const m = new RegExp(name + ":\\s*(?:var\\([^,]+,\\s*)?(#[0-9a-f]{6})\\)?;", "i").exec(blockText);
+  assert.ok(m, name + " declared as a hex, bare or as a var() fallback");
   return m![1].toLowerCase();
 }
-// sRGB hex → OKLCH (Björn Ottosson's OKLab, the standard matrices)
-function oklch(hex: string): { L: number; C: number; h: number } {
+// sRGB hex → OKLab (Björn Ottosson's matrices); OKLCH from it
+function oklab(hex: string): { L: number; a: number; b: number } {
   const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
   const [r, g, b] = [1, 3, 5].map((i) => lin(parseInt(hex.slice(i, i + 2), 16) / 255));
   const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
   const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
   const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
-  const L = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
-  const a = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
-  const bb = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
-  return { L, C: Math.hypot(a, bb), h: ((Math.atan2(bb, a) * 180) / Math.PI + 360) % 360 };
+  return { L: 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+           a: 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+           b: 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s };
+}
+function oklch(hex: string): { L: number; C: number; h: number } {
+  const { L, a, b } = oklab(hex);
+  return { L, C: Math.hypot(a, b), h: ((Math.atan2(b, a) * 180) / Math.PI + 360) % 360 };
 }
 const hueGap = (h: number, ref: number) => Math.abs(((h - ref + 540) % 360) - 180);
+const dist = (x: { L: number; a: number; b: number }, y: { L: number; a: number; b: number }) => Math.hypot(x.L - y.L, x.a - y.a, x.b - y.b);
 
-// the two lines: (L, C) at position 0 and at position 1, the hue held; the comment beside the tokens says the same
+// the two lines: (L, C) at position 0 and at position 1, the hue held, both ends inside sRGB on that hue; the comment
+// beside the tokens says the same
 const MAPS = {
-  dark: { block: ":root {", hue: 244, from: { L: 0.64, C: 0.085 }, to: { L: 0.9, C: 0.05 } },
-  light: { block: "body.theme-light {", hue: 38, from: { L: 0.5, C: 0.11 }, to: { L: 0.25, C: 0.09 } },
+  dark: { block: ":root {", hue: 244, from: { L: 0.65, C: 0.1 }, to: { L: 0.85, C: 0.078 } },
+  light: { block: "body.theme-light {", hue: 38, from: { L: 0.5, C: 0.11 }, to: { L: 0.3, C: 0.1 } },
 };
 const STEPS = ["--postal-coordinate", "--postal-delegate", "--postal-question"];
 
 for (const [theme, map] of Object.entries(MAPS)) {
-  test(theme + ": the three kind tokens sit at 0, 1/2 and 1 of the accent-hue line, evenly spaced", () => {
+  test(theme + ": the three kind tokens sit at 0, 1/2 and 1 of the accent-hue line, evenly spaced, the far end clear of the ink", () => {
     const b = block(map.block);
     const steps = STEPS.map((n) => oklch(token(b, n)));
     steps.forEach((s, i) => {
@@ -50,19 +57,24 @@ for (const [theme, map] of Object.entries(MAPS)) {
       const wantL = map.from.L + (map.to.L - map.from.L) * t, wantC = map.from.C + (map.to.C - map.from.C) * t;
       assert.ok(Math.abs(s.L - wantL) <= 0.012, `${theme} ${STEPS[i]}: L ${s.L.toFixed(3)} is off the line (${wantL})`);
       assert.ok(Math.abs(s.C - wantC) <= 0.012, `${theme} ${STEPS[i]}: C ${s.C.toFixed(3)} is off the line (${wantC})`);
-      assert.ok(hueGap(s.h, map.hue) <= 8, `${theme} ${STEPS[i]}: hue ${s.h.toFixed(1)} is not the accent's ${map.hue}`);
+      assert.ok(hueGap(s.h, map.hue) <= 4, `${theme} ${STEPS[i]}: hue ${s.h.toFixed(1)} is not the accent's ${map.hue} (an endpoint clipped by the gamut drifts)`);
     });
-    // even: the two lightness steps match; wide: the line is the whole map, not a part of it
+    // even: the two lightness steps match
     const d1 = steps[1].L - steps[0].L, d2 = steps[2].L - steps[1].L;
     assert.ok(Math.abs(d1 - d2) <= 0.012, `${theme}: uneven steps ${d1.toFixed(3)} vs ${d2.toFixed(3)}`);
-    assert.ok(Math.abs(steps[2].L - steps[0].L) >= 0.24, `${theme}: the tokens span ${Math.abs(steps[2].L - steps[0].L).toFixed(3)} of lightness, the map is 0.25 or more`);
+    // the far end keeps its distance from the prose ink (--fg): a lone Question is a colour, not body text. The dark end
+    // sits at the ink's own lightness, so its distance is all chroma, the hue's gamut edge there; .075 is just under it
+    const gap = dist(oklab(token(b, "--postal-question")), oklab(token(b, "--fg")));
+    assert.ok(gap >= 0.075, `${theme}: --postal-question is ${gap.toFixed(3)} from --fg in OKLab, too close to the ink`);
   });
 }
 
 test("the comment beside the tokens names the same two endpoints, and the tokens hold their theme's accent hue", () => {
-  assert.match(CSS, /L \.64, C \.085[\s\S]{0,300}L \.90, C \.05/, "the dark line's two endpoints, in the :root comment");
-  assert.match(CSS, /L \.50, C \.11[\s\S]{0,200}L \.25, C \.09/, "the light line's two endpoints, in the light comment");
+  assert.match(CSS, /L \.65, C \.10[\s\S]{0,500}L \.85, C \.078/, "the dark line's two endpoints, in the :root comment");
+  assert.match(CSS, /L \.50, C \.11[\s\S]{0,300}L \.30, C \.10/, "the light line's two endpoints, in the light comment");
   assert.match(CSS, /hue pinned\s+at the accent's 244/);
+  assert.match(CSS, /The trade-off is span against distance from the ink/, "the comment states the trade-off the far end makes");
+  assert.match(CSS, /reads at 4\.5:1 on the PROVISIONAL card, the darkest ground a kind word sits on/, "the comment names the wash as the floor, not the box");
   // the accent itself sits on each line's hue: the ramp is the accent's family, not a neighbour's
   assert.ok(hueGap(oklch(token(block(":root {"), "--accent")).h, MAPS.dark.hue) <= 8, "the dark accent's hue is the dark line's");
   assert.ok(hueGap(oklch(token(block("body.theme-light {"), "--accent")).h, MAPS.light.hue) <= 8, "the light accent's hue is the light line's");

--- a/ui/webview/postal-kind-ramp.test.ts
+++ b/ui/webview/postal-kind-ramp.test.ts
@@ -1,0 +1,68 @@
+// T337 (the user 2026-09-10, who found the three kind colours of T320 too alike): each theme's three tokens sit at
+// positions 0, 1/2 and 1 of ONE straight line in OKLCH, hue pinned to the accent's, from the deepest step that still reads
+// on a boxed card to the far end of the tint the hue holds. The POSITIONS are the pin, not the hexes: a re-ink that keeps
+// the even spacing passes, one that bunches two steps (T320's spanned a fifth of the line) fails. The comment beside the
+// tokens in styles.css names the same knots.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+function block(opener: string): string {
+  const at = CSS.indexOf(opener);
+  assert.ok(at >= 0, opener + " present");
+  return CSS.slice(at, CSS.indexOf("\n}", at)).replace(/\/\*[\s\S]*?\*\//g, "");   // comment-blind, like theme-parity
+}
+function token(blockText: string, name: string): string {
+  const m = new RegExp(name + ":\\s*(#[0-9a-f]{6});", "i").exec(blockText);
+  assert.ok(m, name + " declared as a hex");
+  return m![1].toLowerCase();
+}
+// sRGB hex → OKLCH (Björn Ottosson's OKLab, the standard matrices)
+function oklch(hex: string): { L: number; C: number; h: number } {
+  const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const [r, g, b] = [1, 3, 5].map((i) => lin(parseInt(hex.slice(i, i + 2), 16) / 255));
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  const L = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
+  const a = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
+  const bb = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
+  return { L, C: Math.hypot(a, bb), h: ((Math.atan2(bb, a) * 180) / Math.PI + 360) % 360 };
+}
+const hueGap = (h: number, ref: number) => Math.abs(((h - ref + 540) % 360) - 180);
+
+// the two lines: (L, C) at position 0 and at position 1, the hue held; the comment beside the tokens says the same
+const MAPS = {
+  dark: { block: ":root {", hue: 244, from: { L: 0.64, C: 0.085 }, to: { L: 0.9, C: 0.05 } },
+  light: { block: "body.theme-light {", hue: 38, from: { L: 0.5, C: 0.11 }, to: { L: 0.25, C: 0.09 } },
+};
+const STEPS = ["--postal-coordinate", "--postal-delegate", "--postal-question"];
+
+for (const [theme, map] of Object.entries(MAPS)) {
+  test(theme + ": the three kind tokens sit at 0, 1/2 and 1 of the accent-hue line, evenly spaced", () => {
+    const b = block(map.block);
+    const steps = STEPS.map((n) => oklch(token(b, n)));
+    steps.forEach((s, i) => {
+      const t = i / 2;
+      const wantL = map.from.L + (map.to.L - map.from.L) * t, wantC = map.from.C + (map.to.C - map.from.C) * t;
+      assert.ok(Math.abs(s.L - wantL) <= 0.012, `${theme} ${STEPS[i]}: L ${s.L.toFixed(3)} is off the line (${wantL})`);
+      assert.ok(Math.abs(s.C - wantC) <= 0.012, `${theme} ${STEPS[i]}: C ${s.C.toFixed(3)} is off the line (${wantC})`);
+      assert.ok(hueGap(s.h, map.hue) <= 8, `${theme} ${STEPS[i]}: hue ${s.h.toFixed(1)} is not the accent's ${map.hue}`);
+    });
+    // even: the two lightness steps match; wide: the line is the whole map, not a fifth of it
+    const d1 = steps[1].L - steps[0].L, d2 = steps[2].L - steps[1].L;
+    assert.ok(Math.abs(d1 - d2) <= 0.012, `${theme}: uneven steps ${d1.toFixed(3)} vs ${d2.toFixed(3)}`);
+    assert.ok(Math.abs(steps[2].L - steps[0].L) >= 0.24, `${theme}: the tokens span ${Math.abs(steps[2].L - steps[0].L).toFixed(3)} of lightness, the map is 0.25 or more`);
+  });
+}
+
+test("the comment beside the tokens names the same knots, and the tokens hold their theme's accent hue", () => {
+  assert.match(CSS, /L \.64, C \.085[\s\S]{0,300}L \.90, C \.05/, "the dark line's knots, in the :root comment");
+  assert.match(CSS, /L \.50, C \.11[\s\S]{0,200}L \.25, C \.09/, "the light line's knots, in the light comment");
+  assert.match(CSS, /hue pinned\s+at the accent's 244/);
+  // the accent itself sits on each line's hue: the ramp is the accent's family, not a neighbour's
+  assert.ok(hueGap(oklch(token(block(":root {"), "--accent")).h, MAPS.dark.hue) <= 8, "the dark accent's hue is the dark line's");
+  assert.ok(hueGap(oklch(token(block("body.theme-light {"), "--accent")).h, MAPS.light.hue) <= 8, "the light accent's hue is the light line's");
+});

--- a/ui/webview/postal-kind-ramp.test.ts
+++ b/ui/webview/postal-kind-ramp.test.ts
@@ -3,7 +3,7 @@
 // on a boxed card to the far end of the tint the hue holds. The POSITIONS are the pin, not the hexes: a re-ink that keeps
 // the line, the even spacing and the span passes; one that narrows the span (T320's dark steps spanned .19 of lightness
 // against this line's .26, its light steps .14 against .25) or bunches two steps (T320's light steps were .05 then .09
-// apart) fails. The comment beside the tokens in styles.css names the same knots.
+// apart) fails. The comment beside the tokens in styles.css names the same two endpoints.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -52,16 +52,16 @@ for (const [theme, map] of Object.entries(MAPS)) {
       assert.ok(Math.abs(s.C - wantC) <= 0.012, `${theme} ${STEPS[i]}: C ${s.C.toFixed(3)} is off the line (${wantC})`);
       assert.ok(hueGap(s.h, map.hue) <= 8, `${theme} ${STEPS[i]}: hue ${s.h.toFixed(1)} is not the accent's ${map.hue}`);
     });
-    // even: the two lightness steps match; wide: the line is the whole map, not a fifth of it
+    // even: the two lightness steps match; wide: the line is the whole map, not a part of it
     const d1 = steps[1].L - steps[0].L, d2 = steps[2].L - steps[1].L;
     assert.ok(Math.abs(d1 - d2) <= 0.012, `${theme}: uneven steps ${d1.toFixed(3)} vs ${d2.toFixed(3)}`);
     assert.ok(Math.abs(steps[2].L - steps[0].L) >= 0.24, `${theme}: the tokens span ${Math.abs(steps[2].L - steps[0].L).toFixed(3)} of lightness, the map is 0.25 or more`);
   });
 }
 
-test("the comment beside the tokens names the same knots, and the tokens hold their theme's accent hue", () => {
-  assert.match(CSS, /L \.64, C \.085[\s\S]{0,300}L \.90, C \.05/, "the dark line's knots, in the :root comment");
-  assert.match(CSS, /L \.50, C \.11[\s\S]{0,200}L \.25, C \.09/, "the light line's knots, in the light comment");
+test("the comment beside the tokens names the same two endpoints, and the tokens hold their theme's accent hue", () => {
+  assert.match(CSS, /L \.64, C \.085[\s\S]{0,300}L \.90, C \.05/, "the dark line's two endpoints, in the :root comment");
+  assert.match(CSS, /L \.50, C \.11[\s\S]{0,200}L \.25, C \.09/, "the light line's two endpoints, in the light comment");
   assert.match(CSS, /hue pinned\s+at the accent's 244/);
   // the accent itself sits on each line's hue: the ramp is the accent's family, not a neighbour's
   assert.ok(hueGap(oklch(token(block(":root {"), "--accent")).h, MAPS.dark.hue) <= 8, "the dark accent's hue is the dark line's");

--- a/ui/webview/postal-kind-ramp.test.ts
+++ b/ui/webview/postal-kind-ramp.test.ts
@@ -44,7 +44,7 @@ const dist = (x: { L: number; a: number; b: number }, y: { L: number; a: number;
 // beside the tokens says the same
 const MAPS = {
   dark: { block: ":root {", hue: 244, from: { L: 0.65, C: 0.1 }, to: { L: 0.85, C: 0.078 } },
-  light: { block: "body.theme-light {", hue: 38, from: { L: 0.5, C: 0.11 }, to: { L: 0.3, C: 0.1 } },
+  light: { block: "body.theme-light {", hue: 38, from: { L: 0.5, C: 0.11 }, to: { L: 0.3, C: 0.098 } },   // C .098 is the hue's gamut edge at L .30
 };
 const STEPS = ["--postal-coordinate", "--postal-delegate", "--postal-question"];
 
@@ -62,6 +62,11 @@ for (const [theme, map] of Object.entries(MAPS)) {
     // even: the two lightness steps match
     const d1 = steps[1].L - steps[0].L, d2 = steps[2].L - steps[1].L;
     assert.ok(Math.abs(d1 - d2) <= 0.012, `${theme}: uneven steps ${d1.toFixed(3)} vs ${d2.toFixed(3)}`);
+    // the span may not shrink further: the two floors (the provisional wash below, the prose ink above) already squeeze
+    // the dark line to .20 of lightness, about T320's .19, so the three steps' separation rests on the chroma gradient
+    // (the deep step the most saturated, the far step the palest) and on the hue held; a wider spread would have to
+    // spend hue, which is the user's call, not a re-ink's
+    assert.ok(Math.abs(steps[2].L - steps[0].L) >= 0.19, `${theme}: the tokens span ${Math.abs(steps[2].L - steps[0].L).toFixed(3)} of lightness, below the .19 floor`);
     // the far end keeps its distance from the prose ink (--fg): a lone Question is a colour, not body text. The dark end
     // sits at the ink's own lightness, so its distance is all chroma, the hue's gamut edge there; .075 is just under it
     const gap = dist(oklab(token(b, "--postal-question")), oklab(token(b, "--fg")));
@@ -71,7 +76,7 @@ for (const [theme, map] of Object.entries(MAPS)) {
 
 test("the comment beside the tokens names the same two endpoints, and the tokens hold their theme's accent hue", () => {
   assert.match(CSS, /L \.65, C \.10[\s\S]{0,500}L \.85, C \.078/, "the dark line's two endpoints, in the :root comment");
-  assert.match(CSS, /L \.50, C \.11[\s\S]{0,300}L \.30, C \.10/, "the light line's two endpoints, in the light comment");
+  assert.match(CSS, /L \.50, C \.11[\s\S]{0,300}L \.30, C \.098/, "the light line's two endpoints, in the light comment");
   assert.match(CSS, /hue pinned\s+at the accent's 244/);
   assert.match(CSS, /The trade-off is span against distance from the ink/, "the comment states the trade-off the far end makes");
   assert.match(CSS, /reads at 4\.5:1 on the PROVISIONAL card, the darkest ground a kind word sits on/, "the comment names the wash as the floor, not the box");

--- a/ui/webview/postal-state.test.ts
+++ b/ui/webview/postal-state.test.ts
@@ -15,9 +15,18 @@ test("sent / delivered / read is the ladder messaging apps draw: a hollow circle
   // the filled circle in the page colour (the class the sheet styles).
   const { sent, delivered, read } = DELIVERY_GLYPHS;
   const circle = /<circle cx="8" cy="8" r="([\d.]+)"([^>]*)\/>/;
-  const check = new RegExp('<path class="' + MARK_CHECK_CLASS + '" d="M[^"]+"\\/>');
+  // the check is a THREE-POINT polyline (a bare line is what the user zoomed in on and rejected), every point inside the
+  // circle; the circle plus half its stroke fits the 16-unit box
+  const check = new RegExp('<path class="' + MARK_CHECK_CLASS + '" d="(M[\\d.]+ [\\d.]+ L[\\d.]+ [\\d.]+ L[\\d.]+ [\\d.]+)"\\/>');
   const radii = [sent, delivered, read].map((g) => { const m = circle.exec(g); assert.ok(m, "a circle in " + g); return m![1]; });
   assert.equal(new Set(radii).size, 1, "one radius for the three circles: " + radii.join(" "));
+  const r = parseFloat(radii[0]);
+  assert.ok(r >= 5 && r + 0.75 <= 8, "the circle fills the box without clipping its 1.5 stroke: r=" + r);
+  const pts = check.exec(delivered)![1].match(/[\d.]+/g)!.map(Number);
+  for (let i = 0; i < pts.length; i += 2) {
+    assert.ok(Math.hypot(pts[i] - 8, pts[i + 1] - 8) <= r - 0.75, "check point " + pts[i] + "," + pts[i + 1] + " sits inside the circle");
+  }
+  assert.ok(pts[3] > pts[1] && pts[3] > pts[5], "the middle point is the check's low corner");
   assert.doesNotMatch(sent, check, "sent: the hollow circle alone");
   assert.doesNotMatch(sent, /fill=/, "sent: hollow");
   assert.match(delivered, check, "delivered: the circle with the check");

--- a/ui/webview/postal-state.test.ts
+++ b/ui/webview/postal-state.test.ts
@@ -22,9 +22,11 @@ test("sent / delivered / read is the ladder messaging apps draw: a hollow circle
   assert.equal(new Set(radii).size, 1, "one radius for the three circles: " + radii.join(" "));
   const r = parseFloat(radii[0]);
   assert.ok(r >= 5 && r + 0.75 <= 8, "the circle fills the box without clipping its 1.5 stroke: r=" + r);
+  // every point of the check, its round cap included, stays half a unit clear of the ring's inner edge (ring stroke 1.5
+  // centred on r, cap radius 0.75): a tip that grazes the ring antialiases into it at 14 px (the review of 2026-09-11)
   const pts = check.exec(delivered)![1].match(/[\d.]+/g)!.map(Number);
   for (let i = 0; i < pts.length; i += 2) {
-    assert.ok(Math.hypot(pts[i] - 8, pts[i + 1] - 8) <= r - 0.75, "check point " + pts[i] + "," + pts[i + 1] + " sits inside the circle");
+    assert.ok(Math.hypot(pts[i] - 8, pts[i + 1] - 8) <= r - 1.5 - 0.5, "check point " + pts[i] + "," + pts[i + 1] + " sits clear of the ring");
   }
   assert.ok(pts[3] > pts[1] && pts[3] > pts[5], "the middle point is the check's low corner");
   assert.doesNotMatch(sent, check, "sent: the hollow circle alone");
@@ -42,7 +44,8 @@ test("sent / delivered / read is the ladder messaging apps draw: a hollow circle
   // the drawings are this repo's own primitives (a circle, a three-point check), not an icon set's assets: the module
   // says so where the map is, because Signal's own icons ship under a copyleft licence and may not be copied here
   const src = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "postal-state.ts"), "utf8");
-  assert.match(src, /drawn here from two primitives[\s\S]{0,400}Signal's own icon assets[\s\S]{0,200}not copied/);
+  assert.match(src, /drawn here from two primitives[\s\S]{0,400}Apache-2\.0 \(LICENSE\); Signal's own icon assets ship AGPL-3\.0[\s\S]{0,200}not copied/);
+  assert.match(src, /An adaptation of Signal's ladder, not its rungs one for one/, "the mapping onto Signal's ladder is stated");
 });
 
 test("the kind is a capitalised word per class, empty when unknown", () => {

--- a/ui/webview/postal-state.test.ts
+++ b/ui/webview/postal-state.test.ts
@@ -2,9 +2,39 @@
 // module; the render pins live in postal-card.test.ts).
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { kindLabel, deliveryOf, deliveryTitle } from "./postal-state";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { kindLabel, deliveryOf, deliveryTitle, DELIVERY_GLYPHS, MARK_CHECK_CLASS } from "./postal-state";
 
 const clock = (t: number) => "T" + t;
+
+test("sent / delivered / read is the ladder messaging apps draw: a hollow circle, the circle with a check, the filled circle with a check (T337)", () => {
+  // the user (2026-09-10) liked the marks but wanted the circled check: zoomed in, a bare check read as a line. One circle
+  // on all three rungs, the same geometry, so the ladder reads as ONE mark changing state; the check is one three-point
+  // path, drawn the same on delivered and read (only the circle's fill changes); the read rung's check is knocked out of
+  // the filled circle in the page colour (the class the sheet styles).
+  const { sent, delivered, read } = DELIVERY_GLYPHS;
+  const circle = /<circle cx="8" cy="8" r="([\d.]+)"([^>]*)\/>/;
+  const check = new RegExp('<path class="' + MARK_CHECK_CLASS + '" d="M[^"]+"\\/>');
+  const radii = [sent, delivered, read].map((g) => { const m = circle.exec(g); assert.ok(m, "a circle in " + g); return m![1]; });
+  assert.equal(new Set(radii).size, 1, "one radius for the three circles: " + radii.join(" "));
+  assert.doesNotMatch(sent, check, "sent: the hollow circle alone");
+  assert.doesNotMatch(sent, /fill=/, "sent: hollow");
+  assert.match(delivered, check, "delivered: the circle with the check");
+  assert.doesNotMatch(delivered, /fill=/, "delivered: still hollow");
+  assert.match(read, check, "read: the check…");
+  assert.match(read, /<circle[^>]* fill="currentColor"/, "…on the filled circle");
+  assert.equal(check.exec(delivered)![0], check.exec(read)![0], "one check shape on both rungs");
+  assert.equal(new Set([sent, delivered, read]).size, 3, "three states, three distinct drawings");
+  // the other three states keep their glyphs: the clock, the cross, the return arrow
+  assert.match(DELIVERY_GLYPHS.parked, /<circle cx="8" cy="8" r="5\.6"\/><path d="M8 4\.8 V8\.2 L10\.4 9\.6"\/>/);
+  assert.match(DELIVERY_GLYPHS.bounced, /M4\.5 4\.5 L11\.5 11\.5/);
+  assert.match(DELIVERY_GLYPHS.recalled, /A2\.8 2\.8 0 0 0 12\.8 5\.2/);
+  // the drawings are this repo's own primitives (a circle, a three-point check), not an icon set's assets: the module
+  // says so where the map is, because Signal's own icons ship under a copyleft licence and may not be copied here
+  const src = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "postal-state.ts"), "utf8");
+  assert.match(src, /drawn here from two primitives[\s\S]{0,400}Signal's own icon assets[\s\S]{0,200}not copied/);
+});
 
 test("the kind is a capitalised word per class, empty when unknown", () => {
   assert.equal(kindLabel("delegate"), "Delegation");

--- a/ui/webview/postal-state.ts
+++ b/ui/webview/postal-state.ts
@@ -64,6 +64,32 @@ export function deliveryOf(ev: { direction: "in" | "out"; status?: string | null
   return null;
 }
 
+/** The delivery mark's DRAWINGS, one per state: the inner SVG of a 16-unit box the renderer wraps (render.ts
+ *  deliveryIcon: 14 px, a 1.5 stroke in currentColor, round caps and joins, no fill unless a drawing says so).
+ *
+ *  sent / delivered / read is the ladder messaging apps draw (T337, the user 2026-09-10, who liked the marks but found a
+ *  bare check read as a line when zoomed in): a hollow circle = sent (handed to the relay), the circle with a check =
+ *  delivered (in the recipient's inbox, or the far host's ack), the filled circle with the check knocked out = read (the
+ *  recipient consumed it: the ledger's own exec event, never inferred). One circle, one three-point check: the three
+ *  rungs are one mark changing state, and the read rung's check wears MARK_CHECK_CLASS so the sheet can cut it out in
+ *  the page colour (a presentation attribute cannot carry a var()). The other three states keep their own glyphs: a
+ *  clock = parked, a cross = bounced, a return arrow = recalled. Each mark carries a worded title (deliveryTitle).
+ *
+ *  The marks keep the STATE colour (the sheet: dim for sent and delivered, the accent for read), never the kind's.
+ *
+ *  Licence: the ladder is drawn here from two primitives of our own, a circle and a three-point polyline, in this
+ *  file's own coordinates; Signal's own icon assets ship under the GPL/AGPL with its apps and are not copied into this
+ *  repository, which may go public under a permissive licence. */
+export const MARK_CHECK_CLASS = "postal-mark-check";
+export const DELIVERY_GLYPHS: Record<PostalDeliveryState, string> = {
+  sent: '<circle cx="8" cy="8" r="6.25"/>',
+  delivered: '<circle cx="8" cy="8" r="6.25"/><path class="postal-mark-check" d="M4.9 8.3 L7.1 10.5 L11.3 5.7"/>',
+  read: '<circle cx="8" cy="8" r="6.25" fill="currentColor"/><path class="postal-mark-check" d="M4.9 8.3 L7.1 10.5 L11.3 5.7"/>',
+  parked: '<circle cx="8" cy="8" r="5.6"/><path d="M8 4.8 V8.2 L10.4 9.6"/>',
+  bounced: '<path d="M4.5 4.5 L11.5 11.5"/><path d="M11.5 4.5 L4.5 11.5"/>',
+  recalled: '<path d="M6.6 4.6 L3.2 8 L6.6 11.4"/><path d="M3.2 8 H10 A2.8 2.8 0 0 0 12.8 5.2"/>',
+};
+
 /** The icon's title: the word, the clock when known, the reason for a bounce. `clock` formats an epoch. */
 export function deliveryTitle(d: PostalDelivery, clock: (epochS: number) => string): string {
   let s = d.word;

--- a/ui/webview/postal-state.ts
+++ b/ui/webview/postal-state.ts
@@ -75,13 +75,22 @@ export function deliveryOf(ev: { direction: "in" | "out"; status?: string | null
  *  the page colour (a presentation attribute cannot carry a var()). The other three states keep their own glyphs: a
  *  clock = parked, a cross = bounced, a return arrow = recalled. Each mark carries a worded title (deliveryTitle).
  *
+ *  An adaptation of Signal's ladder, not its rungs one for one: Signal draws sending as the hollow circle, sent as a
+ *  circled check, delivered as a circled double check and read as the filled circle; the kernel files three states, so
+ *  ours maps sent, delivered and read onto hollow, check and filled check.
+ *
+ *  Drawn at 14 px with a 1.5 stroke, heavier than the envelope glyph at the head's other end (12 px, 1.4): a ring with
+ *  a check inside needs the two extra pixels for the check's arms to stay clear of the ring at device scale 1, and the
+ *  1.5 stroke is the mark's own specification (the user's reference).
+ *
  *  The marks keep the STATE colour (the sheet: dim for sent and delivered, the accent for read), never the kind's.
  *
  *  Licence: the ladder is drawn here from two primitives of our own, a circle and a three-point polyline, in this
- *  file's own coordinates; Signal's own icon assets ship under the GPL/AGPL with its apps and are not copied into this
- *  repository, which may go public under a permissive licence. */
+ *  file's own coordinates. This repository is Apache-2.0 (LICENSE); Signal's own icon assets ship AGPL-3.0 with its
+ *  apps and are therefore not copied into it. */
 export const MARK_CHECK_CLASS = "postal-mark-check";
-const CHECK = '<path class="' + MARK_CHECK_CLASS + '" d="M4.9 8.3 L7.1 10.5 L11.3 5.7"/>';   // one three-point check
+const CHECK = '<path class="' + MARK_CHECK_CLASS + '" d="M4.9 8.3 L7.1 10.5 L10.9 6.1"/>';   // one three-point check, its
+                                                                                              // far tip clear of the ring
 export const DELIVERY_GLYPHS: Record<PostalDeliveryState, string> = {
   sent: '<circle cx="8" cy="8" r="6.25"/>',
   delivered: '<circle cx="8" cy="8" r="6.25"/>' + CHECK,

--- a/ui/webview/postal-state.ts
+++ b/ui/webview/postal-state.ts
@@ -81,10 +81,11 @@ export function deliveryOf(ev: { direction: "in" | "out"; status?: string | null
  *  file's own coordinates; Signal's own icon assets ship under the GPL/AGPL with its apps and are not copied into this
  *  repository, which may go public under a permissive licence. */
 export const MARK_CHECK_CLASS = "postal-mark-check";
+const CHECK = '<path class="' + MARK_CHECK_CLASS + '" d="M4.9 8.3 L7.1 10.5 L11.3 5.7"/>';   // one three-point check
 export const DELIVERY_GLYPHS: Record<PostalDeliveryState, string> = {
   sent: '<circle cx="8" cy="8" r="6.25"/>',
-  delivered: '<circle cx="8" cy="8" r="6.25"/><path class="postal-mark-check" d="M4.9 8.3 L7.1 10.5 L11.3 5.7"/>',
-  read: '<circle cx="8" cy="8" r="6.25" fill="currentColor"/><path class="postal-mark-check" d="M4.9 8.3 L7.1 10.5 L11.3 5.7"/>',
+  delivered: '<circle cx="8" cy="8" r="6.25"/>' + CHECK,
+  read: '<circle cx="8" cy="8" r="6.25" fill="currentColor"/>' + CHECK,
   parked: '<circle cx="8" cy="8" r="5.6"/><path d="M8 4.8 V8.2 L10.4 9.6"/>',
   bounced: '<path d="M4.5 4.5 L11.5 11.5"/><path d="M11.5 4.5 L4.5 11.5"/>',
   recalled: '<path d="M6.6 4.6 L3.2 8 L6.6 11.4"/><path d="M3.2 8 H10 A2.8 2.8 0 0 0 12.8 5.2"/>',

--- a/ui/webview/queued-edit.test.ts
+++ b/ui/webview/queued-edit.test.ts
@@ -43,8 +43,8 @@ test("the ✎ opens a field IN the bubble: the editor is keyed by the entry, the
     "the open records the state (the words, the caret at the end, focus, the bubble's width) and posts the hold; the repaint is the acknowledgement");
   assert.match(EDITOR, /if \(ed\.width > 0\) bubble\.style\.width = ed\.width \+ "px";/, "the field keeps the bubble's width as it stood");
   assert.match(DELEGATES, /openQueuedEditor\(sidQ, ref, bub \? bub\.getBoundingClientRect\(\)\.width : 0\);/, "measured at the click");
-  assert.match(CSS, /\.queued-bubble\.editing \{ opacity: 1; border-color: var\(--accent\); padding-right: 52px; box-sizing: border-box; \}/,
-    "the idle bubble's padding stays, so the words do not re-wrap under the caret when the field opens (review find)");
+  assert.match(CSS, /\.queued-bubble\.editing \{ --prov-ink: var\(--fg\); border-color: var\(--accent\); padding-right: 52px; box-sizing: border-box; \}/,
+    "the idle bubble's padding stays, so the words do not re-wrap under the caret when the field opens (review find); full ink while editing (the ink lift, T337)");
   assert.match(KERNEL, /def _relocate_parked\(sid, ops, md, skip=-1, prefer_held=True\):/, "a drifted slot relocates to the twin the editor holds, and refuses when nobody can tell (review find)");
   assert.match(KERNEL, /_park_holds\.pop\(sid, None\)\s+# …and the editors' holds: an obj: key must not outlive its op/);
   assert.match(EDITOR, /function holdQueuedMsg\(sid: string, ref: QueuedEditRef, hold: boolean\): Record<string, unknown> \{\s*\n\s*const m: Record<string, unknown> = \{ type: "holdQueued", id: sid, md: ref\.md, hold \};\s*\n\s*if \(ref\.idx !== undefined\) m\.idx = ref\.idx;\s*\n\s*if \(ref\.park !== undefined\) m\.park = ref\.park;\s*\n\s*if \(ref\.qid\) m\.qid = ref\.qid;/,

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -103,7 +103,7 @@ import { reconcileRewindPass, type RewindEvent } from "./rewind-reconcile";
 import { watchChatVisibility, browserChatVisibilityDeps } from "./chat-visibility";
 import type { PaneHiddenHost } from "./paint-gate";
 import { gistOf, collapseWs, postalHead } from "./gist";   // the shared gist rule + the postal head (T294)
-import { kindLabel, deliveryOf, deliveryTitle, type PostalDelivery, type PostalDeliveryState, type PostalReceipt } from "./postal-state";   // the postal card's kind word + delivery state (T302)
+import { kindLabel, deliveryOf, deliveryTitle, DELIVERY_GLYPHS, type PostalDelivery, type PostalReceipt } from "./postal-state";   // the postal card's kind word + delivery state (T302), the marks' drawings (T337)
 
 for (const [name, lang] of Object.entries({
   bash, sh: bash, shell: bash, python, py: python, javascript, js: javascript,
@@ -4859,26 +4859,17 @@ function postalServiceIntent(body: string | undefined): { label: string; cls: st
 }
 
 // The delivery-state icon at the postal head's right edge (T302, the user 2026-09-10): the way messaging apps
-// show sent / delivered / read. One check = sent (handed to the relay), two dim checks = delivered (in the
-// recipient's inbox, or the far host's ack), two coloured checks = read (the recipient consumed it: the
-// ledger's own exec event, never inferred), a clock = parked, a red mark = bounced, a return arrow = recalled.
-// Each carries a worded title with the clock. States and words: postal-state.ts.
-const DELIVERY_GLYPHS: Record<PostalDeliveryState, string> = {
-  sent: '<path d="M3 8.6 L6.4 12 L13 5"/>',
-  delivered: '<path d="M1.6 8.6 L4.8 11.8 L10.2 5.4"/><path d="M6.6 11.6 L14.4 5.4"/>',
-  read: '<path d="M1.6 8.6 L4.8 11.8 L10.2 5.4"/><path d="M6.6 11.6 L14.4 5.4"/>',
-  parked: '<circle cx="8" cy="8" r="5.6"/><path d="M8 4.8 V8.2 L10.4 9.6"/>',
-  bounced: '<path d="M4.5 4.5 L11.5 11.5"/><path d="M11.5 4.5 L4.5 11.5"/>',
-  recalled: '<path d="M6.6 4.6 L3.2 8 L6.6 11.4"/><path d="M3.2 8 H10 A2.8 2.8 0 0 0 12.8 5.2"/>',
-};
+// show sent / delivered / read. The drawings, states and words live in postal-state.ts (DELIVERY_GLYPHS: the
+// circled-check ladder for sent / delivered / read since T337, a clock = parked, a cross = bounced, a return
+// arrow = recalled); this wraps one in its box: 14 px, a 1.5 stroke in the state's colour, round caps and joins.
 function clockOf(epochS: number): string {
   return new Date(epochS * 1000).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }
 function deliveryIcon(d: PostalDelivery): HTMLElement {
   const span = el("span", "postal-delivery postal-delivery-" + d.state);
   span.dataset.state = d.state;
-  span.innerHTML = '<svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" '
-    + 'stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' + DELIVERY_GLYPHS[d.state] + "</svg>";
+  span.innerHTML = '<svg viewBox="0 0 16 16" width="14" height="14" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">' + DELIVERY_GLYPHS[d.state] + "</svg>";
   const title = deliveryTitle(d, clockOf);
   setTip(span, title);                       // the pane's styled tip on hover…
   span.setAttribute("role", "img");          // …and the same words for a screen reader: a labelled span is announced

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -4861,7 +4861,9 @@ function postalServiceIntent(body: string | undefined): { label: string; cls: st
 // The delivery-state icon at the postal head's right edge (T302, the user 2026-09-10): the way messaging apps
 // show sent / delivered / read. The drawings, states and words live in postal-state.ts (DELIVERY_GLYPHS: the
 // circled-check ladder for sent / delivered / read since T337, a clock = parked, a cross = bounced, a return
-// arrow = recalled); this wraps one in its box: 14 px, a 1.5 stroke in the state's colour, round caps and joins.
+// arrow = recalled); this wraps one in its box: 14 px, a 1.5 stroke in the state's colour, round caps and joins,
+// heavier than the envelope glyph at the head's other end (12 px, 1.4) for the reason postal-state.ts gives: a ring
+// with a check inside needs the room, and the stroke is the mark's own specification.
 function clockOf(epochS: number): string {
   return new Date(epochS * 1000).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -92,11 +92,16 @@ body.scheme-solarized-dark {
                        defined (a phantom token) until 2026-08-26; mirrored in feed.css (own :root). */
   /* the postal card's three KIND colours (T320, the user 2026-09-10): one SEQUENTIAL ramp in the accent's hue, not
      three unrelated hues, ranked by how much the kind asks of the reader: coordination lowest (an FYI), delegation
-     next (work handed over), question highest (an answer owed). More asking = more intense against the page: on the
-     dark page the ramp climbs toward the accent's brightness (OKLCH hue 244, L .66 / .76 / .86; 5.4:1, 7.8:1 and
-     10.8:1 on the page, 5.0:1, 7.3:1 and 9.9:1 on a boxed card, whose --box-bg wash the word also sits on); the light
-     theme re-inks the same three ranks toward the deep end of its clay accent (below). */
-  --postal-coordinate: #7996af;  --postal-delegate: #7fb8e7;  --postal-question: #91d9ff;
+     next (work handed over), question highest (an answer owed). More asking = more intense against the page. The
+     three are sampled EVENLY, at positions 0, 1/2 and 1 of one straight line in OKLCH (T337, the user 2026-09-10, who
+     found the first three too alike: they spanned a fifth of the line, L .66 to .86 at one saturation). On the dark
+     page the line runs from the deepest blue that still reads on a boxed card (L .64, C .085: 4.6:1 on --box-bg, the
+     review's floor being 4.5) to the brightest tint the hue holds (L .90, C .05, the sRGB gamut's edge), hue pinned
+     at the accent's 244 throughout; 5.0:1, 8.1:1 and 12.5:1 on the page, 4.6:1, 7.5:1 and 11.5:1 on a boxed card,
+     whose --box-bg wash the word also sits on. The light theme runs its own line the other way, deepening toward the
+     dark end of its clay accent (below). postal-kind-ramp.test.ts holds the positions, theme-parity.test.ts the
+     contrast. */
+  --postal-coordinate: #5d92bc;  --postal-delegate: #90badd;  --postal-question: #c3e3fd;
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
@@ -234,14 +239,17 @@ body.theme-light {
   --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
-  --postal-coordinate: #974a32;  --postal-delegate: #962b00;  --postal-question: #751000;   /* the kind ramp (T320): the
+  --postal-coordinate: #974a32;  --postal-delegate: #6c2a14;  --postal-question: #430a00;   /* the kind ramp (T320, T337): the
                                                                                             accent's clay hue (OKLCH 38)
-                                                                                            deepening with rank, L .50 /
-                                                                                            .45 / .36; 5.3:1, 6.7:1 and
-                                                                                            9.6:1 on the cream page and
-                                                                                            5.0:1, 6.2:1 and 9.0:1 on a
-                                                                                            boxed card (the review's
-                                                                                            floor is the box, 4.5:1) */
+                                                                                            deepening with rank, sampled
+                                                                                            evenly along the line from
+                                                                                            L .50, C .11 (the same first
+                                                                                            step) to L .25, C .09, a deep
+                                                                                            rust, never black; 5.3:1, 8.9:1
+                                                                                            and 13.7:1 on the cream page,
+                                                                                            4.9:1, 8.3:1 and 12.9:1 on a
+                                                                                            boxed card (the review's floor
+                                                                                            is the box, 4.5:1) */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
@@ -2509,9 +2517,9 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    T320 (the user, later that day): the word wears the prose weight, not bold, and its three colours are one
    sequential ramp ranked by how much the kind asks of the reader (the tokens' comment has the ranking). */
 .postal-kind { font-weight: 400; }
-.postal-kind-delegate { color: var(--postal-delegate, #7fb8e7); }
-.postal-kind-coordinate { color: var(--postal-coordinate, #7996af); }
-.postal-kind-question { color: var(--postal-question, #91d9ff); }
+.postal-kind-delegate { color: var(--postal-delegate, #90badd); }
+.postal-kind-coordinate { color: var(--postal-coordinate, #5d92bc); }
+.postal-kind-question { color: var(--postal-question, #c3e3fd); }
 /* BOTH ENDS of a postal card in the head, each in its session's identity colour (the peer's chip as before, and this
    session's own chip after it); a narrow head collapses this session's chip to its coloured dot, so both colours
    still show where the words would not fit */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2521,9 +2521,13 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   .turn-postal-service .notice-src-self .notice-src-name { display: none; }
 }
 /* the DELIVERY STATE icon at the head's right edge (postal-state.ts for the map): dim for sent and delivered, the
-   accent for read, the heads-up amber for parked, the blocked red for bounced */
+   accent for read, the heads-up amber for parked, the blocked red for bounced. The mark keeps the STATE colour, never
+   the kind word's. sent / delivered / read is the circled-check ladder (T337): the read rung is the filled circle with
+   its check cut out in the page colour, so the check reads as a hole, not a second colour */
 .postal-delivery { flex: 0 0 auto; margin-left: auto; display: inline-flex; align-self: center; color: var(--dim); }
+.postal-delivery svg { display: block; }
 .postal-delivery-read { color: var(--accent); }
+.postal-delivery-read .postal-mark-check { stroke: var(--bg); }
 .postal-delivery-parked { color: var(--warn); }   /* the heads-up amber: waiting, not an error */
 .postal-delivery-bounced { color: var(--st-blocked-bg); }
 /* a postal card with NOTHING TO FOLD hides nothing behind a fold, so it may not hide anything behind an ellipsis

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -94,7 +94,8 @@ body.scheme-solarized-dark {
      three unrelated hues, ranked by how much the kind asks of the reader: coordination lowest (an FYI), delegation
      next (work handed over), question highest (an answer owed). More asking = more intense against the page. The
      three are sampled EVENLY, at positions 0, 1/2 and 1 of one straight line in OKLCH (T337, the user 2026-09-10, who
-     found the first three too alike: they spanned a fifth of the line, L .66 to .86 at one saturation). On the dark
+     found the first three too alike: T320's steps sat at L .66, .76 and .85, a span of .19 against this line's .26,
+     and the top two shared one saturation, so they read as two tints of one blue). On the dark
      page the line runs from the deepest blue that still reads on a boxed card (L .64, C .085: 4.6:1 on --box-bg, the
      review's floor being 4.5) to the brightest tint the hue holds (L .90, C .05, the sRGB gamut's edge), hue pinned
      at the accent's 244 throughout; 5.0:1, 8.1:1 and 12.5:1 on the page, 4.6:1, 7.5:1 and 11.5:1 on a boxed card,

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -246,7 +246,7 @@ body.theme-light {
   --box-border: rgba(0, 0, 0, 0.12);
   /* the kind ramp (T320, T337): the accent's clay hue (OKLCH 38) deepening with rank, sampled evenly along the line
      from L .50, C .11 (the same first step as T320, the lightest clay that reads at 4.5:1 on the provisional wash) to
-     L .30, C .10 (a deep rust that stays red, short of the prose ink --fg at L .236: 0.118 from it in OKLab); 5.3:1, 8.1:1 and 11.8:1
+     L .30, C .098 (the hue's gamut edge there; a deep rust that stays red, short of the prose ink --fg at L .236: 0.118 from it in OKLab); 5.3:1, 8.1:1 and 11.8:1
      on the cream page, 4.9:1, 7.6:1 and 11.1:1 on a boxed card, 4.8:1, 7.3:1 and 10.7:1 on the provisional wash */
   --postal-coordinate: #974a32;  --postal-delegate: #752f18;  --postal-question: #551400;
   --err: #B02A1C;
@@ -1437,8 +1437,8 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* a remote session's "host:" on either chip sits on that shared backing, which is the same in both themes,
    so its colour is too: the global .host-prefix rule's var(--dim) is tuned for the page, and the light
    theme's dim (#5D574E) reads about 2.2 to 2.7:1 on this backing. White at 0.7 alpha reads 9.1:1 on the
-   Awaiting chip and 9.5:1 on the user bubble, the same in both themes (a queued bubble's 0.85 opacity dims the
-   whole chip alike, and the prefix still clears 4.5:1 there), and stays visibly quieter than the #fff peer name
+   Awaiting chip and 9.5:1 on the user bubble, the same in both themes (a queued bubble fades by its text ink, not
+   by an element opacity, so a chip inside it keeps this backing whole: T337), and stays visibly quieter than the #fff peer name
    and the identity-coloured mention name. Not color: inherit (.fileview-sess's idiom): on the mention chip that
    is the identity colour, and the palette's darker swatches are already the faintest text on this backing. */
 .chip-peer-name .host-prefix, .mention-chip .host-prefix { color: rgba(255, 255, 255, 0.7); }
@@ -2045,8 +2045,9 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    undiscoverable and re-render-fragile). The bubble itself is no longer clickable; only the ✕ acts. It sits
    in the top-right corner (the bubble reserves padding for it) — dim until the bubble is hovered, red on
    its own hover, matching the "remove" reading everywhere else. */
-.queued-bubble.cancelable { position: relative; padding-right: 30px; transition: opacity .1s, border-color .1s, background .1s; }
-.queued-bubble.cancelable:hover { opacity: 1; border-color: var(--accent); }
+.queued-bubble.cancelable { position: relative; padding-right: 30px; transition: color .1s, border-color .1s, background .1s; }
+.queued-bubble.cancelable:hover { --prov-ink: var(--fg); border-color: var(--accent); }   /* hovered, the words lift to full ink
+   (the old opacity lift, now that the fade is the ink: T337) */
 .queued-x {
   position: absolute; top: 3px; right: 4px; width: 20px; height: 20px;
   display: flex; align-items: center; justify-content: center;
@@ -2069,7 +2070,7 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    width, the dashed provisional look kept, the ✕ still in its corner — with Save and Cancel under the text. The field
    inherits the bubble's type; the buttons and the labels wear the queued header's 0.82em. A bubble another client is
    editing reads "editing" beside its text; a refused edit says why on its own line. */
-.queued-bubble.editing { opacity: 1; border-color: var(--accent); padding-right: 52px; box-sizing: border-box; }   /* the width set from the measured bubble is its border box; the idle padding kept, so the words keep their wrap (the ✎'s room stays empty) */
+.queued-bubble.editing { --prov-ink: var(--fg); border-color: var(--accent); padding-right: 52px; box-sizing: border-box; }   /* full ink while editing (the old opacity lift, now the ink: T337); the width set from the measured bubble is its border box; the idle padding kept, so the words keep their wrap (the ✎'s room stays empty) */
 .queued-editor { display: flex; flex-direction: column; gap: 6px; }
 .queued-editbox {
   width: 100%; box-sizing: border-box; display: block; resize: none; overflow: hidden;
@@ -2087,7 +2088,8 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
 /* A notice romp itself queued (T243) wears the LANDED romp notice card nested inside the queued bubble: the
    dashed "you" dress comes off the wrapper (the card brings its own gray tone), and the ✕ moves inside the
    card's corner so it reads as the card's control. */
-.queued-bubble.queued-romp { background: transparent; border: 0; padding: 0; opacity: 1; }
+.queued-bubble.queued-romp { background: transparent; border: 0; padding: 0; --prov-ink: var(--fg); }   /* the nested card's
+   gist reads at the landed card's full ink, not the dress's faded ink (T337) */
 .queued-bubble.queued-romp.cancelable { padding-right: 0; }
 .queued-bubble.queued-romp.cancelable:hover { border-color: transparent; }
 .queued-bubble.queued-romp > .notice { margin-top: 0; }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2534,7 +2534,6 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    the kind word's. sent / delivered / read is the circled-check ladder (T337): the read rung is the filled circle with
    its check cut out in the page colour, so the check reads as a hole, not a second colour */
 .postal-delivery { flex: 0 0 auto; margin-left: auto; display: inline-flex; align-self: center; color: var(--dim); }
-.postal-delivery svg { display: block; }
 .postal-delivery-read { color: var(--accent); }
 .postal-delivery-read .postal-mark-check { stroke: var(--bg); }
 .postal-delivery-parked { color: var(--warn); }   /* the heads-up amber: waiting, not an error */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -94,15 +94,19 @@ body.scheme-solarized-dark {
      three unrelated hues, ranked by how much the kind asks of the reader: coordination lowest (an FYI), delegation
      next (work handed over), question highest (an answer owed). More asking = more intense against the page. The
      three are sampled EVENLY, at positions 0, 1/2 and 1 of one straight line in OKLCH (T337, the user 2026-09-10, who
-     found the first three too alike: T320's steps sat at L .66, .76 and .85, a span of .19 against this line's .26,
-     and the top two shared one saturation, so they read as two tints of one blue). On the dark
-     page the line runs from the deepest blue that still reads on a boxed card (L .64, C .085: 4.6:1 on --box-bg, the
-     review's floor being 4.5) to the brightest tint the hue holds (L .90, C .05, the sRGB gamut's edge), hue pinned
-     at the accent's 244 throughout; 5.0:1, 8.1:1 and 12.5:1 on the page, 4.6:1, 7.5:1 and 11.5:1 on a boxed card,
-     whose --box-bg wash the word also sits on. The light theme runs its own line the other way, deepening toward the
-     dark end of its clay accent (below). postal-kind-ramp.test.ts holds the positions, theme-parity.test.ts the
-     contrast. */
-  --postal-coordinate: #5d92bc;  --postal-delegate: #90badd;  --postal-question: #c3e3fd;
+     found the first three too alike: T320's steps sat at L .66, .76 and .85 with the top two at one saturation, so
+     they read as two tints of one blue). The line's two ends are two floors. The deep end is the deepest blue that
+     still reads at 4.5:1 on the PROVISIONAL card, the darkest ground a kind word sits on (a sent card not yet landed
+     wears the pending bubble's dress, an 8.5% wash of --you over the page; the boxed card and the bare page sit above
+     it): L .65, C .10. The far end stops short of the prose ink, so a lone Question still reads as a colour and not
+     as body text: the accent's own height, L .85, C .078, the sRGB gamut's edge for the hue; hue pinned
+     at the accent's 244 throughout. The trade-off is span against distance from the ink: a brighter far end widens
+     the ramp but converges on --fg (L .845), and this end keeps the word 0.079 from it in OKLab, all of it chroma.
+     Contrast: 5.2:1, 7.6:1 and 10.6:1 on the page, 4.8:1, 7.0:1 and 9.8:1 on a boxed card, 4.8:1, 7.0:1 and 9.8:1 on the provisional
+     wash. The light theme runs its own line the other way, deepening toward the dark end of its clay accent (below).
+     postal-kind-ramp.test.ts holds the positions and the distance from the ink, theme-parity.test.ts the contrast on
+     all three grounds. */
+  --postal-coordinate: #5696c8;  --postal-delegate: #7cb5e3;  --postal-question: #a2d4fe;
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
@@ -240,17 +244,11 @@ body.theme-light {
   --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
-  --postal-coordinate: #974a32;  --postal-delegate: #6c2a14;  --postal-question: #430a00;   /* the kind ramp (T320, T337): the
-                                                                                            accent's clay hue (OKLCH 38)
-                                                                                            deepening with rank, sampled
-                                                                                            evenly along the line from
-                                                                                            L .50, C .11 (the same first
-                                                                                            step) to L .25, C .09, a deep
-                                                                                            rust, never black; 5.3:1, 8.9:1
-                                                                                            and 13.7:1 on the cream page,
-                                                                                            4.9:1, 8.3:1 and 12.9:1 on a
-                                                                                            boxed card (the review's floor
-                                                                                            is the box, 4.5:1) */
+  /* the kind ramp (T320, T337): the accent's clay hue (OKLCH 38) deepening with rank, sampled evenly along the line
+     from L .50, C .11 (the same first step as T320, the lightest clay that reads at 4.5:1 on the provisional wash) to
+     L .30, C .10 (a deep rust that stays red, short of the prose ink --fg at L .236: 0.118 from it in OKLab); 5.3:1, 8.1:1 and 11.8:1
+     on the cream page, 4.9:1, 7.6:1 and 11.1:1 on a boxed card, 4.8:1, 7.3:1 and 10.7:1 on the provisional wash */
+  --postal-coordinate: #974a32;  --postal-delegate: #752f18;  --postal-question: #551400;
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
@@ -2028,12 +2026,21 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    box at the bubble's 72% width until the receipt landed; `.notice.queued-bubble` outranks it. The slim selector stays:
    `.notice.notice-slim`, later in the file too, would otherwise beat `.notice.queued-bubble` on the slim card. */
   max-width: 72%; overflow-wrap: anywhere; display: flow-root;
-  background: color-mix(in srgb, var(--you) 10%, transparent); border: 1px dashed color-mix(in srgb, var(--you) 65%, transparent);
-  border-radius: 14px; padding: 7px 12px; color: var(--fg); opacity: 0.85;
+  /* the FADE is in the dress's colours, not an opacity on the element (T337, the review of the kind colours): an element
+     opacity dimmed every colour inside, the postal kind word included, which then read below 4.5:1 on the wash. The
+     three values are the old 10% wash, 65% dashes and --fg text at the old 0.85, folded in, so the pending bubble looks
+     as it did; what changed is that a descendant with a colour of its own (the postal head's chips, kind word and mark,
+     a link or code span in the pending text) now shows that colour whole. --prov-ink is the faded text, read below by
+     the notice's gist and body, whose own rules would otherwise set --fg back. */
+  --prov-ink: color-mix(in srgb, var(--fg) 85%, transparent);
+  background: color-mix(in srgb, var(--you) 8.5%, transparent); border: 1px dashed color-mix(in srgb, var(--you) 55%, transparent);
+  border-radius: 14px; padding: 7px 12px; color: var(--prov-ink);
 }
 .notice.queued-bubble, .notice.notice-slim.queued-bubble { max-width: none; display: block; }   /* the notice keeps its row
    width and flex head at either density; only the dress is the bubble's (the shared rule's specificities, later in the
    file). The boxed card too: it fills the column while provisional, so nothing snaps when the receipt lands. */
+.notice.queued-bubble .notice-gist, .notice.queued-bubble .notice-body { color: var(--prov-ink); }   /* the words fade with
+   the dress; the head's own colours (the ends' chips, the kind word, the delivery mark) stay whole */
 /* A CANCELABLE queued bubble carries an explicit ✕ (the user 2026-07-08 — the old whole-bubble click was
    undiscoverable and re-render-fragile). The bubble itself is no longer clickable; only the ✕ acts. It sits
    in the top-right corner (the bubble reserves padding for it) — dim until the bubble is hovered, red on
@@ -2518,9 +2525,9 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    T320 (the user, later that day): the word wears the prose weight, not bold, and its three colours are one
    sequential ramp ranked by how much the kind asks of the reader (the tokens' comment has the ranking). */
 .postal-kind { font-weight: 400; }
-.postal-kind-delegate { color: var(--postal-delegate, #90badd); }
-.postal-kind-coordinate { color: var(--postal-coordinate, #5d92bc); }
-.postal-kind-question { color: var(--postal-question, #c3e3fd); }
+.postal-kind-delegate { color: var(--postal-delegate, #7cb5e3); }
+.postal-kind-coordinate { color: var(--postal-coordinate, #5696c8); }
+.postal-kind-question { color: var(--postal-question, #a2d4fe); }
 /* BOTH ENDS of a postal card in the head, each in its session's identity colour (the peer's chip as before, and this
    session's own chip after it); a narrow head collapses this session's chip to its coloured dot, so both colours
    still show where the words would not fit */

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -86,6 +86,13 @@ const PAIRS: Array<[string, string, number]> = [
   ["--hl-attr", "--bg", 4.5],
 ];
 
+test("styles.css: the provisional wash the kind pairs are computed against is the one the sheet paints", () => {
+  const css = read("styles.css");
+  const bubble = css.slice(css.indexOf(".queued-bubble, .notice.queued-bubble, .notice.notice-slim.queued-bubble {"), css.indexOf("\n}\n", css.indexOf(".queued-bubble, .notice.queued-bubble, .notice.notice-slim.queued-bubble {")));
+  assert.match(bubble, /background: color-mix\(in srgb, var\(--you\) 8\.5%, transparent\);/);
+  assert.doesNotMatch(bubble, /opacity:/, "the fade is in the colours: no element opacity dims the words on the card");
+});
+
 for (const sheet of ["styles.css", "feed.css"]) {
   const css = read(sheet);
   const dark = props(block(css, ":root {"));
@@ -117,6 +124,17 @@ for (const sheet of ["styles.css", "feed.css"]) {
       // a skip must be loud (PR #763 item 6): pin how many pairs actually ran per sheet/theme —
       // grow these numbers when PAIRS grows, never let them silently shrink
       const expected = sheet === "styles.css" ? PAIRS.length : 20;   // feed's :root holds a deliberate subset (+ the retrying pair, 2026-09-08)
+      // T337: the postal kind words also sit on the PROVISIONAL card (a sent card not yet landed wears the pending
+      // bubble's dress: an 8.5% wash of --you over the page, styles.css .queued-bubble, no element opacity since the
+      // fade moved into the dress's colours), the darkest ground they meet; each reads at 4.5:1 there too
+      if (sheet === "styles.css") {
+        const you = rgbOf(theme.get("--you")!, page)!;
+        const wash = [0, 1, 2].map((i) => Math.round(you[i] * 0.085 + page[i] * 0.915)) as [number, number, number];
+        for (const tok of ["--postal-coordinate", "--postal-delegate", "--postal-question"]) {
+          const fore = rgbOf(theme.get(tok)!, wash)!;
+          assert.ok(contrast(fore, wash) >= 4.5, `${sheet} ${name}: ${tok} on the provisional wash = ${contrast(fore, wash).toFixed(2)} < 4.5`);
+        }
+      }
       assert.ok(evaluated >= expected,
         `${sheet} ${name}: only ${evaluated}/${expected} contrast pairs evaluated — silent skip`);
     }


### PR DESCRIPTION
Two visual changes to the postal message cards in the chat pane, both from the user (2026-09-10, T337).

**Kind colours, evenly spread.** The three kind words (Coordination, Delegation, Question) looked too alike: T320's dark steps sat at lightness .66, .76 and .85 with the top two at one saturation, so they read as two tints of one blue; its light steps sat at .50, .45 and .36, the first two only .05 apart. Each theme's three tokens now sit at positions 0, 1/2 and 1 of one straight line in OKLCH with the hue pinned to the accent's, and the line's two ends are two floors. The deep end is the deepest step that still reads at 4.5:1 on the provisional card, the darkest ground a kind word sits on (a sent card not yet landed wears the pending bubble's wash of the session's own colour). The far end stops short of the prose ink, so a lone Question still reads as a colour and not as body text. Dark: L .65, C .10 to L .85, C .078 (the accent's own height, the gamut's edge for the hue): #5696c8, #7cb5e3, #a2d4fe. Light: L .50, C .11 (the same first step as before) to L .30, C .098 (the hue's gamut edge there; a deep rust that stays red): #974a32, #752f18, #551400. The trade-off is span against distance from the ink: a brighter far end widens the ramp but converges on the body text; each line spans .20 of lightness, against T320's .19 and .14, and keeps Question 0.079 (dark) and 0.118 (light) from the ink in OKLab. The two floors leave the dark line's lightness span at .20, about where T320's .19 stood: what separates the three steps now is the chroma gradient (the deep step is the most saturated, .100, the far step the palest, .079) with the hue held, rather than lightness alone. A wider spread is available only by spending hue, leaving the accent's family for part of the ramp; the ramp test pins the span at .19 or more so it cannot shrink further, and whether to spend hue is a design call for the user, not a re-ink. Ranking, prose weight, placement and the light re-ink rule stay as T320 set them. The documentation stylesheet's mirror of the dark values follows.

**The provisional dress fades by its colours.** The pending bubble's dress (which a sent card wears until it lands) faded the whole element at 0.85, the kind word included, which then read below 4.5:1 on the wash. The fade now lives in the dress's own colours: an 8.5% wash, 55% dashes and text at 85% of the foreground, the old values folded in, so the pending bubble looks as it did; a descendant with a colour of its own (the postal head's chips, kind word and mark; a link or code span in pending text) now shows that colour whole, and the notice's gist and body read the faded ink explicitly. The old opacity lifts are ink lifts: a hovered cancelable bubble and a bubble being edited bring their words to full ink, and a notice romp itself queued keeps its landed card's full ink under the wrapper.

**Delivery marks, the circled check.** Sent, delivered and read are now the ladder messaging apps draw: a hollow circle, the circle with a check, the filled circle with the check cut out in the page colour. One circle and one three-point check, so the three rungs read as one mark changing state; the marks keep the state colour (dim, dim, the accent), never the kind's, and sit where the checks sat. This is an adaptation of Signal's ladder, not its rungs one for one: Signal draws sending hollow, sent as a circled check, delivered as a circled double check and read filled; the kernel files three states, so ours maps sent, delivered and read onto hollow, check and filled check. The drawings are this repository's own primitives in postal-state.ts, not an icon set's assets: the repository is Apache-2.0, Signal's icons are AGPL-3.0 and are not copied (the module's comment carries the note). The box is 14 px with a 1.5 stroke, heavier than the envelope glyph at the head's other end (12 px, 1.4): a ring with a check inside needs the room for the check's arms to stay clear of the ring at device scale 1, and the stroke is the mark's own specification. The clock, cross and return arrow are unchanged.

**Design points.** One rule drives both themes (positions on a line between two stated floors, not hand-picked hexes), so the pin is the position: a re-ink that keeps the line and the even spacing passes, one that bunches two steps, leaves the hue or runs into the ink fails. The read rung's check is a knock-out in `var(--bg)` from the sheet rather than a second colour, because a presentation attribute cannot carry a custom property. The glyph map moved into the side-effect-free module so an executed test, not a source regex, holds the ladder.

**Tests.** `ui/webview/postal-kind-ramp.test.ts` (new) converts the declared tokens to OKLCH and holds the positions, the even steps, the hue, the distance of Question from the foreground ink and the comment's two endpoints. `theme-parity.test.ts` holds every kind token at 4.5:1 on the page, the boxed card and the provisional wash in both themes, and that the wash it computes is the one the sheet paints. `postal-state.test.ts` executes the map: one radius on the three circles fitting the box, a three-point check clear of the ring on delivered and read only, the fill on read only, three distinct drawings, the other glyphs unchanged, the licence and mapping notes. `postal-card.test.ts` and `postal-intent.test.ts` carry the values, the wrapper, the knock-out rule and the dress's colour fade (no element opacity). `tests/test_postal_cards_served.py` reads the three computed kind colours, every kind word's contrast against the ground it sits on (page, box or wash) in both themes, the absence of an element opacity on provisional cards, and the marks as the browser draws them (box, stroke, circle count, fill, the check's stroke against the page colour), the read rung again under the light theme.

**Screenshots** (hermetic served page, synthetic sessions and tags, all three kinds and all three mark states; dark at 1000, 520 and 340 px, light at 1000 and 340 px): `~/.local/state/romp/drops/t337-postal-marks/romp_chat-postal-cards-{dark,light}-{1000,520,340}.png`.
