### PR TITLE
Four lows from the lazy-walkers arm: the planner decides before it hydrates, perf stacks keyed by thread ident, an unstat-able captions file is loud and counted, the rule pin covers the marker's writers

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1405,6 +1405,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `corrupt`), `dirty` (files whose folds moved since their last write),
   `readBytes` and `readByPath` (what the JSONL reader pulled off disk since
   boot, in total and per file).
+- `stacks`: every thread's last six frames, keyed by the thread's ident and
+  name, when the kernel runs with `ROMP_PERF_STACKS` set (a debugging aid for a
+  served test on a runner nobody can log into); `null` otherwise.
 - `asmCheckpoint`: the assembly documents since boot: `written`, `restored`,
   `fallbacks` per reason (`version`, `session`, `inputs`, `lineage`, `shrunk`,
   `rewrite`, `guard`, `identity`, `corrupt`, `restore`), `skipped` per reason

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4329,8 +4329,9 @@ class _LazyView(LazyAtoms):
     and a client's ready frame both building the same chat) every locked access convoyed on the index lock at about one
     atom per scheduler switch, and a restored session's first frame took 20 s on a four-core runner (T358 CI, 2026-09-12).
     A view is per build and short-lived, so what it holds is bounded by the build; an eviction in the parent is not seen by
-    a slot the view already read, so while a build (or a planner pass whose returned tasks hold its views) is alive its
-    read set pins atoms past the index cap by that one build's worth, as the plain-list slices did. json's encoder is refused while the parent's slots are unbuilt; slicing a view is a
+    a slot the view already read, so while a build (or a planner pass whose returned tasks hold its views) is alive
+    its read set pins atoms past the index cap by that one build's worth, as the plain-list slices did. json's encoder
+    is refused while the parent's slots are unbuilt; slicing a view is a
     view of the parent."""
     def __init__(self, parent, start, stop):
         list.__init__(self, [_UNMAT] * (stop - start))

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4329,7 +4329,8 @@ class _LazyView(LazyAtoms):
     and a client's ready frame both building the same chat) every locked access convoyed on the index lock at about one
     atom per scheduler switch, and a restored session's first frame took 20 s on a four-core runner (T358 CI, 2026-09-12).
     A view is per build and short-lived, so what it holds is bounded by the build; an eviction in the parent is not seen by
-    a slot the view already read. json's encoder is refused while the parent's slots are unbuilt; slicing a view is a
+    a slot the view already read, so while a build (or a planner pass whose returned tasks hold its views) is alive its
+    read set pins atoms past the index cap by that one build's worth, as the plain-list slices did. json's encoder is refused while the parent's slots are unbuilt; slicing a view is a
     view of the parent."""
     def __init__(self, parent, start, stop):
         list.__init__(self, [_UNMAT] * (stop - start))

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2688,11 +2688,13 @@ def _ready_tasks(session, store=None, done=()):
             want_w = seg["id"] not in done or (single and not turn_open and turn["id"] not in done)
             if not want_p and not want_w:
                 continue                               # captioned at every grain: no atom of it is built or read
+            want_p = want_p and seg.get("hp") is not False   # a restored segment stores whether its message is human-authored (hp)
+            want_w = want_w and (turn_open and si == len(segs) - 1 or _seg_work(seg))   # ...and whether it has work (w)
+            if not want_p and not want_w:
+                continue                               # nothing to caption here: no atom built, no body read (arm low 1)
             em.hydrate(seg["atoms"])                   # ONE read per planned segment: the prompt and unit texts below then hit the
-            if want_p and seg.get("hp") is not False:      # memo, so the judge thread takes the leaf's read lock once per segment, not
-                                                       # once per prompt and once per unit (the base's granularity; T358 CI red)
-                                                       # a restored segment stores whether its message is human-authored (hp)
-                trig = em.seg_prompt_atom(seg)
+            if want_p:                                 # memo, so the judge thread takes the leaf's read lock once per segment, not
+                trig = em.seg_prompt_atom(seg)         # once per prompt and once per unit (the base's granularity; T358 CI red)
                 if trig and trig.get("author") == "human":   # MESSAGE caption — ready now, even mid-work
                     tasks.append({"kind": "prompt", "atoms": [trig],
                                   "writes": [{"id": seg["id"] + "#p", "grain": "prompt", "t": seg["t"]}]})
@@ -3495,8 +3497,11 @@ def tasks_for(fsid, leaf, files, now, done=None):
     key = list(pair)                                   # as JSON reads it back: [[[mtime, size], ...], cut]
     cap_key = _file_key(str(CAPDIR / (fsid + ".jsonl")))   # the captions file's stat beside it (T358): the memo holds the UNDONE
     if cap_key is not None and not isinstance(cap_key, tuple):   #  units' tasks only, so a caption filed since must miss it (a strike
-        return []                                      #  files none). The sentinel (a file that exists but will not stat): this
-    cap_key = list(cap_key) if cap_key else None      #  session plans nothing this pass; the others' captions proceed
+        _CAPTIONS_STATS["unstatable"] += 1             #  files none). The sentinel (a file that exists but will not stat): this
+        _say_once_judge("captions: %s's captions file exists but cannot be stat'ed: no caption is planned for it until it can "
+                        "(/perf memos.captions.unstatable counts the passes)" % fsid)   # session plans nothing this pass; the others'
+        return []                                      #  captions proceed (arm low 3: loud, and counted, never silent)
+    cap_key = list(cap_key) if cap_key else None
     cf = PCACHE / (fsid + ".json")
     try:
         o = json.loads(cf.read_text())
@@ -3549,7 +3554,22 @@ def tasks_for(fsid, leaf, files, now, done=None):
 # memo serves READERS only (load_goal_archive_shared): every archiver keeps load_goal_archive, a fresh
 # private object it mutates and saves.
 _CAPTIONS_MEMO = {}        # fsid -> (file key taken before the read, the parsed rows)
-_CAPTIONS_STATS = {"served": 0, "parsed": 0}
+_SAID_ONCE = set()
+
+
+def _say_once_judge(line):
+    """One stderr line per distinct text for the process (a condition that recurs every pass is said the first time)."""
+    if line in _SAID_ONCE:
+        return
+    _SAID_ONCE.add(line)
+    try:
+        sys.stderr.write(line + "\n")
+    except Exception:
+        pass
+
+
+_CAPTIONS_STATS = {"served": 0, "parsed": 0, "unstatable": 0}   # unstatable: passes that planned nothing for a session whose
+#                                                                  captions file exists but will not stat (T358 arm low 3)
 _GOALARCH_MEMO = {}        # fsid -> (file key taken before the read, the guarded archive store: read-only)
 _GOALARCH_STATS = {"served": 0, "loaded": 0}
 _FILE_MEMO_MAX = 256

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2704,8 +2704,8 @@ def _ready_tasks(session, store=None, done=()):
                                   "atoms": seg["atoms"],
                                   "writes": [{"id": seg["id"], "grain": "segment", "t": seg["t"]}]})
                 continue                               # no turn-grain while open; the final caption supersedes on close
-            if not want_w or not _seg_work(seg):       # a work-less segment (bare prompt / aborted) → no WORK caption
-                continue                               # (its #p message caption still glosses the ask)
+            if not want_w:                             # a work-less segment (bare prompt / aborted) → no WORK caption
+                continue                               # (its #p message caption still glosses the ask; want_w carried _seg_work)
             writes = [{"id": seg["id"], "grain": "segment", "t": seg["t"]}]
             if single and not turn_open:               # the turn IS this segment → mirror, no 2nd call
                 writes.append({"id": turn["id"], "grain": "turn", "t": turn["t"]})

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -558,8 +558,9 @@ class _PerfStats:
         if os.environ.get("ROMP_PERF_STACKS"):     # a debugging aid (T358): every thread's last frames, named, for a served test that
             import traceback                        #  has to say where a kernel sits while a client waits on a runner nobody can log into
             names = {t.ident: t.name for t in threading.enumerate()}
-            stacks = {names.get(tid, str(tid)): [l.strip() for l in traceback.format_stack(f)[-6:]]
-                      for tid, f in sys._current_frames().items()}
+            stacks = {"%s %s" % (tid, names.get(tid, "?")): [l.strip() for l in traceback.format_stack(f)[-6:]]
+                      for tid, f in sys._current_frames().items()}   # keyed by ident WITH the name: two workers sharing a name
+            #                                                          stay two entries, the duplicate-worker case the aid is for
         return {"now": now, "since": since, "uptime_s": now - _STARTED, "log": _PERF, "stacks": stacks,
                 "process": _process_stats(), "pusher": pusher, "stages_ms": stages,
                 "builds": builds, "sends": sends, "goals": goals, "memos": memos, "judge": judge, "skillLoadIndex": skill_idx, "http": http,

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -456,6 +456,16 @@ class ScalarWalkers(Restored):
         with em._MAT_LOCK:
             em._ASM_INDEX_STATS.update(materialized=0, materializedBy={})
         self.assertEqual(jd._ready_tasks(tree, None, ids), [])
+        work_ids = {w["id"] for t in all_tasks if t["kind"] == "work" for w in t["writes"]}   # every work caption filed, no
+        real = em.segments                                                                   #  prompt caption: with hp False
+        em.segments = lambda turn: [dict(sg, hp=False) if turn.get("pre") else sg for sg in real(turn)]   # nothing is planned...
+        try:
+            h1 = em.asm_checkpoint_stats()["hydratedAtoms"]
+            self.assertEqual(jd._ready_tasks(tree, None, work_ids), [])
+        finally:
+            em.segments = real
+        self.assertEqual((em.asm_index_stats()["materialized"], em.asm_checkpoint_stats()["hydratedAtoms"]), (0, h1),
+                         "...and the segment is neither built nor body-read (arm low 1)")
         self.assertEqual(em.asm_index_stats()["materialized"], 0,
                          "a segment with no human message (no #p caption ever) is not re-checked by building its trigger: %s"
                          % em.asm_index_stats()["materializedBy"])
@@ -492,8 +502,8 @@ class ScalarWalkers(Restored):
         import hashlib, inspect
         rule = "\n".join(inspect.getsource(f).strip() for f in (em.atom_has_work, em._has_text, em.atom_tool_uses, em.seg_prompt_atom,
                                                                 em._prose_chars, em.atom_prose_chars, em.postal_mids, em._encoded_mids,
-                                                                em.is_interrupt_record))
-        self.assertEqual((em._ASM_CKPT_V, hashlib.sha1(rule.encode()).hexdigest()[:10]), (5, "c56a1970a8"),
+                                                                em.is_interrupt_record, em._content, em._text_of, em._lazy_of, em.atom_mids))
+        self.assertEqual((em._ASM_CKPT_V, hashlib.sha1(rule.encode()).hexdigest()[:10]), (5, "42d84c7ab4"),
                          "the stored verdicts' rules changed: bump em._ASM_CKPT_V and re-pin the digest here")
 
     def test_the_stored_rules_on_odd_content_shapes(self):

--- a/tests/test_asm_index.py
+++ b/tests/test_asm_index.py
@@ -457,15 +457,19 @@ class ScalarWalkers(Restored):
             em._ASM_INDEX_STATS.update(materialized=0, materializedBy={})
         self.assertEqual(jd._ready_tasks(tree, None, ids), [])
         work_ids = {w["id"] for t in all_tasks if t["kind"] == "work" for w in t["writes"]}   # every work caption filed, no
-        real = em.segments                                                                   #  prompt caption: with hp False
-        em.segments = lambda turn: [dict(sg, hp=False) if turn.get("pre") else sg for sg in real(turn)]   # nothing is planned...
+        path2, whole2, tree2 = self.restored_tree("compaction_broken_stitch")                #  prompt caption: with hp False
+        with em._MAT_LOCK:                                                                   #  nothing is planned. A FRESH
+            em._ASM_INDEX_STATS.update(materialized=0, materializedBy={})                    #  restored tree: the one above is
+        work_ids2 = {w["id"] for t in jd._ready_tasks(whole2) if t["kind"] == "work" for w in t["writes"]}   # built and hydrated
+        real_segments, real_hydrate, calls = em.segments, em.hydrate, []                     #  whole by now, so its counters
+        em.segments = lambda turn: [dict(sg, hp=False) for sg in real_segments(turn)]      # cannot move; every segment's prompt
+        em.hydrate = lambda atoms, *a, **k: calls.append(len(atoms)) or real_hydrate(atoms, *a, **k)
         try:
-            h1 = em.asm_checkpoint_stats()["hydratedAtoms"]
-            self.assertEqual(jd._ready_tasks(tree, None, work_ids), [])
+            self.assertEqual(jd._ready_tasks(tree2, None, work_ids2), [])
         finally:
-            em.segments = real
-        self.assertEqual((em.asm_index_stats()["materialized"], em.asm_checkpoint_stats()["hydratedAtoms"]), (0, h1),
-                         "...and the segment is neither built nor body-read (arm low 1)")
+            em.segments, em.hydrate = real_segments, real_hydrate
+        self.assertEqual((em.asm_index_stats()["materialized"], calls), (0, []),
+                         "...and no segment is built or handed to hydrate (arm low 1): %s" % em.asm_index_stats()["materializedBy"])
         self.assertEqual(em.asm_index_stats()["materialized"], 0,
                          "a segment with no human message (no #p caption ever) is not re-checked by building its trigger: %s"
                          % em.asm_index_stats()["materializedBy"])
@@ -502,8 +506,9 @@ class ScalarWalkers(Restored):
         import hashlib, inspect
         rule = "\n".join(inspect.getsource(f).strip() for f in (em.atom_has_work, em._has_text, em.atom_tool_uses, em.seg_prompt_atom,
                                                                 em._prose_chars, em.atom_prose_chars, em.postal_mids, em._encoded_mids,
-                                                                em.is_interrupt_record, em._content, em._text_of, em._lazy_of, em.atom_mids))
-        self.assertEqual((em._ASM_CKPT_V, hashlib.sha1(rule.encode()).hexdigest()[:10]), (5, "42d84c7ab4"),
+                                                                em.is_interrupt_record, em._content, em._text_of, em._lazy_of, em.atom_mids,
+                                                                em._machine_written)) + "\n" + em.POSTAL_RE.pattern
+        self.assertEqual((em._ASM_CKPT_V, hashlib.sha1(rule.encode()).hexdigest()[:10]), (5, "56888f276a"),
                          "the stored verdicts' rules changed: bump em._ASM_CKPT_V and re-pin the digest here")
 
     def test_the_stored_rules_on_odd_content_shapes(self):

--- a/tests/test_file_read_memos.py
+++ b/tests/test_file_read_memos.py
@@ -107,7 +107,7 @@ class CaptionsMemo(_Memo):
         self.assertEqual(got[1], {SID + ":s2": 8})
         self.assertEqual(got[2], ["An earlier turn.", "The banner reconnects."], "oldest first")
         self.assertEqual(reads, [SID + ".jsonl"], "one read of the file for three readers")
-        self.assertEqual(jd._CAPTIONS_STATS, {"served": 2, "parsed": 1})
+        self.assertEqual(jd._CAPTIONS_STATS, {"served": 2, "parsed": 1, "unstatable": 0})
 
     def test_an_append_re_derives_even_when_the_file_clock_does_not_move(self):
         self.append(*self.ROWS[:2])
@@ -144,11 +144,11 @@ class CaptionsMemo(_Memo):
         self.assertEqual(first, {SID + ":s1"}, "what the read saw")
         self.assertTrue(landed)
         self.assertEqual(jd.captioned_ids(SID), {SID + ":s1", SID + ":t1"}, "the write moved the stat the second call took")
-        self.assertEqual(jd._CAPTIONS_STATS, {"served": 0, "parsed": 2})
+        self.assertEqual(jd._CAPTIONS_STATS, {"served": 0, "parsed": 2, "unstatable": 0})
 
     def test_an_absent_file_is_empty_and_never_cached(self):
         self.assertEqual((jd.captioned_ids(SID), jd._live_natoms(SID), jd.session_turn_captions(SID)), (set(), {}, []))
-        self.assertEqual(jd._CAPTIONS_STATS, {"served": 0, "parsed": 0})
+        self.assertEqual(jd._CAPTIONS_STATS, {"served": 0, "parsed": 0, "unstatable": 0})
         self.assertNotIn(SID, jd._CAPTIONS_MEMO)
         self.append(*self.ROWS[:1])
         self.assertEqual(jd.captioned_ids(SID), {SID + ":s1"}, "the first row is seen at once")

--- a/tests/test_judge_pass_frame.py
+++ b/tests/test_judge_pass_frame.py
@@ -515,10 +515,17 @@ class PlannerSkipsCaptioned(PassFrame):
         cap = jd.CAPDIR / (SID + ".jsonl")
         real = jd._file_key
         jd._file_key = lambda p: object() if p == str(cap) else real(p)
+        n0 = jd._CAPTIONS_STATS["unstatable"]; jd._SAID_ONCE.clear()
+        import contextlib, io
+        err = io.StringIO()
         try:
-            self.assertEqual(jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100), [])
+            with contextlib.redirect_stderr(err):
+                self.assertEqual(jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100), [])
+                self.assertEqual(jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100), [])
         finally:
             jd._file_key = real
+        self.assertEqual(jd._CAPTIONS_STATS["unstatable"], n0 + 2, "counted per pass")
+        self.assertEqual(err.getvalue().count("cannot be stat'ed"), 1, "said once, loudly")
         self.assertFalse((jd.PCACHE / (SID + ".json")).exists(), "no memo for a pass that planned nothing")
         self.assertTrue(self._ended_work_tasks(jd.tasks_for(SID, str(self.path), [str(self.path)], T0 + 100)), "the next pass plans")
 

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -155,7 +155,7 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["memos"]["chatLedger"]), {"hit", "miss", "bypass_live", "bypass_hold", "bypass_empty", "evict", "entries"})
         self.assertEqual(set(snap["memos"]["chatFoldTasks"]), {"hit", "miss", "entries"})
         self.assertEqual(set(snap["memos"]["plannerSkip"]), {"skipped", "planned", "recorded"})
-        self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed"})
+        self.assertEqual(set(snap["memos"]["captions"]), {"served", "parsed", "unstatable"})
         self.assertEqual(set(snap["memos"]["goalArchive"]), {"served", "loaded"})
         self.assertEqual(set(snap["memos"]["backref"]), {"served", "built"},
                          "the sender-board walk behind the courier link repair: built once per input state (2026-09-09)")
@@ -979,6 +979,33 @@ class PerfRoutes(unittest.TestCase):
         self.assertEqual(after["count"], before["count"] + 1, "and not a second time in the finally")
         self.assertEqual(after["ms"], before["ms"], "a socket's lifetime is not a request time")
 
+
+
+class StacksField(unittest.TestCase):
+    """The perf route's `stacks` (T358, a debugging aid behind ROMP_PERF_STACKS): every thread's last frames, keyed by the
+    thread's ident WITH its name, so two workers sharing a name stay two entries (the duplicate-worker case the aid is for);
+    None without the switch."""
+    def test_two_threads_sharing_a_name_are_two_entries(self):
+        import threading
+        from unittest import mock
+        gate = threading.Event()
+        ths = [threading.Thread(target=gate.wait, name="same-name-worker", daemon=True) for _ in range(2)]
+        for t in ths:
+            t.start()
+        try:
+            with mock.patch.dict(os.environ, {"ROMP_PERF_STACKS": "1"}):
+                snap = km._PerfStats().snapshot()
+            keys = [k for k in (snap.get("stacks") or {}) if k.endswith(" same-name-worker")]
+            self.assertEqual(len(keys), 2, "one entry per thread, the name carried: %s" % sorted(snap.get("stacks") or {}))
+            self.assertEqual(len(set(keys)), 2, "keyed by ident: distinct")
+            self.assertTrue(all(str(t.ident) in k for t, k in zip(sorted(ths, key=lambda t: t.ident), sorted(keys, key=lambda k: int(k.split()[0])))))
+        finally:
+            gate.set()
+            for t in ths:
+                t.join(timeout=5)
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ROMP_PERF_STACKS", None)
+            self.assertIsNone(km._PerfStats().snapshot()["stacks"], "None without the switch")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tier: fix

The follow-up the arm of #1475 queued, none blocking there:

- **The planner decides before it hydrates.** The per-segment hydrate sat above the prompt and work decisions, so a segment with no human prompt whose work was already captioned was built and body-read on every pass for nothing. Test: with every work caption filed and the prompt verdict false, a pass over a restored store builds nothing and reads no body.
- **`/perf` `stacks` keyed by thread ident, carrying the name.** Keyed by name, two workers sharing a name collapsed into one entry, the duplicate-worker case the aid exists for. Test: two threads named alike are two entries.
- **An unstat-able captions file is loud and counted.** It made that session plan nothing silently; now one stderr line per process and `memos.captions.unstatable` per pass (the loud-when-unavailable rule). Test: two passes count two, the line appears once.
- **The stored-verdict rule pin** covers `_content`, `_text_of`, `_lazy_of` and `atom_mids`, which define or write what a stored `nt`, `h`, `pc` and `mid` mean; the view's class comment states the resident bound while a build or a planner pass is alive. Docs: the `stacks` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
