### PR TITLE
The tab hover popover colours its model and effort values as the footer chips do, through the footer's own helper (T372)

### DIFF
--- a/tests/test_tab_tip_tones_browser.py
+++ b/tests/test_tab_tip_tones_browser.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""The session tab's hover popover colours its Model and Effort values with the colour the chat footer's chips wear
+for that session (T372; the user 2026-09-12, who learned the association on the footer and wanted it reproduced in
+the popover). One helper, metaColor, serves both, so the two cannot drift.
+
+This lab drives the real /chat page of a hermetic kernel with twenty synthetic sessions (the notes-api demo world,
+host TESTHOST, placeholder sids), hovers the active session's tab, and reads the popover's Model and Effort value
+spans against the footer's model and effort chips (getComputedStyle color), in the dark theme and in the light
+theme (where the kernel's dark-tuned RGB is re-encoded on both surfaces alike). Asserted: the two colours are equal
+per theme and differ from the page's plain foreground; the labels and the other values stay plain; the light theme
+differs from the dark. TIP_TONES_DIST=<dir> serves another tree's UI bundle (the red run's before);
+TIP_TONES_SHOTS=<prefix> writes <prefix>-dark.png and <prefix>-light.png of the popover over its tab. Skips LOUDLY
+without the extension deps or a Playwright browser, and never otherwise (CI turns a skip in a served module into a
+failure). SYNTHETIC fixtures only."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
+
+# the notes-api demo world: twenty sessions, enough to wrap the strip onto several rows at a narrow width
+NAMES = ["web", "api", "deploy", "tests", "docs", "auth", "search", "cache", "ingest", "export", "billing", "mailer",
+         "worker", "scheduler", "metrics", "backup", "importer", "notifier", "gateway", "indexer"]
+SIDS = {n: "%s-1111-2222-3333-444444444444" % (chr(ord("a") + i) * 8) for i, n in enumerate(NAMES)}
+PALETTE = [("#9cd2ff", "#0c1a2e"), ("#1EA1EB", "#ffffff"), ("#54B204", "#ffffff"), ("#c98cff", "#1a0c2e"),
+           ("#e5a50a", "#1a1200"), ("#4EC9B0", "#00201a")]
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1200, height: 760 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab[data-id]", { timeout: 30000 });
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, cfg.count, { timeout: 30000 });
+// the footer's model and effort chips carry their colours once the status landed
+await page.waitForFunction(() => { const m = document.querySelector('#spinner-meta .meta-btn[data-kind="model"] .meta-label'); return !!m && getComputedStyle(m).color !== ""; }, null, { timeout: 30000 });
+await page.waitForTimeout(500);
+const measure = (label) => page.evaluate((label) => {
+  const cs = (e) => e ? getComputedStyle(e).color : null;
+  const chip = (k) => document.querySelector('#spinner-meta .meta-btn[data-kind="' + k + '"] .meta-label');
+  const tip = document.querySelector(".tab-tip");
+  const rows = tip ? Array.from(tip.querySelectorAll(".tab-tip-row")).map((r) => ({ k: r.children[0].textContent, v: r.children[1] ? r.children[1].textContent : "", vColor: cs(r.children[1]), kColor: cs(r.children[0]) })) : [];
+  const fg = getComputedStyle(document.body).color;
+  return { label, tipShown: !!tip && getComputedStyle(tip).display !== "none", rows, footer: { model: cs(chip("model")), effort: cs(chip("effort")), mode: cs(chip("mode")) }, fg, activeName: (document.querySelector("#tabs .tab.active .tab-label") || {}).textContent || "" };
+}, label);
+const out = { themes: {} };
+const chipColor = () => page.evaluate(() => { const m = document.querySelector('#spinner-meta .meta-btn[data-kind="model"] .meta-label'); return m ? getComputedStyle(m).color : null; });
+for (const theme of ["dark", "light"]) {
+  const before = await chipColor();
+  await page.evaluate((t) => { document.body.classList.toggle("theme-light", t === "light"); }, theme);
+  // the footer re-tints its chips on its one-second ticker (the light theme re-encodes the RGB): wait for that, so the
+  // comparison reads two settled surfaces, not the popover's fresh paint against a chip still wearing the other theme
+  if (theme === "light") await page.waitForFunction((prev) => { const m = document.querySelector('#spinner-meta .meta-btn[data-kind="model"] .meta-label'); return !!m && getComputedStyle(m).color !== prev; }, before, { timeout: 5000 });
+  await page.waitForTimeout(150);
+  const tab = await page.$("#tabs .tab.active[data-id]");
+  const box = await tab.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.waitForFunction(() => { const t = document.querySelector(".tab-tip"); return !!t && getComputedStyle(t).display !== "none"; }, null, { timeout: 5000 });
+  await page.waitForTimeout(150);
+  out.themes[theme] = await measure(theme);
+  if (cfg.shots) await page.screenshot({ path: cfg.shots + "-" + theme + ".png" });   // the whole page: the popover over its tab AND the footer chips it matches
+  await page.mouse.move(5, 700); await page.waitForTimeout(100);
+}
+await page.evaluate(() => document.body.classList.remove("theme-light"));
+fs.writeFileSync(cfg.out, JSON.stringify(out));
+await browser.close();
+console.log("RESULT: ok");
+"""
+
+
+class ServedTabTipTones(unittest.TestCase):
+    maxDiff = None
+    result = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="tip-tones-")
+        before = os.environ.get("TIP_TONES_DIST", "")
+        if before:
+            src = before
+        else:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+            src = os.path.join(EXT, "dist")
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(src, dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        # a lab root writes its own session-hosts off (the conftest rule): hosts are on by default, and a kernel-side boot
+        # attach for twenty alive sessions would otherwise spawn twenty real session hosts on a developer's machine
+        Path(state, "session-hosts").write_text("off\n")
+        os.makedirs(cwd, exist_ok=True)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        for i, name in enumerate(NAMES):
+            sid = SIDS[name]
+            bg, fg = PALETTE[i % len(PALETTE)]
+            Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, bg, fg))
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(
+                {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                 "model": "claude-opus-5", "liveModel": "Opus 5"}))
+            recs = [{"type": "user", "timestamp": iso(t0 + i), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": sid,
+                     "message": {"role": "user", "content": "what does the %s session do in notes-api?" % name}},
+                    {"type": "assistant", "timestamp": iso(t0 + i + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": sid,
+                     "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                                 "content": [{"type": "text", "text": "It keeps the %s side of the notes-api tidy." % name}]}}]
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.port, cls.token = _free_port(), "testtok-tiptones"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    @classmethod
+    def _run(cls):
+        if cls.result is not None:
+            if isinstance(cls.result, BaseException):
+                raise cls.result
+            return cls.result
+        try:
+            cls.result = cls._drive()
+        except BaseException as e:
+            cls.result = e
+            raise
+        return cls.result
+
+    @classmethod
+    def _drive(cls):
+        cfg = os.path.join(cls.lab, "cfg.json")
+        out = os.path.join(cls.lab, "result.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (cls.port, cls.token), "count": len(NAMES), "out": out,
+                       "shots": os.environ.get("TIP_TONES_SHOTS", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(cls.klog).read()[-1500:])
+        if not os.path.exists(out):
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(Path(out).read_text())
+
+    def _theme(self, theme):
+        r = self._run()
+        m = r["themes"][theme]
+        self.assertTrue(m["tipShown"], "the popover is up over the hovered tab: " + json.dumps(m)[:400])
+        return m
+
+    def _assert_tones(self, m):
+        table = "\n  " + json.dumps(m, indent=None)[:1600]
+        rows = {r["k"]: r for r in m["rows"]}
+        self.assertIn("Model", rows); self.assertIn("Effort", rows)
+        self.assertEqual(rows["Model"]["vColor"], m["footer"]["model"], "the popover's Model value wears the footer chip's colour" + table)
+        self.assertEqual(rows["Effort"]["vColor"], m["footer"]["effort"], "the popover's Effort value wears the footer chip's colour" + table)
+        self.assertNotEqual(rows["Model"]["vColor"], m["fg"], "a colour, not the plain foreground" + table)
+        self.assertNotEqual(rows["Effort"]["vColor"], m["fg"], table)
+        for k in ("Mode", "Backend"):
+            if k in rows:
+                self.assertEqual(rows[k]["vColor"], m["fg"], k + " stays plain: the footer tints neither" + table)
+        for r in m["rows"]:
+            self.assertNotEqual(r["kColor"], r["vColor"] if r["k"] in ("Model", "Effort") else None, "the label stays dim: " + r["k"] + table)
+
+    def test_dark_theme_the_popover_values_wear_the_footer_chips_colours(self):
+        self._assert_tones(self._theme("dark"))
+
+    def test_light_theme_the_popover_values_wear_the_footer_chips_colours_re_encoded_alike(self):
+        m = self._assert_tones(self._theme("light")) or self._theme("light")
+        d = self._theme("dark")
+        rows_l = {r["k"]: r for r in m["rows"]}; rows_d = {r["k"]: r for r in d["rows"]}
+        self.assertNotEqual(rows_l["Model"]["vColor"], rows_d["Model"]["vColor"], "the light theme re-encodes the dark-tuned RGB")
+        self.assertNotEqual(m["footer"]["model"], d["footer"]["model"], "…on the footer as well")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5771,13 +5771,17 @@ function showTabTip(tab: HTMLElement, s: Session): void {
   // branch row wears the ⎇ glyph in its label slot for the same consistency. Branch is the top-level
   // session field, resident even when the head system event is windowed out of the wire tail (the user
   // 2026-06-30), and the worktree row shows where the work actually lands when that differs.
-  const rows: Array<[string, string]> = [];
+  // a row's optional third member is the VALUE's colour (T372, the user 2026-09-12): a value that wears a colour on
+  // the chat footer's chips wears the SAME colour here, from the one helper the footer calls (metaColor), so the
+  // association learned on the footer is reproduced and the two cannot drift. Model and effort carry the colormap
+  // rank; the permission mode is untinted on the footer too, and the backend carries no tone, so they stay plain.
+  const rows: Array<[string, string, string?]> = [];
   if (s.cwd) rows.push(["📁", s.cwd]);
   if (s.gitBranch) rows.push(["⎇", s.gitBranch]);
   if (s.workTree) rows.push(["Worktree", s.workTree.dir + (s.workTree.branch ? "  ⎇ " + s.workTree.branch : "")]);
   if (s.status.mode) rows.push(["Mode", prettyMode(s.status.mode)]);
-  if (s.status.model) rows.push(["Model", s.status.model]);
-  if (s.status.effort) rows.push(["Effort", s.status.effort]);
+  if (s.status.model) rows.push(["Model", s.status.model, metaColor("model", s.status)]);
+  if (s.status.effort) rows.push(["Effort", s.status.effort, metaColor("effort", s.status)]);
   // Backend is a plain labelled FIELD now, under the others (the user 2026-07-08 — no longer a coloured
   // "SDK backend" badge at the top of the tooltip; it reads as one of the session's config fields).
   if (be) rows.push(["Backend", backendLabel(be)]);
@@ -5811,10 +5815,11 @@ function showTabTip(tab: HTMLElement, s: Session): void {
           + `${s.status.authLive === "key" ? "the API key" : "the login"} — this session bills that`
         : s.status.auth === "key" ? "API key"
           : (s.status.authAcct ? `Login (${s.status.authAcct})` : "Login")]);
-  for (const [k, v] of rows) {
+  for (const [k, v, color] of rows) {
     const r = el("div", "tab-tip-row");
     const ke = el("span", "tab-tip-k"); ke.textContent = k;
     const ve = el("span", "tab-tip-v"); ve.textContent = v;
+    if (color) ve.style.color = color;   // the footer chip's colour, the label stays dim (T372)
     r.appendChild(ke); r.appendChild(ve); tip.appendChild(r);
   }
   // context BATTERY (the same widget as the bottom bar), not a text %

--- a/ui/webview/tab-backend-tooltip.test.ts
+++ b/ui/webview/tab-backend-tooltip.test.ts
@@ -92,6 +92,8 @@ test("the tooltip still shows the full path + mode/model/effort — path and bra
   assert.match(RENDER, /rows\.push\(\["Worktree", s\.workTree\.dir/);
   assert.doesNotMatch(RENDER, /tab-tip-path/, "the naked top path line is gone — the grid row replaced it");
   assert.match(RENDER, /rows\.push\(\["Mode", prettyMode\(s\.status\.mode\)\]\)/);
-  assert.match(RENDER, /rows\.push\(\["Model", s\.status\.model\]\)/);
-  assert.match(RENDER, /rows\.push\(\["Effort", s\.status\.effort\]\)/);
+  // T372 (the user 2026-09-12): the model and effort VALUES wear the footer chip's colour, from the one helper the
+  // footer calls (metaColor), as the row's third member; the labels stay dim
+  assert.match(RENDER, /rows\.push\(\["Model", s\.status\.model, metaColor\("model", s\.status\)\]\)/);
+  assert.match(RENDER, /rows\.push\(\["Effort", s\.status\.effort, metaColor\("effort", s\.status\)\]\)/);
 });

--- a/ui/webview/tab-tip-tones.test.ts
+++ b/ui/webview/tab-tip-tones.test.ts
@@ -1,0 +1,131 @@
+// The session tab's hover popover colours its Model and Effort VALUES with the colour the chat footer's chips
+// wear for that session (T372, the user 2026-09-12: the association learned on the footer is reproduced there).
+// One helper, metaColor, serves both surfaces, so the two cannot drift: this lifts showTabTip, metaButton and the
+// footer's label tinting from render.ts, executes them against a small DOM stand-in with the REAL tone helpers
+// (ctx-color.ts), and compares the popover's value spans with the footer chip's computed colour, in the dark theme
+// and in the light theme (where readableRgb re-encodes the kernel's dark-tuned RGB). Labels stay dim. The lifted
+// slices add no window listener (the harness slices elsewhere count them).
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+import { pickTone, readableRgb } from "./ctx-color";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const require = createRequire(__filename);
+const esbuild = require("esbuild");
+
+// a lifted function: from its declaration to the closing brace at column 0
+function lift(name: string): string {
+  const at = RENDER.indexOf("function " + name + "(");
+  assert.ok(at >= 0, name + " declared");
+  const end = RENDER.indexOf("\n}\n", at);
+  return RENDER.slice(at, end + 3);
+}
+
+class El {
+  tagName: string; className = ""; textContent = ""; innerHTML = ""; children: El[] = []; style: Record<string, string> = {};
+  dataset: Record<string, string> = {}; attrs = new Map<string, string>(); listeners: string[] = [];
+  constructor(tag: string) { this.tagName = tag; }
+  get classList() { const self = this; return { toggle: (c: string, on?: boolean) => { const has = self.className.split(" ").includes(c); const want = on === undefined ? !has : on; const parts = self.className.split(" ").filter(Boolean).filter((x) => x !== c); if (want) parts.push(c); self.className = parts.join(" "); }, contains: (c: string) => self.className.split(" ").includes(c), add: (c: string) => self.classList.toggle(c, true), remove: (c: string) => self.classList.toggle(c, false) }; }
+  appendChild(c: El): El { this.children.push(c); return c; }
+  append(...cs: El[]): void { for (const c of cs) this.children.push(c); }
+  replaceChildren(...cs: El[]): void { this.children = [...cs]; }
+  setAttribute(k: string, v: string): void { this.attrs.set(k, v); }
+  getAttribute(k: string): string | null { return this.attrs.get(k) ?? null; }
+  addEventListener(k: string): void { this.listeners.push(k); }
+  querySelector(sel: string): El | null { const cls = sel.replace(/^\./, ""); const walk = (n: El): El | null => { for (const c of n.children) { if (c.className.split(" ").includes(cls)) return c; const d = walk(c); if (d) return d; } return null; }; return walk(this); }
+  querySelectorAll(sel: string): El[] { const cls = sel.replace(/^\./, ""); const out: El[] = []; const walk = (n: El) => { for (const c of n.children) { if (c.className.split(" ").includes(cls)) out.push(c); walk(c); } }; walk(this); return out; }
+  get firstElementChild(): El | null { return this.children[0] ?? null; }
+}
+const body = new El("body");   // the theme is the body's class (ctx-color's isLightTheme / nonClassic read it live)
+const bodyClasses = { clear: () => { body.className = ""; }, add: (c: string) => body.classList.add(c) };
+(globalThis as any).document = { createElement: (t: string) => new El(t), body, getElementById: () => null, addEventListener: () => {}, activeElement: null };
+(globalThis as any).window = { addEventListener: () => {}, innerWidth: 1200, innerHeight: 800 };
+
+// the slices: the popover builder, the footer's button and its label tinting, and the colour helper they share
+const PRELUDE = `
+const el = (tag, cls) => { const e = document.createElement(tag); if (cls) e.className = cls; return e; };
+const prettyMode = (m) => m; const backendLabel = (b) => b; const authFellTo = () => ""; const ctxBar = () => el("div"); const setCtxBar = () => {};
+const ledgers = new Map(); let draggedId = null; let tabTipEl = null; const sessions = new Map();
+const setTip = () => {}; const toggleMetaMenu = () => {}; const modeIconSvg = () => ""; const riskyMode = () => false;
+const prettyFast = (f) => f; const metaCurrent = (kind, st) => kind === "model" ? st.model : st.effort; const fastAvailable = () => false;
+const metaDots = () => el("span", "meta-dots"); const isMetaPending = () => false;
+`;
+const SRC = PRELUDE + lift("metaColor") + lift("showTabTip") + lift("metaButton") + lift("syncMetaControls")
+  + "\nreturn { showTabTip, metaButton, metaColor, syncMetaControls };";
+const js = esbuild.transformSync(SRC, { loader: "ts", format: "cjs", target: "es2020" }).code;
+const mod = new Function("pickTone", "readableRgb", "document", "window", js)(pickTone, readableRgb, (globalThis as any).document, (globalThis as any).window);
+
+const status = { state: "ready", sinceEpoch: null, mode: "auto", model: "claude-opus-5", effort: "high", backend: "sdk",
+  modelColor: [156, 210, 255], effortColor: [229, 165, 10], modelTone: [120, 200, 240], effortTone: [240, 180, 40] };
+const session = { id: "11111111-2222-3333-4444-555555555555", name: "web", cwd: "/tmp/notes-api", status } as any;
+
+const popoverValues = () => {
+  mod.showTabTip(new El("div"), session);
+  const tip = body.children[body.children.length - 1];
+  const rows = tip.children.filter((r) => r.className === "tab-tip-row");
+  const byLabel: Record<string, El> = {};
+  for (const r of rows) byLabel[r.children[0].textContent] = r.children[1];
+  return byLabel;
+};
+const footerColours = () => {
+  const meta = new El("div");
+  mod.syncMetaControls(meta, status, null);
+  const out: Record<string, string> = {};
+  for (const b of meta.querySelectorAll(".meta-btn")) out[b.dataset.kind] = b.querySelector(".meta-label")!.style.color || "";
+  return out;
+};
+
+for (const theme of ["dark", "light"] as const) {
+  test(`${theme} theme: the popover's Model and Effort values wear exactly the footer chip's colour; the other values and every label stay plain`, () => {
+    bodyClasses.clear();
+    if (theme === "light") bodyClasses.add("theme-light");
+    const v = popoverValues();
+    const f = footerColours();
+    assert.match(f.model, /^rgb\(\d+,\d+,\d+\)$/, "the footer tints the model: " + JSON.stringify(f));
+    assert.match(f.effort, /^rgb\(\d+,\d+,\d+\)$/, "…and the effort");
+    assert.equal(v["Model"].style.color, f.model, "the popover's Model value is the footer's model colour");
+    assert.equal(v["Effort"].style.color, f.effort, "the popover's Effort value is the footer's effort colour");
+    assert.equal(v["Model"].style.color, mod.metaColor("model", status), "…through the one helper");
+    assert.equal(v["Effort"].style.color, mod.metaColor("effort", status));
+    assert.equal(v["Mode"].style.color ?? "", "", "the mode is untinted on the footer, so it stays plain here");
+    assert.equal(v["Backend"].style.color ?? "", "", "the backend carries no tone");
+    assert.equal(v["📁"].style.color ?? "", "", "the directory is plain");
+    const tip = body.children[body.children.length - 1];
+    for (const r of tip.children) if (r.className === "tab-tip-row") assert.equal(r.children[0].style.color ?? "", "", "labels stay dim: " + r.children[0].textContent);
+    assert.equal(v["Model"].className, "tab-tip-v", "the value span keeps its class: the colour is inline, like the footer's");
+  });
+}
+
+test("the light theme re-encodes the kernel's dark-tuned RGB on BOTH surfaces alike, so the two differ from the dark theme together", () => {
+  bodyClasses.clear();
+  const dark = { pop: popoverValues()["Model"].style.color, foot: footerColours().model };
+  bodyClasses.add("theme-light");
+  const light = { pop: popoverValues()["Model"].style.color, foot: footerColours().model };
+  bodyClasses.clear();
+  assert.notEqual(dark.pop, light.pop, "the light theme re-encodes: " + JSON.stringify({ dark, light }));
+  assert.equal(dark.pop, dark.foot); assert.equal(light.pop, light.foot);
+});
+
+test("a status without colours (an older kernel) leaves the values plain, as the footer leaves its chips", () => {
+  bodyClasses.clear();
+  const bare = { ...status, modelColor: undefined, effortColor: undefined, modelTone: undefined, effortTone: undefined };
+  mod.showTabTip(new El("div"), { ...session, status: bare });
+  const tip = body.children[body.children.length - 1];
+  for (const r of tip.children) if (r.className === "tab-tip-row") assert.equal(r.children[1].style.color ?? "", "", r.children[0].textContent);
+  const meta = new El("div"); mod.syncMetaControls(meta, bare, null);
+  for (const b of meta.querySelectorAll(".meta-btn")) assert.equal(b.querySelector(".meta-label")!.style.color ?? "", "");
+});
+
+test("at source: the rows carry the colour as a third member, the value span takes it inline, and metaColor is the footer's helper", () => {
+  const stt = RENDER.slice(RENDER.indexOf("function showTabTip("), RENDER.indexOf("\n}\n", RENDER.indexOf("function showTabTip(")));
+  assert.match(stt, /const rows: Array<\[string, string, string\?\]> = \[\];/);
+  assert.match(stt, /rows\.push\(\["Model", s\.status\.model, metaColor\("model", s\.status\)\]\);/);
+  assert.match(stt, /rows\.push\(\["Effort", s\.status\.effort, metaColor\("effort", s\.status\)\]\);/);
+  assert.match(stt, /if \(color\) ve\.style\.color = color;/);
+  assert.doesNotMatch(stt, /addEventListener\("(resize|keydown|mousedown)"/, "no window listener inside the lifted slice");
+  const sync = RENDER.slice(RENDER.indexOf("function syncMetaControls("), RENDER.indexOf("\n}\n", RENDER.indexOf("function syncMetaControls(")));
+  assert.match(sync, /label\.style\.color = showDots \? "" : metaColor\(kind, st\);/, "the footer tints through the same helper");
+});


### PR DESCRIPTION
The session tab's hover popover now colours its Model and Effort values with the colour the chat footer's chips wear for that session (the user, 2026-09-12: the association learned on the sessions and the footer, reproduced in the popover).

What changes:
- `showTabTip` (ui/webview/render.ts) gives a row an optional third member, the value's colour, and colours the Model and Effort values through `metaColor`, the very helper the footer's `syncMetaControls` uses to tint its chips, so the two surfaces cannot drift. Labels stay dim. The permission mode is untinted on the footer too and the backend carries no tone, so those values stay plain; both themes follow, since `metaColor` already re-encodes the kernel's dark-tuned RGB for the light theme through `readableRgb`.
- No stylesheet change, no new listener, no new element.

Tests, red first:
- `ui/webview/tab-tip-tones.test.ts`: lifts `metaColor`, `showTabTip`, `metaButton` and `syncMetaControls` out of render.ts and executes them against a DOM stand-in with the REAL tone helpers; for a synthetic status with model and effort colours the popover's value spans carry exactly the footer chip's computed colour, in the dark theme and in the light theme (the light re-encodes both alike, so they differ from the dark together); the other values and every label stay plain; a status without colours leaves both surfaces plain; the source shape is pinned (the third member, the inline colour, the shared helper). Red before the change: the values wore no colour.
- `tests/test_tab_tip_tones_browser.py`: a hermetic kernel with twenty synthetic sessions; the driver hovers the active tab and reads the popover's Model and Effort values against the footer's chips (computed colours) in both themes, waiting for the footer's one-second re-tint after the theme toggle. Against the build before the change (`TIP_TONES_DIST`) both cases fail (the values wore the plain foreground); with the change both pass. `TIP_TONES_SHOTS` wrote `romp_ui-t372-popover-dark.png` and `romp_ui-t372-popover-light.png` (the popover over its tab, the footer chips beneath).
- `tab-backend-tooltip.test.ts` re-pointed to the coloured row shape.

Executed: the popover and tone pins (tab-tip-tones, tab-backend-tooltip, tab-drag-live, tab-strip-skip, tab-strip-skip-exec, skeleton-tabs-wiring, tab-snapshot-pane, model-colors, ctx-color, tab-ctx-gauge) 92 passed, 0 failed; typecheck clean; full extension suite 4586 tests, 4581 passed, 0 failed, 5 skipped (node test, concurrency 2, capped); Python served-test pins 14 passed; the lab under the CI stance 2 passed.

Tier: fix
