### PR TITLE
A Codex transcript that ends mid-line has that line closed before the next record is written, so the record (the next prompt, after a restart) is no longer lost

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -264,6 +264,21 @@ def _tail_state(path):
     return last, set(tail)
 
 
+def _ends_mid_line(path):
+    """True when the file is non-empty and its last byte is not a newline: an earlier write was torn
+    (write(2) returned short under ENOSPC, the process was killed between pages, power was lost) and
+    left a partial line, a record with no line end. The next record must start its own line, or the
+    two join in ONE unparseable line every reader skips."""
+    try:
+        with open(path, "rb") as f:
+            if f.seek(0, os.SEEK_END) == 0:
+                return False
+            f.seek(-1, os.SEEK_END)
+            return f.read(1) != b"\n"
+    except FileNotFoundError:
+        return False
+
+
 class _Session:
     """One Codex session: registry row + runtime state. The worker thread owns the normalizer and
     the file; everything else only reads or enqueues."""
@@ -739,6 +754,15 @@ class CodexBackend:
         workers pushing concurrently AB-BA across their sessions' locks."""
         path = self.transcript_path(s.sid)
         with open(path, "a", encoding="utf-8") as f:
+            if _ends_mid_line(path):
+                # A torn earlier write left a partial line. Written straight after it, this batch's first
+                # record would join it in ONE unparseable line every reader skips (_tail_state, the event
+                # model's readers), so the record vanished while the retire below still took its echo: a
+                # prompt sent after the tear (the first record after a kill and restart) was nowhere in
+                # the UI. Close the fragment first: it stays its own skipped line and the record lands
+                # whole. Logged so the tear is seen, not silently papered over (review find, 2026-09-11).
+                self.log("transcript for %s ended mid-line (a torn write); closing that line" % s.name)
+                f.write("\n")
             for r in recs:
                 f.write(json.dumps(r, ensure_ascii=False) + "\n")
         # A landed user record replaces its optimistic echoes (uuid-independent: match by text, under

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -904,6 +904,42 @@ class Lifecycle(unittest.TestCase):
                              "chain broke across the restart at %s" % r["uuid"])
         self.assertEqual(len({r["uuid"] for r in recs}), len(recs))
 
+    def test_a_torn_trailing_line_does_not_swallow_the_next_record(self):
+        # A torn write (write(2) short under ENOSPC, a kill between pages) leaves the transcript ending
+        # mid-record with no newline. The next batch's first record was written straight after the
+        # fragment: one unparseable line every reader skips, so the record vanished — after a restart
+        # that is the user's next prompt — while _append still retired its echo by text, leaving the
+        # prompt nowhere in the UI. The fix closes the fragment's line before writing.
+        be, fake, tmp = build()
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.send(sid, "first"))
+        self.assertTrue(until(lambda: not be.busy(sid)))
+        p = Path(be.transcript_path(sid))
+        whole = p.read_text()
+        before = [json.loads(l) for l in whole.splitlines()]
+        self.assertEqual([r["type"] for r in before], ["user", "assistant"])
+        fragment = json.dumps({"type": "user", "uuid": "11111111-2222-4333-8444-555555555555",
+                               "parentUuid": before[-1]["uuid"], "timestamp": "2026-06-01T00:00:00.000Z",
+                               "message": {"role": "user", "content": "a record the tear cut short"}})[:60]
+        p.write_text(whole + fragment)          # the tear: a partial record, no line end
+        be2 = cb.CodexBackend(tmp, client_factory=lambda: fake)   # the restart after the kill
+        self.assertTrue(be2.send(sid, "now add a test"))
+        self.assertTrue(until(lambda: not be2.busy(sid) and not be2.pending_queued(sid)))
+        lines = p.read_text().split("\n")
+        parsed = []
+        for l in lines:
+            try:
+                parsed.append(json.loads(l))
+            except ValueError:
+                pass                             # the fragment: skipped, as every reader skips it
+        landed = [r for r in parsed if r["type"] == "user" and "now add a test" in json.dumps(r)]
+        self.assertEqual(len(landed), 1, "the prompt sent after the torn line is not in the transcript")
+        self.assertIn(fragment, lines, "the fragment must stay its own line, not carry the next record")
+        # the chain continues off the last WHOLE record; the fragment is not a link
+        self.assertEqual(landed[0]["parentUuid"], before[-1]["uuid"])
+        # and the echo retire that ran for the landed prompt is now a retire for a record readers can see
+        self.assertTrue(until(lambda: be2.live_atoms(sid) == []))
+
     def test_load_registry_logs_malformed_json_and_falls_back_empty(self):
         tmp = tempfile.mkdtemp()
         root = Path(tmp) / "codex"


### PR DESCRIPTION
Tier: fix

Defect: CodexBackend._append (kernel/codex_backend.py:741-743 on origin/main) opened the
transcript in append mode and wrote each record plus a newline without looking at how the
file ended. A torn earlier write (write(2) returning short under ENOSPC, a kill between
pages, power loss) leaves a partial record with no line end; the next batch's first record
was then written straight after it, so one unparseable line held both the fragment and the
new record. Every reader skips an unparseable line (_tail_state at 245-265, event_model's
_read_jsonl and offset reader, kernel's _transcript_tok_rows), so the record vanished. After
a kill and restart the first record of the next batch is the user's prompt, and _append then
retired that prompt's optimistic echo by text from `recs` (what it was asked to write, not
what a reader can see), so the prompt was nowhere in the chat: not in the transcript, not
as a pending bubble; the reply that followed parented on a uuid no reader had.

Fix: a module helper `_ends_mid_line(path)` reads the file's last byte (rb, seek -1 from the
end; an absent file is a clean start). In _append, when it is not a newline, one "\n" is
written before the batch so the fragment stays its own skipped line and the record lands
whole, and the tear is logged through the backend's log so it is seen rather than silently
papered over. Every caller of _append holds s.norm_lock, so the check and the append see
the same file end; the log callable takes no session lock (the docstring's no-notify rule
concerns push_session, which re-enters live_sessions).

Left out on purpose: no repair of the fragment itself (its bytes are already lost and it is
skipped like any bad line), no change to _tail_state (it already skips the fragment, and
after this change the fragment is still not a link in the chain), no change to the readers.

Test: Lifecycle.test_a_torn_trailing_line_does_not_swallow_the_next_record in
tests/test_codex_backend.py drives a real turn, appends a synthetic cut record with no line
end, restarts the backend over the same state dir (the re-anchor path), sends a prompt, and
asserts the prompt is a parseable user record, the fragment is its own line, the chain
continues off the last whole record, and the echo retire that ran was for a visible record.

Red on origin/main (c0cbd8ff): tests/test_codex_backend.py:936
  AssertionError: 0 != 1 : the prompt sent after the torn line is not in the transcript
  1 failed, 84 passed, 5 subtests passed.
On the branch: 85 passed, 5 subtests passed.

