### PR TITLE
A replayed first result under an unknown watermark sets the watermark, so the next live turn is its own (T354 hot fix)

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5153,6 +5153,8 @@ class SdkSession:
         #   total when the deltas were written (`usage: this.totalUsage`) and is the TURN's own total
         #   on the current CLI — diffing it under-counted every turn but the first (the user
         #   2026-09-06). Which counter is which, and the measurement: _turn_usage.
+        self._spend_unknown_open = False   # True from an attach-unknown seed until the first LIVE result: every replayed
+        #                                    record meanwhile is the lifetime so far and advances the watermarks (T354)
         self._spend_baseline = "fresh"     # what the watermarks stand on: "fresh" (a new CLI process: zero, or the
         #                                    resumed transcript's cost-state record), "attach-pending" (a host attach:
         #                                    the surviving CLI's watermark is read from the registry at the first
@@ -6944,11 +6946,13 @@ class SdkSession:
             toks = cs.get("tokens") if isinstance(cs.get("tokens"), dict) else {}
             self._last_usage_totals = {k: int(v) for k, v in toks.items() if isinstance(v, (int, float))}
             self._spend_baseline = "seeded"
+            self._spend_unknown_open = False
             self.backend._log("spend: %s %s (%s): watermarks seeded at the registry's "
                               "cumulative $%.2f so the first result records only this turn" % (self.name, how, cli, cs["total"]),
                               problem=False)
             return True
         self._spend_baseline = "attach-unknown"
+        self._spend_unknown_open = True
         self.backend._log("spend: %s %s (%s) with no matching watermark on record (%s): its "
                           "first result's total is the process lifetime's, so that result records no spend; the "
                           "watermark is written from it" % (self.name, how.replace("its surviving", "a surviving").replace("its dead", "a dead"), cli or "unnamed",
@@ -7505,7 +7509,6 @@ class SdkSession:
                         # registry's watermark for that process can be read (T354)
                         self._seed_from_reg_cost_state()
                         baseline = self._spend_baseline
-                    unknown = first and baseline == "attach-unknown"
                     # a REDELIVERED result (M2 of 1450's review, reshaped by its round two): hostAck is written at
                     # most once a second while the watermark moves per result, so a kernel death leaves processed
                     # results past the acknowledged offset and the attach's replay hands them over again (the whole
@@ -7518,7 +7521,16 @@ class SdkSession:
                     # it always did; read from the total alone, a reset latched the session at $0 for the process's life
                     tag = getattr(self, "_result_tag", None)          # popped at the top of _on_message for every result
                     duplicate = self._spend_redelivered(tag, total)
-                    if not duplicate:                                  # a replayed record names the replayed epoch: not the watermark's
+                    # the UNKNOWN window (the fix's second round): with no watermark on record, every replayed record is
+                    # the lifetime so far and advances the watermarks to its total (a whole-journal replay, the attach
+                    # whose hostAck names another host, hands over several); the first LIVE result closes the window and
+                    # records its own delta. Keyed on the connect's first result alone, the watermark stayed at the first
+                    # replay's total and the next live result folded the span
+                    unknown = baseline == "attach-unknown" and (first or (duplicate and getattr(self, "_spend_unknown_open", False)))
+                    if not duplicate:
+                        self._spend_unknown_open = False
+                    if not duplicate or unknown:                       # a replayed record names the replayed epoch, not the
+                        #                                                watermark's, unless the replay IS the watermark's source
                         self._spend_session_id = str(getattr(msg, "session_id", "") or "")   # the CLI's session epoch (a /clear moves it)
                     if unknown or duplicate:
                         delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
@@ -7542,6 +7554,9 @@ class SdkSession:
                     else:
                         turn_u = self._turn_usage(msg)
                     if unknown:       # the token watermarks moved with the map; the lifetime's counts are not this turn's
+                        #   (a record without the modelUsage map leaves the token watermark empty, and the next live result's
+                        #   map folds whole: the map is the only cumulative count a result carries, so no line here can do
+                        #   better; the dollar watermark is right either way. Noted in the fix's second round)
                         turn_u = {k: 0 for k in (turn_u or {})} if isinstance(turn_u, dict) else turn_u
                     self._turn_cumulative = float(total)          # the turn row carries the CLI's own cumulative (T354)
                     self._turn_baseline = baseline if first else None
@@ -7576,10 +7591,10 @@ class SdkSession:
                                               "transcript than the connect-time seed (last_cost_state)."
                                               % (self.name, delta, SANE_TURN_USD, total), problem=False)
                     elif unknown:
-                        self.backend._log("spend: %s's first result after a host attach carries the surviving CLI's "
+                        self.backend._log("spend: %s's %s after a host attach carries the surviving CLI's "
                                           "cumulative total ($%.2f) with no watermark on record: this turn's own cost is "
                                           "unknowable and nothing was folded; the watermark is set from here"
-                                          % (self.name, total), problem=False)
+                                          % (self.name, "first result" if first else "replayed result", total), problem=False)
             finally:
                 # T304: one durable row per settled turn (turns.jsonl, see the ledger note by
                 # append_turn_row) — the event stamps the restart monitors read. In the finally, ahead of

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -7524,7 +7524,10 @@ class SdkSession:
                         delta = 0.0       # unknown: the lifetime's total, this turn's share unknowable; duplicate: already folded
                     else:
                         delta = total - self._last_cost_total if total >= self._last_cost_total else total
-                    if not duplicate:
+                    if not duplicate or unknown:
+                        # a replayed result under an UNKNOWN baseline still names the lifetime the watermark starts
+                        # from (live 2026-09-11 22:38Z, the fix's first boot: every session's replayed first result
+                        # left the watermark at zero, and its next live result folded the whole cumulative once)
                         self._last_cost_total = float(total)
                     self._spend_first_result = False   # the watermark moved (or a duplicate was seen): the process's first result is in
                     # the tokens: THIS turn's counts, from whichever result counter is a running total —
@@ -7533,7 +7536,9 @@ class SdkSession:
                         keep = dict(self._last_usage_totals)
                         turn_u = self._turn_usage(msg)
                         turn_u = {k: 0 for k in (turn_u or {})} if isinstance(turn_u, dict) else turn_u
-                        self._last_usage_totals = keep       # the token watermarks are not moved down either
+                        if not unknown:
+                            self._last_usage_totals = keep   # the token watermarks are not moved down either (an unknown
+                            #                                  baseline keeps the map's totals: they start the watermark)
                     else:
                         turn_u = self._turn_usage(msg)
                     if unknown:       # the token watermarks moved with the map; the lifetime's counts are not this turn's

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -372,15 +372,18 @@ class Rebill(unittest.TestCase):
         self.assertAlmostEqual(self._day()["usd"], 1.56, msg="its own delta, not the whole cumulative")
         self.assertEqual(self._day()["tokIn"], 400)
         self.assertEqual(self._cost_state()["total"], 309.71)
-        # the seeded road is unchanged: a replay below a known watermark moves nothing, and an unfolded replay above it
-        # is absorbed by the next live delta
-        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+
+    def test_the_seeded_road_is_unchanged_by_the_unknown_baseline_rule(self):
+        # a replay below a KNOWN watermark moves nothing, and an unfolded replay above it is absorbed by the next live
+        # delta (the round-five behaviour the verifier read as right); only the unknown baseline seeds from a replay
         self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
         s2 = self._session(attach=True, journal_next=10, tags=[{"offset": 8, "replay": True}, {"offset": 9, "replay": True}, {"offset": 10, "replay": False}])
         self._run(s2, _result(480.0, 89000)); self._run(s2, _result(512.5, 90400))
-        self.assertEqual(self._day(), {}); self.assertEqual(s2._last_cost_total, 500.0)
+        self.assertEqual(self._day(), {}, "replays fold nothing")
+        self.assertEqual((s2._last_cost_total, s2._last_usage_totals["input_tokens"]), (500.0, 90000), "the seeded watermarks stand")
         self._run(s2, _result(520.0, 91000))
         self.assertAlmostEqual(self._day()["usd"], 20.0, msg="the unfolded 12.5 rides the live delta")
+        self.assertEqual(self._day()["tokIn"], 1000)
 
     def test_the_transport_tags_each_result_record_with_its_offset_as_it_reads_it(self):
         # the transport unit of the rule: the hello's journal.next bounds the replay; records the reader hands over are

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -357,6 +357,31 @@ class Rebill(unittest.TestCase):
                          "the zero-cost result's own row (no dollars), then the two live ones, none read as a replay")
         self.assertEqual(self._cost_state()["session"], "", "the epoch is stamped from live results (these doubles carry none)")
 
+    def test_a_replayed_first_result_under_an_unknown_baseline_sets_the_watermark_so_the_next_live_turn_is_its_own(self):
+        # live on the fix's first boot (2026-09-11 22:37Z): every session's replayed first result was attach-unknown and
+        # folded nothing, right, but the duplicate branch left the watermark at zero, and the next LIVE result folded the
+        # whole cumulative once per session (romp_PR-triage 159.20 = its cumulative, romp_timeline 309.71 = its cumulative)
+        s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10, tags=[{"offset": 9, "replay": True}, {"offset": 10, "replay": False}])
+        self.assertEqual(s._spend_baseline, "attach-pending")
+        self._run(s, _result(308.15, 90000))                # replayed, no watermark on record: attach-unknown
+        self.assertEqual(self._day(), {}, "the lifetime's total is not a turn")
+        rows = self._turns()
+        self.assertEqual((rows[0].get("usd"), rows[0]["spendBaseline"], rows[0].get("redelivered")), (0.0, "attach-unknown", True))
+        self.assertEqual((s._last_cost_total, s._last_usage_totals.get("input_tokens")), (308.15, 90000), "the watermarks start from the replayed lifetime")
+        self._run(s, _result(309.71, 90400))                # the next LIVE result
+        self.assertAlmostEqual(self._day()["usd"], 1.56, msg="its own delta, not the whole cumulative")
+        self.assertEqual(self._day()["tokIn"], 400)
+        self.assertEqual(self._cost_state()["total"], 309.71)
+        # the seeded road is unchanged: a replay below a known watermark moves nothing, and an unfolded replay above it
+        # is absorbed by the next live delta
+        Path(self.d, "spend.json").unlink(missing_ok=True); Path(self.d, "turns.jsonl").unlink(missing_ok=True)
+        self.be._update_reg(SID, costState={"total": 500.0, "tokens": {"input_tokens": 90000}, "cli": "4242:s1", "t": 1})
+        s2 = self._session(attach=True, journal_next=10, tags=[{"offset": 8, "replay": True}, {"offset": 9, "replay": True}, {"offset": 10, "replay": False}])
+        self._run(s2, _result(480.0, 89000)); self._run(s2, _result(512.5, 90400))
+        self.assertEqual(self._day(), {}); self.assertEqual(s2._last_cost_total, 500.0)
+        self._run(s2, _result(520.0, 91000))
+        self.assertAlmostEqual(self._day()["usd"], 20.0, msg="the unfolded 12.5 rides the live delta")
+
     def test_the_transport_tags_each_result_record_with_its_offset_as_it_reads_it(self):
         # the transport unit of the rule: the hello's journal.next bounds the replay; records the reader hands over are
         # tagged in _take before the yield; the last replayed record tagged at next - 1 is a replay even though the

--- a/tests/test_spend_rebill.py
+++ b/tests/test_spend_rebill.py
@@ -37,9 +37,11 @@ class _AssistantMessage:
     pass
 
 
-def _result(total, tokens_in):
+def _result(total, tokens_in, session=""):
     r = _ResultMessage()
     r.total_cost_usd = total
+    if session:
+        r.session_id = session
     r.model_usage = {"claude-x": {"inputTokens": tokens_in, "outputTokens": 0, "cacheReadInputTokens": 0,
                                   "cacheCreationInputTokens": 0, "webSearchRequests": 0, "costUSD": 0.0}}
     r.usage = {"input_tokens": 9999}
@@ -358,9 +360,9 @@ class Rebill(unittest.TestCase):
         self.assertEqual(self._cost_state()["session"], "", "the epoch is stamped from live results (these doubles carry none)")
 
     def test_a_replayed_first_result_under_an_unknown_baseline_sets_the_watermark_so_the_next_live_turn_is_its_own(self):
-        # live on the fix's first boot (2026-09-11 22:37Z): every session's replayed first result was attach-unknown and
-        # folded nothing, right, but the duplicate branch left the watermark at zero, and the next LIVE result folded the
-        # whole cumulative once per session (romp_PR-triage 159.20 = its cumulative, romp_timeline 309.71 = its cumulative)
+        # live on the fix's first boot (2026-09-11 22:37Z): every hosted session's replayed first result was attach-unknown
+        # and folded nothing, right, but the duplicate branch left the watermark at zero, and the next LIVE result folded
+        # the whole cumulative once per session, each by its own lifetime (a synthetic sequence below)
         s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10, tags=[{"offset": 9, "replay": True}, {"offset": 10, "replay": False}])
         self.assertEqual(s._spend_baseline, "attach-pending")
         self._run(s, _result(308.15, 90000))                # replayed, no watermark on record: attach-unknown
@@ -384,6 +386,26 @@ class Rebill(unittest.TestCase):
         self._run(s2, _result(520.0, 91000))
         self.assertAlmostEqual(self._day()["usd"], 20.0, msg="the unfolded 12.5 rides the live delta")
         self.assertEqual(self._day()["tokIn"], 1000)
+
+    def test_every_replayed_record_under_an_unknown_baseline_advances_the_watermarks_until_the_first_live_result(self):
+        # the fix's second round: a whole-journal replay (hostAck naming another host) hands over several results; keyed
+        # on the connect's first result alone, the watermark stayed at the first replay's total and the next live result
+        # folded the span (replays 100/200/300 then live 301.50 billed 201.50 and 2100 tokens where 1.50 and 100 were due)
+        s = self._session(attach=True, hello_cli=("4242", "s1"), journal_next=10,
+                          tags=[{"offset": 7, "replay": True}, {"offset": 8, "replay": True}, {"offset": 9, "replay": True},
+                                {"offset": 10, "replay": False}])
+        for total, toks in ((100.0, 1000), (200.0, 2000), (300.0, 3000)):
+            self._run(s, _result(total, toks, session="e1"))
+            self.assertEqual((s._last_cost_total, s._last_usage_totals.get("input_tokens")), (total, toks), "each replay advances the watermarks")
+            self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (total, "e1"),
+                             "and persists them with the replayed epoch (the road 1469's guard compares against)")
+        self.assertEqual(self._day(), {}, "replays fold nothing")
+        self.assertEqual([(r.get("usd"), r.get("redelivered")) for r in self._turns()], [(0.0, True)] * 3)
+        self._run(s, _result(301.5, 3100, session="e1"))     # the first LIVE result closes the window
+        self.assertAlmostEqual(self._day()["usd"], 1.5, msg="its own delta over the LAST replay, not the span")
+        self.assertEqual(self._day()["tokIn"], 100)
+        self.assertEqual((self._cost_state()["total"], self._cost_state()["session"]), (301.5, "e1"))
+        self.assertFalse(s._spend_unknown_open, "closed by the live result")
 
     def test_the_transport_tags_each_result_record_with_its_offset_as_it_reads_it(self):
         # the transport unit of the rule: the hello's journal.next bounds the replay; records the reader hands over are


### PR DESCRIPTION
A one-line hole in the spend-ledger fix (pull request 1450), found live on its first boot, 2026-09-11 22:37Z.

**What happened.** On the first boot with the fix, every hosted session's first result was a replayed record under an unknown watermark (the pre-fix kernel had persisted none): the fold read it as attach-unknown and redelivered and recorded nothing, which was right. But the redelivery branch does not move the watermark, and the attach-unknown road relied on that first result to set it, so the watermark stayed at zero and the session's next live result folded its whole cumulative once (two sessions recorded $159 and $310 rows equal to their own cumulative before this fix was written). Every session does it once, then runs clean.

**The fix.** A replayed result under an unknown baseline still sets the dollar and token watermarks to its total: it names the lifetime the watermark starts from, and there is nothing of this kernel's to absorb. The seeded road is unchanged: a replay below a known watermark moves nothing, and an unfolded replay above it is absorbed by the next live delta.

**Test** (`tests/test_spend_rebill.py`): a replayed attach-unknown first result folds nothing and leaves the watermarks at its total, so the next live result folds its own $1.56 and 400 tokens; the seeded road's two behaviours pinned beside it.

**Second round of the review.** The unknown baseline is a window, not the connect's first result alone: with no watermark on record, every replayed record is the lifetime so far and advances the dollar and token watermarks to its total, persisting them with the replayed record's session epoch, and the first live result closes the window and records its own delta. A whole-journal replay (the attach whose acknowledgement names another host) hands over several results, and keyed on the first alone the watermark stayed at the first replay's total, so the next live result folded the span (replays of 100, 200 and 300 then a live 301.50 billed 201.50 and 2100 tokens where 1.50 and 100 were due). The attach's log line names a first or a replayed result. A record without the `modelUsage` map leaves the token watermark empty and the next live result's map folds whole; the map is the only cumulative count a result carries, so that is said in a comment rather than fixed. The test module's comment on the live sequence no longer names sessions. Test: three replays then one live result, each replay's watermarks and persisted epoch asserted, the live result's own delta and tokens.

Tier: fix
