### PR TITLE
Restart path, third round: boot health on the record, exit budgets as shares of the manager's grace, the attach count frozen with its set, cache budget half the machine

### DIFF
--- a/bin/romp-manager
+++ b/bin/romp-manager
@@ -150,6 +150,7 @@ function specEnv(spec, base, ids) {
     ROMP_KERNEL_PORT: String(spec.port),
     ROMP_MANAGER_PID: String(ids.managerPid),  // → kernel's parent-death watchdog
     ROMP_MANAGER_PORT: String(ids.controlPort),
+    ROMP_SHUTDOWN_GRACE_MS: String(SHUTDOWN_GRACE_MS),   // → the kernel's exit budgets (shares of the grace)
   });
   if (spec.postalPort) env.ROMP_POSTAL_PORT = String(spec.postalPort);
   if (spec.stateDir) env.ROMP_STATE_DIR = spec.stateDir;
@@ -378,7 +379,8 @@ const STORM_OPTS = { coalesceMs: RESTART_COALESCE_MS, stormWindowMs: STORM_WINDO
 // exit 800ms after one SIGTERM and escalate to nothing, so a kernel that ignored the signal outlived
 // it, keeping its port and its sessions under a `romp down` marker that said otherwise. The env seam
 // is for the unit tests, which cannot sit through 5s.
-const SHUTDOWN_GRACE_MS = Number(process.env.ROMP_SHUTDOWN_GRACE_MS) || 5000;
+const SHUTDOWN_GRACE_MS = Number(process.env.ROMP_SHUTDOWN_GRACE_MS) || 8000;   // 8 s (was 5; the kernel's exit
+// budgets are shares of this value, passed down in specEnv, so a kernel never assumes more grace than it gets)
 
 // SIGTERM a kernel and, when it is still there once the grace has run out, SIGKILL it and say so.
 // Every stop and every restart goes through here: a kernel that ignores its SIGTERM under `romp

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -648,7 +648,7 @@ _JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-
 # recently used entries go first, one at a time, under the same LRU order the count uses, so a hot leaf survives a
 # cold flood of subagent files exactly as before. A single entry larger than the whole budget still inserts: a leaf is
 # never refused, the budget then holds that one entry. Counters under /perf recordCache.
-# The default is a QUARTER of the machine's memory, never under 4 GiB (2026-09-11, the day the budget shipped at 1 GiB):
+# The default is HALF of the machine's memory (the user's direction, 2026-09-11: use the memory we have), never under 4 GiB (2026-09-11, the day the budget shipped at 1 GiB):
 # the working set of a devbox running 50 sessions is their live leaves, read by every build in every pusher cycle, and
 # a budget below it does not save memory, it thrashes: 18 entries filled the 1 GiB, every build re-read whole
 # transcripts (14.9 GB read in the first 3.5 minutes, 724 evictions, one pusher cycle of 132 s, chat builds of 3 s
@@ -656,11 +656,11 @@ _JSONL_CACHE_MAX = 1024           # bounds MEMORY only (384 → 1024 on 2026-09-
 # (subagent transcripts) leaves through drop_after="quiescent" folds instead; the budget is the backstop, not the
 # mechanism. ROMP_RECORD_CACHE_BUDGET_MB still sets it outright.
 RECORD_CACHE_BUDGET_FLOOR_BYTES = 4 * 1024 ** 3
-RECORD_CACHE_BUDGET_FRACTION = 0.25
+RECORD_CACHE_BUDGET_FRACTION = 0.5
 
 
 def _record_cache_default_budget_bytes(meminfo_text=None):
-    """A quarter of MemTotal (from /proc/meminfo, or the text given), floored at 4 GiB; the floor alone when the file
+    """Half of MemTotal (from /proc/meminfo, or the text given), floored at 4 GiB; the floor alone when the file
     is unreadable (macOS, a container without procfs)."""
     try:
         text = meminfo_text if meminfo_text is not None else open("/proc/meminfo", encoding="utf-8").read()

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -22652,9 +22652,17 @@ def _kernel_sample_tick(now=None):
         return False
 
 
-EXIT_PRIME_BUDGET_S = float(os.environ.get("ROMP_EXIT_PRIME_BUDGET_S", "0.5"))       # the exit's fold priming
-EXIT_CKPT_WRITE_BUDGET_S = float(os.environ.get("ROMP_EXIT_CKPT_WRITE_BUDGET_S", "1.0"))   # its fold checkpoint writes
-EXIT_ASM_BUDGET_S = float(os.environ.get("ROMP_EXIT_ASM_BUDGET_S", "1.0"))   # the exit's assembly-document writes, bounded
+# The exit's budgets are shares of the manager's SIGTERM grace (ROMP_SHUTDOWN_GRACE_MS, which the manager passes to the
+# kernel it spawns; 5 s when absent) less a 0.5 s margin for the cut row and one slow file: priming 10 %, checkpoint
+# writes 35 %, assembly documents 20 %, the SDK drain 35 %. 2026-09-11: fixed budgets summed to 4.5 s against a 5 s
+# grace and the exit met the SIGKILL twice behind a pusher cycle holding the interpreter lock; the checkpoint budget left
+# 21 to 34 files dirty at every exit. An explicit ROMP_EXIT_*_BUDGET_S still sets one outright.
+EXIT_GRACE_S = float(os.environ.get("ROMP_SHUTDOWN_GRACE_MS", "5000")) / 1000.0
+_EXIT_SHARE_S = max(1.0, EXIT_GRACE_S - 0.5)
+EXIT_PRIME_BUDGET_S = float(os.environ.get("ROMP_EXIT_PRIME_BUDGET_S", "%.3f" % (0.10 * _EXIT_SHARE_S)))       # the exit's fold priming
+EXIT_CKPT_WRITE_BUDGET_S = float(os.environ.get("ROMP_EXIT_CKPT_WRITE_BUDGET_S", "%.3f" % (0.35 * _EXIT_SHARE_S)))   # its fold checkpoint writes
+EXIT_ASM_BUDGET_S = float(os.environ.get("ROMP_EXIT_ASM_BUDGET_S", "%.3f" % (0.20 * _EXIT_SHARE_S)))   # the exit's assembly-document writes, bounded
+EXIT_DRAIN_BUDGET_S = float(os.environ.get("ROMP_EXIT_DRAIN_BUDGET_S", "%.3f" % (0.35 * _EXIT_SHARE_S)))   # the SDK drain (0.1 to 0.9 s measured with session hosts on)
 # the three above plus the 2 s SDK drain stay under the manager's 5 s SIGTERM grace with margin for one slow file:
 # the first exit under the bounded path (2026-09-11, 1:19 PM Pacific) still met the SIGKILL, its checkpoint writes unbounded,
 # and the restart lost its cut row
@@ -22761,9 +22769,9 @@ def _append_boot_settled(first_serve, reconcile_done):
             row["attachTimedOut"] = True       # the backstop wrote the row: an attach never settled in time
             be = _sdk_backend or None          # and WHICH attaches (2026-09-11: 23 hellos landed, the mark never came)
             pend = getattr(be, "_boot_attach_unsettled", None)
+            row["attachPending"] = getattr(be, "_boot_attach_pending", None)   # always: an empty set with a count left is its own clue
             if pend:
                 row["attachUnsettled"] = sorted(str(x)[:8] for x in pend)[:40]
-                row["attachPending"] = getattr(be, "_boot_attach_pending", None)
         row.update(_kernel_process_sample())   # T304: the just-born kernel's size, the series' other bookend
         if prev_cut and isinstance(prev_cut.get("t"), int) and first_serve >= prev_cut["t"]:
             row["prevCutT"] = prev_cut["t"]
@@ -22803,6 +22811,34 @@ def _boot_row_due_locked():
         _BOOT_MARKS["_row"] = True             # exactly one row per boot, whichever thread wins
         return True
     return False
+
+
+BOOT_FIRST_CYCLE_BOUND_S = float(os.environ.get("ROMP_BOOT_FIRST_CYCLE_BOUND_S", "10"))
+_BOOT_HEALTH_DONE = [False]
+
+
+def _boot_health_first_cycle(dt):
+    """The pusher's first cycle after a boot is what gates sessions and cards appearing (the user, 2026-09-11: 84 s
+    cycles read as romp unusable and nothing said so). One row in the restart ledger per boot with the cycle's wall
+    seconds and whether it crossed the bound, and a loud stderr line when it did, naming where to look. Returns the
+    row the first time, None after."""
+    if _BOOT_HEALTH_DONE[0]:
+        return None
+    _BOOT_HEALTH_DONE[0] = True
+    row = {"t": int(time.time()), "pid": os.getpid(), "bootHealth": True, "firstCycleS": round(dt, 2),
+           "boundS": BOOT_FIRST_CYCLE_BOUND_S, "slow": dt > BOOT_FIRST_CYCLE_BOUND_S}
+    if row["slow"]:
+        try:
+            sys.stderr.write("boot health: the first pusher cycle took %.1f s (bound %.0f s): sessions and cards waited behind it; "
+                             "read /perf builds, checkpoints.coldFolds, asmIndex.evictions and recordCache.budgetEvictions\n"
+                             % (dt, BOOT_FIRST_CYCLE_BOUND_S))
+        except Exception:
+            pass
+    try:
+        _append_restart_cut(row)
+    except Exception:
+        pass
+    return row
 
 
 def _boot_row_backstop(now=None):
@@ -48162,6 +48198,7 @@ def _pusher_cycle():
         _live_scope.msgsum = None
         _PERF_STATS.cycle(time.monotonic() - _t_cycle, time.thread_time() - _c_cycle,
                           idle=(_PERF_STATS.marks(), jd._GOAL_IO["saves"], jd._GOAL_IO["writes"]) == _m_cycle)
+        _boot_health_first_cycle(time.monotonic() - _t_cycle)   # the boot's first cycle, on the record (a no-op after)
 
 
 def _pusher_cycle_jobs(now, live_map, any_client):
@@ -58506,7 +58543,7 @@ def _drain_and_exit(reason, signum=None, what="SIGTERM", audit=None):
     _drain_t0 = time.monotonic()
     try:
         if be is not None and hasattr(be, "drain"):
-            res = be.drain(2.0)
+            res = be.drain(EXIT_DRAIN_BUDGET_S)
     except Exception:
         # log-and-record, never die recordless (T143: a raising drain lost 2 of 18 restarts' rows)
         err = traceback.format_exc()

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -10213,12 +10213,16 @@ class SdkBackend:
             # option that did what the card said. Context is managed by hand for now. Every cut/queued
             # session resumes here, exactly as it did before the gate.
             to_start = [s for s in to_start if s in self._boot_attach_sids] + [s for s in to_start if s not in self._boot_attach_sids]
+            # the attaches this phase waits for, FROZEN with the count: a session a send started ahead of this loop has its
+            # hello discard its sid from _boot_attach_sids, and a per-iteration membership test then saw no attach, parked no
+            # callback, and the count never reached zero (two boots of 2026-09-11 said attachTimedOut with every hello landed)
+            attach_set = {s for s in to_start if s in self._boot_attach_sids}
             with self._boot_attach_lock:
-                self._boot_attach_pending = sum(1 for s in to_start if s in self._boot_attach_sids)
+                self._boot_attach_pending = len(attach_set)
             if not self._boot_attach_pending:
                 self._boot_milestone("attachDone")       # nothing to attach: the phase is over before it began
             for sid in to_start:                         # re-attaches first, then the cold launches
-                attach = sid in self._boot_attach_sids
+                attach = sid in attach_set
                 # a RE-ATTACH (a live host holds the CLI) is a socket connect, first and on its own wider bound; a
                 # cold launch keeps the spawn stagger (the CPU burst the stagger exists for)
                 sem = self._attach_sem if attach else self._spawn_sem

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -291,12 +291,12 @@ class RecordCacheDefaultBudget(unittest.TestCase):
     """The budget shipped at 1 GiB (2026-09-11) and sat below a 50-session working set: every build re-read whole transcripts
     (14.9 GB in 3.5 min, 132 s pusher cycles). The default is a quarter of the machine's memory, never under 4 GiB."""
 
-    def test_a_quarter_of_the_machine(self):
+    def test_half_of_the_machine(self):
         text = "MemTotal:       123634396 kB\nMemFree:        1 kB\n"
-        self.assertEqual(em._record_cache_default_budget_bytes(text), int(123634396 * 1024 * 0.25))
+        self.assertEqual(em._record_cache_default_budget_bytes(text), int(123634396 * 1024 * 0.5))
 
     def test_never_under_four_gib(self):
-        self.assertEqual(em._record_cache_default_budget_bytes("MemTotal:  8000000 kB\n"), 4 * 1024 ** 3, "a quarter of 8 GB is under the floor")
+        self.assertEqual(em._record_cache_default_budget_bytes("MemTotal:  8000000 kB\n"), 4 * 1024 ** 3, "half of 8 GB is the floor")
         self.assertEqual(em._record_cache_default_budget_bytes("garbage"), 4 * 1024 ** 3, "no MemTotal: the floor")
 
     def test_the_environment_sets_it_outright(self):

--- a/tests/test_restart_phases.py
+++ b/tests/test_restart_phases.py
@@ -3,6 +3,7 @@
 (or a backstop); the producer's first pass waits, bounded, for the boot's attaches; the fold checkpoints are written
 periodically for a session whose leaf moves with no settle evidence; the exit's cut row carries its phase timings and
 the exit's assembly-document writes are bounded. Hermetic: a temp state root, no kernel, no sessions."""
+import io
 import json
 import os
 import pathlib
@@ -161,8 +162,9 @@ class ExitPhases(unittest.TestCase):
         self.assertIn("if time.monotonic() - _asm_t0 > EXIT_ASM_BUDGET_S:", tail, "the assembly-document writes are bounded on the exit path")
         self.assertIn("em.checkpoint_write_dirty(budget_s=EXIT_CKPT_WRITE_BUDGET_S)", tail, "and so are the fold checkpoint writes (the 1:19 PM exit met the SIGKILL)")
         self.assertIn("if time.monotonic() - _prime_t0 > EXIT_PRIME_BUDGET_S:", tail)
-        self.assertLess(km.EXIT_PRIME_BUDGET_S + km.EXIT_CKPT_WRITE_BUDGET_S + km.EXIT_ASM_BUDGET_S + 2.0, 5.0,
-                        "the exit's budgets and the 2 s SDK drain fit under the manager's 5 s grace")
+        self.assertLess(km.EXIT_PRIME_BUDGET_S + km.EXIT_CKPT_WRITE_BUDGET_S + km.EXIT_ASM_BUDGET_S + km.EXIT_DRAIN_BUDGET_S, km.EXIT_GRACE_S,
+                        "the exit's four budgets fit under the manager's grace")
+        self.assertIn("res = be.drain(EXIT_DRAIN_BUDGET_S)", tail, "the SDK drain takes its share of the grace")
         self.assertIn('_phases["ckptS"]', tail); self.assertIn('_phases["drainS"]', tail)
         self.assertIn("audit_reason=reason, phases=_phases)", tail, "the phases reach the cut row")
         self.assertIn("boot_phase=_mark_boot,", src, "the backend's milestones land in the kernel's boot marks")
@@ -205,6 +207,43 @@ class AttachTimedOutNamesTheAttaches(unittest.TestCase):
         self.assertEqual(be._boot_attach_unsettled, {"22222222-0000-0000-0000-000000000002"})
         settled(); settled()
         self.assertEqual(be._boot_attach_unsettled, set(), "fires once; the sid leaves the set at the hello")
+
+
+class ExitBudgetsScaleWithTheGrace(unittest.TestCase):
+    def test_the_shares_follow_the_manager_grace(self):
+        # the constants are read at load; recompute the shares the way the module does for two grace values
+        for grace_ms, share in (("5000", 4.5), ("8000", 7.5)):
+            self.assertAlmostEqual(0.10 * share + 0.35 * share + 0.20 * share + 0.35 * share, share, places=6)
+        src = open(km.__file__).read()
+        self.assertIn('EXIT_GRACE_S = float(os.environ.get("ROMP_SHUTDOWN_GRACE_MS", "5000")) / 1000.0', src, "the kernel assumes 5 s unless the manager says otherwise")
+        self.assertIn("_EXIT_SHARE_S = max(1.0, EXIT_GRACE_S - 0.5)", src)
+        mgr = open(os.path.join(BIN, "romp-manager")).read()
+        self.assertIn("ROMP_SHUTDOWN_GRACE_MS: String(SHUTDOWN_GRACE_MS)", mgr, "the manager passes the grace it enforces to the kernel it spawns")
+
+
+class BootHealthFirstCycle(unittest.TestCase):
+    def setUp(self):
+        km._BOOT_HEALTH_DONE[0] = False
+        self.addCleanup(lambda: km._BOOT_HEALTH_DONE.__setitem__(0, False))
+
+    def test_a_slow_first_cycle_writes_a_flagged_row_and_a_loud_line_once(self):
+        rows, err = [], io.StringIO()
+        with mock.patch.object(km, "_append_restart_cut", rows.append), mock.patch.object(km.sys, "stderr", err):
+            row = km._boot_health_first_cycle(42.0)
+            self.assertIsNone(km._boot_health_first_cycle(0.1), "the second cycle is not the boot's first")
+        self.assertEqual((row["bootHealth"], row["firstCycleS"], row["slow"]), (True, 42.0, True))
+        self.assertEqual(len(rows), 1)
+        self.assertIn("boot health: the first pusher cycle took 42.0 s", err.getvalue())
+
+    def test_a_fast_first_cycle_is_recorded_quietly(self):
+        rows, err = [], io.StringIO()
+        with mock.patch.object(km, "_append_restart_cut", rows.append), mock.patch.object(km.sys, "stderr", err):
+            row = km._boot_health_first_cycle(0.08)
+        self.assertEqual((row["slow"], len(rows), err.getvalue()), (False, 1, ""))
+
+    def test_the_pusher_calls_it_after_its_cycle_accounting(self):
+        src = open(km.__file__).read()
+        self.assertLess(src.index("_PERF_STATS.cycle(time.monotonic() - _t_cycle"), src.index("_boot_health_first_cycle(time.monotonic() - _t_cycle)"))
 
 
 if __name__ == "__main__":

--- a/tests/test_sdk_boot_stagger.py
+++ b/tests/test_sdk_boot_stagger.py
@@ -486,5 +486,36 @@ class BootBudget(unittest.TestCase):
         self.assertLess(rows[0]["durationS"], 5.0)
 
 
+class AttachSetFrozenWithTheCount(unittest.TestCase):
+    """Two boots of 2026-09-11 said attachTimedOut with every host hello landed: a session a send started ahead of the
+    reconcile loop had its hello discard its sid from _boot_attach_sids, the loop's membership test then saw no attach
+    for it, parked no callback, and the count never reached zero. The set the phase waits for is frozen with the count."""
+
+    def test_a_hello_landing_mid_loop_does_not_strand_the_count(self):
+        d = tempfile.mkdtemp(); phases = []
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None, boot_phase=phases.append)
+        attach_sids = ["22222222-bbbb-0000-0000-%012d" % i for i in range(3)]
+        regs = []; alive = {}
+        for i, sid in enumerate(attach_sids):
+            regs.append(_reg(d, sid)); cli, host = 910000000 + 2 * i, 910000001 + 2 * i
+            sb.write_lease(d, {"sid": sid, "fsid": sid, "pid": cli, "start": "1", "holder": {"pid": host, "start": "2", "kind": "host"},
+                               "version": "", "t": __import__("time").time()})
+            alive[cli] = "1"; alive[host] = "2"
+        settles = {}
+        def fake_ensure(sid, on_boot_settled=None):
+            settles[sid] = on_boot_settled
+            be._boot_attach_sids.discard(attach_sids[-1])   # the last attach's hello lands (a send started it) while an earlier one is ensured
+            return object()
+        with mock.patch.dict(sys.modules, {"romp_sdk_backend": sb}), \
+             mock.patch.object(sb, "proc_start", lambda p, run=None: alive.get(p)), \
+             mock.patch.object(be, "_ensure", fake_ensure):
+            be._boot_reconcile(regs)
+        self.assertEqual(phases, ["censusDone"])
+        self.assertTrue(all(callable(settles.get(s)) for s in attach_sids), "every attach counted in the phase parked a callback")
+        for sid in attach_sids:
+            settles[sid]()
+        self.assertEqual(phases, ["censusDone", "attachDone"], "the count reaches zero: the set was frozen with it")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Four follow-ups from the afternoon's restarts (2026-09-11, Pacific), each measured on the devbox:

- **Boot health on the record.** One ledger row per boot with the first pusher cycle's seconds and a loud stderr line when it crosses 10 s (`ROMP_BOOT_FIRST_CYCLE_BOUND_S`). An 84 s first cycle read as romp unusable and nothing said so.
- **Exit budgets as shares of the manager's grace.** The manager passes `ROMP_SHUTDOWN_GRACE_MS` to the kernel (default now 8 s, effective at its next restart); the kernel's priming, checkpoint, assembly and drain budgets are 10/35/20/35 % of the grace less 0.5 s, assuming 5 s when the variable is absent. The exit met the 5 s kill twice and left 21 to 34 checkpoints dirty every time.
- **The attach count frozen with its set.** Two boots reported `attachTimedOut` with every hello landed: a send-started session's hello discarded its sid before the loop reached it. The set is computed once with the count; a timed-out row always carries `attachPending`.
- **Record cache budget: half the machine** (the user's direction), floor 4 GiB.

Tests in `tests/test_restart_phases.py`, `tests/test_sdk_boot_stagger.py`, `tests/test_kernel_jsonl_cache.py`; each fails with its fix reverted.

Tier: fix
