### PR TITLE
The focused section's copies: Tab keeps the copy, Clear from a copy exits the board's header, a pill repaints both (T347 follow-up)

### DIFF
--- a/tests/test_chat_delta_resync.py
+++ b/tests/test_chat_delta_resync.py
@@ -236,6 +236,6 @@ def test_ready_branch_is_wired_to_the_reset():
     src = inspect.getsource(km)
     i = src.find('msg.get("type") == "ready"')
     assert i > 0
-    body = src[i:i + 1600]
+    body = src[i:i + 2400]   # the arm grew past 1600 on 2026-09-11 (the focused-session send, the connect-time reads landing together)
     assert "_client_reset_chat_base(client)" in body, "ready must reset BEFORE its push"
     assert body.find("_client_reset_chat_base(client)") < body.find("_push_one(client)")

--- a/tests/test_feed_focus_served.py
+++ b/tests/test_feed_focus_served.py
@@ -209,10 +209,20 @@ const restored = await survey();
 // (h) Clear on the SECTION's copy clears the card: both elements dismiss and leave together; Undo brings both back
 // (the review of T347: the copy ran the board builder's finish, which guarded on the board's element, so the copy
 // stayed and the card below never left)
-const keyState = () => page.evaluate((k) => {
+const keyState = () => page.evaluate(([k, sid]) => {
   const f = document.querySelector(`#feed-focus [data-key="f:a:${k}"]`), a = document.querySelector(`#feed-cols [data-key="a:${k}"]`);
-  return { copy: !!f, board: !!a, copyDismissing: !!(f && f.classList.contains("dismissing")), boardDismissing: !!(a && a.classList.contains("dismissing")) };
-}, cfg.webDone);
+  // the board's run header for this session in the column the card leaves (Completed): a Clear from the copy must
+  // start its one-motion exit as a Clear on the card below does (the follow-up after the review)
+  const head = document.querySelector(`#feed-cols .col-completed .feed-sess-head[data-fsid="${sid}"]`);
+  return { copy: !!f, board: !!a, copyDismissing: !!(f && f.classList.contains("dismissing")), boardDismissing: !!(a && a.classList.contains("dismissing")),
+           headExiting: !!(head && head.classList.contains("sess-exit")) };
+}, [cfg.webDone, cfg.web]);
+// (i) Tab from a HOVERED copy lands inside the copy, where the pointer is, not on the board's twin below
+await page.hover(`#feed-focus [data-key="f:a:${cfg.webWorking}"]`);
+await page.keyboard.press("Tab");
+const tabbed = await page.evaluate(() => { const ae = document.activeElement; return { inCopy: !!(ae && ae.closest("#feed-focus")), inBoard: !!(ae && ae.closest("#feed-cols")), tag: ae ? ae.tagName : null }; });
+await page.keyboard.press("Escape");
+await park();
 await page.locator(`#feed-focus [data-key="f:a:${cfg.webDone}"] .fdismiss`, { hasText: /^Clear$/ }).click();   // the card's Clear (its Continue wears the same chrome)
 const clearing = await keyState();                    // right after the click: both copies wear .dismissing
 await page.waitForTimeout(300);                       // the 180 ms finish, with room
@@ -223,7 +233,7 @@ await page.waitForSelector(`#feed-cols [data-key="a:${cfg.webDone}"]`, { timeout
 await frame();
 const undone = await keyState();
 fs.writeSync(1, "RESULT:" + JSON.stringify({ off, offFocused, rowsBefore, on, rowsAfter, dark, light: lit, api, none, bare,
-                                              storedBefore, reloaded, restored, clearing, cleared, undone, errors }) + "\n");
+                                              storedBefore, reloaded, restored, tabbed, clearing, cleared, undone, errors }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -382,6 +392,9 @@ class ServedFocusedSessionSection(unittest.TestCase):
         cg, cd, un = r["clearing"], r["cleared"], r["undone"]
         self.assertEqual((cg["copy"], cg["board"], cg["copyDismissing"], cg["boardDismissing"]), (True, True, True, True),
                          "right after the click both copies wear .dismissing: %r" % cg)
+        self.assertTrue(cg["headExiting"], "the board run's header (web's only Completed card) starts its one-motion exit from a Clear on the copy: %r" % cg)
+        tb = r["tabbed"]
+        self.assertEqual((tb["inCopy"], tb["inBoard"]), (True, False), "Tab from a hovered copy lands inside the copy, where the pointer is: %r" % tb)
         self.assertEqual((cd["copy"], cd["board"]), (False, False), "after the finish neither element remains: %r" % cd)
         self.assertEqual((un["copy"], un["board"], un["copyDismissing"], un["boardDismissing"]), (True, True, False, False),
                          "Undo restores the card below and its copy above, neither still dismissing: %r" % un)

--- a/ui/webview/chat-delta-resync.test.ts
+++ b/ui/webview/chat-delta-resync.test.ts
@@ -104,7 +104,9 @@ test("a reconnect clears parked asks — a dead socket's pending needFull can ne
 test("the kernel's ready branch resets the client's WHOLE chat base before its push", () => {
   const i = KERNEL.indexOf('msg.get("type") == "ready"');
   assert.ok(i > 0);
-  const body = KERNEL.slice(i, i + 1600);
+  // the arm's window: it grew with the focused-session send (T347) and the metrics team's connect-time reads
+  // landing together on 2026-09-11, past the 1600 characters this read; the connect push sits near 1700 now
+  const body = KERNEL.slice(i, i + 2400);
   assert.ok(body.includes("_client_reset_chat_base(client)"), "ready = the renderer holds nothing");
   assert.ok(body.indexOf("_client_reset_chat_base(client)") < body.indexOf("_push_one(client)"),
     "…reset first, so the push that follows is full frames");

--- a/ui/webview/feed-clear-hover.test.ts
+++ b/ui/webview/feed-clear-hover.test.ts
@@ -12,7 +12,7 @@ const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", 
 
 test("the ask card's Clear flushes the hover highlight, right before the header conjunction + pendingCleared", () => {
   // the one-motion header exit (2026-08-24) rides between the flush and the suppression — same click
-  assert.match(FEED, /card\.dispatchEvent\(new MouseEvent\("mouseleave"\)\);\s*\n\s*dressHeaderIfLast\(card, it\.sid\);[^\n]*\n\s*pendingCleared\.add\(it\.itemId\);/);
+  assert.match(FEED, /card\.dispatchEvent\(new MouseEvent\("mouseleave"\)\);\s*\n\s*dressHeaderIfLast\(askEls\.get\(it\.itemId\) \?\? card, it\.sid\);[^\n]*\n\s*pendingCleared\.add\(it\.itemId\);/);
 });
 
 test("the group card's Clear flushes the hover highlight too", () => {

--- a/ui/webview/feed-focus-section.test.ts
+++ b/ui/webview/feed-focus-section.test.ts
@@ -146,6 +146,18 @@ test("cross-pane hover and reveal reach the copies: card-key strips the section'
   assert.match(FEED, /if \(key\.startsWith\("f:"\)\) key = key\.slice\(2\);/, "kbHoverId strips it the same way");
 });
 
+test("the three follow-ups after the review: Tab keeps the copy, Clear from a copy dresses the board's header, a pill repaints both copies", () => {
+  // (a) the keyboard scope remembers which twin it holds and re-finds that one; Tab from a hovered copy lands in the copy
+  assert.match(FEED, /let tabScopeCopy = false;/);
+  assert.match(FEED, /tabScopeCopy = isFocusCopy\(card\);/, "set where the scope is taken");
+  assert.equal((FEED.match(/cardElByKey\(tabScopeKey, tabScopeCopy\)/g) || []).length, 3, "every reader of the scope re-finds the same twin (Tab, Enter, the render-tail restore)");
+  assert.match(FEED, /return document\.querySelector<HTMLElement>\('\[data-key="' \+ \(copy \? "f:" \+ k : k\) \+ '"\]'\);/);
+  // (b) Clear from the copy still gives the board run's header its one-motion exit (the section has no run headers)
+  assert.match(FEED, /dressHeaderIfLast\(askEls\.get\(it\.itemId\) \?\? card, it\.sid\);/);
+  // (c) a section pill picked on either copy repaints both: the disclosure is the card's
+  assert.match(FEED, /const twins = cardTwins\(id\);\s*\n\s*if \(twins\.length\) \{ for \(const c of twins\) applySections\(c as any, \(c as any\)\._it \?\? it, distillShown\); \}/);
+});
+
 // ── feed.css: the section's rules, through the variables ─────────────────────────────────────────────
 test("feed.css: #feed-focus, the head, the caption, the rule and the empty line exist, var() only", () => {
   assert.match(CSS, /#feed-focus \{ display: flex; flex-direction: column; gap: 8px; \}/);

--- a/ui/webview/feed-kbscope.test.ts
+++ b/ui/webview/feed-kbscope.test.ts
@@ -12,10 +12,12 @@ import * as path from "node:path";
 const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
 
 test("scope entry: the hovered card (clicks hover too), else the keyboard card cursor", () => {
-  assert.match(FEED, /if \(!card\) card = \(freezeKey \? cardElByKey\(freezeKey\) : null\) \|\| kbCardEl;/,
-    "hover truth (freezeKey rides the card's own mouseenter) first, the kb cursor as the keyboard-only path");
-  assert.match(FEED, /function cardElByKey\(key: string\): HTMLElement \| null/,
-    "keys resolve through the same data-key vocabulary the reconcile writes");
+  // the HOVERED element itself first (T347: the focused section's copy is a second element for the card, and
+  // Tab must land where the pointer is), then hover truth by key, then the kb cursor as the keyboard-only path
+  assert.match(FEED, /if \(!card\) card = document\.querySelector<HTMLElement>\("\.fitem:hover"\) \|\| \(freezeKey \? cardElByKey\(freezeKey\) : null\) \|\| kbCardEl;/,
+    "the pointer's element, then hover truth (freezeKey rides the card's own mouseenter), then the kb cursor");
+  assert.match(FEED, /function cardElByKey\(key: string, copy = false\): HTMLElement \| null/,
+    "keys resolve through the same data-key vocabulary the reconcile writes; `copy` picks the section's twin (T347)");
   // typing in an input OUTSIDE the card keeps its normal Tab
   assert.match(FEED, /if \(ae && \/\^\(INPUT\|TEXTAREA\|SELECT\)\$\/\.test\(ae\.tagName\) && !card\.contains\(ae\)\) return;/);
 });

--- a/ui/webview/feed-sess-exit.test.ts
+++ b/ui/webview/feed-sess-exit.test.ts
@@ -35,8 +35,9 @@ test("the exit un-keys FIRST, removes on the END EVENT, backstops, and honors re
 });
 
 test("the CONJUNCTION: the run's last card takes its header with it, at the same click", () => {
-  assert.match(FEED, /dressHeaderIfLast\(card, it\.sid\);/, "ask-card clears join the motion");
-  assert.match(FEED, /dressHeaderIfLast\(card, cur\.sid\);/, "group-card clears too — a group is one session's turn");
+  // the BOARD's element, when Clear came from the focused section's copy (T347): the section holds no run headers
+  assert.match(FEED, /dressHeaderIfLast\(askEls\.get\(it\.itemId\) \?\? card, it\.sid\);/, "ask-card clears join the motion, from either copy");
+  assert.match(FEED, /dressHeaderIfLast\(groupEls\.get\(cur\.turnId\) \?\? card, cur\.sid\);/, "group-card clears too — a group is one session's turn");
   const dh = FEED.slice(FEED.indexOf("function dressHeaderIfLast"), FEED.indexOf("function reconcileCol"));
   assert.ok(dh.includes("if (!feedPrefs().grouped) return;"), "grouped mode only — flat mode has no headers");
   assert.ok(dh.includes('if (!head || head.getAttribute("data-fsid") !== sid || head.classList.contains("sess-exit")) return;'),

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -1408,7 +1408,7 @@ function makeAskCard(it: AskItem): HTMLElement {
     // never fires and the timeline/chat highlight stuck until you moved the mouse (the user 2026-07-03). The
     // synthetic mouseleave runs the exact leave logic (clears the highlight, or restores a pinned card's).
     card.dispatchEvent(new MouseEvent("mouseleave"));
-    dressHeaderIfLast(card, it.sid);   // the run's last card takes its header with it — one motion (2026-08-24)
+    dressHeaderIfLast(askEls.get(it.itemId) ?? card, it.sid);   // the run's last card takes its header with it — one motion (2026-08-24); the BOARD's element when Clear came from the section's copy (T347)
     pendingCleared.add(it.itemId);   // suppress from incoming pushes until the kernel confirms the clear
     clearedStack.push([(card as any)._it ?? it]);   // cache the FRESHEST payload copy for an instant optimistic Undo (the closure's `it` is the card's creation-time object)
     // BY ITEM, not by this element (T347): the focused-session section holds a second element for the same
@@ -1670,7 +1670,11 @@ function applySections(a: any, it: AskItem, distillShown: boolean): void {
   const pick = (want: "bg" | "summary" | "subgoals" | "tasks" | "stall") => (ev: Event) => {
     ev.stopPropagation();
     secChoice.set(id, choice === want ? "none" : want);   // click the showing one → off; else switch to it
-    applySections(a, it, distillShown);
+    // both elements of the card (T347): the disclosure is the CARD's, so the board's element and the focused
+    // section's copy show the same section after a pick on either
+    const twins = cardTwins(id);
+    if (twins.length) { for (const c of twins) applySections(c as any, (c as any)._it ?? it, distillShown); }
+    else applySections(a, it, distillShown);
   };
   // Background toggle — visible only when there IS background; pressed (.on) when its body is showing
   a._bgBtn.style.display = bg ? "" : "none";
@@ -2695,7 +2699,7 @@ function makeGroupCard(g: AskGroup): HTMLElement {
     ev.stopPropagation();
     card.dispatchEvent(new MouseEvent("mouseleave"));   // flush the group's stuck hover highlight (see the ask card's clear)
     const cur = (card as any)._g as AskGroup;
-    dressHeaderIfLast(card, cur.sid);   // a group is one session's turn — same one-motion rule (2026-08-24)
+    dressHeaderIfLast(groupEls.get(cur.turnId) ?? card, cur.sid);   // a group is one session's turn — same one-motion rule (2026-08-24); the board's element from a copy (T347)
     for (const c of groupTwins(cur.turnId)) c.classList.add("dismissing");   // both copies of the group (T347), see the ask card's Clear
     clearedStack.push(cur.members.slice());   // cache the whole batch for an instant optimistic Undo
     for (const m of cur.members) pendingCleared.add(m.itemId);
@@ -5333,7 +5337,7 @@ function render() {
   // control's element, and a rebuild must not eat keyboard focus (click-safety, applied to the
   // keyboard). Find the control again by LOGICAL identity — class + label, then the old slot.
   if (tabScopeKey && tabScopeSig) {
-    const card = cardElByKey(tabScopeKey);
+    const card = cardElByKey(tabScopeKey, tabScopeCopy);
     const ae = document.activeElement;
     if (!card) releaseTabScope();
     else if (!ae || ae === document.body || !card.contains(ae)) {
@@ -5707,10 +5711,17 @@ function paintFreezeBadges(): void {
 // is inside, the card holds the payload gate hover-freeze uses, so the board cannot move the card
 // being keyed (same gate as the pointer).
 let tabScopeKey: string | null = null;
+let tabScopeCopy = false;   // the scope holds the focused section's copy, not the board's element (T347)
 let tabScopeSig: { sig: string; idx: number } | null = null;
-function cardElByKey(key: string): HTMLElement | null {
-  return document.querySelector<HTMLElement>('[data-key="' + (key.startsWith("g:") ? key : "a:" + key) + '"]');
+function cardElByKey(key: string, copy = false): HTMLElement | null {
+  // `copy`: the focused-session section's element for the card (T347), keyed one prefix over the board's;
+  // the keyboard scope re-finds the element it holds, never the other twin (a Tab from a hovered copy used to
+  // resolve to the board's card and scroll away from the pointer)
+  const k = key.startsWith("g:") ? key : "a:" + key;
+  return document.querySelector<HTMLElement>('[data-key="' + (copy ? "f:" + k : k) + '"]');
 }
+/** Is this card element the focused section's copy (T347)? Its key wears the section's prefix. */
+function isFocusCopy(card: HTMLElement | null): boolean { return !!card && (card.dataset.key || "").startsWith("f:"); }
 function cardControls(card: HTMLElement): HTMLElement[] {
   // the card's own DOM order IS its visual reading order — title row, pills, tail controls
   return Array.from(card.querySelectorAll<HTMLElement>(KB_EL_SEL)).filter((e) => e.offsetParent !== null);
@@ -5723,6 +5734,7 @@ function tabScopeFocus(card: HTMLElement, els: HTMLElement[], i: number): void {
   const el2 = els[i];
   if (!el2) return;
   tabScopeKey = kbHoverId(card);
+  tabScopeCopy = isFocusCopy(card);   // which twin the scope holds (T347)
   tabScopeSig = { sig: ctrlSig(el2), idx: i };
   if (el2.tabIndex < 0 && !el2.matches("button, a, input")) el2.tabIndex = -1;   // focusable, outside page order
   el2.classList.add("kbd-focus");
@@ -5731,6 +5743,7 @@ function tabScopeFocus(card: HTMLElement, els: HTMLElement[], i: number): void {
 function releaseTabScope(): void {
   if (!tabScopeKey) return;
   tabScopeKey = null;
+  tabScopeCopy = false;
   tabScopeSig = null;
   document.querySelectorAll(".kbd-focus").forEach((n) => n.classList.remove("kbd-focus"));
   const ae = document.activeElement as HTMLElement | null;
@@ -5745,8 +5758,10 @@ window.addEventListener("keydown", (e) => {
     return;
   }
   if (e.key === "Tab") {
-    let card = tabScopeKey ? cardElByKey(tabScopeKey) : null;
-    if (!card) card = (freezeKey ? cardElByKey(freezeKey) : null) || kbCardEl;   // hover/click, else the kb cursor
+    let card = tabScopeKey ? cardElByKey(tabScopeKey, tabScopeCopy) : null;
+    // the HOVERED element itself, copy or board (T347): the freeze key names the card, not which twin the
+    // pointer rests on, and Tab must land where the pointer is
+    if (!card) card = document.querySelector<HTMLElement>(".fitem:hover") || (freezeKey ? cardElByKey(freezeKey) : null) || kbCardEl;
     if (!card || !card.isConnected) return;
     const ae = document.activeElement as HTMLElement | null;
     if (ae && /^(INPUT|TEXTAREA|SELECT)$/.test(ae.tagName) && !card.contains(ae)) return;   // typing elsewhere
@@ -5771,7 +5786,7 @@ window.addEventListener("keydown", (e) => {
   }
   if ((e.key === "Enter" || e.key === " ") && tabScopeKey) {
     const ae = document.activeElement as HTMLElement | null;
-    const card = cardElByKey(tabScopeKey);
+    const card = cardElByKey(tabScopeKey, tabScopeCopy);
     if (!ae || !card || !card.contains(ae)) return;
     if (ae.matches("button, a, input")) return;   // native activation already fires the click
     e.preventDefault();


### PR DESCRIPTION
The three low items from the review of the focused-session section (#1425, T347). Tier `fix`.

- **Tab from a hovered copy** resolved the keyboard scope to the board's twin and scrolled away from the pointer. The scope now takes the hovered element itself and remembers which twin it holds, so Tab, Enter and the render-tail focus restore re-find the same element.
- **Clear from a copy** skipped the one-motion exit of the board run's header, because the section holds no run headers. The dress reads the board's element for the card.
- **A section pill picked on a copy** repainted that element alone; the twin kept the old disclosure until its next update. The pick repaints every element of the card.

Tests: source pins on the scope's flag and its three readers, the dress's board element and the twin repaint (`feed-focus-section.test.ts`); the keyboard-scope and header-exit pins follow the change; the served lab (`tests/test_feed_focus_served.py`) hovers a copy and presses Tab (focus lands inside the copy) and, on the Clear from the copy, sees the board run's header start its exit. Also here: two source pins that went red on main when the feature (#1425) and the metrics team's connect-time reads landed together, `ui/webview/chat-delta-resync.test.ts` and `tests/test_chat_delta_resync.py`, read the kernel's ready arm (reset before the connect push) within 1,600 characters; the arm's growth put the push near 1,700, so both windows read 2,400 now, the asserted order unchanged. The clear-hover pin follows the follow-up's dress.

Verified: typecheck, the pinned UI files (55 plus the three pin files), the Python twin of the ready-arm pin, the served lab in a real browser; the whole UI suite over this head, 4486 tests, 4481 pass, 5 skipped, no failures. No kernel or SDK file is touched.
