### PR TITLE
spend-repair: a lifetime billed once more after an attach-unknown row is corrected (T354 follow-up)

### DIFF
--- a/cli/spend_repair.py
+++ b/cli/spend_repair.py
@@ -300,7 +300,7 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
         typical = _typical([_kernel_usd(r) for r in rs if id(r) not in firsts]) or 0.0
         prev_t, prev_cum, steps, restores = day_start, None, [], []
         between = []
-        unknown_cum, since_unknown, lifetime = None, [], []
+        unknown_armed, lifetime = False, []
         for r in rs:
             t, usd = float(r["t"]), float(r["usd"])
             restarted = id(r) in firsts
@@ -308,48 +308,43 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
             if isinstance(r.get("cumulativeUsd"), (int, float)) or r.get("spendBaseline"):
                 # written by a kernel that carries the CLI's cumulative on the row, or names a first result's baseline
                 # (the fix): right, never a step, with ONE rule of its own (the fix's first boot, 2026-09-11 22:38Z): a
-                # row whose KERNEL figure equals its cumulative, following the same session's attach-unknown row with
-                # only ordinary rows between, is the lifetime billed once more (the replayed first result left the
-                # watermark at zero), corrected to the cumulative less that row's cumulative less the rows between. The
-                # match requires the cumulative ABOVE the attach-unknown row's and a positive remainder: the first paid
-                # turn after a mid-life /clear is written with its dollars equal to its cumulative BY DESIGN (the
-                # watermark is zeroed on the /clear), a counter reset that the first cut of this rule zeroed to
-                # max(0, small less large) in silence (the 1473 review's HIGH); the arithmetic contradicting itself is
-                # void evidence, said in a note, never a clamp. The chain disarms on the row it judged (corrected or
-                # not), on a counter reset and on a fresh or seeded baseline row; a corrected row is judged again on
-                # its recorded figure every run (idempotent) and restored when the rule no longer believes it
+                # row whose KERNEL figure equals its cumulative, in a session whose attach-unknown row precedes it, is
+                # the lifetime billed once more (the replayed first result left the watermark at zero), and its true
+                # cost is the kernel's own arithmetic: the cumulative less the PREVIOUS same-session row's cumulative
+                # (a replay row with usd 0 and a rising cumulative counts as that previous row: the unknown window can
+                # replay several, and the first replayed cumulative is the wrong baseline; the 1473 review's third
+                # round). The guard is the kernel's reset comparison: the cumulative ABOVE the previous row's. The first
+                # paid turn after a mid-life /clear is written with its dollars equal to its cumulative BY DESIGN (the
+                # watermark is zeroed on the /clear), a counter reset that the first cut of this rule zeroed in silence
+                # (the review's HIGH); it stands, said in a note, never a clamp. The chain disarms on the row it judged
+                # (corrected or not), on a counter reset and on a fresh or seeded baseline row; a corrected row is judged
+                # again on its recorded figure every run (idempotent) and restored when the rule no longer believes it
                 cum = float(r["cumulativeUsd"]) if isinstance(r.get("cumulativeUsd"), (int, float)) else None
                 base = r.get("spendBaseline")
                 rec_k = _kernel_usd(r)
                 repaired = isinstance(r.get("usdRecorded"), (int, float))
                 candidate = cum is not None and not base and abs(rec_k - cum) < 1e-6 and rec_k > 0
                 who = "%s %s" % (str(r.get("name") or sid[:8]), datetime.fromtimestamp(t).strftime("%H:%M:%S"))
-                if candidate and unknown_cum is not None:
-                    remainder = cum - unknown_cum - sum(since_unknown)
-                    if cum > unknown_cum + 1e-6 and remainder > 1e-6:
+                if candidate and unknown_armed:
+                    if prev_cum is not None and cum > prev_cum + 1e-6:
+                        remainder = cum - prev_cum
                         if abs(remainder - usd) > 1e-6:
-                            lifetime.append((r, usd, remainder, unknown_cum, list(since_unknown), None))
+                            lifetime.append((r, usd, remainder, prev_cum, None))
                     else:
-                        why = ("its cumulative %.4f is at or below the attach-unknown row's %.4f: a counter reset (a /clear's "
-                               "first paid turn is written with its dollars equal to its cumulative), the turn stands"
-                               % (cum, unknown_cum) if cum <= unknown_cum + 1e-6 else
-                               "cumulative %.4f less the attach-unknown row's %.4f less %d row(s) between (%.4f) is not positive: "
-                               "the arithmetic contradicts itself, the turn stands" % (cum, unknown_cum, len(since_unknown), sum(since_unknown)))
+                        why = ("its cumulative %.4f is at or below the previous row's %.4f: a counter reset (a /clear's first paid "
+                               "turn is written with its dollars equal to its cumulative), the turn stands" % (cum, prev_cum)
+                               if prev_cum is not None else "no earlier row of the session carries a cumulative to stand it on")
                         notes.append("%s: the lifetime rule stood down, %s" % (who, why))
                         if repaired and abs(usd - rec_k) > 1e-9:
-                            lifetime.append((r, usd, rec_k, unknown_cum, list(since_unknown), why))   # a restore
-                    unknown_cum, since_unknown = None, []
+                            lifetime.append((r, usd, rec_k, prev_cum, why))   # a restore
+                    unknown_armed = False
                 elif candidate and repaired and abs(usd - rec_k) > 1e-9:
                     # a correction whose attach-unknown row no longer arms a chain before it: restored
-                    lifetime.append((r, usd, rec_k, None, [], "no attach-unknown row arms a chain before it"))
+                    lifetime.append((r, usd, rec_k, None, "no attach-unknown row arms a chain before it"))
                 elif cum is not None and base == "attach-unknown":
-                    unknown_cum, since_unknown = cum, []
+                    unknown_armed = True
                 elif base in ("fresh", "seeded") or (cum is not None and prev_cum is not None and cum < prev_cum - 1e-6):
-                    unknown_cum, since_unknown = None, []             # a new or seeded process, or a counter reset: no lifetime follows
-                elif unknown_cum is not None:
-                    # a row between: its current figure is its cost, unless a mark this rule did not write sits on it
-                    # (then the kernel's figure), so the sum can tell a lifetime-corrected row from one an older rule zeroed
-                    since_unknown.append(usd if (not repaired or r.get("repairRule") == REPAIR_RULE_LIFETIME) else rec_k)
+                    unknown_armed = False                             # a new or seeded process, or a counter reset: no lifetime follows
                 if cum is not None:
                     prev_cum = cum; between = []
                 prev_t = t
@@ -443,12 +438,12 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
             if abs(corrected - cur) < 1e-6:
                 continue                       # already right: a run over repaired rows
             corrections.append(entry(r, sid, rec, cur, corrected, reason))
-        for r, cur, corrected, ucum, between, why in lifetimes.get(sid, []):
+        for r, cur, corrected, pcum, why in lifetimes.get(sid, []):
             rec_k = _kernel_usd(r)
             if why is None:
                 corrections.append(entry(r, sid, rec_k, cur, corrected,
-                                         "the lifetime billed once more after the attach-unknown row (cumulative %.4f less that row's cumulative %.4f less %d row(s) between (%.4f))"
-                                         % (rec_k, ucum, len(between), sum(between)), rule=REPAIR_RULE_LIFETIME))
+                                         "the lifetime billed once more after the attach-unknown row (cumulative %.4f less the previous row's cumulative %.4f)"
+                                         % (rec_k, pcum), rule=REPAIR_RULE_LIFETIME))
             else:
                 corrections.append(entry(r, sid, rec_k, cur, rec_k, "restored: %.4f is no lifetime billed once more: %s" % (rec_k, why), restore=True))
         for r, rec, cur, prev_cum, between in restores:

--- a/cli/spend_repair.py
+++ b/cli/spend_repair.py
@@ -73,6 +73,8 @@ def local_hour(t) -> str:
 REPAIR_JOURNAL = "spend-repair.jsonl"   # beside the ledger: each --apply's row deltas; the mark that their buckets were folded
 #                                          lives INSIDE spend.json (repairJournal.folded), written in the same atomic replace
 REPAIR_RULE = 4                          # stamped on every row this rule corrects (repairRule); a standing correction is kept
+REPAIR_RULE_LIFETIME = 5                 # stamped on a row the lifetime road corrects (a lifetime billed once more after an
+#                                          attach-unknown row) and carried in the journal's deltas, so a row is auditable per rule
 #                                          only when this rule wrote it and it reads as a plausible typical turn
 
 
@@ -276,7 +278,7 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
     for r in rows:
         by_sid.setdefault(str(r.get("sid") or ""), []).append(r)
     day_start = datetime.strptime(day, "%Y-%m-%d").timestamp()
-    corrections, all_ordinary = [], []
+    corrections, all_ordinary, notes = [], [], []
     # first pass per session: which rows are staircase steps, which are ordinary. A row already repaired (usdRecorded
     # keeps the figure the kernel wrote) is judged AGAIN on that figure, so a run over repaired rows finds nothing new
     # when the judgement stands and restores the row when it does not (a rule tightened after the first run brings a
@@ -304,22 +306,50 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
             restarted = id(r) in firsts
             step = False
             if isinstance(r.get("cumulativeUsd"), (int, float)) or r.get("spendBaseline"):
-                # written by a kernel that carries the CLI's cumulative on the row, or names a first result's
-                # baseline (the fix): right, never a step, with ONE exception the fix's first boot showed (2026-09-11
-                # 22:38Z, the rule the manager approved): a row whose dollars EQUAL its cumulative and follow the same
-                # session's attach-unknown row is the lifetime billed once more (the replayed first result left the
-                # watermark at zero), corrected to the cumulative less that row's cumulative less the rows between
+                # written by a kernel that carries the CLI's cumulative on the row, or names a first result's baseline
+                # (the fix): right, never a step, with ONE rule of its own (the fix's first boot, 2026-09-11 22:38Z): a
+                # row whose KERNEL figure equals its cumulative, following the same session's attach-unknown row with
+                # only ordinary rows between, is the lifetime billed once more (the replayed first result left the
+                # watermark at zero), corrected to the cumulative less that row's cumulative less the rows between. The
+                # match requires the cumulative ABOVE the attach-unknown row's and a positive remainder: the first paid
+                # turn after a mid-life /clear is written with its dollars equal to its cumulative BY DESIGN (the
+                # watermark is zeroed on the /clear), a counter reset that the first cut of this rule zeroed to
+                # max(0, small less large) in silence (the 1473 review's HIGH); the arithmetic contradicting itself is
+                # void evidence, said in a note, never a clamp. The chain disarms on the row it judged (corrected or
+                # not), on a counter reset and on a fresh or seeded baseline row; a corrected row is judged again on
+                # its recorded figure every run (idempotent) and restored when the rule no longer believes it
                 cum = float(r["cumulativeUsd"]) if isinstance(r.get("cumulativeUsd"), (int, float)) else None
-                if cum is not None and not r.get("spendBaseline") and abs(usd - cum) < 1e-6 and usd > 0 \
-                        and unknown_cum is not None:
-                    corrected = max(0.0, cum - unknown_cum - sum(since_unknown))
-                    if abs(corrected - usd) > 1e-6:
-                        lifetime.append((r, usd, corrected, unknown_cum, list(since_unknown)))
+                base = r.get("spendBaseline")
+                rec_k = _kernel_usd(r)
+                repaired = isinstance(r.get("usdRecorded"), (int, float))
+                candidate = cum is not None and not base and abs(rec_k - cum) < 1e-6 and rec_k > 0
+                who = "%s %s" % (str(r.get("name") or sid[:8]), datetime.fromtimestamp(t).strftime("%H:%M:%S"))
+                if candidate and unknown_cum is not None:
+                    remainder = cum - unknown_cum - sum(since_unknown)
+                    if cum > unknown_cum + 1e-6 and remainder > 1e-6:
+                        if abs(remainder - usd) > 1e-6:
+                            lifetime.append((r, usd, remainder, unknown_cum, list(since_unknown), None))
+                    else:
+                        why = ("its cumulative %.4f is at or below the attach-unknown row's %.4f: a counter reset (a /clear's "
+                               "first paid turn is written with its dollars equal to its cumulative), the turn stands"
+                               % (cum, unknown_cum) if cum <= unknown_cum + 1e-6 else
+                               "cumulative %.4f less the attach-unknown row's %.4f less %d row(s) between (%.4f) is not positive: "
+                               "the arithmetic contradicts itself, the turn stands" % (cum, unknown_cum, len(since_unknown), sum(since_unknown)))
+                        notes.append("%s: the lifetime rule stood down, %s" % (who, why))
+                        if repaired and abs(usd - rec_k) > 1e-9:
+                            lifetime.append((r, usd, rec_k, unknown_cum, list(since_unknown), why))   # a restore
                     unknown_cum, since_unknown = None, []
-                elif cum is not None and r.get("spendBaseline") == "attach-unknown":
+                elif candidate and repaired and abs(usd - rec_k) > 1e-9:
+                    # a correction whose attach-unknown row no longer arms a chain before it: restored
+                    lifetime.append((r, usd, rec_k, None, [], "no attach-unknown row arms a chain before it"))
+                elif cum is not None and base == "attach-unknown":
                     unknown_cum, since_unknown = cum, []
+                elif base in ("fresh", "seeded") or (cum is not None and prev_cum is not None and cum < prev_cum - 1e-6):
+                    unknown_cum, since_unknown = None, []             # a new or seeded process, or a counter reset: no lifetime follows
                 elif unknown_cum is not None:
-                    since_unknown.append(usd)
+                    # a row between: its current figure is its cost, unless a mark this rule did not write sits on it
+                    # (then the kernel's figure), so the sum can tell a lifetime-corrected row from one an older rule zeroed
+                    since_unknown.append(usd if (not repaired or r.get("repairRule") == REPAIR_RULE_LIFETIME) else rec_k)
                 if cum is not None:
                     prev_cum = cum; between = []
                 prev_t = t
@@ -413,10 +443,14 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
             if abs(corrected - cur) < 1e-6:
                 continue                       # already right: a run over repaired rows
             corrections.append(entry(r, sid, rec, cur, corrected, reason))
-        for r, cur, corrected, ucum, between in lifetimes.get(sid, []):
-            corrections.append(entry(r, sid, cur, cur, corrected,
-                                     "the lifetime billed once more after the attach-unknown row (cumulative %.4f less that row's cumulative %.4f less %d row(s) between (%.4f))"
-                                     % (cur, ucum, len(between), sum(between))))
+        for r, cur, corrected, ucum, between, why in lifetimes.get(sid, []):
+            rec_k = _kernel_usd(r)
+            if why is None:
+                corrections.append(entry(r, sid, rec_k, cur, corrected,
+                                         "the lifetime billed once more after the attach-unknown row (cumulative %.4f less that row's cumulative %.4f less %d row(s) between (%.4f))"
+                                         % (rec_k, ucum, len(between), sum(between)), rule=REPAIR_RULE_LIFETIME))
+            else:
+                corrections.append(entry(r, sid, rec_k, cur, rec_k, "restored: %.4f is no lifetime billed once more: %s" % (rec_k, why), restore=True))
         for r, rec, cur, prev_cum, between in restores:
             if prev_cum == "since":
                 reason = "restored: %.4f precedes the hosts' start (%s), a fresh process's turn" % (
@@ -446,6 +480,7 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
     before = round(sum(h["before"] for h in hours.values()), 6)
     after = round(sum(h["after"] for h in hours.values()), 6)
     return {"day": day, "since": since, "rows": sorted(corrections, key=lambda c: c["t"]), "hours": dict(sorted(hours.items())),
+            "stoodDown": notes,                        # the lifetime rule's refusals, said (never a clamp)
             "unkeyedRows": sum(1 for c in corrections if not c["keyed"]),
             "days": {day: {"before": before, "after": after}}, "bySid": sids, "restarts": len([x for x in restarts if local_day(x) == day])}
 
@@ -534,7 +569,7 @@ def apply_to_turns(path: Path, p: dict, write: bool = True) -> list:
                     o.setdefault("usdRecorded", o["usd"])
                     o["usd"] = c["corrected"]
                     o["repairedT"] = int(time.time())
-                    o["repairRule"] = REPAIR_RULE
+                    o["repairRule"] = int(c.get("rule") or REPAIR_RULE)   # the rule that wrote it, auditable per row
                 done.append(c)
             out.append(json.dumps(o))
         if not done or not write:
@@ -586,9 +621,9 @@ def report(p: dict) -> str:
     for c in p["rows"]:
         lines.append("  %-16s %s %10.2f -> %8.2f  %s" % (c["name"][:16], datetime.fromtimestamp(c["t"]).strftime("%H:%M:%S"),
                                                         c["current"], c["corrected"], c["reason"]))
-    if p.get("notes"):
+    if p.get("notes") or p.get("stoodDown"):
         lines.append("")
-        lines.extend("note: " + n for n in p["notes"])
+        lines.extend("note: " + n for n in list(p.get("stoodDown") or []) + list(p.get("notes") or []))
     return "\n".join(lines)
 
 
@@ -698,7 +733,8 @@ def main(argv=None) -> int:
     planned = apply_to_turns(state / "turns.jsonl", p, write=False)
     stamp_t = time.time()
     deltas = [{"sid": c["sid"], "t": c["t"], "hour": c["hour"], "owner": c["owner"], "keyed": c["keyed"], "name": c["name"],
-               "delta": round(c["corrected"] - c["current"], 6), "corrected": round(c["corrected"], 6)} for c in planned]
+               "delta": round(c["corrected"] - c["current"], 6), "corrected": round(c["corrected"], 6),
+               "rule": (0 if c.get("restore") else int(c.get("rule") or REPAIR_RULE)), "reason": c.get("reason", "")} for c in planned]
     if deltas:
         journal_append(state, {"t": stamp_t, "phase": "rows", "day": day, "deltas": deltas})
     done = apply_to_turns(state / "turns.jsonl", p)

--- a/cli/spend_repair.py
+++ b/cli/spend_repair.py
@@ -281,7 +281,7 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
     # keeps the figure the kernel wrote) is judged AGAIN on that figure, so a run over repaired rows finds nothing new
     # when the judgement stands and restores the row when it does not (a rule tightened after the first run brings a
     # zeroed turn back); a row written by a kernel that carries the CLI's cumulative (T354's fix) is never a step.
-    marked, rs_by_sid, step_ids_by_sid = {}, {}, {}
+    marked, rs_by_sid, step_ids_by_sid, lifetimes = {}, {}, {}, {}
     for sid, rs in by_sid.items():
         # the session's typical turn: the median of its rows that are NOT a first result after a restart (those are a
         # cumulative or a fresh process's first turn, both atypical); the same figure decides the threshold and the
@@ -298,15 +298,30 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
         typical = _typical([_kernel_usd(r) for r in rs if id(r) not in firsts]) or 0.0
         prev_t, prev_cum, steps, restores = day_start, None, [], []
         between = []
+        unknown_cum, since_unknown, lifetime = None, [], []
         for r in rs:
             t, usd = float(r["t"]), float(r["usd"])
             restarted = id(r) in firsts
             step = False
             if isinstance(r.get("cumulativeUsd"), (int, float)) or r.get("spendBaseline"):
                 # written by a kernel that carries the CLI's cumulative on the row, or names a first result's
-                # baseline (the fix): already right, never a step; the cumulative, where named, is the chain's baseline
-                if isinstance(r.get("cumulativeUsd"), (int, float)):
-                    prev_cum = float(r["cumulativeUsd"]); between = []
+                # baseline (the fix): right, never a step, with ONE exception the fix's first boot showed (2026-09-11
+                # 22:38Z, the rule the manager approved): a row whose dollars EQUAL its cumulative and follow the same
+                # session's attach-unknown row is the lifetime billed once more (the replayed first result left the
+                # watermark at zero), corrected to the cumulative less that row's cumulative less the rows between
+                cum = float(r["cumulativeUsd"]) if isinstance(r.get("cumulativeUsd"), (int, float)) else None
+                if cum is not None and not r.get("spendBaseline") and abs(usd - cum) < 1e-6 and usd > 0 \
+                        and unknown_cum is not None:
+                    corrected = max(0.0, cum - unknown_cum - sum(since_unknown))
+                    if abs(corrected - usd) > 1e-6:
+                        lifetime.append((r, usd, corrected, unknown_cum, list(since_unknown)))
+                    unknown_cum, since_unknown = None, []
+                elif cum is not None and r.get("spendBaseline") == "attach-unknown":
+                    unknown_cum, since_unknown = cum, []
+                elif unknown_cum is not None:
+                    since_unknown.append(usd)
+                if cum is not None:
+                    prev_cum = cum; between = []
                 prev_t = t
                 continue
             repaired = isinstance(r.get("usdRecorded"), (int, float))
@@ -366,6 +381,7 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
         step_ids = {id(x[0]) for x in steps}
         ordinary = [_kernel_usd(r) for r in rs if id(r) not in step_ids]   # every row that is not a step, the kernel's figure
         marked[sid] = (steps, restores, _typical(ordinary) or 0.0)
+        lifetimes[sid] = lifetime
         rs_by_sid[sid], step_ids_by_sid[sid] = rs, step_ids
         all_ordinary.extend(ordinary)
     day_typical = _typical(all_ordinary)
@@ -397,6 +413,10 @@ def plan(turns: list, restarts: list, day: str, since=None, owners=None, keyed=N
             if abs(corrected - cur) < 1e-6:
                 continue                       # already right: a run over repaired rows
             corrections.append(entry(r, sid, rec, cur, corrected, reason))
+        for r, cur, corrected, ucum, between in lifetimes.get(sid, []):
+            corrections.append(entry(r, sid, cur, cur, corrected,
+                                     "the lifetime billed once more after the attach-unknown row (cumulative %.4f less that row's cumulative %.4f less %d row(s) between (%.4f))"
+                                     % (cur, ucum, len(between), sum(between))))
         for r, rec, cur, prev_cum, between in restores:
             if prev_cum == "since":
                 reason = "restored: %.4f precedes the hosts' start (%s), a fresh process's turn" % (

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2742,15 +2742,16 @@ already shown. `--since` is the instant the per-session hosts came on: before
 it every restart killed the CLI, so nothing there is a step. Rows the fixed
 kernel writes (`cumulativeUsd`, `spendBaseline`) are never staircase steps; one
 rule of their own reaches them: a row whose kernel figure equals its cumulative,
-following the same session's `attach-unknown` row with only ordinary rows
-between, is the lifetime billed once more (the fix's first boot left the
-watermark at zero after a replayed first result) and is corrected to the
-cumulative less that row's cumulative less the rows between, stamped
-`repairRule` 5. The match requires the cumulative above the attach-unknown
-row's and a positive remainder: the first paid turn after a mid-life `/clear`
-is written with its dollars equal to its cumulative by design, a counter reset,
-and the rule stands down with a note (never a clamp); the chain disarms on the
-row it judged, on a reset and on a fresh or seeded baseline row.
+in a session whose `attach-unknown` row precedes it, is the lifetime billed
+once more (the fix's first boot left the watermark at zero after a replayed
+first result) and is corrected by the kernel's own arithmetic to the cumulative
+less the previous same-session row's cumulative (a replayed row with no dollars
+and a rising cumulative counts as that previous row), stamped `repairRule` 5.
+The guard is the kernel's reset comparison, the cumulative above the previous
+row's: the first paid turn after a mid-life `/clear` is written with its
+dollars equal to its cumulative by design, a counter reset, and the rule stands
+down with a note (never a clamp); the chain disarms on the row it judged, on a
+reset and on a fresh or seeded baseline row.
 
 It prints before and after per hour and per session and changes nothing unless
 `--apply` is given. A corrected row keeps the kernel's figure as `usdRecorded`,

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2740,13 +2740,26 @@ follows it. A row bearing the signature with no restart instant on record (a
 crash leaves no audit row) is taken as a step only on a chain the session has
 already shown. `--since` is the instant the per-session hosts came on: before
 it every restart killed the CLI, so nothing there is a step. Rows the fixed
-kernel writes (`cumulativeUsd`, `spendBaseline`) are never touched.
+kernel writes (`cumulativeUsd`, `spendBaseline`) are never staircase steps; one
+rule of their own reaches them: a row whose kernel figure equals its cumulative,
+following the same session's `attach-unknown` row with only ordinary rows
+between, is the lifetime billed once more (the fix's first boot left the
+watermark at zero after a replayed first result) and is corrected to the
+cumulative less that row's cumulative less the rows between, stamped
+`repairRule` 5. The match requires the cumulative above the attach-unknown
+row's and a positive remainder: the first paid turn after a mid-life `/clear`
+is written with its dollars equal to its cumulative by design, a counter reset,
+and the rule stands down with a note (never a clamp); the chain disarms on the
+row it judged, on a reset and on a fresh or seeded baseline row.
 
 It prints before and after per hour and per session and changes nothing unless
 `--apply` is given. A corrected row keeps the kernel's figure as `usdRecorded`,
 and every run judges a repaired row again on that figure, so a tightened rule
 or a later `--since` restores what an earlier run took, and a run over a
-repaired day changes nothing. Per-session figures fold under the session a row
+repaired day re-judges every correction, staircase and lifetime alike, and
+changes nothing when the judgements stand: a lifetime correction the rule no
+longer believes is restored to `usdRecorded` and its buckets re-folded, the
+same road the staircase rules use. Per-session figures fold under the session a row
 bills (a comment thread's owner, the registry's `threadOf`), and the buckets'
 `key` split moves only for sessions the registry marks as API-key billed; the
 report says how many rows' split was left as recorded. The kernel may be

--- a/tests/test_spend_repair.py
+++ b/tests/test_spend_repair.py
@@ -594,9 +594,12 @@ class Plan(unittest.TestCase):
         self.assertIn("note: hour %sT11 would go 489.0000 below zero; held at zero" % DAY, out.getvalue(), "said on --apply as a new line")
         self.assertEqual(json.loads((state / "spend.json").read_text())["hours"]["%sT11" % DAY]["usd"], 0.0)
 
-    def test_a_lifetime_billed_once_more_after_an_attach_unknown_row_is_corrected_and_a_first_result_row_is_not(self):
-        # the fix's first boot (2026-09-11 22:38Z, the rule the manager approved): the replayed attach-unknown first
-        # result folded nothing but left the watermark at zero, and the next live result recorded the whole cumulative
+    def test_a_lifetime_billed_once_more_after_an_attach_unknown_row_is_corrected_and_a_post_clear_turn_is_not(self):
+        # the fix's first boot (2026-09-11 22:38Z): the replayed attach-unknown first result folded nothing but left the
+        # watermark at zero, and the next live result recorded the whole cumulative. The 1473 review's HIGH: the first
+        # paid turn after a mid-life /clear is written with its dollars equal to its cumulative BY DESIGN (the module's
+        # oracle: a post-clear result 5.00 with costState 5.00), so the match needs the cumulative ABOVE the
+        # attach-unknown row's and a positive remainder, and the rule stands down with a note otherwise
         turns = [row(A, "web", at(10, 0), 3.0) | {"cumulativeUsd": 100.0},
                  row(A, "web", at(10, 40), 0.0) | {"cumulativeUsd": 148.4878, "spendBaseline": "attach-unknown", "redelivered": True},
                  row(A, "web", at(10, 50), 159.2004) | {"cumulativeUsd": 159.2004},         # usd equals its cumulative: the lifetime once more
@@ -604,15 +607,105 @@ class Plan(unittest.TestCase):
                  row(A, "web", at(11, 10), 4.5) | {"cumulativeUsd": 4.5, "spendBaseline": "fresh"},   # a fresh process's first result: its own
                  row(A, "web", at(11, 20), 20.0) | {"cumulativeUsd": 24.5}]
         p = rp.plan(turns, [at(10, 30)], DAY)
-        got = {c["t"]: (c["current"], c["corrected"], c["reason"]) for c in p["rows"]}
+        got = {c["t"]: c for c in p["rows"]}
         self.assertEqual(sorted(got), [at(10, 50)], "the lifetime row alone; the fresh first result and the ordinary rows stand")
-        cur, corr, why = got[at(10, 50)]
-        self.assertEqual((cur, corr), (159.2004, round(159.2004 - 148.4878, 6)))
-        self.assertIn("the lifetime billed once more after the attach-unknown row", why)
+        c = got[at(10, 50)]
+        self.assertEqual((c["current"], c["corrected"], c["recorded"], c["rule"]), (159.2004, round(159.2004 - 148.4878, 6), 159.2004, rp.REPAIR_RULE_LIFETIME))
+        self.assertIn("the lifetime billed once more after the attach-unknown row", c["reason"])
+        self.assertEqual(p["stoodDown"], [])
         # a lifetime row with ordinary rows between it and the attach-unknown row subtracts them too
         turns2 = [turns[1], row(A, "web", at(10, 45), 2.0) | {"cumulativeUsd": 150.4878}, turns[2] | {"usd": 161.2004, "cumulativeUsd": 161.2004}]
         got2 = {c["t"]: c["corrected"] for c in rp.plan(turns2, [at(10, 30)], DAY)["rows"]}
         self.assertEqual(got2, {at(10, 50): round(161.2004 - 148.4878 - 2.0, 6)})
+        # the /clear shape: the post-clear first paid turn follows the attach-unknown row with its cumulative BELOW it
+        turns3 = [turns[1], row(A, "web", at(10, 45), 2.0) | {"cumulativeUsd": 150.4878},
+                  row(A, "web", at(10, 50), 4.25) | {"cumulativeUsd": 4.25},                # /clear, then its first paid turn
+                  row(A, "web", at(10, 55), 1.0) | {"cumulativeUsd": 5.25}]
+        p3 = rp.plan(turns3, [at(10, 30)], DAY)
+        self.assertEqual(p3["rows"], [], "the post-clear turn stands (the first cut zeroed it to max(0, 4.25 - 148.49 - 2))")
+        self.assertEqual(len(p3["stoodDown"]), 1)
+        self.assertIn("4.2500 is at or below the attach-unknown row's 148.4878: a counter reset", p3["stoodDown"][0])
+        self.assertIn("web 10:50:00: the lifetime rule stood down", p3["stoodDown"][0])
+        self.assertIn("note: web 10:50:00: the lifetime rule stood down", rp.report(p3), "said in the report")
+        # the arithmetic contradicting itself (a cumulative above the row's, but the rows between exceed the difference)
+        turns4 = [turns[1], row(A, "web", at(10, 45), 20.0) | {"cumulativeUsd": 168.4878},
+                  row(A, "web", at(10, 50), 160.0) | {"cumulativeUsd": 160.0}]
+        p4 = rp.plan(turns4, [at(10, 30)], DAY)
+        self.assertEqual(p4["rows"], [])
+        self.assertIn("less 1 row(s) between (20.0000) is not positive: the arithmetic contradicts itself", p4["stoodDown"][0])
+        # a fresh or seeded baseline row between disarms the chain: the later usd == cumulative row is nobody's lifetime
+        turns5 = [row(A, "web", at(10, 40), 0.0) | {"cumulativeUsd": 100.0, "spendBaseline": "attach-unknown", "redelivered": True},
+                  row(A, "web", at(10, 45), 3.0) | {"cumulativeUsd": 103.0, "spendBaseline": "seeded"},
+                  row(A, "web", at(10, 50), 105.0) | {"cumulativeUsd": 105.0}]
+        p5 = rp.plan(turns5, [at(10, 30)], DAY)
+        self.assertEqual((p5["rows"], p5["stoodDown"]), ([], []), "disarmed by the seeded row, no judgement made")
+
+    def test_the_lifetime_rule_is_idempotent_stamps_its_own_rule_into_the_row_and_the_journal_and_restores_what_it_no_longer_believes(self):
+        # the 1473 review's two mediums: run two re-armed the chain on the corrected row (its usd no longer equal to its
+        # cumulative) and zeroed the post-clear turn; a lifetime correction was never re-judged or restored
+        d = tempfile.mkdtemp()
+        state = Path(d)
+        turns = [row(A, "web", at(10, 40), 0.0) | {"cumulativeUsd": 148.4878, "spendBaseline": "attach-unknown", "redelivered": True},
+                 row(A, "web", at(10, 50), 159.2004) | {"cumulativeUsd": 159.2004},
+                 row(A, "web", at(11, 0), 2.0) | {"cumulativeUsd": 161.2004},
+                 row(A, "web", at(11, 5), 4.25) | {"cumulativeUsd": 4.25},                  # a /clear's first paid turn, present on every run
+                 row(A, "web", at(11, 8), 1.0) | {"cumulativeUsd": 5.25}]
+        (state / "turns.jsonl").write_text("".join(json.dumps(r) + chr(10) for r in turns))
+        (state / "restart-cuts.jsonl").write_text(json.dumps({"t": at(10, 30), "firstServe": at(10, 30), "settleS": 0.1, "pid": 1}) + chr(10))
+        spend = {"hours": {"%sT10" % DAY: {"usd": 159.2004, "turns": 2, "bySid": {A: {"usd": 159.2004, "turns": 2}}},
+                           "%sT11" % DAY: {"usd": 7.25, "turns": 3, "bySid": {A: {"usd": 7.25, "turns": 3}}}},
+                 "days": {DAY: {"usd": 166.4504, "turns": 5, "bySid": {A: {"usd": 166.4504}}}}}
+        (state / "spend.json").write_text(json.dumps(spend))
+        reg(state, A, name="web")
+        import io, contextlib
+        seen, orig = [], rp.journal_append
+        rp.journal_append = lambda st, entry: (seen.append(entry), orig(st, entry))[1]
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(rp.main(["--day", DAY, "--state", d, "--apply", "--no-backup"]), 0)
+        finally:
+            rp.journal_append = orig
+        rows = {r["t"]: r for r in (json.loads(l) for l in (state / "turns.jsonl").read_text().splitlines())}
+        self.assertEqual((round(rows[at(10, 50)]["usd"], 4), rows[at(10, 50)]["usdRecorded"], rows[at(10, 50)]["repairRule"]), (10.7126, 159.2004, rp.REPAIR_RULE_LIFETIME))
+        self.assertEqual((rows[at(11, 5)]["usd"], "usdRecorded" in rows[at(11, 5)]), (4.25, False), "the post-clear turn stands")
+        deltas = [e for e in seen if e.get("phase") == "rows"][0]["deltas"]
+        self.assertEqual((len(deltas), deltas[0]["rule"]), (1, rp.REPAIR_RULE_LIFETIME), "the journal's delta names the rule")
+        self.assertIn("the lifetime billed once more", deltas[0]["reason"])
+        self.assertAlmostEqual(json.loads((state / "spend.json").read_text())["hours"]["%sT10" % DAY]["usd"], 10.7126, places=4)
+        # run two, the same ledger: nothing to apply, the post-clear turn still stands (the corrected row is judged on its
+        # recorded figure, disarms the chain, and the 4.25 row is never reached)
+        turns_2 = [json.loads(l) for l in (state / "turns.jsonl").read_text().splitlines()]
+        p2 = rp.plan(turns_2, [at(10, 30)], DAY)
+        self.assertEqual((p2["rows"], p2["stoodDown"]), ([], []), "idempotent")
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(rp.main(["--day", DAY, "--state", d, "--apply", "--no-backup"]), 0)
+        rows = {r["t"]: r for r in (json.loads(l) for l in (state / "turns.jsonl").read_text().splitlines())}
+        self.assertEqual((rows[at(11, 5)]["usd"], round(rows[at(10, 50)]["usd"], 4)), (4.25, 10.7126))
+        self.assertAlmostEqual(json.loads((state / "spend.json").read_text())["hours"]["%sT11" % DAY]["usd"], 7.25, places=4)
+        # the restore arm: the post-clear turn zeroed the way the first cut did (usd 0, the figure kept, the old stamp) is
+        # judged again on its recorded figure and restored, buckets re-folded; and a lifetime correction whose
+        # attach-unknown row is gone from the ledger is no longer believed and restored too
+        rows[at(11, 5)] |= {"usd": 0.0, "usdRecorded": 4.25, "repairRule": rp.REPAIR_RULE, "repairedT": 1}
+        kept = [rows[k] for k in sorted(rows) if k != at(10, 40)]
+        (state / "turns.jsonl").write_text("".join(json.dumps(r) + chr(10) for r in kept))
+        sp = json.loads((state / "spend.json").read_text()); sp["hours"]["%sT11" % DAY]["usd"] = 3.0; sp["hours"]["%sT11" % DAY]["bySid"][A]["usd"] = 3.0
+        sp["days"][DAY]["usd"] = round(10.7126 + 3.0, 4); sp["days"][DAY]["bySid"][A]["usd"] = round(10.7126 + 3.0, 4)
+        (state / "spend.json").write_text(json.dumps(sp))
+        p3 = rp.plan(kept, [at(10, 30)], DAY)
+        got = {c["t"]: c for c in p3["rows"]}
+        self.assertEqual(sorted(got), [at(10, 50), at(11, 5)])
+        self.assertTrue(got[at(10, 50)]["restore"] and got[at(11, 5)]["restore"])
+        self.assertEqual((got[at(10, 50)]["corrected"], got[at(11, 5)]["corrected"]), (159.2004, 4.25))
+        self.assertIn("no attach-unknown row arms a chain before it", got[at(10, 50)]["reason"])
+        self.assertIn("no lifetime billed once more", got[at(11, 5)]["reason"])
+        with contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(rp.main(["--day", DAY, "--state", d, "--apply", "--no-backup"]), 0)
+        rows = {r["t"]: r for r in (json.loads(l) for l in (state / "turns.jsonl").read_text().splitlines())}
+        self.assertEqual((rows[at(11, 5)]["usd"], rows[at(10, 50)]["usd"]), (4.25, 159.2004))
+        self.assertFalse(any(k in rows[at(11, 5)] for k in ("usdRecorded", "repairRule", "repairedT")), "the marks are dropped on a restore")
+        sp = json.loads((state / "spend.json").read_text())
+        self.assertAlmostEqual(sp["hours"]["%sT11" % DAY]["usd"], 7.25, places=4)
+        self.assertAlmostEqual(sp["hours"]["%sT10" % DAY]["usd"], 159.2004, places=4)
 
     def test_a_fold_that_would_take_a_bucket_below_zero_is_said_not_hidden(self):
         spend = {"hours": {"%sT10" % DAY: {"usd": 1.0, "turns": 1, "bySid": {A: {"usd": 1.0}}}}, "days": {DAY: {"usd": 1.0, "turns": 1, "bySid": {A: {"usd": 1.0}}}}}

--- a/tests/test_spend_repair.py
+++ b/tests/test_spend_repair.py
@@ -624,15 +624,33 @@ class Plan(unittest.TestCase):
         p3 = rp.plan(turns3, [at(10, 30)], DAY)
         self.assertEqual(p3["rows"], [], "the post-clear turn stands (the first cut zeroed it to max(0, 4.25 - 148.49 - 2))")
         self.assertEqual(len(p3["stoodDown"]), 1)
-        self.assertIn("4.2500 is at or below the attach-unknown row's 148.4878: a counter reset", p3["stoodDown"][0])
+        self.assertIn("4.2500 is at or below the previous row's 150.4878: a counter reset", p3["stoodDown"][0])
         self.assertIn("web 10:50:00: the lifetime rule stood down", p3["stoodDown"][0])
         self.assertIn("note: web 10:50:00: the lifetime rule stood down", rp.report(p3), "said in the report")
-        # the arithmetic contradicting itself (a cumulative above the row's, but the rows between exceed the difference)
+        # the guard is against the PREVIOUS row (the kernel's reset comparison), not the attach-unknown row: a cumulative
+        # above the attach-unknown row's but below the previous row's is a reset too, and stands
         turns4 = [turns[1], row(A, "web", at(10, 45), 20.0) | {"cumulativeUsd": 168.4878},
                   row(A, "web", at(10, 50), 160.0) | {"cumulativeUsd": 160.0}]
         p4 = rp.plan(turns4, [at(10, 30)], DAY)
         self.assertEqual(p4["rows"], [])
-        self.assertIn("less 1 row(s) between (20.0000) is not positive: the arithmetic contradicts itself", p4["stoodDown"][0])
+        self.assertIn("160.0000 is at or below the previous row's 168.4878: a counter reset", p4["stoodDown"][0])
+        # the unknown window can replay several records, each a row with usd 0 and a rising cumulative and no baseline
+        # (the review's third round): the previous row's cumulative is the baseline, never the first replayed one
+        turns6 = [turns[1], row(A, "web", at(10, 45), 0.0) | {"cumulativeUsd": 160.0, "redelivered": True},
+                  row(A, "web", at(10, 50), 170.0) | {"cumulativeUsd": 170.0}]
+        got6 = {c["t"]: (c["corrected"], c["reason"]) for c in rp.plan(turns6, [at(10, 30)], DAY)["rows"]}
+        self.assertEqual(sorted(got6), [at(10, 50)])
+        self.assertEqual(got6[at(10, 50)][0], 10.0, "the turn's own cost: 170 less the replay row's 160, not less the first replay's 148.49")
+        self.assertIn("less the previous row's cumulative 160.0000", got6[at(10, 50)][1])
+        # the multi-replay window, a live turn, then a post-clear first paid turn: it stands (the first cut reduced it to
+        # 3.50 less 0.80 less 1.00 with no note, since 3.50 is above the attach-unknown row's 0.80)
+        turns7 = [row(A, "web", at(10, 40), 0.0) | {"cumulativeUsd": 0.8, "spendBaseline": "attach-unknown", "redelivered": True},
+                  row(A, "web", at(10, 42), 0.0) | {"cumulativeUsd": 3.0, "redelivered": True},
+                  row(A, "web", at(10, 45), 1.0) | {"cumulativeUsd": 4.0},
+                  row(A, "web", at(10, 50), 3.5) | {"cumulativeUsd": 3.5}]
+        p7 = rp.plan(turns7, [at(10, 30)], DAY)
+        self.assertEqual(p7["rows"], [], "a genuine post-clear turn is never reduced")
+        self.assertIn("3.5000 is at or below the previous row's 4.0000: a counter reset", p7["stoodDown"][0])
         # a fresh or seeded baseline row between disarms the chain: the later usd == cumulative row is nobody's lifetime
         turns5 = [row(A, "web", at(10, 40), 0.0) | {"cumulativeUsd": 100.0, "spendBaseline": "attach-unknown", "redelivered": True},
                   row(A, "web", at(10, 45), 3.0) | {"cumulativeUsd": 103.0, "spendBaseline": "seeded"},

--- a/tests/test_spend_repair.py
+++ b/tests/test_spend_repair.py
@@ -594,6 +594,26 @@ class Plan(unittest.TestCase):
         self.assertIn("note: hour %sT11 would go 489.0000 below zero; held at zero" % DAY, out.getvalue(), "said on --apply as a new line")
         self.assertEqual(json.loads((state / "spend.json").read_text())["hours"]["%sT11" % DAY]["usd"], 0.0)
 
+    def test_a_lifetime_billed_once_more_after_an_attach_unknown_row_is_corrected_and_a_first_result_row_is_not(self):
+        # the fix's first boot (2026-09-11 22:38Z, the rule the manager approved): the replayed attach-unknown first
+        # result folded nothing but left the watermark at zero, and the next live result recorded the whole cumulative
+        turns = [row(A, "web", at(10, 0), 3.0) | {"cumulativeUsd": 100.0},
+                 row(A, "web", at(10, 40), 0.0) | {"cumulativeUsd": 148.4878, "spendBaseline": "attach-unknown", "redelivered": True},
+                 row(A, "web", at(10, 50), 159.2004) | {"cumulativeUsd": 159.2004},         # usd equals its cumulative: the lifetime once more
+                 row(A, "web", at(11, 0), 2.0) | {"cumulativeUsd": 161.2004},               # an ordinary fixed-kernel row
+                 row(A, "web", at(11, 10), 4.5) | {"cumulativeUsd": 4.5, "spendBaseline": "fresh"},   # a fresh process's first result: its own
+                 row(A, "web", at(11, 20), 20.0) | {"cumulativeUsd": 24.5}]
+        p = rp.plan(turns, [at(10, 30)], DAY)
+        got = {c["t"]: (c["current"], c["corrected"], c["reason"]) for c in p["rows"]}
+        self.assertEqual(sorted(got), [at(10, 50)], "the lifetime row alone; the fresh first result and the ordinary rows stand")
+        cur, corr, why = got[at(10, 50)]
+        self.assertEqual((cur, corr), (159.2004, round(159.2004 - 148.4878, 6)))
+        self.assertIn("the lifetime billed once more after the attach-unknown row", why)
+        # a lifetime row with ordinary rows between it and the attach-unknown row subtracts them too
+        turns2 = [turns[1], row(A, "web", at(10, 45), 2.0) | {"cumulativeUsd": 150.4878}, turns[2] | {"usd": 161.2004, "cumulativeUsd": 161.2004}]
+        got2 = {c["t"]: c["corrected"] for c in rp.plan(turns2, [at(10, 30)], DAY)["rows"]}
+        self.assertEqual(got2, {at(10, 50): round(161.2004 - 148.4878 - 2.0, 6)})
+
     def test_a_fold_that_would_take_a_bucket_below_zero_is_said_not_hidden(self):
         spend = {"hours": {"%sT10" % DAY: {"usd": 1.0, "turns": 1, "bySid": {A: {"usd": 1.0}}}}, "days": {DAY: {"usd": 1.0, "turns": 1, "bySid": {A: {"usd": 1.0}}}}}
         p = {"day": DAY, "rows": [{"sid": A, "owner": A, "keyed": False, "name": "web", "t": at(10, 0), "hour": "%sT10" % DAY, "current": 5.0, "corrected": 0.0, "recorded": 5.0}]}


### PR DESCRIPTION
A follow-up to the spend ledger repair (`romp spend-repair`, merged as pull request 1443): one more rule, approved and applied live on 2026-09-11.

**A lifetime billed once more after an attach-unknown row.** On the kernel fix's first boot, a session's replayed first result under an unknown watermark folded nothing but left the watermark at zero, so the session's next live result recorded its whole cumulative as one turn. The repair reads that shape: a row whose `usd` equals its `cumulativeUsd`, following the same session's `attach-unknown` row, is corrected to the cumulative less that row's cumulative less the rows recorded between them. A fresh process's first result (a `spendBaseline` row) and an ordinary fixed-kernel row are never touched. Applied live at 22:44Z on two sessions (468.91 corrected to 12.27 together).

**Test** (`tests/test_spend_repair.py`): an attach-unknown row followed by a lifetime row is corrected and a fresh first result beside it stands; a lifetime row with rows between subtracts them too.

**Second round of the review.** The rule as first cut matched a counter reset: the first paid turn after a mid-life `/clear` is written with its dollars equal to its cumulative by design, so in a session carrying a same-day attach-unknown row that genuine turn was corrected to zero in silence, and a second run re-armed the chain on the corrected row and zeroed it again. Now the match requires the target's cumulative above the attach-unknown row's and a positive remainder, judged on the row's kernel figure every run; a non-positive remainder stands the rule down with a note in the report (never a clamp); the chain disarms on the row it judged, on a cumulative drop and on a fresh or seeded baseline row, so two runs over one ledger agree; lifetime corrections carry `repairRule` 5, and the journal's deltas carry the rule and the reason; a lifetime correction the rule no longer believes (its remainder gone, or its attach-unknown row) is restored to the kernel's figure with its marks dropped and its buckets re-folded. `docs/reference.md` states the new contract in place of the two sentences it falsified. Today's live ledger was audited read-only: the rule's two corrections stand above their attach-unknown cumulatives and no post-clear turn was touched. Tests: the post-clear shape stands with its note; the contradiction stands with its note; a seeded row disarms; two identical runs with the post-clear row present; the stamp on the row and in the journal's delta; a row zeroed the old way restored and a correction whose attach-unknown row is gone restored, buckets re-folded.

**Third round of the review.** The rule now uses the kernel's own arithmetic: a lifetime row's true cost is its cumulative less the previous same-session row's cumulative, and the guard is the kernel's reset comparison, the cumulative above that previous row's. The attach-unknown row's cumulative with a sum of the rows between was the wrong baseline twice over: the unknown window can replay several records, each written as a row with no dollars and a rising cumulative, so a live turn after two replays was corrected against the first replay's cumulative (21.51 where the turn cost 10.00), and a post-clear turn whose cumulative sat above the attach-unknown row's but below the previous row's was reduced with no note; against the previous row the first is right and the second stands down. The between-sum and its rule-stamp subtlety are gone with it. The two live corrections keep their figures (no rows between). Tests: the multi-replay window then a live turn (10.00, the reason naming the replay row's cumulative); the multi-replay window, a live turn, then a post-clear turn (stands, with its note); a cumulative above the attach-unknown row's but below the previous row's (stands, with its note).

Tier: fix
