### PR TITLE
A comment thread's mail-off rule, the review's lows: the CLI judges the caller before --from, an unreadable reg fails closed, held mail is named and counted (T356 follow-up)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -404,10 +404,14 @@ agent works in the new folder and reads its `CLAUDE.md`.
 
 A comment thread's mail is off, both directions, until you break it out: peers
 cannot see or mail the thread, and its own mail is refused with a line saying
-so. The popover says "mail off" while it lasts, and the moment you break the
+so. The popover says "mail off" while it lasts (and how many messages wait in
+its box; they land within seconds of a break-out), and the moment you break the
 thread out it is a session like any other, mail on unless you toggle its
 mailbox off (the user 2026-09-11, after a thread received a manager's mail and
-acted as the manager).
+acted as the manager). Only peer mail is gated: what you type into the thread's
+box yourself, and plain text the kernel's own send route carries, is yours and
+still goes through; that is the human channel, by design, not a hole in the
+gate.
 
 A session started from another one joins its tags. Forking a session, breaking
 a comment thread out into its own session, and running `romp new` inside a

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -404,11 +404,12 @@ agent works in the new folder and reads its `CLAUDE.md`.
 
 A comment thread's mail is off, both directions, until you break it out: peers
 cannot see or mail the thread, and its own mail is refused with a line saying
-so. The popover says "mail off" while it lasts (and how many messages wait in
-its box; they land within seconds of a break-out), and the moment you break the
-thread out it is a session like any other, mail on unless you toggle its
-mailbox off (the user 2026-09-11, after a thread received a manager's mail and
-acted as the manager). Only peer mail is gated: what you type into the thread's
+so. The comment box itself says nothing about it (the tab hover's Mail row and
+the Sessions pane show the state), except a count when messages are actually
+held for the thread; they land within seconds of a break-out. The moment you
+break the thread out it is a session like any other, mail on unless you toggle
+its mailbox off (the user 2026-09-11, after a thread received a manager's mail
+and acted as the manager). Only peer mail is gated: what you type into the thread's
 box yourself, and plain text the kernel's own send route carries, is yours and
 still goes through; that is the human channel, by design, not a hole in the
 gate.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14242,8 +14242,10 @@ def _comments_frame(sid, live_map=None):
                         "lastUuid": last_uuid,                         # the newest record shown/held — the client's cap-proof "transcript moved" datum
                         "unreachable": unreachable or None,            # a broken thread (missing transcript / lost cut): owes nothing
                         "promotedName": th.get("promotedName") or "",
-                        # the thread's mail state (T356): off by default until broken out; the popover says so
+                        # the thread's mail state (T356): off by default until broken out; the popover says so, and how
+                        # many messages wait in its box (they land within the bus's retry interval of a break-out)
                         "mailOff": bool(_postal_isolated(tsid)),
+                        "heldMail": _held_mail_count(tsid),
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
                         "sinceEpoch": since_ms,
@@ -23393,6 +23395,16 @@ def _postal_shaped(text):
     isolated session."""
     t = (text or "").strip()
     return "romp-msg-id" in t or t.startswith("####################") or "\U0001F4EC" in t
+
+
+def _held_mail_count(sid):
+    """How many messages wait unread in `sid`'s postal box (the bus's Maildir new/ under the shared state): what a
+    thread whose mail is off will receive the moment it is broken out (T356 follow-up). 0 when the box is absent or
+    unreadable; a directory listing, bounded by the box itself."""
+    try:
+        return sum(1 for _ in (jd.STATE / "postal" / "mail" / str(sid) / "new").iterdir())
+    except OSError:
+        return 0
 
 
 def _thread_mail_off(sid):

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1203,9 +1203,12 @@ def _thread_of(sid):
     if not sid or not _safe_id(sid):
         return ""
     p = SESSION_FLAGS.parent / "sdk" / (sid + ".json")
-    if not p.exists():
-        return ""
     try:
+        # the stat sits INSIDE the try (the review's medium): a directory that cannot be read (EACCES, EIO) raised
+        # out of every reader — read_box, the sender gate, resolve_recipient, the /agents filter — a crash, not a
+        # closed door; here it is the closed door
+        if not p.exists():
+            return ""
         d = json.loads(p.read_text())
         return str(d.get("threadOf") or "") if isinstance(d, dict) else THREAD_REG_UNREADABLE
     except Exception:
@@ -1220,6 +1223,9 @@ def _mail_off_why(sid):
                     reads OFF, and the one way on short of a break-out is the fresh key `threadMail` at the literal
                     True in session-flags.json (never an old key re-read). A break-out clears threadOf, and the
                     promoted session falls to the ordinary rule.
+      "unreadable" — the session's durable record exists but cannot be read (corrupt, or a directory the bus cannot
+                    stat): closed, with its own words (the review's low: an ordinary session with a corrupt record was
+                    told it was a comment thread, a wrong diagnosis the norms then make final).
       "isolation" — the user toggled POSTAL ISOLATION on (the timeline lane's mailbox icon → postalServiceOff;
                     the legacy `postalOff` key still honoured).
     Both read the kernel's shared files. Best-effort on the flag read: any error → the flag is unset (fail OPEN,
@@ -1232,7 +1238,7 @@ def _mail_off_why(sid):
         f = None
     t = _thread_of(sid)
     if t == THREAD_REG_UNREADABLE:
-        return "thread"                                  # a reg that exists but cannot be read: closed, never open
+        return "unreadable"                              # a record that exists but cannot be read: closed, never open
     if t and not (isinstance(f, dict) and f.get("threadMail") is True):
         return "thread"
     return "isolation" if (isinstance(f, dict) and (f.get("postalServiceOff") or f.get("postalOff"))) else ""
@@ -1241,6 +1247,11 @@ def _postal_off(sid):
     """True if the session can neither send nor receive mail (see _mail_off_why): it's invisible to list_agents,
     can't send, and can't receive."""
     return bool(_mail_off_why(sid))
+
+UNREADABLE_REG_SENDER = ("isolation: YOUR OWN mail is held because this session's record (its entry under the kernel's sdk/ "
+                         "directory) cannot be read, so the bus cannot tell what kind of session this is. Mail to and from it is "
+                         "held until the record is repaired. Nothing was sent, and this is final: do not route around it. Tell "
+                         "the user the session record cannot be read.")
 
 THREAD_MAIL_OFF_SENDER = ("isolation: YOUR OWN mail is OFF because this session is a COMMENT THREAD. A thread neither "
                           "sends nor receives peer mail until the user breaks it out into a session of its own. "
@@ -1416,7 +1427,12 @@ def resolve_recipient(to, frm_id=""):
     if peer_cands:
         return {"kind": "relay", "host": peer_cands[0][0], "agent": peer_cands[0][1]}
     if direct_all:                        # live, but every candidate has its mailbox off
-        if any(_mail_off_why(a["id"]) == "thread" for a in direct_all):
+        whys = {a["id"]: _mail_off_why(a["id"]) for a in direct_all}
+        if "unreadable" in whys.values():
+            return {"kind": "error", "status": 403,
+                    "error": "isolation: the RECIPIENT '%s' has a session record the bus cannot read; mail to it is held "
+                             "until the record is repaired. YOUR mailbox is fine; nothing was sent, and this is final." % to}
+        if "thread" in whys.values():
             # a comment thread's mail is off until the user breaks it out (T356): say what it is, so the sender
             # reaches the session the thread belongs to instead of waiting on a mailbox toggle nobody offers
             return {"kind": "error", "status": 403,
@@ -1870,7 +1886,11 @@ def _stuck_warn_text(recip, box_sid, body):
     thread out; nothing to resend, nothing to do."""
     name = recip.get("name") or box_sid[:8]
     original = " ".join(body.split())[:160]
-    if _mail_off_why(box_sid) == "thread":
+    why = _mail_off_why(box_sid)
+    if why == "unreadable":
+        return ("↩ HELD — '%s' has a session record the bus cannot read; your message waits in its box until the record "
+                "is repaired. Nothing to resend.\nOriginal: %s" % (name, original))
+    if why == "thread":
         return ("↩ HELD — '%s' is a comment thread, and a thread's mail is off until the user breaks it out. Your "
                 "message waits in its box and lands the moment they do. Nothing to resend, and no other door: the "
                 "refusal is final.\nOriginal: %s" % (name, original))
@@ -1881,7 +1901,10 @@ def _isolated_bounce_why(named, to):
     """Why an inbound cross-host message to `to` bounces when every session answering to it has its mail off: the
     thread refusal when one of them is a comment thread (the review's low: the sender read 'mailbox off' and waited
     on a toggle nobody offers), else the isolation line."""
-    if any(_mail_off_why(a["id"]) == "thread" for a in named):
+    whys = {_mail_off_why(a["id"]) for a in named}
+    if "unreadable" in whys:
+        return "recipient '%s' has a session record the bus cannot read; mail to it is held until the record is repaired" % to
+    if "thread" in whys:
         return ("recipient '%s' is a COMMENT THREAD, and a thread's mail is off, both directions, until the user "
                 "breaks it out into a session of its own; mail the session the thread belongs to instead" % to)
     return "recipient '%s' has its mailbox off (postal isolation)" % to
@@ -2385,6 +2408,8 @@ class Handler(BaseHTTPRequestHandler):
             why_off = _mail_off_why(frm_id)
             if why_off == "thread":                # a comment thread's own send: refused until broken out (T356)
                 return self._send({"error": THREAD_MAIL_OFF_SENDER}, 403)
+            if why_off == "unreadable":            # its own words: never the thread diagnosis for a corrupt record
+                return self._send({"error": UNREADABLE_REG_SENDER}, 403)
             if why_off:                            # the sender is in isolation → sending is disabled
                 return self._send({"error": "isolation: YOUR OWN mailbox is OFF. This session is in postal "
                                    "isolation (its mailbox icon is toggled off on its timeline lane), so it "
@@ -4005,7 +4030,7 @@ def _relay_in(host, m, token_proven=False):
     # 2026-08-30: a delegate bounced "isolation" with no flag set on either kernel and the
     # maildir delivering minutes either side). Same fetch-pair race the sending resolver's
     # one-fetch fix killed (2026-08-31); `answered` feeds the death-ruling gate at the tail.
-    agents, listing_answered = local_agents_checked()
+    agents, listing_answered = local_agents_checked(threads=True)   # thread rows too: a thread recipient must reach the bounce below, not retry forever (the review)
     to_id = str(m.get("toId") or "")
     if to_id and _ID_FORM_RE.fullmatch(to_id) is None:
         to_id = ""            # a malformed wire toId degrades to name matching — it must NEVER reach
@@ -4996,10 +5021,11 @@ def cli_send(argv):
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     mid, me = _self_identity()
-    if mid and _mail_off_why(mid) == "thread":
+    own = _mail_off_why(mid) if mid else ""
+    if own in ("thread", "unreadable"):
         # the CALLER's own identity is judged before any --from label substitutes a synthetic one (the review's low
         # on this change: --from was a door around the thread's own-send refusal, the incident's shape)
-        sys.stderr.write("[romp mail] %s\n" % THREAD_MAIL_OFF_SENDER)
+        sys.stderr.write("[romp mail] %s\n" % (THREAD_MAIL_OFF_SENDER if own == "thread" else UNREADABLE_REG_SENDER))
         return 1
     if frm_label:
         me, mid = frm_label, "ext:" + frm_label

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1192,17 +1192,24 @@ def present_count_checked():
 def present_count():
     return present_count_checked()[0]
 
+THREAD_REG_UNREADABLE = "?"   # _thread_of: a reg that EXISTS but cannot be read; the mail rule fails closed on it
+
 def _thread_of(sid):
     """The parent sid when `sid` is a COMMENT THREAD (its durable SDK reg, beside session-flags.json in the kernel's
-    state, carries threadOf), else ''. Unreadable or absent → '' (an ordinary session), the same fail-open the flag
-    read below keeps; a thread's reg is written before its first turn, so a live thread always has one."""
+    state, carries threadOf), '' for an ordinary session, and THREAD_REG_UNREADABLE when a reg exists but cannot be
+    read (the review's low on this change: an unreadable reg read as "not a thread" and mail went out; the kernel
+    writes regs by os.replace, so an unreadable one is corrupt, never torn, and the rule fails CLOSED on it). No reg
+    at all is an ordinary session (a thread's reg is written before its first turn, so a live thread always has one)."""
     if not sid or not _safe_id(sid):
         return ""
-    try:
-        d = json.loads((SESSION_FLAGS.parent / "sdk" / (sid + ".json")).read_text())
-        return str(d.get("threadOf") or "") if isinstance(d, dict) else ""
-    except Exception:
+    p = SESSION_FLAGS.parent / "sdk" / (sid + ".json")
+    if not p.exists():
         return ""
+    try:
+        d = json.loads(p.read_text())
+        return str(d.get("threadOf") or "") if isinstance(d, dict) else THREAD_REG_UNREADABLE
+    except Exception:
+        return THREAD_REG_UNREADABLE
 
 def _mail_off_why(sid):
     """Why `sid` can neither send nor receive mail right now, or '' when its mail is on:
@@ -1223,7 +1230,10 @@ def _mail_off_why(sid):
         f = json.loads(SESSION_FLAGS.read_text()).get(sid)
     except Exception:
         f = None
-    if _thread_of(sid) and not (isinstance(f, dict) and f.get("threadMail") is True):
+    t = _thread_of(sid)
+    if t == THREAD_REG_UNREADABLE:
+        return "thread"                                  # a reg that exists but cannot be read: closed, never open
+    if t and not (isinstance(f, dict) and f.get("threadMail") is True):
         return "thread"
     return "isolation" if (isinstance(f, dict) and (f.get("postalServiceOff") or f.get("postalOff"))) else ""
 
@@ -1827,10 +1837,7 @@ def _warn_stuck_mail():
                 continue
             s = by_name.get(meta.get("from", ""))
             if s and s["id"] != box.name:               # warn the live sender (never self)
-                warn = ("↩ STILL UNDELIVERED — '%s' is live but hasn't read your message after %d min; it may "
-                        "be stuck. Check on it or resend.\nOriginal: %s"
-                        % (recip.get("name") or box.name[:8], max(1, STUCK_GRACE // 60),
-                           " ".join(body.split())[:160]))
+                warn = _stuck_warn_text(recip, box.name, body)
                 try:
                     deliver(s["id"], "Romp Postal Service", "", warn)
                     threading.Thread(target=_push, args=(s["id"], s), daemon=True).start()
@@ -1855,6 +1862,29 @@ def _warn_stuck_mail():
     except Exception:
         pass
 
+
+def _stuck_warn_text(recip, box_sid, body):
+    """The one-time line a sender gets about a message its LIVE recipient has not read: 'resend' for a stuck session,
+    but never for a comment thread whose mail is off (the review's low on this change: the resend invitation was the
+    very reroute the thread refusal calls final) — its mail is HELD in the box and lands when the user breaks the
+    thread out; nothing to resend, nothing to do."""
+    name = recip.get("name") or box_sid[:8]
+    original = " ".join(body.split())[:160]
+    if _mail_off_why(box_sid) == "thread":
+        return ("↩ HELD — '%s' is a comment thread, and a thread's mail is off until the user breaks it out. Your "
+                "message waits in its box and lands the moment they do. Nothing to resend, and no other door: the "
+                "refusal is final.\nOriginal: %s" % (name, original))
+    return ("↩ STILL UNDELIVERED — '%s' is live but hasn't read your message after %d min; it may "
+            "be stuck. Check on it or resend.\nOriginal: %s" % (name, max(1, STUCK_GRACE // 60), original))
+
+def _isolated_bounce_why(named, to):
+    """Why an inbound cross-host message to `to` bounces when every session answering to it has its mail off: the
+    thread refusal when one of them is a comment thread (the review's low: the sender read 'mailbox off' and waited
+    on a toggle nobody offers), else the isolation line."""
+    if any(_mail_off_why(a["id"]) == "thread" for a in named):
+        return ("recipient '%s' is a COMMENT THREAD, and a thread's mail is off, both directions, until the user "
+                "breaks it out into a session of its own; mail the session the thread belongs to instead" % to)
+    return "recipient '%s' has its mailbox off (postal isolation)" % to
 
 def _hhmm(iso):
     # _iso_now() -> "2026-06-05T14:23:45-0700"; pull HH:MM, else fall back to now.
@@ -4040,7 +4070,7 @@ def _relay_in(host, m, token_proven=False):
     if named:
         # every live candidate's mailbox flag read TRUE in THIS snapshot — a genuine flag ruling,
         # the only thing allowed to mint an isolation bounce (finality makes this arm zero-tolerance)
-        return "bounce", {"mid": mid, "why": "recipient '%s' has its mailbox off (postal isolation)" % to}
+        return "bounce", {"mid": mid, "why": _isolated_bounce_why(named, to)}
     if not m.get("origin"):                          # one hop MAX: a message that already hopped never re-forwards
         # route by the SID when the mail carries one, by name otherwise (skeptic finds
         # 2026-09-01, both rounds): the hub's name-only forward final-bounced a sid-addressed
@@ -4966,6 +4996,11 @@ def cli_send(argv):
     if not ensure():
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     mid, me = _self_identity()
+    if mid and _mail_off_why(mid) == "thread":
+        # the CALLER's own identity is judged before any --from label substitutes a synthetic one (the review's low
+        # on this change: --from was a door around the thread's own-send refusal, the incident's shape)
+        sys.stderr.write("[romp mail] %s\n" % THREAD_MAIL_OFF_SENDER)
+        return 1
     if frm_label:
         me, mid = frm_label, "ext:" + frm_label
     if not mid:

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -147,7 +147,7 @@ CENSUS = {
     "_session_chip": ("pure", "over classified inputs: the parse and live tail, the row, the backend brackets, the clock booleans, the live task rows, the watches, the states overlay, the store and the downtime list"),
     "_session_cwd": ("sig", "cwd", "the names entry's cwd, else the transcript's stamp"),
     "_session_flag": ("sig", "flags"),
-    "_postal_isolated": ("sig", "flags", "the effective mail state: the mailbox flag with its legacy twin, and a comment thread's default from its reg (T356)"),
+    "_postal_isolated": ("sig", "flags", "the effective mail state: the mailbox flag with its legacy twin (flags), and a comment thread's default read from its reg's threadOf through _thread_reg (reg) (T356)"),
     "_session_meta": ("pure", "over the transcript's records, memoized by record identity (transcript)"),
     "_session_retry_suppressed": ("sig", "retry"),
     "_session_working": ("sig", "downtime", "over the turns, and the host suspensions recorded since boot"),

--- a/tests/test_postal_isolation.py
+++ b/tests/test_postal_isolation.py
@@ -256,9 +256,10 @@ class ThreadMailOffFollowUp(unittest.TestCase):
         d = pm.SESSION_FLAGS.parent / "sdk"; d.mkdir(parents=True, exist_ok=True)
         (d / (THREAD + ".json")).write_text("{not json")
         self.assertEqual(pm._thread_of(THREAD), pm.THREAD_REG_UNREADABLE)
-        self.assertEqual(pm._mail_off_why(THREAD), "thread", "a reg that exists but cannot be read: closed")
+        self.assertEqual(pm._mail_off_why(THREAD), "unreadable", "a record that exists but cannot be read: closed, under its own reason")
+        self.assertTrue(pm._postal_off(THREAD))
         (d / (THREAD + ".json")).write_text(json.dumps(["not", "a", "dict"]))
-        self.assertEqual(pm._mail_off_why(THREAD), "thread", "…whatever shape the corruption takes")
+        self.assertEqual(pm._mail_off_why(THREAD), "unreadable", "…whatever shape the corruption takes")
         (d / (THREAD + ".json")).unlink()
         self.assertEqual(pm._thread_of(THREAD), ""); self.assertEqual(pm._mail_off_why(THREAD), "", "no reg at all: an ordinary session")
 
@@ -284,6 +285,54 @@ class ThreadMailOffFollowUp(unittest.TestCase):
             self.assertEqual(rc3, 0); self.assertEqual(len(calls), 1); self.assertEqual(calls[0][2]["from_id"], "ext:nightly")
         finally:
             pm._self_identity, pm.ensure, pm._http = saved
+
+    def test_a_directory_the_bus_cannot_stat_fails_closed_without_raising(self):
+        # the review's medium: the stat sat outside the try, so EACCES on sdk/ raised out of every reader
+        d = pm.SESSION_FLAGS.parent / "sdk"; d.mkdir(parents=True, exist_ok=True)
+        (d / (THREAD + ".json")).write_text(json.dumps({"sid": THREAD, "threadOf": PARENT}))
+        if os.geteuid() == 0:
+            self.skipTest("root reads through chmod 000")
+        os.chmod(d, 0)
+        try:
+            self.assertEqual(pm._thread_of(THREAD), pm.THREAD_REG_UNREADABLE)
+            self.assertEqual(pm._mail_off_why(THREAD), "unreadable")
+            self.assertEqual(pm.read_box(THREAD, consume=True), [], "the receive gate answers empty, it does not raise")
+            self.assertTrue(pm._postal_off(THREAD))
+        finally:
+            os.chmod(d, 0o755)
+
+    def test_an_unreadable_record_gets_its_own_words_never_the_thread_diagnosis(self):
+        d = pm.SESSION_FLAGS.parent / "sdk"; d.mkdir(parents=True, exist_ok=True)
+        (d / (SENDER + ".json")).write_text("{corrupt")
+        self.assertNotIn("COMMENT THREAD", pm.UNREADABLE_REG_SENDER); self.assertIn("cannot be read", pm.UNREADABLE_REG_SENDER)
+        held = pm._stuck_warn_text({"name": "api"}, SENDER, "hello")
+        self.assertTrue(held.startswith("↩ HELD")); self.assertIn("cannot read", held); self.assertNotIn("COMMENT THREAD", held)
+        self.assertIn("cannot read", pm._isolated_bounce_why([{"id": SENDER, "name": "api"}], "api"))
+        import io
+        saved = (pm._self_identity, pm.ensure, pm._http)
+        try:
+            pm._self_identity = lambda: (SENDER, "api"); pm.ensure = lambda: True; pm._http = lambda *a, **k: {}
+            err = io.StringIO(); real = sys.stderr; sys.stderr = err
+            try:
+                rc = pm.cli_send(["web", "a note"])
+            finally:
+                sys.stderr = real
+            self.assertEqual(rc, 1); self.assertIn("cannot be read", err.getvalue()); self.assertNotIn("COMMENT THREAD", err.getvalue())
+        finally:
+            pm._self_identity, pm.ensure, pm._http = saved
+
+    def test_an_inbound_relay_to_a_thread_bounces_through_relay_in_itself(self):
+        # the review's medium: _relay_in listed the DEFAULT rows (no threads), so the thread arm never ran and the relay retried forever
+        _reg(THREAD, threadOf=PARENT)
+        rows = [{"id": PARENT, "name": "web"}, {"id": THREAD, "name": "web-comment-1", "thread": True, "parent": PARENT}]
+        saved = pm._kernel_sessions_checked
+        pm._kernel_sessions_checked = lambda threads=False: ([r for r in rows if threads or not r.get("thread")], True)
+        try:
+            verdict, bounce = pm._relay_in("TESTHOST", {"mid": "relay-thread-0001", "to": "web-comment-1", "frm": "api", "frm_id": "id-api", "body": "a note", "kind": "coordinate"})
+            self.assertEqual(verdict, "bounce", (verdict, bounce))
+            self.assertIn("COMMENT THREAD", bounce["why"]); self.assertIn("breaks it out", bounce["why"])
+        finally:
+            pm._kernel_sessions_checked = saved
 
     def test_the_stuck_mail_line_says_held_for_a_thread_and_resend_for_a_session(self):
         _reg(THREAD, threadOf=PARENT)

--- a/tests/test_postal_isolation.py
+++ b/tests/test_postal_isolation.py
@@ -7,6 +7,7 @@ end-to-end /send + /agents enforcement is in tests/romp-postal.bats.
 Synthetic only — placeholder UUIDs, hermetic temp state dir, no real session data.
 """
 import json
+import sys
 import os
 import tempfile
 import unittest
@@ -237,6 +238,67 @@ class ThreadOwnSendRefused(unittest.TestCase):
         _reg(THREAD)                                       # broken out: the reg has no threadOf
         status, body = self._send(THREAD, "web-2", "web")
         self.assertNotEqual(status, 403, "a promoted session sends like any other: %r" % (body,))
+
+
+class ThreadMailOffFollowUp(unittest.TestCase):
+    """The review's lows on the thread rule: a reg that exists but cannot be read fails CLOSED; the CLI judges the
+    caller's own identity before a --from label substitutes a synthetic one; a sender's stuck-mail line for a thread
+    says HELD, never resend; an inbound cross-host bounce names the thread refusal."""
+
+    def tearDown(self):
+        for f in (pm.SESSION_FLAGS, pm.SESSION_FLAGS.parent / "sdk" / (THREAD + ".json"), pm.SESSION_FLAGS.parent / "sdk" / (SENDER + ".json")):
+            try:
+                f.unlink()
+            except OSError:
+                pass
+
+    def test_an_unreadable_reg_fails_closed_and_no_reg_stays_open(self):
+        d = pm.SESSION_FLAGS.parent / "sdk"; d.mkdir(parents=True, exist_ok=True)
+        (d / (THREAD + ".json")).write_text("{not json")
+        self.assertEqual(pm._thread_of(THREAD), pm.THREAD_REG_UNREADABLE)
+        self.assertEqual(pm._mail_off_why(THREAD), "thread", "a reg that exists but cannot be read: closed")
+        (d / (THREAD + ".json")).write_text(json.dumps(["not", "a", "dict"]))
+        self.assertEqual(pm._mail_off_why(THREAD), "thread", "…whatever shape the corruption takes")
+        (d / (THREAD + ".json")).unlink()
+        self.assertEqual(pm._thread_of(THREAD), ""); self.assertEqual(pm._mail_off_why(THREAD), "", "no reg at all: an ordinary session")
+
+    def test_the_cli_judges_the_callers_own_identity_before_any_from_label(self):
+        _reg(THREAD, threadOf=PARENT)
+        import io
+        saved = (pm._self_identity, pm.ensure, pm._http)
+        calls = []
+        try:
+            pm._self_identity = lambda: (THREAD, "web-comment-1")
+            pm.ensure = lambda: True
+            pm._http = lambda *a, **k: calls.append(a) or {}
+            err = io.StringIO(); real = sys.stderr; sys.stderr = err
+            try:
+                rc1 = pm.cli_send(["web", "a note"])
+                rc2 = pm.cli_send(["--from", "nightly", "web", "a note"])
+            finally:
+                sys.stderr = real
+            self.assertEqual((rc1, rc2), (1, 1)); self.assertEqual(calls, [], "nothing reached the bus")
+            self.assertEqual(err.getvalue().count("COMMENT THREAD"), 2); self.assertIn("breaks it out", err.getvalue())
+            _reg(THREAD)                                   # broken out: the same calls go through to the bus
+            rc3 = pm.cli_send(["--from", "nightly", "web", "a note"])
+            self.assertEqual(rc3, 0); self.assertEqual(len(calls), 1); self.assertEqual(calls[0][2]["from_id"], "ext:nightly")
+        finally:
+            pm._self_identity, pm.ensure, pm._http = saved
+
+    def test_the_stuck_mail_line_says_held_for_a_thread_and_resend_for_a_session(self):
+        _reg(THREAD, threadOf=PARENT)
+        held = pm._stuck_warn_text({"name": "web-comment-1"}, THREAD, "please  look\nat this")
+        self.assertTrue(held.startswith("↩ HELD")); self.assertIn("breaks it out", held); self.assertIn("Nothing to resend", held)
+        self.assertIn("Original: please look at this", held)
+        stuck = pm._stuck_warn_text({"name": "api"}, SENDER, "hello")
+        self.assertTrue(stuck.startswith("↩ STILL UNDELIVERED")); self.assertIn("resend", stuck)
+
+    def test_an_inbound_bounce_names_the_thread_refusal(self):
+        _reg(THREAD, threadOf=PARENT)
+        why = pm._isolated_bounce_why([{"id": THREAD, "name": "web-comment-1"}], "web-comment-1")
+        self.assertIn("COMMENT THREAD", why); self.assertIn("breaks it out", why)
+        _flags({SENDER: {"postalServiceOff": True}})
+        self.assertEqual(pm._isolated_bounce_why([{"id": SENDER, "name": "api"}], "api"), "recipient 'api' has its mailbox off (postal isolation)")
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_thread_mail_off.py
+++ b/tests/test_thread_mail_off.py
@@ -92,5 +92,21 @@ class ThreadMailOff(unittest.TestCase):
         self.assertNotIn('"postalServiceOff": _session_flag(sid, "postalServiceOff")', whole, "no row reads the raw flag past the effective reader")
 
 
+class HeldMail(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp(); self.saved = km.jd.STATE; km.jd._rebind_state(Path(self.td))
+
+    def tearDown(self):
+        km.jd._rebind_state(self.saved); shutil.rmtree(self.td, ignore_errors=True)
+
+    def test_the_held_count_is_the_boxs_unread_mail_and_zero_without_a_box(self):
+        self.assertEqual(km._held_mail_count(THREAD), 0, "no box")
+        box = Path(self.td) / "postal" / "mail" / THREAD / "new"; box.mkdir(parents=True)
+        for i in range(3):
+            (box / ("m%d" % i)).write_text("From: peer\n\nhello\n")
+        self.assertEqual(km._held_mail_count(THREAD), 3)
+        self.assertIn('"heldMail": _held_mail_count(tsid)', inspect.getsource(km._comments_frame), "the frame carries it beside mailOff")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -10,6 +10,8 @@ export type CommentMsg = { who: "you" | "agent"; text: string; t: number };
 export type CommentThread = {
   /** the thread's mail is off (T356): a comment thread neither sends nor receives peer mail until broken out */
   mailOff?: boolean;
+  /** messages waiting in its postal box (they land when it is broken out) */
+  heldMail?: number;
   tid: string;
   name?: string;              // the thread's editable name (<session>-comment-<N> by default)
   color?: string;             // the comment's identity color — picked distinct from its parent's

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9798,14 +9798,13 @@ function renderCommentPopover(): void {
     crow.append(attach, box, send);
     pop.appendChild(crow);
     if (metaRowPending) pop.appendChild(metaRowPending);   // model/effort under the box, like the chat
-    if (th && th.mailOff) {
-      // T356 (the user 2026-09-11): a thread's mail is off, both directions, until it is broken out; the popover
-      // is the thread's whole surface, so it says so here
-      const mail = el("div", "cmt-note cmt-mail");
+    if (th && th.mailOff && (th.heldMail || 0) > 0) {
+      // T356: a thread's mail is off until it is broken out, but the comment box does not SAY so (the user
+      // 2026-09-11, 3:05 PM PT: not here; the tab hover's Mail row and the Sessions pane tag carry the state quietly).
+      // Only a message actually held in its box is worth a line: the count, and that it lands at the break-out.
       const held = th.heldMail || 0;
-      mail.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out."
-        + (held ? " " + held + (held === 1 ? " message waits" : " messages wait") + " in its box and land when you do." : "");
-      mail.title = "Peers cannot see or mail this thread, and its own mail is refused. Break out turns mail on.";
+      const mail = el("div", "cmt-note cmt-mail");
+      mail.textContent = held + (held === 1 ? " message waits in its box and lands" : " messages wait in its box and land") + " at the break-out.";
       pop.appendChild(mail);
     }
     if (th && th.status === "open") {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9802,7 +9802,9 @@ function renderCommentPopover(): void {
       // T356 (the user 2026-09-11): a thread's mail is off, both directions, until it is broken out; the popover
       // is the thread's whole surface, so it says so here
       const mail = el("div", "cmt-note cmt-mail");
-      mail.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out.";
+      const held = th.heldMail || 0;
+      mail.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out."
+        + (held ? " " + held + (held === 1 ? " message waits" : " messages wait") + " in its box and land when you do." : "");
       mail.title = "Peers cannot see or mail this thread, and its own mail is refused. Break out turns mail on.";
       pop.appendChild(mail);
     }
@@ -9873,9 +9875,13 @@ function renderCommentPopover(): void {
     const note = el("div", "cmt-note");
     note.textContent = "The discussion continues there.";
     pop.appendChild(note);
-    // the break-out flipped its mail on (T356): said once, here, where the user looks after breaking it out
+    // the break-out flipped its mail on (T356): said once, here, where the user looks after breaking it out — from the
+    // EFFECTIVE state the frame carries, so a mailbox the user toggled off since reads as off (the review's low)
     const mailOn = el("div", "cmt-note cmt-mail");
-    mailOn.textContent = "Its mail is on now: peers can reach it and it can send.";
+    const held = th.heldMail || 0;
+    mailOn.textContent = th.mailOff
+      ? "Its mailbox is off: the lane's mailbox toggle turns peer mail back on."
+      : "Its mail is on now: peers can reach it and it can send." + (held ? " " + held + (held === 1 ? " held message lands" : " held messages land") + " in a moment." : "");
     pop.appendChild(mailOn);
     const row = el("div", "cmt-actions");
     const open = el("button", "cmt-act") as HTMLButtonElement;

--- a/ui/webview/thread-mail.test.ts
+++ b/ui/webview/thread-mail.test.ts
@@ -16,10 +16,15 @@ const POSTAL = fs.readFileSync(path.resolve(process.cwd(), "..", "postal", "post
 
 test("the popover says the thread's mail is off, and the promoted view says it is on now", () => {
   assert.match(COMMENTS, /mailOff\?: boolean;/, "the frame's field on the thread type");
-  assert.match(RENDER, /if \(th && th\.mailOff\) \{[\s\S]*?const mail = el\("div", "cmt-note cmt-mail"\);\s*\n\s*mail\.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out\.";/);
-  assert.match(RENDER, /note\.textContent = "The discussion continues there\.";\s*\n\s*pop\.appendChild\(note\);[\s\S]{0,200}mailOn\.textContent = "Its mail is on now: peers can reach it and it can send\.";/,
-               "said once, in the promoted view");
+  assert.match(RENDER, /if \(th && th\.mailOff\) \{[\s\S]*?const mail = el\("div", "cmt-note cmt-mail"\);[\s\S]{0,120}?mail\.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out\."\s*\n\s*\+ \(held \?/);
+  assert.match(RENDER, /note\.textContent = "The discussion continues there\.";\s*\n\s*pop\.appendChild\(note\);[\s\S]{0,600}mailOn\.textContent = th\.mailOff[\s\S]{0,200}: "Its mail is on now: peers can reach it and it can send\."/,
+               "said once, in the promoted view, from the effective state");
   assert.match(CSS, /\.cmt-note\.cmt-mail \{ opacity: 0\.6; font-size: 0\.86em; \}/);
+  // the follow-up: the promoted line reads the EFFECTIVE state (a mailbox toggled off since says so), and both lines
+  // count the mail held in the box
+  assert.match(COMMENTS, /heldMail\?: number;/);
+  assert.match(RENDER, /mailOn\.textContent = th\.mailOff\s*\n\s*\? "Its mailbox is off: the lane's mailbox toggle turns peer mail back on\."/);
+  assert.match(RENDER, /" in its box and land when you do\."/); assert.match(RENDER, /" in a moment\."/);
 });
 
 test("the tab hover and the Sessions pane show a session's mail state", () => {
@@ -35,7 +40,8 @@ test("the kernel and the bus derive the same default from the thread's reg and t
   assert.match(KERNEL, /def _postal_isolated\(sid\):[\s\S]*?return _thread_mail_off\(sid\) or bool\(_session_flag\(sid, "postalServiceOff"\) or _session_flag\(sid, "postalOff"\)\)/);
   assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),/, "the comments frame carries it");
   assert.match(KERNEL, /"postalServiceOff": _postal_isolated\(m\["id"\]\),/, "the Sessions pane rows carry it");
-  assert.match(POSTAL, /if _thread_of\(sid\) and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/);
+  assert.match(POSTAL, /t = _thread_of\(sid\)\s*\n\s*if t == THREAD_REG_UNREADABLE:\s*\n\s*return "thread"[^\n]*\n\s*if t and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/,
+               "an unreadable reg is closed, then the literal-True key");
   assert.match(POSTAL, /if why_off == "thread":[^\n]*\n\s*return self\._send\(\{"error": THREAD_MAIL_OFF_SENDER\}, 403\)/, "the thread's own send");
   assert.match(POSTAL, /if any\(_mail_off_why\(a\["id"\]\) == "thread" for a in direct_all\):/, "a send to the thread");
 });

--- a/ui/webview/thread-mail.test.ts
+++ b/ui/webview/thread-mail.test.ts
@@ -16,7 +16,9 @@ const POSTAL = fs.readFileSync(path.resolve(process.cwd(), "..", "postal", "post
 
 test("the popover says the thread's mail is off, and the promoted view says it is on now", () => {
   assert.match(COMMENTS, /mailOff\?: boolean;/, "the frame's field on the thread type");
-  assert.match(RENDER, /if \(th && th\.mailOff\) \{[\s\S]*?const mail = el\("div", "cmt-note cmt-mail"\);[\s\S]{0,120}?mail\.textContent = "Mail off: this thread neither sends nor receives peer mail until you break it out\."\s*\n\s*\+ \(held \?/);
+  // the user's ruling (2026-09-11, 3:05 PM PT): the comment box says nothing about mail being off; a line only for held mail
+  assert.doesNotMatch(RENDER, /Mail off: this thread neither sends nor receives peer mail/);
+  assert.match(RENDER, /if \(th && th\.mailOff && \(th\.heldMail \|\| 0\) > 0\) \{[\s\S]{0,700}?mail\.textContent = held \+ \(held === 1 \? " message waits in its box and lands" : " messages wait in its box and land"\) \+ " at the break-out\.";/);
   assert.match(RENDER, /note\.textContent = "The discussion continues there\.";\s*\n\s*pop\.appendChild\(note\);[\s\S]{0,600}mailOn\.textContent = th\.mailOff[\s\S]{0,200}: "Its mail is on now: peers can reach it and it can send\."/,
                "said once, in the promoted view, from the effective state");
   assert.match(CSS, /\.cmt-note\.cmt-mail \{ opacity: 0\.6; font-size: 0\.86em; \}/);
@@ -24,7 +26,7 @@ test("the popover says the thread's mail is off, and the promoted view says it i
   // count the mail held in the box
   assert.match(COMMENTS, /heldMail\?: number;/);
   assert.match(RENDER, /mailOn\.textContent = th\.mailOff\s*\n\s*\? "Its mailbox is off: the lane's mailbox toggle turns peer mail back on\."/);
-  assert.match(RENDER, /" in its box and land when you do\."/); assert.match(RENDER, /" in a moment\."/);
+  assert.match(RENDER, /" in a moment\."/);
 });
 
 test("the tab hover and the Sessions pane show a session's mail state", () => {
@@ -40,8 +42,9 @@ test("the kernel and the bus derive the same default from the thread's reg and t
   assert.match(KERNEL, /def _postal_isolated\(sid\):[\s\S]*?return _thread_mail_off\(sid\) or bool\(_session_flag\(sid, "postalServiceOff"\) or _session_flag\(sid, "postalOff"\)\)/);
   assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),/, "the comments frame carries it");
   assert.match(KERNEL, /"postalServiceOff": _postal_isolated\(m\["id"\]\),/, "the Sessions pane rows carry it");
-  assert.match(POSTAL, /t = _thread_of\(sid\)\s*\n\s*if t == THREAD_REG_UNREADABLE:\s*\n\s*return "thread"[^\n]*\n\s*if t and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/,
-               "an unreadable reg is closed, then the literal-True key");
+  assert.match(POSTAL, /t = _thread_of\(sid\)\s*\n\s*if t == THREAD_REG_UNREADABLE:\s*\n\s*return "unreadable"[^\n]*\n\s*if t and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/,
+               "an unreadable record is closed under its own reason, then the literal-True key");
+  assert.match(POSTAL, /agents, listing_answered = local_agents_checked\(threads=True\)/, "the relay lists thread rows, so a thread recipient bounces instead of retrying forever");
   assert.match(POSTAL, /if why_off == "thread":[^\n]*\n\s*return self\._send\(\{"error": THREAD_MAIL_OFF_SENDER\}, 403\)/, "the thread's own send");
-  assert.match(POSTAL, /if any\(_mail_off_why\(a\["id"\]\) == "thread" for a in direct_all\):/, "a send to the thread");
+  assert.match(POSTAL, /whys = \{a\["id"\]: _mail_off_why\(a\["id"\]\) for a in direct_all\}[\s\S]{0,500}?if "unreadable" in whys\.values\(\):[\s\S]{0,500}?if "thread" in whys\.values\(\):/, "a send to the thread, and to a session whose record cannot be read, each with its own words");
 });


### PR DESCRIPTION
The eight lows from the review of the comment-thread mail-off change (the manager's verdict on that PR), two of them the incident's shape.

## What changes

- **The CLI judges the caller first.** `romp mail send --from <label>` substituted a synthetic id before the bus saw the caller, a door around the thread's own-send refusal. `cli_send` now reads the caller's own identity and refuses with the thread text before any label applies; a script with no session identity keeps its door.
- **An unreadable reg fails closed.** A reg that exists but cannot be read counted as "not a thread". It now answers a sentinel and the rule fails closed on it (regs are written by `os.replace`, so unreadable means corrupt, never torn); no reg at all stays an ordinary session.
- **Held mail is named and counted.** The sender's one-time STILL UNDELIVERED line for a thread recipient now says HELD and that there is nothing to resend. The comments frame carries `heldMail`; the popover says how many messages wait and that they land at the break-out; the promoted view says how many land in a moment.
- **The promoted line reads the effective state**, so a mailbox toggled off since says so.
- **The inbound cross-host bounce** names the thread refusal instead of the isolation wording.
- **Docs and the census note**: the human channel (the thread's own box, the kernel's plain-text send) is by design outside the gate; the census names the reg read under its label.

- **The review's fold**: the inbound relay lists thread rows, so a thread recipient bounces (driven through `_relay_in`) instead of retrying forever; the record read's stat is inside its try, a closed door instead of a raise out of every reader (tested with `sdk/` at mode 000); an unreadable record has its own reason and words everywhere, never the thread diagnosis. The user's ruling: the comment box no longer says mail is off; it shows only a held-mail count when any is held.

## Tests

`tests/test_postal_isolation.py` (unreadable reg closed, no reg open; `cli_send` refused from a thread with and without `--from`, through once broken out; the HELD and STILL UNDELIVERED lines; the bounce why), `tests/test_thread_mail_off.py` (the held count and the frame field), `ui/webview/thread-mail.test.ts` (the effective promoted line and the held wording).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
