### PR TITLE
The unfocused pane's follow-up: an emptied strip repaints, an id that can never return says so, no raw sid in the body, an adopted tab persists, the unreachable view-filter route goes (T357 follow-up)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -411,10 +411,11 @@ session name in it. When that same session's tab returns, the pane goes back
 to it. After a kernel restart the page reloads and remembers the tab you were
 on: until that session is listed again the pane stays blank and names it as not
 listed yet, and it never settles on another session meanwhile; if it never
-returns, the blank body stays until you pick a tab. A tab view that stops
-showing your session (a tag removed) blanks the pane the same way and comes back
-to it when the view shows it again. From the blank pane an arrow key or Next Tab
-lands on the first visible tab. Focus moves to a different session only when
+returns, the blank body stays until you pick a tab (a remembered tab that can
+never return, a subagent's viewer or a session still being created, says so at
+once). A tab view that stops showing your session keeps it on the strip as the
+peek. From the blank pane an arrow key or Next Tab lands on the first visible
+tab. Focus moves to a different session only when
 you pick a tab, or when you close the active tab yourself (then the pane returns
 to the tab you used before it).
 

--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -36,6 +36,7 @@ SID_A = "11111111-2222-3333-4444-555555555555"
 SID_B = "aaaaaaaa-1111-2222-3333-444444444444"
 SID_C = "bbbbbbbb-1111-2222-3333-444444444444"   # a session that appears while the user's tab is away: never adopted
 REMOTE = "REMOTEBOX:cccccccc-1111-2222-3333-444444444444"   # a remote host's session this kernel never lists: the reload road's awaited tab
+PROVISIONAL = "new-" + "docs"   # a provisional create's id (ui/webview/provisional.ts): a persisted choice that can never be listed again
 
 
 def _free_port():
@@ -145,6 +146,29 @@ await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .t
 await inject({ type: "tabOrder", order: [cfg.remote, cfg.sidA, cfg.sidB, cfg.sidC], tabs: [R_TAB, A_TAB, B_TAB, C_TAB], live: [cfg.remote, cfg.sidA, cfg.sidB, cfg.sidC], skeleton: [cfg.remote, cfg.sidC] });
 await page.waitForTimeout(500);
 out.pickWins = await state();
+// ---- the follow-up's roads ----
+// (e) an ADOPTED tab (the pane never clicked) is persisted like a pick: clear the choice, reload, the first session
+// adopts the box, and the persisted state names it
+await page.evaluate(() => { const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-")); const st = key ? JSON.parse(localStorage.getItem(key) || "{}") : {}; delete st.activeId; delete st.activeName; localStorage.setItem(key, JSON.stringify(st)); });
+await page.reload();
+await page.waitForFunction(() => !!document.querySelector("#tabs .tab.active[data-id]"), null, { timeout: 20000 });
+out.adopted = await page.evaluate(() => { const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-")); const st = JSON.parse(localStorage.getItem(key) || "{}"); return { active: document.querySelector("#tabs .tab.active[data-id]").dataset.id, persisted: st.activeId || null, name: st.activeName || "" }; });
+// (c) a persisted state that predates the name: the body never shows a raw sid
+await page.evaluate((remote) => { const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-")); const st = JSON.parse(localStorage.getItem(key) || "{}"); st.activeId = remote; delete st.activeName; localStorage.setItem(key, JSON.stringify(st)); }, cfg.remote);
+await page.reload();
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, 2, { timeout: 20000 });
+await page.waitForTimeout(500);
+out.nameless = await state();
+// (a) the strip EMPTIES under the unfocused pane: the body and the box's placeholder follow
+await inject({ type: "tabOrder", order: [], tabs: [], live: [], skeleton: [] });
+await page.waitForFunction(() => { const e = document.getElementById("empty-state"); return !!e && /No sessions yet/.test(e.textContent || ""); }, null, { timeout: 10000 });
+out.emptied = await state();
+// (b) a persisted id that can never be listed again (a provisional create): gone, not awaited
+await page.evaluate((prov) => { const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-")); const st = JSON.parse(localStorage.getItem(key) || "{}"); st.activeId = prov; st.activeName = "docs"; localStorage.setItem(key, JSON.stringify(st)); }, cfg.provisional);
+await page.reload();
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, 2, { timeout: 20000 });
+await page.waitForTimeout(500);
+out.gone = await state();
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
 process.exit(0);
@@ -214,7 +238,7 @@ class ServedUnfocusedPane(unittest.TestCase):
     def test_the_focused_tab_leaving_on_its_own_unfocuses_the_pane_and_its_return_restores_it(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "remote": REMOTE,
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "remote": REMOTE, "provisional": PROVISIONAL,
                        "shots": os.environ.get("PV_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -265,6 +289,18 @@ class ServedUnfocusedPane(unittest.TestCase):
         self.assertTrue(a["composer"]["disabled"]); self.assertEqual(a["statusline"], "")
         self.assertEqual(r["reloadRestored"]["active"], REMOTE, "the remote host relays its strip: focus goes to the remembered tab")
         self.assertEqual(r["pickWins"]["active"], SID_B, "a pick before the relay wins; the relay changes nothing: %r" % r["pickWins"])
+        # the follow-up's roads
+        ad = r["adopted"]
+        self.assertEqual(ad["persisted"], ad["active"], "an adopted tab is persisted like a pick: %r" % ad); self.assertIn(ad["name"], ("web", "api"))
+        nl = r["nameless"]
+        self.assertIsNone(nl["active"]); self.assertIn("a session is not listed yet", nl["empty"]["text"], "no raw sid in the body: %r" % nl["empty"])
+        self.assertNotIn("cccccccc", nl["empty"]["text"])
+        em = r["emptied"]
+        self.assertIsNone(em["active"]); self.assertEqual(em["tabs"], [], "the strip emptied")
+        self.assertIn("No sessions yet.", em["empty"]["text"]); self.assertEqual(em["composer"]["placeholder"], "Click + to add a session", "the box's placeholder followed the strip: %r" % em["composer"])
+        g = r["gone"]
+        self.assertIsNone(g["active"], "a provisional id is never awaited or adopted: %r" % g)
+        self.assertIn("docs", g["empty"]["text"]); self.assertIn("is no longer available. Pick a tab.", g["empty"]["text"])
 
 
 if __name__ == "__main__":

--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -9,7 +9,9 @@ and its transcript comes back. Screenshots of the unfocused state, dark and ligh
 The reload road (the review's HIGH, the user's actual trigger): the persisted state names a REMOTE tab this kernel never
 lists; after a reload the pane stays unfocused naming it, the local sessions adopt nothing, the remote strip entry
 restores focus to it, and a pick made before the relay wins.
-Synthetic fixtures only: placeholder UUIDs, a hermetic state root, an invented notes-api world."""
+The #only= filter (the review's probe): the persisted active tab hidden by the filter goes unfocused, its transcript off
+screen, named as hidden by the view. Synthetic fixtures only: placeholder UUIDs, a hermetic state root, an invented
+notes-api world."""
 import json
 import os
 import re
@@ -169,6 +171,21 @@ await page.reload();
 await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, 2, { timeout: 20000 });
 await page.waitForTimeout(500);
 out.gone = await state();
+// the #only= filter (the review's probe): web persisted active, the page served at #only=api, a reload: the strip shows
+// only api, and web's transcript must NOT be on screen; the pane is unfocused naming web as hidden by the view
+await page.evaluate((sid) => { const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-")); const st = JSON.parse(localStorage.getItem(key) || "{}"); st.activeId = sid; st.activeName = "web"; localStorage.setItem(key, JSON.stringify(st)); }, cfg.sidA);
+await page.goto(cfg.chat + "#only=api");   // a hash-only change is no navigation: the page keeps running, so…
+await page.reload();                        // …reload with the hash in place, the way a restart's reload would find it
+await page.waitForFunction((sid) => { const tabs = Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => t.dataset.id); return tabs.length >= 1 && !tabs.includes(sid); }, cfg.sidA, { timeout: 20000 });
+await page.waitForTimeout(800);
+out.onlyFiltered = await page.evaluate(() => {
+  const act = document.querySelector("#tabs .tab.active[data-id]");
+  const empty = document.getElementById("empty-state");
+  const turns = Array.from(document.querySelectorAll("#content .turn")).filter((t) => { const r = t.getBoundingClientRect(); return r.width > 0 && r.height > 0 && getComputedStyle(t).display !== "none"; });
+  return { active: act ? act.dataset.id : null, tabs: Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => t.dataset.id),
+           empty: empty && getComputedStyle(empty).display !== "none" ? { text: empty.textContent, vanished: empty.dataset.vanished || "" } : null,
+           visibleTurns: turns.length, composerDisabled: document.getElementById("composer-input").disabled };
+});
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
 process.exit(0);
@@ -204,6 +221,7 @@ class ServedUnfocusedPane(unittest.TestCase):
         cwd = os.path.join(cls.lab, "proj")
         for d in ("names", "sdk", "states"):
             os.makedirs(os.path.join(state, d), exist_ok=True)
+        Path(state, "session-hosts").write_text("off\n")   # a lab root writes its own session-hosts off (the conftest rule), or a connect would spawn a real host
         os.makedirs(cwd, exist_ok=True)
         claude = os.path.join(cls.lab, "claude")
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
@@ -300,7 +318,14 @@ class ServedUnfocusedPane(unittest.TestCase):
         self.assertIn("No sessions yet.", em["empty"]["text"]); self.assertEqual(em["composer"]["placeholder"], "Click + to add a session", "the box's placeholder followed the strip: %r" % em["composer"])
         g = r["gone"]
         self.assertIsNone(g["active"], "a provisional id is never awaited or adopted: %r" % g)
-        self.assertIn("docs", g["empty"]["text"]); self.assertIn("is no longer available. Pick a tab.", g["empty"]["text"])
+        self.assertIn("docs", g["empty"]["text"]); self.assertIn("is no longer on the strip. Pick a tab.", g["empty"]["text"])
+        # the #only= filter: the hidden active tab's transcript leaves the screen; the pane is unfocused naming it
+        of = r["onlyFiltered"]
+        self.assertIsNone(of["active"], "no tab active under the filter: %r" % of); self.assertNotIn(SID_A, of["tabs"]); self.assertIn(SID_B, of["tabs"])
+        self.assertEqual(of["visibleTurns"], 0, "the filtered session's transcript is NOT on screen (the demo leak): %r" % of)
+        self.assertIsNotNone(of["empty"]); self.assertEqual(of["empty"]["vanished"], SID_A)
+        self.assertIn("web", of["empty"]["text"]); self.assertIn("is not shown by this tab view", of["empty"]["text"])
+        self.assertTrue(of["composerDisabled"])
 
 
 if __name__ == "__main__":

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -345,7 +345,7 @@ test("the note retires on the exact events: an explicit switch, the session's re
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption persists like a pick");
+  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -345,7 +345,7 @@ test("the note retires on the exact events: an explicit switch, the session's re
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive;[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); \}/, "…and never while the user's own tab is away, or awaited after a reload (T357)");
+  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption persists like a pick");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -78,13 +78,14 @@ test("a filtered view re-points the CHAT BODY, not just the tab bar", () => {
   // whole point of the filter is a clean recording frame, so the selection must follow it.
   // the re-point covers BOTH filters since session views landed (2026-08-18): a hidden or
   // filtered-out active session must not keep its transcript on screen
-  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  // (T357 follow-up: the first-visible-tab fallback is GONE. assertPeekFor runs before every renderTabs and makes an
+  // active tab the view excludes the PEEK, so it stays on the strip and the pane never re-points itself; the filter's
+  // "clean frame" holds because the excluded tab is the peek, not a re-pointed selection.)
+  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  assert.match(RENDER, /function assertPeekFor\(id: string\): void \{\s*\n\s*const next = chatVisible\(id\) \? null : id;/);
   // the deferred bounce re-validates at FIRE time since the ephemeral peek (2026-08-24): an
   // activation between schedule and fire (a feed click opening a peek) makes the active tab
   // visible again — bouncing then would kick the user off the tab they just opened
-  // (T357: the fallback no longer re-points the pane at another session; it goes UNFOCUSED naming the tab the view
-  // hides, which still takes the hidden transcript off screen, and comes back to it when the view shows it again)
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\); \}, 0\);/);
 });
 
 test("feed cards filter by the #only tag; clear bookkeeping still uses the FULL payload", () => {

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -72,17 +72,17 @@ test("chat tabs filter by the #only tag", () => {
   assert.match(RENDER, /const plan = planStrip\(visibleIds,/);
 });
 
-test("a filtered view re-points the CHAT BODY, not just the tab bar", () => {
+test("a filtered view blanks the CHAT BODY too: the active tab it hides goes unfocused, never re-pointed", () => {
   // the filter hid a non-matching TAB but left its transcript rendering — a real session's chat
   // (nimbus) sat in a `#only=api,tests,web` frame, statusline and all (the user 2026-07-16). The
   // whole point of the filter is a clean recording frame, so the selection must follow it.
   // the re-point covers BOTH filters since session views landed (2026-08-18): a hidden or
   // filtered-out active session must not keep its transcript on screen
-  // (T357 follow-up: the first-visible-tab fallback is GONE. assertPeekFor runs before every renderTabs and makes an
-  // active tab the view excludes the PEEK, so it stays on the strip and the pane never re-points itself; the filter's
-  // "clean frame" holds because the excluded tab is the peek, not a re-pointed selection.)
-  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
-  assert.match(RENDER, /function assertPeekFor\(id: string\): void \{\s*\n\s*const next = chatVisible\(id\) \? null : id;/);
+  // (T357: the #only= filter is applied on top of tabInView and is no peek input, so an active tab it hides reaches
+  // this check; the pane goes UNFOCUSED naming it (its transcript leaves the screen, the filter's clean frame holds)
+  // and is never re-pointed at the first visible session; the fire-time check reads the predicate visibleIds uses)
+  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{\s*\n\s*const hid = activeId;\s*\n\s*setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
+  assert.doesNotMatch(RENDER, /setActive\(next\); \}, 0\);/, "no re-point");
   // the deferred bounce re-validates at FIRE time since the ephemeral peek (2026-08-24): an
   // activation between schedule and fire (a feed click opening a peek) makes the active tab
   // visible again — bouncing then would kick the user off the tab they just opened

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -34,7 +34,8 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, true),
                    { head: "No session selected. Pick a tab to start. ", name: "web", tail: " is not listed yet. It comes back here when its host does." });
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: true }, true).tail, " is not listed yet; its host is reconnecting… It comes back here when the host does.");
-  assert.deepEqual(emptyStateParts({ name: "web", why: "gone", dialing: false }, true).tail, " is no longer available. Pick a tab.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "gone", dialing: false }, true).tail, " is no longer on the strip. Pick a tab.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "hidden", dialing: false }, true).tail, " is not shown by this tab view. Pick a tab, or change the view.");
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, false).head, "No sessions yet. ", "an empty strip invites no pick");
   for (const p of [emptyStateParts({ name: "web", why: "hostDrop", dialing: true }, true), emptyStateParts(null, true)]) {
     assert.doesNotMatch(p.head + p.tail, /\b(card|board|goal|column|nudge)\b/, "no romp nouns in the body's line");
@@ -42,7 +43,7 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
 });
 
 test("the wiring: the dismiss branch, the unfocused body, the composer, the restore on return, no adoption meanwhile", () => {
-  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: DismissWhy \| null = null;\s*\nlet vanishedName = "";/m);
+  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: VanishWhy \| null = null;\s*\nlet vanishedName = "";/m);
   const dismiss = fn("dismissSession");
   assert.match(dismiss, /const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;\s*\n\s*if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; \}/);
   assert.match(dismiss, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/, "the T236 note above the box still says whose box went away");
@@ -50,7 +51,7 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null;/, "a pick ends the unfocused state AND the awaited tab");
   assert.match(fn("setActive"), /persistActive\(id\);/, "the pick persists id and name");
   assert.match(fn("persistActive"), /activeId: id, activeName: liveSession\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| ""/, "the name persists beside the id for the reload's body");
-  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "an adopted tab is persisted like a pick (the review's low)");
+  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "an adopted tab asserts its peek and is persisted like a pick (the review's lows)");
   // the empty body: pane-focus's words, the name dressed as the strip dresses it, the composer disabled and nameless
   const show = fn("showActive");
   assert.match(show, /paintEmptyState\(empty\);\s*\n\s*empty\.style\.display = "";\s*\n[\s\S]{0,200}?ta\.disabled = true; ta\.placeholder = order\.length \? "Pick a tab to start" : "Click \+ to add a session"; syncComposerPh\(\);/);
@@ -68,18 +69,26 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(fn("paintEmptyState"), /const awaited = !vanishedId && wantActive \? wantActive : null;/);
   assert.match(RENDER, /renderBgTasks\(\);\s*\n\s*\} else if \(!activeId\) \{[\s\S]{0,300}?showActive\(\);\s*\n\s*\}/, "a frame landing on an unfocused pane paints the body, adopting nothing");
   assert.match(fn("paintEmptyState"), /why: "awaited" as const, dialing: hostIsDialing\(awaited\)/);
-  assert.match(fn("paintEmptyState"), /const nameOf = \(id: string\) => wantActiveName \|\| tabMeta\.get\(id\)\?\.name \|\| "a session";/, "never a raw sid in the body");
+  assert.match(fn("paintEmptyState"), /const nameOf = \(id: string, carried = ""\) => carried \|\| wantActiveName \|\| tabMeta\.get\(id\)\?\.name \|\| sessions\.get\(id\)\?\.name \|\| "a session";/, "never a raw sid in the body, on any branch");
   assert.match(RENDER, /if \(wantActive && \(isSubId\(wantActive\) \|\| isProvisionalId\(wantActive\)\)\) \{ wantActiveGone = wantActive; wantActive = null; \}/, "an id that can never be listed again is not awaited");
   assert.match(fn("paintEmptyState"), /gone \? \{ name: nameOf\(gone\), why: "gone" as const, dialing: false \}/);
   assert.match(fn("applyTabOrder"), /if \(back && order\.includes\(back\)\) setActive\(back\);\s*\n\s*else if \(!activeId\) showActive\(\);/, "the strip changing under an unfocused pane repaints the body (an emptied strip included)");
   // the body repaints on the dial event; the view filter routes through the same rule; the keyboard picks the first tab
   assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); repaintEmptyStateIfUnfocused\(\); \}\);/);
   assert.match(fn("repaintEmptyStateIfUnfocused"), /if \(activeId\) return;[\s\S]*?if \(e\) paintEmptyState\(e\);/);
-  // the view filter: no fallback re-points the selection at all (assertPeekFor makes the excluded active tab the peek
-  // before every renderTabs, so tabInView holds for it); the old first-visible-tab fallback is gone
-  assert.doesNotMatch(fn("renderTabs"), /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab fallback");
-  assert.doesNotMatch(RENDER, /unfocusHiddenByView/, "and no route that only that fallback could reach");
-  assert.match(fn("assertPeekFor"), /const next = chatVisible\(id\) \? null : id;/, "the peek rule that covers a view excluding the active tab");
+  // the strip's filters: a VIEW excluding the active tab is covered by the peek (captureViews asserts it before
+  // applyTabOrder on every tabOrder frame; visibility is a pure function of the views blob), but the #only= filter is
+  // applied on top of tabInView and is no peek input, so an only-filtered active tab goes UNFOCUSED here, never
+  // re-pointed; the fire-time check reads the same predicate visibleIds is built from (stripShows)
+  assert.match(fn("renderTabs"), /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{\s*\n\s*const hid = activeId;\s*\n\s*setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
+  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,200}?if \(!activeId && vanishedId === back && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again");
+  assert.match(fn("stripShows"), /if \(!tabInView\(id\)\) return false;\s*\n\s*const only = onlyTag\(\);\s*\n\s*return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/, "the one predicate");
+  assert.doesNotMatch(RENDER, /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab RE-POINT");
+  assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);
+  assert.match(fn("assertPeekFor"), /const next = chatVisible\(id\) \? null : id;/, "the peek rule, over the views blob alone");
+  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "an adoption asserts the peek like a pick");
+  assert.match(fn("paintEmptyState"), /name: nameOf\(vanishedId, vanishedName\), why: vanishedWhy/, "no raw sid on the dismissal branch either");
+  assert.match(fn("dismissSession"), /const name = sessions\.get\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| "a session";/);
   assert.match(fn("cycleTab"), /if \(pickFirstVisibleTab\(\)\) return;/);
   assert.match(fn("onTabKey"), /if \(!activeId\) \{[^\n]*\n\s*if \(\(e\.key === "ArrowRight"[\s\S]{0,160}pickFirstVisibleTab\(\)\)/);
   assert.match(RENDER, /if \(!activeId\) \{ if \(pickFirstVisibleTab\(\)\) e\.preventDefault\(\); return; \}/, "the window arrow step");

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -34,7 +34,7 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, true),
                    { head: "No session selected. Pick a tab to start. ", name: "web", tail: " is not listed yet. It comes back here when its host does." });
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: true }, true).tail, " is not listed yet; its host is reconnecting… It comes back here when the host does.");
-  assert.deepEqual(emptyStateParts({ name: "web", why: "hidden", dialing: false }, true).tail, " is not shown by this tab view. Pick a tab, or change the view.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "gone", dialing: false }, true).tail, " is no longer available. Pick a tab.");
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, false).head, "No sessions yet. ", "an empty strip invites no pick");
   for (const p of [emptyStateParts({ name: "web", why: "hostDrop", dialing: true }, true), emptyStateParts(null, true)]) {
     assert.doesNotMatch(p.head + p.tail, /\b(card|board|goal|column|nudge)\b/, "no romp nouns in the body's line");
@@ -42,13 +42,15 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
 });
 
 test("the wiring: the dismiss branch, the unfocused body, the composer, the restore on return, no adoption meanwhile", () => {
-  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: VanishWhy \| null = null;\s*\nlet vanishedName = "";/m);
+  assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: DismissWhy \| null = null;\s*\nlet vanishedName = "";/m);
   const dismiss = fn("dismissSession");
   assert.match(dismiss, /const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;\s*\n\s*if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; \}/);
   assert.match(dismiss, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/, "the T236 note above the box still says whose box went away");
   // the pick (and the restore) end the unfocused state
-  assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null;/, "a pick ends the unfocused state AND the awaited tab");
-  assert.match(fn("setActive"), /activeId: id, activeName: liveSession\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| ""/, "the name persists beside the id for the reload's body");
+  assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null;/, "a pick ends the unfocused state AND the awaited tab");
+  assert.match(fn("setActive"), /persistActive\(id\);/, "the pick persists id and name");
+  assert.match(fn("persistActive"), /activeId: id, activeName: liveSession\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| ""/, "the name persists beside the id for the reload's body");
+  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "an adopted tab is persisted like a pick (the review's low)");
   // the empty body: pane-focus's words, the name dressed as the strip dresses it, the composer disabled and nameless
   const show = fn("showActive");
   assert.match(show, /paintEmptyState\(empty\);\s*\n\s*empty\.style\.display = "";\s*\n[\s\S]{0,200}?ta\.disabled = true; ta\.placeholder = order\.length \? "Pick a tab to start" : "Click \+ to add a session"; syncComposerPh\(\);/);
@@ -59,23 +61,29 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = named \|\| "";/, "the body names the vanished or the awaited id");
   assert.doesNotMatch(RENDER, /empty\.textContent = "No session open/, "the one writer of the empty body is paintEmptyState");
   // the return: the session frame, or the strip re-listing it; no other arrival adopts the box meanwhile
-  assert.match(RENDER, /if \(vanishedId === msg\.id\) setActive\(msg\.id\);\s*\n\s*const adopted = !activeId && !vanishedId && !wantActive;/);
+  assert.match(RENDER, /if \(vanishedId === msg\.id\) setActive\(msg\.id\);\s*\n\s*const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;/);
   assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,500}?const back = vanishedId \|\| wantActive;[^\n]*\n\s*if \(back && order\.includes\(back\)\) setActive\(back\);/);
   // the reload road (the review's HIGH): the persisted tab is awaited at boot, the body names it, nothing adopts
   assert.match(RENDER, /^let wantActiveName: string = /m);
   assert.match(fn("paintEmptyState"), /const awaited = !vanishedId && wantActive \? wantActive : null;/);
   assert.match(RENDER, /renderBgTasks\(\);\s*\n\s*\} else if \(!activeId\) \{[\s\S]{0,300}?showActive\(\);\s*\n\s*\}/, "a frame landing on an unfocused pane paints the body, adopting nothing");
   assert.match(fn("paintEmptyState"), /why: "awaited" as const, dialing: hostIsDialing\(awaited\)/);
+  assert.match(fn("paintEmptyState"), /const nameOf = \(id: string\) => wantActiveName \|\| tabMeta\.get\(id\)\?\.name \|\| "a session";/, "never a raw sid in the body");
+  assert.match(RENDER, /if \(wantActive && \(isSubId\(wantActive\) \|\| isProvisionalId\(wantActive\)\)\) \{ wantActiveGone = wantActive; wantActive = null; \}/, "an id that can never be listed again is not awaited");
+  assert.match(fn("paintEmptyState"), /gone \? \{ name: nameOf\(gone\), why: "gone" as const, dialing: false \}/);
+  assert.match(fn("applyTabOrder"), /if \(back && order\.includes\(back\)\) setActive\(back\);\s*\n\s*else if \(!activeId\) showActive\(\);/, "the strip changing under an unfocused pane repaints the body (an emptied strip included)");
   // the body repaints on the dial event; the view filter routes through the same rule; the keyboard picks the first tab
   assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); repaintEmptyStateIfUnfocused\(\); \}\);/);
   assert.match(fn("repaintEmptyStateIfUnfocused"), /if \(activeId\) return;[\s\S]*?if \(e\) paintEmptyState\(e\);/);
-  assert.match(fn("renderTabs"), /if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\);/, "the view filter never re-points at another session");
-  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)/, "…and restores the hidden tab when the view shows it again");
-  assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);
+  // the view filter: no fallback re-points the selection at all (assertPeekFor makes the excluded active tab the peek
+  // before every renderTabs, so tabInView holds for it); the old first-visible-tab fallback is gone
+  assert.doesNotMatch(fn("renderTabs"), /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab fallback");
+  assert.doesNotMatch(RENDER, /unfocusHiddenByView/, "and no route that only that fallback could reach");
+  assert.match(fn("assertPeekFor"), /const next = chatVisible\(id\) \? null : id;/, "the peek rule that covers a view excluding the active tab");
   assert.match(fn("cycleTab"), /if \(pickFirstVisibleTab\(\)\) return;/);
   assert.match(fn("onTabKey"), /if \(!activeId\) \{[^\n]*\n\s*if \(\(e\.key === "ArrowRight"[\s\S]{0,160}pickFirstVisibleTab\(\)\)/);
   assert.match(RENDER, /if \(!activeId\) \{ if \(pickFirstVisibleTab\(\)\) e\.preventDefault\(\); return; \}/, "the window arrow step");
-  assert.doesNotMatch(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) setActive\(next\); \}, 0\);/, "the old re-point is gone");
+  assert.doesNotMatch(RENDER, /setActive\(next\); \}, 0\);/, "the old re-point is gone");
   // the feed relay: showActive announces the active tab (null included) on every branch it takes
   assert.match(show, /^\s*notifyActive\(\);/m);
   assert.match(fn("notifyActive"), /vscodeApi\.postMessage\(\{ type: "activeTab", id: activeId \}\)/, "null rides as null");

--- a/ui/webview/pane-focus.ts
+++ b/ui/webview/pane-focus.ts
@@ -25,8 +25,9 @@ export function focusAfterDismiss(why: Why, mru: readonly string[], order: reado
 
 /** The session that vanished from under the user, for the empty body's line: how it left (a dismissal's reason), or
  *  "awaited" (the tab this page showed before a reload, not listed yet: a kernel restart reloads the page, so no
- *  dismissal ran and the persisted choice is all the pane has), or "hidden" (the tab view no longer shows it). */
-export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "hidden"; dialing: boolean };
+ *  dismissal ran and the persisted choice is all the pane has), or "gone" (a persisted id that can never be listed
+ *  again: a subagent viewer's tab, a provisional create). */
+export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "gone"; dialing: boolean };
 
 /** The empty body's text in three pieces, so the pane can dress the name the way the strip does (host prefix,
  *  identity colour): `head` + `name` + `tail`, `name` null when no session vanished. */
@@ -43,7 +44,7 @@ export function emptyStateParts(v: Vanished | null, hasTabs: boolean): EmptyStat
     : v.why === "omitted" ? " is no longer listed by romp. It comes back here if it returns."
     : v.why === "awaited" ? (v.dialing ? " is not listed yet; its host is reconnecting… It comes back here when the host does."
                                        : " is not listed yet. It comes back here when its host does.")
-    : v.why === "hidden" ? " is not shown by this tab view. Pick a tab, or change the view."
+    : v.why === "gone" ? " is no longer available. Pick a tab."
     : " ended.";
   // an EMPTY strip invites no pick (the review's low): the session named is all there is to say
   return { head: hasTabs ? "No session selected. Pick a tab to start. " : "No sessions yet. ", name: v.name, tail };

--- a/ui/webview/pane-focus.ts
+++ b/ui/webview/pane-focus.ts
@@ -25,9 +25,10 @@ export function focusAfterDismiss(why: Why, mru: readonly string[], order: reado
 
 /** The session that vanished from under the user, for the empty body's line: how it left (a dismissal's reason), or
  *  "awaited" (the tab this page showed before a reload, not listed yet: a kernel restart reloads the page, so no
- *  dismissal ran and the persisted choice is all the pane has), or "gone" (a persisted id that can never be listed
- *  again: a subagent viewer's tab, a provisional create). */
-export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "gone"; dialing: boolean };
+ *  dismissal ran and the persisted choice is all the pane has), "gone" (a persisted id that can never be listed
+ *  again as a tab of its own: a subagent viewer's tab, a provisional create), or "hidden" (the strip's `#only=` filter
+ *  no longer shows the active tab; the peek covers a view's exclusion, not the filter's). */
+export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "gone" | "hidden"; dialing: boolean };
 
 /** The empty body's text in three pieces, so the pane can dress the name the way the strip does (host prefix,
  *  identity colour): `head` + `name` + `tail`, `name` null when no session vanished. */
@@ -44,7 +45,8 @@ export function emptyStateParts(v: Vanished | null, hasTabs: boolean): EmptyStat
     : v.why === "omitted" ? " is no longer listed by romp. It comes back here if it returns."
     : v.why === "awaited" ? (v.dialing ? " is not listed yet; its host is reconnecting… It comes back here when the host does."
                                        : " is not listed yet. It comes back here when its host does.")
-    : v.why === "gone" ? " is no longer available. Pick a tab."
+    : v.why === "gone" ? " is no longer on the strip. Pick a tab."
+    : v.why === "hidden" ? " is not shown by this tab view. Pick a tab, or change the view."
     : " ended.";
   // an EMPTY strip invites no pick (the review's low): the session named is all there is to say
   return { head: hasTabs ? "No session selected. Pick a tab to start. " : "No sessions yet. ", name: v.name, tail };

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -46,7 +46,7 @@ test("peek AUTO-CLOSE: activating any other tab drops it — same derivation, no
   // peek mechanism (plans/subagent-transcripts.md; chatVisible() answers pinnedSubs for a viewer id).
   // 7 → 8 with the acknowledged views writes: holdViews, onViewsAck and onKernelCaps replace the
   // single postViews site.
-  assert.equal(sites.length, 9, "definition + 8 call sites: setActive, focus fast path, captureViews, holdViews, onViewsAck, onKernelCaps, the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame), and the subagent viewer's pin toggle (2026-09-05)");
+  assert.equal(sites.length, 10, "definition + 9 call sites: setActive, focus fast path, captureViews, holdViews, onViewsAck, onKernelCaps, the feed click echo (2026-08-24 — the instant ack derives the peek before the kernel frame), the subagent viewer's pin toggle (2026-09-05), and the ADOPTION of a first-arriving session (2026-09-11: a view-hidden first arrival has a tab, like a pick)");
 });
 
 test("a view change that excludes the ACTIVE session converts it into the peek — never a bounce (the user 2026-08-24)", () => {

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -60,7 +60,10 @@ test("a view change that excludes the ACTIVE session converts it into the peek �
   // the derivation is symmetric, so a view that now INCLUDES the active peek sheds the dress — the
   // same next-null branch the auto-close pin above holds; and the fallback's fire-time revalidation
   // (below) re-checks tabInView, so a converted peek can never be bounced by an in-flight timeout
-  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/, "no first-visible-tab fallback at all (T357 follow-up): the peek holds the excluded active tab");
+  // (T357: a VIEW excluding the active tab never reaches renderTabs's check, since captureViews asserts the peek before
+  // applyTabOrder on every tabOrder frame and visibility is a pure function of the views blob; the #only= filter is
+  // no peek input, so an only-filtered active tab does reach it and goes UNFOCUSED, never re-pointed)
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
 });
 
 test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands in setActive, re-deriving peek", () => {
@@ -73,10 +76,13 @@ test("the first-tab fallback never fires on an active peek: tabInView counts the
   assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| chatVisible\(id\); \}/);
   // the #only=-era bounce reads visibleIds, which is built from tabInView — an active peek is in it
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
-  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{/, "the only-filter's check on the active tab (unfocus, not a re-point)");
   // …and the DEFERRED bounce re-validates at fire time: an activation between schedule and fire
   // (the feed click that just opened this peek) makes the active tab visible — no bounce then
-  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/, "no first-visible-tab fallback at all (T357 follow-up): the peek holds the excluded active tab");
+  // (T357: a VIEW excluding the active tab never reaches renderTabs's check, since captureViews asserts the peek before
+  // applyTabOrder on every tabOrder frame and visibility is a pure function of the views blob; the #only= filter is
+  // no peek input, so an only-filtered active tab does reach it and goes UNFOCUSED, never re-pointed)
+  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
 });
 
 test("the focus fast path (already-active live jump) still re-asserts the peek — setActive is skipped there", () => {

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -60,7 +60,7 @@ test("a view change that excludes the ACTIVE session converts it into the peek �
   // the derivation is symmetric, so a view that now INCLUDES the active peek sheds the dress — the
   // same next-null branch the auto-close pin above holds; and the fallback's fire-time revalidation
   // (below) re-checks tabInView, so a converted peek can never be bounced by an in-flight timeout
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\); \}, 0\);/);
+  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/, "no first-visible-tab fallback at all (T357 follow-up): the peek holds the excluded active tab");
 });
 
 test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands in setActive, re-deriving peek", () => {
@@ -73,10 +73,10 @@ test("the first-tab fallback never fires on an active peek: tabInView counts the
   assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| chatVisible\(id\); \}/);
   // the #only=-era bounce reads visibleIds, which is built from tabInView — an active peek is in it
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
-  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
+  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
   // …and the DEFERRED bounce re-validates at fire time: an activation between schedule and fire
   // (the feed click that just opened this peek) makes the active tab visible — no bounce then
-  assert.match(RENDER, /setTimeout\(\(\) => \{ if \(activeId !== next && activeId && !tabInView\(activeId\)\) unfocusHiddenByView\(activeId\); \}, 0\);/);
+  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/, "no first-visible-tab fallback at all (T357 follow-up): the peek holds the excluded active tab");
 });
 
 test("the focus fast path (already-active live jump) still re-asserts the peek — setActive is skipped there", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1020,10 +1020,8 @@ let activeId: string | null = null;
 // read vanishedId). Only the user's own ✕ keeps the recency fallback, and only a pick by the user moves focus
 // (setActive clears these). pane-focus.ts holds the rule and the words.
 let vanishedId: string | null = null;
-let vanishedWhy: VanishWhy | null = null;
+let vanishedWhy: DismissWhy | null = null;
 let vanishedName = "";
-/** why the pane is unfocused: a dismissal's reason, or "hidden" (the tab view stopped showing the active tab) */
-type VanishWhy = DismissWhy | "hidden";
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
 // The SESSION whose transcript DOM is being built — the id preview/image URLs must bake in, host prefix
 // included. Distinct from renderingSid, which is a fold KEY the comment popover retargets to its thread id.
@@ -1050,6 +1048,19 @@ let wantActive: string | null = (() => { try { return ((vscodeApi?.getState?.() 
 // arrives (its frame, or the strip re-listing it), and clears the wait when the user picks another tab (setActive). A
 // session that never returns leaves the body standing until a pick: no timer.
 let wantActiveName: string = (() => { try { return String(((vscodeApi?.getState?.() || {}) as any).activeName || ""); } catch { return ""; } })();
+// A persisted id that can never be listed again (a subagent viewer's tab, a provisional create) is not awaited: the
+// body says it is gone and invites a pick (the review's low). A session that ended while the page was away is not
+// knowable up front: it is awaited like any other, and the body stands until a pick.
+let wantActiveGone: string | null = null;
+if (wantActive && (isSubId(wantActive) || isProvisionalId(wantActive))) { wantActiveGone = wantActive; wantActive = null; }
+/** The persisted choice this page restores after a reload: the id and the name the body can show before the strip
+ *  knows it. Written by every activation, a pick or an adoption alike (the review's low: an adopted tab was never
+ *  persisted, so a restart still landed elsewhere). */
+function persistActive(id: string): void {
+  try {
+    vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id, activeName: liveSession(id)?.name || tabMeta.get(id)?.name || "" });
+  } catch { /* ignore */ }
+}
 let pendingAnchor: string | null = null; // deep-link target waiting to be scrolled to
 let pendingAnchorIntent: string | null = null; // kind the uuid anchor must honor — sticks with pendingAnchor across render-pass retries (pendingAnchorKind is cleared each pass, this isn't)
 let pendingAnchorT: number | null = null; // time fallback (epoch s) when the uuid can't resolve
@@ -5491,6 +5502,7 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   // skeleton branch of showActive asks for its frame. Another session's tab appearing does nothing here.
   const back = vanishedId || wantActive;   // …or the tab this page showed before a reload, awaited since boot
   if (back && order.includes(back)) setActive(back);
+  else if (!activeId) showActive();   // the strip changed under an unfocused pane (it may have emptied): the body's line and the box's placeholder follow it (the review's low)
   renderTabs();
 }
 // The tabOrder frame's `skeleton` list (2026-09-07): the tabs the kernel is withholding from this page after a
@@ -6257,19 +6269,10 @@ function renderTabs() {
   // found while shooting the demo, with nimbus's transcript filling a "filtered" frame. Re-point the
   // selection at the first visible session. Deferred so we never re-enter the render we're inside;
   // setActive is a no-op once activeId is visible, so this settles in one pass.
-  if (activeId && ids.includes(activeId) && !visibleIds.includes(activeId) && visibleIds.length) {
-    const next = visibleIds[0];
-    // re-validate at FIRE time, not schedule time: an activation between the two (a feed click
-    // opening an ephemeral peek, a reveal landing) can have made the active tab visible — bouncing
-    // then would kick the user off the very tab they just opened (the no-flap rule)
-    // …but never at ANOTHER session on the pane's own initiative (T357): the pane goes unfocused, naming the tab the
-    // view no longer shows, and comes back to it below when the view shows it again
-    setTimeout(() => { if (activeId !== next && activeId && !tabInView(activeId)) unfocusHiddenByView(activeId); }, 0);
-  }
-  if (!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds.includes(vanishedId)) {
-    const back = vanishedId;
-    setTimeout(() => { if (!activeId && vanishedId === back && tabInView(back)) setActive(back); }, 0);
-  }
+  // (No fallback re-points the selection when the view excludes the active tab: assertPeekFor runs before every
+  // renderTabs and makes the excluded active tab the PEEK, so tabInView holds for it and it stays on the strip; the
+  // pane never jumps to another session on its own (T357). The old first-visible-tab fallback was unreachable for
+  // the same reason and is gone with the route that replaced it.)
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
   // header per tag in tagOrder holding a visible tab, each tab under EVERY tag it carries (T264b, the
@@ -11937,10 +11940,15 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 // the strip dresses it (host prefix, identity colour), "reconnecting" when its host is dialing; or the plain invitation.
 function paintEmptyState(empty: HTMLElement): void {
   const awaited = !vanishedId && wantActive ? wantActive : null;   // the persisted tab, not listed yet after a reload
-  const named = vanishedId || awaited;
+  const gone = !vanishedId && !awaited && wantActiveGone ? wantActiveGone : null;   // a persisted id that can never be listed again
+  const named = vanishedId || awaited || gone;
+  // a name over a raw sid: the persisted one, the strip's last known, else "a session" (a page whose persisted state
+  // predates the name has none; the review's low)
+  const nameOf = (id: string) => wantActiveName || tabMeta.get(id)?.name || "a session";
   const v = vanishedId && vanishedWhy && vanishedWhy !== "close"
     ? { name: vanishedName || tabMeta.get(vanishedId)?.name || vanishedId, why: vanishedWhy, dialing: hostIsDialing(vanishedId) }
-    : awaited ? { name: wantActiveName || tabMeta.get(awaited)?.name || awaited, why: "awaited" as const, dialing: hostIsDialing(awaited) }
+    : awaited ? { name: nameOf(awaited), why: "awaited" as const, dialing: hostIsDialing(awaited) }
+    : gone ? { name: nameOf(gone), why: "gone" as const, dialing: false }
     : null;
   const parts = emptyStateParts(v, order.length > 0);
   empty.replaceChildren(document.createTextNode(parts.head));
@@ -11964,17 +11972,6 @@ function repaintEmptyStateIfUnfocused(): void {
   if (e) paintEmptyState(e);
 }
 
-// The tab VIEW stopped showing the active tab (a tag the view selects on was removed; T357, the review): the same
-// rule as a dismissal — the pane goes UNFOCUSED naming the session the view no longer shows, and never re-points
-// itself at another session. renderTabs restores it when the view shows it again.
-function unfocusHiddenByView(id: string): void {
-  if (activeId !== id) return;
-  stashActiveDraft(id);
-  activeId = null; vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || id;
-  loadComposerFor(null);
-  renderTabs();
-  showActive();
-}
 /** From the unfocused pane a keyboard step lands on the first visible tab: a user gesture, allowed (the review's medium:
  *  the cycle and the arrows returned early on no active tab, silently). */
 function pickFirstVisibleTab(): boolean {
@@ -16148,11 +16145,9 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     clearSeek();
   }
   activeId = id;
-  vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null;   // any activation ends the unfocused state, the awaited tab included (T357)
+  vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null;   // any activation ends the unfocused state, the awaited tab included (T357)
   updateLivePaused();   // the entering tab's own detached state shows or hides the strip (round 2, item 7)
-  try {   // the name rides beside the id: after a reload the unfocused body names the awaited tab before its host relays (T357)
-    vscodeApi?.setState?.({ ...(vscodeApi.getState?.() || {}), activeId: id, activeName: liveSession(id)?.name || tabMeta.get(id)?.name || "" });
-  } catch { /* ignore */ }
+  persistActive(id);   // the name rides beside the id: after a reload the unfocused body names the awaited tab before its host relays (T357)
   renderTabs();
   showActive();
   schedulePrebuild(); // warm the OTHER tabs in idle (MRU-first) so the next switch is instant
@@ -16319,8 +16314,8 @@ function upsert(msg: any) {
   // T357: the session the user was on is back (its host re-attached, the relay redialed) → its focus is restored;
   // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
   if (vanishedId === msg.id) setActive(msg.id);
-  const adopted = !activeId && !vanishedId && !wantActive;   // …nor while the persisted tab is still awaited after a reload (T357)
-  if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); }   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
+  const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357)
+  if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again (the review's low)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1020,8 +1020,10 @@ let activeId: string | null = null;
 // read vanishedId). Only the user's own ✕ keeps the recency fallback, and only a pick by the user moves focus
 // (setActive clears these). pane-focus.ts holds the rule and the words.
 let vanishedId: string | null = null;
-let vanishedWhy: DismissWhy | null = null;
+let vanishedWhy: VanishWhy | null = null;
 let vanishedName = "";
+/** why the pane is unfocused: a dismissal's reason, or "hidden" (the strip's #only= filter stopped showing the active tab) */
+type VanishWhy = DismissWhy | "hidden";
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
 // The SESSION whose transcript DOM is being built — the id preview/image URLs must bake in, host prefix
 // included. Distinct from renderingSid, which is a fold KEY the comment popover retargets to its thread id.
@@ -6266,13 +6268,21 @@ function renderTabs() {
   // ...and it must govern the CHAT BODY too, not just the bar (the user 2026-07-16). Hiding a
   // non-matching TAB while its transcript keeps rendering leaks precisely what the filter exists to
   // hide: a real session's chat sitting on screen under `#only=api,tests,web`, statusline and all —
-  // found while shooting the demo, with nimbus's transcript filling a "filtered" frame. Re-point the
-  // selection at the first visible session. Deferred so we never re-enter the render we're inside;
-  // setActive is a no-op once activeId is visible, so this settles in one pass.
-  // (No fallback re-points the selection when the view excludes the active tab: assertPeekFor runs before every
-  // renderTabs and makes the excluded active tab the PEEK, so tabInView holds for it and it stays on the strip; the
-  // pane never jumps to another session on its own (T357). The old first-visible-tab fallback was unreachable for
-  // the same reason and is gone with the route that replaced it.)
+  // found while shooting the demo, with nimbus's transcript filling a "filtered" frame.
+  // WHICH filter needs this: visibility is a pure function of the views blob, and captureViews asserts the active
+  // tab's peek before applyTabOrder on every tabOrder frame, so a VIEW that excludes the active tab never reaches
+  // here (the peek keeps it in tabInView). The `#only=` filter is not a peek input: it is applied on top of tabInView
+  // right above, so an only-filtered active tab does reach here. The pane then goes UNFOCUSED naming the hidden tab
+  // (T357: never re-pointed at another session); the check at fire time reads the same predicate visibleIds does
+  // (stripShows), and the tab comes back below when the filter shows it again.
+  if (activeId && ids.includes(activeId) && !visibleIds.includes(activeId)) {
+    const hid = activeId;
+    setTimeout(() => { if (activeId === hid && !stripShows(hid)) unfocusHiddenByView(hid); }, 0);
+  }
+  if (!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds.includes(vanishedId)) {
+    const back = vanishedId;
+    setTimeout(() => { if (!activeId && vanishedId === back && stripShows(back)) setActive(back); }, 0);
+  }
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
   // header per tag in tagOrder holding a visible tab, each tab under EVERY tag it carries (T264b, the
@@ -11938,15 +11948,35 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 // no DOM left to capture from and the emptied box no longer overflows. undefined = capture here.
 // The empty body's line (pane-focus.ts emptyStateParts, T357): which session vanished and why, its name dressed the way
 // the strip dresses it (host prefix, identity colour), "reconnecting" when its host is dialing; or the plain invitation.
+/** Does the strip show `id` right now: in the tab view (a peek counts) AND matching the `#only=` filter — the one
+ *  predicate renderTabs's visibleIds is built from, read again at fire time so a deferred check judges the strip as
+ *  it is, not as it was scheduled. */
+function stripShows(id: string): boolean {
+  if (!tabInView(id)) return false;
+  const only = onlyTag();
+  return !only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only);
+}
+// The strip's #only= filter stopped showing the active tab (T357, the review's probe: web persisted, `#only=api`, a
+// reload): the same rule as a dismissal — the pane goes UNFOCUSED naming the session the filter hides, its transcript
+// leaves the screen, and it never re-points itself at another session. renderTabs restores it when the filter shows
+// it again.
+function unfocusHiddenByView(id: string): void {
+  if (activeId !== id) return;
+  stashActiveDraft(id);
+  activeId = null; vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || "";
+  loadComposerFor(null);
+  renderTabs();
+  showActive();
+}
 function paintEmptyState(empty: HTMLElement): void {
   const awaited = !vanishedId && wantActive ? wantActive : null;   // the persisted tab, not listed yet after a reload
   const gone = !vanishedId && !awaited && wantActiveGone ? wantActiveGone : null;   // a persisted id that can never be listed again
   const named = vanishedId || awaited || gone;
-  // a name over a raw sid: the persisted one, the strip's last known, else "a session" (a page whose persisted state
-  // predates the name has none; the review's low)
-  const nameOf = (id: string) => wantActiveName || tabMeta.get(id)?.name || "a session";
+  // a name over a raw sid on EVERY branch: the name carried, the persisted one, the strip's last known, else "a
+  // session" (the review's low: the dismissal branch fell to the id)
+  const nameOf = (id: string, carried = "") => carried || wantActiveName || tabMeta.get(id)?.name || sessions.get(id)?.name || "a session";
   const v = vanishedId && vanishedWhy && vanishedWhy !== "close"
-    ? { name: vanishedName || tabMeta.get(vanishedId)?.name || vanishedId, why: vanishedWhy, dialing: hostIsDialing(vanishedId) }
+    ? { name: nameOf(vanishedId, vanishedName), why: vanishedWhy, dialing: hostIsDialing(vanishedId) }
     : awaited ? { name: nameOf(awaited), why: "awaited" as const, dialing: hostIsDialing(awaited) }
     : gone ? { name: nameOf(gone), why: "gone" as const, dialing: false }
     : null;
@@ -16315,7 +16345,7 @@ function upsert(msg: any) {
   // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
   if (vanishedId === msg.id) setActive(msg.id);
   const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357)
-  if (adopted) { activeId = msg.id; loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again (the review's low)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
+  if (adopted) { activeId = msg.id; assertPeekFor(msg.id); loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again; the peek asserted like a pick's, so a view-hidden first arrival has a tab (the review's lows)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork
@@ -16920,7 +16950,7 @@ function flashComposerNote(): void {
 function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string>): void {
   if (peekId === id) peekId = null;   // its tab is going — the peek goes with it
   const wasActive = activeId === id;
-  const name = sessions.get(id)?.name || tabMeta.get(id)?.name || id;   // read before the maps forget it
+  const name = sessions.get(id)?.name || tabMeta.get(id)?.name || "a session";   // read before the maps forget it; never a raw sid in a line the user reads (T357)
   if (wasActive) stashActiveDraft(id);   // FIRST: what is on screen belongs to this id, whatever happens next
   sessions.delete(id);
   onDismiss(skeletonTabs, id);   // a tab that left the strip (✕, the kernel's omission, a host drop) has nothing left to load (2026-09-07)

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -65,11 +65,13 @@ test("the tabOrder frame carries the blob and the strip filters on it, composing
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
-  // no active-tab re-point any more (T357 follow-up): assertPeekFor runs before every renderTabs and makes an active
-  // tab either filter excludes the PEEK, so it stays on the strip and the pane never re-points itself at another
-  // session; the old first-visible-tab fallback was unreachable for that reason and is gone
-  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  // the active tab under BOTH filters (T357): a VIEW that excludes it is covered by the peek, asserted by
+  // captureViews before applyTabOrder on every tabOrder frame (visibility is a pure function of the views blob); the
+  // #only= filter is applied on top of tabInView and is no peek input, so an only-filtered active tab reaches the
+  // check below and the pane goes UNFOCUSED naming it, never re-pointed at another session
+  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{/);
   assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| chatVisible\(id\); \}/);
+  assert.match(RENDER, /captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(/, "the peek is asserted before the strip is applied, on every tabOrder frame");
 });
 
 test("every cycling path walks the VISIBLE order — keyboard can never land on a hidden session", () => {

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -65,9 +65,11 @@ test("the tabOrder frame carries the blob and the strip filters on it, composing
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
   assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
-  // the active-tab re-point covers BOTH filters — but only for a session that still EXISTS: a
-  // torn-down session's reselect belongs to the teardown path's MRU logic, not to us
-  assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\) \{/);
+  // no active-tab re-point any more (T357 follow-up): assertPeekFor runs before every renderTabs and makes an active
+  // tab either filter excludes the PEEK, so it stays on the strip and the pane never re-points itself at another
+  // session; the old first-visible-tab fallback was unreachable for that reason and is gone
+  assert.doesNotMatch(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\) && visibleIds\.length\)/);
+  assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| chatVisible\(id\); \}/);
 });
 
 test("every cycling path walks the VISIBLE order — keyboard can never land on a hidden session", () => {


### PR DESCRIPTION
The review's five lows on the unfocused pane (the follow-up the manager asked for after that PR's verdict).

- **An emptied strip repaints**: the strip changing under an unfocused pane calls the body's paint, so the line and the box's placeholder follow (an emptied strip says "No sessions yet.").
- **An id that can never return says so**: a persisted subagent viewer tab or provisional create is not awaited; the body names it as no longer available and invites a pick. A session that ended while the page was away is awaited until a pick, as documented.
- **No raw sid in the body**: the persisted name, else the strip's last known, else "a session".
- **The two filters, told apart**: a tab view excluding the active tab is covered by the peek (asserted before the strip is applied on every tabOrder frame; visibility is a pure function of the views blob), but the `#only=` filter is applied on top of it and is no peek input: an only-filtered active tab kept its transcript on screen with no tab active (the review's probe). It now goes unfocused through the same rule, the fire-time check reading the predicate the strip is built from, and comes back when the filter shows it again; never a re-point. The pins say the invariant that holds.
- **From the review**: an adoption asserts the peek like a pick; no raw sid in the body on any branch; the lab root writes its session-hosts off; "no longer on the strip" for an id that cannot be a tab again.
- **An adopted tab persists like a pick** (`persistActive`, shared with `setActive`), so a restart lands on it again.

Tests: `pane-focus.test.ts`, the re-pointed `only-filter` and `peek-tab` pins, and four new roads in the served lab (adopted tab persisted, nameless seed, emptied strip, provisional id gone).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
