### PR TITLE
The file viewer's title bar, tidied: grouped controls, a joined format pair, glyphs with their words a hover away, the GitHub link only when it resolves (T367)

### DIFF
--- a/tests/test_file_view_bar_browser.py
+++ b/tests/test_file_view_bar_browser.py
@@ -102,7 +102,7 @@ const bar = (label) => page.evaluate((label) => {
   const seg = acts.querySelector(".fileview-seg");
   const segBtns = seg ? Array.from(seg.children).map((e) => ({ text: e.textContent.trim(), rect: rect(e), radius: getComputedStyle(e).borderRadius, on: e.classList.contains("on") })) : [];
   return { label, controls, bar: rect(barEl), box: rect(box),
-    gh: gh ? { hidden: gh.hidden, busy: gh.getAttribute("aria-busy"), children: gh.children.length, text: gh.textContent.trim() } : null,
+    gh: gh ? { hidden: gh.hidden, busy: gh.getAttribute("aria-busy"), children: gh.children.length, text: gh.textContent.trim(), display: getComputedStyle(gh).display, w: gh.getBoundingClientRect().width } : null,
     seg: seg ? { group: groupOf(seg), sameParent: seg.children.length === 2 && seg.children[0].nextElementSibling === seg.children[1], btns: segBtns } : null,
     groups: Array.from(acts.children).map((c) => c.className + (c.hidden ? "[hidden]" : "")),
     ghWhy: !!acts.querySelector(".fileview-gh-why") };
@@ -155,6 +155,25 @@ for (const f of cfg.files_list) {
     await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(60);
   }
 }
+// the keyboard road (review): Enter on the glyph opens the flyout, Tab moves inside, Escape closes it and returns the focus
+// to the glyph with the viewer still up; then a viewer closed from the keyboard with its flyout OPEN (the cross focused, Enter)
+// must leave no reference behind: Escape on the next file closes that viewer at once
+await open(cfg.files_list[3].path);
+await page.focus("#romp-fileview .fileview-zoom-btn"); await page.keyboard.press("Enter");
+const k1 = await page.evaluate(() => ({ open: !document.querySelector("#romp-fileview .fileview-zoom-menu").hidden, expanded: document.querySelector("#romp-fileview .fileview-zoom-btn").getAttribute("aria-expanded") }));
+await page.keyboard.press("Tab");
+const k2 = await page.evaluate(() => ({ inside: !!(document.activeElement && document.activeElement.closest(".fileview-zoom-menu")), label: document.activeElement ? document.activeElement.getAttribute("aria-label") : null }));
+await page.keyboard.press("Escape");
+const k3 = await page.evaluate(() => ({ closed: document.querySelector("#romp-fileview .fileview-zoom-menu").hidden, focusOnGlyph: document.activeElement === document.querySelector("#romp-fileview .fileview-zoom-btn"), viewerUp: !!document.getElementById("romp-fileview") }));
+await page.focus("#romp-fileview .fileview-zoom-btn"); await page.keyboard.press("Enter");
+await page.focus("#romp-fileview .fileview-close"); await page.keyboard.press("Enter");
+await page.waitForTimeout(100);
+const k4 = await page.evaluate(() => ({ viewerGone: !document.getElementById("romp-fileview") }));
+await open(cfg.files_list[0].path);
+await page.keyboard.press("Escape");
+await page.waitForTimeout(150);
+const k5 = await page.evaluate(() => ({ viewerGone: !document.getElementById("romp-fileview") }));
+out.keys = { k1, k2, k3, k4, k5 };
 fs.writeFileSync(cfg.out, JSON.stringify(out));
 await browser.close();
 console.log("RESULT: ok");
@@ -317,6 +336,8 @@ class ServedFileViewBar(unittest.TestCase):
         self.assertFalse(m["ghWhy"], "no caption text in the bar" + table)
         gh = m["gh"]
         self.assertTrue(gh is None or (gh["hidden"] and gh["children"] == 0), "the unit is hidden and empty: " + json.dumps(gh) + table)
+        if gh is not None:   # and out of the row's flow: a live inline-flex item would eat a gap between the pencil and Download (review)
+            self.assertEqual((gh["display"], gh["w"]), ("none", 0), "the hidden unit still takes room: " + json.dumps(gh))
         self.assertFalse(any(c["text"].startswith("GitHub") and not c["hidden"] for c in m["controls"]), "no GitHub control" + table)
         self.assertFalse(any("not in a git repository" in c["text"] for c in m["controls"]) or "not in a git repository" in json.dumps(m["groups"]), table)
 
@@ -386,6 +407,20 @@ class ServedFileViewBar(unittest.TestCase):
         self.assertGreaterEqual(z["open"]["rect"]["top"], z["open"]["trigger"]["bottom"], "the flyout hangs under the glyph")
         self.assertNotEqual(z["open"]["bg"], "rgba(0, 0, 0, 0)", "the menu surface (the menu tokens)")
         self.assertEqual((z["after"]["hidden"], z["after"]["expanded"], z["after"]["viewerUp"]), (True, "false", True), "Escape closes the flyout and leaves the viewer up: " + json.dumps(z["after"]))
+
+    # ── the keyboard road ──
+    def test_keyboard_enter_opens_the_flyout_escape_closes_it_with_the_focus_back_on_the_glyph(self):
+        k = self._run()["keys"]
+        self.assertEqual((k["k1"]["open"], k["k1"]["expanded"]), (True, "true"), json.dumps(k))
+        self.assertTrue(k["k2"]["inside"], "Tab moves into the flyout: " + json.dumps(k["k2"]))
+        self.assertEqual(k["k2"]["label"], "Smaller text")
+        self.assertEqual((k["k3"]["closed"], k["k3"]["viewerUp"]), (True, True), json.dumps(k["k3"]))
+        self.assertTrue(k["k3"]["focusOnGlyph"], "Escape returns the focus to the glyph, never leaves it on a hidden button (review): " + json.dumps(k["k3"]))
+
+    def test_a_viewer_closed_from_the_keyboard_with_its_flyout_open_leaves_no_stale_flyout_to_swallow_the_next_escape(self):
+        k = self._run()["keys"]
+        self.assertTrue(k["k4"]["viewerGone"], "Enter on the close cross closes the viewer: " + json.dumps(k["k4"]))
+        self.assertTrue(k["k5"]["viewerGone"], "Escape on the NEXT file closes that viewer at once; a stale flyout reference swallowed it before (review): " + json.dumps(k["k5"]))
 
     # ── copy path acknowledges ──
     def test_copy_path_acknowledges_in_the_same_tick_and_settles_to_copied_or_copy_failed(self):

--- a/tests/test_file_view_bar_browser.py
+++ b/tests/test_file_view_bar_browser.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""The file viewer's title bar, tidied (T367; the user 2026-09-12, whose bar for a markdown file read Rendered, Raw,
+A minus, a readout, A plus, Edit, "not in a git repository", a greyed GitHub link, Download, Copy path and a close
+cross on its own row). Now: the Rendered|Raw pair is ONE segmented control; the text size is one zoom glyph opening a
+flyout that holds A minus, the readout and A plus; edit, download and copy path are glyphs whose words ride their
+title and aria-label; the GitHub link shows only when it resolves (a file outside a repository shows neither the link
+nor the explanation); the controls sit in a view group and a file group, the close cross alone at the end; copy path
+acknowledges with a glyph swap.
+
+This lab drives the real /files page of a hermetic kernel (synthetic fixtures only: the notes-api demo world, host
+TESTHOST, placeholder sids) and opens four files through the pane's own relay (the romp viewFile message the shell
+sends): a markdown file committed in a repo whose origin is served from a LOCAL bare repo through a stand-in ssh (the
+GitHub-link tests' idiom, no network), a markdown file OUTSIDE any repository, a small PNG and a Python file. For each
+it reads the bar: every control's tag, words (title, aria-label, text), group, hidden state and rect. Asserted: the
+GitHub unit is hidden with no control for the file outside a repo and is one anchor for the repo file; the download
+control is the lightbox tray glyph (the same path data) with its words; the segment pair's two buttons are adjacent
+siblings in one group whose rects touch; the zoom glyph opens a flyout holding the three size buttons and Escape
+closes it; copy path acknowledges in the same tick and settles to Copied or Copy failed. FILE_BAR_DIST=<dir> serves
+another tree's UI bundle (the red run's before); FILE_BAR_SHOTS=<prefix> writes <prefix>-<file>-<theme>.png of the
+viewer's top for the four files in both themes; FILE_BAR_DUMP=<path> writes the whole measurement. Skips LOUDLY without the extension deps or a Playwright browser, and
+never otherwise (CI turns a skip in a served module into a failure)."""
+import json
+import os
+import re
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+import zlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
+from git_fixture import git, init_repo   # noqa: E402
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+IDENT = ("t@testhost", "t")
+GUIDE = "# Notes API guide\n\nThe web session keeps the notes-api tidy.\n\n## Fold rules\n\nOne rule per line.\n"
+APP_PY = "def notes():\n    return [\"a\", \"b\"]\n"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _png(w=24, h=16, rgb=(84, 178, 4)):
+    """A tiny opaque PNG, assembled at run time (no binary fixture in the repo)."""
+    raw = b"".join(b"\x00" + bytes(rgb) * w for _ in range(h))
+    def chunk(tag, data):
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xffffffff)
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b""))
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const ctx = await browser.newContext({ viewport: { width: 1100, height: 520 } });
+await ctx.grantPermissions(["clipboard-read", "clipboard-write"], { origin: cfg.origin });
+const page = await ctx.newPage();
+await page.goto(cfg.files);
+await page.waitForFunction(() => document.readyState === "complete", null, { timeout: 30000 });
+await page.waitForTimeout(400);
+const bar = (label) => page.evaluate((label) => {
+  const r1 = (v) => Math.round(v * 10) / 10;
+  const rect = (e) => { const b = e.getBoundingClientRect(); return { top: r1(b.top), bottom: r1(b.bottom), left: r1(b.left), right: r1(b.right), w: r1(b.width), h: r1(b.height) }; };
+  const box = document.querySelector("#romp-fileview .fileview"); const barEl = box && box.querySelector(".fileview-bar");
+  if (!barEl) return { label, missing: true };
+  const acts = barEl.querySelector(".fileview-acts");
+  const groupOf = (e) => { const g = e.closest(".fileview-group"); return g ? (g.classList.contains("fileview-group-view") ? "view" : "file") : (e.closest(".fileview-zoom-menu") ? "zoom-menu" : "row"); };
+  const controls = Array.from(acts.querySelectorAll("button, a")).map((e) => ({
+    tag: e.tagName.toLowerCase(), text: (e.textContent || "").trim(), title: e.title || "", aria: e.getAttribute("aria-label") || "",
+    cls: e.className, hidden: e.hidden || getComputedStyle(e).display === "none", hiddenAttr: e.hidden, display: getComputedStyle(e).display, group: groupOf(e), svg: !!e.querySelector("svg"),
+    svgPaths: Array.from(e.querySelectorAll("svg *")).map((n) => n.outerHTML).join(""), rect: rect(e), href: e.href || "" }));
+  const gh = acts.querySelector(".fileview-gh");
+  const seg = acts.querySelector(".fileview-seg");
+  const segBtns = seg ? Array.from(seg.children).map((e) => ({ text: e.textContent.trim(), rect: rect(e), radius: getComputedStyle(e).borderRadius, on: e.classList.contains("on") })) : [];
+  return { label, controls, bar: rect(barEl), box: rect(box),
+    gh: gh ? { hidden: gh.hidden, busy: gh.getAttribute("aria-busy"), children: gh.children.length, text: gh.textContent.trim() } : null,
+    seg: seg ? { group: groupOf(seg), sameParent: seg.children.length === 2 && seg.children[0].nextElementSibling === seg.children[1], btns: segBtns } : null,
+    groups: Array.from(acts.children).map((c) => c.className + (c.hidden ? "[hidden]" : "")),
+    ghWhy: !!acts.querySelector(".fileview-gh-why") };
+}, label);
+const open = async (path) => {
+  await page.evaluate(([path, sid]) => { document.getElementById("romp-fileview")?.remove(); window.postMessage({ romp: "viewFile", path, sid }, "*"); }, [path, cfg.sid]);
+  await page.waitForSelector("#romp-fileview .fileview-bar", { timeout: 15000 });
+  await page.waitForFunction(() => { const g = document.querySelector("#romp-fileview .fileview-gh"); return !g || g.getAttribute("aria-busy") !== "true"; }, null, { timeout: 15000 });   // the kernel's link verdict landed
+  await page.waitForFunction(() => !document.querySelector("#romp-fileview .fileview-load"), null, { timeout: 15000 });
+  await page.waitForTimeout(250);
+};
+const out = { files: {} };
+for (const f of cfg.files_list) {
+  await open(f.path);
+  const m = await bar(f.label);
+  // the zoom flyout: the glyph opens it, the three buttons are inside, Escape closes it
+  m.zoom = await page.evaluate(() => {
+    const t = document.querySelector("#romp-fileview .fileview-zoom-btn"); const menu = document.querySelector("#romp-fileview .fileview-zoom-menu");
+    if (!t || !menu) return { present: false };
+    const before = { hidden: menu.hidden, expanded: t.getAttribute("aria-expanded") };
+    if (t.hidden) return { present: true, triggerHidden: true, before };
+    t.click();
+    const r = (e) => { const b = e.getBoundingClientRect(); return { top: b.top, left: b.left, right: b.right, bottom: b.bottom }; };
+    const open = { hidden: menu.hidden, expanded: t.getAttribute("aria-expanded"), labels: Array.from(menu.querySelectorAll("button")).map((b) => b.getAttribute("aria-label") || b.textContent), rect: r(menu), trigger: r(t),
+                   display: getComputedStyle(menu).display, bg: getComputedStyle(menu).backgroundColor, readout: menu.querySelector(".fileview-size-reset").textContent };
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    const after = { hidden: menu.hidden, expanded: t.getAttribute("aria-expanded"), viewerUp: !!document.getElementById("romp-fileview") };
+    return { present: true, triggerHidden: false, before, open, after };
+  });
+  // copy path: the press acknowledges in the same tick and settles
+  m.copy = await page.evaluate(async () => {
+    const c = Array.from(document.querySelectorAll("#romp-fileview .fileview-acts button")).find((b) => b.getAttribute("aria-label") === "Copy path");
+    if (!c) return { present: false };
+    const glyph0 = c.innerHTML;
+    c.click();
+    const sameTick = { busy: c.classList.contains("fileview-busy") || c.classList.contains("ok") || c.classList.contains("err") };
+    await new Promise((r) => setTimeout(r, 150));
+    const settled = { title: c.title, aria: c.getAttribute("aria-label"), ok: c.classList.contains("ok"), err: c.classList.contains("err"), glyphChanged: c.innerHTML !== glyph0 };
+    let text = null; try { text = await navigator.clipboard.readText(); } catch (e) { text = "unreadable: " + e; }
+    await new Promise((r) => setTimeout(r, 1300));
+    const restored = { title: c.title, glyphBack: c.innerHTML === glyph0 };
+    return { present: true, sameTick, settled, clipboard: text, restored };
+  });
+  out.files[f.label] = m;
+  if (cfg.shots) {
+    const clip = await page.evaluate(() => { const b = document.querySelector("#romp-fileview .fileview").getBoundingClientRect(); return { x: Math.max(0, b.left - 4), y: Math.max(0, b.top - 4), width: Math.min(window.innerWidth, b.width + 8), height: 150 }; });
+    await page.screenshot({ path: cfg.shots + "-" + f.label + "-dark.png", clip });
+    await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(120);
+    await page.screenshot({ path: cfg.shots + "-" + f.label + "-light.png", clip });
+    await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(60);
+  }
+}
+fs.writeFileSync(cfg.out, JSON.stringify(out));
+await browser.close();
+console.log("RESULT: ok");
+"""
+
+
+class ServedFileViewBar(unittest.TestCase):
+    maxDiff = None
+    result = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="file-bar-")
+        before = os.environ.get("FILE_BAR_DIST", "")
+        if before:
+            src = before
+        else:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+            src = os.path.join(EXT, "dist")
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(src, dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "notes-api")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        Path(state, "session-hosts").write_text("off\n")   # a lab root writes its own session-hosts off (the conftest rule)
+        os.makedirs(cwd, exist_ok=True)
+        # the repo: a GitHub-shaped origin served from a LOCAL bare repo through a stand-in ssh (test_file_github's idiom)
+        genv = dict(os.environ, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+        origin_root = os.path.join(cls.lab, "origin")
+        bare = os.path.join(origin_root, "TESTORG", "notes-api.git")
+        os.makedirs(bare)
+        init_repo(bare, "-q", "--bare", ident=IDENT, env=genv)
+        stand_in = os.path.join(origin_root, "stand-in-ssh")
+        Path(stand_in).write_text('#!/bin/sh\nfor a in "$@"; do cmd=$a; done\ncd "%s" && eval "$cmd"\n' % origin_root)
+        os.chmod(stand_in, 0o755)
+        genv["GIT_SSH_COMMAND"] = stand_in
+        init_repo(cwd, "-q", "-b", "main", ident=IDENT, env=genv)
+        os.makedirs(os.path.join(cwd, "docs"), exist_ok=True)
+        os.makedirs(os.path.join(cwd, "src"), exist_ok=True)
+        Path(cwd, "docs", "guide.md").write_text(GUIDE)
+        Path(cwd, "src", "app.py").write_text(APP_PY)
+        Path(cwd, "docs", "figure.png").write_bytes(_png())
+        git(cwd, "add", ".", ident=IDENT, env=genv)
+        git(cwd, "commit", "-q", "-m", "the notes-api guide, app and figure", ident=IDENT, env=genv)
+        git(cwd, "remote", "add", "origin", "git@github.com:TESTORG/notes-api.git", ident=IDENT, env=genv)
+        git(cwd, "push", "-q", "origin", "main", ident=IDENT, env=genv)
+        outside = os.path.join(cls.lab, "outside")
+        os.makedirs(outside)
+        Path(outside, "notes.md").write_text("# Outside\n\nnot under any repository\n")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        Path(state, "names", SID).write_text("web\t%s\t#9cd2ff\t#0c1a2e\n" % cwd)
+        Path(state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": SID, "alive": True,
+             "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        recs = [{"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": SID,
+                 "message": {"role": "user", "content": "what does the web session do in notes-api?"}},
+                {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+                 "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                             "content": [{"type": "text", "text": "It keeps the web side of the notes-api tidy."}]}}]
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.files = [{"label": "md-repo", "path": os.path.join(cwd, "docs", "guide.md")},
+                     {"label": "md-outside", "path": os.path.join(outside, "notes.md")},
+                     {"label": "image", "path": os.path.join(cwd, "docs", "figure.png")},
+                     {"label": "code", "path": os.path.join(cwd, "src", "app.py")}]
+        cls.port, cls.token = _free_port(), "testtok-filebar"
+        # the kernel's git must reach the stand-in origin too: its ls-remote check answers from the local bare repo
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST",
+                              GIT_SSH_COMMAND=stand_in, GIT_CONFIG_GLOBAL=os.devnull, GIT_CONFIG_NOSYSTEM="1")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    @classmethod
+    def _run(cls):
+        if cls.result is not None:
+            if isinstance(cls.result, BaseException):
+                raise cls.result
+            return cls.result
+        try:
+            cls.result = cls._drive()
+        except BaseException as e:
+            cls.result = e
+            raise
+        return cls.result
+
+    @classmethod
+    def _drive(cls):
+        cfg = os.path.join(cls.lab, "cfg.json")
+        out = os.path.join(cls.lab, "result.json")
+        origin = "http://127.0.0.1:%d" % cls.port
+        with open(cfg, "w") as f:
+            json.dump({"files": "%s/files?token=%s" % (origin, cls.token), "origin": origin, "sid": SID, "files_list": cls.files,
+                       "out": out, "shots": os.environ.get("FILE_BAR_SHOTS", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(cls.klog).read()[-1500:])
+        if not os.path.exists(out):
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:])
+        result = json.loads(Path(out).read_text())
+        if os.environ.get("FILE_BAR_DUMP"):   # a path: the whole measurement, for reading the cases side by side
+            Path(os.environ["FILE_BAR_DUMP"]).write_text(json.dumps(result, indent=1) + "\n")
+        return result
+
+    def _file(self, label):
+        r = self._run()
+        m = r["files"].get(label)
+        self.assertIsNotNone(m, "no such file among %r" % list(r["files"]))
+        self.assertFalse(m.get("missing"), "the viewer opened the file: " + json.dumps(m)[:300])
+        return m
+
+    @staticmethod
+    def _ctl(m, aria):
+        return next((c for c in m["controls"] if c["aria"] == aria or c["text"] == aria), None)
+
+    # ── the GitHub unit: only when it resolves ──
+    def test_a_file_outside_a_repository_shows_neither_the_link_nor_an_explanation(self):
+        m = self._file("md-outside")
+        table = "\n  " + json.dumps(m["controls"], indent=None)[:1500]
+        self.assertFalse(m["ghWhy"], "no caption text in the bar" + table)
+        gh = m["gh"]
+        self.assertTrue(gh is None or (gh["hidden"] and gh["children"] == 0), "the unit is hidden and empty: " + json.dumps(gh) + table)
+        self.assertFalse(any(c["text"].startswith("GitHub") and not c["hidden"] for c in m["controls"]), "no GitHub control" + table)
+        self.assertFalse(any("not in a git repository" in c["text"] for c in m["controls"]) or "not in a git repository" in json.dumps(m["groups"]), table)
+
+    def test_a_committed_file_in_a_repo_with_a_github_origin_shows_one_link(self):
+        m = self._file("md-repo")
+        links = [c for c in m["controls"] if c["tag"] == "a" and c["text"] == "GitHub ↗" and not c["hidden"]]
+        self.assertEqual(len(links), 1, json.dumps(m["controls"])[:1500])
+        self.assertIn("github.com/TESTORG/notes-api/blob/main/docs/guide.md", links[0]["href"])
+        self.assertEqual(links[0]["group"], "file", "the link sits in the file group")
+        self.assertFalse(m["ghWhy"], "no caption: the note, when any, rides the tooltip")
+
+    # ── the glyphs ──
+    def test_download_is_the_lightbox_tray_glyph_with_its_words(self):
+        m = self._file("code")
+        dl = self._ctl(m, "Download")
+        self.assertIsNotNone(dl, json.dumps(m["controls"])[:1500])
+        self.assertTrue(dl["svg"], "a glyph, not a word: " + json.dumps(dl))
+        self.assertEqual(dl["text"], "", "no word in the button")
+        self.assertIn('d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"', dl["svgPaths"], "the tray's own path data (icons.ts, the lightbox's glyph)")
+        self.assertEqual((dl["title"], dl["aria"]), ("Download", "Download"))
+        self.assertEqual(dl["group"], "file")
+        for aria in ("Edit", "Copy path"):
+            c = self._ctl(m, aria)
+            self.assertIsNotNone(c, aria)
+            self.assertTrue(c["svg"] and c["text"] == "" and c["aria"] == aria, aria + ": " + json.dumps(c))
+            self.assertEqual(c["group"], "file", aria)
+
+    # ── the groups and the segment pair ──
+    def test_the_rendered_raw_pair_is_one_adjacent_segmented_control_in_the_view_group(self):
+        m = self._file("md-repo")
+        seg = m["seg"]
+        self.assertIsNotNone(seg, json.dumps(m)[:800])
+        self.assertTrue(seg["sameParent"], "two buttons, adjacent siblings in one wrapper: " + json.dumps(seg))
+        self.assertEqual([b["text"] for b in seg["btns"]], ["Rendered", "Raw"])
+        a, b = seg["btns"][0]["rect"], seg["btns"][1]["rect"]
+        self.assertLessEqual(abs(b["left"] - a["right"]), 1.5, "the pair touches (one shared hairline): " + json.dumps(seg))
+        self.assertEqual(seg["group"], "view")
+        self.assertTrue(seg["btns"][0]["radius"].startswith("6px 0px 0px 6px") or seg["btns"][0]["radius"] == "6px 0px 0px 6px", seg["btns"][0]["radius"])
+        # the row's order: the view group, the file group, the close cross
+        kinds = [g.split("[")[0] for g in m["groups"]]
+        self.assertEqual(kinds, ["fileview-group fileview-group-view", "fileview-group fileview-group-file", "fileview-btn fileview-close"], json.dumps(m["groups"]))
+
+    def test_an_image_has_no_view_controls_and_the_view_group_takes_no_room(self):
+        m = self._file("image")
+        self.assertIn("fileview-group fileview-group-view[hidden]", m["groups"], json.dumps(m["groups"]))
+        self.assertIsNone(m["seg"])
+        self.assertTrue(m["zoom"]["present"] and m["zoom"]["triggerHidden"], "no text: no zoom glyph: " + json.dumps(m["zoom"]))
+        # a hidden glyph must not PAINT: an author display on the button beat the browser's [hidden] rule once (the lab's own
+        # image screenshot showed the pencil and the magnifier), so the computed display is what is pinned
+        for c in m["controls"]:
+            if c["hiddenAttr"]:
+                self.assertEqual(c["display"], "none", "hidden but painted: " + json.dumps(c))
+                self.assertEqual((c["rect"]["w"], c["rect"]["h"]), (0, 0), "hidden but taking room: " + json.dumps(c))
+        for aria in ("Edit", "Text size"):
+            c = self._ctl(m, aria)
+            self.assertTrue(c and c["hiddenAttr"] and c["display"] == "none", aria + " hidden for a picture: " + json.dumps(c))
+
+    # ── the zoom flyout ──
+    def test_the_zoom_glyph_opens_a_flyout_with_the_three_size_buttons_and_escape_closes_it(self):
+        m = self._file("code")
+        z = m["zoom"]
+        self.assertTrue(z["present"] and not z["triggerHidden"], json.dumps(z))
+        self.assertEqual((z["before"]["hidden"], z["before"]["expanded"]), (True, "false"))
+        self.assertEqual((z["open"]["hidden"], z["open"]["expanded"], z["open"]["display"]), (False, "true", "flex"), json.dumps(z["open"]))
+        self.assertEqual(z["open"]["labels"], ["Smaller text", "Text size 100%, reset to 100%", "Larger text"], json.dumps(z["open"]))
+        self.assertEqual(z["open"]["readout"], "100%", "the readout reads the size, dimmed at the default")
+        self.assertGreaterEqual(z["open"]["rect"]["top"], z["open"]["trigger"]["bottom"], "the flyout hangs under the glyph")
+        self.assertNotEqual(z["open"]["bg"], "rgba(0, 0, 0, 0)", "the menu surface (the menu tokens)")
+        self.assertEqual((z["after"]["hidden"], z["after"]["expanded"], z["after"]["viewerUp"]), (True, "false", True), "Escape closes the flyout and leaves the viewer up: " + json.dumps(z["after"]))
+
+    # ── copy path acknowledges ──
+    def test_copy_path_acknowledges_in_the_same_tick_and_settles_to_copied_or_copy_failed(self):
+        m = self._file("md-repo")
+        c = m["copy"]
+        self.assertTrue(c["present"], json.dumps(c))
+        self.assertTrue(c["sameTick"]["busy"], "the press is acknowledged before the clipboard answers: " + json.dumps(c))
+        self.assertIn(c["settled"]["title"], ("Copied", "Copy failed"), json.dumps(c))
+        self.assertEqual(c["settled"]["aria"], c["settled"]["title"])
+        self.assertTrue(c["settled"]["glyphChanged"], "a glyph swap, not a word")
+        if c["settled"]["title"] == "Copied":
+            self.assertTrue(c["settled"]["ok"])
+            self.assertEqual(c["clipboard"], self.files[0]["path"], "the path itself reached the clipboard")
+            self.assertEqual((c["restored"]["title"], c["restored"]["glyphBack"]), ("Copy path", True), "and the control restores itself")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1508,9 +1508,39 @@ a.fileview-btn { text-decoration: none; display: inline-flex; align-items: cente
    moves under the pointer when the readout appears after the first press. visibility, not display: the slot
    stays, the button leaves the tab order. */
 .fileview-size-reset { min-width: 5.5em; box-sizing: border-box; text-align: center; font-variant-numeric: tabular-nums; }
-.fileview-size-reset.fileview-size-default { visibility: hidden; }
+.fileview-size-reset.fileview-size-default { color: var(--dim); }
 /* a link whose branch is not on origin yet: dashed, the caption carries the note */
 a.fileview-gh-note { border-style: dashed; }
+/* T367 (the user 2026-09-12): the bar's controls in GROUPS that read as units — the view group (the Rendered|Raw
+   pair, the SVG Source toggle, the text-size glyph) and the file group (edit, the GitHub link, download, copy path),
+   set apart by a wider gap than the controls within them; the close cross alone at the end. */
+.fileview-group { display: inline-flex; align-items: center; gap: 4px; }
+.fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-close { margin-left: 10px; }
+/* the Rendered|Raw pair is ONE segmented control: joined, the shared hairline drawn once, the outer corners rounded,
+   the pressed segment's accent border over the seam */
+.fileview-seg { display: inline-flex; align-items: stretch; }
+.fileview-seg .fileview-btn { border-radius: 0; }
+.fileview-seg .fileview-btn + .fileview-btn { margin-left: -1px; }
+.fileview-seg .fileview-btn:first-child { border-radius: 6px 0 0 6px; }
+.fileview-seg .fileview-btn:last-child { border-radius: 0 6px 6px 0; }
+.fileview-seg .fileview-btn.on { position: relative; z-index: 1; }
+/* a glyph button: the drawing alone, its words in the title and aria-label (one hover away); the copy control's
+   acknowledgements (a check, a cross) recolour it; a busy press dims it until the answer */
+.fileview-btn.fileview-icon { display: inline-flex; align-items: center; justify-content: center; padding: 3px 7px; line-height: 1; }
+.fileview-btn.fileview-icon svg { display: block; }
+/* the display an author rule sets (inline-flex on a glyph button, on a group) would beat the browser's own [hidden]
+   rule, and a hidden edit pencil or zoom glyph would still paint (found on the lab's image screenshot) */
+.fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden] { display: none; }
+.fileview-btn.fileview-icon.ok { color: var(--accent); border-color: var(--accent); }
+.fileview-btn.fileview-icon.err { color: var(--err); border-color: var(--err); }
+.fileview-btn.fileview-busy { opacity: 0.55; }
+/* the text-size flyout under its glyph: the menu vocabulary (the menu tokens, ui/CLAUDE.md), one row holding A−,
+   the readout and A+; the readout at the default reads dimmed (nothing to reset) rather than empty */
+.fileview-zoom { position: relative; display: inline-flex; }
+.fileview-zoom-menu { position: absolute; top: calc(100% + 4px); right: 0; z-index: 5; display: flex; align-items: center; gap: 4px; padding: 4px;
+  background: var(--menu-bg, #252526); color: var(--menu-fg, #cccccc); border: 1px solid var(--menu-border, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius-menu, 6px); box-shadow: var(--shadow-menu, 0 4px 12px rgba(0, 0, 0, 0.35)); }
+.fileview-zoom-menu[hidden] { display: none; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* gutter + code as two columns of ONE scroller: the numbers stay put horizontally against long lines,
    and because they are a sibling element a selection of the code copies without dragging them along */

--- a/ui/webview/feed.css
+++ b/ui/webview/feed.css
@@ -1483,39 +1483,29 @@ body.fileview-open { overflow: hidden; }
 .fileview-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
 a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
-/* the GitHub action is one unit: the control and, when the kernel gave one, its reason as a caption
-   beside it — visible without hover (touch has none, and a disabled button takes no focus), and whole:
-   it wraps inside a bounded width rather than truncating, because nothing in the unit takes a tap,
-   click or focus that could finish a cut sentence; same size as the buttons it annotates, ragged edge
-   away from the control it precedes. */
+/* the GitHub action is one unit holding the link when the kernel's check resolves to a URL, and hidden otherwise
+   (T367: no greyed button, no caption; the [hidden] rule below takes it out of the row's flow) */
 .fileview-gh { display: inline-flex; align-items: center; gap: 5px; min-width: 0; }
-.fileview-gh-why { font-size: 0.82em; line-height: 1.25; color: var(--dim); max-width: 18em; text-align: right; }
-/* pending: the kernel's check is on its way (up to 3 s when it must ask origin), so the slot holds the
-   dimmed button and the loader's dots (.fileview-dot, the pane's own) where the caption will go — a slow
-   check must read as a wait, not as the old no-button state nor as a verdict (the loading-state rule) */
-.fileview-gh-dots { display: inline-flex; align-items: center; gap: 4px; }
-/* a disabled bar button, greyed, hover inert: the GitHub unit's no-link state (a real disabled button, never
-   hidden: an absent button read as "broken" when the file was simply not committed yet, 2026-09-05), the
-   editor's Save while a save is in flight (disabled and reading "Saving…"), and the text-size control's ends
-   (A− at the smallest step, A+ at the largest; aria-disabled, so the button keeps the keyboard focus it holds
-   and the ring stays where the person left it). One treatment for every bar button, so neither an end nor a
-   save in progress reads as live under the pointer. */
+/* a disabled bar button, greyed, hover inert: the editor's Save while a save is in flight (disabled and reading
+   "Saving…"), and the text-size control's ends (A− at the smallest step, A+ at the largest; aria-disabled, so
+   the button keeps the keyboard focus it holds and the ring stays where the person left it). One treatment for
+   every bar button, so neither an end nor a save in progress reads as live under the pointer. */
 .fileview-btn:disabled, .fileview-btn[aria-disabled="true"] { opacity: 0.55; cursor: default; }
 .fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
 .fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active { transform: none; }
-/* the text-size readout between A− and A+ (file-view.ts textSizeControl): a slot of ONE width whatever it
-   says, and at the default (nothing to reset, nothing to say) an empty slot rather than none, so A− never
-   moves under the pointer when the readout appears after the first press. visibility, not display: the slot
-   stays, the button leaves the tab order. */
+/* the text-size readout between A− and A+ in the zoom flyout (file-view.ts textSizeControl): a slot of ONE
+   width whatever it says, so A− never moves under the pointer as the number changes; at the default (nothing
+   to reset) it reads dimmed rather than empty (T367). */
 .fileview-size-reset { min-width: 5.5em; box-sizing: border-box; text-align: center; font-variant-numeric: tabular-nums; }
 .fileview-size-reset.fileview-size-default { color: var(--dim); }
-/* a link whose branch is not on origin yet: dashed, the caption carries the note */
+/* a link whose branch is not on origin yet: dashed, the note in its tooltip and aria-label */
 a.fileview-gh-note { border-style: dashed; }
 /* T367 (the user 2026-09-12): the bar's controls in GROUPS that read as units — the view group (the Rendered|Raw
    pair, the SVG Source toggle, the text-size glyph) and the file group (edit, the GitHub link, download, copy path),
-   set apart by a wider gap than the controls within them; the close cross alone at the end. */
+   set apart by a wider gap than the controls within them; the close cross alone at the end. The wider gaps apply
+   only where groups exist: the file browser's row and the URL viewer's flat row keep their spacing. */
 .fileview-group { display: inline-flex; align-items: center; gap: 4px; }
-.fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-close { margin-left: 10px; }
+.fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-group ~ .fileview-close { margin-left: 10px; }
 /* the Rendered|Raw pair is ONE segmented control: joined, the shared hairline drawn once, the outer corners rounded,
    the pressed segment's accent border over the seam */
 .fileview-seg { display: inline-flex; align-items: stretch; }
@@ -1530,7 +1520,7 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview-btn.fileview-icon svg { display: block; }
 /* the display an author rule sets (inline-flex on a glyph button, on a group) would beat the browser's own [hidden]
    rule, and a hidden edit pencil or zoom glyph would still paint (found on the lab's image screenshot) */
-.fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden] { display: none; }
+.fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden], .fileview-gh[hidden] { display: none; }
 .fileview-btn.fileview-icon.ok { color: var(--accent); border-color: var(--accent); }
 .fileview-btn.fileview-icon.err { color: var(--err); border-color: var(--err); }
 .fileview-btn.fileview-busy { opacity: 0.55; }

--- a/ui/webview/file-view-notice.test.ts
+++ b/ui/webview/file-view-notice.test.ts
@@ -142,7 +142,7 @@ function cardUp(): Card {
   const body = card.children[card.children.length - 1];
   assert.equal(body.className, "fileview-body");
   const acts = bar.children.find((c) => c.classList.contains("fileview-acts"))!;
-  const btn = (label: string) => acts.children.find((c) => c.tagName === "button" && c.textContent === label)!;
+  const btn = (label: string) => { const walk = (n: El): El | undefined => { for (const c of n.children) { if (c.tagName === "button" && (c.textContent === label || c.getAttribute("aria-label") === label)) return c; const d = walk(c); if (d) return d; } return undefined; }; const b = walk(acts); assert.ok(b, "the " + label + " button"); return b!; };   // T367: controls sit in groups, glyph buttons carry their word as aria-label
   return { wrap, card, bar, body, edit: btn("Edit"), save: btn("Save"), cancel: btn("Cancel") };
 }
 /** Open the file, let the text land, click Edit: the editor chunk has no bundle to load from, so the plain

--- a/ui/webview/file-view-perf.test.ts
+++ b/ui/webview/file-view-perf.test.ts
@@ -174,7 +174,7 @@ function card(): Card {
   const body = root.children[root.children.length - 1];
   assert.equal(body.className, "fileview-body");
   const acts = bar.children.find((c) => c.classList.contains("fileview-acts"))!;
-  const btn = (label: string) => { const b = acts.children.find((c) => c.tagName === "button" && c.textContent === label); assert.ok(b, "the " + label + " button"); return b!; };
+  const btn = (label: string) => { const walk = (n: El): El | undefined => { for (const c of n.children) { if (c.tagName === "button" && (c.textContent === label || c.getAttribute("aria-label") === label)) return c; const d = walk(c); if (d) return d; } return undefined; }; const b = walk(acts); assert.ok(b, "the " + label + " button"); return b!; };   // T367: controls sit in groups, glyph buttons carry their word as aria-label
   return { body, btn };
 }
 /** Open the file and let the bytes land. Every open starts from the stored default: Rendered. */

--- a/ui/webview/file-view-text-size.test.ts
+++ b/ui/webview/file-view-text-size.test.ts
@@ -235,7 +235,7 @@ function view(): Promise<typeof import("./file-view")> {
   if (!bound) bound = import("./file-view").then((fv) => { fv.initFileView(() => { /* the WS poster: nothing asks the kernel here */ }); return fv; });
   return bound;
 }
-type Card = { fv: typeof import("./file-view"); wrap: El; root: El; bar: El; acts: El; body: El; down: El; reset: El; up: El; btn: (label: string) => El };
+type Card = { fv: typeof import("./file-view"); wrap: El; root: El; bar: El; acts: El; body: El; down: El; reset: El; up: El; zoom: El; btn: (label: string) => El };   // zoom: the glyph that shows or hides the control (T367)
 /** The card up now, with the control's three buttons held by reference (they are built once per open). */
 function card(fv: typeof import("./file-view")): Card {
   const wrap = doc.getElementById("romp-fileview");
@@ -247,10 +247,10 @@ function card(fv: typeof import("./file-view")): Card {
   const body = root.children[root.children.length - 1];
   assert.equal(body.className, "fileview-body");
   const acts = bar.children.find((c) => c.classList.contains("fileview-acts"))!;
-  const btn = (label: string) => { const b = acts.children.find((c) => c.tagName === "button" && c.textContent === label); assert.ok(b, "the " + label + " button"); return b!; };
-  const reset = acts.children.find((c) => c.classList.contains("fileview-size-reset"));
+  const btn = (label: string) => { const walk = (n: El): El | undefined => { for (const c of n.children) { if (c.tagName === "button" && (c.textContent === label || c.getAttribute("aria-label") === label)) return c; const d = walk(c); if (d) return d; } return undefined; }; const b = walk(acts); assert.ok(b, "the " + label + " button"); return b!; };   // T367: controls sit in groups, glyph buttons carry their word as aria-label
+  const reset = acts.querySelector(".fileview-size-reset");   // inside the zoom flyout since T367
   assert.ok(reset, "the readout between A− and A+ (the reset)");
-  return { fv, wrap: wrap!, root, bar, acts, body, down: btn("A−"), reset: reset!, up: btn("A+"), btn };
+  return { fv, wrap: wrap!, root, bar, acts, body, down: btn("A−"), reset: reset!, up: btn("A+"), zoom: acts.querySelector(".fileview-zoom-btn")!, btn };
 }
 /** Open `p` for the fixture session; `wait` lets the bytes land. The stored size is the caller's, set before the call. */
 async function openFile(t: TestContext, p: string, wait = true): Promise<Card> {
@@ -317,21 +317,28 @@ test("foldWheel: a notch is one step, a pinch's small deltas add up to one, a re
 
 // ── the control over the real openFileView ─────────────────────────────────────────────────────────
 
-test("a markdown file opens at the default: A− and A+ after the format toggles, the readout slot empty, the root at 100; each press steps, stores and acknowledges in the same tick; an end reads as reached and a press there changes nothing", async (t) => {
+test("a markdown file opens at the default: the zoom glyph after the format pair, its flyout holding A−, the readout (dimmed) and A+, the root at 100; each press steps, stores and acknowledges in the same tick; an end reads as reached and a press there changes nothing", async (t) => {
   const { TEXT_SIZES } = await view();
   const o = await openFile(t, REPORT);
   assert.equal(size(o), "100", "the root carries the step the sheets read");
-  assert.equal(o.down.hidden, false); assert.equal(o.up.hidden, false);
-  assert.equal(o.reset.hidden, false, "the readout's slot is in the row from the start, so A− never moves when it fills");
-  assert.equal(blank(o), true, "nothing to reset at the default, so nothing is said: the slot is empty");
+  assert.equal(o.zoom.hidden, false);
+  assert.equal(o.zoom.hidden, false, "the readout's slot is in the flyout from the start, so A− never moves when it fills");
+  assert.equal(blank(o), true, "nothing to reset at the default: the readout reads dimmed (T367: inside the flyout, never an empty slot)");
   assert.equal(o.down.getAttribute("aria-label"), "Smaller text"); assert.equal(o.up.getAttribute("aria-label"), "Larger text");
-  const row = labels(o.acts);
-  assert.ok(row.indexOf("Raw") < row.indexOf("A−") && row.indexOf("A−") < row.indexOf("A+") && row.indexOf("A+") < row.indexOf("Edit"),
-    "the control sits after Rendered and Raw and before Edit: " + row.join(" | "));
-  assert.equal(o.acts.children.indexOf(o.reset), o.acts.children.indexOf(o.down) + 1, "the readout sits between A− and A+");
+  // T367: the row is GROUPS; the view group leads with the Rendered|Raw pair, then the zoom glyph whose flyout holds the three
+  const viewGroup = o.acts.children[0];
+  assert.ok(viewGroup.classList.contains("fileview-group-view"), "the view group leads the row: " + labels(o.acts).join(" | "));
+  assert.ok(viewGroup.children[0].classList.contains("fileview-seg") && viewGroup.children[1].classList.contains("fileview-zoom"), "the zoom glyph follows the Rendered|Raw pair");
+  const zoomBtn = viewGroup.children[1].children[0], menu = viewGroup.children[1].children[1];
+  assert.equal(zoomBtn, o.zoom);
+  assert.equal(zoomBtn.getAttribute("aria-label"), "Text size"); assert.equal(zoomBtn.title, "Text size 100% (Ctrl/Cmd + wheel)", "the hover says the size and the wheel binding");
+  assert.equal(menu.className, "fileview-zoom-menu");
+  assert.deepEqual(menu.children, [o.down, o.reset, o.up], "A−, the readout, A+ ride the flyout in that order");
+  assert.ok(o.acts.children[1].classList.contains("fileview-group-file"), "the file group (edit, download, copy path) follows the view group");
   o.up.click();
   assert.equal(size(o), "115", "one step, synchronously");
   assert.equal(blank(o), false); assert.equal(o.reset.textContent, "115%", "the readout is the acknowledgement");
+  assert.equal(o.zoom.title, "Text size 115% (Ctrl/Cmd + wheel)", "and the glyph's hover follows it");
   assert.equal(store.get(SIZE_KEY), "115", "stored as the percentage, under the viewer's own key");
   o.down.click(); o.down.click();
   assert.equal(size(o), "90"); assert.equal(o.reset.textContent, "90%"); assert.equal(store.get(SIZE_KEY), "90");
@@ -373,11 +380,11 @@ test("persistence: the size survives a close and a fresh open, is on the root be
   const again = await openFile(t, REPORT, false);                    // no settle: the loader still holds the body
   assert.equal(size(again), "150", "the stored step is on the root at open, before the fetch, so the first paint is at size");
   assert.equal(again.reset.textContent, "150%");
-  assert.equal(again.down.hidden, true); assert.equal(again.reset.hidden, true); assert.equal(again.up.hidden, true,
+  assert.equal(again.zoom.hidden, true); assert.equal(again.zoom.hidden, true,
     "the control waits for the bytes: whether this is a text file is the kernel's verdict, in the fetch's headers");
   await settle();
   assert.equal(size(again), "150", "the paint keeps it");
-  assert.equal(again.down.hidden, false); assert.equal(again.reset.hidden, false); assert.equal(blank(again), false);
+  assert.equal(again.zoom.hidden, false); assert.equal(blank(again), false);
   again.fv.closeFileView();
   store.set(SIZE_KEY, "purple");
   const third = await openFile(t, REPORT);
@@ -387,7 +394,7 @@ test("persistence: the size survives a close and a fresh open, is on the root be
   store.set(SIZE_KEY, "80");
   const fourth = await openFile(t, APP);
   assert.equal(size(fourth), "80", "one size for every file this browser opens, a .py included");
-  assert.equal(fourth.down.hidden, false, "a non-markdown text file has the control: its code view scales too");
+  assert.equal(fourth.zoom.hidden, false, "a non-markdown text file has the control: its code view scales too");
   assert.equal(fourth.reset.textContent, "80%");
 });
 
@@ -449,49 +456,49 @@ test("click-safe: the three buttons are built once per open and never rebuilt by
 
 test("the control is absent for a picture and a PDF, present for the SVG Source view, hidden in edit mode and back on exit", async (t) => {
   const pic = await openFile(t, PLOT);
-  assert.equal(pic.down.hidden, true); assert.equal(pic.up.hidden, true); assert.equal(pic.reset.hidden, true, "a picture has no text to size");
+  assert.equal(pic.zoom.hidden, true, "a picture has no text to size");   // the glyph is the control's visibility (T367)
   pic.fv.closeFileView();
   const pdf = await openFile(t, PAPER);
-  assert.equal(pdf.down.hidden, true); assert.equal(pdf.up.hidden, true); assert.equal(pdf.reset.hidden, true, "a PDF: the browser's viewer owns its text");
+  assert.equal(pdf.zoom.hidden, true, "a PDF: the browser's viewer owns its text");   // the glyph is the control's visibility (T367)
   pdf.fv.closeFileView();
   const svg = await openFile(t, FIG);
-  assert.equal(svg.down.hidden, true, "an SVG shown as a picture: no text yet");
+  assert.equal(svg.zoom.hidden, true, "an SVG shown as a picture: no text yet");
   svg.btn("Source").click();
   await settle();
   assert.equal(svg.body.children[0].className, "fileview-code", "the Source view is up");
-  assert.equal(svg.down.hidden, false); assert.equal(svg.up.hidden, false); assert.equal(svg.reset.hidden, false, "the Source view is a text view and has the control");
+  assert.equal(svg.zoom.hidden, false, "the Source view is a text view and has the control");   // the glyph is the control's visibility (T367)
   const ev = wheel({ dy: -100, ctrl: true });
   svg.body.dispatchEvent(ev);
   assert.equal(size(svg), "115", "and the wheel steps it"); assert.equal(ev.defaultPrevented, true);
   svg.fv.closeFileView(); store.delete(SIZE_KEY);
   store.set(SIZE_KEY, "115");
   const o = await openFile(t, REPORT);
-  assert.equal(o.down.hidden, false); assert.equal(blank(o), false, "off the default, the readout says the size");
+  assert.equal(o.zoom.hidden, false); assert.equal(blank(o), false, "off the default, the readout says the size");
   o.btn("Edit").click();
   await settle();
   assert.equal(o.btn("Cancel").hidden, false, "edit mode");
-  assert.equal(o.down.hidden, true); assert.equal(o.up.hidden, true); assert.equal(o.reset.hidden, true, "the editor keeps its own size");
+  assert.equal(o.zoom.hidden, true, "the editor keeps its own size");   // the glyph is the control's visibility (T367)
   const ev2 = wheel({ dy: -100, ctrl: true });
   o.body.dispatchEvent(ev2);
   assert.equal(size(o), "115", "the wheel stands down in edit mode"); assert.equal(ev2.defaultPrevented, false);
   o.btn("Cancel").click();
   assert.equal(o.btn("Cancel").hidden, true);
-  assert.equal(o.down.hidden, false); assert.equal(o.reset.hidden, false); assert.equal(o.up.hidden, false); assert.equal(blank(o), false, "back with the read view");
+  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367) assert.equal(blank(o), false, "back with the read view");
 });
 
 test("the control shows only once a text body is KNOWN: hidden beside the loader, shown when a text file's bytes land, never for a picture", async (t) => {
   store.set(SIZE_KEY, "130");
   const o = await openFile(t, REPORT, false);
-  assert.equal(o.down.hidden, true); assert.equal(o.up.hidden, true); assert.equal(o.reset.hidden, true, "the loader holds the body: not yet a text view");
+  assert.equal(o.zoom.hidden, true, "the loader holds the body: not yet a text view");   // the glyph is the control's visibility (T367)
   assert.equal(size(o), "130", "the step is on the root already, so the first paint is at size");
   await settle();
-  assert.equal(o.down.hidden, false); assert.equal(o.up.hidden, false); assert.equal(o.reset.hidden, false); assert.equal(o.reset.textContent, "130%");
+  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367) assert.equal(o.reset.textContent, "130%");
   o.fv.closeFileView();
   const pic = await openFile(t, PLOT, false);
-  assert.equal(pic.down.hidden, true, "a picture: hidden for the load");
+  assert.equal(pic.zoom.hidden, true, "a picture: hidden for the load");
   await settle();
   assert.equal(pic.body.children[0].className, "fileview-imgbox", "the picture landed");
-  assert.equal(pic.down.hidden, true); assert.equal(pic.up.hidden, true); assert.equal(pic.reset.hidden, true, "and after it: nothing there reads the property");
+  assert.equal(pic.zoom.hidden, true, "and after it: nothing there reads the property");   // the glyph is the control's visibility (T367)
 });
 
 test("a press on a bar control settles no selection: with a passage selected in the body, A+ steps the size and neither re-reads the file nor re-seeds the quote chip; a lift on the bar's path or padding still settles", async (t) => {
@@ -540,12 +547,13 @@ test("openUrlView carries the stored step on its root and mounts the same contro
   t.after(() => { fv.closeFileView(); store.clear(); });
   const o = card(fv);
   assert.equal(size(o), "130", "the stored step is on the root before the document lands");
-  assert.equal(o.down.hidden, true); assert.equal(o.reset.hidden, true); assert.equal(o.up.hidden, true, "hidden beside the loader");
+  assert.equal(o.zoom.hidden, true, "hidden beside the loader");   // the glyph is the control's visibility (T367)
   const row = labels(o.acts);
-  assert.ok(row.indexOf("Raw") < row.indexOf("A−") && row.indexOf("A+") < row.indexOf("Open ↗"), "after Rendered and Raw, before the link out: " + row.join(" | "));
+  const zoomAt = row.findIndex((x) => x.startsWith("A−"));   // the zoom wrap reads as one label: the flyout's three buttons (T367)
+  assert.ok(row.indexOf("Raw") < zoomAt && zoomAt < row.indexOf("Open ↗"), "after Rendered and Raw, before the link out: " + row.join(" | "));
   await settle();
   assert.equal(o.body.children[0].className, "fileview-md", "the document rendered");
-  assert.equal(o.down.hidden, false); assert.equal(o.reset.hidden, false); assert.equal(o.up.hidden, false);
+  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367)
   assert.equal(o.reset.textContent, "130%"); assert.equal(blank(o), false);
   o.up.click();
   assert.equal(size(o), "150"); assert.equal(store.get(SIZE_KEY), "150", "stored under the same key as a local file's");
@@ -651,9 +659,9 @@ test("both sheets: the title bar wraps and its action row shrinks and wraps to t
     assert.deepEqual(decls(ruleOf(css, '.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover {')), ["border-color: var(--card-border)", "color: var(--fg)", "background: transparent"], name + ": the hover is inert (the rest colours, not the accent)");
     assert.deepEqual(decls(ruleOf(css, '.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active {')), ["transform: none"], name + ": no press pulse");
     assert.doesNotMatch(css, /\.fileview-gh \.fileview-btn:disabled/, name + ": the GitHub unit's disabled rules are the bar's now, not its own");
-    // the readout: one width whatever it says, and an empty slot (not none) at the default
+    // the readout: one width whatever it says, and dimmed (not empty) at the default since it moved into the zoom flyout (T367)
     assert.deepEqual(decls(ruleOf(css, ".fileview-size-reset {")), ["min-width: 5.5em", "box-sizing: border-box", "text-align: center", "font-variant-numeric: tabular-nums"], name + ": a slot of one width");
-    assert.deepEqual(decls(ruleOf(css, ".fileview-size-reset.fileview-size-default {")), ["visibility: hidden"], name + ": the empty slot keeps its width and leaves the tab order");
+    assert.deepEqual(decls(ruleOf(css, ".fileview-size-reset.fileview-size-default {")), ["color: var(--dim)"], name + ": at the default the readout reads dimmed inside the flyout (T367): nothing to reset, the slot keeps its width");
   }
   const [chat, feed] = SHEETS.map(([, css]) => css);
   for (const head of [".fileview-bar {", ".fileview-name {", ".fileview-acts {", ".fileview-bar .fileview-name {", ".fileview-bar .fileview-acts {",
@@ -939,7 +947,7 @@ test("in a browser: from 380 to 1400px in both modals the close button and every
         if (g.win <= 600) assert.ok(g.acts.t >= g.name.b - 0.5, cell + " " + what + ": the action row is the line below the path (row top " + g.acts.t + ", path bottom " + g.name.b + ")");
         if (g.win >= 1400) assert.ok(g.acts.t < g.name.b - 0.5 && g.acts.b > g.name.t + 0.5, cell + " " + what + ": room for both, so the path and the action row share a line");
       }
-      assert.equal(off.resetVis, "hidden", cell + ": at the default the readout's slot is empty by visibility");
+      assert.equal(off.resetVis, "visible", cell + ": at the default the readout reads dimmed, its slot kept (T367: inside the flyout, visibility is never hidden)");
       assert.ok(off.reset.w > 20, cell + ": and keeps its width (" + off.reset.w + "px)");
       assert.equal(on.resetVis, "visible", cell + ": off the default the readout shows");
       near(off.down.l, on.down.l, cell + ": A− does not move when the readout fills"); near(off.down.t, on.down.t, cell + ": A− stays on its line");

--- a/ui/webview/file-view-text-size.test.ts
+++ b/ui/webview/file-view-text-size.test.ts
@@ -477,13 +477,16 @@ test("the control is absent for a picture and a PDF, present for the SVG Source 
   o.btn("Edit").click();
   await settle();
   assert.equal(o.btn("Cancel").hidden, false, "edit mode");
+  assert.equal(o.acts.children[0].hidden, true, "the view group takes no room in edit mode: the pair and the glyph are hidden (review)");
   assert.equal(o.zoom.hidden, true, "the editor keeps its own size");   // the glyph is the control's visibility (T367)
   const ev2 = wheel({ dy: -100, ctrl: true });
   o.body.dispatchEvent(ev2);
   assert.equal(size(o), "115", "the wheel stands down in edit mode"); assert.equal(ev2.defaultPrevented, false);
   o.btn("Cancel").click();
   assert.equal(o.btn("Cancel").hidden, true);
-  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367) assert.equal(blank(o), false, "back with the read view");
+  assert.equal(o.acts.children[0].hidden, false, "the view group is back with the read view");
+  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367)
+  assert.equal(blank(o), false, "back with the read view");
 });
 
 test("the control shows only once a text body is KNOWN: hidden beside the loader, shown when a text file's bytes land, never for a picture", async (t) => {
@@ -492,7 +495,8 @@ test("the control shows only once a text body is KNOWN: hidden beside the loader
   assert.equal(o.zoom.hidden, true, "the loader holds the body: not yet a text view");   // the glyph is the control's visibility (T367)
   assert.equal(size(o), "130", "the step is on the root already, so the first paint is at size");
   await settle();
-  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367) assert.equal(o.reset.textContent, "130%");
+  assert.equal(o.zoom.hidden, false);   // the glyph is the control's visibility (T367)
+  assert.equal(o.reset.textContent, "130%");
   o.fv.closeFileView();
   const pic = await openFile(t, PLOT, false);
   assert.equal(pic.zoom.hidden, true, "a picture: hidden for the load");

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -474,6 +474,12 @@ test("the title bar offers Download as the lightbox's tray glyph, in the file gr
   assert.match(VIEW, /fileGroup\.appendChild\(dl\);/);
   assert.match(VIEW, /const copy = el\("button", "fileview-btn fileview-icon"\) as HTMLButtonElement;/);
   assert.match(VIEW, /fileGroup\.appendChild\(copy\);/);
+  // the wider gaps apply only where groups exist: the close cross after a GROUP sibling, never the file browser's row or
+  // the URL viewer's flat row (review)
+  for (const css of [CHAT_CSS, FEED_CSS]) {
+    assert.match(css, /\.fileview-acts > \.fileview-group \+ \.fileview-group, \.fileview-acts > \.fileview-group ~ \.fileview-close \{ margin-left: 10px; \}/);
+    assert.doesNotMatch(css, /\.fileview-acts > \.fileview-close \{/, "an unscoped close margin would move the file browser's and the URL viewer's cross");
+  }
   assert.match(VIEW, /const dl = el\("button", "fileview-btn"\) as HTMLButtonElement;/, "no new styling, no new font size");
 });
 

--- a/ui/webview/file-view.test.ts
+++ b/ui/webview/file-view.test.ts
@@ -370,7 +370,8 @@ test("format prefs: rendered is the markdown default, and a corrupt entry reads 
 test("Raw ⇄ Rendered exists for markdown ONLY, and nothing reaches innerHTML unsanitized", () => {
   assert.match(VIEW, /const isMd = langFor\(path\) === "markdown";/);
   // the two buttons are built inside the isMd gate — a .py file shows no Rendered/Raw toggle
-  assert.match(VIEW, /if \(isMd\) \{\s*\n\s*for \(const mode of \["rendered", "raw"\] as const\)/);
+  assert.match(VIEW, /if \(isMd\) \{\s*\n\s*const seg = el\("span", "fileview-seg"\);[\s\S]{0,400}?for \(const mode of \["rendered", "raw"\] as const\)/,
+    "the pair is built inside the isMd gate, into ONE segmented wrapper (T367)");
   assert.match(VIEW, /const rendered = isMd && fmt\.md === "rendered";/, "non-md never renders as prose");
   assert.match(VIEW, /import \{ sanitizeMd \} from "\.\/md-sanitize";/);
   assert.doesNotMatch(VIEW, /from "dompurify"/, "the viewer spells no profile of its own: every option comes through md-sanitize.ts");
@@ -462,13 +463,17 @@ test("a file opened FROM the listing offers the way back — close only the view
 // show — the kernel's ?download=1 serves anything on disk (the rationale lives with _file_download in
 // kernel.py: the view allowlists are a rendering choice, not a security boundary). ──
 
-test("the title bar offers Download next to Copy path, at the same-origin download URL", () => {
+test("the title bar offers Download as the lightbox's tray glyph, in the file group beside Copy path, at the same-origin download URL (T367)", () => {
   // the URL is fileUrl + the download switch: same origin, cookie-authed, and federation-aware for
   // free — fileUrl already routes a remote session's file through the /remote/<host>/file relay
   assert.match(VIEW, /const dlUrl = fileUrl\(path, sid\) \+ "&download=1";/);
-  assert.match(VIEW, /dl\.textContent = "Download";/);
-  // next to Copy path: appended into the same acts bar, wearing the same button class
-  assert.match(VIEW, /acts\.appendChild\(dl\);\n\n  const copy = el\("button", "fileview-btn"\)/);
+  assert.match(VIEW, /dl\.innerHTML = ICON_DOWNLOAD;/, "the one tray drawing (icons.ts), not a word");
+  assert.match(VIEW, /dl\.title = "Download"; dl\.setAttribute\("aria-label", "Download"\);/, "the word rides the title and aria-label");
+  assert.doesNotMatch(VIEW, /dl\.textContent = "Download";/);
+  // in the file group beside Copy path (a glyph too), wearing the same button class
+  assert.match(VIEW, /fileGroup\.appendChild\(dl\);/);
+  assert.match(VIEW, /const copy = el\("button", "fileview-btn fileview-icon"\) as HTMLButtonElement;/);
+  assert.match(VIEW, /fileGroup\.appendChild\(copy\);/);
   assert.match(VIEW, /const dl = el\("button", "fileview-btn"\) as HTMLButtonElement;/, "no new styling, no new font size");
 });
 

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -20,6 +20,7 @@ import { marked, type Tokens } from "marked";
 import { sanitizeMd } from "./md-sanitize";
 import { hostOf, bareId, hostNameNodes } from "./host-prefix";
 import { fileUrl } from "./preview";
+import { ICON_DOWNLOAD, ICON_COPY, ICON_EDIT, ICON_ZOOM, ICON_CHECK, ICON_CROSS } from "./icons";   // the bar's glyphs (T367)
 import { openPdfTab, wantsOwnTab } from "./preview";   // a PDF's own tab, and the gesture that asks for it
 import { openFileTab, canPreview } from "./preview";   // any file's own tab, for the links inside a shown file, and the web-vs-webview test
 import { kernelUrl } from "./media";
@@ -205,7 +206,7 @@ export function foldWheel(e: { deltaY: number; deltaMode: number }, acc: number)
 // click-safe here: the buttons are built once and never rebuilt by a paint (the format toggles' idiom), and
 // every press acknowledges in the same tick (the attribute, the readout, the dimmed end; the sheets reflow
 // from the attribute alone).
-function textSizeControl(root: HTMLElement, textShowing: () => boolean): { buttons: HTMLButtonElement[]; sync: () => void; bindWheel: (body: HTMLElement) => void } {
+function textSizeControl(root: HTMLElement, textShowing: () => boolean): { buttons: HTMLButtonElement[]; wrap: HTMLElement; trigger: HTMLButtonElement; menu: HTMLElement; sync: () => void; bindWheel: (body: HTMLElement) => void } {
   let pct = loadTextSize();
   const down = el("button", "fileview-btn fileview-size") as HTMLButtonElement;
   down.type = "button"; down.textContent = "A−"; down.title = "Smaller text (Ctrl/Cmd + wheel)";
@@ -216,11 +217,35 @@ function textSizeControl(root: HTMLElement, textShowing: () => boolean): { butto
   up.type = "button"; up.textContent = "A+"; up.title = "Larger text (Ctrl/Cmd + wheel)";
   up.setAttribute("aria-label", "Larger text");
   const buttons = [down, reset, up];
+  // T367 (the user 2026-09-12): the three ride a FLYOUT behind one zoom glyph, the bar's one control for the text
+  // size (a magnifier with a plus; the words in its title and aria-label). The flyout wears the menu vocabulary
+  // (the menu tokens, ui/CLAUDE.md) and opens under the glyph; the glyph again, Escape or a press outside closes
+  // it (one document listener pair for every control, wired once), and it closes with the glyph when no text
+  // shows. Built once per open with the buttons: click-safe, and the wheel binding is untouched.
+  const wrap = el("span", "fileview-zoom");
+  const trigger = el("button", "fileview-btn fileview-icon fileview-zoom-btn") as HTMLButtonElement;
+  trigger.type = "button"; trigger.innerHTML = ICON_ZOOM; trigger.dataset.icon = "1";
+  trigger.setAttribute("aria-label", "Text size");   // the title carries the size too, set by apply() below
+  trigger.setAttribute("aria-haspopup", "true"); trigger.setAttribute("aria-expanded", "false");
+  const menu = el("div", "fileview-zoom-menu");
+  menu.hidden = true;
+  menu.setAttribute("role", "group"); menu.setAttribute("aria-label", "Text size");
+  for (const b of buttons) menu.appendChild(b);
+  wrap.appendChild(trigger); wrap.appendChild(menu);
+  const setOpen = (open: boolean) => {
+    menu.hidden = !open;
+    trigger.setAttribute("aria-expanded", open ? "true" : "false");
+    trigger.classList.toggle("on", open);
+    zoomOpen = open ? { wrap, close: () => setOpen(false) } : (zoomOpen && zoomOpen.wrap === wrap ? null : zoomOpen);
+  };
+  trigger.addEventListener("click", () => setOpen(menu.hidden));
+  wireZoomDismiss();
   const atEnd = (b: HTMLButtonElement, end: boolean) => { if (end) b.setAttribute("aria-disabled", "true"); else b.removeAttribute("aria-disabled"); };
   // the property on the root, and the control's own state, from pct
   const apply = () => {
     root.dataset.fvText = String(pct);
     reset.textContent = pct + "%";
+    trigger.title = "Text size " + pct + "% (Ctrl/Cmd + wheel)";   // the readout is a click away, so the hover says it (review)
     reset.setAttribute("aria-label", "Text size " + pct + "%, reset to " + TEXT_SIZE_DEFAULT + "%");
     reset.classList.toggle("fileview-size-default", pct === TEXT_SIZE_DEFAULT);   // the empty slot
     atEnd(down, pct === TEXT_SIZES[0]);
@@ -246,8 +271,18 @@ function textSizeControl(root: HTMLElement, textShowing: () => boolean): { butto
       if (r.dir) set(stepTextSize(pct, r.dir));
     }, { passive: false });
   };
-  const sync = () => { const hide = !textShowing(); for (const b of buttons) b.hidden = hide; };
-  return { buttons, sync, bindWheel };
+  const sync = () => { const hide = !textShowing(); trigger.hidden = hide; if (hide) setOpen(false); };
+  return { buttons, wrap, trigger, menu, sync, bindWheel };
+}
+// one text-size flyout open at a time, dismissed by Escape (in the capture phase, before the viewer's own Escape
+// closes the file) or a press outside it; the pair of document listeners is wired once, for every control
+let zoomOpen: { wrap: HTMLElement; close: () => void } | null = null;
+let zoomDismissWired = false;
+function wireZoomDismiss(): void {
+  if (zoomDismissWired) return;
+  zoomDismissWired = true;
+  document.addEventListener("mousedown", (e) => { if (zoomOpen && !zoomOpen.wrap.contains(e.target as Node)) zoomOpen.close(); });
+  document.addEventListener("keydown", (e) => { if (e.key === "Escape" && zoomOpen) { zoomOpen.close(); e.stopPropagation(); } }, true);
 }
 
 // The romp loader (swirl + wordmark + three pulsing accent dots), per the loading-state rule: the
@@ -369,70 +404,41 @@ export function registerFileViewAction(a: FileViewAction): void {
 }
 
 // ── the GitHub link (the user 2026-08-15) — the registry's first entry ─────────────────────────────
-// One unit in the action row: the control and, when the kernel gave one, its reason as a caption
-// beside it. The OWNING kernel answers the lazy fileGitLink ask, and until it does the unit holds a
-// PLACEHOLDER — a dimmed disabled button and the loader's pulsing dots where the caption will go —
-// because the check takes up to 3 s when the kernel must ask origin, and an empty slot for that long
-// read as the old no-button state (found in review; the loading-state rule). The answer ALWAYS fills
-// the slot (the user 2026-09-05, who could not tell an uncommitted file from a broken link when the
-// button simply never appeared). A real URL is an anchor — the browser owns the new tab. No URL is
-// a real disabled <button>: assistive tech reads the state and the label, and there is no href to
-// follow or to go stale. The reason rides in the tooltip AND as the caption, because a tooltip alone
-// needs a mouse — touch has no hover, and a disabled button takes no focus — so the caption is what
-// makes the reason glanceable, and it is shown whole: the sheet wraps it inside a bounded width, since
-// nothing in the unit takes a tap, click or focus that could finish a truncated sentence. A URL
-// whose branch is not on origin stays an anchor, dashed, with the note as its caption, since GitHub
-// 404s it until the push. One question per open, reqId-guarded; a socket drop while it is out is
-// the one thing that loses the reply, and the shim's reconnect event re-asks (initFileView), so the
-// placeholder never outlives its wait. Exported for the DOM-shape test.
-const GH_REASONLESS = "this kernel predates link reasons; restart it after updating";
+// One unit in the action row: the link, when the OWNING kernel's lazy fileGitLink ask resolves to a URL,
+// and NOTHING otherwise (T367, the user 2026-09-12, who wanted the greyed link and its explanation gone
+// from a file outside a repository: the 2026-09-05 always-fill-the-slot rule gave way to the tidier bar).
+// A real URL is an anchor — the browser owns the new tab — with the full URL as its tooltip; a URL whose
+// branch is not on origin stays an anchor, dashed, with the kernel's note in the tooltip and aria-label,
+// since GitHub 404s it until the push. No URL (no repo, uncommitted, no GitHub origin, an older kernel)
+// leaves the unit hidden: the verdict still rides the reply, it is just not rowed. The unit stays in the
+// row hidden while the check is out (aria-busy names the wait), so the answer lands in place. One question
+// per open, reqId-guarded; a socket drop while it is out is the one thing that loses the reply, and the
+// shim's reconnect event re-asks (initFileView), so the wait never outlives the socket. Exported for the
+// DOM-shape test.
 let gitSeq = 0;
 let gitHooks: { reqId: number; apply: (url: string, reason: string) => void; ask: () => void } | null = null;
 export const githubLinkAction: FileViewAction = {
   id: "github-link",
   mount({ path, sid }) {
     const unit = el("span", "fileview-gh");
-    // pending: a real disabled button (never an hrefless anchor, which has no role to read) and the
-    // loader's three dots in the caption's place; aria-busy names the wait for assistive tech
-    const wait = el("button", "fileview-btn") as HTMLButtonElement;
-    wait.type = "button"; wait.disabled = true; wait.textContent = "GitHub ↗";
-    wait.title = "Checking GitHub…"; wait.setAttribute("aria-label", wait.title);
-    const dots = el("span", "fileview-gh-dots");
-    for (let i = 0; i < 3; i++) dots.appendChild(el("i", "fileview-dot"));
+    unit.hidden = true;
     unit.setAttribute("aria-busy", "true");
-    unit.appendChild(dots); unit.appendChild(wait);
     const reqId = ++gitSeq;
     const ask = () => post({ type: "fileGitLink", path, sid: sid || undefined, reqId });
     gitHooks = {
       reqId,
       ask,
       apply: (url, reason) => {
-        let ctl: HTMLElement;
-        if (url) {
-          const a = el("a", "fileview-btn") as HTMLAnchorElement;
-          a.href = url; a.target = "_blank"; a.rel = "noopener";
-          a.title = reason ? url + "\n" + reason : url;      // the full URL one hover away, and the note with it
-          if (reason) { a.classList.add("fileview-gh-note"); a.setAttribute("aria-label", "GitHub: " + reason); }
-          ctl = a;
-        } else {
-          // an older kernel answers without a reason — say what that means, rather than invent one
-          const b = el("button", "fileview-btn") as HTMLButtonElement;
-          b.type = "button"; b.disabled = true;
-          b.title = "No GitHub link: " + (reason || GH_REASONLESS);
-          b.setAttribute("aria-label", b.title);
-          ctl = b;
-        }
-        ctl.textContent = "GitHub ↗";
-        const why = reason || (url ? "" : GH_REASONLESS);
-        const parts: HTMLElement[] = [];
-        if (why) {
-          const cap = el("span", "fileview-gh-why");
-          cap.textContent = why;                             // whole, wrapped by the sheet — no tooltip to reach for
-          parts.push(cap);                                   // before the control: it annotates what follows
-        }
-        parts.push(ctl);
-        unit.replaceChildren(...parts);                      // the placeholder leaves with the wait
         unit.removeAttribute("aria-busy");
+        if (!url) { unit.replaceChildren(); unit.hidden = true; return; }   // nothing to link to: nothing shown
+        const a = el("a", "fileview-btn") as HTMLAnchorElement;
+        a.href = url; a.target = "_blank"; a.rel = "noopener";
+        a.textContent = "GitHub ↗";
+        a.title = reason ? url + "\n" + reason : url;       // the full URL one hover away, and the note with it
+        a.setAttribute("aria-label", reason ? "GitHub: " + reason : "GitHub");
+        if (reason) a.classList.add("fileview-gh-note");    // the branch is not on origin yet: dashed
+        unit.replaceChildren(a);
+        unit.hidden = false;
       },
     };
     ask();
@@ -616,8 +622,16 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
   let cm: { value(): string; focus(): void; destroy(): void } | null = null;   // the CodeMirror handle when mounted
   const bufValue = (): string | null => (cm ? cm.value() : ta ? ta.value : null);   // whichever surface owns the buffer
   const isMd = langFor(path) === "markdown";  // .md/.markdown — the only kind with a Rendered form
+  // T367 (the user 2026-09-12): the row reads as GROUPS. The view group holds the Rendered|Raw pair (one
+  // segmented control), the SVG Source toggle and the text-size glyph; the file group holds edit (and Save
+  // and Cancel while editing), the GitHub link when it resolves, download and copy path; the close cross
+  // stands alone at the end. Word buttons became glyphs with their words in the title and aria-label.
+  const viewGroup = el("span", "fileview-group fileview-group-view");
+  const fileGroup = el("span", "fileview-group fileview-group-file");
   const segBtns: Array<["rendered" | "raw", HTMLButtonElement]> = [];
   if (isMd) {
+    const seg = el("span", "fileview-seg");                 // the pair joined: one hairline between, the outer corners rounded
+    seg.setAttribute("role", "group"); seg.setAttribute("aria-label", "Markdown view");
     for (const mode of ["rendered", "raw"] as const) {
       const b = el("button", "fileview-btn") as HTMLButtonElement;
       b.type = "button";
@@ -625,8 +639,9 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
       b.title = mode === "rendered" ? "The prose the markdown means" : "The file's actual bytes";
       b.addEventListener("click", () => { fmt.md = mode; saveFmt(fmt); renderBody(); });
       segBtns.push([mode, b]);
-      acts.appendChild(b);
+      seg.appendChild(b);
     }
+    viewGroup.appendChild(seg);
   }
   // ── text size ── A− and A+ step every text view through TEXT_SIZES, Ctrl/Cmd + wheel over the body
   // does the same, and the percentage between them (said once the size is off the default) is the reset;
@@ -637,7 +652,7 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
   // beside the loader and then takes it away.
   const textShowing = (): boolean => !editing && viewText() !== null;
   const textSize = textSizeControl(box, textShowing);
-  for (const b of textSize.buttons) acts.appendChild(b);
+  viewGroup.appendChild(textSize.wrap);          // the zoom glyph and its flyout (the three buttons inside)
   // ── the SVG Source toggle ── an SVG is served (and shown) as an image, but it IS also XML worth
   // reading; the toggle swaps in the existing highlighted-code view (langFor maps svg → xml) built
   // from the SAME fetched bytes — no second request. Appears only once an image/svg+xml body landed.
@@ -653,14 +668,15 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
     svgSource = !svgSource;
     renderBody();
   });
-  acts.appendChild(srcBtn);
+  viewGroup.appendChild(srcBtn);
 
   // ── edit (the raw-mode slice) ── exactly what raw mode can show is what Edit can touch: the
   // button arms only when the kernel served text/plain WITH a Last-Modified to anchor the save's
   // conflict floor (an old remote kernel that mirrors neither gets no Edit rather than an unguarded
   // one). Markdown edits from its Raw view — what you edit is what raw shows.
   const editBtn = el("button", "fileview-btn") as HTMLButtonElement;
-  editBtn.type = "button"; editBtn.textContent = "Edit"; editBtn.title = "Edit this file in place";
+  editBtn.type = "button"; editBtn.innerHTML = ICON_EDIT; editBtn.classList.add("fileview-icon"); editBtn.dataset.icon = "1";
+  editBtn.title = "Edit this file in place"; editBtn.setAttribute("aria-label", "Edit");
   editBtn.hidden = true;
   // The consent gate (the user 2026-08-22): editing is a kernel-side opt-in the SAVE ROUTE enforces —
   // this popup is where the one yes happens, and it broadcasts through the settings mesh so every
@@ -703,12 +719,12 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
   cancelBtn.type = "button"; cancelBtn.textContent = "Cancel"; cancelBtn.title = "Leave edit mode";
   cancelBtn.hidden = true;
   cancelBtn.addEventListener("click", () => { if (confirmDiscard()) exitEdit(); });
-  acts.appendChild(editBtn); acts.appendChild(saveBtn); acts.appendChild(cancelBtn);
+  fileGroup.appendChild(editBtn); fileGroup.appendChild(saveBtn); fileGroup.appendChild(cancelBtn);
   // Registered actions render after the built-ins — the registry walk is the ONE place row
   // conventions live (see registerFileViewAction above). The GitHub link mounts here.
   for (const a of fileViewActions) {
     const n = a.mount({ path, sid: sid || null });
-    if (n) acts.appendChild(n);
+    if (n) fileGroup.appendChild(n);
   }
 
   // ── download (the user 2026-08-09) ── Any linked file can be SAVED, including everything the pane
@@ -717,22 +733,37 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
   // federation-aware for free — fileUrl already routes a remote session's file through the relay.
   const dlUrl = fileUrl(path, sid) + "&download=1";
   const dl = el("button", "fileview-btn") as HTMLButtonElement;
-  dl.type = "button"; dl.textContent = "Download"; dl.title = "Save this file to your device";
+  dl.type = "button"; dl.innerHTML = ICON_DOWNLOAD; dl.classList.add("fileview-icon"); dl.dataset.icon = "1";   // the tray glyph the lightbox wears (icons.ts)
+  dl.title = "Download"; dl.setAttribute("aria-label", "Download");
   dl.addEventListener("click", () => startDownload(dlUrl, dl));
-  acts.appendChild(dl);
+  fileGroup.appendChild(dl);
 
-  const copy = el("button", "fileview-btn") as HTMLButtonElement;
-  copy.type = "button"; copy.textContent = "Copy path"; copy.title = path;
+  // ── copy path (a glyph since T367) ── the acknowledgement is a glyph swap with the words in the tooltip and
+  // aria-label: the press dims the button in the same tick (click-safe: every press acknowledges), then a check
+  // and "Copied" for a moment, or a cross and "Copy failed" until the next press. No clipboard here (an insecure
+  // origin drops navigator.clipboard) is said at once as the failure.
+  const copy = el("button", "fileview-btn fileview-icon") as HTMLButtonElement;
+  copy.type = "button"; copy.innerHTML = ICON_COPY; copy.dataset.icon = "1";
+  copy.title = "Copy path"; copy.setAttribute("aria-label", "Copy path");
+  let copyTimer: ReturnType<typeof setTimeout> | null = null;
+  const copySay = (icon: string, word: string, cls: string, ms: number | null) => {
+    copy.innerHTML = icon; copy.title = word; copy.setAttribute("aria-label", word);
+    copy.classList.remove("ok", "err", "fileview-busy"); if (cls) copy.classList.add(cls);
+    if (copyTimer) { clearTimeout(copyTimer); copyTimer = null; }
+    if (ms !== null) copyTimer = setTimeout(() => copySay(ICON_COPY, "Copy path", "", null), ms);
+  };
   copy.addEventListener("click", () => {
-    navigator.clipboard?.writeText(path).then(
-      () => { copy.textContent = "Copied"; setTimeout(() => { copy.textContent = "Copy path"; }, 1200); },
-      () => { copy.textContent = "Copy failed"; });
+    copy.classList.add("fileview-busy");                     // the same-tick acknowledgement
+    const w = navigator.clipboard?.writeText(path);
+    if (!w) { copySay(ICON_CROSS, "Copy failed", "err", null); return; }
+    w.then(() => copySay(ICON_CHECK, "Copied", "ok", 1200), () => copySay(ICON_CROSS, "Copy failed", "err", null));
   });
   const close = el("button", "fileview-btn fileview-close") as HTMLButtonElement;
   close.type = "button"; close.textContent = "✕"; close.title = "Close (Esc)";
   close.setAttribute("aria-label", "Close the file viewer");
   close.addEventListener("click", closeFileView);
-  acts.appendChild(copy); acts.appendChild(close);
+  fileGroup.appendChild(copy);
+  acts.appendChild(viewGroup); acts.appendChild(fileGroup); acts.appendChild(close);
   bar.appendChild(name); if (sess) bar.appendChild(sess); bar.appendChild(acts);
 
   const body = el("div", "fileview-body");
@@ -885,6 +916,7 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
     }
     editBtn.hidden = editing || text === null || !isText || !mtimeNs;
     textSize.sync();                          // the text-size control follows every paint: shown over a text view only
+    viewGroup.hidden = !(segBtns.length > 0 || !textSize.trigger.hidden || !srcBtn.hidden);   // an all-hidden group takes no gap
     saveBtn.hidden = !editing;
     cancelBtn.hidden = !editing;
     if (isImage || isPdf) {
@@ -1250,7 +1282,7 @@ export function openUrlView(href: string): void {
   // the text-size control the local viewer has (textSizeControl): a document opened from a link honours
   // the same stored size as a file on disk, and a step here is kept for both
   const textSize = textSizeControl(box, () => text !== null);
-  for (const b of textSize.buttons) acts.appendChild(b);
+  acts.appendChild(textSize.wrap);   // the zoom glyph and its flyout (T367)
   // The way OUT to the URL itself, in a new tab — an anchor wearing the button treatment, the
   // GitHub link's dress: the browser owns the tab. It is also every failure pane's exit below.
   // data-new-tab: this href IS a same-origin .md, exactly what the chat's anchor delegate routes
@@ -1403,9 +1435,16 @@ function startDownload(url: string, btn: HTMLButtonElement): void {
   document.body.appendChild(a);
   a.click();
   a.remove();
-  const was = btn.textContent;
-  btn.textContent = "Downloading…";
-  setTimeout(() => { btn.textContent = was; }, 1500);
+  // the acknowledgement: a glyph button says it in its tooltip and a busy dress (T367), a word button in its text
+  if (btn.dataset.icon) {
+    const was = btn.title;
+    btn.title = "Downloading…"; btn.classList.add("fileview-busy");
+    setTimeout(() => { btn.title = was; btn.classList.remove("fileview-busy"); }, 1500);
+  } else {
+    const was = btn.textContent;
+    btn.textContent = "Downloading…";
+    setTimeout(() => { btn.textContent = was; }, 1500);
+  }
 }
 
 function escapeHtml(s: string): string {

--- a/ui/webview/file-view.ts
+++ b/ui/webview/file-view.ts
@@ -233,10 +233,13 @@ function textSizeControl(root: HTMLElement, textShowing: () => boolean): { butto
   for (const b of buttons) menu.appendChild(b);
   wrap.appendChild(trigger); wrap.appendChild(menu);
   const setOpen = (open: boolean) => {
+    if (open && zoomOpen && zoomOpen.wrap !== wrap) zoomOpen.close();   // one flyout at a time, by rule (review)
+    const focusInside = !open && !menu.hidden && !!document.activeElement && typeof menu.contains === "function" && menu.contains(document.activeElement);
     menu.hidden = !open;
     trigger.setAttribute("aria-expanded", open ? "true" : "false");
     trigger.classList.toggle("on", open);
     zoomOpen = open ? { wrap, close: () => setOpen(false) } : (zoomOpen && zoomOpen.wrap === wrap ? null : zoomOpen);
+    if (focusInside) trigger.focus();   // Escape, or an outside press with the focus inside: back to the glyph, never left on a hidden button (review)
   };
   trigger.addEventListener("click", () => setOpen(menu.hidden));
   wireZoomDismiss();
@@ -281,8 +284,11 @@ let zoomDismissWired = false;
 function wireZoomDismiss(): void {
   if (zoomDismissWired) return;
   zoomDismissWired = true;
-  document.addEventListener("mousedown", (e) => { if (zoomOpen && !zoomOpen.wrap.contains(e.target as Node)) zoomOpen.close(); });
-  document.addEventListener("keydown", (e) => { if (e.key === "Escape" && zoomOpen) { zoomOpen.close(); e.stopPropagation(); } }, true);
+  // a viewer closed with its flyout open (the close cross from the keyboard) leaves no reference behind that could
+  // swallow the next viewer's Escape: closeFileView clears it, and a detached wrap is dropped here as well (review)
+  const live = () => { if (zoomOpen && !zoomOpen.wrap.isConnected) zoomOpen = null; return zoomOpen; };
+  document.addEventListener("mousedown", (e) => { const z = live(); if (z && !z.wrap.contains(e.target as Node)) z.close(); });
+  document.addEventListener("keydown", (e) => { const z = live(); if (e.key === "Escape" && z) { z.close(); e.stopPropagation(); } }, true);
 }
 
 // The romp loader (swirl + wordmark + three pulsing accent dots), per the loading-state rule: the
@@ -411,7 +417,9 @@ export function registerFileViewAction(a: FileViewAction): void {
 // branch is not on origin stays an anchor, dashed, with the kernel's note in the tooltip and aria-label,
 // since GitHub 404s it until the push. No URL (no repo, uncommitted, no GitHub origin, an older kernel)
 // leaves the unit hidden: the verdict still rides the reply, it is just not rowed. The unit stays in the
-// row hidden while the check is out (aria-busy names the wait), so the answer lands in place. One question
+// row hidden while the check is out, so the answer lands in place; aria-busy marks the pending unit in the
+// DOM (the tests read it), and hidden it sits outside the accessibility tree, so no wait is announced for a
+// link nobody sees yet. One question
 // per open, reqId-guarded; a socket drop while it is out is the one thing that loses the reply, and the
 // shim's reconnect event re-asks (initFileView), so the wait never outlives the socket. Exported for the
 // DOM-shape test.
@@ -487,6 +495,7 @@ export function closeFileView(): void {
   dropMediaUrl();                                      // an image/PDF view's bytes leave with the viewer
   dropUrlRead();                                       // …and a URL view's in-flight read is cancelled
   dropWidthWatch();                                    // …and the body's width watch (watchBodyWidth)
+  if (zoomOpen) { zoomOpen.close(); zoomOpen = null; }   // the text-size flyout's reference leaves with the viewer (review: a keyboard close kept it, and the next viewer's first Escape was swallowed)
   wrap.remove();
   document.body.classList.remove("fileview-open");
 }
@@ -916,7 +925,7 @@ export function openFileView(path: string, sid?: string | null, opts?: { line?: 
     }
     editBtn.hidden = editing || text === null || !isText || !mtimeNs;
     textSize.sync();                          // the text-size control follows every paint: shown over a text view only
-    viewGroup.hidden = !(segBtns.length > 0 || !textSize.trigger.hidden || !srcBtn.hidden);   // an all-hidden group takes no gap
+    viewGroup.hidden = !(segBtns.some(([, b]) => !b.hidden) || !textSize.trigger.hidden || !srcBtn.hidden);   // an all-hidden group takes no gap (edit mode hides the pair too)
     saveBtn.hidden = !editing;
     cancelBtn.hidden = !editing;
     if (isImage || isPdf) {

--- a/ui/webview/filebrowse.test.ts
+++ b/ui/webview/filebrowse.test.ts
@@ -451,7 +451,7 @@ function viewerUp(): Viewer {
   const body = card.children[card.children.length - 1];
   assert.equal(body.className, "fileview-body");
   const acts = bar.children.find((c) => c.classList.contains("fileview-acts"))!;
-  const btn = (label: string) => { const b = acts.children.find((c) => c.tagName === "button" && c.textContent === label); assert.ok(b !== undefined, "the " + label + " button"); return b!; };
+  const btn = (label: string) => { const walk = (n: El): El | undefined => { for (const c of n.children) { if (c.tagName === "button" && (c.textContent === label || c.getAttribute("aria-label") === label)) return c; const d = walk(c); if (d) return d; } return undefined; }; const b = walk(acts); assert.ok(b !== undefined, "the " + label + " button"); return b!; };   // T367: controls sit in groups, glyph buttons carry their word as aria-label
   return { wrap: wrap!, body, btn };
 }
 /** Click Edit (the editor chunk has no bundle to load from, so the plain textarea mounts) and type a line: the

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -30,6 +30,12 @@ const RULES = [
   '.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] {', '.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover {',
   '.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active {', ".fileview-size-reset {", ".fileview-size-reset.fileview-size-default {",
   "a.fileview-gh-note {", ".fileview-body {",
+  // T367: the grouped row, the segmented pair, the glyph buttons and the text-size flyout
+  ".fileview-group {", ".fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-close {",
+  ".fileview-seg {", ".fileview-seg .fileview-btn {", ".fileview-seg .fileview-btn + .fileview-btn {", ".fileview-seg .fileview-btn:first-child {",
+  ".fileview-seg .fileview-btn:last-child {", ".fileview-seg .fileview-btn.on {",
+  ".fileview-btn.fileview-icon {", ".fileview-btn.fileview-icon svg {", ".fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden] {", ".fileview-btn.fileview-icon.ok {", ".fileview-btn.fileview-icon.err {", ".fileview-btn.fileview-busy {",
+  ".fileview-zoom {", ".fileview-zoom-menu {", ".fileview-zoom-menu[hidden] {",
   ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {", ".fileview > .fileview-err {",
   ".fileview-dir-link {", ".fileview-dir-link:hover {",
   ".fileview-imgbox {", ".fileview-img {", ".fileview-frame {",

--- a/ui/webview/fileview-parity.test.ts
+++ b/ui/webview/fileview-parity.test.ts
@@ -25,16 +25,16 @@ const RULES = [
   ".fileview-dir {", ".fileview-base {", ".fileview-sess {", ".fileview-sess .host-prefix {", ".fileview-acts {",
   ".fileview-bar .fileview-name {", ".fileview-bar .fileview-acts {",   // the bar's own wrap (scoped: the file browser's row wears .fileview-acts too)
   ".fileview-btn {", ".fileview-btn:hover {",
-  "a.fileview-btn {", ".fileview-gh {", ".fileview-gh-why {", ".fileview-gh-dots {",
+  "a.fileview-btn {", ".fileview-gh {",
   // one disabled dress for every bar button: the GitHub unit's no-link state and the text-size control's ends
   '.fileview-btn:disabled, .fileview-btn[aria-disabled="true"] {', '.fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover {',
   '.fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active {', ".fileview-size-reset {", ".fileview-size-reset.fileview-size-default {",
   "a.fileview-gh-note {", ".fileview-body {",
   // T367: the grouped row, the segmented pair, the glyph buttons and the text-size flyout
-  ".fileview-group {", ".fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-close {",
+  ".fileview-group {", ".fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-group ~ .fileview-close {",
   ".fileview-seg {", ".fileview-seg .fileview-btn {", ".fileview-seg .fileview-btn + .fileview-btn {", ".fileview-seg .fileview-btn:first-child {",
   ".fileview-seg .fileview-btn:last-child {", ".fileview-seg .fileview-btn.on {",
-  ".fileview-btn.fileview-icon {", ".fileview-btn.fileview-icon svg {", ".fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden] {", ".fileview-btn.fileview-icon.ok {", ".fileview-btn.fileview-icon.err {", ".fileview-btn.fileview-busy {",
+  ".fileview-btn.fileview-icon {", ".fileview-btn.fileview-icon svg {", ".fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden], .fileview-gh[hidden] {", ".fileview-btn.fileview-icon.ok {", ".fileview-btn.fileview-icon.err {", ".fileview-btn.fileview-busy {",
   ".fileview-zoom {", ".fileview-zoom-menu {", ".fileview-zoom-menu[hidden] {",
   ".fileview-cm {", ".fileview-cm .cm-editor {", ".fileview-editor {", ".fileview > .fileview-err {",
   ".fileview-dir-link {", ".fileview-dir-link:hover {",

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -69,21 +69,13 @@ const parts = (unit: El) => ({
   dots: unit.childNodes.find((c) => c instanceof El && c.className === "fileview-gh-dots") as El | undefined,
   ctl: unit.childNodes.find((c) => c instanceof El && c.classList.contains("fileview-btn")) as El,
 });
-/** The unit as mounted, before any reply: the placeholder the states below all start from. */
+/** The unit as mounted, before any reply: hidden and empty while the kernel's check is out (T367, the user
+ *  2026-09-12: nothing is rowed until a link resolves; the wait is named for assistive tech). */
 function assertPending(unit: El): void {
   assert.equal(unit.className, "fileview-gh");
-  assert.equal(unit.hidden, false, "shown from the mount: the wait itself is visible");
+  assert.equal(unit.hidden, true, "hidden while the check is out: no greyed button, no dots (T367)");
   assert.equal(unit.getAttribute("aria-busy"), "true", "and named as a wait for assistive tech");
-  const { cap, dots, ctl } = parts(unit);
-  assert.equal(ctl.tagName, "button", "a real disabled button holds the slot — never an hrefless anchor flash");
-  assert.equal(ctl.disabled, true); assert.equal(ctl.href, "");
-  assert.equal(ctl.textContent, "GitHub ↗");
-  assert.equal(ctl.title, "Checking GitHub…"); assert.equal(ctl.getAttribute("aria-label"), ctl.title);
-  assert.equal(cap, undefined, "no verdict yet, so no caption to mistake for one");
-  assert.ok(dots, "the loader's dots stand where the caption will go: a slow check reads as a wait");
-  assert.equal(dots!.childNodes.length, 3);
-  assert.ok(dots!.childNodes.every((c) => c instanceof El && c.tagName === "i" && c.className === "fileview-dot"));
-  assert.ok(unit.childNodes.indexOf(dots!) < unit.childNodes.indexOf(ctl), "dots before the button, as the caption will be");
+  assert.equal(unit.childNodes.length, 0, "no placeholder button, no dots, no caption");
 }
 // The module with its poster bound ONCE for this file: every initFileView call adds another romp:wsup
 // (and message) listener on the shared window, so binding per test would make the re-ask count below
@@ -100,11 +92,11 @@ async function mountAndAnswer(url: string, reason: string): Promise<El> {
   const ask = posted[posted.length - 1];
   assert.deepEqual(ask, { type: "fileGitLink", path: "/tmp/notes-api/src/app.py", sid: undefined, reqId: ask.reqId });
   win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId: ask.reqId, url, reason } }));
-  assert.equal(unit.hidden, false, "the answer always shows the action");
   assert.equal(unit.hasAttribute("aria-busy"), false, "the answer ends the wait");
-  assert.equal(parts(unit).dots, undefined, "the placeholder leaves with it");
-  assert.equal(unit.childNodes.filter((c) => c instanceof El && c.classList.contains("fileview-btn")).length, 1,
-    "one control: the placeholder button is replaced, not joined");
+  assert.equal(parts(unit).dots, undefined); assert.equal(parts(unit).cap, undefined, "never a caption (T367)");
+  assert.equal(unit.childNodes.filter((c) => c instanceof El && c.classList.contains("fileview-btn")).length, url ? 1 : 0,
+    url ? "one control: the link" : "no control: nothing to link to, nothing rowed (T367)");
+  assert.equal(unit.hidden, !url, url ? "shown with the link" : "stays hidden");
   return unit;
 }
 
@@ -119,41 +111,29 @@ test("state 1 — a real URL: an anchor that opens a new tab, no caption, the UR
   assert.equal(cap, undefined, "nothing to say — no caption");
 });
 
-test("state 2 — no URL: a real disabled button, the reason visible beside it and in the tooltip", async () => {
-  // the user 2026-09-05 could not tell an uncommitted file from a broken feature when the button
-  // was simply absent; and a reason only a mouse could reach (the tooltip) left touch and keyboard
-  // users with the same question
+test("state 2 — no URL: nothing is rowed, neither a greyed button nor the reason (T367)", async () => {
+  // the user 2026-09-12 wanted the greyed link and its explanation gone from a file outside a repository: the
+  // 2026-09-05 always-fill-the-slot rule gave way; the kernel's verdict still rides the reply, it is just not rowed
   const unit = await mountAndAnswer("", "the file is not committed");
-  const { cap, ctl } = parts(unit);
-  assert.equal(ctl.tagName, "button", "a real button: assistive tech exposes disabled and the label");
-  assert.equal(ctl.type, "button");
-  assert.equal(ctl.disabled, true);
-  assert.equal(ctl.href, "", "nothing to follow, nothing to go stale");
-  assert.equal(ctl.textContent, "GitHub ↗");
-  assert.equal(ctl.title, "No GitHub link: the file is not committed");
-  assert.equal(ctl.getAttribute("aria-label"), ctl.title);
-  assert.ok(cap, "the caption is the reason itself, without hover");
-  assert.equal(cap!.textContent, "the file is not committed");
-  assert.equal(cap!.title, "", "nothing waits behind a hover: the caption IS the whole reason (it wraps; a truncated "
-    + "sentence had no tap, click or focus to finish it — found in review)");
-  assert.ok(unit.childNodes.indexOf(cap!) < unit.childNodes.indexOf(ctl), "the caption annotates the control after it");
+  assert.equal(unit.hidden, true);
+  assert.equal(unit.childNodes.length, 0, "no button, no caption");
+  assert.equal(unit.hasAttribute("aria-busy"), false, "the wait is over, and it stays hidden");
 });
 
-test("state 2b — a kernel that predates link reasons: the caption says so and what to do", async () => {
-  const { cap, ctl } = parts(await mountAndAnswer("", ""));
-  assert.equal(ctl.disabled, true);
-  assert.equal(cap!.textContent, "this kernel predates link reasons; restart it after updating");
-  assert.equal(ctl.title, "No GitHub link: this kernel predates link reasons; restart it after updating");
+test("state 2b — a kernel that predates link reasons: no URL is no link, nothing rowed", async () => {
+  const unit = await mountAndAnswer("", "");
+  assert.equal(unit.hidden, true);
+  assert.equal(unit.childNodes.length, 0);
 });
 
-test("state 3 — a URL whose branch is not on origin: a dashed anchor with the note as its caption", async () => {
+test("state 3 — a URL whose branch is not on origin: a dashed anchor, the note in its tooltip and aria-label (no caption)", async () => {
   const url = "https://github.com/TESTORG/notes-api/blob/wip/src/app.py";
   const { cap, ctl } = parts(await mountAndAnswer(url, "the branch has not been pushed"));
   assert.equal(ctl.tagName, "a"); assert.equal(ctl.href, url);
   assert.equal(ctl.classList.contains("fileview-gh-note"), true);
   assert.equal(ctl.title, url + "\nthe branch has not been pushed");
   assert.equal(ctl.getAttribute("aria-label"), "GitHub: the branch has not been pushed");
-  assert.equal(cap!.textContent, "the branch has not been pushed");
+  assert.equal(cap, undefined, "the note rides the tooltip and aria-label, not a caption (T367)");
 });
 
 test("a reply for an older open lands nowhere — the newer open keeps waiting for its own", async () => {
@@ -168,8 +148,8 @@ test("a reply for an older open lands nowhere — the newer open keeps waiting f
   assertPending(second);   // a stale reply is not the newer open's answer
   win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId: posted[posted.length - 1].reqId,
     url: "", reason: "the file is not committed" } }));
-  assert.equal(second.hasAttribute("aria-busy"), false); assert.equal(parts(second).ctl.disabled, true);
-  assert.equal(parts(second).cap!.textContent, "the file is not committed");
+  assert.equal(second.hasAttribute("aria-busy"), false);
+  assert.equal(second.hidden, true, "no URL: nothing rowed (T367)"); assert.equal(second.childNodes.length, 0);
 });
 
 test("a socket drop while the ask is out: the reconnect re-asks with the same reqId, so the wait ends", async () => {
@@ -189,7 +169,7 @@ test("a socket drop while the ask is out: the reconnect re-asks with the same re
     "the same question, same reqId: a late first reply and the second are one answer");
   win.dispatchEvent(new MessageEvent("message", { data: { type: "fileGitLink", reqId, url: "", reason: "not committed (staged only)" } }));
   assert.equal(unit.hasAttribute("aria-busy"), false);
-  assert.equal(parts(unit).cap!.textContent, "not committed (staged only)");
+  assert.equal(unit.hidden, true, "no URL: nothing rowed (T367)");
   const settled = posted.length;
   win.dispatchEvent(new Event("romp:wsup"));
   assert.equal(posted.length, settled, "an answered open asks nothing more");
@@ -270,5 +250,5 @@ test("the GitHub link is the action REGISTRY's first entry, not another hand-wir
   assert.match(VIEW, /export const githubLinkAction: FileViewAction = \{\n  id: "github-link",/);
   assert.match(VIEW, /registerFileViewAction\(githubLinkAction\);/);
   // openFileView renders registered actions by WALKING THE TABLE, after the built-ins
-  assert.match(VIEW, /for \(const a of fileViewActions\) \{\n    const n = a\.mount\(\{ path, sid: sid \|\| null \}\);\n    if \(n\) acts\.appendChild\(n\);\n  \}/);
+  assert.match(VIEW, /for \(const a of fileViewActions\) \{\n    const n = a\.mount\(\{ path, sid: sid \|\| null \}\);\n    if \(n\) fileGroup\.appendChild\(n\);\n  \}/, "into the file group (T367)");
 });

--- a/ui/webview/github-link.test.ts
+++ b/ui/webview/github-link.test.ts
@@ -187,20 +187,16 @@ test("the poster is bound at the boot of the document that hosts the viewer", ()
   assert.match(RENDER, /initFileView\(\(m\) => vscodeApi\?\.postMessage\(m\)\);/);
 });
 
-test("the sheets dress the unit: the caption at button size, the disabled button inert, the note dashed", () => {
+test("the sheets dress the unit: the link at button size, hidden and out of the row's flow when there is none, the note dashed (T367)", () => {
   // both sheets: the FEED hosts the same viewer (the file browser), so its unit dresses the same
   for (const css of [CHAT_CSS, FEED_CSS]) {
     assert.match(css, /a\.fileview-btn \{ text-decoration: none;/);
     assert.match(css, /\.fileview-gh \{ display: inline-flex; align-items: center; gap: 5px; min-width: 0; \}/);
-    assert.doesNotMatch(css, /\.fileview-gh\[hidden\]/, "nothing hides the unit any more: the wait is shown, not skipped");
-    // the pending placeholder's dots are the pane's own loader dots (accent, pulsing), laid out inline
-    assert.match(css, /\.fileview-gh-dots \{ display: inline-flex; align-items: center; gap: 4px; \}/);
-    assert.match(css, /\.fileview-dot \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);\n  animation: fileview-pulse/);
-    // same size as the buttons it annotates (labels match labels), bounded in width and WRAPPING: the
-    // unit takes no tap, click or focus, so a truncated caption was a sentence nobody could finish
-    assert.match(css, /\.fileview-gh-why \{ font-size: 0\.82em; line-height: 1\.25; color: var\(--dim\); max-width: 18em; text-align: right; \}/);
-    const why = css.slice(css.indexOf(".fileview-gh-why {"), css.indexOf("}", css.indexOf(".fileview-gh-why {")));
-    assert.doesNotMatch(why, /nowrap|ellipsis|overflow: hidden/, "the caption wraps; it is never cut");
+    // the unit's inline-flex would beat the browser's [hidden] rule and leave a live flex item eating a gap (review)
+    assert.match(css, /\.fileview-btn\[hidden\], \.fileview-group\[hidden\], \.fileview-zoom\[hidden\], \.fileview-gh\[hidden\] \{ display: none; \}/);
+    // the caption and the placeholder dots are gone with the always-fill-the-slot rule: no dead rules for them
+    assert.doesNotMatch(css, /\.fileview-gh-(why|dots)/, "the caption and the placeholder dots left (T367)");
+    assert.match(css, /\.fileview-dot \{ width: 4px; height: 4px; border-radius: 50%; background: var\(--accent\);\n  animation: fileview-pulse/, "the pane's loader dots stay");
     assert.match(css, /\.fileview-btn \{ font: inherit; font-size: 0\.82em;/);
     // the disabled dress is every bar button's since the text-size control's ends took it too; the unit's no-link
     // button is a real disabled button under it

--- a/ui/webview/icons.ts
+++ b/ui/webview/icons.ts
@@ -1,0 +1,22 @@
+// The stroke-family glyphs the bars share: a 24-unit viewBox, currentColor strokes, round caps (the composer
+// buttons' family). ONE drawing per meaning, so a download reads the same in the lightbox's tray and in the file
+// viewer's title bar (T367, the user 2026-09-12: the viewer's word buttons became icons, and the tray's glyph is
+// reused, not redrawn). Inline SVG literals — no sanitize; aria-hidden, the button's title and aria-label carry
+// the words (progressive disclosure: the meaning one hover away).
+const svg = (paths: string): string =>
+  '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"'
+  + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' + paths + '</svg>';
+/** the tray: an arrow down onto a bar (the image lightbox's download control since 2026-08-19) */
+export const ICON_DOWNLOAD = svg('<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>'
+  + '<polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>');
+/** two offset sheets (the lightbox's copy-image control since 2026-08-31) */
+export const ICON_COPY = svg('<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>'
+  + '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>');
+/** a pencil over a baseline */
+export const ICON_EDIT = svg('<path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/>');
+/** a magnifier with a plus: the text-size control's one glyph */
+export const ICON_ZOOM = svg('<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>'
+  + '<line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/>');
+/** the acknowledgements a glyph button swaps to: done, and failed */
+export const ICON_CHECK = svg('<polyline points="20 6 9 17 4 12"/>');
+export const ICON_CROSS = svg('<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>');

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -78,7 +78,9 @@ test("the lightbox offers a download beside the close, saving the same bytes it 
     "between the filename and the ✕ — with copy slotted beside it where the clipboard API exists (2026-08-31)");
   // an inline TRAY SVG, not a codepoint: "⭳" (U+2B73) has no coverage in the mac system fonts and
   // rendered as a tofu box (the user 2026-08-19). Same stroke family as the composer's buttons.
-  assert.ok(body.indexOf('<polyline points="7 10 12 15 17 10"/>') > 0, "the arrow-into-tray glyph");
+  assert.ok(body.indexOf("dl.innerHTML = ICON_DOWNLOAD") > 0, "the tray glyph from icons.ts (T367: one drawing, shared with the file viewer's bar)");
+  const ICONS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "icons.ts"), "utf8");
+  assert.ok(ICONS.indexOf('<polyline points="7 10 12 15 17 10"/>') > 0, "the arrow-into-tray glyph");
   assert.ok(body.indexOf("\u2b73") < 0 && body.indexOf("⭳") < 0, "the uncovered codepoint is gone");
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
   assert.match(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{ font: inherit; font-size: 0\.86em;/,

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -8,6 +8,7 @@
 
 import { hostOf, bareId } from "./host-prefix";
 import { mediaSrc } from "./media";
+import { ICON_DOWNLOAD, ICON_COPY } from "./icons";   // the shared stroke-family glyphs (T367)
 import * as pz from "./pinch";
 
 // Extensions the kernel's _PREVIEW_MIME serves — keep the two lists in step (tests pin both).
@@ -345,10 +346,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   // the tray icon every download control should wear (the composer buttons' stroke family) as an
   // inline SVG: the old text glyph (U+2B73, arrow-to-bar) has no coverage in the mac system fonts
   // and rendered as a tofu box instead of an icon (the user 2026-08-19). A literal — no sanitize.
-  dl.innerHTML = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"'
-    + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
-    + '<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>'
-    + '<polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>';
+  dl.innerHTML = ICON_DOWNLOAD;   // icons.ts: the one tray drawing, shared with the file viewer's bar (T367)
   dl.title = "download";
   dl.setAttribute("aria-label", "download");
   dl.onclick = (ev) => ev.stopPropagation();               // saving must not also dismiss
@@ -362,10 +360,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   // (Safari refuses a write that awaits first — the tailnet phone case). Success and failure both
   // speak in place: the icon flips to a check, or to an × whose title names the reason, and the
   // button restores itself either way.
-  const COPY_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"'
-    + ' stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
-    + '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>'
-    + '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+  const COPY_SVG = ICON_COPY;   // icons.ts: the one two-sheets drawing, shared with the file viewer's bar (T367)
   let cp: HTMLButtonElement | null = null;
   if (curImg && typeof ClipboardItem !== "undefined" && navigator.clipboard && navigator.clipboard.write) {
     const btn = document.createElement("button");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3931,9 +3931,39 @@ a.fileview-btn { text-decoration: none; display: inline-flex; align-items: cente
    moves under the pointer when the readout appears after the first press. visibility, not display: the slot
    stays, the button leaves the tab order. */
 .fileview-size-reset { min-width: 5.5em; box-sizing: border-box; text-align: center; font-variant-numeric: tabular-nums; }
-.fileview-size-reset.fileview-size-default { visibility: hidden; }
+.fileview-size-reset.fileview-size-default { color: var(--dim); }
 /* a link whose branch is not on origin yet: dashed, the caption carries the note */
 a.fileview-gh-note { border-style: dashed; }
+/* T367 (the user 2026-09-12): the bar's controls in GROUPS that read as units — the view group (the Rendered|Raw
+   pair, the SVG Source toggle, the text-size glyph) and the file group (edit, the GitHub link, download, copy path),
+   set apart by a wider gap than the controls within them; the close cross alone at the end. */
+.fileview-group { display: inline-flex; align-items: center; gap: 4px; }
+.fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-close { margin-left: 10px; }
+/* the Rendered|Raw pair is ONE segmented control: joined, the shared hairline drawn once, the outer corners rounded,
+   the pressed segment's accent border over the seam */
+.fileview-seg { display: inline-flex; align-items: stretch; }
+.fileview-seg .fileview-btn { border-radius: 0; }
+.fileview-seg .fileview-btn + .fileview-btn { margin-left: -1px; }
+.fileview-seg .fileview-btn:first-child { border-radius: 6px 0 0 6px; }
+.fileview-seg .fileview-btn:last-child { border-radius: 0 6px 6px 0; }
+.fileview-seg .fileview-btn.on { position: relative; z-index: 1; }
+/* a glyph button: the drawing alone, its words in the title and aria-label (one hover away); the copy control's
+   acknowledgements (a check, a cross) recolour it; a busy press dims it until the answer */
+.fileview-btn.fileview-icon { display: inline-flex; align-items: center; justify-content: center; padding: 3px 7px; line-height: 1; }
+.fileview-btn.fileview-icon svg { display: block; }
+/* the display an author rule sets (inline-flex on a glyph button, on a group) would beat the browser's own [hidden]
+   rule, and a hidden edit pencil or zoom glyph would still paint (found on the lab's image screenshot) */
+.fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden] { display: none; }
+.fileview-btn.fileview-icon.ok { color: var(--accent); border-color: var(--accent); }
+.fileview-btn.fileview-icon.err { color: var(--err); border-color: var(--err); }
+.fileview-btn.fileview-busy { opacity: 0.55; }
+/* the text-size flyout under its glyph: the menu vocabulary (the menu tokens, ui/CLAUDE.md), one row holding A−,
+   the readout and A+; the readout at the default reads dimmed (nothing to reset) rather than empty */
+.fileview-zoom { position: relative; display: inline-flex; }
+.fileview-zoom-menu { position: absolute; top: calc(100% + 4px); right: 0; z-index: 5; display: flex; align-items: center; gap: 4px; padding: 4px;
+  background: var(--menu-bg, #252526); color: var(--menu-fg, #cccccc); border: 1px solid var(--menu-border, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius-menu, 6px); box-shadow: var(--shadow-menu, 0 4px 12px rgba(0, 0, 0, 0.35)); }
+.fileview-zoom-menu[hidden] { display: none; }
 .fileview-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* the raw-mode editor: height: 100% (not flex) — .fileview-body above is a plain overflow block,
    not a flex container, so a flex basis on its child is inert and the textarea sat at the UA's

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3906,39 +3906,29 @@ body.fileview-open { overflow: hidden; }
 .fileview-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 /* the GitHub link wears the button treatment but IS an anchor — the browser owns the new tab */
 a.fileview-btn { text-decoration: none; display: inline-flex; align-items: center; }
-/* the GitHub action is one unit: the control and, when the kernel gave one, its reason as a caption
-   beside it — visible without hover (touch has none, and a disabled button takes no focus), and whole:
-   it wraps inside a bounded width rather than truncating, because nothing in the unit takes a tap,
-   click or focus that could finish a cut sentence; same size as the buttons it annotates, ragged edge
-   away from the control it precedes. */
+/* the GitHub action is one unit holding the link when the kernel's check resolves to a URL, and hidden otherwise
+   (T367: no greyed button, no caption; the [hidden] rule below takes it out of the row's flow) */
 .fileview-gh { display: inline-flex; align-items: center; gap: 5px; min-width: 0; }
-.fileview-gh-why { font-size: 0.82em; line-height: 1.25; color: var(--dim); max-width: 18em; text-align: right; }
-/* pending: the kernel's check is on its way (up to 3 s when it must ask origin), so the slot holds the
-   dimmed button and the loader's dots (.fileview-dot, the pane's own) where the caption will go — a slow
-   check must read as a wait, not as the old no-button state nor as a verdict (the loading-state rule) */
-.fileview-gh-dots { display: inline-flex; align-items: center; gap: 4px; }
-/* a disabled bar button, greyed, hover inert: the GitHub unit's no-link state (a real disabled button, never
-   hidden: an absent button read as "broken" when the file was simply not committed yet, 2026-09-05), the
-   editor's Save while a save is in flight (disabled and reading "Saving…"), and the text-size control's ends
-   (A− at the smallest step, A+ at the largest; aria-disabled, so the button keeps the keyboard focus it holds
-   and the ring stays where the person left it). One treatment for every bar button, so neither an end nor a
-   save in progress reads as live under the pointer. */
+/* a disabled bar button, greyed, hover inert: the editor's Save while a save is in flight (disabled and reading
+   "Saving…"), and the text-size control's ends (A− at the smallest step, A+ at the largest; aria-disabled, so
+   the button keeps the keyboard focus it holds and the ring stays where the person left it). One treatment for
+   every bar button, so neither an end nor a save in progress reads as live under the pointer. */
 .fileview-btn:disabled, .fileview-btn[aria-disabled="true"] { opacity: 0.55; cursor: default; }
 .fileview-btn:disabled:hover, .fileview-btn[aria-disabled="true"]:hover { border-color: var(--card-border); color: var(--fg); background: transparent; }
 .fileview-btn:disabled:active, .fileview-btn[aria-disabled="true"]:active { transform: none; }
-/* the text-size readout between A− and A+ (file-view.ts textSizeControl): a slot of ONE width whatever it
-   says, and at the default (nothing to reset, nothing to say) an empty slot rather than none, so A− never
-   moves under the pointer when the readout appears after the first press. visibility, not display: the slot
-   stays, the button leaves the tab order. */
+/* the text-size readout between A− and A+ in the zoom flyout (file-view.ts textSizeControl): a slot of ONE
+   width whatever it says, so A− never moves under the pointer as the number changes; at the default (nothing
+   to reset) it reads dimmed rather than empty (T367). */
 .fileview-size-reset { min-width: 5.5em; box-sizing: border-box; text-align: center; font-variant-numeric: tabular-nums; }
 .fileview-size-reset.fileview-size-default { color: var(--dim); }
-/* a link whose branch is not on origin yet: dashed, the caption carries the note */
+/* a link whose branch is not on origin yet: dashed, the note in its tooltip and aria-label */
 a.fileview-gh-note { border-style: dashed; }
 /* T367 (the user 2026-09-12): the bar's controls in GROUPS that read as units — the view group (the Rendered|Raw
    pair, the SVG Source toggle, the text-size glyph) and the file group (edit, the GitHub link, download, copy path),
-   set apart by a wider gap than the controls within them; the close cross alone at the end. */
+   set apart by a wider gap than the controls within them; the close cross alone at the end. The wider gaps apply
+   only where groups exist: the file browser's row and the URL viewer's flat row keep their spacing. */
 .fileview-group { display: inline-flex; align-items: center; gap: 4px; }
-.fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-close { margin-left: 10px; }
+.fileview-acts > .fileview-group + .fileview-group, .fileview-acts > .fileview-group ~ .fileview-close { margin-left: 10px; }
 /* the Rendered|Raw pair is ONE segmented control: joined, the shared hairline drawn once, the outer corners rounded,
    the pressed segment's accent border over the seam */
 .fileview-seg { display: inline-flex; align-items: stretch; }
@@ -3953,7 +3943,7 @@ a.fileview-gh-note { border-style: dashed; }
 .fileview-btn.fileview-icon svg { display: block; }
 /* the display an author rule sets (inline-flex on a glyph button, on a group) would beat the browser's own [hidden]
    rule, and a hidden edit pencil or zoom glyph would still paint (found on the lab's image screenshot) */
-.fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden] { display: none; }
+.fileview-btn[hidden], .fileview-group[hidden], .fileview-zoom[hidden], .fileview-gh[hidden] { display: none; }
 .fileview-btn.fileview-icon.ok { color: var(--accent); border-color: var(--accent); }
 .fileview-btn.fileview-icon.err { color: var(--err); border-color: var(--err); }
 .fileview-btn.fileview-busy { opacity: 0.55; }


### PR DESCRIPTION
The file viewer's title bar, tidied (the user, 2026-09-12: for a markdown file it read Rendered, Raw, A minus, a readout, A plus, Edit, "not in a git repository", a greyed GitHub link, Download, Copy path and a close cross on its own row).

Design points (the design set went to the manager and the user before this landed; screenshots `romp_ui-t367-*.png` in the drops folder, before and after, four files, both themes):
- **Groups.** The row is a view group (the Rendered|Raw pair as ONE segmented control, joined with a shared hairline and rounded outer corners; the SVG Source toggle; the text-size glyph), a file group (edit, the GitHub link, download, copy path), and the close cross alone at the end, with a wider gap between groups than within. A group with nothing to show (an image) takes no room.
- **Glyphs.** Download is the lightbox's tray drawing, Copy path the lightbox's two-sheets drawing, both now shared through `ui/webview/icons.ts` (the lightbox imports them too: one drawing per meaning, none redrawn); Edit is a pencil; the text size is a zoom-in magnifier. Every glyph carries its words in `title` and `aria-label` (Download, Edit, Copy path, Text size) so the meaning is one hover away. Save and Cancel stay words in edit mode.
- **Text size.** The zoom glyph opens a flyout under it holding the existing A minus, readout and A plus; the flyout wears the menu vocabulary (`--menu-bg`, `--menu-fg`, `--menu-border`, `--radius-menu`, `--shadow-menu`), one open at a time, closed by the glyph, Escape (captured before the viewer's own Escape) or a press outside. The readout reads dimmed at the default instead of an empty slot; the glyph's tooltip says the size and the wheel binding (`Text size 100% (Ctrl/Cmd + wheel)`). The Ctrl/Cmd + wheel binding is untouched.
- **GitHub.** The link shows only when it resolves: a file outside a repository, an uncommitted file or a non-GitHub origin shows neither a greyed link nor an explanation (the 2026-09-05 always-fill-the-slot rule gave way to the tidier bar; the kernel's verdict still rides the reply). A branch not on origin keeps the dashed link with the note in its tooltip and aria-label.
- **Acknowledgements.** Copy path dims in the same tick, then a check and "Copied" for 1.2 s, or a cross and "Copy failed" until the next press; Download says "Downloading…" in its tooltip with a busy dress.
- **A fix found by the lab's own screenshot.** A glyph button's `display: inline-flex` beat the browser's `[hidden]` rule, so a hidden pencil and magnifier still painted on an image; both sheets now hide `[hidden]` bar buttons, groups and the zoom wrap explicitly, and the lab pins the computed display.

Both viewer sheets (`styles.css`, `feed.css`) carry the same rules byte for byte (the parity test lists the new heads). `render.ts` is untouched. The file browser's context menu keeps its words.

Tests, red first:
- `tests/test_file_view_bar_browser.py`: a hermetic kernel, a session whose folder is a repo with a GitHub-shaped origin served from a local bare repo through a stand-in ssh (no network), and four files opened through the pane's own relay: markdown in the repo, markdown outside any repository, a PNG, a Python file. Pins: the GitHub unit hidden and empty outside a repo and one anchor for the repo file (no caption either way); download is the tray glyph with its words; the pair's two buttons are adjacent siblings whose rects touch, in the view group, the row ordered view group, file group, close; an image hides the view group and paints no hidden glyph; the zoom glyph opens a flyout with the three size buttons and Escape closes it, viewer intact; copy path acknowledges in the same tick and settles. Against the build before the change (`FILE_BAR_DIST`) all 7 fail; with the change 7 pass. `FILE_BAR_SHOTS` wrote the screenshot set.
- Webview pins re-pointed, not weakened: `github-link.test.ts` (pending is hidden and empty; no URL rows nothing; the note rides the tooltip), `file-view-text-size.test.ts` (the control's visibility is the glyph's; the flyout's order; the dimmed default; the tooltip's readout; the URL viewer's row), `file-view.test.ts` (the pair inside one wrapper; the tray glyph in the file group), `file-view-notice`, `file-view-perf`, `filebrowse` (button lookup by word or aria-label, recursive), `preview-core` (the glyph in icons.ts), `fileview-parity` (the new heads pinned byte-equal in both sheets).

Executed: focused webview files 267 passed, 0 failed; full extension suite 4574 tests, 4569 passed, 0 failed, 5 skipped (node test, concurrency 2, capped); typecheck clean; Python `test_file_github`, `test_served_tests_require`, `test_state_isolation_order`, `test_dist_copy_staging` 55 passed.

Tier: feature
