### PR TITLE
The registration read is one memoized stat, an empty record reads by type, the missing set is the bus's, the frame derives mail-off once (T356 review, four later lows)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -14363,29 +14363,44 @@ def _comment_msg_text(rec):
 _thread_reg_memo = {}   # tsid -> ((mtime_ns, size), reg dict) — see _thread_reg
 
 
-def _thread_reg(tsid):
-    """The thread's SDK registry entry (authoritative for cwd/lastSid/threadOf), {} when unreadable.
-    Memoized on the file's (mtime, size, inode) — thirteen callers, two of them per chat build, each decoded
-    the file afresh (2026-09-03). Returns a shallow copy so a caller's edit never leaks into the memo."""
+# the stat errors Path.exists() reads as "no such file" (the bus's rule for a record): a record behind one of these is
+# MISSING, an ordinary session; any other stat error (EACCES on the directory, EIO) is a record that exists but cannot
+# be read, the closed door (the review on T356's follow-ups: the two sides must agree)
+_REG_MISSING_ERRNOS = (errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP)
+
+
+def _thread_reg_read(tsid):
+    """(state, dict) for the session's durable SDK registry entry: ("ok", the record), ("missing", {}) when there is no
+    record, ("unreadable", {}) when one exists but cannot be read or is not a JSON object. Memoized on the file's
+    (mtime, size, inode, ctime) — thirteen callers, two of them per chat build, each decoded the file afresh
+    (2026-09-03); the OUTCOME is memoized too, so an unreadable record costs one stat per call, never a re-parse, and
+    ctime in the key means a permissions repair (no rewrite) is seen. The dict is the memo's own: callers copy."""
     p = jd.STATE / "sdk" / (tsid + ".json")
     try:
         st = p.stat()
-        key = (st.st_mtime_ns, st.st_size, st.st_ino)
-    except OSError:
+        key = (st.st_mtime_ns, st.st_size, st.st_ino, st.st_ctime_ns)
+    except OSError as e:
         _thread_reg_memo.pop(tsid, None)
-        return {}
+        return ("missing" if e.errno in _REG_MISSING_ERRNOS else "unreadable"), {}
     hit = _thread_reg_memo.get(tsid)
     if hit is not None and hit[0] == key:
-        return dict(hit[1])
+        return hit[1], hit[2]
     try:
         d = json.loads(p.read_text())
-        d = d if isinstance(d, dict) else {}
+        state, d = ("ok", d) if isinstance(d, dict) else ("unreadable", {})
     except (OSError, ValueError):
-        return {}
+        state, d = "unreadable", {}
     if len(_thread_reg_memo) > 512:
         _thread_reg_memo.pop(next(iter(_thread_reg_memo)))
-    _thread_reg_memo[tsid] = (key, d)
-    return dict(d)
+    _thread_reg_memo[tsid] = (key, state, d)
+    return state, d
+
+
+def _thread_reg(tsid):
+    """The thread's SDK registry entry (authoritative for cwd/lastSid/threadOf), {} when missing or unreadable (the
+    callers that need the difference read _thread_reg_read). Returns a shallow copy so a caller's edit never leaks into
+    the memo."""
+    return dict(_thread_reg_read(tsid)[1])
 
 
 def _thread_transcript_path(reg, tsid):
@@ -14901,6 +14916,7 @@ def _comments_frame(sid, live_map=None):
                 meta = be.session_meta(tsid) or {}
             except Exception:
                 meta = {}
+        mail_why = _mail_off_why_k(tsid)
         threads.append({"tid": th.get("tid"), "anchorUuid": th.get("anchorUuid"),
                         "relayedT": th.get("relayedT") or 0,   # the persistent sent-back indicator's stamp (T145)
                         "name": th.get("name") or "", "color": th.get("color") or "",
@@ -14916,8 +14932,8 @@ def _comments_frame(sid, live_map=None):
                         # shows only how many messages wait in the box (they land within the bus's retry interval of a
                         # break-out); the PROMOTED view says whether its mail is on, and why not when it is not, so the
                         # reason rides beside the boolean (an unreadable record is no mailbox toggle's to clear)
-                        "mailOff": bool(_postal_isolated(tsid)),
-                        "mailOffWhy": _mail_off_why_k(tsid),
+                        "mailOff": bool(mail_why),        # ONE derivation for both fields: a flags write between two reads could
+                        "mailOffWhy": mail_why,           # ship "on" beside "unreadable" (the review's low)
                         "heldMail": _held_mail_count(tsid),
                         "model": (reg.get("liveModel") or reg.get("model") or "") if reg else "",
                         "effort": (reg.get("effort") or "") if reg else "",
@@ -24158,16 +24174,10 @@ def _reg_unreadable(sid):
     mail as on for it (the review's low: _thread_reg answers {} for missing and unreadable alike). No record → False."""
     if not sid:
         return False
-    p = jd.STATE / "sdk" / (str(sid) + ".json")
-    try:
-        p.stat()
-    except FileNotFoundError:
-        return False
-    except OSError:
-        return True                 # a directory the kernel cannot read: closed, as the bus reads it
-    # the memoized read (_thread_reg, keyed on the file's mtime, size and inode): {} for a record that exists but cannot
-    # be read, never a re-parse per call (the review's low: a sweep of 154 records re-read every one)
-    return not _thread_reg(str(sid))
+    # ONE memoized read (_thread_reg_read: one stat, the outcome remembered) answers by TYPE, not truthiness: an empty
+    # object {} is a readable record (mail on, as the bus reads it); a stat error outside Path.exists()'s ignored set
+    # is a record that exists but cannot be read (the review's lows on the third follow-up)
+    return _thread_reg_read(str(sid))[0] == "unreadable"
 
 
 def _mail_off_why_k(sid):

--- a/tests/test_thread_mail_off.py
+++ b/tests/test_thread_mail_off.py
@@ -84,7 +84,7 @@ class ThreadMailOff(unittest.TestCase):
         # the comments frame says mailOff per thread; the /sessions thread rows and the Sessions pane rows carry the
         # effective postalServiceOff; the timeline lane and the chat rows read the effective reader too
         src = inspect.getsource(km._comments_frame)
-        self.assertIn('"mailOff": bool(_postal_isolated(tsid))', src)
+        self.assertIn('"mailOff": bool(mail_why)', src)
         rows = inspect.getsource(km._thread_rows)
         self.assertIn('"postalServiceOff": _postal_isolated(tsid)', rows); self.assertIn('"mailOffWhy": _mail_off_why_k(tsid)', rows)
         whole = Path(os.path.join(BIN, "romp-kernel")).read_text()
@@ -131,8 +131,31 @@ class UnreadableRecordOnTheKernelSide(unittest.TestCase):
         (Path(self.td) / "session-flags.json").write_text(json.dumps({PARENT: {"postalOff": True}}))
         self.assertEqual(km._mail_off_why_k(PARENT), "isolation", "the legacy key still isolates, under its reason")
         whole = Path(os.path.join(BIN, "romp-kernel")).read_text()
-        self.assertEqual(whole.count('"mailOffWhy": _mail_off_why_k('), 4, "chat rows, thread rows, Sessions pane rows and the comments frame carry the reason")
-        self.assertIn('"mailOffWhy": _mail_off_why_k(tsid)', inspect.getsource(km._comments_frame), "the promoted popover reads the reason")
+        self.assertEqual(whole.count('"mailOffWhy": _mail_off_why_k('), 3, "chat rows, thread rows and Sessions pane rows carry the reason inline")
+        self.assertIn('"mailOffWhy": mail_why', inspect.getsource(km._comments_frame), "…and the comments frame from its one derivation")
+
+    def test_the_record_state_is_by_type_and_by_the_buses_errno_set(self):
+        # the review's lows on the third follow-up: {} is a readable record (type, not truthiness); a symlink loop or a
+        # regular file where the sdk/ directory should be reads MISSING as Path.exists() does on the bus; a chmod repair
+        # is seen without a rewrite (ctime is in the memo's key)
+        d = Path(self.td) / "sdk"
+        (d / (PLAIN + ".json")).write_text("{}")
+        self.assertEqual(km._thread_reg_read(PLAIN), ("ok", {})); self.assertFalse(km._reg_unreadable(PLAIN)); self.assertEqual(km._mail_off_why_k(PLAIN), "")
+        loop = d / (THREAD + ".json"); os.symlink(loop, loop)
+        self.assertEqual(km._thread_reg_read(THREAD)[0], "missing", "ELOOP: no record, as the bus reads it"); self.assertFalse(km._reg_unreadable(THREAD))
+        loop.unlink()
+        (d / (PARENT + ".json")).write_text(json.dumps({"sid": PARENT}))
+        if os.geteuid() != 0:
+            os.chmod(d / (PARENT + ".json"), 0)
+            try:
+                self.assertEqual(km._thread_reg_read(PARENT)[0], "unreadable", "EACCES on the file: closed")
+                self.assertTrue(km._reg_unreadable(PARENT))
+            finally:
+                os.chmod(d / (PARENT + ".json"), 0o644)
+            self.assertEqual(km._thread_reg_read(PARENT)[0], "ok", "the repair (a chmod, no rewrite) is seen: ctime moved the key")
+        src = inspect.getsource(km._comments_frame)
+        self.assertIn("mail_why = _mail_off_why_k(tsid)", src); self.assertIn('"mailOff": bool(mail_why)', src); self.assertIn('"mailOffWhy": mail_why', src)
+        self.assertEqual(src.count("_mail_off_why_k(tsid)"), 1, "one derivation for both fields")
 
     def test_the_unreadable_check_reads_the_registration_memo_not_the_file(self):
         # the review's low: a sweep re-read and re-parsed every record; the memo (mtime, size, inode) answers now
@@ -141,7 +164,7 @@ class UnreadableRecordOnTheKernelSide(unittest.TestCase):
         self.assertFalse(km._reg_unreadable(PLAIN))
         self.assertIn(PLAIN, km._thread_reg_memo, "the read went through the memo")
         src = inspect.getsource(km._reg_unreadable)
-        self.assertIn("return not _thread_reg(str(sid))", src); self.assertNotIn("json.loads", src, "no parse of its own")
+        self.assertIn('return _thread_reg_read(str(sid))[0] == "unreadable"', src); self.assertNotIn("json.loads", src, "no parse of its own"); self.assertNotIn(".stat()", src, "one stat, the memo's")
         (Path(self.td) / "sdk" / (PLAIN + ".json")).write_text("{corrupt")
         self.assertTrue(km._reg_unreadable(PLAIN), "a rewrite is a new memo key: the corrupt record reads unreadable")
         if os.geteuid() != 0:

--- a/ui/webview/thread-mail.test.ts
+++ b/ui/webview/thread-mail.test.ts
@@ -28,7 +28,8 @@ test("the popover says the thread's mail is off, and the promoted view says it i
   assert.match(RENDER, /mailOn\.textContent = !th\.mailOff\s*\n\s*\? "Its mail is on now[^\n]*\n\s*: th\.mailOffWhy === "unreadable" \? "Its mail is held: this session's record cannot be read, and mail flows again once the record is repaired\."\s*\n\s*: "Its mailbox is off: the lane's mailbox toggle turns peer mail back on\."/,
                "the promoted line reads the reason: an unreadable record is no mailbox toggle's to clear");
   assert.match(COMMENTS, /mailOffWhy\?: string;/);
-  assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),\s*\n\s*"mailOffWhy": _mail_off_why_k\(tsid\),/, "the comments frame carries the reason");
+  assert.match(KERNEL, /mail_why = _mail_off_why_k\(tsid\)\s*\n\s*threads\.append\(\{/, "the comments frame derives the reason once, before the row");
+  assert.match(KERNEL, /"mailOff": bool\(mail_why\),[^\n]*\n\s*"mailOffWhy": mail_why,/, "…and both fields read that one derivation");
   assert.match(RENDER, /" in a moment\."/);
 });
 
@@ -48,7 +49,7 @@ test("the kernel and the bus derive the same default from the thread's reg and t
   assert.match(KERNEL, /def _mail_off_why_k\(sid\):[\s\S]*?if _reg_unreadable\(sid\):\s*\n\s*return "unreadable"\s*\n\s*if _thread_mail_off\(sid\):\s*\n\s*return "thread"\s*\n\s*return "isolation" if \(_session_flag\(sid, "postalServiceOff"\) or _session_flag\(sid, "postalOff"\)\) else ""/,
                "the kernel's reasons: unreadable first (the bus holds everything for it), then the thread default, then the mailbox flag");
   assert.match(KERNEL, /def _postal_isolated\(sid\):[\s\S]*?return bool\(_mail_off_why_k\(sid\)\)/);
-  assert.match(KERNEL, /"mailOff": bool\(_postal_isolated\(tsid\)\),/, "the comments frame carries it");
+  assert.match(KERNEL, /"mailOff": bool\(mail_why\),/, "the comments frame carries it (one derivation with the reason)");
   assert.match(KERNEL, /"postalServiceOff": _postal_isolated\(m\["id"\]\),/, "the Sessions pane rows carry it");
   assert.match(POSTAL, /t = _thread_of\(sid\)\s*\n\s*if t == THREAD_REG_UNREADABLE:\s*\n\s*return "unreadable"[^\n]*\n\s*if t and not \(isinstance\(f, dict\) and f\.get\("threadMail"\) is True\):\s*\n\s*return "thread"/,
                "an unreadable record is closed under its own reason, then the literal-True key");


### PR DESCRIPTION
The four later lows from the verdict that armed the third mail-off follow-up.

- **By type, not truthiness**: an empty object `{}` is a readable record (mail on, as the bus reads it). The registration read answers a state (`ok`, `missing`, `unreadable`) and the check reads it.
- **The bus's errno set**: ENOENT, ENOTDIR, EBADF and ELOOP mean no record (a symlink loop, a regular file where the directory should be); any other stat error is a record that cannot be read.
- **One stat per read**: the memo remembers the outcome beside the record, keyed on mtime, size, inode and ctime, so an unreadable record costs one stat and no parse, and a permissions repair without a rewrite is seen. The earlier commit's after-figure (1.3 ms) was two stats and a copy; this is one.
- **One derivation per frame**: the comments frame fills `mailOff` and `mailOffWhy` from one read, so a flags write between two reads can no longer ship "on" beside "unreadable".

Tests: `{}` readable; a symlink loop missing; EACCES unreadable then a chmod repair seen; the check has no stat or parse of its own; the single derivation pinned in Python and TS.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
