### PR TITLE
The spend guard's tree memo follows the live set and is bounded by bytes; the row memo evicts in one pass (T350 follow-up)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36613,6 +36613,7 @@ SPEND_GUARD_TREE_RESCAN_S = 30      # a COLD agent file (idle since before the w
 #                                     not every cycle; a hot one every cycle
 _SPEND_TREE_CACHE = {}              # leaf -> {"dirs": {dir: mtime}, "files": {path: mtime}, "full": epoch of the last full
 #                                     stat pass, "seen": epoch}: the session's subagents tree, watched by directory mtimes
+SPEND_GUARD_TREE_MEMO_BYTES = 32 * 1024 * 1024   # the tree memos together (their path strings, estimated), least recently seen first
 
 
 def _spend_ceiling():
@@ -36773,8 +36774,11 @@ def _spend_file_rows(f, since, prices, dearest):
     _SPEND_ROWS_CACHE[f] = (stamp, floor, rows, time.time())
     if len(_SPEND_ROWS_CACHE) > SPEND_GUARD_ROWS_CACHE_MAX:
         # the least recently used go (LOW b): a finished agent file's rows are asked for while it is in the window and
-        # never again; without a bound a kernel life would hold one list per agent it ever priced
-        for k in sorted(_SPEND_ROWS_CACHE, key=lambda k: _SPEND_ROWS_CACHE[k][3])[:len(_SPEND_ROWS_CACHE) - SPEND_GUARD_ROWS_CACHE_MAX]:
+        # never again; without a bound a kernel life would hold one list per agent it ever priced. Down to three
+        # quarters of the cap in one sort, not one entry per miss (the round-three review's low b: a saturated memo
+        # sorted itself whole on every miss)
+        keep = SPEND_GUARD_ROWS_CACHE_MAX * 3 // 4
+        for k in sorted(_SPEND_ROWS_CACHE, key=lambda k: _SPEND_ROWS_CACHE[k][3])[:len(_SPEND_ROWS_CACHE) - keep]:
             _SPEND_ROWS_CACHE.pop(k, None)
     return [r for r in rows if r[0] >= since]
 
@@ -36875,7 +36879,7 @@ def _spend_guard_stop(sid, be, now):
     if t0 is not None and now - t0 <= 120:
         return "stopping"
     sessions = getattr(be, "sessions", None)
-    if getattr(sessions.get(sid) if isinstance(sessions, dict) else None, "detached", False):
+    if getattr(sessions.get(str(sid)) if isinstance(sessions, dict) else None, "detached", False):   # str(sid), as every other read of the map
         # a DETACHED hosted session (the round-two review's LOW c): the backend's interrupt answers True while the CLI's
         # escalation is skipped on purpose (its host keeps the turn), so nothing would stop and the sentence would say it
         # had. Read before pressing, said as it is. No road to the host exists without pressing: the host's signal rung
@@ -36950,12 +36954,13 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
     rows = _alive_sessions(now, live_map) if sessions is None else sessions
     if prices is None:
         prices = _model_prices(int(now), refresh=False)   # never a network fetch from the pusher's path
-    live = set()
+    live, live_paths = set(), set()
     for s in rows:
         sid, path = s.get("sid"), s.get("path")
         if not sid or not path:
             continue
         live.add(sid)
+        live_paths.add(str(path))
         try:
             rate = _spend_rate_usd_per_hour(path, now, prices=prices)
         except Exception:
@@ -36973,6 +36978,29 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
     if len(_SPEND_GUARD) > SPEND_GUARD_LATCH_MAX:
         for sid in sorted((k for k in _SPEND_GUARD if k not in live), key=lambda k: _SPEND_GUARD[k].get("t") or 0)[:len(_SPEND_GUARD) - SPEND_GUARD_LATCH_MAX]:
             _SPEND_GUARD.pop(sid, None)
+    _spend_tree_memo_prune(live_paths)
+
+
+def _spend_tree_memo_size(m):
+    """A tree memo's weight, estimated from its path strings (the mtimes are a few dozen bytes beside each)."""
+    return sum(len(p) + 32 for p in m["files"]) + sum(len(d) + 32 for d in m["dirs"])
+
+
+def _spend_tree_memo_prune(live_paths):
+    """The tree memos of sessions not in this tick's live set are dropped (a departed session's tree is nobody's
+    window; bounded by entry count alone the memos of a day's two hundred sessions held tens of MB: the round-three
+    review's low a), and the rest are bounded by bytes, the least recently seen going first (a live session whose memo
+    goes is listed again on its next tick, one first listing)."""
+    for k in [k for k in _SPEND_TREE_CACHE if k not in live_paths]:
+        _SPEND_TREE_CACHE.pop(k, None)
+    total = sum(_spend_tree_memo_size(m) for m in _SPEND_TREE_CACHE.values())
+    if total <= SPEND_GUARD_TREE_MEMO_BYTES:
+        return
+    for k in sorted(_SPEND_TREE_CACHE, key=lambda k: _SPEND_TREE_CACHE[k]["seen"]):
+        if total <= SPEND_GUARD_TREE_MEMO_BYTES:
+            break
+        total -= _spend_tree_memo_size(_SPEND_TREE_CACHE[k])
+        _SPEND_TREE_CACHE.pop(k, None)
 
 
 def _spend_series(keyed_only=False, now=None):

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -217,16 +217,40 @@ class Memo(unittest.TestCase):
         ent = km.em._read_jsonl_entry(self.leaf, tail_ok=True)
         self.assertEqual(km._SPEND_ROWS_CACHE[self.leaf][0], (ent[0], ent[1], ent[5]), "mtime, size, base (LOW a)")
         self.assertEqual(len(km._SPEND_ROWS_CACHE[self.leaf]), 4, "and the last use, for the cap")
-        with mock.patch.object(km, "SPEND_GUARD_ROWS_CACHE_MAX", 2):
+        with mock.patch.object(km, "SPEND_GUARD_ROWS_CACHE_MAX", 4):
             others = []
-            for i in range(3):
+            for i in range(3):                             # the leaf's entry plus three: at the cap
                 f = os.path.join(self.td.name, "proj", "agent-%d.jsonl" % i)
                 write_jsonl(f, [assistant(NOW - 40 + i, "m%d" % i, 100)])
                 time.sleep(0.005)
                 km._spend_file_rows(f, NOW - 600, PRICES, None)
                 others.append(f)
-            self.assertEqual(len(km._SPEND_ROWS_CACHE), 2, "capped (LOW b)")
-            self.assertEqual(sorted(km._SPEND_ROWS_CACHE), sorted(others[1:]), "the least recently used went first")
+            self.assertEqual(len(km._SPEND_ROWS_CACHE), 4, "at the cap: nothing evicted yet")
+            f3 = os.path.join(self.td.name, "proj", "agent-3.jsonl")
+            write_jsonl(f3, [assistant(NOW - 20, "m3", 100)]); time.sleep(0.005)
+            km._spend_file_rows(f3, NOW - 600, PRICES, None)          # the fifth: over the cap
+            self.assertEqual(len(km._SPEND_ROWS_CACHE), 3, "evicted down to three quarters of the cap in one pass (LOW b, round three), not one entry per miss")
+            self.assertEqual(sorted(km._SPEND_ROWS_CACHE), sorted([others[1], others[2], f3]), "the least recently used (the leaf, then the first agent) went first")
+
+    def test_the_tree_memo_drops_departed_sessions_and_is_bounded_by_bytes(self):
+        # the round-three review's low a
+        km._SPEND_TREE_CACHE.clear()
+        leaves = []
+        for i in range(3):
+            leaf = os.path.join(self.td.name, "proj", "%08d-2222-3333-4444-000000000350.jsonl" % i)
+            sub = os.path.join(os.path.dirname(leaf), "%08d-2222-3333-4444-000000000350" % i, "subagents")
+            os.makedirs(sub)
+            write_jsonl(leaf, [user(NOW - 100, "u")], mtime=NOW - 100)
+            write_jsonl(os.path.join(sub, "agent-a.jsonl"), [user(NOW - 100, "u")], mtime=NOW - 100)
+            km._spend_window_files(leaf, NOW - 600, now=NOW + i)      # seen at NOW, NOW+1, NOW+2
+            leaves.append(leaf)
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(leaves))
+        km._spend_tree_memo_prune(set(leaves[1:]))
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(leaves[1:]), "a session that left the live set loses its memo")
+        with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", km._spend_tree_memo_size(km._SPEND_TREE_CACHE[leaves[2]]) + 1):
+            km._spend_tree_memo_prune(set(leaves[1:]))
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), [leaves[2]], "over the byte bound the least recently seen goes first")
+        self.assertIn("_spend_tree_memo_prune(live_paths)", inspect.getsource(km._spend_guard_tick), "the tick prunes on every cycle")
 
 
 class Ceiling(unittest.TestCase):
@@ -414,6 +438,7 @@ class Guard(unittest.TestCase):
         self.assertIn("its host keeps the turn, so it was not stopped, but it has been told", row["text"])
         self.assertEqual((row.get("detached"), row.get("stopped"), row.get("stopping"), row.get("told")), (True, False, False, True))
         self.assertNotIn("refused: detached", inspect.getsource(km._spend_guard_fire), "the refusal prose names no branch it cannot reach")
+        self.assertIn("sessions.get(str(sid))", inspect.getsource(km._spend_guard_stop), "the map is keyed as every other read keys it (round three, low c)")
         self.assertNotIn(SID, km._interrupt_clicked, "no stop was pressed, so no stamp")
 
     def test_the_sentence_states_what_the_backend_actually_did(self):


### PR DESCRIPTION
Three follow-ups from the third review of the spend guard (pull request 1424), none blocking there.

**The tree memo follows the live set and is bounded by bytes.** The memo of each session's subagents tree was bounded by entry count alone and never dropped a session that left the live map; over a day of two hundred sessions that is tens of MB of path strings. Every tick now drops the memos of sessions not in its live set, then bounds the rest by an estimate of their path strings (32 MiB), the least recently seen going first; a live session whose memo goes is listed again on its next tick, one first listing.

**The row memo evicts in one pass.** At the cap the memo sorted itself whole on every miss to evict exactly one entry. It now evicts down to three quarters of the cap in one sort.

**The detached read keys the session map as every other read does.** `str(sid)`, normalised once.

**Tests** (`tests/test_spend_guard.py`): a departed session's memo dropped and the byte bound evicting the least recently seen, with the tick's prune pinned; the cap holding at four and a fifth entry leaving three; the map key pinned.

Tier: fix
