### PR TITLE
The new session picker's tag chips: faded at rest, a hover that lightens only the pill's ground, selected at the strongest level (T343)

### DIFF
--- a/tests/test_tag_chips_everywhere_browser.py
+++ b/tests/test_tag_chips_everywhere_browser.py
@@ -17,10 +17,14 @@ The served guard drives the real /chat page from a hermetic kernel with two tagg
 holds, opens the picker with the strip's +, and reads the Tags row: one option per tag, each holding one chip whose
 border wears the tag's colour; the tags the ACTIVE tab holds are selected (the full chip), the rest unselected (the
 faded chip); no dot anywhere. A click flips one option: the state class the create reads (`sel`) and the chip's off
-class move together, and a second click puts them back. No backend pick greys the row (T331)
-(the off chip's fade is not stacked with the row's).
+class move together, and a second click puts them back. No backend pick greys the row (T331; the off chip's fade is not
+stacked with the row's). The three chip states (T343): faded at rest, a hover that lightens only the pill's ground,
+selected at the strongest level whatever the hover (a themed filter: brighter on the dark card, darker on cream);
+TAG_SHOTS=<dir> writes the picker with all three side by side, dark and light.
 
-Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the CI-safe pins ride
+Skips LOUDLY without the extension deps or a Playwright browser; under ROMP_SERVED_TESTS_REQUIRE=1 (the CI extension job,
+which installs Chromium and runs every served file) that skip is a failure, and the Python matrix jobs, with no browser,
+skip. The CI-safe pins ride
 ui/webview/tag-chip-everywhere.test.ts, picker-tag-chips.test.ts and tab-groups.test.ts. All fixtures synthetic (the
 notes-api demo world)."""
 import json
@@ -58,6 +62,20 @@ def _free_port():
     p = s.getsockname()[1]
     s.close()
     return p
+
+
+def _rgba(s):
+    """'rgb(r, g, b)' or 'rgba(r, g, b, a)' as the browser computes it -> (r, g, b, a)."""
+    parts = [float(x) for x in s[s.index("(") + 1:s.index(")")].split(",")]
+    return tuple(parts) + ((1.0,) if len(parts) == 3 else ())
+
+
+def _wash_step(wash, surface):
+    """How far the wash moves the surface once composited over it: the largest per-channel change (a translucent wash
+    string never EQUALS an opaque surface string, so only the composite says whether the two are distinct)."""
+    r, g, b, a = _rgba(wash)
+    R, G, B, _ = _rgba(surface)
+    return max(abs(c * a + s * (1 - a) - s) for c, s in ((r, R), (g, G), (b, B)))
 
 
 def _rgb(hex6):
@@ -128,6 +146,22 @@ const survey = () => page.evaluate(() => {
   };
 });
 const open = await survey();
+// T343 (the user 2026-09-11): the three chip states side by side: web selected, docs hovered (faded), infra faded at
+// rest; then the selected chip hovered; the same in the light theme. The picker box is what the screenshots show.
+const pickerBox = async () => (await page.$("#picker .picker-box")).boundingBox();
+const hoverSurvey = async (tag) => { await page.hover('#picker .picker-tags .picker-be-opt[data-tag="' + tag + '"]'); await page.waitForTimeout(150); return await survey(); };
+const shot = async (name) => { if (!cfg.shots) return; fs.mkdirSync(cfg.shots, { recursive: true }); const b = await pickerBox(); await page.screenshot({ path: cfg.shots + "/" + name + ".png", clip: { x: b.x, y: b.y, width: b.width, height: b.height } }); };
+const surface = () => page.evaluate(() => getComputedStyle(document.querySelector("#picker .picker-box")).backgroundColor);
+const hoverFaded = await hoverSurvey("docs");
+await shot("romp_chat-picker-tag-chips-dark");
+const hoverSel = await hoverSurvey("web");
+const surfaceDark = await surface();
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(150);
+const hoverFadedLight = await hoverSurvey("docs");
+await shot("romp_chat-picker-tag-chips-light");
+const surfaceLight = await surface();
+const hoverSelLight = await hoverSurvey("web");
+await page.evaluate(() => document.body.classList.remove("theme-light")); await page.mouse.move(5, 5); await page.waitForTimeout(150);
 // flip the unselected infra tag on, then off again
 await page.click('#picker .picker-tags .picker-be-opt[data-tag="infra"]');
 await page.waitForTimeout(100);
@@ -143,7 +177,7 @@ await page.evaluate(() => document.body.classList.remove("chat-theme-yatharth", 
 await page.waitForTimeout(100);
 // T331: no backend pick disables the row any more (the terminal backend is no longer offered); the picker's toggles
 const backends = await page.evaluate(() => Array.from(document.querySelectorAll('#picker .picker-be-opt:not([data-tag])')).map((b) => b.getAttribute('data-be')).filter(Boolean));
-fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, lensMenu, open, on, off, light, backends }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ strip, lensMenu, open, on, off, light, backends, hoverFaded, hoverSel, hoverFadedLight, hoverSelLight, surfaceDark, surfaceLight }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -209,14 +243,15 @@ class ServedPickerTagChips(unittest.TestCase):
     def _drive(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "activeSid": SESSIONS[0][1]}, f)
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "activeSid": SESSIONS[0][1],
+                       "shots": os.environ.get("TAG_SHOTS", "")}, f)   # TAG_SHOTS=<dir>: the picker with its three chip states, dark and light (T343)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)
         p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
                            env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
         if p.returncode == 3:
-            raise unittest.SkipTest("no playwright browser on this box, and the served guard needs one (CI installs none)")
+            raise unittest.SkipTest("no playwright browser on this box, and the served guard needs one (the CI extension job installs Chromium and requires this file to run)")
         self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
@@ -293,6 +328,39 @@ class ServedPickerTagChips(unittest.TestCase):
         # T331: the picker offers Claude Code and Codex, both of whose creates take tags: no pick greys the row
         self.assertEqual(out["backends"], ["sdk", "codex"], "the terminal backend is no longer offered")
         self.assertFalse(out["on"]["rowDisabled"], "the row is never disabled")
+
+    def test_three_chip_states_faded_at_rest_a_hover_that_lightens_the_ground_only_selected_brightest_whatever_the_hover(self):
+        """T343 (the user 2026-09-11): faded and selected read too close, and a hover looked like a selection. On the real
+        picker: FADED (unselected at rest) is the off chip on a transparent ground; HOVER lightens the pill's ground one step
+        (the button's --chip-wash, the pill's own shape) and changes no colour, opacity or brightness; SELECTED wears the
+        strongest level whatever the hover: brightness(1.3) on the dark card (the level a hovered chip used to get) and
+        brightness(0.75) on cream, where a lift paled the chip below its faded neighbour (the review's find). In light the
+        wash is the darker step; composited over the picker's card surface it moves the surface by a visible amount."""
+        out = self._once()
+        rest = {x["tag"]: x for x in out["open"]["opts"]}
+        hf = {x["tag"]: x for x in out["hoverFaded"]["opts"]}       # docs (faded) under the pointer
+        hs = {x["tag"]: x for x in out["hoverSel"]["opts"]}         # web (selected) under the pointer
+        for name in ("infra", "docs"):
+            self.assertEqual((rest[name]["chipClass"], rest[name]["chipOpacity"], rest[name]["btnBg"], rest[name]["btnFilter"]),
+                             ("tag-chip-off", "0.45", "rgba(0, 0, 0, 0)", "none"), "faded at rest: the off chip, no ground, no filter: %r" % rest[name])
+        self.assertEqual((rest["web"]["chipClass"], rest["web"]["chipOpacity"], rest["web"]["btnBg"], rest["web"]["btnFilter"]),
+                         ("", "1", "rgba(0, 0, 0, 0)", "brightness(1.3)"), "selected at rest: the full chip at the brightest level, its own ground: %r" % rest["web"])
+        # hover on a faded chip: the ground one step lighter, the chip itself untouched
+        self.assertEqual(hf["docs"]["btnBg"], "rgba(255, 255, 255, 0.1)", "the hovered chip's ground is the wash: %r" % hf["docs"])
+        self.assertEqual((hf["docs"]["btnFilter"], hf["docs"]["chipClass"], hf["docs"]["chipOpacity"], hf["docs"]["chipColor"], hf["docs"]["chipBorder"]),
+                         ("none", "tag-chip-off", "0.45", rest["docs"]["chipColor"], rest["docs"]["chipBorder"]), "…and nothing about the chip changes: no brightness, no colour, still faded: %r" % hf["docs"])
+        self.assertEqual((hf["infra"]["btnBg"], hf["infra"]["btnFilter"]), ("rgba(0, 0, 0, 0)", "none"), "the other faded chip stays at rest")
+        self.assertEqual((hf["web"]["btnBg"], hf["web"]["btnFilter"]), ("rgba(0, 0, 0, 0)", "brightness(1.3)"), "the selected chip keeps its level, its own ground")
+        # hover on the selected chip: the brightness stays, the ground takes the wash
+        self.assertEqual((hs["web"]["btnFilter"], hs["web"]["btnBg"], hs["web"]["chipOpacity"]), ("brightness(1.3)", "rgba(255, 255, 255, 0.1)", "1"), "a hovered selected chip: %r" % hs["web"])
+        self.assertGreaterEqual(_wash_step(hs["web"]["btnBg"], out["surfaceDark"]), 12, "the hovered ground moves the dark card's surface by a visible step: %r over %r" % (hs["web"]["btnBg"], out["surfaceDark"]))
+        # the light theme: the wash is the darker step, distinct from the picker's card surface; the levels hold
+        hfl = {x["tag"]: x for x in out["hoverFadedLight"]["opts"]}
+        hsl = {x["tag"]: x for x in out["hoverSelLight"]["opts"]}
+        self.assertEqual((hfl["docs"]["btnBg"], hfl["docs"]["btnFilter"], hfl["docs"]["chipOpacity"]), ("rgba(0, 0, 0, 0.07)", "none", "0.45"), "light, a hovered faded chip: %r" % hfl["docs"])
+        self.assertGreaterEqual(_wash_step(hfl["docs"]["btnBg"], out["surfaceLight"]), 12, "…and moves the light card's surface by a visible step: %r over %r" % (hfl["docs"]["btnBg"], out["surfaceLight"]))
+        self.assertEqual((hsl["web"]["btnBg"], hsl["web"]["btnFilter"]), ("rgba(0, 0, 0, 0.07)", "brightness(0.75)"), "light, the hovered selected chip: the DARKER level, the wash: %r" % hsl["web"])
+        self.assertEqual((hfl["web"]["btnBg"], hfl["web"]["btnFilter"]), ("rgba(0, 0, 0, 0)", "brightness(0.75)"), "light, the selected chip at rest: darker than its rest colour, never paler")
 
 
 if __name__ == "__main__":

--- a/ui/webview/picker-tag-chips.test.ts
+++ b/ui/webview/picker-tag-chips.test.ts
@@ -26,14 +26,47 @@ test("each option is the shared tag chip: the tag's colour on a thin border, the
   assert.doesNotMatch(RENDER, /ctx-tag-dot/, "the tab menu's Tags flyout wears the chip too: no dot anywhere a tag shows (T321)");
 });
 
-test("the option wears no button chrome around the chip, selected or hovered, so the chip's border is the whole look", () => {
-  assert.match(CSS, /\n\.picker-tags \.picker-be-opt \{ padding: 0; border: none; background: transparent; font-family: inherit; \}\n/,
-    "no weight on the host (the chip carries 400) and the page's typeface: a bare button wears the browser's control face (review find, T321)");
-  assert.match(CSS, /\n\.picker-tags \.picker-be-opt:hover \{ filter: brightness\(1\.3\); \}\n/, "the hover cue is the strip's own: the chip brightened, a property the chip never sets inline");
-  assert.match(CSS, /\n\.picker-tags \.picker-be-opt:hover, \.picker-tags \.picker-be-opt\.sel \{ background: transparent; border-color: transparent; color: inherit; \}\n/,
-    "the Backend row's accent fill and hover wash never reach a tag option");
+test("the option wears no button chrome around the chip at rest, so the chip's border is the whole look", () => {
+  assert.match(CSS, /\n\.picker-tags \.picker-be-opt \{ padding: 0; border: none; background: transparent; font-family: inherit; display: inline-flex; border-radius: 9px; filter: none; \}\n/,
+    "no weight on the host (the chip carries 400) and the page's typeface: a bare button wears the browser's control face (review find, T321); the button hugs the chip and wears its radius, so a hover wash has the pill's shape (T343)");
+  assert.match(CSS, /\n\.picker-tags \.picker-be-opt\.sel \{ background: transparent; border-color: transparent; color: inherit; filter: var\(--chip-sel-filter\); \}\n/,
+    "the Backend row's accent fill never reaches a selected tag option");
   // the specificity that makes the override stick without !important: two classes beat one
   assert.ok(CSS.indexOf(".picker-be-opt.sel { background: var(--accent)") < CSS.indexOf(".picker-tags .picker-be-opt.sel {"), "the tag rule follows the generic one in the sheet");
+});
+
+// T343 (the user 2026-09-11): faded and selected read too close, and a hover looked like a selection. Three states,
+// each explicit and pinned: FADED (unselected at rest) is the off chip on a transparent ground; HOVER lightens the pill's
+// ground one step and changes no colour or brightness; SELECTED wears the brightest level, brightness(1.3), whatever the
+// hover: a themed filter, brighter on the dark card and DARKER on cream (a lift on a light card pales the chip below its
+// faded neighbour: the review's find), the dark value being the level that used to belong to a hovered chip.
+test("three chip states: faded at rest, a hover that lightens the ground only, selected at the strongest level whatever the hover (T343)", () => {
+  const rule = (sel: string) => { const m = CSS.match(new RegExp("\\n" + sel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + " \\{ ([^}]*) \\}\\n")); assert.ok(m, "rule " + sel); return m![1]; };
+  const base = rule(".picker-tags .picker-be-opt"), hover = rule(".picker-tags .picker-be-opt:hover"), sel = rule(".picker-tags .picker-be-opt.sel"), selHover = rule(".picker-tags .picker-be-opt.sel:hover");
+  // faded: the off chip (TAG_CHIP_OFF_CLASS at 0.45, tag-menu.ts) on the button's transparent ground, no filter
+  assert.match(base, /background: transparent;/); assert.match(base, /filter: none;/);
+  // hover: the ground one step lighter, and NOTHING about the chip's colour or brightness
+  assert.equal(hover, "background: var(--chip-wash); border-color: transparent; color: inherit;");
+  assert.doesNotMatch(hover, /filter|brightness|opacity/, "a hover never brightens or recolours the chip");
+  assert.doesNotMatch(CSS, /\.picker-tags \.picker-be-opt:hover \{ filter/, "the old hover brightness is gone");
+  // selected: the strongest level, on its own ground
+  assert.equal(sel, "background: transparent; border-color: transparent; color: inherit; filter: var(--chip-sel-filter);");
+  assert.equal(selHover, "background: var(--chip-wash);", "a hovered selected chip keeps its level and takes the wash");
+  // the level is themed: a lift on the dark card, a darkening on cream, each above the chip's rest contrast
+  const levels = CSS.match(/^  --chip-sel-filter: (brightness\([\d.]+\));/gm) || [];
+  assert.equal(levels.length, 2, "defined once per theme: " + levels.join(" | "));
+  assert.match(levels[0], /brightness\(1\.3\)/, "dark: brighter");
+  assert.match(levels[1], /brightness\(0\.75\)/, "light: darker");
+  assert.ok(CSS.indexOf(levels[0]) < CSS.indexOf("body.theme-light {") && CSS.indexOf(levels[1]) > CSS.indexOf("body.theme-light {"), "the dark value on the root, the light one under body.theme-light");
+  // the cascade by construction: hover, then sel at the same specificity (a selected chip's ground is its own), then sel:hover above both
+  const at = (s: string) => CSS.indexOf("\n" + s + " {");
+  assert.ok(at(".picker-tags .picker-be-opt") < at(".picker-tags .picker-be-opt:hover") && at(".picker-tags .picker-be-opt:hover") < at(".picker-tags .picker-be-opt.sel") && at(".picker-tags .picker-be-opt.sel") < at(".picker-tags .picker-be-opt.sel:hover"));
+  // the wash is themed: one value on the dark root, another on the light body, the light one a darker step that stays distinct from the card
+  const washes = CSS.match(/^  --chip-wash: (rgba\([^)]*\));/gm) || [];
+  assert.equal(washes.length, 2, "defined once per theme: " + washes.join(" | "));
+  assert.match(washes[0], /rgba\(255, 255, 255, 0\.10\)/, "dark: lighter");
+  assert.match(washes[1], /rgba\(0, 0, 0, 0\.07\)/, "light: the visible step on a light card is darker");
+  assert.ok(CSS.indexOf(washes[0]) < CSS.indexOf("body.theme-light {") && CSS.indexOf(washes[1]) > CSS.indexOf("body.theme-light {"), "the dark value on the root, the light one under body.theme-light");
 });
 
 test("the off visual is the one the tag toggles use: TAG_CHIP_OFF_CLASS at the inline opacity, defined on both sheets", () => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -104,6 +104,8 @@ body.scheme-solarized-dark {
   /* THE faint accent wash — the one alpha behind every selected/hovered accent chrome (0.10 and 0.14
      variants drifted in before 2026-08-26). Mirrored in feed.css (own :root). */
   --accent-wash: rgba(156, 210, 255, 0.12);
+  --chip-wash: rgba(255, 255, 255, 0.10);   /* a hovered tag chip's ground, one step lighter than the pill's own (T343) */
+  --chip-sel-filter: brightness(1.3);        /* a SELECTED tag chip's strongest level: brighter on the dark card (T343) */
   --tab-active-bg: rgba(255, 255, 255, 0.14);   /* the selected tab's fill, and the tag row's while its overview shows (T322) */
   /* the menu vocabulary (CLAUDE.md "Menus and dropdowns wear ONE vocabulary") — every dropdown's
      radius and shadow resolve through these; two menus had drifted onto their own shadows before
@@ -245,6 +247,8 @@ body.theme-light {
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
+  --chip-wash: rgba(0, 0, 0, 0.07);   /* a hovered tag chip's ground (T343): on a light card the visible step is darker, and it stays distinct from the card's surface */
+  --chip-sel-filter: brightness(0.75);   /* a SELECTED tag chip's strongest level on cream is DARKER (T343 review): brightness(1.3) here paled every selected chip below its faded neighbour; 0.75 lifts each tag's contrast above its rest value */
   --tab-active-bg: rgba(255, 255, 255, 0.14);   /* the same fill the dark tab wears: a whiter sheet over cream (T322) */
   --cmt-hl: #FFDF70;
   --cmt-hl-outline: #8f6a00;   /* amber ink: 4.2:1 on the cream page — the fill's yellow measures 1.1:1 there, invisible as a line (T310) */
@@ -2964,13 +2968,22 @@ body.picker-lifted > #picker.kb-tight { align-items: flex-start; padding: 12px 1
 .picker-auth-fixed { flex: 0 0 auto; color: var(--fg); font-size: 0.82em; padding: 4px 0; }
 /* the picker's Tags row (tab groups, the user 2026-09-04): one option per tag; several may be selected, a session
    can hold several tags. Each option IS the tag chip every surface draws (T321, the user 2026-09-10): the thin
-   border in the tag's colour, the faded chip (.tag-chip-off) for unselected, so the button around it carries no
-   chrome: no border, no padding, the page's typeface (a bare button wears the browser's control face), and never
-   the Backend row's accent fill or hover wash; the hover cue is the strip's own, the chip brightened */
+   border in the tag's colour, so the button around it carries no chrome: no border, no padding, the page's typeface
+   (a bare button wears the browser's control face), and never the Backend row's accent fill or hover wash. Three
+   states, each explicit (T343, the user 2026-09-11: faded and selected read too close, and a hover looked like a
+   selection): FADED, unselected at rest, is the off chip (.tag-chip-off at 0.45) on a transparent ground; HOVER
+   lightens the pill's own ground one step (--chip-wash on the button, which hugs the chip and wears its radius, so
+   the wash has the pill's shape and shows through the chip's transparent ground at full strength however faded the
+   chip) and never touches the chip's colour or brightness; SELECTED wears the STRONGEST level, the full chip
+   through --chip-sel-filter (brighter on the dark card, darker on cream: a lift on a light card pales the chip
+   below its faded neighbour, the review's find), whatever the hover, and a hovered selected chip keeps it and
+   takes the wash. The .sel rule follows the :hover rule at the same specificity, so a selected chip's ground
+   is its own; .sel:hover then adds the wash by construction. */
 .picker-tags { flex-wrap: wrap; }
-.picker-tags .picker-be-opt { padding: 0; border: none; background: transparent; font-family: inherit; }
-.picker-tags .picker-be-opt:hover, .picker-tags .picker-be-opt.sel { background: transparent; border-color: transparent; color: inherit; }
-.picker-tags .picker-be-opt:hover { filter: brightness(1.3); }
+.picker-tags .picker-be-opt { padding: 0; border: none; background: transparent; font-family: inherit; display: inline-flex; border-radius: 9px; filter: none; }
+.picker-tags .picker-be-opt:hover { background: var(--chip-wash); border-color: transparent; color: inherit; }
+.picker-tags .picker-be-opt.sel { background: transparent; border-color: transparent; color: inherit; filter: var(--chip-sel-filter); }
+.picker-tags .picker-be-opt.sel:hover { background: var(--chip-wash); }
 .picker-list { overflow-y: auto; }
 /* The resume list's heading (the user 2026-08-12): the list sits LAST in the dialog — typing in the
    name box re-filters it, and its changing height used to jump every control below it — so this line


### PR DESCRIPTION
In the new session picker's Tags row an unselected chip was faded, a hover brightened the chip (`filter: brightness(1.3)`), and a selected chip was the full chip: faded and selected read too close, and a hover looked like a selection (the user 2026-09-11).

## Three states, each explicit and pinned

- **Faded** (unselected at rest): the off chip (`.tag-chip-off` at 0.45) on the button's transparent ground, no filter.
- **Hover**: the pill's ground one step lighter. `--chip-wash` on the button, which now hugs the chip (`display: inline-flex`) and wears its radius, so the wash has the pill's shape and shows through the chip's transparent ground at full strength however faded the chip. Nothing about the chip's colour, opacity or brightness changes.
- **Selected**: the strongest level, the full chip through `--chip-sel-filter`, whatever the hover. A hovered selected chip keeps it and takes the wash (`.sel:hover`). The filter is themed: `brightness(1.3)` on the dark card (the level a hovered chip used to get), `brightness(0.75)` on cream, where a lift paled every selected chip below its faded neighbour (the review's find; the light block's convention is to darken for emphasis).

The cascade is by construction: the `:hover` rule, then `.sel` at the same specificity (a selected chip's ground is its own), then `.sel:hover` above both. `--chip-wash` is themed: `rgba(255,255,255,0.10)` on the dark root, `rgba(0,0,0,0.07)` under `body.theme-light` (on a light card the visible step is darker, and it stays distinct from the card's surface).

## Tests

- `picker-tag-chips.test.ts`: the three rules' declarations pinned exactly, the hover rule free of filter/brightness/opacity, the old hover brightness gone, the rule order, the wash and the selected filter each defined once per theme with the dark value on the root and the light one under `body.theme-light`.
- `tests/test_tag_chips_everywhere_browser.py`: on the real picker, the faded chips at rest, the selected chip at rest at `brightness(1.3)` on its own ground, a hovered faded chip (the wash; the chip untouched: no filter, still 0.45, same colour and border), a hovered selected chip (brightness kept, the wash), and the light theme: the selected chip at `brightness(0.75)`, the darker wash composited over the picker's card surface moving it by a visible step.

Screenshots of the picker with one hovered, one selected and one faded chip side by side are in the drops folder as `romp_chat-picker-tag-chips-{dark,light}.png`.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
