### PR TITLE
The spend ledger keeps a per-session cost watermark so a host re-attach records only its own turn (T354, kernel)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2469,11 +2469,16 @@ total. A surviving process with no matching watermark on record (a kernel
 before this rule wrote none) records nothing for that first result, since its
 total is the lifetime's and the turn's share is unknowable; the kernel log says
 so, and the watermark is written from there. The replay of a dead host's
-journal tail seeds the same way for the dead CLI before it drains; a result the
-replay hands over again (its total below the watermark) folds nothing, since
-one process's total only grows apart from a `/clear` the kernel zeroes by
-event; and the attach flag lives one connect, so a rollback to hosts off
-records a fresh child's first turn in full. Each `turns.jsonl` row carries
+journal tail seeds the same way for the dead CLI before it drains. A result the
+attach's replay hands over again folds nothing, decided from the journal
+position the transport tracks (a record before the offset the host's hello
+named as its next is a replay, and a replay at or below the offset acknowledged
+at the attach, or at or below the watermark, is one the ledger already holds;
+its turn row says `redelivered`); a live total below the watermark is a counter
+reset the kernel did not see and folds whole, as before. The attach flag lives
+one connect, so a rollback to hosts off records a fresh child's first turn in
+full, and a `/clear` as the first turn after an attach retires the pending seed
+so the zeroed counter stands. Each `turns.jsonl` row carries
 `cumulativeUsd`, the CLI's own total at that result, and a first result's
 `spendBaseline` (`fresh`, `seeded` or `attach-unknown`). Before this rule every
 restart re-billed each hosted session's lifetime as one turn (2026-09-11: a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2474,10 +2474,12 @@ so, and the watermark is written from there. The replay of a dead host's
 journal tail seeds the same way for the dead CLI before it drains. A result the
 attach's replay hands over again folds nothing, whatever its total, decided
 from the record's own journal position: the transport tags each result record
-with its offset as it reads it, the fold pops the tags in order (the SDK's
-buffered reader runs a record ahead, so the transport's current offset is
-never the handled record's), and a record before the offset the host's hello
-named as its next is a replay; its turn row says `redelivered` and carries
+with its offset as it reads it, the kernel pops one tag for every result record
+it receives, first thing and whatever the result holds (the SDK's buffered
+reader runs a record ahead, so the transport's current offset is never the
+handled record's), and a record before the offset the host's hello named as its
+next is a replay; a dead host's journal replays through the same road, the
+replay reader being the session's transport for the drain; its turn row says `redelivered` and carries
 `journalOffset`. A live total below the watermark is a counter reset the kernel
 did not see and folds whole, as before. An orphan journal's replay keeps the
 dead CLI's watermark as its line: at or below it was folded, above it was not. The attach flag lives

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2472,12 +2472,15 @@ before this rule wrote none) records nothing for that first result, since its
 total is the lifetime's and the turn's share is unknowable; the kernel log says
 so, and the watermark is written from there. The replay of a dead host's
 journal tail seeds the same way for the dead CLI before it drains. A result the
-attach's replay hands over again folds nothing, decided from the journal
-position the transport tracks (a record before the offset the host's hello
-named as its next is a replay, and a replay at or below the offset acknowledged
-at the attach, or at or below the watermark, is one the ledger already holds;
-its turn row says `redelivered`); a live total below the watermark is a counter
-reset the kernel did not see and folds whole, as before. The attach flag lives
+attach's replay hands over again folds nothing, whatever its total, decided
+from the record's own journal position: the transport tags each result record
+with its offset as it reads it, the fold pops the tags in order (the SDK's
+buffered reader runs a record ahead, so the transport's current offset is
+never the handled record's), and a record before the offset the host's hello
+named as its next is a replay; its turn row says `redelivered` and carries
+`journalOffset`. A live total below the watermark is a counter reset the kernel
+did not see and folds whole, as before. An orphan journal's replay keeps the
+dead CLI's watermark as its line: at or below it was folded, above it was not. The attach flag lives
 one connect, so a rollback to hosts off records a fresh child's first turn in
 full, and a `/clear` as the first turn after an attach retires the pending seed
 so the zeroed counter stands. Each `turns.jsonl` row carries

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2469,9 +2469,11 @@ total. A surviving process with no matching watermark on record (a kernel
 before this rule wrote none) records nothing for that first result, since its
 total is the lifetime's and the turn's share is unknowable; the kernel log says
 so, and the watermark is written from there. The replay of a dead host's
-journal tail seeds the same way for the dead CLI before it drains, and the
-attach flag is set on the attach road alone, so a rollback to hosts off records
-a fresh child's first turn in full. Each `turns.jsonl` row carries
+journal tail seeds the same way for the dead CLI before it drains; a result the
+replay hands over again (its total below the watermark) folds nothing, since
+one process's total only grows apart from a `/clear` the kernel zeroes by
+event; and the attach flag lives one connect, so a rollback to hosts off
+records a fresh child's first turn in full. Each `turns.jsonl` row carries
 `cumulativeUsd`, the CLI's own total at that result, and a first result's
 `spendBaseline` (`fresh`, `seeded` or `attach-unknown`). Before this rule every
 restart re-billed each hosted session's lifetime as one turn (2026-09-11: a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2455,6 +2455,28 @@ message written but never placed, a store record never finished), closes each
 one's receipt as refused, and says so once. The sidecars are yours to inspect
 or delete.
 
+## The spend ledger across a host re-attach
+
+A session under a host keeps its CLI process across a kernel restart, and the
+CLI's `total_cost_usd` is cumulative per process. The kernel folds only each
+result's delta over a watermark, so every result persists that watermark on the
+session's registry row (`costState`: the cumulative total, the token
+watermarks, and the CLI's identity as pid and start time). A kernel that
+attaches to a surviving host reads it at the first result and, when it names
+that same CLI, seeds the watermarks from it, so the first result records only
+its own turn; a fresh process still starts at zero and records its whole first
+total. A surviving process with no matching watermark on record (a kernel
+before this rule wrote none) records nothing for that first result, since its
+total is the lifetime's and the turn's share is unknowable; the kernel log says
+so, and the watermark is written from there. The replay of a dead host's
+journal tail seeds the same way for the dead CLI before it drains, and the
+attach flag is set on the attach road alone, so a rollback to hosts off records
+a fresh child's first turn in full. Each `turns.jsonl` row carries
+`cumulativeUsd`, the CLI's own total at that result, and a first result's
+`spendBaseline` (`fresh`, `seeded` or `attach-unknown`). Before this rule every
+restart re-billed each hosted session's lifetime as one turn (2026-09-11: a
+staircase of rows from $436 to $953 on one session across 21 restarts).
+
 ## Restart metrics
 
 `romp restart-metrics` reads what kernel restarts do to the sessions, from the

--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -11,6 +11,7 @@ When the SDK is not importable the class still exists, duck-typed, so the pure p
 """
 from __future__ import annotations
 import asyncio
+import collections
 import json
 import os
 import re
@@ -195,8 +196,11 @@ class HostTransport(_Base):
         self.sock_path = str(sock_path) if sock_path else None
         self.kernel = dict(kernel or {})
         self.ack_offset = int(ack)
-        self.attach_ack = int(ack)      # the offset acknowledged when this transport was made, unchanged after: records at
-        #                                 or below it were handed to an earlier kernel (the spend fold reads it, T354)
+        self.replay_end = None          # the journal's next offset at the attach (the hello's journal.next): records before
+        #                                 it are the replay, records from it on are live (T354's spend fold)
+        self.result_tags = collections.deque()   # one tag per RESULT record handed over, in order: {"offset", "replay"};
+        #                                 the consumer reads the transport through a buffered stream a record ahead, so the
+        #                                 transport's current offset is never the handled record's; the tag is
         self.end_grace = float(end_grace)
         self.on_ack, self.on_hello, self.on_stderr, self.on_exit, self.on_fault = on_ack, on_hello, on_stderr, on_exit, on_fault
         self.journal_dir = str(journal_dir) if journal_dir else None
@@ -245,6 +249,10 @@ class HostTransport(_Base):
                 else:
                     self._early.append(f)
         self.hello = hello
+        try:
+            self.replay_end = int(((hello or {}).get("journal") or {}).get("next"))
+        except (TypeError, ValueError):
+            self.replay_end = None
         self._fr = fr
         self._ready = True
         if self.on_hello:
@@ -373,7 +381,23 @@ class HostTransport(_Base):
 
     def _take(self, out: dict):
         self._advance(out)
+        self._tag(out.get("offset"), out["data"])
         return out["data"]
+
+    def _tag(self, offset, data, replay=None) -> None:
+        """A RESULT record's own offset, queued for the spend fold (T354): the consumer pops one per result it handles,
+        in order, so it reads the record's position, never the transport's current offset (a buffered reader runs a
+        record ahead). `replay` is decided against the hello's journal.next unless the caller knows (an orphan journal
+        replays only)."""
+        if not isinstance(data, dict) or data.get("type") != "result":
+            return
+        try:
+            off = int(offset)
+        except (TypeError, ValueError):
+            off = -1
+        if replay is None:
+            replay = self.replay_end is not None and off < self.replay_end
+        self.result_tags.append({"offset": off, "replay": bool(replay)})
 
     def _answers_mine(self, data) -> bool:
         if not isinstance(data, dict) or data.get("type") != "control_response":
@@ -464,6 +488,7 @@ class HostTransport(_Base):
             self.ack_offset = off
             if self.on_ack:
                 self.on_ack(off)
+            self._tag(off, rec, replay=True)             # an orphan journal's records are all replays
             yield rec
             # answers the Query asked for meanwhile ride between records
             while not self._synth.empty():

--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -195,6 +195,8 @@ class HostTransport(_Base):
         self.sock_path = str(sock_path) if sock_path else None
         self.kernel = dict(kernel or {})
         self.ack_offset = int(ack)
+        self.attach_ack = int(ack)      # the offset acknowledged when this transport was made, unchanged after: records at
+        #                                 or below it were handed to an earlier kernel (the spend fold reads it, T354)
         self.end_grace = float(end_grace)
         self.on_ack, self.on_hello, self.on_stderr, self.on_exit, self.on_fault = on_ack, on_hello, on_stderr, on_exit, on_fault
         self.journal_dir = str(journal_dir) if journal_dir else None

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -6460,6 +6460,11 @@ class SdkSession:
                         self.backend._write_host_ack(self, force=True)   # still attached to a live CLI: the last ack
                     self._host = None
                     self._host_intent = False
+                # the attach flag lives ONE connect (M1 of 1450's review): a reconnect in this thread that never enters
+                # _host_transport_for (hosts off with no lease and no host directory: an effort or auth switch after a
+                # rollback) must seed fresh, not wait for a watermark the kernel child never has; left True, the first
+                # turn recorded nothing and the watermark was then written under an empty CLI identity, once per connect
+                self._host_is_attach = False
             if self.ended or not self._reconnect:
                 break        # drain ended on its own (process exit) or we're shutting down → done
 
@@ -6867,8 +6872,9 @@ class SdkSession:
         self._last_usage_totals = {}  # and its cumulative token counters
         self._spend_first_result = True
         self._spend_baseline = "fresh"
-        if getattr(self, "_host_is_attach", False):
-            # a host ATTACH (T315): the CLI process SURVIVED the kernel, so its counters continued and its first
+        if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:
+            # a host ATTACH (T315), and only with the host transport in hand (the flag alone is not trusted, M1 of
+            # 1450's review): the CLI process SURVIVED the kernel, so its counters continued and its first
             # result's total_cost_usd is the process lifetime's, not this turn's. Zero here recorded that lifetime as
             # one turn at every restart (T354: 21 restarts, a staircase of $436 to $953 rows on one session). The
             # watermark the previous kernel persisted on the registry is read at the first result, when the host's
@@ -7186,7 +7192,10 @@ class SdkSession:
                 self.backend._log("sdk %s: adopting CLI cwd %r (registry had %r)" % (self.sid[:8], cli_cwd, self.cwd))
                 self.cwd = cli_cwd
                 self.backend._update_reg(self.sid, cwd=cli_cwd)
-                if loaded_sid and getattr(self, "_spend_first_result", False):   # getattr: __new__-built test doubles
+                if loaded_sid and getattr(self, "_spend_first_result", False) \
+                        and getattr(self, "_spend_baseline", "fresh") == "fresh":   # getattr: __new__-built test doubles
+                    # (a seed from the registry, or the dead-CLI seed a replayed tail carries, is not clobbered by an
+                    # init record inside that tail whose cwd differs from the registry's: low a of 1450's review)
                     # The connect-time seed read the transcript under the REGISTRY's cwd; the CLI loaded the
                     # one under ITS cwd (the same keying). No result has settled since the connect, so re-seed
                     # from the file the CLI opened: a registry variant that holds no transcript left the seed
@@ -7439,21 +7448,38 @@ class SdkSession:
                         self._seed_from_reg_cost_state()
                         baseline = self._spend_baseline
                     unknown = first and baseline == "attach-unknown"
-                    if unknown:
-                        delta = 0.0       # the lifetime's total: this turn's own share is unknowable, so nothing is folded
+                    # a REDELIVERED result (M2 of 1450's review): hostAck is written at most once a second while the
+                    # watermark moves per result, so a kernel death leaves processed results past the acknowledged
+                    # offset and the attach's replay hands them over again (the whole journal, when the ack names
+                    # another host). One CLI process's total is monotone apart from a /clear the kernel zeroes by
+                    # event, so under a host a total BELOW the watermark is a result the ledger already holds: folded
+                    # whole (the "counter reset" road below, meant for a process we never watched) it was the
+                    # process's lifetime as one turn
+                    hosted = getattr(self, "_host", None) is not None or baseline == "seeded"
+                    duplicate = hosted and total < self._last_cost_total
+                    if unknown or duplicate:
+                        delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
                     else:
                         delta = total - self._last_cost_total if total >= self._last_cost_total else total
-                    self._last_cost_total = float(total)
-                    self._spend_first_result = False   # the watermark moved: the process's first result is in
+                    if not duplicate:
+                        self._last_cost_total = float(total)
+                    self._spend_first_result = False   # the watermark moved (or a duplicate was seen): the process's first result is in
                     # the tokens: THIS turn's counts, from whichever result counter is a running total —
                     # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
-                    turn_u = self._turn_usage(msg)
+                    if duplicate:
+                        keep = dict(self._last_usage_totals)
+                        turn_u = self._turn_usage(msg)
+                        turn_u = {k: 0 for k in (turn_u or {})} if isinstance(turn_u, dict) else turn_u
+                        self._last_usage_totals = keep       # the token watermarks are not moved down either
+                    else:
+                        turn_u = self._turn_usage(msg)
                     if unknown:       # the token watermarks moved with the map; the lifetime's counts are not this turn's
                         turn_u = {k: 0 for k in (turn_u or {})} if isinstance(turn_u, dict) else turn_u
                     self._turn_cumulative = float(total)          # the turn row carries the CLI's own cumulative (T354)
                     self._turn_baseline = baseline if first else None
+                    self._turn_duplicate = duplicate
                     self._turn_spend = (delta, turn_u)   # for the turn ledger row the finally writes (T304)
-                    self._persist_cost_state(total)      # the watermark the next kernel's attach seeds from (T354)
+                    self._persist_cost_state(self._last_cost_total)   # the watermark the next kernel's attach seeds from (T354)
                     self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
                                                sid=self.thread_of or self.sid)   # the rail's spend —
                     #   a comment THREAD bills its owning session (T144: whole-session truth for the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5149,6 +5149,11 @@ class SdkSession:
         #   total when the deltas were written (`usage: this.totalUsage`) and is the TURN's own total
         #   on the current CLI — diffing it under-counted every turn but the first (the user
         #   2026-09-06). Which counter is which, and the measurement: _turn_usage.
+        self._spend_baseline = "fresh"     # what the watermarks stand on: "fresh" (a new CLI process: zero, or the
+        #                                    resumed transcript's cost-state record), "attach-pending" (a host attach:
+        #                                    the surviving CLI's watermark is read from the registry at the first
+        #                                    result), "seeded" (read, and it named this CLI), "attach-unknown" (no
+        #                                    matching watermark: the first result's total is the lifetime's) (T354)
         self._spend_first_result = False   # True from a connect until its first result settles: that result's
         #   delta is checked against SANE_TURN_USD (an info-line trace; see the constant), and the init
         #   handler may re-seed the watermarks while it is still True (a cwd correction; _seed_spend_watermarks)
@@ -6744,6 +6749,12 @@ class SdkSession:
             row["isError"] = ie
         if isinstance(usd, (int, float)) and not isinstance(usd, bool):
             row["usd"] = round(float(usd), 6)
+        cum = getattr(self, "_turn_cumulative", None)     # the CLI's own cumulative total_cost_usd at this result (T354):
+        if isinstance(cum, (int, float)) and not isinstance(cum, bool):   # the repair and the audits read the staircase off it
+            row["cumulativeUsd"] = round(float(cum), 6)
+        bl = getattr(self, "_turn_baseline", None)        # a first result's baseline: fresh, seeded, attach-unknown (T354)
+        if isinstance(bl, str) and bl:
+            row["spendBaseline"] = bl
         if isinstance(turn_u, dict):
             for k, kk in (("input_tokens", "tokIn"), ("output_tokens", "tokOut"),
                           ("cache_read_input_tokens", "tokCacheR"), ("cache_creation_input_tokens", "tokCacheW")):
@@ -6855,6 +6866,15 @@ class SdkSession:
         self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero
         self._last_usage_totals = {}  # and its cumulative token counters
         self._spend_first_result = True
+        self._spend_baseline = "fresh"
+        if getattr(self, "_host_is_attach", False):
+            # a host ATTACH (T315): the CLI process SURVIVED the kernel, so its counters continued and its first
+            # result's total_cost_usd is the process lifetime's, not this turn's. Zero here recorded that lifetime as
+            # one turn at every restart (T354: 21 restarts, a staircase of $436 to $953 rows on one session). The
+            # watermark the previous kernel persisted on the registry is read at the first result, when the host's
+            # hello has named the CLI (_seed_from_reg_cost_state); until then nothing is folded.
+            self._spend_baseline = "attach-pending"
+            return
         sid = resume_sid or self.resume_sid
         if not sid:
             return
@@ -6866,6 +6886,67 @@ class SdkSession:
         self.backend._log("spend: %s resumes a transcript with a cost-state record: watermarks seeded at its "
                           "totals (cumulative $%.2f) so the first result records only this turn"
                           % (self.name, cs["total"]), problem=False)
+
+    def _cli_ident(self) -> str:
+        """The CLI process this session speaks to, as "pid:start" from the host's hello (a hosted session), or ""
+        when there is no host or no hello yet: a plain kernel child dies with the kernel, so its identity never
+        matters to a watermark (a fresh process seeds zero)."""
+        t = getattr(self, "_host", None)
+        hello = getattr(t, "hello", None) if t is not None else None
+        c = (hello or {}).get("cli") if isinstance(hello, dict) else None
+        if isinstance(c, dict) and c.get("pid"):
+            return "%s:%s" % (c.get("pid"), c.get("start"))
+        return ""
+
+    def _seed_for_dead_cli(self, cli: str) -> None:
+        """Before a dead host's journal tail is replayed (T354 review, M7): its result rows carry that CLI's cumulative
+        total, and the replay drains them through the result branch before the connect's own seed runs, so a zero
+        watermark folded the dead process's whole lifetime as one turn. The registry's watermark seeds when it names
+        that CLI (`cli` is its pid:start from the lease, or from hostAck when it names this host), else the first
+        replayed result records nothing. The connect's seed after the replay starts the fresh spawn at zero as ever."""
+        self._last_cost_total = 0.0
+        self._last_usage_totals = {}
+        self._spend_first_result = True
+        self._spend_baseline = "attach-pending"
+        self._seed_from_reg_cost_state(cli=cli, dead=True)
+
+    def _seed_from_reg_cost_state(self, cli=None, dead: bool = False) -> bool:
+        """A host attach's watermark (T354): the registry's `costState`, written by the kernel at every result with
+        the CLI's identity, seeds the watermarks when it names THIS surviving CLI process, so the first result records
+        only its own turn. No matching watermark (a kernel before this fix wrote none, or another CLI's) leaves the
+        baseline "attach-unknown": the first result's total is the process lifetime's and records nothing. Returns
+        True when seeded. `cli` names the process when the caller knows it (a dead host's replay, `dead`); by
+        default it is the surviving CLI the host's hello named."""
+        cli = self._cli_ident() if cli is None else str(cli or "")
+        how = "replaying the journal of its dead CLI" if dead else "attached to its surviving CLI"
+        reg = read_reg(self.backend.state_dir, self.sid) or {}
+        cs = reg.get("costState") if isinstance(reg.get("costState"), dict) else None
+        if cs and cli and str(cs.get("cli") or "") == cli and isinstance(cs.get("total"), (int, float)) and cs["total"] >= 0:
+            self._last_cost_total = float(cs["total"])
+            toks = cs.get("tokens") if isinstance(cs.get("tokens"), dict) else {}
+            self._last_usage_totals = {k: int(v) for k, v in toks.items() if isinstance(v, (int, float))}
+            self._spend_baseline = "seeded"
+            self.backend._log("spend: %s %s (%s): watermarks seeded at the registry's "
+                              "cumulative $%.2f so the first result records only this turn" % (self.name, how, cli, cs["total"]),
+                              problem=False)
+            return True
+        self._spend_baseline = "attach-unknown"
+        self.backend._log("spend: %s %s (%s) with no matching watermark on record (%s): its "
+                          "first result's total is the process lifetime's, so that result records no spend; the "
+                          "watermark is written from it" % (self.name, how.replace("its surviving", "a surviving").replace("its dead", "a dead"), cli or "unnamed",
+                                                             "none recorded" if not cs else "recorded for %s" % (cs.get("cli") or "?")),
+                          problem=False)
+        return False
+
+    def _persist_cost_state(self, total) -> None:
+        """The watermark on the registry, every result (T354): the CLI's cumulative total, the token watermarks and
+        the CLI's identity, so the next kernel's attach to the same process seeds from it. The registry is the
+        kernel's own file (hostAck lives there too); a failed write costs the seed, never the fold."""
+        try:
+            self.backend._update_reg(self.sid, costState={"total": float(total), "tokens": dict(self._last_usage_totals),
+                                                           "cli": self._cli_ident(), "t": int(time.time())})
+        except Exception as e:
+            self.backend._log("spend (%s): costState write failed: %s" % (self.name, e), problem=False)
 
     async def _drain(self, client, AssistantMessage, ResultMessage, SystemMessage):
         """The receive loop. Every streamed message goes through _handle_stream_message, which keeps
@@ -7350,14 +7431,29 @@ class SdkSession:
                 # (The scheduled refreshes above cannot run before this synchronous step: nothing yields.)
                 total = getattr(msg, "total_cost_usd", None)
                 if isinstance(total, (int, float)) and total > 0:
-                    delta = total - self._last_cost_total if total >= self._last_cost_total else total
-                    self._last_cost_total = float(total)
                     first = getattr(self, "_spend_first_result", False)   # getattr: __new__-built test doubles
+                    baseline = getattr(self, "_spend_baseline", "fresh")
+                    if first and baseline == "attach-pending":
+                        # a host attach's first result: the host's hello has named the surviving CLI by now, so the
+                        # registry's watermark for that process can be read (T354)
+                        self._seed_from_reg_cost_state()
+                        baseline = self._spend_baseline
+                    unknown = first and baseline == "attach-unknown"
+                    if unknown:
+                        delta = 0.0       # the lifetime's total: this turn's own share is unknowable, so nothing is folded
+                    else:
+                        delta = total - self._last_cost_total if total >= self._last_cost_total else total
+                    self._last_cost_total = float(total)
                     self._spend_first_result = False   # the watermark moved: the process's first result is in
                     # the tokens: THIS turn's counts, from whichever result counter is a running total —
                     # the two are not the same kind (see _turn_usage; the flat `usage` is per-turn now)
                     turn_u = self._turn_usage(msg)
+                    if unknown:       # the token watermarks moved with the map; the lifetime's counts are not this turn's
+                        turn_u = {k: 0 for k in (turn_u or {})} if isinstance(turn_u, dict) else turn_u
+                    self._turn_cumulative = float(total)          # the turn row carries the CLI's own cumulative (T354)
+                    self._turn_baseline = baseline if first else None
                     self._turn_spend = (delta, turn_u)   # for the turn ledger row the finally writes (T304)
+                    self._persist_cost_state(total)      # the watermark the next kernel's attach seeds from (T354)
                     self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
                                                sid=self.thread_of or self.sid)   # the rail's spend —
                     #   a comment THREAD bills its owning session (T144: whole-session truth for the
@@ -7365,18 +7461,30 @@ class SdkSession:
                     #   + token readout; keyed = THIS session's init-reported auth, so the API sum stays
                     #   honest on a mixed host (see _record_spend)
                     if first and delta > SANE_TURN_USD:
-                        # A first-after-connect delta above the mark: on the CLI as probed a resumed process
-                        # starts its counters at zero (SANE_TURN_USD), so this is the turn's own cost, recorded
-                        # as is and traced as an INFO line, not a problem: the figure is right and there is
-                        # nothing for the user to act on. It is wrong only if a CLI that restores cost history
-                        # read a different file than the connect-time seed (last_cost_state). After the record,
-                        # so a raising log callback costs the line and never the count.
-                        self.backend._log("spend: %s's first result after connect cost $%.2f, above %.0f USD for "
-                                          "one turn (the CLI's cumulative total: $%.2f). Recorded as is: a resumed "
-                                          "CLI process starts its cost at zero, so this is the turn's own cost. It "
-                                          "would be wrong only if a CLI that restores cost history read a different "
-                                          "transcript than the connect-time seed (last_cost_state)."
-                                          % (self.name, delta, SANE_TURN_USD, total), problem=False)
+                        # A first-after-connect delta above the mark, traced as an INFO line, not a problem: the figure
+                        # is right and there is nothing for the user to act on. The text names which process this is
+                        # (T354): a FRESH process starts its counters at zero, so the delta is the turn's own; a
+                        # SURVIVING process (a host attach) was seeded at the registry's watermark, so the delta is the
+                        # turn's own too, and it would be wrong only if that watermark named the wrong process. After
+                        # the record, so a raising log callback costs the line and never the count.
+                        if baseline == "seeded":
+                            self.backend._log("spend: %s's first result after a host attach cost $%.2f, above %.0f USD "
+                                              "for one turn (the surviving CLI's cumulative total: $%.2f, its watermark "
+                                              "seeded from the registry at $%.2f). Recorded as is: the turn's own cost "
+                                              "over the seed." % (self.name, delta, SANE_TURN_USD, total, total - delta),
+                                              problem=False)
+                        else:
+                            self.backend._log("spend: %s's first result after connect cost $%.2f, above %.0f USD for "
+                                              "one turn (the CLI's cumulative total: $%.2f). Recorded as is: a fresh "
+                                              "CLI process starts its cost at zero, so this is the turn's own cost. It "
+                                              "would be wrong only if a CLI that restores cost history read a different "
+                                              "transcript than the connect-time seed (last_cost_state)."
+                                              % (self.name, delta, SANE_TURN_USD, total), problem=False)
+                    elif unknown:
+                        self.backend._log("spend: %s's first result after a host attach carries the surviving CLI's "
+                                          "cumulative total ($%.2f) with no watermark on record: this turn's own cost is "
+                                          "unknowable and nothing was folded; the watermark is set from here"
+                                          % (self.name, total), problem=False)
             finally:
                 # T304: one durable row per settled turn (turns.jsonl, see the ledger note by
                 # append_turn_row) — the event stamps the restart monitors read. In the finally, ahead of
@@ -7389,6 +7497,8 @@ class SdkSession:
                 except Exception as e:
                     self.backend._log("turn ledger (%s): %s" % (self.name, e), problem=False)
                 self._turn_spend = None          # spent with the row, like the feed stamps below
+                self._turn_cumulative = None
+                self._turn_baseline = None
                 self._fed_t = None               # the turn's feed stamps are spent (see _turn_ledger_row)
                 self._first_out_t = None
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the
@@ -9300,6 +9410,11 @@ class SdkBackend:
         survived), or, after replaying an orphan journal and waiting for a dead host's CLI to exit, spawn a
         fresh host. Raises when a live CLI of ours holds the lease under a kernel (the single-writer rule)."""
         ht = _ht()
+        # the attach flag is set True on the attach branch below and NOWHERE else, so every other road (the setting
+        # off, a spawn, a refusal) starts from False: a flag left by an earlier attach in this object's life made the
+        # next connect's seed wait for a registry watermark that a CLI dying with the kernel never has, so a rollback
+        # to hosts off recorded nothing for the fresh child's first turn, once per connect (T354 review, M6)
+        sess._host_is_attach = False
         now = time.time()
         lease = read_lease(self.state_dir, sess.sid)
         state = ht.host_lease_state(lease, now)
@@ -9371,7 +9486,6 @@ class SdkBackend:
         finally:
             with self._lock:
                 self._host_spawning.discard(sess.sid)
-        sess._host_is_attach = False
         t = self._new_host_transport(sess, sock, -1)
         sess._host = t
         self._log("host (%s): started a session host (pid %d)" % (sess.name, proc.pid))
@@ -9448,6 +9562,16 @@ class SdkBackend:
                 self._log("host (%s): clearing a host directory with nothing past the acknowledged offset" % sess.name)
         if has_tail:
             from claude_agent_sdk import ClaudeSDKClient
+            # the tail's result rows carry the DEAD CLI's cumulative total_cost_usd and drain through the same result
+            # branch as a live turn, BEFORE the connect's seed runs (that seed follows the client handshake): seed
+            # the watermarks for that process first, from the registry's costState when it names it, else nothing
+            # is folded for the first replayed result (T354 review, M7: the dead lifetime folded as one turn)
+            cli = ""
+            if isinstance(lease, dict) and lease.get("pid") and lease.get("start"):
+                cli = "%s:%s" % (lease.get("pid"), lease.get("start"))
+            elif ack and ident and str(ack.get("host") or "") == ident:
+                cli = str(ack.get("cli") or "")
+            sess._seed_for_dead_cli(cli)
             replay = ht.HostTransport.from_journal(hdir, ack=offset)
             try:
                 async with ClaudeSDKClient(options=opts, transport=replay) as client:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -6763,6 +6763,9 @@ class SdkSession:
             row["cumulativeUsd"] = round(float(cum), 6)
         if getattr(self, "_turn_redelivered", False):
             row["redelivered"] = True                      # a replayed result the ledger already held: folded nothing (T354)
+        jo = getattr(self, "_turn_journal_offset", None)
+        if isinstance(jo, int) and jo >= 0:
+            row["journalOffset"] = jo                      # the host journal record this result came from
         bl = getattr(self, "_turn_baseline", None)        # a first result's baseline: fresh, seeded, attach-unknown (T354)
         if isinstance(bl, str) and bl:
             row["spendBaseline"] = bl
@@ -6878,6 +6881,7 @@ class SdkSession:
         self._last_usage_totals = {}  # and its cumulative token counters
         self._spend_first_result = True
         self._spend_baseline = "fresh"
+        self._replay_cli = ""         # a dead CLI's replay is over once a connect seeds
         if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:
             # a host ATTACH (T315), and only with the host transport in hand (the flag alone is not trusted, M1 of
             # 1450's review): the CLI process SURVIVED the kernel, so its counters continued and its first
@@ -6908,7 +6912,8 @@ class SdkSession:
         c = (hello or {}).get("cli") if isinstance(hello, dict) else None
         if isinstance(c, dict) and c.get("pid"):
             return "%s:%s" % (c.get("pid"), c.get("start"))
-        return ""
+        return str(getattr(self, "_replay_cli", "") or "")   # an orphan replay: the dead CLI the seed named, so the
+        #                                                       watermark it persists stays under that identity
 
     def _seed_for_dead_cli(self, cli: str) -> None:
         """Before a dead host's journal tail is replayed (T354 review, M7): its result rows carry that CLI's cumulative
@@ -6920,6 +6925,7 @@ class SdkSession:
         self._last_usage_totals = {}
         self._spend_first_result = True
         self._spend_baseline = "attach-pending"
+        self._replay_cli = str(cli or "")
         self._seed_from_reg_cost_state(cli=cli, dead=True)
 
     def _seed_from_reg_cost_state(self, cli=None, dead: bool = False) -> bool:
@@ -6950,33 +6956,38 @@ class SdkSession:
                           problem=False)
         return False
 
-    def _spend_redelivered(self, total) -> bool:
-        """Is this result one an earlier kernel already folded? Decided from the host transport's journal position
-        (T354, the round-two review of the kernel fix): the record being handled sits at the transport's ack offset
-        (the transport advances it as it hands each record over), the host's hello names the journal's next offset at
-        the attach (records before it are the replay), and an orphan journal's reader replays only. A replay at or
-        below the offset acknowledged when the transport was made was handed to an earlier kernel; a replay at or
-        below the watermark was folded by the kernel that persisted it (hostAck lags the watermark by up to a second).
-        A live record is never a redelivery, whatever its total."""
+    def _spend_result_tag(self):
+        """The journal tag the host transport queued for the result being handled (T354, round four of the fix's
+        review): {"offset", "replay"}, popped in order, one per result. None for a plain kernel child, or a hosted
+        session whose transport queued none (a result the transport never saw). The consumer reads the transport
+        through the SDK's buffered stream a record ahead, so the transport's CURRENT offset is never the handled
+        record's own; the tag is."""
         t = getattr(self, "_host", None)
-        if t is None:
-            return False
+        tags = getattr(t, "result_tags", None) if t is not None else None
+        if not tags:
+            return None
         try:
-            pos = int(getattr(t, "ack_offset", -1))
-        except (TypeError, ValueError):
+            return tags.popleft()
+        except (IndexError, AttributeError):
+            return None
+
+    def _spend_redelivered(self, tag, total) -> bool:
+        """Is this result one an earlier kernel already folded? From the record's own journal position (round four of
+        1450's review): a replayed record (its offset before the journal's next at the attach) folds nothing, moves no
+        watermark and marks its row, WHATEVER its total, since the kernel that died folded what it saw and the ack it
+        left lags by at most a second; a live record is never a redelivery, and a live total below the watermark folds
+        whole as a counter reset. An orphan journal's replay (the dead-CLI seed in hand, no kernel ever saw the tail
+        past the ack) keeps the watermark comparison: at or below the dead CLI's watermark was folded, above it was
+        not."""
+        if tag is None:
             return False
-        hello = getattr(t, "hello", None)
-        j = hello.get("journal") if isinstance(hello, dict) and isinstance(hello.get("journal"), dict) else None
-        nxt = j.get("next") if j else None
-        replay_only = getattr(t, "journal_dir", None) is not None and hello is None
-        in_window = replay_only or (isinstance(nxt, (int, float)) and pos < nxt)
-        if not in_window:
+        if not tag.get("replay"):
             return False
-        try:
-            attach_ack = int(getattr(t, "attach_ack", -1))
-        except (TypeError, ValueError):
-            attach_ack = -1
-        return pos <= attach_ack or float(total) <= float(self._last_cost_total)
+        t = getattr(self, "_host", None)
+        orphan = getattr(t, "journal_dir", None) is not None and getattr(t, "hello", None) is None
+        if orphan:
+            return float(total) <= float(self._last_cost_total)
+        return True
 
     def _persist_cost_state(self, total) -> None:
         """The watermark on the registry, every result (T354): the CLI's cumulative total, the token watermarks and
@@ -6984,7 +6995,8 @@ class SdkSession:
         kernel's own file (hostAck lives there too); a failed write costs the seed, never the fold."""
         try:
             self.backend._update_reg(self.sid, costState={"total": float(total), "tokens": dict(self._last_usage_totals),
-                                                           "cli": self._cli_ident(), "t": int(time.time())})
+                                                           "cli": self._cli_ident(), "t": int(time.time()),
+                                                           "session": str(getattr(self, "_spend_session_id", "") or "")})
         except Exception as e:
             self.backend._log("spend (%s): costState write failed: %s" % (self.name, e), problem=False)
 
@@ -7498,7 +7510,9 @@ class SdkSession:
                     # is one the ledger already holds. A LIVE total below the watermark is a counter reset (a /clear
                     # the kernel did not see, a resumed cost-state seed against a print-mode CLI) and folds whole, as
                     # it always did; read from the total alone, a reset latched the session at $0 for the process's life
-                    duplicate = self._spend_redelivered(total)
+                    self._spend_session_id = str(getattr(msg, "session_id", "") or "")   # the CLI's session epoch (a /clear moves it), kept beside the watermark
+                    tag = self._spend_result_tag()
+                    duplicate = self._spend_redelivered(tag, total)
                     if unknown or duplicate:
                         delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
                     else:
@@ -7520,6 +7534,7 @@ class SdkSession:
                     self._turn_cumulative = float(total)          # the turn row carries the CLI's own cumulative (T354)
                     self._turn_baseline = baseline if first else None
                     self._turn_redelivered = duplicate            # the turn row says so (a flag the repair can trust)
+                    self._turn_journal_offset = tag.get("offset") if tag else None
                     self._turn_spend = (delta, turn_u)   # for the turn ledger row the finally writes (T304)
                     self._persist_cost_state(self._last_cost_total)   # the watermark the next kernel's attach seeds from (T354)
                     self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
@@ -7568,6 +7583,7 @@ class SdkSession:
                 self._turn_cumulative = None
                 self._turn_baseline = None
                 self._turn_redelivered = False
+                self._turn_journal_offset = None
                 self._fed_t = None               # the turn's feed stamps are spent (see _turn_ledger_row)
                 self._first_out_t = None
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -6757,6 +6757,8 @@ class SdkSession:
         cum = getattr(self, "_turn_cumulative", None)     # the CLI's own cumulative total_cost_usd at this result (T354):
         if isinstance(cum, (int, float)) and not isinstance(cum, bool):   # the repair and the audits read the staircase off it
             row["cumulativeUsd"] = round(float(cum), 6)
+        if getattr(self, "_turn_redelivered", False):
+            row["redelivered"] = True                      # a replayed result the ledger already held: folded nothing (T354)
         bl = getattr(self, "_turn_baseline", None)        # a first result's baseline: fresh, seeded, attach-unknown (T354)
         if isinstance(bl, str) and bl:
             row["spendBaseline"] = bl
@@ -6943,6 +6945,34 @@ class SdkSession:
                                                              "none recorded" if not cs else "recorded for %s" % (cs.get("cli") or "?")),
                           problem=False)
         return False
+
+    def _spend_redelivered(self, total) -> bool:
+        """Is this result one an earlier kernel already folded? Decided from the host transport's journal position
+        (T354, the round-two review of the kernel fix): the record being handled sits at the transport's ack offset
+        (the transport advances it as it hands each record over), the host's hello names the journal's next offset at
+        the attach (records before it are the replay), and an orphan journal's reader replays only. A replay at or
+        below the offset acknowledged when the transport was made was handed to an earlier kernel; a replay at or
+        below the watermark was folded by the kernel that persisted it (hostAck lags the watermark by up to a second).
+        A live record is never a redelivery, whatever its total."""
+        t = getattr(self, "_host", None)
+        if t is None:
+            return False
+        try:
+            pos = int(getattr(t, "ack_offset", -1))
+        except (TypeError, ValueError):
+            return False
+        hello = getattr(t, "hello", None)
+        j = hello.get("journal") if isinstance(hello, dict) and isinstance(hello.get("journal"), dict) else None
+        nxt = j.get("next") if j else None
+        replay_only = getattr(t, "journal_dir", None) is not None and hello is None
+        in_window = replay_only or (isinstance(nxt, (int, float)) and pos < nxt)
+        if not in_window:
+            return False
+        try:
+            attach_ack = int(getattr(t, "attach_ack", -1))
+        except (TypeError, ValueError):
+            attach_ack = -1
+        return pos <= attach_ack or float(total) <= float(self._last_cost_total)
 
     def _persist_cost_state(self, total) -> None:
         """The watermark on the registry, every result (T354): the CLI's cumulative total, the token watermarks and
@@ -7161,9 +7191,15 @@ class SdkSession:
                     # The CLI zeroed total_cost_usd and modelUsage at this instant (a /clear resets both,
                     # same lifecycle); reset the spend watermarks on the EVENT rather than waiting for the
                     # next result to read below them (review find on #956, 2026-09-07). The shrunken-counter
-                    # rule in _turn_usage / the cost delta stays as the backstop for a reset we did not see.
+                    # rule in _turn_usage / the cost delta stays as the backstop for a reset we did not see, on
+                    # every LIVE result; only a record inside a host's replay window is read as a redelivery.
                     self._last_cost_total = 0.0
                     self._last_usage_totals = {}
+                    if getattr(self, "_spend_baseline", "fresh") == "attach-pending":
+                        # a /clear as the first turn after an attach (MEDIUM of 1450's round two): the deferred seed
+                        # from the registry would have restored the pre-clear cumulative over this zero at the first
+                        # paid result; the counter IS zero now, so the pending seed is retired and the baseline fresh
+                        self._spend_baseline = "fresh"
                     loaded_sid = None   # zero IS the seed here: the cwd re-seed below stands down (the loaded
                     #                     file may carry a record the /clear saver wrote as it abandoned it)
                 # A RESUME landing on a NEW fsid = a fresh-headed fork: record the old->new lineage
@@ -7448,15 +7484,17 @@ class SdkSession:
                         self._seed_from_reg_cost_state()
                         baseline = self._spend_baseline
                     unknown = first and baseline == "attach-unknown"
-                    # a REDELIVERED result (M2 of 1450's review): hostAck is written at most once a second while the
-                    # watermark moves per result, so a kernel death leaves processed results past the acknowledged
-                    # offset and the attach's replay hands them over again (the whole journal, when the ack names
-                    # another host). One CLI process's total is monotone apart from a /clear the kernel zeroes by
-                    # event, so under a host a total BELOW the watermark is a result the ledger already holds: folded
-                    # whole (the "counter reset" road below, meant for a process we never watched) it was the
-                    # process's lifetime as one turn
-                    hosted = getattr(self, "_host", None) is not None or baseline == "seeded"
-                    duplicate = hosted and total < self._last_cost_total
+                    # a REDELIVERED result (M2 of 1450's review, reshaped by its round two): hostAck is written at
+                    # most once a second while the watermark moves per result, so a kernel death leaves processed
+                    # results past the acknowledged offset and the attach's replay hands them over again (the whole
+                    # journal, when the ack names another host). Redelivery is decided from the JOURNAL POSITION the
+                    # transport tracks, never from the total: a record inside the replay window (before the offset
+                    # the host's hello named as its next, or any record of an orphan journal's replay) is a replay,
+                    # and a replay at or below the offset acknowledged at the attach, or at or below the watermark,
+                    # is one the ledger already holds. A LIVE total below the watermark is a counter reset (a /clear
+                    # the kernel did not see, a resumed cost-state seed against a print-mode CLI) and folds whole, as
+                    # it always did; read from the total alone, a reset latched the session at $0 for the process's life
+                    duplicate = self._spend_redelivered(total)
                     if unknown or duplicate:
                         delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
                     else:
@@ -7477,7 +7515,7 @@ class SdkSession:
                         turn_u = {k: 0 for k in (turn_u or {})} if isinstance(turn_u, dict) else turn_u
                     self._turn_cumulative = float(total)          # the turn row carries the CLI's own cumulative (T354)
                     self._turn_baseline = baseline if first else None
-                    self._turn_duplicate = duplicate
+                    self._turn_redelivered = duplicate            # the turn row says so (a flag the repair can trust)
                     self._turn_spend = (delta, turn_u)   # for the turn ledger row the finally writes (T304)
                     self._persist_cost_state(self._last_cost_total)   # the watermark the next kernel's attach seeds from (T354)
                     self.backend._record_spend(delta, turn_u, keyed=self.api_key_auth,
@@ -7525,6 +7563,7 @@ class SdkSession:
                 self._turn_spend = None          # spent with the row, like the feed stamps below
                 self._turn_cumulative = None
                 self._turn_baseline = None
+                self._turn_redelivered = False
                 self._fed_t = None               # the turn's feed stamps are spent (see _turn_ledger_row)
                 self._first_out_t = None
                 # THE SETTLE — everything that makes the turn over for the kernel — runs whatever the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -7172,6 +7172,12 @@ class SdkSession:
             self._ping_feeding = False
             if self._input_wake is not None:
                 self._input_wake.set()   # same-loop thread — the settle path sets it the same way
+        if isinstance(msg, ResultMessage):
+            # the journal tag the transport queued for this RESULT record is popped here, first, for every result
+            # without exception (round five of 1450's review): popped only inside the spend fold's total > 0 gate, a
+            # zero-cost result (a /clear's own), a turn-less result the move settle consumes, or a handler failure
+            # left its tag at the head and every later result read the PREVIOUS record's tag for the transport's life
+            self._result_tag = self._spend_result_tag()
         if isinstance(msg, SystemMessage) and msg.subtype == "init":
             self._fire_boot_settled()   # the CLI is up and streaming — its transcript catch-up burst
             #                             is over, so the boot-stagger slot (if any) frees NOW
@@ -7510,9 +7516,10 @@ class SdkSession:
                     # is one the ledger already holds. A LIVE total below the watermark is a counter reset (a /clear
                     # the kernel did not see, a resumed cost-state seed against a print-mode CLI) and folds whole, as
                     # it always did; read from the total alone, a reset latched the session at $0 for the process's life
-                    self._spend_session_id = str(getattr(msg, "session_id", "") or "")   # the CLI's session epoch (a /clear moves it), kept beside the watermark
-                    tag = self._spend_result_tag()
+                    tag = getattr(self, "_result_tag", None)          # popped at the top of _on_message for every result
                     duplicate = self._spend_redelivered(tag, total)
+                    if not duplicate:                                  # a replayed record names the replayed epoch: not the watermark's
+                        self._spend_session_id = str(getattr(msg, "session_id", "") or "")   # the CLI's session epoch (a /clear moves it)
                     if unknown or duplicate:
                         delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
                     else:
@@ -9662,11 +9669,17 @@ class SdkBackend:
                 cli = str(ack.get("cli") or "")
             sess._seed_for_dead_cli(cli)
             replay = ht.HostTransport.from_journal(hdir, ack=offset)
+            prev_host = getattr(sess, "_host", None)
+            sess._host = replay          # the session's transport for the drain (round five of 1450's review): the spend
+            #                              fold reads the replay's tags through sess._host, and with it None every replayed
+            #                              result read as live and a dead host's tail re-billed the dead CLI's spend
             try:
                 async with ClaudeSDKClient(options=opts, transport=replay) as client:
                     await self._replay_drain(sess, client, msg_classes)
             except Exception as e:
                 self._log("host (%s): orphan journal replay ended on %s" % (sess.name, type(e).__name__))
+            finally:
+                sess._host = prev_host
             self._log("host (%s): replayed the orphan journal from offset %d" % (sess.name, offset + 1))
         remove_lease(self.state_dir, sess.sid)
         shutil.rmtree(str(hdir), ignore_errors=True)

--- a/tests/test_host_transport.py
+++ b/tests/test_host_transport.py
@@ -565,8 +565,9 @@ class BackendHostRules(unittest.TestCase):
         sb.write_reg(Path(d), SID, {"sid": SID, "name": "web", "alive": True, "lastSid": SID,
                                      "hostAck": {"host": "1:a", "cli": "2:c", "offset": 1}})
         self._leftover(d, "9:b", records=3)
+        seeds = []
         s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False,
-                                _seed_for_dead_cli=lambda cli: None)   # the replay's watermark seed (T354): a no-op on this stand-in
+                                _seed_for_dead_cli=seeds.append)   # the replay's watermark seed (T354): recorded here
         acks = []
         capture = classmethod(lambda cls, hdir, ack=-1, **kw: acks.append(ack) or types.SimpleNamespace(hdir=hdir))
         with mock.patch.dict(sys.modules, {"claude_agent_sdk": self._sdk_stub()}), \
@@ -580,6 +581,7 @@ class BackendHostRules(unittest.TestCase):
              mock.patch.object(ht.HostTransport, "from_journal", capture), mock.patch.object(be, "_replay_drain", mock.AsyncMock()):
             asyncio.run(be._host_orphan_recover(s, types.SimpleNamespace(), None, (None, None, None), died=False))
         self.assertEqual(acks, [-1, 1], "this host's ack: the replay starts past it")
+        self.assertEqual(seeds, ["", "2:c"], "the watermark seed runs before each replay (T354 M7), the CLI named by hostAck only when the ack is this host's")
 
     def test_a_host_this_kernel_ended_gets_a_bounded_wait_for_its_lease_and_no_host_died_row(self):
         # item 6: the behaviour, not the bookkeeping: an `end` this kernel asked for races the reconnect; the stale

--- a/tests/test_host_transport.py
+++ b/tests/test_host_transport.py
@@ -477,7 +477,8 @@ class BackendHostRules(unittest.TestCase):
         Path(d, "session-hosts").write_text("off")
         sb.write_reg(Path(d), SID, {"sid": SID, "name": "web", "alive": True, "lastSid": SID})
         sb.write_lease(d, {"sid": SID, "fsid": SID, "pid": 999999997, "start": "1", "holder": {"pid": 999999996, "start": "2", "kind": "host"}, "version": "", "t": time.time()})
-        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False)
+        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False,
+                                _seed_for_dead_cli=lambda cli: None)   # the replay's watermark seed (T354): a no-op on this stand-in
         with mock.patch.object(sb, "proc_start", lambda p, run=None: None):
             out = asyncio.run(be._host_transport_for(s, types.SimpleNamespace(), (None, None, None)))
         self.assertIsNone(out, "the kill switch holds after the orphan road: a plain SDK subprocess, no new host")
@@ -519,7 +520,8 @@ class BackendHostRules(unittest.TestCase):
         sb.write_reg(Path(d), SID, {"sid": SID, "name": "web", "alive": True, "lastSid": SID,
                                      "hostAck": {"host": "5:h", "cli": "6:c", "offset": 0}, "hostLogPos": 3})
         hd = self._leftover(d, "5:h", records=3)
-        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False)
+        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False,
+                                _seed_for_dead_cli=lambda cli: None)   # the replay's watermark seed (T354): a no-op on this stand-in
         self.assertTrue(be._host_lease_applies(s), "a leftover directory is a host that held this session: the road runs whatever the setting")
         acks, drained = [], []
         async def drain(sess, client, msg_classes): drained.append(client.transport)
@@ -543,7 +545,8 @@ class BackendHostRules(unittest.TestCase):
         sb.write_reg(Path(d), SID, {"sid": SID, "name": "web", "alive": True, "lastSid": SID,
                                      "hostAck": {"host": "5:h", "cli": "6:c", "offset": 2}})
         hd = self._leftover(d, "5:h", records=3)          # offsets 0..2, all acknowledged
-        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False)
+        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False,
+                                _seed_for_dead_cli=lambda cli: None)   # the replay's watermark seed (T354): a no-op on this stand-in
         with mock.patch.dict(sys.modules, {"claude_agent_sdk": self._sdk_stub()}), \
              mock.patch.object(be, "_replay_drain", mock.AsyncMock()):
             asyncio.run(be._host_orphan_recover(s, types.SimpleNamespace(), None, (None, None, None), died=False))
@@ -562,7 +565,8 @@ class BackendHostRules(unittest.TestCase):
         sb.write_reg(Path(d), SID, {"sid": SID, "name": "web", "alive": True, "lastSid": SID,
                                      "hostAck": {"host": "1:a", "cli": "2:c", "offset": 1}})
         self._leftover(d, "9:b", records=3)
-        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False)
+        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False,
+                                _seed_for_dead_cli=lambda cli: None)   # the replay's watermark seed (T354): a no-op on this stand-in
         acks = []
         capture = classmethod(lambda cls, hdir, ack=-1, **kw: acks.append(ack) or types.SimpleNamespace(hdir=hdir))
         with mock.patch.dict(sys.modules, {"claude_agent_sdk": self._sdk_stub()}), \
@@ -585,7 +589,8 @@ class BackendHostRules(unittest.TestCase):
         sb.write_reg(Path(d), SID, {"sid": SID, "name": "web", "alive": True, "lastSid": SID})
         sb.write_lease(d, {"sid": SID, "fsid": SID, "pid": 999999997, "start": "1", "holder": {"pid": 999999996, "start": "2", "kind": "host"}, "version": "", "t": time.time()})
         be._host_recently_ended[SID] = "999999996:2"
-        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False)
+        s = types.SimpleNamespace(sid=SID, name="web", _host_intent=True, _host=None, _host_is_attach=False,
+                                _seed_for_dead_cli=lambda cli: None)   # the replay's watermark seed (T354): a no-op on this stand-in
         import threading
         remover = threading.Timer(0.4, lambda: sb.remove_lease(d, SID)); remover.start()
         try:

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""T354: a kernel restart must not re-bill a hosted session's CLI lifetime. A host ATTACH keeps the CLI process, whose
+total_cost_usd is cumulative; the kernel persists the session's cost watermark on its registry row at every result,
+seeds from it at the attach when it names the surviving CLI, records nothing for a first result with no matching
+watermark, and still records a fresh process's whole first total.
+
+SYNTHETIC fixtures only: placeholder ids, an invented session, a fake host hello.
+"""
+import asyncio
+import json
+import os
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()   # hermetic BEFORE the loads
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = load_source("romp_sdk_backend", os.path.join(BIN, "romp_sdk_backend.py"))
+
+SID = "11111111-2222-3333-4444-00000000a354"
+
+
+class _ResultMessage:
+    subtype = "success"
+
+
+class _AssistantMessage:
+    pass
+
+
+def _result(total, tokens_in):
+    r = _ResultMessage()
+    r.total_cost_usd = total
+    r.model_usage = {"claude-x": {"inputTokens": tokens_in, "outputTokens": 0, "cacheReadInputTokens": 0,
+                                  "cacheCreationInputTokens": 0, "webSearchRequests": 0, "costUSD": 0.0}}
+    r.usage = {"input_tokens": 9999}
+    return r
+
+
+class Rebill(unittest.TestCase):
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        Path(self.d, "session-hosts").write_text("off")   # this backend never connects; the pin is the suite's rule
+        self.lines = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=lambda m, **k: self.lines.append(str(m)))
+        self.be._forward = lambda sess, msg: None
+        self.be._turn_completed = lambda sid: None
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
+
+    def _session(self, attach=False, hello_cli=("4242", "s1")):
+        s = sb.SdkSession(self.be, {"sid": SID, "name": "web", "cwd": self.d})
+        async def _noop(): pass
+        s._do_refresh_context = _noop
+        s._do_refresh_usage = _noop
+        if attach:
+            s._host_is_attach = True
+            s._host = types.SimpleNamespace(hello={"host": {"pid": 1, "start": "h"}, "cli": {"pid": hello_cli[0], "start": hello_cli[1]}},
+                                            ack_offset=0, exit_info=None, detach_mode=False)
+        s._seed_spend_watermarks()                          # the connect-time step
+        return s
+
+    def _run(self, s, r):
+        async def go():
+            s._on_message(r, _AssistantMessage, _ResultMessage, type("S", (), {}))
+            await asyncio.sleep(0)
+        asyncio.run(go())
+
+    def _day(self):
+        p = Path(self.d, "spend.json")
+        if not p.exists():
+            return {}
+        return json.loads(p.read_text())["days"].get(time.strftime("%Y-%m-%d"), {})
+
+    def _turns(self):
+        p = Path(self.d, "turns.jsonl")
+        return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+    def _cost_state(self):
+        return (sb.read_reg(Path(self.d), SID) or {}).get("costState")
+
+    def test_a_fresh_process_seeds_zero_and_records_its_whole_first_total_and_persists_the_watermark(self):
+        s = self._session()
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (0.0, "fresh"))
+        self._run(s, _result(3.5, 100))
+        self.assertAlmostEqual(self._day()["usd"], 3.5, msg="a fresh process: the first total is the turn's own")
+        cs = self._cost_state()
+        self.assertEqual((cs["total"], cs["cli"], cs["tokens"]["input_tokens"]), (3.5, "", 100), "the watermark, on the registry, every result")
+        self._run(s, _result(5.0, 160))
+        self.assertAlmostEqual(self._day()["usd"], 5.0)
+        self.assertEqual(self._cost_state()["total"], 5.0)
+        rows = self._turns()
+        self.assertEqual([r["cumulativeUsd"] for r in rows], [3.5, 5.0], "each turn row carries the CLI's cumulative total")
+        self.assertEqual(rows[0].get("spendBaseline"), "fresh")
+        self.assertNotIn("spendBaseline", rows[1], "only a first result names its baseline")
+
+    def test_an_attach_to_the_surviving_cli_seeds_from_the_registry_and_records_one_turns_delta(self):
+        # the previous kernel's last result left the watermark for CLI 4242:s1 at $500 (the staircase's cause was
+        # seeding zero here: the lifetime's $512.50 would have been one turn)
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True, hello_cli=("4242", "s1"))
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (0.0, "attach-pending"), "nothing folded until the hello names the CLI")
+        self._run(s, _result(512.5, 90400))
+        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="only this turn's delta over the seeded watermark")
+        self.assertEqual(self._day()["tokIn"], 400, "the token watermarks seed too")
+        self.assertEqual(s._spend_baseline, "seeded")
+        self.assertEqual(self._cost_state()["total"], 512.5)
+        self.assertTrue(any("attached to its surviving CLI (4242:s1): watermarks seeded at the registry's cumulative $500.00" in l for l in self.lines), self.lines)
+        self.assertEqual(self._turns()[0]["spendBaseline"], "seeded")
+        self.assertEqual(self._turns()[0]["cumulativeUsd"], 512.5)
+        self.assertEqual([r for r in self.be.problems() if "spend" in str(r.get("text") or "")], [], "an info line, never a problem row")
+
+    def test_an_attach_with_no_matching_watermark_records_nothing_for_the_first_result_and_says_so(self):
+        for cs in (None, {"total": 300.0, "tokens": {}, "cli": "other:proc", "t": 1}):
+            sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
+            if cs:
+                self.be._update_reg(SID, costState=cs)
+            Path(self.d, "spend.json").unlink(missing_ok=True)
+            Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+            self.lines.clear()
+            s = self._session(attach=True, hello_cli=("4242", "s1"))
+            self._run(s, _result(512.5, 90400))
+            self.assertEqual(self._day(), {}, "the lifetime's total is not a turn: nothing folded (%r)" % cs)
+            self.assertEqual(s._spend_baseline, "attach-unknown")
+            self.assertTrue(any("attached to a surviving CLI (4242:s1) with no matching watermark on record" in l for l in self.lines), self.lines)
+            self.assertTrue(any("this turn's own cost is unknowable and nothing was folded" in l for l in self.lines), self.lines)
+            self.assertEqual(self._cost_state()["total"], 512.5, "the watermark is set from here…")
+            self.assertEqual(self._cost_state()["cli"], "4242:s1")
+            rows = self._turns()
+            self.assertEqual((rows[0]["spendBaseline"], rows[0]["cumulativeUsd"], rows[0]["usd"]), ("attach-unknown", 512.5, 0.0))
+            self._run(s, _result(520.0, 91000))
+            self.assertAlmostEqual(self._day()["usd"], 7.5, msg="…so the next result records its own delta")
+            self.assertEqual(self._day()["tokIn"], 600)
+
+    def test_a_first_result_above_the_mark_names_which_process_it_was(self):
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True)
+        self._run(s, _result(900.0, 10))                    # a $400 turn over the seed: recorded, said as the attach case
+        self.assertAlmostEqual(self._day()["usd"], 400.0)
+        self.assertTrue(any("first result after a host attach cost $400.00" in l and "seeded from the registry at $500.00" in l for l in self.lines), self.lines)
+        self.lines.clear()
+        s2 = self._session()
+        self._run(s2, _result(300.0, 10))                   # a fresh process's big first turn: the old text
+        self.assertTrue(any("first result after connect cost $300.00" in l and "a fresh CLI process starts its cost at zero" in l for l in self.lines), self.lines)
+
+    def test_the_attach_flag_is_cleared_on_every_road_but_an_attach(self):
+        # M6 (the review of the fix): a flag left True by an earlier attach in this object's life made the seed wait for
+        # a registry watermark on the hosts-off road, where the CLI is a kernel child that dies with the kernel, so a
+        # rollback to hosts off recorded nothing for the fresh child's first turn, once per connect
+        s = self._session()
+        s._host_is_attach = True
+        Path(self.d, "session-hosts").write_text("off")
+        async def go():
+            return await self.be._host_transport_for(s, None, (None, None, None))
+        self.assertIsNone(asyncio.run(go()), "the setting off: a kernel child, no transport")
+        self.assertFalse(s._host_is_attach, "the hosts-off road clears the flag")
+        s._seed_spend_watermarks()
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (0.0, "fresh"))
+        self._run(s, _result(3.5, 100))
+        self.assertAlmostEqual(self._day()["usd"], 3.5, msg="the fresh child's first turn is recorded in full")
+        import inspect
+        src = inspect.getsource(sb.SdkBackend._host_transport_for)
+        self.assertLess(src.index("sess._host_is_attach = False"), src.index('if state == "attach":'),
+                        "cleared before any branch; set True on the attach branch alone")
+        self.assertEqual(src.count("sess._host_is_attach = False"), 1)
+
+    def test_a_dead_hosts_journal_replay_seeds_from_the_dead_clis_watermark_before_it_drains(self):
+        # M7: the tail's result rows carry the DEAD CLI's cumulative and drain through the result branch before the
+        # connect's seed runs; a zero watermark there folded the dead lifetime as one turn
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
+        s = self._session()                                 # a boot's fresh object: no host, no hello
+        s._seed_for_dead_cli("4242:s1")
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (500.0, "seeded"))
+        self.assertTrue(any("replaying the journal of its dead CLI (4242:s1): watermarks seeded at the registry's cumulative $500.00" in l for l in self.lines), self.lines)
+        self._run(s, _result(512.5, 90400))                 # the dead CLI's last result, replayed
+        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="only the replayed turn's own delta")
+        self.assertEqual(self._day()["tokIn"], 400)
+        s._seed_spend_watermarks()                          # the connect's seed for the spawn that follows
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (0.0, "fresh"))
+        self.lines.clear()
+        s2 = self._session()
+        s2._seed_for_dead_cli("other:proc")                 # the watermark names another process
+        self.assertEqual(s2._spend_baseline, "attach-unknown")
+        self.assertTrue(any("replaying the journal of a dead CLI (other:proc) with no matching watermark on record" in l for l in self.lines), self.lines)
+        self._run(s2, _result(700.0, 10))
+        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="nothing folded for a lifetime whose turn share is unknowable")
+        s3 = self._session()
+        s3._seed_for_dead_cli("")                           # no lease and no ack naming the host: unnamed
+        self.assertEqual(s3._spend_baseline, "attach-unknown")
+        import inspect
+        src = inspect.getsource(sb.SdkBackend._host_orphan_recover)
+        self.assertLess(src.index("sess._seed_for_dead_cli(cli)"), src.index("self._replay_drain("), "seeded before the drain")
+        self.assertIn('cli = "%s:%s" % (lease.get("pid"), lease.get("start"))', src, "the lease names the dead CLI")
+        self.assertIn('cli = str(ack.get("cli") or "")', src, "else hostAck, when it names this host")
+
+    def test_the_seed_and_the_result_are_pinned_to_the_registry_road(self):
+        import inspect
+        seed = inspect.getsource(sb.SdkSession._seed_spend_watermarks)
+        self.assertIn('self._spend_baseline = "attach-pending"', seed)
+        self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero", seed, "the fresh seed is unchanged")
+        on = inspect.getsource(sb.SdkSession._on_message)
+        self.assertIn("self._seed_from_reg_cost_state()", on)
+        self.assertIn("self._persist_cost_state(total)", on, "the watermark is written at every result")
+        self.assertIn('costState={"total": float(total), "tokens": dict(self._last_usage_totals),', inspect.getsource(sb.SdkSession._persist_cost_state))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -7,6 +7,7 @@ watermark, and still records a fresh process's whole first total.
 SYNTHETIC fixtures only: placeholder ids, an invented session, a fake host hello.
 """
 import asyncio
+import collections
 import inspect
 import json
 import os
@@ -55,7 +56,7 @@ class Rebill(unittest.TestCase):
         self.be._turn_completed = lambda sid: None
         sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
 
-    def _session(self, attach=False, hello_cli=("4242", "s1"), journal_next=10, attach_ack=5):
+    def _session(self, attach=False, hello_cli=("4242", "s1"), journal_next=10, tags=None):
         s = sb.SdkSession(self.be, {"sid": SID, "name": "web", "cwd": self.d})
         async def _noop(): pass
         s._do_refresh_context = _noop
@@ -63,10 +64,11 @@ class Rebill(unittest.TestCase):
         if attach:
             s._host_is_attach = True
             # the host's hello names the journal's next offset at the attach (records before it are the replay); the
-            # transport's ack_offset is the record being handled; attach_ack the offset acknowledged when it was made
+            # transport queues one tag per result record it hands over, and the fold pops them in order
             s._host = types.SimpleNamespace(hello={"host": {"pid": 1, "start": "h"}, "cli": {"pid": hello_cli[0], "start": hello_cli[1]},
                                                    "journal": {"next": journal_next}},
-                                            ack_offset=journal_next, attach_ack=attach_ack, journal_dir=None, exit_info=None, detach_mode=False)
+                                            ack_offset=journal_next, replay_end=journal_next, journal_dir=None, exit_info=None, detach_mode=False,
+                                            result_tags=collections.deque(tags or []))
         s._seed_spend_watermarks()                          # the connect-time step
         return s
 
@@ -226,43 +228,74 @@ class Rebill(unittest.TestCase):
         self.assertIn('if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:',
                       inspect.getsource(sb.SdkSession._seed_spend_watermarks))
 
-    def test_a_redelivered_result_is_known_by_its_journal_position_and_folds_nothing(self):
-        # M2 of the review, reshaped by its round two: hostAck is written at most once a second while the watermark
-        # moves per result, so a kernel death leaves processed results past the acknowledged offset and the attach's
-        # replay hands them over again. Redelivery is read from the JOURNAL POSITION: the hello names the journal's
-        # next offset (10 here), the attach acknowledged 5, the replay is offsets 6..9, live records start at 10
+    def test_a_redelivered_result_is_known_by_the_tag_the_transport_queued_and_folds_nothing_whatever_its_total(self):
+        # round four of the review: the transport tags each RESULT record with its own offset as it reads it and the
+        # fold pops the tags in order; a record before the journal's next at the attach (10 here) is a replay and folds
+        # nothing, whatever its total; a record from 10 on is live. The SDK's buffered reader runs a record AHEAD of
+        # the handler, so all tags sit queued before the first result is handled (the +1 lookahead the review measured)
+        def tag(off):
+            return {"offset": off, "replay": off < 10}
         self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
-        s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10, attach_ack=5)
-        s._host.ack_offset = 6
-        self._run(s, _result(480.0, 89000))                 # replayed, processed by the dead kernel (below the watermark)
-        self.assertEqual(self._day(), {}, "a result the ledger already holds folds nothing")
-        self.assertEqual((s._last_cost_total, s._last_usage_totals["input_tokens"]), (500.0, 90000), "the watermarks did not move down")
-        s._host.ack_offset = 7
+        s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10, tags=[tag(7), tag(8), tag(9), tag(10), tag(11)])
+        s._host.ack_offset = 11                              # the transport is already past every replayed record: the +1 lookahead
+        self._run(s, _result(480.0, 89000))                 # replayed, below the watermark
+        self.assertEqual(self._day(), {}, "a replay folds nothing")
+        self.assertEqual((s._last_cost_total, s._last_usage_totals["input_tokens"]), (500.0, 90000), "the watermarks did not move")
         self._run(s, _result(500.0, 90000))                 # replayed: the very result the watermark came from
-        self.assertEqual(self._day(), {})
-        s._host.ack_offset = 8
-        self._run(s, _result(512.5, 90400))                 # replayed but ABOVE the watermark: the dead kernel never folded it
-        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="a replay the ledger does not hold is real spend")
-        s._host.ack_offset = 10
-        self._run(s, _result(520.0, 91000))                 # live
+        self._run(s, _result(512.5, 90400))                 # replayed and ABOVE the watermark: still a replay, folds nothing
+        self.assertEqual(self._day(), {}, "position alone decides a replay, never the total")
+        self._run(s, _result(520.0, 91000))                 # live (offset 10): the plain delta over the watermark
         self.assertAlmostEqual(self._day()["usd"], 20.0)
+        self.assertEqual(self._day()["tokIn"], 1000)
+        self._run(s, _result(526.0, 91200))                 # live (offset 11)
+        self.assertAlmostEqual(self._day()["usd"], 26.0)
         rows = self._turns()
-        self.assertEqual([r["usd"] for r in rows], [0.0, 0.0, 12.5, 7.5])
-        self.assertEqual([r.get("redelivered", False) for r in rows], [True, True, False, False], "the row says so, a flag the repair can trust")
-        self.assertEqual([r["cumulativeUsd"] for r in rows], [480.0, 500.0, 512.5, 520.0], "each row still names the CLI's total it carried")
+        self.assertEqual([r["usd"] for r in rows], [0.0, 0.0, 0.0, 20.0, 6.0])
+        self.assertEqual([r.get("redelivered", False) for r in rows], [True, True, True, False, False], "the rows say so")
+        self.assertEqual([r.get("journalOffset") for r in rows], [7, 8, 9, 10, 11], "and carry the record's offset")
+        self.assertEqual([r["cumulativeUsd"] for r in rows], [480.0, 500.0, 512.5, 520.0, 526.0])
+        self.assertEqual(self._cost_state()["session"], "", "the CLI's session epoch rides costState (empty on these doubles)")
 
-    def test_a_replay_at_or_below_the_attach_ack_is_a_redelivery_whatever_its_total(self):
-        # the whole-journal replay (the ack named another host) of a CLI that ran a /clear mid-life: a pre-clear row
-        # replays ABOVE the post-clear watermark; at or below the acknowledged offset it is a replay all the same
-        self.be._update_reg(SID, costState={"total": 20.0, "tokens": {}, "cli": "4242:s1", "t": 1})
-        s = self._session(attach=True, journal_next=10, attach_ack=5)
-        s._host.ack_offset = 3
-        self._run(s, _result(600.0, 10))                    # pre-clear, above the watermark, at or below the ack: a replay
-        self.assertEqual(self._day(), {})
-        self.assertEqual(s._last_cost_total, 20.0)
-        s._host.ack_offset = 10
-        self._run(s, _result(25.0, 10))                     # live: the post-clear counter moving on
-        self.assertAlmostEqual(self._day()["usd"], 5.0)
+    def test_a_replay_across_a_mid_life_clear_bills_nothing(self):
+        # the round-three MEDIUM: the dead kernel folded a pre-clear result (8.00), bracketed the /clear, folded a
+        # post-clear result (5.00, costState 5.00) and died with hostAck lagging; the attach seeds 5.00 and replays
+        # offsets 2 to 4; read from totals, the pre-clear 8 > 5 folded $3 and dragged the watermark to 8, and the
+        # replayed post-clear 5 read as live and folded whole: $8 billed for $0
+        self.be._update_reg(SID, costState={"total": 5.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True, journal_next=5, tags=[{"offset": 2, "replay": True}, {"offset": 4, "replay": True}, {"offset": 5, "replay": False}])
+        s._host.ack_offset = 5
+        self._run(s, _result(8.0, 10))                      # the pre-clear result, replayed
+        self._run(s, _result(5.0, 10))                      # the post-clear result, replayed, handled at the post-next offset
+        self.assertEqual(self._day(), {}, "$0: both are replays")
+        self.assertEqual(s._last_cost_total, 5.0, "the watermark stayed at the post-clear 5")
+        self._run(s, _result(7.0, 10))                      # live
+        self.assertAlmostEqual(self._day()["usd"], 2.0)
+        self.assertEqual([r.get("redelivered", False) for r in self._turns()], [True, True, False])
+
+    def test_the_transport_tags_each_result_record_with_its_offset_as_it_reads_it(self):
+        # the transport unit of the rule: the hello's journal.next bounds the replay; records the reader hands over are
+        # tagged in _take before the yield; the last replayed record tagged at next - 1 is a replay even though the
+        # transport's ack offset has moved on when the consumer handles it
+        ht = load_source("romp_host_transport_tags", os.path.join(ROOT, "kernel", "host_transport.py"))
+        t = ht.HostTransport.__new__(ht.HostTransport)
+        t.ack_offset, t.replay_end, t.result_tags, t.on_ack = 5, None, collections.deque(), None
+        t.hello = None
+        t._advance = lambda out: None
+        t.replay_end = 10
+        for off, typ in ((8, "result"), (9, "assistant"), (9, "result"), (10, "result"), (11, "result")):
+            t._take({"offset": off, "data": {"type": typ, "subtype": "success"}})
+        self.assertEqual(list(t.result_tags), [{"offset": 8, "replay": True}, {"offset": 9, "replay": True},
+                                               {"offset": 10, "replay": False}, {"offset": 11, "replay": False}],
+                         "one tag per RESULT record, in order; the assistant record is not tagged")
+        t.result_tags.clear()
+        t._tag(3, {"type": "result"}, replay=True)          # the orphan reader's road: a replay whatever the window
+        self.assertEqual(list(t.result_tags), [{"offset": 3, "replay": True}])
+        import inspect
+        src = inspect.getsource(ht.HostTransport._take)
+        self.assertLess(src.index("self._tag(out.get(\"offset\"), out[\"data\"])"), src.index("return out[\"data\"]"), "tagged before the hand-over")
+        rm = inspect.getsource(ht.HostTransport._read_journal)
+        self.assertIn("self._tag(off, rec, replay=True)", rm, "the orphan journal's reader tags every record a replay")
+        self.assertIn('self.replay_end = int(((hello or {}).get("journal") or {}).get("next"))', inspect.getsource(ht.HostTransport))
 
     def test_a_live_total_below_the_watermark_is_a_counter_reset_on_every_road_and_never_latches_zero(self):
         # the round-two HIGH: read from the total alone, every real reset was a duplicate and the session stayed at $0
@@ -291,7 +324,8 @@ class Rebill(unittest.TestCase):
         Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
         s3 = self._session()
         s3._host = types.SimpleNamespace(hello={"host": {"pid": 1, "start": "h"}, "cli": {"pid": "7", "start": "s7"}, "journal": {"next": 0}},
-                                         ack_offset=0, attach_ack=-1, journal_dir=None, exit_info=None, detach_mode=False)
+                                         ack_offset=0, replay_end=0, result_tags=collections.deque([{"offset": 0, "replay": False}, {"offset": 1, "replay": False}]),
+                                         journal_dir=None, exit_info=None, detach_mode=False)
         s3._last_cost_total = 500.0                          # the cost-state record's seed
         self._run(s3, _result(3.0, 10)); self._run(s3, _result(8.0, 10))
         self.assertAlmostEqual(self._day()["usd"], 8.0, msg="3 then 5 on a spawn's empty replay window")
@@ -300,12 +334,15 @@ class Rebill(unittest.TestCase):
         self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})   # (b) moved it again
         s4 = self._session()
         s4._seed_for_dead_cli("4242:s1")                     # seeded at 500
-        s4._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=7, attach_ack=6, exit_info=None, detach_mode=False)
+        s4._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=8, exit_info=None, detach_mode=False,
+                                         result_tags=collections.deque([{"offset": 7, "replay": True}, {"offset": 8, "replay": True}]))
         self._run(s4, _result(480.0, 10))
-        self.assertEqual(self._day(), {})
-        s4._host.ack_offset = 8
+        self.assertEqual(self._day(), {}, "at or below the dead CLI's watermark: folded by the kernel that died")
         self._run(s4, _result(512.5, 10))
-        self.assertAlmostEqual(self._day()["usd"], 12.5)
+        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="above it: spend no kernel folded (the orphan road keeps the watermark line)")
+        self.assertEqual(self._cost_state()["cli"], "4242:s1", "the orphan replay persists the watermark under the DEAD CLI's identity (the round-four low)")
+        s4._seed_spend_watermarks()
+        self.assertEqual(s4._cli_ident(), "", "the connect's seed ends the replay identity")
 
     def test_a_replayed_tail_with_no_result_leaves_the_spawn_to_seed_fresh_and_an_init_in_the_tail_never_clobbers_the_dead_seed(self):
         # low b: a dead host's tail with no result record folds nothing and the connect's seed for the spawn that follows

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -7,6 +7,7 @@ watermark, and still records a fresh process's whole first total.
 SYNTHETIC fixtures only: placeholder ids, an invented session, a fake host hello.
 """
 import asyncio
+import inspect
 import json
 import os
 import tempfile
@@ -54,15 +55,18 @@ class Rebill(unittest.TestCase):
         self.be._turn_completed = lambda sid: None
         sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
 
-    def _session(self, attach=False, hello_cli=("4242", "s1")):
+    def _session(self, attach=False, hello_cli=("4242", "s1"), journal_next=10, attach_ack=5):
         s = sb.SdkSession(self.be, {"sid": SID, "name": "web", "cwd": self.d})
         async def _noop(): pass
         s._do_refresh_context = _noop
         s._do_refresh_usage = _noop
         if attach:
             s._host_is_attach = True
-            s._host = types.SimpleNamespace(hello={"host": {"pid": 1, "start": "h"}, "cli": {"pid": hello_cli[0], "start": hello_cli[1]}},
-                                            ack_offset=0, exit_info=None, detach_mode=False)
+            # the host's hello names the journal's next offset at the attach (records before it are the replay); the
+            # transport's ack_offset is the record being handled; attach_ack the offset acknowledged when it was made
+            s._host = types.SimpleNamespace(hello={"host": {"pid": 1, "start": "h"}, "cli": {"pid": hello_cli[0], "start": hello_cli[1]},
+                                                   "journal": {"next": journal_next}},
+                                            ack_offset=journal_next, attach_ack=attach_ack, journal_dir=None, exit_info=None, detach_mode=False)
         s._seed_spend_watermarks()                          # the connect-time step
         return s
 
@@ -222,28 +226,86 @@ class Rebill(unittest.TestCase):
         self.assertIn('if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:',
                       inspect.getsource(sb.SdkSession._seed_spend_watermarks))
 
-    def test_a_redelivered_result_below_the_watermark_folds_nothing_and_the_watermarks_stay(self):
-        # M2: hostAck is written at most once a second while the watermark moves per result, so a kernel death leaves
-        # processed results past the acknowledged offset and the attach's replay hands them over again (the whole
-        # journal when the ack names another host); folded whole as a "counter reset" they were the lifetime as one turn
+    def test_a_redelivered_result_is_known_by_its_journal_position_and_folds_nothing(self):
+        # M2 of the review, reshaped by its round two: hostAck is written at most once a second while the watermark
+        # moves per result, so a kernel death leaves processed results past the acknowledged offset and the attach's
+        # replay hands them over again. Redelivery is read from the JOURNAL POSITION: the hello names the journal's
+        # next offset (10 here), the attach acknowledged 5, the replay is offsets 6..9, live records start at 10
         self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
-        s = self._session(attach=True, hello_cli=("4242", "s1"))
-        self._run(s, _result(480.0, 89000))                 # redelivered: below the seeded 500
+        s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10, attach_ack=5)
+        s._host.ack_offset = 6
+        self._run(s, _result(480.0, 89000))                 # replayed, processed by the dead kernel (below the watermark)
         self.assertEqual(self._day(), {}, "a result the ledger already holds folds nothing")
         self.assertEqual((s._last_cost_total, s._last_usage_totals["input_tokens"]), (500.0, 90000), "the watermarks did not move down")
-        self._run(s, _result(500.0, 90000))                 # redelivered: the very result the watermark came from
+        s._host.ack_offset = 7
+        self._run(s, _result(500.0, 90000))                 # replayed: the very result the watermark came from
         self.assertEqual(self._day(), {})
-        self._run(s, _result(512.5, 90400))                 # the first NEW result
-        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="only the new spend: the true 12.5, not the lifetime's 512.5")
-        self.assertEqual(self._day()["tokIn"], 400)
-        self.assertEqual(self._cost_state()["total"], 512.5)
+        s._host.ack_offset = 8
+        self._run(s, _result(512.5, 90400))                 # replayed but ABOVE the watermark: the dead kernel never folded it
+        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="a replay the ledger does not hold is real spend")
+        s._host.ack_offset = 10
+        self._run(s, _result(520.0, 91000))                 # live
+        self.assertAlmostEqual(self._day()["usd"], 20.0)
         rows = self._turns()
-        self.assertEqual([r["usd"] for r in rows], [0.0, 0.0, 12.5])
-        self.assertEqual([r["cumulativeUsd"] for r in rows], [480.0, 500.0, 512.5], "each row still names the CLI's total it carried")
-        # a fresh process is NOT hosted: a total below the watermark there is still the counter reset it always was
-        s2 = self._session()
-        self._run(s2, _result(10.0, 10)); self._run(s2, _result(4.0, 10))
-        self.assertAlmostEqual(self._day()["usd"], 12.5 + 10.0 + 4.0)
+        self.assertEqual([r["usd"] for r in rows], [0.0, 0.0, 12.5, 7.5])
+        self.assertEqual([r.get("redelivered", False) for r in rows], [True, True, False, False], "the row says so, a flag the repair can trust")
+        self.assertEqual([r["cumulativeUsd"] for r in rows], [480.0, 500.0, 512.5, 520.0], "each row still names the CLI's total it carried")
+
+    def test_a_replay_at_or_below_the_attach_ack_is_a_redelivery_whatever_its_total(self):
+        # the whole-journal replay (the ack named another host) of a CLI that ran a /clear mid-life: a pre-clear row
+        # replays ABOVE the post-clear watermark; at or below the acknowledged offset it is a replay all the same
+        self.be._update_reg(SID, costState={"total": 20.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True, journal_next=10, attach_ack=5)
+        s._host.ack_offset = 3
+        self._run(s, _result(600.0, 10))                    # pre-clear, above the watermark, at or below the ack: a replay
+        self.assertEqual(self._day(), {})
+        self.assertEqual(s._last_cost_total, 20.0)
+        s._host.ack_offset = 10
+        self._run(s, _result(25.0, 10))                     # live: the post-clear counter moving on
+        self.assertAlmostEqual(self._day()["usd"], 5.0)
+
+    def test_a_live_total_below_the_watermark_is_a_counter_reset_on_every_road_and_never_latches_zero(self):
+        # the round-two HIGH: read from the total alone, every real reset was a duplicate and the session stayed at $0
+        # (a) a /clear as the first turn after an attach: the event zeroes the counter and retires the pending seed
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True)
+        self.assertEqual(s._spend_baseline, "attach-pending")
+        s._last_cost_total = 0.0; s._last_usage_totals = {}          # what the /clear event does…
+        if s._spend_baseline == "attach-pending":                    # …and the retirement it now carries (pinned below)
+            s._spend_baseline = "fresh"
+        s._host.ack_offset = 10
+        self._run(s, _result(3.0, 10)); self._run(s, _result(8.0, 10))
+        self.assertAlmostEqual(self._day()["usd"], 8.0, msg="3 then 5, never 0 and 0")
+        src = inspect.getsource(sb.SdkSession._on_message)
+        i = src.index("self._last_cost_total = 0.0" + chr(10) + "                    self._last_usage_totals = {}")
+        self.assertIn('if getattr(self, "_spend_baseline", "fresh") == "attach-pending":', src[i:i + 700], "the /clear event retires a pending attach seed")
+        # (b) a /clear the kernel never saw (unbracketed, in flight when the kernel died): live results below the seed
+        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})   # (a) moved the watermark to 8
+        s2 = self._session(attach=True)
+        s2._host.ack_offset = 10
+        self._run(s2, _result(512.5, 10))                   # the seeded 500: 12.5
+        self._run(s2, _result(3.0, 10)); self._run(s2, _result(8.0, 10))
+        self.assertAlmostEqual(self._day()["usd"], 12.5 + 3.0 + 5.0, msg="a live total below the watermark is a reset: folded whole, then its delta")
+        # (c) a resumed transcript's cost-state seed (baseline fresh) under a spawned host, against a print-mode CLI
+        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+        s3 = self._session()
+        s3._host = types.SimpleNamespace(hello={"host": {"pid": 1, "start": "h"}, "cli": {"pid": "7", "start": "s7"}, "journal": {"next": 0}},
+                                         ack_offset=0, attach_ack=-1, journal_dir=None, exit_info=None, detach_mode=False)
+        s3._last_cost_total = 500.0                          # the cost-state record's seed
+        self._run(s3, _result(3.0, 10)); self._run(s3, _result(8.0, 10))
+        self.assertAlmostEqual(self._day()["usd"], 8.0, msg="3 then 5 on a spawn's empty replay window")
+        # (d) an orphan journal's reader replays only: below the dead CLI's watermark folds nothing, above it folds
+        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})   # (b) moved it again
+        s4 = self._session()
+        s4._seed_for_dead_cli("4242:s1")                     # seeded at 500
+        s4._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=7, attach_ack=6, exit_info=None, detach_mode=False)
+        self._run(s4, _result(480.0, 10))
+        self.assertEqual(self._day(), {})
+        s4._host.ack_offset = 8
+        self._run(s4, _result(512.5, 10))
+        self.assertAlmostEqual(self._day()["usd"], 12.5)
 
     def test_a_replayed_tail_with_no_result_leaves_the_spawn_to_seed_fresh_and_an_init_in_the_tail_never_clobbers_the_dead_seed(self):
         # low b: a dead host's tail with no result record folds nothing and the connect's seed for the spawn that follows

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -272,6 +272,91 @@ class Rebill(unittest.TestCase):
         self.assertAlmostEqual(self._day()["usd"], 2.0)
         self.assertEqual([r.get("redelivered", False) for r in self._turns()], [True, True, False])
 
+    def test_a_dead_hosts_journal_replays_through_the_real_orphan_road_and_bills_nothing_it_already_folded(self):
+        # round five of the review, the HIGH: the orphan road built the replay transport but never made it the session's,
+        # so the fold saw no tags and a dead host's tail across a /clear billed $8 for $0. Driven through the real
+        # _host_orphan_recover with a stub SDK client that reads the real replay transport and hands its records over
+        import sys
+        from unittest import mock
+        hostmod = load_source("romp_host_transport_orphan", os.path.join(ROOT, "kernel", "host_transport.py"))
+        sh = hostmod.sh
+        hdir = hostmod.host_dir(Path(self.d), SID) if hasattr(hostmod, "host_dir") else Path(self.d, "hosts", SID)
+        hdir.mkdir(parents=True, exist_ok=True)
+        (hdir / "identity.json").write_text(json.dumps({"pid": 9, "start": "h9"}))
+        recs = [{"type": "assistant", "n": 0},
+                {"type": "result", "subtype": "success", "total_cost_usd": 8.0, "n": 1},    # pre-clear, folded by the dead kernel
+                {"type": "system", "subtype": "init", "n": 2},                               # the /clear's init flip
+                {"type": "result", "subtype": "success", "total_cost_usd": 0.0, "n": 3},    # the /clear's own zero-cost result
+                {"type": "result", "subtype": "success", "total_cost_usd": 5.0, "n": 4}]    # post-clear, folded (costState 5.0), unacked
+        with open(hdir / "journal-0.jsonl", "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + chr(10))
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True,
+                                         "hostAck": {"host": "9:h9", "cli": "4242:s1", "offset": 1}})   # acked through the pre-clear result
+        self.be._update_reg(SID, costState={"total": 5.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session()
+        classes = (_AssistantMessage, _ResultMessage, type("S", (), {}))
+        def to_msg(rec):
+            if rec.get("type") == "result":
+                r = _ResultMessage(); r.total_cost_usd = rec.get("total_cost_usd"); r.model_usage = {}; r.usage = {}; r.session_id = "e2"
+                return r
+            return object()
+        class Client:
+            """The SDK client's shape as the orphan road uses it: connects the transport (which makes the reader's queue),
+            then hands every record the reader yields to the drain; the initialize is marked answered so the reader
+            ends without its bounded wait for an answer this stub never asks for."""
+            def __init__(self, options=None, transport=None): self.transport = transport
+            async def __aenter__(self):
+                await self.transport.connect()
+                self.transport._init_answered = True
+                return self
+            async def __aexit__(self, *a): return False
+            async def receive_messages(self):
+                async for rec in self.transport.read_messages():
+                    yield to_msg(rec)
+        mod = types.ModuleType("claude_agent_sdk"); mod.ClaudeSDKClient = Client
+        async def go():
+            await self.be._host_orphan_recover(s, types.SimpleNamespace(), None, classes, died=False)
+        with mock.patch.dict(sys.modules, {"claude_agent_sdk": mod}):
+            asyncio.run(go())
+        self.assertEqual(self._day(), {}, "$0: the tail past the ack is a replay of what the dead kernel folded (the /clear's own result and the post-clear result)")
+        rows = self._turns()
+        self.assertEqual([(r.get("usd"), r.get("redelivered", False)) for r in rows], [(None, False), (0.0, True)],
+                         "the /clear's zero-cost result (no dollars folded, its tag consumed), then the post-clear result, replayed")
+        self.assertEqual(self._cost_state()["cli"], "4242:s1", "persisted under the dead CLI's identity")
+        self.assertIsNone(s._host, "the replay transport was the session's for the drain alone")
+        # the same road with hostAck naming ANOTHER host: the whole journal replays, and bills nothing
+        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+        hdir.mkdir(parents=True, exist_ok=True)
+        (hdir / "identity.json").write_text(json.dumps({"pid": 9, "start": "h9"}))
+        with open(hdir / "journal-0.jsonl", "w") as f:
+            for r in recs:
+                f.write(json.dumps(r) + chr(10))
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True, "hostAck": {"host": "1:other", "cli": "4242:s1", "offset": 3}})
+        self.be._update_reg(SID, costState={"total": 5.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s2 = self._session()
+        async def go2():
+            await self.be._host_orphan_recover(s2, types.SimpleNamespace(), None, classes, died=False)
+        with mock.patch.dict(sys.modules, {"claude_agent_sdk": mod}):
+            asyncio.run(go2())
+        self.assertEqual(self._day(), {}, "$0 for the whole-journal replay too (8.00 above the watermark is a replay all the same)")
+
+    def test_a_zero_cost_result_consumes_its_tag_so_later_results_read_their_own(self):
+        # round five's MEDIUM: popped only inside the total > 0 gate, a /clear's zero-cost result left its tag at the
+        # head and the first live result was read as the replay
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True, journal_next=10, tags=[{"offset": 9, "replay": True}, {"offset": 10, "replay": False}, {"offset": 11, "replay": False}])
+        z = _result(0.0, 0)                                   # the /clear's own result: nothing to fold, but a record with a tag
+        self._run(s, z)
+        self.assertEqual(len(s._host.result_tags), 2, "its tag is gone")
+        self._run(s, _result(520.0, 10))                      # live (offset 10): folded as its own delta, not as the replay
+        self.assertAlmostEqual(self._day()["usd"], 20.0)
+        self._run(s, _result(526.0, 10))                      # live (offset 11)
+        self.assertAlmostEqual(self._day()["usd"], 26.0)
+        self.assertEqual([(r.get("usd"), r.get("redelivered", False)) for r in self._turns()], [(None, False), (20.0, False), (6.0, False)],
+                         "the zero-cost result's own row (no dollars), then the two live ones, none read as a replay")
+        self.assertEqual(self._cost_state()["session"], "", "the epoch is stamped from live results (these doubles carry none)")
+
     def test_the_transport_tags_each_result_record_with_its_offset_as_it_reads_it(self):
         # the transport unit of the rule: the hello's journal.next bounds the replay; records the reader hands over are
         # tagged in _take before the yield; the last replayed record tagged at next - 1 is a replay even though the

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -199,6 +199,68 @@ class Rebill(unittest.TestCase):
         self.assertIn('cli = "%s:%s" % (lease.get("pid"), lease.get("start"))', src, "the lease names the dead CLI")
         self.assertIn('cli = str(ack.get("cli") or "")', src, "else hostAck, when it names this host")
 
+    def test_a_reconnect_that_skips_the_host_connect_seeds_fresh_the_flag_gone_with_the_transport(self):
+        # M1 of the review of this pull request: the connect calls _host_transport_for only with hosts on or a lease that
+        # applies, so a reconnect in the same thread after a rollback to hosts off (an effort or auth switch) never
+        # reached the clear there; the stale True made the seed wait for a watermark the kernel child never has, and
+        # the fresh child's first turn recorded nothing, then the watermark was written under an empty CLI identity.
+        # The connect's finally now drops the flag with the transport, and the seed trusts the flag only with the
+        # transport in hand: this is the state that finally leaves (host None, flag stale) fed to the seed
+        s = self._session()
+        s._host_is_attach = True
+        s._host = None
+        s._seed_spend_watermarks()
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (0.0, "fresh"), "no transport: a fresh kernel child")
+        self._run(s, _result(3.5, 100))
+        self.assertAlmostEqual(self._day()["usd"], 3.5, msg="the child's first turn is recorded in full")
+        self.assertEqual(self._cost_state()["cli"], "", "a kernel child's watermark names no CLI")
+        import inspect
+        src = inspect.getsource(sb)
+        i = src.index("self._host = None" + chr(10) + "                    self._host_intent = False" + chr(10))
+        self.assertIn("self._host_is_attach = False", src[i:i + 900], "the connect's finally drops the flag with the transport")
+        self.assertLess(src.index("self._host_is_attach = False", i), src.index("if self.ended or not self._reconnect:", i))
+        self.assertIn('if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:',
+                      inspect.getsource(sb.SdkSession._seed_spend_watermarks))
+
+    def test_a_redelivered_result_below_the_watermark_folds_nothing_and_the_watermarks_stay(self):
+        # M2: hostAck is written at most once a second while the watermark moves per result, so a kernel death leaves
+        # processed results past the acknowledged offset and the attach's replay hands them over again (the whole
+        # journal when the ack names another host); folded whole as a "counter reset" they were the lifetime as one turn
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
+        s = self._session(attach=True, hello_cli=("4242", "s1"))
+        self._run(s, _result(480.0, 89000))                 # redelivered: below the seeded 500
+        self.assertEqual(self._day(), {}, "a result the ledger already holds folds nothing")
+        self.assertEqual((s._last_cost_total, s._last_usage_totals["input_tokens"]), (500.0, 90000), "the watermarks did not move down")
+        self._run(s, _result(500.0, 90000))                 # redelivered: the very result the watermark came from
+        self.assertEqual(self._day(), {})
+        self._run(s, _result(512.5, 90400))                 # the first NEW result
+        self.assertAlmostEqual(self._day()["usd"], 12.5, msg="only the new spend: the true 12.5, not the lifetime's 512.5")
+        self.assertEqual(self._day()["tokIn"], 400)
+        self.assertEqual(self._cost_state()["total"], 512.5)
+        rows = self._turns()
+        self.assertEqual([r["usd"] for r in rows], [0.0, 0.0, 12.5])
+        self.assertEqual([r["cumulativeUsd"] for r in rows], [480.0, 500.0, 512.5], "each row still names the CLI's total it carried")
+        # a fresh process is NOT hosted: a total below the watermark there is still the counter reset it always was
+        s2 = self._session()
+        self._run(s2, _result(10.0, 10)); self._run(s2, _result(4.0, 10))
+        self.assertAlmostEqual(self._day()["usd"], 12.5 + 10.0 + 4.0)
+
+    def test_a_replayed_tail_with_no_result_leaves_the_spawn_to_seed_fresh_and_an_init_in_the_tail_never_clobbers_the_dead_seed(self):
+        # low b: a dead host's tail with no result record folds nothing and the connect's seed for the spawn that follows
+        # starts at zero; low a: the init record's cwd re-seed is for a resumed FRESH process only
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {}, "cli": "4242:s1", "t": 1})
+        s = self._session()
+        s._seed_for_dead_cli("4242:s1")
+        self.assertEqual(s._spend_baseline, "seeded")
+        s._seed_spend_watermarks()                          # nothing replayed; the spawn's seed
+        self.assertEqual((s._last_cost_total, s._spend_baseline), (0.0, "fresh"))
+        self.assertEqual(self._day(), {})
+        import inspect
+        src = inspect.getsource(sb)
+        want = ("if loaded_sid and getattr(self, \"_spend_first_result\", False) " + chr(92) + chr(10)
+                + "                        and getattr(self, \"_spend_baseline\", \"fresh\") == \"fresh\":")
+        self.assertIn(want, src, "the init's cwd re-seed runs for a fresh baseline only, never over a registry or dead-CLI seed")
+
     def test_the_seed_and_the_result_are_pinned_to_the_registry_road(self):
         import inspect
         seed = inspect.getsource(sb.SdkSession._seed_spend_watermarks)
@@ -206,7 +268,7 @@ class Rebill(unittest.TestCase):
         self.assertIn("self._last_cost_total = 0.0   # a fresh CLI process starts its cumulative cost at zero", seed, "the fresh seed is unchanged")
         on = inspect.getsource(sb.SdkSession._on_message)
         self.assertIn("self._seed_from_reg_cost_state()", on)
-        self.assertIn("self._persist_cost_state(total)", on, "the watermark is written at every result")
+        self.assertIn("self._persist_cost_state(self._last_cost_total)", on, "the watermark is written at every result (the kept watermark, not a duplicate's lower total)")
         self.assertIn('costState={"total": float(total), "tokens": dict(self._last_usage_totals),', inspect.getsource(sb.SdkSession._persist_cost_state))
 
 


### PR DESCRIPTION
The spend ledger re-billed every hosted session's whole CLI-lifetime cost at every kernel restart (T354, urgent; the kernel half of the fix, split out of pull request 1443 so it lands first; the repair tool follows in 1443).

**What happened.** A session under a per-session host keeps its CLI process across a kernel restart, and the CLI's `total_cost_usd` is cumulative per process. The connect-time seed reset the kernel's watermark to zero for what it took for a fresh process, so the first result after each restart recorded the process lifetime as one turn. On 2026-09-11, with hosts on from the morning and 21 restarts, one session's turn rows read $436, $493, $593 ... $953, each the first result after a restart; the day's ledger summed to about $26,900 against a true figure near $7,500.

**The fix.** Every result persists the session's cost watermark on its registry row: `costState` with the cumulative total, the token watermarks and the CLI's identity (pid and start time from the host's hello; empty for a plain kernel child, which dies with the kernel). A host attach defers its seed to the first result, when the hello has named the surviving CLI, and seeds from the registry when the watermark names that same process, so the first result records only its own turn (dollars and tokens). A surviving process with no matching watermark on record (a kernel before this fix wrote none) records nothing for that first result, since its total is the lifetime's and the turn's share is unknowable; the kernel log says so and the watermark is set from there. A fresh process still seeds zero and records its whole first total. The first-result trace names which process it saw. Each `turns.jsonl` row carries `cumulativeUsd` (the CLI's own total at that result) and a first result's `spendBaseline` (`fresh`, `seeded`, `attach-unknown`), so the staircase is readable from the ledger itself from now on.

**Two more roads from the review of the first head.** The attach flag is set on the attach road alone and cleared at the top of the host connect, so a flag left by an earlier attach no longer makes the hosts-off road (a rollback) wait for a watermark a kernel child never has: the fresh child's first turn is recorded in full. The replay of a dead host's journal tail drains that CLI's result rows through the same result branch before the connect's seed runs, so the replay now seeds first, from the registry's watermark when it names the dead CLI (its pid and start time from the lease, else from `hostAck` when that names the host), and otherwise folds nothing for the first replayed result.

**Tests.** `tests/test_spend_rebill.py`: a fresh process seeds zero, records its whole first total and persists the watermark; an attach to the surviving CLI seeds from the registry and records one turn's delta in dollars and tokens; an attach with no matching watermark, or another CLI's, records nothing for the first result and its own delta for the next; the first-result trace names the process; the hosts-off road clears the attach flag and the fresh child's first turn is recorded (with the connect's source order pinned); a dead host's replay seeds from the dead CLI's watermark before it drains, records nothing when none matches, and the orphan road's source order is pinned. The host-transport suite's session stand-ins carry the seed as a no-op. Documented in `docs/reference.md` under its own heading before Restart metrics.

**Round two of the review.** The attach flag now lives one connect: the connect loop's `finally` drops it with the transport, and the seed trusts it only with the host transport in hand, so a reconnect in the same thread that never enters the host connect (hosts off with no lease and no host directory, an effort or auth switch after a rollback) seeds fresh and records the child's first turn in full instead of nothing, once per connect. A redelivered result is a duplicate, never a reset: `hostAck` is written at most once a second while the watermark moves per result, so a kernel death leaves processed results past the acknowledged offset and the attach's replay hands them over again (the whole journal when the ack names another host); one process's total is monotone apart from a `/clear` the kernel zeroes by event, so under a host a total below the watermark folds nothing and moves neither the dollar nor the token watermarks down, where before the "counter reset" road folded the process's lifetime as one turn. The init record's cwd re-seed runs for a fresh baseline only, so an init inside a replayed tail never clobbers the dead-CLI seed. Tests: the reconnect state the finally leaves (host None, flag stale) fed to the seed records the first turn, with the finally's and the seed's source pinned; two redelivered results fold nothing and leave the watermarks, the first new result records its own delta, and a fresh process's counter reset still folds whole; a replayed tail with no result leaves the spawn to seed fresh; the orphan road's hostack test records the seed's CLI identity as the road runs (the ack's CLI only when the ack is this host's).

**Round three of the review.** Redelivery is decided from the journal position the host transport tracks, never from the total: the transport advances its acknowledged offset as it hands each record over, so the offset it holds while a result is handled is that record's own; the host's hello names the journal's next offset at the attach, so records before it are the replay, and an orphan journal's reader replays only. A replay at or below the offset acknowledged when the transport was made (kept as `attach_ack`), or at or below the watermark, is one the ledger already holds and folds nothing, its turn row saying `redelivered`; a replay above the watermark is spend the dead kernel never folded and records its delta. A live total below the watermark is a counter reset and folds whole, as before, so a `/clear` the kernel did not see, a `/clear` as the first turn after an attach, and a resumed cost-state seed against a print-mode CLI each fold 3 then 5, never 0 and 0 (the previous head read every real reset as a duplicate and latched the session at $0). A `/clear` as the first turn after an attach also retires the pending registry seed, so the zeroed counter stands. Tests: the position rule (replays below and at the watermark fold nothing, one above it folds its delta, a live record folds its delta; the rows carry the flag), a replay at or below the attach ack whatever its total, the three live-reset roads and the orphan reader's replay.

**Round four of the review.** The position is now exact and decides replays alone. The transport tags each result record with its own journal offset as it reads it (before the hand-over, so a buffered consumer that runs a record ahead still reads the right one), one tag per result in order; the fold pops one tag per result it handles. A record before the offset the host's hello named as its next is a replay: it folds nothing, moves no watermark and its turn row says `redelivered`, whatever its total, since the kernel that died folded what it saw and the ack it left lags by at most a second. A live record folds its plain delta, and a live total below the watermark folds whole as a counter reset. The attach-ack clause is gone (no result record ever arrives at or below it). A replay across a mid-life `/clear` therefore bills nothing where the total rule billed $8. An orphan journal's replay keeps the dead CLI's watermark as its line (at or below it was folded, above it was not) and persists the watermark under the dead CLI's identity. `costState` also carries the CLI's session id, the `/clear` epoch, beside the watermark, and each turn row carries `journalOffset`. Tests: the tags popped in order with every replay queued ahead of the first handled result (the lookahead), replays below, at and above the watermark all folding nothing and the live records their deltas, rows flagged and stamped; the mid-life `/clear` replay billing $0; the transport's tagging unit (one tag per result record, the assistant record untagged, the orphan reader tagging every record a replay, the hello setting the window); the orphan replay's identity. The fake-host socket harness was not driven for this; the transport unit and the fold are tested at their seam, said plainly.

**Round five of the review.** The replay reader is the session's transport for the orphan drain, so the fold reads its tags and a dead host's tail past the acknowledged offset bills nothing it already folded (before, the session's transport was None there, every replayed result read as live, and a tail across a `/clear` re-billed the dead CLI's spend). The tag is popped at the top of the message handler for every result record, before any gate, so a zero-cost result (a `/clear`'s own), a turn-less result the move settle consumes, or a handler failure can no longer leave its tag at the head for the next result to read. The CLI's session id is stamped on the watermark from live results only. Tests: the real orphan road driven through `_host_orphan_recover` with a stub SDK client that connects the real replay transport and hands its records over, across a `/clear` with the acknowledged offset two results behind (the tail bills $0, the row says redelivered, the watermark persists under the dead CLI, the session's transport is restored) and for a whole-journal replay under an ack naming another host ($0); a zero-cost result consuming its tag so the next live results fold their own deltas.

The repair of the live ledger and its tool are pull request 1443, rebased to this head once it lands.

Tier: fix
