### PR TITLE
A Codex session parked on a model the account refuses takes the model pick that fixes it, instead of queuing the pick behind the stuck send

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -822,11 +822,28 @@ class CodexBackend:
         return out
 
     def busy(self, sid):
+        """A turn is open, or a queued send is about to open one. A queue the worker has PARKED on a permanent
+        request rejection (a model the account refuses: _work breaks to kick.wait() with no timer) is neither:
+        nothing is in flight and nothing runs until an explicit change bumps change_generation. It must read
+        NOT busy, because the kernel takes busy() as its authoritative "turn open" word and parks a model or
+        effort pick behind it (Codex applies a pick at the next turn_start, model_switches_live False), and its
+        drain skips the session for as long as busy() holds — so a parked queue that read busy parked the very
+        pick that would have unparked it, with no way out: Codex has no unqueue, and kill + resume re-arm the
+        same queue with the same model (review, 2026-09-11). The rejection is stale the moment an explicit
+        change moves the generation (send, set_model, set_mode, set_effort, resume all bump it and kick), so
+        busy() flips back to True right then, before the worker wakes and clears the tuple, and a pick pressed
+        after that one parks behind the retry in press order. A new client generation is the worker's own
+        clear (it is kicked for it), a scheduling quantum later."""
         s = self._session(sid)
         if not s:
             return None
         with s.lock:
-            return None if s.dead else bool(s.turn_id or s.queue)
+            if s.dead:
+                return None
+            if s.turn_id:
+                return True
+            parked = s.turn_rejection is not None and s.turn_rejection[0] == s.change_generation
+            return bool(s.queue) and not parked
 
     # ── control ──────────────────────────────────────────────────────────────────────────────────
     def send(self, sid, text):

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -625,6 +625,60 @@ class Lifecycle(unittest.TestCase):
         self.assertEqual(len(fake.attempts), 2, "the replacement request parks if it is rejected too")
         self.assertTrue(be.kill(sid))
 
+    def test_a_queue_parked_on_a_permanent_rejection_reads_not_busy_until_a_change_re_arms_it(self):
+        # The kernel takes busy() as its authoritative "turn open" word: a model or effort pick parks behind
+        # it (a Codex pick applies at the next turn_start), and its drain skips the session for as long as
+        # busy() holds. A queue the worker parked on a permanent rejection read busy — non-empty, yet nothing
+        # in flight and no timer — so the very pick that would have unparked it was parked in turn, with no
+        # way out: this backend has no unqueue, and kill + resume re-arm the same queue with the same model
+        # (review, 2026-09-11). Parked reads not busy; an explicit change re-arms the retry and reads busy
+        # again from that event on, so a pick pressed after it parks behind the retry in press order.
+        class InvalidParamsError(RuntimeError):
+            def __init__(self, message):
+                super().__init__(message)
+                self.code = -32602
+
+        class RejectingClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.attempts = []
+                self.retry_started = threading.Event()   # the accepted retry is held INSIDE turn_start
+                self.release_retry = threading.Event()
+
+            def turn_start(self, tid, input_items, params=None):
+                self.attempts.append((list(input_items), dict(params or {})))
+                if (params or {}).get("model") != "gpt-5-fixed":
+                    raise InvalidParamsError("model is not available")
+                self.retry_started.set()
+                self.release_retry.wait(5)
+                return super().turn_start(tid, input_items, params)
+
+        fake = RejectingClient()
+        be, _, _ = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "keep this durable"))
+        self.assertTrue(until(lambda: be.launch_error(sid) is not None))   # written with the park, under the lock
+        self.assertEqual(len(fake.attempts), 1)
+        self.assertEqual(be.pending_queued(sid), ["keep this durable"], "the send stays visible as queued")
+        self.assertFalse(be.busy(sid), "a queue parked on a permanent rejection is neither in flight nor about to run")
+        # The event is the explicit change, not the worker's wake: with the worker still asleep in kick.wait(),
+        # a setter's generation bump alone re-arms the retry, and busy() says so before the worker clears the
+        # rejection — so a send handed over right then never arms a hold waiting for a turn to open.
+        s = be._session(sid)
+        with s.lock:
+            s.change_generation += 1
+        self.assertTrue(be.busy(sid), "a moved generation is a retry about to run")
+        with s.lock:
+            s.change_generation -= 1
+        self.assertFalse(be.busy(sid))
+        self.assertTrue(be.set_model(sid, "gpt-5-fixed"))
+        self.assertTrue(fake.retry_started.wait(5))
+        self.assertTrue(be.busy(sid), "the retry the pick armed is in flight: busy, so a later pick parks behind it")
+        fake.release_retry.set()
+        self.assertTrue(until(lambda: not be.busy(sid) and not be.pending_queued(sid)))
+        self.assertEqual(fake.attempts[1][1]["model"], "gpt-5-fixed")
+        self.assertTrue(be.kill(sid))
+
     def test_permanent_placeholder_prepare_parks_until_cwd_change(self):
         class InvalidParamsError(RuntimeError):
             code = -32602

--- a/tests/test_model_live_midturn.py
+++ b/tests/test_model_live_midturn.py
@@ -14,8 +14,13 @@ below pin the rule each way for the day one of them can flip. Every other park r
 Synthetic only — no real session data."""
 import os
 import tempfile
+import threading
+import time
 import unittest
 from romp_load import load_source
+from types import SimpleNamespace
+
+from tests.conftest import thread_census, wait_for_census
 
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # isolate: importing the kernel must not touch live state
 os.environ.pop("ROMP_STATE_DIR", None)
@@ -201,6 +206,68 @@ class ModelLiveMidTurn(unittest.TestCase):
         self.assertEqual(be.calls, [], "parked, and the send chained behind it")
         self.assertEqual(km._pending_ops.get(SID),
                          [("model", "claude-fable-5-1"), ("send", "after the pick", "human")])
+
+    def test_the_real_codex_backend_parked_on_a_rejected_model_lets_the_pick_that_fixes_it_through(self):
+        # The wedge this rule met on the REAL backend (review, 2026-09-11): a Codex send the worker parked on a
+        # permanent request rejection (the account refuses the model) kept busy() True with nothing in flight,
+        # the real _working_now took that as an open turn, and this setter parked the pick — the one change
+        # that re-arms the retry — behind a queue that would never move; the drain skipped the sid on the same
+        # word every cycle, and no unqueue, kill or resume led out. A parked queue reads not-working now, so
+        # the pick fires into set_model and the worker retries with the picked model.
+        root = os.path.dirname(HERE)
+        cb = load_source("romp_codex_backend_parked", os.path.join(root, "kernel", "codex_backend.py"))
+
+        class InvalidParamsError(RuntimeError):
+            def __init__(self, message):
+                super().__init__(message)
+                self.code = -32602
+
+        class RejectingClient:
+            """The slice of the app-server client that spawn and a rejected turn_start touch; nothing streams,
+            and the pump parks on next_notification until close."""
+            def __init__(self):
+                self.attempts = []
+                self._closed = threading.Event()
+            def account_read(self, *a, **k):
+                return SimpleNamespace(requires_openai_auth=False, account={"ok": True})
+            def thread_start(self, params=None):
+                return SimpleNamespace(thread=SimpleNamespace(id="T-1"), model="gpt-5-test")
+            def thread_set_name(self, tid, name):
+                pass
+            def turn_start(self, tid, input_items, params=None):
+                self.attempts.append(dict(params or {}))
+                raise InvalidParamsError("model is not available")
+            def next_notification(self):
+                self._closed.wait()
+                raise RuntimeError("client closed")
+            def close(self):
+                self._closed.set()
+
+        def settle(fn, timeout=5.0):
+            deadline = time.monotonic() + timeout
+            while not fn() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            return fn()
+
+        census0 = thread_census()
+        self.addCleanup(lambda: self.assertEqual(wait_for_census(census0, timeout=10), [],
+                                                 "the backend's worker and pump end with the test"))
+        fake = RejectingClient()
+        be = cb.CodexBackend(tempfile.mkdtemp(), client_factory=lambda: fake, log=lambda m: None)
+        sid = be.spawn("web", "/TESTDIR")
+        self.addCleanup(lambda: km._pending_ops.pop(sid, None))
+        self.addCleanup(fake.close)
+        self.addCleanup(be.kill, sid)
+        km._working_now = self._saved[1]                  # the REAL gate: this case is about its answer
+        km.Sessions.backend_for = lambda s: be
+        self.assertTrue(be.send(sid, "keep this durable"))
+        self.assertTrue(settle(lambda: be.launch_error(sid) is not None))   # written with the park, under the lock
+        self.assertEqual(len(fake.attempts), 1)
+        self.assertEqual(be.pending_queued(sid), ["keep this durable"])
+        self.assertFalse(km._set_model_or_park(be, sid, "gpt-5-fixed"), "nothing is in flight: the pick fires now")
+        self.assertIsNone(km._pending_ops.get(sid), "no chip parked behind the stuck queue")
+        self.assertTrue(settle(lambda: len(fake.attempts) == 2))
+        self.assertEqual(fake.attempts[1].get("model"), "gpt-5-fixed", "the worker retried with the picked model")
 
     # ── the neighbour that must NOT change ──
     def test_effort_still_parks_while_working_because_it_is_connect_time(self):


### PR DESCRIPTION
Tier: fix

Defect. CodexBackend.busy() answered bool(s.turn_id or s.queue), so a send queue the worker had PARKED on a
permanent request rejection (the account refuses the model: _work records s.turn_rejection and breaks to
kick.wait() with no timer) read busy forever although nothing was in flight and nothing was going to run.
The kernel takes busy() as its authoritative "turn open" word (_working_now), a Codex model pick lands at
the next turn_start (model_switches_live False), so _set_model_or_park parked the pick as a queued chip and
the drain skipped the session on the same word every cycle: the send waited for a model change, the model
change waited for the send. An effort pick took the same path through _ops_gate. No exit existed in the
product: Codex has no unqueue, interrupt needs a turn id, a follow-up send or a mode change retried the
same refused model and re-parked, and kill + resume re-armed the same queue with the same model (a killed
sid reads unowned, so the pick could not even land while dead). docs/codex.md names the picker as the way
out of exactly this rejection. The backend's own park test called set_model directly and never met the
kernel's gate.

Fix. busy() no longer counts a queue the worker has parked on a rejection: an open turn is busy; a queue is
busy unless s.turn_rejection is set for the CURRENT change_generation. The rejection is stale the moment an
explicit change moves the generation (send, set_model, set_mode, set_effort, resume all bump it and kick),
so busy() flips back to True on that event itself, before the worker wakes and clears the tuple, and a pick
pressed after the fixing one parks behind the retry in press order; a send the drain hands over right then
reads busy at once and never arms a hold waiting for the turn to open. A new client generation is left to
the worker's own clear (it is kicked for it). The chat's queued bubble renders from pending_queued, not
busy(), so the parked send stays visible.

Left out, deliberately. The same wedge exists for a queue stuck in the TRANSIENT retry loop (a rejection
text the classifier does not match, or a repeating failure): the queue is non-empty, a retry IS armed on a
timer, and busy() stays True, so a pick parks until the retry succeeds. Covering that needs a kernel-side
rule (a pick for a backend that applies it at the next turn_start goes through whenever no turn is OPEN,
a turn_inflight hook) and is its own change. The SessionBackend.busy docstring ("in flight or queued") is
left as is; the Codex override carries the exception.

Tests. tests/test_codex_backend.py Lifecycle: the parked queue reads not busy while still pending_queued,
a generation bump alone reads busy again, the pick's retry reads busy while its turn_start is in flight,
and the queue drains on the picked model. tests/test_model_live_midturn.py: the REAL _working_now over the
REAL backend parked on a rejection lets km._set_model_or_park fire (returns False, no chip), and the worker
retries with the picked model; the backend's worker and pump are ended and the thread census pinned.

Red on origin/main (each module run alone):
  tests/test_codex_backend.py:663 AssertionError: True is not false : a queue parked on a permanent
    rejection is neither in flight nor about to run  (1 failed)
  tests/test_model_live_midturn.py:267 AssertionError: True is not false : nothing is in flight: the pick
    fires now  (1 failed)
On the branch: tests/test_codex_backend.py 85 passed, 5 subtests passed; tests/test_model_live_midturn.py
17 passed.

