### PR TITLE
The two comment-mark served labs wait 60 s for the highlight: the comments frame trails the chat frame on a loaded runner

### DIFF
--- a/tests/test_comment_pop_size_browser.py
+++ b/tests/test_comment_pop_size_browser.py
@@ -74,8 +74,11 @@ const page = await browser.newPage({ viewport: { width: cfg.W, height: cfg.H } }
 
 async function load() {
   await page.goto(cfg.chat);
-  await page.waitForSelector("#content .turn p", { timeout: 20000 });
-  await page.waitForSelector("mark.cmt-hl[data-tid]", { timeout: 20000 });   // the seeded thread's highlight has landed
+  // 60 s, not 20: the highlight lands after the kernel's comments frame, which on a loaded runner follows the chat frame
+  // by tens of seconds (2026-09-11: red twice on CI for a head that changed nothing on this road; under a 20% CPU quota
+  // main itself misses 20 s two runs in three and lands by 90 s). The wait is still the event, only its ceiling moved.
+  await page.waitForSelector("#content .turn p", { timeout: 60000 });
+  await page.waitForSelector("mark.cmt-hl[data-tid]", { timeout: 60000 });   // the seeded thread's highlight has landed
   await page.waitForTimeout(300);
 }
 const geom = () => page.evaluate(() => {

--- a/tests/test_comment_promoted_popup_browser.py
+++ b/tests/test_comment_promoted_popup_browser.py
@@ -96,7 +96,9 @@ await page.locator(`#tabs .tab[data-id="${cfg.sid}"]`).first().click();   // the
 // the parent's transcript renders and the kernel's comments frame lands: the highlights wrap both passages
 // (attached, not visible — every session's view stays in the DOM, hidden when not active; the click below
 // auto-waits for the visible one)
-for (const tid of [cfg.promoted, cfg.open]) await page.waitForSelector(`mark.cmt-hl[data-tid="${tid}"]`, { state: "attached", timeout: 30000 });
+// 60 s: the highlights land after the kernel's comments frame, tens of seconds behind the chat frame on a loaded runner
+// (2026-09-11: red on CI at 30 s for a head that changed nothing on this road)
+for (const tid of [cfg.promoted, cfg.open]) await page.waitForSelector(`mark.cmt-hl[data-tid="${tid}"]`, { state: "attached", timeout: 60000 });
 
 // the popup as painted — rects and computed styles, read-only
 const MEASURE = () => {


### PR DESCRIPTION
The sizing and promoted-popup served labs wait for the seeded thread's highlight after the transcript renders; that highlight lands with the kernel's comments frame, which trails the chat frame by tens of seconds on a loaded runner. CI's extension job was red twice today at those waits for a head that changed nothing on the mark's road. Reproduced with contention and no load (a systemd scope at a 20% CPU quota): the sizing lab misses its 20 s on main itself two runs in three and on that head's merge-base; with the wait at 90 s it passes at 92 s, so the mark is late, never absent. The waits stay event-based (the selector); only the ceiling moves to 60 s.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)