### PR TITLE
The converge pass holds the quiescence drops through the heal and the prime and pays them once; viaDrop counts only a write that happened (T362 follow-up review)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1035,11 +1035,13 @@ is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under
 `quiescent`: its heal would read the file whole every cycle and the write
-would find no entry; the one exception is a leaf whose whole entry from the
-boot's own read is still resident, which the pass heals and primes in memory
-so that the launch fold's quiescence drop writes the document from that read
-and pops the entry (`viaDrop`), once, after which the leaf is refused like any
-other;
+would find no entry; the one exception, with the drop write on, is a leaf
+whose whole entry from the boot's own read is still resident: the pass heals
+and primes it in memory with its quiescence drops held, then pays them once,
+so the launch fold's drop writes the document from that read (`viaDrop`, counted
+only for a write that happened) and pops the entry when a fold stepped records
+(a restore at the witness leaves it resident), after which the converged leaf
+simply leaves the candidate set;
 a path the pass refused or whose write produced nothing is skipped until its
 file changes under the reader (`skipped` counts each such hold once, per file
 state, and the check reads the reader's own entry rather than stat the file
@@ -1471,7 +1473,8 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `quiescent` for leaves refused as quiescent, `skipped` for candidates held
   off until their file changes, once per hold, `dropWrites` and `dropDeferred`
   for the documents written at the reader's quiescence drop and the drops
-  deferred a cycle for the shared budget), `coldWrites` (per fold name, writes that kept such a tail-only state
+  deferred a cycle for the shared budget, `viaDrop` for the resident quiescent
+  leaves the pass primed and the drop wrote), `coldWrites` (per fold name, writes that kept such a tail-only state
   out of the document so no later kernel restores it as complete), `droppedRestores` (a
   restore lost to a read that replaced the entry under it; the reader
   serializes reads per path, so this should stay at zero), `documentBytes`

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -847,6 +847,8 @@ _CKPT_CYCLE = {"cap": _ckpt_cycle_default_cap(), "spent": 0}   # the cycle in pr
 _DROP_OWED = {}                   # path -> when its quiescence drop was deferred for the cycle's budget (T362): paid at the next
 #                                   cycle's start with the room it has, oldest first, or by the next fold over the file
 _DROP_OWED_MAX = 4096             # over it the OLDEST owed entry is popped unwritten (its memory released), never the table cleared
+_DROP_HOLD = threading.local()    # the converge pass holds this thread's quiescence drops while it heals and primes a leaf, then pays
+#                                   them once (T362 follow-up review, low 2): {path: pop} of the drops held, or absent
 _CKPT_LOCK = threading.Lock()
 _CKPT_PENDING = {}                # path -> {"count": N, "gen": g, "folds": {name: {"count", "state"}}} restores not yet taken
 _CKPT_SEQ = {}                    # path -> the seq of the last checkpoint read or written for it
@@ -1195,15 +1197,6 @@ def _path_needs_write(key, ent, at_drop=False):
     return False
 
 
-def checkpoint_path_needs_write(path):
-    """The one rule asked from outside for the reader's current entry of `path` (the converge pass, after priming a quiescent
-    leaf: did the launch fold's drop already write everything?): False with no entry."""
-    key = str(path)
-    with _JSONL_CACHE_LOCK:
-        ent = _JSONL_CACHE.get(key)
-    return ent is not None and _path_needs_write(key, ent)
-
-
 def checkpoint_cycle_begin(cap):
     """The pusher's cycle begins: the checkpoint byte budget `cap` (documents written and read, leaves read for a heal) is
     whole again; the converge pass and the quiescence drop's writes charge it (T362). A cap of 0 (the pass off, or a zero
@@ -1235,6 +1228,36 @@ def _pop_owed_entry(key):
         if w:
             _RECORD_CACHE_STATS["dropped"] += 1
             _RECORD_CACHE_STATS["droppedBytes"] += w
+
+
+class hold_quiescent_drops:
+    """`with hold_quiescent_drops():` on this thread a quiescent-drop fold neither writes nor pops at its end; the drop is held
+    (with whether it would have popped) for pay_held_drops, so a pass that heals and primes a leaf over its resident entry
+    writes the document ONCE, after every fold is current, and pops once (a heal whose last fold was the launch fold popped the
+    entry mid-heal before, and the folds never called stayed out of the document)."""
+    def __enter__(self):
+        _DROP_HOLD.held = {}
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is not None:
+            _DROP_HOLD.held = None                        # a raise inside the block: nothing stays held on this thread (an unpaid
+        return False                                      #  hold would hold every later drop here; the entries fall to the reader's LRU)
+
+
+def pay_held_drops():
+    """Pay the drops held on this thread (see hold_quiescent_drops): {path: True when its document was written}. Each is paid
+    as the fold would have (the write when the rule says so, the pop when a fold stepped records), against the cycle's budget."""
+    held = getattr(_DROP_HOLD, "held", None)
+    _DROP_HOLD.held = None
+    out = {}
+    for key, pop in (held or {}).items():
+        with _JSONL_CACHE_LOCK:
+            ent = _JSONL_CACHE.get(key)
+        if ent is None:
+            continue
+        out[key] = bool(_drop_quiescent_entry(key, ent, pop=pop))
+    return out
 
 
 def checkpoint_pay_owed_drops():
@@ -1865,12 +1888,17 @@ def _drop_quiescent_entry(key, ent, pop=True):
     once a fold has stepped them: the fold's cursor (and its checkpoint) stands, the file's bytes leave memory. Only the
     very entry this fold read is dropped (another thread's newer entry is left alone); a file still changing keeps its
     records, since its next append would otherwise re-read it whole. Without `pop` (a fold that stepped nothing: a hit or
-    a restore at the witness) only the T362 write below runs and the entry stays, as it always has on that path."""
+    a restore at the witness) only the T362 write below runs and the entry stays, as it always has on that path. Returns
+    True when the document was written here."""
     try:
         if time.time() - float(ent[0]) < _DROP_AFTER_QUIESCENT_S:
-            return
+            return False
     except Exception:
-        return
+        return False
+    held = getattr(_DROP_HOLD, "held", None)
+    if held is not None:                                  # the converge pass is healing and priming this leaf on this thread: held,
+        held[key] = held.get(key, False) or pop           #  paid once after (pay_held_drops), with the pop if any fold stepped
+        return False
     with _CKPT_LOCK:
         if key in _DROP_OWED:                             # a drop deferred for the budget is taken at the next fold over the file
             _DROP_OWED.pop(key, None); pop = True         #  (whichever path that fold takes) or at the next cycle's start
@@ -1885,6 +1913,7 @@ def _drop_quiescent_entry(key, ent, pop=True):
         needs = checkpoint_drop_writes_on() and _path_needs_write(key, ent, at_drop=True)   # off (a cap of 0): the pop alone
     except Exception:
         needs = False
+    wrote = False
     if needs:
         cp = _ckpt_file(key)
         try:
@@ -1904,22 +1933,24 @@ def _drop_quiescent_entry(key, ent, pop=True):
                         _DROP_OWED.pop(oldest, None)
             if oldest is not None:
                 _pop_owed_entry(oldest)                   # outside _CKPT_LOCK: the reader's lock alone
-            return
+            return False
         if checkpoint_write(key):
             try:
                 written = cp.stat().st_size if cp is not None else 0
             except OSError:
                 written = 0
             checkpoint_cycle_charge(written - est)       # the true-up: what was written against the estimate taken above
+            wrote = True
             with _CKPT_LOCK:
                 _CKPT_STATS["converge"]["dropWrites"] += 1
     if not pop:
-        return
+        return wrote
     with _JSONL_CACHE_LOCK:
         if _JSONL_CACHE.get(key) is ent:
             w = _cache_pop_locked(key)
             _RECORD_CACHE_STATS["dropped"] += 1
             _RECORD_CACHE_STATS["droppedBytes"] += w
+    return wrote
 
 
 _UNPINNED = object()

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9949,32 +9949,36 @@ def _converge_checkpoints(now):
             em.converge_stat("deferred", len(cands) - i)   # gated on candidates PROCESSED, not documents written: a first
             break                                          #  candidate that writes nothing must not lift the budget (review)
         quiescent = p in leaves and em.file_quiescent(p)
-        if quiescent and not em.entry_whole_resident(p):   # T361 (the live loop): a leaf unchanged past the reader's quiescence
-            em.converge_stat("quiescent"); _converge_skip(p)   #  window loses its whole entry right after a fold steps it, so a heal
-            continue                                       #  or a prime here would READ it whole every cycle and the write would
+        if quiescent and (not em.entry_whole_resident(p) or not em.checkpoint_drop_writes_on()):
+            em.converge_stat("quiescent"); _converge_skip(p)   # T361 (the live loop): a leaf unchanged past the reader's quiescence
+            continue                                       #  window loses its whole entry right after a fold steps it, so a heal
+        #                                                    or a prime here would READ it whole every cycle and the write would
         #                                                    find no entry. With the boot's own whole read still resident (T362
-        #                                                    follow-up) the heal and the prime step records in hand, no read, and
-        #                                                    the prime's last fold (the agent-launch state, the one that drops
-        #                                                    quiescent leaves) writes the document from that read at its drop and
-        #                                                    pops the entry: the idle leaf converges once, and with its entry gone
-        #                                                    it is refused here on any later cycle, never read again by the pass
+        #                                                    follow-up) and the drop write on, the heal and the prime step records
+        #                                                    in hand, no read, the quiescence drops they meet are held, and one
+        #                                                    payment after writes the document from that read at the drop and pops
+        #                                                    the entry when a fold stepped records (a restore at the witness leaves
+        #                                                    it resident): the idle leaf converges once and leaves the candidate set;
+        #                                                    with the drop write off there is nothing to gain, so it is refused and
+        #                                                    the boot's read kept
         cold = [k for k, r in em.cold_fold_reasons(p).items() if r == "cold"]
-        if p in leaves:
-            before = _read_bytes_of(p)
-            healed = _heal_cold_folds(p)                   # drops every tail-only cursor, reruns the five leaf folds
-            if healed:
-                got = _read_bytes_of(p) - before
-                em.converge_stat("heals", len(healed)); em.converge_stat("healBytes", got); em.checkpoint_cycle_charge(got)
-            unhealed = [k for k in cold if k not in healed]
-            if em.entry_whole_resident(p) and _prime_leaf_folds(p):
-                em.converge_stat("primed")
-        else:
-            unhealed = em.drop_cold_cursors(p)
-        if quiescent and not em.checkpoint_path_needs_write(p):   # the launch fold's drop wrote the document from the boot's read
-            em.converge_stat("viaDrop")                    #  (converge.dropWrites, charged to this cycle's take; the entry popped, or
-            continue                                       #  kept after a restore at the witness): no write of the pass's own
+        with em.hold_quiescent_drops():                    # a heal whose last fold is the launch fold would otherwise pop the entry
+            if p in leaves:                                #  mid-heal, before the prime ran (review, low 2)
+                before = _read_bytes_of(p)
+                healed = _heal_cold_folds(p)               # drops every tail-only cursor, reruns the five leaf folds
+                if healed:
+                    got = _read_bytes_of(p) - before
+                    em.converge_stat("heals", len(healed)); em.converge_stat("healBytes", got); em.checkpoint_cycle_charge(got)
+                unhealed = [k for k in cold if k not in healed]
+                if em.entry_whole_resident(p) and _prime_leaf_folds(p):
+                    em.converge_stat("primed")
+            else:
+                unhealed = em.drop_cold_cursors(p)
         if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
             em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
+        if em.pay_held_drops().get(p) and quiescent:       # the held drop wrote the document from the boot's read (converge.dropWrites,
+            em.converge_stat("viaDrop")                    #  charged to this cycle's take): no write of the pass's own; a write that
+            continue                                       #  did not happen (deferred, failed) falls to the pass's own below
         try:                                               # the write reads the document on disk for its carry: that read is the
             pre = em._ckpt_file(p).stat().st_size          #  pass's I/O too, so it counts against the budget (review, round 3)
         except (OSError, AttributeError):

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1180,6 +1180,73 @@ class KernelFolds(Base):
         km._begin_checkpoint_cycle(); self.assertEqual(km._converge_checkpoints(TS0 + 601), 0)
         self.assertEqual((em.checkpoint_stats()["converge"]["passes"], self.doc(self.leaf)["seq"]), (1, d["seq"]), "one pass, one write")
 
+    def test_with_the_drop_write_off_the_pass_refuses_a_resident_quiescent_leaf_and_keeps_its_read(self):
+        """Follow-up review, low 1: under a zero byte budget the prime popped the boot's read without writing and viaDrop counted a
+        leaf where the drop wrote nothing. With the drop write off the exception does not apply: refused, the entry kept."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf); seq = self.doc(self.leaf)["seq"]
+        saved = km.CKPT_CONVERGE_BYTES; km.CKPT_CONVERGE_BYTES = 0
+        self.addCleanup(setattr, km, "CKPT_CONVERGE_BYTES", saved)
+        km._begin_checkpoint_cycle()
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0)
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["quiescent"], cv["viaDrop"], cv["dropWrites"], cv["heals"]), (1, 0, 0, 0), "%s" % cv)
+        self.assertTrue(em.entry_whole_resident(self.leaf), "the boot's read is kept, not discarded with the document stale")
+        self.assertEqual(self.doc(self.leaf)["seq"], seq)
+
+    def test_via_drop_counts_only_a_write_that_happened(self):
+        """Follow-up review, low 1: with the drop's write failing, the pop still left nothing to write, and viaDrop counted it. It
+        counts from a write that happened for that path; a failed one is the pass's failure, skipped until the file changes."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing"}, quiescent=True)
+        jd._bg_scan(self.leaf); seq = self.doc(self.leaf)["seq"]
+        saved = em.checkpoint_write; em.checkpoint_write = lambda path, force=False: False
+        self.addCleanup(setattr, em, "checkpoint_write", saved)
+        km._begin_checkpoint_cycle()
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0)
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["viaDrop"], cv["dropWrites"], cv["failed"]), (0, 0, 1), "%s" % cv)
+        self.assertTrue(km._converge_skipped(self.leaf)); self.assertEqual(self.doc(self.leaf)["seq"], seq)
+
+    def test_a_cold_launch_fold_is_healed_and_the_other_folds_still_primed_before_the_drop(self):
+        """Follow-up review, low 2: when the launch fold was itself the cold one, the heal's rerun of it dropped the entry mid-heal,
+        the prime never ran, and the folds this process never called stayed out of the document. The drop is held while the pass
+        heals and primes, then paid once: one write with every leaf fold, one pop."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "bare", "bgAll": "missing", "sessionMeta": "missing"}, quiescent=True)
+        km._agent_launch_state(self.leaf)                             # the boot: the launch fold restores cold over the tail
+        jd._bg_scan(self.leaf)                                        # the judges' first pass: the whole read, resident
+        self.assertEqual(em.cold_fold_reasons(self.leaf), {"agentLaunches": "cold"}); self.assertTrue(em.entry_whole_resident(self.leaf))
+        km._begin_checkpoint_cycle()
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0)
+        d = self.doc(self.leaf)
+        self.assertEqual(sorted(d["folds"]), ["agentLaunches", "bgAll", "bgJudge", "bgRunning", "sessionMeta"], "every leaf fold, primed before the drop")
+        self.assertTrue(all("state" in f for f in d["folds"].values()), "the healed launch state complete, the rest primed")
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["heals"], cv["viaDrop"], cv["dropWrites"], cv["writes"]), (1, 1, 1, 0), "%s" % cv)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(self.leaf), "one pop, after the prime")
+        self.assertEqual(em.checkpoint_converge_candidates(), [])
+
+    def test_an_unhealable_cold_fold_is_counted_on_the_via_drop_path_too(self):
+        """Follow-up review, low 3: the viaDrop continue preceded the unhealed counter, so a cold fold the pass could not rerun
+        (not one of the leaf's five) was dropped uncounted."""
+        self._converge_world({"bgJudge": "missing", "agentLaunches": "missing", "wakeTail": "bare"}, extra=("wakeTail",), quiescent=True)
+        em.fold_records({}, self.leaf, list, lambda st, o: st + [1], ckpt="wakeTail")   # the boot: the generic fold restores cold
+        jd._bg_scan(self.leaf)
+        self.assertEqual(em.cold_fold_reasons(self.leaf), {"wakeTail": "cold"})
+        km._begin_checkpoint_cycle()
+        self.assertEqual(km._converge_checkpoints(TS0 + 600), 0)
+        cv = em.checkpoint_stats()["converge"]
+        self.assertEqual((cv["unhealed"], cv["viaDrop"], cv["dropWrites"]), (1, 1, 1), "%s" % cv)
+        self.assertNotIn("wakeTail", self.doc(self.leaf)["folds"], "left out: its next run reads the file whole once")
+
+    def test_a_raise_inside_the_drop_hold_leaves_nothing_held_on_the_thread(self):
+        """A hold left set by a raise would hold every later drop on the pusher thread, unpaid, for the kernel's life."""
+        with self.assertRaises(RuntimeError):
+            with em.hold_quiescent_drops():
+                em._DROP_HOLD.held["x"] = True
+                raise RuntimeError("a fold raised")
+        self.assertIsNone(em._DROP_HOLD.held); self.assertEqual(em.pay_held_drops(), {})
+
     def test_converge_skips_a_path_whose_write_failed_until_its_file_changes(self):
         """T361 (b): a failed write must not repeat every cycle."""
         self._converge_world({"bgJudge": "missing"})


### PR DESCRIPTION
Fix tier. The four lows from the review of the pass fix (the converge pass primes a resident quiescent leaf so the launch fold's drop writes its document):

- **viaDrop counts only a write that happened.** It was inferred from the one rule reading false after the prime, so it counted a leaf where the drop wrote nothing (a zero byte budget popping the boot's read unwritten; a failed write). The drop now reports whether it wrote, and with the drop write off the exception does not apply: the leaf is refused and its read kept.
- **The drops are held through the heal and the prime, then paid once.** When the launch fold was itself the cold one, the heal's rerun popped the entry mid-heal and the prime never ran, so the folds this process never called stayed out of the document. `hold_quiescent_drops` (thread-local) holds them; `pay_held_drops` writes once with every fold current and pops once when a fold stepped records. A raise inside the block clears the hold.
- **The unhealed count precedes the viaDrop exit.**
- **Docs:** the pop happens only when a fold stepped records (a restore at the witness leaves the entry resident), a converged leaf leaves the candidate set rather than being refused, and `viaDrop` is in the /perf enumeration; the kernel comment matches.

**Tests** (`tests/test_fold_checkpoints.py`, red first on main for the first three): the drop write off refuses a resident quiescent leaf and keeps its read; a failing drop write counts as the pass's failure, not viaDrop; a cold launch fold is healed with the other folds still primed before the one drop; an unhealable cold fold is counted on the viaDrop path; a raise inside the hold leaves nothing held. Full Python suite green locally (12,479 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)