### PR TITLE
An orphan replay from another epoch or under an unnamed seed folds nothing; a frame without an offset is live (T354 follow-up)

### DIFF
--- a/kernel/host_transport.py
+++ b/kernel/host_transport.py
@@ -394,10 +394,11 @@ class HostTransport(_Base):
         try:
             off = int(offset)
         except (TypeError, ValueError):
-            off = -1
+            off = None                                    # a frame with no offset (no host writes one; a protocol change)
         if replay is None:
-            replay = self.replay_end is not None and off < self.replay_end
-        self.result_tags.append({"offset": off, "replay": bool(replay)})
+            replay = off is not None and self.replay_end is not None and off < self.replay_end   # unknown position: live,
+            #                                                                                       never a replay that folds nothing
+        self.result_tags.append({"offset": off if off is not None else -1, "replay": bool(replay)})
 
     def _answers_mine(self, data) -> bool:
         if not isinstance(data, dict) or data.get("type") != "control_response":

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -6883,6 +6883,7 @@ class SdkSession:
         self._last_usage_totals = {}  # and its cumulative token counters
         self._spend_first_result = True
         self._spend_baseline = "fresh"
+        self._spend_seed_session = ""
         self._replay_cli = ""         # a dead CLI's replay is over once a connect seeds
         if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:
             # a host ATTACH (T315), and only with the host transport in hand (the flag alone is not trusted, M1 of
@@ -6927,6 +6928,7 @@ class SdkSession:
         self._last_usage_totals = {}
         self._spend_first_result = True
         self._spend_baseline = "attach-pending"
+        self._spend_seed_session = ""
         self._replay_cli = str(cli or "")
         self._seed_from_reg_cost_state(cli=cli, dead=True)
 
@@ -6947,6 +6949,7 @@ class SdkSession:
             self._last_usage_totals = {k: int(v) for k, v in toks.items() if isinstance(v, (int, float))}
             self._spend_baseline = "seeded"
             self._spend_unknown_open = False
+            self._spend_seed_session = str(cs.get("session") or "")   # the epoch the watermark's totals belong to
             self.backend._log("spend: %s %s (%s): watermarks seeded at the registry's "
                               "cumulative $%.2f so the first result records only this turn" % (self.name, how, cli, cs["total"]),
                               problem=False)
@@ -6975,7 +6978,7 @@ class SdkSession:
         except (IndexError, AttributeError):
             return None
 
-    def _spend_redelivered(self, tag, total) -> bool:
+    def _spend_redelivered(self, tag, total, session_id="") -> bool:
         """Is this result one an earlier kernel already folded? From the record's own journal position (round four of
         1450's review): a replayed record (its offset before the journal's next at the attach) folds nothing, moves no
         watermark and marks its row, WHATEVER its total, since the kernel that died folded what it saw and the ack it
@@ -6990,6 +6993,16 @@ class SdkSession:
         t = getattr(self, "_host", None)
         orphan = getattr(t, "journal_dir", None) is not None and getattr(t, "hello", None) is None
         if orphan:
+            # the dead CLI's watermark is the line, with two exceptions (the lows of the fix's round five): a seed that
+            # named no watermark (attach-unknown) knows no line, so every replayed record folds nothing rather than
+            # every ascending step after the first folding its delta; and a record from another session epoch (a
+            # /clear the dead kernel bracketed, its post-clear watermark on record) is not comparable to the
+            # watermark's totals at all, so it folds nothing
+            if getattr(self, "_spend_baseline", "") == "attach-unknown":
+                return True
+            seed_epoch = str(getattr(self, "_spend_seed_session", "") or "")
+            if seed_epoch and session_id and str(session_id) != seed_epoch:
+                return True
             return float(total) <= float(self._last_cost_total)
         return True
 
@@ -7520,7 +7533,7 @@ class SdkSession:
                     # the kernel did not see, a resumed cost-state seed against a print-mode CLI) and folds whole, as
                     # it always did; read from the total alone, a reset latched the session at $0 for the process's life
                     tag = getattr(self, "_result_tag", None)          # popped at the top of _on_message for every result
-                    duplicate = self._spend_redelivered(tag, total)
+                    duplicate = self._spend_redelivered(tag, total, str(getattr(msg, "session_id", "") or ""))
                     # the UNKNOWN window (the fix's second round): with no watermark on record, every replayed record is
                     # the lifetime so far and advances the watermarks to its total (a whole-journal replay, the attach
                     # whose hostAck names another host, hands over several); the first LIVE result closes the window and

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5155,6 +5155,8 @@ class SdkSession:
         #   2026-09-06). Which counter is which, and the measurement: _turn_usage.
         self._spend_unknown_open = False   # True from an attach-unknown seed until the first LIVE result: every replayed
         #                                    record meanwhile is the lifetime so far and advances the watermarks (T354)
+        self._spend_seed_epoch_seen = False   # an orphan drain: a record of the watermark's own epoch has been replayed, so
+        #                                       a different epoch from here on is a NEWER one (_spend_redelivered)
         self._spend_baseline = "fresh"     # what the watermarks stand on: "fresh" (a new CLI process: zero, or the
         #                                    resumed transcript's cost-state record), "attach-pending" (a host attach:
         #                                    the surviving CLI's watermark is read from the registry at the first
@@ -6929,6 +6931,7 @@ class SdkSession:
         self._spend_first_result = True
         self._spend_baseline = "attach-pending"
         self._spend_seed_session = ""
+        self._spend_seed_epoch_seen = False
         self._replay_cli = str(cli or "")
         self._seed_from_reg_cost_state(cli=cli, dead=True)
 
@@ -6995,14 +6998,22 @@ class SdkSession:
         if orphan:
             # the dead CLI's watermark is the line, with two exceptions (the lows of the fix's round five): a seed that
             # named no watermark (attach-unknown) knows no line, so every replayed record folds nothing rather than
-            # every ascending step after the first folding its delta; and a record from another session epoch (a
-            # /clear the dead kernel bracketed, its post-clear watermark on record) is not comparable to the
-            # watermark's totals at all, so it folds nothing
+            # every ascending step after the first folding its delta (the watermark advances with each, the fix's
+            # second round); and a record from another session epoch is not comparable to the watermark's totals, so
+            # it is judged by its POSITION in the tail (the follow-up's second round): before the watermark epoch's own
+            # records it is OLDER (a /clear the dead kernel bracketed, its post-clear watermark on record: folded, so
+            # it folds nothing); after them it is NEWER (a /clear the dead kernel never folded past: live, and a total
+            # below the watermark folds whole as the counter reset it is, the new epoch's watermark from there)
             if getattr(self, "_spend_baseline", "") == "attach-unknown":
                 return True
             seed_epoch = str(getattr(self, "_spend_seed_session", "") or "")
-            if seed_epoch and session_id and str(session_id) != seed_epoch:
-                return True
+            if seed_epoch and session_id:
+                if str(session_id) == seed_epoch:
+                    self._spend_seed_epoch_seen = True
+                elif getattr(self, "_spend_seed_epoch_seen", False):
+                    return False                     # a newer epoch: live
+                else:
+                    return True                      # an older epoch: folded before the dead kernel's /clear
             return float(total) <= float(self._last_cost_total)
         return True
 
@@ -7013,7 +7024,11 @@ class SdkSession:
         try:
             self.backend._update_reg(self.sid, costState={"total": float(total), "tokens": dict(self._last_usage_totals),
                                                            "cli": self._cli_ident(), "t": int(time.time()),
-                                                           "session": str(getattr(self, "_spend_session_id", "") or "")})
+                                                           # the epoch a live result named, else the watermark's own (a drain
+                                                           # of duplicates alone must not erase the epoch the next drain's
+                                                           # guard compares against: the follow-up's second round, low b)
+                                                           "session": str(getattr(self, "_spend_session_id", "") or
+                                                                          getattr(self, "_spend_seed_session", "") or "")})
         except Exception as e:
             self.backend._log("spend (%s): costState write failed: %s" % (self.name, e), problem=False)
 

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -6885,6 +6885,8 @@ class SdkSession:
         self._last_usage_totals = {}  # and its cumulative token counters
         self._spend_first_result = True
         self._spend_baseline = "fresh"
+        self._spend_unknown_open = False   # no unknown window on a fresh seed (the follow-up's second round, low 3)
+        self._spend_seed_epoch_seen = False
         self._spend_seed_session = ""
         self._replay_cli = ""         # a dead CLI's replay is over once a connect seeds
         if getattr(self, "_host_is_attach", False) and getattr(self, "_host", None) is not None:
@@ -7557,9 +7559,15 @@ class SdkSession:
                     unknown = baseline == "attach-unknown" and (first or (duplicate and getattr(self, "_spend_unknown_open", False)))
                     if not duplicate:
                         self._spend_unknown_open = False
-                    if not duplicate or unknown:                       # a replayed record names the replayed epoch, not the
-                        #                                                watermark's, unless the replay IS the watermark's source
-                        self._spend_session_id = str(getattr(msg, "session_id", "") or "")   # the CLI's session epoch (a /clear moves it)
+                    epoch = str(getattr(msg, "session_id", "") or "")
+                    seed_epoch = str(getattr(self, "_spend_seed_session", "") or "")
+                    if not duplicate or unknown or (epoch and epoch == seed_epoch):
+                        # the CLI's session epoch (a /clear moves it): a live record names it; a replayed record names the
+                        # replayed epoch, which is the watermark's only when the replay IS its source (the unknown window)
+                        # or when it is the seed's own (the seeded road: persisted, so the next drain's guard has it;
+                        # an OLDER epoch's replay must not overwrite it). A record without one keeps the epoch on record
+                        # (the follow-up's second round, lows 1 and 2)
+                        self._spend_session_id = epoch or str(getattr(self, "_spend_session_id", "") or "")
                     if unknown or duplicate:
                         delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
                     else:

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -365,15 +365,15 @@ class Rebill(unittest.TestCase):
         # the whole cumulative once per session, each by its own lifetime (a synthetic sequence below)
         s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10, tags=[{"offset": 9, "replay": True}, {"offset": 10, "replay": False}])
         self.assertEqual(s._spend_baseline, "attach-pending")
-        self._run(s, _result(308.15, 90000))                # replayed, no watermark on record: attach-unknown
+        self._run(s, _result(120.5, 40000))                # replayed, no watermark on record: attach-unknown
         self.assertEqual(self._day(), {}, "the lifetime's total is not a turn")
         rows = self._turns()
         self.assertEqual((rows[0].get("usd"), rows[0]["spendBaseline"], rows[0].get("redelivered")), (0.0, "attach-unknown", True))
-        self.assertEqual((s._last_cost_total, s._last_usage_totals.get("input_tokens")), (308.15, 90000), "the watermarks start from the replayed lifetime")
-        self._run(s, _result(309.71, 90400))                # the next LIVE result
-        self.assertAlmostEqual(self._day()["usd"], 1.56, msg="its own delta, not the whole cumulative")
-        self.assertEqual(self._day()["tokIn"], 400)
-        self.assertEqual(self._cost_state()["total"], 309.71)
+        self.assertEqual((s._last_cost_total, s._last_usage_totals.get("input_tokens")), (120.5, 40000), "the watermarks start from the replayed lifetime")
+        self._run(s, _result(123.0, 40300))                # the next LIVE result
+        self.assertAlmostEqual(self._day()["usd"], 2.5, msg="its own delta, not the whole cumulative")
+        self.assertEqual(self._day()["tokIn"], 300)
+        self.assertEqual(self._cost_state()["total"], 123.0)
 
     def test_the_seeded_road_is_unchanged_by_the_unknown_baseline_rule(self):
         # a replay below a KNOWN watermark moves nothing, and an unfolded replay above it is absorbed by the next live
@@ -392,18 +392,20 @@ class Rebill(unittest.TestCase):
         # on the connect's first result alone, the watermark stayed at the first replay's total and the next live result
         # folded the span (replays 100/200/300 then live 301.50 billed 201.50 and 2100 tokens where 1.50 and 100 were due)
         s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10,
-                          tags=[{"offset": 7, "replay": True}, {"offset": 8, "replay": True}, {"offset": 9, "replay": True},
-                                {"offset": 10, "replay": False}])
+                          tags=[{"offset": 6, "replay": True}, {"offset": 7, "replay": True}, {"offset": 8, "replay": True},
+                                {"offset": 9, "replay": True}, {"offset": 10, "replay": False}])
         for total, toks in ((100.0, 1000), (200.0, 2000), (300.0, 3000)):
             self._run(s, _result(total, toks, session="e1"))
             self.assertEqual((s._last_cost_total, s._last_usage_totals.get("input_tokens")), (total, toks), "each replay advances the watermarks")
             self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (total, "e1"),
                              "and persists them with the replayed epoch (the road 1469's guard compares against)")
+        self._run(s, _result(300.5, 3050))                   # a replayed record naming no epoch (low 2 of the follow-up's second round)
+        self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (300.5, "e1"), "the epoch on record is kept, the watermark advances")
         self.assertEqual(self._day(), {}, "replays fold nothing")
-        self.assertEqual([(r.get("usd"), r.get("redelivered")) for r in self._turns()], [(0.0, True)] * 3)
+        self.assertEqual([(r.get("usd"), r.get("redelivered")) for r in self._turns()], [(0.0, True)] * 4)
         self._run(s, _result(301.5, 3100, session="e1"))     # the first LIVE result closes the window
-        self.assertAlmostEqual(self._day()["usd"], 1.5, msg="its own delta over the LAST replay, not the span")
-        self.assertEqual(self._day()["tokIn"], 100)
+        self.assertAlmostEqual(self._day()["usd"], 1.0, msg="its own delta over the LAST replay, not the span")
+        self.assertEqual(self._day()["tokIn"], 50)
         self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (301.5, "e1"))
         self.assertFalse(s._spend_unknown_open, "closed by the live result")
     def test_an_orphan_replay_from_another_epoch_or_under_an_unnamed_seed_folds_nothing(self):
@@ -420,11 +422,13 @@ class Rebill(unittest.TestCase):
         pre = _result(8.0, 10); pre.session_id = "e1"       # pre-clear, another epoch, above the post-clear watermark
         self._run(s, pre)
         self.assertEqual(self._day(), {}, "(a) not comparable to the watermark's epoch: folds nothing")
+        self.assertEqual(self._cost_state()["session"], "e2", "an older epoch's replay does not overwrite the watermark's epoch")
         post = _result(5.0, 10); post.session_id = "e2"
         self._run(s, post)
         self.assertEqual(self._day(), {})
         self.assertEqual(s._last_cost_total, 5.0)
-        self.assertEqual(self._cost_state()["session"], "e2", "a drain of duplicates alone keeps the watermark's epoch on record (low b)")
+        self.assertEqual((s._spend_session_id, self._cost_state()["session"]), ("e2", "e2"),
+                         "the seeded road stamps the epoch from a replay of the watermark's own epoch and persists it (low b)")
         # (b): no watermark on record for the dead CLI
         Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
         sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
@@ -449,6 +453,13 @@ class Rebill(unittest.TestCase):
             self._run(s3, _result(total, 10, session="e1"))
         self.assertEqual(self._day(), {}, "the re-drain re-bills nothing")
         self.assertEqual(len(self._turns()), 6)
+
+    def test_a_fresh_seed_closes_the_unknown_window_and_forgets_the_seen_epoch(self):
+        # low 3 of the follow-up's second round: _seed_spend_watermarks reset every spend field but these two
+        s = self._session()
+        s._spend_unknown_open = True; s._spend_seed_epoch_seen = True
+        s._seed_spend_watermarks()
+        self.assertEqual((s._spend_unknown_open, s._spend_seed_epoch_seen, s._spend_baseline), (False, False, "fresh"))
 
     def test_an_orphan_tail_from_other_epochs_is_judged_by_position_and_a_re_drain_folds_nothing(self):
         # the follow-up's second round (low c): the epoch guard could not tell an OLDER epoch (before the watermark

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -406,6 +406,47 @@ class Rebill(unittest.TestCase):
         self.assertEqual(self._day()["tokIn"], 100)
         self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (301.5, "e1"))
         self.assertFalse(s._spend_unknown_open, "closed by the live result")
+    def test_an_orphan_replay_from_another_epoch_or_under_an_unnamed_seed_folds_nothing(self):
+        # the lows of the fix's round five: (a) an orphan tail reaching back before a /clear the dead kernel bracketed
+        # compared pre-clear totals to the post-clear watermark and re-billed the excess; the record's session_id
+        # against the watermark's epoch says the two are not comparable; (b) an unnamed seed (attach-unknown) protected
+        # the first replayed result alone, every ascending step after it folded its delta
+        self.be._update_reg(SID, costState={"total": 5.0, "tokens": {}, "cli": "4242:s1", "t": 1, "session": "e2"})
+        s = self._session()
+        s._seed_for_dead_cli("4242:s1")
+        self.assertEqual(s._spend_seed_session, "e2", "the watermark's epoch rides the seed")
+        s._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=8, exit_info=None, detach_mode=False,
+                                        result_tags=collections.deque([{"offset": 2, "replay": True}, {"offset": 4, "replay": True}]))
+        pre = _result(8.0, 10); pre.session_id = "e1"       # pre-clear, another epoch, above the post-clear watermark
+        self._run(s, pre)
+        self.assertEqual(self._day(), {}, "(a) not comparable to the watermark's epoch: folds nothing")
+        post = _result(5.0, 10); post.session_id = "e2"
+        self._run(s, post)
+        self.assertEqual(self._day(), {})
+        self.assertEqual(s._last_cost_total, 5.0)
+        # (b): no watermark on record for the dead CLI
+        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
+        s2 = self._session()
+        s2._seed_for_dead_cli("9:unknown")
+        self.assertEqual(s2._spend_baseline, "attach-unknown")
+        s2._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=3, exit_info=None, detach_mode=False,
+                                         result_tags=collections.deque([{"offset": 1, "replay": True}, {"offset": 2, "replay": True}, {"offset": 3, "replay": True}]))
+        for total in (8.0, 12.0, 20.0):
+            self._run(s2, _result(total, 10))
+        self.assertEqual(self._day(), {}, "every replayed record of an unnamed replay folds nothing, not the first alone")
+        self.assertEqual([r.get("redelivered", False) for r in self._turns()], [True, True, True])
+
+    def test_a_frame_with_no_offset_is_read_as_live_never_as_a_replay(self):
+        # low (c): a missing offset was tagged -1 and read as a replay (below any journal.next), folding nothing
+        ht = load_source("romp_host_transport_nooffset", os.path.join(ROOT, "kernel", "host_transport.py"))
+        t = ht.HostTransport.__new__(ht.HostTransport)
+        t.ack_offset, t.replay_end, t.result_tags, t.on_ack, t.hello = 5, 10, collections.deque(), None, None
+        t._advance = lambda out: None
+        t._take({"data": {"type": "result", "subtype": "success"}})            # no offset field
+        t._take({"offset": 3, "data": {"type": "result", "subtype": "success"}})
+        self.assertEqual(list(t.result_tags), [{"offset": -1, "replay": False}, {"offset": 3, "replay": True}],
+                         "unknown position: live; a positioned record before journal.next: a replay")
 
     def test_the_transport_tags_each_result_record_with_its_offset_as_it_reads_it(self):
         # the transport unit of the rule: the hello's journal.next bounds the replay; records the reader hands over are

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -424,6 +424,7 @@ class Rebill(unittest.TestCase):
         self._run(s, post)
         self.assertEqual(self._day(), {})
         self.assertEqual(s._last_cost_total, 5.0)
+        self.assertEqual(self._cost_state()["session"], "e2", "a drain of duplicates alone keeps the watermark's epoch on record (low b)")
         # (b): no watermark on record for the dead CLI
         Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
         sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "web", "cwd": self.d, "alive": True})
@@ -433,9 +434,47 @@ class Rebill(unittest.TestCase):
         s2._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=3, exit_info=None, detach_mode=False,
                                          result_tags=collections.deque([{"offset": 1, "replay": True}, {"offset": 2, "replay": True}, {"offset": 3, "replay": True}]))
         for total in (8.0, 12.0, 20.0):
-            self._run(s2, _result(total, 10))
+            self._run(s2, _result(total, 10, session="e1"))
         self.assertEqual(self._day(), {}, "every replayed record of an unnamed replay folds nothing, not the first alone")
         self.assertEqual([r.get("redelivered", False) for r in self._turns()], [True, True, True])
+        self.assertEqual((self._cost_state()["total"], self._cost_state()["cli"], self._cost_state()["session"]), (20.0, "9:unknown", "e1"),
+                         "the watermark persisted under the dead CLI with the replayed epoch (low a)")
+        # a re-drain of the same tail (hostAck never advanced, no hello) seeds from it and bills nothing
+        s3 = self._session()
+        s3._seed_for_dead_cli("9:unknown")
+        self.assertEqual((s3._spend_baseline, s3._last_cost_total, s3._spend_seed_session), ("seeded", 20.0, "e1"))
+        s3._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=3, exit_info=None, detach_mode=False,
+                                         result_tags=collections.deque([{"offset": 1, "replay": True}, {"offset": 2, "replay": True}, {"offset": 3, "replay": True}]))
+        for total in (8.0, 12.0, 20.0):
+            self._run(s3, _result(total, 10, session="e1"))
+        self.assertEqual(self._day(), {}, "the re-drain re-bills nothing")
+        self.assertEqual(len(self._turns()), 6)
+
+    def test_an_orphan_tail_from_other_epochs_is_judged_by_position_and_a_re_drain_folds_nothing(self):
+        # the follow-up's second round (low c): the epoch guard could not tell an OLDER epoch (before the watermark
+        # epoch's records: folded already) from a NEWER one (after them: a post-clear tail the dead kernel never folded)
+        self.be._update_reg(SID, costState={"total": 5.0, "tokens": {}, "cli": "4242:s1", "t": 1, "session": "e2"})
+        tail = [(8.0, "e1"), (5.0, "e2"), (6.0, "e2"), (1.0, "e3"), (2.5, "e3")]
+
+        def drain(sess):
+            sess._host = types.SimpleNamespace(hello=None, journal_dir="/nonexistent/journal", ack_offset=0, exit_info=None, detach_mode=False,
+                                               result_tags=collections.deque([{"offset": i, "replay": True} for i in range(len(tail))]))
+            for total, epoch in tail:
+                self._run(sess, _result(total, 10, session=epoch))
+        s = self._session()
+        s._seed_for_dead_cli("4242:s1")
+        drain(s)
+        self.assertAlmostEqual(self._day()["usd"], 3.5, msg="e1 before e2's records: older, nothing; e2 at 6.0 over the 5.0 watermark: 1.0; "
+                                                             "e3 after them: newer, 1.0 whole as a counter reset then 1.5")
+        self.assertEqual([r.get("usd") for r in self._turns() if r.get("usd")], [1.0, 1.0, 1.5])
+        self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (2.5, "e3"), "the watermark persisted under the newest epoch")
+        # the same tail drained again (hostAck never advanced, no hello): the seed names e3 at 2.5, every record is older or at the line
+        s2 = self._session()
+        s2._seed_for_dead_cli("4242:s1")
+        self.assertEqual((s2._spend_baseline, s2._spend_seed_session, s2._last_cost_total), ("seeded", "e3", 2.5))
+        drain(s2)
+        self.assertAlmostEqual(self._day()["usd"], 3.5, msg="the re-drain bills nothing")
+        self.assertEqual([r.get("redelivered", False) for r in self._turns()][-5:], [True] * 5)
 
     def test_a_frame_with_no_offset_is_read_as_live_never_as_a_replay(self):
         # low (c): a missing offset was tagged -1 and read as a replay (below any journal.next), folding nothing


### PR DESCRIPTION
Three follow-ups from the fifth review of the spend-ledger kernel fix (pull request 1450), none blocking there.

**An orphan replay from another session epoch folds nothing.** A dead host's journal tail reaching back before a `/clear` the dead kernel bracketed compared pre-clear totals to the post-clear watermark and re-billed the excess. The watermark's session id now rides the seed, and a replayed record whose session id differs from it folds nothing.

**An unnamed replay folds nothing for every record.** A seed with no watermark on record (attach-unknown) protected the first replayed result alone while every ascending step after it folded its delta; every record of such a replay folds nothing.

**A frame with no offset is live.** It was tagged -1 and read as a replay below any journal position; an unknown position is never a replay that folds nothing.

**Tests** (`tests/test_spend_rebill.py`): the other-epoch record and the unnamed replay through the orphan seed, both folding nothing with their rows flagged; the transport tagging a frame without an offset as live beside a positioned replay.

**Second round of the review** (rebased onto the hot fix, pull request 1470, whose unknown-baseline window advances the watermark and stamps the epoch on every replayed record). A drain of duplicates alone persisted the watermark with an empty epoch (the epoch is stamped from live results, and a boot-fresh session had none), so a re-drain of the same tail had nothing to compare against; the persisted epoch falls back to the watermark's own. A record from another session epoch is judged by its position in the tail: before the watermark epoch's own records it is older (a `/clear` the dead kernel bracketed, folded already, so it folds nothing); after them it is newer (a post-clear tail the dead kernel never folded, so it is live, a total below the watermark folding whole as the counter reset it is, and the new epoch's watermark runs from there). Tests: an unnamed seed's drain persists the watermark under the dead CLI with the replayed epoch and a re-drain of the same tail bills nothing; a tail of three epochs bills the older one nothing, the watermark epoch's excess, and the newer one whole then by delta, and a re-drain of that tail bills nothing; a drain of duplicates keeps the epoch on record.

Tier: fix
