### PR TITLE
Postal cards: the wash probe tells a refused colour by two sentinels, and the comment scopes its contrast figure to the shipped grounds (T337d)

### DIFF
--- a/ui/webview/postal-wash.test.ts
+++ b/ui/webview/postal-wash.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { oklabLightness, groundOf, syncPostalWash } from "./postal-wash";
+import { oklabLightness, groundOf, syncPostalWash, resolveColour } from "./postal-wash";
 
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -29,6 +29,35 @@ test("a document that cannot draw leaves the token to the sheet", () => {
   } as unknown as Document;
   assert.equal(syncPostalWash(doc), false);
   assert.deepEqual(removed, ["--postal-wash-l"], "an unmeasurable page clears any stale inline value");
+});
+
+// a canvas as the probe sees it: a value it takes becomes the fill (reported as a colour string); one it refuses leaves
+// the previous fill in place, which is exactly how a real 2d context behaves on an unparsable fillStyle
+function fakeDoc(accepts: (v: string) => string | null): Document {
+  let fill = "";
+  const ctx = {
+    set fillStyle(v: string) { const r = accepts(v); if (r !== null) fill = r; },
+    get fillStyle() { return fill; },
+    clearRect() {}, fillRect() {},
+    getImageData() { const m = /rgb\((\d+), (\d+), (\d+)\)/.exec(fill)!; return { data: [+m[1], +m[2], +m[3], 255] }; },
+  };
+  return { createElement: () => ({ getContext: () => ctx }) } as unknown as Document;
+}
+const CANVAS_TAKES = (v: string) => {
+  if (v === "#010203") return "rgb(1, 2, 3)";
+  if (v === "#040506") return "rgb(4, 5, 6)";
+  if (/^rgb\(0 0 0\)$|^#000000ff$|^black$/.test(v)) return "rgb(0, 0, 0)";
+  if (v === "#1e1e1e") return "rgb(30, 30, 30)";
+  return null;                                       // refused: the fill stays
+};
+
+test("the probe resolves every spelling of black and refuses garbage by two sentinels, not an enumeration", () => {
+  for (const black of ["rgb(0 0 0)", "#000000ff", "black"]) {
+    assert.deepEqual(resolveColour(fakeDoc(CANVAS_TAKES), black), [0, 0, 0, 1], black + " is the measured ground, not a fallback");
+  }
+  assert.deepEqual(resolveColour(fakeDoc(CANVAS_TAKES), "#1e1e1e"), [30, 30, 30, 1]);
+  assert.equal(resolveColour(fakeDoc(CANVAS_TAKES), "not a colour"), null, "a refused value leaves each sentinel: null");
+  assert.equal(resolveColour(fakeDoc(CANVAS_TAKES), ""), null);
 });
 
 test("the chat installs the measurement at boot, and the sheet's rule reads the token with the shipped fallback", () => {

--- a/ui/webview/postal-wash.ts
+++ b/ui/webview/postal-wash.ts
@@ -36,9 +36,12 @@ export function resolveColour(doc: Document, css: string): RGBA | null {
     const ctx = cv.getContext("2d");
     if (!ctx) return null;
     ctx.clearRect(0, 0, 1, 1);
-    ctx.fillStyle = "#000000";                     // a value the canvas refuses leaves the previous fill: make it detectable
-    ctx.fillStyle = v;
-    if (ctx.fillStyle === "#000000" && !/^(#000000|#000|black|rgb\(0,\s*0,\s*0\)|rgba\(0,\s*0,\s*0,\s*1\))$/i.test(v)) return null;
+    // a value the canvas refuses leaves the previous fill in place: set TWO different sentinels in turn and read the
+    // fill back after each; a value the canvas took gives the same colour both times, one it refused gives the two
+    // sentinels (the review of 2026-09-11: an enumeration of black's spellings missed rgb(0 0 0), #000000ff, hsl(...))
+    ctx.fillStyle = "#010203"; ctx.fillStyle = v; const first = ctx.fillStyle;
+    ctx.fillStyle = "#040506"; ctx.fillStyle = v; const second = ctx.fillStyle;
+    if (first !== second) return null;
     ctx.fillRect(0, 0, 1, 1);
     const d = ctx.getImageData(0, 0, 1, 1).data;
     return [d[0], d[1], d[2], d[3] / 255];

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2556,8 +2556,10 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
    (and darkens a light one toward a dark peer's), and the dimmest kind word then read under the 4.5:1 floor the kind
    ramp holds on its ground (T320: 4.38:1 on a green peer's mix), while the ramp's own two floors (postal-kind-ramp.test.ts)
    leave its deep end no room to move; on a hue at the ground's own lightness every kind word stays above 4.5:1 for every
-   hue, measured (the worst, the dark coordination word, 4.75:1; OKLab lightness is not WCAG luminance, so the ratio moves
-   by up to a third of a point across the hues). One declaration, so a further ruling is one line either way. The sent
+   hue on the two SHIPPED grounds, measured (the worst, the dark coordination word, 4.75:1; OKLab lightness is not WCAG
+   luminance, so the ratio moves by up to a third of a point across the hues). Not an invariant of the tint: on a lighter
+   dark host theme (a page around L .30) the coordination word reads near 4.0 to 4.3:1 on the plain box already, and the
+   tint at that ground's lightness neither helps nor hurts it (the review of 2026-09-11). One declaration, so a further ruling is one line either way. The sent
    card keeps its slim line and the provisional dress, untinted. The tokens carry fallbacks: `background` is a shorthand,
    and a missing token would have made the declaration invalid at computed-value time and the card lose its ground.
    oklch(from ...) needs Chromium 119 (VS Code from Electron 28): an older host drops the declaration at parse time and


### PR DESCRIPTION
## What

The two lows left from the review of the measured tint: the probe that turns a CSS colour into channels now tells a refused value from a taken one by two sentinels rather than an enumeration of black's spellings, and the sheet's comment scopes its contrast figure to the two shipped grounds instead of claiming an invariant.

## Design

- **Two sentinels.** A canvas context leaves its fill in place when it refuses a value, so the probe sets one sentinel, assigns the value and reads the fill back, then repeats with a second sentinel: a taken value reads the same colour both times, a refused one reads the two sentinels. Before this the probe compared the fill to black and enumerated five spellings, so `rgb(0 0 0)`, `#000000ff`, `hsl(0 0% 0%)` or `color(srgb 0 0 0)` as the page colour fell back to the sheet's value instead of the measured ground.
- **The claim, scoped.** Every kind word reads above 4.5:1 for every hue on the two shipped grounds, the worst 4.75:1 on the dark coordination word. On a lighter dark host theme, a page around L .30, the coordination word reads near 4.0 to 4.3:1 on the plain box already; the tint at that ground's lightness neither helps nor hurts it, and the comment now says so rather than clamping the measured lightness away from the page.

## Tests

`ui/webview/postal-wash.test.ts` drives the probe against a canvas stub that behaves as a real context does on an unparsable fill: three spellings of black resolve to the measured ground, an ordinary colour resolves, a refused value and an empty one give null.

Tier: fix
