### PR TITLE
The note test compares child order by index, and the modal style names its twin by its current class

### DIFF
--- a/ui/webview/feed-render-incremental.test.ts
+++ b/ui/webview/feed-render-incremental.test.ts
@@ -1040,7 +1040,11 @@ test("a far host's parked-question note shows on its own line with no brief, in 
   assert.equal(card("g4")._distill.style.display, "none", "the distill line is hidden without a brief");
   assert.equal(rn().textContent, note, "the note is the card's own line");
   assert.equal(rn().style.display, "", "…and shows (appended inside the distill element it was hidden with it)");
-  assert.equal(rn().parentNode, card("g4")._secs.parentNode, "beside the sections, not inside them");
+  // compared by INDEX, never by node identity: a failed identity assertion formats two stand-in nodes (a cyclic
+  // tree) and kills the runner before it prints a message (the manager's verifier, with the old placement restored)
+  const kids = card("g4")._secs.parentNode.childNodes;
+  assert.equal(kids.indexOf(rn()), kids.indexOf(card("g4")._face) + 1, "beside the sections, right after the face line, not inside them");
+  assert.equal(kids.indexOf(card("g4")._face), kids.indexOf(card("g4")._secs) + 1, "the face line follows the sections");
   // collapsed mode: every section closed by default, the brief's included
   const setPrefs = (v: string) => { stores.local.set("romp:settings", v); win.dispatchEvent(Object.assign(new Event("storage"), { key: "romp:settings", newValue: v })); };
   setPrefs(JSON.stringify({ collapsed: true }));

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -766,7 +766,7 @@ body { display: flex; flex-direction: column; position: relative; }   /* column 
 .ftree-seclabel { font-size: 0.92em; color: var(--dim); margin-top: 4px; }
 .ftree-summary-link { cursor: pointer; border-radius: 6px; transition: background 0.1s ease; }
 .ftree-summary-link:hover { background: rgba(255, 255, 255, 0.07); text-decoration: underline; text-underline-offset: 2px; }
-.ftree-relaynote { font-size: 0.86em; line-height: 1.45; margin: 0 0 6px; color: var(--dim); white-space: pre-wrap; overflow-wrap: anywhere; }   /* the modal's twin of .fsum-relaynote */
+.ftree-relaynote { font-size: 0.86em; line-height: 1.45; margin: 0 0 6px; color: var(--dim); white-space: pre-wrap; overflow-wrap: anywhere; }   /* the modal's twin of .fask-relaynote */
 .st-done .ftree-mark { color: var(--rel-done); }
 /* a BLOCKED (needs-you) node: the "?" is RED inside a RED ring the SAME 13px size as the ✓ checkbox disc,
    and its label reads "BLOCKED" in red (the user 2026-06-17) — a stronger, unmistakable block signal than


### PR DESCRIPTION
## What

Two cosmetic follow-ups from the verifier of the parked-question note change, kept out of that change so its armed head stayed put.

- **The feed's stand-in test compares child order by index.** The placement assertion for the note's element compared two DOM stand-in nodes by identity. When such an assertion fails, the runner formats both nodes, a cyclic tree, and is killed before it prints a message. The assertion now compares child indexes: the note sits right after the face line, which follows the sections. Broken on purpose, the failure prints the expected and actual indexes.
- **The modal note style's comment names its twin by its current class.** It still named the card class by the name the change renamed away.

## Tests

`ui/webview/feed-render-incremental.test.ts` and `ui/webview/relay-note.test.ts` pass; the type check is clean.

Tier: fix
