### PR TITLE
The three mail kinds take three hues from the aurora colormap, green, teal-blue and purple (T371)

### DIFF
--- a/tests/test_postal_cards_served.py
+++ b/tests/test_postal_cards_served.py
@@ -2,8 +2,8 @@
 """T302 (the user 2026-09-10): the postal cards in the chat pane, rendered by the real /chat page of a hermetic
 kernel over a synthetic chat with web (the viewed session), api and tests (its peers) — every state at once.
 
-Asserted on the page: the interaction KIND is coloured text (Delegation / Coordination / Question, three positions
-sampled evenly along one line in the accent's hue, T337), never a chip; the DELIVERY STATE is one icon per state at the
+Asserted on the page: the interaction KIND is coloured text (Delegation / Coordination / Question, three hues from the
+aurora colormap's stops, green, teal-blue and purple, T371), never a chip; the DELIVERY STATE is one icon per state at the
 head's right edge with a worded title (delivered, read, parked, bounced, recalled, and sent for a message handed to the
 relay; sent / delivered / read as the circled-check ladder, the read check cut out in the page colour, T337), from what the kernel
 files (the send-time stamp, and the postal ledger's exec / relayed / bounced / recall rows joined by message id);
@@ -407,9 +407,9 @@ class ServedPostalCards(unittest.TestCase):
             else:
                 self.assertIn(c["kind"], ("Delegation", "Coordination", "Question"), c)
             self.assertFalse(c["chip"], "no chip: %r" % c)
-        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(124, 181, 227)", "delegation: the line's middle position (T320, re-sampled T337)")
-        self.assertEqual(card("Heads-up")["kindColor"], "rgb(86, 150, 200)", "coordination: the line's start (T320, re-sampled T337)")
-        self.assertEqual(card("Which cap")["kindColor"], "rgb(162, 212, 254)", "question: the line's end (T337)")
+        self.assertEqual(card("Take the retry-loop")["kindColor"], "rgb(144, 136, 240)", "delegation: the aurora ramp's last stop, purple (T371)")
+        self.assertEqual(card("Heads-up")["kindColor"], "rgb(84, 178, 4)", "coordination: the ramp's first stop, green (T371)")
+        self.assertEqual(card("Which cap")["kindColor"], "rgb(66, 169, 176)", "question: the ramp's fourth stop, teal-blue (T371)")
         # T337 (the review): the provisional dress fades by its colours, not by an element opacity that dimmed the kind
         # word too, so every kind word reads at 4.5:1 on the ground it sits on, the provisional wash included, in both themes
         for m, name in ((wide, "dark"), (light, "light")):
@@ -562,19 +562,31 @@ class ServedPostalCards(unittest.TestCase):
             self.assertGreaterEqual(light["contrastPage"][k] or 0, 4.5, "%s reads on the bare light page too" % k)
         self.assertEqual(light["contrastOn"]["coordinate"], "box", "the first coordination word is on a boxed incoming card: the measurement that matters")
         # T320 (the user 2026-09-10): the kind word wears the prose weight, not bold, in both themes, and its three
-        # colours are ONE sequential ramp ranked coordination < delegation < question: monotone in luminance against
-        # the page (brighter with rank on the dark page, darker with rank on the light one), as the browser computes them
+        # the three kinds are three HUES from the aurora colormap (T371: the user found T337's one-hue ramp's steps alike),
+        # so as the browser computes them every pair sits a real hue distance apart in both themes, and the cream page
+        # wears the same three hues deepened (postal-kind-ramp.test.ts holds the stops against bin/romp_colormap.py)
         for m in (wide, light, r["light340"]):
             self.assertEqual({k: m["kindWeight"][k] for k in ("delegate", "coordinate", "question")},
                              {"delegate": "400", "coordinate": "400", "question": "400"}, "prose weight: %r" % m["kindWeight"])
-        def _lum(css):
+        def _hue(css):
             r, g, b = [int(x) for x in re.findall(r"\d+", css)[:3]]
-            ch = lambda c: (c / 255) / 12.92 if (c / 255) <= 0.03928 else (((c / 255) + 0.055) / 1.055) ** 2.4
-            return 0.2126 * ch(r) + 0.7152 * ch(g) + 0.0722 * ch(b)
-        d = [_lum(wide["kinds"][k]) for k in ("coordinate", "delegate", "question")]
-        self.assertTrue(d[0] < d[1] < d[2], "dark page: the ramp brightens with rank: %r" % wide["kinds"])
-        lt = [_lum(light["kinds"][k]) for k in ("coordinate", "delegate", "question")]
-        self.assertTrue(lt[0] > lt[1] > lt[2], "light page: the ramp deepens with rank: %r" % light["kinds"])
+            ch = lambda c: (c / 255) / 12.92 if (c / 255) <= 0.04045 else (((c / 255) + 0.055) / 1.055) ** 2.4
+            rl, gl, bl = ch(r), ch(g), ch(b)
+            l_ = (0.4122214708 * rl + 0.5363325363 * gl + 0.0514459929 * bl) ** (1 / 3)
+            m_ = (0.2119034982 * rl + 0.6806995451 * gl + 0.1073969566 * bl) ** (1 / 3)
+            s_ = (0.0883024619 * rl + 0.2817188376 * gl + 0.6299787005 * bl) ** (1 / 3)
+            oa = 1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_
+            ob = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_
+            import math
+            return (math.degrees(math.atan2(ob, oa)) + 360) % 360
+        for theme, m in (("dark", wide), ("light", light)):
+            hues = {k: _hue(m["kinds"][k]) for k in ("coordinate", "delegate", "question")}
+            for x, y in (("coordinate", "delegate"), ("coordinate", "question"), ("delegate", "question")):
+                gap = abs(((hues[x] - hues[y] + 540) % 360) - 180)
+                self.assertGreaterEqual(gap, 50, "%s page: %s and %s sit %.0f degrees apart, two tints of one hue: %r" % (theme, x, y, gap, m["kinds"]))
+        self.assertEqual({k: light["kinds"][k] for k in ("coordinate", "delegate", "question")},
+                         {"coordinate": "rgb(56, 111, 24)", "delegate": "rgb(95, 87, 171)", "question": "rgb(13, 109, 115)"},
+                         "the cream page: the same three hues deepened (T371)")
         # the phone-width light pass reads too (the fourth screenshot the user looks at)
         for k in ("delegate", "coordinate", "question"):
             self.assertGreaterEqual(r["light340"]["contrast"][k] or 0, 4.5, "%s reads on the light page at 340 px" % k)

--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -17,30 +17,27 @@ function fn(name: string): string {
 }
 const CARD = fn("renderPostalService");
 
-test("the kind is coloured text in the meta slot, never a chip, at prose weight, on one ranked ramp", () => {
+test("the kind is coloured text in the meta slot, never a chip, at prose weight, in three colormap hues", () => {
   assert.match(RENDER, /import \{ kindLabel, deliveryOf, deliveryTitle[^}]*\} from "\.\/postal-state";/);
   assert.match(CARD, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
   assert.match(CARD, /meta = el\("span", "postal-kind postal-kind-" \+ intent\.cls\); meta\.textContent = kind;/);
   assert.doesNotMatch(CARD, /postal-service-intent|notice-chip/, "no chip");
   // T320 (the user 2026-09-10): the word is NOT bold (the prose weight), and the three colours are TOKENS on ONE
-  // sequential ramp in the accent's hue, ranked coordination < delegation < question by how much each asks of the
-  // reader, each with a light-theme re-ink (the parity test holds every one at 4.5:1 on its page)
+  // three hues from the aurora colormap (T371: coordinate green, question teal-blue, delegate purple, the two the user
+  // confused farthest apart), each with a light-theme re-ink (the parity test holds every one at 4.5:1 on its grounds)
   assert.match(CSS, /\.postal-kind \{ font-weight: 400; \}/, "prose weight, not bold");
   assert.doesNotMatch(CSS, /\.postal-kind \{ font-weight: (600|700|bold)/);
-  // (T337: the three are re-sampled evenly along the line; postal-kind-ramp.test.ts holds the positions, these the values)
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7cb5e3\); \}/);
-  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #5696c8\); \}/);
-  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #a2d4fe\); \}/);
-  assert.match(CSS, /\n  --postal-coordinate: #5696c8;\s+--postal-delegate: #7cb5e3;\s+--postal-question: #a2d4fe;/, "the dark ramp, low to high");
+  // (T371: three hues from the aurora colormap, the two the user confused farthest apart; postal-kind-ramp.test.ts
+  // holds the stops, the hue distances and the light re-ink, these the values)
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #9088f0\); \}/);
+  assert.match(CSS, /\.postal-kind-coordinate \{ color: var\(--postal-coordinate, #54b204\); \}/);
+  assert.match(CSS, /\.postal-kind-question \{ color: var\(--postal-question, #42a9b0\); \}/);
+  assert.match(CSS, /\n  --postal-coordinate: #54b204;\s+--postal-delegate: #9088f0;\s+--postal-question: #42a9b0;/, "the dark tokens: the ramp's first, last and fourth stops");
   const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}\n", CSS.indexOf("body.theme-light {")));
-  assert.match(light, /--postal-coordinate: #974a32;\s+--postal-delegate: #752f18;\s+--postal-question: #551400;/, "the light ramp, low to high, deepening");
-  // the ramp IS a ramp: in each theme the three steps are monotone in luminance in rank order (brighter with rank on
-  // the dark page, darker with rank on the light one), so the eye reads one scale, not three tags
-  const lumOf = (hex: string) => { const c = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255).map((v) => v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)); return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]; };
-  const dark = ["#5696c8", "#7cb5e3", "#a2d4fe"].map(lumOf), lightRamp = ["#974a32", "#752f18", "#551400"].map(lumOf);
-  assert.ok(dark[0] < dark[1] && dark[1] < dark[2], "dark: coordination < delegation < question in luminance");
-  assert.ok(lightRamp[0] > lightRamp[1] && lightRamp[1] > lightRamp[2], "light: coordination > delegation > question in luminance");
-  assert.match(CSS, /coordination lowest \(an FYI\), delegation\s+next \(work handed over\), question highest \(an answer owed\)/, "the ranking sits beside the tokens");
+  assert.match(light, /--postal-coordinate: #386f18;\s+--postal-delegate: #5f57ab;\s+--postal-question: #0d6d73;/, "the light tokens: the same hues, deepened");
+  // three hues, not one ramp: the eye tells the kinds apart by hue, so no luminance order is pinned any more (T337's
+  // monotone ladder is retired with the line); the mapping sentence sits beside the tokens
+  assert.match(CSS, /coordinate = the ramp's first stop \(green\), question = its fourth stop \(teal-blue\), delegate = its\s+last stop \(purple\)/, "the mapping sits beside the tokens");
   // under the narrow container query the head WRAPS: the gist takes its own full-width line, word-wise, and the kind
   // word keeps the first line whole and inside the card (T313; the 4ch floor that squeezed the gist into a letter
   // column beside the ends is gone)

--- a/ui/webview/postal-intent.test.ts
+++ b/ui/webview/postal-intent.test.ts
@@ -40,5 +40,5 @@ test("the intent reads as coloured TEXT in the postal head's meta slot — no ch
   assert.match(RENDER, /const kind = kindLabel\(intent \? intent\.cls : null\);/);
   assert.doesNotMatch(RENDER, /meta\.push\("delivered"\)/);
   assert.doesNotMatch(CSS, /\.postal-service-intent/);
-  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #7cb5e3\); \}/);   // the ramp's middle step (T320; re-sampled T337)
+  assert.match(CSS, /\.postal-kind-delegate \{ color: var\(--postal-delegate, #9088f0\); \}/);   // the aurora ramp's last stop (T371; postal-kind-ramp.test.ts holds the stops)
 });

--- a/ui/webview/postal-kind-ramp.test.ts
+++ b/ui/webview/postal-kind-ramp.test.ts
@@ -1,16 +1,17 @@
-// T337 (the user 2026-09-10, who found the three kind colours of T320 too alike): each theme's three tokens sit at
-// positions 0, 1/2 and 1 of ONE straight line in OKLCH, hue pinned to the accent's. The line's two ends are two floors:
-// the deep end is the deepest step that still reads at 4.5:1 on the PROVISIONAL card's wash (theme-parity.test.ts holds
-// that contrast, and the box's and the page's), the far end stops short of the prose ink so a lone Question still reads
-// as a colour and not as body text (the distance is pinned here). The POSITIONS are the pin, not the hexes: a re-ink that
-// keeps the line and the even spacing passes; one that bunches two steps (T320's light steps were .05 then .09 apart),
-// drifts off the hue or runs into the ink fails. The comment beside the tokens in styles.css names the same two endpoints.
+// T371 (the user 2026-09-12, who found coordinate and delegate alike: T337's three steps on ONE accent-hue line read as
+// three tints of one blue): each theme's three kind tokens are three HUES sampled from the default progress colormap
+// (aurora, bin/romp_colormap.py), the two the user confused farthest apart on the ramp. The pin reads the ramp FROM the
+// colormap file, never a copied literal: the dark tokens ARE stops of it (coordinate the first, delegate the last, question
+// a middle one), the light tokens hold the same three hues deepened for the cream page, and in both themes every pair
+// of tokens sits a real hue distance apart and every token keeps its distance from the prose ink. The mapping is written
+// once, in the :root comment beside the tokens, and this test pins that sentence; a swap of the mapping moves both.
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const COLORMAP = fs.readFileSync(path.resolve(process.cwd(), "..", "bin", "romp_colormap.py"), "utf8");
 function block(opener: string): string {
   const at = CSS.indexOf(opener);
   assert.ok(at >= 0, opener + " present");
@@ -22,7 +23,16 @@ function token(blockText: string, name: string): string {
   assert.ok(m, name + " declared as a hex, bare or as a var() fallback");
   return m![1].toLowerCase();
 }
-// sRGB hex → OKLab (Björn Ottosson's matrices); OKLCH from it
+// the aurora ramp, dark to light, read from the colormap module's own table
+function auroraStops(): string[] {
+  const m = /"aurora":\s*\[([\s\S]*?)\]/.exec(COLORMAP);
+  assert.ok(m, "bin/romp_colormap.py declares the aurora ramp");
+  const stops = Array.from(m![1].matchAll(/\((\d+),\s*(\d+),\s*(\d+)\)/g)).map((t) =>
+    "#" + [t[1], t[2], t[3]].map((v) => parseInt(v, 10).toString(16).padStart(2, "0")).join(""));
+  assert.ok(stops.length >= 5, "the ramp has its stops (" + stops.length + ")");
+  return stops;
+}
+// sRGB hex -> OKLab (Bjorn Ottosson's matrices); OKLCH from it
 function oklab(hex: string): { L: number; a: number; b: number } {
   const lin = (c: number) => (c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
   const [r, g, b] = [1, 3, 5].map((i) => lin(parseInt(hex.slice(i, i + 2), 16) / 255));
@@ -40,47 +50,43 @@ function oklch(hex: string): { L: number; C: number; h: number } {
 const hueGap = (h: number, ref: number) => Math.abs(((h - ref + 540) % 360) - 180);
 const dist = (x: { L: number; a: number; b: number }, y: { L: number; a: number; b: number }) => Math.hypot(x.L - y.L, x.a - y.a, x.b - y.b);
 
-// the two lines: (L, C) at position 0 and at position 1, the hue held, both ends inside sRGB on that hue; the comment
-// beside the tokens says the same
-const MAPS = {
-  dark: { block: ":root {", hue: 244, from: { L: 0.65, C: 0.1 }, to: { L: 0.85, C: 0.078 } },
-  light: { block: "body.theme-light {", hue: 38, from: { L: 0.5, C: 0.11 }, to: { L: 0.3, C: 0.098 } },   // C .098 is the hue's gamut edge at L .30
-};
-const STEPS = ["--postal-coordinate", "--postal-delegate", "--postal-question"];
+const STEPS = ["--postal-coordinate", "--postal-question", "--postal-delegate"];   // in ramp order: first, middle, last stop
+const MIN_HUE_GAP = 50;      // degrees of OKLCH hue between any two kinds: two tints of one hue sit at 0, T337's three at 0
+const INK_GAP = 0.075;       // OKLab distance from --fg, T337's floor: a lone kind word is a colour, never body text
 
-for (const [theme, map] of Object.entries(MAPS)) {
-  test(theme + ": the three kind tokens sit at 0, 1/2 and 1 of the accent-hue line, evenly spaced, the far end clear of the ink", () => {
-    const b = block(map.block);
-    const steps = STEPS.map((n) => oklch(token(b, n)));
-    steps.forEach((s, i) => {
-      const t = i / 2;
-      const wantL = map.from.L + (map.to.L - map.from.L) * t, wantC = map.from.C + (map.to.C - map.from.C) * t;
-      assert.ok(Math.abs(s.L - wantL) <= 0.012, `${theme} ${STEPS[i]}: L ${s.L.toFixed(3)} is off the line (${wantL})`);
-      assert.ok(Math.abs(s.C - wantC) <= 0.012, `${theme} ${STEPS[i]}: C ${s.C.toFixed(3)} is off the line (${wantC})`);
-      assert.ok(hueGap(s.h, map.hue) <= 4, `${theme} ${STEPS[i]}: hue ${s.h.toFixed(1)} is not the accent's ${map.hue} (an endpoint clipped by the gamut drifts)`);
-    });
-    // even: the two lightness steps match
-    const d1 = steps[1].L - steps[0].L, d2 = steps[2].L - steps[1].L;
-    assert.ok(Math.abs(d1 - d2) <= 0.012, `${theme}: uneven steps ${d1.toFixed(3)} vs ${d2.toFixed(3)}`);
-    // the span may not shrink further: the two floors (the provisional wash below, the prose ink above) already squeeze
-    // the dark line to .20 of lightness, about T320's .19, so the three steps' separation rests on the chroma gradient
-    // (the deep step the most saturated, the far step the palest) and on the hue held; a wider spread would have to
-    // spend hue, which is the user's call, not a re-ink's
-    assert.ok(Math.abs(steps[2].L - steps[0].L) >= 0.19, `${theme}: the tokens span ${Math.abs(steps[2].L - steps[0].L).toFixed(3)} of lightness, below the .19 floor`);
-    // the far end keeps its distance from the prose ink (--fg): a lone Question is a colour, not body text. The dark end
-    // sits at the ink's own lightness, so its distance is all chroma, the hue's gamut edge there; .075 is just under it
-    const gap = dist(oklab(token(b, "--postal-question")), oklab(token(b, "--fg")));
-    assert.ok(gap >= 0.075, `${theme}: --postal-question is ${gap.toFixed(3)} from --fg in OKLab, too close to the ink`);
-  });
-}
+test("dark: the three kind tokens ARE stops of the aurora ramp, coordinate the first and delegate the last, a hue apart", () => {
+  const stops = auroraStops();
+  const b = block(":root {");
+  const hexes = STEPS.map((n) => token(b, n));
+  hexes.forEach((h, i) => assert.ok(stops.includes(h), `${STEPS[i]} ${h} is not a stop of the aurora ramp (${stops.join(" ")})`));
+  assert.equal(new Set(hexes).size, 3, "three different stops");
+  assert.equal(hexes[0], stops[0], "coordinate is the ramp's first stop (green)");
+  assert.equal(hexes[2], stops[stops.length - 1], "delegate is the ramp's last stop (purple): the two the user confused, farthest apart");
+  const qi = stops.indexOf(hexes[1]);
+  assert.ok(qi > 0 && qi < stops.length - 1, "question is a middle stop (teal-blue)");
+  const hs = hexes.map((h) => oklch(h).h);
+  for (let i = 0; i < 3; i++) for (let j = i + 1; j < 3; j++)
+    assert.ok(hueGap(hs[i], hs[j]) >= MIN_HUE_GAP, `${STEPS[i]} and ${STEPS[j]} are ${hueGap(hs[i], hs[j]).toFixed(0)} degrees apart, under ${MIN_HUE_GAP}`);
+  const ink = oklab(token(b, "--fg"));
+  hexes.forEach((h, i) => assert.ok(dist(oklab(h), ink) >= INK_GAP, `${STEPS[i]} is ${dist(oklab(h), ink).toFixed(3)} from --fg, too close to the ink`));
+});
 
-test("the comment beside the tokens names the same two endpoints, and the tokens hold their theme's accent hue", () => {
-  assert.match(CSS, /L \.65, C \.10[\s\S]{0,500}L \.85, C \.078/, "the dark line's two endpoints, in the :root comment");
-  assert.match(CSS, /L \.50, C \.11[\s\S]{0,300}L \.30, C \.098/, "the light line's two endpoints, in the light comment");
-  assert.match(CSS, /hue pinned\s+at the accent's 244/);
-  assert.match(CSS, /The trade-off is span against distance from the ink/, "the comment states the trade-off the far end makes");
-  assert.match(CSS, /reads at 4\.5:1 on the PROVISIONAL card, the darkest ground a kind word sits on/, "the comment names the wash as the floor, not the box");
-  // the accent itself sits on each line's hue: the ramp is the accent's family, not a neighbour's
-  assert.ok(hueGap(oklch(token(block(":root {"), "--accent")).h, MAPS.dark.hue) <= 8, "the dark accent's hue is the dark line's");
-  assert.ok(hueGap(oklch(token(block("body.theme-light {"), "--accent")).h, MAPS.light.hue) <= 8, "the light accent's hue is the light line's");
+test("light: the same three hues, each deepened on its own hue for the cream page, a hue apart and clear of the ink", () => {
+  const dark = block(":root {"), light = block("body.theme-light {");
+  const pairs = STEPS.map((n) => ({ name: n, d: oklch(token(dark, n)), l: oklch(token(light, n)) }));
+  for (const p of pairs) {
+    assert.ok(hueGap(p.l.h, p.d.h) <= 4, `${p.name}: the light hue ${p.l.h.toFixed(1)} is not the dark stop's ${p.d.h.toFixed(1)}`);
+    assert.ok(p.l.L < p.d.L - 0.1, `${p.name}: the light token (L ${p.l.L.toFixed(3)}) is not deepened below the stop (L ${p.d.L.toFixed(3)})`);
+  }
+  for (let i = 0; i < 3; i++) for (let j = i + 1; j < 3; j++)
+    assert.ok(hueGap(pairs[i].l.h, pairs[j].l.h) >= MIN_HUE_GAP, `${STEPS[i]} and ${STEPS[j]} (light) are ${hueGap(pairs[i].l.h, pairs[j].l.h).toFixed(0)} degrees apart`);
+  const ink = oklab(token(light, "--fg"));
+  STEPS.forEach((n) => assert.ok(dist(oklab(token(light, n)), ink) >= INK_GAP, `${n} (light) is too close to the ink`));
+});
+
+test("the mapping is written once, beside the dark tokens, and names the colormap", () => {
+  assert.match(CSS, /coordinate = the ramp's first stop \(green\), question = its fourth stop \(teal-blue\), delegate = its\s+last stop \(purple\)/,
+               "the :root comment states the mapping in one sentence");
+  assert.match(CSS, /default progress colormap \(aurora, bin\/romp_colormap\.py\)/, "the comment names the ramp and its file");
+  assert.match(CSS, /the :root comment holds the mapping/, "the light block's comment points at that one place");
 });

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -90,23 +90,15 @@ body.scheme-solarized-dark {
   --err: #c0392b;   /* unified with the awaiting/blocked red (the user 2026-06-24): one "needs you" red. API-error (--st-blocked-bg #e5484d) stays distinct. */
   --warn: #d7a23a;  /* the heads-up amber — "attention, not an error". Was referenced with fallbacks but never
                        defined (a phantom token) until 2026-08-26; mirrored in feed.css (own :root). */
-  /* the postal card's three KIND colours (T320, the user 2026-09-10): one SEQUENTIAL ramp in the accent's hue, not
-     three unrelated hues, ranked by how much the kind asks of the reader: coordination lowest (an FYI), delegation
-     next (work handed over), question highest (an answer owed). More asking = more intense against the page. The
-     three are sampled EVENLY, at positions 0, 1/2 and 1 of one straight line in OKLCH (T337, the user 2026-09-10, who
-     found the first three too alike: T320's steps sat at L .66, .76 and .85 with the top two at one saturation, so
-     they read as two tints of one blue). The line's two ends are two floors. The deep end is the deepest blue that
-     still reads at 4.5:1 on the PROVISIONAL card, the darkest ground a kind word sits on (a sent card not yet landed
-     wears the pending bubble's dress, an 8.5% wash of --you over the page; the boxed card and the bare page sit above
-     it): L .65, C .10. The far end stops short of the prose ink, so a lone Question still reads as a colour and not
-     as body text: the accent's own height, L .85, C .078, the sRGB gamut's edge for the hue; hue pinned
-     at the accent's 244 throughout. The trade-off is span against distance from the ink: a brighter far end widens
-     the ramp but converges on --fg (L .845), and this end keeps the word 0.079 from it in OKLab, all of it chroma.
-     Contrast: 5.2:1, 7.6:1 and 10.6:1 on the page, 4.8:1, 7.0:1 and 9.8:1 on a boxed card, 4.8:1, 7.0:1 and 9.8:1 on the provisional
-     wash. The light theme runs its own line the other way, deepening toward the dark end of its clay accent (below).
-     postal-kind-ramp.test.ts holds the positions and the distance from the ink, theme-parity.test.ts the contrast on
-     all three grounds. */
-  --postal-coordinate: #5696c8;  --postal-delegate: #7cb5e3;  --postal-question: #a2d4fe;
+  /* the three mail KINDS (Delegation / Coordination / Question) as coloured TEXT on the card head (T302; T371, the user
+     2026-09-12, who found coordinate and delegate alike: T337's three steps on ONE accent-hue line read as three tints
+     of one blue): three HUES now, sampled from the default progress colormap (aurora, bin/romp_colormap.py), so the two
+     the user confused sit farthest apart on the ramp. The mapping, in this one place (the light block below re-inks the
+     same three hues): coordinate = the ramp's first stop (green), question = its fourth stop (teal-blue), delegate = its
+     last stop (purple). The dark tokens ARE the stops; each reads above 5:1 on the page, the boxed card, the
+     provisional wash and the peer-tinted ground (theme-parity.test.ts holds the contrast on all four), and
+     postal-kind-ramp.test.ts holds the stops, the hue distances and the distance from the prose ink. */
+  --postal-coordinate: #54b204;  --postal-delegate: #9088f0;  --postal-question: #42a9b0;
   --postal-wash-l: 0.263;  --postal-wash-c: 0.03;   /* the incoming card's tint: the peer's hue at the box ground's own
                                                        OKLab lightness (the page under the 3% box), a gentle chroma (T337b).
                                                        The lightness here is the shipped theme's FALLBACK: the chat measures
@@ -251,11 +243,10 @@ body.theme-light {
   --hl-cmt: #67614f; --hl-title: #8C4A00; --hl-meta: #6E6455; --hl-attr: #7A5A20;   /* --hl-cmt from #6E675C (4.39:1 on a code block) to 4.86:1 */
   --box-bg: rgba(0, 0, 0, 0.03);
   --box-border: rgba(0, 0, 0, 0.12);
-  /* the kind ramp (T320, T337): the accent's clay hue (OKLCH 38) deepening with rank, sampled evenly along the line
-     from L .50, C .11 (the same first step as T320, the lightest clay that reads at 4.5:1 on the provisional wash) to
-     L .30, C .098 (the hue's gamut edge there; a deep rust that stays red, short of the prose ink --fg at L .236: 0.118 from it in OKLab); 5.3:1, 8.1:1 and 11.8:1
-     on the cream page, 4.9:1, 7.6:1 and 11.1:1 on a boxed card, 4.8:1, 7.3:1 and 10.7:1 on the provisional wash */
-  --postal-coordinate: #974a32;  --postal-delegate: #752f18;  --postal-question: #551400;
+  /* the three kind hues of the aurora stops (the :root comment holds the mapping), each deepened on its own hue to read
+     at 4.6:1 or better on the cream page, the boxed card, the provisional wash and the peer-tinted ground at every hue
+     (T371: the hues hold within a degree of the stops, OKLCH L about .49, chroma at the gamut's edge for the two vivid ones) */
+  --postal-coordinate: #386f18;  --postal-delegate: #5f57ab;  --postal-question: #0d6d73;
   --postal-wash-l: 0.919;  --postal-wash-c: 0.045;  /* the cream under the 3% box; a stronger chroma: the cream's own hue
                                                        (71) sits near a warm peer's, and at .03 that tint read at less than half
                                                        a cool one's distance from the ground (T337c, the review of 2026-09-11) */
@@ -2590,9 +2581,9 @@ pre code .file-uri-link { color: var(--accent); }   /* a fenced block's path (20
    T320 (the user, later that day): the word wears the prose weight, not bold, and its three colours are one
    sequential ramp ranked by how much the kind asks of the reader (the tokens' comment has the ranking). */
 .postal-kind { font-weight: 400; }
-.postal-kind-delegate { color: var(--postal-delegate, #7cb5e3); }
-.postal-kind-coordinate { color: var(--postal-coordinate, #5696c8); }
-.postal-kind-question { color: var(--postal-question, #a2d4fe); }
+.postal-kind-delegate { color: var(--postal-delegate, #9088f0); }
+.postal-kind-coordinate { color: var(--postal-coordinate, #54b204); }
+.postal-kind-question { color: var(--postal-question, #42a9b0); }
 /* BOTH ENDS of a postal card in the head, each in its session's identity colour (the peer's chip as before, and this
    session's own chip after it); a narrow head collapses this session's chip to its coloured dot, so both colours
    still show where the words would not fit */


### PR DESCRIPTION
The three mail kinds on a postal card (Delegation, Coordination, Question) rendered as three tints of one accent blue, and the user found coordinate and delegate indistinguishable (2026-09-12). They now take three hues from the default progress colormap (aurora, `bin/romp_colormap.py`), the two the user confused sitting farthest apart on the ramp.

**The mapping, written once** in the `:root` comment beside the tokens in `ui/webview/styles.css`: coordinate is the ramp's first stop (green, `#54b204`), question its fourth stop (teal-blue, `#42a9b0`), delegate its last stop (purple, `#9088f0`). The dark tokens are the stops themselves; each reads above 5:1 on the page, the boxed card, the provisional wash and the peer-tinted ground at every hue. The cream theme re-inks the same three hues deepened on their own hue (`#386f18`, `#0d6d73`, `#5f57ab`; OKLCH lightness about .49, hues within a degree of the stops) to read at 4.6:1 or better on the cream page and the same three grounds. The `.postal-kind-*` fallbacks carry the same hexes. The only surface that colours a kind is the card head's kind word (`render.ts`, class `postal-kind-<kind>`, the CSS reading the tokens); the timeline lanes and the feed colour no kind.

**Tests** (red on the unchanged stylesheet: 5 of 12 failed, the new pin naming the old blue as no stop of the ramp and the light hue as the clay). `ui/webview/postal-kind-ramp.test.ts` is rewritten for the new design: it reads the aurora ramp from `bin/romp_colormap.py` (never a copied literal) and pins that the dark tokens are three distinct stops with coordinate the first and delegate the last, that every pair of kinds sits at least 50 degrees of OKLCH hue apart in both themes, that the light tokens hold their dark stop's hue within 4 degrees and sit deepened below it, that every token keeps T337's distance from the prose ink, and that the mapping sentence and the colormap's name sit in the comment. `theme-parity.test.ts` (the token census and the contrast on the page, the box, the provisional wash and the peer-tinted ground) passes unchanged with the new hexes; the literal pins in `postal-card.test.ts` and `postal-intent.test.ts` move with the tokens, and the retired luminance ladder pin is replaced by the mapping pin. The served postal-cards test measures each kind word's contrast on the ground it sits on, and its three computed-colour pins move to the new stops.

**Screenshots** of a chat with all three kinds, dark and cream, in the drops folder as `romp_timeline-t371-dark.png` and `romp_timeline-t371-light.png`.

Tier: fix
