### PR TITLE
The converge pass primes a quiescent leaf whose whole entry is resident, so the launch fold's drop writes its document from the boot's read (T362 follow-up)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1035,7 +1035,11 @@ is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under
 `quiescent`: its heal would read the file whole every cycle and the write
-would find no entry (the boot's cold refold or the next settle converges it);
+would find no entry; the one exception is a leaf whose whole entry from the
+boot's own read is still resident, which the pass heals and primes in memory
+so that the launch fold's quiescence drop writes the document from that read
+and pops the entry (`viaDrop`), once, after which the leaf is refused like any
+other;
 a path the pass refused or whose write produced nothing is skipped until its
 file changes under the reader (`skipped` counts each such hold once, per file
 state, and the check reads the reader's own entry rather than stat the file

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -767,7 +767,7 @@ _CKPT_STATS = {"restored": 0, "writes": 0, "swept": 0, "skippedFolds": 0, "fallb
                "oversizeFolds": {}, "coldFolds": {}, "coldWrites": {},
                "converge": {"passes": 0, "writes": 0, "bytes": 0, "heals": 0, "healBytes": 0, "primed": 0, "deferred": 0,
                             "failed": 0, "unhealed": 0, "docReadBytes": 0, "quiescent": 0, "skipped": 0,
-                            "dropWrites": 0, "dropDeferred": 0}}   # T360, T361, T362
+                            "dropWrites": 0, "dropDeferred": 0, "viaDrop": 0}}   # T360, T361, T362
 _CKPT_DOC_FOLDS = {}              # path -> {fold name: "state" | "over" | "cold" | "bare"}: the document on disk as last written or
 #                                   loaded in this process, so the converge pass can tell a document lacking a state without a read
 _COLD = object()                  # a restored cursor with no state (its fold was oversize): fold_records inits it and steps the tail
@@ -1193,6 +1193,15 @@ def _path_needs_write(key, ent, at_drop=False):
         if _cursor_recordable(cache.get(key), gen, base, total) and shapes.get(name) not in ("state", "over"):
             return True
     return False
+
+
+def checkpoint_path_needs_write(path):
+    """The one rule asked from outside for the reader's current entry of `path` (the converge pass, after priming a quiescent
+    leaf: did the launch fold's drop already write everything?): False with no entry."""
+    key = str(path)
+    with _JSONL_CACHE_LOCK:
+        ent = _JSONL_CACHE.get(key)
+    return ent is not None and _path_needs_write(key, ent)
 
 
 def checkpoint_cycle_begin(cap):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9931,7 +9931,9 @@ def _converge_checkpoints(now):
     whole read, its bytes counted), and over a whole-resident entry every leaf fold is primed (a step over records in hand,
     no read), so one write carries all five. For another file a tail-only cursor is dropped so the write leaves it out and
     its next run reads the small file whole once. A document already carrying every fold that ran is never a candidate,
-    so an idle session's document is written once and then left alone. Returns the documents written."""
+    so an idle session's document is written once and then left alone. A quiescent leaf (T361) is refused unless the boot's
+    own whole read is still resident, in which case the prime's launch fold writes its document at the quiescence drop from
+    that read (`viaDrop`), no read of the pass's own. Returns the documents written."""
     if CKPT_CONVERGE_MS <= 0 or not em.checkpoint_has_work():
         _CKPT_JUST_WRITTEN.clear()
         return 0                                           # off (ROMP_CKPT_CONVERGE_MS=0), or nothing dirty and nothing cold: a quiet
@@ -9946,10 +9948,16 @@ def _converge_checkpoints(now):
         if i and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or not em.checkpoint_cycle_room(0)):
             em.converge_stat("deferred", len(cands) - i)   # gated on candidates PROCESSED, not documents written: a first
             break                                          #  candidate that writes nothing must not lift the budget (review)
-        if p in leaves and em.file_quiescent(p):           # T361 (the live loop): a leaf unchanged past the reader's quiescence
+        quiescent = p in leaves and em.file_quiescent(p)
+        if quiescent and not em.entry_whole_resident(p):   # T361 (the live loop): a leaf unchanged past the reader's quiescence
             em.converge_stat("quiescent"); _converge_skip(p)   #  window loses its whole entry right after a fold steps it, so a heal
-            continue                                       #  or a prime here would read it whole every cycle and the write would
-        #                                                    find no entry; the boot's cold refold or the next settle converges it
+            continue                                       #  or a prime here would READ it whole every cycle and the write would
+        #                                                    find no entry. With the boot's own whole read still resident (T362
+        #                                                    follow-up) the heal and the prime step records in hand, no read, and
+        #                                                    the prime's last fold (the agent-launch state, the one that drops
+        #                                                    quiescent leaves) writes the document from that read at its drop and
+        #                                                    pops the entry: the idle leaf converges once, and with its entry gone
+        #                                                    it is refused here on any later cycle, never read again by the pass
         cold = [k for k, r in em.cold_fold_reasons(p).items() if r == "cold"]
         if p in leaves:
             before = _read_bytes_of(p)
@@ -9962,6 +9970,9 @@ def _converge_checkpoints(now):
                 em.converge_stat("primed")
         else:
             unhealed = em.drop_cold_cursors(p)
+        if quiescent and not em.checkpoint_path_needs_write(p):   # the launch fold's drop wrote the document from the boot's read
+            em.converge_stat("viaDrop")                    #  (converge.dropWrites, charged to this cycle's take; the entry popped, or
+            continue                                       #  kept after a restore at the witness): no write of the pass's own
         if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
             em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
         try:                                               # the write reads the document on disk for its carry: that read is the

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1131,6 +1131,55 @@ class KernelFolds(Base):
         km._session_meta(self.leaf)                                       # a fold re-reads it: the entry's stamp moved
         self.assertFalse(km._converge_skipped(self.leaf), "the pass may look again")
 
+    def test_converge_primes_a_quiescent_leaf_whose_entry_is_whole_resident_and_the_drop_writes_it(self):
+        """T362 follow-up (the first live boot after the merge: dropWrites 0, the pairing still missing from 37 of 60 documents).
+        The only fold that drops quiescent leaves is the agent-launch fold, which the builders call for sessions with agents and
+        the pass never reached for a quiescent leaf (the T361 refusal), so after the boot's whole read nothing ran a drop over an
+        idle leaf and its document stayed stale with the read resident. The refusal is narrowed to a leaf whose entry is NOT
+        whole-resident: with the boot's read in hand the heal and the prime step records in memory, the prime's last fold is
+        the launch fold, and its drop writes the document from that read and pops the entry; the pass counts it."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing", "bgAll": "bare"}, quiescent=True)
+        size = os.path.getsize(self.leaf)
+        km._bg_scan_all_cached(self.leaf)                             # the boot: the background view restores cold over the tail
+        jd._bg_scan(self.leaf)                                        # the judges' first pass: the whole read, resident
+        self.assertTrue(em.entry_whole_resident(self.leaf)); self.assertEqual(em.cold_fold_reasons(self.leaf), {"bgAll": "cold"})
+        read0 = em.read_bytes_report().get(self.leaf, 0); dropped0 = em.record_cache_stats()["dropped"]
+        km._begin_checkpoint_cycle()
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0, "the pass wrote nothing itself")
+        self.assertGreater(em._CKPT_CYCLE["spent"], 0, "the drop's write charged the cycle's take")
+        d = self.doc(self.leaf)
+        self.assertEqual(sorted(d["folds"]), ["agentLaunches", "bgAll", "bgJudge", "bgRunning", "sessionMeta"])
+        self.assertTrue(all("state" in f for f in d["folds"].values()), "the healed view and the primed folds, all complete")
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "and the entry left memory")
+        self.assertEqual(em.checkpoint_converge_candidates(), [], "nothing left to converge")
+        for k in (1, 2):                                              # the guard (the T361 loop was a pass acting every cycle):
+            km._begin_checkpoint_cycle()                              #  two more cycles do nothing for this leaf
+            self.assertEqual(km._converge_checkpoints(TS0 + 600 + k), 0)
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["passes"], cv["heals"], cv["viaDrop"], cv["dropWrites"], cv["quiescent"], cv["failed"], cv["writes"]),
+                         (1, 1, 1, 1, 0, 0, 0), "three cycles: one heal, one drop write, then nothing: %s" % cv)
+        self.assertEqual(em.record_cache_stats()["dropped"], dropped0 + 1, "one pop")
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0) - read0, 256, "no read of records: the write's 64-byte guard check alone")
+        self.assertIn("viaDrop", km._PERF_STATS.snapshot()["checkpoints"]["converge"], "the story is on /perf")
+        self.fresh_process()
+        jd._bg_scan(self.leaf)
+        self.assertLess(em.read_bytes_report().get(self.leaf, 0), size / 2, "the next boot reads the tail")
+
+    def test_converge_over_a_resident_quiescent_leaf_whose_launch_fold_restores_writes_once(self):
+        """The other live shape: the document carries the launch state and lacks the pairing. The prime's launch fold restores
+        at the witness, the drop writes without popping (nothing stepped), and the pass, asking the rule, writes nothing more."""
+        self._converge_world({"bgJudge": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf)
+        km._begin_checkpoint_cycle()
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0)
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["viaDrop"], cv["dropWrites"], cv["writes"], cv["quiescent"]), (1, 1, 0, 0), "%s" % cv)
+        d = self.doc(self.leaf); self.assertIn("state", d["folds"]["bgJudge"])
+        self.assertTrue(em.entry_whole_resident(self.leaf), "nothing stepped: the entry stays")
+        km._begin_checkpoint_cycle(); self.assertEqual(km._converge_checkpoints(TS0 + 601), 0)
+        self.assertEqual((em.checkpoint_stats()["converge"]["passes"], self.doc(self.leaf)["seq"]), (1, d["seq"]), "one pass, one write")
+
     def test_converge_skips_a_path_whose_write_failed_until_its_file_changes(self):
         """T361 (b): a failed write must not repeat every cycle."""
         self._converge_world({"bgJudge": "missing"})


### PR DESCRIPTION
Fix tier. Follow-up to the checkpoint-at-the-quiescence-drop change: the first live boot after it landed showed the drop write never ran (converge.dropWrites 0, the record cache dropped 0, the judges' pairing still missing from 37 of 60 leaf documents; first cycle 40.5 s from 62.9 s, 2.13 GB of leaf reads). The only fold that drops quiescent leaves is the agent-launch fold, which the builders call for sessions with agents, and the pass refused every quiescent leaf, so nothing ran a quiescent-drop fold over an idle leaf after the boot's whole read: the read stayed resident and the document stale.

**The change:** the pass refuses a quiescent leaf only when its entry is NOT whole-resident. With the boot's own read in hand, the heal and the prime step records in memory (no read); the prime's last fold is the launch fold, whose drop writes the document from that read and pops the entry; the pass asks the one rule (`checkpoint_path_needs_write`) and, with nothing left, counts `converge.viaDrop` instead of writing itself. Guard against the earlier loop: whole-resident only, and with its entry gone the leaf is refused like any other on later cycles.

**Tests** (`tests/test_fold_checkpoints.py`, red first on main): three cycles over one idle leaf give one heal, one drop write, one pop, then nothing, the write charged to the cycle's budget and the counters on /perf; the other live shape (the launch state present, the pairing missing) restores at the witness, the drop writes without popping, and the pass writes nothing more. Full Python suite green locally (12,474 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)