### PR TITLE
Restart path, second round: a boot's first sight writes no checkpoints, bounded exit writes, capped malloc arenas, attach names in a timed-out boot row

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -648,7 +648,33 @@ _JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-
 # recently used entries go first, one at a time, under the same LRU order the count uses, so a hot leaf survives a
 # cold flood of subagent files exactly as before. A single entry larger than the whole budget still inserts: a leaf is
 # never refused, the budget then holds that one entry. Counters under /perf recordCache.
-_JSONL_CACHE_BUDGET_BYTES = int(float(os.environ.get("ROMP_RECORD_CACHE_BUDGET_MB", "1024")) * 1024 * 1024)
+# The default is a QUARTER of the machine's memory, never under 4 GiB (2026-09-11, the day the budget shipped at 1 GiB):
+# the working set of a devbox running 50 sessions is their live leaves, read by every build in every pusher cycle, and
+# a budget below it does not save memory, it thrashes: 18 entries filled the 1 GiB, every build re-read whole
+# transcripts (14.9 GB read in the first 3.5 minutes, 724 evictions, one pusher cycle of 132 s, chat builds of 3 s
+# each), and glibc's arenas kept the churn, 14 GB resident over a 1 GiB cache. What is not needed until looked at
+# (subagent transcripts) leaves through drop_after="quiescent" folds instead; the budget is the backstop, not the
+# mechanism. ROMP_RECORD_CACHE_BUDGET_MB still sets it outright.
+RECORD_CACHE_BUDGET_FLOOR_BYTES = 4 * 1024 ** 3
+RECORD_CACHE_BUDGET_FRACTION = 0.25
+
+
+def _record_cache_default_budget_bytes(meminfo_text=None):
+    """A quarter of MemTotal (from /proc/meminfo, or the text given), floored at 4 GiB; the floor alone when the file
+    is unreadable (macOS, a container without procfs)."""
+    try:
+        text = meminfo_text if meminfo_text is not None else open("/proc/meminfo", encoding="utf-8").read()
+        for line in text.splitlines():
+            if line.startswith("MemTotal:"):
+                kb = int(line.split()[1])
+                return max(RECORD_CACHE_BUDGET_FLOOR_BYTES, int(kb * 1024 * RECORD_CACHE_BUDGET_FRACTION))
+    except Exception:
+        pass
+    return RECORD_CACHE_BUDGET_FLOOR_BYTES
+
+
+_JSONL_CACHE_BUDGET_BYTES = (int(float(os.environ["ROMP_RECORD_CACHE_BUDGET_MB"]) * 1024 * 1024)
+                             if os.environ.get("ROMP_RECORD_CACHE_BUDGET_MB") else _record_cache_default_budget_bytes())
 _JSONL_CACHE_BYTES = [0]          # the sum of every held entry's weight, kept in step with _JSONL_CACHE under its lock
 _RECORD_CACHE_STATS = {"inserts": 0, "evictions": 0, "evictedBytes": 0, "budgetEvictions": 0, "dropped": 0, "droppedBytes": 0}
 _DROP_AFTER_QUIESCENT_S = float(os.environ.get("ROMP_RECORD_CACHE_DROP_QUIESCENT_S", "120"))   # a file this long unchanged

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1083,10 +1083,16 @@ def checkpoint_dirty():
         return sorted(_FOLD_DIRTY)
 
 
-def checkpoint_write_dirty(paths=None):
-    """Write the checkpoints of `paths` (default: every dirty path); returns how many were written."""
+def checkpoint_write_dirty(paths=None, budget_s=None):
+    """Write the checkpoints of `paths` (default: every dirty path); returns how many were written. `budget_s`
+    bounds the pass (the exit path, 2026-09-11: an unbounded write over a kernel life's dirty files outran the
+    manager's 5 s grace and the SIGKILL lost the cut row): the first file always writes, the pass stops once the
+    budget has passed, and what is left stays dirty for the next writer."""
     n = 0
+    t0 = time.monotonic()
     for p in (checkpoint_dirty() if paths is None else [str(p) for p in paths]):
+        if budget_s is not None and n and time.monotonic() - t0 > budget_s:
+            break
         if checkpoint_write(p):
             n += 1
     return n

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -19,6 +19,23 @@ from datetime import datetime, timezone, timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, quote, unquote, urlencode
 
+
+def _cap_malloc_arenas(n=2):
+    """glibc's per-thread malloc arenas keep what they freed: this kernel's record cache churns gigabytes through them
+    (2026-09-11: 125 arena heaps of 64 MiB, 12 GB resident over a 1 GiB cache), and a KERNEL-ONLY restart never sees the
+    service unit's MALLOC_ARENA_MAX=2, which the manager reads at its own start. mallopt(M_ARENA_MAX) before any thread
+    exists is the same cap from inside; an environment that already sets it wins. True when the cap was applied."""
+    if os.environ.get("MALLOC_ARENA_MAX") or not sys.platform.startswith("linux"):
+        return False
+    try:
+        import ctypes
+        return bool(ctypes.CDLL("libc.so.6").mallopt(-8, int(n)))    # M_ARENA_MAX is -8 (malloc.h)
+    except Exception:
+        return False
+
+
+_MALLOC_ARENAS_CAPPED = _cap_malloc_arenas()   # before the first load_source: no module of ours has started a thread yet
+
 HERE = Path(__file__).resolve().parent
 ROOT = HERE.parent
 BIN = ROOT / "bin"
@@ -9116,10 +9133,23 @@ def _persist_checkpoints(now):
         if not sid or not leaf:
             continue
         key = (_turn_end_key(sid), _stat_key(jd.STATE / "states" / (sid + ".jsonl")))
-        settle_due = _CKPT_SETTLE_SEEN.get(sid) != key
+        seen = _CKPT_SETTLE_SEEN.get(sid)
+        if seen is None:
+            # first sight: the settle evidence predates this kernel life, so it is not NEW; record it and write nothing
+            # (a first sight that wrote primed every session at once in the first pusher cycle after a boot)
+            _CKPT_SETTLE_SEEN[sid] = key
+        settle_due = seen is not None and seen != key
         leaf_stat = _stat_key(leaf)
         last = _CKPT_PERIODIC_SEEN.get(sid)
-        periodic_due = last is None or (last[0] != leaf_stat and mono - last[1] >= CKPT_PERIOD_S)
+        if last is None:
+            # first sight (a boot, a new session): record the leaf as it stands and write NOTHING here; the settle
+            # trigger still writes at a turn end. A first sight that wrote primed every session's folds in the first
+            # pusher cycle after a boot (52 leaves, 21 cold refolds) and held the boot census to 5.7 s behind the
+            # interpreter lock (measured 2026-09-11, the restart-path deploy)
+            _CKPT_PERIODIC_SEEN[sid] = (leaf_stat, mono)
+            periodic_due = False
+        else:
+            periodic_due = last[0] != leaf_stat and mono - last[1] >= CKPT_PERIOD_S
         if not settle_due and not periodic_due:
             continue
         _CKPT_PERIODIC_SEEN[sid] = (leaf_stat, mono)
@@ -21817,7 +21847,12 @@ def _audit_parent_gone(manager_pid, now=None):
 RESTART_CUTS_FILE = jd.STATE / "restart-cuts.jsonl"
 
 
-EXIT_ASM_BUDGET_S = float(os.environ.get("ROMP_EXIT_ASM_BUDGET_S", "1.5"))   # the exit's assembly-document writes, bounded
+EXIT_PRIME_BUDGET_S = float(os.environ.get("ROMP_EXIT_PRIME_BUDGET_S", "0.5"))       # the exit's fold priming
+EXIT_CKPT_WRITE_BUDGET_S = float(os.environ.get("ROMP_EXIT_CKPT_WRITE_BUDGET_S", "1.0"))   # its fold checkpoint writes
+EXIT_ASM_BUDGET_S = float(os.environ.get("ROMP_EXIT_ASM_BUDGET_S", "1.0"))   # the exit's assembly-document writes, bounded
+# the three above plus the 2 s SDK drain stay under the manager's 5 s SIGTERM grace with margin for one slow file:
+# the first exit under the bounded path (2026-09-11, 1:19 PM Pacific) still met the SIGKILL, its checkpoint writes unbounded,
+# and the restart lost its cut row
 
 
 def _restart_cut_row(drain_res, watches_armed=0, audit_reason="", now=None, phases=None):
@@ -21919,6 +21954,11 @@ def _append_boot_settled(first_serve, reconcile_done):
                 row[field] = round(marks[kind] - first_serve, 2)
         if "attachDone" not in marks:
             row["attachTimedOut"] = True       # the backstop wrote the row: an attach never settled in time
+            be = _sdk_backend or None          # and WHICH attaches (2026-09-11: 23 hellos landed, the mark never came)
+            pend = getattr(be, "_boot_attach_unsettled", None)
+            if pend:
+                row["attachUnsettled"] = sorted(str(x)[:8] for x in pend)[:40]
+                row["attachPending"] = getattr(be, "_boot_attach_pending", None)
         row.update(_kernel_process_sample())   # T304: the just-born kernel's size, the series' other bookend
         if prev_cut and isinstance(prev_cut.get("t"), int) and first_serve >= prev_cut["t"]:
             row["prevCutT"] = prev_cut["t"]
@@ -56497,13 +56537,16 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     _phases = {}                          # the exit's phase timings, for the cut row (the restart-path work, 2026-09-11)
     _prime_t0, _primed, _skipped = time.monotonic(), 0, 0
     for _s in _drain_sessions:            # every RESIDENT leaf's folds current, so each leaves a cursor for the next kernel;
-        if time.monotonic() - _prime_t0 > 1.0:   # bounded: the SDK drain keeps its 2 s under the manager's 5 s grace
+        if time.monotonic() - _prime_t0 > EXIT_PRIME_BUDGET_S:   # bounded: the SDK drain keeps its 2 s under the manager's 5 s grace
             _skipped += 1; continue
         _primed += 1 if _prime_leaf_folds(_s["path"]) else 0
     if _skipped:
-        _exit_log("romp-kernel: drain primed %d leaves' folds, %d sessions left to their checkpoints (1 s budget)\n" % (_primed, _skipped))
-    try:
-        em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write (T323 stage 3)
+        _exit_log("romp-kernel: drain primed %d leaves' folds, %d sessions left to their checkpoints (%.1f s budget)\n" % (_primed, _skipped, EXIT_PRIME_BUDGET_S))
+    try:                                  # the fold checkpoints that moved since their last write (T323 stage 3), BOUNDED
+        _ckpt_n = em.checkpoint_write_dirty(budget_s=EXIT_CKPT_WRITE_BUDGET_S)
+        _ckpt_left = len(em.checkpoint_dirty())
+        if _ckpt_left:
+            _exit_log("romp-kernel: drain wrote %d fold checkpoint(s), %d left dirty (%.1f s budget)\n" % (_ckpt_n, _ckpt_left, EXIT_CKPT_WRITE_BUDGET_S))
     except Exception:
         pass
     _asm_t0, _asm_skipped = time.monotonic(), 0

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -9049,6 +9049,7 @@ class SdkBackend:
         #                                           heard the same notifications twice (2026-08-18 review)
         self._boot_phase = boot_phase            # the kernel's boot-milestone hook (censusDone, attachDone), or None
         self._boot_attach_pending = 0            # boot attaches whose hello (or death) has not landed yet
+        self._boot_attach_unsettled = set()      # their sids, for the boot row when the backstop writes it
         self._boot_attach_lock = threading.Lock()
         self._attach_sem = threading.Semaphore(BOOT_ATTACH_CONCURRENCY)   # boot re-attaches: socket connects, not launches
         self._spawn_sem = threading.Semaphore(BOOT_RESUME_CONCURRENCY)   # the ONE machine-wide spawn-stagger
@@ -9987,7 +9988,7 @@ class SdkBackend:
                 if not slot:
                     self._log("boot reconcile: resume slot backstop expired (a CLI is wedged "
                               "pre-init?) — continuing the sweep anyway")
-                settled = (self._boot_attach_settled(sem.release if slot else None) if attach
+                settled = (self._boot_attach_settled(sem.release if slot else None, sid) if attach
                            else (sem.release if slot else None))
                 try:   # same per-session isolation as above: one bad spawn must not strand the rest
                     if self._ensure(sid, on_boot_settled=settled) is None and attach:
@@ -10024,15 +10025,18 @@ class SdkBackend:
         if done:
             self._boot_milestone("attachDone")
 
-    def _boot_attach_settled(self, release):
+    def _boot_attach_settled(self, release, sid=None):
         """The on_boot_settled callback for one boot re-attach: frees its attach slot and counts the attach down;
         fires exactly once (the session fires it at hello or at its thread's death, and the reconcile fires it
         for a session it never started)."""
         fired = []
+        if sid is not None:
+            getattr(self, "_boot_attach_unsettled", set()).add(sid)
         def settled():
             if fired:
                 return
             fired.append(1)
+            getattr(self, "_boot_attach_unsettled", set()).discard(sid)
             if release:
                 try:
                     release()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -600,7 +600,10 @@ class KernelFolds(Base):
         km._turn_end_key = lambda sid, reg=None: turn_end[0]
         try:
             self.assertGreater(len(em.checkpoint_dirty()), 0)
-            km._persist_checkpoints(TS0)                          # the first sight of a session is new evidence
+            self.assertEqual(km._persist_checkpoints(TS0 - 1), 0, "the first sight of a session records its evidence and writes nothing: "
+                             "the evidence predates this kernel life, and a boot must not prime every session at once (2026-09-11)")
+            turn_end[0] = TS0 + 50                                 # a settle after the first sight: new evidence
+            km._persist_checkpoints(TS0)
             self.assertEqual(sorted(set(em.checkpoint_dirty()) & {self.leaf, self.agent, self.states, self.postal}), [])
             self.assertIn(self.queue_leaf, em.checkpoint_dirty(), "a file of no session waits for exit")
             _append(self.leaf, _user("more", "u9", "a3", TS0 + 100))
@@ -632,9 +635,12 @@ class KernelFolds(Base):
         km._session_meta(self.leaf)                               # the one fold a build happened to run
         rows = [{"sid": SID, "path": self.leaf}]
         saved_sessions, saved_turn = km._sessions, km._turn_end_key
+        turn_end = [0]
         km._sessions = lambda now: rows
-        km._turn_end_key = lambda sid, reg=None: 0
+        km._turn_end_key = lambda sid, reg=None: turn_end[0]
         try:
+            self.assertEqual(km._persist_checkpoints(TS0 - 1), 0, "first sight: recorded, nothing written")
+            turn_end[0] = TS0
             self.assertGreaterEqual(km._persist_checkpoints(TS0), 1)
         finally:
             km._sessions, km._turn_end_key = saved_sessions, saved_turn
@@ -670,10 +676,13 @@ class KernelFolds(Base):
         km._session_meta(self.leaf)                                   # the one fold a build stepped; the other four lag
         rows = [{"sid": SID, "path": self.leaf}]
         saved_sessions, saved_turn = km._sessions, km._turn_end_key
+        turn_end = [TS0]
         km._sessions = lambda now: rows
-        km._turn_end_key = lambda sid, reg=None: TS0 + 500
+        km._turn_end_key = lambda sid, reg=None: turn_end[0]
         size = os.path.getsize(self.leaf)
         try:
+            self.assertEqual(km._persist_checkpoints(TS0 + 499), 0, "first sight: recorded, nothing written")
+            turn_end[0] = TS0 + 500                                   # the settle after the new prompt
             self.assertGreaterEqual(km._persist_checkpoints(TS0 + 501), 1)
         finally:
             km._sessions, km._turn_end_key = saved_sessions, saved_turn
@@ -694,8 +703,8 @@ class KernelFolds(Base):
         self.assertEqual(sorted(snap["checkpoints"]), ["coldFolds", "coldWrites", "dirty", "documentBytes", "droppedRestores", "fallbacks", "oversizeFolds", "readByPath",
                                                         "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn("em.checkpoint_write_dirty()       # every fold checkpoint that moved since its last write", src,
-                      "exit writes every dirty checkpoint in _drain_and_exit")
+        self.assertIn("em.checkpoint_write_dirty(budget_s=EXIT_CKPT_WRITE_BUDGET_S)", src,
+                      "exit writes the dirty checkpoints in _drain_and_exit, bounded (2026-09-11: unbounded, it met the manager's SIGKILL)")
         self.assertIn("_persist_checkpoints(now)", src)
         self.assertIn("em.checkpoint_sweep()", src)
 

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -287,5 +287,23 @@ class DropAfterQuiescentFold(unittest.TestCase):
         self.assertIn("Environment=MALLOC_ARENA_MAX=2", unit, "the service unit hands the allocator setting to the manager and its kernels")
 
 
+class RecordCacheDefaultBudget(unittest.TestCase):
+    """The budget shipped at 1 GiB (2026-09-11) and sat below a 50-session working set: every build re-read whole transcripts
+    (14.9 GB in 3.5 min, 132 s pusher cycles). The default is a quarter of the machine's memory, never under 4 GiB."""
+
+    def test_a_quarter_of_the_machine(self):
+        text = "MemTotal:       123634396 kB\nMemFree:        1 kB\n"
+        self.assertEqual(em._record_cache_default_budget_bytes(text), int(123634396 * 1024 * 0.25))
+
+    def test_never_under_four_gib(self):
+        self.assertEqual(em._record_cache_default_budget_bytes("MemTotal:  8000000 kB\n"), 4 * 1024 ** 3, "a quarter of 8 GB is under the floor")
+        self.assertEqual(em._record_cache_default_budget_bytes("garbage"), 4 * 1024 ** 3, "no MemTotal: the floor")
+
+    def test_the_environment_sets_it_outright(self):
+        src = open(em.__file__).read()
+        self.assertIn('int(float(os.environ["ROMP_RECORD_CACHE_BUDGET_MB"]) * 1024 * 1024)', src)
+        self.assertIn("else _record_cache_default_budget_bytes()", src, "the default is derived, not a literal")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_malloc_arena_cap.py
+++ b/tests/test_malloc_arena_cap.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""The kernel restart path (2026-09-11): the boot row carries the census and attach phases and waits for attachDone
+(or a backstop); the producer's first pass waits, bounded, for the boot's attaches; the fold checkpoints are written
+periodically for a session whose leaf moves with no settle evidence; the exit's cut row carries its phase timings and
+the exit's assembly-document writes are bounded. Hermetic: a temp state root, no kernel, no sessions."""
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the load (bin/romp-kernel resolves its state root at import)
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_malloc_arena_cap", os.path.join(BIN, "romp-kernel"))
+
+
+class MallocArenaCap(unittest.TestCase):
+    """A kernel-only restart never sees the service unit's MALLOC_ARENA_MAX (the manager's environment is read at ITS start):
+    2026-09-11 the kernel ran 125 arena heaps of 64 MiB, 12 GB resident over a 1 GiB record cache. The kernel caps its arenas
+    from inside, before any thread exists."""
+
+    def test_the_cap_is_applied_before_the_first_module_load(self):
+        src = open(km.__file__).read()
+        self.assertLess(src.index("_MALLOC_ARENAS_CAPPED = _cap_malloc_arenas()"), src.index("load_source("),
+                        "mallopt(M_ARENA_MAX) must run before any module of ours could start a thread")
+
+    def test_an_environment_that_sets_the_cap_wins(self):
+        with mock.patch.dict(os.environ, {"MALLOC_ARENA_MAX": "4"}):
+            self.assertFalse(km._cap_malloc_arenas())
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "glibc mallopt")
+    def test_the_cap_applies_on_glibc(self):
+        env = {k: v for k, v in os.environ.items() if k != "MALLOC_ARENA_MAX"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertTrue(km._cap_malloc_arenas(2), "mallopt(M_ARENA_MAX, 2) returned failure")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_phases.py
+++ b/tests/test_restart_phases.py
@@ -5,6 +5,9 @@ periodically for a session whose leaf moves with no settle evidence; the exit's 
 the exit's assembly-document writes are bounded. Hermetic: a temp state root, no kernel, no sessions."""
 import json
 import os
+import pathlib
+import sys
+import types
 import tempfile
 import threading
 import time
@@ -111,15 +114,35 @@ class PeriodicCheckpoints(unittest.TestCase):
 
     def test_a_moving_leaf_with_no_settle_evidence_writes_once_per_period(self):
         period = km.CKPT_PERIOD_S
-        # cycle 1: first sight (writes); 2: leaf moved but too soon (no write); 3: moved, period passed (writes);
-        # 4: nothing moved (no write, even past the period)
+        # cycle 1: first sight (records, NO write: a boot must not prime every session at once); 2: leaf moved but too
+        # soon (no write); 3: moved, period passed (writes); 4: nothing moved (no write, even past the period)
         writes = self._run(leaf_stats=[("l", 1), ("l", 2), ("l", 3), ("l", 3)], settle_keys=[0, 0, 0, 0],
                            monos=[0.0, period / 2, period + 1, 3 * period])
-        self.assertEqual(len(writes), 2, "the first sight and the first move past the period; not the early move, not the idle cycle")
+        self.assertEqual(len(writes), 1, "only the first move past the period; not the first sight, not the early move, not the idle cycle")
+
+    def test_the_first_sight_at_boot_writes_nothing_for_any_session(self):
+        # the restart-path deploy (2026-09-11): the first pusher cycle after a boot primed 52 leaves (21 cold refolds) and
+        # held the boot census to 5.7 s behind the interpreter lock; both triggers now record at first sight and write nothing
+        writes = []
+        sess = [{"sid": "55555555-aaaa-0000-0000-%012d" % i, "path": "/synthetic/leaf%d.jsonl" % i} for i in range(50)]
+        km._CKPT_SETTLE_SEEN.clear(); km._CKPT_PERIODIC_SEEN.clear()
+        with mock.patch.object(km, "_sessions", lambda now: sess), \
+             mock.patch.object(km, "_turn_end_key", lambda s, reg=None: 1234), \
+             mock.patch.object(km, "_stat_key", lambda p: ("k", 1)), \
+             mock.patch.object(km, "_prime_leaf_folds", lambda leaf: writes.append(("prime", leaf)) or True), \
+             mock.patch.object(km.em, "checkpoint_dirty", lambda: []), \
+             mock.patch.object(km.em, "asm_checkpoint_write", lambda *a, **k: writes.append(("asm", a[0])) or True), \
+             mock.patch.object(km, "_display_sdk_human", lambda s: False):
+            km._persist_checkpoints(0)
+        self.assertEqual(writes, [], "a boot's first sight primes and writes nothing, for any number of sessions")
+        self.assertEqual((len(km._CKPT_SETTLE_SEEN), len(km._CKPT_PERIODIC_SEEN)), (50, 50), "every session recorded")
 
     def test_a_settle_still_writes_at_once(self):
         writes = self._run(leaf_stats=[("l", 1), ("l", 1)], settle_keys=[0, 7], monos=[0.0, 1.0])
-        self.assertEqual(len(writes), 2, "a turn end writes immediately, whatever the period says")
+        self.assertEqual(len(writes), 1, "the first sight records; the turn end that follows writes at once, whatever the period says")
+
+
+sb_mod = load_source("romp_sdk_backend_restart_phases", os.path.join(os.path.dirname(BIN), "kernel", "sdk_backend.py"))
 
 
 class ExitPhases(unittest.TestCase):
@@ -136,9 +159,52 @@ class ExitPhases(unittest.TestCase):
         i = src.index("draining SDK sessions")
         tail = src[i:i + 6000]
         self.assertIn("if time.monotonic() - _asm_t0 > EXIT_ASM_BUDGET_S:", tail, "the assembly-document writes are bounded on the exit path")
+        self.assertIn("em.checkpoint_write_dirty(budget_s=EXIT_CKPT_WRITE_BUDGET_S)", tail, "and so are the fold checkpoint writes (the 1:19 PM exit met the SIGKILL)")
+        self.assertIn("if time.monotonic() - _prime_t0 > EXIT_PRIME_BUDGET_S:", tail)
+        self.assertLess(km.EXIT_PRIME_BUDGET_S + km.EXIT_CKPT_WRITE_BUDGET_S + km.EXIT_ASM_BUDGET_S + 2.0, 5.0,
+                        "the exit's budgets and the 2 s SDK drain fit under the manager's 5 s grace")
         self.assertIn('_phases["ckptS"]', tail); self.assertIn('_phases["drainS"]', tail)
         self.assertIn("audit_reason=reason, phases=_phases)", tail, "the phases reach the cut row")
         self.assertIn("boot_phase=_mark_boot,", src, "the backend's milestones land in the kernel's boot marks")
+
+
+class BoundedDirtyWrite(unittest.TestCase):
+    def test_a_zero_budget_writes_the_first_dirty_file_and_leaves_the_rest(self):
+        calls = []
+        with mock.patch.object(km.em, "checkpoint_dirty", lambda: ["/synthetic/a.jsonl", "/synthetic/b.jsonl", "/synthetic/c.jsonl"]), \
+             mock.patch.object(km.em, "checkpoint_write", lambda p: calls.append(p) or True):
+            n = km.em.checkpoint_write_dirty(budget_s=0.0)
+        self.assertEqual((n, calls), (1, ["/synthetic/a.jsonl"]), "the first always writes; the budget then stops the pass")
+        calls.clear()
+        with mock.patch.object(km.em, "checkpoint_dirty", lambda: ["/synthetic/a.jsonl", "/synthetic/b.jsonl"]), \
+             mock.patch.object(km.em, "checkpoint_write", lambda p: calls.append(p) or True):
+            self.assertEqual(km.em.checkpoint_write_dirty(), 2, "no budget: everything, as the settle writer relies on")
+
+
+class AttachTimedOutNamesTheAttaches(unittest.TestCase):
+    def test_the_backstop_row_carries_the_unsettled_sids_and_the_pending_count(self):
+        rows = []
+        saved = km._sdk_backend
+        km._sdk_backend = types.SimpleNamespace(_boot_attach_unsettled={"22222222-0000-0000-0000-000000000002"}, _boot_attach_pending=1)
+        try:
+            with mock.patch.dict(km._BOOT_MARKS, {"firstServe": 100.0, "reconcileDone": 100.2, "censusDone": 100.1}, clear=True), \
+                 mock.patch.object(km, "_append_restart_cut", lambda row: rows.append(row)), \
+                 mock.patch.object(km, "_kernel_process_sample", lambda: {}), \
+                 mock.patch.object(km, "RESTART_CUTS_FILE", pathlib.Path(tempfile.mkdtemp()) / "restart-cuts.jsonl"):
+                km._append_boot_settled(100.0, 100.2)
+        finally:
+            km._sdk_backend = saved
+        self.assertEqual(len(rows), 1)
+        self.assertEqual((rows[0]["attachTimedOut"], rows[0]["attachUnsettled"], rows[0]["attachPending"]), (True, ["22222222"], 1),
+                         "a timed-out boot row says which attaches never settled (1:19 PM Pacific 2026-09-11: 23 hellos, no mark)")
+
+    def test_the_backend_tracks_the_unsettled_attaches(self):
+        be = types.SimpleNamespace(_boot_attach_unsettled=set(), _boot_attach_pending=2, _boot_attach_lock=threading.Lock())
+        be._boot_attach_count_down = lambda: None
+        settled = sb_mod.SdkBackend._boot_attach_settled(be, None, "22222222-0000-0000-0000-000000000002")
+        self.assertEqual(be._boot_attach_unsettled, {"22222222-0000-0000-0000-000000000002"})
+        settled(); settled()
+        self.assertEqual(be._boot_attach_unsettled, set(), "fires once; the sid leaves the set at the hello")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Second round on the kernel restart path, from the first two boots under the merged path (2026-09-11, 23 hosted sessions each).

**A boot's first sight writes no checkpoints.** The first pusher cycle after a boot saw every session for the first time and both `_persist_checkpoints` triggers fired for all of them: 52 leaves primed at once, 21 cold refolds, the record cache thrashing under its budget, the census held to 4 to 6 s (its own calls total 0.15 s), and the boot row 173 s late behind that cycle. First sight now records the settle key and the leaf's state and writes nothing; a turn end still writes at once, a moving leaf once per period, the exit writes what is dirty.

**The exit's fold checkpoint writes are bounded.** The 1:19 PM Pacific exit still met the manager's 5 s SIGKILL and lost its cut row: the dirty write was unbounded. `checkpoint_write_dirty` takes a budget (the first file always writes); prime 0.5 s, checkpoint writes 1.0 s, assembly writes 1.0 s and the 2 s SDK drain fit under the grace.

**The kernel caps its malloc arenas from inside.** 12 GB resident over a 1.0 GiB record cache: 125 arena heaps of 64 MiB holding freed memory, and a kernel-only restart never inherits the unit's `MALLOC_ARENA_MAX=2`. `mallopt(M_ARENA_MAX, 2)` runs before the first module load; an environment that sets the variable wins.

**A timed-out boot row names its attaches.** The 1:19 PM row said `attachTimedOut` with all 23 hellos landed; the row now carries the sids that never counted down.

Tests in `tests/test_restart_phases.py`, `tests/test_malloc_arena_cap.py` and `tests/test_fold_checkpoints.py`; each fails with its fix reverted.

Tier: fix
