### PR TITLE
Boot re-delivery drops stale sends behind an age line; romp send reports a late answer honestly

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1569,9 +1569,28 @@ w=sys.argv[2] if len(sys.argv)>2 else ""
 if w: d["when"]=w
 print(json.dumps(d))' "$_who" "$_when")"
     fi
-    _resp="$(_romp_token_cfg | curl -sf -m 10 --config - -X POST "http://127.0.0.1:$_kport/$_verb" \
-                  -H 'Content-Type: application/json' -d "$_payload")" \
-        || { echo "romp $_verb: kernel not reachable on :$_kport (is romp running?)" >&2; exit 1; }
+    # The exit code says what HAPPENED, not what curl felt (2026-09-12). Until this change every curl failure
+    # wore one message, "kernel not reachable", and exit 1 — including a TIMEOUT (curl 28) on a kernel that
+    # had already taken the request and delivered it but answered late (a boot storm: the minutes after a
+    # restart, the box under load). A caller that retries on a non-zero exit then re-sends a delivered message
+    # every time — one wake service sent nine copies of each wake twenty seconds apart after a restart. So:
+    # a connection the kernel never took (curl 7, 6, 52) is "not reachable", exit 1, nothing sent; a timeout
+    # AFTER the request went out is exit 3 with the truth — the message may have been delivered, do not retry
+    # blindly; a refusal the kernel wrote is its own words, exit 1 (below). The cap is ROMP_KERNEL_HTTP_TIMEOUT_S
+    # (default 10 s), so a slow box can widen it and a test can shrink it.
+    _cap="${ROMP_KERNEL_HTTP_TIMEOUT_S:-10}"
+    _crc=0
+    _resp="$(_romp_token_cfg | curl -sf -m "$_cap" --config - -X POST "http://127.0.0.1:$_kport/$_verb" \
+                  -H 'Content-Type: application/json' -d "$_payload")" || _crc=$?   # `|| ...`: survives set -e
+    if [[ $_crc -ne 0 ]]; then
+        case $_crc in
+            28) echo "romp $_verb: the kernel on :$_kport took the request but did not answer within ${_cap}s" \
+                     "(mid-restart or under load) — it may already have $([[ "$_verb" == send ]] && echo 'delivered the message' || echo 'acted on it');" \
+                     "do not retry blindly (ROMP_KERNEL_HTTP_TIMEOUT_S widens the wait)" >&2; exit 3 ;;
+            22) echo "romp $_verb: the kernel refused the request (HTTP error) — not delivered" >&2; exit 1 ;;
+            *)  echo "romp $_verb: kernel not reachable on :$_kport (is romp running?) [curl exit $_crc]" >&2; exit 1 ;;
+        esac
+    fi
     if [[ "$_resp" == *'"ok": true'* || "$_resp" == *'"ok":true'* ]]; then
         if [[ "$_verb" == "send" && ( "$_resp" == *'"queued": true'* || "$_resp" == *'"queued":true'* ) ]]; then
             # the kernel PARKED it (a turn is open / compacting / the account is limit-held) and delivers it

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3193,6 +3193,30 @@ BOOT_RESUME_CONCURRENCY = max(1, int(os.environ.get("ROMP_BOOT_RESUME_CONCURRENC
 # Backstop ONLY (never the mechanism): a CLI that wedges before init would otherwise hold its slot
 # forever and trap the whole sweep — after this long the sweep proceeds anyway, loudly.
 BOOT_RESUME_SLOT_S = float(os.environ.get("ROMP_BOOT_RESUME_SLOT_S", "180"))
+# The re-delivery AGE LINE (2026-09-12). The boot and dead-spawn re-delivery arm (_mark_dropped_echoes) re-feeds
+# a human send whose text the transcript scan cannot find. That scan is only as good as its reading of the
+# transcript, and a landing it cannot see is re-fed at EVERY restart, forever: a kernel whose scan read only
+# native user records (never the queued_command attachment a mid-turn feed lands as) and only the last 2 MB of
+# the file re-fed 194 sends across 13 sessions at one restart and 264 at the next, the same texts each time,
+# some three days old, one text landing six times (measured 2026-09-12). A send older than this at the restart
+# is not re-fed and not scanned (a mark-less echo streams the whole transcript): it takes the flag path
+# (dropped, kept in the chat as never-delivered) and ONE notice names the count and the oldest stamp, so nothing
+# drops silently. The queue proper (reg['queue'], sends never fed) is NOT under this line: those are the
+# person's words waiting their turn, however long the kernel was down. Seconds; 0 switches the line off.
+REDELIVER_MAX_AGE_S = float(os.environ.get("ROMP_REDELIVER_MAX_AGE_S", "1800"))
+
+
+def stale_redelivery_notice(n: int, oldest_t: float, max_age_s: float) -> str:
+    """The ONE line a session reads when the restart's re-delivery dropped `n` sends as stale (REDELIVER_MAX_AGE_S).
+    Same sanctioned [romp] mechanics family as the restart notice: it is about the restart's own bookkeeping."""
+    when = time.strftime("%Y-%m-%d %H:%M", time.localtime(oldest_t))
+    one = n == 1
+    return ("<!-- romp-injected --><!-- romp-system -->[romp] %d queued message%s from before the restart %s "
+            "dropped as stale (older than %s); the oldest was from %s. None of them was re-delivered; anything "
+            "that still matters has to be sent again."
+            "<!-- romp-gist: %d stale message%s dropped at the restart -->"
+            % (n, "" if one else "s", "was" if one else "were", _gap_text(int(max_age_s)), when,
+               n, "" if one else "s"))
 # The UserPromptSubmit hook's WALL-TIME CAP (2026-09-12). The SDK runs SdkSession._prompt_submit_hook
 # for every prompt a session receives and REFUSES the prompt when the hook misses the CLI's own hook
 # deadline (about 30 s), instead of failing open — under a host load of 100 to 300 on 64 cores the
@@ -8297,6 +8321,12 @@ class SdkSession:
         self.backend._log("cron dedupe (%s): blocked a replayed schedule fire — its %s slot was "
                           "already delivered (a fresh process re-fires passed slots on resume)"
                           % (self.name, when), problem=False)
+        mark = getattr(self.backend, "mark_echo_refused", None)
+        if callable(mark):
+            try:                                   # off the loop thread like the reg write; never decides the block
+                await asyncio.to_thread(mark, self.sid, prompt, "replayed schedule slot")
+            except Exception as e:
+                self.backend._log("cron dedupe (%s): refused-echo mark failed: %s" % (self.name, e))
         return {"decision": "block",
                 "reason": "This scheduled prompt already ran for its %s slot — skipping the "
                           "duplicate." % when}
@@ -12511,6 +12541,9 @@ class SdkBackend:
                     e["fsid"] = str(a.get("_echo_fsid") or "")
                 if a.get("_landed"):
                     e["landed"] = True            # the boot/spawn scan found its record: prune_live retires it
+                for flag in ("stale", "refused"):
+                    if a.get(flag):
+                        e[flag] = True            # WHY it was dropped (the age line / the prompt gate), for the chat
                 snap.append(e)
         try:
             self._update_reg(sid, echoes=snap)
@@ -12545,6 +12578,9 @@ class SdkBackend:
                     atom["dropped"] = True
                     if hasattr(self, "forget_fed"):      # a stand-in backend in tests borrows this method without the ledger
                         self.forget_fed(reg["sid"], atom.get("uuid"))   # its landing will never come (T252c)
+                for flag in ("stale", "refused"):
+                    if e.get(flag):
+                        atom[flag] = True                # the reason rides with the flag (2026-09-12)
                 if isinstance(e.get("off"), int) and not isinstance(e.get("off"), bool):
                     atom["_echo_off"], atom["_echo_fsid"] = e["off"], str(e.get("fsid") or "")
                 if e.get("landed"):
@@ -12622,10 +12658,18 @@ class SdkBackend:
         # romp-authored echoes (nudges) keep the flag path: re-delivering one could double-nudge,
         # and its content is regenerable machinery, not the user's words. A refeed=False caller
         # (the resumable reconnect — docstring above) keeps EVERY echo on the flag path.
-        redeliver, landed, outrun = [], set(), set()
+        redeliver, landed, outrun, stale = [], set(), set(), []
+        now = time.time()
         if refeed:
             for a in sorted(newly, key=lambda x: x.get("t") or 0):
                 if a.get("author") != "human":
+                    continue
+                # The AGE LINE (REDELIVER_MAX_AGE_S) runs BEFORE the scans: a send older than it at this restart is
+                # not re-fed whatever the transcript says, and is not scanned either (2026-09-12: a scan that could
+                # not see a landing re-fed the same days-old texts at every restart; the line ends that at one).
+                t0 = int(a.get("t") or 0)
+                if REDELIVER_MAX_AGE_S > 0 and t0 and now - t0 > REDELIVER_MAX_AGE_S:
+                    stale.append(a)
                     continue
                 seen = self._text_landed(sid, a["_echo_text"], a.get("t"),
                                          a.get("_echo_off"), a.get("_echo_fsid"))
@@ -12647,7 +12691,9 @@ class SdkBackend:
                     landed.add(a["_echo_text"])
                     with self._live_lock:
                         self._touch_live(sid)              # a flag write outside the lock: still a change to the tail
-        if redeliver:
+        notice = (stale_redelivery_notice(len(stale), min(int(a.get("t") or 0) for a in stale), REDELIVER_MAX_AGE_S)
+                  if stale else None)
+        if redeliver or notice:
             # The LIVE-session caller (a fresh spawn's _run) must deliver through the session's
             # own queue: there the in-memory _pending is authoritative and its very next
             # _persist_queue snapshot rewrites reg['queue'] — a reg-only write sat in limbo (echo
@@ -12671,6 +12717,8 @@ class SdkBackend:
                     _enqueue_with_id(s, a["_echo_text"], a.get("uuid"), a.get("t"))   # under the echo's own id (T252c)
                     self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
                               % (sid[:8], a["_echo_text"]))
+                if notice and notice not in have:
+                    s.enqueue(notice)                      # one line, behind the re-delivered sends, no identity
             else:
                 with self._reg_lock:
                     reg = read_reg(self.state_dir, sid)
@@ -12681,6 +12729,8 @@ class SdkBackend:
                         _have = [{"md": t, "qid": (m or {}).get("qid")} for t, m in zip(have, queue_meta_from_reg(reg))]
                         adds = [a for a in redeliver if not _echo_queued_in(a, _have)]
                         add = [a["_echo_text"] for a in adds]
+                        if notice and notice not in have:
+                            add.append(notice)             # one line, behind the re-delivered sends, no identity
                         if add:
                             reg["queue"] = have + add      # behind the surviving queue: original send order
                             # each re-delivered copy keeps the echo's uuid as its id (T252c): the seed restores it
@@ -12692,16 +12742,21 @@ class SdkBackend:
                                 self._log("%s: re-delivering a typed send the dead CLI was holding: %.80r"
                                           % (sid[:8], a["_echo_text"]))
         rekeyed = {a["_echo_text"] for a in redeliver}
+        stale_ids = {id(a) for a in stale}
         for a in newly:
             if a["_echo_text"] in rekeyed:
                 continue                                   # now in the queue → renders as queued, prunes on landing
             if a["_echo_text"] in landed:
                 continue                                   # landed, un-pruned → the next build's prune_live
             a["dropped"] = True
+            if id(a) in stale_ids:
+                a["stale"] = True                          # past the age line at the restart: the notice says so
             if hasattr(self, "forget_fed"):
                 self.forget_fed(sid, a.get("uuid"))   # its landing will never come (T252c)
             with self._live_lock:
                 self._touch_live(sid)                  # a flag write outside the lock: still a change to the tail
+            if id(a) in stale_ids:
+                continue                                   # counted in the one summary row below, not one row each
             if a["_echo_text"] in outrun:
                 self._log("%s: a send never reached its conversation (the CLI took a later message while "
                           "still holding it) — kept in the chat as never-delivered, not re-sent: %.80r"
@@ -12709,8 +12764,46 @@ class SdkBackend:
             else:
                 self._log("%s: a send never reached its CLI (the process died holding it) — kept in the chat "
                           "as never-delivered: %.80r" % (sid[:8], a["_echo_text"]), problem=True)
+        if stale:
+            oldest = min(int(a.get("t") or 0) for a in stale)
+            self._log("%s: %d send(s) older than the re-delivery age line (%s) at the restart were not re-fed; the "
+                      "oldest was from %s — kept in the chat as never-delivered, one notice queued"
+                      % (sid[:8], len(stale), _gap_text(int(REDELIVER_MAX_AGE_S)),
+                         time.strftime("%Y-%m-%d %H:%M", time.localtime(oldest))), problem=True)
         self._persist_echoes(sid)
         self._wake_push()
+
+    def mark_echo_refused(self, sid: str, text: str, reason: str = "") -> int:
+        """The prompt gate REFUSED `text` for this session (_prompt_submit_gate's block: a replayed schedule slot).
+        The CLI will not run it, so no record will ever land it — and an echo left pending would read as a lost
+        send at the next restart and be re-fed (2026-09-12). Flag every unlanded echo wearing the text dropped AND
+        refused: kept in the chat as never-delivered, never re-delivered, both flags riding the mirror. Matched
+        under echo_keys like every other echo reader. Returns the count flagged (0: nothing wore the text)."""
+        want = set(echo_keys(text))
+        if not want:
+            return 0
+        hit = []
+        with self._live_lock:
+            d = self._live.get(sid) or {}
+            for a in d.values():
+                et = a.get("_echo_text")
+                if not et or a.get("command") or a.get("dropped") or a.get("_landed"):
+                    continue
+                if want & set(echo_keys(et)):
+                    a["dropped"] = True
+                    a["refused"] = True
+                    if reason:
+                        a["refusedWhy"] = str(reason)[:200]
+                    hit.append(a.get("uuid"))
+            if hit:
+                self._touch_live(sid)
+        if hit:
+            if hasattr(self, "forget_fed"):
+                for u in hit:
+                    self.forget_fed(sid, u)                # its landing will never come (T252c)
+            self._persist_echoes(sid)                      # the flags ride the restart mirror at once
+            self._wake_push()
+        return len(hit)
 
     def _text_landed(self, sid: str, text: str, t: int | None = None, off=None, fsid=None):
         """Did `text` land in the sid's transcript? The re-delivery guard: the echo prune is lazy (a landed

--- a/tests/romp-headless.bats
+++ b/tests/romp-headless.bats
@@ -19,15 +19,19 @@ teardown() {
 }
 
 # Start a one-shot fake kernel; writes its port to $TEST_DIR/port and its request to $TEST_DIR/req.
-start_fake_kernel() {   # $1 = response body
-    python3 - "$1" "$TEST_DIR" <<'PY' &
-import http.server, json, sys
-body, tdir = sys.argv[1].encode(), sys.argv[2]
+# $2 (optional): seconds to hold the answer AFTER reading the request — a kernel that took the message
+# but answers late (the boot-storm shape the exit-code test below drives).
+start_fake_kernel() {   # $1 = response body, $2 = answer delay in seconds (default 0)
+    python3 - "$1" "$TEST_DIR" "${2:-0}" <<'PY' &
+import http.server, json, sys, time
+body, tdir, delay = sys.argv[1].encode(), sys.argv[2], float(sys.argv[3])
 class H(http.server.BaseHTTPRequestHandler):
     def do_POST(self):
         n = int(self.headers.get("Content-Length") or 0)
         with open(tdir + "/req", "w") as f:
             f.write(self.path + "\n" + self.rfile.read(n).decode())
+        if delay:
+            time.sleep(delay)
         self.send_response(200)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
@@ -271,4 +275,27 @@ PY
     grep -q '"name": "-oddname"' "$TEST_DIR/req"
     run "$ROMP_SCRIPT" compact --wait
     [ "$status" -eq 2 ]
+}
+
+@test "romp send: a kernel that took the request but answers late exits 3 and says the message may be delivered" {
+    # 2026-09-12: this shape wore "kernel not reachable" and exit 1, so a retry-on-exit caller re-sent a delivered
+    # message on every try (nine copies of one wake, twenty seconds apart, after a restart). The request must be
+    # on the fake kernel's disk (it was taken), the exit distinct from a refusal, and the words honest.
+    start_fake_kernel '{"ok": true}' 3
+    ROMP_KERNEL_HTTP_TIMEOUT_S=1 run "$ROMP_SCRIPT" send helper 'a wake the kernel took slowly'
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"took the request but did not answer within 1s"* ]]
+    [[ "$output" == *"may already have delivered the message"* ]]
+    [[ "$output" == *"do not retry blindly"* ]]
+    [[ "$output" != *"not reachable"* ]]
+    grep -q "^/send$" <(head -1 "$TEST_DIR/req")
+}
+
+@test "romp send: a kernel nobody is listening on is 'not reachable', exit 1, and nothing was sent" {
+    # a port with no listener: the request never left, so the old message and code stand, and the curl code is named
+    export ROMP_KERNEL_PORT=1
+    run "$ROMP_SCRIPT" send helper 'a message nobody took'
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"kernel not reachable"* ]]
+    [[ "$output" == *"[curl exit"* ]]
 }

--- a/tests/test_live_tail_rev.py
+++ b/tests/test_live_tail_rev.py
@@ -16,6 +16,7 @@ import json
 import os
 import tempfile
 import types
+import time
 import unittest
 from romp_load import load_source
 
@@ -173,7 +174,7 @@ class SdkLiveTailRevision(unittest.TestCase):
         self.assertEqual(self.rev(), r0 + 1, "the `dropped` verdict is a change")
         self.be._mark_dropped_echoes(SID, queued_texts=(), refeed=False)
         self.assertEqual(self.rev(), r0 + 1, "already flagged: nothing newly dropped, no bump")
-        self.be._stash_live(SID, "e2", _echo("e2", "landed, un-pruned", 7))
+        self.be._stash_live(SID, "e2", _echo("e2", "landed, un-pruned", int(time.time()) - 5))   # recent: inside the re-delivery age line
         self.be._text_landed = lambda sid, text, t=None, off=None, fsid=None: True
         r1 = self.rev()
         self.be._mark_dropped_echoes(SID, queued_texts=())                  # the scan finds the record

--- a/tests/test_restart_redelivery.py
+++ b/tests/test_restart_redelivery.py
@@ -27,6 +27,9 @@ sb = load_source("romp_sdk_backend_redeliver", os.path.join(BIN, "romp-event-mod
 sb = load_source("romp_sdk_backend_redeliver2", os.path.join(HERE, "..", "kernel", "sdk_backend.py"))
 
 SID = "11111111-2222-3333-4444-555555555555"
+# Send stamps are RECENT epoch seconds (2026-09-12): re-delivery has an age line (REDELIVER_MAX_AGE_S), so a
+# stamp of 100 (1970) would read as a stale send and take the flag path instead of the re-feed under test.
+T0 = int(__import__("time").time()) - 600
 
 
 class Redelivery(unittest.TestCase):
@@ -70,7 +73,7 @@ class Redelivery(unittest.TestCase):
         sb.write_reg(self.be.state_dir, SID, {"sid": SID, "alive": True, "cwd": self.cwd,
                                               "lastSid": SID, "queue": []})
 
-    def _echo(self, text, author="human", t=100):
+    def _echo(self, text, author="human", t=T0):
         self.be._live.setdefault(SID, {})["echo:" + text[:8]] = {
             "_echo_text": text, "author": author, "t": t}
 
@@ -82,8 +85,8 @@ class Redelivery(unittest.TestCase):
         os.environ.pop("CLAUDE_CONFIG_DIR", None)
 
     def test_lost_human_send_re_enters_the_queue_in_send_order(self):
-        self._echo("first typed message", t=100)
-        self._echo("second typed message", t=200)
+        self._echo("first typed message", t=T0)
+        self._echo("second typed message", t=T0 + 100)
         self.be._mark_dropped_echoes(SID, [])
         self.assertEqual(self._reg_queue(), ["first typed message", "second typed message"])
         for a in self.be._live[SID].values():
@@ -108,7 +111,7 @@ class Redelivery(unittest.TestCase):
 
     def test_surviving_queue_texts_stay_ahead_and_undropped(self):
         self._echo("still queued text")
-        self._echo("lost text", t=300)
+        self._echo("lost text", t=T0 + 200)
         sb.write_reg(self.be.state_dir, SID, {"sid": SID, "alive": True, "cwd": self.cwd,
                                               "lastSid": SID, "queue": ["still queued text"]})
         self.be._mark_dropped_echoes(SID, ["still queued text"])
@@ -166,7 +169,7 @@ class BootDeliversARefedSend(unittest.TestCase):
         return (sb.read_reg(self.state, SID) or {}).get("queue") or []
 
     def test_a_re_queued_send_earns_the_resume_the_same_boot(self):
-        ensured = self._boot([{"t": 100, "text": "typed just before the restart", "author": "human"}])
+        ensured = self._boot([{"t": T0, "text": "typed just before the restart", "author": "human"}])
         self.assertEqual(self._reg_queue(), ["typed just before the restart"],
                          "the reseed re-queued the lost send (the half that already worked)")
         self.assertEqual(ensured, [SID], "…and the same boot's sweep resumes the session to deliver it")
@@ -174,7 +177,7 @@ class BootDeliversARefedSend(unittest.TestCase):
     def test_a_dormant_threads_re_queued_reply_earns_the_resume_too(self):
         # a comment thread is never auto-resumed at boot EXCEPT for a queued reply of the user's own
         # — and a re-queued reply is exactly that
-        ensured = self._boot([{"t": 100, "text": "a reply the thread never started", "author": "human"}],
+        ensured = self._boot([{"t": T0, "text": "a reply the thread never started", "author": "human"}],
                              threadOf="11111111-2222-3333-4444-000000000000")
         self.assertEqual(self._reg_queue(), ["a reply the thread never started"])
         self.assertEqual(ensured, [SID])

--- a/tests/test_restart_redelivery_stale.py
+++ b/tests/test_restart_redelivery_stale.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Re-delivery has an AGE LINE and a REFUSED flag (2026-09-12). The boot and dead-spawn re-delivery arm
+(_mark_dropped_echoes) re-feeds a human send whose text the transcript scan cannot find. A landing the scan
+cannot see is re-fed at EVERY restart, forever: a kernel whose scan read only native user records (never the
+queued_command attachment a mid-turn feed lands as) and only the last 2 MB of the file re-fed the same texts,
+some days old, at two restarts in one night, one text landing six times. So: a send older than
+REDELIVER_MAX_AGE_S at the restart is not re-fed and not scanned — it takes the flag path (dropped, kept in
+the chat as never-delivered) and ONE notice names the count and the oldest stamp; a send the prompt gate
+REFUSED is flagged dropped + refused at the refusal, so it is never re-fed; both flags ride the registry
+mirror across restarts. The queue proper (sends never fed) is not under the line. SYNTHETIC."""
+import json
+import os
+import tempfile
+import time
+import unittest
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+sb = load_source("romp_sdk_backend_stale0", os.path.join(BIN, "romp-event-model"))
+sb = load_source("romp_sdk_backend_stale", os.path.join(HERE, "..", "kernel", "sdk_backend.py"))
+
+SID = "11111111-2222-3333-4444-666666666666"
+NOW = int(time.time())
+FRESH_T = NOW - 60                       # a minute before the restart: inside any sane line
+STALE_T = NOW - 3 * 86400                # three days before it: the pile the field measured
+
+
+class Fixture(unittest.TestCase):
+    def setUp(self):
+        self.td = tempfile.mkdtemp()
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.td, "claude")
+        self.cwd = os.path.join(self.td, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        self.tpath = tp
+        open(tp, "w").close()                       # an empty transcript: nothing has landed
+
+        class BE:
+            state_dir = None
+            _live = {}
+            _reg_lock = __import__("threading").RLock()
+            _live_lock = __import__("threading").RLock()
+            _persisted = []
+            _logs = []
+            _problems = []
+            _forgotten = []
+
+            def _log(self, msg, problem=False, **kw):
+                self._logs.append(msg)
+                if problem:
+                    self._problems.append(msg)
+
+            def _persist_echoes(self, sid):
+                self._persisted.append(sid)
+
+            def _wake_push(self):
+                pass
+
+            def _touch_live(self, sid):
+                pass
+
+            def forget_fed(self, sid, uuid_):
+                self._forgotten.append(uuid_)
+        self.be = BE()
+        import pathlib
+        self.be.state_dir = pathlib.Path(self.td)
+        for name in ("_mark_dropped_echoes", "_text_landed", "mark_echo_refused"):
+            setattr(self.be, name, getattr(sb.SdkBackend, name).__get__(self.be))
+        sb.write_reg(self.be.state_dir, SID, {"sid": SID, "alive": True, "cwd": self.cwd,
+                                              "lastSid": SID, "queue": []})
+        self._line = sb.REDELIVER_MAX_AGE_S
+
+    def tearDown(self):
+        self.be._live.clear()
+        sb.REDELIVER_MAX_AGE_S = self._line
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def _echo(self, text, t, author="human"):
+        d = self.be._live.setdefault(SID, {})
+        key = "echo:%d" % (len(d) + 1)               # one key per stash: two echoes may wear one text
+        d[key] = {"_echo_text": text, "author": author, "t": t, "uuid": key}
+        return d[key]
+
+    def _reg_queue(self):
+        return (sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or []
+
+
+class TheAgeLine(Fixture):
+    def test_a_send_past_the_line_is_not_refed_and_one_notice_names_the_count_and_the_oldest(self):
+        fresh = self._echo("fresh typed words", FRESH_T)
+        stale = self._echo("three day old words", STALE_T)
+        self.be._mark_dropped_echoes(SID, [])
+        q = self._reg_queue()
+        self.assertEqual(q[0], "fresh typed words", "the fresh send is re-delivered exactly as before")
+        self.assertEqual(len(q), 2, "…followed by ONE notice, and nothing else: %r" % (q,))
+        notice = q[1]
+        self.assertIn("[romp]", notice)
+        self.assertIn("1 queued message from before the restart was dropped as stale", notice)
+        self.assertIn(time.strftime("%Y-%m-%d %H:%M", time.localtime(STALE_T)), notice,
+                      "the notice names the oldest dropped send's stamp")
+        self.assertNotIn("three day old words", q, "the stale send never re-enters the queue")
+        self.assertTrue(stale.get("dropped") and stale.get("stale"),
+                        "the stale send takes the flag path and says why")
+        self.assertNotIn("dropped", fresh, "the fresh send is queued, not lost")
+        self.assertEqual(len([p for p in self.be._problems if "age line" in p]), 1,
+                         "one problem row for the whole drop, not one per send")
+
+    def test_two_stale_sends_make_one_notice_with_the_oldest_stamp(self):
+        self._echo("older stale words", STALE_T - 3600)
+        self._echo("newer stale words", STALE_T)
+        self.be._mark_dropped_echoes(SID, [])
+        q = self._reg_queue()
+        self.assertEqual(len(q), 1, "one notice, no re-delivery: %r" % (q,))
+        self.assertIn("2 queued messages from before the restart were dropped as stale", q[0])
+        self.assertIn(time.strftime("%Y-%m-%d %H:%M", time.localtime(STALE_T - 3600)), q[0])
+
+    def test_a_stale_send_is_not_scanned(self):
+        # the scan is the expensive step (a mark-less echo streams the whole transcript); the line runs first
+        self._echo("three day old words", STALE_T)
+        calls = []
+        self.be._text_landed = lambda *a, **k: calls.append(a) or False
+        with mock.patch.object(sb, "_input_landed_after", side_effect=AssertionError("scanned a stale send")):
+            self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(calls, [], "no transcript scan for a send past the line")
+
+    def test_the_line_is_measured_from_the_send_stamp_not_the_text(self):
+        # a send just inside the line is re-fed; one just outside is dropped — the stamp decides
+        inside = self._echo("inside the line", NOW - int(sb.REDELIVER_MAX_AGE_S) + 120)
+        outside = self._echo("outside the line", NOW - int(sb.REDELIVER_MAX_AGE_S) - 120)
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertIn("inside the line", self._reg_queue())
+        self.assertNotIn("outside the line", self._reg_queue())
+        self.assertTrue(outside.get("stale"))
+        self.assertNotIn("dropped", inside)
+
+    def test_the_line_can_be_switched_off(self):
+        sb.REDELIVER_MAX_AGE_S = 0
+        self._echo("three day old words", STALE_T)
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(self._reg_queue(), ["three day old words"], "0 restores the unbounded re-feed")
+
+    def test_the_line_never_touches_the_queue_proper(self):
+        # a send still in reg['queue'] (never fed) is the person's words waiting their turn: it stays, whatever its age
+        self._echo("waiting its turn", STALE_T)
+        sb.write_reg(self.be.state_dir, SID, {"sid": SID, "alive": True, "cwd": self.cwd,
+                                              "lastSid": SID, "queue": ["waiting its turn"]})
+        self.be._mark_dropped_echoes(SID, ["waiting its turn"])
+        self.assertEqual(self._reg_queue(), ["waiting its turn"])
+        self.assertFalse(any(a.get("dropped") for a in self.be._live[SID].values()))
+
+    def test_a_stale_romp_authored_echo_makes_no_notice(self):
+        self._echo("an old nudge body", STALE_T, author="romp")
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(self._reg_queue(), [], "a nudge was never re-fed; nothing to announce")
+        self.assertTrue(all(a.get("dropped") for a in self.be._live[SID].values()))
+
+    def test_a_live_session_gets_the_notice_through_its_own_queue(self):
+        class S:
+            def __init__(self):
+                self.q = []
+            def pending(self):
+                return list(self.q)
+            def enqueue(self, text, qid=None, qts=None):
+                self.q.append(text)
+        s = S()
+        self.be.sessions = {SID: s}
+        self.be._lock = __import__("threading").RLock()
+        self._echo("fresh typed words", FRESH_T)
+        self._echo("three day old words", STALE_T)
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(s.q[0], "fresh typed words")
+        self.assertEqual(len(s.q), 2)
+        self.assertIn("dropped as stale", s.q[1])
+        self.assertEqual(self._reg_queue(), [], "the live session's queue is authoritative; the reg is not written")
+
+
+class TheRefusedFlag(Fixture):
+    def test_a_refused_send_is_flagged_and_never_refed(self):
+        a = self._echo("a prompt the gate refused", FRESH_T)
+        self.assertEqual(self.be.mark_echo_refused(SID, "a prompt the gate refused", "replayed schedule slot"), 1)
+        self.assertTrue(a.get("dropped") and a.get("refused"))
+        self.assertEqual(self.be._persisted, [SID], "the flags ride the mirror at once")
+        self.assertEqual(self.be._forgotten, [a["uuid"]], "its landing will never come")
+        self.be._mark_dropped_echoes(SID, [])
+        self.assertEqual(self._reg_queue(), [], "a refused send is not a lost send: nothing re-fed, no notice")
+
+    def test_the_mark_matches_under_the_echo_key_and_skips_landed_and_other_texts(self):
+        a = self._echo("  a prompt the gate refused \n", FRESH_T)
+        b = self._echo("another message entirely", FRESH_T)
+        c = self._echo("a prompt the gate refused", FRESH_T - 5)
+        c["_landed"] = True
+        self.assertEqual(self.be.mark_echo_refused(SID, "a prompt the gate refused"), 1)
+        self.assertTrue(a.get("refused"))
+        self.assertNotIn("refused", b)
+        self.assertNotIn("refused", c, "a landed echo is not refused: its record exists")
+        self.assertEqual(self.be.mark_echo_refused(SID, ""), 0)
+        self.assertEqual(self.be.mark_echo_refused(SID, "nothing wears this"), 0)
+
+    def test_the_gates_block_marks_the_echo(self):
+        # The real gate over a real backend (tests/test_cron_replay_dedupe.py's shape): the first fire records the
+        # slot, a FRESH session's second fire is the restart replay and is blocked — and the block flags the echo
+        # wearing that prompt refused, so the next boot's re-delivery never treats it as a lost send.
+        import asyncio
+        from pathlib import Path
+        d = tempfile.mkdtemp()
+        be = sb.SdkBackend(d, "/bin/true", lambda *a, **k: None, log=lambda *a, **k: None)
+        cron, prompt = "* * * * *", "ping me every minute"
+        sb.write_reg(Path(d), SID, {
+            "sid": SID, "name": "web", "cwd": "/tmp", "alive": True,
+            "sessionCrons": [{"id": "c1", "cron": cron, "prompt": prompt, "kind": "cron", "recurring": True,
+                              "armedAt": time.time() - 3600, "dueEpoch": None, "procGen": "gen-A"}]})
+        first = sb.SdkSession(be, sb.read_reg(Path(d), SID))
+        self.assertEqual(asyncio.run(first._prompt_submit_hook({"prompt": prompt}, None, None)), {},
+                         "the first fire of the slot runs and is recorded")
+        be._stash_live(SID, "echo:refused1", {"type": "user", "uuid": "echo:refused1", "session_id": SID,
+                                              "t": FRESH_T, "author": "human", "_echo_text": prompt,
+                                              "message": {"role": "user", "content": [{"type": "text", "text": prompt}]}})
+        again = sb.SdkSession(be, sb.read_reg(Path(d), SID))
+        out = asyncio.run(again._prompt_submit_hook({"prompt": prompt}, None, None))
+        self.assertEqual(out.get("decision"), "block", "the replayed slot is refused")
+        a = be._live[SID]["echo:refused1"]
+        self.assertTrue(a.get("dropped") and a.get("refused"), "…and the echo wearing it is flagged refused")
+        mirror = (sb.read_reg(Path(d), SID) or {}).get("echoes") or []
+        self.assertTrue(any(e.get("refused") for e in mirror), "the flag is on the mirror already")
+
+
+class TheMirror(Fixture):
+    def test_stale_and_refused_ride_the_mirror_both_ways(self):
+        writes = []
+        self.be._update_reg = lambda sid, **kw: writes.append(kw)
+        self.be._persist_echoes = sb.SdkBackend._persist_echoes.__get__(self.be)
+        a = self._echo("three day old words", STALE_T)
+        a["dropped"] = a["stale"] = True
+        b = self._echo("a prompt the gate refused", FRESH_T)
+        b["dropped"] = b["refused"] = True
+        self.be._persist_echoes(SID)
+        snap = {e["text"]: e for e in writes[-1]["echoes"]}
+        self.assertTrue(snap["three day old words"].get("stale") and snap["three day old words"].get("dropped"))
+        self.assertTrue(snap["a prompt the gate refused"].get("refused"))
+        self.assertNotIn("refused", snap["three day old words"])
+        stashed = []
+        self.be._stash_live = lambda sid, key, atom: stashed.append(atom)
+        self.be._reseed_echoes = sb.SdkBackend._reseed_echoes.__get__(self.be)
+        self.be._live.clear()                         # nothing live → the reseed stashes and stops
+        self.be._reseed_echoes([{"sid": SID, "alive": True, "echoes": writes[-1]["echoes"], "queue": []}])
+        by = {x["_echo_text"]: x for x in stashed}
+        self.assertTrue(by["three day old words"].get("dropped") and by["three day old words"].get("stale"))
+        self.assertTrue(by["a prompt the gate refused"].get("dropped") and by["a prompt the gate refused"].get("refused"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_restart_redelivery_stale.py
+++ b/tests/test_restart_redelivery_stale.py
@@ -25,13 +25,23 @@ sb = load_source("romp_sdk_backend_stale0", os.path.join(BIN, "romp-event-model"
 sb = load_source("romp_sdk_backend_stale", os.path.join(HERE, "..", "kernel", "sdk_backend.py"))
 
 SID = "11111111-2222-3333-4444-666666666666"
-NOW = int(time.time())
-FRESH_T = NOW - 60                       # a minute before the restart: inside any sane line
-STALE_T = NOW - 3 * 86400                # three days before it: the pile the field measured
+NOW = FRESH_T = STALE_T = 0              # set per test by Fixture.setUp (_reset_clock), never at import
+
+
+def _reset_clock():
+    """Every stamp is relative to the clock the TEST runs on, read in setUp — never at import. pytest imports
+    each module at collection and runs this one minutes later under the full suite, while the code under test
+    reads time.time() at the call: an import-time NOW put the send planted 120 s INSIDE the line past it by the
+    time the arm ran (CI 2026-09-12: both sends dropped, the standalone run green at every timezone)."""
+    global NOW, FRESH_T, STALE_T
+    NOW = int(time.time())
+    FRESH_T = NOW - 60                       # a minute before the restart: inside any sane line
+    STALE_T = NOW - 3 * 86400                # three days before it: the pile the field measured
 
 
 class Fixture(unittest.TestCase):
     def setUp(self):
+        _reset_clock()
         self.td = tempfile.mkdtemp()
         os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.td, "claude")
         self.cwd = os.path.join(self.td, "proj")

--- a/tests/test_sdk_echo_durability.py
+++ b/tests/test_sdk_echo_durability.py
@@ -439,7 +439,8 @@ class RedeliveryFeedsTheAuthoritativeQueue(unittest.TestCase):
         self.be.sessions[SID] = s          # register WITHOUT starting the thread (no loop)
         return s
 
-    def _stash_echo(self, text, t=100):
+    def _stash_echo(self, text, t=None):
+        t = int(time.time()) - 100 if t is None else t   # a RECENT stamp: re-delivery has an age line (2026-09-12)
         e = {"type": "user", "uuid": "echo:" + text[:10], "session_id": SID, "t": t,
              "parentUuid": None, "author": "human", "_echo_text": text,
              "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
@@ -452,7 +453,7 @@ class RedeliveryFeedsTheAuthoritativeQueue(unittest.TestCase):
     def test_live_session_redelivery_reaches_pending_and_survives_the_next_persist(self):
         reg = self._reg(queue=[])
         s = self._sess(reg)
-        e = self._stash_echo("typed while the old client was dying", t=300)
+        e = self._stash_echo("typed while the old client was dying", t=int(time.time()) - 60)
         self.be._mark_dropped_echoes(SID, s.pending())     # the fresh-spawn (_run) call shape
         self.assertEqual(s.pending(), ["typed while the old client was dying"],
                          "a live session's recovered send must enter _pending — a reg-only write "
@@ -507,7 +508,8 @@ class ReconnectStrandIsFlagOnly(unittest.TestCase):
         self.be.sessions[SID] = s          # register WITHOUT starting the thread (no loop)
         return s
 
-    def _stash_echo(self, text, t=100):
+    def _stash_echo(self, text, t=None):
+        t = int(time.time()) - 100 if t is None else t   # a RECENT stamp: re-delivery has an age line (2026-09-12)
         e = {"type": "user", "uuid": "echo:" + text[:10], "session_id": SID, "t": t,
              "parentUuid": None, "author": "human", "_echo_text": text,
              "message": {"role": "user", "content": [{"type": "text", "text": text}]}}


### PR DESCRIPTION
## What this fixes

Every kernel restart replayed a burst of old prompts into every live session (194 re-deliveries across 13 sessions at one restart on 2026-09-12, 264 at the next, the same texts both times: handled wake prompts, answered chat lines, a message days old). The replay travelled the kernel's own prompt path, not postal mail.

## Diagnosis

The per-session registry keeps an `echoes` mirror of sends whose text has not yet been seen in the transcript. At boot the reseed re-queues every human-authored echo the transcript scan cannot find and no later composer input outran. `romp send` relays, wakes and chat lines all count as human, so all were candidates. The kernel that was running read only the last 2 MB of the transcript and only native `user` records, while a message fed into a running turn lands only as a `queued_command` attachment, so the re-fed copies were invisible to the very scan that decides re-delivery: nothing ever marked them landed, the pile only grew (one session held 36 unlanded echoes aged up to 79 hours, one text landed six times), and every restart replayed all of it. Main's newer scan does read attachments, so on main the same pile reads as landed; this change guards any landing the scan cannot see and bounds the boot cost.

## The fix (boot path only; normal operation unchanged)

- `REDELIVER_MAX_AGE_S` (env `ROMP_REDELIVER_MAX_AGE_S`, default 30 minutes, 0 turns it off): a human echo older than this at the restart is neither scanned nor re-fed; it takes the existing never-delivered flag path with a `stale` reason, and one `[romp]` notice in the restart-notice family names the count and the oldest stamp so nothing drops silently. The queue proper (sends never fed) is untouched.
- `SdkBackend.mark_echo_refused`: when the prompt gate blocks a replayed schedule slot, the echo wearing that prompt is flagged dropped and refused at once, so it is never re-fed. Both flags ride the mirror. The recurring-cron delivered-slot gate is unchanged.
- `romp send|interrupt|end`: a curl timeout on a kernel that took the request but answered late used to read "kernel not reachable", exit 1, so a retry-on-exit caller re-sent delivered messages (nine copies of each wake after a restart). It now exits 3 with honest words; a connection nobody took stays exit 1; the cap is `ROMP_KERNEL_HTTP_TIMEOUT_S`.

## Tests

`tests/test_restart_redelivery_stale.py` (12 tests, all failing before the change: the age line, the single notice and its wording, no scan for a stale send, the switch-off, the queue proper untouched, the live-session route, the refused flag through the real gate, the mirror round trip). Three existing fixtures that stamped echoes at epoch 100 to 300 now use recent stamps. `tests/romp-headless.bats` gains a late-answering fake kernel and two exit-code tests. Locally: the new module plus the fourteen related kernel modules pass (376 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
