### PR TITLE
A stale live echo sits where its send time belongs, never among later rows (T344)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1531,7 +1531,8 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   live roots, keyed on the parsed transcript's identity, the store's
   identity and seams, `cleared.jsonl`'s identity and the warm-anchor table's
   per-session revision: `hit` and `miss`, `bypass_live` (a build that merged
-  live atoms: the last turn's segments differ from the parse's),
+  live atoms: the last turn's segments differ from the parse's, and since
+  T344 a stale echo may sit in an earlier turn or a turn of its own),
   `bypass_hold` (an armed rewind hold filters a store copy per build),
   `bypass_empty` (a store with no nodes), `evict` (entries dropped for tabs
   no longer shown) and the gauge `entries`. `chatFoldTasks` is the per-turn

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -962,8 +962,8 @@ def _last_plain_user_turn_t(turns):
         trig = turn.get("trigger") or {}
         tuid = trig.get("uuid") if isinstance(trig, dict) else trig
         a = next((x for x in atoms if x.get("uuid") == tuid), None) or (atoms[0] if atoms else None)
-        if not a or a.get("author") != "human":
-            continue
+        if not a or a.get("author") != "human" or a.get("_echo_text") or turn.get("echoTurn"):
+            continue    # an echo (a send the transcript never took; since T344 placed by time) is never a prompt turn
         if "romp-goal-id" in (_atom_user_text(a) or ""):   # a nudge / typed card-reply → targeted, not a plain reply
             continue
         best = max(best, a.get("t") or turn.get("t") or 0)
@@ -31201,6 +31201,15 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     # stamped after the last turn's start and takes the tail below, as before.
     last_start = turns[-1].get("t") or 0
     stale = [a for a in fresh if a.get("_echo_text") and a.get("t", 0) < last_start]
+    if stale:
+        # Only a send NOBODY still owes is stale: a held copy (T306) keeps its send stamp while the queue
+        # behind it feeds, so on release it is older than the last turn's start yet still a pending
+        # message, and it must ride the tail until it lands. Owed = queued behind a busy turn
+        # (`shown_texts`, the backend's pending_queued) or listed by the CLI's own queue ledger
+        # (_pending_ledger, the settle's "still owed" read); read only when a candidate exists.
+        p = _path_of(sid)
+        owed = {sb.echo_text_key(t) for t in shown_texts if t} | {sb.echo_text_key(t) for t in (_pending_ledger(p) if p else ())}
+        stale = [a for a in stale if not _echo_landed_in(a["_echo_text"], owed)]
     placed = ()
     if stale:
         turns = _place_stale_echoes(turns, stale)
@@ -31246,13 +31255,28 @@ def _place_stale_echoes(turns, echoes):
         if i is not None and t <= (out[i].get("end") or out[i].get("t") or 0):
             out[i] = dict(out[i])
             out[i]["atoms"] = sorted(list(out[i]["atoms"]) + [a], key=key)
+            out[i]["placedEchoes"] = list(out[i].get("placedEchoes") or []) + [a.get("uuid")]
         else:
             gaps.setdefault(0 if i is None else i + 1, []).append(a)
     for idx in sorted(gaps, reverse=True):      # back to front, so earlier indices stay valid
         atoms = sorted(gaps[idx], key=key)
         out.insert(idx, {"id": "live-" + str(atoms[0].get("uuid") or atoms[0].get("t", 0)), "trigger": None,
-                         "t": atoms[0].get("t", 0), "end": atoms[-1].get("t", 0), "ended": True, "atoms": atoms})
+                         "t": atoms[0].get("t", 0), "end": atoms[-1].get("t", 0), "ended": True, "atoms": atoms,
+                         "echoTurn": True, "placedEchoes": [a.get("uuid") for a in atoms]})
     return out
+
+
+def _turn_sans_placed_echoes(turn):
+    """The turn without the stale echoes _place_stale_echoes put into it (`placedEchoes`), for the
+    segmenters: a judged turn's segments and their ids must mirror the judge's own parse, which never
+    sees an echo, so a placed echo (a user atom, hence a segment input) must not split the turn's bar or
+    re-key its captions. A turn with nothing placed is returned as is; the tail's live echoes are not
+    placed and keep splitting the last turn as before."""
+    placed = turn.get("placedEchoes")
+    if not placed:
+        return turn
+    placed = set(placed)
+    return {**turn, "atoms": [a for a in turn.get("atoms") or [] if a.get("uuid") not in placed]}
 
 
 def _sdk_transcript_path(sid):
@@ -32607,7 +32631,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
     # ── the ledger memo (2026-09-09): the tree walk and the live roots below are a function of exactly these
     # inputs, each in the key or held by identity: the parse (seg_trig and seg_work come from it; by the parsed
     # object's identity, and only while no live atoms were merged, since the merge reshapes the last turn's
-    # segments); the store's seams (_seams_sig, from the store this build's seg maps were cut with: the
+    # segments and, since T344, places a stale echo into an earlier turn); the store's seams (_seams_sig, from the store this build's seg maps were cut with: the
     # build loads the store twice, once at the top for the seg ids and once here for the nodes, and a
     # publish landing between the two loads pairs the old seams' seg maps with the new store object, so
     # the seams stay a key component beside the store's identity or that build's tree would serve next
@@ -33042,7 +33066,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
             # every other pane, whose payloads dedup correctly, stayed instant.) The spawn time is
             # persisted and fixed; None when genuinely unknown, which the client tolerates — render.ts
             # keeps what it already had (`msg.firstSeen ?? prev.firstSeen`).
-            "firstSeen": session["turns"][0]["t"] if session["turns"] else _sdk_spawned_at(sid)}
+            "firstSeen": next((_t["t"] for _t in session["turns"] if not _t.get("echoTurn")), None) or _sdk_spawned_at(sid)}
 
 
 EPISODE_EVENT_CAP = 200   # events shipped per pre-clear episode expand — bounded, honest about the cut
@@ -37137,7 +37161,7 @@ def _segs_seam(turn, store):
     """Seam-aware segmentation — MUST mirror the judge's jd._segs (plans/segment-regrowth.md): seg ids
     the judges place/anchor against a settle-split have to be the same ids the kernel renders/resolves,
     or trails and deep-links written for a tail would silently stop matching."""
-    return jd.apply_seams(em.segments(turn), store or {})
+    return jd.apply_seams(em.segments(_turn_sans_placed_echoes(turn)), store or {})
 
 
 def _atom_prose_chars(a):
@@ -37906,6 +37930,8 @@ def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None):
     st_turns = session["turns"]
     bars, last_t, seg_ends, nsegs, complained = [], None, {}, 0, False   # seg_ends: seg-start t → work-END t (for completion marks)
     for ti, turn in enumerate(st_turns):
+        if turn.get("echoTurn"):
+            continue        # a stale echo's own turn (T344): a send the transcript never took draws no bar
         turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
                      and not any(x["type"] == "idle" for x in turn["atoms"])
                      and not _suspended_after(turn["end"]))   # dead lane (live False) or pre-sleep freeze → not an open bar
@@ -37917,7 +37943,7 @@ def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None):
             _bars_complain(sid, "seams", e)
             complained = True
             try:
-                segs = em.segments(turn)
+                segs = em.segments(_turn_sans_placed_echoes(turn))
             except Exception:
                 segs = []
         for si, seg in enumerate(segs):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31216,14 +31216,12 @@ def _merge_live_atoms(session, sid, shown_texts=()):
         stale = [a for a in stale if not _echo_landed_in(a["_echo_text"], owed)]
     placed = ()
     if stale:
-        turns = _place_stale_echoes(turns, stale)
+        # `placed` is what the chat fold keys its sealed prefix on (build_session, the "echo" refold): a placed
+        # echo sits in a turn the fold seals, and its state moves without a parse change (dismissed, flagged
+        # dropped, landed), so the fold compares this tuple build to build instead of re-reading the turns.
+        turns, placed = _place_stale_echoes(turns, stale)
         stale_ids = {id(a) for a in stale}
         fresh = [a for a in fresh if id(a) not in stale_ids]
-        # What the chat fold keys its sealed prefix on (build_session, the "echo" refold): a placed echo
-        # sits in a turn the fold seals, and its state moves without a parse change (dismissed, flagged
-        # dropped, landed), so the fold compares this tuple build to build instead of re-reading the turns.
-        placed = tuple((i, a.get("uuid"), bool(a.get("dropped")))
-                       for i, turn in enumerate(turns) for a in turn["atoms"] if id(a) in stale_ids)
     if fresh:
         turns[-1] = dict(turns[-1])
         # An in-flight input ECHO — the kernel's copy of a send the model has not read yet — sorts AFTER every atom the
@@ -31249,17 +31247,29 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     return {**session, "turns": turns, "_placed": placed}
 
 
+def _turn_activity_end(turn):
+    """When the turn's RECORDED activity ended: the latest non-idle atom's time. Never the turn's `end`: a
+    finished SDK turn carries a synthesized idle atom (event_model.synthesize_idle) whose end is the NEXT
+    state row, and _finalize_turn takes the max end, so a turn that ended at 22:01 reads as ending when the
+    next turn began. A window decided on that would swallow every notice sent while the session sat idle."""
+    return max((a.get("t") or 0 for a in turn.get("atoms") or [] if a.get("type") != "idle"),
+               default=turn.get("t") or 0)
+
+
 def _place_stale_echoes(turns, echoes):
     """Place echo atoms stamped before the last turn's start where their send time belongs (T344). Each echo
-    joins the turn whose window [t, end] holds it; an echo that falls in the gap between two turns, or before
-    the first, goes into a closed synthetic turn at that place (trigger None, like the turn a transcript-less
-    session gets), one turn per gap holding every echo sent in it, sorted, so two notices sent together stay
-    a run. The synthetic turn's id derives from its first echo's uuid, so the same echo yields the same turn
-    build after build. Returns a new turns list; the caller's turn dicts are copied before a write (the parse
-    cache is never mutated)."""
+    joins the turn whose ACTIVITY window holds it, [turn.t, _turn_activity_end(turn)]; an echo that falls in
+    the gap between two turns' activity, or before the first, goes into a closed synthetic turn at that place
+    (trigger None, like the turn a transcript-less session gets), one turn per gap holding every echo sent in
+    it, sorted, so two notices sent together stay a run. The synthetic turn's id derives from its first echo's
+    uuid, so the same echo yields the same turn build after build. Returns (turns, placed): a new turns list
+    (the caller's turn dicts are copied before a write; the parse cache is never mutated) and the fold's key,
+    a tuple of (destination turn index, uuid, dropped) per echo, read off the destinations rather than by a
+    scan of every atom (three merges per push cycle while a dropped echo exists)."""
     out = list(turns)
     key = lambda a: (a.get("t", 0), a.get("_seq", 0))
     gaps = {}                                   # insertion index in `turns` → the echoes sent in that gap
+    dest = []                                   # (the destination turn dict, echo) per echo, resolved to indexes below
     for a in sorted(echoes, key=key):
         t = a.get("t", 0)
         i = None                                # the last turn starting at or before the echo
@@ -31268,18 +31278,23 @@ def _place_stale_echoes(turns, echoes):
                 i = k
             else:
                 break
-        if i is not None and t <= (out[i].get("end") or out[i].get("t") or 0):
+        if i is not None and t <= _turn_activity_end(out[i]):
             out[i] = dict(out[i])
             out[i]["atoms"] = sorted(list(out[i]["atoms"]) + [a], key=key)
             out[i]["placedEchoes"] = list(out[i].get("placedEchoes") or []) + [a.get("uuid")]
+            dest.append((out[i], a))
         else:
             gaps.setdefault(0 if i is None else i + 1, []).append(a)
     for idx in sorted(gaps, reverse=True):      # back to front, so earlier indices stay valid
         atoms = sorted(gaps[idx], key=key)
-        out.insert(idx, {"id": "live-" + str(atoms[0].get("uuid") or atoms[0].get("t", 0)), "trigger": None,
-                         "t": atoms[0].get("t", 0), "end": atoms[-1].get("t", 0), "ended": True, "atoms": atoms,
-                         "echoTurn": True, "placedEchoes": [a.get("uuid") for a in atoms]})
-    return out
+        turn = {"id": "live-" + str(atoms[0].get("uuid") or atoms[0].get("t", 0)), "trigger": None,
+                "t": atoms[0].get("t", 0), "end": atoms[-1].get("t", 0), "ended": True, "atoms": atoms,
+                "echoTurn": True, "placedEchoes": [a.get("uuid") for a in atoms]}
+        out.insert(idx, turn)
+        dest.extend((turn, a) for a in atoms)
+    index_of = {id(turn): k for k, turn in enumerate(out)}
+    placed = tuple(sorted((index_of[id(turn)], a.get("uuid"), bool(a.get("dropped"))) for turn, a in dest))
+    return out, placed
 
 
 def _turn_sans_placed_echoes(turn):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31189,16 +31189,62 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     if not turns:
         turns = [{"id": "live", "trigger": None, "t": fresh[0]["t"], "end": fresh[-1]["t"],
                   "ended": not live_work, "atoms": []}]
-    turns[-1] = dict(turns[-1])
-    turns[-1]["atoms"] = sorted(list(turns[-1]["atoms"]) + fresh, key=lambda a: (a.get("t", 0), a.get("_seq", 0)))
-    # Extend the turn's window over the appended tail (the user 2026-07-02): segments() spans [turn.t,
-    # turn.end], so a live atom past the disk turn's end (a /model invocation minutes after the last work)
-    # otherwise falls OUTSIDE every segment — its timeline dot then appeared only retroactively, once the
-    # disk write moved the real end past it.
-    turns[-1]["end"] = max(turns[-1].get("end") or 0, max(a.get("t", 0) for a in fresh))
-    if live_work:
-        turns[-1]["ended"] = False
+    # A STALE echo is placed by its send time, never among later rows (T344, the user 2026-09-11, who saw
+    # a 10:28 PM row between 7:05 AM rows): an echo stamped before the last turn's start is a send the
+    # transcript has moved past (a romp notice that never landed, reseeded at boot from the registry's
+    # echoes), and appended to the last turn it sat among today's rows wearing yesterday's clock, which
+    # the chat's day walk read as a day boundary. _place_stale_echoes puts each such echo into the turn
+    # whose window holds it, or into a closed turn of its own in the gap where it was sent, so the rows
+    # the chat reads are in time order and the day walk needs no special case. A pending send is always
+    # stamped after the last turn's start and takes the tail below, as before.
+    last_start = turns[-1].get("t") or 0
+    stale = [a for a in fresh if a.get("_echo_text") and a.get("t", 0) < last_start]
+    if stale:
+        turns = _place_stale_echoes(turns, stale)
+        stale_ids = {id(a) for a in stale}
+        fresh = [a for a in fresh if id(a) not in stale_ids]
+    if fresh:
+        turns[-1] = dict(turns[-1])
+        turns[-1]["atoms"] = sorted(list(turns[-1]["atoms"]) + fresh, key=lambda a: (a.get("t", 0), a.get("_seq", 0)))
+        # Extend the turn's window over the appended tail (the user 2026-07-02): segments() spans [turn.t,
+        # turn.end], so a live atom past the disk turn's end (a /model invocation minutes after the last work)
+        # otherwise falls OUTSIDE every segment — its timeline dot then appeared only retroactively, once the
+        # disk write moved the real end past it.
+        turns[-1]["end"] = max(turns[-1].get("end") or 0, max(a.get("t", 0) for a in fresh))
+        if live_work:
+            turns[-1]["ended"] = False
     return {**session, "turns": turns}
+
+
+def _place_stale_echoes(turns, echoes):
+    """Place echo atoms stamped before the last turn's start where their send time belongs (T344). Each echo
+    joins the turn whose window [t, end] holds it; an echo that falls in the gap between two turns, or before
+    the first, goes into a closed synthetic turn at that place (trigger None, like the turn a transcript-less
+    session gets), one turn per gap holding every echo sent in it, sorted, so two notices sent together stay
+    a run. The synthetic turn's id derives from its first echo's uuid, so the same echo yields the same turn
+    build after build. Returns a new turns list; the caller's turn dicts are copied before a write (the parse
+    cache is never mutated)."""
+    out = list(turns)
+    key = lambda a: (a.get("t", 0), a.get("_seq", 0))
+    gaps = {}                                   # insertion index in `turns` → the echoes sent in that gap
+    for a in sorted(echoes, key=key):
+        t = a.get("t", 0)
+        i = None                                # the last turn starting at or before the echo
+        for k, turn in enumerate(out):
+            if (turn.get("t") or 0) <= t:
+                i = k
+            else:
+                break
+        if i is not None and t <= (out[i].get("end") or out[i].get("t") or 0):
+            out[i] = dict(out[i])
+            out[i]["atoms"] = sorted(list(out[i]["atoms"]) + [a], key=key)
+        else:
+            gaps.setdefault(0 if i is None else i + 1, []).append(a)
+    for idx in sorted(gaps, reverse=True):      # back to front, so earlier indices stay valid
+        atoms = sorted(gaps[idx], key=key)
+        out.insert(idx, {"id": "live-" + str(atoms[0].get("uuid") or atoms[0].get("t", 0)), "trigger": None,
+                         "t": atoms[0].get("t", 0), "end": atoms[-1].get("t", 0), "ended": True, "atoms": atoms})
+    return out
 
 
 def _sdk_transcript_path(sid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31115,7 +31115,9 @@ def _merge_tx_sets(session, sid):
 def _merge_live_atoms(session, sid, shown_texts=()):
     """Merge in-memory LIVE-TAIL atoms into the parsed session, AHEAD of the transcript on disk, so messages
     appear instantly (the stream / a composer send leads the disk write). NON-MUTATING — `session` is the
-    _parse cache, so this returns a shallow copy with the last turn's atoms extended. The source is the
+    _parse cache, so this returns a shallow copy: the last turn's atoms extended by the fresh tail, and a
+    STALE echo placed by its send time into an earlier turn or a synthetic turn of its own (T344, the
+    placement comment below; the copy carries `_placed`, the fold's key for those). The source is the
     owning backend's live tail (the SDK backend's _live: stream + its own input echo; the Codex backend's
     list). Dedup: drop any live atom the transcript already has, by uuid (stream
     messages: SDK uuid == transcript uuid) or by text (an optimistic input echo carries a synthetic uuid).
@@ -31199,10 +31201,16 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     # stamped after the last turn's start and takes the tail below, as before.
     last_start = turns[-1].get("t") or 0
     stale = [a for a in fresh if a.get("_echo_text") and a.get("t", 0) < last_start]
+    placed = ()
     if stale:
         turns = _place_stale_echoes(turns, stale)
         stale_ids = {id(a) for a in stale}
         fresh = [a for a in fresh if id(a) not in stale_ids]
+        # What the chat fold keys its sealed prefix on (build_session, the "echo" refold): a placed echo
+        # sits in a turn the fold seals, and its state moves without a parse change (dismissed, flagged
+        # dropped, landed), so the fold compares this tuple build to build instead of re-reading the turns.
+        placed = tuple((i, a.get("uuid"), bool(a.get("dropped")))
+                       for i, turn in enumerate(turns) for a in turn["atoms"] if id(a) in stale_ids)
     if fresh:
         turns[-1] = dict(turns[-1])
         turns[-1]["atoms"] = sorted(list(turns[-1]["atoms"]) + fresh, key=lambda a: (a.get("t", 0), a.get("_seq", 0)))
@@ -31213,7 +31221,7 @@ def _merge_live_atoms(session, sid, shown_texts=()):
         turns[-1]["end"] = max(turns[-1].get("end") or 0, max(a.get("t", 0) for a in fresh))
         if live_work:
             turns[-1]["ended"] = False
-    return {**session, "turns": turns}
+    return {**session, "turns": turns, "_placed": placed}
 
 
 def _place_stale_echoes(turns, echoes):
@@ -31669,6 +31677,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
     # last turn is never cached (live atoms, overlays). Every gate names the exact input whose change
     # could render an earlier turn differently, and demotes to _fk = 0 when it moved.
     _turns = session["turns"]
+    _placed = tuple(session.get("_placed") or ())    # stale echoes placed into sealable turns (T344): the fold's "echo" key
     _n_pref = len(_turns) - 1                 # candidate prefix: every turn but the last
     _fk, _fe, _fold_ok, _fold_why = 0, None, False, None
     _pref_len = 0
@@ -31704,6 +31713,8 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                 _fold_why = "turnfp"                  # an earlier turn's atoms moved (a states-row atom, a heal)
             elif _fe["seams"] != _seams_sig:
                 _fold_why = "seam"                    # seg ids → tlId / deep-link anchors of old events
+            elif _fe.get("placed", ()) != _placed:
+                _fold_why = "echo"                    # a stale echo placed into the prefix was dismissed, flagged or landed (T344)
             elif _fe["floor"] != (_note_floor, len(_epi_rows_for_notes)):
                 _fold_why = "episode"                 # a /clear moved the durable-note floor
             elif _fe["notes"] != tuple(tuple(tuple(sorted(_x.items())) for _x in _lst
@@ -32319,7 +32330,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                     "fps": [_chat_turn_fp(_turns[_i]) for _i in range(_np)],
                     "events": events[:_b],
                     "seg": tuple(_seg_pref), "cursors": _cur, "last_t": _lt, "last_model": _lm,
-                    "disk_texts": _dt, "seams": _seams_sig,
+                    "disk_texts": _dt, "seams": _seams_sig, "placed": _placed,
                     "floor": (_note_floor, len(_epi_rows_for_notes)),
                     "notes": (tuple(tuple(sorted(_x.items())) for _x in recoveries[:_cur[0]]),
                               tuple(tuple(sorted(_x.items())) for _x in gaveups[:_cur[1]]),

--- a/tests/test_chat_fold.py
+++ b/tests/test_chat_fold.py
@@ -995,6 +995,27 @@ class PlacedEchoes(Gates):
         self.assertEqual(km._chat_fold_get(SID)["placed"], ((0, self.ECHO, True),))
         self.assert_folding()                           # and folds again once the state is sealed anew
 
+    def test_a_placed_echo_that_lands_refolds_and_leaves_the_prefix(self):
+        # the third exit the fold's docstring names: the echo's TEXT lands in the transcript (a record carrying
+        # it), the display dedup drops the echo from the merge, `placed` empties, the sealed copy must go
+        self.grow(3)
+        t_first = self.s.now - 3 * 86400 + 6
+        self.be.live.append(self._echo(t_first))
+        self.equiv("stale echo placed")
+        self.assert_folding()
+        s = self.s
+        u = s.uid(); s.append([uline(s.tick(), self.NOTICE, u, s.last)])   # the notice lands as a user record
+        # The landing is a parse change too, and the sealed turn's fingerprint moves with the echo's departure
+        # (one atom fewer), so the gate chain demotes on "turnfp" before it reaches "echo"; either way the
+        # build refolds, and `placed` records the emptiness. What matters is that no ghost survives.
+        n_fp, n_echo = km._CHAT_FOLD_STATS.get("g:turnfp", 0), km._CHAT_FOLD_STATS.get("g:echo", 0)
+        inc = self.equiv("the placed echo landed")
+        self.assertTrue(km._CHAT_FOLD_STATS.get("g:turnfp", 0) > n_fp or km._CHAT_FOLD_STATS.get("g:echo", 0) > n_echo,
+                        "the landing refolds: the turn fingerprint moved with the echo's departure, or the echo gate fired")
+        self.assertNotIn(self.ECHO, self._sealed_uuids(), "the landed echo's sealed copy is gone")
+        self.assertNotIn(self.ECHO, [ev.get("uuid") for ev in inc["events"]], "…and the payload shows the record, not the echo")
+        self.assertEqual(km._chat_fold_get(SID)["placed"], ())
+
     def test_a_fresh_echo_in_the_last_turn_never_touches_the_fold(self):
         self.grow(3)
         self.assert_folding()

--- a/tests/test_chat_fold.py
+++ b/tests/test_chat_fold.py
@@ -923,5 +923,87 @@ class Wiring(unittest.TestCase):
         self.assertIn('fold=_chat_fold_last_info().get("fold", 0)', src)
 
 
+class PlacedEchoes(Gates):
+    """A STALE live echo placed into a sealed turn (T344: an echo stamped before the last turn's start sits
+    where its send time belongs) changes state without a parse change: dismissed (dismissEcho pops it from
+    the live tail), flagged dropped, or landed. The fold keys its sealed prefix on the merge's `_placed`
+    report and refolds ("echo") on a change, so the sealed events never hold a ghost of a dismissed echo
+    or a stale copy of its flag; the equivalence with a full build holds through every step."""
+
+    ECHO = "echo:" + "d" * 32
+    NOTICE = "[romp] The condition you asked romp to watch now HOLDS: the notes-api search suite has its verdict."
+
+    class _Backend(km._UnownedBackend):
+        """The owning backend as the chat build reads it: a live tail this test edits, a prune that retires nothing."""
+
+        def __init__(self):
+            self.live = []
+
+        def owns(self, sid):
+            return True
+
+        def live_atoms(self, sid):
+            return sorted(self.live, key=lambda a: a.get("t", 0))
+
+        def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
+            return None
+
+    def setUp(self):
+        super().setUp()
+        self.be = self._Backend()
+        self._saved_bf = km.Sessions.backend_for
+        km.Sessions.backend_for = staticmethod(lambda sid: self.be)
+
+    def tearDown(self):
+        km.Sessions.backend_for = self._saved_bf
+        super().tearDown()
+
+    def _echo(self, t, **extra):
+        a = {"type": "user", "uuid": self.ECHO, "session_id": SID, "t": t, "parentUuid": None, "author": "romp",
+             "_echo_text": self.NOTICE, "message": {"role": "user", "content": [{"type": "text", "text": self.NOTICE}]}}
+        a.update(extra)
+        return a
+
+    def _sealed_uuids(self):
+        return [ev.get("uuid") for ev in km._chat_fold_get(SID)["events"]]
+
+    def test_a_placed_echo_is_sealed_and_its_dismissal_refolds(self):
+        self.grow(3)
+        t_first = self.s.now - 3 * 86400 + 6           # inside the FIRST turn's window: placed there, sealed with it
+        self.be.live.append(self._echo(t_first))
+        self.equiv("stale echo placed into a sealed turn")
+        e = km._chat_fold_get(SID)
+        self.assertIn(self.ECHO, self._sealed_uuids(), "the placed echo's event is part of the sealed prefix")
+        self.assertEqual(e["placed"], ((0, self.ECHO, False),), "…and the entry records its placement and state")
+        self.assert_folding()
+        self.be.live.clear()                            # dismissEcho: the live tail no longer holds it
+        inc = self._demotes("echo", "the placed echo dismissed")
+        self.assertNotIn(self.ECHO, self._sealed_uuids(), "the refold dropped the ghost from the sealed prefix")
+        self.assertNotIn(self.ECHO, [ev.get("uuid") for ev in inc["events"]], "…and from the payload")
+        self.assertEqual(km._chat_fold_get(SID)["placed"], ())
+
+    def test_a_placed_echo_flagged_dropped_refolds_and_the_sealed_copy_reads_dropped(self):
+        self.grow(3)
+        t_first = self.s.now - 3 * 86400 + 6
+        self.be.live.append(self._echo(t_first))
+        self.equiv("stale echo placed")
+        self.assert_folding()
+        self.be.live[0]["dropped"] = True                # _mark_dropped_echoes / settle_echoes flagged it
+        inc = self._demotes("echo", "the placed echo flagged dropped")
+        ev = next(x for x in inc["events"] if x.get("uuid") == self.ECHO)
+        self.assertTrue(ev.get("undelivered"), "the payload reads the flag (`undelivered`): %r" % {k: ev[k] for k in ev if k != "md"})
+        self.assertEqual(km._chat_fold_get(SID)["placed"], ((0, self.ECHO, True),))
+        self.assert_folding()                           # and folds again once the state is sealed anew
+
+    def test_a_fresh_echo_in_the_last_turn_never_touches_the_fold(self):
+        self.grow(3)
+        self.assert_folding()
+        self.be.live.append(self._echo(self.s.t + 1))    # after the last turn's start: the tail, as before
+        f0 = km._CHAT_FOLD_STATS["fold"]
+        inc = self.equiv("fresh echo in the tail")
+        self.assertIn(self.ECHO, [ev.get("uuid") for ev in inc["events"]])
+        self.assertGreater(km._CHAT_FOLD_STATS["fold"], f0, "a tail echo folds like any live tail")
+        self.assertEqual(km._chat_fold_get(SID)["placed"], ())
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_day_divider_served.py
+++ b/tests/test_day_divider_served.py
@@ -2,32 +2,41 @@
 """T339 (the user 2026-09-11, screenshot): the chat's day divider. Three faults on the real /chat page of a hermetic kernel:
 (1) the rail's vertical line broke above and below the divider; (2) the date sat at the prose edge with the hairline to its
 right alone; (3) a collapsed run of notices whose FIRST member carried yesterday's time among today's rows drew a
-"Yesterday" divider inside today and wore yesterday's clock. The producer, from the kernel's code: a session's LIVE echo
+"Yesterday" divider inside today and wore yesterday's clock. The producer of (3), history now: a session's LIVE echo
 atoms (the kernel's own copies of sent messages, kept until the transcript lands their text; persisted in the registry's
-`echoes` mirror and reseeded at boot) are merged into the chat's LAST turn sorted by their own SEND time (kernel.py, the
-live-atom merge), so a romp notice sent yesterday whose text never landed sits right after the previous turn's rows, among
-today's, stamped yesterday; two such echoes fold into one notice run timed by its first.
+`echoes` mirror and reseeded at boot) were merged into the chat's LAST turn sorted by their own SEND time (kernel.py, the
+live-atom merge), so a romp notice sent yesterday whose text never landed sat right after the previous turn's rows, among
+today's, stamped yesterday, and two such echoes folded into one notice run timed by its first. T339 closed the walk's side
+(a forward-only crossing against a high-water mark, time-marker.ts DayWalk); T344 closed the producer (2026-09-11): an
+echo stamped before the last turn's start is placed by its send time, into the turn whose window holds it or into a
+closed turn of its own in the gap where it was sent (one per gap, so echoes sent together stay a run), and only an echo at
+or after the last turn's start still takes the tail. So the rows the chat reads are in time order and the walk needs no
+special case; this lab reads that order off the served page.
 
 Two synthetic sessions on one kernel. `web`: rows two days ago, yesterday and today (two turns), the registry mirroring two
-echoes of romp notices, the first sent yesterday, the second today between the two turns. `api`: the same shape read a day
-later, rows all yesterday and both echoes two days ago (a run whose latest member is itself stale): against the previous
-row alone the stale run drew no divider but became the reference, and the next in-sequence row crossed "forward" into a
-day already open, a second "Yesterday" mid-day (the review's finding; time-marker.ts DayWalk is the high-water mark that
-closes it). Asserted, dark and light: `web` shows two dividers only (the weekday over two days ago, "Yesterday" over
-yesterday's first row) and none above the notice run, whose head wears its latest member's time; `api` shows exactly one
-"Yesterday"; each divider's label is centered in the column between two hairlines of equal width; the divider's rail
-segment is painted on the turns' own line (the same page x) and reaches the neighbouring turns' boxes above and below
-(painted geometry, not the rule text); a divider that leads the transcript (nothing on the rail above it: the first child,
-or the one after the pinned system-context card, which sits off the rail) draws no segment and the turn after it starts
-its rail where a first turn does. The browser's clock is pinned to the epoch the fixture was stamped from, so a run that
-crosses local midnight between the boot and the drive still agrees with itself.
+echoes of romp notices, the first sent yesterday 09:47 (the gap between the two-days-ago turn and yesterday's), the second
+today 00:12 (the gap between today's two turns). `api`: the same shape read a day later, rows all yesterday and both echoes
+two days ago, before the first turn: one synthetic turn LEADING the transcript. Asserted, dark and light: every timed row
+is in time order and each echo row wears its OWN local HH:MM; `web` shows two dividers only (the weekday over two days
+ago, "Yesterday" whose next row is the 09:47 echo, now yesterday's first row, not the 10:00 row) and no collapsed run
+at all (the two echoes are a day apart, no longer adjacent); `api` shows the weekday divider leading the transcript over
+the notice run (whose head anchors on its latest member, 09:41, its previous sibling the divider), then exactly ONE
+"Yesterday" over the first real row; each divider's label is centered in the column between two hairlines of equal width;
+the divider's rail segment is painted on the turns' own line (the same page x) and reaches the neighbouring turns' boxes
+above and below (painted geometry, not the rule text); a divider that leads the transcript (nothing on the rail above it:
+the first child, or the one after the pinned system-context card, which sits off the rail) draws no segment and the turn
+after it starts its rail where a first turn does. The browser's clock is pinned to the epoch the fixture was stamped from,
+so a run that crosses local midnight between the boot and the drive still agrees with itself.
 
 With DD_SHOTS=<dir> the driver writes screenshots (dark and light, the `web` session); DD_BEFORE_DIST=<dist> serves another
-tree's bundle for the before shots and skips the assertions, unless DD_BEFORE_ASSERT=1 keeps them (how the test is proven
-red against the bundle before the change: a third divider inside today above `web`'s notice run; and, against the branch
-before the high-water mark, a second "Yesterday" in `api`). Skips LOUDLY without the extension deps or a Playwright
-browser; the extension CI job installs Chromium and runs served files with ROMP_SERVED_TESTS_REQUIRE=1, which turns any
-skip into a failure there. SYNTHETIC fixtures only (sessions web and api, invented notice texts, the notes-api demo world)."""
+tree's bundle for the before shots and skips the assertions, unless DD_BEFORE_ASSERT=1 keeps them (how T339 was proven
+red against the bundle before its change: a third divider inside today above `web`'s notice run; and, against the branch
+before the high-water mark, a second "Yesterday" in `api`). The T344 half is red against a KERNEL before the change, the
+bundle as is: the echoes then sat in the last turn, so `web`'s rows stepped back in time and its "Yesterday" opened the
+10:00 row (not the 09:47 echo), and `api` had no weekday divider leading the transcript (its stale run sat among
+yesterday's rows, with nothing opening its day). Skips LOUDLY without the extension deps or a Playwright browser; the
+extension CI job installs Chromium and runs served files with ROMP_SERVED_TESTS_REQUIRE=1, which turns any skip into a
+failure there. SYNTHETIC fixtures only (sessions web and api, invented notice texts, the notes-api demo world)."""
 import json
 import os
 import re
@@ -51,8 +60,8 @@ EXT = os.path.join(ROOT, "vscode-extension")
 sys.path.insert(0, HERE)
 import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
 
-SID_A = "aaaaaaaa-1111-2222-3333-444444444444"   # web: today's rows, one stale echo among them
-SID_B = "bbbbbbbb-1111-2222-3333-444444444444"   # api: the same read a day later, both echoes stale
+SID_A = "aaaaaaaa-1111-2222-3333-444444444444"   # web: rows across three days, an echo in two of the gaps
+SID_B = "bbbbbbbb-1111-2222-3333-444444444444"   # api: the same read a day later, both echoes before the first turn
 
 
 def _free_port():
@@ -82,8 +91,10 @@ NOTICE_2 = "[romp] The condition you asked romp to watch now HOLDS: the second l
 
 def _echoes(now, shift):
     """The registry's echo mirror: two romp notices the kernel sent and whose text never landed. Reseeded at boot as live
-    atoms, they merge into the last turn by their own send time: after the first turn's rows, before the second turn's.
-    `shift` 0 (web): the first sent YESTERDAY 09:47, the second today 00:12. `shift` 1 (api): both two days ago."""
+    atoms, each is older than the last turn's start and is placed by its send time (T344): a closed turn of its own in the
+    gap where it was sent, one turn per gap. `shift` 0 (web): the first sent YESTERDAY 09:47 (the gap before yesterday's
+    turn), the second today 00:12 (the gap between today's two turns). `shift` 1 (api): both two days ago, before the
+    first turn, so they share one turn that leads the transcript."""
     if shift == 0:
         return [{"uuid": "echo:" + "a" * 32, "t": _local_day(1, 9, 47, now), "text": NOTICE_1, "author": "romp"},
                 {"uuid": "echo:" + "b" * 32, "t": _local_day(0, 0, 12, now), "text": NOTICE_2, "author": "romp"}]
@@ -93,7 +104,8 @@ def _echoes(now, shift):
 
 def _records(sid, now, shift):
     """The transcript. `shift` 0 (web): a pair two days ago, a pair yesterday (a real day boundary), then today: two turns,
-    the echoes merging between them. `shift` 1 (api): two turns, all yesterday (the transcript read a day later)."""
+    the 00:12 echo in the gap between them, the 09:47 echo in the gap before yesterday's pair. `shift` 1 (api): two turns,
+    all yesterday (the transcript read a day later), both echoes before the first."""
     def user(uuid, parent, t, text):
         return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent, "promptSource": "typed", "sessionId": sid,
                 "message": {"role": "user", "content": text}}
@@ -111,7 +123,7 @@ def _records(sid, now, shift):
             asst("a2", "u2", d1 + 60, "Five attempts, then surface the failure."),
             user("u3", "a2", t0, "please run the notes-api search suite"),
             asst("a3", "u3", t0 + 60, "Running the search suite now."),
-            # the second turn of today; the two echoes (00:12 today and 09:47 yesterday) sort before its trigger
+            # the second turn of today; the 00:12 echo sits in the gap before its trigger (the 09:47 one before u2)
             user("u4", "a3", t0 + 180, "and the docs suite after it"),
             asst("a4", "u4", t0 + 240, "Both suites are green; the search module is done."),
         ]
@@ -119,7 +131,7 @@ def _records(sid, now, shift):
     return [
         user("u1", None, y0, "please run the notes-api search suite"),
         asst("a1", "u1", y0 + 60, "Running the search suite now."),
-        # the second turn of yesterday; both echoes (two days ago) sort before its trigger
+        # the second turn of yesterday; both echoes (two days ago) precede u1, one run leading the transcript
         user("u2", "a1", y0 + 300, "and the docs suite after it"),
         asst("a2", "u2", y0 + 360, "Both suites are green; the search module is done."),
     ]
@@ -305,36 +317,62 @@ class ServedDayDivider(unittest.TestCase):
         if self.before and not os.environ.get("DD_BEFORE_ASSERT"):
             self.skipTest("a before-the-change dist: screenshots only, the assertions describe the change")
         now = self.now
-        yesterday_first = _local_day(1, 10, 0, now)
         two_days_ago = time.strftime("%a", time.localtime(_local_day(2, 10, 0, now)))   # the marker's weekday label for a day within the week
-        later_t = _echoes(now, 0)[1]["t"]
-        # web: today's rows with one stale echo among them
+
+        def hm(t):
+            return time.strftime("%H:%M", time.localtime(t))
+
+        def timed(m):
+            return [int(row["t"]) for row in m["rows"] if row["t"] is not None]
+
+        def echo_row(m, t):
+            hits = [row for row in m["rows"] if row["t"] == str(t)]
+            self.assertEqual(len(hits), 1, "one row at the echo's send time %s: %r" % (hm(t), [(row["cls"], row["t"]) for row in m["rows"]]))
+            return hits[0]
+        # web: two stale echoes, each in a gap of its own (T344): the rows are in time order and each echo wears its own clock
+        yesterday_echo_t, today_echo_t = (e["t"] for e in _echoes(now, 0))
         for theme in ("dark", "light"):
             m = r["web"][theme]
             self.assertEqual(m["theme"], theme)
-            # (3) two dividers only: the first row (two days ago) opens its day, yesterday's first row opens "Yesterday";
-            # none inside today, where the notice run sits with its first member stamped yesterday
+            ts = timed(m)
+            self.assertEqual(ts, sorted(ts), "the rows the chat reads are in time order (a stale echo sits at its send time, never among later rows) in %s: %r" % (theme, ts))
+            for t in (yesterday_echo_t, today_echo_t):
+                row = echo_row(m, t)
+                self.assertIn("turn-notice", row["cls"], "the echo is a notice row of its own: %r" % row)
+                self.assertNotIn("turn-noticegroup", row["cls"], "…not a run (the two echoes are a day apart, no longer adjacent): %r" % row)
+                self.assertEqual((row["marker"], row["markerEpoch"]), (hm(t), str(t)), "an echo row wears its OWN time: %r" % row)
+            self.assertIsNone(m["head"], "no collapsed notice run in web (the echoes sit in different gaps): %r" % [row["cls"] for row in m["rows"]])
+            # (3) two dividers only: the first row (two days ago) opens its day; "Yesterday" opens on the 09:47 echo, now
+            # yesterday's first row (it sits in the gap before the 10:00 row); none inside today
             self.assertEqual([d["label"] for d in m["divs"]], [two_days_ago, "Yesterday"], "two dividers, the transcript's two past days, in %s: %r" % (theme, [d["label"] for d in m["divs"]]))
-            d = m["divs"][1]
-            self.assertEqual(d["next"]["markerEpoch"], str(yesterday_first), "…yesterday's first row: %r" % d["next"])
-            self.assertIsNotNone(m["head"], "the two echoed notices collapsed into one run: %r" % [row["cls"] for row in m["rows"]])
-            self.assertFalse(m["head"]["prevIsDivider"], "no divider above the notice run (its first member is stamped yesterday, its place is today): %r" % m["head"])
-            self.assertEqual(m["head"]["marker"], time.strftime("%H:%M", time.localtime(later_t)), "the run's head wears its LATEST member's time, today's, not yesterday's: %r" % m["head"])
-            self.assertEqual(m["head"]["t"], str(later_t), "…and anchors on it")
             self.assertTrue(m["divs"][0]["leads"], "the transcript leads with its first day's divider (after the system-context card): %r" % m["divs"][0])
+            d = m["divs"][1]
+            self.assertEqual((d["next"]["t"], d["next"]["markerEpoch"]), (str(yesterday_echo_t), str(yesterday_echo_t)),
+                             "\"Yesterday\" opens on the 09:47 echo, yesterday's first row under the placement, not the 10:00 row: %r" % d["next"])
+            self.assertIn("turn-notice", d["next"]["cls"], "…the echo's own notice row: %r" % d["next"])
             for d in m["divs"]:
                 self._divider_shape(d, m, theme)
-        # api: the same read a day later, both echoes stale: exactly ONE "Yesterday" (the review's duplicate closed)
-        b_later_t = _echoes(now, 1)[1]["t"]
+        # api: both echoes precede the first turn and share one synthetic turn that LEADS the transcript: the weekday
+        # divider opens on the notice run, then exactly ONE "Yesterday" over the first real row
+        b_first_t, b_later_t = _local_day(1, 9, 5, now), _echoes(now, 1)[1]["t"]
         for theme in ("dark", "light"):
             m = r["api"][theme]
             self.assertEqual(m["theme"], theme)
-            self.assertEqual([d["label"] for d in m["divs"]], ["Yesterday"], "one divider: the stale run opens nothing and never becomes the reference, so the return to yesterday's rows opens nothing either, in %s: %r" % (theme, [d["label"] for d in m["divs"]]))
-            self.assertIsNotNone(m["head"], "the two stale echoes collapsed into one run: %r" % [row["cls"] for row in m["rows"]])
-            self.assertFalse(m["head"]["prevIsDivider"], "no divider above the stale run: %r" % m["head"])
-            self.assertEqual(m["head"]["t"], str(b_later_t), "the run's head anchors on its latest member, stale as it is")
-            self.assertTrue(m["divs"][0]["leads"])
-            self._divider_shape(m["divs"][0], m, theme)
+            ts = timed(m)
+            self.assertEqual(ts, sorted(ts), "the rows are in time order (the stale run leads, it is not among yesterday's rows) in %s: %r" % (theme, ts))
+            self.assertEqual([d["label"] for d in m["divs"]], [two_days_ago, "Yesterday"], "the weekday divider leads (the run's day, two days ago), then one \"Yesterday\", in %s: %r" % (theme, [d["label"] for d in m["divs"]]))
+            self.assertIsNotNone(m["head"], "the two stale echoes, sent together, collapsed into one run: %r" % [row["cls"] for row in m["rows"]])
+            self.assertTrue(m["head"]["prevIsDivider"], "the weekday divider sits right above the run: %r" % m["head"])
+            self.assertEqual((m["head"]["t"], m["head"]["marker"]), (str(b_later_t), hm(b_later_t)), "the run's head anchors on its latest member and wears its own time, two days ago: %r" % m["head"])
+            lead, yday = m["divs"]
+            self.assertTrue(lead["leads"], "the weekday divider leads the transcript (after the system-context card): %r" % lead)
+            self.assertIn("turn-noticegroup", lead["next"]["cls"], "…and opens on the notice run: %r" % lead["next"])
+            self.assertEqual(lead["next"]["t"], str(b_later_t), "…anchored on its latest member: %r" % lead["next"])
+            self.assertFalse(yday["leads"], "\"Yesterday\" has the run on the rail above it: %r" % yday)
+            self.assertIn("turn-noticegroup", yday["prev"]["cls"], "\"Yesterday\" follows the run: %r" % yday["prev"])
+            self.assertEqual(yday["next"]["markerEpoch"], str(b_first_t), "…and opens yesterday's first real row: %r" % yday["next"])
+            for d in m["divs"]:
+                self._divider_shape(d, m, theme)
 
 
 if __name__ == "__main__":

--- a/tests/test_stale_echo_placement.py
+++ b/tests/test_stale_echo_placement.py
@@ -209,6 +209,59 @@ class StaleEchoPlacement(unittest.TestCase):
         self.assertIn("live-reply-1", [a["uuid"] for a in merged["turns"][-1]["atoms"]])
         self.assertFalse(merged["turns"][-1]["ended"])
 
+    def test_a_send_the_cli_still_owes_keeps_the_tail_however_old_its_stamp(self):
+        # a held copy (T306) keeps its send stamp while the queue behind it feeds: on release it is older than
+        # the last turn's start but still pending, listed by the CLI's queue ledger, and rides the tail
+        saved = km._pending_ledger
+        km._path_of = lambda sid, now=None: "/nonexistent/notes-api/%s.jsonl" % SID
+        km._pending_ledger = lambda path: ["one more thing"]
+        try:
+            owed = _echo(T_DAY1 + 22 * 3600 + 28 * 60, key="echo:" + "ab" * 16, author="human", _echo_text="one more thing")
+            owed["message"]["content"][0]["text"] = "one more thing"
+            merged, _ = self._merge(_two_days(), [owed])
+        finally:
+            km._pending_ledger = saved
+        self.assertEqual(len(merged["turns"]), 2, "no placement for an owed send")
+        self.assertEqual(merged["turns"][-1]["atoms"][0]["uuid"], owed["uuid"], "it sorts into the tail by time, as before")
+        self.assertEqual(merged["_placed"], ())
+
+    def test_the_synthetic_turn_is_marked_and_names_its_echoes(self):
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60)
+        merged, _ = self._merge(_two_days(), [stale])
+        gap = merged["turns"][1]
+        self.assertTrue(gap.get("echoTurn"))
+        self.assertEqual(gap.get("placedEchoes"), [stale["uuid"]])
+        inside = _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "f" * 32)
+        merged2, _ = self._merge(_two_days(), [inside])
+        self.assertEqual(merged2["turns"][0].get("placedEchoes"), [inside["uuid"]], "a window placement is named on the turn")
+        self.assertFalse(merged2["turns"][0].get("echoTurn"), "…which is a real turn")
+
+    def test_a_placed_echo_never_splits_a_judged_turns_segments(self):
+        # a judged turn's segment ids mirror the judge's parse, which never sees an echo: the segmenters
+        # read the turn without its placed echoes, so the bar and its captions keep their keys
+        inside = _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "f" * 32)
+        turns = _two_days()
+        merged, _ = self._merge(turns, [inside])
+        before = [seg["id"] for seg in km.em.segments(turns[0])]
+        after = [seg["id"] for seg in km.em.segments(km._turn_sans_placed_echoes(merged["turns"][0]))]
+        self.assertEqual(after, before)
+        self.assertNotEqual([seg["id"] for seg in km.em.segments(merged["turns"][0])], before,
+                            "(the raw placed turn WOULD split: that is what the helper prevents)")
+        self.assertEqual([seg["id"] for seg in km._segs_seam(merged["turns"][0], {})], before, "the seam-aware segmenter reads it too")
+        untouched = merged["turns"][-1]
+        self.assertIs(km._turn_sans_placed_echoes(untouched), untouched, "a turn with nothing placed is handed back as is")
+
+    def test_the_feeds_plain_prompt_reader_never_reads_an_echo_as_a_prompt(self):
+        # a stale HUMAN echo (a swallowed send) is not the user talking on the thread: the re-judging latch
+        # must never arm off it (the code's own rule: the parse's plain-reply turn, never the echo)
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60, author="human", _echo_text="are we done here?")
+        stale["message"]["content"][0]["text"] = "are we done here?"
+        inside = _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "f" * 32, author="human", _echo_text="and this?")
+        inside["message"]["content"][0]["text"] = "and this?"
+        merged, _ = self._merge(_two_days(), [stale, inside])
+        self.assertEqual(km._last_plain_user_turn_t(merged["turns"]), T_DAY2 + 7 * 3600 + 300, "the later day's real prompt, not an echo")
+        self.assertEqual(km._last_plain_user_turn_t([merged["turns"][1]]), 0, "an echo's own turn is no prompt turn")
+
     def test_the_parse_object_is_not_mutated(self):
         turns = _two_days()
         before = [(t["id"], len(t["atoms"])) for t in turns]

--- a/tests/test_stale_echo_placement.py
+++ b/tests/test_stale_echo_placement.py
@@ -87,6 +87,21 @@ def _two_days():
     return [a, b]
 
 
+def _idle(t, end):
+    """The idle atom event_model.synthesize_idle appends to a finished turn: from the Stop state row to the
+    NEXT state row, so a finished turn's `end` reaches the next turn's start (the production shape)."""
+    return {"type": "idle", "uuid": None, "session_id": SID, "t": t, "end": end, "_seq": 10 ** 12 + t}
+
+
+def _two_days_idle():
+    """The production shape: the earlier day's turn carries a trailing idle atom stretched to the later day's
+    turn start, so its parsed `end` is 07:05 the next day although its work ended at 22:01."""
+    a, b = _two_days()
+    a["atoms"].append(_idle(a["end"], b["t"]))
+    a["end"] = b["t"]
+    return [a, b]
+
+
 def _flat(session):
     return [a for turn in session["turns"] for a in turn["atoms"]]
 
@@ -121,6 +136,32 @@ class StaleEchoPlacement(unittest.TestCase):
         self.assertEqual([t["id"] for t in merged["turns"]], ["t1", holder["id"], "t2"], "…placed before the later day's turn")
         # the last turn keeps its own window and ended state: a stale echo is not live work
         self.assertEqual((merged["turns"][-1]["end"], merged["turns"][-1]["ended"]), (T_DAY2 + 7 * 3600 + 360, True))
+
+    def test_a_finished_turns_idle_stretch_is_not_its_window(self):
+        # the manager's review of the first cut: every finished SDK turn's `end` is the NEXT turn's start (the
+        # synthesized idle atom), so a window read off `end` swallowed every notice sent while the session sat
+        # idle; the window ends at the turn's last recorded non-idle activity
+        turns = _two_days_idle()
+        self.assertEqual(turns[0]["end"], turns[1]["t"], "the fixture has the production shape")
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60)                     # 27 minutes after the work ended
+        merged, _ = self._merge(turns, [stale])
+        self.assertEqual([t["id"] for t in merged["turns"]][::2], ["t1", "t2"], "a synthetic turn in the gap")
+        self.assertTrue(merged["turns"][1].get("echoTurn"))
+        self.assertNotIn(stale["uuid"], [a["uuid"] for a in merged["turns"][0]["atoms"]],
+                         "the echo never joins a turn that ended before it was sent")
+        self.assertEqual(km._turn_activity_end(turns[0]), T_DAY1 + 22 * 3600 + 60, "the last reply, not the idle atom's end")
+        inside = _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "f" * 32)  # between the prompt and the reply
+        merged2, _ = self._merge(_two_days_idle(), [inside])
+        self.assertIn(inside["uuid"], [a["uuid"] for a in merged2["turns"][0]["atoms"]], "inside the activity: joins")
+        self.assertEqual(len(merged2["turns"]), 2)
+
+    def test_the_placer_returns_the_destinations_with_the_turns(self):
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60, dropped=True)
+        inside = _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "f" * 32)
+        turns, placed = km._place_stale_echoes(_two_days(), [stale, inside])
+        self.assertEqual([t["id"] for t in turns][::2], ["t1", "t2"])
+        self.assertEqual(placed, ((0, inside["uuid"], False), (1, stale["uuid"], True)),
+                         "(destination index, uuid, dropped) per echo, indexes after the insertions")
 
     def test_an_echo_inside_an_earlier_turns_window_joins_that_turn(self):
         turns = _two_days()
@@ -250,6 +291,10 @@ class StaleEchoPlacement(unittest.TestCase):
         self.assertNotEqual([seg["id"] for seg in km.em.segments(merged["turns"][0])], before,
                             "(the raw placed turn WOULD split: that is what the helper prevents)")
         self.assertEqual([seg["id"] for seg in km._segs_seam(merged["turns"][0], {})], before, "the seam-aware segmenter reads it too")
+        # the anchors too (the dot's prompt atom, the bar's first work atom, the reply): byte-identical with and
+        # without the placed echo, for the chat build's maps and the lanes' bars alike
+        anchors = lambda t: [km._seg_anchors(seg["atoms"]) for seg in km._segs_seam(t, {})]
+        self.assertEqual(anchors(km._turn_sans_placed_echoes(merged["turns"][0])), anchors(turns[0]))
         untouched = merged["turns"][-1]
         self.assertIs(km._turn_sans_placed_echoes(untouched), untouched, "a turn with nothing placed is handed back as is")
 

--- a/tests/test_stale_echo_placement.py
+++ b/tests/test_stale_echo_placement.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""A stale live echo sits where its send time belongs, never among later rows (T344, the user 2026-09-11, who
+saw a 10:28 PM row between 7:05 AM rows). The kernel keeps its own copies of sent messages as LIVE echo atoms
+(mirrored in the registry's echoes and reseeded at boot) until the transcript lands their text; the chat merge
+(_merge_live_atoms) used to put every fresh echo into the chat's LAST turn, sorted by its own send time, so a
+romp notice sent yesterday whose text never landed sat among today's rows stamped with yesterday's clock, and
+the day walk read the step back as a day boundary (T339 closed the walk's side; this is the producer).
+
+The rule pinned here: a fresh echo stamped at or after the last turn's start stays in the last turn (a pending
+send is always newer than the transcript); an echo OLDER than that is placed by time: into the turn whose
+window [t, end] holds it, or, when it falls in the gap between two turns (or before the first), into a closed
+synthetic turn of its own at that place, one per gap, so the rows the chat reads are in time order and the day
+walk just works. Live stream atoms (a reply in flight) and command feedback stay in the last turn as before.
+SYNTHETIC fixtures only: a private synthetic sid, the notes-api demo world, invented notice text."""
+import os
+import tempfile
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_stale_echo", os.path.join(BIN, "romp-kernel"))
+
+SID = "7e7e7e7e-8f8f-4a9a-b0b0-c1c1c1c1c1c1"      # private synthetic sid
+DAY = 86400
+T_DAY1 = 1_800_000_000                            # the earlier day's rows
+T_DAY2 = T_DAY1 + DAY                             # the later day's rows
+NOTICE = "[romp] The condition you asked romp to watch now HOLDS: the notes-api search suite has its verdict."
+
+
+def _user(uuid, t, text, author="human"):
+    return {"type": "user", "uuid": uuid, "t": t, "author": author, "parentUuid": None, "session_id": SID,
+            "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+
+def _asst(uuid, t, text):
+    return {"type": "assistant", "uuid": uuid, "t": t, "author": "assistant", "parentUuid": None, "session_id": SID,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+def _turn(tid, atoms, ended=True):
+    return {"id": tid, "trigger": {"uuid": atoms[0]["uuid"]}, "t": atoms[0]["t"], "end": atoms[-1]["t"], "ended": ended,
+            "atoms": list(atoms)}
+
+
+def _echo(t, text=NOTICE, key="echo:" + "e" * 32, author="romp", **extra):
+    a = {"type": "user", "uuid": key, "session_id": SID, "t": t, "parentUuid": None, "author": author,
+         "_echo_text": text, "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+    a.update(extra)
+    return a
+
+
+def _stream(t, uuid="live-reply-1"):
+    return {"type": "assistant", "uuid": uuid, "t": t, "author": "assistant", "session_id": SID, "parentUuid": None,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "still working on it"}]}}
+
+
+class _Backend:
+    """The owning backend as the merge sees it: a live tail and a prune that retires nothing."""
+
+    def __init__(self, live):
+        self.live = list(live)
+        self.pruned = []
+
+    def live_atoms(self, sid):
+        return sorted(self.live, key=lambda a: a.get("t", 0))
+
+    def prune_live(self, sid, tx_uuids, tx_user_texts=(), human_floor=0):
+        self.pruned.append((frozenset(tx_uuids), human_floor))
+
+
+def _session(turns):
+    return {"rompUuid": SID, "name": "web", "dir": "/tmp/notes-api", "color": "#1EA1EB", "turns": turns}
+
+
+def _two_days():
+    """Two turns: one late on the earlier day (22:00, 22:01), one early on the later day (07:05, 07:06)."""
+    a = _turn("t1", [_user("u1", T_DAY1 + 22 * 3600, "please run the notes-api search suite"),
+                     _asst("a1", T_DAY1 + 22 * 3600 + 60, "Running the search suite now.")])
+    b = _turn("t2", [_user("u2", T_DAY2 + 7 * 3600 + 300, "and the docs suite after it"),
+                     _asst("a2", T_DAY2 + 7 * 3600 + 360, "Both suites are green.")])
+    return [a, b]
+
+
+def _flat(session):
+    return [a for turn in session["turns"] for a in turn["atoms"]]
+
+
+class StaleEchoPlacement(unittest.TestCase):
+    def setUp(self):
+        self.saved = (km.Sessions.backend_for, km._path_of)
+        km._merge_sets_memo.clear()
+        km._path_of = lambda sid, now=None: None
+
+    def tearDown(self):
+        km.Sessions.backend_for, km._path_of = self.saved
+        km._merge_sets_memo.clear()
+
+    def _merge(self, turns, live):
+        be = _Backend(live)
+        km.Sessions.backend_for = staticmethod(lambda sid: be)
+        return km._merge_live_atoms(_session(turns), SID), be
+
+    def test_an_echo_sent_between_two_days_turns_sits_between_them_not_among_the_later_rows(self):
+        # the user's case: a notice sent at 22:28 on the earlier day, never landed, read the next morning
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60)
+        merged, _ = self._merge(_two_days(), [stale])
+        ts = [a["t"] for a in _flat(merged)]
+        self.assertEqual(ts, sorted(ts), "the rows the chat reads are in time order: %r" % ts)
+        self.assertNotIn(stale["uuid"], [a["uuid"] for a in merged["turns"][-1]["atoms"]],
+                         "the stale echo is not in the LAST turn (that put a 10:28 PM row between 7:05 AM rows)")
+        holder = next(t for t in merged["turns"] if any(a["uuid"] == stale["uuid"] for a in t["atoms"]))
+        self.assertEqual((holder["t"], holder["end"], holder["ended"]), (stale["t"], stale["t"], True),
+                         "in the gap between the turns it gets a closed turn of its own at its send time: %r" % holder)
+        self.assertIsNone(holder["trigger"])
+        self.assertEqual([t["id"] for t in merged["turns"]], ["t1", holder["id"], "t2"], "…placed before the later day's turn")
+        # the last turn keeps its own window and ended state: a stale echo is not live work
+        self.assertEqual((merged["turns"][-1]["end"], merged["turns"][-1]["ended"]), (T_DAY2 + 7 * 3600 + 360, True))
+
+    def test_an_echo_inside_an_earlier_turns_window_joins_that_turn(self):
+        turns = _two_days()
+        inside = _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "f" * 32)   # between u1 and a1
+        merged, _ = self._merge(turns, [inside])
+        self.assertEqual([a["uuid"] for a in merged["turns"][0]["atoms"]], ["u1", inside["uuid"], "a1"])
+        self.assertEqual(len(merged["turns"]), 2, "no synthetic turn when a window holds the echo")
+        self.assertEqual(merged["turns"][0]["end"], turns[0]["end"], "the window already held it: unchanged")
+
+    def test_an_echo_older_than_the_first_turn_leads_the_transcript(self):
+        oldest = _echo(T_DAY1 + 9 * 3600, key="echo:" + "d" * 32)
+        merged, _ = self._merge(_two_days(), [oldest])
+        self.assertEqual(merged["turns"][0]["atoms"][0]["uuid"], oldest["uuid"])
+        self.assertEqual([t["id"] for t in merged["turns"]][1:], ["t1", "t2"])
+
+    def test_two_echoes_in_one_gap_share_one_synthetic_turn_in_time_order(self):
+        e1 = _echo(T_DAY1 + 23 * 3600, key="echo:" + "c" * 32)
+        e2 = _echo(T_DAY1 + 22 * 3600 + 28 * 60, key="echo:" + "b" * 32)
+        merged, _ = self._merge(_two_days(), [e1, e2])
+        self.assertEqual(len(merged["turns"]), 3)
+        gap = merged["turns"][1]
+        self.assertEqual([a["uuid"] for a in gap["atoms"]], [e2["uuid"], e1["uuid"]])
+        self.assertEqual((gap["t"], gap["end"]), (e2["t"], e1["t"]), "the synthetic turn spans its members")
+
+    def test_a_fresh_echo_stays_in_the_last_turn_as_before(self):
+        # a pending send: stamped after the last turn's start; the last turn's window extends over it
+        fresh = _echo(T_DAY2 + 7 * 3600 + 400, key="echo:" + "a" * 32, author="human", _echo_text="one more thing")
+        fresh["message"]["content"][0]["text"] = "one more thing"
+        merged, _ = self._merge(_two_days(), [fresh])
+        self.assertEqual(len(merged["turns"]), 2)
+        self.assertEqual(merged["turns"][-1]["atoms"][-1]["uuid"], fresh["uuid"])
+        self.assertEqual(merged["turns"][-1]["end"], fresh["t"])
+        self.assertTrue(merged["turns"][-1]["ended"], "an echo never reopens the turn")
+
+    def test_a_streaming_reply_is_live_work_in_the_last_turn_whatever_its_stamp(self):
+        turns = _two_days()
+        turns[-1]["ended"] = False
+        merged, _ = self._merge(turns, [_stream(T_DAY2 + 7 * 3600 + 361)])
+        self.assertEqual(len(merged["turns"]), 2)
+        self.assertEqual(merged["turns"][-1]["atoms"][-1]["uuid"], "live-reply-1")
+        self.assertFalse(merged["turns"][-1]["ended"])
+
+    def test_the_synthetic_turns_id_is_stable_across_builds(self):
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60)
+        a, _ = self._merge(_two_days(), [stale])
+        km._merge_sets_memo.clear()
+        b, _ = self._merge(_two_days(), [stale])
+        self.assertEqual(a["turns"][1]["id"], b["turns"][1]["id"], "the same echo yields the same turn id build after build")
+        self.assertNotIn(a["turns"][1]["id"], ("t1", "t2", "live"))
+
+    def test_the_parse_object_is_not_mutated(self):
+        turns = _two_days()
+        before = [(t["id"], len(t["atoms"])) for t in turns]
+        self._merge(turns, [_echo(T_DAY1 + 22 * 3600 + 28 * 60)])
+        self.assertEqual([(t["id"], len(t["atoms"])) for t in turns], before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stale_echo_placement.py
+++ b/tests/test_stale_echo_placement.py
@@ -171,11 +171,51 @@ class StaleEchoPlacement(unittest.TestCase):
         self.assertEqual(a["turns"][1]["id"], b["turns"][1]["id"], "the same echo yields the same turn id build after build")
         self.assertNotIn(a["turns"][1]["id"], ("t1", "t2", "live"))
 
+    def test_a_stale_echo_and_a_fresh_one_in_the_same_build_each_take_their_place(self):
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60, key="echo:" + "beef" * 8)
+        fresh = _echo(T_DAY2 + 7 * 3600 + 400, key="echo:" + "cafe" * 8, author="human", _echo_text="one more thing")
+        fresh["message"]["content"][0]["text"] = "one more thing"
+        merged, _ = self._merge(_two_days(), [stale, fresh])
+        self.assertEqual([t["id"] for t in merged["turns"]][::2], ["t1", "t2"])
+        self.assertEqual(merged["turns"][1]["atoms"][0]["uuid"], stale["uuid"], "the stale one in the gap")
+        self.assertEqual(merged["turns"][-1]["atoms"][-1]["uuid"], fresh["uuid"], "the fresh one in the tail")
+        self.assertEqual(merged["turns"][-1]["end"], fresh["t"], "the tail still extends the last turn's window")
+
+    def test_boundaries_an_echo_at_a_turns_end_joins_it_and_one_at_the_last_turns_start_takes_the_tail(self):
+        turns = _two_days()
+        at_end = _echo(turns[0]["end"], key="echo:" + "dead" * 8)                 # stamped exactly at t1's end
+        at_last_start = _echo(turns[1]["t"], key="echo:" + "face" * 8)          # stamped exactly at t2's start
+        merged, _ = self._merge(turns, [at_end, at_last_start])
+        self.assertEqual(len(merged["turns"]), 2, "neither needs a synthetic turn")
+        self.assertIn(at_end["uuid"], [a["uuid"] for a in merged["turns"][0]["atoms"]])
+        self.assertIn(at_last_start["uuid"], [a["uuid"] for a in merged["turns"][1]["atoms"]])
+
+    def test_a_dropped_echo_keeps_its_flag_and_the_placement_is_reported_for_the_fold(self):
+        stale = _echo(T_DAY1 + 22 * 3600 + 28 * 60, dropped=True)
+        merged, _ = self._merge(_two_days(), [stale])
+        a = next(x for t in merged["turns"] for x in t["atoms"] if x["uuid"] == stale["uuid"])
+        self.assertTrue(a.get("dropped"), "placement never touches the atom")
+        self.assertEqual(merged["_placed"], ((1, stale["uuid"], True),),
+                         "the chat fold keys its sealed prefix on (turn index, uuid, dropped) of every placed echo")
+        fresh_only, _ = self._merge(_two_days(), [_echo(T_DAY2 + 7 * 3600 + 400, key="echo:" + "a" * 32)])
+        self.assertEqual(fresh_only["_placed"], (), "a tail echo is not placed and not reported")
+
+    def test_an_older_stream_atom_is_still_the_last_turns_live_work(self):
+        # a reply in flight is never placed by time: only echoes are
+        turns = _two_days()
+        turns[-1]["ended"] = False
+        merged, _ = self._merge(turns, [_stream(T_DAY1 + 23 * 3600)])
+        self.assertEqual(len(merged["turns"]), 2)
+        self.assertIn("live-reply-1", [a["uuid"] for a in merged["turns"][-1]["atoms"]])
+        self.assertFalse(merged["turns"][-1]["ended"])
+
     def test_the_parse_object_is_not_mutated(self):
         turns = _two_days()
         before = [(t["id"], len(t["atoms"])) for t in turns]
-        self._merge(turns, [_echo(T_DAY1 + 22 * 3600 + 28 * 60)])
+        atom_lists = [t["atoms"] for t in turns]
+        self._merge(turns, [_echo(T_DAY1 + 22 * 3600 + 28 * 60), _echo(T_DAY1 + 22 * 3600 + 30, key="echo:" + "b" * 32)])
         self.assertEqual([(t["id"], len(t["atoms"])) for t in turns], before)
+        self.assertTrue(all(t["atoms"] is l for t, l in zip(turns, atom_lists)), "the parse's atom lists are the same objects")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
T344 (the user 2026-09-11, who saw a 10:28 PM row between 7:05 AM rows): a stale live echo sits where its send time belongs, never among later rows. Tier `fix`.

## The producer

The kernel keeps its own copies of sent messages as live echo atoms until the transcript lands their text (mirrored in the registry's `echoes` and reseeded at boot). The chat merge (`_merge_live_atoms`) put every fresh echo into the chat's LAST turn, sorted by its own send time, so a romp notice sent yesterday whose text never landed sat among today's rows stamped with yesterday's clock, and the day walk read the step back as a day boundary. T339 fixed the walk's side (a collapsed run anchors on its latest member; a high-water mark) and left this producer as a known limit.

## The rule

An echo stamped at or after the last turn's start is a pending send and stays in the last turn, as before; so does an older echo that someone still owes (queued behind a busy turn, or listed by the CLI's own queue ledger: a held copy keeps its send stamp while the queue behind it feeds, and must ride the tail until it lands). An echo older than that and owed by nobody is placed by its send time (`_place_stale_echoes`): into the turn whose window holds it, or, when it falls in the gap between two turns or before the first, into a closed synthetic turn of its own at that place (trigger `None`, the shape a transcript-less session's live turn already has), one per gap holding every echo sent in it, so two notices sent together stay a run. The synthetic turn's id derives from its first echo's uuid and is the same build after build. The parse cache is never mutated. Live stream atoms and command feedback keep the last turn, its window and its ended state as before. The placement never reaches the timeline or the feed's readers: a synthetic turn is marked and draws no bar, a placed echo is left out of the segmenters (`_turn_sans_placed_echoes`) so a judged turn's segments and captions keep their keys, the feed's plain-prompt reader never reads an echo as a prompt turn (its re-judging latch must arm only off the parse), and `firstSeen` reads the first transcript turn. Everything lives in `kernel/kernel.py`; no SDK file or `event_model` is touched; of the chat build's fold, only the gate clause and commit field below.

Of the three candidates, this is the first: placed by time, the walk reads the echo in order and the divider logic needs no special case. On the second candidate, the review traced the existing dedup: the display dedup drops an echo whose text the transcript carries (under either of its keys), the `_landed` flag drops one the boot scan found on disk, and `prune_live` retires by text only through a record at or after the send. The user's echo was a romp notice whose text never landed, so none of those exits could apply, by design: an unlanded send must stay visible. No dedup gap contributed; the defect was the append to the last turn alone. (A residual the review noted as suspected, outside this change: a romp-authored echo is never scanned for a landing by the boot marker, so a notice recorded in a file the parse no longer covers stays flagged dropped.)

## Merge of main and the third review round

Main's chat change (an in-flight echo sorts after every atom of the last turn, whatever its send time) landed while this waited; main is merged in, not rebased: the placement of stale echoes runs first, the tail sort is main's. The manager's review of the first cut, checked against the merged head: a finished SDK turn carries a synthesized idle atom whose end is the next state row, so the window test read off the turn's `end` swallowed a notice sent while the session sat idle; the window now ends at the turn's last recorded non-idle activity (`_turn_activity_end`), with the production shape as a test. A judged turn's segment ids and anchors are pinned identical with and without a placed echo. The placer returns the destination indexes with the turns, so the fold's key is not a scan of every atom per merge. The fold test drives the landed-echo exit its docstring names. The served lab's sticky-label assertion (the chat team's day-context change) is re-aimed for the run that now leads the transcript, and says that its two values coincide there, so that team's own source pins are the discriminating guard.

## Tests

- `tests/test_stale_echo_placement.py`: a transcript spanning two days plus a registry echo stamped the earlier day and never landed; red before (the echo after the later day's rows), green after; the window, leading, one-turn-per-gap, fresh-echo, live-work, stable-id and no-mutation cases.
- `tests/test_day_divider_served.py` (the T339 served lab): the assertions read the placement on the real page: every timed row in non-decreasing order; `web`'s two echoes are two single notice rows at their own times, and the "Yesterday" divider opens on the 09:47 echo row; `api`'s two-days-ago notices lead the transcript under the weekday divider as one run anchored on its latest member, then exactly one "Yesterday" (the count the review's duplicate-divider finding closed stays one; the weekday divider over the stale run is where those notices were sent). Every divider keeps its shape checks in both themes. Red against a kernel before this change, as its docstring says.
- `tests/test_chat_fold.py`: a placed echo is sealed with its turn and its dismissal or its dropped flag refolds ("echo"); a tail echo never touches the fold.

## Verification

Python: `test_stale_echo_placement` (18), `test_chat_fold` (44 with the four new cases), the served day-divider lab in a real browser with skips forbidden (`ROMP_SERVED_TESTS_REQUIRE=1`), and the 24 suites that exercise the echo merge (677 passed); the full suite over the tree before the merge of main, 11927 passed, 55 skipped, no failures; the full suite over the merged and reviewed head, 11974 passed, 55 skipped, no failures; bats 579 ok. Bats: every suite, 579 ok. Review: two read-only lenses over the diff (every consumer of the merged turn list; the rule's boundaries and the dedup question). Folded: the fold sealing a placed echo (the second commit); a held send's release placing a pending message mid-history (the owed exception); a placed echo splitting a judged turn's segments and re-keying its captions; the feed's plain-prompt reader arming its re-judging latch off a stale human echo; `firstSeen` reading a stale echo's turn (the third commit).

**Coordination:** the two fold lines (the gate clause and the commit field) sit where PR 1404 (the metrics team's fold work) also edits; this branch is rebased onto main once that lands, as agreed with its author by mail.
