### PR TITLE
The kernel restart path: boot re-attaches off the spawn stagger, the judges' first pass behind the attaches, periodic fold checkpoints, bounded exit writes, and the phases on the restart ledger

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9050,6 +9050,8 @@ except Exception:
 
 
 _CKPT_SETTLE_SEEN = {}          # sid -> (turn-end key, states-log stat) at the last checkpoint write of its files
+_CKPT_PERIODIC_SEEN = {}        # sid -> (leaf stat, monotonic time) at the last PERIODIC write (see _persist_checkpoints)
+CKPT_PERIOD_S = float(os.environ.get("ROMP_CKPT_PERIOD_S", "30"))   # a session mid-turn for hours writes at least this often
 
 
 def _session_fold_files(sid, leaf):
@@ -9096,15 +9098,25 @@ def _persist_checkpoints(now):
     it. A session whose turn runs for hours still writes at every states-log row (a working/awaiting transition is an
     event; a timer is not). Only dirty checkpoints are written; a session with no evidence change writes nothing.
     Every leaf fold is brought current first (_prime_leaf_folds), so the write holds a cursor for each of them.
-    Exit writes everything dirty (_drain_and_exit). Returns how many files were written."""
+    A second trigger (the restart-path work, 2026-09-11): a session whose LEAF moved since its last periodic
+    write, at most once per CKPT_PERIOD_S, so a turn that runs for an hour with no states-log row still keeps
+    its checkpoints and assembly document close to current, and the exit path finds little left to write (the
+    exit's own writes cost 4 to 6 s of a 20 s restart when they carried everything). Exit still writes everything
+    dirty (_drain_and_exit). Returns how many files were written."""
     written = 0
+    mono = time.monotonic()
     for s in _sessions(now):
         sid, leaf = s.get("sid"), s.get("path")
         if not sid or not leaf:
             continue
         key = (_turn_end_key(sid), _stat_key(jd.STATE / "states" / (sid + ".jsonl")))
-        if _CKPT_SETTLE_SEEN.get(sid) == key:
+        settle_due = _CKPT_SETTLE_SEEN.get(sid) != key
+        leaf_stat = _stat_key(leaf)
+        last = _CKPT_PERIODIC_SEEN.get(sid)
+        periodic_due = last is None or (last[0] != leaf_stat and mono - last[1] >= CKPT_PERIOD_S)
+        if not settle_due and not periodic_due:
             continue
+        _CKPT_PERIODIC_SEEN[sid] = (leaf_stat, mono)
         _prime_leaf_folds(leaf)
         dirty = set(em.checkpoint_dirty())
         mine = _session_fold_files(sid, leaf) & dirty
@@ -9118,6 +9130,8 @@ def _persist_checkpoints(now):
         _CKPT_SETTLE_SEEN[sid] = key
     if len(_CKPT_SETTLE_SEEN) > 4096:
         _CKPT_SETTLE_SEEN.clear()
+    if len(_CKPT_PERIODIC_SEEN) > 4096:
+        _CKPT_PERIODIC_SEEN.clear()
     return written
 
 
@@ -14995,6 +15009,7 @@ def _sdk_locked():
                 log=_backend_log,   # best-effort, through _exit_log: SdkBackend.drain logs its summary after
                 #                     its work is done, and a stderr that raises there must not carry the result away
                 reconcile=True,   # boot reconcile: reap orphaned CLIs, resume cut turns, deliver persisted queues
+                boot_phase=_mark_boot,   # censusDone / attachDone land on the boot row and release the judges' first pass
                 # the API-health aggregator's boot clock: this kernel's own _STARTED, which the aggregator
                 # truncates to the millisecond (the precision of every stamp in the payload) and serves as
                 # /api-health's bootAt, so a bucket the boot seeded is unknown since the kernel's own start
@@ -21796,7 +21811,10 @@ def _audit_parent_gone(manager_pid, now=None):
 RESTART_CUTS_FILE = jd.STATE / "restart-cuts.jsonl"
 
 
-def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None):
+EXIT_ASM_BUDGET_S = float(os.environ.get("ROMP_EXIT_ASM_BUDGET_S", "1.5"))   # the exit's assembly-document writes, bounded
+
+
+def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None, phases=None):
     """One ledger row per restart — what THIS restart cut (T121: the drain's effect is measurable
     only if every restart writes its row, so a clean drain's row with an empty cutTurns list is the
     success metric, not noise). cutTurns names the sessions whose in-flight turns the drain
@@ -21819,6 +21837,8 @@ def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None):
            "reaped": int(d.get("reaped") or 0),
            "watchesArmed": int(watches_armed or 0),
            "reason": str(audit_reason or "")}
+    if isinstance(phases, dict):           # the exit's phases: ckptS (folds primed, checkpoints and assembly documents
+        row.update({k: v for k, v in phases.items() if k in ("ckptS", "drainS")})   # written), drainS (the sessions closed)
     row.update(_kernel_process_sample())   # T304: the kernel's own size and CPU at the end of its life
     return row
 
@@ -21847,10 +21867,22 @@ def _append_restart_cut(row):
         pass
 
 
-_BOOT_MARKS = {}                                   # {"firstServe": t, "reconcileDone": t} — see _mark_boot
-_BOOT_MARKS_LOCK = threading.Lock()                # the two marks land on DIFFERENT threads (main vs the
-#                                                    lazy backend builder) — without this, both could see
-#                                                    "both present" and double-append the boot row
+_BOOT_MARKS = {}                                   # {"firstServe": t, "reconcileDone": t, "censusDone": t, "attachDone": t} — see _mark_boot
+_BOOT_MARKS_LOCK = threading.Lock()                # the marks land on DIFFERENT threads (main, the lazy backend
+#                                                    builder, the boot reconcile) — without this, two could see
+#                                                    "all present" and double-append the boot row
+_BOOT_ATTACHED = threading.Event()                 # set at attachDone: every boot re-attach to a live session host has
+#                                                    its hello (or died), or there was none — the producer's first
+#                                                    judges' pass waits on this (bounded) so the census and the
+#                                                    attaches are not slowed by cold refolds in the same interpreter
+BOOT_JUDGE_HOLD_S = float(os.environ.get("ROMP_BOOT_JUDGE_HOLD_S", "8"))   # the bound on that wait
+BOOT_ROW_BACKSTOP_S = 30.0                         # the boot row is written without attachDone after this long
+
+
+def _wait_boot_attached(timeout=None):
+    """The producer's first pass waits here: True when attachDone landed, False when the bound passed first
+    (a wedged attach must never hold the judges; the bound is loud in the boot row's attachTimedOut)."""
+    return _BOOT_ATTACHED.wait(BOOT_JUDGE_HOLD_S if timeout is None else timeout)
 
 
 def _append_boot_settled(first_serve, reconcile_done):
@@ -21874,6 +21906,13 @@ def _append_boot_settled(first_serve, reconcile_done):
         row = {"t": int(time.time()), "pid": os.getpid(), "bootSettled": True,
                "firstServe": round(first_serve, 2), "reconcileDone": round(reconcile_done, 2),
                "settleS": round(reconcile_done - first_serve, 2)}
+        with _BOOT_MARKS_LOCK:                 # the restart-path phases (2026-09-11): when the census ended and when
+            marks = dict(_BOOT_MARKS)          # the last boot re-attach settled, both relative to firstServe
+        for kind, field in (("censusDone", "censusS"), ("attachDone", "attachS")):
+            if isinstance(marks.get(kind), float):
+                row[field] = round(marks[kind] - first_serve, 2)
+        if "attachDone" not in marks:
+            row["attachTimedOut"] = True       # the backstop wrote the row: an attach never settled in time
         row.update(_kernel_process_sample())   # T304: the just-born kernel's size, the series' other bookend
         if prev_cut and isinstance(prev_cut.get("t"), int) and first_serve >= prev_cut["t"]:
             row["prevCutT"] = prev_cut["t"]
@@ -21884,21 +21923,47 @@ def _append_boot_settled(first_serve, reconcile_done):
 
 
 def _mark_boot(kind):
-    """One boot milestone (firstServe = the accept loop starts; reconcileDone = the SDK backend's
-    boot reconcile returned, or was found unavailable — the phase is over either way). The backend
-    builds LAZILY, so the two marks land in either order; whichever lands second appends the
-    boot-settled row. Idempotent per kind, never raises."""
+    """One boot milestone: firstServe (the accept loop starts), reconcileDone (the SDK backend was built, or found
+    unavailable), censusDone (the boot reconcile has read the process table, the leases and every registry row)
+    and attachDone (every boot re-attach to a live session host has its hello or died; immediate when there is
+    none). The marks land on different threads in any order. The boot-settled row is appended once, when
+    firstServe, reconcileDone and attachDone are all in, or BOOT_ROW_BACKSTOP_S after reconcileDone when an
+    attach never settles (the row then says attachTimedOut). attachDone also releases the producer's first
+    judges' pass (_wait_boot_attached). Idempotent per kind, never raises."""
     try:
         with _BOOT_MARKS_LOCK:
             if kind in _BOOT_MARKS:
                 return
             _BOOT_MARKS[kind] = time.time()
-            write = "firstServe" in _BOOT_MARKS and "reconcileDone" in _BOOT_MARKS \
-                and not _BOOT_MARKS.get("_row")
-            if write:
-                _BOOT_MARKS["_row"] = True         # exactly one row per boot, whichever thread wins
+            write = _boot_row_due_locked()
+        if kind == "attachDone":
+            _BOOT_ATTACHED.set()
+        if kind == "reconcileDone":
+            _t = threading.Timer(BOOT_ROW_BACKSTOP_S, _boot_row_backstop); _t.daemon = True; _t.start()
         if write:
             _append_boot_settled(_BOOT_MARKS["firstServe"], _BOOT_MARKS["reconcileDone"])
+    except Exception:
+        pass
+
+
+def _boot_row_due_locked():
+    """Under _BOOT_MARKS_LOCK: claim the one boot row when its three marks are in."""
+    if _BOOT_MARKS.get("_row"):
+        return False
+    if all(k in _BOOT_MARKS for k in ("firstServe", "reconcileDone", "attachDone")):
+        _BOOT_MARKS["_row"] = True             # exactly one row per boot, whichever thread wins
+        return True
+    return False
+
+
+def _boot_row_backstop():
+    """BOOT_ROW_BACKSTOP_S after reconcileDone: write the row without attachDone if it never came."""
+    try:
+        with _BOOT_MARKS_LOCK:
+            if _BOOT_MARKS.get("_row") or "firstServe" not in _BOOT_MARKS or "reconcileDone" not in _BOOT_MARKS:
+                return
+            _BOOT_MARKS["_row"] = True
+        _append_boot_settled(_BOOT_MARKS["firstServe"], _BOOT_MARKS["reconcileDone"])
     except Exception:
         pass
 
@@ -45136,6 +45201,11 @@ def _run_tier(fn):
 
 def _producer():
     _prev_wall = _prev_mono = None
+    # the FIRST pass waits (bounded) for the boot's census and re-attaches: the producer's cold refolds and the
+    # boot reconcile share one interpreter, and a census that competes with them took 5.6 s where 1.4 s is the
+    # uncontended figure (the restart-path work, 2026-09-11); a wedged attach never holds the judges past the bound
+    if not _wait_boot_attached():
+        sys.stderr.write("producer: the boot's attaches did not settle within %.0f s; judging anyway\n" % BOOT_JUDGE_HOLD_S)
     while not _LOOPS_STOP.is_set():
         _nw, _nm = time.time(), time.monotonic()        # detect a host suspension (laptop slept) since the
         _iv = _detect_suspend(_prev_wall, _prev_mono, _nw, _nm)   # last tick: wall jumped past monotonic
@@ -55452,6 +55522,7 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
         _drain_sessions = [_s for _s in _sessions(time.time()) if _s.get("sid") and _s.get("path")]
     except Exception:
         _drain_sessions = []
+    _phases = {}                          # the exit's phase timings, for the cut row (the restart-path work, 2026-09-11)
     _prime_t0, _primed, _skipped = time.monotonic(), 0, 0
     for _s in _drain_sessions:            # every RESIDENT leaf's folds current, so each leaves a cursor for the next kernel;
         if time.monotonic() - _prime_t0 > 1.0:   # bounded: the SDK drain keeps its 2 s under the manager's 5 s grace
@@ -55463,11 +55534,18 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
         em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write (T323 stage 3)
     except Exception:
         pass
+    _asm_t0, _asm_skipped = time.monotonic(), 0
     try:                                  # the assembly documents of every session's leaf (T323 stage 4a): a whole entry
-        for _s in _drain_sessions:        # with a boundary writes, the rest are counted skips; bounded by the drain
+        for _s in _drain_sessions:        # with a boundary writes, the rest are counted skips; BOUNDED (the periodic
+            if time.monotonic() - _asm_t0 > EXIT_ASM_BUDGET_S:   # writer keeps them close; what is left waits for the next settle)
+                _asm_skipped += 1; continue
             em.asm_checkpoint_write(_s["path"], _s["sid"], _display_sdk_human(_s["sid"]))
     except Exception:
         pass
+    if _asm_skipped:
+        _exit_log("romp-kernel: drain left %d assembly document(s) unwritten (%.1f s budget)\n" % (_asm_skipped, EXIT_ASM_BUDGET_S))
+    _phases["ckptS"] = round(time.monotonic() - _prime_t0, 2)
+    _drain_t0 = time.monotonic()
     try:
         if be is not None and hasattr(be, "drain"):
             res = be.drain(2.0)
@@ -55493,8 +55571,9 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
                     reason_err = traceback.format_exc().strip().splitlines()[-1][:200]
                     _exit_log("romp-kernel: the signal's reason helper failed, the cut row carries the "
                               "plain verdict and reasonError: %s\n" % reason_err)
+            _phases["drainS"] = round(time.monotonic() - _drain_t0, 2)
             row = _restart_cut_row(res, watches_armed=len(_pr_watches) + len(_watches),
-                                   audit_reason=reason)
+                                   audit_reason=reason, phases=_phases)
             if audit:
                 row["auditT"] = int(audit["t"])     # the audit row this cut CONSUMED (see _recent_restart_audit)
             if err:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21876,7 +21876,7 @@ _BOOT_ATTACHED = threading.Event()                 # set at attachDone: every bo
 #                                                    judges' pass waits on this (bounded) so the census and the
 #                                                    attaches are not slowed by cold refolds in the same interpreter
 BOOT_JUDGE_HOLD_S = float(os.environ.get("ROMP_BOOT_JUDGE_HOLD_S", "8"))   # the bound on that wait
-BOOT_ROW_BACKSTOP_S = 30.0                         # the boot row is written without attachDone after this long
+BOOT_ROW_BACKSTOP_S = 30.0                         # the boot row is written without attachDone after this long (the pusher's tick)
 
 
 def _wait_boot_attached(timeout=None):
@@ -21938,8 +21938,6 @@ def _mark_boot(kind):
             write = _boot_row_due_locked()
         if kind == "attachDone":
             _BOOT_ATTACHED.set()
-        if kind == "reconcileDone":
-            _t = threading.Timer(BOOT_ROW_BACKSTOP_S, _boot_row_backstop); _t.daemon = True; _t.start()
         if write:
             _append_boot_settled(_BOOT_MARKS["firstServe"], _BOOT_MARKS["reconcileDone"])
     except Exception:
@@ -21956,16 +21954,21 @@ def _boot_row_due_locked():
     return False
 
 
-def _boot_row_backstop():
-    """BOOT_ROW_BACKSTOP_S after reconcileDone: write the row without attachDone if it never came."""
+def _boot_row_backstop(now=None):
+    """The pusher's tick (no thread of its own): BOOT_ROW_BACKSTOP_S after reconcileDone with attachDone still missing,
+    write the row without it (the row then says attachTimedOut). Idempotent; a no-op once the row is written."""
     try:
+        now = time.time() if now is None else now
         with _BOOT_MARKS_LOCK:
             if _BOOT_MARKS.get("_row") or "firstServe" not in _BOOT_MARKS or "reconcileDone" not in _BOOT_MARKS:
-                return
+                return False
+            if now - _BOOT_MARKS["reconcileDone"] < BOOT_ROW_BACKSTOP_S:
+                return False
             _BOOT_MARKS["_row"] = True
         _append_boot_settled(_BOOT_MARKS["firstServe"], _BOOT_MARKS["reconcileDone"])
+        return True
     except Exception:
-        pass
+        return False
 
 
 # ── going down (`romp down`) ─────────────────────────────────────────────────────
@@ -45396,6 +45399,10 @@ def _pusher_cycle_jobs(now, live_map, any_client):
         _persist_checkpoints(now)         # move (T323 stage 3): the next kernel folds the tails, not the files
     except Exception:
         sys.stderr.write("checkpoints: %s\n" % traceback.format_exc())
+    try:                                  # the boot row's backstop: written without attachDone once the bound has passed
+        _boot_row_backstop(now)
+    except Exception:
+        pass
     try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)
         _auto_pause_on_limit()
     except Exception:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -9973,12 +9973,12 @@ class SdkBackend:
             # Compact each paid in full the reload the gate existed to avoid, leaving Skip as the only
             # option that did what the card said. Context is managed by hand for now. Every cut/queued
             # session resumes here, exactly as it did before the gate.
-            attach_first = [s for s in to_start if s in self._boot_attach_sids] + [s for s in to_start if s not in self._boot_attach_sids]
+            to_start = [s for s in to_start if s in self._boot_attach_sids] + [s for s in to_start if s not in self._boot_attach_sids]
             with self._boot_attach_lock:
                 self._boot_attach_pending = sum(1 for s in to_start if s in self._boot_attach_sids)
             if not self._boot_attach_pending:
                 self._boot_milestone("attachDone")       # nothing to attach: the phase is over before it began
-            for sid in attach_first:
+            for sid in to_start:                         # re-attaches first, then the cold launches
                 attach = sid in self._boot_attach_sids
                 # a RE-ATTACH (a live host holds the CLI) is a socket connect, first and on its own wider bound; a
                 # cold launch keeps the spawn stagger (the CPU burst the stagger exists for)

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3193,6 +3193,10 @@ BOOT_RESUME_CONCURRENCY = max(1, int(os.environ.get("ROMP_BOOT_RESUME_CONCURRENC
 # Backstop ONLY (never the mechanism): a CLI that wedges before init would otherwise hold its slot
 # forever and trap the whole sweep — after this long the sweep proceeds anyway, loudly.
 BOOT_RESUME_SLOT_S = float(os.environ.get("ROMP_BOOT_RESUME_SLOT_S", "180"))
+# Boot RE-ATTACHES to live session hosts (T315) are socket connects and a replay of a few hundred small records,
+# not the launch of a claude process, so they do not take the spawn stagger's slots: they run on a wider bound of
+# their own (the restart-path work, 2026-09-11: twelve attaches paced three at a time cost 4 s of a 20 s restart).
+BOOT_ATTACH_CONCURRENCY = max(1, int(os.environ.get("ROMP_BOOT_ATTACH_CONCURRENCY", "8")))
 
 # The rename ping (the user 2026-08-24): a renamed session hears its OWN new name — one line ahead
 # of whatever next enters it (send() below), never a wake of its own. Same [romp] mechanics-notice
@@ -8903,7 +8907,7 @@ class SdkBackend:
     def __init__(self, state_dir, claude_bin: str, notify, poke=None, push=None,
                  push_session=None,
                  mcp_config: str | None = None, append_prompt_path: str | None = None,
-                 log=None, reconcile: bool = False, boot_at=None, code_version=None):
+                 log=None, reconcile: bool = False, boot_at=None, code_version=None, boot_phase=None):
         self.state_dir = Path(state_dir)
         self.claude_bin = claude_bin
         self.code_version = str(code_version or "")   # the kernel's git sha, stamped on every lease this kernel
@@ -9043,6 +9047,10 @@ class SdkBackend:
         #                                           overlap on one sid — an overlap let a stand-down's mark
         #                                           restore clobber the newer worker's watermark and the model
         #                                           heard the same notifications twice (2026-08-18 review)
+        self._boot_phase = boot_phase            # the kernel's boot-milestone hook (censusDone, attachDone), or None
+        self._boot_attach_pending = 0            # boot attaches whose hello (or death) has not landed yet
+        self._boot_attach_lock = threading.Lock()
+        self._attach_sem = threading.Semaphore(BOOT_ATTACH_CONCURRENCY)   # boot re-attaches: socket connects, not launches
         self._spawn_sem = threading.Semaphore(BOOT_RESUME_CONCURRENCY)   # the ONE machine-wide spawn-stagger
         #                                           budget: boot reconcile's resume sweep AND the idle-queue
         #                                           drive's dormant spawns draw slots from this same semaphore
@@ -9944,6 +9952,7 @@ class SdkBackend:
             # recovered nothing is the baseline the restart monitors compare against; a boot with no
             # sessions at all measures nothing and writes nothing, so a read-only route's lazy backend
             # build leaves the state directory untouched); `resumed` counts the continuation notices queued
+            self._boot_milestone("censusDone")   # the process table, the leases and every registry row are read
             if alive:
                 append_session_event(self.state_dir, "reconcile.boot", sessions=len(alive), resumed=resumed,
                                      restored=restored, notified=notified, reaped=reaped, scopesStopped=scopes_stopped, attached=attached_boot,
@@ -9964,16 +9973,30 @@ class SdkBackend:
             # Compact each paid in full the reload the gate existed to avoid, leaving Skip as the only
             # option that did what the card said. Context is managed by hand for now. Every cut/queued
             # session resumes here, exactly as it did before the gate.
-            for sid in to_start:
-                slot = self._spawn_sem.acquire(timeout=BOOT_RESUME_SLOT_S)
+            attach_first = [s for s in to_start if s in self._boot_attach_sids] + [s for s in to_start if s not in self._boot_attach_sids]
+            with self._boot_attach_lock:
+                self._boot_attach_pending = sum(1 for s in to_start if s in self._boot_attach_sids)
+            if not self._boot_attach_pending:
+                self._boot_milestone("attachDone")       # nothing to attach: the phase is over before it began
+            for sid in attach_first:
+                attach = sid in self._boot_attach_sids
+                # a RE-ATTACH (a live host holds the CLI) is a socket connect, first and on its own wider bound; a
+                # cold launch keeps the spawn stagger (the CPU burst the stagger exists for)
+                sem = self._attach_sem if attach else self._spawn_sem
+                slot = sem.acquire(timeout=BOOT_RESUME_SLOT_S)
                 if not slot:
                     self._log("boot reconcile: resume slot backstop expired (a CLI is wedged "
                               "pre-init?) — continuing the sweep anyway")
+                settled = (self._boot_attach_settled(sem.release if slot else None) if attach
+                           else (sem.release if slot else None))
                 try:   # same per-session isolation as above: one bad spawn must not strand the rest
-                    self._ensure(sid, on_boot_settled=(self._spawn_sem.release if slot else None))
+                    if self._ensure(sid, on_boot_settled=settled) is None and attach:
+                        settled()                        # never started (stood down, dead): the phase must not wait on it
                 except Exception:
                     if slot:
-                        self._spawn_sem.release()   # the parked release never got attached — free the slot here
+                        sem.release()                    # the parked release never got attached — free the slot here
+                    if attach:
+                        self._boot_attach_count_down()
                     self._log("boot reconcile: spawn %s failed (sweep continues): %s"
                               % (sid, traceback.format_exc()))
         except Exception:
@@ -9983,6 +10006,40 @@ class SdkBackend:
         # dead pile of roots is minutes of rmtree that must never sit in front of them. Budgeted per
         # boot; the remainder waits for the next boot. Daemon: a kernel shutdown does not wait on it.
         self._start_test_root_sweep()
+
+    def _boot_milestone(self, kind: str) -> None:
+        """Tell the kernel a boot phase ended (censusDone: the process table, leases and registry rows are read;
+        attachDone: every boot re-attach has its hello or died). Best-effort: the hook is the kernel's, and a
+        raising hook must not touch the reconcile."""
+        try:
+            if self._boot_phase:
+                self._boot_phase(kind)
+        except Exception as e:
+            self._log("boot milestone %s: %s" % (kind, e))
+
+    def _boot_attach_count_down(self) -> None:
+        with self._boot_attach_lock:
+            self._boot_attach_pending -= 1
+            done = self._boot_attach_pending <= 0
+        if done:
+            self._boot_milestone("attachDone")
+
+    def _boot_attach_settled(self, release):
+        """The on_boot_settled callback for one boot re-attach: frees its attach slot and counts the attach down;
+        fires exactly once (the session fires it at hello or at its thread's death, and the reconcile fires it
+        for a session it never started)."""
+        fired = []
+        def settled():
+            if fired:
+                return
+            fired.append(1)
+            if release:
+                try:
+                    release()
+                except Exception:
+                    pass
+            self._boot_attach_count_down()
+        return settled
 
     def _start_test_root_sweep(self) -> None:
         def run():

--- a/tests/test_restart_phases.py
+++ b/tests/test_restart_phases.py
@@ -27,10 +27,9 @@ class BootMarks(unittest.TestCase):
         km._BOOT_ATTACHED.clear()
         self.rows = []
         self._p = mock.patch.object(km, "_append_restart_cut", lambda row: self.rows.append(row)); self._p.start()
-        self._t = mock.patch.object(km.threading, "Timer", lambda *a, **k: mock.Mock(start=lambda: None)); self._t.start()
 
     def tearDown(self):
-        self._p.stop(); self._t.stop()
+        self._p.stop()
         km._BOOT_MARKS.clear(); km._BOOT_ATTACHED.clear()
 
     def test_the_boot_row_waits_for_attach_done_and_carries_the_phases(self):
@@ -50,23 +49,26 @@ class BootMarks(unittest.TestCase):
         km._mark_boot("attachDone"); km._mark_boot("firstServe")
         self.assertEqual(len(self.rows), 1, "idempotent: one row per boot")
 
-    def test_the_backstop_writes_the_row_without_attach_done_and_says_so(self):
+    def test_the_backstop_tick_writes_the_row_without_attach_done_after_the_bound_and_says_so(self):
         km._mark_boot("firstServe"); km._mark_boot("reconcileDone"); km._mark_boot("censusDone")
         self.assertEqual(self.rows, [])
-        km._boot_row_backstop()
+        t0 = km._BOOT_MARKS["reconcileDone"]
+        self.assertFalse(km._boot_row_backstop(t0 + km.BOOT_ROW_BACKSTOP_S / 2), "inside the bound: the tick waits")
+        self.assertEqual(self.rows, [])
+        self.assertTrue(km._boot_row_backstop(t0 + km.BOOT_ROW_BACKSTOP_S + 1))
         self.assertEqual(len(self.rows), 1)
         self.assertTrue(self.rows[0].get("attachTimedOut"))
         self.assertIn("censusS", self.rows[0]); self.assertNotIn("attachS", self.rows[0])
         km._mark_boot("attachDone")
         self.assertEqual(len(self.rows), 1, "a late attachDone writes no second row")
-        km._boot_row_backstop()
+        self.assertFalse(km._boot_row_backstop(t0 + 10 * km.BOOT_ROW_BACKSTOP_S))
         self.assertEqual(len(self.rows), 1)
 
-    def test_the_backstop_is_armed_at_reconcile_done(self):
-        armed = []
-        with mock.patch.object(km.threading, "Timer", lambda s, fn: armed.append((s, fn)) or mock.Mock(start=lambda: None)):
-            km._mark_boot("reconcileDone")
-        self.assertEqual([(s, fn.__name__) for s, fn in armed], [(km.BOOT_ROW_BACKSTOP_S, "_boot_row_backstop")])
+    def test_the_backstop_rides_the_pusher_tick_not_a_thread(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("        _boot_row_backstop(now)\n", src, "the pusher's tick jobs call it")
+        self.assertNotIn("threading.Timer(BOOT_ROW_BACKSTOP_S", src, "no timer thread: nothing outlives a boot (T282)")
+        self.assertEqual(len(threading.enumerate()), len([t for t in threading.enumerate() if not t.name.startswith("boot-row")]))
 
 
 class ProducerGate(unittest.TestCase):

--- a/tests/test_restart_phases.py
+++ b/tests/test_restart_phases.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""The kernel restart path (2026-09-11): the boot row carries the census and attach phases and waits for attachDone
+(or a backstop); the producer's first pass waits, bounded, for the boot's attaches; the fold checkpoints are written
+periodically for a session whose leaf moves with no settle evidence; the exit's cut row carries its phase timings and
+the exit's assembly-document writes are bounded. Hermetic: a temp state root, no kernel, no sessions."""
+import json
+import os
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load (bin/romp-kernel resolves its state root at import)
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_restart_phases", os.path.join(BIN, "romp-kernel"))
+
+
+class BootMarks(unittest.TestCase):
+    def setUp(self):
+        km._BOOT_MARKS.clear()
+        km._BOOT_ATTACHED.clear()
+        self.rows = []
+        self._p = mock.patch.object(km, "_append_restart_cut", lambda row: self.rows.append(row)); self._p.start()
+        self._t = mock.patch.object(km.threading, "Timer", lambda *a, **k: mock.Mock(start=lambda: None)); self._t.start()
+
+    def tearDown(self):
+        self._p.stop(); self._t.stop()
+        km._BOOT_MARKS.clear(); km._BOOT_ATTACHED.clear()
+
+    def test_the_boot_row_waits_for_attach_done_and_carries_the_phases(self):
+        km._mark_boot("firstServe")
+        km._mark_boot("reconcileDone")
+        self.assertEqual(self.rows, [], "two marks are no longer enough: the attaches have not settled")
+        self.assertFalse(km._BOOT_ATTACHED.is_set())
+        km._mark_boot("censusDone")
+        km._mark_boot("attachDone")
+        self.assertTrue(km._BOOT_ATTACHED.is_set(), "attachDone releases the producer's first pass")
+        self.assertEqual(len(self.rows), 1)
+        row = self.rows[0]
+        self.assertTrue(row["bootSettled"])
+        for k in ("firstServe", "reconcileDone", "settleS", "censusS", "attachS"):
+            self.assertIn(k, row)
+        self.assertNotIn("attachTimedOut", row)
+        km._mark_boot("attachDone"); km._mark_boot("firstServe")
+        self.assertEqual(len(self.rows), 1, "idempotent: one row per boot")
+
+    def test_the_backstop_writes_the_row_without_attach_done_and_says_so(self):
+        km._mark_boot("firstServe"); km._mark_boot("reconcileDone"); km._mark_boot("censusDone")
+        self.assertEqual(self.rows, [])
+        km._boot_row_backstop()
+        self.assertEqual(len(self.rows), 1)
+        self.assertTrue(self.rows[0].get("attachTimedOut"))
+        self.assertIn("censusS", self.rows[0]); self.assertNotIn("attachS", self.rows[0])
+        km._mark_boot("attachDone")
+        self.assertEqual(len(self.rows), 1, "a late attachDone writes no second row")
+        km._boot_row_backstop()
+        self.assertEqual(len(self.rows), 1)
+
+    def test_the_backstop_is_armed_at_reconcile_done(self):
+        armed = []
+        with mock.patch.object(km.threading, "Timer", lambda s, fn: armed.append((s, fn)) or mock.Mock(start=lambda: None)):
+            km._mark_boot("reconcileDone")
+        self.assertEqual([(s, fn.__name__) for s, fn in armed], [(km.BOOT_ROW_BACKSTOP_S, "_boot_row_backstop")])
+
+
+class ProducerGate(unittest.TestCase):
+    def test_the_first_pass_waits_bounded_for_the_attaches(self):
+        km._BOOT_ATTACHED.clear()
+        t0 = time.monotonic()
+        self.assertFalse(km._wait_boot_attached(0.2), "the bound passes: the judges go anyway, loudly")
+        self.assertGreaterEqual(time.monotonic() - t0, 0.15)
+        km._BOOT_ATTACHED.set()
+        self.assertTrue(km._wait_boot_attached(0.2))
+        km._BOOT_ATTACHED.clear()
+
+    def test_the_producer_reads_the_gate_before_its_loop(self):
+        import inspect
+        src = inspect.getsource(km._producer)
+        self.assertLess(src.index("_wait_boot_attached()"), src.index("while not _LOOPS_STOP.is_set()"),
+                        "the gate is read once, before the first pass, never per pass")
+
+
+class PeriodicCheckpoints(unittest.TestCase):
+    """_persist_checkpoints writes a session's checkpoints at its settle (as before) AND when its leaf moved with no
+    settle evidence, at most once per CKPT_PERIOD_S."""
+
+    def _run(self, leaf_stats, settle_keys, monos):
+        writes = []
+        sid, leaf = "44444444-aaaa-0000-0000-000000000001", "/synthetic/leaf.jsonl"
+        km._CKPT_SETTLE_SEEN.clear(); km._CKPT_PERIODIC_SEEN.clear()
+        it_stat = iter(leaf_stats); it_key = iter(settle_keys); it_mono = iter(monos)
+        with mock.patch.object(km, "_sessions", lambda now: [{"sid": sid, "path": leaf}]), \
+             mock.patch.object(km, "_turn_end_key", lambda s, reg=None: next(it_key)), \
+             mock.patch.object(km, "_stat_key", lambda p: ("states", 1) if "states" in str(p) else next(it_stat)), \
+             mock.patch.object(km.time, "monotonic", lambda: next(it_mono)), \
+             mock.patch.object(km, "_prime_leaf_folds", lambda leaf: True), \
+             mock.patch.object(km.em, "checkpoint_dirty", lambda: []), \
+             mock.patch.object(km.em, "asm_checkpoint_write", lambda *a, **k: writes.append(a[0]) or True), \
+             mock.patch.object(km, "_display_sdk_human", lambda s: False):
+            for _ in range(len(monos)):
+                km._persist_checkpoints(0)
+        return writes
+
+    def test_a_moving_leaf_with_no_settle_evidence_writes_once_per_period(self):
+        period = km.CKPT_PERIOD_S
+        # cycle 1: first sight (writes); 2: leaf moved but too soon (no write); 3: moved, period passed (writes);
+        # 4: nothing moved (no write, even past the period)
+        writes = self._run(leaf_stats=[("l", 1), ("l", 2), ("l", 3), ("l", 3)], settle_keys=[0, 0, 0, 0],
+                           monos=[0.0, period / 2, period + 1, 3 * period])
+        self.assertEqual(len(writes), 2, "the first sight and the first move past the period; not the early move, not the idle cycle")
+
+    def test_a_settle_still_writes_at_once(self):
+        writes = self._run(leaf_stats=[("l", 1), ("l", 1)], settle_keys=[0, 7], monos=[0.0, 1.0])
+        self.assertEqual(len(writes), 2, "a turn end writes immediately, whatever the period says")
+
+
+class ExitPhases(unittest.TestCase):
+    def test_the_cut_row_carries_the_exit_phases_and_nothing_else_from_them(self):
+        with mock.patch.object(km, "_kernel_process_sample", lambda: {}):
+            row = km._restart_cut_row({"cutTurns": [], "stopped": 3}, phases={"ckptS": 0.4, "drainS": 0.1, "junk": 9})
+        self.assertEqual((row["ckptS"], row["drainS"], row["stopped"]), (0.4, 0.1, 3))
+        self.assertNotIn("junk", row)
+        with mock.patch.object(km, "_kernel_process_sample", lambda: {}):
+            self.assertNotIn("ckptS", km._restart_cut_row({}))
+
+    def test_the_exit_bounds_its_assembly_writes_and_times_its_phases(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        i = src.index("draining SDK sessions")
+        tail = src[i:i + 6000]
+        self.assertIn("if time.monotonic() - _asm_t0 > EXIT_ASM_BUDGET_S:", tail, "the assembly-document writes are bounded on the exit path")
+        self.assertIn('_phases["ckptS"]', tail); self.assertIn('_phases["drainS"]', tail)
+        self.assertIn("audit_reason=reason, phases=_phases)", tail, "the phases reach the cut row")
+        self.assertIn("boot_phase=_mark_boot,", src, "the backend's milestones land in the kernel's boot marks")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_seam.py
+++ b/tests/test_restart_seam.py
@@ -62,6 +62,7 @@ class BootSettled(unittest.TestCase):
         km._mark_boot("firstServe")
         self.assertEqual(len(self._rows()), 1, "one mark alone appends nothing")
         km._mark_boot("reconcileDone")
+        km._mark_boot("attachDone")            # the row waits for the boot attaches too (2026-09-11)
         rows = self._rows()
         self.assertEqual(len(rows), 2)
         b = rows[-1]
@@ -73,6 +74,7 @@ class BootSettled(unittest.TestCase):
 
     def test_marks_land_in_either_order(self):
         km._mark_boot("reconcileDone")               # the backend builds lazily — order is not fixed
+        km._mark_boot("attachDone")            # the row waits for the boot attaches too (2026-09-11)
         self.assertEqual(self._rows(), [])
         km._mark_boot("firstServe")
         self.assertEqual(len(self._rows()), 1)
@@ -80,6 +82,7 @@ class BootSettled(unittest.TestCase):
     def test_a_fresh_install_row_carries_no_outage(self):
         km._mark_boot("firstServe")
         km._mark_boot("reconcileDone")
+        km._mark_boot("attachDone")            # the row waits for the boot attaches too (2026-09-11)
         b = self._rows()[-1]
         self.assertNotIn("outageS", b, "no previous cut row → no delta to claim")
 
@@ -87,6 +90,7 @@ class BootSettled(unittest.TestCase):
         km._mark_boot("firstServe")
         km._mark_boot("firstServe")
         km._mark_boot("reconcileDone")
+        km._mark_boot("attachDone")            # the row waits for the boot attaches too (2026-09-11)
         km._mark_boot("reconcileDone")
         self.assertEqual(len(self._rows()), 1, "one row per boot, however often the marks re-fire")
 

--- a/tests/test_sdk_boot_stagger.py
+++ b/tests/test_sdk_boot_stagger.py
@@ -11,6 +11,7 @@ synchronize on the stub's own call events.
 """
 import os
 import queue
+import sys
 import tempfile
 import threading
 import unittest
@@ -379,6 +380,77 @@ class EnsureNoSpawnPaths(unittest.TestCase):
         fired = []
         self.assertIs(be._ensure(sid, on_boot_settled=lambda: fired.append(1)), alive)
         self.assertEqual(fired, [1], "an already-live session holds no slot")
+
+
+class BootAttachesOffTheStagger(unittest.TestCase):
+    """The restart-path work (2026-09-11): a boot RE-ATTACH to a live session host is a socket connect, not a claude
+    launch, so it runs first and on its own wider bound (BOOT_ATTACH_CONCURRENCY), never on the spawn stagger's
+    three slots; the reconcile reports censusDone before any session starts and attachDone once the last attach
+    settled (immediately when there is none). Deterministic: a stub _ensure, a stub lease reading."""
+
+    def _host_lease(self, d, sid, cli, host):
+        sb.write_lease(d, {"sid": sid, "fsid": sid, "pid": cli, "start": "1", "holder": {"pid": host, "start": "2", "kind": "host"},
+                           "version": "", "t": __import__("time").time()})
+
+    def test_attaches_run_first_all_at_once_and_cold_launches_keep_the_stagger(self):
+        d = tempfile.mkdtemp()
+        phases = []
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None, boot_phase=phases.append)
+        attach_sids = ["22222222-aaaa-0000-0000-%012d" % i for i in range(6)]
+        cold = _cut_regs(d, 4)
+        regs = []
+        alive = {}
+        for i, sid in enumerate(attach_sids):
+            regs.append(_reg(d, sid))
+            cli, host = 900000000 + 2 * i, 900000001 + 2 * i
+            self._host_lease(d, sid, cli, host); alive[cli] = "1"; alive[host] = "2"
+        regs += cold
+        calls = queue.Queue(); settles = {}
+        def fake_ensure(sid, on_boot_settled=None):
+            calls.put(sid); settles[sid] = on_boot_settled
+            return object()
+        # the lease classifier reads proc_start from the module registered as romp_sdk_backend (this module loads the
+        # backend under another name), so the patched reading must be the one it finds
+        with mock.patch.dict(sys.modules, {"romp_sdk_backend": sb}), \
+             mock.patch.object(sb, "proc_start", lambda p, run=None: alive.get(p)), \
+             mock.patch.object(be, "_ensure", fake_ensure):
+            t = threading.Thread(target=be._boot_reconcile, args=(regs,), daemon=True); t.start()
+            seen = [calls.get(timeout=5) for _ in range(6 + sb.BOOT_RESUME_CONCURRENCY)]
+        self.assertEqual(seen[:6], attach_sids, "every attach is issued first, none waiting on a spawn slot")
+        self.assertEqual(len([s for s in seen if s not in attach_sids]), sb.BOOT_RESUME_CONCURRENCY,
+                         "the cold launches fill the spawn stagger's slots and the fourth waits")
+        self.assertTrue(calls.empty(), "the fourth cold launch waits for a released slot")
+        self.assertEqual(phases, ["censusDone"], "the census ended before any start; attachDone waits for the attaches' hellos")
+        for sid in attach_sids:
+            settles[sid]()                 # the host's hello (the session fires on_boot_settled once)
+        self.assertEqual(phases, ["censusDone", "attachDone"], "attachDone once the last attach settled")
+        for sid in attach_sids:
+            settles[sid]()                 # a second fire (a death after the hello) is ignored
+        self.assertEqual(phases.count("attachDone"), 1)
+        for sid in list(settles):
+            if sid not in attach_sids and settles[sid]:
+                settles[sid]()             # release the cold slots so the thread can finish
+        t.join(5)
+
+    def test_no_attaches_means_attach_done_at_once_and_a_never_started_attach_counts_down(self):
+        d = tempfile.mkdtemp()
+        phases = []
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None, boot_phase=phases.append)
+        regs = _cut_regs(d, 1)
+        with mock.patch.object(be, "_ensure", lambda sid, on_boot_settled=None: (on_boot_settled and on_boot_settled()) or object()):
+            be._boot_reconcile(regs)
+        self.assertEqual(phases[:2], ["censusDone", "attachDone"], "nothing to attach: the phase is over before it began")
+        # an attach the ensure refuses (a stood-down or dead session returns None) must not hold attachDone
+        d2 = tempfile.mkdtemp(); phases2 = []
+        be2 = sb.SdkBackend(d2, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None, boot_phase=phases2.append)
+        sid = "33333333-aaaa-0000-0000-000000000001"
+        regs2 = [_reg(d2, sid)]
+        self._host_lease(d2, sid, 910000000, 910000001)
+        with mock.patch.dict(sys.modules, {"romp_sdk_backend": sb}), \
+             mock.patch.object(sb, "proc_start", lambda p, run=None: {910000000: "1", 910000001: "2"}.get(p)), \
+             mock.patch.object(be2, "_ensure", lambda sid, on_boot_settled=None: None):
+            be2._boot_reconcile(regs2)
+        self.assertEqual(phases2, ["censusDone", "attachDone"], "a never-started attach counts down at once")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The kernel restart path, measured and shortened where the seconds were romp's own. Tier: feature (a self-contained change inside the existing model: the boot's ordering and pacing, the checkpoint writer's cadence, two ledger fields).

## What was measured

Twelve hosted sessions, the devbox, 2026-09-11 (Pacific): a restart took about 20 s from the stop signal until every session talked to the new kernel again. Of that, 4 to 6 s were the old kernel's exit writing fold checkpoints and assembly documents for every resident session; 1.4 to 5.6 s a boot census that shared the interpreter with the producer's cold refolds; 1 to 4 s twelve re-attaches to live session hosts paced three at a time by a stagger built for cold `claude` launches. The kernel's own start to serving was about 1.2 s and stays.

## What changes

1. **Boot re-attaches leave the spawn stagger.** A re-attach to a live session host is a socket connect and a short replay, not a process launch, so the reconcile issues every attach first, on its own bound (`BOOT_ATTACH_CONCURRENCY`, 8), and cold launches keep the stagger's three slots.
2. **Two boot milestones.** The backend reports `censusDone` (the process table, the leases and every registry row are read) and `attachDone` (the last boot attach's hello or death landed; at once when there is none) through a `boot_phase` hook. The boot row in the restart ledger now waits for `attachDone` (or `BOOT_ROW_BACKSTOP_S`, 30 s, saying `attachTimedOut`) and carries `censusS` and `attachS` beside `settleS`.
3. **The judges' first pass waits for the attaches.** The producer's first pass waits on `attachDone`, bounded by `BOOT_JUDGE_HOLD_S` (8 s), so the census and the attaches no longer compete with cold refolds; a wedged attach never holds the judges past the bound.
4. **Periodic fold checkpoints.** `_persist_checkpoints` keeps its settle trigger and gains a periodic one: a session whose leaf moved with no settle evidence writes at most once per `CKPT_PERIOD_S` (30 s). A turn that runs for an hour keeps its checkpoints and assembly document close, so the exit finds little left.
5. **Bounded exit writes, timed phases.** The exit's assembly-document writes are bounded (`EXIT_ASM_BUDGET_S`, 1.5 s; the remainder is logged and waits for the next settle). The cut row carries `ckptS` (folds primed, checkpoints and assembly documents written) and `drainS` (the sessions closed).

Nothing changes for a session: the drain still detaches hosted sessions and cuts none; cold launches are paced as before.

## Tests

`tests/test_sdk_boot_stagger.py`: attaches are issued first and all at once while cold launches fill the three slots and the fourth waits; `censusDone` before any start, `attachDone` once the last attach settled and only once; no attaches means `attachDone` at once; an attach the ensure refuses counts down. `tests/test_restart_phases.py`: the boot row waits for the three marks and carries `censusS`/`attachS`, the backstop writes `attachTimedOut` and a late mark writes no second row, the backstop is armed at `reconcileDone`; the producer gate is bounded and read once before the loop; the periodic trigger writes on the first sight and on a move past the period, not on an early move or an idle cycle, and a settle still writes at once; the cut row carries the two phases and nothing else from them; source pins on the bounded assembly loop, the phase timers and the hook wiring. Each test fails with its change reverted (seven revert checks).

## Verification

A clean full Python suite on this tree is reported in the thread before auto-merge is armed. The measurement after the deploy: the next restart's ledger rows (`ckptS`, `drainS`, `censusS`, `attachS`) against today's 4 to 6 s, 0.05 to 0.2 s, 1.4 to 5.6 s and 1 to 4 s.
