### PR TITLE
A window nobody navigated to never detaches an attached reader, no older-history ask on a downward move, and the paused strip names the navigation that detached (T366)

### DIFF
--- a/tests/test_kernel_delta_send.py
+++ b/tests/test_kernel_delta_send.py
@@ -169,7 +169,9 @@ class RenderHandlesTheTail(unittest.TestCase):
         self.assertIn("headFrom: kept && prev ? prev.headFrom : (msg.headFrom ?? 0),", r)
         # scroll to the top of the resident tail with older on the server → request the previous chunk
         self.assertIn('vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.proto === 2 ? s.firstUuid : s.headFrom });', r)
-        self.assertIn("if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx) { requestOlder(", r)
+        # …only on an upward or unchanged move of the view (T366: a downward flick inside the estimate's top band never asks)
+        self.assertIn("const upward = olderRequestAllowed(v.edgeTop, st);", r)
+        self.assertIn("if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx && upward) { requestOlder(", r)
         # chatHead PREPENDS the chunk + lowers headFrom + re-anchors
         self.assertIn('else if (m.type === "chatHead") chatHead(m);', r)
         self.assertIn("if (older.length) s.events = older.concat(s.events);", r)

--- a/tests/test_kernel_delta_send.py
+++ b/tests/test_kernel_delta_send.py
@@ -170,7 +170,8 @@ class RenderHandlesTheTail(unittest.TestCase):
         # scroll to the top of the resident tail with older on the server → request the previous chunk
         self.assertIn('vscodeApi?.postMessage({ type: "loadOlder", id: sid, before: s.proto === 2 ? s.firstUuid : s.headFrom });', r)
         # …only on an upward or unchanged move of the view (T366: a downward flick inside the estimate's top band never asks)
-        self.assertIn("const upward = olderRequestAllowed(v.edgeTop, st);", r)
+        self.assertIn("if (gesture) v.edgeUp = olderRequestAllowed(v.edgeTop, st);", r)
+        self.assertIn("const upward = v.edgeUp !== false;", r)
         self.assertIn("if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx && upward) { requestOlder(", r)
         # chatHead PREPENDS the chunk + lowers headFrom + re-anchors
         self.assertIn('else if (m.type === "chatHead") chatHead(m);', r)

--- a/tests/test_live_paused_window_browser.py
+++ b/tests/test_live_paused_window_browser.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 """T366 (the user 2026-09-12): the chat's "live updates are paused" strip appeared while they scrolled DOWN toward
-the bottom of a live session they had clicked nothing in. The laptop's rows put a chatWindow reply landing mid-flick,
-asked by a re-land of the reader's own row after a rebuild, not by any navigation; the reply's verdict detached the
-run, the strip showed, and two page requests later the reader reached the tail and it went away.
+the bottom of a live session. The landing audit named the pass behind it: a NAVIGATION frame (a card's or a lane's,
+carrying a message's uuid and its time far back in history) whose window reply landed in the middle of a flick, so the
+jump read as the scroll pausing the page; two page requests later the reader reached the tail and the strip went away.
+Two things follow. The strip now names such a detach ("Showing the message from <clock> you opened; live updates are
+paused") instead of the plain sentence. And the one window ask that is NO navigation, the re-land of the reader's own
+row across a rebuild, which would produce the same landing with nothing to name, is refused: it never detaches an
+attached reader. Whether a landing that arrives after the reader has scrolled since the click should still land is
+held for the user.
 
 The served guard drives the real /chat page over a transcript longer than the wire tail (older history stays on the
 server) and lands proto-2 window frames on it through window.postMessage, the kernel's own frame shape:
@@ -14,9 +19,10 @@ server) and lands proto-2 window frames on it through window.postMessage, the ke
   2. the same page when the reader DID navigate (a focus frame with an anchor and its time into history the page does
      not hold, a card's road): the client asks for the window, the reply lands and detaches, and the strip names the
      jump and the opened message's time instead of the plain sentence: the rule refuses only the window nobody asked
-     for, and a jump that lands mid-scroll no longer reads as the scroll pausing the page.
-  3. a fast downward flick from the top band of the resident run sends no loadOlder: an older-history ask needs an
-     upward or unchanged move.
+     for.
+  3. a one-write jump to the top of the resident run asks for older history exactly once, and the downward flick that
+     follows asks for none: the direction is the reader's own gesture, never the page's compensating write (verifier
+     medium 2: the re-window's write read as downward and refused the ask the base always made).
 
 Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the executed rules and the
 wiring pins ride ui/webview/chat-window.test.ts. All fixtures synthetic.
@@ -87,7 +93,7 @@ const state = () => page.evaluate(() => {
            strip: !!strip && !strip.hidden && getComputedStyle(strip).display !== "none",   // fixed-position: no offsetParent to read
            firstUuid: turns.length ? turns[0].dataset.uuid : null, lastUuid: turns.length ? turns[turns.length - 1].dataset.uuid : null,
            turns: turns.length,
-           sent: window.__sent.map((m) => m.type + (m.why ? ":" + m.why : "")) };
+           sent: window.__sent.map((m) => m.type + (m.why ? ":" + m.why : "") + (m.what ? ":" + m.what + (m.data && m.data.writer ? ":" + m.data.writer : "") + (m.what === "windowask" && m.data ? ":nav=" + m.data.nav + ":reland=" + m.data.reland : "") : "")) };
 });
 const sentOf = (type) => page.evaluate((t) => window.__sent.filter((m) => m.type === t).length, type);
 const boot = await state();
@@ -138,6 +144,7 @@ process.exit(0);
 DRIVER_FLICK = DRIVER_HEAD + r"""
 // to the top band of the resident run in ONE write (an upward move: the one older ask it may make is allowed), then
 // wait for that ask's reply to settle the view
+const olderAtBoot = await sentOf("loadOlder");
 await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 1; });
 await page.waitForTimeout(1500);
 const settled = await state();
@@ -149,7 +156,7 @@ for (let i = 0; i < 40; i++) { await page.mouse.wheel(0, 240); await page.waitFo
 await page.waitForTimeout(600);
 const flicked = await state();
 const olderAfterDown = await sentOf("loadOlder");
-fs.writeSync(1, "RESULT:" + JSON.stringify({ boot, settled, flicked, olderAfterUp, olderAfterDown }) + "\n");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ boot, settled, flicked, olderDuringJump: olderAfterUp - olderAtBoot, olderDuringFlick: olderAfterDown - olderAfterUp }) + "\n");
 await browser.close();
 process.exit(0);
 """
@@ -261,11 +268,11 @@ class ServedWindowLanding(unittest.TestCase):
         self.assertTrue(nav["stripText"].startswith("Showing the message from ") and nav["stripText"].endswith(" you opened; live updates are paused."),
                         "the strip names the navigation and the opened message's time: %r" % nav["stripText"])
 
-    def test_a_downward_flick_from_the_top_band_asks_for_no_older_history(self):
+    def test_a_jump_to_the_top_asks_once_and_the_downward_flick_asks_for_no_older_history(self):
         r = self._drive(DRIVER_FLICK, "flick")
         print("RESULT:" + json.dumps(r), file=sys.stderr)
-        self.assertLessEqual(r["olderAfterUp"], 1, "the one upward write may ask once: %r" % r)
-        self.assertEqual(r["olderAfterDown"], r["olderAfterUp"], "the downward flick asked for older history: %r" % r)
+        self.assertEqual(r["olderDuringJump"], 1, "a one-write jump to the top asks once at the head, as the base did: %r" % r)
+        self.assertEqual(r["olderDuringFlick"], 0, "the downward flick asked for older history: %r" % r)
         self.assertGreater(r["flicked"]["top"], r["settled"]["top"], "the flick moved down: %r" % r)
 
 

--- a/tests/test_live_paused_window_browser.py
+++ b/tests/test_live_paused_window_browser.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""T366 (the user 2026-09-12): the chat's "live updates are paused" strip appeared while they scrolled DOWN toward
+the bottom of a live session they had clicked nothing in. The laptop's rows put a chatWindow reply landing mid-flick,
+asked by a re-land of the reader's own row after a rebuild, not by any navigation; the reply's verdict detached the
+run, the strip showed, and two page requests later the reader reached the tail and it went away.
+
+The served guard drives the real /chat page over a transcript longer than the wire tail (older history stays on the
+server) and lands proto-2 window frames on it through window.postMessage, the kernel's own frame shape:
+
+  1. a reader attached to the live run, scrolled above the bottom, receives a window NOBODY navigated to (no
+     request of theirs is in flight) whose verdict would detach: the window is not adopted, no strip shows, the
+     resident tail stays on screen, and the client asks the kernel to re-base it on the tail (needFull, reattach).
+     Red on main: the window replaced the run and the strip showed.
+  2. the same page when the reader DID navigate (a focus frame with an anchor and its time into history the page does
+     not hold, a card's road): the client asks for the window, the reply lands and detaches, and the strip names the
+     jump and the opened message's time instead of the plain sentence: the rule refuses only the window nobody asked
+     for, and a jump that lands mid-scroll no longer reads as the scroll pausing the page.
+  3. a fast downward flick from the top band of the resident run sends no loadOlder: an older-history ask needs an
+     upward or unchanged move.
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none); the executed rules and the
+wiring pins ride ui/webview/chat-window.test.ts. All fixtures synthetic.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TURNS = 320   # 640 events: past the wire tail, so older history stays on the server and the page's run is a tail
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER_HEAD = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+// every frame the page sends its kernel, by type: the window asks, the older asks and the re-attach ask are the evidence
+await page.addInitScript(() => {
+  const send = WebSocket.prototype.send;
+  window.__sent = [];
+  WebSocket.prototype.send = function (d) {
+    try { const m = JSON.parse(d); if (m && m.type) window.__sent.push(m); } catch (e) { /* not a frame */ }
+    return send.call(this, d);
+  };
+});
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction(() => document.querySelectorAll("#content .turn[data-uuid]").length >= 40, null, { timeout: 30000 });
+await page.waitForTimeout(500);
+const state = () => page.evaluate(() => {
+  const c = document.getElementById("content");
+  const strip = document.getElementById("live-paused");
+  // the run's rendered EVENT turns: a notice unit at the tail (an api-error note) carries a word, not a uuid
+  const turns = Array.from(document.querySelectorAll("#content .turn[data-uuid]")).filter((t) => /^[0-9a-f-]{36}$/.test(t.dataset.uuid));
+  return { top: c.scrollTop, sh: c.scrollHeight, ch: c.clientHeight,
+           atBottom: c.scrollHeight - c.scrollTop - c.clientHeight <= 2,
+           strip: !!strip && !strip.hidden && getComputedStyle(strip).display !== "none",   // fixed-position: no offsetParent to read
+           firstUuid: turns.length ? turns[0].dataset.uuid : null, lastUuid: turns.length ? turns[turns.length - 1].dataset.uuid : null,
+           turns: turns.length,
+           sent: window.__sent.map((m) => m.type + (m.why ? ":" + m.why : "")) };
+});
+const sentOf = (type) => page.evaluate((t) => window.__sent.filter((m) => m.type === t).length, type);
+const boot = await state();
+if (!boot.atBottom) { console.error("the page did not land at the bottom: " + JSON.stringify(boot)); process.exit(1); }
+// OLDER events of the transcript itself (turns k0..k1, none resident: the page holds the tail), in the wire's shape, so a
+// window around them does not overlap the run and the kernel can place any page ask that follows them
+const pad = (n) => String(n).padStart(12, "0");
+const older = (k0, k1) => Array.from({ length: k1 - k0 }, (_, i) => k0 + i).flatMap((k) => [
+  { uuid: "11111111-2222-3333-4444-" + pad(2 * k), kind: "user", md: "question number " + k + " about the notes api", ts: new Date((cfg.base + 2 * k) * 1000).toISOString() },
+  { uuid: "22222222-3333-4444-5555-" + pad(2 * k + 1), kind: "assistant", md: "Answer " + k + ": the handler reads the note by id and returns it.", ts: new Date((cfg.base + 2 * k + 1) * 1000).toISOString() }]);
+"""
+
+# road 1 and road 2 in one page: the unasked window first (the reader attached, above the bottom), then the deep link
+DRIVER_LANDING = DRIVER_HEAD + r"""
+// the reader scrolls up a screen and a half: attached (nothing asked), above the bottom
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.scrollTop - Math.round(c.clientHeight * 1.5); });
+await page.waitForTimeout(400);
+const before = await state();
+const olderAsksBefore = await sentOf("loadOlder");
+const fullBefore = await sentOf("needFull");
+// a window NOBODY asked for lands: the kernel's frame shape, a verdict that would detach (nothing of the run in it,
+// more after it, not connected to the client's base); sixty turns, so an adopted window overflows the viewport and no
+// edge check walks it back to the tail on its own
+await page.evaluate((frame) => window.postMessage(frame, "*"), {
+  type: "chatWindow", id: cfg.sid, anchor: "11111111-2222-3333-4444-" + pad(2 * 60), events: older(30, 90),
+  moreBefore: true, moreAfter: true, connected: false });
+await page.waitForTimeout(800);
+const after = await state();
+const fullAfter = await sentOf("needFull");
+const reattach = await page.evaluate(() => window.__sent.filter((m) => m.type === "needFull" && m.why === "reattach").length);
+// road 2: the reader NAVIGATES into history the page does not hold (a focus frame with an anchor kind, the deep-link
+// road): the page asks for a window around it and the kernel's reply lands
+const deep = cfg.deepUuid;
+await page.evaluate((frame) => window.postMessage(frame, "*"), { type: "focus", id: cfg.sid, anchor: deep, anchorT: cfg.deepT });
+try { await page.waitForFunction((u) => !!document.querySelector('#content .turn[data-uuid="' + u + '"]'), deep, { timeout: 20000 }); }
+catch (e) { const st = await state(); console.error("the deep link never landed: " + JSON.stringify(st)); process.exit(1); }
+await page.waitForTimeout(600);
+const navigated = await state();
+navigated.stripText = await page.evaluate(() => (document.querySelector("#live-paused .live-paused-text") || {}).textContent || "");
+const windowAsks = await sentOf("loadAround");
+if (cfg.shots) await page.screenshot({ path: cfg.shots + "-landing.png" });
+fs.writeSync(1, "RESULT:" + JSON.stringify({ boot, before, after, navigated, olderAsksBefore, fullBefore, fullAfter, reattach, windowAsks }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+# road 3: a fast downward flick from the top band of the resident run
+DRIVER_FLICK = DRIVER_HEAD + r"""
+// to the top band of the resident run in ONE write (an upward move: the one older ask it may make is allowed), then
+// wait for that ask's reply to settle the view
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 1; });
+await page.waitForTimeout(1500);
+const settled = await state();
+const olderAfterUp = await sentOf("loadOlder");
+// the flick DOWN: forty wheel steps over the transcript, each a downward move, from wherever the reply left the reader
+const box = await page.evaluate(() => { const r = document.getElementById("content").getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; });
+await page.mouse.move(box.x, box.y);
+for (let i = 0; i < 40; i++) { await page.mouse.wheel(0, 240); await page.waitForTimeout(16); }
+await page.waitForTimeout(600);
+const flicked = await state();
+const olderAfterDown = await sentOf("loadOlder");
+fs.writeSync(1, "RESULT:" + JSON.stringify({ boot, settled, flicked, olderAfterUp, olderAfterDown }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedWindowLanding(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="live-paused-window-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "session-hosts").write_text("off\n")   # a lab root of its own: no session host (T348)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # TURNS user/assistant pairs, one a second, ending in the past: past the wire tail, so the page holds a tail
+        recs, prev = [], None
+        base = 1789000000
+        for k in range(TURNS):
+            u = "11111111-2222-3333-4444-%012d" % (2 * k)
+            a = "22222222-3333-4444-5555-%012d" % (2 * k + 1)
+            tu = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(base + 2 * k))
+            ta = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(base + 2 * k + 1))
+            recs.append({"type": "user", "uuid": u, "parentUuid": prev, "timestamp": tu, "sessionId": SID,
+                         "message": {"role": "user", "content": "question number %d about the notes api" % k}})
+            recs.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": ta, "sessionId": SID,
+                         "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                                     "content": [{"type": "text", "text": "Answer %d: the handler reads the note by id and returns it." % k}]}})
+            prev = a
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.deep_uuid = "11111111-2222-3333-4444-%012d" % 20   # the eleventh question: far above the tail the page holds
+        cls.deep_t = base + 20                                     # …and its time, as a card's focus frame carries it
+        cls.base = base
+        cls.port = _free_port()
+        cls.token = "testtok-livepaused"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self, script, name):
+        cfg = os.path.join(self.lab, name + ".json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sid": SID,
+                       "deepUuid": self.deep_uuid, "deepT": self.deep_t, "base": self.base,
+                       "shots": os.environ.get("LIVE_PAUSED_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, name + ".mjs")
+        with open(driver, "w") as f:
+            f.write(script)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    def test_a_window_nobody_asked_for_never_detaches_an_attached_reader_and_a_deep_link_still_lands(self):
+        r = self._drive(DRIVER_LANDING, "landing")
+        print("RESULT:" + json.dumps(r), file=sys.stderr)   # the whole measurement rides a failure's captured stderr
+        before, after, nav = r["before"], r["after"], r["navigated"]
+        self.assertFalse(before["strip"], "attached before the window: no strip: %r" % before)
+        self.assertFalse(before["atBottom"], "the reader is above the bottom: %r" % before)
+        # road 1: the unasked window
+        self.assertFalse(after["strip"], "a window nobody asked for showed the paused strip: %r" % after)
+        self.assertEqual(after["lastUuid"], before["lastUuid"], "the resident tail left the screen: %r → %r" % (before["lastUuid"], after["lastUuid"]))
+        self.assertNotEqual(after["firstUuid"], "11111111-2222-3333-4444-%012d" % 60, "the window's events were adopted: %r" % after)
+        self.assertEqual(after["turns"], before["turns"], "the rendered run changed under the reader: %r" % after)
+        self.assertGreaterEqual(r["reattach"], 1, "the kernel was not asked to re-base this client on the tail (needFull reattach): %r" % after["sent"])
+        self.assertEqual(r["fullAfter"] - r["fullBefore"], r["reattach"], "the only full ask the window caused is the re-attach: %r" % after["sent"])
+        # road 2: the reader's own navigation lands, detaches and says so
+        self.assertGreaterEqual(r["windowAsks"], 1, "the deep link asked for no window: %r" % nav["sent"])
+        self.assertTrue(nav["strip"], "a window the reader navigated to must land and show the strip: %r" % nav)
+        self.assertTrue(nav["stripText"].startswith("Showing the message from ") and nav["stripText"].endswith(" you opened; live updates are paused."),
+                        "the strip names the navigation and the opened message's time: %r" % nav["stripText"])
+
+    def test_a_downward_flick_from_the_top_band_asks_for_no_older_history(self):
+        r = self._drive(DRIVER_FLICK, "flick")
+        print("RESULT:" + json.dumps(r), file=sys.stderr)
+        self.assertLessEqual(r["olderAfterUp"], 1, "the one upward write may ask once: %r" % r)
+        self.assertEqual(r["olderAfterDown"], r["olderAfterUp"], "the downward flick asked for older history: %r" % r)
+        self.assertGreater(r["flicked"]["top"], r["settled"]["top"], "the flick moved down: %r" % r)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/at-bottom.test.ts
+++ b/ui/webview/at-bottom.test.ts
@@ -89,7 +89,7 @@ test("follow mode and the chip read atBottom at every site", () => {
     /unitChangeRow\(activeId \|\| "", dh, cls, BOX_FROM_TAIL, v\.stick, atBottom\(c\), c\.scrollHeight, c\.clientHeight\)/,   // the scroller's boxes outside the thread (T262n follow-up)
   ];
   for (const re of follow) assert.match(RENDER, re, String(re));
-  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 14, "thirteen call sites plus the definition (the re-show follow rule reads the same true bottom, T262 2026-09-09)");
+  assert.equal((RENDER.match(/\batBottom\(/g) || []).length, 15, "fourteen call sites plus the definition (the re-show follow rule reads the same true bottom, T262 2026-09-09; the window ask's diagnostic row reads it too, T366)");
 });
 
 test("only the user's own send reveal keeps the 80 px band", () => {

--- a/ui/webview/chat-proto2-exec.test.ts
+++ b/ui/webview/chat-proto2-exec.test.ts
@@ -10,7 +10,7 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
-import { mergeWindow, keyOf, fullFrameMerges, windowDetached, afterMore } from "./chat-window";
+import { mergeWindow, keyOf, fullFrameMerges, windowDetached, afterMore, livePausedText } from "./chat-window";
 
 const requireCjs = createRequire(__filename);
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -49,9 +49,10 @@ function liftPaused(sessions: Map<string, any>, activeId: string | null) {
     sessions, activeId, document, window: { innerHeight: 800 },
     liveSession: (id: string | null) => (id ? sessions.get(id) : undefined),
     el: (_tag: string, cls: string) => { const e = fakeEl(); e.className = cls; return e; },
-    livePausedEl: null,
+    livePausedEl: null, livePausedTxt: null,
+    livePausedText, clockOf: (t: number) => "clock-" + t,   // the real sentence rule; a stand-in clock (T366)
   };
-  const js = liftBetween("function updateLivePaused(): void {", "function reattachLive(sid: string): void {");
+  const js = liftBetween("function updateLivePaused(): void {", "function reattachLive(sid: string, force = false): void {");
   const api = liftWith(js, scope, ["updateLivePaused"]);
   return { api, scope, body };
 }

--- a/ui/webview/chat-proto2-exec.test.ts
+++ b/ui/webview/chat-proto2-exec.test.ts
@@ -10,7 +10,7 @@ import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
-import { mergeWindow, keyOf, fullFrameMerges, windowDetached, afterMore, livePausedText } from "./chat-window";
+import { mergeWindow, keyOf, fullFrameMerges, windowDetached, afterMore, livePausedText, windowLanding } from "./chat-window";
 
 const requireCjs = createRequire(__filename);
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -162,4 +162,43 @@ test("upsert merges a proto-2 full frame into the held run only when it answers 
   // the three pure rules the frames route through, once more beside the DOM paths
   assert.equal(windowDetached(true, false, true, "merge", "w", "w"), true);
   assert.deepEqual(afterMore(false, true, 4), { detached: false, headTotal: 4 });
+});
+
+// ── the window ask's mark (T366, verifier medium 1) ───────────────────────────────────────────────────────────────────
+// requestAround marks each ask with whether a NAVIGATION made it. The one ask that is no navigation is the keep-offset
+// re-land of the reader's own row across a rebuild (relandAsk, raised only around keepPlaceAcrossWindow's landing). The
+// page-reload restore of a reader's saved place arms the same keep offset, so a rule that read the keep offset refused
+// the restore's window too and a reader reloaded while reading older history lost their place: that ask must land.
+function liftAsk(relandAsk: boolean, keepY: number | null, anchorT: number | null, kind: string | null) {
+  const rows: any[] = [], posted: any[] = [];
+  const scope: Record<string, unknown> = {
+    sessions: new Map<string, any>([["A", { id: "A", proto: 2, detached: false, events: [] }]]),
+    loadingOlder: new Set<string>(), relandAsk, pendingAnchorKeepY: keepY, pendingAnchorT: anchorT, pendingAnchorKind: kind, pendingAnchorIntent: null,
+    document: { getElementById: () => null }, atBottom: () => false, landTrail: ["pointer-fetch-window"],
+    scrollDiagRow: (k: string, d: any) => rows.push({ k, d }), pendingOlderAnchor: new Map(), pendingOlderKeepY: new Map(),
+    showLoadingPill: () => undefined, vscodeApi: { postMessage: (m: any) => posted.push(m) },
+  };
+  const js = liftBetween("const pendingWindowNav = new Map<string, { nav: boolean; named: boolean; t: number | null }>();", "// The page after a DETACHED window's newest event");
+  const api = liftWith(js, scope, ["requestAround", "pendingWindowNav"]);
+  return { api, rows, posted };
+}
+
+test("the reload restore's window ask (a keep offset, no re-land) is a navigation and lands; the re-land's is refused; a card's carries its time (T366)", () => {
+  const restore = liftAsk(false, 12, null, null);
+  assert.equal(restore.api.requestAround("A", "u1"), true);
+  assert.deepEqual(restore.api.pendingWindowNav.get("A"), { nav: true, named: false, t: null }, "the reader's saved place is theirs to get back: a navigation, unnamed (the plain strip sentence)");
+  assert.equal(windowLanding(true, true, restore.api.pendingWindowNav.get("A").nav), "detach", "…so a detaching window lands (no forced re-attach)");
+  const reland = liftAsk(true, 12, null, null);
+  reland.api.requestAround("A", "u2");
+  assert.deepEqual(reland.api.pendingWindowNav.get("A"), { nav: false, named: false, t: null }, "the re-land of the reader's own row is the one ask that is no navigation");
+  assert.equal(windowLanding(true, true, reland.api.pendingWindowNav.get("A").nav), "reattach", "…so its detaching window is refused and the client re-attached");
+  const card = liftAsk(false, null, 1700000000, null);
+  card.api.requestAround("A", "u3");
+  assert.deepEqual(card.api.pendingWindowNav.get("A"), { nav: true, named: true, t: 1700000000 }, "a card's or lane's frame carried the message's time: named, and the strip says the clock");
+  const notch = liftAsk(false, null, null, "prompt");
+  notch.api.requestAround("A", "u4");
+  assert.deepEqual(notch.api.pendingWindowNav.get("A"), { nav: true, named: true, t: null }, "a kind without a time: named, and the strip says the message was opened without a clock");
+  assert.equal(restore.rows.length, 1); assert.equal(restore.rows[0].k, "windowask");
+  assert.deepEqual({ nav: restore.rows[0].d.nav, keep: restore.rows[0].d.keep, reland: restore.rows[0].d.reland, trail: restore.rows[0].d.trail }, { nav: true, keep: true, reland: false, trail: ["pointer-fetch-window"] }, "the ask's diagnostic row names the keep offset and the re-land flag apart, under the scroll rows' budget");
+  assert.deepEqual(restore.posted, [{ type: "loadAround", id: "A", uuid: "u1" }], "the ask itself goes out after the mark");
 });

--- a/ui/webview/chat-window.test.ts
+++ b/ui/webview/chat-window.test.ts
@@ -94,8 +94,8 @@ test("the paused strip names a navigation's detach, with the opened message's cl
   assert.ok(strip.includes("livePausedTxt.textContent = livePausedText(!!s.detachNav, s.detachNav ? s.detachNav.t : null, clockOf);"), "the strip re-says its sentence on every evaluation from the session's detach");
   assert.ok(strip.indexOf("livePausedTxt.textContent = livePausedText(") > strip.indexOf("document.body.appendChild(livePausedEl);"), "…after the one-time build, so a later detach changes the words");
   const win = RENDER.slice(RENDER.indexOf("function chatWindow(msg: any) {"), RENDER.indexOf("function chatMore(msg: any) {"));
-  assert.ok(win.includes("s.detachNav = detached && ask?.nav ? { t: ask.t } : null;"), "a landed window records whether a navigation detached, and its time");
-  assert.ok(RENDER.includes("pendingWindowNav.set(sid, { nav, t: nav ? (pendingAnchorT ?? null) : null });"), "the ask carries the navigation's time to the reply");
+  assert.ok(win.includes("s.detachNav = detached && ask?.named ? { t: ask.t } : null;"), "a landed window records whether a card, lane or deep link detached, and its time");
+  assert.ok(RENDER.includes("pendingWindowNav.set(sid, { nav, named: nav && (pendingAnchorT != null || !!kind), t: nav ? (pendingAnchorT ?? null) : null });"), "the ask carries the navigation's time to the reply, and whether its frame carried a kind or a time (a reload restore has neither: the plain sentence)");
 });
 
 test("an older-history ask needs an upward or unchanged move; a downward gesture never asks (T366)", () => {
@@ -109,15 +109,25 @@ test("an older-history ask needs an upward or unchanged move; a downward gesture
 
 test("render.ts asks for older history only on an upward move, marks each window ask with whether a navigation made it, and files the ask (T366)", () => {
   const virt = RENDER.slice(RENDER.indexOf("function virtualizeToViewport()"), RENDER.indexOf("\n}\n", RENDER.indexOf("function virtualizeToViewport()")));
-  assert.ok(virt.includes("const upward = olderRequestAllowed(v.edgeTop, st);"), "the direction is read from the view's last edge-check top");
-  assert.ok(virt.indexOf("const upward = olderRequestAllowed(v.edgeTop, st);") < virt.indexOf("v.edgeTop = st;"), "…before the top is remembered for the next check");
+  assert.ok(virt.includes("const gesture = v.gestureScroll === true;\n  v.gestureScroll = undefined;\n  if (gesture) v.edgeUp = olderRequestAllowed(v.edgeTop, st);"), "the direction is read only on the reader's own gesture, from the view's last edge-check top, and the mark is consumed");
+  assert.ok(virt.indexOf("if (gesture) v.edgeUp = olderRequestAllowed(v.edgeTop, st);") < virt.indexOf("v.edgeTop = st;"), "…before the top is remembered for the next check (the page's own writes move it too)");
+  assert.ok(virt.includes("const upward = v.edgeUp !== false;"), "the last gesture's verdict holds across the page's compensating writes; no verdict yet allows the ask");
   assert.ok(virt.includes("st < topH + edgePx && upward) { requestOlder(activeId, v, content); return; }"), "the older ask is gated on the direction, not only the estimate's band");
-  assert.ok(RENDER.includes("edgeTop?: number;"), "the view remembers the top the last edge check saw");
-  assert.ok(RENDER.includes("v.unitTotal = undefined; v.edgeTop = undefined; v.stale = true; }"), "a window rebuild forgets it: the first check after a rebuild may ask");
+  assert.match(RENDER, /const cls = classifyScroll\(c\.scrollTop, lastScrollWriteAfter\);\n\s*const gv = activeId \? views\.get\(activeId\) : null;\n\s*if \(gv\) gv\.gestureScroll = cls === "gesture";/, "the scroll listener marks a gesture (a write's echo is none) for the edge check that runs next");
+  assert.ok(RENDER.includes("edgeTop?: number; edgeUp?: boolean; gestureScroll?: boolean;"), "the view remembers the top the last edge check saw, the last verdict and the gesture mark");
+  assert.ok(RENDER.includes("v.unitTotal = undefined; v.edgeTop = undefined; v.edgeUp = undefined; v.stale = true; }"), "a window rebuild forgets both: the first check after a rebuild may ask");
   const around = RENDER.slice(RENDER.indexOf("function requestAround(sid: string, uuid: string): boolean {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function requestAround(sid: string, uuid: string): boolean {")));
-  assert.ok(around.includes("const nav = pendingAnchorKeepY == null;") && around.includes("pendingWindowNav.set(sid, { nav,"), "a window ask records whether a navigation made it: every anchor landing but the keep-offset re-land of the reader's own row");
-  assert.ok(around.includes('what: "windowask"'), "…and files a diagnostic row: the report's rows had the landing but not the ask");
+  assert.ok(around.includes("const nav = !relandAsk;") && around.includes("pendingWindowNav.set(sid, { nav,"), "a window ask records whether a navigation made it: every anchor landing but the re-land of the reader's own row across a rebuild");
+  const keep = RENDER.slice(RENDER.indexOf("function keepPlaceAcrossWindow("), RENDER.indexOf("\n}\n", RENDER.indexOf("function keepPlaceAcrossWindow(")));
+  assert.ok(keep.includes("relandAsk = true;\n  let landed = false;\n  try { landed = scrollToAnchor(keep.uuid); } finally { relandAsk = false; }"), "the re-land's own flag is set only around its landing (the reload restore shares the keep offset and must land)");
+  assert.equal((RENDER.match(/relandAsk = true;/g) || []).length, 1, "nothing else raises the flag");
+  assert.ok(around.includes('scrollDiagRow("windowask", {'), "…and files a diagnostic row under the scroll rows' per-minute budget: the report's rows had the landing but not the ask");
+  assert.ok(RENDER.includes('| "unitchange" | "windowask", data: any): void {'), "the budgeted row kinds include it");
   assert.ok(around.indexOf("pendingWindowNav.set(sid, { nav,") < around.indexOf('type: "loadAround"'), "the mark is set before the ask goes out");
+  // a refused window leaves the kernel's base on the window until the re-attach lands; a tail pushed meanwhile misses its
+  // anchor and asks for a full frame as a gap, which must not overwrite the pending reattach reason (a replace, not a merge)
+  const full = RENDER.slice(RENDER.indexOf("function requestFullSession(id: string, why: NeedFullWhy): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function requestFullSession(id: string, why: NeedFullWhy): void {")));
+  assert.ok(full.indexOf("if (!id || awaitingFull.has(id)) return;") < full.indexOf("pendingFullWhy.set(id, why);"), "a second full ask while one is in flight is dropped before it can overwrite the pending reason");
 });
 
 test("render.ts wires the three rules, tracks the pending needFull reason, hides the paused strip on a frame and a tab switch, and lands orphan notes by record uuid", () => {

--- a/ui/webview/chat-window.test.ts
+++ b/ui/webview/chat-window.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { applyTailAfter, prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore, reattachKeys, REATTACH_KEYS } from "./chat-window";
+import { applyTailAfter, prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore, reattachKeys, REATTACH_KEYS, windowLanding, olderRequestAllowed, livePausedText } from "./chat-window";
 
 const ev = (u: string) => ({ uuid: u, kind: "user", md: u });
 const run = (...u: string[]) => u.map(ev);
@@ -75,6 +75,51 @@ test("after a chatMore: detached while more follows; at the tail the count is th
   assert.deepEqual(afterMore(false, false, 40), { detached: false, headTotal: null });
 });
 
+test("a detaching window lands on an attached active reader only when their own navigation asked for it (T366)", () => {
+  assert.equal(windowLanding(false, true, false), "attach", "a verdict that does not detach lands as is");
+  assert.equal(windowLanding(false, false, true), "attach");
+  assert.equal(windowLanding(true, true, false), "reattach", "attached, on screen, nobody navigated: the window is not adopted");
+  assert.equal(windowLanding(true, true, true), "detach", "the reader clicked a card, a notch or a deep link: the window lands");
+  assert.equal(windowLanding(true, false, false), "detach", "a run already detached, or a view not on screen, takes the window");
+  assert.equal(windowLanding(true, false, true), "detach");
+});
+
+test("the paused strip names a navigation's detach, with the opened message's clock when the frame carried its time (T366)", () => {
+  const clock = (t: number) => "at-" + t;
+  assert.equal(livePausedText(false, null, clock), "Live updates are paused while you read older history.", "no navigation behind the detach: the plain sentence");
+  assert.equal(livePausedText(false, 1700000000, clock), "Live updates are paused while you read older history.", "a time without a navigation is not a click");
+  assert.equal(livePausedText(true, 1700000000, clock), "Showing the message from at-1700000000 you opened; live updates are paused.");
+  assert.equal(livePausedText(true, null, clock), "Showing the message you opened; live updates are paused.", "a navigation whose frame carried no time");
+  const strip = RENDER.slice(RENDER.indexOf("function updateLivePaused(): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function updateLivePaused(): void {")));
+  assert.ok(strip.includes("livePausedTxt.textContent = livePausedText(!!s.detachNav, s.detachNav ? s.detachNav.t : null, clockOf);"), "the strip re-says its sentence on every evaluation from the session's detach");
+  assert.ok(strip.indexOf("livePausedTxt.textContent = livePausedText(") > strip.indexOf("document.body.appendChild(livePausedEl);"), "…after the one-time build, so a later detach changes the words");
+  const win = RENDER.slice(RENDER.indexOf("function chatWindow(msg: any) {"), RENDER.indexOf("function chatMore(msg: any) {"));
+  assert.ok(win.includes("s.detachNav = detached && ask?.nav ? { t: ask.t } : null;"), "a landed window records whether a navigation detached, and its time");
+  assert.ok(RENDER.includes("pendingWindowNav.set(sid, { nav, t: nav ? (pendingAnchorT ?? null) : null });"), "the ask carries the navigation's time to the reply");
+});
+
+test("an older-history ask needs an upward or unchanged move; a downward gesture never asks (T366)", () => {
+  assert.equal(olderRequestAllowed(undefined, 120), true, "no previous top: a fresh or rebuilt view may ask");
+  assert.equal(olderRequestAllowed(null, 0), true);
+  assert.equal(olderRequestAllowed(500, 120), true, "moving up");
+  assert.equal(olderRequestAllowed(120, 120), true, "unchanged (a resize, a relayout)");
+  assert.equal(olderRequestAllowed(120, 121), false, "moving down, by any amount");
+  assert.equal(olderRequestAllowed(0, 3000), false, "a flick down from the very top");
+});
+
+test("render.ts asks for older history only on an upward move, marks each window ask with whether a navigation made it, and files the ask (T366)", () => {
+  const virt = RENDER.slice(RENDER.indexOf("function virtualizeToViewport()"), RENDER.indexOf("\n}\n", RENDER.indexOf("function virtualizeToViewport()")));
+  assert.ok(virt.includes("const upward = olderRequestAllowed(v.edgeTop, st);"), "the direction is read from the view's last edge-check top");
+  assert.ok(virt.indexOf("const upward = olderRequestAllowed(v.edgeTop, st);") < virt.indexOf("v.edgeTop = st;"), "…before the top is remembered for the next check");
+  assert.ok(virt.includes("st < topH + edgePx && upward) { requestOlder(activeId, v, content); return; }"), "the older ask is gated on the direction, not only the estimate's band");
+  assert.ok(RENDER.includes("edgeTop?: number;"), "the view remembers the top the last edge check saw");
+  assert.ok(RENDER.includes("v.unitTotal = undefined; v.edgeTop = undefined; v.stale = true; }"), "a window rebuild forgets it: the first check after a rebuild may ask");
+  const around = RENDER.slice(RENDER.indexOf("function requestAround(sid: string, uuid: string): boolean {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function requestAround(sid: string, uuid: string): boolean {")));
+  assert.ok(around.includes("const nav = pendingAnchorKeepY == null;") && around.includes("pendingWindowNav.set(sid, { nav,"), "a window ask records whether a navigation made it: every anchor landing but the keep-offset re-land of the reader's own row");
+  assert.ok(around.includes('what: "windowask"'), "…and files a diagnostic row: the report's rows had the landing but not the ask");
+  assert.ok(around.indexOf("pendingWindowNav.set(sid, { nav,") < around.indexOf('type: "loadAround"'), "the mark is set before the ask goes out");
+});
+
 test("render.ts wires the three rules, tracks the pending needFull reason, hides the paused strip on a frame and a tab switch, and lands orphan notes by record uuid", () => {
   const upsert = RENDER.slice(RENDER.indexOf("function upsert(msg: any) {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function upsert(msg: any) {")));
   assert.ok(upsert.includes("fullFrameMerges(fullWhy)"), "upsert merges by the pending reason");
@@ -84,7 +129,11 @@ test("render.ts wires the three rules, tracks the pending needFull reason, hides
   assert.match(RENDER, /vscodeApi\?\.postMessage\(\{ type: "needFull", id, why \}\);\n  pendingFullWhy\.set\(id, why\);/, "requestFullSession records the reason with the ask");
   assert.match(RENDER, /window\.addEventListener\("romp:wsup", \(\) => pendingFullWhy\.clear\(\)\);/, "…and a new socket forgets the reasons with the asks");
   const win = RENDER.slice(RENDER.indexOf("function chatWindow(msg: any) {"), RENDER.indexOf("function chatMore(msg: any) {"));
-  assert.ok(win.includes("s.detached = windowDetached(!!msg.moreAfter, !!msg.connected, wasDetached, r.mode, heldLast, s.lastUuid);"), "chatWindow decides through the rule, with the state before the merge");
+  assert.ok(win.includes("const detached = windowDetached(!!msg.moreAfter, !!msg.connected, wasDetached, r.mode, heldLast, newLast);"), "chatWindow decides through the rule, with the state before the merge");
+  assert.ok(win.includes("const landing = windowLanding(detached, msg.id === activeId && !wasDetached, ask?.nav ?? false);"), "…and the landing rule decides whether the verdict is adopted (T366)");
+  assert.ok(win.indexOf("const landing = windowLanding(") < win.indexOf("s.events = r.events as ChatEvent[];"), "the landing is decided BEFORE the window's events replace the run");
+  assert.ok(win.includes('if (landing === "reattach") {') && win.includes("reattachLive(msg.id, true);"), "a window not adopted re-bases the kernel on the tail at once");
+  assert.ok(win.indexOf('if (landing === "reattach") {') < win.indexOf("s.detached = detached;"), "…and returns before the detached flag is set: no strip");
   assert.ok(win.includes("window.requestAnimationFrame(() => edgeCheckAfterWindow(msg.id));"), "a window runs the edge check once it painted");
   assert.ok(RENDER.includes("if (cur && cur.detached && c && c.scrollHeight <= c.clientHeight + 1) { requestNewer(sid); return; }"), "a detached run that does not overflow asks for its next page directly");
   const more = RENDER.slice(RENDER.indexOf("function chatMore(msg: any) {"), RENDER.indexOf("let livePausedEl"));
@@ -105,7 +154,7 @@ test("the re-attach ask carries the run's newest keys, bounded, and render.ts po
   const keys = reattachKeys(long);
   assert.equal(keys.length, REATTACH_KEYS); assert.equal(keys[0], "k40"); assert.equal(keys[keys.length - 1], "k" + (REATTACH_KEYS + 39));
   assert.deepEqual(reattachKeys([ev("a"), { uuid: "a", key: "a#2", kind: "tool" }, { kind: "todo" }]), ["a", "a#2"], "keys, not uuids; a keyless card is skipped");
-  const fn = RENDER.slice(RENDER.indexOf("function reattachLive(sid: string): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function reattachLive(sid: string): void {")));
+  const fn = RENDER.slice(RENDER.indexOf("function reattachLive(sid: string, force = false): void {"), RENDER.indexOf("\n}\n", RENDER.indexOf("function reattachLive(sid: string, force = false): void {")));
   assert.ok(fn.indexOf('type: "reattachKeys", id: sid, keys: reattachKeys(') > 0 && fn.indexOf('type: "reattachKeys"') < fn.indexOf('requestFullSession(sid, "reattach")'), "the keys go out before the ask");
 });
 

--- a/ui/webview/chat-window.ts
+++ b/ui/webview/chat-window.ts
@@ -78,6 +78,40 @@ export function windowDetached(moreAfter: boolean, connected: boolean, wasDetach
   return !!moreAfter && !connected && !(mergeMode === "merge" && !wasDetached && heldLast != null && newLast === heldLast);
 }
 
+/** Where a chatWindow reply LANDS a client whose verdict (windowDetached) would detach it (T366, the user 2026-09-12: the
+ *  "live updates are paused" strip appeared while they scrolled DOWN toward the bottom of a live session; the landing
+ *  audit put a navigation's window landing mid-flick, and the same landing would follow the one window ask that is no
+ *  navigation, the re-land of the reader's own row). A window that nobody navigated to must never take an ATTACHED reader off the live run, at the bottom or
+ *  above it: when the reply lands on the active view of a run that was attached, and the window was not asked by the
+ *  reader's own navigation (a card, a notch, a deep link with a kind, a durable seek), the client re-attaches at once
+ *  ("reattach": the window is not adopted, the kernel is asked to re-base this client on the tail, no strip). A window
+ *  the reader asked for lands and detaches as before ("detach"), as does one for a view already detached or not on
+ *  screen; a verdict that does not detach is "attach". */
+export type WindowLanding = "attach" | "detach" | "reattach";
+export function windowLanding(detached: boolean, attachedActiveReader: boolean, userNavigation: boolean): WindowLanding {
+  if (!detached) return "attach";
+  if (attachedActiveReader && !userNavigation) return "reattach";
+  return "detach";
+}
+
+/** The paused strip's sentence (T366): a detach that a NAVIGATION of the reader's own caused (a card or lane click, a
+ *  deep link) names what happened, with the opened message's clock when the frame carried its time, so a jump that
+ *  lands mid-scroll does not read as the scroll pausing the page; a detach with no navigation behind it keeps the
+ *  plain sentence. `clock` renders an epoch-seconds time in the reader's locale. */
+export function livePausedText(nav: boolean, t: number | null | undefined, clock: (epochS: number) => string): string {
+  if (!nav) return "Live updates are paused while you read older history.";
+  return (t != null ? "Showing the message from " + clock(t) + " you opened" : "Showing the message you opened") + "; live updates are paused.";
+}
+
+/** Whether a scroll may ask for OLDER history (T366): only an upward or unchanged move of the view (`top` at or above
+ *  the top the last edge check saw). A downward gesture never asks, whatever the spacer estimate says the edge is:
+ *  the estimate (an average row height) can put the viewport inside the top band while the reader is heading for the
+ *  bottom, and the request's reply then re-anchors the view under them. No previous top (a fresh view, a rebuilt one)
+ *  allows the ask. */
+export function olderRequestAllowed(prevTop: number | null | undefined, top: number): boolean {
+  return prevTop == null || top <= prevTop;
+}
+
 /** Whether a full session frame MERGES into the resident run instead of replacing it (round 2, item 3): only when it
  *  answers this client's own re-attach ask, so the pages the reader walked stay resident. A change-driven full frame (a
  *  tool output filling an earlier card, a floor move) replaces: a merge would keep the client's stale copies of the

--- a/ui/webview/keep-across-window.test.ts
+++ b/ui/webview/keep-across-window.test.ts
@@ -20,7 +20,7 @@ test("keepPlaceAcrossWindow: the direct restore first; on a miss, the deep-link 
   const body = m![1];
   assert.match(body, /if \(restoreScrollAnchor\(content, v, keep\)\) return true;/, "the cheap path when the turn is rendered");
   assert.match(body, /pendingAnchor = keep\.uuid; pendingAnchorKeepY = keep\.y;/, "armed with the kept offset, so the land writes keep-offset, not a flashed top-of-viewport jump");
-  assert.match(body, /const landed = scrollToAnchor\(keep\.uuid\);/, "the window-around-unit land");
+  assert.match(body, /relandAsk = true;\s*\n\s*let landed = false;\s*\n\s*try \{ landed = scrollToAnchor\(keep\.uuid\); \} finally \{ relandAsk = false; \}/, "the window-around-unit land, flagged as the re-land of the reader's own row while it runs (T366: the one window ask that is no navigation)");
   assert.match(body, /if \(!anchorPendingOlder\) \{ pendingAnchor = null; pendingAnchorKeepY = null; \}/, "disarmed unless an older-history fetch will re-land on arrival");
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -1308,7 +1308,7 @@ let landTrail: string[] = [];
 // count is NOT len − winStart + spacer: a unit may own more than one node (the day
 // divider that opens a new day precedes its turn), so anything mapping DOM back to
 // units reads data-unit off the node rather than counting children.
-interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; edgeTop?: number; working?: boolean; uo?: ResizeObserver; uh?: WeakMap<Element, number>; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
+interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; edgeTop?: number; edgeUp?: boolean; gestureScroll?: boolean; working?: boolean; uo?: ResizeObserver; uh?: WeakMap<Element, number>; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
@@ -10857,7 +10857,7 @@ function tailMutations(records: MutationRecord[]): { removedTail: string[]; adde
 // the cap is the default unless the page's localStorage says otherwise (a laptop capturing raises it; T262j)
 const scrollDiagCap = readScrollDiagCap((k) => { try { return localStorage.getItem(k); } catch { return null; } });
 const scrollDiag = new ScrollDiagBudget(scrollDiagCap);
-function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer" | "tailmut" | "unitchange", data: any): void {
+function scrollDiagRow(kind: "scrollwrite" | "scrollgesture" | "tailchange" | "spacer" | "tailmut" | "unitchange" | "windowask", data: any): void {
   const v = scrollDiag.take(activeId || "", kind, Date.now());
   if (v === "drop") return;
   vscodeApi?.postMessage(v === "cap"
@@ -12513,10 +12513,18 @@ function showActive(keep?: { uuid: string; y: number } | null) {
 // screen). When the direct restore misses, the deep-link land takes over with the kept offset: it renders a
 // window AROUND the anchor's unit (or fetches older history and re-lands on arrival) and writes "keep-offset",
 // the anchor's exact on-screen position — the same machinery a jump into folded history uses.
+// True only while keepPlaceAcrossWindow lands the reader's own row across a rebuild (T366): the one window ask that is no
+// navigation. The reload restore arms the same keep offset (the reader's saved place, which they want back), the durable
+// seek, a card, a notch and a deep link arm an anchor of their own; every one of those lands (verifier medium 1: keying
+// the refusal on the keep offset refused the reload restore too, and a reader reloaded while reading older history lost
+// their place)
+let relandAsk = false;
 function keepPlaceAcrossWindow(content: HTMLElement, v: View, keep: { uuid: string; y: number }): boolean {
   if (restoreScrollAnchor(content, v, keep)) return true;
   pendingAnchor = keep.uuid; pendingAnchorKeepY = keep.y;
-  const landed = scrollToAnchor(keep.uuid);
+  relandAsk = true;
+  let landed = false;
+  try { landed = scrollToAnchor(keep.uuid); } finally { relandAsk = false; }
   if (!anchorPendingOlder) { pendingAnchor = null; pendingAnchorKeepY = null; }   // an older-history fetch keeps them armed for chatHead's re-land
   return landed;
 }
@@ -12990,7 +12998,10 @@ function updateReplyChips(): void {
     followReader(activeId ? views.get(activeId) : null, c.scrollTop, atBottom(c), pendingBuildRaf != null);
     // the scroll nobody's code asked for is the user's (T262): filed so a recording lines up with the journal;
     // a write's own echo (within a pixel of the value written) is consumed here and never read as a gesture
-    if (classifyScroll(c.scrollTop, lastScrollWriteAfter) === "write-echo") lastScrollWriteAfter = null;
+    const cls = classifyScroll(c.scrollTop, lastScrollWriteAfter);
+    const gv = activeId ? views.get(activeId) : null;
+    if (gv) gv.gestureScroll = cls === "gesture";   // read once by the edge check this event runs next (T366): a write's echo is no gesture
+    if (cls === "write-echo") lastScrollWriteAfter = null;
     else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });
     lastKnownSh = c.scrollHeight;   // sh/ch: a clamp reads top == sh - ch after sh dropped (T262e)
   }, { passive: true });
@@ -13213,10 +13224,16 @@ function virtualizeToViewport(): void {
   const topH = topEl ? topEl.offsetHeight : 0;
   const renderedBottom = botEl ? botEl.getBoundingClientRect().top - cRectTop + content.scrollTop : content.scrollHeight;
   const st = content.scrollTop, vh = content.clientHeight;
-  // the gesture's direction (T366): an older-history ask needs an upward or unchanged move; a reader heading DOWN never
-  // asks, whatever the spacer estimate says about the top band (chat-window.ts olderRequestAllowed)
-  const upward = olderRequestAllowed(v.edgeTop, st);
+  // the gesture's direction (T366): an older-history ask needs an upward or unchanged move OF THE READER'S OWN; a reader
+  // heading DOWN never asks, whatever the spacer estimate says about the top band (chat-window.ts olderRequestAllowed).
+  // The page's compensating writes (a re-window's, a land's) move scrollTop too and echo as scroll events, so the
+  // direction is read only on a gesture event (the scroll listener marks it) and the last verdict holds across the page's
+  // own writes: a one-write jump to the top asks once at the head as it always did (verifier medium 2)
+  const gesture = v.gestureScroll === true;
+  v.gestureScroll = undefined;
+  if (gesture) v.edgeUp = olderRequestAllowed(v.edgeTop, st);
   v.edgeTop = st;
+  const upward = v.edgeUp !== false;
   // At the top of the RESIDENT events with older history still on the server → fetch the previous chunk
   // (loadOlder → chatHead). winStart 0 ⇒ no top spacer left to expand into; topH is 0 so this is "near 0".
   if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx && upward) { requestOlder(activeId, v, content); return; }
@@ -16982,18 +16999,21 @@ function olderOnServer(s: Session): boolean {
 // index wire's fetch-older-until-resident loop. False when nothing can be asked (an index session, a request in flight).
 // sid -> the window was asked by a NAVIGATION (a card, a notch, a deep link, a seek, a reload's restore of the reader's
 // saved place: every anchor landing but one), not by the keep-offset RE-LAND of the reader's own row across a rebuild
-// (pendingAnchorKeepY set), the one ask that exists only to keep their row on screen and must never move them off the
-// live run (T366: a window landing mid-flick detached a reader; a navigation's window may, a re-land's never)
-const pendingWindowNav = new Map<string, { nav: boolean; t: number | null }>();   // …and the navigation's time when its frame carried one (the strip names it)
+// (relandAsk), the one ask that exists only to keep their row on screen and must never move them off the live run (T366:
+// a window landing mid-flick detached a reader; a navigation's window may, a re-land's never); `named` says the ask came
+// from a frame that carried a kind or the message's time (a card or lane click, a deep link), which the strip names
+const pendingWindowNav = new Map<string, { nav: boolean; named: boolean; t: number | null }>();
 function requestAround(sid: string, uuid: string): boolean {
   const s = sessions.get(sid);
   if (!s || s.proto !== 2 || loadingOlder.has(sid)) return false;
-  const nav = pendingAnchorKeepY == null;
-  pendingWindowNav.set(sid, { nav, t: nav ? (pendingAnchorT ?? null) : null });
+  const nav = !relandAsk;
+  const kind = pendingAnchorKind ?? pendingAnchorIntent ?? null;
+  pendingWindowNav.set(sid, { nav, named: nav && (pendingAnchorT != null || !!kind), t: nav ? (pendingAnchorT ?? null) : null });
   // every window ask leaves a diagnostic row (T366: the rows of the report had the reply's landing but nothing said
-  // which pass asked for the window): the landing trail so far, the anchor's kind, whether a keep-offset restore asked
+  // which pass asked for the window): the landing trail so far, the anchor's kind, whether a keep-offset restore asked;
+  // under the same per-minute budget as the other scroll rows (verifier low 5)
   const cAsk = document.getElementById("content");
-  vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "windowask", data: { sid, nav, kind: pendingAnchorKind ?? null, intent: pendingAnchorIntent ?? null, keep: pendingAnchorKeepY != null, trail: landTrail.slice(-4), detached: !!s.detached, atBottom: !!cAsk && atBottom(cAsk) } });
+  scrollDiagRow("windowask", { sid, nav, kind, keep: pendingAnchorKeepY != null, reland: relandAsk, trail: landTrail.slice(-4), detached: !!s.detached, atBottom: !!cAsk && atBottom(cAsk) });
   pendingOlderAnchor.set(sid, uuid);
   pendingOlderKeepY.delete(sid);
   loadingOlder.add(sid);
@@ -17038,6 +17058,9 @@ function chatWindow(msg: any) {
   const landing = windowLanding(detached, msg.id === activeId && !wasDetached, ask?.nav ?? false);
   pendingWindowNav.delete(msg.id);
   if (landing === "reattach") {
+    // the kernel's base for this client is the window until the re-attach lands; a tail it pushes meanwhile misses its
+    // afterUuid here and asks for a full frame as a gap, which requestFullSession drops while the re-attach ask is in
+    // flight (awaitingFull), so the pending reason stays reattach and the frame MERGES into the held run (verifier low 4)
     reconcileOptimistic(s);
     if (msg.id === activeId) { if (pendingAnchor === anchorUuid) { pendingAnchor = null; pendingAnchorKeepY = null; } anchorPendingOlder = false; landTrail.push("window-not-adopted"); }
     reattachLive(msg.id, true);
@@ -17048,12 +17071,12 @@ function chatWindow(msg: any) {
   s.firstUuid = keyOf(s.events[0] as { uuid?: string; key?: string } | undefined) ?? null;
   s.lastUuid = newLast;
   s.detached = detached;
-  s.detachNav = detached && ask?.nav ? { t: ask.t } : null;   // the strip names a navigation's detach (T366); read only while detached
+  s.detachNav = detached && ask?.named ? { t: ask.t } : null;   // the strip names a detach by a card, lane or deep link (T366); read only while detached
   if (msg.moreBefore === false) s.headKnown = true;
   s.headTotal = s.headKnown && !s.detached ? s.events.length : null;   // a count only when the whole is resident
   reconcileOptimistic(s);
   const v = views.get(msg.id);
-  if (v) { v.rendered = 0; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; v.edgeTop = undefined; v.stale = true; }
+  if (v) { v.rendered = 0; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; v.edgeTop = undefined; v.edgeUp = undefined; v.stale = true; }
   if (msg.id !== activeId) return;
   const target = typeof msg.anchor === "string" ? msg.anchor : anchorUuid;
   if (target) { pendingAnchor = target; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null; flashedAnchor = null; pendingAnchorKeepY = null; anchorPendingOlder = false; }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -21,7 +21,7 @@ import { applyTheme } from "./theme";
 import { installPostalWash } from "./postal-wash";   // the incoming postal card's tint lightness, measured from the page (T337c)
 import { applyDenseChrome } from "./dense-chrome";
 import { SessionViews, viewVisible, viewsKey, revealIn, viewTagUnion, viewTags, type TagUnion, type SessionTag } from "./session-views";
-import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore, reattachKeys } from "./chat-window";   // the uuid-anchored wire (T323 stage 4b)
+import { prependHead, appendMore, mergeWindow, historyLabel, indexOfUuid, keyOf, windowDetached, fullFrameMerges, afterMore, reattachKeys, windowLanding, olderRequestAllowed, livePausedText } from "./chat-window";   // the uuid-anchored wire (T323 stage 4b)
 import { SUBAGENT_OPEN_WAIT_MS, subagentStallText, subagentStalled } from "./subagent-wait";   // the viewer's wait bound and its stall (T355)
 import { placeholderKind, placeholderStands, fillPlaceholder } from "./pane-placeholder";   // the empty pane's placeholder, by kind (T355)
 import { mintWriteId, ackOutcome, adoptViews, seqOf, capsAdopts, announcedSeq, announcedAfter, createInFlight, rederivePending, lensBlob, applyLensFields, type InflightWrite, type LensFields, type TagEditOp, type ViewsAck } from "./views-writes";
@@ -333,7 +333,7 @@ interface BgTasks { count: number; tasks: BgTask[]; }
 // kernel ships only the last WIRE_TAIL events (headFrom > 0) to keep startup light; older history streams in
 // on scroll-back (loadOlder → chatHead prepends, lowering headFrom). headFrom 0 = the whole transcript is
 // resident. chatTail's `from` is GLOBAL and mapped through headFrom.
-interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; githubRepo?: string | null; headFrom?: number; headTotal?: number | null; proto?: number; headKnown?: boolean; firstUuid?: string | null; lastUuid?: string | null; detached?: boolean; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; mailOffWhy?: string; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
+interface Session { id: string; name: string; color: Color | null; events: ChatEvent[]; status: Status; firstSeen?: number; cwd?: string; gitBranch?: string; workTree?: { dir: string; branch: string } | null; githubRepo?: string | null; headFrom?: number; headTotal?: number | null; proto?: number; headKnown?: boolean; firstUuid?: string | null; lastUuid?: string | null; detached?: boolean; detachNav?: { t: number | null } | null; bgTasks?: BgTasks; hideFromFeed?: boolean; postalServiceOff?: boolean; mailOffWhy?: string; notify?: boolean; branch?: { fromSid: string; fromName: string; cut: string; t: number } | null; branches?: { sid: string; name: string; cut: string; t: number }[] | null; sub?: SubInfo; }
 // A SUBAGENT VIEWER pseudo-session (plans/subagent-transcripts.md): a read-only tab whose events are one
 // agent's own transcript, fed by {type:"subagent"} frames. Client-only — the kernel never lists it in
 // tabOrder (reconcileTabOrder keeps a known, never-kernel-seen id), so it lives exactly as long as the
@@ -1308,7 +1308,7 @@ let landTrail: string[] = [];
 // count is NOT len − winStart + spacer: a unit may own more than one node (the day
 // divider that opens a new day precedes its turn), so anything mapping DOM back to
 // units reads data-unit off the node rather than counting children.
-interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; working?: boolean; uo?: ResizeObserver; uh?: WeakMap<Element, number>; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
+interface View { el: HTMLElement; rendered: number; scrollTop: number; stick: boolean; shown: boolean; stale: boolean; winStart: number; winEnd?: number; avgTurnH?: number; spacerCount?: number; spacerCountBot?: number; unitTotal?: number; edgeTop?: number; working?: boolean; uo?: ResizeObserver; uh?: WeakMap<Element, number>; ro?: ResizeObserver; mo?: MutationObserver; }   // working: the session's state at the last sync, the "worked …" footer's one non-event input (syncViewInner)
 const views = new Map<string, View>();
 
 // Pending pickers (AskUserQuestion / tool-permission) keyed by session id. These
@@ -13213,9 +13213,13 @@ function virtualizeToViewport(): void {
   const topH = topEl ? topEl.offsetHeight : 0;
   const renderedBottom = botEl ? botEl.getBoundingClientRect().top - cRectTop + content.scrollTop : content.scrollHeight;
   const st = content.scrollTop, vh = content.clientHeight;
+  // the gesture's direction (T366): an older-history ask needs an upward or unchanged move; a reader heading DOWN never
+  // asks, whatever the spacer estimate says about the top band (chat-window.ts olderRequestAllowed)
+  const upward = olderRequestAllowed(v.edgeTop, st);
+  v.edgeTop = st;
   // At the top of the RESIDENT events with older history still on the server → fetch the previous chunk
   // (loadOlder → chatHead). winStart 0 ⇒ no top spacer left to expand into; topH is 0 so this is "near 0".
-  if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx) { requestOlder(activeId, v, content); return; }
+  if (moreOnServer && (v.winStart ?? 0) === 0 && st < topH + edgePx && upward) { requestOlder(activeId, v, content); return; }
   // At the bottom of a DETACHED proto-2 window (an older window with more after it) → the next page (loadNewer → chatMore)
   if (s.detached && (v.winEnd ?? total) >= total && st + vh > renderedBottom - edgePx) { requestNewer(activeId); return; }
   const nearTopEdge = (v.winStart ?? 0) > 0 && st < topH + edgePx;
@@ -16976,9 +16980,20 @@ function olderOnServer(s: Session): boolean {
 }
 // A deep-link anchor past the resident run: ONE round trip for a window around it (chatWindow), instead of the
 // index wire's fetch-older-until-resident loop. False when nothing can be asked (an index session, a request in flight).
+// sid -> the window was asked by a NAVIGATION (a card, a notch, a deep link, a seek, a reload's restore of the reader's
+// saved place: every anchor landing but one), not by the keep-offset RE-LAND of the reader's own row across a rebuild
+// (pendingAnchorKeepY set), the one ask that exists only to keep their row on screen and must never move them off the
+// live run (T366: a window landing mid-flick detached a reader; a navigation's window may, a re-land's never)
+const pendingWindowNav = new Map<string, { nav: boolean; t: number | null }>();   // …and the navigation's time when its frame carried one (the strip names it)
 function requestAround(sid: string, uuid: string): boolean {
   const s = sessions.get(sid);
   if (!s || s.proto !== 2 || loadingOlder.has(sid)) return false;
+  const nav = pendingAnchorKeepY == null;
+  pendingWindowNav.set(sid, { nav, t: nav ? (pendingAnchorT ?? null) : null });
+  // every window ask leaves a diagnostic row (T366: the rows of the report had the reply's landing but nothing said
+  // which pass asked for the window): the landing trail so far, the anchor's kind, whether a keep-offset restore asked
+  const cAsk = document.getElementById("content");
+  vscodeApi?.postMessage({ type: "clientDiag", surface: "chat", what: "windowask", data: { sid, nav, kind: pendingAnchorKind ?? null, intent: pendingAnchorIntent ?? null, keep: pendingAnchorKeepY != null, trail: landTrail.slice(-4), detached: !!s.detached, atBottom: !!cAsk && atBottom(cAsk) } });
   pendingOlderAnchor.set(sid, uuid);
   pendingOlderKeepY.delete(sid);
   loadingOlder.add(sid);
@@ -17010,18 +17025,35 @@ function chatWindow(msg: any) {
   stripOptimistic(s);
   const heldLast = s.lastUuid, wasDetached = !!s.detached;
   const r = mergeWindow(s.events as { uuid?: string }[], msg.events as { uuid?: string }[]);
-  s.events = r.events as ChatEvent[];
-  s.firstUuid = keyOf(s.events[0] as { uuid?: string; key?: string } | undefined) ?? null;
-  s.lastUuid = keyOf(s.events[s.events.length - 1] as { uuid?: string; key?: string } | undefined) ?? null;
+  const newLast = keyOf(r.events[r.events.length - 1] as { uuid?: string; key?: string } | undefined) ?? null;
   // detached only when the merged run's newest event is not the live tail the page held: a window that overlaps the
   // resident tail merges into one contiguous run through it and stays attached (review find G; the kernel says so
   // too, `connected`); a client detached BEFORE the window stays so on the merge clause (round 2, item 2)
-  s.detached = windowDetached(!!msg.moreAfter, !!msg.connected, wasDetached, r.mode, heldLast, s.lastUuid);
+  const detached = windowDetached(!!msg.moreAfter, !!msg.connected, wasDetached, r.mode, heldLast, newLast);
+  // …but a detaching window that lands on the active view of a run that was ATTACHED, asked by no navigation of the
+  // reader's own (the re-land of their row after a rebuild), never takes them off it (T366, the user 2026-09-12: the
+  // paused strip mid-flick toward the bottom): the window is not adopted, and the kernel, whose base for this client
+  // moved to the window, is asked to re-base it on the tail (a full frame that merges into the held run)
+  const ask = pendingWindowNav.get(msg.id) ?? null;
+  const landing = windowLanding(detached, msg.id === activeId && !wasDetached, ask?.nav ?? false);
+  pendingWindowNav.delete(msg.id);
+  if (landing === "reattach") {
+    reconcileOptimistic(s);
+    if (msg.id === activeId) { if (pendingAnchor === anchorUuid) { pendingAnchor = null; pendingAnchorKeepY = null; } anchorPendingOlder = false; landTrail.push("window-not-adopted"); }
+    reattachLive(msg.id, true);
+    updateLivePaused();
+    return;
+  }
+  s.events = r.events as ChatEvent[];
+  s.firstUuid = keyOf(s.events[0] as { uuid?: string; key?: string } | undefined) ?? null;
+  s.lastUuid = newLast;
+  s.detached = detached;
+  s.detachNav = detached && ask?.nav ? { t: ask.t } : null;   // the strip names a navigation's detach (T366); read only while detached
   if (msg.moreBefore === false) s.headKnown = true;
   s.headTotal = s.headKnown && !s.detached ? s.events.length : null;   // a count only when the whole is resident
   reconcileOptimistic(s);
   const v = views.get(msg.id);
-  if (v) { v.rendered = 0; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; v.stale = true; }
+  if (v) { v.rendered = 0; v.winStart = 0; v.winEnd = 0; v.avgTurnH = undefined; v.spacerCount = undefined; v.spacerCountBot = undefined; v.unitTotal = undefined; v.edgeTop = undefined; v.stale = true; }
   if (msg.id !== activeId) return;
   const target = typeof msg.anchor === "string" ? msg.anchor : anchorUuid;
   if (target) { pendingAnchor = target; pendingAnchorIntent = null; pendingAnchorT = null; pendingAnchorKind = null; flashedAnchor = null; pendingAnchorKeepY = null; anchorPendingOlder = false; }
@@ -17073,6 +17105,7 @@ function chatMore(msg: any) {
 // returns too. The return is a full frame (needFull "reattach"): upsert merges it into the held run when they
 // overlap, so the pages the reader walked stay resident.
 let livePausedEl: HTMLElement | null = null;
+let livePausedTxt: HTMLElement | null = null;   // the strip's sentence, re-said on every evaluation (T366)
 function updateLivePaused(): void {
   const s = activeId ? liveSession(activeId) : null;
   const on = !!(s && s.proto === 2 && s.detached);
@@ -17080,19 +17113,22 @@ function updateLivePaused(): void {
   if (!livePausedEl) {
     livePausedEl = el("div", "live-paused");
     livePausedEl.id = "live-paused";
-    const txt = el("span", "live-paused-text"); txt.textContent = "Live updates are paused while you read older history.";
+    livePausedTxt = el("span", "live-paused-text");
     const btn = document.createElement("button"); btn.className = "live-paused-btn"; btn.type = "button"; btn.textContent = "Return to live";
     btn.onclick = () => { if (activeId) reattachLive(activeId); };
-    livePausedEl.appendChild(txt); livePausedEl.appendChild(btn);
+    livePausedEl.appendChild(livePausedTxt); livePausedEl.appendChild(btn);
     document.body.appendChild(livePausedEl);
   }
+  // the sentence names a navigation's detach (a card or lane click with the message's time) and keeps the plain one
+  // otherwise (T366): a jump landing mid-scroll must not read as the scroll pausing the page
+  if (livePausedTxt) livePausedTxt.textContent = livePausedText(!!s.detachNav, s.detachNav ? s.detachNav.t : null, clockOf);
   livePausedEl.hidden = false;
   const c = document.getElementById("content");
   if (c) livePausedEl.style.bottom = (Math.max(0, window.innerHeight - c.getBoundingClientRect().bottom) + 40) + "px";
 }
-function reattachLive(sid: string): void {
+function reattachLive(sid: string, force = false): void {
   const s = sessions.get(sid);
-  if (!s || s.proto !== 2 || !s.detached) return;
+  if (!s || s.proto !== 2 || (!s.detached && !force)) return;   // force: a window the client did not adopt moved the KERNEL's base for it (T366)
   vscodeApi?.postMessage({ type: "reattachKeys", id: sid, keys: reattachKeys(s.events as { uuid?: string; key?: string }[]) });   // the run as held, for the kernel's shared clause
   requestFullSession(sid, "reattach");   // the kernel's full tail frame re-bases this client; upsert merges it into the held run
 }

--- a/ui/webview/scroll-keep-on-show.test.ts
+++ b/ui/webview/scroll-keep-on-show.test.ts
@@ -79,7 +79,7 @@ test("render.ts: the reshow decision counts a live durable seek for the tab as n
 test("render.ts: the #content scroll listener keeps the active view's saved spot current (passive, no timer)", () => {
   assert.match(RENDER, /import \{ followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxBelow, followTailShrink, reshowStick \} from "\.\/scroll-keep";/);   // + followTail (T262: follow only on new content)
   // …and stands down while a deferred build is pending: the reveal's clamp fires a scroll event before the land
-  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,5}?\s*\}, \{ passive: true \}\);/);
+  assert.match(RENDER, /c\.addEventListener\("scroll", \(\) => \{\n\s*if \(c\.clientHeight <= 0\) return;\n\s*followReader\(activeId \? views\.get\(activeId\) : null, c\.scrollTop, atBottom\(c\), pendingBuildRaf != null\);\n(?:.*\n){0,9}?\s*\}, \{ passive: true \}\);/);   // up to nine lines follow the follow rule: the gesture classification, its mark on the view for the edge check (T366), the gesture row and the sh/ch note
   // landActive's landing rule itself is unchanged — its INPUT is what the fix repairs
   assert.match(RENDER, /if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);   // (T262: every #content write rides writeScroll)
 });

--- a/ui/webview/scroll-movers.test.ts
+++ b/ui/webview/scroll-movers.test.ts
@@ -54,6 +54,6 @@ test("render.ts: every mover of #content is a writeScroll — scrollBy and scrol
 test("render.ts: a spacer re-size of the active view files a spacer row; the cap comes from localStorage", () => {
   assert.match(RENDER, /if \(\(topAfter !== topBefore \|\| botAfter !== botBefore\) && activeId && views\.get\(activeId\) === v\) \{\s*\n\s*const content = document\.getElementById\("content"\);\s*\n\s*scrollDiagRow\("spacer", spacerRow\(activeId, topBefore, topAfter, botBefore, botAfter,/);
   assert.match(RENDER, /const scrollDiagCap = readScrollDiagCap\(\(k\) => \{ try \{ return localStorage\.getItem\(k\); \} catch \{ return null; \} \}\);\s*\n\s*const scrollDiag = new ScrollDiagBudget\(scrollDiagCap\);/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange" \| "windowask", data: any\): void \{/);
   assert.match(RENDER, /data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/, "the capped row says which cap");
 });

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -55,5 +55,5 @@ test("render.ts: one helper writes #content.scrollTop, files the row only when t
   const raw = RENDER.split("\n").filter((l) => /\b(content|c)\.scrollTop (=|\+=|-=) /.test(l) && !/writeScroll|const |let /.test(l));
   assert.deepEqual(raw.map((l) => l.trim()), ["content.scrollTop = top;"], "the only assignment is the helper's own");
   // the gesture marker: a write's echo is consumed, anything else files a gesture row
-  assert.match(RENDER, /if \(classifyScroll\(c\.scrollTop, lastScrollWriteAfter\) === "write-echo"\) lastScrollWriteAfter = null;\s*\n\s*else scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true, sh: c\.scrollHeight, ch: c\.clientHeight \}\);/);
+  assert.match(RENDER, /const cls = classifyScroll\(c\.scrollTop, lastScrollWriteAfter\);\s*\n\s*const gv = activeId \? views\.get\(activeId\) : null;\s*\n\s*if \(gv\) gv\.gestureScroll = cls === "gesture";[^\n]*\n\s*if \(cls === "write-echo"\) lastScrollWriteAfter = null;\s*\n\s*else scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true, sh: c\.scrollHeight, ch: c\.clientHeight \}\);/, "the scroll nobody's code asked for is the user's; a write's echo is consumed, never filed (the classification is read once and marks the view for the edge check, T366)");
 });

--- a/ui/webview/tail-change-row.test.ts
+++ b/ui/webview/tail-change-row.test.ts
@@ -28,7 +28,7 @@ test("the tail label is the last child that is not a virtualization spacer", () 
 
 test("render.ts files the row from both tail observers, beside the tail-shrink rule, through the capped diag path", () => {
   assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow, unitChangeRow, unitChanges, boxChanges, boxLabel, BOX_FROM_TAIL \} from "\.\/scroll-write";/);   // + spacerRow, readScrollDiagCap (T262j)
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);   // + spacer (T262j)
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange" \| "windowask", data: any\): void \{/);   // + spacer (T262j)
   assert.match(RENDER, /if \(content && lastH >= 0 && activeId === id && view\.shown && h !== lastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(id, h - lastH, tailLabel\(view\.el\.children\), view\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.match(RENDER, /if \(content && tailLastH >= 0 && v && v\.shown && h !== tailLastH\)\s*\n\s*scrollDiagRow\("tailchange", tailChangeRow\(activeId \|\| "", h - tailLastH, "live-ask", v\.stick, content\.scrollHeight, content\.clientHeight\)\);/);
   assert.equal((RENDER.match(/"tailchange"/g) || []).length, 3, "the kind in the router's union and the two filings");

--- a/ui/webview/tail-mutation.test.ts
+++ b/ui/webview/tail-mutation.test.ts
@@ -39,7 +39,7 @@ test("the row carries what left, whether it came back, and the scroll height bef
 
 test("render.ts observes the active view's children and the live-ask host's, and files the row through the capped diag path", () => {
   assert.match(RENDER, /import \{[^}]*\bsummarizeTailMutations\b[^}]*\btailMutRow\b[^}]*\} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange" \| "windowask", data: any\): void \{/);
   assert.match(RENDER, /mo\?: MutationObserver; \}/, "the View carries its mutation observer");
   assert.match(RENDER, /v\.mo = new MutationObserver\(\(records\) => \{/);
   assert.match(RENDER, /v\.mo\.observe\(elv, \{ childList: true \}\);/);

--- a/ui/webview/unit-change-row.test.ts
+++ b/ui/webview/unit-change-row.test.ts
@@ -111,7 +111,7 @@ test("render.ts watches #content's non-thread boxes: appear, change in place and
 test("render.ts wires one observer per view over every unit, through the mutation observer, into the capped diag path", () => {
   const ev = RENDER.split("function ensureView(id: string): View {")[1].split("\n}")[0];
   assert.match(RENDER, /import \{[^}]*\bunitChangeRow\b[^}]*\bunitChanges\b[^}]*\} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange", data: any\): void \{/);
+  assert.match(RENDER, /function scrollDiagRow\(kind: "scrollwrite" \| "scrollgesture" \| "tailchange" \| "spacer" \| "tailmut" \| "unitchange" \| "windowask", data: any\): void \{/);
   assert.match(RENDER, /uo\?: ResizeObserver; uh\?: WeakMap<Element, number>; ro\?: ResizeObserver; mo\?: MutationObserver; \}/, "the View carries the unit observer and its heights");
   // a hidden view's units measure 0x0 on hide and their full height on re-show: neither is a change (the review's
   // find: one switch back would have filed a row per unit and burnt the minute's cap). The hide forgets baselines


### PR DESCRIPTION
The chat's "live updates are paused" strip appeared for a reader who was scrolling down toward the bottom of a live session and had, as far as they knew, clicked nothing.

**What the rows said.** The window's scroll rows had a tab switch landing on the saved place, a trackpad flick running downward, and, mid-flick, a window reply landing with an anchor write while the scroll height shrank to a replaced run; the reader kept flicking to the window's bottom, two page loads reached the tail, and the strip went away. The rows could not say which pass asked for the window. The landing audit the kernel serving the session keeps could: one attempt with an anchor uuid and an anchor time many hours back, no kind, no keep flag, trail pointer-fetch-window, then a landing with pointer-exact. That is a navigation frame carrying a message's uuid and time (a card's or a lane's), whose reply landed in the middle of a flick, so the jump read as the scroll pausing the page. (All times and ids here are described, not quoted; the fixtures are synthetic.)

**What changes.**

- A window that no navigation asked for never detaches an attached reader, at the bottom or above it. The one such ask the client makes is the keep-offset re-land of the reader's own row across a rebuild; when its reply would detach, the window is not adopted, the kernel, whose base for this client moved to the window, is asked to re-base it on the tail at once, and no strip shows. Every other window ask (a card, a notch, a deep link, a durable seek, a reload's restore of the reader's saved place) lands as before.
- An older-history ask needs an upward or unchanged move of the view. A downward gesture never asks, whatever the spacer estimate says about the top band.
- The strip names a navigation's detach: "Showing the message from 12:14 AM you opened; live updates are paused", with the same Return to live control, when the frame carried the message's time; "Showing the message you opened" when it did not; a detach with no navigation behind it keeps the plain sentence.
- Every window ask files a windowask client-diag row with the landing trail so far, the anchor kind, whether a keep-offset restore asked, and whether the view was at the bottom, so the next report names its click without a second pull.

The two rules and the sentence are pure functions in `ui/webview/chat-window.ts` (`windowLanding`, `olderRequestAllowed`, `livePausedText`), executed in `chat-window.test.ts` with source pins on the wiring; the moved pins were re-pointed.

**The served lab** (`tests/test_live_paused_window_browser.py`, synthetic transcript longer than the wire tail so older history stays on the server): a reader attached above the bottom receives a window nobody asked for whose verdict would detach, and the page shows no strip, keeps its resident tail on screen, adopts none of the window's events and asks the kernel to re-attach (red on the merge-base: the window replaced the run and the strip showed); the same page then navigates by a focus frame with an anchor and its time into history it does not hold, asks for the window, lands, detaches, and the strip names the opened message's time; a downward flick from the top band of the resident run sends no older-history ask.

**Held for the user's call** (the manager is asking): whether a landing that arrives after the reader has scrolled since the click should still land, and whether followup-bound cards should land at the tail.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
