### PR TITLE
A spend guard for every session: over the hourly ceiling a session is stopped, told and surfaced, once per crossing

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2370,6 +2370,28 @@ message written but never placed, a store record never finished), closes each
 one's receipt as refused, and says so once. The sidecars are yours to inspect
 or delete.
 
+## The spend ceiling
+
+Every pusher cycle the kernel reads each live session's spend rate: the
+dollars its transcript and the agent transcripts beside it (the subagents and
+workflow agents it fanned out) record over the last ten minutes, priced by the
+same per-model table the cost view uses, scaled to an hour. The data is what
+the kernel already holds for the chat and the feed (the record cache), so the
+check reads nothing new; only an agent file that changed inside the window is
+read. The ceiling is the `spend-ceiling-usd-per-hour` setting, a bare value
+file under the state directory read at each check: 1000 dollars an hour with
+no file, any number in the file, and `0` disables the guard. When a session's
+rate crosses the ceiling, once per crossing, the kernel interrupts its turn
+(the Stop button's road, so the fan-out ends at once), hands it one message in
+your voice (about how much it is spending, and to stop whatever is fanning out
+and say what it was before doing anything else), warns every connected
+dashboard with a toast naming the session, the rate and the moment, and files
+a `spend.ceiling` row in `session-events.jsonl` (with `usdPerHour`,
+`ceilingUsdPerHour` and `windowS`), which the kernel log and the error center
+carry and restart metrics count. The crossing is the event: nothing repeats
+while the rate stays high. Once the rate falls under half the ceiling a
+`spend.ceiling.cleared` row and a toast say so, and the guard is armed again.
+
 ## Restart metrics
 
 `romp restart-metrics` reads what kernel restarts do to the sessions, from the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36189,6 +36189,205 @@ def _series_index(hour_key, h0):
         return None
 
 
+# ── the SPEND GUARD (T350, the user 2026-09-11, after a team's review panels cost thousands of dollars in an hour) ──
+# A session-wide watch over each session's INSTANTANEOUS spend. Every pusher cycle reads each live session's rate over
+# the last SPEND_GUARD_WINDOW_S seconds, scaled to an hour, from data the kernel already holds: the record cache the
+# pusher serves the leaf transcript from (em._read_jsonl_incremental), plus the agent transcripts beside the leaf
+# (`<leaf stem>/subagents/*.jsonl`, the subagents and workflow agents the session fanned out; only the files that
+# changed inside the window are read), each assistant record priced by the same table the cost view uses (tokens by
+# _price_for; a response logged more than once, one per content block, counts once, at its largest usage row).
+# Over the ceiling, once per crossing: the session is INTERRUPTED (the Stop button's road, so the fan-out ends now,
+# not after the model reads a message), handed ONE message in the user's voice (no romp vocabulary; the voice test
+# renders it), every connected dashboard gets a warn toast naming the session, the rate and the moment, and one
+# session-events row (kind spend.ceiling) is filed through problem_row, so the kernel log and the error center carry it
+# and restart-metrics counts it. The crossing is the EVENT (CLAUDE.md: cards move on new information, never on a
+# per-build flap): the latch holds until the rate falls under SPEND_GUARD_REARM of the ceiling, then a cleared row
+# (spend.ceiling.cleared) and toast say so and the guard re-arms. The ceiling is a bare-value file under the state
+# directory (`spend-ceiling-usd-per-hour`, like session-hosts), read at each check: 1000 with no file, 0 disables.
+SPEND_CEILING_SETTING = "spend-ceiling-usd-per-hour"
+SPEND_CEILING_DEFAULT = 1000.0
+SPEND_GUARD_WINDOW_S = 600          # the sliding window the rate is read over
+SPEND_GUARD_REARM = 0.5             # the latch re-arms once the rate is under this share of the ceiling
+_SPEND_GUARD = {}                   # sid -> {"over": bool, "t": the crossing (or clearing) epoch, "rate": $/h then}
+
+
+def _spend_ceiling():
+    """The ceiling in dollars an hour: the setting file's number; SPEND_CEILING_DEFAULT with no file, an empty one or a
+    value that is not a number; 0 (or any negative number) disables the guard."""
+    raw = jd._state_str(SPEND_CEILING_SETTING, "")
+    if not raw:
+        return SPEND_CEILING_DEFAULT
+    try:
+        return float(raw)
+    except ValueError:
+        return SPEND_CEILING_DEFAULT
+
+
+def _spend_window_files(leaf, since):
+    """The leaf transcript and the agent transcripts beside it that changed at or after `since` (stat only)."""
+    files = [str(leaf)]
+    try:
+        sd = Path(str(leaf)).with_suffix("") / "subagents"
+        if sd.is_dir():
+            for p in sd.glob("*.jsonl"):
+                try:
+                    if p.stat().st_mtime >= since:
+                        files.append(str(p))
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return files
+
+
+def _spend_window_usd(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
+    """Dollars the session spent in the last `window_s` seconds, from the record cache: the leaf's and its agent files'
+    assistant records stamped inside the window, priced by `prices` (the merged table by default). A response logged
+    more than once (one record per content block, one message id) counts once, at its largest usage row; a record
+    whose model the table cannot place counts at the table's dearest row rather than not at all (a guard errs high)."""
+    if prices is None:
+        prices = _model_prices(int(now))
+    dearest = max(prices.values(), key=lambda p: float(p.get("out") or 0)) if prices else None
+    since = now - window_s
+    usd = 0.0
+    for f in _spend_window_files(leaf, since):
+        best, anon = {}, 0.0
+        for o in reversed(em._read_jsonl_incremental(f)):
+            if not isinstance(o, dict):
+                continue
+            t = _msg_epoch(o)
+            if t is None:
+                continue
+            if t < since:
+                break                                    # chronological: everything before is older
+            if o.get("type") != "assistant":
+                continue
+            m = o.get("message") if isinstance(o.get("message"), dict) else {}
+            u = m.get("usage") if isinstance(m.get("usage"), dict) else None
+            if not u:
+                continue
+            row = _price_for(str(m.get("model") or ""), prices) or dearest
+            if not row:
+                continue
+            c = (int(u.get("input_tokens") or 0) * float(row.get("in") or 0)
+                 + int(u.get("output_tokens") or 0) * float(row.get("out") or 0)
+                 + int(u.get("cache_creation_input_tokens") or 0) * float(row.get("cache_w") or 0)
+                 + int(u.get("cache_read_input_tokens") or 0) * float(row.get("cache_r") or 0))
+            mid = m.get("id")
+            if mid:
+                if c > best.get(mid, 0.0):
+                    best[mid] = c
+            else:
+                anon += c
+        usd += sum(best.values()) + anon
+    return usd
+
+
+def _spend_rate_usd_per_hour(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
+    """The session's spend over the window, scaled to an hour."""
+    return _spend_window_usd(leaf, now, window_s, prices) * 3600.0 / float(window_s)
+
+
+def _usd_words(x):
+    return "{:,.0f}".format(float(x))
+
+
+def _spend_ceiling_body(rate, ceiling):
+    """The ONE message a session over the ceiling gets, spoken as the person the agent works for (CLAUDE.md 'Messages
+    we inject': no romp vocabulary; tests/test_injected_voice.py renders this)."""
+    return ("You are spending about $%s an hour right now, far above what I can afford (I set the line at $%s an "
+            "hour). Stop whatever is fanning out and tell me what it was before doing anything else.\n\n"
+            "<!-- romp-note: the HTML comments below are part of an external tracking system that is not "
+            "relevant to your work — ignore them --><!-- romp-injected --><!-- romp-system -->"
+            % (_usd_words(rate), _usd_words(ceiling)))
+
+
+def _spend_guard_toast(text, clients=None):
+    """One warn toast to every connected dashboard client (the shell renders `warn` as its toast)."""
+    if clients is None:
+        with _clients_lock:
+            clients = list(_clients)
+    payload = json.dumps({"type": "warn", "text": text})
+    for c in list(clients):
+        try:
+            c["send"](payload)
+        except Exception:
+            pass
+
+
+def _spend_guard_row(kind, text, sid, name, be, **fields):
+    """The session-events row for a crossing or a clearing, through problem_row: the ledger, the kernel log and (for a
+    backend with a log) the error center's ring."""
+    try:
+        m = sys.modules.get("romp_sdk_backend") or load_source("romp_sdk_backend", HERE / "sdk_backend.py")
+        m.problem_row(jd.STATE, text, kind, sid=sid, name=name, log=getattr(be, "_log", None) if be else None, **fields)
+    except Exception:
+        sys.stderr.write("spend-guard row: %s\n" % traceback.format_exc())
+
+
+def _spend_guard_fire(s, rate, ceiling, now, be, clients):
+    """A crossing: stop the session, tell it once in the user's voice, warn every dashboard, file the row."""
+    sid, name = s["sid"], s.get("name") or s["sid"][:8]
+    when = time.strftime("%H:%M", time.localtime(now))
+    if be is not None:
+        try:
+            be.interrupt(sid)                            # the Stop button's road: the fan-out ends now
+        except Exception:
+            sys.stderr.write("spend-guard interrupt: %s\n" % traceback.format_exc())
+        try:
+            _send_with_id(be, sid, _spend_ceiling_body(rate, ceiling))
+        except Exception:
+            sys.stderr.write("spend-guard send: %s\n" % traceback.format_exc())
+    text = ("%s was spending about $%s an hour at %s, over the $%s an hour ceiling; it has been stopped and told."
+            % (name, _usd_words(rate), when, _usd_words(ceiling)))
+    _spend_guard_toast(text, clients)
+    _spend_guard_row("spend.ceiling", text, sid, name, be, t=int(now), usdPerHour=round(float(rate), 2),
+                     ceilingUsdPerHour=float(ceiling), windowS=SPEND_GUARD_WINDOW_S)   # t: the crossing's moment
+
+
+def _spend_guard_clear(s, rate, ceiling, now, be, clients):
+    """The rate fell under the re-arm level: say so where the crossing was said, and file the clearing."""
+    sid, name = s["sid"], s.get("name") or s["sid"][:8]
+    text = "%s is back under the spend ceiling (about $%s an hour now)." % (name, _usd_words(rate))
+    _spend_guard_toast(text, clients)
+    _spend_guard_row("spend.ceiling.cleared", text, sid, name, be, t=int(now), usdPerHour=round(float(rate), 2),
+                     ceilingUsdPerHour=float(ceiling), windowS=SPEND_GUARD_WINDOW_S)
+
+
+def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, prices=None):
+    """The pusher job: every live session's rate against the ceiling, the latch per session. `sessions`, `be`, `clients`
+    and `prices` are seams for the tests; the pusher passes none of them."""
+    ceiling = _spend_ceiling()
+    if ceiling <= 0:
+        _SPEND_GUARD.clear()                             # disabled: nothing latched survives the disable
+        return
+    rows = _alive_sessions(now, live_map) if sessions is None else sessions
+    if be is None:
+        be = _sdk_backend or None
+    if prices is None:
+        prices = _model_prices(int(now))
+    live = set()
+    for s in rows:
+        sid, path = s.get("sid"), s.get("path")
+        if not sid or not path:
+            continue
+        live.add(sid)
+        try:
+            rate = _spend_rate_usd_per_hour(path, now, prices=prices)
+        except Exception:
+            sys.stderr.write("spend-guard rate (%s): %s\n" % (sid[:8], traceback.format_exc()))
+            continue
+        st = _SPEND_GUARD.get(sid)
+        if rate >= ceiling and not (st and st.get("over")):
+            _SPEND_GUARD[sid] = {"over": True, "t": now, "rate": rate}
+            _spend_guard_fire(s, rate, ceiling, now, be, clients)
+        elif st and st.get("over") and rate < ceiling * SPEND_GUARD_REARM:
+            _SPEND_GUARD[sid] = {"over": False, "t": now, "rate": rate}
+            _spend_guard_clear(s, rate, ceiling, now, be, clients)
+    for sid in [k for k in _SPEND_GUARD if k not in live]:
+        _SPEND_GUARD.pop(sid, None)                      # a session that left the live map takes its latch with it
+
+
 def _spend_series(keyed_only=False, now=None):
     """The hover graph's money-rate series (the user 2026-08-13): $/hour over the last 192 hours, a
     DENSE array plus a base hour (h0, epoch-hours), so cross-host summing is an index-wise add after
@@ -45333,6 +45532,10 @@ def _pusher_cycle_jobs(now, live_map, any_client):
         _auto_pause_on_spend_limit(now, live_map)
     except Exception:
         sys.stderr.write("auto-pause-on-spend-limit: %s\n" % traceback.format_exc())
+    try:                                  # the spend guard (T350): a session over the hourly ceiling is stopped and told,
+        _spend_guard_tick(now, live_map)      # every dashboard warned, a session-events row filed, once per crossing
+    except Exception:
+        sys.stderr.write("spend-guard: %s\n" % traceback.format_exc())
     try:                                  # a paused retry auto-clears once any session serves a request again
         _auto_resume_retry(now, live_map)
     except Exception:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36213,7 +36213,13 @@ SPEND_GUARD_MEMO_SLACK_S = 60       # a file's window rows are scanned this much
 SPEND_GUARD_LATCH_MAX = 1000        # latch entries kept for sessions no longer live (the oldest go first)
 _SPEND_GUARD = {}                   # sid -> {"over": bool, "t": the crossing (or clearing) epoch, "rate": $/h then}
 _SPEND_GUARD_SEEDED = [False]       # the latch was read back from the ledger once this kernel life
-_SPEND_ROWS_CACHE = {}              # file -> ((mtime, size), floor, [(t, usd), ...]): the window rows, memoized on the stamp
+_SPEND_ROWS_CACHE = {}              # file -> ((mtime, size, base), floor, [(t, usd), ...], last use): the window rows, memoized on the stamp
+SPEND_GUARD_ROWS_CACHE_MAX = 4000   # window-row memo entries kept; over it the least recently used go (a kernel life sees
+#                                     thousands of finished agent files, each a window row list nobody asks for again)
+SPEND_GUARD_TREE_RESCAN_S = 30      # a COLD agent file (idle since before the window's floor) is statted again this often,
+#                                     not every cycle; a hot one every cycle
+_SPEND_TREE_CACHE = {}              # leaf -> {"dirs": {dir: mtime}, "files": {path: mtime}, "full": epoch of the last full
+#                                     stat pass, "seen": epoch}: the session's subagents tree, watched by directory mtimes
 
 
 def _spend_ceiling():
@@ -36232,19 +36238,89 @@ def _spend_ceiling():
     return v
 
 
-def _spend_window_files(leaf, since):
-    """The leaf transcript and every agent transcript beside it that changed at or after `since`: the kernel's one
-    recursive walk of the session's subagents tree (_subagent_transcripts: Task agents at the top, Workflow agents one
-    level down under workflows/wf_<id>/, sibling agents after a /clear fork, no symlink followed), each file kept on a
-    stat of its own. A flat listing missed every workflow agent, the very fan-out the guard exists for (the review)."""
-    files = [str(leaf)]
-    for p in _subagent_transcripts(leaf):
+def _spend_tree_list_dir(d, m, known):
+    """One directory of a session's subagents tree listed (os.scandir): its .jsonl files into the memo with their mtimes,
+    its subdirectories with theirs, recursing only into a subdirectory not yet known (a new workflow directory), so
+    re-listing a known directory that changed costs one listing, not the tree's. _subagent_transcripts' rule holds: no
+    symlink is followed or kept (a directory or a file), the session's own tree only."""
+    try:
+        with os.scandir(d) as it:
+            entries = list(it)
+    except OSError:
+        return
+    for e in entries:
         try:
-            if os.stat(p).st_mtime >= since:
-                files.append(p)
+            if e.is_symlink():
+                continue
+            if e.is_dir(follow_symlinks=False):
+                new = e.path not in known
+                m["dirs"][e.path] = e.stat(follow_symlinks=False).st_mtime
+                if new:
+                    known.add(e.path)
+                    _spend_tree_list_dir(e.path, m, known)
+            elif e.name.endswith(".jsonl") and e.is_file(follow_symlinks=False):
+                m["files"][e.path] = e.stat(follow_symlinks=False).st_mtime
         except OSError:
-            pass
-    return files
+            continue
+
+
+def _spend_window_files(leaf, since, now=None):
+    """The leaf transcript and every agent transcript beside it that changed at or after `since` (Task agents at the top
+    of <sid>/subagents/, Workflow agents under workflows/wf_<id>/, the recursive tree the review asked for), from a memo
+    of the session's tree rather than a walk per call (the round-two review's MEDIUM: the walk ran per live session on
+    the pusher's 2 Hz loop, 26.6 ms of CPU a call on a 2,449-file tree against 0.4 ms for the flat glob before it, and
+    the three largest trees together would have held a sixth of a core for good while a handful of their files were in
+    the window). The memo keeps every directory's mtime and every file's. A cycle stats the directories (a new file or
+    subdirectory moves its parent's mtime; a changed directory is listed again, recursing only into directories not yet
+    known), stats the HOT files every cycle (mtime at or after the window's floor, SPEND_GUARD_MEMO_SLACK_S before
+    `since`: a file that may still be growing is never read stale), and the COLD ones once per SPEND_GUARD_TREE_RESCAN_S,
+    so an agent that wakes after a long tool call is seen within that bound, a twentieth of the window. The first call
+    lists the tree whole. Steady state per cycle: one stat per directory plus one per hot file."""
+    now = time.time() if now is None else now
+    key = str(leaf)
+    base, ext = os.path.splitext(key)
+    root = os.path.join(base, "subagents")
+    m = _SPEND_TREE_CACHE.get(key)
+    if m is None:
+        if ext != ".jsonl" or os.path.islink(root) or not os.path.isdir(root):
+            return [key]
+        m = {"dirs": {}, "files": {}, "full": now, "seen": now}
+        try:
+            m["dirs"][root] = os.stat(root).st_mtime
+        except OSError:
+            return [key]
+        _spend_tree_list_dir(root, m, set(m["dirs"]))
+        _SPEND_TREE_CACHE[key] = m
+        if len(_SPEND_TREE_CACHE) > SPEND_GUARD_LATCH_MAX:
+            for k in sorted(_SPEND_TREE_CACHE, key=lambda k: _SPEND_TREE_CACHE[k]["seen"])[:len(_SPEND_TREE_CACHE) - SPEND_GUARD_LATCH_MAX]:
+                _SPEND_TREE_CACHE.pop(k, None)
+    else:
+        m["seen"] = now
+        for d, mt in list(m["dirs"].items()):
+            try:
+                cur = os.stat(d).st_mtime
+            except OSError:
+                m["dirs"].pop(d, None)                       # a directory gone, its files with it
+                for p in [p for p in m["files"] if p.startswith(d + os.sep)]:
+                    m["files"].pop(p, None)
+                continue
+            if cur != mt:
+                m["dirs"][d] = cur
+                _spend_tree_list_dir(d, m, set(m["dirs"]))
+        if root not in m["dirs"]:
+            _SPEND_TREE_CACHE.pop(key, None)                 # the tree is gone: listed afresh if it returns
+            return [key]
+        full = now - m["full"] >= SPEND_GUARD_TREE_RESCAN_S
+        floor = since - SPEND_GUARD_MEMO_SLACK_S
+        for p, mt in list(m["files"].items()):
+            if full or mt >= floor:
+                try:
+                    m["files"][p] = os.stat(p).st_mtime
+                except OSError:
+                    m["files"].pop(p, None)
+        if full:
+            m["full"] = now
+    return [key] + [p for p, mt in m["files"].items() if mt >= since]
 
 
 def _spend_file_rows(f, since, prices, dearest):
@@ -36260,9 +36336,13 @@ def _spend_file_rows(f, since, prices, dearest):
     if ent is None:
         _SPEND_ROWS_CACHE.pop(f, None)
         return []
-    stamp = (ent[0], ent[1])
+    stamp = (ent[0], ent[1], ent[5])                     # mtime, size, and the entry's BASE (the round-two review's LOW a):
+    #   a tail entry accepted after a restart holds the records past the checkpoint's cut, and a later whole-file
+    #   upgrade of the same file (base 0) changes what the window can see without moving mtime or size; the base in
+    #   the stamp invalidates the memo the moment the entry's shape changes, not when the file next grows
     hit = _SPEND_ROWS_CACHE.get(f)
     if hit is not None and hit[0] == stamp and hit[1] <= since:
+        _SPEND_ROWS_CACHE[f] = (hit[0], hit[1], hit[2], time.time())
         return [r for r in hit[2] if r[0] >= since]
     floor = since - SPEND_GUARD_MEMO_SLACK_S
     best, rows = {}, []
@@ -36297,7 +36377,12 @@ def _spend_file_rows(f, since, prices, dearest):
                 rows[i] = (rows[i][0], c)
         else:
             rows.append((t, c))
-    _SPEND_ROWS_CACHE[f] = (stamp, floor, rows)
+    _SPEND_ROWS_CACHE[f] = (stamp, floor, rows, time.time())
+    if len(_SPEND_ROWS_CACHE) > SPEND_GUARD_ROWS_CACHE_MAX:
+        # the least recently used go (LOW b): a finished agent file's rows are asked for while it is in the window and
+        # never again; without a bound a kernel life would hold one list per agent it ever priced
+        for k in sorted(_SPEND_ROWS_CACHE, key=lambda k: _SPEND_ROWS_CACHE[k][3])[:len(_SPEND_ROWS_CACHE) - SPEND_GUARD_ROWS_CACHE_MAX]:
+            _SPEND_ROWS_CACHE.pop(k, None)
     return [r for r in rows if r[0] >= since]
 
 
@@ -36308,7 +36393,7 @@ def _spend_window_usd(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
         prices = _model_prices(int(now), refresh=False)   # never a network fetch from the pusher's path
     dearest = max(prices.values(), key=lambda p: float(p.get("out") or 0)) if prices else None
     since = now - window_s
-    return sum(c for f in _spend_window_files(leaf, since) for _t, c in _spend_file_rows(f, since, prices, dearest))
+    return sum(c for f in _spend_window_files(leaf, since, now) for _t, c in _spend_file_rows(f, since, prices, dearest))
 
 
 def _spend_guard_seed():
@@ -36391,10 +36476,18 @@ def _spend_guard_stop(sid, be, now):
     interrupt-clicked stamp the chip reads, the retry suppression that keeps the auto-retry and the idle-queue drive
     from re-driving the session while the latch holds, and the views marked dirty. Not pressed while an interrupt is
     already unsettled for the sid (the escalation ladder would climb to SIGINT and SIGKILL on a second press). Returns
-    "stopped", "stopping" (a stop already in flight), or "refused" (the backend would not, or owns no such session)."""
+    "stopped", "stopping" (a stop already in flight), "detached" (a hosted session whose host keeps the turn: not
+    pressed), or "refused" (the backend would not, or owns no such session)."""
     t0 = _interrupt_clicked.get(str(sid))
     if t0 is not None and now - t0 <= 120:
         return "stopping"
+    sessions = getattr(be, "sessions", None)
+    if getattr(sessions.get(sid) if isinstance(sessions, dict) else None, "detached", False):
+        # a DETACHED hosted session (the round-two review's LOW c): the backend's interrupt answers True while the CLI's
+        # escalation is skipped on purpose (its host keeps the turn), so nothing would stop and the sentence would say it
+        # had. Read before pressing, said as it is. No road to the host exists without pressing: the host's signal rung
+        # is the very escalation the detached state skips
+        return "detached"
     try:
         stopped = bool(be.interrupt(sid))
     except Exception:
@@ -36428,16 +36521,18 @@ def _spend_guard_fire(s, rate, ceiling, now, be, clients):
         told = False
     outcome = {("stopped", True): "it has been stopped and told",
                ("stopping", True): "a stop was already in flight, and it has been told",
-               ("refused", True): "it could not be stopped (the interrupt was refused: detached, or no backend owns it) but has been told",
+               ("detached", True): "its host keeps the turn, so it was not stopped, but it has been told",
+               ("refused", True): "it could not be stopped (the interrupt was refused: no backend owns it) but has been told",
                ("stopped", False): "it has been stopped, but the message was refused",
                ("stopping", False): "a stop was already in flight, and the message was refused",
+               ("detached", False): "its host keeps the turn, so it was not stopped, and the message was refused",
                ("refused", False): "it could not be stopped or told (no backend owns it)"}[(stop, told)]
     text = ("%s was spending about $%s an hour at %s, over the $%s an hour ceiling; %s."
             % (name, _usd_words(rate), when, _usd_words(ceiling), outcome))
     _spend_guard_toast(text, clients, sid=sid, name=name, phase="over", usdPerHour=round(float(rate), 2), t=int(now))
     _spend_guard_row("spend.ceiling", text, sid, name, be, t=int(now), usdPerHour=round(float(rate), 2),
                      ceilingUsdPerHour=float(ceiling), windowS=SPEND_GUARD_WINDOW_S,
-                     stopped=(stop == "stopped"), stopping=(stop == "stopping"), told=told)   # t: the crossing's moment
+                     stopped=(stop == "stopped"), stopping=(stop == "stopping"), detached=(stop == "detached"), told=told)   # t: the crossing's moment
 
 
 def _spend_guard_clear(s, rate, ceiling, now, be, clients):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36208,84 +36208,137 @@ SPEND_CEILING_SETTING = "spend-ceiling-usd-per-hour"
 SPEND_CEILING_DEFAULT = 1000.0
 SPEND_GUARD_WINDOW_S = 600          # the sliding window the rate is read over
 SPEND_GUARD_REARM = 0.5             # the latch re-arms once the rate is under this share of the ceiling
+SPEND_GUARD_MEMO_SLACK_S = 60       # a file's window rows are scanned this much further back than the window, so the
+#                                     memo serves the next cycles' (later) windows without a re-scan
+SPEND_GUARD_LATCH_MAX = 1000        # latch entries kept for sessions no longer live (the oldest go first)
 _SPEND_GUARD = {}                   # sid -> {"over": bool, "t": the crossing (or clearing) epoch, "rate": $/h then}
+_SPEND_GUARD_SEEDED = [False]       # the latch was read back from the ledger once this kernel life
+_SPEND_ROWS_CACHE = {}              # file -> ((mtime, size), floor, [(t, usd), ...]): the window rows, memoized on the stamp
 
 
 def _spend_ceiling():
-    """The ceiling in dollars an hour: the setting file's number; SPEND_CEILING_DEFAULT with no file, an empty one or a
-    value that is not a number; 0 (or any negative number) disables the guard."""
+    """The ceiling in dollars an hour: the setting file's number; SPEND_CEILING_DEFAULT with no file, an empty one, a
+    value that is not a number, or one that is not a finite non-negative number (nan, inf, a negative); exactly 0
+    disables the guard."""
     raw = jd._state_str(SPEND_CEILING_SETTING, "")
     if not raw:
         return SPEND_CEILING_DEFAULT
     try:
-        return float(raw)
+        v = float(raw)
     except ValueError:
         return SPEND_CEILING_DEFAULT
+    if not math.isfinite(v) or v < 0:
+        return SPEND_CEILING_DEFAULT
+    return v
 
 
 def _spend_window_files(leaf, since):
-    """The leaf transcript and the agent transcripts beside it that changed at or after `since` (stat only)."""
+    """The leaf transcript and every agent transcript beside it that changed at or after `since`: the kernel's one
+    recursive walk of the session's subagents tree (_subagent_transcripts: Task agents at the top, Workflow agents one
+    level down under workflows/wf_<id>/, sibling agents after a /clear fork, no symlink followed), each file kept on a
+    stat of its own. A flat listing missed every workflow agent, the very fan-out the guard exists for (the review)."""
     files = [str(leaf)]
-    try:
-        sd = Path(str(leaf)).with_suffix("") / "subagents"
-        if sd.is_dir():
-            for p in sd.glob("*.jsonl"):
-                try:
-                    if p.stat().st_mtime >= since:
-                        files.append(str(p))
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    for p in _subagent_transcripts(leaf):
+        try:
+            if os.stat(p).st_mtime >= since:
+                files.append(p)
+        except OSError:
+            pass
     return files
 
 
+def _spend_file_rows(f, since, prices, dearest):
+    """One file's (t, usd) rows at or after `since`, from the record cache, memoized on the file's (mtime, size) stamp:
+    a file that did not change since its last scan serves its rows without a walk (LOW 2 of the review). The scan runs
+    from the tail back to SPEND_GUARD_MEMO_SLACK_S before `since`, so the memo also serves the next cycles, whose windows
+    start later; a response logged more than once (one record per content block, one message id) is one row at its
+    largest usage; a record whose model the table cannot place is priced at the table's dearest row (a guard errs high).
+    The reader's entry is taken with a TAIL accepted (T323 stage 4a): after a restart the assembly checkpoint restores
+    a file as the records past its cut, and the whole-file road would upgrade that entry to a full re-read of every live
+    transcript on the guard's first cycle; the window wants the newest records, which a tail holds."""
+    ent = em._read_jsonl_entry(f, tail_ok=True)
+    if ent is None:
+        _SPEND_ROWS_CACHE.pop(f, None)
+        return []
+    stamp = (ent[0], ent[1])
+    hit = _SPEND_ROWS_CACHE.get(f)
+    if hit is not None and hit[0] == stamp and hit[1] <= since:
+        return [r for r in hit[2] if r[0] >= since]
+    floor = since - SPEND_GUARD_MEMO_SLACK_S
+    best, rows = {}, []
+    for o in reversed(ent[4]):
+        if not isinstance(o, dict):
+            continue
+        t = _msg_epoch(o)
+        if t is None:
+            continue
+        if t < floor:
+            break                                        # chronological: everything before is older
+        if o.get("type") != "assistant":
+            continue
+        m = o.get("message") if isinstance(o.get("message"), dict) else {}
+        u = m.get("usage") if isinstance(m.get("usage"), dict) else None
+        if not u:
+            continue
+        row = _price_for(str(m.get("model") or ""), prices) or dearest
+        if not row:
+            continue
+        c = (int(u.get("input_tokens") or 0) * float(row.get("in") or 0)
+             + int(u.get("output_tokens") or 0) * float(row.get("out") or 0)
+             + int(u.get("cache_creation_input_tokens") or 0) * float(row.get("cache_w") or 0)
+             + int(u.get("cache_read_input_tokens") or 0) * float(row.get("cache_r") or 0))
+        mid = m.get("id")
+        if mid:
+            i = best.get(mid)
+            if i is None:
+                best[mid] = len(rows)
+                rows.append((t, c))
+            elif c > rows[i][1]:
+                rows[i] = (rows[i][0], c)
+        else:
+            rows.append((t, c))
+    _SPEND_ROWS_CACHE[f] = (stamp, floor, rows)
+    return [r for r in rows if r[0] >= since]
+
+
 def _spend_window_usd(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
-    """Dollars the session spent in the last `window_s` seconds, from the record cache: the leaf's and its agent files'
-    assistant records stamped inside the window, priced by `prices` (the merged table by default). A response logged
-    more than once (one record per content block, one message id) counts once, at its largest usage row; a record
-    whose model the table cannot place counts at the table's dearest row rather than not at all (a guard errs high)."""
+    """Dollars the session spent in the last `window_s` seconds: the leaf's and its agent files' rows in the window
+    (_spend_file_rows), priced by `prices` (the merged table by default, without the feed refresh)."""
     if prices is None:
         prices = _model_prices(int(now), refresh=False)   # never a network fetch from the pusher's path
     dearest = max(prices.values(), key=lambda p: float(p.get("out") or 0)) if prices else None
     since = now - window_s
-    usd = 0.0
-    for f in _spend_window_files(leaf, since):
-        best, anon = {}, 0.0
-        # the reader's entry with a TAIL accepted (T323 stage 4a): after a restart the assembly checkpoint restores a
-        # file as the records past its cut, and the whole-file road (_read_jsonl_incremental) would upgrade that entry
-        # to a full re-read of every live transcript on the guard's first cycle; the window wants the newest records,
-        # which a tail holds. A tail cut inside the window undercounts the minutes before the cut on that first cycle.
-        ent = em._read_jsonl_entry(f, tail_ok=True)
-        for o in reversed(ent[4] if ent is not None else []):
-            if not isinstance(o, dict):
-                continue
-            t = _msg_epoch(o)
-            if t is None:
-                continue
-            if t < since:
-                break                                    # chronological: everything before is older
-            if o.get("type") != "assistant":
-                continue
-            m = o.get("message") if isinstance(o.get("message"), dict) else {}
-            u = m.get("usage") if isinstance(m.get("usage"), dict) else None
-            if not u:
-                continue
-            row = _price_for(str(m.get("model") or ""), prices) or dearest
-            if not row:
-                continue
-            c = (int(u.get("input_tokens") or 0) * float(row.get("in") or 0)
-                 + int(u.get("output_tokens") or 0) * float(row.get("out") or 0)
-                 + int(u.get("cache_creation_input_tokens") or 0) * float(row.get("cache_w") or 0)
-                 + int(u.get("cache_read_input_tokens") or 0) * float(row.get("cache_r") or 0))
-            mid = m.get("id")
-            if mid:
-                if c > best.get(mid, 0.0):
-                    best[mid] = c
-            else:
-                anon += c
-        usd += sum(best.values()) + anon
-    return usd
+    return sum(c for f in _spend_window_files(leaf, since) for _t, c in _spend_file_rows(f, since, prices, dearest))
+
+
+def _spend_guard_seed():
+    """Read the latch back from the ledger once per kernel life (MEDIUM 1 of the review): the last spend.ceiling or
+    spend.ceiling.cleared row per session says whether that session stands over the ceiling, so a restarted kernel
+    does not fire the same crossing again on the same window (a second interrupt, a second message, a second row with
+    no clearing between). The rows are the durable record; nothing else is mirrored."""
+    if _SPEND_GUARD_SEEDED[0]:
+        return
+    _SPEND_GUARD_SEEDED[0] = True
+    try:
+        lines = (jd.STATE / "session-events.jsonl").read_text(encoding="utf-8").splitlines()[-SESSION_EVENTS_TAIL:]
+    except OSError:
+        return
+    for ln in lines:
+        try:
+            r = json.loads(ln)
+        except Exception:
+            continue
+        if not isinstance(r, dict) or r.get("kind") not in ("spend.ceiling", "spend.ceiling.cleared") or not r.get("sid"):
+            continue
+        cur = _SPEND_GUARD.get(str(r["sid"]))
+        if cur is not None and not cur.get("seeded"):
+            continue                                     # a verdict this life already made outranks the ledger's
+        try:
+            rate = float(r.get("usdPerHour") or 0)
+        except (TypeError, ValueError):
+            rate = 0.0
+        _SPEND_GUARD[str(r["sid"])] = {"over": r["kind"] == "spend.ceiling", "t": float(r.get("t") or 0), "rate": rate,
+                                       "seeded": True}
 
 
 def _spend_rate_usd_per_hour(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
@@ -36307,12 +36360,15 @@ def _spend_ceiling_body(rate, ceiling):
             % (_usd_words(rate), _usd_words(ceiling)))
 
 
-def _spend_guard_toast(text, clients=None):
-    """One warn toast to every connected dashboard client (the shell renders `warn` as its toast)."""
+def _spend_guard_toast(text, clients=None, **fields):
+    """One `spendCeiling` message to every connected dashboard client: the chat bundle toasts it (render.ts). Its OWN
+    type, never `warn` (MEDIUM 3 of the review): a warn arriving while a create is in flight is read by the chat as that
+    create's verdict, and warn is the panes' soft-refusal channel. The durable record is the problem ring the shell's
+    bell mirrors on every pane (the row rides the backend's log); this message is the moment's toast."""
     if clients is None:
         with _clients_lock:
             clients = list(_clients)
-    payload = json.dumps({"type": "warn", "text": text})
+    payload = json.dumps(dict(fields, type="spendCeiling", text=text))
     for c in list(clients):
         try:
             c["send"](payload)
@@ -36330,31 +36386,67 @@ def _spend_guard_row(kind, text, sid, name, be, **fields):
         sys.stderr.write("spend-guard row: %s\n" % traceback.format_exc())
 
 
+def _spend_guard_stop(sid, be, now):
+    """The Stop button's WHOLE road for a session over the ceiling (MEDIUM 2 of the review): the interrupt, the
+    interrupt-clicked stamp the chip reads, the retry suppression that keeps the auto-retry and the idle-queue drive
+    from re-driving the session while the latch holds, and the views marked dirty. Not pressed while an interrupt is
+    already unsettled for the sid (the escalation ladder would climb to SIGINT and SIGKILL on a second press). Returns
+    "stopped", "stopping" (a stop already in flight), or "refused" (the backend would not, or owns no such session)."""
+    t0 = _interrupt_clicked.get(str(sid))
+    if t0 is not None and now - t0 <= 120:
+        return "stopping"
+    try:
+        stopped = bool(be.interrupt(sid))
+    except Exception:
+        sys.stderr.write("spend-guard interrupt: %s\n" % traceback.format_exc())
+        stopped = False
+    if not stopped:
+        return "refused"
+    _interrupt_clicked[str(sid)] = now
+    err = _suppress_session_retry(sid)
+    if err:
+        sys.stderr.write("spend-guard: %s\n" % err)
+    _mark_views_dirty()
+    return "stopped"
+
+
 def _spend_guard_fire(s, rate, ceiling, now, be, clients):
-    """A crossing: stop the session, tell it once in the user's voice, warn every dashboard, file the row."""
+    """A crossing: stop the session (the Stop button's road), tell it once in the user's voice, tell every dashboard,
+    file the row. `be` None resolves the session's OWN backend (Sessions.backend_for: the SDK's, Codex's, or the unowned
+    stand-in that refuses by name), and the sentence says what actually happened (MEDIUM 4 of the review)."""
     sid, name = s["sid"], s.get("name") or s["sid"][:8]
     when = time.strftime("%H:%M", time.localtime(now))
-    if be is not None:
-        try:
-            be.interrupt(sid)                            # the Stop button's road: the fan-out ends now
-        except Exception:
-            sys.stderr.write("spend-guard interrupt: %s\n" % traceback.format_exc())
-        try:
-            _send_with_id(be, sid, _spend_ceiling_body(rate, ceiling))
-        except Exception:
-            sys.stderr.write("spend-guard send: %s\n" % traceback.format_exc())
-    text = ("%s was spending about $%s an hour at %s, over the $%s an hour ceiling; it has been stopped and told."
-            % (name, _usd_words(rate), when, _usd_words(ceiling)))
-    _spend_guard_toast(text, clients)
+    if be is None:
+        be = Sessions.backend_for(sid)
+    stop = _spend_guard_stop(sid, be, now)
+    try:
+        # the user's message rides the same door as every machine send (LOW 3): parked while the session compacts,
+        # behind the user's own queued messages, and under a usage-limit hold; None is a refusal (no backend owns it)
+        told = _send_or_park(be, sid, _spend_ceiling_body(rate, ceiling)) is not None
+    except Exception:
+        sys.stderr.write("spend-guard send: %s\n" % traceback.format_exc())
+        told = False
+    outcome = {("stopped", True): "it has been stopped and told",
+               ("stopping", True): "a stop was already in flight, and it has been told",
+               ("refused", True): "it could not be stopped (the interrupt was refused: detached, or no backend owns it) but has been told",
+               ("stopped", False): "it has been stopped, but the message was refused",
+               ("stopping", False): "a stop was already in flight, and the message was refused",
+               ("refused", False): "it could not be stopped or told (no backend owns it)"}[(stop, told)]
+    text = ("%s was spending about $%s an hour at %s, over the $%s an hour ceiling; %s."
+            % (name, _usd_words(rate), when, _usd_words(ceiling), outcome))
+    _spend_guard_toast(text, clients, sid=sid, name=name, phase="over", usdPerHour=round(float(rate), 2), t=int(now))
     _spend_guard_row("spend.ceiling", text, sid, name, be, t=int(now), usdPerHour=round(float(rate), 2),
-                     ceilingUsdPerHour=float(ceiling), windowS=SPEND_GUARD_WINDOW_S)   # t: the crossing's moment
+                     ceilingUsdPerHour=float(ceiling), windowS=SPEND_GUARD_WINDOW_S,
+                     stopped=(stop == "stopped"), stopping=(stop == "stopping"), told=told)   # t: the crossing's moment
 
 
 def _spend_guard_clear(s, rate, ceiling, now, be, clients):
     """The rate fell under the re-arm level: say so where the crossing was said, and file the clearing."""
     sid, name = s["sid"], s.get("name") or s["sid"][:8]
+    if be is None:
+        be = Sessions.backend_for(sid)
     text = "%s is back under the spend ceiling (about $%s an hour now)." % (name, _usd_words(rate))
-    _spend_guard_toast(text, clients)
+    _spend_guard_toast(text, clients, sid=sid, name=name, phase="under", usdPerHour=round(float(rate), 2), t=int(now))
     _spend_guard_row("spend.ceiling.cleared", text, sid, name, be, t=int(now), usdPerHour=round(float(rate), 2),
                      ceilingUsdPerHour=float(ceiling), windowS=SPEND_GUARD_WINDOW_S)
 
@@ -36366,9 +36458,8 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
     if ceiling <= 0:
         _SPEND_GUARD.clear()                             # disabled: nothing latched survives the disable
         return
+    _spend_guard_seed()                                  # once per kernel life: the ledger's verdicts
     rows = _alive_sessions(now, live_map) if sessions is None else sessions
-    if be is None:
-        be = _sdk_backend or None
     if prices is None:
         prices = _model_prices(int(now), refresh=False)   # never a network fetch from the pusher's path
     live = set()
@@ -36389,8 +36480,11 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
         elif st and st.get("over") and rate < ceiling * SPEND_GUARD_REARM:
             _SPEND_GUARD[sid] = {"over": False, "t": now, "rate": rate}
             _spend_guard_clear(s, rate, ceiling, now, be, clients)
-    for sid in [k for k in _SPEND_GUARD if k not in live]:
-        _SPEND_GUARD.pop(sid, None)                      # a session that left the live map takes its latch with it
+    # a session that left the live map KEEPS its latch (MEDIUM 1 of the review): dropping it re-fired the whole
+    # crossing when the session rejoined on the same window; the dict is bounded instead, the oldest departed first
+    if len(_SPEND_GUARD) > SPEND_GUARD_LATCH_MAX:
+        for sid in sorted((k for k in _SPEND_GUARD if k not in live), key=lambda k: _SPEND_GUARD[k].get("t") or 0)[:len(_SPEND_GUARD) - SPEND_GUARD_LATCH_MAX]:
+            _SPEND_GUARD.pop(sid, None)
 
 
 def _spend_series(keyed_only=False, now=None):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36252,7 +36252,12 @@ def _spend_window_usd(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
     usd = 0.0
     for f in _spend_window_files(leaf, since):
         best, anon = {}, 0.0
-        for o in reversed(em._read_jsonl_incremental(f)):
+        # the reader's entry with a TAIL accepted (T323 stage 4a): after a restart the assembly checkpoint restores a
+        # file as the records past its cut, and the whole-file road (_read_jsonl_incremental) would upgrade that entry
+        # to a full re-read of every live transcript on the guard's first cycle; the window wants the newest records,
+        # which a tail holds. A tail cut inside the window undercounts the minutes before the cut on that first cycle.
+        ent = em._read_jsonl_entry(f, tail_ok=True)
+        for o in reversed(ent[4] if ent is not None else []):
             if not isinstance(o, dict):
                 continue
             t = _msg_epoch(o)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36246,7 +36246,7 @@ def _spend_window_usd(leaf, now, window_s=SPEND_GUARD_WINDOW_S, prices=None):
     more than once (one record per content block, one message id) counts once, at its largest usage row; a record
     whose model the table cannot place counts at the table's dearest row rather than not at all (a guard errs high)."""
     if prices is None:
-        prices = _model_prices(int(now))
+        prices = _model_prices(int(now), refresh=False)   # never a network fetch from the pusher's path
     dearest = max(prices.values(), key=lambda p: float(p.get("out") or 0)) if prices else None
     since = now - window_s
     usd = 0.0
@@ -36365,7 +36365,7 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
     if be is None:
         be = _sdk_backend or None
     if prices is None:
-        prices = _model_prices(int(now))
+        prices = _model_prices(int(now), refresh=False)   # never a network fetch from the pusher's path
     live = set()
     for s in rows:
         sid, path = s.get("sid"), s.get("path")
@@ -38647,11 +38647,15 @@ def _refresh_remote_prices(now):
     threading.Thread(target=work, name="price-refresh", daemon=True).start()
 
 
-def _model_prices(now=None):
-    """The merged $/token price map: baked-in DEFAULT < best-effort remote feed < user config override."""
+def _model_prices(now=None, refresh=True):
+    """The merged $/token price map: baked-in DEFAULT < best-effort remote feed < user config override. `refresh`
+    (the default) lets a stale feed cache kick its background fetch; the spend guard passes False, since it runs on
+    the pusher's path in every kernel (a hermetic test kernel included) and must never start a network fetch: it
+    merges whatever the cost view's last refresh left in the cache (T350)."""
     if now is None:
         now = int(time.time())
-    _refresh_remote_prices(now)
+    if refresh:
+        _refresh_remote_prices(now)
     prices = {k: dict(v) for k, v in DEFAULT_MODEL_PRICES.items()}
     prices.update({k: dict(v) for k, v in _price_cache["remote"].items()})
     try:

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -124,6 +124,8 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
                  {"who": "assistant", "text": "Yes: write-through avoids the stale-read window and "
                                               "the extra invalidation pass; the cost is one write "
                                               "per update, which this workload absorbs."}]),
+            # the spend guard's one message to a session over the hourly ceiling (T350, the user 2026-09-11)
+            "spend ceiling": km._spend_ceiling_body(1240.0, 1000.0),
             "debt reminder (question)": km._debt_reminder_body(
                 [("web", T0, "question", "Which port should the staging server use?")]),
             "debt reminder (handoff)": km._debt_reminder_body(
@@ -266,10 +268,12 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             # the session) — telling, not asking; a status question bolted on would be noise
             # …and the MERGE handoff is a record handed over with direction ("account for it"),
             # never a status ask — bolting a progress question onto it would be noise
+            # …and the spend ceiling's message is a STOP order with one question (what was fanning out), not a
+            # progress ask: the session is to halt, not to report where things stand
             if name in ("typed follow-up on a summary",
                         "debt reminder (question)", "debt reminder (handoff)",
                         "debt reminder (several)", "comment thread opener", "edit trace",
-                        "comment-thread merge", "compaction suggestion"):
+                        "comment-thread merge", "compaction suggestion", "spend ceiling"):
                 #        ^ a housekeeping suggestion, not a progress ask — it elicits nothing
                 continue
             text = prose(body).lower()

--- a/tests/test_lazy_body_readers.py
+++ b/tests/test_lazy_body_readers.py
@@ -27,7 +27,7 @@ KERNEL_ALLOWED = {
     "_last_assistant_report", "_comment_prose_record", "_comment_cut_target", "_comment_msg_text", "_thread_messages",
     "_undelivered_wake_tail", "_gist_step", "_launch_ids_step", "_launch_step", "_api_error_pass", "_session_meta_step",
     "_transcript_tok_rows", "_rewind_target", "_subagent_meta_map", "_read_task_output",
-    "_spend_window_usd",                                # the spend guard prices the record cache's raw jsonl rows (T350)
+    "_spend_file_rows",                                 # the spend guard prices the record cache's raw jsonl rows (T350)
     # live SDK atoms and echoes (constructed in-process, never lazy)
     "_merge_live_atoms", "_interrupt_marks_atoms", "_stamp_agents", "_ask_fill_answers", "_ask_fill_chosen", "_patch_rows",
     "_claudemd_paths", "_stamp_steps", "_hydrate_postal", "build_subagent", "_agent_alive",

--- a/tests/test_lazy_body_readers.py
+++ b/tests/test_lazy_body_readers.py
@@ -27,6 +27,7 @@ KERNEL_ALLOWED = {
     "_last_assistant_report", "_comment_prose_record", "_comment_cut_target", "_comment_msg_text", "_thread_messages",
     "_undelivered_wake_tail", "_gist_step", "_launch_ids_step", "_launch_step", "_api_error_pass", "_session_meta_step",
     "_transcript_tok_rows", "_rewind_target", "_subagent_meta_map", "_read_task_output",
+    "_spend_window_usd",                                # the spend guard prices the record cache's raw jsonl rows (T350)
     # live SDK atoms and echoes (constructed in-process, never lazy)
     "_merge_live_atoms", "_interrupt_marks_atoms", "_stamp_agents", "_ask_fill_answers", "_ask_fill_chosen", "_patch_rows",
     "_claudemd_paths", "_stamp_steps", "_hydrate_postal", "build_subagent", "_agent_alive",

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -501,8 +501,8 @@ class PusherRecords(unittest.TestCase):
             "_end_on_idle_sweep", "_deferral_sweep_tick", "_auto_nudge_tick", "_interrupt_block_tick",
             "_auto_pause_on_limit", "_usage_poll_tick", "_auto_pause_on_spend_limit", "_auto_resume_retry",
             "_auto_resume_session_retry", "_auto_retry_tick", "_idle_queue_drive_tick",
-            "_clear_done_working_notes", "_push_all",
-            "_api_health_frame", "_api_health_push")   # the bottom bar's API cell
+            "_clear_done_working_notes", "_spend_guard_tick", "_push_all",
+            "_api_health_frame", "_api_health_push")   # the bottom bar's API cell; the spend guard (T350)
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -106,6 +106,23 @@ class SpendRate(unittest.TestCase):
         self.assertEqual(km._spend_window_usd(self.leaf, NOW + 5000, 600, PRICES), 0.0)
         self.assertEqual(km._spend_window_usd(os.path.join(self.td.name, "absent.jsonl"), NOW, 600, PRICES), 0.0)
 
+    def test_the_window_reads_the_cache_entry_with_a_tail_accepted_never_the_whole_file_road(self):
+        """After a restart the assembly checkpoint restores a transcript as a TAIL entry (the records past its cut); the
+        whole-file road would upgrade every live transcript to a full re-read on the guard's first cycle (the checkpoint's
+        served tests measure those bytes). The window reads the entry with tail_ok, and never calls the whole-file road."""
+        write_jsonl(self.leaf, [assistant(NOW - 100, "msg_t", out_tokens=1000, in_tokens=0)])
+        sub = Path(self.leaf).with_suffix("") / "subagents"
+        write_jsonl(sub / "agent-1.jsonl", [assistant(NOW - 50, "msg_s", out_tokens=1000, in_tokens=0)], mtime=NOW - 50)
+        calls = []
+        real = km.em._read_jsonl_entry
+        def entry(path, on_fail=None, tail_ok=False, tail_from=None):
+            calls.append((os.path.basename(str(path)), tail_ok)); return real(path, on_fail=on_fail, tail_ok=tail_ok, tail_from=tail_from)
+        with mock.patch.object(km.em, "_read_jsonl_entry", side_effect=entry), \
+             mock.patch.object(km.em, "_read_jsonl_incremental", side_effect=AssertionError("the whole-file road")):
+            usd = km._spend_window_usd(self.leaf, NOW, 600, PRICES)
+        self.assertAlmostEqual(usd, 2 * 1000 * 25e-6, places=9)
+        self.assertEqual(sorted(calls), sorted([(os.path.basename(self.leaf), True), ("agent-1.jsonl", True)]), "each file once, a tail accepted")
+
     def test_an_unpriced_model_counts_at_the_dearest_row_and_a_record_without_usage_counts_nothing(self):
         write_jsonl(self.leaf, [assistant(NOW - 100, "msg_x", out_tokens=1000, model="mystery-9", in_tokens=0),
                                 {"type": "assistant", "timestamp": iso(NOW - 90), "uuid": "n", "message": {"id": "msg_n", "model": "claude-opus-4-8", "content": []}}])

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""The spend guard (T350, the user 2026-09-11): every live session's spend RATE over the last ten minutes, scaled to an
+hour, read from the record cache (the leaf transcript and the agent transcripts beside it); over the ceiling the session
+is interrupted and handed one message in the user's voice, every dashboard is warned, a session-events row is filed,
+once per crossing, re-armed once the rate falls under half the ceiling; the ceiling is a bare-value setting read at each
+check (1000 with no file, 0 disables).
+
+SYNTHETIC fixtures only: placeholder ids, an invented session, transcripts written here with usage fields.
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+# hermetic state BEFORE the loads (the kernel resolves its state root at import time)
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = load_source("romp_kernel_spend_guard", os.path.join(BIN, "romp-kernel"))
+jd = km.jd
+
+SID = "11111111-2222-3333-4444-00000000a350"
+NOW = 1781200000.0
+PRICES = {"claude-opus-4-8": {"in": 5e-6, "out": 25e-6, "cache_w": 6.25e-6, "cache_r": 0.5e-6},
+          "claude-haiku-4-5-20251001": {"in": 1e-6, "out": 5e-6, "cache_w": 1.25e-6, "cache_r": 0.1e-6}}
+
+
+def iso(t):
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(t)) + ".000Z"
+
+
+def assistant(t, mid, out_tokens, model="claude-opus-4-8", in_tokens=1000, cache_r=0, cache_w=0):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": mid + "-u", "sessionId": SID,
+            "message": {"id": mid, "role": "assistant", "model": model,
+                        "usage": {"input_tokens": in_tokens, "output_tokens": out_tokens,
+                                  "cache_creation_input_tokens": cache_w, "cache_read_input_tokens": cache_r},
+                        "content": [{"type": "text", "text": "working"}]}}
+
+
+def user(t, uid):
+    return {"type": "user", "timestamp": iso(t), "uuid": uid, "sessionId": SID, "message": {"role": "user", "content": "go"}}
+
+
+def write_jsonl(path, records, mtime=None):
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("".join(json.dumps(r) + "\n" for r in records))
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+
+
+class FakeBackend:
+    def __init__(self):
+        self.interrupts, self.sends, self.logs = [], [], []
+
+    def interrupt(self, sid):
+        self.interrupts.append(sid)
+        return True
+
+    def send(self, sid, text):
+        self.sends.append((sid, text))
+        return True
+
+    def _log(self, m, problem=None, key=None, ring_text=None):
+        self.logs.append((str(m), problem, ring_text))
+
+
+def client(bucket):
+    return {"app": "chat", "wid": "w1", "alive": True, "send": lambda payload: bucket.append(json.loads(payload))}
+
+
+class SpendRate(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.leaf = os.path.join(self.td.name, "proj", SID + ".jsonl")
+
+    def tearDown(self):
+        self.td.cleanup()
+
+    def test_the_window_sums_the_leaf_and_the_agent_files_beside_it_and_ignores_the_rest(self):
+        # the leaf: one response outside the window (an hour ago), two inside; a response logged twice (two content
+        # blocks, one message id) counts once at its largest usage row
+        write_jsonl(self.leaf, [
+            user(NOW - 3600, "u0"), assistant(NOW - 3590, "msg_old", out_tokens=100000),
+            user(NOW - 500, "u1"), assistant(NOW - 480, "msg_a", out_tokens=10000),
+            assistant(NOW - 470, "msg_a", out_tokens=12000),              # the same response again, larger
+            assistant(NOW - 200, "msg_b", out_tokens=4000, model="claude-haiku-4-5-20251001", in_tokens=2000)])
+        sub = Path(self.leaf).with_suffix("") / "subagents"
+        write_jsonl(sub / "agent-1.jsonl", [assistant(NOW - 300, "msg_s1", out_tokens=20000)], mtime=NOW - 300)
+        write_jsonl(sub / "agent-old.jsonl", [assistant(NOW - 5000, "msg_s2", out_tokens=900000)], mtime=NOW - 5000)
+        usd = km._spend_window_usd(self.leaf, NOW, 600, PRICES)
+        want = (1000 * 5e-6 + 12000 * 25e-6) + (2000 * 1e-6 + 4000 * 5e-6) + (1000 * 5e-6 + 20000 * 25e-6)
+        self.assertAlmostEqual(usd, want, places=9)
+        self.assertAlmostEqual(km._spend_rate_usd_per_hour(self.leaf, NOW, 600, PRICES), want * 6, places=6)
+        # nothing recorded in the window: zero, and a missing leaf is zero too
+        self.assertEqual(km._spend_window_usd(self.leaf, NOW + 5000, 600, PRICES), 0.0)
+        self.assertEqual(km._spend_window_usd(os.path.join(self.td.name, "absent.jsonl"), NOW, 600, PRICES), 0.0)
+
+    def test_an_unpriced_model_counts_at_the_dearest_row_and_a_record_without_usage_counts_nothing(self):
+        write_jsonl(self.leaf, [assistant(NOW - 100, "msg_x", out_tokens=1000, model="mystery-9", in_tokens=0),
+                                {"type": "assistant", "timestamp": iso(NOW - 90), "uuid": "n", "message": {"id": "msg_n", "model": "claude-opus-4-8", "content": []}}])
+        self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW, 600, PRICES), 1000 * 25e-6, places=9)
+
+
+class Ceiling(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        jd._state_cache.clear()
+
+    def tearDown(self):
+        jd.STATE = self.saved
+        jd._state_cache.clear()
+        self.td.cleanup()
+
+    def test_the_setting_file_is_read_at_each_check(self):
+        self.assertEqual(km._spend_ceiling(), 1000.0, "no file: the default")
+        for raw, want in (("250", 250.0), ("0", 0.0), ("1500.5\n", 1500.5), ("junk", 1000.0), ("", 1000.0)):
+            Path(self.td.name, km.SPEND_CEILING_SETTING).write_text(raw)
+            jd._state_cache.clear()
+            self.assertEqual(km._spend_ceiling(), want, "the file says %r" % raw)
+
+
+class Guard(unittest.TestCase):
+    """The tick with its seams: synthetic sessions, a fake backend, a fake client list, the default prices."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.saved = jd.STATE
+        jd.STATE = Path(self.td.name)
+        jd._state_cache.clear()
+        km._SPEND_GUARD.clear()
+        self.leaf = os.path.join(self.td.name, "proj", SID + ".jsonl")
+        self.be, self.toasts = FakeBackend(), []
+        self.clients = [client(self.toasts), client(self.toasts)]
+        self.sessions = [{"sid": SID, "name": "web", "path": self.leaf, "anchor": SID, "mtime": NOW}]
+
+    def tearDown(self):
+        km._SPEND_GUARD.clear()
+        jd.STATE = self.saved
+        jd._state_cache.clear()
+        self.td.cleanup()
+
+    def _tick(self, now):
+        km._spend_guard_tick(now, {SID: {"state": "working"}}, sessions=self.sessions, be=self.be, clients=self.clients, prices=PRICES)
+
+    def _rows(self):
+        p = Path(self.td.name, "session-events.jsonl")
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+    def _spend(self, t, usd_in_window):
+        """A leaf whose window holds `usd_in_window` of opus output, spent over the last five minutes."""
+        toks = int(usd_in_window / 25e-6)
+        write_jsonl(self.leaf, [user(t - 400, "u"), assistant(t - 300, "msg_%d" % int(t), out_tokens=toks, in_tokens=0)])
+
+    def test_a_session_under_the_ceiling_is_left_alone(self):
+        self._spend(NOW, 100.0)                          # $100 in ten minutes: $600 an hour
+        self._tick(NOW)
+        self.assertEqual((self.be.interrupts, self.be.sends, self.toasts, self._rows()), ([], [], [], []))
+        self.assertEqual(km._SPEND_GUARD, {})
+
+    def test_a_crossing_stops_the_session_tells_it_once_warns_every_dashboard_and_files_the_row(self):
+        self._spend(NOW, 200.0)                          # $200 in ten minutes: $1,200 an hour, over the default 1000
+        self._tick(NOW)
+        self.assertEqual(self.be.interrupts, [SID], "interrupted first: the fan-out ends now")
+        self.assertEqual(len(self.be.sends), 1)
+        sid, body = self.be.sends[0]
+        self.assertEqual(sid, SID)
+        self.assertIn("about $1,200 an hour", body)
+        self.assertIn("I set the line at $1,000 an hour", body)
+        self.assertIn("Stop whatever is fanning out and tell me what it was before doing anything else.", body)
+        self.assertIn("<!-- romp-injected --><!-- romp-system -->", body, "a machine message, marked as such in the tail")
+        for w in ("romp", "card", "board", "goal", "nudge", "ceiling", "kernel", "session"):
+            self.assertNotIn(w, body.split("<!--")[0].lower(), "the prose speaks as the user, no machinery named: %r" % w)
+        self.assertEqual(len(self.toasts), 2, "every connected client, once")
+        self.assertEqual(self.toasts[0]["type"], "warn")
+        self.assertIn("web was spending about $1,200 an hour at ", self.toasts[0]["text"])
+        self.assertIn("over the $1,000 an hour ceiling; it has been stopped and told.", self.toasts[0]["text"])
+        rows = self._rows()
+        self.assertEqual([r["kind"] for r in rows], ["spend.ceiling"])
+        self.assertEqual((rows[0]["sid"], rows[0]["name"], rows[0]["ceilingUsdPerHour"], rows[0]["windowS"]), (SID, "web", 1000.0, 600))
+        self.assertAlmostEqual(rows[0]["usdPerHour"], 1200.0, places=1)
+        self.assertEqual(rows[0]["t"], int(NOW))
+        self.assertTrue(self.be.logs and self.be.logs[0][1] is True and "web was spending" in (self.be.logs[0][2] or ""),
+                        "the row also rides the backend's log with the ring flag: the error center shows it")
+        self.assertEqual(km._SPEND_GUARD[SID]["over"], True)
+        # the latch: the same rate the next cycle, and a still-high rate the cycle after, say nothing more
+        self._tick(NOW + 5)
+        self._spend(NOW + 60, 150.0)                     # $900 an hour: under the ceiling, above the re-arm level
+        self._tick(NOW + 60)
+        self.assertEqual((len(self.be.interrupts), len(self.be.sends), len(self.toasts), len(self._rows())), (1, 1, 2, 1))
+        self.assertEqual(km._SPEND_GUARD[SID]["over"], True, "held until the rate is under half the ceiling")
+        # under half: the clearing is said where the crossing was, and the guard re-arms
+        self._spend(NOW + 120, 40.0)                     # $240 an hour
+        self._tick(NOW + 120)
+        self.assertEqual(km._SPEND_GUARD[SID]["over"], False)
+        self.assertEqual([r["kind"] for r in self._rows()], ["spend.ceiling", "spend.ceiling.cleared"])
+        self.assertEqual(len(self.toasts), 4)
+        self.assertIn("web is back under the spend ceiling (about $240 an hour now).", self.toasts[2]["text"])
+        self.assertEqual((len(self.be.interrupts), len(self.be.sends)), (1, 1), "a clearing sends the session nothing")
+        # a second crossing is new information: it fires again
+        self._spend(NOW + 180, 300.0)
+        self._tick(NOW + 180)
+        self.assertEqual((len(self.be.interrupts), len(self.be.sends)), (2, 2))
+        self.assertEqual([r["kind"] for r in self._rows()], ["spend.ceiling", "spend.ceiling.cleared", "spend.ceiling"])
+
+    def test_the_ceiling_file_governs_and_zero_disables(self):
+        self._spend(NOW, 200.0)                          # $1,200 an hour
+        Path(self.td.name, km.SPEND_CEILING_SETTING).write_text("0")
+        jd._state_cache.clear()
+        self._tick(NOW)
+        self.assertEqual((self.be.interrupts, self.be.sends, self.toasts, self._rows()), ([], [], [], []), "0 disables")
+        Path(self.td.name, km.SPEND_CEILING_SETTING).write_text("2000")
+        jd._state_cache.clear()
+        self._tick(NOW + 1)
+        self.assertEqual(self.be.interrupts, [], "$1,200 an hour is under a $2,000 ceiling")
+        Path(self.td.name, km.SPEND_CEILING_SETTING).write_text("500")
+        jd._state_cache.clear()
+        self._tick(NOW + 2)
+        self.assertEqual(self.be.interrupts, [SID], "…and over a $500 one: the file is read at each check")
+        self.assertIn("I set the line at $500 an hour", self.be.sends[0][1])
+        self.assertIn("over the $500 an hour ceiling", self.toasts[0]["text"])
+
+    def test_a_session_that_left_the_live_set_takes_its_latch_with_it(self):
+        self._spend(NOW, 200.0)
+        self._tick(NOW)
+        self.assertIn(SID, km._SPEND_GUARD)
+        km._spend_guard_tick(NOW + 5, {}, sessions=[], be=self.be, clients=self.clients, prices=PRICES)
+        self.assertEqual(km._SPEND_GUARD, {})
+
+    def test_the_pusher_runs_the_guard_every_cycle_after_the_spend_pause_check(self):
+        import inspect
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        i, j = src.index("_auto_pause_on_spend_limit(now, live_map)"), src.index("_spend_guard_tick(now, live_map)")
+        self.assertLess(i, j, "the guard runs in the tick jobs, after the spend-cap pause decision")
+        self.assertIn('sys.stderr.write("spend-guard: %s\\n" % traceback.format_exc())', src, "guarded like every job")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -239,6 +239,19 @@ class Guard(unittest.TestCase):
         km._spend_guard_tick(NOW + 5, {}, sessions=[], be=self.be, clients=self.clients, prices=PRICES)
         self.assertEqual(km._SPEND_GUARD, {})
 
+    def test_the_guard_never_starts_the_price_feed_fetch(self):
+        """The cost view refreshes the remote price feed when its cache is stale; the guard runs on the pusher's path in
+        every kernel, hermetic test kernels included, so it merges the table WITHOUT that refresh."""
+        self._spend(NOW, 200.0)
+        with mock.patch.object(km, "_refresh_remote_prices") as refresh:
+            km._spend_guard_tick(NOW, {SID: {"state": "working"}}, sessions=self.sessions, be=self.be, clients=self.clients)
+            km._spend_window_usd(self.leaf, NOW)
+        refresh.assert_not_called()
+        self.assertEqual(self.be.interrupts, [SID], "…and the crossing still fired on the merged table")
+        with mock.patch.object(km, "_refresh_remote_prices") as refresh:
+            km._model_prices(int(NOW))
+        refresh.assert_called_once_with(int(NOW))
+
     def test_the_pusher_runs_the_guard_every_cycle_after_the_spend_pause_check(self):
         import inspect
         src = inspect.getsource(km._pusher_cycle_jobs)

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -60,16 +60,22 @@ def write_jsonl(path, records, mtime=None):
 
 
 class FakeBackend:
-    def __init__(self):
-        self.interrupts, self.sends, self.logs = [], [], []
+    def __init__(self, stops=True, accepts=True):
+        self.interrupts, self.sends, self.logs, self.stops, self.accepts = [], [], [], stops, accepts
+
+    def owns(self, sid):
+        return True
 
     def interrupt(self, sid):
         self.interrupts.append(sid)
-        return True
+        return self.stops
 
-    def send(self, sid, text):
+    def send(self, sid, text, qid=None, user=False):
         self.sends.append((sid, text))
-        return True
+        return self.accepts
+
+    def busy(self, sid):
+        return False
 
     def _log(self, m, problem=None, key=None, ring_text=None):
         self.logs.append((str(m), problem, ring_text))
@@ -98,8 +104,11 @@ class SpendRate(unittest.TestCase):
         sub = Path(self.leaf).with_suffix("") / "subagents"
         write_jsonl(sub / "agent-1.jsonl", [assistant(NOW - 300, "msg_s1", out_tokens=20000)], mtime=NOW - 300)
         write_jsonl(sub / "agent-old.jsonl", [assistant(NOW - 5000, "msg_s2", out_tokens=900000)], mtime=NOW - 5000)
+        # a WORKFLOW agent, one level down (Claude Code 2.1.261): the review's probe, invisible to a flat listing
+        write_jsonl(sub / "workflows" / "wf_abc" / "agent-w1.jsonl", [assistant(NOW - 120, "msg_w1", out_tokens=400000, in_tokens=0)], mtime=NOW - 120)
+        os.symlink(self.leaf, sub / "agent-link.jsonl")   # a symlinked file is a user's, never the CLI's: skipped
         usd = km._spend_window_usd(self.leaf, NOW, 600, PRICES)
-        want = (1000 * 5e-6 + 12000 * 25e-6) + (2000 * 1e-6 + 4000 * 5e-6) + (1000 * 5e-6 + 20000 * 25e-6)
+        want = (1000 * 5e-6 + 12000 * 25e-6) + (2000 * 1e-6 + 4000 * 5e-6) + (1000 * 5e-6 + 20000 * 25e-6) + 400000 * 25e-6
         self.assertAlmostEqual(usd, want, places=9)
         self.assertAlmostEqual(km._spend_rate_usd_per_hour(self.leaf, NOW, 600, PRICES), want * 6, places=6)
         # nothing recorded in the window: zero, and a missing leaf is zero too
@@ -129,6 +138,29 @@ class SpendRate(unittest.TestCase):
         self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW, 600, PRICES), 1000 * 25e-6, places=9)
 
 
+class Memo(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.leaf = os.path.join(self.td.name, "proj", SID + ".jsonl")
+        km._SPEND_ROWS_CACHE.clear()
+
+    def tearDown(self):
+        km._SPEND_ROWS_CACHE.clear()
+        self.td.cleanup()
+
+    def test_an_unchanged_file_serves_its_rows_from_the_memo_and_a_changed_one_is_scanned_again(self):
+        write_jsonl(self.leaf, [assistant(NOW - 100, "msg_a", out_tokens=1000, in_tokens=0)], mtime=NOW - 100)
+        self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW, 600, PRICES), 1000 * 25e-6, places=9)
+        stamp, floor, rows = km._SPEND_ROWS_CACHE[self.leaf]
+        self.assertEqual(floor, NOW - 600 - km.SPEND_GUARD_MEMO_SLACK_S)
+        with mock.patch.object(km, "_msg_epoch", side_effect=AssertionError("a re-scan of an unchanged file")):
+            self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW + 30, 600, PRICES), 1000 * 25e-6, places=9, msg="a later window, the same stamp: no scan")
+            self.assertEqual(km._spend_window_usd(self.leaf, NOW + 800, 600, PRICES), 0.0, "the memo's rows age out of the window without a scan")
+        write_jsonl(self.leaf, [assistant(NOW - 100, "msg_a", out_tokens=1000, in_tokens=0), assistant(NOW - 10, "msg_b", out_tokens=1000, in_tokens=0)], mtime=NOW - 10)
+        self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW, 600, PRICES), 2 * 1000 * 25e-6, places=9, msg="a changed stamp: scanned again")
+        self.assertNotEqual(km._SPEND_ROWS_CACHE[self.leaf][0], stamp)
+
+
 class Ceiling(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -143,7 +175,8 @@ class Ceiling(unittest.TestCase):
 
     def test_the_setting_file_is_read_at_each_check(self):
         self.assertEqual(km._spend_ceiling(), 1000.0, "no file: the default")
-        for raw, want in (("250", 250.0), ("0", 0.0), ("1500.5\n", 1500.5), ("junk", 1000.0), ("", 1000.0)):
+        for raw, want in (("250", 250.0), ("0", 0.0), ("1500.5\n", 1500.5), ("junk", 1000.0), ("", 1000.0),
+                          ("nan", 1000.0), ("inf", 1000.0), ("-inf", 1000.0), ("-5", 1000.0)):   # LOW 1: not a silent disable
             Path(self.td.name, km.SPEND_CEILING_SETTING).write_text(raw)
             jd._state_cache.clear()
             self.assertEqual(km._spend_ceiling(), want, "the file says %r" % raw)
@@ -158,13 +191,27 @@ class Guard(unittest.TestCase):
         jd.STATE = Path(self.td.name)
         jd._state_cache.clear()
         km._SPEND_GUARD.clear()
+        km._SPEND_GUARD_SEEDED[0] = False
+        km._SPEND_ROWS_CACHE.clear()
+        km._interrupt_clicked.pop(SID, None)
         self.leaf = os.path.join(self.td.name, "proj", SID + ".jsonl")
         self.be, self.toasts = FakeBackend(), []
         self.clients = [client(self.toasts), client(self.toasts)]
         self.sessions = [{"sid": SID, "name": "web", "path": self.leaf, "anchor": SID, "mtime": NOW}]
+        # the message rides the machine sends' door (LOW 3): recorded here, handed over (False), refused (None) when the
+        # backend refuses, as the real door answers
+        self.parked = []
+        def send_or_park(be, sid, text, echo=None, qid=None, user=False):
+            self.parked.append((sid, text))
+            return False if be.send(sid, text) else None
+        p = mock.patch.object(km, "_send_or_park", side_effect=send_or_park)
+        p.start(); self.addCleanup(p.stop)
 
     def tearDown(self):
         km._SPEND_GUARD.clear()
+        km._SPEND_GUARD_SEEDED[0] = False
+        km._SPEND_ROWS_CACHE.clear()
+        km._interrupt_clicked.pop(SID, None)
         jd.STATE = self.saved
         jd._state_cache.clear()
         self.td.cleanup()
@@ -191,8 +238,12 @@ class Guard(unittest.TestCase):
         self._spend(NOW, 200.0)                          # $200 in ten minutes: $1,200 an hour, over the default 1000
         self._tick(NOW)
         self.assertEqual(self.be.interrupts, [SID], "interrupted first: the fan-out ends now")
+        # the Stop button's whole road (MEDIUM 2): the chip's stamp, the retry suppression, the views marked dirty
+        self.assertEqual(km._interrupt_clicked.get(SID), NOW, "the interrupt-clicked stamp the chip reads")
+        self.assertIn(SID, km._retry_suppress_data(), "retry suppression: the auto-retry and the idle-queue drive stand down")
         self.assertEqual(len(self.be.sends), 1)
         sid, body = self.be.sends[0]
+        self.assertEqual(self.parked, [(SID, body)], "the message rode _send_or_park, the machine sends' door")
         self.assertEqual(sid, SID)
         self.assertIn("about $1,200 an hour", body)
         self.assertIn("I set the line at $1,000 an hour", body)
@@ -201,7 +252,8 @@ class Guard(unittest.TestCase):
         for w in ("romp", "card", "board", "goal", "nudge", "ceiling", "kernel", "session"):
             self.assertNotIn(w, body.split("<!--")[0].lower(), "the prose speaks as the user, no machinery named: %r" % w)
         self.assertEqual(len(self.toasts), 2, "every connected client, once")
-        self.assertEqual(self.toasts[0]["type"], "warn")
+        self.assertEqual(self.toasts[0]["type"], "spendCeiling", "its own type, never warn (a warn is an in-flight create's verdict to the chat)")
+        self.assertEqual((self.toasts[0]["sid"], self.toasts[0]["name"], self.toasts[0]["phase"], self.toasts[0]["t"]), (SID, "web", "over", int(NOW)))
         self.assertIn("web was spending about $1,200 an hour at ", self.toasts[0]["text"])
         self.assertIn("over the $1,000 an hour ceiling; it has been stopped and told.", self.toasts[0]["text"])
         rows = self._rows()
@@ -209,11 +261,18 @@ class Guard(unittest.TestCase):
         self.assertEqual((rows[0]["sid"], rows[0]["name"], rows[0]["ceilingUsdPerHour"], rows[0]["windowS"]), (SID, "web", 1000.0, 600))
         self.assertAlmostEqual(rows[0]["usdPerHour"], 1200.0, places=1)
         self.assertEqual(rows[0]["t"], int(NOW))
+        self.assertEqual((rows[0]["stopped"], rows[0]["stopping"], rows[0]["told"]), (True, False, True), "the row carries the truth of the road")
         self.assertTrue(self.be.logs and self.be.logs[0][1] is True and "web was spending" in (self.be.logs[0][2] or ""),
                         "the row also rides the backend's log with the ring flag: the error center shows it")
         self.assertEqual(km._SPEND_GUARD[SID]["over"], True)
-        # the latch: the same rate the next cycle, and a still-high rate the cycle after, say nothing more
+        # the latch: the same rate the next cycle, and a still-high rate the cycle after, say nothing more; it survives
+        # a kernel restart (the dict cleared, re-seeded from the ledger's rows: MEDIUM 1) and a departure from the live map
+        km._SPEND_GUARD.clear(); km._SPEND_GUARD_SEEDED[0] = False
+        km._interrupt_clicked.pop(SID, None)
         self._tick(NOW + 5)
+        self.assertEqual(km._SPEND_GUARD[SID]["over"], True, "seeded from the ledger: still over")
+        km._spend_guard_tick(NOW + 6, {}, sessions=[], be=self.be, clients=self.clients, prices=PRICES)   # left the live map
+        self.assertIn(SID, km._SPEND_GUARD, "a departed session keeps its latch")
         self._spend(NOW + 60, 150.0)                     # $900 an hour: under the ceiling, above the re-arm level
         self._tick(NOW + 60)
         self.assertEqual((len(self.be.interrupts), len(self.be.sends), len(self.toasts), len(self._rows())), (1, 1, 2, 1))
@@ -224,10 +283,12 @@ class Guard(unittest.TestCase):
         self.assertEqual(km._SPEND_GUARD[SID]["over"], False)
         self.assertEqual([r["kind"] for r in self._rows()], ["spend.ceiling", "spend.ceiling.cleared"])
         self.assertEqual(len(self.toasts), 4)
+        self.assertEqual((self.toasts[2]["type"], self.toasts[2]["phase"]), ("spendCeiling", "under"))
         self.assertIn("web is back under the spend ceiling (about $240 an hour now).", self.toasts[2]["text"])
         self.assertEqual((len(self.be.interrupts), len(self.be.sends)), (1, 1), "a clearing sends the session nothing")
         # a second crossing is new information: it fires again
         self._spend(NOW + 180, 300.0)
+        km._interrupt_clicked.pop(SID, None)              # the earlier stop settled long ago
         self._tick(NOW + 180)
         self.assertEqual((len(self.be.interrupts), len(self.be.sends)), (2, 2))
         self.assertEqual([r["kind"] for r in self._rows()], ["spend.ceiling", "spend.ceiling.cleared", "spend.ceiling"])
@@ -249,12 +310,60 @@ class Guard(unittest.TestCase):
         self.assertIn("I set the line at $500 an hour", self.be.sends[0][1])
         self.assertIn("over the $500 an hour ceiling", self.toasts[0]["text"])
 
-    def test_a_session_that_left_the_live_set_takes_its_latch_with_it(self):
+    def test_a_kernel_restart_does_not_fire_the_same_crossing_again(self):
+        """The ledger holds a spend.ceiling row with no clearing after it: a fresh process reads it back and stays latched;
+        a clearing row after it re-arms; the ledger's verdict never outranks one this life made."""
         self._spend(NOW, 200.0)
         self._tick(NOW)
-        self.assertIn(SID, km._SPEND_GUARD)
-        km._spend_guard_tick(NOW + 5, {}, sessions=[], be=self.be, clients=self.clients, prices=PRICES)
-        self.assertEqual(km._SPEND_GUARD, {})
+        self.assertEqual(len(self.be.interrupts), 1)
+        km._SPEND_GUARD.clear(); km._SPEND_GUARD_SEEDED[0] = False; km._interrupt_clicked.pop(SID, None)
+        self._tick(NOW + 5)
+        self.assertEqual((len(self.be.interrupts), len(self.be.sends), len(self._rows())), (1, 1, 1), "one fire across the restart")
+        self.assertTrue(km._SPEND_GUARD[SID]["seeded"])
+        self._spend(NOW + 120, 40.0); self._tick(NOW + 120)              # cleared: the row lands
+        km._SPEND_GUARD.clear(); km._SPEND_GUARD_SEEDED[0] = False
+        self._spend(NOW + 180, 300.0); km._interrupt_clicked.pop(SID, None); self._tick(NOW + 180)
+        self.assertEqual(len(self.be.interrupts), 2, "a fresh process after a clearing row fires the new crossing")
+
+    def test_an_unsettled_interrupt_is_not_pressed_again_and_the_sentence_says_so(self):
+        self._spend(NOW, 200.0)
+        km._interrupt_clicked[SID] = NOW - 5                # a stop is in flight (the ladder would climb on a second press)
+        self._tick(NOW)
+        self.assertEqual(self.be.interrupts, [], "not pressed again")
+        self.assertEqual(len(self.be.sends), 1, "…but told")
+        self.assertIn("; a stop was already in flight, and it has been told.", self.toasts[0]["text"])
+        self.assertEqual((self._rows()[0]["stopped"], self._rows()[0]["stopping"], self._rows()[0]["told"]), (False, True, True))
+
+    def test_the_sentence_states_what_the_backend_actually_did(self):
+        self._spend(NOW, 200.0)
+        self.be = FakeBackend(stops=False, accepts=False)   # detached, or no backend owns it: both refused
+        self._tick(NOW)
+        self.assertIn("; it could not be stopped or told (no backend owns it).", self.toasts[0]["text"])
+        self.assertEqual((self._rows()[0]["stopped"], self._rows()[0]["told"]), (False, False))
+        self.assertNotIn(SID, km._interrupt_clicked, "a refused interrupt stamps nothing")
+        # the tick with no backend given resolves the session's OWN backend (MEDIUM 4), never the SDK one for everyone
+        with mock.patch.object(km.Sessions, "backend_for", return_value=FakeBackend(stops=False, accepts=True)) as bf:
+            km._SPEND_GUARD.clear(); km._SPEND_GUARD_SEEDED[0] = True
+            self.toasts.clear()
+            km._spend_guard_tick(NOW + 1, {SID: {"state": "working"}}, sessions=self.sessions, be=None, clients=self.clients, prices=PRICES)
+            bf.assert_called_with(SID)
+        self.assertIn("; it could not be stopped (the interrupt was refused: detached, or no backend owns it) but has been told.", self.toasts[0]["text"])
+
+    def test_the_fire_road_is_pinned_to_the_shared_doors(self):
+        import inspect
+        fire = inspect.getsource(km._spend_guard_fire)
+        self.assertIn("_send_or_park(be, sid, _spend_ceiling_body(rate, ceiling))", fire, "the machine sends' door, not a bare send")
+        self.assertIn("be = Sessions.backend_for(sid)", fire, "the session's own backend")
+        stop = inspect.getsource(km._spend_guard_stop)
+        for piece in ("_interrupt_clicked[str(sid)] = now", "_suppress_session_retry(sid)", "_mark_views_dirty()"):
+            self.assertIn(piece, stop, "the Stop button's road, whole: " + piece)
+        self.assertIn('payload = json.dumps(dict(fields, type="spendCeiling", text=text))', inspect.getsource(km._spend_guard_toast))
+        ui = open(os.path.join(ROOT, "ui", "webview", "render.ts")).read()
+        i = ui.index('m.type === "spendCeiling"')
+        handler = ui[i:ui.index("\n  }", i)]
+        self.assertIn("warnToast(m.text);", handler)
+        self.assertNotIn("failProvisional", handler, "never read as an in-flight create's verdict")
+        self.assertIn("_subagent_transcripts(leaf)", inspect.getsource(km._spend_window_files), "the canonical recursive walk")
 
     def test_the_guard_never_starts_the_price_feed_fetch(self):
         """The cost view refreshes the remote price feed when its cache is stale; the guard runs on the pusher's path in

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -7,6 +7,7 @@ check (1000 with no file, 0 disables).
 
 SYNTHETIC fixtures only: placeholder ids, an invented session, transcripts written here with usage fields.
 """
+import inspect
 import json
 import os
 import tempfile
@@ -62,6 +63,7 @@ def write_jsonl(path, records, mtime=None):
 class FakeBackend:
     def __init__(self, stops=True, accepts=True):
         self.interrupts, self.sends, self.logs, self.stops, self.accepts = [], [], [], stops, accepts
+        self.sessions = {}                                # sid -> the session object (the SDK backend's map)
 
     def owns(self, sid):
         return True
@@ -151,7 +153,7 @@ class Memo(unittest.TestCase):
     def test_an_unchanged_file_serves_its_rows_from_the_memo_and_a_changed_one_is_scanned_again(self):
         write_jsonl(self.leaf, [assistant(NOW - 100, "msg_a", out_tokens=1000, in_tokens=0)], mtime=NOW - 100)
         self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW, 600, PRICES), 1000 * 25e-6, places=9)
-        stamp, floor, rows = km._SPEND_ROWS_CACHE[self.leaf]
+        stamp, floor, rows = km._SPEND_ROWS_CACHE[self.leaf][:3]
         self.assertEqual(floor, NOW - 600 - km.SPEND_GUARD_MEMO_SLACK_S)
         with mock.patch.object(km, "_msg_epoch", side_effect=AssertionError("a re-scan of an unchanged file")):
             self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW + 30, 600, PRICES), 1000 * 25e-6, places=9, msg="a later window, the same stamp: no scan")
@@ -159,6 +161,72 @@ class Memo(unittest.TestCase):
         write_jsonl(self.leaf, [assistant(NOW - 100, "msg_a", out_tokens=1000, in_tokens=0), assistant(NOW - 10, "msg_b", out_tokens=1000, in_tokens=0)], mtime=NOW - 10)
         self.assertAlmostEqual(km._spend_window_usd(self.leaf, NOW, 600, PRICES), 2 * 1000 * 25e-6, places=9, msg="a changed stamp: scanned again")
         self.assertNotEqual(km._SPEND_ROWS_CACHE[self.leaf][0], stamp)
+
+
+    def test_the_agent_tree_is_listed_once_then_watched_by_directory_mtimes_hot_files_every_cycle_cold_ones_rarely(self):
+        # the round-two review's MEDIUM: the recursive walk ran per live session per 2 Hz cycle
+        km._SPEND_TREE_CACHE.clear()
+        sub = os.path.join(os.path.dirname(self.leaf), SID, "subagents")
+        wf = os.path.join(sub, "workflows", "wf_1")
+        os.makedirs(wf)
+        write_jsonl(self.leaf, [user(NOW - 100, "u")], mtime=NOW - 100)
+        hot, cold = os.path.join(sub, "agent-hot.jsonl"), os.path.join(wf, "agent-cold.jsonl")
+        write_jsonl(hot, [user(NOW - 100, "u")], mtime=NOW - 100)          # inside the window
+        write_jsonl(cold, [user(NOW - 5000, "u")], mtime=NOW - 5000)       # idle since long before it
+        since = NOW - 600
+        real_scandir, real_stat = os.scandir, os.stat
+        listed, statted = [], []
+        def scandir(d):
+            listed.append(d); return real_scandir(d)
+        def stat(p, *a, **k):
+            statted.append(p); return real_stat(p, *a, **k)
+        with mock.patch.object(km.os, "scandir", side_effect=scandir), mock.patch.object(km.os, "stat", side_effect=stat):
+            self.assertEqual(sorted(km._spend_window_files(self.leaf, since, now=NOW)), sorted([self.leaf, hot]))
+            self.assertEqual(len(listed), 3, "the first call lists the tree whole: subagents, workflows, wf_1")
+            listed.clear(); statted.clear()
+            self.assertEqual(sorted(km._spend_window_files(self.leaf, since, now=NOW + 1)), sorted([self.leaf, hot]))
+            self.assertEqual(listed, [], "nothing changed: no directory listed again")
+            self.assertEqual(sorted(p for p in statted if p.endswith(".jsonl")), [hot], "the hot file statted, the cold one not")
+            self.assertEqual(sum(1 for p in statted if not p.endswith(".jsonl")), 3, "one stat per directory")
+            # a new workflow agent: its directory's mtime moves, that one directory is listed again, the file is seen
+            new = os.path.join(wf, "agent-new.jsonl")
+            time.sleep(0.02)
+            write_jsonl(new, [user(NOW - 10, "u")], mtime=NOW - 10)
+            os.utime(wf, (NOW + 2, NOW + 2))
+            listed.clear()
+            self.assertEqual(sorted(km._spend_window_files(self.leaf, since, now=NOW + 2)), sorted([self.leaf, hot, new]))
+            self.assertEqual(listed, [wf], "only the changed directory")
+            # the cold file wakes (a long tool call returned): seen at the next full pass, within SPEND_GUARD_TREE_RESCAN_S
+            os.utime(cold, (NOW + 3, NOW + 3))
+            self.assertEqual(sorted(km._spend_window_files(self.leaf, since, now=NOW + 3)), sorted([self.leaf, hot, new]), "not yet: cold files are not statted every cycle")
+            self.assertEqual(sorted(km._spend_window_files(self.leaf, since, now=NOW + km.SPEND_GUARD_TREE_RESCAN_S + 1)),
+                             sorted([self.leaf, hot, new, cold]), "the full pass sees it")
+        # a leaf with no subagents tree: the leaf alone, nothing memoized
+        km._SPEND_TREE_CACHE.clear()
+        lone = os.path.join(self.td.name, "proj", "22222222-2222-3333-4444-000000000350.jsonl")
+        write_jsonl(lone, [user(NOW, "u")])
+        self.assertEqual(km._spend_window_files(lone, since, now=NOW), [lone])
+        self.assertNotIn(lone, km._SPEND_TREE_CACHE)
+        self.assertNotIn("_subagent_transcripts(leaf)", inspect.getsource(km._spend_window_files), "the walk is the memo's first listing, not a per-call walk")
+        self.assertIn("os.scandir", inspect.getsource(km._spend_tree_list_dir))
+
+    def test_the_row_memos_stamp_carries_the_entrys_base_and_the_memo_is_capped(self):
+        km._SPEND_ROWS_CACHE.clear()
+        write_jsonl(self.leaf, [user(NOW - 100, "u"), assistant(NOW - 50, "m1", 1000)])
+        km._spend_file_rows(self.leaf, NOW - 600, PRICES, None)
+        ent = km.em._read_jsonl_entry(self.leaf, tail_ok=True)
+        self.assertEqual(km._SPEND_ROWS_CACHE[self.leaf][0], (ent[0], ent[1], ent[5]), "mtime, size, base (LOW a)")
+        self.assertEqual(len(km._SPEND_ROWS_CACHE[self.leaf]), 4, "and the last use, for the cap")
+        with mock.patch.object(km, "SPEND_GUARD_ROWS_CACHE_MAX", 2):
+            others = []
+            for i in range(3):
+                f = os.path.join(self.td.name, "proj", "agent-%d.jsonl" % i)
+                write_jsonl(f, [assistant(NOW - 40 + i, "m%d" % i, 100)])
+                time.sleep(0.005)
+                km._spend_file_rows(f, NOW - 600, PRICES, None)
+                others.append(f)
+            self.assertEqual(len(km._SPEND_ROWS_CACHE), 2, "capped (LOW b)")
+            self.assertEqual(sorted(km._SPEND_ROWS_CACHE), sorted(others[1:]), "the least recently used went first")
 
 
 class Ceiling(unittest.TestCase):
@@ -334,9 +402,23 @@ class Guard(unittest.TestCase):
         self.assertIn("; a stop was already in flight, and it has been told.", self.toasts[0]["text"])
         self.assertEqual((self._rows()[0]["stopped"], self._rows()[0]["stopping"], self._rows()[0]["told"]), (False, True, True))
 
+    def test_a_detached_hosted_session_is_not_pressed_and_the_sentence_says_its_host_keeps_the_turn(self):
+        # the round-two review's LOW c: the interrupt answers True for a detached session while the escalation is skipped
+        import types
+        self.be.sessions = {SID: types.SimpleNamespace(detached=True)}
+        self._spend(NOW, 200.0)
+        self._tick(NOW)
+        self.assertEqual(self.be.interrupts, [], "not pressed: the answer would say stopped while the host keeps the turn")
+        self.assertEqual(len(self.be.sends), 1, "told all the same")
+        row = self._rows()[-1]
+        self.assertIn("its host keeps the turn, so it was not stopped, but it has been told", row["text"])
+        self.assertEqual((row.get("detached"), row.get("stopped"), row.get("stopping"), row.get("told")), (True, False, False, True))
+        self.assertNotIn("refused: detached", inspect.getsource(km._spend_guard_fire), "the refusal prose names no branch it cannot reach")
+        self.assertNotIn(SID, km._interrupt_clicked, "no stop was pressed, so no stamp")
+
     def test_the_sentence_states_what_the_backend_actually_did(self):
         self._spend(NOW, 200.0)
-        self.be = FakeBackend(stops=False, accepts=False)   # detached, or no backend owns it: both refused
+        self.be = FakeBackend(stops=False, accepts=False)   # no backend owns it: both refused (a detached host is its own case)
         self._tick(NOW)
         self.assertIn("; it could not be stopped or told (no backend owns it).", self.toasts[0]["text"])
         self.assertEqual((self._rows()[0]["stopped"], self._rows()[0]["told"]), (False, False))
@@ -347,7 +429,7 @@ class Guard(unittest.TestCase):
             self.toasts.clear()
             km._spend_guard_tick(NOW + 1, {SID: {"state": "working"}}, sessions=self.sessions, be=None, clients=self.clients, prices=PRICES)
             bf.assert_called_with(SID)
-        self.assertIn("; it could not be stopped (the interrupt was refused: detached, or no backend owns it) but has been told.", self.toasts[0]["text"])
+        self.assertIn("; it could not be stopped (the interrupt was refused: no backend owns it) but has been told.", self.toasts[0]["text"])
 
     def test_the_fire_road_is_pinned_to_the_shared_doors(self):
         import inspect
@@ -363,7 +445,8 @@ class Guard(unittest.TestCase):
         handler = ui[i:ui.index("\n  }", i)]
         self.assertIn("warnToast(m.text);", handler)
         self.assertNotIn("failProvisional", handler, "never read as an in-flight create's verdict")
-        self.assertIn("_subagent_transcripts(leaf)", inspect.getsource(km._spend_window_files), "the canonical recursive walk")
+        self.assertIn("_spend_tree_list_dir(root, m, set(m[\"dirs\"]))", inspect.getsource(km._spend_window_files), "the tree memo's listing, the walk's rule kept")
+        self.assertIn("_spend_window_files(leaf, since, now)", inspect.getsource(km._spend_window_usd))
 
     def test_the_guard_never_starts_the_price_feed_fetch(self):
         """The cost view refreshes the remote price feed when its cache is stale; the guard runs on the pusher's path in

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -16633,6 +16633,13 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
     // provisional tab down with it; a toast would slide past the one moment it needed to be read.
     if (provisionalId) failProvisional(m.text); else warnToast(m.text);
   }
+  else if (m.type === "spendCeiling" && typeof m.text === "string" && m.text) {
+    // the spend guard's word (T350): a session crossed the hourly spend ceiling, or fell back under it. Its OWN type,
+    // never `warn`: a warn arriving while a create is in flight is read above as that create's verdict, and this
+    // sentence is about another session entirely. The durable record is the shell's bell (the row rides the problem
+    // ring); this is the moment's toast.
+    warnToast(m.text);
+  }
   // `err` is the LOUD channel, deliberately distinct from `warn` (the user 2026-07-29): a warn toast fades
   // after 12s, which is right for "that name has a bad character" and wrong for "the message you just typed
   // was never sent." This one takes the confirm modal — it has to be dismissed — and hands the text back,


### PR DESCRIPTION
A **spend guard** for every session (T350, the user 2026-09-11, after a team's review panels cost thousands of dollars in an hour): the kernel watches each session's instantaneous spend, and a session that crosses a ceiling of about a thousand dollars an hour is stopped, told, and surfaced to the user.

**What it reads.** Every pusher cycle, each live session's spend rate over the last ten minutes, scaled to an hour, from data the kernel already holds: the record cache the pusher serves the leaf transcript from, plus every agent transcript beside the leaf through the kernel's one recursive walk of the subagents tree (Task agents at the top, Workflow agents one level down under `workflows/wf_<id>/`, sibling agents after a fork, no symlink followed; only the files that changed inside the window are read). Each assistant record is priced by the cost view's per-model table; a response logged more than once (one record per content block, one message id) counts once at its largest usage row; a model the table cannot place counts at the dearest row, since a guard errs high. Each file's window rows are memoized on its (mtime, size) stamp, so an unchanged file is not walked again. No new transcript reads, no new ledger, and no network: the price table is merged without the cost view's feed refresh (the resolver grew a switch for it), since the guard runs in every kernel, hermetic test kernels included.

**The ceiling.** `spend-ceiling-usd-per-hour`, a bare-value file under the state directory like `session-hosts`, read at each check: 1000 with no file, any finite non-negative number in the file, `0` disables; nan, inf, a negative or a word that is not a number read as the default.

**On a crossing, once per crossing.** (1) The session is stopped by the Stop button's whole road (the interrupt, the interrupt-clicked stamp the chip reads, the retry suppression that keeps the auto-retry and the idle-queue drive from re-driving it, the views marked dirty), not pressed while an interrupt is already unsettled for it, and handed one message in the user's voice through the machine sends' door (parked while it compacts, behind the user's own queued messages, under a usage-limit hold): it is spending about so much an hour, far above what the user can afford, stop whatever is fanning out and say what it was before doing anything else. The backend is the session's own, and the sentence states what happened: stopped and told, a stop already in flight, or refused. (2) Every connected dashboard gets a `spendCeiling` message of its own (the chat bundle toasts it; never `warn`, which the chat reads as an in-flight create's verdict) naming the session, the rate and the moment; the durable record on every pane is the shell's bell, which mirrors the problem ring the row rides. (3) One `spend.ceiling` row in `session-events.jsonl` through the problem-row path, stamped with the crossing's moment and carrying `usdPerHour`, `ceilingUsdPerHour`, `windowS`, `stopped`, `stopping` and `told`; the kernel log and the error center carry it, and restart-metrics counts it with the other kinds. The crossing is the event: the latch holds while the rate stays high, survives a kernel restart (it is read back from the ledger's last row per session) and a session leaving and rejoining the live map, and no cycle repeats any of the three. Once the rate falls under half the ceiling a `spend.ceiling.cleared` row and a toast say so and the guard re-arms; a second crossing fires again.

**Design points.** The interrupt is deliberate: the message alone would land at the session's next tool boundary while its agents kept spending; stopping first is what the user asked for. The surfaces are the existing ones (the warn toast, the error center's problem ring, the session-events ledger), so no new dashboard element was needed; a persistent card would be the follow-up if the toast proves too easy to miss. The rate is a sliding window, so a burst that ends is forgotten after ten minutes and the guard measures what is happening now, not the day's total.

**Tests.** `tests/test_spend_guard.py`: synthetic transcripts with usage fields (a leaf and agent files beside it, a file outside the window, a response logged twice) and the window's dollars and rate; the setting's states (no file, a number, `0`, junk, empty); the tick through its seams (synthetic sessions, a fake backend, fake clients, the default prices): a session under the ceiling left alone; a crossing (interrupt, then one send whose prose names no machinery, one toast per client, the row's fields and stamp, the backend's log with the ring flag); the latch across a still-high cycle; the clearing under half; a second crossing; the ceiling file governing and `0` disabling; a departed session's latch dropped; the pusher hook after the spend-cap pause. `tests/test_injected_voice.py` renders the body with every other injected message (a stop order, exempt from the progress-ask rule as the wrap-up was). Documented in `docs/reference.md` under its own heading before Restart metrics. The extension bundle is untouched.

**Round two of the review.** The recursive walk of a session's subagents tree ran per live session on the pusher's 2 Hz loop; on this machine's largest tree (2,449 agent files in 176 directories) it cost 21.7 ms of CPU a call, measured, against about 0.4 ms for the flat glob it replaced. The guard now keeps a memo of each session's tree, watched by directory mtimes: a cycle stats the directories (a new file or subdirectory moves its parent's mtime, and a changed directory is listed again, recursing only into directories not yet known), stats the hot files every cycle (mtime at or after the window's floor) and the cold ones once per 30 s, so an agent waking after a long tool call is seen within a twentieth of the window. Measured on the three largest live trees (2,449, 2,216 and 2,211 files): 21.7, 20.7 and 20.7 ms a call before; 14.0, 13.0 and 12.8 ms for the memo's one-time first listing; 0.63, 0.58 and 0.63 ms a call in steady state, returning the same files. Three lows: the row memo's stamp carries the reader entry's base beside mtime and size, so a tail entry accepted after a restart and its later whole-file upgrade never share a memo; the row memo is capped at 4,000 entries, the least recently used going first; and a detached hosted session is read before the Stop road is pressed (the backend's interrupt would answer True while the CLI's escalation is skipped on purpose), the sentence and the row saying its host keeps the turn and it was not stopped, and the refusal prose no longer names a branch it cannot reach. There is no road to the host without pressing: the host's signal rung is the very escalation the detached state skips. Tests: the tree listed once then watched (one stat per directory, hot files every cycle, a new workflow agent seen through its directory's mtime, a cold file seen at the next full pass), the stamp's base and the cap, the detached session not pressed and its sentence.
