### PR TITLE
Peer mail stranded by a connection rebuild goes back to the bus by id instead of vanishing

### DIFF
--- a/bin/romp
+++ b/bin/romp
@@ -1517,6 +1517,17 @@ fi
 # unknown session fails LOUDLY, never silently.
 if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
     _verb="${1#--}"; shift
+    # `romp send --tag <label> <session> <text>` — the render hint AHEAD of the session name (2026-09-12). Until
+    # this line the word `--tag` was taken AS the session name and its label as the text: a timer's ten-minute
+    # send went to a session called `--tag` four times in one night, refused into nowhere while the timer read
+    # "sent". A verb's own flag is never a session name; the label is checked and appended below with the
+    # documented trailing form (`romp send <session> --tag <label> <text>`), which still works.
+    _tag=""
+    if [[ "$_verb" == "send" && "${1:-}" == "--tag" ]]; then
+        _tag="${2:-}"
+        [[ -n "$_tag" ]] || { echo "usage: romp send <session> [--tag <label>] <text>" >&2; exit 2; }
+        shift 2
+    fi
     _who="${1:-}"
     if [[ -z "$_who" ]]; then echo "usage: romp $_verb <session> $([[ "$_verb" == send ]] && echo '<text>')" >&2; exit 2; fi
     shift
@@ -1540,8 +1551,7 @@ if [[ "${1:-}" =~ ^(--)?(send|interrupt|end)$ ]]; then
         # brief): the chat shows a tagged message as machine-sent under that label instead of posing
         # it as the user's typed words (the user 2026-08-15). Sugar for appending the marker comment
         # `<!-- romp-tag: <label> -->` yourself; the label is one word, letters/digits/dashes.
-        _tag=""
-        if [[ "${1:-}" == "--tag" ]]; then
+        if [[ "${1:-}" == "--tag" ]]; then       # …or trailing the session name (the leading form set _tag above)
             _tag="${2:-}"
             shift 2 || { echo "usage: romp send <session> [--tag <label>] <text>" >&2; exit 2; }
         fi

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3081,6 +3081,27 @@ def _bus_recall_relay(sid, mid):
         return "unknown"
 
 
+def _bus_restore_mail(sid, mids):
+    """POST /restore to the local bus for a postal banner the SDK backend fed and a connection rebuild stranded
+    (SdkSession._return_stranded_mail, 2026-09-12): the bus puts each named message back into the session's new/
+    under its ORIGINAL id (its `restore`) and wakes the session, so the mail re-delivers as itself. Returns the set
+    of ids the bus put back — authoritative about the bus's files (an id missing from it is gone from cur/) — and
+    RAISES when the bus could not be asked or refused, so the caller re-heads the banner rather than drop it: a
+    quiet False here would be the loss this exists to end."""
+    conn = http.client.HTTPConnection("127.0.0.1", BUS_PORT, timeout=5)
+    try:
+        conn.request("POST", "/restore", json.dumps({"id": sid, "mids": list(mids)}),
+                     {"Content-Type": "application/json", "X-Romp-Token": TOKEN})
+        resp = conn.getresponse()
+        data = resp.read()
+    finally:
+        conn.close()
+    body = json.loads(data.decode("utf-8", "replace") or "{}") if resp.status == 200 else None
+    if not isinstance(body, dict) or not body.get("ok"):
+        raise RuntimeError("bus /restore answered %d: %s" % (resp.status, data[:200].decode("utf-8", "replace")))
+    return set(m for m in (body.get("restored") or []) if isinstance(m, str))
+
+
 ROMP_VOICE_WORDS = ("romp", "card", "board", "goal", "cleared", "dismissal", "status check", "nudge")
 #   the vocabulary an injected body must never speak to a session (CLAUDE.md, "Messages we inject into a session");
 #   tests/test_injected_voice.py's list of the same words, with the why of each, is pinned to this one
@@ -15973,6 +15994,9 @@ def _sdk_locked():
             # pick can never sit in the UI as applied fact on a box that demonstrably cannot apply it
             _sdk_backend.login_ok = lambda: (None if _claude_account_state() == "unreadable" else bool(_claude_account()))
             #   None = cannot tell (the account file is mid-rewrite or unreadable): no launch falls on it (2026-09-09)
+            # a postal banner the backend fed and a connection rebuild stranded goes BACK to the bus by message id
+            # (SdkSession._return_stranded_mail → the bus's POST /restore), never dropped (2026-09-12)
+            _sdk_backend.postal_restore = _bus_restore_mail
             # NO thread-wake model remap. The T223 rider installed _family_newest_model as the
             # backend's wake hook, so a dormant comment thread registered on a superseded full id came
             # up on its family's newest at its next explicit wake — built for the artefact where a

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -5840,13 +5840,20 @@ class SdkSession:
         The bus's put-back is its `restore` — the roll-back its not-injected push already takes: cur/<mid> moves
         back to new/, the exec row is retracted, the session is woken. It is reached through
         SdkBackend.postal_restore, which the kernel installs (a POST to the bus's /restore). The answer is the set
-        of ids the bus put back, and it is AUTHORITATIVE about the bus's own files: an id it did not put back is
-        gone from cur/ (recalled by its sender, swept) — named in the log, never re-fed on this side's say-so. A
-        banner the bus could not take back at all (no hook installed, a bus that could not be reached, refused, or
-        gave no answer) is RE-HEADED in the queue under its own id instead — the not-resumable branch's path. The
-        resumable branch refuses re-feeds because a duplicate of the person's own words is a visible defect; a
-        banner landing twice in the resumed conversation beats a peer told "delivered" for mail nobody read, and
-        the bus's copy is the one that is gone. Never raises; one log line per banner names its ids and their fate."""
+        of ids the bus put back, and it is AUTHORITATIVE about the bus's own files: a PARTIAL answer names the ids
+        gone from the bus's box (recalled by its sender, swept), which are never re-fed on this side's say-so. An
+        answer that put back NONE of them means this bus never held the banner: nothing removes a live session's
+        cur/ file (recall reads new/ only; the orphan sweep skips live boxes), so the ids are a session's whose
+        maildir sits on another host's bus, the wake-router having forwarded the banner here, and the banner text
+        is the last copy of the mail. That banner is RE-HEADED in the queue under its own id, the same as one the
+        bus could not take back at all (no hook installed, a bus that could not be reached, refused, or gave no
+        answer): the not-resumable branch's path. The resumable branch refuses re-feeds because a duplicate of the
+        person's own words is a visible defect; a banner landing twice in the resumed conversation beats a peer
+        told "delivered" for mail nobody read, and the duplicate is accepted only when the transcript scan cannot
+        rule it out: a banner _text_landed FINDS in the transcript (the CLI wrote its user record before the
+        teardown) is left where it is, since the resumed conversation carries it and a put-back would deliver the
+        same mail twice; a False or None answer proceeds, a miss being no proof of loss. Never raises; one log line
+        per banner names its ids and their fate."""
         mail = [(t, postal_mids(t)) for t in stranded if isinstance(t, str)]
         mail = [(t, mids) for t, mids in mail if mids]
         if not mail:
@@ -5854,6 +5861,17 @@ class SdkSession:
         hook = getattr(self.backend, "postal_restore", None)
         rehead = []
         for text, mids in mail:
+            # Landed before the teardown? A stream error or timeout can tear the client down AFTER the CLI wrote
+            # the banner's user record; the resumed conversation then carries it, and a put-back would deliver the
+            # same mail twice. True is definitive (the banner keys to itself, markers included, under
+            # echo_text_key); False or None proceeds, a miss being no proof of loss (the abandoned client may
+            # still have been flushing the record). Review fix, 2026-09-12.
+            seen = self.backend._text_landed(self.sid, text)
+            if seen is True:
+                self.backend._log("stranded mail (%s): a banner fed to the abandoned client landed in the transcript "
+                                  "before the teardown; the resumed conversation carries it, not handed back (%s)"
+                                  % (self.name, ", ".join(mids)))
+                continue
             back, why = None, "no bus hook is installed"
             if callable(hook):
                 try:
@@ -5871,9 +5889,19 @@ class SdkSession:
                                   % (self.name, why, ", ".join(mids)), problem=True)
                 continue
             gone = [m for m in mids if m not in back]
+            if len(gone) == len(mids):
+                # The bus put back NONE of them. Nothing removes a live session's cur/ file (recall reads new/
+                # only; the orphan sweep skips live boxes and touches new/ only), so this bus never held them:
+                # a session whose maildir sits on another host's bus (the wake-router forwarded the banner
+                # here). The banner text is the last copy of the mail; re-head it, the no-answer path.
+                rehead.append(text)
+                self.backend._log("stranded mail (%s): a banner fed to the abandoned client never resulted, and the "
+                                  "bus holds none of its ids (%s); re-heading it so the new client is fed it"
+                                  % (self.name, ", ".join(mids)), problem=True)
+                continue
             self.backend._log("stranded mail (%s): a banner fed to the abandoned client never resulted; handed back "
                               "to the bus by id for re-delivery (%s)%s"
-                              % (self.name, ", ".join(m for m in mids if m in back) or "none",
+                              % (self.name, ", ".join(m for m in mids if m in back),
                                  ("; no longer in the bus's box, not re-fed: %s" % ", ".join(gone)) if gone else ""),
                               problem=False)
         if rehead:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -3255,6 +3255,23 @@ def fed_text_opener(text: str) -> str:
     return "injected" if "<!-- romp-injected -->" in (text or "") else "human"
 
 
+# The bus banner's per-message marker, event_model's one detector (its POSTAL_RE; the fallback is the same pattern
+# for a stand-in event_model in tests).
+_POSTAL_MID_RE = getattr(_em, "POSTAL_RE", None) or re.compile(r"<!--\s*romp-msg-id:\s*(\S+?)\s*-->")
+
+
+def postal_mids(text) -> list[str]:
+    """The postal message ids a fed text carries — its `<!-- romp-msg-id: <id> -->` markers, in order, deduped. A
+    non-empty answer says the text is a bus BANNER (SdkBackend.deliver): peer mail, whose only durable copy is the
+    bus's maildir and which has no input echo, so a loss of it has nothing to flag and must go back to the bus by
+    these ids (SdkSession._return_stranded_mail, 2026-09-12)."""
+    out: list[str] = []
+    for m in _POSTAL_MID_RE.findall(text or ""):
+        if m not in out:
+            out.append(m)
+    return out
+
+
 # A CLI that cannot even START says so on the way out — and the ONE cause that reliably does this is the
 # account being out of usage: `claude` refuses the handshake and exits with the limit in its own words
 # ("You've hit your session limit · resets 1:10pm (America/Los_Angeles)"). romp used to swallow that
@@ -5805,8 +5822,64 @@ class SdkSession:
                 self._q_prepend(stranded, self._unfeed_locked(stranded))   # back at the head under their own ids
             self._persist_queue()                  # the fresh inputs() drains _pending on its first pass
         elif stranded:
+            # Peer mail FIRST (2026-09-12): a bus banner has no echo for the flag path below to flip
+            # (SdkBackend.deliver: it is not composer input), so on this branch it was DROPPED outright — no
+            # queue entry, no flag, no log line, no word to the bus, whose only durable copy had been retired on
+            # `injected: true` (which means "queued in kernel memory", nothing more). Fifteen messages to two
+            # sessions vanished that way in twenty minutes, each fed to a client that a model-pin rebuild tore
+            # down before the turn resulted, every sender told "delivered". The banner names its messages; hand
+            # them back to the bus by id — _return_stranded_mail. Everything else fed keeps the flag path.
+            self._return_stranded_mail(stranded)
             self.backend._mark_dropped_echoes(self.sid, self.pending_meta() or self.pending(), refeed=False)
         self.backend._poke()
+
+    def _return_stranded_mail(self, stranded) -> None:
+        """Hand every POSTAL banner in `stranded` (fed to the abandoned client, never resulted) back to the bus by
+        message id, so the mail re-delivers under its ORIGINAL identity instead of vanishing (2026-09-12).
+
+        The bus's put-back is its `restore` — the roll-back its not-injected push already takes: cur/<mid> moves
+        back to new/, the exec row is retracted, the session is woken. It is reached through
+        SdkBackend.postal_restore, which the kernel installs (a POST to the bus's /restore). The answer is the set
+        of ids the bus put back, and it is AUTHORITATIVE about the bus's own files: an id it did not put back is
+        gone from cur/ (recalled by its sender, swept) — named in the log, never re-fed on this side's say-so. A
+        banner the bus could not take back at all (no hook installed, a bus that could not be reached, refused, or
+        gave no answer) is RE-HEADED in the queue under its own id instead — the not-resumable branch's path. The
+        resumable branch refuses re-feeds because a duplicate of the person's own words is a visible defect; a
+        banner landing twice in the resumed conversation beats a peer told "delivered" for mail nobody read, and
+        the bus's copy is the one that is gone. Never raises; one log line per banner names its ids and their fate."""
+        mail = [(t, postal_mids(t)) for t in stranded if isinstance(t, str)]
+        mail = [(t, mids) for t, mids in mail if mids]
+        if not mail:
+            return
+        hook = getattr(self.backend, "postal_restore", None)
+        rehead = []
+        for text, mids in mail:
+            back, why = None, "no bus hook is installed"
+            if callable(hook):
+                try:
+                    res = hook(self.sid, list(mids))
+                    if res is None:
+                        why = "the bus gave no answer"
+                    else:
+                        back = set(res)
+                except Exception as e:
+                    why = "the bus could not be asked (%r)" % (e,)
+            if back is None:
+                rehead.append(text)
+                self.backend._log("stranded mail (%s): a banner fed to the abandoned client never resulted, and %s; "
+                                  "re-heading it (%s) so the new client is fed it"
+                                  % (self.name, why, ", ".join(mids)), problem=True)
+                continue
+            gone = [m for m in mids if m not in back]
+            self.backend._log("stranded mail (%s): a banner fed to the abandoned client never resulted; handed back "
+                              "to the bus by id for re-delivery (%s)%s"
+                              % (self.name, ", ".join(m for m in mids if m in back) or "none",
+                                 ("; no longer in the bus's box, not re-fed: %s" % ", ".join(gone)) if gone else ""),
+                              problem=False)
+        if rehead:
+            with self._lock:
+                self._q_prepend(rehead, self._unfeed_locked(rehead))   # back at the head under their own ids
+            self._persist_queue()
 
     # ---- async internals (run inside the quarantined loop) ----
 
@@ -9302,6 +9375,11 @@ class SdkBackend:
         self.thread_wake_model = None      # kernel-installed: model_id -> replacement or None, consulted
         #                                    ONLY when a comment THREAD is explicitly woken (T223 rider) —
         #                                    the catalog lives in the kernel; the backend never imports it
+        self.postal_restore = None         # kernel-installed: (sid, [mid, ...]) -> the set of ids the bus put back in
+        #                                    the session's new/ (kernel._bus_restore_mail → the bus's POST /restore);
+        #                                    raises when the bus could not be asked. Consulted ONLY by a resumable
+        #                                    reconnect that stranded a fed postal banner (_return_stranded_mail,
+        #                                    2026-09-12); None (a stand-in, an older kernel) → the banner is re-headed
         self._notify = notify              # notify(app, msg) -> push to clients (kernel._send_to_app)
         self._poke_cb = poke               # wake the kernel's producer/judges (optional)
         self._owns_memo: dict = {}         # sid -> ((reg mtime_ns, size), owns?) — see owns()

--- a/postal/postal_service.py
+++ b/postal/postal_service.py
@@ -858,6 +858,29 @@ def restore(sid, mid):
     _mark_pending(sid)                   # new/ is non-empty again -> raise the marker
     return True
 
+def restore_stranded(data):
+    """POST /restore {id, mids} — the kernel handing back mail it FED and LOST (SdkSession._return_stranded_mail,
+    2026-09-12): a banner fed to a session's client that was torn down before the turn resulted was dropped on the
+    kernel's side, while this bus had retired its durable copy on `injected: true` (which only ever meant "queued
+    in kernel memory"). Each named message goes back to new/ under its ORIGINAL id (restore, the same roll-back the
+    not-injected push takes), and the session is woken so it re-delivers now; the retry pass covers a session that
+    cannot take the wake yet. Answers {ok, restored: [...], missing: [...]}: `missing` are ids no longer in cur/
+    (recalled, swept, never claimed, or unsafe as a path) — the caller's cue NOT to re-feed them on its own. 400
+    for a malformed ask (no safe session id, mids not a list of strings)."""
+    sid = str(data.get("id") or "")
+    mids = data.get("mids")
+    if not sid or not _safe_id(sid) or not isinstance(mids, list) or not mids \
+            or not all(isinstance(m, str) and m for m in mids):
+        return {"ok": False, "error": "id and a list of message ids required"}, 400
+    restored, missing = [], []
+    for mid in mids:
+        (restored if _safe_id(mid) and restore(sid, mid) else missing).append(mid)
+    if restored:
+        _log("restore for %s: %d message(s) the kernel fed and lost (a connection rebuild stranded the turn) put back "
+             "in new/ under their own ids for re-delivery: %s" % (sid, len(restored), ", ".join(restored)))
+        threading.Thread(target=_wake_when_ready, args=(sid,), daemon=True).start()
+    return {"ok": True, "restored": restored, "missing": missing}, 200
+
 def _queue_read_receipt(meta, unread=False, dmid=""):
     """Cross-host read backflow: mail delivered over the peer bus carries X-Peer-Mid/X-Peer-Via
     (see deliver); consuming it queues {mid, t} into the readbox for the DIRECT peer it arrived
@@ -2600,6 +2623,9 @@ class Handler(BaseHTTPRequestHandler):
             text = data.get("text")                # optional human-edited body for approve
             ok, err = quarantine_decide(mid, action, text, feedback=data.get("feedback"))
             return self._send({"ok": ok} if ok else {"ok": False, "error": err}, 200 if ok else 400)
+        if u.path == "/restore":                   # the kernel handing back fed-and-lost mail by id (restore_stranded)
+            payload, status = restore_stranded(data)
+            return self._send(payload, status)
         self._send({"error": "not found"}, 404)
 
 def _log(msg):

--- a/tests/romp-headless.bats
+++ b/tests/romp-headless.bats
@@ -272,3 +272,25 @@ PY
     run "$ROMP_SCRIPT" compact --wait
     [ "$status" -eq 2 ]
 }
+
+@test "romp send --tag ahead of the session name tags the send instead of addressing a session called --tag" {
+    # 2026-09-12: a timer's `romp send --tag <label> <session> <text>` read `--tag` AS the session name four
+    # times in one night and the kernel refused a paste to a target that does not exist, while the timer read
+    # "sent". A verb's own flag is never a session name; the leading form tags and addresses like the trailing one.
+    start_fake_kernel '{"ok": true}'
+    run "$ROMP_SCRIPT" send --tag wake helper 'the ten-minute pulse'
+    [ "$status" -eq 0 ]
+    python3 - "$TEST_DIR/req" <<'PY'
+import json, sys
+body = open(sys.argv[1]).read().split("\n", 1)[1]
+d = json.loads(body)
+assert d["name"] == "helper", d
+assert d["text"] == "the ten-minute pulse\n\n<!-- romp-tag: wake -->", d
+PY
+    run "$ROMP_SCRIPT" send --tag
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp send"* ]]
+    run "$ROMP_SCRIPT" send --tag wake
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"usage: romp send"* ]]
+}

--- a/tests/test_kernel_bus_restore.py
+++ b/tests/test_kernel_bus_restore.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""The kernel's side of handing fed-and-lost mail back to the bus: kernel._bus_restore_mail POSTs /restore to the
+local bus with the session id and the message ids, behind the serve token, and returns the set of ids the bus put
+back; a bus that could not be asked, or that refused, RAISES so the backend re-heads the banner instead of dropping
+it (SdkSession._return_stranded_mail, tests/test_postal_stranded_putback.py). The hook is installed on the SDK
+backend at kernel boot as `postal_restore`. Synthetic fixtures only; a fake bus stands in on a loopback port."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
+
+SID = "11111111-2222-3333-4444-555555555555"
+MID1 = "1700000000.111111.TESTHOST"
+MID2 = "1700000001.222222.TESTHOST"
+
+
+class _FakeBus:
+    """A loopback bus answering /restore with a canned status and body, recording what it was asked."""
+
+    def __init__(self, status=200, body=None):
+        self.seen = []
+        outer = self
+
+        class H(BaseHTTPRequestHandler):
+            def do_POST(self):
+                n = int(self.headers.get("Content-Length") or 0)
+                outer.seen.append((self.path, dict(self.headers), json.loads(self.rfile.read(n) or b"{}")))
+                data = json.dumps(body if body is not None else {}).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def log_message(self, *a):
+                pass
+
+        self.srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=self.srv.serve_forever, daemon=True).start()
+
+    @property
+    def port(self):
+        return self.srv.server_address[1]
+
+    def close(self):
+        self.srv.shutdown()
+        self.srv.server_close()
+
+
+class BusRestoreMail(unittest.TestCase):
+    def setUp(self):
+        self._port = km.BUS_PORT
+
+    def tearDown(self):
+        km.BUS_PORT = self._port
+
+    def test_posts_restore_behind_the_token_and_returns_what_the_bus_put_back(self):
+        bus = _FakeBus(200, {"ok": True, "restored": [MID1], "missing": [MID2]})
+        try:
+            km.BUS_PORT = bus.port
+            self.assertEqual(km._bus_restore_mail(SID, [MID1, MID2]), {MID1},
+                             "the answer is the set the bus put back; the missing id is not invented into it")
+        finally:
+            bus.close()
+        path, headers, body = bus.seen[0]
+        self.assertEqual(path, "/restore")
+        self.assertEqual(body, {"id": SID, "mids": [MID1, MID2]})
+        self.assertEqual(headers.get("X-Romp-Token"), km.TOKEN, "the bus's serve-token gate is honoured")
+
+    def test_a_refusal_raises_rather_than_reading_as_nothing_restored(self):
+        for status, body in ((403, {"error": "token required"}), (400, {"ok": False, "error": "bad ask"}),
+                             (200, {"ok": False}), (200, "not an object")):
+            bus = _FakeBus(status, body)
+            try:
+                km.BUS_PORT = bus.port
+                with self.assertRaises(Exception, msg=(status, body)):
+                    km._bus_restore_mail(SID, [MID1])
+            finally:
+                bus.close()
+
+    def test_an_unreachable_bus_raises(self):
+        bus = _FakeBus()
+        port = bus.port
+        bus.close()                                       # nothing listens here now
+        km.BUS_PORT = port
+        with self.assertRaises(Exception):
+            km._bus_restore_mail(SID, [MID1])
+
+    def test_the_hook_is_what_boot_installs_on_the_backend(self):
+        # The install line at boot: `_sdk_backend.postal_restore = _bus_restore_mail`. Read from the source rather
+        # than booting a kernel: the boot path spawns real processes.
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        self.assertIn("_sdk_backend.postal_restore = _bus_restore_mail", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postal_stranded_putback.py
+++ b/tests/test_postal_stranded_putback.py
@@ -15,9 +15,12 @@ The fix: a banner names its own messages (`<!-- romp-msg-id: <id> -->`), and the
 claimed message back under its original id (restore, the roll-back the not-injected push takes). On the resumable
 branch a stranded banner's ids are handed back to the bus (SdkBackend.postal_restore, the kernel-installed hook that
 POSTs the bus's /restore), which puts them back in new/ and wakes the session, so the mail re-delivers under the same
-identity. A banner the bus could not take back (no bus, a refusal) is re-headed in the queue instead: a banner landing
-twice in the resumed conversation beats a peer told "delivered" for mail nobody read. Every OTHER fed text keeps the
-flag-only path exactly as before (ReconnectStrandIsFlagOnly in test_sdk_echo_durability pins it).
+identity. A banner the bus could not take back (no bus, a refusal), or whose ids it holds NONE of (another host's bus
+does: the wake-router forwarded it here), is re-headed in the queue instead: a banner landing twice in the resumed
+conversation beats a peer told "delivered" for mail nobody read. The duplicate is accepted only when the transcript
+scan (_text_landed) cannot rule it out: a banner that already landed before the teardown stays where it is. Every
+OTHER fed text keeps the flag-only path exactly as before (ReconnectStrandIsFlagOnly in test_sdk_echo_durability
+pins it).
 
 SYNTHETIC fixtures only: invented text, placeholder uuids, no real session names or message ids."""
 import json
@@ -127,13 +130,63 @@ class StrandedMailGoesBackToTheBus(_StrandWorld):
                         "the log names the id and says it was re-headed: %r" % (self.logged,))
 
     def test_an_id_the_bus_no_longer_holds_is_not_re_fed(self):
-        # The bus's answer is authoritative about its own files: an id it did not put back is gone from cur/
-        # (recalled by its sender, or swept) and must not come back through the queue on the kernel's say-so.
+        # The bus's answer is authoritative about its own files: in a PARTIAL answer, an id it did not put back is
+        # gone from its box (recalled by its sender, or swept) and must not come back through the queue on the
+        # kernel's say-so. (An answer holding none of the ids is another matter: the next case.)
         s = self._sess()
         self.be.postal_restore = lambda sid, mids: {MID1}            # MID2 was recalled meanwhile
         self._strand(s, _banner(MID1, MID2))
         self.assertEqual(s.pending(), [], "the bus answered: what it holds re-delivers, what it lost is gone")
         self.assertTrue(any(MID2 in ln for ln in self.logged), "the missing id is named: %r" % (self.logged,))
+
+    def test_a_bus_that_holds_none_of_the_ids_gets_the_banner_re_headed(self):
+        # The wake-router case: the banner was forwarded from another host, whose bus holds the claimed file;
+        # the local bus answers with nothing put back. Nothing else removes a live session's cur/ file, so an
+        # empty answer is "never held", not "gone", and the banner text is the last copy of the mail.
+        s = self._sess()
+        self.be.postal_restore = lambda sid, mids: set()
+        banner = _banner(MID1, MID2)
+        self._strand(s, banner)
+        self.assertEqual(s.pending(), [banner], "re-headed for the new client, not dropped")
+        self.assertEqual((sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or [], [banner], "and persisted")
+        self.assertTrue(any(MID1 in ln and MID2 in ln and "re-head" in ln for ln in self.logged),
+                        "a problem line names both ids and says it was re-headed: %r" % (self.logged,))
+
+    def test_a_banner_that_landed_before_the_teardown_is_not_handed_back(self):
+        # The teardown can come AFTER the CLI wrote the banner's user record (a stream error or timeout mid-turn,
+        # the record written before the model call). The resumed conversation already carries the mail; the bus
+        # re-delivering it under the same id would put the delegate in front of the agent twice. The transcript
+        # scan answers True here, which is definitive, so the banner is left where it is.
+        s = self._sess()
+        banner = _banner(MID1)
+        with open(sb.transcript_path(self.cwd, SID), "a") as f:
+            f.write(json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00.000Z",
+                                "message": {"role": "user", "content": [{"type": "text", "text": banner}]}}) + "\n")
+        self.assertIs(self.be._text_landed(SID, banner), True)
+        called = []
+        self.be.postal_restore = lambda sid, mids: called.append(list(mids)) or set(mids)
+        self._strand(s, banner)
+        self.assertEqual(called, [], "the bus is not asked to put back mail the conversation already carries")
+        self.assertEqual(s.pending(), [], "and nothing is re-fed")
+        self.assertEqual((sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or [], [])
+        self.assertEqual(len([ln for ln in self.logged if MID1 in ln and "landed" in ln]), 1,
+                         "one log line names the id and says it landed: %r" % (self.logged,))
+
+    def test_a_banner_the_scan_cannot_place_is_still_handed_back(self):
+        # The skip needs a DEFINITIVE answer. The harness's empty transcript reads False (readable, nothing landed:
+        # the incident's shape) and a transcript that cannot be read reads None; neither proves the banner landed,
+        # since the abandoned client may still have been flushing its record, so both hand back as before.
+        handed = []
+        self.be.postal_restore = lambda sid, mids: handed.append(list(mids)) or set(mids)
+        s = self._sess()
+        self.assertIs(self.be._text_landed(SID, _banner(MID1)), False)
+        self._strand(s, _banner(MID1))
+        os.remove(sb.transcript_path(self.cwd, SID))
+        s = self._sess()
+        self.assertIsNone(self.be._text_landed(SID, _banner(MID2)))
+        self._strand(s, _banner(MID2))
+        self.assertEqual(handed, [[MID1], [MID2]], "False and None both proceed to the bus; only True skips")
+        self.assertEqual(s.pending(), [])
 
     def test_without_a_hook_installed_the_banner_is_still_not_lost(self):
         # A stand-in backend (older kernels, tests) with no postal_restore: the fallback is the re-head.

--- a/tests/test_postal_stranded_putback.py
+++ b/tests/test_postal_stranded_putback.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Peer mail fed to a session and stranded by a connection rebuild is HANDED BACK to the bus, never dropped.
+
+The bus delivers a message by writing it into the recipient's maildir, CLAIMING it (new/ -> cur/), and POSTing
+the banner to the kernel's /deliver; the kernel enqueues it and answers `injected: true`, on which the bus treats
+its durable copy as spent. `injected` only ever meant "queued in kernel memory". When the session's connection is
+rebuilt (a model or effort pin does this silently) after the banner was FED but before its turn resulted,
+SdkSession._reconcile_stranded takes the fed text off the in-flight list; on a RESUMABLE conversation its documented
+policy is flag-only (a re-feed could duplicate a turn that genuinely landed), and the flag it flips is the send's
+input ECHO. Peer mail has no echo by design (SdkBackend.deliver), so until 2026-09-12 the banner was dropped with no
+queue entry, no flag, no log line and no word to the bus, whose only copy sat in cur/ where nothing reads it again:
+fifteen messages to two sessions vanished in twenty minutes while every sender was told "delivered".
+
+The fix: a banner names its own messages (`<!-- romp-msg-id: <id> -->`), and the bus already knows how to put a
+claimed message back under its original id (restore, the roll-back the not-injected push takes). On the resumable
+branch a stranded banner's ids are handed back to the bus (SdkBackend.postal_restore, the kernel-installed hook that
+POSTs the bus's /restore), which puts them back in new/ and wakes the session, so the mail re-delivers under the same
+identity. A banner the bus could not take back (no bus, a refusal) is re-headed in the queue instead: a banner landing
+twice in the resumed conversation beats a peer told "delivered" for mail nobody read. Every OTHER fed text keeps the
+flag-only path exactly as before (ReconnectStrandIsFlagOnly in test_sdk_echo_durability pins it).
+
+SYNTHETIC fixtures only: invented text, placeholder uuids, no real session names or message ids."""
+import json
+import os
+import tempfile
+import threading
+import unittest
+import uuid
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+# Hermetic state BEFORE the loads — both modules resolve their state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+sb = load_source("romp_sdk_backend_putback", os.path.join(BIN, "romp_sdk_backend.py"))
+pm = load_source("romp_postal_putback", os.path.join(BIN, "romp-postal-service"))
+
+SID = "11111111-2222-3333-4444-555555555555"
+PEER = "22222222-3333-4444-5555-666666666666"
+MID1 = "1700000000.111111.TESTHOST"
+MID2 = "1700000001.222222.TESTHOST"
+
+
+def _banner(*mids, body="the pod is up; please take the next fire"):
+    """A bus banner exactly as _push hands it to /deliver: one message per id, the bus's own formatter."""
+    return pm.format_push([{"from": "alpha", "from_id": PEER, "body": body, "id": m, "date": ""} for m in mids])
+
+
+class _StrandWorld(unittest.TestCase):
+    """A registry + empty transcript for one RESUMABLE SDK session, registered without its thread (no loop), the
+    same harness ReconnectStrandIsFlagOnly uses: _text_landed answers False, the exact 'missed scan' shape the
+    resumable branch refuses to trust with a re-feed."""
+
+    def setUp(self):
+        self.state = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.state, "sdk"))
+        with open(os.path.join(self.state, "session-hosts"), "w") as f:
+            f.write("off")                            # a self-minted state root pins per-session hosts off
+        os.environ["CLAUDE_CONFIG_DIR"] = os.path.join(self.state, "claude")
+        self.cwd = os.path.join(self.state, "proj")
+        os.makedirs(self.cwd, exist_ok=True)
+        tp = sb.transcript_path(self.cwd, SID)
+        os.makedirs(os.path.dirname(tp), exist_ok=True)
+        open(tp, "w").close()
+        self.logged = []
+        self.be = sb.SdkBackend(self.state, "/bin/true", lambda *a, **k: None, log=self.logged.append)
+
+    def tearDown(self):
+        os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def _sess(self, **extra):
+        reg = {"sid": SID, "name": "web", "mode": "acceptEdits",
+               "alive": True, "cwd": self.cwd, "lastSid": SID}
+        reg.update(extra)
+        sb.write_reg(self.be.state_dir, SID, reg)
+        s = sb.SdkSession(self.be, dict(reg))
+        self.be.sessions[SID] = s
+        return s
+
+    def _strand(self, s, *texts):
+        s.inflight = len(texts)
+        s._inflight_texts.extend(texts)
+        s._reconcile_stranded()
+
+    def _stash_echo(self, text, t=100):
+        e = {"type": "user", "uuid": "echo:" + text[:10], "session_id": SID, "t": t,
+             "parentUuid": None, "author": "human", "_echo_text": text,
+             "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+        self.be._live.setdefault(SID, {})[e["uuid"]] = e
+        return e
+
+
+class StrandedMailGoesBackToTheBus(_StrandWorld):
+
+    def test_a_stranded_banner_is_handed_back_to_the_bus_by_message_id(self):
+        s = self._sess()                                  # lastSid set → resumable: the flag-only branch
+        self.assertEqual(s.resume_sid, SID)
+        handed = []
+        self.be.postal_restore = lambda sid, mids: (handed.append((sid, list(mids))), set(mids))[1]
+        self._strand(s, _banner(MID1, MID2))
+        self.assertEqual(handed, [(SID, [MID1, MID2])],
+                         "a fed-but-unresulted postal banner is handed back to the bus by its message ids; "
+                         "before the fix it was dropped: no echo to flag, no queue entry, no word to the bus")
+        self.assertEqual(s.pending(), [], "the bus re-delivers under the same ids; nothing is re-fed here")
+        self.assertEqual((sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or [], [])
+        self.assertEqual(s.inflight, 0, "the strand still settles the counters")
+        self.assertTrue(any(MID1 in ln and MID2 in ln for ln in self.logged),
+                        "one log line names the ids handed back: %r" % (self.logged,))
+
+    def test_a_banner_the_bus_cannot_take_back_is_re_headed_not_dropped(self):
+        s = self._sess()
+        def refuse(sid, mids):
+            raise ConnectionRefusedError("no bus on the port")
+        self.be.postal_restore = refuse
+        banner = _banner(MID1)
+        self._strand(s, banner)
+        self.assertEqual(s.pending(), [banner],
+                         "with no bus to hold it, the banner goes back to the head of the queue for the new "
+                         "client — a duplicate in the resumed conversation beats a silent loss")
+        self.assertEqual((sb.read_reg(self.be.state_dir, SID) or {}).get("queue") or [], [banner],
+                         "…and it is persisted, so a restart in between cannot lose it either")
+        self.assertTrue(any(MID1 in ln and "re-head" in ln for ln in self.logged),
+                        "the log names the id and says it was re-headed: %r" % (self.logged,))
+
+    def test_an_id_the_bus_no_longer_holds_is_not_re_fed(self):
+        # The bus's answer is authoritative about its own files: an id it did not put back is gone from cur/
+        # (recalled by its sender, or swept) and must not come back through the queue on the kernel's say-so.
+        s = self._sess()
+        self.be.postal_restore = lambda sid, mids: {MID1}            # MID2 was recalled meanwhile
+        self._strand(s, _banner(MID1, MID2))
+        self.assertEqual(s.pending(), [], "the bus answered: what it holds re-delivers, what it lost is gone")
+        self.assertTrue(any(MID2 in ln for ln in self.logged), "the missing id is named: %r" % (self.logged,))
+
+    def test_without_a_hook_installed_the_banner_is_still_not_lost(self):
+        # A stand-in backend (older kernels, tests) with no postal_restore: the fallback is the re-head.
+        s = self._sess()
+        self.assertFalse(callable(getattr(self.be, "postal_restore", None)))
+        banner = _banner(MID1)
+        self._strand(s, banner)
+        self.assertEqual(s.pending(), [banner])
+
+    def test_a_typed_send_keeps_the_flag_only_path(self):
+        # Unchanged for everything that is not a postal banner (ReconnectStrandIsFlagOnly's contract).
+        s = self._sess()
+        called = []
+        self.be.postal_restore = lambda sid, mids: called.append(mids) or set(mids)
+        text = "typed while the reconnect tore the client down"
+        e = self._stash_echo(text, t=300)
+        self._strand(s, text)
+        self.assertEqual(called, [], "a typed send carries no message id; the bus is never asked about it")
+        self.assertEqual(s.pending(), [], "flag-only: never re-fed")
+        self.assertTrue(e.get("dropped"), "the loss surfaces on the echo as before")
+
+    def test_a_mixed_strand_hands_back_the_mail_and_flags_the_typing(self):
+        s = self._sess()
+        handed = []
+        self.be.postal_restore = lambda sid, mids: (handed.append(list(mids)), set(mids))[1]
+        text = "and the human's follow-up, fed the same second"
+        e = self._stash_echo(text, t=300)
+        self._strand(s, _banner(MID1), text)
+        self.assertEqual(handed, [[MID1]])
+        self.assertEqual(s.pending(), [])
+        self.assertTrue(e.get("dropped"))
+
+    def test_a_fresh_conversation_still_re_heads_everything(self):
+        # The other branch is untouched: no init ever streamed → the queue re-head is the loss-proof path.
+        s = self._sess(lastSid="")
+        self.assertIsNone(s.resume_sid)
+        called = []
+        self.be.postal_restore = lambda sid, mids: called.append(mids) or set(mids)
+        banner = _banner(MID1)
+        self._strand(s, banner)
+        self.assertEqual(s.pending(), [banner])
+        self.assertEqual(called, [], "re-headed here, not handed back: the new client feeds it itself")
+
+    def test_postal_mids_reads_the_banner_and_nothing_else(self):
+        self.assertEqual(sb.postal_mids(_banner(MID1, MID2)), [MID1, MID2])
+        self.assertEqual(sb.postal_mids(_banner(MID1, MID1)), [MID1], "deduped, order kept")
+        self.assertEqual(sb.postal_mids("a typed line with no marker"), [])
+        self.assertEqual(sb.postal_mids(""), [])
+        self.assertEqual(sb.postal_mids(None), [])
+
+
+class TheBusPutsAStrandedMessageBack(unittest.TestCase):
+    """The bus side of the hand-back: POST /restore {id, mids} moves each named message from cur/ back to new/
+    under its ORIGINAL id (restore), retracts the exec row, and wakes the session so it re-delivers."""
+
+    def setUp(self):
+        self.saved = (pm._wake_when_ready, pm.SERVE_TOKEN)
+        self.woken = []
+        pm._wake_when_ready = lambda sid: self.woken.append(sid)
+        self.sid = str(uuid.uuid4())                  # a fresh synthetic mailbox per test: no leak between claims
+
+    def tearDown(self):
+        pm._wake_when_ready, pm.SERVE_TOKEN = self.saved
+
+    def _claimed(self, body):
+        """Deliver one message to self.sid and CLAIM it the way the push does: it now sits in cur/."""
+        mid = pm.deliver(self.sid, "alpha", PEER, body)
+        got = pm.read_box(self.sid, consume=True)
+        self.assertEqual([m["id"] for m in got], [mid])
+        self.assertTrue((pm.MAILROOT / self.sid / "cur" / mid).is_file())
+        self.assertFalse((pm.MAILROOT / self.sid / "new" / mid).exists())
+        return mid
+
+    def test_restore_stranded_puts_the_named_messages_back_in_new(self):
+        m1 = self._claimed("first, fed and lost")
+        m2 = self._claimed("second, fed and lost")
+        payload, status = pm.restore_stranded({"id": self.sid, "mids": [m1, m2, "1700000002.333333.TESTHOST"]})
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["restored"], [m1, m2])
+        self.assertEqual(payload["missing"], ["1700000002.333333.TESTHOST"], "an id not in cur/ is named, not invented")
+        for m in (m1, m2):
+            self.assertTrue((pm.MAILROOT / self.sid / "new" / m).is_file(), "back in new/ under its ORIGINAL id")
+            self.assertFalse((pm.MAILROOT / self.sid / "cur" / m).exists())
+        self.assertEqual(self.woken, [self.sid], "the session is woken so the mail re-delivers now")
+        rows = [json.loads(ln) for ln in (pm.TLDIR / "messages.jsonl").read_text().splitlines() if ln.strip()]
+        self.assertEqual([r["ev"] for r in rows if r.get("id") == m1], ["sent", "exec", "unexec"],
+                         "the claim is retracted on the ledger, so the sender's receipt reads pending again")
+
+    def test_nothing_to_restore_wakes_nobody(self):
+        payload, status = pm.restore_stranded({"id": self.sid, "mids": ["1700000003.444444.TESTHOST"]})
+        self.assertEqual((status, payload["restored"], payload["missing"]), (200, [], ["1700000003.444444.TESTHOST"]))
+        self.assertEqual(self.woken, [])
+
+    def test_a_malformed_ask_is_refused(self):
+        for bad in ({"id": "", "mids": ["x"]}, {"id": self.sid, "mids": "x"}, {"id": self.sid, "mids": [1]},
+                    {"id": "../etc", "mids": ["x"]}, {"id": self.sid}):
+            payload, status = pm.restore_stranded(bad)
+            self.assertEqual(status, 400, bad)
+            self.assertFalse(payload["ok"])
+        payload, status = pm.restore_stranded({"id": self.sid, "mids": ["../escape"]})
+        self.assertEqual((status, payload["restored"], payload["missing"]), (200, [], ["../escape"]),
+                         "an unsafe message id is reported missing, never resolved to a path")
+
+    def test_the_route_answers_over_http_behind_the_token(self):
+        m1 = self._claimed("over the wire")
+        pm.SERVE_TOKEN = "test-token-DO-NOT-USE"
+        srv = ThreadingHTTPServer(("127.0.0.1", 0), pm.Handler)
+        t = threading.Thread(target=srv.serve_forever, daemon=True); t.start()
+        try:
+            url = "http://127.0.0.1:%d/restore" % srv.server_address[1]
+            body = json.dumps({"id": self.sid, "mids": [m1]}).encode()
+            with self.assertRaises(urllib.error.HTTPError) as cm:
+                urllib.request.urlopen(urllib.request.Request(url, body, {"Content-Type": "application/json"}), timeout=5)
+            self.assertEqual(cm.exception.code, 403, "no token, no route")
+            self.assertTrue((pm.MAILROOT / self.sid / "cur" / m1).is_file(), "…and nothing moved")
+            req = urllib.request.Request(url, body, {"Content-Type": "application/json",
+                                                     "X-Romp-Token": "test-token-DO-NOT-USE"})
+            with urllib.request.urlopen(req, timeout=5) as r:
+                ans = json.loads(r.read())
+            self.assertEqual((ans["ok"], ans["restored"], ans["missing"]), (True, [m1], []))
+            self.assertTrue((pm.MAILROOT / self.sid / "new" / m1).is_file())
+            self.assertEqual(self.woken, [self.sid])
+        finally:
+            srv.shutdown(); srv.server_close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tier: fix

## What was lost

Peer mail is written to the recipient's maildir, claimed (`new/` → `cur/`), and its banner POSTed to the kernel's `/deliver`; the kernel enqueues it and answers `injected: true`, on which the bus treats its durable copy as spent. `injected` only ever meant "queued in kernel memory". When the session's connection was rebuilt (a model or effort pin does this silently; a stream error or timeout too) after the banner was **fed** but before its turn produced a result, `_reconcile_stranded`'s resumable branch (`kernel/sdk_backend.py`, the `elif stranded:` arm) took the fed text off the in-flight list and, by its documented flag-only policy, only flipped the send's input echo to "never delivered". A postal banner has no echo by design (`SdkBackend.deliver`: peer mail is not composer input), so the text was dropped with no queue entry, no flag, no log line and no word to the bus, whose only copy sat in `cur/` where nothing reads it again. On 2026-09-12 fifteen messages to two sessions vanished this way in twenty minutes while every sender was told "delivered".

## Why the fix holds

The banner names its own messages (`<!-- romp-msg-id: <id> -->`), and the bus already knows how to put a claimed message back under its original id (`restore`, the roll-back its not-injected push takes). This PR wires the two together and changes nothing else about the branch:

- `kernel/sdk_backend.py`: `postal_mids(text)` reads a fed text's message ids (event_model's `POSTAL_RE`). `SdkSession._return_stranded_mail` runs first in the resumable branch: for each stranded banner it calls the kernel-installed `SdkBackend.postal_restore` hook with the ids and logs one line naming them and their fate. The bus's answer is authoritative about its own files: an id it did not put back (recalled by its sender, swept) is named and never re-fed on the kernel's say-so. A banner the bus could not take back at all (no hook, unreachable, refused, no answer) is **re-headed** in the queue under its own id, the not-resumable branch's existing path, because a banner landing twice in the resumed conversation beats a peer told "delivered" for mail nobody read. Every other fed text keeps the flag-only path unchanged (`ReconnectStrandIsFlagOnly` in `tests/test_sdk_echo_durability.py` still pins it).
- `postal/postal_service.py`: `restore_stranded(data)` behind a new `POST /restore {id, mids}` route (serve-token gated like every route): `restore(sid, mid)` per id, one log line, and a `_wake_when_ready` thread so the mail re-delivers now; the retry pass covers a session that cannot take the wake yet. Answers `{ok, restored, missing}`; 400 for a malformed ask.
- `kernel/kernel.py`: `_bus_restore_mail(sid, mids)` POSTs `/restore` and **raises** on any failure (a quiet `False` would be the loss this ends); installed at boot as `_sdk_backend.postal_restore`.

The shape chosen is the report's second option (hand a stranded banner back by id). The first option (answer `/deliver` only once the fed turn has landed) would have needed a per-banner landing tracker across the kernel and a bus that holds an open request or polls, for the same outcome.

## Composition with #1496 (the re-delivery age line)

The two are disjoint in code and in data. #1496's `REDELIVER_MAX_AGE_S` gates human **echoes** inside `_mark_dropped_echoes`' `refeed=True` arm at boot and dead-spawn. This PR's put-back never enters `_mark_dropped_echoes`: a postal banner has no echo, and it goes back to the **bus** by id, which re-delivers under the bus's own rules. The `_mark_dropped_echoes(..., refeed=False)` call in the resumable branch is untouched and still runs after the hand-back. The hunks do not overlap (`_reconcile_stranded` ~L5830 and `SdkBackend.__init__` here; L3193, L8297 and L12622 there), so either merge order is clean.

## Also fixed here

`romp send --tag <label> <session> <text>`: the leading form read `--tag` **as** the session name, so a timer's ten-minute send addressed a session called `--tag` four times in one night (05:40, 05:49, 06:00, 06:10Z) and the kernel refused a paste to a target that does not exist while the timer read "sent". `bin/romp` now accepts `--tag <label>` ahead of the session name as well as trailing it; a bare `--tag` still exits 2 with usage. Bats case added.

## Not fixed here

- **Federated (remote-host) sessions**: for cross-host mail the claimed file sits in the *origin* host's bus, so the owning kernel's local bus answers `missing` for those ids and the banner is not re-fed there. The incident was local-host mail. A cross-host put-back would need the bus to forward `/restore` the way it forwards wakes.
- **Why the connections were rebuilt** for the two sessions in that window is not established (the report's open question); this PR makes the rebuild non-lossy regardless of cause.

## Tests

- `tests/test_postal_stranded_putback.py` (12): the hand-back by id, the re-head fallback when the bus cannot be asked or no hook is installed, an id the bus no longer holds is not re-fed, a typed send keeps the flag-only path, a mixed strand, the fresh-conversation branch unchanged, `postal_mids`; the bus's `restore_stranded` over a real maildir (files move `cur/` → `new/`, the `unexec` row lands, the wake fires), its refusals, and the `/restore` route over HTTP behind the token. On the unfixed code 10 of 12 fail (the two that pass are the unchanged-behaviour pins); the core assertion is `handed == []`: the banner reached neither the bus nor the queue.
- `tests/test_kernel_bus_restore.py` (4): the kernel's POST path, body and token; a refusal or an unreachable bus raises; the boot install line.
- `tests/romp-headless.bats`: the leading `--tag` form.
- Ran: `tests/test_restart_redelivery.py tests/test_sdk_echo_*.py tests/test_injected_voice.py tests/test_postal_delivery.py` plus the two new modules: 128 passed, 222 subtests passed.

Synthetic fixtures only (invented text, placeholder uuids, `TESTHOST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
