### PR TITLE
A stop on a session with nothing in flight no longer reads Interrupting… for two minutes

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15936,8 +15936,25 @@ def _drive(msg, client):
         else:
             _push_soon()
     elif t == "interrupt":
-        be.interrupt(sid)                                 # Esc/stop AND settle idle (in the backend)
-        _interrupt_clicked[str(sid)] = time.time()        # chip → "interrupting" NOW (event-cleared on settle)
+        # The stamp lands only when the backend TOOK the stop (2026-09-11). A session with no turn in flight
+        # (Ctrl+C in an idle composer, a Stop click reaching the kernel just as the turn ends, a dead tab)
+        # has nothing to interrupt: the Codex backend answers False and sends nothing, and since the merged
+        # liveness row carries no `interrupting` flag, _interrupting could clear the stamp only on a stop
+        # record that never comes or at its 120 s cap — so the chip, the lane and the feed badge read
+        # Interrupting… for two minutes with nothing in flight, and a turn started inside that window read
+        # Interrupting… over Working. Only an explicit False is a refusal (the ABC's bool; the SDK's False
+        # is an unknown sid): a backend with no verdict keeps the optimistic chip.
+        if be.interrupt(sid) is not False:                # Esc/stop AND settle idle (in the backend)
+            _interrupt_clicked[str(sid)] = time.time()    # chip → "interrupting" NOW (event-cleared on settle)
+        elif be.busy(sid):
+            # A refusal WITH work in flight is a stop that did NOT land, not a stop with nothing to stop
+            # (review find, 2026-09-11): the Codex backend also answers False while a turn's start is still
+            # being acknowledged (queued, no turn id yet), when its app-server client is gone, and when the
+            # interrupt RPC raised (kernel log only). Read as an idle press those left the chip on Working
+            # and the click with no visible effect at all. busy() is the ABC's authoritative in-flight
+            # signal: True in exactly those cases, None or False when there was nothing to stop, so an idle
+            # Ctrl+C stays quiet. The sendMessage arm's warn idiom (fail loudly).
+            client["send"](json.dumps({"type": "warn", "text": "the stop was not delivered: the session is still working"}))
         err = _suppress_session_retry(sid)                # interrupting a thread STOPS romp's auto-retry into it until a
                                                           # successful turn re-arms (the user 2026-07-06) — the interrupt
                                                           # already aborted any in-flight CLI retry; this stops the relapse
@@ -52459,8 +52476,15 @@ class Handler(BaseHTTPRequestHandler):
                     return self._send(200, json.dumps(res), "application/json")
                 be = Sessions.backend_for(sid)
                 if u.path == "/interrupt":
-                    be.interrupt(sid)                           # Esc/stop AND settle idle (in the backend)
-                    _interrupt_clicked[str(sid)] = time.time()  # chip → "interrupting" NOW, same as the WS op
+                    # the WS op's gate: a stop the backend refused (nothing in flight) paints nothing
+                    if be.interrupt(sid) is not False:          # Esc/stop AND settle idle (in the backend)
+                        _interrupt_clicked[str(sid)] = time.time()  # chip → "interrupting" NOW, same as the WS op
+                    elif be.busy(sid):
+                        # …and a refusal WITH work in flight is a stop that did not land (the WS arm's toast):
+                        # said, never answered ok, so `romp interrupt` prints this and exits non-zero — the
+                        # /send route's refusal shape (review find, 2026-09-11)
+                        return self._send(200, json.dumps({"ok": False, "error":
+                            "the stop was not delivered: %s is still working" % who}), "application/json")
                 elif isinstance(b, dict) and b.get("when") == "idle":
                     # SELF-CLOSE deferral (the user 2026-08-15): record the wish; the pusher's sweep
                     # kills at the turn's settle, so a session ending itself finishes its goodbye first

--- a/tests/test_kernel_headless_ops.py
+++ b/tests/test_kernel_headless_ops.py
@@ -118,6 +118,35 @@ class HeadlessRoutes(unittest.TestCase):
         self.assertIn(str(sid), km._interrupt_clicked,
                       "the chat chip flips to 'interrupting' exactly like the WS op")
 
+    def test_interrupt_route_paints_nothing_when_the_backend_refuses(self):
+        # the WS op's gate, mirrored (2026-09-11): a stop the backend refused — a Codex session with no
+        # turn in flight, a dead tab — interrupted nothing, so the chip must not read Interrupting… for
+        # the 120 s cap, the only thing that could clear a stamp whose stop record never comes
+        fake = mock.Mock()
+        fake.interrupt.return_value = False
+        fake.busy.return_value = None                     # a dead tab: no backend, no in-flight signal (a bare Mock is truthy)
+        with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)):
+            code, resp = self._post("/interrupt", {"name": "web"})
+        self.assertEqual(code, 200)
+        fake.interrupt.assert_called_once()
+        sid = fake.interrupt.call_args[0][0]
+        self.assertNotIn(str(sid), km._interrupt_clicked, "a refused stop leaves no optimistic stamp")
+
+    def test_interrupt_route_says_when_the_stop_did_not_land(self):
+        # a refusal WITH work in flight (the Codex backend's False while a turn's start is still being
+        # acknowledged, with its client gone, or after a failed interrupt RPC) is a stop that did not land:
+        # the /send route's refusal shape, so `romp interrupt` exits non-zero instead of printing ok
+        fake = mock.Mock()
+        fake.interrupt.return_value = False
+        fake.busy.return_value = True
+        with mock.patch.object(km.Sessions, "backend_for", staticmethod(lambda sid: fake)):
+            code, resp = self._post("/interrupt", {"name": "web"})
+        self.assertEqual(code, 200)
+        self.assertIs(resp.get("ok"), False, "a dropped stop is never answered ok")
+        self.assertEqual(resp.get("error"), "the stop was not delivered: web is still working")
+        sid = fake.interrupt.call_args[0][0]
+        self.assertNotIn(str(sid), km._interrupt_clicked, "no stop landed, so nothing reads Interrupting…")
+
     def test_end_route_kills_and_announces_close(self):
         fake = mock.Mock()
         sent = []

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -7,6 +7,7 @@ Isolated from test_kernel.py (a peer is churning it). Synthetic fixtures only.""
 import json
 import os
 import tempfile
+import types
 import unittest
 from datetime import datetime, timezone
 from romp_load import load_source
@@ -648,3 +649,83 @@ class KernelDisplayParseReadsStates(unittest.TestCase):
                         "the states idle transition became an idle atom in the display parse")
         self.assertFalse(km._session_working(ps["turns"]),
                          "a states-only idle transition clears 'working' on the display parse (cache busted)")
+
+
+class RefusedInterruptPaintsNothing(unittest.TestCase):
+    """The optimistic stamp lands only when the backend TOOK the stop (2026-09-11). Ctrl+C in an idle Codex
+    session's composer, or a Stop click reaching the kernel just as its turn ended, asked the Codex backend to
+    interrupt a session with no turn in flight: it answered False and sent nothing, yet the WS op stamped
+    _interrupt_clicked anyway. The merged liveness row carries no `interrupting` flag (the SDK merge copies an
+    explicit key list), so _interrupting took the transcript path and could clear the stamp only on a stop
+    record an idle session never writes, or at the 120 s cap: the chat chip, the timeline lane and the feed
+    badge read Interrupting… for two minutes with nothing in flight, and a turn started inside that window
+    read Interrupting… over Working. And a refusal WITH work in flight (the Codex backend answers False too
+    while a turn's start is still being acknowledged, when its app-server client is gone, or when the
+    interrupt RPC raised) is a stop that did not land: gated on the stamp alone it read as an idle press and
+    the click had no visible effect, so that case toasts (review find, same day). Drives the real _drive with
+    the backend as the one stubbed seam; busy() is the ABC's in-flight signal the arm reads on a refusal."""
+
+    def setUp(self):
+        self._saved = (km._kernel_knows, km.Sessions.__dict__["backend_for"],
+                       km._suppress_session_retry, km._mark_views_dirty)
+        km._kernel_knows = lambda sid: True                 # a session this kernel has; _drive refuses a foreign one
+        self.suppressed = []                                # the ledger write is test_session_retry_suppress's subject;
+        km._suppress_session_retry = lambda sid: (self.suppressed.append(sid), None)[1]   # here only THAT it ran
+        km._mark_views_dirty = lambda *a, **k: None         # no pusher in the test
+        km._interrupt_clicked.clear()
+        self.warned = []
+        self.client = {"send": lambda s: self.warned.append(json.loads(s))}
+
+    def tearDown(self):
+        (km._kernel_knows, km.Sessions.backend_for, km._suppress_session_retry, km._mark_views_dirty) = self._saved
+        km._interrupt_clicked.clear()
+
+    def _backend(self, verdict, busy=None):
+        asked = []
+        be = types.SimpleNamespace(interrupt=lambda sid: (asked.append(sid), verdict)[1], busy=lambda sid: busy)
+        km.Sessions.backend_for = staticmethod(lambda sid: be)
+        return asked
+
+    def test_a_refused_stop_leaves_no_interrupting_stamp(self):
+        asked = self._backend(False, busy=False)            # Codex with no turn in flight and nothing queued
+        self.assertTrue(km._drive({"type": "interrupt", "id": SID}, self.client), "the op is consumed")
+        self.assertEqual(asked, [SID], "the backend was asked — the gate reads its answer, it does not pre-empt it")
+        self.assertNotIn(SID, km._interrupt_clicked,
+                         "nothing was interrupted, so nothing reads Interrupting… — the chip stays honest")
+        self.assertEqual(self.warned, [], "nothing to stop is not a failure: an idle Ctrl+C stays quiet")
+        self.assertEqual(self.suppressed, [SID],
+                         "a refused stop is still the person asking romp to stop retrying into this thread")
+
+    def test_a_refused_stop_on_a_dead_tab_stays_quiet_too(self):
+        self._backend(False, busy=None)                     # the unowned route: no backend, no in-flight signal
+        self.assertTrue(km._drive({"type": "interrupt", "id": SID}, self.client))
+        self.assertNotIn(SID, km._interrupt_clicked)
+        self.assertEqual(self.warned, [], "no signal of work in flight → nothing to report")
+
+    def test_a_refused_stop_with_work_in_flight_says_so(self):
+        # the Codex backend's False with a turn still in flight: its start not yet acknowledged, its
+        # app-server client gone, or the interrupt RPC raised — the stop did NOT land
+        asked = self._backend(False, busy=True)
+        self.assertTrue(km._drive({"type": "interrupt", "id": SID}, self.client))
+        self.assertEqual(asked, [SID])
+        self.assertNotIn(SID, km._interrupt_clicked, "no stop landed, so nothing reads Interrupting…")
+        self.assertEqual([w["type"] for w in self.warned], ["warn"],
+                         "…and the person who clicked hears that their stop was dropped, once")
+        self.assertEqual(self.warned[0]["text"], "the stop was not delivered: the session is still working")
+        self.assertEqual(self.suppressed, [SID], "the press still stops romp's auto-retry into the thread")
+
+    def test_a_backend_with_no_verdict_keeps_the_optimistic_stamp(self):
+        # only an explicit False is a refusal (the ABC's bool): a double, or a backend, that answers None
+        # keeps the stamp — a truthiness gate would drop it and read every such stop as refused
+        asked = self._backend(None)
+        self.assertTrue(km._drive({"type": "interrupt", "id": SID}, self.client))
+        self.assertEqual(asked, [SID])
+        self.assertIn(SID, km._interrupt_clicked, "no verdict is not a refusal: the chip flips NOW, as before")
+        self.assertEqual(self.warned, [])
+
+    def test_an_accepted_stop_still_stamps_at_once(self):
+        asked = self._backend(True)                         # the SDK: False only for an unknown sid
+        self.assertTrue(km._drive({"type": "interrupt", "id": SID}, self.client))
+        self.assertEqual(asked, [SID])
+        self.assertIn(SID, km._interrupt_clicked, "a stop the backend took flips the chip NOW, as before")
+        self.assertEqual(self.warned, [])


### PR DESCRIPTION
Tier: fix

Defect: Ctrl+C in the composer of an idle Codex session (ui/webview/render.ts:17688-17691 posts the
interrupt with no working check), a Stop click reaching the kernel just after its turn ended, or a
POST /interrupt on such a session, called be.interrupt(sid) and stamped _interrupt_clicked[sid]
unconditionally (kernel/kernel.py:15939-15940; the route at 52462-52463 the same). CodexBackend.interrupt
answers False and sends nothing when the session has no turn_id (kernel/codex_backend.py:877-878), as
does the unowned route for a dead tab (_UnownedBackend.interrupt). _interrupting (kernel.py:28520-28542)
clears the stamp early only through a row-level `interrupting` flag, which the merged liveness row never
carries (kernel.py:43065-43067 says so: the SDK merge copies an explicit key list, and the Codex row at
17003-17007 has no such field), so it took the transcript path and waited for a '[Request interrupted by
user]' record an idle session never writes, or the 120 s cap. _session_chip (28755) ranks interrupting
above working, so the chat chip, the timeline lane and the feed badge read Interrupting… for two minutes
with nothing in flight, and a turn started inside that window read Interrupting… over Working.

Fix: the WS arm and the POST route stamp only when be.interrupt(sid) is not False, so a refused stop
paints nothing and the chip stays at the session's honest state. Only an explicit False is a refusal
(the ABC's bool contract; the SDK's False is an unknown sid), so a backend with no verdict keeps the
optimistic chip and every existing test double keeps its stamp. The pinned literal
`_interrupt_clicked[str(sid)] = time.time()` (tests/test_kernel_interrupt.py) stays on a line.
_suppress_session_retry still runs on every press: "suppressed since your most recent interrupt" is its
invariant, and a refused stop is still the person asking romp to stop retrying into that thread.

Review fold (2026-09-11): a False is not always "nothing to stop". CodexBackend.interrupt also answers
False with work the person wants stopped when the stop did not land: a turn whose turn_start RPC is
still in flight (s.queue non-empty, s.turn_id set only after the ack, codex_backend.py:1459-1467), a
session whose app-server client is gone (`c is None`), and a turn_interrupt that raised (kernel log
only). Gated on the stamp alone those read as an idle press: the chip stayed on Working and the click had
no visible effect at all, the silent degrade the first cut traded the wrong chip for. be.busy(sid) is the
ABC's authoritative in-flight signal, True in exactly those cases (Codex: bool(s.turn_id or s.queue),
codex_backend.py:824-829) and None or False when there was nothing to stop, so on a refusal the WS arm
now toasts "the stop was not delivered: the session is still working" when busy is truthy (the
sendMessage arm's warn idiom) and stays quiet otherwise (an idle Ctrl+C, a dead tab), and the route
answers {"ok": false, "error": ...} in the same case, the /send route's refusal shape, so
`romp interrupt` prints it and exits non-zero instead of ok. The tests now also pin the two design claims
above: a None verdict keeps the stamp (a truthiness gate would drop it) and the suppress call runs on a
refused press (folding it under the gate would drop it).

Leave-outs: the route's {"ok": true} for a refused stop with nothing to stop is unchanged (a second
contract, what a stop that found nothing should say; the chip tells the truth on its own). No Codex
`interrupting` flag carried through Sessions.live(): the merged row carries neither backend's flag
today, a wider change than this stamp. The SDK's own idle interrupt (True with nothing to stop, the same
transcript-path pin) is untouched: the SDK dispatched a real control request, and this fix is keyed on
the backend's verdict. The toast does not say WHICH of the three dropped-stop cases it was: the backend's
bool carries no reason, and plumbing one is its own change.

Red on main (both test files copied into a scratch worktree at c0cbd8ff):
  tests/test_kernel_interrupt.py (3 failed, 51 passed), RefusedInterruptPaintsNothing::
    test_a_refused_stop_leaves_no_interrupting_stamp
      AssertionError: '11111111-2222-3333-4444-555555555555' unexpectedly found in {...}: nothing was
      interrupted, so nothing reads Interrupting… — the chip stays honest
    test_a_refused_stop_on_a_dead_tab_stays_quiet_too
      AssertionError: '11111111-2222-3333-4444-555555555555' unexpectedly found in {...}
    test_a_refused_stop_with_work_in_flight_says_so
      AssertionError: '11111111-2222-3333-4444-555555555555' unexpectedly found in {...}: no stop landed,
      so nothing reads Interrupting…
  tests/test_kernel_headless_ops.py (2 failed, 18 passed), HeadlessRoutes::
    test_interrupt_route_paints_nothing_when_the_backend_refuses
      AssertionError: 'web' unexpectedly found in {...}: a refused stop leaves no optimistic stamp
    test_interrupt_route_says_when_the_stop_did_not_land
      AssertionError: True is not False : a dropped stop is never answered ok
  test_a_backend_with_no_verdict_keeps_the_optimistic_stamp and test_an_accepted_stop_still_stamps_at_once
  are green on main by design: they pin the gate's shape against a wrong follow-up, not the defect.
On the branch: test_kernel_interrupt.py 54 passed; test_kernel_headless_ops.py 20 passed;
test_session_retry_suppress.py 24 passed (its source pins read the interrupt arm's block).

