### PR TITLE
Postal cards: the incoming card wears the peer's colour again, as a hue on its own ground (T337b)

### DIFF
--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -170,6 +170,12 @@ catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
 const measure = () => page.evaluate(() => {
   const probe = document.createElement("div"); probe.style.background = "var(--box-bg)"; document.body.appendChild(probe);
   const boxBg = getComputedStyle(probe).backgroundColor; probe.remove();
+  // an oklch() relative colour (the incoming card's tint, T337b) comes back as oklch(...) from getComputedStyle; the
+  // contrast arithmetic below reads rgb, so a 1x1 canvas resolves it (an rgba() carrying alpha is left as it is)
+  const asRGB = (css) => { if (!/^(oklch|oklab|color)\(/.test(css) || /\//.test(css)) return css;
+    const cv = document.createElement("canvas"); cv.width = cv.height = 1; const ctx = cv.getContext("2d");
+    ctx.fillStyle = css; ctx.fillRect(0, 0, 1, 1); const d = ctx.getImageData(0, 0, 1, 1).data;
+    return "rgb(" + d[0] + ", " + d[1] + ", " + d[2] + ")"; };
   const cards = Array.from(document.querySelectorAll(".turn-postal-service")).map((t) => {
     const n = t.querySelector(".notice");
     const kind = t.querySelector(".postal-kind");
@@ -219,7 +225,7 @@ const measure = () => page.evaluate(() => {
       peerText: peer ? peer.textContent : null, peerBg: peer ? getComputedStyle(peer).backgroundColor : null,
       selfText: self ? self.textContent : null, selfBg: self ? getComputedStyle(self).backgroundColor : null,
       selfWidth: self ? Math.round(self.getBoundingClientRect().width) : null,
-      bg: cs.backgroundColor, border: cs.borderTopStyle, provisional: n.classList.contains("queued-bubble"),
+      bg: asRGB(cs.backgroundColor), border: cs.borderTopStyle, provisional: n.classList.contains("queued-bubble"),
       opacity: cs.opacity,   // T337: the provisional dress fades by its colours, never by an element opacity
       // the provisional dress at either density: the card's max-width as computed, and the box it actually takes
       maxWidth: cs.maxWidth, width: Math.round(n.getBoundingClientRect().width),
@@ -452,14 +458,15 @@ class ServedPostalCards(unittest.TestCase):
         self.assertEqual(card("Take the cap decision")["mark"]["paths"], 2, "bounced keeps the cross")
         self.assertEqual(card("Ignore my last note")["mark"]["paths"], 2, "recalled keeps the return arrow")
         self.assertIn("isolated", card("Take the cap decision")["title"], "a bounce carries its reason")
-        # (3) both ends, each in its session's colour; no wash; boxed vs slim
+        # (3) both ends, each in its session's colour; the incoming card's tint in the peer's hue (the user 2026-09-11,
+        # restoring what T302 removed the day before); boxed vs slim
         for c in cards:
             self.assertTrue(c["peerText"], c)
             self.assertTrue(c["selfText"] and "web" in c["selfText"], "this session's own end: %r" % c)
             self.assertEqual(c["selfBg"], "rgb(156, 210, 255)", "web's own colour on its chip: %r" % c)
             if c["dir"] == "in":
                 self.assertTrue(c["boxed"] and not c["slim"], "incoming is boxed: %r" % c)
-                self.assertEqual(c["bg"], wide["boxBg"], "no wash: the box is the plain box colour: %r" % c)
+                self.assertNotEqual(c["bg"], wide["boxBg"], "the tint: the peer's hue on the ground, never the plain box: %r" % c)
                 if not c["collapsible"]:
                     self.assertEqual(c["gistWrap"], "normal", "a boxed one-liner with nothing to fold wraps, never an ellipsis with nothing behind it: %r" % c)
             else:
@@ -467,6 +474,18 @@ class ServedPostalCards(unittest.TestCase):
             self.assertFalse(c["selfDot"], "the own chip wears no working dot: %r" % c)
         self.assertEqual(card("Take the retry-loop")["peerBg"], "rgb(30, 161, 235)", "api's colour on its chip")
         self.assertEqual(card("Heads-up")["peerBg"], "rgb(84, 178, 4)", "tests' colour on its chip")
+        # the tint is the PEER's hue: two peers' incoming cards wear two grounds, in both themes, and a landed sent card none
+        for m, name in ((wide, "dark"), (light, "light")):
+            grounds = {}
+            for c in m["cards"]:
+                if c["dir"] == "in":
+                    self.assertNotEqual(c["bg"], m["boxBg"], "%s: the incoming card is tinted: %r" % (name, c))
+                    grounds.setdefault(c["peerText"], set()).add(c["bg"])
+                elif c["boxed"] and not c["provisional"]:
+                    self.assertEqual(c["bg"], m["boxBg"], "%s: a landed boxed sent card keeps the plain box: %r" % (name, c))
+            self.assertGreaterEqual(len(grounds), 2, "%s: two peers seen: %r" % (name, grounds))
+            self.assertTrue(all(len(v) == 1 for v in grounds.values()), "%s: one ground per peer: %r" % (name, grounds))
+            self.assertEqual(len({next(iter(v)) for v in grounds.values()}), len(grounds), "%s: each peer its own ground: %r" % (name, grounds))
         # (amendment) the provisional dress: the pending send's own class on the not-yet-landed sent cards only
         prov = {c["gist"][:20]: c["provisional"] for c in cards}
         self.assertTrue(card("Please run the whole")["provisional"], "parked → provisional")

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -1,7 +1,7 @@
 // T302 (the user 2026-09-10, after seeing old and new postal cards side by side): the kind is coloured TEXT in the
 // old chip colours, the delivery state is an icon at the head's right edge (sent / delivered / read / parked /
 // bounced / recalled, from what the kernel files), both ENDS wear their sessions' colours (the peer's chip, then
-// this session's own), no card wears a background wash, and a sent card whose message has not landed wears the
+// this session's own), the incoming card wears the peer's hue as a tint on its own ground (back since 2026-09-11), and a sent card whose message has not landed wears the
 // pending send's own provisional dress (the queued bubble's class and rule). Source pins (render.ts has
 // import-time DOM side effects); the pure module is executed in postal-state.test.ts.
 import { test } from "node:test";
@@ -50,6 +50,18 @@ test("the kind is coloured text in the meta slot, never a chip, at prose weight,
   // never truncated: the postal meta stays rigid
   assert.match(CSS, /\.turn-postal-service \.notice-meta \{ flex: 1 0 auto; display: inline-flex; align-items: baseline; gap: 7px; min-width: 0; \}/,
     "the postal meta never shrinks (the kind word stays whole) and grows to the head's edge to carry the icon (T313)");
+});
+
+test("the incoming card wears the peer's hue at its ground's own lightness, in both themes; the sent card does not", () => {
+  // the user 2026-09-11, who missed the tint T302 had removed the day before on their own side-by-side ruling. A hue at
+  // the ground's lightness, not a mix: a mix lifts the ground and the dimmest kind word fell under the ramp's 4.5:1 floor
+  assert.match(CSS, /\.turn-postal-service\.postal-service-in \.notice:not\(\.notice-slim\) \{\n  background: oklch\(from var\(--notice-rail, var\(--box-bg\)\) var\(--postal-wash-l\) var\(--postal-wash-c\) h\); \}/,
+               "one declaration: the rail's hue (the peer's colour) at the ground's lightness and a gentle chroma");
+  assert.match(CSS, /\n  --postal-wash-l: 0\.263;  --postal-wash-c: 0\.03;/, "the dark ground's lightness and the chroma, beside the kind tokens");
+  assert.match(CSS, /\n  --postal-wash-l: 0\.919;/, "the light ground's lightness, in the light block");
+  assert.doesNotMatch(CSS, /theme-light[^{}]*postal-service-in[^{}]*\{[^}]*background/, "no theme takes it back");
+  assert.doesNotMatch(CSS, /postal-service-out[^{}]*\{[^}]*oklch\(from var\(--notice-rail/, "the sent card is untinted");
+  assert.match(fn("renderPostalService"), /rail: ev\.color \? ev\.color\.bg : undefined/, "the rail is the peer's colour, so the hue is the peer's");
 });
 
 const STATE = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "postal-state.ts"), "utf8");
@@ -110,9 +122,9 @@ test("both ends wear their sessions' colours: the peer's chip, then this session
   assert.match(CSS, /\.turn-postal-service \.notice-src-self \.notice-src-name \{ display: none; \}/);
 });
 
-test("no card wears a background wash in a session's colour; incoming keeps border + rail, sent stays slim", () => {
-  assert.doesNotMatch(CSS, /\.notice-peer > \.notice:not\(\.notice-slim\)/, "the 6% peer wash is gone");
-  assert.doesNotMatch(CSS, /color-mix\(in srgb, var\(--notice-rail, transparent\) 6%/);
+test("the old 6% mix and its hook stay gone; incoming keeps border + rail, sent stays slim", () => {
+  assert.doesNotMatch(CSS, /\.notice-peer > \.notice:not\(\.notice-slim\)/, "the retired hook's rule stays gone");
+  assert.doesNotMatch(CSS, /color-mix\(in srgb, var\(--notice-rail, transparent\) 6%/, "the mix that lifted the ground stays gone: the tint is a hue at the ground's lightness (below)");
   assert.match(CARD, /rail: ev\.color \? ev\.color\.bg : undefined,/, "the rail still names the peer");
   // the shared notice rule (a body → a card, head-only → slim) stands, and the postal card overrides it for ONE
   // direction: incoming keeps its box even with nothing to fold; sent stays slim

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5017,8 +5017,10 @@ function deliveryIcon(d: PostalDelivery): HTMLElement {
 function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>): HTMLElement {
   // BOTH ENDS in the head, each in its session's colour (T302, the user 2026-09-10, after seeing old and new
   // renderings): "from <peer> to <this session>" for incoming, "to <peer> from <this session>" for sent — the
-  // peer's chip in the peer's identity colour, this session's chip in its own, and NO wash of either colour on
-  // the card (a wash read as this session's colour). Click a name → that session's tab.
+  // peer's chip in the peer's identity colour, this session's chip in its own. The card's wash of the peer's
+  // colour, which that ruling removed as reading like this session's, is back since 2026-09-11 (the user asked
+  // where the tint had gone): styles.css paints the incoming card's ground from its rail, which is the peer's
+  // colour here (`rail` below), so nothing more is set on the card. Click a name → that session's tab.
   const peer = el("span", "notice-src-chip");
   peer.textContent = ev.peer;
   if (ev.color) { peer.style.setProperty("--peer-bg", ev.color.bg); peer.style.setProperty("--peer-fg", ev.color.fg); }

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -107,6 +107,8 @@ body.scheme-solarized-dark {
      postal-kind-ramp.test.ts holds the positions and the distance from the ink, theme-parity.test.ts the contrast on
      all three grounds. */
   --postal-coordinate: #5696c8;  --postal-delegate: #7cb5e3;  --postal-question: #a2d4fe;
+  --postal-wash-l: 0.263;  --postal-wash-c: 0.03;   /* the incoming card's tint: the peer's hue at the box ground's own
+                                                       OKLab lightness (the page under the 3% box), a gentle chroma (T337b) */
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
@@ -251,6 +253,7 @@ body.theme-light {
      L .30, C .098 (the hue's gamut edge there; a deep rust that stays red, short of the prose ink --fg at L .236: 0.118 from it in OKLab); 5.3:1, 8.1:1 and 11.8:1
      on the cream page, 4.9:1, 7.6:1 and 11.1:1 on a boxed card, 4.8:1, 7.3:1 and 10.7:1 on the provisional wash */
   --postal-coordinate: #974a32;  --postal-delegate: #752f18;  --postal-question: #551400;
+  --postal-wash-l: 0.919;  --postal-wash-c: 0.03;   /* the cream under the 3% box; the same gentle chroma (T337b) */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
@@ -2540,6 +2543,18 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    container, not the head: a container query resolves against an element's ANCESTORS, so a rule on the head could
    never query the head's own size (the head-as-container of T302 served only the gist, its child). */
 .turn-postal-service .notice { container-type: inline-size; }
+/* the INCOMING card's TINT (the user 2026-09-11, who missed it): the peer's identity colour, which is the card's rail, as a
+   HUE on the card's own ground: an oklch relative colour, the rail's hue at the box ground's lightness (--postal-wash-l,
+   per theme) and a gentle chroma (--postal-wash-c). History: a 6% mix of the peer's colour over the ground left with T302
+   on 2026-09-10, when a side-by-side ruling read it as this session's colour; the day after, the user asked where the
+   tint had gone and ruled it back. Not the old mix, on purpose: a mix LIFTS a dark ground toward a light peer's colour
+   (and darkens a light one toward a dark peer's), and the dimmest kind word then read under the 4.5:1 floor the kind
+   ramp holds on its ground (T320: 4.38:1 on a green peer's mix), while the ramp's own two floors (postal-kind-ramp.test.ts)
+   leave its deep end no room to move; a hue at the ground's own lightness changes no word's contrast for any peer. One
+   declaration, so a further ruling is one line either way. The sent card keeps its slim line and the provisional dress,
+   untinted. */
+.turn-postal-service.postal-service-in .notice:not(.notice-slim) {
+  background: oklch(from var(--notice-rail, var(--box-bg)) var(--postal-wash-l) var(--postal-wash-c) h); }
 /* the postal meta never shrinks, and it GROWS to the head's right edge: it holds the kind word and, after it, the
    delivery icon (margin-left auto inside it), so the icon sits at the edge as before and, when a phone-width head
    wraps, the kind word and the icon move to the next line as ONE unit (T313) */


### PR DESCRIPTION
## What

The incoming mail card wears the peer's colour again, in both themes. The user asked on 2026-09-11 where the tint on a mail card had gone. It left with the postal-card rework of 2026-09-10, whose side-by-side ruling read the 6% mix of the peer's colour as this session's colour; the day after, the user ruled it back.

## Design

- **The peer's hue on the card's own ground.** The incoming boxed card's ground is an oklch relative colour from the card's rail, which is the peer's identity colour: the rail's hue, at the box ground's OKLab lightness for the theme (`--postal-wash-l`: .263 dark, .919 light) and a gentle chroma (`--postal-wash-c`: .03). One declaration keyed on the card's direction class, two tokens. The renderer changes nothing but its comment; the rail already carries the peer's colour. The sent card keeps its slim line and the provisional dress, untinted. A further ruling is one line either way.
- **Why not the old 6% mix.** A mix lifts a dark ground toward a light peer's colour (and darkens a light one toward a dark peer's). On it the dimmest kind word, coordination, read at 4.38:1 with the fixture's green peer and 4.02:1 with a white one, under the 4.5:1 floor the kind ramp holds on its ground, and the ramp's own two floors (the deepest blue that still reads on the provisional card below, the prose ink above) leave its deep end no room to move. A hue at the ground's own lightness changes no word's contrast for any peer: every kind word reads exactly as it does on the plain box, in either theme.

## Tests

`ui/webview/postal-card.test.ts` pins the rule, the two tokens, no theme taking the tint back, the sent card untinted and the rail being the peer's colour; the old case keeps the retired hook's and the old mix's absence under a new title. `tests/test_postal_cards_served.py` resolves a computed oklch() ground through a one-pixel canvas so its contrast arithmetic reads it, and asserts, in both themes, that every incoming card's ground differs from the plain box, that each peer's tint is its own and one per peer, that a landed boxed sent card keeps the plain box, and that every kind word still reads at 4.5:1 on its ground. Before and after screenshots at three widths in dark and two in light are in the drops folder.

Tier: fix
