### PR TITLE
Three memory ceilings sized to the machine: the assembly index's atom cap, the hydrated-body memo, the fold checkpoint state cap

### DIFF
--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -782,7 +782,34 @@ def _say_once(line):
         pass
 
 
-_CKPT_FOLD_CAP = 64 * 1024        # bytes of encoded state a fold may put in a checkpoint. A state that grows with its file (the postal
+def _machine_memory_bytes(meminfo_text=None):
+    """MemTotal from /proc/meminfo (or the text given) in bytes; 0 when unreadable (macOS, a container without procfs).
+    The ceilings below are fractions of it (the user's direction, 2026-09-11: romp uses the machine's memory; every cache
+    is one shared pool sized to the machine, never a small literal that sits below the working set and thrashes)."""
+    try:
+        text = meminfo_text if meminfo_text is not None else open("/proc/meminfo", encoding="utf-8").read()
+        for line in text.splitlines():
+            if line.startswith("MemTotal:"):
+                return int(line.split()[1]) * 1024
+    except Exception:
+        pass
+    return 0
+
+
+def _env_or(name, default, scale=1):
+    """An integer knob from the environment (scaled), else the derived default."""
+    try:
+        v = os.environ.get(name)
+        return int(float(v) * scale) if v else default
+    except (TypeError, ValueError):
+        return default
+
+
+# 8 MiB, was 64 KB (2026-09-11, the day the checkpoints shipped): 31 leaves' bgAll states sat over 64 KB and every boot
+# cold-refolded them whole, 1.74 GB read in the first pusher cycle (65 s of tick jobs); a document of a few MB reads in
+# milliseconds. ROMP_CKPT_FOLD_CAP_KB sets it outright.
+_CKPT_FOLD_CAP = _env_or("ROMP_CKPT_FOLD_CAP_KB", 8 * 1024 * 1024, 1024)
+#                                   bytes of encoded state a fold may put in a checkpoint. A state that grows with its file (the postal
 #                                   log fold's map of every sent row, the state intervals' list of every transition, the every-task
 #                                   background view on a long transcript) would make the document a second copy of the file: reading
 #                                   it at boot costs what the checkpoint exists to save (measured 2026-09-11: 11 MB of documents in a
@@ -4050,7 +4077,11 @@ def _asm_fold(entry, delta, leaf_recs, leaf_key, leaf_stem, rompuuid, postal_ind
 # the next settle writes a new document with the new cut.
 _ASM_CKPT_V = 4                       # 2: atom rows carry [offset, len], nt for every atom; 3: the carry holds skill_loads (T333);
 #                                       4: a `turns` section over the pre-cut rows (T323 stage 4c: the lazy index)
-_MAT_CAP = 20000                      # materialized pre-cut atoms resident across every session (the lazy index's LRU)
+# Materialized pre-cut atoms resident across every session (the lazy index's LRU): MemTotal / 32 KiB, never under 500,000
+# (3.9 million on a 118 GiB machine); ROMP_ASM_INDEX_CAP sets it outright. At 20,000 (2026-09-11, the day the index
+# shipped) 50 sessions' 4,080 restored turns materialized 1.2 million atoms and evicted 1.19 million of them in 150 s,
+# every chat build cold at 5.6 s: a ceiling under the working set is a thrash, not a saving.
+_MAT_CAP = _env_or("ROMP_ASM_INDEX_CAP", max(500_000, _machine_memory_bytes() // (32 * 1024)))
 _MAT_LRU = collections.OrderedDict()  # (id(LazyAtoms), row) → (LazyAtoms, row): eviction drops the memo, never a field in place
 _MAT_LOCK = threading.Lock()
 _ASM_INDEX_STATS = {"materialized": 0, "materializedBy": {}, "resident": 0, "evictions": 0, "restoredTurns": 0, "rowDecodes": 0}
@@ -4340,7 +4371,9 @@ _ASM_CKPT_SAID = set()             # (path, reason) said once per process
 _LAZY_FILES = {}                   # rompuuid -> {fsid: path}: where hydrate finds a lazy atom's record
 _HYDRATED = {}                     # uuid -> the body fields read; dict order = LRU
 _HYDRATED_BYTES = [0]
-_HYDRATED_CAP = 64 * 1024 * 1024   # the hydrated-body memo's byte cap (a judge pass re-reading one large body every cycle
+_HYDRATED_CAP = _env_or("ROMP_HYDRATED_CAP_MB", max(1024 ** 3, _machine_memory_bytes() // 32), 1024 * 1024)
+#                                    the hydrated-body memo's byte cap: MemTotal / 32, never under 1 GiB (3.7 GiB on a 118 GiB
+#                                    machine; 64 MB hydrated 3.1 GB of bodies in 150 s on 2026-09-11) (a judge pass re-reading one large body every cycle
 #                                    shows in hydratedBytes; the memo keeps the common case at one read)
 _LAZY_KINDS = ("a", "u", "c", "o", "k", "b")   # atom kinds whose message is lazy; boundary and refusal atoms carry no message
 

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -15,6 +15,7 @@ import pickle
 import re
 import sys
 import unittest
+from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 import test_asm_checkpoint as T                                   # noqa: E402  the stage 4a harness, its event model
 from test_asm_checkpoint_served import transcript                 # noqa: E402  the served fixture's builder: many turns, compacting
@@ -370,6 +371,34 @@ class AuditGuard(unittest.TestCase):
                    'entry["atoms"] = entry["atoms"] + new_atoms')                    # the assembly entry's TAIL atoms: a plain list
         bad = [b for b in bad if not (b.startswith("event_model.py") and any(x in b for x in allowed))]
         self.assertEqual(bad, [], "a reader that would copy a turn's storage or dump a tree: %s" % bad)
+
+
+class CapsSizedToTheMachine(unittest.TestCase):
+    """2026-09-11: the index's 20,000-atom literal evicted 1.19 million atoms in 150 s on a 50-session devbox, the 64 MB body memo
+    hydrated 3.1 GB, and the 64 KB fold-state cap cold-refolded 31 leaves (1.74 GB) at every boot. The user's direction: caches are
+    one shared pool sized to the machine, never a small literal."""
+
+    def test_the_index_cap_is_a_fraction_of_the_machine_with_a_floor(self):
+        text = "MemTotal:       123634396 kB\n"
+        self.assertEqual(em._machine_memory_bytes(text), 123634396 * 1024)
+        self.assertEqual(em._machine_memory_bytes("garbage"), 0, "unreadable: zero, so the floors apply")
+        self.assertGreaterEqual(em._MAT_CAP, 500_000)
+        self.assertGreaterEqual(em._HYDRATED_CAP, 1024 ** 3)
+        self.assertEqual(em._CKPT_FOLD_CAP, 8 * 1024 * 1024)
+
+    def test_the_environment_sets_each_cap_outright(self):
+        with mock.patch.dict(os.environ, {"ROMP_ASM_INDEX_CAP": "777", "ROMP_HYDRATED_CAP_MB": "3", "ROMP_CKPT_FOLD_CAP_KB": "2"}):
+            self.assertEqual(em._env_or("ROMP_ASM_INDEX_CAP", 1), 777)
+            self.assertEqual(em._env_or("ROMP_HYDRATED_CAP_MB", 1, 1024 * 1024), 3 * 1024 * 1024)
+            self.assertEqual(em._env_or("ROMP_CKPT_FOLD_CAP_KB", 1, 1024), 2048)
+        with mock.patch.dict(os.environ, {"ROMP_ASM_INDEX_CAP": "junk"}):
+            self.assertEqual(em._env_or("ROMP_ASM_INDEX_CAP", 5), 5, "a bad value: the derived default")
+
+    def test_the_caps_are_derived_in_source_not_literals(self):
+        src = open(em.__file__).read()
+        self.assertIn('_MAT_CAP = _env_or("ROMP_ASM_INDEX_CAP", max(500_000, _machine_memory_bytes() // (32 * 1024)))', src)
+        self.assertIn('_HYDRATED_CAP = _env_or("ROMP_HYDRATED_CAP_MB", max(1024 ** 3, _machine_memory_bytes() // 32), 1024 * 1024)', src)
+        self.assertIn('_CKPT_FOLD_CAP = _env_or("ROMP_CKPT_FOLD_CAP_KB", 8 * 1024 * 1024, 1024)', src)
 
 
 if __name__ == "__main__":

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -364,6 +364,9 @@ class GenericFold(Base):
         state past the cap is left out, counted per name; its CURSOR stays, so the next process starts that fold cold at the
         cut and steps the tail only (counted under coldFolds, said once) instead of reading the file whole at every restart;
         the bounded folds beside it restore whole."""
+        saved_cap = em._CKPT_FOLD_CAP                                  # the cap is sized to the machine now (8 MiB); this test's
+        em._CKPT_FOLD_CAP = 64 * 1024                                  # oversize state is 170 KB, so pin the cap it was written for
+        self.addCleanup(setattr, em, "_CKPT_FOLD_CAP", saved_cap)
         _write(self.p, [{"n": i, "pad": "x" * 400} for i in range(400)])           # ~170 KB of records
         big = {}
         self.fold()                                                               # "t": a list of 400 ints, small


### PR DESCRIPTION
Three ceilings sized to the machine, replacing small literals that sat below the working set and thrashed (the user's direction of 2026-09-11: romp uses the machine's memory; every cache is one shared pool sized as a fraction of MemTotal).

Measured on the kernel booted 3:22 PM Pacific, 150 s into its life, 50 sessions: the lazy assembly index's 20,000-atom cap materialized 1.21 million atoms and evicted 1.19 million (every chat build cold at 5.6 s, sessions took minutes to open); the 64 MB hydrated-body memo re-hydrated 3.1 GB; the 64 KB fold-state cap cold-refolded 31 leaves (1.74 GB) at every boot.

- `_MAT_CAP`: MemTotal / 32 KiB, floor 500,000 (`ROMP_ASM_INDEX_CAP`)
- `_HYDRATED_CAP`: MemTotal / 32, floor 1 GiB (`ROMP_HYDRATED_CAP_MB`)
- `_CKPT_FOLD_CAP`: 8 MiB (`ROMP_CKPT_FOLD_CAP_KB`)

The index's eviction rule and `/perf` `asmIndex.cap` are unchanged; the stage owner agreed to the raise and takes the proper follow-up (judge walkers reading pre-turn scalars) in their next stage. Tests in `tests/test_asm_index.py`; each cap fails its test when put back to the literal.

Tier: fix
