### PR TITLE
Every frame-reachable focus write reads the restore rule; the lab pins the filter leak by a DOM transient with the view cached (T357 follow-up)

### DIFF
--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -187,26 +187,47 @@ out.onlyFiltered = await page.evaluate(() => {
            visibleTurns: turns.length, composerDisabled: document.getElementById("composer-input").disabled };
 });
 // a ROUTINE push under the filter (the review's leak, pre-existing on main): applyTabOrder's restore re-focused the
-// filtered-out session for one animation frame per push, its cached transcript on screen, before renderTabs's deferred
-// unfocus put the body back. A frame recorder samples every animation frame across a tabOrder push listing web.
+// filtered-out session for one task per push, its CACHED transcript on screen, before renderTabs's deferred unfocus put
+// the body back. The leak needs web's view cached, so web is focused live first (the filter lifted live restores it), the
+// filter is set live again (unfocused, view cached), and a MutationObserver samples every DOM change across a routine
+// tabOrder push listing web: the most transcript rows visible at once, and how often the body was down. A frame
+// recorder saw nothing here (headless Chromium reverts the leak in the same task, before any paint); the observer sees
+// the transient: 4 rows / 1 body-down per push on the merge-base, 0 / 0 on the fix.
+await page.evaluate(() => { location.hash = ""; });
+await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid && document.querySelectorAll("#content .turn").length > 0; }, cfg.sidA, { timeout: 10000 });
+await page.evaluate(() => { location.hash = "#only=api"; });
+await page.waitForFunction((sid) => !document.querySelector("#tabs .tab.active[data-id]") && !Array.from(document.querySelectorAll("#tabs .tab[data-id]")).some((t) => t.dataset.id === sid), cfg.sidA, { timeout: 10000 });
+await page.waitForTimeout(300);
 await page.evaluate(() => {
-  window.__rec = [];
+  const visibleRows = () => Array.from(document.querySelectorAll("#content .turn")).filter((t) => { const r = t.getBoundingClientRect(); return r.width > 0 && r.height > 0 && getComputedStyle(t).display !== "none"; }).length;
   const empty = document.getElementById("empty-state");
-  const tick = () => {
-    const turns = Array.from(document.querySelectorAll("#content .turn")).filter((t) => { const r = t.getBoundingClientRect(); return r.width > 0 && r.height > 0 && getComputedStyle(t).display !== "none"; }).length;
-    window.__rec.push({ turns, active: !!document.querySelector("#tabs .tab.active[data-id]"), emptyShown: !!empty && getComputedStyle(empty).display !== "none" });
-    if (window.__rec.length < 90) requestAnimationFrame(tick);
+  window.__mo = { samples: 0, maxRows: 0, bodyDown: 0, focused: 0 };
+  const sample = () => {
+    window.__mo.samples++;
+    window.__mo.maxRows = Math.max(window.__mo.maxRows, visibleRows());
+    if (!empty || getComputedStyle(empty).display === "none") window.__mo.bodyDown++;
+    if (document.querySelector("#tabs .tab.active[data-id]")) window.__mo.focused++;
   };
-  requestAnimationFrame(tick);
+  const obs = new MutationObserver(sample);
+  obs.observe(document.body, { subtree: true, childList: true, attributes: true, attributeFilter: ["class", "style", "hidden"] });
+  window.__moStop = () => obs.disconnect();
 });
 await inject({ type: "tabOrder", order: [cfg.sidA, cfg.sidB], tabs: [A_TAB, B_TAB], live: [cfg.sidA, cfg.sidB], skeleton: [] });
-await page.waitForFunction(() => window.__rec && window.__rec.length >= 90, null, { timeout: 15000 });
-out.pushUnderFilter = await page.evaluate(() => ({ frames: window.__rec.length, leaked: window.__rec.filter((f) => f.turns > 0 || f.active).length, bodyDown: window.__rec.filter((f) => !f.emptyShown).length }));
+await page.waitForTimeout(600);
+out.pushUnderFilter = await page.evaluate(() => { window.__moStop(); return window.__mo; });
 // the hidden tab torn down while the pane is unfocused (the review's low): the body's line follows the reason
 await inject({ type: "closed", id: cfg.sidA, hostDrop: true });
 await inject({ type: "tabOrder", order: [cfg.sidB], tabs: [B_TAB], live: [cfg.sidB], skeleton: [] });
 await page.waitForFunction((sid) => { const e = document.getElementById("empty-state"); return !!e && (e.textContent || "").includes("host disconnected") && !document.querySelector('#tabs .tab[data-id="' + sid + '"]'); }, cfg.sidA, { timeout: 10000 });
 out.tornDownWhileHidden = await state();
+// a FIRST arrival the filter hides is not adopted (the review's low: the adopt wrote activeId past the rule's visibility
+// half): nothing persisted, the page served at #only=api, the sessions arrive: the pane adopts the first VISIBLE one
+await page.evaluate(() => { for (const k of Object.keys(localStorage)) if (k.startsWith("romp-vscode-state-")) localStorage.removeItem(k); });
+await page.goto(cfg.chat + "#only=api");
+await page.reload();
+await page.waitForFunction(() => document.querySelectorAll("#tabs .tab[data-id]").length >= 1, null, { timeout: 20000 });
+await page.waitForTimeout(800);
+out.firstArrivalUnderFilter = await state();
 // the SHELL road (the review's medium): on the dashboard the chat pane is a same-origin iframe of the shell and the
 // filter lives on the SHELL's URL (only-filter.ts reads window.top), so a live edit of the shell's hash must reach the
 // framed pane, whose own hash never changes: the pane unfocuses at once and restores when the filter shows the tab again
@@ -376,7 +397,11 @@ class ServedUnfocusedPane(unittest.TestCase):
         # a routine push under the filter never re-focuses the hidden tab, not for one animation frame (the review's leak:
         # 1 frame of 70 with the body down and four transcript rows visible per push)
         pu = r["pushUnderFilter"]
-        self.assertGreaterEqual(pu["frames"], 90); self.assertEqual((pu["leaked"], pu["bodyDown"]), (0, 0), "no frame with a focused tab, a visible transcript row, or the body down: %r" % pu)
+        self.assertGreater(pu["samples"], 0, "the push mutated the strip, so the observer sampled: %r" % pu)
+        self.assertEqual((pu["maxRows"], pu["bodyDown"], pu["focused"]), (0, 0, 0), "no transient with a transcript row visible, the body down or a tab focused (the merge-base: 4 rows and 1 body-down per push): %r" % pu)
+        fa = r["firstArrivalUnderFilter"]
+        self.assertNotIn(SID_A, fa["tabs"]); self.assertNotEqual(fa["active"], SID_A, "a first arrival the filter hides is never adopted: %r" % fa)
+        self.assertEqual(fa["active"], SID_B, "…the first VISIBLE arrival is: %r" % fa)
         # the hidden tab torn down while the pane is unfocused: the line follows the reason, naming the tab
         td = r["tornDownWhileHidden"]
         self.assertIsNone(td["active"]); self.assertEqual(td["empty"]["vanished"], SID_A); self.assertNotIn(SID_A, td["tabs"])

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -338,14 +338,14 @@ test("the note retires on the exact events: an explicit switch, the session's re
   // setActive: a real switch re-binds the box → the note is stale
   assert.match(RENDER, /function setActive\(id: string[\s\S]*?if \(ta && activeId !== id\) \{[\s\S]*?clearComposerNote\(\);/);
   // the session frame: the torn-down session is back while the note still holds → back on it (setActive retires the note)
-  assert.match(RENDER, /if \(composerNoteSid === msg\.id\) setActive\(msg\.id\);/);
+  assert.match(RENDER, /if \(composerNoteSid === msg\.id\) restoreIfShown\(msg\.id\);/, "the note's own tab comes back through the one restore rule (shown takes focus; hidden does not)");
   // its own ✕
   assert.match(RENDER, /function renderComposerNote\(sid: string, why: DismissWhy, name: string\): void \{[\s\S]*?x\.dataset\.act = "composerNoteX";/);   // the ✕ rides the body delegate since 2026-09-08 (click-safe, no per-node listener)
   assert.match(RENDER, /composerNoteX: \(\) => clearComposerNote\(\),/);
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
+  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone && stripShows\(msg\.id\);[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -62,7 +62,10 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = named \|\| "";/, "the body names the vanished or the awaited id");
   assert.doesNotMatch(RENDER, /empty\.textContent = "No session open/, "the one writer of the empty body is paintEmptyState");
   // the return: the session frame, or the strip re-listing it; no other arrival adopts the box meanwhile
-  assert.match(RENDER, /if \(vanishedId === msg\.id\) restoreIfShown\(msg\.id\);[^\n]*\n\s*const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;/);
+  assert.match(RENDER, /if \(vanishedId === msg\.id\) restoreIfShown\(msg\.id\);[^\n]*\n\s*const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone && stripShows\(msg\.id\);/, "an adoption reads the rule's visibility half: a first arrival the filter hides is not adopted (the review's low)");
+  assert.match(RENDER, /if \(composerNoteSid === msg\.id\) restoreIfShown\(msg\.id\);/, "the composer note's restore goes through the rule too");
+  assert.equal((RENDER.match(/\bsetActive\(msg\.id\)/g) || []).length, 0, "no frame-reachable direct setActive(msg.id) is left in the arrival path");
+  assert.ok(RENDER.indexOf("/** Does the strip show `id` right now:") > RENDER.indexOf("function restoreIfShown("), "stripShows's docstring sits above its own function, after restoreIfShown");
   assert.match(fn("applyTabOrder"), /for \(const id of kernelOrder\) kernelListed\.add\(id\);[\s\S]{0,500}?const back = vanishedId \|\| wantActive;[^\n]*\n\s*if \(back && restoreIfShown\(back\)\)/);
   // every restore reads ONE rule (the review's leak: applyTabOrder's had no visibility predicate, so a routine push
   // re-focused a filtered-out session for one frame): listed AND shown takes focus back; listed but hidden leaves the

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7205,7 +7205,8 @@ const onOnlyHashChange = (): void => renderTabs();
 const onlyHashWindow = onlyWindow();
 onlyHashWindow.addEventListener("hashchange", onOnlyHashChange);
 // a closed split column: the shell removes this pane's iframe, and a listener left on the shell's window would hold the
-// detached pane alive and re-run its renderTabs on every later hash edit (the review): pagehide takes it off again
+// detached pane's document alive for the shell's lifetime (retention is the whole cost: Chromium does not run a removed
+// frame's handler, the review's probe showed): pagehide takes it off again
 window.addEventListener("pagehide", () => onlyHashWindow.removeEventListener("hashchange", onOnlyHashChange));
 window.addEventListener("mousedown", (e) => { if (ctxMenuEl && !ctxMenuEl.contains(e.target as Node)) dismissTabMenu(); }, true);
 // an Escape that closed the menu says so on the event (preventDefault), so the section view's own Escape
@@ -11971,9 +11972,6 @@ function fillSnapshotRow(btn: HTMLElement, r: SnapRow, now: number): void {
 // no DOM left to capture from and the emptied box no longer overflows. undefined = capture here.
 // The empty body's line (pane-focus.ts emptyStateParts, T357): which session vanished and why, its name dressed the way
 // the strip dresses it (host prefix, identity colour), "reconnecting" when its host is dialing; or the plain invitation.
-/** Does the strip show `id` right now: in the tab view (a peek counts) AND matching the `#only=` filter — the one
- *  predicate renderTabs's visibleIds is built from, read again at fire time so a deferred check judges the strip as
- *  it is, not as it was scheduled. `only` may be passed by a caller that read the hash once for many ids. */
 /** The strip's MEMBERSHIP: the ids renderTabs paints a tab for (the kernel's order, plus a pushed tab not yet in it, a
  *  placeholder), less a tab the user just closed. One rule for the paint and for every restore's fire-time check (the
  *  review of T357's later lows: the schedule read visibleIds, built over order AND tabMeta, while the timer read order
@@ -11993,6 +11991,9 @@ function restoreIfShown(id: string): boolean {
   if (!activeId) { vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || vanishedName || wantActiveName || ""; }
   return false;
 }
+/** Does the strip show `id` right now: in the tab view (a peek counts) AND matching the `#only=` filter — the one
+ *  predicate renderTabs's visibleIds is built from, read again at fire time so a deferred check judges the strip as
+ *  it is, not as it was scheduled. `only` may be passed by a caller that read the hash once for many ids. */
 function stripShows(id: string, only: string | null = onlyTag()): boolean {
   if (!tabInView(id)) return false;
   return !only || matchesOnly(sessions.get(id)?.name ?? tabMeta.get(id)?.name ?? "", only);
@@ -16383,11 +16384,11 @@ function upsert(msg: any) {
   // where they were — its tab active, its kept draft in the box. Merely retiring the note here left the
   // fallback tab active with the box unheld, and the next blind keystroke landed there after all (the
   // T236 harness, omission path: the tab is re-listed within seconds). setActive clears the note.
-  if (composerNoteSid === msg.id) setActive(msg.id);
+  if (composerNoteSid === msg.id) restoreIfShown(msg.id);   // …through the one restore rule: a tab the view or the filter hides takes no focus (the review's low)
   // T357: the session the user was on is back (its host re-attached, the relay redialed) → its focus is restored;
   // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
   if (vanishedId === msg.id) restoreIfShown(msg.id);   // …if the strip shows it: hidden by the view or the filter, the pane stays unfocused (applyTabOrder's rule)
-  const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone;   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357)
+  const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone && stripShows(msg.id);   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357); and never a session the view or the #only= filter hides (the review's low: the adopt wrote activeId past the restore rule's visibility half; membership is the append above)
   if (adopted) { activeId = msg.id; assertPeekFor(msg.id); loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again; the peek asserted like a pick's, so a view-hidden first arrival has a tab (the review's lows)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
   if (wantActive && msg.id === wantActive && stripLists(msg.id)) { wantActive = null; restoreIfShown(msg.id); }   // restore persisted tab on arrival, if the strip shows it (else unfocused as hidden, restored when shown)
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order


### PR DESCRIPTION
Four later lows from the verifier of the T357 fix PR.

- **Every frame-reachable focus write reads the restore rule.** The composer note's own-tab restore goes through `restoreIfShown`; an adoption reads the rule's visibility half (`stripShows`, membership being the append above), so a first arrival the `#only=` filter hides is never adopted and the first visible one is. No direct `setActive(msg.id)` is left in the arrival path (pinned by count).
- **The lab pins the leak by a DOM transient with the view cached.** The frame recorder passed on the merge-base too (the leak reverts in the same task, before any paint, and web's view was never built after the reload). The road lifts the filter live so web is focused and its view cached, sets the filter live again, and a MutationObserver samples every DOM change across a routine push: most rows visible at once, body-down count, focused count (4 / 1 on the merge-base, 0 / 0 / 0 on the fix). A first-arrival road under the filter reads the first visible session adopted.
- `stripShows`'s docstring sits above its own function again.
- The listener comment says retention is the whole cost of a dead listener; Chromium does not run a removed frame's handler.
