### PR TITLE
The delegator fallback stands only on a standing relation: the dispatch's own goal, open at the mint; a split-born goal inherits its parent's anchor

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -203,7 +203,10 @@ that delegated the work the block sits under (the courier-planted top's
 origin when present; else the sender of the delegate mail the goal's anchor
 names, the primary record, and only for a top the latch has read as a machine
 record: a goal you typed keeps its blocks, a goal split out of one you typed
-inherits that, and a script mailer's pseudo-sid is never a peer; a goal whose
+inherits that, a goal split out of a delegated one reads its own record (a
+typed step stays yours, a system-record step is the manager's again), a
+delegate mail with no message id sustains nothing, and a script mailer's
+pseudo-sid is never a peer; a goal whose
 anchor names no dispatch, or whose stamp the latch has not written yet, falls
 back to the newest delegate the session received before its mint whose own
 goal, latched or courier-planted, was still open at the mint, so a finished or
@@ -282,10 +285,13 @@ delegate mail its anchor names (the delegate-kind marker of the delivery that
 is a dispatch to this session, never one quoted from another session's, so a
 batched inbox whose first mail is a peer's heads-up still belongs to the
 manager whose dispatch follows it; a stamp naming no such dispatch leaves the
-newest delegate whose own goal is open at the mint as the fallback), so a
-worker two managers dispatched relays each block to the manager that asked,
-and a dispatch handled without a goal, or finished, claims none of the
-session's later goals.
+newest delegate whose own goal is open at the mint as the fallback, a row
+with no message id never), so a worker two managers dispatched relays each
+block to the manager that asked, and a dispatch handled without a goal, or
+finished, claims none of the session's later goals; a goal split out of a
+goal you typed inherits your anchor, one split out of a delegated goal reads
+its own record, so a typed step stays yours and a system-record step is the
+manager's again.
 An open question to a peer the block never names does not capture a block in
 the delegator's work: that block goes to the delegator, relayed. Rows filed before the rule convert once per boot. The debt ladder judges a debtor's
 reminder only at an idle turn end (the nudge walk's own gates); for a manager

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -204,10 +204,11 @@ origin when present; else the sender of the delegate mail the goal's anchor
 names, the primary record, and only for a top the latch has read as a machine
 record: a goal you typed keeps its blocks, a goal split out of one you typed
 inherits that, and a script mailer's pseudo-sid is never a peer; a goal whose
-anchor names no dispatch falls back to the latest delegate the session
-received before its mint only while that dispatch's own goal was still open
-at the mint, so a finished or goal-less dispatch never claims your later
-decisions), and words only to pick among
+anchor names no dispatch, or whose stamp the latch has not written yet, falls
+back to the newest delegate the session received before its mint whose own
+goal, latched or courier-planted, was still open at the mint, so a finished or
+goal-less dispatch never claims your later decisions and a stray hand-off note
+never displaces the manager's standing one), and words only to pick among
 several open asks; a block on a
 "delegated to <peer>" tracker waits on that peer, whose report ends the
 delegate edge. A block in a
@@ -281,10 +282,10 @@ delegate mail its anchor names (the delegate-kind marker of the delivery that
 is a dispatch to this session, never one quoted from another session's, so a
 batched inbox whose first mail is a peer's heads-up still belongs to the
 manager whose dispatch follows it; a stamp naming no such dispatch leaves the
-latest delegate as the fallback, and only while that dispatch's own goal is
-open at the mint), so a worker two managers dispatched relays each block to
-the manager that asked, and a dispatch handled without a goal, or finished,
-claims none of the session's later goals.
+newest delegate whose own goal is open at the mint as the fallback), so a
+worker two managers dispatched relays each block to the manager that asked,
+and a dispatch handled without a goal, or finished, claims none of the
+session's later goals.
 An open question to a peer the block never names does not capture a block in
 the delegator's work: that block goes to the delegator, relayed. Rows filed before the rule convert once per boot. The debt ladder judges a debtor's
 reminder only at an idle turn end (the nudge walk's own gates); for a manager

--- a/docs/judges.md
+++ b/docs/judges.md
@@ -200,10 +200,14 @@ you being the bottleneck). Both judges file blocks through one writer that
 reads the addressee from evidence, never from words alone: the session's own
 open question to a live peer (the wait graph's source), failing that the peer
 that delegated the work the block sits under (the courier-planted top's
-origin when present; else the sender of the delegate mail the session received
-before the goal was minted, the primary record, and only for a top the latch
-has read as a machine record: a goal you typed keeps its blocks, and a script
-mailer's pseudo-sid is never a peer), and words only to pick among
+origin when present; else the sender of the delegate mail the goal's anchor
+names, the primary record, and only for a top the latch has read as a machine
+record: a goal you typed keeps its blocks, a goal split out of one you typed
+inherits that, and a script mailer's pseudo-sid is never a peer; a goal whose
+anchor names no dispatch falls back to the latest delegate the session
+received before its mint only while that dispatch's own goal was still open
+at the mint, so a finished or goal-less dispatch never claims your later
+decisions), and words only to pick among
 several open asks; a block on a
 "delegated to <peer>" tracker waits on that peer, whose report ends the
 delegate edge. A block in a
@@ -277,8 +281,10 @@ delegate mail its anchor names (the delegate-kind marker of the delivery that
 is a dispatch to this session, never one quoted from another session's, so a
 batched inbox whose first mail is a peer's heads-up still belongs to the
 manager whose dispatch follows it; a stamp naming no such dispatch leaves the
-latest delegate as the fallback), so a worker two managers dispatched relays
-each block to the manager that asked.
+latest delegate as the fallback, and only while that dispatch's own goal is
+open at the mint), so a worker two managers dispatched relays each block to
+the manager that asked, and a dispatch handled without a goal, or finished,
+claims none of the session's later goals.
 An open question to a peer the block never names does not capture a block in
 the delegator's work: that block goes to the delegator, relayed. Rows filed before the rule convert once per boot. The debt ladder judges a debtor's
 reminder only at an idle turn end (the nudge walk's own gates); for a manager

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -135,8 +135,9 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
   peer, else from the peer that delegated the work it sits under (the planted
   origin, or the delegate mail the goal's anchor names; a goal whose anchor
   names no dispatch falls back to the newest delegate received before its mint
-  only while that dispatch's own goal was still open at the mint; never a goal
-  you typed, nor one split out of it), and file the
+  only while that dispatch's own goal was still open at the mint, an id-less
+  mail never; never a goal you typed, nor one split out of it, while a goal
+  split out of a delegated one reads its own record), and file the
   awaiting-a-peer stamp instead of the block, so the card shows the "Awaiting
   <peer>" chip in working and never a needs-you; when the worker never mailed
   that peer, the kernel relays the block's why to it as the worker's own question,

--- a/docs/read-side.md
+++ b/docs/read-side.md
@@ -133,8 +133,10 @@ completed); the feed just paints columns. (Reflected in `docs/judges.md`.)
 - **A block addressed to a peer is a peer wait, in working** (2026-09-11): the
   judges read a block's addressee from the session's own open question to a live
   peer, else from the peer that delegated the work it sits under (the planted
-  origin, or the delegate mail the session received before the goal was minted;
-  never a goal you typed), and file the
+  origin, or the delegate mail the goal's anchor names; a goal whose anchor
+  names no dispatch falls back to the newest delegate received before its mint
+  only while that dispatch's own goal was still open at the mint; never a goal
+  you typed, nor one split out of it), and file the
   awaiting-a-peer stamp instead of the block, so the card shows the "Awaiting
   <peer>" chip in working and never a needs-you; when the worker never mailed
   that peer, the kernel relays the block's why to it as the worker's own question,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10703,7 +10703,8 @@ def _latch_prompt_msg_ids(session, store):
     it; the last delegate when a drained inbox holds several, the rule author_of applies to the delivery's peer), or ""
     when it carries no delegate (checked: a batched inbox whose first mail is a peer's coordinate and whose second the
     manager's dispatch is the manager's, and a delivery with no dispatch in it leaves _delegator_of its fallback, the
-    latest delegate at or before the mint; the manager's fourth review). The delegating peer of a top is then the
+    latest delegate at or before the mint, which stands only while that dispatch's own top is open at the mint; the
+    manager's fourth review and the 2026-09-12 fix). The delegating peer of a top is then the
     sender of THAT mail (_delegator_of), never merely the latest delegate the session received (a worker dispatched by
     two managers relays each block to the manager that asked, T334)."""
     cands = [nd for nd in store.get("nodes", {}).values()
@@ -12206,6 +12207,13 @@ def apply_group(store, menu, ops, t):
             child = menu[o["goal"] - 1]["id"]          # it) to a top-level card of its own — the inverse
             if child not in nodes or nodes[child].get("parentId") is None:
                 continue                               # merged away this reply, or already a top
+            ptop = nodes.get(_top_of(nodes, child) or "") or {}
+            if ptop.get("askAnchor") and not isinstance(nodes[child].get("origin"), dict):
+                for k in ("askAnchor", "askAnchorRecord", "promptMsgId"):   # the parent's anchor verdict comes along: the
+                    if k in ptop:                      #   child's own mint record is a step's (a system record after a
+                        nodes[child][k] = ptop[k]      #   compaction, a notice), which a later latch would read as a
+                    else:                              #   machine anchor and hand the user's own decision to a peer
+                        nodes[child].pop(k, None)      #   (the manager's live case, 2026-09-12)
             nodes[child]["parentId"] = None            # of group: a drifted tangent gets its own card
             if o.get("retitle"):                       # a step-phrased title may not stand alone as a card
                 nodes[child]["text"] = o["retitle"]
@@ -12807,7 +12815,7 @@ _DELEG_BY_MID = {}           # message id -> (from_id, to_sid) of that delegate 
 
 
 def _delegates_to():
-    """{recipient sid: [(t, from_id), ...] ascending} for every DELEGATE row in the postal log that reached its recipient
+    """{recipient sid: [(t, from_id, mid), ...] ascending} for every DELEGATE row in the postal log that reached its recipient
     (a returned or withdrawn send, _learn_return, makes no entry): the team relation as the mail recorded it. The
     courier's planted origin, when present, is derived from these rows; today's stores hold none, so this is the
     primary record (T334). Cross-host rows key on the resolved to_sid like _postal_ask_maps."""
@@ -12834,7 +12842,7 @@ def _delegates_to():
             f, t_, ts = o.get("from_id"), o.get("to_sid") or o.get("to_id"), o.get("t")
             if not (f and t_ and ts) or str(o.get("id") or "") in returned or str(t_).startswith("peer:"):
                 continue
-            out.setdefault(str(t_), []).append((int(ts), str(f)))
+            out.setdefault(str(t_), []).append((int(ts), str(f), str(o.get("id") or "")))
             if o.get("id"):
                 by_mid[str(o["id"])] = (str(f), str(t_))
         for v in out.values():
@@ -12857,13 +12865,50 @@ def _delegate_sender(mid, sid=None):
     return frm if sid is None or str(to) == str(sid) else None
 
 
+def _open_at(nd, at):
+    """Whether node `nd` was open (neither done nor cleared) at evidence time `at`: its log folded up to that time, the
+    same fold that materializes its live state (_fold_node). A node whose log holds events, none of them by `at`, was
+    open then (its story had not begun); a node with NO log at all reads its live flags (an older store's node
+    completed before the log carried the story)."""
+    full = nd.get("log") or []
+    if not full:
+        return not nd.get("nodeComplete") and not nd.get("cleared")
+    log = [e for e in full if int(e.get("ev_t") or 0) <= int(at or 0)]
+    if not log:
+        return True
+    return _fold_node(dict(nd, log=log)).get("state") not in ("done", "cleared")
+
+
+def _delegate_relation_open(nodes, row, at, exclude=None):
+    """Whether the delegate mail `row` ((t, from_id, mid) of _delegates_to) still stood as a relation at evidence time
+    `at`: a top of this store other than `exclude` carries that mail as its anchor (promptMsgId, the latch's stamp) and
+    was open then (_open_at). A dispatch that anchored no top (handled without a goal) or whose top had finished is no
+    standing relation, and a later top minted with no dispatch of its own is the user's."""
+    mid = str(row[2] or "") if len(row) > 2 else ""
+    if not mid:
+        return False
+    for tid, tn in nodes.items():
+        if tid == exclude or not isinstance(tn, dict) or tn.get("parentId") is not None:
+            continue
+        if str(tn.get("promptMsgId") or "") == mid and _open_at(tn, at):
+            return True
+    return False
+
+
 def _delegator_of(store, nid):
     """The peer that delegated the work `nid` sits under, or None when the goal is the user's own. Two records, the
-    courier's first: the top's planted origin.peer; else the sender of the latest DELEGATE mail this session received
-    at or before the top was minted (_delegates_to), provided the latch has POSITIVELY read the top's anchor as a
-    machine record (askAnchor "machine": the dispatch mail, never a prompt the user typed). An unlatched top, one
-    whose anchor is gone ("absent") or a scheduled prompt's top is left to the user (fail open to the block), whatever
-    mail the session got before. A top minted before any delegate reached the session predates the relation."""
+    courier's first: the top's planted origin.peer; else the sender of the DELEGATE mail the top's anchor names
+    (promptMsgId, the latch's stamp of the delivery's own dispatch), provided the latch has POSITIVELY read the top's
+    anchor as a machine record (askAnchor "machine": the dispatch mail, never a prompt the user typed). An unlatched
+    top, one whose anchor is gone ("absent") or a scheduled prompt's top is left to the user (fail open to the block),
+    whatever mail the session got before. A top whose anchor names no dispatch (a delivery holding only a peer's
+    heads-up, a watch notice, a record after a compaction) falls back to the latest delegate this session received at
+    or before its mint ONLY while that dispatch stands as a relation: its own top, open at the mint
+    (_delegate_relation_open). A worker under a manager's standing dispatch mints later tops from notices and peers'
+    mails, and those blocks still go to the manager; a dispatch that anchored no top or whose top has finished is no
+    relation, and the fallback would otherwise hand the user's own decisions to whichever peer last sent any delegate
+    mail (the manager's live case, 2026-09-12: three decisions relayed to an unrelated peer nine hours after its mail,
+    whose reply lifted a wait nobody should have been in). The time proxy stands only on that event."""
     nodes = store.get("nodes", {})
     top = _top_of(nodes, nid) if nid in nodes else None
     tn = nodes.get(top) or {}
@@ -12875,9 +12920,10 @@ def _delegator_of(store, nid):
     sid = str(store.get("rompUuid") or str(nid).rsplit(":", 1)[0])
     peer = _delegate_sender(tn["promptMsgId"], sid) if tn.get("promptMsgId") else None   # the mail the anchor names, first
     if not peer:                                  # no mail id on the anchor, or one that is no dispatch to this session (a
-        before = [r for r in _delegates_to().get(sid, []) if r[0] <= int(tn.get("t") or 0)]   # stamp from before the
-        peer = before[-1][1] if before else None  #   delegate-kind rule, a quoted marker): the latest delegate at or
-                                                  #   before the mint, as for an anchor that names none
+        mint = int(tn.get("t") or 0)              #   stamp from before the delegate-kind rule, a quoted marker): the latest
+        before = [r for r in _delegates_to().get(sid, []) if r[0] <= mint]   # delegate at or before the mint, and only
+        if before and _delegate_relation_open(nodes, before[-1], mint, exclude=top):   # while its own top stood open then
+            peer = before[-1][1]
     return None if not peer or ":" in peer else peer   # an ext: mailer or an unresolved cross-host key is no session that
                                                        #   could ever be asked (judge _presumed_closed: closed by construction)
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -10703,8 +10703,9 @@ def _latch_prompt_msg_ids(session, store):
     it; the last delegate when a drained inbox holds several, the rule author_of applies to the delivery's peer), or ""
     when it carries no delegate (checked: a batched inbox whose first mail is a peer's coordinate and whose second the
     manager's dispatch is the manager's, and a delivery with no dispatch in it leaves _delegator_of its fallback, the
-    latest delegate at or before the mint, which stands only while that dispatch's own top is open at the mint; the
-    manager's fourth review and the 2026-09-12 fix). The delegating peer of a top is then the
+    newest delegate at or before the mint whose relation stands, its own top open at the mint, walking past a stray
+    that anchored nothing (_standing_delegator); the manager's fourth review and the 2026-09-12 fix). The delegating
+    peer of a top is then the
     sender of THAT mail (_delegator_of), never merely the latest delegate the session received (a worker dispatched by
     two managers relays each block to the manager that asked, T334)."""
     cands = [nd for nd in store.get("nodes", {}).values()
@@ -12885,30 +12886,40 @@ def _open_at(nd, at):
     return _fold_node(dict(nd, log=log)).get("state") not in ("done", "cleared")
 
 
-def _delegate_relation_open(nodes, row, at, exclude=None):
-    """Whether the delegate mail `row` ((t, from_id, mid) of _delegates_to) still stood as a relation at evidence time
-    `at`: a top of this store other than `exclude` carries that mail as its anchor, by the latch's stamp (promptMsgId)
-    or by the courier's planted origin (origin.msgId), and was open then (_open_at). A dispatch that anchored no top
-    (handled without a goal) or whose top had finished is no standing relation, and a later top minted with no
-    dispatch of its own is the user's. A delegate row with no message id cannot qualify: nothing could name it."""
-    mid = str(row[2] or "") if len(row) > 2 else ""
-    if not mid:
-        return False
+def _dispatch_tops_open_at(nodes, at, exclude=None):
+    """{message id: whether a top it anchored was open at evidence time `at`} over the parentless nodes other than
+    `exclude`, keyed by the latch's stamp (promptMsgId) and the courier's planted origin (origin.msgId) alike; a mail
+    two tops name is open when either was (_open_at). Built once per attribution, so the walk over the delegate rows
+    costs a lookup per row rather than a pass over the store (the verifier's second round: rows times tops per call)."""
+    out = {}
     for tid, tn in nodes.items():
         if tid == exclude or not isinstance(tn, dict) or tn.get("parentId") is not None:
             continue
         o = tn.get("origin") if isinstance(tn.get("origin"), dict) else {}
-        if (str(tn.get("promptMsgId") or "") == mid or str(o.get("msgId") or "") == mid) and _open_at(tn, at):
-            return True
-    return False
+        mids = {str(tn.get("promptMsgId") or ""), str(o.get("msgId") or "")} - {""}
+        if not mids:
+            continue
+        opened = _open_at(tn, at)
+        for m in mids:
+            out[m] = out.get(m, False) or opened
+    return out
 
 
 def _standing_delegator(nodes, rows, at, exclude=None):
-    """The sender of the NEWEST delegate row at or before `at` whose relation stands (_delegate_relation_open), else
-    None: a stray later delegate from another peer that anchored nothing (a hand-off note) neither captures the block
-    nor strands it as the user's while the manager's dispatch top is open (the verifier's first round)."""
-    for row in reversed([r for r in rows if r[0] <= at]):
-        if _delegate_relation_open(nodes, row, at, exclude=exclude):
+    """The sender of the NEWEST delegate row ((t, from_id, mid) of _delegates_to) at or before `at` whose relation
+    stands, else None. A relation stands when a top of this store other than `exclude` carries the row's mail as its
+    anchor, by the latch's stamp or the courier's planted origin, and was open at `at` (_dispatch_tops_open_at). A
+    dispatch that anchored no top (handled without a goal) or whose top had finished is no standing relation; a row
+    with no message id sustains nothing (nothing could name it); and a stray later delegate from another peer that
+    anchored nothing (a hand-off note) is walked past, so it neither captures the block nor strands it as the user's
+    while the manager's dispatch top is open (the verifier's first round)."""
+    before = [r for r in rows if r[0] <= at]
+    if not before:
+        return None
+    open_by_mid = _dispatch_tops_open_at(nodes, at, exclude=exclude)
+    for row in reversed(before):
+        mid = str(row[2] or "") if len(row) > 2 else ""
+        if mid and open_by_mid.get(mid):
             return row[1]
     return None
 
@@ -12923,7 +12934,7 @@ def _delegator_of(store, nid):
     heads-up, a watch notice, a record after a compaction; an unlatched stamp gets the same bound) falls back to the
     newest delegate this session received at or before its mint whose dispatch stands as a relation: its own top,
     latched or courier-planted, open at the mint (_standing_delegator, walking the rows newest first past any stray
-    delegate that anchored nothing). A worker under a manager's standing dispatch mints later tops from notices and peers'
+    delegate that anchored nothing; a row with no message id sustains nothing). A worker under a manager's standing dispatch mints later tops from notices and peers'
     mails, and those blocks still go to the manager; a dispatch that anchored no top or whose top has finished is no
     relation, and the fallback would otherwise hand the user's own decisions to whichever peer last sent any delegate
     mail (the manager's live case, 2026-09-12: three decisions relayed to an unrelated peer nine hours after its mail,

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -12208,12 +12208,18 @@ def apply_group(store, menu, ops, t):
             if child not in nodes or nodes[child].get("parentId") is None:
                 continue                               # merged away this reply, or already a top
             ptop = nodes.get(_top_of(nodes, child) or "") or {}
-            if ptop.get("askAnchor") and not isinstance(nodes[child].get("origin"), dict):
-                for k in ("askAnchor", "askAnchorRecord", "promptMsgId"):   # the parent's anchor verdict comes along: the
-                    if k in ptop:                      #   child's own mint record is a step's (a system record after a
-                        nodes[child][k] = ptop[k]      #   compaction, a notice), which a later latch would read as a
-                    else:                              #   machine anchor and hand the user's own decision to a peer
-                        nodes[child].pop(k, None)      #   (the manager's live case, 2026-09-12)
+            if ptop.get("askAnchor") and ptop.get("askAnchor") != "machine" and not isinstance(nodes[child].get("origin"), dict):
+                for k in ("askAnchor", "askAnchorRecord", "promptMsgId"):   # a NON-machine parent's verdict (human,
+                    if k in ptop:                      #   scheduled, absent) comes along: the child's own mint record is
+                        nodes[child][k] = ptop[k]      #   a step's (a system record after a compaction, a notice), which
+                    else:                              #   a later latch would read as a machine anchor and hand the
+                        nodes[child].pop(k, None)      #   user's own decision to a peer (the manager's live case,
+                #                                          2026-09-12). A MACHINE parent's child is left to latch itself
+                #                                          from its own record: a system record reads machine with no
+                #                                          stamp and meets the standing-relation check, a typed record
+                #                                          reads human, where an inherited machine verdict would have
+                #                                          mailed the user's own question to the peer and dropped the top
+                #                                          out of the feed heal's hosts set (the verifier's first round)
             nodes[child]["parentId"] = None            # of group: a drifted tangent gets its own card
             if o.get("retitle"):                       # a step-phrased title may not stand alone as a card
                 nodes[child]["text"] = o["retitle"]
@@ -12810,7 +12816,7 @@ def _peer_name(sid):
         return ""
 
 
-_DELEG_CACHE = [None, {}]    # (mtime_ns, size), {to_sid: [(t, from_id), ...] ascending}: one scan per log change
+_DELEG_CACHE = [None, {}]    # (mtime_ns, size), {to_sid: [(t, from_id, mid), ...] ascending}: one scan per log change
 _DELEG_BY_MID = {}           # message id -> (from_id, to_sid) of that delegate row (filled by the same scan)
 
 
@@ -12881,18 +12887,30 @@ def _open_at(nd, at):
 
 def _delegate_relation_open(nodes, row, at, exclude=None):
     """Whether the delegate mail `row` ((t, from_id, mid) of _delegates_to) still stood as a relation at evidence time
-    `at`: a top of this store other than `exclude` carries that mail as its anchor (promptMsgId, the latch's stamp) and
-    was open then (_open_at). A dispatch that anchored no top (handled without a goal) or whose top had finished is no
-    standing relation, and a later top minted with no dispatch of its own is the user's."""
+    `at`: a top of this store other than `exclude` carries that mail as its anchor, by the latch's stamp (promptMsgId)
+    or by the courier's planted origin (origin.msgId), and was open then (_open_at). A dispatch that anchored no top
+    (handled without a goal) or whose top had finished is no standing relation, and a later top minted with no
+    dispatch of its own is the user's. A delegate row with no message id cannot qualify: nothing could name it."""
     mid = str(row[2] or "") if len(row) > 2 else ""
     if not mid:
         return False
     for tid, tn in nodes.items():
         if tid == exclude or not isinstance(tn, dict) or tn.get("parentId") is not None:
             continue
-        if str(tn.get("promptMsgId") or "") == mid and _open_at(tn, at):
+        o = tn.get("origin") if isinstance(tn.get("origin"), dict) else {}
+        if (str(tn.get("promptMsgId") or "") == mid or str(o.get("msgId") or "") == mid) and _open_at(tn, at):
             return True
     return False
+
+
+def _standing_delegator(nodes, rows, at, exclude=None):
+    """The sender of the NEWEST delegate row at or before `at` whose relation stands (_delegate_relation_open), else
+    None: a stray later delegate from another peer that anchored nothing (a hand-off note) neither captures the block
+    nor strands it as the user's while the manager's dispatch top is open (the verifier's first round)."""
+    for row in reversed([r for r in rows if r[0] <= at]):
+        if _delegate_relation_open(nodes, row, at, exclude=exclude):
+            return row[1]
+    return None
 
 
 def _delegator_of(store, nid):
@@ -12902,9 +12920,10 @@ def _delegator_of(store, nid):
     anchor as a machine record (askAnchor "machine": the dispatch mail, never a prompt the user typed). An unlatched
     top, one whose anchor is gone ("absent") or a scheduled prompt's top is left to the user (fail open to the block),
     whatever mail the session got before. A top whose anchor names no dispatch (a delivery holding only a peer's
-    heads-up, a watch notice, a record after a compaction) falls back to the latest delegate this session received at
-    or before its mint ONLY while that dispatch stands as a relation: its own top, open at the mint
-    (_delegate_relation_open). A worker under a manager's standing dispatch mints later tops from notices and peers'
+    heads-up, a watch notice, a record after a compaction; an unlatched stamp gets the same bound) falls back to the
+    newest delegate this session received at or before its mint whose dispatch stands as a relation: its own top,
+    latched or courier-planted, open at the mint (_standing_delegator, walking the rows newest first past any stray
+    delegate that anchored nothing). A worker under a manager's standing dispatch mints later tops from notices and peers'
     mails, and those blocks still go to the manager; a dispatch that anchored no top or whose top has finished is no
     relation, and the fallback would otherwise hand the user's own decisions to whichever peer last sent any delegate
     mail (the manager's live case, 2026-09-12: three decisions relayed to an unrelated peer nine hours after its mail,
@@ -12920,10 +12939,9 @@ def _delegator_of(store, nid):
     sid = str(store.get("rompUuid") or str(nid).rsplit(":", 1)[0])
     peer = _delegate_sender(tn["promptMsgId"], sid) if tn.get("promptMsgId") else None   # the mail the anchor names, first
     if not peer:                                  # no mail id on the anchor, or one that is no dispatch to this session (a
-        mint = int(tn.get("t") or 0)              #   stamp from before the delegate-kind rule, a quoted marker): the latest
-        before = [r for r in _delegates_to().get(sid, []) if r[0] <= mint]   # delegate at or before the mint, and only
-        if before and _delegate_relation_open(nodes, before[-1], mint, exclude=top):   # while its own top stood open then
-            peer = before[-1][1]
+        mint = int(tn.get("t") or 0)              #   stamp from before the delegate-kind rule, a quoted marker): the newest
+        peer = _standing_delegator(nodes, _delegates_to().get(sid, []), mint, exclude=top)   # delegate at or before the
+        #                                                                                       mint whose own top stood open then
     return None if not peer or ":" in peer else peer   # an ext: mailer or an unresolved cross-host key is no session that
                                                        #   could ever be asked (judge _presumed_closed: closed by construction)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -3026,7 +3026,7 @@ def _delegated_to(manager, worker):
         if nd.get("parentId") is None and isinstance(o, dict) and str(o.get("peer") or "") == str(manager):
             return True
     try:                                               # the primary record: a delegate mail from the manager to the worker
-        return any(f == str(manager) for _t, f in jd._delegates_to().get(str(worker), []))
+        return any(r[1] == str(manager) for r in jd._delegates_to().get(str(worker), []))
     except Exception as e:
         sys.stderr.write("delegated-to (%s -> %s): %r\n" % (manager, worker, e))
         return False

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -239,8 +239,11 @@ class CloserBlocks(_Peer):
         self.ask("ext:morning", WORKER, T0 - 100, kind="delegate")
         st, top, step = self.store()
         st["nodes"][top]["askAnchor"] = "machine"
-        nd = self._close(st, step, "cannot move further without you")
+        tid = WORKER + ":g0"                               # the mailer's dispatch anchored an open top, so the relation
+        st["nodes"][tid] = node(tid, "The morning sweep", t=T0 - 50, askAnchor="machine", promptMsgId=self.rows[-1]["id"])
+        nd = self._close(st, step, "cannot move further without you")   #   stands and the ext: filter itself is what decides
         self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
         st2, top2, step2 = self.store(delegated=True)
         st2["nodes"][top2]["origin"]["peer"] = "ext:morning"
         nd2 = self._close(st2, step2, "cannot move further without you")
@@ -1247,6 +1250,74 @@ class TwoDelegators(_Peer):
         self._coordinate_only_top(st, top)
         nd = self._close_block(st, step, "cannot move further without you")
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the relation stood when the top was born: judged at the mint, not at the block")
+
+    def test_a_typed_step_split_out_of_a_delegated_top_stays_the_users(self):
+        # the inheritance runs one way only: a step whose OWN record is the user's typed prompt, filed under a
+        # machine-anchored delegated top and split out, must not inherit machine and the dispatch stamp (the latch
+        # skips a top with a verdict, so nothing could correct it and the user's own question would be mailed away)
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"; st["nodes"][top]["promptMsgId"] = "m-web-1"   # the delegated top
+        st["nodes"][step]["promptUuid"] = "u-typed-step"  # the step's own record: a prompt the user typed mid-thread
+        menu = [st["nodes"][top], st["nodes"][step]]
+        self.assertEqual(jd.apply_group(st, menu, [{"do": "split", "goal": 2, "why": "a thread of its own"}], T0 + 100), 1)
+        self.assertNotIn("askAnchor", st["nodes"][step], "a machine parent's verdict is not inherited: the child latches itself")
+        self.assertNotIn("promptMsgId", st["nodes"][step])
+        session = {"turns": [{"atoms": [{"uuid": "u-typed-step", "type": "user", "author": "human",
+                                         "message": {"role": "user", "content": "should the exporter keep the old client too?"}}]}]}
+        jd._latch_ask_anchors(WORKER, session, st)
+        jd._latch_prompt_msg_ids(session, st)
+        self.assertEqual(st["nodes"][step].get("askAnchor"), "human", "its own record: the user's typed prompt")
+        nd = self._close_block(st, step, "should the exporter keep the old client too?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [], "a goal the user typed keeps its blocks")
+        self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
+
+    def test_a_system_record_step_split_out_of_a_delegated_top_latches_machine_and_meets_the_relation(self):
+        # the other half of the one-way rule: a machine parent's child latches from its own record; a system record
+        # reads machine with no stamp, and the standing-relation check then attributes it to the manager as before
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        st["nodes"][top]["askAnchor"] = "machine"; st["nodes"][top]["promptMsgId"] = "m-web-1"
+        st["nodes"][step]["promptUuid"] = "u-sys"
+        menu = [st["nodes"][top], st["nodes"][step]]
+        self.assertEqual(jd.apply_group(st, menu, [{"do": "split", "goal": 2, "why": "a thread of its own"}], T0 + 100), 1)
+        session = {"turns": [{"atoms": [{"uuid": "u-sys", "type": "user", "author": "system",
+                                         "message": {"role": "user", "content": [{"type": "text", "text": "<!-- romp-note: bookkeeping -->"}]}}]}]}
+        jd._latch_ask_anchors(WORKER, session, st)
+        jd._latch_prompt_msg_ids(session, st)
+        self.assertEqual(st["nodes"][step].get("askAnchor"), "machine")
+        self.assertEqual(st["nodes"][step].get("promptMsgId"), "")
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the dispatch's top (its former parent) is open: the manager's work")
+
+    def test_a_stray_later_delegate_that_anchors_nothing_does_not_end_the_managers_relation(self):
+        # the walk takes the newest delegate whose relation STANDS, not the newest row: a hand-off note from another
+        # peer that anchored no goal must neither capture the block (the base) nor strand it as a needs-you (a head
+        # that judged the latest row alone)
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self.rows.append(mail(OTHER, WORKER, T0 - 100, kind="delegate", mid="m-tests-1"))   # anchors nothing
+        self._write_mail()
+        st, top, step = self.store()
+        self._dispatch_top(st, "m-web-1")                  # the manager's dispatch top, open
+        self._coordinate_only_top(st, top)
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the newest delegate whose top is open")
+        self.assertTrue(nd.get("relayWanted"))
+
+    def test_a_courier_planted_dispatch_top_sustains_the_fallback_too(self):
+        # LOW 3: the relation is recognised through the planted origin's msgId as well as the latch's promptMsgId
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        tid = WORKER + ":g0"
+        st["nodes"][tid] = node(tid, "Land the exporter's login check", t=T0 - 150,
+                                origin={"peer": MANAGER, "goalId": MANAGER + ":g7", "msgId": "m-web-1"})
+        self._coordinate_only_top(st, top)
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the planted dispatch top stands as the relation")
 
     def test_a_top_split_out_of_a_human_anchored_top_stays_the_users(self):
         # the second observation: three decisions were split out of a top the user typed, and the split children were

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -216,6 +216,7 @@ class CloserBlocks(_Peer):
         self.ask(MANAGER, WORKER, T0 - 100, kind="delegate")
         st, top, step = self.store()
         st["nodes"][top]["askAnchor"] = "machine"
+        st["nodes"][top]["promptMsgId"] = self.rows[-1]["id"]   # the anchor names the dispatch (the latch's stamp)
         nd = self._close(st, step, "cannot move further without you")
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
         self.assertEqual(nd["relayWanted"]["peer"], MANAGER)
@@ -1156,8 +1157,9 @@ class TwoDelegators(_Peer):
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "web's mail anchored it, though tests wrote later")
         st2, top2, step2 = self.store()
         st2["nodes"][top2]["askAnchor"] = "machine"; st2["nodes"][top2]["promptMsgId"] = ""
+        self._dispatch_top(st2, "m-tests-1")               # tests' dispatch anchored a top of this session, still open
         nd2 = self._close_block(st2, step2, "cannot move further without you")
-        self.assertEqual(list(nd2.get("awaitingPeers") or ()), [OTHER], "no mail id on the anchor: the latest delegate")
+        self.assertEqual(list(nd2.get("awaitingPeers") or ()), [OTHER], "no mail id on the anchor: the latest delegate whose top is open")
 
     def test_the_planner_pass_latches_the_anchors_mail_id_from_the_parse(self):
         self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
@@ -1184,17 +1186,90 @@ class TwoDelegators(_Peer):
         nd = self._close_block(st, step, "cannot move further without you")
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER])
 
-    def test_a_delivery_with_no_delegate_marker_leaves_the_fallback_to_the_latest_delegate(self):
-        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
-        self._write_mail()
-        st, top, step = self.store()
+    def _dispatch_top(self, st, mid, t=T0 - 150, done_at=None):
+        """A top this session minted from the dispatch `mid` (its anchor latched machine, promptMsgId the mail's id), open
+        unless `done_at` says when romp completed it."""
+        tid = WORKER + ":g0"
+        st["nodes"][tid] = node(tid, "Land the exporter's login check", t=t, askAnchor="machine", promptMsgId=mid)
+        if done_at is not None:
+            st["nodes"][tid]["nodeComplete"] = True
+            st["nodes"][tid]["log"] = [{"kind": "done", "src": "closer", "ev_t": done_at, "at": done_at, "why": "landed"}]
+        return tid
+
+    def _coordinate_only_top(self, st, top):
+        """The fixture's top, minted from a delivery holding only a peer's heads-up: anchored machine, no dispatch."""
         text = "Heads up\n<!-- romp-msg-id: m-tests-c -->\n<!-- romp-msg-kind: coordinate -->"
         session = {"turns": [{"atoms": [{"uuid": "u1", "type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}]}]}
         st["nodes"][top]["promptUuid"] = "u1"; st["nodes"][top]["askAnchor"] = "machine"
         jd._latch_prompt_msg_ids(session, st)
         self.assertEqual(st["nodes"][top]["promptMsgId"], "", "no delegate in the delivery")
+
+    def test_a_delivery_with_no_delegate_marker_falls_back_only_while_the_dispatchs_top_is_open(self):
+        # the worker case kept: the manager's dispatch anchored a top of this session still open at the mint, so a
+        # later top the worker minted from a peer's heads-up is still the manager's work, its block relayed there
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        self._dispatch_top(st, "m-web-1")
+        self._coordinate_only_top(st, top)
         nd = self._close_block(st, step, "cannot move further without you")
-        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the latest delegate at or before the mint")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the dispatch's top is open: the relation stands")
+        self.assertTrue(nd.get("relayWanted"), "and the question is relayed to the manager")
+
+    def test_a_delegate_whose_top_is_complete_is_no_standing_relation(self):
+        # the live case: a dispatch handled and finished hours earlier; a top minted later from a post-compaction record
+        # holds a decision only the user can make, and its block must stay theirs
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        self._dispatch_top(st, "m-web-1", done_at=T0 - 50)   # finished before the later top was minted at T0
+        self._coordinate_only_top(st, top)
+        nd = self._close_block(st, step, "did the real-token login check pass?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [], "the user's decision, never the peer's")
+        self.assertTrue(nd["blocked"], "filed as the user's block")
+        self.assertNotIn("relayWanted", nd, "nothing is asked on the session's behalf")
+
+    def test_a_delegate_that_anchored_no_top_is_no_standing_relation(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()                       # the dispatch was handled without a goal: no top names it
+        self._coordinate_only_top(st, top)
+        nd = self._close_block(st, step, "did the real-token login check pass?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [], "no top ever carried that dispatch: no relation")
+        self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
+
+    def test_a_dispatchs_top_completed_after_the_mint_was_open_at_the_mint(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        self._dispatch_top(st, "m-web-1", done_at=T0 + 30)   # completed after the later top's mint (T0) and before its block
+        self._coordinate_only_top(st, top)
+        nd = self._close_block(st, step, "cannot move further without you")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the relation stood when the top was born: judged at the mint, not at the block")
+
+    def test_a_top_split_out_of_a_human_anchored_top_stays_the_users(self):
+        # the second observation: three decisions were split out of a top the user typed, and the split children were
+        # re-latched from their own mint record (a system record after a compaction) as machine, then attributed
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        st, top, step = self.store()
+        self._dispatch_top(st, "m-web-1")                  # a standing relation exists...
+        st["nodes"][top]["askAnchor"] = "human"; st["nodes"][top]["promptUuid"] = "u-typed"   # ...but this top the user typed
+        st["nodes"][step]["promptUuid"] = "u-sys"          # the step's own mint turn: a system record
+        menu = [st["nodes"][top], st["nodes"][step]]
+        self.assertEqual(jd.apply_group(st, menu, [{"do": "split", "goal": 2, "why": "a thread of its own"}], T0 + 100), 1)
+        self.assertIsNone(st["nodes"][step]["parentId"], "split out as a top of its own")
+        self.assertEqual(st["nodes"][step].get("askAnchor"), "human", "the split-born top inherits the parent's anchor")
+        session = {"turns": [{"atoms": [{"uuid": "u-sys", "type": "user", "author": "system",
+                                         "message": {"role": "user", "content": [{"type": "text", "text": "<!-- romp-note: bookkeeping -->"}]}}]}]}
+        jd._latch_ask_anchors(WORKER, session, st)         # a later latch pass over the parse
+        jd._latch_prompt_msg_ids(session, st)
+        self.assertEqual(st["nodes"][step].get("askAnchor"), "human", "…and is not re-latched from its own mint record")
+        nd = self._close_block(st, step, "pick the glossary design?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [], "the user's call, never the peer's")
+        self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
 
     def _close_block(self, st, step, why):
         with contextlib.redirect_stderr(io.StringIO()):
@@ -1235,8 +1310,9 @@ class TwoDelegators(_Peer):
         self._write_mail()
         st, top, step = self.store()
         st["nodes"][top]["askAnchor"] = "machine"; st["nodes"][top]["promptMsgId"] = "m-tests-c"   # an older stamp (the first-marker rule)
+        self._dispatch_top(st, "m-web-1")                  # the manager's dispatch anchored a top of this session, still open
         nd = self._close_block(st, step, "cannot move further without you")
-        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "as for an anchor that names none: the latest delegate")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "as for an anchor that names none: the latest delegate whose top is open")
 
 
 class MoreRules(_Peer):

--- a/tests/test_peer_wait_blocks.py
+++ b/tests/test_peer_wait_blocks.py
@@ -34,9 +34,12 @@ MANAGER = "11111111-2222-3333-4444-bbbbbbbbbbbb"    # the peer that delegated it
 OTHER = "11111111-2222-3333-4444-cccccccccccc"      # another peer it asked something
 
 
-def mail(from_id, to_id, t, kind="question", mid=None):
-    return {"id": mid or "m-%s-%s-%d" % (from_id[-4:], to_id[-4:], t), "from_id": from_id, "to_id": to_id,
-            "from": "api", "to": "web", "t": t, "kind": kind}
+def mail(from_id, to_id, t, kind="question", mid=None, noid=False):
+    d = {"id": mid or "m-%s-%s-%d" % (from_id[-4:], to_id[-4:], t), "from_id": from_id, "to_id": to_id,
+         "from": "api", "to": "web", "t": t, "kind": kind}
+    if noid:
+        d.pop("id")                                        # an older row shape: nothing could ever name it
+    return d
 
 
 def node(nid, text, parent=None, t=T0, **kw):
@@ -1318,6 +1321,32 @@ class TwoDelegators(_Peer):
         self._coordinate_only_top(st, top)
         nd = self._close_block(st, step, "cannot move further without you")
         self.assertEqual(list(nd.get("awaitingPeers") or ()), [MANAGER], "the planted dispatch top stands as the relation")
+
+    def test_a_courier_planted_dispatch_top_sustains_the_fallback_only_while_open_at_the_mint(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", mid="m-web-1"))
+        self._write_mail()
+        for done_at, expect in ((T0 - 50, []), (T0 + 30, [MANAGER])):   # finished before the mint: nothing; after: stands
+            with self.subTest(done_at=done_at):
+                st, top, step = self.store()
+                tid = WORKER + ":g0"
+                st["nodes"][tid] = node(tid, "Land the exporter's login check", t=T0 - 150, nodeComplete=True,
+                                        origin={"peer": MANAGER, "goalId": MANAGER + ":g7", "msgId": "m-web-1"},
+                                        log=[{"kind": "done", "src": "closer", "ev_t": done_at, "at": done_at, "why": "landed"}])
+                self._coordinate_only_top(st, top)
+                nd = self._close_block(st, step, "cannot move further without you")
+                self.assertEqual(list(nd.get("awaitingPeers") or ()), expect)
+                self.assertEqual(nd["blocked"], not expect)
+
+    def test_a_delegate_row_without_a_message_id_sustains_nothing(self):
+        self.rows.append(mail(MANAGER, WORKER, T0 - 200, kind="delegate", noid=True))
+        self._write_mail()
+        st, top, step = self.store()
+        self._dispatch_top(st, "m-web-1")                  # even an open top claiming some id: nothing names the id-less row
+        self._coordinate_only_top(st, top)
+        nd = self._close_block(st, step, "did the real-token login check pass?")
+        self.assertEqual(list(nd.get("awaitingPeers") or ()), [], "an id-less delegate sustains no relation")
+        self.assertTrue(nd["blocked"])
+        self.assertNotIn("relayWanted", nd)
 
     def test_a_top_split_out_of_a_human_anchored_top_stays_the_users(self):
         # the second observation: three decisions were split out of a top the user typed, and the split children were

--- a/tests/test_relay_context.py
+++ b/tests/test_relay_context.py
@@ -236,7 +236,7 @@ class OnTheMarkerAndInTheMail(unittest.TestCase):
         node = lambda nid, text, parent=None, t=T0: {"id": nid, "text": text, "parentId": parent, "nodeComplete": False,
                                                     "blocked": False, "cleared": False, "trail": [], "t": t, "mt": t, "log": []}
         st = {"rompUuid": WORKER, "seq": 2, "placements": {}, "status": {top: "working"}, "confirming": [],
-              "nodes": {top: dict(node(top, "Ship the exporter"), askAnchor="machine"),   # a machine-anchored, delegated top
+              "nodes": {top: dict(node(top, "Ship the exporter"), askAnchor="machine", promptMsgId="m-d"),   # a machine-anchored top whose anchor names the dispatch
                         step: node(step, "Ask which client", parent=top, t=T0 + 60)}}
         return st, top, step
 


### PR DESCRIPTION
## What

The peer-wait relay's delegator fallback attributed a session's own decisions to whichever peer last sent it any delegate mail, and relayed the user's blocks to that peer as questions on the session's behalf. Live case: a session's planner minted three decision goals from a post-compaction turn whose anchor is a system record, so their anchors named no dispatch; the fallback took the latest delegate mail the session had received, nine hours earlier, unrelated, and handled without a goal. One goal's block was filed as a wait on that peer and its question mailed there; the peer's reply lifted the wait, and the user's decision left the Blocked column with nobody asked.

## Rule

The fallback is a time proxy for a relation, and now stands only on the relation's own event. A goal whose anchor names no dispatch falls back to the latest delegate at or before its mint **only while that dispatch's own goal was still open at the mint**: some top of the store carries that mail as its anchor and its log, folded up to the mint, is neither done nor cleared. A dispatch that anchored no goal, or whose goal had finished, is no standing relation, and the new goal is the user's, exactly as the absent-anchor case already fails open. A worker under a manager's standing dispatch still mints later goals from notices and peers' mails, and their blocks still go to the manager. The delegate rows carry the mail id so the fallback can find the goal a dispatch anchored.

The fallback walks the delegate rows at or before the mint newest first and takes the first whose relation stands, so a stray later delegate from another peer that anchored nothing (a hand-off note) neither captures the block nor strands it as the user's while the manager's dispatch goal is open. The walk reads one map per attribution, message id to open-at-the-mint over the parentless goals (the latch's stamp and the planted origin both keyed), a lookup per row rather than a pass over the store per row. A courier-planted dispatch goal (its origin naming the mail) sustains the fallback like a latched one, and only while open at the mint; a delegate row with no message id sustains nothing. An anchor whose mail-id stamp the latch has not written yet gets the same bound as an empty stamp.

A goal split out of another inherits the parent's anchor verdict (anchor class, anchor record, mail id) in the fail-open direction only: when the parent is not a machine anchor (typed, scheduled, absent). The child's own mint record is a step's, a system record after a compaction or a notice, which a later latch read as a machine anchor and handed the user's own decision to a peer; the three live goals were born by such a split from a goal the user typed. A machine parent's child is left to latch itself from its own record: a system record reads machine with no stamp and meets the standing-relation check, a typed record reads human and keeps its block, where an inherited machine verdict would have mailed the user's own question away with nothing able to correct it.

## Tests

Red first on the old code, in `tests/test_peer_wait_blocks.py` beside the fallback pins: a delegate whose goal is complete is no standing relation (the user's block, no relay); a delegate that anchored no goal is none either; a goal split out of a human-anchored goal stays the user's through a later latch pass. Kept green: the worker case, the dispatch's goal open at the mint and the later goal's block relayed to the manager; and a dispatch's goal completed after the mint counted as open at the mint. From the verifier's first round, red first on the previous head: a typed step split out of a delegated goal stays the user's through a later latch pass; a stray later delegate that anchors nothing does not end the manager's relation; a courier-planted dispatch goal sustains the fallback; a system-record step split out of a delegated goal latches machine with no stamp and meets the relation. Three fixtures that leaned on the unbounded fallback now name the dispatch on their anchor or carry its open goal, the pseudo-sid test's first half among them so its filter is what decides. From the second round, red first on the base: a courier-planted dispatch goal completed before the mint sustains nothing while one completed after the mint does; a delegate row without a message id sustains nothing. Both docstrings, the judges page and the read-side page say the bounded rule.

Tier: fix
