### PR TITLE
The chat pane never jumps to another session on its own: a focused tab that vanishes leaves the pane unfocused, and its return restores it (T357)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -408,9 +408,15 @@ host reconnects, a relay down, a session that ended), the pane goes blank: no
 tab is selected, the body names the session that vanished (and says it is
 reconnecting when that is known), and the message box is disabled with no
 session name in it. When that same session's tab returns, the pane goes back
-to it. Focus moves to a different session only when you pick a tab, or when you
-close the active tab yourself (then the pane returns to the tab you used before
-it).
+to it. After a kernel restart the page reloads and remembers the tab you were
+on: until that session is listed again the pane stays blank and names it as not
+listed yet, and it never settles on another session meanwhile; if it never
+returns, the blank body stays until you pick a tab. A tab view that stops
+showing your session (a tag removed) blanks the pane the same way and comes back
+to it when the view shows it again. From the blank pane an arrow key or Next Tab
+lands on the first visible tab. Focus moves to a different session only when
+you pick a tab, or when you close the active tab yourself (then the pane returns
+to the tab you used before it).
 
 A session started from another one joins its tags. Forking a session, breaking
 a comment thread out into its own session, and running `romp new` inside a

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -402,6 +402,16 @@ a subproject that became its own repository, right-click its tab and choose
 name, mail and history stay with the session, and from the next turn on the
 agent works in the new folder and reads its `CLAUDE.md`.
 
+The chat pane never jumps to another session on its own. If the tab you are
+on disappears (a kernel restart that hides a remote host's sessions until the
+host reconnects, a relay down, a session that ended), the pane goes blank: no
+tab is selected, the body names the session that vanished (and says it is
+reconnecting when that is known), and the message box is disabled with no
+session name in it. When that same session's tab returns, the pane goes back
+to it. Focus moves to a different session only when you pick a tab, or when you
+close the active tab yourself (then the pane returns to the tab you used before
+it).
+
 A session started from another one joins its tags. Forking a session, breaking
 a comment thread out into its own session, and running `romp new` inside a
 session's shell all put the new session in the parent's groups, so a session's

--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -6,6 +6,9 @@ active tab, the body names the session that vanished, the composer disabled with
 the box. A tabOrder push that adds a NEW session changes nothing (no adoption). A tabOrder push listing the vanished
 session again restores focus to it,
 and its transcript comes back. Screenshots of the unfocused state, dark and light (PV_SHOTS names the folder).
+The reload road (the review's HIGH, the user's actual trigger): the persisted state names a REMOTE tab this kernel never
+lists; after a reload the pane stays unfocused naming it, the local sessions adopt nothing, the remote strip entry
+restores focus to it, and a pick made before the relay wins.
 Synthetic fixtures only: placeholder UUIDs, a hermetic state root, an invented notes-api world."""
 import json
 import os
@@ -32,6 +35,7 @@ import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (th
 SID_A = "11111111-2222-3333-4444-555555555555"
 SID_B = "aaaaaaaa-1111-2222-3333-444444444444"
 SID_C = "bbbbbbbb-1111-2222-3333-444444444444"   # a session that appears while the user's tab is away: never adopted
+REMOTE = "REMOTEBOX:cccccccc-1111-2222-3333-444444444444"   # a remote host's session this kernel never lists: the reload road's awaited tab
 
 
 def _free_port():
@@ -110,6 +114,37 @@ await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .t
 // wears the session's colour again
 await page.waitForFunction(() => { const e = document.getElementById("empty-state"); const ta = document.getElementById("composer-input"); return (!e || getComputedStyle(e).display === "none") && ta && !ta.disabled && document.body.style.getPropertyValue("--active-accent") !== ""; }, null, { timeout: 20000 });
 out.restored = await state();
+
+// ---- the reload road (the review's HIGH, the user's actual trigger): a kernel restart RELOADS the page, so no dismissal
+// runs; the page remembers the REMOTE tab it showed, the local kernel's sessions arrive first, and the remote host relays
+// later. Seed the persisted state with a remote sid and reload: the pane must stay unfocused naming it, adopt nothing,
+// and focus it when its strip entry arrives; a pick in between wins.
+const seed = () => page.evaluate((remote) => {
+  const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-"));
+  const st = key ? JSON.parse(localStorage.getItem(key) || "{}") : {};
+  // the name as the page persists it for a remote session: federation prefixes the host (host-prefix.ts hostPrefix)
+  localStorage.setItem(key, JSON.stringify({ ...st, activeId: remote, activeName: "REMOTEBOX:web" }));
+  return key;
+}, cfg.remote);
+out.seedKey = await seed();
+await page.reload();
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, 2, { timeout: 20000 });
+await page.waitForTimeout(600);   // the local sessions' frames land: nothing may adopt
+out.reloadAwaiting = await state();
+const R_TAB = { id: cfg.remote, name: "web", color: { bg: "#f2b26b", fg: "#1a1206" } };
+await inject({ type: "tabOrder", order: [cfg.remote, cfg.sidA, cfg.sidB, cfg.sidC], tabs: [R_TAB, A_TAB, B_TAB, C_TAB], live: [cfg.remote, cfg.sidA, cfg.sidB, cfg.sidC], skeleton: [cfg.remote, cfg.sidC] });
+await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid; }, cfg.remote, { timeout: 10000 });
+out.reloadRestored = await state();
+// …and a pick in between wins: seed again, reload, click B before the remote host relays; the relay then changes nothing
+await seed();
+await page.reload();
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, 2, { timeout: 20000 });
+await page.waitForTimeout(300);
+await page.click('#tabs .tab[data-id="' + cfg.sidB + '"]');
+await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid; }, cfg.sidB, { timeout: 10000 });
+await inject({ type: "tabOrder", order: [cfg.remote, cfg.sidA, cfg.sidB, cfg.sidC], tabs: [R_TAB, A_TAB, B_TAB, C_TAB], live: [cfg.remote, cfg.sidA, cfg.sidB, cfg.sidC], skeleton: [cfg.remote, cfg.sidC] });
+await page.waitForTimeout(500);
+out.pickWins = await state();
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
 process.exit(0);
@@ -179,7 +214,7 @@ class ServedUnfocusedPane(unittest.TestCase):
     def test_the_focused_tab_leaving_on_its_own_unfocuses_the_pane_and_its_return_restores_it(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C,
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "remote": REMOTE,
                        "shots": os.environ.get("PV_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -221,6 +256,15 @@ class ServedUnfocusedPane(unittest.TestCase):
         self.assertFalse(s["composer"]["disabled"]); self.assertIn("web", s["composer"]["ph"] or "", "the box names its session again (the name overlay): %r" % s["composer"])
         self.assertEqual(s["accent"], r["before"]["accent"], "the window border wears what it wore before the tab vanished")
         self.assertNotEqual(s["statusline"], "", "the statusline names the restored session's state again")
+        # the reload road: the persisted remote tab is awaited, the body names it, the local sessions adopt nothing
+        self.assertTrue(r["seedKey"], "the shim's persisted state was found and seeded")
+        a = r["reloadAwaiting"]
+        self.assertIsNone(a["active"], "after the reload nothing adopts the box while the remembered tab is awaited: %r" % a)
+        self.assertIsNotNone(a["empty"]); self.assertTrue(a["empty"]["unfocused"]); self.assertEqual(a["empty"]["vanished"], REMOTE)
+        self.assertIn("web", a["empty"]["text"]); self.assertIn("REMOTEBOX", a["empty"]["text"], "the host the tab wore"); self.assertIn("not listed yet", a["empty"]["text"])
+        self.assertTrue(a["composer"]["disabled"]); self.assertEqual(a["statusline"], "")
+        self.assertEqual(r["reloadRestored"]["active"], REMOTE, "the remote host relays its strip: focus goes to the remembered tab")
+        self.assertEqual(r["pickWins"]["active"], SID_B, "a pick before the relay wins; the relay changes nothing: %r" % r["pickWins"])
 
 
 if __name__ == "__main__":

--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""The chat pane never jumps to another session on its own (T357, the user 2026-09-11). On the real chat page: two
+sessions, the user on the first; its tab leaves the strip on its own (federation's synthetic `closed` with hostDrop, the
+frame a host relay going down produces, and the merged strip without that host's tabs) and the pane goes UNFOCUSED: no
+active tab, the body names the session that vanished, the composer disabled with no session name, no session colour on
+the box. A tabOrder push that adds a NEW session changes nothing (no adoption). A tabOrder push listing the vanished
+session again restores focus to it,
+and its transcript comes back. Screenshots of the unfocused state, dark and light (PV_SHOTS names the folder).
+Synthetic fixtures only: placeholder UUIDs, a hermetic state root, an invented notes-api world."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SID_A = "11111111-2222-3333-4444-555555555555"
+SID_B = "aaaaaaaa-1111-2222-3333-444444444444"
+SID_C = "bbbbbbbb-1111-2222-3333-444444444444"   # a session that appears while the user's tab is away: never adopted
+
+
+def _free_port():
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); p = s.getsockname()[1]; s.close(); return p
+
+
+def _transcript(sid, text):
+    u, a = "u-" + sid[:8], "a-" + sid[:8]
+    return (json.dumps({"type": "user", "uuid": u, "parentUuid": None, "timestamp": "2026-09-05T00:00:00.000Z", "sessionId": sid,
+                        "message": {"role": "user", "content": "Where do the notes-api docs start?"}}) + "\n"
+            + json.dumps({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": "2026-09-05T00:00:05.000Z", "sessionId": sid,
+                          "message": {"role": "assistant", "model": "claude-opus-5", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}) + "\n")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 });
+await page.goto(cfg.chat);
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, 2, { timeout: 20000 });
+const state = () => page.evaluate(() => {
+  const act = document.querySelector("#tabs .tab.active[data-id]");
+  const empty = document.getElementById("empty-state");
+  const ta = document.getElementById("composer-input");
+  const box = document.getElementById("composer");
+  const note = document.getElementById("composer-note");
+  const views = Array.from(document.querAll ? [] : document.querySelectorAll("#content .view, #content [data-sid]"));
+  return { active: act ? act.dataset.id : null, tabs: Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => t.dataset.id),
+           empty: empty && getComputedStyle(empty).display !== "none" ? { text: empty.textContent, unfocused: empty.classList.contains("unfocused"), vanished: empty.dataset.vanished || "" } : null,
+           composer: ta ? { disabled: ta.disabled, placeholder: ta.placeholder, identity: box ? box.style.getPropertyValue("--composer-identity") : "",
+                            ph: (() => { const ph = document.getElementById("composer-ph"); return ph && getComputedStyle(ph).display !== "none" ? ph.textContent : ""; })() } : null,
+           note: note ? note.textContent : null,
+           accent: document.body.style.getPropertyValue("--active-accent"),
+           statusline: (document.getElementById("statusline") || {}).textContent || "",
+           theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const inject = (frame) => page.evaluate((f) => { window.postMessage(f, "*"); }, frame);
+const out = {};
+// the user picks A
+await page.click('#tabs .tab[data-id="' + cfg.sidA + '"]');
+await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid; }, cfg.sidA, { timeout: 10000 });
+await page.waitForFunction(() => !document.getElementById("composer-input").disabled, null, { timeout: 10000 });
+out.before = await state();
+// A's tab leaves on its own: the frames federation dispatches when a host drops off — a synthetic `closed` per session
+// of that host, and the merged strip without them (the strip paints a tab for every id the last tabOrder carried)
+const B_TAB = { id: cfg.sidB, name: "api", color: { bg: "#9cd2ff", fg: "#0c1a2e" } };
+const A_TAB = { id: cfg.sidA, name: "web", color: { bg: "#f2b26b", fg: "#1a1206" } };
+const C_TAB = { id: cfg.sidC, name: "docs", color: { bg: "#b5e3a1", fg: "#0f1f0a" } };
+await inject({ type: "closed", id: cfg.sidA, hostDrop: true });
+await inject({ type: "tabOrder", order: [cfg.sidB], tabs: [B_TAB], live: [cfg.sidB], skeleton: [] });
+await page.waitForFunction((sid) => !document.querySelector("#tabs .tab.active[data-id]") && !document.querySelector('#tabs .tab[data-id="' + sid + '"]'), cfg.sidA, { timeout: 10000 });
+await page.waitForTimeout(300);
+out.unfocused = await state();
+const shot = async (name) => { if (!cfg.shots) return; fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/" + name + ".png" }); };   // the whole pane: the strip, the body's line, the disabled box
+await shot("romp_chat-unfocused-pane-dark");
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(200);
+await shot("romp_chat-unfocused-pane-light");
+await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(100);
+// another session appearing meanwhile takes nothing: a NEW tab (docs) joins the strip and the pane stays unfocused
+await inject({ type: "tabOrder", order: [cfg.sidB, cfg.sidC], tabs: [B_TAB, C_TAB], live: [cfg.sidB, cfg.sidC], skeleton: [cfg.sidC] });
+await page.waitForFunction((sid) => !!document.querySelector('#tabs .tab[data-id="' + sid + '"]'), cfg.sidC, { timeout: 10000 });
+await page.waitForTimeout(300);
+out.otherArrived = await state();
+// A's tab is re-listed (the host re-attached): the kernel's strip names it a skeleton (this page holds no frame for it
+// any more), focus goes back to it, the skeleton branch asks for its frame, and its transcript returns
+await inject({ type: "tabOrder", order: [cfg.sidA, cfg.sidB, cfg.sidC], tabs: [A_TAB, B_TAB, C_TAB], live: [cfg.sidA, cfg.sidB, cfg.sidC], skeleton: [cfg.sidA, cfg.sidC] });
+await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid; }, cfg.sidA, { timeout: 10000 });
+// the restore lands in two steps: the strip's skeleton tab takes focus at once, and its session frame follows (the
+// skeleton branch asks for it); the state is read once the transcript is on screen, which is when the window border
+// wears the session's colour again
+await page.waitForFunction(() => { const e = document.getElementById("empty-state"); const ta = document.getElementById("composer-input"); return (!e || getComputedStyle(e).display === "none") && ta && !ta.disabled && document.body.style.getPropertyValue("--active-accent") !== ""; }, null, { timeout: 20000 });
+out.restored = await state();
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedUnfocusedPane(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served lab needs them; CI's extension job has them and requires this file to run")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served lab needs one; CI's extension job installs Chromium and requires this file to run")
+        cls.lab = tempfile.mkdtemp(prefix="unfocused-pane-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        for sid, name, color, text in ((SID_A, "web", ("#f2b26b", "#1a1206"), "The web notes start in docs/guide.md."),
+                                       (SID_B, "api", ("#9cd2ff", "#0c1a2e"), "The api notes start in docs/api.md.")):
+            Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, color[0], color[1]))
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                 "model": "claude-opus-5", "liveModel": "Opus 5"}))
+            Path(proj, sid + ".jsonl").write_text(_transcript(sid, text))
+        cls.port, cls.token = _free_port(), "testtok-unfocused"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_the_focused_tab_leaving_on_its_own_unfocuses_the_pane_and_its_return_restores_it(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C,
+                       "shots": os.environ.get("PV_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served lab needs one; CI's extension job installs Chromium and requires this file to run")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertEqual(r["before"]["active"], SID_A); self.assertFalse(r["before"]["composer"]["disabled"])
+        # the tab left on its own → UNFOCUSED: no active tab, the body names web and says its host disconnected, the
+        # composer disabled with no session name, no session colour on the box or the window border
+        u = r["unfocused"]
+        self.assertIsNone(u["active"], "no tab is active: %r" % u)
+        self.assertNotIn(SID_A, u["tabs"], "the tab is gone from the strip"); self.assertIn(SID_B, u["tabs"], "the other tab stays")
+        self.assertIsNotNone(u["empty"], "the blank body is up")
+        self.assertTrue(u["empty"]["unfocused"]); self.assertEqual(u["empty"]["vanished"], SID_A)
+        self.assertIn("No session selected. Pick a tab to start.", u["empty"]["text"])
+        self.assertIn("web", u["empty"]["text"]); self.assertIn("host disconnected", u["empty"]["text"])
+        self.assertTrue(u["composer"]["disabled"], "the box takes no input")
+        self.assertEqual(u["composer"]["placeholder"], "Pick a tab to start", "no session name in the placeholder")
+        self.assertEqual(u["composer"]["ph"], "", "the name overlay is down: no session name anywhere on the box")
+        self.assertEqual(u["composer"]["identity"], "", "no session colour on the focus ring")
+        self.assertEqual(u["accent"], "", "no session colour on the window border")
+        self.assertEqual(u["statusline"], "", "the statusline says nothing: not the vanished session's chips")
+        self.assertIn("web", u["note"] or "", "the note above the box still says whose box went away (T236)")
+        # another session's tab re-listed meanwhile: nothing changes hands
+        o = r["otherArrived"]
+        self.assertIsNone(o["active"], "a different session appearing does not take focus: %r" % o)
+        self.assertIn(SID_C, o["tabs"], "the new tab is on the strip"); self.assertTrue(o["composer"]["disabled"])
+        self.assertIsNotNone(o["empty"]); self.assertEqual(o["empty"]["vanished"], SID_A, "the body still names the session that vanished")
+        # the same session's tab is back → focus restored to it, its transcript on screen, the box live again
+        s = r["restored"]
+        self.assertEqual(s["active"], SID_A, "focus went back to the session the user chose: %r" % s)
+        self.assertIsNone(s["empty"], "the blank body is gone")
+        self.assertFalse(s["composer"]["disabled"]); self.assertIn("web", s["composer"]["ph"] or "", "the box names its session again (the name overlay): %r" % s["composer"])
+        self.assertEqual(s["accent"], r["before"]["accent"], "the window border wears what it wore before the tab vanished")
+        self.assertNotEqual(s["statusline"], "", "the statusline names the restored session's state again")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/chat-window.test.ts
+++ b/ui/webview/chat-window.test.ts
@@ -91,7 +91,9 @@ test("render.ts wires the three rules, tracks the pending needFull reason, hides
   assert.ok(more.includes("const am = afterMore(!!msg.more, !!s.headKnown, s.events.length);"), "chatMore decides through the rule");
   assert.ok(more.includes("if (msg.id === activeId && s.detached) window.requestAnimationFrame(() => edgeCheckAfterWindow(msg.id));"), "…and a still-detached run re-checks its edge after the page painted");
   const active = RENDER.slice(RENDER.indexOf("function setActive(id: string"), RENDER.indexOf("\n}\n", RENDER.indexOf("function setActive(id: string")));
-  assert.ok(active.includes("activeId = id;\n  updateLivePaused();"), "a tab switch re-evaluates the strip for the entering tab");
+  // (T357: the unfocused state's clear sits between the two lines; the re-evaluation still follows the activation)
+  const actAt = active.indexOf("activeId = id;\n  vanishedId = null;"), pausedAt = active.indexOf("updateLivePaused();");
+  assert.ok(actAt >= 0 && pausedAt > actAt && pausedAt - actAt < 200, "a tab switch re-evaluates the strip for the entering tab");
   assert.ok(RENDER.includes('turn.dataset.orphanOf = String((ev as { orphanOf?: string }).orphanOf)'), "an orphan note's turn carries its record uuid");
   assert.equal((RENDER.match(/\.turn\[data-orphan-of="\$\{cssEscape\(uuid\)\}"\]/g) || []).length, 2, "…and both anchor lookups read it");
   assert.ok(RENDER.includes("(e as { orphanOf?: string }).orphanOf === uuid"), "…as does the events-list search behind them");

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -345,7 +345,7 @@ test("the note retires on the exact events: an explicit switch, the session's re
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const adopted = !activeId && !vanishedId;\s*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); \}/, "…and never while the user's own tab is away (T357)");
+  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive;[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); \}/, "…and never while the user's own tab is away, or awaited after a reload (T357)");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -304,9 +304,11 @@ test("an active tab torn down under the user: stash first, prune the fallback, b
   // the live text is stashed under ITS id before anything is cleared or re-bound
   assert.ok(fn.indexOf("stashActiveDraft(id)") >= 0 && fn.indexOf("stashActiveDraft(id)") < fn.indexOf("sessions.delete(id)"), "stash precedes the teardown");
   // the dismissed id leaves the recency stack BEFORE the fallback is read
-  assert.ok(fn.indexOf("mru.splice(mi, 1)") < fn.indexOf("activeId = mru.find("), "pin (iv): fallback never the dismissed id");
+  assert.ok(fn.indexOf("mru.splice(mi, 1)") < fn.indexOf("focusAfterDismiss(why, mru, order, goingToo)"), "pin (iv): fallback never the dismissed id");
   // …and never an id the strip no longer shows: the re-bound box loads the fallback's own draft through the shared loader
-  assert.match(fn, /const home = hostOf\(id\);[^\n]*\n\s*const goingToo = \(x: string\) => \(doomed\?\.has\(x\) \?\? false\) \|\| \(why === "hostDrop" && !!home && hostOf\(x\) === home\);[\s\S]*?activeId = mru\.find\(\(x\) => order\.includes\(x\) && !goingToo\(x\)\) \|\| order\.find\(\(x\) => !goingToo\(x\)\) \|\| null;[\s\S]*?loadComposerFor\(activeId\);/);
+  // (T357: the fallback itself moved to pane-focus.ts focusAfterDismiss and runs for the user's own ✕ alone; every
+  // other departure leaves the pane unfocused — pane-focus.test.ts executes both)
+  assert.match(fn, /const home = hostOf\(id\);[^\n]*\n\s*const goingToo = \(x: string\) => \(doomed\?\.has\(x\) \?\? false\) \|\| \(why === "hostDrop" && !!home && hostOf\(x\) === home\);\s*\n\s*const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;[\s\S]*?loadComposerFor\(activeId\);/);
   // …and, unless the user themself clicked ✕, the box is blurred and the note names what went away
   assert.match(fn, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/);
 });
@@ -343,7 +345,7 @@ test("the note retires on the exact events: an explicit switch, the session's re
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const adopted = !activeId;\s*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); \}/);
+  assert.match(RENDER, /const adopted = !activeId && !vanishedId;\s*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); \}/, "…and never while the user's own tab is away (T357)");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/host-dial-live.test.ts
+++ b/ui/webview/host-dial-live.test.ts
@@ -80,7 +80,7 @@ test("the foot's swirl sits after the sentence as the gist's flex sibling, only 
   assert.match(RENDER, /swirl\.src = mediaSrc\("romp-swirl-glyph\.svg"\); swirl\.alt = ""; swirl\.onerror = \(\) => swirl\.remove\(\);/);
   assert.match(RENDER, /const gistEl = card\.querySelector\("\.notice-head \.notice-gist"\);\n\s*if \(gistEl\) gistEl\.after\(swirl\);/,
     "a flex SIBLING right after the gist, never inside it (the gist ellipsizes on a narrow pane and would clip the swirl first)");
-  assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); \}\);/,
+  assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); repaintEmptyStateIfUnfocused\(\); \}\);/,   // (T357: the unfocused body's "reconnecting" rides the same event)
     "repainted on federation's dial event, and on nothing timed");
 });
 

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -82,7 +82,9 @@ test("a filtered view re-points the CHAT BODY, not just the tab bar", () => {
   // the deferred bounce re-validates at FIRE time since the ephemeral peek (2026-08-24): an
   // activation between schedule and fire (a feed click opening a peek) makes the active tab
   // visible again — bouncing then would kick the user off the tab they just opened
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/);
+  // (T357: the fallback no longer re-points the pane at another session; it goes UNFOCUSED naming the tab the view
+  // hides, which still takes the hidden transcript off screen, and comes back to it when the view shows it again)
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\); \}, 0\);/);
 });
 
 test("feed cards filter by the #only tag; clear bookkeeping still uses the FULL payload", () => {

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -1,0 +1,64 @@
+// The chat pane never jumps to another session on its own (T357, the user 2026-09-11): a tab that leaves the strip
+// on its own leaves the pane UNFOCUSED, the same session takes focus back when its tab returns, and only the user's
+// own ✕ keeps the recency fallback. The rule and the words are executed here (pane-focus.ts); the wiring is pinned.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { focusAfterDismiss, emptyStateParts } from "./pane-focus";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const fn = (name: string) => { const i = RENDER.indexOf("function " + name + "("); const b = RENDER.slice(i); return b.slice(0, b.indexOf("\n}\n") + 3); };
+
+test("focusAfterDismiss: the user's own ✕ keeps the recency fallback; every other departure leaves the pane unfocused", () => {
+  const none = () => false;
+  assert.deepEqual(focusAfterDismiss("close", ["b", "a"], ["a", "b", "c"], none), { activeId: "b", unfocused: false }, "MRU first");
+  assert.deepEqual(focusAfterDismiss("close", ["x"], ["a", "b"], none), { activeId: "a", unfocused: false }, "no recency on the strip: the first tab");
+  assert.deepEqual(focusAfterDismiss("close", ["b"], ["a", "b"], (id) => id === "b"), { activeId: "a", unfocused: false }, "never one the same teardown takes next");
+  assert.deepEqual(focusAfterDismiss("close", [], [], none), { activeId: null, unfocused: false }, "nothing left: no tab, not the unfocused state");
+  for (const why of ["hostDrop", "omitted", "end"] as const) {
+    assert.deepEqual(focusAfterDismiss(why, ["b", "a"], ["a", "b", "c"], none), { activeId: null, unfocused: true },
+                     why + ": no other session takes the box, whatever the recency says");
+  }
+});
+
+test("emptyStateParts: the body names the session that vanished and why; reconnecting when the host is dialing", () => {
+  assert.deepEqual(emptyStateParts(null, false), { head: "No session open — click + to add one.", name: null, tail: "" });
+  assert.deepEqual(emptyStateParts(null, true), { head: "No session selected. Pick a tab to start.", name: null, tail: "" });
+  assert.deepEqual(emptyStateParts({ name: "web", why: "hostDrop", dialing: true }, true),
+                   { head: "No session selected. Pick a tab to start. ", name: "web", tail: "’s host disconnected; reconnecting… It comes back here when the host does." });
+  assert.deepEqual(emptyStateParts({ name: "web", why: "hostDrop", dialing: false }, true).tail, "’s host disconnected. It comes back here when the host does.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "omitted", dialing: false }, true).tail, " is no longer listed by romp. It comes back here if it returns.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "end", dialing: false }, true).tail, " ended.");
+  for (const p of [emptyStateParts({ name: "web", why: "hostDrop", dialing: true }, true), emptyStateParts(null, true)]) {
+    assert.doesNotMatch(p.head + p.tail, /\b(card|board|goal|column|nudge)\b/, "no romp nouns in the body's line");
+  }
+});
+
+test("the wiring: the dismiss branch, the unfocused body, the composer, the restore on return, no adoption meanwhile", () => {
+  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: DismissWhy \| null = null;\s*\nlet vanishedName = "";/m);
+  const dismiss = fn("dismissSession");
+  assert.match(dismiss, /const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;\s*\n\s*if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; \}/);
+  assert.match(dismiss, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/, "the T236 note above the box still says whose box went away");
+  // the pick (and the restore) end the unfocused state
+  assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = "";/);
+  // the empty body: pane-focus's words, the name dressed as the strip dresses it, the composer disabled and nameless
+  const show = fn("showActive");
+  assert.match(show, /paintEmptyState\(empty\);\s*\n\s*empty\.style\.display = "";\s*\n[\s\S]{0,200}?ta\.disabled = true; ta\.placeholder = order\.length \? "Pick a tab to start" : "Click \+ to add a session"; syncComposerPh\(\);/);
+  assert.match(show, /if \(sendBtn\) sendBtn\.disabled = true;\s*\n\s*\}\s*\n\s*document\.body\.style\.removeProperty\("--active-accent"\);/, "no session colour on the window border either");
+  const paint = fn("paintEmptyState");
+  assert.match(paint, /dialing: hostIsDialing\(vanishedId\)/, "reconnecting is the host's dial state, never a timer");
+  assert.match(paint, /b\.replaceChildren\(\.\.\.hostNameNodes\(parts\.name, vanishedId\)\);/, "the host prefix the tab wore");
+  assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = vanishedId \|\| "";/);
+  assert.doesNotMatch(RENDER, /empty\.textContent = "No session open/, "the one writer of the empty body is paintEmptyState");
+  // the return: the session frame, or the strip re-listing it; no other arrival adopts the box meanwhile
+  assert.match(RENDER, /if \(vanishedId === msg\.id\) setActive\(msg\.id\);\s*\n\s*const adopted = !activeId && !vanishedId;/);
+  assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,400}?if \(vanishedId && order\.includes\(vanishedId\)\) setActive\(vanishedId\);/);
+  // the feed relay: showActive announces the active tab (null included) on every branch it takes
+  assert.match(show, /^\s*notifyActive\(\);/m);
+  assert.match(fn("notifyActive"), /vscodeApi\.postMessage\(\{ type: "activeTab", id: activeId \}\)/, "null rides as null");
+  assert.match(CSS, /\.empty-state\.unfocused \{/); assert.match(CSS, /\.empty-state-name \{ font-weight: 600; \}/);
+  // the statusline says nothing with no active session: not the vanished session's chips (the served lab's screenshot found it)
+  assert.match(fn("updateStatusline"), /if \(!s\) \{ sl\.replaceChildren\(\); return; \}/);
+});

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -31,30 +31,50 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
   assert.deepEqual(emptyStateParts({ name: "web", why: "hostDrop", dialing: false }, true).tail, "’s host disconnected. It comes back here when the host does.");
   assert.deepEqual(emptyStateParts({ name: "web", why: "omitted", dialing: false }, true).tail, " is no longer listed by romp. It comes back here if it returns.");
   assert.deepEqual(emptyStateParts({ name: "web", why: "end", dialing: false }, true).tail, " ended.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, true),
+                   { head: "No session selected. Pick a tab to start. ", name: "web", tail: " is not listed yet. It comes back here when its host does." });
+  assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: true }, true).tail, " is not listed yet; its host is reconnecting… It comes back here when the host does.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "hidden", dialing: false }, true).tail, " is not shown by this tab view. Pick a tab, or change the view.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, false).head, "No sessions yet. ", "an empty strip invites no pick");
   for (const p of [emptyStateParts({ name: "web", why: "hostDrop", dialing: true }, true), emptyStateParts(null, true)]) {
     assert.doesNotMatch(p.head + p.tail, /\b(card|board|goal|column|nudge)\b/, "no romp nouns in the body's line");
   }
 });
 
 test("the wiring: the dismiss branch, the unfocused body, the composer, the restore on return, no adoption meanwhile", () => {
-  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: DismissWhy \| null = null;\s*\nlet vanishedName = "";/m);
+  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: VanishWhy \| null = null;\s*\nlet vanishedName = "";/m);
   const dismiss = fn("dismissSession");
   assert.match(dismiss, /const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;\s*\n\s*if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; \}/);
   assert.match(dismiss, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/, "the T236 note above the box still says whose box went away");
   // the pick (and the restore) end the unfocused state
-  assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = "";/);
+  assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null;/, "a pick ends the unfocused state AND the awaited tab");
+  assert.match(fn("setActive"), /activeId: id, activeName: liveSession\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| ""/, "the name persists beside the id for the reload's body");
   // the empty body: pane-focus's words, the name dressed as the strip dresses it, the composer disabled and nameless
   const show = fn("showActive");
   assert.match(show, /paintEmptyState\(empty\);\s*\n\s*empty\.style\.display = "";\s*\n[\s\S]{0,200}?ta\.disabled = true; ta\.placeholder = order\.length \? "Pick a tab to start" : "Click \+ to add a session"; syncComposerPh\(\);/);
   assert.match(show, /if \(sendBtn\) sendBtn\.disabled = true;\s*\n\s*\}\s*\n\s*document\.body\.style\.removeProperty\("--active-accent"\);/, "no session colour on the window border either");
   const paint = fn("paintEmptyState");
   assert.match(paint, /dialing: hostIsDialing\(vanishedId\)/, "reconnecting is the host's dial state, never a timer");
-  assert.match(paint, /b\.replaceChildren\(\.\.\.hostNameNodes\(parts\.name, vanishedId\)\);/, "the host prefix the tab wore");
-  assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = vanishedId \|\| "";/);
+  assert.match(paint, /b\.replaceChildren\(\.\.\.hostNameNodes\(parts\.name, named\)\);/, "the host prefix the tab wore (the vanished or the awaited id)");
+  assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = named \|\| "";/, "the body names the vanished or the awaited id");
   assert.doesNotMatch(RENDER, /empty\.textContent = "No session open/, "the one writer of the empty body is paintEmptyState");
   // the return: the session frame, or the strip re-listing it; no other arrival adopts the box meanwhile
-  assert.match(RENDER, /if \(vanishedId === msg\.id\) setActive\(msg\.id\);\s*\n\s*const adopted = !activeId && !vanishedId;/);
-  assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,400}?if \(vanishedId && order\.includes\(vanishedId\)\) setActive\(vanishedId\);/);
+  assert.match(RENDER, /if \(vanishedId === msg\.id\) setActive\(msg\.id\);\s*\n\s*const adopted = !activeId && !vanishedId && !wantActive;/);
+  assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,500}?const back = vanishedId \|\| wantActive;[^\n]*\n\s*if \(back && order\.includes\(back\)\) setActive\(back\);/);
+  // the reload road (the review's HIGH): the persisted tab is awaited at boot, the body names it, nothing adopts
+  assert.match(RENDER, /^let wantActiveName: string = /m);
+  assert.match(fn("paintEmptyState"), /const awaited = !vanishedId && wantActive \? wantActive : null;/);
+  assert.match(RENDER, /renderBgTasks\(\);\s*\n\s*\} else if \(!activeId\) \{[\s\S]{0,300}?showActive\(\);\s*\n\s*\}/, "a frame landing on an unfocused pane paints the body, adopting nothing");
+  assert.match(fn("paintEmptyState"), /why: "awaited" as const, dialing: hostIsDialing\(awaited\)/);
+  // the body repaints on the dial event; the view filter routes through the same rule; the keyboard picks the first tab
+  assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ if \(!activeId\) \{ const e = document\.getElementById\("empty-state"\); if \(e\) paintEmptyState\(e\); \} \}\);/);
+  assert.match(fn("renderTabs"), /if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\);/, "the view filter never re-points at another session");
+  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)/, "…and restores the hidden tab when the view shows it again");
+  assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);
+  assert.match(fn("cycleTab"), /if \(pickFirstVisibleTab\(\)\) return;/);
+  assert.match(fn("onTabKey"), /if \(!activeId\) \{[^\n]*\n\s*if \(\(e\.key === "ArrowRight"[\s\S]{0,160}pickFirstVisibleTab\(\)\)/);
+  assert.match(RENDER, /if \(!activeId\) \{ if \(pickFirstVisibleTab\(\)\) e\.preventDefault\(\); return; \}/, "the window arrow step");
+  assert.doesNotMatch(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/, "the old re-point is gone");
   // the feed relay: showActive announces the active tab (null included) on every branch it takes
   assert.match(show, /^\s*notifyActive\(\);/m);
   assert.match(fn("notifyActive"), /vscodeApi\.postMessage\(\{ type: "activeTab", id: activeId \}\)/, "null rides as null");

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -67,7 +67,8 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(RENDER, /renderBgTasks\(\);\s*\n\s*\} else if \(!activeId\) \{[\s\S]{0,300}?showActive\(\);\s*\n\s*\}/, "a frame landing on an unfocused pane paints the body, adopting nothing");
   assert.match(fn("paintEmptyState"), /why: "awaited" as const, dialing: hostIsDialing\(awaited\)/);
   // the body repaints on the dial event; the view filter routes through the same rule; the keyboard picks the first tab
-  assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ if \(!activeId\) \{ const e = document\.getElementById\("empty-state"\); if \(e\) paintEmptyState\(e\); \} \}\);/);
+  assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); repaintEmptyStateIfUnfocused\(\); \}\);/);
+  assert.match(fn("repaintEmptyStateIfUnfocused"), /if \(activeId\) return;[\s\S]*?if \(e\) paintEmptyState\(e\);/);
   assert.match(fn("renderTabs"), /if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\);/, "the view filter never re-points at another session");
   assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)/, "…and restores the hidden tab when the view shows it again");
   assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);

--- a/ui/webview/pane-focus.ts
+++ b/ui/webview/pane-focus.ts
@@ -1,0 +1,44 @@
+// Where the chat pane's focus goes when a tab leaves the strip, and what the pane says while no tab is active
+// (T357, the user 2026-09-11). Their report: a kernel restart while they were on a REMOTE session's tab dropped the
+// remote tabs until their host reconnected, the pane jumped to a local session, and when the host came back it jumped
+// again to the remote one; they ended up unsure which box they were typing to. Their rule: the pane never jumps to
+// ANOTHER session on its own. The one departure that keeps the recency fallback is the user's own ✕ (they closed the
+// tab: the box changing hands is the one case they already know, and the MRU-then-first-tab rule of T236 applies).
+// Every other departure (a restart, a host relay down, a session gone) leaves the pane UNFOCUSED: no active tab, a
+// blank body that names the session that vanished, the composer disabled with no session name, no session colour
+// on the focus ring; and when THAT session's tab returns (the relay redial, the host re-attach) focus goes back to
+// it, since the user chose it. Only a pick by the user moves focus to a different session.
+
+/** Why a tab left the strip: the pane's own DismissWhy (render.ts), spelled here so this module stays import-free. */
+export type Why = "close" | "end" | "hostDrop" | "omitted";
+
+export type FocusAfterDismiss = { activeId: string | null; unfocused: boolean };
+
+/** The active tab after `why` took the active one. `mru` is the recency stack with the dismissed id already gone,
+ *  `order` the strip, `goingToo` the ids the same teardown takes next (never a fallback). */
+export function focusAfterDismiss(why: Why, mru: readonly string[], order: readonly string[],
+                                  goingToo: (id: string) => boolean): FocusAfterDismiss {
+  if (why !== "close") return { activeId: null, unfocused: true };
+  return { activeId: mru.find((x) => order.includes(x) && !goingToo(x)) || order.find((x) => !goingToo(x)) || null,
+           unfocused: false };
+}
+
+/** The session that vanished from under the user, for the empty body's line. */
+export type Vanished = { name: string; why: Exclude<Why, "close">; dialing: boolean };
+
+/** The empty body's text in three pieces, so the pane can dress the name the way the strip does (host prefix,
+ *  identity colour): `head` + `name` + `tail`, `name` null when no session vanished. */
+export type EmptyStateParts = { head: string; name: string | null; tail: string };
+
+export function emptyStateParts(v: Vanished | null, hasTabs: boolean): EmptyStateParts {
+  if (!v) {
+    return hasTabs ? { head: "No session selected. Pick a tab to start.", name: null, tail: "" }
+                   : { head: "No session open — click + to add one.", name: null, tail: "" };
+  }
+  const tail = v.why === "hostDrop"
+    ? (v.dialing ? "’s host disconnected; reconnecting… It comes back here when the host does."
+                 : "’s host disconnected. It comes back here when the host does.")
+    : v.why === "omitted" ? " is no longer listed by romp. It comes back here if it returns."
+    : " ended.";
+  return { head: "No session selected. Pick a tab to start. ", name: v.name, tail };
+}

--- a/ui/webview/pane-focus.ts
+++ b/ui/webview/pane-focus.ts
@@ -23,8 +23,10 @@ export function focusAfterDismiss(why: Why, mru: readonly string[], order: reado
            unfocused: false };
 }
 
-/** The session that vanished from under the user, for the empty body's line. */
-export type Vanished = { name: string; why: Exclude<Why, "close">; dialing: boolean };
+/** The session that vanished from under the user, for the empty body's line: how it left (a dismissal's reason), or
+ *  "awaited" (the tab this page showed before a reload, not listed yet: a kernel restart reloads the page, so no
+ *  dismissal ran and the persisted choice is all the pane has), or "hidden" (the tab view no longer shows it). */
+export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "hidden"; dialing: boolean };
 
 /** The empty body's text in three pieces, so the pane can dress the name the way the strip does (host prefix,
  *  identity colour): `head` + `name` + `tail`, `name` null when no session vanished. */
@@ -39,6 +41,10 @@ export function emptyStateParts(v: Vanished | null, hasTabs: boolean): EmptyStat
     ? (v.dialing ? "’s host disconnected; reconnecting… It comes back here when the host does."
                  : "’s host disconnected. It comes back here when the host does.")
     : v.why === "omitted" ? " is no longer listed by romp. It comes back here if it returns."
+    : v.why === "awaited" ? (v.dialing ? " is not listed yet; its host is reconnecting… It comes back here when the host does."
+                                       : " is not listed yet. It comes back here when its host does.")
+    : v.why === "hidden" ? " is not shown by this tab view. Pick a tab, or change the view."
     : " ended.";
-  return { head: "No session selected. Pick a tab to start. ", name: v.name, tail };
+  // an EMPTY strip invites no pick (the review's low): the session named is all there is to say
+  return { head: hasTabs ? "No session selected. Pick a tab to start. " : "No sessions yet. ", name: v.name, tail };
 }

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -60,7 +60,7 @@ test("a view change that excludes the ACTIVE session converts it into the peek �
   // the derivation is symmetric, so a view that now INCLUDES the active peek sheds the dress — the
   // same next-null branch the auto-close pin above holds; and the fallback's fire-time revalidation
   // (below) re-checks tabInView, so a converted peek can never be bounced by an in-flight timeout
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/);
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\); \}, 0\);/);
 });
 
 test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands in setActive, re-deriving peek", () => {
@@ -76,7 +76,7 @@ test("the first-tab fallback never fires on an active peek: tabInView counts the
   assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
   // …and the DEFERRED bounce re-validates at fire time: an activation between schedule and fire
   // (the feed click that just opened this peek) makes the active tab visible — no bounce then
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/);
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\); \}, 0\);/);
 });
 
 test("the focus fast path (already-active live jump) still re-asserts the peek — setActive is skipped there", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1016,8 +1016,10 @@ let activeId: string | null = null;
 // read vanishedId). Only the user's own ✕ keeps the recency fallback, and only a pick by the user moves focus
 // (setActive clears these). pane-focus.ts holds the rule and the words.
 let vanishedId: string | null = null;
-let vanishedWhy: DismissWhy | null = null;
+let vanishedWhy: VanishWhy | null = null;
 let vanishedName = "";
+/** why the pane is unfocused: a dismissal's reason, or "hidden" (the tab view stopped showing the active tab) */
+type VanishWhy = DismissWhy | "hidden";
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
 // The SESSION whose transcript DOM is being built — the id preview/image URLs must bake in, host prefix
 // included. Distinct from renderingSid, which is a fold KEY the comment popover retargets to its thread id.
@@ -1037,6 +1039,13 @@ let renderingOwnerSid: string | null = null;
 let renderingIntoThread = false;
 // restore the last-active tab on refresh (persisted via setState); one-shot, applied when its session arrives
 let wantActive: string | null = (() => { try { return ((vscodeApi?.getState?.() || {}) as any).activeId || null; } catch { return null; } })();
+// THE USER'S ACTUAL TRIGGER (T357, the review): a kernel restart RELOADS the page, so no dismissal runs; the persisted
+// choice above is all the pane has, and the local kernel's sessions arrive before a remote host relays again. An
+// outstanding wantActive is treated like a vanished id: the pane stays UNFOCUSED, its body naming the awaited session
+// (the name persisted beside the id, since the page knows nothing else about it yet), adopts nothing until that id
+// arrives (its frame, or the strip re-listing it), and clears the wait when the user picks another tab (setActive). A
+// session that never returns leaves the body standing until a pick: no timer.
+let wantActiveName: string = (() => { try { return String(((vscodeApi?.getState?.() || {}) as any).activeName || ""); } catch { return ""; } })();
 let pendingAnchor: string | null = null; // deep-link target waiting to be scrolled to
 let pendingAnchorIntent: string | null = null; // kind the uuid anchor must honor — sticks with pendingAnchor across render-pass retries (pendingAnchorKind is cleared each pass, this isn't)
 let pendingAnchorT: number | null = null; // time fallback (epoch s) when the uuid can't resolve
@@ -5303,7 +5312,8 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   for (const id of kernelOrder) kernelListed.add(id);
   // T357: the tab the user was on is re-listed (a host re-attach, a relay redial) → focus goes back to it; the
   // skeleton branch of showActive asks for its frame. Another session's tab appearing does nothing here.
-  if (vanishedId && order.includes(vanishedId)) setActive(vanishedId);
+  const back = vanishedId || wantActive;   // …or the tab this page showed before a reload, awaited since boot
+  if (back && order.includes(back)) setActive(back);
   renderTabs();
 }
 // The tabOrder frame's `skeleton` list (2026-09-07): the tabs the kernel is withholding from this page after a
@@ -6073,7 +6083,13 @@ function renderTabs() {
     // re-validate at FIRE time, not schedule time: an activation between the two (a feed click
     // opening an ephemeral peek, a reveal landing) can have made the active tab visible — bouncing
     // then would kick the user off the very tab they just opened (the no-flap rule)
-    setTimeout(() => { if (activeId !== next && activeId && !tabInView(activeId)) setActive(next); }, 0);
+    // …but never at ANOTHER session on the pane's own initiative (T357): the pane goes unfocused, naming the tab the
+    // view no longer shows, and comes back to it below when the view shows it again
+    setTimeout(() => { if (activeId !== next && activeId && !tabInView(activeId)) unfocusHiddenByView(activeId); }, 0);
+  }
+  if (!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds.includes(vanishedId)) {
+    const back = vanishedId;
+    setTimeout(() => { if (!activeId && vanishedId === back && tabInView(back)) setActive(back); }, 0);
   }
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
@@ -6981,7 +6997,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
 window.addEventListener("romp-hosts", () => { renderTabs(); syncComposerPh(); });
 // a dial attempt to a remote host began or ended (federation.ts dialEvent): the host-down foot's swirl
 // spins while one is in flight, as of the last /tunnels poll, so it repaints on this event and on nothing else
-window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); });
+window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); });   // (the unfocused body repaints on the same event: paintEmptyState)
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
 // (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it
@@ -7057,7 +7073,11 @@ function startTabRename(id: string, copy?: string) {   // `copy`: which copy of 
 // Keyboard nav on a focused tab: ←/→ step prev/next; ↑/↓ jump to the nearest tab
 // in the row above/below (tabs wrap via flex-wrap).
 function onTabKey(e: KeyboardEvent) {
-  if (!activeId || !order.length) return;
+  if (!order.length) return;
+  if (!activeId) {   // from the unfocused pane an arrow lands on the first visible tab (T357)
+    if ((e.key === "ArrowRight" || e.key === "ArrowLeft" || e.key === "ArrowUp" || e.key === "ArrowDown") && pickFirstVisibleTab()) { e.preventDefault(); focusActiveTab(); }
+    return;
+  }
   if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
     e.preventDefault();
     const dir = e.key === "ArrowRight" ? 1 : -1;
@@ -7137,7 +7157,8 @@ window.addEventListener("keydown", (e) => {
   if (isTypingTarget(e.target)) return;
   if (document.querySelector(".picker-overlay")) return;   // #picker / #confirm open
   if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
-    if (!activeId || order.length < 2) return;
+    if (!activeId) { if (pickFirstVisibleTab()) e.preventDefault(); return; }   // from the unfocused pane: the first visible tab (T357)
+    if (order.length < 2) return;
     const dir = e.key === "ArrowRight" ? 1 : -1;
     const ord = visibleOrder();                 // never cycle onto a view-hidden session
     const i = ord.indexOf(activeId);
@@ -11744,21 +11765,48 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 // The empty body's line (pane-focus.ts emptyStateParts, T357): which session vanished and why, its name dressed the way
 // the strip dresses it (host prefix, identity colour), "reconnecting" when its host is dialing; or the plain invitation.
 function paintEmptyState(empty: HTMLElement): void {
+  const awaited = !vanishedId && wantActive ? wantActive : null;   // the persisted tab, not listed yet after a reload
+  const named = vanishedId || awaited;
   const v = vanishedId && vanishedWhy && vanishedWhy !== "close"
     ? { name: vanishedName || tabMeta.get(vanishedId)?.name || vanishedId, why: vanishedWhy, dialing: hostIsDialing(vanishedId) }
+    : awaited ? { name: wantActiveName || tabMeta.get(awaited)?.name || awaited, why: "awaited" as const, dialing: hostIsDialing(awaited) }
     : null;
   const parts = emptyStateParts(v, order.length > 0);
   empty.replaceChildren(document.createTextNode(parts.head));
   if (parts.name != null) {
     const b = el("b", "empty-state-name");
-    b.replaceChildren(...hostNameNodes(parts.name, vanishedId));
-    const c = vanishedId ? tabMeta.get(vanishedId)?.color?.bg : null;
+    b.replaceChildren(...hostNameNodes(parts.name, named));
+    const c = named ? tabMeta.get(named)?.color?.bg : null;
     if (c) b.style.color = c;
     empty.appendChild(b);
   }
   empty.appendChild(document.createTextNode(parts.tail));
   empty.classList.toggle("unfocused", !!v);
-  empty.dataset.vanished = vanishedId || "";
+  empty.dataset.vanished = named || "";
+}
+// The body's "reconnecting" is the federation manager's dial state: re-painted on its change event, so a redial that
+// starts a moment after the paint says so (the review), never a timer.
+window.addEventListener("romp:hostDial", () => { if (!activeId) { const e = document.getElementById("empty-state"); if (e) paintEmptyState(e); } });
+
+// The tab VIEW stopped showing the active tab (a tag the view selects on was removed; T357, the review): the same
+// rule as a dismissal — the pane goes UNFOCUSED naming the session the view no longer shows, and never re-points
+// itself at another session. renderTabs restores it when the view shows it again.
+function unfocusHiddenByView(id: string): void {
+  if (activeId !== id) return;
+  stashActiveDraft(id);
+  activeId = null; vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || id;
+  loadComposerFor(null);
+  renderTabs();
+  showActive();
+}
+/** From the unfocused pane a keyboard step lands on the first visible tab: a user gesture, allowed (the review's medium:
+ *  the cycle and the arrows returned early on no active tab, silently). */
+function pickFirstVisibleTab(): boolean {
+  if (activeId) return false;
+  const first = visibleOrder()[0];
+  if (!first) return false;
+  setActive(first);
+  return true;
 }
 
 function showActive(keep?: { uuid: string; y: number } | null) {
@@ -15886,15 +15934,18 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     clearSeek();
   }
   activeId = id;
-  vanishedId = null; vanishedWhy = null; vanishedName = "";   // any activation ends the unfocused state (T357)
+  vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null;   // any activation ends the unfocused state, the awaited tab included (T357)
   updateLivePaused();   // the entering tab's own detached state shows or hides the strip (round 2, item 7)
-  try { vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id }); } catch { /* ignore */ }
+  try {   // the name rides beside the id: after a reload the unfocused body names the awaited tab before its host relays (T357)
+    vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id, activeName: liveSession(id)?.name || tabMeta.get(id)?.name || "" });
+  } catch { /* ignore */ }
   renderTabs();
   showActive();
   schedulePrebuild(); // warm the OTHER tabs in idle (MRU-first) so the next switch is instant
 }
 
 function cycleTab(dir: number) {
+  if (pickFirstVisibleTab()) return;            // from the unfocused pane: the first visible tab (T357)
   const ord = visibleOrder();                   // never cycle onto a view-hidden session
   if (ord.length < 2 || !activeId) return;
   const i = ord.indexOf(activeId);
@@ -16054,7 +16105,7 @@ function upsert(msg: any) {
   // T357: the session the user was on is back (its host re-attached, the relay redialed) → its focus is restored;
   // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
   if (vanishedId === msg.id) setActive(msg.id);
-  const adopted = !activeId && !vanishedId;
+  const adopted = !activeId && !vanishedId && !wantActive;   // …nor while the persisted tab is still awaited after a reload (T357)
   if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); }   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
@@ -16078,6 +16129,10 @@ function upsert(msg: any) {
       }
     }
     renderBgTasks();
+  } else if (!activeId) {
+    // no tab is active (the awaited tab after a reload, the unfocused pane): the arriving view stays hidden and the
+    // body paints its line over the boot loader — nothing adopted it above (T357)
+    showActive();
   }
   // A non-active session's view is left to sync lazily when it's next shown.
   // The session the user just created has ARRIVED: the provisional tab hands over its queued messages

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6997,7 +6997,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
 window.addEventListener("romp-hosts", () => { renderTabs(); syncComposerPh(); });
 // a dial attempt to a remote host began or ended (federation.ts dialEvent): the host-down foot's swirl
 // spins while one is in flight, as of the last /tunnels poll, so it repaints on this event and on nothing else
-window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); });   // (the unfocused body repaints on the same event: paintEmptyState)
+window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); repaintEmptyStateIfUnfocused(); });   // the unfocused body's "reconnecting" follows the dial state too (T357)
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
 // (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it
@@ -11784,9 +11784,14 @@ function paintEmptyState(empty: HTMLElement): void {
   empty.classList.toggle("unfocused", !!v);
   empty.dataset.vanished = named || "";
 }
-// The body's "reconnecting" is the federation manager's dial state: re-painted on its change event, so a redial that
-// starts a moment after the paint says so (the review), never a timer.
-window.addEventListener("romp:hostDial", () => { if (!activeId) { const e = document.getElementById("empty-state"); if (e) paintEmptyState(e); } });
+// The body's "reconnecting" is the federation manager's dial state: re-painted on its change event (the romp:hostDial
+// listener beside syncHostOfflineFoot calls this), so a redial that starts a moment after the paint says so (the
+// review), never a timer.
+function repaintEmptyStateIfUnfocused(): void {
+  if (activeId) return;
+  const e = document.getElementById("empty-state");
+  if (e) paintEmptyState(e);
+}
 
 // The tab VIEW stopped showing the active tab (a tag the view selects on was removed; T357, the review): the same
 // rule as a dismissal — the pane goes UNFOCUSED naming the session the view no longer shows, and never re-points

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -72,6 +72,7 @@ import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
 import { hostNameNodes, hostPartsNodes, hostPrefix, hostOf, hostIsDown, hostIsDialing, hostDownNote } from "./host-prefix";
+import { focusAfterDismiss, emptyStateParts } from "./pane-focus";   // where focus goes when a tab leaves, and the empty body's line (T357)
 import { MENTION_MAX_ROWS, mentionQuery, rankMentions, mentionMoreNote, mentionToken, insertMention, mentionKeyAction, mentionSegments } from "./composer-mention";   // the @-mention card's rules, pure; the DOM is setupComposer's mention block and markMentions
 import type { MentionCandidate, MentionQuery } from "./composer-mention";
 import { defaultCommentName, defaultBreakoutName, defaultForkName, nameToSend } from "./comment-name";
@@ -1007,6 +1008,15 @@ fetch(kernelUrl("/palette"), { cache: "no-store" }).then((r) => r.json())
   .then((d) => { if (Array.isArray(d.colors)) paletteColors = d.colors; }).catch(() => { /* menu omits the swatch row */ });
 const mru: string[] = [];             // recency stack, front = most-recently-active (close → return to previous)
 let activeId: string | null = null;
+// UNFOCUSED (T357, the user 2026-09-11): the tab the user was on left the strip on its own (a kernel restart that
+// dropped the remote tabs until their host came back, a host relay down, a session gone). The pane never jumps to
+// ANOTHER session on its own: no active tab, a body that names the session that vanished, the composer disabled with
+// no session name, and focus RESTORED to that same session when its tab returns (the arrival path and applyTabOrder
+// read vanishedId). Only the user's own ✕ keeps the recency fallback, and only a pick by the user moves focus
+// (setActive clears these). pane-focus.ts holds the rule and the words.
+let vanishedId: string | null = null;
+let vanishedWhy: DismissWhy | null = null;
+let vanishedName = "";
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
 // The SESSION whose transcript DOM is being built — the id preview/image URLs must bake in, host prefix
 // included. Distinct from renderingSid, which is a fold KEY the comment popover retargets to its thread id.
@@ -5290,6 +5300,9 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   order.length = 0;
   for (const id of next) order.push(id);
   for (const id of kernelOrder) kernelListed.add(id);
+  // T357: the tab the user was on is re-listed (a host re-attach, a relay redial) → focus goes back to it; the
+  // skeleton branch of showActive asks for its frame. Another session's tab appearing does nothing here.
+  if (vanishedId && order.includes(vanishedId)) setActive(vanishedId);
   renderTabs();
 }
 // The tabOrder frame's `skeleton` list (2026-09-07): the tabs the kernel is withholding from this page after a
@@ -11727,6 +11740,26 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 // `keep` (review find, 2026-09-08): a caller that must EMPTY the view before showing it (rerenderAll on a
 // settings change) captures the reader's anchor first and hands it here — by the time this runs there is
 // no DOM left to capture from and the emptied box no longer overflows. undefined = capture here.
+// The empty body's line (pane-focus.ts emptyStateParts, T357): which session vanished and why, its name dressed the way
+// the strip dresses it (host prefix, identity colour), "reconnecting" when its host is dialing; or the plain invitation.
+function paintEmptyState(empty: HTMLElement): void {
+  const v = vanishedId && vanishedWhy && vanishedWhy !== "close"
+    ? { name: vanishedName || tabMeta.get(vanishedId)?.name || vanishedId, why: vanishedWhy, dialing: hostIsDialing(vanishedId) }
+    : null;
+  const parts = emptyStateParts(v, order.length > 0);
+  empty.replaceChildren(document.createTextNode(parts.head));
+  if (parts.name != null) {
+    const b = el("b", "empty-state-name");
+    b.replaceChildren(...hostNameNodes(parts.name, vanishedId));
+    const c = vanishedId ? tabMeta.get(vanishedId)?.color?.bg : null;
+    if (c) b.style.color = c;
+    empty.appendChild(b);
+  }
+  empty.appendChild(document.createTextNode(parts.tail));
+  empty.classList.toggle("unfocused", !!v);
+  empty.dataset.vanished = vanishedId || "";
+}
+
 function showActive(keep?: { uuid: string; y: number } | null) {
   const content = document.getElementById("content");
   if (!content) return;
@@ -11811,11 +11844,18 @@ function showActive(keep?: { uuid: string; y: number } | null) {
       // design. AFTER notifyActive above, so `activeTab` precedes `needFull` on the wire and the kernel builds
       // this tab first; the awaitingFull guard makes it one ask per outstanding load.
       if (skeleton) requestFullSession(activeId, "skeleton-click");
-    } else if (!empty) {
-      empty = el("div", "empty-state"); empty.id = "empty-state";
-      empty.textContent = "No session open — click + to add one.";
-      content.appendChild(empty);
-    } else { empty.style.display = ""; }
+    } else {
+      // UNFOCUSED, or no tab at all (T357): the body says which session vanished and that a pick is the way on; the
+      // box takes no input and names no session (a pick re-enables it: the skeleton branch above, or the session
+      // frame's own showActive through setComposerAskMode)
+      if (!empty) { empty = el("div", "empty-state"); empty.id = "empty-state"; content.appendChild(empty); }
+      paintEmptyState(empty);
+      empty.style.display = "";
+      const ta = document.getElementById("composer-input") as HTMLTextAreaElement | null;
+      if (ta) { ta.disabled = true; ta.placeholder = order.length ? "Pick a tab to start" : "Click + to add a session"; syncComposerPh(); }
+      const sendBtn = document.getElementById("composer-send") as HTMLButtonElement | null;
+      if (sendBtn) sendBtn.disabled = true;
+    }
     document.body.style.removeProperty("--active-accent"); // no session → neutral window border
     updateStatusline();
     // Take the leaving tab's go-to-bottom and reply chips down with it. They were measured against ITS transcript,
@@ -14476,7 +14516,7 @@ function updateStatusline() {
     sl.replaceChildren(openingLine(loading ? "Loading session" : "Opening session"));
     return;
   }
-  if (!s) return;
+  if (!s) { sl.replaceChildren(); return; }   // no tab at all, or the UNFOCUSED pane (T357): the line says nothing, not the last session's chips
   sl.replaceChildren();
   if (s.sub) {
     // a subagent viewer has no session state, model or context to show — the header above the
@@ -15845,6 +15885,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     clearSeek();
   }
   activeId = id;
+  vanishedId = null; vanishedWhy = null; vanishedName = "";   // any activation ends the unfocused state (T357)
   updateLivePaused();   // the entering tab's own detached state shows or hides the strip (round 2, item 7)
   try { vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id }); } catch { /* ignore */ }
   renderTabs();
@@ -16009,7 +16050,10 @@ function upsert(msg: any) {
   // fallback tab active with the box unheld, and the next blind keystroke landed there after all (the
   // T236 harness, omission path: the tab is re-listed within seconds). setActive clears the note.
   if (composerNoteSid === msg.id) setActive(msg.id);
-  const adopted = !activeId;
+  // T357: the session the user was on is back (its host re-attached, the relay redialed) → its focus is restored;
+  // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
+  if (vanishedId === msg.id) setActive(msg.id);
+  const adopted = !activeId && !vanishedId;
   if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); }   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
@@ -16633,15 +16677,19 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
   const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);   // before the fallback read below — never the dead id
   renderTabs();                          // tab removed from `order` above → repaint without it
   if (wasActive) {
-    // MRU: return to the previously-active tab, not the positional neighbor — one still on the strip (the
-    // dead id left `mru` above; an id `order` no longer carries would bind the box to a tab nobody can see,
-    // and the next keystroke would file under it) and not one this same teardown takes next.
+    // Where the box goes (pane-focus.ts focusAfterDismiss; T357, the user 2026-09-11): only the user's OWN ✕ hands it
+    // to the recency fallback — MRU, then the first tab still on the strip (the dead id left `mru` above; an id `order`
+    // no longer carries would bind the box to a tab nobody can see), never one this same teardown takes next — since
+    // they closed the tab and the box changing hands is the one case they already know. Every other departure (a
+    // kernel restart that dropped the remote tabs until their host came back, a host relay down, a session gone)
+    // leaves the pane UNFOCUSED: activeId null with the strip still showing, the body naming what vanished, and focus
+    // restored to THAT session when its tab returns — never to another session on the pane's own initiative (the
+    // user ended up typing to a box they had not chosen). The arrival path guards its adoption on vanishedId.
     const home = hostOf(id);   // "" for a local id, and then no sibling rule: every local tab would "share" it
     const goingToo = (x: string) => (doomed?.has(x) ?? false) || (why === "hostDrop" && !!home && hostOf(x) === home);
-    // …and with no recency left (the user only ever looked at this one tab), the first tab still on the
-    // strip: leaving activeId null with tabs showing read "No session open" under a visible strip, and
-    // handed the box to whichever session frame happened to arrive next (the harness caught both, T236).
-    activeId = mru.find((x) => order.includes(x) && !goingToo(x)) || order.find((x) => !goingToo(x)) || null;
+    const next = focusAfterDismiss(why, mru, order, goingToo);
+    activeId = next.activeId;
+    if (next.unfocused) { vanishedId = id; vanishedWhy = why; vanishedName = name; }
     loadComposerFor(activeId);   // the strip was showing the CLOSED session's chip/thumbnails/draft — swap in the new active tab's (usually none)
     // The box just changed hands under the user. Their own ✕ is the one case they already know; for every
     // other reason BLUR it — a keystroke a moment later must not land in the survivor's session unnoticed

--- a/ui/webview/skeleton-tabs-wiring.test.ts
+++ b/ui/webview/skeleton-tabs-wiring.test.ts
@@ -135,7 +135,7 @@ test("showActive gates the active session on the set, shows the loader with LOAD
   // prefetch skips the active tab by design, so nothing else would load it
   assert.equal(RENDER.split('"skeleton-click"').length - 1, 2, "one call site (+ the type's literal)");
   assert.match(fn("setActive"), /renderTabs\(\);\s*\n\s*showActive\(\);/, "the click path: strip repaint, then showActive → loader + ask");
-  assert.match(fn("dismissSession"), /activeId = mru\.find\([\s\S]*?showActive\(\);/, "the fallback path lands in showActive too");
+  assert.match(fn("dismissSession"), /activeId = next\.activeId;[\s\S]*?showActive\(\);/, "the fallback path (and the unfocused one, T357) lands in showActive too");
   // The branch ends by taking the leaving tab's chips down (run in the chip tests below). They were measured
   // against ITS transcript, and a tab left at the top of a long one fires none of the chips' events on the switch:
   // no scroll clamp (scrollTop is 0 and stays 0) and no #content resize (the pane's height is the body minus its
@@ -319,6 +319,8 @@ function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript
     const { sessions, views, tabMeta, skeletonTabs, commentThreads, jumpBtn, replyChips, atBottomDist, isReplyReady, hostOf, el, rompLoaderInner, HOOKS } = W;
     let activeId = null, skeletonLoading = null, replyChipSig = "";
     const placeReviveLoader = () => {}, notifyActive = () => {}, renderLedger = () => {}, renderLiveAsk = () => {}, renderBgTasks = () => {}, renderSubHead = () => {}, updateStatusline = () => {};
+    // the unfocused body's painter and the box's name overlay (T357): inert here, the strip test is about the chips
+    const paintEmptyState = () => {}, syncComposerPh = () => {}, order = [];
     // the section-at-a-glance view, inert: no section shows (snapView null), so showActive's branch is not taken
     let snapView = null, snapKeep = null;
     const renderSnapshot = () => false, hideSnapshot = () => {}, composerRestingPlaceholder = () => "";

--- a/ui/webview/skeleton-tabs.test.ts
+++ b/ui/webview/skeleton-tabs.test.ts
@@ -133,3 +133,16 @@ test("an array never adopts an id the strip does not list: a session that ended 
   assert.deepEqual(st.order, ["B"], "Z is not on the strip → not a skeleton either (the prefetch must never ask for it)");
   assert.equal(st.ids.has("Z"), false);
 });
+
+test("a dismissed tab leaves the loaded set, so its re-listing is a skeleton again and the pane asks for its frame (T357)", () => {
+  const st = newSkeletonState();
+  applyTabOrderSkeleton(st, ["A"], ["A", "B"]);
+  onFull(st, "A");                                    // its frame landed on this socket
+  assert.ok(st.loaded.has("A")); assert.ok(!st.ids.has("A"));
+  applyTabOrderSkeleton(st, ["A"], ["A", "B"]);       // re-listed as a skeleton while loaded: refused, the page has it
+  assert.ok(!st.ids.has("A"), "a loaded id is never re-skeletoned on the same socket");
+  onDismiss(st, "A");                                 // its tab left the strip (a host drop, an omission): the view went with it
+  assert.ok(!st.loaded.has("A"), "no longer loaded here");
+  applyTabOrderSkeleton(st, ["A"], ["A", "B"]);       // the host re-attached: the strip names it a skeleton again
+  assert.ok(st.ids.has("A"), "…and now it is one, so the pane asks for its frame");
+});

--- a/ui/webview/skeleton-tabs.ts
+++ b/ui/webview/skeleton-tabs.ts
@@ -90,6 +90,11 @@ export function onFull(st: SkeletonState, id: string): boolean {
 
 /** The tab left the strip (a close, the kernel's omission, a host drop): nothing to load any more. */
 export function onDismiss(st: SkeletonState, id: string): void {
+  // its view and session left the page with the tab, so it is no longer LOADED here: a later re-listing (a host
+  // re-attach, a relay redial) names it a skeleton again and the pane asks for its frame — the way the unfocused
+  // pane gets the session the user was on back (T357); before, a once-loaded id could never be a skeleton again on
+  // the same socket, so the re-listed tab sat with an "opening…" loader and no ask
+  st.loaded.delete(id);
   if (!st.ids.delete(id)) return;
   st.order = st.order.filter((x) => x !== id);
   st.status.delete(id);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -831,6 +831,9 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    `ledger-tri empty` + the feed's `ftree-tri empty`, both zero-content spans), blowing them up to
    80×80px boxes and giving the dropdown ledger giant gaps (the user 2026-06-16). */
 .empty-state { color: var(--dim); text-align: center; padding: 40px; }
+/* the UNFOCUSED body (T357): the session that vanished is named in its own colour, the rest stays dim */
+.empty-state.unfocused { padding: 48px 40px; line-height: 1.6; }
+.empty-state-name { font-weight: 600; }
 /* brief hint while a first-visited tab's transcript builds on the next frame (the deferred build keeps the
    switch itself instant — the user 2026-06-17); the build replaces it. */
 .tx-loading { color: var(--dim); text-align: center; padding: 28px; font-size: 0.92em;


### PR DESCRIPTION
The chat pane never jumps to another session on its own (the user 2026-09-11): a kernel restart while they were on a remote session's tab dropped the remote tabs until their host reconnected, the pane jumped to a local session, then jumped back when the host returned, and they ended up unsure which box they were typing to.

## Design points

- **The rule** (`ui/webview/pane-focus.ts`, pure): only the user's own close keeps the recency fallback (the most recently used tab still on the strip, else the first; never one the same teardown takes next). Every other departure (a restart hiding a host's sessions, a relay down, a session that ended) leaves the pane **unfocused**: no active tab, the body naming the session that vanished and why ("reconnecting" while its host is dialing), the composer disabled with no session name, no identity colour on the ring or the window border. The T236 note above the box still says whose box went away.
- **Its return restores it.** When that same session's tab comes back (its frame, or the strip re-listing it), focus goes back to it, since the user chose it. A different session appearing meanwhile adopts nothing. Only a pick by the user or their own close moves focus elsewhere.
- **The relays** to the host and to the feed's focused section already carry a null active tab.
- **One seam for the return** (`skeleton-tabs.ts`): a dismissed tab leaves the "loaded on this socket" set, so its re-listing is a skeleton again and the pane asks for its frame. Before, a once-loaded id could never be re-skeletoned on the same socket; a re-listed tab sat with an "opening…" loader and no ask (the served lab found it).

- **The reload road** (the review's HIGH, the user's actual trigger): a kernel restart reloads the page, so no dismissal runs; the persisted tab held the remote sid, the local sessions arrived first and adopted, and the remote frame jumped again. An outstanding persisted tab is now treated like a vanished one: the pane stays unfocused naming it (its name persisted beside the id), adopts nothing until it arrives (its frame or the strip re-listing it), and a pick clears the wait; a session that never returns leaves the body until a pick, no timer.
- **The rest of the fold**: the body repaints on the federation dial event ("reconnecting"); the tab view filter routes through the same rule (unfocused, naming the tab the view no longer shows, restored when it shows again) instead of re-pointing at the first visible session; from the unfocused pane Next/Previous Tab and the arrow keys land on the first visible tab; an empty strip says "No sessions yet." The served lab drives the reload road end to end (seed, reload, local sessions land unfocused, the remote strip entry restores, a pick in between wins).

## Tests

- `ui/webview/pane-focus.test.ts`: the rule and the body's words executed; the wiring pinned (the dismiss branch, the empty body and the composer, the clear on pick, the restore on frame and on strip, no adoption while away, the relay).
- `tests/test_unfocused_pane_browser.py`: on the real chat page, the frames of a dropped host leave the pane unfocused with the named body and the disabled nameless box; a new tab appearing changes nothing; the strip re-listing the vanished session restores focus and its transcript. Screenshots dark and light in the drops folder as `romp_chat-unfocused-pane-{dark,light}.png`.

Tier: feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
