### PR TITLE
The headless spend-modal test reads the session list as the range-following list it became

### DIFF
--- a/tests/spend_modal_headless.js
+++ b/tests/spend_modal_headless.js
@@ -110,6 +110,11 @@ const { chromium } = require('playwright');
   await pg.waitForFunction(() => document.querySelector('#rsp-panel [data-act="range:days"]').classList.contains('on')
     && document.querySelector('#rsp-panel [data-act="measure:tok"]').classList.contains('on'), null, { timeout: 5000 });
   const days = await pg.evaluate(() => ({
+    // T353: the session list follows the chart's range, so the FULL list (every session with spend in 90 days) is
+    // read here, with its pane's scroll: the seven days shown at open list only the sessions with hourly spend
+    rows: Array.from(document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr')).map((tr) => tr.textContent),
+    deadRows: document.querySelectorAll('#rsp-panel .rsp-tbl tbody tr.rsp-dead').length,
+    pane: (() => { const p = document.getElementById('rsp-table'); const panel = document.getElementById('rsp-panel'); return { scrolls: !!p && p.scrollHeight > p.clientHeight + 4, h: p ? p.clientHeight : null, panelScrolls: panel.scrollHeight > panel.clientHeight + 2 }; })(),
     segs: document.querySelectorAll('#rsp-chart .rsp-seg').length,
     ylabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gy')).map((e) => e.textContent),
     xlabels: Array.from(document.querySelectorAll('#rsp-chart .ru-tip-gx span')).map((e) => e.textContent),

--- a/tests/test_spend_modal_headless.py
+++ b/tests/test_spend_modal_headless.py
@@ -152,10 +152,12 @@ class SpendModalServed(unittest.TestCase):
         self.assertEqual(o["out"]["backdrop"], "rgba(0, 0, 0, 0.55)", "the panel rule's backdrop")
         self.assertEqual(o["out"]["head"], "API spend · 2 machines", "the header names the machines when several contribute (review find)")
         rows = o["out"]["rows"]
-        # T247c: two hosts contribute, so every row names its host in the tab strip's host-prefix voice
+        # T247c: two hosts contribute, so every row names its host in the tab strip's host-prefix voice. T353: the
+        # list follows the chart's range, seven days by hour at open, and sorts by the spend IN that range: web
+        # (an hourly dollar over the ledger's 60 hours), then api, then the peer's worker
         self.assertTrue(rows[0].startswith("TESTHOST:web"), rows[0])
-        self.assertTrue(rows[1].startswith("PEERHOST:worker"), rows[1])
-        self.assertTrue(rows[2].startswith("TESTHOST:api"), rows[2])
+        self.assertTrue(rows[1].startswith("TESTHOST:api"), rows[1])
+        self.assertTrue(rows[2].startswith("PEERHOST:worker"), rows[2])
         self.assertTrue(any("OLDHOST" in n and "older build" in n for n in o["out"]["notes"]), o["out"]["notes"])
         self.assertFalse(any("this machine only" in n for n in o["out"]["notes"]))
         self.assertTrue(any("aligned by clock time" in n for n in o["out"]["notes"]), "hosts in different zones: the timezone rule is stated")
@@ -164,14 +166,18 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(o["out"]["chartFirst"], "the chart section precedes the session list")
         self.assertEqual(o["out"]["legendNodes"], 0, "no legend")
         self.assertEqual(o["out"]["swatches"], 0, "no swatch in a session row")
-        self.assertEqual(len(rows), 3 + 20 + 1 + 1, "every session across both hosts, plus the unattributed row")
+        # T353: the seven days shown carry the three hourly-ledger sessions, the peer's worker and the unattributed
+        # hour; the twenty filler sessions spend by the day only, so they appear once the 90-day range is shown
+        self.assertEqual(len(rows), 5, "the sessions with spend in the range shown: " + " | ".join(rows))
+        self.assertEqual(len(o["days"]["rows"]), 3 + 20 + 1 + 1, "the 90-day range lists every session across both hosts, plus the unattributed row")
         self.assertEqual(o["out"]["title"]["color"], "rgb(30, 161, 235)", "web's title wears its identity color")
         self.assertEqual(o["out"]["title"]["weight"], "600")
         self.assertEqual(o["out"]["title"]["prefix"], "TESTHOST:")
-        self.assertTrue(o["out"]["pane"]["scrolls"], o["out"]["pane"])
+        self.assertTrue(o["days"]["pane"]["scrolls"], "the full list scrolls in its pane (T247e): " + str(o["days"]["pane"]))
         self.assertEqual(o["out"]["pane"]["sticky"], "sticky")
         self.assertEqual(o["out"]["pane"]["thOpacity"], "1", "the sticky header occludes: muted by color, not opacity (review find)")
         self.assertFalse(o["out"]["pane"]["panelScrolls"], "the card itself does not scroll at 820px: the pane takes the room under the chart (review find)")
+        self.assertFalse(o["days"]["pane"]["panelScrolls"], "nor with the full list: the pane scrolls, not the card")
         # T247f: "your order" — the strip's order (api before web from session-order.json, then the peer's own
         # order), unknown sessions trailing by spend; the chart's bottom stack follows; a viewer arrangement
         # (the strip's localStorage key) reorders both; the choice persists with the other toggles
@@ -190,8 +196,10 @@ class SpendModalServed(unittest.TestCase):
         self.assertTrue(mg["rows"][0].startswith("team · 2 sessions"), mg["rows"][:3])
         self.assertTrue(mg["rows"][1].startswith("ops · 2 sessions"), mg["rows"][:3])
         self.assertFalse(any(r.startswith("TESTHOST:web") or r.startswith("TESTHOST:api") or r.startswith("PEERHOST:worker") for r in mg["rows"]), "tagged sessions merge away")
-        self.assertIn("$1200", mg["rows"][0].replace(",", ""), "team = web 960 + api 240")
-        self.assertIn("$540", mg["rows"][1].replace(",", ""), "ops = api 240 + worker 300")
+        # the merged rows are read in the 90-day range (the driver left it there), where the fixture's whole ledger
+        # lies: the sums over that range are the ledger's totals (T353: the list follows the chart's range)
+        self.assertIn("$1200", mg["rows"][0].replace(",", ""), "team = web 960 + api 240: " + mg["rows"][0])
+        self.assertIn("$540", mg["rows"][1].replace(",", ""), "ops = api 240 + worker 300: " + mg["rows"][1])
         self.assertEqual(mg["tagColor"], "rgb(194, 65, 12)", "the tag row wears the tag store's color")
         self.assertEqual((mg["tagBorder"], mg["tagWeight"]), ("rgb(194, 65, 12)", "400"), "…as the one tag chip: its colour on a thin border, never bold (T321)")
         self.assertTrue(any("1 session carries several tags" in n for n in mg["notes"]), mg["notes"])


### PR DESCRIPTION
Main is red on `tests/test_spend_modal_headless.py` since the range-following session list landed: the served test pinned the all-time list (the peer's worker as the second row, twenty-five rows, a scrolling pane) while the list at open now follows the seven days the chart shows by hour, over which the fixture has three hourly-ledger sessions, the peer's worker and the unattributed hour, sorted by spend in that range (web, api, worker).

What changes (tests only, no production code):
- The test pins the five rows and their in-range order at open.
- The driver reads the full session list and its pane under the 90-day range, where every session across both hosts has spend; the twenty-five-row count and the pane-scrolls pins move there, and the card-does-not-scroll pin is checked there as well.
- The merged-by-tag sums were already read under the 90-day range, where the fixture's whole ledger lies, so their pins stand with a note saying why.

Red first: the module fails on main at the second-row pin (`TESTHOST:api` where `PEERHOST:worker` was expected) and passes with this change; the whole headless spend module was executed.

```
capped uv run --quiet --with pytest --with pytest-timeout python -m pytest tests/test_spend_modal_headless.py -q
```

Tier: fix
