### PR TITLE
The feed's focused-session section: the chat's active tab's cards on top, above a divider, off by default (T347)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1532,6 +1532,10 @@ background:#9cd2ff;color:#0c1a2e;font-weight:600;cursor:pointer">Open</button>
 
 _clients = []                                # connected WS clients: {app, wid, send, alive}
 _clients_lock = threading.Lock()
+# wid -> the session id the chat pane of that dashboard window shows (None: no tab), from the chat's activeTab
+# (T347: the feed's focused-session section is a view of the chat pane's active tab; one window's panes share
+# a wid, so the chat's report is filed under it and read by that window's feed — _relay_active_chat below)
+_ACTIVE_CHAT_BY_WID = {}   # type: dict[str, str | None]
 _client_seen = [0.0]
 # SIDs seen ALIVE at any point during THIS kernel run. (Retained for diagnostics; it no longer drives
 # tabs — the user 2026-06-17 reversed the earlier keep-a-tab-when-it-dies rule: a dead session is now TIMELINE-ONLY,
@@ -43861,6 +43865,48 @@ def _apih_resend(client):
             pass
 
 
+def _active_chat_wid(client):
+    """The window key a chat's active tab is filed under: the client's wid as a string, "" for a pane that reported
+    none (a page opened outside a dashboard), so the record and every read use one key shape."""
+    return str(client.get("wid") or "")
+
+
+def _send_active_chat(client):
+    """Tell ONE feed client which session the chat pane of its window shows — {type: "activeChat", id: sid|null},
+    the value recorded for its wid — on the ("activeChat",) dedup slot, so an unchanged value is not re-sent
+    (_send_client, within _DEDUP_REPOST_S). Nothing when no chat of that window has reported yet: the feed keeps
+    its own resting state rather than reading a null the kernel never learned. Returns whether a frame was
+    offered to the slot. A socket that fails is marked dead by _client_send; the relay's other feeds go on.
+
+    Called from two arms of Handler._dispatch_ws: the chat's activeTab (through _relay_active_chat, every feed of
+    the window) and a FEED client's `ready`, between that arm's reset and its connect push, so a reloaded feed's
+    first paint already knows its focused session. The ready arm and not the WS handshake: a frame sent before
+    the bundle's ready lands in a document with no message listener (the ready arm's own comment), and a
+    reloaded feed is exactly the client that has to learn the focus."""
+    wid = _active_chat_wid(client)
+    if wid not in _ACTIVE_CHAT_BY_WID:
+        return False
+    try:
+        _send_client(client, ("activeChat",), {"type": "activeChat", "id": _ACTIVE_CHAT_BY_WID[wid]})
+    except Exception:
+        return False
+    return True
+
+
+def _relay_active_chat(client, sid):
+    """A chat client's activeTab: record the session under its window's wid (None for no tab) and send the window's
+    live feed clients the frame (T347: the feed's focused-session section is a view of the chat pane's active tab,
+    never a move of a card; one window's panes share a wid, and a pane outside a dashboard files under ""). The
+    two chat columns of a split window both report here and the later report stands. The client list is copied
+    under _clients_lock; the sends run outside it, as every other fan-out does."""
+    wid = _active_chat_wid(client)
+    _ACTIVE_CHAT_BY_WID[wid] = str(sid) if sid else None
+    with _clients_lock:
+        feeds = [c for c in _clients if c.get("alive") and c.get("app") == "feed" and _active_chat_wid(c) == wid]
+    for c in feeds:
+        _send_active_chat(c)
+
+
 # ── Web Push: the same bell events, delivered to the phone (plans/ios-app.md proposal 2; the user
 # 2026-08-07, who wants "needs you" to reach them wherever they are, not just the kernel box's
 # desktop). A device opts in from the shell's bell (mobile tab bar → _LANDING_PUSH_JS): it
@@ -53563,7 +53609,10 @@ class Handler(BaseHTTPRequestHandler):
             if msg.get("id"):
                 _release_skeleton(client, str(msg["id"]))   # a skeleton tab clicked: its full rides that push (2026-09-07)
             _pusher_wake.set()                 # …and that push starts when the in-flight cycle ends, not
-            return                             #    after the 0.5 s backstop (the tab switch IS the event)
+            #                                     after the 0.5 s backstop (the tab switch IS the event)
+            if client.get("app") == "chat":
+                _relay_active_chat(client, msg.get("id"))   # …and the window's feed learns which session is focused (T347)
+            return
         if msg and msg.get("type") == "needSlot" and msg.get("slot") in _DELTA_SLOTS:
             # The shim could not apply a view delta (its base revision did not match what it holds — a
             # frame it never saw, a reload mid-stream): forget what we believe it holds and re-send the
@@ -53663,6 +53712,8 @@ class Handler(BaseHTTPRequestHandler):
             # because cached bundles win the race). Same repair as needFull above, client-wide;
             # ready is posted once per renderer life, so this cannot loop.
             _client_reset_chat_base(client)
+            if client.get("app") == "feed":
+                _send_active_chat(client)      # T347: the window's focus, ahead of the first paint
             # Capture the seq of the views blob the pushes below serve — from the frames THIS thread
             # enqueues, so a pusher-thread frame landing meanwhile is not mistaken for the connect push's
             # (the caps frame's viewsSeq, see KERNEL_WS_CAPS)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -39825,7 +39825,12 @@ def _client_reset_chat_base(client):
         # is nothing it could lazily reload — every tab must arrive whole, and the status slots go with the set
         client.pop("skeleton", None); client.pop("skeletonOrder", None); client.pop("reconnect", None)
         snt = client.get("sent", {})
-        for k in [k for k in snt if isinstance(k, tuple) and k and k[0] in ("chat", "status", "taborder")]:
+        # …and the ("activeChat",) slot (T347): a feed page that reloads registers while its bundle still
+        # evaluates, and a tab switch in its window relays a frame to a document with no listener yet; the
+        # slot remembers that frame, so the ready arm's re-send would be deduped for _DEDUP_REPOST_S and the
+        # section would read "no session is focused" until the next tab click. A renderer that just
+        # evaluated holds nothing: the slot goes with the others.
+        for k in [k for k in snt if isinstance(k, tuple) and k and k[0] in ("chat", "status", "taborder", "activeChat")]:
             snt.pop(k, None)
 
 
@@ -43891,6 +43896,16 @@ def _send_active_chat(client):
     except Exception:
         return False
     return True
+
+
+def _forget_active_chat_if_last(client):
+    """Drop the window's active-chat record when the client leaving was the last pane of that wid: the dict
+    is keyed by dashboard window id, and a window closed for good must not keep an entry for the kernel's
+    life (one per window ever opened). Called under _clients_lock, after the client left _clients; a window
+    with another pane still connected (its chat, a second feed) keeps the record for that pane's reload."""
+    wid = _active_chat_wid(client)
+    if wid in _ACTIVE_CHAT_BY_WID and not any(_active_chat_wid(c) == wid for c in _clients):
+        _ACTIVE_CHAT_BY_WID.pop(wid, None)
 
 
 def _relay_active_chat(client, sid):
@@ -54756,6 +54771,7 @@ class Handler(BaseHTTPRequestHandler):
             with _clients_lock:
                 if client in _clients:
                     _clients.remove(client)
+                _forget_active_chat_if_last(client)   # the window's focus record goes with its last pane (T347)
             _release_client_holds(client)          # its open editors' holds go with it: the disconnect is the event (T306)
 
     def _remote_ws(self, host, query):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -54771,8 +54771,9 @@ class Handler(BaseHTTPRequestHandler):
             with _clients_lock:
                 if client in _clients:
                     _clients.remove(client)
-                _forget_active_chat_if_last(client)   # the window's focus record goes with its last pane (T347)
             _release_client_holds(client)          # its open editors' holds go with it: the disconnect is the event (T306)
+            with _clients_lock:
+                _forget_active_chat_if_last(client)   # the window's focus record goes with its last pane (T347)
 
     def _remote_ws(self, host, query):
         """GET /remote/<host>/ws — relay a federated-dashboard WebSocket to an attached host's

--- a/tests/test_chat_skeleton_reconnect.py
+++ b/tests/test_chat_skeleton_reconnect.py
@@ -410,7 +410,7 @@ class SkeletonReconnect(unittest.TestCase):
         self.assertIn("_release_skeleton_locked(client, sid)", inspect.getsource(km._client_reset_chat_sid))
         s = inspect.getsource(km._client_reset_chat_base)
         for k in ('client.pop("skeleton", None)', 'client.pop("skeletonOrder", None)',
-                  'client.pop("reconnect", None)', 'k[0] in ("chat", "status", "taborder")'):
+                  'client.pop("reconnect", None)', 'k[0] in ("chat", "status", "taborder", "activeChat")'):
             self.assertIn(k, s)
         s = inspect.getsource(km._push)
         self.assertIn("_send_chat_or_status(c, m, ms, change_from, led_changed)", s)

--- a/tests/test_feed_focus_served.py
+++ b/tests/test_feed_focus_served.py
@@ -206,8 +206,24 @@ await park();
 const reloaded = await survey();
 await deliver({ type: "activeChat", id: cfg.web });
 const restored = await survey();
+// (h) Clear on the SECTION's copy clears the card: both elements dismiss and leave together; Undo brings both back
+// (the review of T347: the copy ran the board builder's finish, which guarded on the board's element, so the copy
+// stayed and the card below never left)
+const keyState = () => page.evaluate((k) => {
+  const f = document.querySelector(`#feed-focus [data-key="f:a:${k}"]`), a = document.querySelector(`#feed-cols [data-key="a:${k}"]`);
+  return { copy: !!f, board: !!a, copyDismissing: !!(f && f.classList.contains("dismissing")), boardDismissing: !!(a && a.classList.contains("dismissing")) };
+}, cfg.webDone);
+await page.locator(`#feed-focus [data-key="f:a:${cfg.webDone}"] .fdismiss`, { hasText: /^Clear$/ }).click();   // the card's Clear (its Continue wears the same chrome)
+const clearing = await keyState();                    // right after the click: both copies wear .dismissing
+await page.waitForTimeout(300);                       // the 180 ms finish, with room
+const cleared = await keyState();
+await page.waitForSelector("#feed-undoclear", { state: "visible", timeout: 10000 });
+await page.click("#feed-undoclear");
+await page.waitForSelector(`#feed-cols [data-key="a:${cfg.webDone}"]`, { timeout: 10000 });
+await frame();
+const undone = await keyState();
 fs.writeSync(1, "RESULT:" + JSON.stringify({ off, offFocused, rowsBefore, on, rowsAfter, dark, light: lit, api, none, bare,
-                                              storedBefore, reloaded, restored, errors }) + "\n");
+                                              storedBefore, reloaded, restored, clearing, cleared, undone, errors }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -361,6 +377,14 @@ class ServedFocusedSessionSection(unittest.TestCase):
         self.assertEqual(sorted(c["key"] for c in rs["secCards"]), sorted(WEB_KEYS), "…and web's three copies: %r" % rs["secCards"])
         self.assertEqual(self._by_col(rs["secCards"], WEB_KEYS), self._by_col(rs["boardCards"], web_board_keys), "per column the same titles as the board's")
         self.assertEqual(sorted(c["key"] for c in rs["boardCards"]), board_keys, "the board below is whole after the reload too")
+
+        # (h) Clear on the section's copy: both elements dismiss, both leave, Undo restores both (review of T347)
+        cg, cd, un = r["clearing"], r["cleared"], r["undone"]
+        self.assertEqual((cg["copy"], cg["board"], cg["copyDismissing"], cg["boardDismissing"]), (True, True, True, True),
+                         "right after the click both copies wear .dismissing: %r" % cg)
+        self.assertEqual((cd["copy"], cd["board"]), (False, False), "after the finish neither element remains: %r" % cd)
+        self.assertEqual((un["copy"], un["board"], un["copyDismissing"], un["boardDismissing"]), (True, True, False, False),
+                         "Undo restores the card below and its copy above, neither still dismissing: %r" % un)
 
 
 if __name__ == "__main__":

--- a/tests/test_feed_focus_served.py
+++ b/tests/test_feed_focus_served.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""T347 (the user 2026-09-11, who wanted the focused session's cards on top of the feed): THE FOCUSED SESSION SECTION.
+
+When a session tab has focus in the chat pane, the feed shows that session's cards ABOVE a horizontal divider — the
+board's three columns (Working / Blocked / Completed), a miniature of the feed for one session, headed by the session's
+name — while the board below stays exactly as it is, so those cards appear twice. OFF by default; the View menu's
+fourth row ("Show focused session") switches it, persisted in the feed's view state under `focused`; the kernel relays
+the chat pane's active tab to the feed clients of the same window as {type:"activeChat", id}. EVENT-based: the section
+rebuilds on that frame and on the feed's own frames, never on a timer; no card below moves because of it (a view, not a
+move).
+
+The served guard drives the real /feed page from a hermetic kernel and hands it a SYNTHETIC payload — the notes-api demo
+world: `web` with a card in each column, `api` with one working card, `tests` with none — through the page's own frame
+path (a MessageEvent, exactly what the socket shim dispatches), then walks the whole lab in one browser run:
+  (a) the switch off (the default): no #feed-focus anywhere;
+  (b) an activeChat frame for `web` with the switch off: still no section;
+  (c) the View menu's "Show focused session" row clicked: the section is #feed-list's first child, right above
+      #feed-cols, headed `web`, its three columns holding exactly web's cards (the same titles per column as web's
+      cards on the board), the divider under it, every board card still where it was, the row aria-checked;
+  (d) an activeChat frame for `api`: the section rebuilds with api's one card, read one animation frame after the
+      dispatch (no timer to wait out);
+  (e) an activeChat frame with a null id: the one quiet line "No session is focused in the chat"; a frame for `tests`,
+      a session with no cards: "tests has no cards";
+  (f) a reload keeps the switch on (romp:feedview carries `"focused":true`) — the section is back with the no-focus line
+      (the sid is not persisted; a reloaded feed is told again) — and a fresh frame restores web's cards;
+  (g) both themes: the divider and the quiet line take their colours from the theme's tokens, so the light theme
+      (the classes the feed's theme switch sets) recolours them.
+Screenshots with FEED_FOCUS_SHOTS=<path-prefix>: -off-dark, -off-light, -on-dark, -on-light (the "on" pair with web
+focused). Skips LOUDLY without the extension deps or a Playwright browser (CI's Python jobs install none;
+ROMP_SERVED_TESTS_REQUIRE=1 turns the skips red where the browser is installed). The CI-safe source pins ride
+ui/webview/feed-focus-section.test.ts, the pure pick ui/webview/feed-focus-entries.test.ts, the persisted key
+ui/webview/feed-view-state.test.ts, the kernel relay tests/test_kernel_active_chat_relay.py. All fixtures synthetic.
+"""
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes: an
+#                                   imported TestCase would be collected here a second time)
+
+SID_WEB = "aaaaaaaa-1111-2222-3333-777777777777"
+SID_API = "aaaaaaaa-1111-2222-3333-888888888888"
+SID_TESTS = "aaaaaaaa-1111-2222-3333-999999999999"
+WEB_BLOCKED = "cccccccc-1111-2222-3333-000000000001"
+WEB_WORKING = "cccccccc-1111-2222-3333-000000000002"
+WEB_DONE = "cccccccc-1111-2222-3333-000000000003"
+API_WORKING = "cccccccc-1111-2222-3333-000000000011"
+WEB_KEYS = {"f:a:" + WEB_BLOCKED, "f:a:" + WEB_WORKING, "f:a:" + WEB_DONE}
+
+NO_FOCUS = "No session is focused in the chat"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+// tall enough for the section AND the board under it: the screenshots show both
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 });
+const errors = [];   // an exception mid-render aborts the view-state write: every page error is evidence
+page.on("pageerror", (e) => errors.push(String(e && e.stack || e).slice(0, 400)));
+page.on("console", (m) => { if (m.type() === "error") errors.push("console: " + m.text().slice(0, 300)); });
+const ready = async () => {
+  // the columns are built by the first render, which the first payload triggers: wait for the page's script, not the DOM
+  await page.waitForFunction(() => document.readyState === "complete" && typeof window.acquireVsCodeApi === "function", null, { timeout: 20000 });
+  await page.waitForTimeout(600);
+};
+await page.goto(cfg.feed);
+await ready();
+// the synthetic payload: web with a card in EACH column, api with one working card, tests listed with none
+const now = Math.floor(Date.now() / 1000);
+const ask = (itemId, sid, name, column, text, t) => ({ itemId, sid, name, color: cfg.colors[name], text, t, live: true,
+  turnId: "turn-" + itemId.slice(-2), trgb: [30, 161, 235], column, tree: [] });   // tree: the card's (empty) sub-goal DAG — render iterates it
+const payload = { type: "feed", asks: [
+    ask(cfg.webBlocked, cfg.web, "web", "needs_input", "notes-api: pick the retry policy", now - 300),
+    ask(cfg.webWorking, cfg.web, "web", "working", "notes-api: draft the search index", now - 60),
+    ask(cfg.webDone, cfg.web, "web", "completed", "notes-api: write the index schema", now - 240),
+    ask(cfg.apiWorking, cfg.api, "api", "working", "notes-api: wire the tag filter", now - 120)],
+  sessions: [{ sid: cfg.web, name: "web" }, { sid: cfg.api, name: "api" }, { sid: cfg.tests, name: "tests" }],
+  order: [cfg.web, cfg.api, cfg.tests] };
+// the page's own frame path; then ONE animation frame — the handler renders synchronously, there is no timer to wait out
+const deliver = (m) => page.evaluate((m) => new Promise((res) => {
+  window.dispatchEvent(new MessageEvent("message", { data: m }));
+  requestAnimationFrame(() => res(null));
+}), m);
+const frame = () => page.evaluate(() => new Promise((res) => requestAnimationFrame(() => res(null))));
+// off every card: a hovered card holds the board (hover-freeze) and would defer the section's repaint to the release
+const park = async () => { await page.mouse.move(2, 2); await page.waitForTimeout(120); };
+await deliver(payload);
+for (const id of [cfg.webBlocked, cfg.webWorking, cfg.webDone, cfg.apiWorking]) await page.waitForSelector(`#feed-cols [data-key="a:${id}"]`, { timeout: 10000 });
+await park();
+const survey = () => page.evaluate(() => {
+  const COLS = ["asks", "needsInput", "completed"];
+  const list = document.getElementById("feed-list");
+  const board = document.getElementById("feed-cols");
+  const sec = document.getElementById("feed-focus");
+  const cards = (root) => root ? Array.from(root.querySelectorAll(".fitem[data-key]")).map((c) => ({
+    key: c.dataset.key, col: (c.closest(".feed-col")?.className.match(/\bcol-(asks|needsInput|completed)\b/) || [])[1] || null,
+    title: c.querySelector(".fcard-title")?.textContent || "", name: c.querySelector(".fname")?.textContent || "" })) : [];
+  const shown = (e) => !!e && e.style.display !== "none";
+  const q = (s) => sec ? sec.querySelector(s) : null;
+  return {
+    section: !!sec, label: sec ? sec.getAttribute("aria-label") : null,
+    first: list && list.firstElementChild ? (list.firstElementChild.id || list.firstElementChild.className) : null,
+    aboveBoard: sec ? sec.nextElementSibling === board : null,
+    kids: sec ? Array.from(sec.children).map((c) => c.tagName.toLowerCase() + "." + c.className.split(" ").join(".")) : [],
+    headShown: shown(q(".feed-focus-head")), headName: q(".feed-focus-head .fname")?.textContent ?? null, cap: q(".feed-focus-cap")?.textContent ?? null,
+    emptyShown: shown(q(".feed-focus-empty")), emptyText: q(".feed-focus-empty")?.textContent ?? null,
+    colsShown: shown(q(".feed-focus-cols")),
+    chips: sec ? Array.from(sec.querySelectorAll(".feed-focus-cols .feed-col-head .fcol-chip")).map((c) => c.textContent) : [],
+    counts: sec ? Object.fromEntries(COLS.map((k) => [k, q(".feed-focus-cols .col-" + k + " .feed-col-count")?.textContent ?? null])) : {},
+    folds: sec ? sec.querySelectorAll(".fcol-fold").length : 0,
+    divider: !!q("hr.feed-focus-divider"),
+    secCards: cards(sec), boardCards: cards(board),
+    hovered: !!document.querySelector(".fitem:hover"),
+    stored: localStorage.getItem("romp:feedview"),
+  };
+});
+const light = async (on) => {   // LIGHT theme: the classes the feed's theme switch sets
+  await page.evaluate((on) => { document.body.classList[on ? "add" : "remove"]("chat-theme-yatharth", "theme-light"); }, on);
+  await page.waitForTimeout(250);
+};
+const theme = () => page.evaluate(() => {
+  const d = document.querySelector("#feed-focus .feed-focus-divider"), e = document.querySelector("#feed-focus .feed-focus-empty"),
+        n = document.querySelector("#feed-focus .feed-focus-head .fname"), c = document.querySelector("#feed-focus .feed-focus-cap");
+  if (!d || !e || !n || !c) return null;
+  return { divider: getComputedStyle(d).borderTopColor, empty: getComputedStyle(e).color, cap: getComputedStyle(c).color,
+           emptySize: getComputedStyle(e).fontSize, headSize: getComputedStyle(n).fontSize, capSize: getComputedStyle(c).fontSize };
+});
+// (a) the default: the switch off, no section
+const off = await survey();
+// (b) the chat focuses web while the switch is off: nothing appears
+await deliver({ type: "activeChat", id: cfg.web });
+const offFocused = await survey();
+if (cfg.shots) {
+  await page.screenshot({ path: cfg.shots + "-off-dark.png" });
+  await light(true);
+  await page.screenshot({ path: cfg.shots + "-off-light.png" });
+  await light(false);
+}
+// (c) the View menu's row
+const menuRows = () => page.evaluate(() => Array.from(document.querySelectorAll(".feed-viewmenu .ctx-item")).map((r) => ({
+  text: r.textContent, role: r.getAttribute("role"), checked: r.getAttribute("aria-checked") })));
+await page.waitForSelector("#feed-viewbtn", { state: "visible", timeout: 10000 });
+await page.click("#feed-viewbtn");
+await page.waitForSelector(".feed-viewmenu .ctx-item", { timeout: 10000 });
+const rowsBefore = await menuRows();
+await page.locator(".feed-viewmenu .ctx-item", { hasText: "Show focused session" }).click();
+await page.waitForSelector(".feed-viewmenu", { state: "detached", timeout: 10000 });   // a row click closes the menu
+await park();
+await frame();
+const on = await survey();
+await page.click("#feed-viewbtn");
+await page.waitForSelector(".feed-viewmenu .ctx-item", { timeout: 10000 });
+const rowsAfter = await menuRows();
+await page.keyboard.press("Escape");
+await page.waitForSelector(".feed-viewmenu", { state: "detached", timeout: 10000 });
+await park();
+// (g) both themes, with web focused
+const dark = await theme();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-on-dark.png" });
+await light(true);
+const lit = await theme();
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-on-light.png" });
+await light(false);
+// (d) the chat focuses api: the section rebuilds on the frame, read one animation frame later
+await deliver({ type: "activeChat", id: cfg.api });
+const api = await survey();
+// (e) no tab has focus; then a session with no cards
+await deliver({ type: "activeChat", id: null });
+const none = await survey();
+await deliver({ type: "activeChat", id: cfg.tests });
+const bare = await survey();
+// (f) RELOAD: the switch persists; the sid does not (the kernel tells a registering feed again — here nothing is recorded)
+const storedBefore = await page.evaluate(() => localStorage.getItem("romp:feedview"));
+await page.reload();
+await ready();
+await deliver(payload);
+await page.waitForSelector(`#feed-cols [data-key="a:${cfg.webWorking}"]`, { timeout: 10000 });
+await park();
+const reloaded = await survey();
+await deliver({ type: "activeChat", id: cfg.web });
+const restored = await survey();
+fs.writeSync(1, "RESULT:" + JSON.stringify({ off, offFocused, rowsBefore, on, rowsAfter, dark, light: lit, api, none, bare,
+                                              storedBefore, reloaded, restored, errors }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedFocusedSessionSection(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="feedfocus-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        os.makedirs(state, exist_ok=True)
+        cls.port = _free_port()
+        cls.token = "testtok-feedfocus"
+        env = _lab.kernel_env(cls.lab, os.path.join(cls.lab, "claude"), dist, cls.port, cls.token)
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(os.path.join(cls.lab, "kernel.log"), "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    @staticmethod
+    def _by_col(cards, keys):
+        """{column: sorted titles} of the cards whose data-key is in `keys`."""
+        out = {}
+        for c in cards:
+            if c["key"] in keys:
+                out.setdefault(c["col"], []).append(c["title"])
+        return {k: sorted(v) for k, v in out.items()}
+
+    def test_the_section_follows_the_chats_active_tab_switches_on_from_the_view_menu_and_persists(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"feed": "http://127.0.0.1:%d/feed?token=%s" % (self.port, self.token),
+                       "web": SID_WEB, "api": SID_API, "tests": SID_TESTS,
+                       "webBlocked": WEB_BLOCKED, "webWorking": WEB_WORKING, "webDone": WEB_DONE, "apiWorking": API_WORKING,
+                       "colors": {"web": {"bg": "#1EA1EB", "fg": "#ffffff"}, "api": {"bg": "#E0A526", "fg": "#000000"}},
+                       "shots": os.environ.get("FEED_FOCUS_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertEqual(r.get("errors"), [], "the page threw nothing (an exception mid-render would skip the view-state write): %r" % r.get("errors"))
+        off, on = r["off"], r["on"]
+        board_keys = sorted(c["key"] for c in off["boardCards"])
+        web_board_keys = {"a:" + WEB_BLOCKED, "a:" + WEB_WORKING, "a:" + WEB_DONE}
+        # the world: four cards on the board, web's three in three different columns, api's one in Working
+        self.assertEqual(board_keys, sorted(["a:" + WEB_BLOCKED, "a:" + WEB_WORKING, "a:" + WEB_DONE, "a:" + API_WORKING]), "four cards landed: %r" % off["boardCards"])
+        self.assertEqual(self._by_col(off["boardCards"], web_board_keys),
+                         {"needsInput": ["notes-api: pick the retry policy"], "asks": ["notes-api: draft the search index"], "completed": ["notes-api: write the index schema"]},
+                         "web has a card in each column: %r" % off["boardCards"])
+        # (a) OFF by default: no section, and nothing saved says otherwise
+        self.assertFalse(off["section"], "the switch is off by default — no #feed-focus: %r" % off)
+        self.assertNotIn('"focused":true', off["stored"] or "", "a fresh view state does not carry the switch on: %r" % (off["stored"] or "")[:300])
+        # (b) the chat focuses web while the switch is off: still nothing (the sid is remembered, the section is not built)
+        self.assertFalse(r["offFocused"]["section"], "an activeChat frame with the switch off builds no section: %r" % r["offFocused"])
+        self.assertEqual(sorted(c["key"] for c in r["offFocused"]["boardCards"]), board_keys, "…and moves no card")
+        # (c) the View menu: the fourth row, a ✓ row, unchecked before the click
+        rows = r["rowsBefore"]
+        self.assertEqual(len(rows), 4, "four rows: %r" % rows)
+        self.assertEqual((rows[3]["text"], rows[3]["role"], rows[3]["checked"]), ("Show focused session", "menuitemcheckbox", "false"), "the row before the click: %r" % rows)
+        self.assertEqual(r["rowsAfter"][3]["checked"], "true", "the row is aria-checked after the click: %r" % r["rowsAfter"])
+        self.assertEqual([x["text"] for x in r["rowsAfter"][:3]], [x["text"] for x in rows[:3]], "the other rows are untouched")
+        # the section: #feed-list's first child, directly above #feed-cols, its parts in order
+        self.assertTrue(on["section"], "the click built the section: %r" % on)
+        self.assertFalse(on["hovered"], "no card is hovered (a hovered card would hold the repaint): %r" % on)
+        self.assertEqual(on["first"], "feed-focus", "the section is the first child of #feed-list: %r" % on["first"])
+        self.assertTrue(on["aboveBoard"], "…directly before #feed-cols")
+        self.assertEqual(on["label"], "the chat's focused session")
+        self.assertEqual(on["kids"], ["div.feed-focus-head", "div.feed-focus-empty", "div.feed-cols.feed-focus-cols", "hr.feed-focus-divider"], "head, quiet line, columns, rule: %r" % on["kids"])
+        self.assertTrue(on["divider"], "the rule under the section")
+        # headed by the session's name, with the one word saying why it sits on top
+        self.assertTrue(on["headShown"], "the head shows for a focused session")
+        self.assertEqual(on["headName"], "web", "the head names the focused session: %r" % on["headName"])
+        self.assertEqual(on["cap"], "focused")
+        self.assertFalse(on["emptyShown"], "no quiet line while the session has cards: %r" % on["emptyText"])
+        self.assertTrue(on["colsShown"])
+        # the board's three columns, the board's chips, no fold caret; each column counts its one card
+        self.assertEqual(on["chips"], ["Working", "Blocked", "Completed"], "the same column chips as the board: %r" % on["chips"])
+        self.assertEqual(on["folds"], 0, "the section's heads carry no fold caret")
+        self.assertEqual(on["counts"], {"asks": "1", "needsInput": "1", "completed": "1"}, "one card per column: %r" % on["counts"])
+        # exactly web's cards, per column the same titles as web's cards on the board, under the section's own keys
+        self.assertEqual(sorted(c["key"] for c in on["secCards"]), sorted(WEB_KEYS), "the section holds web's three cards under f: keys: %r" % on["secCards"])
+        self.assertEqual(self._by_col(on["secCards"], WEB_KEYS), self._by_col(on["boardCards"], web_board_keys),
+                         "per column, the section's titles are web's titles on the board: %r vs %r" % (on["secCards"], on["boardCards"]))
+        self.assertTrue(all(c["name"] == "web" for c in on["secCards"]), "every copy names web: %r" % on["secCards"])
+        # THE BOARD IS UNTOUCHED: every card below is still there, same count, same columns (a view, not a move)
+        self.assertEqual(sorted(c["key"] for c in on["boardCards"]), board_keys, "every board card is still on the board: %r" % on["boardCards"])
+        self.assertEqual({c["key"]: c["col"] for c in on["boardCards"]}, {c["key"]: c["col"] for c in off["boardCards"]}, "…in the column it had")
+        self.assertIn('"focused":true', on["stored"] or "", "the switch is persisted in the view state: %r" % (on["stored"] or "")[:300])
+        # (g) both themes: the rule and the quiet line read the theme's tokens, so the light theme recolours them
+        dark, lit = r["dark"], r["light"]
+        self.assertIsNotNone(dark, "the theme probe found the section's parts")
+        self.assertEqual(dark["divider"], "rgba(255, 255, 255, 0.12)", "dark: the menus' hairline (--menu-border): %r" % dark)
+        self.assertEqual(lit["divider"], "rgba(0, 0, 0, 0.12)", "light: the light theme's hairline: %r" % lit)
+        self.assertNotEqual(dark["empty"], lit["empty"], "the quiet line's colour follows --dim across themes: %r vs %r" % (dark, lit))
+        self.assertNotEqual(dark["cap"], lit["cap"], "…and so does the 'focused' word's")
+        self.assertEqual(lit["headSize"], dark["headSize"], "geometry is not theme: the head's size holds across themes")
+        # (d) the chat focuses api: the section rebuilt on the frame — api's one card in Working, web's copies gone
+        api = r["api"]
+        self.assertEqual(api["headName"], "api", "the head follows the focus: %r" % api["headName"])
+        self.assertEqual([(c["key"], c["col"], c["title"]) for c in api["secCards"]], [("f:a:" + API_WORKING, "asks", "notes-api: wire the tag filter")], "exactly api's card: %r" % api["secCards"])
+        self.assertEqual(api["counts"], {"asks": "1", "needsInput": "", "completed": ""}, "the counts follow: %r" % api["counts"])
+        self.assertEqual(sorted(c["key"] for c in api["boardCards"]), board_keys, "the board below still holds all four")
+        # (e) no tab has focus: the head steps aside for the one quiet line; then a focused session with no cards
+        none = r["none"]
+        self.assertTrue(none["section"] and none["emptyShown"], "the section stays, with the quiet line: %r" % none)
+        self.assertEqual(none["emptyText"], NO_FOCUS)
+        self.assertFalse(none["headShown"] or none["colsShown"], "no head, no columns without a focus: %r" % none)
+        self.assertEqual(none["secCards"], [], "no copies without a focus")
+        self.assertTrue(none["divider"], "the rule stays, so the section still reads as a section")
+        bare = r["bare"]
+        self.assertEqual((bare["headShown"], bare["headName"], bare["emptyShown"], bare["emptyText"], bare["colsShown"], bare["secCards"]),
+                         (True, "tests", True, "tests has no cards", False, []), "a focused session with no cards keeps its head and says so: %r" % bare)
+        # (f) RELOAD: the switch survives (the stored blob), the sid does not — the fresh page shows the no-focus line
+        # until the kernel tells it again; a fresh frame restores web's cards
+        self.assertIn('"focused":true', r["storedBefore"] or "", "stored before the reload: %r" % (r["storedBefore"] or "")[:300])
+        rl, rs = r["reloaded"], r["restored"]
+        self.assertTrue(rl["section"], "the reloaded page builds the section from the persisted switch: %r" % rl)
+        self.assertEqual((rl["emptyShown"], rl["emptyText"], rl["headShown"]), (True, NO_FOCUS, False), "…with the no-focus line, the sid unpersisted: %r" % rl)
+        self.assertEqual(rs["headName"], "web", "a fresh activeChat frame restores the head: %r" % rs["headName"])
+        self.assertEqual(sorted(c["key"] for c in rs["secCards"]), sorted(WEB_KEYS), "…and web's three copies: %r" % rs["secCards"])
+        self.assertEqual(self._by_col(rs["secCards"], WEB_KEYS), self._by_col(rs["boardCards"], web_board_keys), "per column the same titles as the board's")
+        self.assertEqual(sorted(c["key"] for c in rs["boardCards"]), board_keys, "the board below is whole after the reload too")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_active_chat_relay.py
+++ b/tests/test_kernel_active_chat_relay.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""The active-chat relay (T347, the user 2026-09-11, who wanted the focused session's cards on top of the feed).
+
+The feed's focused-session section is a view of the chat pane's active tab. The chat pane already posts
+{type: "activeTab", id} on every tab switch; the kernel now files that sid under the poster's dashboard-window id
+(wid — one window's panes share it) in _ACTIVE_CHAT_BY_WID and sends the same window's feed clients
+{type: "activeChat", id: sid|null} on the ("activeChat",) dedup slot; a feed whose bundle says ready is sent the
+current value ahead of its connect push, so a reloaded feed learns the focus without waiting for a tab switch.
+Nothing else in the push cycle changes, and no card moves: the section is a view.
+
+Drives the REAL Handler._dispatch_ws over fake clients (the test_chat_skeleton_reconnect.py shape). Synthetic
+only: placeholder session ids, dashboard ids W1/W2/W3.
+"""
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+# Hermetic state BEFORE the loads — they resolve their state root at import time, and only
+# pytest runs conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_active_chat_relay", os.path.join(BIN, "romp-kernel"))
+
+WEB = "aaaaaaaa-1111-4111-8111-111111111111"    # the notes-api demo world's `web` session
+API = "aaaaaaaa-2222-4222-8222-222222222222"    # …and its `api` session
+
+
+class _Self:
+    """The handler's `self` for _dispatch_ws: the ready arm's connect push is the one method reached here."""
+    def __init__(self):
+        self.calls = []
+
+    def _push_one(self, client):
+        self.calls.append(client)
+
+
+def _dispatch(msg, client):
+    km.Handler._dispatch_ws(_Self(), msg, client)
+
+
+class ActiveChatRelay(unittest.TestCase):
+    def setUp(self):
+        self._clients = list(km._clients)
+        self._record = dict(km._ACTIVE_CHAT_BY_WID)
+        del km._clients[:]
+        km._ACTIVE_CHAT_BY_WID.clear()
+        km._pusher_wake.clear()
+
+    def tearDown(self):
+        del km._clients[:]
+        km._clients.extend(self._clients)
+        km._ACTIVE_CHAT_BY_WID.clear()
+        km._ACTIVE_CHAT_BY_WID.update(self._record)
+
+    def _client(self, app, wid=None, register=True, send=None):
+        frames = []
+        c = {"app": app, "alive": True, "sent": {}, "_frames": frames,
+             "send": send or (lambda s: frames.append(json.loads(s)))}
+        if wid is not None:
+            c["wid"] = wid
+        if register:
+            km._clients.append(c)
+        return c
+
+    @staticmethod
+    def _relayed(c):
+        return [f for f in c["_frames"] if f["type"] == "activeChat"]
+
+    def test_01_a_tab_switch_reaches_the_feed_of_the_same_window_only(self):
+        chat = self._client("chat", "W1")
+        feed1 = self._client("feed", "W1")
+        feed2 = self._client("feed", "W2")
+        timeline = self._client("timeline", "W1")
+        chat2 = self._client("chat", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        self.assertEqual(self._relayed(feed1), [{"type": "activeChat", "id": WEB}])
+        for c, what in ((feed2, "another window's feed"), (timeline, "the window's timeline"),
+                        (chat, "the poster"), (chat2, "the window's other chat column")):
+            self.assertEqual(c["_frames"], [], what + " is sent nothing")
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID, {"W1": WEB})
+        # the arm's own work is untouched: the active tab is recorded and the pusher is woken
+        self.assertEqual(chat["active"], WEB)
+        self.assertTrue(km._pusher_wake.is_set())
+        self.assertIn(("activeChat",), feed1["sent"], "the frame rides its own dedup slot")
+
+    def test_02_the_same_tab_again_is_deduped_and_a_different_one_relays(self):
+        chat = self._client("chat", "W1")
+        feed = self._client("feed", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        self.assertEqual([f["id"] for f in self._relayed(feed)], [WEB], "an unchanged value is not re-sent")
+        _dispatch({"type": "activeTab", "id": API}, chat)
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        self.assertEqual([f["id"] for f in self._relayed(feed)], [WEB, API, WEB])
+
+    def test_03_no_tab_relays_null(self):
+        chat = self._client("chat", "W1")
+        feed = self._client("feed", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        _dispatch({"type": "activeTab", "id": None}, chat)          # the chat says no tab has focus
+        self.assertEqual([f["id"] for f in self._relayed(feed)], [WEB, None])
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID, {"W1": None}, "recorded as None, and the key stays")
+        _dispatch({"type": "activeTab", "id": API}, chat)
+        _dispatch({"type": "activeTab"}, chat)                      # …or omits the id altogether
+        self.assertEqual([f["id"] for f in self._relayed(feed)], [WEB, None, API, None])
+        _dispatch({"type": "activeTab", "id": ""}, chat)            # an empty id is no tab, and no new value
+        self.assertEqual([f["id"] for f in self._relayed(feed)], [WEB, None, API, None])
+
+    def test_04_a_feed_that_says_ready_learns_the_current_focus_once(self):
+        chat = self._client("chat", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)           # recorded with no feed connected yet
+        feed = self._client("feed", "W1")                             # …then the window's feed (re)loads
+        h = _Self()
+        km.Handler._dispatch_ws(h, {"type": "ready"}, feed)
+        self.assertEqual(h.calls, [feed], "the connect push still runs")
+        self.assertEqual(self._relayed(feed), [{"type": "activeChat", "id": WEB}])
+        types = [f["type"] for f in feed["_frames"]]
+        self.assertIn("caps", types, "the ready arm's own closing frame")
+        self.assertLess(types.index("activeChat"), types.index("caps"),
+                        "ahead of the connect push, never after the caps frame the shim's redial gate reads")
+        km.Handler._dispatch_ws(_Self(), {"type": "ready"}, feed)
+        self.assertEqual(len(self._relayed(feed)), 1, "a second ready re-sends nothing: the slot dedups it")
+        # a window whose chat has never reported gets no frame at all — not even a null
+        other = self._client("feed", "W3")
+        km.Handler._dispatch_ws(_Self(), {"type": "ready"}, other)
+        self.assertEqual(self._relayed(other), [])
+        self.assertNotIn(("activeChat",), other["sent"])
+        # and a chat, timeline or shell that says ready is never sent one, whatever its window holds
+        for app in ("chat", "timeline", "shell"):
+            c = self._client(app, "W1")
+            km.Handler._dispatch_ws(_Self(), {"type": "ready"}, c)
+            self.assertEqual(self._relayed(c), [], app)
+
+    def test_05_the_record_is_keyed_by_the_wid_string_and_a_missing_wid_is_the_empty_key(self):
+        chat = self._client("chat")                 # no wid at all: a page opened outside a dashboard
+        feed = self._client("feed")
+        feed_blank = self._client("feed", "")
+        feed_w1 = self._client("feed", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID, {"": WEB})
+        self.assertEqual([f["id"] for f in self._relayed(feed)], [WEB])
+        self.assertEqual([f["id"] for f in self._relayed(feed_blank)], [WEB], "an empty wid is the same key")
+        self.assertEqual(self._relayed(feed_w1), [])
+        chat_n = self._client("chat", 7)            # a non-string wid files under its string form
+        feed_n = self._client("feed", "7")
+        _dispatch({"type": "activeTab", "id": API}, chat_n)
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID, {"": WEB, "7": API})
+        self.assertEqual([f["id"] for f in self._relayed(feed_n)], [API])
+        self.assertTrue(all(isinstance(k, str) for k in km._ACTIVE_CHAT_BY_WID))
+
+    def test_06_a_dead_feed_does_not_stop_the_relay_to_the_window_s_other_feeds(self):
+        chat = self._client("chat", "W1")
+
+        def boom(s):
+            raise BrokenPipeError("gone")
+        dead = self._client("feed", "W1", send=boom)
+        live = self._client("feed", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        self.assertEqual([f["id"] for f in self._relayed(live)], [WEB])
+        self.assertFalse(dead["alive"], "the failing socket is marked dead, as every sender marks it")
+        # a client already marked dead is skipped outright
+        gone = self._client("feed", "W1")
+        gone["alive"] = False
+        _dispatch({"type": "activeTab", "id": API}, chat)
+        self.assertEqual(gone["_frames"], [])
+        self.assertEqual([f["id"] for f in self._relayed(live)], [WEB, API])
+
+    def test_07_only_a_chat_client_s_tab_switch_is_relayed(self):
+        # the record is the CHAT pane's active tab; another pane posting activeTab (none does today) files nothing
+        feed = self._client("feed", "W1")
+        tl = self._client("timeline", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, tl)
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID, {})
+        self.assertEqual(feed["_frames"], [])
+        self.assertEqual(tl["active"], WEB, "the arm's own bookkeeping still applies to it")
+
+
+class Wiring(unittest.TestCase):
+    """Source pins on the two arms (the repo's convention for handler wiring): the relay call sits in the activeTab
+    arm after the wake, and the ready arm sends the recorded value after its reset and before its connect push."""
+    def test_the_activetab_arm_relays_after_the_wake(self):
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        i = src.index('msg.get("type") == "activeTab"')
+        body = src[i:src.index('msg.get("type") == "needSlot"', i)]
+        self.assertIn('_relay_active_chat(client, msg.get("id"))', body)
+        self.assertLess(body.index("_pusher_wake.set()"), body.index("_relay_active_chat("),
+                        "release, wake, THEN relay: the older pins on the arm's first 400 chars hold")
+
+    def test_the_ready_arm_sends_the_record_between_the_reset_and_the_push(self):
+        src = inspect.getsource(km.Handler._dispatch_ws)
+        i = src.index('msg.get("type") == "ready"')
+        body = src[i:src.index("_send_caps(client, views_seq=views_seq)", i)]
+        self.assertIn("_send_active_chat(client)", body)
+        self.assertLess(body.index("_client_reset_chat_base(client)"), body.index("_send_active_chat(client)"))
+        self.assertLess(body.index("_send_active_chat(client)"), body.index("self._push_one(client)"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kernel_active_chat_relay.py
+++ b/tests/test_kernel_active_chat_relay.py
@@ -125,7 +125,8 @@ class ActiveChatRelay(unittest.TestCase):
         self.assertLess(types.index("activeChat"), types.index("caps"),
                         "ahead of the connect push, never after the caps frame the shim's redial gate reads")
         km.Handler._dispatch_ws(_Self(), {"type": "ready"}, feed)
-        self.assertEqual(len(self._relayed(feed)), 1, "a second ready re-sends nothing: the slot dedups it")
+        self.assertEqual(len(self._relayed(feed)), 2, "a second ready re-sends: a renderer that just evaluated holds nothing, "
+                         "so the reset forgets the slot (a dedup here left a reloaded feed without its focus)")
         # a window whose chat has never reported gets no frame at all — not even a null
         other = self._client("feed", "W3")
         km.Handler._dispatch_ws(_Self(), {"type": "ready"}, other)
@@ -136,6 +137,29 @@ class ActiveChatRelay(unittest.TestCase):
             c = self._client(app, "W1")
             km.Handler._dispatch_ws(_Self(), {"type": "ready"}, c)
             self.assertEqual(self._relayed(c), [], app)
+
+    def test_04b_a_relay_before_ready_never_starves_the_ready_arms_send(self):
+        # the review's case: the feed page reloads and registers while its bundle still evaluates; a tab switch
+        # in the window relays a frame into that listener-less document (it vanishes) and writes the slot; the
+        # ready arm's send was then deduped for _DEDUP_REPOST_S and the section read "no session is focused"
+        chat = self._client("chat", "W1")
+        feed = self._client("feed", "W1")                             # registered, bundle not yet evaluated
+        _dispatch({"type": "activeTab", "id": WEB}, chat)             # relayed into the void, slot written
+        self.assertEqual(self._relayed(feed), [{"type": "activeChat", "id": WEB}])
+        self.assertIn(("activeChat",), feed["sent"])
+        km.Handler._dispatch_ws(_Self(), {"type": "ready"}, feed)     # the bundle evaluated: the reset forgets the slot
+        self.assertEqual(self._relayed(feed), [{"type": "activeChat", "id": WEB}] * 2, "ready re-sends the focus")
+
+    def test_08_the_record_leaves_with_the_windows_last_pane(self):
+        chat = self._client("chat", "W1")
+        feed = self._client("feed", "W1")
+        _dispatch({"type": "activeTab", "id": WEB}, chat)
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID.get("W1"), WEB)
+        km._clients.remove(chat); km._forget_active_chat_if_last(chat)
+        self.assertEqual(km._ACTIVE_CHAT_BY_WID.get("W1"), WEB, "the window's feed is still connected: the record stays for its reload")
+        km._clients.remove(feed); km._forget_active_chat_if_last(feed)
+        self.assertNotIn("W1", km._ACTIVE_CHAT_BY_WID, "the last pane of the window left: the record goes")
+        other = self._client("feed", "W2"); km._clients.remove(other); km._forget_active_chat_if_last(other)   # a wid with no record: a no-op
 
     def test_05_the_record_is_keyed_by_the_wid_string_and_a_missing_wid_is_the_empty_key(self):
         chat = self._client("chat")                 # no wid at all: a page opened outside a dashboard

--- a/ui/webview/active-tab-local-route.test.ts
+++ b/ui/webview/active-tab-local-route.test.ts
@@ -1,0 +1,29 @@
+// The chat pane's activeTab reaches the LOCAL kernel too when the active session is remote (T347): the local
+// kernel records each window's active tab for its feed pane's focused-session section, and the merged board
+// names a remote session's cards by the host-prefixed id, so the record must carry "host:sid". Before, the
+// id-addressed route sent activeTab to the owning host alone and a feed reload named the last LOCAL session.
+// EXECUTES routeOutbound (./federation). Synthetic ids only.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { routeOutbound, LOCAL } from "./federation";
+
+const SID = "11111111-2222-3333-4444-555555555555";
+
+test("a remote session's activeTab goes to its host with the bare id AND to the local kernel with the prefixed id", () => {
+  const routes = routeOutbound({ type: "activeTab", id: "TESTHOST:" + SID }, new Set(["TESTHOST"]));
+  assert.deepEqual(routes.map((r) => r.host), ["TESTHOST", LOCAL], "the owning host first (it builds and streams the tab first), then the local record");
+  assert.equal(routes[0].msg.id, SID, "the owning kernel gets the id it knows");
+  assert.equal(routes[1].msg.id, "TESTHOST:" + SID, "the local kernel records the merged board's spelling");
+  assert.equal(routes[1].msg.type, "activeTab");
+});
+
+test("a local session's activeTab takes the one local route, id intact, as before", () => {
+  const routes = routeOutbound({ type: "activeTab", id: SID }, new Set(["TESTHOST"]));
+  assert.deepEqual(routes, [{ host: LOCAL, msg: { type: "activeTab", id: SID } }]);
+});
+
+test("no tab (a null id) is one local route too — nothing to strip, nothing to relay elsewhere", () => {
+  const routes = routeOutbound({ type: "activeTab", id: null }, new Set(["TESTHOST"]));
+  assert.deepEqual(routes.map((r) => r.host), [LOCAL]);
+  assert.equal(routes[0].msg.id, null);
+});

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -55,8 +55,9 @@ test("the feed dot matches too: dotFor picks work/await per name, the dot retint
   assert.match(FEED, /else if \(st && has\) paint\(prev!\);/);
   assert.match(FEED, /d\.classList\.toggle\(k, st === k\);/);
   // every name-dot site routes through dotFor: cards, group cards, both modal headers, grouped
-  // headers, and the session-filter button (2026-08-08; its menu rows route via setWorkDot(label,…))
-  assert.equal((FEED.match(/setWorkDot\((?:a\._name|agent|nm), dotFor\(/g) || []).length, 6);
+  // headers, the session-filter button (2026-08-08; its menu rows route via setWorkDot(label,…)), and the
+  // focused-session section's head (T347)
+  assert.equal((FEED.match(/setWorkDot\((?:a\._name|agent|nm), dotFor\(/g) || []).length, 7);
   assert.match(FEEDCSS, /\.fwork-dot\.await \{ background: #54B204; \}/);
   assert.match(FED, /const ARRAY_ID = \["order", "names", "working", "awaiting", "stateUnknown", "live", "skeleton"\];/);   // + the tabOrder frame's live set (T258) + skeleton (2026-09-07: the reconnect strip's not-yet-loaded tabs ride the merged order)
   assert.match(FED, /if \(Array\.isArray\(f\.awaiting\)\) merged\.awaiting\.push\(\.\.\.f\.awaiting\);/);

--- a/ui/webview/card-key.test.ts
+++ b/ui/webview/card-key.test.ts
@@ -125,3 +125,14 @@ test("a pinned card still bolds to full when another pane hovers it", () => {
   assert.ok(FEEDCSS.indexOf(".fitem.ask.pinned") < FEEDCSS.indexOf(".fitem.ask.focused, .fitem.ask.dot-hl"),
     "the shared highlight must come after .pinned");
 });
+
+test("a focused-section copy (T347) answers to its board key and to the bare domain id, like the card below", () => {
+  // the section renders a second element per card under "f:a:<itemId>" / "f:g:<turnId>": one more prefix over
+  // the board's key, the same identity; a cross-pane hover or a reveal must reach the copy too
+  assert.equal(extHoverMatches("f:a:" + GOAL, new Set([GOAL])), true, "the host's bare goal id lights the copy");
+  assert.equal(extHoverMatches("f:a:" + GOAL, new Set(["a:" + GOAL])), true, "a host speaking DOM keys lights it too");
+  assert.equal(extHoverMatches("f:g:" + TURN, new Set([TURN])), true, "a group copy matches on its turn id");
+  assert.equal(extHoverMatches("f:a:" + GOAL, new Set([SID + ":g228"])), false, "exact after the prefixes, never a substring");
+  assert.deepEqual(cardKeyAliases("f:a:" + GOAL), ["f:a:" + GOAL, "a:" + GOAL, GOAL], "most-specific first: the copy, the board's key, the bare id");
+  assert.deepEqual(cardKeyAliases("a:" + GOAL), ["a:" + GOAL, GOAL], "a board key is unchanged by the bridge");
+});

--- a/ui/webview/card-key.ts
+++ b/ui/webview/card-key.ts
@@ -16,6 +16,10 @@
 // to know, and the goal-node id is the real shared identity. Matching stays exact after the prefix — no
 // substring or startsWith matching, which would let one goal's id light a different card.
 
+// The focused-session section (T347) renders a second element per card under "f:a:<itemId>" / "f:g:<turnId>":
+// the board's key behind one more prefix, the same identity. The bridge strips it first, so a cross-pane
+// hover or a reveal names the copy too (kbHoverId in feed.ts strips it the same way for the keyboard cursor).
+const FOCUS = /^f:/;
 const NS = /^(?:a:|g:|s:)/;
 
 /** True when a card carrying `domKey` is one of the host-named `keys`. Accepts a host that already speaks
@@ -23,13 +27,19 @@ const NS = /^(?:a:|g:|s:)/;
 export function extHoverMatches(domKey: string | null | undefined, keys: Set<string>): boolean {
   if (!domKey || !keys || !keys.size) return false;
   if (keys.has(domKey)) return true;
-  const bare = domKey.replace(NS, "");
-  return bare !== domKey && keys.has(bare);
+  const board = domKey.replace(FOCUS, "");          // a focused-section copy answers to its board key…
+  if (board !== domKey && keys.has(board)) return true;
+  const bare = board.replace(NS, "");               // …and, like the board's element, to the bare domain id
+  return bare !== board && keys.has(bare);
 }
 
 /** The host-named keys a DOM key can satisfy — the same bridge, for callers that need to look up rather
  *  than test (e.g. finding the card to scroll to). Ordered most-specific first. */
 export function cardKeyAliases(domKey: string): string[] {
-  const bare = domKey.replace(NS, "");
-  return bare !== domKey ? [domKey, bare] : [domKey];
+  const out = [domKey];
+  const board = domKey.replace(FOCUS, "");
+  if (board !== domKey) out.push(board);
+  const bare = board.replace(NS, "");
+  if (bare !== board) out.push(bare);
+  return out;
 }

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -386,6 +386,16 @@ export function routeOutbound(msg: any, knownHosts?: ReadonlySet<string>): Route
   // the path as local (see bin/romp-kernel's openFolder handler + _split_host_id).
   if (msg.type === "openFolder") return [{ host: LOCAL, msg }];
 
+  // activeTab (render.ts notifyActive) goes to the owning host AND, for a remote session, to the LOCAL kernel
+  // with the id left prefixed (T347): the local kernel records each window's active tab for its feed pane's
+  // focused-session section, and the section names cards by the merged board's prefixed ids, so a remote
+  // session's focus must reach the local record as "host:sid". The owning host still gets the bare id it
+  // builds and streams first, as before. A local session takes the one local route below.
+  if (msg.type === "activeTab" && typeof msg.id === "string") {
+    const h = hostOf(msg.id);
+    if (h && h !== LOCAL) return [{ host: h, msg: { ...msg, id: stripHost(h, msg.id) } }, { host: LOCAL, msg }];
+  }
+
   // a scalar session id picks the owning host.
   let host = LOCAL;
   for (const k of SCALAR_ID) {

--- a/ui/webview/feed-flip.test.ts
+++ b/ui/webview/feed-flip.test.ts
@@ -65,5 +65,5 @@ test("a card repaints only when its object or a board-level input it reads chang
   assert.match(SRC, /m\.type === "reviveFailed" && typeof m\.id === "string" && m\.id\) \{[\s\S]*?rearmLatches\(\{ kind: "revive", id: m\.id \}\)/);
   assert.match(SRC, /\(a\._revive as any\)\._idle = a\._revive\.textContent;/);
   // Undo takes .dismissing off a card restored inside its collapse window (the class rewrite no longer does)
-  assert.match(SRC, /askEls\.get\(it\.itemId\)\?\.classList\.remove\("dismissing"\);/);
+  assert.match(SRC, /for \(const c of cardTwins\(it\.itemId\)\) c\.classList\.remove\("dismissing"\);/);
 });

--- a/ui/webview/feed-focus-entries.test.ts
+++ b/ui/webview/feed-focus-entries.test.ts
@@ -1,0 +1,76 @@
+// The FOCUSED SESSION section's pure half (T347, the user 2026-09-11, who wanted the focused session's cards on
+// top of the feed): feed-focus.ts picks, from the board's three column buckets, the entries the section shows for
+// one session. No DOM, so node --test runs it directly on synthetic entries; the wiring in feed.ts and feed.css is
+// pinned in feed-focus-section.test.ts. (feed-focus.test.ts, the older file of that name, is the keyboard-focus
+// policy — a different feature.) Synthetic ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import { focusedEntries, focusedCardCount } from "./feed-focus";
+
+const WEB = "aaaaaaaa-1111-2222-3333-444444444444", API = "aaaaaaaa-1111-2222-3333-555555555555";
+const TESTS = "aaaaaaaa-1111-2222-3333-666666666666";
+type E = { kind: "ask" | "group" | "sess"; t: number; sid: string; id: string; n: number };
+const ask = (id: string, sid: string, t: number): E => ({ kind: "ask", t, sid, id, n: 1 });
+const group = (id: string, sid: string, t: number, members: number): E => ({ kind: "group", t, sid, id, n: members });
+const sess = (sid: string): E => ({ kind: "sess", t: 0, sid, id: "head:" + sid, n: 0 });
+const sidOf = (e: E) => e.sid;
+const cards = (e: E) => e.n;
+// the board's buckets as grouped mode leaves them: run headers open each session's run, cards in column order
+const board = () => ({
+  asks: [sess(WEB), ask("g1", WEB, 1), group("t1", WEB, 2, 2), sess(API), ask("g2", API, 3)],
+  needsInput: [sess(API), ask("g3", API, 4)],
+  completed: [sess(WEB), ask("g4", WEB, 5), ask("g5", WEB, 6)],
+});
+const ids = (xs: E[]) => xs.map((e) => e.id);
+const EMPTY = { asks: [], needsInput: [], completed: [] };
+
+test("the section's entries are the board's cards for the session, per column, in the column's order", () => {
+  const b = board();
+  const got = focusedEntries(b, WEB, sidOf);
+  assert.deepEqual({ asks: ids(got.asks), needsInput: ids(got.needsInput), completed: ids(got.completed) },
+    { asks: ["g1", "t1"], needsInput: [], completed: ["g4", "g5"] });
+  assert.equal(got.asks[0], b.asks[1], "the same entry objects, never copies — the caller's update gate keys on identity");
+});
+
+test("run headers are dropped: one session needs no header between runs, its name is the section's head", () => {
+  const got = focusedEntries(board(), WEB, sidOf);
+  assert.ok([...got.asks, ...got.needsInput, ...got.completed].every((e) => e.kind !== "sess"));
+  assert.deepEqual(ids(got.completed), ["g4", "g5"], "the header that opened the run is gone, its cards stay");
+});
+
+test("another session's cards are excluded", () => {
+  const b = board();
+  assert.deepEqual(ids(focusedEntries(b, API, sidOf).asks), ["g2"]);
+  assert.deepEqual(ids(focusedEntries(b, API, sidOf).needsInput), ["g3"]);
+  assert.deepEqual(ids(focusedEntries(b, API, sidOf).completed), []);
+});
+
+test("a focused session with no cards, or no focused tab (null), is three empty columns", () => {
+  const b = board();
+  assert.deepEqual(focusedEntries(b, TESTS, sidOf), EMPTY, "a focused session with no cards");
+  assert.deepEqual(focusedEntries(b, null, sidOf), EMPTY, "no tab has focus in the chat");
+  assert.deepEqual(focusedEntries({ asks: [], needsInput: [], completed: [] } as Record<"asks" | "needsInput" | "completed", E[]>, WEB, sidOf),
+    EMPTY, "an empty board");
+});
+
+test("each column keeps the order it arrived in — newest-first below reads newest-first above", () => {
+  const b = board();
+  b.completed = [sess(WEB), ask("g5", WEB, 6), ask("g4", WEB, 5)];   // the board sorted newest-first
+  assert.deepEqual(ids(focusedEntries(b, WEB, sidOf).completed), ["g5", "g4"]);
+});
+
+test("the input buckets are left untouched", () => {
+  const b = board();
+  const before = JSON.stringify(b);
+  focusedEntries(b, WEB, sidOf);
+  focusedEntries(b, null, sidOf);
+  assert.equal(JSON.stringify(b), before);
+});
+
+test("the count is CARDS with the board's rule — a turn-group is its members — and zero for the empty section", () => {
+  const b = board();
+  assert.equal(focusedCardCount(focusedEntries(b, WEB, sidOf), cards), 5, "g1 + a two-member group + g4 + g5 = 1 + 2 + 1 + 1");
+  assert.equal(focusedCardCount(focusedEntries(b, API, sidOf), cards), 2);
+  assert.equal(focusedCardCount(focusedEntries(b, TESTS, sidOf), cards), 0);
+  assert.equal(focusedCardCount(focusedEntries(b, null, sidOf), cards), 0);
+});

--- a/ui/webview/feed-focus-section.test.ts
+++ b/ui/webview/feed-focus-section.test.ts
@@ -124,6 +124,28 @@ test("the two quiet states, only while the switch is on: no tab focused; a focus
   assert.match(FEED, /removeFocusSection\(\);   \/\/ an empty board is the wordmark alone/, "an empty board shows the wordmark, not the section");
 });
 
+test("Clear, its 180 ms finish and Undo resolve by ITEM across both copies, never by one element (the review of T347)", () => {
+  // Clear on the section's copy used to run the board builder's handler, whose finish guarded on the BOARD's
+  // element (askEls.get(id) === card): the copy stayed, dropDismissed never ran, and Undo stripped .dismissing
+  // from the board's element alone. Every element carrying the item dismisses and finalizes together.
+  assert.match(FEED, /function cardTwins\(itemId: string\): HTMLElement\[\] \{[\s\S]*?askEls\.get\(itemId\)[\s\S]*?fsAskEls\.get\(itemId\)/, "the board's element and the section's copy");
+  assert.match(FEED, /function groupTwins\(turnId: string\): HTMLElement\[\] \{[\s\S]*?groupEls\.get\(turnId\)[\s\S]*?fsGroupEls\.get\(turnId\)/);
+  assert.match(FEED, /for \(const c of cardTwins\(it\.itemId\)\) c\.classList\.add\("dismissing"\);\s*\n\s*vscodeApi\?\.postMessage\(\{ type: "askClear"/, "the ask card's Clear marks both copies");
+  assert.match(FEED, /const twins = cardTwins\(it\.itemId\)\.filter\(\(c\) => c\.classList\.contains\("dismissing"\)\);[\s\S]*?if \(fsAskEls\.get\(it\.itemId\) === c\) fsAskEls\.delete\(it\.itemId\); \}\s*\n\s*dropDismissed\(\[it\.itemId\]\);/, "the finish removes every copy still dismissing and forgets both caches");
+  assert.doesNotMatch(FEED, /if \(askEls\.get\(it\.itemId\) === card && card\.classList\.contains\("dismissing"\)\)/, "the element-identity guard is gone from the ask card's finish");
+  assert.match(FEED, /for \(const c of groupTwins\(cur\.turnId\)\) c\.classList\.add\("dismissing"\);/, "…and the group card's");
+  assert.match(FEED, /for \(const c of cardTwins\(it\.itemId\)\) c\.classList\.remove\("dismissing"\);/, "Undo restores both copies");
+  assert.match(FEED, /const f = fsAskEls\.get\(m\.itemId\);[\s\S]*?leaving\.push\(\[f, \(\) => fsAskEls\.get\(m\.itemId\) === f, \(\) => fsAskEls\.delete\(m\.itemId\)\]\);/, "the session-wide Clear takes the copies along");
+  assert.match(FEED, /for \(const \[tid, g\] of Array\.from\(fsGroupEls\)\) \{/, "…group copies too");
+});
+
+test("cross-pane hover and reveal reach the copies: card-key strips the section's prefix, the keyboard cursor likewise", () => {
+  const CK = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "card-key.ts"), "utf8");
+  assert.match(CK, /const FOCUS = \/\^f:\/;/);
+  assert.match(CK, /const board = domKey\.replace\(FOCUS, ""\);/);
+  assert.match(FEED, /if \(key\.startsWith\("f:"\)\) key = key\.slice\(2\);/, "kbHoverId strips it the same way");
+});
+
 // ── feed.css: the section's rules, through the variables ─────────────────────────────────────────────
 test("feed.css: #feed-focus, the head, the caption, the rule and the empty line exist, var() only", () => {
   assert.match(CSS, /#feed-focus \{ display: flex; flex-direction: column; gap: 8px; \}/);

--- a/ui/webview/feed-focus-section.test.ts
+++ b/ui/webview/feed-focus-section.test.ts
@@ -1,0 +1,141 @@
+// The FOCUSED SESSION section (T347, the user 2026-09-11, who wanted the focused session's cards on top): when a
+// tab has focus in the chat pane, the feed shows that session's cards ABOVE a divider — the board's three columns,
+// a miniature of the feed for one session, headed by its name — while the board below stays exactly as it is.
+// OFF by default; the View menu's fourth row switches it; the kernel relays the chat's active tab to the feed as
+// {type:"activeChat", id}. This file pins the wiring in feed.ts and feed.css at the source (feed.ts has no jsdom
+// harness, the repo convention); the pure pick (feed-focus.ts) runs directly in feed-focus-entries.test.ts, and the
+// switch's persistence (FeedViewState.focused) in feed-view-state.test.ts. Synthetic ids only.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+// ── the switch: the View menu's fourth row ───────────────────────────────────────────────────────────
+test("the fourth row reads 'Show focused session', a ✓ row after Group by session, and flips the persisted switch", () => {
+  const groupAt = FEED.indexOf('set(2, "Group by session');
+  const focusAt = FEED.indexOf('set(3, "Show focused session"');
+  assert.ok(groupAt > 0 && focusAt > groupAt, "fourth, after the grouping row");
+  assert.match(FEED, /if \(rows\.length !== 4\) return;/, "paintViewMenu syncs four rows");
+  assert.match(FEED, /mk\(true, \(\) => \{ showFocused = !showFocused; persistViewState\(\); render\(\); \}\);/,
+    "a menuitemcheckbox row (mk(true)) that flips the switch, persists and re-renders — no shared pref");
+  assert.match(FEED, /set\(3, "Show focused session", \{\s*\n\s*current: showFocused,/);
+  assert.doesNotMatch(FEED, /setViewPref\("focused"/, "never romp:settings: the gear and the other panes have nothing to read");
+});
+
+test("the switch is the feed's own view state under `focused`: OFF unless a blob saved it on", () => {
+  assert.match(FEED, /let showFocused = false;/);
+  assert.match(FEED, /showFocused = st\.focused;/, "hydrated with the rest of the view state");
+  assert.match(FEED, /order: colOrder\.slice\(\), focused: showFocused \};/, "currentViewState carries it, so persistViewState writes it");
+});
+
+// ── the event: the kernel's activeChat frame ─────────────────────────────────────────────────────────
+test("the activeChat frame sets the focused sid and re-renders; nothing in the section runs on a clock", () => {
+  const at = FEED.indexOf('} else if (m.type === "activeChat") {');
+  assert.ok(at > 0, "the feed handles the kernel's relay of the chat pane's active tab");
+  const branch = FEED.slice(at, FEED.indexOf('} else if (m.type === "hoverCards") {', at));
+  assert.match(branch, /focusedSid = typeof m\.id === "string" && m\.id \? m\.id : null;/, "the frame's id, or null when no tab has focus");
+  assert.match(branch, /if \(!showFocused\) return;\s*\n\s*if \(freezeKey \|\| tabScopeKey\) \{ focusStale = true; return; \}\s*\n\s*render\(\);/,
+    "off: nothing to paint; held under the pointer: paint on the release; else the frame IS the render");
+  assert.doesNotMatch(branch, /setTimeout|setInterval|requestAnimationFrame/);
+  const section = FEED.slice(FEED.indexOf("function ensureFocusSection("), FEED.indexOf("// ── FLIP: animate a card FLYING"));
+  assert.ok(section.includes("function removeFocusSection(): void {"), "the slice spans the whole section code");
+  assert.doesNotMatch(section, /setTimeout|setInterval|requestAnimationFrame|Date\.now/, "event-based: no timer, no clock");
+});
+
+test("a tab switch that lands while a card is held under the pointer paints on the release (the hover-freeze contract)", () => {
+  assert.match(FEED, /let focusStale = false;/);
+  const flush = FEED.slice(FEED.indexOf("function flushFreeze(): void {"), FEED.indexOf('window.addEventListener("blur", () => { releaseTabScope();'));
+  assert.match(flush, /if \(m\) applyFeedPayload\(m\);[^\n]*\n\s*else if \(focusStale\) render\(\);[^\n]*\n\s*focusStale = false;/,
+    "the release renders the section when no payload was queued; a queued payload's render covers it");
+});
+
+// ── the section: its own elements, above the board, the board untouched ─────────────────────────────
+test("#feed-focus sits directly before #feed-cols: head, empty line, the three columns, the rule", () => {
+  assert.match(FEED, /sec\.id = "feed-focus";/);
+  assert.match(FEED, /if \(board && sec\.nextSibling !== board\) \{ list\.insertBefore\(sec, board\); applyColStack\(\); \}/,
+    "ensure-once, kept right above #feed-cols across renders; a fresh section takes the board's column order");
+  for (const mint of ['el("div", "feed-focus-head")', 'el("a", "fname")', 'el("span", "feed-focus-cap")', 'el("div", "feed-focus-empty")',
+                      'el("div", "feed-cols feed-focus-cols")', 'el("hr", "feed-focus-divider")']) {
+    assert.ok(FEED.includes(mint), "builds " + mint);
+  }
+  assert.match(FEED, /el\("span", "feed-col-name fcol-chip fcol-chip-" \+ chip\); name\.textContent = label;\s*\n\s*const count = el\("span", "feed-col-count"\);\s*\n\s*h\.append\(name, count\);/,
+    "the board's chips and count, NO fold caret and NO drag on the section's heads");
+  // in render(): the pick is taken before grouping (a folded thread below must not empty the section), the
+  // section is painted before the board's reconcile, and the board's own reconcile is what it always was
+  const pickAt = FEED.indexOf("const focusBuckets = showFocused ? focusedEntries(buckets, focusedSid, entrySid) : null;");
+  const groupAt = FEED.indexOf("if (feedPrefs().grouped) {", pickAt);
+  const callAt = FEED.indexOf("if (focusBuckets) renderFocusSection(list, focusBuckets, gate); else removeFocusSection();");
+  const flipAt = FEED.indexOf("const flipFirst = needFlip ? captureCardRects(cols) : new Map<string, FlipState>();");
+  const boardAt = FEED.indexOf("reconcileCol(cols.asks, buckets.asks, desired, gate);");
+  assert.ok(pickAt > 0 && groupAt > pickAt && callAt > groupAt && flipAt > callAt && boardAt > flipAt,
+    "pick → grouping → section → the board's FLIP capture → the board's reconcile");
+  // the section sits ABOVE the board, so it must have settled before the board's First rects are read: a capture
+  // taken before it would have every card below glide by the section's height change on top of its own move
+  assert.ok(FEED.indexOf("const gate: GateEnv = {") < flipAt, "the gate the section needs is built before the capture");
+});
+
+test("the section's cards are SECOND elements: its own caches under 'f:' keys, the board's caches untouched", () => {
+  const sec = FEED.slice(FEED.indexOf("function ensureFocusSection("), FEED.indexOf("// ── FLIP: animate a card FLYING"));
+  assert.match(sec, /key = "f:a:" \+ e\.ask\.itemId;/);
+  assert.match(sec, /key = "f:g:" \+ e\.group\.turnId;/);
+  assert.match(sec, /card = fsAskEls\.get\(e\.ask\.itemId\) \|\| makeAskCard\(e\.ask\);\s*\n\s*card\.dataset\.key = key;/, "the builder's bare key is re-stamped with the section's");
+  assert.match(sec, /card = fsGroupEls\.get\(e\.group\.turnId\) \|\| makeGroupCard\(e\.group\);\s*\n\s*card\.dataset\.key = key;/);
+  assert.doesNotMatch(sec, /\baskEls\b|\bgroupEls\b/, "never the board's caches — no card below moves because of the section");
+  // the same update gate as the board (feed-card-gate.ts)
+  assert.match(sec, /const ik = cardInputsKey\(e\.ask, gate\);\s*\n\s*if \(cardNeedsUpdate\(card as any, e\.ask, ik\)\) \{ updateAskCard\(card, e\.ask\); \(card as any\)\._ik = ik; \}/);
+  assert.match(sec, /function removeFocusSection\(\): void \{\s*\n\s*document\.getElementById\("feed-focus"\)\?\.remove\(\);\s*\n\s*fsAskEls\.clear\(\); fsGroupEls\.clear\(\);/);
+  // both copies of a card light together, hold the same latches, and tick the same ages
+  assert.match(FEED, /for \(const \[id, card\] of fsAskEls\) card\.classList\.toggle\("focused", id === eff\);/);
+  assert.equal((FEED.match(/for \(const card of \[\.\.\.askEls\.values\(\), \.\.\.fsAskEls\.values\(\)\]\)/g) || []).length, 2, "rearmLatches and livePass walk both");
+});
+
+test("the board's own column lookups are scoped to #feed-cols now that the section carries the same classes", () => {
+  assert.match(FEED, /document\.querySelector<HTMLElement>\("#feed-cols \.feed-col\.col-" \+ key\)/, "applyColStack folds the board's column");
+  assert.match(FEED, /const twin = document\.querySelector<HTMLElement>\("#feed-focus \.feed-col\.col-" \+ key\);/, "…and writes the dragged order to the section's twin column too");
+  assert.match(FEED, /else col\.style\.removeProperty\("--col-order"\);/, "the board's own statement stands as feed-col-fold.test.ts pins it");
+  assert.match(FEED, /document\.querySelector<HTMLElement>\("#feed-cols \.feed-col\.col-" \+ k\)/, "the drag's FLIP reads the board");
+  assert.match(FEED, /document\.querySelector<HTMLElement>\("#feed-cols \.feed-col\.col-" \+ other\)/);
+  assert.match(FEED, /put\(document\.querySelector\("#feed-cols \.feed-col\.col-" \+ key \+ " \.feed-col-head"\), d\.cols\[key\]\);/, "the freeze badges land on the board's heads");
+  assert.doesNotMatch(FEED, /querySelector<HTMLElement>\("\.feed-col\.col-"/, "no bare column query survives to land on the section's copy first");
+  // a copy's key reads as the card's own identity for the hover-freeze heal (a hovered copy holds the gate)
+  assert.match(FEED, /if \(key\.startsWith\("f:"\)\) key = key\.slice\(2\);/);
+  // …and the keyboard cursor walks the BOARD's cards: a walk over both would interleave a copy with its card below
+  assert.match(FEED, /querySelectorAll<HTMLElement>\("#feed-cols \.fitem:not\(\.dismissing\)"\)/, "kbCardEls reads #feed-cols");
+  assert.doesNotMatch(FEED, /querySelectorAll<HTMLElement>\("\.feed-cols \.fitem:not\(\.dismissing\)"\)/);
+});
+
+test("the head: the session's dot and name, its identity colour, opening the session like a run header does", () => {
+  assert.match(FEED, /nm\.replaceChildren\(\.\.\.hostNameNodes\(who\.name, sid\)\)/, "a remote session's host: prefix stays quiet metadata");
+  assert.match(FEED, /nm\.style\.color = who\.color \? who\.color\.bg : "";/);
+  assert.match(FEED, /nm\.onclick = \(ev\) => \{ ev\.stopPropagation\(\); openOrReviveSession\(sid, who\.live, who\.name\); \};/);
+  assert.match(FEED, /setWorkDot\(nm, dotFor\(who\.name\)\);/);
+  assert.match(FEED, /const s = sessionsMeta\.find\(\(x\) => x\.sid === sid\);\s*\n\s*const a = asks\.find\(\(x\) => x\.sid === sid\);/,
+    "the name from this pane's session list, else a card, else the kernel's stub");
+});
+
+test("the two quiet states, only while the switch is on: no tab focused; a focused session with no cards", () => {
+  assert.match(FEED, /setText\(empty, "No session is focused in the chat"\);/);
+  assert.match(FEED, /setText\(empty, who\.name \+ " has no cards"\);/);
+  assert.match(FEED, /head\.style\.display = sid \? "" : "none";\s*\n\s*empty\.style\.display = sid && total \? "none" : "";\s*\n\s*cols\.style\.display = total \? "" : "none";/,
+    "no sid: the line stands in for the head; no cards: head and line; the rule stays in both");
+  assert.match(FEED, /removeFocusSection\(\);   \/\/ an empty board is the wordmark alone/, "an empty board shows the wordmark, not the section");
+});
+
+// ── feed.css: the section's rules, through the variables ─────────────────────────────────────────────
+test("feed.css: #feed-focus, the head, the caption, the rule and the empty line exist, var() only", () => {
+  assert.match(CSS, /#feed-focus \{ display: flex; flex-direction: column; gap: 8px; \}/);
+  assert.match(CSS, /\.feed-focus-head \{[^}]*font-weight: 600;[^}]*\}/, "the session headers' weight");
+  assert.match(CSS, /\.feed-focus-head \.fname \{ font-size: inherit; \}/, "the name at the card titles' size, as .feed-sess-head does");
+  assert.match(CSS, /\.feed-focus-cap \{[^}]*font-size: 0\.72em;[^}]*color: var\(--dim\);[^}]*\}/, "the column head's 0.72em, dim — no new size");
+  assert.match(CSS, /\.feed-focus-cols \.feed-col-head \.fcol-chip \{ cursor: default; \}/, "no grab cursor where nothing drags");
+  assert.match(CSS, /\.feed-focus-divider \{ border: 0; border-top: 1px solid var\(--menu-border, rgba\(255, 255, 255, 0\.12\)\); margin: 6px 0 2px; \}/);
+  assert.match(CSS, /\.feed-focus-empty \{ color: var\(--dim\); font-size: 0\.82em; \}/);
+  // every colour in the section's declarations is a var(); the one literal is that var()'s fallback
+  const block = CSS.slice(CSS.indexOf("#feed-focus {"), CSS.indexOf(".feed-focus-empty {") + ".feed-focus-empty { color: var(--dim); font-size: 0.82em; }".length);
+  const decls = (block.match(/\{[^}]*\}/g) || []).join("\n").replace(/var\([^)]*\)/g, "");
+  assert.doesNotMatch(decls, /#[0-9a-fA-F]{3,8}\b|rgba?\(/, "no hex or rgb outside a var() fallback");
+  assert.ok(/--menu-border\s*:/.test(CSS) && /--dim\s*:/.test(CSS), "the variables it reads are defined in this sheet (both themes)");
+});

--- a/ui/webview/feed-focus.ts
+++ b/ui/webview/feed-focus.ts
@@ -1,0 +1,33 @@
+// The FOCUSED SESSION section's pure half (T347, the user 2026-09-11, who wanted the focused session's cards
+// on top of the feed): WHICH of the board's entries the section shows. render() builds its three column
+// buckets once; this picks, per column, the entries whose session is the chat's focused one, in the column's
+// own order, and drops the by-session run headers — a section that shows ONE session needs no header between
+// runs, its name is the section's own head. No DOM, no state: node --test runs it directly
+// (feed-focus-section.test.ts), and feed.ts feeds it the real buckets.
+import { FEED_COLUMNS, type FeedColumn } from "./feed-view-state";
+
+/** An entry as the pick reads it: its kind, so run headers ("sess") can be dropped. Structural, so the
+ *  tests pass plain objects and feed.ts passes its Entry union. */
+export interface FocusEntry { kind: string }
+
+/** The focused session's entries per column. `sidOf` names each entry's session. A null `sid` (no tab has
+ *  focus in the chat) yields three empty columns, as does a session with no cards; each column keeps the
+ *  order it arrived in, and the entries are the SAME objects (no copies), so the caller's gates hold. The
+ *  input buckets are never touched. */
+export function focusedEntries<E extends FocusEntry>(
+  buckets: Record<FeedColumn, E[]>, sid: string | null, sidOf: (e: E) => string,
+): Record<FeedColumn, E[]> {
+  const out = { asks: [], needsInput: [], completed: [] } as Record<FeedColumn, E[]>;
+  if (!sid) return out;
+  for (const col of FEED_COLUMNS) out[col] = buckets[col].filter((e) => e.kind !== "sess" && sidOf(e) === sid);
+  return out;
+}
+
+/** How many CARDS the picked entries hold across the three columns — the board's one counting rule
+ *  (`cards` is feed.ts entryCards: a turn-group is worth its members). Zero is the "<name> has no cards"
+ *  state. */
+export function focusedCardCount<E>(entries: Record<FeedColumn, E[]>, cards: (e: E) => number): number {
+  let n = 0;
+  for (const col of FEED_COLUMNS) for (const e of entries[col]) n += cards(e);
+  return n;
+}

--- a/ui/webview/feed-freeze.test.ts
+++ b/ui/webview/feed-freeze.test.ts
@@ -163,8 +163,10 @@ test("badges wear the header conventions: accent adds, block-red removes, the co
   assert.match(CSS, /\.freeze-badge \.fz-add \{ color: var\(--accent\); \}/, "never a re-hardcoded accent hex");
   assert.match(CSS, /\.freeze-badge \.fz-del \{ color: var\(--err\); \}/, "the board's existing block red");
   assert.doesNotMatch(CSS, /\.freeze-badge[^}]*font-size/, "no new font sizes — the badge inherits the head's scale");
-  // painted on the build-once column heads and the data-fsid-stamped session headers; cleared when quiet
-  assert.match(FEED, /put\(document\.querySelector\("\.feed-col\.col-" \+ key \+ " \.feed-col-head"\), d\.cols\[key\]\);/);
+  // painted on the build-once column heads and the data-fsid-stamped session headers; cleared when quiet. The
+  // BOARD's heads, under #feed-cols: the focused-session section (T347) above the board carries the same column
+  // classes and comes first in the DOM, so a bare query would hang the badges on the miniature's head instead
+  assert.match(FEED, /put\(document\.querySelector\("#feed-cols \.feed-col\.col-" \+ key \+ " \.feed-col-head"\), d\.cols\[key\]\);/);
   assert.match(FEED, /h\.setAttribute\("data-fsid", e\.sid\);/);
   assert.match(FEED, /if \(h\.getAttribute\("data-fcol"\) !== e\.col\) h\.setAttribute\("data-fcol", e\.col\);/,
     "the column stamp beside the sid, compare-first like it: the two together are the row the hover key names");

--- a/ui/webview/feed-group-mode.test.ts
+++ b/ui/webview/feed-group-mode.test.ts
@@ -69,6 +69,7 @@ test("clearing a run's last card drops its session header at once, not on the ne
   assert.match(FEED, /function dropDismissed\(ids: string\[\]\): void \{/);
   assert.match(FEED, /asks = asks\.filter\(\(a\) => !gone\.has\(a\.itemId\)\);\s*\n\s*render\(\);/);
   // both optimistic dismiss paths finish through it: the single ask card and the sibling-group card
-  assert.match(FEED, /card\.remove\(\); askEls\.delete\(it\.itemId\); dropDismissed\(\[it\.itemId\]\);/);
-  assert.match(FEED, /groupEls\.delete\(cur\.turnId\); dropDismissed\(cur\.members\.map\(\(m\) => m\.itemId\)\);/);
+  assert.match(FEED, /for \(const c of twins\) \{ c\.remove\(\); if \(askEls\.get\(it\.itemId\) === c\) askEls\.delete\(it\.itemId\);[^\n]*\n\s*dropDismissed\(\[it\.itemId\]\);/);
+  // the group card's finish, by ITEM across both copies since T347: every copy still dismissing leaves, both caches forget it, then the members drop
+  assert.match(FEED, /if \(fsGroupEls\.get\(cur\.turnId\) === c\) fsGroupEls\.delete\(cur\.turnId\); \}\s*\n\s*dropDismissed\(cur\.members\.map\(\(m\) => m\.itemId\)\);/);
 });

--- a/ui/webview/feed-view-state.test.ts
+++ b/ui/webview/feed-view-state.test.ts
@@ -21,6 +21,7 @@ function sample(): FeedViewState {
     asks: ["card-a"],
     threads: [],   // the card-prune tests below assert on CARD state; the thread exemption has its own
     cols: ["completed"], order: ["asks", "completed", "needsInput"],
+    focused: false,
   };
 }
 
@@ -61,7 +62,7 @@ test("an itemId containing a colon is not mis-attributed by the prune", () => {
   // its FIRST colon would read this card as "blocked" and prune state that is very much live.
   const s: FeedViewState = {
     v: 1, sec: { "blocked:sess-7": "bg" }, tree: ["blocked:sess-7:n1"], nodes: [], logs: [], asks: [],
-    threads: [], cols: [], order: [],
+    threads: [], cols: [], order: [], focused: false,
   };
   const pruned = pruneViewState(s, new Set(["blocked:sess-7"]));
   assert.deepEqual(pruned.sec, { "blocked:sess-7": "bg" }, "the colon-bearing id survives");
@@ -92,7 +93,7 @@ test("the cap is a backstop that trims cheap state first and section choices las
     nodes: Array.from({ length: 10 }, (_, i) => `a:n${i}`),
     logs: Array.from({ length: 10 }, (_, i) => `a:l${i}`),
     asks: ["a"],
-    threads: ["sid-1"], cols: [], order: [],
+    threads: ["sid-1"], cols: [], order: [], focused: false,
   };
   const capped = capViewState(big, 20);
   assert.equal(viewStateSize(capped), 20);
@@ -108,6 +109,7 @@ test("a folded thread SURVIVES the card prune — that is the whole point of it"
   // card would silently re-expand the thread and the next card would arrive unfolded.
   const s: FeedViewState = {
     v: 1, sec: { "card-a": "bg" }, tree: [], nodes: [], logs: [], asks: [], threads: ["sid-quiet"], cols: [], order: [],
+    focused: false,
   };
   const pruned = pruneViewState(s, new Set<string>());   // no live cards at all
   assert.deepEqual(pruned.threads, ["sid-quiet"]);
@@ -190,6 +192,58 @@ test("stacked-column state persists, tolerates old blobs, and gates on the three
   const pruned = pruneViewState(sample(), new Set<string>([]));
   assert.deepEqual(pruned.cols, ["completed"], "layout state survives a full card prune");
   assert.deepEqual(pruned.order, ["asks", "completed", "needsInput"]);
+});
+
+// ── T347 (the user 2026-09-11, who wanted the focused session's cards on top): the `focused` switch ────────
+test("executed: the focused-session switch is OFF by default and round-trips both ways", () => {
+  assert.equal(emptyViewState().focused, false, "off for everyone until the VIEW menu row is flipped");
+  const on = { ...sample(), focused: true };
+  assert.equal(parseViewState(serializeViewState(on)).focused, true);
+  assert.deepEqual(parseViewState(serializeViewState(on)), on, "…and the rest of the state rides along");
+  const off = { ...sample(), focused: false };
+  assert.equal(parseViewState(serializeViewState(off)).focused, false);
+  assert.ok(serializeViewState(on).includes('"focused":true'), "the key is written, not implied");
+});
+
+test("executed: a blob saved before `focused` existed reads OFF and keeps everything else (v stays 1)", () => {
+  // the same shape as the `threads` and `cols`/`order` upgrades: a new key, no version bump, so yesterday's
+  // saved sections survive rather than the whole blob reading as corrupt
+  const old = JSON.stringify({ v: 1, sec: { a: "bg" }, tree: ["a:n1"], nodes: [], logs: [], asks: ["a"],
+                               threads: ["sid-1"], cols: ["completed"], order: [] });
+  const s = parseViewState(old);
+  assert.equal(s.focused, false);
+  assert.deepEqual(s.sec, { a: "bg" }, "the sections the user had open survive the upgrade");
+  assert.deepEqual(s.threads, ["sid-1"]);
+  assert.deepEqual(s.cols, ["completed"]);
+  assert.equal(s.v, 1);
+});
+
+test("executed: only the literal true switches `focused` on; a wrong-typed value reads OFF", () => {
+  const base = { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [], cols: [], order: [] };
+  for (const junk of ["yes", "true", 1, 0, null, {}, [], "false"]) {
+    assert.equal(parseViewState(JSON.stringify({ ...base, focused: junk })).focused, false,
+      `focused=${JSON.stringify(junk)} is not the literal true`);
+  }
+  assert.equal(parseViewState(JSON.stringify({ ...base, focused: true })).focused, true);
+  assert.equal(parseViewState(JSON.stringify({ ...base, focused: false })).focused, false);
+});
+
+test("executed: prune and cap leave `focused` untouched — it describes the view, not a card", () => {
+  // prune-EXEMPT like cols/order: there is no card to prune it against, and a full card prune (no live
+  // cards at all) must not flip the switch the user set
+  for (const v of [true, false]) {
+    const s = { ...sample(), focused: v };
+    assert.equal(pruneViewState(s, new Set<string>()).focused, v, `prune keeps focused=${v}`);
+    assert.equal(pruneViewState(s, new Set(["card-a"])).focused, v);
+    assert.equal(capViewState(s, VIEW_STATE_CAP).focused, v, `an under-cap state keeps focused=${v}`);
+    // an OVER-cap trim copies the state field by field; the switch must ride through the copy
+    const big = { ...s, logs: Array.from({ length: 30 }, (_, i) => `card-a:l${i}`) };
+    const capped = capViewState(big, 10);
+    assert.equal(viewStateSize(capped), 10, "the trim happened");
+    assert.equal(capped.focused, v, `a trimmed state keeps focused=${v}`);
+  }
+  // …and it is not an entry: the size the cap measures does not count it
+  assert.equal(viewStateSize({ ...sample(), focused: true }), viewStateSize({ ...sample(), focused: false }));
 });
 
 // ── T263c (the user 2026-09-08): the fold key is (session, column) ─────────────────────────────────────────

--- a/ui/webview/feed-view-state.ts
+++ b/ui/webview/feed-view-state.ts
@@ -35,6 +35,10 @@ export interface FeedViewState {
   // are prune-EXEMPT like `threads` and bounded by their three known keys instead.
   cols: string[];
   order: string[];
+  // The feed's FOCUSED SESSION section (T347, the user 2026-09-11, who wanted the focused session's cards
+  // on top): whether the feed shows the chat pane's active session as a miniature above a divider. OFF by
+  // default. A view switch, not a card: prune-EXEMPT like `cols`/`order`, and not counted by the cap.
+  focused: boolean;
 }
 
 export const VIEW_STATE_KEY = "romp:feedview";
@@ -56,7 +60,8 @@ export function threadKeys(stored: string): string[] {
 export const VIEW_STATE_CAP = 4000;
 
 export function emptyViewState(): FeedViewState {
-  return { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [], cols: [], order: [] };
+  return { v: 1, sec: {}, tree: [], nodes: [], logs: [], asks: [], threads: [], cols: [], order: [],
+           focused: false };
 }
 
 /** Parse a stored blob. ANY malformed/foreign/old-version value reads as empty rather than throwing — a
@@ -72,11 +77,14 @@ export function parseViewState(raw: string | null | undefined): FeedViewState {
       for (const [k, v] of Object.entries(o.sec as Record<string, unknown>)) if (typeof v === "string") sec[k] = v;
     }
     // `threads` post-dates v1 blobs, so a stored entry without it reads as "nothing collapsed" rather
-    // than as corrupt — no version bump, and yesterday's saved sections survive the upgrade.
+    // than as corrupt — no version bump, and yesterday's saved sections survive the upgrade. `focused`
+    // (T347) is the same shape: a new key under the same v, so a blob saved before it, or one carrying a
+    // foreign-typed value, reads as the default (OFF) and keeps everything else it stored. Only the
+    // literal `true` switches it on.
     const col = (x: unknown): string[] =>
       arr(x).filter((k) => k === "asks" || k === "needsInput" || k === "completed");
     return { v: 1, sec, tree: arr(o.tree), nodes: arr(o.nodes), logs: arr(o.logs), asks: arr(o.asks),
-             threads: arr(o.threads), cols: col(o.cols), order: col(o.order) };
+             threads: arr(o.threads), cols: col(o.cols), order: col(o.order), focused: o.focused === true };
   } catch {
     return emptyViewState();
   }
@@ -118,15 +126,20 @@ export function keyIsLive(key: string, liveIds: Set<string>): boolean {
  *  entry meaningless; a collapsed thread describes a SESSION's run in a column, and its whole purpose is to
  *  hold while that run has no cards on the board so the next one arrives collapsed too. Pruning it against the live set
  *  would silently re-expand a thread the moment its last card cleared — exactly the "collapse it and it
- *  stays collapsed" the feature is for. It is bounded by the cap instead. */
+ *  stays collapsed" the feature is for. It is bounded by the cap instead.
+ *
+ *  `cols`, `order` and `focused` are exempt for the plainer reason that they describe the VIEW (the column
+ *  layout, the focused-session switch) and name no card at all; there is nothing to prune them against. */
 export function pruneViewState(s: FeedViewState, liveIds: Set<string>): FeedViewState {
   const sec: Record<string, string> = {};
   for (const [k, v] of Object.entries(s.sec)) if (keyIsLive(k, liveIds)) sec[k] = v;
   const keep = (xs: string[]) => xs.filter((k) => keyIsLive(k, liveIds));
   return capViewState({ v: 1, sec, tree: keep(s.tree), nodes: keep(s.nodes), logs: keep(s.logs),
-                        asks: keep(s.asks), threads: s.threads, cols: s.cols, order: s.order });
+                        asks: keep(s.asks), threads: s.threads, cols: s.cols, order: s.order,
+                        focused: s.focused });
 }
 
+// `cols`/`order` (three known keys) and `focused` (one boolean) are fixed-size view state and never count.
 export function viewStateSize(s: FeedViewState): number {
   return Object.keys(s.sec).length + s.tree.length + s.nodes.length + s.logs.length + s.asks.length
     + s.threads.length;
@@ -135,7 +148,8 @@ export function viewStateSize(s: FeedViewState): number {
 /** Backstop trim. Order is deliberate: the per-card SECTION choice is the state the user notices losing, so
  *  it is trimmed last; the per-node tree/log expansions are cheap to re-open and go first. Collapsed
  *  THREADS sit just above sec — they are few (one per session, not per card) and the most durable choice
- *  here, so they are the last thing to give before the sections do. */
+ *  here, so they are the last thing to give before the sections do. The view fields (`cols`, `order`,
+ *  `focused`) ride through the spread untouched: they are not entries and the cap never trims them. */
 export function capViewState(s: FeedViewState, cap: number = VIEW_STATE_CAP): FeedViewState {
   let over = viewStateSize(s) - cap;
   if (over <= 0) return s;

--- a/ui/webview/feed-viewmenu.test.ts
+++ b/ui/webview/feed-viewmenu.test.ts
@@ -1,6 +1,7 @@
 // The footer VIEW MENU (the user 2026-08-24): the three view controls — sort direction, single-column
 // layout, by-session grouping — live behind ONE monochrome icon button, replacing the Modified/Stack/
-// Group word-buttons. The popup wears the repo-wide menu vocabulary (.ctx-menu chrome + the ✓-in-circle
+// Group word-buttons; a fourth row, "Show focused session" (T347, 2026-09-11), puts the chat's focused
+// session's cards on top of the feed (feed-focus-section.test.ts owns what it does). The popup wears the repo-wide menu vocabulary (.ctx-menu chrome + the ✓-in-circle
 // current mark); prefs still write the shared romp:settings, so the gear watcher and other panes read
 // the same keys. feed.ts has no jsdom harness → source pins (the repo convention).
 import { test } from "node:test";
@@ -23,11 +24,13 @@ test("one 'View ▴' word-button replaces the three toggles; the old footer togg
   assert.match(FEED, /b\.setAttribute\("aria-haspopup", "menu"\);/);
 });
 
-test("the menu holds exactly the three rows, in order: sort direction, single column, group", () => {
+test("the menu holds exactly the four rows, in order: sort direction, single column, group, focused session", () => {
   const sortAt = FEED.indexOf('set(0, "Sort by most recent');
   const stackAt = FEED.indexOf('set(1, "Single column view');
   const groupAt = FEED.indexOf('set(2, "Group by session');
-  assert.ok(sortAt > 0 && stackAt > sortAt && groupAt > stackAt, "three rows, this order");
+  const focusAt = FEED.indexOf('set(3, "Show focused session');
+  assert.ok(sortAt > 0 && stackAt > sortAt && groupAt > stackAt && focusAt > groupAt, "four rows, this order");
+  assert.match(FEED, /if \(rows\.length !== 4\) return;/, "paintViewMenu syncs exactly four");
   // each ✓ row declares its role; the direction row stays a plain menuitem (feed-sort.test.ts owns that)
   assert.match(FEED, /r\.setAttribute\("role", check \? "menuitemcheckbox" : "menuitem"\);/);
   assert.match(FEED, /r\.setAttribute\("aria-checked", opts\.current \? "true" : "false"\);/);

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -402,6 +402,28 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
   .fcol-fold:hover, .fcol-fold:focus-visible { color: var(--fg); }
 }
 
+/* ---------- the FOCUSED SESSION section (T347, the user 2026-09-11, who wanted the focused session's cards on top) ----------
+   When a tab has focus in the chat pane, the feed puts that session's cards ABOVE the board — its name as the
+   head, the board's three column chips, a horizontal rule under it — and the board below stays exactly as it
+   is (feed.ts renderFocusSection). The section's columns carry .feed-cols / .feed-col, so the row layout, the
+   stacked container query above and the dragged --col-order all reach them unchanged; what differs is here:
+   no sticky heads (a miniature is short), no grab cursor (nothing to drag there), and the rule. Both themes
+   read through the variables; the one literal is a var() fallback. */
+#feed-focus { display: flex; flex-direction: column; gap: 8px; }
+/* the head wears the session headers' typography (.feed-sess-head): 600, the name at the card titles' size */
+.feed-focus-head { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin: 2px 3px 0; font-weight: 600; }
+.feed-focus-head .fname { font-size: inherit; }
+/* "focused", after the name — why this session sits on top. The fold count's own dress (.feed-sess-foldn):
+   the column head's 0.72em, weight 400, dim; no new size */
+.feed-focus-cap { flex: none; font-weight: 400; font-size: 0.72em; color: var(--dim); }
+.feed-focus-cols .feed-col-head { position: static; }
+.feed-focus-cols .feed-col-head .fcol-chip { cursor: default; }
+/* the rule under the section: the menus' hairline token, so each theme draws it in its own ink. The margin
+   shorthand zeroes the <hr>'s auto inline margins, which would otherwise keep a flex item from stretching. */
+.feed-focus-divider { border: 0; border-top: 1px solid var(--menu-border, rgba(255, 255, 255, 0.12)); margin: 6px 0 2px; }
+/* "No session is focused in the chat" / "<name> has no cards" — one quiet line, the menus' sub-line size */
+.feed-focus-empty { color: var(--dim); font-size: 0.82em; }
+
 /* ---------- ask card (the inbox unit): three rows (the user 2026-06-14) ---------- */
 /* row 1 — ask title, full width across the top. Hit-area still fits its TEXT (the title must
    NOT flex-grow, else clicking blank space right of it triggers locate instead of the modal —

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -37,6 +37,7 @@ import { canPreview } from "./preview";
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { initFileBrowse, openFileBrowse } from "./file-browse";
 import { VIEW_STATE_KEY, parseViewState, serializeViewState, pruneViewState, capViewState, type FeedViewState, threadKey, threadKeys } from "./feed-view-state";
+import { focusedEntries, focusedCardCount } from "./feed-focus";   // the focused-session section's pure pick (T347)
 import { wireTip, setTip, pruneTip } from "./tip";
 import { perfFrameHandler } from "./perf-telemetry";
 import { listenForFrames } from "./frame-listener";
@@ -188,8 +189,17 @@ function applyFocus() {
   const eff = hoverAskId ?? pinnedAskId;
   for (const [id, card] of askEls) card.classList.toggle("focused", id === eff);
   for (const [tid, card] of groupEls) card.classList.toggle("focused", "g:" + tid === eff);
+  // the focused-session section's copies (T347) light with the card below — one card, two elements
+  for (const [id, card] of fsAskEls) card.classList.toggle("focused", id === eff);
+  for (const [tid, card] of fsGroupEls) card.classList.toggle("focused", "g:" + tid === eff);
 }
 const askEls = new Map<string, HTMLElement>();
+// The FOCUSED SESSION section's own element caches (T347): the section duplicates the focused session's
+// cards above the board, so each card there is a SECOND element, keyed "f:a:<itemId>" / "f:g:<turnId>" and
+// cached here, never in askEls/groupEls — the board's reconcile, its FLIP capture and every lookup by a
+// card's bare key see only the copy below, so nothing below moves because the section did.
+const fsAskEls = new Map<string, HTMLElement>();
+const fsGroupEls = new Map<string, HTMLElement>();
 // Optimistically-cleared item ids: Clear animates a card out + posts askClear, but a feed push that
 // arrives BEFORE the kernel processes the clear still lists the card — re-rendering it strips the
 // `.dismissing` class (updateAskCard resets className) so it pops back, then a later push drops it. We
@@ -1033,7 +1043,7 @@ function rearmLatches(reply: LatchReply): number {
   const arm = (b: HTMLButtonElement | undefined, label: string) => {
     if (b && b.disabled) { b.disabled = false; b.textContent = label; n++; }
   };
-  for (const card of askEls.values()) {
+  for (const card of [...askEls.values(), ...fsAskEls.values()]) {   // the focused section's copies hold the same latches (T347)
     const a = card as any;
     const it = a._it as AskItem | undefined;
     if (!it) continue;
@@ -1525,6 +1535,13 @@ const cardTreeExpanded = new Set<string>();
 // arrangement dragged before the merge survives it).
 const collapsedCols = new Set<string>();
 let colOrder: string[] = [];                         // [] = each layout's own CSS default
+// THE FOCUSED SESSION section (T347, the user 2026-09-11, who wanted the focused session's cards on top): the
+// chat pane's active tab, relayed by the kernel as {type:"activeChat", id} to the feed clients of the same
+// window (on every tab switch, and once when this client registers), and the View menu's switch that puts
+// that session's cards above a divider. The switch is view state (persisted with the rest, prune-exempt,
+// OFF by default); the sid is not persisted — a reloaded feed registers and is told again.
+let focusedSid: string | null = null;
+let showFocused = false;
 
 (function hydrateViewState() {
   let st;
@@ -1537,6 +1554,7 @@ let colOrder: string[] = [];                         // [] = each layout's own C
   for (const k of st.threads) for (const key of threadKeys(k)) collapsedThreads.add(key);   // a pre-T263c bare sid = every column
   for (const k of st.cols) collapsedCols.add(k);
   colOrder = st.order.slice();
+  showFocused = st.focused;   // the focused-session section's switch (T347); a blob saved before it reads OFF
 })();
 
 function currentViewState(): FeedViewState {
@@ -1544,7 +1562,7 @@ function currentViewState(): FeedViewState {
   secChoice.forEach((v, k) => { sec[k] = v; });
   return { v: 1, sec, tree: [...cardTreeExpanded], nodes: [...collapsedNodes], logs: [...nodeLogOpen],
            asks: [...expandedAsks], threads: [...collapsedThreads], cols: [...collapsedCols],
-           order: colOrder.slice() };
+           order: colOrder.slice(), focused: showFocused };
 }
 
 // Written at the END of every render rather than from each toggle handler: the feed re-renders on every
@@ -3576,6 +3594,10 @@ type Entry =
 function entryCards(e: Entry): number {
   return e.kind === "sess" ? e.folded : e.kind === "group" ? e.group.members.length : 1;
 }
+/** The session an entry belongs to: a card's or a turn-group's owner, a run header's own sid. */
+function entrySid(e: Entry): string {
+  return e.kind === "ask" ? e.ask.sid : e.kind === "group" ? e.group.sid : e.sid;
+}
 
 // Grouped-mode session headers, one reused element per (column, sid) — same keyed-incremental treatment as
 // cards so re-renders never rebuild a header mid-press. Pruned when a reconcile drops them from the DOM.
@@ -3891,12 +3913,17 @@ function buildViewMenu(menu: HTMLElement): void {
   mk(false, () => setViewPref("newestFirst", !feedPrefs().newestFirst));
   mk(true, () => setViewPref("stacked", !feedPrefs().stacked, applyStacked));
   mk(true, () => setViewPref("grouped", !feedPrefs().grouped));
+  // "Show focused session" (T347, the user 2026-09-11): the chat's focused session's cards on top of the
+  // feed, above a divider. View state of the feed itself, not a shared pref: it rides the feed's persisted
+  // view state (FeedViewState.focused, OFF by default), never romp:settings, so the gear and the other panes
+  // have nothing to read — and the click re-renders directly, the way the fold carets do.
+  mk(true, () => { showFocused = !showFocused; persistViewState(); render(); });
 }
-// Sync the three rows to the CURRENT prefs — labels, ✓s, the forced state — without rebuilding them.
+// Sync the four rows to the CURRENT prefs — labels, ✓s, the forced state — without rebuilding them.
 function paintViewMenu(menu: HTMLElement): void {
   const p = feedPrefs();
   const rows = menu.querySelectorAll(".ctx-item");
-  if (rows.length !== 3) return;
+  if (rows.length !== 4) return;
   const set = (i: number, label: string, opts: { current: boolean; forced?: boolean; title: string }) => {
     const r = rows[i] as HTMLElement;
     r.textContent = label;
@@ -3920,6 +3947,11 @@ function paintViewMenu(menu: HTMLElement): void {
     current: p.grouped,
     title: p.grouped ? "grouped by session — click for the flat column order"
       : "group each column's cards by session (tab order), a session header between runs",
+  });
+  set(3, "Show focused session", {
+    current: showFocused,
+    title: showFocused ? "the chat's focused session has its cards on top — click to hide the section"
+      : "put the chat's focused session's cards on top of the feed, above a divider",
   });
 }
 function openViewMenu(btn: HTMLElement): void {
@@ -3949,7 +3981,7 @@ function ensureViewMenuBtn(): HTMLElement {
     b = el("button", "fdismiss ffollow feed-modetoggle");
     b.id = "feed-viewbtn";
     b.textContent = "View \u25b4";
-    b.title = "view options — sort direction, single column, group by session";
+    b.title = "view options — sort direction, single column, group by session, the focused session on top";
     b.setAttribute("aria-haspopup", "menu");
     b.onclick = (ev) => {   // opening the menu IS the acknowledgement (same as the session filter)
       ev.stopPropagation();
@@ -4196,12 +4228,19 @@ const ROW_DEFAULT = ["asks", "needsInput", "completed"];     // the side-by-side
 function applyColStack(): void {
   const custom = colOrder.length === 3 ? colOrder : null;
   for (const key of ["asks", "needsInput", "completed"]) {
-    const col = document.querySelector<HTMLElement>(".feed-col.col-" + key);
+    // the BOARD's column, under #feed-cols: the focused-session section above it carries the same column
+    // classes (T347), and a bare query would land on that copy first. The dragged order reaches BOTH — the
+    // section mirrors the arrangement below — the fold only the board's (the section has no caret to reopen with).
+    const col = document.querySelector<HTMLElement>("#feed-cols .feed-col.col-" + key);
     if (!col) continue;
     const folded = collapsedCols.has(key);
     col.classList.toggle("col-collapsed", folded);
     if (custom) col.style.setProperty("--col-order", String(custom.indexOf(key) + 1));
     else col.style.removeProperty("--col-order");
+    // …and the focused-session section's column of the same key (T347) wears the same order, so the miniature
+    // above mirrors the arrangement below — one dragged order, two renderings
+    const twin = document.querySelector<HTMLElement>("#feed-focus .feed-col.col-" + key);
+    if (twin) { if (custom) twin.style.setProperty("--col-order", String(custom.indexOf(key) + 1)); else twin.style.removeProperty("--col-order"); }
     const fold = col.querySelector<HTMLElement>(".fcol-fold");
     if (fold) {
       fold.textContent = folded ? "▸" : "▾";
@@ -4239,7 +4278,7 @@ function wireColDrag(chip: HTMLElement, col: HTMLElement, key: string): void {
     const applyOrderFlip = (order: string[]) => {
       const els: Array<[string, HTMLElement]> = [];
       for (const k of ["asks", "needsInput", "completed"]) {
-        const e = document.querySelector<HTMLElement>(".feed-col.col-" + k);
+        const e = document.querySelector<HTMLElement>("#feed-cols .feed-col.col-" + k);   // the board's, not the focused section's copy (T347)
         if (e) els.push([k, e]);
       }
       const before = new Map(els.map(([k, e]) => [k, edge(e.getBoundingClientRect())]));
@@ -4260,7 +4299,7 @@ function wireColDrag(chip: HTMLElement, col: HTMLElement, key: string): void {
       let to = from;
       for (const other of order) {
         if (other === key) continue;
-        const oc = document.querySelector<HTMLElement>(".feed-col.col-" + other);
+        const oc = document.querySelector<HTMLElement>("#feed-cols .feed-col.col-" + other);
         if (!oc) continue;
         const m = midOf(oc.getBoundingClientRect());
         const oi = order.indexOf(other);
@@ -4500,6 +4539,148 @@ function reconcileCol(listEl: HTMLElement, entries: Entry[], globalDesired: Set<
   }
   // an empty column shows NOTHING (the user 2026-06-25) — no "—" placeholder. (Any stray non-keyed child,
   // including an old placeholder, is already removed at the top of this reconcile.)
+}
+
+// ── THE FOCUSED SESSION SECTION (T347, the user 2026-09-11, who wanted the focused session's cards on top) ──
+// When a tab has focus in the chat pane, the feed puts that session's cards ABOVE the board: the session's
+// name as the head, the board's three columns (Working / Blocked / Completed, the same chips), a horizontal
+// rule under it. The board below stays exactly as it is, so those cards appear twice. A VIEW, not a move:
+// the section has its own elements and caches (fsAskEls / fsGroupEls, keys "f:a:…" / "f:g:…"), and
+// nothing below is touched by it — the FLIP capture reads #feed-cols, the modal's and the keyboard scope's
+// lookups match the bare keys, applyFocus lights both copies. EVENT-based: it rebuilds inside render(),
+// which the kernel's activeChat frame (a tab switch) and the feed's own frames drive; no timer anywhere.
+// Built once and synced in place: the head's name link and the column heads are stable nodes
+// (click-safety), only the card lists reconcile — with the same builders and the same update gate the
+// board uses, so a copy repaints exactly when the card below would.
+function ensureFocusSection(list: HTMLElement): HTMLElement {
+  let sec = document.getElementById("feed-focus");
+  if (!sec) {
+    sec = el("section", "");
+    sec.id = "feed-focus";
+    sec.setAttribute("aria-label", "the chat's focused session");
+    const head = el("div", "feed-focus-head");
+    const nm = el("a", "fname"); nm.title = "open this session";
+    const cap = el("span", "feed-focus-cap"); cap.textContent = "focused";   // the one word that says why this session sits on top
+    head.append(nm, cap);
+    const empty = el("div", "feed-focus-empty");
+    const cols = el("div", "feed-cols feed-focus-cols");
+    const lists: Partial<Record<Column, HTMLElement>> = {}, counts: Partial<Record<Column, HTMLElement>> = {};
+    // the board's own column chips and labels (ensureCols), minus the fold caret and the drag: the section's
+    // columns follow the board's order (applyColStack writes --col-order to both) and never fold on their own
+    for (const [key, label, chip] of [["asks", "Working", "working"], ["needsInput", "Blocked", "blocked"], ["completed", "Completed", "completed"]] as const) {
+      const col = el("div", "feed-col col-" + key);
+      const h = el("div", "feed-col-head");
+      const name = el("span", "feed-col-name fcol-chip fcol-chip-" + chip); name.textContent = label;
+      const count = el("span", "feed-col-count");
+      h.append(name, count);
+      const body = el("div", "feed-col-list");
+      col.append(h, body);
+      cols.appendChild(col);
+      lists[key] = body; counts[key] = count;
+    }
+    const rule = el("hr", "feed-focus-divider");
+    sec.append(head, empty, cols, rule);
+    (sec as any)._head = head; (sec as any)._name = nm; (sec as any)._empty = empty; (sec as any)._cols = cols;
+    (sec as any)._lists = lists; (sec as any)._counts = counts;
+  }
+  // directly above the board, every render: right before #feed-cols (the host loading strip, which announces
+  // what is coming, keeps the very top while it shows). A fresh section takes the board's column order at once.
+  const board = document.getElementById("feed-cols");
+  if (board && sec.nextSibling !== board) { list.insertBefore(sec, board); applyColStack(); }
+  return sec;
+}
+/** How the section names the focused session: this pane's session list (the chat's tab set, relayed per
+ *  frame), else a card of that session, else the kernel's 8-character stub — the same resolution the file
+ *  viewer's identity uses (setFileViewIdentity). Liveness is a card's word when there is one; a tab with no
+ *  cards is taken as live (the chat is showing it). */
+function focusedIdentity(sid: string): { name: string; color: { bg: string; fg: string } | null; live: boolean } {
+  const s = sessionsMeta.find((x) => x.sid === sid);
+  const a = asks.find((x) => x.sid === sid);
+  if (s) return { name: s.name, color: s.color ?? a?.color ?? null, live: a ? !!a.live : true };
+  if (a) return { name: a.name, color: a.color ?? null, live: !!a.live };
+  return { name: hostStub(sid)?.name || sid.slice(0, 8), color: null, live: true };
+}
+function renderFocusSection(list: HTMLElement, buckets: Record<Column, Entry[]>, gate: GateEnv): void {
+  const sec = ensureFocusSection(list) as any;
+  const head = sec._head as HTMLElement, nm = sec._name as HTMLElement, empty = sec._empty as HTMLElement, cols = sec._cols as HTMLElement;
+  const lists = sec._lists as Record<Column, HTMLElement>, counts = sec._counts as Record<Column, HTMLElement>;
+  const total = focusedCardCount(buckets, entryCards);
+  const sid = focusedSid;
+  if (sid) {
+    const who = focusedIdentity(sid);
+    // the name nodes are minted only when what they show changes (the session headers' rule): a Text-node
+    // replacement per render is the churn the card gate exists to avoid
+    const sig = who.name + "\u0000" + sid + "\u0000" + (hostIsDown(sid) ? "d" : "");
+    if (sec._nmSig !== sig) { sec._nmSig = sig; nm.replaceChildren(...hostNameNodes(who.name, sid)); }
+    nm.style.color = who.color ? who.color.bg : "";
+    nm.classList.toggle("dead", !who.live);
+    nm.onclick = (ev) => { ev.stopPropagation(); openOrReviveSession(sid, who.live, who.name); };   // the session headers' click: open, or offer to revive
+    setWorkDot(nm, dotFor(who.name));   // the same working / awaiting dot the session headers wear
+    setText(empty, who.name + " has no cards");
+  } else {
+    setText(empty, "No session is focused in the chat");
+  }
+  // the two quiet states: no tab focused → the line stands in for the head; a focused session with no cards →
+  // the head stays and the line says so. The rule stays in both, so the section still reads as a section.
+  head.style.display = sid ? "" : "none";
+  empty.style.display = sid && total ? "none" : "";
+  cols.style.display = total ? "" : "none";
+  const desired = new Set<string>();
+  for (const k of Object.keys(buckets) as Column[]) {
+    reconcileFocusCol(lists[k], buckets[k], gate, desired);
+    const n = buckets[k].reduce((acc, e) => acc + entryCards(e), 0);   // the board's counting rule: CARDS, and a number only when there are some
+    setText(counts[k], n ? String(n) : "");
+    counts[k].style.display = n ? "" : "none";
+  }
+  // a copy whose card left the focused session's view — cleared, folded into another turn, or the focus
+  // moved on — goes now; the board's copy below has its own cache and its own exit
+  for (const id of Array.from(fsAskEls.keys())) if (!desired.has("f:a:" + id)) { fsAskEls.get(id)?.remove(); fsAskEls.delete(id); }
+  for (const tid of Array.from(fsGroupEls.keys())) if (!desired.has("f:g:" + tid)) { fsGroupEls.get(tid)?.remove(); fsGroupEls.delete(tid); }
+}
+// reconcileCol's twin for ONE of the section's columns: the same keyed in-place reconcile (a card whose
+// column changed is MOVED, not rebuilt), over the section's own caches, under the section's own keys —
+// "f:a:<itemId>" / "f:g:<turnId>" in data-key, so the board's FLIP capture, the reveal jump and the modal's
+// lookups (all by the bare key) never take a copy for the card. Entries never include a run header
+// (focusedEntries drops them); one that did would be skipped, not built.
+function reconcileFocusCol(listEl: HTMLElement, entries: Entry[], gate: GateEnv, desired: Set<string>): void {
+  const existing = new Map<string, HTMLElement>();
+  for (const c of Array.from(listEl.children) as HTMLElement[]) {
+    const k = c.dataset.key;
+    if (k) existing.set(k, c); else c.remove();
+  }
+  const ordered: HTMLElement[] = [];
+  const colDesired = new Set<string>();
+  for (const e of entries) {
+    let key: string, card: HTMLElement;
+    if (e.kind === "ask") {
+      key = "f:a:" + e.ask.itemId;
+      card = fsAskEls.get(e.ask.itemId) || makeAskCard(e.ask);
+      card.dataset.key = key;   // the builder stamps the bare key; the copy wears the section's
+      fsAskEls.set(e.ask.itemId, card);
+      // THE UPDATE GATE (feed-card-gate.ts), as the board applies it: repaint a copy only when the kernel
+      // re-sent the card or a board-level input it reads changed
+      const ik = cardInputsKey(e.ask, gate);
+      if (cardNeedsUpdate(card as any, e.ask, ik)) { updateAskCard(card, e.ask); (card as any)._ik = ik; }
+    } else if (e.kind === "group") {
+      key = "f:g:" + e.group.turnId;
+      card = fsGroupEls.get(e.group.turnId) || makeGroupCard(e.group);
+      card.dataset.key = key;
+      fsGroupEls.set(e.group.turnId, card);
+      updateGroupCard(card, e.group);
+    } else continue;
+    desired.add(key); colDesired.add(key);
+    ordered.push(card);
+  }
+  for (const [k, c] of existing) if (!colDesired.has(k)) c.remove();
+  let cur: ChildNode | null = listEl.firstChild;
+  for (const node of ordered) {
+    if (cur === node) { cur = cur.nextSibling; continue; }
+    listEl.insertBefore(node, cur);
+  }
+}
+function removeFocusSection(): void {
+  document.getElementById("feed-focus")?.remove();
+  fsAskEls.clear(); fsGroupEls.clear();
 }
 
 // ── FLIP: animate a card FLYING to its new column when its status changes (the user 2026-06-27) ──
@@ -4914,6 +5095,7 @@ function render() {
     //                     wordmark never rendered (the user 2026-07-08; payload-audit fallout). Goal cards are
     //                     the only feed unit now, so an empty asks list IS an empty feed.
     askEls.clear(); groupEls.clear();
+    removeFocusSection();   // an empty board is the wordmark alone; the section returns with the cards (T347)
     skipFlipOnce = false;   // this IS the release paint when the board emptied while away — the snap is spent
     // inbox zero → the romp wordmark (a CSS background). role/aria-label + title keep the meaning for hover /
     // screen readers, since a background image carries no accessible text. Created ONCE (idempotent): on the
@@ -4949,6 +5131,10 @@ function render() {
   // (default off, the user 2026-07-07) reverses each column to newest-at-top.
   const newestFirst = feedPrefs().newestFirst;
   for (const k of Object.keys(buckets) as Column[]) buckets[k].sort((x, y) => newestFirst ? y.t - x.t : x.t - y.t);
+  // THE FOCUSED SESSION's view of these buckets (T347), taken HERE, before grouping: the section shows one
+  // session, so it carries no run headers, and a thread folded below must not empty it — the fold hides
+  // cards behind a caret the section does not have, and a compact view never dead-ends (ui/CLAUDE.md).
+  const focusBuckets = showFocused ? focusedEntries(buckets, focusedSid, entrySid) : null;
   // GROUPED mode (the user 2026-07-13): within each column, cards gather by SESSION — session order = the
   // kernel's session-order list (the same order the chat tabs + timeline lanes hold; sessions the list
   // doesn't know keep their time order after it) — with a name+dot header entry opening each run. The sort
@@ -4994,6 +5180,25 @@ function render() {
     // (the "item"/standalone bucket kind was removed with the FeedItem subsystem — no third branch)
   }
 
+  // The per-card update gate's inputs, resolved ONCE for this render (feed-card-gate.ts cardInputsKey):
+  // everything updateAskCard reads outside the ask object. A card is repainted when its object or this key
+  // changed, so a frame's cost scales with the cards the kernel re-sent and the cards a changed input
+  // reaches, not with the board.
+  const gprefs = feedPrefs();
+  const gate: GateEnv = {
+    dot: dotFor, working: (n) => workingSet.has(n),
+    focusId: hoverAskId ?? pinnedAskId, pinnedId: pinnedAskId, notifyOn: cardNotifyOn,
+    prefs: { grouped: gprefs.grouped, collapsed: gprefs.collapsed, colormap: gprefs.colormap },
+    hostDown: hostIsDown, selfHost: feedSelfHost, repo: prRepoOf, seq: ++renderSeq,
+  };
+  // The focused session's section above the board (T347): its own elements and caches, the same builders and
+  // the same update gate. Painted BEFORE the board's FLIP capture below: the section sits above the board, so
+  // its height is part of where every board card rests, and a First rect read before the section settled would
+  // have every card below glide by the section's change on top of its own move (a card moving column on a
+  // frame that also changes the section's card count). The capture itself reads #feed-cols alone, so no copy
+  // in the section is ever a First or a Last rect, and the board's reconcile after it is what it always was.
+  if (focusBuckets) renderFocusSection(list, focusBuckets, gate); else removeFocusSection();
+
   // FLIP step 1 (the user 2026-06-27): record every visible card's position + column BEFORE the reconcile, so
   // a card that changes column can FLY from its old spot to the new one instead of teleporting. Only when
   // something CAN move: the capture and the fly each force a layout of the whole document, and most frames
@@ -5008,17 +5213,6 @@ function render() {
   prevCols = nextCols;
   const flipFirst = needFlip ? captureCardRects(cols) : new Map<string, FlipState>();
 
-  // The per-card update gate's inputs, resolved ONCE for this render (feed-card-gate.ts cardInputsKey):
-  // everything updateAskCard reads outside the ask object. A card is repainted when its object or this key
-  // changed, so a frame's cost scales with the cards the kernel re-sent and the cards a changed input
-  // reaches, not with the board.
-  const gprefs = feedPrefs();
-  const gate: GateEnv = {
-    dot: dotFor, working: (n) => workingSet.has(n),
-    focusId: hoverAskId ?? pinnedAskId, pinnedId: pinnedAskId, notifyOn: cardNotifyOn,
-    prefs: { grouped: gprefs.grouped, collapsed: gprefs.collapsed, colormap: gprefs.colormap },
-    hostDown: hostIsDown, selfHost: feedSelfHost, repo: prRepoOf, seq: ++renderSeq,
-  };
   const desired = new Set<string>();
   reconcileCol(cols.asks, buckets.asks, desired, gate);
   reconcileCol(cols.needsInput, buckets.needsInput, desired, gate);
@@ -5176,7 +5370,10 @@ function kbCardEls(): HTMLElement[] {
   // VISUAL order, not DOM order (review 2026-08-24): the columns re-sequence via --col-order — in
   // both layouts since the drag extended — so the arrow cursor sorts cards by their column's
   // effective `order` (getComputedStyle resolves the var), DOM order within a column.
-  const els = Array.from(document.querySelectorAll<HTMLElement>(".feed-cols .fitem:not(.dismissing)"));
+  // the BOARD's cards, under #feed-cols: the focused-session section (T347) above it carries the same column
+  // classes, and a walk over both would interleave a copy with its card below by column order — the section is
+  // a view of the board, and the cursor's field stays the board
+  const els = Array.from(document.querySelectorAll<HTMLElement>("#feed-cols .fitem:not(.dismissing)"));
   const slot = new Map<HTMLElement, number>();
   for (const e of els) {
     const col = e.closest<HTMLElement>(".feed-col");
@@ -5187,7 +5384,8 @@ function kbCardEls(): HTMLElement[] {
     .map((x) => x.e);
 }
 function kbHoverId(el: HTMLElement): string {
-  const key = el.dataset.key || "";
+  let key = el.dataset.key || "";
+  if (key.startsWith("f:")) key = key.slice(2);         // a focused-section copy (T347) IS the card below: the same identity under an "f:" prefix
   return key.startsWith("g:") ? key : key.slice(2);   // group card → "g:<tid>" (applyFocus key); ask/deliverable → itemId
 }
 function kbSelectCard(el: HTMLElement | null): void {
@@ -5319,6 +5517,7 @@ function mirrorBadges(items: AskItem[], clears: ClearNoticeRow[], sdk: SdkNotice
 // under the pointer flushes too, via its synthetic mouseleave — and window blur is the backstop.
 let freezeKey: string | null = null;     // the hovered card's focus key, or null — pointer truth, no debounce
 let pendingFeedPayload: any = null;      // newest queued payload; older ones are superseded unseen
+let focusStale = false;                  // an activeChat frame landed while the gate was held: the section repaints on release (T347)
 function freezeEnter(key: string): void { freezeKey = key; }
 function freezeLeave(key: string): void {
   if (tabScopeKey === key) releaseTabScope();   // hover-away releases the keyboard scope too
@@ -5341,6 +5540,8 @@ function flushFreeze(): void {
     const m = pendingFeedPayload;
     pendingFeedPayload = null;
     if (m) applyFeedPayload(m);          // render() repaints the badges away (nothing pending)
+    else if (focusStale) render();       // a tab switch that landed while a card was held paints now (T347)
+    focusStale = false;                  // either way the section is current: applyFeedPayload renders too
   });
 }
 window.addEventListener("blur", () => { releaseTabScope(); freezeKey = null; flushFreeze(); });   // backstop:
@@ -5415,7 +5616,7 @@ function paintFreezeBadges(): void {
     paintFreezeParts(b, c);
   };
   for (const key of ["asks", "needsInput", "completed"]) {
-    put(document.querySelector(".feed-col.col-" + key + " .feed-col-head"), d.cols[key]);
+    put(document.querySelector("#feed-cols .feed-col.col-" + key + " .feed-col-head"), d.cols[key]);   // the board's heads, never the focused section's (T347)
   }
   const groupedNow = feedPrefs().grouped;
   // The HOVERED header row must not change shape (T285 review): a badge appended inside it lands after the
@@ -5674,6 +5875,16 @@ listenForFrames(perfFrameHandler("feed", (m) => vscodeApi?.postMessage(m), (e: M
     // hint the deferred churn on the headers instead; mouseleave/blur flush it (see freezeEnter).
     if (freezeKey || tabScopeKey) { pendingFeedPayload = m; paintFreezeBadges(); return; }
     applyFeedPayload(m);
+  } else if (m.type === "activeChat") {
+    // THE FOCUSED SESSION (T347): the kernel relays the chat pane's active tab to the feed clients of the same
+    // window — on every tab switch, and once when this client registers, so a reloaded feed learns the focus
+    // without waiting for one. The frame IS the event: the section repaints here, never on a clock. While a
+    // card is held under the pointer (hover-freeze) the repaint waits for the release, like a payload does:
+    // the held card's rect standing still is that gate's whole contract, and the section's height sits above it.
+    focusedSid = typeof m.id === "string" && m.id ? m.id : null;
+    if (!showFocused) return;
+    if (freezeKey || tabScopeKey) { focusStale = true; return; }
+    render();
   } else if (m.type === "hoverCards") {
     // rail-dot hover in the CHAT panel → white-outline the card(s) built from
     // that turn, plus the matching ROWS inside an open modal (eid). The host
@@ -6012,7 +6223,7 @@ function revealCards(keys: Set<string>) {
 // definition of "hidden".
 function livePass(): void {
   const now = nowSec();
-  for (const card of askEls.values()) {
+  for (const card of [...askEls.values(), ...fsAskEls.values()]) {   // …and the focused section's copies (T347)
     const it = (card as any)._it as AskItem | undefined;
     if (!it) continue;
     // the latched Continue's hover title names how long ago it was sent (contTitle, T150): a title, so it

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -5095,8 +5095,8 @@ function render() {
     //                     wordmark never rendered (the user 2026-07-08; payload-audit fallout). Goal cards are
     //                     the only feed unit now, so an empty asks list IS an empty feed.
     askEls.clear(); groupEls.clear();
-    removeFocusSection();   // an empty board is the wordmark alone; the section returns with the cards (T347)
     skipFlipOnce = false;   // this IS the release paint when the board emptied while away — the snap is spent
+    removeFocusSection();   // an empty board is the wordmark alone; the section returns with the cards (T347)
     // inbox zero → the romp wordmark (a CSS background). role/aria-label + title keep the meaning for hover /
     // screen readers, since a background image carries no accessible text. Created ONCE (idempotent): on the
     // transition from cards→empty we mint it (its CSS fade-in plays once, the user 2026-06-25), and every

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -200,6 +200,21 @@ const askEls = new Map<string, HTMLElement>();
 // card's bare key see only the copy below, so nothing below moves because the section did.
 const fsAskEls = new Map<string, HTMLElement>();
 const fsGroupEls = new Map<string, HTMLElement>();
+/** Every element on the page that renders this card: the board's, and the focused section's copy when the
+ *  section shows it. Clear, its 180 ms finish and Undo resolve by ITEM through these, never by one element,
+ *  so a gesture on either copy reaches both (the review of T347: Clear on a copy left the card below). */
+function cardTwins(itemId: string): HTMLElement[] {
+  const out: HTMLElement[] = [];
+  const a = askEls.get(itemId); if (a) out.push(a);
+  const f = fsAskEls.get(itemId); if (f) out.push(f);
+  return out;
+}
+function groupTwins(turnId: string): HTMLElement[] {
+  const out: HTMLElement[] = [];
+  const g = groupEls.get(turnId); if (g) out.push(g);
+  const f = fsGroupEls.get(turnId); if (f) out.push(f);
+  return out;
+}
 // Optimistically-cleared item ids: Clear animates a card out + posts askClear, but a feed push that
 // arrives BEFORE the kernel processes the clear still lists the card — re-rendering it strips the
 // `.dismissing` class (updateAskCard resets className) so it pops back, then a later push drops it. We
@@ -1396,9 +1411,18 @@ function makeAskCard(it: AskItem): HTMLElement {
     dressHeaderIfLast(card, it.sid);   // the run's last card takes its header with it — one motion (2026-08-24)
     pendingCleared.add(it.itemId);   // suppress from incoming pushes until the kernel confirms the clear
     clearedStack.push([(card as any)._it ?? it]);   // cache the FRESHEST payload copy for an instant optimistic Undo (the closure's `it` is the card's creation-time object)
-    card.classList.add("dismissing");
+    // BY ITEM, not by this element (T347): the focused-session section holds a second element for the same
+    // card, and Clear on either copy clears the card, so both wear .dismissing now and both leave together.
+    // The stale-timeout guard is per element: a render inside the window that revived the card (its update
+    // resets the class) or replaced its element leaves that copy alone.
+    for (const c of cardTwins(it.itemId)) c.classList.add("dismissing");
     vscodeApi?.postMessage({ type: "askClear", itemId: it.itemId, sid: it.sid });
-    setTimeout(() => { if (askEls.get(it.itemId) === card && card.classList.contains("dismissing")) { card.remove(); askEls.delete(it.itemId); dropDismissed([it.itemId]); } }, 180);
+    setTimeout(() => {
+      const twins = cardTwins(it.itemId).filter((c) => c.classList.contains("dismissing"));
+      if (!twins.length) return;
+      for (const c of twins) { c.remove(); if (askEls.get(it.itemId) === c) askEls.delete(it.itemId); if (fsAskEls.get(it.itemId) === c) fsAskEls.delete(it.itemId); }
+      dropDismissed([it.itemId]);
+    }, 180);
   };
   cont.onclick = (ev) => {
     ev.stopPropagation();
@@ -2672,7 +2696,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     card.dispatchEvent(new MouseEvent("mouseleave"));   // flush the group's stuck hover highlight (see the ask card's clear)
     const cur = (card as any)._g as AskGroup;
     dressHeaderIfLast(card, cur.sid);   // a group is one session's turn — same one-motion rule (2026-08-24)
-    card.classList.add("dismissing");
+    for (const c of groupTwins(cur.turnId)) c.classList.add("dismissing");   // both copies of the group (T347), see the ask card's Clear
     clearedStack.push(cur.members.slice());   // cache the whole batch for an instant optimistic Undo
     for (const m of cur.members) pendingCleared.add(m.itemId);
     // ONE kernel batch for every member (askClearMany): the kernel's Undo restores a batch by its one
@@ -2680,7 +2704,12 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     vscodeApi?.postMessage({ type: "askClearMany", itemIds: cur.members.map((m) => m.itemId), sid: cur.sid });
     // only finalize if a render in the 180ms window didn't revive (re-render clears
     // .dismissing) or replace this card — else a stale timeout yanks the wrong one
-    setTimeout(() => { if (groupEls.get(cur.turnId) === card && card.classList.contains("dismissing")) { card.remove(); groupEls.delete(cur.turnId); dropDismissed(cur.members.map((m) => m.itemId)); } }, 180);
+    setTimeout(() => {
+      const twins = groupTwins(cur.turnId).filter((c) => c.classList.contains("dismissing"));
+      if (!twins.length) return;
+      for (const c of twins) { c.remove(); if (groupEls.get(cur.turnId) === c) groupEls.delete(cur.turnId); if (fsGroupEls.get(cur.turnId) === c) fsGroupEls.delete(cur.turnId); }
+      dropDismissed(cur.members.map((m) => m.itemId));
+    }, 180);
   };
   // hover (120ms intent) → white border + preview the group's timeline journey
   // (first member). leave → restore the pin (ask OR group) or clear.
@@ -3736,7 +3765,7 @@ function makeUndoClearBtn(): HTMLElement {
         // a card still inside its 180 ms collapse keeps its element AND its object, so the per-card update
         // gate would leave `.dismissing` on it and the collapse timer would then remove the restored card:
         // the Undo gesture is the event that takes the class off
-        askEls.get(it.itemId)?.classList.remove("dismissing");
+        for (const c of cardTwins(it.itemId)) c.classList.remove("dismissing");   // the board's element and the focused section's copy (T347)
         if (!asks.some((a) => a.itemId === it.itemId)) asks.push(it);        // show it NOW
       }
       render();
@@ -4468,9 +4497,14 @@ function clearSessionCards(sid: string): void {
   for (const m of members) {
     const c = askEls.get(m.itemId);
     if (c) leaving.push([c, () => askEls.get(m.itemId) === c, () => askEls.delete(m.itemId)]);
+    const f = fsAskEls.get(m.itemId);   // the focused section's copy leaves with its card (T347)
+    if (f) leaving.push([f, () => fsAskEls.get(m.itemId) === f, () => fsAskEls.delete(m.itemId)]);
   }
   for (const [tid, g] of Array.from(groupEls)) {
     if (turns.has(tid) && ((g as any)._g as AskGroup | undefined)?.sid === sid) leaving.push([g, () => groupEls.get(tid) === g, () => groupEls.delete(tid)]);
+  }
+  for (const [tid, g] of Array.from(fsGroupEls)) {
+    if (turns.has(tid) && ((g as any)._g as AskGroup | undefined)?.sid === sid) leaving.push([g, () => fsGroupEls.get(tid) === g, () => fsGroupEls.delete(tid)]);
   }
   for (const [c] of leaving) { c.dispatchEvent(new MouseEvent("mouseleave")); c.classList.add("dismissing"); }
   // The header row holds the hover-freeze gate too, and its Clear all sits on the row: the pointer that clicked it

--- a/ui/webview/relay-active-rearm.test.ts
+++ b/ui/webview/relay-active-rearm.test.ts
@@ -40,11 +40,14 @@ test("the active tab is re-announced on a socket's open only when THAT kernel ow
   assert.equal(activeTabToReannounce(null, ""), false, "no tab open, local socket");
 });
 
-test("the re-announced activeTab reaches exactly the owning host, its id bared (the contract notifyActive relies on)", () => {
+test("the re-announced activeTab reaches the owning host first, its id bared (the contract notifyActive relies on), and the local record", () => {
   // notifyActive posts {type:"activeTab", id: activeId} with the HOST-PREFIXED id; federation's outbound
-  // router must land it on that host's relay with the bare id the remote kernel knows, and a local id local
+  // router must land it on that host's relay with the bare id the remote kernel knows, and a local id local.
+  // Since T347 the LOCAL kernel hears a remote session's report too, prefixed, for its feed's focused-session
+  // section (active-tab-local-route.test.ts); the owning host's route is unchanged and comes first.
   assert.deepEqual(routeOutbound({ type: "activeTab", id: "TESTHOST:" + SID }),
-                   [{ host: "TESTHOST", msg: { type: "activeTab", id: SID } }]);
+                   [{ host: "TESTHOST", msg: { type: "activeTab", id: SID } },
+                    { host: "", msg: { type: "activeTab", id: "TESTHOST:" + SID } }]);
   assert.deepEqual(routeOutbound({ type: "activeTab", id: SID }), [{ host: "", msg: { type: "activeTab", id: SID } }]);
 });
 


### PR DESCRIPTION
T347 (the user 2026-09-11, who wanted the focused session's cards on top of the feed): the FOCUSED SESSION section. Tier `feature`, experimental, off by default.

## What it does

When a session's tab has focus in the chat pane and the switch is on, the feed shows, above a horizontal divider, a miniature of itself for that one session: the same three columns (Working, Blocked, Completed), the same cards, headed by the session's name and its work dot. The feed below stays exactly as it is; the cards appear twice, above in the section and in their normal place. With the switch on and no tab focused, the section is one quiet line ("No session is focused in the chat"); a focused session with no cards reads "<name> has no cards". Both themes through the shared variables.

## Design points

- **Off by default, a View menu row.** The switch is the fourth row of the feed's View menu, "Show focused session" (a `menuitemcheckbox` in the shared menu vocabulary, painted in place like the other three). It persists with the feed's other view state in `feed-view-state.ts` (`FeedViewState.focused`, version 1 unchanged: a missing or wrong-typed key reads off, so yesterday's saved sections survive; prune and cap leave it alone like the layout keys).
- **Event-based, the kernel relays the focus.** The chat pane already tells the kernel its active tab on every switch (`activeTab`). The kernel records it per window (one window's panes share a dashboard id, `wid`) and sends every feed pane of that window one small frame, `{type: "activeChat", id}`, on the switch and once when a feed pane connects; the feed rebuilds the section on that frame and on its own frames, never on a timer.
- **A view, not a move.** The section builds its own card elements from the render's buckets, filtered to the focused session (a pure helper, `feed-focus.ts`), with its own element caches keyed apart from the feed's, so nothing in the feed below, its element caches, its FLIP capture or its hover and modal lookups changes because the section exists. The cards-move-on-new-information rule holds by construction.
- **Dress.** The section reuses the column heads' chips and counts (no fold caret, no drag), the session header's typography for its head, and a hairline divider under it; the stacked layout applies to its columns as to the feed's.
- **Empty states, stated.** One quiet line rather than hiding: a switch that leaves no trace when nothing is focused would read as broken.

No SDK file is touched. Not covered: a VS Code host whose panes do not share a window id reads "No session is focused in the chat"; two chat columns of one window both report their active tab, the later report wins (stated in the kernel comment).

## The review's five items, folded

1. A feed page that reloads registers while its bundle still evaluates; a tab switch in its window relayed the focus into a document with no listener and wrote the dedup slot, so the ready arm's re-send was swallowed for a minute. The ready arm's reset now forgets the `activeChat` slot with the others; a test relays before ready and sees ready re-send.
2. Clear on the section's copy ran the board builder's finish, which guarded on the board's element: the copy stayed and Undo restored the board's element alone. Clear, its finish, the session-wide Clear and Undo resolve by item across both copies (`cardTwins` / `groupTwins`); the served lab clears a card from the copy and undoes it, checking both elements each time.
3. Cross-pane hover and reveal reach the copies: the card-key bridge strips the section's prefix.
4. The per-window focus record leaves with the window's last pane.
5. A remote session's active tab reaches the local kernel too, prefixed, beside the owning host's bare report, so a feed reload names the remote session (the route test pins both legs).

## Tests

- `ui/webview/feed-view-state.test.ts`: `focused` is off by default, round-trips true and false, a blob without the key or with a wrong-typed value reads off with the rest intact, prune and cap leave it alone.
- `ui/webview/feed-focus-entries.test.ts`: the pure pick: the card set per column equals the board's cards for that session, other sessions and run headers excluded, order preserved, no cards or no session yields empty columns.
- `ui/webview/feed-focus-section.test.ts` and `feed-viewmenu.test.ts`: the fourth row's wording and role, the `activeChat` handler rebuilding without a timer, the section before `#feed-cols`, its own caches and keys, the render order (section before the FLIP capture), the board-scoped keyboard walk and freeze badges, the twin column order, the dress in `feed.css` through variables.
- `tests/test_kernel_active_chat_relay.py`: the relay reaches same-window feed panes only, dedups an unchanged value, relays a null, the ready hook sends the current value once ahead of the connect push, a dead socket does not stop the fan-out, a non-chat pane's report files nothing.
- `tests/test_feed_focus_served.py`: the real `/feed` page under a browser: default off; a focus report with the switch off changes nothing; the switch from the View menu; the section's card set per column equals the board's for that session and every board card stays where it was; the rebuild on an active-tab change; the quiet lines; persistence across a reload (the switch stays, the session is learned again); both themes.

## Screenshots

Written by the served lab into the drops folder, the dashboard's feed page with a synthetic three-session board: `romp_feed-focused-section-off-dark.png`, `-off-light.png` (the switch off: the board alone), `-on-dark.png`, `-on-light.png` (the switch on, `web` focused: its three cards above the divider, the board below unchanged).

## Verification

UI node suite: 4448 tests, 4443 pass, 5 skipped, no failures (two source pins followed the section: the work-dot site count and the empty-board branch's line order). Full Python suite: 11953 passed, 55 skipped, two browser-driven failures while the machine's capped pool was saturated (the known served wedge probe and a comment-dialog size test), both green when re-run alone on this tree (the wedge twice) and on main. Bats: every suite, 579 ok. After the review folds: the WebSocket handler, relay, skeleton and fold suites (163), the served lab in a browser; the whole UI suite over the folded head, 4454 tests, 4449 pass, 5 skipped, no failures (three source pins followed the twins and the kernel's disconnect block keeps its pinned shape); the full Python suite over the folded kernel, 11957 passed, 55 skipped, no failures. Typecheck clean. The served lab passed in a real browser. Reviewed by a read-through of the diff (no review panel, per the spend hold of 2026-09-11).
