### PR TITLE
The preview card carries no open control: the link itself opens the file (T369)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1742,8 +1742,9 @@ names, after a short dwell; it closes when the pointer leaves (with a grace to
 cross into the card), on Escape, on a scroll, on a click elsewhere and at every
 tab-strip rebuild. The card is the comment popover's card (its surface and its
 fractions of the pane) and is never draggable or resizable; the romp loader shows
-first and the text replaces it the moment it lands. "open" opens the full file
-viewer, scrolled to the section.
+first and the text replaces it the moment it lands. The card carries no open
+control: clicking the link itself opens the full file viewer, scrolled to the
+section the link names.
 
 **What a hover may fetch.** A hover is a gesture the user did not choose, so the
 popover is stricter than the viewer (whose own rule, that any path the agent
@@ -1755,8 +1756,8 @@ and a link whose own name claims another kind than its target is refused; a hard
 link is another name for the same bytes and no path check can see its other
 names, so a `notes.md` hard-linked onto a `.env` passes the name rules and is
 caught only by the content belt below). A
-link absent from the map gets the text-only card (the path as words plus "open")
-and **no request**: a path outside the session's folder and the user's home, one
+link absent from the map gets the text-only card (the path as words, the link
+still opening the file) and **no request**: a path outside the session's folder and the user's home, one
 the kernel could not verify, a secrets-shaped name (the `.env` family, `.netrc`,
 `.npmrc`, `.pypirc`, any name carrying `credential`, `token`, `secret` or
 `password`, `id_*`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, key stores, and any file

--- a/tests/test_file_preview_browser.py
+++ b/tests/test_file_preview_browser.py
@@ -173,9 +173,9 @@ await page.focus(sel("docs/guide.md", null)); await page.waitForTimeout(150); ou
 await page.waitForFunction(() => { const p = document.getElementById("file-preview-pop"); return !!p && getComputedStyle(p).display !== "none" && !!p.querySelector(".fp-body"); }, null, { timeout: 5000 });
 out.focusCard = await card();
 await page.keyboard.press("Escape"); await page.waitForTimeout(100); out.escapeHidden = !(await shown());
-// "open" on the section card lands the viewer scrolled to the heading
+// the LINK opens the viewer scrolled to the heading it names (the card carries no open control, T369); the card was up
 await hoverCard("docs/guide.md", "fold-rules");
-await page.click(CARD + " .fp-open");
+await page.click(sel("docs/guide.md", "fold-rules"));
 await page.waitForSelector("#romp-fileview", { timeout: 10000 });
 await page.waitForFunction(() => !!document.querySelector('#romp-fileview [id="md-fold-rules"]'), null, { timeout: 10000 });   // the viewer's heading ids wear md- (file-view.ts)
 await page.waitForTimeout(400);
@@ -336,7 +336,7 @@ class ServedFilePreview(unittest.TestCase):
                 self.assertGreaterEqual(h["ms"], 300, "%s/%s: the card came up only after the dwell: %r ms" % (theme, name, h["ms"]))
                 self.assertIsNotNone(h["card"], "%s/%s: the card is up" % (theme, name))
                 self.assertEqual(h["card"]["theme"], theme)
-                self.assertTrue(h["card"]["hasOpen"], "%s/%s: the way to the full file" % (theme, name))
+                self.assertFalse(h["card"]["hasOpen"], "%s/%s: a file card carries no open control; the link opens the file (T369)" % (theme, name))
                 self.assertGreaterEqual(h["card"]["box"]["w"], 300); self.assertGreaterEqual(h["card"]["box"]["h"], 120)
                 self.assertFalse(t[name + "Hidden"], "%s/%s: leaving closes the card after the grace" % (theme, name))
             head, sec, miss = t["head"]["card"], t["section"]["card"], t["missing"]["card"]
@@ -393,7 +393,7 @@ class ServedFilePreview(unittest.TestCase):
                 json.dump(latency, f)
         self.assertFalse(r["focusEarly"]); self.assertIsNotNone(r["focusCard"]); self.assertEqual(r["focusCard"]["title"], "guide.md")
         self.assertTrue(r["escapeHidden"], "Escape closes the card")
-        # "open" lands the viewer on the section
+        # the link lands the viewer on the section it names, and the card closes
         # the link attributes: the kind on the previewable links, the why on the refused ones (the next report reads it off the DOM)
         by = {(l["path"], l["frag"]): l for l in r["links"]}
         bare_link, leaky_link = by[("docs/notes/rollup-notes.md", None)], by[("docs/notes/leaky-notes.md", None)]

--- a/ui/webview/file-preview.test.ts
+++ b/ui/webview/file-preview.test.ts
@@ -36,24 +36,25 @@ test("the routes: the slice with its anchor and session, the bytes route for med
 
 test("contentFor fills the one shape per kind; a missing anchor falls back to the head with a one-line note", () => {
   const md = contentFor("docs/g.md", "", "markdown", "s", { title: "g.md", text: "# G\nbody", found: true, allowed: true });
-  assert.deepEqual(md, { kind: "markdown", title: "g.md", subtitle: undefined, body: { markdown: "# G\nbody" }, note: undefined, open: { label: "open", path: "docs/g.md", frag: undefined } });
+  assert.deepEqual(md, { kind: "markdown", title: "g.md", subtitle: undefined, body: { markdown: "# G\nbody" }, note: undefined });
   const sec = contentFor("docs/g.md", "fold", "markdown", "s", { title: "g.md", text: "## Fold\nabout folds", found: true, allowed: true });
-  assert.equal(sec.kind, "section"); assert.equal(sec.subtitle, "#fold"); assert.equal(sec.open!.frag, "fold");
+  assert.equal(sec.kind, "section"); assert.equal(sec.subtitle, "#fold");
+  assert.equal(sec.open, undefined, "no open control on a file card: the link itself opens the file at the section (T369)");
   const miss = contentFor("docs/g.md", "nope", "markdown", "s", { title: "g.md", text: "# G\nhead", found: false, allowed: true });
   assert.equal(miss.kind, "markdown"); assert.equal(miss.subtitle, undefined);
-  assert.equal(miss.note, 'no section "nope" in this file; its head instead'); assert.equal(miss.open!.frag, "nope", "open still tries the anchor the link named");
+  assert.equal(miss.note, 'no section "nope" in this file; its head instead'); assert.equal(miss.open, undefined);
   const cut = contentFor("docs/g.md", "", "markdown", "s", { title: "g.md", text: "…", found: true, truncated: true, allowed: true });
-  assert.equal(cut.note, "the head of the file; open for the rest");
+  assert.equal(cut.note, "the head of the file; the link opens the rest");
   const code = contentFor("src/app.py", "", "code", "s", { title: "app.py", text: "print(1)", allowed: true });
   assert.deepEqual(code.body, { text: "print(1)", lang: "python" }); assert.equal(code.kind, "code");
   const img = contentFor("plots/a.png", "", "image", "s", null);
-  assert.deepEqual(img, { kind: "image", title: "a.png", body: { url: "/file?path=plots%2Fa.png&sid=s" }, open: { label: "open", path: "plots/a.png", frag: undefined } });
+  assert.deepEqual(img, { kind: "image", title: "a.png", body: { url: "/file?path=plots%2Fa.png&sid=s" } });
   const pdf = contentFor("r.pdf", "", "pdf", null, null);
   assert.equal(pdf.kind, "pdf"); assert.equal(pdf.subtitle, "first page"); assert.equal(pdf.body.url, "/file?path=r.pdf");
   const refused = contentFor("x.md", "", "markdown", "s", { allowed: false, why: "a secrets-shaped name" });
   assert.equal(refused.kind, "text"); assert.equal(refused.note, "a secrets-shaped name"); assert.equal(refused.body.text, "x.md");
   const t = textOnlyContent("/etc/hosts", "", "outside");
-  assert.deepEqual(t, { kind: "text", title: "hosts", subtitle: undefined, body: { text: "/etc/hosts" }, note: "outside", open: { label: "open", path: "/etc/hosts", frag: undefined } });
+  assert.deepEqual(t, { kind: "text", title: "hosts", subtitle: undefined, body: { text: "/etc/hosts" }, note: "outside" });
 });
 
 // a fake clock: timers fire in order when advanced

--- a/ui/webview/file-preview.ts
+++ b/ui/webview/file-preview.ts
@@ -23,7 +23,7 @@ export interface PreviewContent {
   subtitle?: string;                   // "#slug" for a section, the source path for a term
   body: { markdown?: string; html?: string; text?: string; url?: string; lang?: string };
   note?: string;                       // one line the card says above the body (a missing anchor, why a path is text-only)
-  open?: { label: string; path: string; frag?: string };   // the affordance to the full view
+  open?: { label: string; path: string; frag?: string };   // a control to a fuller view; the FILE cards carry none (T369: the link itself opens the file, the user 2026-09-12), the glossary's term card keeps its own
 }
 
 /** `path#slug` → the path and the anchor; a `#` inside a file name is not an anchor unless what follows reads as a
@@ -147,26 +147,26 @@ export function stripRemoteLoads(root: ParentNode, origin: string, base: string)
 /** The text-only card: the path as words and the way to the full view, nothing fetched. */
 export function textOnlyContent(path: string, anchor: string, why?: string): PreviewContent {
   return { kind: "text", title: baseName(path), subtitle: anchor ? "#" + anchor : undefined,
-           body: { text: path }, note: why, open: { label: "open", path, frag: anchor || undefined } };
+           body: { text: path }, note: why };
 }
 
 /** The card's content for a kind the kernel allowed, from the slice route's answer (text kinds) or from the path
  *  alone (an image or a PDF, whose bytes ride the plain route). */
 export function contentFor(path: string, anchor: string, kind: string, sid: string | null, answer: SliceAnswer | null): PreviewContent {
-  const open = { label: "open", path, frag: anchor || undefined };
+  // no open control on a file card (T369): clicking the link already opens the file at the section it names
   const title = (answer && answer.title) || baseName(path);
-  if (kind === "image") return { kind: "image", title, body: { url: fileUrl(path, sid) }, open };
-  if (kind === "pdf") return { kind: "pdf", title, subtitle: "first page", body: { url: fileUrl(path, sid) }, open };
+  if (kind === "image") return { kind: "image", title, body: { url: fileUrl(path, sid) } };
+  if (kind === "pdf") return { kind: "pdf", title, subtitle: "first page", body: { url: fileUrl(path, sid) } };
   if (!answer || answer.allowed === false) return textOnlyContent(path, anchor, answer && answer.why ? answer.why : undefined);
   const text = answer.text || "";
   if (kind === "code") {
-    return { kind: "code", title, body: { text, lang: langOf(path) }, note: answer.truncated ? "the head of the file; open for the rest" : undefined, open };
+    return { kind: "code", title, body: { text, lang: langOf(path) }, note: answer.truncated ? "the head of the file; the link opens the rest" : undefined };
   }
   const found = answer.found !== false;
   const note = anchor && !found ? 'no section "' + anchor + '" in this file; its head instead'
-             : answer.truncated ? (anchor ? "the head of the section; open for the rest" : "the head of the file; open for the rest") : undefined;
+             : answer.truncated ? (anchor ? "the head of the section; the link opens the rest" : "the head of the file; the link opens the rest") : undefined;
   return { kind: anchor && found ? "section" : "markdown", title, subtitle: anchor && found ? "#" + anchor : undefined,
-           body: { markdown: text }, note, open };
+           body: { markdown: text }, note };
 }
 
 /** The hover's timing, with the timers injected so the tests run it without a clock: `enter(link)` starts the dwell


### PR DESCRIPTION
The hover preview card had an open button; clicking the link already opens the file, so the button was one element too many (the user, 2026-09-12).

- Every file card (rendered markdown, section, code, image, pdf and the text-only card) drops the control. The header stays the file name plus the section. Click-to-open on the link itself is untouched, and a link with a section still lands the viewer on that heading.
- The glossary's term card keeps its own Open glossary control: a different card under lab_manager's contract.
- The truncation notes say the link opens the rest. The reference says the card carries no open control.

Red first: the served lab's per-theme card probe asserts no open control (red on main, the card carried it) and its section road now clicks the link to land the viewer on the heading; the executed card tests assert the builders' shapes carry no open field (red on main).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
