### PR TITLE
The chat's day divider: a notice run timed by its latest member, a day opens only forward, the date centered with the rail through it (T339)

### DIFF
--- a/tests/test_day_divider_served.py
+++ b/tests/test_day_divider_served.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""T339 (the user 2026-09-11, screenshot): the chat's day divider. Three faults on the real /chat page of a hermetic kernel:
+(1) the rail's vertical line broke above and below the divider; (2) the date sat at the prose edge with the hairline to its
+right alone; (3) a collapsed run of notices whose FIRST member carried yesterday's time among today's rows drew a
+"Yesterday" divider inside today and wore yesterday's clock. The producer, from the kernel's code: a session's LIVE echo
+atoms (the kernel's own copies of sent messages, kept until the transcript lands their text; persisted in the registry's
+`echoes` mirror and reseeded at boot) are merged into the chat's LAST turn sorted by their own SEND time (kernel.py, the
+live-atom merge), so a romp notice sent yesterday whose text never landed sits right after the previous turn's rows, among
+today's, stamped yesterday; two such echoes fold into one notice run timed by its first.
+
+Two synthetic sessions on one kernel. `web`: rows two days ago, yesterday and today (two turns), the registry mirroring two
+echoes of romp notices, the first sent yesterday, the second today between the two turns. `api`: the same shape read a day
+later, rows all yesterday and both echoes two days ago (a run whose latest member is itself stale): against the previous
+row alone the stale run drew no divider but became the reference, and the next in-sequence row crossed "forward" into a
+day already open, a second "Yesterday" mid-day (the review's finding; time-marker.ts DayWalk is the high-water mark that
+closes it). Asserted, dark and light: `web` shows two dividers only (the weekday over two days ago, "Yesterday" over
+yesterday's first row) and none above the notice run, whose head wears its latest member's time; `api` shows exactly one
+"Yesterday"; each divider's label is centered in the column between two hairlines of equal width; the divider's rail
+segment is painted on the turns' own line (the same page x) and reaches the neighbouring turns' boxes above and below
+(painted geometry, not the rule text); a divider that leads the transcript (nothing on the rail above it: the first child,
+or the one after the pinned system-context card, which sits off the rail) draws no segment and the turn after it starts
+its rail where a first turn does. The browser's clock is pinned to the epoch the fixture was stamped from, so a run that
+crosses local midnight between the boot and the drive still agrees with itself.
+
+With DD_SHOTS=<dir> the driver writes screenshots (dark and light, the `web` session); DD_BEFORE_DIST=<dist> serves another
+tree's bundle for the before shots and skips the assertions, unless DD_BEFORE_ASSERT=1 keeps them (how the test is proven
+red against the bundle before the change: a third divider inside today above `web`'s notice run; and, against the branch
+before the high-water mark, a second "Yesterday" in `api`). Skips LOUDLY without the extension deps or a Playwright
+browser; the extension CI job installs Chromium and runs served files with ROMP_SERVED_TESTS_REQUIRE=1, which turns any
+skip into a failure there. SYNTHETIC fixtures only (sessions web and api, invented notice texts, the notes-api demo world)."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SID_A = "aaaaaaaa-1111-2222-3333-444444444444"   # web: today's rows, one stale echo among them
+SID_B = "bbbbbbbb-1111-2222-3333-444444444444"   # api: the same read a day later, both echoes stale
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _local_day(days_ago, hour, minute, now):
+    """An epoch on the LOCAL day `days_ago` days before `now` at hour:minute (the chat's day keys are the browser's local
+    time, the same machine's as this runner's; the browser's clock is pinned to `now` too)."""
+    lt = time.localtime(now)
+    base = time.mktime((lt.tm_year, lt.tm_mon, lt.tm_mday, hour, minute, 0, 0, 0, -1))
+    return int(base) - days_ago * 86400
+
+
+NOTICE_MARKERS = "\n\n<!-- romp-injected --><!-- romp-system --><!-- romp-tag: watch -->"
+NOTICE_1 = "[romp] The condition you asked romp to watch now HOLDS: the search suite's log has its verdict.<!-- romp-gist: the condition it was watching now holds -->" + NOTICE_MARKERS
+NOTICE_2 = "[romp] The condition you asked romp to watch now HOLDS: the second log has its verdict.<!-- romp-gist: the condition it was watching now holds -->" + NOTICE_MARKERS
+
+
+def _echoes(now, shift):
+    """The registry's echo mirror: two romp notices the kernel sent and whose text never landed. Reseeded at boot as live
+    atoms, they merge into the last turn by their own send time: after the first turn's rows, before the second turn's.
+    `shift` 0 (web): the first sent YESTERDAY 09:47, the second today 00:12. `shift` 1 (api): both two days ago."""
+    if shift == 0:
+        return [{"uuid": "echo:" + "a" * 32, "t": _local_day(1, 9, 47, now), "text": NOTICE_1, "author": "romp"},
+                {"uuid": "echo:" + "b" * 32, "t": _local_day(0, 0, 12, now), "text": NOTICE_2, "author": "romp"}]
+    return [{"uuid": "echo:" + "c" * 32, "t": _local_day(2, 9, 40, now), "text": NOTICE_1, "author": "romp"},
+            {"uuid": "echo:" + "d" * 32, "t": _local_day(2, 9, 41, now), "text": NOTICE_2, "author": "romp"}]
+
+
+def _records(sid, now, shift):
+    """The transcript. `shift` 0 (web): a pair two days ago, a pair yesterday (a real day boundary), then today: two turns,
+    the echoes merging between them. `shift` 1 (api): two turns, all yesterday (the transcript read a day later)."""
+    def user(uuid, parent, t, text):
+        return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed", "sessionId": sid,
+                "message": {"role": "user", "content": text}}
+    def asst(uuid, parent, t, text):
+        return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "sessionId": sid,
+                "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn", "content": [{"type": "text", "text": text}]}}
+    if shift == 0:
+        d2, d1 = _local_day(2, 10, 0, now), _local_day(1, 10, 0, now)
+        # today's rows early in the local day, so the fixture's "today" holds from 00:00 on
+        t0 = _local_day(0, 0, 10, now)
+        return [
+            user("u1", None, d2, "how should the notes-api retry loop back off?"),
+            asst("a1", "u1", d2 + 60, "Use exponential backoff with a jitter of ten percent."),
+            user("u2", "a1", d1, "and the cap on retries?"),
+            asst("a2", "u2", d1 + 60, "Five attempts, then surface the failure."),
+            user("u3", "a2", t0, "please run the notes-api search suite"),
+            asst("a3", "u3", t0 + 60, "Running the search suite now."),
+            # the second turn of today; the two echoes (00:12 today and 09:47 yesterday) sort before its trigger
+            user("u4", "a3", t0 + 180, "and the docs suite after it"),
+            asst("a4", "u4", t0 + 240, "Both suites are green; the search module is done."),
+        ]
+    y0 = _local_day(1, 9, 5, now)
+    return [
+        user("u1", None, y0, "please run the notes-api search suite"),
+        asst("a1", "u1", y0 + 60, "Running the search suite now."),
+        # the second turn of yesterday; both echoes (two days ago) sort before its trigger
+        user("u2", "a1", y0 + 300, "and the docs suite after it"),
+        asst("a2", "u2", y0 + 360, "Both suites are green; the search module is done."),
+    ]
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 });
+await page.clock.setFixedTime(cfg.nowMs);   // the page's Date.now() is the epoch the fixture was stamped from; timers keep running
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab[data-id]", { timeout: 20000 });
+const show = async (sid, turns) => {
+  await page.click('#tabs .tab[data-id="' + sid + '"]');
+  await page.waitForFunction((n) => Array.from(document.querySelectorAll("#content .turn")).filter((t) => t.offsetParent !== null).length >= n, turns, { timeout: 30000 });
+  await page.mouse.move(700, 600); await page.waitForTimeout(500);
+};
+const measure = () => page.evaluate(() => {
+  const turn0 = Array.from(document.querySelectorAll("#content .turn")).find((t) => t.offsetParent !== null);
+  const thread = turn0.parentElement;
+  const kids = Array.from(thread.children);
+  const rows = kids.map((n) => {
+    const cs = getComputedStyle(n);
+    const isDiv = n.classList.contains("day-divider");
+    const marker = n.querySelector(":scope > .time-marker");
+    const r = n.getBoundingClientRect();
+    return { cls: n.className, unit: n.dataset.unit ?? null, t: n.dataset.t ?? null, marker: marker ? marker.textContent : null,
+             markerEpoch: marker ? marker.dataset.epoch : null, label: isDiv ? n.querySelector(".day-divider-label").textContent : null,
+             top: r.top, bottom: r.bottom, height: r.height, marginTop: cs.marginTop, marginBottom: cs.marginBottom };
+  });
+  const railX = (n) => { const b = getComputedStyle(n, "::before"); return n.getBoundingClientRect().left + parseFloat(b.left); };
+  const divs = kids.filter((n) => n.classList.contains("day-divider")).map((n) => {
+    const r = n.getBoundingClientRect(); const cs = getComputedStyle(n);
+    const lbl = n.querySelector(".day-divider-label").getBoundingClientRect();
+    const rules = Array.from(n.querySelectorAll(".day-divider-rule")).map((x) => { const b = x.getBoundingClientRect(); return { left: b.left, width: b.width, height: b.height }; });
+    const before = getComputedStyle(n, "::before");
+    const contentLeft = r.left + parseFloat(cs.paddingLeft);
+    const prev = n.previousElementSibling, next = n.nextElementSibling;
+    const box = (m) => m ? { cls: m.className, top: m.getBoundingClientRect().top, bottom: m.getBoundingClientRect().bottom, railX: m.classList.contains("turn") ? railX(m) : null,
+                             railTop: m.classList.contains("turn") ? getComputedStyle(m, "::before").top : null,
+                             t: m.dataset.t ?? null, markerEpoch: (m.querySelector(":scope > .time-marker") || {}).dataset?.epoch ?? null } : null;
+    // leads: nothing rail-bearing above it (the system-context card sits off the rail with its line suppressed)
+    return { label: n.querySelector(".day-divider-label").textContent, leads: kids.slice(0, kids.indexOf(n)).every((m) => m.classList.contains("turn-system")),
+             labelCenter: (lbl.left + lbl.right) / 2, columnCenter: (contentLeft + r.right) / 2, top: r.top, bottom: r.bottom, rules,
+             rail: { display: before.display, width: before.width, left: before.left, top: before.top, bottom: before.bottom, bg: before.backgroundColor, opacity: before.opacity, position: before.position,
+                     x: railX(n), segTop: r.top + parseFloat(before.top), segBottom: r.bottom - parseFloat(before.bottom) },
+             prev: box(prev), next: box(next) };
+  });
+  const tb = getComputedStyle(turn0, "::before");
+  const head = Array.from(document.querySelectorAll("#content .turn-noticegroup")).find((t) => t.offsetParent !== null);
+  return { rows, divs, turnRail: { width: tb.width, left: tb.left, bg: tb.backgroundColor, opacity: tb.opacity },
+           head: head ? { marker: (head.querySelector(":scope > .time-marker") || {}).textContent ?? null, t: head.dataset.t ?? null,
+                          prevIsDivider: !!(head.previousElementSibling && head.previousElementSibling.classList.contains("day-divider")),
+                          gist: head.textContent.trim().slice(0, 80) } : null,
+           theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const out = { web: {}, api: {} };
+await show(cfg.web, 8);
+out.web.dark = await measure();
+if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-day-divider-dark" + (cfg.shotSuffix || "") + ".png", fullPage: false }); }
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(300);
+out.web.light = await measure();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-day-divider-light" + (cfg.shotSuffix || "") + ".png", fullPage: false });
+await show(cfg.api, 4);
+out.api.light = await measure();
+await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(300);
+out.api.dark = await measure();
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedDayDivider(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:          # a skip OR a failure: never leave a kernel or a lab behind
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them; CI's extension job has them and requires this file to run")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one; CI's extension job installs Chromium and requires this file to run")
+        cls.lab = tempfile.mkdtemp(prefix="day-divider-")
+        cls.before = os.environ.get("DD_BEFORE_DIST", "")
+        if not cls.before:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(cls.before or os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        cls.now = time.time()   # ONE epoch for the fixture and the browser's clock: the run cannot straddle midnight against itself
+        for sid, name, shift, colour in ((SID_A, "web", 0, ("#9cd2ff", "#0c1a2e")), (SID_B, "api", 1, ("#ffd29c", "#2e1a0c"))):
+            cwd = os.path.join(cls.lab, "proj-" + name)
+            os.makedirs(cwd, exist_ok=True)
+            Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, colour[0], colour[1]))
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                 "model": "claude-opus-5", "liveModel": "Opus 5", "echoes": _echoes(cls.now, shift)}))
+            proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+            os.makedirs(proj, exist_ok=True)
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in _records(sid, cls.now, shift)))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.port, cls.token = _free_port(), "testtok-daydivider"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _divider_shape(self, d, m, theme):
+        """(2) the date centered over the column, a hairline either side; (1) the rail runs through: the segment is the
+        turn's own line at the same page x, and reaches the neighbouring turns' boxes (painted geometry, not the rule)."""
+        self.assertEqual(len(d["rules"]), 2, "two hairlines: %r" % d)
+        self.assertTrue(all(x["width"] > 40 and abs(x["height"] - 1) < 0.6 for x in d["rules"]), "both rules have room and are hairlines: %r" % d["rules"])
+        self.assertLess(abs(d["rules"][0]["width"] - d["rules"][1]["width"]), 2, "the two rules share the room equally: %r" % d["rules"])
+        self.assertLess(abs(d["labelCenter"] - d["columnCenter"]), 2, "the label sits in the middle of the column: %r" % d)
+        nxt = d["next"]
+        self.assertIsNotNone(nxt, "a divider precedes the turn it opens: %r" % d)
+        self.assertTrue(nxt["cls"].startswith("turn"), "…a turn: %r" % nxt)
+        if d["leads"]:
+            # a LEADING divider: no segment above the date; the turn it opens starts its rail at its first dot, as a first turn does
+            self.assertEqual(d["rail"]["display"], "none", "a leading divider draws no segment in %s: %r" % (theme, d["rail"]))
+            self.assertEqual(nxt["railTop"], "16px", "…and its turn starts its rail where a first turn does: %r" % nxt)
+            return
+        self.assertEqual((d["rail"]["position"], d["rail"]["width"]), ("absolute", m["turnRail"]["width"]), "a 2px segment: %r" % d["rail"])
+        self.assertEqual((d["rail"]["bg"], d["rail"]["opacity"]), (m["turnRail"]["bg"], m["turnRail"]["opacity"]), "the turn's colour and opacity: %r vs %r" % (d["rail"], m["turnRail"]))
+        self.assertLess(abs(d["rail"]["x"] - nxt["railX"]), 0.5, "painted on the turns' own line (the same page x): %r vs %r" % (d["rail"], nxt))
+        prv = d["prev"]
+        self.assertIsNotNone(prv, "a turn above: %r" % d)
+        self.assertLessEqual(d["rail"]["segTop"], prv["bottom"] + 0.5, "the segment reaches the turn above: %r / %r" % (d["rail"], prv))
+        self.assertGreaterEqual(d["rail"]["segBottom"], nxt["top"] - 0.5, "…and the turn below: %r / %r" % (d["rail"], nxt))
+
+    def test_the_divider_opens_each_past_day_once_centered_with_the_rail_through_it_and_never_on_a_stale_row(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "web": SID_A, "api": SID_B,
+                       "nowMs": int(self.now * 1000),
+                       "shots": os.environ.get("DD_SHOTS", ""), "shotSuffix": "-before" if self.before else ""}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one; CI's extension job installs Chromium and requires this file to run")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        if self.before and not os.environ.get("DD_BEFORE_ASSERT"):
+            self.skipTest("a before-the-change dist: screenshots only, the assertions describe the change")
+        now = self.now
+        yesterday_first = _local_day(1, 10, 0, now)
+        two_days_ago = time.strftime("%a", time.localtime(_local_day(2, 10, 0, now)))   # the marker's weekday label for a day within the week
+        later_t = _echoes(now, 0)[1]["t"]
+        # web: today's rows with one stale echo among them
+        for theme in ("dark", "light"):
+            m = r["web"][theme]
+            self.assertEqual(m["theme"], theme)
+            # (3) two dividers only: the first row (two days ago) opens its day, yesterday's first row opens "Yesterday";
+            # none inside today, where the notice run sits with its first member stamped yesterday
+            self.assertEqual([d["label"] for d in m["divs"]], [two_days_ago, "Yesterday"], "two dividers, the transcript's two past days, in %s: %r" % (theme, [d["label"] for d in m["divs"]]))
+            d = m["divs"][1]
+            self.assertEqual(d["next"]["markerEpoch"], str(yesterday_first), "…yesterday's first row: %r" % d["next"])
+            self.assertIsNotNone(m["head"], "the two echoed notices collapsed into one run: %r" % [row["cls"] for row in m["rows"]])
+            self.assertFalse(m["head"]["prevIsDivider"], "no divider above the notice run (its first member is stamped yesterday, its place is today): %r" % m["head"])
+            self.assertEqual(m["head"]["marker"], time.strftime("%H:%M", time.localtime(later_t)), "the run's head wears its LATEST member's time, today's, not yesterday's: %r" % m["head"])
+            self.assertEqual(m["head"]["t"], str(later_t), "…and anchors on it")
+            self.assertTrue(m["divs"][0]["leads"], "the transcript leads with its first day's divider (after the system-context card): %r" % m["divs"][0])
+            for d in m["divs"]:
+                self._divider_shape(d, m, theme)
+        # api: the same read a day later, both echoes stale: exactly ONE "Yesterday" (the review's duplicate closed)
+        b_later_t = _echoes(now, 1)[1]["t"]
+        for theme in ("dark", "light"):
+            m = r["api"][theme]
+            self.assertEqual(m["theme"], theme)
+            self.assertEqual([d["label"] for d in m["divs"]], ["Yesterday"], "one divider: the stale run opens nothing and never becomes the reference, so the return to yesterday's rows opens nothing either, in %s: %r" % (theme, [d["label"] for d in m["divs"]]))
+            self.assertIsNotNone(m["head"], "the two stale echoes collapsed into one run: %r" % [row["cls"] for row in m["rows"]])
+            self.assertFalse(m["head"]["prevIsDivider"], "no divider above the stale run: %r" % m["head"])
+            self.assertEqual(m["head"]["t"], str(b_later_t), "the run's head anchors on its latest member, stale as it is")
+            self.assertTrue(m["divs"][0]["leads"])
+            self._divider_shape(m["divs"][0], m, theme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ui-verify/fixtures/notices-chat.html
+++ b/tools/ui-verify/fixtures/notices-chat.html
@@ -10,7 +10,7 @@
 <!-- 1 · system context: a SYSTEM notice off the rail (nested; .turn-system hides the line) -->
 <div class="turn turn-system"><div class="notice notice-nested notice-sev-info notice-collapsible"><div class="notice-head" data-act="noticetoggle" data-nkey="notice:sysctx:11111111-2222-3333-4444-555555555555"><span class="notice-caret">▸</span><span class="notice-glyph notice-glyph-system"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.3"/><circle cx="8" cy="8" r="5"/><path d="M8 1.6 V3 M8 13 V14.4 M1.6 8 H3 M13 8 H14.4 M3.5 3.5 L4.5 4.5 M11.5 11.5 L12.5 12.5 M3.5 12.5 L4.5 11.5 M11.5 4.5 L12.5 3.5"/></svg></span><span class="notice-src">system</span><span class="notice-gist">System context</span><span class="notice-meta">Opus 4.8 · notes-api · 2 CLAUDE.md</span></div><div class="notice-body"><div><div class="sys-meta"><span class="sys-key">Model</span><span class="sys-val">claude-opus-4-8</span></div></div></div></div></div>
 
-<div class="day-divider"><span class="day-divider-label">Yesterday</span></div>
+<div class="day-divider"><span class="day-divider-rule"></span><span class="day-divider-label">Yesterday</span><span class="day-divider-rule"></span></div>
 
 <div class="turn turn-user"><div class="time-marker">09:12</div><span class="dot user"></span><div class="user-bubble md"><p>Can you ship the notes-api exporter today?</p></div></div>
 

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -480,6 +480,12 @@ test("the thread's identity rail runs continuous — no holes at the list's flex
   assert.match(CSS, /\.cmt-msgs \{ flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 6px; \}/,
     "the 6px gap the -6px below must stay paired with");
   assert.match(CSS, /\.cmt-msgs \.turn \+ \.turn::before \{ top: -6px; \}/);
+  // the day divider between two turns (T339): the flex gap sits on both sides of it and `.turn + .turn` does not fire
+  // after it, so its own segment spans margin plus gap each side; derived from the gap and the divider's margins
+  const gap = Number(CSS.match(/^\.cmt-msgs \{[^}]*gap: (\d+)px;/m)![1]);
+  const margins = CSS.match(/^\.day-divider \{[^}]*margin: (\d+)px 0 (\d+)px;/m)!;
+  assert.match(CSS, new RegExp("^\\.cmt-msgs \\.day-divider::before \\{ top: -" + (gap + Number(margins[1])) + "px; bottom: -" + (gap + Number(margins[2])) + "px; \\}", "m"),
+    "the popover's divider segment covers the gap above and below");
 });
 
 test("the quoted passage is CONTEXT on the thread's opening message — never an item above the branch divider", () => {
@@ -653,7 +659,7 @@ test("the pending echo prunes against EVENTS too — a landed user turn never do
 
 test("the parity bundle (2026-08-26): dividers, owner-scoped in-turn controls, the sid stamp", () => {
   // day dividers open new days in the popover exactly as in the chat (same helper, same idiom)
-  assert.match(UI, /const dayOpen = eventEpoch\(evs\[itemFirstEvent\(it\)\]\);[\s\S]{0,300}?if \(dayOpen != null\) \{\s*\n\s*const dv = dayDividerFor\(dayOpen, prev\);/);   // the T145 relay-note insert sits between
+  assert.match(UI, /const anchor = itemAnchor\(it, \(i\) => eventEpoch\(evs\[i\]\)\);\s*\n\s*const dayOpen = eventEpoch\(evs\[anchor\]\);[\s\S]{0,300}?if \(dayOpen != null\) \{\s*\n\s*const dv = dayDividerFor\(dayOpen, walk\);/);   // the T145 relay-note insert sits between; the unit timed by its anchor member, the divider decided against the walk's mark (T339)
   // the popover's list is stamped with the THREAD sid, and in-turn controls resolve their owner
   // from the DOM at click time — queued ✕ and the api-error card act on the thread, never the tab
   assert.match(UI, /list\.dataset\.session = th\.tid;/);

--- a/ui/webview/compact.test.ts
+++ b/ui/webview/compact.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { compactDisplay, summarizeTools, toolCounts, STANDALONE_TOOLS } from "./compact";
+import { compactDisplay, summarizeTools, toolCounts, itemAnchor, STANDALONE_TOOLS, type DisplayItem } from "./compact";
 
 test("compactDisplay: thinking is dropped entirely", () => {
   const d = compactDisplay(["user", "thinking", "assistant"]);
@@ -144,4 +144,18 @@ test("retry runs and tool runs break each other — two folds, never one mixed g
 test("thinking hides without breaking a retry run, same as a tool run", () => {
   const kinds = ["retried", "thinking", "retried"];
   assert.deepEqual(compactDisplay(kinds), [{ kind: "noticegroup", indices: [0, 2] }]);   // noticegroup since 2026-09-08
+});
+
+// T339 (the user 2026-09-11): a collapsed run is placed and timed by its LATEST member, never its first. The user's
+// transcript held a notice run whose first member carried yesterday's clock among today's rows.
+test("itemAnchor: a lone event is its own anchor; a run anchors on its latest member, ties on the later one", () => {
+  const epochs = [1000, 2000, 500, 2000, null, 3000];
+  const at = (i: number) => epochs[i] ?? null;
+  assert.equal(itemAnchor({ kind: "event", index: 2 }, at), 2);
+  assert.equal(itemAnchor({ kind: "noticegroup", indices: [2, 5] }, at), 5, "yesterday then today: today");
+  assert.equal(itemAnchor({ kind: "noticegroup", indices: [5, 2] }, at), 5, "the latest, wherever it sits in the run");
+  assert.equal(itemAnchor({ kind: "noticegroup", indices: [1, 3] }, at), 3, "a tie: the later member");
+  assert.equal(itemAnchor({ kind: "noticegroup", indices: [0, 4, 1] }, at), 1, "a member with no epoch never anchors");
+  assert.equal(itemAnchor({ kind: "toolgroup", indices: [2, 5] }, at), 2, "a tool run keeps its first member, as before");
+  assert.equal(itemAnchor({ kind: "noticegroup", indices: [4, 4] } as DisplayItem, at), 4, "no timed member: the first");
 });

--- a/ui/webview/compact.ts
+++ b/ui/webview/compact.ts
@@ -60,6 +60,25 @@ export function compactDisplay(kinds: readonly string[], names?: readonly (strin
   return out;
 }
 
+/** The member a display unit is PLACED and TIMED by (T339, the user 2026-09-11). A collapsed NOTICE run anchors on the
+ *  member with the LATEST epoch (ties: the later one), never the first: a run can hold a notice stamped earlier than the
+ *  rows around it (one that kept the moment it was queued and landed in the transcript at delivery), so timed by its first
+ *  member the run wore yesterday's clock among today's rows and the day walk read the step back as a day boundary. The
+ *  latest member is the one in sequence with its neighbours; the head's rail time, the day walk and the walk's exit all
+ *  read it (a run with no timed member falls to its first). Every other unit keeps its FIRST member, as before: a lone
+ *  event is its own anchor, and a tool run's members are in transcript order with its head timed by its first.
+ *  `epochAt(i)` is event i's epoch or null. */
+export function itemAnchor(it: DisplayItem, epochAt: (i: number) => number | null): number {
+  if (it.kind === "event") return it.index;
+  if (it.kind === "toolgroup") return it.indices[0];
+  let best = it.indices[0], bestEp: number | null = null;
+  for (const i of it.indices) {
+    const ep = epochAt(i);
+    if (ep != null && (bestEp == null || ep >= bestEp)) { best = i; bestEp = ep; }
+  }
+  return best;
+}
+
 // One pluralized count of a tool kind, e.g. { label: "Edits", count: 3 }. The label keeps the tool's
 // own Capitalized name (so it reads AS a tool — the user 2026-06-14, matching the bold .tool-name in
 // the non-compact view); only the Edit variants merge under "Edit".

--- a/ui/webview/day-divider.test.ts
+++ b/ui/webview/day-divider.test.ts
@@ -19,10 +19,38 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("dayDividerFor returns a divider only on the first turn of a past day", () => {
+test("dayDividerFor returns a divider only on the first turn of a past day, reached FORWARD (T339)", () => {
   const fn = RENDER.slice(RENDER.indexOf("function dayDividerFor"));
-  assert.match(fn.slice(0, 400), /if \(!day \|\| !date\) return null/, "every other turn gets nothing");
-  assert.match(fn.slice(0, 400), /markerLabel\(epoch, prevEpoch, Date\.now\(\)\)/, "same day-boundary rule as the marker");
+  assert.match(fn.slice(0, 400), /function dayDividerFor\(epoch: number, walk: DayWalk\)[^\n]*\n\s*const date = walk\.open\(epoch, Date\.now\(\)\);\s*\n\s*if \(!date\) return null/, "the marker's day rule plus the forward condition against the walk's high-water mark (time-marker.ts DayWalk, executed in time-marker.test.ts)");
+  // the date centered between two hairlines: a rule, the label, a rule
+  assert.match(fn.slice(0, 600), /d\.append\(el\("span", "day-divider-rule"\), lbl, el\("span", "day-divider-rule"\)\);/);
+});
+
+test("a collapsed run is placed and timed by its ANCHOR member, the latest, on both unit paths (T339)", () => {
+  // the chat's windowed path (appendItem) and the comment popover's parity loop both pick the anchor with the one pure
+  // rule (compact.ts itemAnchor, executed in compact.test.ts) and hand the day walk, the head and the walk's exit to it
+  const ai = RENDER.slice(RENDER.indexOf("function appendItem("), RENDER.indexOf("function renderWindowItems("));
+  assert.match(ai, /const anchor = itemAnchor\(it, \(i\) => eventEpoch\(s\.events\[i\]\)\);\s*\n\s*const dayOpen = eventEpoch\(s\.events\[anchor\]\);/, "the day walk reads the anchor");
+  assert.match(ai, /const dv = dayDividerFor\(dayOpen, walk\);/, "…against the walk's mark, never the raw previous row");
+  assert.match(ai, /renderNoticeGroup\(notes, s\.events\[anchor\], prevEpoch, key, open\)/, "the head is timed by the anchor");
+  assert.match(ai, /renderNoticeGroup\([^\n]*\n\s*adv\(anchor\);/, "the walk leaves a closed run on its anchor");
+  const ng = ai.slice(ai.indexOf('it.kind === "noticegroup"'), ai.lastIndexOf("} else {"));
+  assert.doesNotMatch(ng, /adv\(it\.indices\[0\]\)/, "never the first member of a notice run");
+  assert.match(ng, /\}\);\s*\n\s*adv\(anchor\);/, "…nor the last child of an open one: the anchor");
+  // a tool run is untouched: its members are in transcript order, its head is timed by its first, its walk exits as before
+  assert.match(ai, /renderToolGroup\(tools, prevEpoch, key, open\)\)\);\s*\n\s*adv\(it\.indices\[0\]\);/);
+  const pop = RENDER.slice(RENDER.indexOf("const dayOpen = eventEpoch(evs[anchor]);") - 200, RENDER.indexOf("if (!relayNoted) list.appendChild(cmtRelayedNote"));
+  assert.match(pop, /const anchor = itemAnchor\(it, \(i\) => eventEpoch\(evs\[i\]\)\);/);
+  assert.match(pop, /renderNoticeGroup\(run, evs\[anchor\], prev, key, open\)/);
+  assert.match(pop, /exit = it\.kind === "noticegroup" \? eventEpoch\(evs\[anchor\]\) : prev;[^\n]*\n\s*if \(it\.kind === "noticegroup" && exit != null\) prev = exit;/, "the popover's walk leaves an open notice run on its anchor too");
+  assert.match(pop, /exit = eventEpoch\(it\.kind === "noticegroup" \? evs\[anchor\] : run\[run\.length - 1\]\); if \(exit != null\) prev = exit;/, "…and a closed one; a closed tool run exits on its last member, as before");
+  assert.match(pop, /walk\.pass\(exit\);\s*\n\s*continue;/, "the day mark passes the run's exit");
+  assert.doesNotMatch(RENDER, /eventEpoch\(evs\[itemFirstEvent\(it\)\]\)|eventEpoch\(s\.events\[itemFirstEvent\(it\)\]\)/, "no day walk reads a run's first member");
+  // the head: rail time, data-t, uuid and hover from the anchor; the words from the first member
+  const rng = RENDER.slice(RENDER.indexOf("function renderNoticeGroup("), RENDER.indexOf("function toggleToolGroup("));
+  assert.match(rng, /function renderNoticeGroup\(evs: ChatEvent\[\], anchor: ChatEvent, prevEpoch: number \| null, key: string, open: boolean\)/);
+  assert.match(rng, /const epoch = eventEpoch\(anchor\);\s*\n\s*const anchorUuid = anchor\.uuid \?\? null;/);
+  assert.match(rng, /const b = noticeBrief\(evs\[0\]\);/);
 });
 
 test("the divider is a sibling of the turn, never a child (the dot anchors to the turn's top)", () => {
@@ -57,12 +85,25 @@ test("the incremental tail trim goes by data-unit, not by child count", () => {
   assert.match(RENDER, /n\.dataset\.unit != null \? Number\(n\.dataset\.unit\) : -1/);
 });
 
-test("the divider label is never constrained to a fixed width", () => {
+test("the divider label is never constrained to a fixed width; two hairlines share the leftover room so it centers (T339)", () => {
   const rule = CSS.slice(CSS.indexOf(".day-divider-label"));
   assert.doesNotMatch(rule.slice(0, 200), /\bwidth:|max-width:/, "a fixed width is the bug being closed");
-  // the hairline fills the leftover room, so the label takes exactly what it needs
-  assert.match(CSS, /\.day-divider::after \{[^}]*flex: 1 1 auto/);
+  // the hairlines fill the leftover room equally, so the label takes exactly what it needs and lands in the middle
+  assert.match(CSS, /^\.day-divider-rule \{ flex: 1 1 auto; height: 1px; background: var\(--box-border\); \}/m);
   assert.match(CSS, /\.day-divider-label \{[^}]*flex: 0 0 auto/);
+  assert.doesNotMatch(CSS, /\.day-divider::after/, "the one-sided rule is gone");
+});
+
+test("the rail runs through the divider: its own segment, the turn's line in the turn's colour, spanning its margins (T339)", () => {
+  const turnRail = CSS.match(/^\.turn::before \{ content: ""; position: absolute; left: ([\d.]+px); top: 0; bottom: 0; width: (\d+px); background: ([^;]+); opacity: ([\d.]+); \}/m);
+  assert.ok(turnRail, "the turn's rail rule, the one this segment mirrors");
+  const seg = CSS.match(/^\.day-divider::before \{ content: ""; position: absolute; left: ([\d.]+px); top: (-?\d+px); bottom: (-?\d+px); width: (\d+px); background: ([^;]+); opacity: ([\d.]+); \}/m);
+  assert.ok(seg, "the divider's rail segment");
+  assert.deepEqual([seg![1], seg![4], seg![5], seg![6]], [turnRail![1], turnRail![2], turnRail![3], turnRail![4]], "same left, width, colour and opacity as the turn's line");
+  const box = CSS.match(/^\.day-divider \{[^}]*margin: (\d+px) 0 (\d+px);[^}]*\}/m);
+  assert.ok(box, "the divider's margins");
+  assert.deepEqual([seg![2], seg![3]], ["-" + box![1], "-" + box![2]], "the segment spans the divider's own margins, so the line is continuous");
+  assert.match(CSS, /^\.day-divider \{[^}]*position: relative;/m, "…anchored to the divider");
 });
 
 test("the divider label matches the rail marker's type size", () => {
@@ -77,4 +118,43 @@ test("the divider label matches the rail marker's type size", () => {
   const size = (s: string): string | null => (s.match(/font-size: ([\d.]+em)/) ?? [])[1] ?? null;
   assert.equal(size(rule(".day-divider")), size(rule(".time-marker")));
   assert.equal(size(rule(".day-divider")), "0.72em");
+});
+
+// T339 review: the day walk's reference is a HIGH-WATER MARK (time-marker.ts DayWalk, executed in time-marker.test.ts),
+// separate from the rail's raw previous-row chain (prevEpoch / prevTimedEpoch, the same-minute rule). Every path that
+// emits a divider decides against the mark and passes its unit's exit; a window opening mid-transcript seeds the mark
+// as a walk from the top would have (unitExit, the one rule for both).
+test("every day walk decides against a DayWalk mark and never a raw epoch; windows and tails seed the mark from the top", () => {
+  const calls = RENDER.match(/(?<!function )dayDividerFor\([^)]*\)/g) || [];
+  assert.equal(calls.length, 4, "four call sites: " + calls.join(" | "));
+  for (const c of calls) assert.match(c, /^dayDividerFor\(\w+, walk\)$/, "each hands the walk, not a number: " + c);
+  const ai = RENDER.slice(RENDER.indexOf("function appendItem("), RENDER.indexOf("function renderWindowItems("));
+  assert.match(ai, /^function appendItem\(v: View, s: Session, items: DisplayItem\[\], u: number, prevEpoch: number \| null, walk: DayWalk, working: boolean\): number \| null \{/m);
+  assert.match(ai, /walk\.pass\(unitExit\(s, it\)\);\s*\n\s*return prevEpoch;\s*\n\}/, "the unit's exit passes the mark on the way out");
+  const rw = RENDER.slice(RENDER.indexOf("function renderWindowItems("), RENDER.indexOf("function sizeSpacers("));
+  assert.match(rw, /const walk = dayWalkBefore\(s, items, unitStart\);[^\n]*\n\s*for \(let u = unitStart; u < unitEnd; u\+\+\) prevEpoch = appendItem\(v, s, items, u, prevEpoch, walk, working\);/, "a window seeds the mark by walking the units before it");
+  assert.match(RENDER, /function dayWalkBefore\(s: Session, items: DisplayItem\[\], unitStart: number\): DayWalk \{\s*\n\s*const w = new DayWalk\(\);\s*\n\s*for \(let u = 0; u < unitStart && u < items\.length; u\+\+\) w\.pass\(unitExit\(s, items\[u\]\)\);/);
+  // unitExit: the one rule — a lone event its own epoch, a notice run its anchor, a tool run its first (collapsed) or last (expanded)
+  const ue = RENDER.slice(RENDER.indexOf("function unitExit("), RENDER.indexOf("function dayWalkBefore("));
+  assert.match(ue, /if \(it\.kind === "event"\) return eventEpoch\(s\.events\[it\.index\]\);/);
+  assert.match(ue, /if \(it\.kind === "noticegroup"\) return eventEpoch\(s\.events\[itemAnchor\(it, \(i\) => eventEpoch\(s\.events\[i\]\)\)\]\);/);
+  assert.match(ue, /const open = openFolds\.has\(toolGroupKey\(s\.events\[it\.indices\[0\]\]\)\);\s*\n\s*return eventEpoch\(s\.events\[open \? it\.indices\[it\.indices\.length - 1\] : it\.indices\[0\]\]\);/);
+  // the normal-mode tail: the mark seeded over the events before `from`, passed per row; the rail keeps its raw chain
+  assert.match(RENDER, /const walk = dayWalkBeforeEvent\(s\.events, from\);[^\n]*\n\s*for \(let i = from; i < len; i\+\+\) \{\s*\n\s*const prev = prevTimedEpoch\(s\.events, i\);/);
+  assert.match(RENDER, /v\.el\.appendChild\(node\);\s*\n\s*walk\.pass\(ep\);\s*\n\s*\}/, "…and passes each row");
+  // the cleared-episode fold and the comment popover carry their own walk
+  assert.match(RENDER, /const walk = new DayWalk\(\);   \/\/ the fold divides days/);
+  assert.match(RENDER, /prevEp = ep; walk\.pass\(ep\);/);
+  assert.match(RENDER, /let prev: number \| null = null;[^\n]*\n\s*const walk = new DayWalk\(\);/, "the popover");
+  assert.match(RENDER, /if \(ep != null\) prev = ep;\s*\n\s*walk\.pass\(ep\);\s*\n\s*\}/, "…passes each lone row");
+  assert.doesNotMatch(RENDER, /prevEpoch = prevEpoch == null \? ep : Math\.max/, "the rail's chain stays raw: the mark is the walk's, not the marker's");
+});
+
+test("a divider that leads the transcript draws no rail segment above the date, and its turn starts at its first dot (T339 review)", () => {
+  // leading = the thread's first child, or right after the system-context card, which sits off the rail (its line suppressed)
+  assert.match(CSS, /^\.turn-system::before \{ display: none; \}/m, "the card's own line is off, so a divider after it has nothing above");
+  assert.match(CSS, /^\.day-divider:first-child::before, \.turn-system \+ \.day-divider::before \{ display: none; \}/m);
+  const first = CSS.match(/^\.turn:first-child::before \{ top: (\d+px); \}/m);
+  assert.ok(first, "the first turn's own rule, the one this mirrors");
+  assert.match(CSS, new RegExp("^\\.day-divider:first-child \\+ \\.turn::before, \\.turn-system \\+ \\.day-divider \\+ \\.turn::before \\{ top: " + first![1] + "; \\}", "m"), "the turn after a leading divider starts its rail where a first turn does");
 });

--- a/ui/webview/notice-vocab.test.ts
+++ b/ui/webview/notice-vocab.test.ts
@@ -113,7 +113,8 @@ test("(g) the gallery fixture is checked in and mirrors the builder class-for-cl
   assert.match(fx, /SYNTHETIC/, "the fixture declares itself synthetic (privacy rule)");
   for (const cls of ["notice-sev-info", "notice-sev-romp", "notice-sev-err", "notice-sev-compact", "notice-sev-retry", "notice-sev-warn",
                      "notice-slim", "notice-boxed", "notice-nested", "notice-head", "notice-glyph", "notice-src", "notice-gist", "notice-meta",
-                     "notice-acts", "notice-act", "notice-body", "notice-src-chip", "romp-bubble", "queued-bubble", "undelivered-note"]) {
+                     "notice-acts", "notice-act", "notice-body", "notice-src-chip", "romp-bubble", "queued-bubble", "undelivered-note",
+                     "day-divider-rule"]) {   // the divider's two hairlines around its date (T339)
     assert.ok(fx.includes(cls), "fixture shows ." + cls);
   }
   assert.match(fx, /data-act="noticetoggle"/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -24,8 +24,8 @@ import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, a
 import { lensVisible, surfaceLens } from "./tag-lens";
 import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
 import { syncSessionsFromTabMeta, applyMetaToSession, notePendingMeta, PendingTabMeta } from "./tab-meta";
-import { markerLabel, dayContext } from "./time-marker";
-import { compactDisplay, toolCounts, type DisplayItem } from "./compact";
+import { markerLabel, dayContext, DayWalk } from "./time-marker";
+import { compactDisplay, toolCounts, itemAnchor, type DisplayItem } from "./compact";
 import { senderKind, SenderKind } from "./sender-identity";
 import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompSettings } from "./settings";
 import { backendLabel, effectiveDefaultBackend } from "./backend-names";
@@ -2688,12 +2688,16 @@ function timeMarker(epoch: number, prevEpoch: number | null): HTMLElement {
 // It must be a SIBLING, never the turn's first child: .dot and .time-marker are absolutely
 // positioned against the TURN's top edge, so a divider inside it would shove the message down
 // and leave the dot stranded up beside the rule.
-function dayDividerFor(epoch: number, prevEpoch: number | null): HTMLElement | null {
-  const { day, date } = markerLabel(epoch, prevEpoch, Date.now());
-  if (!day || !date) return null;
+// Only a FORWARD crossing opens a day, against the walk's high-water mark (time-marker.ts DayWalk, T339): a row stamped
+// earlier than the rows around it draws no divider and never becomes the reference. The date sits CENTERED over the
+// column between two hairlines, and the divider carries its own segment of the rail (styles.css .day-divider::before) so
+// the line runs through it (the user 2026-09-11).
+function dayDividerFor(epoch: number, walk: DayWalk): HTMLElement | null {
+  const date = walk.open(epoch, Date.now());
+  if (!date) return null;
   const d = el("div", "day-divider");
   const lbl = el("span", "day-divider-label"); lbl.textContent = date;
-  d.appendChild(lbl);
+  d.append(el("span", "day-divider-rule"), lbl, el("span", "day-divider-rule"));
   return d;
 }
 
@@ -3821,14 +3825,15 @@ function fillClearBody(body: HTMLElement, got: { events: ChatEvent[]; truncated?
   }
   const wrap = el("div", "clear-episode");
   let prevEp: number | null = null;
+  const walk = new DayWalk();   // the fold divides days by the chat's own high-water mark (T339)
   for (const e of got.events) {
     try {
       const ep = eventEpoch(e);
-      const prior = prevEp;   // the PREVIOUS event's epoch — chained, so the fold divides days
+      const prior = prevEp;   // the PREVIOUS event's epoch — chained, so the rail's same-minute rule holds
       if (ep != null) {       // rather than re-stamping the full date on every turn in it
-        const dv = dayDividerFor(ep, prior);
+        const dv = dayDividerFor(ep, walk);
         if (dv) wrap.appendChild(dv);
-        prevEp = ep;
+        prevEp = ep; walk.pass(ep);
       }
       wrap.appendChild(renderEvent(e, prior));
     }
@@ -8931,7 +8936,8 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
     renderingSid = th.tid;
     renderingOwnerSid = sid;   // fold keys are per-thread; file/preview URLs belong to the thread's SESSION
     renderingIntoThread = true;   // same renderer, minus the transcript-coupled hover chrome (see the flag)
-    let prev: number | null = null;
+    let prev: number | null = null;       // the rail's raw previous epoch (the same-minute rule)
+    const walk = new DayWalk();           // the day walk's high-water mark (T339)
     let quoteHost: HTMLElement | null = null;   // the thread's OPENING message — the quote's home
     // the SAME display units the chat renders (the user 2026-08-24, leg C: the popover ignored the
     // compact/hide-thinking setting — thinking blocks and raw tool runs showed regardless of the
@@ -8946,14 +8952,15 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
     let relayNoted = !th.relayedT;   // T145: drop the sent-back marker at its place in time, once
     for (const it of items) {
       // a new day opens with the chat's own divider (the parity bundle, 2026-08-26) — same helper,
-      // same placement idiom as appendItem
-      const dayOpen = eventEpoch(evs[itemFirstEvent(it)]);
+      // same placement idiom as appendItem, the unit timed by its anchor member (T339)
+      const anchor = itemAnchor(it, (i) => eventEpoch(evs[i]));
+      const dayOpen = eventEpoch(evs[anchor]);
       if (!relayNoted && dayOpen != null && dayOpen > (th.relayedT || 0)) {
         list.appendChild(cmtRelayedNote(th.relayedT || 0));
         relayNoted = true;
       }
       if (dayOpen != null) {
-        const dv = dayDividerFor(dayOpen, prev);
+        const dv = dayDividerFor(dayOpen, walk);
         if (dv) list.appendChild(dv);
       }
       if (it.kind === "toolgroup" || it.kind === "noticegroup") {
@@ -8962,7 +8969,8 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
         const open = openFolds.has(key);
         list.appendChild(it.kind === "toolgroup"
           ? renderToolGroup(run as Extract<ChatEvent, { kind: "tool" }>[], prev, key, open)
-          : renderNoticeGroup(run, prev, key, open));
+          : renderNoticeGroup(run, evs[anchor], prev, key, open));
+        let exit: number | null;   // the epoch the run leaves the walk on (the rail chain and the day mark alike)
         if (open) {
           it.indices.forEach((ix, j) => {   // the run's own members — it.indices already excludes thinking
             const child = renderEvent(evs[ix], prev, turnWorkedSecs(evs, ix, thWorking));
@@ -8970,9 +8978,12 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
             list.appendChild(child);
             const ep = eventEpoch(evs[ix]); if (ep != null) prev = ep;
           });
+          exit = it.kind === "noticegroup" ? eventEpoch(evs[anchor]) : prev;   // a notice run leaves the walk on its anchor, whatever order its members came in (T339)
+          if (it.kind === "noticegroup" && exit != null) prev = exit;
         } else {
-          const ep = eventEpoch(run[run.length - 1]); if (ep != null) prev = ep;
+          exit = eventEpoch(it.kind === "noticegroup" ? evs[anchor] : run[run.length - 1]); if (exit != null) prev = exit;
         }
+        walk.pass(exit);
         continue;
       }
       const ev = evs[it.index];
@@ -8983,6 +8994,7 @@ function fillCommentMsgs(list: HTMLElement, th: CommentThread, sid: string): voi
       if (!quoteHost && ev.kind === "user") quoteHost = node;
       const ep = eventEpoch(ev);
       if (ep != null) prev = ep;
+      walk.pass(ep);
     }
     if (!relayNoted) list.appendChild(cmtRelayedNote(th.relayedT || 0));   // relay at the tail — nothing new after it yet
     renderingIntoThread = false;
@@ -10749,16 +10761,18 @@ function syncViewInner(id: string, atBottom?: boolean): View {
   const unitOf = (n: ChildNode): number =>
     n instanceof HTMLElement && n.dataset.unit != null ? Number(n.dataset.unit) : -1;
   while (v.el.lastChild && unitOf(v.el.lastChild) >= from) v.el.removeChild(v.el.lastChild);
+  const walk = dayWalkBeforeEvent(s.events, from);   // the day walk's high-water mark up to here (T339)
   for (let i = from; i < len; i++) {
-    const prev = prevTimedEpoch(s.events, i);
+    const prev = prevTimedEpoch(s.events, i);   // the rail's raw previous epoch (the same-minute rule)
     const ep = eventEpoch(s.events[i]);
     if (ep != null) {   // a day boundary opens with its divider here too, or the tail append would drop it
-      const dv = dayDividerFor(ep, prev);
+      const dv = dayDividerFor(ep, walk);
       if (dv) { dv.dataset.unit = String(i); v.el.appendChild(dv); }
     }
     const node = renderEvent(s.events[i], prev, turnWorkedSecs(s.events, i, working));
     node.dataset.unit = String(i);   // unit === event in normal mode
     v.el.appendChild(node);
+    walk.pass(ep);
   }
   patchWorkedFooters(v, s, from, working);
   v.winEnd = total; v.spacerCount = v.winStart ?? 0; v.spacerCountBot = 0; v.unitTotal = total; v.rendered = len;
@@ -10807,6 +10821,29 @@ function prevTimedEpoch(events: ChatEvent[], i: number): number | null {
   return null;
 }
 
+// The epoch a display unit leaves the day walk on (T339): a lone event its own; a notice run its ANCHOR member (the
+// latest, compact.ts itemAnchor); a tool run its first member when collapsed and its last when expanded, exactly what
+// appendItem's rail chain (adv) leaves behind. One rule for the walk and for a window's seed, so a window opening
+// mid-transcript decides its first divider as a walk from the top would have.
+function unitExit(s: Session, it: DisplayItem): number | null {
+  if (it.kind === "event") return eventEpoch(s.events[it.index]);
+  if (it.kind === "noticegroup") return eventEpoch(s.events[itemAnchor(it, (i) => eventEpoch(s.events[i]))]);
+  const open = openFolds.has(toolGroupKey(s.events[it.indices[0]]));
+  return eventEpoch(s.events[open ? it.indices[it.indices.length - 1] : it.indices[0]]);
+}
+// the day walk's high-water mark a walk from the top would hold before unit `unitStart` (compact units) …
+function dayWalkBefore(s: Session, items: DisplayItem[], unitStart: number): DayWalk {
+  const w = new DayWalk();
+  for (let u = 0; u < unitStart && u < items.length; u++) w.pass(unitExit(s, items[u]));
+  return w;
+}
+// … and before event `i` in normal mode, where every unit is one event
+function dayWalkBeforeEvent(events: ChatEvent[], i: number): DayWalk {
+  const w = new DayWalk();
+  for (let j = 0; j < i && j < events.length; j++) w.pass(eventEpoch(events[j]));
+  return w;
+}
+
 // ── Unified bidirectional virtualization (the user 2026-06-25) ─────────────────────────────────────────
 // Both modes render a window of UNITS [winStart, winEnd): a unit is one event (normal) or one folded
 // compactDisplay item (compact). The hidden head [0, winStart) collapses into a TOP spacer and the hidden
@@ -10841,16 +10878,20 @@ function lastCompactUnit(s: Session, items: DisplayItem[]): number {
 }
 
 // Append one display unit's DOM to v.el (a turn, or a folded toolgroup + its expansion), tagging every node
-// with data-unit = u for the scroll↔unit map. Returns the advanced prevEpoch.
-function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEpoch: number | null, working: boolean): number | null {
+// with data-unit = u for the scroll↔unit map. Returns the advanced prevEpoch (the rail's raw chain, for the same-minute
+// rule); `walk` is the day walk's high-water mark, advanced over the unit's exit (unitExit) and never rewound (T339).
+function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEpoch: number | null, walk: DayWalk, working: boolean): number | null {
   const it = items[u];
   const tag = (node: HTMLElement): HTMLElement => { node.dataset.unit = String(u); return node; };
   const adv = (i: number) => { const ep = eventEpoch(s.events[i]); if (ep != null) prevEpoch = ep; };
   // A new day opens with its divider, above whatever unit starts that day (tagged with the same
-  // data-unit so the scroll↔unit map still resolves every node it walks).
-  const dayOpen = eventEpoch(s.events[itemFirstEvent(it)]);
+  // data-unit so the scroll↔unit map still resolves every node it walks). The unit is placed and timed by its ANCHOR
+  // member (compact.ts itemAnchor, T339): a run's latest member, the one in sequence with its neighbours, never a member
+  // stamped earlier than the rows around it.
+  const anchor = itemAnchor(it, (i) => eventEpoch(s.events[i]));
+  const dayOpen = eventEpoch(s.events[anchor]);
   if (dayOpen != null) {
-    const dv = dayDividerFor(dayOpen, prevEpoch);
+    const dv = dayDividerFor(dayOpen, walk);
     if (dv) v.el.appendChild(tag(dv));
   }
   if (it.kind === "toolgroup") {
@@ -10874,19 +10915,21 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
     const notes = it.indices.map((i) => s.events[i]);
     const key = noticeGroupKey(notes[0]);
     const open = openFolds.has(key);
-    v.el.appendChild(tag(renderNoticeGroup(notes, prevEpoch, key, open)));
-    adv(it.indices[0]);
+    v.el.appendChild(tag(renderNoticeGroup(notes, s.events[anchor], prevEpoch, key, open)));   // timed by the anchor member (T339)
+    adv(anchor);
     if (open) {
       it.indices.forEach((i, j) => {
         const child = renderEvent(s.events[i], prevEpoch, turnWorkedSecs(s.events, i, working));
         child.classList.add("tg-child"); if (j === it.indices.length - 1) child.classList.add("tg-last");
         v.el.appendChild(tag(child)); adv(i);
       });
+      adv(anchor);   // the walk leaves the run on its latest member, whatever order its members came in
     }
   } else {
     v.el.appendChild(tag(renderEvent(s.events[it.index], prevEpoch, turnWorkedSecs(s.events, it.index, working))));
     adv(it.index);
   }
+  walk.pass(unitExit(s, it));
   return prevEpoch;
 }
 
@@ -10899,7 +10942,8 @@ function renderWindowItems(v: View, s: Session, items: DisplayItem[], unitStart:
   while (v.el.firstChild) v.el.removeChild(v.el.firstChild);
   if (unitStart > 0) v.el.appendChild(el("div", "tx-spacer tx-spacer-top"));
   let prevEpoch = unitStart > 0 && unitStart < total ? prevTimedEpoch(s.events, itemFirstEvent(items[unitStart])) : null;
-  for (let u = unitStart; u < unitEnd; u++) prevEpoch = appendItem(v, s, items, u, prevEpoch, working);
+  const walk = dayWalkBefore(s, items, unitStart);   // the mark a walk from the top would hold here (T339)
+  for (let u = unitStart; u < unitEnd; u++) prevEpoch = appendItem(v, s, items, u, prevEpoch, walk, working);
   if (unitEnd < total) v.el.appendChild(el("div", "tx-spacer tx-spacer-bot"));
   v.winStart = unitStart; v.winEnd = unitEnd;
   v.spacerCount = unitStart; v.spacerCountBot = total - unitEnd; v.unitTotal = total;
@@ -11030,18 +11074,21 @@ function noticeBrief(ev: ChatEvent): { src: string; glyph: NoticeGlyphKind; gist
   }
   return { src: "session", glyph: "session", gist: "" };
 }
-function renderNoticeGroup(evs: ChatEvent[], prevEpoch: number | null, key: string, open: boolean): HTMLElement {
+// `anchor` is the member the run is placed and timed by (compact.ts itemAnchor, T339): its latest, the one in sequence
+// with the rows around it. The head's rail time, data-t, uuid and hover wiring all read it; the words (the source, the
+// glyph, the first gist) stay the first member's, which is what the run reads as.
+function renderNoticeGroup(evs: ChatEvent[], anchor: ChatEvent, prevEpoch: number | null, key: string, open: boolean): HTMLElement {
   const b = noticeBrief(evs[0]);
   const turn = notice({ src: b.src, glyph: b.glyph, gist: `${evs.length} notices`, meta: open ? undefined : b.gist,
                         group: { key, open }, cls: "turn-toolgroup turn-noticegroup" + (open ? " expanded" : ""),
                         tip: open ? "click to collapse" : "click to expand" });
-  const epoch = eventEpoch(evs[0]);
-  const anchorUuid = evs[0].uuid ?? null;
+  const epoch = eventEpoch(anchor);
+  const anchorUuid = anchor.uuid ?? null;
   if (anchorUuid) turn.dataset.uuid = anchorUuid;
   if (epoch != null) turn.dataset.t = String(epoch);
   if (epoch != null) turn.insertBefore(timeMarker(epoch, prevEpoch ?? null), turn.firstChild);
   const railDot = turn.querySelector(".dot") as HTMLElement | null;
-  if (anchorUuid || epoch != null) wireTurnHover(turn, railDot, anchorUuid, epoch ?? 0, evs[0].tlId ?? null);
+  if (anchorUuid || epoch != null) wireTurnHover(turn, railDot, anchorUuid, epoch ?? 0, anchor.tlId ?? null);
   return turn;
 }
 

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1776,14 +1776,27 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    gutter is 59px wide and "Yesterday" measures 52.6px bold, so its "Y" fell off the left edge
    of the pane; anything sized to FIT that gutter re-clips the moment --vscode-chat-font-size
    grows. Out here the label has the whole column, so no date string can ever be cut off.
-   Left-aligned with the prose (turns pad 24px); the rule fills the rest of the line. */
+   The date is CENTERED over the column (T339, the user 2026-09-11: it sat at the prose edge with the
+   rule to its right alone), a hairline either side: the two rules share the leftover room equally, so
+   the label lands in the middle. padding-left keeps the row in the prose column (turns pad 24px). */
 .day-divider {
-  display: flex; align-items: center; gap: 9px;
+  display: flex; align-items: center; gap: 9px; position: relative;
   margin: 16px 0 6px; padding-left: 24px;
   font-size: 0.72em; letter-spacing: 0.02em;   /* same size as .time-marker — same kind of label */
 }
 .day-divider-label { flex: 0 0 auto; color: var(--fg); font-weight: 700; white-space: nowrap; }
-.day-divider::after { content: ""; flex: 1 1 auto; height: 1px; background: var(--box-border); }
+.day-divider-rule { flex: 1 1 auto; height: 1px; background: var(--box-border); }
+/* the rail runs THROUGH the divider (T339): the line is drawn per turn (.turn::before below), so a divider between
+   two turns left a gap the height of itself and its margins. This segment is the same 2px at the same left in the
+   same colour and opacity, and spans the divider's own margins, so the line is continuous. */
+.day-divider::before { content: ""; position: absolute; left: 10.5px; top: -16px; bottom: -6px; width: 2px; background: var(--active-accent, var(--rail)); opacity: 0.7; }
+/* a divider that LEADS the transcript (a session whose first row is a past day, read from its top) has no line above
+   it: the thread's first child, or the one right after the pinned system-context card, which sits OFF the rail with its
+   own line suppressed (.turn-system::before below). No segment there, and the turn it opens starts its rail at its first
+   dot, as a first turn does (.turn:first-child::before). A windowed head (.tx-spacer-top first) keeps the segment: the
+   rail continues from the turns the spacer stands in for. */
+.day-divider:first-child::before, .turn-system + .day-divider::before { display: none; }
+.day-divider:first-child + .turn::before, .turn-system + .day-divider + .turn::before { top: 16px; }
 /* "worked …" footer — how long the session ran on a finished prompt. Sits IN-FLOW
    below that prompt's last reply, left-justified under the response text (turns pad
    30px on the left, so a normal block lands at the text's left edge). It used to ride
@@ -3572,6 +3585,10 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
    (pending bubbles, dots, notes) come after the turns, so the + combinator never misses a pair;
    keep the -6px paired with .cmt-msgs' gap above. */
 .cmt-msgs .turn + .turn::before { top: -6px; }
+/* the day divider between two turns (fillCommentMsgs, T339): its segment spans only its own margins (16px above, 6px
+   below), and this flex column adds its 6px gap on both sides of it, which the rule above does not bridge (the turn after
+   a divider is not `.turn + .turn`); stretch the segment over margin plus gap each side, so the rail runs through here too */
+.cmt-msgs .day-divider::before { top: -22px; bottom: -12px; }
 /* the quoted passage as CONTEXT on the thread's opening message (the user 2026-08-24) — the
    .cmt-quote dress, sitting inside the turn above its bubble, the chat's citation-as-context shape */
 .cmt-quote-ctx { margin: 0 0 4px; }

--- a/ui/webview/time-marker.test.ts
+++ b/ui/webview/time-marker.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert";
-import { markerLabel, dayContext } from "./time-marker";
+import { markerLabel, dayContext, dayOpens, DayWalk } from "./time-marker";
 
 // All epochs below are built from local-time components so the test is timezone-agnostic
 // (markerLabel reads getHours()/getMinutes()/getDate() in local time, matching the browser).
@@ -103,4 +103,48 @@ test("dayContext speaks the relative-day vocabulary, midnight-relative", () => {
   assert.equal(dayContext(at(2026, 6, 22), now), "3 weeks ago", "26 days");
   assert.equal(dayContext(at(2026, 6, 15), now), "Jul 15", "past a month → the divider's own date form");
   assert.equal(dayContext(at(2025, 11, 30), now), "Dec 30 2025", "a different year says so");
+});
+
+// T339 (the user 2026-09-11): a day divider opens only on a FORWARD crossing into a past day. A row stamped earlier than the
+// row before it (a notice that kept the moment it was queued and landed at delivery) drew "Yesterday" inside today.
+test("dayOpens: the first row of a past day opens it, forward; today never opens; the same day never opens", () => {
+  assert.strictEqual(dayOpens(at(2026, 5, 11, 10, 0), at(2026, 5, 10, 10, 0), NOW), "Yesterday", "two days ago → yesterday: a forward crossing");
+  assert.strictEqual(dayOpens(at(2026, 5, 11, 10, 0), null, NOW), "Yesterday", "the first timed row of a past day, nothing before it");
+  assert.strictEqual(dayOpens(at(2026, 5, 12, 7, 5), at(2026, 5, 11, 22, 28), NOW), "", "yesterday → today: today wears no divider");
+  assert.strictEqual(dayOpens(at(2026, 5, 11, 10, 28), at(2026, 5, 11, 10, 0), NOW), "", "the same day: no boundary");
+  assert.strictEqual(dayOpens(at(2026, 5, 9, 10, 0), at(2026, 5, 8, 10, 0), NOW), "Tue", "a weekday within the week");
+});
+
+test("dayOpens: a step BACK in time is not a day opening, whatever markerLabel would have said", () => {
+  // the reported shape: a row of today, then a row stamped yesterday (a notice run's first member), then today again
+  assert.strictEqual(dayOpens(at(2026, 5, 11, 9, 47), at(2026, 5, 12, 8, 15), NOW), "", "yesterday after today: no divider");
+  assert.strictEqual(markerLabel(at(2026, 5, 11, 9, 47), at(2026, 5, 12, 8, 15), NOW).day, true, "…though the marker rule alone reads it as a day change (the bug)");
+  assert.strictEqual(dayOpens(at(2026, 5, 12, 8, 15), at(2026, 5, 11, 9, 47), NOW), "", "and the return to today opens nothing either");
+  assert.strictEqual(dayOpens(at(2026, 5, 10, 9, 0), at(2026, 5, 11, 9, 0), NOW), "", "two days ago after yesterday: a step back, no divider");
+  assert.strictEqual(dayOpens(at(2026, 5, 11, 9, 0), at(2026, 5, 11, 9, 0), NOW), "", "the same instant: no divider");
+});
+
+// T339 review: the walk's reference is a HIGH-WATER MARK. Against the previous row alone, a step back followed by a return
+// into a PAST day re-opened it: the stale row drew no divider but became the reference, and the next in-sequence row then
+// crossed "forward" into a day already open. Today never opens, so only a same-day-as-today return was ever safe.
+test("DayWalk: a step back never rewinds the mark, so the return into a past day opens nothing a second time", () => {
+  const TOMORROW = new Date(2026, 5, 13, 12, 0, 0).getTime();   // the transcript read the next day: its rows are yesterday's
+  const w = new DayWalk();
+  const seen: string[] = [];
+  for (const ep of [at(2026, 5, 12, 9, 5), at(2026, 5, 10, 9, 40), at(2026, 5, 10, 9, 41), at(2026, 5, 12, 9, 10)]) {
+    seen.push(w.open(ep, TOMORROW)); w.pass(ep);
+  }
+  assert.deepStrictEqual(seen, ["Yesterday", "", "", ""], "one divider for yesterday, none for the two stale rows, none on the return");
+  assert.strictEqual(w.mark, at(2026, 5, 12, 9, 10), "the mark is the latest epoch passed");
+});
+
+test("DayWalk: passing an earlier epoch or null leaves the mark; a forward crossing into a past day opens once", () => {
+  const w = new DayWalk();
+  assert.strictEqual(w.open(at(2026, 5, 10, 10, 0), NOW), "Wed", "the first row of a past day opens it");
+  w.pass(at(2026, 5, 10, 10, 0)); w.pass(null); w.pass(at(2026, 5, 9, 23, 0));
+  assert.strictEqual(w.mark, at(2026, 5, 10, 10, 0), "null and an earlier epoch never move the mark");
+  assert.strictEqual(w.open(at(2026, 5, 10, 10, 5), NOW), "", "the same day again: nothing");
+  assert.strictEqual(w.open(at(2026, 5, 11, 8, 0), NOW), "Yesterday", "the next day opens");
+  w.pass(at(2026, 5, 11, 8, 0));
+  assert.strictEqual(w.open(at(2026, 5, 12, 8, 0), NOW), "", "today never opens");
 });

--- a/ui/webview/time-marker.ts
+++ b/ui/webview/time-marker.ts
@@ -49,6 +49,31 @@ export function markerLabel(epoch: number, prevEpoch: number | null, nowMs: numb
   return { text: time, day: false, hm: time, date: "" };
 }
 
+/** The date a day divider shows above a row, or "" for none: the boundary rule markerLabel applies (the first row of a
+ *  PAST day), with one more condition (T339, the user 2026-09-11): the crossing must be FORWARD. A row stamped earlier
+ *  than the row before it (a notice that kept the moment it was queued and landed at delivery, a clock skew) is not a
+ *  day opening: reading the step back as a boundary drew "Yesterday" inside today, above a row whose neighbours were all
+ *  today's. Such a row keeps its own time and draws no divider. */
+export function dayOpens(epoch: number, prevEpoch: number | null, nowMs: number): string {
+  if (prevEpoch != null && epoch < prevEpoch) return "";
+  const { day, date } = markerLabel(epoch, prevEpoch, nowMs);
+  return day && date ? date : "";
+}
+
+/** The day walk's state (T339 review): the reference a divider is decided against is a HIGH-WATER MARK, the latest
+ *  epoch the walk has passed, never the row just before. A row stamped earlier than the rows around it (a live echo the
+ *  kernel merges into the last turn at its send time) opens no day (dayOpens) and must not become the reference either:
+ *  the next in-sequence row would cross "forward" out of the stale day and open a SECOND divider for a day already open,
+ *  whenever that day is not today (today never opens, which is the one case a previous-row rule got right). `open` asks
+ *  whether a row opens a day against the mark; `pass` moves the mark over a row (or a unit's exit epoch) and never
+ *  rewinds. The rail's own HH:MM chain is separate (it reads the raw previous row), so a row after a stale one still
+ *  shows its time. */
+export class DayWalk {
+  mark: number | null = null;
+  open(epoch: number, nowMs: number): string { return dayOpens(epoch, this.mark, nowMs); }
+  pass(epoch: number | null): void { if (epoch != null && (this.mark == null || epoch > this.mark)) this.mark = epoch; }
+}
+
 // (A chooseStamps() spacing pass used to live here: it re-revealed a suppressed same-minute stamp every
 // ~6 rows so the gutter never went long without a time. The sticky rail stamp now guarantees a time at the
 // top of the view at all times, which made those repeats pure noise — so the pass is gone and a stamp means


### PR DESCRIPTION
Three faults in the chat's day divider (the user 2026-09-11, a screenshot): a "Yesterday" divider drawn **inside today** over a collapsed run of two romp notices that wore yesterday's clock; the date label at the prose edge with the hairline to its right alone; the rail's line broken above and below the divider.

## The misplaced divider

**Producer** (kernel, unchanged here): a session's live echo atoms, the kernel's own copies of sent messages kept until the transcript lands their text (mirrored in the registry's `echoes` and reseeded at boot), are merged into the chat's last turn sorted by their own **send** time. A romp notice sent yesterday whose text never landed therefore sits after the previous turn's rows, among today's, stamped yesterday. Transcript records themselves are sorted by timestamp and cannot do this.

**Chat side**: `appendItem` timed a `noticegroup` by its first member and `renderNoticeGroup` read `evs[0]`, and `markerLabel` treats any different-day epoch as a day change whatever its direction, so the step back drew a divider.

**Fix**, event-based and minimal:
- `compact.ts itemAnchor(it, epochAt)`: the member a unit is placed and timed by. A notice run anchors on its **latest** member (ties: the later one), the one in sequence with its neighbours; every other unit keeps its first member as before (a tool run's members are in transcript order, its head timed by its first).
- `render.ts`: `appendItem` and the comment popover's parity loop read the anchor for the day walk, hand it to `renderNoticeGroup(evs, anchor, prevEpoch, key, open)` (the head's rail time, `data-t`, uuid and hover from the anchor; the words from the first member), and leave the walk on it, open or closed.
- `time-marker.ts dayOpens(epoch, prevEpoch, nowMs)`: the marker's day rule plus the forward condition. `time-marker.ts DayWalk`: the walk's reference is a **high-water mark**, the latest epoch passed, never the row just before. The review found that against the previous row a step back followed by a return into a *past* day re-opened it (the stale row drew no divider but became the reference; today never opens, so only a return to today was safe). `dayDividerFor(epoch, walk)` reads the mark; every path that emits dividers (`appendItem`, the window seed, the normal-mode tail loop, the comment popover, the cleared-episode fold) passes its unit's exit through one rule (`unitExit`) and never rewinds. The rail's HH:MM chain keeps the raw previous row, so a row after a stale one still shows its time.

## The label and the rail

- The divider is `[rule, label, rule]`: two `.day-divider-rule` spans share the leftover room, so the date lands in the middle of the column.
- `.day-divider::before` is a rail segment with `.turn::before`'s left, width, colour and opacity, spanning the divider's own margins (`top: -16px; bottom: -6px`), so the line runs through. The one-sided `::after` rule is gone.
- In the comment popover's flex column the segment spans margin plus the 6px gap on each side (`.cmt-msgs .day-divider::before { top: -22px; bottom: -12px; }`).
- A divider that **leads** the transcript (the thread's first child, or the one right after the pinned system-context card, which sits off the rail with its own line suppressed) draws no segment, and the turn it opens starts its rail at its first dot as a first turn does.
- `tools/ui-verify/fixtures/notices-chat.html` mirrors the builder's three-span divider.

**Known limits**: a lone stale echo (an undelivered notice the kernel merges into the last turn by its send time) still wears yesterday's clock among today's rows with no day word; the producer is the echo merge, a kernel change for another day, not this change. The sticky day-context label at the top of the view (`paintRailSticky`) reads the top row's own epoch, so scrolled to a stale echo at the top it can say "2 days ago" while the walk keeps the rows under one "Yesterday" (pre-existing; a follow-on could feed it the walk's mark).

## Tests

- `compact.test.ts` (`itemAnchor`) and `time-marker.test.ts` (`dayOpens`, including the step back that `markerLabel` alone reads as a day change; `DayWalk`: a step back never rewinds the mark, so a return into a past day opens nothing a second time): executed.
- `day-divider.test.ts`: the pins follow (`DayWalk` in `dayDividerFor` and at every call site, the anchor on both unit paths, the tool run untouched, `unitExit` as the one rule for the walk and a window's seed, the two rules, the rail segment mirroring `.turn::before` and spanning the margins, the leading-divider rules); `comments.test.ts` pins the popover's segment derived from the gap and the margins; `notice-vocab.test.ts` pins the fixture's hairlines.
- `tests/test_day_divider_served.py`: a hermetic kernel serving two synthetic sessions. `web`: rows two days ago, yesterday and today (two turns), the registry mirroring two echoes of romp notices, the first sent yesterday, the second today between the turns. `api`: the same read a day later, rows all yesterday and both echoes two days ago. On the real `/chat` page, dark and light: `web` shows two dividers only (the weekday over two days ago, "Yesterday" over yesterday's first row) and none above the notice run, whose head wears its latest member's time; `api` shows exactly one "Yesterday"; each label is centered between two hairlines of equal width; the segment is painted on the turns' own line and reaches the neighbouring turns' boxes (geometry, not the rule text); the leading divider draws no segment and its turn starts at its first dot. The browser's clock is pinned to the fixture's epoch, so a run across local midnight agrees with itself. Against a bundle built from main (`DD_BEFORE_DIST` with `DD_BEFORE_ASSERT=1`) the same test is red: a third divider, "Yesterday" inside today above `web`'s run.

Screenshots (dark and light, before and after) are in the drops folder as `romp_chat-day-divider-{dark,light}{,-before}.png`.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
