### PR TITLE
The timeline holds each live lane's closed turns as a prefix, so a moved transcript derives only its tail

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -39971,6 +39971,9 @@ _lanes_memo = {}          # sid -> (session, goals_obj, caps_key, key, value, pr
 _LANES_MEMO_MAX = 256
 _lanes_stats = {"hit": 0, "miss": 0, "live_tail": 0, "complain_skip": 0, "unshared_skip": 0, "evict": 0,
                 "segs_hit": 0, "segs_miss": 0,
+                # the PREFIX memo (2026-09-12): derivations that reused a held prefix of closed turns, and the segments
+                # those prefixes carried (work a whole-lane derivation would have redone); segs_miss counts only the derived
+                "prefix_hit": 0, "prefix_segs": 0,
                 # the DEAD lanes of a bars build, counted by build_timeline (this memo never sees one): served from
                 # _dead_lane_memo (dead_serve), derived through _lane_segments (dead_miss: cached after, unless the
                 # store faulted, the transcript could not be stat'd or a stage complained), or served as the empty
@@ -39999,9 +40002,46 @@ def _lanes_forget(keep):
             _lanes_memo.pop(k, None)
         if gone:
             _lanes_stats["evict"] += len(gone)
+    with _LANE_PREFIX_LOCK:
+        for k in [k for k in _lane_prefix_memo if k not in keep]:
+            _lane_prefix_memo.pop(k, None)
 
 
-def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None):
+# The lane PREFIX memo (2026-09-12, the user's performance program): a live lane whose transcript moved, or whose
+# live tail was merged (a turn in flight: `session is not parsed`, 35 % of the per-lane memo's lookups on the devbox),
+# re-derived EVERY turn of its history each build: 1.19 million segments re-walked in 25 minutes for 149 builds of
+# 3.4 s each, a third of the pusher's wall time. Every closed turn's bars depend only on that turn and the lane's
+# inputs (the goals object for the seams, the captions file for the captions, live, the branch clip, the host's
+# downtime), never on its neighbours, so the bars of the turns BEFORE the last one are held per lane and reused
+# while those turns' identities and the inputs stand; only the tail (and any turn after the first that changed) is
+# derived. Keyed like _lanes_memo (its comment names the inputs); the goals object is compared by identity, so an
+# unshared mutable store disables the prefix for that build (the derivation stays whole). Bounded by the lanes the
+# builds draw (_lanes_forget drops the rest) and by _LANES_MEMO_MAX like the lane memo; the bars it holds are the
+# same objects the lane memo and the wire cache hold. Counted under memos.lanes as prefix_hit and prefix_segs.
+_lane_prefix_memo = {}    # sid -> (inputs, turn_keys, bars, seg_ends, prompts, last_t, nsegs, complained)
+_LANE_PREFIX_LOCK = threading.Lock()
+
+
+def _turn_prefix_key(turn):
+    """A closed turn's identity for the prefix: its id, whether it ended, its atom count and its end."""
+    return (turn.get("id"), bool(turn.get("ended")), len(turn.get("atoms") or ()), turn.get("end"))
+
+
+def _lane_prefix_inputs(goals, cap_key, live, bft):
+    """The non-turn inputs a prefix is valid under, or None when the prefix must not be used this build (an unshared
+    mutable goals store, captions read with no file key)."""
+    if isinstance(goals, jd.FrozenStore):
+        gkey = ("shared", id(goals))
+    elif goals is None or (not goals.get("seams") and not goals.get("nodes")):
+        gkey = "empty"
+    else:
+        return None
+    if not (isinstance(cap_key, tuple) or cap_key == "empty"):   # a stat key, or the lane memo's "no file, no rows"
+        return None
+    return (gkey, cap_key, bool(live), bft, tuple(_downtime))
+
+
+def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None, cap_key=None):
     """The SEGMENT part of one timeline lane: the turn loop build_timeline ran inline, moved here so the per-lane
     memo (_lane_memo; the comment above _lanes_memo names every input) can hold its result: (bars, seg_ends,
     last_t, compactions, cap_marks, other_marks, nsegs, complained). bars are the lane's wire bars in turn order
@@ -40019,7 +40059,40 @@ def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None):
         full_prompts = {}
     st_turns = session["turns"]
     bars, last_t, seg_ends, nsegs, complained = [], None, {}, 0, False   # seg_ends: seg-start t → work-END t (for completion marks)
-    for ti, turn in enumerate(st_turns):
+    # the prefix: the held bars of the closed turns before the last one, reused while their identities and the inputs stand
+    inputs = _lane_prefix_inputs(goals, cap_key, live, bft)
+    n_last = len(st_turns) - 1
+    turn_keys = [_turn_prefix_key(t) for t in st_turns[:n_last]] if inputs is not None and n_last > 0 else []
+    start_k = 0
+    if turn_keys:
+        with _LANE_PREFIX_LOCK:
+            held = _lane_prefix_memo.get(sid)
+        if held is not None and held[0] == inputs:
+            k = 0
+            for a, b in zip(held[1], turn_keys):
+                if a != b:
+                    break
+                k += 1
+            if k > 0:
+                if k == len(held[1]):                       # the whole held prefix stands: reuse its objects
+                    bars = list(held[2]); seg_ends = dict(held[3]); prompts_held = held[4]; last_t = held[5]; nsegs_held = held[6]
+                    complained = held[7]
+                else:                                       # a shorter common prefix: keep the bars of the turns that stand
+                    nsegs_held = 0; prompts_held = {}
+                    keep_ids = set()
+                    for t in st_turns[:k]:
+                        keep_ids.update(x.get("id") for x in (t.get("atoms") or ()) if False)   # (bars carry seg ids, below)
+                    k = 0                                   # partial reuse is not attempted: a changed middle turn re-derives all
+                if k > 0:
+                    full_prompts.update(prompts_held)
+                    start_k = k
+                    with _LANES_LOCK:
+                        _lanes_stats["prefix_hit"] += 1
+                        _lanes_stats["prefix_segs"] += nsegs_held
+    snap = None
+    for ti, turn in enumerate(st_turns[start_k:], start=start_k):
+        if ti == n_last and turn_keys and snap is None:
+            snap = (list(bars), dict(seg_ends), dict(full_prompts), last_t, nsegs, complained)   # the closed turns' part, before the tail
         if turn.get("echoTurn"):
             continue        # a stale echo's own turn (T344): a send the transcript never took draws no bar
         turn_open = (live and ti == len(st_turns) - 1 and not turn["ended"]
@@ -40112,6 +40185,12 @@ def _lane_segments(sid, session, goals, caps, live, bft, full_prompts=None):
                     # whose dot had drawn as a human prompt instead of wearing the logo), mirroring the chat's 2026-07-05 rule
                     bar["o"] = True
                 bars.append(bar)
+    if turn_keys and snap is not None and not snap[5]:
+        with _LANE_PREFIX_LOCK:                             # hold the closed turns' part for the next derivation of this lane
+            _lane_prefix_memo.pop(sid, None)
+            while len(_lane_prefix_memo) >= _LANES_MEMO_MAX:
+                _lane_prefix_memo.pop(next(iter(_lane_prefix_memo)))
+            _lane_prefix_memo[sid] = (inputs, turn_keys, snap[0], snap[1], snap[2], snap[3], snap[4] + (nsegs_held if start_k else 0), False)
     try:
         cap_marks, other_marks = _derive_judging_marks(sid, caps, goals, seg_ends) if goals is not None else ([], [])
         # The horizon comparisons run in _judging_assemble, per build, outside this lane's guard; the one-pass form
@@ -40184,7 +40263,7 @@ def _lane_memo(sid, parsed, session, goals, caps, cap_key, live, bft, parse_ok=T
             if ent[0] is not parsed:
                 _lanes_memo.pop(sid, None)                    # its parse object is no longer the build's: it cannot hit again
     lane_prompts = {}
-    value = _lane_segments(sid, session, goals, caps, live, bft, lane_prompts)
+    value = _lane_segments(sid, session, goals, caps, live, bft, lane_prompts, cap_key=ckey)
     if full_prompts is not None:
         full_prompts.update(lane_prompts)
     outcome = skip or ("complain_skip" if value[7] else "miss")

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -148,7 +148,7 @@ class Collector(unittest.TestCase):
             for k, v in snap["memos"][blk].items():
                 self.assertIsInstance(v, int, "%s.%s" % (blk, k))
         self.assertEqual(set(snap["memos"]["lanes"]), {"hit", "miss", "live_tail", "complain_skip", "unshared_skip", "evict", "entries",
-                                                     "segs_hit", "segs_miss", "dead_serve", "dead_miss", "dead_failed_serve"},
+                                                     "segs_hit", "segs_miss", "prefix_hit", "prefix_segs", "dead_serve", "dead_miss", "dead_failed_serve"},
                          "the timeline's per-lane segment memo: one outcome per live lane per bars build, the dead lanes beside")
         self.assertTrue(all(type(v) is int for v in snap["memos"]["lanes"].values()))
         self.assertEqual(set(snap["memos"]["chatMergeSets"]), {"hit", "miss", "entries"})

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -1337,13 +1337,60 @@ class PerfWiring(LaneMemoBase):
         self.build(); self.build()
         blk = km._PERF_STATS.snapshot()["memos"]["lanes"]
         self.assertEqual(set(blk), {"hit", "miss", "live_tail", "complain_skip", "unshared_skip", "evict", "entries",
-                                    "segs_hit", "segs_miss", "dead_serve", "dead_miss", "dead_failed_serve"})
+                                    "segs_hit", "segs_miss", "prefix_hit", "prefix_segs", "dead_serve", "dead_miss", "dead_failed_serve"})
         self.assertEqual((blk["hit"], blk["miss"], blk["entries"], blk["segs_hit"], blk["segs_miss"]), (1, 1, 1, 1, 1))
         self.assertEqual((blk["dead_serve"], blk["dead_miss"], blk["dead_failed_serve"]), (0, 0, 0), "live lanes only so far")
         self.build(live_map={}); self.build(live_map={})
         blk = km._PERF_STATS.snapshot()["memos"]["lanes"]
         self.assertEqual((blk["dead_serve"], blk["dead_miss"], blk["dead_failed_serve"]), (1, 1, 0), "the dead lanes ride the same block")
         self.assertEqual((blk["hit"], blk["miss"]), (1, 1), "and leave the live counters alone")
+
+
+class PrefixMemo(LaneMemoBase):
+    """The lane PREFIX memo (2026-09-12): a live lane whose transcript moved re-derived every turn of its history each
+    build (1.19 million segments re-walked in 25 minutes on the devbox, a third of the pusher's time). The closed
+    turns before the last one are held per lane and reused; only the tail is derived, and the bars equal a whole
+    derivation's."""
+
+    def _prefix_counts(self):
+        st = self.stats()
+        return (st["prefix_hit"], st["prefix_segs"])
+
+    def test_a_third_turn_reuses_the_held_prefix_and_equals_a_whole_derivation(self):
+        km.jd.append_caption(LIVE_SID, self.seg_id(), "segment", self.t0, "Added backoff")
+        self.build()                                                  # one turn: nothing before the tail, no prefix held
+        self.append_records([_rec("user", self.t0 + 100, "u2", "a1", "and cap the delay"),
+                             _rec("assistant", self.t0 + 120, "a2", "u2", "Capped at two minutes.")])
+        self.build()                                                  # two turns: the first turn is held as the prefix
+        self.assertEqual(self._prefix_counts(), (0, 0), "nothing to reuse yet: the held prefix was empty at the first build")
+        self.append_records([_rec("user", self.t0 + 200, "u3", "a2", "and log each retry"),
+                             _rec("assistant", self.t0 + 220, "a3", "u3", "Logged with the delay.")])
+        tl3 = self.build()                                            # three turns: the first turn's bars come from the prefix
+        self.assertEqual(self._prefix_counts(), (1, 1), "one derivation reused the prefix, one segment came from it")
+        self.assertEqual(len(tl3["turns"][LIVE_SID]), 3)
+        # what the prefix served equals a whole derivation on the same objects
+        km._lane_prefix_memo.clear()
+        session = km._parse(str(self.tpath()), LIVE_SID, self.now)
+        goals = km.jd.load_goals_shared(LIVE_SID)
+        caps = km._captions(LIVE_SID)
+        bars, seg_ends, last_t, compactions, cap_marks, other_marks, nsegs, complained = km._lane_segments(
+            LIVE_SID, session, goals, caps, True, None)
+        self.assertEqual(json.dumps(tl3["turns"][LIVE_SID]), json.dumps(bars), "the prefix path and the whole derivation agree")
+        self.assertEqual(nsegs, 3)
+        self.assertEqual(self.stats()["segs_miss"], 1 + 2 + 2, "the derivations walked 1, then 2, then only the 2 turns after the prefix")
+
+    def test_a_captions_change_is_a_new_input_and_the_prefix_is_not_served_under_the_old_one(self):
+        self.append_records([_rec("user", self.t0 + 100, "u2", "a1", "and cap the delay"),
+                             _rec("assistant", self.t0 + 120, "a2", "u2", "Capped at two minutes.")])
+        self.build()
+        self.append_records([_rec("user", self.t0 + 200, "u3", "a2", "and log each retry"),
+                             _rec("assistant", self.t0 + 220, "a3", "u3", "Logged with the delay.")])
+        self.build()
+        self.assertEqual(self._prefix_counts()[0], 1)
+        km.jd.append_caption(LIVE_SID, self.seg_id(), "segment", self.t0, "Added backoff")   # the first turn's caption changes
+        tl = self.build()
+        self.assertEqual(self._prefix_counts()[0], 1, "a changed captions file is a changed input: the old prefix is not served")
+        self.assertEqual(tl["turns"][LIVE_SID][0].get("c"), "Added backoff", "and the first bar carries the new caption")
 
 
 if __name__ == "__main__":

--- a/tests/test_timeline_lane_memo.py
+++ b/tests/test_timeline_lane_memo.py
@@ -544,6 +544,7 @@ class LaneMemoBase(unittest.TestCase):
         self._saved_backend = km.Sessions.backend_for
         self._saved_file_key = km.jd._file_key
         km._lanes_memo.clear(); _zero(km._lanes_stats)
+        km._lane_prefix_memo.clear()                 # the prefix memo (2026-09-12) holds turn keys that repeat across tests
         km._sdk = lambda: None
         km._run_judging = lambda t0, alive, semantic: [dict(m) for m in semantic]
         self.now = int(time.time())
@@ -563,6 +564,7 @@ class LaneMemoBase(unittest.TestCase):
         km.jd._file_key = self._saved_file_key
         km.jd._SHARED_OFF[0] = False
         km._lanes_memo.clear(); _zero(km._lanes_stats)
+        km._lane_prefix_memo.clear()                 # the prefix memo (2026-09-12) holds turn keys that repeat across tests
         km._dead_lane_memo.clear(); km._downtime[:] = []
         km.jd._rebind_state(self._saved_state)
         km.jd.PROJECTS = self._saved_proj


### PR DESCRIPTION
The timeline's per-lane memo re-derived a moved lane's whole history on every build: on the devbox that was 149 builds × 3.4 s in 25 minutes (34 % of the pusher's wall time), 1.19 million segments re-walked, with a turn in flight defeating the memo for a third of lookups.

Each live lane now holds the bars of its closed turns (all but the last) as a prefix keyed on the same inputs the lane memo uses plus the turns' identities; a moved transcript derives only its tail. A changed input or middle turn, an unshared store, or a complaining lane derives whole as before. Counted under `/perf` `memos.lanes` as `prefix_hit` / `prefix_segs`.

Tests: `tests/test_timeline_lane_memo.py::PrefixMemo` (reuse and equality with a whole derivation; a captions change invalidates), key pins updated. The reuse test fails with the prefix disabled.

Tier: fix
