### PR TITLE
A workflow subagent's transcript opens from the dashboard: nested agent files resolve, and a frame that never comes gives a stall with a retry instead of a loader for good

### DIFF
--- a/cli/spend_rebuild.py
+++ b/cli/spend_rebuild.py
@@ -102,6 +102,19 @@ def _bucket_keys(ts):
     return t.strftime("%Y-%m-%dT%H"), t.strftime("%Y-%m-%d")
 
 
+def _lane_files(subdir):
+    """Every .jsonl under a session's subagents directory, at any depth (Claude Code 2.1.261 writes a Workflow agent's
+    transcript at workflows/wf_<id>/agent-<id>.jsonl; a flat glob missed every one, T355), no symlink followed or taken:
+    the kernel's _subagent_transcripts rule."""
+    if os.path.islink(subdir) or not os.path.isdir(subdir):
+        return []
+    out = []
+    for root, dirs, files in os.walk(subdir):        # followlinks=False
+        dirs.sort()
+        out.extend(p for p in (os.path.join(root, n) for n in files if n.endswith(".jsonl")) if not os.path.islink(p))
+    return sorted(out)
+
+
 def _scan(paths, seen):
     """Per-call usage from transcript files: [(hour, day, {kind: n})]. Streaming writes one message as several
     records that share `message.id` — counted once. Subagent (sidechain) calls count: the recorder's source,
@@ -148,7 +161,8 @@ def recount(state, claude, ledger):
         paths = []
         for fid in sorted(info["ids"]):
             paths += glob.glob(str(claude / "projects" / "*" / (fid + ".jsonl")))
-            paths += glob.glob(str(claude / "projects" / "*" / fid / "subagents" / "*.jsonl"))   # the Agent tool's lanes
+            for sd in glob.glob(str(claude / "projects" / "*" / fid / "subagents")):   # the Agent tool's lanes, one level or deeper
+                paths += _lane_files(sd)                                                #  (workflow agents sit under workflows/wf_<id>/)
         for hk, dk, u in _scan(sorted(set(paths)), seen):
             for kind, key in (("hours", hk), ("days", dk)):
                 slot = per.setdefault((kind, key), {}).setdefault(owner, {k: 0 for k, _ in KINDS})

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25140,6 +25140,7 @@ def _bg_tasks(path, spawned_at=None, live=None):
 # (mtime, size) keys, the transcript's own launch↔notification pairing, and the SDK's live sets.
 _AGENT_ID_RE = re.compile(r"^a[0-9a-f]{16}$")
 _SUBAGENT_META_CACHE = {}       # subagents dir -> (dir mtime_ns, {toolUseId: {agentId, agentType, description, spawnDepth}})
+_SUBAGENT_FILE_CACHE = {}       # (parent transcript, agentId) -> (the tree's stamps, the agent file's path or None): the walk, once per change
 _AGENT_GIST_CACHE = {}          # agent jsonl path -> em.fold_records entry (the Agent head's steps fold state)
 _AGENT_LAUNCH_CACHE = {}        # parent jsonl path -> em.fold_records entry (foreground launches + their settles)
 _SUBAGENT_FRAMES = {}           # (sid, agentId) -> (change key, frame, serialized) — shared by every client with it open
@@ -25178,7 +25179,10 @@ def _subagent_meta_map(path):
         _SUBAGENT_META_CACHE.pop(str(d), None)
         _chat_dep_note_taskout(str(d), None)              # a running chat build: the directory's absence is a dependency too
         return {}
-    dirs = _subagent_dirs(str(d)) or [str(d)]
+    dirs = _subagent_dirs(str(d))
+    if not dirs:                                          # a symlinked subagents/ is not this session's tree (never listed)
+        _SUBAGENT_META_CACHE.pop(str(d), None)
+        return {}
     stamps = []
     for sd in dirs:
         try:
@@ -25222,10 +25226,29 @@ def _subagent_meta_map(path):
     return out
 
 
-def _subagent_meta(path, agent_id):
+def _subagent_tree_key(path):
+    """The stamps a resolved agent path stays valid under: the session's own subagents directories' mtimes (a file landing
+    in one moves it) and the project directory's (a sibling fsid's directory appearing moves that). Cheap: one stat per
+    directory under subagents/ plus one, no file listed."""
+    own = _subagents_dir(path)
+    stamps = []
+    for sd in _subagent_dirs(str(own)):
+        try:
+            stamps.append((sd, os.stat(sd).st_mtime_ns))
+        except OSError:
+            pass
+    try:
+        stamps.append(("..", os.stat(Path(str(path)).parent).st_mtime_ns))
+    except OSError:
+        pass
+    return tuple(stamps)
+
+
+def _subagent_meta(path, agent_id, apath=None):
     """One agent's sidecar (agentType, description, spawnDepth, toolUseId) read directly, beside the agent's own file
-    wherever that was found (a workflow agent's sits under workflows/wf_<id>/, T355); {} when absent."""
-    ap = _subagent_file(path, agent_id)
+    wherever that was found (a workflow agent's sits under workflows/wf_<id>/, T355; `apath` when the caller resolved it
+    already, else the memoized resolution); {} when absent."""
+    ap = apath if apath is not None else _subagent_file(path, agent_id)
     mp = (ap.with_name("agent-%s.meta.json" % agent_id) if ap is not None
           else _subagents_dir(path) / ("agent-%s.meta.json" % agent_id))
     try:
@@ -25252,10 +25275,24 @@ def _subagent_file(path, agent_id):
     fork's fsid — the one file of that name anywhere in the project dir, nested or not. None when missing."""
     if not path or not _AGENT_ID_RE.match(str(agent_id or "")):
         return None
+    ckey = (str(path), str(agent_id))
+    tkey = _subagent_tree_key(path)
+    hit = _SUBAGENT_FILE_CACHE.get(ckey)           # the walk once per change of the tree (the pusher asks every cycle per
+    if hit is not None and hit[0] == tkey:          #  open viewer, the chat build once per Agent card): memoized on its stamps
+        return hit[1]
+    found = _subagent_file_walk(path, agent_id)
+    if len(_SUBAGENT_FILE_CACHE) > 1024:
+        _SUBAGENT_FILE_CACHE.clear()
+    _SUBAGENT_FILE_CACHE[ckey] = (tkey, found)
+    return found
+
+
+def _subagent_file_walk(path, agent_id):
+    """_subagent_file's walk itself (no memo)."""
     name = "agent-%s.jsonl" % agent_id
     own = _subagents_dir(path)
     ap = own / name
-    if ap.exists():
+    if os.path.isfile(ap) and not os.path.islink(ap):  # a file, and this tree's own (a symlink at the flat depth is not taken)
         return ap
     nested = _find_agent_file(own, name)
     if nested is not None:
@@ -25535,7 +25572,7 @@ def build_subagent(sid, agent_id, now, live_map=None):
     if apath is None:
         return {**base, "error": "The transcript file for agent %s is missing beside this session's transcript "
                                  "(subagents/agent-%s.jsonl), so it can't be shown." % (agent_id, agent_id)}
-    meta = _subagent_meta(ppath, agent_id)
+    meta = _subagent_meta(ppath, agent_id, apath)
     full = build_session(sid, now, live_map, path_override=str(apath), sidechain=True, meta_path=ppath)
     if not full:
         return {**base, "error": "This session isn't known to romp any more, so its agent can't be shown."}
@@ -25554,7 +25591,7 @@ def _subagent_frame_cached(sid, agent_id, now, live_map=None):
     live_map = _live_map() if live_map is None else live_map
     ppath = _path_of(sid, now)
     apath = _subagent_file(ppath, agent_id) if ppath else None
-    meta = _subagent_meta(ppath, agent_id) if ppath else {}
+    meta = _subagent_meta(ppath, agent_id, apath) if ppath else {}
     running = (_agent_running_for(ppath, meta.get("toolUseId"), agent_id, live_map.get(str(sid)), _sdk_spawned_at(sid))
                if ppath else False)
     key = (ppath, _chat_stat_key(str(apath)) if apath is not None else None, running, bool(meta))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25152,10 +25152,25 @@ def _subagents_dir(path):
     return Path(str(path)).with_suffix("") / "subagents"
 
 
+def _subagent_dirs(d):
+    """The subagents directory `d` and every directory under it (Claude Code 2.1.261 writes a Workflow agent's file and
+    sidecar one level down, workflows/wf_<id>/), in walk order, no symlink followed (the walk's rule, _subagent_transcripts).
+    [] when `d` is not a directory or is a symlink."""
+    if not os.path.isdir(d) or os.path.islink(d):
+        return []
+    out = []
+    for root, dirs, _files in os.walk(d):                 # followlinks=False: never leaves the session's own tree
+        dirs.sort()
+        out.append(root)
+    return out
+
+
 def _subagent_meta_map(path):
     """toolUseId → {agentId, agentType, description, spawnDepth, parentAgentId} for every agent-*.meta.json beside the
-    transcript at `path`, cached on the DIRECTORY's mtime (a sidecar landing changes it — a stat, never a
-    timer). {} when the directory does not exist (older CLIs wrote no subagent files)."""
+    transcript at `path`, the nested workflow directories included (T355: a workflow agent's sidecar sits under
+    workflows/wf_<id>/, and a flat listing missed it, so its Agent card never learned its id), cached on the
+    directories' mtimes (a sidecar landing changes its directory's — a stat, never a timer). {} when the directory does
+    not exist (older CLIs wrote no subagent files)."""
     d = _subagents_dir(path)
     try:
         st = os.stat(d)
@@ -25163,26 +25178,36 @@ def _subagent_meta_map(path):
         _SUBAGENT_META_CACHE.pop(str(d), None)
         _chat_dep_note_taskout(str(d), None)              # a running chat build: the directory's absence is a dependency too
         return {}
-    key = st.st_mtime_ns
-    # the running chat build's dependency record (the taskout idiom, _chat_dep_note_taskout): a sidecar landing
-    # moves the directory's mtime, which the next cycle's signature re-stats
-    _chat_dep_note_taskout(str(d), (st.st_mtime, st.st_size))
+    dirs = _subagent_dirs(str(d)) or [str(d)]
+    stamps = []
+    for sd in dirs:
+        try:
+            sst = os.stat(sd)
+        except OSError:
+            continue
+        stamps.append((sd, sst.st_mtime_ns))
+        # the running chat build's dependency record (the taskout idiom, _chat_dep_note_taskout): a sidecar landing
+        # moves its directory's mtime, which the next cycle's signature re-stats
+        _chat_dep_note_taskout(sd, (sst.st_mtime, sst.st_size))
+    key = tuple(stamps)
     hit = _SUBAGENT_META_CACHE.get(str(d))
     if hit is not None and hit[0] == key:
         return hit[1]
     out = {}
-    try:
-        names = sorted(os.listdir(d))
-    except OSError:
-        names = []
-    for nm in names:
+    entries = []
+    for sd in dirs:
+        try:
+            entries.extend((sd, nm) for nm in sorted(os.listdir(sd)))
+        except OSError:
+            continue
+    for sd, nm in entries:
         if not (nm.startswith("agent-") and nm.endswith(".meta.json")):
             continue
         aid = nm[len("agent-"):-len(".meta.json")]
         if not _AGENT_ID_RE.match(aid):
             continue
         try:
-            meta = json.loads((d / nm).read_text())
+            meta = json.loads((Path(sd) / nm).read_text())
         except (OSError, ValueError):
             continue
         if not isinstance(meta, dict) or not meta.get("toolUseId"):
@@ -25198,8 +25223,11 @@ def _subagent_meta_map(path):
 
 
 def _subagent_meta(path, agent_id):
-    """One agent's sidecar (agentType, description, spawnDepth, toolUseId) read directly; {} when absent."""
-    mp = _subagents_dir(path) / ("agent-%s.meta.json" % agent_id)
+    """One agent's sidecar (agentType, description, spawnDepth, toolUseId) read directly, beside the agent's own file
+    wherever that was found (a workflow agent's sits under workflows/wf_<id>/, T355); {} when absent."""
+    ap = _subagent_file(path, agent_id)
+    mp = (ap.with_name("agent-%s.meta.json" % agent_id) if ap is not None
+          else _subagents_dir(path) / ("agent-%s.meta.json" % agent_id))
     try:
         meta = json.loads(mp.read_text())
     except (OSError, ValueError):
@@ -25207,24 +25235,43 @@ def _subagent_meta(path, agent_id):
     return meta if isinstance(meta, dict) else {}
 
 
+def _find_agent_file(subdir, name):
+    """`name` anywhere under the subagents directory `subdir`, one level or deeper (workflows/wf_<id>/agent-<id>.jsonl),
+    no symlink followed or taken; None when absent."""
+    for root in _subagent_dirs(str(subdir)):
+        cand = os.path.join(root, name)
+        if os.path.isfile(cand) and not os.path.islink(cand):
+            return Path(cand)
+    return None
+
+
 def _subagent_file(path, agent_id):
-    """The agent's own transcript beside the parent transcript `path`, or — when the sidecar dir has moved
-    under a /clear fork's fsid — the one file of that name anywhere in the project dir. None when missing."""
+    """The agent's own transcript beside the parent transcript `path`: subagents/agent-<id>.jsonl, or one level or
+    more down (a Workflow agent's, workflows/wf_<id>/agent-<id>.jsonl, since Claude Code 2.1.261: the flat lookup
+    missed it and the viewer said the file was missing, T355), or — when the sidecar dir has moved under a /clear
+    fork's fsid — the one file of that name anywhere in the project dir, nested or not. None when missing."""
     if not path or not _AGENT_ID_RE.match(str(agent_id or "")):
         return None
-    ap = _subagents_dir(path) / ("agent-%s.jsonl" % agent_id)
+    name = "agent-%s.jsonl" % agent_id
+    own = _subagents_dir(path)
+    ap = own / name
     if ap.exists():
         return ap
+    nested = _find_agent_file(own, name)
+    if nested is not None:
+        return nested
     # A miss is a dependency of the chat payload that asked (the taskout idiom, _chat_dep_note_taskout): the
     # file appearing at its own place, or a sibling fsid's directory gaining one, changes the Agent card.
     _chat_dep_note_taskout(str(ap), None)
     try:
-        for d in Path(str(path)).parent.iterdir():
-            if d.is_dir():                                # the directory the glob below reads: a file landing in
+        for d in sorted(Path(str(path)).parent.iterdir()):
+            if d.is_dir():                                # the directory the walk below reads: a file landing in
                 sd = d / "subagents"                      # <sib>/subagents/ moves ITS mtime, not the sibling's
                 _chat_dep_note_taskout(str(sd), _chat_stat_key(str(sd)))
-        for cand in Path(str(path)).parent.glob("*/subagents/agent-%s.jsonl" % agent_id):
-            return cand
+                if sd != own:
+                    cand = _find_agent_file(sd, name)
+                    if cand is not None:
+                        return cand
     except OSError:
         pass
     return None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25316,22 +25316,17 @@ def _subagent_meta_map(path):
     return out
 
 
-def _subagent_tree_key(path):
-    """The stamps a resolved agent path stays valid under: the session's own subagents directories' mtimes (a file landing
-    in one moves it) and the project directory's (a sibling fsid's directory appearing moves that). Cheap: one stat per
-    directory under subagents/ plus one, no file listed."""
-    own = _subagents_dir(path)
-    stamps = []
-    for sd in _subagent_dirs(str(own)):
+def _dir_stamps(dirs):
+    """(dir, mtime_ns) for each directory, stats only (a missing one stamps None): the resolver's memo key. A file landing
+    in a directory moves that directory's mtime; a directory appearing moves its parent's; so the directories a walk READ
+    are exactly what a later hit must re-stat, and nothing is listed on a hit."""
+    out = []
+    for sd in dirs:
         try:
-            stamps.append((sd, os.stat(sd).st_mtime_ns))
+            out.append((sd, os.stat(sd).st_mtime_ns))
         except OSError:
-            pass
-    try:
-        stamps.append(("..", os.stat(Path(str(path)).parent).st_mtime_ns))
-    except OSError:
-        pass
-    return tuple(stamps)
+            out.append((sd, None))
+    return tuple(out)
 
 
 def _subagent_meta(path, agent_id, apath=None):
@@ -25348,12 +25343,17 @@ def _subagent_meta(path, agent_id, apath=None):
     return meta if isinstance(meta, dict) else {}
 
 
-def _find_agent_file(subdir, name):
+def _find_agent_file(subdir, name, read=None):
     """`name` anywhere under the subagents directory `subdir`, one level or deeper (workflows/wf_<id>/agent-<id>.jsonl),
-    no symlink followed or taken; None when absent."""
-    for root in _subagent_dirs(str(subdir)):
+    no symlink followed or taken, and never a file reached THROUGH a symlink (its real path stays under the tree's);
+    None when absent. `read` collects the directories walked."""
+    dirs = _subagent_dirs(str(subdir))
+    if read is not None:
+        read.extend(dirs)
+    real_root = os.path.realpath(str(subdir))
+    for root in dirs:
         cand = os.path.join(root, name)
-        if os.path.isfile(cand) and not os.path.islink(cand):
+        if os.path.isfile(cand) and not os.path.islink(cand) and os.path.realpath(cand).startswith(real_root + os.sep):
             return Path(cand)
     return None
 
@@ -25366,37 +25366,41 @@ def _subagent_file(path, agent_id):
     if not path or not _AGENT_ID_RE.match(str(agent_id or "")):
         return None
     ckey = (str(path), str(agent_id))
-    tkey = _subagent_tree_key(path)
-    hit = _SUBAGENT_FILE_CACHE.get(ckey)           # the walk once per change of the tree (the pusher asks every cycle per
-    if hit is not None and hit[0] == tkey:          #  open viewer, the chat build once per Agent card): memoized on its stamps
-        return hit[1]
-    found = _subagent_file_walk(path, agent_id)
+    hit = _SUBAGENT_FILE_CACHE.get(ckey)           # the walk once per change of what it read (the pusher asks every cycle per
+    if hit is not None and _dir_stamps([d for d, _m in hit[0]]) == hit[0]:   # open viewer, the chat build once per Agent card):
+        return hit[1]                                 #  a hit re-stats the directories the walk read, own tree and siblings, never lists
+    read = []
+    found = _subagent_file_walk(path, agent_id, read)
     if len(_SUBAGENT_FILE_CACHE) > 1024:
         _SUBAGENT_FILE_CACHE.clear()
-    _SUBAGENT_FILE_CACHE[ckey] = (tkey, found)
-    return found
+    _SUBAGENT_FILE_CACHE[ckey] = (_dir_stamps(read), found)   # a miss is memoized too, on the same stamps: a file landing later
+    return found                                                #  under a sibling's tree moves that directory and re-walks
 
 
-def _subagent_file_walk(path, agent_id):
-    """_subagent_file's walk itself (no memo)."""
+def _subagent_file_walk(path, agent_id, read=None):
+    """_subagent_file's walk itself (no memo); `read` collects every directory it looked at, the memo's stamps."""
+    read = read if read is not None else []
     name = "agent-%s.jsonl" % agent_id
     own = _subagents_dir(path)
+    read.append(str(own))
     ap = own / name
-    if os.path.isfile(ap) and not os.path.islink(ap):  # a file, and this tree's own (a symlink at the flat depth is not taken)
-        return ap
-    nested = _find_agent_file(own, name)
+    if not os.path.islink(own) and os.path.isfile(ap) and not os.path.islink(ap):   # this tree's own file (a symlinked
+        return ap                                                                   #  subagents/ or file is not taken)
+    nested = _find_agent_file(own, name, read)
     if nested is not None:
         return nested
     # A miss is a dependency of the chat payload that asked (the taskout idiom, _chat_dep_note_taskout): the
     # file appearing at its own place, or a sibling fsid's directory gaining one, changes the Agent card.
     _chat_dep_note_taskout(str(ap), None)
     try:
+        read.append(str(Path(str(path)).parent))         # the project directory: a sibling fsid's directory appearing moves it
         for d in sorted(Path(str(path)).parent.iterdir()):
             if d.is_dir():                                # the directory the walk below reads: a file landing in
                 sd = d / "subagents"                      # <sib>/subagents/ moves ITS mtime, not the sibling's
                 _chat_dep_note_taskout(str(sd), _chat_stat_key(str(sd)))
                 if sd != own:
-                    cand = _find_agent_file(sd, name)
+                    read.append(str(sd))
+                    cand = _find_agent_file(sd, name, read)
                     if cand is not None:
                         return cand
     except OSError:

--- a/tests/test_spend_rebuild.py
+++ b/tests/test_spend_rebuild.py
@@ -66,9 +66,10 @@ class SpendRebuild(unittest.TestCase):
                                                  "content": [{"type": "text", "text": "ok"}]}}))
         (self.proj / (sid + ".jsonl")).write_text("\n".join(lines) + "\n")
 
-    def _subagent(self, sid, agent, calls):
-        """A subagent lane's transcript under the session's sidecar folder — same record shape."""
-        d = self.proj / sid / "subagents"
+    def _subagent(self, sid, agent, calls, nested=""):
+        """A subagent lane's transcript under the session's sidecar folder — same record shape; `nested` puts it one level
+        down (a workflow agent's workflows/wf_<id>/)."""
+        d = self.proj / sid / "subagents" / nested if nested else self.proj / sid / "subagents"
         d.mkdir(parents=True, exist_ok=True)
         lines = []
         for off, mid, u, side in calls:
@@ -129,6 +130,18 @@ class SpendRebuild(unittest.TestCase):
         h = self._read()["hours"][self.hour]
         self.assertEqual(h["tokCacheR"], 5000 + 5300 + 1000)
         self.assertEqual(h["bySid"][WEB]["tok"], _tok(U1) + _tok(U2) + _tok(U3), "lanes bill the session that ran them")
+
+    def test_a_workflow_agents_nested_lane_counts_too(self):
+        # Claude Code 2.1.261 writes a workflow agent's transcript under subagents/workflows/wf_<id>/; the flat glob
+        # missed every one, so a recount under-billed exactly the sessions that ran workflows (T355)
+        self._transcript(WEB, [(0, "m1", U1, False)])
+        self._subagent(WEB, "agent-a1", [(20, "s1", U2, True)])
+        self._subagent(WEB, "agent-a2", [(40, "s2", U3, True)], nested="workflows/wf_0123456789abcdef")
+        self._reg(WEB, "web")
+        self._ledger({self.day: self._wrong_bucket()}, {self.hour: self._wrong_bucket()})
+        self.assertEqual(self._run("--apply"), 0)
+        h = self._read()["hours"][self.hour]
+        self.assertEqual(h["bySid"][WEB]["tok"], _tok(U1) + _tok(U2) + _tok(U3), "the nested lane bills its session too")
 
     def test_a_dry_run_writes_nothing(self):
         self._transcript(WEB, [(0, "m1", U1, False), (60, "m2", U2, False)])

--- a/tests/test_subagent_transcripts.py
+++ b/tests/test_subagent_transcripts.py
@@ -158,7 +158,7 @@ class World(unittest.TestCase):
         self.live = {"state": "waiting", "since": T0, "model": "", "effort": "", "context": None,
                      "compactPct": None, "color": None, "backend": "sdk"}
         km._live_map = lambda: self.tm
-        for cache in (km._chat_fold, km._parse_cache, km._SUBAGENT_META_CACHE, km._AGENT_GIST_CACHE,
+        for cache in (km._chat_fold, km._parse_cache, km._SUBAGENT_META_CACHE, km._SUBAGENT_FILE_CACHE, km._AGENT_GIST_CACHE,
                       km._AGENT_LAUNCH_CACHE, km._SUBAGENT_FRAMES, km._bgtasks_cache, km._bgall_cache):
             cache.clear()
 
@@ -524,6 +524,38 @@ class NestedWorkflowAgent(World):
         self.assertEqual(km._subagent_file(str(self.tpath), AID_WF), moved / "subagents" / "workflows" / "wf_0123456789abcdef" / ("agent-%s.jsonl" % AID_WF))
         self.assertEqual(km._subagent_meta(str(self.tpath), AID_WF).get("toolUseId"), TU_WF)
         self.assertIsNone(km._subagent_file(str(self.tpath), "a9999999999999999"))
+
+    def test_a_miss_memoized_before_the_file_lands_under_a_sibling_tree_resolves_when_it_lands(self):
+        """Round 3's medium: the memo latched a miss when the file landed under a sibling fsid's tree (a /clear fork's agents
+        land under the old fsid), since only the own tree and the project directory were stamped; every directory the walk
+        read is stamped now, siblings included, and a hit re-stats those alone."""
+        aid = "a5555555555555555"
+        self.assertIsNone(km._subagent_file(str(self.tpath), aid), "absent everywhere: a miss, memoized")
+        sib = self.proj / "66666666-7777-8888-9999-000000000000" / "subagents"
+        sib.mkdir(parents=True)                                      # a sibling fsid's tree appears (the project directory moves)
+        self.assertIsNone(km._subagent_file(str(self.tpath), aid), "still absent")
+        wf = sib / "workflows" / "wf_00000000000000ff"; wf.mkdir(parents=True)
+        write_jsonl(wf / ("agent-%s.jsonl" % aid), self._agent_records(aid, T0 + 200, []))   # …and the file lands in it, nested
+        self.assertEqual(km._subagent_file(str(self.tpath), aid), wf / ("agent-%s.jsonl" % aid), "found without a restart")
+        # a hit re-stats the directories the walk read and lists nothing
+        real_listdir, real_walk, count = os.listdir, os.walk, [0]
+        os.listdir = lambda *a, **k: (count.__setitem__(0, count[0] + 1), real_listdir(*a, **k))[1]
+        os.walk = lambda *a, **k: (count.__setitem__(0, count[0] + 1), real_walk(*a, **k))[1]
+        try:
+            self.assertEqual(km._subagent_file(str(self.tpath), aid), wf / ("agent-%s.jsonl" % aid))
+            self.assertEqual(count[0], 0, "a memo hit: stats only")
+        finally:
+            os.listdir, os.walk = real_listdir, real_walk
+
+    def test_a_symlinked_subagents_directory_yields_no_file_and_no_sidecar_map(self):
+        """Round 3's low d: a file reached THROUGH a symlinked subagents/ is not this session's."""
+        outside = Path(self._td) / "elsewhere" / "subagents"; outside.mkdir(parents=True)
+        write_jsonl(outside / ("agent-%s.jsonl" % AID_BG), self._agent_records(AID_BG, T0, []))
+        (outside / ("agent-%s.meta.json" % AID_BG)).write_text(json.dumps({"agentType": "x", "toolUseId": TU_BG}))
+        shutil.rmtree(self.subdir); os.symlink(str(outside), str(self.subdir))
+        km._SUBAGENT_FILE_CACHE.clear(); km._SUBAGENT_META_CACHE.clear()
+        self.assertIsNone(km._subagent_file(str(self.tpath), AID_BG), "the own tree is a symlink: not taken")
+        self.assertEqual(km._subagent_meta_map(str(self.tpath)), {}, "…and its sidecars are not listed")
 
     def test_a_symlink_into_the_tree_is_neither_followed_nor_taken(self):
         outside = Path(self._td) / "outside"; outside.mkdir()

--- a/tests/test_subagent_transcripts.py
+++ b/tests/test_subagent_transcripts.py
@@ -462,6 +462,78 @@ class Viewer(World):
         self.assertIsNone(km._subagent_file(str(self.tpath), "a9999999999999999"))
 
 
+AID_WF = "a0000000000000c0de"[:17]                 # a WORKFLOW agent (Claude Code 2.1.261): its file one level down
+TU_WF = "toolu_wf_0001"
+
+
+class NestedWorkflowAgent(World):
+    """T355 (the user, 2026-09-11): opening a WORKFLOW subagent's transcript from the dashboard hung. The CLI writes a
+    workflow agent's file and sidecar under subagents/workflows/wf_<id>/, and the viewer's lookup read only the flat
+    subagents/agent-<id>.jsonl (plus the sibling-fsid glob at the same depth), so the frame carried the 'missing beside
+    this session's transcript' sentence, and the Agent card's sidecar join never learned the agent's id."""
+
+    def setUp(self):
+        super().setUp()
+        self.wfdir = self.subdir / "workflows" / "wf_0123456789abcdef"
+        self.wfdir.mkdir(parents=True)
+        (self.wfdir / ("agent-%s.meta.json" % AID_WF)).write_text(json.dumps(
+            {"agentType": "workflow", "description": "review the api changes", "spawnDepth": 1, "toolUseId": TU_WF}))
+        self.wf_file = self.wfdir / ("agent-%s.jsonl" % AID_WF)
+        write_jsonl(self.wf_file, self._agent_records(AID_WF, T0 + 120, [
+            ("Read", {"file_path": "/tmp/notes-api/api/notes.py"}, "def list_notes(): ..."),
+            ("Bash", {"command": "uv run pytest -q tests/", "description": "run the api tests"}, "4 passed"),
+        ], closing="The api changes hold: four tests pass."))
+        ack = {"isAsync": True, "status": "async_launched", "agentId": AID_WF, "description": "review the api changes",
+               "outputFile": "/tmp/claude-1000/-tmp-notes-api/%s/tasks/%s.output" % (SID, AID_WF), "taskType": "local_agent"}
+        append_jsonl(self.tpath, [
+            urec(T0 + 100, "u5", "run the review workflow on the api changes", self.last),
+            arec(T0 + 102, "a5", [tool_use(TU_WF, "Agent", {"description": "review the api changes", "prompt": "Review the api changes.",
+                                                            "subagent_type": "workflow", "run_in_background": True})], "u5", stop="tool_use"),
+            urec(T0 + 103, "r5", [tool_result(TU_WF, "Async agent launched. Agent ID: %s. Output file: %s" % (AID_WF, ack["outputFile"]))], "a5",
+                 toolUseResult=ack),
+            arec(T0 + 104, "a6", [{"type": "text", "text": "The workflow is running."}], "r5")])
+        self.last = "a6"
+        km._SUBAGENT_META_CACHE.clear()
+
+    def test_the_nested_file_and_sidecar_resolve_and_the_viewer_renders_them(self):
+        self.assertEqual(km._subagent_file(str(self.tpath), AID_WF), self.wf_file, "one level down: found")
+        self.assertEqual(km._subagent_meta(str(self.tpath), AID_WF).get("agentType"), "workflow", "the sidecar beside the file")
+        mp = km._subagent_meta_map(str(self.tpath))
+        self.assertEqual(mp.get(TU_WF, {}).get("agentId"), AID_WF, "the Agent card's join sees the nested sidecar")
+        self.assertEqual(mp.get(TU_BG, {}).get("agentId"), AID_BG, "…beside the flat ones")
+        fr = km.build_subagent(SID, AID_WF, NOW, self.tm)
+        self.assertNotIn("error", fr, fr.get("error"))
+        self.assertEqual(fr["meta"]["agentType"], "workflow"); self.assertEqual(fr["meta"]["toolUseId"], TU_WF)
+        kinds = [e.get("kind") for e in fr["events"]]
+        self.assertIn("tool", kinds); self.assertTrue(any("four tests pass" in (e.get("md") or "") for e in fr["events"]))
+        ev = self._agent_events().get(TU_WF)
+        self.assertIsNotNone(ev, "the parent's Agent card"); self.assertEqual(ev.get("agentId"), AID_WF)
+
+    def test_the_socket_arm_answers_a_nested_agents_open_with_its_events(self):
+        c = _Client()
+        km.Handler._dispatch_ws(object.__new__(km.Handler), {"type": "openSubagent", "id": SID, "agentId": AID_WF}, c)
+        fr = next(f for f in c.out if f.get("type") == "subagent")
+        self.assertEqual((fr["id"], fr["agentId"]), (SID, AID_WF))
+        self.assertNotIn("error", fr, "the frame the pane shows: events, not the 'missing' sentence")
+        self.assertGreater(len(fr["events"]), 0)
+
+    def test_the_nested_file_is_found_under_a_forked_fsid_dir_too(self):
+        moved = self.proj / "66666666-7777-8888-9999-000000000000"
+        shutil.move(str(self.proj / SID), str(moved))
+        km._SUBAGENT_META_CACHE.clear()
+        self.assertEqual(km._subagent_file(str(self.tpath), AID_WF), moved / "subagents" / "workflows" / "wf_0123456789abcdef" / ("agent-%s.jsonl" % AID_WF))
+        self.assertEqual(km._subagent_meta(str(self.tpath), AID_WF).get("toolUseId"), TU_WF)
+        self.assertIsNone(km._subagent_file(str(self.tpath), "a9999999999999999"))
+
+    def test_a_symlink_into_the_tree_is_neither_followed_nor_taken(self):
+        outside = Path(self._td) / "outside"; outside.mkdir()
+        write_jsonl(outside / "agent-a3333333333333333.jsonl", self._agent_records("a3333333333333333", T0, []))
+        os.symlink(str(outside), str(self.subdir / "workflows" / "wf_link"))
+        os.symlink(str(outside / "agent-a3333333333333333.jsonl"), str(self.wfdir / "agent-a4444444444444444.jsonl"))
+        self.assertIsNone(km._subagent_file(str(self.tpath), "a3333333333333333"), "a symlinked directory is not followed")
+        self.assertIsNone(km._subagent_file(str(self.tpath), "a4444444444444444"), "a symlinked file is not taken")
+
+
 class _Client(dict):
     """A ws client record as _dispatch_ws sees it: frames land in `out`."""
 

--- a/ui/webview/pane-placeholder.test.ts
+++ b/ui/webview/pane-placeholder.test.ts
@@ -1,0 +1,89 @@
+// The empty pane's placeholder, DRIVEN on a stub DOM (T355): a viewer's loader gives way to the stall with its Retry and to the
+// kernel's error sentence when the kind changes, the same kind twice is left standing, and the Retry asks again.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { placeholderKind, placeholderStands, fillPlaceholder } from "./pane-placeholder";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+
+function fakeEl(tag = "div", cls = ""): any {
+  const classes = new Set(cls ? cls.split(" ") : []);
+  const el: any = { tag, textContent: "", dataset: {}, children: [] as any[], type: "", className: "", onclick: null as any,
+                    classList: { add: (c: string) => classes.add(c), contains: (c: string) => classes.has(c), remove: (c: string) => classes.delete(c) },
+                    appendChild(c: any) { el.children.push(c); return c; } };
+  return el;
+}
+const ctx = (retries: number[]) => ({
+  el: fakeEl, loader: (t: string) => { const l = fakeEl("div", "romp-loader"); l.textContent = t; return l; },
+  button: () => fakeEl("button"), br: () => fakeEl("br"),
+  text: { error: null as string | null, failedRevive: null, stall: "stalled after 15 seconds", sessionName: "web" },
+  onRetry: () => { retries.push(1); },
+});
+
+/** The pane's own rule, as render.ts applies it: rebuild unless the standing placeholder is of this kind. */
+function paint(pane: { children: any[] }, st: any, c: any): any {
+  const only = pane.children.length === 1 ? pane.children[0] : null;
+  const kind = placeholderKind(st);
+  if (!only || !only.classList.contains("tx-empty") || !placeholderStands(only, kind)) {
+    pane.children.length = 0;
+    const ph = fakeEl("div", "tx-empty"); pane.children.push(ph);
+    fillPlaceholder(ph, kind, c);
+  }
+  return pane.children[0];
+}
+
+test("a viewer's loader gives way to the stall with a Retry, then to the kernel's error sentence, and a repeat of a kind stands", () => {
+  const retries: number[] = []; const c = ctx(retries);
+  const pane = { children: [] as any[] };
+  const sub: any = { error: null, loaded: false, stalled: false };
+  const p1 = paint(pane, { sub }, c);
+  assert.equal(p1.dataset.ph, "sub-loading"); assert.ok(p1.classList.contains("tx-starting")); assert.equal(p1.children[0].textContent, "opening the agent's transcript…");
+  const p1b = paint(pane, { sub }, c);
+  assert.strictEqual(p1b, p1, "the same kind: the loader stands (no churn)");
+  sub.stalled = true;                                    // the wait passed with no frame
+  const p2 = paint(pane, { sub }, c);
+  assert.notStrictEqual(p2, p1, "another kind: rebuilt");
+  assert.equal(p2.dataset.ph, "sub-stall"); assert.match(p2.textContent, /stalled after 15 seconds/);
+  const btn = p2.children.find((x: any) => x.tag === "button");
+  assert.ok(btn && btn.textContent === "Retry", "…with a Retry");
+  btn.onclick(); assert.deepEqual(retries, [1], "the Retry asks again");
+  sub.error = "The transcript file for agent a1 is missing beside this session's transcript, so it can't be shown."; sub.loaded = true; sub.stalled = false;
+  c.text.error = sub.error;
+  const p3 = paint(pane, { sub }, c);
+  assert.equal(p3.dataset.ph, "sub-error"); assert.match(p3.textContent, /missing beside/); assert.ok(p3.classList.contains("tx-revive-failed"));
+  sub.error = null;                                      // a later frame with events... none: the agent wrote nothing
+  const p4 = paint(pane, { sub }, c);
+  assert.equal(p4.dataset.ph, "sub-empty"); assert.equal(p4.textContent, "This agent has written nothing yet.");
+});
+
+test("the loader painted at open also gives way straight to the error frame (the user's 'both kernels up' case)", () => {
+  const c = ctx([]); const pane = { children: [] as any[] };
+  const sub: any = { error: null, loaded: false, stalled: false };
+  paint(pane, { sub }, c);
+  sub.error = "missing"; sub.loaded = true; c.text.error = "missing";
+  assert.equal(paint(pane, { sub }, c).dataset.ph, "sub-error");
+});
+
+test("the kinds: a failed revive first, a starting tab's loader and its failed create, a plain empty session", () => {
+  assert.equal(placeholderKind({ failedRevive: "gone", sub: { error: "x", loaded: true } }), "revive-failed");
+  assert.equal(placeholderKind({ provisional: true }), "starting");
+  assert.equal(placeholderKind({ provisional: true, provisionalFailed: true }), "start-failed");
+  assert.equal(placeholderKind({}), "empty");
+  const c = ctx([]);
+  const st = fillPlaceholder(fakeEl("div", "tx-empty"), "starting", { ...c, swirl: () => fakeEl("img", "tx-starting-swirl") });
+  assert.ok(st.classList.contains("tx-starting")); assert.match(st.children[1].textContent, /^Starting web…/);
+  assert.equal(fillPlaceholder(fakeEl("div", "tx-empty"), "empty", c).textContent, "No messages yet.");
+  assert.equal(placeholderStands(null, "empty"), false);
+});
+
+test("render.ts paints through the module and re-asks only the viewers still waiting, on every reconnect-class event", () => {
+  const branch = RENDER.slice(RENDER.indexOf("  if (s.events.length === 0) {\n    const only = v.el.childNodes.length === 1"), RENDER.indexOf("v.rendered = 0; v.stale = false; v.winStart = 0; v.winEnd = 0;"));
+  assert.ok(branch.includes("const kind = placeholderKind({ sub: s.sub, failedRevive: failedRevives.get(id) || null,"), "the kind decided from the session's state");
+  assert.ok(branch.includes('if (!only || !only.classList?.contains("tx-empty") || !placeholderStands(only, kind)) {'), "rebuilt when the kind changed");
+  assert.ok(branch.includes("fillPlaceholder(ph, kind, {"), "…and filled by the module");
+  assert.ok(RENDER.includes("for (const [id, s] of sessions) if (s.sub && (!s.sub.loaded || s.sub.stalled)) askSubagent(id);"), "waiting viewers only");
+  for (const ev of ['window.addEventListener("romp:wsup", () => reaskWaitingSubagents());', 'window.addEventListener("romp:hostRelayUp", () => reaskWaitingSubagents());', 'if (m.type === "pipeState" && m.up) reaskWaitingSubagents();'])
+    assert.ok(RENDER.includes(ev), ev);
+});

--- a/ui/webview/pane-placeholder.test.ts
+++ b/ui/webview/pane-placeholder.test.ts
@@ -83,7 +83,7 @@ test("render.ts paints through the module and re-asks only the viewers still wai
   assert.ok(branch.includes("const kind = placeholderKind({ sub: s.sub, failedRevive: failedRevives.get(id) || null,"), "the kind decided from the session's state");
   assert.ok(branch.includes('if (!only || !only.classList?.contains("tx-empty") || !placeholderStands(only, kind)) {'), "rebuilt when the kind changed");
   assert.ok(branch.includes("fillPlaceholder(ph, kind, {"), "…and filled by the module");
-  assert.ok(RENDER.includes("for (const [id, s] of sessions) if (s.sub && (!s.sub.loaded || s.sub.stalled)) askSubagent(id);"), "waiting viewers only");
-  for (const ev of ['window.addEventListener("romp:wsup", () => reaskWaitingSubagents());', 'window.addEventListener("romp:hostRelayUp", () => reaskWaitingSubagents());', 'if (m.type === "pipeState" && m.up) reaskWaitingSubagents();'])
+  assert.ok(RENDER.includes("if (s.sub && (!s.sub.loaded || s.sub.stalled) && (host === undefined || hostOf(s.sub.parentId) === host)) askSubagent(id);"), "waiting viewers only, the named host's alone");
+  for (const ev of ['window.addEventListener("romp:wsup", () => reaskWaitingSubagents(""));', 'reaskWaitingSubagents(h || undefined);', 'if (m.type === "pipeState" && m.up) reaskWaitingSubagents();'])
     assert.ok(RENDER.includes(ev), ev);
 });

--- a/ui/webview/pane-placeholder.ts
+++ b/ui/webview/pane-placeholder.ts
@@ -1,0 +1,91 @@
+// The chat pane's PLACEHOLDER for a session with no events (T355, the user 2026-09-11): what the pane shows in place of
+// turns, decided from the session's state, and rebuilt when that DECISION changes. The pane once rebuilt the placeholder
+// only when its single child was not a placeholder at all, so the loader painted at a viewer's open outlived every
+// later state: the kernel's error sentence, the stall past the wait, and "written nothing yet" never replaced it, and a
+// workflow agent's transcript read "opening…" for good whatever the kernel answered. The kind rides the element as a
+// data attribute; the same kind twice is left alone (no churn on repeated pushes that stay empty).
+export type PlaceholderKind = "revive-failed" | "sub-error" | "sub-stall" | "sub-loading" | "sub-empty" | "start-failed" | "starting" | "empty";
+
+export interface PlaceholderState {
+  sub?: { error: string | null; loaded: boolean; stalled?: boolean } | null;
+  failedRevive?: string | null;      // the couldn't-revive notice for this tab, when one stands
+  provisional?: boolean;             // a tab whose session is still being created
+  provisionalFailed?: boolean;       // …whose create failed
+}
+
+export function placeholderKind(st: PlaceholderState): PlaceholderKind {
+  if (st.failedRevive) return "revive-failed";
+  if (st.sub) {
+    if (st.sub.error) return "sub-error";
+    if (!st.sub.loaded && st.sub.stalled) return "sub-stall";
+    if (!st.sub.loaded) return "sub-loading";
+    return "sub-empty";
+  }
+  if (st.provisional && st.provisionalFailed) return "start-failed";
+  if (st.provisional) return "starting";
+  return "empty";
+}
+
+/** Whether the pane's single child already is the placeholder of `kind` (then nothing is rebuilt). */
+export function placeholderStands(only: { classList?: { contains(c: string): boolean }; dataset?: Record<string, string | undefined> } | null, kind: PlaceholderKind): boolean {
+  return !!only && !!only.classList?.contains("tx-empty") && only.dataset?.ph === kind;
+}
+
+export interface PlaceholderCtx {
+  el: (tag: string, cls: string) => any;              // the pane's element maker (render.ts el)
+  loader: (text: string) => any;                      // the romp loader's inner element (rompLoaderInner)
+  button: () => any;                                  // document.createElement("button")
+  br: () => any;                                      // document.createElement("br")
+  swirl?: () => any;                                  // the starting tab's swirl image, when the pane has one
+  text: { error?: string | null; failedRevive?: string | null; stall: string; sessionName: string };
+  onRetry: () => void;
+}
+
+/** Fill a fresh placeholder element for `kind`; returns it, stamped with the kind. */
+export function fillPlaceholder(ph: any, kind: PlaceholderKind, ctx: PlaceholderCtx): any {
+  ph.dataset.ph = kind;
+  switch (kind) {
+    case "revive-failed":
+      ph.textContent = ctx.text.failedRevive || "";
+      ph.classList.add("tx-revive-failed");
+      break;
+    case "sub-error":
+      // the kernel could not open the agent's file: its sentence, loud, in the pane (never a blank)
+      ph.textContent = ctx.text.error || "";
+      ph.classList.add("tx-revive-failed");
+      break;
+    case "sub-stall": {
+      // the ask went unanswered past the wait: say so and offer the retry, never a loader for good
+      ph.textContent = ctx.text.stall;
+      ph.classList.add("tx-revive-failed");
+      const retry = ctx.button(); retry.className = "picker-action confirm-btn"; retry.type = "button";
+      retry.textContent = "Retry"; retry.onclick = () => ctx.onRetry();
+      ph.appendChild(ctx.br()); ph.appendChild(retry);
+      break;
+    }
+    case "sub-loading":
+      // the viewer's first frame is in flight → the romp loader holds the pane (the wait-state rule)
+      ph.classList.add("tx-starting");
+      ph.appendChild(ctx.loader("opening the agent's transcript…"));
+      break;
+    case "sub-empty":
+      ph.textContent = "This agent has written nothing yet.";
+      break;
+    case "start-failed":
+      ph.textContent = "This session couldn't start. What you typed is kept in the box below; ✕ on the tab discards both.";
+      break;
+    case "starting": {
+      // a PROVISIONAL tab is not empty, it is STARTING — so it wears the romp loader (the repo's rule for any wait), not
+      // the placeholder that tells you to send something; the composer below it is live either way
+      ph.classList.add("tx-starting");
+      if (ctx.swirl) ph.appendChild(ctx.swirl());
+      const wm = ctx.el("div", "tx-starting-msg");
+      wm.textContent = "Starting " + ctx.text.sessionName + "… you can type now; romp sends it when it's up.";
+      ph.appendChild(wm);
+      break;
+    }
+    default:
+      ph.textContent = "No messages yet.";
+  }
+  return ph;
+}

--- a/ui/webview/provisional.test.ts
+++ b/ui/webview/provisional.test.ts
@@ -13,6 +13,7 @@ import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional,
   PROVISIONAL_PREFIX } from "./provisional";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PLACEHOLDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "pane-placeholder.ts"), "utf8");   // the empty pane's placeholder, by kind (T355)
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a provisional id carries NO colon — federation would read it as a host", () => {
@@ -140,8 +141,11 @@ test("a failed create says so in a dialog, in the kernel's own words — ON the 
   assert.ok(!fail.includes("= dropProvisional()"), "the tab is NOT torn down — it holds the text");
   assert.ok(fail.includes("failedProvisionals.add(id);"));
   // the failed tab's transcript says what happened (the starting loader would be a lie)…
-  assert.match(RENDER, /This session couldn't start\. What you typed is kept in the box below/);
-  assert.match(RENDER, /const staleStart = !!only && only\.classList\?\.contains\("tx-starting"\) && failedProvisionals\.has\(id\);/);
+  assert.match(PLACEHOLDER, /This session couldn't start\. What you typed is kept in the box below/);   // the placeholder by kind (pane-placeholder.ts, T355)
+  // …the starting loader gives way to it because the placeholder's KIND changed (starting → start-failed), the rule that
+  // replaced the stale-start special case: the failed create feeds the kind, and a kind change rebuilds
+  assert.match(RENDER, /provisional: isProvisionalId\(id\), provisionalFailed: failedProvisionals\.has\(id\) \}\);/);
+  assert.match(PLACEHOLDER, /if \(st\.provisional && st\.provisionalFailed\) return "start-failed";\s*\n\s*if \(st\.provisional\) return "starting";/);
   // …and its composer stays LIVE despite the closed-tab treatment, so the text is editable/copyable
   assert.match(RENDER, /const closed = s\.status\.state === "closed" && !failedProvisionals\.has\(activeId!\);/);
 });
@@ -166,9 +170,10 @@ test("the folder question retires the tab and holds what was typed for the retry
 });
 
 test("a starting tab shows the romp loader, not the 'No messages yet' placeholder", () => {
-  assert.match(RENDER, /\} else if \(isProvisionalId\(id\)\) \{\s*\n\s*ph\.classList\.add\("tx-starting"\);/);
+  assert.match(PLACEHOLDER, /case "starting": \{[\s\S]{0,400}?ph\.classList\.add\("tx-starting"\);/);   // the placeholder by kind (pane-placeholder.ts, T355)
   assert.match(RENDER, /romp-swirl-glyph\.svg/);
-  assert.match(RENDER, /"Starting " \+ s\.name \+ "… you can type now; romp sends it when it's up\."/);
+  assert.match(PLACEHOLDER, /"Starting " \+ ctx\.text\.sessionName \+ "… you can type now; romp sends it when it's up\."/);
+  assert.match(RENDER, /sessionName: s\.name \},/);
   assert.match(CSS, /\.tx-starting-swirl \{[\s\S]*?animation: tx-starting-spin/);
   assert.match(CSS, /prefers-reduced-motion: reduce\) \{ \.tx-starting-swirl \{ animation: none/);
   assert.doesNotMatch(CSS, /opening-dots/, "the bouncing-dots modal CSS went with it");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -20,7 +20,8 @@ import { ctxFallbackColor, pickTone, readableRgb } from "./ctx-color";
 import { applyTheme } from "./theme";
 import { applyDenseChrome } from "./dense-chrome";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
-import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore } from "./chat-window";   // the uuid-anchored wire (T323 stage 4b)
+import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore } from "./chat-window";
+import { SUBAGENT_OPEN_WAIT_MS, subagentStallText, subagentStalled } from "./subagent-wait";   // the viewer's wait bound and its stall (T355)   // the uuid-anchored wire (T323 stage 4b)
 import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
 import { lensVisible, surfaceLens } from "./tag-lens";
 import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
@@ -330,7 +331,8 @@ interface Session { id: string; name: string; color: Color | null; events: ChatE
 // agent's own transcript, fed by {type:"subagent"} frames. Client-only — the kernel never lists it in
 // tabOrder (reconcileTabOrder keeps a known, never-kernel-seen id), so it lives exactly as long as the
 // viewer. anchorUuid = the parent's Agent tool head, for the header's link back.
-interface SubInfo { parentId: string; agentId: string; meta: SubMeta | null; running: boolean; truncated: boolean; error: string | null; loaded: boolean; anchorUuid: string | null; }
+interface SubInfo { parentId: string; agentId: string; meta: SubMeta | null; running: boolean; truncated: boolean; error: string | null; loaded: boolean; anchorUuid: string | null;
+                    stalled?: boolean; askedAt?: number; }   // stalled: the ask went unanswered past SUBAGENT_OPEN_WAIT_MS (T355)
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -10886,6 +10888,13 @@ function syncViewInner(id: string, atBottom?: boolean): View {
         // the kernel could not open the agent's file: its sentence, loud, in the pane (never a blank)
         ph.textContent = s.sub.error;
         ph.classList.add("tx-revive-failed");
+      } else if (s.sub && !s.sub.loaded && s.sub.stalled) {
+        // the ask went unanswered past the wait (T355): say so and offer the retry, never a loader for good
+        ph.textContent = subagentStallText();
+        ph.classList.add("tx-revive-failed");
+        const retry = document.createElement("button"); retry.className = "picker-action confirm-btn"; retry.type = "button";
+        retry.textContent = "Retry"; retry.onclick = () => askSubagent(id);
+        ph.appendChild(document.createElement("br")); ph.appendChild(retry);
       } else if (s.sub && !s.sub.loaded) {
         // the viewer's first frame is in flight → the romp loader holds the pane (the wait-state rule)
         ph.classList.add("tx-starting");
@@ -12901,9 +12910,39 @@ function openSubagentView(parentId: string, agentId: string, anchorUuid: string 
     });
     if (!order.includes(id)) order.push(id);
     vscodeApi?.postMessage({ type: "openSubagent", id: parentId, agentId });
+    armSubagentWait(id);   // the frame is expected within SUBAGENT_OPEN_WAIT_MS (T355)
   } else if (anchorUuid && cur.sub) cur.sub.anchorUuid = anchorUuid;
   setActive(id);
 }
+
+// The viewer's ask, with its wait (T355): the frame is expected on this socket within SUBAGENT_OPEN_WAIT_MS; past that the
+// pane shows the stall and a retry in place of the loader (a frame that never arrives left "opening…" up for good).
+function askSubagent(id: string): void {
+  const s = sessions.get(id);
+  if (!s || !s.sub) return;
+  vscodeApi?.postMessage({ type: "openSubagent", id: s.sub.parentId, agentId: s.sub.agentId });
+  armSubagentWait(id);
+}
+function armSubagentWait(id: string): void {
+  const s = sessions.get(id);
+  if (!s || !s.sub) return;
+  const p = s.sub;
+  p.loaded = false; p.stalled = false; p.askedAt = Date.now();
+  const asked = p.askedAt;
+  window.setTimeout(() => {
+    const cur = sessions.get(id);
+    if (!cur || !cur.sub || cur.sub.askedAt !== asked) return;   // answered, retried or closed meanwhile
+    if (!subagentStalled(cur.sub.loaded, Date.now() - asked)) return;
+    cur.sub.stalled = true;
+    const v = views.get(id);
+    if (v) { v.rendered = 0; v.stale = true; }
+    if (activeId === id) showActive();
+  }, SUBAGENT_OPEN_WAIT_MS);
+}
+// A socket coming back: the reconnected kernel holds no viewer registry for this client, so every open viewer asks again
+// (a frame lost to a restart between the ask and its answer arrives on the retry; the frames the agent's file changes
+// bring keep coming afterwards). The asks are bookkeeping: the pane shows what it holds meanwhile.
+window.addEventListener("romp:wsup", () => { for (const [id, s] of sessions) if (s.sub) askSubagent(id); });
 
 function closeSubagentView(id: string): void {
   const p = subParts(id);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -21,7 +21,8 @@ import { applyTheme } from "./theme";
 import { applyDenseChrome } from "./dense-chrome";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
 import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore } from "./chat-window";
-import { SUBAGENT_OPEN_WAIT_MS, subagentStallText, subagentStalled } from "./subagent-wait";   // the viewer's wait bound and its stall (T355)   // the uuid-anchored wire (T323 stage 4b)
+import { SUBAGENT_OPEN_WAIT_MS, subagentStallText, subagentStalled } from "./subagent-wait";   // the viewer's wait bound and its stall (T355)
+import { placeholderKind, placeholderStands, fillPlaceholder } from "./pane-placeholder";   // the empty pane's placeholder, by kind (T355)   // the uuid-anchored wire (T323 stage 4b)
 import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
 import { lensVisible, surfaceLens } from "./tag-lens";
 import { openTagMenu, tagMenuButton, syncTagFilter, tagChip } from "./tag-menu";
@@ -10871,47 +10872,20 @@ function syncViewInner(id: string, atBottom?: boolean): View {
   // (the user 2026-06-19). Idempotent: leaves an existing placeholder in place; the first real event clears it.
   if (s.events.length === 0) {
     const only = v.el.childNodes.length === 1 ? (v.el.firstChild as HTMLElement) : null;
-    // …and rebuild a placeholder whose STARTING loader outlived its create (the failure flips it to
-    // the couldn't-start notice below — the spinning loader would be a lie on a failed tab)
-    const staleStart = !!only && only.classList?.contains("tx-starting") && failedProvisionals.has(id);
-    if (!only || !only.classList?.contains("tx-empty") || staleStart) {
+    // The placeholder is rebuilt when its KIND changes (pane-placeholder.ts): a viewer's loader gives way to the kernel's
+    // error sentence, the stall past the wait, or "written nothing yet"; a starting tab's loader to the couldn't-start
+    // notice (its create failed); the same kind twice is left alone (no churn on repeated pushes that stay empty).
+    const kind = placeholderKind({ sub: s.sub, failedRevive: failedRevives.get(id) || null,
+                                   provisional: isProvisionalId(id), provisionalFailed: failedProvisionals.has(id) });
+    if (!only || !only.classList?.contains("tx-empty") || !placeholderStands(only, kind)) {
       while (v.el.firstChild) v.el.removeChild(v.el.firstChild);
       const ph = el("div", "tx-empty"); v.el.appendChild(ph);
-      // A PROVISIONAL tab is not empty, it is STARTING — so it wears the romp loader (the repo's rule for
-      // any wait), not the placeholder that tells you to send something. The composer below it is live
-      // either way: anything typed here is held and flushed when the session lands. A FAILED create's
-      // tab says what happened instead (the user 2026-08-08) — the loader would be a lie.
-      if (failedRevives.has(id)) {
-        ph.textContent = failedRevives.get(id) || "";
-        ph.classList.add("tx-revive-failed");
-      } else if (s.sub && s.sub.error) {
-        // the kernel could not open the agent's file: its sentence, loud, in the pane (never a blank)
-        ph.textContent = s.sub.error;
-        ph.classList.add("tx-revive-failed");
-      } else if (s.sub && !s.sub.loaded && s.sub.stalled) {
-        // the ask went unanswered past the wait (T355): say so and offer the retry, never a loader for good
-        ph.textContent = subagentStallText();
-        ph.classList.add("tx-revive-failed");
-        const retry = document.createElement("button"); retry.className = "picker-action confirm-btn"; retry.type = "button";
-        retry.textContent = "Retry"; retry.onclick = () => askSubagent(id);
-        ph.appendChild(document.createElement("br")); ph.appendChild(retry);
-      } else if (s.sub && !s.sub.loaded) {
-        // the viewer's first frame is in flight → the romp loader holds the pane (the wait-state rule)
-        ph.classList.add("tx-starting");
-        ph.appendChild(rompLoaderInner("opening the agent's transcript…"));
-      } else if (s.sub) {
-        ph.textContent = "This agent has written nothing yet.";
-      } else if (isProvisionalId(id) && failedProvisionals.has(id)) {
-        ph.textContent = "This session couldn't start. What you typed is kept in the box below; "
-          + "✕ on the tab discards both.";
-      } else if (isProvisionalId(id)) {
-        ph.classList.add("tx-starting");
-        const sw = el("img", "tx-starting-swirl") as HTMLImageElement;
-        sw.src = mediaSrc("romp-swirl-glyph.svg"); sw.alt = ""; sw.onerror = () => sw.remove();
-        const wm = el("div", "tx-starting-msg");
-        wm.textContent = "Starting " + s.name + "… you can type now; romp sends it when it's up.";
-        ph.append(sw, wm);
-      } else ph.textContent = "No messages yet.";
+      fillPlaceholder(ph, kind, {
+        el, loader: rompLoaderInner, button: () => document.createElement("button"), br: () => document.createElement("br"),
+        swirl: () => { const sw = el("img", "tx-starting-swirl") as HTMLImageElement; sw.src = mediaSrc("romp-swirl-glyph.svg"); sw.alt = ""; sw.onerror = () => sw.remove(); return sw; },
+        text: { error: s.sub?.error, failedRevive: failedRevives.get(id), stall: subagentStallText(), sessionName: s.name },
+        onRetry: () => askSubagent(id),
+      });
     }
     v.rendered = 0; v.stale = false; v.winStart = 0; v.winEnd = 0;
     return v;
@@ -12939,10 +12913,16 @@ function armSubagentWait(id: string): void {
     if (activeId === id) showActive();
   }, SUBAGENT_OPEN_WAIT_MS);
 }
-// A socket coming back: the reconnected kernel holds no viewer registry for this client, so every open viewer asks again
-// (a frame lost to a restart between the ask and its answer arrives on the retry; the frames the agent's file changes
-// bring keep coming afterwards). The asks are bookkeeping: the pane shows what it holds meanwhile.
-window.addEventListener("romp:wsup", () => { for (const [id, s] of sessions) if (s.sub) askSubagent(id); });
+// A connection coming back: the reconnected kernel holds no viewer registry for this client, so every viewer STILL WAITING
+// (no frame yet, or stalled) asks again; a viewer that has its answer keeps it (a re-ask would put the loader back over
+// "written nothing yet"). The reconnect-class events this pane can see: the local socket's romp:wsup, a remote host's relay
+// socket reopening (romp:hostRelayUp: a remote kernel's restart fires that and not wsup, the 2026-09-01 finding the upload
+// re-ship records), and the extension's pipeState up (the VS Code webview never sees wsup).
+function reaskWaitingSubagents(): void {
+  for (const [id, s] of sessions) if (s.sub && (!s.sub.loaded || s.sub.stalled)) askSubagent(id);
+}
+window.addEventListener("romp:wsup", () => reaskWaitingSubagents());
+window.addEventListener("romp:hostRelayUp", () => reaskWaitingSubagents());
 
 function closeSubagentView(id: string): void {
   const p = subParts(id);
@@ -16782,6 +16762,7 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
     return;
   }
   // the pipe's down edge is the VS Code twin of the shim's romp:wsdown: unconfirmed sends say so (markPendingLost)
+  if (m.type === "pipeState" && m.up) reaskWaitingSubagents();   // the extension's reconnect-class event (it never sees romp:wsup), T355
   if (m.type === "pipeState") { if (!m.up) markPendingLost("connection"); pipeBanner(!!m.up, Number(m.queued) || 0); return; }
   // any kernel message proves the kernel is reachable again — heal previews whose fetch died in a
   // restart window (preview.ts retryFailedPreviews; a no-op when nothing failed). federation's

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -12921,11 +12921,12 @@ function armSubagentWait(id: string): void {
 // "written nothing yet"). The reconnect-class events this pane can see: the local socket's romp:wsup, a remote host's relay
 // socket reopening (romp:hostRelayUp: a remote kernel's restart fires that and not wsup, the 2026-09-01 finding the upload
 // re-ship records), and the extension's pipeState up (the VS Code webview never sees wsup).
-function reaskWaitingSubagents(): void {
-  for (const [id, s] of sessions) if (s.sub && (!s.sub.loaded || s.sub.stalled)) askSubagent(id);
+function reaskWaitingSubagents(host?: string): void {
+  for (const [id, s] of sessions)
+    if (s.sub && (!s.sub.loaded || s.sub.stalled) && (host === undefined || hostOf(s.sub.parentId) === host)) askSubagent(id);
 }
-window.addEventListener("romp:wsup", () => reaskWaitingSubagents());
-window.addEventListener("romp:hostRelayUp", () => reaskWaitingSubagents());
+window.addEventListener("romp:wsup", () => reaskWaitingSubagents(""));   // the local kernel's own viewers (a host's relay
+//                                                                            reopening re-asks in the romp:hostRelayUp listener below)
 
 function closeSubagentView(id: string): void {
   const p = subParts(id);
@@ -12951,7 +12952,7 @@ function applySubagentFrame(m: any): void {
   const id = subTabId(parentId, agentId);
   const s = sessions.get(id);
   if (!s || !s.sub) { vscodeApi?.postMessage({ type: "closeSubagent", id: parentId, agentId }); return; }
-  s.sub.loaded = true;
+  s.sub.loaded = true; s.sub.stalled = false;   // answered, late or not: no re-ask puts the loader back over it (T355)
   s.sub.error = m.error ? String(m.error) : null;
   s.sub.running = !!m.running;
   s.sub.truncated = !!m.truncated;
@@ -14772,6 +14773,7 @@ window.addEventListener("romp:hostRelayUp", (e) => {
   // event a remote kernel's restart produces (it fires neither romp:wsup nor hostUp), so settled previews
   // make their one attempt here as well
   refreshSettledPreviews();
+  reaskWaitingSubagents(h || undefined);   // …and that host's subagent viewers still waiting ask again (T355: a remote kernel's restart)
   // …and the tab this pane is LOOKING AT, when that host owns it (T246, the user 2026-09-07): the relay's
   // open is the moment the remote kernel holds a FRESH client for this pane — after that kernel restarted,
   // one with no active tab at all. Its pusher builds and flushes a client's active tab first; every tab is

--- a/ui/webview/revive-loader.test.ts
+++ b/ui/webview/revive-loader.test.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PLACEHOLDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "pane-placeholder.ts"), "utf8");   // the empty pane's placeholder, by kind (T355)
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("the Revive click acknowledges at once: post reviveSession AND show the loader", () => {
@@ -59,7 +60,9 @@ test("failure is loud AND pane-local: named error in the session's placeholder +
   assert.match(RENDER, /failedRevives\.set\(id, msg\);/);
   assert.match(RENDER, /warnToast\(msg\);/, "the warn-toast family — dismissible (✕ / Esc), never window-blocking");
   // the session's own pane says it: the empty-transcript placeholder wears the named failure
-  assert.match(RENDER, /if \(failedRevives\.has\(id\)\) \{\s*\n\s*ph\.textContent = failedRevives\.get\(id\) \|\| "";\s*\n\s*ph\.classList\.add\("tx-revive-failed"\);/);
+  assert.match(RENDER, /failedRevive: failedRevives\.get\(id\) \|\| null,/, "the failed revive decides the placeholder's kind first (pane-placeholder.ts, T355)");
+  assert.match(PLACEHOLDER, /if \(st\.failedRevive\) return "revive-failed";/);
+  assert.match(PLACEHOLDER, /case "revive-failed":\s*\n\s*ph\.textContent = ctx\.text\.failedRevive \|\| "";\s*\n\s*ph\.classList\.add\("tx-revive-failed"\);/);
   assert.match(CSS, /\.tx-empty\.tx-revive-failed \{ color: var\(--vscode-errorForeground, #f48771\); \}/);
   // a fresh revive attempt clears the parked failure — the gesture beats the stale verdict
   assert.match(RENDER, /failedRevives\.delete\(id\);/);

--- a/ui/webview/subagent-view.test.ts
+++ b/ui/webview/subagent-view.test.ts
@@ -11,6 +11,7 @@ import * as path from "node:path";
 import { subTabId, isSubId, subParts, subLabel, gistLines, stepLines, stepsNote, agentFoldLabel, elapsedSince, subHeadParts, openIconSvg, pinIconSvg, SUB_SEP, PREVIEW_ROWS } from "../../ui/webview/subagent-view";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PLACEHOLDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "pane-placeholder.ts"), "utf8");   // the empty pane's placeholder, by kind (T355)
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 // ── the pure module ─────────────────────────────────────────────────────────────────────────────
@@ -219,8 +220,12 @@ test("frames: events replace in place through appendActive (the chat's scroll ru
   // a frame for a viewer that is gone tells the kernel to stop pushing
   assert.match(RENDER, /if \(!s \|\| !s\.sub\) \{ vscodeApi\?\.postMessage\(\{ type: "closeSubagent", id: parentId, agentId \}\); return; \}/);
   // the empty-transcript placeholder: error sentence (loud), else the romp loader until the first frame
-  assert.match(RENDER, /\} else if \(s\.sub && s\.sub\.error\) \{[\s\S]{0,200}?ph\.textContent = s\.sub\.error;/);
-  assert.match(RENDER, /\} else if \(s\.sub && !s\.sub\.loaded\) \{[\s\S]{0,300}?ph\.appendChild\(rompLoaderInner\("opening the agent's transcript…"\)\);/);
+  // the placeholder by kind (pane-placeholder.ts, T355): the error sentence, the loader while the frame is in flight
+  assert.match(PLACEHOLDER, /if \(st\.sub\.error\) return "sub-error";[\s\S]{0,200}?if \(!st\.sub\.loaded\) return "sub-loading";/);
+  assert.match(PLACEHOLDER, /case "sub-error":[\s\S]{0,200}?ph\.textContent = ctx\.text\.error \|\| "";/);
+  assert.match(PLACEHOLDER, /case "sub-loading":[\s\S]{0,300}?ph\.appendChild\(ctx\.loader\("opening the agent's transcript…"\)\);/);
+  assert.match(RENDER, /text: \{ error: s\.sub\?\.error, failedRevive: failedRevives\.get\(id\), stall: subagentStallText\(\), sessionName: s\.name \},/);
+  assert.match(RENDER, /el, loader: rompLoaderInner, button: \(\) => document\.createElement\("button"\)/);
   // file/preview URLs bake the PARENT's id for a viewer
   assert.match(RENDER, /const subOf = subParts\(id\);\s*\n\s*if \(subOf\) renderingOwnerSid = subOf\.parentId;/);
 });

--- a/ui/webview/subagent-wait.test.ts
+++ b/ui/webview/subagent-wait.test.ts
@@ -25,7 +25,9 @@ test("render.ts asks through askSubagent with the wait armed, re-asks every open
   assert.ok(ask.includes("}, SUBAGENT_OPEN_WAIT_MS);"), "one timer per ask, the module's bound");
   assert.ok(ask.includes("if (!subagentStalled(cur.sub.loaded, Date.now() - asked)) return;"), "the rule decides");
   assert.ok(ask.includes("cur.sub.askedAt !== asked) return;"), "a later ask or a close disarms the earlier timer");
-  assert.ok(RENDER.includes('window.addEventListener("romp:wsup", () => reaskWaitingSubagents());'), "a reconnect re-asks the waiting viewers");
+  assert.ok(RENDER.includes('window.addEventListener("romp:wsup", () => reaskWaitingSubagents(""));'), "a reconnect re-asks the local kernel's waiting viewers");
+  assert.ok(RENDER.includes("reaskWaitingSubagents(h || undefined);") && RENDER.includes('(host === undefined || hostOf(s.sub.parentId) === host)'), "a relay's reopen re-asks that host's viewers alone");
+  assert.ok(RENDER.includes("s.sub.loaded = true; s.sub.stalled = false;"), "a frame clears the stall: an answered viewer is never re-asked");
   assert.ok(RENDER.includes("onRetry: () => askSubagent(id),"), "the stall's Retry asks through the same ask (pane-placeholder.test.ts drives the DOM)");
 });
 

--- a/ui/webview/subagent-wait.test.ts
+++ b/ui/webview/subagent-wait.test.ts
@@ -1,0 +1,43 @@
+// The subagent viewer's wait and retry (T355), executed, and the federated route of its ask and its frame.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { SUBAGENT_OPEN_WAIT_MS, subagentStallText, subagentStalled } from "./subagent-wait";
+import { routeOutbound, prefixInbound } from "./federation";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const U = "11111111-2222-3333-4444-555555555555";
+
+test("a viewer stalls only past the wait and only while no frame landed; the text names the bound and the causes", () => {
+  assert.equal(SUBAGENT_OPEN_WAIT_MS, 15000, "the relay handshake's own bound (REMOTE_CONNECT_MS)");
+  assert.equal(subagentStalled(false, 14999), false);
+  assert.equal(subagentStalled(false, 15000), true);
+  assert.equal(subagentStalled(true, 60000), false, "a frame landed: never a stall");
+  assert.match(subagentStallText(), /15 seconds/); assert.match(subagentStallText(), /restarted/); assert.match(subagentStallText(), /host dropped/);
+});
+
+test("render.ts asks through askSubagent with the wait armed, re-asks every open viewer when the socket comes back, and paints the stall with a retry", () => {
+  const open = RENDER.slice(RENDER.indexOf("function openSubagentView("), RENDER.indexOf("function askSubagent(id: string): void {"));
+  assert.ok(open.includes('vscodeApi?.postMessage({ type: "openSubagent", id: parentId, agentId });\n    armSubagentWait(id);'), "the first open asks and arms the wait");
+  const ask = RENDER.slice(RENDER.indexOf("function askSubagent(id: string): void {"), RENDER.indexOf("function closeSubagentView("));
+  assert.ok(ask.includes('vscodeApi?.postMessage({ type: "openSubagent", id: s.sub.parentId, agentId: s.sub.agentId });\n  armSubagentWait(id);'), "a retry or a reconnect asks and arms the same wait");
+  assert.ok(ask.includes("}, SUBAGENT_OPEN_WAIT_MS);"), "one timer per ask, the module's bound");
+  assert.ok(ask.includes("if (!subagentStalled(cur.sub.loaded, Date.now() - asked)) return;"), "the rule decides");
+  assert.ok(ask.includes("cur.sub.askedAt !== asked) return;"), "a later ask or a close disarms the earlier timer");
+  assert.ok(RENDER.includes('window.addEventListener("romp:wsup", () => { for (const [id, s] of sessions) if (s.sub) askSubagent(id); });'), "a reconnect re-asks every open viewer");
+  const ph = RENDER.slice(RENDER.indexOf("} else if (s.sub && !s.sub.loaded && s.sub.stalled) {"), RENDER.indexOf("} else if (s.sub && !s.sub.loaded) {"));
+  assert.ok(ph.includes("ph.textContent = subagentStallText();") && ph.includes('retry.textContent = "Retry"; retry.onclick = () => askSubagent(id);'), "the stall replaces the loader and retries through the same ask");
+});
+
+test("the ask and its frame cross the federation by the session id's host: the ask bared for the owning kernel, the frame prefixed for the page", () => {
+  const ask = routeOutbound({ type: "openSubagent", id: "gpu1:" + U, agentId: "a1111111111111111" }, new Set(["gpu1"]));
+  assert.deepEqual(ask, [{ host: "gpu1", msg: { type: "openSubagent", id: U, agentId: "a1111111111111111" } }]);
+  const close = routeOutbound({ type: "closeSubagent", id: "gpu1:" + U, agentId: "a1111111111111111" }, new Set(["gpu1"]));
+  assert.equal(close[0].host, "gpu1"); assert.equal(close[0].msg.id, U);
+  const frame = prefixInbound("gpu1", { type: "subagent", id: U, agentId: "a1111111111111111", events: [], meta: { agentType: "workflow" } });
+  assert.equal(frame.id, "gpu1:" + U, "the frame lands on the viewer keyed by the prefixed parent id");
+  assert.equal(frame.agentId, "a1111111111111111", "the agent id is not a session id: untouched");
+  const err = prefixInbound("gpu1", { type: "subagent", id: U, agentId: "a1111111111111111", error: "missing" });
+  assert.equal(err.id, "gpu1:" + U); assert.equal(err.error, "missing");
+});

--- a/ui/webview/subagent-wait.test.ts
+++ b/ui/webview/subagent-wait.test.ts
@@ -25,9 +25,8 @@ test("render.ts asks through askSubagent with the wait armed, re-asks every open
   assert.ok(ask.includes("}, SUBAGENT_OPEN_WAIT_MS);"), "one timer per ask, the module's bound");
   assert.ok(ask.includes("if (!subagentStalled(cur.sub.loaded, Date.now() - asked)) return;"), "the rule decides");
   assert.ok(ask.includes("cur.sub.askedAt !== asked) return;"), "a later ask or a close disarms the earlier timer");
-  assert.ok(RENDER.includes('window.addEventListener("romp:wsup", () => { for (const [id, s] of sessions) if (s.sub) askSubagent(id); });'), "a reconnect re-asks every open viewer");
-  const ph = RENDER.slice(RENDER.indexOf("} else if (s.sub && !s.sub.loaded && s.sub.stalled) {"), RENDER.indexOf("} else if (s.sub && !s.sub.loaded) {"));
-  assert.ok(ph.includes("ph.textContent = subagentStallText();") && ph.includes('retry.textContent = "Retry"; retry.onclick = () => askSubagent(id);'), "the stall replaces the loader and retries through the same ask");
+  assert.ok(RENDER.includes('window.addEventListener("romp:wsup", () => reaskWaitingSubagents());'), "a reconnect re-asks the waiting viewers");
+  assert.ok(RENDER.includes("onRetry: () => askSubagent(id),"), "the stall's Retry asks through the same ask (pane-placeholder.test.ts drives the DOM)");
 });
 
 test("the ask and its frame cross the federation by the session id's host: the ask bared for the owning kernel, the frame prefixed for the page", () => {

--- a/ui/webview/subagent-wait.ts
+++ b/ui/webview/subagent-wait.ts
@@ -1,0 +1,19 @@
+// The subagent viewer's wait (T355, the user 2026-09-11: a workflow agent's transcript "stuck loading forever"). The
+// viewer asks the kernel for the agent's frame once and paints the loader until it lands; a frame that never comes (the
+// kernel restarted between the ask and its answer, the relay socket to the agent's host dropped) left the loader up for
+// good, with nothing to press. After SUBAGENT_OPEN_WAIT_MS with no frame the pane says so and offers a retry; every open
+// viewer asks again when the socket comes back (the reconnected kernel holds no viewer registry for this client).
+// The bound: the kernel answers an open synchronously on the socket thread, so a local answer takes the frame's build
+// (well under a second for a capped tail) and a relayed one adds the relay's handshake, whose own bound is fifteen
+// seconds (REMOTE_CONNECT_MS in federation.ts); past that the frame is not coming on this socket.
+export const SUBAGENT_OPEN_WAIT_MS = 15000;
+
+export function subagentStallText(seconds: number = SUBAGENT_OPEN_WAIT_MS / 1000): string {
+  return "The agent's transcript has not arrived after " + seconds + " seconds. The kernel may have restarted, or the " +
+         "connection to its host dropped.";
+}
+
+/** Whether a viewer whose ask went out `sinceMs` ago with no frame should show the stall instead of the loader. */
+export function subagentStalled(loaded: boolean, sinceMs: number, waitMs: number = SUBAGENT_OPEN_WAIT_MS): boolean {
+  return !loaded && sinceMs >= waitMs;
+}

--- a/ui/webview/transcript-empty.test.ts
+++ b/ui/webview/transcript-empty.test.ts
@@ -9,6 +9,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const PLACEHOLDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "pane-placeholder.ts"), "utf8");   // the empty pane's placeholder, by kind (T355)
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("syncView shows a 'No messages yet.' placeholder for a zero-event transcript", () => {
@@ -18,7 +19,8 @@ test("syncView shows a 'No messages yet.' placeholder for a zero-event transcrip
   // (2026-07-30: a PROVISIONAL tab takes the romp loader instead — it is not empty, it is starting —
   // so the placeholder text moved to the else branch. A real empty transcript reads exactly as before.)
   assert.match(RENDER, /el\("div", "tx-empty"\); v\.el\.appendChild\(ph\);/);
-  assert.match(RENDER, /\} else ph\.textContent = "No messages yet\.";/);
+  assert.match(PLACEHOLDER, /default:\s*\n\s*ph\.textContent = "No messages yet\.";/);   // the placeholder by kind (pane-placeholder.ts, T355)
+  assert.match(PLACEHOLDER, /return "empty";/);
   // idempotent: an already-present placeholder is left alone (no churn on repeated pushes that stay empty)
   assert.match(RENDER, /only\.classList\?\.contains\("tx-empty"\)/);
 });


### PR DESCRIPTION
Opening a WORKFLOW subagent's transcript from the dashboard hung (the user, 2026-09-11, a laptop session whose earlier window had run the workflow; the history was cleared since).

**Finding.** Three faults, two on the client. On the kernel, the viewer's file lookup read `subagents/agent-<id>.jsonl` and the sibling-fsid glob at the same depth only, while Claude Code 2.1.261 writes a workflow agent's file and sidecar one level down at `subagents/workflows/wf_<id>/agent-<id>.jsonl`; the sidecar map read the flat directory too. So a workflow agent's open answered the frame "The transcript file for agent … is missing beside this session's transcript (subagents/agent-….jsonl), so it can't be shown." and the pane showed that sentence, while the parent's Agent card never learned the agent's id from its sidecar (the background launch's ack still names it, which is how the open button existed at all). On the client, the viewer asked once and painted "opening the agent's transcript…" until a frame landed; a frame that never came (that morning both kernels restarted several times between 9:10 and 10:12 AM Pacific: an ask sent to a kernel that restarted before answering, or across a relay socket that dropped, is answered by nothing, and the reconnected kernel holds no viewer registry for the client, so no later push brings it either) left the loader up for good with nothing to press. The third, and the one that explains the endless loader even with both kernels up: the pane rebuilt its placeholder only when its single child was not a placeholder at all, and the loader painted at the viewer's open is one, so neither the kernel's error sentence nor any later state ever replaced it. The "stuck loading forever" the user saw is the third fault whatever the kernel answered; the first is what they would have read once the pane repainted.

**Fix.**
- `_subagent_file` resolves the agent's file one level or deeper under the session's own `subagents/` (the same symlink-free walk `_subagent_transcripts` uses), then under a sibling fsid's tree (a `/clear` fork moves the directory); `_subagent_meta` reads the sidecar beside the file found; `_subagent_meta_map` lists nested sidecars too (cached on every walked directory's mtime), so the Agent card's id join and the awaiting rows see workflow agents.
- The viewer's ask (`askSubagent`) arms a wait of fifteen seconds (the relay handshake's own bound, `REMOTE_CONNECT_MS`: a local answer is the frame's build, a relayed one adds the handshake; past that the frame is not coming on this socket); when it passes with no frame the pane replaces the loader with the sentence naming the bound and the causes and a Retry that asks again; every open viewer asks again when the socket comes back, so a restart mid-request completes on the reconnect. An error frame already replaced the loader with its sentence (kept).
- The pane's placeholder is decided by KIND from the session's state (`pane-placeholder.ts`: a failed revive, the agent's error, the stall, the loader, an agent that wrote nothing, a starting tab, its failed create, an empty session), stamped on the element, and rebuilt when the kind changes; the same kind twice is left standing.
- The agent file's resolution is memoized per (parent transcript, agent) on the subagents directories' and the project directory's mtimes, and the sidecar read takes the path already found: the pusher's per-cycle re-send of an open viewer costs a few stats, not two walks of the tree. The re-ask fires on the local socket's `romp:wsup`, a remote host's relay reopening (`romp:hostRelayUp`, what a remote kernel's restart produces) and the extension's `pipeState` up, and only for viewers still waiting. A symlink at the flat depth is not taken, a symlinked `subagents/` is not listed, and the spend rebuild walks the lanes at any depth (a workflow agent's lane was missed by the recount too).
- The feed opens no viewer of its own (its awaiting rows link to the chat's Agent card); the card's id join is what the nested sidecar map fixes.

**Tests.** `ui/webview/pane-placeholder.test.ts` drives the placeholder on a stub DOM: the loader gives way to the stall with its Retry, to the error sentence and to "written nothing yet" as the kind changes, the same kind stands, the Retry asks again, the loader at open gives way straight to an error frame; `tests/test_spend_rebuild.py` counts a nested workflow lane. `tests/test_subagent_transcripts.py` `NestedWorkflowAgent`: the nested file, sidecar and sidecar map resolve and the viewer renders the agent through the chat pipeline; the socket arm answers a nested agent's open with its events (the frame the pane shows); the nested file under a forked fsid; a symlinked directory or file is neither followed nor taken. `ui/webview/subagent-wait.test.ts`: the stall rule and text executed, the wiring pinned (one timer per ask, a later ask disarms it, the reconnect re-asks every viewer, the stall replaces the loader with a Retry), and the federated route executed (`openSubagent`/`closeSubagent` bared for the owning kernel, the frame's parent id prefixed for the page, the agent id untouched).

Tier: fix.
