### PR TITLE
The unfocused pane's #only= road, four later lows: a live hash edit repaints, the restore re-reads the reason, one visibility predicate, a name-free line (T357 later lows)

### DIFF
--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -186,6 +186,32 @@ out.onlyFiltered = await page.evaluate(() => {
            empty: empty && getComputedStyle(empty).display !== "none" ? { text: empty.textContent, vanished: empty.dataset.vanished || "" } : null,
            visibleTurns: turns.length, composerDisabled: document.getElementById("composer-input").disabled };
 });
+// the SHELL road (the review's medium): on the dashboard the chat pane is a same-origin iframe of the shell and the
+// filter lives on the SHELL's URL (only-filter.ts reads window.top), so a live edit of the shell's hash must reach the
+// framed pane, whose own hash never changes: the pane unfocuses at once and restores when the filter shows the tab again
+await page.evaluate((sid) => { const key = Object.keys(localStorage).find((k) => k.startsWith("romp-vscode-state-")); const st = JSON.parse(localStorage.getItem(key) || "{}"); st.activeId = sid; st.activeName = "web"; localStorage.setItem(key, JSON.stringify(st)); }, cfg.sidA);
+await page.goto(cfg.shell);
+await page.waitForSelector("#f-chat", { timeout: 20000 });
+const fr = await (await page.$("#f-chat")).contentFrame();
+await fr.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid; }, cfg.sidA, { timeout: 20000 });
+await fr.waitForFunction(() => document.querySelectorAll("#content .turn").length > 0, null, { timeout: 20000 });
+const frameState = () => fr.evaluate(() => {
+  const act = document.querySelector("#tabs .tab.active[data-id]");
+  const empty = document.getElementById("empty-state");
+  const turns = Array.from(document.querySelectorAll("#content .turn")).filter((t) => { const r = t.getBoundingClientRect(); return r.width > 0 && r.height > 0 && getComputedStyle(t).display !== "none"; });
+  let topHash = null; try { topHash = window.top.location.hash; } catch (e) { topHash = "cross-origin"; }
+  return { active: act ? act.dataset.id : null, tabs: Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => t.dataset.id),
+           empty: empty && getComputedStyle(empty).display !== "none" ? { text: empty.textContent, vanished: empty.dataset.vanished || "" } : null,
+           visibleTurns: turns.length, paneHash: location.hash, topHash };
+});
+const t0 = Date.now();
+await page.evaluate(() => { location.hash = "#only=api"; });   // the SHELL's hash; the pane's own URL is untouched
+await fr.waitForFunction((sid) => !document.querySelector("#tabs .tab.active[data-id]") && !Array.from(document.querySelectorAll("#tabs .tab[data-id]")).some((t) => t.dataset.id === sid), cfg.sidA, { timeout: 5000 });
+out.shellHidden = Object.assign(await frameState(), { ms: Date.now() - t0 });
+await page.evaluate(() => { location.hash = "#only="; });      // the filter lifted, on the shell again
+await fr.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid; }, cfg.sidA, { timeout: 5000 });
+await fr.waitForFunction(() => document.querySelectorAll("#content .turn").length > 0, null, { timeout: 5000 });
+out.shellRestored = await frameState();
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
 process.exit(0);
@@ -256,7 +282,7 @@ class ServedUnfocusedPane(unittest.TestCase):
     def test_the_focused_tab_leaving_on_its_own_unfocuses_the_pane_and_its_return_restores_it(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "remote": REMOTE, "provisional": PROVISIONAL,
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "shell": "http://127.0.0.1:%d/?token=%s" % (self.port, self.token), "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "remote": REMOTE, "provisional": PROVISIONAL,
                        "shots": os.environ.get("PV_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -326,6 +352,18 @@ class ServedUnfocusedPane(unittest.TestCase):
         self.assertIsNotNone(of["empty"]); self.assertEqual(of["empty"]["vanished"], SID_A)
         self.assertEqual(of["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.", "name-free: a clean recording frame")
         self.assertTrue(of["composerDisabled"])
+        # the SHELL road (the review's medium): the pane framed on the dashboard, the filter edited on the SHELL's URL
+        # (where only-filter.ts reads it): the pane's own hash never changes, yet the framed pane unfocuses off the live
+        # edit and restores when the filter lifts
+        sh = r["shellHidden"]
+        self.assertEqual((sh["paneHash"], sh["topHash"]), ("", "#only=api"), "the edit was the shell's; the pane's own URL carries no hash: %r" % sh)
+        self.assertIsNone(sh["active"]); self.assertNotIn(SID_A, sh["tabs"]); self.assertIn(SID_B, sh["tabs"])
+        self.assertEqual(sh["visibleTurns"], 0, "the filtered session's transcript left the framed pane: %r" % sh)
+        self.assertEqual(sh["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.")
+        self.assertLess(sh["ms"], 2000, "off the live edit, not a later kernel frame: %r" % sh)
+        sr = r["shellRestored"]
+        self.assertEqual(sr["active"], SID_A, "the filter lifted on the shell: the hidden tab takes focus back: %r" % sr)
+        self.assertGreater(sr["visibleTurns"], 0); self.assertIsNone(sr["empty"])
 
 
 if __name__ == "__main__":

--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -324,7 +324,7 @@ class ServedUnfocusedPane(unittest.TestCase):
         self.assertIsNone(of["active"], "no tab active under the filter: %r" % of); self.assertNotIn(SID_A, of["tabs"]); self.assertIn(SID_B, of["tabs"])
         self.assertEqual(of["visibleTurns"], 0, "the filtered session's transcript is NOT on screen (the demo leak): %r" % of)
         self.assertIsNotNone(of["empty"]); self.assertEqual(of["empty"]["vanished"], SID_A)
-        self.assertIn("web", of["empty"]["text"]); self.assertIn("is not shown by this tab view", of["empty"]["text"])
+        self.assertEqual(of["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.", "name-free: a clean recording frame")
         self.assertTrue(of["composerDisabled"])
 
 

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -5,7 +5,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { onlyTag, matchesOnly, onlyTags } from "./only-filter";
+import { onlyTag, matchesOnly, onlyTags, onlyWindow } from "./only-filter";
 
 const read = (p: string) => fs.readFileSync(path.resolve(process.cwd(), "..", p), "utf8");
 const RENDER = read("ui/webview/render.ts");
@@ -55,6 +55,23 @@ test("onlyTag reads #only= / ?only= from the shell URL (window.top), lowercased"
   } finally { g.window = prev; }
 });
 
+test("onlyWindow: the shell's window when readable (a same-origin frame), else this pane's own (a top-level page, a cross-origin top, a harness)", () => {
+  const g = global as any;
+  const prev = g.window;
+  try {
+    const top: any = { location: { hash: "#only=demo", search: "" } };
+    const pane: any = { top, location: { hash: "", search: "" } };
+    g.window = pane; assert.equal(onlyWindow(), top); assert.equal(onlyTag(), "demo", "the filter is read from the shell's URL, not the pane's");
+    const cross: any = { get location() { throw new Error("SecurityError"); } };
+    const pane2: any = { top: cross, location: { hash: "#only=own", search: "" } };
+    g.window = pane2; assert.equal(onlyWindow(), pane2); assert.equal(onlyTag(), "own", "a cross-origin top throws on the read: the pane's own URL");
+    const solo: any = { location: { hash: "", search: "" } }; solo.top = solo;
+    g.window = solo; assert.equal(onlyWindow(), solo, "a top-level page is its own top");
+    const noTop: any = { location: { hash: "", search: "" } };
+    g.window = noTop; assert.equal(onlyWindow(), noTop, "no top at all (a harness window): the pane's own");
+  } finally { g.window = prev; }
+});
+
 test("the helper: case-insensitive prefix + reads the shell URL via window.top", () => {
   assert.match(ONLY, /export function onlyTag\(\)/);
   assert.match(ONLY, /window\.top \|\| window/);
@@ -66,7 +83,8 @@ test("the timeline's standalone helper splits the tag the same way", () => {
 });
 
 test("chat tabs filter by the #only tag", () => {
-  assert.match(RENDER, /import \{ onlyTag, matchesOnly \} from "\.\/only-filter";/);
+  assert.match(RENDER, /import \{ onlyTag, matchesOnly, onlyWindow \} from "\.\/only-filter";/);
+  assert.match(RENDER, /onlyWindow\(\)\.addEventListener\("hashchange", \(\) => renderTabs\(\)\);/, "the strip's live-edit listener binds to the window the filter is read from (the shell's when framed)");
   assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the #only= filter rides the one predicate the deferred checks read too (stripShows: tabInView, then matchesOnly over the hash)");
   assert.match(RENDER, /return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/);
   // the filtered ids are what the strip plan renders (tab-groups.ts planStrip, since tab groups 2026-09-04)

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -67,7 +67,8 @@ test("the timeline's standalone helper splits the tag the same way", () => {
 
 test("chat tabs filter by the #only tag", () => {
   assert.match(RENDER, /import \{ onlyTag, matchesOnly \} from "\.\/only-filter";/);
-  assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
+  assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the #only= filter rides the one predicate the deferred checks read too (stripShows: tabInView, then matchesOnly over the hash)");
+  assert.match(RENDER, /return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/);
   // the filtered ids are what the strip plan renders (tab-groups.ts planStrip, since tab groups 2026-09-04)
   assert.match(RENDER, /const plan = planStrip\(visibleIds,/);
 });

--- a/ui/webview/only-filter.ts
+++ b/ui/webview/only-filter.ts
@@ -12,6 +12,15 @@
 // `#only=demo` on the dashboard URL scopes all four panes at once. A cross-origin top (an embedded
 // webview) falls back to the pane's own URL.
 
+/** The window whose URL carries the filter: the shell's (window.top) when this pane is a same-origin iframe of it on
+ *  the dashboard, else this pane's own (a top-level /chat page, or a cross-origin top such as an embedded webview,
+ *  which throws on the read). onlyTag reads it, and the strip's hashchange listener binds to it, so a live edit of the
+ *  SHELL's hash repaints the framed pane (the review of T357's later lows: the listener sat on the pane's window, whose
+ *  hash never changes on the dashboard). */
+export function onlyWindow(): Window {
+  try { const t = window.top || window; void t.location.hash; return t; } catch { return window; }
+}
+
 export function onlyTag(): string | null {
   const read = (loc: Location): string | null => {
     try {
@@ -21,8 +30,7 @@ export function onlyTag(): string | null {
     } catch { return null; }
   };
   if (typeof window === "undefined") return null;    // no DOM (a test/headless context) → no filter
-  try { return read((window.top || window).location); } catch { /* cross-origin top */ }
-  try { return read(window.location); } catch { return null; }   // fall back to this pane's own URL
+  try { return read(onlyWindow().location); } catch { return null; }   // the shell's URL, else this pane's own
 }
 
 export function matchesOnly(name: string | null | undefined, tag: string | null): boolean {

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -81,10 +81,12 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   // applied on top of tabInView and is no peek input, so an only-filtered active tab goes UNFOCUSED here, never
   // re-pointed; the fire-time check reads the same predicate visibleIds is built from (stripShows)
   assert.match(fn("renderTabs"), /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{\s*\n\s*const hid = activeId;\s*\n\s*setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
-  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,240}?if \(!activeId && vanishedId === back && vanishedWhy === "hidden" && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again, the reason re-read at fire time");
+  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,900}?if \(!activeId && vanishedId === back && vanishedWhy === "hidden" && order\.includes\(back\) && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again, the reason AND the strip's membership re-read at fire time (a tab torn down meanwhile left `order` with the reason still hidden)");
+  assert.doesNotMatch(fn("renderTabs"), /const nameOf = /, "no second name ladder in renderTabs: stripShows carries the one (the review's low)");
   assert.match(fn("stripShows"), /function stripShows\(id: string, only: string \| null = onlyTag\(\)\): boolean \{\s*\n\s*if \(!tabInView\(id\)\) return false;\s*\n\s*return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/, "the one predicate");
   assert.match(fn("renderTabs"), /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "visibleIds is built from it: no second copy");
-  assert.match(RENDER, /window\.addEventListener\("hashchange", \(\) => renderTabs\(\)\);/, "a live edit of the #only= hash repaints at once");
+  assert.match(RENDER, /onlyWindow\(\)\.addEventListener\("hashchange", \(\) => renderTabs\(\)\);/, "a live edit of the #only= hash repaints at once, heard on the window that carries the filter (the shell's when framed)");
+  assert.doesNotMatch(RENDER, /window\.addEventListener\("hashchange"/, "never the pane's own window alone: framed on the dashboard its hash never changes (the review's medium)");
   assert.doesNotMatch(RENDER, /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab RE-POINT");
   assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);
   assert.match(fn("assertPeekFor"), /const next = chatVisible\(id\) \? null : id;/, "the peek rule, over the views blob alone");

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -35,7 +35,7 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
                    { head: "No session selected. Pick a tab to start. ", name: "web", tail: " is not listed yet. It comes back here when its host does." });
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: true }, true).tail, " is not listed yet; its host is reconnecting… It comes back here when the host does.");
   assert.deepEqual(emptyStateParts({ name: "web", why: "gone", dialing: false }, true).tail, " is no longer on the strip. Pick a tab.");
-  assert.deepEqual(emptyStateParts({ name: "web", why: "hidden", dialing: false }, true).tail, " is not shown by this tab view. Pick a tab, or change the view.");
+  assert.deepEqual(emptyStateParts({ name: "web", why: "hidden", dialing: false }, true), { head: "This tab view shows no session. Change the view, or pick a tab.", name: null, tail: "" }, "name-free: a clean recording frame, the pick said once");
   assert.deepEqual(emptyStateParts({ name: "web", why: "awaited", dialing: false }, false).head, "No sessions yet. ", "an empty strip invites no pick");
   for (const p of [emptyStateParts({ name: "web", why: "hostDrop", dialing: true }, true), emptyStateParts(null, true)]) {
     assert.doesNotMatch(p.head + p.tail, /\b(card|board|goal|column|nudge)\b/, "no romp nouns in the body's line");
@@ -81,8 +81,10 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   // applied on top of tabInView and is no peek input, so an only-filtered active tab goes UNFOCUSED here, never
   // re-pointed; the fire-time check reads the same predicate visibleIds is built from (stripShows)
   assert.match(fn("renderTabs"), /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{\s*\n\s*const hid = activeId;\s*\n\s*setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
-  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,200}?if \(!activeId && vanishedId === back && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again");
-  assert.match(fn("stripShows"), /if \(!tabInView\(id\)\) return false;\s*\n\s*const only = onlyTag\(\);\s*\n\s*return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/, "the one predicate");
+  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,240}?if \(!activeId && vanishedId === back && vanishedWhy === "hidden" && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again, the reason re-read at fire time");
+  assert.match(fn("stripShows"), /function stripShows\(id: string, only: string \| null = onlyTag\(\)\): boolean \{\s*\n\s*if \(!tabInView\(id\)\) return false;\s*\n\s*return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/, "the one predicate");
+  assert.match(fn("renderTabs"), /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "visibleIds is built from it: no second copy");
+  assert.match(RENDER, /window\.addEventListener\("hashchange", \(\) => renderTabs\(\)\);/, "a live edit of the #only= hash repaints at once");
   assert.doesNotMatch(RENDER, /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab RE-POINT");
   assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);
   assert.match(fn("assertPeekFor"), /const next = chatVisible\(id\) \? null : id;/, "the peek rule, over the views blob alone");

--- a/ui/webview/pane-focus.ts
+++ b/ui/webview/pane-focus.ts
@@ -46,8 +46,10 @@ export function emptyStateParts(v: Vanished | null, hasTabs: boolean): EmptyStat
     : v.why === "awaited" ? (v.dialing ? " is not listed yet; its host is reconnecting… It comes back here when the host does."
                                        : " is not listed yet. It comes back here when its host does.")
     : v.why === "gone" ? " is no longer on the strip. Pick a tab."
-    : v.why === "hidden" ? " is not shown by this tab view. Pick a tab, or change the view."
     : " ended.";
+  // the #only= filter hid the tab: a NAME-FREE line (the frame's purpose is a clean recording, and the pick
+  // instruction is said once): the manager's call, 2026-09-11
+  if (v.why === "hidden") return { head: "This tab view shows no session. Change the view, or pick a tab.", name: null, tail: "" };
   // an EMPTY strip invites no pick (the review's low): the session named is all there is to say
   return { head: hasTabs ? "No session selected. Pick a tab to start. " : "No sessions yet. ", name: v.name, tail };
 }

--- a/ui/webview/peek-tab.test.ts
+++ b/ui/webview/peek-tab.test.ts
@@ -75,7 +75,7 @@ test("peek is FIRST-CLASS in nav history by storing only the sid — apply lands
 test("the first-tab fallback never fires on an active peek: tabInView counts the peek as visible", () => {
   assert.match(RENDER, /function tabInView\(id: string\): boolean \{ return id === peekId \|\| chatVisible\(id\); \}/);
   // the #only=-era bounce reads visibleIds, which is built from tabInView — an active peek is in it
-  assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
+  assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the view (tabInView, a peek counts) and the #only= filter through ONE predicate, stripShows (T357 later lows)");
   assert.match(RENDER, /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{/, "the only-filter's check on the active tab (unfocus, not a re-point)");
   // …and the DEFERRED bounce re-validates at fire time: an activation between schedule and fire
   // (the feed click that just opened this peek) makes the active tab visible — no bounce then

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6265,9 +6265,9 @@ function renderTabs() {
   const only = onlyTag();
   const nameOf = (id: string) => sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "";
   // the session VIEWS filter composes here too (the user 2026-08-18): a view-hidden session keeps
-  // its state, drafts and cached transcript — it just loses its tab until revealed
-  const inViewIds = ids.filter(tabInView);
-  const visibleIds = only ? inViewIds.filter((id) => matchesOnly(nameOf(id), only)) : inViewIds;
+  // its state, drafts and cached transcript — it just loses its tab until revealed. ONE predicate (stripShows) builds
+  // this list and answers the deferred checks below, so the two can never disagree (the review's low)
+  const visibleIds = ids.filter((id) => stripShows(id, only));
   // ...and it must govern the CHAT BODY too, not just the bar (the user 2026-07-16). Hiding a
   // non-matching TAB while its transcript keeps rendering leaks precisely what the filter exists to
   // hide: a real session's chat sitting on screen under `#only=api,tests,web`, statusline and all —
@@ -6284,7 +6284,7 @@ function renderTabs() {
   }
   if (!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds.includes(vanishedId)) {
     const back = vanishedId;
-    setTimeout(() => { if (!activeId && vanishedId === back && stripShows(back)) setActive(back); }, 0);
+    setTimeout(() => { if (!activeId && vanishedId === back && vanishedWhy === "hidden" && stripShows(back)) setActive(back); }, 0);   // the reason re-read too: a teardown queued in between must not be undone
   }
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
@@ -7193,6 +7193,9 @@ window.addEventListener("romp-hosts", () => { renderTabs(); syncComposerPh(); })
 // a dial attempt to a remote host began or ended (federation.ts dialEvent): the host-down foot's swirl
 // spins while one is in flight, as of the last /tunnels poll, so it repaints on this event and on nothing else
 window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); repaintEmptyStateIfUnfocused(); });   // the unfocused body's "reconnecting" follows the dial state too (T357)
+// the `#only=` filter is the location hash, so a LIVE edit of the hash repaints the strip at once: the hidden tab's
+// unfocus and its return both run off this repaint, not off the next kernel frame (T357 later lows)
+window.addEventListener("hashchange", () => renderTabs());
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
 // (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it
@@ -11958,12 +11961,12 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 // the strip dresses it (host prefix, identity colour), "reconnecting" when its host is dialing; or the plain invitation.
 /** Does the strip show `id` right now: in the tab view (a peek counts) AND matching the `#only=` filter — the one
  *  predicate renderTabs's visibleIds is built from, read again at fire time so a deferred check judges the strip as
- *  it is, not as it was scheduled. */
-function stripShows(id: string): boolean {
+ *  it is, not as it was scheduled. `only` may be passed by a caller that read the hash once for many ids. */
+function stripShows(id: string, only: string | null = onlyTag()): boolean {
   if (!tabInView(id)) return false;
-  const only = onlyTag();
   return !only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only);
 }
+
 // The strip's #only= filter stopped showing the active tab (T357, the review's probe: web persisted, `#only=api`, a
 // reload): the same rule as a dismissal — the pane goes UNFOCUSED naming the session the filter hides, its transcript
 // leaves the screen, and it never re-points itself at another session. renderTabs restores it when the filter shows

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -58,7 +58,7 @@ import { reconcileHeld, heldAsQueued, type HeldCopy, type HeldQueued, type HeldM
 import { reloadHoldReason } from "./reload-hold";
 import { liveNotices, keepReloadNotices, takeReloadNotices } from "./reload-notices";
 import { mintProvisionalId, isProvisionalId, provisionalName, adoptsProvisional, focusResolvesProvisional } from "./provisional";
-import { onlyTag, matchesOnly } from "./only-filter";
+import { onlyTag, matchesOnly, onlyWindow } from "./only-filter";
 import { numberDiff, type DiffRow } from "./diff-lines";
 import { parseAgentNotif, notifHead, type AgentNotif } from "./agent-notif";
 import { injectedHead, type InjectedSource } from "./injected-source";
@@ -6263,7 +6263,6 @@ function renderTabs() {
   // demo/recording view filter (the user 2026-07-14): `#only=<tag>` shows only matching-name tabs; the
   // real sessions keep running, just hidden from this view. No tag → visibleIds === ids (unchanged).
   const only = onlyTag();
-  const nameOf = (id: string) => sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "";
   // the session VIEWS filter composes here too (the user 2026-08-18): a view-hidden session keeps
   // its state, drafts and cached transcript — it just loses its tab until revealed. ONE predicate (stripShows) builds
   // this list and answers the deferred checks below, so the two can never disagree (the review's low)
@@ -6284,7 +6283,11 @@ function renderTabs() {
   }
   if (!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds.includes(vanishedId)) {
     const back = vanishedId;
-    setTimeout(() => { if (!activeId && vanishedId === back && vanishedWhy === "hidden" && stripShows(back)) setActive(back); }, 0);   // the reason re-read too: a teardown queued in between must not be undone
+    // the reason re-read too: a teardown queued in between must not be undone. And the strip's MEMBERSHIP, not only the
+    // predicate: a teardown of a tab that is not active writes no vanished* (dismissSession does that for the active tab
+    // alone), so the reason still reads "hidden" after the tab left `order`; stripShows knows the view and the filter,
+    // not the strip, and would hand focus to a tab nobody can see (the review's low)
+    setTimeout(() => { if (!activeId && vanishedId === back && vanishedWhy === "hidden" && order.includes(back) && stripShows(back)) setActive(back); }, 0);
   }
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
@@ -7194,8 +7197,11 @@ window.addEventListener("romp-hosts", () => { renderTabs(); syncComposerPh(); })
 // spins while one is in flight, as of the last /tunnels poll, so it repaints on this event and on nothing else
 window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); repaintEmptyStateIfUnfocused(); });   // the unfocused body's "reconnecting" follows the dial state too (T357)
 // the `#only=` filter is the location hash, so a LIVE edit of the hash repaints the strip at once: the hidden tab's
-// unfocus and its return both run off this repaint, not off the next kernel frame (T357 later lows)
-window.addEventListener("hashchange", () => renderTabs());
+// unfocus and its return both run off this repaint, not off the next kernel frame (T357 later lows). On the dashboard
+// this pane is a same-origin iframe of the shell and the filter lives on the SHELL's URL (only-filter.ts reads
+// window.top), so the listener binds to the window onlyTag reads: the shell's there, this pane's own on a top-level
+// page or under a cross-origin top (the review: the pane's own hash never changes on the dashboard)
+onlyWindow().addEventListener("hashchange", () => renderTabs());
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
 // (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -63,8 +63,8 @@ test("the tabOrder frame carries the blob and the strip filters on it, composing
   // kernel's own name, selfHost, is adopted first of all — pr-links.test.ts pins that line)
   assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/,
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
-  assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
-  assert.match(RENDER, /const visibleIds = only \? inViewIds\.filter\(\(id\) => matchesOnly\(nameOf\(id\), only\)\) : inViewIds;/);
+  assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the view (tabInView, a peek counts) and the #only= filter through ONE predicate, stripShows (T357 later lows)");
+  assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "one predicate: the view (a peek counts) and the #only= filter (T357 follow-up)");
   // the active tab under BOTH filters (T357): a VIEW that excludes it is covered by the peek, asserted by
   // captureViews before applyTabOrder on every tabOrder frame (visibility is a pure function of the views blob); the
   // #only= filter is applied on top of tabInView and is no peek input, so an only-filtered active tab reaches the

--- a/ui/webview/session-views.test.ts
+++ b/ui/webview/session-views.test.ts
@@ -64,7 +64,7 @@ test("the tabOrder frame carries the blob and the strip filters on it, composing
   assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/,
     "echo-less frames still reach captureViews — an older kernel must age out a pending edit");
   assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the view (tabInView, a peek counts) and the #only= filter through ONE predicate, stripShows (T357 later lows)");
-  assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "one predicate: the view (a peek counts) and the #only= filter (T357 follow-up)");
+  assert.match(RENDER, /function stripShows\(id: string, only: string \| null = onlyTag\(\)\): boolean \{\s*\n\s*if \(!tabInView\(id\)\) return false;\s*\n\s*return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/, "the predicate's body: the view first (a peek counts), then the #only= filter over the name ladder (T357 later lows)");
   // the active tab under BOTH filters (T357): a VIEW that excludes it is covered by the peek, asserted by
   // captureViews before applyTabOrder on every tabOrder frame (visibility is a pure function of the views blob); the
   // #only= filter is applied on top of tabInView and is no peek input, so an only-filtered active tab reaches the

--- a/ui/webview/tab-meta.test.ts
+++ b/ui/webview/tab-meta.test.ts
@@ -118,5 +118,5 @@ test("the tabOrder frame's views land before the strip repaints — a CLI tag ed
   // the frame's provenance rides along since T233 (captureViews still runs before the strip is applied; the
   // kernel's own name, selfHost, is adopted first of all — pr-links.test.ts pins that line)
   assert.match(RENDER, /else if \(m\.type === "tabOrder"\) \{\s*\n\s*if \(typeof m\.selfHost === "string" && m\.selfHost\) adoptSelfHost\(m\.selfHost\);[^\n]*\n\s*captureViews\(m\.views \|\| null\);\s*\n\s*applyTabOrder\(m\.order, m\.tabs, \{ reemit: m\.reemit === true, freshHost: typeof m\.freshHost === "string" \? m\.freshHost : undefined \}, m\.live\);\s*\n\s*\}/);
-  assert.match(RENDER, /const inViewIds = ids\.filter\(tabInView\);/);
+  assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the view (tabInView, a peek counts) and the #only= filter through ONE predicate, stripShows (T357 later lows)");
 });

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -67,6 +67,8 @@ type Hooks = {
   tabStateClass: typeof tabStateClass; tabDotClass: typeof tabDotClass; tabDotTitle: typeof tabDotTitle; sectionPip: typeof sectionPip; sectionPipMembers: typeof sectionPipMembers; sectionPipTitle: typeof sectionPipTitle;
   newSkeletonState: typeof newSkeletonState; renderKind: typeof renderKind;   // the skeleton strip (2026-09-07): empty here, so every listed id is a loaded tab or a placeholder
   skeletons: number;          // skeleton tabs minted (none expected: the set stays empty in these worlds)
+  timers: Array<() => void>;  // the deferred checks renderTabs schedules (setTimeout 0), fired by the test when it chooses
+  activated: string[];        // every setActive the fired checks made (T357 later lows: the hidden tab's restore)
 };
 type Api = {
   renderTabs: () => void; sig: () => string; folded: () => Set<string>;
@@ -88,6 +90,7 @@ function lift(): (hooks: Hooks) => Api {
     let renameActive = false, renderPendingAfterRename = false, tabPointerHeld = false, renderPendingWhilePressed = false;
     let tabStripSig = "", activeId = null, peekId = null, allHiddenBlanked = false, draggedId = null, draggedEl = null, tabDragCommitted = false;
     let order = [], closingTabs = new Set(), tabMeta = new Map(), sessions = new Map(), views = new Map();
+    let vanishedId = null, vanishedWhy = null;   // the unfocused pane's memory of what vanished and why (T357)
     let collapsedTabIds = new Set(), draggedGroup = null, provisionalId = null, provisionalTags = [];
     // stripGroupRows mirrors the default. Its break site is never reached here: FakeEl has no childElementCount,
     // so the gate's last operand is undefined whatever the setting, hence no makeRowBreak stub. Give FakeEl a
@@ -102,7 +105,8 @@ function lift(): (hooks: Hooks) => Api {
     const tabInView = (id) => id === peekId || !H.hidden.has(id);
     // the one visibility predicate renderTabs builds visibleIds from (T357 later lows): the view, then the #only= filter
     const stripShows = (id, only) => tabInView(id) && (!only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only));
-    const setActive = () => {}; const setTimeout = () => 0;
+    const setActive = (id) => { H.activated.push(id); }; const setTimeout = (f) => { H.timers.push(f); return 0; };   // the deferred checks, held for the test to fire
+    const unfocusHiddenByView = () => {};
     // the section-at-a-glance view's readers on the strip, inert: the plan the view reads (lastStripItems), the
     // section the pane shows (snapView, null: no view open, so stripAftermath's follow does nothing), and the
     // view's own painter and focus probe (never reached while snapView is null)
@@ -143,6 +147,7 @@ function lift(): (hooks: Hooks) => Api {
         else if (k === "sessions") sessions = p[k]; else if (k === "tabMeta") tabMeta = p[k]; else if (k === "settings") settings = p[k];
         else if (k === "views") views = p[k]; else if (k === "renameActive") renameActive = p[k]; else if (k === "tabPointerHeld") tabPointerHeld = p[k];
         else if (k === "provisionalId") provisionalId = p[k]; else if (k === "provisionalTags") provisionalTags = p[k];
+        else if (k === "vanishedId") vanishedId = p[k]; else if (k === "vanishedWhy") vanishedWhy = p[k];
         else throw new Error("unknown knob " + k); } },
       pending: () => ({ renderPendingAfterRename, renderPendingWhilePressed }) };
   `;
@@ -163,7 +168,7 @@ function world(): { H: Hooks; api: Api; sessions: Map<string, any>; tabMeta: Map
                      keyHint: "Open a session (K)", lens: { all: true }, unions: [], tips: [], aftermaths: [], rowPaints: 0, tagSyncs: 0, placeholders: 0,
                      groupsRaw: null, phone: false, heads: [],
                      planStrip, parseTabGroups, headWords, tabStateClass, tabDotClass, tabDotTitle, sectionPip, sectionPipMembers, sectionPipTitle,
-                     newSkeletonState, renderKind, skeletons: 0 };
+                     newSkeletonState, renderKind, skeletons: 0, timers: [], activated: [] };
   const api = lift()(H);
   const sessions = new Map<string, any>([["a", session("web", "ready")], ["b", session("api", "working")]]);
   const tabMeta = new Map<string, any>([["p", { name: "tests", color: { bg: "#112233", fg: "#ffffff" } }]]);
@@ -407,4 +412,25 @@ test("the all-hidden blank lands on the skip path when the active view appears b
   api.renderTabs();
   assert.equal(H.bar.wipes, 2);
   assert.equal(av.el.style.display, "", "restored once anything is visible");
+});
+
+test("executed: the hidden tab's restore fires only for a tab still on the strip (T357 later lows, the review's low)", () => {
+  // the pane unfocused with web hidden by the filter (vanishedWhy "hidden"); the filter lifts and renderTabs schedules
+  // the restore. BEFORE it fires, web is torn down while not active: dismissSession writes vanished* for the active tab
+  // alone, so the reason still reads "hidden" while web has left `order`. The timer must not hand focus to a tab nobody
+  // can see: the fire-time check reads the strip's membership, not only the predicate
+  const { H, api, sessions } = world();
+  api.set({ activeId: null, vanishedId: "a", vanishedWhy: "hidden" });
+  api.renderTabs();
+  assert.equal(H.timers.length, 1, "the restore is scheduled once");
+  api.set({ order: ["b", "p"] }); sessions.delete("a");
+  H.timers[0]();
+  assert.deepEqual(H.activated, [], "…and does not fire for a tab that left the strip meanwhile");
+  // the same schedule with the tab still listed restores it
+  const w2 = world();
+  w2.api.set({ activeId: null, vanishedId: "a", vanishedWhy: "hidden" });
+  w2.api.renderTabs();
+  assert.equal(w2.H.timers.length, 1);
+  w2.H.timers[0]();
+  assert.deepEqual(w2.H.activated, ["a"], "the tab still on the strip takes focus back");
 });

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -100,6 +100,8 @@ function lift(): (hooks: Hooks) => Api {
       createTextNode: (t) => { const n = new H.FakeEl("#text"); n.textContent = t; return n; } };
     const auditTabOrder = () => {}; const onlyTag = () => H.only; const matchesOnly = (name, only) => name.includes(only);
     const tabInView = (id) => id === peekId || !H.hidden.has(id);
+    // the one visibility predicate renderTabs builds visibleIds from (T357 later lows): the view, then the #only= filter
+    const stripShows = (id, only) => tabInView(id) && (!only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only));
     const setActive = () => {}; const setTimeout = () => 0;
     // the section-at-a-glance view's readers on the strip, inert: the plan the view reads (lastStripItems), the
     // section the pane shows (snapView, null: no view open, so stripAftermath's follow does nothing), and the


### PR DESCRIPTION
The four later lows from the verdict that armed the unfocused pane's follow-up.

- A live edit of the `#only=` hash repaints the strip at once (a `hashchange` listener), so the hidden tab's unfocus and its return do not wait for a kernel frame.
- The deferred restore re-reads the reason as well as the strip, so a teardown queued in between is never undone.
- One visibility predicate: `visibleIds` is built from `stripShows`, the hash read once per repaint.
- The hidden line is name-free: "This tab view shows no session. Change the view, or pick a tab."

Tests: the pins in pane-focus and session-views; the served lab's `#only=` road reads the exact line.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## The review's fold

- **The hash listener binds to the window the filter is read from.** On the dashboard the chat pane is a same-origin iframe of the shell and `#only=` lives on the shell's URL (only-filter.ts reads `window.top`), so a live edit of the shell's hash reached the pane's `onlyTag` but never its `hashchange` listener, which sat on the pane's own window. `onlyWindow()` (the shell's window when readable, the pane's own on a top-level page or under a cross-origin top) is what `onlyTag` reads and what the listener binds to. The lab serves the shell with the pane framed, edits the shell's hash, and reads the framed pane unfocusing off the live edit and restoring when the filter lifts, its own hash unchanged throughout.
- **The restore checks the strip's membership.** A teardown of a tab that is not active writes no vanished state, so the reason still read "hidden" after the tab left `order`; the fire-time check now requires membership in `order` beside the predicate. The executed strip harness drives a teardown between the schedule and the fire.
- A dead `nameOf` local in renderTabs is gone (pinned absent); the duplicated pin in session-views.test.ts is the predicate's body now.
