### PR TITLE
A Codex lane's model pick changes the session's model instead of reaching its agent as a typed prompt

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -30101,7 +30101,20 @@ def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
     # ours to swallow: it stays the CLI's, verbatim, and the user sees the CLI's own error.
     if not value or len(value.split()) != 1:
         return False
-    is_meta = ((head == "/model" and _vouched_model(value)) or (head == "/effort" and value in _EFFORT_VALUES)
+    # A Codex session's model vocabulary is its engine's (gpt-…), which the catalog behind _vouched_model
+    # never carries, so such a pick is vouched by the owning backend's own acceptance rule instead
+    # (CodexBackend.set_model refuses every other value). Before this the lane menu's "/model gpt-…" was no
+    # meta command at all and fell through to _send_or_park, so the Codex agent read the pick as a literal
+    # prompt (idle: sent; working: parked as a command chip that fired alone) while the chat statusline's
+    # setModel op landed the same pick — the two surfaces disagreed on one gesture (review find, 2026-09-11).
+    # The unowned route is vouched for the same shape: a DEAD Codex session still reports its backend (the
+    # lane reads the durable row, _session_backend), so its menu still offers gpt-… while backend_for says
+    # _UNOWNED (CodexBackend.owns is False once dead) — and the refusal arm below is the one place the client
+    # hears that the pick went nowhere; _UNOWNED.send refuses on stderr alone (review find, 2026-09-11).
+    model_pick = head == "/model" and (_vouched_model(value)
+                                        or (value.startswith("gpt") and be is not None
+                                            and (be is _UNOWNED or be is _codex())))
+    is_meta = (model_pick or (head == "/effort" and value in _EFFORT_VALUES)
                or (head == "/fast" and value in ("on", "off")))
     if is_meta and be is _UNOWNED:
         # a session no running backend owns takes no setting: refuse before any stamp (the switching dots
@@ -30114,7 +30127,7 @@ def _route_meta_command(be, sid, text, client=None, floating=False, state=None):
             client["send"](json.dumps({"type": "warn", "text": why}))
         sys.stderr.write("meta command %s for %s refused: no backend owns this session\n" % (head, sid))
         return True
-    if head == "/model" and _vouched_model(value):
+    if model_pick:
         # the model setter has its OWN rule (an open turn fires it live only on a backend that declares
         # model_switches_live — none shipped does yet, so the SDK still parks; #923), so its verdict is
         # read, not inferred from _ops_gate, which would say `queued` for a pick that had already applied

--- a/tests/test_sdk_kernel.py
+++ b/tests/test_sdk_kernel.py
@@ -9,6 +9,7 @@ anything else → the unowned route, whose every op refuses — plus the live-se
 """
 import contextlib
 import io
+import json
 import os
 import unittest
 from romp_load import load_source
@@ -161,6 +162,61 @@ class KernelWiring(unittest.TestCase):
         finally:
             km._codex, km._name_of = saved, saved_name
             km._model_switch_pending.pop("sid-codex", None)       # the pick's switching-dots stamp — don't leak it
+
+    def test_a_codex_model_pick_in_its_own_vocabulary_takes_the_setter_on_both_surfaces(self):
+        # The VALUE is vouched by the owning backend's vocabulary, not only by the kernel's catalog: a gpt-… id
+        # is the one value CodexBackend.set_model accepts, and no Claude table can vouch it. Before this, the
+        # timeline lane's pick (the sendCommand arm, keyed by session NAME) and the same text typed into the
+        # composer were no meta command at all: they fell through to _send_or_park and the Codex agent read the
+        # pick as a literal prompt, while the chat statusline's setModel op landed it (review find, 2026-09-11).
+        # The vouch is the OWNING backend's: the same text on an SDK sid stays the CLI's, verbatim.
+        cx = FakeBackend(); cx._owned = {"sid-codex"}
+        saved, saved_name, saved_sid_of = km._codex, km._name_of, km._sid_of
+        km._codex = lambda: cx
+        km._name_of = lambda sid: "web"
+        km._sid_of = lambda who: "sid-codex" if who == "web" else who   # the lane menu keys its ops by session NAME
+        try:
+            self.assertTrue(self._route({"type": "sendCommand", "name": "web", "cmd": "/model gpt-5-test"}))
+            self.assertTrue(self._route({"type": "sendMessage", "id": "sid-codex", "text": "/model gpt-5-test"}))
+            self.assertEqual([c for c in cx.calls if c[0] == "send"], [], "neither reaches the agent as text")
+            self.assertEqual([c for c in cx.calls if c[0] == "set_model"],
+                             [("set_model", "sid-codex", "gpt-5-test")] * 2, "the lane and the composer both reach the setter")
+            self.assertTrue(self._route({"type": "sendMessage", "id": "sid-sdk", "text": "/model gpt-5-test"}))
+            self.assertEqual(self.be.calls, [("send", "sid-sdk", "/model gpt-5-test")],
+                             "an SDK session's gpt-… is not its vocabulary: the CLI answers it, as before")
+        finally:
+            km._codex, km._name_of, km._sid_of = saved, saved_name, saved_sid_of
+            km._model_switch_pending.pop("sid-codex", None)       # the pick's switching-dots stamp — don't leak it
+
+    def test_a_dead_codex_lanes_model_pick_is_refused_to_the_client_not_on_stderr_alone(self):
+        # A DEAD Codex session still reports backend 'codex' (_session_backend reads the durable registry row), so
+        # its timeline lane still offers the gpt-… choices — and a pick sends "/model gpt-…" for a sid no backend
+        # owns (CodexBackend.owns says False once dead; backend_for answers _UNOWNED). That pick is vouched for the
+        # unowned route too, so it reaches the route's refusal arm like a dead SDK lane's "/model opus": the client
+        # is warned and nothing is stamped. Before this the gpt-… vouch asked only the live Codex backend, the route
+        # answered False, and the sendCommand arm handed the text to _UNOWNED.send, whose refusal is a stderr line
+        # the client never hears (review find, 2026-09-11).
+        cx = FakeBackend(); cx._owned = set()                      # the Codex backend is up; this session of its own is dead
+        saved, saved_name, saved_sid_of = km._codex, km._name_of, km._sid_of
+        km._codex = lambda: cx
+        km._name_of = lambda sid: "web"
+        km._sid_of = lambda who: "sid-unowned" if who == "web" else who
+        heard = []
+        try:
+            self.assertIs(km.Sessions.backend_for("sid-unowned"), km._UNOWNED)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                self.assertTrue(km._drive({"type": "sendCommand", "name": "web", "cmd": "/model gpt-5-test"},
+                                          {"send": heard.append}))
+            warns = [json.loads(m) for m in heard if json.loads(m).get("type") == "warn"]
+            self.assertEqual(len(warns), 1, "the client hears the refusal once: %r" % (heard,))
+            self.assertIn("no running backend owns this session", warns[0]["text"])
+            self.assertNotIn("sid-unowned", km._model_switch_pending, "refused before any switching-dots stamp")
+            self.assertEqual(cx.calls, [], "a dead session's backend is not asked to set or send anything")
+            self.assertEqual(self.be.calls, [], "the SDK backend was untouched")
+        finally:
+            km._codex, km._name_of, km._sid_of = saved, saved_name, saved_sid_of
+            km._model_switch_pending.pop("sid-unowned", None)
 
     def test_ui_op_falls_through_even_for_sdk_sid(self):
         # closeTab/openSession are backend-agnostic UI ops → never intercepted


### PR DESCRIPTION
Tier: fix

Defect: _route_meta_command vouched a "/model X" only through _vouched_model, which knows Claude
vocabulary alone (_MODEL_VALUES, _version_family, the claude-* grammar of _MODEL_ID_RE). A Codex
session's model ids (gpt-…) were never vouched, so the route answered False and _drive's sendCommand
arm (and the composer's sendMessage arm, and POST /send) handed the text to _send_or_park: an idle
Codex session received "/model gpt-…" as a user prompt and answered it; a working one parked it as a
command chip that fired alone at turn end, again as text. The timeline lane's picker sends exactly
this shape ('/model ' + value from CODEX_MODEL_CHOICES, ui/romp-timeline-view.js), so its pick
dimmed for 20 s and reverted while the chat statusline's setModel op landed the same pick.
CodexBackend.set_model was never called (review find, 2026-09-11).

Fix: the route vouches a /model value by the owning backend's vocabulary as well as the kernel's
catalog: on the Codex backend (be is _codex(), the idiom _not_claude_code_reason already uses) a
value starting with "gpt" — CodexBackend.set_model's own acceptance rule — is a meta command and
takes _set_model_or_park like every other pick. The unowned route is vouched for the same shape
(be is _UNOWNED): a dead Codex session still reports backend 'codex' (_session_backend reads the
durable row), so its lane menu still offers gpt-… while backend_for answers _UNOWNED
(CodexBackend.owns is False once dead), and without the vouch that pick fell to _UNOWNED.send,
whose refusal is a stderr line the client never hears — the sendCommand arm ignores the None. Now
it reaches the route's refusal arm like a dead SDK lane's "/model opus": the client is warned,
POST /send answers refused, nothing is stamped (fold of a review find, 2026-09-11). Catalog-vouched
values are unchanged, and the _codex() read only happens for a gpt-… value the catalog could not
vouch. The /effort side needed nothing: the Codex lane's effort choices are all in _EFFORT_VALUES.

Left out, deliberately: a Claude alias typed on a Codex session still routes to
CodexBackend.set_model, which refuses it with no word to the client — a separate defect, and the
existing opus-on-Codex test pins that routing. No vouches_model backend hook: the inline check is
the smallest change, and the comment names the backend rule it mirrors. An SDK session's
"/model gpt-…" stays the CLI's, verbatim, as before (the new test pins that boundary). The unowned
vouch is by shape, not by the dead session's former backend: a dead SDK lane's typed "/model gpt-…"
is refused the same way, which is the right answer for a command no backend can deliver, and the
route stays free of a registry read. The lane's 20 s pending dim and docs/codex.md are untouched.

Red on origin/main (tests/test_sdk_kernel.py -k "test_a_codex_model_pick_in_its_own_vocabulary or
test_a_dead_codex_lanes_model_pick"):
  tests/test_sdk_kernel.py:181: AssertionError: Lists differ:
    [('send', 'sid-codex', '/model gpt-5-test'), ('send', 'sid-codex', '/model gpt-5-test')] != []
    : neither reaches the agent as text
  tests/test_sdk_kernel.py:212: AssertionError: 0 != 1 : the client hears the refusal once: []
  2 failed, 36 deselected. On the branch: tests/test_sdk_kernel.py 38 passed.

