### PR TITLE
A comment thread's mail is off, both directions, until the user breaks it out; a break-out turns it on (T356)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -402,6 +402,13 @@ a subproject that became its own repository, right-click its tab and choose
 name, mail and history stay with the session, and from the next turn on the
 agent works in the new folder and reads its `CLAUDE.md`.
 
+A comment thread's mail is off, both directions, until you break it out: peers
+cannot see or mail the thread, and its own mail is refused with a line saying
+so. The popover says "mail off" while it lasts, and the moment you break the
+thread out it is a session like any other, mail on unless you toggle its
+mailbox off (the user 2026-09-11, after a thread received a manager's mail and
+acted as the manager).
+
 A session started from another one joins its tags. Forking a session, breaking
 a comment thread out into its own session, and running `romp new` inside a
 session's shell all put the new session in the parent's groups, so a session's

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3518,7 +3518,7 @@ def _painted_flag_value(sid, flag):
     if flag == "notify":
         return bool(_notify_session_effective(sid))
     if flag == "postalServiceOff":
-        return bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))
+        return bool(_postal_isolated(sid))      # a comment thread paints its mail-off default (T356)
     return bool(_session_flag(sid, flag))
 
 
@@ -14158,6 +14158,8 @@ def _comments_frame(sid, live_map=None):
                         "lastUuid": last_uuid,                         # the newest record shown/held — the client's cap-proof "transcript moved" datum
                         "unreachable": unreachable or None,            # a broken thread (missing transcript / lost cut): owes nothing
                         "promotedName": th.get("promotedName") or "",
+                        # the thread's mail state (T356): off by default until broken out; the popover says so
+                        "mailOff": bool(_postal_isolated(tsid)),
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
                         "sinceEpoch": since_ms,
@@ -22695,7 +22697,11 @@ def _thread_rows():
         out.append({"id": tsid, "name": nm or tsid[:8], "state": meta.get("state", ""),
                     "dir": _cwd_of(tsid), "thread": True, "parent": parent,
                     "lastSid": jd._sdk_last_sid(tsid) or tsid,
-                    "working": "", "backend": "sdk"})
+                    "working": "", "backend": "sdk",
+                    # a thread's mail is off until the user breaks it out (T356): the row says so, so a listing
+                    # consumer never has to derive it
+                    "postalServiceOff": _postal_isolated(tsid),
+                    "mailOffWhy": "thread" if _thread_mail_off(tsid) else ""})
     return out
 
 
@@ -23276,9 +23282,24 @@ def _postal_shaped(text):
     return "romp-msg-id" in t or t.startswith("####################") or "\U0001F4EC" in t
 
 
+def _thread_mail_off(sid):
+    """A comment thread's mail is OFF by default, both directions, until the user breaks it out (T356, the user
+    2026-09-11: a comment thread of a manager session received the manager's mail, mailed two of its workers and
+    merged a pull request as if it were the manager). The default derives from the thread-ness itself (the reg's
+    threadOf), so a thread already on disk with no flag reads OFF; the one way on short of a break-out is the fresh
+    key `threadMail` at the literal True (never an old key re-read: the flip-a-default rule). A break-out clears
+    threadOf, so the promoted session falls back to the ordinary rule below: mail on unless the user toggled its
+    mailbox off. The postal bus derives the same answer from the same two files (_mail_off_why)."""
+    if not sid or not _thread_reg(sid).get("threadOf"):
+        return False
+    f = _session_flags().get(sid)
+    return not (isinstance(f, dict) and f.get("threadMail") is True)
+
+
 def _postal_isolated(sid):
-    """The session's postal-isolation flag (the timeline lane's mailbox icon), legacy key included."""
-    return bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))
+    """The session's EFFECTIVE postal isolation: a comment thread whose mail is off (_thread_mail_off), else the
+    mailbox flag the timeline lane's icon writes, legacy key included."""
+    return _thread_mail_off(sid) or bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))
 
 
 _FOLLOWUP_GOAL_RE = re.compile(r"romp-goal-id:\s*([^\s>]+)")
@@ -33364,7 +33385,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
             # per-session view flags (the user 2026-06-26): the tab right-click menu toggles these too, mirroring
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
-            "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),
+            "postalServiceOff": _postal_isolated(sid),    # EFFECTIVE: a comment thread reads off until broken out (T356)
             "notify": _notify_session_effective(sid),   # session-level bell, EFFECTIVE (override, else the master default): OS notification when its work blocks on you / completes (the user 2026-07-28)
             # NEVER `now`. This rides the chat payload, and _send_client dedups by comparing the
             # SERIALIZED payload against what that client last received — so a firstSeen that ticked
@@ -39226,7 +39247,7 @@ def build_timeline(now, live_map=None, with_bars=True, live_only=False):
             "branch": branch_of.get(sid),
             "comments": _comment_markers(sid),
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),    # lane checkbox → mute from feed (timeline-only)
-            "postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service)
+            "postalServiceOff": _postal_isolated(sid),  # lane mailbox → isolate from the Romp Postal Service (bin/romp-postal-service); EFFECTIVE, a thread's default included (T356)
             "notify": _notify_session_effective(sid)})   # lane bell, EFFECTIVE (override, else the master default) → OS notification when this session's work blocks on you / completes (the user 2026-07-28)
     if with_bars and not live_only:
         # the live-lane memo releases the lanes that left the timeline here: a full build's lane set (live sessions
@@ -43599,6 +43620,7 @@ def _push(targets, connect=False, live_map=None):
             if chat_sessions or want_fleet:
                 feed["ledgers"] = [{"sid": m["id"], "name": m["name"], "color": m.get("color"),
                                     "status": m.get("status"),
+                                    "postalServiceOff": _postal_isolated(m["id"]),   # the Sessions pane shows a mail-off session (T356)
                                     # attach the archived-completed TOP tasks so the Fleet's "Show completed"
                                     # can surface a finished+archived session (the user 2026-06-27); cached, so
                                     # ~free. The client renders them only when the toggle is on.

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1192,18 +1192,52 @@ def present_count_checked():
 def present_count():
     return present_count_checked()[0]
 
-def _postal_off(sid):
-    """True if the session toggled POSTAL ISOLATION on (the timeline lane's mailbox icon → postalServiceOff): it's
-    invisible to list_agents, can't send, and can't receive — for working privately. Reads the kernel's
-    shared session-flags.json. Back-compat: also honours the legacy `postalOff` key so sessions isolated
-    before the rename stay isolated. Best-effort: any error → not isolated (fail OPEN, never wedge messaging)."""
+def _thread_of(sid):
+    """The parent sid when `sid` is a COMMENT THREAD (its durable SDK reg, beside session-flags.json in the kernel's
+    state, carries threadOf), else ''. Unreadable or absent → '' (an ordinary session), the same fail-open the flag
+    read below keeps; a thread's reg is written before its first turn, so a live thread always has one."""
+    if not sid or not _safe_id(sid):
+        return ""
+    try:
+        d = json.loads((SESSION_FLAGS.parent / "sdk" / (sid + ".json")).read_text())
+        return str(d.get("threadOf") or "") if isinstance(d, dict) else ""
+    except Exception:
+        return ""
+
+def _mail_off_why(sid):
+    """Why `sid` can neither send nor receive mail right now, or '' when its mail is on:
+      "thread"    — a comment thread (T356, the user 2026-09-11: a thread of a manager session received the
+                    manager's mail, mailed two workers and merged a pull request as if it were the manager). A
+                    thread's mail is OFF by default, both directions, until the user breaks it out into a session
+                    of its own; the default derives from the thread-ness itself, so a thread on disk with no flag
+                    reads OFF, and the one way on short of a break-out is the fresh key `threadMail` at the literal
+                    True in session-flags.json (never an old key re-read). A break-out clears threadOf, and the
+                    promoted session falls to the ordinary rule.
+      "isolation" — the user toggled POSTAL ISOLATION on (the timeline lane's mailbox icon → postalServiceOff;
+                    the legacy `postalOff` key still honoured).
+    Both read the kernel's shared files. Best-effort on the flag read: any error → the flag is unset (fail OPEN,
+    never wedge messaging); the thread default holds regardless of the flag file's health."""
     if not sid:
-        return False
+        return ""
     try:
         f = json.loads(SESSION_FLAGS.read_text()).get(sid)
-        return bool(isinstance(f, dict) and (f.get("postalServiceOff") or f.get("postalOff")))
     except Exception:
-        return False
+        f = None
+    if _thread_of(sid) and not (isinstance(f, dict) and f.get("threadMail") is True):
+        return "thread"
+    return "isolation" if (isinstance(f, dict) and (f.get("postalServiceOff") or f.get("postalOff"))) else ""
+
+def _postal_off(sid):
+    """True if the session can neither send nor receive mail (see _mail_off_why): it's invisible to list_agents,
+    can't send, and can't receive."""
+    return bool(_mail_off_why(sid))
+
+THREAD_MAIL_OFF_SENDER = ("isolation: YOUR OWN mail is OFF because this session is a COMMENT THREAD. A thread neither "
+                          "sends nor receives peer mail until the user breaks it out into a session of its own. "
+                          "Nothing was sent, and this is final: do not route around it (not the kernel's /send, not "
+                          "another session's mailbox, not a file drop). Answer in the thread, and leave mail to the "
+                          "session the thread belongs to. When you relay this, say the thread's mail is off until it "
+                          "is broken out.")
 
 def _git_branch(d):
     """Current git branch of a dir (for the agent list — same-branch is what makes
@@ -1372,6 +1406,14 @@ def resolve_recipient(to, frm_id=""):
     if peer_cands:
         return {"kind": "relay", "host": peer_cands[0][0], "agent": peer_cands[0][1]}
     if direct_all:                        # live, but every candidate has its mailbox off
+        if any(_mail_off_why(a["id"]) == "thread" for a in direct_all):
+            # a comment thread's mail is off until the user breaks it out (T356): say what it is, so the sender
+            # reaches the session the thread belongs to instead of waiting on a mailbox toggle nobody offers
+            return {"kind": "error", "status": 403,
+                    "error": "isolation: the RECIPIENT '%s' is a COMMENT THREAD, and a thread's mail is OFF, both "
+                             "directions, until the user breaks it out into a session of its own. YOUR mailbox is "
+                             "fine; nothing was sent, and this is final. Mail the session the thread belongs to "
+                             "instead, or wait for the user to break the thread out." % to}
         return {"kind": "error", "status": 403,
                 "error": "isolation: the RECIPIENT '%s' has its mailbox OFF (it's in "
                          "postal isolation — its mailbox icon is toggled off), so it can't receive "
@@ -2310,7 +2352,10 @@ class Handler(BaseHTTPRequestHandler):
             tracked = tracked and kind == "delegate"
             #   (the user 2026-08-24): only a delegate can be tracked; wire metadata only — nothing
             #   about the flag ever appears in message prose (the injected-voice rule)
-            if _postal_off(frm_id):                # the sender is in isolation → sending is disabled
+            why_off = _mail_off_why(frm_id)
+            if why_off == "thread":                # a comment thread's own send: refused until broken out (T356)
+                return self._send({"error": THREAD_MAIL_OFF_SENDER}, 403)
+            if why_off:                            # the sender is in isolation → sending is disabled
                 return self._send({"error": "isolation: YOUR OWN mailbox is OFF. This session is in postal "
                                    "isolation (its mailbox icon is toggled off on its timeline lane), so it "
                                    "can't send OR receive any mail. This is NOT the recipient's mailbox — the "

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -147,6 +147,7 @@ CENSUS = {
     "_session_chip": ("pure", "over classified inputs: the parse and live tail, the row, the backend brackets, the clock booleans, the live task rows, the watches, the states overlay, the store and the downtime list"),
     "_session_cwd": ("sig", "cwd", "the names entry's cwd, else the transcript's stamp"),
     "_session_flag": ("sig", "flags"),
+    "_postal_isolated": ("sig", "flags", "the effective mail state: the mailbox flag with its legacy twin, and a comment thread's default from its reg (T356)"),
     "_session_meta": ("pure", "over the transcript's records, memoized by record identity (transcript)"),
     "_session_retry_suppressed": ("sig", "retry"),
     "_session_working": ("sig", "downtime", "over the turns, and the host suspensions recorded since boot"),

--- a/tests/test_kernel_tab_flags.py
+++ b/tests/test_kernel_tab_flags.py
@@ -24,8 +24,11 @@ class TabFlags(unittest.TestCase):
     def test_build_session_carries_the_feed_and_postal_flags(self):
         src = inspect.getsource(km.build_session)
         self.assertIn('"hideFromFeed": _session_flag(sid, "hideFromFeed")', src)
-        self.assertIn('"postalServiceOff": _session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff")', src,
-                      "canonical postalServiceOff with the legacy postalOff fallback, like build_timeline")
+        self.assertIn('"postalServiceOff": _postal_isolated(sid)', src,
+                      "the EFFECTIVE state, like build_timeline: canonical postalServiceOff with the legacy postalOff fallback "
+                      "(_postal_isolated), and a comment thread's mail-off default (T356)")
+        self.assertIn('or bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))', inspect.getsource(km._postal_isolated),
+                      "the legacy fallback lives in the one reader")
 
     def test_kernel_handles_a_chat_side_setSessionFlag(self):
         text = open(KPATH).read()

--- a/tests/test_postal_isolation.py
+++ b/tests/test_postal_isolation.py
@@ -83,8 +83,9 @@ class WiringAcrossSurfaces(unittest.TestCase):
 
     def test_kernel_boot_exposes_postaloff(self):
         src = open(os.path.join(BIN, "romp-kernel")).read()
-        self.assertIn('"postalServiceOff": _session_flag(sid, "postalServiceOff")', src,
-                      "the kernel must publish postalServiceOff in the session boot so the timeline can render it")
+        self.assertIn('"postalServiceOff": _postal_isolated(sid)', src,
+                      "the kernel must publish postalServiceOff in the session boot so the timeline can render it: the EFFECTIVE "
+                      "state (the mailbox flag with its legacy twin, and a comment thread's mail-off default, T356)")
 
     def test_timeline_view_draws_and_toggles_the_mailbox(self):
         # Since 2026-07-28 the mailbox lives in the lane GEAR's drop-down (LANE_TOGGLES) rather than as
@@ -96,6 +97,146 @@ class WiringAcrossSurfaces(unittest.TestCase):
                       "the gear menu row toggles the postalServiceOff flag")
         self.assertIn("this._setSessionFlag(s, t.flag, next);", src, "menu rows persist via _setSessionFlag")
 
+
+
+# ── a comment thread's mail is OFF until the user breaks it out (T356) ──────────────────────────────────
+
+PARENT = "22222222-3333-4444-5555-666666666666"
+THREAD = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+SENDER = "77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+
+
+def _reg(sid, **fields):
+    d = pm.SESSION_FLAGS.parent / "sdk"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / (sid + ".json")).write_text(json.dumps({"sid": sid, "alive": True, **fields}))
+
+
+def _flags(data):
+    pm.SESSION_FLAGS.parent.mkdir(parents=True, exist_ok=True)
+    pm.SESSION_FLAGS.write_text(json.dumps(data))
+
+
+class ThreadMailOff(unittest.TestCase):
+    """The bus derives a thread's mail-off default from the kernel's durable reg (threadOf) beside the flags file:
+    a thread on disk with NO flag reads OFF (the user 2026-09-11: a manager's comment thread received the manager's
+    mail, mailed two workers and merged a pull request as if it were the manager); the fresh key `threadMail` at the
+    literal True is the one way on short of a break-out; a break-out (threadOf gone) returns the ordinary rule."""
+
+    def tearDown(self):
+        for f in (pm.SESSION_FLAGS, pm.SESSION_FLAGS.parent / "sdk" / (THREAD + ".json"), pm.SESSION_FLAGS.parent / "sdk" / (SENDER + ".json")):
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+    def test_a_thread_with_no_flag_reads_off_and_says_why(self):
+        _reg(THREAD, threadOf=PARENT)
+        self.assertEqual(pm._mail_off_why(THREAD), "thread"); self.assertTrue(pm._postal_off(THREAD))
+        self.assertEqual(pm._mail_off_why(PARENT), "", "the session it belongs to is untouched")
+        self.assertEqual(pm._thread_of(THREAD), PARENT); self.assertEqual(pm._thread_of(PARENT), "", "no reg: an ordinary session")
+
+    def test_the_fresh_key_at_the_literal_true_turns_it_on_and_nothing_else_does(self):
+        _reg(THREAD, threadOf=PARENT)
+        _flags({THREAD: {"threadMail": True}})
+        self.assertEqual(pm._mail_off_why(THREAD), "")
+        for v in ("true", 1, "on"):
+            _flags({THREAD: {"threadMail": v}})
+            self.assertEqual(pm._mail_off_why(THREAD), "thread", repr(v))
+        _flags({THREAD: {"postalServiceOff": False}})
+        self.assertEqual(pm._mail_off_why(THREAD), "thread", "the mailbox flag at False is no way on for a thread")
+        _flags({THREAD: {"threadMail": True, "postalServiceOff": True}})
+        self.assertEqual(pm._mail_off_why(THREAD), "isolation", "mail on for the thread, then the user's own isolation holds")
+        _flags("{not json")
+        self.assertEqual(pm._mail_off_why(THREAD), "thread", "a corrupt flags file cannot turn a thread's mail on")
+
+    def test_breaking_out_returns_the_ordinary_rule(self):
+        _reg(THREAD, threadOf=PARENT)
+        self.assertTrue(pm._postal_off(THREAD))
+        _reg(THREAD)                                   # promotion pops threadOf from the reg
+        self.assertEqual(pm._mail_off_why(THREAD), ""); self.assertFalse(pm._postal_off(THREAD))
+        _flags({THREAD: {"postalOff": True}})
+        self.assertEqual(pm._mail_off_why(THREAD), "isolation")
+
+    def test_the_receive_gate_holds_a_threads_mail_in_its_box(self):
+        _reg(THREAD, threadOf=PARENT)
+        box = pm.MAILROOT / THREAD / "new"
+        box.mkdir(parents=True, exist_ok=True)
+        (box / "msg1").write_text("From: peer\nFrom-Id: x\nDate: now\n\nhello\n")
+        self.assertEqual(pm.read_box(THREAD, consume=True), [], "held, not delivered")
+        self.assertTrue((box / "msg1").exists(), "…and kept for the day the thread is broken out")
+
+    def test_a_thread_is_invisible_to_peers_and_a_send_to_it_is_refused_with_the_thread_reason(self):
+        _reg(THREAD, threadOf=PARENT)
+        rows = [{"id": PARENT, "name": "web"}, {"id": THREAD, "name": "web-comment-1", "thread": True, "parent": PARENT},
+                {"id": SENDER, "name": "api"}]
+        saved = pm._kernel_sessions_checked
+        pm._kernel_sessions_checked = lambda threads=False: ([r for r in rows if threads or not r.get("thread")], True)
+        try:
+            visible = [a["id"] for a in pm.all_agents(threads=True) if not pm._postal_off(a["id"])]   # the /agents filter
+            self.assertNotIn(THREAD, visible); self.assertIn(PARENT, visible)
+            res = pm.resolve_recipient("web-comment-1", SENDER)
+            self.assertEqual((res["kind"], res["status"]), ("error", 403))
+            self.assertIn("COMMENT THREAD", res["error"]); self.assertIn("breaks it out", res["error"]); self.assertIn("final", res["error"])
+            _flags({THREAD: {"threadMail": True}})
+            res = pm.resolve_recipient("web-comment-1", SENDER)
+            self.assertEqual(res["kind"], "direct", "with mail on, the thread is a recipient like any other")
+        finally:
+            pm._kernel_sessions_checked = saved
+
+
+class ThreadOwnSendRefused(unittest.TestCase):
+    """The thread's OWN send, over the real handler: 403 whose text says the thread's mail is off until it is
+    broken out (final; the isolation refusal a peer must not route around)."""
+
+    @classmethod
+    def setUpClass(cls):
+        import threading
+        from http.server import ThreadingHTTPServer
+        cls.srv = ThreadingHTTPServer(("127.0.0.1", 0), pm.Handler)
+        cls.port = cls.srv.server_address[1]
+        threading.Thread(target=cls.srv.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.srv.shutdown(); cls.srv.server_close()
+
+    def setUp(self):
+        _reg(THREAD, threadOf=PARENT)
+        self._saved = pm._kernel_sessions_checked
+        rows = [{"id": PARENT, "name": "web"}, {"id": THREAD, "name": "web-comment-1", "thread": True, "parent": PARENT}]
+        pm._kernel_sessions_checked = lambda threads=False: ([r for r in rows if threads or not r.get("thread")], True)
+        pm.STATE.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        pm._kernel_sessions_checked = self._saved
+        for f in (pm.SESSION_FLAGS, pm.SESSION_FLAGS.parent / "sdk" / (THREAD + ".json")):
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+    def _send(self, frm_id, frm, to):
+        import urllib.error
+        import urllib.request
+        req = urllib.request.Request("http://127.0.0.1:%d/send" % self.port, method="POST",
+                                     data=json.dumps({"to": to, "from": frm, "from_id": frm_id, "body": "a note", "kind": "coordinate"}).encode("utf-8"),
+                                     headers={"Content-Type": "application/json", "X-Romp-Token": pm.SERVE_TOKEN})
+        try:
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return r.status, json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            return e.code, json.loads(e.read())
+
+    def test_the_threads_own_send_is_refused_until_broken_out(self):
+        status, body = self._send(THREAD, "web-comment-1", "web")
+        self.assertEqual(status, 403, body)
+        self.assertTrue(body["error"].startswith("isolation:"), "the isolation refusal a peer treats as final")
+        self.assertIn("COMMENT THREAD", body["error"]); self.assertIn("breaks it out", body["error"]); self.assertIn("Nothing was sent", body["error"])
+        self.assertFalse((pm.MAILROOT / PARENT / "new").exists() and any((pm.MAILROOT / PARENT / "new").iterdir()), "nothing landed")
+        _reg(THREAD)                                       # broken out: the reg has no threadOf
+        status, body = self._send(THREAD, "web-2", "web")
+        self.assertNotEqual(status, 403, "a promoted session sends like any other: %r" % (body,))
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_thread_mail_off.py
+++ b/tests/test_thread_mail_off.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""A comment thread's mail is OFF by default, both directions, until the user breaks it out (T356, the user 2026-09-11:
+a comment thread of a manager session received the manager's mail, mailed two of its workers and merged a pull
+request as if it were the manager). The kernel's effective isolation reader derives the default from the thread's
+reg (threadOf), so a thread already on disk with no flag reads OFF; the fresh key `threadMail` at the literal True is
+the one way on short of a break-out (never an old key re-read); promotion clears threadOf and the ordinary rule
+returns. Synthetic fixtures only: placeholder UUIDs, a hermetic state root."""
+import inspect
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from romp_load import load_source
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel_thread_mail", os.path.join(BIN, "romp-kernel"))
+sb = load_source("romp_sdk_backend_thread_mail", os.path.join(BIN, "romp_sdk_backend.py"))
+
+PARENT = "11111111-2222-3333-4444-555555555555"
+THREAD = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+PLAIN = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+class ThreadMailOff(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        self.saved = km.jd.STATE
+        km.jd._rebind_state(Path(self.td))
+        km._thread_reg_memo.clear()
+        self.be = sb.SdkBackend(Path(self.td), "/bin/true", lambda *a, **k: None)
+        self.be.spawn("parent", self.td, sid=PARENT)
+        self.be.fork("thread-x", PARENT, "a1", sid=THREAD, thread_of=PARENT)
+
+    def tearDown(self):
+        km.jd._rebind_state(self.saved)
+        km._thread_reg_memo.clear()
+        shutil.rmtree(self.td, ignore_errors=True)
+
+    def _flags(self, flags):
+        (Path(self.td) / "session-flags.json").write_text(json.dumps(flags))
+        km._session_flags.cache_clear() if hasattr(km._session_flags, "cache_clear") else None
+
+    def test_a_new_thread_reads_mail_off_with_no_flag_on_disk(self):
+        self.assertTrue(km._thread_mail_off(THREAD)); self.assertTrue(km._postal_isolated(THREAD))
+        self.assertTrue(km._painted_flag_value(THREAD, "postalServiceOff"), "the display paints the default too")
+        self.assertFalse(km._postal_isolated(PARENT), "the session it belongs to is untouched")
+
+    def test_the_fresh_key_at_the_literal_true_is_the_one_way_on(self):
+        self._flags({THREAD: {"threadMail": True}})
+        self.assertFalse(km._thread_mail_off(THREAD)); self.assertFalse(km._postal_isolated(THREAD))
+        for v in ("true", 1, "on", [True]):
+            self._flags({THREAD: {"threadMail": v}})
+            self.assertTrue(km._postal_isolated(THREAD), "%r is not the literal True (the flip-a-default rule)" % (v,))
+        self._flags({THREAD: {"postalServiceOff": False}})
+        self.assertTrue(km._postal_isolated(THREAD), "the mailbox flag at False is not a way on for a thread")
+        self._flags({THREAD: {"threadMail": True, "postalServiceOff": True}})
+        self.assertTrue(km._postal_isolated(THREAD), "mail on for the thread, then the user's own isolation still holds")
+
+    def test_breaking_out_flips_mail_on_by_default(self):
+        self.assertTrue(km._postal_isolated(THREAD))
+        self.assertTrue(self.be.promote_thread(THREAD, "web-2"))
+        km._thread_reg_memo.clear()
+        self.assertFalse(km._thread_mail_off(THREAD), "no threadOf: not a thread any more")
+        self.assertFalse(km._postal_isolated(THREAD), "a promoted session's mail is on by default")
+        self._flags({THREAD: {"postalServiceOff": True}})
+        self.assertTrue(km._postal_isolated(THREAD), "…and follows the ordinary mailbox toggle from then on")
+
+    def test_an_ordinary_session_keeps_the_ordinary_rule(self):
+        self.be.spawn("plain", self.td, sid=PLAIN)
+        self.assertFalse(km._postal_isolated(PLAIN))
+        self._flags({PLAIN: {"postalOff": True}})
+        self.assertTrue(km._postal_isolated(PLAIN), "the legacy key still isolates")
+        self.assertFalse(km._thread_mail_off(""), "no sid: not a thread")
+
+    def test_the_frames_carry_the_effective_state(self):
+        # the comments frame says mailOff per thread; the /sessions thread rows and the Sessions pane rows carry the
+        # effective postalServiceOff; the timeline lane and the chat rows read the effective reader too
+        src = inspect.getsource(km._comments_frame)
+        self.assertIn('"mailOff": bool(_postal_isolated(tsid))', src)
+        rows = inspect.getsource(km._thread_rows)
+        self.assertIn('"postalServiceOff": _postal_isolated(tsid)', rows); self.assertIn('"mailOffWhy": "thread" if _thread_mail_off(tsid) else ""', rows)
+        whole = Path(os.path.join(BIN, "romp-kernel")).read_text()
+        self.assertEqual(whole.count('"postalServiceOff": _postal_isolated('), 4, "chat rows, timeline lanes, thread rows, Sessions pane rows")
+        self.assertNotIn('"postalServiceOff": _session_flag(sid, "postalServiceOff")', whole, "no row reads the raw flag past the effective reader")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -8,6 +8,8 @@
 export type CommentMsg = { who: "you" | "agent"; text: string; t: number };
 
 export type CommentThread = {
+  /** the thread's mail is off (T356): a comment thread neither sends nor receives peer mail until broken out */
+  mailOff?: boolean;
   tid: string;
   name?: string;              // the thread's editable name (<session>-comment-<N> by default)
   color?: string;             // the comment's identity color — picked distinct from its parent's

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -34,7 +34,8 @@ interface LedgerNode {
   promptAnchorUuid?: string | null; anchorUuid?: string | null;
 }
 interface Ledger { summary?: string; tree: LedgerNode[]; current?: { t?: number } | null; archivedTops?: LedgerNode[]; }
-interface FleetSession { sid: string; name: string; color: Color; status?: { state?: string } | null; ledger?: Ledger | null; }
+interface FleetSession { sid: string; name: string; color: Color; status?: { state?: string } | null; ledger?: Ledger | null;
+                         postalServiceOff?: boolean; }   // the session's mail is off (isolation, or a comment thread's default; T356)
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -602,6 +603,13 @@ function render() {
       nameInto(nm, s.name, s.sid, curSearch);   // highlight a name match (remote "host:" stays quiet metadata)
       if (s.color?.bg) nm.style.color = s.color.bg;
       head.appendChild(nm);
+      if (s.postalServiceOff) {
+        // T356: a session whose mail is off says so on its row, quietly
+        const mo = el("span", "fl-mail-off");
+        mo.textContent = "mail off";
+        mo.title = "this session neither sends nor receives peer mail";
+        head.appendChild(mo);
+      }
       head.title = "Open this session";
       head.dataset.act = "open"; head.dataset.sid = s.sid;   // click-safe: action lives on the #fleet-list delegate
       sec.appendChild(head);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5437,7 +5437,9 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   if (s.status.effort) rows.push(["Effort", s.status.effort]);
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
-  if (be) rows.push(["Backend", backendLabel(be)]);   // the shared names (T288); a session still running on the retired terminal backend (until stage 3) reads its id, never blank (review find)
+  if (be) rows.push(["Backend", backendLabel(be)]);
+  // the session's mail state (T356): off means peers cannot see or mail it and its own sends are refused
+  rows.push(["Mail", s.postalServiceOff ? "off: this session neither sends nor receives peer mail" : "on"]);   // the shared names (T288); a session still running on the retired terminal backend (until stage 3) reads its id, never blank (review find)
   // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
   // user 2026-08-09: shown whenever the backend reports it, one-auth machines included). No key material, ever.
   // When the CLI's own init landed on the OTHER side (authLive — say, a key found via apiKeyHelper
@@ -9795,6 +9797,14 @@ function renderCommentPopover(): void {
     crow.append(attach, box, send);
     pop.appendChild(crow);
     if (metaRowPending) pop.appendChild(metaRowPending);   // model/effort under the box, like the chat
+    if (th && th.mailOff) {
+      // T356 (the user 2026-09-11): a thread's mail is off, both directions, until it is broken out; the popover
+      // is the thread's whole surface, so it says so here
+      const mail = el("div", "cmt-note cmt-mail");
+      mail.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out.";
+      mail.title = "Peers cannot see or mail this thread, and its own mail is refused. Break out turns mail on.";
+      pop.appendChild(mail);
+    }
     if (th && th.status === "open") {
       // the thread is a real session under the hood — its model/effort switch LIVE through the
       // chat's own ops (setModel/setEffort route by sid; be.owns makes the thread reachable).
@@ -9862,6 +9872,10 @@ function renderCommentPopover(): void {
     const note = el("div", "cmt-note");
     note.textContent = "The discussion continues there.";
     pop.appendChild(note);
+    // the break-out flipped its mail on (T356): said once, here, where the user looks after breaking it out
+    const mailOn = el("div", "cmt-note cmt-mail");
+    mailOn.textContent = "Its mail is on now: peers can reach it and it can send.";
+    pop.appendChild(mailOn);
     const row = el("div", "cmt-actions");
     const open = el("button", "cmt-act") as HTMLButtonElement;
     open.type = "button";

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3723,6 +3723,9 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-act:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }   /* the feed word-button hover (2026-08-25): Break out / Merge / Delete light up like Clear/Undo */
 .cmt-act.cmt-del.armed { border-color: var(--st-blocked-bg, #c94f4f); color: var(--st-blocked-bg, #c94f4f); }
 .cmt-note.cmt-err { color: var(--st-blocked-bg, #c94f4f); opacity: 0.9; }
+/* the thread's mail state (T356): one quiet line under the composer */
+.cmt-note.cmt-mail { opacity: 0.6; font-size: 0.86em; }
+.fl-mail-off { flex: 0 0 auto; font-size: 0.72em; opacity: 0.6; padding: 0 5px; border: 1px solid currentColor; border-radius: 8px; margin-left: 4px; }
 /* a thread that became its own session (the user 2026-09-10): nothing in its view grows. The kernel
    ships it with no messages or events, so the .sized quote's flex had nothing beside it to share the
    box's fixed height with — a one-line quote ran hundreds of pixels tall over a void. The quote keeps

--- a/ui/webview/thread-mail.test.ts
+++ b/ui/webview/thread-mail.test.ts
@@ -1,0 +1,41 @@
+// A comment thread's mail is off until it is broken out (T356, the user 2026-09-11): the thread's whole surface is
+// the comment popover, so the popover says so; the tab hover and the Sessions pane show a session's mail state, so
+// a promoted thread's flip shows where a session is looked at; the kernel's frames carry the effective state.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ui = (...p: string[]) => fs.readFileSync(path.resolve(process.cwd(), "..", "ui", ...p), "utf8");
+const RENDER = ui("webview", "render.ts");
+const FLEET = ui("webview", "fleet.ts");
+const COMMENTS = ui("webview", "comments.ts");
+const CSS = ui("webview", "styles.css");
+const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
+const POSTAL = fs.readFileSync(path.resolve(process.cwd(), "..", "postal", "postal_service.py"), "utf8");
+
+test("the popover says the thread's mail is off, and the promoted view says it is on now", () => {
+  assert.match(COMMENTS, /mailOff\?: boolean;/, "the frame's field on the thread type");
+  assert.match(RENDER, /if \(th && th\.mailOff\) \{[\s\S]*?const mail = el\("div", "cmt-note cmt-mail"\);\s*\n\s*mail\.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out\.";/);
+  assert.match(RENDER, /note\.textContent = "The discussion continues there\.";\s*\n\s*pop\.appendChild\(note\);[\s\S]{0,200}mailOn\.textContent = "Its mail is on now: peers can reach it and it can send\.";/,
+               "said once, in the promoted view");
+  assert.match(CSS, /\.cmt-note\.cmt-mail \{ opacity: 0\.6; font-size: 0\.86em; \}/);
+});
+
+test("the tab hover and the Sessions pane show a session's mail state", () => {
+  assert.match(RENDER, /rows\.push\(\["Mail", s\.postalServiceOff \? "off: this session neither sends nor receives peer mail" : "on"\]\);/);
+  assert.match(FLEET, /postalServiceOff\?: boolean;/, "the Sessions pane row type carries it");
+  assert.match(FLEET, /if \(s\.postalServiceOff\) \{[\s\S]*?const mo = el\("span", "fl-mail-off"\);\s*\n\s*mo\.textContent = "mail off";/);
+  assert.match(CSS, /\.fl-mail-off \{/);
+});
+
+test("the kernel and the bus derive the same default from the thread's reg and the fresh key", () => {
+  assert.match(KERNEL, /def _thread_mail_off\(sid\):[\s\S]*?if not sid or not _thread_reg\(sid\)\.get\("threadOf"\):\s*\n\s*return False\s*\n\s*f = _session_flags\(\)\.get\(sid\)\s*\n\s*return not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\)/,
+               "literal True only (the flip-a-default rule)");
+  assert.match(KERNEL, /def _postal_isolated\(sid\):[\s\S]*?return _thread_mail_off\(sid\) or bool\(_session_flag\(sid, "postalServiceOff"\) or _session_flag\(sid, "postalOff"\)\)/);
+  assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),/, "the comments frame carries it");
+  assert.match(KERNEL, /"postalServiceOff": _postal_isolated\(m\["id"\]\),/, "the Sessions pane rows carry it");
+  assert.match(POSTAL, /if _thread_of\(sid\) and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/);
+  assert.match(POSTAL, /if why_off == "thread":[^\n]*\n\s*return self\._send\(\{"error": THREAD_MAIL_OFF_SENDER\}, 403\)/, "the thread's own send");
+  assert.match(POSTAL, /if any\(_mail_off_why\(a\["id"\]\) == "thread" for a in direct_all\):/, "a send to the thread");
+});


### PR DESCRIPTION
A comment thread's mail is off, both directions, until the user breaks it out into a session of its own; the break-out turns it on (the user 2026-09-11, after a comment thread of the manager session received the manager's mail, mailed two of its workers and merged a pull request as if it were the manager).

## Design points

- **One reader per side.** The kernel's effective isolation reader and the postal bus's derive a thread's mail state from the thread's own durable reg (`threadOf`) beside the shared flags file, so a thread with **no flag on disk reads off** (every thread already running is covered at landing). The one way on short of a break-out is the fresh key `threadMail` at the literal `true` (never an old key re-read; `"true"`, `1` and a mailbox flag at `false` are not it). A break-out clears `threadOf` (it already did) and the promoted session falls to the ordinary rule: mail on unless its mailbox is toggled off.
- **Both directions, final.** Through the bus's existing isolation sites: invisible to `list_agents`, inbox held undelivered, a send **to** it refused, its **own** send refused; each a 403 `isolation:` refusal (the kind a peer treats as final) whose text says it is a comment thread whose mail is off until the user breaks it out.
- **Where it shows.** The popover (the thread's whole surface) says "Mail off: this thread neither sends nor receives peer mail until you break it out."; the promoted view says once "Its mail is on now: peers can reach it and it can send." The tab hover gains a **Mail** row and the Sessions pane a quiet "mail off" tag, from the effective state the kernel ships on every row (chat, timeline, `GET /sessions?threads=1` with `mailOffWhy`, the Sessions pane). `docs/guide.md` says it.
- **Kernel and bus in one PR**: the two readers must agree from the same commit.

## Tests

- `tests/test_thread_mail_off.py`: a real backend fork as a thread; off with no flag; the literal-`true` key and its impostors; `promote_thread` flipping it on; an ordinary session's rule; the frames pinned.
- `tests/test_postal_isolation.py`: the bus's reason, impostors, a corrupt flags file, the receive hold, the `/agents` filter, `resolve_recipient`'s 403 text, and the thread's own `POST /send` over the real handler (403 with the thread text, then a plain send once broken out).
- `ui/webview/thread-mail.test.ts`: the popover and promoted lines, the tab tip row, the Sessions pane tag, both readers pinned. Two older pins re-pointed from the raw flag expression to the effective reader.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
