### PR TITLE
The per-session host program is on by default; the session-hosts file stays the toggle

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1058,11 +1058,15 @@ restart monitors read. Two CLIs on one conversation is the boot sweep's own row
 there. The CLI takes no lock on a transcript it resumes, so the one writer per
 conversation is entirely the lease's to keep.
 
-A session can outlive the kernel that started it. With the `session-hosts`
-setting on (a bare value file under the state directory, `on` or `off`, off
-by default; the devbox opts in first), a new session's CLI runs under a small
-per-session host process, `bin/romp-session-host`, instead of as the kernel's
-child. The host spawns the CLI from a spawn specification the kernel writes
+A session can outlive the kernel that started it. By default, on every machine
+on this version, a new session's CLI runs under a small per-session host
+process, `bin/romp-session-host`, instead of as the kernel's child. The
+`session-hosts` setting is the toggle: a bare value file under the state
+directory; write `off` to it to run a machine's sessions as plain kernel
+children again (`on`, or no file at all, leaves hosts on). It is read at each
+connect, so a flip needs no restart: a session already running as a plain
+child becomes hosted at its next respawn (one more cut, at the next kernel
+restart), a new session at once. The host spawns the CLI from a spawn specification the kernel writes
 (`hosts/<sid>/spawn.json`, the plain fields of the SDK's options, at mode 0600
 in a 0700 directory, since it carries the environment overlay), through the
 SDK's own subprocess transport, so the command line and the environment are

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1064,7 +1064,8 @@ process, `bin/romp-session-host`, instead of as the kernel's child. The
 `session-hosts` setting is the toggle: a bare value file under the state
 directory. Write `off` to it to run a machine's sessions as plain kernel
 children again; `on`, or no file at all, leaves hosts on (`on`, `1`, `true` and
-`yes` read as on, any other content as off). It is read at each connect, so a
+`yes` read as on; an empty file, or one holding only whitespace, is the default,
+on; any other content reads as off). It is read at each connect, so a
 flip needs no restart: a session already running as a plain child becomes
 hosted at its next respawn, whatever prompts it (a model or effort switch, a
 crash resume, or the next kernel restart, which cuts a plain child's turn one

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1062,11 +1062,14 @@ A session can outlive the kernel that started it. By default, on every machine
 on this version, a new session's CLI runs under a small per-session host
 process, `bin/romp-session-host`, instead of as the kernel's child. The
 `session-hosts` setting is the toggle: a bare value file under the state
-directory; write `off` to it to run a machine's sessions as plain kernel
-children again (`on`, or no file at all, leaves hosts on). It is read at each
-connect, so a flip needs no restart: a session already running as a plain
-child becomes hosted at its next respawn (one more cut, at the next kernel
-restart), a new session at once. The host spawns the CLI from a spawn specification the kernel writes
+directory. Write `off` to it to run a machine's sessions as plain kernel
+children again; `on`, or no file at all, leaves hosts on (`on`, `1`, `true` and
+`yes` read as on, any other content as off). It is read at each connect, so a
+flip needs no restart: a session already running as a plain child becomes
+hosted at its next respawn, whatever prompts it (a model or effort switch, a
+crash resume, or the next kernel restart, which cuts a plain child's turn one
+last time); a new session is hosted at once. The host spawns the CLI from a
+spawn specification the kernel writes
 (`hosts/<sid>/spawn.json`, the plain fields of the SDK's options, at mode 0600
 in a 0700 directory, since it carries the environment overlay), through the
 SDK's own subprocess transport, so the command line and the environment are

--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -2,8 +2,8 @@
 """The kernel's side of the per-session host (stage 4 of #1317, T315; kernel/session_host.py is the host,
 the T315 design note is the design): a Transport the SDK client drives over the host's Unix socket, the
 same class over an orphan journal file (one consumer path for live attach and for replay after a host
-death), the spawn specification the kernel writes for a host, the settings (the session-hosts toggle, on by default, and
-the host grace), and the host-lease classification the backend attaches by.
+death), the spawn specification the kernel writes for a host, the settings (the session-hosts toggle, on by
+default, and the host grace), and the host-lease classification the backend attaches by.
 
 The SDK's `Transport` is documented as unstable; `HostTransport` implements its six methods (connect,
 write, read_messages, close, is_ready, end_input) and a test pins the set against the abstract class.

--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -62,17 +62,22 @@ def _setting(state_dir, name: str, default: str) -> str:
     return v or default
 
 
+SESSION_HOSTS_ON_WORDS = ("on", "1", "true", "yes")
+
+
+def session_hosts_read(state_dir) -> "tuple[bool, str]":
+    """ONE read of the setting: (on, value). `value` is the file's stripped text, "" with no file. On unless the file
+    says otherwise: a machine with no file is on; an empty file (or one holding only whitespace) is the default, on; a
+    file saying off, 0, false or no is the toggle; any other word reads as off too. A caller that decides and then logs
+    reads once through this, so the decision and the value it names agree (a flip between two reads cannot contradict)."""
+    value = _setting(state_dir, SESSION_HOSTS_SETTING, "")
+    return (True if not value else value.lower() in SESSION_HOSTS_ON_WORDS), value
+
+
 def session_hosts_on(state_dir) -> bool:
-    """Whether NEW sessions start through a host: on unless the setting file says otherwise (a machine with no file
-    is on; a file saying off, 0, false or no is the toggle; an empty file is the default). Read at each connect, so a
-    flip needs no restart: a plain-child session becomes hosted at its next respawn, a new one at once."""
-    return _setting(state_dir, SESSION_HOSTS_SETTING, "on").lower() in ("on", "1", "true", "yes")
-
-
-def session_hosts_value(state_dir) -> str:
-    """The setting file's text as read (stripped), "" when there is no file: for the log line that names what the
-    machine actually wrote (any content that is not an on word turns hosts off, not only the word off)."""
-    return _setting(state_dir, SESSION_HOSTS_SETTING, "")
+    """Whether NEW sessions start through a host (session_hosts_read's verdict). Read at each connect, so a flip needs no
+    restart: a plain-child session becomes hosted at its next respawn, a new one at once."""
+    return session_hosts_read(state_dir)[0]
 
 
 def session_host_grace_s(state_dir) -> float:

--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -43,7 +43,9 @@ load_source = _ls_mod.load_source
 sh = sys.modules.get("romp_session_host") or load_source("romp_session_host", _HERE / "session_host.py")
 
 # ── settings (bare value files under the state directory, like tmux-backend) ─────────────────────
-SESSION_HOSTS_SETTING = "session-hosts"            # "on" | "off" (default off)
+SESSION_HOSTS_SETTING = "session-hosts"            # the toggle: "off" (or 0 / false / no) turns hosts off on this
+                                                   # machine; "on", or no file at all, leaves them on (on by default
+                                                   # since T348, the user 2026-09-11; off by default before)
 SESSION_HOST_GRACE_SETTING = "session-host-grace"  # seconds an unattached idle CLI lives (default 900)
 HOST_SCOPE_PREFIX = "romp-host-"
 _HOST_SCOPE_RE = re.compile(r"romp-host-([0-9a-fA-F]{1,8})-(\d+)\.scope\Z")
@@ -61,8 +63,10 @@ def _setting(state_dir, name: str, default: str) -> str:
 
 
 def session_hosts_on(state_dir) -> bool:
-    """Whether NEW sessions start through a host. Read at each connect, so a flip needs no restart."""
-    return _setting(state_dir, SESSION_HOSTS_SETTING, "off").lower() in ("on", "1", "true", "yes")
+    """Whether NEW sessions start through a host: on unless the setting file says otherwise (a machine with no file
+    is on; a file saying off, 0, false or no is the toggle; an empty file is the default). Read at each connect, so a
+    flip needs no restart: a plain-child session becomes hosted at its next respawn, a new one at once."""
+    return _setting(state_dir, SESSION_HOSTS_SETTING, "on").lower() in ("on", "1", "true", "yes")
 
 
 def session_host_grace_s(state_dir) -> float:

--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -2,8 +2,8 @@
 """The kernel's side of the per-session host (stage 4 of #1317, T315; kernel/session_host.py is the host,
 the T315 design note is the design): a Transport the SDK client drives over the host's Unix socket, the
 same class over an orphan journal file (one consumer path for live attach and for replay after a host
-death), the spawn specification the kernel writes for a host, the settings that turn hosts on, and the
-host-lease classification the backend attaches by.
+death), the spawn specification the kernel writes for a host, the settings (the session-hosts toggle, on by default, and
+the host grace), and the host-lease classification the backend attaches by.
 
 The SDK's `Transport` is documented as unstable; `HostTransport` implements its six methods (connect,
 write, read_messages, close, is_ready, end_input) and a test pins the set against the abstract class.
@@ -67,6 +67,12 @@ def session_hosts_on(state_dir) -> bool:
     is on; a file saying off, 0, false or no is the toggle; an empty file is the default). Read at each connect, so a
     flip needs no restart: a plain-child session becomes hosted at its next respawn, a new one at once."""
     return _setting(state_dir, SESSION_HOSTS_SETTING, "on").lower() in ("on", "1", "true", "yes")
+
+
+def session_hosts_value(state_dir) -> str:
+    """The setting file's text as read (stripped), "" when there is no file: for the log line that names what the
+    machine actually wrote (any content that is not an on word turns hosts off, not only the word off)."""
+    return _setting(state_dir, SESSION_HOSTS_SETTING, "")
 
 
 def session_host_grace_s(state_dir) -> float:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -9320,13 +9320,14 @@ class SdkBackend:
             # records no kernel consumed. Replay that tail through the same road (no wait: no holder to wait
             # for; no host.died row: nothing died), then clear the directory.
             await self._host_orphan_recover(sess, opts, None, msg_classes, died=False)
-        if state == "none" and not self.session_hosts_on():
+        hosts_on, hosts_value = _ht().session_hosts_read(self.state_dir)   # one read: the branch and its log agree
+        if state == "none" and not hosts_on:
             # the kill switch: with the setting file saying off nothing SPAWNS a host, whatever happened to the last
             # one; the session runs the plain SDK subprocess and the connect loop's finally closes a kernel lease.
             # Hosts are on by default (T348), so this branch runs only when the file on this machine says off.
             sess._host_intent = False
             self._log("host (%s): the session-hosts file reads %r, not an on word; running the CLI as a kernel child"
-                      % (sess.name, _ht().session_hosts_value(self.state_dir)))
+                      % (sess.name, hosts_value))
             return None
         if state == "attach":
             sess._host_is_attach = True

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -9325,7 +9325,8 @@ class SdkBackend:
             # one; the session runs the plain SDK subprocess and the connect loop's finally closes a kernel lease.
             # Hosts are on by default (T348), so this branch runs only when the file on this machine says off.
             sess._host_intent = False
-            self._log("host (%s): the session-hosts file says off; running the CLI as a kernel child" % sess.name)
+            self._log("host (%s): the session-hosts file reads %r, not an on word; running the CLI as a kernel child"
+                      % (sess.name, _ht().session_hosts_value(self.state_dir)))
             return None
         if state == "attach":
             sess._host_is_attach = True

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -9321,10 +9321,11 @@ class SdkBackend:
             # for; no host.died row: nothing died), then clear the directory.
             await self._host_orphan_recover(sess, opts, None, msg_classes, died=False)
         if state == "none" and not self.session_hosts_on():
-            # the kill switch: with the setting off nothing SPAWNS a host, whatever happened to the last one;
-            # the session runs the plain SDK subprocess and the connect loop's finally closes a kernel lease
+            # the kill switch: with the setting file saying off nothing SPAWNS a host, whatever happened to the last
+            # one; the session runs the plain SDK subprocess and the connect loop's finally closes a kernel lease.
+            # Hosts are on by default (T348), so this branch runs only when the file on this machine says off.
             sess._host_intent = False
-            self._log("host (%s): session-hosts is off; running the CLI as a kernel child" % sess.name)
+            self._log("host (%s): the session-hosts file says off; running the CLI as a kernel child" % sess.name)
             return None
         if state == "attach":
             sess._host_is_attach = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,11 @@ os.environ["GIT_AUTHOR_EMAIL"] = os.environ["GIT_COMMITTER_EMAIL"] = "tests@exam
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # inside the root; the hook records it
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
+# the postal bus port likewise (2026-09-11): a machine whose bus runs on a named port hands ROMP_POSTAL_PORT to every
+# session's shell, and a test run from one would carry the machine's name into every lab and in-process kernel; the
+# bus refuses its fixed port under a test unless the port is the run's own, which the marker beside a port says
+os.environ.pop("ROMP_POSTAL_PORT", None)
+os.environ["ROMP_POSTAL_HERMETIC"] = "1"
 # No test spawns a per-session HOST by omission (2026-09-11, T348): hosts are on by default now, so a backend built over
 # a state dir with no `session-hosts` file starts a real bin/romp-session-host for any session it connects. The root the
 # runner floors carries the toggle set to off from the start, re-asserted per test below (a test that deletes or rewrites
@@ -148,11 +153,6 @@ def _floor_session_hosts_off():
 
 
 _floor_session_hosts_off()
-# the postal bus port likewise (2026-09-11): a machine whose bus runs on a named port hands ROMP_POSTAL_PORT to every
-# session's shell, and a test run from one would carry the machine's name into every lab and in-process kernel; the
-# bus refuses its fixed port under a test unless the port is the run's own, which the marker beside a port says
-os.environ.pop("ROMP_POSTAL_PORT", None)
-os.environ["ROMP_POSTAL_HERMETIC"] = "1"
 
 # No test may resolve the REAL ~/.claude (2026-09-08): the judge module and the event model compute
 # their projects root at IMPORT from CLAUDE_CONFIG_DIR (default ~/.claude), the kernel and the SDK

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,25 @@ os.environ["GIT_AUTHOR_EMAIL"] = os.environ["GIT_COMMITTER_EMAIL"] = "tests@exam
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp(prefix="romp-tests-state-")   # inside the root; the hook records it
 os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel exports this to its sessions; it outranks the XDG floor
+# No test spawns a per-session HOST by omission (2026-09-11, T348): hosts are on by default now, so a backend built over
+# a state dir with no `session-hosts` file starts a real bin/romp-session-host for any session it connects. The root the
+# runner floors carries the toggle set to off from the start, re-asserted per test below (a test that deletes or rewrites
+# it gets it back); the deliberate hosts-on tests write `on` into their OWN state roots and are unaffected. A test that
+# builds its own bare state dir pins the setting itself (kernel/host_transport.py session_hosts_read).
+_SESSION_HOSTS_OFF = os.path.join(os.environ["XDG_STATE_HOME"], "romp", "session-hosts")
+
+
+def _floor_session_hosts_off():
+    try:
+        os.makedirs(os.path.dirname(_SESSION_HOSTS_OFF), exist_ok=True)
+        if not os.path.exists(_SESSION_HOSTS_OFF) or open(_SESSION_HOSTS_OFF).read().strip().lower() != "off":
+            with open(_SESSION_HOSTS_OFF, "w") as f:
+                f.write("off\n")
+    except OSError:
+        pass
+
+
+_floor_session_hosts_off()
 # the postal bus port likewise (2026-09-11): a machine whose bus runs on a named port hands ROMP_POSTAL_PORT to every
 # session's shell, and a test run from one would carry the machine's name into every lab and in-process kernel; the
 # bus refuses its fixed port under a test unless the port is the run's own, which the marker beside a port says
@@ -253,6 +272,14 @@ def _no_real_service_env():
 @pytest.fixture(autouse=True)
 def _no_real_claude_config():
     os.environ["CLAUDE_CONFIG_DIR"] = _CLAUDE_CONFIG
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _hosts_off_in_the_floored_root():
+    """The floored state root reads hosts OFF before every test (T348): the file is re-written when a test removed or
+    changed it, so no later test spawns a real host by omission."""
+    _floor_session_hosts_off()
     yield
 
 

--- a/tests/test_cli_scope.py
+++ b/tests/test_cli_scope.py
@@ -235,7 +235,9 @@ class _Backend(unittest.TestCase):
         self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
         if self._fake_sdk:
             fake = types.ModuleType("claude_agent_sdk")
-            fake.HookMatcher = lambda **kw: kw
+            # an attribute-bearing stand-in, like the SDK's dataclass: with hosts on (the default since T348) the
+            # options loop sets each matcher's `timeout` to the host's hook bound, which a plain dict refused
+            fake.HookMatcher = lambda **kw: types.SimpleNamespace(**kw)
             sys.modules["claude_agent_sdk"] = fake
         self.logged = []
         # A backend whose verdict is ON exports ROMP_CLI_REAL into os.environ (the SDK's version probe

--- a/tests/test_cut_turn_tree_kill.py
+++ b/tests/test_cut_turn_tree_kill.py
@@ -61,7 +61,11 @@ CLI, TOOL, LOOP, BYSTANDER, MANAGER, KERNEL, TERMINAL, LIVE = (P + 42, P + 50, P
 
 
 def _backend(d=None):
-    return sb.SdkBackend(d or tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+    d = d or tempfile.mkdtemp()
+    # hosts OFF in this bare state dir (T348: on by default): the real _boot_reconcile below starts the sessions it
+    # classes as cut, and with no file it would spawn a real bin/romp-session-host for each on a box with the SDK
+    Path(d, "session-hosts").write_text("off")
+    return sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
 
 
 class _Sess:

--- a/tests/test_env_credential_names.py
+++ b/tests/test_env_credential_names.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import sys
 import tempfile
 from types import ModuleType
+import types
 import unittest
 from unittest.mock import patch
 from romp_load import load_source
@@ -125,7 +126,9 @@ class BootWiring(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
         fake = ModuleType("claude_agent_sdk")
-        fake.HookMatcher = lambda **kw: kw
+        # an attribute-bearing stand-in, like the SDK's dataclass: with hosts on (the default since T348) the
+        # options loop sets each matcher's `timeout` to the host's hook bound, which a plain dict refused
+        fake.HookMatcher = lambda **kw: types.SimpleNamespace(**kw)
         fake.ClaudeAgentOptions = dict
         fake.ClaudeSDKClient = unittest.mock.Mock()
         for n in ("AssistantMessage", "ResultMessage", "SystemMessage"):

--- a/tests/test_host_transport.py
+++ b/tests/test_host_transport.py
@@ -55,23 +55,31 @@ class Settings(unittest.TestCase):
         self.assertTrue(ht.session_hosts_on(d), "an empty file is the default: on")
         Path(d, "session-hosts").write_text("maybe")
         self.assertFalse(ht.session_hosts_on(d), "a word that is not one of the on words is off, as before")
+        self.assertEqual(ht.session_hosts_value(d), "maybe", "the value reader hands the log line what the file holds")
+        self.assertEqual(ht.session_hosts_value(tempfile.mkdtemp()), "", "…and nothing for a machine with no file")
         self.assertIn('return _setting(state_dir, SESSION_HOSTS_SETTING, "on")', inspect.getsource(ht.session_hosts_on), "the default is the literal on")
 
     def test_the_default_is_stated_where_the_reader_and_the_docs_speak_of_it(self):
         """Every place that states the default says on (T348): the reader's comment, the backend's log line for the
         off branch, and the reference's paragraph on session hosts."""
-        src = open(os.path.join(ROOT, "kernel", "host_transport.py")).read()
-        self.assertIn("on by default\n" + " " * 51 + "# since T348", src, "the setting's comment names the default and its origin")
+        # the pins compare whitespace-FLATTENED text (comment continuations joined, line breaks folded), so a re-wrap
+        # or a re-aligned comment column leaves them standing; only the statements themselves are held
+        flat = lambda s: " ".join(re.sub(r"\n\s*#", "", s).split())
+        src = flat(open(os.path.join(ROOT, "kernel", "host_transport.py")).read())
+        self.assertIn("leaves them on (on by default since T348", src, "the setting's comment names the default and its origin")
         bsrc = open(os.path.join(ROOT, "kernel", "sdk_backend.py")).read()
-        self.assertIn('self._log("host (%s): the session-hosts file says off; running the CLI as a kernel child" % sess.name)', bsrc,
-                      "the off branch names the toggle's state honestly: the file says off")
+        self.assertIn("the session-hosts file reads %r, not an on word; running the CLI as a kernel child", bsrc,
+                      "the off branch names what the file holds: any content that is not an on word, not only off")
+        self.assertIn("_ht().session_hosts_value(self.state_dir)", bsrc, "…read through the value reader")
         self.assertNotIn("session-hosts is off;", bsrc, "the old line, which read as the default, is gone")
         doc = open(os.path.join(ROOT, "docs", "reference.md")).read()
         i = doc.index("A session can outlive the kernel that started it.")
-        para = doc[i:i + 900]
-        self.assertIn("By default, on every machine\non this version, a new session's CLI runs under a small per-session host", para)
-        self.assertIn("write `off` to it to run a machine's sessions as plain kernel\nchildren again", para)
-        self.assertNotIn("off\nby default", para, "the reference no longer says off by default")
+        para = flat(doc[i:i + 1200])
+        self.assertIn("By default, on every machine on this version, a new session's CLI runs under a small per-session host process", para)
+        self.assertIn("Write `off` to it to run a machine's sessions as plain kernel children again", para)
+        self.assertIn("`on`, `1`, `true` and `yes` read as on, any other content as off", para, "the accepted words")
+        self.assertIn("becomes hosted at its next respawn, whatever prompts it", para, "the rollout: a respawn of any kind")
+        self.assertNotIn("off by default", para, "the reference no longer says off by default")
         self.assertNotIn("the devbox opts in first", para, "the rollout wording went with the opt-in")
 
     def test_the_grace_default_and_its_file(self):
@@ -887,11 +895,11 @@ class Pins(unittest.TestCase):
         self.assertIn('user="<!-- romp-tag: " not in body["text"]', ksrc, "POST /send: an untagged send is the user's, a tagged one a machine's")
         self.assertIn('return "user" in inspect.signature(fn).parameters', ksrc, "read from the signature, so a stand-in send without the keyword is called as before")
 
-    def test_a_backend_with_hosts_off_touches_no_host_code_at_construction(self):
+    def test_construction_reads_no_setting_and_the_file_is_the_toggle_read_on_each_ask(self):
         d = tempfile.mkdtemp(); be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
-        self.assertTrue(be.session_hosts_on(), "on by default (T348)")
+        self.assertTrue(be.session_hosts_on(), "on by default (T348): a bare state dir")
         Path(d, "session-hosts").write_text("off")
-        self.assertFalse(be.session_hosts_on(), "the file is the toggle, read on each ask")
+        self.assertFalse(be.session_hosts_on(), "the file is the toggle, read on each ask, no restart")
 
     def test_host_log_rows_are_filed_once_per_line(self):
         d = tempfile.mkdtemp(); logs = []

--- a/tests/test_host_transport.py
+++ b/tests/test_host_transport.py
@@ -51,13 +51,16 @@ class Settings(unittest.TestCase):
         for word in ("on", "1", "true", "yes", "On\n"):
             Path(d, "session-hosts").write_text(word)
             self.assertTrue(ht.session_hosts_on(d), "a file saying %r stays on" % word)
-        Path(d, "session-hosts").write_text("")
-        self.assertTrue(ht.session_hosts_on(d), "an empty file is the default: on")
+        for blank in ("", "  \n\t"):
+            Path(d, "session-hosts").write_text(blank)
+            self.assertTrue(ht.session_hosts_on(d), "an empty file, or one holding only whitespace, is the default: on")
         Path(d, "session-hosts").write_text("maybe")
         self.assertFalse(ht.session_hosts_on(d), "a word that is not one of the on words is off, as before")
-        self.assertEqual(ht.session_hosts_value(d), "maybe", "the value reader hands the log line what the file holds")
-        self.assertEqual(ht.session_hosts_value(tempfile.mkdtemp()), "", "…and nothing for a machine with no file")
-        self.assertIn('return _setting(state_dir, SESSION_HOSTS_SETTING, "on")', inspect.getsource(ht.session_hosts_on), "the default is the literal on")
+        self.assertEqual(ht.session_hosts_read(d), (False, "maybe"), "one read hands the branch its verdict and the log the value")
+        self.assertEqual(ht.session_hosts_read(tempfile.mkdtemp()), (True, ""), "…and (on, nothing) for a machine with no file")
+        src = inspect.getsource(ht.session_hosts_read)
+        self.assertIn("(True if not value else value.lower() in SESSION_HOSTS_ON_WORDS), value", src, "the default is on: no file, or an empty one")
+        self.assertEqual(ht.SESSION_HOSTS_ON_WORDS, ("on", "1", "true", "yes"))
 
     def test_the_default_is_stated_where_the_reader_and_the_docs_speak_of_it(self):
         """Every place that states the default says on (T348): the reader's comment, the backend's log line for the
@@ -70,17 +73,34 @@ class Settings(unittest.TestCase):
         bsrc = open(os.path.join(ROOT, "kernel", "sdk_backend.py")).read()
         self.assertIn("the session-hosts file reads %r, not an on word; running the CLI as a kernel child", bsrc,
                       "the off branch names what the file holds: any content that is not an on word, not only off")
-        self.assertIn("_ht().session_hosts_value(self.state_dir)", bsrc, "…read through the value reader")
+        self.assertIn("hosts_on, hosts_value = _ht().session_hosts_read(self.state_dir)", bsrc,
+                      "ONE read for the branch and its log: a flip between two reads cannot log a value the branch did not decide on")
+        self.assertIn('if state == "none" and not hosts_on:', bsrc)
+        self.assertIn("% (sess.name, hosts_value))", bsrc, "the log names the value the branch read")
+        self.assertNotIn("session_hosts_value(", bsrc, "no second read of the file on that road")
         self.assertNotIn("session-hosts is off;", bsrc, "the old line, which read as the default, is gone")
         doc = open(os.path.join(ROOT, "docs", "reference.md")).read()
         i = doc.index("A session can outlive the kernel that started it.")
         para = flat(doc[i:i + 1200])
         self.assertIn("By default, on every machine on this version, a new session's CLI runs under a small per-session host process", para)
         self.assertIn("Write `off` to it to run a machine's sessions as plain kernel children again", para)
-        self.assertIn("`on`, `1`, `true` and `yes` read as on, any other content as off", para, "the accepted words")
+        self.assertIn("`on`, `1`, `true` and `yes` read as on; an empty file, or one holding only whitespace, is the default, on; any other content reads as off", para,
+                      "the accepted words, the empty file and the stray word, all three stated")
         self.assertIn("becomes hosted at its next respawn, whatever prompts it", para, "the rollout: a respawn of any kind")
         self.assertNotIn("off by default", para, "the reference no longer says off by default")
         self.assertNotIn("the devbox opts in first", para, "the rollout wording went with the opt-in")
+
+    def test_the_runners_floored_state_root_reads_hosts_off(self):
+        """The belt (T348): tests/conftest.py writes `off` into the state root it floors for the run and re-asserts it per
+        test, so no test spawns a real host by omission under the new default. Skipped outside that runner."""
+        root = os.path.join(os.environ.get("XDG_STATE_HOME", ""), "romp")
+        marker = os.path.join(root, "session-hosts")
+        if not os.path.exists(marker):
+            self.skipTest("the runner's floor (tests/conftest.py) is not in play")
+        self.assertEqual(Path(marker).read_text().strip(), "off")
+        self.assertEqual(ht.session_hosts_read(root), (False, "off"), "a fresh floored root reads hosts off")
+        Path(marker).unlink()                                     # a test that removes it gets it back before the next test
+        self.assertTrue(ht.session_hosts_on(root), "…and a bare root is on, which is exactly what the belt prevents")
 
     def test_the_grace_default_and_its_file(self):
         d = tempfile.mkdtemp()

--- a/tests/test_host_transport.py
+++ b/tests/test_host_transport.py
@@ -8,6 +8,7 @@ frame protocol), synthetic ids, no real CLI. Tests needing the SDK skip without 
 """
 import asyncio
 import importlib.util
+import inspect
 import json
 import os
 import re
@@ -40,13 +41,43 @@ SID = "11111111-2222-3333-4444-0000000000b1"
 
 
 class Settings(unittest.TestCase):
-    def test_hosts_default_off_and_the_grace_default(self):
+    def test_hosts_default_on_and_the_file_is_the_toggle(self):
+        """T348 (the user 2026-09-11): hosts are on for everyone on this version; the file turns them off per machine."""
         d = tempfile.mkdtemp()
-        self.assertFalse(ht.session_hosts_on(d))
+        self.assertTrue(ht.session_hosts_on(d), "a machine with no file is on")
+        for word in ("off", "0", "false", "no", " Off\n", "OFF"):
+            Path(d, "session-hosts").write_text(word)
+            self.assertFalse(ht.session_hosts_on(d), "the toggle: a file saying %r is off" % word)
+        for word in ("on", "1", "true", "yes", "On\n"):
+            Path(d, "session-hosts").write_text(word)
+            self.assertTrue(ht.session_hosts_on(d), "a file saying %r stays on" % word)
+        Path(d, "session-hosts").write_text("")
+        self.assertTrue(ht.session_hosts_on(d), "an empty file is the default: on")
+        Path(d, "session-hosts").write_text("maybe")
+        self.assertFalse(ht.session_hosts_on(d), "a word that is not one of the on words is off, as before")
+        self.assertIn('return _setting(state_dir, SESSION_HOSTS_SETTING, "on")', inspect.getsource(ht.session_hosts_on), "the default is the literal on")
+
+    def test_the_default_is_stated_where_the_reader_and_the_docs_speak_of_it(self):
+        """Every place that states the default says on (T348): the reader's comment, the backend's log line for the
+        off branch, and the reference's paragraph on session hosts."""
+        src = open(os.path.join(ROOT, "kernel", "host_transport.py")).read()
+        self.assertIn("on by default\n" + " " * 51 + "# since T348", src, "the setting's comment names the default and its origin")
+        bsrc = open(os.path.join(ROOT, "kernel", "sdk_backend.py")).read()
+        self.assertIn('self._log("host (%s): the session-hosts file says off; running the CLI as a kernel child" % sess.name)', bsrc,
+                      "the off branch names the toggle's state honestly: the file says off")
+        self.assertNotIn("session-hosts is off;", bsrc, "the old line, which read as the default, is gone")
+        doc = open(os.path.join(ROOT, "docs", "reference.md")).read()
+        i = doc.index("A session can outlive the kernel that started it.")
+        para = doc[i:i + 900]
+        self.assertIn("By default, on every machine\non this version, a new session's CLI runs under a small per-session host", para)
+        self.assertIn("write `off` to it to run a machine's sessions as plain kernel\nchildren again", para)
+        self.assertNotIn("off\nby default", para, "the reference no longer says off by default")
+        self.assertNotIn("the devbox opts in first", para, "the rollout wording went with the opt-in")
+
+    def test_the_grace_default_and_its_file(self):
+        d = tempfile.mkdtemp()
         self.assertEqual(ht.session_host_grace_s(d), sh.UNATTACHED_GRACE_DEFAULT_S)
-        Path(d, "session-hosts").write_text("on\n")
         Path(d, "session-host-grace").write_text("120")
-        self.assertTrue(ht.session_hosts_on(d))
         self.assertEqual(ht.session_host_grace_s(d), 120.0)
         Path(d, "session-host-grace").write_text("junk")
         self.assertEqual(ht.session_host_grace_s(d), sh.UNATTACHED_GRACE_DEFAULT_S, "junk falls back, loudly enough by being the default")
@@ -858,7 +889,9 @@ class Pins(unittest.TestCase):
 
     def test_a_backend_with_hosts_off_touches_no_host_code_at_construction(self):
         d = tempfile.mkdtemp(); be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None)
-        self.assertFalse(be.session_hosts_on())
+        self.assertTrue(be.session_hosts_on(), "on by default (T348)")
+        Path(d, "session-hosts").write_text("off")
+        self.assertFalse(be.session_hosts_on(), "the file is the toggle, read on each ask")
 
     def test_host_log_rows_are_filed_once_per_line(self):
         d = tempfile.mkdtemp(); logs = []

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2373,6 +2373,10 @@ class AskRoundTrip(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self._orig_client = _sdk.ClaudeSDKClient
 
         QUESTION = {"questions": [{
@@ -2579,6 +2583,10 @@ class CustomAnswerRoundTrip(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self.actions = []
         def notify(app, msg):
             if msg.get("type") == "askLive" and self.actions:
@@ -2626,6 +2634,10 @@ class PermissionAndPlanRoundTrip(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self.answer = "1"
         def notify(app, msg):
             if msg.get("type") == "askLive":
@@ -3963,6 +3975,10 @@ class InterruptSettlesStall(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self._orig = _sdk.ClaudeSDKClient
         import asyncio as _aio
 
@@ -4213,6 +4229,10 @@ class PendingQueueLoop(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self._orig_client = _sdk.ClaudeSDKClient
         import asyncio as _aio
 
@@ -4299,6 +4319,10 @@ class InterruptWithQueue(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self._orig = _sdk.ClaudeSDKClient
         import asyncio as _aio
 
@@ -4382,6 +4406,10 @@ class ReconnectReconcilesInflight(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
+        os.makedirs(self.d, exist_ok=True)
+        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
+        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.d, "session-hosts"), "w").write("off")
         self._orig = _sdk.ClaudeSDKClient
         import asyncio as _aio
 

--- a/tests/test_sdk_backend.py
+++ b/tests/test_sdk_backend.py
@@ -2366,6 +2366,13 @@ except Exception:
     _HAVE_SDK = False
 
 
+def _hosts_off(state_dir):
+    """A class that drives the connect loop with a fake client tests the plain-child road: hosts OFF explicitly, since
+    they are on by default (T348) and a bare state dir would send the connect to a real host spawn."""
+    os.makedirs(state_dir, exist_ok=True)
+    open(os.path.join(state_dir, "session-hosts"), "w").write("off")
+
+
 @unittest.skipUnless(_HAVE_SDK, "claude_agent_sdk not installed")
 class AskRoundTrip(unittest.TestCase):
     """Drive a full turn through a fake client and assert the AskUserQuestion
@@ -2373,10 +2380,7 @@ class AskRoundTrip(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self._orig_client = _sdk.ClaudeSDKClient
 
         QUESTION = {"questions": [{
@@ -2583,10 +2587,7 @@ class CustomAnswerRoundTrip(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self.actions = []
         def notify(app, msg):
             if msg.get("type") == "askLive" and self.actions:
@@ -2634,10 +2635,7 @@ class PermissionAndPlanRoundTrip(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self.answer = "1"
         def notify(app, msg):
             if msg.get("type") == "askLive":
@@ -3975,10 +3973,7 @@ class InterruptSettlesStall(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self._orig = _sdk.ClaudeSDKClient
         import asyncio as _aio
 
@@ -4229,10 +4224,7 @@ class PendingQueueLoop(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self._orig_client = _sdk.ClaudeSDKClient
         import asyncio as _aio
 
@@ -4319,10 +4311,7 @@ class InterruptWithQueue(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self._orig = _sdk.ClaudeSDKClient
         import asyncio as _aio
 
@@ -4406,10 +4395,7 @@ class ReconnectReconcilesInflight(unittest.TestCase):
 
     def setUp(self):
         self.d = tempfile.mkdtemp()
-        os.makedirs(self.d, exist_ok=True)
-        # this class drives the connect loop with a fake client on the plain-child road: hosts OFF explicitly, since
-        # they are on by default (T348) and a bare state dir would send the connect to a real host spawn
-        open(os.path.join(self.d, "session-hosts"), "w").write("off")
+        _hosts_off(self.d)
         self._orig = _sdk.ClaudeSDKClient
         import asyncio as _aio
 

--- a/tests/test_sdk_launch_error.py
+++ b/tests/test_sdk_launch_error.py
@@ -684,7 +684,9 @@ class TheClisStderrIsCaptured(unittest.TestCase):
 
         sess = _sess_for_options()
         fake_sdk = types.ModuleType("claude_agent_sdk")
-        fake_sdk.HookMatcher = lambda **kw: kw
+        # an attribute-bearing stand-in, like the SDK's dataclass: with hosts on (the default since T348) the
+        # options loop sets each matcher's `timeout` to the host's hook bound, which a plain dict refused
+        fake_sdk.HookMatcher = lambda **kw: types.SimpleNamespace(**kw)
         saved = sys.modules.get("claude_agent_sdk")
         sys.modules["claude_agent_sdk"] = fake_sdk
         try:

--- a/tests/test_sdk_stream_survives_handler_errors.py
+++ b/tests/test_sdk_stream_survives_handler_errors.py
@@ -1029,12 +1029,17 @@ class TheDeferredReconnectTakesTheHeldQueueWithIt(unittest.TestCase):
         self._Client.instances = []
         fake = types.ModuleType("claude_agent_sdk")
         fake.__spec__ = ModuleSpec("claude_agent_sdk", loader=None)   # sdk_importable's find_spec reads it
-        fake.ClaudeSDKClient, fake.ClaudeAgentOptions, fake.HookMatcher = self._Client, self._Options, (lambda **kw: kw)
+        # the matcher stand-in bears attributes like the SDK's dataclass: the options loop sets each matcher's `timeout`
+        # under hosts (the default since T348), which a plain dict refused
+        fake.ClaudeSDKClient, fake.ClaudeAgentOptions, fake.HookMatcher = self._Client, self._Options, (lambda **kw: types.SimpleNamespace(**kw))
         fake.AssistantMessage, fake.ResultMessage = _AssistantMessage, _ResultMessage
         fake.SystemMessage, fake.TextBlock = _SystemMessage, _TextBlock
         self._saved_sdk = sys.modules.get("claude_agent_sdk")
         sys.modules["claude_agent_sdk"] = fake
         self.state = tempfile.mkdtemp()
+        # this class runs the REAL connect loop against the fake client on the plain-child road: hosts OFF explicitly,
+        # since they are on by default (T348) and a bare state dir would send the connect to a real host spawn
+        open(os.path.join(self.state, "session-hosts"), "w").write("off")
         cwd = os.path.join(self.state, "proj")
         os.makedirs(cwd)
         self.lines = []

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -169,7 +169,9 @@ class _OptionsHarness(_Keyed):
         self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
         if self._fake_sdk:
             fake = types.ModuleType("claude_agent_sdk")
-            fake.HookMatcher = lambda **kw: kw
+            # an attribute-bearing stand-in, like the SDK's dataclass: with hosts on (the default since T348) the
+            # options loop sets each matcher's `timeout` to the host's hook bound, which a plain dict refused
+            fake.HookMatcher = lambda **kw: types.SimpleNamespace(**kw)
             sys.modules["claude_agent_sdk"] = fake
 
     def tearDown(self):

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -202,7 +202,9 @@ class _OptionsBackend(_Backend):
         self._fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
         if self._fake_sdk:
             fake = types.ModuleType("claude_agent_sdk")
-            fake.HookMatcher = lambda **kw: kw
+            # an attribute-bearing stand-in, like the SDK's dataclass: with hosts on (the default since T348) the
+            # options loop sets each matcher's `timeout` to the host's hook bound, which a plain dict refused
+            fake.HookMatcher = lambda **kw: types.SimpleNamespace(**kw)
             sys.modules["claude_agent_sdk"] = fake
 
     def tearDown(self):

--- a/tests/test_session_host_restart.py
+++ b/tests/test_session_host_restart.py
@@ -8,7 +8,8 @@ SIGTERM five seconds in (the manager's restart: a drain that now DETACHES); a se
 state directory, attaches to the live host, and the turn finishes under it: the session settles waiting, the
 old kernel's restart-cuts row has an empty cutTurns, the CLI is the same process throughout (one writer), no
 continuation notice was queued, and a host.attached row with boot true is on the ledger. A second run with
-the setting OFF pins today's behaviour (the turn is cut, a notice is queued, a new CLI pid), so the test proves
+the setting OFF (a toggled-off machine, since hosts are on by default) pins the plain child's behaviour (the turn is
+cut, a notice is queued, a new CLI pid), so the test proves
 the difference, not a constant.
 
 Hermetic: a temp state root and Claude config dir, the fake CLI as ROMP_CLAUDE_BIN, no scopes, the SDK venv
@@ -208,7 +209,7 @@ class ServedRestart(unittest.TestCase):
 
     def test_control_with_hosts_off_the_restart_cuts_the_turn(self):
         lease1, cut, queued = self._run(hosts_on=False)
-        self.assertEqual([c["sid"] for c in cut["cutTurns"]], [self.sid], "today's behaviour: the turn is cut")
+        self.assertEqual([c["sid"] for c in cut["cutTurns"]], [self.sid], "the toggled-off machine: the turn is cut")
         # the continuation notice reached the CLI (the fake logs every stdin line): a user message naming the restart
         fed = [json.loads(l) for l in Path(self.fake_log).read_text().splitlines() if l.strip()]
         users = [m for m in fed if m.get("type") == "user"]


### PR DESCRIPTION
The per-session host program is **on by default from this version** (T348, the user 2026-09-11). Every new session's CLI runs under `bin/romp-session-host` so it can outlive the kernel that started it; the `session-hosts` setting stays as the toggle.

**What changes.** `kernel/host_transport.py` reads the same bare-value file under the state directory, now with the default on: a machine with no file is on; a file saying `off` (or `0`, `false`, `no`) is off; a file saying `on` stays on; an empty or whitespace-only file is the default, on; any other word reads as off. One reader, `session_hosts_read`, returns the verdict and the value together, and the backend's off branch reads it once so the decision and the log line it writes cannot disagree across a flip; `session_hosts_on` is that read's verdict. It is read at each connect, so a flip needs no restart. Nothing else about the host program changes.

**To turn it off on a machine**, write `off` to the file:

```
echo off > ~/.local/state/romp/session-hosts
```

**Rollout.** A session already running as a plain child becomes hosted at its next respawn, whatever prompts it: a model or effort switch, a crash resume, or the next kernel restart, which cuts a plain child's turn one last time. New sessions are hosted at once.

**Every place that stated the default follows.** The setting's comment and the reader's docstring; the backend's log line for the off branch, which now names what the file holds (any content that is not one of `on`, `1`, `true`, `yes` turns hosts off, so the line reads the value rather than restating the rule); the reference's paragraph on sessions outliving the kernel (on by default, the toggle and its accepted words, the rollout; the opt-in wording is gone).

**Tests.** `tests/test_host_transport.py` Settings: the missing file, the on words, the off words, the empty file and a stray word, with the literal default and the value reader pinned; a second test holds the three places that state the default (the reader's comment, the log line, the reference paragraph) on whitespace-flattened text, so a re-wrap leaves it standing; the construction pin asserts the bare-directory default and the toggle read on each ask. The SDK's `HookMatcher` stand-in in six test harnesses (`test_session_auth.py`, `test_session_env.py`, `test_cli_scope.py`, `test_env_credential_names.py`, `test_sdk_launch_error.py`, `test_sdk_stream_survives_handler_errors.py`) was a plain dict; with hosts on the default path the options loop sets each matcher's hook bound as an attribute, which the dict refused, so the stand-in is an attribute-bearing namespace like the dataclass it stands for (one file's dict leaked into the module table and broke the others under the full run). The harnesses that drive the real connect loop with a fake client on the plain-child road (the stream-survives class and the seven SDK-gated backend classes that swap in a fake client (the ask, custom-answer and permission round trips, the pending-queue loop, the interrupt-settles-stall, interrupt-with-queue and reconnect-reconciles classes)) now write `off` to their state directory, since a bare directory would send the connect to a real host spawn. `tests/test_session_host_restart.py` still runs both states explicitly and no longer calls the off run today's behaviour. **No test spawns a host by omission.** One tree-kill test reached the real boot reconcile on a bare state dir and, with the SDK present on the developer box, would have spawned a real host: its backend helper pins `off`, and `tests/conftest.py` writes `off` into the state root it floors for the run and re-asserts it before every test, with a test pinning that a fresh floored root reads hosts off (the deliberate hosts-on end-to-end tests write `on` into their own roots and are unaffected). Checked that no test spawns a host under the new default (hosts listed after the full run: none from a test root).
