### PR TITLE
The stale-echo placer copies a turn once, so two echoes into one turn resolve their destination (T344 regression)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31270,6 +31270,10 @@ def _place_stale_echoes(turns, echoes):
     key = lambda a: (a.get("t", 0), a.get("_seq", 0))
     gaps = {}                                   # insertion index in `turns` → the echoes sent in that gap
     dest = []                                   # (the destination turn dict, echo) per echo, resolved to indexes below
+    copied = set()                              # turns copied for a write: ONCE each, so every echo destined for the
+    #                                             same turn lands in the same dict (a second copy left `dest` holding
+    #                                             an object no longer in `out`, and the index lookup below missed:
+    #                                             every feed build failed on a session with two such echoes, 2026-09-11)
     for a in sorted(echoes, key=key):
         t = a.get("t", 0)
         i = None                                # the last turn starting at or before the echo
@@ -31279,7 +31283,9 @@ def _place_stale_echoes(turns, echoes):
             else:
                 break
         if i is not None and t <= _turn_activity_end(out[i]):
-            out[i] = dict(out[i])
+            if i not in copied:
+                out[i] = dict(out[i])
+                copied.add(i)
             out[i]["atoms"] = sorted(list(out[i]["atoms"]) + [a], key=key)
             out[i]["placedEchoes"] = list(out[i].get("placedEchoes") or []) + [a.get("uuid")]
             dest.append((out[i], a))

--- a/tests/test_stale_echo_placement.py
+++ b/tests/test_stale_echo_placement.py
@@ -309,6 +309,25 @@ class StaleEchoPlacement(unittest.TestCase):
         self.assertEqual(km._last_plain_user_turn_t(merged["turns"]), T_DAY2 + 7 * 3600 + 300, "the later day's real prompt, not an echo")
         self.assertEqual(km._last_plain_user_turn_t([merged["turns"][1]]), 0, "an echo's own turn is no prompt turn")
 
+    def test_two_echoes_into_one_turns_window_land_in_one_copy_and_the_placement_returns(self):
+        # the live regression of 2026-09-11 (every feed build failed on a session with two such echoes): the
+        # second echo into the same turn re-copied it, the destinations kept the first copy, and the index
+        # lookup at the end raised KeyError. Each turn is copied once; both echoes sit in that one copy.
+        turns = _two_days()
+        e1 = _echo(T_DAY1 + 22 * 3600 + 20, key="echo:" + "aa" * 16)
+        e2 = _echo(T_DAY1 + 22 * 3600 + 40, key="echo:" + "bb" * 16, dropped=True)
+        placed_turns, placed = km._place_stale_echoes(turns, [e1, e2])
+        self.assertEqual([a["uuid"] for a in placed_turns[0]["atoms"]], ["u1", e1["uuid"], e2["uuid"], "a1"])
+        self.assertEqual(placed, ((0, e1["uuid"], False), (0, e2["uuid"], True)))
+        self.assertEqual(placed_turns[0].get("placedEchoes"), [e1["uuid"], e2["uuid"]])
+        self.assertIsNot(placed_turns[0], turns[0], "…in a copy, the parse's turn untouched")
+        self.assertEqual([a["uuid"] for a in turns[0]["atoms"]], ["u1", "a1"])
+        # the whole merge, with a third echo in the gap after that turn: every destination resolves
+        gap = _echo(T_DAY1 + 22 * 3600 + 28 * 60, key="echo:" + "cc" * 16)
+        merged, _ = self._merge(_two_days(), [e1, e2, gap])
+        self.assertEqual([t["id"] for t in merged["turns"]][::2], ["t1", "t2"])
+        self.assertEqual(merged["_placed"], ((0, e1["uuid"], False), (0, e2["uuid"], True), (1, gap["uuid"], False)))
+
     def test_the_parse_object_is_not_mutated(self):
         turns = _two_days()
         before = [(t["id"], len(t["atoms"])) for t in turns]


### PR DESCRIPTION
A live regression of the stale-echo placement (T344, merged this morning as part of #1418): `_place_stale_echoes` copied the destination turn on every echo it put into it, so a second echo into the same turn's window replaced the copy the first echo's destination record still pointed at, and the index lookup at the end raised `KeyError`. Every feed build failed on a session holding two such echoes: 238 push-build tracebacks in five minutes on the devbox kernel, the dashboard's feed reading "waiting" (found by the perf session, 2026-09-11). Tier `fix`.

Each turn is copied once (a `copied` set), so every echo destined for it lands in the same dict and every destination resolves.

Test: `tests/test_stale_echo_placement.py`, two echoes into one turn's window land in one copy and the placement returns both destinations; the whole merge resolves with a third echo in the gap after it. Red on main's kernel with `KeyError`, green with the fix; the placement suite (19) and the chat fold suite (44) pass.