### PR TITLE
A model picked before a Codex session's thread exists stays picked when the thread is created

### DIFF
--- a/kernel/codex_backend.py
+++ b/kernel/codex_backend.py
@@ -1441,18 +1441,25 @@ class CodexBackend:
         with s.lock:
             if s.dead:
                 return False
-            tid, cwd = s.tid, s.cwd
+            tid, cwd, model = s.tid, s.cwd, s.model
             create = tid.startswith("pending-") or tid.startswith("failed-")
         if create:
-            resp = c.thread_start({"cwd": cwd, **_approval_params(s.mode),
-                                   **_execution_permissions(cwd, thread_start=True)})
+            params = {"cwd": cwd, **_approval_params(s.mode),
+                      **_execution_permissions(cwd, thread_start=True)}
+            if model:
+                params["model"] = model    # picked while the row was a placeholder: born on it
+            resp = c.thread_start(params)
             loaded_client_generation = self._client_generation_for(c)
             with s.lock:
                 if s.dead:
                     return False
                 prior = (s.tid, s.model, s.loaded, s.loaded_client_generation)
                 s.tid = resp.thread.id
-                s.model = getattr(resp, "model", "") or s.model
+                # The pick outlives the create. The server's reply names ITS model, never empty
+                # (ThreadStartResponse.model is a required string), so `resp.model or s.model` let
+                # the default overwrite a model the user chose on the pending-/failed- row, saved
+                # it below, and ran every turn on it with no word to anyone (2026-09-11).
+                s.model = s.model or getattr(resp, "model", "") or ""
                 s.loaded = True
                 s.loaded_client_generation = loaded_client_generation
                 try:

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -321,6 +321,96 @@ class ApprovalModes(unittest.TestCase):
         self.assertEqual(params["approvalsReviewer"], "auto_review")
         restored.kill(sid)
 
+    def test_pending_session_recovery_keeps_the_picked_model(self):
+        # a model picked while the row was still a placeholder vanished at the first send:
+        # thread/start went out without it, and the server's reply (its default, never empty)
+        # overwrote the pick in memory and in the registry, so the turn ran on the default and
+        # the picker showed it, with no word to the user
+        def unavailable():
+            raise RuntimeError("synthetic unavailable client")
+        be, _, tmp = build(factory=unavailable)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be.set_model(sid, "gpt-5-picked"))
+        fake = FakeClient()
+        restored = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        try:
+            self.assertTrue(restored.send(sid, "synthetic recovery"))
+            self.assertTrue(until(lambda: not restored.busy(sid)))
+            self.assertEqual(fake.called("turn_start")[-1][3].get("model"), "gpt-5-picked",
+                             "the turn runs on the pick, not the server's default")
+            self.assertEqual(restored.live_sessions()[sid]["model"], "gpt-5-picked")
+            rows = json.loads(restored._reg_path().read_text())
+            self.assertEqual(rows[sid]["model"], "gpt-5-picked", "the registry keeps the pick")
+            self.assertEqual(fake.called("thread_start")[-1][1].get("model"), "gpt-5-picked",
+                             "the thread is created on the pick")
+        finally:
+            restored.kill(sid)
+
+    def test_failed_placeholder_recovery_keeps_the_picked_model(self):
+        # the same loss without a restart: thread/start raised at spawn (a failed- row on a live
+        # client), the user picked a model on the idle row, then sent
+        class BoomOnce(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.boom = True
+
+            def thread_start(self, params=None):
+                if self.boom:
+                    self.boom = False
+                    raise RuntimeError("synthetic thread/start failure")
+                return super().thread_start(params)
+        fake = BoomOnce()
+        be, _, _ = build(factory=lambda: fake)
+        sid = be.spawn("web", "/TESTDIR")
+        self.assertTrue(be._sessions[sid].tid.startswith("failed-"))
+        self.assertTrue(be.set_model(sid, "gpt-5-picked"))
+        try:
+            self.assertTrue(be.send(sid, "synthetic recovery"))
+            self.assertTrue(until(lambda: not be.busy(sid)))
+            self.assertEqual(fake.called("turn_start")[-1][3].get("model"), "gpt-5-picked")
+            self.assertEqual(be.live_sessions()[sid]["model"], "gpt-5-picked")
+            self.assertEqual(fake.called("thread_start")[-1][1].get("model"), "gpt-5-picked")
+        finally:
+            be.kill(sid)
+
+    def test_model_picked_while_the_thread_is_being_created_stays_picked(self):
+        # the create RPC runs under mode_lock alone and set_model takes the session lock alone, so
+        # a pick can land while thread/start is in flight; the reply must read the live model, not
+        # the snapshot the params were built from, or the server's default overwrites that pick
+        class Holding(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.entered = threading.Event()
+                self.release = threading.Event()
+
+            def thread_start(self, params=None):
+                self.entered.set()
+                assert self.release.wait(timeout=10), "the create was never released"
+                return super().thread_start(params)
+        def unavailable():
+            raise RuntimeError("synthetic unavailable client")
+        be, _, tmp = build(factory=unavailable)
+        sid = be.spawn("web", "/TESTDIR")
+        fake = Holding()
+        restored = cb.CodexBackend(tmp, client_factory=lambda: fake)
+        try:
+            self.assertEqual(restored._sessions[sid].model, "", "no pick before the send")
+            self.assertTrue(restored.send(sid, "synthetic recovery"))
+            self.assertTrue(fake.entered.wait(timeout=5), "thread/start never went out")
+            self.assertTrue(restored.set_model(sid, "gpt-5-picked"))
+            fake.release.set()
+            self.assertTrue(until(lambda: not restored.busy(sid)))
+            self.assertNotIn("model", fake.called("thread_start")[-1][1],
+                             "the pick landed after the create went out")
+            self.assertEqual(fake.called("turn_start")[-1][3].get("model"), "gpt-5-picked",
+                             "the turn runs on the pick that landed during the create")
+            self.assertEqual(restored.live_sessions()[sid]["model"], "gpt-5-picked")
+            rows = json.loads(restored._reg_path().read_text())
+            self.assertEqual(rows[sid]["model"], "gpt-5-picked", "the registry keeps the pick")
+        finally:
+            fake.release.set()             # a failure above must not leave the worker parked
+            restored.kill(sid)
+
     def test_mode_change_refuses_inflight_turn_and_rolls_back_failed_save(self):
         be, fake, _ = build()
         sid = be.spawn("web", "/TESTDIR")
@@ -2268,7 +2358,8 @@ class RaisingRegistryTransactions(unittest.TestCase):
             s = be._session(sid)
             s.tid = "pending-%s" % sid[:8]         # force the create path
             s.loaded = False
-            prior_model = s.model
+            s.model = ""                           # no pick on the placeholder: the server's answer
+            prior_model = s.model                  # fills the field, so the flip is observable
 
             class OtherModel(type(fake)):
                 def thread_start(self2, params):


### PR DESCRIPTION
Tier: fix

A Codex session whose thread/start failed at spawn (a failed- row on a live client,
e.g. the sandbox startup failure docs/codex.md describes) or that was created while the
app-server client was unavailable (a pending- row, also the shape a kernel restart loads)
sits as a visible placeholder until the next send. The user can pick a model on that row
(set_model, kernel/codex_backend.py:902, stores the pick on any known session and saves
it). At the next send _prepare_thread turned the placeholder into a real thread and threw
the pick away: thread/start went out with cwd, approval and permissions only (:1265-1266),
and `s.model = getattr(resp, "model", "") or s.model` (:1272) let the server's reply win.
ThreadStartResponse.model is a required string in the pinned SDK, never empty, so the
server's DEFAULT always replaced the pick; the overwrite was saved (:1275,
fields=("tid", "model")) and every turn then sent the default (:1443-1444). The picker
showed the default, and nothing told the user their choice was gone. The mode picked on
the same placeholder was already carried through this recovery
(test_pending_session_recovery_uses_selected_mode); the model was not.

Fix, in the create branch of _prepare_thread only: the pick, snapshotted under the lock
with tid and cwd, rides the thread/start params when there is one (ThreadStartParams
accepts `model`), so the thread is born on it; and the reply fills the model only when
none was picked: `s.model = s.model or getattr(resp, "model", "") or ""`. The current
s.model is read, not the snapshot, so a pick landing during the RPC also stands. The
rollback tuple on a failed registry save is unchanged. A model the server refuses at
create fails as loudly as it did at the turn: _run_turn_in_mode wraps a thread-preparation
rejection in the same _PermanentRequestRejection, a visible launch error parked until a
send or model change.

Left out on purpose: spawn is untouched (no pick can exist before the row does); no
reconciliation of a server-normalized model name against the pick (the turn sends the
pick each time and the server accepted it at create); the ordering where the pick lands
while a send is already queued was never affected (the kernel parks it and replays it
after the create) and is not re-tested; docs/codex.md does not describe this recovery,
so no doc line changes.

Tests (tests/test_codex_backend.py, class ApprovalModes, mirroring the mode twin):
test_pending_session_recovery_keeps_the_picked_model (pick on a pending- row, kernel
restart, send: the turn, live_sessions, the registry row and the thread/start params all
carry the pick), test_failed_placeholder_recovery_keeps_the_picked_model (the same
without a restart: thread/start raised once at spawn, pick on the idle failed- row, send)
and test_model_picked_while_the_thread_is_being_created_stays_picked (the pick lands
while thread/start is in flight: _run_turn holds mode_lock alone across _prepare_thread
and set_model takes the session lock alone, so the window is open at every first send
after a placeholder; a fake whose thread/start parks until released, the pick made in
that window, then the turn, live_sessions and the registry row carry it while the create
params, built before it, do not). The third is the one that tells the live read from the
snapshot: with `s.model = model or ...` (the snapshot the params were built from) the
first two pass and it fails at :403 with 'gpt-5-test' != 'gpt-5-picked' (1 failed,
2 passed, verified on this branch before restoring the line).
test_a_raising_tid_save_rolls_the_thread_flip_back now starts the placeholder from an
empty model: with a pick outliving the create, the model the fake's spawn had already
filled in stopped flipping to the planted "gpt-other", which made that test's model-half
rollback assertion vacuous; from "" the flip and its rollback are observable again.

Red on origin/main (c0cbd8ff), the module run with the new test file copied in:
  tests/test_codex_backend.py:337  AssertionError: 'gpt-5-test' != 'gpt-5-picked' :
    the turn runs on the pick, not the server's default
    (test_pending_session_recovery_keeps_the_picked_model)
  tests/test_codex_backend.py:368  AssertionError: 'gpt-5-test' != 'gpt-5-picked'
    (test_failed_placeholder_recovery_keeps_the_picked_model)
  tests/test_codex_backend.py:403  AssertionError: 'gpt-5-test' != 'gpt-5-picked' :
    the turn runs on the pick that landed during the create
    (test_model_picked_while_the_thread_is_being_created_stays_picked)
  3 failed, 84 passed, 5 subtests passed
On the branch: 87 passed, 5 subtests passed.

