### PR TITLE
The liveness merge reads a Codex row's float since, so an idle Codex session fades like an SDK one

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17097,8 +17097,20 @@ def _rename_session(sid, name):
 
 
 def _num(x):
+    """A backend row's `since` as an epoch int, else None. A float string parses too, truncated
+    (2026-09-11): the Codex backend stamps since = time.time() and ships it raw (the SDK backend ships
+    str(int(...))), and the SDK backend's dormant read serves the state log's LAST record, whose
+    machineCut and resume-fork lines carry a float t. The digits-only test read every such since as
+    None, so _idle_faded never fired: a Codex session idle past FADED_S stayed a solid "ready" in the
+    chat tab and the timeline lane while every idle SDK tab and lane dimmed. Non-numbers, nan and inf
+    stay None."""
     x = (x or "").strip()
-    return int(x) if x.lstrip("-").isdigit() else None
+    if x.lstrip("-").isdigit():
+        return int(x)
+    try:
+        return int(float(x))
+    except (ValueError, OverflowError):
+        return None
 
 
 # One liveness snapshot per PUSHER CYCLE (the 2026-08-10 CPU fix). Every Sessions.live() read sweeps the

--- a/tests/test_kernel_awaiting_merge.py
+++ b/tests/test_kernel_awaiting_merge.py
@@ -121,5 +121,78 @@ class NudgeFailedRespectsAwaiting(unittest.TestCase):
         self.assertTrue(km._auto_nudge_data()["nudged"][self.gid].get("failed"))
 
 
+class _FakeCodexBackend:
+    def __init__(self, snap):
+        self._snap = snap
+
+    def live_sessions(self):
+        return {SID: dict(self._snap)}
+
+
+class MergeReadsACodexSince(unittest.TestCase):
+    """The Codex backend stamps since = time.time() (a float) and live_sessions ships it raw, where the
+    SDK backend ships str(int(...)). Sessions.live() parsed since with a digits-only test, so every
+    Codex row's since merged as None and _idle_faded never fired: a Codex session idle past FADED_S
+    stayed a solid "ready" in the chat tab and the timeline lane while every idle SDK tab and lane
+    dimmed (2026-09-11). Through the REAL merge with a fake Codex backend, like the class above. The SDK
+    arm has the same latent gap, which is why the parse was widened in the merge and not in the Codex
+    backend: its dormant read serves the state log's LAST record, and the machineCut and resume-fork
+    lines carry a float t by design (a bound that must not move earlier), so a dormant SDK row whose last
+    line is one of those ships a float string too — the third case drives that arm."""
+
+    def test_a_codex_rows_float_since_merges_as_an_epoch_and_fades_past_the_hour(self):
+        snap = {"state": "waiting", "since": 1781100000.5, "model": "gpt-5-test", "effort": "",
+                "mode": "sandboxed", "context": None, "compactPct": None, "backend": "codex",
+                "name": "web", "cwd": "/TESTDIR", "color": None}
+        saved_sdk, saved_codex = km._sdk, km._codex
+        fake = _FakeCodexBackend(snap)
+        km._sdk = lambda: None            # no SDK backend on this box: the merge is the Codex rows alone
+        km._codex = lambda: fake
+        try:
+            out = km.Sessions.live()
+        finally:
+            km._sdk, km._codex = saved_sdk, saved_codex
+            km._LIVE_LAST_ROWS.pop("codex", None)
+        self.assertIn(SID, out)
+        self.assertEqual(out[SID]["backend"], "codex")
+        self.assertEqual(out[SID]["since"], 1781100000,
+                         "the merged map carries the Codex row's since as an epoch — the faded rule reads it here")
+        # ...and the one faded rule fires off exactly that merged value, as it does for an SDK row
+        self.assertFalse(km._idle_faded("ready", out[SID]["since"], 1781100000 + km.FADED_S))
+        self.assertTrue(km._idle_faded("ready", out[SID]["since"], 1781100000 + km.FADED_S + 1),
+                        "a Codex session idle past the hour wears the faded look like an SDK one")
+
+    def test_a_dormant_sdk_rows_float_since_merges_as_an_epoch_too(self):
+        # the dormant SDK read ships str(last_state(...)["t"]); after a machineCut or resume-fork line that
+        # is "1781100000.5", where a state line's is "1781100000" — the SDK arm of the merge parses it too
+        snap = {"state": "waiting", "since": "1781100000.5", "model": "Fable 5", "effort": "",
+                "modelPending": False, "effortPending": False, "retryCount": 0, "retryInfo": None,
+                "ctx": None, "mode": "auto", "subagents": [], "bgTasks": []}
+        saved_sdk, saved_codex = km._sdk, km._codex
+        fake = _FakeSdkBackend(snap)
+        km._sdk = lambda: fake
+        km._codex = lambda: None          # no Codex backend on this box: the merge is the SDK rows alone
+        # a fresh process: no previous SDK rows to go on. This module's state root has no sdk/ directory (no
+        # boot pass ran), and with rows left from an earlier read the merge would judge the registry blind
+        # and serve THOSE rows instead of this fake's (_sdk_records_blind)
+        km._LIVE_LAST_ROWS.pop("sdk", None)
+        try:
+            out = km.Sessions.live()
+        finally:
+            km._sdk, km._codex = saved_sdk, saved_codex
+            km._LIVE_LAST_ROWS.pop("sdk", None)
+        self.assertIn(SID, out)
+        self.assertEqual(out[SID]["backend"], "sdk")
+        self.assertEqual(out[SID]["since"], 1781100000,
+                         "a dormant SDK row whose last state-log line is a machineCut or resume-fork ships a float since")
+
+    def test_the_since_parser_reads_a_float_string_and_stays_none_for_non_numbers(self):
+        self.assertEqual(km._num("1781100000.5"), 1781100000)
+        self.assertEqual(km._num("1781100000"), 1781100000)
+        self.assertEqual(km._num("-3"), -3)
+        for bad in ("", "  ", "soon", "nan", "inf", None):
+            self.assertIsNone(km._num(bad), repr(bad))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tier: fix

Defect: Sessions.live()'s Codex arm (kernel/kernel.py, the `"since": _num(str(st.get("since") or ""))`
row) fed the Codex backend's since through _num, which parsed digit-only strings and answered None for
anything else. CodexBackend stamps since = time.time() (a float: codex_backend.py _Session.__init__ and
the three turn-boundary writes) and live_sessions ships it raw, so str() gave "1781100000.5" and the
merged map carried None for every Codex row. The SDK backend stamps int(time.time()) and ships
str(since), so its rows parsed. Every reader of the merged since therefore saw None for Codex:
_idle_faded (bool(since) False → never faded) at the chat tab, the timeline lane and the chip
signature. A Codex session that ended a turn and sat idle past FADED_S stayed a solid "ready" while
every idle SDK tab and lane dimmed — the one faded rule, broken for the Codex backend only. (The
conserve sweep reads the SDK backend's raw rows directly and never serves Codex, and Codex never
reports "compacting", so those two readers were unaffected.)

Fix: _num parses a float string too, truncated to an epoch int (int(float(x)); ValueError and
OverflowError → None, so non-numbers, nan and inf stay None). _num's only two callers are the two
since arms, and the fix sits there rather than in the Codex backend because the SDK arm has the same
latent gap: its dormant read (_live_row) serves the state log's LAST record, and the machineCut and
resume-fork lines (append_machine_cut, append_resume_fork) carry a float t by design (a float bound
that must not move earlier), so a dormant SDK row whose last line is one of those shipped a float
string as well. Digit strings parse exactly as before.

Left out, deliberately: CodexBackend.live_sessions still ships the raw float (the backend's own clock
stays as it is; the merge is the one place that normalizes rows); no loud error when a since fails to
parse (a wider change than this defect); the SDK arm's code is untouched.

Test (tests/test_kernel_awaiting_merge.py, MergeReadsACodexSince): through the REAL Sessions.live() with
a fake Codex backend whose since is 1781100000.5, the merged since is 1781100000 and _idle_faded is
False at exactly FADED_S and True one second past it; through the same real merge with the module's
fake SDK backend shipping "1781100000.5" (the dormant read's shape after a machineCut or resume-fork
line), the SDK row's merged since is 1781100000 too — the case that pins WHY the parse sits in _num
and not in the Codex backend (a review fold; it clears the previous read's SDK rows first, since this
module's state root has no sdk/ directory and leftover rows would make the read blind and served from
them, _sdk_records_blind); plus _num's contract on a float string, a digit string, a negative, and the
non-numbers. Red on origin/main (3 failed, 3 passed):
  tests/test_kernel_awaiting_merge.py:158  AssertionError: None != 1781100000 : the merged map carries the Codex row's since as an epoch — the faded rule reads it here
  tests/test_kernel_awaiting_merge.py:186  AssertionError: None != 1781100000 : a dormant SDK row whose last state-log line is a machineCut or resume-fork ships a float since
  tests/test_kernel_awaiting_merge.py:190  AssertionError: None != 1781100000
Branch: 6 passed.

