### PR TITLE
The chat wire's re-attach reads the run the client holds, never the broadcast diff; the warming settles a tail-only board and counts a shared page once

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1623,7 +1623,10 @@ announces `chatProto2` in its `caps`:
   re-attaches it (the page's "Return to live" strip and its jump chip ask for
   one, and the full frame answering that ask merges into the held run it
   overlaps, so the pages the reader walked stay, the kernel's base keeping the
-  run's older first edge with it; every other full frame replaces the run, its
+  run's older first edge with it (the page sends its newest resident keys with
+  the ask, `reattachKeys`, and the kernel keeps the older edge when the highest
+  of them still in the list lies inside the frame); every other full frame
+  replaces the run, its
   in-list events being the fresh copies); a reconnect's `ready` starts a fresh
   base. A window that overlaps the run the client holds
   through the live tail, by turn span, keeps it attached (`connected`; a

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27384,7 +27384,8 @@ def _ledger_memo_report():
 # only draws a window) and streams OLDER history in on scroll-back, WIRE_CHUNK events per `loadOlder` request.
 # The build itself is unchanged (every session still builds its full events + ledger — so the Fleet ledger
 # that rides the chat builds is intact); only what crosses the wire is trimmed.
-WIRE_TAIL = 250                                  # events shipped on a full chat send; older streams in on scroll-back
+WIRE_TAIL = 250
+REATTACH_KEYS = 512                              # the newest resident keys a proto-2 client sends with its re-attach ask                                  # events shipped on a full chat send; older streams in on scroll-back
 WIRE_CHUNK = 250                                 # events per loadOlder (chatHead) response
 
 
@@ -40098,9 +40099,10 @@ def _reattach_edge(client, sid, msg):
         return None
     with _client_lock(client):
         old = (client.get("echat") or {}).get(sid)
+        keys = (client.get("reattachKeys") or {}).pop(sid, None)   # the client's newest resident keys (reattachKeys, M1)
     if not isinstance(old, dict) or not old.get("first"):
         return None
-    return {"first": old["first"], "last": old.get("last"), "detached": False, "reattach": True}
+    return {"first": old["first"], "last": old.get("last"), "detached": False, "reattach": True, "keys": keys}
 
 
 def _client_reset_chat_base(client):
@@ -41020,8 +41022,9 @@ def _warm_history_pages(feed, now, live_map=None):
             if keys and len(keys | set(window)) > WARM_PAGES_MAX:
                 pending += 1                      # its pages would take the set past the bound: it waits (a shared page is free)
                 continue
+            new_keys = [k for k in window if k not in keys]     # a page two windows share is probed, rendered and counted once
             keys.update(window)
-            for key in window:
+            for key in new_keys:
                 with _page_lock:
                     hit = _PAGE_CACHE.get(key)
                 if hit is None:
@@ -41037,8 +41040,8 @@ def _warm_history_pages(feed, now, live_map=None):
         _PAGE_STATS["warmPending"] = pending
         _PAGE_STATS["warmMs"] += (time.monotonic() - t0) * 1000.0
         _PAGE_STATS["warmCycles"] += 1
-        resident_all = bool(keys) and unresolved == 0 and all(k in _PAGE_CACHE for k in keys)   # an empty or unresolved set is
-    if resident_all:                                                                              #  never "settled" (round 3, A)
+        resident_all = unresolved == 0 and all(k in _PAGE_CACHE for k in keys)   # an unresolved set is never "settled" (round 3, A); a
+    if resident_all:                                                                #  resolved board with every anchor in the tail settles EMPTY
         _WARM_MEMO.update(anchors=tuple(anchors), keys=frozenset(keys), sigs={sid_: e[4] for sid_, e in per_sid.items() if e is not None})
     else:
         _WARM_MEMO.update(anchors=(), keys=frozenset(), sigs={})
@@ -41383,14 +41386,18 @@ def _send_chat_proto2(c, m, ms, change_from, led_changed, st, pc):
         # newest event left the list (a fork, a /clear) is replaced on the client, and the frame's first is the base's
         pos = _uuid_positions(evs, sid)
         pf, pl = pos.get(pc["first"]), pos.get(pc.get("last"))
-        # the run shares a key with the frame (the client's merge overlaps on ANY resident key) when its newest event is
-        # inside the frame, or, its newest gone (a fork rewrote the tail), when the fork point lies inside the frame: the
-        # run held everything up to its newest, so the keys just below the fork point survive in the list and are in the
-        # frame exactly when the fork left fewer than WIRE_TAIL new events behind it (round 4: a fork of 250 or more
-        # leaves no run key in the frame, the client replaces, and the base takes the frame's first with it). The fork
-        # point is this push's change index (the shared diff against the last list sent).
-        fork_in_frame = pl is None and 0 < change_from < total and change_from > head_from
-        shared = (pl is not None and pl >= head_from) or fork_in_frame
+        # the run shares a key with the frame (the client's merge overlaps on ANY resident key) when the highest RESIDENT
+        # key of the run, as the client holds it, lies inside the frame: the client sends its newest REATTACH_KEYS keys with
+        # the ask (reattachKeys), and a fork that cut them all leaves no shared key (the client replaces, and the base takes
+        # the frame's first with it). The broadcast diff's change index is no fork point here: the repair frame is a
+        # connect push over an unchanged build (M1). An older bundle sends no keys: its newest edge decides. A resident key
+        # is required either way (M2): a run the fork cut entirely is replaced, never given a first that is in no list.
+        keys = pc.get("keys")
+        if keys is not None:
+            res = [pos[k] for k in keys if k in pos]
+            shared = bool(res) and max(res) >= head_from
+        else:
+            shared = pl is not None and pl >= head_from
         if shared and (pf is None or pf < head_from):
             first = pc["first"]
     st[sid] = {"first": first, "last": _last_anchor(evs), "detached": False}
@@ -54632,6 +54639,13 @@ class Handler(BaseHTTPRequestHandler):
             # client, and two threads over its held state would rebase a full the dedup then swallowed.
             client.setdefault("resync", set()).add(str(msg["slot"]))
             _pusher_wake.set()
+            return
+        if msg and msg.get("type") == "reattachKeys" and msg.get("id"):
+            # a proto-2 client's newest resident keys, sent right before its needFull("reattach") (T323 follow-up, M1): the
+            # repair frame's shared clause reads THESE, the run as the client holds it, not the broadcast diff's change index
+            keys = [str(k) for k in (msg.get("keys") or []) if k][-REATTACH_KEYS:]
+            with _client_lock(client):
+                client.setdefault("reattachKeys", {})[str(msg["id"])] = keys
             return
         if msg and msg.get("type") == "needFull" and msg.get("id"):
             # The client REJECTED a delta because it started past what it holds (render.ts chatTail's gap

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -27384,8 +27384,9 @@ def _ledger_memo_report():
 # only draws a window) and streams OLDER history in on scroll-back, WIRE_CHUNK events per `loadOlder` request.
 # The build itself is unchanged (every session still builds its full events + ledger — so the Fleet ledger
 # that rides the chat builds is intact); only what crosses the wire is trimmed.
-WIRE_TAIL = 250
-REATTACH_KEYS = 512                              # the newest resident keys a proto-2 client sends with its re-attach ask                                  # events shipped on a full chat send; older streams in on scroll-back
+WIRE_TAIL = 250                                 # events shipped on a full chat send; older streams in on scroll-back
+REATTACH_KEYS = 512                              # the newest resident keys a proto-2 client sends with its re-attach ask
+REATTACH_KEYS_CLIENTS = 16                       # sessions whose posted keys one client may hold at once (the oldest dropped)
 WIRE_CHUNK = 250                                 # events per loadOlder (chatHead) response
 
 
@@ -54644,8 +54645,14 @@ class Handler(BaseHTTPRequestHandler):
             # a proto-2 client's newest resident keys, sent right before its needFull("reattach") (T323 follow-up, M1): the
             # repair frame's shared clause reads THESE, the run as the client holds it, not the broadcast diff's change index
             keys = [str(k) for k in (msg.get("keys") or []) if k][-REATTACH_KEYS:]
+            sid = str(msg["id"])
             with _client_lock(client):
-                client.setdefault("reattachKeys", {})[str(msg["id"])] = keys
+                if sid not in (client.get("echat") or {}):
+                    return                            # a session this client holds no base for: nothing to re-attach (1448 low b)
+                d = client.setdefault("reattachKeys", {})
+                d.pop(sid, None); d[sid] = keys
+                while len(d) > REATTACH_KEYS_CLIENTS:  # bounded: a posted list with no ask behind it never grows the map
+                    d.pop(next(iter(d)))
             return
         if msg and msg.get("type") == "needFull" and msg.get("id"):
             # The client REJECTED a delta because it started past what it holds (render.ts chatTail's gap

--- a/tests/test_chat_pages.py
+++ b/tests/test_chat_pages.py
@@ -494,6 +494,26 @@ class RealArm(Harness):
         self.assertTrue(w2["connected"])
 
 
+class ReattachKeysArm(Harness):
+    """1448's lows: a posted key list is held only for a session the client has a base for, and the map is bounded."""
+
+    def test_unknown_sessions_are_ignored_and_the_map_is_bounded(self):
+        c, sent = _client()
+        c["echat"]["s-known"] = {"first": "a", "last": "b", "detached": False}
+        arm = lambda msg: km.Handler._dispatch_ws(object.__new__(km.Handler), msg, c)
+        arm({"type": "reattachKeys", "id": "s-unknown", "keys": ["k1"]})
+        self.assertNotIn("reattachKeys", c, "a session this client holds no base for: dropped")
+        arm({"type": "reattachKeys", "id": "s-known", "keys": ["k%d" % i for i in range(700)]})
+        self.assertEqual(len(c["reattachKeys"]["s-known"]), km.REATTACH_KEYS, "the newest keys, bounded")
+        for i in range(km.REATTACH_KEYS_CLIENTS + 3):
+            sid = "s-%d" % i
+            c["echat"][sid] = {"first": "a", "last": "b", "detached": False}
+            arm({"type": "reattachKeys", "id": sid, "keys": ["k"]})
+        self.assertEqual(len(c["reattachKeys"]), km.REATTACH_KEYS_CLIENTS, "the map is capped")
+        self.assertNotIn("s-known", c["reattachKeys"], "…the oldest dropped first")
+        self.assertIn("s-%d" % (km.REATTACH_KEYS_CLIENTS + 2), c["reattachKeys"])
+
+
 class OrphanGate(Harness):
     """Round 2 item 11, executed: the fold's orphan demotion gate reads the note's own window."""
 

--- a/tests/test_chat_pages.py
+++ b/tests/test_chat_pages.py
@@ -427,9 +427,12 @@ class RealArm(Harness):
                     self.assertTrue(mo["more"], "the walk stops inside the list, still detached")
                 if w is not None or mo is not None:
                     if any((e.get("key") or e["uuid"]) in list_keys for e in run):
-                        state["step"] = "reattach"
-                        return self._frame({"type": "needFull", "id": SID, "why": "reattach"})   # Return to live
+                        state["step"] = "keys"
+                        return self._frame({"type": "reattachKeys", "id": SID, "keys": [e.get("key") or e["uuid"] for e in run[-512:]]})
                     return self._frame({"type": "loadNewer", "id": SID, "after": run[-1].get("key") or run[-1]["uuid"]})
+            elif state["step"] == "keys":
+                state["step"] = "reattach"
+                return self._frame({"type": "needFull", "id": SID, "why": "reattach"})   # Return to live, the keys ahead of it
             elif state["step"] == "reattach":
                 f = newest("session")
                 if f is not None:
@@ -916,23 +919,33 @@ class Proto2Wire(Harness):
         # a window that holds NO part of the run (a far anchor) still detaches the client, kernel and page agreeing
         far = km._chat_history_reply(SID, {"type": "loadAround", "id": SID, "uuid": whole[2]["uuid"]}, NOW, base=c["echat"][SID])
         self.assertFalse(far["connected"]); self.assertTrue(far["_base"]["detached"])
-        # a re-attach whose run's NEWEST key left the list (a fork rewrote the tail): the run held everything up to that key,
-        # so the keys just below the fork point survive; they are in the frame exactly when the fork left fewer than WIRE_TAIL
-        # new events, the client's merge then shares them and the kernel keeps the older first (round 4)
+        # the re-attach's shared clause reads the client's OWN resident keys (reattachKeys), never the broadcast diff's change
+        # index: the repair frame is a connect push over an unchanged build, so change_from is total there (T323 follow-up, M1)
         head_from = len(evs) - km.WIRE_TAIL
+        run_keys = [e.get("key") or e["uuid"] for e in evs[:head_from + 10]]       # a run from the list's head into the frame
         c2, sent2 = _client()
-        c2["echat"][SID] = {"first": evs[0]["uuid"], "last": "gone-after-a-fork", "detached": False, "reattach": True}
-        km._send_chat_locked(c2, m, None, head_from + 5, False)          # the fork point inside the frame: shared
-        self.assertEqual(sent2[-1]["type"], "session"); self.assertEqual(c2["echat"][SID]["first"], evs[0]["uuid"])
-        self.assertNotEqual(sent2[-1]["firstUuid"], evs[0]["uuid"], "…before the frame's first")
-        c3, sent3 = _client()
-        c3["echat"][SID] = {"first": evs[0]["uuid"], "last": "gone-after-a-fork", "detached": False, "reattach": True}
-        km._send_chat_locked(c3, m, None, head_from - 5, False)          # a fork of WIRE_TAIL or more: no run key in the frame
-        self.assertEqual(c3["echat"][SID]["first"], sent3[-1]["firstUuid"], "the client replaces: the base takes the frame's first")
-        c4, sent4 = _client()
-        c4["echat"][SID] = {"first": "gone-1", "last": "gone-2", "detached": False, "reattach": True}   # no key left at all
-        km._send_chat_locked(c4, m, None, 0, False)
-        self.assertEqual(c4["echat"][SID]["first"], sent4[-1]["firstUuid"])
+        c2["echat"][SID] = {"first": evs[0]["uuid"], "last": "gone-after-a-fork", "detached": False, "reattach": True, "keys": run_keys[-512:]}
+        km._send_chat_locked(c2, m, None, len(evs), False)               # an unchanged build: change_from == total
+        self.assertEqual(sent2[-1]["type"], "session"); self.assertEqual(c2["echat"][SID]["first"], evs[0]["uuid"], "the older first kept")
+        self.assertNotEqual(sent2[-1]["firstUuid"], evs[0]["uuid"])
+        w2 = km._chat_history_reply(SID, {"type": "loadAround", "id": SID, "uuid": evs[3]["uuid"]}, NOW, base=c2["echat"][SID])
+        self.assertTrue(w2["connected"], "a window below the frame after the re-attach stays connected: no divergence")
+        c3, sent3 = _client()                                            # the fork cut every key the client holds: replaced (M2)
+        c3["echat"][SID] = {"first": "dead-1", "last": "dead-2", "detached": False, "reattach": True, "keys": ["dead-1", "dead-9", "dead-2"]}
+        km._send_chat_locked(c3, m, None, len(evs), False)
+        self.assertEqual(c3["echat"][SID]["first"], sent3[-1]["firstUuid"], "no resident key: the base takes the frame's first")
+        c3b, sent3b = _client()                                          # resident keys, all below the frame: no shared key either
+        c3b["echat"][SID] = {"first": evs[0]["uuid"], "last": "gone", "detached": False, "reattach": True, "keys": run_keys[:head_from - 5]}
+        km._send_chat_locked(c3b, m, None, len(evs), False)
+        self.assertEqual(c3b["echat"][SID]["first"], sent3b[-1]["firstUuid"])
+        c4, sent4 = _client()                                            # an older bundle sends no keys: the newest edge decides
+        c4["echat"][SID] = {"first": evs[0]["uuid"], "last": evs[-1]["uuid"], "detached": False, "reattach": True}
+        km._send_chat_locked(c4, m, None, len(evs), False)
+        self.assertEqual(c4["echat"][SID]["first"], evs[0]["uuid"])
+        c5, sent5 = _client()
+        c5["echat"][SID] = {"first": evs[0]["uuid"], "last": "gone", "detached": False, "reattach": True}
+        km._send_chat_locked(c5, m, None, len(evs), False)
+        self.assertEqual(c5["echat"][SID]["first"], sent5[-1]["firstUuid"])
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn('if base.pop("keepLast", False):', src, "the handler applies a loadOlder's first-edge advance")
 

--- a/tests/test_chat_pages_warm.py
+++ b/tests/test_chat_pages_warm.py
@@ -127,8 +127,11 @@ class WarmTheCards(P.Harness):
                                                                         {"id": "d", "kind": "handoff", "status": "open", "anchorUuid": deep}]}]}
         self.assertEqual(km._card_anchors(feed), [(SID, tail_anchor)], "a completed card's rows, a done row and a handoff row do not count")
         self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0, "a tail anchor is resident already")
+        self.assertEqual(km._WARM_MEMO["anchors"], tuple(km._card_anchors(feed)), "a resolved board with every anchor in the tail SETTLES (an empty set)")
+        self.assertEqual(km._warm_history_pages(feed, NOW, {}), 0)
+        self.assertEqual(km._PAGE_STATS["warmCycles"], 2, "…and the next cycle is the probe alone")
         self.assertEqual(km._warm_history_pages({"type": "feed", "asks": []}, NOW, {}), 0, "no anchors: no cycle")
-        self.assertEqual(km._PAGE_STATS["warmCycles"], 1)
+        self.assertEqual(km._PAGE_STATS["warmCycles"], 2)
 
     def test_a_slow_pusher_stands_down_and_the_next_cycle_in_budget_warms(self):
         whole, m = self._restored()
@@ -241,6 +244,27 @@ class WarmTheCards(P.Harness):
         src = open(os.path.join(P.BIN, "romp-kernel")).read()
         fn = src[src.index("def _warm_history_pages("):src.index("def _turn_of_uuid(")]
         self.assertLess(fn.index("WARM_SKIP_MS:"), fn.index('_WARM_MEMO["anchors"]:'), "the stand-down precedes the probe")
+
+    def test_a_page_two_windows_share_is_counted_once_in_the_sets_bytes(self):
+        """The follow-up's low: the page bound treated a shared page as free while the byte count added it twice, closing the set early."""
+        whole, m = self._restored(turns=600, compact_every=150)
+        floor = m["floor"]
+        turns = km._parse(self.leaf, SID, NOW)["turns"]
+        first = lambda j: next(a["uuid"] for a in turns[j]["atoms"] if a.get("uuid"))
+        page = km._chat_history_page(SID, floor - km.PAGE_TURNS, floor, NOW)
+        with km._page_lock:
+            page_bytes = max(b for _, b in km._PAGE_CACHE.values())
+        saved = km._PAGE_CACHE_BYTES
+        km._PAGE_CACHE_BYTES = page_bytes * 5                        # half the bound: two and a half pages
+        try:
+            # two anchors in one window (the same two pages) and a third in another: with the shared pages counted once the
+            # set holds two pages after the first two anchors, so the third window is admitted; counted twice it was closed
+            feed = self._feed(self._card([first(8), first(9), first(40)]))
+            n = km._warm_history_pages(feed, NOW, {})
+            self.assertEqual(n, 4, "both windows rendered: four pages")
+            self.assertEqual(km._PAGE_STATS["warmPending"], 0)
+        finally:
+            km._PAGE_CACHE_BYTES = saved
 
     def test_the_window_is_two_aligned_pages_around_the_anchor(self):
         w = km._window_turns

--- a/ui/webview/chat-window.test.ts
+++ b/ui/webview/chat-window.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { applyTailAfter, prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore } from "./chat-window";
+import { applyTailAfter, prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore, reattachKeys, REATTACH_KEYS } from "./chat-window";
 
 const ev = (u: string) => ({ uuid: u, kind: "user", md: u });
 const run = (...u: string[]) => u.map(ev);
@@ -95,6 +95,15 @@ test("render.ts wires the three rules, tracks the pending needFull reason, hides
   assert.ok(RENDER.includes('turn.dataset.orphanOf = String((ev as { orphanOf?: string }).orphanOf)'), "an orphan note's turn carries its record uuid");
   assert.equal((RENDER.match(/\.turn\[data-orphan-of="\$\{cssEscape\(uuid\)\}"\]/g) || []).length, 2, "…and both anchor lookups read it");
   assert.ok(RENDER.includes("(e as { orphanOf?: string }).orphanOf === uuid"), "…as does the events-list search behind them");
+});
+
+test("the re-attach ask carries the run's newest keys, bounded, and render.ts posts them ahead of the ask", () => {
+  const long = Array.from({ length: REATTACH_KEYS + 40 }, (_, i) => ev("k" + i));
+  const keys = reattachKeys(long);
+  assert.equal(keys.length, REATTACH_KEYS); assert.equal(keys[0], "k40"); assert.equal(keys[keys.length - 1], "k" + (REATTACH_KEYS + 39));
+  assert.deepEqual(reattachKeys([ev("a"), { uuid: "a", key: "a#2", kind: "tool" }, { kind: "todo" }]), ["a", "a#2"], "keys, not uuids; a keyless card is skipped");
+  const fn = RENDER.slice(RENDER.indexOf("function reattachLive(sid: string): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function reattachLive(sid: string): void {")));
+  assert.ok(fn.indexOf('type: "reattachKeys", id: sid, keys: reattachKeys(') > 0 && fn.indexOf('type: "reattachKeys"') < fn.indexOf('requestFullSession(sid, "reattach")'), "the keys go out before the ask");
 });
 
 test("render.ts speaks proto 2 at ready and routes the four proto-2 frames through this module", () => {

--- a/ui/webview/chat-window.ts
+++ b/ui/webview/chat-window.ts
@@ -91,3 +91,13 @@ export function fullFrameMerges(pendingWhy: string | null | undefined): boolean 
 export function afterMore(more: boolean, headKnown: boolean, resident: number): { detached: boolean; headTotal: number | null } {
   return { detached: !!more, headTotal: !more && headKnown ? resident : null };
 }
+
+/** The newest resident keys a proto-2 client sends ahead of its re-attach ask (reattachKeys): the kernel's repair frame
+ *  keeps the run's older first edge when the highest of THESE that is still in the list lies inside the frame, the same
+ *  overlap mergeWindow finds; the broadcast diff's change index is no fork point for a connect push (T323 follow-up). */
+export const REATTACH_KEYS = 512;
+export function reattachKeys(events: readonly Ev[]): string[] {
+  const out: string[] = [];
+  for (const e of events.slice(-REATTACH_KEYS)) { const k = keyOf(e); if (k) out.push(k); }
+  return out;
+}

--- a/ui/webview/federation-skeleton.test.ts
+++ b/ui/webview/federation-skeleton.test.ts
@@ -222,7 +222,7 @@ test("routeOutbound: a re-attach's resident keys go to the owning kernel by the 
   assert.deepEqual(routeOutbound({ type: "reattachKeys", id: "B", keys }, new Set(["gpu1"])), [{ host: "", msg: { type: "reattachKeys", id: "B", keys } }]);
   assert.deepEqual(routeOutbound({ type: "reattachKeys", id: "gpu1:" + V, keys }, new Set(["gpu1"])), [{ host: "gpu1", msg: { type: "reattachKeys", id: V, keys } }]);
   assert.ok(BOOKKEEPING.has("reattachKeys"), "held for the socket's open like the other proto-2 asks, never toasted");
-  assert.equal(BOOKKEEPING.get("reattachKeys")!({ id: "B" }), BOOKKEEPING.get("loadNewer")!({ id: "B" }).replace("loadNewer", "reattachKeys"));
+  assert.equal(BOOKKEEPING.get("reattachKeys")!({ id: "B" }), String(BOOKKEEPING.get("loadNewer")!({ id: "B" })).replace("loadNewer", "reattachKeys"));
 });
 
 test("the manager's outbound puts needFull(+why) on the owning kernel's wire — local send or remote socket", () => {

--- a/ui/webview/federation-skeleton.test.ts
+++ b/ui/webview/federation-skeleton.test.ts
@@ -18,7 +18,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { FederationManager, prefixInbound, routeOutbound } from "./federation";
+import { FederationManager, prefixInbound, routeOutbound, BOOKKEEPING } from "./federation";
 
 const U = "11111111-2222-3333-4444-555555555555";
 const V = "99999999-8888-7777-6666-555555555555";
@@ -215,6 +215,14 @@ test("routeOutbound: needFull's optional `why` passes through untouched — only
   assert.deepEqual(remote, [{ host: "gpu1", msg: { type: "needFull", id: V, why: "prefetch" } }], "a remote id: stripped for its kernel, `why` intact");
   const bare = routeOutbound({ type: "needFull", id: "B" }, new Set(["gpu1"]));
   assert.deepEqual(bare, [{ host: "", msg: { type: "needFull", id: "B" } }], "no `why` → no `why` minted");
+});
+
+test("routeOutbound: a re-attach's resident keys go to the owning kernel by the id's host, the id bared, the keys intact (T323 follow-up)", () => {
+  const keys = ["k1", "k2#2"];
+  assert.deepEqual(routeOutbound({ type: "reattachKeys", id: "B", keys }, new Set(["gpu1"])), [{ host: "", msg: { type: "reattachKeys", id: "B", keys } }]);
+  assert.deepEqual(routeOutbound({ type: "reattachKeys", id: "gpu1:" + V, keys }, new Set(["gpu1"])), [{ host: "gpu1", msg: { type: "reattachKeys", id: V, keys } }]);
+  assert.ok(BOOKKEEPING.has("reattachKeys"), "held for the socket's open like the other proto-2 asks, never toasted");
+  assert.equal(BOOKKEEPING.get("reattachKeys")!({ id: "B" }), BOOKKEEPING.get("loadNewer")!({ id: "B" }).replace("loadNewer", "reattachKeys"));
 });
 
 test("the manager's outbound puts needFull(+why) on the owning kernel's wire — local send or remote socket", () => {

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -118,6 +118,7 @@ export const BOOKKEEPING: ReadonlyMap<string, (m: any) => string | null> = new M
   ["loadOlder",      (m) => "loadOlder" + K + m.id],               // render.ts: the head's older page on a scroll-up or a deep link into it
   ["loadAround",     (m) => "loadAround" + K + m.id],              // render.ts: a window around a deep-link anchor past the resident list (proto 2)
   ["loadNewer",      (m) => "loadNewer" + K + m.id],               // render.ts: the page after a detached window's newest event (proto 2)
+  ["reattachKeys",   (m) => "reattachKeys" + K + m.id],            // render.ts: the run's newest keys ahead of a re-attach ask (proto 2)
   ["loadEpisode",    (m) => "loadEpisode" + K + m.id],             // render.ts noticeOpened: a clear notice's conversation on first expand
   ["imgRequest",     (m) => "imgRequest" + K + m.id + K + m.path], // render.ts: an inline image's bytes, asked on render
   ["commentSeen",    (m) => "commentSeen" + K + m.id + K + m.tid], // render.ts: a thread's read watermark as its popover opens or a reply lands in it

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -20,7 +20,7 @@ import { ctxFallbackColor, pickTone, readableRgb } from "./ctx-color";
 import { applyTheme } from "./theme";
 import { applyDenseChrome } from "./dense-chrome";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
-import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore } from "./chat-window";   // the uuid-anchored wire (T323 stage 4b)
+import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore, reattachKeys } from "./chat-window";   // the uuid-anchored wire (T323 stage 4b)
 import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
 import { lensVisible, surfaceLens } from "./tag-lens";
 import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
@@ -16428,6 +16428,7 @@ function updateLivePaused(): void {
 function reattachLive(sid: string): void {
   const s = sessions.get(sid);
   if (!s || s.proto !== 2 || !s.detached) return;
+  vscodeApi?.postMessage({ type: "reattachKeys", id: sid, keys: reattachKeys(s.events as { uuid?: string; key?: string }[]) });   // the run as held, for the kernel's shared clause
   requestFullSession(sid, "reattach");   // the kernel's full tail frame re-bases this client; upsert merges it into the held run
 }
 


### PR DESCRIPTION
Two mediums the merged proto-2 chat wire's re-attach clause carried, and two lows of the pages-cache warming, found by the manager's verifier after the merges.

- **The re-attach's shared clause reads the run the client holds, not the broadcast diff.** A proto-2 client returning to live from an older window asks for a full frame; the kernel keeps the run's older first edge when the frame overlaps the run, as the page's merge does. The clause took the fork point from the push's change index, but the repair frame is a connect push over an unchanged build, so that index is the list's length (or a later change), never the fork point: the kernel recorded the frame's first while the page kept its older run, and a later window below the frame answered not connected and detached the base. Now the page sends its newest resident keys (`reattachKeys`, at most 512) right before the ask, and the kernel keeps the older edge when the highest of them still in the list lies inside the frame. A resident key is required: a run the fork cut entirely is replaced, never given a first that is in no list (the second medium). An older bundle that sends no keys is judged by its newest edge, as before.
- **The warming settles a resolved board whose anchors all sit in the tail** (an empty set memoized; only an unresolved anchor blocks the memo), and **a page two windows share is counted once** in the set's bytes.

Tests: the pages harness drives the repair push over an unchanged build (the older first kept, a window below the frame connected afterwards), a run with no resident key and one whose keys all lie below the frame (replaced), and an older bundle without keys (its newest edge); the socket handler's own arms carry the keys ahead of the ask in the real-arm sequence; `chat-window.test.ts` executes the keys' bound and pins the order in `reattachLive`; the federation routes `reattachKeys` by the id's host; the warming tests assert the empty set settles and the shared page's single count.

Tier: fix.
