### PR TITLE
A comment thread's mail-off rule, two later lows: the comments frame carries the reason, the unreadable-record check reads the registration memo (T356 third follow-up)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14910,10 +14910,13 @@ def _comments_frame(sid, live_map=None):
                         "lastUuid": last_uuid,                         # the newest record shown/held — the client's cap-proof "transcript moved" datum
                         "unreachable": unreachable or None,            # a broken thread (missing transcript / lost cut): owes nothing
                         "promotedName": th.get("promotedName") or "",
-                        # the thread's mail state (T356): off by default until broken out. The popover does not announce
-                        # it (the user 2026-09-11; the tab hover and the Sessions pane carry the state); it shows only how
-                        # many messages wait in the box (they land within the bus's retry interval of a break-out)
+                        # the thread's mail state (T356): off by default until broken out. An open thread's popover does
+                        # not announce it (the user 2026-09-11; the tab hover and the Sessions pane carry the state) and
+                        # shows only how many messages wait in the box (they land within the bus's retry interval of a
+                        # break-out); the PROMOTED view says whether its mail is on, and why not when it is not, so the
+                        # reason rides beside the boolean (an unreadable record is no mailbox toggle's to clear)
                         "mailOff": bool(_postal_isolated(tsid)),
+                        "mailOffWhy": _mail_off_why_k(tsid),
                         "heldMail": _held_mail_count(tsid),
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
@@ -24156,11 +24159,14 @@ def _reg_unreadable(sid):
         return False
     p = jd.STATE / "sdk" / (str(sid) + ".json")
     try:
-        if not p.exists():
-            return False
-        return not isinstance(json.loads(p.read_text()), dict)
-    except (OSError, ValueError):
-        return True
+        p.stat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True                 # a directory the kernel cannot read: closed, as the bus reads it
+    # the memoized read (_thread_reg, keyed on the file's mtime, size and inode): {} for a record that exists but cannot
+    # be read, never a re-parse per call (the review's low: a sweep of 154 records re-read every one)
+    return not _thread_reg(str(sid))
 
 
 def _mail_off_why_k(sid):

--- a/tests/test_thread_mail_off.py
+++ b/tests/test_thread_mail_off.py
@@ -131,7 +131,25 @@ class UnreadableRecordOnTheKernelSide(unittest.TestCase):
         (Path(self.td) / "session-flags.json").write_text(json.dumps({PARENT: {"postalOff": True}}))
         self.assertEqual(km._mail_off_why_k(PARENT), "isolation", "the legacy key still isolates, under its reason")
         whole = Path(os.path.join(BIN, "romp-kernel")).read_text()
-        self.assertEqual(whole.count('"mailOffWhy": _mail_off_why_k('), 3, "chat rows, thread rows, Sessions pane rows carry the reason")
+        self.assertEqual(whole.count('"mailOffWhy": _mail_off_why_k('), 4, "chat rows, thread rows, Sessions pane rows and the comments frame carry the reason")
+        self.assertIn('"mailOffWhy": _mail_off_why_k(tsid)', inspect.getsource(km._comments_frame), "the promoted popover reads the reason")
+
+    def test_the_unreadable_check_reads_the_registration_memo_not_the_file(self):
+        # the review's low: a sweep re-read and re-parsed every record; the memo (mtime, size, inode) answers now
+        (Path(self.td) / "sdk" / (PLAIN + ".json")).write_text(json.dumps({"sid": PLAIN, "alive": True}))
+        km._thread_reg_memo.clear()
+        self.assertFalse(km._reg_unreadable(PLAIN))
+        self.assertIn(PLAIN, km._thread_reg_memo, "the read went through the memo")
+        src = inspect.getsource(km._reg_unreadable)
+        self.assertIn("return not _thread_reg(str(sid))", src); self.assertNotIn("json.loads", src, "no parse of its own")
+        (Path(self.td) / "sdk" / (PLAIN + ".json")).write_text("{corrupt")
+        self.assertTrue(km._reg_unreadable(PLAIN), "a rewrite is a new memo key: the corrupt record reads unreadable")
+        if os.geteuid() != 0:
+            os.chmod(Path(self.td) / "sdk", 0)
+            try:
+                self.assertTrue(km._reg_unreadable(PLAIN), "a directory the kernel cannot read: closed")
+            finally:
+                os.chmod(Path(self.td) / "sdk", 0o755)
 
 
 if __name__ == "__main__":

--- a/ui/webview/comments.ts
+++ b/ui/webview/comments.ts
@@ -10,6 +10,8 @@ export type CommentMsg = { who: "you" | "agent"; text: string; t: number };
 export type CommentThread = {
   /** the thread's mail is off (T356): a comment thread neither sends nor receives peer mail until broken out */
   mailOff?: boolean;
+  /** why, when it is off: "thread" (not yet broken out), "isolation" (the lane's mailbox toggle), "unreadable" (its record cannot be read) */
+  mailOffWhy?: string;
   /** messages waiting in its postal box (they land when it is broken out) */
   heldMail?: number;
   tid: string;

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10092,9 +10092,10 @@ function renderCommentPopover(): void {
     // EFFECTIVE state the frame carries, so a mailbox the user toggled off since reads as off (the review's low)
     const mailOn = el("div", "cmt-note cmt-mail");
     const held = th.heldMail || 0;
-    mailOn.textContent = th.mailOff
-      ? "Its mailbox is off: the lane's mailbox toggle turns peer mail back on."
-      : "Its mail is on now: peers can reach it and it can send." + (held ? " " + held + (held === 1 ? " held message lands" : " held messages land") + " in a moment." : "");
+    mailOn.textContent = !th.mailOff
+      ? "Its mail is on now: peers can reach it and it can send." + (held ? " " + held + (held === 1 ? " held message lands" : " held messages land") + " in a moment." : "")
+      : th.mailOffWhy === "unreadable" ? "Its mail is held: this session's record cannot be read, and mail flows again once the record is repaired."
+      : "Its mailbox is off: the lane's mailbox toggle turns peer mail back on.";   // the reason rides the frame: a remedy that fits (T356)
     pop.appendChild(mailOn);
     const row = el("div", "cmt-actions");
     const open = el("button", "cmt-act") as HTMLButtonElement;

--- a/ui/webview/thread-mail.test.ts
+++ b/ui/webview/thread-mail.test.ts
@@ -19,13 +19,16 @@ test("the popover says the thread's mail is off, and the promoted view says it i
   // the user's ruling (2026-09-11, 3:05 PM PT): the comment box says nothing about mail being off; a line only for held mail
   assert.doesNotMatch(RENDER, /Mail off: this thread neither sends nor receives peer mail/);
   assert.match(RENDER, /if \(th && th\.mailOff && \(th\.heldMail \|\| 0\) > 0\) \{[\s\S]{0,700}?mail\.textContent = held \+ \(held === 1 \? " message waits in its box and lands" : " messages wait in its box and land"\) \+ " at the break-out\.";/);
-  assert.match(RENDER, /note\.textContent = "The discussion continues there\.";\s*\n\s*pop\.appendChild\(note\);[\s\S]{0,600}mailOn\.textContent = th\.mailOff[\s\S]{0,200}: "Its mail is on now: peers can reach it and it can send\."/,
+  assert.match(RENDER, /note\.textContent = "The discussion continues there\.";\s*\n\s*pop\.appendChild\(note\);[\s\S]{0,600}mailOn\.textContent = !th\.mailOff[\s\S]{0,80}\? "Its mail is on now: peers can reach it and it can send\."/,
                "said once, in the promoted view, from the effective state");
   assert.match(CSS, /\.cmt-note\.cmt-mail \{ opacity: 0\.6; font-size: 0\.86em; \}/);
   // the follow-up: the promoted line reads the EFFECTIVE state (a mailbox toggled off since says so), and both lines
   // count the mail held in the box
   assert.match(COMMENTS, /heldMail\?: number;/);
-  assert.match(RENDER, /mailOn\.textContent = th\.mailOff\s*\n\s*\? "Its mailbox is off: the lane's mailbox toggle turns peer mail back on\."/);
+  assert.match(RENDER, /mailOn\.textContent = !th\.mailOff\s*\n\s*\? "Its mail is on now[^\n]*\n\s*: th\.mailOffWhy === "unreadable" \? "Its mail is held: this session's record cannot be read, and mail flows again once the record is repaired\."\s*\n\s*: "Its mailbox is off: the lane's mailbox toggle turns peer mail back on\."/,
+               "the promoted line reads the reason: an unreadable record is no mailbox toggle's to clear");
+  assert.match(COMMENTS, /mailOffWhy\?: string;/);
+  assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),\s*\n\s*"mailOffWhy": _mail_off_why_k\(tsid\),/, "the comments frame carries the reason");
   assert.match(RENDER, /" in a moment\."/);
 });
 


### PR DESCRIPTION
The two later lows from the review of the second mail-off follow-up.

- **The comments frame carries the reason**: a promoted thread whose record cannot be read was told the lane's mailbox toggle would turn mail back on, which cannot clear that door. The frame ships `mailOffWhy` beside `mailOff`; the promoted line reads it and says the record must be repaired; the comment above the field says what each branch shows.
- **The unreadable-record check reads the memo**: it re-read and re-parsed every record per call. It now stats the file (missing: an ordinary session; a directory the kernel cannot read: closed, as the bus reads it) and takes the answer from the registration memo, which re-reads only when the file's mtime, size or inode moved.

Tests: the frame field and the promoted line pinned; the memo path executed (a clean record remembered, a corrupt rewrite a new key, a directory at mode 000 closed).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
