### PR TITLE
The plan notes say exactly how each plan met the tmux backend, hard-wrapped (follow-up to stage 5 of #1398)

### DIFF
--- a/plans/clear-episodes.md
+++ b/plans/clear-episodes.md
@@ -1,6 +1,8 @@
 # `/clear` is an episode boundary, not a deletion
 
-*History (2026-09-11): the terminal (tmux) backend this plan describes a lane shape for was removed from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux passages below describe the state at the time of writing and are kept as history.*
+*History (2026-09-11): the terminal (tmux) backend this plan lists among its accepted gaps was
+removed from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux
+passages below describe the state at the time of writing and are kept as history.*
 
 Direction picked by the user (2026-07-26): when a session's conversation is
 cleared, keep the session — its name, tab slot, mailbox, worktree naming, and

--- a/plans/codex-backend.md
+++ b/plans/codex-backend.md
@@ -1,6 +1,9 @@
 # The Codex session backend
 
-*History (2026-09-11): the terminal (tmux) backend this plan contrasts its control channel with was removed from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux passages below describe the state at the time of writing and are kept as history.*
+*History (2026-09-11): the terminal (tmux) backend this plan rejects a TUI-driving alternative in
+the spirit of was removed from romp on that date (issue #1398; the migration note is in
+`docs/reference.md`). The tmux passages below describe the state at the time of writing and are kept
+as history.*
 
 A third `SessionBackend` that drives **OpenAI Codex** sessions, so Codex agents
 sit on the same board as Claude sessions — same lanes, cards, chat, judges, and

--- a/plans/sdk-backend.md
+++ b/plans/sdk-backend.md
@@ -1,6 +1,8 @@
 # The SDK (non-tmux) session backend
 
-*History (2026-09-11): the terminal (tmux) backend this plan was written to coexist with was removed from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux passages below describe the state at the time of writing and are kept as history.*
+*History (2026-09-11): the terminal (tmux) backend this plan was written to coexist with was removed
+from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux
+passages below describe the state at the time of writing and are kept as history.*
 
 Resolves the open question in `event-model.md` ("Agent SDK vs hand-rolled
 stream-json client for the future headless-with-parity substrate") and the

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -1,6 +1,8 @@
 # Subagent transcripts: open any agent's whole conversation from the dashboard
 
-*History (2026-09-11): the terminal (tmux) backend this plan names among the session kinds was removed from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux passages below describe the state at the time of writing and are kept as history.*
+*History (2026-09-11): the terminal (tmux) backend this plan names among the session kinds was
+removed from romp on that date (issue #1398; the migration note is in `docs/reference.md`). The tmux
+passages below describe the state at the time of writing and are kept as history.*
 
 **Status: slice 1 IN FLIGHT** (branch `subagent-transcripts`, PR #935, 2026-09-05; lands with that PR's
 merge commit; a second cut the same day flattened the Agent head's fold — see "The head's fold").


### PR DESCRIPTION
A follow-up to the stage 5 history pointers of the tmux backend removal, issue #1398. Tier `docs`.

Two of the four plan notes said more than the plan's own passage does: `plans/clear-episodes.md` lists the terminal backend among its accepted gaps (not a lane shape it describes), and `plans/codex-backend.md` rejects driving a TUI in tmux as an alternative for Codex (it does not contrast its control channel with the backend). Both notes now say what the passage does. All four notes wrap at a hundred columns, the shape the note in `plans/multi-kernel.md` already has.

Verification: the docs-reading tests (`test_reference_billing_label`, `test_tier_policy`, `test_subagent_transcripts`, `test_judge_authoritative_plan_sync`) plus the maintainer's untracked identifier scanner pass on the branch. No SDK file is touched.
