### PR TITLE
The automatic converge waits only to spare turns a restart would cut, and says so every pass it holds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,16 @@ Every bug fix or feature change must land with a test that covers it (user rule,
 surfaces. Reproduce the bug in a failing test first when practical; fixtures
 live in `tests/fixtures/`.
 
+### A test that mints its own state root pins `session-hosts` off (2026-09-11)
+Per-session hosts are ON by default (T348): a backend over a state directory with no
+`session-hosts` file starts a real `bin/romp-session-host` for any session it connects. The
+runner's conftest writes `off` into the one state root it floors for the run, and only that
+one. A test that builds its own temp state root (a bare `tempfile.mkdtemp()` handed to
+`SdkBackend`, a lab kernel's xdg root) is outside that belt and must write `off` into
+`<its root>/session-hosts` itself, unless it means to run a host, as the hosts-on end-to-end
+tests do by writing `on`. Precedent: `tests/test_cut_turn_tree_kill.py` `_backend` and the
+connect-loop harnesses in `tests/test_sdk_backend.py` (`_hosts_off`).
+
 ### Goal-store fixtures use a PRIVATE synthetic sid (2026-08-24)
 An instance of the standing synthetic-fixtures rule with a mechanism behind it:
 any Python test that MINTS GOALS under the shared `11111111-2222-…` placeholder

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2281,6 +2281,18 @@ the same note) is not the delivery either: that cut is named by the note,
 the self-bounce's `refresh` note, is the delivery: the cut row names the
 request and consumes it.
 
+The automatic converge spaces itself: after a deploy restart lands on a box
+(its own converge, a peer's push, a clicked Update), the next automatic
+converge waits 25 minutes, so a batch of merges costs one restart, and it
+stands down while a quiet deploy is parked for the code already on disk. Both
+waits exist to spare in-flight turns from the restart's cut, so neither applies
+to a restart that would cut none: when every working session runs under a host
+(the default), the converge proceeds at once. Every pass in which main has
+moved and the box does not converge says why on the kernel's log, each time it
+holds: the cool-down's remaining seconds and the turns a restart would cut, the
+parked quiet deploy, or that main could not be read (`git ls-remote` at the
+release remote failed or timed out).
+
 When no row qualifies, the kernel writes a row with action `signal`: the signal
 name, its pid and its parent's pid, the manager pid it was started with,
 whether a manager restart was pending, `managerRequested: false`, and

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1052,9 +1052,9 @@ def _kernel_sha():
                                    capture_output=True, text=True, timeout=2)
                 if d.returncode == 0 and d.stdout.strip():
                     sha += "-dirty"
-            _SHA = sha
-        except Exception:
-            _SHA = ""
+            _SHA = sha or None      # an EMPTY answer is not remembered (T352 review): a 2 s git timeout at a busy boot
+        except Exception:           # used to pin '' for the process's life, and the drift check's restart leg then
+            _SHA = None             # had no running sha to compare until a restart; the next call asks again
     return _SHA or None
 
 
@@ -7766,16 +7766,20 @@ def _main_drift_check():
     checkout = _checkout_sha()      # ONE read each: the verdict's inputs and the parked-deploy
     running = _kernel_sha()         # match below read the same shas the verdict examined
     origin = _origin_main_sha()
+    kind, target = _main_drift_verdict(origin, checkout, running)
     if not origin or not checkout or not running:
-        # no verdict this pass, said each time (T352): an unreadable input used to pass in silence, indistinguishable
-        # in the journal from a check thread that had died. `main` unreadable is git ls-remote failing or timing out
-        # (15 s) at the release remote: offline, an auth prompt, or a box too busy to answer in time.
+        # an unreadable input is a NOTE each pass, never a gate (T352, and its review): the verdict keeps its per-leg
+        # shape, so main unreadable (git ls-remote failing or timing out at the release remote: offline, an auth prompt,
+        # a box too busy to answer in 15 s) still lets a checkout ahead of the running kernel converge the restart leg,
+        # while a pull needs main and the checkout both. Silence here used to read, in the journal, like a check thread
+        # that had died.
         gone = [n for n, v in (("main at %s (git ls-remote failed or timed out)" % _release_remote(), origin),
                                ("the checkout's HEAD", checkout), ("the running kernel's sha", running)) if not v]
-        _converge_say("no verdict this pass: %s could not be read; main %s, checkout %s, running %s; again in %d s"
-                      % (" and ".join(gone), origin or "?", checkout or "?", running or "?", _MAIN_CHECK_EVERY_S))
-        return
-    kind, target = _main_drift_verdict(origin, checkout, running)
+        _converge_say("%s could not be read this pass (main %s, checkout %s, running %s): %s; again in %d s"
+                      % (" and ".join(gone), origin or "?", checkout or "?", running or "?",
+                         "no verdict" if not kind else "the %s leg still decides from what was read" % kind, _MAIN_CHECK_EVERY_S))
+        if not kind:
+            return
     if kind == "restart" and target == _REBUILT_FOR[0]:
         return                                        # already converged in place (UI-only rebuild)
     if kind == "restart" and not _kernel_code_changed(running, target):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7721,6 +7721,37 @@ def _parked_quiet_deploy(checkout, now=None):
     return int(rec["t"]) if isinstance(rec.get("t"), (int, float)) else 0
 
 
+def _deploy_would_cut():
+    """The turns a deploy restart NOW would cut, as the drain would record them (SdkBackend.would_cut), or None when
+    that is unknown (no backend built yet, or one without the method). The gates that spare in-flight turns apply to
+    an unknown answer exactly as to a non-empty one (T352): only a KNOWN empty list waives them."""
+    be = _sdk_backend or None
+    if be is None or not hasattr(be, "would_cut"):
+        return None
+    try:
+        return list(be.would_cut())
+    except Exception:
+        return None
+
+
+def _cut_words(cut):
+    """The tail of a converge line naming what a restart now would cut: the turns, or that it is unknown."""
+    if cut is None:
+        return "; what a restart would cut is unknown (no backend yet)"
+    if not cut:
+        return "; a restart now would cut no turn"
+    names = ", ".join(str(c.get("name") or str(c.get("sid") or "")[:8]) for c in cut[:6]) + (", …" if len(cut) > 6 else "")
+    return "; a restart now would cut %d turn%s: %s" % (len(cut), "" if len(cut) == 1 else "s", names)
+
+
+def _converge_say(text):
+    """One line on the kernel's log for EVERY pass in which main has moved and this box does not converge: a hold, a
+    stand-down, an unreadable read (T352: a merged fix waited 23 minutes behind a cool-down that said nothing, so
+    the journal could not tell a hold from a dead thread). Every pass, never once per sha: the reader of the journal
+    must see the wait still standing, and the cadence is one pass per five minutes."""
+    sys.stderr.write("romp-kernel: converge: %s\n" % text)
+
+
 def _main_drift_check():
     """One origin/checkout/running comparison pass; fires the SAME banner as the release check (the
     shell's offer() renders the main-drift wording off kind:"main"). Re-fires only when the target sha
@@ -7734,7 +7765,17 @@ def _main_drift_check():
         return
     checkout = _checkout_sha()      # ONE read each: the verdict's inputs and the parked-deploy
     running = _kernel_sha()         # match below read the same shas the verdict examined
-    kind, target = _main_drift_verdict(_origin_main_sha(), checkout, running)
+    origin = _origin_main_sha()
+    if not origin or not checkout or not running:
+        # no verdict this pass, said each time (T352): an unreadable input used to pass in silence, indistinguishable
+        # in the journal from a check thread that had died. `main` unreadable is git ls-remote failing or timing out
+        # (15 s) at the release remote: offline, an auth prompt, or a box too busy to answer in time.
+        gone = [n for n, v in (("main at %s (git ls-remote failed or timed out)" % _release_remote(), origin),
+                               ("the checkout's HEAD", checkout), ("the running kernel's sha", running)) if not v]
+        _converge_say("no verdict this pass: %s could not be read; main %s, checkout %s, running %s; again in %d s"
+                      % (" and ".join(gone), origin or "?", checkout or "?", running or "?", _MAIN_CHECK_EVERY_S))
+        return
+    kind, target = _main_drift_verdict(origin, checkout, running)
     if kind == "restart" and target == _REBUILT_FOR[0]:
         return                                        # already converged in place (UI-only rebuild)
     if kind == "restart" and not _kernel_code_changed(running, target):
@@ -7783,21 +7824,44 @@ def _main_drift_check():
         # for the rest of the window, and a pull must not wait on a park that already delivered
         # (review find). When a stand-down ends without that landing — the row expired, the park
         # died with its manager — say so once and let the converge proceed on its own terms.
+        # Both waits below exist to spare IN-FLIGHT TURNS from a restart's cut: the quiet window waits for them to
+        # end, the cool-down spaces the cuts. A restart that would cut none (every working session under a host,
+        # T315; the default since T348) has nothing to spare, so neither wait applies to it (T352, the manager's
+        # find: a merged fix waited 23 minutes behind the cool-down on a box where every session was hosted). The
+        # answer comes from the drain's own predicate (SdkBackend.would_cut), and only a KNOWN empty list waives a
+        # wait: unknown (no backend yet) keeps both, as before. Every held pass says so, each time.
+        cut = _deploy_would_cut()
+        spares = cut is not None and not cut
         if not _sha_same(running, checkout) and _parked_quiet_deploy(checkout):
-            if _QUIET_PARKED_LOGGED[0] != checkout:
+            if spares:
+                _QUIET_PARKED_LOGGED[0] = ""             # pre-empted knowingly: no "no longer pending" line below
+                _converge_say("%s is parked as a quiet deploy, but a restart now would cut no turn: converging "
+                              "without waiting for the window" % checkout[:8])
+            else:
                 _QUIET_PARKED_LOGGED[0] = checkout
-                sys.stderr.write("romp-kernel: converge: %s already parked as a quiet deploy — leaving it "
-                                 "to the quiet window\n" % checkout[:8])
-            _MAIN_DRIFT[slot] = ""
-            return
+                _converge_say("%s is parked as a quiet deploy; leaving it to the quiet window%s"
+                              % (checkout[:8], _cut_words(cut)))
+                _MAIN_DRIFT[slot] = ""
+                return
         if _QUIET_PARKED_LOGGED[0] == checkout:
             _QUIET_PARKED_LOGGED[0] = ""
-            sys.stderr.write("romp-kernel: converge: the quiet deploy parked for %s is no longer pending — "
-                             "the converge proceeds on its own terms\n" % checkout[:8])
+            _converge_say("the quiet deploy parked for %s is no longer pending; the converge proceeds on its own "
+                          "terms" % checkout[:8])
         last = max(_LAST_AUTO_CONVERGE[0], _last_deploy_restart_t())
-        if time.time() - last < _CONVERGE_COOLDOWN_S:
-            _MAIN_DRIFT[slot] = ""
-            return
+        left = _CONVERGE_COOLDOWN_S - (time.time() - last)
+        if left > 0:
+            since = time.strftime("%H:%M:%SZ", time.gmtime(last))
+            if spares:
+                _converge_say("main is at %s (this box runs %s): %d s of the %d min cool-down since the deploy "
+                              "restart at %s remain, but a restart now would cut no turn: converging now"
+                              % (target, running[:8], int(left), int(_CONVERGE_COOLDOWN_S // 60), since))
+            else:
+                _converge_say("main is at %s (the checkout %s, this box runs %s): holding %d s more of the %d min "
+                              "cool-down since the deploy restart at %s%s"
+                              % (target, checkout[:8], running[:8], int(left), int(_CONVERGE_COOLDOWN_S // 60), since,
+                                 _cut_words(cut)))
+                _MAIN_DRIFT[slot] = ""
+                return
         _LAST_AUTO_CONVERGE[0] = time.time()
         _run_main_update(kind, target=target)
     else:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1037,12 +1037,18 @@ _load_downtime()
 _SHA = None                                  # lazily-resolved git short-sha of the code this kernel runs
 
 
+_SHA_MISS_T = [0.0]         # when git last failed to answer _kernel_sha
+_SHA_REASK_S = 30           # and how long that failure stands before git is asked again (the round-two review's low)
+
+
 def _kernel_sha():
     """git short-sha of HEAD, plus '-dirty' if the working tree has uncommitted edits — the kernel
     loads bin/*.py straight from the worktree, so a dirty tree means it's running code that isn't at
     any commit. Resolved once (a restart re-reads it). None outside a git checkout."""
     global _SHA
     if _SHA is None:
+        if time.time() - _SHA_MISS_T[0] < _SHA_REASK_S:
+            return None             # asked and unanswered within the bound: /version and /sw.js call this per request
         try:
             r = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "--short", "HEAD"],
                                capture_output=True, text=True, timeout=2)
@@ -1052,9 +1058,11 @@ def _kernel_sha():
                                    capture_output=True, text=True, timeout=2)
                 if d.returncode == 0 and d.stdout.strip():
                     sha += "-dirty"
-            _SHA = sha or None      # an EMPTY answer is not remembered (T352 review): a 2 s git timeout at a busy boot
-        except Exception:           # used to pin '' for the process's life, and the drift check's restart leg then
-            _SHA = None             # had no running sha to compare until a restart; the next call asks again
+            _SHA = sha or None      # an EMPTY answer is not remembered for the process's life (T352 review): a 2 s git
+        except Exception:           # timeout at a busy boot used to pin '' and the drift check's restart leg then had
+            _SHA = None             # no running sha to compare until a restart; it is asked again after _SHA_REASK_S
+        if _SHA is None:
+            _SHA_MISS_T[0] = time.time()
     return _SHA or None
 
 
@@ -7834,40 +7842,48 @@ def _main_drift_check():
         # find: a merged fix waited 23 minutes behind the cool-down on a box where every session was hosted). The
         # answer comes from the drain's own predicate (SdkBackend.would_cut), and only a KNOWN empty list waives a
         # wait: unknown (no backend yet) keeps both, as before. Every held pass says so, each time.
-        cut = _deploy_would_cut()
-        spares = cut is not None and not cut
-        if not _sha_same(running, checkout) and _parked_quiet_deploy(checkout):
-            if spares:
-                _QUIET_PARKED_LOGGED[0] = ""             # pre-empted knowingly: no "no longer pending" line below
-                _converge_say("%s is parked as a quiet deploy, but a restart now would cut no turn: converging "
-                              "without waiting for the window" % checkout[:8])
-            else:
-                _QUIET_PARKED_LOGGED[0] = checkout
-                _converge_say("%s is parked as a quiet deploy; leaving it to the quiet window%s"
-                              % (checkout[:8], _cut_words(cut)))
-                _MAIN_DRIFT[slot] = ""
-                return
-        if _QUIET_PARKED_LOGGED[0] == checkout:
-            _QUIET_PARKED_LOGGED[0] = ""
-            _converge_say("the quiet deploy parked for %s is no longer pending; the converge proceeds on its own "
-                          "terms" % checkout[:8])
-        last = max(_LAST_AUTO_CONVERGE[0], _last_deploy_restart_t())
-        left = _CONVERGE_COOLDOWN_S - (time.time() - last)
-        if left > 0:
-            since = time.strftime("%H:%M:%SZ", time.gmtime(last))
-            if spares:
-                _converge_say("main is at %s (this box runs %s): %d s of the %d min cool-down since the deploy "
-                              "restart at %s remain, but a restart now would cut no turn: converging now"
-                              % (target, running[:8], int(left), int(_CONVERGE_COOLDOWN_S // 60), since))
-            else:
-                _converge_say("main is at %s (the checkout %s, this box runs %s): holding %d s more of the %d min "
-                              "cool-down since the deploy restart at %s%s"
-                              % (target, checkout[:8], running[:8], int(left), int(_CONVERGE_COOLDOWN_S // 60), since,
-                                 _cut_words(cut)))
-                _MAIN_DRIFT[slot] = ""
-                return
-        _LAST_AUTO_CONVERGE[0] = time.time()
-        _run_main_update(kind, target=target)
+        try:
+            cut = _deploy_would_cut()
+            spares = cut is not None and not cut
+            if not _sha_same(running, checkout) and _parked_quiet_deploy(checkout):
+                if spares:
+                    _QUIET_PARKED_LOGGED[0] = ""             # pre-empted knowingly: no "no longer pending" line below
+                    _converge_say("%s is parked as a quiet deploy, but a restart now would cut no turn: converging "
+                                  "without waiting for the window" % (checkout or "?")[:8])
+                else:
+                    _QUIET_PARKED_LOGGED[0] = checkout
+                    _converge_say("%s is parked as a quiet deploy; leaving it to the quiet window%s"
+                                  % ((checkout or "?")[:8], _cut_words(cut)))
+                    _MAIN_DRIFT[slot] = ""
+                    return
+            if _QUIET_PARKED_LOGGED[0] == checkout:
+                _QUIET_PARKED_LOGGED[0] = ""
+                _converge_say("the quiet deploy parked for %s is no longer pending; the converge proceeds on its own "
+                              "terms" % (checkout or "?")[:8])
+            last = max(_LAST_AUTO_CONVERGE[0], _last_deploy_restart_t())
+            left = _CONVERGE_COOLDOWN_S - (time.time() - last)
+            if left > 0:
+                since = time.strftime("%H:%M:%SZ", time.gmtime(last))
+                if spares:
+                    _converge_say("main is at %s (this box runs %s): %d s of the %d min cool-down since the deploy "
+                                  "restart at %s remain, but a restart now would cut no turn: converging now"
+                                  % (target, (running or "?")[:8], int(left), int(_CONVERGE_COOLDOWN_S // 60), since))
+                else:
+                    _converge_say("main is at %s (the checkout %s, this box runs %s): holding %d s more of the %d min "
+                                  "cool-down since the deploy restart at %s%s"
+                                  % (target, (checkout or "?")[:8], (running or "?")[:8], int(left), int(_CONVERGE_COOLDOWN_S // 60), since,
+                                     _cut_words(cut)))
+                    _MAIN_DRIFT[slot] = ""
+                    return
+            _LAST_AUTO_CONVERGE[0] = time.time()
+            _run_main_update(kind, target=target)
+        except Exception:
+            # a crash in the hold branches (the T352 round-two review: a None running sha inside the cool-down raised
+            # at a [:8] AFTER the latch above took the target, and the hold's own reset never ran, so every later
+            # pass returned at the latch and that commit never converged, in silence) leaves no target latched:
+            # the next pass judges afresh, and the crash itself reaches the check thread's log as before
+            _MAIN_DRIFT[slot] = ""
+            raise
     else:
         if target in _dismissed_updates():
             return                    # Not-now'd THIS sha, durably — a NEW sha offers again

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -10170,6 +10170,21 @@ class SdkBackend:
                 #                                     reconnect, raise — frees the sid for the next
                 #                                     parse's acceptance
 
+    @staticmethod
+    def cut_list(sessions) -> list:
+        """The turns a restart would CUT among `sessions`: every session with an in-flight turn that no host holds
+        (T315: a session under a host, or mid-attach by intent, is detached, never cut; T143: `ended` is not a filter,
+        a mid-shutdown session with a live turn is a cut too). The drain's ledger row and the deploy gates read this
+        one predicate (T352), so "would a restart now cut anything" is answered exactly as the drain would record."""
+        return [{"sid": s.sid, "name": s.name} for s in sessions
+                if s.inflight and getattr(s, "_host", None) is None and not getattr(s, "_host_intent", False)]
+
+    def would_cut(self) -> list:
+        """The turns a restart NOW would cut (cut_list over the live sessions): the converge gates' input (T352)."""
+        with self._lock:
+            sessions = list(self.sessions.values())
+        return self.cut_list(sessions)
+
     def drain(self, timeout: float = 2.0, kill=os.kill) -> dict:
         """Graceful-shutdown drain (the kernel's SIGTERM handler): stop every running session cleanly
         within `timeout` — interrupt any in-flight turn and close the SDK clients so the claude
@@ -10201,8 +10216,7 @@ class SdkBackend:
                 s.detached = True                       # by intent too: a session mid-attach must not be ended
                 if s._host is not None:
                     s._host.detach_mode = True
-        cut = [{"sid": s.sid, "name": s.name} for s in sessions
-               if s.inflight and getattr(s, "_host", None) is None and not getattr(s, "_host_intent", False)]
+        cut = self.cut_list(sessions)
         inflight = len(cut)
         for s in sessions:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,8 +137,12 @@ os.environ["ROMP_POSTAL_HERMETIC"] = "1"
 # No test spawns a per-session HOST by omission (2026-09-11, T348): hosts are on by default now, so a backend built over
 # a state dir with no `session-hosts` file starts a real bin/romp-session-host for any session it connects. The root the
 # runner floors carries the toggle set to off from the start, re-asserted per test below (a test that deletes or rewrites
-# it gets it back); the deliberate hosts-on tests write `on` into their OWN state roots and are unaffected. A test that
-# builds its own bare state dir pins the setting itself (kernel/host_transport.py session_hosts_read).
+# it gets it back); the deliberate hosts-on tests write `on` into their OWN state roots and are unaffected.
+# THE BELT'S REACH: it covers this one root and nothing else. A test that mints its own temp state root (a bare
+# tempfile.mkdtemp() handed to SdkBackend, a lab kernel's xdg root) stands outside it and MUST write `off` into
+# `<its root>/session-hosts` itself unless it means to run a host, or the first connect it drives spawns a real
+# bin/romp-session-host on the developer's box (tests/test_cut_turn_tree_kill.py did, 2026-09-11). The rule for test
+# authors is in CLAUDE.md under Testing.
 _SESSION_HOSTS_OFF = os.path.join(os.environ["XDG_STATE_HOME"], "romp", "session-hosts")
 
 

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import unittest
 from unittest import mock
+import time
 from romp_load import load_source
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -623,15 +624,58 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
             if len(calls) == 1:
                 raise _sp.TimeoutExpired(argv, 2)     # a busy boot: git did not answer in time
             return mock.Mock(returncode=0, stdout="" if argv[-1] == "--porcelain" else "abc1234\n")   # a clean tree
+        saved_miss = km._SHA_MISS_T[0]
         try:
             km._SHA = None
+            km._SHA_MISS_T[0] = 0.0
             with mock.patch.object(km.subprocess, "run", side_effect=run):
                 self.assertIsNone(real(), "the blip answers nothing…")
-                self.assertEqual(real(), "abc1234", "…and is not remembered: the next call asks git again")
+                self.assertIsNone(real(), "…and within the re-ask bound the miss stands without a git call (the round-two low: "
+                                          "/version and /sw.js call this per request)")
+                self.assertEqual(calls, ["HEAD"], "one git call so far")
+                km._SHA_MISS_T[0] = time.time() - km._SHA_REASK_S - 1     # the bound passed
+                self.assertEqual(real(), "abc1234", "…and is not remembered for the process's life: asked again after the bound")
                 self.assertEqual(real(), "abc1234", "a real answer is memoized")
             self.assertEqual(calls, ["HEAD", "HEAD", "--porcelain"])
         finally:
             km._SHA = saved
+            km._SHA_MISS_T[0] = saved_miss
+
+    def test_a_missing_running_sha_inside_the_cool_down_holds_says_so_and_the_next_pass_converges(self):
+        # the round-two review's MEDIUM: with the pass no longer returning early on an unreadable input, a None running
+        # sha (a 2 s rev-parse timeout on a busy box) inside the cool-down raised at running[:8] AFTER the latch took
+        # the target, and the hold's own reset never ran: every later pass returned at the latch, the commit never
+        # converged, in silence
+        self._deploy_landed(300)
+        km._kernel_sha = lambda: None
+        km._deploy_would_cut = lambda: [{"sid": "1" * 36, "name": "web"}]
+        self._pass()
+        self.assertEqual(self.ran, [], "inside the cool-down with a turn to spare: held")
+        self.assertIn("main is at bbb (the checkout aaa, this box runs ?): holding ", self._lines()[-1])
+        self.assertEqual(km._MAIN_DRIFT[0], "", "the hold's reset ran: no target latched")
+        km._kernel_sha = lambda: "aaa"
+        km.RESTART_CUTS_FILE.unlink()                    # the cool-down is over
+        self._pass()
+        self.assertEqual(self.ran, ["pull"], "the next pass converges")
+        # the spares branch with a None running sha says so too
+        self.ran.clear(); km._MAIN_DRIFT[0] = ""
+        self._deploy_landed(300)
+        km._kernel_sha = lambda: None
+        km._deploy_would_cut = lambda: []
+        self._pass()
+        self.assertEqual(self.ran, ["pull"], "a restart now would cut no turn: converging")
+        self.assertIn("main is at bbb (this box runs ?): ", self._lines()[-1])
+
+    def test_a_crash_in_the_hold_branches_never_leaves_a_target_latched(self):
+        def boom():
+            raise RuntimeError("boom")
+        km._deploy_would_cut = boom
+        with self.assertRaises(RuntimeError):
+            self._pass()
+        self.assertEqual(km._MAIN_DRIFT[0], "", "the latch is reset on the way out, so the next pass judges afresh")
+        km._deploy_would_cut = lambda: []
+        self._pass()
+        self.assertEqual(self.ran, ["pull"])
 
     def test_a_parked_quiet_deploy_stands_down_every_pass_unless_nothing_would_be_cut(self):
         km._checkout_sha = lambda: "bbb"                  # the checkout is ahead of the kernel: a restart is owed…

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -8,6 +8,7 @@ import inspect
 import os
 import tempfile
 import unittest
+from unittest import mock
 from romp_load import load_source
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -595,16 +596,42 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
         self.assertEqual(self.ran, [], "unknown keeps both waits, as before")
         self.assertIn("; what a restart would cut is unknown (no backend yet)", self._lines()[0])
 
-    def test_an_unreadable_main_says_so_every_pass(self):
+    def test_an_unreadable_main_says_so_every_pass_and_the_restart_leg_still_converges(self):
         km._origin_main_sha = lambda: ""                  # git ls-remote failed or timed out
         km._deploy_would_cut = lambda: []
         self._pass(); self._pass()
-        self.assertEqual(self.ran, [])
+        self.assertEqual(self.ran, [], "the checkout and the kernel agree: nothing to do, said each pass")
         lines = self._lines()
         self.assertEqual(len(lines), 2, lines)
         for l in lines:
-            self.assertIn("no verdict this pass: main at ", l)
-            self.assertIn("(git ls-remote failed or timed out) could not be read; main ?, checkout aaa, running aaa; again in 300 s", l)
+            self.assertIn("main at ", l)
+            self.assertIn("(git ls-remote failed or timed out) could not be read this pass (main ?, checkout aaa, running aaa): no verdict; again in 300 s", l)
+        # the per-leg shape (the review's M1): the checkout ahead of the running kernel converges the restart leg with
+        # main unreadable, as it always did; only a pull needs main and the checkout both
+        km._checkout_sha = lambda: "bbb"
+        self._pass()
+        self.assertEqual(self.ran, ["restart"], "offline, the restart leg still converges")
+        self.assertIn("the restart leg still decides from what was read; again in 300 s", self._lines()[-1])
+
+    def test_an_empty_kernel_sha_is_asked_again_never_remembered(self):
+        import subprocess as _sp
+        saved = km._SHA
+        real = self.saved[3]                              # the REAL reader: setUp stubbed km._kernel_sha for the gate tests
+        calls = []
+        def run(argv, **kw):
+            calls.append(argv[-1])
+            if len(calls) == 1:
+                raise _sp.TimeoutExpired(argv, 2)     # a busy boot: git did not answer in time
+            return mock.Mock(returncode=0, stdout="" if argv[-1] == "--porcelain" else "abc1234\n")   # a clean tree
+        try:
+            km._SHA = None
+            with mock.patch.object(km.subprocess, "run", side_effect=run):
+                self.assertIsNone(real(), "the blip answers nothing…")
+                self.assertEqual(real(), "abc1234", "…and is not remembered: the next call asks git again")
+                self.assertEqual(real(), "abc1234", "a real answer is memoized")
+            self.assertEqual(calls, ["HEAD", "HEAD", "--porcelain"])
+        finally:
+            km._SHA = saved
 
     def test_a_parked_quiet_deploy_stands_down_every_pass_unless_nothing_would_be_cut(self):
         km._checkout_sha = lambda: "bbb"                  # the checkout is ahead of the kernel: a restart is owed…
@@ -625,7 +652,9 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
     def test_the_backend_answers_would_cut_with_the_drains_own_predicate(self):
         import sys, tempfile, types
         sbm = sys.modules.get("romp_sdk_backend") or load_source("romp_sdk_backend", os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py"))
-        be = sbm.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        d = tempfile.mkdtemp()
+        open(os.path.join(d, "session-hosts"), "w").write("off")   # a bare state root pins hosts off (the suite's rule, T348)
+        be = sbm.SdkBackend(d, "/bin/true", lambda *a, **k: None)
         mk = lambda sid, name, inflight, host=None, intent=False: types.SimpleNamespace(sid=sid, name=name, inflight=inflight, _host=host, _host_intent=intent)
         be.sessions = {"a": mk("a" * 36, "plain-busy", True), "b": mk("b" * 36, "plain-idle", False),
                        "c": mk("c" * 36, "hosted-busy", True, host=object()), "d": mk("d" * 36, "attaching-busy", True, intent=True)}
@@ -654,7 +683,9 @@ class UiOnlyConverge(unittest.TestCase):
         self._saved = {n: getattr(km, n) for n in
                        ("_main_drift_verdict", "_kernel_code_changed", "_rebuild_dist",
                         "_sync_notice", "_update_mode", "_send_to_app", "_kernel_sha",
-                        "_main_tracking", "_converge_classes")}
+                        "_main_tracking", "_converge_classes", "_origin_main_sha", "_checkout_sha")}
+        km._origin_main_sha = lambda: "tgt"     # stubbed: the real one runs `git ls-remote`, a NETWORK call per test
+        km._checkout_sha = lambda: "tgt"        # (the classifier test's precedent; the stubbed verdict decides below)
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
         km._INPLACE_TRIED[0] = ""
@@ -799,12 +830,14 @@ class PersistentDismissal(unittest.TestCase):
     def test_a_dismissed_drift_sha_never_banners_but_a_new_one_does(self):
         saved = {n: getattr(km, n) for n in
                  ("_main_tracking", "_main_drift_verdict", "_send_to_app", "_update_mode",
-                  "_kernel_sha", "_kernel_code_changed")}
+                  "_kernel_sha", "_kernel_code_changed", "_origin_main_sha", "_checkout_sha")}
         banners = []
         try:
             km._update_mode = lambda: "ask"
             km._main_tracking = lambda: True
             km._kernel_sha = lambda: "cur"
+            km._origin_main_sha = lambda: "tgt"     # stubbed: the real one is a network call (the classifier test's precedent)
+            km._checkout_sha = lambda: "tgt"
             km._kernel_code_changed = lambda a, b: True
             km._send_to_app = lambda app, payload: banners.append(payload)
             km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -323,9 +323,10 @@ class DriftWiring(unittest.TestCase):
                                          "reason": "from TESTHOST to f3dc387a", "when": "quiet"}) + "\n")
             out = check()
             self.assertEqual(ran, [], "a quiet deploy for this very code is parked: the converge stands down")
-            self.assertIn("already parked as a quiet deploy", out, "one line says why nothing happened")
+            self.assertIn("f3dc387a is parked as a quiet deploy; leaving it to the quiet window", out, "one line says why nothing happened")
             self.assertEqual(km._MAIN_DRIFT[1], "", "the sha is not marked acted on — the next pass re-evaluates")
-            self.assertNotIn("already parked", check(), "…but says it once per sha, not once per pass")
+            self.assertIn("is parked as a quiet deploy; leaving it to the quiet window", check(),
+                          "…and says it on EVERY pass (T352: a silent hold read as a dead thread), no longer once per sha")
             self.assertEqual(ran, [])
             # the 08:42Z shape: origin reads ahead of the checkout too (a stale fetch, or a merge
             # that landed meanwhile) — the parked restart still delivers the code on disk first;
@@ -518,6 +519,126 @@ class DriftWiring(unittest.TestCase):
         self.assertIn('kind = "pull" if d0 else ("restart" if d1 else "")', src,
                       "no version or kind is ever taken from the client")
         self.assertIn('"target": d0 or d1', src, "the click converges onto the commit the banner named")
+
+
+
+class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
+    """T352 (the manager's find, 2026-09-11): a merged fix waited 23 minutes behind the auto-converge cool-down on a box
+    where every session was hosted, and the hold wrote nothing to the journal. The two waits (the cool-down, the parked
+    quiet deploy) exist to spare in-flight turns, so a restart that would cut none skips them; every pass that holds,
+    stands down, or cannot read main says so on the kernel's log, each time."""
+
+    def setUp(self):
+        import io
+        self.saved = (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha, km._run_main_update,
+                      km._deploy_would_cut, km._parked_quiet_deploy, km._kernel_code_changed,
+                      km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._QUIET_PARKED_LOGGED[0])
+        self.ran = []
+        km._update_mode = lambda: "auto"
+        km._checkout_sha = lambda: "aaa"
+        km._kernel_sha = lambda: "aaa"
+        km._origin_main_sha = lambda: "bbb"
+        km._run_main_update = lambda kind, immediate=False, target="": self.ran.append(kind)
+        km._parked_quiet_deploy = lambda checkout, now=None: 0
+        km._kernel_code_changed = lambda running, target: True
+        km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        km._QUIET_PARKED_LOGGED[0] = ""
+        km._LAST_AUTO_CONVERGE[0] = 0.0
+        self.err = io.StringIO()
+
+    def tearDown(self):
+        (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha, km._run_main_update,
+         km._deploy_would_cut, km._parked_quiet_deploy, km._kernel_code_changed) = self.saved[:8]
+        km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._QUIET_PARKED_LOGGED[0] = self.saved[8:]
+        if km.RESTART_CUTS_FILE.exists():
+            km.RESTART_CUTS_FILE.unlink()
+
+    def _pass(self):
+        import contextlib
+        with contextlib.redirect_stderr(self.err):
+            km._main_drift_check()
+
+    def _lines(self):
+        return [l for l in self.err.getvalue().splitlines() if l.startswith("romp-kernel: converge: ")]
+
+    def _deploy_landed(self, ago):
+        import json, time
+        km.RESTART_CUTS_FILE.write_text(json.dumps({"t": int(time.time() - ago), "reason": "p2p-update: from X to Y",
+                                                    "cutTurns": []}) + "\n")
+
+    def test_a_held_converge_says_so_every_pass_and_names_the_turns_it_spares(self):
+        self._deploy_landed(300)
+        km._deploy_would_cut = lambda: [{"sid": "1" * 36, "name": "web"}, {"sid": "2" * 36, "name": "api"}]
+        self._pass(); self._pass()
+        self.assertEqual(self.ran, [], "inside the cool-down with turns to spare: no restart")
+        lines = self._lines()
+        self.assertEqual(len(lines), 2, "one line per held pass, never once per sha: %r" % lines)
+        for l in lines:
+            self.assertIn("main is at bbb (the checkout aaa, this box runs aaa): holding ", l)
+            self.assertRegex(l, r"holding \d+ s more of the 25 min cool-down since the deploy restart at \d\d:\d\d:\d\dZ")
+            self.assertIn("; a restart now would cut 2 turns: web, api", l)
+        self.assertEqual(km._MAIN_DRIFT[0], "", "the deferred sha stays unoffered: the first pass past the window takes the latest")
+
+    def test_a_converge_that_would_cut_nothing_skips_the_cool_down_and_says_why(self):
+        self._deploy_landed(300)
+        km._deploy_would_cut = lambda: []                 # every working session hosted: a restart cuts nothing
+        self._pass()
+        self.assertEqual(self.ran, ["pull"], "nothing to spare: the converge proceeds inside the cool-down")
+        lines = self._lines()
+        self.assertEqual(len(lines), 1, lines)
+        self.assertRegex(lines[0], r"^romp-kernel: converge: main is at bbb \(this box runs aaa\): \d+ s of the 25 min cool-down since the deploy restart at \d\d:\d\d:\d\dZ remain, but a restart now would cut no turn: converging now$")
+
+    def test_an_unknown_cut_set_keeps_the_hold(self):
+        self._deploy_landed(300)
+        km._deploy_would_cut = lambda: None               # no backend yet: unknown is not "none"
+        self._pass()
+        self.assertEqual(self.ran, [], "unknown keeps both waits, as before")
+        self.assertIn("; what a restart would cut is unknown (no backend yet)", self._lines()[0])
+
+    def test_an_unreadable_main_says_so_every_pass(self):
+        km._origin_main_sha = lambda: ""                  # git ls-remote failed or timed out
+        km._deploy_would_cut = lambda: []
+        self._pass(); self._pass()
+        self.assertEqual(self.ran, [])
+        lines = self._lines()
+        self.assertEqual(len(lines), 2, lines)
+        for l in lines:
+            self.assertIn("no verdict this pass: main at ", l)
+            self.assertIn("(git ls-remote failed or timed out) could not be read; main ?, checkout aaa, running aaa; again in 300 s", l)
+
+    def test_a_parked_quiet_deploy_stands_down_every_pass_unless_nothing_would_be_cut(self):
+        km._checkout_sha = lambda: "bbb"                  # the checkout is ahead of the kernel: a restart is owed…
+        km._origin_main_sha = lambda: "bbb"
+        km._parked_quiet_deploy = lambda checkout, now=None: 1   # …and a quiet deploy is parked for it
+        km._deploy_would_cut = lambda: [{"sid": "1" * 36, "name": "web"}]
+        self._pass(); self._pass()
+        self.assertEqual(self.ran, [], "with a turn to spare the parked quiet deploy stands the check down")
+        lines = self._lines()
+        self.assertEqual(len(lines), 2, "said on every pass, not once per sha: %r" % lines)
+        for l in lines:
+            self.assertEqual(l, "romp-kernel: converge: bbb is parked as a quiet deploy; leaving it to the quiet window; a restart now would cut 1 turn: web")
+        km._deploy_would_cut = lambda: []
+        self._pass()
+        self.assertEqual(self.ran, ["restart"], "nothing to spare: the converge does not wait for the window")
+        self.assertEqual(self._lines()[-1], "romp-kernel: converge: bbb is parked as a quiet deploy, but a restart now would cut no turn: converging without waiting for the window")
+
+    def test_the_backend_answers_would_cut_with_the_drains_own_predicate(self):
+        import sys, tempfile, types
+        sbm = sys.modules.get("romp_sdk_backend") or load_source("romp_sdk_backend", os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py"))
+        be = sbm.SdkBackend(tempfile.mkdtemp(), "/bin/true", lambda *a, **k: None)
+        mk = lambda sid, name, inflight, host=None, intent=False: types.SimpleNamespace(sid=sid, name=name, inflight=inflight, _host=host, _host_intent=intent)
+        be.sessions = {"a": mk("a" * 36, "plain-busy", True), "b": mk("b" * 36, "plain-idle", False),
+                       "c": mk("c" * 36, "hosted-busy", True, host=object()), "d": mk("d" * 36, "attaching-busy", True, intent=True)}
+        self.assertEqual(be.would_cut(), [{"sid": "a" * 36, "name": "plain-busy"}], "only a plain child with a turn in flight is a cut")
+        be.sessions = {"c": mk("c" * 36, "hosted-busy", True, host=object())}
+        self.assertEqual(be.would_cut(), [], "every working session hosted: a restart cuts nothing")
+        self.assertEqual(km._deploy_would_cut(), None, "no backend in this process: unknown")
+        saved = km._sdk_backend
+        km._sdk_backend = be
+        try:
+            self.assertEqual(km._deploy_would_cut(), [])
+        finally:
+            km._sdk_backend = saved
 
 
 if __name__ == "__main__":

--- a/tests/test_restart_cuts.py
+++ b/tests/test_restart_cuts.py
@@ -205,8 +205,9 @@ class CutRow(unittest.TestCase):
         sbmod = km.sb if hasattr(km, "sb") else None
         src = open(os.path.join(os.path.dirname(HERE), "kernel", "sdk_backend.py")).read()
         # …and a session under a per-session host is detached, never cut (T315): the join keeps that filter
-        self.assertIn("cut = [{\"sid\": s.sid, \"name\": s.name} for s in sessions\n               if s.inflight and getattr(s, \"_host\", None) is None and not getattr(s, \"_host_intent\", False)]", src,
-                      "every in-flight session is a cut — ended included (the join, not a filter)")
+        self.assertIn("return [{\"sid\": s.sid, \"name\": s.name} for s in sessions\n                if s.inflight and getattr(s, \"_host\", None) is None and not getattr(s, \"_host_intent\", False)]", src,
+                      "every in-flight session is a cut — ended included (the join, not a filter); the predicate is cut_list (T352)")
+        self.assertIn("        cut = self.cut_list(sessions)\n        inflight = len(cut)", src, "the drain records cut_list's answer")
         self.assertIn("if s.thread is not None:", src,
                       "a threadless session can no longer crash the drain")
 


### PR DESCRIPTION
The automatic converge waits only to spare turns a restart would cut, and it says so on every pass it holds (T352).

**What happened.** A peer's deploy restarted this kernel at 17:23:27Z on 2026-09-11, which started the 25-minute cool-down auto mode keeps between deploy restarts. A fix merged at 17:41Z fell inside that window: the 17:43Z pass saw main ahead and held, writing nothing, so the journal could not tell a hold from a dead check thread, and the pass that would have converged, at 17:48Z, came after the deploy had been made by hand. With every working session under a host, the restart would have cut nothing, so the cool-down had nothing to protect.

**The fix.** The drain's cut predicate is one method, `SdkBackend.cut_list`, which the drain's ledger row and the converge gates now share; `would_cut` answers what a restart now would cut. A known empty answer waives both waits, the cool-down and the stand-down for a parked quiet deploy; an unknown answer (no backend built yet) keeps them exactly as before. Every pass in which main has moved and the box does not converge writes one line to the kernel's log (its stderr, the manager's journal; not `update.log`, which is the deploy runner's own file), each time rather than once per sha: the cool-down's remaining seconds since the deploy restart and the turns a restart would cut, the parked quiet deploy, or that main could not be read (`git ls-remote` at the release remote failed or timed out), with the shas it did read. The stand-down's own line is now said on every pass too. An unreadable input (main at the remote, the checkout, the running kernel) is a note on every pass, never a gate: the verdict keeps its per-leg shape, so a checkout ahead of the running kernel converges the restart leg with main unreadable, as before, while a pull needs both; and the running kernel's sha is no longer memoized when a busy boot's git call times out, so one blip cannot disable auto-converge until a restart.

**Tests.** `tests/test_main_drift_notice.py`: the held cool-down says so on every pass and names the turns it spares; a converge that would cut nothing proceeds inside the cool-down and says why; an unknown cut set keeps the hold; an unreadable main is said on every pass; a parked quiet deploy stands the check down on every pass and not when nothing would be cut; `would_cut` over fake sessions (a plain child with a turn in flight is the only cut; a hosted or attaching one is not) and the kernel's reader of it. The existing quiet-park test expects its line on every pass. `tests/test_restart_cuts.py` follows the predicate into `cut_list`. Documented in `docs/reference.md` beside the restart audit's paragraph.

**Also here, on the manager's word (no separate pull request):** the hosts-off belt's reach is stated for test authors. The runner's conftest writes `off` into the one state root it floors and nothing else; a test that mints its own temp state root must write `off` itself unless it means to run a host. Said in the conftest's comment and as a rule under Testing in the repository's CLAUDE.md.

**Round two of the review.** With the pass no longer returning early on an unreadable input, a None running sha (a 2 s rev-parse timeout on a busy box) inside the cool-down raised at a `[:8]` after the latch had taken the target, and the hold branches' own reset never ran, so every later pass returned at the latch and that commit never converged, in silence. The shas print as `?` when unread, the hold branches run under a guard that clears the latch on any exception (the crash itself still reaches the check thread's log), and a git miss stands for 30 s before it is asked again, so the per-request routes (`/version`, `/sw.js`) do not fork git on every call. Tests: a None running sha inside the cool-down is held and said, and the next pass with git answering converges; the spares branch with a None sha converges and says so; a crash in the hold branches leaves no target latched; the re-ask bound.

Tier: fix
