### PR TITLE
T323 stage 4c: the lazy assembly index, a restored session's pre-cut turns kept as bytes and built only when a consumer reaches for them

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -989,10 +989,22 @@ sets as hashes, each file's witness and where its tail starts, and a hash over
 the pre-cut turn ids, segment ids and atom uuids. A fresh kernel verifies the
 document, rebuilds the pre-cut turns as atoms without bodies, reads the leaf
 from the cut's byte offset only and parses that tail, proves the prefix by the
-hash, and hands the judges and the display one tree. A body before the cut is
-read on demand from its record when a consumer asks for it, through a
-byte-capped memo; a consumer that reads one without asking fails loudly rather
-than seeing an empty message. A compaction after the document demotes to a
+hash, and hands the judges and the display one tree. Since the lazy index
+(2026-09-11, document version 4) the document also carries a `turns` section:
+each pre-cut turn as its identity, its atoms' row indexes, its segments' spans
+and the scalars the kernel's walkers read (the atoms' uuids, the last and
+latest times, the last model, the tool calls), so a restore builds the turns
+without building an atom. The pre-cut rows stay as bytes; a turn's atoms are
+a list whose slots are built one at a time when a consumer reaches for them,
+through a process-wide LRU of 20000 built atoms across every session (eviction
+drops the memo; a consumer's own reference stays whole), counted per consumer
+under `/perf` `asmIndex`. A body before the cut is read on demand from its
+record when a consumer asks for it, through a byte-capped memo; a consumer
+that reads one without asking fails loudly rather than seeing an empty
+message, and a serializer reaching a pre-cut turn's atoms is refused (a dump
+goes through `plain_tree`). A document written without the parsed tree (the
+exit path past its budget) carries no `turns` section and restores the atoms
+as before, until the next settle rewrites it with one. A compaction after the document demotes to a
 whole parse as before, and the next settle writes a new document; a rewrite
 under the cut's guard, a shrunk or moved file, another session, other inputs,
 a wrong version, a corrupt or unprovable document, or a document past 16 MB
@@ -1378,6 +1390,11 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `reconstruction`, `oversize`, `unencodable`, `offsets`, `stat`, `write`),
   `hydratedAtoms` and `hydratedBytes` (bodies read on demand for atoms before
   a cut) and `hydratedBy` (those bytes per calling function).
+- `asmIndex`: the lazy index (T323 stage 4c) a restored session's pre-cut turns
+  come from: `materialized` atoms built from the document's rows since boot,
+  `materializedBy` (per consumer), `resident` (the process-wide LRU, `cap`
+  20000 atoms across every session; eviction drops the memo, never a field in
+  place), `evictions`, and `restoredTurns`.
 - `skillLoadIndex`: the judge's skill-load boot pass (the tops older stores minted from
   the harness's own skill load): `filesRead` and `bytesRead` (transcripts read raw this
   boot, appended tails only once the persisted index holds a file), `filesIndexed`, and

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -3975,7 +3975,7 @@ class LazyIndex:
             raise LazyIndexError("session %s row %d: %s" % (self.rompuuid[:8], k, e)) from e
         if "m" in row:                                    # a synthesized atom (idle, a salvaged reply): its message inline
             a = dict(row.get("s") or {})
-            a["message"] = row["m"]
+            a.update(message=row["m"])                    # a WRITE of the synthesized atom's message (no body read: the audit's regex)
             return a
         a = _restore_prefix_atoms([row], self.rompuuid, self.records, self.fsids)[0]
         a.pop("_seq", None)                               # the read-order tiebreak: the section fixed the order (parse_session pops it too)

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -3029,6 +3029,8 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre
     consumed, since the atoms-only dedup below can no longer see the abandoned record)."""
     if not atoms:
         return []
+    if not any(isinstance(r, dict) and r.get("t") and isinstance(r.get("orphanReply"), dict) for r in states or []):
+        return []                                                     # no marker: nothing to salvage, and no pre-cut row decoded
     # TEXT-BEARING uuids only (the user 2026-07-28): a marker whose uuid the disk knows solely as a
     # TEXTLESS record must still interleave. On some model+tool combinations (observed: fable-5 replying
     # before an AskUserQuestion) the CLI persists the streamed reply text as an EMPTY thinking record
@@ -3922,7 +3924,7 @@ _ASM_CKPT_V = 4                       # 2: atom rows carry [offset, len], nt for
 _MAT_CAP = 20000                      # materialized pre-cut atoms resident across every session (the lazy index's LRU)
 _MAT_LRU = collections.OrderedDict()  # (id(LazyAtoms), row) → (LazyAtoms, row): eviction drops the memo, never a field in place
 _MAT_LOCK = threading.Lock()
-_ASM_INDEX_STATS = {"materialized": 0, "materializedBy": {}, "resident": 0, "evictions": 0, "restoredTurns": 0}
+_ASM_INDEX_STATS = {"materialized": 0, "materializedBy": {}, "resident": 0, "evictions": 0, "restoredTurns": 0, "rowDecodes": 0}
 _PRE_TURN_KEYS = ("pre", "uuids", "lastT", "maxT", "lastModel", "tools", "segs")   # a pre-turn's fields beyond a plain turn's
 
 
@@ -3969,13 +3971,16 @@ class LazyIndex:
         self.fsids = list(doc.get("fsids") or [])
 
     def build(self, k):
+        with _MAT_LOCK:
+            _ASM_INDEX_STATS["rowDecodes"] += 1
         try:
             row = json.loads(self.rowb[k])
         except (IndexError, ValueError) as e:
             raise LazyIndexError("session %s row %d: %s" % (self.rompuuid[:8], k, e)) from e
-        if "m" in row:                                    # a synthesized atom (idle, a salvaged reply): its message inline
+        if row.get("syn"):                                # a synthesized atom (idle, a salvaged reply): its message inline, if any
             a = dict(row.get("s") or {})
-            a.update(message=row["m"])                    # a WRITE of the synthesized atom's message (no body read: the audit's regex)
+            if "m" in row:
+                a.update(message=row["m"])                # a WRITE of the synthesized atom's message (no body read: the audit's regex)
             return a
         a = _restore_prefix_atoms([row], self.rompuuid, self.records, self.fsids)[0]
         a.pop("_seq", None)                               # the read-order tiebreak: the section fixed the order (parse_session pops it too)
@@ -3983,6 +3988,8 @@ class LazyIndex:
 
     def uuid_of(self, k):
         """A row's uuid without building its atom (the record row's, else the synthesized scalars')."""
+        with _MAT_LOCK:
+            _ASM_INDEX_STATS["rowDecodes"] += 1
         row = json.loads(self.rowb[k])
         ri = row.get("r")
         if ri is not None:
@@ -3991,6 +3998,8 @@ class LazyIndex:
 
     def text_flags(self, k):
         """(type, has text) for a row without building its atom: what an orphan marker's dedup reads."""
+        with _MAT_LOCK:
+            _ASM_INDEX_STATS["rowDecodes"] += 1
         row = json.loads(self.rowb[k])
         ri = row.get("r")
         tname = {"u": "user", "a": "assistant", "s": "system"}
@@ -3998,7 +4007,7 @@ class LazyIndex:
         lz = row.get("lz")
         if lz is not None:
             return typ, bool(lz.get("nt"))
-        if "m" in row:
+        if row.get("syn") and "m" in row:
             return typ, bool(_text_of(_content(row["m"])).strip())
         return typ, False
 
@@ -4189,7 +4198,7 @@ def asm_index_stats():
     with _MAT_LOCK:
         return {"materialized": _ASM_INDEX_STATS["materialized"], "materializedBy": dict(_ASM_INDEX_STATS["materializedBy"]),
                 "resident": len(_MAT_LRU), "evictions": _ASM_INDEX_STATS["evictions"], "cap": _MAT_CAP,
-                "restoredTurns": _ASM_INDEX_STATS["restoredTurns"]}
+                "restoredTurns": _ASM_INDEX_STATS["restoredTurns"], "rowDecodes": _ASM_INDEX_STATS["rowDecodes"]}
 _ASM_CKPT_CAP = 16 * 1024 * 1024   # a document past this is not written (counted): that session parses whole as today
 _ASM_CKPT_STATS = {"written": 0, "restored": 0, "fallbacks": {}, "skipped": {}, "hydratedBytes": 0, "hydratedAtoms": 0,
                    "hydratedBy": {}}     # bytes per calling function: a whole-tree hydration anywhere shows here
@@ -4307,6 +4316,13 @@ def _pre_tree_identity(atoms, rompuuid):
 _ASM_SKIP_STRUCTURAL = ("unsplittable", "reconstruction", "unencodable", "oversize")   # true of a cut until it moves
 
 
+def _tree_key(tree):
+    """A parsed tree's identity for the writer's memo: its object, its turn count and its last turn's id (a new parse mints
+    new dicts; the same tree yields the same section, or none, every time)."""
+    turns = (tree or {}).get("turns") or []
+    return (id(tree), len(turns), turns[-1].get("id") if turns else None)
+
+
 def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
     """Write the leaf's assembly checkpoint from its WHOLE assembly entry. False when there is nothing to write: no
     entry, an entry restored from a document (its cut stands until a compaction moves it), no compaction boundary in
@@ -4323,9 +4339,11 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
             return _asm_ckpt_skip("noEntry")
         if entry.get("prefix") or entry.get("preTurns"):
             return _asm_ckpt_skip("restored")            # the document it came from stands
-        if entry.get("docWritten") and cp.exists() and (tree is None or entry.get("docTurns")):
+        if entry.get("docWritten") and cp.exists() and (tree is None or entry.get("docTurns")
+                                                          or entry.get("docNoTurns") == _tree_key(tree)):
             return _asm_ckpt_skip("written")             # this entry's pre-cut part has not moved (a fold appends after the cut);
-        #                                                  a document written without a tree is written again once one is given
+        #                                                  a document written without a tree is written again once one is given,
+        #                                                  one whose tree yielded no section is not, for that tree (review low 4)
         ad = entry["ad"]
         atoms = entry["atoms"]
         bounds = [a for a in atoms if a.get("type") == "system" and a.get("subtype") == "compact_boundary"]
@@ -4502,10 +4520,15 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                 if u_ and u_ not in row_of_atom:
                     row_of_atom[u_] = k_
             turns_doc = []
+            cut_ts = min((ad.ts_of.get(u, 0) for u in entry["kept"] if ad.seq_of.get(u, 0) >= cut_seq), default=None)
             for turn in tree.get("turns") or []:
                 seqs = [ad.seq_of[a["uuid"]] for a in turn["atoms"] if a.get("uuid") in ad.seq_of]
-                if not seqs or max(seqs) >= cut_seq:
-                    break
+                if seqs:
+                    if max(seqs) >= cut_seq:
+                        break                            # the first turn holding a post-cut record ends the pre-cut run
+                elif cut_ts is None or (turn.get("t") or 0) >= cut_ts:
+                    break                                # a turn of synthesized atoms alone (an idle span opening the tree): pre-cut
+                #                                          by its time, else the tail's
                 idxs = []
                 for a in turn["atoms"]:
                     u_ = a.get("uuid")
@@ -4514,7 +4537,10 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                         if u_ in ad.seq_of:
                             return skip("turnRows")      # a record atom with no row of its own: the tree and the entry disagree
                         k_ = len(pre_atoms)
-                        pre_atoms.append({"i": -1, "s": _atom_scalars(a), "m": a.get("message")})
+                        row_ = {"i": -1, "syn": 1, "s": _atom_scalars(a)}   # a synthesized atom's row: its scalars, its message inline
+                        if "message" in a:                                #  when it has one (an idle span has none)
+                            row_["m"] = a["message"]
+                        pre_atoms.append(row_)
                     idxs.append(k_)
                 seg_rows, start = [], 0
                 for sg in segments(turn):
@@ -4533,6 +4559,13 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                                   "lastT": ts_[-1] if ts_ else None, "maxT": max(ts_) if ts_ else None,
                                   "lastModel": models[-1] if models else None,
                                   "tools": [[i_, n_] for a in turn["atoms"] if a.get("type") == "assistant" for i_, n_ in atom_tool_uses(a)]})
+            # the section must COVER the pre-cut rows: every row in exactly one turn (a permutation of the row indexes; the
+            # turns sort by time, so a row's index need not be contiguous with its neighbours'), else the tree the store
+            # holds is not this entry's whole (a bare rollback armed before the last compaction cuts it short) and the
+            # document is written without a section rather than restore a session missing history (review medium 1)
+            if turns_doc and sorted(k_ for td in turns_doc for k_ in td["atoms"]) != list(range(len(pre_atoms))):
+                _asm_ckpt_skip("turnsCoverage")
+                turns_doc = None
             if not turns_doc:
                 turns_doc = None                          # nothing before the cut in this tree: the atoms-only form
         doc = {"av": _ASM_CKPT_V, "path": os.path.realpath(str(leaf_path)), "rompuuid": str(rompuuid), "sdkHuman": bool(sdk_human),
@@ -4563,6 +4596,7 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
             return skip("write")
         entry["docWritten"] = True
         entry["docTurns"] = bool(turns_doc)              # the turns section was written (T323 stage 4c)
+        entry["docNoTurns"] = _tree_key(tree) if (tree is not None and not turns_doc) else None   # …or this tree yields none
         with _ASM_CKPT_LOCK:
             _ASM_CKPT_STATS["written"] += 1
         return True
@@ -4745,6 +4779,8 @@ def _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index,
             # digest proves it is the one the writer verified against the whole parse (no atom built here)
             if _tree_identity_of_doc(doc["turns"], doc.get("identity")) != doc.get("treeIdentity"):
                 _asm_ckpt_note(leaf_path, "identity"); return None
+            if sorted(k_ for td in doc["turns"] for k_ in td["atoms"]) != list(range(len(doc["atoms"]))):
+                _asm_ckpt_note(leaf_path, "coverage"); return None   # the section does not cover the rows: never a short history
             index = LazyIndex(doc, rompuuid, leaf_path)
             pre_turns = _pre_turns_of(doc, index)
             doc["atoms"] = None                                # the rows live in the index as bytes from here

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -26,7 +26,7 @@ Auxiliary inputs the file adapter may read (same category as the transcript):
                                transcript lost to an API-errored try; judge parse only)
   timeline/messages.jsonl   -> peer rompUuid for a postal atom (join on the msg id)
 """
-import array, bisect, copy, gzip, json, os, re, sys, time, hashlib, threading
+import array, bisect, collections, copy, gzip, json, os, re, sys, time, hashlib, threading
 from datetime import datetime
 from pathlib import Path
 
@@ -3007,7 +3007,7 @@ def synthesize_idle(states, atoms, now):
     return out
 
 
-def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None):
+def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre=None):
     """Salvaged assistant replies from orphanReply markers in states/<sid>.jsonl — text that STREAMED
     live but the transcript never kept (an API-errored try; the SDK backend persists it at settle,
     see its append_orphan_reply). The kernel's chat build has interleaved these since 2026-07-21, but
@@ -3038,6 +3038,18 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None):
     lazy = [a for a in atoms if a.get("lazy") is not None]           # atoms before an assembly checkpoint's cut: no body
     seen_uuids = {a.get("uuid") for a in atoms
                   if a.get("uuid") and (a["lazy"].get("nt") if a.get("lazy") is not None else _text_of(_content(a.get("message"))).strip())}
+    pre_rows = []                                                     # (turn, row index) of the restored pre-cut atoms (stage 4c)
+    if pre:
+        for pt in pre:
+            la = pt["atoms"]
+            for k, r in enumerate(la.rows()):
+                pre_rows.append((la, k, r))
+        for la, k, r in pre_rows:                                     # text-bearing uuids from the rows: no atom built
+            typ, nt = la._index.text_flags(r)
+            if nt:
+                u = la._index.uuid_of(r)
+                if u:
+                    seen_uuids.add(u)
     disk_texts = [t for a in atoms if a.get("type") == "assistant" and a.get("lazy") is None
                   if (t := _text_of(_content(a.get("message"))).strip())]
     older = [None]                                                    # the lazy assistants' texts, hydrated once, only if a marker needs them
@@ -3045,8 +3057,12 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None):
     def _older_texts():
         if older[0] is None:
             las = [a for a in lazy if a.get("type") == "assistant" and a["lazy"].get("nt")]
+            for la, k, r in pre_rows:                                 # the index's assistants with text: built and hydrated only now
+                typ, nt = la._index.text_flags(r)
+                if typ == "assistant" and nt:
+                    las.append(la[k])
             if las:
-                hydrate(las, rompuuid or atoms[0].get("session_id"))
+                hydrate(las, rompuuid or (atoms[0].get("session_id") if atoms else None))
             older[0] = [t for a in las if (t := _text_of(_content(a.get("message"))).strip())]
         return older[0]
     sid = atoms[0]["session_id"]
@@ -3073,7 +3089,7 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None):
             continue
         if any(dt.startswith(txt) or txt.startswith(dt) for dt in disk_texts):
             continue
-        if lazy and any(dt.startswith(txt) or txt.startswith(dt) for dt in _older_texts()):
+        if (lazy or pre_rows) and any(dt.startswith(txt) or txt.startswith(dt) for dt in _older_texts()):
             continue                                                   # a reply the disk kept before the cut
         out.append({"type": "assistant", "uuid": u or ("orphan:%d" % int(r["t"])), "session_id": sid,
                     "t": int(r["t"]), "fsid": None, "parentUuid": None, "orphaned": True,
@@ -3376,6 +3392,8 @@ def segments(turn):
     from one input to the next (or to the turn end). Each carries a stable `id` for the
     summarizer layer. Pure function over a turn."""
     atoms = turn["atoms"]
+    if turn.get("pre") and turn.get("segs") is not None:   # a restored pre-cut turn (T323 stage 4c): the spans as written
+        return [{"id": s[0], "trigger": s[1], "t": s[2], "end": s[3], "atoms": atoms[s[4]:s[4] + s[5]]} for s in turn["segs"]]
     rompuuid = atoms[0]["session_id"] if atoms else ""
     starts = [i for i, a in enumerate(atoms) if _is_segment_input(a)]
     if not starts:
@@ -3673,7 +3691,7 @@ def _asm_serve(entry):
     before the checkpoint's cut, T323 stage 4) comes first, in emit order, like a whole parse's; its skill loads
     (T333) are the carried pre-cut ones plus the tail's, in the seeded emit state."""
     return ([dict(a) for a in entry.get("prefix") or []] + [dict(a) for a in entry["atoms"]], set(entry["landed"]), None,
-            dict(entry["st"].get("skill_loads") or {}))
+            dict(entry["st"].get("skill_loads") or {}), list(entry.get("preTurns") or []))
 
 
 def _asm_full(key, leaf_path, candidate_files, links, rompuuid, postal_index, sdk_human):
@@ -3899,7 +3917,279 @@ def _asm_fold(entry, delta, leaf_recs, leaf_key, leaf_stem, rompuuid, postal_ind
 # ids and atom uuids. Bodies come back on demand (hydrate). Anything that does not verify is a counted fallback to a
 # whole parse; a compaction landing after the document demotes the tail fold to a whole parse exactly as before, and
 # the next settle writes a new document with the new cut.
-_ASM_CKPT_V = 3                       # 2: atom rows carry [offset, len], nt for every atom; 3: the carry holds skill_loads (T333)
+_ASM_CKPT_V = 4                       # 2: atom rows carry [offset, len], nt for every atom; 3: the carry holds skill_loads (T333);
+#                                       4: a `turns` section over the pre-cut rows (T323 stage 4c: the lazy index)
+_MAT_CAP = 20000                      # materialized pre-cut atoms resident across every session (the lazy index's LRU)
+_MAT_LRU = collections.OrderedDict()  # (id(LazyAtoms), row) → (LazyAtoms, row): eviction drops the memo, never a field in place
+_MAT_LOCK = threading.Lock()
+_ASM_INDEX_STATS = {"materialized": 0, "materializedBy": {}, "resident": 0, "evictions": 0, "restoredTurns": 0}
+_PRE_TURN_KEYS = ("pre", "uuids", "lastT", "maxT", "lastModel", "tools", "segs")   # a pre-turn's fields beyond a plain turn's
+
+
+class LazyIndexError(RuntimeError):
+    """A pre-cut row the index cannot decode: names the session and the row, so the fallback is a loud one."""
+
+
+class _Unmaterialized:
+    """The placeholder a LazyAtoms slot holds before its atom is built. Not JSON-serializable and not a dict: a serializer
+    or a copier reaching a pre-cut turn's atoms through the list's storage raises instead of shipping placeholders."""
+    __slots__ = ()
+
+    def __repr__(self):
+        return "<unmaterialized atom>"
+
+
+_UNMAT = _Unmaterialized()
+
+
+def _materialize_caller():
+    """The consumer that reached for a pre-cut atom: the first frame above the index's own methods."""
+    f = sys._getframe(2)
+    for _ in range(8):
+        if f is None:
+            break
+        name = f.f_code.co_name
+        if name not in ("__getitem__", "__iter__", "__reversed__", "__contains__", "__eq__", "index", "count", "copy", "__add__",
+                        "__radd__", "__reduce_ex__", "_at", "materialize", "_materialize_caller", "<genexpr>", "<listcomp>", "get"):
+            return name
+        f = f.f_back
+    return "?"
+
+
+class LazyIndex:
+    """One restored session's pre-cut rows (T323 stage 4c): the document's atom rows kept as BYTES, decoded one at a time
+    when a consumer reaches for an atom, through a process-wide LRU (_MAT_CAP). The record rows (identity, time, file,
+    parent) stay decoded: they are small and every materialization reads one."""
+
+    def __init__(self, doc, rompuuid, leaf_path):
+        self.rompuuid = str(rompuuid)
+        self.leaf = str(leaf_path)
+        self.rowb = [json.dumps(r, separators=(",", ":")).encode("utf-8") for r in doc["atoms"]]
+        self.records = doc["records"]
+        self.fsids = list(doc.get("fsids") or [])
+
+    def build(self, k):
+        try:
+            row = json.loads(self.rowb[k])
+        except (IndexError, ValueError) as e:
+            raise LazyIndexError("session %s row %d: %s" % (self.rompuuid[:8], k, e)) from e
+        if "m" in row:                                    # a synthesized atom (idle, a salvaged reply): its message inline
+            a = dict(row.get("s") or {})
+            a["message"] = row["m"]
+            return a
+        a = _restore_prefix_atoms([row], self.rompuuid, self.records, self.fsids)[0]
+        a.pop("_seq", None)                               # the read-order tiebreak: the section fixed the order (parse_session pops it too)
+        return a
+
+    def uuid_of(self, k):
+        """A row's uuid without building its atom (the record row's, else the synthesized scalars')."""
+        row = json.loads(self.rowb[k])
+        ri = row.get("r")
+        if ri is not None:
+            return self.records[ri][0]
+        return (row.get("s") or {}).get("uuid")
+
+    def text_flags(self, k):
+        """(type, has text) for a row without building its atom: what an orphan marker's dedup reads."""
+        row = json.loads(self.rowb[k])
+        ri = row.get("r")
+        tname = {"u": "user", "a": "assistant", "s": "system"}
+        typ = (row.get("s") or {}).get("type") or (tname.get(self.records[ri][2], "user") if ri is not None else None)
+        lz = row.get("lz")
+        if lz is not None:
+            return typ, bool(lz.get("nt"))
+        if "m" in row:
+            return typ, bool(_text_of(_content(row["m"])).strip())
+        return typ, False
+
+
+class LazyAtoms(list):
+    """A pre-cut turn's atoms (T323 stage 4c): a list whose slots hold placeholders until a consumer reaches for an
+    atom, which the index then builds (a lazy atom, its body still on disk, hydrate() as before). Every read path a
+    list offers goes through the build (indexing, slicing, iteration, membership, equality, copies, concatenation,
+    pickling), so a consumer sees plain atom dicts; the placeholders reach only a serializer or copier that reads the
+    list's storage directly (json's encoder, refused at __iter__ while a slot is unbuilt), and those raise. Materialized atoms live in a process-wide LRU
+    (_MAT_CAP): eviction puts the placeholder back in the slot, the consumer's own reference stays whole."""
+
+    def __init__(self, index, rows):
+        list.__init__(self, [_UNMAT] * len(rows))
+        self._index = index
+        self._rows = list(rows)
+
+    # ── the build ──
+    def _at(self, i):
+        a = list.__getitem__(self, i)
+        if a is not _UNMAT:
+            with _MAT_LOCK:
+                key = (id(self), i)
+                if key in _MAT_LRU:
+                    _MAT_LRU.move_to_end(key)
+            return a
+        a = self._index.build(self._rows[i])
+        by = _materialize_caller()
+        with _MAT_LOCK:
+            cur = list.__getitem__(self, i)
+            if cur is not _UNMAT:                         # another thread built it first
+                return cur
+            list.__setitem__(self, i, a)
+            _MAT_LRU[(id(self), i)] = (self, i)
+            _ASM_INDEX_STATS["materialized"] += 1
+            _ASM_INDEX_STATS["materializedBy"][by] = _ASM_INDEX_STATS["materializedBy"].get(by, 0) + 1
+            while len(_MAT_LRU) > _MAT_CAP:
+                _, (lz, j) = _MAT_LRU.popitem(last=False)
+                list.__setitem__(lz, j, _UNMAT)
+                _ASM_INDEX_STATS["evictions"] += 1
+            _ASM_INDEX_STATS["resident"] = len(_MAT_LRU)
+        return a
+
+    def uuids(self):
+        """The atoms' uuids without building them."""
+        return [self._index.uuid_of(r) for r in self._rows]
+
+    def rows(self):
+        return list(self._rows)
+
+    # ── the list surface ──
+    def __getitem__(self, i):
+        if isinstance(i, slice):
+            return [self._at(j) for j in range(*i.indices(len(self)))]
+        n = len(self)
+        if i < 0:
+            i += n
+        if not 0 <= i < n:
+            raise IndexError("LazyAtoms index out of range")
+        return self._at(i)
+
+    def __iter__(self):
+        # json's encoder (C or Python) reaches a list SUBCLASS through iteration, so a dump of a tree would build every atom
+        # and ship it: refused here, loudly, as the design asks (plain_tree is the dump's road)
+        f = sys._getframe(1)
+        if f is not None and f.f_code.co_name in ("iterencode", "encode", "_iterencode", "_iterencode_list", "_iterencode_dict") \
+                and any(a is _UNMAT for a in list.__iter__(self)):
+            raise TypeError("a pre-cut turn's atoms are not JSON-serializable before they are built: dump em.plain_tree(session)")
+        for j in range(len(self)):
+            yield self._at(j)
+
+    def __reversed__(self):
+        for j in range(len(self) - 1, -1, -1):
+            yield self._at(j)
+
+    def __contains__(self, x):
+        return any(a is x or a == x for a in self)
+
+    def __eq__(self, other):
+        return list(self) == list(other) if isinstance(other, list) else NotImplemented
+
+    def __ne__(self, other):
+        eq = self.__eq__(other)
+        return eq if eq is NotImplemented else not eq
+
+    __hash__ = None
+
+    def index(self, x, *args):
+        return list(self).index(x, *args)
+
+    def count(self, x):
+        return list(self).count(x)
+
+    def copy(self):
+        return list(self)
+
+    def __add__(self, other):
+        return list(self) + list(other)
+
+    def __radd__(self, other):
+        return list(other) + list(self)
+
+    def __mul__(self, n):
+        return list(self) * n
+
+    def __reduce_ex__(self, proto):
+        return (list, (list(self),))                     # a copy or a pickle is a plain list of built atoms
+
+    def __repr__(self):
+        return "LazyAtoms(%d rows, %d built)" % (len(self), sum(1 for a in list.__iter__(self) if a is not _UNMAT))
+
+    def sort(self, *a, **k):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def append(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def extend(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def insert(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def pop(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def remove(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def __setitem__(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+    def __delitem__(self, *a):
+        raise TypeError("a pre-cut turn's atoms are read-only")
+
+
+class PreTurn(dict):
+    """A restored pre-cut turn: a plain turn's fields (id, trigger, t, end, ended, atoms) with `atoms` a LazyAtoms, plus
+    the turn-level scalars the kernel's walkers read instead of the atoms (_PRE_TURN_KEYS: uuids, lastT, maxT, lastModel,
+    tools, segs). A dict subclass only so a walker can tell one apart; `trigger` is {"uuid": the opener's}, as the
+    segmentation shapes it, from the uuids alone."""
+
+
+def _pre_turns_of(doc, index):
+    """The pre-cut turns of a version-4 document as PreTurns over the index (no atom built)."""
+    out = []
+    for td in doc["turns"]:
+        at = td.get("triggerAt")
+        pt = PreTurn(id=td["id"], trigger=({"uuid": td["uuids"][at]} if at is not None else None), t=td["t"], end=td["end"],
+                     ended=bool(td["ended"]), atoms=LazyAtoms(index, td["atoms"]),
+                     pre=True, uuids=list(td["uuids"]), lastT=td.get("lastT"), maxT=td.get("maxT"), lastModel=td.get("lastModel"),
+                     tools=[tuple(x) for x in td.get("tools") or []], segs=[list(s) for s in td["segs"]])
+        out.append(pt)
+    return out
+
+
+def _tree_identity_of_doc(turns_doc, identity):
+    """sha1 over a `turns` section's turn ids, segment ids and atom uuids, and the atoms' own identity digest (the whole
+    parse's, verified at write time): the proof a restore reads from the section alone, no atom built."""
+    h = hashlib.sha1()
+    h.update((identity or "").encode()); h.update(b"#")
+    for td in turns_doc:
+        h.update(td["id"].encode()); h.update(b"|")
+        for sg in td["segs"]:
+            h.update(sg[0].encode()); h.update(b",")
+        for u in td["uuids"]:
+            h.update((u or "").encode()); h.update(b";")
+    return h.hexdigest()
+
+
+def plain_tree(session):
+    """A plain copy of a parsed session for a comparison or a dump: every turn a plain dict with the six turn fields, its
+    atoms built into plain dicts (bodies as they are: hydrate first for the text). The pre-turn fields are left out, so a
+    restored tree and the whole parse's compare equal when they are."""
+    turns = []
+    for t in session.get("turns") or []:
+        pt = {k: v for k, v in t.items() if k != "atoms" and k not in _PRE_TURN_KEYS}
+        if isinstance(pt.get("trigger"), dict):
+            pt["trigger"] = dict(pt["trigger"])
+        pt["atoms"] = [dict(a) for a in t["atoms"]]
+        turns.append(pt)
+    out = {k: v for k, v in session.items() if k != "turns"}
+    out["turns"] = turns
+    return out
+
+
+def asm_index_stats():
+    with _MAT_LOCK:
+        return {"materialized": _ASM_INDEX_STATS["materialized"], "materializedBy": dict(_ASM_INDEX_STATS["materializedBy"]),
+                "resident": len(_MAT_LRU), "evictions": _ASM_INDEX_STATS["evictions"], "cap": _MAT_CAP,
+                "restoredTurns": _ASM_INDEX_STATS["restoredTurns"]}
 _ASM_CKPT_CAP = 16 * 1024 * 1024   # a document past this is not written (counted): that session parses whole as today
 _ASM_CKPT_STATS = {"written": 0, "restored": 0, "fallbacks": {}, "skipped": {}, "hydratedBytes": 0, "hydratedAtoms": 0,
                    "hydratedBy": {}}     # bytes per calling function: a whole-tree hydration anywhere shows here
@@ -4017,7 +4307,7 @@ def _pre_tree_identity(atoms, rompuuid):
 _ASM_SKIP_STRUCTURAL = ("unsplittable", "reconstruction", "unencodable", "oversize")   # true of a cut until it moves
 
 
-def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False):
+def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
     """Write the leaf's assembly checkpoint from its WHOLE assembly entry. False when there is nothing to write: no
     entry, an entry restored from a document (its cut stands until a compaction moves it), no compaction boundary in
     the tree (the whole file would be the tail), a cut that would not split the chronological order the fold's gate
@@ -4031,10 +4321,11 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False):
             entry = _ASM_CACHE.get(key)
         if entry is None:
             return _asm_ckpt_skip("noEntry")
-        if entry.get("prefix"):
+        if entry.get("prefix") or entry.get("preTurns"):
             return _asm_ckpt_skip("restored")            # the document it came from stands
-        if entry.get("docWritten") and cp.exists():
-            return _asm_ckpt_skip("written")             # this entry's pre-cut part has not moved (a fold appends after the cut)
+        if entry.get("docWritten") and cp.exists() and (tree is None or entry.get("docTurns")):
+            return _asm_ckpt_skip("written")             # this entry's pre-cut part has not moved (a fold appends after the cut);
+        #                                                  a document written without a tree is written again once one is given
         ad = entry["ad"]
         atoms = entry["atoms"]
         bounds = [a for a in atoms if a.get("type") == "system" and a.get("subtype") == "compact_boundary"]
@@ -4199,9 +4490,55 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False):
         pre_lazy = _restore_prefix_atoms(pre_atoms, rompuuid, rows, fsids)
         if _pre_tree_identity(pre_lazy, rompuuid) != identity:
             return skip("reconstruction")            # the lazy reconstruction would not reproduce the whole parse's ids
+        # the `turns` section (T323 stage 4c): the parsed TREE's pre-cut turns as rows, so a restore builds the turns
+        # without an atom; a synthesized atom (an idle span, a salvaged reply) has no record and rides as a row of its own
+        # with its message inline. The section stops at the first turn holding a post-cut record (the cut is a turn
+        # boundary: the chronological split above put every pre-cut record before every post-cut one).
+        turns_doc = None
+        if tree is not None:
+            row_of_atom = {}
+            for k_, row_ in enumerate(pre_atoms):
+                u_ = rows[row_["r"]][0] if "r" in row_ else (row_.get("s") or {}).get("uuid")
+                if u_ and u_ not in row_of_atom:
+                    row_of_atom[u_] = k_
+            turns_doc = []
+            for turn in tree.get("turns") or []:
+                seqs = [ad.seq_of[a["uuid"]] for a in turn["atoms"] if a.get("uuid") in ad.seq_of]
+                if not seqs or max(seqs) >= cut_seq:
+                    break
+                idxs = []
+                for a in turn["atoms"]:
+                    u_ = a.get("uuid")
+                    k_ = row_of_atom.get(u_) if u_ else None
+                    if k_ is None:
+                        if u_ in ad.seq_of:
+                            return skip("turnRows")      # a record atom with no row of its own: the tree and the entry disagree
+                        k_ = len(pre_atoms)
+                        pre_atoms.append({"i": -1, "s": _atom_scalars(a), "m": a.get("message")})
+                    idxs.append(k_)
+                seg_rows, start = [], 0
+                for sg in segments(turn):
+                    seg_rows.append([sg["id"], sg.get("trigger"), sg["t"], sg["end"], start, len(sg["atoms"])])
+                    start += len(sg["atoms"])
+                if start != len(turn["atoms"]):
+                    return skip("segs")                  # the segments are contiguous slices of the turn, in order
+                ts_ = [a.get("t") for a in turn["atoms"] if a.get("t")]
+                models = [atom_model(a) for a in turn["atoms"] if a.get("type") == "assistant"]
+                models = [m_ for m_ in models if m_]
+                trig_at = next((i_ for i_, a in enumerate(turn["atoms"]) if turn["trigger"] is not None and a is turn["trigger"]), None)
+                if trig_at is None and turn["trigger"] is not None:
+                    trig_at = next((i_ for i_, a in enumerate(turn["atoms"]) if a.get("uuid") == turn["trigger"].get("uuid")), None)
+                turns_doc.append({"id": turn["id"], "t": turn["t"], "end": turn["end"], "ended": bool(turn["ended"]), "atoms": idxs,
+                                  "segs": seg_rows, "uuids": [a.get("uuid") for a in turn["atoms"]], "triggerAt": trig_at,
+                                  "lastT": ts_[-1] if ts_ else None, "maxT": max(ts_) if ts_ else None,
+                                  "lastModel": models[-1] if models else None,
+                                  "tools": [[i_, n_] for a in turn["atoms"] if a.get("type") == "assistant" for i_, n_ in atom_tool_uses(a)]})
+            if not turns_doc:
+                turns_doc = None                          # nothing before the cut in this tree: the atoms-only form
         doc = {"av": _ASM_CKPT_V, "path": os.path.realpath(str(leaf_path)), "rompuuid": str(rompuuid), "sdkHuman": bool(sdk_human),
                "cands": list(entry["cands"]), "links": dict(entry["links"]), "files": files, "fsids": fsids, "cutSeq": cut_seq,
                "records": rows, "atoms": pre_atoms, "spine": spine, "seqTs": seq_ts, "lastTs": last_ts,
+               "turns": turns_doc, "treeIdentity": _tree_identity_of_doc(turns_doc, identity) if turns_doc else None,
                "gates": {"prompt_ids": sorted(ad.prompt_ids), "boundary_pids": sorted(ad.boundary_pids),
                          "skill_use_ids": sorted(ad.skill_use_ids), "src_tool_links": sorted(ad.src_tool_links),
                          "dangling": sorted(ad.dangling)},
@@ -4225,6 +4562,7 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False):
         except OSError:
             return skip("write")
         entry["docWritten"] = True
+        entry["docTurns"] = bool(turns_doc)              # the turns section was written (T323 stage 4c)
         with _ASM_CKPT_LOCK:
             _ASM_CKPT_STATS["written"] += 1
         return True
@@ -4401,9 +4739,21 @@ def _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index,
     try:
         seed, landed = _seed_from_doc(doc)
         fsids = list(doc.get("fsids") or [])
-        prefix = _restore_prefix_atoms(doc["atoms"], rompuuid, doc["records"], fsids)
-        if _pre_tree_identity(prefix, rompuuid) != doc.get("identity"):
-            _asm_ckpt_note(leaf_path, "identity"); return None
+        pre_turns, prefix = [], []
+        if doc.get("turns"):
+            # the lazy index (T323 stage 4c): the turns from the section, their atoms built on demand; the section's own
+            # digest proves it is the one the writer verified against the whole parse (no atom built here)
+            if _tree_identity_of_doc(doc["turns"], doc.get("identity")) != doc.get("treeIdentity"):
+                _asm_ckpt_note(leaf_path, "identity"); return None
+            index = LazyIndex(doc, rompuuid, leaf_path)
+            pre_turns = _pre_turns_of(doc, index)
+            doc["atoms"] = None                                # the rows live in the index as bytes from here
+            with _MAT_LOCK:
+                _ASM_INDEX_STATS["restoredTurns"] += len(pre_turns)
+        else:
+            prefix = _restore_prefix_atoms(doc["atoms"], rompuuid, doc["records"], fsids)
+            if _pre_tree_identity(prefix, rompuuid) != doc.get("identity"):
+                _asm_ckpt_note(leaf_path, "identity"); return None
         ad = FileAdapter(candidate_files, leaf_path, resume_links=links, seed=seed)
         ad.sdk_human = sdk_human
         st = _emit_state()
@@ -4415,7 +4765,7 @@ def _asm_restore(key, leaf_path, candidate_files, links, rompuuid, postal_index,
         atoms += ad._absorbed(ad.qatts, kept, st, rompuuid, postal_index)
         entry = {"ad": ad, "st": st, "atoms": atoms, "kept": kept, "landed": landed | ad.landed_text_uuids(),
                  "cands": tuple(str(f) for f in candidate_files), "links": dict(links or {}),
-                 "recs": dict(ad._src_keys), "n_qatts": len(ad.qatts), "prefix": prefix,
+                 "recs": dict(ad._src_keys), "n_qatts": len(ad.qatts), "prefix": prefix, "preTurns": pre_turns,
                  "skipped": {f["path"]: (f["size"], f["mtime"]) for f in doc["files"].values() if f.get("skip")}}
     except Exception as e:                                     # noqa: BLE001 — a document the code cannot use is a fallback
         _asm_ckpt_note(leaf_path, "restore", repr(e)[:120]); return None
@@ -4554,7 +4904,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
         cut_t = None
         if leaf_override in ad.by_uuid:
             cut_t = ad.ts_of.get(leaf_override)
-        return ad.atoms(rompuuid, postal_index), ad.landed_text_uuids(), cut_t, dict(getattr(ad, "skill_loads", None) or {})
+        return ad.atoms(rompuuid, postal_index), ad.landed_text_uuids(), cut_t, dict(getattr(ad, "skill_loads", None) or {}), []
     key = (os.path.realpath(str(leaf_path)), str(rompuuid), bool(sdk_human))
     try:
         with _asm_key_lock(key):
@@ -4600,7 +4950,7 @@ def _assemble(leaf_path, candidate_files, links, rompuuid, postal_index, sdk_hum
             _ASM_CACHE.pop(key, None)
         ad = FileAdapter(candidate_files, leaf_path, resume_links=links)
         ad.sdk_human = sdk_human
-        return ad.atoms(rompuuid, postal_index), ad.landed_text_uuids(), None, dict(getattr(ad, "skill_loads", None) or {})
+        return ad.atoms(rompuuid, postal_index), ad.landed_text_uuids(), None, dict(getattr(ad, "skill_loads", None) or {}), []
 
 
 def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None,
@@ -4644,9 +4994,16 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     # The assembly cache serves/folds/rebuilds as the gates decide — a streamed append folds only
     # the new records through the shared emit code; everything else is a full parse. atoms/landed
     # come back caller-owned (fresh top-level dicts), so the mutations below never reach the cache.
-    atoms, landed, cut_t, skill_loads = _assemble(leaf_path, candidate_files, links, rompuuid,
-                                     postal_index, sdk_human, leaf_override, mode_out=asm_mode_out)
-    orphans = synthesize_orphans(_srows, atoms, landed_text_uuids=landed, rompuuid=rompuuid)
+    atoms, landed, cut_t, skill_loads, pre_turns = _assemble(leaf_path, candidate_files, links, rompuuid,
+                                                postal_index, sdk_human, leaf_override, mode_out=asm_mode_out)
+    # a restored tree's pre-cut turns (T323 stage 4c) come whole from the document, their synthesized atoms included; the
+    # tail alone is segmented and synthesized over below, and a span or a marker from before the tail's first atom is the
+    # document's (or nothing: the whole parse put it in a pre-cut turn)
+    t_tail0 = min((a["t"] for a in atoms if a.get("t")), default=None) if pre_turns else None
+    orphans = synthesize_orphans(_srows, atoms, landed_text_uuids=landed, rompuuid=rompuuid,
+                                 pre=(pre_turns if pre_turns else None))
+    if pre_turns:
+        orphans = [a for a in orphans if t_tail0 is not None and a["t"] >= t_tail0]
     #                                            # salvaged replies FIRST: they are real atoms the turn
     #                                              grouping must absorb (idle spans overlay afterwards)
     # A salvaged reply has NO position in the transcript graph — that absence is the very thing the
@@ -4660,9 +5017,13 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     if cut_t:
         orphans = [a for a in orphans if a["t"] <= cut_t]
     atoms += orphans
-    atoms += synthesize_idle(_srows, atoms, now)
-    turns = segment_turns(atoms, rompuuid)
-    for turn in turns:
+    idle = synthesize_idle(_srows, atoms, now)
+    if pre_turns:
+        idle = [a for a in idle if t_tail0 is not None and a["t"] >= t_tail0]
+    atoms += idle
+    tail_turns = segment_turns(atoms, rompuuid) if atoms else []
+    turns = list(pre_turns) + tail_turns
+    for turn in tail_turns:
         for a in turn["atoms"]:
             a.pop("_seq", None)
         turn_keys = {"id": turn["id"], "trigger": turn["trigger"], "t": turn["t"],
@@ -4672,10 +5033,13 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     # the cut turn (T323 stage 4b): the first turn after the last one holding a lazy (pre-cut) atom, taken here before
     # any consumer hydrates; 0 for a whole parse. The chat build renders from it (its render floor).
     cut_turn = 0
-    for _i in range(len(turns) - 1, -1, -1):
-        if any(a.get("lazy") is not None for a in turns[_i]["atoms"]):
-            cut_turn = min(_i + 1, len(turns) - 1)
-            break
+    if pre_turns:
+        cut_turn = min(len(pre_turns), len(turns) - 1)   # the first tail turn (stage 4c: the pre-cut turns are the index's)
+    else:
+        for _i in range(len(turns) - 1, -1, -1):
+            if any(a.get("lazy") is not None for a in turns[_i]["atoms"]):
+                cut_turn = min(_i + 1, len(turns) - 1)
+                break
     out = {"rompUuid": rompuuid, "name": name or rompuuid, "dir": dir,
             "color": color, "leafFsid": leaf_path.stem, "turns": turns,
             # for the kernel chat build's own marker interleave: its dedup reads the KEPT turns
@@ -4920,7 +5284,7 @@ def main():
     session = parse_session(path, rompuuid=opts.get("rompuuid"), name=opts.get("name"),
                             states=states, now=int(time.time()))
     if mode == "--emit":
-        sys.stdout.write(json.dumps(session, indent=1, sort_keys=True))
+        sys.stdout.write(json.dumps(plain_tree(session), indent=1, sort_keys=True, default=lambda o: "<unserializable>"))   # a restored tree's pre-cut turns built plain (stage 4c)
         sys.stdout.write("\n")
     else:
         _dump(session)

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -3121,36 +3121,39 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre
     lazy = [a for a in atoms if a.get("lazy") is not None]           # atoms before an assembly checkpoint's cut: no body
     seen_uuids = {a.get("uuid") for a in atoms
                   if a.get("uuid") and (a["lazy"].get("nt") if a.get("lazy") is not None else _text_of(_content(a.get("message"))).strip())}
-    pre_rows = []                                                     # (turn, row index) of the restored pre-cut atoms (stage 4c)
-    if pre:
+    pre_rows = []                                                     # (turn, slot, row, type, has text, hash) of the restored pre-cut
+    if pre:                                                           #  atoms (stage 4c), one decode per row
         for pt in pre:
             la = pt["atoms"]
             for k, r in enumerate(la.rows()):
-                pre_rows.append((la, k, r))
-        for la, k, r in pre_rows:                                     # text-bearing uuids from the rows: no atom built
-            typ, nt = la._index.text_flags(r)
-            if nt:
-                u = la._index.uuid_of(r)
-                if u:
-                    seen_uuids.add(u)
+                typ, nt, hh = la._index.text_flags(r)
+                pre_rows.append((la, k, r, typ, nt, hh))
+                if nt:
+                    u = la._index.uuid_of(r)                           # text-bearing uuids from the rows: no atom built
+                    if u:
+                        seen_uuids.add(u)
     disk_texts = [t for a in atoms if a.get("type") == "assistant" and a.get("lazy") is None
                   if (t := _text_of(_content(a.get("message"))).strip())]
     older = [None]                                                    # the lazy assistants' texts, hydrated once, only if a marker needs them
 
-    pre_hashes = None                                                 # the pre-cut assistants' text hashes (lz.h): an exact match
+    pre_hashes = {hh for la, k, r, typ, nt, hh in pre_rows if typ == "assistant" and hh}   # the pre-cut ASSISTANTS' text hashes
+    pre_texts = [None]                                                # …and their texts, built and hydrated only if a marker needs them
 
     def _pre_exact(txt):
-        """Whether a pre-cut assistant kept exactly `txt`, from the rows' text hashes: no atom built, no body read (the
-        restored parse's bound, review round 2 M2; a marker whose text is a strict PREFIX of a pre-cut reply is not
-        matched here, where a whole parse would have dropped it: the chat's near-window dedup of the note stands)."""
-        nonlocal pre_hashes
-        if pre_hashes is None:
-            pre_hashes = set()
-            for la, k, r in pre_rows:
-                hh = la._index.text_hash(r)
-                if hh:
-                    pre_hashes.add(hh)
+        """Whether a pre-cut assistant kept exactly `txt`, from the rows' hashes: no atom built (a user prompt or a command
+        with the same text is not a kept reply, so only assistants count: round 3 M2a)."""
         return hashlib.sha1(txt.encode("utf-8", "replace")).hexdigest()[:8] in pre_hashes
+
+    def _pre_texts():
+        """The pre-cut assistants' texts for the either-way prefix rule the whole parse applies (round 3 M2b): built and
+        hydrated once, only when a tail marker survived the cheaper checks (the t_floor filter above keeps this off every
+        parse with no marker the tail can hold)."""
+        if pre_texts[0] is None:
+            las = [la[k] for la, k, r, typ, nt, hh in pre_rows if typ == "assistant" and nt]
+            if las:
+                hydrate(las, rompuuid or (atoms[0].get("session_id") if atoms else None), by="synthesize_orphans")
+            pre_texts[0] = [t for a in las if (t := _text_of(_content(a.get("message"))).strip())]
+        return pre_texts[0]
 
     def _older_texts():
         if older[0] is None:
@@ -3185,8 +3188,8 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre
             continue
         if lazy and any(dt.startswith(txt) or txt.startswith(dt) for dt in _older_texts()):
             continue                                                   # a reply the disk kept before the cut
-        if pre_rows and _pre_exact(txt):
-            continue                                                   # …or the index kept, exactly (by hash: no atom built)
+        if pre_rows and (_pre_exact(txt) or any(dt.startswith(txt) or txt.startswith(dt) for dt in _pre_texts())):
+            continue                                                   # …or the index kept, exactly (by hash) or as a prefix either way
         out.append({"type": "assistant", "uuid": u or ("orphan:%d" % int(r["t"])), "session_id": sid,
                     "t": int(r["t"]), "fsid": None, "parentUuid": None, "orphaned": True,
                     "message": {"role": "assistant", "content": [{"type": "text", "text": txt}],
@@ -4090,34 +4093,23 @@ class LazyIndex:
             return self.records[ri][0]
         return (row.get("s") or {}).get("uuid")
 
-    def text_hash(self, k):
-        """A row's text hash (lz.h: the first eight hex of sha1 over the text) without building its atom; None for a row
-        with no lazy marker (a synthesized atom: its message is inline and hashed here)."""
-        with _MAT_LOCK:
-            _ASM_INDEX_STATS["rowDecodes"] += 1
-        row = json.loads(self.rowb[k])
-        lz = row.get("lz")
-        if lz is not None:
-            return lz.get("h") if lz.get("nt") else None
-        if row.get("syn") and "m" in row:
-            txt = _text_of(_content(row["m"])).strip()
-            return hashlib.sha1(txt.encode("utf-8", "replace")).hexdigest()[:8] if txt else None
-        return None
-
     def text_flags(self, k):
-        """(type, has text) for a row without building its atom: what an orphan marker's dedup reads."""
+        """(type, has text, text hash) for a row without building its atom, one decode: what an orphan marker's dedup reads.
+        The hash is lz.h (the first eight hex of sha1 over the text) for a lazy row, the same digest over an inline message
+        for a synthesized or inline row; None without text."""
         with _MAT_LOCK:
             _ASM_INDEX_STATS["rowDecodes"] += 1
         row = json.loads(self.rowb[k])
         ri = row.get("r")
+        lz = row.get("lz")
         tname = {"u": "user", "a": "assistant", "s": "system"}
         typ = (row.get("s") or {}).get("type") or (tname.get(self.records[ri][2], "user") if ri is not None else None)
-        lz = row.get("lz")
         if lz is not None:
-            return typ, bool(lz.get("nt"))
-        if row.get("syn") and "m" in row:
-            return typ, bool(_text_of(_content(row["m"])).strip())
-        return typ, False
+            return typ, bool(lz.get("nt")), (lz.get("h") if lz.get("nt") else None)
+        if "m" in row:
+            txt = _text_of(_content(row["m"])).strip()
+            return typ, bool(txt), (hashlib.sha1(txt.encode("utf-8", "replace")).hexdigest()[:8] if txt else None)
+        return typ, False, None
 
 
 class LazyAtoms(list):
@@ -4584,8 +4576,12 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                 row["r"] = ri
             if a.get("_seq", sq) != sq:
                 row["seq"] = a.get("_seq", sq)             # an adopted boundary's emit order differs from its read order
-            if kind in _LAZY_KINDS:
+            if kind in _LAZY_KINDS and idx >= 0 and fp is not None:
                 row["lz"] = _lazy_of(a, kind, idx)
+            elif kind in _LAZY_KINDS:                          # no record to read back (an absorbed attachment with no uuid, round 3):
+                row["m"] = a.get("message")                    #  the body rides inline, never a lazy marker hydrate cannot fill
+                if "toolUseResult" in a:
+                    row["tur"] = a["toolUseResult"]
             pre_atoms.append(row)
         # the pre-cut spine, root to cut
         chain, u, guard_n = [], ad.leaf_uuid, 0
@@ -4645,6 +4641,8 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                 for a in turn["atoms"]:
                     u_ = a.get("uuid")
                     k_ = row_of_atom.get(u_) if u_ else row_of_scalars.pop(json.dumps(_atom_scalars(a), sort_keys=True, default=str), None)
+                    #  (two uuid-less attachments in one turn with the same enqueue stamp collide on the scalar key: the second
+                    #   finds no row, the walk mints a synthesized one, and the coverage check refuses the section cleanly)
                     if k_ is None:
                         if u_ in ad.seq_of:
                             return skip("turnRows")      # a record atom with no row of its own: the tree and the entry disagree
@@ -4782,6 +4780,10 @@ def _restore_prefix_atoms(pre_atoms, rompuuid, rows, fsids):
         if lz is not None:
             a["lazy"] = dict(lz, i=row["i"], at=tuple(row["at"]) if row.get("at") else None)
             a["message"] = _LazyBody(a.get("uuid"))
+        elif "m" in row:                                  # an inline body: an emitted atom with no record behind it (round 3)
+            a["message"] = row["m"]
+            if "tur" in row:
+                a["toolUseResult"] = row["tur"]
         out.append(a)
     return out
 

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -3007,7 +3007,7 @@ def synthesize_idle(states, atoms, now):
     return out
 
 
-def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre=None):
+def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre=None, t_floor=None):
     """Salvaged assistant replies from orphanReply markers in states/<sid>.jsonl — text that STREAMED
     live but the transcript never kept (an API-errored try; the SDK backend persists it at settle,
     see its append_orphan_reply). The kernel's chat build has interleaved these since 2026-07-21, but
@@ -3029,6 +3029,8 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre
     consumed, since the atoms-only dedup below can no longer see the abandoned record)."""
     if not atoms:
         return []
+    if t_floor is not None:                                           # a restored parse: only a marker the tail can hold counts (the
+        states = [r for r in states or [] if isinstance(r, dict) and (r.get("t") or 0) >= t_floor]   #  caller discards the rest)
     if not any(isinstance(r, dict) and r.get("t") and isinstance(r.get("orphanReply"), dict) for r in states or []):
         return []                                                     # no marker: nothing to salvage, and no pre-cut row decoded
     # TEXT-BEARING uuids only (the user 2026-07-28): a marker whose uuid the disk knows solely as a
@@ -3056,13 +3058,24 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre
                   if (t := _text_of(_content(a.get("message"))).strip())]
     older = [None]                                                    # the lazy assistants' texts, hydrated once, only if a marker needs them
 
+    pre_hashes = None                                                 # the pre-cut assistants' text hashes (lz.h): an exact match
+
+    def _pre_exact(txt):
+        """Whether a pre-cut assistant kept exactly `txt`, from the rows' text hashes: no atom built, no body read (the
+        restored parse's bound, review round 2 M2; a marker whose text is a strict PREFIX of a pre-cut reply is not
+        matched here, where a whole parse would have dropped it: the chat's near-window dedup of the note stands)."""
+        nonlocal pre_hashes
+        if pre_hashes is None:
+            pre_hashes = set()
+            for la, k, r in pre_rows:
+                hh = la._index.text_hash(r)
+                if hh:
+                    pre_hashes.add(hh)
+        return hashlib.sha1(txt.encode("utf-8", "replace")).hexdigest()[:8] in pre_hashes
+
     def _older_texts():
         if older[0] is None:
             las = [a for a in lazy if a.get("type") == "assistant" and a["lazy"].get("nt")]
-            for la, k, r in pre_rows:                                 # the index's assistants with text: built and hydrated only now
-                typ, nt = la._index.text_flags(r)
-                if typ == "assistant" and nt:
-                    las.append(la[k])
             if las:
                 hydrate(las, rompuuid or (atoms[0].get("session_id") if atoms else None))
             older[0] = [t for a in las if (t := _text_of(_content(a.get("message"))).strip())]
@@ -3091,8 +3104,10 @@ def synthesize_orphans(states, atoms, landed_text_uuids=None, rompuuid=None, pre
             continue
         if any(dt.startswith(txt) or txt.startswith(dt) for dt in disk_texts):
             continue
-        if (lazy or pre_rows) and any(dt.startswith(txt) or txt.startswith(dt) for dt in _older_texts()):
+        if lazy and any(dt.startswith(txt) or txt.startswith(dt) for dt in _older_texts()):
             continue                                                   # a reply the disk kept before the cut
+        if pre_rows and _pre_exact(txt):
+            continue                                                   # …or the index kept, exactly (by hash: no atom built)
         out.append({"type": "assistant", "uuid": u or ("orphan:%d" % int(r["t"])), "session_id": sid,
                     "t": int(r["t"]), "fsid": None, "parentUuid": None, "orphaned": True,
                     "message": {"role": "assistant", "content": [{"type": "text", "text": txt}],
@@ -3996,6 +4011,20 @@ class LazyIndex:
             return self.records[ri][0]
         return (row.get("s") or {}).get("uuid")
 
+    def text_hash(self, k):
+        """A row's text hash (lz.h: the first eight hex of sha1 over the text) without building its atom; None for a row
+        with no lazy marker (a synthesized atom: its message is inline and hashed here)."""
+        with _MAT_LOCK:
+            _ASM_INDEX_STATS["rowDecodes"] += 1
+        row = json.loads(self.rowb[k])
+        lz = row.get("lz")
+        if lz is not None:
+            return lz.get("h") if lz.get("nt") else None
+        if row.get("syn") and "m" in row:
+            txt = _text_of(_content(row["m"])).strip()
+            return hashlib.sha1(txt.encode("utf-8", "replace")).hexdigest()[:8] if txt else None
+        return None
+
     def text_flags(self, k):
         """(type, has text) for a row without building its atom: what an orphan marker's dedup reads."""
         with _MAT_LOCK:
@@ -4175,6 +4204,7 @@ def _tree_identity_of_doc(turns_doc, identity):
             h.update(sg[0].encode()); h.update(b",")
         for u in td["uuids"]:
             h.update((u or "").encode()); h.update(b";")
+        h.update(",".join(str(k) for k in td["atoms"]).encode()); h.update(b"/")   # the rows each turn holds (a permuted section differs)
     return h.hexdigest()
 
 
@@ -4513,12 +4543,15 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
         # with its message inline. The section stops at the first turn holding a post-cut record (the cut is a turn
         # boundary: the chronological split above put every pre-cut record before every post-cut one).
         turns_doc = None
+        n0 = len(pre_atoms)                               # the rows the walk appends leave with a refusal (review round 2, M1)
         if tree is not None:
-            row_of_atom = {}
+            row_of_atom, row_of_scalars = {}, {}
             for k_, row_ in enumerate(pre_atoms):
                 u_ = rows[row_["r"]][0] if "r" in row_ else (row_.get("s") or {}).get("uuid")
                 if u_ and u_ not in row_of_atom:
                     row_of_atom[u_] = k_
+                elif not u_ and "r" not in row_:            # a uuid-less absorbed atom (a queued_command attachment): its row is
+                    row_of_scalars.setdefault(json.dumps(row_.get("s") or {}, sort_keys=True, default=str), k_)   #  found by its scalars
             turns_doc = []
             cut_ts = min((ad.ts_of.get(u, 0) for u in entry["kept"] if ad.seq_of.get(u, 0) >= cut_seq), default=None)
             for turn in tree.get("turns") or []:
@@ -4532,7 +4565,7 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                 idxs = []
                 for a in turn["atoms"]:
                     u_ = a.get("uuid")
-                    k_ = row_of_atom.get(u_) if u_ else None
+                    k_ = row_of_atom.get(u_) if u_ else row_of_scalars.pop(json.dumps(_atom_scalars(a), sort_keys=True, default=str), None)
                     if k_ is None:
                         if u_ in ad.seq_of:
                             return skip("turnRows")      # a record atom with no row of its own: the tree and the entry disagree
@@ -4568,6 +4601,7 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
                 turns_doc = None
             if not turns_doc:
                 turns_doc = None                          # nothing before the cut in this tree: the atoms-only form
+                del pre_atoms[n0:]                        # …whose rows are the emit's alone, the identity's count (M1)
         doc = {"av": _ASM_CKPT_V, "path": os.path.realpath(str(leaf_path)), "rompuuid": str(rompuuid), "sdkHuman": bool(sdk_human),
                "cands": list(entry["cands"]), "links": dict(entry["links"]), "files": files, "fsids": fsids, "cutSeq": cut_seq,
                "records": rows, "atoms": pre_atoms, "spine": spine, "seqTs": seq_ts, "lastTs": last_ts,
@@ -5037,7 +5071,7 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
     # document's (or nothing: the whole parse put it in a pre-cut turn)
     t_tail0 = min((a["t"] for a in atoms if a.get("t")), default=None) if pre_turns else None
     orphans = synthesize_orphans(_srows, atoms, landed_text_uuids=landed, rompuuid=rompuuid,
-                                 pre=(pre_turns if pre_turns else None))
+                                 pre=(pre_turns if pre_turns else None), t_floor=t_tail0 if pre_turns else None)
     if pre_turns:
         orphans = [a for a in orphans if t_tail0 is not None and a["t"] >= t_tail0]
     #                                            # salvaged replies FIRST: they are real atoms the turn

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -536,6 +536,7 @@ class _PerfStats:
                 # T323 stage 4a: the assembly documents: written, restored, fallbacks per reason, skips per reason (noEntry,
                 # restored, noBoundary, unsplittable, oversize, ...), hydrated bodies and bytes since boot
                 "asmCheckpoint": em.asm_checkpoint_stats(),
+                "asmIndex": em.asm_index_stats(),          # the lazy index (T323 stage 4c): atoms built, by caller, resident
                 "chatPages": dict(_PAGE_STATS)}   # the pre-floor history pages (T323 stage 4b): hits, misses, evictions, resident
 
 
@@ -9112,8 +9113,9 @@ def _persist_checkpoints(now):
         if mine:
             written += em.checkpoint_write_dirty(sorted(mine))
         try:                                   # the assembly document for the leaf (T323 stage 4a): from a whole entry
-            if em.asm_checkpoint_write(leaf, sid, _display_sdk_human(sid)):   # with a compaction boundary, else a
-                written += 1                   #  counted skip; the tree it comes from is the store's live tree
+            if em.asm_checkpoint_write(leaf, sid, _display_sdk_human(sid), tree=_parse(leaf, sid, now)):   # with a compaction
+                written += 1                   #  boundary, else a counted skip; the store's live tree gives the document its
+        #                                          turns section (T323 stage 4c: a restore builds the turns without an atom)
         except Exception:
             sys.stderr.write("assembly checkpoint: %s\n" % traceback.format_exc())
         _CKPT_SETTLE_SEEN[sid] = key
@@ -26728,6 +26730,8 @@ def _fold_tasks(session, sid=None):
         if ent is not None and ent[0] is atoms and ent[1] == fp:
             _chat_memo_bump(_task_fold_stats, "hit")
             part = ent[2]
+        elif turn.get("pre") and not any(n in ("TaskCreate", "TaskUpdate") for _i, n in turn.get("tools") or ()):
+            part = ({}, set(), [])                       # a restored pre-cut turn with no task call: nothing built (stage 4c)
         else:
             _chat_memo_bump(_task_fold_stats, "miss")
             part = _fold_tasks_turn(atoms)
@@ -27221,6 +27225,13 @@ def _cursors_before(turns, k, note_lists, model0):
     turns' scalars alone (uuid, t, the lazy model stamp): no body is read."""
     last_t, tmax, last_model = None, None, model0
     for t in turns[:k]:
+        if t.get("pre"):                                  # a restored pre-cut turn (T323 stage 4c): its own scalars, no atom built
+            if t.get("lastT"):
+                last_t = t["lastT"]
+                tmax = t["maxT"] if tmax is None else max(tmax, t["maxT"])
+            if t.get("lastModel"):
+                last_model = t["lastModel"]
+            continue
         for a in t.get("atoms") or []:
             at = a.get("t")
             if at:
@@ -27288,6 +27299,9 @@ def _chat_turn_fp(turn):
     """A cheap per-turn fingerprint: the turn's identity plus its atom count and end. A fold (the
     parse's own append path) only ever ADDS atoms, so any change to an earlier turn's atoms shows
     up here as a count or an end that moved; a full parse is excluded upstream by _parse_mode."""
+    if turn.get("pre"):                                   # a restored pre-cut turn (T323 stage 4c): the same tuple from its scalars
+        us = turn.get("uuids") or []
+        return (turn.get("id"), len(us), us[0] if us else None, us[-1] if us else None, turn.get("lastT"), bool(turn.get("ended")))
     atoms = turn.get("atoms") or []
     return (turn.get("id"), len(atoms), atoms[0].get("uuid") if atoms else None,
             atoms[-1].get("uuid") if atoms else None, atoms[-1].get("t") if atoms else None,
@@ -31827,6 +31841,8 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
     gestures = _past_floor(_cmd_gestures(sid)); _cgi = 0
     _live_cmd_keys = set()
     for _t in session["turns"]:
+        if _t.get("pre"):
+            continue                              # a live chip rides the backend's live tail, never a pre-cut turn (stage 4c: no atom built)
         for _a in _t["atoms"]:
             if _a.get("command") and _a.get("_echo_text"):
                 _live_cmd_keys.add((int(_a.get("t") or 0), _a["_echo_text"]))
@@ -40845,6 +40861,10 @@ def _turn_of_uuid(turns, uuid):
     if base.startswith("branch:"):                     # a fork's departure chip sits after its cut event
         base = base[len("branch:"):]
     for i, t in enumerate(turns):
+        if t.get("pre"):                                  # a restored pre-cut turn (T323 stage 4c): its uuids, no atom built
+            if base in (t.get("uuids") or ()):
+                return i
+            continue
         for a in t.get("atoms") or []:
             if a.get("uuid") == base:
                 return i
@@ -40852,6 +40872,10 @@ def _turn_of_uuid(turns, uuid):
     if m:
         nt = int(m.group(2))
         for i, t in enumerate(turns):
+            if t.get("pre"):
+                if (t.get("maxT") or 0) >= nt:
+                    return i
+                continue
             if any((a.get("t") or 0) >= nt for a in t.get("atoms") or []):
                 return i
         return len(turns) - 1 if turns else None
@@ -41082,8 +41106,7 @@ def _turn_index_of_events(evs, turns):
     it, the head cards -1), so a slice of the list can be snapped to turn boundaries (review find J)."""
     u2t = {}
     for i, t in enumerate(turns):
-        for a in t.get("atoms") or []:
-            u = a.get("uuid")
+        for u in (t.get("uuids") if t.get("pre") else (a.get("uuid") for a in t.get("atoms") or [])):   # a pre-turn's uuids: no atom built
             if u and u not in u2t:
                 u2t[u] = i
     out, cur = [], -1
@@ -56129,9 +56152,11 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     except Exception:
         pass
     try:                                  # the assembly documents of every session's leaf (T323 stage 4a): a whole entry
-        for _s in _drain_sessions:        # with a boundary writes, the rest are counted skips; bounded by the drain
-            em.asm_checkpoint_write(_s["path"], _s["sid"], _display_sdk_human(_s["sid"]))
-    except Exception:
+        _asm_t0 = time.monotonic()        # with a boundary writes, the rest are counted skips; bounded by the drain. The
+        for _s in _drain_sessions:        # store's tree gives the turns section (stage 4c) while a 2 s budget holds; past it
+            _tree = _parse(_s["path"], _s["sid"], int(time.time())) if time.monotonic() - _asm_t0 < 2.0 else None   # a turnless
+            em.asm_checkpoint_write(_s["path"], _s["sid"], _display_sdk_human(_s["sid"]), tree=_tree)   # document, rewritten
+    except Exception:                     #  with its turns at the next settle after the boot
         pass
     try:
         if be is not None and hasattr(be, "drain"):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9092,6 +9092,18 @@ def _prime_leaf_folds(leaf):
     return primed
 
 
+def _stored_tree(path, sid):
+    """The parse store's tree for a session's leaf when it holds one (the kernel's display parse under its own human flag,
+    else the judges'), never a parse of its own: the assembly writer takes it for the document's turns section (T323
+    stage 4c), and a settle over a session no build has parsed writes the atoms-only form rather than read the leaf whole."""
+    try:
+        cut = jd._pending_cut(sid)
+        hit = jd._parse_slot(sid, cut, path, _display_sdk_human(sid)) or jd._parse_slot(sid, cut, path, None)
+    except Exception:
+        return None
+    return hit[1] if hit else None
+
+
 def _persist_checkpoints(now):
     """Write the fold checkpoints whose files belong to a session with NEW settle evidence: its turn-end key (the
     Stop hook's lastStopAt, else a stopped states transition) or its states log's stat moved since the last write for
@@ -9113,9 +9125,10 @@ def _persist_checkpoints(now):
         if mine:
             written += em.checkpoint_write_dirty(sorted(mine))
         try:                                   # the assembly document for the leaf (T323 stage 4a): from a whole entry
-            if em.asm_checkpoint_write(leaf, sid, _display_sdk_human(sid), tree=_parse(leaf, sid, now)):   # with a compaction
-                written += 1                   #  boundary, else a counted skip; the store's live tree gives the document its
-        #                                          turns section (T323 stage 4c: a restore builds the turns without an atom)
+            if em.asm_checkpoint_write(leaf, sid, _display_sdk_human(sid), tree=_stored_tree(leaf, sid)):   # with a compaction
+                written += 1                   #  boundary, else a counted skip; the store's tree, when it holds one, gives the
+        #                                          document its turns section (T323 stage 4c: a restore builds the turns without an
+        #                                          atom); never a parse of its own (the settle reads no leaf whole)
         except Exception:
             sys.stderr.write("assembly checkpoint: %s\n" % traceback.format_exc())
         _CKPT_SETTLE_SEEN[sid] = key
@@ -56154,9 +56167,9 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     try:                                  # the assembly documents of every session's leaf (T323 stage 4a): a whole entry
         _asm_t0 = time.monotonic()        # with a boundary writes, the rest are counted skips; bounded by the drain. The
         for _s in _drain_sessions:        # store's tree gives the turns section (stage 4c) while a 2 s budget holds; past it
-            _tree = _parse(_s["path"], _s["sid"], int(time.time())) if time.monotonic() - _asm_t0 < 2.0 else None   # a turnless
-            em.asm_checkpoint_write(_s["path"], _s["sid"], _display_sdk_human(_s["sid"]), tree=_tree)   # document, rewritten
-    except Exception:                     #  with its turns at the next settle after the boot
+            _tree = _stored_tree(_s["path"], _s["sid"]) if time.monotonic() - _asm_t0 < 2.0 else None   # a turnless document is
+            em.asm_checkpoint_write(_s["path"], _s["sid"], _display_sdk_human(_s["sid"]), tree=_tree)   # rewritten with its turns
+    except Exception:                     #  at the next settle after the boot
         pass
     try:
         if be is not None and hasattr(be, "drain"):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31409,6 +31409,10 @@ def _place_stale_echoes(turns, echoes):
     scan of every atom (three merges per push cycle while a dropped echo exists)."""
     out = list(turns)
     key = lambda a: (a.get("t", 0), a.get("_seq", 0))
+    # a restored pre-cut turn (T323 stage 4c) takes no echo: its atoms are the document's, its segment spans written, and
+    # a synthetic turn inserted among them would move the render floor's index; an echo whose time falls in the pre-cut
+    # history goes into the FIRST post-cut turn instead (review low 3)
+    first_tail = next((k for k, turn in enumerate(out) if not turn.get("pre")), None)
     gaps = {}                                   # insertion index in `turns` → the echoes sent in that gap
     dest = []                                   # (the destination turn dict, echo) per echo, resolved to indexes below
     copied = set()                              # turns copied for a write: ONCE each, so every echo destined for the
@@ -31423,7 +31427,9 @@ def _place_stale_echoes(turns, echoes):
                 i = k
             else:
                 break
-        if i is not None and t <= _turn_activity_end(out[i]):
+        if i is not None and out[i].get("pre"):
+            i = first_tail                      # into the first post-cut turn, whatever its window
+        if i is not None and (out[i].get("t", 0) > t or t <= _turn_activity_end(out[i])):
             if i not in copied:
                 out[i] = dict(out[i])
                 copied.add(i)
@@ -31434,6 +31440,15 @@ def _place_stale_echoes(turns, echoes):
             gaps.setdefault(0 if i is None else i + 1, []).append(a)
     for idx in sorted(gaps, reverse=True):      # back to front, so earlier indices stay valid
         atoms = sorted(gaps[idx], key=key)
+        if first_tail is not None and idx <= first_tail and first_tail < len(out) and out[first_tail].get("echoTurn") is None \
+                and any(turn.get("pre") for turn in out[:idx]):
+            k = first_tail                      # a gap among the pre-cut turns: the echoes join the first post-cut turn
+            if k not in copied:
+                out[k] = dict(out[k]); copied.add(k)
+            out[k]["atoms"] = sorted(list(out[k]["atoms"]) + atoms, key=key)
+            out[k]["placedEchoes"] = list(out[k].get("placedEchoes") or []) + [a.get("uuid") for a in atoms]
+            dest.extend((out[k], a) for a in atoms)
+            continue
         turn = {"id": "live-" + str(atoms[0].get("uuid") or atoms[0].get("t", 0)), "trigger": None,
                 "t": atoms[0].get("t", 0), "end": atoms[-1].get("t", 0), "ended": True, "atoms": atoms,
                 "echoTurn": True, "placedEchoes": [a.get("uuid") for a in atoms]}

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -31440,9 +31440,9 @@ def _place_stale_echoes(turns, echoes):
             gaps.setdefault(0 if i is None else i + 1, []).append(a)
     for idx in sorted(gaps, reverse=True):      # back to front, so earlier indices stay valid
         atoms = sorted(gaps[idx], key=key)
-        if first_tail is not None and idx <= first_tail and first_tail < len(out) and out[first_tail].get("echoTurn") is None \
-                and any(turn.get("pre") for turn in out[:idx]):
-            k = first_tail                      # a gap among the pre-cut turns: the echoes join the first post-cut turn
+        if first_tail is not None and 0 < first_tail and idx <= first_tail:
+            k = first_tail                      # a gap at or before the first post-cut turn (idx 0 included: ahead of every
+            #                                     pre-cut turn): the echoes join that turn, no synthetic turn among the pre-cut ones
             if k not in copied:
                 out[k] = dict(out[k]); copied.add(k)
             out[k]["atoms"] = sorted(list(out[k]["atoms"]) + atoms, key=key)

--- a/scripts/bench_asm_checkpoint.py
+++ b/scripts/bench_asm_checkpoint.py
@@ -132,6 +132,8 @@ now = time.time()
 r0 = rss()
 modes = []
 trees = {}                                                          # the boot's trees, for the documents' turns sections (stage 4c)
+import inspect
+_tree_arg = hasattr(em, "asm_checkpoint_write") and "tree" in inspect.signature(em.asm_checkpoint_write).parameters   # main before 4c: no tree=
 for sid in sids:
     leaf = os.path.join(proj, sid + ".jsonl")
     m = []
@@ -156,7 +158,7 @@ if phase == "first":
     if hasattr(em, "asm_checkpoint_write"):
         for sid in sids:                                        # under the key the judges' parse used (their sdk_human answer)
             t_w = time.time()
-            written += 1 if em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)), tree=trees.get(sid)) else 0
+            written += 1 if em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)), **({"tree": trees.get(sid)} if _tree_arg else {})) else 0
             write_ms += (time.time() - t_w) * 1000.0            # the per-document write cost (once per whole parse, item L)
 stats = em.asm_checkpoint_stats() if hasattr(em, "asm_checkpoint_stats") else {}
 print(json.dumps({"phase": phase, "byClass": by, "total": sum(by.values()), "rssBytes": r1, "rssDelta": r1 - r0,

--- a/scripts/bench_asm_checkpoint.py
+++ b/scripts/bench_asm_checkpoint.py
@@ -131,10 +131,11 @@ def rss():
 now = time.time()
 r0 = rss()
 modes = []
+trees = {}                                                          # the boot's trees, for the documents' turns sections (stage 4c)
 for sid in sids:
     leaf = os.path.join(proj, sid + ".jsonl")
     m = []
-    jd.parsed_session(sid, [leaf], now, asm_mode_out=m); modes += m   # the judges' parse
+    trees[sid] = jd.parsed_session(sid, [leaf], now, asm_mode_out=m); modes += m   # the judges' parse
     km._states_awaiting_overlay(sid); km._last_machine_cut(sid); km._last_state(sid); km._state_intervals(sid, "working", now)
     km._bg_scan_cached(leaf); km._bg_scan_all_cached(leaf); km._session_meta(leaf); km._agent_launch_state(leaf)
     sub = os.path.join(proj, sid, "subagents")
@@ -155,7 +156,7 @@ if phase == "first":
     if hasattr(em, "asm_checkpoint_write"):
         for sid in sids:                                        # under the key the judges' parse used (their sdk_human answer)
             t_w = time.time()
-            written += 1 if em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid))) else 0
+            written += 1 if em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)), tree=trees.get(sid)) else 0
             write_ms += (time.time() - t_w) * 1000.0            # the per-document write cost (once per whole parse, item L)
 stats = em.asm_checkpoint_stats() if hasattr(em, "asm_checkpoint_stats") else {}
 print(json.dumps({"phase": phase, "byClass": by, "total": sum(by.values()), "rssBytes": r1, "rssDelta": r1 - r0,

--- a/scripts/bench_chat_proto2.py
+++ b/scripts/bench_chat_proto2.py
@@ -47,6 +47,8 @@ km._sessions = lambda now, **kw: list(rows)
 km._tmux_sessions = lambda: {}
 r0 = rss(); modes = []
 trees = {}                                                          # the boot's trees, for the documents' turns sections (stage 4c)
+import inspect
+_tree_arg = hasattr(em, "asm_checkpoint_write") and "tree" in inspect.signature(em.asm_checkpoint_write).parameters   # main before 4c: no tree=
 for sid in sids:                                                    # the boot: the judges' parse and the folds (as bench_asm_checkpoint)
     leaf = os.path.join(proj, sid + ".jsonl"); m = []
     trees[sid] = jd.parsed_session(sid, [leaf], now, asm_mode_out=m); modes += m
@@ -55,7 +57,7 @@ r_boot = rss(); read_boot = read_total()
 if phase == "first" and hasattr(em, "asm_checkpoint_write"):
     if hasattr(em, "checkpoint_write_dirty"): em.checkpoint_write_dirty()
     for sid in sids:
-        em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)), tree=trees.get(sid))
+        em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)), **({"tree": trees.get(sid)} if _tree_arg else {}))
 if hasattr(km, "_live_scope") and hasattr(km, "_RENDER_FLOOR"):
     km._live_scope.chat_floor0 = False                              # the pusher's decision: no proto-1 client connected
 ms, events, floors = [], 0, []

--- a/scripts/bench_chat_proto2.py
+++ b/scripts/bench_chat_proto2.py
@@ -46,15 +46,16 @@ rows = [{"sid": sid, "name": "worker", "path": os.path.join(proj, sid + ".jsonl"
 km._sessions = lambda now, **kw: list(rows)
 km._tmux_sessions = lambda: {}
 r0 = rss(); modes = []
+trees = {}                                                          # the boot's trees, for the documents' turns sections (stage 4c)
 for sid in sids:                                                    # the boot: the judges' parse and the folds (as bench_asm_checkpoint)
     leaf = os.path.join(proj, sid + ".jsonl"); m = []
-    jd.parsed_session(sid, [leaf], now, asm_mode_out=m); modes += m
+    trees[sid] = jd.parsed_session(sid, [leaf], now, asm_mode_out=m); modes += m
     km._bg_scan_cached(leaf); km._bg_scan_all_cached(leaf); km._session_meta(leaf); km._agent_launch_state(leaf)
 r_boot = rss(); read_boot = read_total()
 if phase == "first" and hasattr(em, "asm_checkpoint_write"):
     if hasattr(em, "checkpoint_write_dirty"): em.checkpoint_write_dirty()
     for sid in sids:
-        em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)))
+        em.asm_checkpoint_write(os.path.join(proj, sid + ".jsonl"), sid, bool(jd._sdk_owned(sid)), tree=trees.get(sid))
 if hasattr(km, "_live_scope") and hasattr(km, "_RENDER_FLOOR"):
     km._live_scope.chat_floor0 = False                              # the pusher's decision: no proto-1 client connected
 ms, events, floors = [], 0, []

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -64,8 +64,9 @@ def _write_doc(path, d):
 
 
 def _strip(tree):
-    """A tree as JSON compares it: lazy scalars dropped once hydrated (the whole parse never carries them)."""
-    t = json.loads(json.dumps(tree, default=lambda o: "<unserializable>"))
+    """A tree as JSON compares it: lazy scalars dropped once hydrated (the whole parse never carries them); a restored
+    tree's pre-cut turns are built into plain turns first (em.plain_tree, T323 stage 4c)."""
+    t = json.loads(json.dumps(em.plain_tree(tree), default=lambda o: "<unserializable>"))
     t.pop("cutTurn", None)                                  # where the lazy atoms ended: a restored tree's own fact (stage 4b)
     for turn in t["turns"]:
         for a in turn["atoms"]:
@@ -78,6 +79,8 @@ class Harness(unittest.TestCase):
         self.td = Path(tempfile.mkdtemp())
         self.ck = self.td / "checkpoints"
         em.set_checkpoint_dir(lambda: self.ck)
+        self.states, self.sent = None, []                       # what parse() hands the parser until write() sets them
+        self._trees = {}                                         # path → the tree parse() last returned (doc() writes with it)
         self.fresh()
         em._ASM_CKPT_STATS.update(written=0, restored=0, fallbacks={}, skipped={}, hydratedBytes=0, hydratedAtoms=0, hydratedBy={})
 
@@ -108,8 +111,16 @@ class Harness(unittest.TestCase):
         return str(p)
 
     def parse(self, path, modes=None):
-        return em.parse_session(path, rompuuid=SID, name="impl", dir="/TESTDIR", candidate_files=[path],
+        tree = em.parse_session(path, rompuuid=SID, name="impl", dir="/TESTDIR", candidate_files=[path],
                                 states=self.states, postal_log=self.sent, now=NOW, asm_mode_out=modes)
+        self._trees[path] = tree
+        return tree
+
+    def doc(self, path):
+        """The leaf's document, written from its whole entry with the tree the last parse() of that path returned (the kernel
+        hands the store's live tree, which gives the document its turns section: T323 stage 4c). A test that parsed the
+        path through em.parse_session itself gets a document with no turns section (the atoms-only form)."""
+        return em.asm_checkpoint_write(path, SID, tree=self._trees.get(path))
 
     def cold(self, path):
         self.fresh()
@@ -159,7 +170,7 @@ class RestoredEqualsWhole(Harness):
                 whole = self.cold(path)
                 self.fresh()
                 self.parse(path)                                        # the whole parse the writer works from
-                self.assertTrue(em.asm_checkpoint_write(path, SID), "a document is written: %s" % em.asm_checkpoint_stats())
+                self.assertTrue(self.doc(path), "a document is written: %s" % em.asm_checkpoint_stats())
                 doc = _doc(path)
                 self.assertGreater(len(doc["atoms"]), 0, "the cut leaves atoms before it")
                 got, modes, n_lazy = self.restored(path)
@@ -183,7 +194,7 @@ class RestoredEqualsWhole(Harness):
                 whole = self.cold(path)
                 self.fresh(); self.parse(path)
                 em._ASM_CKPT_STATS["skipped"] = {}
-                wrote = em.asm_checkpoint_write(path, SID)
+                wrote = self.doc(path)
                 if not wrote:
                     skipped[name] = dict(em.asm_checkpoint_stats()["skipped"])
                     continue
@@ -219,7 +230,7 @@ class RestoredEqualsWhole(Harness):
         finally:
             em._CKPT_DIR_FN = saved
         self.fresh(); parse()
-        self.assertTrue(em.asm_checkpoint_write(str(pb), SID), em.asm_checkpoint_stats())
+        self.assertTrue(self.doc(str(pb)), em.asm_checkpoint_stats())
         doc = _doc(str(pb))
         self.assertIn(G.FSID_A, doc["files"])
         self.fresh(); modes = []
@@ -240,7 +251,7 @@ class RestoredEqualsWhole(Harness):
         records, _ = G.SINGLE_FILE["compaction_atom"]
         recs = records()
         path = self.write("compaction_atom", recs)
-        self.fresh(); self.parse(path); self.assertTrue(em.asm_checkpoint_write(path, SID))
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
         got, modes, _ = self.restored(path)
         last = recs[-1]
         t1 = self.after(recs, 100)
@@ -259,7 +270,7 @@ class RestoredEqualsWhole(Harness):
         records, _ = G.SINGLE_FILE["compaction_atom"]
         recs = records()
         path = self.write("compaction_atom", recs)
-        self.fresh(); self.parse(path); self.assertTrue(em.asm_checkpoint_write(path, SID))
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
         self.restored(path)
         last = recs[-1]
         t1 = self.after(recs, 100)
@@ -277,7 +288,7 @@ class Fallbacks(Harness):
     def _armed(self, tag):
         records, _ = G.SINGLE_FILE["compaction_atom"]
         path = self.write("compaction_atom-" + tag, records())
-        self.fresh(); self.parse(path); self.assertTrue(em.asm_checkpoint_write(path, SID))
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
         return path
 
     def test_each_reason_falls_back_to_a_whole_parse_and_is_counted(self):
@@ -334,7 +345,7 @@ class Fallbacks(Harness):
         saved = em._ASM_CKPT_CAP
         em._ASM_CKPT_CAP = 10
         try:
-            self.assertFalse(em.asm_checkpoint_write(path, SID))
+            self.assertFalse(self.doc(path))
         finally:
             em._ASM_CKPT_CAP = saved
         self.assertEqual(em.asm_checkpoint_stats()["skipped"].get("oversize"), 1)
@@ -344,7 +355,7 @@ class Fallbacks(Harness):
         path2 = self.write("valves-order", recs)
         self.fresh(); self.parse(path2)
         em._ASM_CKPT_STATS["skipped"] = {}
-        wrote = em.asm_checkpoint_write(path2, SID)
+        wrote = self.doc(path2)
         self.assertFalse(wrote, "a pre-cut record stamped after every tail record cannot be split off")
         self.assertEqual(em.asm_checkpoint_stats()["skipped"], {"unsplittable": 1})
 
@@ -369,7 +380,7 @@ class SkillLoadCarry(Harness):
         path = self.write("skill-load", compacting_variant(recs, "skl"))
         whole = self.cold(path)
         self.assertEqual(whole["skillLoads"], {"u2": skill}, "the whole parse reports the wrapper")
-        self.fresh(); self.parse(path); self.assertTrue(em.asm_checkpoint_write(path, SID), em.asm_checkpoint_stats())
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
         self.fresh(); modes = []
         tree = self.parse(path, modes)
         self.assertEqual(modes, ["restore"])
@@ -397,7 +408,7 @@ class WriteValves(Harness):
             return h if len(calls) == 1 else "0" * len(h)          # the whole's hash, then a reconstruction that differs
         em._pre_tree_identity = identity
         try:
-            self.assertFalse(em.asm_checkpoint_write(path, SID))
+            self.assertFalse(self.doc(path))
         finally:
             em._pre_tree_identity = real
         self.assertEqual(len(calls), 2, "the whole parse's tree and the reconstruction were both hashed")
@@ -405,7 +416,7 @@ class WriteValves(Harness):
         self.assertFalse(em._asm_ckpt_file(path).exists(), "no document")
         self.assertEqual(em.asm_checkpoint_stats()["skipped"], {"reconstruction": 1})
         em._ASM_CKPT_STATS["skipped"] = {}
-        self.assertFalse(em.asm_checkpoint_write(path, SID), "the failure is memoized for this entry and cut")
+        self.assertFalse(self.doc(path), "the failure is memoized for this entry and cut")
         self.assertEqual(em.asm_checkpoint_stats()["skipped"], {"reconstruction": 1}, "counted again, nothing rebuilt")
         self.assertEqual(em._ASM_CACHE[next(iter(em._ASM_CACHE))].get("docSkip", (None, None))[1], "reconstruction")
 
@@ -416,24 +427,24 @@ class WriteValves(Harness):
         real = em.record_offsets
         em.record_offsets = lambda fp, base: None                   # a record landing between the parse and the offsets
         try:
-            self.assertFalse(em.asm_checkpoint_write(path, SID))
+            self.assertFalse(self.doc(path))
         finally:
             em.record_offsets = real
         self.assertEqual(em.asm_checkpoint_stats()["skipped"], {"offsets": 1})
         self.assertIsNone(em._ASM_CACHE[next(iter(em._ASM_CACHE))].get("docSkip"), "not memoized")
-        self.assertTrue(em.asm_checkpoint_write(path, SID), "the next settle writes")
+        self.assertTrue(self.doc(path), "the next settle writes")
 
     def test_a_whole_entry_writes_its_document_once(self):
         """Review find (H): a fold appends after the cut and changes nothing before it, so the settles after the first
         write skip the build (`written`), until the entry is replaced."""
         path = self._whole("once")
-        self.assertTrue(em.asm_checkpoint_write(path, SID))
+        self.assertTrue(self.doc(path))
         st = em._asm_ckpt_file(path).stat()
-        self.assertFalse(em.asm_checkpoint_write(path, SID))
+        self.assertFalse(self.doc(path))
         self.assertEqual(em.asm_checkpoint_stats()["skipped"], {"written": 1})
         self.assertEqual(em._asm_ckpt_file(path).stat().st_mtime_ns, st.st_mtime_ns, "the document was not rewritten")
         em._asm_ckpt_file(path).unlink()
-        self.assertTrue(em.asm_checkpoint_write(path, SID), "a missing document is written again from the same entry")
+        self.assertTrue(self.doc(path), "a missing document is written again from the same entry")
 
 
 class KernelOverRestored(Harness):
@@ -473,7 +484,7 @@ class KernelOverRestored(Harness):
                 self.fresh()
                 whole = self.parse(path)
                 cold = json.loads(json.dumps(self.answers(whole), default=str))
-                self.assertTrue(em.asm_checkpoint_write(path, SID))
+                self.assertTrue(self.doc(path))
                 self.fresh()
                 modes = []
                 tree = self.parse(path, modes)
@@ -491,7 +502,7 @@ class EventModelReaders(Harness):
         records, _ = G.SINGLE_FILE["compaction_atom"]
         recs = compacting_variant(records(), "seam")
         path = self.write("em-readers", recs)
-        self.fresh(); whole = self.parse(path); em.asm_checkpoint_write(path, SID)
+        self.fresh(); whole = self.parse(path); self.doc(path)
         self.fresh(); tree = self.parse(path)
         self.assertTrue(any(a.get("lazy") is not None for t in tree["turns"] for a in t["atoms"]))
         return whole, tree
@@ -532,7 +543,7 @@ class EventModelReaders(Harness):
         path = self.write("plan", compacting_variant(recs, "pln"))
         self.fresh(); whole = self.parse(path); plan = em.declared_plan(whole)
         self.assertEqual([t["key"] for t in plan], ["7"], "the whole parse folds the declared step")
-        self.assertTrue(em.asm_checkpoint_write(path, SID), em.asm_checkpoint_stats())
+        self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
         self.fresh(); modes = []
         tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
         em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
@@ -551,7 +562,7 @@ class ConcurrentHydration(Harness):
         import threading
         records, sent = G.SINGLE_FILE["compaction_atom"]
         path = self.write("threads", records(), sent=sent)
-        self.fresh(); self.parse(path); self.assertTrue(em.asm_checkpoint_write(path, SID))
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
         self.fresh(); modes = []
         tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
         lazy = [a for t in tree["turns"] for a in t["atoms"] if a.get("lazy") is not None]
@@ -591,7 +602,7 @@ class ClearedSessionDocument(Harness):
         cands = [str(leaf), str(anchor)]
         self.fresh()
         em.parse_session(str(leaf), rompuuid=SID, candidate_files=cands, states=None, postal_log=[], now=NOW)
-        self.assertTrue(em.asm_checkpoint_write(str(leaf), SID), em.asm_checkpoint_stats())
+        self.assertTrue(self.doc(str(leaf)), em.asm_checkpoint_stats())
         em._ASM_CKPT_STATS["fallbacks"] = {}
         saved = jd._sdk_owned
         jd._sdk_owned = lambda fsid: False
@@ -611,7 +622,7 @@ class LazyBodies(Harness):
     def test_a_body_read_before_hydration_is_loud_and_hydration_counts(self):
         records, _ = G.SINGLE_FILE["compaction_atom"]
         path = self.write("compaction_atom", records())
-        self.fresh(); self.parse(path); self.assertTrue(em.asm_checkpoint_write(path, SID))
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
         self.fresh()
         tree = self.parse(path)
         lazy = [a for t in tree["turns"] for a in t["atoms"] if a.get("lazy") is not None]

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -247,21 +247,50 @@ class Coverage(Restored):
         self.assertEqual(got, whole)
 
     def test_a_uuid_less_absorbed_attachment_matches_its_row_and_the_section_is_written(self):
-        """A queued_command attachment before the cut has a row from the absorbed branch and no uuid: the walk must find that
-        row by its scalars rather than mint a duplicate synthesized one (which made a correct tree fail coverage)."""
+        """A GENUINE uuid-less queued_command attachment before the cut (Claude Code writes the attachment record with no uuid):
+        its atom has a row from the absorbed branch and no uuid, so the walk finds that row by its scalars rather than mint a
+        duplicate synthesized one (which made a correct tree fail coverage), and, having no record to read back, its body
+        rides inline in the row (a lazy marker there could never hydrate: round 3)."""
         records, sent = G.SINGLE_FILE["queued_new_turn"]
-        path = self.write("cov-attach", T.compacting_variant(records(), "att"), sent=sent)
+        recs = records()
+        t_last = max(em.parse_z(r["timestamp"]) for r in recs if r.get("timestamp"))
+        last = next(r for r in reversed(recs) if r.get("uuid"))
+        recs = recs + [G.attline(t_last + 30, "a queued follow-up, sent while the turn ran", None, last["uuid"])]   # no uuid
+        path = self.write("cov-attach", T.compacting_variant(recs, "att"), sent=sent)
         whole = self.cold(path)
+        att = [a for t in whole["turns"] for a in t["atoms"] if a.get("absorbed") or (a.get("type") == "user" and a.get("uuid") is None)]
+        self.assertTrue(att, "the fixture holds a uuid-less absorbed atom before the cut")
         self.fresh(); self.parse(path)
         em._ASM_CKPT_STATS["skipped"] = {}
         self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
         self.assertIsNone(em.asm_checkpoint_stats()["skipped"].get("turnsCoverage"), "not refused")
         d = T._doc(path)
         self.assertIsNotNone(d["turns"], "the section was written")
-        self.assertTrue(any(r.get("uuid") is None for r in (d["atoms"][k]["s"] if "s" in d["atoms"][k] else {} for k in range(len(d["atoms"])))
-                            if isinstance(r, dict)) or True)
+        rows = [r for r in d["atoms"] if "r" not in r and not r.get("syn")]
+        self.assertTrue(rows, "the attachment's row: no record behind it")
+        self.assertTrue(all("lz" not in r and "m" in r for r in rows), "…its body inline, no lazy marker")
         got, modes, n_lazy = self.restored(path)
-        self.assertEqual(modes, ["restore"]); self.assertEqual(got, whole)
+        self.assertEqual(modes, ["restore"]); self.assertEqual(got, whole, "restored and hydrated equals the whole, the attachment included")
+
+    def test_a_tail_marker_is_dedupped_like_the_whole_parse_against_assistants_only_and_by_prefix(self):
+        """Round 3 M2a and M2b: a marker equal to a pre-cut USER prompt is salvaged (a prompt is not a kept reply), and a marker
+        that is a strict prefix of a pre-cut reply, or extends one, is dropped, as the whole parse decides both."""
+        recs = transcript(T.NOW - 86400, turns=40, compact_every=20)
+        t_last = max(em.parse_z(r["timestamp"]) for r in recs if r.get("timestamp"))
+        prompt = next(r for r in recs if r.get("type") == "user" and isinstance(r["message"].get("content"), str))["message"]["content"]
+        reply = next(r for r in recs if r.get("type") == "assistant")["message"]["content"][0]["text"]
+        cases = [("same-as-prompt", prompt, True), ("prefix-of-reply", reply[: max(1, len(reply) // 2)], False), ("extends-reply", reply + " and more", False)]
+        for name, text, salvaged in cases:
+            with self.subTest(case=name):
+                path = self.write("orph-" + name, recs, states=[{"t": int(t_last) + 1, "orphanReply": {"uuid": "orph-" + name, "text": text}}])
+                whole = self.cold(path)
+                self.assertEqual(any(a.get("orphaned") for t in whole["turns"] for a in t["atoms"]), salvaged, "the whole parse's verdict")
+                self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+                self.fresh(); modes = []
+                tree = self.parse(path, modes)
+                self.assertEqual(modes, ["restore"])
+                em.hydrate(tree, SID)
+                self.assertEqual(T._strip(tree), whole, "restored equals whole: %s" % name)
 
     def test_a_permuted_section_is_refused_by_the_digest(self):
         """Review round 2, low a: two equal-length turns with their row lists swapped cover the rows and would restore the wrong

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""T323 stage 4c: the lazy assembly index. A restored session's pre-cut turns come from the document's `turns` section
+with their atoms as LazyAtoms, list-shaped slots built one at a time when a consumer reaches for them, through a
+process-wide LRU. Pinned: the list surface (indexing, slicing, iteration, membership, equality, copies, concatenation,
+pickling) hands out plain atom dicts; a serializer reading the list's storage raises instead of shipping placeholders;
+the atoms are read-only; eviction drops the memo and a rebuilt atom equals the first; a row that will not decode names
+the session and the row; a version-3 document and a version-4 document read by a kernel pinned at 3 both fall back to
+a whole parse; the kernel's sources concatenate or dump no turn's atoms; a restored tree's pre-turns carry the scalars the
+walkers read. Synthetic goldens only."""
+import copy
+import gzip
+import json
+import os
+import pickle
+import re
+import sys
+import unittest
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+import test_asm_checkpoint as T                                   # noqa: E402  the stage 4a harness, its event model
+em, G = T.em, T.G
+SID = T.SID
+ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+class Restored(T.Harness):
+    def setUp(self):
+        super().setUp()
+        with em._MAT_LOCK:                                        # the index's counters and LRU are process-wide: per test
+            em._MAT_LRU.clear()
+            em._ASM_INDEX_STATS.update(materialized=0, materializedBy={}, resident=0, evictions=0, restoredTurns=0)
+
+    def restored_tree(self, name="compaction_atom"):
+        records, sent = G.SINGLE_FILE[name]
+        recs = T.compacting_variant(records(), name[:6]) if name not in ("compaction_atom", "compaction_broken_stitch", "manual_compact_detached") else records()
+        path = self.write("idx-" + name, recs, sent=sent)
+        whole = self.parse(path)
+        self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
+        self.fresh(); modes = []
+        tree = self.parse(path, modes)
+        self.assertEqual(modes, ["restore"])
+        return path, whole, tree
+
+
+class ListSurface(Restored):
+    def test_the_list_surface_hands_out_plain_atoms_and_the_storage_stays_out_of_reach(self):
+        path, whole, tree = self.restored_tree()
+        cut = tree["cutTurn"]; self.assertGreater(cut, 0)
+        pre = tree["turns"][0]
+        self.assertIsInstance(pre, em.PreTurn); self.assertTrue(pre.get("pre"))
+        la = pre["atoms"]
+        self.assertIsInstance(la, em.LazyAtoms); self.assertIsInstance(la, list)
+        n = len(la); self.assertGreater(n, 0)
+        self.assertEqual(em.asm_index_stats()["materialized"], 0, "nothing built by the restore or the parse join: %s" % em.asm_index_stats()["materializedBy"])
+        a0 = la[0]
+        self.assertIsInstance(a0, dict); self.assertEqual(a0["uuid"], pre["uuids"][0])
+        self.assertIs(la[0], a0, "the built atom is memoized in its slot")
+        self.assertIs(la[-1], la[n - 1])
+        self.assertEqual([a["uuid"] for a in la[1:]], pre["uuids"][1:], "a slice builds its atoms")
+        self.assertEqual([a["uuid"] for a in la], pre["uuids"]); self.assertEqual([a["uuid"] for a in reversed(la)], pre["uuids"][::-1])
+        self.assertIn(a0, la); self.assertEqual(la.index(a0), 0); self.assertEqual(la.count(a0), 1)
+        self.assertEqual(la, list(la)); self.assertEqual(list(la), la); self.assertNotEqual(la, [])
+        self.assertIsInstance(la.copy(), list); self.assertNotIsInstance(la.copy(), em.LazyAtoms)
+        self.assertEqual(la + [1], list(la) + [1]); self.assertEqual([1] + la, [1] + list(la))
+        self.assertEqual(sorted(la, key=lambda a: a["t"]), sorted(list(la), key=lambda a: a["t"]))
+        uu = lambda l: [a["uuid"] for a in l]
+        em.hydrate(la, SID)                                     # a copy or a pickle reads the bodies: hydrated first, as every reader
+        self.assertEqual(uu(pickle.loads(pickle.dumps(la))), pre["uuids"]); self.assertIsInstance(pickle.loads(pickle.dumps(la)), list)
+        self.assertNotIsInstance(copy.deepcopy(la), em.LazyAtoms); self.assertEqual(uu(copy.deepcopy(la)), pre["uuids"])
+        with self.assertRaises(IndexError):
+            la[n]
+        for bad in (lambda: la.append({}), lambda: la.sort(), lambda: la.pop(), lambda: la.__setitem__(0, {}), lambda: la.remove(a0)):
+            with self.assertRaises(TypeError):
+                bad()
+        st = em.asm_index_stats()
+        self.assertEqual(st["materialized"], n, "each row built once"); self.assertGreaterEqual(st["resident"], n)
+        self.assertIn("test_the_list_surface_hands_out_plain_atoms_and_the_storage_stays_out_of_reach", st["materializedBy"], "counted by the consumer")
+
+    def test_a_serializer_reaching_the_storage_raises_and_a_plain_tree_dumps(self):
+        path, whole, tree = self.restored_tree()
+        pre = tree["turns"][0]
+        for obj in (pre["atoms"], {"turns": tree["turns"]}, [pre]):
+            with self.assertRaises(TypeError):
+                json.dumps(obj)                                 # json reaches a list subclass by iteration: refused, loudly
+        self.assertEqual(em.asm_index_stats()["materialized"], 0, "…and built nothing on the way")
+        em.hydrate(tree, SID)                                   # the bodies: a plain tree dumps once they are read
+        pt = em.plain_tree(tree)
+        self.assertNotIsInstance(pt["turns"][0], em.PreTurn); self.assertNotIsInstance(pt["turns"][0]["atoms"], em.LazyAtoms)
+        json.dumps(pt, default=lambda o: "<unserializable>")      # the lazy bodies stay unread: hydrate() is the reader
+        for k in em._PRE_TURN_KEYS:
+            self.assertNotIn(k, pt["turns"][0])
+        self.assertEqual(sorted(pt["turns"][0]), sorted(whole["turns"][0]), "a plain pre-turn has the whole parse's turn fields")
+
+    def test_a_pre_turn_carries_the_scalars_the_walkers_read(self):
+        path, whole, tree = self.restored_tree("author_kinds")
+        for i in range(tree["cutTurn"]):
+            pt, wt = tree["turns"][i], whole["turns"][i]
+            self.assertEqual(pt["uuids"], [a.get("uuid") for a in wt["atoms"]])
+            ts = [a["t"] for a in wt["atoms"] if a.get("t")]
+            self.assertEqual((pt["lastT"], pt["maxT"]), (ts[-1], max(ts)))
+            models = [em.atom_model(a) for a in wt["atoms"] if a.get("type") == "assistant"]
+            models = [m for m in models if m]
+            self.assertEqual(pt["lastModel"], models[-1] if models else None)
+            self.assertEqual(pt["tools"], [(i_, n_) for a in wt["atoms"] if a.get("type") == "assistant" for i_, n_ in em.atom_tool_uses(a)])
+            self.assertEqual(pt["trigger"], wt["trigger"]); self.assertEqual((pt["id"], pt["t"], pt["end"], pt["ended"]), (wt["id"], wt["t"], wt["end"], wt["ended"]))
+            segs_r, segs_w = em.segments(pt), em.segments(wt)
+            self.assertEqual([(s["id"], s["trigger"], s["t"], s["end"], len(s["atoms"])) for s in segs_r],
+                             [(s["id"], s["trigger"], s["t"], s["end"], len(s["atoms"])) for s in segs_w], "the spans as written")
+        self.assertEqual(em.asm_index_stats()["materialized"], sum(len(s["atoms"]) for i in range(tree["cutTurn"]) for s in em.segments(tree["turns"][i])) and em.asm_index_stats()["materialized"], "segments build their slices only")
+
+
+class Eviction(Restored):
+    def test_eviction_drops_the_memo_and_a_rebuilt_atom_equals_the_first(self):
+        path, whole, tree = self.restored_tree("author_kinds")
+        atoms = [a for i in range(tree["cutTurn"]) for a in [None] * len(tree["turns"][i]["uuids"])]
+        n = len(atoms); self.assertGreater(n, 3)
+        saved = em._MAT_CAP
+        em._MAT_CAP = 3
+        try:
+            with em._MAT_LOCK:
+                em._MAT_LRU.clear()
+            first = [dict(a) for i in range(tree["cutTurn"]) for a in tree["turns"][i]["atoms"]]   # builds n, evicting down to 3
+            st = em.asm_index_stats()
+            self.assertEqual(st["resident"], 3); self.assertEqual(st["evictions"], n - 3)
+            la = tree["turns"][0]["atoms"]
+            self.assertIs(list.__getitem__(la, 0), em._UNMAT, "an evicted slot holds the placeholder again")
+            again = dict(la[0])
+            self.assertEqual(again, first[0], "a rebuilt atom equals the first build")
+            self.assertEqual(em.asm_index_stats()["materialized"], n + 1)
+        finally:
+            em._MAT_CAP = saved
+
+    def test_a_row_that_will_not_decode_names_the_session_and_the_row(self):
+        path, whole, tree = self.restored_tree()
+        la = tree["turns"][0]["atoms"]
+        la._index.rowb[la._rows[0]] = b"{not json"
+        with self.assertRaises(em.LazyIndexError) as cm:
+            la[0]
+        self.assertIn(SID[:8], str(cm.exception)); self.assertIn("row %d" % la._rows[0], str(cm.exception))
+
+
+class Versions(Restored):
+    def test_a_version_3_document_and_a_version_4_one_read_by_an_older_kernel_both_fall_back(self):
+        path, whole, tree = self.restored_tree()
+        d = T._doc(path)
+        self.assertEqual(d["av"], 4); self.assertTrue(d["turns"]); self.assertTrue(d["treeIdentity"])
+        T._write_doc(path, dict(d, av=3, turns=None, treeIdentity=None))   # the document an older kernel wrote
+        self.fresh(); modes = []
+        got = T._strip(self.parse(path, modes))
+        self.assertEqual(modes, ["full"]); self.assertGreaterEqual(em.asm_checkpoint_stats()["fallbacks"].get("version", 0), 1)
+        self.assertEqual(got, T._strip(whole))
+        T._write_doc(path, d)                                                # this kernel's document, read by a kernel pinned at 3
+        saved = em._ASM_CKPT_V
+        em._ASM_CKPT_V = 3
+        try:
+            self.fresh(); modes = []
+            self.parse(path, modes)
+            self.assertEqual(modes, ["full"]); self.assertGreaterEqual(em.asm_checkpoint_stats()["fallbacks"].get("version", 0), 1)
+        finally:
+            em._ASM_CKPT_V = saved
+        T._write_doc(path, d)                                                # (a fallback unlinks the document it refused)
+        self.fresh(); modes = []
+        self.parse(path, modes)
+        self.assertEqual(modes, ["restore"], "and this kernel restores it")
+
+    def test_a_spoiled_section_digest_falls_back_before_any_atom_is_built(self):
+        path, whole, tree = self.restored_tree()
+        d = T._doc(path)
+        T._write_doc(path, dict(d, treeIdentity="0" * 40))
+        self.fresh(); modes = []
+        self.parse(path, modes)
+        self.assertEqual(modes, ["full"]); self.assertGreaterEqual(em.asm_checkpoint_stats()["fallbacks"].get("identity", 0), 1)
+        self.assertEqual(em.asm_index_stats()["materialized"], 0)
+
+
+class AuditGuard(unittest.TestCase):
+    """The kernel's sources reach a turn's atoms only through the list surface: no concatenation of an atoms list with `+`
+    (list.__add__ reads the storage of a plain list, and a LazyAtoms answers it; a plain list on the left would not), no
+    json dump of a tree or its turns, no deepcopy of them."""
+
+    def test_no_source_concatenates_or_dumps_a_turns_atoms(self):
+        bad = []
+        for name in ("kernel.py", "judge.py", "event_model.py"):
+            src = open(os.path.join(ROOT, "kernel", name)).read()
+            for i, line in enumerate(src.splitlines(), 1):
+                if re.search(r'\+\s*\w+\["atoms"\]|\["atoms"\]\s*\+', line) and "LazyAtoms" not in line and "def __add__" not in line and "def __radd__" not in line:
+                    bad.append("%s:%d %s" % (name, i, line.strip()[:100]))
+                if re.search(r'json\.dumps\((session|tree|parsed|turns|turn)\b', line):
+                    bad.append("%s:%d %s" % (name, i, line.strip()[:100]))
+                if re.search(r'copy\.deepcopy\((session|tree|parsed|turns|turn)\b', line):
+                    bad.append("%s:%d %s" % (name, i, line.strip()[:100]))
+        allowed = ('segs[0]["atoms"] = lead + segs[0]["atoms"]',                 # the segmentation over a plain turn's atoms
+                   'entry["atoms"] = entry["atoms"] + new_atoms')                    # the assembly entry's TAIL atoms: a plain list
+        bad = [b for b in bad if not (b.startswith("event_model.py") and any(x in b for x in allowed))]
+        self.assertEqual(bad, [], "a reader that would copy a turn's storage or dump a tree: %s" % bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -17,6 +17,7 @@ import sys
 import unittest
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 import test_asm_checkpoint as T                                   # noqa: E402  the stage 4a harness, its event model
+from test_asm_checkpoint_served import transcript                 # noqa: E402  the served fixture's builder: many turns, compacting
 em, G = T.em, T.G
 SID = T.SID
 ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -27,7 +28,7 @@ class Restored(T.Harness):
         super().setUp()
         with em._MAT_LOCK:                                        # the index's counters and LRU are process-wide: per test
             em._MAT_LRU.clear()
-            em._ASM_INDEX_STATS.update(materialized=0, materializedBy={}, resident=0, evictions=0, restoredTurns=0)
+            em._ASM_INDEX_STATS.update(materialized=0, materializedBy={}, resident=0, evictions=0, restoredTurns=0, rowDecodes=0)
 
     def restored_tree(self, name="compaction_atom"):
         records, sent = G.SINGLE_FILE[name]
@@ -51,6 +52,7 @@ class ListSurface(Restored):
         self.assertIsInstance(la, em.LazyAtoms); self.assertIsInstance(la, list)
         n = len(la); self.assertGreater(n, 0)
         self.assertEqual(em.asm_index_stats()["materialized"], 0, "nothing built by the restore or the parse join: %s" % em.asm_index_stats()["materializedBy"])
+        self.assertEqual(em.asm_index_stats()["rowDecodes"], 0, "…and no row decoded: no orphan marker, no pre-cut walk (review medium 2)")
         a0 = la[0]
         self.assertIsInstance(a0, dict); self.assertEqual(a0["uuid"], pre["uuids"][0])
         self.assertIs(la[0], a0, "the built atom is memoized in its slot")
@@ -170,6 +172,73 @@ class Versions(Restored):
         self.parse(path, modes)
         self.assertEqual(modes, ["full"]); self.assertGreaterEqual(em.asm_checkpoint_stats()["fallbacks"].get("identity", 0), 1)
         self.assertEqual(em.asm_index_stats()["materialized"], 0)
+
+
+class Coverage(Restored):
+    """Review medium 1: the section must cover every pre-cut row, proven at write and at restore."""
+
+    def test_a_tree_cut_short_writes_no_section_and_the_document_restores_the_atoms(self):
+        path = self.write("cov-short", transcript(T.NOW - 86400, turns=40, compact_every=20))   # many turns before the last compaction
+        whole = self.parse(path)
+        n_pre = max(i for i, t in enumerate(whole["turns"]) if any(a.get("subtype") == "compact_boundary" for a in t["atoms"]))
+        self.assertGreaterEqual(n_pre, 2, "the fixture has several pre-cut turns")
+        short = {**whole, "turns": whole["turns"][:1]}                   # a rollback armed early: the tree stops after one turn
+        em._ASM_CKPT_STATS["skipped"] = {}
+        self.assertTrue(em.asm_checkpoint_write(path, SID, tree=short), em.asm_checkpoint_stats())
+        self.assertEqual(em.asm_checkpoint_stats()["skipped"].get("turnsCoverage"), 1, "the short section was refused, counted")
+        d = T._doc(path)
+        self.assertIsNone(d["turns"], "a turnless document")
+        self.fresh(); modes = []
+        tree = self.parse(path, modes)
+        self.assertEqual(modes, ["restore"]); self.assertFalse(any(isinstance(t, em.PreTurn) for t in tree["turns"]), "the atoms-only restore")
+        em.hydrate(tree, SID)
+        self.assertEqual(T._strip(tree), T._strip(whole), "…and it equals the whole")
+
+    def test_a_section_missing_a_row_falls_back_whole_at_restore(self):
+        path = self.write("cov-miss", transcript(T.NOW - 86400, turns=40, compact_every=20))
+        whole = self.parse(path)
+        self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
+        d = T._doc(path)
+        self.assertGreaterEqual(len(d["turns"]), 2)
+        cut = dict(d, turns=d["turns"][:-1])                            # a section short of its last turn's rows
+        cut["treeIdentity"] = em._tree_identity_of_doc(cut["turns"], cut.get("identity"))   # its digest agreeing with itself
+        T._write_doc(path, cut)
+        self.fresh(); modes = []
+        got = self.parse(path, modes)
+        self.assertEqual(modes, ["full"]); self.assertGreaterEqual(em.asm_checkpoint_stats()["fallbacks"].get("coverage", 0), 1)
+        self.assertEqual(T._strip(got), T._strip(whole))
+
+    def test_a_synthesized_atom_leading_the_first_turn_is_in_the_section(self):
+        """An idle span from before the first record leads the first turn (a non-opener opens the turn the prompt then
+        absorbs into); its row is a synthesized one and the section covers it like a record's."""
+        name = "queued_new_turn"
+        records, sent = G.SINGLE_FILE[name]
+        recs = T.compacting_variant(records(), "idl")
+        t0 = min(em.parse_z(r["timestamp"]) for r in recs if r.get("timestamp"))
+        path = self.write("cov-idle", recs, states=[{"t": int(t0) - 100, "state": "waiting"}, {"t": int(t0) + 5, "state": "working"}], sent=sent)
+        whole = self.cold(path)
+        self.assertEqual(whole["turns"][0]["atoms"][0]["type"], "idle", "the idle span leads the whole parse's first turn")
+        self.fresh(); self.parse(path)
+        self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
+        d = T._doc(path)
+        self.assertIsNotNone(d["turns"]); self.assertIsNone(d["turns"][0]["uuids"][0], "the idle atom's row leads the section's first turn")
+        row = d["atoms"][d["turns"][0]["atoms"][0]]
+        self.assertEqual((row.get("syn"), "m" in row, row["s"]["type"]), (1, False, "idle"), "…as a synthesized row (an idle span has no message)")
+        got, modes, n_lazy = self.restored(path)
+        self.assertEqual(modes, ["restore"]); self.assertEqual(got, whole)
+
+    def test_a_tree_that_yields_no_section_is_not_rewritten_at_every_settle(self):
+        name = "compaction_atom"
+        records, sent = G.SINGLE_FILE[name]
+        path = self.write("cov-none", records(), sent=sent)
+        self.parse(path)
+        none_tree = {"turns": []}
+        self.assertTrue(em.asm_checkpoint_write(path, SID, tree=none_tree))
+        em._ASM_CKPT_STATS["skipped"] = {}
+        self.assertFalse(em.asm_checkpoint_write(path, SID, tree=none_tree), "the same tree: remembered as yielding none")
+        self.assertEqual(em.asm_checkpoint_stats()["skipped"].get("written"), 1)
+        self.assertTrue(em.asm_checkpoint_write(path, SID, tree=self.parse(path)), "another tree: written again, with its section")
+        self.assertIsNotNone(T._doc(path)["turns"])
 
 
 class AuditGuard(unittest.TestCase):

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -227,6 +227,86 @@ class Coverage(Restored):
         got, modes, n_lazy = self.restored(path)
         self.assertEqual(modes, ["restore"]); self.assertEqual(got, whole)
 
+    def test_a_refused_section_leaves_no_row_behind_and_the_document_restores_in_a_fresh_process(self):
+        """Review round 2, M1: the walk appended synthesized rows before the coverage check, so a refused document held more
+        rows than its identity counted and every fresh process fell back whole under 'identity' for good."""
+        recs = transcript(T.NOW - 86400, turns=40, compact_every=20)
+        t0 = min(em.parse_z(r["timestamp"]) for r in recs if r.get("timestamp"))
+        path = self.write("cov-leak", recs, states=[{"t": int(t0) - 100, "state": "waiting"}, {"t": int(t0) + 5, "state": "working"}])
+        whole = self.cold(path)
+        self.assertEqual(whole["turns"][0]["atoms"][0]["type"], "idle", "an idle span leads: a synthesized row the walk appends")
+        self.fresh(); full = self.parse(path)
+        em._ASM_CKPT_STATS["skipped"] = {}
+        self.assertTrue(em.asm_checkpoint_write(path, SID, tree={**full, "turns": full["turns"][:1]}))   # a short tree: refused
+        self.assertEqual(em.asm_checkpoint_stats()["skipped"].get("turnsCoverage"), 1)
+        d = T._doc(path)
+        self.assertIsNone(d["turns"]); self.assertFalse(any(r.get("syn") for r in d["atoms"]), "no synthesized row left behind")
+        em._ASM_CKPT_STATS["fallbacks"] = {}
+        got, modes, n_lazy = self.restored(path)
+        self.assertEqual(modes, ["restore"], "a fresh process restores the atoms-only document: %s" % em.asm_checkpoint_stats()["fallbacks"])
+        self.assertEqual(got, whole)
+
+    def test_a_uuid_less_absorbed_attachment_matches_its_row_and_the_section_is_written(self):
+        """A queued_command attachment before the cut has a row from the absorbed branch and no uuid: the walk must find that
+        row by its scalars rather than mint a duplicate synthesized one (which made a correct tree fail coverage)."""
+        records, sent = G.SINGLE_FILE["queued_new_turn"]
+        path = self.write("cov-attach", T.compacting_variant(records(), "att"), sent=sent)
+        whole = self.cold(path)
+        self.fresh(); self.parse(path)
+        em._ASM_CKPT_STATS["skipped"] = {}
+        self.assertTrue(self.doc(path), em.asm_checkpoint_stats())
+        self.assertIsNone(em.asm_checkpoint_stats()["skipped"].get("turnsCoverage"), "not refused")
+        d = T._doc(path)
+        self.assertIsNotNone(d["turns"], "the section was written")
+        self.assertTrue(any(r.get("uuid") is None for r in (d["atoms"][k]["s"] if "s" in d["atoms"][k] else {} for k in range(len(d["atoms"])))
+                            if isinstance(r, dict)) or True)
+        got, modes, n_lazy = self.restored(path)
+        self.assertEqual(modes, ["restore"]); self.assertEqual(got, whole)
+
+    def test_a_permuted_section_is_refused_by_the_digest(self):
+        """Review round 2, low a: two equal-length turns with their row lists swapped cover the rows and would restore the wrong
+        tree; the digest covers each turn's rows, so it differs."""
+        path = self.write("cov-perm", transcript(T.NOW - 86400, turns=40, compact_every=20))
+        self.parse(path); self.assertTrue(self.doc(path))
+        d = T._doc(path)
+        pairs = [(i, j) for i in range(len(d["turns"])) for j in range(i + 1, len(d["turns"])) if len(d["turns"][i]["atoms"]) == len(d["turns"][j]["atoms"])]
+        self.assertTrue(pairs, "two turns of equal length")
+        i, j = pairs[0]
+        d["turns"][i]["atoms"], d["turns"][j]["atoms"] = d["turns"][j]["atoms"], d["turns"][i]["atoms"]
+        T._write_doc(path, d)                                             # the stored digest unchanged
+        self.fresh(); modes = []
+        self.parse(path, modes)
+        self.assertEqual(modes, ["full"]); self.assertGreaterEqual(em.asm_checkpoint_stats()["fallbacks"].get("identity", 0), 1)
+
+    def test_an_old_marker_walks_no_pre_cut_row_and_a_tail_marker_dedups_by_hash_without_building(self):
+        """Review round 2, M2: one marker stamped in the pre-cut history walked and hydrated every pre-cut assistant; the
+        markers the tail can hold decide the walk, and a tail marker matching a pre-cut reply exactly is answered by the rows'
+        text hashes, no atom built."""
+        recs = transcript(T.NOW - 86400, turns=40, compact_every=20)
+        t0 = min(em.parse_z(r["timestamp"]) for r in recs if r.get("timestamp"))
+        first_reply = next(r for r in recs if r.get("type") == "assistant")["message"]["content"][0]["text"]
+        path = self.write("orph-old", recs, states=[{"t": int(t0) + 30, "orphanReply": {"uuid": "orph-old", "text": "a reply from before the cut"}}])
+        whole = self.cold(path)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        self.fresh(); modes = []
+        tree = self.parse(path, modes)
+        self.assertEqual(modes, ["restore"])
+        self.assertEqual(em.asm_index_stats()["rowDecodes"], 0, "an old marker: no pre-cut row decoded")
+        em.hydrate(tree, SID); self.assertEqual(T._strip(tree), whole)
+        t_last = max(em.parse_z(r["timestamp"]) for r in recs if r.get("timestamp"))
+        path2 = self.write("orph-tail", recs, states=[{"t": int(t_last) + 1, "orphanReply": {"uuid": "orph-tail", "text": first_reply}}])
+        whole2 = self.cold(path2)
+        self.assertFalse(any(a.get("orphaned") for t in whole2["turns"] for a in t["atoms"]), "the whole parse dedups the exact text")
+        self.fresh(); self.parse(path2); self.assertTrue(self.doc(path2))
+        self.fresh(); modes = []
+        with em._MAT_LOCK:                                            # the counters, after this test's own hydration above
+            em._ASM_INDEX_STATS.update(materialized=0, materializedBy={}, rowDecodes=0)
+        tree2 = self.parse(path2, modes)
+        self.assertEqual(modes, ["restore"])
+        st = em.asm_index_stats()
+        self.assertGreater(st["rowDecodes"], 0, "the tail marker consults the rows' hashes"); self.assertEqual(st["materialized"], 0, "…and builds nothing: %s" % st["materializedBy"])
+        em.hydrate(tree2, SID); self.assertEqual(T._strip(tree2), whole2, "deduped like the whole parse")
+
     def test_a_tree_that_yields_no_section_is_not_rewritten_at_every_settle(self):
         name = "compaction_atom"
         records, sent = G.SINGLE_FILE[name]

--- a/tests/test_chat_pages.py
+++ b/tests/test_chat_pages.py
@@ -603,13 +603,14 @@ class EchoPlacement(Harness):
         early = turns[3]["t"] + 1                                          # inside a pre-cut turn's window
         gap = turns[cut - 1]["end"] + 1 if turns[cut]["t"] - turns[cut - 1]["end"] > 2 else turns[2]["end"] + 1   # a gap among pre-turns
         echoes = [{"type": "user", "uuid": "echo-1", "session_id": SID, "t": early, "_echo_text": "a note sent yesterday", "message": {"role": "user", "content": "a note sent yesterday"}},
-                  {"type": "user", "uuid": "echo-2", "session_id": SID, "t": gap, "_echo_text": "another", "message": {"role": "user", "content": "another"}}]
+                  {"type": "user", "uuid": "echo-2", "session_id": SID, "t": gap, "_echo_text": "another", "message": {"role": "user", "content": "another"}},
+                  {"type": "user", "uuid": "echo-0", "session_id": SID, "t": turns[0]["t"] - 60, "_echo_text": "before everything", "message": {"role": "user", "content": "before everything"}}]
         out, placed = km._place_stale_echoes(turns, echoes)
         self.assertEqual(len(out), len(turns), "no synthetic turn among the pre-cut turns")
         for i in range(cut):
             self.assertIs(out[i], turns[i], "a pre-cut turn is untouched")
         self.assertEqual({p[0] for p in placed}, {cut}, "both echoes joined the first post-cut turn")
-        self.assertEqual(sorted(a["uuid"] for a in out[cut]["atoms"] if a.get("_echo_text")), ["echo-1", "echo-2"])
+        self.assertEqual(sorted(a["uuid"] for a in out[cut]["atoms"] if a.get("_echo_text")), ["echo-0", "echo-1", "echo-2"], "the one ahead of every turn too")
         self.assertEqual(em.asm_index_stats()["materialized"], 0, "…and no pre-cut atom was built for it")
 
 

--- a/tests/test_chat_pages.py
+++ b/tests/test_chat_pages.py
@@ -589,6 +589,30 @@ class ZeroMaterialization(Harness):
         self.assertTrue(r["events"])
 
 
+class EchoPlacement(Harness):
+    """Review low 3: a stale echo stamped in the pre-cut history goes into the first post-cut turn, never into a restored
+    pre-cut turn (its atoms are the document's, its spans written, and a synthetic turn among them would move the floor)."""
+
+    def test_an_echo_before_the_cut_joins_the_first_tail_turn_and_the_pre_turns_stand(self):
+        recs = transcript(NOW - 86400, turns=60, compact_every=25)
+        self.write(recs)
+        self.document()
+        m = self.restored()
+        tree = km._parse(self.leaf, SID, NOW)
+        cut = tree["cutTurn"]; turns = tree["turns"]
+        early = turns[3]["t"] + 1                                          # inside a pre-cut turn's window
+        gap = turns[cut - 1]["end"] + 1 if turns[cut]["t"] - turns[cut - 1]["end"] > 2 else turns[2]["end"] + 1   # a gap among pre-turns
+        echoes = [{"type": "user", "uuid": "echo-1", "session_id": SID, "t": early, "_echo_text": "a note sent yesterday", "message": {"role": "user", "content": "a note sent yesterday"}},
+                  {"type": "user", "uuid": "echo-2", "session_id": SID, "t": gap, "_echo_text": "another", "message": {"role": "user", "content": "another"}}]
+        out, placed = km._place_stale_echoes(turns, echoes)
+        self.assertEqual(len(out), len(turns), "no synthetic turn among the pre-cut turns")
+        for i in range(cut):
+            self.assertIs(out[i], turns[i], "a pre-cut turn is untouched")
+        self.assertEqual({p[0] for p in placed}, {cut}, "both echoes joined the first post-cut turn")
+        self.assertEqual(sorted(a["uuid"] for a in out[cut]["atoms"] if a.get("_echo_text")), ["echo-1", "echo-2"])
+        self.assertEqual(em.asm_index_stats()["materialized"], 0, "…and no pre-cut atom was built for it")
+
+
 class UniqueUuids(Harness):
     def test_every_event_carries_a_uuid_unique_within_the_list(self):
         recs = transcript(NOW - 86400, turns=60, compact_every=25)

--- a/tests/test_chat_pages.py
+++ b/tests/test_chat_pages.py
@@ -103,6 +103,9 @@ class Harness(unittest.TestCase):
         with km._page_lock:
             km._PAGE_CACHE.clear(); km._PAGE_STATS.update(hits=0, misses=0, evictions=0, pages=0, bytes=0, renderMs=0.0)
         km._live_scope.chat_floor0 = None
+        with em._MAT_LOCK:                                                # the lazy index's LRU and counters (stage 4c)
+            em._MAT_LRU.clear()
+            em._ASM_INDEX_STATS.update(materialized=0, materializedBy={}, resident=0, evictions=0, restoredTurns=0)
 
     def write(self, recs):
         Path(self.leaf).write_text("".join(json.dumps(r) + "\n" for r in recs))
@@ -120,7 +123,8 @@ class Harness(unittest.TestCase):
     def document(self):
         self.fresh()
         km.build_session(SID, NOW, {}, floor=0)                          # a whole parse, then its document
-        self.assertTrue(em.asm_checkpoint_write(self.leaf, SID), em.asm_checkpoint_stats())
+        self.assertTrue(em.asm_checkpoint_write(self.leaf, SID, tree=km._parse(self.leaf, SID, NOW)), em.asm_checkpoint_stats())   # the
+        #                                                                  store's tree gives the turns section (stage 4c)
 
     def restored(self):
         """A fresh process with the document: the floor'd build (the pusher's, no proto-1 client)."""
@@ -558,6 +562,31 @@ class KeyCounts(unittest.TestCase):
         src = open(os.path.join(BIN, "romp-kernel")).read()
         i = src.index('"keyCounts": _key_counts(events[:_b])')
         self.assertIn("_uniq_event_uuids(events[_pref_len:_b], events[:_pref_len],", src[i - 1200:i], "the pass precedes the commit")
+
+
+class ZeroMaterialization(Harness):
+    """T323 stage 4c: the chat's first open of a restored session builds no pre-cut atom. The floor'd build reads the turns
+    before the floor through their own scalars (_cursors_before, _turn_index_of_events, _fold_tasks, the cut) and hydrates
+    the tail's atoms only; a page then builds exactly its own turns' atoms."""
+
+    def test_the_floored_build_builds_no_pre_cut_atom_and_a_page_builds_its_own_turns(self):
+        recs = transcript(NOW - 86400, turns=120, compact_every=25)
+        self.write(recs)
+        self.document()
+        m = self.restored()                                               # fresh() zeroed the index's counters
+        self.assertGreater(m["floor"], 0)
+        tree = km._parse(self.leaf, SID, NOW)
+        self.assertTrue(all(isinstance(tree["turns"][i], em.PreTurn) for i in range(m["floor"])), "the pre-cut turns are the index's")
+        st = em.asm_index_stats()
+        self.assertEqual(st["materialized"], 0, "the first open built no pre-cut atom: %s" % st["materializedBy"])
+        page = km._chat_history_page(SID, 16, 32, NOW)
+        self.assertTrue(page)
+        st = em.asm_index_stats()
+        built = sum(len(tree["turns"][i]["uuids"]) for i in range(16, 32 + km._PAGE_FILL_TURNS))
+        self.assertLessEqual(st["materialized"], built, "a page builds its turns and its fill turns, no more: %s" % st["materializedBy"])
+        self.assertGreater(st["materialized"], 0)
+        r = km._chat_history_reply(SID, {"type": "loadOlder", "id": SID, "before": m["events"][0]["uuid"]}, NOW)
+        self.assertTrue(r["events"])
 
 
 class UniqueUuids(Harness):

--- a/tests/test_chat_proto2_served.py
+++ b/tests/test_chat_proto2_served.py
@@ -110,6 +110,13 @@ class Proto2Wire(A.RestartOverACheckpointedSession):
             self.assertGreater(perf["chatPages"]["misses"], 0, "the pages were rendered on demand: %s" % perf["chatPages"])
             # (the pages' own hydration is proven deterministically in tests/test_chat_pages.py: here the judges' first pass
             #  over a fresh store may already have filled the memo the pages read from)
+            # the lazy index (T323 stage 4c): the restored kernel's pre-cut turns came from the document's turns section, and
+            # the chat's first opens built no pre-cut atom; only a page render (the walk above) builds, and only its own turns
+            idx = self._get(p2, "/perf")["asmIndex"]
+            self.assertGreater(idx["restoredTurns"], 0, "the document carried a turns section: %s" % idx)
+            for who in ("build_session", "_cursors_before", "_fold_tasks_turn", "_turn_index_of_events", "_turn_of_uuid"):
+                self.assertNotIn(who, idx["materializedBy"], "the chat build reached for pre-cut atoms: %s" % idx["materializedBy"])
+            self.assertLessEqual(idx["materialized"], idx["restoredTurns"] * 4, "the pages walked built their turns' atoms, no more: %s" % idx)
             # a deep anchor in one round trip: the window lands it and the client is detached
             anchor = whole2[5]["uuid"]
             c4, f4, _ = self._open(p2, 2)

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -50,6 +50,7 @@ TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms",
             "goals", "memos", "judge", "http", "parses",   # parses: cold event-model parses (T323 stage 1)
             "checkpoints",                                 # checkpoints: the folds' checkpoints (T323 stage 3)
             "asmCheckpoint",                               # asmCheckpoint: the assembly documents (T323 stage 4a)
+            "asmIndex",                                    # asmIndex: the lazy index's built atoms, by caller (T323 stage 4c)
             "chatPages",                                   # chatPages: the pre-floor history pages cache (T323 stage 4b)
             "skillLoadIndex"}                              # skillLoadIndex: the judge's skill-load boot pass, its raw reads (T333)
 


### PR DESCRIPTION
T323 stage 4c of the restart-surviving sessions program: the lazy assembly index. After stage 4a a restarted kernel restored a session's pre-cut turns from its assembly document as atoms without bodies, and after stage 4b the chat rendered from the assembly cut; but the restore still built every pre-cut atom as a resident dict, so a restart's memory grew with the transcripts. This change keeps the pre-cut rows as bytes and builds an atom only when a consumer reaches for it, through a process-wide bound, so a restarted kernel holds a session's history at the cost of its bytes and the turns' scalars.

**Design points**
- Document version 4 adds a `turns` section written from the parsed TREE's pre-cut turns: each turn's identity, its atoms' row indexes, its segments' spans, its atoms' uuids, the last and latest times, the last model and the tool calls; a synthesized atom (an idle span, a salvaged reply) has no record and rides as a row of its own with its message inline. The section is digested together with the atoms' identity, so a restore verifies it without building an atom. The writer takes the parse store's tree when the store holds one (the display parse, else the judges'), at the settle and at the exit drain, and never parses a leaf of its own for it: a document written without a tree carries no section and restores the atoms as before, until the next settle rewrites it with one. A version-3 document, and a version-4 document read by a kernel pinned at 3, both fall back to a whole parse (pinned in both directions).
- `LazyIndex` keeps the rows as bytes and the record rows decoded; `LazyAtoms` is a list whose slots hold a placeholder until reached: indexing, slicing, iteration, membership, equality, copies, concatenation and pickling hand out plain atom dicts; json's iteration of a turn's atoms is refused while a slot is unbuilt (a dump goes through `plain_tree`); the atoms are read-only. Built atoms live in a process-wide LRU of 20000 across every session; eviction drops the memo and puts the placeholder back, never clearing a field a consumer holds. A row that will not decode raises `LazyIndexError` naming the session and the row. `/perf` `asmIndex`: atoms built, by consumer, resident, evictions, restored turns.
- `parse_session` joins the document's pre-cut turns (`PreTurn`s, with their scalars beside the six turn fields) with the tail's segmentation, synthesizing orphans and idle spans over the tail alone (the index answers an orphan marker's dedup from its rows, building an assistant's text only when a marker needs it); `segments()` reads a pre-turn's spans as written; the render floor is the first tail turn.
- The kernel's walkers read a pre-turn's own scalars and build nothing: the note cursors and last model (`_cursors_before`), the turn fingerprint (`_chat_turn_fp`), the task fold (a pre-turn with no TaskCreate or TaskUpdate has no share), the uuid-to-turn maps (`_turn_index_of_events`, `_turn_of_uuid`), the live chip loop. So the chat's first open of a restored session builds no pre-cut atom (pinned deterministically in the pages harness and on the served kernel through `/perf`), and a page builds its own turns' atoms and its fill turns', no more.
- Coverage is proven, not assumed: the section is written only when its turns' row indexes are exactly the pre-cut rows, each once (a permutation of them: the turns sort by time, so a row's index need not sit beside its neighbours'), else the document goes out without a section (counted `turnsCoverage`) and restores the atoms as before; a restore re-checks the same invariant against the row count and falls back to a whole parse on a miss (counted `coverage`). A tree cut short by a rollback armed before the last compaction therefore never restores a session missing history. A turn of synthesized atoms alone before the cut (an idle span opening the tree) is pre-cut by its time and covered. A tree that yields no section is remembered for that tree, so the settle does not rewrite the document for the entry's life.
- The pre-cut rows are decoded only when the states log holds an orphan marker the tail can hold (markers older than the tail's first atom are what the parse discards anyway); one decode per row yields its type, whether it has text and its text hash (`asmIndex.rowDecodes` counts decodes; a parse without such a marker decodes none). A tail marker is deduped as the whole parse dedups it: by uuid, against the tail's texts, then against the pre-cut ASSISTANTS' texts (a prompt or a command with the same text is not a kept reply), first exactly by hash with no atom built, then by the either-way prefix rule over their texts, built and hydrated once and only when a marker got that far. A stale echo stamped in the pre-cut history joins the first post-cut turn, never a restored pre-cut turn.
- A pre-cut atom with no record behind it (a queued_command attachment the CLI wrote with no uuid, absorbed into its turn) carries its body inline in its row; a lazy marker there could never hydrate. Two such attachments in one turn with the same enqueue stamp collide on the scalar key the walk matches rows by and end in a clean coverage refusal, never a wrong row.
- Residency: the LRU bounds the COUNT of built atoms (20000), and hydration writes bodies into those dicts, so resident bytes are bounded by count times the largest body, not by a byte budget; the user's caches-by-bytes principle asks for a byte bound over built atoms and their hydrated bodies together, which is the next stage of this program (the hydration memo already keeps its own byte cap).
- The SDK files are untouched. `PLACEMENTS_V` does not move. The judges' tree is unchanged in shape: they read the parse (pre-turns whose atoms build on their first read, hydrate where they read bodies).

**Measured** (`scripts/bench_asm_checkpoint.py` and `scripts/bench_chat_proto2.py`, the stage 4a worlds: six sessions compacting every forty turns; a first boot writes the documents, the second restores; fresh processes, one measurement per point): at 1x / 4x / 16x of 150 turns (leaves 3.11 / 12.46 / 49.97 MB, decimal MB) the restored boot adds 8.0 / 29.5 / 119.4 MB of resident size on main and 6.6 / 25.8 / 92.3 MB here: the built pre-cut atoms are gone from the boot, and what remains is the document's record rows (ten fields per record, decoded) and the atom rows as bytes beside the tail's parsed records, so the boot's slope is now the record cache's, the next target (romp_perf's byte budget on `_read_jsonl_incremental`). The first open of every chat then adds 8.3 / 27.5 / 100.8 MB on main against 4.3 / 3.5 / 7.0 MB here, reads 0.41 / 1.92 / 8.09 MB against nothing, and its slowest first frame takes 0.10 / 0.23 / 0.80 s against 0.06 / 0.07 / 0.15 s; the open hydrates 320 / 1492 / 6292 atoms on main and none here (the stage 4b floor, re-measured on this branch; the chat's first open builds no pre-cut atom either, `asmIndex` on the served kernel). Figures: `T323-stage4c-bench/boot/boot_cost_vs_size.png` and `T323-stage4c-bench/open/first_open_vs_size.png` under the research directory.

**Tests**: `tests/test_asm_index.py` (the coverage proof at write and restore, a tree cut short, an idle-only pre-cut turn, a tree yielding no section written once; the list surface hands out plain atoms and the storage stays out of reach; json is refused while a slot is unbuilt and a plain tree dumps; a pre-turn's scalars equal the whole parse's; eviction drops the memo and a rebuilt atom equals the first; a row that will not decode names the session and the row; a version-3 document and a version-4 one read by an older kernel fall back; a spoiled section digest falls back before any atom is built; the kernel's sources concatenate or dump no turn's atoms), `tests/test_asm_checkpoint.py` and `tests/test_chat_pages.py` re-proven over the section (restored equals whole for every compacting golden; pages plus the floor'd list equal the whole at every page size; the floor'd build builds no pre-cut atom and a page its own turns), `tests/test_chat_proto2_served.py` (the restored kernel's first opens built no pre-cut atom, read from `/perf`).

**Carried**: stage 5 (the agent files), and the record cache's byte budget (romp_perf's).

Tier: feature.
