### PR TITLE
The cold kernel's first push sends the feed frame before it builds the chat pages and the timeline

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -41927,7 +41927,7 @@ def _dedup_sig(msg, s):
 # shipped as str() (_wire_default, one per encode). Bumped through _wire_bump, under a lock: the pusher and a
 # handler-thread connect push both split, and whichever sender thread first materializes a _LazyWire bumps its
 # counter, so a bare `+= 1` here would be a read-modify-write across threads (the tests assert exact counts).
-_wire_stats = {"split_hit": 0, "split_miss": 0, "feed_body": 0, "bars_body": 0, "feed_sig_fallback": 0,
+_wire_stats = {"split_hit": 0, "split_miss": 0, "feed_body": 0, "bars_body": 0, "feed_sig_fallback": 0, "feed_first": 0,
                "bars_sig_fallback": 0, "default_str": 0}
 _WIRE_STATS_LOCK = threading.Lock()
 _wire_default_said = set()   # type names _wire_default has written to stderr: a type is said once, not per value
@@ -45868,6 +45868,38 @@ def _chat_sig_ok(sid):
             _chat_sig_faults.pop(str(sid), None)
 
 
+def _feed_first(now, live_map, targets, connect):
+    """The cold kernel's first feed frame, built and sent to the feed panes among `targets` before the chat and timeline
+    builds of the same push (see the CARDS FIRST note in _push). The build goes through _cached_feed, so the push's own
+    feed section finds it warm; the wire tuple is built exactly as the send stage builds it and left in _feed_wire, so a
+    later frame with the same ledgers reuses it. Counted under _wire_stats feed_first and the push.feedFirst stage."""
+    global _feed_wire
+    _t0 = time.monotonic()
+    fsig = _fleet_view_sig(now, live_map)
+    feed_src = _cached_feed(now, live_map, fsig, connect)
+    if feed_src is None:
+        return False
+    feed = dict(feed_src)                            # the copy the send stage would make; no ledgers yet (no session build ran)
+    feed_parts = _delta_parts("feed", feed)
+    if feed_parts is not None:
+        feed_sig = _parts_sig(feed_parts)
+        feed_ms = _LazyWire(lambda f=feed: json.dumps(f, default=_wire_default_in("_push feed")), _parts_est(feed_parts), "feed_body")
+    else:
+        s_ = json.dumps(feed, default=_wire_default_in("_push feed"))
+        feed_ms, feed_sig = _LazyWire(None, len(s_), text=s_), _dedup_sig(feed, s_)
+        _wire_bump("feed_sig_fallback")
+    _feed_wire = (feed_src, feed.get("ledgers"), feed, feed_ms, feed_sig, feed_parts)
+    for c in targets:
+        if c["app"] == "feed":
+            try:
+                _send_slot(c, "feed", feed, feed_ms, feed_sig, feed_parts)
+            except Exception:
+                sys.stderr.write("push feed-first send: %s\n" % traceback.format_exc())
+    _wire_bump("feed_first")
+    _PERF_STATS.stage("push.feedFirst", time.monotonic() - _t0)
+    return True
+
+
 def _push(targets, connect=False, live_map=None):
     """Build the payloads once (cached parses) and send each target only the pieces that CHANGED for it.
     Drives both the periodic pusher (all clients) and a fresh connect (one client): a new/reconnecting
@@ -45890,6 +45922,18 @@ def _push(targets, connect=False, live_map=None):
     want_feed = _feed_audience(targets)          # the Sessions pane (app "fleet") rides the feed payload; chat needs feed["working"]
     want_tl = any(c["app"] == "timeline" for c in targets)
     chat_clients = [c for c in targets if c["app"] == "chat"]
+    # CARDS FIRST on a cold kernel (the user 2026-09-12: after a restart the sessions load fast now and the cards still
+    # wait): the first push after a boot builds every chat page (cold parses, ~25 s of a 37 s first cycle on the devbox)
+    # and the timeline before the feed frame leaves at the send stage. With no feed built since start and a feed pane
+    # among the targets, the feed is built and sent to those panes FIRST (_feed_first); the regular feed section below
+    # serves the same build from the cache with the ledgers attached, and the send stage's delta path carries only what
+    # that added. A warm kernel (a feed already built, or any cycle after the first) takes no extra step.
+    if (want_feed and _built_feed[1] is None and "firstServe" in _BOOT_MARKS and _PERF_STATS.pusher.get("cycles", 0) == 0
+            and any(c["app"] == "feed" for c in targets)):      # the boot's FIRST pusher cycle, and only it
+        try:
+            _feed_first(now, live_map, targets, connect)
+        except Exception:
+            sys.stderr.write("push feed-first: %s\n" % traceback.format_exc())
     try:
         chat_list = _chat_tab_sessions(now, live_map)   # live + explicitly kept-open (read-only reopened dead) — nothing else
         tab_order = [s["sid"] for s in chat_list]

--- a/tests/test_feed_first_cold_push.py
+++ b/tests/test_feed_first_cold_push.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Cards first on a cold kernel (2026-09-12): the first push after a boot sends the feed frame to the feed panes before
+it builds the chat pages and the timeline; a warm kernel takes no extra step. Hermetic: a temp state root, stubbed
+builders, fake clients; no kernel, no sessions."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+_tmp_state = tempfile.mkdtemp()
+os.environ["XDG_STATE_HOME"] = _tmp_state
+os.environ["ROMP_STATE_DIR"] = os.path.join(_tmp_state, "romp")
+from romp_load import load_source   # noqa: E402
+
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+km = load_source("romp_kernel_feed_first", os.path.join(BIN, "romp-kernel"))
+
+S1 = "77777777-1111-2222-3333-444444444401"
+S2 = "77777777-1111-2222-3333-444444444402"
+FEED = {"type": "feed", "asks": [{"itemId": "g1", "sid": S1, "title": "a card"}], "working": ["web"], "awaiting": []}
+
+
+def _sess(sid, state):
+    """A synthetic build_session payload in the shape the push's chat send expects (the skeleton test's stub)."""
+    return {"type": "session", "id": sid, "name": "web" if sid == S1 else "api",
+            "events": [{"kind": "assistant", "uuid": "u%d" % i, "md": "m%d" % i} for i in range(3)],
+            "status": {"state": state, "sinceEpoch": None}, "ledger": None}
+
+
+class FeedFirstColdPush(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.paths = {}
+        for sid in (S1, S2):
+            p = os.path.join(self.tmp, sid + ".jsonl"); open(p, "w").write("x" * 10); self.paths[sid] = p
+        self._saved = (km._chat_tab_sessions, km._live_map, km._cached_feed, km.build_session, km._comments_frame,
+                       km._push_subagents, km.NAMES, km.jd.STATE, list(km._clients), list(km._built_feed), km._feed_wire,
+                       dict(km._wire_stats))
+        km._chat_tab_sessions = lambda now, live_map: [{"sid": s, "name": _sess(s, "working")["name"], "path": self.paths[s], "anchor": s} for s in (S1, S2)]
+        km._live_map = lambda: {}
+        self.seq = []                                        # every frame every client receives, in send order
+        self.feed_calls = []
+        def cached_feed(now, live_map, sig, connect=False):
+            self.feed_calls.append(connect)
+            return json.loads(json.dumps(FEED))
+        km._cached_feed = cached_feed
+        def build(sid, now, live_map=None, **kw):
+            self.seq.append(("build", sid))
+            return json.loads(json.dumps(_sess(sid, "working")))
+        km.build_session = build
+        km._comments_frame = lambda sid, live_map: None
+        km._push_subagents = lambda clients, now, live_map: None
+        km.NAMES = Path(self.tmp) / "names"; km.NAMES.mkdir()
+        km.jd.STATE = Path(self.tmp) / "state"; km.jd.STATE.mkdir(parents=True, exist_ok=True)
+        km._built_chat.clear(); del km._clients[:]
+        km._built_feed[:] = [None, None, 0.0, 0.0]
+        km._feed_wire = None
+        self._marks, self._cycles = dict(km._BOOT_MARKS), km._PERF_STATS.pusher.get("cycles", 0)
+        km._BOOT_MARKS["firstServe"] = 1.0                   # a kernel that is serving, in its first pusher cycle
+        with km._PERF_STATS.lock:
+            km._PERF_STATS.pusher["cycles"] = 0
+        for k in km._wire_stats:
+            km._wire_stats[k] = 0
+
+    def tearDown(self):
+        (km._chat_tab_sessions, km._live_map, km._cached_feed, km.build_session, km._comments_frame, km._push_subagents,
+         km.NAMES, km.jd.STATE, clients, built_feed, km._feed_wire, stats) = self._saved
+        del km._clients[:]; km._clients.extend(clients)
+        km._built_feed[:] = built_feed
+        km._wire_stats.update(stats)
+        km._built_chat.clear()
+        km._BOOT_MARKS.clear(); km._BOOT_MARKS.update(self._marks)
+        with km._PERF_STATS.lock:
+            km._PERF_STATS.pusher["cycles"] = self._cycles
+
+    def _client(self, app):
+        c = {"app": app, "alive": True, "sent": {}}
+        c["send"] = lambda s, c=c: self.seq.append((c["app"], json.loads(s).get("type")))
+        return c
+
+    def test_a_cold_kernels_first_push_sends_the_feed_before_any_chat_build(self):
+        feed_c, chat_c = self._client("feed"), self._client("chat")
+        km._push([feed_c, chat_c])
+        kinds = [(a, t) for a, t in self.seq]
+        first_feed = kinds.index(("feed", "feed"))
+        first_build = kinds.index(("build", S1)) if ("build", S1) in kinds else kinds.index(("build", S2))
+        self.assertLess(first_feed, first_build, "the feed frame leaves before the first chat page is built: %r" % kinds)
+        self.assertEqual(km._wire_stats["feed_first"], 1)
+        self.assertEqual(self.feed_calls[0], False, "the early build is the cycle's own, not a connect serve")
+
+    def test_a_warm_kernel_takes_no_extra_step(self):
+        feed_c, chat_c = self._client("feed"), self._client("chat")
+        km._built_feed[1] = json.loads(json.dumps(FEED))          # a feed already built since start
+        km._push([feed_c, chat_c])
+        self.assertEqual(km._wire_stats["feed_first"], 0, "no early pass on a warm kernel")
+        self.assertIn(("feed", "feed"), self.seq, "the regular feed section still serves the pane: %r" % self.seq)
+
+    def test_a_later_cycle_takes_no_extra_step(self):
+        with km._PERF_STATS.lock:
+            km._PERF_STATS.pusher["cycles"] = 1
+        km._push([self._client("feed"), self._client("chat")])
+        self.assertEqual(km._wire_stats["feed_first"], 0, "only the boot's first cycle sends the feed first")
+
+    def test_no_feed_pane_means_no_early_pass(self):
+        chat_c = self._client("chat")
+        km._push([chat_c])
+        self.assertEqual(km._wire_stats["feed_first"], 0)
+
+    def test_the_early_pass_precedes_the_chat_section_in_the_source(self):
+        src = open(os.path.join(BIN, "romp-kernel")).read()
+        push = src[src.index("def _push(targets, connect=False, live_map=None):"):]
+        self.assertLess(push.index("_feed_first(now, live_map, targets, connect)"), push.index("chat_list = _chat_tab_sessions(now, live_map)"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
After the timeline and chat memos a restart loads the sessions fast and the cards still wait: on the 9:17 AM Pacific boot the first pusher cycle spent 37 s building every session's chat page from cold parses, then the timeline, before the feed frame left at the send stage.

On the boot's first pusher cycle only, `_push` now builds and sends the feed frame to the feed panes before the chat and timeline builds (`_feed_first`); the regular feed section serves the same build with the ledgers attached, and the delta path carries what that added. A warm kernel, a later cycle, or a push without a feed pane takes no extra step. Counted under `_wire_stats.feed_first` and the `push.feedFirst` stage.

Tests in `tests/test_feed_first_cold_push.py`; the order test fails with the early pass removed.

Tier: fix
