### PR TITLE
A Codex session whose shared name never landed is republished from the registry at the next load; the rename heal carries the registry's colour

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -327,6 +327,7 @@ class CodexBackend:
         self._sessions_lock = threading.RLock()
         self._reg_lock = threading.Lock()
         self._load_registry()
+        self._republish_missing_names()
         # A kernel restart must not strand a durable backend queue until the user happens to send
         # again. Re-arm every live queued session immediately; client retry backoff keeps failures cool.
         for _, s in self._session_items():
@@ -379,6 +380,33 @@ class CodexBackend:
                 s.note = r.get("note", "")
                 s.launch_error = r.get("launchError") if isinstance(r.get("launchError"), dict) else None
                 self._sessions[sid] = s
+
+    def _republish_missing_names(self):
+        """spawn writes the durable registry row, then names/<sid>. A kernel death between the two
+        left a LIVE row with no shared identity file, and nothing rewrote it: _load_registry rebuilt
+        the session from the row, the first turn took _prepare_thread's resume branch (no names
+        write), and only a rename would have healed it. Every surface that reads names/ alone
+        (sender name and colour, cwd, the duplicate-name claim, which sees live names through that
+        file only) was blind to the session, so a same-name create could mint a second live one
+        (2026-09-11). The registry IS the durable source for name, cwd and colour, so a live row
+        whose file is missing is republished from it here, once, at load. A row whose file exists
+        is left alone (the names consumers watch the mtime); a dead row claims no name slot. fg is
+        not in the registry and comes back empty, exactly as a rename's heal leaves it."""
+        d = self.state / "names"
+        for sid, s in self._session_items():
+            with s.lock:
+                dead = s.dead
+            if dead or (d / sid).is_file():
+                continue
+            try:
+                self._write_name(s)
+            except (OSError, UnicodeDecodeError) as e:
+                self.log("codex: names/%s could not be republished at load (%s) — the session runs "
+                         "UNNAMED on shared surfaces until a rename lands; a same-name create may "
+                         "collide meanwhile" % (sid, e))
+            else:
+                self.log("codex: republished names/%s, missing at load for a live registry row "
+                         "(a kernel death between spawn's registry write and its name publish)" % sid)
 
     def _session(self, sid):
         with self._sessions_lock:
@@ -1049,7 +1077,11 @@ class CodexBackend:
                 old = (d / s.sid).read_text().rstrip("\n").split("\t")
             except (OSError, UnicodeDecodeError):
                 old = []
-            bg = bg or (old[2] if len(old) > 2 else "")
+            bg = bg or (old[2] if len(old) > 2 else "") or s.color
+            #    the FILE first: a kernel-side recolour (_set_session_color) writes names/ only
+            #    and never updates s.color. The registry's colour is the fallback for a file with
+            #    none — a rename that healed a MISSING file wrote an empty colour although the
+            #    registry knew it (2026-09-11)
             fg = fg or (old[3] if len(old) > 3 else "")
             tmp = d / (s.sid + ".tmp")
             try:

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -1535,6 +1535,92 @@ class LaunchErrorNames(unittest.TestCase):
             self.assertIn("webby", open(name_file).read())
 
 
+class RegistryNamesHeal(unittest.TestCase):
+    """spawn writes the durable registry row, then names/<sid>. A kernel death between the two left a
+    LIVE row with no shared identity file: the next boot rebuilt the session from the registry but
+    republished nothing, so every names/-derived surface (sender name and colour, cwd, the duplicate-
+    name claim) was blind to it, and the one heal a user could reach, a rename, wrote an empty colour
+    although the registry knew it (2026-09-11). All data synthetic per CLAUDE.md."""
+
+    def _crash_between_row_and_publish(self):
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR", "#336699", "#ffffff")
+        nf = Path(tmp) / "names" / sid
+        nf.unlink()                            # the crash window: the row landed, the publish never ran
+        return be, fake, tmp, sid, nf
+
+    def test_a_live_row_missing_its_names_entry_is_republished_at_load(self):
+        be, fake, tmp, sid, nf = self._crash_between_row_and_publish()
+        logs = []
+        be2 = cb.CodexBackend(tmp, client_factory=lambda: fake, log=logs.append)
+        self.assertTrue(be2.owns(sid), "the row is live in the registry")
+        self.assertTrue(nf.is_file(), "the next boot republishes the identity file from the registry")
+        parts = nf.read_text().rstrip("\n").split("\t")
+        self.assertEqual(parts[:3], ["web", "/TESTDIR", "#336699"],
+                         "name, cwd and colour come from the registry, the durable source")
+        self.assertEqual(sorted(p.name for p in nf.parent.iterdir()), [sid], "no staging file left behind")
+        self.assertTrue(any(sid in m and "missing at load" in m for m in logs),
+                        "the heal is loud: the log names the sid and the state it repaired")
+
+    def test_a_failed_republish_at_load_leaves_the_boot_alive_and_names_the_unnamed_state(self):
+        # the heal's failure branch: the boot must not die over an identity file, and the log must
+        # NAME the state it leaves — a live row with no published name is the duplicate-name hole.
+        # The REAL writer runs under _disk_full, so the publish (os.replace onto names/<sid>) fails
+        # with ENOSPC exactly as it would on a full disk
+        be, fake, tmp, sid, nf = self._crash_between_row_and_publish()
+        logs = []
+        with _disk_full(nf):
+            be2 = cb.CodexBackend(tmp, client_factory=lambda: fake, log=logs.append)
+        self.assertTrue(be2.owns(sid), "the boot survived the failed write and the row is still live")
+        self.assertFalse(nf.exists(), "a failed publish creates nothing")
+        self.assertEqual(sorted(p.name for p in nf.parent.iterdir()), [], "no staging file left behind")
+        said = [m for m in logs if sid in m and "could not be republished at load" in m]
+        self.assertEqual(len(said), 1, logs)
+        self.assertIn("[Errno 28]", said[0], "the log names the errno")
+        self.assertIn("UNNAMED", said[0], "the log names the state the session is left in")
+
+    def test_a_row_whose_names_entry_exists_is_left_untouched_at_load(self):
+        # green on origin/main as well (it wrote nothing at load): the pin that the heal is for the
+        # MISSING file only — the names producers watch the mtime, and a kernel-side recolour lives
+        # in the file alone, so a rewrite from the registry would both flap and revert it
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR", "#336699", "#ffffff")
+        nf = Path(tmp) / "names" / sid
+        nf.write_text("web\t/TESTDIR\t#abcdef\t#000000\n")   # a kernel-side recolour: names/ only
+        before = (nf.read_bytes(), nf.stat().st_mtime_ns)
+        logs = []
+        cb.CodexBackend(tmp, client_factory=lambda: fake, log=logs.append)
+        self.assertEqual((nf.read_bytes(), nf.stat().st_mtime_ns), before,
+                         "byte-identical and no mtime bump: nothing was missing, so nothing was written")
+        self.assertEqual([m for m in logs if "names/" in m], [])
+
+    def test_a_dead_row_missing_its_names_entry_is_not_republished(self):
+        # green on origin/main as well: a dead row claims no name slot — republishing it would
+        # hold the name against the create it no longer owns
+        be, fake, tmp, sid, nf = self._crash_between_row_and_publish()
+        self.assertTrue(be.kill(sid))
+        cb.CodexBackend(tmp, client_factory=lambda: fake)
+        self.assertFalse(nf.exists(), "a dead row claims no name slot")
+
+    def test_the_rename_heal_carries_the_registry_colour(self):
+        be, fake, tmp, sid, nf = self._crash_between_row_and_publish()
+        self.assertTrue(be.rename(sid, "api"))
+        parts = nf.read_text().rstrip("\n").split("\t")
+        self.assertEqual(parts[:3], ["api", "/TESTDIR", "#336699"],
+                         "the healed file carries the colour the registry knows, not an empty one")
+
+    def test_a_recolour_in_the_names_file_outranks_the_registry_colour(self):
+        # green on origin/main as well: the pin for the ORDER of the fallback (the file first) — a
+        # kernel-side recolour (_set_session_color) writes names/ only and never updates the
+        # registry's colour, so a rename must keep the file's, not revert to spawn's
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR", "#336699", "#ffffff")
+        nf = Path(tmp) / "names" / sid
+        nf.write_text("web\t/TESTDIR\t#abcdef\t#000000\n")
+        self.assertTrue(be.rename(sid, "api"))
+        self.assertEqual(nf.read_text(), "api\t/TESTDIR\t#abcdef\t#000000\n")
+
+
 class RaisingRegistryTransactions(unittest.TestCase):
     """The r28 verification, executed on the real backend: every durable-write failure must
     publish NOTHING — no moved names file, no in-memory lifecycle flip, no phantom row."""


### PR DESCRIPTION
Tier: fix

Defect. spawn() persists the registry row (_save_registry(create=True)) and only
afterwards publishes names/<sid> (_publish_spawn_name), with _ensure_norm and a
transcript touch in between. A kernel death in that window leaves a LIVE row with
no names/ entry, and nothing ever rewrote it: _load_registry rebuilt the _Session
with name, cwd and colour from the row but wrote no names/ file; the first turn
took _prepare_thread's resume branch, which never calls _write_name; only a rename
would have healed it. The kernel resolves identity from names/<sid> alone
(_names_parts -> _name_of/_cwd_of/_name_color), and the duplicate-name claim
(_claim_session_name) builds its live set from _name_of, so the row was invisible
to it: a same-name create minted a second live session, postal cards carried no
sender name or colour, _cwd_of fell back to the transcript stamp, and when the
crash landed before the touch there was no transcript either, so the live session
was on no surface at all while live_sessions() still reported it.
_prepare_thread's own log already named this state as the hole ("a same-name
create may collide meanwhile"). And the one heal the user could reach lost the
colour: _write_name fell back to the OLD FILE's bg only, never to the registry's
s.color, so a rename over a missing file wrote an empty colour the registry knew.

Fix, two small pieces in kernel/codex_backend.py:
- _republish_missing_names(), called in __init__ right after _load_registry():
  for every live row whose names/<sid> is not a file, _write_name(s) republishes
  name, cwd and colour from the registry, the durable source. A row whose file
  exists is left byte-identical (the names consumers watch the mtime; a
  kernel-side recolour lives in that file alone), and a dead row claims no name
  slot. Loud either way: one log line for the heal, one naming the unnamed state
  when the write fails (the boot must not die over an identity file).
- _write_name's bg fallback becomes `bg or old[2] or s.color`: the file first,
  because _set_session_color writes names/ only and never updates s.color, then
  the registry's colour. This is what makes both the load-time heal and a rename
  over a missing file carry the colour.

Left out, deliberately:
- fg is not in the registry, so the heal (like a rename's) republishes it empty;
  storing fg durably is a schema change, not this fix.
- The two launch-error spawn branches build their _Session without color=bg and
  publish without bg/fg, so a launch-error row's names file has no colour today;
  a separate pre-existing defect, untouched.
- spawn's order (registry row, then names/) stays: the row must be durable before
  the name is claimed (the v1.3.12 / r29 rationale), so the window is closed by
  healing at load, not by reordering.
- No cross-session dedupe at load: if a second live session was minted under the
  same name during the window, both remain; the heal only makes the first one
  visible and claimable again.

Tests (tests/test_codex_backend.py, class RegistryNamesHeal, real backend over a
fake client; the crash window is modelled by unlinking names/<sid> after spawn,
and the write failure by the module's _disk_full fixture, ENOSPC beneath the REAL
writer's os.replace). Red on origin/main, 3 of 6:
  FAILED RegistryNamesHeal::test_a_live_row_missing_its_names_entry_is_republished_at_load
    AssertionError: False is not true : the next boot republishes the identity file from the registry
  FAILED RegistryNamesHeal::test_the_rename_heal_carries_the_registry_colour
    AssertionError: Lists differ: ['api', '/TESTDIR', ''] != ['api', '/TESTDIR', '#336699']
  FAILED RegistryNamesHeal::test_a_failed_republish_at_load_leaves_the_boot_alive_and_names_the_unnamed_state
    AssertionError: 0 != 1 : []
    (main has no heal, so the boot writes nothing and logs nothing; on the branch
    the failed republish leaves the boot alive, the row live, no file and no
    staging file, and exactly one log line naming the sid, the errno and the
    UNNAMED state — the pin that a narrowed except or a reordered boot cannot
    turn an ENOSPC at load into a dead backend with the module still green)
The other three are green on main as well and pin the shape: an existing file is
left untouched at load (bytes and mtime), a dead row is not republished, and a
recolour in the file outranks the registry's colour on rename. Branch: 90 passed,
5 subtests passed. pin-scan: 6818 assertIn literals checked, 0 lost; no
getsource/def-slice pins on the changed functions.

