### PR TITLE
The far host's parked-question note is the card's own line, dropped on any settle; the voice fixture renders the real header; a rowless recall list spends its entry

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -261,8 +261,8 @@ entry carries a token of its own that the spend's re-read compares, so a
 fresh entry flushed over the path during a pass is never taken for the spent
 one; a question the far host carried on before it could be withdrawn, or one
 the host could not be reached to withdraw, leaves a note on the node that the
-brief, the card and the modal show beside the block until a later relay
-reaches the peer); a parked
+brief's owed why carries and the card and the modal show as their own line
+under the brief, dropped when the node's wait next settles); a parked
 question completes only on the far
 host's delivered row, never on a later message; a refused relay's note reaches
 the card's brief beside the question it could not carry; a dead worker's block is not relayed; each record lands

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13183,6 +13183,14 @@ def _relay_marker_id(ev_t, peer="", nid=""):
     return "%d-%s-%s" % (int(ev_t or 0), str(peer or "")[:8] or "peer", str(nid or "").rsplit(":", 1)[-1] or "node")
 
 
+def _relay_owes_recall(nd):
+    """True when the node owes at least one recall ROW (a dict in relayRecall). The flush, the boot pass and the tick's
+    recall entry all ask this rather than the raw list's truth, so a list holding no dict (a hand-edited store, a
+    future writer's shape) never writes, re-queues or keeps an entry (the manager's fourth verdict)."""
+    lst = nd.get("relayRecall") if isinstance(nd, dict) else None
+    return isinstance(lst, list) and any(isinstance(r, dict) for r in lst)
+
+
 def _relay_retire_marker(store, nd):
     """Retire the node's marker for a wait that ended (a new wait replaces it, or the block became the user's): it is
     settled (relaySettled), and when it had already been handed to a far host (pendingMid: parked or unacked) it is
@@ -13312,7 +13320,7 @@ def _relay_flush(fsid, store, pending):
         rw = nd.get("relayWanted") if isinstance(nd, dict) else None
         if isinstance(rw, dict):
             n += 1 if _relay_write_entry(str(fsid), str(nid), rw.get("id") or "", store.get("rev") or 0) else 0
-        if isinstance(nd, dict) and nd.get("relayRecall"):   # recalls owed ride their own entry, beside the marker's
+        if _relay_owes_recall(nd):                         # recalls owed ride their own entry, beside the marker's
             n += 1 if _relay_write_entry(str(fsid), str(nid), "recall", store.get("rev") or 0) else 0
     return n
 
@@ -13333,7 +13341,7 @@ def _requeue_relays_all():
                 continue
             if isinstance(nd.get("relayWanted"), dict) and not _relay_entry_path(p.stem, nid).exists():
                 n += 1 if _relay_write_entry(p.stem, nid, nd["relayWanted"].get("id") or "", (raw or {}).get("rev") or 0) else 0
-            if nd.get("relayRecall") and not _relay_recall_entry_path(p.stem, nid).exists():   # recalls owed: their own entry
+            if _relay_owes_recall(nd) and not _relay_recall_entry_path(p.stem, nid).exists():   # recalls owed: their own entry
                 n += 1 if _relay_write_entry(p.stem, nid, "recall", (raw or {}).get("rev") or 0) else 0
     return n
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -13200,6 +13200,10 @@ def _relay_retire_marker(store, nd):
     if not isinstance(old, dict):
         return
     _relay_mark_settled(nd, old.get("id") or "")
+    nd.pop("relayCarried", None)                           # this road ends a wait without the kernel's settle (file_block
+    #                                                        deciding the block is the user's, a new wait replacing an ended
+    #                                                        one), and a stale "still parked" note would annotate every
+    #                                                        later block on the node and feed the distiller through _owed_why
     if old.get("pendingMid"):
         lst = [r for r in (nd.get("relayRecall") or []) if isinstance(r, dict)
                and str(r.get("pendingMid") or "") != str(old.get("pendingMid"))]

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3460,7 +3460,7 @@ def _relay_store(sid, ents, now, alive_ids=None):
             jd.save_goals(sid, store)                      # the record lands first; a raise here keeps the entry
         if spent:
             nd = store["nodes"].get(str(e["nid"]))
-            if isinstance(nd, dict) and nd.get("relayRecall") and not jd._relay_recall_entry_path(sid, str(e["nid"])).exists():
+            if jd._relay_owes_recall(nd) and not jd._relay_recall_entry_path(sid, str(e["nid"])).exists():   # the rows, like the other readers
                 jd._relay_write_entry(sid, str(e["nid"]), "recall", int(store.get("rev") or 0))   # a recall still owed:
                 quiet = False                              #   its OWN entry beside the marker's (never a rewrite of the
             _relay_spend(f, e)                             #   marker's file, which the judge may have renamed a newer

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3181,9 +3181,11 @@ def _relay_settle(nd, rw, now, key, **more):
     nd[key] = _relay_record(rw, now, **more)
     jd._relay_mark_settled(nd, rw.get("id") or "")
     nd.pop("relayWanted", None)
+    nd.pop("relayCarried", None)                           # ANY settle of the node's wait (relayed, stood down, refused) drops
+    #                                                        the note on a stale question a far host still held: a refused or
+    #                                                        user-owned next block never keeps a stale line (the fourth verdict)
     if key == "relayed":
         nd.pop("relayRefusal", None)                       # a later relay on the node succeeded: the old refusal's note goes
-        nd.pop("relayCarried", None)                       #   and so does the note on a stale question a far host still held
 
 
 def _relay_revert(store, nd, rw, err, now, ev_t=None):
@@ -3218,22 +3220,14 @@ def _relay_ended_since(sid, nid, t):
 
 def _relay_carried_note(r, how):
     """The note a node carries when a far host still holds a relayed question after its wait ended: who it was for,
-    where it sits, why it stands. Read by jd._owed_why (the brief's owed why), _brief_with_relay_note (the card and
-    the modal) and dropped when a later relay on the node reaches the peer (_relay_settle)."""
+    where it sits, why it stands. Read by jd._owed_why (the brief's owed why) and carried to the card and the modal
+    as their relayNote field (their own line under the brief, never a brief paragraph: the feed maps briefParts onto
+    the brief's paragraphs and a note paragraph broke every per-paragraph stamp); dropped on any settle of the node's
+    wait (_relay_settle: relayed, stood down or refused), so a refused or user-owned next block never keeps a stale
+    line (the manager's fourth verdict)."""
     peer = str(r.get("peer") or "")
     return "a question to %s is still parked on %s: %s" % (_name_of(peer) or peer[:8] or "the peer",
                                                           str(r.get("pendingHost") or "a far host"), how)
-
-
-def _brief_with_relay_note(nd):
-    """The node's decision brief as the card and the modal show it, with the kernel's note on a question a far host
-    still holds after the wait ended (relayCarried) as a closing line. The brief was distilled when the block was
-    filed and the recall's outcome comes ticks later, so the note rides beside it at read time and vanishes with it."""
-    brief = (nd or {}).get("blockSummary")
-    note = str((nd or {}).get("relayCarried") or "").strip()
-    if not note:
-        return brief
-    return ("%s\n\n%s" % (str(brief).rstrip(), note)) if brief else note
 
 
 def _relay_recall_sweep(sid, nd, now):
@@ -3246,6 +3240,9 @@ def _relay_recall_sweep(sid, nd, now):
     said a far host still held a question after its wait ended (the third verdict)."""
     owed = [r for r in (nd.get("relayRecall") or []) if isinstance(r, dict)]
     if not owed:
+        if nd.get("relayRecall"):                          # a list holding no recall row (a hand-edited store, a future
+            nd.pop("relayRecall", None)                    #   writer's shape): dropped, so its entry is spent and the boot
+            return True, 0                                 #   pass never re-queues it (the fourth verdict)
         return False, 0
     keep, done, changed = [], list(nd.get("relayRecalled") or []), False
     next_at = 0                                            # when the earliest hold ends: the tick looks again then
@@ -3302,7 +3299,7 @@ def _relay_entry(store, sid, f, e, rev, now, alive_ids=None):
         got = _relay_recall_sweep(sid, nd, now)          # (changed, when the earliest hold ends) on every path; a
         changed, recall_next = got if isinstance(got, tuple) and len(got) == 2 else (bool(got), 0)   # bare flag tolerated
     if marker == "recall":                                 # the node's recall entry (its own file beside the marker's)
-        owed = isinstance(nd, dict) and bool(nd.get("relayRecall"))
+        owed = jd._relay_owes_recall(nd)                   # from the recall ROWS, so a junk list's entry is spent
         return 0, changed, not owed, (False if changed else (recall_next or True))
     rw = nd.get("relayWanted") if isinstance(nd, dict) else None
     if not isinstance(rw, dict) or (marker and str(rw.get("id") or "") != marker):
@@ -36145,7 +36142,8 @@ def build_feed(now, live_map=None):
                         "anchorUuid": _wa,
                         "promptAnchorUuid": _pa,
                         "summary": nd.get("summary"),                   # distiller's key takeaway — shown in the MODAL only — the user 2026-06-17
-                        "blockSummary": _brief_with_relay_note(nd),     # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18; a far host's parked question noted under it
+                        "blockSummary": nd.get("blockSummary"),         # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18
+                        "relayNote": nd.get("relayCarried") or None,    # a far host still holds a relayed question after its wait ended (relayCarried): its own line under the brief, never a brief paragraph (briefParts maps those)
                         "followupPending": nd.get("followupPending"),   # per-node "Followed up" chip in the modal tree (business 2026-06-17)
                         # the per-item story (MODAL, non-done only): newest block/unblock/verdict rows with
                         # anchors, so an open sub answers 'is this still active?' in place (the user 2026-07-20)
@@ -36693,7 +36691,8 @@ def build_feed(now, live_map=None):
                               "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
                 "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
                 "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
-                "blockSummary": _brief_with_relay_note(nodes[nid]),   # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18; a far host's parked question noted under it
+                "blockSummary": nodes[nid].get("blockSummary"),    # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18
+                "relayNote": nodes[nid].get("relayCarried") or None,   # a far host still holds a relayed question after its wait ended (relayCarried): the card's own line under the brief, never a brief paragraph (the per-paragraph stamps map briefParts onto the brief's paragraphs and allow exactly one extra)
                 "briefParts": nodes[nid].get("briefParts") or None,   # MULTI-item brief: [{id, since}] one per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null for single-item briefs, whose stamp is the card header's age (the user 2026-07-24)
                 "summaryParts": nodes[nid].get("summaryParts") or None,
                 # the user FOLLOWED UP after the takeaway they read (followupAt postdates what the

--- a/tests/test_injected_voice.py
+++ b/tests/test_injected_voice.py
@@ -86,6 +86,15 @@ def prose(body):
     return body.split("<!--")[0]
 
 
+def _atom(role, text, tools=0):
+    blocks = [{"type": "text", "text": text}] + [{"type": "tool_use", "name": "Read"} for _ in range(tools)]
+    return {"type": role, "t": 1, "message": {"role": role, "content": blocks}}
+
+
+_RELAY_TURN = {"t": 1, "end": 2, "atoms": [_atom("user", "start on the exporter"),
+                                         _atom("assistant", "which client should it target?", tools=2)]}
+
+
 class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
@@ -143,8 +152,9 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
             "relayed question (procedural why)": km._relay_body("api", jd.NUDGE_BLOCK_WHY),
             "relayed question (with the conversation)": km._relay_body(
                 "api", "which client should the exporter target?",
-                "The conversation this question ends, oldest first: 1 of 1 turn.\n\n--- turn 1 of 1 ---\n"
-                "user: start on the exporter\napi: which client should it target?\n(2 tool calls)"),
+                jd._relay_excerpt([_RELAY_TURN], 1, 4096, who="api")),   # the REAL header and turn rendering, so the
+            #                                                             scan reads the words the code emits (the
+            #                                                             manager's fourth verdict: a copied header went stale)
             # a comment thread's opening message (the user 2026-08-13): the highlight + comment are
             # the user's own words; the quoting frame around them is romp-authored and scanned here
             "comment thread opener": km._comment_first_message(
@@ -165,6 +175,13 @@ class InjectedBodiesSpeakAsTheUser(unittest.TestCase):
         for i, v in enumerate(km.AUTO_NUDGE_STALLED_VARIANTS, 1):
             bodies["fork nudge variant %d" % i] = v
         return bodies
+
+    def test_the_relayed_conversation_fixture_is_rendered_by_the_real_excerpt(self):
+        body = self._bodies()["relayed question (with the conversation)"]
+        self.assertIn("The conversation this question ends, oldest first: 1 of 1 turn shown.", body)
+        self.assertIn("user: start on the exporter", body)
+        self.assertIn("(2 tool calls)", body)
+        self.assertNotIn("1 of 1 turn.\n", body, "the pre-change header wording is gone from the fixture")
 
     def test_the_relay_scrub_speaks_this_lists_words(self):
         # the kernel scrubs a relayed question's why by the same vocabulary this file scans for (T334): one list

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -1752,6 +1752,9 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertFalse(jd._relay_recall_entry_path(WORKER, step).exists(), "the junk list's entry is spent, not kept for good")
         self.assertNotIn("relayRecall", jd.load_goals(WORKER)["nodes"][step], "and the junk list is dropped from the node")
         self.assertEqual(jd._requeue_relays_all(), 0, "the boot pass re-queues nothing for it")
+        src = Path(km.__file__).read_text()
+        self.assertIn("if jd._relay_owes_recall(nd) and not jd._relay_recall_entry_path(sid, str(e[\"nid\"])).exists():", src,
+                      "the re-queue on a spent marker entry reads the rows too, like the sweep, the flush and the boot pass")
 
     def test_a_question_a_far_host_still_holds_is_noted_beside_the_block(self):
         st, top, step = self.store(delegated=True)
@@ -1821,6 +1824,31 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertNotIn("relayCarried", nd, "any settle of the wait drops the stale line: %s" % outcome)
         self.assertNotIn("relayWanted", nd)
         return nd
+
+    def test_the_parked_note_is_dropped_when_the_users_follow_up_makes_the_block_theirs(self):
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-ret-a", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "still stuck", NOW + 60)     # M1 retired while parked, M2 minted
+        self._save(st)
+        km._bus_recall_relay = lambda sid, mid: "carried"
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-ret-b", "parked": "TESTHOST"})
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._relay_tick(NOW + 70)                       # px-ret-a carried: the note; M2 pending on the far host
+        st = jd.load_goals(WORKER)
+        self.assertIn("relayCarried", st["nodes"][step])
+        jd.record_verdict(st, st["nodes"][top], "user", "reopen", NOW + 80, msg=True)   # the user follows up: the next block is theirs
+        self._close(st, step, "still stuck after the answer", NOW + 85)   # file_block: the user's block, M2 retired on the judge's road
+        nd = st["nodes"][step]
+        self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
+        self.assertNotIn("relayCarried", nd, "the retire road drops the note: no kernel settle runs for this wait")
+        self.assertNotIn("still parked", jd._owed_why(nd), "so the distiller's owed why never carries the stale line")
+        self.assertEqual([r["pendingMid"] for r in nd["relayRecall"]], ["px-ret-b"], "M2's recall is still owed")
 
     def test_the_parked_note_is_dropped_when_the_next_relay_is_refused(self):
         nd = self._carried_note_then("refused")

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -1749,6 +1749,9 @@ class SaverFlushesItsOwn(_RelayFixture):
         with contextlib.redirect_stderr(io.StringIO()) as err:
             self.assertEqual(km._relay_tick(NOW), 1, "the question goes out; the junk list is skipped, never raised on")
         self.assertNotIn("Traceback", err.getvalue())
+        self.assertFalse(jd._relay_recall_entry_path(WORKER, step).exists(), "the junk list's entry is spent, not kept for good")
+        self.assertNotIn("relayRecall", jd.load_goals(WORKER)["nodes"][step], "and the junk list is dropped from the node")
+        self.assertEqual(jd._requeue_relays_all(), 0, "the boot pass re-queues nothing for it")
 
     def test_a_question_a_far_host_still_holds_is_noted_beside_the_block(self):
         st, top, step = self.store(delegated=True)
@@ -1768,10 +1771,11 @@ class SaverFlushesItsOwn(_RelayFixture):
         self.assertIn("still parked on TESTHOST", nd["relayCarried"])
         self.assertIn("before it could be withdrawn", nd["relayCarried"])
         self.assertTrue(jd._owed_why(nd).endswith("(%s)" % nd["relayCarried"]), "the brief's owed why carries the note in brackets")
-        nd["blockSummary"] = "Decide the retry policy."
-        self.assertEqual(km._brief_with_relay_note(nd), "Decide the retry policy.\n\n" + nd["relayCarried"], "the card and the modal show it under the brief")
-        self.assertEqual(km._brief_with_relay_note({"relayCarried": nd["relayCarried"]}), nd["relayCarried"], "and alone before the brief is distilled")
-        self.assertIsNone(km._brief_with_relay_note({}), "no note, no brief: null as before")
+        src = Path(km.__file__).read_text()                   # the card and the modal carry the note as their OWN field: a
+        self.assertIn('"relayNote": nodes[nid].get("relayCarried") or None,', src)   #   paragraph appended to the brief broke the
+        self.assertIn('"relayNote": nd.get("relayCarried") or None,', src)           #   feed's per-paragraph stamps (fourth verdict)
+        self.assertFalse(hasattr(km, "_brief_with_relay_note"), "the brief is the distiller's alone")
+        self.assertNotIn("_brief_with_relay_note", src)
         st = jd.load_goals(WORKER)                         # a later relay that reaches the peer drops the note
         jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 75, why="", lift=True, end_ev=NOW + 75)
         self._close(st, step, "a fresh question", NOW + 80)
@@ -1781,6 +1785,50 @@ class SaverFlushesItsOwn(_RelayFixture):
         with contextlib.redirect_stderr(io.StringIO()):
             self.assertEqual(km._relay_tick(NOW + 90), 1)
         self.assertNotIn("relayCarried", jd.load_goals(WORKER)["nodes"][step])
+
+    def _carried_note_then(self, outcome):
+        """A carried note on the node, then M2's wait settles by `outcome`: the note must go either way."""
+        st, top, step = self.store(delegated=True)
+        self._close(st, step, "first question", T0 + 400)
+        self._save(st)
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-any-1", "parked": "TESTHOST"})
+        self.assertEqual(km._relay_tick(NOW), 0)
+        st = jd.load_goals(WORKER)
+        jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 5, why="", lift=True, end_ev=NOW + 5)
+        self._close(st, step, "still stuck", NOW + 60)     # M1 retired while parked, M2 minted
+        self._save(st)
+        km._bus_recall_relay = lambda sid, mid: "carried"
+        km._bus_send_relay = lambda payload: (True, "", False, {"ok": True, "id": "px-any-2", "parked": "TESTHOST"})
+        with contextlib.redirect_stderr(io.StringIO()):
+            km._relay_tick(NOW + 70)
+        self.assertIn("relayCarried", jd.load_goals(WORKER)["nodes"][step])
+        km._bus_recall_relay = lambda sid, mid: "withdrawn"
+        if outcome == "refused":                           # M2 comes back: the block is the user's, with the refusal noted
+            real = km._relay_pending_status
+            km._relay_pending_status = lambda sid, peer, mid, at: ("bounced", "no live recipient on TESTHOST", NOW + 80)
+            try:
+                with contextlib.redirect_stderr(io.StringIO()):
+                    km._relay_tick(NOW + 90)
+            finally:
+                km._relay_pending_status = real
+        else:                                              # M2's wait ended another way: stood down
+            st = jd.load_goals(WORKER)
+            jd.record_verdict(st, st["nodes"][step], "romp", "awaiting", NOW + 80, why="", lift=True, end_ev=NOW + 80)
+            jd.save_goals(WORKER, st)
+            with contextlib.redirect_stderr(io.StringIO()):
+                km._relay_tick(NOW + 90)
+        nd = jd.load_goals(WORKER)["nodes"][step]
+        self.assertNotIn("relayCarried", nd, "any settle of the wait drops the stale line: %s" % outcome)
+        self.assertNotIn("relayWanted", nd)
+        return nd
+
+    def test_the_parked_note_is_dropped_when_the_next_relay_is_refused(self):
+        nd = self._carried_note_then("refused")
+        self.assertIn("could not be asked", nd.get("relayRefusal") or "", "the refusal's own note stands")
+
+    def test_the_parked_note_is_dropped_when_the_next_wait_stands_down(self):
+        nd = self._carried_note_then("stood-down")
+        self.assertEqual((nd.get("relayDone") or {}).get("outcome"), "stood-down")
 
     def test_an_unanswerable_recall_is_said_once_and_backs_off(self):
         st, top, step = self.store(delegated=True)

--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -1029,3 +1029,35 @@ test("a header re-mints its name nodes when its host's link goes down or comes b
   mock.timers.tick(700);
   mock.timers.reset();
 });
+
+test("a far host's parked-question note shows on its own line with no brief, in collapsed mode and on a working card, and clears on the next push", async () => {
+  mock.timers.enable({ apis: ["Date", "setTimeout", "setInterval"], now: T0 * 1000 });
+  const note = "a question to api is still parked on PEERHOST: it went on before it could be withdrawn";
+  // a blocked card with NO brief yet (the distiller still running): the section logic chooses "none" and hides the distill line
+  const g4 = cardOf("g4", WEB, "web", "#3366cc", "Decide the exporter's client", "needs_input", { distillState: "blocked", relayNote: note });
+  await dispatch(frame([g1, g4]));
+  const rn = () => card("g4")._relayNote;
+  assert.equal(card("g4")._distill.style.display, "none", "the distill line is hidden without a brief");
+  assert.equal(rn().textContent, note, "the note is the card's own line");
+  assert.equal(rn().style.display, "", "…and shows (appended inside the distill element it was hidden with it)");
+  assert.equal(rn().parentNode, card("g4")._secs.parentNode, "beside the sections, not inside them");
+  // collapsed mode: every section closed by default, the brief's included
+  const setPrefs = (v: string) => { stores.local.set("romp:settings", v); win.dispatchEvent(Object.assign(new Event("storage"), { key: "romp:settings", newValue: v })); };
+  setPrefs(JSON.stringify({ collapsed: true }));
+  await dispatch(frame([g1, { ...g4, blockSummary: "Pick the client the exporter targets." }]));
+  assert.equal(card("g4")._distill.style.display, "none", "collapsed: the brief's section is closed");
+  assert.equal(rn().style.display, "", "the note still shows");
+  assert.equal(rn().textContent, note);
+  setPrefs(JSON.stringify({}));
+  // a working-column card, where the brief is withheld: the note shows all the same
+  await dispatch(frame([{ ...g1, relayNote: note }, g4], { working: ["web"] }));
+  assert.equal(card("g1")._distill.style.display, "none", "working: no distill line");
+  assert.equal(card("g1")._relayNote.style.display, "", "the note shows on a working card");
+  assert.equal(card("g1")._relayNote.textContent, note);
+  // the next push without the record clears it
+  await dispatch(frame([g1, { ...g4, blockSummary: "Pick the client the exporter targets.", relayNote: null }]));
+  assert.equal(rn().style.display, "none", "cleared when the kernel stops sending it");
+  assert.equal(rn().textContent, "");
+  assert.equal(card("g1")._relayNote.style.display, "none");
+  mock.timers.reset();
+});

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1307,8 +1307,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 /* the STALE-takeaway note above a completed card's summary: the user followed up after reading it */
 .fsum-stale { font-style: italic; opacity: 0.62; font-size: 0.92em; margin-bottom: 3px; }
 /* A far host still holds a relayed question after its wait ended (feed.ts relayNote): the card's own dim line
-   under the brief, never a paragraph of it (the per-paragraph stamps map the brief's paragraphs). */
-.fsum-relaynote { color: var(--dim); font-size: 0.92em; margin-top: 3px; white-space: pre-wrap; overflow-wrap: anywhere; }
+   beside the sections (outside them, like the face), never a paragraph of the brief (the per-paragraph stamps
+   map the brief's paragraphs) and never inside the distill element (the sections hide that without a brief). */
+.fask-relaynote { color: var(--dim); opacity: 1; white-space: pre-wrap; overflow-wrap: anywhere; }
 .fcheck-text.lz-hl { background: rgba(255, 255, 255, 0.12); border-radius: 3px; box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12); }
 .fcheck-mark.lz-hl { box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16); }
 /* standalone-completion modal: same tree vocabulary as ask cards; pending

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -766,6 +766,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ftree-seclabel { font-size: 0.92em; color: var(--dim); margin-top: 4px; }
 .ftree-summary-link { cursor: pointer; border-radius: 6px; transition: background 0.1s ease; }
 .ftree-summary-link:hover { background: rgba(255, 255, 255, 0.07); text-decoration: underline; text-underline-offset: 2px; }
+.ftree-relaynote { font-size: 0.86em; line-height: 1.45; margin: 0 0 6px; color: var(--dim); white-space: pre-wrap; overflow-wrap: anywhere; }   /* the modal's twin of .fsum-relaynote */
 .st-done .ftree-mark { color: var(--rel-done); }
 /* a BLOCKED (needs-you) node: the "?" is RED inside a RED ring the SAME 13px size as the ✓ checkbox disc,
    and its label reads "BLOCKED" in red (the user 2026-06-17) — a stronger, unmistakable block signal than
@@ -1305,6 +1306,9 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .fcheck.freviewed:hover { opacity: 0.85; }
 /* the STALE-takeaway note above a completed card's summary: the user followed up after reading it */
 .fsum-stale { font-style: italic; opacity: 0.62; font-size: 0.92em; margin-bottom: 3px; }
+/* A far host still holds a relayed question after its wait ended (feed.ts relayNote): the card's own dim line
+   under the brief, never a paragraph of it (the per-paragraph stamps map the brief's paragraphs). */
+.fsum-relaynote { color: var(--dim); font-size: 0.92em; margin-top: 3px; white-space: pre-wrap; overflow-wrap: anywhere; }
 .fcheck-text.lz-hl { background: rgba(255, 255, 255, 0.12); border-radius: 3px; box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.12); }
 .fcheck-mark.lz-hl { box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16); }
 /* standalone-completion modal: same tree vocabulary as ask cards; pending

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -2296,18 +2296,6 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     sn.textContent = staleNote;
     (a._distill as HTMLElement).prepend(sn);
   }
-  // A far host still holds a relayed question after its wait ended (it.relayNote, kernel relayCarried: the
-  // question went on before it could be withdrawn, or the host could not be reached to withdraw it). Its OWN
-  // dim line under the brief, never a paragraph OF the brief: the per-paragraph stamps above map briefParts
-  // onto the brief's paragraphs and allow exactly one extra, so a note paragraph dropped every stamp and
-  // citation on a briefed top node. Appended after the parts-split and the stale note (both rewrite the
-  // element), so it survives either rendering; shown on its own while no brief exists yet.
-  if (it.relayNote) {
-    const rn = el("div", "fsum-relaynote");
-    rn.textContent = it.relayNote;
-    (a._distill as HTMLElement).append(rn);
-    (a._distill as HTMLElement).style.display = "";
-  }
   const dl = a._distill as HTMLElement;
   if (distillShown && it.summaryAnchorUuid) {
     dl.classList.add("fask-distill-link");
@@ -2362,6 +2350,27 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
       fe.textContent = "";
       fe.style.display = "none";
     }
+  }
+  // A far host still holds a relayed question after its wait ended (it.relayNote, kernel relayCarried: the
+  // question went on before it could be withdrawn, or the host could not be reached to withdraw it). Its OWN
+  // line like the face above, created once beside the sections, kept OUTSIDE them and set AFTER the section
+  // logic: appended inside the distill element it was hidden with that line (no brief yet → the sections
+  // choose none and set the element's display to none; likewise in collapsed mode, on a card whose open
+  // section is not the summary, and on a working-column card, where the brief is withheld). Never a
+  // paragraph OF the brief either: the per-paragraph stamps map briefParts onto the brief's paragraphs and
+  // allow exactly one extra, so a note paragraph dropped every stamp and citation on a briefed top node.
+  // The effect is RUN in feed-render-incremental.test.ts (no brief, collapsed mode, a working card).
+  {
+    let rn = a._relayNote as HTMLElement | undefined;
+    if (!rn) {
+      rn = el("div", "fask-distill fask-relaynote");
+      const anchor = (a._face as HTMLElement | undefined) || (a._secs as HTMLElement);
+      anchor.parentNode!.insertBefore(rn, anchor.nextSibling);
+      a._relayNote = rn;
+    }
+    const note = (it.relayNote || "").trim();
+    rn.textContent = note;
+    rn.style.display = note ? "" : "none";
   }
   // API error → a red "API error" badge + a Retry button that pastes "retry" into the session to resume
   // the stalled turn (the user 2026-06-16). The card STAYS in Working (the user 2026-06-29) — an API error is

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -70,6 +70,7 @@ interface AskTreeNode {
   followupPending?: boolean;                                     // this sub was optimistically reopened by a per-sub follow-up → "↻ Followed up" chip (kernel flatten, judges 047264f)
   summary?: string | null;                                       // the DISTILLER's key takeaway for a completed goal (artifact or 1-3 sentences) → the modal's auto-line for a DONE node (kernel flatten 78fc97b)
   blockSummary?: string | null;                                  // the BLOCK-distiller's decision brief for a blocked goal → the modal's auto-line for a BLOCKED node (kernel 466393c); null until produced
+  relayNote?: string | null;   // a far host still holds a relayed question after its wait ended (kernel relayCarried) → its own dim line under the brief, never a brief paragraph
   trgb?: [number, number, number];                               // last-activity recency tint (timestamp)
   cleared?: boolean;                                             // user-cleared sub (nodeOverride op:clear) → struck-through faded row + "cleared" chip; the mark stays tied to status (box = done, the user 2026-07-26)
   reviewedEarlier?: boolean;                                     // this done sub predates the top's review boundary (kernel flatten ↔ jd.review_boundary, the distiller's own scoping) → collapsed behind one "N reviewed earlier" row (the user 2026-08-19)
@@ -119,6 +120,7 @@ interface AskItem {
   summary?: string | null;                         // distiller's key takeaway for a COMPLETED goal → the done card's one auto-written line (kernel asks.append); null until produced
   distillState?: "completed" | "blocked" | null;   // the GENUINE resolution state the distiller line keys on, so the brief/takeaway rides the real block instead of the transient `column` (which recheck/rejudging flicker to working) — the user 2026-07-21; absent from older/remote payloads → fall back to column
   blockSummary?: string | null;                    // block-distiller's decision brief for a BLOCKED goal → the blocked card's one auto-written line (kernel 466393c); null until produced
+  relayNote?: string | null;   // a far host still holds a relayed question after its wait ended (kernel relayCarried) → its own dim line under the brief, never a brief paragraph
   briefParts?: { id?: string; since: number }[] | null;   // MULTI-item brief: one {id, since} per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null/absent = single ask, the card header's age is the stamp (the user 2026-07-24)
   summaryParts?: { id?: string; since: number }[] | null;   // the DONE twin: per-paragraph done-event stamps for a takeaway the distiller split by <completed-items> (the user 2026-07-24)
   summaryStale?: boolean;                          // the user followed up AFTER the shown takeaway (kernel: followupAt > distilledMt) → the summary section carries the stale note until the re-distill lands (the user 2026-08-19)
@@ -2294,6 +2296,18 @@ function updateAskCard(card: HTMLElement, it: AskItem) {
     sn.textContent = staleNote;
     (a._distill as HTMLElement).prepend(sn);
   }
+  // A far host still holds a relayed question after its wait ended (it.relayNote, kernel relayCarried: the
+  // question went on before it could be withdrawn, or the host could not be reached to withdraw it). Its OWN
+  // dim line under the brief, never a paragraph OF the brief: the per-paragraph stamps above map briefParts
+  // onto the brief's paragraphs and allow exactly one extra, so a note paragraph dropped every stamp and
+  // citation on a briefed top node. Appended after the parts-split and the stale note (both rewrite the
+  // element), so it survives either rendering; shown on its own while no brief exists yet.
+  if (it.relayNote) {
+    const rn = el("div", "fsum-relaynote");
+    rn.textContent = it.relayNote;
+    (a._distill as HTMLElement).append(rn);
+    (a._distill as HTMLElement).style.display = "";
+  }
   const dl = a._distill as HTMLElement;
   if (distillShown && it.summaryAnchorUuid) {
     dl.classList.add("fask-distill-link");
@@ -3276,6 +3290,13 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
       sum.onclick = goWork;
     }
     box.appendChild(sum);
+  }
+  // The same note in the modal tree (node.relayNote): its own line under the node's brief, never part of it.
+  if (node.relayNote) {
+    const rn = el("div", "ftree-relaynote");
+    rn.style.paddingLeft = ((depth + 1) * TREE_INDENT_EM) + "em";
+    rn.textContent = node.relayNote;
+    box.appendChild(rn);
   }
   // The per-item STORY (the user 2026-07-20: 'I don't know if they're still active'): a non-done node
   // with verdict history shows a one-line gist — its newest event in outcome words + how long ago —

--- a/ui/webview/relay-note.test.ts
+++ b/ui/webview/relay-note.test.ts
@@ -1,0 +1,36 @@
+// A far host still holding a relayed question after its wait ended is said on the card and in the modal as
+// its OWN line (relayNote), never as a paragraph appended to the brief: the feed maps briefParts onto the
+// brief's paragraphs and allows exactly one extra, so a note paragraph on a briefed top node dropped every
+// per-paragraph age stamp and citation (the manager's fourth verdict on the peer wait). No jsdom for the feed
+// renderer, so the wiring is pinned at the source, as feed-distill-state.test.ts pins the distiller line.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const FEED = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "feed.css"), "utf8");
+
+test("the card item and the modal tree node both carry relayNote from the kernel", () => {
+  assert.equal((FEED.match(/^  relayNote\?: string \| null;/gm) || []).length, 2);
+});
+
+test("the card renders the note as its own element after the parts-split, never inside the brief's text", () => {
+  const i = FEED.indexOf('el("div", "fsum-relaynote")');
+  assert.ok(i > 0, "the note element exists");
+  const split = FEED.indexOf("distillShown.split(/\\n\\s*\\n/)");
+  assert.ok(split > 0 && split < i, "appended after the paragraph split, which rewrites the element");
+  assert.match(FEED, /rn\.textContent = it\.relayNote;\s*\n\s*\(a\._distill as HTMLElement\)\.append\(rn\);\s*\n\s*\(a\._distill as HTMLElement\)\.style\.display = "";/,
+               "appended to the distill element and shown even before a brief exists");
+  // the brief's paragraph count is read from the TEXT the distiller line returned, so the note element never joins it
+  assert.doesNotMatch(FEED, /blockSummary[^\n]*relayNote|relayNote[^\n]*blockSummary/, "the note is never folded into the brief's text");
+});
+
+test("the modal tree shows the note under the node's brief, indented with the node", () => {
+  assert.match(FEED, /if \(node\.relayNote\) \{\s*\n\s*const rn = el\("div", "ftree-relaynote"\);\s*\n\s*rn\.style\.paddingLeft = \(\(depth \+ 1\) \* TREE_INDENT_EM\) \+ "em";/);
+});
+
+test("both lines are styled dim, as a note beside the brief and not the brief", () => {
+  assert.match(CSS, /\.fsum-relaynote \{[^}]*color: var\(--dim\)/);
+  assert.match(CSS, /\.ftree-relaynote \{[^}]*color: var\(--dim\)/);
+});

--- a/ui/webview/relay-note.test.ts
+++ b/ui/webview/relay-note.test.ts
@@ -1,8 +1,12 @@
 // A far host still holding a relayed question after its wait ended is said on the card and in the modal as
-// its OWN line (relayNote), never as a paragraph appended to the brief: the feed maps briefParts onto the
+// its OWN line (relayNote), never as a paragraph appended to the brief (the feed maps briefParts onto the
 // brief's paragraphs and allows exactly one extra, so a note paragraph on a briefed top node dropped every
-// per-paragraph age stamp and citation (the manager's fourth verdict on the peer wait). No jsdom for the feed
-// renderer, so the wiring is pinned at the source, as feed-distill-state.test.ts pins the distiller line.
+// per-paragraph age stamp and citation) and never inside the distill element (the section logic sets that
+// element's display to none without a brief, in collapsed mode, when another section is open and on a
+// working-column card, so a note appended there showed nothing; the manager's verifier on this change). The
+// card's wiring is pinned here at the source, as session-started-face.test.ts pins the face line it mirrors;
+// the EFFECT (the note visible with no brief, in collapsed mode, on a working card, cleared on the next
+// push) is RUN under the DOM stand-in in feed-render-incremental.test.ts.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -15,15 +19,16 @@ test("the card item and the modal tree node both carry relayNote from the kernel
   assert.equal((FEED.match(/^  relayNote\?: string \| null;/gm) || []).length, 2);
 });
 
-test("the card renders the note as its own element after the parts-split, never inside the brief's text", () => {
-  const i = FEED.indexOf('el("div", "fsum-relaynote")');
-  assert.ok(i > 0, "the note element exists");
-  const split = FEED.indexOf("distillShown.split(/\\n\\s*\\n/)");
-  assert.ok(split > 0 && split < i, "appended after the paragraph split, which rewrites the element");
-  assert.match(FEED, /rn\.textContent = it\.relayNote;\s*\n\s*\(a\._distill as HTMLElement\)\.append\(rn\);\s*\n\s*\(a\._distill as HTMLElement\)\.style\.display = "";/,
-               "appended to the distill element and shown even before a brief exists");
-  // the brief's paragraph count is read from the TEXT the distiller line returned, so the note element never joins it
-  assert.doesNotMatch(FEED, /blockSummary[^\n]*relayNote|relayNote[^\n]*blockSummary/, "the note is never folded into the brief's text");
+test("the card's note is its own element beside the sections, outside them, set after the section logic", () => {
+  const made = FEED.indexOf('rn = el("div", "fask-distill fask-relaynote");');
+  assert.ok(made > 0, "the note has its own element (the distill line's look), created once");
+  assert.ok(FEED.includes("anchor.parentNode!.insertBefore(rn, anchor.nextSibling);"), "inserted beside the sections, never inside them or the distill element");
+  const sections = FEED.indexOf("applySections(a, it, !!distillShown);");
+  assert.ok(sections > 0 && made > sections, "set after the section logic runs, so nothing re-hides it");
+  const body = FEED.slice(FEED.indexOf("function applySections("), FEED.indexOf("\nfunction updateAskCard("));
+  assert.ok(body.length > 1000 && !body.includes("_relayNote"), "the section logic never touches the note's element");
+  assert.doesNotMatch(FEED, /\(a\._distill as HTMLElement\)\.append\(rn\)/, "never appended into the distill element again");
+  assert.doesNotMatch(FEED, /blockSummary[^\n]*relayNote|relayNote[^\n]*blockSummary/, "never folded into the brief's text");
 });
 
 test("the modal tree shows the note under the node's brief, indented with the node", () => {
@@ -31,6 +36,6 @@ test("the modal tree shows the note under the node's brief, indented with the no
 });
 
 test("both lines are styled dim, as a note beside the brief and not the brief", () => {
-  assert.match(CSS, /\.fsum-relaynote \{[^}]*color: var\(--dim\)/);
+  assert.match(CSS, /\.fask-relaynote \{[^}]*color: var\(--dim\)/);
   assert.match(CSS, /\.ftree-relaynote \{[^}]*color: var\(--dim\)/);
 });


### PR DESCRIPTION
## What

Four small fixes to the peer-wait relay and its relayed context, from the manager's verification of the two changes that landed just before this one: how the card tells the user that a far host still holds a relayed question after its wait ended, when that note goes away, a voice fixture that had drifted from the code, and a recall list with no rows leaving a queue entry behind for good.

## Fixes

- **The parked-question note is the card's own line, not a paragraph of the brief.** The kernel carried it to the card and the modal by appending a paragraph to the decision brief. The feed maps the brief's per-paragraph age stamps and citations onto the brief's paragraphs and allows exactly one extra trailing paragraph, so on a briefed top node the appended note dropped every stamp and citation. The note now rides as its own field (`relayNote`) on the card item and on each modal tree node; the webview renders it as its own dim line beside the collapsible sections, created once and kept outside them like the session-started face line, and set after the section logic runs. Inside the distill element it was hidden with that line: without a brief the sections choose none and set the element's display to none, and the same happens in collapsed mode, when another section is open, and on a working-column card, where the brief is withheld. The effect is run under the feed's DOM stand-in: the note visible with no brief, in collapsed mode and on a working card, cleared on the next push. The brief is the distiller's alone again.
- **The note is dropped whenever the node's wait ends.** It was cleared only by a later relay that reached the peer, so a refused or user-owned next block kept a stale "still parked" line. Every settle of the node's wait, relayed, stood down or refused, drops it, and so does the judge's own retire of a marker (the block decided to be the user's, or a new wait replacing an ended one), a road that reaches no kernel settle and would otherwise have annotated every later block on the node and fed the distiller through the owed why.
- **The voice fixture renders the header through the real function.** The injected-voice test's fixture for a relayed question with its conversation carried a copied header whose wording the code no longer emits, so the romp-vocabulary scan was reading stale words. The fixture builds its excerpt through the excerpt function from a synthetic turn.
- **A recall list holding no rows spends its entry.** Whether a node owes a recall was read from the raw list's truth while the sweep filtered for rows, so a hand-edited or future-shaped list kept the node's recall entry in the queue for good and the boot pass re-queued it. Owed is now read from the rows in every reader, the flush, the boot pass, the tick's recall entry and the re-queue on a spent marker entry, and the sweep drops a rowless list.

## Tests

`tests/test_peer_wait_blocks.py`: the payload fields pinned at the source and the brief helper gone; the note dropped after a refused relay, after a stood-down wait, and on the judge's retire when the user's follow-up makes the next block theirs (through the block writer, the owed why clean); the rowless list's entry spent, the list dropped, nothing re-queued at boot, the fourth reader pinned. `tests/test_injected_voice.py`: the fixture carries the real header and turn. `ui/webview/feed-render-incremental.test.ts`: the card update run under the DOM stand-in, the note visible with no brief, in collapsed mode and on a working card, cleared on the next push. `ui/webview/relay-note.test.ts`: both types carry the field, the card's element sits beside the sections and is set after the section logic, which never touches it, the modal indents it with the node, both lines dim.

Tier: fix
