### PR TITLE
The CI comment says which tools the bats suites need (follow-up to stage 4 of #1398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,11 @@ jobs:
       # bats comes from the pinned release tarball, NOT apt: an Azure apt-mirror outage hung
       # `apt-get update` to the job timeout three runs in a row (2026-08-19, ~35 wasted minutes
       # each). GitHub itself is already on the critical path (checkout), so this adds no new
-      # dependency — and no bats test needs a runtime beyond bash (every suite mocks its subjects on
-      # PATH); gitleaks, two steps below, is the one extra tool, for tests/gitleaks-config.bats. The step timeout kills any residual network hang in
-      # minutes instead of letting it eat the job's budget.
+      # dependency — and no bats test needs a tool the runner image lacks: node, python3 and curl are
+      # on the GitHub images (the manager suites run the real bin/romp-manager under node; romp.bats and
+      # install-sh.bats run python3 and curl), the rest mock their subjects on PATH; gitleaks, two steps
+      # below, is the one extra install, for tests/gitleaks-config.bats. The step timeout kills any
+      # residual network hang in minutes instead of letting it eat the job's budget.
       - name: Install bats (Linux)
         if: runner.os == 'Linux'
         timeout-minutes: 5


### PR DESCRIPTION
A follow-up to stage 4 of the tmux backend removal, issue #1398. Tier `docs`: a comment in `.github/workflows/ci.yml` only.

Stage 4 reworded the bats install comment to say no suite needs a runtime beyond bash, which is false: `romp-manager-ensure.bats` and `romp-manager-origin.bats` run the real `bin/romp-manager` under the image's node, and `romp.bats` and `install-sh.bats` run python3 and curl. The base text had claimed only that no test needs a real tmux. The comment now says what is true: no suite needs a tool the GitHub runner image lacks (node, python3 and curl are on the images), the rest mock their subjects on PATH, and gitleaks is the one extra install. The sentence about the step timeout, left on an overlong line by that edit, wraps again.

Verification: the two tests that read the workflow file (`test_ci_workflow_concurrency`, `test_tier_policy`) pass; the YAML parses. Touches `.github/` (a comment), which the tier policy gates on the owner's approval for non-admin authors; filed under the owner's account. No SDK file is touched.