### PR TITLE
The kernel's record cache holds a byte budget, a returned subagent's records leave memory once folded, and the service runs on two allocator arenas

### DIFF
--- a/bin/romp-service
+++ b/bin/romp-service
@@ -170,6 +170,10 @@ write_unit() {
     if [[ -n "$_unit_env" ]]; then _unit_env+=$'\n'; fi
     local _unit_envf; _unit_envf="$(_service_env_override unit)"
     if [[ -n "$_unit_envf" ]]; then _unit_envf+=$'\n'; fi
+    # MALLOC_ARENA_MAX=2 (the kernel memory work, 2026-09-11): the kernel is a Python process with dozens of threads
+    # (per-session SDK threads, the judge pools, the pusher, the dashboard senders) rebuilding large record lists, and
+    # glibc's per-thread arenas kept ten 100 to 140 MB arenas of freed memory between restarts; two arenas hand freed
+    # memory back. The manager inherits it and passes it to every kernel it spawns; service.env may override it.
     cat > "$UNIT" <<EOF
 [Unit]
 Description=romp kernel supervisor (romp-manager)
@@ -182,6 +186,7 @@ RestartSec=2
 Environment=PATH=$PATH
 Environment=ROMP_DIR=$ROMP_DIR
 Environment=ROMP_SUPERVISED=1
+Environment=MALLOC_ARENA_MAX=2
 ${_unit_envf}EnvironmentFile=-$(printf '%s' "$SERVICE_ENV_FILE" | sed 's/%/%%/g')
 ${_unit_env}
 [Install]

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -589,6 +589,8 @@ and their memory limits, the perf log), never a key. The service reads the file
 at manager startup, so a change needs a manager restart. `ROMP_SERVICE_ENV_FILE`
 overrides the file's path.
 
+The installed unit also sets `MALLOC_ARENA_MAX=2` for the manager and every kernel it spawns (2026-09-11): the kernel is a many-threaded Python process that rebuilds large record lists, and the allocator's per-thread arenas kept hundreds of megabytes of freed memory between restarts; two arenas return it. A line in `service.env` overrides it.
+
 Romp holds no API key (the user 2026-09-08, who wants romp to hold no key). A
 session's credential is Claude Code's own resolution: the `apiKeyHelper` in its
 settings (the helper) for a key, the login otherwise. Romp injects no credential

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -641,6 +641,63 @@ _JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-
                                   # states/postal logs became tenants too (2026-09-01): one states file per session
                                   # plus messages.jsonl now share the slots, and an evicted LEAF slot also demotes
                                   # the assembly cache's identity gate to a full parse.
+# A BYTE budget beside the count (the kernel memory work, 2026-09-11): the count bounded slots, never memory, and the
+# working set is files of every size (a 177 MB leaf and a 2 KB states log take one slot each), so the kernel climbed to
+# 5 to 8 GB between restarts holding every live and subagent transcript's records (about 1.7 bytes resident per file
+# byte). Each entry weighs the bytes it holds (the file size less a tail entry's offset); past the budget the least
+# recently used entries go first, one at a time, under the same LRU order the count uses, so a hot leaf survives a
+# cold flood of subagent files exactly as before. A single entry larger than the whole budget still inserts: a leaf is
+# never refused, the budget then holds that one entry. Counters under /perf recordCache.
+_JSONL_CACHE_BUDGET_BYTES = int(float(os.environ.get("ROMP_RECORD_CACHE_BUDGET_MB", "1024")) * 1024 * 1024)
+_JSONL_CACHE_BYTES = [0]          # the sum of every held entry's weight, kept in step with _JSONL_CACHE under its lock
+_RECORD_CACHE_STATS = {"inserts": 0, "evictions": 0, "evictedBytes": 0, "budgetEvictions": 0, "dropped": 0, "droppedBytes": 0}
+_DROP_AFTER_QUIESCENT_S = float(os.environ.get("ROMP_RECORD_CACHE_DROP_QUIESCENT_S", "120"))   # a file this long unchanged
+#                                   is one whose writer has finished (a subagent that returned): its records are not kept
+
+
+def _entry_weight(ent) -> int:
+    """The bytes an entry holds: the file's size less the offset a tail entry started at (a checkpoint's cut)."""
+    try:
+        size, base = int(ent[1]), int(ent[5])
+        return max(0, size - int(ent[2])) if base > 0 else size
+    except Exception:
+        return 0
+
+
+def _cache_pop_locked(path):
+    """Under _JSONL_CACHE_LOCK: drop `path`'s entry and its weight; returns the weight (0 when absent)."""
+    ent = _JSONL_CACHE.pop(path, None)
+    if ent is None:
+        return 0
+    w = _entry_weight(ent)
+    _JSONL_CACHE_BYTES[0] = max(0, _JSONL_CACHE_BYTES[0] - w)
+    return w
+
+
+def _cache_insert_locked(path, ent):
+    """Under _JSONL_CACHE_LOCK: insert `ent` at the LRU tail, evicting the least recently used entries past the count cap
+    and past the byte budget (the new entry's own weight counted; an entry larger than the budget alone still inserts)."""
+    _cache_pop_locked(path)
+    w = _entry_weight(ent)
+    while len(_JSONL_CACHE) >= _JSONL_CACHE_MAX:
+        _RECORD_CACHE_STATS["evictions"] += 1
+        _RECORD_CACHE_STATS["evictedBytes"] += _cache_pop_locked(next(iter(_JSONL_CACHE)))   # oldest-used first; hot entries survive any cold flood
+    while _JSONL_CACHE and _JSONL_CACHE_BYTES[0] + w > _JSONL_CACHE_BUDGET_BYTES:
+        _RECORD_CACHE_STATS["evictions"] += 1; _RECORD_CACHE_STATS["budgetEvictions"] += 1
+        _RECORD_CACHE_STATS["evictedBytes"] += _cache_pop_locked(next(iter(_JSONL_CACHE)))
+    _JSONL_CACHE[path] = ent
+    _JSONL_CACHE_BYTES[0] += w
+    _RECORD_CACHE_STATS["inserts"] += 1
+
+
+def record_cache_stats() -> dict:
+    """The record cache for /perf: entries, held bytes, the budget, and the counters (inserts, evictions by count and by
+    budget, evicted bytes, drop-after-fold drops)."""
+    with _JSONL_CACHE_LOCK:
+        return {"entries": len(_JSONL_CACHE), "bytes": _JSONL_CACHE_BYTES[0], "budgetBytes": _JSONL_CACHE_BUDGET_BYTES,
+                "countCap": _JSONL_CACHE_MAX, **_RECORD_CACHE_STATS}
+
+
 _JSONL_TAIL_GUARD = 64            # bytes of pre-offset content re-verified before an incremental read
 _JSONL_CACHE_LOCK = threading.Lock()   # the cache has cross-thread callers (the judge tiers' worker pools,
                                        # the pusher, the warm threads) and HITS mutate (LRU reinsert): the
@@ -1163,7 +1220,7 @@ def _read_jsonl_entry(path, on_fail=None, tail_ok=False, tail_from=None):
         st = os.stat(path)
     except OSError as e:
         with _JSONL_CACHE_LOCK:
-            _JSONL_CACHE.pop(path, None)
+            _cache_pop_locked(path)
         if on_fail is not None and not isinstance(e, FileNotFoundError):
             on_fail(e)
         return None
@@ -1191,7 +1248,7 @@ def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False, tail_from=None
         st = os.stat(path)
     except OSError as e:
         with _JSONL_CACHE_LOCK:
-            _JSONL_CACHE.pop(path, None)
+            _cache_pop_locked(path)
         if on_fail is not None and not isinstance(e, FileNotFoundError):
             on_fail(e)
         return None
@@ -1269,20 +1326,17 @@ def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False, tail_from=None
                 sys.stderr.write("reader: %s %s base=%d gen=%d size=%d by %s\n" % (kind, path, base, gen, st.st_size, who))
     except OSError as e:
         with _JSONL_CACHE_LOCK:
-            _JSONL_CACHE.pop(path, None)
+            _cache_pop_locked(path)
         if on_fail is not None and not isinstance(e, FileNotFoundError):
             on_fail(e)
         return None
     ent = (st.st_mtime, st.st_size, offset, tail, records, base, gen, offs)
     with _JSONL_CACHE_LOCK:
-        _JSONL_CACHE.pop(path, None)
-        while len(_JSONL_CACHE) >= _JSONL_CACHE_MAX:
-            _JSONL_CACHE.pop(next(iter(_JSONL_CACHE)))   # oldest-used first; hot entries survive any cold flood
-        _JSONL_CACHE[path] = ent
+        _cache_insert_locked(path, ent)      # the count cap and the byte budget, LRU order (hot entries survive any cold flood)
     return ent
 
 
-def fold_records(cache, path, init, step, on=None, ckpt=None):
+def fold_records(cache, path, init, step, on=None, ckpt=None, drop_after=None):
     """Fold a JSONL file's records into a carried state, APPEND-INCREMENTALLY (issue 903, 2026-09-03):
     the states/transcript readers re-read their whole file behind an (mtime,size) key that every append
     invalidates — O(file) per push for every working session. The reader serves the parsed records of a
@@ -1312,6 +1366,10 @@ def fold_records(cache, path, init, step, on=None, ckpt=None):
     the next call reads again; an ABSENT file is not a failure and folds to init() through the normal path).
     A caller's counters ride it (the kernel's `_states_awaiting_overlay`); the fold itself keeps no counters,
     since one cache dict serves many readers and a caller's counters are locked per reader.
+    `drop_after` (the kernel memory work, 2026-09-11): "quiescent" drops the file's records from the shared reader's
+    cache once this fold has stepped them, when the file has not changed for _DROP_AFTER_QUIESCENT_S (a subagent
+    that returned; the user's rule: nothing stays resident that nobody looks at). The cursor and its checkpoint stand;
+    a later fold of an unchanged file re-reads it once, a growing file keeps its records (see _drop_quiescent_entry).
 
     Lives here (moved from the kernel, 2026-09-03) so the judge's readers can fold too — the
     background-task pairing below is shared by both."""
@@ -1389,7 +1447,28 @@ def fold_records(cache, path, init, step, on=None, ckpt=None):
             _FOLD_DIRTY.add(key)
     if on is not None:
         on(kind)
-    return _fold_eof_fragment(key, ent, state, step)
+    out = _fold_eof_fragment(key, ent, state, step)
+    if drop_after == "quiescent" and ent is not None:
+        _drop_quiescent_entry(key, ent)
+    return out
+
+
+def _drop_quiescent_entry(key, ent):
+    """drop_after="quiescent" (the kernel memory work, 2026-09-11): a file unchanged for _DROP_AFTER_QUIESCENT_S is one
+    whose writer has finished (a subagent that returned), and its records are not kept in the shared reader's cache
+    once a fold has stepped them: the fold's cursor (and its checkpoint) stands, the file's bytes leave memory. Only the
+    very entry this fold read is dropped (another thread's newer entry is left alone); a file still changing keeps its
+    records, since its next append would otherwise re-read it whole."""
+    try:
+        if time.time() - float(ent[0]) < _DROP_AFTER_QUIESCENT_S:
+            return
+    except Exception:
+        return
+    with _JSONL_CACHE_LOCK:
+        if _JSONL_CACHE.get(key) is ent:
+            w = _cache_pop_locked(key)
+            _RECORD_CACHE_STATS["dropped"] += 1
+            _RECORD_CACHE_STATS["droppedBytes"] += w
 
 
 _UNPINNED = object()

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -533,6 +533,7 @@ class _PerfStats:
                 # T323 stage 3: the folds' checkpoints: restored, written, swept at boot, folds skipped as unencodable,
                 # fallbacks per reason (version, path, shrunk, guard, rewrite, corrupt) and the bytes the reader read
                 "checkpoints": em.checkpoint_stats(),
+                "recordCache": em.record_cache_stats(),   # the shared reader's byte budget and its evictions (2026-09-11)
                 # T323 stage 4a: the assembly documents: written, restored, fallbacks per reason, skips per reason (noEntry,
                 # restored, noBoundary, unsplittable, oversize, ...), hydrated bodies and bytes since boot
                 "asmCheckpoint": em.asm_checkpoint_stats(),
@@ -25301,7 +25302,7 @@ def _agent_launch_ids(agent_path):
     transcript half of _awaiting_nest's attribution: a background command whose tool_use id is in THIS
     file was launched by THIS agent. set() when unreadable."""
     try:
-        return em.fold_records(_AGENT_LAUNCH_IDS_CACHE, str(agent_path), _launch_ids_fresh, _launch_ids_step, ckpt="agentLaunchIds")
+        return em.fold_records(_AGENT_LAUNCH_IDS_CACHE, str(agent_path), _launch_ids_fresh, _launch_ids_step, ckpt="agentLaunchIds", drop_after="quiescent")
     except Exception:
         return set()
 
@@ -25315,7 +25316,7 @@ def _agent_steps(agent_path):
     either way); the running preview's clock (agentGist: calls/since/last) rides only while it runs."""
     _chat_dep_note_taskout(str(agent_path), _chat_stat_key(str(agent_path)))   # a growing agent file moves the key
     try:
-        st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step, ckpt="agentGist")
+        st = em.fold_records(_AGENT_GIST_CACHE, str(agent_path), _gist_fresh, _gist_step, ckpt="agentGist", drop_after="quiescent")
     except Exception:
         return None
     if not st["since"]:
@@ -25357,7 +25358,7 @@ def _launch_step(state, o):
 
 
 def _agent_launch_state(path):
-    return em.fold_records(_AGENT_LAUNCH_CACHE, str(path), _launch_fresh, _launch_step, ckpt="agentLaunches")
+    return em.fold_records(_AGENT_LAUNCH_CACHE, str(path), _launch_fresh, _launch_step, ckpt="agentLaunches", drop_after="quiescent")
 
 
 def _agent_alive(row, agent_id, tm, spawned_at):

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -165,5 +165,127 @@ class JsonlCacheThreadSafety(unittest.TestCase):
         self.assertEqual(served, em._read_jsonl_incremental(p))
 
 
+class RecordCacheByteBudget(unittest.TestCase):
+    """The kernel memory work (2026-09-11): a BYTE budget beside the count cap. Entries weigh the bytes they hold; past
+    the budget the least recently used go, one at a time, in the same order as the count cap, so a hot file survives a
+    cold flood; a single entry larger than the budget still inserts; the ledger stays in step; /perf sees it."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="jsonl-budget-")
+        em._JSONL_CACHE.clear(); em._JSONL_CACHE_BYTES[0] = 0
+        for k in em._RECORD_CACHE_STATS: em._RECORD_CACHE_STATS[k] = 0
+        self._budget = em._JSONL_CACHE_BUDGET_BYTES
+        self._real_scan = em._scan_jsonl_bytes
+        self.scans = []
+        def spy(data, base_offset, *a, **k):
+            self.scans.append((len(data), base_offset)); return self._real_scan(data, base_offset, *a, **k)
+        em._scan_jsonl_bytes = spy
+
+    def tearDown(self):
+        em._JSONL_CACHE_BUDGET_BYTES = self._budget
+        em._scan_jsonl_bytes = self._real_scan
+        em._JSONL_CACHE.clear(); em._JSONL_CACHE_BYTES[0] = 0
+
+    def _file(self, name, n):
+        path = os.path.join(self.dir, name); _write_jsonl(path, n); return path
+
+    def _ledger_ok(self):
+        with em._JSONL_CACHE_LOCK:
+            return em._JSONL_CACHE_BYTES[0] == sum(em._entry_weight(e) for e in em._JSONL_CACHE.values())
+
+    def test_the_budget_evicts_the_least_recently_used_and_a_hot_file_survives(self):
+        hot = self._file("hot.jsonl", 40)
+        em._read_jsonl_incremental(hot)
+        one = os.path.getsize(hot)
+        em._JSONL_CACHE_BUDGET_BYTES = int(one * 3.5)            # room for three such files, not four
+        cold = [self._file("cold%d.jsonl" % i, 40) for i in range(6)]
+        for c in cold:
+            em._read_jsonl_incremental(hot)                       # the hot file is USED between every cold read
+            em._read_jsonl_incremental(c)
+            self.assertTrue(self._ledger_ok())
+            self.assertLessEqual(em._JSONL_CACHE_BYTES[0], em._JSONL_CACHE_BUDGET_BYTES)
+        self.assertIn(hot, em._JSONL_CACHE, "the hot file survived six cold reads under a three-file budget")
+        self.assertLessEqual(len(em._JSONL_CACHE), 3)
+        n = len(self.scans)
+        em._read_jsonl_incremental(hot)
+        self.assertEqual(len(self.scans), n, "and still serves from the cache")
+        st = em.record_cache_stats()
+        self.assertGreaterEqual(st["budgetEvictions"], 4); self.assertGreater(st["evictedBytes"], 0)
+        self.assertEqual(st["budgetBytes"], em._JSONL_CACHE_BUDGET_BYTES)
+        for k in ("entries", "bytes", "countCap", "inserts", "evictions", "dropped", "droppedBytes"):
+            self.assertIn(k, st)
+
+    def test_an_entry_larger_than_the_whole_budget_still_inserts_alone(self):
+        big = self._file("big.jsonl", 200); small = self._file("small.jsonl", 5)
+        em._read_jsonl_incremental(small)
+        em._JSONL_CACHE_BUDGET_BYTES = os.path.getsize(big) // 2
+        em._read_jsonl_incremental(big)
+        self.assertIn(big, em._JSONL_CACHE, "a leaf is never refused")
+        self.assertNotIn(small, em._JSONL_CACHE, "the budget then holds that one entry")
+        self.assertTrue(self._ledger_ok())
+
+    def test_the_ledger_follows_appends_and_failures(self):
+        path = self._file("grow.jsonl", 10)
+        em._read_jsonl_incremental(path); w1 = em._JSONL_CACHE_BYTES[0]
+        with open(path, "a") as f:
+            for i in range(10, 20): f.write(json.dumps({"uuid": "u%d" % i, "type": "user"}) + "\n")
+        em._read_jsonl_incremental(path)
+        self.assertEqual(em._JSONL_CACHE_BYTES[0], os.path.getsize(path)); self.assertGreater(em._JSONL_CACHE_BYTES[0], w1)
+        os.unlink(path)
+        em._read_jsonl_incremental(path)                          # an absent file pops its entry: the ledger follows
+        self.assertEqual(em._JSONL_CACHE_BYTES[0], 0); self.assertTrue(self._ledger_ok())
+
+
+class DropAfterQuiescentFold(unittest.TestCase):
+    """fold_records(drop_after="quiescent"): a file unchanged for _DROP_AFTER_QUIESCENT_S (a subagent that returned) is
+    dropped from the reader's cache once the fold stepped it; the cursor stands; a fresh file keeps its records."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="jsonl-drop-")
+        em._JSONL_CACHE.clear(); em._JSONL_CACHE_BYTES[0] = 0
+        for k in em._RECORD_CACHE_STATS: em._RECORD_CACHE_STATS[k] = 0
+        self._real_scan = em._scan_jsonl_bytes; self.scans = []
+        def spy(data, base_offset, *a, **k):
+            self.scans.append((len(data), base_offset)); return self._real_scan(data, base_offset, *a, **k)
+        em._scan_jsonl_bytes = spy
+
+    def tearDown(self):
+        em._scan_jsonl_bytes = self._real_scan
+        em._JSONL_CACHE.clear(); em._JSONL_CACHE_BYTES[0] = 0
+
+    def _fold(self, cache, path, **kw):
+        return em.fold_records(cache, path, lambda: {"n": 0}, lambda st, r: {"n": st["n"] + 1}, **kw)
+
+    def test_a_quiescent_file_is_dropped_after_the_fold_and_a_fresh_one_kept(self):
+        old = os.path.join(self.dir, "returned-agent.jsonl"); _write_jsonl(old, 30)
+        t = time.time() - em._DROP_AFTER_QUIESCENT_S - 60
+        os.utime(old, (t, t))
+        fresh = os.path.join(self.dir, "running-agent.jsonl"); _write_jsonl(fresh, 30)
+        cache = {}
+        self.assertEqual(self._fold(cache, old, drop_after="quiescent")["n"], 30)
+        self.assertNotIn(old, em._JSONL_CACHE, "the returned agent's records leave memory once folded")
+        self.assertIn(old, cache, "its fold cursor stands")
+        self.assertEqual(self._fold(cache, fresh, drop_after="quiescent")["n"], 30)
+        self.assertIn(fresh, em._JSONL_CACHE, "a file still fresh keeps its records: its next append is a delta")
+        self.assertEqual(self._fold(cache, fresh)["n"], 30)
+        self.assertIn(fresh, em._JSONL_CACHE, "no policy, no drop")
+        st = em.record_cache_stats()
+        self.assertEqual(st["dropped"], 1); self.assertGreater(st["droppedBytes"], 0)
+        self.assertEqual(em._JSONL_CACHE_BYTES[0], os.path.getsize(fresh), "the ledger followed the drop")
+        # the dropped file folds again: one re-read, the same answer, no double-count in the cursor
+        n = len(self.scans)
+        self.assertEqual(self._fold(cache, old, drop_after="quiescent")["n"], 30)
+        self.assertEqual(len(self.scans), n + 1, "one read for the second fold of a dropped file")
+
+    def test_the_kernel_drops_only_its_subagent_folds_and_reports_the_cache(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        for name in ("agentLaunchIds", "agentGist", "agentLaunches"):
+            self.assertIn('ckpt="%s", drop_after="quiescent")' % name, src, "the %s fold drops a returned agent's records" % name)
+        self.assertNotIn('ckpt="bgAll", drop_after', src, "a LEAF fold never drops: the live session's records stay warm")
+        self.assertIn('"recordCache": em.record_cache_stats(),', src, "/perf carries the record cache")
+        unit = open(os.path.join(BIN, "romp-service")).read()
+        self.assertIn("Environment=MALLOC_ARENA_MAX=2", unit, "the service unit hands the allocator setting to the manager and its kernels")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -50,6 +50,7 @@ TOP_KEYS = {"now", "since", "uptime_s", "log", "process", "pusher", "stages_ms",
             "goals", "memos", "judge", "http", "parses",   # parses: cold event-model parses (T323 stage 1)
             "checkpoints",                                 # checkpoints: the folds' checkpoints (T323 stage 3)
             "asmCheckpoint",                               # asmCheckpoint: the assembly documents (T323 stage 4a)
+            "recordCache",                                 # recordCache: the shared reader's byte budget and evictions (2026-09-11)
             "chatPages",                                   # chatPages: the pre-floor history pages cache (T323 stage 4b)
             "skillLoadIndex"}                              # skillLoadIndex: the judge's skill-load boot pass, its raw reads (T333)
 


### PR DESCRIPTION
The kernel's memory, bounded where it grew. Tier: feature (a byte budget on an existing cache, a drop policy on three existing folds, one service-unit line; no contract changes).

## What was measured

The kernel starts each life near 150 to 200 MB and reached 4.7 to 7.9 GB by each restart on 2026-09-11. The earlier investigation found the cause: the shared reader's cache of parsed transcript records (`_JSONL_CACHE` in `kernel/event_model.py`) is bounded by a count of 1,024 entries and never by bytes, so every live session's leaf and every subagent transcript it folds stays resident at about 1.7 bytes per file byte (2.9 GB for 47 leaves alone; 10,410 subagent files, 2.2 GB on disk, on top); and glibc kept ten 100 to 140 MB per-thread arenas of freed memory.

## What changes

1. **A byte budget beside the count** (`ROMP_RECORD_CACHE_BUDGET_MB`, default 1024). Each entry weighs the bytes it holds (a tail entry its bytes past the checkpoint's cut). Past the budget the least recently used entries go one at a time in the same order the count cap uses, so a hot leaf survives a cold flood of subagent files exactly as before. An entry larger than the whole budget still inserts: a leaf is never refused. The ledger follows every insert, append, failure pop and eviction. `/perf` gains `recordCache` (entries, bytes, budgetBytes, countCap, inserts, evictions, budgetEvictions, evictedBytes, dropped, droppedBytes).
2. **A returned subagent's records leave memory once folded.** `fold_records(drop_after="quiescent")`: a file unchanged for `ROMP_RECORD_CACHE_DROP_QUIESCENT_S` (120 s) is a subagent that returned; the kernel's three subagent folds (`agentGist`, `agentLaunchIds`, `agentLaunches`) drop its records from the cache once stepped. The fold's cursor and its checkpoint stand; a later fold of an unchanged file re-reads it once; a growing file keeps its records; a leaf fold never drops. This is the user's rule for romp's memory: nothing stays resident that nobody looks at.
3. **Two allocator arenas.** The installed service unit sets `MALLOC_ARENA_MAX=2` for the manager and every kernel it spawns (`docs/reference.md`); `service.env` may override it.

Coordinated with the lazy-transcript program: the record cache is a separate store from the hydration memo and the materialized-atom cache, reports under its own key, and touches none of the assembly writer, restore, serve or parse paths.

## Tests

`tests/test_kernel_jsonl_cache.py`: the budget evicts the least recently used while a hot file read between every cold one survives six cold reads under a three-file budget and still serves from the cache; an entry larger than the budget inserts alone; the byte ledger follows appends and an absent-file pop; the perf shape; a quiescent file is dropped after its fold with its cursor kept while a fresh file and a policy-less fold keep their records, and the dropped file's next fold costs exactly one read; source pins on the three folds, the perf key and the unit line. `tests/test_perf_stats.py`'s documented `/perf` shape gains the key. Each change fails its test when reverted (five revert checks).

## Verification

A clean full Python suite on this tree is reported in the thread before auto-merge is armed. The measurement after the deploy: `/perf recordCache` (bytes against the budget, evictions, drops) and the kernel's resident size on the restart ledger's rows against today's 4.7 to 7.9 GB.
