### PR TITLE
A successful converge clears the crash hold on every road (T352 follow-up 2)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7896,6 +7896,7 @@ def _main_drift_check():
                     return
             _LAST_AUTO_CONVERGE[0] = time.time()
             _run_main_update(kind, target=target)
+            _CONVERGE_CRASH_T[0] = 0.0                    # a converge that ran clears the crash hold (the follow-up review)
         except Exception:
             # a crash in the hold branches (the T352 round-two review: a None running sha inside the cool-down raised
             # at a [:8] AFTER the latch above took the target, and the hold's own reset never ran, so every later
@@ -8013,6 +8014,9 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
         #                            sha — two reads raced a moving checkout and latched a target
         #                            the verdict never examined (T216 review)
         if not _kernel_code_changed(_kernel_sha(reask=True), pulled) and _in_place_converge(pulled):
+            _CONVERGE_CRASH_T[0] = 0.0                    # an in-place converge is a success too: the crash hold clears
+            #                                               (the follow-up review: a stale stamp held a later converge
+            #                                               for up to a cool-down after a success that bypassed the gate)
             return
     # Pay the bundle rebuild BEFORE the old kernel dies (T216): the checkout is already at the
     # target here, so this builds the NEW code's bundles while the old kernel still serves — the

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7808,6 +7808,9 @@ def _main_drift_check():
         # is ADVISORY here (audit + the bus arm): the skip VERDICT itself came from
         # _kernel_code_changed, which fails toward restarting on any error.
         if _in_place_converge(target):
+            _CONVERGE_CRASH_T[0] = 0.0                # a converge that ran and succeeded clears the crash hold on this
+            #                                           road too (the follow-up review's second round: it returned with
+            #                                           the stamp standing, and a later converge waited out a cool-down)
             return
     if not kind:
         _MAIN_DRIFT[0] = _MAIN_DRIFT[1] = ""          # in sync: a future drift is new information again
@@ -7895,8 +7898,10 @@ def _main_drift_check():
                     _MAIN_DRIFT[slot] = ""
                     return
             _LAST_AUTO_CONVERGE[0] = time.time()
-            _run_main_update(kind, target=target)
-            _CONVERGE_CRASH_T[0] = 0.0                    # a converge that ran clears the crash hold (the follow-up review)
+            if _run_main_update(kind, target=target):
+                _CONVERGE_CRASH_T[0] = 0.0                # a converge that ran and SUCCEEDED clears the crash hold (the
+                #                                           follow-up review; its second round: a refusal returned too, and
+                #                                           a clear keyed on the return alone cleared on a refused pull)
         except Exception:
             # a crash in the hold branches (the T352 round-two review: a None running sha inside the cool-down raised
             # at a [:8] AFTER the latch above took the target, and the hold's own reset never ran, so every later
@@ -7937,7 +7942,10 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
     Every step reads its own exit code: a failing `git status` is UNKNOWN, never clean (a tree that
     cannot be read is not a tree that may be moved), and a failed fetch aborts instead of checking
     out whatever the stale local ref points at. Every refusal is said on the sync surface
-    (_sync_notice, ok=False — the row every updater failure already lands on) and re-arms the notice."""
+    (_sync_notice, ok=False — the row every updater failure already lands on) and re-arms the notice.
+    Returns True when a converge ran and succeeded (the in-place rebuild, or the restart requested of the
+    manager) and False on every refusal, so the caller's crash-hold clear keys on the outcome and not on the
+    return (the follow-up review's second round)."""
     if kind == "pull":
         remote = _release_remote()
         target = _sha8(target)
@@ -7954,35 +7962,35 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
             if not target:
                 refuse("the checkout was left alone: no commit was named for the move. Update again "
                        "once the next check has read main")
-                return
+                return False
             st = subprocess.run(["git", "status", "--porcelain"], cwd=str(ROOT),
                                 capture_output=True, text=True, timeout=10)
             if st.returncode != 0:
                 refuse("the checkout was left alone: its state could not be read, so it was not "
                        "assumed clean", st)
-                return
+                return False
             if st.stdout.strip():
                 refuse("the romp checkout has uncommitted work, so it was left alone. Commit or "
                        "stash it, then Update again")
-                return
+                return False
             f = subprocess.run(["git", "fetch", remote, "main"], cwd=str(ROOT),
                                capture_output=True, text=True, timeout=60)
             if f.returncode != 0:
                 refuse("the checkout was left alone: the fetch failed", f)
-                return
+                return False
             anc = subprocess.run(["git", "merge-base", "--is-ancestor", "HEAD", target], cwd=str(ROOT),
                                  capture_output=True, text=True, timeout=10)
             if anc.returncode == 1:
                 # a real non-ancestor: the histories diverged — never merged on the user's behalf
                 refuse("the checkout was left alone: %s is not a fast-forward of it — the histories "
                        "diverged, which is yours to move by hand" % target)
-                return
+                return False
             if anc.returncode != 0:
                 # git could not even name it (128): the fetch did not bring the advertised commit
                 # (main was rewound), or the short prefix is ambiguous — the next check re-reads main
                 refuse("the checkout was left alone: the fetch did not bring %s, so it could not be "
                        "verified; the next check re-reads main" % target, anc)
-                return
+                return False
             # The local `main` BRANCH moves too (the user 2026-09-08): the converge used to check the
             # target out DETACHED and never touch `main`, so a later `git checkout main` landed on a
             # months-old pointer and the user pulled "an enormous amount". When main is an ANCESTOR of the
@@ -8001,14 +8009,14 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
                                    capture_output=True, text=True, timeout=30)
             if r.returncode != 0:
                 refuse("the checkout did not advance onto %s" % target, r)
-                return
+                return False
             if mb.returncode == 1:
                 _sync_notice("main moved at %s: the checkout is at %s, detached. Your local main branch has "
                              "commits that are not on %s/main, so it was left where it is; merge or rebase it "
                              "yourself when you want it on the new main." % (remote, target, remote), ok=True)
         except Exception as e:
             refuse("the pull step failed: %s" % e)
-            return
+            return False
     if kind == "pull":
         pulled = _checkout_sha()   # ONE read: verdict input and converge target must be the same
         #                            sha — two reads raced a moving checkout and latched a target
@@ -8017,7 +8025,7 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
             _CONVERGE_CRASH_T[0] = 0.0                    # an in-place converge is a success too: the crash hold clears
             #                                               (the follow-up review: a stale stamp held a later converge
             #                                               for up to a cool-down after a success that bypassed the gate)
-            return
+            return True
     # Pay the bundle rebuild BEFORE the old kernel dies (T216): the checkout is already at the
     # target here, so this builds the NEW code's bundles while the old kernel still serves — the
     # fresh kernel's pre-bind _ensure_bundles then finds them current instead of paying esbuild
@@ -8049,6 +8057,8 @@ def _run_main_update(kind, immediate=True, manager_port=_PORT_FROM_ENV, target="
     except Exception as e:
         _sync_notice("romp is updated on disk but the restart request failed (%s) — "
                      "restart it yourself: romp refresh" % e, ok=False)
+        return False
+    return True
 
 
 def _update_check_loop():

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -534,7 +534,8 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
         import io
         self.saved = (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha, km._run_main_update,
                       km._deploy_would_cut, km._parked_quiet_deploy, km._kernel_code_changed,
-                      km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._QUIET_PARKED_LOGGED[0])
+                      km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._QUIET_PARKED_LOGGED[0],
+                      km._CONVERGE_CRASH_T[0])
         self.ran = []
         km._update_mode = lambda: "auto"
         km._checkout_sha = lambda: "aaa"
@@ -552,7 +553,8 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
     def tearDown(self):
         (km._update_mode, km._origin_main_sha, km._checkout_sha, km._kernel_sha, km._run_main_update,
          km._deploy_would_cut, km._parked_quiet_deploy, km._kernel_code_changed) = self.saved[:8]
-        km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._QUIET_PARKED_LOGGED[0] = self.saved[8:]
+        (km._LAST_AUTO_CONVERGE[0], km._MAIN_DRIFT[0], km._MAIN_DRIFT[1], km._QUIET_PARKED_LOGGED[0],
+         km._CONVERGE_CRASH_T[0]) = self.saved[8:]     # the crash stamp restored too (the follow-up review)
         if km.RESTART_CUTS_FILE.exists():
             km.RESTART_CUTS_FILE.unlink()
 
@@ -698,6 +700,16 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
         km._CONVERGE_CRASH_T[0] = time.time() - km._CONVERGE_COOLDOWN_S - 1
         self._pass()
         self.assertEqual(self.ran, ["pull"], "the cool-down over, the retry converges")
+        self.assertEqual(km._CONVERGE_CRASH_T[0], 0.0, "a converge that ran clears the crash hold (the follow-up review)")
+
+    def test_an_in_place_converge_clears_the_crash_hold_too(self):
+        # the follow-up review: a success that bypassed the gate (an in-place converge from the restart leg or /update)
+        # left the stamp, and a later converge waited out a cool-down it had no reason to
+        import inspect
+        src = inspect.getsource(self.saved[4])           # the REAL _run_main_update (setUp stubs km's)
+        i = src.index("_in_place_converge(pulled):")
+        self.assertIn("_CONVERGE_CRASH_T[0] = 0.0", src[i:i + 400], "cleared on the in-place road before its return")
+        self.assertLess(src.index("_CONVERGE_CRASH_T[0] = 0.0", i), src.index("return", i + 30))
 
     def test_the_converge_leg_asks_git_again_for_the_running_sha_within_the_miss_bound(self):
         # the round-three review's low b: the 30 s miss memo made the leg's own read (in _run_main_update) return None

--- a/tests/test_main_drift_notice.py
+++ b/tests/test_main_drift_notice.py
@@ -541,7 +541,7 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
         km._checkout_sha = lambda: "aaa"
         km._kernel_sha = lambda: "aaa"
         km._origin_main_sha = lambda: "bbb"
-        km._run_main_update = lambda kind, immediate=False, target="": self.ran.append(kind)
+        km._run_main_update = lambda kind, immediate=False, target="": (self.ran.append(kind), True)[1]   # ran and succeeded
         km._parked_quiet_deploy = lambda checkout, now=None: 0
         km._kernel_code_changed = lambda running, target: True
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
@@ -702,6 +702,21 @@ class ConvergeWaitsSpareOnlyCuts(unittest.TestCase):
         self.assertEqual(self.ran, ["pull"], "the cool-down over, the retry converges")
         self.assertEqual(km._CONVERGE_CRASH_T[0], 0.0, "a converge that ran clears the crash hold (the follow-up review)")
 
+    def test_a_refused_converge_leaves_the_crash_stamp_standing(self):
+        # the second round of the follow-up review: the clear keyed on _run_main_update having RETURNED, and every
+        # refusal returns too. The stamp pre-loaded is an EXPIRED one (a live one holds the pass at the cool-down gate
+        # above, before the leg runs), so the road reaches the leg and the no-op is what is pinned
+        stamp = time.time() - km._CONVERGE_COOLDOWN_S - 1
+        km._CONVERGE_CRASH_T[0] = stamp
+        km._run_main_update = lambda kind, immediate=False, target="": (self.ran.append(kind), False)[1]   # a refusal
+        self._pass()
+        self.assertEqual(self.ran, ["pull"], "the leg ran")
+        self.assertEqual(km._CONVERGE_CRASH_T[0], stamp, "a refusal is no converge that succeeded: the stamp stands")
+        self.ran.clear(); km._MAIN_DRIFT[0] = ""; km._LAST_AUTO_CONVERGE[0] = 0.0   # the cool-down the first pass stamped
+        km._run_main_update = lambda kind, immediate=False, target="": (self.ran.append(kind), True)[1]
+        self._pass()
+        self.assertEqual((self.ran, km._CONVERGE_CRASH_T[0]), (["pull"], 0.0), "a converge that succeeded clears it")
+
     def test_an_in_place_converge_clears_the_crash_hold_too(self):
         # the follow-up review: a success that bypassed the gate (an in-place converge from the restart leg or /update)
         # left the stamp, and a later converge waited out a cool-down it had no reason to
@@ -798,6 +813,7 @@ class UiOnlyConverge(unittest.TestCase):
         km._update_mode = lambda: "ask"
         km._kernel_sha = lambda: "cur-sha"
         km._main_tracking = lambda: True   # these tests exercise POST-gate behavior; the gate has its own
+        self._stamp = km._CONVERGE_CRASH_T[0]
 
     def tearDown(self):
         for n, f in self._saved.items():
@@ -805,6 +821,21 @@ class UiOnlyConverge(unittest.TestCase):
         km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
         km._REBUILT_FOR[0] = ""
         km._INPLACE_TRIED[0] = ""
+        km._CONVERGE_CRASH_T[0] = self._stamp
+
+    def test_the_restart_legs_in_place_converge_clears_the_crash_hold_and_a_failed_build_does_not(self):
+        # the follow-up review's second round: this road returned on success with the stamp standing
+        km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-ui")
+        km._kernel_code_changed = lambda a, b: False
+        km._rebuild_dist = lambda: (False, "esbuild boom")
+        km._CONVERGE_CRASH_T[0] = expired = time.time() - km._CONVERGE_COOLDOWN_S - 1
+        km._main_drift_check()
+        self.assertEqual(km._CONVERGE_CRASH_T[0], expired, "a failed build converged nothing: the stamp stands")
+        km._REBUILT_FOR[0] = ""; km._INPLACE_TRIED[0] = ""; km._MAIN_DRIFT[0] = km._MAIN_DRIFT[1] = ""
+        km._rebuild_dist = lambda: (self.rebuilds.append(1), (True, ""))[1]
+        km._main_drift_check()
+        self.assertEqual((len(self.rebuilds), km._REBUILT_FOR[0]), (1, "tgt-ui"))
+        self.assertEqual(km._CONVERGE_CRASH_T[0], 0.0, "the in-place converge from the restart leg clears the crash hold")
 
     def test_ui_only_restart_drift_rebuilds_in_place_and_latches(self):
         km._main_drift_verdict = lambda o, c, k: ("restart", "tgt-ui")
@@ -1045,11 +1076,19 @@ class ConvergePullStep(unittest.TestCase):
              mock.patch.object(urllib.request, "urlopen",
                                side_effect=AssertionError("the restart POST must not ride urllib")), \
              mock.patch.dict(km.os.environ, env):
-            km._run_main_update("pull", immediate=True, manager_port="1", target=target)
+            self.result = km._run_main_update("pull", immediate=True, manager_port="1", target=target)
         return [s for s, _ in self.calls if s != "other"]
 
     def _refusals(self):
         return [m for m, ok in self.notices if not ok]
+
+    def test_the_return_says_whether_a_converge_ran_and_succeeded(self):
+        # the follow-up review's second round: the drift check's crash-hold clear keys on this
+        self._drive()
+        self.assertIs(self.result, True, "the checkout moved and the restart was requested")
+        self._drive(target="")
+        self.assertIs(self.result, False, "a refusal (no commit named) is not a converge")
+        self.assertTrue(self._refusals(), "and it was said")
 
     def test_the_happy_path_moves_onto_the_advertised_commit_and_restarts(self):
         steps = self._drive()


### PR DESCRIPTION
Two follow-ups from the verifier's reading of the converge's first follow-up (pull request 1461), none blocking there; for whenever.

**A successful converge clears the crash hold.** The hold was stamped by a crash in the converge leg and nothing cleared it on a success that bypassed the gate (an in-place converge from the restart leg or `/update`), so a stale stamp could hold a later converge for up to a cool-down. It clears after a converge that ran and on the in-place road before its return.

**The drift tests restore the crash stamp** in their teardown, with the other saved state.

**Tests** (`tests/test_main_drift_notice.py`): the retry converging clears the stamp; the in-place road's clear pinned before its return; the stamp in the saved tuple.

**Second round of the review.** The restart leg's in-place converge (a drift that touches nothing the running process executes, converged by a rebuild in place) returned on success with the crash stamp standing; it clears the stamp before its return. `_run_main_update` returns True when a converge ran and succeeded (the in-place rebuild, or the restart requested of the manager) and False on every refusal, and the drift check's clear keys on that return: a refused pull (a dirty tree, a failed fetch, no commit named) leaves the stamp as it was. Tests: the restart leg's in-place converge clears an expired stamp and a failed build leaves it; a refusal through the gate leaves an expired stamp standing and a success then clears it; the real function's return on the happy path and on a refusal.

Tier: fix
