### PR TITLE
The spend guard's tree memo evicts largest-first to a fraction of its bound and clears on a disabled ceiling (T350 follow-up 2)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -37124,6 +37124,8 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
     ceiling = _spend_ceiling()
     if ceiling <= 0:
         _SPEND_GUARD.clear()                             # disabled: nothing latched survives the disable
+        _SPEND_TREE_CACHE.clear()                        # and no tree memo outlives it (the follow-up review: the return
+        #                                                  before the prune stranded them for the kernel's life)
         return
     _spend_guard_seed()                                  # once per kernel life: the ledger's verdicts
     rows = _alive_sessions(now, live_map) if sessions is None else sessions
@@ -37157,8 +37159,9 @@ def _spend_guard_tick(now, live_map, sessions=None, be=None, clients=None, price
 
 
 def _spend_tree_memo_size(m):
-    """A tree memo's weight, estimated from its path strings (the mtimes are a few dozen bytes beside each)."""
-    return sum(len(p) + 32 for p in m["files"]) + sum(len(d) + 32 for d in m["dirs"])
+    """A tree memo's weight: its path strings at about twice their character count (a str's header and the dict's
+    slot beside each; measured resident cost about 2x the characters), plus the mtime floats."""
+    return sum(2 * len(p) + 64 for p in m["files"]) + sum(2 * len(d) + 64 for d in m["dirs"])
 
 
 def _spend_tree_memo_prune(live_paths):
@@ -37171,8 +37174,12 @@ def _spend_tree_memo_prune(live_paths):
     total = sum(_spend_tree_memo_size(m) for m in _SPEND_TREE_CACHE.values())
     if total <= SPEND_GUARD_TREE_MEMO_BYTES:
         return
-    for k in sorted(_SPEND_TREE_CACHE, key=lambda k: _SPEND_TREE_CACHE[k]["seen"]):
-        if total <= SPEND_GUARD_TREE_MEMO_BYTES:
+    # over the bound every survivor is live and carries this tick's seen stamp, so an oldest-first order was insertion
+    # order and one eviction a cycle re-walked whole trees in rotation (the follow-up review): the LARGEST trees go
+    # first, down to three quarters of the bound, so the bound does not bind again next cycle
+    target = SPEND_GUARD_TREE_MEMO_BYTES * 3 // 4
+    for k in sorted(_SPEND_TREE_CACHE, key=lambda k: -_spend_tree_memo_size(_SPEND_TREE_CACHE[k])):
+        if total <= target:
             break
         total -= _spend_tree_memo_size(_SPEND_TREE_CACHE[k])
         _SPEND_TREE_CACHE.pop(k, None)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -510,6 +510,7 @@ class _PerfStats:
                           ("liftGate", _lift_gate_report), ("bgTops", _bg_tops_report),
                           ("intrMarks", _intr_marks_memo_report), ("statesOverlay", _states_overlay_report),
                           ("lanes", _lanes_memo_report),   # the timeline's per-lane segment memo, live lanes; the dead lanes beside
+                          ("spendTree", _spend_tree_memo_report),   # the spend guard's subagent-tree memos: bytes against their bound
                           # the chat build's fixed-cost memos (2026-09-09): the live merge's transcript-side
                           # sets, the fold's sealed postal cards, the ledger's goal-tree walk, the task fold
                           ("chatMergeSets", _merge_sets_report), ("chatPostal", _chat_postal_report),
@@ -36788,7 +36789,41 @@ SPEND_GUARD_TREE_RESCAN_S = 30      # a COLD agent file (idle since before the w
 #                                     not every cycle; a hot one every cycle
 _SPEND_TREE_CACHE = {}              # leaf -> {"dirs": {dir: mtime}, "files": {path: mtime}, "full": epoch of the last full
 #                                     stat pass, "seen": epoch}: the session's subagents tree, watched by directory mtimes
-SPEND_GUARD_TREE_MEMO_BYTES = 32 * 1024 * 1024   # the tree memos together (their path strings, estimated), least recently seen first
+
+
+def _mem_total_bytes():
+    """The machine's memory (MemTotal from /proc/meminfo; sysconf where there is no procfs), for the bounds that scale
+    with the box (the user's caches direction 2026-09-11: a memo's bound is a fraction of memory, never a small literal)."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError, AttributeError):
+        return 8 * 1024 ** 3
+
+
+def _spend_tree_memo_bound():
+    """The tree memos' byte bound: ROMP_SPEND_GUARD_TREE_MEMO_BYTES when it names a positive integer, else a sixty-fourth
+    of the machine's memory (128 MB on an 8 GB box, 2 GB on 128 GB). The memos are the LIVE sessions' path strings,
+    departed sessions dropped every tick, so the bound is a backstop against a runaway tree and not a working-set knob;
+    a literal of 32 MB bound across a day's live sessions and the prune re-listed a tree every cycle (the follow-up
+    review's second round). Read once at import; GET /perf reports it beside the memos' bytes (memos.spendTree)."""
+    raw = os.environ.get("ROMP_SPEND_GUARD_TREE_MEMO_BYTES", "")
+    try:
+        if raw and int(raw) > 0:
+            return int(raw)
+    except ValueError:
+        pass
+    return _mem_total_bytes() // 64
+
+
+SPEND_GUARD_TREE_MEMO_BYTES = _spend_tree_memo_bound()   # the tree memos together (their path strings, estimated); over
+#                                                          it the largest goes first, and only the deficit is shed
 
 
 def _spend_ceiling():
@@ -37167,8 +37202,8 @@ def _spend_tree_memo_size(m):
 def _spend_tree_memo_prune(live_paths):
     """The tree memos of sessions not in this tick's live set are dropped (a departed session's tree is nobody's
     window; bounded by entry count alone the memos of a day's two hundred sessions held tens of MB: the round-three
-    review's low a), and the rest are bounded by bytes, the least recently seen going first (a live session whose memo
-    goes is listed again on its next tick, one first listing)."""
+    review's low a), and the rest are bounded by bytes, the LARGEST going first (the fewest evictions; a live session
+    whose memo goes is listed again on its next tick, one first listing) and only the deficit shed."""
     for k in [k for k in _SPEND_TREE_CACHE if k not in live_paths]:
         _SPEND_TREE_CACHE.pop(k, None)
     total = sum(_spend_tree_memo_size(m) for m in _SPEND_TREE_CACHE.values())
@@ -37176,13 +37211,27 @@ def _spend_tree_memo_prune(live_paths):
         return
     # over the bound every survivor is live and carries this tick's seen stamp, so an oldest-first order was insertion
     # order and one eviction a cycle re-walked whole trees in rotation (the follow-up review): the LARGEST trees go
-    # first, down to three quarters of the bound, so the bound does not bind again next cycle
-    target = SPEND_GUARD_TREE_MEMO_BYTES * 3 // 4
+    # first, and only the deficit is shed (the second round: shedding to three quarters re-listed the largest tree
+    # every cycle once the bound bound across the live sessions). One tree alone over the bound is evicted and listed
+    # again next cycle, every cycle: the bound is the bound, and /perf's memos.spendTree shows it binding
     for k in sorted(_SPEND_TREE_CACHE, key=lambda k: -_spend_tree_memo_size(_SPEND_TREE_CACHE[k])):
-        if total <= target:
+        if total <= SPEND_GUARD_TREE_MEMO_BYTES:
             break
         total -= _spend_tree_memo_size(_SPEND_TREE_CACHE[k])
         _SPEND_TREE_CACHE.pop(k, None)
+
+
+def _spend_tree_memo_report():
+    """The tree memos' occupancy for GET /perf (memos.spendTree): entries, their estimated bytes and the bound they are
+    held under, so a bound that binds (bytes at the bound cycle after cycle) is visible. The pusher thread writes the
+    dict; a resize under the sum is read again."""
+    for _ in range(3):
+        try:
+            size = sum(_spend_tree_memo_size(m) for m in list(_SPEND_TREE_CACHE.values()))
+            break
+        except RuntimeError:
+            size = -1
+    return {"entries": len(_SPEND_TREE_CACHE), "bytes": size, "bound": SPEND_GUARD_TREE_MEMO_BYTES}
 
 
 def _spend_series(keyed_only=False, now=None):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36791,20 +36791,28 @@ _SPEND_TREE_CACHE = {}              # leaf -> {"dirs": {dir: mtime}, "files": {p
 #                                     stat pass, "seen": epoch}: the session's subagents tree, watched by directory mtimes
 
 
-def _mem_total_bytes():
+def _mem_total_bytes(meminfo="/proc/meminfo"):
     """The machine's memory (MemTotal from /proc/meminfo; sysconf where there is no procfs), for the bounds that scale
-    with the box (the user's caches direction 2026-09-11: a memo's bound is a fraction of memory, never a small literal)."""
+    with the box (the user's caches direction 2026-09-11: a memo's bound is a fraction of memory, never a small literal).
+    A masked /proc or a hardened container answers sysconf with 0 or -1 (its documented indeterminate answer), and a
+    bound of zero would drop every live memo each tick, the opposite of a memo, so anything not positive falls to an
+    8 GB default (the follow-up review's second round)."""
+    total = 0
     try:
-        with open("/proc/meminfo") as f:
+        with open(meminfo) as f:
             for line in f:
                 if line.startswith("MemTotal:"):
-                    return int(line.split()[1]) * 1024
+                    total = int(line.split()[1]) * 1024
+                    break
     except (OSError, ValueError, IndexError):
-        pass
-    try:
-        return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
-    except (OSError, ValueError, AttributeError):
-        return 8 * 1024 ** 3
+        total = 0
+    if total <= 0:
+        try:
+            pages, page = os.sysconf("SC_PHYS_PAGES"), os.sysconf("SC_PAGE_SIZE")
+            total = pages * page if pages > 0 and page > 0 else 0   # each factor on its own: two -1s multiply to 1
+        except (OSError, ValueError, AttributeError, TypeError):
+            total = 0
+    return total if total > 0 else 8 * 1024 ** 3
 
 
 def _spend_tree_memo_bound():
@@ -37213,7 +37221,9 @@ def _spend_tree_memo_prune(live_paths):
     # order and one eviction a cycle re-walked whole trees in rotation (the follow-up review): the LARGEST trees go
     # first, and only the deficit is shed (the second round: shedding to three quarters re-listed the largest tree
     # every cycle once the bound bound across the live sessions). One tree alone over the bound is evicted and listed
-    # again next cycle, every cycle: the bound is the bound, and /perf's memos.spendTree shows it binding
+    # again next cycle, every cycle, and when the SUM of the live memos binds the largest is re-listed each cycle the
+    # same way (one first listing a cycle, the price of a bound that binds): the bound is the bound, and /perf's
+    # memos.spendTree shows it binding
     for k in sorted(_SPEND_TREE_CACHE, key=lambda k: -_spend_tree_memo_size(_SPEND_TREE_CACHE[k])):
         if total <= SPEND_GUARD_TREE_MEMO_BYTES:
             break

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -122,8 +122,10 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
         self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
-                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes",
+                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes", "spendTree",
                                               "chatMergeSets", "chatPostal", "chatLedger", "chatFoldTasks"})   # the chat build's fixed-cost memos (2026-09-09)
+        self.assertEqual(set(snap["memos"]["spendTree"]), {"entries", "bytes", "bound"}, "the spend guard's tree memos against their bound")
+        self.assertEqual(snap["memos"]["spendTree"]["bound"], km.SPEND_GUARD_TREE_MEMO_BYTES)
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
                          "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
         for k, v in snap["memos"]["bgTops"].items():

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -247,9 +247,20 @@ class Memo(unittest.TestCase):
         self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(leaves))
         km._spend_tree_memo_prune(set(leaves[1:]))
         self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(leaves[1:]), "a session that left the live set loses its memo")
-        with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", km._spend_tree_memo_size(km._SPEND_TREE_CACHE[leaves[2]]) + 1):
+        # over the byte bound the LARGEST memo goes first, down to three quarters of the bound (the follow-up review: with
+        # every survivor seen this tick, oldest-first was insertion order and one eviction a cycle re-walked trees in
+        # rotation). leaves[1] gets an extra file so it is the largest; the bound sits just under the pair's size
+        extra = os.path.join(os.path.dirname(leaves[1]), "%08d-2222-3333-4444-000000000350" % 1, "subagents", "agent-b.jsonl")
+        write_jsonl(extra, [user(NOW - 100, "u")], mtime=NOW - 100)
+        km._SPEND_TREE_CACHE[leaves[1]]["files"][extra] = NOW - 100
+        sizes = {k: km._spend_tree_memo_size(km._SPEND_TREE_CACHE[k]) for k in leaves[1:]}
+        with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", sizes[leaves[1]] + sizes[leaves[2]] - 1):
             km._spend_tree_memo_prune(set(leaves[1:]))
-        self.assertEqual(sorted(km._SPEND_TREE_CACHE), [leaves[2]], "over the byte bound the least recently seen goes first")
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), [leaves[2]], "the largest memo went; the smaller one fits under three quarters of the bound")
+        self.assertGreaterEqual(km._spend_tree_memo_size({"files": {"x" * 10: 0}, "dirs": {}}), 2 * 10, "the estimate counts about twice the characters")
+        # a disabled ceiling drops every tree memo instead of stranding them
+        km._SPEND_TREE_CACHE["ghost"] = {"dirs": {}, "files": {}, "full": 0, "seen": 0}
+        self.assertIn("_SPEND_TREE_CACHE.clear()", inspect.getsource(km._spend_guard_tick).split("_spend_guard_seed()")[0], "cleared before the disabled-ceiling return")
         self.assertIn("_spend_tree_memo_prune(live_paths)", inspect.getsource(km._spend_guard_tick), "the tick prunes on every cycle")
 
 

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -261,16 +261,24 @@ class Memo(unittest.TestCase):
         with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", sizes[leaves[1]] + sizes[leaves[2]] - 1):
             km._spend_tree_memo_prune(set(leaves[1:]))
         self.assertEqual(sorted(km._SPEND_TREE_CACHE), [leaves[1]], "the largest memo went; the least recently seen survives")
-        # only the deficit is shed: three memos over the bound by one byte lose exactly the largest (three quarters of
-        # the bound would have taken a second)
+        # only the deficit is shed: FIVE memos over the bound by one byte lose exactly the largest (shedding to three
+        # quarters of the bound took a second: with three memos both policies evict one, so five tell them apart)
+        for i in (3, 4):
+            leaf = os.path.join(self.td.name, "proj", "%08d-2222-3333-4444-000000000350.jsonl" % i)
+            sub = os.path.join(os.path.dirname(leaf), "%08d-2222-3333-4444-000000000350" % i, "subagents")
+            os.makedirs(sub)
+            write_jsonl(leaf, [user(NOW - 100, "u")], mtime=NOW - 100)
+            write_jsonl(os.path.join(sub, "agent-a.jsonl"), [user(NOW - 100, "u")], mtime=NOW - 100)
+            leaves.append(leaf)
         km._SPEND_TREE_CACHE.clear()
-        for i in range(3):
+        for i in range(5):
             km._spend_window_files(leaves[i], NOW - 600, now=NOW + i)
         sizes = {k: km._spend_tree_memo_size(km._SPEND_TREE_CACHE[k]) for k in leaves}
         self.assertEqual(max(sizes, key=sizes.get), leaves[2])
         with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", sum(sizes.values()) - 1):
             km._spend_tree_memo_prune(set(leaves))
-        self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(leaves[:2]), "one eviction closed the deficit; the rest stand")
+        survivors = [k for k in leaves if k != leaves[2]]
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(survivors), "one eviction closed the deficit; the other four stand")
         self.assertEqual(km._spend_tree_memo_size({"files": {"x" * 10: 0}, "dirs": {}}), 2 * 10 + 64, "the estimate: twice the characters and a slot")
         # the bound is a sixty-fourth of the machine's memory unless the environment names one; /perf shows it beside the bytes
         self.assertEqual(km._spend_tree_memo_bound(), km._mem_total_bytes() // 64)
@@ -278,9 +286,16 @@ class Memo(unittest.TestCase):
             self.assertEqual(km._spend_tree_memo_bound(), 4096)
         with mock.patch.dict(os.environ, {"ROMP_SPEND_GUARD_TREE_MEMO_BYTES": "lots"}):
             self.assertEqual(km._spend_tree_memo_bound(), km._mem_total_bytes() // 64, "an unreadable override falls back to the fraction")
-        self.assertGreater(km.SPEND_GUARD_TREE_MEMO_BYTES, 16 * 1024 * 1024, "no small literal: above 16 MB on any box with a GB or more")
+        self.assertEqual(km.SPEND_GUARD_TREE_MEMO_BYTES, km._spend_tree_memo_bound(), "the module constant IS the fraction, no literal")
+        self.assertGreater(km.SPEND_GUARD_TREE_MEMO_BYTES, 16 * 1024 * 1024, "above 16 MB on any box with a GB or more")
+        # a masked /proc (a hardened container) answers sysconf with 0 or -1: the bound never reaches zero, which would
+        # drop every live memo each tick
+        self.assertEqual(km._mem_total_bytes(meminfo="/nonexistent/meminfo"), os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE"), "no procfs: sysconf")
+        for indeterminate in (0, -1):
+            with mock.patch.object(os, "sysconf", lambda name, _v=indeterminate: _v):
+                self.assertEqual(km._mem_total_bytes(meminfo="/nonexistent/meminfo"), 8 * 1024 ** 3, "sysconf %d: the 8 GB default" % indeterminate)
         rep = km._spend_tree_memo_report()
-        self.assertEqual((rep["entries"], rep["bytes"], rep["bound"]), (2, sizes[leaves[0]] + sizes[leaves[1]], km.SPEND_GUARD_TREE_MEMO_BYTES))
+        self.assertEqual((rep["entries"], rep["bytes"], rep["bound"]), (4, sum(sizes[k] for k in survivors), km.SPEND_GUARD_TREE_MEMO_BYTES))
         # a disabled ceiling drops every tree memo instead of stranding them: the tick itself, with the ceiling at zero
         km._SPEND_TREE_CACHE["ghost"] = {"dirs": {}, "files": {}, "full": 0, "seen": 0}
         with mock.patch.object(km, "_spend_ceiling", lambda: 0.0):

--- a/tests/test_spend_guard.py
+++ b/tests/test_spend_guard.py
@@ -250,17 +250,42 @@ class Memo(unittest.TestCase):
         # over the byte bound the LARGEST memo goes first, down to three quarters of the bound (the follow-up review: with
         # every survivor seen this tick, oldest-first was insertion order and one eviction a cycle re-walked trees in
         # rotation). leaves[1] gets an extra file so it is the largest; the bound sits just under the pair's size
-        extra = os.path.join(os.path.dirname(leaves[1]), "%08d-2222-3333-4444-000000000350" % 1, "subagents", "agent-b.jsonl")
+        # leaves[2], the most recently seen, gets an extra file so it is the largest: the old policy (least recently seen
+        # first) evicted leaves[1]; largest-first evicts leaves[2] and leaves[1] survives (the second round: the earlier
+        # assertion held under both policies)
+        extra = os.path.join(os.path.dirname(leaves[2]), "%08d-2222-3333-4444-000000000350" % 2, "subagents", "agent-b.jsonl")
         write_jsonl(extra, [user(NOW - 100, "u")], mtime=NOW - 100)
-        km._SPEND_TREE_CACHE[leaves[1]]["files"][extra] = NOW - 100
+        km._SPEND_TREE_CACHE[leaves[2]]["files"][extra] = NOW - 100
         sizes = {k: km._spend_tree_memo_size(km._SPEND_TREE_CACHE[k]) for k in leaves[1:]}
+        self.assertGreater(sizes[leaves[2]], sizes[leaves[1]])
         with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", sizes[leaves[1]] + sizes[leaves[2]] - 1):
             km._spend_tree_memo_prune(set(leaves[1:]))
-        self.assertEqual(sorted(km._SPEND_TREE_CACHE), [leaves[2]], "the largest memo went; the smaller one fits under three quarters of the bound")
-        self.assertGreaterEqual(km._spend_tree_memo_size({"files": {"x" * 10: 0}, "dirs": {}}), 2 * 10, "the estimate counts about twice the characters")
-        # a disabled ceiling drops every tree memo instead of stranding them
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), [leaves[1]], "the largest memo went; the least recently seen survives")
+        # only the deficit is shed: three memos over the bound by one byte lose exactly the largest (three quarters of
+        # the bound would have taken a second)
+        km._SPEND_TREE_CACHE.clear()
+        for i in range(3):
+            km._spend_window_files(leaves[i], NOW - 600, now=NOW + i)
+        sizes = {k: km._spend_tree_memo_size(km._SPEND_TREE_CACHE[k]) for k in leaves}
+        self.assertEqual(max(sizes, key=sizes.get), leaves[2])
+        with mock.patch.object(km, "SPEND_GUARD_TREE_MEMO_BYTES", sum(sizes.values()) - 1):
+            km._spend_tree_memo_prune(set(leaves))
+        self.assertEqual(sorted(km._SPEND_TREE_CACHE), sorted(leaves[:2]), "one eviction closed the deficit; the rest stand")
+        self.assertEqual(km._spend_tree_memo_size({"files": {"x" * 10: 0}, "dirs": {}}), 2 * 10 + 64, "the estimate: twice the characters and a slot")
+        # the bound is a sixty-fourth of the machine's memory unless the environment names one; /perf shows it beside the bytes
+        self.assertEqual(km._spend_tree_memo_bound(), km._mem_total_bytes() // 64)
+        with mock.patch.dict(os.environ, {"ROMP_SPEND_GUARD_TREE_MEMO_BYTES": "4096"}):
+            self.assertEqual(km._spend_tree_memo_bound(), 4096)
+        with mock.patch.dict(os.environ, {"ROMP_SPEND_GUARD_TREE_MEMO_BYTES": "lots"}):
+            self.assertEqual(km._spend_tree_memo_bound(), km._mem_total_bytes() // 64, "an unreadable override falls back to the fraction")
+        self.assertGreater(km.SPEND_GUARD_TREE_MEMO_BYTES, 16 * 1024 * 1024, "no small literal: above 16 MB on any box with a GB or more")
+        rep = km._spend_tree_memo_report()
+        self.assertEqual((rep["entries"], rep["bytes"], rep["bound"]), (2, sizes[leaves[0]] + sizes[leaves[1]], km.SPEND_GUARD_TREE_MEMO_BYTES))
+        # a disabled ceiling drops every tree memo instead of stranding them: the tick itself, with the ceiling at zero
         km._SPEND_TREE_CACHE["ghost"] = {"dirs": {}, "files": {}, "full": 0, "seen": 0}
-        self.assertIn("_SPEND_TREE_CACHE.clear()", inspect.getsource(km._spend_guard_tick).split("_spend_guard_seed()")[0], "cleared before the disabled-ceiling return")
+        with mock.patch.object(km, "_spend_ceiling", lambda: 0.0):
+            km._spend_guard_tick(NOW, {})
+        self.assertEqual(km._SPEND_TREE_CACHE, {}, "the tick under a disabled ceiling cleared every memo, the ghost included")
         self.assertIn("_spend_tree_memo_prune(live_paths)", inspect.getsource(km._spend_guard_tick), "the tick prunes on every cycle")
 
 


### PR DESCRIPTION
Three follow-ups from the verifier's reading of the spend guard's first follow-up (pull request 1460), none blocking there; for whenever.

**The tree memo's byte bound evicts the largest memos first, down to three quarters of the bound.** After the live prune every survivor is live and carries the tick's seen stamp, so the oldest-first order was insertion order and one eviction a cycle re-listed whole trees in rotation. The largest go first and only the deficit is shed (the second round below).

**A disabled ceiling clears the tree memos** instead of returning before the prune and stranding them for the kernel's life.

**The size estimate counts about twice the characters**, closer to the strings' resident cost.

**Tests** (`tests/test_spend_guard.py`): the largest memo evicted first under a bound just below two memos' size, the estimate's factor, and the clear pinned before the disabled-ceiling return.

**Second round of the review.** The memo bound is a sixty-fourth of the machine's memory (`_mem_total_bytes`, MemTotal from `/proc/meminfo`), `ROMP_SPEND_GUARD_TREE_MEMO_BYTES` overriding it, never a small literal: the memos are the live sessions' path strings, so the bound is a backstop against a runaway tree, and a 32 MB literal bound across a day's live sessions. The prune sheds the deficit only, largest first (the fewest evictions); shedding to three quarters re-listed the largest tree every cycle once the bound bound. One tree alone over the bound is evicted and listed again each cycle, said in the comment. GET /perf reports the memos' entries, bytes and bound under `memos.spendTree`. The constant's comment and the prune's docstring say largest first. Tests: the order test makes the most recently seen memo the largest and asserts the least recently seen survives (the memo the old policy evicted); the deficit-only prune (three memos over by one byte lose exactly the largest); the estimate's exact figure; the bound's fraction, the override and an unreadable override; the /perf field's shape and its bound; the disabled ceiling exercised through the tick itself with the ceiling at zero, the cache asserted empty.

**Third round of the review.** The memory read floors its answer: a masked `/proc` or a hardened container answers sysconf with 0 or -1 (its documented indeterminate answer), and a bound of zero would have dropped every live memo each tick, so anything not positive falls to an 8 GB default. The deficit-only test uses five memos, which tell the two policies apart (shedding to three quarters evicts two of five, the deficit one). The module constant is pinned equal to the fraction function, so no literal can stand in for it. The prune's comment names the sum-binding case beside the single oversized tree: when the live memos together bind, the largest is re-listed each cycle, one first listing a cycle. Tests: sysconf forced to 0 and to -1 with no procfs file, the five-memo prune, the constant's pin.

Tier: fix
