### PR TITLE
The composer's placeholder paints the session's name halfway between its identity colour and an inactive tab label's fade (T341)

### DIFF
--- a/tests/test_composer_placeholder_remote_served.py
+++ b/tests/test_composer_placeholder_remote_served.py
@@ -73,7 +73,7 @@ await page.waitForTimeout(600);
 // the dress of a host span: the class, the italic, the ink, the weight (the four the tab label's rule sets), and its words
 // (defined inside the page's evaluate, where getComputedStyle lives)
 const measure = () => page.evaluate(() => {
-  const dress = (n) => { if (!n) return null; const cs = getComputedStyle(n); return { cls: n.className, text: n.textContent, style: cs.fontStyle, color: cs.color, weight: cs.fontWeight, size: cs.fontSize }; };
+  const dress = (n) => { if (!n) return null; const cs = getComputedStyle(n); return { cls: n.className, text: n.textContent, style: cs.fontStyle, color: cs.color, weight: cs.fontWeight, size: cs.fontSize, opacity: cs.opacity }; };
   const tab = document.querySelector("#tabs .tab.active[data-id]");
   const ph = document.getElementById("composer-ph"); const nm = ph && ph.querySelector(".composer-ph-name");
   const ta = document.getElementById("composer-input");
@@ -241,10 +241,10 @@ class ServedComposerPlaceholderRemoteHost(unittest.TestCase):
             self.assertEqual(m["phHost"]["style"], "italic"); self.assertEqual(m["phHost"]["weight"], "400", "the host is quiet, not bold")
             self.assertEqual(m["phName"]["text"], "api", "only the name is the bold run: %r" % m["phName"])
             self.assertEqual(m["phName"]["weight"], "600")
-            # …in the session's identity colour at an at-rest tab label's fade (T335): every channel moved from the identity
-            # colour toward the page background, never the full colour, and the overlay carries the strip's at-rest class so
-            # the host span fades with the name (the exact level is proven against a real at-rest label in
-            # tests/test_session_name_served.py)
+            # …in the session's identity colour HALFWAY toward an at-rest tab label's fade (T335 set the full at-rest fade;
+            # T341 halves it, render.ts PH_NAME_FADE): every channel moved from the identity colour toward the page
+            # background, never the full colour, and the overlay carries the strip's at-rest class so the host span fades
+            # with the name (the exact midpoint is proven against a real at-rest label in tests/test_session_name_served.py)
             rgb = lambda c: tuple(int(x) for x in re.findall(r"\d+", c or "")[:3])
             ident, name, bg = (100, 181, 246), rgb(m["phNameColor"]), rgb(m["bodyBg"])
             if theme == "dark":
@@ -256,6 +256,10 @@ class ServedComposerPlaceholderRemoteHost(unittest.TestCase):
                 self.assertTrue(lo <= name[i] <= hi, "channel %d of the name lies between the identity colour and the page background in %s: %r %r %r" % (i, theme, ident, name, bg))
             self.assertTrue(m["phFaded"], "the overlay carries the strip's at-rest class")
             self.assertNotEqual(m["phHost"]["color"], m["phNameColor"], "the host does not wear the identity colour")
+            # the host prefix fades in tandem with the name it precedes, at the name's midpoint (T341): the strip's rule at the
+            # overlay's strength, 0.75, between the active label's full 1 and an at-rest label's 0.5
+            self.assertEqual(m["tabHost"]["opacity"], "1", "the ACTIVE tab's host wears no fade: %r" % m["tabHost"])
+            self.assertEqual(m["phHost"]["opacity"], "0.75", "the overlay's host at the midpoint in %s: %r" % (theme, m["phHost"]))
             self.assertTrue((m["nativePlaceholder"] or "").startswith("Message this session"), "the native placeholder beneath stays the plain resting text for assistive tech")
 
 

--- a/tests/test_session_name_served.py
+++ b/tests/test_session_name_served.py
@@ -1,9 +1,9 @@
 """The chat names the session it messages (the user 2026-09-09), in a real browser against a hermetic kernel: the composer's
 resting placeholder reads "Message <name>…" with the name bold in the session's identity colour and follows the active tab;
-since T335 (the user 2026-09-10) the name is painted at an INACTIVE tab label's level: the strip's own perceptual fade of the
-identity colour, so it sits with the faded placeholder text; this test reads the same session's at-rest label colour once the
-tab is inactive and requires the placeholder's name colour to equal it, dark and light (PH_SHOTS=<dir> writes screenshots of
-the box under the strip; PH_BEFORE_DIST=<dist> serves another tree's bundle for the before shots and skips the fade checks);
+since T335 (the user 2026-09-10) the name is painted with the strip's own perceptual fade of the identity colour, so it sits
+with the faded placeholder text, and since T341 (the user 2026-09-11: the full fade read too faint) at HALF strength; this test
+reads the same session's at-rest label colour once the tab is inactive and requires the placeholder's name colour to sit
+halfway between it and the identity colour, dark and light (PH_SHOTS=<dir> writes screenshots of the box under the strip; PH_BEFORE_DIST=<dist> serves another tree's bundle for the before shots and skips the fade checks);
 the statusline badge (the name in black on that colour) is a SETTING, off by default (the maintainers via the user,
 2026-09-10), and a flip of the setting shows it and hides it again without a reload. Skips LOUDLY when the extension deps
 or a playwright browser are absent (CI installs none). Synthetic sessions and text only."""
@@ -108,7 +108,7 @@ await fr.click('#tabs .tab[data-id="' + cfg.sidA + '"]'); await waitActive(cfg.s
 await waitFn(() => { const d = document.getElementById("f-chat").contentDocument; const ph = d.getElementById("composer-ph"); return !!(ph && ph.querySelector(".composer-ph-name")); }, null, "the placeholder overlay never named the session");
 out.a = await naming();
 await page.mouse.move(700, 500); await page.waitForTimeout(300);   // off the strip: no hover un-fade, no tooltip in the shot
-await shot("romp_chat-composer-name-fade-dark");
+await shot("romp_chat-composer-name-half-fade-dark");
 // the other tab: the placeholder follows the active session
 await fr.click('#tabs .tab[data-id="' + cfg.sidB + '"]'); await waitActive(cfg.sidB);
 await waitFn((b) => { const d = document.getElementById("f-chat").contentDocument; const nm = d.querySelector("#composer-ph .composer-ph-name"); return !!nm && nm.textContent !== b; }, out.a.phName, "the placeholder never followed the tab switch");
@@ -120,7 +120,7 @@ await fr.click('#tabs .tab[data-id="' + cfg.sidA + '"]'); await waitActive(cfg.s
 await waitFn((a) => { const d = document.getElementById("f-chat").contentDocument; const nm = d.querySelector("#composer-ph .composer-ph-name"); return !!nm && nm.textContent === a; }, out.a.phName, "the placeholder never named A again under the light theme");
 await page.mouse.move(700, 500); await page.waitForTimeout(300);
 out.aLight = await naming();
-await shot("romp_chat-composer-name-fade-light");
+await shot("romp_chat-composer-name-half-fade-light");
 await fr.click('#tabs .tab[data-id="' + cfg.sidB + '"]'); await waitActive(cfg.sidB);
 await waitFn((b) => { const d = document.getElementById("f-chat").contentDocument; const nm = d.querySelector("#composer-ph .composer-ph-name"); return !!nm && nm.textContent === b; }, out.b.phName, "the placeholder never followed to B under the light theme");
 out.bLight = await naming();
@@ -292,7 +292,7 @@ class ServedSessionName(unittest.TestCase):
             return "rgb(%d,%d,%d)" % tuple(int(c[i:i + 2], 16) for i in (1, 3, 5))
         return c
 
-    def test_1_the_placeholder_names_the_active_session_bold_at_an_inactive_labels_fade_and_follows_the_tab(self):
+    def test_1_the_placeholder_names_the_active_session_bold_halfway_to_an_inactive_labels_fade_and_follows_the_tab(self):
         r = self._r(); a, b = r["a"], r["b"]
         self.assertEqual((a["active"], a["phName"]), (SID_A, "web"))
         self.assertEqual((b["active"], b["phName"]), (SID_B, "api"), "the placeholder follows the active tab")
@@ -304,22 +304,28 @@ class ServedSessionName(unittest.TestCase):
         self.assertNotEqual(a["tabBg"], b["tabBg"], "two sessions, two colours")
         if self.before:
             self.skipTest("a before-the-change dist: screenshots only, the fade checks describe the change")
-        # T335: the name's colour is the SAME session's at-rest label colour (the strip's perceptual fade), read off A's label
-        # once B is active, dark and light; not the full identity colour it wore before
+        # T335: the name's colour is the strip's perceptual fade of the SAME session's identity colour, read off A's at-rest
+        # label once B is active; T341 (the user 2026-09-11: the full fade read too faint): at HALF strength, so every
+        # channel sits at the midpoint of the identity colour and the at-rest label's, dark and light
+        chan = lambda c: tuple(int(x) for x in re.findall(r"\d+", self._rgb(c))[:3])
         for act, rest, theme in ((a, b, "dark"), (r["aLight"], r["bLight"], "light")):
             self.assertEqual((act["theme"], rest["theme"]), (theme, theme))
             restA = next(t for t in rest["tabs"] if t["id"] == SID_A)
             self.assertFalse(restA["active"]); self.assertTrue(restA["faded"], "A's tab is at rest and faded in %s: %r" % (theme, restA))
             self.assertTrue(restA["labelColor"], "the at-rest label carries the computed fade inline: %r" % restA)
-            self.assertEqual(self._rgb(act["phColor"]), self._rgb(restA["labelColor"]), "the box names A at A's inactive label colour in %s: %r vs %r" % (theme, act["phColor"], restA))
-            self.assertEqual(act["phComputed"], restA["labelComputed"], "…and the computed inks agree")
+            ident, at_rest, name = chan(act["tabBg"]), chan(restA["labelColor"]), chan(act["phColor"])
+            mid = tuple(round((i + f) / 2) for i, f in zip(ident, at_rest))
+            self.assertTrue(all(abs(n - m) <= 1 for n, m in zip(name, mid)), "the box names A halfway between A's identity colour and A's inactive label colour in %s: identity %r, at rest %r, box %r" % (theme, ident, at_rest, name))
             self.assertTrue(act["phFaded"], "the overlay carries the strip's at-rest class, so a remote host's prefix would fade with the name")
             if theme == "dark":
-                self.assertNotEqual(self._rgb(act["phColor"]), self._rgb(act["tabBg"]), "faded, not the full identity colour, in the dark theme")
+                self.assertNotEqual(at_rest, ident, "the at-rest label is faded in the dark theme")
+                self.assertNotEqual(name, ident, "the box: not the full identity colour")
+                self.assertNotEqual(name, at_rest, "…nor the at-rest label's fade (T335's level): the midpoint")
             else:
                 # the strip's fade blends toward a LOW luminance target (fadedColor), which a light page already exceeds, so an
-                # at-rest label keeps its full colour there by the strip's own rule; the box matches that, whatever it is
-                self.assertEqual(self._rgb(act["phColor"]), self._rgb(act["tabBg"]), "the light theme: the strip's at-rest label is unfaded, and so is the box's name")
+                # at-rest label keeps its full colour there by the strip's own rule at any strength; the box matches that
+                self.assertEqual(at_rest, ident, "the light theme: the strip's at-rest label is unfaded")
+                self.assertEqual(name, ident, "…and so is the box's name")
 
     def test_2_the_badge_is_off_by_default_and_a_flip_of_the_setting_shows_it_and_hides_it_live(self):
         r = self._r(); a, b, on, off = r["a"], r["b"], r["bOn"], r["bOff"]

--- a/ui/webview/composer-placeholder.test.ts
+++ b/ui/webview/composer-placeholder.test.ts
@@ -58,12 +58,13 @@ test("render.ts: the overlay mirrors the placeholder, wears the identity colour,
   assert.match(fn, /parts\.kind === "named" && !ta\.value/, "the styled form only for the resting placeholder, only while the box is empty");
   assert.match(fn, /ta\.classList\.toggle\("ph-on", show\);/, "the native placeholder goes transparent beneath the overlay");
   assert.match(fn, /const colorBg = \(live\?\.color\?\.bg \|\| meta\?\.color\?\.bg\) \|\| null;/, "the identity colour: the live session's, else the strip's own word on the tab (a skeleton's), never a stale session (skeleton-tabs-wiring)");
-  // T335 (the user 2026-09-10): the name is painted at an INACTIVE tab label's level, the strip's own perceptual fade of the
-  // identity colour (fadedColor, what an at-rest tab wears), so it sits with the faded placeholder text instead of outshining
-  // it; the weight stays; the host span fades in tandem through the strip's .name-faded class carried by the overlay
-  assert.match(fn, /if \(colorBg\) nm\.style\.color = fadedColor\(colorBg\); else nm\.style\.removeProperty\("color"\);/, "the name wears the session's identity colour at the at-rest tab label's fade");
+  // T335 (the user 2026-09-10): the name is painted with the strip's own perceptual fade of the identity colour (fadedColor,
+  // what an at-rest tab wears), so it sits with the faded placeholder text instead of outshining it; T341 (the user
+  // 2026-09-11): at HALF strength, since the full fade read too faint; the weight stays; the host span fades in tandem
+  // through the strip's .name-faded class carried by the overlay
+  assert.match(fn, /if \(colorBg\) nm\.style\.color = fadedColor\(colorBg, PH_NAME_FADE\); else nm\.style\.removeProperty\("color"\);/, "the name wears the session's identity colour at half the at-rest tab label's fade");
   assert.match(fn, /ph\.classList\.add\("name-faded"\);/, "the overlay carries the strip's at-rest class, once, at its making");
-  assert.match(RENDER, /^function fadedColor\(hex: string\): string \{/m, "…the one fade rule, the strip's (bright hues fade as far as dim ones)");
+  assert.match(RENDER, /^function fadedColor\(hex: string, amount = 1\): string \{/m, "…the one fade rule, the strip's (bright hues fade as far as dim ones), with a strength");
   // the fade reads the page background live, so the overlay re-syncs on the strip's REBUILD (the event that repaints every
   // at-rest label's fade), beside the tip hide: a host-rewritten background reaches the box when it reaches the strip
   const tabs = RENDER.slice(RENDER.indexOf("function renderTabs() {"), RENDER.indexOf("function stripAftermath("));
@@ -90,8 +91,8 @@ test("render.ts: the overlay mirrors the placeholder, wears the identity colour,
 test("styles.css: the overlay sits over the box, dim like a placeholder, the name bold; the native placeholder is transparent while it shows", () => {
   assert.match(CSS, /#composer-ph \{ position: absolute; pointer-events: none; color: var\(--dim\);/);
   assert.match(CSS, /#composer-ph \.composer-ph-name \{ font-weight: 600; \}/);
-  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: 0\.5; \}/m, "the host prefix fades by the strip's own rule wherever the class is carried (T335)");
-  assert.doesNotMatch(CSS, /#composer-ph[^\n]*opacity/, "no opacity of the overlay's own: the fade is the colour the strip computes");
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: var\(--host-fade, 0\.5\); \}/m, "the host prefix fades by the strip's own rule wherever the class is carried (T335), at a strength the carrier may set (T341)");
+  assert.doesNotMatch(CSS, /#composer-ph[^\n]*opacity/, "no opacity rule of the overlay's own: the fade is the strip's rule at the overlay's strength");
   assert.match(CSS, /#composer-input\.ph-on::placeholder \{ color: transparent; \}/);
   // the question flow (the user 2026-09-10): the answering tint rule sits at that rule's specificity and came later, so
   // both texts showed — the overlay takes the tint, the native placeholder stays transparent under it
@@ -105,4 +106,32 @@ test("render.ts: the placeholder and the answering tint have one owner — the r
   assert.match(RENDER, /if \(closed\) \{ composer\.placeholder = "Session closed — read-only"; composer\.classList\.remove\("answering"\); syncComposerPh\(\); \}\n\s*else setComposerAskMode\(\);/);
   const writers = RENDER.match(/\.placeholder = composerRestingPlaceholder\(\)/g) || [];
   assert.equal(writers.length, 2, "setComposerAskMode's own write and the phone's resize shortening; nothing else writes the resting form");
+});
+
+// T341 (the user 2026-09-11, looking at the shipped T335): the name in the box read TOO faded at the strip's at-rest level;
+// it sits halfway between the full identity colour and that fade. One fade rule with a STRENGTH, never a second colour
+// formula: the strip at 1 (unchanged), the overlay's name at 0.5, its host prefix at the matching midpoint of the opacities
+// (1 at the full colour, 0.5 at the strip's fade: 0.75). The served test proves the midpoint against a real at-rest label.
+test("one fade rule, two strengths (T341): the strip at 1, the composer's name at 0.5, its host at the midpoint 0.75", () => {
+  const fade = RENDER.slice(RENDER.indexOf("function fadedColor("), RENDER.indexOf("function fadedColor(") + 1200);
+  assert.match(fade, /^function fadedColor\(hex: string, amount = 1\): string \{/m, "the strength defaults to the strip's");
+  assert.match(fade, /if \(Lc <= Lt\) return hex;/, "the dim-hue early return stays, ahead of the strength");
+  assert.match(fade, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale \* amount;/, "the strength scales the one blend");
+  assert.equal((fade.match(/amount/g) || []).length, 2, "…and nothing else reads it: no second formula");
+  assert.match(RENDER, /^const PH_NAME_FADE = 0\.5;/m, "the overlay's strength: half the way");
+  assert.match(RENDER, /label\.style\.color = fadedColor\(full\);/, "the strip's labels at the default strength, unchanged");
+  assert.doesNotMatch(RENDER, /fadedColor\(full, /, "…no second strength for the strip");
+  assert.equal((RENDER.match(/(?<!function )fadedColor\([^)]*, /g) || []).length, 1, "one call names a strength: the overlay's name");
+  // the host prefix: the strip's rule reads a variable whose default is the strip's own 0.5; the overlay alone sets 0.75
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: var\(--host-fade, 0\.5\); \}/m);
+  assert.match(CSS, /^#composer-ph \{[^\n]*; --host-fade: 0\.75; \}/m, "the overlay's own strength, on the overlay's rule");
+  assert.equal((CSS.match(/--host-fade:/g) || []).length, 1, "one setter: the tab label keeps the default");
+  assert.equal((CSS.match(/var\(--host-fade/g) || []).length, 1, "one reader: the strip's rule");
+  // the two midpoints agree, read off the source: the host's opacity sits where the name's strength puts it between the
+  // full colour (1) and the strip's host fade, 1 - strength × (1 - the strip's fade) = 1 - 0.5 × (1 - 0.5) = 0.75; moving
+  // one constant without the other fails here
+  const nameFade = Number(/^const PH_NAME_FADE = ([\d.]+);/m.exec(RENDER)![1]);
+  const hostDefault = Number(/\.name-faded \.host-prefix\.off \{ opacity: var\(--host-fade, ([\d.]+)\); \}/.exec(CSS)![1]);
+  const hostFade = Number(/^#composer-ph \{[^\n]*; --host-fade: ([\d.]+); \}/m.exec(CSS)![1]);
+  assert.equal(hostFade, 1 - nameFade * (1 - hostDefault), "the two midpoints agree: the host's opacity sits where the name's strength puts it");
 });

--- a/ui/webview/host-offline.test.ts
+++ b/ui/webview/host-offline.test.ts
@@ -88,7 +88,7 @@ test("the mark goes on the HOST token, never on the session name", () => {
   // the two rules that both set the token's opacity (T335 review): the at-rest fade (0.5) and this cue (0.75). The fade wins
   // by SPECIFICITY through its compound selector, whatever their order in the sheet: an at-rest label on a down host fades
   // with its name and still wears the cue's italic and dotted underline
-  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: 0\.5; \}/m, "the fade names the .off token too");
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: var\(--host-fade, 0\.5\); \}/m, "the fade names the .off token too");
   assert.match(CSS, /^\.host-prefix\.off \{\s*\n\s*opacity: 0\.75;/m, "the cue keeps its own opacity for an active label's token");
   assert.match(FEEDCSS, /\.host-prefix\.off \{[\s\S]*?text-decoration: underline dotted 1px/,
     "the feed page loads only feed.css");

--- a/ui/webview/host-prefix.test.ts
+++ b/ui/webview/host-prefix.test.ts
@@ -68,7 +68,7 @@ test("the host prefix FADES in tandem with the name it precedes (the user 2026-0
   assert.match(RENDER, /label\.classList\.add\("name-faded"\)/);
   assert.match(RENDER, /mouseenter", \(\) => \{ label\.style\.color = full; label\.classList\.remove\("name-faded"\); \}/);
   assert.match(RENDER, /mouseleave", \(\) => \{ label\.style\.color = fadedColor\(full\); label\.classList\.add\("name-faded"\); \}/);
-  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: 0\.5; \}/m, "one rule for both carriers of the class: the tab label and the composer's name overlay (T335)");
+  assert.match(CSS, /^\.name-faded \.host-prefix, \.name-faded \.host-prefix\.off \{ opacity: var\(--host-fade, 0\.5\); \}/m, "one rule for both carriers of the class: the tab label and the composer's name overlay (T335); the strength a variable the overlay sets to its own midpoint (T341)");
   // TIMELINE: the SVG twin — a tspan's own fill beats the parent <text>, so fade it explicitly and
   // register it for the same hover un-fade the name uses
   assert.match(TL, /hostTsp = el\('tspan', \{ fill: F\(MODEL_FG\)/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5009,7 +5009,15 @@ function bgRgb(): [number, number, number] {
 // as a dim one (blue) — consistent "faded-ness" regardless of color. Never
 // touches the bright color (only used for at-rest tabs).
 const CLASSIC_FADE_SCALE = 0.9;   // T118 (the user 2026-08-27): +10% brighter faded tab labels under Classic — one tunable knob (half the parked T113 number)
-function fadedColor(hex: string): string {
+// The composer's name overlay fades HALFWAY (T341, the user 2026-09-11: at the strip's full fade the name in the box read
+// too faint; at none it outshone the placeholder). The strength of the one fade rule, not a second colour formula: 0.5
+// covers half the perceptual distance the strip's at-rest label covers. Its host prefix sits at the matching midpoint
+// (styles.css --host-fade on #composer-ph).
+const PH_NAME_FADE = 0.5;
+// `amount` is the fade's strength: 1 (the default) is the strip's at-rest fade, unchanged for tabs; 0.5 is half the way
+// from the identity colour toward the page background. It scales the one blend, so the dim-hue early return holds at every
+// strength and a light page (already past the luminance target) stays a no-op.
+function fadedColor(hex: string, amount = 1): string {
   const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
   if (!m) return hex;
   const n = parseInt(m[1], 16);
@@ -5020,7 +5028,7 @@ function fadedColor(hex: string): string {
   if (Lc <= Lt) return hex; // already dim — leave it
   // Classic fades 10% less far toward the background (T118); Yatharth keeps his full fade.
   const scale = settings.chatTabTheme === "yatharth" ? 1 : CLASSIC_FADE_SCALE;
-  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb)) * scale;
+  const t = Math.min(0.85, (Lc - Lt) / (Lc - Lb)) * scale * amount;
   const hx = (a: number, c: number) => Math.round(a * (1 - t) + c * t).toString(16).padStart(2, "0");
   return `#${hx(r, br)}${hx(g, bgc)}${hx(b, bb)}`;
 }
@@ -13076,11 +13084,12 @@ function syncComposerPh(): void {
     // the quiet .host-prefix span, marked when the host's link is down, and only the name below is bold and coloured
     ph.appendChild(hostNameNodes(parts.host + parts.name, activeId)[0]);
   }
-  // the name at an INACTIVE tab label's level (T335, the user 2026-09-10: it stood out brighter than every other word of
-  // the faded placeholder): the strip's own perceptual fade of the identity colour (fadedColor, what an at-rest tab's
-  // label wears), the weight kept; the host span fades in tandem through the strip's own class on the overlay
+  // the name HALFWAY between its identity colour and an inactive tab label's level (T335, the user 2026-09-10: at the full
+  // colour it stood out brighter than every other word of the faded placeholder; T341, the user 2026-09-11: at the strip's
+  // full fade it read too faint): the strip's own perceptual fade of the identity colour (fadedColor) at half strength,
+  // the weight kept; the host span fades in tandem through the strip's own class on the overlay, at the matching midpoint
   const nm = el("b", "composer-ph-name"); nm.textContent = parts.name;
-  if (colorBg) nm.style.color = fadedColor(colorBg); else nm.style.removeProperty("color");
+  if (colorBg) nm.style.color = fadedColor(colorBg, PH_NAME_FADE); else nm.style.removeProperty("color");
   ph.appendChild(nm);
   ph.appendChild(document.createTextNode(parts.after));
   // where the box's own first line sits: inside its border and padding, in its font (offsets are relative to

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1352,7 +1352,7 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
 /* the resting placeholder names the session (the user 2026-09-09): an overlay over the empty box, the name bold in
    the session's identity colour (its tab label's); the native placeholder beneath it goes transparent while it
    shows, and stays for assistive tech. Positioned and sized by render.ts syncComposerPh from the box's own metrics. */
-#composer-ph { position: absolute; pointer-events: none; color: var(--dim); white-space: pre; overflow: hidden; text-overflow: ellipsis; box-sizing: border-box; z-index: 1; }
+#composer-ph { position: absolute; pointer-events: none; color: var(--dim); white-space: pre; overflow: hidden; text-overflow: ellipsis; box-sizing: border-box; z-index: 1; --host-fade: 0.75; }   /* the host prefix at the midpoint its name sits at (T341; the rule is .name-faded .host-prefix below) */
 #composer-ph .composer-ph-name { font-weight: 600; }
 #composer-input.ph-on::placeholder { color: transparent; }
 /* A box grown past the height cap scrolls — and the scrollbar's TRACK paints square into the rounded
@@ -3339,12 +3339,15 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
    the at-rest tab's inline faded color can't inherit into it, so a remote session's "host:" stayed bright
    while its name dimmed (the user 2026-07-22). renderTabs adds .name-faded whenever it applies the faded
    name color, and drops it on hover, so the two always move together. The composer's name overlay wears the
-   class too (#composer-ph, T335): its name is painted at the at-rest label's faded colour, so its host fades
-   by this same rule; one selector for both carriers, never two values. The compound second selector keeps the
-   fade WINNING over the stale-link cue below (.host-prefix.off, opacity 0.75) by specificity, as the scoped
-   rule did before: an at-rest label on a down host fades with its name, and the cue's italic and dotted
-   underline still show. A state rule wins the cascade by construction, never by order. */
-.name-faded .host-prefix, .name-faded .host-prefix.off { opacity: 0.5; }
+   class too (#composer-ph, T335): its name is painted faded, so its host fades by this same rule; one
+   selector for both carriers. The STRENGTH is a variable with the strip's value as its
+   default (T341, the user 2026-09-11): the overlay's name is painted halfway between its identity colour and
+   the at-rest fade (render.ts PH_NAME_FADE), so its host sits at the matching midpoint, 0.75, set on
+   #composer-ph alone; the tab label keeps 0.5. One rule, two strengths, never a second rule. The compound
+   second selector keeps the fade WINNING over the stale-link cue below (.host-prefix.off, opacity 0.75) by
+   specificity, as the scoped rule did before: an at-rest label on a down host fades with its name, and the
+   cue's italic and dotted underline still show. A state rule wins the cascade by construction, never by order. */
+.name-faded .host-prefix, .name-faded .host-prefix.off { opacity: var(--host-fade, 0.5); }
 /* DISCONNECTED host (the user 2026-07-29): its sessions keep their tabs, lanes and cards — dropping them
    would lose the thread — but the "host:" token says the link is down, so nobody reads a frozen transcript
    thinking it is live. Struck + dimmed, the strike on the HOST only: a struck WHOLE name already means a

--- a/ui/webview/tab-theme.test.ts
+++ b/ui/webview/tab-theme.test.ts
@@ -60,7 +60,7 @@ test("Classic: NO identity tint — every tint rule lives under the theme class"
 test("Classic: faded labels brighten 10% — one tunable knob, Yatharth keeps his full fade (T118)", () => {
   assert.match(RENDER, /const CLASSIC_FADE_SCALE = 0\.9;/);
   assert.match(RENDER, /const scale = settings\.chatTabTheme === "yatharth" \? 1 : CLASSIC_FADE_SCALE;/);
-  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale;/);
+  assert.match(RENDER, /const t = Math\.min\(0\.85, \(Lc - Lt\) \/ \(Lc - Lb\)\) \* scale \* amount;/);   // × the caller's strength since T341 (1 for the strip)
 });
 
 test("Classic: ONE dark background — no band, no explicit body fill, baseline transparency (T141)", () => {


### PR DESCRIPTION
The composer's resting placeholder paints the session's name **halfway** between its full identity colour and an inactive tab label's fade (the user 2026-09-11, looking at the shipped fade: at the strip's full at-rest level it read too faint; before that change it outshone the placeholder). The host prefix of a remote session moves to the matching midpoint with it.

## Shape

One fade rule with a **strength**, never a second colour formula:

- `render.ts fadedColor(hex, amount = 1)`: `amount` scales the one perceptual blend (after the dim-hue early return, which therefore holds at every strength; a light page, already past the luminance target, stays a no-op). 1 is the strip's at-rest fade, unchanged for every tab label; `syncComposerPh` paints the overlay's name with `PH_NAME_FADE = 0.5`.
- The host prefix fades in tandem with the name it precedes (the standing rule): the strip's rule reads `opacity: var(--host-fade, 0.5)` and `#composer-ph` alone sets `--host-fade: 0.75` (1 − 0.5 × (1 − 0.5)). The tab label keeps 0.5, and the compound selector keeps winning over `.host-prefix.off` by specificity as before.

## Tests

- `composer-placeholder.test.ts`: the pins follow (the call with `PH_NAME_FADE`, the signature with a strength, the CSS variable), plus one new test: one rule with two strengths (the strength scales the one blend and nothing else reads it; the dim-hue return ahead of it; the strip's calls at the default; exactly one call naming a strength; one setter and one reader of `--host-fade`).
- `host-prefix.test.ts`, `host-offline.test.ts`: the rule's pin reads the variable.
- `tests/test_session_name_served.py`: on the real page the box's name is asserted at the per-channel midpoint (within 1) of the identity colour and the same session's real at-rest label, dark; neither the identity colour nor the at-rest fade. The light theme stays the identity colour.
- `tests/test_composer_placeholder_remote_served.py`: the overlay's host span at opacity 0.75 while the active tab's host span is at 1.

Screenshots (the three levels side by side: the full colour before the fade, the full fade, and this midpoint) are in the drops folder as `romp_chat-composer-name-fade-{dark,light}-before.png`, `romp_chat-composer-name-fade-{dark,light}.png` and `romp_chat-composer-name-half-fade-{dark,light}.png`.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
