### PR TITLE
A Codex app-server that starts but never answers is ended after 30s and the reason shown, instead of holding every Codex creation and the models list forever

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -102,6 +102,7 @@ SEED_TAIL = 200   # records whose uuids seed the normalizer's dedup on re-attach
 CLIENT_RETRY_MIN = 0.25
 CLIENT_RETRY_MAX = 5.0
 WORKER_JOIN_TIMEOUT = 2.0
+HANDSHAKE_TIMEOUT_S = 30.0   # a new app-server answers its start-up requests within this, or the child is ended
 
 _PERMANENT_RPC_ERRORS = {"ParseError", "InvalidRequestError", "MethodNotFoundError",
                          "InvalidParamsError"}
@@ -140,6 +141,14 @@ class _PermanentRequestRejection(RuntimeError):
         self.operation = operation
         self.change_generation = change_generation
         self.client_generation = client_generation
+
+
+class _HandshakeTimeout(RuntimeError):
+    """The handshake clock ran out and the child was ended (_handshake). Its own class because its retry floor
+    differs: re-probing a child that never answers costs the whole clock again, under _client_lock, so the
+    record does not retry it before HANDSHAKE_TIMEOUT_S. The ordinary backoff (cap CLIENT_RETRY_MAX = 5s) would
+    have re-run the probe almost continuously while the fault lasted, holding the creation door and the
+    models list for the clock out of every clock-plus-cap."""
 
 
 def _execution_permissions(cwd, thread_start=False):
@@ -567,16 +576,19 @@ class CodexBackend:
             try:
                 if self._client_factory:
                     candidate = self._client_factory()
+                    self._handshake(candidate, lambda: None)
                 else:
                     if not ensure_codex_sdk(self.state):
                         raise RuntimeError(SETUP_HINT)
                     from openai_codex.client import CodexClient, CodexConfig
                     cfg = _codex_config(CodexConfig, self.codex_bin, self.state)
                     candidate = CodexClient(config=cfg, approval_handler=self._handle_approval)
-                    candidate.start()
-                    candidate.initialize()
+
+                    def bring_up():
+                        candidate.start()
+                        candidate.initialize()
+                    self._handshake(candidate, bring_up)
                     self.log("app-server runtime: %s" % (self.codex_bin or "ROMP-managed %s" % getattr(_runtime, "VERSION", "")))
-                self._check_auth(candidate)
                 self._client = candidate
                 self._client_err = None
                 self._client_retry_at = 0.0
@@ -593,12 +605,70 @@ class CodexBackend:
                 self._record_client_failure_locked(e, candidate)
                 return None
 
+    def _handshake(self, candidate, bring_up):
+        """Run a new client's start-up requests (`bring_up`: start + initialize on a real client; nothing for
+        an injected one) and the login check under ONE clock, ending the child when it runs out.
+
+        The pinned SDK's request wait has no timeout: the one event that unblocks it is the reader thread
+        failing every waiter, which happens when the child's stdout ends. So a codex that starts, holds stdout
+        open and never writes its first frame (a start-up stalled on a hung ~/.codex or state mount, a stub
+        that sleeps) parked _get_client in that wait with _client_lock HELD, forever: every Codex creation,
+        resume, send and turn worker queued behind it, /models blocked under _catalog_lock, the tab whose
+        receive loop made the call read no more ops, and nothing was logged or recorded (2026-09-11). The
+        child offers no event of its own, so the clock stands in for one; its expiry is candidate.close(),
+        the SDK's own unblocking event (child terminated, reader sees EOF, the wait raises), and the failure
+        is recorded as the plain reason rather than the transport's text. The gate makes the two outcomes
+        exclusive: a clock that fires after the handshake settled must not close an installed client, and a
+        handshake that settled after the clock fired must not install a closed one (_check_auth swallows the
+        account_read error the close provokes, so the flag is read after it, not only on the raise path).
+        The expiry is its own class, _HandshakeTimeout, so _record_client_failure_locked floors the retry at
+        the clock: the next probe costs the whole clock again with the lock held, and the ordinary backoff (cap
+        5s) would have re-run it almost continuously while the fault lasted; inside the floor every caller gets
+        the recorded reason at once."""
+        gate = threading.Lock()
+        state = {"expired": False, "settled": False}
+
+        def expire():
+            with gate:
+                if state["settled"]:
+                    return
+                state["expired"] = True
+            try:
+                candidate.close()
+            except Exception:
+                pass
+
+        def settle():
+            timer.cancel()
+            with gate:
+                state["settled"] = True
+                return state["expired"]
+
+        timer = threading.Timer(HANDSHAKE_TIMEOUT_S, expire)
+        timer.daemon = True
+        timer.name = "codex-handshake-clock"
+        timer.start()
+        text = ("The Codex app-server (%s) did not answer within %.0fs of starting, so it was ended; "
+                "check the codex binary, then try again"
+                % (self.codex_bin or "managed runtime", HANDSHAKE_TIMEOUT_S))
+        try:
+            bring_up()
+            self._check_auth(candidate)
+        except Exception as e:
+            if settle():
+                raise _HandshakeTimeout(text) from e
+            raise
+        if settle():
+            raise _HandshakeTimeout(text)
+
     def _record_client_failure_locked(self, error, candidate=None):
         """Record one failed client generation. Caller owns _client_lock."""
         self._client_err = str(error) or error.__class__.__name__
         self._client_failures += 1
         delay = min(CLIENT_RETRY_MAX,
                     CLIENT_RETRY_MIN * (2 ** min(self._client_failures - 1, 8)))
+        if isinstance(error, _HandshakeTimeout):
+            delay = max(delay, HANDSHAKE_TIMEOUT_S)   # a re-probe costs the whole clock, lock held: not before then
         self._client_retry_at = time.monotonic() + delay
         if candidate is None:
             candidate = self._client

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import os
 import queue
+import re
 import subprocess
 import sys
 import tempfile
@@ -1145,6 +1146,102 @@ for i in range(20):
         self.assertIn("codex login", err["text"])
         self.assertFalse(err["limit"])
         self.assertFalse(be.available())
+
+    def test_a_handshake_that_never_answers_is_ended_and_named(self):
+        # A codex that starts, holds stdout open and never writes its first frame (a start-up stalled on a hung
+        # mount, a stub that sleeps) left _get_client in the SDK's untimed wait with _client_lock HELD: every
+        # Codex creation, resume, send and /models read queued behind it, the tab whose receive loop made the
+        # call read no more ops, and nothing was logged or recorded (2026-09-11). The handshake now runs under
+        # a clock whose expiry ends the child, the one event the SDK's wait answers to, and names the reason.
+        # The reason then stands for at least the clock: a re-probe costs the whole clock again, lock held, so
+        # the ordinary backoff (cap 5s) would have re-run it almost continuously while the fault lasted.
+        class SilentClient(FakeClient):
+            """Every account_read parks until the next close(): the shape of a live child that never answers,
+            however often it is probed. (The injected path has no start/initialize; account_read is the
+            handshake call both paths share.)"""
+
+            def __init__(self):
+                super().__init__()
+                self.gate = threading.Event()
+
+            def account_read(self, *a, **k):
+                self._rec("account_read")
+                self.gate = gate = threading.Event()
+                gate.wait()
+                raise RuntimeError("Codex process closed stdout.")   # what the SDK's wait raises after close()
+
+            def close(self):
+                super().close()
+                self.gate.set()
+        saved = getattr(cb, "HANDSHAKE_TIMEOUT_S", None)
+        cb.HANDSHAKE_TIMEOUT_S = 0.3                     # the clock under test
+        self.addCleanup(setattr, cb, "HANDSHAKE_TIMEOUT_S", saved)
+        fake = SilentClient()
+        self.addCleanup(lambda: fake.gate.set())         # without the clock the probe parks forever; let it out
+        logs = []
+        be = cb.CodexBackend(tempfile.mkdtemp(), client_factory=lambda: fake, log=logs.append)
+        out = []
+        probe = threading.Thread(target=lambda: out.append(be.available()), name="probe", daemon=True)
+        probe.start()
+        probe.join(5)
+        self.assertFalse(probe.is_alive(), "available() must return once the handshake clock runs out")
+        self.assertEqual(out, [False])
+        self.assertTrue(fake.called("close"), "the clock ends the child; that is what unblocks the SDK's wait")
+        self.assertIn("did not answer", be._client_err or "")
+        recorded = [m for m in logs if "did not answer" in m]
+        self.assertTrue(recorded, logs)
+        delay = float(re.search(r"retry in ([\d.]+)s", recorded[0]).group(1))
+        self.assertGreaterEqual(delay, cb.HANDSHAKE_TIMEOUT_S,
+                                "a probe that costs the whole clock is not re-run before the clock: %s" % recorded[0])
+        sid = be.spawn("web", "/TESTDIR")                 # the session exists, visibly broken, with the reason
+        self.assertIn("did not answer", be.launch_error(sid)["text"])
+
+    def test_a_handshake_ended_by_its_clock_names_the_reason_not_the_transport(self):
+        # On a real client the parked call is initialize() inside bring_up: the clock's close() ends the child,
+        # the SDK's reader fails its waiter with the transport's text ("Codex process closed stdout. stderr_tail=
+        # ...") and that RAISES out of the handshake, the branch the injected path above never reaches (its
+        # account_read error is swallowed by the login check). The user reads the plain reason, not the
+        # transport's text and a stderr tail; the transport error stays attached as the cause.
+        class EndedClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.ended = threading.Event()
+
+            def close(self):
+                super().close()
+                self.ended.set()
+        fake = EndedClient()
+        transport = RuntimeError("Codex process closed stdout. stderr_tail=")   # the SDK's TransportClosedError shape
+
+        def bring_up():                                   # start + initialize on a real client: parks until the close
+            fake.ended.wait()
+            raise transport
+        saved = getattr(cb, "HANDSHAKE_TIMEOUT_S", None)
+        cb.HANDSHAKE_TIMEOUT_S = 0.3
+        self.addCleanup(setattr, cb, "HANDSHAKE_TIMEOUT_S", saved)
+        self.addCleanup(fake.ended.set)
+        be, _, _ = build(factory=lambda: fake)
+        with self.assertRaises(RuntimeError) as cm:
+            be._handshake(fake, bring_up)
+        self.assertIsInstance(cm.exception, cb._HandshakeTimeout)   # the class the record floors the retry on
+        self.assertIn("did not answer", str(cm.exception))
+        self.assertNotIn("stderr_tail", str(cm.exception))
+        self.assertIs(cm.exception.__cause__, transport)
+        self.assertTrue(fake.called("close"), "the clock ended the child")
+        self.assertEqual(fake.called("account_read"), [], "the login check never ran: the raise came first")
+
+    def test_a_handshake_that_settles_first_dismisses_its_clock(self):
+        # The other side of the gate: a good handshake cancels its clock, so no clock fires after it settled to
+        # close the installed client. The clock's thread ending is the event; a live one could still fire.
+        saved = getattr(cb, "HANDSHAKE_TIMEOUT_S", None)
+        cb.HANDSHAKE_TIMEOUT_S = 0.2
+        self.addCleanup(setattr, cb, "HANDSHAKE_TIMEOUT_S", saved)
+        be, fake, _ = build()
+        self.assertTrue(be.available())
+        self.assertTrue(until(lambda: not any(t.name == "codex-handshake-clock" for t in threading.enumerate())),
+                        "a settled handshake dismisses its clock")
+        self.assertEqual(fake.called("close"), [], "a clock dismissed by the handshake never ends the client")
+        self.assertIs(be._client, fake)
 
     def test_claude_only_knobs_refuse(self):
         be, _, _ = build()


### PR DESCRIPTION
Tier: fix

Defect. _get_client (kernel/codex_backend.py) held _client_lock while it ran
candidate.start(), candidate.initialize() and _check_auth (account_read). In the
pinned SDK (openai-codex 0.144.4, client.py) both requests go through _request_raw,
whose waiter.get() has no timeout; the one thing that unblocks a waiter is the reader
thread failing every waiter, which happens when the child's stdout ends (or a
malformed frame arrives). So a codex that starts, holds stdout open and never writes
its first frame (a start-up stalled on a hung ~/.codex or state mount, a stub that
sleeps) parked _get_client forever with the lock held: nothing recorded _client_err,
nothing logged, _codex_ready could not return, and every later caller queued on the
lock: POST /new and the resume door on handler threads, the WS createSession arm
inside the connection's receive loop (so that tab read no more ops), /models via
model_catalog under _catalog_lock, and every session worker in _run_turn_in_mode.
The user saw a dashboard that never answered the New-session click and no text
anywhere. The judge path bounds the same failure class with a perl alarm; the
backend had no bound.

Fix. The handshake (start + initialize on a real client, nothing for an injected one,
then the login check) runs inside _handshake under one clock, HANDSHAKE_TIMEOUT_S =
30s. The child offers no event of its own, so the clock stands in for one; its expiry
is candidate.close(), the SDK's own unblocking event (child terminated, reader sees
EOF, the wait raises). A small gate makes the two outcomes exclusive: a clock that
fires after the handshake settled must not close an installed client, and a handshake
that settled after the clock fired must not install a closed one. Because _check_auth
swallows the account_read error the close provokes, the expired flag is read after it
as well as on the raise path. On expiry the failure is recorded through the existing
_record_client_failure_locked as a plain reason ("The Codex app-server (<bin>) did
not answer within 30s of starting, so it was ended; check the codex binary, then try
again") instead of the transport's text, so launch_error, /models and the log all
carry it. The expiry is its own failure class, _HandshakeTimeout, and the record floors
its retry at the clock (review fold): the ordinary backoff caps at 5s, so from the
sixth failure on it would have re-run a 30s probe every 5s with the lock held, and
every caller arriving after the deadline (the /models read under _catalog_lock, POST
/new, the WS createSession arm, every session worker's send) would have waited the
clock again, about 30s of every 35s while the fault lasted. Inside the floor they all
get the recorded reason at once, and the next probe runs at most once per clock. The
ordinary constants are unchanged for the failures they were tuned for, which fail fast.

Leave-outs. The retry-deadline check still runs under _client_lock, so callers that
arrive during an in-flight handshake wait for it (now at most 30s) rather than
getting a fast None; changing that widens available()'s contract for concurrent
callers. A Popen that itself never returns, or a child SIGKILL cannot end, is outside
the SDK's unblocking mechanism and is not bounded here. The "app-server runtime" log
line now follows the login check instead of preceding it; nothing pins the order. A
session worker parked on the recorded failure waits up to the floor; its kick still
wakes it for a new send, and _get_client answers with the reason until the deadline.

Tests. tests/test_codex_backend.py, Lifecycle:
- test_a_handshake_that_never_answers_is_ended_and_named: a FakeClient whose every
  account_read parks until the next close() (the injected path never calls
  start/initialize; account_read is the handshake call both paths share), available()
  run on a probe thread with the clock at 0.3s; asserts the return, the close, the
  recorded reason, the recorded retry delay >= the clock (read from the log line), and
  the reason on a spawned session's launch_error.
- test_a_handshake_ended_by_its_clock_names_the_reason_not_the_transport (review fold):
  the real-client branch, where the parked initialize raises the transport's text after
  the close. _handshake called directly with a bring_up that parks until close() and
  then raises a TransportClosedError-shaped error; asserts a _HandshakeTimeout whose
  text is the plain reason (no stderr tail) with the transport error as its cause, the
  close, and that the login check never ran.
- test_a_handshake_that_settles_first_dismisses_its_clock (review fold): the other side
  of the gate; a good handshake's clock thread is gone and the client is never closed.
  Passes on origin/main by construction (no clock there): it guards the fix's own hazard.
Red on origin/main (c0cbd8ff):
  tests/test_codex_backend.py:1187: AssertionError: True is not false : available() must return once the handshake clock runs out
  tests/test_codex_backend.py:1225: AttributeError: 'CodexBackend' object has no attribute '_handshake'
  2 failed, 1 passed, 84 deselected
Against the pre-fold commit (6c36c586) the folded assertions are what fail: 0.25 not
greater than or equal to 0.3 (the retry floor, :1194) and no attribute
_HandshakeTimeout (:1226).
On the branch: 87 passed, 5 subtests passed.

