### PR TITLE
A bounded converge pass writes the documents a boot's whole reads left dirty, so a fold that never ran in the writing process is read whole once, not at every boot (T360)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1007,8 +1007,13 @@ default 150 ms of wall, and `ROMP_CKPT_CONVERGE_MB`, default 8 MB of documents
 written plus leaf bytes read for a heal), heals a legacy bare cursor under the
 same budget, and never rewrites a document that already carries every fold
 that ran. Every write merges the on-disk document's states for folds the
-writing process never ran (verified by that document's guard), so a rewrite
-from one process's cursors strips no state an earlier process stored. Checkpoints
+writing process never ran (verified by that document's stat and guard as a
+restore would), so a rewrite from one process's cursors strips no state an
+earlier process stored. A fold's count may lag the entry's by 64 records or an
+eighth of the entry, whichever is more, and still be written or carried at its
+own count; further behind, the fold is left out (it refolds whole once when it
+next runs), so a fold that ran early and stopped cannot drag the document's
+cut, and every later boot's tail read, back to its count. Checkpoints
 are written when a session's turn settles or its states log moves, and all of
 them at exit; checkpoints of files that no longer exist are swept at boot. A
 compaction appends records and changes nothing here.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -997,7 +997,16 @@ so, and is healed by one whole refold: a leaf's folds at the session's next
 settle, before the write, so that write carries their states; another file's
 fold (a states log's) is left out of its next checkpoint write and read whole
 once at the next boot. After that the fold is written whole and every later
-boot restores it warm. Checkpoints
+boot restores it warm. A fold that never ran in the process that wrote the
+document has no entry there, and the next kernel reads the file whole for it
+at first touch; the converge pass on the pusher's cycle then writes that
+document (and, over the whole entry the read left, every leaf fold with it),
+independent of settle evidence, so the read is paid once even for a session
+that never settles again; the pass is bounded per cycle (`ROMP_CKPT_CONVERGE_MS`,
+default 150 ms of wall, and `ROMP_CKPT_CONVERGE_MB`, default 8 MB of documents
+written plus leaf bytes read for a heal), heals a legacy bare cursor under the
+same budget, and never rewrites a document that already carries every fold
+that ran. Checkpoints
 are written when a session's turn settles or its states log moves, and all of
 them at exit; checkpoints of files that no longer exist are swept at boot. A
 compaction appends records and changes nothing here.
@@ -1409,7 +1418,8 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   state, with the state's KB as the reason, and the next kernel starts the fold
   cold at the cut over the tail only), `coldFolds` (per fold name, folds that
   started cold this boot, for that reason or for a cursor recorded without a
-  state, which the next settle heals), `coldWrites` (per fold name, writes that kept such a tail-only state
+  state, which the next settle heals), `converge` (the converge pass: `passes`,
+  `writes`, `bytes`, `heals`, `healBytes`, `primed`, `deferred`), `coldWrites` (per fold name, writes that kept such a tail-only state
   out of the document so no later kernel restores it as complete), `droppedRestores` (a
   restore lost to a read that replaced the entry under it; the reader
   serializes reads per path, so this should stay at zero), `documentBytes`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1428,7 +1428,8 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   state, which the next settle heals), `converge` (the converge pass: `passes`,
   `writes`, `bytes`, `heals`, `healBytes`, `primed`, `deferred`, `failed` for a
   write that wrote nothing, `unhealed` for a cold fold the pass could not rerun,
-  whose cursor it dropped so its next run reads the file whole once), `coldWrites` (per fold name, writes that kept such a tail-only state
+  whose cursor it dropped so its next run reads the file whole once, and
+  `docReadBytes`, the documents the pass's writes read for their carry), `coldWrites` (per fold name, writes that kept such a tail-only state
   out of the document so no later kernel restores it as complete), `droppedRestores` (a
   restore lost to a read that replaced the entry under it; the reader
   serializes reads per path, so this should stay at zero), `documentBytes`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1006,7 +1006,9 @@ that never settles again; the pass is bounded per cycle (`ROMP_CKPT_CONVERGE_MS`
 default 150 ms of wall, and `ROMP_CKPT_CONVERGE_MB`, default 8 MB of documents
 written plus leaf bytes read for a heal), heals a legacy bare cursor under the
 same budget, and never rewrites a document that already carries every fold
-that ran. Checkpoints
+that ran. Every write merges the on-disk document's states for folds the
+writing process never ran (verified by that document's guard), so a rewrite
+from one process's cursors strips no state an earlier process stored. Checkpoints
 are written when a session's turn settles or its states log moves, and all of
 them at exit; checkpoints of files that no longer exist are swept at boot. A
 compaction appends records and changes nothing here.
@@ -1419,7 +1421,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   cold at the cut over the tail only), `coldFolds` (per fold name, folds that
   started cold this boot, for that reason or for a cursor recorded without a
   state, which the next settle heals), `converge` (the converge pass: `passes`,
-  `writes`, `bytes`, `heals`, `healBytes`, `primed`, `deferred`), `coldWrites` (per fold name, writes that kept such a tail-only state
+  `writes`, `bytes`, `heals`, `healBytes`, `primed`, `deferred`, `failed` for a
+  write that wrote nothing, `unhealed` for a cold fold the pass could not rerun,
+  whose cursor it dropped so its next run reads the file whole once), `coldWrites` (per fold name, writes that kept such a tail-only state
   out of the document so no later kernel restores it as complete), `droppedRestores` (a
   restore lost to a read that replaced the entry under it; the reader
   serializes reads per path, so this should stay at zero), `documentBytes`

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -918,6 +918,7 @@ def _ckpt_fallback(path, reason, detail=""):
     with _CKPT_LOCK:
         _CKPT_STATS["fallbacks"][reason] = _CKPT_STATS["fallbacks"].get(reason, 0) + 1
         _CKPT_PENDING.pop(str(path), None)
+        _CKPT_DOC_FOLDS.pop(str(path), None)              # the document is gone: the converge pass must not believe it whole
     try:
         sys.stderr.write("checkpoint fallback (%s) for %s%s\n" % (reason, path, (": " + detail) if detail else ""))
     except Exception:
@@ -1115,7 +1116,17 @@ def _restored_cursor(key, name, ent):
         _ckpt_fallback(key, "corrupt", "fold %s: %s" % (name, e)); return None
 
 
-def _carry_forward_states(key, folds, base, count):
+_CKPT_LAG_FLOOR = 64                # a fold's count may lag the entry's by this many records, or an eighth of the entry, whichever
+#                                     is more, and still be written (or carried) at its own count; further behind it is left out,
+#                                     so a fold that ran early and stopped (a skipped wake-tail, a cursor dropped at quiescence)
+#                                     cannot drag the document's cut, and with it every later boot's tail read, back to its count
+
+
+def _lag_ok(count, c):
+    return count - c <= max(_CKPT_LAG_FLOOR, count // 8)
+
+
+def _carry_forward_states(key, folds, base, count, size, mtime):
     """The on-disk document's entries for folds this process holds no cursor for (a fold that never ran here, such as the
     transcript's wake-tail or queue-ledger folds beside the five leaf folds), carried into the next write so a write from
     this process's cursors alone does not strip states an earlier process stored (T360 review, medium 2: before the
@@ -1127,17 +1138,22 @@ def _carry_forward_states(key, folds, base, count):
     if cp is None or not cp.exists():
         return {}
     try:
-        doc = json.loads(cp.read_bytes().decode("utf-8"))
+        text = cp.read_bytes(); _count_read(str(cp), len(text))    # the carry's reads are the write's I/O: counted like the rest
+        doc = json.loads(text.decode("utf-8"))
     except (OSError, ValueError):
         return {}
     if not isinstance(doc, dict) or doc.get("v") != _CKPT_V or doc.get("path") != os.path.realpath(key):
         return {}
     try:
+        if _ckpt_verdict(doc, size, mtime):                   # the entry's stat against the document, as the restore paths ask: a
+            return {}                                         #  same-size edit under another mtime is a rewrite, and carries nothing
         off, guard = int(doc["offset"]), bytes.fromhex(doc.get("guard") or "")
         with open(key, "rb") as fh:
             fh.seek(max(0, off - len(guard)))
-            if fh.read(len(guard)) != guard:
-                return {}
+            ok = fh.read(len(guard)) == guard
+        _count_read(key, len(guard))
+        if not ok:
+            return {}
     except (OSError, ValueError, TypeError, KeyError):
         return {}
     out = {}
@@ -1148,7 +1164,7 @@ def _carry_forward_states(key, folds, base, count):
             c = int(f["count"])
         except (KeyError, TypeError, ValueError):
             continue
-        if base <= c <= count:
+        if base <= c <= count and _lag_ok(count, c):          # a carried count too far behind would drag the cut (the bound above)
             out[name] = f
     return out
 
@@ -1169,8 +1185,9 @@ def checkpoint_write(path, force=False):
     folds = {}
     for name, cache in list(_FOLD_REG.items()):
         cur = cache.get(key)
-        if cur is None or cur[1] != gen or not base <= cur[0] <= count:
-            continue                                      # no cursor at this entry, or one outside its held records
+        if cur is None or cur[1] != gen or not base <= cur[0] <= count or not _lag_ok(count, cur[0]):
+            continue                                      # no cursor at this entry, one outside its held records, or one too far
+        #                                                   behind to be written at its count without dragging the cut (_lag_ok)
         fcount = cur[0]                                   # the fold's OWN count (T359): a fold stepped by builds, not by the settle,
         with _CKPT_LOCK:                                  #  lags the entry and was left out silently before, to read the leaf whole
             cold = (key, name) in _COLD_FOLDS             #  at the next boot; the restore steps the held tail from its count
@@ -1197,7 +1214,7 @@ def checkpoint_write(path, force=False):
                 _CKPT_STATS["skippedFolds"] += 1
     if not folds and not force:
         return False
-    folds.update(_carry_forward_states(key, folds, base, count))   # the disk document's states for folds this process never ran
+    folds.update(_carry_forward_states(key, folds, base, count, size, mtime))   # the disk document's states for folds this process never ran
     cut = min([f["count"] for f in folds.values()] or [count])   # the document's cut: the LOWEST written cursor (T359), so the
     moved = None                                          #  next process's tail read holds every record a lagging fold has
     if cut < count and len(ent) >= 8 and ent[7]:          #  yet to step (its append), bounded by the records this entry holds

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -766,7 +766,7 @@ _CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None
 _CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}, "droppedRestores": 0,
                "oversizeFolds": {}, "coldFolds": {}, "coldWrites": {},
                "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0,
-                            "failed": 0, "unhealed": 0}}   # T360
+                            "failed": 0, "unhealed": 0, "docReadBytes": 0}}   # T360
 _CKPT_DOC_FOLDS = {}              # path -> {fold name: "state" | "over" | "cold" | "bare"}: the document on disk as last written or
 #                                   loaded in this process, so the converge pass can tell a document lacking a state without a read
 _COLD = object()                  # a restored cursor with no state (its fold was oversize): fold_records inits it and steps the tail
@@ -897,7 +897,7 @@ def set_checkpoint_dir(fn):
     global _CKPT_DIR_FN
     _CKPT_DIR_FN = fn
     with _CKPT_LOCK:
-        _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear()
+        _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear(); _CKPT_DOC_FOLDS.clear()
 
 
 def _ckpt_dir():
@@ -1292,14 +1292,15 @@ def checkpoint_converge_candidates():
         if ent is None:
             continue
         shapes = _CKPT_DOC_FOLDS.get(key, {})
+        total = ent[5] + len(ent[4])
         for name, cache in list(_FOLD_REG.items()):
             if (key, name) in cold:
                 out.append(key); break
             cur = cache.get(key)
-            if cur is None or cur[1] != ent[6] or not ent[5] <= cur[0] <= ent[5] + len(ent[4]):
-                continue
-            if shapes.get(name) not in ("state", "over"):
-                out.append(key); break
+            if cur is None or cur[1] != ent[6] or not ent[5] <= cur[0] <= total or not _lag_ok(total, cur[0]):
+                continue                                  # no cursor the writer would record: a fold stopped beyond the lag bound
+            if shapes.get(name) not in ("state", "over"):   #  is left out by the writer and refused by the carry, so it is no
+                out.append(key); break                    #  candidate either (it refolds once when it runs, then is written current)
     return out
 
 

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -765,7 +765,8 @@ _CKPT_V = 1
 _CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None = checkpoints off
 _CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}, "droppedRestores": 0,
                "oversizeFolds": {}, "coldFolds": {}, "coldWrites": {},
-               "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0}}   # T360
+               "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0,
+                            "failed": 0, "unhealed": 0}}   # T360
 _CKPT_DOC_FOLDS = {}              # path -> {fold name: "state" | "over" | "cold" | "bare"}: the document on disk as last written or
 #                                   loaded in this process, so the converge pass can tell a document lacking a state without a read
 _COLD = object()                  # a restored cursor with no state (its fold was oversize): fold_records inits it and steps the tail
@@ -848,8 +849,10 @@ def drop_cold_cursors(path):
     key = str(path)
     with _CKPT_LOCK:
         names = [n for k, n in _COLD_FOLDS if k == key and _COLD_REASONS.get((k, n), "cold") == "cold"]
-    for n in names:
-        cache = _FOLD_REG.get(n)
+        for n in names:                                   # the cold marks go with the cursor: the fold's next run is a whole refold,
+            _COLD_FOLDS.discard((key, n)); _COLD_REASONS.pop((key, n), None); _COLD_OVER_KB.pop((key, n), None)   #  and until then
+    for n in names:                                       #  the path is no candidate for it (review: an unhealable cold fold kept a
+        cache = _FOLD_REG.get(n)                          #  document being written every cycle)
         if cache is not None:
             cache.pop(key, None)
     return names
@@ -1112,6 +1115,44 @@ def _restored_cursor(key, name, ent):
         _ckpt_fallback(key, "corrupt", "fold %s: %s" % (name, e)); return None
 
 
+def _carry_forward_states(key, folds, base, count):
+    """The on-disk document's entries for folds this process holds no cursor for (a fold that never ran here, such as the
+    transcript's wake-tail or queue-ledger folds beside the five leaf folds), carried into the next write so a write from
+    this process's cursors alone does not strip states an earlier process stored (T360 review, medium 2: before the
+    converge pass an idle session's document was never rewritten, so they survived). Only entries with a state, or an
+    over-the-cap cursor, at a count inside this entry's held records, and only when the document's own guard still
+    stands on disk (a file rewritten since voids its states); a bare or tail-only cursor is not carried: the next boot reads
+    the file whole for that fold once and the write after carries its state."""
+    cp = _ckpt_file(key)
+    if cp is None or not cp.exists():
+        return {}
+    try:
+        doc = json.loads(cp.read_bytes().decode("utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(doc, dict) or doc.get("v") != _CKPT_V or doc.get("path") != os.path.realpath(key):
+        return {}
+    try:
+        off, guard = int(doc["offset"]), bytes.fromhex(doc.get("guard") or "")
+        with open(key, "rb") as fh:
+            fh.seek(max(0, off - len(guard)))
+            if fh.read(len(guard)) != guard:
+                return {}
+    except (OSError, ValueError, TypeError, KeyError):
+        return {}
+    out = {}
+    for name, f in (doc.get("folds") or {}).items():
+        if name in folds or not isinstance(f, dict) or not ("state" in f or f.get("over")):
+            continue
+        try:
+            c = int(f["count"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if base <= c <= count:
+            out[name] = f
+    return out
+
+
 def checkpoint_write(path, force=False):
     """Write `path`'s checkpoint from the reader's entry and every registered fold whose cursor stands at the entry's
     record count. False when there is nothing to write (no entry, or no fold at the witness and not `force`)."""
@@ -1156,6 +1197,7 @@ def checkpoint_write(path, force=False):
                 _CKPT_STATS["skippedFolds"] += 1
     if not folds and not force:
         return False
+    folds.update(_carry_forward_states(key, folds, base, count))   # the disk document's states for folds this process never ran
     cut = min([f["count"] for f in folds.values()] or [count])   # the document's cut: the LOWEST written cursor (T359), so the
     moved = None                                          #  next process's tail read holds every record a lagging fold has
     if cut < count and len(ent) >= 8 and ent[7]:          #  yet to step (its append), bounded by the records this entry holds
@@ -1255,14 +1297,19 @@ def checkpoint_write_dirty(paths=None, budget_s=None):
     bounds the pass (the exit path, 2026-09-11: an unbounded write over a kernel life's dirty files outran the
     manager's 5 s grace and the SIGKILL lost the cut row): the first file always writes, the pass stops once the
     budget has passed, and what is left stays dirty for the next writer."""
-    n = 0
+    return len(checkpoint_write_dirty_paths(paths, budget_s))
+
+
+def checkpoint_write_dirty_paths(paths=None, budget_s=None):
+    """checkpoint_write_dirty, returning the paths written (the settle's converge pass skips them that cycle)."""
+    out = []
     t0 = time.monotonic()
     for p in (checkpoint_dirty() if paths is None else [str(p) for p in paths]):
-        if budget_s is not None and n and time.monotonic() - t0 > budget_s:
+        if budget_s is not None and out and time.monotonic() - t0 > budget_s:
             break
         if checkpoint_write(p):
-            n += 1
-    return n
+            out.append(p)
+    return out
 
 
 def checkpoint_sweep():

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -764,7 +764,10 @@ def read_bytes_report():
 _CKPT_V = 1
 _CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None = checkpoints off
 _CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}, "droppedRestores": 0,
-               "oversizeFolds": {}, "coldFolds": {}, "coldWrites": {}}
+               "oversizeFolds": {}, "coldFolds": {}, "coldWrites": {},
+               "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0}}   # T360
+_CKPT_DOC_FOLDS = {}              # path -> {fold name: "state" | "over" | "cold" | "bare"}: the document on disk as last written or
+#                                   loaded in this process, so the converge pass can tell a document lacking a state without a read
 _COLD = object()                  # a restored cursor with no state (its fold was oversize): fold_records inits it and steps the tail
 _COLD_FOLDS = set()               # (path, fold name) whose state in this process began cold at a cut: a TAIL-ONLY state, written as a
 _COLD_OVER_KB = {}                # (path, fold name) -> the KB an over-the-cap state measured, carried through a cold write (T359)
@@ -1004,6 +1007,7 @@ def _checkpoint_entry(path, st):
     guard bytes are verified by the reader against the file; here the document and the size are: a file shorter than
     the recorded offset is a shrink."""
     doc = _ckpt_load(path)
+    _CKPT_DOC_FOLDS[str(path)] = _doc_fold_shapes(doc.get("folds")) if isinstance(doc, dict) else {}   # what the disk holds (T360)
     if doc is None:
         return None
     offset, count = int(doc["offset"]), int(doc["count"])
@@ -1032,6 +1036,7 @@ def _ckpt_pending(path, ent):
         if key in _CKPT_SEQ:                          # already consulted (or written) in this process: nothing new
             return None
     doc = _ckpt_load(path)
+    _CKPT_DOC_FOLDS[str(path)] = _doc_fold_shapes(doc.get("folds")) if isinstance(doc, dict) else {}   # what the disk holds (T360)
     if doc is None:
         with _CKPT_LOCK:
             _CKPT_SEQ.setdefault(key, 0)
@@ -1192,6 +1197,7 @@ def checkpoint_write(path, force=False):
     with _CKPT_LOCK:
         _CKPT_SEQ[key] = seq
         _CKPT_STATS["writes"] += 1
+        _CKPT_DOC_FOLDS[key] = _doc_fold_shapes(folds)
         if left_out:
             _FOLD_DIRTY.add(key)                          # a lagging fold has no cursor in this document yet
         else:
@@ -1203,6 +1209,45 @@ def checkpoint_dirty():
     """The paths whose fold cursors moved since their checkpoint was last written."""
     with _CKPT_LOCK:
         return sorted(_FOLD_DIRTY)
+
+
+def _doc_fold_shapes(folds):
+    return {n: ("state" if "state" in f else "over" if f.get("over") else "cold" if f.get("cold") else "bare")
+            for n, f in (folds or {}).items() if isinstance(f, dict)}
+
+
+def checkpoint_converge_candidates():
+    """The dirty paths whose document on disk lacks a complete state for a fold this process holds a cursor for at the
+    current entry (the fold is missing from it, or recorded as a bare or tail-only cursor), or whose fold began cold for
+    want of a state: the writes that make a boot's whole reads pay ONCE (T360). Before them a fold that never ran in the
+    writing process had no entry, the next boot read the leaf whole for it, and an idle session, which never settles,
+    paid that at every boot. A dirty path whose document already carries every fold that ran is not one: a live session's
+    leaf is dirty every turn and is written at its settle, never here (no steady stream of writes)."""
+    out = []
+    with _CKPT_LOCK:
+        cold = {(k, n) for k, n in _COLD_FOLDS if _COLD_REASONS.get((k, n), "cold") == "cold"}
+        paths = sorted(_FOLD_DIRTY | {k for k, n in cold})   # a cold cursor at the witness steps nothing and marks nothing dirty
+    for key in paths:
+        with _JSONL_CACHE_LOCK:
+            ent = _JSONL_CACHE.get(key)
+        if ent is None:
+            continue
+        shapes = _CKPT_DOC_FOLDS.get(key, {})
+        for name, cache in list(_FOLD_REG.items()):
+            if (key, name) in cold:
+                out.append(key); break
+            cur = cache.get(key)
+            if cur is None or cur[1] != ent[6] or not ent[5] <= cur[0] <= ent[5] + len(ent[4]):
+                continue
+            if shapes.get(name) not in ("state", "over"):
+                out.append(key); break
+    return out
+
+
+def converge_stat(name, n=1):
+    """Count a converge pass's work under checkpoints.converge (the kernel's pass reports through here)."""
+    with _CKPT_LOCK:
+        _CKPT_STATS["converge"][name] = _CKPT_STATS["converge"].get(name, 0) + n
 
 
 def checkpoint_write_dirty(paths=None, budget_s=None):
@@ -1258,7 +1303,7 @@ def checkpoint_stats():
     with _CKPT_LOCK:
         out = dict(_CKPT_STATS); out["fallbacks"] = dict(_CKPT_STATS["fallbacks"]); out["restoredFolds"] = dict(_CKPT_STATS["restoredFolds"])
         out["oversizeFolds"] = dict(_CKPT_STATS["oversizeFolds"]); out["coldFolds"] = dict(_CKPT_STATS["coldFolds"])
-        out["coldWrites"] = dict(_CKPT_STATS["coldWrites"])
+        out["coldWrites"] = dict(_CKPT_STATS["coldWrites"]); out["converge"] = dict(_CKPT_STATS["converge"])
     d = _ckpt_dir()
     with _READ_BYTES_LOCK:
         out["documentBytes"] = sum(n for p_, n in _READ_BYTES.items() if d is not None and p_.startswith(str(d) + os.sep))

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9802,6 +9802,8 @@ except Exception:
 _CKPT_SETTLE_SEEN = {}          # sid -> (turn-end key, states-log stat) at the last checkpoint write of its files
 _CKPT_PERIODIC_SEEN = {}        # sid -> (leaf stat, monotonic time) at the last PERIODIC write (see _persist_checkpoints)
 CKPT_PERIOD_S = float(os.environ.get("ROMP_CKPT_PERIOD_S", "30"))   # a session mid-turn for hours writes at least this often
+CKPT_CONVERGE_MS = float(os.environ.get("ROMP_CKPT_CONVERGE_MS", "150"))          # the converge pass's wall budget per pusher cycle (T360)
+CKPT_CONVERGE_BYTES = int(float(os.environ.get("ROMP_CKPT_CONVERGE_MB", "8")) * 1024 * 1024)   # ...and its bytes (documents written plus leaves read for a heal)
 
 
 def _session_fold_files(sid, leaf):
@@ -9880,6 +9882,47 @@ def _stored_tree(path, sid):
     except Exception:
         return None
     return hit[1] if hit else None
+
+
+def _converge_checkpoints(now):
+    """The converge pass (T360), one per pusher cycle after the settle writes: the dirty documents that lack a complete
+    state this process now holds (em.checkpoint_converge_candidates: a fold missing from the document because it never ran
+    in the writing process, a legacy bare cursor, a tail-only one) are written now, independent of settle evidence, so a
+    boot's whole reads pay once and the next boot restores every fold that ran. Bounded per cycle by CKPT_CONVERGE_MS of
+    wall and CKPT_CONVERGE_BYTES of documents written plus leaf bytes read for a heal (the first candidate always goes; the
+    rest wait for the next cycle, counted as deferred). For a leaf: a fold cold for want of a state is healed first (one
+    whole read, its bytes counted), and over a whole-resident entry every leaf fold is primed (a step over records in hand,
+    no read), so one write carries all five. For another file a tail-only cursor is dropped so the write leaves it out and
+    its next run reads the small file whole once. A document already carrying every fold that ran is never a candidate,
+    so an idle session's document is written once and then left alone. Returns the documents written."""
+    cands = em.checkpoint_converge_candidates()
+    if not cands:
+        return 0
+    em.converge_stat("passes")
+    leaves = {str(s.get("path")) for s in _sessions(now) if s.get("path")}
+    t0 = time.monotonic(); spent = 0; n = 0
+    for i, p in enumerate(cands):
+        if n and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or spent > CKPT_CONVERGE_BYTES):
+            em.converge_stat("deferred", len(cands) - i)
+            break
+        if p in leaves:
+            before = em.read_bytes_report().get(p, 0)
+            healed = _heal_cold_folds(p)
+            if healed:
+                got = em.read_bytes_report().get(p, 0) - before
+                em.converge_stat("heals", len(healed)); em.converge_stat("healBytes", got); spent += got
+            if em.entry_whole_resident(p) and _prime_leaf_folds(p):
+                em.converge_stat("primed")
+        else:
+            em.drop_cold_cursors(p)
+        if em.checkpoint_write(p):
+            n += 1
+            try:
+                size = em._ckpt_file(p).stat().st_size
+            except OSError:
+                size = 0
+            em.converge_stat("writes"); em.converge_stat("bytes", size); spent += size
+    return n
 
 
 def _persist_checkpoints(now):
@@ -48531,6 +48574,7 @@ def _pusher_cycle_jobs(now, live_map, any_client):
         sys.stderr.write("tick-seen: %s\n" % traceback.format_exc())
     try:                                  # the folds' checkpoints, written for a session at its settle or a states-log
         _persist_checkpoints(now)         # move (T323 stage 3): the next kernel folds the tails, not the files
+        _converge_checkpoints(now)        # ...and the documents a boot's whole reads left dirty, bounded per cycle (T360)
     except Exception:
         sys.stderr.write("checkpoints: %s\n" % traceback.format_exc())
     try:                                  # the boot row's backstop: written without attachDone once the bound has passed

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9923,6 +9923,12 @@ def _converge_checkpoints(now):
             unhealed = em.drop_cold_cursors(p)
         if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
             em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
+        try:                                               # the write reads the document on disk for its carry: that read is the
+            pre = em._ckpt_file(p).stat().st_size          #  pass's I/O too, so it counts against the budget (review, round 3)
+        except (OSError, AttributeError):
+            pre = 0
+        if pre:
+            em.converge_stat("docReadBytes", pre); spent += pre
         if em.checkpoint_write(p):                         #  run reads the file whole once, and the path is no candidate for it
             n += 1
             try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9884,6 +9884,9 @@ def _stored_tree(path, sid):
     return hit[1] if hit else None
 
 
+_CKPT_JUST_WRITTEN = set()          # the paths the settle write took this cycle; the converge pass skips them (T360 review, low 4)
+
+
 def _converge_checkpoints(now):
     """The converge pass (T360), one per pusher cycle after the settle writes: the dirty documents that lack a complete
     state this process now holds (em.checkpoint_converge_candidates: a fold missing from the document because it never ran
@@ -9895,33 +9898,40 @@ def _converge_checkpoints(now):
     no read), so one write carries all five. For another file a tail-only cursor is dropped so the write leaves it out and
     its next run reads the small file whole once. A document already carrying every fold that ran is never a candidate,
     so an idle session's document is written once and then left alone. Returns the documents written."""
-    cands = em.checkpoint_converge_candidates()
+    just_written = set(_CKPT_JUST_WRITTEN); _CKPT_JUST_WRITTEN.clear()   # the settle's writes this cycle: one write per path per cycle
+    cands = [p for p in em.checkpoint_converge_candidates() if p not in just_written]
     if not cands:
         return 0
     em.converge_stat("passes")
     leaves = {str(s.get("path")) for s in _sessions(now) if s.get("path")}
     t0 = time.monotonic(); spent = 0; n = 0
     for i, p in enumerate(cands):
-        if n and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or spent > CKPT_CONVERGE_BYTES):
-            em.converge_stat("deferred", len(cands) - i)
-            break
+        if i and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or spent > CKPT_CONVERGE_BYTES):
+            em.converge_stat("deferred", len(cands) - i)   # gated on candidates PROCESSED, not documents written: a first
+            break                                          #  candidate that writes nothing must not lift the budget (review)
+        cold = [k for k, r in em.cold_fold_reasons(p).items() if r == "cold"]
         if p in leaves:
             before = em.read_bytes_report().get(p, 0)
-            healed = _heal_cold_folds(p)
+            healed = _heal_cold_folds(p)                   # drops every tail-only cursor, reruns the five leaf folds
             if healed:
                 got = em.read_bytes_report().get(p, 0) - before
                 em.converge_stat("heals", len(healed)); em.converge_stat("healBytes", got); spent += got
+            unhealed = [k for k in cold if k not in healed]
             if em.entry_whole_resident(p) and _prime_leaf_folds(p):
                 em.converge_stat("primed")
         else:
-            em.drop_cold_cursors(p)
-        if em.checkpoint_write(p):
+            unhealed = em.drop_cold_cursors(p)
+        if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
+            em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
+        if em.checkpoint_write(p):                         #  run reads the file whole once, and the path is no candidate for it
             n += 1
             try:
                 size = em._ckpt_file(p).stat().st_size
             except OSError:
                 size = 0
             em.converge_stat("writes"); em.converge_stat("bytes", size); spent += size
+        else:
+            em.converge_stat("failed")                     # nothing to write, or the write failed (a full or read-only disk)
     return n
 
 
@@ -9971,7 +9981,8 @@ def _persist_checkpoints(now):
             if _p != leaf:                     #  dropped so the write leaves it out and the next boot reads that small file
                 em.drop_cold_cursors(_p)       #  whole once, complete again (T359 review, low 3; the leaf's folds heal above)
         if mine:
-            written += em.checkpoint_write_dirty(sorted(mine))
+            wrote = em.checkpoint_write_dirty_paths(sorted(mine))
+            written += len(wrote); _CKPT_JUST_WRITTEN.update(wrote)
         try:                                   # the assembly document for the leaf (T323 stage 4a): from a whole entry
             if em.asm_checkpoint_write(leaf, sid, _display_sdk_human(sid), tree=_stored_tree(leaf, sid)):   # with a compaction
                 written += 1                   #  boundary, else a counted skip; the store's tree, when it holds one, gives the

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1038,9 +1038,32 @@ class KernelFolds(Base):
         self.assertTrue(em.checkpoint_write(self.leaf, force=True))
         self.assertEqual((self.doc(self.leaf)["count"], sorted(self.doc(self.leaf)["folds"])), (1990, ["near", "whole"]), "a small lag is written at its count")
 
+    def test_a_fold_stopped_beyond_the_bound_on_a_dirty_leaf_does_not_keep_the_pass_writing(self):
+        """Round three: a fold stopped more than the bound behind on a path dirty without a settle (the leaf mid-turn) was left out
+        by the writer and refused by the carry, its shape read None, and the pass rewrote the identical document every dirty
+        cycle. The candidate check knows the bound: such a fold is no candidate (it refolds once when it runs)."""
+        self._converge_world({"bgJudge": "missing"})
+        _write(self.leaf, [json.loads(l) for l in open(self.leaf)] + [_user("p%d" % i, "ux%d" % i, None, TS0 + 1000 + i) for i in range(400)])
+        stopped = {}
+        em.fold_records(stopped, self.leaf, list, lambda st, o: st + [1], ckpt="stopped")   # a sixth fold, run over the whole leaf...
+        stopped[self.leaf] = (2, stopped[self.leaf][1], [1, 1])                              # ...and stopped at count 2 (skipped since)
+        jd._bg_scan(self.leaf)                                                                 # the missing pairing: a real candidate
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 1, "one write, for the pairing")
+        self.assertNotIn("stopped", self.doc(self.leaf)["folds"])
+        seq = self.doc(self.leaf)["seq"]
+        for k in range(3):                                                                     # three dirty cycles: an append and a fold each
+            _write(self.leaf, [json.loads(l) for l in open(self.leaf)] + [_user("q%d" % k, "uq%d" % k, None, TS0 + 2000 + k)])
+            km._session_meta(self.leaf)
+            self.assertIn(self.leaf, em.checkpoint_dirty())
+            self.assertEqual(em.checkpoint_converge_candidates(), [], "a fold beyond the bound is no candidate")
+            self.assertEqual(km._converge_checkpoints(TS0 + 601 + k), 0)
+        self.assertEqual(self.doc(self.leaf)["seq"], seq, "no write over three dirty cycles")
+
     def test_a_fallback_forgets_the_documents_shape(self):
         """Review, low 4: _ckpt_fallback removed the document but left the pass believing it still carried every state."""
         self._converge_world({})
+        self.assertNotIn(self.leaf, em._CKPT_DOC_FOLDS, "a fresh process knows no shapes until it consults a document")
+        km._session_meta(self.leaf)                                       # the restore consults the document: its shape is known
         self.assertTrue(em._CKPT_DOC_FOLDS.get(self.leaf))
         em._ckpt_fallback(self.leaf, "guard", "test")
         self.assertNotIn(self.leaf, em._CKPT_DOC_FOLDS)
@@ -1048,16 +1071,24 @@ class KernelFolds(Base):
 
     def test_the_carry_refuses_a_same_size_edit_under_another_mtime(self):
         """Review, low 3: the carry checked the guard bytes alone, so an in-place edit outside them (a same-size rewrite under
-        another mtime) was laundered into a fresh document the restore then trusted. The carry asks the restore's verdict first."""
+        another mtime) was laundered into a fresh document the restore then trusted. The carry asks the restore's verdict first.
+        The gate is driven directly: the reader's entry is a plain whole read that consulted no document (so no restore fallback
+        removed it first), a cursor is planted at that entry, and the write's carry meets the document over the edited file. In
+        production the restore usually falls back before a write can carry, so this path is defensive."""
         self._converge_world({}, extra=("extraA",))
         recs = [json.loads(l) for l in open(self.leaf)]
         recs[1] = dict(recs[1], text="X" * len(recs[1].get("text", "")))   # a same-size edit inside the prefix, outside the guard
         _write(self.leaf, recs); os.utime(self.leaf, ns=(os.stat(self.leaf).st_atime_ns, os.stat(self.leaf).st_mtime_ns + 10 ** 9))
         self.fresh_process()
-        km._session_meta(self.leaf)                                       # the restore refuses the rewritten file (a fallback)...
-        self.assertTrue(em.checkpoint_stats()["fallbacks"])
-        self.assertTrue(em.checkpoint_write(self.leaf, force=True))       # ...and the write carries nothing from the void document
-        self.assertNotIn("extraA", self.doc(self.leaf)["folds"])
+        ent = em._read_jsonl_entry(self.leaf)                              # a whole read, no document consulted
+        self.assertEqual(ent[5], 0)
+        em._FOLD_REG["planted"] = {self.leaf: (ent[5] + len(ent[4]), ent[6], [1])}   # a cursor at that entry
+        self.addCleanup(em._FOLD_REG.pop, "planted", None)
+        self.assertTrue(os.path.exists(em._ckpt_file(self.leaf)), "the older document is still on disk when the write runs")
+        self.assertEqual(em.checkpoint_stats()["fallbacks"], {}, "no restore refused it first: the carry's own gate decides")
+        self.assertTrue(em.checkpoint_write(self.leaf, force=True))
+        self.assertEqual(sorted(self.doc(self.leaf)["folds"]), ["planted"], "the write carries nothing from a document the verdict calls a rewrite")
+        self.assertEqual(em.checkpoint_stats()["fallbacks"], {})
 
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -982,20 +982,82 @@ class KernelFolds(Base):
         self.assertIn("state", self.doc(self.leaf)["folds"]["extraA"], "...and the pass writes its state")
 
     def test_a_path_the_settle_wrote_is_not_written_again_by_the_pass_in_the_same_cycle(self):
-        """Review, low 4: a settling file was written twice in one cycle (the settle write, then the pass, identical documents).
-        The pass skips the paths the settle just wrote."""
-        self._converge_world({"bgJudge": "missing"})
-        jd._bg_scan(self.leaf)
+        """Review, low 4: a settling session's states log whose fold began cold (a legacy bare cursor) while the log's other folds
+        hold cursors was written twice in one cycle: the settle write (dropping the cold cursor), then the pass again for the
+        cold mark that survived the drop (seq 2 to 3, identical documents). The drop clears the mark and the pass skips the
+        paths the settle just wrote."""
+        self._converge_world({})
+        d = self.doc(self.states); d["folds"]["lastState"] = {"count": d["folds"]["lastState"]["count"]}   # the log's legacy cursor
+        em._ckpt_file(self.states).write_text(json.dumps(d))
+        self.fresh_process()
+        km._states_notes(SID); km._last_state(SID)                 # one fold restored at the witness, one cold
+        self.assertEqual(em.cold_fold_reasons(self.states), {"lastState": "cold"})
+        with open(self.states, "a") as f:                            # the settle's evidence: a states-log row, and a fold over it
+            f.write(json.dumps({"t": TS0 + 480, "state": "idle"}) + "\n")
+        km._states_notes(SID)                                        # ...stepped, so the log is dirty for the settle write
+        self.assertIn(self.states, em.checkpoint_dirty())
         saved_turn = km._turn_end_key; turn_end = [TS0]
         km._turn_end_key = lambda sid, reg=None: turn_end[0]
         self.addCleanup(setattr, km, "_turn_end_key", saved_turn)
         self.assertEqual(km._persist_checkpoints(TS0 + 499), 0, "first sight")
         turn_end[0] = TS0 + 500
-        self.assertGreaterEqual(km._persist_checkpoints(TS0 + 501), 1, "the settle writes the leaf")
-        seq = self.doc(self.leaf)["seq"]
+        self.assertGreaterEqual(km._persist_checkpoints(TS0 + 501), 1, "the settle writes the session's files")
+        seq = self.doc(self.states)["seq"]
+        self.assertNotIn("lastState", self.doc(self.states)["folds"], "the cold cursor dropped: left out, to refold whole at its next run")
         self.assertEqual(km._converge_checkpoints(TS0 + 501), 0, "the pass writes nothing for it this cycle")
-        self.assertEqual(self.doc(self.leaf)["seq"], seq, "one write per path per cycle")
-        self.assertIn("bgJudge", self.doc(self.leaf)["folds"], "the settle's write carried the pairing")
+        self.assertEqual(self.doc(self.states)["seq"], seq, "one write per path per cycle")
+
+    def test_a_fold_far_behind_the_entry_is_left_out_so_it_cannot_drag_the_cut(self):
+        """Review: a carried (or lagging) fold at a low count moved the document's cut back to it, and every later boot read from
+        that count to the end and held those records resident (a 2000-record leaf carrying one fold at count 1: the next boot
+        read the file whole where it had read 128 bytes). Both the writer's own lagging cursors and the carry stop at 64 records
+        or an eighth of the entry behind; further behind the fold is left out and refolds whole once when it next runs."""
+        _write(self.leaf, [_user("p%d" % i, "u%d" % i, None, TS0 + i) for i in range(2000)])
+        early = {}
+        em.fold_records(early, self.leaf, list, lambda st, o: st + [1], ckpt="early")   # runs over 1 record...
+        early[self.leaf] = (1, early[self.leaf][1], [1])                                 # ...and stopped at count 1 (a skipped fold)
+        self.fold_leaf = lambda: em.fold_records({}, self.leaf, list, lambda st, o: st + [1], ckpt="whole")
+        self.fold_leaf()
+        self.assertTrue(em.checkpoint_write(self.leaf, force=True))
+        d = self.doc(self.leaf)
+        self.assertEqual((d["count"], sorted(d["folds"])), (2000, ["whole"]), "the fold 1999 behind is left out, the cut stays at the witness")
+        d["folds"]["early"] = {"count": 1, "state": em._ckpt_encode([1])}                  # the same fold carried from an older document
+        em._ckpt_file(self.leaf).write_text(json.dumps(d))
+        self.fresh_process()
+        self.fold_leaf()                                                                    # a restore; the write must not carry count 1
+        self.assertTrue(em.checkpoint_write(self.leaf, force=True))
+        d = self.doc(self.leaf)
+        self.assertEqual((d["count"], sorted(d["folds"])), (2000, ["whole"]), "the carry stops at the bound too")
+        self.fresh_process()
+        size = os.path.getsize(self.leaf)
+        self.fold_leaf()
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0), 512, "the next boot reads the tail only: %d of %d bytes" % (em.read_bytes_report().get(self.leaf, 0), size))
+        near = {}
+        em.fold_records(near, self.leaf, list, lambda st, o: st + [1], ckpt="near")
+        near[self.leaf] = (1990, near[self.leaf][1], [1] * 1990)                           # ten behind: inside the bound
+        self.assertTrue(em.checkpoint_write(self.leaf, force=True))
+        self.assertEqual((self.doc(self.leaf)["count"], sorted(self.doc(self.leaf)["folds"])), (1990, ["near", "whole"]), "a small lag is written at its count")
+
+    def test_a_fallback_forgets_the_documents_shape(self):
+        """Review, low 4: _ckpt_fallback removed the document but left the pass believing it still carried every state."""
+        self._converge_world({})
+        self.assertTrue(em._CKPT_DOC_FOLDS.get(self.leaf))
+        em._ckpt_fallback(self.leaf, "guard", "test")
+        self.assertNotIn(self.leaf, em._CKPT_DOC_FOLDS)
+        self.assertEqual(em.checkpoint_stats()["fallbacks"].get("guard"), 1)
+
+    def test_the_carry_refuses_a_same_size_edit_under_another_mtime(self):
+        """Review, low 3: the carry checked the guard bytes alone, so an in-place edit outside them (a same-size rewrite under
+        another mtime) was laundered into a fresh document the restore then trusted. The carry asks the restore's verdict first."""
+        self._converge_world({}, extra=("extraA",))
+        recs = [json.loads(l) for l in open(self.leaf)]
+        recs[1] = dict(recs[1], text="X" * len(recs[1].get("text", "")))   # a same-size edit inside the prefix, outside the guard
+        _write(self.leaf, recs); os.utime(self.leaf, ns=(os.stat(self.leaf).st_atime_ns, os.stat(self.leaf).st_mtime_ns + 10 ** 9))
+        self.fresh_process()
+        km._session_meta(self.leaf)                                       # the restore refuses the rewritten file (a fallback)...
+        self.assertTrue(em.checkpoint_stats()["fallbacks"])
+        self.assertTrue(em.checkpoint_write(self.leaf, force=True))       # ...and the write carries nothing from the void document
+        self.assertNotIn("extraA", self.doc(self.leaf)["folds"])
 
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -91,7 +91,9 @@ class Base(unittest.TestCase):
         (jd.STATE / "timeline").mkdir(parents=True, exist_ok=True)
         self.fresh_process()
         em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={}, restoredFolds={}, droppedRestores=0, oversizeFolds={},
-                              coldFolds={}, coldWrites={}, converge={"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0})
+                              coldFolds={}, coldWrites={})
+        if "converge" in em._CKPT_STATS:                          # reset, never injected: the /perf key pin tests the production default
+            em._CKPT_STATS["converge"] = {k: 0 for k in em._CKPT_STATS["converge"]}
 
     def tearDown(self):
         jd._rebind_state(self.saved_state)
@@ -816,11 +818,14 @@ class KernelFolds(Base):
         self.assertEqual(em.checkpoint_stats()["coldFolds"].get("bgAll", 0), cold_before, "and not cold")
         self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2, "and reads no leaf whole")
 
-    def _converge_world(self, strip):
+    def _converge_world(self, strip, extra=()):
         """Documents for every file, then the leaf's document with `strip`'s folds removed or reduced to bare cursors (what an
-        older kernel, or a kernel where the fold never ran, left behind), then a fresh process."""
+        older kernel, or a kernel where the fold never ran, left behind), then a fresh process. `extra` names generic folds
+        run over the leaf beside the five leaf folds (the transcript's wake-tail and queue-ledger folds in production)."""
         self.write_all(tail=False)
         self.answers()
+        for name in extra:
+            em.fold_records({}, self.leaf, list, lambda st, o: st + [1], ckpt=name)
         for p in self.files:
             em.checkpoint_write(p)
         d = self.doc(self.leaf)
@@ -913,8 +918,88 @@ class KernelFolds(Base):
         self.assertEqual(km._converge_checkpoints(TS0 + 601), 1, "the next pass takes it")
         self.assertEqual(em.checkpoint_converge_candidates(), [])
 
+    def test_converge_budget_holds_when_the_first_candidate_writes_nothing(self):
+        """Review, medium 1: the budget was gated on documents WRITTEN, so a first candidate that wrote nothing (a non-leaf whose
+        only cold cursor was dropped, a failed write) let the pass heal every remaining leaf whole. Gated on candidates
+        processed now, and the empty write is counted."""
+        self._converge_world({"bgJudge": "missing"})
+        a = str(self.td / "aaa.jsonl")                                # sorts before the leaves: the first candidate
+        _write(a, [{"n": 0}, {"n": 1}])
+        em.fold_records({}, a, list, lambda st, o: st + [o["n"]], ckpt="gen")
+        em.checkpoint_write(a, force=True)
+        d = self.doc(a); d["folds"]["gen"] = {"count": d["folds"]["gen"]["count"]}; em._ckpt_file(a).write_text(json.dumps(d))
+        leaf2 = str(self.proj / ("bbbbbbbb-2222-3333-4444-555555555555.jsonl"))
+        import shutil; shutil.copy(self.leaf, leaf2)
+        self.fresh_process()
+        km._sessions = lambda now, **kw: [{"sid": SID, "path": self.leaf}, {"sid": "bbbbbbbb-2222-3333-4444-555555555555", "path": leaf2}]
+        em.fold_records({}, a, list, lambda st, o: st + [o["n"]], ckpt="gen")   # cold: the first candidate, writing nothing
+        jd._bg_scan(self.leaf); jd._bg_scan(leaf2)
+        self.assertEqual(em.checkpoint_converge_candidates(), [a, self.leaf, leaf2])
+        saved = (km.CKPT_CONVERGE_MS, km.CKPT_CONVERGE_BYTES); km.CKPT_CONVERGE_MS, km.CKPT_CONVERGE_BYTES = 0.0, 1
+        self.addCleanup(lambda: setattr(km, "CKPT_CONVERGE_MS", saved[0])); self.addCleanup(lambda: setattr(km, "CKPT_CONVERGE_BYTES", saved[1]))
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0, "the empty first candidate, then the budget")
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["deferred"], cv["heals"], cv["failed"], cv["unhealed"]), (2, 0, 1, 1), "nothing healed past the budget: %s" % cv)
+
+    def test_converge_keeps_the_states_of_folds_this_process_never_ran(self):
+        """Review, medium 2: a converge write rebuilt the document from this process's cursors, stripping the states of folds it
+        never ran (the transcript's wake-tail and queue-ledger folds beside the five leaf folds), and the next boot read the
+        leaf whole for them. Every write merges the on-disk document's states for such folds (verified by its guard)."""
+        self._converge_world({"bgJudge": "missing"}, extra=("extraA", "extraB"))
+        self.assertEqual(len(self.doc(self.leaf)["folds"]), 6, "five leaf folds less the stripped one, plus two extra")
+        jd._bg_scan(self.leaf)
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 1)
+        d = self.doc(self.leaf)
+        self.assertEqual(sorted(d["folds"]), ["agentLaunches", "bgAll", "bgJudge", "bgRunning", "extraA", "extraB", "sessionMeta"], "seven: the two carried")
+        self.assertTrue(all("state" in f for f in d["folds"].values()))
+        self.fresh_process()
+        self.assertEqual(em.fold_records({}, self.leaf, list, lambda st, o: st + [1], on=self.kinds_sink(), ckpt="extraA"), [1] * 4)
+        self.assertEqual(self._kinds[-1], "restore", "the next boot restores the carried fold")
+
+    def kinds_sink(self):
+        self._kinds = []
+        return self._kinds.append
+
+    def test_converge_drops_an_unhealable_cold_fold_once_and_the_next_boot_completes_it(self):
+        """Review, medium 3: a cold fold the heal cannot rerun (not one of the leaf's five) kept its path a candidate for the
+        kernel's life, one write every cycle. Its cursor and cold mark are dropped (counted unhealed), the write leaves it out,
+        the pass writes once, and the next boot reads the leaf whole for that fold and writes its state."""
+        self._converge_world({}, extra=("extraA",))
+        d = self.doc(self.leaf); d["folds"]["extraA"] = {"count": d["folds"]["extraA"]["count"]}; em._ckpt_file(self.leaf).write_text(json.dumps(d))
+        self.fresh_process()
+        km._session_meta(self.leaf)
+        em.fold_records({}, self.leaf, list, lambda st, o: st + [1], on=self.kinds_sink(), ckpt="extraA")
+        self.assertEqual(self._kinds[-1], "cold"); self.assertEqual(em.cold_fold_reasons(self.leaf), {"extraA": "cold"})
+        self.assertEqual(em.checkpoint_converge_candidates(), [self.leaf])
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 1)
+        self.assertEqual(em.checkpoint_stats()["converge"]["unhealed"], 1)
+        self.assertNotIn("extraA", self.doc(self.leaf)["folds"]); self.assertEqual(em.cold_fold_reasons(self.leaf), {})
+        self.assertEqual(em.checkpoint_converge_candidates(), []); self.assertEqual(km._converge_checkpoints(TS0 + 601), 0, "once")
+        self.fresh_process()
+        em.fold_records({}, self.leaf, list, lambda st, o: st + [1], on=self.kinds_sink(), ckpt="extraA")
+        self.assertEqual(self._kinds[-1], "refold", "the next boot reads the leaf whole for it, once")
+        self.assertEqual(km._converge_checkpoints(TS0 + 700), 1)
+        self.assertIn("state", self.doc(self.leaf)["folds"]["extraA"], "...and the pass writes its state")
+
+    def test_a_path_the_settle_wrote_is_not_written_again_by_the_pass_in_the_same_cycle(self):
+        """Review, low 4: a settling file was written twice in one cycle (the settle write, then the pass, identical documents).
+        The pass skips the paths the settle just wrote."""
+        self._converge_world({"bgJudge": "missing"})
+        jd._bg_scan(self.leaf)
+        saved_turn = km._turn_end_key; turn_end = [TS0]
+        km._turn_end_key = lambda sid, reg=None: turn_end[0]
+        self.addCleanup(setattr, km, "_turn_end_key", saved_turn)
+        self.assertEqual(km._persist_checkpoints(TS0 + 499), 0, "first sight")
+        turn_end[0] = TS0 + 500
+        self.assertGreaterEqual(km._persist_checkpoints(TS0 + 501), 1, "the settle writes the leaf")
+        seq = self.doc(self.leaf)["seq"]
+        self.assertEqual(km._converge_checkpoints(TS0 + 501), 0, "the pass writes nothing for it this cycle")
+        self.assertEqual(self.doc(self.leaf)["seq"], seq, "one write per path per cycle")
+        self.assertIn("bgJudge", self.doc(self.leaf)["folds"], "the settle's write carried the pairing")
+
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()
+        self.assertIn("converge", em._CKPT_STATS, "the production default carries the converge counters (the fixture injects nothing)")
         self.assertEqual(sorted(snap["checkpoints"]), ["coldFolds", "coldWrites", "converge", "dirty", "documentBytes", "droppedRestores", "fallbacks", "oversizeFolds",
                                                         "readByPath", "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
         src = open(os.path.join(BIN, "romp-kernel")).read()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -91,7 +91,7 @@ class Base(unittest.TestCase):
         (jd.STATE / "timeline").mkdir(parents=True, exist_ok=True)
         self.fresh_process()
         em._CKPT_STATS.update(restored=0, writes=0, swept=0, skippedFolds=0, fallbacks={}, restoredFolds={}, droppedRestores=0, oversizeFolds={},
-                              coldFolds={}, coldWrites={})
+                              coldFolds={}, coldWrites={}, converge={"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0})
 
     def tearDown(self):
         jd._rebind_state(self.saved_state)
@@ -816,10 +816,107 @@ class KernelFolds(Base):
         self.assertEqual(em.checkpoint_stats()["coldFolds"].get("bgAll", 0), cold_before, "and not cold")
         self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2, "and reads no leaf whole")
 
+    def _converge_world(self, strip):
+        """Documents for every file, then the leaf's document with `strip`'s folds removed or reduced to bare cursors (what an
+        older kernel, or a kernel where the fold never ran, left behind), then a fresh process."""
+        self.write_all(tail=False)
+        self.answers()
+        for p in self.files:
+            em.checkpoint_write(p)
+        d = self.doc(self.leaf)
+        for name, how in strip.items():
+            if how == "missing":
+                d["folds"].pop(name, None)
+            else:
+                d["folds"][name] = {"count": d["folds"][name]["count"]}
+        em._ckpt_file(self.leaf).write_text(json.dumps(d))
+        self.fresh_process()
+        rows = [{"sid": SID, "path": self.leaf}]
+        self._saved_sessions = km._sessions
+        km._sessions = lambda now, **kw: rows
+        self.addCleanup(setattr, km, "_sessions", self._saved_sessions)
+
+    def test_converge_writes_the_folds_a_boot_ran_whole_and_the_next_boot_restores_them(self):
+        """T360: a fold missing from a document (it never ran in the writing process) is read whole at the next boot, and that
+        cost was paid at EVERY boot because an idle session never settles, so its document was never rewritten (the devbox:
+        the judges' pairing missing from 39 of 60 documents, 2.4 GB per boot). The converge pass, on the pusher's cycle, writes
+        a dirty document that lacks a state this process now holds; over the whole entry the boot's read left, every leaf
+        fold is primed first, so one write carries all five and the next boot restores them."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"})
+        size = os.path.getsize(self.leaf)
+        jd._bg_scan(self.leaf)                                        # the judges' first pass: no document entry, a whole refold
+        self.assertGreaterEqual(em.read_bytes_report().get(self.leaf, 0), size, "the boot paid the whole read")
+        self.assertEqual(em.checkpoint_converge_candidates(), [self.leaf], "a dirty document lacking a fold this process holds")
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 1)
+        self.assertEqual(sorted(self.doc(self.leaf)["folds"]), ["agentLaunches", "bgAll", "bgJudge", "bgRunning", "sessionMeta"],
+                         "the write carries every leaf fold: the four others primed over the whole entry")
+        self.assertTrue(all("state" in f for f in self.doc(self.leaf)["folds"].values()))
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["writes"], cv["primed"]), (1, 1)); self.assertGreater(cv["bytes"], 0)
+        self.assertEqual(em.checkpoint_converge_candidates(), [], "nothing left to converge")
+        self.assertEqual(km._converge_checkpoints(TS0 + 601), 0, "idempotent: the second pass writes nothing")
+        self.assertEqual(em.checkpoint_stats()["converge"]["writes"], 1)
+        self.fresh_process()
+        before = em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0)
+        jd._bg_scan(self.leaf)
+        self.assertEqual(em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0), before + 1, "the next boot restores the pairing warm")
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2, "and reads no leaf whole")
+
+    def test_converge_leaves_a_document_that_carries_every_fold_alone(self):
+        """Idempotence on a live session: its leaf is dirty every turn, but its document carries every fold that ran, so the
+        converge pass never rewrites it (the settle does); no steady stream of writes."""
+        self._converge_world({})
+        km._session_meta(self.leaf)                                   # a restore: not dirty
+        _append(self.leaf, _user("another prompt", "u_more", "a3", TS0 + 700))
+        km._session_meta(self.leaf); km._bg_scan_all_cached(self.leaf)   # appends: dirty, the document's folds all present
+        self.assertIn(self.leaf, em.checkpoint_dirty())
+        self.assertEqual(em.checkpoint_converge_candidates(), [], "a document carrying every fold that ran is not a candidate")
+        self.assertEqual(km._converge_checkpoints(TS0 + 701), 0)
+        self.assertEqual(em.checkpoint_stats()["converge"]["writes"], 0)
+        self.assertIn(self.leaf, em.checkpoint_dirty(), "...and stays dirty for the settle")
+
+    def test_converge_heals_an_idle_sessions_legacy_bare_cursor_once(self):
+        """T360 (2): the legacy bare cursors of idle sessions (18 on the devbox), which no settle reaches: the converge pass heals
+        the fold with one whole refold under its budget and writes the state; the next boot restores it warm."""
+        self._converge_world({"bgAll": "bare"})
+        size = os.path.getsize(self.leaf)
+        km._session_meta(self.leaf); km._bg_scan_all_cached(self.leaf)
+        self.assertEqual(em.cold_fold_reasons(self.leaf), {"bgAll": "cold"})
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2, "the boot itself read the tail only")
+        self.assertEqual(em.checkpoint_converge_candidates(), [self.leaf])
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 1)
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual(cv["heals"], 1); self.assertGreaterEqual(cv["healBytes"], size, "the heal's whole read is counted against the budget")
+        self.assertIn("state", self.doc(self.leaf)["folds"]["bgAll"]); self.assertEqual(em.cold_fold_reasons(self.leaf), {})
+        self.assertEqual(km._converge_checkpoints(TS0 + 601), 0)
+        self.fresh_process()
+        before = em.checkpoint_stats()["restoredFolds"].get("bgAll", 0)
+        km._bg_scan_all_cached(self.leaf)
+        self.assertEqual(em.checkpoint_stats()["restoredFolds"].get("bgAll", 0), before + 1)
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2)
+
+    def test_converge_is_bounded_per_cycle_in_bytes_and_defers_the_rest(self):
+        """The budget: a second leaf (a copy) with the same gap; with a one-byte budget the pass writes the first candidate and
+        defers the second (counted), the next pass takes it. The knobs: CKPT_CONVERGE_MS and CKPT_CONVERGE_BYTES."""
+        self._converge_world({"bgJudge": "missing"})
+        leaf2 = str(self.proj / ("bbbbbbbb-2222-3333-4444-555555555555.jsonl"))
+        import shutil; shutil.copy(self.leaf, leaf2)
+        rows = [{"sid": SID, "path": self.leaf}, {"sid": "bbbbbbbb-2222-3333-4444-555555555555", "path": leaf2}]
+        km._sessions = lambda now, **kw: rows
+        jd._bg_scan(self.leaf); jd._bg_scan(leaf2)                    # both read whole, both dirty, both lacking the pairing
+        self.assertEqual(sorted(em.checkpoint_converge_candidates()), sorted([self.leaf, leaf2]))
+        saved = km.CKPT_CONVERGE_BYTES; km.CKPT_CONVERGE_BYTES = 1
+        self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved)
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 1, "the first always writes; the budget stops the second")
+        self.assertEqual(em.checkpoint_stats()["converge"]["deferred"], 1)
+        self.assertEqual(len(em.checkpoint_converge_candidates()), 1)
+        self.assertEqual(km._converge_checkpoints(TS0 + 601), 1, "the next pass takes it")
+        self.assertEqual(em.checkpoint_converge_candidates(), [])
+
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()
-        self.assertEqual(sorted(snap["checkpoints"]), ["coldFolds", "coldWrites", "dirty", "documentBytes", "droppedRestores", "fallbacks", "oversizeFolds", "readByPath",
-                                                        "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
+        self.assertEqual(sorted(snap["checkpoints"]), ["coldFolds", "coldWrites", "converge", "dirty", "documentBytes", "droppedRestores", "fallbacks", "oversizeFolds",
+                                                        "readByPath", "readBytes", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("em.checkpoint_write_dirty(budget_s=EXIT_CKPT_WRITE_BUDGET_S)", src,
                       "exit writes the dirty checkpoints in _drain_and_exit, bounded (2026-09-11: unbounded, it met the manager's SIGKILL)")


### PR DESCRIPTION
Tier: fix

**Bug.** After #1489 the devbox's boots still read 2.4 GB of leaves whole (36.5 s first cycle): of 60 leaf documents only 7 had been written after the deploy, the judges' pairing fold was missing from 39 and the agent-launch state from 51. A fold that never ran in the process that wrote a document has no entry there, so the next kernel reads the leaf whole for it; and a session with no new turns never settles, so its document is never rewritten: the same whole read at every boot, forever. The exit drain's budgeted write of dirty paths catches a few (the 7).

**Fix.** The pusher's cycle runs a converge pass after the settle writes (`_converge_checkpoints`): the dirty documents that lack a complete state this process holds (a fold missing from the document, a legacy bare cursor, a tail-only one; `em.checkpoint_converge_candidates` reads the document's shape as last written or loaded, no file read; a cold fold at the witness marks nothing dirty, so the cold set joins the candidates) are written independent of settle evidence, bounded per cycle by `ROMP_CKPT_CONVERGE_MS` (150 ms of wall) and `ROMP_CKPT_CONVERGE_MB` (8 MB of documents written plus leaf bytes read for a heal); the first candidate always goes, the rest wait for the next cycle, counted as `deferred`. Over the whole entry a boot's read left, every leaf fold is primed first (a step over records in hand, no read), so one write carries all five; a legacy bare cursor is healed under the same budget (one whole read, counted), which reaches the idle sessions no settle does. A document that already carries every fold that ran is never a candidate: a live session's leaf, dirty every turn, is still written at its settle only, and an idle session's document is written once and left alone. Counters under `/perf` `checkpoints.converge` (`passes`, `writes`, `bytes`, `heals`, `healBytes`, `primed`, `deferred`).

**Cost, bounded and measured** (six sessions of the 4000-turn fixture, the documents stripped to the devbox's census in miniature, no settle; script and log under the research state): the pass converges the six documents within four passes over three cycles, writing 6 documents and 6085 bytes in all, healing 6 bare cursors (3.8 KB read: the entries were whole-resident after the judges' read), priming 6, deferring 9 to later cycles under the budget; the counters then stay flat through cycle 11 (idempotent). The next boot restores every fold (cold folds none, zero cold lines) where the base's next boot still had all six background folds cold. The knobs above bound the steady state: a document is written only when the disk lacks a state the process holds.

**Tests** (`tests/test_fold_checkpoints.py`, red before): a document missing two folds is written after the boot's whole read with all five folds and the next boot restores them warm; a second pass writes nothing; a live session's dirty leaf whose document carries every fold is never rewritten by the pass; an idle session's legacy bare cursor is healed once under the budget and restored warm at the next boot; a one-byte budget writes the first candidate and defers the second, counted, and the next pass takes it; the `/perf` key pin carries `converge`.

**Live measurement** across the next two boots after the deploy (first-cycle wall, cold folds, missing folds per document, read bytes) against tonight's 36.5 s / 2.42 GB and the 60-document census follows in the head mail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
