### PR TITLE
The top-of-view day-context label reads the day walk's mark at the top row, not the row's own moment (T342)

### DIFF
--- a/tests/test_day_divider_served.py
+++ b/tests/test_day_divider_served.py
@@ -19,8 +19,11 @@ yesterday's first row) and none above the notice run, whose head wears its lates
 segment is painted on the turns' own line (the same page x) and reaches the neighbouring turns' boxes above and below
 (painted geometry, not the rule text); a divider that leads the transcript (nothing on the rail above it: the first child,
 or the one after the pinned system-context card, which sits off the rail) draws no segment and the turn after it starts
-its rail where a first turn does. The browser's clock is pinned to the epoch the fixture was stamped from, so a run that
-crosses local midnight between the boot and the drive still agrees with itself.
+its rail where a first turn does. The top-of-view day-context label (render.ts paintRailSticky) over `api`'s stale run,
+scrolled to the top line in a short viewport, reads the walk's day, "Yesterday", while the run's head keeps its own HH:MM
+(T342: it used to read the top row's own epoch and said "2 days ago" there). The browser's clock is pinned to the epoch
+the fixture was stamped from, so a run that crosses local midnight between the boot and the drive still agrees with
+itself.
 
 With DD_SHOTS=<dir> the driver writes screenshots (dark and light, the `web` session); DD_BEFORE_DIST=<dist> serves another
 tree's bundle for the before shots and skips the assertions, unless DD_BEFORE_ASSERT=1 keeps them (how the test is proven
@@ -193,6 +196,26 @@ await show(cfg.api, 4);
 out.api.light = await measure();
 await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(300);
 out.api.dark = await measure();
+// the stale run's head at the TOP LINE of a short viewport: the sticky day label names the walk's day there (T342)
+await page.setViewportSize({ width: 1100, height: 330 });   // short enough that the rows after the run out-measure the pane, so the head can reach the top
+await page.evaluate(() => {
+  const h = Array.from(document.querySelectorAll("#content .turn-noticegroup")).find((t) => t.offsetParent !== null);
+  const c = document.getElementById("content");
+  h.scrollIntoView({ block: "start" });
+  c.scrollTop += h.getBoundingClientRect().top - c.getBoundingClientRect().top;   // the head's top exactly at the pane's top, past the pane's own padding
+});
+await page.waitForTimeout(500);
+out.api.sticky = await page.evaluate(() => {
+  const h = Array.from(document.querySelectorAll("#content .turn-noticegroup")).find((t) => t.offsetParent !== null);
+  const content = document.getElementById("content").getBoundingClientRect();
+  const day = document.querySelector(".rail-day"), sticky = document.querySelector(".rail-sticky");
+  const m = h.querySelector(":scope > .time-marker");
+  const vis = (n) => !!n && getComputedStyle(n).display !== "none";
+  const c = document.getElementById("content");
+  return { headTop: h.getBoundingClientRect().top - content.top, pane: [c.scrollTop, c.scrollHeight, c.clientHeight], headMarker: m ? m.textContent : null, headMarkerVisible: !!m && getComputedStyle(m).visibility !== "hidden",
+           headDay: m ? m.dataset.day : null, headEpoch: m ? m.dataset.epoch : null,
+           dayLabel: vis(day) ? day.textContent : null, stickyHm: vis(sticky) ? sticky.textContent : null };
+});
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
 process.exit(0);
@@ -335,6 +358,15 @@ class ServedDayDivider(unittest.TestCase):
             self.assertEqual(m["head"]["t"], str(b_later_t), "the run's head anchors on its latest member, stale as it is")
             self.assertTrue(m["divs"][0]["leads"])
             self._divider_shape(m["divs"][0], m, theme)
+        # T342: the stale run's head scrolled to the top line: the day-context label names the WALK's day there, "Yesterday",
+        # never the run's own "2 days ago"; the rail's HH:MM over it stays the run's own (its stale anchor's clock)
+        st = r["api"]["sticky"]
+        self.assertLessEqual(st["headTop"], 6.5, "the head sits at the top line: %r" % st)
+        self.assertEqual(st["dayLabel"], "Yesterday", "the day label over the stale run is the walk's day, not the run's own 2 days ago: %r" % st)
+        stale_hm = time.strftime("%H:%M", time.localtime(b_later_t))
+        self.assertIn(stale_hm, (st["headMarker"] if st["headMarkerVisible"] else None, st["stickyHm"]), "the HH:MM at the top is the run's own, stale as it is: %r" % st)
+        self.assertEqual(st["headDay"], str(_local_day(1, 9, 5, now) + 60), "the head's marker carries the walk's mark after the run: the row before it, yesterday: %r" % st)
+        self.assertEqual(st["headEpoch"], str(b_later_t), "…beside its own moment")
 
 
 if __name__ == "__main__":

--- a/ui/webview/day-divider.test.ts
+++ b/ui/webview/day-divider.test.ts
@@ -130,7 +130,7 @@ test("every day walk decides against a DayWalk mark and never a raw epoch; windo
   for (const c of calls) assert.match(c, /^dayDividerFor\(\w+, walk\)$/, "each hands the walk, not a number: " + c);
   const ai = RENDER.slice(RENDER.indexOf("function appendItem("), RENDER.indexOf("function renderWindowItems("));
   assert.match(ai, /^function appendItem\(v: View, s: Session, items: DisplayItem\[\], u: number, prevEpoch: number \| null, walk: DayWalk, working: boolean\): number \| null \{/m);
-  assert.match(ai, /walk\.pass\(unitExit\(s, it\)\);\s*\n\s*return prevEpoch;\s*\n\}/, "the unit's exit passes the mark on the way out");
+  assert.match(ai, /walk\.pass\(unitExit\(s, it\)\);\s*\n\s*for \(const n of nodes\) stampWalkDay\(n, walk\);\s*\n\s*return prevEpoch;\s*\n\}/, "the unit's exit passes the mark on the way out, and every node the unit appended is stamped with the walk's day (T342)");
   const rw = RENDER.slice(RENDER.indexOf("function renderWindowItems("), RENDER.indexOf("function sizeSpacers("));
   assert.match(rw, /const walk = dayWalkBefore\(s, items, unitStart\);[^\n]*\n\s*for \(let u = unitStart; u < unitEnd; u\+\+\) prevEpoch = appendItem\(v, s, items, u, prevEpoch, walk, working\);/, "a window seeds the mark by walking the units before it");
   assert.match(RENDER, /function dayWalkBefore\(s: Session, items: DisplayItem\[\], unitStart: number\): DayWalk \{\s*\n\s*const w = new DayWalk\(\);\s*\n\s*for \(let u = 0; u < unitStart && u < items\.length; u\+\+\) w\.pass\(unitExit\(s, items\[u\]\)\);/);
@@ -141,7 +141,7 @@ test("every day walk decides against a DayWalk mark and never a raw epoch; windo
   assert.match(ue, /const open = openFolds\.has\(toolGroupKey\(s\.events\[it\.indices\[0\]\]\)\);\s*\n\s*return eventEpoch\(s\.events\[open \? it\.indices\[it\.indices\.length - 1\] : it\.indices\[0\]\]\);/);
   // the normal-mode tail: the mark seeded over the events before `from`, passed per row; the rail keeps its raw chain
   assert.match(RENDER, /const walk = dayWalkBeforeEvent\(s\.events, from\);[^\n]*\n\s*for \(let i = from; i < len; i\+\+\) \{\s*\n\s*const prev = prevTimedEpoch\(s\.events, i\);/);
-  assert.match(RENDER, /v\.el\.appendChild\(node\);\s*\n\s*walk\.pass\(ep\);\s*\n\s*\}/, "…and passes each row");
+  assert.match(RENDER, /v\.el\.appendChild\(node\);\s*\n\s*walk\.pass\(ep\);\s*\n\s*stampWalkDay\(node, walk\);\s*\n\s*\}/, "…and passes each row, stamping it with the walk's day (T342)");
   // the cleared-episode fold and the comment popover carry their own walk
   assert.match(RENDER, /const walk = new DayWalk\(\);   \/\/ the fold divides days/);
   assert.match(RENDER, /prevEp = ep; walk\.pass\(ep\);/);

--- a/ui/webview/rail-day.test.ts
+++ b/ui/webview/rail-day.test.ts
@@ -117,3 +117,21 @@ test("executed: no label (today) leaves the slot line AT the line — today's la
 test("executed: an anchor below the pane's bottom paints nothing", () => {
   assert.equal(placeDay({ ...G, label: "Yesterday", dayW: 45, slotTop: 701 }).show, false);
 });
+
+// T342 (the manager's review of T339): the day label read the top row's OWN epoch, so a stale echo at the top line (an
+// undelivered notice the kernel merges into the last turn by its send time) said "2 days ago" between rows the divider
+// walk keeps under one "Yesterday". The label now reads the WALK's day at that row: the high-water mark after the row's
+// unit, stamped on the marker as data-day by the walk itself (appendItem, the normal-mode tail loop); the row's own epoch
+// stays the fallback and the rail's HH:MM stays the row's own. DayWalk.pass returning the mark is executed in
+// time-marker.test.ts on the two reported sequences.
+test("the day label reads the walk's day at the top row (data-day), never the row's own moment (T342)", () => {
+  assert.match(RENDER, /const ep = anchorM \? Number\(anchorM\.dataset\.day \|\| anchorM\.dataset\.epoch \|\| 0\) : 0;/, "the walk's day first, the row's own as the fallback");
+  const st = RENDER.slice(RENDER.indexOf("function stampWalkDay("), RENDER.indexOf("function dayWalkBefore("));
+  assert.match(st, /const m = node\.firstChild as HTMLElement \| null;/);
+  assert.match(st, /if \(walk\.mark != null && m && m\.nodeType === 1 && m\.classList && m\.classList\.contains\("time-marker"\)\) m\.dataset\.day = String\(walk\.mark\);/, "the marker carries the mark; a divider or an untimed row is left alone");
+  // stamped by both walks that paint the chat: the unit path after its exit passed, the tail loop after each row
+  assert.match(RENDER, /walk\.pass\(unitExit\(s, it\)\);\s*\n\s*for \(const n of nodes\) stampWalkDay\(n, walk\);/);
+  assert.match(RENDER, /walk\.pass\(ep\);\s*\n\s*stampWalkDay\(node, walk\);/);
+  assert.match(RENDER, /const tag = \(node: HTMLElement\): HTMLElement => \{ node\.dataset\.unit = String\(u\); nodes\.push\(node\); return node; \};/, "every node the unit appends is collected for the stamp");
+  assert.match(RENDER, /m\.dataset\.epoch = String\(epoch\);/, "the row's own moment still rides the marker (deep links, hover, the fallback)");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2668,7 +2668,7 @@ function timeMarker(epoch: number, prevEpoch: number | null): HTMLElement {
   const { text, day, hm } = markerLabel(epoch, prevEpoch, Date.now());
   const m = el("div", "time-marker");
   m.dataset.hm = hm;
-  m.dataset.epoch = String(epoch);   // the top-of-view day-context label reads this (paintRailSticky)
+  m.dataset.epoch = String(epoch);   // the row's own moment; the top-of-view day-context label reads data-day, the walk's mark (stampWalkDay), and falls back to this (paintRailSticky)
   // The gutter shows the TIME and nothing else. The date rides a full-width day divider
   // instead (dayDividerFor below) — no date word has to fit 47px of rail any more.
   if (text) m.textContent = day ? hm : text;
@@ -3022,7 +3022,10 @@ function paintRailSticky(): void {
   // AT the line, so when a
   // label shows, the slot line drops by the label's height to make that room (the 2026-08-17 first
   // cut floated the label above the sticky without shifting it, and bled into the tab bar).
-  const ep = anchorM ? Number(anchorM.dataset.epoch || 0) : 0;
+  // the WALK's day at that row (data-day, stampWalkDay), not the row's own moment (T342): a stale echo at the top line
+  // used to say "2 days ago" between rows the divider walk keeps under one "Yesterday"; the row's own epoch is the
+  // fallback for a marker no walk stamped
+  const ep = anchorM ? Number(anchorM.dataset.day || anchorM.dataset.epoch || 0) : 0;
   const label = ep && gRect ? dayContext(ep, Date.now()) : "";
   let dayW = 0, dayH = 0;
   if (label) {
@@ -10785,6 +10788,7 @@ function syncViewInner(id: string, atBottom?: boolean): View {
     node.dataset.unit = String(i);   // unit === event in normal mode
     v.el.appendChild(node);
     walk.pass(ep);
+    stampWalkDay(node, walk);
   }
   patchWorkedFooters(v, s, from, working);
   v.winEnd = total; v.spacerCount = v.winStart ?? 0; v.spacerCountBot = 0; v.unitTotal = total; v.rendered = len;
@@ -10843,6 +10847,15 @@ function unitExit(s: Session, it: DisplayItem): number | null {
   const open = openFolds.has(toolGroupKey(s.events[it.indices[0]]));
   return eventEpoch(s.events[open ? it.indices[it.indices.length - 1] : it.indices[0]]);
 }
+// The day the WALK is in at a row (T342, the manager's review of T339): the top-of-view day-context label
+// (paintRailSticky) read the top row's own epoch, so a stale echo at the top line said "2 days ago" between rows the
+// divider walk keeps under one "Yesterday". Every turn a walk appends carries the walk's mark after its unit as
+// data-day on its marker; the label reads that, and the rail's HH:MM stays the row's own. A divider or an untimed
+// row has no marker and is left alone.
+function stampWalkDay(node: HTMLElement, walk: DayWalk): void {
+  const m = node.firstChild as HTMLElement | null;
+  if (walk.mark != null && m && m.nodeType === 1 && m.classList && m.classList.contains("time-marker")) m.dataset.day = String(walk.mark);
+}
 // the day walk's high-water mark a walk from the top would hold before unit `unitStart` (compact units) …
 function dayWalkBefore(s: Session, items: DisplayItem[], unitStart: number): DayWalk {
   const w = new DayWalk();
@@ -10894,7 +10907,8 @@ function lastCompactUnit(s: Session, items: DisplayItem[]): number {
 // rule); `walk` is the day walk's high-water mark, advanced over the unit's exit (unitExit) and never rewound (T339).
 function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEpoch: number | null, walk: DayWalk, working: boolean): number | null {
   const it = items[u];
-  const tag = (node: HTMLElement): HTMLElement => { node.dataset.unit = String(u); return node; };
+  const nodes: HTMLElement[] = [];   // every node this unit appends: stamped with the walk's day on the way out (T342)
+  const tag = (node: HTMLElement): HTMLElement => { node.dataset.unit = String(u); nodes.push(node); return node; };
   const adv = (i: number) => { const ep = eventEpoch(s.events[i]); if (ep != null) prevEpoch = ep; };
   // A new day opens with its divider, above whatever unit starts that day (tagged with the same
   // data-unit so the scroll↔unit map still resolves every node it walks). The unit is placed and timed by its ANCHOR
@@ -10942,6 +10956,7 @@ function appendItem(v: View, s: Session, items: DisplayItem[], u: number, prevEp
     adv(it.index);
   }
   walk.pass(unitExit(s, it));
+  for (const n of nodes) stampWalkDay(n, walk);
   return prevEpoch;
 }
 

--- a/ui/webview/time-marker.test.ts
+++ b/ui/webview/time-marker.test.ts
@@ -148,3 +148,21 @@ test("DayWalk: passing an earlier epoch or null leaves the mark; a forward cross
   w.pass(at(2026, 5, 11, 8, 0));
   assert.strictEqual(w.open(at(2026, 5, 12, 8, 0), NOW), "", "today never opens");
 });
+
+// T342: the top-of-view day label names the WALK's day at a row, the mark after passing it, which pass() returns. On the
+// two reported sequences the label over the stale echo reads the surrounding rows' day, never the echo's own.
+test("DayWalk.pass returns the mark after the row: a stale echo sits under the walk's day, never its own", () => {
+  const TOMORROW = new Date(2026, 5, 13, 12, 0, 0).getTime();
+  // rows all yesterday, two echoes two days ago between them (the served lab's `api`), read the next day
+  const w = new DayWalk();
+  const labels = [at(2026, 5, 12, 9, 5), at(2026, 5, 12, 9, 6), at(2026, 5, 11, 9, 40), at(2026, 5, 11, 9, 41), at(2026, 5, 12, 9, 10)]
+    .map((ep) => dayContext(w.pass(ep)!, TOMORROW));
+  assert.deepStrictEqual(labels, ["Yesterday", "Yesterday", "Yesterday", "Yesterday", "Yesterday"], "the echoes read Yesterday, never 2 days ago");
+  assert.deepStrictEqual([dayContext(at(2026, 5, 11, 9, 40), TOMORROW)], ["2 days ago"], "…which their own moment would have said");
+  // today's rows with one echo stamped yesterday among them (the served lab's `web`): today wears no label at all
+  const w2 = new DayWalk();
+  const labels2 = [at(2026, 5, 12, 0, 10), at(2026, 5, 12, 0, 11), at(2026, 5, 11, 9, 47), at(2026, 5, 12, 0, 12)]
+    .map((ep) => dayContext(w2.pass(ep)!, NOW));
+  assert.deepStrictEqual(labels2, ["", "", "", ""], "no day word over today's rows, the stale echo included");
+  assert.strictEqual(new DayWalk().pass(null), null, "nothing passed yet: no mark");
+});

--- a/ui/webview/time-marker.ts
+++ b/ui/webview/time-marker.ts
@@ -71,7 +71,10 @@ export function dayOpens(epoch: number, prevEpoch: number | null, nowMs: number)
 export class DayWalk {
   mark: number | null = null;
   open(epoch: number, nowMs: number): string { return dayOpens(epoch, this.mark, nowMs); }
-  pass(epoch: number | null): void { if (epoch != null && (this.mark == null || epoch > this.mark)) this.mark = epoch; }
+  /** Moves the mark over a row (or a unit's exit) and returns the mark after it: the day the walk is IN at that row,
+   *  which is what the top-of-view day-context label names for it (render.ts stampWalkDay / paintRailSticky, T342);
+   *  a stale row keeps its own HH:MM in the rail but sits under the walk's day, as the dividers already say. */
+  pass(epoch: number | null): number | null { if (epoch != null && (this.mark == null || epoch > this.mark)) this.mark = epoch; return this.mark; }
 }
 
 // (A chooseStamps() spacing pass used to live here: it re-revealed a suppressed same-minute stamp every


### PR DESCRIPTION
The sticky day-context label above the rail's top stamp (`paintRailSticky`) read the top row's **own** epoch. With a stale echo at the top line (an undelivered notice the kernel merges into the last turn by its send time, the shape behind the misplaced day divider), or a collapsed run whose latest member is stale, it said "2 days ago" between rows the divider walk keeps under one "Yesterday": the same inconsistency one line higher (the manager's review of the divider change).

## Shape

The label names the **walk's** day at that row.
- `time-marker.ts DayWalk.pass` returns the mark after the row.
- `render.ts stampWalkDay`: every turn a walk appends carries that mark as `data-day` on its marker. `appendItem` stamps every node its unit appended once the unit's exit has passed; the normal-mode tail loop stamps each row after passing it.
- `paintRailSticky` reads `data-day` and falls back to the row's own `data-epoch` for a marker no walk stamped (the comment popover and the cleared-episode fold have no sticky label).

A stale row keeps its own HH:MM in the rail; only the day word is the walk's, as the dividers already are.

## Tests

- `time-marker.test.ts`: `DayWalk.pass` returns the mark; on the two reported sequences (rows yesterday with two echoes two days ago, read the next day; today's rows with one echo stamped yesterday) the label at every row is the walk's: "Yesterday" throughout, never "2 days ago", and nothing over today.
- `rail-day.test.ts`: the label reads `data-day` first; `stampWalkDay` stamps only a marker, from both walks; the marker keeps `data-epoch`. The walk pins in `day-divider.test.ts` follow.
- `tests/test_day_divider_served.py`: the `api` session's stale run scrolled to the top line of a short viewport: the day label reads "Yesterday", the HH:MM at the top is the run's own, and the head's marker carries the walk's mark (the row before it) beside its own moment. Red before the change ("2 days ago").

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
