### PR TITLE
Chat: a path in a fenced code block links too, on the kernel's verdict and under the viewer's code-aware gate

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -147,7 +147,8 @@ same document scrolls to it when the document has a heading or an anchor by that
 click, since a section of the shown file has no tab of its own. One click does one thing: a plain
 click acts in the dashboard, and a Cmd-click (Ctrl on Windows and Linux) or a middle-click opens
 the link in a browser tab of its own. Inside a file the test for a path is stricter than the one
-a chat message gets: a path links only when it has a slash and a file extension, starts on its
+a chat message's prose gets, and a fenced code block in a chat message follows the file's test
+too, linking a path only once the kernel has verified it is a file: a path links only when it has a slash and a file extension, starts on its
 own, at the start of a line or after a space, a quote, a bracket, a comma, a semicolon, an
 equals sign, a pipe or Markdown's `*` (so `$HOME/docs/a.md`, `@scope/pkg/index.js` and
 `C:/Users/x.txt` stay text), is not part of a web address, does not start with a site name

--- a/ui/webview/chat-inline-preview.test.ts
+++ b/ui/webview/chat-inline-preview.test.ts
@@ -157,7 +157,7 @@ test("a verified relative path is previewable exactly like an absolute one — t
   // eager and the expanded render hand previewFull the SAME entry previewable carries — pin lookup
   // included, so a relative embed rides its own pin key ((pathPins || {})[p]).
   assert.match(LINKS, /const target = isUri \? fileUriToPath\(tok\) : \(fixed \?\? tok\);\n\s*const open = opts && opts\.resolve \? opts\.resolve\(target\) : target;/);   // the walk's open target (path-links.ts; the chat passes no resolve)…
-  assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{/);   // …is what the chat reads per hit
+  assert.match(RENDER, /for \(const \{ el: link, open, verified, inPre \} of linkifyPathTokens\(root, pathLinks, FENCE_WALK\)\) \{/);   // …is what the chat reads per hit (a fenced hit is skipped for the preview, 2026-09-12)
   assert.match(RENDER, /previewable\.push\(open\);/);
   assert.match(PREVIEW, /const ext = path\.slice\(path\.lastIndexOf\("\."\) \+ 1\)\.toLowerCase\(\);/);
   assert.match(RENDER, /previewFull\(p, renderingOwnerSid \?\? activeId, kernelVerified\.has\(p\), \(pathPins \|\| \{\}\)\[p\]\)/);

--- a/ui/webview/chat-path-links.test.ts
+++ b/ui/webview/chat-path-links.test.ts
@@ -43,7 +43,8 @@ test("membership in pathLinks gates the link, and the map's value is the OPEN ta
   assert.match(LINKS, /a\.setAttribute\("title", "Open " \+ open\);/);
   // …and the chat binds the click per span, off the span's own data (the walk marks; render.ts acts)
   assert.match(RENDER, /const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";/);
-  assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{\n\s*bindPathLink\(link\);/);
+  assert.match(RENDER, /for \(const \{ el: link, open, verified, inPre \} of linkifyPathTokens\(root, pathLinks, FENCE_WALK\)\) \{\n\s*bindPathLink\(link\);/,
+    "the chat's walk, with its fenced-block options (2026-09-12; file-uri-link.test.ts pins them)");
 });
 
 test("file:// URIs are explicit absolute paths — never gated on the map", () => {

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -34,12 +34,20 @@ test("linkify runs on chat message bodies (assistant reply + user bubble + nudge
   assert.equal(uses.length, 4, "linkifyFileUris is defined once and applied to exactly the three chat bodies");
 });
 
-test("linkify works inside INLINE backticks (agents backtick paths), skips only fenced code + existing links, trims trailing punctuation", () => {
-  // inline <code> is NOT skipped — a `file://…` path in backticks still linkifies; only fenced <pre> + links are skipped
+test("linkify works inside INLINE backticks (agents backtick paths), skips existing links, trims trailing punctuation; a fenced block links on the kernel's verdict under the viewer's code gate (2026-09-12)", () => {
+  // inline <code> is NOT skipped — a `file://…` path in backticks still linkifies; links and inline SVGs are dead text
   assert.match(LINKS, /export const DEAD_TEXT = "a, \.file-uri-link, svg";/);
-  assert.match(LINKS, /const skip = opts && opts\.inPre \? DEAD_TEXT : DEAD_TEXT \+ ", pre";/, "the chat skips a link, an inline SVG and a fenced block; never inline code");
+  assert.match(LINKS, /const skip = opts && opts\.inPre \? DEAD_TEXT : DEAD_TEXT \+ ", pre";/, "a surface that asks for no fenced walk skips the block; never inline code");
   assert.doesNotMatch(LINKS, /DEAD_TEXT \+ ", code/);
   assert.match(LINKS, /tok = tok\.slice\(0, tok\.length - trail\[0\]\.length\)/);
+  // the chat asks for the fenced walk (the user 2026-09-12: a report's path printed in a ``` block did not link): the
+  // kernel's verdict or nothing inside a fence, the viewer's code-aware gate there, the fence's rows as units, and a
+  // fenced hit opens the file and previews on hover like any link, and renders no figure under a code sample
+  assert.match(RENDER, /^import \{ viewerPathGate \} from "\.\/file-view-links";/m);
+  assert.match(RENDER, /^const FENCE_WALK: PathLinkOptions = \{\n\s*inPre: true, preVerified: true, unit: "\.cl",\n\s*accept: \(tok, ctx\) => !ctx\.inPre \|\| viewerPathGate\(tok, ctx\),/m);
+  assert.match(RENDER, /for \(const \{ el: link, open, verified, inPre \} of linkifyPathTokens\(root, pathLinks, FENCE_WALK\)\) \{\n\s*bindPathLink\(link\);\n\s*armPreview\(link, link\.textContent \|\| "", open\);\n\s*absorbFragment\(link\);\n\s*if \(verified\) kernelVerified\.add\(open\);[^\n]*\n\s*if \(inPre\) continue;/);
+  assert.match(LINKS, /if \(!isUri && span\.inPre && opts && opts\.preVerified && typeof fixed !== "string"\) continue;/, "fenced: the kernel's word or nothing");
+  assert.match(CSS, /^pre code \.file-uri-link \{ color: var\(--accent\); \}/m, "the link keeps the accent over the highlight's token colour");
 });
 
 test(".file-uri-link is styled as a wrapping accent link", () => {

--- a/ui/webview/file-view-links.test.ts
+++ b/ui/webview/file-view-links.test.ts
@@ -759,7 +759,7 @@ test("source: the body's listener and its gesture: a drag-select opens nothing, 
   const opener = RENDER.slice(RENDER.indexOf('document.addEventListener("click", (e) => {\n  const a = (e.target as HTMLElement)?.closest?.("a[href]")'), RENDER.indexOf("}, true);", RENDER.indexOf('closest?.("a[href]")')));
   assert.match(opener, /if \(!a\) return;\n(?:\s*\/\/[^\n]*\n)*\s*if \(!a\.draggable && selectionOpenIn\(a\)\) \{ e\.preventDefault\(\); return; \}\n\s*const href = a\.getAttribute\("href"\) \|\| "";/,
     "the chat's opener: for a non-draggable anchor only, the selection open inside it (the click that ends a drag-select: cancelled, never opened; a chat anchor is draggable and a selection left around it by a triple-click is not a drag on it), then the href");
-  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens, selectionOpenIn \} from "\.\/path-links";/);
+  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens, selectionOpenIn, type PathLinkOptions \} from "\.\/path-links";/);   // + the options type for the chat's fenced walk (2026-09-12)
   assert.match(VIEW, /import \{ selectionOpenIn \} from "\.\/path-links";/);
   assert.doesNotMatch(d, /getSelection|isCollapsed/, "no second spelling of the selection test in the listener");
   assert.match(VIEW, /const linkOf = \(t: Element \| null\): HTMLElement \| null => \{\n\s*const x = t && typeof t\.closest === "function" \? t\.closest\("\.file-uri-link, a\." \+ URL_LINK_CLASS \+ ", a\." \+ FRAG_LINK_CLASS\) as HTMLElement \| null : null;\n\s*return x && body\.contains\(x\) \? x : null;/);
@@ -806,7 +806,8 @@ test("source: a link's line scrolls the code view's row once the text lands, spe
 });
 
 test("source: the shared walk's options, the line units and the anchor marker live in path-links.ts, defaults unchanged for the chat; the module writes attributes, never markup", () => {
-  assert.match(LINKS, /export interface PathLinkOptions \{\n\s*inPre\?: boolean;\n\s*accept\?: \(tok: string, ctx: \{ text: string; at: number \}\) => boolean;\n\s*resolve\?: \(tok: string\) => string;\n\s*lineSuffix\?: boolean;\n\s*unit\?: string;\n\}/);
+  assert.match(LINKS, /export interface PathLinkOptions \{\n\s*inPre\?: boolean;\n\s*preVerified\?: boolean;\n\s*accept\?: \(tok: string, ctx: \{ text: string; at: number; inPre: boolean \}\) => boolean;\n\s*resolve\?: \(tok: string\) => string;\n\s*lineSuffix\?: boolean;\n\s*unit\?: string;\n\}/,
+    "+ preVerified and the ctx's inPre for the chat's fenced blocks (2026-09-12); the viewer passes neither");
   assert.match(LINKS, /export function linkifyPathTokens\(root: HTMLElement, pathLinks\?: Record<string, string>, opts\?: PathLinkOptions\): PathLinkHit\[\] \{/);
   assert.match(LINKS, /export const DEAD_TEXT = "a, \.file-uri-link, svg";/, "a link, and an inline SVG (an element put inside SVG text does not render)");
   assert.match(LINKS, /const skip = opts && opts\.inPre \? DEAD_TEXT : DEAD_TEXT \+ ", pre";/, "the chat still skips fenced blocks");
@@ -830,11 +831,11 @@ test("source: the shared walk's options, the line units and the anchor marker li
   assert.ok(lb.indexOf("if (call) return") < lb.indexOf("lastIndexOf(\"\\n\", s - 1)"), "a call: return before the line is read back");
   assert.match(lb, /const isImport = word === "from" \? STATEMENT_HEAD_RE\.test\(head\) \|\| continuesImport\(lineOf\(text, lineStart, at\)\) : \/\^\\s\*\$\/\.test\(head\);/);
   assert.match(MOD, /const lineEnd = text\.indexOf\("\\n", at\);\n\s*return text\.slice\(lineStart, lineEnd < 0 \? text\.length : lineEnd\);/, "a from's line is read forward to its break, bounded by the line as the look-behind is");
-  assert.match(LINKS, /opts\.accept\(tok, \{ text, at: start \}\)/, "the walk hands the gate the token's line and offset, and nothing above them");
+  assert.match(LINKS, /opts\.accept\(tok, \{ text, at: start, inPre: span\.inPre \}\)/, "the walk hands the gate the token's line and offset, and whether it sat in a fenced block (2026-09-12) — nothing above them");
   assert.match(MOD, /const STATEMENT_HEAD_RE = \/\^\\s\*\(\?:import\|export\)\\b\/;/);
   assert.match(LINKS, /for \(const u of textUnits\(root, opts && opts\.unit, skip\)\) \{/, "no unit: every node its own unit, the chat's walk as it was");
   assert.match(LINKS, /const span = spanHolding\(u, start, start \+ tok\.length\);\n\s*if \(!span\) continue;/, "a token across a node's edge is left as it is");
-  assert.match(LINKS, /if \(!isUri && opts && opts\.accept && !opts\.accept\(tok, \{ text, at: start \}\)\) continue;/);
+  assert.match(LINKS, /if \(!isUri && opts && opts\.accept && !opts\.accept\(tok, \{ text, at: start, inPre: span\.inPre \}\)\) continue;/);
   assert.match(LINKS, /if \(isUri && opts && opts\.lineSuffix\) \{ const tail = URI_LINE_TAIL_RE\.exec\(tok\); if \(tail\) tok = tok\.slice\(0, tail\.index\); \}/);
   assert.match(LINKS, /export const LINE_SUFFIX_RE = \/\^\(\?::\(\\d\+\)\(\?::\\d\+\)\?\|#L\(\\d\+\)\(\?:-L\?\\d\+\)\?\)\(\?!\[\\w\/\]\)\/;/);
   assert.match(LINKS, /export function markPathLink\(a: HTMLElement, open: string, relative = false\): HTMLElement \{\n\s*const cls = a\.getAttribute\("class"\) \|\| "";\n\s*if \(!\(" " \+ cls \+ " "\)\.includes\(" file-uri-link "\)\) a\.setAttribute\("class", \(cls \? cls \+ " " : ""\) \+ "file-uri-link"\);\n\s*a\.setAttribute\("title", "Open " \+ open\);/, "attributes, so an SVG <a> is marked too");

--- a/ui/webview/path-links.test.ts
+++ b/ui/webview/path-links.test.ts
@@ -297,11 +297,12 @@ test("source: the module marks and binds nothing; render.ts binds the click and 
   const RENDER = fs.readFileSync(path.join(UI, "render.ts"), "utf8");
   assert.doesNotMatch(LINKS, /addEventListener|onclick|openPath\(|window\.open|postMessage|fetch\(/, "no action of its own: its handlers are about focus (keydown, the press)");
   assert.match(LINKS, /export function linkifyPathTokens\(root: HTMLElement, pathLinks\?: Record<string, string>, opts\?: PathLinkOptions\): PathLinkHit\[\] \{/);
-  assert.match(LINKS, /export interface PathLinkHit \{ el: HTMLElement; open: string; verified: boolean \}/);
-  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens, selectionOpenIn \} from "\.\/path-links";/);
+  assert.match(LINKS, /export interface PathLinkHit \{ el: HTMLElement; open: string; verified: boolean; inPre: boolean \}/, "+ inPre: the chat skips its figure pass for a fenced hit (2026-09-12)");
+  assert.match(RENDER, /import \{ openPathLink, linkifyPathTokens, selectionOpenIn, type PathLinkOptions \} from "\.\/path-links";/);
   assert.match(RENDER, /function bindPathLink\(a: HTMLElement\): HTMLElement \{\n\s*const open = a\.dataset\.path \|\| "", relative = a\.dataset\.rel === "1";\n\s*a\.addEventListener\("click", \(e\) => \{\n\s*e\.stopPropagation\(\);\n\s*filePreviewIntent\.cancel\(\);\n\s*openPath\(open, relative \? activeId : null, e, a\.dataset\.frag \|\| null\);[^\n]*\n\s*\}\);\n\s*onMiddleClick\(a, \(e\) => openPath\(open, relative \? activeId : null, e, a\.dataset\.frag \|\| null\)\);\n\s*armFilePreview\(a\);[^\n]*\n\s*return a;\n\}/);
   assert.match(RENDER, /const link = bindPathLink\(openPathLink\(tok, tok, true\)\);\n\s*armPreview\(link, tok, tok\);\n\s*code\.replaceChildren\(link\);/, "the kernel-verified spaced span takes the same binder");
-  assert.match(RENDER, /for \(const \{ el: link, open, verified \} of linkifyPathTokens\(root, pathLinks\)\) \{\n\s*bindPathLink\(link\);\n\s*armPreview\(link, link\.textContent \|\| "", open\);\n\s*absorbFragment\(link\);\n\s*if \(verified\) kernelVerified\.add\(open\);/);
+  assert.match(RENDER, /for \(const \{ el: link, open, verified, inPre \} of linkifyPathTokens\(root, pathLinks, FENCE_WALK\)\) \{\n\s*bindPathLink\(link\);\n\s*armPreview\(link, link\.textContent \|\| "", open\);\n\s*absorbFragment\(link\);\n\s*if \(verified\) kernelVerified\.add\(open\);/,
+    "the chat's walk carries its fenced-block options (2026-09-12); every hit is bound and previewable, a fenced one renders no figure");
   // the matcher lives in ONE place: render.ts no longer declares the regex or its gates
   for (const name of ["CLICKABLE_PATH_RE", "function looksLikeFilePath", "function looksLikeBareFileName", "const BARE_FILE_EXTS", "function fileUriToPath", "function openPathLink", "function fileUriLink"]) {
     assert.ok(!RENDER.includes(name), name + " is path-links.ts's alone");
@@ -462,4 +463,31 @@ test("the walk under the viewer's options: inPre reads a code body, unit joins a
   const h2 = linkifyPathTokens(chat as unknown as HTMLElement);
   assert.deepEqual(h2.map((h) => h.open), ["docs/e.md"]);
   assert.deepEqual(textNodesOf(chat.childNodes[0] as El).map((t) => t.data), ["see ", "docs/e.md", ":12 now"], "the :12 stays prose in the chat");
+});
+
+test("the chat's fenced blocks (the user 2026-09-12): under inPre + preVerified a fenced token links ONLY on the kernel's verdict and under the surface's code gate; prose in the same body keeps the chat's rules; a fenced hit says so", async () => {
+  const { linkifyPathTokens } = await import("./path-links");
+  const { viewerPathGate } = await import("./file-view-links");
+  const row = (...kids: Array<El | string>) => el("span", "cl", el("span", "ct", ...kids));   // code-block.ts's rows, as the chat's highlight leaves a fence
+  const opts = { inPre: true, preVerified: true, unit: ".cl",
+    accept: (tok: string, ctx: { text: string; at: number; inPre: boolean }) => !ctx.inPre || viewerPathGate(tok, ctx) };
+  const body = () => el("div", "",
+    el("p", "", "see docs/e.md and a/dup.md"),
+    el("pre", "", el("code", "hljs",
+      row("open ", el("span", "hljs-string", "'/tmp/TESTHOST/report/viewer.html'"), " now"),
+      row("import fp from ", el("span", "hljs-string", "'lodash/fp.js'")),
+      row("cat docs/e.md"))));
+  // the kernel's map names the fenced path, the import's package and the prose path: the fenced path and both docs/e.md
+  // link; the package stays text under the code gate, verdict or not; a/dup.md (no verdict) stays prose
+  const map = { "/tmp/TESTHOST/report/viewer.html": "/tmp/TESTHOST/report/viewer.html", "lodash/fp.js": "node_modules/lodash/fp.js", "docs/e.md": "docs/e.md" };
+  const b1 = body();
+  assert.deepEqual(linkifyPathTokens(b1 as unknown as HTMLElement, map, opts).map((h) => [h.open, h.verified, h.inPre]),
+    [["docs/e.md", true, false], ["/tmp/TESTHOST/report/viewer.html", true, true], ["docs/e.md", true, true]]);
+  assert.deepEqual(links(b1).map((a) => a.textContent), ["docs/e.md", "/tmp/TESTHOST/report/viewer.html", "docs/e.md"], "the quotes around the fenced path stay text");
+  // no map at all (an old kernel, a cached payload): prose links on shape as before; NOTHING in the fence does
+  assert.deepEqual(linkifyPathTokens(body() as unknown as HTMLElement, undefined, opts).map((h) => [h.open, h.inPre]), [["docs/e.md", false], ["a/dup.md", false]]);
+  // an empty map is a verdict of none: nothing links anywhere
+  assert.deepEqual(linkifyPathTokens(body() as unknown as HTMLElement, {}, opts), []);
+  // without the options the fence is dead text, as every other surface walked it before
+  assert.deepEqual(linkifyPathTokens(body() as unknown as HTMLElement, map).map((h) => h.open), ["docs/e.md"]);
 });

--- a/ui/webview/path-links.ts
+++ b/ui/webview/path-links.ts
@@ -219,7 +219,7 @@ export class PathTokenScanner {
 
 /** One link the walk emitted: the element, what it opens, and whether the kernel stat'd that target this
  *  build (a fixed mention). The chat's figure pass wants exactly these. */
-export interface PathLinkHit { el: HTMLElement; open: string; verified: boolean }
+export interface PathLinkHit { el: HTMLElement; open: string; verified: boolean; inPre: boolean }   // inPre: the token sat in a fenced block
 
 // `opts` is how a surface whose text is not chat prose runs the same walk (the file viewer, file-view-links.ts).
 // `inPre` walks the text inside <pre> too (the viewer's code body IS one); `accept` narrows every non-URI token
@@ -233,9 +233,13 @@ export interface PathLinkHit { el: HTMLElement; open: string; verified: boolean 
 // element whose text nodes are scanned as ONE string (the viewer's row: a highlight's spans cut a line's text
 // into several nodes, and a token is what the LINE says, never what one node says). Absent, the walk is
 // exactly the chat's.
+// `preVerified` (the chat, 2026-09-12): with `inPre` on, a token INSIDE a <pre> links only on the kernel's verdict — a
+// fenced block is verbatim material, so a path there links when the kernel has stat'd the file, never on shape alone
+// as prose may; `accept`'s ctx says whether the token sat in a <pre>, so a surface can gate its code differently.
 export interface PathLinkOptions {
   inPre?: boolean;
-  accept?: (tok: string, ctx: { text: string; at: number }) => boolean;
+  preVerified?: boolean;
+  accept?: (tok: string, ctx: { text: string; at: number; inPre: boolean }) => boolean;
   resolve?: (tok: string) => string;
   lineSuffix?: boolean;
   unit?: string;
@@ -251,7 +255,7 @@ const LINE_SUFFIX_AT_RE = new RegExp(LINE_SUFFIX_RE.source.replace(/^\^/, ""), "
 
 /** One text node's place in its unit's joined text. `dead`: inside a link (or, in the chat, a fenced block): the
  *  scan READS it, so a token glued to it is seen whole, but never marks in it. */
-export interface TextSpan { tn: Text; start: number; end: number; dead: boolean; inCode: boolean }
+export interface TextSpan { tn: Text; start: number; end: number; dead: boolean; inCode: boolean; inPre: boolean }
 export interface TextUnit { text: string; spans: TextSpan[] }
 /** The ancestors whose text no walk marks in, whatever the surface: a link already made, and an inline SVG (an
  *  HTML span or anchor put inside SVG text does not render, so a mark there would make the token vanish from the
@@ -284,7 +288,7 @@ export function textUnits(root: HTMLElement, unit: string | undefined, skip: str
     broke = false;
     const start = last.text.length;
     last.text += tn.data;
-    last.spans.push({ tn, start, end: last.text.length, dead: !!p?.closest(skip), inCode: !!p?.closest("code") });
+    last.spans.push({ tn, start, end: last.text.length, dead: !!p?.closest(skip), inCode: !!p?.closest("code"), inPre: !!p?.closest("pre") });
   }
   return units;
 }
@@ -333,7 +337,7 @@ export function rewriteSpan(u: TextUnit, span: TextSpan, marks: Array<{ start: n
 // walk's first.
 export function linkifyPathTokens(root: HTMLElement, pathLinks?: Record<string, string>, opts?: PathLinkOptions): PathLinkHit[] {
   const hits: PathLinkHit[] = [];
-  const skip = opts && opts.inPre ? DEAD_TEXT : DEAD_TEXT + ", pre";   // a link, an SVG, or (the chat) a fenced code block
+  const skip = opts && opts.inPre ? DEAD_TEXT : DEAD_TEXT + ", pre";   // a link, an SVG, or (a surface that asks for none) a fenced code block
   for (const u of textUnits(root, opts && opts.unit, skip)) {
     if (u.spans.every((s) => s.dead)) continue;
     const text = u.text;
@@ -355,9 +359,10 @@ export function linkifyPathTokens(root: HTMLElement, pathLinks?: Record<string, 
       const span = spanHolding(u, start, start + tok.length);
       if (!span) continue;                          // across a node's edge, or inside a link: as it is
       if (!isUri && !looksLikeFilePath(tok) && !(span.inCode && looksLikeBareFileName(tok))) continue;   // "and/or", `np.array` etc.: leave as prose
-      if (!isUri && opts && opts.accept && !opts.accept(tok, { text, at: start })) continue;   // the surface's own gate (the viewer's: an extension on the file)
+      if (!isUri && opts && opts.accept && !opts.accept(tok, { text, at: start, inPre: span.inPre })) continue;   // the surface's own gate (the viewer's: an extension on the file)
       const fixed = !isUri && pathLinks ? pathLinks[tok] : undefined;   // the kernel's verdict, when it rendered one
       if (!isUri && pathLinks && typeof fixed !== "string") continue;   // checked against the filesystem: no such file (or several) → prose
+      if (!isUri && span.inPre && opts && opts.preVerified && typeof fixed !== "string") continue;   // fenced: the kernel's word or nothing (no map at all → nothing)
       // what the link opens: a URI's own path (absolute, percent-decoded), else the kernel's fixed target or the token;
       // placed by the surface's resolve when it has one (the viewer normalizes a URI's path there as it does any
       // absolute path, so `file:///a/b/../c.md` opens and is titled the same whichever way it was written)
@@ -374,7 +379,7 @@ export function linkifyPathTokens(root: HTMLElement, pathLinks?: Record<string, 
       let list = marks.get(span);
       if (!list) { list = []; marks.set(span, list); }
       list.push({ start, end: last, el: link });
-      hits.push({ el: link, open, verified: !isUri && typeof fixed === "string" });   // the kernel stat'd a fixed one this build
+      hits.push({ el: link, open, verified: !isUri && typeof fixed === "string", inPre: span.inPre });   // the kernel stat'd a fixed one this build
       from = last;                                  // a linked token: resume right after what was linked; its trimmed tail is prose
     }
     for (const [span, list] of marks) rewriteSpan(u, span, list);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -69,8 +69,9 @@ import { fileLinkRoute, browseRoute, type BrowseRoute } from "./file-route";   /
 // initFileView rides its OWN line: the import above is pinned verbatim by file-view.test.ts
 import { initFileView, setFileViewIdentity, hostStub } from "./file-view";
 import { openUrlView } from "./file-view";                 // the URL mode of the same viewer (md-url-view.test.ts)
+import { viewerPathGate } from "./file-view-links";       // the viewer's code-aware path gate, for the chat's fenced blocks (2026-09-12)
 import { isMarkdownUrl } from "./md-links";
-import { openPathLink, linkifyPathTokens, selectionOpenIn } from "./path-links";   // the path matcher the chat's links are made from (a shared module)
+import { openPathLink, linkifyPathTokens, selectionOpenIn, type PathLinkOptions } from "./path-links";   // the path matcher the chat's links are made from (a shared module)
 import { PREVIEW_DWELL_MS, PREVIEW_GRACE_MS, HoverIntent, parsePreviewLink, previewKindOf, sliceUrl, contentFor, textOnlyContent, stripRemoteLoads, type PreviewContent } from "./file-preview";
 import { buildMatcher, linkifyTerms, termContent, type GlossaryIndex, type GlossaryEntry, type TermMatcher } from "./glossary-links";   // the team's coinages, linked where written (T351 stage 2)   // the file preview popover's pure half (T351)
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
@@ -2434,6 +2435,10 @@ function showFilePreview(a: HTMLElement): void {
 // kernel, a cached payload) keeps today's shape-only linking rather than unlinking history.
 // file:// URIs are explicit absolute paths — never gated on the map. (The gates and the map walk are
 // path-links.ts's; the map is threaded through to it.)
+const FENCE_WALK: PathLinkOptions = {
+  inPre: true, preVerified: true, unit: ".cl",
+  accept: (tok, ctx) => !ctx.inPre || viewerPathGate(tok, ctx),   // prose keeps the chat's rules; a fenced token takes the viewer's
+};
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
     pathLinks?: Record<string, string>, pathPins?: Record<string, string>, pathPreview?: Record<string, string>): void {
   // pathPreview (T351): the kernel's word on which of these links a hover may PREVIEW, by kind; the link carries it
@@ -2481,11 +2486,19 @@ function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: 
   // The token walk is the shared one (path-links.ts linkifyPathTokens): it marks every path-shaped token, the
   // kernel's pathLinks verdict narrowing it when the event carries one, and hands back the hits in document
   // order; this document binds each click and reads the hits for the figure pass below.
-  for (const { el: link, open, verified } of linkifyPathTokens(root, pathLinks)) {
+  // FENCED blocks walk too (the user 2026-09-12, whose session printed a report's path in a ``` block and got dead
+  // text): a path there links under the file viewer's code-aware gate (an import's or require()'s package, a glob's
+  // tail, a substitution, a site name stay text) and ONLY on the kernel's verdict — code is verbatim material, so a
+  // path in it links when the kernel has stat'd the file, never on shape alone as prose may. The block's rows (.cl,
+  // code-block.ts) are the units, as the viewer's rows are, so a highlight's spans never cut a line's path into pieces
+  // the scan cannot see. A fenced hit opens the file and previews on hover like any link, but renders no figure under a
+  // code sample.
+  for (const { el: link, open, verified, inPre } of linkifyPathTokens(root, pathLinks, FENCE_WALK)) {
     bindPathLink(link);
     armPreview(link, link.textContent || "", open);
     absorbFragment(link);
     if (verified) kernelVerified.add(open);   // the kernel stat'd it this build
+    if (inPre) continue;                      // no figure under a code sample
     if (previewKind(open) && !previewable.includes(open) && !(skipThumbs && skipThumbs.includes(open))) {
       previewable.push(open);
       mentionAt.set(open, link);

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2195,6 +2195,7 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   text-decoration: underline dotted; text-underline-offset: 2px;
 }
 .file-uri-link:hover { text-decoration: underline; }
+pre code .file-uri-link { color: var(--accent); }   /* a fenced block's path (2026-09-12): the accent over the highlight's token colour beneath it */
 .img-copy { flex: 0 0 auto; cursor: pointer; padding: 0 3px; border-radius: 3px; }
 .img-copy:hover { background: rgba(255, 255, 255, 0.18); }
 /* (harness-injected user-role lines — a compact summary, /command stdout — are a SYSTEM notice now; the


### PR DESCRIPTION
## What this adds

A path a session prints inside a fenced ``` block now links in the chat, the way the same path in prose or in inline backticks does. Until now the chat's walk skipped fenced blocks outright, a rule that was never written down and that predates two safeguards: the kernel's check that a mentioned path is a real file (`pathLinks`), and the file viewer's code-aware shape rules for paths inside code.

## Design points

- **The kernel's word or nothing inside a fence.** Prose keeps its shape-only linking under an old kernel; a fenced token links only when the kernel's verdict names it. Code is verbatim material, so nothing there links on shape alone.
- **The viewer's code gate applies to fenced tokens.** An `import`'s or `require()`'s package, a glob's tail, a substitution, a site name stay text, exactly as inside a shown file. Prose keeps the chat's rules.
- **A fence's rows are the walk's units**, as the viewer's rows are, so a highlight's spans never cut a line's path into pieces the scan cannot see.
- **A fenced hit opens the file and previews on hover like any link, and renders no figure** under a code sample.
- The shared walk (`path-links.ts`) grows two small things: `preVerified`, and `inPre` on the gate's context and on each hit. The viewer passes neither and is unchanged.

## Tests

- `path-links.test.ts` executes the fenced walk against the fake DOM: a verified fenced path links (quotes stay text), a package the kernel could verify is refused by the code gate, prose beside it links as before, no verdict leaves the fence dead while prose still links on shape, an empty verdict links nothing, and the walk without the options is the old walk.
- Source pins on the chat's call, the options, the hit shape and the CSS follow (`file-uri-link`, `chat-path-links`, `chat-inline-preview`, `file-view-links` tests); `tests/test_path_links.py` (kernel–client token parity) is unchanged and green.
- `docs/guide.md` names the rule beside the viewer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)