### PR TITLE
Postal cards: the tint's lightness is measured from the page, its tokens carry fallbacks, the cream's warm peers read stronger (T337c)

### DIFF
--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -101,9 +101,12 @@ KINDLESS = "Merged the fixtures branch; nothing else is pending on my side."
 # it must wear the same provisional dress as the slim parked card beside it (the box rule used to win its border and
 # background, and the bubble's 72% cap its width)
 LONG_PARKED = "Once the fixtures land, run the whole integration suite against notes-api and write every flaky case into the README."
+# a sent card that LANDED and folds (a body past the head's clip): boxed, read, and so the one landed boxed sent card, whose
+# ground must stay the plain box while the incoming cards wear the tint (T337c review, 2026-09-11)
+LONG_READ = "Review the schema change before the rest: it touches the export path, and the retry budget now sits in the README beside the jitter cap of two minutes."
 
 
-# The world: eleven cards, every kind and every state, among them one legacy card with no kind and one parked card with a
+# The world: twelve cards, every kind and every state, among them one legacy card with no kind and one parked card with a
 # fold. Bodies are invented notes-api chatter.
 def world(t0):
     msgs = {
@@ -118,6 +121,7 @@ def world(t0):
         "out-bounced": ("web", WEB, "delegate", "Take the cap decision and write it down in the README."),
         "out-recalled": ("web", WEB, "coordinate", "Ignore my last note, wrong thread."),
         "out-nokind": ("web", WEB, None, KINDLESS),
+        "out-long-read": ("web", WEB, "coordinate", LONG_READ),
     }
     log, recs = [], []
     t = t0
@@ -145,6 +149,8 @@ def world(t0):
         ("out-recalled", "tests", TESTS, "Delivered to 'tests'.", False,
          [lambda t: {"t": t + 40, "ev": "recall", "id": "out-recalled"}]),
         ("out-nokind", "api", API, "Delivered to 'api'.", False, []),   # a legacy send: no kind anywhere, an icon all the same
+        ("out-long-read", "api", API, "Delivered to 'api'.", False,
+         [lambda t: {"t": t + 20, "ev": "exec", "id": "out-long-read"}]),   # landed, read, and boxed by its fold
     ]
     for i, (mid, to_name, to_id, result, err, later) in enumerate(outs):
         t += 60
@@ -349,7 +355,7 @@ class ServedPostalCards(unittest.TestCase):
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
-        cls.count = 11
+        cls.count = 12
         cls.port, cls.token = _free_port(), "testtok-postal"
         env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
         cls.klog = os.path.join(cls.lab, "kernel.log")
@@ -388,7 +394,7 @@ class ServedPostalCards(unittest.TestCase):
         r = json.loads(line[len("RESULT:"):])
         wide, narrow, phone, light = r["1000"], r["520"], r["340"], r["light"]
         cards = wide["cards"]
-        self.assertEqual(len(cards), 11, cards)
+        self.assertEqual(len(cards), 12, cards)
         by = {c["gist"][:24]: c for c in cards}
         def card(prefix):
             m = [c for c in cards if c["gist"].startswith(prefix)]
@@ -477,12 +483,15 @@ class ServedPostalCards(unittest.TestCase):
         # the tint is the PEER's hue: two peers' incoming cards wear two grounds, in both themes, and a landed sent card none
         for m, name in ((wide, "dark"), (light, "light")):
             grounds = {}
+            landed_boxed = 0
             for c in m["cards"]:
                 if c["dir"] == "in":
                     self.assertNotEqual(c["bg"], m["boxBg"], "%s: the incoming card is tinted: %r" % (name, c))
                     grounds.setdefault(c["peerText"], set()).add(c["bg"])
                 elif c["boxed"] and not c["provisional"]:
+                    landed_boxed += 1
                     self.assertEqual(c["bg"], m["boxBg"], "%s: a landed boxed sent card keeps the plain box: %r" % (name, c))
+            self.assertGreaterEqual(landed_boxed, 1, "%s: the fixture holds a landed boxed sent card, so the branch above runs" % name)
             self.assertGreaterEqual(len(grounds), 2, "%s: two peers seen: %r" % (name, grounds))
             self.assertTrue(all(len(v) == 1 for v in grounds.values()), "%s: one ground per peer: %r" % (name, grounds))
             self.assertEqual(len({next(iter(v)) for v in grounds.values()}), len(grounds), "%s: each peer its own ground: %r" % (name, grounds))
@@ -514,7 +523,7 @@ class ServedPostalCards(unittest.TestCase):
         # (phone) under the 360 px container query the head WRAPS (T313): the two ends keep the first line; the kind word
         # and the icon stay on it when they fit and otherwise move to the next line as one unit; the gist comes last on its
         # own full-width line and breaks by words, never into a letter column — every card, slim, boxed and provisional
-        self.assertEqual(len(phone["cards"]), 11, phone["cards"])
+        self.assertEqual(len(phone["cards"]), 12, phone["cards"])
         for c in phone["cards"]:
             self.assertFalse(c["kindClipped"], "at 340 px the kind word is whole: %r" % c)
             self.assertEqual(c["headWrap"], "wrap", "the head wraps at phone width: %r" % c)

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -55,10 +55,10 @@ test("the kind is coloured text in the meta slot, never a chip, at prose weight,
 test("the incoming card wears the peer's hue at its ground's own lightness, in both themes; the sent card does not", () => {
   // the user 2026-09-11, who missed the tint T302 had removed the day before on their own side-by-side ruling. A hue at
   // the ground's lightness, not a mix: a mix lifts the ground and the dimmest kind word fell under the ramp's 4.5:1 floor
-  assert.match(CSS, /\.turn-postal-service\.postal-service-in \.notice:not\(\.notice-slim\) \{\n  background: oklch\(from var\(--notice-rail, var\(--box-bg\)\) var\(--postal-wash-l\) var\(--postal-wash-c\) h\); \}/,
-               "one declaration: the rail's hue (the peer's colour) at the ground's lightness and a gentle chroma");
+  assert.match(CSS, /\.turn-postal-service\.postal-service-in \.notice:not\(\.notice-slim\) \{\n  background: oklch\(from var\(--notice-rail, var\(--box-bg\)\) var\(--postal-wash-l, 0\.263\) var\(--postal-wash-c, 0\.03\) h\); \}/,
+               "one declaration: the rail's hue (the peer's colour) at the ground's lightness and a gentle chroma, each token with a fallback");
   assert.match(CSS, /\n  --postal-wash-l: 0\.263;  --postal-wash-c: 0\.03;/, "the dark ground's lightness and the chroma, beside the kind tokens");
-  assert.match(CSS, /\n  --postal-wash-l: 0\.919;/, "the light ground's lightness, in the light block");
+  assert.match(CSS, /\n  --postal-wash-l: 0\.919;  --postal-wash-c: 0\.045;/, "the light ground's lightness and a stronger chroma for the cream's warm hue, in the light block");
   assert.doesNotMatch(CSS, /theme-light[^{}]*postal-service-in[^{}]*\{[^}]*background/, "no theme takes it back");
   assert.doesNotMatch(CSS, /postal-service-out[^{}]*\{[^}]*oklch\(from var\(--notice-rail/, "the sent card is untinted");
   assert.match(fn("renderPostalService"), /rail: ev\.color \? ev\.color\.bg : undefined/, "the rail is the peer's colour, so the hue is the peer's");

--- a/ui/webview/postal-wash.test.ts
+++ b/ui/webview/postal-wash.test.ts
@@ -1,0 +1,39 @@
+// The incoming card's tint lightness is MEASURED from the page under it (postal-wash.ts, T337c): the pure parts here,
+// the sheet's fallback values checked against the measurement for the two shipped themes, and the hook pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { oklabLightness, groundOf, syncPostalWash } from "./postal-wash";
+
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+test("the shipped fallbacks are the measured grounds of the two themes", () => {
+  // dark: #1e1e1e under a 3% white box; light: the cream #F1EAE2 under a 3% black box (styles.css)
+  const dark = oklabLightness(groundOf([30, 30, 30, 1], [255, 255, 255, 0.03]));
+  const light = oklabLightness(groundOf([241, 234, 226, 1], [0, 0, 0, 0.03]));
+  assert.ok(Math.abs(dark - 0.263) < 0.002, "dark ground L " + dark.toFixed(3));
+  assert.ok(Math.abs(light - 0.919) < 0.002, "light ground L " + light.toFixed(3));
+  assert.match(CSS, /--postal-wash-l: 0\.263;/, "the dark fallback is the measurement");
+  assert.match(CSS, /--postal-wash-l: 0\.919;/, "the light fallback is the measurement");
+});
+
+test("a document that cannot draw leaves the token to the sheet", () => {
+  // a minimal document: no canvas context, so nothing is measured and no inline value is set
+  const removed: string[] = [];
+  const doc = {
+    body: { style: { removeProperty: (k: string) => removed.push(k), setProperty: () => { throw new Error("must not set"); } } },
+    createElement: () => ({ getContext: () => null }),
+    defaultView: { getComputedStyle: () => ({ getPropertyValue: (k: string) => (k === "--bg" ? "#1e1e1e" : "rgba(255,255,255,0.03)") }) },
+  } as unknown as Document;
+  assert.equal(syncPostalWash(doc), false);
+  assert.deepEqual(removed, ["--postal-wash-l"], "an unmeasurable page clears any stale inline value");
+});
+
+test("the chat installs the measurement at boot, and the sheet's rule reads the token with the shipped fallback", () => {
+  assert.match(RENDER, /import \{ installPostalWash \} from "\.\/postal-wash";/);
+  assert.match(RENDER, /installPostalWash\(document\);/);
+  assert.match(CSS, /background: oklch\(from var\(--notice-rail, var\(--box-bg\)\) var\(--postal-wash-l, 0\.263\) var\(--postal-wash-c, 0\.03\) h\); \}/,
+               "the rule falls back to the dark values when a token is missing, so the card never loses its background");
+});

--- a/ui/webview/postal-wash.ts
+++ b/ui/webview/postal-wash.ts
@@ -1,0 +1,76 @@
+// The incoming postal card's tint: the peer's hue at the card ground's OWN lightness (styles.css, T337b). The
+// lightness token, --postal-wash-l, ships with the two themes' values as fallbacks, but the page under the card is
+// host-derived in the VS Code webview (--bg reads --vscode-editor-background), so a dark host theme other than the
+// default would leave the tint lighter or darker than its ground. This module MEASURES the ground: the page colour
+// and the box overlay, resolved through a one-pixel canvas (the one way to turn any CSS colour into channels), composited,
+// converted to OKLab lightness, and written on the body as the token's inline value, which outranks every theme block.
+// It runs at boot and again whenever the body's classes or the root's inline style change (a theme toggle, a host
+// theme change: VS Code rewrites the root's custom properties). A page where the canvas cannot resolve a colour (a
+// test document without a canvas) leaves the token to the sheet's fallback (T337c, the review of 2026-09-11).
+
+export type RGBA = [number, number, number, number];
+
+function lin(c: number): number { return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); }
+
+/** OKLab lightness of an opaque sRGB colour (channels 0..255). */
+export function oklabLightness(rgb: [number, number, number]): number {
+  const [r, g, b] = rgb.map((v) => lin(v / 255));
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+  return 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s;
+}
+
+/** The card ground: the (opaque) page with the box overlay composited over it. */
+export function groundOf(page: RGBA, box: RGBA): [number, number, number] {
+  const a = box[3];
+  return [0, 1, 2].map((i) => page[i] * (1 - a) + box[i] * a) as [number, number, number];
+}
+
+/** Any CSS colour as channels, through a one-pixel canvas; null when the document cannot draw (no canvas, an unparsable value). */
+export function resolveColour(doc: Document, css: string): RGBA | null {
+  const v = (css || "").trim();
+  if (!v) return null;
+  try {
+    const cv = doc.createElement("canvas"); cv.width = 1; cv.height = 1;
+    const ctx = cv.getContext("2d");
+    if (!ctx) return null;
+    ctx.clearRect(0, 0, 1, 1);
+    ctx.fillStyle = "#000000";                     // a value the canvas refuses leaves the previous fill: make it detectable
+    ctx.fillStyle = v;
+    if (ctx.fillStyle === "#000000" && !/^(#000000|#000|black|rgb\(0,\s*0,\s*0\)|rgba\(0,\s*0,\s*0,\s*1\))$/i.test(v)) return null;
+    ctx.fillRect(0, 0, 1, 1);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return [d[0], d[1], d[2], d[3] / 255];
+  } catch {
+    return null;
+  }
+}
+
+/** Measure the ground under an incoming card and write its lightness on the body; false when nothing could be measured. */
+export function syncPostalWash(doc: Document): boolean {
+  const cs = doc.defaultView ? doc.defaultView.getComputedStyle(doc.body) : null;
+  if (!cs) return false;
+  const page = resolveColour(doc, cs.getPropertyValue("--bg"));
+  const box = resolveColour(doc, cs.getPropertyValue("--box-bg"));
+  if (!page || page[3] < 1) { doc.body.style.removeProperty("--postal-wash-l"); return false; }
+  const L = oklabLightness(groundOf(page, box || [0, 0, 0, 0]));
+  doc.body.style.setProperty("--postal-wash-l", L.toFixed(3));
+  return true;
+}
+
+/** Sync now and on every theme or host change (the body's classes, the root's inline style). */
+export function installPostalWash(doc: Document): void {
+  syncPostalWash(doc);
+  if (typeof MutationObserver === "undefined") return;
+  if (doc.body.dataset.postalWash === "1") return;   // idempotent: a second call (a theme applied again) re-measured above
+  doc.body.dataset.postalWash = "1";
+  let queued = false;
+  const later = () => {
+    if (queued) return;
+    queued = true;
+    (doc.defaultView || window).requestAnimationFrame(() => { queued = false; syncPostalWash(doc); });
+  };
+  new MutationObserver(later).observe(doc.body, { attributes: true, attributeFilter: ["class"] });
+  new MutationObserver(later).observe(doc.documentElement, { attributes: true, attributeFilter: ["style", "class"] });
+}

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -18,6 +18,7 @@ import { CMT_POP_SIZE_KEY, CMT_POP_THREAD_DEFAULT, parseCmtPopSize, clampCmtPopP
          centerCmtPop, cmtPopCapPx } from "./comment-pop-size";
 import { ctxFallbackColor, pickTone, readableRgb } from "./ctx-color";
 import { applyTheme } from "./theme";
+import { installPostalWash } from "./postal-wash";   // the incoming postal card's tint lightness, measured from the page (T337c)
 import { applyDenseChrome } from "./dense-chrome";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore } from "./chat-window";   // the uuid-anchored wire (T323 stage 4b)
@@ -18419,6 +18420,7 @@ function applyChatScheme(s: RompSettings): void {
   // the overall theme (T113 promoted 2026-08-28): the shared applier toggles the strip-aesthetic
   // and light-theme classes from s.theme. Applies live — onExternalSettingsChange re-runs this.
   applyTheme(document, s);
+  installPostalWash(document);   // once: the observers; every later call re-measures the ground (a theme just applied)
   // compact tabs and agents (the user 2026-09-08): a body class the strip's and the #bg-tasks panel's dense
   // rules key on (styles.css body.dense-chrome). The same two moments as the scheme and the theme, so the
   // gear's flip repaints both surfaces at once through the cascade; neither is rebuilt.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -108,7 +108,10 @@ body.scheme-solarized-dark {
      all three grounds. */
   --postal-coordinate: #5696c8;  --postal-delegate: #7cb5e3;  --postal-question: #a2d4fe;
   --postal-wash-l: 0.263;  --postal-wash-c: 0.03;   /* the incoming card's tint: the peer's hue at the box ground's own
-                                                       OKLab lightness (the page under the 3% box), a gentle chroma (T337b) */
+                                                       OKLab lightness (the page under the 3% box), a gentle chroma (T337b).
+                                                       The lightness here is the shipped theme's FALLBACK: the chat measures
+                                                       the real ground at run time and writes the token on the body
+                                                       (postal-wash.ts), since --bg is host-derived in the webview (T337c) */
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
@@ -253,7 +256,9 @@ body.theme-light {
      L .30, C .098 (the hue's gamut edge there; a deep rust that stays red, short of the prose ink --fg at L .236: 0.118 from it in OKLab); 5.3:1, 8.1:1 and 11.8:1
      on the cream page, 4.9:1, 7.6:1 and 11.1:1 on a boxed card, 4.8:1, 7.3:1 and 10.7:1 on the provisional wash */
   --postal-coordinate: #974a32;  --postal-delegate: #752f18;  --postal-question: #551400;
-  --postal-wash-l: 0.919;  --postal-wash-c: 0.03;   /* the cream under the 3% box; the same gentle chroma (T337b) */
+  --postal-wash-l: 0.919;  --postal-wash-c: 0.045;  /* the cream under the 3% box; a stronger chroma: the cream's own hue
+                                                       (71) sits near a warm peer's, and at .03 that tint read at less than half
+                                                       a cool one's distance from the ground (T337c, the review of 2026-09-11) */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
   --accent-wash: rgba(194, 65, 12, 0.10);
@@ -2550,11 +2555,15 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    tint had gone and ruled it back. Not the old mix, on purpose: a mix LIFTS a dark ground toward a light peer's colour
    (and darkens a light one toward a dark peer's), and the dimmest kind word then read under the 4.5:1 floor the kind
    ramp holds on its ground (T320: 4.38:1 on a green peer's mix), while the ramp's own two floors (postal-kind-ramp.test.ts)
-   leave its deep end no room to move; a hue at the ground's own lightness changes no word's contrast for any peer. One
-   declaration, so a further ruling is one line either way. The sent card keeps its slim line and the provisional dress,
-   untinted. */
+   leave its deep end no room to move; on a hue at the ground's own lightness every kind word stays above 4.5:1 for every
+   hue, measured (the worst, the dark coordination word, 4.75:1; OKLab lightness is not WCAG luminance, so the ratio moves
+   by up to a third of a point across the hues). One declaration, so a further ruling is one line either way. The sent
+   card keeps its slim line and the provisional dress, untinted. The tokens carry fallbacks: `background` is a shorthand,
+   and a missing token would have made the declaration invalid at computed-value time and the card lose its ground.
+   oklch(from ...) needs Chromium 119 (VS Code from Electron 28): an older host drops the declaration at parse time and
+   the plain box shows, never a transparent card (T337c). */
 .turn-postal-service.postal-service-in .notice:not(.notice-slim) {
-  background: oklch(from var(--notice-rail, var(--box-bg)) var(--postal-wash-l) var(--postal-wash-c) h); }
+  background: oklch(from var(--notice-rail, var(--box-bg)) var(--postal-wash-l, 0.263) var(--postal-wash-c, 0.03) h); }
 /* the postal meta never shrinks, and it GROWS to the head's right edge: it holds the kind word and, after it, the
    delivery icon (margin-left auto inside it), so the icon sits at the edge as before and, when a phone-width head
    wraps, the kind word and the icon move to the next line as ONE unit (T313) */

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -43,6 +43,16 @@ function lum(rgb: [number, number, number]): number {
   const ch = (c: number) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
   return 0.2126 * ch(rgb[0]) + 0.7152 * ch(rgb[1]) + 0.0722 * ch(rgb[2]);
 }
+/** OKLCH (L 0..1, C, hue in degrees) to sRGB channels 0..255, clamped to the gamut: the tinted ground of an incoming card. */
+function oklchToRgb(L: number, C: number, hDeg: number): [number, number, number] {
+  const h = (hDeg * Math.PI) / 180, a = C * Math.cos(h), b = C * Math.sin(h);
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b, m_ = L - 0.1055613458 * a - 0.0638541728 * b, s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+  const l = l_ ** 3, m = m_ ** 3, s = s_ ** 3;
+  const lin = [4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s, -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+               -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s];
+  return lin.map((c) => { c = Math.max(0, Math.min(1, c)); const v = c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055; return Math.round(v * 255); }) as [number, number, number];
+}
+
 function contrast(a: [number, number, number], b: [number, number, number]): number {
   const [hi, lo] = [lum(a), lum(b)].sort((x, y) => y - x);
   return (hi + 0.05) / (lo + 0.05);
@@ -133,6 +143,23 @@ for (const sheet of ["styles.css", "feed.css"]) {
         for (const tok of ["--postal-coordinate", "--postal-delegate", "--postal-question"]) {
           const fore = rgbOf(theme.get(tok)!, wash)!;
           assert.ok(contrast(fore, wash) >= 4.5, `${sheet} ${name}: ${tok} on the provisional wash = ${contrast(fore, wash).toFixed(2)} < 4.5`);
+        }
+      }
+      // T337c: the INCOMING card no longer wears --box-bg but the peer's hue at the ground's lightness (styles.css: an oklch
+      // relative colour from the rail, the tokens --postal-wash-l and --postal-wash-c), a different ground for every peer;
+      // each kind word reads at 4.5:1 there for EVERY hue (the sent boxed card still wears --box-bg: those pairs stand)
+      if (sheet === "styles.css") {
+        const L = parseFloat(theme.get("--postal-wash-l")!), C = parseFloat(theme.get("--postal-wash-c")!);
+        assert.ok(L > 0 && L < 1 && C > 0, `${sheet} ${name}: the wash tokens parse (${L}, ${C})`);
+        for (const tok of ["--postal-coordinate", "--postal-delegate", "--postal-question"]) {
+          let worst = Infinity, worstHue = -1;
+          for (let h = 0; h < 360; h++) {
+            const ground = oklchToRgb(L, C, h);
+            const fore = rgbOf(theme.get(tok)!, ground)!;
+            const c = contrast(fore, ground);
+            if (c < worst) { worst = c; worstHue = h; }
+          }
+          assert.ok(worst >= 4.5, `${sheet} ${name}: ${tok} on the tinted ground = ${worst.toFixed(2)} at hue ${worstHue} < 4.5`);
         }
       }
       assert.ok(evaluated >= expected,


### PR DESCRIPTION
## What

The six low items from the review of the tint's return, none blocking: the incoming mail card's tint now measures its lightness from the page under it, its tokens carry fallbacks, a warm peer's tint on the cream reads stronger, and every kind word is pinned above 4.5:1 on the tinted ground for all 360 hues.

## Design

- **The lightness tracks the host page.** `ui/webview/postal-wash.ts` measures the ground under an incoming card: the page colour and the box overlay, resolved through a one-pixel canvas, composited, converted to OKLab lightness, and written on the body as the token's inline value, at boot and whenever the body's classes or the root's inline style change (a theme toggle, a host theme change, which rewrites the root's custom properties). The two shipped themes' values stay in the sheet as fallbacks, and a page that cannot be measured leaves them standing. Before this the dark value was fixed while the page is host-derived in the VS Code webview, so a dark host theme other than the default would have left the tint lighter or darker than its ground.
- **Fallbacks on the tokens.** `background` is a shorthand: a missing token would have made the declaration invalid at computed-value time and the card would have lost its ground. Each token now falls back to the dark theme's value.
- **The cream's warm peers.** The cream's own hue sits near a warm peer's, so at a chroma of .03 a warm tint read at less than half a cool one's distance from the ground. The light theme's chroma rises to .045; every hue still clears 4.5:1, the worst at 4.84.
- **What is claimed.** The sheet's comment now says what was measured: every kind word stays above 4.5:1 for every hue (the worst, the dark coordination word, 4.75:1), rather than that a hue swap changes no word's contrast, since OKLab lightness is not WCAG luminance and the ratio moves by up to a third of a point across the hues. It also notes that `oklch(from ...)` needs Chromium 119, so an older host drops the declaration and shows the plain box, never a transparent card.

## Tests

`ui/webview/postal-wash.test.ts`: the shipped fallbacks equal the measured grounds of the two themes; a document that cannot draw leaves the token to the sheet and clears a stale inline value; the chat installs the measurement at boot and the rule falls back. `ui/webview/theme-parity.test.ts`: every kind word above 4.5:1 on the tinted ground for all 360 hues in both themes, the box pairs kept for the sent boxed card. `ui/webview/postal-card.test.ts`: the fallbacks and the light chroma. `tests/test_postal_cards_served.py`: a twelfth card, a landed boxed sent card, so the plain-box branch runs and the test says so. Screenshots at three widths in dark and two in light are in the drops folder with a follow-up suffix.

Tier: fix
