### PR TITLE
The paused-strip pin is the order not a distance, a declined record's line says the first arrival is hidden, the teardown road asserts the durable claims (T357 final pass)

### DIFF
--- a/tests/test_unfocused_pane_browser.py
+++ b/tests/test_unfocused_pane_browser.py
@@ -441,11 +441,15 @@ class ServedUnfocusedPane(unittest.TestCase):
         nm = r["noMatchFilter"]
         self.assertIsNone(nm["active"]); self.assertEqual(nm["tabs"], [], "no tab shows under a filter matching nothing: %r" % nm)
         self.assertEqual(nm["empty"]["vanished"], SID_B, "the declined FIRST arrival (api arrives first in this world) is recorded, and a later hidden arrival never overwrites it: %r" % nm)
-        self.assertEqual(nm["empty"]["text"], "This tab view shows no session. Change the view, or pick a tab.")
+        self.assertEqual(nm["empty"]["text"], "The first session to arrive is hidden by this view. Pick a tab, or change the view.", "the declined record's own head, name-free")
         nl = r["noMatchLifted"]
         self.assertEqual(nl["active"], nm["empty"]["vanished"], "lifting the filter restores the recorded session through the schedule: %r" % nl)
         dt = r["declinedTornDown"]
-        self.assertIsNone(dt["active"]); self.assertEqual(dt["empty"]["vanished"], "", "the declined record went with its session: %r" % dt)
+        # the durable claims (the surviving hidden session's next frame re-records it by design, so `vanished` may be empty
+        # or the survivor): no active tab, and the line name-free with no bold name, whichever head stands
+        self.assertIsNone(dt["active"])
+        self.assertIn(dt["empty"]["text"], ("No session selected. Pick a tab to start.", "No session open — click + to add one.",
+                                            "The first session to arrive is hidden by this view. Pick a tab, or change the view."), "a name-free head after a declined record's teardown: %r" % dt)
         for nm_ in ("web", "api"):
             self.assertNotIn(nm_, dt["empty"]["text"], "the frame stays name-free after a declined record's teardown (the review's medium): %r" % dt)
         # the hidden tab torn down while the pane is unfocused: the line follows the reason, naming the tab

--- a/ui/webview/chat-window.test.ts
+++ b/ui/webview/chat-window.test.ts
@@ -91,9 +91,10 @@ test("render.ts wires the three rules, tracks the pending needFull reason, hides
   assert.ok(more.includes("const am = afterMore(!!msg.more, !!s.headKnown, s.events.length);"), "chatMore decides through the rule");
   assert.ok(more.includes("if (msg.id === activeId && s.detached) window.requestAnimationFrame(() => edgeCheckAfterWindow(msg.id));"), "…and a still-detached run re-checks its edge after the page painted");
   const active = RENDER.slice(RENDER.indexOf("function setActive(id: string"), RENDER.indexOf("\n}\n", RENDER.indexOf("function setActive(id: string")));
-  // (T357: the unfocused state's clear sits between the two lines; the re-evaluation still follows the activation)
-  const actAt = active.indexOf("activeId = id;\n  vanishedId = null;"), pausedAt = active.indexOf("updateLivePaused();");
-  assert.ok(actAt >= 0 && pausedAt > actAt && pausedAt - actAt < 200, "a tab switch re-evaluates the strip for the entering tab");
+  // (T357: the unfocused state's clear sits between the two lines; the re-evaluation still follows the activation.) The
+  // pin is the ORDER: the activation, the clear line, then updateLivePaused with no statement between (a character
+  // distance was consumed by every comment edit: 198 of 200 at one point)
+  assert.match(active, /activeId = id;\n  vanishedId = null;[^\n]*\n  updateLivePaused\(\);/, "a tab switch re-evaluates the strip for the entering tab, right after the activation and its clear");
   assert.ok(RENDER.includes('turn.dataset.orphanOf = String((ev as { orphanOf?: string }).orphanOf)'), "an orphan note's turn carries its record uuid");
   assert.equal((RENDER.match(/\.turn\[data-orphan-of="\$\{cssEscape\(uuid\)\}"\]/g) || []).length, 2, "…and both anchor lookups read it");
   assert.ok(RENDER.includes("(e as { orphanOf?: string }).orphanOf === uuid"), "…as does the events-list search behind them");

--- a/ui/webview/pane-focus.test.ts
+++ b/ui/webview/pane-focus.test.ts
@@ -23,6 +23,14 @@ test("focusAfterDismiss: the user's own ✕ keeps the recency fallback; every ot
   }
 });
 
+test("emptyStateParts: a declined record's hidden line says the first arrival is hidden, name-free; the user's own hidden tab keeps the view's line", () => {
+  const own = emptyStateParts({ name: "web", why: "hidden", dialing: false }, true);
+  assert.deepEqual(own, { head: "This tab view shows no session. Change the view, or pick a tab.", name: null, tail: "" });
+  const declined = emptyStateParts({ name: "api", why: "hidden", dialing: false, declined: true }, true);
+  assert.deepEqual(declined, { head: "The first session to arrive is hidden by this view. Pick a tab, or change the view.", name: null, tail: "" }, "worded for the record's case, still name-free (a visible placeholder tab may be on the strip)");
+  assert.equal(emptyStateParts({ name: "api", why: "hidden", dialing: false, declined: true }, false).name, null);
+});
+
 test("emptyStateParts: the body names the session that vanished and why; reconnecting when the host is dialing", () => {
   assert.deepEqual(emptyStateParts(null, false), { head: "No session open — click + to add one.", name: null, tail: "" });
   assert.deepEqual(emptyStateParts(null, true), { head: "No session selected. Pick a tab to start.", name: null, tail: "" });

--- a/ui/webview/pane-focus.ts
+++ b/ui/webview/pane-focus.ts
@@ -28,7 +28,8 @@ export function focusAfterDismiss(why: Why, mru: readonly string[], order: reado
  *  dismissal ran and the persisted choice is all the pane has), "gone" (a persisted id that can never be listed
  *  again as a tab of its own: a subagent viewer's tab, a provisional create), or "hidden" (the strip's `#only=` filter
  *  no longer shows the active tab; the peek covers a view's exclusion, not the filter's). */
-export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "gone" | "hidden"; dialing: boolean };
+export type Vanished = { name: string; why: Exclude<Why, "close"> | "awaited" | "gone" | "hidden"; dialing: boolean;
+                         declined?: boolean };   // "hidden" by a DECLINED adoption (no tab was ever the user's): the head says so, name-free
 
 /** The empty body's text in three pieces, so the pane can dress the name the way the strip does (host prefix,
  *  identity colour): `head` + `name` + `tail`, `name` null when no session vanished. */
@@ -49,7 +50,12 @@ export function emptyStateParts(v: Vanished | null, hasTabs: boolean): EmptyStat
     : " ended.";
   // the #only= filter hid the tab: a NAME-FREE line (the frame's purpose is a clean recording, and the pick
   // instruction is said once): the manager's call, 2026-09-11
-  if (v.why === "hidden") return { head: "This tab view shows no session. Change the view, or pick a tab.", name: null, tail: "" };
+  if (v.why === "hidden") {
+    // a declined record (the first session to arrive was hidden; nothing was the user's yet) says so, since a visible
+    // placeholder tab may well be on the strip (the review's low: "shows no session" read wrong beside a tab)
+    if (v.declined) return { head: "The first session to arrive is hidden by this view. Pick a tab, or change the view.", name: null, tail: "" };
+    return { head: "This tab view shows no session. Change the view, or pick a tab.", name: null, tail: "" };
+  }
   // an EMPTY strip invites no pick (the review's low): the session named is all there is to say
   return { head: hasTabs ? "No session selected. Pick a tab to start. " : "No sessions yet. ", name: v.name, tail };
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -12104,7 +12104,7 @@ function paintEmptyState(empty: HTMLElement): void {
   // session" (the review's low: the dismissal branch fell to the id)
   const nameOf = (id: string, carried = "") => carried || wantActiveName || tabMeta.get(id)?.name || sessions.get(id)?.name || "a session";
   const v = vanishedId && vanishedWhy && vanishedWhy !== "close"
-    ? { name: nameOf(vanishedId, vanishedName), why: vanishedWhy, dialing: hostIsDialing(vanishedId) }
+    ? { name: nameOf(vanishedId, vanishedName), why: vanishedWhy, dialing: hostIsDialing(vanishedId), declined: vanishedByDecline }
     : awaited ? { name: nameOf(awaited), why: "awaited" as const, dialing: hostIsDialing(awaited) }
     : gone ? { name: nameOf(gone), why: "gone" as const, dialing: false }
     : null;


### PR DESCRIPTION
The last three lows from the T357 next pass's verifier.

- **An order pin, not a distance.** chat-window.test.ts pins that `updateLivePaused` follows setActive's activation and its clear line with no statement between, instead of a 200-character distance any comment edit consumed.
- **A declined record's own head.** `Vanished` carries `declined`; the hidden line for a declined record says the first session to arrive is hidden by this view, name-free, since a visible placeholder tab may be on the strip.
- **Durable claims after the record's teardown.** The lab asserts no active tab, a name-free head and no session name, rather than an empty vanished id the survivor's next frame re-records.
