### PR TITLE
A file's checkpoint is written at the reader's quiescence drop, from the read that already happened (T362)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1010,16 +1010,26 @@ that ran. An idle session's leaf, which no settle reaches and the pass must
 refuse, converges at the reader's quiescence drop instead: when a fold that
 drops quiescent files ends over a file unchanged for two minutes, its document
 is written from the entry in memory (the boot's own read, whichever fold made
-it) if it lacks anything the process holds (the pass's rule, `_path_needs_write`,
-with a dirty path counting here and not for the pass), before the entry is
-popped, and on a hit or a restore at the witness the entry stays as it always
-has; the write is charged to the cycle's byte budget shared with the pass, and
-over the budget the write and the drop wait one cycle with the entry held
-(`converge.dropDeferred`), the drop then owed to the next fold over the file.
-A document already whole is never rewritten at a later drop
-(`converge.dropWrites` counts the writes), and a dropped file's next fold
-restores its cursor from the document over a tail read instead of reading the
-file whole. A leaf unchanged for longer than the reader keeps a quiescent
+it) if a write would improve it with a state the process holds (the pass's
+rule, `_path_needs_write`; a dirty path counts here and not for the pass, and a
+fold cold for want of a state counts for the pass, which heals it, and not
+here, where it would only be written cold again), before the entry is popped,
+and on a hit or a restore at the witness the entry stays as it always has. The
+write is charged to the pusher cycle's byte budget, which the kernel begins at
+each cycle's start and the pass shares near its end; over the budget the write
+and the drop wait with the entry held (`converge.dropDeferred`), the drop then
+owed and paid at the next cycle's start with the room that cycle has, oldest
+first, or by the next fold over the file, whichever comes first. A document
+already whole is never rewritten at a later drop (`converge.dropWrites` counts
+the writes), and a dropped file's next fold restores its cursor from the
+document over a tail read instead of reading the file whole, provided the
+document's cursor carries a state: against a state the process holds, a cursor
+without one (an over-cap, cold or legacy bare write) is refused and the fold
+reads whole as before, so a complete state is never replaced by a tail-only one.
+The knobs: `ROMP_CKPT_CONVERGE_MS=0` turns the pass off and the drop write with
+it (the drop then pops as it did before the write existed); `ROMP_CKPT_CONVERGE_MB`
+is the cycle budget both charge, and `0` turns the drop write off the same way
+rather than deferring every drop. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under
 `quiescent`: its heal would read the file whole every cycle and the write
 would find no entry (the boot's cold refold or the next settle converges it);

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1029,7 +1029,10 @@ reads whole as before, so a complete state is never replaced by a tail-only one.
 The knobs: `ROMP_CKPT_CONVERGE_MS=0` turns the pass off and the drop write with
 it (the drop then pops as it did before the write existed); `ROMP_CKPT_CONVERGE_MB`
 is the cycle budget both charge, and `0` turns the drop write off the same way
-rather than deferring every drop. A leaf unchanged for longer than the reader keeps a quiescent
+rather than deferring every drop; both are read where the drop lives, so they
+hold from the first fold, before the first pusher cycle begins. The owed table
+is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
+file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under
 `quiescent`: its heal would read the file whole every cycle and the write
 would find no entry (the boot's cold refold or the next settle converges it);

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1006,12 +1006,27 @@ that never settles again; the pass is bounded per cycle (`ROMP_CKPT_CONVERGE_MS`
 default 150 ms of wall, and `ROMP_CKPT_CONVERGE_MB`, default 8 MB of documents
 written plus leaf bytes read for a heal), heals a legacy bare cursor under the
 same budget, and never rewrites a document that already carries every fold
-that ran. A leaf unchanged for longer than the reader keeps a quiescent
+that ran. An idle session's leaf, which no settle reaches and the pass must
+refuse, converges at the reader's quiescence drop instead: when a fold that
+drops quiescent files ends over a file unchanged for two minutes, its document
+is written from the entry in memory (the boot's own read, whichever fold made
+it) if it lacks anything the process holds (the pass's rule, `_path_needs_write`,
+with a dirty path counting here and not for the pass), before the entry is
+popped, and on a hit or a restore at the witness the entry stays as it always
+has; the write is charged to the cycle's byte budget shared with the pass, and
+over the budget the write and the drop wait one cycle with the entry held
+(`converge.dropDeferred`), the drop then owed to the next fold over the file.
+A document already whole is never rewritten at a later drop
+(`converge.dropWrites` counts the writes), and a dropped file's next fold
+restores its cursor from the document over a tail read instead of reading the
+file whole. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under
 `quiescent`: its heal would read the file whole every cycle and the write
 would find no entry (the boot's cold refold or the next settle converges it);
 a path the pass refused or whose write produced nothing is skipped until its
-file changes (`skipped`); `ROMP_CKPT_CONVERGE_MS=0` turns the pass off. Every
+file changes under the reader (`skipped` counts each such hold once, per file
+state, and the check reads the reader's own entry rather than stat the file
+while one is held); `ROMP_CKPT_CONVERGE_MS=0` turns the pass off. Every
 write merges the on-disk document's states for folds the
 writing process never ran (verified by that document's stat and guard as a
 restore would), so a rewrite from one process's cursors strips no state an
@@ -1437,7 +1452,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   whose cursor it dropped so its next run reads the file whole once, and
   `docReadBytes`, the documents the pass's writes read for their carry,
   `quiescent` for leaves refused as quiescent, `skipped` for candidates held
-  off until their file changes), `coldWrites` (per fold name, writes that kept such a tail-only state
+  off until their file changes, once per hold, `dropWrites` and `dropDeferred`
+  for the documents written at the reader's quiescence drop and the drops
+  deferred a cycle for the shared budget), `coldWrites` (per fold name, writes that kept such a tail-only state
   out of the document so no later kernel restores it as complete), `droppedRestores` (a
   restore lost to a read that replaced the entry under it; the reader
   serializes reads per path, so this should stay at zero), `documentBytes`

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -768,9 +768,6 @@ _CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallb
                "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0,
                             "failed": 0, "unhealed": 0, "docReadBytes": 0, "quiescent": 0, "skipped": 0,
                             "dropWrites": 0, "dropDeferred": 0}}   # T360, T361, T362
-_DROP_OWED = set()                                    # paths whose quiescence drop was deferred for the cycle's budget (T362)
-_CKPT_CYCLE = {"cap": None, "spent": 0}   # the pusher cycle's byte budget for checkpoint work, shared by the converge pass and the
-#                                           quiescence drop's write (T362): the pass begins each cycle; both charge it
 _CKPT_DOC_FOLDS = {}              # path -> {fold name: "state" | "over" | "cold" | "bare"}: the document on disk as last written or
 #                                   loaded in this process, so the converge pass can tell a document lacking a state without a read
 _COLD = object()                  # a restored cursor with no state (its fold was oversize): fold_records inits it and steps the tail
@@ -821,6 +818,15 @@ def _env_or(name, default, scale=1):
 # cold-refolded them whole, 1.74 GB read in the first pusher cycle (65 s of tick jobs); a document of a few MB reads in
 # milliseconds. ROMP_CKPT_FOLD_CAP_KB sets it outright.
 _CKPT_FOLD_CAP = _env_or("ROMP_CKPT_FOLD_CAP_KB", 8 * 1024 * 1024, 1024)
+_CKPT_CYCLE_CAP_DEFAULT = _env_or("ROMP_CKPT_CONVERGE_MB", 8 * 1024 * 1024, 1024 * 1024)   # the pusher cycle's byte budget for
+#                                   checkpoint work (documents written and read, leaves read for a heal), shared by the converge pass
+#                                   and the quiescence drop's write (T362); the kernel's knob reads the same default
+_CKPT_CYCLE = {"cap": _CKPT_CYCLE_CAP_DEFAULT, "spent": 0}   # the cycle in progress: the kernel begins each pusher cycle at its
+#                                   START (so the boot's first builds are capped where the volume is); before any cycle, and in a
+#                                   process that never begins one (the judges), the default cap stands; a cap of 0 turns the drop
+#                                   write off (the drop pops as before T362)
+_DROP_OWED = {}                   # path -> when its quiescence drop was deferred for the cycle's budget (T362): paid at the next
+#                                   cycle's start with the room it has, oldest first, or by the next fold over the file; bounded
 #                                   bytes of encoded state a fold may put in a checkpoint. A state that grows with its file (the postal
 #                                   log fold's map of every sent row, the state intervals' list of every transition, the every-task
 #                                   background view on a long transcript) would make the document a second copy of the file: reading
@@ -902,6 +908,7 @@ def set_checkpoint_dir(fn):
     _CKPT_DIR_FN = fn
     with _CKPT_LOCK:
         _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear(); _CKPT_DOC_FOLDS.clear(); _DROP_OWED.clear()
+        _CKPT_CYCLE["cap"] = _CKPT_CYCLE_CAP_DEFAULT; _CKPT_CYCLE["spent"] = 0
 
 
 def _ckpt_dir():
@@ -1075,6 +1082,15 @@ def _ckpt_pending(path, ent):
     return pend
 
 
+def _document_carries_state(key, name, ent):
+    """Whether the document's pending restore for `key` carries a complete state for fold `name` (a cursor with `state`), as
+    a stale-generation fold asks before taking it over a state it holds (T362 round one, medium). Consults the same pending
+    record the restore would, taking nothing."""
+    pend = _ckpt_pending(key, ent)
+    f = pend["folds"].get(name) if pend is not None else None
+    return isinstance(f, dict) and "state" in f
+
+
 def _restored_cursor(key, name, ent):
     """The fold cursor (count, gen, state) a checkpoint carries for fold `name` of `key`, when it stands at a count
     the current entry can resume from; None otherwise. Each fold's restore is taken once."""
@@ -1141,20 +1157,26 @@ def _cursor_recordable(cur, gen, base, total):
     return cur is not None and cur[1] == gen and _count_recordable(base, total, cur[0])
 
 
-def _path_needs_write(key, ent, dirty_counts=False):
-    """Whether `key`'s document on disk lacks something this process holds for it (T360's candidate rule, T362's one rule): a
-    fold over it began cold for want of a state, or a recordable cursor's fold has no complete state in the document (missing,
-    a bare cursor, a tail-only one); with `dirty_counts`, a dirty path too (the quiescence drop: a file about to leave memory
-    whose folds moved since its document; never the converge pass, for which a live leaf is dirty every turn and is written at
-    its settle). False for a whole document over a clean path: nothing to write."""
+def _path_needs_write(key, ent, at_drop=False):
+    """Whether a write now would improve `key`'s document on disk with something this process holds (T360's candidate rule,
+    T362's one rule): a recordable cursor whose fold holds a complete state here and has none in the document (missing, a bare
+    cursor, a tail-only one). For the converge pass, a fold cold for want of a state too (the pass heals it: a whole refold,
+    then the write). At the drop (`at_drop`): a dirty path too (a file about to leave memory whose folds moved since its
+    document; never for the pass, for which a live leaf is dirty every turn and is written at its settle), and a cold fold
+    never (the drop cannot heal it, and a write would record it cold again: no improvement, so a quiescent file whose document
+    holds the dropping fold's cursor without a state is not rewritten at every fold; round one, low 1). False for a whole
+    document over a clean path: nothing to write."""
     with _CKPT_LOCK:
-        if dirty_counts and key in _FOLD_DIRTY:
+        if at_drop and key in _FOLD_DIRTY:
             return True
-        if any(k == key and _COLD_REASONS.get((k, n), "cold") == "cold" for k, n in _COLD_FOLDS):
+        cold = {n for k, n in _COLD_FOLDS if k == key}
+        if not at_drop and any(_COLD_REASONS.get((key, n), "cold") == "cold" for n in cold):
             return True
     shapes = _CKPT_DOC_FOLDS.get(key, {})
     base, gen, total = ent[5], ent[6], ent[5] + len(ent[4])
     for name, cache in list(_FOLD_REG.items()):
+        if name in cold:
+            continue                                      # a tail-only state is written as a cursor without one: nothing gained
         if _cursor_recordable(cache.get(key), gen, base, total) and shapes.get(name) not in ("state", "over"):
             return True
     return False
@@ -1162,22 +1184,62 @@ def _path_needs_write(key, ent, dirty_counts=False):
 
 def checkpoint_cycle_begin(cap):
     """The pusher's cycle begins: the checkpoint byte budget `cap` (documents written and read, leaves read for a heal) is
-    whole again; the converge pass and the quiescence drop's writes charge it (T362)."""
+    whole again; the converge pass and the quiescence drop's writes charge it (T362). A cap of 0 (the pass off, or a zero
+    byte knob) turns the drop write off: the drop pops as before, holding nothing."""
     with _CKPT_LOCK:
-        _CKPT_CYCLE["cap"] = cap; _CKPT_CYCLE["spent"] = 0
+        _CKPT_CYCLE["cap"] = int(cap); _CKPT_CYCLE["spent"] = 0
+
+
+def checkpoint_cycle_take(n):
+    """Take `n` bytes of the cycle's budget in ONE step (the room check and the charge under one lock, so concurrent folds
+    cannot each pass a check the other's charge would fail): True and charged when they fit, False and uncharged otherwise."""
+    with _CKPT_LOCK:
+        if _CKPT_CYCLE["spent"] + int(n) > _CKPT_CYCLE["cap"]:
+            return False
+        _CKPT_CYCLE["spent"] += int(n)
+        return True
+
+
+def checkpoint_drop_writes_on():
+    """Whether the quiescence drop writes documents this cycle (a cap above zero)."""
+    with _CKPT_LOCK:
+        return _CKPT_CYCLE["cap"] > 0
+
+
+def checkpoint_pay_owed_drops():
+    """The cycle's start (T362 round one, low 2): the drops deferred for an earlier cycle's budget are paid now, oldest first,
+    with the room this cycle has, since the files this serves (a returned subagent's transcript) may never be folded again and
+    their whole entries would otherwise stay resident for the kernel's life. An owed path whose entry or file is gone is
+    forgotten. Returns the drops paid (written or popped)."""
+    with _CKPT_LOCK:
+        owed = list(_DROP_OWED)
+    paid = 0
+    for key in owed:
+        with _JSONL_CACHE_LOCK:
+            ent = _JSONL_CACHE.get(key)
+        if ent is None or not os.path.exists(key):
+            with _CKPT_LOCK:
+                _DROP_OWED.pop(key, None)
+            continue
+        _drop_quiescent_entry(key, ent, pop=True)         # takes the owed mark itself; over the budget again it re-defers
+        with _CKPT_LOCK:
+            if key not in _DROP_OWED:
+                paid += 1
+    return paid
 
 
 def checkpoint_cycle_charge(n):
-    """Charge `n` bytes to the cycle's budget; True while the cycle stays within it (no cap set: always)."""
+    """Charge `n` bytes to the cycle's budget (the pass's reads and writes, known only after the fact; a true-up may be
+    negative); True while the cycle stays within it."""
     with _CKPT_LOCK:
         _CKPT_CYCLE["spent"] += int(n)
-        return _CKPT_CYCLE["cap"] is None or _CKPT_CYCLE["spent"] <= _CKPT_CYCLE["cap"]
+        return _CKPT_CYCLE["spent"] <= _CKPT_CYCLE["cap"]
 
 
 def checkpoint_cycle_room(n):
-    """Whether `n` more bytes would stay within the cycle's budget (no cap set: always)."""
+    """Whether `n` more bytes would stay within the cycle's budget (the pass's gate between candidates)."""
     with _CKPT_LOCK:
-        return _CKPT_CYCLE["cap"] is None or _CKPT_CYCLE["spent"] + int(n) <= _CKPT_CYCLE["cap"]
+        return _CKPT_CYCLE["spent"] + int(n) <= _CKPT_CYCLE["cap"]
 
 
 def _carry_forward_states(key, folds, base, count, size, mtime):
@@ -1702,8 +1764,11 @@ def fold_records(cache, path, init, step, on=None, ckpt=None, drop_after=None):
     if ckpt is not None and ent is not None and (hit is None or hit[1] != gen):
         # no cursor, or one at an entry that left memory (the quiescence drop, an eviction) while the file stood: the reader's
         # new entry came from the file's document when it stands, and the document's cursor for this fold serves the fold at
-        # that entry (T362: a dropped file's later fold is a tail read, not a whole one); with nothing to restore, a refold
-        restored = _restored_cursor(key, ckpt, ent)
+        # that entry (T362: a dropped file's later fold is a tail read, not a whole one); with nothing to restore, a refold.
+        # Against a HELD state the document's cursor is taken only when it carries a state of its own (round one, medium): a
+        # cursor without one (an over-cap, cold or bare legacy write) would replace the complete state this process holds
+        # with a tail-only one that answers empty, and for an idle file nothing would ever heal it; the fold reads whole instead
+        restored = _restored_cursor(key, ckpt, ent) if hit is None or _document_carries_state(key, ckpt, ent) else None
         if restored is not None:
             hit = restored
             kind = "restore"
@@ -1774,8 +1839,8 @@ def _drop_quiescent_entry(key, ent, pop=True):
     except Exception:
         return
     with _CKPT_LOCK:
-        if key in _DROP_OWED:                             # a drop deferred for the budget is taken at the next fold over the file,
-            _DROP_OWED.discard(key); pop = True           #  whichever path that fold takes
+        if key in _DROP_OWED:                             # a drop deferred for the budget is taken at the next fold over the file
+            _DROP_OWED.pop(key, None); pop = True         #  (whichever path that fold takes) or at the next cycle's start
     # T362: the entry a quiescent-drop fold ends over is a read that already happened (the boot's, by whichever fold read the
     # file whole); if the file's document lacks something this process holds (the one rule), it is written NOW, before any
     # pop, from that read: the idle sessions' documents converge here, where no settle reaches them and the converge pass must
@@ -1784,7 +1849,7 @@ def _drop_quiescent_entry(key, ent, pop=True):
     # budget the write AND the drop are deferred by one cycle (the entry stays; the read is not lost), counted under
     # checkpoints.converge.dropDeferred.
     try:
-        needs = _path_needs_write(key, ent, dirty_counts=True)
+        needs = checkpoint_drop_writes_on() and _path_needs_write(key, ent, at_drop=True)   # off (a cap of 0): the pop alone
     except Exception:
         needs = False
     if needs:
@@ -1793,19 +1858,22 @@ def _drop_quiescent_entry(key, ent, pop=True):
             est = cp.stat().st_size if cp is not None and cp.exists() else 0
         except OSError:
             est = 0
-        if not checkpoint_cycle_room(2 * est):           # the previous document read for the carry, and about as much written
-            with _CKPT_LOCK:
+        if est <= 0:                                      # no previous document (a first write, or one the fallback removed): an
+            est = max(4096, int(ent[1]) // 8)             #  estimate from the file, never a free pass against the budget
+        if not checkpoint_cycle_take(2 * est):           # the previous document read for the carry, and about as much written:
+            with _CKPT_LOCK:                              #  taken in one step, or deferred (the drop owed) when it does not fit
                 _CKPT_STATS["converge"]["dropDeferred"] += 1
                 if pop:
-                    _DROP_OWED.add(key)
+                    _DROP_OWED[key] = time.time()
+                    if len(_DROP_OWED) > 4096:            # bounded like its neighbours; the reader's own budget still frees entries
+                        _DROP_OWED.clear()
             return
-        checkpoint_cycle_charge(est)
         if checkpoint_write(key):
             try:
                 written = cp.stat().st_size if cp is not None else 0
             except OSError:
                 written = 0
-            checkpoint_cycle_charge(written)
+            checkpoint_cycle_charge(written - est)       # the true-up: what was written against the estimate taken above
             with _CKPT_LOCK:
                 _CKPT_STATS["converge"]["dropWrites"] += 1
     if not pop:

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -766,7 +766,11 @@ _CKPT_DIR_FN = None               # () -> Path of the checkpoint directory; None
 _CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallbacks": {}, "restoredFolds": {}, "droppedRestores": 0,
                "oversizeFolds": {}, "coldFolds": {}, "coldWrites": {},
                "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0,
-                            "failed": 0, "unhealed": 0, "docReadBytes": 0, "quiescent": 0, "skipped": 0}}   # T360, T361
+                            "failed": 0, "unhealed": 0, "docReadBytes": 0, "quiescent": 0, "skipped": 0,
+                            "dropWrites": 0, "dropDeferred": 0}}   # T360, T361, T362
+_DROP_OWED = set()                                    # paths whose quiescence drop was deferred for the cycle's budget (T362)
+_CKPT_CYCLE = {"cap": None, "spent": 0}   # the pusher cycle's byte budget for checkpoint work, shared by the converge pass and the
+#                                           quiescence drop's write (T362): the pass begins each cycle; both charge it
 _CKPT_DOC_FOLDS = {}              # path -> {fold name: "state" | "over" | "cold" | "bare"}: the document on disk as last written or
 #                                   loaded in this process, so the converge pass can tell a document lacking a state without a read
 _COLD = object()                  # a restored cursor with no state (its fold was oversize): fold_records inits it and steps the tail
@@ -897,7 +901,7 @@ def set_checkpoint_dir(fn):
     global _CKPT_DIR_FN
     _CKPT_DIR_FN = fn
     with _CKPT_LOCK:
-        _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear(); _CKPT_DOC_FOLDS.clear()
+        _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear(); _CKPT_DOC_FOLDS.clear(); _DROP_OWED.clear()
 
 
 def _ckpt_dir():
@@ -1126,6 +1130,56 @@ def _lag_ok(count, c):
     return count - c <= max(_CKPT_LAG_FLOOR, count // 8)
 
 
+def _count_recordable(base, total, c):
+    """Whether a fold count `c` can be recorded against an entry holding records base..total: inside the held records and not
+    further behind than the lag bound. The ONE count rule of the writer, the carry, the candidate check and the drop (T362)."""
+    return base <= c <= total and _lag_ok(total, c)
+
+
+def _cursor_recordable(cur, gen, base, total):
+    """Whether a fold's cursor `cur` (count, gen, state) is one the writer records at this entry."""
+    return cur is not None and cur[1] == gen and _count_recordable(base, total, cur[0])
+
+
+def _path_needs_write(key, ent, dirty_counts=False):
+    """Whether `key`'s document on disk lacks something this process holds for it (T360's candidate rule, T362's one rule): a
+    fold over it began cold for want of a state, or a recordable cursor's fold has no complete state in the document (missing,
+    a bare cursor, a tail-only one); with `dirty_counts`, a dirty path too (the quiescence drop: a file about to leave memory
+    whose folds moved since its document; never the converge pass, for which a live leaf is dirty every turn and is written at
+    its settle). False for a whole document over a clean path: nothing to write."""
+    with _CKPT_LOCK:
+        if dirty_counts and key in _FOLD_DIRTY:
+            return True
+        if any(k == key and _COLD_REASONS.get((k, n), "cold") == "cold" for k, n in _COLD_FOLDS):
+            return True
+    shapes = _CKPT_DOC_FOLDS.get(key, {})
+    base, gen, total = ent[5], ent[6], ent[5] + len(ent[4])
+    for name, cache in list(_FOLD_REG.items()):
+        if _cursor_recordable(cache.get(key), gen, base, total) and shapes.get(name) not in ("state", "over"):
+            return True
+    return False
+
+
+def checkpoint_cycle_begin(cap):
+    """The pusher's cycle begins: the checkpoint byte budget `cap` (documents written and read, leaves read for a heal) is
+    whole again; the converge pass and the quiescence drop's writes charge it (T362)."""
+    with _CKPT_LOCK:
+        _CKPT_CYCLE["cap"] = cap; _CKPT_CYCLE["spent"] = 0
+
+
+def checkpoint_cycle_charge(n):
+    """Charge `n` bytes to the cycle's budget; True while the cycle stays within it (no cap set: always)."""
+    with _CKPT_LOCK:
+        _CKPT_CYCLE["spent"] += int(n)
+        return _CKPT_CYCLE["cap"] is None or _CKPT_CYCLE["spent"] <= _CKPT_CYCLE["cap"]
+
+
+def checkpoint_cycle_room(n):
+    """Whether `n` more bytes would stay within the cycle's budget (no cap set: always)."""
+    with _CKPT_LOCK:
+        return _CKPT_CYCLE["cap"] is None or _CKPT_CYCLE["spent"] + int(n) <= _CKPT_CYCLE["cap"]
+
+
 def _carry_forward_states(key, folds, base, count, size, mtime):
     """The on-disk document's entries for folds this process holds no cursor for (a fold that never ran here, such as the
     transcript's wake-tail or queue-ledger folds beside the five leaf folds), carried into the next write so a write from
@@ -1164,7 +1218,7 @@ def _carry_forward_states(key, folds, base, count, size, mtime):
             c = int(f["count"])
         except (KeyError, TypeError, ValueError):
             continue
-        if base <= c <= count and _lag_ok(count, c):          # a carried count too far behind would drag the cut (the bound above)
+        if _count_recordable(base, count, c):                 # a carried count too far behind would drag the cut (the bound above)
             out[name] = f
     return out
 
@@ -1185,7 +1239,7 @@ def checkpoint_write(path, force=False):
     folds = {}
     for name, cache in list(_FOLD_REG.items()):
         cur = cache.get(key)
-        if cur is None or cur[1] != gen or not base <= cur[0] <= count or not _lag_ok(count, cur[0]):
+        if not _cursor_recordable(cur, gen, base, count):
             continue                                      # no cursor at this entry, one outside its held records, or one too far
         #                                                   behind to be written at its count without dragging the cut (_lag_ok)
         fcount = cur[0]                                   # the fold's OWN count (T359): a fold stepped by builds, not by the settle,
@@ -1291,16 +1345,8 @@ def checkpoint_converge_candidates():
             ent = _JSONL_CACHE.get(key)
         if ent is None:
             continue
-        shapes = _CKPT_DOC_FOLDS.get(key, {})
-        total = ent[5] + len(ent[4])
-        for name, cache in list(_FOLD_REG.items()):
-            if (key, name) in cold:
-                out.append(key); break
-            cur = cache.get(key)
-            if cur is None or cur[1] != ent[6] or not ent[5] <= cur[0] <= total or not _lag_ok(total, cur[0]):
-                continue                                  # no cursor the writer would record: a fold stopped beyond the lag bound
-            if shapes.get(name) not in ("state", "over"):   #  is left out by the writer and refused by the carry, so it is no
-                out.append(key); break                    #  candidate either (it refolds once when it runs, then is written current)
+        if _path_needs_write(key, ent):                   # the one rule (T362): dirty, cold for want of a state, or a recordable
+            out.append(key)                               #  cursor whose fold has no complete state in the document
     return out
 
 
@@ -1653,9 +1699,13 @@ def fold_records(cache, path, init, step, on=None, ckpt=None, drop_after=None):
     total = base + len(recs)
     hit = cache.get(key)
     kind = None
-    if hit is None and ckpt is not None and ent is not None:
-        hit = _restored_cursor(key, ckpt, ent)
-        if hit is not None:
+    if ckpt is not None and ent is not None and (hit is None or hit[1] != gen):
+        # no cursor, or one at an entry that left memory (the quiescence drop, an eviction) while the file stood: the reader's
+        # new entry came from the file's document when it stands, and the document's cursor for this fold serves the fold at
+        # that entry (T362: a dropped file's later fold is a tail read, not a whole one); with nothing to restore, a refold
+        restored = _restored_cursor(key, ckpt, ent)
+        if restored is not None:
+            hit = restored
             kind = "restore"
             if hit[2] is _COLD:                           # the cursor without its state: the fold starts at the entry's
                 hit = (base, hit[1], init()); kind = "cold"   #  base and steps the tail it holds
@@ -1668,6 +1718,9 @@ def fold_records(cache, path, init, step, on=None, ckpt=None, drop_after=None):
                 on("hit" if kind is None else kind)
             if kind is not None:
                 cache[key] = hit                          # a restore at the witness: the cursor stands, nothing stepped
+            if drop_after == "quiescent" and ent is not None:
+                _drop_quiescent_entry(key, ent, pop=False)   # T362: the document is written here too; the entry stays, since
+            #                                                   nothing was stepped (unless a deferred drop is owed)
             return _fold_eof_fragment(key, ent, state0, step)   # unchanged records; a newline-less tail may still sit past them
         if g0 == gen and base <= n0 < total:
             state, start = copy.deepcopy(state0), n0 - base
@@ -1708,16 +1761,54 @@ def fold_records(cache, path, init, step, on=None, ckpt=None, drop_after=None):
     return out
 
 
-def _drop_quiescent_entry(key, ent):
+def _drop_quiescent_entry(key, ent, pop=True):
     """drop_after="quiescent" (the kernel memory work, 2026-09-11): a file unchanged for _DROP_AFTER_QUIESCENT_S is one
     whose writer has finished (a subagent that returned), and its records are not kept in the shared reader's cache
     once a fold has stepped them: the fold's cursor (and its checkpoint) stands, the file's bytes leave memory. Only the
     very entry this fold read is dropped (another thread's newer entry is left alone); a file still changing keeps its
-    records, since its next append would otherwise re-read it whole."""
+    records, since its next append would otherwise re-read it whole. Without `pop` (a fold that stepped nothing: a hit or
+    a restore at the witness) only the T362 write below runs and the entry stays, as it always has on that path."""
     try:
         if time.time() - float(ent[0]) < _DROP_AFTER_QUIESCENT_S:
             return
     except Exception:
+        return
+    with _CKPT_LOCK:
+        if key in _DROP_OWED:                             # a drop deferred for the budget is taken at the next fold over the file,
+            _DROP_OWED.discard(key); pop = True           #  whichever path that fold takes
+    # T362: the entry a quiescent-drop fold ends over is a read that already happened (the boot's, by whichever fold read the
+    # file whole); if the file's document lacks something this process holds (the one rule), it is written NOW, before any
+    # pop, from that read: the idle sessions' documents converge here, where no settle reaches them and the converge pass must
+    # refuse them (a heal on the cycle re-read them whole). The write runs with neither lock held (checkpoint_write takes
+    # _CKPT_LOCK and _JSONL_CACHE_LOCK itself); it charges the pusher cycle's byte budget shared with the pass, and over the
+    # budget the write AND the drop are deferred by one cycle (the entry stays; the read is not lost), counted under
+    # checkpoints.converge.dropDeferred.
+    try:
+        needs = _path_needs_write(key, ent, dirty_counts=True)
+    except Exception:
+        needs = False
+    if needs:
+        cp = _ckpt_file(key)
+        try:
+            est = cp.stat().st_size if cp is not None and cp.exists() else 0
+        except OSError:
+            est = 0
+        if not checkpoint_cycle_room(2 * est):           # the previous document read for the carry, and about as much written
+            with _CKPT_LOCK:
+                _CKPT_STATS["converge"]["dropDeferred"] += 1
+                if pop:
+                    _DROP_OWED.add(key)
+            return
+        checkpoint_cycle_charge(est)
+        if checkpoint_write(key):
+            try:
+                written = cp.stat().st_size if cp is not None else 0
+            except OSError:
+                written = 0
+            checkpoint_cycle_charge(written)
+            with _CKPT_LOCK:
+                _CKPT_STATS["converge"]["dropWrites"] += 1
+    if not pop:
         return
     with _JSONL_CACHE_LOCK:
         if _JSONL_CACHE.get(key) is ent:

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -818,15 +818,6 @@ def _env_or(name, default, scale=1):
 # cold-refolded them whole, 1.74 GB read in the first pusher cycle (65 s of tick jobs); a document of a few MB reads in
 # milliseconds. ROMP_CKPT_FOLD_CAP_KB sets it outright.
 _CKPT_FOLD_CAP = _env_or("ROMP_CKPT_FOLD_CAP_KB", 8 * 1024 * 1024, 1024)
-_CKPT_CYCLE_CAP_DEFAULT = _env_or("ROMP_CKPT_CONVERGE_MB", 8 * 1024 * 1024, 1024 * 1024)   # the pusher cycle's byte budget for
-#                                   checkpoint work (documents written and read, leaves read for a heal), shared by the converge pass
-#                                   and the quiescence drop's write (T362); the kernel's knob reads the same default
-_CKPT_CYCLE = {"cap": _CKPT_CYCLE_CAP_DEFAULT, "spent": 0}   # the cycle in progress: the kernel begins each pusher cycle at its
-#                                   START (so the boot's first builds are capped where the volume is); before any cycle, and in a
-#                                   process that never begins one (the judges), the default cap stands; a cap of 0 turns the drop
-#                                   write off (the drop pops as before T362)
-_DROP_OWED = {}                   # path -> when its quiescence drop was deferred for the cycle's budget (T362): paid at the next
-#                                   cycle's start with the room it has, oldest first, or by the next fold over the file; bounded
 #                                   bytes of encoded state a fold may put in a checkpoint. A state that grows with its file (the postal
 #                                   log fold's map of every sent row, the state intervals' list of every transition, the every-task
 #                                   background view on a long transcript) would make the document a second copy of the file: reading
@@ -834,6 +825,28 @@ _DROP_OWED = {}                   # path -> when its quiescence drop was deferre
 #                                   44 MB world). Such a fold is left out, counted per name, and cold-folds at first touch; the folds
 #                                   whose state is bounded (the gist's capped steps, the running tasks, the newest rows) are the ones
 #                                   the checkpoint pays for. A bounded projection for the growing ones is a later stage's item.
+_CKPT_CYCLE_CAP_DEFAULT = _env_or("ROMP_CKPT_CONVERGE_MB", 8 * 1024 * 1024, 1024 * 1024)   # the pusher cycle's byte budget for
+#                                   checkpoint work (documents written and read, leaves read for a heal), shared by the converge pass
+#                                   and the quiescence drop's write (T362); the kernel's knobs read these defaults, so they reach
+#                                   the drop write before the first cycle begins (round two, low 3)
+try:
+    _CKPT_CONVERGE_MS_DEFAULT = float(os.environ.get("ROMP_CKPT_CONVERGE_MS", "150"))   # the pass's wall budget; 0 turns the pass
+except ValueError:                                                                        #  off and the drop write with it
+    _CKPT_CONVERGE_MS_DEFAULT = 150.0
+
+
+def _ckpt_cycle_default_cap():
+    """The cycle budget that stands before any pusher cycle has begun, and in a process that never begins one (the judges):
+    the byte knob, or 0 (the drop write off) when either knob is zero."""
+    return _CKPT_CYCLE_CAP_DEFAULT if _CKPT_CONVERGE_MS_DEFAULT > 0 and _CKPT_CYCLE_CAP_DEFAULT > 0 else 0
+
+
+_CKPT_CYCLE = {"cap": _ckpt_cycle_default_cap(), "spent": 0}   # the cycle in progress: the kernel begins each pusher cycle at
+#                                   its START (so the boot's first builds are capped where the volume is); before any cycle the
+#                                   default above stands; a cap of 0 turns the drop write off (the drop pops as before T362)
+_DROP_OWED = {}                   # path -> when its quiescence drop was deferred for the cycle's budget (T362): paid at the next
+#                                   cycle's start with the room it has, oldest first, or by the next fold over the file
+_DROP_OWED_MAX = 4096             # over it the OLDEST owed entry is popped unwritten (its memory released), never the table cleared
 _CKPT_LOCK = threading.Lock()
 _CKPT_PENDING = {}                # path -> {"count": N, "gen": g, "folds": {name: {"count", "state"}}} restores not yet taken
 _CKPT_SEQ = {}                    # path -> the seq of the last checkpoint read or written for it
@@ -908,7 +921,7 @@ def set_checkpoint_dir(fn):
     _CKPT_DIR_FN = fn
     with _CKPT_LOCK:
         _CKPT_PENDING.clear(); _CKPT_SEQ.clear(); _FOLD_DIRTY.clear(); _CKPT_DOC_FOLDS.clear(); _DROP_OWED.clear()
-        _CKPT_CYCLE["cap"] = _CKPT_CYCLE_CAP_DEFAULT; _CKPT_CYCLE["spent"] = 0
+        _CKPT_CYCLE["cap"] = _ckpt_cycle_default_cap(); _CKPT_CYCLE["spent"] = 0
 
 
 def _ckpt_dir():
@@ -1206,6 +1219,15 @@ def checkpoint_drop_writes_on():
         return _CKPT_CYCLE["cap"] > 0
 
 
+def _pop_owed_entry(key):
+    """Release `key`'s cached entry unwritten (an owed drop paid by the pop alone), under the reader's lock only."""
+    with _JSONL_CACHE_LOCK:
+        w = _cache_pop_locked(key)
+        if w:
+            _RECORD_CACHE_STATS["dropped"] += 1
+            _RECORD_CACHE_STATS["droppedBytes"] += w
+
+
 def checkpoint_pay_owed_drops():
     """The cycle's start (T362 round one, low 2): the drops deferred for an earlier cycle's budget are paid now, oldest first,
     with the room this cycle has, since the files this serves (a returned subagent's transcript) may never be folded again and
@@ -1220,6 +1242,8 @@ def checkpoint_pay_owed_drops():
         if ent is None or not os.path.exists(key):
             with _CKPT_LOCK:
                 _DROP_OWED.pop(key, None)
+            if ent is not None:                           # the file is gone: nothing to write, everything to release (round two,
+                _pop_owed_entry(key)                      #  low 2: the memory the drop was owed for)
             continue
         _drop_quiescent_entry(key, ent, pop=True)         # takes the owed mark itself; over the budget again it re-defers
         with _CKPT_LOCK:
@@ -1861,12 +1885,16 @@ def _drop_quiescent_entry(key, ent, pop=True):
         if est <= 0:                                      # no previous document (a first write, or one the fallback removed): an
             est = max(4096, int(ent[1]) // 8)             #  estimate from the file, never a free pass against the budget
         if not checkpoint_cycle_take(2 * est):           # the previous document read for the carry, and about as much written:
-            with _CKPT_LOCK:                              #  taken in one step, or deferred (the drop owed) when it does not fit
+            oldest = None                                 #  taken in one step, or deferred (the drop owed) when it does not fit
+            with _CKPT_LOCK:
                 _CKPT_STATS["converge"]["dropDeferred"] += 1
                 if pop:
                     _DROP_OWED[key] = time.time()
-                    if len(_DROP_OWED) > 4096:            # bounded like its neighbours; the reader's own budget still frees entries
-                        _DROP_OWED.clear()
+                    if len(_DROP_OWED) > _DROP_OWED_MAX:  # over the bound the OLDEST owed drop is paid by its pop alone (round
+                        oldest = next(iter(_DROP_OWED))   #  two, low 1: a cleared mark left its entry neither paid nor popped)
+                        _DROP_OWED.pop(oldest, None)
+            if oldest is not None:
+                _pop_owed_entry(oldest)                   # outside _CKPT_LOCK: the reader's lock alone
             return
         if checkpoint_write(key):
             try:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9823,7 +9823,9 @@ except Exception:
 _CKPT_SETTLE_SEEN = {}          # sid -> (turn-end key, states-log stat) at the last checkpoint write of its files
 _CKPT_PERIODIC_SEEN = {}        # sid -> (leaf stat, monotonic time) at the last PERIODIC write (see _persist_checkpoints)
 CKPT_PERIOD_S = float(os.environ.get("ROMP_CKPT_PERIOD_S", "30"))   # a session mid-turn for hours writes at least this often
-CKPT_CONVERGE_MS = float(os.environ.get("ROMP_CKPT_CONVERGE_MS", "150"))          # the converge pass's wall budget per pusher cycle (T360)
+CKPT_CONVERGE_MS = em._CKPT_CONVERGE_MS_DEFAULT   # the converge pass's wall budget per pusher cycle (T360); 0 turns the pass off and the
+#                                                    quiescence drop's write with it (T362); the event model reads the knob so both reach
+#                                                    the drop before the first cycle begins
 CKPT_CONVERGE_BYTES = em._CKPT_CYCLE_CAP_DEFAULT   # ...and its bytes (documents written plus leaves read for a heal), the cycle budget the
 #                                                     quiescence drop's writes share (T362); 0 turns those writes off too (the drop then pops as before)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9824,7 +9824,8 @@ _CKPT_SETTLE_SEEN = {}          # sid -> (turn-end key, states-log stat) at the 
 _CKPT_PERIODIC_SEEN = {}        # sid -> (leaf stat, monotonic time) at the last PERIODIC write (see _persist_checkpoints)
 CKPT_PERIOD_S = float(os.environ.get("ROMP_CKPT_PERIOD_S", "30"))   # a session mid-turn for hours writes at least this often
 CKPT_CONVERGE_MS = float(os.environ.get("ROMP_CKPT_CONVERGE_MS", "150"))          # the converge pass's wall budget per pusher cycle (T360)
-CKPT_CONVERGE_BYTES = int(float(os.environ.get("ROMP_CKPT_CONVERGE_MB", "8")) * 1024 * 1024)   # ...and its bytes (documents written plus leaves read for a heal)
+CKPT_CONVERGE_BYTES = em._CKPT_CYCLE_CAP_DEFAULT   # ...and its bytes (documents written plus leaves read for a heal), the cycle budget the
+#                                                     quiescence drop's writes share (T362); 0 turns those writes off too (the drop then pops as before)
 
 
 def _session_fold_files(sid, leaf):
@@ -9908,6 +9909,16 @@ def _stored_tree(path, sid):
 _CKPT_JUST_WRITTEN = set()          # the paths the settle write took this cycle; the converge pass skips them (T360 review, low 4)
 
 
+def _begin_checkpoint_cycle():
+    """The pusher cycle's START (T362 round one, lows 2 and 3): the cycle's checkpoint byte budget is whole again, shared by the
+    builds' quiescence-drop writes and the converge pass near the cycle's end (the boot's first builds are capped where the
+    volume is; before, the pass began the cycle and the first cycle's drops ran uncapped), and the drops an earlier cycle
+    deferred are paid with this cycle's room, oldest first, no fold over their files needed. The pass's off switch
+    (ROMP_CKPT_CONVERGE_MS=0) covers the drop write: the cycle begins with no budget, and the drop pops as before T362."""
+    em.checkpoint_cycle_begin(CKPT_CONVERGE_BYTES if CKPT_CONVERGE_MS > 0 else 0)
+    em.checkpoint_pay_owed_drops()
+
+
 def _converge_checkpoints(now):
     """The converge pass (T360), one per pusher cycle after the settle writes: the dirty documents that lack a complete
     state this process now holds (em.checkpoint_converge_candidates: a fold missing from the document because it never ran
@@ -9919,7 +9930,6 @@ def _converge_checkpoints(now):
     no read), so one write carries all five. For another file a tail-only cursor is dropped so the write leaves it out and
     its next run reads the small file whole once. A document already carrying every fold that ran is never a candidate,
     so an idle session's document is written once and then left alone. Returns the documents written."""
-    em.checkpoint_cycle_begin(CKPT_CONVERGE_BYTES)         # the cycle's checkpoint byte budget, shared with the quiescence drop (T362)
     if CKPT_CONVERGE_MS <= 0 or not em.checkpoint_has_work():
         _CKPT_JUST_WRITTEN.clear()
         return 0                                           # off (ROMP_CKPT_CONVERGE_MS=0), or nothing dirty and nothing cold: a quiet
@@ -48642,6 +48652,10 @@ def _pusher_cycle():
 
 def _pusher_cycle_jobs(now, live_map, any_client):
     _t_jobs = time.monotonic()            # /perf: this function minus the _push_all below is the `jobs` stage
+    try:                                  # the cycle's checkpoint byte budget, whole again, and the drops owed from the last one
+        _begin_checkpoint_cycle()         # (T362): before the builds below, whose quiescence drops write against it
+    except Exception:
+        sys.stderr.write("checkpoint-cycle: %s\n" % traceback.format_exc())
     _t_push = 0.0
     try:                                  # parked ops deliver on the settle EVENT this cycle was woken for
         _apply_pending_ops()              # (_wake_kernel, /tick, a park/cancel/move, the 0.5 s backstop) —

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9919,6 +9919,7 @@ def _converge_checkpoints(now):
     no read), so one write carries all five. For another file a tail-only cursor is dropped so the write leaves it out and
     its next run reads the small file whole once. A document already carrying every fold that ran is never a candidate,
     so an idle session's document is written once and then left alone. Returns the documents written."""
+    em.checkpoint_cycle_begin(CKPT_CONVERGE_BYTES)         # the cycle's checkpoint byte budget, shared with the quiescence drop (T362)
     if CKPT_CONVERGE_MS <= 0 or not em.checkpoint_has_work():
         _CKPT_JUST_WRITTEN.clear()
         return 0                                           # off (ROMP_CKPT_CONVERGE_MS=0), or nothing dirty and nothing cold: a quiet
@@ -9928,9 +9929,9 @@ def _converge_checkpoints(now):
         return 0
     em.converge_stat("passes")
     leaves = {str(s.get("path")) for s in _sessions(now) if s.get("path")}
-    t0 = time.monotonic(); spent = 0; n = 0
+    t0 = time.monotonic(); n = 0
     for i, p in enumerate(cands):
-        if i and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or spent > CKPT_CONVERGE_BYTES):
+        if i and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or not em.checkpoint_cycle_room(0)):
             em.converge_stat("deferred", len(cands) - i)   # gated on candidates PROCESSED, not documents written: a first
             break                                          #  candidate that writes nothing must not lift the budget (review)
         if p in leaves and em.file_quiescent(p):           # T361 (the live loop): a leaf unchanged past the reader's quiescence
@@ -9943,7 +9944,7 @@ def _converge_checkpoints(now):
             healed = _heal_cold_folds(p)                   # drops every tail-only cursor, reruns the five leaf folds
             if healed:
                 got = _read_bytes_of(p) - before
-                em.converge_stat("heals", len(healed)); em.converge_stat("healBytes", got); spent += got
+                em.converge_stat("heals", len(healed)); em.converge_stat("healBytes", got); em.checkpoint_cycle_charge(got)
             unhealed = [k for k in cold if k not in healed]
             if em.entry_whole_resident(p) and _prime_leaf_folds(p):
                 em.converge_stat("primed")
@@ -9956,21 +9957,24 @@ def _converge_checkpoints(now):
         except (OSError, AttributeError):
             pre = 0
         if pre:
-            em.converge_stat("docReadBytes", pre); spent += pre
+            em.converge_stat("docReadBytes", pre); em.checkpoint_cycle_charge(pre)
         if em.checkpoint_write(p):                         #  run reads the file whole once, and the path is no candidate for it
             n += 1
             try:
                 size = em._ckpt_file(p).stat().st_size
             except OSError:
                 size = 0
-            em.converge_stat("writes"); em.converge_stat("bytes", size); spent += size
+            em.converge_stat("writes"); em.converge_stat("bytes", size); em.checkpoint_cycle_charge(size)
         else:
             em.converge_stat("failed"); _converge_skip(p)  # nothing to write, or the write failed: not again until the file changes
     return n
 
 
-_CONVERGE_SKIP = {}                 # path -> the file's (mtime_ns, size) when the pass last refused or failed it (T361): the path is
-#                                     no candidate until that changes, so a refusal is one per file state, never one per cycle
+_CONVERGE_SKIP = {}                 # path -> [the file's (mtime_ns, size) when the pass last refused or failed it, the reader's own
+#                                     entry stamp (mtime, size) then, counted] (T361):
+#                                     the path is no candidate until that changes, so a refusal is one per file state, never one per
+#                                     cycle; `skipped` counts once per (path, file state) too (T362 low), and while the reader holds
+#                                     the file's entry the check reads that entry's stamp, no stat
 
 
 def _stat_key_ns(p):
@@ -9982,18 +9986,32 @@ def _stat_key_ns(p):
 
 
 def _converge_skip(p):
-    _CONVERGE_SKIP[p] = _stat_key_ns(p)
+    _CONVERGE_SKIP[p] = [_stat_key_ns(p), _entry_stamp(p), False]
     if len(_CONVERGE_SKIP) > 4096:
         _CONVERGE_SKIP.clear()
 
 
+def _entry_stamp(p):
+    """The file's (mtime, size) as the reader's own entry records it, when the reader holds one; None otherwise."""
+    with em._JSONL_CACHE_LOCK:
+        ent = em._JSONL_CACHE.get(p)
+    return None if ent is None else (ent[0], ent[1])
+
+
 def _converge_skipped(p):
-    """True while the file stands as it did when the pass last refused or failed it."""
-    k = _CONVERGE_SKIP.get(p)
-    if k is None:
+    """True while the file stands as it did when the pass last refused or failed it: the reader's entry says so without a stat
+    when it holds one (a stat only for a file the reader let go; an entry no fold has refreshed since an append holds the
+    skip too, and rightly: the process then holds nothing newer to write), and `skipped` counts the hold once, not every
+    cycle."""
+    row = _CONVERGE_SKIP.get(p)
+    if row is None:
         return False
-    if _stat_key_ns(p) == k:
-        em.converge_stat("skipped")
+    stamp = _entry_stamp(p)
+    held = (stamp is not None and stamp == row[1]) or _stat_key_ns(p) == row[0]
+    if held:
+        if not row[2]:
+            row[2] = True
+            em.converge_stat("skipped")
         return True
     _CONVERGE_SKIP.pop(p, None)
     return False

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -922,9 +922,11 @@ class KernelFolds(Base):
         self.assertEqual(sorted(em.checkpoint_converge_candidates()), sorted([self.leaf, leaf2]))
         saved = km.CKPT_CONVERGE_BYTES; km.CKPT_CONVERGE_BYTES = 1
         self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved)
+        km._begin_checkpoint_cycle()                                  # the cycle's start hands the pass its budget (T362)
         self.assertEqual(km._converge_checkpoints(TS0 + 600), 1, "the first always writes; the budget stops the second")
         self.assertEqual(em.checkpoint_stats()["converge"]["deferred"], 1)
         self.assertEqual(len(em.checkpoint_converge_candidates()), 1)
+        km._begin_checkpoint_cycle()
         self.assertEqual(km._converge_checkpoints(TS0 + 601), 1, "the next pass takes it")
         self.assertEqual(em.checkpoint_converge_candidates(), [])
 
@@ -1244,33 +1246,127 @@ class KernelFolds(Base):
 
     def test_the_agent_files_gist_drop_writes_its_document_too(self):
         self._converge_world({}, quiescent=True)
-        d = self.doc(self.agent); d["folds"].pop("agentGist", None); em._ckpt_file(self.agent).write_text(json.dumps(d))
         old = time.time() - 600; os.utime(self.agent, (old, old))
+        d = self.doc(self.agent); d["folds"].pop("agentGist", None); d["mtime"] = os.stat(self.agent).st_mtime   # the idle file's
+        em._ckpt_file(self.agent).write_text(json.dumps(d))                                                     #  document, as written
         self.fresh_process()
         km._agent_steps(self.agent)                                   # a whole read (no document entry), then the drop writes
         self.assertIn("state", self.doc(self.agent)["folds"].get("agentGist", {}))
         self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
 
-    def test_a_drop_over_the_cycles_byte_budget_is_deferred_with_the_entry_held(self):
-        """The budget is shared with the converge pass: over it, the drop is deferred by one cycle (the entry stays, the read is
-        not lost), counted; the next cycle writes and pops."""
+    def test_a_drop_over_the_cycles_byte_budget_is_deferred_and_paid_by_the_next_cycles_start(self):
+        """The budget is shared with the converge pass: over it, the write and the drop are deferred (the entry stays, the read
+        is not lost), counted. Round one, low 2: the population this serves (a returned subagent's transcript) is never folded
+        again, so the drop owed is paid at the next cycle's START with the room that cycle has, oldest first, no fold needed;
+        an owed path whose file is gone is forgotten."""
         self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        old = time.time() - 600; os.utime(self.agent, (old, old))
+        d = self.doc(self.agent); d["folds"].pop("agentGist", None); d["mtime"] = os.stat(self.agent).st_mtime
+        em._ckpt_file(self.agent).write_text(json.dumps(d))
         jd._bg_scan(self.leaf)
         saved = km.CKPT_CONVERGE_BYTES; km.CKPT_CONVERGE_BYTES = 1
         self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved)
-        km._converge_checkpoints(TS0 + 600)                           # the cycle begins with a one-byte budget (the pass refuses the quiescent leaf)
-        km._agent_launch_state(self.leaf)
+        km._begin_checkpoint_cycle()                                  # the cycle begins with a one-byte budget
+        km._agent_launch_state(self.leaf); km._agent_steps(self.agent)
         with em._JSONL_CACHE_LOCK:
             self.assertIsNotNone(em._JSONL_CACHE.get(self.leaf), "deferred: the entry is held")
         cv = em.checkpoint_stats()["converge"]
-        self.assertEqual((cv["dropWrites"], cv["dropDeferred"]), (0, 1))
+        self.assertEqual((cv["dropWrites"], cv["dropDeferred"]), (0, 2))
+        self.assertEqual(list(em._DROP_OWED), [self.leaf, self.agent], "owed, oldest first")
+        km._begin_checkpoint_cycle()                                  # still a one-byte budget: held again, counted again
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropDeferred"], 4)
+        os.unlink(self.agent)
         km.CKPT_CONVERGE_BYTES = saved
-        km._converge_checkpoints(TS0 + 601)                           # the next cycle begins with the normal budget
-        km._agent_launch_state(self.leaf)
-        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
+        km._begin_checkpoint_cycle()                                  # the next cycle's start pays what is owed: no fold over the file
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["dropWrites"], cv["dropDeferred"]), (1, 4))
         self.assertIn("bgJudge", self.doc(self.leaf)["folds"])
         with em._JSONL_CACHE_LOCK:
             self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "written, then popped")
+        self.assertEqual(list(em._DROP_OWED), [], "paid, and the deleted file's path forgotten")
+        import inspect
+        src = inspect.getsource(km._pusher_cycle_jobs)
+        self.assertLess(src.index("_begin_checkpoint_cycle()"), src.index("_push_all("), "the cycle's budget begins before its builds")
+        self.assertNotIn("checkpoint_cycle_begin", inspect.getsource(km._converge_checkpoints), "the pass shares the cycle, it does not begin it")
+
+    def test_the_cycle_budget_stands_before_the_first_cycle_begins(self):
+        """Round one, low 3: the boot's first cycle charged no budget (no cap until the pass, near the cycle's end, began one), so
+        the drops this change exists for were uncapped where the volume is. The default cap stands from import and after a
+        fresh process, and the kernel's knob is that default."""
+        self.assertEqual(em._CKPT_CYCLE_CAP_DEFAULT, km.CKPT_CONVERGE_BYTES)
+        self.fresh_process()
+        self.assertTrue(em.checkpoint_cycle_take(1)); self.assertFalse(em.checkpoint_cycle_take(em._CKPT_CYCLE_CAP_DEFAULT))
+
+    def test_the_pass_off_switch_covers_the_drop_write(self):
+        """Round one, low 4: ROMP_CKPT_CONVERGE_MS=0 stopped the pass and not the drop write. Off, the drop pops as before T362:
+        no write, no deferral, no held entry."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf); seq = self.doc(self.leaf)["seq"]
+        saved = km.CKPT_CONVERGE_MS; km.CKPT_CONVERGE_MS = 0.0
+        self.addCleanup(setattr, km, "CKPT_CONVERGE_MS", saved)
+        km._begin_checkpoint_cycle(); km._agent_launch_state(self.leaf)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "popped, not held")
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["dropWrites"], cv["dropDeferred"], self.doc(self.leaf)["seq"]), (0, 0, seq))
+
+    def test_a_zero_byte_budget_pops_without_holding(self):
+        """Round one, low 4: ROMP_CKPT_CONVERGE_MB=0 deferred every drop and HELD the entries, worse than a no-op."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf); seq = self.doc(self.leaf)["seq"]
+        saved = km.CKPT_CONVERGE_BYTES; km.CKPT_CONVERGE_BYTES = 0
+        self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved)
+        km._begin_checkpoint_cycle(); km._agent_launch_state(self.leaf)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "popped, not held")
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["dropWrites"], cv["dropDeferred"], self.doc(self.leaf)["seq"]), (0, 0, seq))
+
+    def test_a_stateless_document_cursor_never_replaces_a_held_state_after_the_drop(self):
+        """Round one, medium: after the drop popped the entry, the next fold's stale-generation restore took the document's cursor
+        even without a state (an over-cap, cold or bare legacy write), so a complete state this process held was replaced by a
+        tail-only one that answered empty, forever (the pass refuses a quiescent leaf, an idle session never settles for the
+        heal; 9 of 481 live documents carry such a cursor). A stateless document cursor against a held state is refused: the
+        fold reads whole and answers what it held, as before."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf)
+        held = km._agent_launch_state(self.leaf)                      # the refold's answer; the drop writes and pops
+        self.assertTrue(held["launched"], "the fixture's leaf holds a launch")
+        d = self.doc(self.leaf); d["folds"]["agentLaunches"] = {"count": d["folds"]["agentLaunches"]["count"]}   # a bare legacy cursor
+        em._ckpt_file(self.leaf).write_text(json.dumps(d))
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf))
+        read0 = em.read_bytes_report().get(self.leaf, 0); size = os.path.getsize(self.leaf)
+        again = km._agent_launch_state(self.leaf)
+        self.assertEqual(again["launched"], held["launched"], "the held launch, not an empty tail-only state")
+        self.assertGreaterEqual(em.read_bytes_report().get(self.leaf, 0) - read0, size, "read whole, as the base did")
+        self.assertEqual(km._agent_launch_state(self.leaf)["launched"], held["launched"], "and it stays")
+
+    def test_the_post_drop_fold_answers_from_the_document_over_a_tail_read(self):
+        """Round one, low 5: the fold after a drop takes its cursor from the DOCUMENT (a state planted there is the answer) over a
+        tail read, and writes nothing."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf); km._agent_launch_state(self.leaf)   # written, popped
+        d = self.doc(self.leaf)
+        d["folds"]["agentLaunches"]["state"] = em._ckpt_encode({"launched": {"planted": {"t": 1}}, "settled": set()})
+        em._ckpt_file(self.leaf).write_text(json.dumps(d))
+        read0 = em.read_bytes_report().get(self.leaf, 0); size = os.path.getsize(self.leaf)
+        self.assertEqual(km._agent_launch_state(self.leaf)["launched"], {"planted": {"t": 1}}, "the document's cursor is the fold's answer")
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0) - read0, size / 2, "over a tail read")
+        self.assertEqual((em.checkpoint_stats()["converge"]["dropWrites"], self.doc(self.leaf)["seq"]), (1, d["seq"]), "and no rewrite")
+
+    def test_a_cold_fold_at_the_drop_is_not_rewritten_every_fold(self):
+        """Round one, low 1: the rule stayed true forever for a fold cold for want of a state, so a quiescent file whose document
+        held the dropping fold's cursor without a state was rewritten at every fold (seq 2, 3, 4). A write that cannot improve
+        the document (the cold fold is written cold again) is not needed; the fold is left for the heal."""
+        self._converge_world({"agentLaunches": "bare"}, quiescent=True)
+        km._session_meta(self.leaf)                                   # the boot: the tail
+        seq = self.doc(self.leaf)["seq"]
+        for k in range(3):
+            km._begin_checkpoint_cycle(); km._agent_launch_state(self.leaf); km._converge_checkpoints(TS0 + 600 + k)
+        self.assertEqual(em.cold_fold_reasons(self.leaf), {"agentLaunches": "cold"}, "restored cold at the cut, left for the heal")
+        self.assertEqual((self.doc(self.leaf)["seq"], em.checkpoint_stats()["converge"]["dropWrites"]), (seq, 0),
+                         "nothing to improve on the document: no write")
 
     def test_one_rule_for_the_writer_the_carry_the_candidates_and_the_drop(self):
         import inspect
@@ -1281,6 +1377,7 @@ class KernelFolds(Base):
         self.assertIn("_cursor_recordable(", inspect.getsource(em._path_needs_write))
         src = inspect.getsource(em._drop_quiescent_entry)
         self.assertLess(src.index("checkpoint_write("), src.index("with _JSONL_CACHE_LOCK"), "the write before the reader's lock")
+        self.assertIn("checkpoint_cycle_take(", src); self.assertNotIn("checkpoint_cycle_room(", src)   # the room check and the charge are one step
 
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1114,11 +1114,20 @@ class KernelFolds(Base):
         for k in range(3):
             self.assertEqual(km._converge_checkpoints(TS0 + 600 + k), 0)
         cv = em.checkpoint_stats()["converge"]
-        self.assertEqual((cv["quiescent"], cv["skipped"], cv["heals"], cv["writes"], cv["failed"]), (1, 2, 0, 0, 0), "refused once, skipped twice: %s" % cv)
+        self.assertEqual((cv["quiescent"], cv["skipped"], cv["heals"], cv["writes"], cv["failed"]), (1, 1, 0, 0, 0),
+                         "refused once, the hold counted once for the file's state, not per cycle: %s" % cv)
         self.assertEqual(em.read_bytes_report().get(self.leaf, 0), read0, "the pass read nothing of the leaf")
         self.assertEqual(em.cold_fold_reasons(self.leaf), {"bgAll": "cold"}, "left for the boot's cold refold or the next settle")
-        _append(self.leaf, _user("a new prompt", "u_new", "a3", TS0 + 700))   # the file changes: the pass may look again
-        self.assertFalse(km._converge_skipped(self.leaf))
+        saved = km._stat_key_ns
+        km._stat_key_ns = lambda p: self.fail("the held entry's stamp answers: no stat while the reader holds the file")
+        try:
+            self.assertTrue(km._converge_skipped(self.leaf), "stat-free while the reader's entry stands")
+        finally:
+            km._stat_key_ns = saved
+        _append(self.leaf, _user("a new prompt", "u_new", "a3", TS0 + 700))   # the file changes
+        self.assertTrue(km._converge_skipped(self.leaf), "held until the reader sees the change: no fold has looked, nothing new to write")
+        km._session_meta(self.leaf)                                       # a fold re-reads it: the entry's stamp moved
+        self.assertFalse(km._converge_skipped(self.leaf), "the pass may look again")
 
     def test_converge_skips_a_path_whose_write_failed_until_its_file_changes(self):
         """T361 (b): a failed write must not repeat every cycle."""
@@ -1153,6 +1162,125 @@ class KernelFolds(Base):
         self.addCleanup(setattr, km, "CKPT_CONVERGE_MS", saved)
         self.assertEqual(km._converge_checkpoints(TS0 + 600), 0)
         self.assertEqual(em.checkpoint_stats()["converge"]["passes"], 0, "no pass counted: off")
+
+    def _lock_free_write(self):
+        """checkpoint_write wrapped to assert neither the reader's lock nor the checkpoint lock is held by the caller (T362: the
+        drop must call the write outside _JSONL_CACHE_LOCK, no inversion with the reader's own lock on another thread)."""
+        real = em.checkpoint_write
+        seen = []
+        def wrapped(path, force=False):
+            for name in ("_JSONL_CACHE_LOCK", "_CKPT_LOCK"):
+                lock = getattr(em, name)
+                got = lock.acquire(blocking=False)
+                seen.append((name, got))
+                if got:
+                    lock.release()
+            return real(path, force)
+        em.checkpoint_write = wrapped
+        self.addCleanup(setattr, em, "checkpoint_write", real)
+        return seen
+
+    def test_the_quiescence_drop_writes_the_document_from_the_boots_own_read(self):
+        """T362: an idle leaf (unchanged past the reader's quiescence window) whose document lacks the judges' pairing. The boot's
+        first pass reads it whole; the next quiescent-drop fold over it (the leaf's agent-launch state) writes the document
+        BEFORE popping the entry, so every leaf fold is recorded from a read that already happened, no heal on the cycle. The
+        entry is gone after; the next boot restores the pairing warm and reads the tail only. The document lacks the launch
+        state too (the live shape: both missing from most idle documents), so the fold refolds and the drop pops."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        size = os.path.getsize(self.leaf)
+        jd._bg_scan(self.leaf)                                        # the boot's read: whole, the path dirty
+        self.assertGreaterEqual(em.read_bytes_report().get(self.leaf, 0), size)
+        seen = self._lock_free_write()
+        km._agent_launch_state(self.leaf)                             # a drop_after="quiescent" fold over the idle leaf
+        self.assertTrue(seen and all(got for _, got in seen), "the drop calls the write holding neither lock: %s" % seen)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "the entry left memory after the write")
+        d = self.doc(self.leaf)
+        self.assertEqual(sorted(d["folds"]), ["agentLaunches", "bgAll", "bgJudge", "bgRunning", "sessionMeta"], "written from the read that already happened")
+        self.assertTrue(all("state" in f for f in d["folds"].values()))
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["dropWrites"], cv["dropDeferred"]), (1, 0))
+        self.assertEqual(em.checkpoint_converge_candidates(), [], "the pass finds nothing to do")
+        read1 = em.read_bytes_report().get(self.leaf, 0)
+        km._agent_launch_state(self.leaf)                             # a later drop over the unchanged whole document
+        self.assertEqual(self.doc(self.leaf)["seq"], d["seq"], "idempotent: never rewritten at a later drop")
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0) - read1, size / 2, "and no whole read for it")
+        self.fresh_process()
+        before = em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0)
+        jd._bg_scan(self.leaf)
+        self.assertEqual(em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0), before + 1, "the next boot restores the pairing warm")
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2, "and reads the tail only")
+
+    def test_a_fold_restored_at_the_witness_writes_the_document_and_keeps_the_entry(self):
+        """The document carries the launch state but lacks the pairing: the launch fold restores at the witness and steps nothing,
+        the path the fold returns from before the pop (the entry stays, as it always has there). The write still runs, from
+        the whole entry the judges' pass left, so the pairing converges for this shape too."""
+        self._converge_world({"bgJudge": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf)
+        seen = self._lock_free_write()
+        km._agent_launch_state(self.leaf)
+        self.assertTrue(seen and all(got for _, got in seen), "the write is called holding neither lock: %s" % seen)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNotNone(em._JSONL_CACHE.get(self.leaf), "nothing stepped: the entry stays")
+        d = self.doc(self.leaf)
+        self.assertIn("state", d["folds"].get("bgJudge", {}), "the pairing written from the read that already happened")
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
+        km._agent_launch_state(self.leaf)
+        self.assertEqual(self.doc(self.leaf)["seq"], d["seq"], "a hit at the witness over a whole document: no write")
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
+
+    def test_the_drop_writes_once_more_after_an_append_and_a_new_quiescence(self):
+        self._converge_world({"bgJudge": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf); km._agent_launch_state(self.leaf)
+        seq = self.doc(self.leaf)["seq"]
+        _append(self.leaf, _user("a new prompt", "u_new", "a3", TS0 + 700))
+        km._session_meta(self.leaf); km._agent_launch_state(self.leaf)   # fresh again: no drop, no write
+        self.assertEqual(self.doc(self.leaf)["seq"], seq, "a changing file is not dropped, so not written here")
+        old = time.time() - 600; os.utime(self.leaf, (old, old))       # quiescent once more, its folds stepped since the write
+        km._session_meta(self.leaf); km._agent_launch_state(self.leaf)
+        self.assertEqual(self.doc(self.leaf)["seq"], seq + 1, "one more write at the next drop")
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 2)
+
+    def test_the_agent_files_gist_drop_writes_its_document_too(self):
+        self._converge_world({}, quiescent=True)
+        d = self.doc(self.agent); d["folds"].pop("agentGist", None); em._ckpt_file(self.agent).write_text(json.dumps(d))
+        old = time.time() - 600; os.utime(self.agent, (old, old))
+        self.fresh_process()
+        km._agent_steps(self.agent)                                   # a whole read (no document entry), then the drop writes
+        self.assertIn("state", self.doc(self.agent)["folds"].get("agentGist", {}))
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
+
+    def test_a_drop_over_the_cycles_byte_budget_is_deferred_with_the_entry_held(self):
+        """The budget is shared with the converge pass: over it, the drop is deferred by one cycle (the entry stays, the read is
+        not lost), counted; the next cycle writes and pops."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf)
+        saved = km.CKPT_CONVERGE_BYTES; km.CKPT_CONVERGE_BYTES = 1
+        self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved)
+        km._converge_checkpoints(TS0 + 600)                           # the cycle begins with a one-byte budget (the pass refuses the quiescent leaf)
+        km._agent_launch_state(self.leaf)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNotNone(em._JSONL_CACHE.get(self.leaf), "deferred: the entry is held")
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["dropWrites"], cv["dropDeferred"]), (0, 1))
+        km.CKPT_CONVERGE_BYTES = saved
+        km._converge_checkpoints(TS0 + 601)                           # the next cycle begins with the normal budget
+        km._agent_launch_state(self.leaf)
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 1)
+        self.assertIn("bgJudge", self.doc(self.leaf)["folds"])
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "written, then popped")
+
+    def test_one_rule_for_the_writer_the_carry_the_candidates_and_the_drop(self):
+        import inspect
+        self.assertIn("_cursor_recordable(", inspect.getsource(em.checkpoint_write))
+        self.assertIn("_count_recordable(", inspect.getsource(em._carry_forward_states))
+        self.assertIn("_path_needs_write(", inspect.getsource(em.checkpoint_converge_candidates))
+        self.assertIn("_path_needs_write(", inspect.getsource(em._drop_quiescent_entry))
+        self.assertIn("_cursor_recordable(", inspect.getsource(em._path_needs_write))
+        src = inspect.getsource(em._drop_quiescent_entry)
+        self.assertLess(src.index("checkpoint_write("), src.index("with _JSONL_CACHE_LOCK"), "the write before the reader's lock")
 
     def test_perf_carries_the_checkpoint_counters_and_the_kernel_wires_the_three_events(self):
         snap = km._PERF_STATS.snapshot()

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1276,6 +1276,8 @@ class KernelFolds(Base):
         km._begin_checkpoint_cycle()                                  # still a one-byte budget: held again, counted again
         self.assertEqual(em.checkpoint_stats()["converge"]["dropDeferred"], 4)
         os.unlink(self.agent)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNotNone(em._JSONL_CACHE.get(self.agent), "the deleted file's entry is still held")
         km.CKPT_CONVERGE_BYTES = saved
         km._begin_checkpoint_cycle()                                  # the next cycle's start pays what is owed: no fold over the file
         cv = em.checkpoint_stats()["converge"]
@@ -1283,11 +1285,42 @@ class KernelFolds(Base):
         self.assertIn("bgJudge", self.doc(self.leaf)["folds"])
         with em._JSONL_CACHE_LOCK:
             self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "written, then popped")
+            self.assertIsNone(em._JSONL_CACHE.get(self.agent), "the deleted file's entry released by the payment (round two, low 2)")
         self.assertEqual(list(em._DROP_OWED), [], "paid, and the deleted file's path forgotten")
         import inspect
         src = inspect.getsource(km._pusher_cycle_jobs)
         self.assertLess(src.index("_begin_checkpoint_cycle()"), src.index("_push_all("), "the cycle's budget begins before its builds")
         self.assertNotIn("checkpoint_cycle_begin", inspect.getsource(km._converge_checkpoints), "the pass shares the cycle, it does not begin it")
+
+    def test_the_owed_tables_overflow_pops_the_oldest_owed_entry(self):
+        """Round two, low 1: over the bound the table was cleared, leaving those entries neither paid nor popped. The oldest owed
+        drop is paid by its pop alone instead."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        old = time.time() - 600; os.utime(self.agent, (old, old))
+        d = self.doc(self.agent); d["folds"].pop("agentGist", None); d["mtime"] = os.stat(self.agent).st_mtime
+        em._ckpt_file(self.agent).write_text(json.dumps(d))
+        jd._bg_scan(self.leaf)
+        saved = (km.CKPT_CONVERGE_BYTES, em._DROP_OWED_MAX); km.CKPT_CONVERGE_BYTES = 1; em._DROP_OWED_MAX = 1
+        self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved[0]); self.addCleanup(setattr, em, "_DROP_OWED_MAX", saved[1])
+        km._begin_checkpoint_cycle()
+        km._agent_launch_state(self.leaf)                             # owed: the leaf
+        km._agent_steps(self.agent)                                   # owed: the agent file; the table overflows, the leaf is popped
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "the oldest owed entry released")
+            self.assertIsNotNone(em._JSONL_CACHE.get(self.agent), "the newest still owed and held")
+        self.assertEqual(list(em._DROP_OWED), [self.agent])
+        self.assertEqual(em.checkpoint_stats()["converge"]["dropWrites"], 0, "unwritten: the budget was gone")
+
+    def test_the_knobs_reach_the_drop_write_before_the_first_cycle(self):
+        """Round two, low 3: before the first pusher cycle the drop write was on whatever the knobs said. The event model reads
+        the knobs, and the kernel's constants are those reads."""
+        self.assertEqual(km.CKPT_CONVERGE_MS, em._CKPT_CONVERGE_MS_DEFAULT)
+        saved = em._CKPT_CONVERGE_MS_DEFAULT; em._CKPT_CONVERGE_MS_DEFAULT = 0.0
+        self.addCleanup(setattr, em, "_CKPT_CONVERGE_MS_DEFAULT", saved)
+        self.fresh_process()                                          # a process that has begun no cycle
+        self.assertFalse(em.checkpoint_drop_writes_on(), "the pass off: the drop write off before any cycle")
+        em._CKPT_CONVERGE_MS_DEFAULT = saved; self.fresh_process()
+        self.assertTrue(em.checkpoint_drop_writes_on())
 
     def test_the_cycle_budget_stands_before_the_first_cycle_begins(self):
         """Round one, low 3: the boot's first cycle charged no budget (no cap until the pass, near the cycle's end, began one), so


### PR DESCRIPTION
Fix tier. After the fold-checkpoint work of 2026-09-11 (lagging folds, the converge pass, the pass's refusal of quiescent leaves) the boot still read about 2.3 GB of leaves whole and its first pusher cycle took about 60 s: idle sessions' documents lacked folds (the judges' pairing missing from 38 of 60 leaf documents, the agent-launch state from 46) and nothing ever rewrote them, since no settle reaches an idle session and the pass must refuse a quiescent leaf (its heal re-read the leaf whole every cycle).

**The change:** the fold that drops a quiescent file's records from the reader's cache writes the file's checkpoint first, from the entry already in memory (the boot's own read), whenever the document on disk lacks something this process holds.

- `_path_needs_write` is the one rule for the writer, the carry, the candidate check and the drop, with a source test pinning all four callers. A dirty path counts for the drop only (a live leaf is dirty every turn and is written at its settle).
- The write runs on every path a quiescent-drop fold ends on: after a refold (the entry is then popped as before), and on a hit or a restore at the witness (the entry stays, as it always has there). Before, that second path returned before the drop, so a document carrying the launch state but lacking the pairing was never written.
- Lock order: the write is called holding neither `_CKPT_LOCK` nor `_JSONL_CACHE_LOCK` (it takes both itself); the pop takes the reader's lock alone afterwards. Pinned by a wrapped write that acquires both locks non-blocking, and by source order.
- The cycle's checkpoint byte budget (`ROMP_CKPT_CONVERGE_MB`, 8 MiB) is shared between the converge pass and the drop's writes; over the budget the drop is deferred one cycle with the entry held (`converge.dropDeferred`), owed to the next fold over the file. `converge.dropWrites` counts the writes.
- A fold whose cursor's entry generation went stale (the entry left memory) consults the document's restore before refolding, so a dropped file's next fold is a tail read, not a whole one, and the drop write is idempotent: a whole document is never rewritten at a later drop.
- The pass's `skipped` counter counts once per (path, file state), and the per-cycle check reads the reader's own entry stamp instead of a stat while an entry is held.

**Cost:** on a fixture with a 242 KB document plus a carried state (every write reads the previous document), 1.2 to 1.7 ms per drop write. The devbox's worst first minute is about 60 documents, most far smaller, under 0.1 s of wall and about 15 MB written, spread over the builds that touch the leaves and capped per cycle by the shared budget.

**Tests:** `tests/test_fold_checkpoints.py` (the drop write on both paths, idempotence and the next boot's warm restore, the agent file's gist fold, the deferred and owed drop, the one-rule and lock-order pins, the skip count once per file state and stat-free). Full Python suite green locally (12,458 passed).

**Measurement after deploy:** the document census to zero over two boots, the first cycle from 62.9 s, `converge.quiescent` to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)