### PR TITLE
Tests: one shared force-until-moved ctime helper for the thread mail-off test and the two memo tests (T356)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -81,8 +81,8 @@ os.environ["ROMP_SERVE_PORT"] = "1"
 # sys.path itself. One module object either way.
 from . import romp_load as _romp_load  # noqa: E402
 sys.modules.setdefault("romp_load", _romp_load)
-# fs_clock (2026-09-12): the shared force-until-moved ctime helper the memo tests and the thread mail-off test import, registered like romp_load
-# `from fs_clock import move_ctime` in a test module (tests/fs_clock.py): the shared force-until-moved ctime helper, registered like romp_load
+# `from fs_clock import move_ctime` in a test module (tests/fs_clock.py, 2026-09-12): the shared force-until-moved ctime
+# helper the memo tests and the thread mail-off test import, registered under its bare name like romp_load above
 from . import fs_clock as _fs_clock  # noqa: E402
 sys.modules.setdefault("fs_clock", _fs_clock)
 # `from git_fixture import git, init_repo` (tests/git_fixture.py, T299): the throwaway-repo fixtures' one git

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -81,6 +81,10 @@ os.environ["ROMP_SERVE_PORT"] = "1"
 # sys.path itself. One module object either way.
 from . import romp_load as _romp_load  # noqa: E402
 sys.modules.setdefault("romp_load", _romp_load)
+# fs_clock (2026-09-12): the shared force-until-moved ctime helper the memo tests and the thread mail-off test import, registered like romp_load
+# `from fs_clock import move_ctime` in a test module (tests/fs_clock.py): the shared force-until-moved ctime helper, registered like romp_load
+from . import fs_clock as _fs_clock  # noqa: E402
+sys.modules.setdefault("fs_clock", _fs_clock)
 # `from git_fixture import git, init_repo` (tests/git_fixture.py, T299): the throwaway-repo fixtures' one git
 # runner, registered the same way for the same reason.
 from . import git_fixture as _git_fixture  # noqa: E402

--- a/tests/fs_clock.py
+++ b/tests/fs_clock.py
@@ -1,0 +1,19 @@
+"""The filesystem clock, forced: a test that wants a file's ctime to move (a permissions repair the memos must see) cannot
+sleep and hope, since a coarse filesystem clock can hand two chmods one timestamp. Shared by the memo tests and the
+thread mail-off test (lifted from their identical copies, 2026-09-12)."""
+import os
+import time
+
+
+def move_ctime(path):
+    """Move a file's ctime and nothing else: flip its mode between 0o600 and 0o644, checking the stat after each
+    chmod, until the ctime differs. mtime, size and inode stand. Bounded at 5 s: a filesystem that never ticks ctime
+    under chmod fails the test loudly rather than passing it."""
+    before = cur = os.stat(path)
+    deadline = time.monotonic() + 5
+    while cur.st_ctime_ns == before.st_ctime_ns:
+        if time.monotonic() > deadline:
+            raise AssertionError("ctime did not move under chmod within 5 s")
+        os.chmod(path, 0o644 if (cur.st_mode & 0o777) == 0o600 else 0o600)
+        cur = os.stat(path)
+    return cur

--- a/tests/test_cleared_set_memo.py
+++ b/tests/test_cleared_set_memo.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 import unittest
 from romp_load import load_source
+from fs_clock import move_ctime as _move_ctime   # noqa: E402  the shared test helper, on the path the line above put there
 from pathlib import Path
 from unittest.mock import patch
 
@@ -34,21 +35,6 @@ jd = km.jd
 SID = "11111111-2222-3333-4444-888888888802"
 G1, G2, G3 = SID + ":g1", SID + ":g2", SID + ":g3"
 NOW = 1_800_000_000
-
-
-def _move_ctime(path):
-    """Move a file's ctime and nothing else: flip its mode between 0o600 and 0o644, checking the stat after
-    each chmod, until the ctime differs (a coarse filesystem clock can hand two chmods one timestamp). mtime,
-    size and inode stand. Bounded at 5 s: a filesystem that never ticks ctime under chmod fails the test
-    loudly rather than passing it."""
-    before = cur = os.stat(path)
-    deadline = time.monotonic() + 5
-    while cur.st_ctime_ns == before.st_ctime_ns:
-        if time.monotonic() > deadline:
-            raise AssertionError("ctime did not move under chmod within 5 s")
-        os.chmod(path, 0o644 if (cur.st_mode & 0o777) == 0o600 else 0o600)
-        cur = os.stat(path)
-    return cur
 
 
 class _Memo(unittest.TestCase):

--- a/tests/test_thread_mail_off.py
+++ b/tests/test_thread_mail_off.py
@@ -7,12 +7,12 @@ the one way on short of a break-out (never an old key re-read); promotion clears
 returns. Synthetic fixtures only: placeholder UUIDs, a hermetic state root."""
 import inspect
 import json
-import time
 import os
 import shutil
 import tempfile
 import unittest
 from romp_load import load_source
+from fs_clock import move_ctime   # noqa: E402  the shared test helper, on the path the line above put there
 from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -153,8 +153,7 @@ class UnreadableRecordOnTheKernelSide(unittest.TestCase):
         p = Path(self.td) / "sdk" / (PLAIN + ".json"); p.write_text(json.dumps({"sid": PLAIN}))
         before = km._chat_ident(p)
         self.assertEqual(len(before), 4); self.assertEqual(before[3], p.stat().st_ctime_ns, "ctime is the fourth component")
-        time.sleep(0.02)   # past the filesystem clock's granularity, so the repair's ctime differs
-        os.chmod(p, 0o600)
+        move_ctime(p)   # forced until the clock ticked (fs_clock: a coarse filesystem clock can hand two chmods one timestamp)
         after = km._chat_ident(p)
         self.assertEqual(after[:3], before[:3], "inode, mtime and size stand across a chmod"); self.assertNotEqual(after, before, "…and the identity moved on ctime alone")
         self.assertIsNone(km._chat_ident(Path(self.td) / "sdk" / "nonesuch.json"))

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -31,6 +31,7 @@ import unittest
 from contextlib import redirect_stderr
 from datetime import datetime, timezone
 from romp_load import load_source
+from fs_clock import move_ctime   # noqa: E402  the shared test helper, on the path the line above put there
 from pathlib import Path
 
 HERE = os.path.dirname(os.path.realpath(__file__))
@@ -56,21 +57,6 @@ def _rec(kind, t, uuid, parent, text):
                 "message": {"role": "user", "content": text}}
     return {"type": "assistant", "timestamp": _iso(t), "uuid": uuid, "parentUuid": parent,
             "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
-
-
-def move_ctime(path):
-    """Move a file's ctime and nothing else: flip its mode between 0o600 and 0o644, checking the stat after
-    each chmod, until the ctime differs (a coarse filesystem clock can hand two chmods one timestamp). mtime,
-    size and inode stand. Bounded at 5 s: a filesystem that never ticks ctime under chmod fails the test
-    loudly rather than passing it."""
-    before = cur = os.stat(path)
-    deadline = time.monotonic() + 5
-    while cur.st_ctime_ns == before.st_ctime_ns:
-        if time.monotonic() > deadline:
-            raise AssertionError("ctime did not move under chmod within 5 s")
-        os.chmod(path, 0o644 if (cur.st_mode & 0o777) == 0o600 else 0o600)
-        cur = os.stat(path)
-    return cur
 
 
 class DeadLaneMemo(unittest.TestCase):


### PR DESCRIPTION
Test-only. The thread mail-off test's chat-identity case slept 20 ms and hoped the filesystem clock had ticked before its chmod; the repo carried the bounded force-until-moved helper twice (the timeline lane memo test, the cleared-set memo test). It is lifted to `tests/fs_clock.py` (flip the mode until ctime differs, bounded at 5 s, loud on a filesystem that never ticks ctime under chmod) and the three tests import it.
