### PR TITLE
The unfocused pane's restores read one rule: listed and shown takes focus back, hidden stays unfocused; the hash listener is named and removed on pagehide; a vanished tab's teardown writes its reason (T357 fix)

### DIFF
--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -186,6 +186,27 @@ out.onlyFiltered = await page.evaluate(() => {
            empty: empty && getComputedStyle(empty).display !== "none" ? { text: empty.textContent, vanished: empty.dataset.vanished || "" } : null,
            visibleTurns: turns.length, composerDisabled: document.getElementById("composer-input").disabled };
 });
+// a ROUTINE push under the filter (the review's leak, pre-existing on main): applyTabOrder's restore re-focused the
+// filtered-out session for one animation frame per push, its cached transcript on screen, before renderTabs's deferred
+// unfocus put the body back. A frame recorder samples every animation frame across a tabOrder push listing web.
+await page.evaluate(() => {
+  window.__rec = [];
+  const empty = document.getElementById("empty-state");
+  const tick = () => {
+    const turns = Array.from(document.querySelectorAll("#content .turn")).filter((t) => { const r = t.getBoundingClientRect(); return r.width > 0 && r.height > 0 && getComputedStyle(t).display !== "none"; }).length;
+    window.__rec.push({ turns, active: !!document.querySelector("#tabs .tab.active[data-id]"), emptyShown: !!empty && getComputedStyle(empty).display !== "none" });
+    if (window.__rec.length < 90) requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+});
+await inject({ type: "tabOrder", order: [cfg.sidA, cfg.sidB], tabs: [A_TAB, B_TAB], live: [cfg.sidA, cfg.sidB], skeleton: [] });
+await page.waitForFunction(() => window.__rec && window.__rec.length >= 90, null, { timeout: 15000 });
+out.pushUnderFilter = await page.evaluate(() => ({ frames: window.__rec.length, leaked: window.__rec.filter((f) => f.turns > 0 || f.active).length, bodyDown: window.__rec.filter((f) => !f.emptyShown).length }));
+// the hidden tab torn down while the pane is unfocused (the review's low): the body's line follows the reason
+await inject({ type: "closed", id: cfg.sidA, hostDrop: true });
+await inject({ type: "tabOrder", order: [cfg.sidB], tabs: [B_TAB], live: [cfg.sidB], skeleton: [] });
+await page.waitForFunction((sid) => { const e = document.getElementById("empty-state"); return !!e && (e.textContent || "").includes("host disconnected") && !document.querySelector('#tabs .tab[data-id="' + sid + '"]'); }, cfg.sidA, { timeout: 10000 });
+out.tornDownWhileHidden = await state();
 // the SHELL road (the review's medium): on the dashboard the chat pane is a same-origin iframe of the shell and the
 // filter lives on the SHELL's URL (only-filter.ts reads window.top), so a live edit of the shell's hash must reach the
 // framed pane, whose own hash never changes: the pane unfocuses at once and restores when the filter shows the tab again
@@ -352,6 +373,14 @@ class ServedUnfocusedPane(unittest.TestCase):
         self.assertIsNotNone(of["empty"]); self.assertEqual(of["empty"]["vanished"], SID_A)
         self.assertEqual(of["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.", "name-free: a clean recording frame")
         self.assertTrue(of["composerDisabled"])
+        # a routine push under the filter never re-focuses the hidden tab, not for one animation frame (the review's leak:
+        # 1 frame of 70 with the body down and four transcript rows visible per push)
+        pu = r["pushUnderFilter"]
+        self.assertGreaterEqual(pu["frames"], 90); self.assertEqual((pu["leaked"], pu["bodyDown"]), (0, 0), "no frame with a focused tab, a visible transcript row, or the body down: %r" % pu)
+        # the hidden tab torn down while the pane is unfocused: the line follows the reason, naming the tab
+        td = r["tornDownWhileHidden"]
+        self.assertIsNone(td["active"]); self.assertEqual(td["empty"]["vanished"], SID_A); self.assertNotIn(SID_A, td["tabs"])
+        self.assertIn("web", td["empty"]["text"]); self.assertIn("host disconnected", td["empty"]["text"], "no longer the view's name-free line once the tab is gone: %r" % td)
         # the SHELL road (the review's medium): the pane framed on the dashboard, the filter edited on the SHELL's URL
         # (where only-filter.ts reads it): the pane's own hash never changes, yet the framed pane unfocuses off the live
         # edit and restores when the filter lifts

--- a/ui/webview/notify-click-reveal.test.ts
+++ b/ui/webview/notify-click-reveal.test.ts
@@ -54,7 +54,7 @@ test("a reveal outranks the persisted-tab restore: the focus handler retires wan
   assert.ok(focusBlock.length > 100, "found the focus handler");
   assert.match(focusBlock, /\n    wantActive = null;/);
   // …and the restore itself is still the one-shot it was: consumed on arrival, or retired here
-  assert.match(RENDER, /if \(wantActive && msg\.id === wantActive\) \{ wantActive = null; setActive\(msg\.id\); \}/);
+  assert.match(RENDER, /if \(wantActive && msg\.id === wantActive && stripLists\(msg\.id\)\) \{ wantActive = null; restoreIfShown\(msg\.id\); \}/, "consumed on arrival, through the one restore rule (shown takes focus; hidden stays unfocused)");
 });
 
 test("a focus on a federated session its host has not relayed yet shows the loader, not 'No session open'", () => {

--- a/ui/webview/only-filter.test.ts
+++ b/ui/webview/only-filter.test.ts
@@ -84,7 +84,7 @@ test("the timeline's standalone helper splits the tag the same way", () => {
 
 test("chat tabs filter by the #only tag", () => {
   assert.match(RENDER, /import \{ onlyTag, matchesOnly, onlyWindow \} from "\.\/only-filter";/);
-  assert.match(RENDER, /onlyWindow\(\)\.addEventListener\("hashchange", \(\) => renderTabs\(\)\);/, "the strip's live-edit listener binds to the window the filter is read from (the shell's when framed)");
+  assert.match(RENDER, /const onlyHashWindow = onlyWindow\(\);\s*\n\s*onlyHashWindow\.addEventListener\("hashchange", onOnlyHashChange\);/, "the strip's live-edit listener binds to the window the filter is read from (the shell's when framed)");
   assert.match(RENDER, /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "the #only= filter rides the one predicate the deferred checks read too (stripShows: tabInView, then matchesOnly over the hash)");
   assert.match(RENDER, /return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/);
   // the filtered ids are what the strip plan renders (tab-groups.ts planStrip, since tab groups 2026-09-04)
@@ -132,4 +132,23 @@ test("timeline lanes filter by the #only tag (self-contained helper in the stand
   assert.match(TL, /function _rompOnlyTag\(\)/);
   assert.match(TL, /function _rompMatchesOnly\(name, tag\)/);
   assert.match(TL, /sessions: data\.sessions\.filter\(\(s\) => _rompMatchesOnly\(s\.name, _only\)\)/);
+});
+
+test("the hash listener is a named handler and comes off the shell's window on pagehide (a closed split column must not hold the pane alive)", () => {
+  const a = RENDER.indexOf("const onOnlyHashChange = ");
+  const p = RENDER.indexOf('window.addEventListener("pagehide", () => onlyHashWindow.removeEventListener', a);
+  const b = RENDER.indexOf("\n", p);
+  assert.ok(a > 0 && p > a && b > p, "anchors not found: the listener block moved; re-anchor");
+  const js = RENDER.slice(a, b).replace(/\(\): void =>/g, "() =>");
+  const shell: any = { added: [] as string[], removed: [] as string[], f: null,
+    addEventListener(t: string, f: unknown) { this.added.push(t); this.f = f; },
+    removeEventListener(t: string, f: unknown) { this.removed.push(t + (f === this.f ? ":same" : ":other")); } };
+  const paneHandlers: Record<string, () => void> = {};
+  const pane: any = { addEventListener(t: string, f: () => void) { paneHandlers[t] = f; } };
+  let repaints = 0;
+  new Function("onlyWindow", "renderTabs", "window", js)(() => shell, () => { repaints++; }, pane);
+  assert.deepEqual(shell.added, ["hashchange"], "one listener on the window the filter is read from");
+  assert.deepEqual(Object.keys(paneHandlers), ["pagehide"], "the pane's own window carries only the pagehide belt");
+  shell.f(); assert.equal(repaints, 1, "the named handler repaints the strip");
+  paneHandlers.pagehide(); assert.deepEqual(shell.removed, ["hashchange:same"], "the same handler comes off on pagehide");
 });

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -62,8 +62,17 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = named \|\| "";/, "the body names the vanished or the awaited id");
   assert.doesNotMatch(RENDER, /empty\.textContent = "No session open/, "the one writer of the empty body is paintEmptyState");
   // the return: the session frame, or the strip re-listing it; no other arrival adopts the box meanwhile
-  assert.match(RENDER, /if \(vanishedId === msg\.id\) setActive\(msg\.id\);\s*\n\s*const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;/);
-  assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,500}?const back = vanishedId \|\| wantActive;[^\n]*\n\s*if \(back && order\.includes\(back\)\) setActive\(back\);/);
+  assert.match(RENDER, /if \(vanishedId === msg\.id\) restoreIfShown\(msg\.id\);[^\n]*\n\s*const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;/);
+  assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,500}?const back = vanishedId \|\| wantActive;[^\n]*\n\s*if \(back && restoreIfShown\(back\)\)/);
+  // every restore reads ONE rule (the review's leak: applyTabOrder's had no visibility predicate, so a routine push
+  // re-focused a filtered-out session for one frame): listed AND shown takes focus back; listed but hidden leaves the
+  // pane unfocused as "hidden", for renderTabs's schedule to restore when the filter shows it
+  assert.match(fn("restoreIfShown"), /if \(!stripLists\(id\)\) return false;\s*\n\s*if \(stripShows\(id\)\) \{ setActive\(id\); return true; \}\s*\n\s*if \(!activeId\) \{ vanishedId = id; vanishedWhy = "hidden";/);
+  assert.match(fn("stripLists"), /return !closingTabs\.has\(id\) && \(order\.includes\(id\) \|\| tabMeta\.has\(id\)\);/, "the paint's membership rule, shared with every restore");
+  assert.match(RENDER, /if \(wantActive && msg\.id === wantActive && stripLists\(msg\.id\)\) \{ wantActive = null; restoreIfShown\(msg\.id\); \}/, "the persisted tab's arrival restores only if shown");
+  assert.equal((RENDER.match(/\bsetActive\(back\)/g) || []).length, 1, "the one direct setActive(back) left is renderTabs's own fire-time restore, behind stripLists and stripShows");
+  // a hidden tab torn down while the pane is unfocused: the body's line follows the reason (the review's low)
+  assert.match(fn("dismissSession"), /if \(!wasActive && vanishedId === id\) \{[\s\S]{0,400}?vanishedWhy = why; vanishedName = name;\s*\n\s*repaintEmptyStateIfUnfocused\(\);\s*\n\s*\}/);
   // the reload road (the review's HIGH): the persisted tab is awaited at boot, the body names it, nothing adopts
   assert.match(RENDER, /^let wantActiveName: string = /m);
   assert.match(fn("paintEmptyState"), /const awaited = !vanishedId && wantActive \? wantActive : null;/);
@@ -72,7 +81,7 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(fn("paintEmptyState"), /const nameOf = \(id: string, carried = ""\) => carried \|\| wantActiveName \|\| tabMeta\.get\(id\)\?\.name \|\| sessions\.get\(id\)\?\.name \|\| "a session";/, "never a raw sid in the body, on any branch");
   assert.match(RENDER, /if \(wantActive && \(isSubId\(wantActive\) \|\| isProvisionalId\(wantActive\)\)\) \{ wantActiveGone = wantActive; wantActive = null; \}/, "an id that can never be listed again is not awaited");
   assert.match(fn("paintEmptyState"), /gone \? \{ name: nameOf\(gone\), why: "gone" as const, dialing: false \}/);
-  assert.match(fn("applyTabOrder"), /if \(back && order\.includes\(back\)\) setActive\(back\);\s*\n\s*else if \(!activeId\) showActive\(\);/, "the strip changing under an unfocused pane repaints the body (an emptied strip included)");
+  assert.match(fn("applyTabOrder"), /if \(back && restoreIfShown\(back\)\) \{[^\n]*\}\s*\n\s*else if \(!activeId\) showActive\(\);/, "the strip changing under an unfocused pane repaints the body (an emptied strip, or the named tab listed but hidden)");
   // the body repaints on the dial event; the view filter routes through the same rule; the keyboard picks the first tab
   assert.match(RENDER, /window\.addEventListener\("romp:hostDial", \(\) => \{ syncHostOfflineFoot\(\); repaintEmptyStateIfUnfocused\(\); \}\);/);
   assert.match(fn("repaintEmptyStateIfUnfocused"), /if \(activeId\) return;[\s\S]*?if \(e\) paintEmptyState\(e\);/);
@@ -81,11 +90,12 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   // applied on top of tabInView and is no peek input, so an only-filtered active tab goes UNFOCUSED here, never
   // re-pointed; the fire-time check reads the same predicate visibleIds is built from (stripShows)
   assert.match(fn("renderTabs"), /if \(activeId && ids\.includes\(activeId\) && !visibleIds\.includes\(activeId\)\) \{\s*\n\s*const hid = activeId;\s*\n\s*setTimeout\(\(\) => \{ if \(activeId === hid && !stripShows\(hid\)\) unfocusHiddenByView\(hid\); \}, 0\);/);
-  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,900}?if \(!activeId && vanishedId === back && vanishedWhy === "hidden" && order\.includes\(back\) && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again, the reason AND the strip's membership re-read at fire time (a tab torn down meanwhile left `order` with the reason still hidden)");
+  assert.match(fn("renderTabs"), /if \(!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds\.includes\(vanishedId\)\)[\s\S]{0,900}?if \(!activeId && vanishedId === back && vanishedWhy === "hidden" && stripLists\(back\) && stripShows\(back\)\) setActive\(back\);/, "…and comes back when the filter shows it again, the reason AND the strip's membership (stripLists, the paint's rule) re-read at fire time");
   assert.doesNotMatch(fn("renderTabs"), /const nameOf = /, "no second name ladder in renderTabs: stripShows carries the one (the review's low)");
   assert.match(fn("stripShows"), /function stripShows\(id: string, only: string \| null = onlyTag\(\)\): boolean \{\s*\n\s*if \(!tabInView\(id\)\) return false;\s*\n\s*return !only \|\| matchesOnly\(sessions\.get\(id\)\?\.name \?\? tabMeta\.get\(id\)\?\.name \?\? "", only\);/, "the one predicate");
   assert.match(fn("renderTabs"), /const visibleIds = ids\.filter\(\(id\) => stripShows\(id, only\)\);/, "visibleIds is built from it: no second copy");
-  assert.match(RENDER, /onlyWindow\(\)\.addEventListener\("hashchange", \(\) => renderTabs\(\)\);/, "a live edit of the #only= hash repaints at once, heard on the window that carries the filter (the shell's when framed)");
+  assert.match(RENDER, /const onlyHashWindow = onlyWindow\(\);\s*\n\s*onlyHashWindow\.addEventListener\("hashchange", onOnlyHashChange\);/, "a live edit of the #only= hash repaints at once, heard on the window that carries the filter (the shell's when framed), by a NAMED handler…");
+  assert.match(RENDER, /window\.addEventListener\("pagehide", \(\) => onlyHashWindow\.removeEventListener\("hashchange", onOnlyHashChange\)\);/, "…taken off the shell's window on pagehide (a closed split column must not hold the detached pane alive)");
   assert.doesNotMatch(RENDER, /window\.addEventListener\("hashchange"/, "never the pane's own window alone: framed on the dashboard its hash never changes (the review's medium)");
   assert.doesNotMatch(RENDER, /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab RE-POINT");
   assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5503,8 +5503,8 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   // T357: the tab the user was on is re-listed (a host re-attach, a relay redial) → focus goes back to it; the
   // skeleton branch of showActive asks for its frame. Another session's tab appearing does nothing here.
   const back = vanishedId || wantActive;   // …or the tab this page showed before a reload, awaited since boot
-  if (back && order.includes(back)) setActive(back);
-  else if (!activeId) showActive();   // the strip changed under an unfocused pane (it may have emptied): the body's line and the box's placeholder follow it (the review's low)
+  if (back && restoreIfShown(back)) { /* focus is back on the tab the pane named; nothing more to paint here */ }
+  else if (!activeId) showActive();   // the strip changed under an unfocused pane (it may have emptied), or the tab it names is listed but hidden: the body's line and the box's placeholder follow it (the review's low)
   renderTabs();
 }
 // The tabOrder frame's `skeleton` list (2026-09-07): the tabs the kernel is withholding from this page after a
@@ -6257,8 +6257,8 @@ function renderTabs() {
   // placeholder back on screen. Cleared the moment the kernel's list agrees — see ackClosingTabs.
   const ids: string[] = [];
   const seen = new Set<string>();
-  for (const id of order) { if (!seen.has(id) && !closingTabs.has(id)) { seen.add(id); ids.push(id); } }
-  for (const id of tabMeta.keys()) { if (!seen.has(id) && !closingTabs.has(id)) { seen.add(id); ids.push(id); } }   // any pushed tab not yet in `order` (placeholder)
+  for (const id of order) { if (!seen.has(id) && stripLists(id)) { seen.add(id); ids.push(id); } }
+  for (const id of tabMeta.keys()) { if (!seen.has(id) && stripLists(id)) { seen.add(id); ids.push(id); } }   // any pushed tab not yet in `order` (placeholder); stripLists is the one membership rule the restores read too
   auditTabOrder(ids);
   // demo/recording view filter (the user 2026-07-14): `#only=<tag>` shows only matching-name tabs; the
   // real sessions keep running, just hidden from this view. No tag → visibleIds === ids (unchanged).
@@ -6283,11 +6283,11 @@ function renderTabs() {
   }
   if (!activeId && vanishedId && vanishedWhy === "hidden" && visibleIds.includes(vanishedId)) {
     const back = vanishedId;
-    // the reason re-read too: a teardown queued in between must not be undone. And the strip's MEMBERSHIP, not only the
-    // predicate: a teardown of a tab that is not active writes no vanished* (dismissSession does that for the active tab
-    // alone), so the reason still reads "hidden" after the tab left `order`; stripShows knows the view and the filter,
-    // not the strip, and would hand focus to a tab nobody can see (the review's low)
-    setTimeout(() => { if (!activeId && vanishedId === back && vanishedWhy === "hidden" && order.includes(back) && stripShows(back)) setActive(back); }, 0);
+    // the reason re-read too: a teardown queued in between must not be undone. And the strip's MEMBERSHIP (stripLists,
+    // the paint's own rule: order and the placeholders, less a closing tab), not only the predicate: a torn-down tab has
+    // left the strip while its reason may still read "hidden", and stripShows knows the view and the filter, not the
+    // strip (the review's low, and the next review's: the schedule and the fire read ONE membership rule)
+    setTimeout(() => { if (!activeId && vanishedId === back && vanishedWhy === "hidden" && stripLists(back) && stripShows(back)) setActive(back); }, 0);
   }
   // TAB SECTIONS (the user 2026-09-04): groups are tags. With sectioning on (per browser — the
   // tag-lens menu's "Group tabs by tag") and some tag holding a visible tab, the strip renders one
@@ -7201,7 +7201,12 @@ window.addEventListener("romp:hostDial", () => { syncHostOfflineFoot(); repaintE
 // this pane is a same-origin iframe of the shell and the filter lives on the SHELL's URL (only-filter.ts reads
 // window.top), so the listener binds to the window onlyTag reads: the shell's there, this pane's own on a top-level
 // page or under a cross-origin top (the review: the pane's own hash never changes on the dashboard)
-onlyWindow().addEventListener("hashchange", () => renderTabs());
+const onOnlyHashChange = (): void => renderTabs();
+const onlyHashWindow = onlyWindow();
+onlyHashWindow.addEventListener("hashchange", onOnlyHashChange);
+// a closed split column: the shell removes this pane's iframe, and a listener left on the shell's window would hold the
+// detached pane alive and re-run its renderTabs on every later hash edit (the review): pagehide takes it off again
+window.addEventListener("pagehide", () => onlyHashWindow.removeEventListener("hashchange", onOnlyHashChange));
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
 // (installSnapshotEscape, armed at this same capture phase, later in the listener order) yields to it
@@ -11969,6 +11974,25 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 /** Does the strip show `id` right now: in the tab view (a peek counts) AND matching the `#only=` filter — the one
  *  predicate renderTabs's visibleIds is built from, read again at fire time so a deferred check judges the strip as
  *  it is, not as it was scheduled. `only` may be passed by a caller that read the hash once for many ids. */
+/** The strip's MEMBERSHIP: the ids renderTabs paints a tab for (the kernel's order, plus a pushed tab not yet in it, a
+ *  placeholder), less a tab the user just closed. One rule for the paint and for every restore's fire-time check (the
+ *  review of T357's later lows: the schedule read visibleIds, built over order AND tabMeta, while the timer read order
+ *  alone, so a placeholder-only tab painted while its restore declined). */
+function stripLists(id: string): boolean {
+  return !closingTabs.has(id) && (order.includes(id) || tabMeta.has(id));
+}
+/** The unfocused pane's restore of the tab it names or awaits (T357): only a tab the strip LISTS and SHOWS takes focus
+ *  back. A listed tab the view or the #only= filter hides leaves the pane unfocused with the name-free line (vanished as
+ *  "hidden"), and renderTabs's schedule restores it when the filter shows it again. The review measured the leak this
+ *  closes: applyTabOrder's restore had no visibility predicate, so every routine tabOrder push re-focused a filtered-out
+ *  session for one animation frame, its cached transcript on screen, before renderTabs's deferred unfocus put the body
+ *  back (1 frame of 70 per push). */
+function restoreIfShown(id: string): boolean {
+  if (!stripLists(id)) return false;
+  if (stripShows(id)) { setActive(id); return true; }
+  if (!activeId) { vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || vanishedName || wantActiveName || ""; }
+  return false;
+}
 function stripShows(id: string, only: string | null = onlyTag()): boolean {
   if (!tabInView(id)) return false;
   return !only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only);
@@ -16362,10 +16386,10 @@ function upsert(msg: any) {
   if (composerNoteSid === msg.id) setActive(msg.id);
   // T357: the session the user was on is back (its host re-attached, the relay redialed) → its focus is restored;
   // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
-  if (vanishedId === msg.id) setActive(msg.id);
+  if (vanishedId === msg.id) restoreIfShown(msg.id);   // …if the strip shows it: hidden by the view or the filter, the pane stays unfocused (applyTabOrder's rule)
   const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357)
   if (adopted) { activeId = msg.id; assertPeekFor(msg.id); loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again; the peek asserted like a pick's, so a view-hidden first arrival has a tab (the review's lows)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
-  if (wantActive && msg.id === wantActive) { wantActive = null; setActive(msg.id); }   // restore persisted tab on arrival
+  if (wantActive && msg.id === wantActive && stripLists(msg.id)) { wantActive = null; restoreIfShown(msg.id); }   // restore persisted tab on arrival, if the strip shows it (else unfocused as hidden, restored when shown)
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork
   // lands at the bottom/anchor (showActive). This is what keeps new pushes from snapping to bottom.
@@ -16991,6 +17015,12 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
   const oi = order.indexOf(id); if (oi >= 0) order.splice(oi, 1);
   const mi = mru.indexOf(id); if (mi >= 0) mru.splice(mi, 1);   // before the fallback read below — never the dead id
   renderTabs();                          // tab removed from `order` above → repaint without it
+  if (!wasActive && vanishedId === id) {
+    // the tab the UNFOCUSED pane names is torn down while not active: the body's line follows the reason (the review's
+    // low: it kept the view's name-free line after the tab was gone; the vanished write below is the active tab's alone)
+    vanishedWhy = why; vanishedName = name;
+    repaintEmptyStateIfUnfocused();
+  }
   if (wasActive) {
     // Where the box goes (pane-focus.ts focusAfterDismiss; T357, the user 2026-09-11): only the user's OWN ✕ hands it
     // to the recency fallback — MRU, then the first tab still on the strip (the dead id left `mru` above; an id `order`

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -181,8 +181,9 @@ test("closeTabLocally drops the tab, THEN records the close — in that order", 
 
 test("the strip skips a just-closed tab on BOTH passes (order AND the tabMeta placeholder pass)", () => {
   // the tabMeta pass is the one that drew the swirl: an id the kernel still lists with no session behind it
-  assert.match(RENDER, /for \(const id of order\) \{ if \(!seen\.has\(id\) && !closingTabs\.has\(id\)\)/);
-  assert.match(RENDER, /for \(const id of tabMeta\.keys\(\)\) \{ if \(!seen\.has\(id\) && !closingTabs\.has\(id\)\)/);
+  assert.match(RENDER, /for \(const id of order\) \{ if \(!seen\.has\(id\) && stripLists\(id\)\)/);
+  assert.match(RENDER, /for \(const id of tabMeta\.keys\(\)\) \{ if \(!seen\.has\(id\) && stripLists\(id\)\)/);
+  assert.match(RENDER, /function stripLists\(id: string\): boolean \{\s*\n\s*return !closingTabs\.has\(id\) && \(order\.includes\(id\) \|\| tabMeta\.has\(id\)\);/, "the closing set is read through the strip's one membership rule (T357 fix)");
 });
 
 test("every close path is optimistic — the in-page ✕, a dead read-only tab, and the kernel's confirmClose", () => {

--- a/ui/webview/tab-strip-skip-exec.test.ts
+++ b/ui/webview/tab-strip-skip-exec.test.ts
@@ -105,6 +105,7 @@ function lift(): (hooks: Hooks) => Api {
     const tabInView = (id) => id === peekId || !H.hidden.has(id);
     // the one visibility predicate renderTabs builds visibleIds from (T357 later lows): the view, then the #only= filter
     const stripShows = (id, only) => tabInView(id) && (!only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only));
+    const stripLists = (id) => !closingTabs.has(id) && (order.includes(id) || tabMeta.has(id));   // the strip's one membership rule (T357 fix)
     const setActive = (id) => { H.activated.push(id); }; const setTimeout = (f) => { H.timers.push(f); return 0; };   // the deferred checks, held for the test to fire
     const unfocusHiddenByView = () => {};
     // the section-at-a-glance view's readers on the strip, inert: the plan the view reads (lastStripItems), the
@@ -433,4 +434,16 @@ test("executed: the hidden tab's restore fires only for a tab still on the strip
   assert.equal(w2.H.timers.length, 1);
   w2.H.timers[0]();
   assert.deepEqual(w2.H.activated, ["a"], "the tab still on the strip takes focus back");
+});
+
+test("executed: the restore's fire-time membership is the paint's own rule: a tab listed only as a placeholder paints, so it restores (T357 fix)", () => {
+  // the schedule reads visibleIds (order AND the tabMeta placeholders); the fire-time check read `order` alone, so a
+  // tab present only as a placeholder painted while its restore declined (the review's low). One rule at both ends.
+  const { H, api, tabMeta } = world();
+  tabMeta.set("a", { name: "web", color: { bg: "#112233", fg: "#ffffff" } });
+  api.set({ order: ["b", "p"], activeId: null, vanishedId: "a", vanishedWhy: "hidden" });
+  api.renderTabs();
+  assert.equal(H.timers.length, 1, "the placeholder-only tab is visible, so the restore is scheduled");
+  H.timers[0]();
+  assert.deepEqual(H.activated, ["a"], "…and fires: it paints, so it restores");
 });


### PR DESCRIPTION
The unfocused pane's restores read one rule (T357, the review of the later lows). Four items the verifier of the later lows found, the first pre-existing on main.

## The live leak under the filter

applyTabOrder's restore (`const back = vanishedId || wantActive; if (back && order.includes(back)) setActive(back)`) had no visibility predicate, so on EVERY routine tabOrder push a filtered-out focused session was re-focused for one animation frame and its cached transcript showed before renderTabs's deferred unfocus put the body back (the verifier measured 1 frame of 70 with four transcript rows visible per push). Every restore now reads `restoreIfShown`: a tab the strip LISTS and SHOWS takes focus back; a listed tab the view or the `#only=` filter hides leaves the pane unfocused as hidden, for renderTabs's schedule to restore when the filter shows it again. The same rule guards the session frame's arrival (the vanished tab's return, the persisted tab's arrival). The lab installs a requestAnimationFrame recorder across a routine push under the filter and asserts no frame with a focused tab, a visible transcript row or the body down.

## One membership rule at both ends

The schedule read visibleIds (order and the tabMeta placeholders) while the fire-time check read `order`, so a placeholder-only tab painted while its restore declined. `stripLists` (order or a placeholder, less a closing tab) is the paint's rule and every restore's; the executed strip harness drives the placeholder-only case.

## A named, removable hash listener

The listener on the shell's window was anonymous and never removed: a closed split chat column (the shell removes the iframe) left a dead listener holding the detached pane alive and re-running its renderTabs on later hash edits. The handler is named and comes off on `pagehide`; a unit test executes the three statements against fake windows.

## The teardown of a vanished tab writes its reason

A hidden tab torn down while the pane was unfocused kept the view's name-free line: the vanished write was the active tab's alone. The teardown of the tab the pane names writes the reason and repaints; the lab tears the hidden tab down and reads the line naming it with its host's disconnection.
