### PR TITLE
A comment thread's mail-off rule, the last three lows: the CLI judges every closed door, the kernel reads an unreadable record as held, the frame's comment says what the popover shows (T356 second follow-up)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14316,8 +14316,9 @@ def _comments_frame(sid, live_map=None):
                         "lastUuid": last_uuid,                         # the newest record shown/held — the client's cap-proof "transcript moved" datum
                         "unreachable": unreachable or None,            # a broken thread (missing transcript / lost cut): owes nothing
                         "promotedName": th.get("promotedName") or "",
-                        # the thread's mail state (T356): off by default until broken out; the popover says so, and how
-                        # many messages wait in its box (they land within the bus's retry interval of a break-out)
+                        # the thread's mail state (T356): off by default until broken out. The popover does not announce
+                        # it (the user 2026-09-11; the tab hover and the Sessions pane carry the state); it shows only how
+                        # many messages wait in the box (they land within the bus's retry interval of a break-out)
                         "mailOff": bool(_postal_isolated(tsid)),
                         "heldMail": _held_mail_count(tsid),
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
@@ -22948,7 +22949,7 @@ def _thread_rows():
                     # a thread's mail is off until the user breaks it out (T356): the row says so, so a listing
                     # consumer never has to derive it
                     "postalServiceOff": _postal_isolated(tsid),
-                    "mailOffWhy": "thread" if _thread_mail_off(tsid) else ""})
+                    "mailOffWhy": _mail_off_why_k(tsid)})
     return out
 
 
@@ -23553,10 +23554,36 @@ def _thread_mail_off(sid):
     return not (isinstance(f, dict) and f.get("threadMail") is True)
 
 
+def _reg_unreadable(sid):
+    """Does `sid`'s durable record exist but defy reading (corrupt, or a directory the kernel cannot stat)? The bus
+    holds every message for such a session (its _mail_off_why answers "unreadable"), so the kernel must not paint
+    mail as on for it (the review's low: _thread_reg answers {} for missing and unreadable alike). No record → False."""
+    if not sid:
+        return False
+    p = jd.STATE / "sdk" / (str(sid) + ".json")
+    try:
+        if not p.exists():
+            return False
+        return not isinstance(json.loads(p.read_text()), dict)
+    except (OSError, ValueError):
+        return True
+
+
+def _mail_off_why_k(sid):
+    """Why the session can neither send nor receive mail, the kernel's twin of the bus's _mail_off_why over the same
+    two files: "unreadable" (its record cannot be read: the bus holds everything), "thread" (a comment thread not yet
+    broken out, _thread_mail_off), "isolation" (the mailbox flag the timeline lane's icon writes, legacy key included),
+    or "" (mail on). Rides the rows as mailOffWhy so the tab hover and the Sessions pane can say which."""
+    if _reg_unreadable(sid):
+        return "unreadable"
+    if _thread_mail_off(sid):
+        return "thread"
+    return "isolation" if (_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff")) else ""
+
+
 def _postal_isolated(sid):
-    """The session's EFFECTIVE postal isolation: a comment thread whose mail is off (_thread_mail_off), else the
-    mailbox flag the timeline lane's icon writes, legacy key included."""
-    return _thread_mail_off(sid) or bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))
+    """The session's EFFECTIVE postal isolation: any closed door of _mail_off_why_k."""
+    return bool(_mail_off_why_k(sid))
 
 
 _FOLLOWUP_GOAL_RE = re.compile(r"romp-goal-id:\s*([^\s>]+)")
@@ -33781,6 +33808,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
             # the timeline lane's feed checkbox + postal mailbox. Same flags + legacy fallback as build_timeline.
             "hideFromFeed": _session_flag(sid, "hideFromFeed"),
             "postalServiceOff": _postal_isolated(sid),    # EFFECTIVE: a comment thread reads off until broken out (T356)
+            "mailOffWhy": _mail_off_why_k(sid),             # …and why (thread, isolation, an unreadable record), for the tab hover's words
             "notify": _notify_session_effective(sid),   # session-level bell, EFFECTIVE (override, else the master default): OS notification when its work blocks on you / completes (the user 2026-07-28)
             # NEVER `now`. This rides the chat payload, and _send_client dedups by comparing the
             # SERIALIZED payload against what that client last received — so a firstSeen that ticked
@@ -44810,6 +44838,7 @@ def _push(targets, connect=False, live_map=None):
                 feed["ledgers"] = [{"sid": m["id"], "name": m["name"], "color": m.get("color"),
                                     "status": m.get("status"),
                                     "postalServiceOff": _postal_isolated(m["id"]),   # the Sessions pane shows a mail-off session (T356)
+                                    "mailOffWhy": _mail_off_why_k(m["id"]),
                                     # attach the archived-completed TOP tasks so the Fleet's "Show completed"
                                     # can surface a finished+archived session (the user 2026-06-27); cached, so
                                     # ~free. The client renders them only when the toggle is on.

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -1248,6 +1248,11 @@ def _postal_off(sid):
     can't send, and can't receive."""
     return bool(_mail_off_why(sid))
 
+ISOLATION_SENDER = ("isolation: YOUR OWN mailbox is OFF. This session is in postal isolation (its mailbox icon is toggled off "
+                    "on its timeline lane), so it can't send OR receive any mail. This is NOT the recipient's mailbox — the "
+                    "recipient is fine; nothing was sent. To fix, ask the USER to toggle THIS session's mailbox back on in "
+                    "the timeline, then retry. When you relay this, say it's YOUR mailbox that's off, not theirs.")
+
 UNREADABLE_REG_SENDER = ("isolation: YOUR OWN mail is held because this session's record (its entry under the kernel's sdk/ "
                          "directory) cannot be read, so the bus cannot tell what kind of session this is. Mail to and from it is "
                          "held until the record is repaired. Nothing was sent, and this is final: do not route around it. Tell "
@@ -2411,12 +2416,7 @@ class Handler(BaseHTTPRequestHandler):
             if why_off == "unreadable":            # its own words: never the thread diagnosis for a corrupt record
                 return self._send({"error": UNREADABLE_REG_SENDER}, 403)
             if why_off:                            # the sender is in isolation → sending is disabled
-                return self._send({"error": "isolation: YOUR OWN mailbox is OFF. This session is in postal "
-                                   "isolation (its mailbox icon is toggled off on its timeline lane), so it "
-                                   "can't send OR receive any mail. This is NOT the recipient's mailbox — the "
-                                   "recipient is fine; nothing was sent. To fix, ask the USER to toggle THIS "
-                                   "session's mailbox back on in the timeline, then retry. When you relay this, "
-                                   "say it's YOUR mailbox that's off, not theirs."}, 403)
+                return self._send({"error": ISOLATION_SENDER}, 403)
             # ONE resolution step for every case (self, ambiguous, isolated, relayed, unknown) —
             # see resolve_recipient. A name that answers to more than one live session is refused
             # here, not tiebroken.
@@ -5022,10 +5022,11 @@ def cli_send(argv):
         sys.stderr.write("[romp mail] %s\n" % _unreachable_hint()); return 1
     mid, me = _self_identity()
     own = _mail_off_why(mid) if mid else ""
-    if own in ("thread", "unreadable"):
-        # the CALLER's own identity is judged before any --from label substitutes a synthetic one (the review's low
-        # on this change: --from was a door around the thread's own-send refusal, the incident's shape)
-        sys.stderr.write("[romp mail] %s\n" % (THREAD_MAIL_OFF_SENDER if own == "thread" else UNREADABLE_REG_SENDER))
+    if own:
+        # the CALLER's own identity is judged before any --from label substitutes a synthetic one, for every closed
+        # door (the review: --from was a door around the thread's own-send refusal, the incident's shape; then around
+        # a mailbox the user toggled off too)
+        sys.stderr.write("[romp mail] %s\n" % {"thread": THREAD_MAIL_OFF_SENDER, "unreadable": UNREADABLE_REG_SENDER}.get(own, ISOLATION_SENDER))
         return 1
     if frm_label:
         me, mid = frm_label, "ext:" + frm_label

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -149,6 +149,7 @@ CENSUS = {
     "_session_cwd": ("sig", "cwd", "the names entry's cwd, else the transcript's stamp"),
     "_session_flag": ("sig", "flags"),
     "_postal_isolated": ("sig", "flags", "the effective mail state: the mailbox flag with its legacy twin (flags), and a comment thread's default read from its reg's threadOf through _thread_reg (reg) (T356)"),
+    "_mail_off_why_k": ("sig", "flags", "the reason behind _postal_isolated: the record's readability and threadOf (reg), then the mailbox flag with its legacy twin (flags) (T356)"),
     "_session_meta": ("pure", "over the transcript's records, memoized by record identity (transcript)"),
     "_session_retry_suppressed": ("sig", "retry"),
     "_session_working": ("sig", "downtime", "over the turns, and the host suspensions recorded since boot"),

--- a/tests/test_kernel_tab_flags.py
+++ b/tests/test_kernel_tab_flags.py
@@ -27,7 +27,7 @@ class TabFlags(unittest.TestCase):
         self.assertIn('"postalServiceOff": _postal_isolated(sid)', src,
                       "the EFFECTIVE state, like build_timeline: canonical postalServiceOff with the legacy postalOff fallback "
                       "(_postal_isolated), and a comment thread's mail-off default (T356)")
-        self.assertIn('or bool(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))', inspect.getsource(km._postal_isolated),
+        self.assertIn('(_session_flag(sid, "postalServiceOff") or _session_flag(sid, "postalOff"))', inspect.getsource(km._mail_off_why_k),
                       "the legacy fallback lives in the one reader")
 
     def test_kernel_handles_a_chat_side_setSessionFlag(self):

--- a/tests/test_postal_isolation.py
+++ b/tests/test_postal_isolation.py
@@ -349,5 +349,34 @@ class ThreadMailOffFollowUp(unittest.TestCase):
         _flags({SENDER: {"postalServiceOff": True}})
         self.assertEqual(pm._isolated_bounce_why([{"id": SENDER, "name": "api"}], "api"), "recipient 'api' has its mailbox off (postal isolation)")
 
+
+class CliJudgesIsolationToo(unittest.TestCase):
+    """`romp mail send --from <label>` judged the caller for the thread and unreadable doors only; a mailbox the user
+    toggled OFF fell through (the review's low). Every closed door now stops the CLI before any label applies."""
+
+    def tearDown(self):
+        try:
+            pm.SESSION_FLAGS.unlink()
+        except OSError:
+            pass
+
+    def test_an_isolated_caller_is_stopped_with_the_isolation_words_with_and_without_from(self):
+        _flags({SENDER: {"postalServiceOff": True}})
+        import io
+        saved = (pm._self_identity, pm.ensure, pm._http)
+        calls = []
+        try:
+            pm._self_identity = lambda: (SENDER, "api"); pm.ensure = lambda: True; pm._http = lambda *a, **k: calls.append(a) or {}
+            err = io.StringIO(); real = sys.stderr; sys.stderr = err
+            try:
+                rc1 = pm.cli_send(["web", "a note"]); rc2 = pm.cli_send(["--from", "nightly", "web", "a note"])
+            finally:
+                sys.stderr = real
+            self.assertEqual((rc1, rc2), (1, 1)); self.assertEqual(calls, [], "nothing reached the bus")
+            self.assertEqual(err.getvalue().count("YOUR OWN mailbox is OFF"), 2); self.assertNotIn("COMMENT THREAD", err.getvalue())
+            self.assertEqual(pm.ISOLATION_SENDER, pm.ISOLATION_SENDER.strip()); self.assertIn("isolation:", pm.ISOLATION_SENDER)
+        finally:
+            pm._self_identity, pm.ensure, pm._http = saved
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_thread_mail_off.py
+++ b/tests/test_thread_mail_off.py
@@ -86,7 +86,7 @@ class ThreadMailOff(unittest.TestCase):
         src = inspect.getsource(km._comments_frame)
         self.assertIn('"mailOff": bool(_postal_isolated(tsid))', src)
         rows = inspect.getsource(km._thread_rows)
-        self.assertIn('"postalServiceOff": _postal_isolated(tsid)', rows); self.assertIn('"mailOffWhy": "thread" if _thread_mail_off(tsid) else ""', rows)
+        self.assertIn('"postalServiceOff": _postal_isolated(tsid)', rows); self.assertIn('"mailOffWhy": _mail_off_why_k(tsid)', rows)
         whole = Path(os.path.join(BIN, "romp-kernel")).read_text()
         self.assertEqual(whole.count('"postalServiceOff": _postal_isolated('), 4, "chat rows, timeline lanes, thread rows, Sessions pane rows")
         self.assertNotIn('"postalServiceOff": _session_flag(sid, "postalServiceOff")', whole, "no row reads the raw flag past the effective reader")
@@ -106,6 +106,32 @@ class HeldMail(unittest.TestCase):
             (box / ("m%d" % i)).write_text("From: peer\n\nhello\n")
         self.assertEqual(km._held_mail_count(THREAD), 3)
         self.assertIn('"heldMail": _held_mail_count(tsid)', inspect.getsource(km._comments_frame), "the frame carries it beside mailOff")
+
+
+class UnreadableRecordOnTheKernelSide(unittest.TestCase):
+    """The bus holds every message for a session whose record cannot be read; the kernel must not paint mail as on for
+    it (the review's low): the same closed door, with its own reason on the rows."""
+
+    def setUp(self):
+        self.td = tempfile.mkdtemp(); self.saved = km.jd.STATE; km.jd._rebind_state(Path(self.td)); km._thread_reg_memo.clear()
+        (Path(self.td) / "sdk").mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        km.jd._rebind_state(self.saved); km._thread_reg_memo.clear(); shutil.rmtree(self.td, ignore_errors=True)
+
+    def test_the_kernel_derives_unreadable_thread_and_isolation_with_their_reasons(self):
+        self.assertEqual(km._mail_off_why_k(PLAIN), "", "no record: an ordinary session, mail on")
+        (Path(self.td) / "sdk" / (PLAIN + ".json")).write_text("{corrupt")
+        self.assertTrue(km._reg_unreadable(PLAIN)); self.assertEqual(km._mail_off_why_k(PLAIN), "unreadable"); self.assertTrue(km._postal_isolated(PLAIN))
+        (Path(self.td) / "sdk" / (PLAIN + ".json")).write_text(json.dumps(["not", "a", "dict"]))
+        self.assertEqual(km._mail_off_why_k(PLAIN), "unreadable", "…whatever shape the corruption takes")
+        (Path(self.td) / "sdk" / (THREAD + ".json")).write_text(json.dumps({"sid": THREAD, "threadOf": PARENT, "alive": True}))
+        self.assertEqual(km._mail_off_why_k(THREAD), "thread")
+        (Path(self.td) / "sdk" / (PARENT + ".json")).write_text(json.dumps({"sid": PARENT, "alive": True}))
+        (Path(self.td) / "session-flags.json").write_text(json.dumps({PARENT: {"postalOff": True}}))
+        self.assertEqual(km._mail_off_why_k(PARENT), "isolation", "the legacy key still isolates, under its reason")
+        whole = Path(os.path.join(BIN, "romp-kernel")).read_text()
+        self.assertEqual(whole.count('"mailOffWhy": _mail_off_why_k('), 3, "chat rows, thread rows, Sessions pane rows carry the reason")
 
 
 if __name__ == "__main__":

--- a/ui/webview/fleet.ts
+++ b/ui/webview/fleet.ts
@@ -35,7 +35,7 @@ interface LedgerNode {
 }
 interface Ledger { summary?: string; tree: LedgerNode[]; current?: { t?: number } | null; archivedTops?: LedgerNode[]; }
 interface FleetSession { sid: string; name: string; color: Color; status?: { state?: string } | null; ledger?: Ledger | null;
-                         postalServiceOff?: boolean; }   // the session's mail is off (isolation, or a comment thread's default; T356)
+                         postalServiceOff?: boolean; mailOffWhy?: string; }   // the session's mail is off, and why (isolation, a comment thread's default, an unreadable record; T356)
 
 const vscodeApi =
   typeof (window as any).acquireVsCodeApi === "function" ? (window as any).acquireVsCodeApi() : undefined;
@@ -606,8 +606,10 @@ function render() {
       if (s.postalServiceOff) {
         // T356: a session whose mail is off says so on its row, quietly
         const mo = el("span", "fl-mail-off");
-        mo.textContent = "mail off";
-        mo.title = "this session neither sends nor receives peer mail";
+        mo.textContent = s.mailOffWhy === "unreadable" ? "mail held" : "mail off";
+        mo.title = s.mailOffWhy === "unreadable" ? "this session's record cannot be read: mail waits until it is repaired"
+          : s.mailOffWhy === "thread" ? "a comment thread's mail is off until it is broken out"
+          : "this session neither sends nor receives peer mail";
         head.appendChild(mo);
       }
       head.title = "Open this session";

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -330,7 +330,7 @@ interface BgTasks { count: number; tasks: BgTask[]; }
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; githubRepo?: string | null; headFrom?: number; headTotal?: number | null; proto?: number; headKnown?: boolean; firstUuid?: string | null; lastUuid?: string | null; detached?: boolean; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; githubRepo?: string | null; headFrom?: number; headTotal?: number | null; proto?: number; headKnown?: boolean; firstUuid?: string | null; lastUuid?: string | null; detached?: boolean; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; mailOffWhy?: string; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
 // A SUBAGENT VIEWER pseudo-session (plans/subagent-transcripts.md): a read-only tab whose events are one
 // agent's own transcript, fed by {type:"subagent"} frames. Client-only — the kernel never lists it in
 // tabOrder (reconcileTabOrder keeps a known, never-kernel-seen id), so it lives exactly as long as the
@@ -5640,7 +5640,10 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
   if (be) rows.push(["Backend", backendLabel(be)]);
   // the session's mail state (T356): off means peers cannot see or mail it and its own sends are refused
-  rows.push(["Mail", s.postalServiceOff ? "off: this session neither sends nor receives peer mail" : "on"]);   // the shared names (T288); a session still running on the retired terminal backend (until stage 3) reads its id, never blank (review find)
+  rows.push(["Mail", !s.postalServiceOff ? "on"
+    : s.mailOffWhy === "unreadable" ? "held: this session's record cannot be read, so mail waits until it is repaired"
+    : s.mailOffWhy === "thread" ? "off until the thread is broken out"
+    : "off: this session neither sends nor receives peer mail"]);   // the shared names (T288); a session still running on the retired terminal backend (until stage 3) reads its id, never blank (review find)
   // Billing: whether this tab bills the API key or the Claude login — and WHICH login account (the
   // user 2026-08-09: shown whenever the backend reports it, one-auth machines included). No key material, ever.
   // When the CLI's own init landed on the OTHER side (authLive — say, a key found via apiKeyHelper
@@ -16258,6 +16261,7 @@ function upsert(msg: any) {
     bgTasks: ("bgTasks" in msg) ? msg.bgTasks : (prev ? prev.bgTasks : undefined),
     hideFromFeed: ("hideFromFeed" in msg) ? !!msg.hideFromFeed : (prev ? prev.hideFromFeed : undefined),
     postalServiceOff: ("postalServiceOff" in msg) ? !!msg.postalServiceOff : (prev ? prev.postalServiceOff : undefined),
+    mailOffWhy: ("mailOffWhy" in msg) ? String(msg.mailOffWhy || "") : (prev ? prev.mailOffWhy : undefined),   // why the mail is off (T356): thread, isolation, an unreadable record
     notify: ("notify" in msg) ? !!msg.notify : (prev ? prev.notify : undefined),
   };
   sessions.set(msg.id, s);

--- a/ui/webview/thread-mail.test.ts
+++ b/ui/webview/thread-mail.test.ts
@@ -30,16 +30,21 @@ test("the popover says the thread's mail is off, and the promoted view says it i
 });
 
 test("the tab hover and the Sessions pane show a session's mail state", () => {
-  assert.match(RENDER, /rows\.push\(\["Mail", s\.postalServiceOff \? "off: this session neither sends nor receives peer mail" : "on"\]\);/);
+  assert.match(RENDER, /rows\.push\(\["Mail", !s\.postalServiceOff \? "on"\s*\n\s*: s\.mailOffWhy === "unreadable" \? "held: this session's record cannot be read, so mail waits until it is repaired"\s*\n\s*: s\.mailOffWhy === "thread" \? "off until the thread is broken out"\s*\n\s*: "off: this session neither sends nor receives peer mail"\]\);/,
+               "the tab hover says which door is closed");
+  assert.match(RENDER, /mailOffWhy: \("mailOffWhy" in msg\) \? String\(msg\.mailOffWhy \|\| ""\) : \(prev \? prev\.mailOffWhy : undefined\),/, "the reason rides the session frame");
+  assert.match(FLEET, /mo\.textContent = s\.mailOffWhy === "unreadable" \? "mail held" : "mail off";/, "the Sessions pane tag says held for an unreadable record");
   assert.match(FLEET, /postalServiceOff\?: boolean;/, "the Sessions pane row type carries it");
-  assert.match(FLEET, /if \(s\.postalServiceOff\) \{[\s\S]*?const mo = el\("span", "fl-mail-off"\);\s*\n\s*mo\.textContent = "mail off";/);
+  assert.match(FLEET, /if \(s\.postalServiceOff\) \{[\s\S]*?const mo = el\("span", "fl-mail-off"\);\s*\n\s*mo\.textContent = s\.mailOffWhy === "unreadable" \? "mail held" : "mail off";/);
   assert.match(CSS, /\.fl-mail-off \{/);
 });
 
 test("the kernel and the bus derive the same default from the thread's reg and the fresh key", () => {
   assert.match(KERNEL, /def _thread_mail_off\(sid\):[\s\S]*?if not sid or not _thread_reg\(sid\)\.get\("threadOf"\):\s*\n\s*return False\s*\n\s*f = _session_flags\(\)\.get\(sid\)\s*\n\s*return not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\)/,
                "literal True only (the flip-a-default rule)");
-  assert.match(KERNEL, /def _postal_isolated\(sid\):[\s\S]*?return _thread_mail_off\(sid\) or bool\(_session_flag\(sid, "postalServiceOff"\) or _session_flag\(sid, "postalOff"\)\)/);
+  assert.match(KERNEL, /def _mail_off_why_k\(sid\):[\s\S]*?if _reg_unreadable\(sid\):\s*\n\s*return "unreadable"\s*\n\s*if _thread_mail_off\(sid\):\s*\n\s*return "thread"\s*\n\s*return "isolation" if \(_session_flag\(sid, "postalServiceOff"\) or _session_flag\(sid, "postalOff"\)\) else ""/,
+               "the kernel's reasons: unreadable first (the bus holds everything for it), then the thread default, then the mailbox flag");
+  assert.match(KERNEL, /def _postal_isolated\(sid\):[\s\S]*?return bool\(_mail_off_why_k\(sid\)\)/);
   assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),/, "the comments frame carries it");
   assert.match(KERNEL, /"postalServiceOff": _postal_isolated\(m\["id"\]\),/, "the Sessions pane rows carry it");
   assert.match(POSTAL, /t = _thread_of\(sid\)\s*\n\s*if t == THREAD_REG_UNREADABLE:\s*\n\s*return "unreadable"[^\n]*\n\s*if t and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/,


### PR DESCRIPTION
The last three lows from the review of the thread mail-off follow-up.

- **The CLI judges every closed door**: `romp mail send --from <label>` stopped the caller for the thread and unreadable doors only; a mailbox the user toggled off fell through the label substitution. Every closed door stops it first, with the bus's own isolation words (one constant shared with the send handler).
- **The kernel reads an unreadable record as held**: it read such a record as mail on while the bus held everything for it. The kernel now derives the bus's reasons (unreadable, thread, isolation); the effective state is any of them; the reason rides every row, so the tab hover says which door is closed and the Sessions pane tag reads "mail held" for an unreadable record.
- **The comments-frame comment** no longer says the popover announces the mail state.

Tests: the kernel's reasons and the rows carrying them; the CLI stopped for an isolated caller with and without `--from`; the census entry; the pins follow the new words.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
