### PR TITLE
Unread comment cue: the tab strip's dashed needs-you ring, by the passage's line count; the rail tick's halo agrees

### DIFF
--- a/tests/test_comment_outline_served.py
+++ b/tests/test_comment_outline_served.py
@@ -1,18 +1,25 @@
 #!/usr/bin/env python3
-"""T310 (the user 2026-09-10): an unread comment thread's cue on the real /chat page is ONE solid outline in the
-scroll notch's yellow around the WHOLE highlighted passage — never a dashed box per line.
+"""An unread comment thread's cue on the real /chat page. T310 (the user 2026-09-10): ONE outline around the WHOLE
+highlighted passage, never a box per line. The user 2026-09-12: the stroke is the tab strip's needs-you ring again
+(dashed, --st-awaiting-bg), the cue follows the passage's LINE COUNT (one or two rows: the per-fragment ring on the
+marks, no box; three or more: the box, no ring), and the rail tick's unread halo wears the same red while its fill
+keeps the notch's own ink.
 
-A hermetic kernel serves a synthetic chat (the notes-api demo world: session web) whose one answer carries two open
-comment threads with a landed, unseen reply each: a passage that wraps over two lines and one over five
-(on a 640 px page; the kernel ships a thread's exact text capped at 500 characters, so the mark covers at most that),
-plus an incoming question card whose long body scrolls, with a third thread on its last sentence: that box exists only
-while its passage shows inside the body (cut to the scrolling container, repainted when the body scrolls). Asserted on
-the page: every unread thread has EXACTLY one outline box, positioned (the text under it never moves) and transparent
-to the pointer, whose rect covers every line fragment of the thread's marks; the box's outline is solid and its
-colour is byte-equal to the thread's scroll tick and reads at 3:1 or better against the page, in the dark theme and the light one; no mark fragment wears an
-outline of its own; opening a thread (a click on its mark) removes ITS box on the same pass and leaves the other's.
-With COMMENT_SHOTS=<dir> the driver also writes a dark and a light screenshot. Skips LOUDLY without the extension
-deps or a Playwright browser. SYNTHETIC fixtures only (placeholder UUIDs, invented prose, host TESTHOST)."""
+A hermetic kernel serves a synthetic chat (the notes-api demo world: session web) whose one answer carries three open
+comment threads with a landed, unseen reply each: a passage that wraps over two lines, one over five and one on a
+single line (on a 640 px page; the kernel ships a thread's exact text capped at 500 characters, so the mark covers at
+most that), plus an incoming question card whose long body scrolls, with a fourth thread on its three-line last
+sentence: that box exists only while its passage shows inside the body (cut to the scrolling container, repainted
+when the body scrolls). Asserted on the page, in the dark theme and the light one: the five-line and the question
+passages have EXACTLY one outline box each (when visible), positioned (the text under it never moves) and transparent
+to the pointer, dashed, in the computed --st-awaiting-bg, covering every line fragment of the thread's marks, and no
+fragment of theirs wears an outline of its own; the one- and two-line passages have NO box and every fragment ringed
+(dashed, the same red, 1px off the glyphs); the red reads at 3:1 or better against the page; the unread tick's halo is
+that red and its fill the notch's ink; narrowing the window carries the two-line passage past two rows and swaps its
+ring for the box, widening swaps back (the existing resize hook, nothing added); opening a thread (a click on its mark)
+removes ITS cue on the same pass and leaves the others'. With COMMENT_SHOTS=<dir> the driver also writes a dark and a
+light screenshot. Skips LOUDLY without the extension deps or a Playwright browser. SYNTHETIC fixtures only
+(placeholder UUIDs, invented prose, host TESTHOST)."""
 import json
 import os
 import re
@@ -39,8 +46,9 @@ import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a 
 WEB = "aaaaaaaa-1111-2222-3333-444444444444"
 THREAD2 = "bbbbbbbb-1111-2222-3333-444444444444"   # the two-line passage's thread
 THREAD5 = "cccccccc-1111-2222-3333-444444444444"   # the five-line passage's thread
+THREAD1 = "99999999-1111-2222-3333-444444444444"   # the one-line passage's thread
 
-# the answer: two paragraphs, each the exact text of one thread's highlight
+# the answer: three paragraphs, each the exact text of one thread's highlight
 P2 = ("Use exponential backoff with a jitter of ten percent on every retry of the notes-api sync loop, and cap the "
       "delay at two minutes.")
 P5 = ("The retry budget itself should live in one place: a small table keyed by the failing endpoint, holding the "
@@ -48,11 +56,15 @@ P5 = ("The retry budget itself should live in one place: a small table keyed by 
       "endpoints are struggling and the operator can reset one row without touching the others. Persist that table "
       "with the notes themselves, never in memory alone, because a restart in the middle of an outage would otherwise "
       "forget every backoff and hammer the endpoint when it comes back.")
+P1 = "Log every retry at debug level, nothing louder."
 assert len(P5) <= 500, "the kernel ships a thread's exact text capped at 500 chars; the mark covers what ships"
 THREADQ = "dddddddd-1111-2222-3333-444444444444"   # the thread on the question card's LAST sentence (a scrolled notice body)
 API = "eeeeeeee-1111-2222-3333-444444444444"
 BAR = "#" * 44
-PQ_LAST = "Which of the two caps do you want written into the README, two minutes or five?"
+# three lines or more at 640 px, so the scrolled-container case stays a BOX case (a one- or two-row passage would ring)
+PQ_LAST = ("Which of the two caps do you want written into the README, two minutes or five? The operators will read that "
+           "number as a promise, so pick the one you can keep on the slowest endpoint we have, and say whether it applies "
+           "to the notes-api alone or to every service the dashboard polls on the same schedule.")
 # an incoming QUESTION card opens by default and its body scrolls at the notice body's 420 px max height: forty short
 # paragraphs, then the sentence the third thread anchors to, so that passage starts scrolled OUT of the body's view
 PQ = "\n\n".join("Point %d: the retry table needs a row for endpoint number %d, with its own attempt count and next allowed time." % (i, i)
@@ -115,6 +127,10 @@ await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
 await page.waitForFunction((n) => document.querySelectorAll("mark.cmt-hl.unread").length >= n, cfg.minMarks, { timeout: 30000 });
 await page.waitForTimeout(400);   // the rail's rAF pass after the marks landed
 const measure = () => page.evaluate(() => {
+  // the computed value of --st-awaiting-bg on THIS page in THIS theme: a probe painted with it (a custom property's own
+  // computed value is its raw text, so it is read through a colour)
+  const probe = document.createElement("span"); probe.style.color = "var(--st-awaiting-bg)"; document.body.appendChild(probe);
+  const needsYou = getComputedStyle(probe).color; probe.remove();
   const tids = Array.from(new Set(Array.from(document.querySelectorAll("mark.cmt-hl")).map((m) => m.dataset.tid)));
   const threads = {};
   for (const tid of tids) {
@@ -129,8 +145,12 @@ const measure = () => page.evaluate(() => {
                position: cs.position, pointer: cs.pointerEvents, parentIsTurn: box.parentElement.classList.contains("turn"),
                sameTurn: box.parentElement === marks[0].closest(".turn") };
     });
+    const ringed = marks.filter((m) => getComputedStyle(m).outlineStyle !== "none");
     threads[tid] = { unread: marks.some((m) => m.classList.contains("unread")), fragments: rects.length, lines,
                      markOutlines: Array.from(new Set(marks.map((m) => getComputedStyle(m).outlineStyle))),
+                     ringed: ringed.length, marks: marks.length,
+                     ringColors: Array.from(new Set(ringed.map((m) => getComputedStyle(m).outlineColor))),
+                     ringOffsets: Array.from(new Set(ringed.map((m) => getComputedStyle(m).outlineOffset))),
                      union: rects.length ? { l: Math.min(...rects.map((q) => q.l)), t: Math.min(...rects.map((q) => q.t)),
                                              r: Math.max(...rects.map((q) => q.r)), b: Math.max(...rects.map((q) => q.b)) } : null,
                      boxes };
@@ -141,7 +161,8 @@ const measure = () => page.evaluate(() => {
   const solid = (c) => c && !/^rgba\(.*,\s*0\)$/.test(c) && c !== "transparent";
   const pageBg = [document.getElementById("content"), document.body, document.documentElement]
     .map((n) => n && getComputedStyle(n).backgroundColor).find(solid) || "rgb(30, 30, 30)";
-  return { threads, tickColor: tick ? getComputedStyle(tick).backgroundColor : null, pageBg,
+  return { threads, needsYou, tickColor: tick ? getComputedStyle(tick).backgroundColor : null,
+           tickHalo: tick ? getComputedStyle(tick).boxShadow : null, pageBg,
            noticeBody: nb ? { l: nbr.left, t: nbr.top, r: nbr.right, b: nbr.bottom, scrollTop: nb.scrollTop, scrollHeight: nb.scrollHeight, clientHeight: nb.clientHeight } : null,
            boxCount: document.querySelectorAll(".cmt-outline").length,
            theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
@@ -161,13 +182,21 @@ const light = await measure();
 if (cfg.shots) await page.screenshot({ path: cfg.shots + "/romp_chat-comment-outline-light.png", fullPage: false });
 await page.evaluate(() => document.body.classList.remove("theme-light"));
 await page.waitForTimeout(200);
+// a narrower window carries the two-line passage past two rows: the existing window-resize hook repaints, and the ring
+// swaps for the box; widening again swaps back
+await page.setViewportSize({ width: 420, height: 900 });
+await page.waitForTimeout(400);
+const narrow = await measure();
+await page.setViewportSize({ width: 640, height: 900 });
+await page.waitForTimeout(400);
+const widened = await measure();
 // read the two-line thread: a click on its mark opens the popover, which drops the unread bit and re-runs the marks pass
 await page.click(`mark.cmt-hl[data-tid="${cfg.read}"]`);
 await page.waitForFunction((tid) => !document.querySelector(`.cmt-outline[data-tid="${tid}"]`), cfg.read, { timeout: 10000 }).catch(() => {});
 await page.waitForTimeout(300);
 const afterRead = await measure();
 afterRead.popover = await page.evaluate(() => !!document.querySelector("#cmt-pop"));
-fs.writeSync(1, "RESULT:" + JSON.stringify({ dark, scrolled, light, afterRead }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ dark, scrolled, light, narrow, widened, afterRead }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -215,18 +244,19 @@ class ServedCommentOutline(unittest.TestCase):
         Path(state, "timeline", "messages.jsonl").write_text(json.dumps(
             {"t": t0 + 30, "ev": "sent", "id": "q-cap", "from": "api", "from_id": API, "to_id": WEB, "body": PQ, "kind": "question", "from_host": ""}) + "\n")
         parent = [user(t0, "u1", None, "how should the notes-api retry loop back off, and where does its budget live?", WEB),
-                  agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5, WEB),
+                  agent(t0 + 5, "a1", "u1", P2 + "\n\n" + P5 + "\n\n" + P1, WEB),
                   user(t0 + 31, "m1", "a1", banner("api", "question", "q-cap", PQ, t0 + 30), WEB)]
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         Path(proj, WEB + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in parent))
-        # two threads, each a fork cut at the answer (the copied history, then the exchange), a reply landed and
+        # four threads, each a fork cut at its anchor (the copied history, then the exchange), a reply landed and
         # never seen (no lastSeenT) — the kernel's unread bit; no names/ entry (a thread is never on the board)
         rows = []
         for i, (tsid, anchor, exact, ask, reply) in enumerate([
                 (THREAD2, "a1", P2, "why jitter at all?", "Jitter spreads simultaneous retries apart so they do not arrive as one wave."),
                 (THREAD5, "a1", P5, "why persist the budget?", "A restart mid-outage would otherwise forget every backoff and storm the endpoint."),
-                (THREADQ, "m1", PQ_LAST, "is five too long?", "Five minutes is too long for a notes sync; two keeps the user waiting under a coffee.")]):
+                (THREADQ, "m1", PQ_LAST, "is five too long?", "Five minutes is too long for a notes sync; two keeps the user waiting under a coffee."),
+                (THREAD1, "a1", P1, "why debug level?", "Anything louder would page someone for a retry that succeeds on its own.")]):
             t = t0 + 60 * (i + 1)
             thread = [r for r in parent if r["uuid"] in ("u1", "a1") or anchor == "m1"]   # the copied history, up to the cut
             thread = [dict(r, sessionId=tsid) for r in thread]
@@ -259,10 +289,10 @@ class ServedCommentOutline(unittest.TestCase):
             k.kill(); k.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
-    def test_one_solid_box_around_the_whole_passage_in_the_ticks_yellow_gone_once_read(self):
+    def test_the_cue_by_row_count_dashed_in_the_needs_you_red_gone_once_read(self):
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
-            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "minMarks": 3, "read": "tid-1",
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "minMarks": 4, "read": "tid-1",
                        "shots": os.environ.get("COMMENT_SHOTS", "")}, f)
         driver = os.path.join(self.lab, "driver.mjs")
         with open(driver, "w") as f:
@@ -275,58 +305,97 @@ class ServedCommentOutline(unittest.TestCase):
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
         r = json.loads(line[len("RESULT:"):])
-        for theme, want in (("dark", "rgb(255, 213, 74)"), ("light", "rgb(143, 106, 0)")):
+        RED = "rgb(192, 57, 43)"   # --st-awaiting-bg, the tab strip's needs-you red, the same in both themes
+
+        def ringed(th, red, label):
+            """every fragment of the passage wears the dashed ring in the needs-you red, 1px off the glyphs; no box."""
+            self.assertTrue(th["unread"], th)
+            self.assertEqual(th["boxes"], [], "%s: a one- or two-row passage has no box: %r" % (label, th))
+            self.assertEqual(th["markOutlines"], ["dashed"], "%s: every fragment rings: %r" % (label, th))
+            self.assertEqual(th["ringed"], th["marks"], "%s: every mark of the thread, not some: %r" % (label, th))
+            self.assertEqual(th["ringColors"], [red], "%s: the ring in the needs-you red: %r" % (label, th))
+            self.assertEqual(th["ringOffsets"], ["1px"], "%s: 1px clear of the glyphs: %r" % (label, th))
+
+        def boxed(th, red, label):
+            """ONE dashed box in the needs-you red covering every fragment, hugging their union; no ring on any fragment."""
+            self.assertTrue(th["unread"], th)
+            self.assertEqual(th["markOutlines"], ["none"], "%s: no fragment wears an outline of its own: %r" % (label, th))
+            self.assertEqual(len(th["boxes"]), 1, "%s: ONE box for the whole passage: %r" % (label, th))
+            box, u = th["boxes"][0], th["union"]
+            style, width, colour = box["outline"].split(" ", 2)
+            self.assertEqual((style, colour), ("dashed", red), "%s: dashed, in the needs-you red: %r" % (label, box))
+            self.assertTrue(1 <= float(width.rstrip("px")) <= 2, "the 1.5px rule, as the engine snaps it: %r" % box)
+            self.assertEqual(box["position"], "absolute", "positioned: the text never moves")
+            self.assertEqual(box["pointer"], "none", "hover and click land on the marks beneath")
+            self.assertTrue(box["parentIsTurn"] and box["sameTurn"], "a child of the anchor turn: %r" % box)
+            # the box covers every fragment (1px clear of the glyphs) and hugs the union, not the whole line
+            self.assertLessEqual(box["l"], u["l"] - 0.5); self.assertLessEqual(box["t"], u["t"] - 0.5)
+            self.assertGreaterEqual(box["r"], u["r"] + 0.5); self.assertGreaterEqual(box["b"], u["b"] + 0.5)
+            for side in ("l", "t", "r", "b"):
+                self.assertLess(abs(box[side] - u[side]), 4, "%s: the box hugs the union on the %s side: %r vs %r" % (label, side, box, u))
+
+        for theme, ink in (("dark", "rgb(255, 213, 74)"), ("light", "rgb(143, 106, 0)")):
             m = r[theme]
             self.assertEqual(m["theme"], theme)
-            self.assertEqual(set(m["threads"]), {"tid-1", "tid-2", "tid-3"}, m)
-            self.assertEqual(m["tickColor"], want, "the scroll tick's ink in this theme: %r" % m)
-            self.assertGreaterEqual(_contrast(want, m["pageBg"]), 3.0, "the ink reads as a LINE against the page: %r on %r" % (want, m["pageBg"]))
-            # the third thread's passage sits below the question card's scrolled body: no box for it until it shows
+            self.assertEqual(set(m["threads"]), {"tid-1", "tid-2", "tid-3", "tid-4"}, m)
+            self.assertEqual(m["needsYou"], RED, "the token resolves to the tab strip's red in this theme: %r" % m["needsYou"])
+            self.assertGreaterEqual(_contrast(RED, m["pageBg"]), 3.0, "the red reads as a LINE against the page: %r on %r" % (RED, m["pageBg"]))
+            # the scroll notch keeps its OWN ink (the comment's yellow; amber on cream), and its unread halo — the outer 3px
+            # ring past the 1.5px page-coloured gap — agrees with the box by colour
+            self.assertEqual(m["tickColor"], ink, "the tick's fill is still the notch's ink in this theme: %r" % m)
+            self.assertGreaterEqual(_contrast(ink, m["pageBg"]), 3.0, "the ink reads against the page: %r on %r" % (ink, m["pageBg"]))
+            halo = re.search(r"(rgba?\([^)]*\)) 0px 0px 0px 3px", m["tickHalo"] or "")
+            self.assertIsNotNone(halo, "the unread tick's outer ring: %r" % m["tickHalo"])
+            self.assertEqual(halo.group(1), RED, "the halo in the needs-you red: %r" % m["tickHalo"])
+            self.assertNotIn(ink, m["tickHalo"], "no yellow halo left: %r" % m["tickHalo"])
+            # the fourth thread's passage (three lines) sits below the question card's scrolled body: unread, three rows or more,
+            # so a BOX case — and no box until it shows (cut to the scrolling container); no ring either way
             q = m["threads"]["tid-3"]
             self.assertTrue(q["unread"], q)
+            self.assertGreaterEqual(q["lines"], 3, "the question passage wraps over three lines or more: %r" % q)
+            self.assertEqual(q["markOutlines"], ["none"], "three rows or more never ring: %r" % q)
             self.assertEqual(m["noticeBody"]["scrollTop"], 0, m["noticeBody"])
             self.assertGreater(m["noticeBody"]["scrollHeight"], m["noticeBody"]["clientHeight"] + 200, "the body scrolls: %r" % m["noticeBody"])
             self.assertGreater(q["union"]["t"], m["noticeBody"]["b"], "the passage starts scrolled out of the body's view: %r vs %r" % (q["union"], m["noticeBody"]))
             self.assertEqual(q["boxes"], [], "a fragment scrolled out of its container draws no box over the content below: %r" % q)
-            self.assertEqual(m["boxCount"], 2, "one box per VISIBLE unread thread: %r" % m)
-            two, five = m["threads"]["tid-1"], m["threads"]["tid-2"]
-            self.assertGreaterEqual(two["lines"], 2, "the first passage wraps over at least two lines: %r" % two)
+            two, five, one = m["threads"]["tid-1"], m["threads"]["tid-2"], m["threads"]["tid-4"]
+            self.assertEqual(two["lines"], 2, "the first passage wraps over exactly two lines at 640px: %r" % two)
             self.assertGreaterEqual(five["lines"], 5, "the second passage wraps over at least five lines: %r" % five)
-            for th in (two, five):
-                self.assertTrue(th["unread"], th)
-                self.assertEqual(th["markOutlines"], ["none"], "no fragment wears an outline of its own: %r" % th)
-                self.assertEqual(len(th["boxes"]), 1, "ONE box for the whole passage: %r" % th)
-                box, u = th["boxes"][0], th["union"]
-                style, width, colour = box["outline"].split(" ", 2)
-                self.assertEqual((style, colour), ("solid", want), "solid, in the tick's exact colour: %r" % box)
-                self.assertTrue(1 <= float(width.rstrip("px")) <= 2, "the 1.5px rule, as the engine snaps it: %r" % box)
-                self.assertEqual(box["position"], "absolute", "positioned: the text never moves")
-                self.assertEqual(box["pointer"], "none", "hover and click land on the marks beneath")
-                self.assertTrue(box["parentIsTurn"] and box["sameTurn"], "a child of the anchor turn: %r" % box)
-                # the box covers every fragment (1px clear of the glyphs) and hugs the union, not the whole line
-                self.assertLessEqual(box["l"], u["l"] - 0.5); self.assertLessEqual(box["t"], u["t"] - 0.5)
-                self.assertGreaterEqual(box["r"], u["r"] + 0.5); self.assertGreaterEqual(box["b"], u["b"] + 0.5)
-                for side in ("l", "t", "r", "b"):
-                    self.assertLess(abs(box[side] - u[side]), 4, "the box hugs the union on the %s side: %r vs %r" % (side, box, u))
-        # scrolled to the body's end (a scroll inside the pane, captured by the rail scheduler): the third thread's box
+            self.assertEqual(one["lines"], 1, "the third passage sits on one line: %r" % one)
+            ringed(two, RED, theme + " two-line")
+            ringed(one, RED, theme + " one-line")
+            boxed(five, RED, theme + " five-line")
+            self.assertEqual(m["boxCount"], 1, "one box per VISIBLE unread thread of three rows or more: %r" % m)
+        # scrolled to the body's end (a scroll inside the pane, captured by the rail scheduler): the question thread's box
         # appears on its passage, inside the body's rect, hugging the visible fragments
         sc = r["scrolled"]
         q, nb = sc["threads"]["tid-3"], sc["noticeBody"]
         self.assertGreater(nb["scrollTop"], 0, nb)
-        self.assertEqual(len(q["boxes"]), 1, "the box follows the scrolled marks: %r" % q)
+        boxed(q, RED, "scrolled question")
         box = q["boxes"][0]
         self.assertGreaterEqual(box["t"], nb["t"] - 1.5); self.assertLessEqual(box["b"], nb["b"] + 1.5)
         self.assertGreaterEqual(box["l"], nb["l"] - 1.5); self.assertLessEqual(box["r"], nb["r"] + 1.5)
-        for side in ("l", "t", "r", "b"):
-            self.assertLess(abs(box[side] - q["union"][side]), 4, "the box hugs the now-visible passage on the %s side: %r vs %r" % (side, box, q["union"]))
-        self.assertEqual(sc["boxCount"], 3)
+        self.assertEqual(sc["boxCount"], 2)
+        # a narrower window: the two-line passage now spans three rows or more, and the ring gives way to the box on the
+        # existing resize hook; widened again, it is two rows and ringed. The five-line passage is a box either way.
+        na, wi = r["narrow"], r["widened"]
+        self.assertGreaterEqual(na["threads"]["tid-1"]["lines"], 3, "at 420px the first passage wraps past two rows: %r" % na["threads"]["tid-1"])
+        boxed(na["threads"]["tid-1"], RED, "narrow two-line→box")
+        boxed(na["threads"]["tid-2"], RED, "narrow five-line")
+        ringed(na["threads"]["tid-4"], RED, "narrow one-line")
+        self.assertEqual(wi["threads"]["tid-1"]["lines"], 2, wi["threads"]["tid-1"])
+        ringed(wi["threads"]["tid-1"], RED, "widened two-line→ring")
+        boxed(wi["threads"]["tid-2"], RED, "widened five-line")
+        self.assertEqual(wi["boxCount"], 1, "back to the one visible box: %r" % wi)
+        # read the two-line thread: the click drops its unread bit, and its ring goes on the same marks pass; the others keep theirs
         a = r["afterRead"]
         self.assertTrue(a["popover"], "the click opened the thread: %r" % a)
         self.assertFalse(a["threads"]["tid-1"]["unread"], "read: the unread bit dropped on the click")
-        self.assertEqual(a["threads"]["tid-1"]["boxes"], [], "…and its box went on the same pass: %r" % a["threads"]["tid-1"])
-        self.assertEqual(len(a["threads"]["tid-2"]["boxes"]), 1, "the other thread keeps its box: %r" % a["threads"]["tid-2"])
-        self.assertEqual(a["boxCount"], 1, "the read thread's box gone, the scrolled-out one still clipped away: %r" % a)
-
+        self.assertEqual(a["threads"]["tid-1"]["markOutlines"], ["none"], "…and its ring went with it: %r" % a["threads"]["tid-1"])
+        self.assertEqual(a["threads"]["tid-1"]["boxes"], [], a["threads"]["tid-1"])
+        boxed(a["threads"]["tid-2"], RED, "after read, five-line")
+        ringed(a["threads"]["tid-4"], RED, "after read, one-line")
+        self.assertEqual(a["boxCount"], 1, "the five-line box, the scrolled-out one still clipped away: %r" % a)
 
 if __name__ == "__main__":
     unittest.main()

--- a/ui/webview/comment-mark.test.ts
+++ b/ui/webview/comment-mark.test.ts
@@ -1,10 +1,12 @@
-// The comment mark's UNREAD cue (the user 2026-09-10): a landed reply you have not opened draws ONE solid outline
-// in the scroll notch's yellow around the WHOLE highlighted passage — in place of the 2026-09-08 dashed ring, which
-// was an outline on the inline mark and so painted once per line fragment (a wrapped passage wore a stack of dashed
-// boxes). The fill keeps saying pending vs landed exactly as before (T237: the green .busy wash = a reply still
-// being written, the 45% yellow .unread tier = landed); the box is the only cue for unread, and only on unread.
-// Source pins (no jsdom harness for the renderers); the union geometry itself is measured on the served page by
-// tests/test_comment_outline_served.py.
+// The comment mark's UNREAD cue: a landed reply you have not opened. Since T310 (the user 2026-09-10) a passage wears
+// ONE box around the WHOLE highlighted area, never a box per line — the 2026-09-08 ring was an outline on the inline
+// mark and so painted once per line fragment. Since 2026-09-12 (the user) that box is dashed in the needs-you red the
+// tab strip uses, and the cue follows the row count: a passage on one or two lines wears the per-fragment ring after
+// all (it hugs the text, where a box over two lines takes in the un-highlighted head and tail), three or more the box.
+// The painter (paintCommentOutlines) makes that call and toggles .cmt-ring on the marks; no mark rule but that one
+// carries an outline. The fill keeps saying pending vs landed exactly as before (T237: the green .busy wash = a reply
+// still being written, the 45% yellow .unread tier = landed). Source pins (no jsdom harness for the renderers); the
+// geometry itself is measured on the served page by tests/test_comment_outline_served.py.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -13,12 +15,16 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-test("the per-fragment dashed ring is gone: no outline on the mark itself, in any state", () => {
-  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/);
-  assert.doesNotMatch(CSS, /dashed var\(--st-awaiting-bg\); outline-offset: 1px/);
+test("the ring is the painter's call: only mark.cmt-hl.unread.cmt-ring carries an outline; plain .unread still does not", () => {
+  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/, "unread alone decides nothing: the row count does");
+  assert.match(CSS, /^mark\.cmt-hl\.unread\.cmt-ring \{ outline: 1\.5px dashed var\(--st-awaiting-bg\); outline-offset: 1px; \}$/m, "the one- or two-row cue: the tab strip's needs-you ring, hugging the text");
   const marks = CSS.match(/^mark\.cmt-hl[^{]*\{[^}]*\}/gms) || [];
-  assert.ok(marks.length >= 6, "the mark rules are found");
-  for (const rule of marks) assert.doesNotMatch(rule, /outline/, "an outline on an inline mark paints per line fragment: " + rule);
+  assert.ok(marks.length >= 7, "the mark rules are found");
+  for (const rule of marks) {
+    if (rule.startsWith("mark.cmt-hl.unread.cmt-ring ")) continue;
+    assert.doesNotMatch(rule, /outline/, "an outline on an inline mark paints per line fragment — only the painter's .cmt-ring may, on one or two rows: " + rule);
+  }
+  assert.match(RENDER, /m\.classList\.toggle\("cmt-ring", ring\);/, "the painter toggles it");
 });
 
 test("read marks wear no box, and the fill tiers are byte-untouched — the colour still says pending vs landed", () => {

--- a/ui/webview/comment-outline.test.ts
+++ b/ui/webview/comment-outline.test.ts
@@ -1,7 +1,13 @@
-// T310 (the user 2026-09-10): an unread comment thread's cue is ONE solid outline in the scroll notch's yellow around
-// the WHOLE highlighted area — never a box per line. Source pins for the rule, the painter and its hooks; the
-// geometry (exactly one box per unread thread, covering every fragment; gone once read) is measured on the served
-// page by tests/test_comment_outline_served.py.
+// T310 (the user 2026-09-10) gave an unread comment thread ONE box around the WHOLE highlighted area, never a box per
+// line. On 2026-09-12 the user asked for two things on top of that geometry: the stroke is the tab strip's needs-you
+// ring again (dashed, in --st-awaiting-bg, the idiom for "something here waits on you", which the 2026-09-10 change
+// dropped when it matched the scroll notch's ink), and the cue follows the passage's LINE COUNT: one or two rows wear
+// the pre-T310 ring on each fragment (it hugs the text; a box over two lines encloses the first line's un-highlighted
+// head and the second's tail), three or more the single box (a stack of rings reads as many things; one box as one).
+// The rail's unread tick agrees by colour: its halo is the same red, its fill still the notch's ink. Source pins for the
+// rules, the painter and its hooks; the geometry (one box per unread thread of three rows or more, covering every
+// fragment; a ring per fragment under that; both gone once read) is measured on the served page by
+// tests/test_comment_outline_served.py.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -10,35 +16,56 @@ import * as path from "node:path";
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
-const RULE = /\.cmt-outline \{ position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;\s*\n\s*outline: 1\.5px solid var\(--cmt-hl-outline\); border-radius: 3px; \}/;
+const RULE = /\.cmt-outline \{ position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;\s*\n\s*outline: 1\.5px dashed var\(--st-awaiting-bg\); border-radius: 3px; \}/;
+const RING = /mark\.cmt-hl\.unread\.cmt-ring \{ outline: 1\.5px dashed var\(--st-awaiting-bg\); outline-offset: 1px; \}/;
+const painter = () => {
+  const at = RENDER.indexOf("function paintCommentOutlines(sid: string): void {");
+  assert.ok(at > 0, "the painter exists");
+  return RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+};
 
-test("one solid outline in the notch's yellow: the same token the tick wears, as an outline on a positioned box", () => {
+test("the box: one DASHED outline in the needs-you red — the tab strip's idiom — as an outline on a positioned box", () => {
   assert.match(CSS, RULE);
   const rule = CSS.match(RULE)![0];
-  assert.match(rule, /outline: 1\.5px solid var\(--cmt-hl-outline\)/, "solid, not dashed; the token, never a hex");
-  assert.doesNotMatch(rule, /#[0-9a-fA-F]{3,6}\b|border(?!-radius)[-\w]*:|box-shadow|background/, "an outline on an empty box: nothing reflows, nothing tints");
+  assert.match(rule, /outline: 1\.5px dashed var\(--st-awaiting-bg\)/, "dashed, in the token the tab strip's needs-you ring wears; never a hex, never solid");
+  assert.doesNotMatch(rule, /#[0-9a-fA-F]{3,6}\b|border(?!-radius)[-\w]*:|box-shadow|background|cmt-hl/, "an outline on an empty box: nothing reflows, nothing tints, none of the notch's ink");
   assert.match(rule, /position: absolute/, "positioned: the text under it never moves");
   assert.match(rule, /pointer-events: none/, "hover and click land on the marks beneath");
-  // the notch for the same thread: .cmt-tick's fill is the very same token, in both themes — the INK, which is the
-  // highlighter yellow itself in the dark theme and a darker amber on the cream page (the review measured the yellow
-  // at 1.1:1 there: a fill reads, a line does not); the fill tokens stay the highlighter yellow in both
-  assert.match(CSS, /\.cmt-tick \{[^}]*background: var\(--cmt-hl-outline\);/s);
-  assert.match(CSS, /\.cmt-tick\.unread \{[^}]*color-mix\(in srgb, var\(--cmt-hl-outline\) 85%, transparent\)/s, "the unread tick's ring, the same ink");
+  // the idiom it borrows: a session tab that waits on you
+  assert.match(CSS, /\.tab\.tab-awaiting \{ --state: var\(--st-awaiting-bg\); \}/);
+  assert.match(CSS, /\.tab\.tab-awaiting, \.tab\.tab-blocked, \.tab\.tab-retrying \{ outline: 2px dashed var\(--state\);/);
+  // the token is the same red in both themes, and theme-parity holds it to 3:1 against the page: it is a LINE now
   const dark = CSS.split("body.theme-light {")[0];
   const light = CSS.split("body.theme-light {")[1].split("\n}")[0];
-  assert.match(dark, /--cmt-hl: #ffd54a;/);
-  assert.match(dark, /--cmt-hl-outline: #ffd54a;/, "dark: the ink IS the fill's yellow");
-  assert.match(light, /--cmt-hl: #FFDF70;/);
+  assert.match(dark, /--st-awaiting-bg: #c0392b;/);
+  assert.match(light, /--st-awaiting-bg: #c0392b;/);
+  assert.match(fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "theme-parity.test.ts"), "utf8"), /\["--st-awaiting-bg", "--bg", 3\]/);
+});
+
+test("the ring: the unread marks of a one- or two-row passage wear the per-fragment dashed ring — the only mark rule with an outline", () => {
+  assert.match(CSS, RING);
+  const marks = CSS.match(/^mark\.cmt-hl[^{]*\{[^}]*\}/gms) || [];
+  assert.ok(marks.length >= 7, "the mark rules are found");
+  assert.deepEqual(marks.filter((r) => /outline/.test(r)).map((r) => r.split(" {")[0]), ["mark.cmt-hl.unread.cmt-ring"],
+    "plain .unread carries none: which cue a thread wears is the painter's call, by row count");
+});
+
+test("the notch keeps its own ink; its UNREAD halo agrees with the box by colour (a 10×6 tick cannot show a dash)", () => {
+  assert.match(CSS, /\.cmt-tick \{[^}]*background: var\(--cmt-hl-outline\);/s, "the fill stays the comment ink: 'a comment here'");
+  assert.match(CSS, /\.cmt-tick\.unread \{[^}]*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px var\(--st-awaiting-bg\); \}/s, "the halo: 'waits on you', the box's red, past the same 1.5px gap");
+  assert.doesNotMatch(CSS.match(/\.cmt-tick\.unread \{[^}]*\}/s)![0], /cmt-hl-outline|color-mix/, "no yellow halo left");
+  const dark = CSS.split("body.theme-light {")[0];
+  const light = CSS.split("body.theme-light {")[1].split("\n}")[0];
+  assert.match(dark, /--cmt-hl-outline: #ffd54a;/, "dark: the notch's ink IS the fill's yellow");
   assert.match(light, /--cmt-hl-outline: #8f6a00;/, "light: amber ink, 4.2:1 on the cream page (theme-parity pins the ratio)");
   assert.match(fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "theme-parity.test.ts"), "utf8"), /\["--cmt-hl-outline", "--bg", 3\]/);
 });
 
 test("a fragment inside a scrolling container counts only where it shows: cut to every scrolling ancestor, and the pane's scroll listener captures inner scrolls", () => {
-  const at = RENDER.indexOf("function paintCommentOutlines(sid: string): void {");
-  const fn = RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+  const fn = painter();
   assert.match(fn, /for \(let a = m\.parentElement; a && a !== turn; a = a\.parentElement\) \{\s*\n\s*const cs = getComputedStyle\(a\);\s*\n\s*if \(cs\.overflowX === "visible" && cs\.overflowY === "visible"\) continue;/, "every ancestor that clips, up to the turn");
   assert.match(fn, /cl = Math\.max\(cl, ar\.left\); ct = Math\.max\(ct, ar\.top\); cr = Math\.min\(cr, ar\.right\); cb = Math\.min\(cb, ar\.bottom\);/, "the intersection of their rects");
-  assert.match(fn, /if \(qr <= ql \|\| qb <= qt\) continue;\s*\/\/ clipped away by a scrolling ancestor/, "a fragment scrolled out adds nothing");
+  assert.match(fn, /if \(qr <= ql \|\| qb <= qt\) continue;\s*\/\/ clipped away by a scrolling ancestor/, "a fragment scrolled out adds nothing to the box");
   // a notice body is such a container; so is a wide display formula
   assert.match(CSS, /\.notice-body \{ margin-top: 7px; max-height: 420px; overflow: auto;/);
   assert.match(CSS, /\.katex-display \{ overflow-x: auto; overflow-y: hidden; \}/);
@@ -46,10 +73,8 @@ test("a fragment inside a scrolling container counts only where it shows: cut to
   assert.match(RENDER, /c\.addEventListener\("scroll", scheduleRailSticky, \{ passive: true, capture: true \}\);/);
 });
 
-test("the painter: one box per unread thread, a child of the turn, sized to the union of the fragments' client rects", () => {
-  const at = RENDER.indexOf("function paintCommentOutlines(sid: string): void {");
-  assert.ok(at > 0, "the painter exists");
-  const fn = RENDER.slice(at, RENDER.indexOf("\n}\n", at));
+test("the painter: one box per unread thread of three rows or more, a child of the turn, sized to the union of the fragments' client rects", () => {
+  const fn = painter();
   assert.match(fn, /querySelectorAll\("mark\.cmt-hl\.unread"\)/, "unread marks only");
   assert.match(fn, /want\.get\(tid\)/, "grouped by thread: one box per tid");
   assert.match(fn, /m\.getClientRects\(\)/, "every line fragment of every mark of the thread");
@@ -58,9 +83,32 @@ test("the painter: one box per unread thread, a child of the turn, sized to the 
   assert.match(fn, /box = el\("div", "cmt-outline"\); box\.dataset\.tid = tid; turn\.appendChild\(box\);/);
   assert.match(fn, /turn\.getBoundingClientRect\(\)/, "turn-relative coordinates");
   assert.match(fn, /if \(!marks \|\| marks\[0\]\.closest\("\.turn"\) !== box\.parentElement\) box\.remove\(\);/, "a box whose thread is read, resolved or gone is removed");
-  assert.match(fn, /if \(!isFinite\(l\)\) \{ box\?\.remove\(\); continue; \}/, "no fragment has a box (hidden) → no outline");
+  assert.match(fn, /if \(ring \|\| !isFinite\(l\)\) \{ box\?\.remove\(\); continue; \}/, "a ringed thread has no box; nor has one with no visible fragment (hidden, or all scrolled out)");
   assert.match(fn, /if \(box\.style\[k\] !== css\[k\]\) box\.style\[k\] = css\[k\];/, "writes only what changed: the rAF path is a measure pass most frames");
   assert.match(CSS, /^\.turn \{ position: relative;/m, "the turn is the positioning context the box relies on");
+});
+
+test("the row rule: line rows counted from the rects the painter already reads; one or two → the ring class on the fragments, three or more → the box", () => {
+  const fn = painter();
+  // a fragment opens a new row when its top sits at least half the shorter height from the current row's: fragments split
+  // across an inline-code or KaTeX host share a line (tops a padding apart), consecutive lines sit a line-height apart —
+  // a fraction of the rect's own height, never a magic pixel count
+  assert.match(fn, /let rows = 0, rowTop = 0, rowH = 0;/);
+  assert.match(fn, /if \(!rows \|\| Math\.abs\(q\.top - rowTop\) >= Math\.min\(q\.height, rowH\) \/ 2\) \{ rows\+\+; rowTop = q\.top; rowH = q\.height; \}/);
+  // counted on every fragment BEFORE the clip: the passage's shape is a fact of its layout, not of a container's scroll
+  const count = fn.indexOf("rows++"), clip = fn.indexOf("clipped away by a scrolling ancestor");
+  assert.ok(count > 0 && clip > count, "the row count precedes the clip");
+  assert.match(fn, /const ring = rows > 0 && rows <= 2;/, "one or two rows: the ring; three or more: the box; none visible: neither");
+  assert.match(fn, /for \(const m of marks\) m\.classList\.toggle\("cmt-ring", ring\);/, "the class on every fragment of the thread, on or off");
+  // zero new machinery (the user 2026-09-12): the rule rides the painter's three hooks and its existing reads — getClientRects
+  // once per mark, getBoundingClientRect once per clipping ancestor and once per turn; the painter registers nothing
+  assert.equal((fn.match(/getClientRects\(\)/g) || []).length, 1, "one rects read per mark: the rows and the union come from the same call");
+  assert.equal((fn.match(/getBoundingClientRect\(\)/g) || []).length, 2, "no per-mark layout read beyond the clip ancestors' and the turn's");
+  assert.doesNotMatch(fn, /ResizeObserver|MutationObserver|IntersectionObserver|addEventListener|requestAnimationFrame|setTimeout|setInterval/);
+  assert.equal((RENDER.match(/paintCommentOutlines\(/g) || []).length, 5, "the definition and its four call sites: the marks pass (twice), the rail's rAF scheduler, the window resize hook");
+  // the ring goes with the unread bit exactly where the box does: styleCommentMark drops it on the pass that drops unread
+  // (the popover opening, a resolve); a deleted thread's or a windowed-out turn's marks leave the DOM, class and all
+  assert.match(RENDER, /m\.classList\.toggle\("unread", !!th\.unread && th\.status === "open"\);\s*\n\s*if \(!\(th\.unread && th\.status === "open"\)\) m\.classList\.toggle\("cmt-ring", false\);/);
 });
 
 test("the box follows the marks: repainted after every marks pass, on the rail's rAF scheduler and on window resize — no timers", () => {
@@ -70,11 +118,11 @@ test("the box follows the marks: repainted after every marks pass, on the rail's
   assert.match(pass, /for \(const th of list\) ensureCommentMark\(turn, th\);[\s\S]*paintCommentOutlines\(sid\);/, "after the marks are placed");
   assert.match(RENDER, /requestAnimationFrame\(\(\) => \{ railStickyPending = false; paintRailSticky\(\); paintScrollMarks\(\); updateCommentRail\(\); if \(activeId && hasUnreadOpenThread\(activeId\)\) paintCommentOutlines\(activeId\); \}\);/,
     "the notches' and ticks' own repaint path (a re-render, the view's resize observer, every scroll frame) — gated");
-  assert.match(RENDER, /window\.addEventListener\("resize", \(\) => \{ updateCommentRail\(\); if \(activeId && hasUnreadOpenThread\(activeId\)\) paintCommentOutlines\(activeId\); \}\);/);
+  assert.match(RENDER, /window\.addEventListener\("resize", \(\) => \{ updateCommentRail\(\); if \(activeId && hasUnreadOpenThread\(activeId\)\) paintCommentOutlines\(activeId\); \}\);/,
+    "a resize can carry a passage across the two-row line; this hook is what flips it");
   // the gate is a store read, never a DOM walk: a scroll frame on a session with nothing unread costs a Map lookup
   assert.match(RENDER, /function hasUnreadOpenThread\(sid: string\): boolean \{\s*\n\s*return \(commentThreads\.get\(sid\) \|\| \[\]\)\.some\(\(t\) => !!t\.unread && t\.status === "open"\);\s*\n\}/);
   // …while the marks pass stays ungated: it is the removal path (the last unread thread gone takes its box with it)
-  const pass2 = RENDER.slice(RENDER.indexOf("function applyCommentMarks(sid: string): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function applyCommentMarks(sid: string): void {")));
-  assert.doesNotMatch(pass2, /hasUnreadOpenThread/);
-  assert.doesNotMatch(RENDER.slice(RENDER.indexOf("function paintCommentOutlines"), RENDER.indexOf("\n}\n", RENDER.indexOf("function paintCommentOutlines"))), /setTimeout|setInterval/);
+  assert.doesNotMatch(pass, /hasUnreadOpenThread/);
+  assert.doesNotMatch(painter(), /setTimeout|setInterval/);
 });

--- a/ui/webview/comments.test.ts
+++ b/ui/webview/comments.test.ts
@@ -99,14 +99,18 @@ test("an unread thread wears ONE outline box around its whole passage and a shou
   // the user 2026-08-23: the 45% unread tint alone was too subtle — a thread that replied while the
   // box was closed needs a visible element. That element was a yellow corner dot on the run's last
   // segment until 2026-09-08 (then the tab strip's dashed needs-you ring on the mark), and since
-  // 2026-09-10 it is ONE solid outline in the notch's yellow around the WHOLE highlighted area: the
-  // ring was an outline on the inline mark and painted once per line fragment, a dashed box per line.
-  // The box is a positioned child of the turn that render.ts measures from the marks (its pins live in
-  // comment-outline.test.ts). The rail tick still grows and double-rings. Both clear with the unread
-  // flag on open.
+  // 2026-09-10 it is ONE outline around the WHOLE highlighted area: the ring was an outline on the
+  // inline mark and painted once per line fragment, a dashed box per line. Since 2026-09-12 the box is
+  // dashed in the needs-you red again (the user wanted the tab strip's idiom back; matching the notch
+  // had made it solid yellow), and a passage of one or two rows wears the per-fragment ring instead —
+  // the painter's call, by row count. The box is a positioned child of the turn that render.ts measures
+  // from the marks (its pins live in comment-outline.test.ts). The rail tick still grows and
+  // double-rings, its halo in the same red. All clear with the unread flag on open.
   assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread\.hl-last::after/, "the corner dot is gone");
-  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/, "no outline on the mark itself: it would paint per line fragment");
-  assert.match(CSS, /\.cmt-outline \{ position: absolute; pointer-events: none;[^}]*outline: 1\.5px solid var\(--cmt-hl-outline\);/s, "one box, the notch's ink");
+  assert.doesNotMatch(CSS, /mark\.cmt-hl\.unread \{ outline/, "no outline on the mark by unread alone: it would paint per line fragment");
+  assert.match(CSS, /\.cmt-outline \{ position: absolute; pointer-events: none;[^}]*outline: 1\.5px dashed var\(--st-awaiting-bg\);/s, "one box, the needs-you ring");
+  assert.match(CSS, /mark\.cmt-hl\.unread\.cmt-ring \{ outline: 1\.5px dashed var\(--st-awaiting-bg\); outline-offset: 1px; \}/, "the one- or two-row ring, the same stroke");
+  assert.match(CSS, /\.cmt-tick\.unread \{[^}]*0 0 0 3px var\(--st-awaiting-bg\); \}/s, "the tick's halo agrees by colour");
   assert.match(UI, /function paintCommentOutlines\(sid: string\): void \{/);
   assert.doesNotMatch(CSS, /mark\.cmt-hl \{[^}]*position: relative;/s, "nothing left for the mark to anchor");
   assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1;/);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -9009,20 +9009,26 @@ function applyCommentMarks(sid: string): void {
   if (sid === activeId) updateReplyChips();
 }
 
-/** ONE outline around the WHOLE highlighted passage of an unread open thread (the user 2026-09-10), in the scroll
- *  notch's yellow (var(--cmt-hl)) — in place of the dashed ring each line fragment wore (an outline on the inline
- *  mark paints per fragment, so a wrapped passage read as a stack of dashed boxes). CSS cannot merge the fragments,
- *  so the box is an absolutely positioned child of the TURN (.cmt-outline, one per thread), sized to the union of the
- *  thread's mark fragments' client rects, turn-relative: it scrolls with the text and needs no repaint on scroll.
- *  Each fragment is first cut to every scrolling ancestor between its mark and the turn (a notice body, a wide formula):
- *  the box sits outside those containers, so an unclipped fragment scrolled out of one would draw over the content
- *  below. Repainted where the geometry can move — after every marks pass (each transcript rebuild and comments frame),
- *  on the rail's rAF scheduler (a re-render, the view's resize observer, every scroll in the pane, inner containers'
- *  included through the capture-phase listener) and on window resize — those two only while the session has an unread
- *  open thread (hasUnreadOpenThread: a store read, so a scroll frame with nothing to move walks no DOM); the same measure-then-write
- *  pass either way, writing only what changed. pointer-events: none, so hover and click land on the marks beneath.
- *  A box goes with its unread bit (styleCommentMark drops the class when the popover opens or the thread resolves)
- *  and with its marks (a windowed-out turn, a deleted thread); a hidden view has no boxes to measure and keeps none. */
+/** The needs-you cue on an unread open thread's passage, in the tab strip's idiom (the user 2026-09-12): a dashed stroke
+ *  in var(--st-awaiting-bg), in one of two shapes by the passage's LINE COUNT. One or two rows: a ring on each unread mark
+ *  itself (the .cmt-ring class; it hugs the text, where a box over two lines takes in the first line's un-highlighted head
+ *  and the second's tail). Three or more: ONE box around the WHOLE passage (T310, the user 2026-09-10 — an outline on the
+ *  inline mark paints per fragment, so a wrapped passage read as a stack of dashed boxes, and CSS cannot merge the
+ *  fragments), an absolutely positioned child of the TURN (.cmt-outline, one per thread) sized to the union of the
+ *  thread's mark fragments' client rects, turn-relative: it scrolls with the text and needs no repaint on scroll. Each
+ *  fragment is first cut to every scrolling ancestor between its mark and the turn (a notice body, a wide formula): the
+ *  box sits outside those containers, so an unclipped fragment scrolled out of one would draw over the content below.
+ *  The rows are counted from those same rects, before the clip, so the shape is the passage's and never flips with a
+ *  container's scroll. Repainted where the geometry can move — after every marks pass (each transcript rebuild and
+ *  comments frame), on the rail's rAF scheduler (a re-render, the view's resize observer, every scroll in the pane, inner
+ *  containers' included through the capture-phase listener) and on window resize (which can carry a passage across the
+ *  two-row line: that hook is what swaps the shape) — those two only while the session has an unread open thread
+ *  (hasUnreadOpenThread: a store read, so a scroll frame with nothing to move walks no DOM). The row rule added no hook
+ *  and no layout read: one pass over the rects the union already needs (the user 2026-09-12: zero new machinery). The
+ *  same measure-then-write pass either way, writing only what changed. pointer-events: none on the box, so hover and
+ *  click land on the marks beneath. Both shapes go with the unread bit (styleCommentMark drops the class, and the ring
+ *  with it, when the popover opens or the thread resolves) and with the marks (a windowed-out turn, a deleted thread); a
+ *  hidden view has no boxes to measure and keeps none. */
 /** The cheap gate for the geometry hooks (the rail scheduler fires on every scroll frame, the resize listener on every
  *  resize): a session with no unread open thread has no box to move, so those paths never walk its DOM (review find,
  *  T310). Read from the thread store, no DOM. The marks pass calls the painter unconditionally: it is the removal path
@@ -9053,6 +9059,12 @@ function paintCommentOutlines(sid: string): void {
     const turn = marks[0].closest(".turn") as HTMLElement | null;
     if (!turn) continue;
     let l = Infinity, t = Infinity, r = -Infinity, b = -Infinity;
+    // the LINE ROWS the passage spans, from the same rects (the user 2026-09-12): a fragment opens a new row when its top
+    // sits at least half the shorter height from the current row's — fragments split across an inline-code or KaTeX host
+    // share a line, their tops a padding apart; consecutive lines sit a line-height apart — a fraction of the rect's own
+    // height, never a magic pixel count. Counted on every fragment BEFORE the clip: the passage's shape is a fact of its
+    // layout, not of a container's scroll, so the cue never swaps while a notice body scrolls under it.
+    let rows = 0, rowTop = 0, rowH = 0;
     for (const m of marks) {
       // a fragment counts only where it can be SEEN: the box lives on the turn, outside any scrolling container between
       // the mark and the turn (a notice body at its max height, a wide formula), whose clip the fragment's own rect
@@ -9067,13 +9079,19 @@ function paintCommentOutlines(sid: string): void {
       }
       for (const q of Array.from(m.getClientRects())) {
         if (!q.width && !q.height) continue;
+        if (!rows || Math.abs(q.top - rowTop) >= Math.min(q.height, rowH) / 2) { rows++; rowTop = q.top; rowH = q.height; }
         const ql = Math.max(q.left, cl), qt = Math.max(q.top, ct), qr = Math.min(q.right, cr), qb = Math.min(q.bottom, cb);
         if (qr <= ql || qb <= qt) continue;              // clipped away by a scrolling ancestor
         l = Math.min(l, ql); t = Math.min(t, qt); r = Math.max(r, qr); b = Math.max(b, qb);
       }
     }
+    // ONE or TWO rows: the ring on each fragment (mark.cmt-hl.unread.cmt-ring) hugs the text, where a box would enclose the
+    // first line's un-highlighted head and the second's tail; THREE or more: one box reads as one thing where a stack of
+    // rings reads as many. No visible fragment at all: neither, until a paint that sees one decides.
+    const ring = rows > 0 && rows <= 2;
+    for (const m of marks) m.classList.toggle("cmt-ring", ring);
     let box = turn.querySelector(`:scope > .cmt-outline[data-tid="${cssEscape(tid)}"]`) as HTMLElement | null;
-    if (!isFinite(l)) { box?.remove(); continue; }        // no visible fragment (a display:none ancestor, or all scrolled out)
+    if (ring || !isFinite(l)) { box?.remove(); continue; }   // ringed, or no visible fragment (a display:none ancestor, or all scrolled out)
     if (!box) { box = el("div", "cmt-outline"); box.dataset.tid = tid; turn.appendChild(box); }
     const tr = turn.getBoundingClientRect();
     const css = { left: (l - tr.left - PAD) + "px", top: (t - tr.top - PAD) + "px", width: (r - l + 2 * PAD) + "px", height: (b - t + 2 * PAD) + "px" };
@@ -9291,6 +9309,7 @@ function ensureCommentMark(turn: HTMLElement, th: CommentThread): void {
 function styleCommentMark(m: HTMLElement, th: CommentThread): void {
   m.classList.toggle("resolved", th.status === "resolved" || th.status === "merged");
   m.classList.toggle("unread", !!th.unread && th.status === "open");
+  if (!(th.unread && th.status === "open")) m.classList.toggle("cmt-ring", false);   // the ring is the painter's call on an UNREAD mark (paintCommentOutlines, by row count): it goes with the bit, on this same pass
   m.classList.toggle("busy", commentInFlight(th));
   m.title = th.status === "promoted" ? "thread, now the session '" + th.promotedName + "'"
     : th.status === "merged" ? "relayed thread: its discussion was sent back into the session"

--- a/ui/webview/scroll-marks.test.ts
+++ b/ui/webview/scroll-marks.test.ts
@@ -207,9 +207,10 @@ test("a reply dot sits at its anchor's position in the notches' own frame, over 
 
 test("the dot is the comment's landed colour; UNREAD shouts; keyed on the kernel's bit on an open thread", () => {
   // the tick's fill is the comment INK (T310): the highlighter yellow itself in the dark theme, a darker amber on the cream
-  // page, the same token the unread passage's outline box wears — never a raw hex
+  // page — never a raw hex; its UNREAD halo is the needs-you red the passage's box and ring wear (the user 2026-09-12:
+  // the rail agrees with the box's cue, by colour, since a 10×6 tick cannot show a dash)
   assert.match(CSS, /\.cmt-tick \{\s*\n\s*position: absolute; right: 1px; width: 8px; height: 4px;[\s\S]{0,120}background: var\(--cmt-hl-outline\);/, "the ink token, never a raw hex");
-  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;\s*\n\s*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px color-mix\(in srgb, var\(--cmt-hl-outline\) 85%, transparent\); \}/,
+  assert.match(CSS, /\.cmt-tick\.unread \{ width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;\s*\n\s*box-shadow: 0 0 0 1\.5px var\(--bg\), 0 0 0 3px var\(--st-awaiting-bg\); \}/,
     "…and lifted above a read sibling at the same top (nested-marks.test.ts)");
   assert.match(RAIL, /\+ \(th\.unread && th\.status === "open" \? " unread" : ""\)/, "the same predicate the mark's ring and the reply chips read");
   assert.match(RAIL, /\+ ":" \+ \(t\.th\.unread \? 1 : 0\)/, "the unread bit rides the signature: a reply landing repaints the dot");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -186,7 +186,7 @@ body.scheme-solarized-dark {
      stroke, DISTINCT from both the accent blue (selection/chrome) and the working-status yellow
      chip. Text-highlight use only — comment chrome (badge, buttons, chips) stays var(--accent). */
   --cmt-hl: #ffd54a;
-  --cmt-hl-outline: #ffd54a;   /* the ink of the comment notch and the unread box: the fill's yellow here, darker on cream (T310) */
+  --cmt-hl-outline: #ffd54a;   /* the ink of the comment notch (the rail tick's fill): the fill's yellow here, darker on cream (T310) */
   /* fast mode ON — the CLI's own fastMode orange, a STATUS color (means "this session runs fast
      mode"), so the badge reads the same here as in the Claude Code TUI. Not the accent. */
   --fast: #ff6a00;
@@ -3551,21 +3551,27 @@ mark.cmt-hl {
   cursor: pointer;
 }
 mark.cmt-hl.unread { background: color-mix(in srgb, var(--cmt-hl) 45%, transparent); }
-/* UNREAD = ONE outline around the WHOLE passage (the user 2026-09-10): a landed reply you have not opened draws a
-   single solid box in the scroll notch's ink — var(--cmt-hl-outline), the colour .cmt-tick wears for the same thread:
-   the highlighter yellow itself in the dark theme, a darker amber on the cream page, where the yellow reads as a fill
-   but not as a line — around the union of the highlight's line fragments, clipped to any scrolling container between
-   the marks and the turn (a notice body, a wide formula). The 2026-09-08 dashed ring was an outline on the inline
-   mark, which Chromium paints once per line fragment, so a wrapped passage wore a stack of dashed boxes. CSS
-   cannot merge a mark's fragments (box-decoration-break: clone keeps them apart), so the box is a positioned
-   child of the TURN that render.ts's paintCommentOutlines measures from the marks' client rects — turn-relative,
-   so it scrolls with the text and needs no repaint on scroll; repainted after every marks pass, on the rail's
-   rAF scheduler (a re-render, the view's resize) and on window resize. An OUTLINE on an empty box, so nothing
-   reflows when it comes and goes; 1px clear of the glyphs; transparent to the pointer, so hover and click land
-   on the marks beneath. The fill still says pending vs landed exactly as before (the 45% tier above, .busy's
-   green below); read marks have no box. */
+/* UNREAD = the needs-you cue on the passage: a landed reply you have not opened. Since 2026-09-12 (the user) the stroke
+   is the one the tab strip wears for a session that waits on you — .tab.tab-awaiting's dashed ring, in the same red,
+   var(--st-awaiting-bg) — and which of TWO shapes carries it follows the passage's LINE COUNT, decided by render.ts's
+   paintCommentOutlines from the marks' client rects:
+   · ONE or TWO rows: a dashed ring on each unread mark itself (mark.cmt-hl.unread.cmt-ring below), which hugs exactly
+     the highlighted text. A box over two lines would enclose the first line's un-highlighted head and the second's tail.
+   · THREE or more rows: ONE box around the WHOLE passage (T310, the user 2026-09-10) — a ring per fragment there reads
+     as a stack of many things, one box as one. An outline on the inline mark paints once per line fragment and CSS
+     cannot merge them (box-decoration-break: clone keeps them apart), so the box is a positioned child of the TURN that
+     the painter sizes to the union of the fragments' client rects, each cut to any scrolling container between the
+     marks and the turn (a notice body, a wide formula); turn-relative, so it scrolls with the text and needs no repaint
+     on scroll; repainted after every marks pass, on the rail's rAF scheduler (a re-render, the view's resize) and on
+     window resize — a resize can carry a passage across the two-row line, and that hook is what swaps the shape. An
+     OUTLINE on an empty box, so nothing reflows when it comes and goes; 1px clear of the glyphs; transparent to the
+     pointer, so hover and click land on the marks beneath.
+   The 2026-09-10 change had made the box SOLID in the scroll notch's ink (var(--cmt-hl-outline)) as a side effect of
+   matching the notch; the notch keeps that ink (.cmt-tick below) and only its UNREAD halo joins this red. The fill still
+   says pending vs landed exactly as before (the 45% tier above, .busy's green below); read marks wear neither shape. */
 .cmt-outline { position: absolute; pointer-events: none; user-select: none; box-sizing: border-box;
-  outline: 1.5px solid var(--cmt-hl-outline); border-radius: 3px; }
+  outline: 1.5px dashed var(--st-awaiting-bg); border-radius: 3px; }
+mark.cmt-hl.unread.cmt-ring { outline: 1.5px dashed var(--st-awaiting-bg); outline-offset: 1px; }
 /* the turn's rail segment shouts an unread thread (the user 2026-08-23): the identity line's own
    segment tints the comment yellow — wider and fully opaque so it reads from across the pane — and
    the rail-hit strip over it opens the thread on click. applyCommentMarks clears the class the
@@ -3818,16 +3824,20 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .cmt-tick {
   position: absolute; right: 1px; width: 8px; height: 4px;
   border: 0; border-radius: 2px; padding: 0;
-  background: var(--cmt-hl-outline); opacity: 0.75; pointer-events: auto; cursor: pointer;   /* the ink the unread box shares (T310) */
+  background: var(--cmt-hl-outline); opacity: 0.75; pointer-events: auto; cursor: pointer;   /* the notch's own ink (T310); the unread halo below is the needs-you red */
 }
 .cmt-tick:hover { opacity: 1; }
 .cmt-tick.resolved { opacity: 0.3; }
 /* an UNREAD thread's tick shouts (the user 2026-08-23): full width, taller, double-ringed — the old
-   faint glow read as a rendering artifact, not as "new here". It also stacks ABOVE its read siblings:
-   two threads on one passage share a `top`, and the later-painted read tick covered the unread one
+   faint glow read as a rendering artifact, not as "new here". The outer ring is the needs-you red the
+   passage's box and ring wear (the user 2026-09-12 wanted the rail to agree with the box's cue; a 10×6
+   tick cannot show a dash, so it agrees by colour), past a 1.5px gap in the page colour; the fill stays
+   the notch's ink, so the tick still says "a comment here" and the halo "it waits on you" — the same
+   pattern as .cmt-tick.busy wearing the await green. It also stacks ABOVE its read siblings: two
+   threads on one passage share a `top`, and the later-painted read tick covered the unread one
    (the user 2026-09-10) */
 .cmt-tick.unread { width: 10px; height: 6px; right: 0; opacity: 1; z-index: 1;
-  box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px color-mix(in srgb, var(--cmt-hl-outline) 85%, transparent); }
+  box-shadow: 0 0 0 1.5px var(--bg), 0 0 0 3px var(--st-awaiting-bg); }
 /* a WRITING thread's tick wears the same await-green as the passage (the user 2026-08-24: the
    marching-ants crawl — the "spinning dots" — is retired; the state COLOR is the in-flight cue,
    here as everywhere on the rail) */

--- a/ui/webview/theme-parity.test.ts
+++ b/ui/webview/theme-parity.test.ts
@@ -64,7 +64,8 @@ const PAIRS: Array<[string, string, number]> = [
   ["--dim", "--bg", 4.5],
   ["--fg", "--surface-raised", 4.5],
   ["--accent", "--bg", 3],
-  ["--cmt-hl-outline", "--bg", 3],   // the comment notch and the unread box: a LINE, so it must read against the page (T310)
+  ["--cmt-hl-outline", "--bg", 3],   // the comment notch (the rail tick's fill): a LINE, so it must read against the page (T310)
+  ["--st-awaiting-bg", "--bg", 3],   // the unread passage's dashed box and ring, and the tick's halo (2026-09-12): a line in the needs-you red
   ["--accent-fg", "--accent", 3],
   ["--warn", "--bg", 3],
   ["--err", "--bg", 3],


### PR DESCRIPTION
Tier: fix

## Why

T310 (#1345, 2026-09-10) made an unread comment thread's cue ONE box around the whole passage, which fixed the stack of per-line rings. Making that box SOLID in the scroll notch's yellow was a side effect of matching the notch, not a ruling anyone asked for, and it dropped the needs-you cue: the dashed ring the tab strip wears for a session that waits on you. The user (2026-09-12) wants that idiom back, wants the shape to follow the passage's line count, and wants the rail tick to agree.

## Change

- `.cmt-outline` strokes `1.5px dashed var(--st-awaiting-bg)`: the same token `.tab.tab-awaiting` resolves to. It is defined in both theme blocks already (`#c0392b`; 3.1:1 on the dark page, 4.6:1 on cream), so no new token; `theme-parity.test.ts` now pins it at 3:1 against `--bg` as a line. Geometry, painter and repaint hooks from T310 are unchanged.
- Line-count rule: a passage on ONE or TWO rows wears the pre-T310 per-fragment ring on its unread marks (`mark.cmt-hl.unread.cmt-ring { outline: 1.5px dashed var(--st-awaiting-bg); outline-offset: 1px; }`) and NO box; THREE or more rows keep the single box and no ring. A ring hugs the text where a box over two lines encloses the first line's un-highlighted head and the second's tail; from three rows up a stack of rings reads as many things and one box as one.
- `paintCommentOutlines` counts the rows from the client rects it already reads for the union: a fragment opens a new row when its top sits at least half the shorter height from the current row's (a mark split across an inline-code or KaTeX host yields several rects on one line, tops a padding apart; consecutive lines sit a line-height apart). Counted before the clip, so the shape is the passage's and never flips with a scrolling container. `styleCommentMark` drops the ring class with the unread bit on the same pass the box goes (popover open, resolve); a deleted thread's or windowed-out turn's marks leave the DOM, class and all.
- `.cmt-tick.unread`'s outer halo is `var(--st-awaiting-bg)` (a 10x6 tick cannot show a dash, so the rail agrees by colour, past the same 1.5px page-coloured gap); the tick's fill stays the notch's ink, `--cmt-hl-outline`.
- Untouched: fill tiers (45% landed, green busy), the notch's own colour, read marks (no box, no ring), the rail segment tint.

**Hooks and cost.** No new machinery: no ResizeObserver, MutationObserver, IntersectionObserver, scroll or resize listener, rAF loop or timer. The repaint fires from the painter's three existing hooks only: the marks pass (`applyCommentMarks`, both call sites), the rail's rAF scheduler (`scheduleRailSticky`, gated by `hasUnreadOpenThread`), and the existing `window` resize hook (also gated), which is what swaps ring and box when a resize carries a passage across two rows. Per repaint the rule adds one pass over the `getClientRects()` results the union already needs plus a `classList.toggle` per mark; no extra layout read (`comment-outline.test.ts` pins one `getClientRects()` and two `getBoundingClientRect()` in the painter, and the call-site count).

## Tests (all fail on the previous CSS and painter)

- `ui/webview/comment-outline.test.ts`: the dashed box rule, the ring rule as the only mark rule with an outline, the tick's halo, the row count and class toggle, the hook and read counts.
- `ui/webview/comment-mark.test.ts`, `comments.test.ts`, `scroll-marks.test.ts`, `theme-parity.test.ts`: pins updated to the new stroke, ring and halo.
- `tests/test_comment_outline_served.py`: on the served chat page, in both themes, a one-line and a two-line passage ring on every fragment with no box; a five-line passage and a three-line passage inside a scrolled notice body wear one dashed box each (the latter only while visible) and no ring; the ring/box colour equals the computed `--st-awaiting-bg`; the unread tick's halo is that red and its fill the notch's ink; a 420px viewport carries the two-line passage past two rows and swaps its ring for the box, 640px swaps back; opening a thread drops its cue on the same pass.

Ran: `npm run typecheck` clean; `npm test` 4549 tests, 4543 pass, 1 fail (the pre-existing KaTeX fraction-layout test on this box), 5 skipped; `npm run build` clean; full pytest in chunks: 12,526 passed, 5 failed, of which 3 reproduce on the untouched main checkout (`test_kernel_awaiting_stamp`, `test_feed_focus_served`, `test_asm_checkpoint_served`) and 2 pass when run alone (`test_kernel_remote_identity`, `test_perf_stats`: load-sensitive under four parallel suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
