### PR TITLE
The prompt hook answers ordinary prompts from a cache and fails open on a stall

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3193,6 +3193,32 @@ BOOT_RESUME_CONCURRENCY = max(1, int(os.environ.get("ROMP_BOOT_RESUME_CONCURRENC
 # Backstop ONLY (never the mechanism): a CLI that wedges before init would otherwise hold its slot
 # forever and trap the whole sweep — after this long the sweep proceeds anyway, loudly.
 BOOT_RESUME_SLOT_S = float(os.environ.get("ROMP_BOOT_RESUME_SLOT_S", "180"))
+# The UserPromptSubmit hook's WALL-TIME CAP (2026-09-12). The SDK runs SdkSession._prompt_submit_hook
+# for every prompt a session receives and REFUSES the prompt when the hook misses the CLI's own hook
+# deadline (about 30 s), instead of failing open — under a host load of 100 to 300 on 64 cores the
+# hook's reg read stalled past it and six sessions missed messages for 14 to 76 minutes each. The
+# hook now gives up FIRST: its body runs under asyncio.wait_for with this cap (env
+# ROMP_PROMPT_HOOK_TIMEOUT_S, read at call time so a test can set it; default 8 s) and answers a
+# timeout with {} — the prompt runs. The matcher-level deadline handed to the SDK for this hook
+# (PROMPT_HOOK_SDK_TIMEOUT_S, when the installed HookMatcher takes one) sits far above it, so the
+# inner cap is always the one that fires and the SDK's refusal never is.
+PROMPT_HOOK_TIMEOUT_S_DEFAULT = 8.0
+PROMPT_HOOK_SDK_TIMEOUT_S = 120.0
+# How often (wall clock, at most) an ORDINARY prompt may cost the gate a stat of the reg — the
+# backstop that catches a sessionCrons writer this session object never saw (see the prompt-cache
+# note above _prompt_submit_hook). Only a moved mtime costs a read.
+CRON_PROMPTS_REFRESH_S = 60.0
+
+
+def prompt_hook_timeout_s() -> float:
+    """The prompt hook's cap in seconds, read from ROMP_PROMPT_HOOK_TIMEOUT_S at call time; a value
+    that will not parse, or is not positive, falls to PROMPT_HOOK_TIMEOUT_S_DEFAULT."""
+    raw = os.environ.get("ROMP_PROMPT_HOOK_TIMEOUT_S", "")
+    try:
+        v = float(raw) if raw.strip() else PROMPT_HOOK_TIMEOUT_S_DEFAULT
+    except ValueError:
+        return PROMPT_HOOK_TIMEOUT_S_DEFAULT
+    return v if v > 0 else PROMPT_HOOK_TIMEOUT_S_DEFAULT
 # Boot RE-ATTACHES to live session hosts (T315) are socket connects and a replay of a few hundred small records,
 # not the launch of a claude process, so they do not take the spawn stagger's slots: they run on a wider bound of
 # their own (the restart-path work, 2026-09-11: twelve attaches paced three at a time cost 4 s of a 20 s restart).
@@ -4920,6 +4946,13 @@ class SdkSession:
         self.name = reg.get("name", self.sid)
         self.cwd = reg.get("cwd") or os.path.expanduser("~")
         self.mode = reg.get("mode") or "acceptEdits"
+        # The recurring-cron PROMPT CACHE (2026-09-12): the prompt hook's common path touches no file
+        # (see the note above _prompt_submit_hook). Seeded from the reg this session was built from;
+        # every sessionCrons writer on this object re-reads it, and a 60 s mtime backstop covers the rest.
+        self._cron_prompts: frozenset = frozenset()
+        self._cron_prompts_at = 0.0                 # monotonic stamp of the last (attempted) refresh
+        self._cron_prompts_mtime = None             # the reg file's st_mtime_ns the cache was read at
+        self._cron_prompts_seed(reg)
         # The PROCESS GENERATION stamp: session-scoped timers live in THIS CLI process's memory, so
         # every armed-timer record carries the generation that armed it (procGen). A recorded timer
         # whose generation is still the live one WILL be fired by the CLI itself — the kernel must
@@ -7985,6 +8018,7 @@ class SdkSession:
                         slim.append(c)
                 if slim != prev.get("sessionCrons"):
                     self.backend._update_reg(self.sid, sessionCrons=slim, sessionCronsAt=int(nw))
+                    self._cron_prompts_refresh()       # the armed set moved under the gate's cache
         except Exception as e:
             self.backend._log("stop hook (%s): session_crons record failed: %s" % (self.name, e))
         # Reconcile the LAUNCH LEDGER against the payload's background_tasks — the per-turn snapshot
@@ -8080,6 +8114,7 @@ class SdkSession:
                     # cancels its own pending wakeup on stop, and keeping ours would fabricate a wake
                     cur = [c for c in cur if not (c.get("src") == "toolhook" and not c.get("recurring"))]
                     self.backend._update_reg(self.sid, sessionCrons=cur, sessionCronsAt=int(nw))
+                    self._cron_prompts_refresh()
                     return {}
                 delay = targs.get("delaySeconds")
                 prompt = str(targs.get("prompt") or "")[:500]
@@ -8107,9 +8142,65 @@ class SdkSession:
             else:
                 return {}
             self.backend._update_reg(self.sid, sessionCrons=cur, sessionCronsAt=int(nw))
+            self._cron_prompts_refresh()               # an arm or delete: the gate's cache follows it
         except Exception as e:
             self.backend._log("sched tool hook (%s): %s" % (self.name, e))
         return {}
+
+    # ── the recurring-cron PROMPT CACHE (2026-09-12) ─────────────────────────────────────────────
+    # _prompt_submit_hook runs for EVERY prompt a session receives, and the SDK REFUSES a prompt whose
+    # hook misses the CLI's hook deadline (about 30 s) instead of failing open. Its first step used to
+    # be a reg read on every prompt; under a host load of 100 to 300 on 64 cores (2026-09-11 21:00Z to
+    # 2026-09-12 00:00Z) that read stalled past the deadline and six sessions missed messages for 14 to
+    # 76 minutes each — the one failure the gate's own docstring forbids. So the gate answers an
+    # ORDINARY prompt from memory: this set holds the recurring-cron prompt heads (recurring_crons(reg)
+    # → prompt[:500], exactly what the gate matches on), seeded from the reg at construction, re-read
+    # by every sessionCrons writer on this object (the Stop hook's record, the scheduling-tool hook's
+    # arm and delete) and, once a minute at most, by a stat-then-read backstop when the reg's mtime
+    # moved (a writer this object never saw: the boot reconcile, a kernel-side prune). Only a prompt IN
+    # the set costs a read. A stale set errs on the side the gate was always built to err on: a
+    # schedule fires once more (a duplicate), never once less.
+
+    def _reg_mtime_ns(self):
+        """The reg file's st_mtime_ns, None when it cannot be read (absent reg, a fake backend)."""
+        try:
+            return _reg_path(self.backend.state_dir, self.sid).stat().st_mtime_ns
+        except Exception:
+            return None
+
+    def _cron_prompts_seed(self, reg, mtime=None):
+        """Rebuild the cache from a reg ALREADY IN HAND — a reseed never costs a read of its own.
+        `mtime` is the reg file's st_mtime_ns taken BEFORE that reg was read: stamping the pre-read
+        stat means any write landing after it shows as a change to the backstop. None stats now
+        (construction, where the caller read the reg moments ago)."""
+        if not isinstance(reg, dict):
+            return
+        self._cron_prompts = frozenset(str(c.get("prompt") or "")[:500] for c in recurring_crons(reg))
+        self._cron_prompts_at = time.monotonic()
+        self._cron_prompts_mtime = self._reg_mtime_ns() if mtime is None else mtime
+
+    def _cron_prompts_refresh(self):
+        """Stat, read, reseed — what every sessionCrons writer on this object runs after its write.
+        A reg that will not read leaves the cache as it was: the hook fails OPEN on a stale miss."""
+        try:
+            m = self._reg_mtime_ns()
+            reg = read_reg(self.backend.state_dir, self.sid)
+            if reg is not None:
+                self._cron_prompts_seed(reg, m)
+        except Exception:
+            pass
+
+    def _cron_prompts_backstop(self):
+        """The once-a-minute backstop body (runs OFF the loop thread): a read only when the reg's
+        mtime moved since the cache was seeded."""
+        if self._reg_mtime_ns() != self._cron_prompts_mtime:
+            self._cron_prompts_refresh()
+
+    def _reg_read_stamped(self):
+        """(st_mtime_ns before the read, read_reg_for_rmw's answer): the gate's own read, run off the
+        loop thread so the hook's cap can interrupt a stall."""
+        m = self._reg_mtime_ns()
+        return m, read_reg_for_rmw(self.backend.state_dir, self.sid)
 
     async def _prompt_submit_hook(self, inp, tool_use_id, context):
         """UserPromptSubmit: the RECURRING-CRON REPLAY GATE (T211, 2026-09-01). A resumed CLI
@@ -8126,52 +8217,83 @@ class SdkSession:
         slot the dead process genuinely never delivered still fires exactly once after a restart
         (the CLI's own catch-up becomes the recovery instead of the bug). Every uncertain path fails
         OPEN (unreadable reg, unparseable schedule, hook error → the prompt runs): a duplicate fire
-        costs a turn, a swallowed slot costs the schedule itself."""
+        costs a turn, a swallowed slot costs the schedule itself.
+
+        BOUNDED, and FILE-FREE for an ordinary prompt (2026-09-12; the prompt-cache note above): the
+        body runs under asyncio.wait_for with prompt_hook_timeout_s() (ROMP_PROMPT_HOOK_TIMEOUT_S,
+        default 8 s — well inside the SDK's deadline, which is the one that refuses the prompt), with
+        the reg read on a worker thread because wait_for can only interrupt a body that yields: a
+        blocking read on the loop thread would run the cap out without ever tripping it. A timeout
+        is logged as a problem and answered {} — the prompt runs."""
+        cap = prompt_hook_timeout_s()
         try:
-            prompt = str((inp or {}).get("prompt") or "")
-            if not prompt:
-                return {}
-            reg = read_reg_for_rmw(self.backend.state_dir, self.sid)
-            if reg is None:
-                self.backend._log("cron dedupe (%s): reg unreadable — prompt allowed rather than "
-                                  "risking a swallowed schedule slot" % self.name, problem=True)
-                return {}
-            hits = [c for c in recurring_crons(reg)
-                    if str(c.get("prompt") or "") == prompt[:500] and str(c.get("cron") or "").strip()]
-            if not hits:
-                return {}
-            delivered = reg.get("cronDelivered")
-            delivered = dict(delivered) if isinstance(delivered, dict) else {}
-            now = time.time()
-            record, replay_of = {}, None
-            for c in hits:
-                slot = cron_prev_due(str(c.get("cron")), now)
-                if slot is None:
-                    return {}                  # a shape we can't reason about exactly → stand down
-                k = cron_slot_key(str(c.get("cron")), prompt[:500])
-                if float(delivered.get(k) or 0) >= slot:
-                    replay_of = slot           # this schedule's current slot already delivered
-                else:
-                    record[k] = slot
-            if record:
-                # Record AT the delivery moment; keys whose schedule left the armed set drop here
-                # (natural GC — the map can never outgrow the armed set + this delivery).
-                live = {cron_slot_key(str(c.get("cron")), str(c.get("prompt") or ""))
-                        for c in recurring_crons(reg)}
-                delivered = {k: v for k, v in delivered.items() if k in live}
-                delivered.update(record)
-                self.backend._update_reg(self.sid, cronDelivered=delivered)
-                return {}
-            when = time.strftime("%Y-%m-%d %H:%M", time.localtime(replay_of))
-            self.backend._log("cron dedupe (%s): blocked a replayed schedule fire — its %s slot was "
-                              "already delivered (a fresh process re-fires passed slots on resume)"
-                              % (self.name, when), problem=False)
-            return {"decision": "block",
-                    "reason": "This scheduled prompt already ran for its %s slot — skipping the "
-                              "duplicate." % when}
+            return await asyncio.wait_for(self._prompt_submit_gate(inp), timeout=cap)
+        except asyncio.TimeoutError:
+            self.backend._log("cron dedupe (%s): the prompt hook ran past its %.2fs cap "
+                              "(ROMP_PROMPT_HOOK_TIMEOUT_S) — prompt allowed rather than left for the SDK "
+                              "to refuse at its own deadline" % (self.name, cap), problem=True)
+            return {}
         except Exception as e:
             self.backend._log("cron dedupe (%s): %s — prompt allowed" % (self.name, e))
             return {}
+
+    async def _prompt_submit_gate(self, inp):
+        """The replay gate proper — the body _prompt_submit_hook runs under its cap. Its first step
+        is a set lookup, not a read: only a prompt some armed recurring schedule carries goes on to
+        the reg (and that read is what the backstop and the writers keep the set faithful to)."""
+        prompt = str((inp or {}).get("prompt") or "")
+        if not prompt:
+            return {}
+        head = prompt[:500]
+        if head not in self._cron_prompts:
+            # The common path: no armed recurring schedule carries this prompt → no file is touched.
+            # Once a minute at most, a stat off the loop thread asks whether a writer this object
+            # never saw moved the reg; only a moved mtime costs a read. The slot is claimed BEFORE the
+            # stat so prompts arriving while it runs skip it instead of piling on.
+            if time.monotonic() - self._cron_prompts_at >= CRON_PROMPTS_REFRESH_S:
+                self._cron_prompts_at = time.monotonic()
+                await asyncio.to_thread(self._cron_prompts_backstop)
+            if head not in self._cron_prompts:
+                return {}
+        mtime, reg = await asyncio.to_thread(self._reg_read_stamped)
+        if reg is None:
+            self.backend._log("cron dedupe (%s): reg unreadable — prompt allowed rather than "
+                              "risking a swallowed schedule slot" % self.name, problem=True)
+            return {}
+        self._cron_prompts_seed(reg, mtime)        # a reseed for free, from the read just paid for
+        hits = [c for c in recurring_crons(reg)
+                if str(c.get("prompt") or "") == prompt[:500] and str(c.get("cron") or "").strip()]
+        if not hits:
+            return {}
+        delivered = reg.get("cronDelivered")
+        delivered = dict(delivered) if isinstance(delivered, dict) else {}
+        now = time.time()
+        record, replay_of = {}, None
+        for c in hits:
+            slot = cron_prev_due(str(c.get("cron")), now)
+            if slot is None:
+                return {}                  # a shape we can't reason about exactly → stand down
+            k = cron_slot_key(str(c.get("cron")), prompt[:500])
+            if float(delivered.get(k) or 0) >= slot:
+                replay_of = slot           # this schedule's current slot already delivered
+            else:
+                record[k] = slot
+        if record:
+            # Record AT the delivery moment; keys whose schedule left the armed set drop here
+            # (natural GC — the map can never outgrow the armed set + this delivery).
+            live = {cron_slot_key(str(c.get("cron")), str(c.get("prompt") or ""))
+                    for c in recurring_crons(reg)}
+            delivered = {k: v for k, v in delivered.items() if k in live}
+            delivered.update(record)
+            self.backend._update_reg(self.sid, cronDelivered=delivered)
+            return {}
+        when = time.strftime("%Y-%m-%d %H:%M", time.localtime(replay_of))
+        self.backend._log("cron dedupe (%s): blocked a replayed schedule fire — its %s slot was "
+                          "already delivered (a fresh process re-fires passed slots on resume)"
+                          % (self.name, when), problem=False)
+        return {"decision": "block",
+                "reason": "This scheduled prompt already ran for its %s slot — skipping the "
+                          "duplicate." % when}
 
     # ---- subagent tracking (the transparency tmux never had) ----
 
@@ -11417,6 +11539,27 @@ class SdkBackend:
                 self._log("kernel wake failed: %s" % e)
 
     # ---- SDK option assembly (mirrors the tmux launch flags) ----
+    def _prompt_hook_matcher(self, HookMatcher, sess: SdkSession):
+        """The UserPromptSubmit matcher, with the SDK-side hook deadline RAISED where nothing else raises it.
+        The CLI refuses a prompt whose hook misses that deadline — how six sessions went deaf under host
+        load on 2026-09-11 — so the hook's own cap (ROMP_PROMPT_HOOK_TIMEOUT_S, 8 s) must always fire first.
+        Under session hosts (the default since T348) _options's loop below already gives EVERY matcher the
+        host's HOOK_TIMEOUT_S (540 s), far above the cap, and only fills a `timeout` that is None — so
+        with hosts on this leaves it None and lets the host bound stand; with hosts OFF it passes
+        PROMPT_HOOK_SDK_TIMEOUT_S (120 s), so the SDK's default is never the deadline that fires.
+        HookMatcher takes `timeout` in claude-agent-sdk 0.2.152 (the installed version); an older venv's
+        HookMatcher refuses the keyword, and the matcher is then built without it — logged as a problem,
+        so the degraded deadline is visible rather than silent."""
+        if self.session_hosts_on():
+            return HookMatcher(matcher=None, hooks=[sess._prompt_submit_hook])
+        try:
+            return HookMatcher(matcher=None, hooks=[sess._prompt_submit_hook], timeout=PROMPT_HOOK_SDK_TIMEOUT_S)
+        except TypeError:
+            self._log("prompt hook: this claude-agent-sdk's HookMatcher takes no timeout — the SDK's own "
+                      "hook deadline stays at its default; the hook's %.0fs cap still fails open"
+                      % PROMPT_HOOK_TIMEOUT_S_DEFAULT, problem=True, key="prompt-hook-matcher-timeout")
+            return HookMatcher(matcher=None, hooks=[sess._prompt_submit_hook])
+
     def _options(self, sess: SdkSession, ClaudeAgentOptions):
         from claude_agent_sdk import HookMatcher
         kw = dict(
@@ -11444,7 +11587,7 @@ class SdkBackend:
             can_use_tool=sess._can_use_tool,
             hooks={"Stop": [HookMatcher(matcher=None, hooks=[sess._stop_hook])],          # awaiting overlay producer
                    # recurring-cron replay gate: a resumed CLI re-fires passed slots (T211)
-                   "UserPromptSubmit": [HookMatcher(matcher=None, hooks=[sess._prompt_submit_hook])],
+                   "UserPromptSubmit": [self._prompt_hook_matcher(HookMatcher, sess)],
                    "SubagentStart": [HookMatcher(matcher=None, hooks=[sess._subagent_start_hook])],  # live subagent
                    "SubagentStop": [HookMatcher(matcher=None, hooks=[sess._subagent_stop_hook])],    #   count/types
                    # scheduling tools record their arm at the CALL moment, with the exact due time the

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -8222,16 +8222,18 @@ class SdkSession:
         BOUNDED, and FILE-FREE for an ordinary prompt (2026-09-12; the prompt-cache note above): the
         body runs under asyncio.wait_for with prompt_hook_timeout_s() (ROMP_PROMPT_HOOK_TIMEOUT_S,
         default 8 s — well inside the SDK's deadline, which is the one that refuses the prompt), with
-        the reg read on a worker thread because wait_for can only interrupt a body that yields: a
-        blocking read on the loop thread would run the cap out without ever tripping it. A timeout
-        is logged as a problem and answered {} — the prompt runs."""
+        the reg read AND the cronDelivered write on a worker thread because wait_for can only
+        interrupt a body that yields: a blocking read or write on the loop thread would run the cap
+        out without ever tripping it. A timeout is logged as a problem (one counted ring row per
+        session for the whole stall, not a row per prompt) and answered {} — the prompt runs."""
         cap = prompt_hook_timeout_s()
         try:
             return await asyncio.wait_for(self._prompt_submit_gate(inp), timeout=cap)
         except asyncio.TimeoutError:
             self.backend._log("cron dedupe (%s): the prompt hook ran past its %.2fs cap "
                               "(ROMP_PROMPT_HOOK_TIMEOUT_S) — prompt allowed rather than left for the SDK "
-                              "to refuse at its own deadline" % (self.name, cap), problem=True)
+                              "to refuse at its own deadline" % (self.name, cap), problem=True,
+                              key=("prompt-hook-cap", self.sid))
             return {}
         except Exception as e:
             self.backend._log("cron dedupe (%s): %s — prompt allowed" % (self.name, e))
@@ -8285,7 +8287,11 @@ class SdkSession:
                     for c in recurring_crons(reg)}
             delivered = {k: v for k, v in delivered.items() if k in live}
             delivered.update(record)
-            self.backend._update_reg(self.sid, cronDelivered=delivered)
+            # Off the loop thread like the read: _update_reg is a lock wait, a read and a write, and
+            # the cap can only interrupt at an await. A write the cap cuts still lands (the worker
+            # finishes it), which is the outcome this {} was about to record: the prompt runs and
+            # the slot is on file, so the next resume's catch-up sees it as delivered.
+            await asyncio.to_thread(self.backend._update_reg, self.sid, cronDelivered=delivered)
             return {}
         when = time.strftime("%Y-%m-%d %H:%M", time.localtime(replay_of))
         self.backend._log("cron dedupe (%s): blocked a replayed schedule fire — its %s slot was "

--- a/tests/test_prompt_hook_failopen.py
+++ b/tests/test_prompt_hook_failopen.py
@@ -12,10 +12,12 @@ recurring schedule carries still reads the reg and still blocks a replayed slot 
 The cache follows the armed set through its three refresh paths: construction, every sessionCrons
 writer on the session object (the scheduling-tool hook's arm and delete, the Stop hook's record),
 and a once-a-minute stat-then-read backstop for writers the object never saw. (2) The whole body runs
-under a wall-time cap (ROMP_PROMPT_HOOK_TIMEOUT_S, default 8 s) with the reg read off the loop
-thread, so a stall — even a blocking one — is answered {} inside the cap: the prompt runs. Plus the
-SDK-side matcher deadline: raised to 120 s where no session host raises it, left to the host's own
-540 s bound where one does. Synthetic fixtures (hostname TESTHOST, placeholder sid); PRIVATE sid."""
+under a wall-time cap (ROMP_PROMPT_HOOK_TIMEOUT_S, default 8 s) with the reg read AND the
+cronDelivered write off the loop thread, so a stall — even a blocking one — is answered {} inside the
+cap: the prompt runs, and a stall that outlasts many prompts is one counted problem row per session,
+not a row per prompt. Plus the SDK-side matcher deadline: raised to 120 s where no session host
+raises it, left to the host's own 540 s bound where one does. Synthetic fixtures (hostname TESTHOST,
+placeholder sid); PRIVATE sid."""
 import asyncio
 import json
 import os
@@ -329,6 +331,52 @@ class TimeoutFailsOpen(_Gate):
         self.assertEqual(out, {}, "the cron prompt is allowed rather than refused at the SDK's deadline")
         self.assertLess(took, 0.5, "the hook did not wait for the stalled read")
         self.assertTrue(any("ran past its" in m for m in self.logs))
+
+    def test_a_stalled_blocking_cron_delivered_write_is_cut_too(self):
+        """The cron-prompt path's OTHER file touch: recording the slot is _update_reg, a lock wait plus a
+        read plus a write, and the cap can only interrupt at an await, so the write runs off the loop
+        thread as the read does. Pinned by a BLOCKING sleep in write_reg (which _update_reg reaches
+        by module name); the cut write still lands, so the slot the prompt ran is on file."""
+        self._write([_armed()])
+        s = self._session()
+        os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = "0.05"
+        real = sb.write_reg
+
+        def stalled(state_dir, sid, reg):
+            time.sleep(0.6)
+            return real(state_dir, sid, reg)
+        sb.write_reg = stalled
+        self.addCleanup(setattr, sb, "write_reg", real)
+        out, took = self._timed_fire(s)
+        self.assertEqual(out, {}, "the cron prompt is allowed rather than refused at the SDK's deadline")
+        self.assertLess(took, 0.5, "the hook did not wait for the stalled write")
+        self.assertTrue(any("ran past its" in m for m in self.logs))
+        self.assertTrue(self._reg().get("cronDelivered"),
+                        "the worker finished the write the cap cut: the delivered slot is recorded")
+
+    def test_repeated_timeouts_are_one_counted_problem_row(self):
+        """A stall lasts an EPISODE, not a prompt. The kernel log gets every timed-out hook's line, but
+        the ring row is keyed per session, so the dashboard sees one counted row rather than a fresh
+        entry per prompt evicting every other problem (the 2026-09-06 class)."""
+        self._write([_armed()])
+        s = self._session()
+        os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = "0.05"
+        real = sb.read_reg_for_rmw
+
+        def stalled(state_dir, sid):
+            time.sleep(0.6)
+            return real(state_dir, sid)
+        sb.read_reg_for_rmw = stalled
+        self.addCleanup(setattr, sb, "read_reg_for_rmw", real)
+        self.assertEqual(self._timed_fire(s)[0], {})
+        self.assertEqual(self._timed_fire(s)[0], {})
+        self.assertEqual(len([m for m in self.logs if "ran past its" in m]), 2,
+                         "the kernel log still gets every line")
+        rows = [p for p in self.be._problems if "ran past its" in str(p.get("text"))]
+        self.assertEqual(len(rows), 1, "…but the ring holds ONE row for the episode")
+        self.assertEqual(rows[0].get("count"), 2, "…that counts the repeat")
+        self.assertIn("1 repeat", rows[0]["text"])
+        self.assertEqual(rows[0].get("key"), ("prompt-hook-cap", SID), "keyed per session")
 
     def test_the_cap_reads_the_env_at_call_time(self):
         self.assertEqual(sb.prompt_hook_timeout_s(), sb.PROMPT_HOOK_TIMEOUT_S_DEFAULT)

--- a/tests/test_prompt_hook_failopen.py
+++ b/tests/test_prompt_hook_failopen.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Sessions went DEAF under host load (2026-09-11 21:00Z to 2026-09-12 00:00Z, a load of 100 to 300
+on 64 cores). The SDK runs SdkSession._prompt_submit_hook for EVERY prompt a session receives, the
+hook opened with a reg read on every prompt — before it could tell the prompt was not a recurring
+cron's at all — and when that read stalled past the CLI's hook deadline the SDK REFUSED the prompt
+instead of failing open: six sessions missed messages for 14 to 76 minutes each. The hook's own
+docstring forbids exactly that ("every uncertain path fails OPEN").
+
+Two guards, pinned here. (1) An ORDINARY prompt is answered from the per-session cache of
+recurring-cron prompt heads and touches no file — no read, no stat — while a prompt an armed
+recurring schedule carries still reads the reg and still blocks a replayed slot exactly as before.
+The cache follows the armed set through its three refresh paths: construction, every sessionCrons
+writer on the session object (the scheduling-tool hook's arm and delete, the Stop hook's record),
+and a once-a-minute stat-then-read backstop for writers the object never saw. (2) The whole body runs
+under a wall-time cap (ROMP_PROMPT_HOOK_TIMEOUT_S, default 8 s) with the reg read off the loop
+thread, so a stall — even a blocking one — is answered {} inside the cap: the prompt runs. Plus the
+SDK-side matcher deadline: raised to 120 s where no session host raises it, left to the host's own
+540 s bound where one does. Synthetic fixtures (hostname TESTHOST, placeholder sid); PRIVATE sid."""
+import asyncio
+import json
+import os
+import tempfile
+import time
+import types
+import unittest
+from pathlib import Path
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the load — the module resolves its state root at import time, and only
+# pytest runs conftest's floor (a bare unittest run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = load_source("romp_sdk_backend_prompt_hook", os.path.join(BIN, "romp_sdk_backend.py"))
+
+SID = "11111111-2222-4333-8444-000000000911"        # private synthetic sid — never the shared one
+HOST = "TESTHOST"
+PROMPT = "nightly sweep of the notes-api test corpus"
+ORDINARY = "please rerun the failing web tests and summarize"
+CRON = "0 0 1 1 *"          # Jan 1 00:00 — its most recent slot is FIXED for the whole test run
+CORRUPT = b'{"sid": "trunca'
+
+
+def _armed(prompt=PROMPT, cron=CRON):
+    return {"id": "c1", "cron": cron, "prompt": prompt, "kind": "cron", "recurring": True,
+            "armedAt": time.time() - 3600, "dueEpoch": None, "procGen": "gen-A"}
+
+
+class _Gate(unittest.TestCase):
+    """A real backend + session over a private reg on a temp state dir; no real CLI."""
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.logs = []
+        self.be = sb.SdkBackend(self.d, "/bin/true", lambda *a, **k: None, log=self.logs.append)
+        self._path = sb._reg_path(Path(self.d), SID)
+        self._env_before = os.environ.get("ROMP_PROMPT_HOOK_TIMEOUT_S")
+        os.environ.pop("ROMP_PROMPT_HOOK_TIMEOUT_S", None)
+
+    def tearDown(self):
+        if self._env_before is None:
+            os.environ.pop("ROMP_PROMPT_HOOK_TIMEOUT_S", None)
+        else:
+            os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = self._env_before
+
+    def _write(self, crons):
+        sb.write_reg(Path(self.d), SID, {"sid": SID, "name": "sched", "cwd": "/tmp", "host": HOST,
+                                         "alive": True, "sessionCrons": crons})
+
+    def _session(self):
+        return sb.SdkSession(self.be, sb.read_reg(Path(self.d), SID))
+
+    def _fire(self, sess, prompt=PROMPT):
+        return asyncio.run(sess._prompt_submit_hook({"prompt": prompt}, None, None))
+
+    def _reg(self):
+        """Read the reg file directly — never through the module readers a test may have wrapped."""
+        try:
+            return json.loads(self._path.read_text())
+        except (OSError, ValueError):
+            return {}
+
+    def _count_reads(self):
+        """Wrap the module's reg readers (looked up at call time) with counters; restored in tearDown."""
+        counts = {"rmw": 0, "read": 0}
+        real_rmw, real_read = sb.read_reg_for_rmw, sb.read_reg
+
+        def rmw(state_dir, sid):
+            counts["rmw"] += 1
+            return real_rmw(state_dir, sid)
+
+        def read(state_dir, sid):
+            counts["read"] += 1
+            return real_read(state_dir, sid)
+
+        sb.read_reg_for_rmw, sb.read_reg = rmw, read
+        self.addCleanup(setattr, sb, "read_reg_for_rmw", real_rmw)
+        self.addCleanup(setattr, sb, "read_reg", real_read)
+        return counts
+
+    def _forbid_reads(self, sess):
+        """Every file touch the hook could make RAISES (and is counted): the readers by module name, the
+        stat by the session's own method. A hook that reaches any of them is caught by its except → {}
+        — which is why the tests assert the COUNT, not just the answer."""
+        counts = {"rmw": 0, "read": 0, "stat": 0}
+
+        def boom(which):
+            def f(*a, **k):
+                counts[which] += 1
+                raise AssertionError("the common path touched the reg (%s)" % which)
+            return f
+
+        real_rmw, real_read = sb.read_reg_for_rmw, sb.read_reg
+        sb.read_reg_for_rmw, sb.read_reg = boom("rmw"), boom("read")
+        self.addCleanup(setattr, sb, "read_reg_for_rmw", real_rmw)
+        self.addCleanup(setattr, sb, "read_reg", real_read)
+        sess._reg_mtime_ns = boom("stat")
+        return counts
+
+
+class OrdinaryPromptsTouchNoFile(_Gate):
+    """(a) The common path: a prompt no armed recurring schedule carries costs no read and no stat."""
+
+    def test_an_ordinary_prompt_never_reads_the_reg(self):
+        self._write([_armed()])
+        s = self._session()
+        counts = self._forbid_reads(s)
+        self.assertEqual(self._fire(s, ORDINARY), {}, "the prompt runs")
+        self.assertEqual(counts, {"rmw": 0, "read": 0, "stat": 0},
+                         "no reg read, no stat: the answer came from the cache")
+        self.assertNotIn("cronDelivered", self._reg(), "and nothing was written")
+        self.assertFalse(any("prompt allowed" in m for m in self.logs),
+                         "no fail-open log either — this was a plain miss, not an error path")
+
+    def test_a_session_with_no_schedules_is_the_same_free_path(self):
+        self._write([])
+        s = self._session()
+        counts = self._forbid_reads(s)
+        for i in range(50):
+            self.assertEqual(self._fire(s, "message %d for the web session" % i), {})
+        self.assertEqual(counts, {"rmw": 0, "read": 0, "stat": 0},
+                         "fifty prompts inside a minute: not one file touch")
+
+    def test_an_empty_prompt_is_ignored_without_a_read(self):
+        self._write([_armed()])
+        s = self._session()
+        counts = self._forbid_reads(s)
+        self.assertEqual(self._fire(s, ""), {})
+        self.assertEqual(asyncio.run(s._prompt_submit_hook({}, None, None)), {})
+        self.assertEqual(counts, {"rmw": 0, "read": 0, "stat": 0})
+
+
+class CronPromptsStillGate(_Gate):
+    """(b) A prompt IN the cache consults the reg and blocks a replayed slot exactly as before."""
+
+    def test_construction_seeds_the_cache_from_the_reg(self):
+        self._write([_armed()])
+        s = self._session()
+        self.assertEqual(s._cron_prompts, frozenset({PROMPT}))
+        self.assertIsNotNone(s._cron_prompts_mtime, "the reg's mtime is stamped beside it")
+
+    def test_matching_prompt_reads_the_reg_and_blocks_the_restart_replay(self):
+        self._write([_armed()])
+        counts = self._count_reads()
+        s1 = self._session()
+        self.assertEqual(self._fire(s1), {}, "the first delivery of a slot goes through")
+        self.assertEqual(counts["rmw"], 1, "…and it DID consult the reg (read_reg_for_rmw, once)")
+        slot = sb.cron_prev_due(CRON, time.time())
+        key = sb.cron_slot_key(CRON, PROMPT)
+        self.assertEqual(self._reg().get("cronDelivered"), {key: slot},
+                         "delivery — not arming — writes the durable slot record")
+        s2 = self._session()                       # the kernel restarted; boot re-arm resumed it
+        out = self._fire(s2)                       # the fresh CLI catch-up re-fires the slot
+        self.assertEqual(counts["rmw"], 2, "the replay check is a reg read too")
+        self.assertEqual(out.get("decision"), "block", "the replay is refused")
+        self.assertIn("already ran", out.get("reason", ""))
+        self.assertEqual(self._reg().get("cronDelivered"), {key: slot}, "a refused replay changes nothing")
+        self.assertTrue(any("blocked a replayed schedule fire" in m for m in self.logs), "loudly")
+
+    def test_long_prompts_match_on_the_recorded_500(self):
+        long_prompt = "x" * 480 + PROMPT           # the reg stores prompt[:500]
+        self._write([_armed(prompt=long_prompt[:500])])
+        counts = self._count_reads()
+        s1 = self._session()
+        self.assertEqual(self._fire(s1, long_prompt), {})
+        self.assertEqual(counts["rmw"], 1, "the cache keys on the same first 500 characters the reg holds")
+        s2 = self._session()
+        self.assertEqual(self._fire(s2, long_prompt).get("decision"), "block")
+
+    def test_unreadable_reg_on_a_cron_prompt_fails_open_and_says_so(self):
+        self._write([_armed()])
+        s = self._session()
+        self._path.write_bytes(CORRUPT)
+        self.assertEqual(self._fire(s), {}, "fail OPEN")
+        self.assertEqual(self._path.read_bytes(), CORRUPT, "…and never writes through the corruption")
+        self.assertTrue(any("unreadable" in m for m in self.logs), "loudly")
+
+    def test_one_shots_never_enter_the_cache(self):
+        self._write([{"id": "w1", "cron": "", "prompt": PROMPT, "recurring": False, "armedAt": time.time(),
+                      "dueEpoch": time.time() + 60, "procGen": "gen-A", "src": "toolhook"}])
+        s = self._session()
+        self.assertEqual(s._cron_prompts, frozenset(), "recurring_crons(reg) is the cache's predicate")
+        counts = self._forbid_reads(s)
+        self.assertEqual(self._fire(s), {})
+        self.assertEqual(counts["rmw"], 0, "a one-shot's prompt is an ordinary prompt to the gate")
+
+
+class CacheFollowsTheArmedSet(_Gate):
+    """The refresh paths: the scheduling-tool hook's arm and delete, the Stop hook's record, and the
+    once-a-minute mtime backstop for a writer this object never saw."""
+
+    def _tool(self, s, tool, **tool_input):
+        return asyncio.run(s._sched_tool_hook({"tool_name": tool, "tool_input": tool_input}, None, None))
+
+    def test_cron_create_via_the_tool_hook_arms_the_gate(self):
+        self._write([])
+        s = self._session()
+        counts = self._count_reads()
+        self.assertEqual(self._fire(s), {})
+        self.assertEqual(counts["rmw"], 0, "before the arm, the prompt is ordinary: no read")
+        self._tool(s, "CronCreate", name="c1", schedule=CRON, prompt=PROMPT)
+        self.assertIn(PROMPT, s._cron_prompts, "the arm refreshed the cache")
+        reads = counts["rmw"]
+        self.assertEqual(self._fire(s), {}, "the first delivery goes through…")
+        self.assertEqual(counts["rmw"], reads + 1, "…via a reg read")
+        self.assertTrue(self._reg().get("cronDelivered"), "…and records the slot")
+        self.assertEqual(self._fire(s).get("decision"), "block", "the same slot again is a replay")
+
+    def test_cron_delete_via_the_tool_hook_disarms_it(self):
+        self._write([_armed()])
+        s = self._session()
+        self._tool(s, "CronDelete", name="c1")
+        self.assertEqual(s._cron_prompts, frozenset(), "the delete refreshed the cache")
+        counts = self._forbid_reads(s)
+        self.assertEqual(self._fire(s), {})
+        self.assertEqual(counts["rmw"], 0, "the prompt is ordinary again: no read")
+
+    def test_stop_hook_record_refreshes_the_cache(self):
+        self._write([])
+        s = self._session()
+        self.assertEqual(s._cron_prompts, frozenset())
+        asyncio.run(s._stop_hook({"session_crons": [{"id": "c1", "schedule": CRON, "prompt": PROMPT,
+                                                     "kind": "cron", "recurring": True}]}, None, None))
+        self.assertIn(PROMPT, s._cron_prompts, "the Stop hook's sessionCrons record is a writer too")
+
+    def test_backstop_rereads_when_the_reg_mtime_moved(self):
+        self._write([])
+        s = self._session()
+        # another writer (the boot reconcile, a kernel-side prune) arms a schedule behind this object
+        self._write([_armed()])
+        st = self._path.stat()
+        os.utime(self._path, ns=(st.st_atime_ns, st.st_mtime_ns + 5_000_000_000))   # a moved mtime, for certain
+        counts = self._count_reads()
+        s._cron_prompts_at = time.monotonic() - sb.CRON_PROMPTS_REFRESH_S - 1      # the minute is up
+        self.assertEqual(self._fire(s), {}, "the backstop found the arm: this is the slot's first delivery")
+        self.assertIn(PROMPT, s._cron_prompts)
+        self.assertGreaterEqual(counts["read"], 1, "the moved mtime cost a read")
+        self.assertTrue(self._reg().get("cronDelivered"), "…and the gate engaged")
+
+    def test_backstop_costs_one_stat_and_no_read_when_the_mtime_is_unchanged(self):
+        self._write([])
+        s = self._session()
+        counts = self._count_reads()
+        stats = {"n": 0}
+        real_stat = s._reg_mtime_ns
+
+        def counted():
+            stats["n"] += 1
+            return real_stat()
+        s._reg_mtime_ns = counted
+        s._cron_prompts_at = time.monotonic() - sb.CRON_PROMPTS_REFRESH_S - 1
+        self.assertEqual(self._fire(s, ORDINARY), {})
+        self.assertEqual((stats["n"], counts["read"], counts["rmw"]), (1, 0, 0),
+                         "one stat, no read: the mtime had not moved")
+        self.assertEqual(self._fire(s, ORDINARY), {})
+        self.assertEqual(stats["n"], 1, "the slot was claimed: the next prompt inside the minute skips the stat")
+
+    def test_backstop_is_not_reached_inside_the_minute(self):
+        self._write([])
+        s = self._session()
+        counts = self._forbid_reads(s)
+        self.assertEqual(self._fire(s, ORDINARY), {})
+        self.assertEqual(counts["stat"], 0, "a fresh cache is trusted for the whole minute")
+
+
+class TimeoutFailsOpen(_Gate):
+    """(c) The cap: a body that runs long is answered {} — and logged as a problem — inside the cap."""
+
+    def _timed_fire(self, s, prompt=PROMPT):
+        async def run():
+            t0 = time.monotonic()
+            out = await s._prompt_submit_hook({"prompt": prompt}, None, None)
+            return out, time.monotonic() - t0
+        return asyncio.run(run())
+
+    def test_a_slow_body_is_cut_and_the_prompt_runs(self):
+        self._write([_armed()])
+        s = self._session()
+        os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = "0.05"
+
+        async def slow(inp):
+            await asyncio.sleep(0.6)
+            return {"decision": "block", "reason": "too late to matter"}
+        s._prompt_submit_gate = slow
+        out, took = self._timed_fire(s)
+        self.assertEqual(out, {}, "fail OPEN: the prompt runs")
+        self.assertLess(took, 0.5, "…answered inside the cap, not after the body finished")
+        self.assertTrue(any("ran past its" in m for m in self.logs), "loudly")
+        self.assertTrue(any("ran past its" in str(p.get("text")) for p in self.be._problems),
+                        "…as a PROBLEM (the dashboard's error ring), not a plain log line")
+
+    def test_a_stalled_blocking_reg_read_is_cut_too(self):
+        """The 2026-09-11 shape exactly: the reg read itself hangs. wait_for can only interrupt a body
+        that yields, so the read runs off the loop thread — pinned here by a BLOCKING sleep."""
+        self._write([_armed()])
+        s = self._session()
+        os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = "0.05"
+        real = sb.read_reg_for_rmw
+
+        def stalled(state_dir, sid):
+            time.sleep(0.6)
+            return real(state_dir, sid)
+        sb.read_reg_for_rmw = stalled
+        self.addCleanup(setattr, sb, "read_reg_for_rmw", real)
+        out, took = self._timed_fire(s)
+        self.assertEqual(out, {}, "the cron prompt is allowed rather than refused at the SDK's deadline")
+        self.assertLess(took, 0.5, "the hook did not wait for the stalled read")
+        self.assertTrue(any("ran past its" in m for m in self.logs))
+
+    def test_the_cap_reads_the_env_at_call_time(self):
+        self.assertEqual(sb.prompt_hook_timeout_s(), sb.PROMPT_HOOK_TIMEOUT_S_DEFAULT)
+        self.assertEqual(sb.PROMPT_HOOK_TIMEOUT_S_DEFAULT, 8.0)
+        os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = "2.5"
+        self.assertEqual(sb.prompt_hook_timeout_s(), 2.5)
+        for bad in ("abc", "0", "-3", " "):
+            os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = bad
+            self.assertEqual(sb.prompt_hook_timeout_s(), 8.0, "unusable value → the default: %r" % bad)
+
+    def test_a_fast_body_is_untouched_by_the_cap(self):
+        self._write([_armed()])
+        s = self._session()
+        os.environ["ROMP_PROMPT_HOOK_TIMEOUT_S"] = "5"
+        self.assertEqual(self._fire(s), {})
+        self.assertEqual(self._fire(s).get("decision"), "block", "the gate's verdicts pass through the cap intact")
+        self.assertFalse(any("ran past its" in m for m in self.logs))
+
+
+class MatcherDeadline(_Gate):
+    """The SDK-side deadline on the UserPromptSubmit matcher."""
+
+    def _hosts(self, on):
+        Path(self.d, "session-hosts").write_text("on" if on else "off")
+
+    def test_hosts_off_raises_the_sdk_deadline_to_120(self):
+        self._write([])
+        self._hosts(False)
+        fake = lambda **kw: types.SimpleNamespace(**kw)
+        s = self._session()
+        m = self.be._prompt_hook_matcher(fake, s)
+        self.assertEqual(m.timeout, sb.PROMPT_HOOK_SDK_TIMEOUT_S)
+        self.assertEqual(m.timeout, 120.0)
+        self.assertGreater(m.timeout, sb.PROMPT_HOOK_TIMEOUT_S_DEFAULT, "the hook's own cap always fires first")
+        self.assertEqual(m.hooks, [s._prompt_submit_hook])
+        self.assertIsNone(m.matcher)
+
+    def test_hosts_on_leaves_the_deadline_to_the_host_bound(self):
+        self._write([])
+        self._hosts(True)
+        fake = lambda **kw: types.SimpleNamespace(**kw)
+        s = self._session()
+        m = self.be._prompt_hook_matcher(fake, s)
+        self.assertFalse(hasattr(m, "timeout"), "None for _options's host loop to fill with HOOK_TIMEOUT_S")
+        self.assertEqual(m.hooks, [s._prompt_submit_hook])
+
+    def test_an_older_sdk_without_timeout_still_gets_its_matcher_loudly(self):
+        self._write([])
+        self._hosts(False)
+
+        def old(matcher=None, hooks=None):
+            return types.SimpleNamespace(matcher=matcher, hooks=hooks)
+        s = self._session()
+        m = self.be._prompt_hook_matcher(old, s)
+        self.assertEqual(m.hooks, [s._prompt_submit_hook])
+        self.assertFalse(hasattr(m, "timeout"))
+        self.assertTrue(any("takes no timeout" in x for x in self.logs), "the degraded deadline is visible")
+        self.assertTrue(any("takes no timeout" in str(p.get("text")) for p in self.be._problems))
+
+    def test_options_wires_the_builder_into_the_hooks_dict(self):
+        import sys
+        self._write([])
+        self._hosts(False)
+        fake_sdk = "claude_agent_sdk" not in sys.modules and not sb.sdk_importable()
+        if fake_sdk:
+            fake = types.ModuleType("claude_agent_sdk")
+            fake.HookMatcher = lambda **kw: types.SimpleNamespace(**kw)
+            sys.modules["claude_agent_sdk"] = fake
+            self.addCleanup(sys.modules.pop, "claude_agent_sdk", None)
+        fetch_before = sb._fetch_key_fast_org
+        sb._fetch_key_fast_org = lambda key: None     # a real HTTPS GET otherwise — never from a test
+        self.addCleanup(setattr, sb, "_fetch_key_fast_org", fetch_before)
+        s = self._session()
+        kw = self.be._options(s, dict)
+        m = kw["hooks"]["UserPromptSubmit"][0]
+        self.assertEqual(getattr(m, "timeout", None), 120.0)
+        self.assertEqual(m.hooks, [s._prompt_submit_hook])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The fault

Sessions went deaf under host load (2026-09-11 21:00Z to 2026-09-12 00:00Z, a load of 100 to 300 on 64 cores). The SDK runs `SdkSession._prompt_submit_hook` (the recurring-cron replay gate) for **every** prompt a session receives. The hook opened with `read_reg_for_rmw` on every prompt, before it could tell the prompt was not a recurring cron's at all; when that read stalled past the CLI's hook deadline, the SDK **refused the prompt** instead of failing open. Six sessions missed messages for 14 to 76 minutes each. The hook's own docstring says every uncertain path fails OPEN; this is the path it missed.

## The fix

1. **The common path is free of file IO.** Each `SdkSession` caches the set of recurring-cron prompt heads (`recurring_crons(reg)` → `prompt[:500]`, exactly what the gate matches on). An ordinary prompt is answered from that set: no read, no stat. Only a prompt in the set reads the reg, and the replay-gate semantics for those prompts are unchanged (the gate logic moved verbatim into `_prompt_submit_gate`). The cache is kept faithful three ways: seeded at construction; re-read by every `sessionCrons` writer on the object (`_sched_tool_hook`'s arm and delete, and the Stop hook's `session_crons` record); and a once-a-minute backstop that stats the reg off the loop thread and re-reads only when its mtime moved (a writer this object never saw). A stale cache errs on the side the gate was always built to err on: one duplicate fire, never a swallowed one.
2. **The hook's wall time is bounded.** The body runs under `asyncio.wait_for` with `ROMP_PROMPT_HOOK_TIMEOUT_S` (read at call time, default 8 s). The reg read runs on a worker thread (`asyncio.to_thread`), because `wait_for` can only interrupt a body that yields — a blocking read on the loop thread would run the cap out without ever tripping it. A timeout is logged once via `_log(..., problem=True)` and answered `{}`: the prompt runs.
3. **SDK-side matcher deadline.** The installed claude-agent-sdk (0.2.152, in the kernel's sdkvenv) does accept `HookMatcher(timeout=...)` and passes it through to the CLI's hook config (`_hooks_to_internal_format`). On this branch, with session hosts on (the default since T348), `_options` already sets every matcher's `timeout` to the host bound (540 s) when it is `None`; so the new `_prompt_hook_matcher` leaves it `None` under hosts and passes **120 s** only when hosts are off, where the SDK default would otherwise be the deadline. An older SDK whose `HookMatcher` refuses the keyword gets the matcher without it, logged as a problem (not a silent degrade).

## Tests (`tests/test_prompt_hook_failopen.py`)

- an ordinary prompt calls neither `read_reg_for_rmw` nor `read_reg` nor `stat` (patched to raise and counted); fifty prompts in a minute, zero touches
- a cached cron prompt still reads the reg and still blocks a replayed slot exactly as before (the existing `test_cron_replay_dedupe.py` passes unchanged)
- a slow body, and a **blocking** stalled `read_reg_for_rmw`, are both answered `{}` inside a 0.05 s cap, logged as a problem
- arm via `CronCreate`, disarm via `CronDelete`, the Stop hook's record, the mtime backstop (moved mtime → read; unchanged mtime → one stat, no read; inside the minute → nothing)
- the matcher deadline: 120 s with hosts off, left to the host bound with hosts on, an old `HookMatcher` handled loudly, and `_options` wiring

Ran: `pytest tests/test_prompt_hook_failopen.py tests/test_cron_replay_dedupe.py tests/test_injected_voice.py tests/test_scheduled_sessions.py tests/test_reg_field_gutting.py tests/test_session_env.py tests/test_sdk_launch_error.py tests/test_cli_scope.py tests/test_sdk_compacting_signal.py tests/test_expected_auth.py tests/test_queued_copy_identity.py tests/test_host_transport.py` → 372 passed, 1 skipped (pre-existing skip). The full suite was not run locally on purpose (the host was at load 178 on 64 cores); CI runs it here.

## Applying it

The running kernel process must restart to load the new module; a kernel on an older branch needs this commit cherry-picked first (the hook body is byte-identical between this branch and the older `devbox-staging`, so it applies cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
