### PR TITLE
The pusher warms the chat's pages cache for the active cards' anchors

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1389,14 +1389,19 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   the pusher's send stage (`push.warm`), with a board client and a proto-2 chat
   client connected: `warmed` pages rendered ahead of a click for the feed's
   cards' anchors (the distilled summary's own targets first, a completed card's
-  too, then the active cards' heads and open rows; at most 32 anchors probed
-  and 16 pages rendered per cycle, a resident page costing a dictionary read,
-  so an unchanged board settles to a probe and an evicted page is warmed
-  again), `warmPending` (pages over the cycle's render budget, rendered on the
-  cycles after), `warmMs`, `warmCycles`, and `warmSkipped` (cycles the warm
-  stood down because the pusher's last cycle ran over 1.5 s). A page's cache
-  key reads what a pre-floor render reads and none of the live tail, so a
-  warmed page survives the turns that stream after it.
+  too, then the active cards' heads and open rows; the feed's first 32 anchors,
+  so a late session's summaries can fall past the cap; the warm SET is bounded
+  to 16 pages, half the cache: anchors past it wait for the next board change,
+  and a set that fits settles, an unchanged board costing one probe of its
+  remembered keys), `warmPending` (anchors waiting past the bound), `warmMs`,
+  `warmCycles`, and `warmSkipped` (cycles the warm stood down because the
+  pusher's last cycle ran over 1.5 s). A page's cache key reads what a
+  pre-floor render reads and none of the live tail (the reg's fork value, not
+  the reg file, which every send rewrites), so a warmed page survives the turns
+  that stream after it until the session's next judge publish (the goal store's
+  identity is a component: the segment anchors come from it); the postal
+  caption map is not a component, so a pre-floor page holding a card rendered
+  before its caption landed keeps the caption-less card until an eviction.
 - `parses`: the cold event-model parses through the one parse store the
   kernel and the judges share: `total` (every miss, whoever asked), `kernel`
   (the display's asks among them, with `bytes`, the parsed files' sizes, and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1385,7 +1385,18 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
 - `chatPages`: the rendered pages of chat history before a session's render
   floor (the chat wire's `loadOlder`, `loadAround` and `loadNewer` answers, below):
   `hits`, `misses`, `evictions`, `pages` and `bytes` resident (a bound of 32
-  pages or 16 MB per kernel), `renderMs` spent rendering.
+  pages or 16 MB per kernel), `renderMs` spent rendering; the warming, after
+  the pusher's send stage (`push.warm`), with a board client and a proto-2 chat
+  client connected: `warmed` pages rendered ahead of a click for the feed's
+  cards' anchors (the distilled summary's own targets first, a completed card's
+  too, then the active cards' heads and open rows; at most 32 anchors probed
+  and 16 pages rendered per cycle, a resident page costing a dictionary read,
+  so an unchanged board settles to a probe and an evicted page is warmed
+  again), `warmPending` (pages over the cycle's render budget, rendered on the
+  cycles after), `warmMs`, `warmCycles`, and `warmSkipped` (cycles the warm
+  stood down because the pusher's last cycle ran over 1.5 s). A page's cache
+  key reads what a pre-floor render reads and none of the live tail, so a
+  warmed page survives the turns that stream after it.
 - `parses`: the cold event-model parses through the one parse store the
   kernel and the judges share: `total` (every miss, whoever asked), `kernel`
   (the display's asks among them, with `bytes`, the parsed files' sizes, and

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1391,9 +1391,12 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   cards' anchors (the distilled summary's own targets first, a completed card's
   too, then the active cards' heads and open rows; the feed's first 32 anchors,
   so a late session's summaries can fall past the cap; the warm SET is bounded
-  to 16 pages, half the cache: anchors past it wait for the next board change,
-  and a set that fits settles, an unchanged board costing one probe of its
-  remembered keys), `warmPending` (anchors waiting past the bound), `warmMs`,
+  to half the cache in pages and in bytes: anchors past it wait for the next
+  board change, and a set that fits settles, an unchanged board costing one
+  probe of its remembered keys; a set with an anchor whose session has no
+  render floor yet is never remembered as settled, so the floor's return
+  warms), `warmPending` (anchors waiting past the bound), `warmMs` (the
+  probes' time included),
   `warmCycles`, and `warmSkipped` (cycles the warm stood down because the
   pusher's last cycle ran over 1.5 s). A page's cache key reads what a
   pre-floor render reads and none of the live tail (the reg's fork value, not

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40799,9 +40799,13 @@ def _page_sig(sess, sid, now, floor=None, turns=None):
     written: its identity here is the leaf path, the render floor and the uuid of the last atom below the floor (a
     rewind or a /clear that reaches below the floor moves one of them). The rest are the inputs the page reshape
     reads besides the atoms: the episodes file (the note floor, the boundary card), the goal store (the segment
-    anchors), the reg (a fork's branch marker), the gone marker, the rewind hold and the pending cut, and the
-    components every tab shares (the postal caption map and the names snapshot among them, _chat_sig_shared). None
-    when the session has no transcript path."""
+    anchors), the reg's forkedFrom (a fork's branch marker; the value, since the reg file itself is rewritten on every
+    send), the gone marker, the rewind hold and the pending cut, and the components every tab shares (the names
+    snapshot among them, _chat_sig_shared; the postal caption map is NOT among them: a pre-floor page holding a postal
+    card that was rendered before its caption landed keeps the caption-less card until an eviction re-renders it,
+    accepted, the card's text being the same). The goal store's identity is a component too, so a page survives the
+    turns that stream after it until the next judge publish for the session. None when the session has no transcript
+    path."""
     path = sess.get("path") if sess else None
     if not path:
         return None
@@ -40821,7 +40825,8 @@ def _page_sig(sess, sid, now, floor=None, turns=None):
     shared = getattr(_live_scope, "chat_shared", None) or _chat_sig_shared()
     raw = [os.path.realpath(path), int(floor), last,
            _chat_ident(jd.EPIDIR / (sid + ".jsonl")), jd._store_identity(sid)[1:],
-           _chat_ident(jd.STATE / "sdk" / (sid + ".json")), _chat_ident(jd.GONEDIR / (sid + ".json")),
+           (_thread_reg(sid) or {}).get("forkedFrom"),    # the one reg field a page reads (the branch marker): the FILE's identity
+           _chat_ident(jd.GONEDIR / (sid + ".json")),     #  moves on every send (the queue and echo mirrors rewrite it; warming review 2)
            (_hold.get("cutT"), _hold.get("leaf"), _hold.get("at")) if _hold else None,
            _be.pending_cut(sid) if _be else "", shared]
     return hashlib.sha1(json.dumps(raw, sort_keys=True, default=str).encode("utf-8")).hexdigest()
@@ -40901,10 +40906,14 @@ def _history_pages(sid, lo, hi, now, sess=None, live_map=None, sig=None, stats=N
 
 # ── warming the pages cache for the active cards' anchors (the user 2026-09-10: a click on a summary far in the past
 # took long to load; the cache behind the active cards) ──────────────────────────────────────────────────────────
-WARM_ANCHORS_MAX = 32                            # anchors probed per cycle
-WARM_PAGES_MAX = _PAGE_CACHE_MAX // 2            # pages RENDERED per cycle: half the cache, so a warm never evicts the pages a
-#                                                  reader just scrolled into nor its own first half; the rest wait a cycle
+WARM_ANCHORS_MAX = 32                            # anchors probed per cycle, in the feed's order (a late session's summaries can
+#                                                  fall past the cap: accepted, the board's first cards are the ones read)
+WARM_PAGES_MAX = _PAGE_CACHE_MAX // 2            # the warm SET: half the cache in pages, so a warm never evicts the pages a
+#                                                  reader just scrolled into nor its own first half; anchors past it wait for
+#                                                  the next board change (a set that fits settles to a probe)
 WARM_SKIP_MS = 1500                              # a pusher cycle slower than this: the warm stands down (counted)
+_WARM_MEMO = {"anchors": (), "keys": frozenset(), "sigs": {}}   # the last anchor list whose set was fully resident, that set's
+#                                                                  page keys, and the page signature per session they were keyed on
 
 
 def _card_anchors(feed):
@@ -40941,18 +40950,34 @@ def _card_anchors(feed):
 
 def _warm_history_pages(feed, now, live_map=None):
     """Render, into the pages cache, the pages the feed's cards' anchors would ask for (the window loadAround serves,
-    _window_turns), so a click on one lands from the cache. Each anchor's pages are PROBED first: a page resident
-    under the session's current page signature costs nothing, one that is not is rendered, so a page evicted by a
-    reader's scrolling or invalidated by a floor flip is warmed again on the next cycle, and an unchanged board settles
-    to a probe (a turn map and one signature per session, dictionary reads per page). Bounded: WARM_ANCHORS_MAX
-    anchors probed and WARM_PAGES_MAX pages rendered per cycle (the pages over the budget are counted as
-    chatPages.warmPending and rendered on the cycles after); skipped whole when the pusher's last cycle ran over
-    WARM_SKIP_MS (chatPages.warmSkipped). Only sessions whose chat has been built with a render floor and only anchors
-    before it (the tail is resident already). Returns the number of pages rendered by THIS call (its own count, not
-    a shared counter's difference: a handler's render meanwhile is not the warm's)."""
+    _window_turns), so a click on one lands from the cache. The warm SET is bounded to WARM_PAGES_MAX pages (half the
+    cache): anchors are taken in the feed's order and the first whose window would take the set past the bound, and
+    every anchor after it, wait for the next board change (counted as chatPages.warmPending), so the warm never evicts
+    its own pages nor a reader's and a bounded set SETTLES (the warming review, 2026-09-11: an unbounded set over the
+    cache re-rendered itself every cycle for the kernel's life). Each admitted page is PROBED first: one resident under
+    the session's current page signature costs nothing, one that is not is rendered, so a page a reader's scrolling
+    evicted or a floor flip re-keyed is warmed again; an unchanged board whose set is fully resident costs one probe of
+    the remembered keys (_WARM_MEMO), nothing else. Skipped whole when the pusher's last cycle ran over WARM_SKIP_MS
+    (chatPages.warmSkipped). Only sessions whose chat has been built with a render floor and only anchors before it
+    (the tail is resident already). Returns the number of pages rendered by THIS call (its own count, not a shared
+    counter's difference: a handler's render meanwhile is not the warm's)."""
     anchors = _card_anchors(feed)[:WARM_ANCHORS_MAX]
     if not anchors:
         return 0
+    rows = {x["sid"]: x for x in _sessions(now)}
+    if tuple(anchors) == _WARM_MEMO["anchors"]:
+        # a settled board: its set still resident under the sessions' CURRENT page signatures costs this probe alone (a
+        # floor flip or a judge publish moves a signature: the remembered keys are then another key's pages)
+        try:
+            same = all(_page_sig(rows[sid_], sid_, now) == sg for sid_, sg in _WARM_MEMO["sigs"].items() if sid_ in rows)
+        except Exception:
+            same = False
+        with _page_lock:
+            settled = same and all(k in _PAGE_CACHE for k in _WARM_MEMO["keys"])
+        if settled:
+            with _page_lock:
+                _PAGE_STATS["warmCycles"] += 1
+            return 0
     last_ms = _PERF_STATS.pusher.get("cycle_ms_last", 0.0) if hasattr(_PERF_STATS, "pusher") else 0.0
     if last_ms > WARM_SKIP_MS:
         with _page_lock:
@@ -40961,10 +40986,12 @@ def _warm_history_pages(feed, now, live_map=None):
     if live_map is None:
         live_map = _live_map()
     t0 = time.monotonic()
-    st, pending = {"rendered": 0}, 0
-    rows = {x["sid"]: x for x in _sessions(now)}
+    st, pending, keys = {"rendered": 0}, 0, set()
     per_sid = {}                                  # sid → (floor, sess, turns, uuid → turn index below the floor, page signature)
     for sid, uuid in anchors:
+        if len(keys) >= WARM_PAGES_MAX:
+            pending += 1                          # past the set's bound: this anchor waits for the next board change
+            continue
         try:
             if sid not in per_sid:
                 floor, sess = _RENDER_FLOOR.get(sid), rows.get(sid)
@@ -40984,17 +41011,16 @@ def _warm_history_pages(feed, now, live_map=None):
             if j is None or j >= floor:
                 continue
             lo, hi = _window_turns(j, floor)
-            a = lo
-            while a < hi:
-                b = min(hi, a + PAGE_TURNS)
+            window = [(sid, a, min(hi, a + PAGE_TURNS), sig) for a in range(lo, hi, PAGE_TURNS)]
+            if keys and len(keys | set(window)) > WARM_PAGES_MAX:
+                pending += 1                      # its pages would take the set past the bound: it waits (a shared page is free)
+                continue
+            keys.update(window)
+            for key in window:
                 with _page_lock:
-                    resident = (sid, a, b, sig) in _PAGE_CACHE
+                    resident = key in _PAGE_CACHE
                 if not resident:
-                    if st["rendered"] >= WARM_PAGES_MAX:
-                        pending += 1
-                    else:
-                        _chat_history_page(sid, a, b, now, sess=sess, live_map=live_map, sig=sig, stats=st)
-                a = b
+                    _chat_history_page(sid, key[1], key[2], now, sess=sess, live_map=live_map, sig=sig, stats=st)
         except Exception:
             sys.stderr.write("chat pages warm: %s\n" % traceback.format_exc().strip().splitlines()[-1])
     with _page_lock:
@@ -41002,6 +41028,11 @@ def _warm_history_pages(feed, now, live_map=None):
         _PAGE_STATS["warmPending"] = pending
         _PAGE_STATS["warmMs"] += (time.monotonic() - t0) * 1000.0
         _PAGE_STATS["warmCycles"] += 1
+        resident_all = all(k in _PAGE_CACHE for k in keys)
+    if resident_all:
+        _WARM_MEMO.update(anchors=tuple(anchors), keys=frozenset(keys), sigs={sid_: e[4] for sid_, e in per_sid.items() if e is not None})
+    else:
+        _WARM_MEMO.update(anchors=(), keys=frozenset(), sigs={})
     return st["rendered"]
 
 
@@ -43649,14 +43680,14 @@ def _push(targets, connect=False, live_map=None):
             sys.stderr.write("push send %s (%s): %s\n" % ("feed" if is_feed else "bars", c.get("app"), traceback.format_exc()))
     _PERF_STATS.stage("push.send", time.monotonic() - _t_stage)
     # the cards' windows, ahead of a click (the warming, 2026-09-11): AFTER the send stage, so the feed frame of the cycle a
-    # card moves never waits for the renders; only with a board to click on (a feed or fleet client among the targets,
-    # want_feed) and a proto-2 chat client to serve pages to; its own stage key
+    # card moves never waits for the renders; only with a board to click on (a feed or fleet client among the targets;
+    # want_feed counts the chat too, which cannot click a card) and a proto-2 chat client to serve pages to; its own stage key
     _t_stage = time.monotonic()
     try:
         _fs = feed_src
     except NameError:
         _fs = None
-    if want_feed and _fs and not connect and any(c.get("proto") == 2 for c in chat_clients):
+    if any(c["app"] in ("feed", "fleet") for c in targets) and _fs and not connect and any(c.get("proto") == 2 for c in chat_clients):
         try:
             _warm_history_pages(_fs, now, live_map)
         except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40951,10 +40951,12 @@ def _card_anchors(feed):
 def _warm_history_pages(feed, now, live_map=None):
     """Render, into the pages cache, the pages the feed's cards' anchors would ask for (the window loadAround serves,
     _window_turns), so a click on one lands from the cache. The warm SET is bounded to WARM_PAGES_MAX pages (half the
-    cache): anchors are taken in the feed's order and the first whose window would take the set past the bound, and
-    every anchor after it, wait for the next board change (counted as chatPages.warmPending), so the warm never evicts
-    its own pages nor a reader's and a bounded set SETTLES (the warming review, 2026-09-11: an unbounded set over the
-    cache re-rendered itself every cycle for the kernel's life). Each admitted page is PROBED first: one resident under
+    cache, in pages AND in bytes, half of each bound): anchors are taken in the feed's order and the first whose window
+    would take the set past the bound, and every anchor after it, wait for the next board change (counted as
+    chatPages.warmPending), so the warm never evicts its own pages nor a reader's and a bounded set SETTLES (the warming
+    review, 2026-09-11: an unbounded set over the cache re-rendered itself every cycle for the kernel's life). A set is
+    remembered as settled only when it is non-empty and every anchor resolved (a session with no render floor yet, an
+    index client holding the tabs at 0, leaves the set unresolved, so the floor's return warms). Each admitted page is PROBED first: one resident under
     the session's current page signature costs nothing, one that is not is rendered, so a page a reader's scrolling
     evicted or a floor flip re-keyed is warmed again; an unchanged board whose set is fully resident costs one probe of
     the remembered keys (_WARM_MEMO), nothing else. Skipped whole when the pusher's last cycle ran over WARM_SKIP_MS
@@ -40964,33 +40966,35 @@ def _warm_history_pages(feed, now, live_map=None):
     anchors = _card_anchors(feed)[:WARM_ANCHORS_MAX]
     if not anchors:
         return 0
+    last_ms = _PERF_STATS.pusher.get("cycle_ms_last", 0.0) if hasattr(_PERF_STATS, "pusher") else 0.0
+    if last_ms > WARM_SKIP_MS:                    # the stand-down first: an over-budget pusher pays not even the probe (round 3, C)
+        with _page_lock:
+            _PAGE_STATS["warmSkipped"] += 1
+        return 0
+    t0 = time.monotonic()
     rows = {x["sid"]: x for x in _sessions(now)}
     if tuple(anchors) == _WARM_MEMO["anchors"]:
         # a settled board: its set still resident under the sessions' CURRENT page signatures costs this probe alone (a
-        # floor flip or a judge publish moves a signature: the remembered keys are then another key's pages)
+        # floor flip or a judge publish moves a signature: the remembered keys are then another key's pages); the probe's
+        # time is the warm's (warmMs)
         try:
             same = all(_page_sig(rows[sid_], sid_, now) == sg for sid_, sg in _WARM_MEMO["sigs"].items() if sid_ in rows)
         except Exception:
             same = False
         with _page_lock:
             settled = same and all(k in _PAGE_CACHE for k in _WARM_MEMO["keys"])
-        if settled:
-            with _page_lock:
+            if settled:
                 _PAGE_STATS["warmCycles"] += 1
+                _PAGE_STATS["warmMs"] += (time.monotonic() - t0) * 1000.0
+        if settled:
             return 0
-    last_ms = _PERF_STATS.pusher.get("cycle_ms_last", 0.0) if hasattr(_PERF_STATS, "pusher") else 0.0
-    if last_ms > WARM_SKIP_MS:
-        with _page_lock:
-            _PAGE_STATS["warmSkipped"] += 1
-        return 0
     if live_map is None:
         live_map = _live_map()
-    t0 = time.monotonic()
-    st, pending, keys = {"rendered": 0}, 0, set()
+    st, pending, keys, unresolved, set_bytes = {"rendered": 0}, 0, set(), 0, 0
     per_sid = {}                                  # sid → (floor, sess, turns, uuid → turn index below the floor, page signature)
     for sid, uuid in anchors:
-        if len(keys) >= WARM_PAGES_MAX:
-            pending += 1                          # past the set's bound: this anchor waits for the next board change
+        if len(keys) >= WARM_PAGES_MAX or (keys and set_bytes >= _PAGE_CACHE_BYTES // 2):
+            pending += 1                          # past the set's bound (pages, or bytes: round 3, B): waits for the next board change
             continue
         try:
             if sid not in per_sid:
@@ -41003,7 +41007,8 @@ def _warm_history_pages(feed, now, live_map=None):
                     per_sid[sid] = (floor, sess, turns, u2t, _page_sig(sess, sid, now, floor=floor, turns=turns))
             entry = per_sid[sid]
             if entry is None:
-                continue
+                unresolved += 1                   # no floor yet (an index client holds every tab at 0), or no row: this
+                continue                          #  anchor's pages are unknown, so the set cannot be called settled (round 3, A)
             floor, sess, turns, u2t, sig = entry
             j = u2t.get(str(uuid).split("#", 1)[0])
             if j is None:
@@ -41018,18 +41023,22 @@ def _warm_history_pages(feed, now, live_map=None):
             keys.update(window)
             for key in window:
                 with _page_lock:
-                    resident = key in _PAGE_CACHE
-                if not resident:
+                    hit = _PAGE_CACHE.get(key)
+                if hit is None:
                     _chat_history_page(sid, key[1], key[2], now, sess=sess, live_map=live_map, sig=sig, stats=st)
+                    with _page_lock:
+                        hit = _PAGE_CACHE.get(key)
+                set_bytes += hit[1] if hit is not None else 0   # the set's bytes: a page over the half-bound alone is admitted, and the set closes
         except Exception:
+            unresolved += 1
             sys.stderr.write("chat pages warm: %s\n" % traceback.format_exc().strip().splitlines()[-1])
     with _page_lock:
         _PAGE_STATS["warmed"] += st["rendered"]
         _PAGE_STATS["warmPending"] = pending
         _PAGE_STATS["warmMs"] += (time.monotonic() - t0) * 1000.0
         _PAGE_STATS["warmCycles"] += 1
-        resident_all = all(k in _PAGE_CACHE for k in keys)
-    if resident_all:
+        resident_all = bool(keys) and unresolved == 0 and all(k in _PAGE_CACHE for k in keys)   # an empty or unresolved set is
+    if resident_all:                                                                              #  never "settled" (round 3, A)
         _WARM_MEMO.update(anchors=tuple(anchors), keys=frozenset(keys), sigs={sid_: e[4] for sid_, e in per_sid.items() if e is not None})
     else:
         _WARM_MEMO.update(anchors=(), keys=frozenset(), sigs={})

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -40786,22 +40786,61 @@ PAGE_TURNS = 16                                  # turns per rendered page of pr
 WINDOW_TURNS = 8                                 # turns each side of a loadAround anchor
 _PAGE_CACHE = {}                                 # (sid, lo, hi, sig) → (events, bytes); LRU by insertion order
 _PAGE_CACHE_MAX, _PAGE_CACHE_BYTES = 32, 16 * 1024 * 1024
-_PAGE_STATS = {"hits": 0, "misses": 0, "evictions": 0, "pages": 0, "bytes": 0, "renderMs": 0.0}
+_PAGE_STATS = {"hits": 0, "misses": 0, "evictions": 0, "pages": 0, "bytes": 0, "renderMs": 0.0, "warmPending": 0,
+               "warmed": 0, "warmMs": 0.0, "warmCycles": 0, "warmSkipped": 0}   # the active cards' windows warmed ahead of a click
 _page_lock = threading.Lock()
 
 
-def _chat_history_page(sid, lo, hi, now, sess=None, live_map=None):
+def _page_sig(sess, sid, now, floor=None, turns=None):
+    """The pages cache's key for a session: a digest of every input a PRE-FLOOR page render reads that can change it,
+    and none of the live tail's (the transcript's stat, the liveness row, the backend's live revision, the queue, the
+    task store), which move at turn rate for exactly the working sessions the board shows and would evict a warmed
+    page before its click (the warming review, 2026-09-11). The pre-cut prefix a page renders from is fixed once
+    written: its identity here is the leaf path, the render floor and the uuid of the last atom below the floor (a
+    rewind or a /clear that reaches below the floor moves one of them). The rest are the inputs the page reshape
+    reads besides the atoms: the episodes file (the note floor, the boundary card), the goal store (the segment
+    anchors), the reg (a fork's branch marker), the gone marker, the rewind hold and the pending cut, and the
+    components every tab shares (the postal caption map and the names snapshot among them, _chat_sig_shared). None
+    when the session has no transcript path."""
+    path = sess.get("path") if sess else None
+    if not path:
+        return None
+    sid = str(sid)
+    if turns is None or floor is None:
+        try:
+            parsed = _parse(path, sid, now)
+        except Exception:
+            return None
+        turns = parsed["turns"] if turns is None else turns
+        floor = _RENDER_FLOOR.get(sid, _asm_cut_turn(parsed)) if floor is None else floor
+    last = None
+    if 0 < floor <= len(turns) and turns[floor - 1].get("atoms"):
+        last = turns[floor - 1]["atoms"][-1].get("uuid")
+    _hold = _rewind_hold_get(sid)
+    _be = _sdk()
+    shared = getattr(_live_scope, "chat_shared", None) or _chat_sig_shared()
+    raw = [os.path.realpath(path), int(floor), last,
+           _chat_ident(jd.EPIDIR / (sid + ".jsonl")), jd._store_identity(sid)[1:],
+           _chat_ident(jd.STATE / "sdk" / (sid + ".json")), _chat_ident(jd.GONEDIR / (sid + ".json")),
+           (_hold.get("cutT"), _hold.get("leaf"), _hold.get("at")) if _hold else None,
+           _be.pending_cut(sid) if _be else "", shared]
+    return hashlib.sha1(json.dumps(raw, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+
+
+def _chat_history_page(sid, lo, hi, now, sess=None, live_map=None, sig=None, stats=None):
     """The rendered events of turns [lo, hi) of `sid` (build_session's page mode), through a bounded LRU keyed on the
-    session's whole chat-build signature: any input that would change the render misses. Counted (/perf chatPages)."""
+    session's page signature (_page_sig: what a pre-floor page reads, none of the live tail; `sig` when the caller
+    computed it once for several pages). Counted (/perf chatPages); `stats["rendered"]` is bumped when this call
+    rendered, so a caller counts its own renders and not a concurrent handler's."""
     if live_map is None:
         live_map = _live_map()
     if sess is None:
         sess = next((x for x in _sessions(now) if x["sid"] == sid), None)
-    try:                                          # the whole chat-build signature, as one digest (its components hold dicts)
-        raw = _chat_build_sig(sess, live_map.get(sid), now, live_map=live_map, deps=False) if sess else None
-        sig = hashlib.sha1(json.dumps(raw, sort_keys=True, default=str).encode("utf-8")).hexdigest() if raw is not None else None
-    except Exception:
-        sig = None
+    if sig is None:
+        try:
+            sig = _page_sig(sess, sid, now) if sess else None
+        except Exception:
+            sig = None
     key = (sid, lo, hi, sig)
     with _page_lock:
         hit = _PAGE_CACHE.get(key) if sig is not None else None
@@ -40810,6 +40849,8 @@ def _chat_history_page(sid, lo, hi, now, sess=None, live_map=None):
             _PAGE_STATS["hits"] += 1
             return hit[0]
         _PAGE_STATS["misses"] += 1
+    if stats is not None:
+        stats["rendered"] = stats.get("rendered", 0) + 1
     t0 = time.monotonic()
     try:
         page = build_session(sid, now, live_map, page=(lo, hi))
@@ -40833,6 +40874,135 @@ def _chat_history_page(sid, lo, hi, now, sess=None, live_map=None):
                 _PAGE_STATS["bytes"] -= _b; _PAGE_STATS["evictions"] += 1
             _PAGE_STATS["pages"] = len(_PAGE_CACHE)
     return evs
+
+
+def _window_turns(j, floor):
+    """The turns [lo, hi) a loadAround window covers for an anchor in turn j before the floor: the two PAGE-ALIGNED pages
+    around it (the page holding j and its nearer neighbour), so the window is at least WINDOW_TURNS each side where the
+    history allows, every page it renders is a whole cache entry, and the windows of anchors in the same pages share
+    entries (the warm and the click render the same keys)."""
+    p = (j // PAGE_TURNS) * PAGE_TURNS
+    if j - p < PAGE_TURNS // 2 and p > 0:
+        lo, hi = p - PAGE_TURNS, p + PAGE_TURNS
+    else:
+        lo, hi = p, p + 2 * PAGE_TURNS           # the second half, or the head's own page: the page after it
+    return lo, max(lo, min(floor, hi))
+
+
+def _history_pages(sid, lo, hi, now, sess=None, live_map=None, sig=None, stats=None):
+    """The rendered events of turns [lo, hi) as page-aligned pages (PAGE_TURNS each), through the pages cache."""
+    out, a = [], lo
+    while a < hi:
+        b = min(hi, (a // PAGE_TURNS + 1) * PAGE_TURNS)
+        out.extend(_chat_history_page(sid, a, b, now, sess=sess, live_map=live_map, sig=sig, stats=stats))
+        a = b
+    return out
+
+
+# ── warming the pages cache for the active cards' anchors (the user 2026-09-10: a click on a summary far in the past
+# took long to load; the cache behind the active cards) ──────────────────────────────────────────────────────────
+WARM_ANCHORS_MAX = 32                            # anchors probed per cycle
+WARM_PAGES_MAX = _PAGE_CACHE_MAX // 2            # pages RENDERED per cycle: half the cache, so a warm never evicts the pages a
+#                                                  reader just scrolled into nor its own first half; the rest wait a cycle
+WARM_SKIP_MS = 1500                              # a pusher cycle slower than this: the warm stands down (counted)
+
+
+def _card_anchors(feed):
+    """(sid, uuid) for every deep-link anchor the feed's cards carry that a click would land in the chat: first the card's
+    distilled summary's own targets (summaryAnchorUuid, the summary line's click, and each paragraph's `u`; a
+    completed card's too: the takeaway far in the past is the click the user named, 2026-09-10), then, for the cards
+    in every column but completed, the head's work and prompt anchors and its open rows' (a done row's are not
+    warmed; a handoff row points at another session's card and is that card's to warm). Ordered as the feed lists
+    them, deduplicated."""
+    out, seen = [], set()
+
+    def add(sid, u):
+        if u and (sid, u) not in seen:
+            seen.add((sid, u)); out.append((sid, u))
+    for card in (feed or {}).get("asks") or []:
+        if not isinstance(card, dict) or not card.get("sid"):
+            continue
+        sid = str(card["sid"])
+        add(sid, card.get("summaryAnchorUuid"))
+        for p in card.get("summaryAnchorsPara") or []:
+            if isinstance(p, dict):
+                add(sid, p.get("u"))
+        if card.get("column") == "completed":
+            continue
+        for i, row in enumerate(card.get("tree") or []):
+            if not isinstance(row, dict) or row.get("kind") == "handoff":
+                continue
+            if i > 0 and row.get("status") == "done":
+                continue
+            for k in ("anchorUuid", "promptAnchorUuid"):
+                add(sid, row.get(k))
+    return out
+
+
+def _warm_history_pages(feed, now, live_map=None):
+    """Render, into the pages cache, the pages the feed's cards' anchors would ask for (the window loadAround serves,
+    _window_turns), so a click on one lands from the cache. Each anchor's pages are PROBED first: a page resident
+    under the session's current page signature costs nothing, one that is not is rendered, so a page evicted by a
+    reader's scrolling or invalidated by a floor flip is warmed again on the next cycle, and an unchanged board settles
+    to a probe (a turn map and one signature per session, dictionary reads per page). Bounded: WARM_ANCHORS_MAX
+    anchors probed and WARM_PAGES_MAX pages rendered per cycle (the pages over the budget are counted as
+    chatPages.warmPending and rendered on the cycles after); skipped whole when the pusher's last cycle ran over
+    WARM_SKIP_MS (chatPages.warmSkipped). Only sessions whose chat has been built with a render floor and only anchors
+    before it (the tail is resident already). Returns the number of pages rendered by THIS call (its own count, not
+    a shared counter's difference: a handler's render meanwhile is not the warm's)."""
+    anchors = _card_anchors(feed)[:WARM_ANCHORS_MAX]
+    if not anchors:
+        return 0
+    last_ms = _PERF_STATS.pusher.get("cycle_ms_last", 0.0) if hasattr(_PERF_STATS, "pusher") else 0.0
+    if last_ms > WARM_SKIP_MS:
+        with _page_lock:
+            _PAGE_STATS["warmSkipped"] += 1
+        return 0
+    if live_map is None:
+        live_map = _live_map()
+    t0 = time.monotonic()
+    st, pending = {"rendered": 0}, 0
+    rows = {x["sid"]: x for x in _sessions(now)}
+    per_sid = {}                                  # sid → (floor, sess, turns, uuid → turn index below the floor, page signature)
+    for sid, uuid in anchors:
+        try:
+            if sid not in per_sid:
+                floor, sess = _RENDER_FLOOR.get(sid), rows.get(sid)
+                if not floor or sess is None:
+                    per_sid[sid] = None
+                else:
+                    turns = _parse(sess["path"], sid, now)["turns"]
+                    u2t = {a["uuid"]: i for i, t in enumerate(turns[:floor]) for a in t.get("atoms") or [] if a.get("uuid")}
+                    per_sid[sid] = (floor, sess, turns, u2t, _page_sig(sess, sid, now, floor=floor, turns=turns))
+            entry = per_sid[sid]
+            if entry is None:
+                continue
+            floor, sess, turns, u2t, sig = entry
+            j = u2t.get(str(uuid).split("#", 1)[0])
+            if j is None:
+                j = _turn_of_uuid(turns, uuid)    # a note's key, a fork's chip: by time
+            if j is None or j >= floor:
+                continue
+            lo, hi = _window_turns(j, floor)
+            a = lo
+            while a < hi:
+                b = min(hi, a + PAGE_TURNS)
+                with _page_lock:
+                    resident = (sid, a, b, sig) in _PAGE_CACHE
+                if not resident:
+                    if st["rendered"] >= WARM_PAGES_MAX:
+                        pending += 1
+                    else:
+                        _chat_history_page(sid, a, b, now, sess=sess, live_map=live_map, sig=sig, stats=st)
+                a = b
+        except Exception:
+            sys.stderr.write("chat pages warm: %s\n" % traceback.format_exc().strip().splitlines()[-1])
+    with _page_lock:
+        _PAGE_STATS["warmed"] += st["rendered"]
+        _PAGE_STATS["warmPending"] = pending
+        _PAGE_STATS["warmMs"] += (time.monotonic() - t0) * 1000.0
+        _PAGE_STATS["warmCycles"] += 1
+    return st["rendered"]
 
 
 def _turn_of_uuid(turns, uuid):
@@ -40890,13 +41060,7 @@ def _chat_history_reply(sid, msg, now, base=None):
         return _turn_of_uuid(turns, k)
 
     def pages(lo, hi):
-        out = []
-        a = lo
-        while a < hi:
-            b = min(hi, (a // PAGE_TURNS + 1) * PAGE_TURNS)
-            out.extend(_chat_history_page(sid, a, b, now, sess=sess, live_map=live_map))
-            a = b
-        return out
+        return _history_pages(sid, lo, hi, now, sess=sess, live_map=live_map)
 
     def older_than_turn(j, want):
         """Whole turns before turn j, at least `want` events when there are that many: (events, first turn)."""
@@ -40935,7 +41099,7 @@ def _chat_history_reply(sid, msg, now, base=None):
             j = _turn_of_uuid(turns, anchor)
             if j is None or j >= floor:
                 return {"type": "chatWindow", "id": sid, "anchor": anchor, "events": [], "moreBefore": False, "moreAfter": False, "missing": True}
-            lo, hi = max(0, j - WINDOW_TURNS), min(floor, j + WINDOW_TURNS)
+            lo, hi = _window_turns(j, floor)
             out = pages(lo, hi)
             body_first = _event_key(out[0]) if out else None   # the first EVENT: a head card's key places in no turn (round 3, B)
             more_before = lo > 0
@@ -43484,6 +43648,20 @@ def _push(targets, connect=False, live_map=None):
                     bars_down = True
             sys.stderr.write("push send %s (%s): %s\n" % ("feed" if is_feed else "bars", c.get("app"), traceback.format_exc()))
     _PERF_STATS.stage("push.send", time.monotonic() - _t_stage)
+    # the cards' windows, ahead of a click (the warming, 2026-09-11): AFTER the send stage, so the feed frame of the cycle a
+    # card moves never waits for the renders; only with a board to click on (a feed or fleet client among the targets,
+    # want_feed) and a proto-2 chat client to serve pages to; its own stage key
+    _t_stage = time.monotonic()
+    try:
+        _fs = feed_src
+    except NameError:
+        _fs = None
+    if want_feed and _fs and not connect and any(c.get("proto") == 2 for c in chat_clients):
+        try:
+            _warm_history_pages(_fs, now, live_map)
+        except Exception:
+            sys.stderr.write("chat pages warm: %s\n" % traceback.format_exc().strip().splitlines()[-1])
+        _PERF_STATS.stage("push.warm", time.monotonic() - _t_stage)
     with _clients_lock:
         _clients[:] = [c for c in _clients if c.get("alive", True)]
 

--- a/tests/test_chat_pages_warm.py
+++ b/tests/test_chat_pages_warm.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Warming the chat's pages cache for the feed's cards (2026-09-11; the user 2026-09-10: a click on a distilled summary
+far in the past took long to load, and they asked whether the transcript behind the active cards could be cached). The
+pusher, after its send stage, with a board client and a proto-2 chat client connected, renders into the pages cache the
+pages the cards' anchors would ask for (what loadAround serves), so the click lands from the cache. Pinned: the anchors
+are the summary's own click targets first (a completed card's too), then the active columns' cards' heads and open rows
+(a done row and a handoff row are not); every anchor's pages are probed, so an unchanged board settles to a probe and an
+evicted page is warmed again; the render budget per cycle is half the cache and the rest waits, counted; the warm stands
+down while the pusher is over its budget; a pre-floor page's key survives a turn; the counts are the warm's own; a warmed
+window is a cache hit for loadAround with no render. Synthetic transcript only."""
+import json
+import os
+import sys
+import unittest
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import test_chat_pages as P                                   # noqa: E402  the render-floor harness and its kernel load
+
+km, em, jd = P.km, P.em, P.jd
+SID, NOW = P.SID, P.NOW
+
+
+class WarmTheCards(P.Harness):
+    def setUp(self):
+        super().setUp()
+        km._PAGE_STATS.update(warmed=0, warmMs=0.0, warmCycles=0, warmSkipped=0, warmPending=0)   # the warm counters, per test
+        km._PERF_STATS.pusher["cycle_ms_last"] = 20.0
+
+    def _restored(self, turns=200, compact_every=25):
+        """The whole build's events (a cold parse), then the document, then the pusher's floor'd build (its floor set)."""
+        recs = P.transcript(NOW - 86400, turns=turns, compact_every=compact_every)
+        self.write(recs)
+        whole = self.whole()
+        self.document()
+        m = self.restored()
+        self.assertGreater(m["floor"], 0)
+        return whole, m
+
+    @staticmethod
+    def _card(anchors, column="working", done=False, item="n0", summary=None, paras=None):
+        rows = [{"id": "%s-%d" % (item, i), "kind": "ask", "status": "done" if (done and i) else "open", "anchorUuid": u, "promptAnchorUuid": None}
+                for i, u in enumerate(anchors)]
+        return {"itemId": item, "sid": SID, "column": column, "tree": rows, "summaryAnchorUuid": summary, "summaryAnchorsPara": paras}
+
+    def _feed(self, *cards):
+        return {"type": "feed", "asks": list(cards)}
+
+    def _hit(self, uuid):
+        """loadAround on the anchor, asserting the window came from the cache: no render."""
+        misses = km._PAGE_STATS["misses"]
+        r = km._chat_history_reply(SID, {"type": "loadAround", "id": SID, "uuid": uuid}, NOW)
+        self.assertIn(uuid, [e["uuid"] for e in r["events"]])
+        return km._PAGE_STATS["misses"] == misses
+
+    def test_the_summarys_own_targets_are_warmed_first_a_completed_cards_too_and_the_click_hits(self):
+        whole, m = self._restored()
+        deep, para, row = whole[5]["uuid"], whole[60]["uuid"], whole[120]["uuid"]
+        feed = self._feed(self._card([], column="completed", item="c", summary=deep, paras=[{"u": para, "q": "quoted"}, None]),
+                          self._card([row], column="working", item="w"))
+        self.assertEqual(km._card_anchors(feed), [(SID, deep), (SID, para), (SID, row)],
+                         "the completed card's summary line and paragraph targets first, then the active card's row")
+        n = km._warm_history_pages(feed, NOW, {})
+        self.assertGreater(n, 0, "pages rendered for the anchors' windows")
+        st = dict(km._PAGE_STATS)
+        self.assertEqual((st["warmed"], st["warmCycles"], st["warmSkipped"], st["warmPending"]), (n, 1, 0, 0))
+        for u in (deep, para, row):
+            self.assertTrue(self._hit(u), "the click's window came from the cache: no render (%s)" % u)
+        self.assertGreater(km._PAGE_STATS["hits"], 0)
+
+    def test_the_probe_costs_nothing_while_resident_and_warms_again_after_an_eviction(self):
+        whole, m = self._restored()
+        feed = self._feed(self._card([whole[5]["uuid"], whole[60]["uuid"]]))
+        n = km._warm_history_pages(feed, NOW, {})
+        self.assertGreater(n, 0)
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "every page resident: the probe renders nothing")
+        self.assertEqual(km._PAGE_STATS["warmCycles"], 2, "…and the cycle is counted")
+        with km._page_lock:                                           # a reader's scrolling evicted the pages (or a floor flip re-keyed them)
+            km._PAGE_CACHE.clear(); km._PAGE_STATS["pages"] = 0; km._PAGE_STATS["bytes"] = 0
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), n, "the same pages are rendered again")
+        self.assertEqual(km._PAGE_STATS["warmed"], 2 * n)
+        km._RENDER_FLOOR[SID] = m["floor"] - 16                       # a floor move re-keys the pages: warmed again
+        self.assertGreater(km._warm_history_pages(feed, NOW, {}), 0)
+
+    def test_the_render_budget_is_half_the_cache_and_the_rest_waits_a_cycle(self):
+        whole, m = self._restored(turns=600, compact_every=150)
+        floor = m["floor"]
+        turns = km._parse(self.leaf, SID, NOW)["turns"]
+        anchors = []                                                  # one per two pages: disjoint windows of two pages each
+        for p in range(0, floor - 2 * km.PAGE_TURNS, 2 * km.PAGE_TURNS):
+            j = p + km.PAGE_TURNS // 2                                # a turn in the page's second half: its window is [p, p+32)
+            anchors.append(next(a["uuid"] for a in turns[j]["atoms"] if a.get("uuid")))
+        self.assertGreater(2 * len(anchors), km.WARM_PAGES_MAX, "more pages than one cycle's budget")
+        self.assertLessEqual(2 * len(anchors), km._PAGE_CACHE_MAX, "…but they all fit the cache")
+        feed = self._feed(self._card(anchors))
+        n1 = km._warm_history_pages(feed, NOW, {})
+        self.assertEqual(n1, km.WARM_PAGES_MAX, "one cycle renders the budget")
+        self.assertEqual(km._PAGE_STATS["warmPending"], 2 * len(anchors) - km.WARM_PAGES_MAX, "the rest is counted as pending")
+        first, last = anchors[0], anchors[-1]
+        self.assertTrue(self._hit(first), "the FIRST anchor's window is resident: the warm did not evict its own first half")
+        self.assertFalse(self._hit(last), "the last anchor's window waits for the next cycle")
+        n2 = km._warm_history_pages(feed, NOW, {})
+        self.assertEqual(n2, 2 * len(anchors) - km.WARM_PAGES_MAX - 2, "the next cycle renders the rest (the click above rendered one window)")
+        self.assertEqual(km._PAGE_STATS["warmPending"], 0)
+        self.assertTrue(self._hit(first)); self.assertTrue(self._hit(last))
+        self.assertEqual(km.WARM_PAGES_MAX, km._PAGE_CACHE_MAX // 2)
+
+    def test_done_rows_handoffs_completed_rows_and_tail_anchors_are_not_warmed(self):
+        whole, m = self._restored()
+        deep = whole[5]["uuid"]
+        tail_anchor = m["events"][-1]["uuid"]                         # in the resident tail: nothing to warm
+        feed = {"type": "feed", "asks": [
+            {"itemId": "c1", "sid": SID, "column": "completed", "tree": [{"id": "a", "kind": "ask", "status": "done", "anchorUuid": deep}]},
+            {"itemId": "c2", "sid": SID, "column": "working", "tree": [{"id": "b", "kind": "ask", "status": "open", "anchorUuid": tail_anchor},
+                                                                        {"id": "c", "kind": "ask", "status": "done", "anchorUuid": deep},
+                                                                        {"id": "d", "kind": "handoff", "status": "open", "anchorUuid": deep}]}]}
+        self.assertEqual(km._card_anchors(feed), [(SID, tail_anchor)], "a completed card's rows, a done row and a handoff row do not count")
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "a tail anchor is resident already")
+        self.assertEqual(km._warm_history_pages({"type": "feed", "asks": []}, NOW, {}), 0, "no anchors: no cycle")
+        self.assertEqual(km._PAGE_STATS["warmCycles"], 1)
+
+    def test_a_slow_pusher_stands_down_and_the_next_cycle_in_budget_warms(self):
+        whole, m = self._restored()
+        feed = self._feed(self._card([whole[5]["uuid"]]))
+        km._PERF_STATS.pusher["cycle_ms_last"] = 5000.0              # the pusher is behind
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0)
+        self.assertEqual((km._PAGE_STATS["warmSkipped"], km._PAGE_STATS["warmCycles"]), (1, 0), "counted, nothing rendered")
+        km._PERF_STATS.pusher["cycle_ms_last"] = 20.0
+        self.assertGreater(km._warm_history_pages(feed, NOW, {}), 0, "the next cycle in budget warms")
+
+    def test_a_pre_floor_pages_key_survives_a_turn_and_the_render_count_is_the_calls_own(self):
+        """A page rendered from the pre-cut prefix cannot change while a turn streams: its key reads none of the live tail."""
+        whole, m = self._restored()
+        st = {}
+        page = km._chat_history_page(SID, 0, km.PAGE_TURNS, NOW, stats=st)
+        self.assertEqual(st, {"rendered": 1})
+        self.assertEqual(P._strip(page), whole[:len(page)], "the first page is the whole's first slice")
+        km._chat_history_page(SID, 0, km.PAGE_TURNS, NOW, stats=st)
+        self.assertEqual(st, {"rendered": 1}, "a hit is not a render")
+        recs = P.transcript(NOW - 86400, turns=200, compact_every=25)
+        last = next(r for r in reversed(recs) if r.get("uuid"))
+        t_last = em.parse_z(last["timestamp"])
+        more = [P.G.uline(t_last + 60, "one more step", "u_more_1", last["uuid"]),
+                P.G.aline(t_last + 90, "done with the step", "a_more_1", "u_more_1", stop="end_turn")]
+        self.write(recs + more)                                       # a turn streamed: the transcript's stat moved
+        km._live_scope.chat_floor0 = False
+        try:
+            m2 = km.build_session(SID, NOW + 100, {})
+        finally:
+            km._live_scope.chat_floor0 = None
+        self.assertEqual(len(m2["events"]), len(m["events"]) + 2, "the tail grew")
+        misses = km._PAGE_STATS["misses"]
+        self.assertEqual(P._strip(km._chat_history_page(SID, 0, km.PAGE_TURNS, NOW + 100, stats=st)), P._strip(page))
+        self.assertEqual((km._PAGE_STATS["misses"], st["rendered"]), (misses, 1), "the page's key survived the turn: a hit")
+
+    def test_the_window_is_two_aligned_pages_around_the_anchor(self):
+        w = km._window_turns
+        self.assertEqual(w(3, 400), (0, 32), "the head's page and the next")
+        self.assertEqual(w(20, 400), (0, 32), "the first half of a page: the page before it")
+        self.assertEqual(w(24, 400), (16, 48), "the second half: the page after it")
+        self.assertEqual(w(390, 400), (368, 400), "clipped at the floor")
+        self.assertEqual(w(8, 12), (0, 12))
+
+    def test_the_wiring(self):
+        src = open(os.path.join(P.BIN, "romp-kernel")).read()
+        send = src.index('_PERF_STATS.stage("push.send", time.monotonic() - _t_stage)')
+        block = src[send:src.index("def _broadcast_restarting", send)]
+        self.assertIn("_warm_history_pages(_fs, now, tmux)", block, "the pusher warms AFTER its send stage")
+        self.assertIn('if want_feed and _fs and not connect and any(c.get("proto") == 2 for c in chat_clients):', block,
+                      "only with a board client among the targets and a proto-2 chat client connected")
+        self.assertIn('_PERF_STATS.stage("push.warm", time.monotonic() - _t_stage)', block, "its own stage key")
+        self.assertNotIn("_warm_history_pages(feed_src", src, "the hook before the ledgers and the timeline is gone")
+        self.assertIn("lo, hi = _window_turns(j, floor)", src, "loadAround's window is the warm's")
+        self.assertEqual(sorted(k for k in km._PAGE_STATS if k.startswith("warm")), ["warmCycles", "warmMs", "warmPending", "warmSkipped", "warmed"])
+        self.assertEqual(km.WARM_ANCHORS_MAX, 32)
+        self.assertFalse(hasattr(km, "_WARM_MEMO"), "the anchor-set memo is gone: the probe is the memo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chat_pages_warm.py
+++ b/tests/test_chat_pages_warm.py
@@ -176,6 +176,72 @@ class WarmTheCards(P.Harness):
         reg.write_text(json.dumps({"forkedFrom": {"sid": "22222222-3333-4444-5555-666666666666", "uuid": whole[3]["uuid"]}}))
         self.assertNotEqual(km._page_sig(self.rows[0], SID, NOW), k1, "a fork lineage: another key (the branch marker moves)")
 
+    def test_a_cycle_with_no_floor_never_settles_and_the_floors_return_warms(self):
+        """Round 3, A: with an index client connected every tab's floor is 0, so no anchor resolves; the memo must not call the
+        empty set settled, or the floor's return would find the warm asleep and the click miss."""
+        whole, m = self._restored()
+        feed = self._feed(self._card([whole[5]["uuid"], whole[60]["uuid"]]))
+        km._RENDER_FLOOR[SID] = 0                                     # a proto-1 client holds every tab at turn 0
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "nothing to warm below a floor of 0")
+        self.assertEqual(km._WARM_MEMO["anchors"], (), "…and the empty set is not remembered as settled")
+        self.assertEqual(km._PAGE_STATS["warmPending"], 0)
+        km._RENDER_FLOOR[SID] = m["floor"]                            # it left: the floor is back
+        n = km._warm_history_pages(feed, NOW, {})
+        self.assertGreater(n, 0, "the next cycle warms the windows")
+        self.assertTrue(self._hit(whole[5]["uuid"]))
+        # a second session with no row beside a resolved one: the set is unresolved, not settled
+        feed2 = {"type": "feed", "asks": feed["asks"] + [{"itemId": "z", "sid": "99999999-0000-4000-8000-000000000099", "column": "working",
+                                                           "tree": [{"id": "r", "kind": "ask", "status": "open", "anchorUuid": "u-nowhere"}]}]}
+        km._warm_history_pages(feed2, NOW, {})
+        self.assertEqual(km._WARM_MEMO["anchors"], (), "an anchor with no session row leaves the set unresolved")
+
+    def test_the_set_is_bounded_in_bytes_too_and_a_readers_page_beside_it_survives(self):
+        """Round 3, B: the cache evicts on bytes as well as count; a set bounded by count alone re-rendered itself every cycle
+        once its pages passed the byte bound."""
+        whole, m = self._restored(turns=600, compact_every=150)
+        floor = m["floor"]
+        turns = km._parse(self.leaf, SID, NOW)["turns"]
+        anchors = [next(a["uuid"] for a in turns[p + km.PAGE_TURNS // 2]["atoms"] if a.get("uuid"))
+                   for p in range(0, floor - 2 * km.PAGE_TURNS, 2 * km.PAGE_TURNS)]
+        reader = km._chat_history_page(SID, floor - km.PAGE_TURNS, floor, NOW)        # a page the reader scrolled into, beside the set
+        self.assertTrue(reader)
+        with km._page_lock:
+            page_bytes = max(b for _, b in km._PAGE_CACHE.values())
+        saved = km._PAGE_CACHE_BYTES
+        km._PAGE_CACHE_BYTES = page_bytes * 9                        # nine pages of room: the set may take half (four to five)
+        try:
+            feed = self._feed(self._card(anchors))
+            n1 = km._warm_history_pages(feed, NOW, {})
+            self.assertGreater(n1, 0); self.assertLess(n1, km.WARM_PAGES_MAX, "the byte bound closed the set before the page bound")
+            self.assertGreater(km._PAGE_STATS["warmPending"], 0)
+            ev0 = km._PAGE_STATS["evictions"]
+            for _ in range(4):
+                self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "the set settles under the byte bound")
+            self.assertEqual(km._PAGE_STATS["evictions"], ev0, "…and evicts nothing")
+            misses = km._PAGE_STATS["misses"]
+            km._chat_history_page(SID, floor - km.PAGE_TURNS, floor, NOW)
+            self.assertEqual(km._PAGE_STATS["misses"], misses, "the reader's page beside the set survived the warm")
+            self.assertTrue(self._hit(anchors[0]))
+        finally:
+            km._PAGE_CACHE_BYTES = saved
+
+    def test_an_over_budget_pusher_stands_down_before_the_probe(self):
+        """Round 3, C: the stand-down comes first, so a slow pusher pays not even the settled probe; the probe's time is the warm's."""
+        whole, m = self._restored()
+        feed = self._feed(self._card([whole[5]["uuid"]]))
+        self.assertGreater(km._warm_history_pages(feed, NOW, {}), 0)
+        cycles, ms = km._PAGE_STATS["warmCycles"], km._PAGE_STATS["warmMs"]
+        km._PERF_STATS.pusher["cycle_ms_last"] = 5000.0
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0)
+        self.assertEqual((km._PAGE_STATS["warmSkipped"], km._PAGE_STATS["warmCycles"], km._PAGE_STATS["warmMs"]), (1, cycles, ms),
+                         "stood down before the probe: no cycle, no time")
+        km._PERF_STATS.pusher["cycle_ms_last"] = 20.0
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "the remembered set: a probe")
+        self.assertEqual(km._PAGE_STATS["warmCycles"], cycles + 1); self.assertGreater(km._PAGE_STATS["warmMs"], ms, "…counted")
+        src = open(os.path.join(P.BIN, "romp-kernel")).read()
+        fn = src[src.index("def _warm_history_pages("):src.index("def _turn_of_uuid(")]
+        self.assertLess(fn.index("WARM_SKIP_MS:"), fn.index('_WARM_MEMO["anchors"]:'), "the stand-down precedes the probe")
+
     def test_the_window_is_two_aligned_pages_around_the_anchor(self):
         w = km._window_turns
         self.assertEqual(w(3, 400), (0, 32), "the head's page and the next")

--- a/tests/test_chat_pages_warm.py
+++ b/tests/test_chat_pages_warm.py
@@ -23,6 +23,7 @@ class WarmTheCards(P.Harness):
     def setUp(self):
         super().setUp()
         km._PAGE_STATS.update(warmed=0, warmMs=0.0, warmCycles=0, warmSkipped=0, warmPending=0)   # the warm counters, per test
+        km._WARM_MEMO.update(anchors=(), keys=frozenset(), sigs={})
         km._PERF_STATS.pusher["cycle_ms_last"] = 20.0
 
     def _restored(self, turns=200, compact_every=25):
@@ -71,16 +72,23 @@ class WarmTheCards(P.Harness):
         feed = self._feed(self._card([whole[5]["uuid"], whole[60]["uuid"]]))
         n = km._warm_history_pages(feed, NOW, {})
         self.assertGreater(n, 0)
+        self.assertEqual(km._WARM_MEMO["anchors"], tuple(km._card_anchors(feed)), "the set is fully resident: remembered")
+        self.assertEqual(len(km._WARM_MEMO["keys"]), n)
         self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "every page resident: the probe renders nothing")
         self.assertEqual(km._PAGE_STATS["warmCycles"], 2, "…and the cycle is counted")
         with km._page_lock:                                           # a reader's scrolling evicted the pages (or a floor flip re-keyed them)
             km._PAGE_CACHE.clear(); km._PAGE_STATS["pages"] = 0; km._PAGE_STATS["bytes"] = 0
         self.assertEqual(km._warm_history_pages(feed, NOW, {}), n, "the same pages are rendered again")
         self.assertEqual(km._PAGE_STATS["warmed"], 2 * n)
+        with km._page_lock:
+            k0 = next(iter(km._WARM_MEMO["keys"])); km._PAGE_CACHE.pop(k0); km._PAGE_STATS["pages"] -= 1
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 1, "one page evicted: the remembered set is probed and that page alone rendered")
         km._RENDER_FLOOR[SID] = m["floor"] - 16                       # a floor move re-keys the pages: warmed again
         self.assertGreater(km._warm_history_pages(feed, NOW, {}), 0)
 
-    def test_the_render_budget_is_half_the_cache_and_the_rest_waits_a_cycle(self):
+    def test_the_warm_set_is_bounded_to_half_the_cache_and_settles_and_a_board_change_admits_the_rest(self):
+        """The warming review (item 3): an unbounded set over the cache re-rendered itself every cycle for the kernel's life
+        (23 windows: 14 to 16 renders on each of eight cycles, 92 evictions). The SET is bounded: anchors past it wait."""
         whole, m = self._restored(turns=600, compact_every=150)
         floor = m["floor"]
         turns = km._parse(self.leaf, SID, NOW)["turns"]
@@ -88,19 +96,24 @@ class WarmTheCards(P.Harness):
         for p in range(0, floor - 2 * km.PAGE_TURNS, 2 * km.PAGE_TURNS):
             j = p + km.PAGE_TURNS // 2                                # a turn in the page's second half: its window is [p, p+32)
             anchors.append(next(a["uuid"] for a in turns[j]["atoms"] if a.get("uuid")))
-        self.assertGreater(2 * len(anchors), km.WARM_PAGES_MAX, "more pages than one cycle's budget")
-        self.assertLessEqual(2 * len(anchors), km._PAGE_CACHE_MAX, "…but they all fit the cache")
+        self.assertGreater(2 * len(anchors), km.WARM_PAGES_MAX, "more pages than the set's bound")
         feed = self._feed(self._card(anchors))
         n1 = km._warm_history_pages(feed, NOW, {})
-        self.assertEqual(n1, km.WARM_PAGES_MAX, "one cycle renders the budget")
-        self.assertEqual(km._PAGE_STATS["warmPending"], 2 * len(anchors) - km.WARM_PAGES_MAX, "the rest is counted as pending")
-        first, last = anchors[0], anchors[-1]
-        self.assertTrue(self._hit(first), "the FIRST anchor's window is resident: the warm did not evict its own first half")
-        self.assertFalse(self._hit(last), "the last anchor's window waits for the next cycle")
-        n2 = km._warm_history_pages(feed, NOW, {})
-        self.assertEqual(n2, 2 * len(anchors) - km.WARM_PAGES_MAX - 2, "the next cycle renders the rest (the click above rendered one window)")
-        self.assertEqual(km._PAGE_STATS["warmPending"], 0)
-        self.assertTrue(self._hit(first)); self.assertTrue(self._hit(last))
+        admitted = km.WARM_PAGES_MAX // 2                             # windows of two pages each
+        self.assertEqual(n1, km.WARM_PAGES_MAX, "one cycle renders the set's bound")
+        self.assertEqual(km._PAGE_STATS["warmPending"], len(anchors) - admitted, "the anchors past the bound wait")
+        ev0 = km._PAGE_STATS["evictions"]
+        for _ in range(4):                                            # the cycles after: the set settles, nothing re-rendered
+            self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "a bounded set settles: no render")
+        self.assertEqual(km._PAGE_STATS["evictions"], ev0, "…and evicts nothing")
+        self.assertEqual(km._PAGE_STATS["warmCycles"], 5)
+        self.assertTrue(self._hit(anchors[0]), "the first anchor's window stays resident")
+        self.assertFalse(self._hit(anchors[-1]), "the last anchor's waits for a board change")
+        # a board change: the first four cards left; their windows' place admits the next four
+        feed2 = self._feed(self._card(anchors[4:]))
+        n2 = km._warm_history_pages(feed2, NOW, {})
+        self.assertEqual(n2, 2 * 4, "the next four windows admitted and rendered (the click above rendered the LAST anchor's, still waiting)")
+        self.assertEqual(km._PAGE_STATS["warmPending"], len(anchors) - 4 - admitted)
         self.assertEqual(km.WARM_PAGES_MAX, km._PAGE_CACHE_MAX // 2)
 
     def test_done_rows_handoffs_completed_rows_and_tail_anchors_are_not_warmed(self):
@@ -151,6 +164,18 @@ class WarmTheCards(P.Harness):
         self.assertEqual(P._strip(km._chat_history_page(SID, 0, km.PAGE_TURNS, NOW + 100, stats=st)), P._strip(page))
         self.assertEqual((km._PAGE_STATS["misses"], st["rendered"]), (misses, 1), "the page's key survived the turn: a hit")
 
+    def test_a_pages_key_reads_the_regs_fork_value_not_the_file(self):
+        """The warming review (item 2): the queue and echo mirrors rewrite STATE/sdk/<sid>.json on every send, so a key on
+        the file's identity re-keyed every page of the session the user was prompting."""
+        whole, m = self._restored()
+        reg = jd.STATE / "sdk" / (SID + ".json")
+        reg.write_text(json.dumps({"forkedFrom": None, "queue": []}))
+        k1 = km._page_sig(self.rows[0], SID, NOW)
+        reg.write_text(json.dumps({"forkedFrom": None, "queue": [{"text": "a send"}], "echoes": [1]}))   # a send: the mirror rewrote
+        self.assertEqual(km._page_sig(self.rows[0], SID, NOW), k1, "the same fork value: the same key")
+        reg.write_text(json.dumps({"forkedFrom": {"sid": "22222222-3333-4444-5555-666666666666", "uuid": whole[3]["uuid"]}}))
+        self.assertNotEqual(km._page_sig(self.rows[0], SID, NOW), k1, "a fork lineage: another key (the branch marker moves)")
+
     def test_the_window_is_two_aligned_pages_around_the_anchor(self):
         w = km._window_turns
         self.assertEqual(w(3, 400), (0, 32), "the head's page and the next")
@@ -163,15 +188,15 @@ class WarmTheCards(P.Harness):
         src = open(os.path.join(P.BIN, "romp-kernel")).read()
         send = src.index('_PERF_STATS.stage("push.send", time.monotonic() - _t_stage)')
         block = src[send:src.index("def _broadcast_restarting", send)]
-        self.assertIn("_warm_history_pages(_fs, now, tmux)", block, "the pusher warms AFTER its send stage")
-        self.assertIn('if want_feed and _fs and not connect and any(c.get("proto") == 2 for c in chat_clients):', block,
-                      "only with a board client among the targets and a proto-2 chat client connected")
+        self.assertIn("_warm_history_pages(_fs, now, live_map)", block, "the pusher warms AFTER its send stage")
+        self.assertIn('if any(c["app"] in ("feed", "fleet") for c in targets) and _fs and not connect and any(c.get("proto") == 2 for c in chat_clients):', block,
+                      "only with a board client (feed or fleet, never the chat alone) among the targets and a proto-2 chat client connected")
         self.assertIn('_PERF_STATS.stage("push.warm", time.monotonic() - _t_stage)', block, "its own stage key")
         self.assertNotIn("_warm_history_pages(feed_src", src, "the hook before the ledgers and the timeline is gone")
         self.assertIn("lo, hi = _window_turns(j, floor)", src, "loadAround's window is the warm's")
         self.assertEqual(sorted(k for k in km._PAGE_STATS if k.startswith("warm")), ["warmCycles", "warmMs", "warmPending", "warmSkipped", "warmed"])
         self.assertEqual(km.WARM_ANCHORS_MAX, 32)
-        self.assertFalse(hasattr(km, "_WARM_MEMO"), "the anchor-set memo is gone: the probe is the memo")
+        self.assertEqual(sorted(km._WARM_MEMO), ["anchors", "keys", "sigs"], "the remembered resident set: the anchor list, its page keys, the signatures")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A click on a distilled summary far in the past took a long time to load, and the user asked whether the transcript behind the active cards and their summaries could be cached (2026-09-10). The pages cache the proto-2 chat wire added (the render floor's history, rendered a page of turns at a time on demand) is that cache; this change warms it for the anchors the feed's ACTIVE cards point at, so the click lands from the cache in one round trip with no render.

**Design points**
- Derivation, on the pusher's path after its send stage (`push.warm`): the feed's cards contribute first their distilled summary's own click targets (`summaryAnchorUuid`, the summary line, and each `summaryAnchorsPara` paragraph's `u`; a completed card's too, the takeaway far in the past being the click the user named), then, for the cards in every column but `completed`, their head's work and prompt anchors (`anchorUuid`, `promptAnchorUuid`) and their open rows' (a done row and a handoff row pointing at another session's card are not warmed). For each (session, anchor) whose turn lies before the session's render floor, the pusher probes the pages the window `loadAround` would serve (the two page-aligned pages around the anchor, `_window_turns`, the same for the click and the warm so windows share entries) and renders the ones not resident. Only with a board client (feed or fleet) among the targets and a proto-2 chat client connected: index clients hold the whole list and never ask for pages.
- Bound: the feed's first 32 anchors are probed (a late session's summaries can fall past the cap; the board's first cards are the ones read), and the warm SET is bounded to half the cache in pages (16) and in bytes (8 MB): anchors are admitted in the feed's order until the next window would take the set past either bound, and the rest wait for a board change (`warmPending`), so a warm never evicts its own pages nor a reader's and a bounded set settles (the review reproduced an unbounded set over the cache re-rendering itself every cycle for the kernel's life, first by count, then by bytes). Every admitted page is probed under the cache lock and rendered only when not resident; a board whose set is fully resident is remembered (only when the set is non-empty and every anchor resolved: with an index client holding the tabs at floor 0 nothing resolves and the floor's return warms) and costs one probe of those keys, the stand-down for an over-budget pusher coming before even that probe; a page a reader's scrolling evicted, or a floor flip re-keyed, is warmed again; the warm stands down when the pusher's last cycle ran over 1.5 s (`warmSkipped`). A page is about 10 ms and 60 KB on the served fixture. Counted under `/perf` `chatPages`: `warmed` pages (the warm's own renders, not a shared counter's difference), `warmPending`, `warmMs`, `warmCycles`, `warmSkipped`.
- The pages cache's key (`_page_sig`) reads what a pre-floor page render reads and none of the live tail: the leaf path, the render floor and the uuid of the last atom below it (the pre-cut prefix's identity: a rewind or `/clear` reaching below the floor moves one of them), the episodes file, the goal store, the reg's `forkedFrom` value (the reg file itself is rewritten by the queue and echo mirrors on every send, so its identity would re-key every page of the session being prompted), the gone marker, the rewind hold, the pending cut and the components every tab shares. Two accepted limits, stated in the reference: the goal store's identity is a component (the segment anchors come from it), so a warmed page survives the streamed turns until the session's next judge publish; and the postal caption map is not, so a pre-floor page holding a card rendered before its caption landed keeps the caption-less card until an eviction. Before this change a page was keyed on the whole chat-build signature, which moves at turn rate for exactly the working sessions the board shows (the transcript's stat, the live revision, the liveness row), so a warmed page was unreachable by the time of the click. A page rendered from the pre-cut prefix cannot change while a turn streams, and the equivalence proof (pages plus the floor'd list equal the whole) stands.
- Nothing else moves: the wire, the floor, the pages and their equivalence proof are the stage 4b change this stacks on; the SDK files are untouched.

**Tests**: `tests/test_chat_pages_warm.py` over the stage 4b harness: a completed card's summary line and paragraph targets come first and the click's `loadAround` on each is a cache hit with no render; the probe renders nothing while the pages are resident and renders them again after an eviction or a floor move; with more windows than the set's bound the first anchor's window stays resident, the cycles after render nothing and evict nothing, the last anchor waits, and a board change admits the next windows; a reg rewrite with the same fork value keeps a page's key and a fork lineage moves it; a completed card's rows, a done row, a handoff row and a tail anchor are not warmed; a slow pusher stands down, counted; a pre-floor page's key survives a streamed turn (a hit after the transcript grew) and a page counts only its own renders; the window shape; the wiring (after the send stage, the audience gate, the stage key). **Review folds**: the eight items of the manager's first review, the four of the second (the bounded, settling set; the fork value in the key; the caption map stated as not a component; the explicit feed-or-fleet gate) and the three of the third (a set with no floor or an empty set is never remembered as settled; the set is bounded in bytes as well as pages, a reader's page beside it surviving; the stand-down precedes the probe and the probe's time is counted), each pinned above. Rebased onto the wire branch's merge of main.

Stacked on the proto-2 wire's branch (`stack/romp_metrics-t323s4b`): retargeted to main once that lands.

Tier: fix.
