### PR TITLE
A crash in the converge leg holds one cool-down before the retry; the leg asks git once more for the running sha (T352 follow-up)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -1041,16 +1041,19 @@ _SHA = None                                  # lazily-resolved git short-sha of 
 
 _SHA_MISS_T = [0.0]         # when git last failed to answer _kernel_sha
 _SHA_REASK_S = 30           # and how long that failure stands before git is asked again (the round-two review's low)
+_CONVERGE_CRASH_T = [0.0]   # when the automatic converge's leg last crashed: one cool-down is held before the retry
 
 
-def _kernel_sha():
+def _kernel_sha(reask=False):
     """git short-sha of HEAD, plus '-dirty' if the working tree has uncommitted edits — the kernel
     loads bin/*.py straight from the worktree, so a dirty tree means it's running code that isn't at
     any commit. Resolved once (a restart re-reads it). None outside a git checkout."""
     global _SHA
     if _SHA is None:
-        if time.time() - _SHA_MISS_T[0] < _SHA_REASK_S:
+        if not reask and time.time() - _SHA_MISS_T[0] < _SHA_REASK_S:
             return None             # asked and unanswered within the bound: /version and /sw.js call this per request
+            #                         (`reask`: the converge leg asks once more, so one blip at the top of a pass does
+            #                         not turn an in-place converge into a restart; the round-three review's low b)
         try:
             r = subprocess.run(["git", "-C", str(ROOT), "rev-parse", "--short", "HEAD"],
                                capture_output=True, text=True, timeout=2)
@@ -7849,6 +7852,15 @@ def _main_drift_check():
         # answer comes from the drain's own predicate (SdkBackend.would_cut), and only a KNOWN empty list waives a
         # wait: unknown (no backend yet) keeps both, as before. Every held pass says so, each time.
         try:
+            since_crash = time.time() - _CONVERGE_CRASH_T[0]
+            if _CONVERGE_CRASH_T[0] and since_crash < _CONVERGE_COOLDOWN_S:
+                # the leg crashed within this cool-down: one full cool-down is held before the retry, whatever a
+                # restart would cut (the round-three review's low a: the spares branch below waived the cool-down the
+                # crash had just stamped, so a crashing leg retried every 300 s pass on a hosted box)
+                _converge_say("main is at %s: the converge leg crashed %d s ago; holding %d s more of one cool-down "
+                              "before the retry" % (target, int(since_crash), int(_CONVERGE_COOLDOWN_S - since_crash)))
+                _MAIN_DRIFT[slot] = ""
+                return
             cut = _deploy_would_cut()
             spares = cut is not None and not cut
             if not _sha_same(running, checkout) and _parked_quiet_deploy(checkout):
@@ -7889,6 +7901,7 @@ def _main_drift_check():
             # pass returned at the latch and that commit never converged, in silence) leaves no target latched:
             # the next pass judges afresh, and the crash itself reaches the check thread's log as before
             _MAIN_DRIFT[slot] = ""
+            _CONVERGE_CRASH_T[0] = time.time()
             raise
     else:
         if target in _dismissed_updates():
@@ -7998,7 +8011,7 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
         pulled = _checkout_sha()   # ONE read: verdict input and converge target must be the same
         #                            sha — two reads raced a moving checkout and latched a target
         #                            the verdict never examined (T216 review)
-        if not _kernel_code_changed(_kernel_sha(), pulled) and _in_place_converge(pulled):
+        if not _kernel_code_changed(_kernel_sha(reask=True), pulled) and _in_place_converge(pulled):
             return
     # Pay the bundle rebuild BEFORE the old kernel dies (T216): the checkout is already at the
     # target here, so this builds the NEW code's bundles while the old kernel still serves — the

--- a/tests/test_kernel_update.py
+++ b/tests/test_kernel_update.py
@@ -913,7 +913,7 @@ class Wiring(unittest.TestCase):
         # code converges in place with the kernel left up (_kernel_code_changed + _in_place_converge).
         # The copy names both routes. The route line is pinned too, so a change to the route flags
         # the copy for re-reading.
-        self.assertIn("if not _kernel_code_changed(_kernel_sha(), pulled) and _in_place_converge(pulled):",
+        self.assertIn("if not _kernel_code_changed(_kernel_sha(reask=True), pulled) and _in_place_converge(pulled):",
                       self.src)
         self.assertNotIn("quiet moment", self.gear,
                          "the gear still promises a quiet-window restart; since T269 every deploy restart "

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -546,6 +546,7 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._QUIET_PARKED_LOGGED[0] = ""
         km._LAST_AUTO_CONVERGE[0] = 0.0
+        km._CONVERGE_CRASH_T[0] = 0.0
         self.err = io.StringIO()
 
     def tearDown(self):
@@ -674,8 +675,52 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
             self._pass()
         self.assertEqual(km._MAIN_DRIFT[0], "", "the latch is reset on the way out, so the next pass judges afresh")
         km._deploy_would_cut = lambda: []
+        km._CONVERGE_CRASH_T[0] = 0.0                    # the crash hold is its own test below
         self._pass()
         self.assertEqual(self.ran, ["pull"])
+
+    def test_a_crash_in_the_converge_leg_holds_one_cool_down_before_the_retry(self):
+        # the round-three review's low a: the spares branch waived the cool-down the crash had just stamped, so a
+        # crashing leg retried every pass on a hosted box
+        def boom():
+            raise RuntimeError("boom")
+        km._deploy_would_cut = boom
+        with self.assertRaises(RuntimeError):
+            self._pass()
+        self.assertGreater(km._CONVERGE_CRASH_T[0], 0.0, "the crash is stamped")
+        km._deploy_would_cut = lambda: []                # a restart would cut nothing: the spares branch would converge
+        self._pass(); self._pass()
+        self.assertEqual(self.ran, [], "held: one cool-down after a crash, whatever a restart would cut")
+        held = [l for l in self._lines() if "the converge leg crashed" in l]
+        self.assertEqual(len(held), 2, "said on every held pass: %r" % self._lines())
+        self.assertIn("holding ", held[0]); self.assertIn(" s more of one cool-down before the retry", held[0])
+        self.assertEqual(km._MAIN_DRIFT[0], "", "no target latched while held")
+        km._CONVERGE_CRASH_T[0] = time.time() - km._CONVERGE_COOLDOWN_S - 1
+        self._pass()
+        self.assertEqual(self.ran, ["pull"], "the cool-down over, the retry converges")
+
+    def test_the_converge_leg_asks_git_again_for_the_running_sha_within_the_miss_bound(self):
+        # the round-three review's low b: the 30 s miss memo made the leg's own read (in _run_main_update) return None
+        # for a blip at the top of the same pass, so a main commit touching no kernel code took a full restart
+        import subprocess as _sp
+        real = self.saved[3]
+        saved, saved_miss = km._SHA, km._SHA_MISS_T[0]
+        calls = []
+        def run(argv, **kw):
+            calls.append(argv[-1])
+            return mock.Mock(returncode=0, stdout="" if argv[-1] == "--porcelain" else "abc1234\n")
+        try:
+            km._SHA = None
+            km._SHA_MISS_T[0] = time.time()              # git blipped a moment ago
+            with mock.patch.object(km.subprocess, "run", side_effect=run):
+                self.assertIsNone(real(), "within the bound the miss stands…")
+                self.assertEqual(calls, [])
+                self.assertEqual(real(reask=True), "abc1234", "…but the converge leg's read asks once more")
+            self.assertEqual(calls, ["HEAD", "--porcelain"])
+            self.assertIn("_kernel_code_changed(_kernel_sha(reask=True), pulled)", inspect.getsource(self.saved[4]),
+                          "the REAL _run_main_update (setUp stubs km's) asks once more")
+        finally:
+            km._SHA, km._SHA_MISS_T[0] = saved, saved_miss
 
     def test_a_parked_quiet_deploy_stands_down_every_pass_unless_nothing_would_be_cut(self):
         km._checkout_sha = lambda: "bbb"                  # the checkout is ahead of the kernel: a restart is owed…
@@ -805,7 +850,7 @@ class UiOnlyConverge(unittest.TestCase):
     def test_the_pull_path_carries_the_same_in_place_converge(self):
         src = inspect.getsource(km._run_main_update)
         self.assertIn("pulled = _checkout_sha()", src)
-        self.assertIn("not _kernel_code_changed(_kernel_sha(), pulled) and _in_place_converge(pulled)",
+        self.assertIn("not _kernel_code_changed(_kernel_sha(reask=True), pulled) and _in_place_converge(pulled)",
                       src, "verdict input and converge target are the SAME read — never raced")
         conv = inspect.getsource(km._in_place_converge)
         self.assertIn("_rebuild_dist()", conv)


### PR DESCRIPTION
Two follow-ups from the third review of the automatic converge's wait rules (pull request 1428), neither blocking there.

**A crash in the converge leg holds one cool-down before the retry.** The hold branches run under a guard that clears the latch on any exception, so a crash no longer leaves a target latched; but the spares branch then waived the cool-down the crash had just stamped, so a crashing leg retried on every 300 s pass on a hosted box. The crash's moment is remembered, and a pass within one cool-down of it holds, says so each time (how long ago, how long remains), and latches nothing, whatever a restart would cut.

**The converge leg asks git once more for the running sha.** A git miss stands for 30 s so the per-request routes do not fork git per call; but the leg's own read inside the update (which decides an in-place converge against a restart) fell under the same memo, so one blip at the top of a pass turned a main commit touching no kernel code into a full restart. That read asks again.

**Tests** (`tests/test_main_drift_notice.py`): a crash then two held passes, each said, no target latched, and the retry converging once the cool-down is over; the miss standing within the bound while the leg's read asks again, with the leg's call pinned.

Tier: fix
