### PR TITLE
A declined adoption is recorded and yields to a visible first arrival; the first-arrival road hides the first-arriving session (T357 next pass)

### DIFF
--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -192,7 +192,7 @@ out.onlyFiltered = await page.evaluate(() => {
 // filter is set live again (unfocused, view cached), and a MutationObserver samples every DOM change across a routine
 // tabOrder push listing web: the most transcript rows visible at once, and how often the body was down. A frame
 // recorder saw nothing here (headless Chromium reverts the leak in the same task, before any paint); the observer sees
-// the transient: 4 rows / 1 body-down per push on the merge-base, 0 / 0 on the fix.
+// the transient: 4 rows / 1 body-down per push with applyTabOrder's visibility predicate reverted, 0 / 0 with it.
 await page.evaluate(() => { location.hash = ""; });
 await page.waitForFunction((sid) => { const a = document.querySelector("#tabs .tab.active[data-id]"); return !!a && a.dataset.id === sid && document.querySelectorAll("#content .turn").length > 0; }, cfg.sidA, { timeout: 10000 });
 await page.evaluate(() => { location.hash = "#only=api"; });
@@ -221,13 +221,27 @@ await inject({ type: "tabOrder", order: [cfg.sidB], tabs: [B_TAB], live: [cfg.si
 await page.waitForFunction((sid) => { const e = document.getElementById("empty-state"); return !!e && (e.textContent || "").includes("host disconnected") && !document.querySelector('#tabs .tab[data-id="' + sid + '"]'); }, cfg.sidA, { timeout: 10000 });
 out.tornDownWhileHidden = await state();
 // a FIRST arrival the filter hides is not adopted (the review's low: the adopt wrote activeId past the rule's visibility
-// half): nothing persisted, the page served at #only=api, the sessions arrive: the pane adopts the first VISIBLE one
-await page.evaluate(() => { for (const k of Object.keys(localStorage)) if (k.startsWith("romp-vscode-state-")) localStorage.removeItem(k); });
-await page.goto(cfg.chat + "#only=api");
+// half): nothing persisted, the page served under a filter that hides the FIRST-arriving session (api arrives before web in
+// this world) and shows a later one, the sessions arrive: the pane adopts the first VISIBLE one, never the hidden first
+const clearState = () => page.evaluate(() => { for (const k of Object.keys(localStorage)) if (k.startsWith("romp-vscode-state-")) localStorage.removeItem(k); });
+await clearState();
+await page.goto(cfg.chat + "#only=web");
 await page.reload();
 await page.waitForFunction(() => document.querySelectorAll("#tabs .tab[data-id]").length >= 1, null, { timeout: 20000 });
 await page.waitForTimeout(800);
 out.firstArrivalUnderFilter = await state();
+// a filter matching NO live session: every adoption is declined, and the declined first arrival is RECORDED (the review's
+// low: the body showed the generic line and lifting the filter restored nothing), so the body wears the view's line and
+// lifting the filter live restores that session through renderTabs's schedule
+await clearState();
+await page.goto(cfg.chat + "#only=nomatch-zz");
+await page.reload();
+await page.waitForFunction(() => document.getElementById("empty-state") && getComputedStyle(document.getElementById("empty-state")).display !== "none" && (document.getElementById("empty-state").dataset.vanished || "") !== "", null, { timeout: 20000 });
+await page.waitForTimeout(300);
+out.noMatchFilter = await state();
+await page.evaluate(() => { location.hash = ""; });
+await page.waitForFunction(() => !!document.querySelector("#tabs .tab.active[data-id]"), null, { timeout: 10000 });
+out.noMatchLifted = await state();
 // the SHELL road (the review's medium): on the dashboard the chat pane is a same-origin iframe of the shell and the
 // filter lives on the SHELL's URL (only-filter.ts reads window.top), so a live edit of the shell's hash must reach the
 // framed pane, whose own hash never changes: the pane unfocuses at once and restores when the filter shows the tab again
@@ -398,10 +412,16 @@ class ServedUnfocusedPane(unittest.TestCase):
         # 1 frame of 70 with the body down and four transcript rows visible per push)
         pu = r["pushUnderFilter"]
         self.assertGreater(pu["samples"], 0, "the push mutated the strip, so the observer sampled: %r" % pu)
-        self.assertEqual((pu["maxRows"], pu["bodyDown"], pu["focused"]), (0, 0, 0), "no transient with a transcript row visible, the body down or a tab focused (the merge-base: 4 rows and 1 body-down per push): %r" % pu)
+        self.assertEqual((pu["maxRows"], pu["bodyDown"], pu["focused"]), (0, 0, 0), "no transient with a transcript row visible, the body down or a tab focused (4 rows and 1 body-down per push with applyTabOrder's predicate reverted): %r" % pu)
         fa = r["firstArrivalUnderFilter"]
-        self.assertNotIn(SID_A, fa["tabs"]); self.assertNotEqual(fa["active"], SID_A, "a first arrival the filter hides is never adopted: %r" % fa)
-        self.assertEqual(fa["active"], SID_B, "…the first VISIBLE arrival is: %r" % fa)
+        self.assertNotIn(SID_B, fa["tabs"]); self.assertNotEqual(fa["active"], SID_B, "the first arrival (api), hidden by #only=web, is never adopted: %r" % fa)
+        self.assertEqual(fa["active"], SID_A, "…the first VISIBLE arrival (web) is, over the declined record: %r" % fa)
+        nm = r["noMatchFilter"]
+        self.assertIsNone(nm["active"]); self.assertEqual(nm["tabs"], [], "no tab shows under a filter matching nothing: %r" % nm)
+        self.assertIn(nm["empty"]["vanished"], (SID_A, SID_B), "the declined first arrival is recorded: %r" % nm)
+        self.assertEqual(nm["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.")
+        nl = r["noMatchLifted"]
+        self.assertEqual(nl["active"], nm["empty"]["vanished"], "lifting the filter restores the recorded session through the schedule: %r" % nl)
         # the hidden tab torn down while the pane is unfocused: the line follows the reason, naming the tab
         td = r["tornDownWhileHidden"]
         self.assertIsNone(td["active"]); self.assertEqual(td["empty"]["vanished"], SID_A); self.assertNotIn(SID_A, td["tabs"])

--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -230,6 +230,13 @@ await page.reload();
 await page.waitForFunction(() => document.querySelectorAll("#tabs .tab[data-id]").length >= 1, null, { timeout: 20000 });
 await page.waitForTimeout(800);
 out.firstArrivalUnderFilter = await state();
+// …and the adoption ended the unfocused state (the review's high): with the filter lifted live, one routine tabOrder push
+// must leave the pane on web; a declined record left standing would have handed api to applyTabOrder's restore
+await page.evaluate(() => { location.hash = ""; });
+await page.waitForTimeout(300);
+await inject({ type: "tabOrder", order: [cfg.sidA, cfg.sidB], tabs: [A_TAB, B_TAB], live: [cfg.sidA, cfg.sidB], skeleton: [] });
+await page.waitForTimeout(400);
+out.afterLiftAndPush = await state();
 // a filter matching NO live session: every adoption is declined, and the declined first arrival is RECORDED (the review's
 // low: the body showed the generic line and lifting the filter restored nothing), so the body wears the view's line and
 // lifting the filter live restores that session through renderTabs's schedule
@@ -242,6 +249,19 @@ out.noMatchFilter = await state();
 await page.evaluate(() => { location.hash = ""; });
 await page.waitForFunction(() => !!document.querySelector("#tabs .tab.active[data-id]"), null, { timeout: 10000 });
 out.noMatchLifted = await state();
+// a declined record's session torn down (its host dropped, the kernel stopped listing it): the record goes with it and the
+// frame stays NAME-FREE (the review's medium: the teardown's reason painted the session's name in bold in its colour on a
+// frame the filter is meant to keep clean)
+await clearState();
+await page.goto(cfg.chat + "#only=nomatch-zz");
+await page.reload();
+await page.waitForFunction(() => document.getElementById("empty-state") && (document.getElementById("empty-state").dataset.vanished || "") !== "", null, { timeout: 20000 });
+const recorded = await page.evaluate(() => document.getElementById("empty-state").dataset.vanished);
+const other = recorded === cfg.sidA ? cfg.sidB : cfg.sidA;
+await inject({ type: "closed", id: recorded, hostDrop: true });
+await inject({ type: "tabOrder", order: [other], tabs: [other === cfg.sidA ? A_TAB : B_TAB], live: [other], skeleton: [] });
+await page.waitForTimeout(400);
+out.declinedTornDown = Object.assign(await state(), { recorded });
 // the SHELL road (the review's medium): on the dashboard the chat pane is a same-origin iframe of the shell and the
 // filter lives on the SHELL's URL (only-filter.ts reads window.top), so a live edit of the shell's hash must reach the
 // framed pane, whose own hash never changes: the pane unfocuses at once and restores when the filter shows the tab again
@@ -416,12 +436,18 @@ class ServedUnfocusedPane(unittest.TestCase):
         fa = r["firstArrivalUnderFilter"]
         self.assertNotIn(SID_B, fa["tabs"]); self.assertNotEqual(fa["active"], SID_B, "the first arrival (api), hidden by #only=web, is never adopted: %r" % fa)
         self.assertEqual(fa["active"], SID_A, "…the first VISIBLE arrival (web) is, over the declined record: %r" % fa)
+        lp = r["afterLiftAndPush"]
+        self.assertEqual(lp["active"], SID_A, "the adoption ended the unfocused state: the filter lifted and one routine push later the pane is still on web, never handed api (the review's high): %r" % lp)
         nm = r["noMatchFilter"]
         self.assertIsNone(nm["active"]); self.assertEqual(nm["tabs"], [], "no tab shows under a filter matching nothing: %r" % nm)
-        self.assertIn(nm["empty"]["vanished"], (SID_A, SID_B), "the declined first arrival is recorded: %r" % nm)
+        self.assertEqual(nm["empty"]["vanished"], SID_B, "the declined FIRST arrival (api arrives first in this world) is recorded, and a later hidden arrival never overwrites it: %r" % nm)
         self.assertEqual(nm["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.")
         nl = r["noMatchLifted"]
         self.assertEqual(nl["active"], nm["empty"]["vanished"], "lifting the filter restores the recorded session through the schedule: %r" % nl)
+        dt = r["declinedTornDown"]
+        self.assertIsNone(dt["active"]); self.assertEqual(dt["empty"]["vanished"], "", "the declined record went with its session: %r" % dt)
+        for nm_ in ("web", "api"):
+            self.assertNotIn(nm_, dt["empty"]["text"], "the frame stays name-free after a declined record's teardown (the review's medium): %r" % dt)
         # the hidden tab torn down while the pane is unfocused: the line follows the reason, naming the tab
         td = r["tornDownWhileHidden"]
         self.assertIsNone(td["active"]); self.assertEqual(td["empty"]["vanished"], SID_A); self.assertNotIn(SID_A, td["tabs"])

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -337,7 +337,7 @@ test("while the note holds the box, the type-from-anywhere defaults stand down; 
 test("the note retires on the exact events: an explicit switch, the session's return, or its ✕", () => {
   // setActive: a real switch re-binds the box → the note is stale
   assert.match(RENDER, /function setActive\(id: string[\s\S]*?if \(ta && activeId !== id\) \{[\s\S]*?clearComposerNote\(\);/);
-  // the session frame: the torn-down session is back while the note still holds → back on it (setActive retires the note)
+  // the session frame: the torn-down session is back while the note still holds → back on it through restoreIfShown, which retires the note (setActive) only when the strip shows the tab
   assert.match(RENDER, /if \(composerNoteSid === msg\.id\) restoreIfShown\(msg\.id\);/, "the note's own tab comes back through the one restore rule (shown takes focus; hidden does not)");
   // its own ✕
   assert.match(RENDER, /function renderComposerNote\(sid: string, why: DismissWhy, name: string\): void \{[\s\S]*?x\.dataset\.act = "composerNoteX";/);   // the ✕ rides the body delegate since 2026-09-08 (click-safe, no per-node listener)
@@ -345,7 +345,7 @@ test("the note retires on the exact events: an explicit switch, the session's re
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone && stripShows\(msg\.id\);[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
+  assert.match(RENDER, /const wouldAdopt = !activeId && \(!vanishedId \|\| vanishedByDecline\) && !wantActive && !wantActiveGone;[^\n]*\n\s*const adopted = wouldAdopt && stripShows\(msg\.id\);[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/draft-teardown.test.ts
+++ b/ui/webview/draft-teardown.test.ts
@@ -345,7 +345,7 @@ test("the note retires on the exact events: an explicit switch, the session's re
 });
 
 test("the `!activeId` adoption loads the adopted session's draft (once-per-page restore is not enough)", () => {
-  assert.match(RENDER, /const wouldAdopt = !activeId && \(!vanishedId \|\| vanishedByDecline\) && !wantActive && !wantActiveGone;[^\n]*\n\s*const adopted = wouldAdopt && stripShows\(msg\.id\);[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
+  assert.match(RENDER, /const wouldAdopt = !activeId && \(!vanishedId \|\| vanishedByDecline\) && !wantActive && !wantActiveGone;[^\n]*\n\s*const adopted = wouldAdopt && stripShows\(msg\.id\);[^\n]*\n\s*if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); vanishedId = null;/, "…and never while the user's own tab is away, awaited after a reload, or shown as gone (T357); an adoption asserts the peek and persists like a pick");
   // …and the adoption is a first SHOW even for a payload the page already held (the append path never re-reveals a hidden view)
   assert.match(RENDER, /if \(existed && !forked && !firstBuild && !adopted\) \{\s*\n\s*appendActive\(\);/);
   // the loader: box ← drafts.get(id), chips, thumbnails, staged stack — the same set setActive paints

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -62,7 +62,11 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(paint, /empty\.classList\.toggle\("unfocused", !!v\);\s*\n\s*empty\.dataset\.vanished = named \|\| "";/, "the body names the vanished or the awaited id");
   assert.doesNotMatch(RENDER, /empty\.textContent = "No session open/, "the one writer of the empty body is paintEmptyState");
   // the return: the session frame, or the strip re-listing it; no other arrival adopts the box meanwhile
-  assert.match(RENDER, /if \(vanishedId === msg\.id\) restoreIfShown\(msg\.id\);[^\n]*\n\s*const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone && stripShows\(msg\.id\);/, "an adoption reads the rule's visibility half: a first arrival the filter hides is not adopted (the review's low)");
+  assert.match(RENDER, /if \(vanishedId === msg\.id\) restoreIfShown\(msg\.id\);[^\n]*\n\s*const wouldAdopt = !activeId && \(!vanishedId \|\| vanishedByDecline\) && !wantActive && !wantActiveGone;[^\n]*\n\s*const adopted = wouldAdopt && stripShows\(msg\.id\);/, "an adoption reads the rule's visibility half: a first arrival the filter hides is not adopted (the review's low)");
+  // a DECLINED adoption is recorded like restoreIfShown's hidden case, so the schedule restores it when the filter shows
+  // it; the record yields to a later visible first arrival (nothing was chosen), and any activation clears the mark
+  assert.match(RENDER, /else if \(wouldAdopt\) \{ vanishedId = msg\.id; vanishedWhy = "hidden"; vanishedName = sessions\.get\(msg\.id\)\?\.name \|\| tabMeta\.get\(msg\.id\)\?\.name \|\| ""; vanishedByDecline = true; \}/);
+  assert.match(fn("setActive"), /wantActiveGone = null;[^\n]*\n\s*vanishedByDecline = false;/, "…cleared with the rest of the unfocused state");
   assert.match(RENDER, /if \(composerNoteSid === msg\.id\) restoreIfShown\(msg\.id\);/, "the composer note's restore goes through the rule too");
   assert.equal((RENDER.match(/\bsetActive\(msg\.id\)/g) || []).length, 0, "no frame-reachable direct setActive(msg.id) is left in the arrival path");
   assert.ok(RENDER.indexOf("/** Does the strip show `id` right now:") > RENDER.indexOf("function restoreIfShown("), "stripShows's docstring sits above its own function, after restoreIfShown");

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -66,7 +66,7 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   // a DECLINED adoption is recorded like restoreIfShown's hidden case, so the schedule restores it when the filter shows
   // it; the record yields to a later visible first arrival (nothing was chosen), and any activation clears the mark
   assert.match(RENDER, /else if \(wouldAdopt\) \{ vanishedId = msg\.id; vanishedWhy = "hidden"; vanishedName = sessions\.get\(msg\.id\)\?\.name \|\| tabMeta\.get\(msg\.id\)\?\.name \|\| ""; vanishedByDecline = true; \}/);
-  assert.match(fn("setActive"), /wantActiveGone = null;[^\n]*\n\s*vanishedByDecline = false;/, "…cleared with the rest of the unfocused state");
+  assert.match(fn("setActive"), /wantActiveGone = null; vanishedByDecline = false;/, "…cleared with the rest of the unfocused state (on the same line: chat-window.test.ts bounds the distance from the activation to the paused strip's re-evaluation)");
   assert.match(RENDER, /if \(composerNoteSid === msg\.id\) restoreIfShown\(msg\.id\);/, "the composer note's restore goes through the rule too");
   assert.equal((RENDER.match(/\bsetActive\(msg\.id\)/g) || []).length, 0, "no frame-reachable direct setActive(msg.id) is left in the arrival path");
   assert.ok(RENDER.indexOf("/** Does the strip show `id` right now:") > RENDER.indexOf("function restoreIfShown("), "stripShows's docstring sits above its own function, after restoreIfShown");

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -45,13 +45,13 @@ test("emptyStateParts: the body names the session that vanished and why; reconne
 test("the wiring: the dismiss branch, the unfocused body, the composer, the restore on return, no adoption meanwhile", () => {
   assert.match(RENDER, /^let vanishedId: string \| null = null;\s*\nlet vanishedWhy: VanishWhy \| null = null;\s*\nlet vanishedName = "";/m);
   const dismiss = fn("dismissSession");
-  assert.match(dismiss, /const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;\s*\n\s*if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; \}/);
+  assert.match(dismiss, /const next = focusAfterDismiss\(why, mru, order, goingToo\);\s*\n\s*activeId = next\.activeId;\s*\n\s*if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; vanishedByDecline = false; \}/);
   assert.match(dismiss, /if \(why !== "close"\) \{[\s\S]*?ta\.blur\(\);[\s\S]*?renderComposerNote\(id, why, name\);/, "the T236 note above the box still says whose box went away");
   // the pick (and the restore) end the unfocused state
   assert.match(fn("setActive"), /activeId = id;\s*\n\s*vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null;/, "a pick ends the unfocused state AND the awaited tab");
   assert.match(fn("setActive"), /persistActive\(id\);/, "the pick persists id and name");
   assert.match(fn("persistActive"), /activeId: id, activeName: liveSession\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| ""/, "the name persists beside the id for the reload's body");
-  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "an adopted tab asserts its peek and is persisted like a pick (the review's lows)");
+  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null; vanishedByDecline = false; \}/, "an adopted tab asserts its peek and is persisted like a pick (the review's lows)");
   // the empty body: pane-focus's words, the name dressed as the strip dresses it, the composer disabled and nameless
   const show = fn("showActive");
   assert.match(show, /paintEmptyState\(empty\);\s*\n\s*empty\.style\.display = "";\s*\n[\s\S]{0,200}?ta\.disabled = true; ta\.placeholder = order\.length \? "Pick a tab to start" : "Click \+ to add a session"; syncComposerPh\(\);/);
@@ -65,7 +65,11 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(RENDER, /if \(vanishedId === msg\.id\) restoreIfShown\(msg\.id\);[^\n]*\n\s*const wouldAdopt = !activeId && \(!vanishedId \|\| vanishedByDecline\) && !wantActive && !wantActiveGone;[^\n]*\n\s*const adopted = wouldAdopt && stripShows\(msg\.id\);/, "an adoption reads the rule's visibility half: a first arrival the filter hides is not adopted (the review's low)");
   // a DECLINED adoption is recorded like restoreIfShown's hidden case, so the schedule restores it when the filter shows
   // it; the record yields to a later visible first arrival (nothing was chosen), and any activation clears the mark
-  assert.match(RENDER, /else if \(wouldAdopt\) \{ vanishedId = msg\.id; vanishedWhy = "hidden"; vanishedName = sessions\.get\(msg\.id\)\?\.name \|\| tabMeta\.get\(msg\.id\)\?\.name \|\| ""; vanishedByDecline = true; \}/);
+  assert.match(RENDER, /else if \(wouldAdopt && !vanishedId\) \{ vanishedId = msg\.id; vanishedWhy = "hidden"; vanishedName = sessions\.get\(msg\.id\)\?\.name \|\| tabMeta\.get\(msg\.id\)\?\.name \|\| ""; vanishedByDecline = true; \}/, "…on FIRST sight only (the review's low: the last hidden arrival overwrote it)");
+  // the adoption over a declined record ends the unfocused state as setActive does (the review's high: a record left beside
+  // an active tab handed its session to applyTabOrder's restore when the filter lifted); the mark clears on every other unfocus
+  assert.match(fn("unfocusHiddenByView"), /vanishedName = sessions\.get\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| ""; vanishedByDecline = false;/);
+  assert.match(fn("dismissSession"), /if \(next\.unfocused\) \{ vanishedId = id; vanishedWhy = why; vanishedName = name; vanishedByDecline = false; \}/);
   assert.match(fn("setActive"), /wantActiveGone = null; vanishedByDecline = false;/, "…cleared with the rest of the unfocused state (on the same line: chat-window.test.ts bounds the distance from the activation to the paused strip's re-evaluation)");
   assert.match(RENDER, /if \(composerNoteSid === msg\.id\) restoreIfShown\(msg\.id\);/, "the composer note's restore goes through the rule too");
   assert.equal((RENDER.match(/\bsetActive\(msg\.id\)/g) || []).length, 0, "no frame-reachable direct setActive(msg.id) is left in the arrival path");
@@ -79,7 +83,7 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.match(RENDER, /if \(wantActive && msg\.id === wantActive && stripLists\(msg\.id\)\) \{ wantActive = null; restoreIfShown\(msg\.id\); \}/, "the persisted tab's arrival restores only if shown");
   assert.equal((RENDER.match(/\bsetActive\(back\)/g) || []).length, 1, "the one direct setActive(back) left is renderTabs's own fire-time restore, behind stripLists and stripShows");
   // a hidden tab torn down while the pane is unfocused: the body's line follows the reason (the review's low)
-  assert.match(fn("dismissSession"), /if \(!wasActive && vanishedId === id\) \{[\s\S]{0,400}?vanishedWhy = why; vanishedName = name;\s*\n\s*repaintEmptyStateIfUnfocused\(\);\s*\n\s*\}/);
+  assert.match(fn("dismissSession"), /if \(!wasActive && vanishedId === id\) \{[\s\S]{0,700}?if \(vanishedByDecline\) \{ vanishedId = null; vanishedWhy = null; vanishedName = ""; vanishedByDecline = false; \}\s*\n\s*else \{ vanishedWhy = why; vanishedName = name; \}\s*\n\s*repaintEmptyStateIfUnfocused\(\);\s*\n\s*\}/, "the user's tab's teardown writes its reason; a declined record's takes the record with it, name-free (the review's medium)");
   // the reload road (the review's HIGH): the persisted tab is awaited at boot, the body names it, nothing adopts
   assert.match(RENDER, /^let wantActiveName: string = /m);
   assert.match(fn("paintEmptyState"), /const awaited = !vanishedId && wantActive \? wantActive : null;/);
@@ -107,7 +111,7 @@ test("the wiring: the dismiss branch, the unfocused body, the composer, the rest
   assert.doesNotMatch(RENDER, /visibleIds\.includes\(activeId\) && visibleIds\.length/, "no first-visible-tab RE-POINT");
   assert.match(fn("unfocusHiddenByView"), /activeId = null; vanishedId = id; vanishedWhy = "hidden";/);
   assert.match(fn("assertPeekFor"), /const next = chatVisible\(id\) \? null : id;/, "the peek rule, over the views blob alone");
-  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); \}/, "an adoption asserts the peek like a pick");
+  assert.match(RENDER, /if \(adopted\) \{ activeId = msg\.id; assertPeekFor\(msg\.id\); loadComposerFor\(msg\.id, true\); persistActive\(msg\.id\); vanishedId = null;/, "an adoption asserts the peek like a pick");
   assert.match(fn("paintEmptyState"), /name: nameOf\(vanishedId, vanishedName\), why: vanishedWhy/, "no raw sid on the dismissal branch either");
   assert.match(fn("dismissSession"), /const name = sessions\.get\(id\)\?\.name \|\| tabMeta\.get\(id\)\?\.name \|\| "a session";/);
   assert.match(fn("cycleTab"), /if \(pickFirstVisibleTab\(\)\) return;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -16302,8 +16302,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
     clearSeek();
   }
   activeId = id;
-  vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null;   // any activation ends the unfocused state, the awaited tab included (T357)
-  vanishedByDecline = false;
+  vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null; vanishedByDecline = false;   // any activation ends the unfocused state (T357)
   updateLivePaused();   // the entering tab's own detached state shows or hides the strip (round 2, item 7)
   persistActive(id);   // the name rides beside the id: after a reload the unfocused body names the awaited tab before its host relays (T357)
   renderTabs();

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1023,6 +1023,7 @@ let activeId: string | null = null;
 let vanishedId: string | null = null;
 let vanishedWhy: VanishWhy | null = null;
 let vanishedName = "";
+let vanishedByDecline = false;   // the vanished record is a declined first adoption's (hidden by the filter), not the user's own tab: a later visible first arrival may adopt over it (T357)
 /** why the pane is unfocused: a dismissal's reason, or "hidden" (the strip's #only= filter stopped showing the active tab) */
 type VanishWhy = DismissWhy | "hidden";
 let renderingSid: string | null = null;   // the session id syncView is currently building (for per-session fold keys)
@@ -16302,6 +16303,7 @@ function setActive(id: string, anchor?: string, anchorT?: number, anchorKind?: s
   }
   activeId = id;
   vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null;   // any activation ends the unfocused state, the awaited tab included (T357)
+  vanishedByDecline = false;
   updateLivePaused();   // the entering tab's own detached state shows or hides the strip (round 2, item 7)
   persistActive(id);   // the name rides beside the id: after a reload the unfocused body names the awaited tab before its host relays (T357)
   renderTabs();
@@ -16466,13 +16468,16 @@ function upsert(msg: any) {
   // since (a click into the box, a tab switch or the ✕ would have retired it), so put them back exactly
   // where they were — its tab active, its kept draft in the box. Merely retiring the note here left the
   // fallback tab active with the box unheld, and the next blind keystroke landed there after all (the
-  // T236 harness, omission path: the tab is re-listed within seconds). setActive clears the note.
+  // T236 harness, omission path: the tab is re-listed within seconds). restoreIfShown retires the note through setActive,
+  // and only when the strip shows the tab: a tab the view or the filter hides keeps the box held for it.
   if (composerNoteSid === msg.id) restoreIfShown(msg.id);   // …through the one restore rule: a tab the view or the filter hides takes no focus (the review's low)
   // T357: the session the user was on is back (its host re-attached, the relay redialed) → its focus is restored;
   // and while it is away, an arrival of ANY OTHER session adopts nothing — the pane stays unfocused
   if (vanishedId === msg.id) restoreIfShown(msg.id);   // …if the strip shows it: hidden by the view or the filter, the pane stays unfocused (applyTabOrder's rule)
-  const adopted = !activeId && !vanishedId && !wantActive && !wantActiveGone && stripShows(msg.id);   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357); and never a session the view or the #only= filter hides (the review's low: the adopt wrote activeId past the restore rule's visibility half; membership is the append above)
+  const wouldAdopt = !activeId && (!vanishedId || vanishedByDecline) && !wantActive && !wantActiveGone;   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357); and never a session the view or the #only= filter hides (the review's low: the adopt wrote activeId past the restore rule's visibility half; membership is the append above)
+  const adopted = wouldAdopt && stripShows(msg.id);   // …and never a session the view or the #only= filter hides (the review's low: the adopt wrote activeId past the rule's visibility half; membership is the append above)
   if (adopted) { activeId = msg.id; assertPeekFor(msg.id); loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again; the peek asserted like a pick's, so a view-hidden first arrival has a tab (the review's lows)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
+  else if (wouldAdopt) { vanishedId = msg.id; vanishedWhy = "hidden"; vanishedName = sessions.get(msg.id)?.name || tabMeta.get(msg.id)?.name || ""; vanishedByDecline = true; }   // a DECLINED adoption records the session as restoreIfShown does, so renderTabs's schedule restores it when the filter shows it (the review's low: under a filter matching no live session the body showed the generic line and lifting the filter restored nothing); the record yields to a later VISIBLE first arrival (vanishedByDecline), since nothing was chosen
   if (wantActive && msg.id === wantActive && stripLists(msg.id)) { wantActive = null; restoreIfShown(msg.id); }   // restore persisted tab on arrival, if the strip shows it (else unfocused as hidden, restored when shown)
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -12090,7 +12090,7 @@ function stripShows(id: string, only: string | null = onlyTag()): boolean {
 function unfocusHiddenByView(id: string): void {
   if (activeId !== id) return;
   stashActiveDraft(id);
-  activeId = null; vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || "";
+  activeId = null; vanishedId = id; vanishedWhy = "hidden"; vanishedName = sessions.get(id)?.name || tabMeta.get(id)?.name || ""; vanishedByDecline = false;   // the user's own tab: no arrival may adopt over it
   loadComposerFor(null);
   renderTabs();
   showActive();
@@ -16475,8 +16475,8 @@ function upsert(msg: any) {
   if (vanishedId === msg.id) restoreIfShown(msg.id);   // …if the strip shows it: hidden by the view or the filter, the pane stays unfocused (applyTabOrder's rule)
   const wouldAdopt = !activeId && (!vanishedId || vanishedByDecline) && !wantActive && !wantActiveGone;   // …nor while the persisted tab is awaited after a reload, nor while the body says it is gone: a pick, not an arrival, moves on (T357); and never a session the view or the #only= filter hides (the review's low: the adopt wrote activeId past the restore rule's visibility half; membership is the append above)
   const adopted = wouldAdopt && stripShows(msg.id);   // …and never a session the view or the #only= filter hides (the review's low: the adopt wrote activeId past the rule's visibility half; membership is the append above)
-  if (adopted) { activeId = msg.id; assertPeekFor(msg.id); loadComposerFor(msg.id, true); persistActive(msg.id); }   // persisted like a pick: a restart lands here again; the peek asserted like a pick's, so a view-hidden first arrival has a tab (the review's lows)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back)
-  else if (wouldAdopt) { vanishedId = msg.id; vanishedWhy = "hidden"; vanishedName = sessions.get(msg.id)?.name || tabMeta.get(msg.id)?.name || ""; vanishedByDecline = true; }   // a DECLINED adoption records the session as restoreIfShown does, so renderTabs's schedule restores it when the filter shows it (the review's low: under a filter matching no live session the body showed the generic line and lifting the filter restored nothing); the record yields to a later VISIBLE first arrival (vanishedByDecline), since nothing was chosen
+  if (adopted) { activeId = msg.id; assertPeekFor(msg.id); loadComposerFor(msg.id, true); persistActive(msg.id); vanishedId = null; vanishedWhy = null; vanishedName = ""; wantActive = null; wantActiveGone = null; vanishedByDecline = false; }   // persisted like a pick: a restart lands here again; the peek asserted like a pick's, so a view-hidden first arrival has a tab (the review's lows)   // adopted as the only tab → its draft too (T236: the once-per-page restore below never covers a session that LEFT and came back) An adoption ends the unfocused state exactly as setActive does (the review's high: a declined record left standing beside the adopted tab would hand its session to applyTabOrder's restore the moment the filter lifted, and the pane jumped to a session the user never had).
+  else if (wouldAdopt && !vanishedId) { vanishedId = msg.id; vanishedWhy = "hidden"; vanishedName = sessions.get(msg.id)?.name || tabMeta.get(msg.id)?.name || ""; vanishedByDecline = true; }   // a DECLINED adoption records the session as restoreIfShown does, so renderTabs's schedule restores it when the filter shows it (the review's low: under a filter matching no live session the body showed the generic line and lifting the filter restored nothing); the record yields to a later VISIBLE first arrival (vanishedByDecline), since nothing was chosen, and is taken on FIRST sight only: a later hidden arrival never overwrites it, so which session the lift restores does not change between builds (the review's low)
   if (wantActive && msg.id === wantActive && stripLists(msg.id)) { wantActive = null; restoreIfShown(msg.id); }   // restore persisted tab on arrival, if the strip shows it (else unfocused as hidden, restored when shown)
   renderTabs();                                   // a new id appended to `order` above → strip repaints in kernel order
   // Active tab: a content refresh appends + preserves scroll (appendActive); a new tab or a fork
@@ -17105,8 +17105,12 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
   renderTabs();                          // tab removed from `order` above → repaint without it
   if (!wasActive && vanishedId === id) {
     // the tab the UNFOCUSED pane names is torn down while not active: the body's line follows the reason (the review's
-    // low: it kept the view's name-free line after the tab was gone; the vanished write below is the active tab's alone)
-    vanishedWhy = why; vanishedName = name;
+    // low: it kept the view's name-free line after the tab was gone; the vanished write below is the active tab's alone).
+    // A DECLINED record's session (never the user's; hidden by a filter meant to keep the frame clean) takes its record
+    // with it instead, so the frame never paints that session's name (the review's medium), and the next hidden arrival
+    // may be recorded on first sight
+    if (vanishedByDecline) { vanishedId = null; vanishedWhy = null; vanishedName = ""; vanishedByDecline = false; }
+    else { vanishedWhy = why; vanishedName = name; }
     repaintEmptyStateIfUnfocused();
   }
   if (wasActive) {
@@ -17122,7 +17126,7 @@ function dismissSession(id: string, why: DismissWhy, doomed?: ReadonlySet<string
     const goingToo = (x: string) => (doomed?.has(x) ?? false) || (why === "hostDrop" && !!home && hostOf(x) === home);
     const next = focusAfterDismiss(why, mru, order, goingToo);
     activeId = next.activeId;
-    if (next.unfocused) { vanishedId = id; vanishedWhy = why; vanishedName = name; }
+    if (next.unfocused) { vanishedId = id; vanishedWhy = why; vanishedName = name; vanishedByDecline = false; }   // the user's own tab went: no arrival may adopt over it (the review's high)
     loadComposerFor(activeId);   // the strip was showing the CLOSED session's chip/thumbnails/draft — swap in the new active tab's (usually none)
     // The box just changed hands under the user. Their own ✕ is the one case they already know; for every
     // other reason BLUR it — a keystroke a moment later must not land in the survivor's session unnoticed


### PR DESCRIPTION
Four lows from the verifier of the T357 follow-up.

- **A declined adoption is recorded, and yields to a visible first arrival.** Under a filter matching no live session the body showed the generic line and lifting the filter restored nothing. The declined first arrival is recorded as `restoreIfShown`'s hidden case so `renderTabs`'s schedule restores it when the filter shows it; the record is marked as a declined adoption's (`vanishedByDecline`) so a later visible first arrival still adopts over it, and any activation clears the mark.
- **The first-arrival road bites.** It runs under `#only=web`, which hides the first-arriving session (api) and shows a later one (web); a no-match road reads the recorded session on the body and its restore when the filter lifts live.
- The note's comment and pin say `restoreIfShown` retires the note through `setActive` only when the strip shows the tab.
- The lab's transient numbers are attributed to the applyTabOrder predicate reverted, not to the merge-base.

### Round two

- **An adoption ends the unfocused state as a pick does.** A declined record left beside the adopted tab handed its session to applyTabOrder's restore when the filter lifted; the adoption clears the vanished state and the mark like `setActive`, and the mark clears on every other unfocus (the user's own tab is never adoptable over). Lab: adopt over a decline, lift, one push, still on the adopted tab.
- **A declined record's teardown stays name-free.** The record goes with its session instead of taking the teardown's reason and name; the next hidden arrival may be recorded. Lab: the recorded session torn down, no name on the frame.
- **First sight only.** The record is never overwritten by a later hidden arrival, so the lift restores the same session between builds.
