### PR TITLE
The kernel's size is sampled over each life, the boot has a regression tripwire, and a script reads the restart phases and the samples

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -21814,6 +21814,51 @@ def _audit_parent_gone(manager_pid, now=None):
 
 
 RESTART_CUTS_FILE = jd.STATE / "restart-cuts.jsonl"
+KERNEL_SAMPLES_FILE = jd.STATE / "kernel-samples.jsonl"   # the kernel's own size over each life (the performance metrics, 2026-09-11)
+KERNEL_SAMPLE_MARKS_S = (300.0, 1800.0, 3600.0)          # samples at 5, 30 and 60 minutes of uptime, then every hour
+_KERNEL_SAMPLES_TAKEN = []                                # the uptimes sampled this life, in order
+
+
+def _kernel_sample_due(uptime_s):
+    """The next sample mark this life has not taken yet, or None: the fixed marks first, then each whole hour."""
+    taken = len(_KERNEL_SAMPLES_TAKEN)
+    if taken < len(KERNEL_SAMPLE_MARKS_S):
+        mark = KERNEL_SAMPLE_MARKS_S[taken]
+    else:
+        mark = 3600.0 * (taken - len(KERNEL_SAMPLE_MARKS_S) + 2)
+    return mark if uptime_s >= mark else None
+
+
+def _kernel_sample_tick(now=None):
+    """The pusher's tick: at 5, 30 and 60 minutes of uptime and every hour after, one row in kernel-samples.jsonl with
+    the kernel's resident size, processor seconds, thread count and the record cache's held bytes (when the event model
+    reports them), so the kernel's growth within a life is a series beside the restart ledger's two bookends and a
+    change that lets it climb again shows in the file, not in the machine's swap. Best-effort; never raises."""
+    try:
+        now = time.time() if now is None else now
+        up = now - _STARTED
+        mark = _kernel_sample_due(up)
+        if mark is None:
+            return False
+        _KERNEL_SAMPLES_TAKEN.append(mark)
+        row = {"t": int(now), "pid": os.getpid(), "uptimeS": round(up, 1), "markS": mark}
+        try:
+            ps = _process_stats()
+            row.update({"rssKb": int(ps.get("rss_kb") or 0), "cpuS": round(float(ps.get("cpu_s") or 0.0), 2), "threads": int(ps.get("threads") or 0)})
+        except Exception:
+            pass
+        rc = getattr(em, "record_cache_stats", None)
+        if rc is not None:
+            try:
+                st = rc()
+                row["recordCacheBytes"] = int(st.get("bytes") or 0); row["recordCacheEntries"] = int(st.get("entries") or 0)
+            except Exception:
+                pass
+        with open(KERNEL_SAMPLES_FILE, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, separators=(",", ":")) + "\n")
+        return True
+    except Exception:
+        return False
 
 
 EXIT_ASM_BUDGET_S = float(os.environ.get("ROMP_EXIT_ASM_BUDGET_S", "1.5"))   # the exit's assembly-document writes, bounded
@@ -46310,6 +46355,10 @@ def _pusher_cycle_jobs(now, live_map, any_client):
         sys.stderr.write("checkpoints: %s\n" % traceback.format_exc())
     try:                                  # the boot row's backstop: written without attachDone once the bound has passed
         _boot_row_backstop(now)
+    except Exception:
+        pass
+    try:                                  # the kernel's own size at 5, 30 and 60 minutes and every hour (kernel-samples.jsonl)
+        _kernel_sample_tick(now)
     except Exception:
         pass
     try:                                  # hitting a usage limit auto-engages the retry-pause (before the resume check)

--- a/scripts/perf/restart-phases.py
+++ b/scripts/perf/restart-phases.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""The kernel's restart phases and its size over each life, from the ledgers romp already writes.
+
+    scripts/perf/restart-phases.py [--state DIR] [--last N] [--json]
+
+Reads restart-cuts.jsonl (one cut row per exit, one boot row per start) and kernel-samples.jsonl (the kernel's size at
+5, 30 and 60 minutes of uptime and every hour after) under the state directory, pairs each cut with the boot that
+followed it, and prints per restart: the exit's checkpoint writes (ckptS) and the sessions' close (drainS), the gap
+from the cut to the next kernel serving (outageS), the new kernel's census (censusS) and last attach (attachS)
+relative to its first serve, the turns the cut interrupted, and the old kernel's resident size at its exit; then,
+per kernel life, the sampled sizes. Fields written by older kernels are absent and print as a dash. Read-only."""
+import argparse
+import datetime
+import json
+import os
+import sys
+
+
+def _rows(path):
+    out = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    r = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(r, dict):
+                    out.append(r)
+    except OSError:
+        pass
+    return out
+
+
+def cycles(cut_rows, last=None):
+    """Pair each cut row with the boot row that followed it (by time); the newest `last` pairs."""
+    cuts = [r for r in cut_rows if "cutTurns" in r]
+    boots = [r for r in cut_rows if r.get("bootSettled")]
+    out = []
+    for c in cuts:
+        b = next((x for x in boots if x.get("prevCutT") == c.get("t")), None) or next((x for x in boots if x.get("t", 0) >= c.get("t", 0)), None)
+        out.append({"cutT": c.get("t"), "pid": c.get("pid"), "ckptS": c.get("ckptS"), "drainS": c.get("drainS"),
+                    "cutTurns": len(c.get("cutTurns") or []), "stopped": c.get("stopped"), "exitRssMb": round((c.get("rssKb") or 0) / 1024),
+                    "outageS": b.get("outageS") if b else None, "censusS": b.get("censusS") if b else None,
+                    "attachS": b.get("attachS") if b else None, "attachTimedOut": bool(b.get("attachTimedOut")) if b else None,
+                    "bootPid": b.get("pid") if b else None})
+    return out[-last:] if last else out
+
+
+def samples_by_life(sample_rows):
+    by = {}
+    for r in sample_rows:
+        by.setdefault(r.get("pid"), []).append(r)
+    return by
+
+
+def _fmt(v, unit=""):
+    return "-" if v is None else ("%s%s" % (v, unit))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--state", default=os.environ.get("ROMP_STATE_DIR") or os.path.join(os.environ.get("XDG_STATE_HOME") or os.path.expanduser("~/.local/state"), "romp"))
+    ap.add_argument("--last", type=int, default=10)
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args(argv)
+    cyc = cycles(_rows(os.path.join(a.state, "restart-cuts.jsonl")), a.last)
+    smp = samples_by_life(_rows(os.path.join(a.state, "kernel-samples.jsonl")))
+    if a.json:
+        print(json.dumps({"cycles": cyc, "samples": smp}, indent=1))
+        return 0
+    print("%-19s %7s %7s %8s %8s %8s %5s %8s" % ("cut (local time)", "ckptS", "drainS", "outageS", "censusS", "attachS", "cut", "exitRSS"))
+    for c in cyc:
+        t = datetime.datetime.fromtimestamp(c["cutT"]).strftime("%m-%d %H:%M:%S") if c.get("cutT") else "-"
+        print("%-19s %7s %7s %8s %8s %8s %5s %7sM" % (t, _fmt(c["ckptS"]), _fmt(c["drainS"]), _fmt(c["outageS"]), _fmt(c["censusS"]),
+                                                    _fmt(c["attachS"]) + ("!" if c.get("attachTimedOut") else ""), c["cutTurns"], c["exitRssMb"]))
+    for pid, rows in list(smp.items())[-a.last:]:
+        print("life pid %s: " % pid + ", ".join("%.0fmin %dM" % (r.get("markS", 0) / 60, (r.get("rssKb") or 0) // 1024) +
+                                                  (" (cache %dM)" % (r["recordCacheBytes"] // 1048576) if "recordCacheBytes" in r else "") for r in rows))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kernel_samples.py
+++ b/tests/test_kernel_samples.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""The kernel's own size over a life (the performance metrics, 2026-09-11): a pusher tick writes one row in
+kernel-samples.jsonl at 5, 30 and 60 minutes of uptime and every hour after, with the resident size, processor
+seconds, threads and the record cache's held bytes when the event model reports them. Hermetic: a temp state root."""
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_samples", os.path.join(BIN, "romp-kernel"))
+
+
+class KernelSamples(unittest.TestCase):
+    def setUp(self):
+        km._KERNEL_SAMPLES_TAKEN.clear()
+        self.f = km.KERNEL_SAMPLES_FILE
+        if os.path.exists(self.f):
+            os.unlink(self.f)
+
+    def _rows(self):
+        return [json.loads(l) for l in open(self.f)] if os.path.exists(self.f) else []
+
+    def test_samples_land_at_the_marks_and_hourly_after_and_never_between(self):
+        t0 = km._STARTED
+        ticks = [(60, 0), (299, 0), (300, 1), (900, 1), (1799, 1), (1800, 2), (3599, 2), (3600, 3), (5000, 3), (7200, 4), (10800, 5)]
+        for up, expected in ticks:
+            km._kernel_sample_tick(t0 + up)
+            self.assertEqual(len(self._rows()), expected, "at uptime %d s" % up)
+        rows = self._rows()
+        self.assertEqual([r["markS"] for r in rows], [300.0, 1800.0, 3600.0, 7200.0, 10800.0])
+        for r in rows:
+            for k in ("t", "pid", "uptimeS", "rssKb", "cpuS", "threads"):
+                self.assertIn(k, r)
+            self.assertGreater(r["rssKb"], 0)
+
+    def test_the_record_cache_bytes_ride_when_the_event_model_reports_them(self):
+        t0 = km._STARTED
+        with mock.patch.object(km.em, "record_cache_stats", lambda: {"bytes": 12345, "entries": 7}, create=True):
+            km._kernel_sample_tick(t0 + 300)
+        self.assertEqual((self._rows()[0]["recordCacheBytes"], self._rows()[0]["recordCacheEntries"]), (12345, 7))
+
+    def test_a_late_kernel_takes_the_marks_it_passed_one_per_tick(self):
+        # a tick arriving late (the pusher was busy) takes one mark per tick, so the series keeps every mark
+        t0 = km._STARTED
+        km._kernel_sample_tick(t0 + 4000); km._kernel_sample_tick(t0 + 4001); km._kernel_sample_tick(t0 + 4002); km._kernel_sample_tick(t0 + 4003)
+        self.assertEqual([r["markS"] for r in self._rows()], [300.0, 1800.0, 3600.0])
+
+    def test_the_tick_rides_the_pusher(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("        _kernel_sample_tick(now)\n", src)
+        self.assertLess(src.index("_boot_row_backstop(now)\n"), src.index("        _kernel_sample_tick(now)\n"), "beside the boot row's backstop in the tick jobs")
+
+
+class RestartPhasesScript(unittest.TestCase):
+    def test_the_reader_pairs_cuts_with_boots_and_lists_the_samples(self):
+        import subprocess, sys as _sys
+        d = tempfile.mkdtemp()
+        rows = [{"t": 1000, "pid": 1, "cutTurns": ["a"], "stopped": 3, "rssKb": 4096000, "ckptS": 0.4, "drainS": 0.1},
+                {"t": 1003, "pid": 2, "bootSettled": True, "firstServe": 1002.5, "reconcileDone": 1002.6, "settleS": 0.1, "prevCutT": 1000, "outageS": 2.5, "censusS": 0.9, "attachS": 1.4},
+                {"t": 2000, "pid": 2, "cutTurns": [], "stopped": 5, "rssKb": 2048000},
+                {"t": 2004, "pid": 3, "bootSettled": True, "firstServe": 2003.0, "reconcileDone": 2003.1, "settleS": 0.1, "prevCutT": 2000, "outageS": 3.0, "attachTimedOut": True}]
+        with open(os.path.join(d, "restart-cuts.jsonl"), "w") as f:
+            for r in rows: f.write(json.dumps(r) + "\n")
+        with open(os.path.join(d, "kernel-samples.jsonl"), "w") as f:
+            f.write(json.dumps({"t": 1302, "pid": 2, "uptimeS": 300, "markS": 300.0, "rssKb": 204800, "recordCacheBytes": 52428800}) + "\n")
+        script = os.path.join(os.path.dirname(HERE), "scripts", "perf", "restart-phases.py")
+        out = subprocess.run([_sys.executable, script, "--state", d, "--json"], capture_output=True, text=True, timeout=30)
+        self.assertEqual(out.returncode, 0, out.stderr)
+        data = json.loads(out.stdout)
+        self.assertEqual([c["outageS"] for c in data["cycles"]], [2.5, 3.0])
+        self.assertEqual((data["cycles"][0]["ckptS"], data["cycles"][0]["censusS"], data["cycles"][0]["attachS"]), (0.4, 0.9, 1.4))
+        self.assertIsNone(data["cycles"][1]["ckptS"], "an older kernel's row has no phases: a dash, not a crash")
+        self.assertTrue(data["cycles"][1]["attachTimedOut"])
+        self.assertEqual(data["samples"]["2"][0]["recordCacheBytes"], 52428800)
+        text = subprocess.run([_sys.executable, script, "--state", d], capture_output=True, text=True, timeout=30).stdout
+        self.assertIn("ckptS", text); self.assertIn("life pid 2", text); self.assertIn("cache 50M", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sdk_boot_stagger.py
+++ b/tests/test_sdk_boot_stagger.py
@@ -453,5 +453,38 @@ class BootAttachesOffTheStagger(unittest.TestCase):
         self.assertEqual(phases2, ["censusDone", "attachDone"], "a never-started attach counts down at once")
 
 
+class BootBudget(unittest.TestCase):
+    """A regression tripwire for the boot (the performance metrics, 2026-09-11): the reconcile over forty alive sessions
+    with cut turns, every start stubbed, must read its census and reach its first start within a generous bound, and
+    the census milestone must land before any start. Generous on purpose (a shared CI box): it catches a boot that
+    started reading transcripts or waiting on something before it starts sessions, not a slow disk."""
+
+    def test_forty_sessions_census_then_starts_inside_the_bound(self):
+        import time as _time
+        d = tempfile.mkdtemp()
+        phases = []
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None, boot_phase=lambda k: phases.append((k, _time.monotonic())))
+        regs = _cut_regs(d, 40)
+        starts = []
+        def fake_ensure(sid, on_boot_settled=None):
+            starts.append(_time.monotonic())
+            if on_boot_settled:
+                on_boot_settled()           # the CLI proves up at once: the stagger never waits here
+            return object()
+        t0 = _time.monotonic()
+        with mock.patch.object(be, "_ensure", fake_ensure):
+            be._boot_reconcile(regs)
+        total = _time.monotonic() - t0
+        self.assertEqual(len(starts), 40)
+        census = dict(phases).get("censusDone")
+        self.assertIsNotNone(census, "the census milestone landed")
+        self.assertLess(census, min(starts), "the census ends before the first start")
+        self.assertLess(total, 5.0, "forty sessions reconciled and started within the bound: took %.2f s" % total)
+        import json as _json
+        rows = [_json.loads(l) for l in open(os.path.join(d, sb.SESSION_EVENTS_FILE)) if '"reconcile.boot"' in l]
+        self.assertEqual(len(rows), 1)
+        self.assertLess(rows[0]["durationS"], 5.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The performance measurements that keep the restart and memory work honest. Tier: feature (one tick job writing a new ledger, one regression test, one read-only script).

## What changes

1. **The kernel's size over each life.** A pusher tick writes one row in `kernel-samples.jsonl` at 5, 30 and 60 minutes of uptime and every hour after: resident size, processor seconds, threads, and the record cache's held bytes when the event model reports them (the record cache change lands separately). With the restart ledger's cut and boot rows this makes the kernel's growth a series, so a change that lets it climb again shows in a file before it shows in swap. A late tick takes one passed mark per tick, so the series keeps every mark.
2. **A boot regression tripwire.** Forty alive sessions with cut turns reconcile with the census milestone before the first start and start within five seconds, every start stubbed. Generous on purpose for a shared CI machine: it catches a boot that starts reading transcripts or waiting on something ahead of the sessions, not a slow disk.
3. **`scripts/perf/restart-phases.py`.** Pairs each cut row with the boot that followed it and prints per restart the exit's checkpoint writes and the sessions' close, the gap to the next kernel serving, the census and the last attach, the turns cut and the old kernel's size at exit, then the sampled sizes per life. Rows from older kernels print dashes. `--json` for machines.

## Tests

`tests/test_kernel_samples.py`: samples land at the marks and hourly after and never between; the row fields; the record cache bytes ride when reported; a late kernel takes the marks it passed one per tick; the tick's place beside the boot row's backstop; the script over a synthetic ledger (pairing, dashes for old rows, the samples). `tests/test_sdk_boot_stagger.py`: the boot budget. Three revert checks bite (the marks, the hourly cadence, the tick site).

## Verification

A clean full Python suite on this tree is reported in the thread before auto-merge is armed.
