### PR TITLE
The hover preview on a remote host's session and on a bare filename: the fetch rides the host relay, the card says the exact refusal, a sealed event without a verdict refolds once (T364)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1780,7 +1780,9 @@ bytes) ride this kernel's `/remote/<host>/file` relay with the bare session id,
 exactly as the inline images do; the remote kernel builds that session's
 messages and judges its own files, and the relay is available only while the
 host is attached (a host reached through a relay alone shows the text card
-until it attaches). The belt reads the file's first
+until it attaches).
+
+The belt reads the file's first
 64 KB at load (so at warm time): a hit there means the file is never cached and
 the link ships without a preview kind. It reads the served slice again on the
 route: a secret past the first 64 KB passes the load-time read, so that file's

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1765,7 +1765,22 @@ under `.ssh`, `.gnupg`, `.aws`, `.docker`, `.kube`, `.azure`, `.gcloud`,
 kind the card cannot show, or a file over the caps (2 MB of text, 50 MB of
 media). Under the name rules sits a content belt: a text shaped like a
 credential (a private-key block, a key or token assignment, a provider token, a
-JWT) is refused with "looks like a secret". The belt reads the file's first
+JWT) is refused with "looks like a secret". For every verified link the kernel
+does **not** allow, it ships the exact condition beside the kinds, as
+`pathPreviewWhy` (token to why), and the text card says it: "shown as text: a
+secrets-shaped name", "shown as text: looks like a secret", "shown as text:
+outside the session's folder and your home", and so on; a link the kernel
+shipped no verdict for at all says that instead. `pathPreview` rides every
+message with verified links (empty when none previews), so a message sealed
+before the kernel judged previews is rebuilt once and gains its verdicts.
+
+**A session on another host.** A remote session's files live on that
+machine's disk, so the card's fetches (the text slice and the image or PDF
+bytes) ride this kernel's `/remote/<host>/file` relay with the bare session id,
+exactly as the inline images do; the remote kernel builds that session's
+messages and judges its own files, and the relay is available only while the
+host is attached (a host reached through a relay alone shows the text card
+until it attaches). The belt reads the file's first
 64 KB at load (so at warm time): a hit there means the file is never cached and
 the link ships without a preview kind. It reads the served slice again on the
 route: a secret past the first 64 KB passes the load-time read, so that file's

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -33376,6 +33376,16 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                     if _chat_stat_key(_of) != _key:
                         _fold_why = "task-output"
                         break
+            if _fold_why is None:
+                # an event sealed with path links but NO preview verdict (built by a kernel before the previews, or
+                # restored from a document that predates them, T364): one refold gives it the key, and the clause is
+                # quiet from then on (every build attaches pathPreview beside a non-empty pathLinks). A restored entry
+                # may lack the field itself; then the events are scanned once here
+                _pvm = _fe.get("pv_missing")
+                if _pvm is None:
+                    _pvm = [_i for _i, _e in enumerate(_fe["events"]) if _e.get("pathLinks") and "pathPreview" not in _e]
+                if _pvm:
+                    _fold_why = "path-preview"
             if _fold_why is None and _fe["pl_pending"]:
                 # unresolved path tokens are retried on every build BY DESIGN (a mention precedes the file):
                 # retry exactly those, and rebuild if one now resolves
@@ -33649,9 +33659,11 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                             pl = _path_links(prompt, sid, a.get("uuid"), _pl_memo)
                             if pl is not None:
                                 ev["pathLinks"] = pl    # path-shaped tokens, filesystem-verified/fixed → the client's link gate
-                                pv = _path_previews(pl, sid)
-                                if pv:
-                                    ev["pathPreview"] = pv   # the links a hover may preview, by kind; the markdown ones warmed (T351)
+                                pv, pw = _path_preview_verdicts(pl, sid)
+                                if pl:
+                                    ev["pathPreview"] = pv   # the links a hover may preview, by kind; the markdown ones warmed (T351). The key rides EVERY event with links (empty when none previews): its presence is the verdict, and the fold refolds an event built without one (T364)
+                                if pw:
+                                    ev["pathPreviewWhy"] = pw   # …and for each link it may not, the exact refusal, the text card's words (T364)
                             pp = _path_pins(sid, a.get("uuid"))
                             if pp:
                                 ev["pathPins"] = pp     # mention-time snapshots: this message's embeds keep these bytes
@@ -33758,9 +33770,11 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                         pl = _path_links(txt, sid, a.get("uuid"), _pl_memo)
                         if pl is not None:
                             ev["pathLinks"] = pl    # path-shaped tokens, filesystem-verified/fixed → the client's link gate
-                            pv = _path_previews(pl, sid)
-                            if pv:
-                                ev["pathPreview"] = pv   # the links a hover may preview, by kind; the markdown ones warmed (T351)
+                            pv, pw = _path_preview_verdicts(pl, sid)
+                            if pl:
+                                ev["pathPreview"] = pv   # the links a hover may preview, by kind; the markdown ones warmed (T351). The key rides EVERY event with links (empty when none previews): its presence is the verdict, and the fold refolds an event built without one (T364)
+                            if pw:
+                                ev["pathPreviewWhy"] = pw   # …and for each link it may not, the exact refusal, the text card's words (T364)
                         pp = _path_pins(sid, a.get("uuid"))
                         if pp:
                             ev["pathPins"] = pp     # mention-time snapshots: this message's embeds keep these bytes
@@ -33920,6 +33934,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                 else:
                     _pdeps = tuple(_pdeps_sealed) + _postal_card_deps(_pcards_new, _pidx, _msum)
                 _plp = list(_fe["pl_pending"]) if _fold_ok else []
+                _pvm = list(_fe.get("pv_missing") or ()) if _fold_ok else []   # sealed events with links but no preview verdict (T364)
                 _touts = list(_fe["task_outs"]) if _fold_ok else []
                 for _e in _newpart:
                     for _r in (_e.get("reminders") or []) if _e.get("kind") == "user" else ():
@@ -33932,6 +33947,8 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                         _hit = _PATH_LINK_CACHE.get((sid, _e["uuid"]))
                         if _hit is not None and _hit[1]:
                             _plp.append((_e["uuid"], _e["md"], _i))
+                        if _e.get("pathLinks") and "pathPreview" not in _e:
+                            _pvm.append(_i)
                 _seg_pref = [dict(_fe["seg"][_q]) if _fold_ok else {} for _q in range(4)]
                 for _ti in range(_fk, _np):
                     for _q in range(4):
@@ -33966,7 +33983,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                                     + [(em.parse_z(_e.get("ts")) or 0, (_e.get("md") or "").strip()) for _e in _newpart if _e.get("orphaned")],
                     "open_tools": _open_tools, "skill_unfilled": _skill_unf,
                     "postal_raw": _praw, "postal_cards": _pcards,
-                    "postal_key": _pk, "postal_deps": _pdeps, "pl_pending": _plp,
+                    "postal_key": _pk, "postal_deps": _pdeps, "pl_pending": _plp, "pv_missing": _pvm,
                     "task_outs": _touts,
                     # the sealed Agent cards, for _chat_agents_moved: (toolUseId, agentId, pending) —
                     # pending = a background launch sealed without its report (the ack stands as output)
@@ -44328,6 +44345,25 @@ def _slice_warm(fp):
     return why in ("", "too large to show", "unreadable")   # a transient refusal keeps the kind; a secret or a binary drops it
 
 
+def _slice_warm_why(fp):
+    """_slice_warm's refusal as words, "" when the markdown may be previewed: the content belt's "looks like a secret"
+    or "not text" drops the kind (a credential-shaped line in a notes file is the likeliest reason a markdown link
+    the repo index resolved shows as text, T364); a transient refusal keeps it, as _slice_warm does."""
+    real = os.path.realpath(fp)
+    try:
+        st = os.stat(real)
+        with _SLICE_CACHE_LOCK:
+            if (real, st.st_mtime_ns) in _SLICE_CACHE:
+                return ""
+    except OSError:
+        return "not a file"
+    e, _hit, why = _slice_load(real)
+    if e is not None:
+        _PERF_STATS.file_slice(False, 0, warm=True)
+        return ""
+    return "" if why in ("", "too large to show", "unreadable") else why
+
+
 def _slice_body(fp, sid, anchor):
     """The slice route's answer, pure of the socket: (status, payload, content_type), the payload a dict to send as JSON
     or the plain text of a 415. 403 with `why` when the popover may not render the path (the client never asks for one
@@ -44583,16 +44619,31 @@ def _glossary_lookup(sid, term):
     return 404, {"error": "no such term in the group's glossary: %r" % want, "tried": [_tilde(str(path))], "group": group}
 
 
-def _path_previews(links, sid):
-    """{token: kind} for the verified links the preview popover may fetch for session `sid` (shipped as pathPreview
-    beside pathLinks; a token absent here is shown as text plus "open", with NO request), warming the markdown ones."""
-    out = {}
+def _path_preview_verdicts(links, sid):
+    """({token: kind}, {token: why}) for the verified links of session `sid`: the kinds the preview popover may fetch
+    (shipped as pathPreview beside pathLinks; a token absent there is shown as text plus "open", with NO request), and
+    for every token it may NOT, the exact condition that refused it (shipped as pathPreviewWhy, the text card's words:
+    T364, the review of the laptop report, where the card blamed the confinement for whatever the reason was). The
+    whys are _slice_allowed's, plus the markdown warm's content-belt refusals ("looks like a secret", "not text"). The
+    markdown ones are warmed here."""
+    kinds, whys = {}, {}
     for tok, target in (links or {}).items():
         fp = _resolve_open_path(target, sid)
-        kind, _why = _slice_allowed(fp, sid)
-        if kind and (kind != "markdown" or _slice_warm(fp)):
-            out[tok] = kind
-    return out
+        kind, why = _slice_allowed(fp, sid)
+        if kind and kind == "markdown":
+            why = _slice_warm_why(fp)
+            if why:
+                kind = None
+        if kind:
+            kinds[tok] = kind
+        else:
+            whys[tok] = why or "not previewed"
+    return kinds, whys
+
+
+def _path_previews(links, sid):
+    """{token: kind} alone (the callers that need the refusals read _path_preview_verdicts)."""
+    return _path_preview_verdicts(links, sid)[0]
 
 
 def _human_bytes(n):
@@ -45215,6 +45266,20 @@ def _repo_index_key(cwd):
         return None
 
 
+_REPO_INDEX_STOOD_DOWN = set()   # the cwds whose stand-down was said once (T364: a silent None left a bare filename unlinked with no trace)
+
+
+def _repo_index_stood_down(cwd, why):
+    """One stderr line per cwd when the repo index cannot be had (git absent or failing, a listing past the ceiling), so
+    a bare filename that stays plain text is diagnosable from the kernel log (T364, the laptop report)."""
+    if cwd in _REPO_INDEX_STOOD_DOWN:
+        return
+    if len(_REPO_INDEX_STOOD_DOWN) >= 256:
+        _REPO_INDEX_STOOD_DOWN.clear()
+    _REPO_INDEX_STOOD_DOWN.add(cwd)
+    sys.stderr.write("path links: the repo index for %s stood down (%s); bare filenames in this session's messages stay plain text\n" % (_tilde(cwd), why))
+
+
 def _repo_file_index(cwd):
     """basename -> [repo-relative paths] for every tracked or untracked-unignored file under `cwd`,
     or None when there is no list to be had (not a git repo, git absent/failing, or a listing past
@@ -45236,12 +45301,15 @@ def _repo_file_index(cwd):
     try:
         out = subprocess.run(["git", "ls-files", "-co", "--exclude-standard"],
                              cwd=cwd, capture_output=True, text=True, timeout=10)
-    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError) as e:
+        _repo_index_stood_down(cwd, "git did not run: %s" % (e,))
         return None
     if out.returncode != 0:
+        _repo_index_stood_down(cwd, "git ls-files exited %d: %s" % (out.returncode, (out.stderr or "").strip()[:200]))
         return None
     names = set(out.stdout.splitlines())   # a set: an index/worktree duplicate must not fake ambiguity
     if len(names) > _REPO_LIST_MAX:
+        _repo_index_stood_down(cwd, "%d files, past the %d-file ceiling" % (len(names), _REPO_LIST_MAX))
         return None
     idx = {}
     for p in names:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -45274,6 +45274,11 @@ def _repo_index_stood_down(cwd, why):
     a bare filename that stays plain text is diagnosable from the kernel log (T364, the laptop report)."""
     if cwd in _REPO_INDEX_STOOD_DOWN:
         return
+    # a .git pointer file that cannot be followed is already named, once per fault episode, by _git_file_fault (its
+    # stderr line and bell row carry the path): the index standing down there is the same finding, not a second line
+    with _git_file_faults_lock:
+        if os.path.join(_tree_of(cwd)[0] or cwd, ".git") in _git_file_faults:
+            return
     if len(_REPO_INDEX_STOOD_DOWN) >= 256:
         _REPO_INDEX_STOOD_DOWN.clear()
     _REPO_INDEX_STOOD_DOWN.add(cwd)

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -33377,13 +33377,16 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                         _fold_why = "task-output"
                         break
             if _fold_why is None:
-                # an event sealed with path links but NO preview verdict (built by a kernel before the previews, or
-                # restored from a document that predates them, T364): one refold gives it the key, and the clause is
-                # quiet from then on (every build attaches pathPreview beside a non-empty pathLinks). A restored entry
-                # may lack the field itself; then the events are scanned once here
+                # a belt for a fold DOCUMENT written by an older kernel (T364): its events may carry path links with no
+                # preview verdict, and its entries may lack this field. In a process running this code the clause never
+                # fires (the one writer attaches pathPreview beside every non-empty pathLinks and records pv_missing as
+                # the empty list); what gives the user's existing messages their verdicts is the attach-site change plus
+                # the restart a deploy implies (the fold and the built-chat memo come up cold). An entry without the
+                # field is scanned once and the result recorded, empty included, so the scan does not repeat per build
                 _pvm = _fe.get("pv_missing")
                 if _pvm is None:
                     _pvm = [_i for _i, _e in enumerate(_fe["events"]) if _e.get("pathLinks") and "pathPreview" not in _e]
+                    _fe["pv_missing"] = _pvm
                 if _pvm:
                     _fold_why = "path-preview"
             if _fold_why is None and _fe["pl_pending"]:
@@ -44641,11 +44644,6 @@ def _path_preview_verdicts(links, sid):
     return kinds, whys
 
 
-def _path_previews(links, sid):
-    """{token: kind} alone (the callers that need the refusals read _path_preview_verdicts)."""
-    return _path_preview_verdicts(links, sid)[0]
-
-
 def _human_bytes(n):
     """Byte count → a short human size, for the 413 that has to explain itself."""
     for unit, step in (("GB", 1 << 30), ("MB", 1 << 20), ("KB", 1 << 10)):
@@ -45266,13 +45264,14 @@ def _repo_index_key(cwd):
         return None
 
 
-_REPO_INDEX_STOOD_DOWN = set()   # the cwds whose stand-down was said once (T364: a silent None left a bare filename unlinked with no trace)
+_REPO_INDEX_STOOD_DOWN = set()   # (cwd, why) pairs said once (T364: a silent None left a bare filename unlinked with no trace)
 
 
 def _repo_index_stood_down(cwd, why):
-    """One stderr line per cwd when the repo index cannot be had (git absent or failing, a listing past the ceiling), so
-    a bare filename that stays plain text is diagnosable from the kernel log (T364, the laptop report)."""
-    if cwd in _REPO_INDEX_STOOD_DOWN:
+    """One stderr line per cwd AND reason when the repo index cannot be had (git absent or failing, a listing past the
+    ceiling), so a bare filename that stays plain text is diagnosable from the kernel log (T364, the laptop report); a
+    changed reason for the same cwd is a new line (verifier low, round one)."""
+    if (cwd, why) in _REPO_INDEX_STOOD_DOWN:
         return
     # a .git pointer file that cannot be followed is already named, once per fault episode, by _git_file_fault (its
     # stderr line and bell row carry the path): the index standing down there is the same finding, not a second line
@@ -45281,7 +45280,7 @@ def _repo_index_stood_down(cwd, why):
             return
     if len(_REPO_INDEX_STOOD_DOWN) >= 256:
         _REPO_INDEX_STOOD_DOWN.clear()
-    _REPO_INDEX_STOOD_DOWN.add(cwd)
+    _REPO_INDEX_STOOD_DOWN.add((cwd, why))
     sys.stderr.write("path links: the repo index for %s stood down (%s); bare filenames in this session's messages stay plain text\n" % (_tilde(cwd), why))
 
 

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -124,7 +124,7 @@ CENSUS = {
     "_patch_rows": ("pure", "over a structured patch"),
     "_path_links": ("sig", "pathlink", "a resolved token latches for the message's life; an unresolved one is retried, and the retry is the pathlink dep"),
     "_path_pins": ("sig", "pathlink", "the pins latched beside the links"),
-    "_path_previews": ("sig", "pathlink", "the preview popover's verdict per verified link (T351): a stat of each target beside the links, and it warms the cache; it moves only when the links move or a file appears, the pathlink dep"),
+    "_path_preview_verdicts": ("sig", "pathlink", "the preview popover's verdict per verified link, with the refusal for each link that does not preview (T351, T364): a stat of each target beside the links, and it warms the cache; it moves only when the links move or a file appears, the pathlink dep"),
     "_postal_card_deps": ("sig", "postal"),
     "_postal_index": ("sig", "postal", "memoized on the log's identity"),
     "_queue_recallable": ("sig", "backend"),

--- a/tests/test_chat_fold.py
+++ b/tests/test_chat_fold.py
@@ -245,6 +245,30 @@ class Gates(_Fold):
         self.assertGreater(km._CHAT_FOLD_STATS.get(g, 0), n0, "the %s gate must demote here" % reason)
         return inc
 
+    def test_an_event_sealed_without_a_preview_verdict_refolds_once(self):
+        # T364: an event built before the kernel judged previews (or restored from a document that predates them)
+        # carries pathLinks and no pathPreview key, and the fold kept it sealed for good, so links in existing messages
+        # never gained a preview. One refold gives every such event the key; afterwards the clause is quiet
+        s = self.s
+        (s.cdir / "notes.md").write_text("# Notes\n")
+        u1 = s.uid(); s.append([uline(s.tick(), "see notes.md", u1, None)])
+        a1 = s.uid(); s.append([aline(s.tick(), "Read notes.md first.", a1, u1, stop="end_turn")])
+        u2 = s.uid(); s.append([uline(s.tick(), "ok", u2, a1)])
+        a2 = s.uid(); s.append([aline(s.tick(), "Done.", a2, u2)])
+        self.equiv("two turns, a link in the first")
+        sealed = [e for e in km._chat_fold_get(SID)["events"] if e.get("pathLinks")]
+        self.assertTrue(sealed, "the first turn's link is sealed")
+        self.assertTrue(all("pathPreview" in e for e in sealed), "every sealed event with links carries the verdict key: %r" % [sorted(e) for e in sealed])
+        self.assert_folding()
+        fe = km._chat_fold_get(SID)
+        for e in fe["events"]:
+            e.pop("pathPreview", None); e.pop("pathPreviewWhy", None)   # the old shape
+        fe.pop("pv_missing", None)                                       # a restored entry's shape: no field; the events are scanned once
+        inc = self._demotes("path-preview", "the old shape refolds once")
+        self.assertTrue(all("pathPreview" in e for e in inc["events"] if e.get("pathLinks")), "…and the rebuilt events carry the key")
+        self.assertEqual(km._chat_fold_get(SID).get("pv_missing"), [], "nothing left to refold for")
+        self.assert_folding()
+
     def test_a_tool_result_landing_in_a_later_turn_demotes(self):
         # turn 1 ENDS with a tool call still unanswered (a typed prompt only opens a new turn after an
         # ended one — an unfinished turn absorbs it); the prompt opens turn 2; THEN the result lands, in

--- a/tests/test_file_preview_browser.py
+++ b/tests/test_file_preview_browser.py
@@ -102,11 +102,15 @@ page.on("request", (r) => { if (/\/file\?/.test(r.url())) fileRequests++; });
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab[data-id]", { timeout: 20000 });
 await page.click('#tabs .tab[data-id="' + cfg.sid + '"]');
-await page.waitForFunction(() => document.querySelectorAll("#content .file-uri-link").length >= 9, null, { timeout: 20000 });
+try { await page.waitForFunction(() => document.querySelectorAll("#content .file-uri-link").length >= 11, null, { timeout: 20000 }); }
+catch (e) {   // say which links rendered, so a short count is diagnosable from the failure alone
+  const got = await page.evaluate(() => Array.from(document.querySelectorAll("#content .file-uri-link")).map((a) => a.dataset.path + (a.dataset.frag ? "#" + a.dataset.frag : "")));
+  console.error("links rendered (" + got.length + "): " + JSON.stringify(got)); process.exit(1);
+}
 await page.mouse.move(900, 720); await page.waitForTimeout(300);
 const CARD = "#file-preview-pop";
 const shown = () => page.evaluate(() => { const p = document.getElementById("file-preview-pop"); return !!p && getComputedStyle(p).display !== "none"; });
-const links = await page.evaluate(() => Array.from(document.querySelectorAll("#content .file-uri-link")).map((a) => ({ text: a.textContent, path: a.dataset.path, frag: a.dataset.frag || null, preview: a.dataset.preview || null, rel: a.dataset.rel || null })));
+const links = await page.evaluate(() => Array.from(document.querySelectorAll("#content .file-uri-link")).map((a) => ({ text: a.textContent, path: a.dataset.path, frag: a.dataset.frag || null, preview: a.dataset.preview || null, rel: a.dataset.rel || null, why: a.dataset.previewWhy || null })));
 const sel = (path, frag) => '#content .file-uri-link[data-path="' + path + '"]' + (frag ? '[data-frag="' + frag + '"]' : ":not([data-frag])");
 const card = () => page.evaluate(() => {
   const p = document.getElementById("file-preview-pop"); if (!p || getComputedStyle(p).display === "none") return null;
@@ -156,6 +160,11 @@ for (const theme of ["dark", "light"]) {
   const warmBefore = (await perfNow()).warm; bumpCold(); t.cold = await hoverCard("docs/cold.md", null); t.coldWarmedAhead = (await perfNow()).warm > warmBefore; t.coldHidden = await leave();
   t.outside = await hoverCard(cfg.outside, null); await shot("romp_chat-file-preview-textonly-" + theme); t.outsideHidden = await leave();
   t.secret = await hoverCard("docs/.env", null); t.secretHidden = await leave();
+  // a BARE filename the repo index resolved (tier 3): the preview comes from the resolved absolute path, the same path
+  // the click opens (T364 step A); a notes file whose text is credential-shaped is text with the belt's own words
+  // (a code-span link is keyed by its RESOLVED target, the path the click opens; the token is the span's text)
+  t.bare = await hoverCard("docs/notes/rollup-notes.md", null); t.bareHidden = await leave();
+  t.leaky = await hoverCard("docs/notes/leaky-notes.md", null); t.leakyHidden = await leave();
   out.themes[theme] = t;
 }
 await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(200);
@@ -238,6 +247,12 @@ class ServedFilePreview(unittest.TestCase):
         for d in ("docs", "plots", "src"):
             os.makedirs(os.path.join(cwd, d), exist_ok=True)
         os.makedirs(os.path.join(cls.lab, "outside"), exist_ok=True)
+        subprocess.run(["git", "init", "-q"], cwd=cwd, check=True, capture_output=True)   # the repo index behind a bare filename (tier 3)
+        os.makedirs(os.path.join(cwd, "docs", "notes"), exist_ok=True)
+        Path(cwd, "docs", "notes", "rollup-notes.md").write_text("# Rollup notes\n\nThe rollup gathers every open task into one line per session.\n")
+        # a notes file whose TEXT is credential-shaped (assembled here, never a literal: the scanner reads this repo too):
+        # the content belt refuses its warm, and the card must say so (T364: it blamed the confinement instead)
+        Path(cwd, "docs", "notes", "leaky-notes.md").write_text("# Leaky notes\n\n" + "api" + "_key" + " = " + "Q" * 24 + "\n")
         Path(cwd, "docs", "guide.md").write_text(GUIDE)
         Path(cwd, "docs", ".env").write_text("SETTING=not-a-real-value\n")
         Path(cwd, "docs", "cold.md").write_text(COLD)
@@ -256,7 +271,8 @@ class ServedFilePreview(unittest.TestCase):
         os.makedirs(proj, exist_ok=True)
         reply = ("Read docs/guide.md first, then the rule at docs/guide.md#fold-rules (docs/guide.md#no-such-section is not a section).\n\n"
                  "The plot is at plots/figure.png and the code at src/app.py; the secrets live in docs/.env (and docs/report.md is a link to them); "
-                 "the later note is docs/cold.md; notes outside the project sit at %s." % cls.outside)
+                 "the later note is docs/cold.md; notes outside the project sit at %s. "
+                 "The rollup is written up in `rollup-notes.md` and the leak in `leaky-notes.md`." % cls.outside)   # bare filenames as a session writes them: in code spans
         Path(proj, SID + ".jsonl").write_text(
             json.dumps({"type": "user", "uuid": U_UUID, "parentUuid": None, "timestamp": "2026-09-05T00:00:00.000Z", "sessionId": SID,
                         "message": {"role": "user", "content": "Where do I start with the notes-api docs?"}}) + "\n" +
@@ -359,10 +375,17 @@ class ServedFilePreview(unittest.TestCase):
             code = t["code"]["card"]
             self.assertEqual(code["title"], "app.py"); self.assertIn("fp-code", code["kind"]); self.assertIn("print", code["text"])
             self.assertIn("language-python", code["codeClass"] or "", "highlighted as Python: %r" % code["codeClass"])
-            for name, expect_title in (("outside", "notes.md"), ("secret", ".env")):
+            # the text card says exactly which condition refused (T364: a four-way guess blamed the confinement for everything)
+            for name, expect_title, why in (("outside", "notes.md", "outside the session's folder and your home"), ("secret", ".env", "a secrets-shaped name"),
+                                            ("leaky", "leaky-notes.md", "looks like a secret")):
                 c = t[name]["card"]
                 self.assertEqual(c["title"], expect_title); self.assertIn("fp-text", c["kind"])
-                self.assertIn("shown as text", c["note"] or ""); self.assertEqual(t[name]["requests"], 0, "%s/%s: no request at all" % (theme, name))
+                self.assertEqual(c["note"], "shown as text: " + why, "%s/%s: the kernel's own refusal on the card" % (theme, name))
+                self.assertEqual(t[name]["requests"], 0, "%s/%s: no request at all" % (theme, name))
+            # a bare filename the repo index resolved previews from its resolved path (step A: the local kernel)
+            bare = t["bare"]["card"]
+            self.assertEqual(bare["title"], "rollup-notes.md"); self.assertIn("fp-markdown", bare["kind"]); self.assertIn("one line per session", bare["text"])
+            self.assertGreaterEqual(t["bare"]["requests"], 1, "%s: the slice fetched from the resolved path" % theme)
             self.assertGreaterEqual(t["head"]["requests"], 1, "a text preview is one fetch")
         # the keyboard's route and Escape
         if os.environ.get("PV_LATENCY"):
@@ -371,6 +394,14 @@ class ServedFilePreview(unittest.TestCase):
         self.assertFalse(r["focusEarly"]); self.assertIsNotNone(r["focusCard"]); self.assertEqual(r["focusCard"]["title"], "guide.md")
         self.assertTrue(r["escapeHidden"], "Escape closes the card")
         # "open" lands the viewer on the section
+        # the link attributes: the kind on the previewable links, the why on the refused ones (the next report reads it off the DOM)
+        by = {(l["path"], l["frag"]): l for l in r["links"]}
+        bare_link, leaky_link = by[("docs/notes/rollup-notes.md", None)], by[("docs/notes/leaky-notes.md", None)]
+        self.assertEqual((bare_link["text"], bare_link["preview"]), ("rollup-notes.md", "markdown"), "a bare name the index resolved links to its resolved path and carries the kind: %r" % r["links"])
+        self.assertEqual((leaky_link["text"], leaky_link["preview"], leaky_link["why"]), ("leaky-notes.md", None, "looks like a secret"))
+        self.assertEqual(by[(self.outside, None)]["why"], "outside the session's folder and your home")
+        self.assertEqual(by[("docs/.env", None)]["why"], "a secrets-shaped name")
+        self.assertEqual(by[("docs/report.md", None)]["why"], "a secrets-shaped name", "the symlink named as markdown over the secrets file: the REAL path is judged first, so the reason names the secret: %r" % by[("docs/report.md", None)])
         o = r["opened"]
         self.assertEqual(o["heading"], "Fold Rules"); self.assertTrue(o["inView"], "the heading is in the viewer's view: %r" % o)
         self.assertTrue(o["cardHidden"], "the card closed when the viewer opened")

--- a/tests/test_file_preview_remote_served.py
+++ b/tests/test_file_preview_remote_served.py
@@ -1,0 +1,264 @@
+"""The file preview popover on a REMOTE host's session (T364): a hub kernel's /chat page shows a session that lives on a
+second hermetic kernel checked in as host TESTHOST (the mobile handshake, no ssh; the shape tests/test_composer_placeholder_remote_served.py
+boots). The session's chat mentions a markdown file and an image that exist on the REMOTE kernel's disk only. Before the
+fix the popover fetched the LOCAL origin (/file on the hub) for the remote session's file and got the wrong kernel's
+answer (a 403: the hub knows neither the session nor the path), so a laptop-hosted session's card never rendered; the
+fetch rides the hub's /remote/<host>/file relay with the bare sid now, as the inline images always did (preview.ts).
+
+Synthetic throughout: placeholder sids, TESTHOST, invented file names. Skips where Playwright or its browser is absent.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+import zlib
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SID = "77777777-2222-3333-4444-555555555555"
+COLOR = ("#9cd2ff", "#0c1a2e")
+NOTES = "# Remote notes\n\nThe notes-api retry loop backs off with a jitter of ten percent.\n\n## Later\n\nA second section.\n"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def _png(w=2, h=2, rgb=(60, 120, 200)):
+    def chunk(tag, data):
+        c = struct.pack(">I", len(data)) + tag + data
+        return c + struct.pack(">I", zlib.crc32(tag + data) & 0xffffffff)
+    raw = b"".join(b"\x00" + bytes(rgb) * w for _ in range(h))
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b""))
+
+
+def iso(t):
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(t)) + ".000Z"
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 760 } });
+const fileRequests = [];   // every /file request the page makes, by URL: the route is the claim
+page.on("request", (r) => { if (/\/file\?/.test(r.url())) fileRequests.push(r.url().replace(/^https?:\/\/[^/]+/, "")); });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+// the remote host's tab appears once the hub reports the check-in up and the relay socket is open
+const remoteTab = page.locator("#tabs .tab", { hasText: "TESTHOST" }).first();
+try { await remoteTab.waitFor({ timeout: 45000 }); }
+catch (e) { console.error("no remote tab: " + JSON.stringify(await page.evaluate(() => (document.getElementById("tabs") || {}).textContent))); process.exit(1); }
+await remoteTab.click();
+await page.waitForFunction(() => document.querySelectorAll("#content .file-uri-link").length >= 2, null, { timeout: 30000 });
+await page.mouse.move(900, 720); await page.waitForTimeout(300);
+const out = {};
+out.active = await page.evaluate(() => { const t = document.querySelector("#tabs .tab.active[data-id]"); return t ? t.dataset.id : null; });
+out.links = await page.evaluate(() => Array.from(document.querySelectorAll("#content .file-uri-link")).map((a) => ({ path: a.dataset.path, preview: a.dataset.preview || null, why: a.dataset.previewWhy || null })));
+const sel = (path, frag) => '#content .file-uri-link[data-path="' + path + '"]' + (frag ? '[data-frag="' + frag + '"]' : ":not([data-frag])");
+const card = () => page.evaluate(() => {
+  const p = document.getElementById("file-preview-pop"); if (!p || getComputedStyle(p).display === "none") return null;
+  const body = p.querySelector(".fp-body"); const img = p.querySelector(".fp-img");
+  return { title: (p.querySelector(".fp-title") || {}).textContent ?? null, note: (p.querySelector(".fp-note") || {}).textContent ?? null,
+           kind: body ? body.className : null, text: body ? body.textContent.trim().slice(0, 300) : null,
+           img: img ? { src: img.getAttribute("src"), natural: img.naturalWidth } : null };
+});
+const hoverCard = async (path, frag) => {
+  const n0 = fileRequests.length;
+  await page.hover(sel(path, frag));
+  await page.waitForFunction(() => { const p = document.getElementById("file-preview-pop"); return !!p && getComputedStyle(p).display !== "none" && !!p.querySelector(".fp-body") && !p.querySelector(".rl-in"); }, null, { timeout: 8000 });
+  await page.waitForTimeout(300);
+  const c = await card();
+  await page.mouse.move(900, 720); await page.waitForTimeout(400);
+  return { card: c, requests: fileRequests.slice(n0) };
+};
+out.md = await hoverCard("docs/remote-notes.md", null);
+out.section = await hoverCard("docs/remote-notes.md", "later");
+// the image card: the bytes ride the relay too; the img must have decoded (a natural width)
+await page.hover(sel("plots/remote-figure.png", null));
+await page.waitForFunction(() => { const i = document.querySelector("#file-preview-pop .fp-img"); return !!i && i.naturalWidth > 0; }, null, { timeout: 8000 }).catch(() => {});
+out.img = { card: await card(), requests: fileRequests.slice(-3) };
+if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-file-preview-remote.png" }); }
+fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+def _kernel(lab, name, port, token, records=None, sid=None, files=None):
+    """Boot one hermetic kernel: its own state root, dist, and (optionally) one session with a transcript and files under its cwd."""
+    state = os.path.join(lab, name, "xdg", "romp")
+    claude = os.path.join(lab, name, "claude")
+    cwd = os.path.join(lab, name, "proj")
+    for d in ("names", "sdk", "states"):
+        os.makedirs(os.path.join(state, d), exist_ok=True)
+    os.makedirs(cwd, exist_ok=True)
+    Path(state, "session-hosts").write_text("off\n")   # a lab root writes its own hosts off (the conftest rule)
+    Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+    for rel, data in (files or {}).items():
+        p = Path(cwd, rel); p.parent.mkdir(parents=True, exist_ok=True)
+        (p.write_bytes if isinstance(data, bytes) else p.write_text)(data)
+    if records is not None:
+        Path(state, "names", sid).write_text("api\t%s\t%s\t%s\n" % (cwd, COLOR[0], COLOR[1]))
+        Path(state, "sdk", sid + ".json").write_text(json.dumps(
+            {"sid": sid, "name": "api", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": sid, "alive": True, "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in records))
+    env = _lab.kernel_env(os.path.join(lab, name), claude, os.path.join(lab, "dist"), port, token,
+                          ROMP_HOST_NAME=name.upper())
+    log = os.path.join(lab, name + "-kernel.log")
+    proc = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(log, "w"), stderr=subprocess.STDOUT, env=env)
+    for _ in range(120):
+        try:
+            urllib.request.urlopen("http://127.0.0.1:%d/healthz" % port, timeout=1)
+            return proc, log
+        except Exception:
+            time.sleep(0.5)
+    proc.kill(); proc.wait()
+    raise unittest.SkipTest("hermetic kernel %s never served /healthz here" % name)
+
+
+class ServedRemoteFilePreview(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:          # a skip OR a failure: never leave a kernel or a lab behind
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served lab needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served lab needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="file-preview-remote-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        copy_dist(os.path.join(EXT, "dist"), os.path.join(cls.lab, "dist"))
+        cls.procs = []
+        t0 = int(time.time()) - 900
+        recs = [
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": SID,
+             "message": {"role": "user", "content": "where are the retry notes?"}},
+            {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": "The notes are in docs/remote-notes.md (the later part at docs/remote-notes.md#later) and the plot at plots/remote-figure.png."}]}},
+        ]
+        # the REMOTE kernel owns the session and its files; the HUB has neither and shows the session through the relay
+        cls.rport, cls.rtoken = _free_port(), "testtok-remote-fp"
+        cls.hport, cls.htoken = _free_port(), "testtok-hub-fp"
+        try:
+            rp, cls.rlog = _kernel(cls.lab, "testhost", cls.rport, cls.rtoken, records=recs, sid=SID,
+                                   files={"docs/remote-notes.md": NOTES, "plots/remote-figure.png": _png()})
+            cls.procs.append(rp)
+            hp, cls.hlog = _kernel(cls.lab, "hub", cls.hport, cls.htoken)
+            cls.procs.append(hp)
+        except unittest.SkipTest:
+            cls.tearDownClass()
+            raise
+        body = json.dumps({"host": "TESTHOST", "kernelPort": cls.rport, "busPort": _free_port(), "token": cls.rtoken}).encode()
+        req = urllib.request.Request("http://127.0.0.1:%d/checkin?token=%s" % (cls.hport, cls.htoken), data=body,
+                                     headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            ans = json.loads(resp.read().decode())
+        if not ans.get("ok"):
+            cls.tearDownClass()
+            raise unittest.SkipTest("the hub refused the check-in: %r" % ans)
+        for _ in range(60):   # the hub's supervisor probes the peer and reports it up; the browser dials only then
+            try:
+                with urllib.request.urlopen("http://127.0.0.1:%d/tunnels?token=%s" % (cls.hport, cls.htoken), timeout=3) as r2:
+                    rows = json.loads(r2.read().decode()).get("tunnels") or []
+            except Exception:
+                rows = []
+            row = next((t for t in rows if t.get("host") == "TESTHOST"), None)
+            if row and row.get("status") == "up" and row.get("hasToken"):
+                break
+            time.sleep(0.5)
+        else:
+            cls.tearDownClass()
+            raise unittest.SkipTest("the hub never reported the checked-in peer up: %r" % (rows,))
+
+    @classmethod
+    def tearDownClass(cls):
+        for p in getattr(cls, "procs", []):
+            try:
+                p.kill(); p.wait()
+            except Exception:
+                pass
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def test_a_remote_sessions_links_preview_through_the_hosts_relay(self):
+        cfg = os.path.join(self.lab, "cfg.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.hport, self.htoken), "shots": os.environ.get("PV_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:]
+                         + "\nhub:\n" + open(self.hlog).read()[-1500:] + "\nremote:\n" + open(self.rlog).read()[-800:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        r = json.loads(line[len("RESULT:"):])
+        self.assertEqual(r["active"], "TESTHOST:" + SID, "the remote session's tab is active, under its host prefix")
+        # the REMOTE kernel built the events and judged its own files: every link carries a preview kind
+        by = {l["path"]: l for l in r["links"]}
+        self.assertEqual(by["docs/remote-notes.md"]["preview"], "markdown", "judged on the remote's disk: %r" % r["links"])
+        self.assertEqual(by["plots/remote-figure.png"]["preview"], "image")
+        # the markdown card rendered from the relay, never from the hub's own /file
+        md = r["md"]
+        self.assertIn("fp-markdown", md["card"]["kind"] or "", "the remote file rendered: %r" % md)
+        self.assertIn("jitter of ten percent", md["card"]["text"] or "")
+        self.assertTrue(md["requests"], "the hover fetched the slice")
+        for u in md["requests"]:
+            self.assertTrue(u.startswith("/remote/TESTHOST/file?"), "the fetch rides the host relay, not the local origin: %r" % md["requests"])
+            self.assertIn("sid=" + SID, u, "…with the bare sid the remote kernel knows (no host prefix): %r" % u)
+        sec = r["section"]
+        self.assertIn("A second section", sec["card"]["text"] or "", "the section road rides the relay too: %r" % sec)
+        # the image card: the bytes came through the relay and decoded
+        img = r["img"]["card"]
+        self.assertIsNotNone(img and img["img"], "the image card: %r" % r["img"])
+        self.assertTrue(img["img"]["src"].startswith("/remote/TESTHOST/file?"), "the img src is the relay's: %r" % img["img"])
+        self.assertGreater(img["img"]["natural"], 0, "the image decoded (the relay served the bytes): %r" % img["img"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_file_slice.py
+++ b/tests/test_file_slice.py
@@ -204,7 +204,7 @@ class Allowed(unittest.TestCase):
         self.assertEqual(km._slice_allowed(link4, SID), (None, "a link dressed as another kind"), "a code file behind a markdown name")
         out = self.w("outside/o.md"); link5 = os.path.join(self.cwd, "docs", "escape.md"); os.symlink(out, link5)
         self.assertEqual(km._slice_allowed(link5, SID), (None, "outside the session's folder and your home"), "a symlink out of the roots")
-        self.assertEqual(km._path_previews({"docs/report.md": "docs/report.md", "docs/alias.md": "docs/alias.md"}, SID), {"docs/alias.md": "markdown"},
+        self.assertEqual(km._path_preview_verdicts({"docs/report.md": "docs/report.md", "docs/alias.md": "docs/alias.md"}, SID)[0], {"docs/alias.md": "markdown"},
                          "the map omits the dressed link; only the honest one is warmed")
         self.assertEqual([k[0] for k in km._SLICE_CACHE], [os.path.realpath(plain)], "the cache holds the real path of the honest link, nothing of the secret")
 
@@ -303,13 +303,13 @@ class Allowed(unittest.TestCase):
         before = dict(km._PERF_STATS.snapshot()["fileSlice"])
         secretish = self.w("proj/docs/leak.md", "# L\n\n" + "api" + "_key" + " = " + "Z" * 24 + "\n")
         links["docs/leak.md"] = "docs/leak.md"
-        pv = km._path_previews(links, SID)
+        pv = km._path_preview_verdicts(links, SID)[0]
         self.assertEqual(pv, {"docs/g.md": "markdown", "src.py": "code", "p.png": "image"},
                          "the outside path and the zip are absent (text-only, no request), and so is the markdown whose text looks like a secret (the belt at warm time)")
         self.assertEqual([k[0] for k in km._SLICE_CACHE], [g], "the honest markdown was warmed; the secret-shaped one never entered the cache; code waits for a hover")
         after = km._PERF_STATS.snapshot()["fileSlice"]
         self.assertEqual(after["warm"], before["warm"] + 1)
-        km._path_previews(links, SID)
+        km._path_preview_verdicts(links, SID)
         self.assertEqual(km._PERF_STATS.snapshot()["fileSlice"]["warm"], before["warm"] + 1, "already warm: no second read")
 
 
@@ -325,7 +325,6 @@ class Allowed(unittest.TestCase):
         self.assertEqual(kinds, {"docs/g.md": "markdown"})
         self.assertEqual(whys, {"../outside/o.md": "outside the session's folder and your home", "notes.zip": "not a file",
                                 "docs/leak.md": "looks like a secret", "gone.md": "not a file"}, "one why per link that does not preview, the kernel's own words")
-        self.assertEqual(km._path_previews(links, SID), kinds, "the kinds alone, for the callers that need no reasons")
         self.assertEqual(km._slice_warm_why(g), ""); self.assertEqual(km._slice_warm_why(leak), "looks like a secret")
         self.assertEqual(km._slice_warm_why(os.path.join(self.cwd, "docs", "nonesuch.md")), "not a file")
 

--- a/tests/test_file_slice.py
+++ b/tests/test_file_slice.py
@@ -313,6 +313,23 @@ class Allowed(unittest.TestCase):
         self.assertEqual(km._PERF_STATS.snapshot()["fileSlice"]["warm"], before["warm"] + 1, "already warm: no second read")
 
 
+    def test_the_verdicts_carry_the_exact_refusal_for_every_link_that_does_not_preview(self):
+        # T364 (the laptop report): the text card said "outside the session's folder and your home, or not a kind the
+        # preview shows" whatever the reason was; the kernel now ships the exact condition beside the kinds, the
+        # markdown warm's content-belt refusal included (the likeliest reason a notes file the repo index resolved shows
+        # as text: a credential-shaped line inside it)
+        g = self.w("proj/docs/g.md", "# G\n"); o = self.w("outside/o.md")
+        leak = self.w("proj/docs/leak.md", "# L\n\n" + "api" + "_key" + " = " + "Z" * 24 + "\n")
+        links = {"docs/g.md": "docs/g.md", "../outside/o.md": o, "notes.zip": "notes.zip", "docs/leak.md": "docs/leak.md", "gone.md": "gone.md"}
+        kinds, whys = km._path_preview_verdicts(links, SID)
+        self.assertEqual(kinds, {"docs/g.md": "markdown"})
+        self.assertEqual(whys, {"../outside/o.md": "outside the session's folder and your home", "notes.zip": "not a file",
+                                "docs/leak.md": "looks like a secret", "gone.md": "not a file"}, "one why per link that does not preview, the kernel's own words")
+        self.assertEqual(km._path_previews(links, SID), kinds, "the kinds alone, for the callers that need no reasons")
+        self.assertEqual(km._slice_warm_why(g), ""); self.assertEqual(km._slice_warm_why(leak), "looks like a secret")
+        self.assertEqual(km._slice_warm_why(os.path.join(self.cwd, "docs", "nonesuch.md")), "not a file")
+
+
 class Perf(unittest.TestCase):
     def test_the_slice_counters_ride_the_perf_snapshot(self):
         before = dict(km._PERF_STATS.snapshot()["fileSlice"])

--- a/tests/test_path_links.py
+++ b/tests/test_path_links.py
@@ -178,6 +178,28 @@ class RepoListEdges(_Repo):
         self.assertEqual(sorted(idx["dup.py"]), ["a/dup.py", "b/dup.py"])
         self.assertEqual(idx["render.js"], ["ui/render.js"])
 
+    def test_a_stand_down_is_said_once_per_cwd_on_stderr(self):
+        # T364: the index returned None silently on any git failure or a runaway listing, so a bare filename that stayed
+        # plain text left no trace in the kernel log; one stderr line per cwd names the reason
+        import contextlib
+        import io
+        km._REPO_INDEX_STOOD_DOWN.clear()
+        saved = km._REPO_LIST_MAX
+        err = io.StringIO()
+        try:
+            km._REPO_LIST_MAX = 1
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._repo_file_index(str(self.cwd)))
+                self.assertIsNone(km._repo_file_index(str(self.cwd)))
+        finally:
+            km._REPO_LIST_MAX = saved
+        lines = [l for l in err.getvalue().splitlines() if "stood down" in l]
+        self.assertEqual(len(lines), 1, "said once per cwd: %r" % err.getvalue())
+        self.assertIn("past the 1-file ceiling", lines[0]); self.assertIn("bare filenames in this session's messages stay plain text", lines[0])
+        with tempfile.TemporaryDirectory() as plain, contextlib.redirect_stderr(err):
+            self.assertIsNone(km._repo_file_index(plain))
+        self.assertIn("git ls-files exited", err.getvalue(), "a cwd that is no repo says git's own exit: %r" % err.getvalue())
+
     def test_the_index_is_built_at_most_once_per_build_pass(self):
         calls = []
         saved = km._repo_file_index

--- a/tests/test_path_links.py
+++ b/tests/test_path_links.py
@@ -194,8 +194,17 @@ class RepoListEdges(_Repo):
         finally:
             km._REPO_LIST_MAX = saved
         lines = [l for l in err.getvalue().splitlines() if "stood down" in l]
-        self.assertEqual(len(lines), 1, "said once per cwd: %r" % err.getvalue())
+        self.assertEqual(len(lines), 1, "said once per cwd and reason: %r" % err.getvalue())
         self.assertIn("past the 1-file ceiling", lines[0]); self.assertIn("bare filenames in this session's messages stay plain text", lines[0])
+        # a CHANGED reason for the same cwd is a new line (the ceiling moved: the same cwd stands down for another reason)
+        try:
+            km._REPO_LIST_MAX = 2
+            with contextlib.redirect_stderr(err):
+                self.assertIsNone(km._repo_file_index(str(self.cwd)))
+        finally:
+            km._REPO_LIST_MAX = saved
+        lines = [l for l in err.getvalue().splitlines() if "stood down" in l]
+        self.assertEqual(len(lines), 2, "a changed reason is said: %r" % err.getvalue()); self.assertIn("past the 2-file ceiling", lines[1])
         with tempfile.TemporaryDirectory() as plain, contextlib.redirect_stderr(err):
             self.assertIsNone(km._repo_file_index(plain))
         self.assertIn("git ls-files exited", err.getvalue(), "a cwd that is no repo says git's own exit: %r" % err.getvalue())

--- a/ui/webview/chat-md.test.ts
+++ b/ui/webview/chat-md.test.ts
@@ -99,7 +99,7 @@ test("userMd() renders through the breaks:true instance and the SAME sanitizer a
 
 test("the user bubble renders the user's OWN words with userMd, harness notes and everything else with md", () => {
   // the landed bubble: kind "user" → userMd; the harness-injected note sharing the branch → md
-  assert.match(RENDER, /bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);/);
+  assert.match(RENDER, /bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);/);
   assert.doesNotMatch(RENDER, /bubble\.innerHTML = md\(ev\.md\);/, "no user bubble left on the soft-wrap grammar");
   // the queued / optimistic bubble is the same message a beat earlier — same renderer, so the swap to the
   // landed bubble changes nothing on screen

--- a/ui/webview/chat-pin-history.test.ts
+++ b/ui/webview/chat-pin-history.test.ts
@@ -16,9 +16,9 @@ const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 
 test("pathPins ride the chat events as a sibling map and thread into every linkify pass", () => {
-  assert.match(RENDER, /pathLinks\?: Record<string, string>; pathPins\?: Record<string, string>; pathPreview\?: Record<string, string> \}\n  \| \{ kind: "assistant";/);
-  assert.match(RENDER, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>\): void/);
-  const uses = RENDER.match(/linkifyFileUris\((?:body|bubble|full), [^)]*ev\.pathPins, ev\.pathPreview\)/g) || [];
+  assert.match(RENDER, /pathLinks\?: Record<string, string>; pathPins\?: Record<string, string>; pathPreview\?: Record<string, string>; pathPreviewWhy\?: Record<string, string> \}\n  \| \{ kind: "assistant";/);
+  assert.match(RENDER, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>,\s*\n\s*pathPreviewWhy\?: Record<string, string>\): void/);
+  const uses = RENDER.match(/linkifyFileUris\((?:body|bubble|full), [^)]*ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\)/g) || [];
   assert.equal(uses.length, 3, "all three chat bodies thread the pins");
 });
 

--- a/ui/webview/chat-space-paths.test.ts
+++ b/ui/webview/chat-space-paths.test.ts
@@ -35,7 +35,7 @@ test("the kernel verifies with the filesystem, resolved exactly like a click", (
 });
 
 test("linkifyFileUris whole-links a verified span's entire inline-code content", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>,\s*\n\s*pathPreviewWhy\?: Record<string, string>\): void/);
   // the pass targets inline <code> only, skips anything already linked or fenced
   assert.match(RENDER, /for \(const code of Array\.from\(root\.querySelectorAll\("code"\)\)\) \{\s*\n\s*if \(code\.closest\("a, \.file-uri-link, pre"\)\) continue;/);
   // exact-match against the kernel's verified set, then the whole content becomes one open link
@@ -54,7 +54,7 @@ test("the whole-span pass runs BEFORE the token walk, so the new link is skipped
 });
 
 test("every message render threads its event's spacePaths through", () => {
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);/);   // user bubble
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);/);     // expanded nudge body
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);/);    // assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);/);   // user bubble
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);/);     // expanded nudge body
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);/);    // assistant reply
 });

--- a/ui/webview/composer-mention-pane.test.ts
+++ b/ui/webview/composer-mention-pane.test.ts
@@ -819,7 +819,7 @@ test("the composer's keydown: the slash menu, then the card, then an IME's commi
 
 test("renderTabs opens with the whole-roster hook, ahead of its guards; the user's bubble is marked after its path links, and so is the echo of a send", () => {
   assert.match(RENDER, /function renderTabs\(\) \{\n  mentionRosterChanged\(\);/);
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);[^\n]*\n\s*linkTerms\(bubble\);[^\n]*\n\s*if \(kind === "user"\) markMentions\(bubble\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);[^\n]*\n\s*linkTerms\(bubble\);[^\n]*\n\s*if \(kind === "user"\) markMentions\(bubble\);/);
   // the echo keeps the pinned renderer statement as it stands (chat-md and queued-indicator hold it verbatim); the chip is the next statement
   assert.match(RENDER, /if \(!t\.romp && !isCmd\) bubble\.innerHTML = userMd\(t\.md\);[^\n]*\n\s*if \(!t\.romp && !isCmd\) markMentions\(bubble\);/);
 });

--- a/ui/webview/file-preview-pop.test.ts
+++ b/ui/webview/file-preview-pop.test.ts
@@ -48,14 +48,14 @@ test("the kernel's verdict rides the link as data-preview; a link without it get
   assert.match(RENDER, /pathPins\?: Record<string, string>; pathPreview\?: Record<string, string>; pathPreviewWhy\?: Record<string, string> \}/, "the event carries pathPreview and its whys beside pathLinks and pathPins");
   const show = RENDER.slice(RENDER.indexOf("function showFilePreview("), RENDER.indexOf("function linkifyFileUris("));
   assert.match(show, /const kind = a\.dataset\.preview \|\| null;/);
-  assert.match(show, /if \(!kind\) \{[\s\S]*?renderFilePreview\(p, textOnlyContent\(path, anchor, "shown as text: " \+ \(a\.dataset\.previewWhy \|\| "no preview verdict from the kernel for this link"\)\), sid\);\s*\n\s*stamp\(null\);\s*\n\s*return;\s*\n\s*\}/, "no fetch for a link the kernel did not allow");
+  assert.match(show, /if \(!kind\) \{[\s\S]*?const why = \/\^file:\/i\.test\(open\) \? "file links are opened, not previewed" : \(a\.dataset\.previewWhy \|\| "no preview verdict from the kernel for this link"\);\s*\n\s*renderFilePreview\(p, textOnlyContent\(path, anchor, "shown as text: " \+ why\), sid\);\s*\n\s*stamp\(null\);\s*\n\s*return;\s*\n\s*\}/, "no fetch for a link the kernel did not allow; a bare file link says it is opened, not previewed, and a path link says the kernel's why");
   assert.match(show, /if \(kind === "image" \|\| kind === "pdf"\) \{ renderFilePreview\(p, contentFor\(path, anchor, kind, sid, null\), sid\); stamp\(null\); return; \}/, "media needs no slice: the bytes route");
   assert.match(show, /p\.replaceChildren\(rompLoaderInner\("reading…", \{ wordmark: false \}\)\);/, "the loader first");
   assert.match(show, /fetch\(sliceUrl\(path, sid, anchor\), \{ credentials: "same-origin" \}\)/);
   assert.match(show, /if \(seq !== filePreviewSeq\) return;/, "a stale answer never fills a card that moved on");
   // the kernel's half: the preview map shipped beside pathLinks on both message paths, warming markdown
   assert.equal((KERNEL.match(/ev\["pathPreview"\] = pv/g) || []).length, 2, "both the assistant and the user message build ship it");
-  assert.match(KERNEL, /def _path_previews\(links, sid\):/);
+  assert.match(KERNEL, /def _path_preview_verdicts\(links, sid\):/);
   assert.match(RENDER, /p\.dataset\.renderMs = \(performance\.now\(\) - t0\)\.toFixed\(1\)/, "the card stamps dwell end to rendered content (the acceptance is latency)");
   assert.match(RENDER, /p\.dataset\.sliceHit = hit \? "1" : "0"/, "…and whether the slice was cached");
   assert.match(KERNEL, /hit=hit\)/, "the slice answer says whether it came from the cache");

--- a/ui/webview/file-preview-pop.test.ts
+++ b/ui/webview/file-preview-pop.test.ts
@@ -36,19 +36,19 @@ test("every path link is armed: a hover or a focus starts the dwell, leaving or 
 
 test("the kernel's verdict rides the link as data-preview; a link without it gets the text-only card and no request", () => {
   const lf = RENDER.slice(RENDER.indexOf("function linkifyFileUris("), RENDER.indexOf("function openPath(") > 0 ? RENDER.length : RENDER.length);
-  assert.match(lf, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>\): void \{/, "the pass takes the map");
+  assert.match(lf, /pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>,\s*\n\s*pathPreviewWhy\?: Record<string, string>\): void \{/, "the pass takes the map");
   assert.match(lf, /const k = previewKindOf\(tok, pathPreview\) \|\| previewKindOf\(open, pathPreview\);\s*\n\s*if \(k\) link\.dataset\.preview = k; else delete link\.dataset\.preview;/);
   assert.match(lf, /armPreview\(link, tok, tok\);/, "the kernel-verified spaced span");
   assert.match(lf, /bindPathLink\(link\);\s*\n\s*armPreview\(link, link\.textContent \|\| "", open\);/, "every hit of the token walk");
-  for (const call of ["linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview);",
-                      "linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview);",
-                      "linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview);"]) {
+  for (const call of ["linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview, ev.pathPreviewWhy);",
+                      "linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview, ev.pathPreviewWhy);",
+                      "linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview, ev.pathPreviewWhy);"]) {
     assert.ok(RENDER.includes(call), "the map is threaded: " + call);
   }
-  assert.match(RENDER, /pathPins\?: Record<string, string>; pathPreview\?: Record<string, string> \}/, "the event carries pathPreview beside pathLinks and pathPins");
+  assert.match(RENDER, /pathPins\?: Record<string, string>; pathPreview\?: Record<string, string>; pathPreviewWhy\?: Record<string, string> \}/, "the event carries pathPreview and its whys beside pathLinks and pathPins");
   const show = RENDER.slice(RENDER.indexOf("function showFilePreview("), RENDER.indexOf("function linkifyFileUris("));
   assert.match(show, /const kind = a\.dataset\.preview \|\| null;/);
-  assert.match(show, /if \(!kind\) \{[^}]*renderFilePreview\(p, textOnlyContent\(path, anchor, "shown as text: outside the session's folder and your home, or not a kind the preview shows"\), sid\);\s*\n\s*stamp\(null\);\s*\n\s*return;\s*\n\s*\}/, "no fetch for a link the kernel did not allow");
+  assert.match(show, /if \(!kind\) \{[\s\S]*?renderFilePreview\(p, textOnlyContent\(path, anchor, "shown as text: " \+ \(a\.dataset\.previewWhy \|\| "no preview verdict from the kernel for this link"\)\), sid\);\s*\n\s*stamp\(null\);\s*\n\s*return;\s*\n\s*\}/, "no fetch for a link the kernel did not allow");
   assert.match(show, /if \(kind === "image" \|\| kind === "pdf"\) \{ renderFilePreview\(p, contentFor\(path, anchor, kind, sid, null\), sid\); stamp\(null\); return; \}/, "media needs no slice: the bytes route");
   assert.match(show, /p\.replaceChildren\(rompLoaderInner\("reading…", \{ wordmark: false \}\)\);/, "the loader first");
   assert.match(show, /fetch\(sliceUrl\(path, sid, anchor\), \{ credentials: "same-origin" \}\)/);
@@ -59,7 +59,8 @@ test("the kernel's verdict rides the link as data-preview; a link without it get
   assert.match(RENDER, /p\.dataset\.renderMs = \(performance\.now\(\) - t0\)\.toFixed\(1\)/, "the card stamps dwell end to rendered content (the acceptance is latency)");
   assert.match(RENDER, /p\.dataset\.sliceHit = hit \? "1" : "0"/, "…and whether the slice was cached");
   assert.match(KERNEL, /hit=hit\)/, "the slice answer says whether it came from the cache");
-  assert.match(KERNEL, /if kind and \(kind != "markdown" or _slice_warm\(fp\)\):/, "the pusher's path warms the markdown it links, and a markdown the warm refuses (the content belt) ships without a kind");
+  assert.match(KERNEL, /if kind and kind == "markdown":\s*\n\s*why = _slice_warm_why\(fp\)\s*\n\s*if why:\s*\n\s*kind = None/, "the pusher's path warms the markdown it links, and a markdown the warm refuses (the content belt) ships without a kind and WITH the belt's why (T364)");
+  assert.match(KERNEL, /whys\[tok\] = why or "not previewed"/, "every link that does not preview carries a reason");
 });
 
 test("the card: the comment popover's size and surface, transient; closes on Escape, a scroll, a click elsewhere, a strip rebuild", () => {
@@ -103,4 +104,14 @@ test("open carries the section anchor to the viewer through both routes, and the
   assert.match(FILES, /openFileView\(path, sid, \{ frag \}\)/);
   assert.match(FILES, /typeof m\.frag === "string" \? m\.frag : null\);/);
   assert.match(KERNEL, /postMessage\(\{romp:'viewFile',path:m\.path,sid:m\.sid,identity:m\.identity\|\|null,frag:m\.frag\|\|null\},'\*'\)/, "the shell's relay forwards it");
+});
+
+test("the kernel's exact refusal rides the link as data-preview-why and the text card says it (T364)", () => {
+  // the four-way guess ("outside the session's folder and your home, or not a kind the preview shows") went: the card
+  // names the condition the kernel refused on, or says the kernel gave no verdict for this link at all
+  const lf = RENDER.slice(RENDER.indexOf("function linkifyFileUris("), RENDER.indexOf("\n}\n", RENDER.indexOf("function linkifyFileUris(")));
+  assert.match(lf, /pathPreview\?: Record<string, string>,\s*\n\s*pathPreviewWhy\?: Record<string, string>\): void \{/, "the why map is threaded beside the kinds");
+  assert.match(lf, /const w = !k && pathPreviewWhy \? \(pathPreviewWhy\[tok\] \|\| pathPreviewWhy\[open\] \|\| ""\) : "";\s*\n\s*if \(w\) link\.dataset\.previewWhy = w; else delete link\.dataset\.previewWhy;/);
+  assert.equal((RENDER.match(/ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\)/g) || []).length, 3, "the three linkify calls hand the why through");
+  assert.doesNotMatch(RENDER, /outside the session's folder and your home, or not a kind the preview shows/, "no guessed sentence is left");
 });

--- a/ui/webview/file-preview.test.ts
+++ b/ui/webview/file-preview.test.ts
@@ -2,7 +2,7 @@
 // what a link may preview, the routes' URLs, the one content shape per kind, and the hover's timing run on fake timers.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
-import { PREVIEW_DWELL_MS, PREVIEW_GRACE_MS, HoverIntent, parsePreviewLink, previewKindOf, sliceUrl, fileUrl, langOf, baseName,
+import { PREVIEW_DWELL_MS, PREVIEW_GRACE_MS, HoverIntent, parsePreviewLink, previewKindOf, sliceUrl, fileUrl, previewRoute, langOf, baseName,
          contentFor, textOnlyContent, remoteLoad, stripRemoteLoads } from "./file-preview";
 
 test("parsePreviewLink: path#slug splits on a slug, a # that is not a slug stays in the path", () => {
@@ -166,3 +166,19 @@ test("stripRemoteLoads on the inert tree: an img becomes its alt text, every oth
     "the remote img is its alt text (empty alt: nothing), the poster'd video and its source are gone, the remote track is gone from the local video, the svg keeps its local image, a link is not a load");
 });
 
+
+test("a remote session's preview fetches ride the host relay with the bare sid, as the inline images do (T364)", () => {
+  // the popover asked the LOCAL origin for a remote session's file and got the wrong kernel's answer; the route is the
+  // one preview.ts builds for an inline image: /remote/<host>/file with the sid the remote kernel knows
+  const rsid = "TESTHOST:11111111-2222-3333-4444-555555555555";
+  assert.deepEqual(previewRoute(rsid), { base: "/remote/TESTHOST/file", sid: "11111111-2222-3333-4444-555555555555" });
+  assert.deepEqual(previewRoute("11111111-2222-3333-4444-555555555555"), { base: "/file", sid: "11111111-2222-3333-4444-555555555555" });
+  assert.deepEqual(previewRoute(null), { base: "/file", sid: "" });
+  assert.equal(sliceUrl("docs/a.md", rsid, "top"), "/remote/TESTHOST/file?path=docs%2Fa.md&slice=1&sid=11111111-2222-3333-4444-555555555555&anchor=top");
+  assert.equal(fileUrl("plots/a.png", rsid), "/remote/TESTHOST/file?path=plots%2Fa.png&sid=11111111-2222-3333-4444-555555555555");
+  assert.equal(fileUrl("plots/a.png", "s"), "/file?path=plots%2Fa.png&sid=s", "a local session: the local route, unchanged");
+  const fs = require("node:fs"), path = require("node:path");
+  const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+  const FP = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "file-preview.ts"), "utf8");
+  for (const src of [PREVIEW, FP]) assert.match(src, /"\/remote\/" \+ encodeURIComponent\(host\) \+ "\/file" : "\/file"/, "the two builders share the relay's shape");
+});

--- a/ui/webview/file-preview.ts
+++ b/ui/webview/file-preview.ts
@@ -6,6 +6,8 @@
 // lookup included), and the hover's timing (a dwell before it opens, a grace to cross into the card). render.ts owns
 // the card itself: the element, the fetch, the rendering per kind, the placement.
 
+import { hostOf, bareId } from "./host-prefix";   // pure: a remote session's sid carries its host (T364)
+
 export const PREVIEW_DWELL_MS = 350;   // a hover shorter than this is a pass-through, not a question
 export const PREVIEW_GRACE_MS = 150;   // leaving the link toward the card must not close it on the way
 
@@ -41,16 +43,27 @@ export function previewKindOf(token: string, pathPreview?: Record<string, string
   return k && /^(markdown|image|code|pdf)$/.test(k) ? k : null;
 }
 
+/** The route a preview fetch takes and the sid it carries: a session on a REMOTE host (a host-prefixed sid,
+ *  host-prefix.ts) lives on that machine's disk, so the fetch rides this kernel's /remote/<host>/file relay with the
+ *  bare sid the remote kernel knows, exactly as the inline images do (preview.ts fileUrl); a local session's fetch is
+ *  the local /file. T364: the popover asked the LOCAL origin for a remote session's file and got the wrong kernel's
+ *  answer (a 404 or a foreign session's verdict), so a laptop-hosted session's card never rendered. */
+export function previewRoute(sid: string | null): { base: string; sid: string } {
+  const host = sid ? hostOf(sid) : "";
+  return { base: host ? "/remote/" + encodeURIComponent(host) + "/file" : "/file", sid: sid ? bareId(sid) : "" };
+}
 /** GET /file?slice=1: the one fetch behind a text preview (the kernel slices the file's cached text). */
 export function sliceUrl(path: string, sid: string | null, anchor: string): string {
-  let u = "/file?path=" + encodeURIComponent(path) + "&slice=1";
-  if (sid) u += "&sid=" + encodeURIComponent(sid);
+  const r = previewRoute(sid);
+  let u = r.base + "?path=" + encodeURIComponent(path) + "&slice=1";
+  if (r.sid) u += "&sid=" + encodeURIComponent(r.sid);
   if (anchor) u += "&anchor=" + encodeURIComponent(anchor);
   return u;
 }
 /** GET /file: the bytes behind an image or a PDF preview (the route the figures already use). */
 export function fileUrl(path: string, sid: string | null): string {
-  return "/file?path=" + encodeURIComponent(path) + (sid ? "&sid=" + encodeURIComponent(sid) : "");
+  const r = previewRoute(sid);
+  return r.base + "?path=" + encodeURIComponent(path) + (r.sid ? "&sid=" + encodeURIComponent(r.sid) : "");
 }
 
 const LANG_BY_EXT: Record<string, string> = {

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -13,7 +13,7 @@ const LINKS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview",
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 
 test("a bare file:// URL becomes a clickable .file-uri-link that opens the file in the host app", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>,\s*\n\s*pathPreviewWhy\?: Record<string, string>\): void/);
   assert.match(LINKS, /el\("span", "file-uri-link"\)/);
   // clicking is ROUTED by openPath, never a blocked window.open(file://) — a file:// URI is absolute,
   // so it takes the shared openPathLink's no-session-id branch (no data-rel on the span; render.ts's
@@ -26,9 +26,9 @@ test("a bare file:// URL becomes a clickable .file-uri-link that opens the file 
 });
 
 test("linkify runs on chat message bodies (assistant reply + user bubble + nudge full text) and nowhere else — never tool summaries", () => {
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\)/);   // the assistant reply
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\)/); // your own bubble (in-bubble images don't re-thumb)
-  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\)/);   // a compact nudge's expanded full text (2026-07-17)
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\)/);   // the assistant reply
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\)/); // your own bubble (in-bubble images don't re-thumb)
+  assert.match(RENDER, /linkifyFileUris\(full, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\)/);   // a compact nudge's expanded full text (2026-07-17)
   // exactly the definition + those three applications — so tool-use reports/summaries stay untouched
   const uses = RENDER.match(/linkifyFileUris\(/g) || [];
   assert.equal(uses.length, 4, "linkifyFileUris is defined once and applied to exactly the three chat bodies");

--- a/ui/webview/glossary-links.test.ts
+++ b/ui/webview/glossary-links.test.ts
@@ -72,7 +72,7 @@ test("the term card fills the popover's contract from the index, no fetch; a ret
 test("the wiring: the frame per session, the matcher per index, links at the two chat grammars and the mail body, the card on the popover, the click to the viewer", () => {
   assert.match(RENDER, /else if \(m\.type === "glossary" && typeof m\.id === "string"\) \{[\s\S]{0,300}?glossaries\.set\(m\.id, m as GlossaryIndex\);\s*\n\s*relinkTerms\(m\.id\);/);
   assert.equal((RENDER.match(/\blinkTerms\((full|bubble|body)\)/g) || []).length, 6, "the nudge, continue and tagged-template bubbles' full text, the user bubble, the assistant body, the mail body (the review's low: the two bubbles never linked)");
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);[^\n]*\n\s*linkTerms\(body\);/, "after the path links, so a path token is never split by a term");
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);[^\n]*\n\s*linkTerms\(body\);/, "after the path links, so a path token is never split by a term");
   assert.match(RENDER, /s\.dataset\.path = m\.index\.path; s\.dataset\.frag = e\.slug;[\s\S]{0,200}?armFilePreview\(s\);/, "a term span is a path link's counterpart: the same hover road");
   assert.match(RENDER, /if \(a\.dataset\.term\) \{[\s\S]{0,600}?renderFilePreview\(p, termContent\(e, ix\), a\.dataset\.gsid \|\| activeId\);/, "the card from the index, no fetch");
   assert.match(RENDER, /closest\?\.\("span\.term-link"\)[\s\S]{0,300}?openPath\(s\.dataset\.path \|\| "", s\.dataset\.gsid \|\| activeId, e, s\.dataset\.frag \|\| null\);/, "a click opens the glossary at the heading");

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -2416,9 +2416,11 @@ function showFilePreview(a: HTMLElement): void {
     if (hit !== null) p.dataset.sliceHit = hit ? "1" : "0";
   };
   if (!kind) {                                   // the kernel allowed no preview: text and the way to the file, no request
-    // the card says exactly which condition refused (the kernel's why on the link, T364); a link with no verdict at all
-    // (an event built before the kernel judged previews, or a kernel that ships none) says that, not a guess
-    renderFilePreview(p, textOnlyContent(path, anchor, "shown as text: " + (a.dataset.previewWhy || "no preview verdict from the kernel for this link")), sid);
+    // the card says exactly which condition refused (the kernel's why on the link, T364); a bare file:// link is opened,
+    // never judged (the kernel's path links exclude it by design), and says so; a path link with no verdict at all (an
+    // event built before the kernel judged previews, or a kernel that ships none) says that, not a guess
+    const why = /^file:/i.test(open) ? "file links are opened, not previewed" : (a.dataset.previewWhy || "no preview verdict from the kernel for this link");
+    renderFilePreview(p, textOnlyContent(path, anchor, "shown as text: " + why), sid);
     stamp(null);
     return;
   }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -148,8 +148,8 @@ type ChatEvent = (
   // event renders as a labelled notice (renderInjected), never the user's bubble (the user 2026-09-07)
   // gist: a romp SYSTEM notice's USER-facing head, lifted by the kernel from the notice's <!-- romp-gist -->
   // marker (2026-09-08) — the body is written to the agent and never doubles as the head
-  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; gist?: string; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; absorbed?: boolean; sentAt?: number; hiddenByPending?: boolean; source?: InjectedSource; preamble?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string>; pathPreview?: Record<string, string> }
-  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string>; pathPreview?: Record<string, string> }   // pathPreview: the links a hover may preview, by kind (T351). spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
+  | { kind: "user"; md: string; uuid?: string; ts?: string; reminders?: string[]; taskOutputs?: TaskOutputs; human?: boolean; romp?: boolean; rompAuto?: boolean; rompSystem?: boolean; gist?: string; followUp?: boolean; goal?: string; fuCtx?: string; canned?: string; tag?: string; mid?: string; mids?: string[]; images?: { src: string; path?: string }[]; undelivered?: boolean; echoT?: number; absorbed?: boolean; sentAt?: number; hiddenByPending?: boolean; source?: InjectedSource; preamble?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string>; pathPreview?: Record<string, string>; pathPreviewWhy?: Record<string, string> }
+  | { kind: "assistant"; md: string; uuid?: string; ts?: string; spacePaths?: string[]; pathLinks?: Record<string, string>; pathPins?: Record<string, string>; pathPreview?: Record<string, string>; pathPreviewWhy?: Record<string, string> }   // pathPreview: the links a hover may preview, by kind (T351). spacePaths: backticked filenames WITH spaces the kernel verified exist (build_session _space_paths) → whole-span links. pathLinks: path-shaped tokens the kernel verified against the filesystem, token → real open target (build_session _path_links) — the linkifier's gate
   | { kind: "thinking"; text: string; encrypted: boolean; uuid?: string; ts?: string }
   | {
       kind: "tool";
@@ -2416,7 +2416,9 @@ function showFilePreview(a: HTMLElement): void {
     if (hit !== null) p.dataset.sliceHit = hit ? "1" : "0";
   };
   if (!kind) {                                   // the kernel allowed no preview: text and the way to the file, no request
-    renderFilePreview(p, textOnlyContent(path, anchor, "shown as text: outside the session's folder and your home, or not a kind the preview shows"), sid);
+    // the card says exactly which condition refused (the kernel's why on the link, T364); a link with no verdict at all
+    // (an event built before the kernel judged previews, or a kernel that ships none) says that, not a guess
+    renderFilePreview(p, textOnlyContent(path, anchor, "shown as text: " + (a.dataset.previewWhy || "no preview verdict from the kernel for this link")), sid);
     stamp(null);
     return;
   }
@@ -2455,12 +2457,16 @@ function showFilePreview(a: HTMLElement): void {
 // file:// URIs are explicit absolute paths — never gated on the map. (The gates and the map walk are
 // path-links.ts's; the map is threaded through to it.)
 function linkifyFileUris(root: HTMLElement, skipThumbs?: string[], spacePaths?: string[],
-    pathLinks?: Record<string, string>, pathPins?: Record<string, string>, pathPreview?: Record<string, string>): void {
+    pathLinks?: Record<string, string>, pathPins?: Record<string, string>, pathPreview?: Record<string, string>,
+    pathPreviewWhy?: Record<string, string>): void {
   // pathPreview (T351): the kernel's word on which of these links a hover may PREVIEW, by kind; the link carries it
-  // as data-preview, and a link without it gets the text-only card with no request
+  // as data-preview, and a link without it gets the text-only card with no request. pathPreviewWhy (T364): for a link
+  // it may not, the kernel's exact refusal rides as data-preview-why, the card's words (the four-way guess went)
   const armPreview = (link: HTMLElement, tok: string, open: string) => {
     const k = previewKindOf(tok, pathPreview) || previewKindOf(open, pathPreview);
     if (k) link.dataset.preview = k; else delete link.dataset.preview;
+    const w = !k && pathPreviewWhy ? (pathPreviewWhy[tok] || pathPreviewWhy[open] || "") : "";
+    if (w) link.dataset.previewWhy = w; else delete link.dataset.previewWhy;
   };
   // A whole-backtick http(s) URL becomes a TAPPABLE link that still looks like code (the user
   // 2026-08-16, on mobile, wanting to tap through to a dashboard link a session sent). Bare URLs
@@ -3707,7 +3713,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         if (more) {
           const full = el("div", "nudge-full md");
           full.innerHTML = md(raw);
-          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview);
+          linkifyFileUris(full, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview, ev.pathPreviewWhy);
           linkTerms(full);
           bubble.appendChild(full);
           bubble.classList.add("nudge-collapsible");
@@ -3723,7 +3729,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
         // the user's OWN words keep their line breaks (userMd); a harness-injected note — compact
         // summary, command stdout — shares this branch and stays on the assistant grammar
         bubble.innerHTML = kind === "user" ? userMd(ev.md) : md(ev.md);
-        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview);   // bare file:// URLs in a message → clickable (open in the host's default app)
+        linkifyFileUris(bubble, imgPaths, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview, ev.pathPreviewWhy);   // bare file:// URLs in a message → clickable (open in the host's default app)
         linkTerms(bubble);   // the team's coinages, in the user's own words too (T351 stage 2)
         if (kind === "user") markMentions(bubble);   // in the user's own bubble a typed "@name" that names a live session wears that session's color; a harness note is not the user naming a session
       }
@@ -3881,7 +3887,7 @@ function renderEventInner(ev: ChatEvent): HTMLElement {
     const body = el("div", "assistant md");
     body.innerHTML = md(ev.md);
     highlight(body);
-    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview);   // bare file:// URLs + verified spaced filenames → clickable
+    linkifyFileUris(body, undefined, ev.spacePaths, ev.pathLinks, ev.pathPins, ev.pathPreview, ev.pathPreviewWhy);   // bare file:// URLs + verified spaced filenames → clickable
     linkTerms(body);   // the team's coinages (T351 stage 2)
     turn.appendChild(body);
     return turn;

--- a/ui/webview/slash-cmd-chip.test.ts
+++ b/ui/webview/slash-cmd-chip.test.ts
@@ -18,7 +18,7 @@ test("a leading slash command in a human bubble becomes a .slash-cmd-chip, args 
   // the non-command path still renders markdown as before (now also linkifies bare file:// URLs, and in the
   // user's own bubble marks a typed @name that names a live session: composer-mention-pane.test.ts); the
   // user's own words through userMd (newlines kept), a harness note through md
-  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);[^\n]*\n\s*linkTerms\(bubble\);[^\n]*\n\s*if \(kind === "user"\) markMentions\(bubble\);[^\n]*\n\s*\}/);
+  assert.match(RENDER, /\} else if \(ev\.md\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*bubble\.innerHTML = kind === "user" \? userMd\(ev\.md\) : md\(ev\.md\);\s*\n\s*linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);[^\n]*\n\s*linkTerms\(bubble\);[^\n]*\n\s*if \(kind === "user"\) markMentions\(bubble\);[^\n]*\n\s*\}/);
 });
 
 test("the chip is a monospace, outlined keyword pill that reads on the blue bubble", () => {

--- a/ui/webview/user-img-dedup.test.ts
+++ b/ui/webview/user-img-dedup.test.ts
@@ -15,7 +15,7 @@ const RENDER = fs.readFileSync(
   path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 
 test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbnail strip", () => {
-  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>\): void/);
+  assert.match(RENDER, /function linkifyFileUris\(root: HTMLElement, skipThumbs\?: string\[\], spacePaths\?: string\[\],\s*\n\s*pathLinks\?: Record<string, string>, pathPins\?: Record<string, string>, pathPreview\?: Record<string, string>,\s*\n\s*pathPreviewWhy\?: Record<string, string>\): void/);
   // the previewable push gates on skipThumbs — the path stays a LINK, it just doesn't render a figure
   assert.match(RENDER,
     /if \(previewKind\(open\) && !previewable\.includes\(open\) && !\(skipThumbs && skipThumbs\.includes\(open\)\)\) \{\s*\n\s*previewable\.push\(open\);\s*\n\s*mentionAt\.set\(open, link\);/);
@@ -24,9 +24,9 @@ test("linkifyFileUris takes skipThumbs and excludes those paths from the thumbna
 test("the user bubble passes its ev.images paths (caption path AND path:-src) as skipThumbs", () => {
   // both ways an in-bubble image names its file: im.path (caption) and a "path:<abs>" src
   assert.match(RENDER, /\.flatMap\(\(im\) => \[im\.path, im\.src\.startsWith\("path:"\) \? im\.src\.slice\(5\) : ""\]\)/);
-  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);/);
+  assert.match(RENDER, /linkifyFileUris\(bubble, imgPaths, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);/);
   // the assistant reply has no ev.images — its call stays bare (mentioned plots still thumb there)
-  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview\);/);
+  assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);/);
 });
 
 // executed: replicate the strip-collection decision — a path already rendered as an in-bubble


### PR DESCRIPTION
The hover preview did not deliver for a laptop-hosted session: links showed the text card ("outside the session's folder and your home, or not a kind the preview shows") and images did not render, while inline images already render for remote sessions. Three defects and one blind spot.

## The remote fetch (step B)

`sliceUrl` and `fileUrl` asked the LOCAL origin for a remote session's file and got the wrong kernel's answer. They build `/remote/<host>/file` with the bare sid for a host-prefixed session now, exactly as `preview.ts` does for inline images (`previewRoute`). Which kernel builds a remote session's events: its own, through the `/remote/<host>/ws` splice, judging its own files, which is right. Lab: a hub and a checked-in TESTHOST kernel; the remote session's markdown, section and image cards render through the relay, and every fetch's URL is the relay's with the bare sid.

## The exact refusal (diagnosability)

The kernel ships `pathPreviewWhy` beside `pathPreview`: for every verified link it may not preview, `_slice_allowed`'s condition or the markdown warm's content-belt refusal (`looks like a secret`, `not text`). The link carries it as `data-preview-why` and the card says `shown as text: <why>`; a link with no verdict at all says that. The four-way guess is gone.

## Existing messages (step C)

Events sealed before the kernel judged previews carried `pathLinks` and no `pathPreview` key, and the fold kept them sealed. `pathPreview` rides every event with links (empty when none previews), the fold entry records the sealed events without the key (`pv_missing`; a restored entry is scanned once), and the gate's `path-preview` clause refolds once. romp_metrics was told before the gate chain was touched; no document version bump.

## A bare filename on the local kernel (step A)

A bare name the repo index resolves (tier 3) previews from its resolved absolute path, the same path the click opens; the lab's synthetic git repo proves it. Step A holds as built.

## The bundle after a restart (step D)

A standalone chat page asks `/version` on its socket's reopen and the reload core reloads on a new boot id (`kernel.py` shim, T265); `tests/test_ship_reship.py`'s wedge executes that reload. Nothing to add.
