### PR TITLE
A tab dragged into a new chat column stays there: the column waits for its kernel's own strip before it can report itself empty

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -53238,10 +53238,14 @@ drag={sid:m.sid,name:typeof m.name==='string'?m.name:'',from:Number(colOf(e.sour
 if(m.romp==='colEmpty'&&Array.isArray(m.gone)){var c=Number(colOf(e.source)),en=c>=2?entry(c):null;if(!en)return;
 var gone=en.ids.filter(function(id){return m.gone.indexOf(id)>=0;});en.ids=en.ids.filter(function(id){return m.gone.indexOf(id)<0;});
 if(en.ids.length){save();return;}
-// the ids return to the first column, but the kernel may still list one closed from its own cross for a push or two: the
-// first column's page holds them back (closingTabs) until the kernel's strip omits them, so no tab flashes into its strip
-// on the way out (review find 2026-09-11; the message is queued ahead of the store write's storage event)
-var home=document.getElementById('f-chat');try{if(home&&gone.length)home.contentWindow.postMessage({romp:'closing',ids:gone},'*');}catch(e){}
+// the ids return to the first column. One the page's own CROSS removed (m.crossed) the kernel may still list for a push or
+// two: the first column's page holds those back (closingTabs, the "Couldn't close" backstop behind it) until the kernel's
+// strip omits them, so no tab flashes into its strip on the way out (review find 2026-09-11; the message is queued ahead of
+// the store write's storage event). Nothing else is held: a member gone for any other reason is simply the first column's
+// again, shown the moment its strip repaints — a hold over a session the kernel still listed hid the tab for the backstop
+// and toasted a close nobody asked for (the vanishing tab, the user 2026-09-12)
+var crossed=Array.isArray(m.crossed)?gone.filter(function(id){return m.crossed.indexOf(id)>=0;}):[];
+var home=document.getElementById('f-chat');try{if(home&&crossed.length)home.contentWindow.postMessage({romp:'closing',ids:crossed},'*');}catch(e){}
 close(en.n);return;}
 // ORPHANED STATE (review find 2026-09-11): a page holds a draft, citations, attachments or staged messages for a session
 // it does not show — a column blob written before the partition (a v1 column was a whole chat page, so its blob may name

--- a/tests/test_chat_split.py
+++ b/tests/test_chat_split.py
@@ -276,8 +276,11 @@ class SplitSourcePins(unittest.TestCase):
         mt = split[split.index("function moveTab(sid,to){"):split.index("function close(n,keep){")]
         self.assertLess(mt.index("if(!movable(src,sid))"), mt.index("if(to==='new'){"), "refused before anything is taken or grown")
         self.assertLess(mt.index("busy(src)"), mt.index("var st=take(src,sid)"), "refused before the hand-off")
-        # a column closed for emptiness tells the first column which ids are on their way home, ahead of the store write
-        self.assertIn("home.contentWindow.postMessage({romp:'closing',ids:gone},'*');", split)
+        # a column closed for emptiness tells the first column which of its gone ids the page's own cross removed, ahead of
+        # the store write; nothing else is held (the vanishing tab, 2026-09-12)
+        self.assertIn("var crossed=Array.isArray(m.crossed)?gone.filter(function(id){return m.crossed.indexOf(id)>=0;}):[];", split)
+        self.assertIn("home.contentWindow.postMessage({romp:'closing',ids:crossed},'*');", split)
+        self.assertNotIn("{romp:'closing',ids:gone}", split)
         ce = split[split.index("if(m.romp==='colEmpty'"):split.index("if(m.romp==='orphanState'")]
         self.assertLess(ce.index("{romp:'closing'"), ce.index("close(en.n)"))
         # …and orphaned state offered by a page is handed to the owner's page when that page can hear it
@@ -556,16 +559,27 @@ boot({ 'romp-chat-cols': JSON.stringify({ v: 2, cols: [{ n: 2, ids: [WEB] }] }) 
 BUSY['f-chat-2'] = true; STORE['romp-chat-cols'] = JSON.stringify({ v: 2, cols: [] }); CALLS.notify = [];
 window.dispatchEvent({ type: 'storage', key: 'romp-chat-cols' });
 out.busy.reconciled = { ids: ids(), notify: CALLS.notify.slice() };
-// M) a colEmpty that closes a column tells the first column which ids are on their way home, ahead of the store write;
-//    a prune that leaves members says nothing
+// M) a colEmpty that closes a column tells the first column which of its gone ids the page's own cross removed (crossed),
+//    ahead of the store write; a prune that leaves members says nothing; a gone id nobody crossed is not held (it is the
+//    first column's the moment its strip repaints); a crossed id the entry did not hold is ignored
 boot({}, false);
 window.__rompMoveTab(API, 'new'); window.__rompMoveTab(TESTS, 2);
 CALLS.posted = []; SEQ = [];
-msg({ romp: 'colEmpty', gone: [TESTS] }, 'f-chat-2');
+msg({ romp: 'colEmpty', gone: [TESTS], crossed: [TESTS] }, 'f-chat-2');
 out.closing = { partial: CALLS.posted.slice() };
 CALLS.posted = []; SEQ = [];
-msg({ romp: 'colEmpty', gone: [API, X] }, 'f-chat-2');
+msg({ romp: 'colEmpty', gone: [API, X], crossed: [API, X] }, 'f-chat-2');
 out.closing.all = { posted: CALLS.posted.slice(), seq: SEQ.filter((x) => x.indexOf('post:') === 0 || x === 'set:romp-chat-cols'), ids: ids(), stored: cols() };
+boot({}, false);
+window.__rompMoveTab(API, 'new');
+CALLS.posted = [];
+msg({ romp: 'colEmpty', gone: [API] }, 'f-chat-2');   // no cross named (a page misled by a stale frame, an older page): the column closes, nothing is held
+out.closing.uncrossed = { posted: CALLS.posted.filter((p) => p.m && p.m.romp === 'closing'), ids: ids(), stored: cols() };
+boot({}, false);
+window.__rompMoveTab(API, 'new');
+CALLS.posted = [];
+msg({ romp: 'colEmpty', gone: [API], crossed: [] }, 'f-chat-2');
+out.closing.emptyCross = { posted: CALLS.posted.filter((p) => p.m && p.m.romp === 'closing'), ids: ids(), stored: cols() };
 // N) ORPHANED STATE: a page's offer of state for sessions it does not show is taken from it and handed to the owner's page
 //    when that page can hear it; its own member and junk are skipped; a target not yet evaluated leaves the state where it is
 boot({ 'romp-chat-cols': '[2]', 'romp-vscode-state-chat:2': JSON.stringify({ activeId: WEB, drafts: { [WEB]: 'a', [API]: 'b' } }) }, false);
@@ -854,14 +868,20 @@ class SplitExecutes(unittest.TestCase):
 
     def test_a_column_closed_for_emptiness_tells_the_first_column_which_ids_are_on_their_way_home(self):
         # the kernel may still list a member closed from its own cross for a push or two, and the first column would draw
-        # its tab until then (review find 2026-09-11): the ids ride ahead of the store write, so the first column's page
-        # holds them back (closingTabs) until the kernel's strip omits them
+        # its tab until then (review find 2026-09-11): the CROSSED ids ride ahead of the store write, so the first column's
+        # page holds them back (closingTabs) until the kernel's strip omits them. Only those: the backstop behind that hold
+        # toasts "Couldn't close", right for a refused cross and wrong for anything else — a hold over a session the kernel
+        # still listed hid the tab for fifteen seconds and toasted a close nobody asked for (the vanishing tab, 2026-09-12)
         c = self.out["closing"]
         self.assertEqual(c["partial"], [], "a prune that leaves members posts nothing")
         a = c["all"]
-        self.assertEqual(a["posted"], [{"id": "f-chat", "m": {"romp": "closing", "ids": [API]}}], "the entry's members the page reported gone, never an id it did not hold")
+        self.assertEqual(a["posted"], [{"id": "f-chat", "m": {"romp": "closing", "ids": [API]}}], "the entry's members the page reported crossed, never an id it did not hold")
         self.assertEqual(a["seq"], ["post:f-chat:closing", "set:romp-chat-cols"], "the message is queued ahead of the store write's storage event")
         self.assertEqual(a["ids"], ["f-chat"]); self.assertEqual(a["stored"], {"v": 2, "cols": []})
+        for key in ("uncrossed", "emptyCross"):
+            u = c[key]
+            self.assertEqual(u["posted"], [], "%s: a gone id nobody crossed is not held — the first column shows it the moment its strip repaints" % key)
+            self.assertEqual(u["ids"], ["f-chat"], "%s: the column still closes" % key); self.assertEqual(u["stored"], {"v": 2, "cols": []})
 
     def test_orphaned_state_is_handed_to_the_column_that_shows_the_session_when_its_page_can_hear_it(self):
         # a v1 column's blob held drafts for many sessions and the migration keeps one (review find 2026-09-11): the page

--- a/tests/test_chat_split_served.py
+++ b/tests/test_chat_split_served.py
@@ -147,9 +147,11 @@ await page.routeWebSocket((u) => /[?&]col=2(?:&|$)/.test(u.href), (ws) => {
   const server = ws.connectToServer();
   col2Wire = ws; col2Held = [];
   ws.onMessage((m) => { try { const f = JSON.parse(m); if (f && f.type === "needFull") col2Asks.push([f.id, f.why || ""]); } catch (e) { /* a non-JSON frame */ } server.send(m); });
-  server.onMessage((m) => { if (holdCol2) col2Held.push(m); else ws.send(m); });
+  server.onMessage((m) => { if (holdCol2) { col2Held.push(m); if (heldOnceResolve) { heldOnceResolve(); heldOnceResolve = null; } } else ws.send(m); });   // the first held frame resolves heldOnce: step 11 writes the arrangement only once the kernel's burst is in hand
   server.onClose(() => ws.close()); ws.onClose(() => server.close());
 });
+let heldOnceResolve = null, heldOnce = Promise.resolve();   // armed with the hold (below): resolves on the first frame held at the wire
+const armHeldOnce = () => { heldOnce = new Promise((r) => { heldOnceResolve = r; }); };
 const releaseCol2 = () => { holdCol2 = false; const held = col2Held.splice(0); for (const m of held) { try { col2Wire.send(m); } catch (e) { /* the column closed under the hold */ } } return held.length; };
 // The shell's log (the top document: every column's posts land there, and the store's writes are the shell's own): the
 // split's colEmpty traffic with its source frame, and every write of romp-chat-cols, stamped. And the lab's knob: the
@@ -458,7 +460,7 @@ await waitGone("chat-pane-2");
 await waitTabs("f-chat", [cfg.sidA, cfg.sidB, cfg.sidC]);
 await clickTab("f-chat", cfg.sidB); await waitActive("f-chat", cfg.sidB);
 await page.evaluate(() => { window.__shellLog = []; });
-holdCol2 = true;
+holdCol2 = true; armHeldOnce();
 await dragStart("f-chat", cfg.sidB);
 await waitFn(() => !!document.querySelector(".col-drop.col-drop-edge"), null, "step 11: the edge zone never mounted");
 const edge11 = await page.evaluate(() => { const z = document.querySelector(".col-drop.col-drop-edge"); const r = z.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; });
@@ -469,6 +471,9 @@ await page.mouse.up();
 out.s11 = { storeAtDrop: await page.evaluate(() => localStorage.getItem("romp-chat-cols")) };
 // the window: the column's bundle has evaluated (its page functions are published) while its kernel frames are still held
 out.s11.bundleUp = await page.waitForFunction(() => { const f = document.getElementById("f-chat-2"); try { return !!(f && f.contentWindow && typeof f.contentWindow.__rompTakeSessionState === "function"); } catch (e) { return false; } }, null, { timeout: T }).then(() => true).catch(() => false);
+// …and the kernel's connect burst has reached the wire (held there): on a slow runner the burst can trail the bundle by more
+// than the bundle's own evaluation, so the write waits for the first held frame, bounded, rather than assuming it
+await Promise.race([heldOnce, new Promise((r) => setTimeout(r, T))]);
 out.s11.heldAtWrite = col2Held.length;
 await page.evaluate(() => { const cur = localStorage.getItem("romp:vieworder") || "[]"; const next = cur.includes(", ") ? cur.replace(/, /g, ",") : cur.replace(/,/g, ", "); localStorage.setItem("romp:vieworder", next === cur ? cur + " " : next); });
 // the page's reaction to the event settles in its own task, the shell's (a colEmpty) one message hop later: one bounded beat

--- a/tests/test_chat_split_served.py
+++ b/tests/test_chat_split_served.py
@@ -230,6 +230,7 @@ const sends = (p, slot) => (((p || {}).sends || {}).full || {})[slot]?.count || 
 await page.goto(cfg.url);
 await waitTabs("f-chat", [cfg.sidA, cfg.sidB, cfg.sidC]);
 await waitBootGone();
+const board = (await tabsIn("f-chat")).length;   // the board: the status frames a skeleton column receives are one per OTHER tab
 if ((await activeIn("f-chat")) !== cfg.sidA) { await clickTab("f-chat", cfg.sidA); await waitActive("f-chat", cfg.sidA); }
 out.col1Before = await activeIn("f-chat");
 
@@ -274,7 +275,12 @@ const perfAtPaint = await page.evaluate(() => window.__obs.perfAtPaint ? window.
 out.s1.col2Active = await activeIn("f-chat-2"); out.s1.col1After = await activeIn("f-chat");
 out.s1.col2Tabs = await tabsIn("f-chat-2"); out.s1.col1Tabs = await tabsIn("f-chat");
 out.s1.obs = await page.evaluate(() => { const { perfAtPaint, ...rest } = window.__obs; return rest; });
-out.s1.fullChatDelta = sends(perfAtPaint, "chat") - sends(perf0, "chat"); out.s1.statusDelta = sends(perfAtPaint, "status") - sends(perf0, "status");
+out.s1.fullChatDelta = sends(perfAtPaint, "chat") - sends(perf0, "chat");   // read AT the paint: a later read could count the page's idle prefetch
+// the statuses trail the one full on a slow runner (strip, the full, then a status per other tab, in the ready arm's push):
+// wait for the kernel's counter to reach the board, bounded, instead of reading it at the paint
+const needStatus = sends(perf0, "status") + board - 1;
+const perfSettled = await page.waitForFunction(async (need) => { const p = await fetch("/perf").then((r) => r.json()); const c = ((((p || {}).sends || {}).full || {}).status || {}).count || 0; return c >= need ? p : false; }, needStatus, { timeout: T }).then((h) => h.jsonValue()).catch(() => null);
+out.s1.statusDelta = sends(perfSettled || perfAtPaint, "status") - sends(perf0, "status");
 out.s1.col2Asks = col2Asks.slice();
 out.s1.targetB = await targetOf(cfg.sidB); out.s1.targetA = await targetOf(cfg.sidA); out.s1.targetX = await targetOf(cfg.sidX);
 

--- a/tests/test_chat_split_served.py
+++ b/tests/test_chat_split_served.py
@@ -33,7 +33,14 @@ driver run walks the whole story in order, each step landing in its own assertio
      dragged from column 2 onto column 1's pane wears the cue there and, dropped, comes home and column 2 closes;
  10. a column blob from BEFORE the partition (a v1 store, its column-2 blob naming B and holding a draft for A, as a
      whole chat page's blob could) reloads into column 2 on B, and A's draft reaches column 1's box: the page offers
-     state for a session it no longer shows to the shell, which hands it to the column that does.
+     state for a session it no longer shows to the shell, which hands it to the column that does;
+ 11. THE VANISHING TAB (the user 2026-09-12): B, column 1's ACTIVE tab, dragged into the edge while another pane's
+     arrangement write reaches the new column ahead of the kernel's first strip (column 2's kernel frames held at the
+     wire until the shell has rewritten romp:vieworder): column 2 stands and lists B once its strip lands, no colEmpty
+     is posted, column 1 re-points to a member of its own, and past the close backstop (shortened for the lab) a strip
+     change raises no "Couldn't close" toast;
+ 12. the hold behind that toast is for the user's own cross: a colEmpty naming a session the kernel still lists, with no
+     cross, closes the column and B is on column 1's strip at once, no toast.
 Skips LOUDLY when the extension deps or a playwright browser are absent (CI installs none). Synthetic only:
 placeholder sids, invented notes-api prompt text, no real session data."""
 import json
@@ -80,6 +87,7 @@ FILLERS = [("11111111-2222-4333-8444-00000000030%d" % k, name, k)
 BOARD = 2 + len(FILLERS)
 DRAG_PX = 200
 SLACK_PX = 40
+CLOSE_ACK_MS_LAB = 1500   # render.ts CLOSE_ACK_MS for the lab (the romp:closeAckMs knob): the wait past the backstop in steps 11 and 12 is short
 DRAFT = "a half-typed note for the api session, kept across the move"
 ORPHAN_DRAFT = "a note for the web session, left in a column blob from before the partition"
 
@@ -130,11 +138,35 @@ const out = { t0: Date.now() };
 // Column 2's asks, read at the socket layer (the browser reports every frame's sockets): a needFull from a column opened
 // as a view of one session is the fingerprint of the board loading behind the view. 2026-09-11: seven `nobase` asks per
 // open, one per withheld tab, when the shim's FIFO delivered the status frames ahead of the strip that named their set.
+// …read at the WIRE (page.routeWebSocket sees every frame's sockets, the column iframes' included), which also lets step 11
+// HOLD the kernel's frames to column 2 from its connect until the driver releases them: the window between the new
+// column's bundle evaluating and its first strip landing is then held open for as long as the step needs, never raced.
 const col2Asks = [];
-page.on("websocket", (ws) => {
-  if (!/[?&]col=2(?:&|$)/.test(ws.url())) return;
-  ws.on("framesent", (f) => { try { const m = JSON.parse(f.payload); if (m && m.type === "needFull") col2Asks.push([m.id, m.why || ""]); } catch (e) { /* a non-JSON frame */ } });
+let holdCol2 = false, col2Held = [], col2Wire = null;
+await page.routeWebSocket((u) => /[?&]col=2(?:&|$)/.test(u.href), (ws) => {
+  const server = ws.connectToServer();
+  col2Wire = ws; col2Held = [];
+  ws.onMessage((m) => { try { const f = JSON.parse(m); if (f && f.type === "needFull") col2Asks.push([f.id, f.why || ""]); } catch (e) { /* a non-JSON frame */ } server.send(m); });
+  server.onMessage((m) => { if (holdCol2) col2Held.push(m); else ws.send(m); });
+  server.onClose(() => ws.close()); ws.onClose(() => server.close());
 });
+const releaseCol2 = () => { holdCol2 = false; const held = col2Held.splice(0); for (const m of held) { try { col2Wire.send(m); } catch (e) { /* the column closed under the hold */ } } return held.length; };
+// The shell's log (the top document: every column's posts land there, and the store's writes are the shell's own): the
+// split's colEmpty traffic with its source frame, and every write of romp-chat-cols, stamped. And the lab's knob: the
+// close backstop (render.ts CLOSE_ACK_MS, read from localStorage at a page's boot) at 1.5 s, so step 11's wait past it
+// is short. An init script runs in the top document before its scripts; the column iframes read the same storage.
+await page.addInitScript((ackMs) => {
+  if (window !== window.top) return;
+  try { localStorage.setItem("romp:closeAckMs", String(ackMs)); } catch (e) { /* */ }
+  window.__shellLog = [];
+  window.addEventListener("message", (e) => {
+    const m = e && e.data; if (!m || typeof m !== "object" || m.romp !== "colEmpty") return;
+    let src = null; try { const f = window.__rompFrameOfWin && window.__rompFrameOfWin(e.source); src = f ? f.id : null; } catch (err) { /* */ }
+    window.__shellLog.push({ t: Date.now(), romp: m.romp, src, gone: m.gone, crossed: m.crossed });
+  }, true);
+  const setItem = Storage.prototype.setItem;
+  Storage.prototype.setItem = function (k, v) { if (k === "romp-chat-cols") window.__shellLog.push({ t: Date.now(), store: v }); return setItem.call(this, k, v); };
+}, cfg.ackMs);
 const die = async (why) => {
   out.ms = Date.now() - out.t0;
   fs.writeSync(1, "RESULT:" + JSON.stringify({ ...out, died: why }) + "\n");
@@ -404,6 +436,81 @@ await waitActive("f-chat", cfg.sidA);
 await waitFn(([fid, draft]) => { const d = document.getElementById(fid).contentDocument; const ta = d && d.getElementById("composer-input"); return !!ta && ta.value === draft; }, ["f-chat", cfg.orphan], "column 1's box never showed the draft column 2's blob held for A");
 out.s10.draftInCol1 = await composerIn("f-chat");
 out.s10.blob2 = await page.evaluate(() => JSON.parse(localStorage.getItem("romp-vscode-state-chat:2") || "null"));
+out.msStory = Date.now() - out.t0;
+try {   // steps 11 and 12 record their own failure rather than taking the story's record with them
+// ---- 11. THE VANISHING TAB (the user 2026-09-12): the ACTIVE tab dragged into the edge while another pane's arrangement write reaches the new column ahead of the kernel's strip ----
+// Column 2 (step 10) closes from its cross; B comes home and is made column 1's ACTIVE tab (the user's case). Column 2's
+// kernel frames are HELD at the wire from its connect, so the window between the new column's bundle evaluating (its frame
+// handler registered with the federation manager) and the kernel's first strip landing stays open; in it the shell rewrites
+// romp:vieworder (the same list, a new spelling: what another chat pane's absorbHostReport, a drag elsewhere or another
+// dashboard window does on a busy board), a real cross-context storage event in every column. Before the fix column 2's
+// manager re-emitted the merged order from its EMPTY store, the page took that as the board and posted colEmpty for B,
+// the shell closed the column and told column 1 to hold B back: no column showed B, and fifteen seconds later the
+// "Couldn't close" toast let it back into column 1.
+const toastsIn = (fid) => page.evaluate((fid) => { const f = document.getElementById(fid); const d = f && f.contentDocument; return d ? Array.from(d.querySelectorAll(".warn-toast-msg")).map((e) => e.textContent) : null; }, fid);
+const emptyLineIn = (fid) => page.evaluate((fid) => { const f = document.getElementById(fid); const d = f && f.contentDocument; if (!d) return null; const es = d.getElementById("empty-state"); return es && es.style.display !== "none" ? (es.textContent || "").trim().slice(0, 120) : null; }, fid);
+const listsIn = (fid, sid, timeout) => page.waitForFunction(([fid, sid]) => { const f = document.getElementById(fid); const d = f && f.contentDocument; return !!d && Array.from(d.querySelectorAll("#tabs .tab[data-id]")).some((t) => t.dataset.id === sid); }, [fid, sid], { timeout }).then(() => true).catch(() => false);
+const rename = (sid, name) => page.evaluate(async ([sid, name]) => { const r = await fetch("/rename", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ target: sid, name }) }); return r.status; }, [sid, name]);
+const labelSeen = (sid, name) => page.waitForFunction(([sid, name]) => { const d = document.getElementById("f-chat").contentDocument; const t = d && d.querySelector('#tabs .tab[data-id="' + sid + '"] .tab-label'); return !!t && (t.textContent || "").includes(name); }, [sid, name], { timeout: T }).then(() => true).catch(() => false);
+const shellLog = () => page.evaluate(() => window.__shellLog.slice());
+await page.evaluate(() => document.querySelector("#chat-pane-2 .col-x").click());
+await waitGone("chat-pane-2");
+await waitTabs("f-chat", [cfg.sidA, cfg.sidB, cfg.sidC]);
+await clickTab("f-chat", cfg.sidB); await waitActive("f-chat", cfg.sidB);
+await page.evaluate(() => { window.__shellLog = []; });
+holdCol2 = true;
+await dragStart("f-chat", cfg.sidB);
+await waitFn(() => !!document.querySelector(".col-drop.col-drop-edge"), null, "step 11: the edge zone never mounted");
+const edge11 = await page.evaluate(() => { const z = document.querySelector(".col-drop.col-drop-edge"); const r = z.getBoundingClientRect(); return { x: r.left + r.width / 2, y: r.top + r.height / 2 }; });
+await page.mouse.move(edge11.x, edge11.y, { steps: 8 });
+await waitFn(() => document.getElementById("col-ghost").classList.contains("on"), null, "step 11: the rectangle never showed");
+const t11 = Date.now();
+await page.mouse.up();
+out.s11 = { storeAtDrop: await page.evaluate(() => localStorage.getItem("romp-chat-cols")) };
+// the window: the column's bundle has evaluated (its page functions are published) while its kernel frames are still held
+out.s11.bundleUp = await page.waitForFunction(() => { const f = document.getElementById("f-chat-2"); try { return !!(f && f.contentWindow && typeof f.contentWindow.__rompTakeSessionState === "function"); } catch (e) { return false; } }, null, { timeout: T }).then(() => true).catch(() => false);
+out.s11.heldAtWrite = col2Held.length;
+await page.evaluate(() => { const cur = localStorage.getItem("romp:vieworder") || "[]"; const next = cur.includes(", ") ? cur.replace(/, /g, ",") : cur.replace(/,/g, ", "); localStorage.setItem("romp:vieworder", next === cur ? cur + " " : next); });
+// the page's reaction to the event settles in its own task, the shell's (a colEmpty) one message hop later: one bounded beat
+await page.evaluate(() => new Promise((r) => setTimeout(r, 300)));
+out.s11.beforeRelease = { frames: await page.evaluate(() => window.__rompChatFrameIds()), cols: await page.evaluate(() => localStorage.getItem("romp-chat-cols")), log: await shellLog() };
+out.s11.released = releaseCol2();
+out.s11.col2ListsB = await listsIn("f-chat-2", cfg.sidB, T);
+out.s11.col2Active = await activeIn("f-chat-2");
+out.s11.col1Tabs = await tabsIn("f-chat"); out.s11.col2Tabs = await tabsIn("f-chat-2");
+out.s11.after = await shell();
+// the source column was ON B: it re-points to a member of its own, never the view line
+out.s11.col1Active = await activeIn("f-chat"); out.s11.col1Empty = await emptyLineIn("f-chat");
+// past the close backstop, a strip change (a rename of another session) runs column 1's applyTabOrder → ackClosingTabs: a hold left standing would toast here
+const left11 = t11 + cfg.ackMs + 500 - Date.now(); if (left11 > 0) await page.waitForTimeout(left11);
+out.s11.rename = await rename(cfg.sidC, "tests-renamed");
+out.s11.renamedSeen = await labelSeen(cfg.sidC, "tests-renamed");
+out.s11.toasts1 = await toastsIn("f-chat"); out.s11.toasts2 = await toastsIn("f-chat-2");
+out.s11.log = await shellLog();
+out.s11.final = { col1Tabs: await tabsIn("f-chat"), col2Tabs: await tabsIn("f-chat-2"), col1Active: await activeIn("f-chat"), col2Active: await activeIn("f-chat-2"), frames: (await shell()).frameIds };
+
+// ---- 12. the hold is for the user's own cross: a column closed for emptiness over a session the kernel still lists returns it to the first column at once ----
+// A colEmpty naming B with no cross, from column 2's own window (what a page misled by a stale frame would post): the shell
+// prunes the entry and closes the column, and B is column 1's the moment its strip repaints. Before, the shell told column
+// 1 to hold B back as a closing tab: B was in no column until the backstop, and the "Couldn't close" toast let it back.
+if (!(await page.$("#f-chat-2"))) {   // step 11 lost the column (the defect): this step stands on its own, so a column on B is opened again
+  await page.evaluate((sidB) => window.__rompMoveTab(sidB, "new"), cfg.sidB);
+  await waitTabs("f-chat-2", [cfg.sidB]); await waitActive("f-chat-2", cfg.sidB);
+}
+const f2 = await (await page.$("#f-chat-2")).contentFrame();
+await page.evaluate(() => { window.__shellLog = []; });
+const t12 = Date.now();
+await f2.evaluate((sid) => window.parent.postMessage({ romp: "colEmpty", gone: [sid] }, "*"), cfg.sidB);
+out.s12 = { colGone: await page.waitForFunction(() => !document.getElementById("chat-pane-2"), null, { timeout: T }).then(() => true).catch(() => false) };
+out.s12.col1ListsB = await listsIn("f-chat", cfg.sidB, 3000);
+out.s12.msToList = Date.now() - t12;
+out.s12.after = await shell(); out.s12.col1Tabs = await tabsIn("f-chat");
+const left12 = t12 + cfg.ackMs + 500 - Date.now(); if (left12 > 0) await page.waitForTimeout(left12);
+out.s12.rename = await rename(cfg.sidC, "tests-again");
+out.s12.renamedSeen = await labelSeen(cfg.sidC, "tests-again");
+out.s12.toasts1 = await toastsIn("f-chat");
+out.s12.log = await shellLog();
+} catch (e) { out.lateError = String((e && e.stack) || e); }
 out.ms = Date.now() - out.t0;
 fs.writeSync(1, "RESULT:" + JSON.stringify(out) + "\n");
 await browser.close();
@@ -481,7 +588,7 @@ class ServedChatSplit(unittest.TestCase):
         cfg = os.path.join(cls.lab, "cfg.json")
         with open(cfg, "w") as f:
             json.dump({"url": "http://127.0.0.1:%d/?token=%s" % (cls.port, cls.token),
-                       "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "sidX": SID_X, "dragPx": DRAG_PX, "draft": DRAFT, "orphan": ORPHAN_DRAFT}, f)
+                       "sidA": SID_A, "sidB": SID_B, "sidC": SID_C, "sidX": SID_X, "dragPx": DRAG_PX, "draft": DRAFT, "orphan": ORPHAN_DRAFT, "ackMs": CLOSE_ACK_MS_LAB}, f)
         driver = os.path.join(cls.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)
@@ -688,7 +795,9 @@ class ServedChatSplit(unittest.TestCase):
 
     def test_8_the_whole_story_runs_in_well_under_half_a_minute(self):
         r = self._r()
-        self.assertLess(r["ms"], 30000, "the driver waits on conditions, never on fixed sleeps: %d ms" % r["ms"])
+        self.assertLess(r["msStory"], 30000, "the driver waits on conditions, never on fixed sleeps: %d ms" % r["msStory"])
+        # steps 11 and 12 each wait past the close backstop by design (shortened to CLOSE_ACK_MS_LAB), so they are bounded apart
+        self.assertLess(r["ms"] - r["msStory"], 4 * CLOSE_ACK_MS_LAB + 10000, "steps 11 and 12: two backstops plus their waits on conditions: %d ms" % (r["ms"] - r["msStory"]))
 
     def test_9_a_tab_dragged_into_the_right_edge_opens_a_column_and_dragged_onto_another_column_moves_there(self):
         """The drag (the user 2026-09-11): a real pointer drag, the shell's zones mounted on the page's tabDrag message,
@@ -747,6 +856,62 @@ class ServedChatSplit(unittest.TestCase):
         self.assertEqual(s["col2Tabs"], [SID_B])
         self.assertEqual(s["draftInCol1"], ORPHAN_DRAFT, "A's draft, held in column 2's blob, is in column 1's box once A is picked there: %r" % s)
         self.assertNotIn(SID_A, ((s["blob2"] or {}).get("drafts") or {}), "…and left column 2's blob: %r" % s["blob2"])
+
+
+    def test_11_the_active_tab_dragged_into_a_new_column_stays_there_when_another_pane_s_arrangement_write_beats_the_kernel_s_strip(self):
+        """The vanishing tab (the user 2026-09-12): a tab dragged into a new column vanished from every column and came back
+        about fifteen seconds later behind a "Couldn't close … romp still has it open" toast. Client-side end to end: the new
+        column's federation manager, subscribed to the view-order storage event before its kernel's first strip had been
+        absorbed, re-emitted the merged order from an EMPTY store on another pane's arrangement write; applyTabOrder took that
+        synthetic frame as the board, noteColumnEmptiness posted colEmpty for a member the kernel never stopped listing, the
+        shell closed the column and column 1 held the id back until the backstop. Held open here at the wire, that window
+        must produce nothing: no colEmpty, the column standing and listing B once its strip lands, the source column re-pointed
+        to a member of its own (it was ON B), and no toast when a strip change runs past the backstop."""
+        r = self._r()
+        self.assertNotIn("lateError", r, "steps 11/12 raised: %s" % r.get("lateError"))
+        s = r["s11"]
+        self.assertEqual(json.loads(s["storeAtDrop"]), {"v": 2, "cols": [{"n": 2, "ids": [SID_B]}]}, "the drop wrote the store: %r" % s["storeAtDrop"])
+        self.assertTrue(s["bundleUp"], "column 2's bundle evaluated while its kernel frames were held: %r" % s)
+        self.assertGreaterEqual(s["heldAtWrite"], 1, "the kernel's connect burst was held at the wire when the shell wrote the arrangement: %r" % s)
+        b = s["beforeRelease"]
+        self.assertEqual([e for e in b["log"] if e.get("romp") == "colEmpty"], [], "a column that has not heard its kernel reports no emptiness: %r" % b["log"])
+        self.assertEqual(b["frames"], ["f-chat", "f-chat-2"], "column 2 stands through the window: %r" % b)
+        self.assertEqual(json.loads(b["cols"]), {"v": 2, "cols": [{"n": 2, "ids": [SID_B]}]}, "…and the store still holds B in it: %r" % b)
+        self.assertGreaterEqual(s["released"], 1, "the held frames were released: %r" % s["released"])
+        self.assertTrue(s["col2ListsB"], "with its strip landed, column 2 lists B: %r" % s)
+        self.assertEqual(s["col2Active"], SID_B); self.assertEqual(s["col2Tabs"], [SID_B])
+        self.assertNotIn(SID_B, s["col1Tabs"], "B left column 1: %r" % s["col1Tabs"])
+        # the source column was ON B: the re-point falls to a member of its own, never the "tab view shows no session" line
+        self.assertIsNotNone(s["col1Active"], "column 1 re-points to one of its own tabs: %r" % {k: s[k] for k in ("col1Active", "col1Empty", "col1Tabs")})
+        self.assertIn(s["col1Active"], s["col1Tabs"]); self.assertNotEqual(s["col1Active"], SID_B)
+        self.assertIsNone(s["col1Empty"], "…and shows no empty-state line: %r" % s["col1Empty"])
+        # past the close backstop, on a strip change: no "Couldn't close" toast in either column, and still no colEmpty
+        self.assertEqual(s["rename"], 200, "the rename that pushes a fresh strip: %r" % s["rename"])
+        self.assertTrue(s["renamedSeen"], "the pushed strip reached column 1's tab label: %r" % s)
+        self.assertEqual(s["toasts1"], [], "no toast in column 1: %r" % s["toasts1"]); self.assertEqual(s["toasts2"], [])
+        self.assertEqual([e for e in s["log"] if e.get("romp") == "colEmpty"], [], "%r" % s["log"])
+        f = s["final"]
+        self.assertEqual(f["frames"], ["f-chat", "f-chat-2"]); self.assertEqual(f["col2Tabs"], [SID_B]); self.assertNotIn(SID_B, f["col1Tabs"])
+        self.assertEqual(f["col2Active"], SID_B)
+
+    def test_12_a_column_closed_for_emptiness_over_a_session_the_kernel_still_lists_returns_it_to_the_first_column_at_once(self):
+        """The hold behind the "Couldn't close" toast (column 1's closingTabs, fed by the shell's `closing` message) is for a
+        tab the user crossed in the closing column, which the kernel goes on listing for a push or two; the toast is right
+        when that cross is refused. A colEmpty naming a session nobody crossed (a page misled by a stale frame, an older page)
+        must not use it: the shell closes the column and the session is column 1's the moment its strip repaints, and no
+        toast follows when a strip change runs past the backstop."""
+        r = self._r()
+        self.assertNotIn("lateError", r, "steps 11/12 raised: %s" % r.get("lateError"))
+        s = r["s12"]
+        self.assertTrue(s["colGone"], "the column closed: %r" % s)
+        self.assertTrue(s["col1ListsB"], "B is on column 1's strip within a moment, not held back for the backstop: %r" % s)
+        self.assertEqual(s["after"]["frameIds"], ["f-chat"]); self.assertEqual(json.loads(s["after"]["cols"]), {"v": 2, "cols": []})
+        self.assertIn(SID_B, s["col1Tabs"])
+        self.assertEqual(s["rename"], 200); self.assertTrue(s["renamedSeen"], "the pushed strip reached column 1: %r" % s)
+        self.assertEqual(s["toasts1"], [], "no 'Couldn't close' toast: nothing was crossed: %r" % s["toasts1"])
+        posts = [e for e in s["log"] if e.get("romp") == "colEmpty"]
+        self.assertEqual([(e["src"], e["gone"], e.get("crossed")) for e in posts], [("f-chat-2", [SID_B], None)],
+                         "the one colEmpty at the shell is the driver's own, from column 2's window, naming no cross: %r" % s["log"])
 
 
 if __name__ == "__main__":

--- a/ui/webview/chat-split-exec.test.ts
+++ b/ui/webview/chat-split-exec.test.ts
@@ -17,6 +17,9 @@ import { columnHolds, type ColSets } from "./chat-columns";
 import { isProvisionalId } from "./provisional";
 import { isSubId } from "./subagent-view";
 import { StagedStack } from "./staged-messages";
+import { syncSessionsFromTabMeta } from "./tab-meta";
+import { reconcileTabOrder, retainLiveOmitted, localStrip } from "./tab-order";
+import { hostOf } from "./host-prefix";
 
 const requireCjs = createRequire(__filename);
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
@@ -72,7 +75,7 @@ function world(o: { col?: string; sets?: ColSets | null; tabOrderSeen?: boolean;
     let colSets = W.sets, tabOrderSeen = W.tabOrderSeen, activeId = W.activeId, provisionalId = W.provisionalId, wantActive = W.wantActive;
     let vanishedId = null;   // T357's tab-that-left; never set in these worlds (the fallback yields to it, pinned in chat-split.test.ts)
     const failedProvisionals = new Set(W.failed || []);
-    let colEmptyPosted = false;
+    let colEmptyPosted = false; const closingTabs = new Map(); let boardLive = new Set();
     const readColSets = () => { HOOKS.reads++; return W.shell.sets; };
     const peekId = null; const chatVisible = () => true;
     const setTimeout = (f) => { HOOKS.timers.push(f); return HOOKS.timers.length; };
@@ -105,14 +108,14 @@ test("the emptiness post: once per emptiness, reset by a member listed again; no
   w.api.render([WEB, TESTS]);
   assert.deepEqual(w.HOOKS.posts, [], "one member still listed: the column stands");
   w.api.render([WEB]);
-  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API, TESTS] }], "none listed: the shell is told which ids are gone");
+  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API, TESTS], crossed: [] }], "none listed: the shell is told which ids are gone, and that none went by this page's own cross");
   w.api.render([WEB]); w.api.render([]);
   assert.equal(w.HOOKS.posts.length, 1, "said once per emptiness, not per render");
   w.api.render([WEB, TESTS]);
   assert.equal(w.HOOKS.posts.length, 1, "a member listed again resets the latch…");
   w.api.render([WEB]);
   assert.equal(w.HOOKS.posts.length, 2, "…so the next emptiness is said again");
-  assert.deepEqual(w.HOOKS.posts[1], { romp: "colEmpty", gone: [API, TESTS] });
+  assert.deepEqual(w.HOOKS.posts[1], { romp: "colEmpty", gone: [API, TESTS], crossed: [] });
   // the gates
   const early = world({ col: "2", sets: { "2": [API] }, tabOrderSeen: false });
   early.api.render([WEB]);
@@ -137,7 +140,7 @@ test("a create in flight, or a failed one still holding its text, keeps the colu
   w.api.set({ provisionalId: null, failed: [PROV] }); w.api.render([WEB]);
   assert.deepEqual(w.HOOKS.posts, [], "a failed create holding its text keeps it too, until its ✕ discards it");
   w.api.set({ failed: [] }); w.api.render([WEB]);
-  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API] }], "with the create gone the emptiness is said");
+  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API], crossed: [] }], "with the create gone the emptiness is said");
 });
 
 test("the stale-active fallback belongs to the partition: no sets, nothing scheduled; with sets, the first visible member after the timer, a wanted tab held elsewhere retired", () => {
@@ -262,4 +265,112 @@ test("adoptSessionState joins every slice onto what is already here, persists on
   assert.equal(w.HOOKS.persisted, 2);
   w.api.adoptSessionState("", { draft: "x" }); w.api.adoptSessionState(API, null); w.api.adoptSessionState(API, "junk");
   assert.equal(w.HOOKS.persisted, 2, "junk changes nothing");
+});
+
+// ── the strip's arrival, RUN: applyTabOrder itself, with the frames a column receives ─────────────────────────────
+// The vanishing tab (the user 2026-09-12): a tab dragged into a new column vanished from every column and came back
+// about fifteen seconds later behind a "Couldn't close" toast. The chain was client-side: the new column's federation
+// manager re-emitted the merged order from an EMPTY store (a view-order storage event from another pane landing between
+// the bundle's frame-handler registration and the kernel's first strip), applyTabOrder took that synthetic frame as
+// the board, and noteColumnEmptiness posted colEmpty for a member the kernel never stopped listing. The world below
+// lifts the real applyTabOrder, ackClosingTabs, noteColumnEmptiness and stripLists, with the strip pass renderTabs
+// runs before the post (order, then pushed tabs not yet in it, each through stripLists; chat-split.test.ts pins the
+// real lines) and stubs for the teardown, the restore and the body.
+const U = "11111111-2222-3333-4444-555555555509";
+const T3 = [{ id: WEB, name: "web" }, { id: API, name: "api" }, { id: TESTS, name: "tests" }];
+const T2 = [{ id: WEB, name: "web" }, { id: TESTS, name: "tests" }];
+type StripHooks = { posts: Record<string, unknown>[]; renders: string[][]; dismissed: [string, string][]; toasts: string[]; shown: number };
+type StripApi = {
+  frame: (o: string[], tabs: { id: string; name: string }[], report: { reemit?: boolean; freshHost?: string } | undefined, live: string[]) => void;
+  cross: (id: string) => void;
+  tick: (ms: number) => void;
+  state: () => { tabOrderSeen: boolean; order: string[]; tabMeta: string[]; closing: string[]; colEmptyPosted: boolean };
+};
+function stripWorld(o: { col: string; sets: ColSets | null; wantActive?: string | null }): { api: StripApi; HOOKS: StripHooks; W: { sets: ColSets | null } } {
+  const HOOKS: StripHooks = { posts: [], renders: [], dismissed: [], toasts: [], shown: 0 };
+  const W = { sets: o.sets };
+  const PARENT = { postMessage(m: Record<string, unknown>) { HOOKS.posts.push(m); }, __rompChatSets: () => W.sets };
+  const win = { parent: PARENT, frameElement: { id: "f-chat-" + o.col } };
+  const js = requireCjs("esbuild").transformSync(
+    [line("heldHere"), line("tabInView"), fn("stripLists"), fn("ackClosingTabs"), fn("applyTabOrder"), fn("noteColumnEmptiness")].join("\n"), { loader: "ts" }).code;
+  const prelude = `
+    const { columnHolds, isProvisionalId, isSubId, syncSessionsFromTabMeta, reconcileTabOrder, retainLiveOmitted, hostOf, localStrip, HOOKS } = W;
+    const COL = W.col;
+    let colSets = W.sets, tabOrderSeen = false, activeId = null, provisionalId = null, wantActive = W.wantActive, vanishedId = null;
+    const failedProvisionals = new Set(); let colEmptyPosted = false; let boardLive = new Set();
+    const readColSets = () => W.shell.sets;
+    const peekId = null; const chatVisible = () => true;
+    const tabMeta = new Map(), sessions = new Map(), pendingTabMeta = new Map(), closingTabs = new Map(), kernelListed = new Set(); const order = [];
+    const CLOSE_ACK_MS = 15_000; let clock = 1_000_000; const Date = { now: () => clock };
+    const vscodeApi = null;
+    const dismissSession = (id, why) => { HOOKS.dismissed.push([id, why]); sessions.delete(id); const i = order.indexOf(id); if (i >= 0) order.splice(i, 1); };
+    const restoreIfShown = () => false; const showActive = () => { HOOKS.shown++; }; const warnToast = (t) => { HOOKS.toasts.push(t); };
+    const renderTabs = () => { colSets = readColSets(); const ids = [], seen = new Set();
+      for (const id of order) { if (!seen.has(id) && stripLists(id)) { seen.add(id); ids.push(id); } }
+      for (const id of tabMeta.keys()) { if (!seen.has(id) && stripLists(id)) { seen.add(id); ids.push(id); } }
+      HOOKS.renders.push(ids.slice()); noteColumnEmptiness(ids); };
+  `;
+  const epilogue = `
+    return {
+      frame: (o, tabs, report, live) => applyTabOrder(o, tabs, report, live),
+      cross: (id) => { closingTabs.set(id, Date.now()); dismissSession(id, "close"); renderTabs(); },
+      tick: (ms) => { clock += ms; },
+      state: () => ({ tabOrderSeen, order: order.slice(), tabMeta: [...tabMeta.keys()], closing: [...closingTabs.keys()], colEmptyPosted }),
+    };
+  `;
+  const make = new Function("W", "window", prelude + js + epilogue) as (w: unknown, win: unknown) => StripApi;
+  const api = make({ columnHolds, isProvisionalId, isSubId, syncSessionsFromTabMeta, reconcileTabOrder, retainLiveOmitted, hostOf, localStrip, HOOKS,
+                     col: o.col, sets: W.sets, shell: W, wantActive: o.wantActive ?? null }, win);
+  return { api, HOOKS, W };
+}
+
+test("the vanishing tab: a synthetic re-emission served from an empty store ahead of the kernel's strip is not the board, so a fresh column posts no emptiness; the kernel's own strip arms the flag", () => {
+  const w = stripWorld({ col: "2", sets: { "2": [API] }, wantActive: API });
+  w.api.frame([], [], { reemit: true }, []);   // federation.ts emitMergedOrder over an empty per-host store: order [], flagged reemit
+  assert.equal(w.api.state().tabOrderSeen, false, "a re-emission is never the kernel's word: the board has not been heard");
+  assert.deepEqual(w.HOOKS.posts, [], "…so nothing is said about emptiness and the column stands");
+  w.api.frame([WEB, API, TESTS], T3, { freshHost: "" }, [WEB, API, TESTS]);   // the LOCAL kernel's strip, fresh
+  assert.equal(w.api.state().tabOrderSeen, true, "the kernel's own strip arms it");
+  assert.deepEqual(w.HOOKS.posts, [], "the member is listed");
+  assert.deepEqual(w.HOOKS.renders.at(-1), [WEB, API, TESTS]);
+  w.api.frame([WEB, API, TESTS], T3, { reemit: true }, [WEB, API, TESTS]);   // another pane's drag: a re-emission from a filled store
+  assert.deepEqual(w.HOOKS.posts, [], "a re-emission carrying the member says nothing either");
+  w.api.frame([WEB, TESTS], T2, { freshHost: "" }, [WEB, TESTS]);   // the member ended: the kernel omits it and no longer affirms it live
+  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API], crossed: [] }], "the emptiness is said from the kernel's own strip, and no member went by this page's cross");
+});
+
+test("provenance: a remote host's fresh push ahead of the local strip arms nothing; a frame with no provenance (a kernel that sends directly, VS Code) is the kernel's own word", () => {
+  const r = stripWorld({ col: "2", sets: { "2": [API] } });
+  r.api.frame(["TESTHOST:" + U], [{ id: "TESTHOST:" + U, name: "remote" }], { freshHost: "TESTHOST" }, ["TESTHOST:" + U]);
+  assert.equal(r.api.state().tabOrderSeen, false, "another kernel's push says nothing about this kernel's sessions");
+  assert.deepEqual(r.HOOKS.posts, []);
+  r.api.frame([WEB, API, "TESTHOST:" + U], [...T3.slice(0, 2), { id: "TESTHOST:" + U, name: "remote" }], { freshHost: "" }, [WEB, API, "TESTHOST:" + U]);
+  assert.equal(r.api.state().tabOrderSeen, true);
+  const s = stripWorld({ col: "2", sets: { "2": [API] } });
+  s.api.frame([WEB, API], T3.slice(0, 2), { reemit: false, freshHost: undefined }, [WEB, API]);   // the dispatch's shape for a frame the kernel sent directly
+  assert.equal(s.api.state().tabOrderSeen, true, "no federation: the frame is the kernel's");
+});
+
+test("a first strip that omits a live member (T258's shape on a fresh column) keeps the column: the kernel's live set affirms it", () => {
+  const w = stripWorld({ col: "2", sets: { "2": [API] } });
+  w.api.frame([WEB, TESTS], T2, { freshHost: "" }, [WEB, API, TESTS]);
+  assert.equal(w.api.state().tabOrderSeen, true);
+  assert.deepEqual(w.HOOKS.posts, [], "the kernel affirms the member live: a strip omitting it is a transient read failure, never an emptiness");
+  w.api.frame([WEB, API, TESTS], T3, { freshHost: "" }, [WEB, API, TESTS]);
+  assert.deepEqual(w.HOOKS.renders.at(-1), [WEB, API, TESTS], "re-listed in place");
+  w.api.frame([WEB, TESTS], T2, { freshHost: "" }, [WEB, TESTS]);
+  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API], crossed: [] }], "omitted AND no longer live: gone");
+});
+
+test("the user's own cross empties the column at once and is named (crossed), so the shell holds only that id back in the first column; an ended member is gone but not crossed", () => {
+  const w = stripWorld({ col: "2", sets: { "2": [API, TESTS] } });
+  w.api.frame([WEB, API, TESTS], T3, { freshHost: "" }, [WEB, API, TESTS]);
+  w.api.cross(API);   // ✕ on API: the kernel goes on listing it for a push or two
+  assert.deepEqual(w.HOOKS.posts, [], "TESTS still listed: the column stands");
+  w.api.frame([WEB, API], T3.slice(0, 2), { freshHost: "" }, [WEB, API]);   // TESTS ended meanwhile; API still listed, still crossed here
+  assert.deepEqual(w.HOOKS.posts, [{ romp: "colEmpty", gone: [API, TESTS], crossed: [API] }], "both gone from this column; only API by this page's cross");
+  const b = stripWorld({ col: "2", sets: { "2": [API, TESTS] } });
+  b.api.frame([WEB, API, TESTS], T3, { freshHost: "" }, [WEB, API, TESTS]);
+  b.api.cross(API); b.api.cross(TESTS);
+  assert.deepEqual(b.HOOKS.posts, [{ romp: "colEmpty", gone: [API, TESTS], crossed: [API, TESTS] }], "two crosses: both named");
 });

--- a/ui/webview/chat-split.test.ts
+++ b/ui/webview/chat-split.test.ts
@@ -73,8 +73,14 @@ test("a pick of a session another column holds is shown where it lives: the setA
   // column: no emptiness post while it stands (review find 2026-09-11: the column closed under it and the queued text died)
   assert.match(RENDER, /function staleActiveFallback\(ids: readonly string\[\], visibleIds: readonly string\[\]\): void \{\n\s*if \(colSets === null\) return;[^\n]*\n(?:\s*\/\/[^\n]*\n)*\s*if \(activeId \|\| vanishedId \|\| !tabOrderSeen \|\| provisionalId \|\| !visibleIds\.length\) return;\n\s*if \(wantActive && heldHere\(wantActive\)\) return;/,
     "the fallback yields to an active tab, a tab that left on its own, and a wanted tab this column holds (T357 keeps the pane unfocused for its return); a wanted tab held elsewhere is retired");
-  assert.match(RENDER, /function noteColumnEmptiness\(ids: readonly string\[\]\): void \{\n\s*if \(!COL \|\| !colSets \|\| !tabOrderSeen\) return;\n(?:\s*\/\/[^\n]*\n)*\s*if \(provisionalId \|\| failedProvisionals\.size\) return;[\s\S]*?window\.parent\.postMessage\(\{ romp: "colEmpty", gone: mine\.slice\(\) \}, "\*"\);/);
-  assert.match(RENDER, /tabOrderSeen = true;[^\n]*\n\s*renderTabs\(\);\n\}/, "set in applyTabOrder, ahead of its render");
+  // …a member the kernel's live set still affirms counts as present unless this page's own cross removed it (T258 on a fresh
+  // column), and the post names the crossed members, the only ones the shell holds back (the vanishing tab, 2026-09-12)
+  assert.match(RENDER, /function noteColumnEmptiness\(ids: readonly string\[\]\): void \{\n\s*if \(!COL \|\| !colSets \|\| !tabOrderSeen\) return;\n(?:\s*\/\/[^\n]*\n)*\s*if \(provisionalId \|\| failedProvisionals\.size\) return;\n\s*const mine = colSets\[COL\] \|\| \[\];\n\s*const present = \(id: string\) => ids\.includes\(id\) \|\| \(boardLive\.has\(id\) && !closingTabs\.has\(id\)\);\n\s*const empty = mine\.length > 0 && !mine\.some\(present\);[\s\S]*?const crossed = mine\.filter\(\(id\) => closingTabs\.has\(id\)\);\n\s*try \{ window\.parent\.postMessage\(\{ romp: "colEmpty", gone: mine\.slice\(\), crossed \}, "\*"\);/);
+  assert.match(RENDER, /boardLive = liveSet;/, "applyTabOrder keeps the frame's live set for the emptiness post");
+  // the flag is armed by the LOCAL kernel's own strip only (tab-order.ts localStrip): a synthetic re-emission — on a fresh
+  // page served from an EMPTY store, order [] — or another host's fresh push is never the board (the vanishing tab, 2026-09-12)
+  assert.match(RENDER, /if \(localStrip\(report\)\) tabOrderSeen = true;\n\s*renderTabs\(\);\n\}/, "set in applyTabOrder on the kernel's own strip, ahead of its render");
+  assert.match(RENDER, /import \{ localStrip, readCloseAckMs \} from "\.\/tab-order";/);
   // the shell's two questions before it moves a tab or closes a column (kernel.py moveTab / close; tests/test_chat_split.py
   // runs the refusals): an id a column can hold, and a create in flight here
   assert.match(RENDER, /\(window as any\)\.__rompMovableSession = \(sid: unknown\): boolean => typeof sid === "string" && !!sid && !isProvisionalId\(sid\) && !isSubId\(sid\);/);
@@ -84,7 +90,11 @@ test("a pick of a session another column holds is shown where it lives: the setA
   // the ids a colEmpty close sends home are held back on the first column's strip until the kernel's strip omits them
   // (the same closingTabs a ✕ uses), so no tab flashes into that strip on its way out
   assert.match(RENDER, /if \(m\.romp === "closing"\) \{ if \(Array\.isArray\(m\.ids\)\) for \(const id of m\.ids\) \{ if \(typeof id === "string" && id\) closingTabs\.set\(id, Date\.now\(\)\); \} renderTabs\(\); return; \}/);
-  assert.ok(KERNEL.includes("home.contentWindow.postMessage({romp:'closing',ids:gone},'*');"));
+  // …and the shell names ONLY the ids the page's own cross removed (colEmpty's `crossed`): the backstop behind the hold toasts
+  // "Couldn't close", right for a refused cross and wrong for anything else (the vanishing tab, 2026-09-12)
+  assert.ok(KERNEL.includes("var crossed=Array.isArray(m.crossed)?gone.filter(function(id){return m.crossed.indexOf(id)>=0;}):[];"));
+  assert.ok(KERNEL.includes("home.contentWindow.postMessage({romp:'closing',ids:crossed},'*');"));
+  assert.ok(!KERNEL.includes("{romp:'closing',ids:gone}"), "no hold over the whole gone list");
   // orphaned state (a v1 column blob's drafts for sessions the column no longer shows) is offered to the shell every
   // render while it remains, from renderTabs right after the emptiness post, and the shell hands it to the owner's page
   assert.match(RENDER, /noteColumnEmptiness\(ids\);[^\n]*\n\s*noteOrphanState\(\);/);

--- a/ui/webview/federation-direct-delivery.test.ts
+++ b/ui/webview/federation-direct-delivery.test.ts
@@ -114,6 +114,8 @@ test("a detach's hostDrop `closed` frames and an undeliverable send's `warn` sta
   withManager((fm, windowed) => {
     const got: any[] = [];
     fm.onFrame((e: MessageEvent) => got.push(e.data));
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }] });   // the local kernel's strip lands first, as on every page (tabs-first on connect): the merged order's re-emissions are held until it has (federation-order-hold.test.ts)
+    got.length = 0;
     // an attached host whose socket is not open: its sessions are on screen, its tunnel is down
     fm.conns.set("TESTHOST", { host: "TESTHOST", ws: null, url: "", closed: false, live: false, lastRecv: 0, resumeProvisional: 0, connT: 0, pending: new Map() });
     fm.hostSeq.push("TESTHOST");
@@ -184,6 +186,8 @@ test("a throw on a detach's lanes emission still lets its bars emission run", ()
   withManager((fm, windowed, reported) => {
     const got: string[] = [];
     fm.onFrame((e: MessageEvent) => { got.push(e.data.type); if (e.data.type === "data") throw new Error("lanes bug"); });
+    fm.inbound("", { type: "tabOrder", order: [U], tabs: [{ id: U, name: "web" }] });   // the local strip first, as on every page: the detach's order re-emission below is held until it has landed (federation-order-hold.test.ts)
+    got.length = 0;
     fm.inbound("", laneData([U]));
     fm.inbound("", { type: "bars", turns: [] });
     fm.inbound("TESTHOST", laneData([V]));

--- a/ui/webview/federation-order-hold.test.ts
+++ b/ui/webview/federation-order-hold.test.ts
@@ -1,0 +1,99 @@
+// The merged tab order holds its synthetic re-emissions until the LOCAL kernel's strip is in the store (the vanishing
+// tab, the user 2026-09-12): a fresh chat column's manager subscribes to the view-order storage event before the local
+// kernel's first strip has been absorbed, and another pane's arrangement write in that window re-emitted the merged
+// order over an EMPTY per-host store — `order: []`, flagged reemit — which the pane took as the board and reported its
+// one member gone; the shell closed the column and the tab was in no column for fifteen seconds. The hold is the one
+// emitMergedTimeline already applies to its own payload: the local arrival itself emits, so nothing is lost. A host's
+// own FRESH push still emits (its ids are that kernel's current word). And the arrangement prune respects `live`: a
+// strip that omits a live id (T258's shape) no longer drops it from the browser's arrangement to re-adopt it at the end.
+// Executed against the real manager. Synthetic only (host TESTHOST, placeholder ids).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FederationManager } from "./federation";
+import { listenForFrames } from "./frame-listener";
+import { VIEW_ORDER_KEY } from "./view-order";
+
+const A = "11111111-2222-3333-4444-555555555501", B = "11111111-2222-3333-4444-555555555502", C = "11111111-2222-3333-4444-555555555503";
+const U = "99999999-8888-7777-6666-555555555555";
+const tabs = (...ids: string[]) => ids.map((id) => ({ id, name: id.slice(-3) }));
+
+function withManager(fn: (fm: any, emitted: any[], store: Map<string, string>) => void): void {
+  const emitted: any[] = [];
+  const store = new Map<string, string>();
+  const g: any = globalThis;
+  const hadWindow = "window" in g, prevWindow = g.window;
+  const hadLS = "localStorage" in g, prevLS = g.localStorage;
+  g.window = { dispatchEvent: (ev: any) => { if (ev && ev.data) emitted.push(ev.data); } };
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  try { fn(new FederationManager(), emitted, store); } finally {
+    if (hadWindow) g.window = prevWindow; else delete g.window;
+    if (hadLS) g.localStorage = prevLS; else delete g.localStorage;
+  }
+}
+const orders = (emitted: any[]) => emitted.filter((m) => m && m.type === "tabOrder");
+
+test("a synthetic re-emission before the local kernel's strip emits no order; a remote host's fresh push emits; the local arrival emits, and re-emissions flow after it", () => {
+  withManager((fm, emitted) => {
+    fm.emitMergedOrder();                                            // a view-order storage event, a caps adoption, a closed fold, a host drop
+    assert.deepEqual(orders(emitted), [], "an empty store is not the board: nothing is emitted");
+    fm.inbound("TESTHOST", { type: "tabOrder", order: [U], tabs: tabs(U) });
+    assert.equal(orders(emitted).length, 1, "a host's OWN push is its current word: emitted");
+    assert.equal(orders(emitted)[0].freshHost, "TESTHOST");
+    assert.deepEqual(orders(emitted)[0].order, ["TESTHOST:" + U]);
+    fm.emitMergedOrder();
+    assert.equal(orders(emitted).length, 1, "still held: the local kernel has not spoken");
+    fm.inbound("", { type: "tabOrder", order: [A, B], tabs: tabs(A, B) });
+    assert.equal(orders(emitted).length, 2, "the local arrival itself emits");
+    assert.equal(orders(emitted)[1].freshHost, "");
+    assert.deepEqual(orders(emitted)[1].order, ["TESTHOST:" + U, A, B], "every host's sessions, in the arrangement's order (the remote's arrival was adopted first)");
+    fm.emitMergedOrder();
+    assert.equal(orders(emitted).length, 3, "…and from then on re-emissions flow");
+    assert.equal(orders(emitted)[2].reemit, true);
+    assert.deepEqual(orders(emitted)[2].order, ["TESTHOST:" + U, A, B]);
+  });
+});
+
+test("through start(): a view-order storage event on a fresh page (the window the vanishing tab fell into) hands the pane no tabOrder; after the local strip it does", () => {
+  const g: any = globalThis;
+  const saved: Record<string, [boolean, unknown]> = {};
+  for (const k of ["window", "document", "localStorage", "setInterval", "fetch"]) saved[k] = [k in g, g[k]];
+  const win: any = new EventTarget();
+  win.__rompApp = "chat";
+  const store = new Map<string, string>();
+  g.window = win;
+  g.document = Object.assign(new EventTarget(), { visibilityState: "visible" });
+  g.localStorage = { getItem: (k: string) => store.get(k) ?? null, setItem: (k: string, v: string) => { store.set(k, v); } };
+  g.setInterval = () => 0;
+  g.fetch = () => Promise.reject(new Error("no kernel"));
+  try {
+    const fm: any = new FederationManager();
+    fm.start();
+    const got: any[] = [];
+    listenForFrames((e: MessageEvent) => got.push(e.data));   // the bundle's registration: from here every emission reaches the pane
+    store.set(VIEW_ORDER_KEY, JSON.stringify([A, B]));
+    win.dispatchEvent(new Event("storage"));                   // another pane's arrangement write, before this page's kernel strip
+    assert.deepEqual(orders(got), [], "no order reaches the pane: the store holds no host yet, and [] would read as the board");
+    fm.inbound("", { type: "tabOrder", order: [A, B], tabs: tabs(A, B), live: [A, B] });
+    assert.ok(orders(got).length >= 1, "the local strip lands");
+    assert.deepEqual(orders(got).at(-1).order, [A, B]);
+    const n = orders(got).length;
+    win.dispatchEvent(new Event("storage"));
+    assert.equal(orders(got).length, n + 1, "with the local strip in the store the re-emission is served");
+    assert.equal(orders(got).at(-1).reemit, true);
+  } finally {
+    for (const k of Object.keys(saved)) { const [had, v] = saved[k]; if (had) g[k] = v; else delete g[k]; }
+  }
+});
+
+test("the arrangement prune respects live: a strip omitting a live id (T258) keeps its slot instead of dropping it and re-adopting it at the end", () => {
+  withManager((fm, emitted, store) => {
+    fm.inbound("", { type: "tabOrder", order: [A, B, C], tabs: tabs(A, B, C), live: [A, B, C] });
+    assert.deepEqual(JSON.parse(store.get(VIEW_ORDER_KEY)!), [A, B, C], "the first report adopts every arrival");
+    fm.inbound("", { type: "tabOrder", order: [A, C], tabs: tabs(A, C), live: [A, B, C] });   // B's transcript briefly unreadable: omitted, still live
+    assert.deepEqual(JSON.parse(store.get(VIEW_ORDER_KEY)!), [A, B, C], "a live id is not pruned from the arrangement");
+    fm.inbound("", { type: "tabOrder", order: [A, B, C], tabs: tabs(A, B, C), live: [A, B, C] });
+    assert.deepEqual(orders(emitted).at(-1).order, [A, B, C], "re-listed, B is where it was, not at the end of the strip");
+    fm.inbound("", { type: "tabOrder", order: [A, C], tabs: tabs(A, C), live: [A, C] });   // B ended: omitted and no longer live
+    assert.deepEqual(JSON.parse(store.get(VIEW_ORDER_KEY)!), [A, C], "…while an id the host no longer lists nor affirms is pruned as before");
+  });
+});

--- a/ui/webview/federation.ts
+++ b/ui/webview/federation.ts
@@ -1302,10 +1302,17 @@ export class FederationManager {
   // tabOrder push mutates the store, in absorbHostReport below, because only a host's own report is
   // evidence about what exists.
   private emitMergedOrder(fresh = false, freshHost: string = LOCAL): void {
+    this.publishPending();   // before the hold, as emitMergedTimeline does: a pane waiting on its LOCAL strip is waiting on the remotes too
+    // HOLD a synthetic re-emission until the LOCAL kernel's strip is in the store — the hold emitMergedTimeline applies to
+    // its own payload. A re-emission is re-served from the stored slices, and on a fresh page those are EMPTY until the
+    // local strip is absorbed: the merged order would be [], which the chat reads as the board (the vanishing tab, the
+    // user 2026-09-12: another pane's view-order write reached a new chat column's manager in that window, the column
+    // reported its one member gone and the shell closed it). The local kernel pushes its strip on connect, so the hold is
+    // momentary, and the local arrival itself emits; a host's own FRESH push is never held — its ids are its word.
+    if (!fresh && !(LOCAL in this.perHostOrder)) return;
     const order = mergeHostOrder(this.perHostOrder, this.hostSeq, this.view());
     const tabs = this.hostSeq.flatMap((h) => this.perHostTabs[h] || []);
     const live = this.hostSeq.flatMap((h) => this.perHostLive[h] || []);   // T258: the union the pane's omission guard reads
-    this.publishPending();
     // `skeleton` rides EVERY merged strip, an array even when empty: the pane's rule is "array → replace,
     // absent → keep", and this frame is the union of every host's slice — the authority the pane must
     // replace from. Leaving the key off an empty union would tell the pane "no news" and let a set the
@@ -1350,6 +1357,7 @@ export class FederationManager {
     const reporting = new Set(Object.keys(this.perHostOrder));
     const live = new Set<string>();
     for (const h of reporting) for (const id of this.perHostOrder[h] || []) live.add(id);
+    for (const h of reporting) for (const id of this.perHostLive[h] || []) live.add(id);   // T258: an id the host affirms live but this strip omits stays placed — a transient read failure must not drop it from the arrangement to re-adopt it at the end
     const seed: string[] = [];
     for (const h of this.hostSeq) seed.push(...(this.perHostOrder[h] || []));
     const next = adoptArrivals(pruneViewOrder(healed, hostOf, reporting, live), seed);

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -86,6 +86,7 @@ import { followReader, keepPlaceAcrossShow, followTail, atBottomDist, followBoxB
 import { phParts } from "./composer-placeholder";   // the resting placeholder names the session (2026-09-09)
 import { badgeSpec } from "./session-badge";   // the statusline badge names the session (2026-09-09)
 import { retainLiveOmitted } from "./tab-order";
+import { localStrip, readCloseAckMs } from "./tab-order";
 import { userTurnShows } from "./user-turn-content";
 import { ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow, unitChangeRow, unitChanges, boxChanges, boxLabel, BOX_FROM_TAIL } from "./scroll-write";
 import { reloadScrollRecord, takeReloadScroll, type ReloadScroll } from "./reload-restore";
@@ -685,8 +686,9 @@ const tabMeta = new Map<string, { name: string; color: Color | null }>();
 const closingTabs = new Map<string, number>();
 // …with a backstop for the ack that never comes. A refused/failed end leaves no failure EVENT to key on:
 // the sole evidence a close didn't take is the kernel still listing the tab long after. Past this we say
-// so and let the tab back, rather than hiding a session that's really still open.
-const CLOSE_ACK_MS = 15_000;
+// so and let the tab back, rather than hiding a session that's really still open. Fifteen seconds, or the page's
+// localStorage knob for a lab (tab-order.ts readCloseAckMs: the served split test waits past it in seconds, not fifteen).
+const CLOSE_ACK_MS = readCloseAckMs((k) => { try { return localStorage.getItem(k); } catch { return null; } });
 // Optimistic label/color edits awaiting their kernel echo — holds a stale in-flight push from
 // reverting the strip (see tab-meta.ts; the sessionViews pending machinery's reasoning).
 const pendingTabMeta = new Map<string, PendingTabMeta>();
@@ -978,7 +980,10 @@ function assertPeekFor(id: string): void {
 // plan and the signature, so a tab moved away is simply gone from this strip.
 const COL = colFromSearch(location.search);
 let colSets: ColSets | null = null;
-let tabOrderSeen = false;   // the kernel's first strip has landed on this socket (applyTabOrder): the emptiness post and the stale-active fallback wait for it
+let tabOrderSeen = false;   // the kernel's first strip has landed on this socket (applyTabOrder, the local kernel's own frame only — tab-order.ts localStrip): the emptiness post and the stale-active fallback wait for it
+// The ids the last applied strip's `live` set affirms (the kernel's raw liveness, T258): a member of this column the strip
+// omits while live still names it is a transient read failure, never an emptiness (noteColumnEmptiness).
+let boardLive = new Set<string>();
 function readColSets(): ColSets | null {
   try {
     if (!window.parent || window.parent === window) return null;
@@ -5593,6 +5598,7 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   // older kernel sends no `live` and this is a no-op. One clientDiag row names any id it saves, so a kernel
   // that omits a live session is seen, never silently papered over.
   const liveSet = new Set<string>(Array.isArray(live) ? live.filter((x: any) => typeof x === "string") : []);
+  boardLive = liveSet;
   const omitted = new Set(order.filter((id) => kernelListed.has(id) && !inKernel.has(id) && !liveSet.has(id)));   // all of them first: no fallback onto one going in the same breath
   const keptLive = order.filter((id) => kernelListed.has(id) && !inKernel.has(id) && liveSet.has(id));
   if (keptLive.length && vscodeApi) vscodeApi.postMessage({ type: "clientDiag", surface: "chat", what: "live-omitted-kept", data: { ids: keptLive } });
@@ -5611,7 +5617,14 @@ function applyTabOrder(o: any, tabs?: any, report?: OrderReport, live?: any) {
   colSets = readColSets();   // membership is fresh for the restore below (the chat split)
   if (back && heldHere(back) && restoreIfShown(back)) { /* focus is back on the tab the pane named; nothing more to paint here. Only a tab this column holds (the chat split): another column's session is its owner's to restore, and no record of it is this column's to keep */ }
   else if (!activeId) showActive();   // the strip changed under an unfocused pane (it may have emptied), or the tab it names is listed but hidden: the body's line and the box's placeholder follow it (the review's low)
-  tabOrderSeen = true;   // the board has been heard once on this socket (the chat split's emptiness post and stale-active fallback wait for it; set after the restore above, so its render is the first that may post or fall back)
+  // The board has been heard on this socket ONLY when this frame is the local kernel's own strip (tab-order.ts localStrip):
+  // a synthetic re-emission is re-served from the manager's store, EMPTY on a fresh page (order []), and another host's
+  // fresh push says nothing about this kernel's sessions. The vanishing tab (the user 2026-09-12): a view-order storage
+  // event from another pane reached a new column between its bundle's registration and its first strip, the re-emitted []
+  // armed this flag, and the render below reported the column's one member gone (colEmpty) while the kernel listed it all
+  // along; the shell closed the column and the tab was in no column until the close backstop toasted. Set after the
+  // restore above, so its render is the first that may post or fall back.
+  if (localStrip(report)) tabOrderSeen = true;
   renderTabs();
 }
 // The tabOrder frame's `skeleton` list (2026-09-07): the tabs the kernel is withholding from this page after a
@@ -6409,7 +6422,16 @@ function renderTabs() {
   // right above, so an only-filtered active tab does reach here. The pane then goes UNFOCUSED naming the hidden tab
   // (T357: never re-pointed at another session); the check at fire time reads the same predicate visibleIds does
   // (stripShows), and the tab comes back below when the filter shows it again.
-  if (activeId && ids.includes(activeId) && !visibleIds.includes(activeId)) {
+  // THE ACTIVE TAB MOVED TO ANOTHER COLUMN (the chat split; the user 2026-09-12, whose source column sat on "This tab view
+  // shows no session" after the drag): a tab the user dragged away is not hidden by a view or a filter, so the pane does
+  // not go unfocused naming it (T357 keeps the box for a tab that comes back when the filter lifts; a moved tab lives in
+  // its own column now). The box falls to this column's first visible member — deferred and re-checked at fire time like
+  // the re-point below — and the persisted tab then names a member, so a reload lands here on one of its own.
+  if (activeId && ids.includes(activeId) && !heldHere(activeId) && visibleIds.length) {
+    const moved = activeId, first = visibleIds[0];
+    setTimeout(() => { if (activeId === moved && !heldHere(moved) && stripLists(first) && stripShows(first)) setActive(first); }, 0);
+  }
+  else if (activeId && ids.includes(activeId) && !visibleIds.includes(activeId)) {
     const hid = activeId;
     setTimeout(() => { if (activeId === hid && !stripShows(hid)) unfocusHiddenByView(hid); }, 0);
   }
@@ -7898,9 +7920,15 @@ function claimSession(id: string): void {
 // EMPTINESS (the chat split): a later column none of whose members the kernel's strip lists any more — ended, or
 // closed from a tab's cross (`ids` excludes closingTabs, so the user's own cross empties the column at once: the
 // acknowledgement) — tells the shell, which prunes the gone ids and closes a column left with none. Once per
-// emptiness: the flag resets when a member is listed again. Waits for the kernel's first strip (tabOrderSeen), so
+// emptiness: the flag resets when a member is listed again. Waits for the kernel's own first strip (tabOrderSeen), so
 // a page that has not heard the board yet says nothing; `ids` keeps host-down remote tabs and live-omitted ids
-// (T258), so neither a tunnel blip nor a transient read failure closes a column.
+// (T258), and a member the strip omits while the kernel's `live` set still affirms it counts as present (boardLive:
+// on a fresh column retainLiveOmitted has no order to keep it in), so neither a tunnel blip nor a transient read
+// failure closes a column. The message names the gone members this page's own ✕ removed (`crossed`): the shell holds
+// ONLY those back in the first column, whose "Couldn't close" backstop is for a cross the kernel refused; a member
+// gone for any other reason is simply the first column's again, shown the moment its strip repaints (the vanishing
+// tab, the user 2026-09-12: a hold over a session the kernel still listed hid it for the backstop and toasted a close
+// nobody asked for).
 let colEmptyPosted = false;
 function noteColumnEmptiness(ids: readonly string[]): void {
   if (!COL || !colSets || !tabOrderSeen) return;
@@ -7909,11 +7937,13 @@ function noteColumnEmptiness(ids: readonly string[]): void {
   // text and the draft died with the document (review find 2026-09-11)
   if (provisionalId || failedProvisionals.size) return;
   const mine = colSets[COL] || [];
-  const empty = mine.length > 0 && !mine.some((id) => ids.includes(id));
+  const present = (id: string) => ids.includes(id) || (boardLive.has(id) && !closingTabs.has(id));
+  const empty = mine.length > 0 && !mine.some(present);
   if (!empty) { colEmptyPosted = false; return; }
   if (colEmptyPosted) return;
   colEmptyPosted = true;
-  try { window.parent.postMessage({ romp: "colEmpty", gone: mine.slice() }, "*"); } catch (e) { /* no shell */ }
+  const crossed = mine.filter((id) => closingTabs.has(id));
+  try { window.parent.postMessage({ romp: "colEmpty", gone: mine.slice(), crossed }, "*"); } catch (e) { /* no shell */ }
 }
 // ORPHANED STATE (the chat split, review find 2026-09-11): a draft, citations, attachments or staged messages this page
 // holds for a session it does not show — a column blob written before the partition (a v1 column was a whole chat page,
@@ -17420,7 +17450,9 @@ listenForFrames(perfFrameHandler("chat", (m) => vscodeApi?.postMessage(m), (e: M
   if (m.romp === "adopt") { adoptSessionState(m.sid, m.state); return; }
   // the shell closed a later column whose members the kernel's strip no longer lists (colEmpty): they return to this,
   // the first column, but the kernel may still list one closed from its own cross for a push or two — held back here
-  // (closingTabs, retired by the kernel's next strip as any ✕ is) so no tab flashes into this strip on its way out
+  // (closingTabs, retired by the kernel's next strip as any ✕ is) so no tab flashes into this strip on its way out. The
+  // shell names ONLY the ids that page's own cross removed (colEmpty's `crossed`): the backstop behind this hold toasts
+  // "Couldn't close", which is right for a refused cross and wrong for anything else (the vanishing tab, 2026-09-12)
   if (m.romp === "closing") { if (Array.isArray(m.ids)) for (const id of m.ids) { if (typeof id === "string" && id) closingTabs.set(id, Date.now()); } renderTabs(); return; }
   // the shell's pane set, which panes are on screen by key: the cache openPath routes file links by (panesOn
   // above; the shell posts it on every toggle, on this iframe's load and on a phone's tab switch). Whole-set

--- a/ui/webview/tab-close-optimistic.test.ts
+++ b/ui/webview/tab-close-optimistic.test.ts
@@ -176,7 +176,9 @@ test("closeTabLocally drops the tab, THEN records the close — in that order", 
   // declared beside tabMeta, NOT down by dismissSession: renderTabs reads it and can run before the module
   // finishes evaluating, which would make a `const` down there a temporal-dead-zone throw.
   assert.match(RENDER, /const tabMeta = new Map[\s\S]{0,900}?const closingTabs = new Map<string, number>\(\);/);
-  assert.match(RENDER, /const CLOSE_ACK_MS = 15_000;/);
+  // fifteen seconds by default, read through tab-order.ts readCloseAckMs so a lab can shorten the backstop (the served split
+  // test waits past it in seconds); tab-order.test.ts pins the default and the knob
+  assert.match(RENDER, /const CLOSE_ACK_MS = readCloseAckMs\(\(k\) => \{ try \{ return localStorage\.getItem\(k\); \} catch \{ return null; \} \}\);/);
 });
 
 test("the strip skips a just-closed tab on BOTH passes (order AND the tabMeta placeholder pass)", () => {

--- a/ui/webview/tab-order.test.ts
+++ b/ui/webview/tab-order.test.ts
@@ -184,3 +184,23 @@ test("a session frame's id joins the order once: not when its tabOrder frame alr
   assert.equal(adoptArrival(order, "a", true), false, "an existing session's frame never pushes");
   assert.deepEqual(order, ["a", "b", "c", "d"]);
 });
+
+// ── the strip's provenance and the close backstop's knob (the vanishing tab, the user 2026-09-12) ──
+import { localStrip, readCloseAckMs, CLOSE_ACK_KEY, CLOSE_ACK_DEFAULT_MS } from "./tab-order";
+
+test("localStrip: the local kernel's own strip, or a frame with no provenance, is the board; a synthetic re-emission or another host's fresh push is not", () => {
+  assert.equal(localStrip(undefined), true, "a frame the kernel sent directly (VS Code, no federation manager)");
+  assert.equal(localStrip({ reemit: false, freshHost: undefined }), true, "the dispatch's shape for that frame");
+  assert.equal(localStrip({ freshHost: "" }), true, "the LOCAL kernel's push under federation (host key '')");
+  assert.equal(localStrip({ reemit: true }), false, "a re-emission from the store: on a fresh page an EMPTY order, never the board");
+  assert.equal(localStrip({ reemit: true, freshHost: "" }), false, "reemit wins over any host named");
+  assert.equal(localStrip({ freshHost: "TESTHOST" }), false, "another kernel's push says nothing about this kernel's sessions");
+});
+
+test("readCloseAckMs: fifteen seconds unless the page's localStorage holds a positive integer of ms under the knob", () => {
+  assert.equal(CLOSE_ACK_DEFAULT_MS, 15_000);
+  assert.equal(readCloseAckMs(() => null), 15_000);
+  assert.equal(readCloseAckMs((k) => (k === CLOSE_ACK_KEY ? "1500" : null)), 1500, "the lab's knob");
+  for (const junk of ["0", "-5", "1.5", "soon", ""]) assert.equal(readCloseAckMs(() => junk), 15_000, "junk keeps the default: " + JSON.stringify(junk));
+  assert.equal(readCloseAckMs(() => { throw new Error("no storage"); }), 15_000, "a storage that throws (a sandboxed frame) keeps the default");
+});

--- a/ui/webview/tab-order.ts
+++ b/ui/webview/tab-order.ts
@@ -85,3 +85,37 @@ export function adoptArrival(order: string[], id: string, existed: boolean): boo
   order.push(id);
   return true;
 }
+
+/** The provenance a merged tabOrder frame carries (render.ts OrderReport; federation.ts emitMergedOrder): `reemit` for a
+ *  synthetic re-emission served from the manager's stored slices, `freshHost` naming the one host whose own push drove a
+ *  fresh emission ("" is the local kernel, host-prefix.ts hostOf's key for an unprefixed id). A frame the kernel sent
+ *  directly (VS Code, a page without a federation manager) carries neither. */
+export type StripReport = { reemit?: boolean; freshHost?: string } | undefined;
+
+/**
+ * Is this frame the LOCAL kernel's own strip — the one event that means "the board has been heard on this socket"?
+ * A synthetic re-emission never is: it is re-served from whatever the manager has stored, which on a fresh page is
+ * NOTHING, so its order is [] (the vanishing tab, the user 2026-09-12: a view-order storage event from another pane
+ * landed between a new chat column's bundle registering its frame handler and its kernel's first strip; the column
+ * read that empty re-emission as the board, reported its one member gone, and was closed under it while the kernel
+ * listed the session all along). Nor is another host's fresh push: its ids are that kernel's word, not this one's.
+ * No provenance at all (a frame the kernel sent directly) is the kernel's own.
+ */
+export function localStrip(report: StripReport): boolean {
+  if (!report) return true;
+  if (report.reemit) return false;
+  return report.freshHost === undefined || report.freshHost === "";
+}
+
+/** The close backstop (render.ts CLOSE_ACK_MS): how long a ✕'d tab the kernel keeps listing stays hidden before the page
+ *  says the close did not take and lets it back. Fifteen seconds, or the page's localStorage under this key — a positive
+ *  integer of milliseconds — for a lab that drives the backstop in seconds rather than waiting out fifteen
+ *  (tests/test_chat_split_served.py), the shape scroll-write.ts readScrollDiagCap gives its own knob. */
+export const CLOSE_ACK_KEY = "romp:closeAckMs";
+export const CLOSE_ACK_DEFAULT_MS = 15_000;
+export function readCloseAckMs(getItem: (key: string) => string | null): number {
+  let raw: string | null = null;
+  try { raw = getItem(CLOSE_ACK_KEY); } catch { raw = null; }
+  const n = raw == null ? NaN : Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : CLOSE_ACK_DEFAULT_MS;
+}

--- a/ui/webview/view-order-wiring.test.ts
+++ b/ui/webview/view-order-wiring.test.ts
@@ -56,7 +56,9 @@ test("a pane answers another pane's drag by re-emitting, never by rewriting the 
     "inbound tabOrder is the one store-mutating moment");
   // (the signature carries provenance since T233 — fresh/host-driven vs synthetic re-emit — but every
   // caller still re-emits from the store, never rewrites it)
-  assert.match(FED, /private emitMergedOrder\(fresh = false, freshHost: string = LOCAL\): void \{\s*\n\s*const order = mergeHostOrder/,
+  // (…and holds a synthetic re-emission until the local kernel's strip is in the store — the vanishing tab, 2026-09-12;
+  // federation-order-hold.test.ts — still without a write: the shell's pending list, the hold, then the merge)
+  assert.match(FED, /private emitMergedOrder\(fresh = false, freshHost: string = LOCAL\): void \{\s*\n\s*this\.publishPending\(\);[^\n]*\n(?:\s*\/\/[^\n]*\n)*\s*if \(!fresh && !\(LOCAL in this\.perHostOrder\)\) return;\s*\n\s*const order = mergeHostOrder/,
     "every other caller — both drag paths included — re-emits without touching the stored order");
   assert.doesNotMatch(FED, /private gcView|this\.gcView/,
     "the old gc-on-emit hook is gone, folded into absorbHostReport");


### PR DESCRIPTION
## What this fixes

A tab dragged into a new chat column could vanish: the column opened, reported itself empty at once, and the shell closed it and held the tab back in the first column as "closing"; fifteen seconds later the close-refused toast returned the tab. Reported by the user on 2026-09-12; also the cause of the chat-split served test aborting on a slow continuous-integration run.

## Cause

The new column's federation manager subscribes to the arrangement's storage event before it has absorbed the local kernel's first strip. Another pane's arrangement write in that window made it re-emit the merged order from an empty store, a synthetic frame flagged `reemit`. The page's tab-order arm set its "board seen" flag on that frame, so the emptiness check saw no member and posted `colEmpty` for a session the kernel never stopped listing.

## Fix

- The "board seen" flag is armed only by the local kernel's own strip, never by a synthetic re-emission or another host's push.
- The emptiness check counts a member present when the frame's `live` set affirms it, so a first strip that omits a live id cannot close a fresh column either; the message names the members this page's own cross removed, and the shell holds back only those.
- The federation layer holds synthetic re-emissions until the local strip has arrived, the same hold the merged timeline already applies; its prune respects `live`.
- Moving the active tab now re-points the source column to its first visible member instead of the empty view line.
- A lab seam lets the served test shorten the close backstop; the default is unchanged.

## Tests

Red first, then green: a node test drives the tab-order arm with a re-emitted empty frame ahead of the local strip; a federation test pins the hold; the chat-split served test gains steps that hold column two's kernel frames at the wire while the shell rewrites the arrangement, asserting the column stays open and lists its session, the tab is in exactly one column, and no toast follows past the backstop. Whole node suite, the Python suites and both browser globs green.

Tier: fix
