### PR TITLE
The message box's focus ring wears the session's identity colour, in the accent ring's own geometry (T345)

### DIFF
--- a/tests/test_session_name_served.py
+++ b/tests/test_session_name_served.py
@@ -4,6 +4,8 @@ since T335 (the user 2026-09-10) the name is painted with the strip's own percep
 with the faded placeholder text, and since T341 (the user 2026-09-11: the full fade read too faint) at HALF strength; this test
 reads the same session's at-rest label colour once the tab is inactive and requires the placeholder's name colour to sit
 halfway between it and the identity colour, dark and light (PH_SHOTS=<dir> writes screenshots of the box under the strip; PH_BEFORE_DIST=<dist> serves another tree's bundle for the before shots and skips the fade checks);
+the FOCUSED box's border is that colour too, in the accent ring's own 1px geometry, the accent its fallback (T345, the user
+2026-09-11; PH_SHOTS adds romp_chat-composer-focus-ring-{web,api}-{dark,light}.png);
 the statusline badge (the name in black on that colour) is a SETTING, off by default (the maintainers via the user,
 2026-09-10), and a flip of the setting shows it and hides it again without a reload. Skips LOUDLY when the extension deps
 or a playwright browser are absent (CI installs none). Synthetic sessions and text only."""
@@ -147,6 +149,38 @@ const probe = (cls) => page.evaluate((cls) => {
 }, cls);
 out.answering = await probe(true);
 out.resting = await probe(false);
+// ---- the focus ring (T345, the user 2026-09-11): the FOCUSED box's border is the colour of the session you are messaging, in
+// the accent ring's own geometry (a fill of the existing 1px border, no glow); the accent stays the fallback ----
+const ring = () => page.evaluate(() => {
+  const d = document.getElementById("f-chat").contentDocument; const ta = d.getElementById("composer-input"); const box = d.getElementById("composer");
+  const cs = getComputedStyle(ta);
+  const acc = d.createElement("span"); acc.style.color = "var(--accent)"; d.body.appendChild(acc); const accent = getComputedStyle(acc).color; acc.remove();
+  return { focused: d.activeElement === ta, border: cs.borderTopColor, width: cs.borderTopWidth, style: cs.borderTopStyle, shadow: cs.boxShadow, outline: cs.outlineStyle,
+           identity: box.style.getPropertyValue("--composer-identity"), accent, active: (d.querySelector("#tabs .tab.active[data-id]") || { dataset: {} }).dataset.id || null,
+           theme: d.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const ringLeg = async (sid, shotName) => {
+  await fr.click('#tabs .tab[data-id="' + sid + '"]'); await waitActive(sid);
+  await page.waitForTimeout(150);
+  const rest = await ring();                                   // the unfocused border, for the geometry comparison
+  await fr.focus("#composer-input"); await page.mouse.move(700, 500); await page.waitForTimeout(150);   // off the strip: no tab tip in the shot
+  const foc = await ring();
+  await shot(shotName);
+  await page.evaluate(() => { document.getElementById("f-chat").contentDocument.getElementById("composer-input").blur(); });
+  return { rest, foc };
+};
+out.ringDark = { a: await ringLeg(cfg.sidA, "romp_chat-composer-focus-ring-web-dark"), b: await ringLeg(cfg.sidB, "romp_chat-composer-focus-ring-api-dark") };
+await page.evaluate(() => { document.getElementById("f-chat").contentDocument.body.classList.add("theme-light"); });
+out.ringLight = { a: await ringLeg(cfg.sidA, "romp_chat-composer-focus-ring-web-light"), b: await ringLeg(cfg.sidB, "romp_chat-composer-focus-ring-api-light") };
+// the fallback: nothing published (a session with no colour) → the accent ring, probed with the variable lifted off the box
+out.ringFallback = await page.evaluate(() => {
+  const d = document.getElementById("f-chat").contentDocument; const box = d.getElementById("composer"); const ta = d.getElementById("composer-input");
+  const had = box.style.getPropertyValue("--composer-identity"); box.style.removeProperty("--composer-identity");
+  ta.focus(); const c = getComputedStyle(ta).borderTopColor; ta.blur();
+  if (had) box.style.setProperty("--composer-identity", had);
+  return c;
+});
+await page.evaluate(() => { document.getElementById("f-chat").contentDocument.body.classList.remove("theme-light"); });
 out.ms = Date.now() - out.t0;
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
@@ -344,6 +378,25 @@ class ServedSessionName(unittest.TestCase):
         self.assertEqual(a["overlay"], a["tint"], "…and the overlay wears the answering tint in its place")
         self.assertNotEqual(a["tint"], a["dim"], "the probe tells the two colours apart")
         self.assertEqual(b["native"], "rgba(0, 0, 0, 0)"); self.assertEqual(b["overlay"], b["dim"], "resting again: dim, one text")
+
+    def test_4_the_focused_box_wears_the_sessions_colour_as_its_ring_in_the_accent_rings_geometry(self):
+        # T345 (the user 2026-09-11): the thin border around the focused message box is the colour of the session you are
+        # messaging, at the accent ring's own 1px geometry; two sessions, two rings; the unfocused border is unchanged; with
+        # nothing published (a session with no colour) the ring falls back to the accent. Both themes.
+        r = self._r()
+        colors = {"a": "#e57373", "b": "#64b5f6"}
+        for theme, legs in (("dark", r["ringDark"]), ("light", r["ringLight"])):
+            for k in ("a", "b"):
+                rest, foc = legs[k]["rest"], legs[k]["foc"]
+                self.assertEqual((foc["theme"], foc["focused"], rest["focused"]), (theme, True, False), "the leg's state in %s: %r / %r" % (theme, foc, rest))
+                self.assertEqual(self._rgb(foc["border"]), self._rgb(colors[k]), "the focused border is the session's identity colour in %s: %r" % (theme, foc))
+                self.assertEqual(foc["identity"], colors[k], "…published on the box from the placeholder's own source: %r" % foc)
+                self.assertNotEqual(self._rgb(foc["border"]), self._rgb(foc["accent"]), "not the accent")
+                self.assertEqual((foc["width"], foc["style"], foc["shadow"], foc["outline"]), (rest["width"], rest["style"], rest["shadow"], rest["outline"]),
+                                 "the accent ring's geometry, untouched: a fill of the existing border, no glow, no outline: %r vs %r" % (foc, rest))
+                self.assertNotEqual(self._rgb(rest["border"]), self._rgb(foc["border"]), "the unfocused border is unchanged, not the identity colour: %r" % rest)
+            self.assertNotEqual(self._rgb(legs["a"]["foc"]["border"]), self._rgb(legs["b"]["foc"]["border"]), "two sessions, two rings")
+        self.assertEqual(self._rgb(r["ringFallback"]), self._rgb(r["ringLight"]["a"]["foc"]["accent"]), "nothing published: the accent ring (probed in light, where the accent is the warm one)")
 
 
 if __name__ == "__main__":

--- a/ui/webview/composer-placeholder.test.ts
+++ b/ui/webview/composer-placeholder.test.ts
@@ -135,3 +135,35 @@ test("one fade rule, two strengths (T341): the strip at 1, the composer's name a
   const hostFade = Number(/^#composer-ph \{[^\n]*; --host-fade: ([\d.]+); \}/m.exec(CSS)![1]);
   assert.equal(hostFade, 1 - nameFade * (1 - hostDefault), "the two midpoints agree: the host's opacity sits where the name's strength puts it");
 });
+
+// T345 (the user 2026-09-11): the thin border around the FOCUSED message box is the colour of the session you are
+// messaging, at the same 1px geometry the accent ring had. The colour is the placeholder's own source (the live session's
+// colour, else the strip's word on the tab), published once per sync as --composer-identity on #composer; the focus rule
+// reads it with the accent as the fallback, for a session with no colour or one too close to the page's luminance to read
+// as a ring (identityReadable: the strip's luminance margin, applied on both sides of the page since a light page sits
+// above every colour). The live picker's free-text tint keeps winning by construction: same specificity, later.
+test("the focused box's border is the session's identity colour, the accent its fallback; the answering tint still wins (T345)", () => {
+  const fn = RENDER.slice(RENDER.indexOf("function syncComposerPh("), RENDER.indexOf("function syncComposerPh(") + 4000);
+  assert.match(fn, /const ring = colorBg && identityReadable\(colorBg\) \? colorBg : "";/, "the placeholder's colour source, gated by the readability test");
+  assert.match(fn, /if \(box\.style\.getPropertyValue\("--composer-identity"\) !== ring\) \{\s*\n\s*if \(ring\) box\.style\.setProperty\("--composer-identity", ring\); else box\.style\.removeProperty\("--composer-identity"\);/, "published on the box, written only on a change, cleared when there is nothing to publish");
+  assert.ok(fn.indexOf("const ring = ") < fn.indexOf('const show = parts.kind === "named"'), "…before the overlay's own early returns, so a box with text or a picker up still wears the ring");
+  // the readability test shares the strip's numbers: the one luminance function and the one margin
+  assert.match(RENDER, /^const LUM_MARGIN = 38;/m);
+  assert.match(RENDER, /^function identityReadable\(hex: string\): boolean \{[\s\S]{0,400}?return Math\.abs\(lum\(c\[0\], c\[1\], c\[2\]\) - lum\(br, bgc, bb\)\) > LUM_MARGIN;/m, "both sides of the page's luminance");
+  assert.match(RENDER, /const Lc = lum\(r, g, b\), Lb = lum\(br, bgc, bb\), Lt = Lb \+ LUM_MARGIN;/, "the fade's target is the same margin");
+  // the page's colour under the picker's LIFT: the body is transparent then and its ::before backing carries var(--bg); read
+  // as black, a light page's yellow session passed the test and wore an invisible ring after the picker closed (the review)
+  const bg = RENDER.slice(RENDER.indexOf("function bgRgb("), RENDER.indexOf("function bgRgb(") + 900);
+  assert.match(bg, /const transparent = own === "transparent" \|\| \/\^rgba\\\(\[\^\)\]\*,\\s\*0\\\)\$\/\.test\(own\);/, "a transparent body is recognised");
+  assert.match(bg, /parse\(transparent \? getComputedStyle\(document\.body, "::before"\)\.backgroundColor : own\)/, "…and read as its backing");
+  assert.match(CSS, /^body\.picker-lifted::before \{ content: ""; position: absolute; inset: 0; background: var\(--bg\); z-index: -1; \}/m, "the backing the reader falls to");
+  assert.match(RENDER, /signalPickerOverlay\(false\);[^\n]*\n\s*syncComposerPh\(\);/, "the picker's close re-verdicts the ring against the page the box is back on");
+  assert.equal((RENDER.match(/0\.2126 \* /g) || []).length, 1, "one luminance formula in the file");
+  // the focus rule: the variable with the accent as its fallback, the geometry untouched (a fill of the existing 1px border)
+  assert.match(CSS, /^#composer-input:focus \{ border-color: var\(--composer-identity, var\(--accent\)\); \}$/m);
+  assert.doesNotMatch(CSS, /#composer-input:focus \{[^}]*(box-shadow|outline|border-width)/, "no glow, no layout shift: the ring is the border's colour alone");
+  // the live picker's free-text tint keeps winning while it applies: the same specificity (one id, one class or pseudo-class), later in the sheet
+  assert.match(CSS, /^#composer-input\.answering \{ border-color: var\(--accent\);/m);
+  assert.ok(CSS.indexOf("#composer-input:focus { border-color:") < CSS.indexOf("#composer-input.answering { border-color: var(--accent);"), "the answering rule follows the focus rule");
+  assert.doesNotMatch(CSS, /#composer-input:focus:not\(\.answering\)|#composer:focus-within/, "no second ring: the one border, one rule for its colour");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5112,8 +5112,14 @@ function renderTeammate(ev: Extract<ChatEvent, { kind: "teammate" }>): HTMLEleme
 
 function bgRgb(): [number, number, number] {
   try {
-    const m = /(\d+)\D+(\d+)\D+(\d+)/.exec(getComputedStyle(document.body).backgroundColor || "");
-    if (m) return [+m[1], +m[2], +m[3]];
+    const parse = (c: string): [number, number, number] | null => { const m = /(\d+)\D+(\d+)\D+(\d+)/.exec(c || ""); return m ? [+m[1], +m[2], +m[3]] : null; };
+    const own = getComputedStyle(document.body).backgroundColor || "";
+    // the picker's lift paints the body TRANSPARENT (styles.css body.picker-lifted) and backs the page with its ::before at
+    // var(--bg): a transparent body is that backing's colour, not black (T345 review: read as black, a light page's
+    // yellow session passed the ring's readability test under the lift and wore an invisible ring after it)
+    const transparent = own === "transparent" || /^rgba\([^)]*,\s*0\)$/.test(own);
+    const c = parse(transparent ? getComputedStyle(document.body, "::before").backgroundColor : own);
+    if (c) return c;
   } catch { /* ignore */ }
   return [30, 30, 30];
 }
@@ -5128,17 +5134,33 @@ const CLASSIC_FADE_SCALE = 0.9;   // T118 (the user 2026-08-27): +10% brighter f
 // covers half the perceptual distance the strip's at-rest label covers. Its host prefix sits at the matching midpoint
 // (styles.css --host-fade on #composer-ph).
 const PH_NAME_FADE = 0.5;
+const LUM_MARGIN = 38;   // the luminance step a colour must stand off the page by to read as its own (the fade's target, the ring's test)
+const lum = (x: number, y: number, z: number) => 0.2126 * x + 0.7152 * y + 0.0722 * z;
+function hexRgb(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+// Does an identity colour stand off the page enough to read as a RING around the message box (T345)? The strip's fade
+// asks a one-sided version of this (is the colour brighter than the page by the margin, so a fade has room), which on a
+// light page is true of no colour at all; a ring reads on either side of the page's luminance, so the same margin is
+// applied both ways. A colour within the margin falls back to the accent.
+function identityReadable(hex: string): boolean {
+  const c = hexRgb(hex);
+  if (!c) return false;
+  const [br, bgc, bb] = bgRgb();
+  return Math.abs(lum(c[0], c[1], c[2]) - lum(br, bgc, bb)) > LUM_MARGIN;
+}
 // `amount` is the fade's strength: 1 (the default) is the strip's at-rest fade, unchanged for tabs; 0.5 is half the way
 // from the identity colour toward the page background. It scales the one blend, so the dim-hue early return holds at every
 // strength and a light page (already past the luminance target) stays a no-op.
 function fadedColor(hex: string, amount = 1): string {
-  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
-  if (!m) return hex;
-  const n = parseInt(m[1], 16);
-  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  const c = hexRgb(hex);
+  if (!c) return hex;
+  const [r, g, b] = c;
   const [br, bgc, bb] = bgRgb();
-  const lum = (x: number, y: number, z: number) => 0.2126 * x + 0.7152 * y + 0.0722 * z;
-  const Lc = lum(r, g, b), Lb = lum(br, bgc, bb), Lt = Lb + 38;
+  const Lc = lum(r, g, b), Lb = lum(br, bgc, bb), Lt = Lb + LUM_MARGIN;
   if (Lc <= Lt) return hex; // already dim — leave it
   // Classic fades 10% less far toward the background (T118); Yatharth keeps his full fade.
   const scale = settings.chatTabTheme === "yatharth" ? 1 : CLASSIC_FADE_SCALE;
@@ -10046,6 +10068,7 @@ function closePicker() {
   const o = document.getElementById("picker");
   if (o) o.style.display = "none";
   signalPickerOverlay(false);   // release the full-window lift — the chat iframe returns to its pane
+  syncComposerPh();             // …and the box re-reads its ring against the page it is back on (T345)
   if (pickMode) {
     if (vscodeApi) vscodeApi.postMessage({ type: "pickResult", id: null });
     pickMode = false;
@@ -13266,6 +13289,14 @@ function syncComposerPh(): void {
   const live = liveSession(activeId);
   const meta = activeId ? tabMeta.get(activeId) : undefined;
   const colorBg = (live?.color?.bg || meta?.color?.bg) || null;
+  // the box's FOCUS ring wears the session's identity colour (T345, the user 2026-09-11: the thin border around the focused
+  // box should be the colour of the session you are messaging): published here, the one place that knows the active
+  // session's colour, as a variable on the box for the focus rule (styles.css #composer-input:focus) to read; the accent
+  // stays the fallback for a session with no colour, or one too close to the page's luminance to read as a ring
+  const ring = colorBg && identityReadable(colorBg) ? colorBg : "";
+  if (box.style.getPropertyValue("--composer-identity") !== ring) {
+    if (ring) box.style.setProperty("--composer-identity", ring); else box.style.removeProperty("--composer-identity");
+  }
   const parts = phParts(ta.placeholder, live?.name || meta?.name || "", activeId);   // the sid tells a remote host's prefix from a name (host-prefix.ts)
   const show = parts.kind === "named" && !ta.value && !ta.disabled && ta.offsetParent !== null;
   ph.style.display = show ? "" : "none";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -1383,10 +1383,14 @@ body.composer-resizing { cursor: ns-resize; user-select: none; }
   #composer-send:disabled { background: rgba(255, 255, 255, 0.10); color: var(--dim); opacity: 1; }
   #composer-input { min-height: 40px; border-radius: 20px; padding: 10px 14px; }
 }
-/* Cursor in the message box → a thin romp-blue border, exactly on the box edge — the same accent blue that
-   marks the focused panel (the user 2026-06-26). It only fills in the existing 1px border (no glow, no layout
-   shift), so the chat's two focus spots read clearly: the tabs, or the message box. */
-#composer-input:focus { border-color: var(--accent); }
+/* Cursor in the message box → a thin border, exactly on the box edge, in the colour of the SESSION you are messaging
+   (T345, the user 2026-09-11): --composer-identity, published on #composer by the placeholder's sync (render.ts
+   syncComposerPh) from the same source the placeholder's name uses; the accent blue that marks the focused panel
+   (the user 2026-06-26) stays the fallback for a session with no colour or one too close to the page to read as a
+   ring. It only fills in the existing 1px border (no glow, no layout shift), so the chat's two focus spots read
+   clearly: the tabs, or the message box. The live picker's free-text tint below keeps winning while it applies: its
+   rule follows this one at the same specificity, so a focused answering box wears the accent. */
+#composer-input:focus { border-color: var(--composer-identity, var(--accent)); }
 /* A live picker with a free-text path is up → the message box IS that picker's "add your own answer" field
    now (the user 2026-07-09). Tint it so it's discoverable that typing here answers the prompt (the placeholder
    also reads "add your own answer…"); the picker's controls stay visible above. */

--- a/vscode-extension/src/chat-focus-model.test.ts
+++ b/vscode-extension/src/chat-focus-model.test.ts
@@ -50,7 +50,7 @@ test("Enter from the bare chat area (no focused control) drops into the message 
 });
 
 test("the message box shows a thin accent-blue border when focused (panel-focus blue, on the border)", () => {
-  assert.match(CSS, /#composer-input:focus \{ border-color: var\(--accent\); \}/);
+  assert.match(CSS, /#composer-input:focus \{ border-color: var\(--composer-identity, var\(--accent\)\); \}/);
 });
 
 test("the tab-menu feed/mail icons use the accent blue when on (matching the timeline lanes)", () => {


### PR DESCRIPTION
The thin border around the **focused** message box was the accent blue (the 2026-06-26 rule). The user (2026-09-11) wants it in the colour of the session they are messaging, same thickness.

## Shape

- The colour is the placeholder's own source (`syncComposerPh`: the live session's colour, else the strip's word on the tab), published on `#composer` as `--composer-identity` once per sync, written only on a change and cleared when there is nothing to publish. The write sits before the overlay's early returns, so a box with text or a picker up still wears the ring.
- `#composer-input:focus { border-color: var(--composer-identity, var(--accent)); }`: the accent stays the fallback for a session with no colour, or one too close to the page's luminance to read as a ring. The geometry is untouched: a fill of the existing 1px border, no glow, no layout shift.
- The readability test (`identityReadable`) reuses the strip's luminance function and margin (`fadedColor` is refactored onto the same `LUM_MARGIN` and `lum`), applied on **both** sides of the page's luminance. The strip's own test is one-sided (is there room to fade toward the page), which on a light page is true of no colour at all; a ring reads on either side, so the same margin is applied both ways rather than a new formula.
- The live picker's free-text tint keeps winning while it applies: its rule follows the focus rule at the same specificity, pinned.
- From the review: `bgRgb`, the page colour both the fade and the ring read, treats a **transparent** body as its `::before` backing (`var(--bg)`) rather than black. Under the picker's full-window lift the body is transparent, and read as black a light page's yellow session passed the ring test and wore an invisible ring after the picker closed; `closePicker` re-syncs the box so the ring is re-read against the page it is back on.
- Kept as designed (a review note): a colour within the margin of a **dark** page (a deep red, a magenta from the shipped palettes) falls back to the accent while the name in the box keeps that colour at full strength. The fade leaves a dim colour alone; the ring falls back, per the rule for a colour too dim to read as a ring.

The ask was read as replacing the accent ring's colour, and the replacement is what is built; in the screenshots the identity ring reads clearly on its own, and a second ring beside the accent would add a line the eye has to resolve, so none is proposed.

## Tests

- `composer-placeholder.test.ts`: the writer (source, gate, before the early returns, written on change and cleared), the shared margin and the single luminance formula, the transparent-body branch of `bgRgb` and the backing it reads, the picker's close re-sync, the focus rule with the accent fallback and no glow, outline or width in it, the answering rule after it at the same specificity, no second ring.
- `tests/test_session_name_served.py`: on the real page, two sessions of different colours, dark and light: the focused border is the session's colour, the variable on the box is that colour, the ring's width, style, shadow and outline equal the unfocused box's, the unfocused border is unchanged, two sessions give two rings, and with the variable lifted off the box the ring is the accent.

Screenshots of the focused box on the two sessions, dark and light, are in the drops folder as `romp_chat-composer-focus-ring-{web,api}-{dark,light}.png`.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
