### PR TITLE
The postal card's head carries no tooltip restating its kind badge

### DIFF
--- a/ui/webview/postal-card.test.ts
+++ b/ui/webview/postal-card.test.ts
@@ -173,3 +173,9 @@ test("a sent card that has not landed wears the pending send's own provisional d
   assert.doesNotMatch(CSS, /\.queued-bubble[^\n{]*\{[^}]*\bopacity:/, "no queued-bubble rule sets an opacity: the fade and its lifts are the ink");
   assert.match(CSS, /\.queued-bubble\.cancelable \{ position: relative; padding-right: 30px; transition: color \.1s, border-color \.1s, background \.1s; \}/, "the transition names what changes");
 });
+
+test("the postal card's head carries no tooltip restating its kind badge (the user 2026-09-12)", () => {
+  // the badge already says coordination, delegation or question; a hover that repeated it was one more thing to read
+  assert.match(RENDER, /cls: "turn-postal-service postal-service-" \+ ev\.direction \}\);/, "the notice spec ends at the class: no tip");
+  assert.ok(!RENDER.includes('"interaction type: "'), "the restating sentence is gone");
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -5410,8 +5410,7 @@ function renderPostalService(ev: Extract<ChatEvent, { kind: "postal-service" }>)
   const owed = !!intent && intent.cls === "question" && ev.direction === "in";
   const turn = notice({ src, glyph: "peer", gist: summaryText, meta, body, open: owed,
                         key: "postal:" + (ev.mid || ev.uuid || ""), rail: ev.color ? ev.color.bg : undefined,
-                        cls: "turn-postal-service postal-service-" + ev.direction,
-                        tip: kind ? "interaction type: " + kind.toLowerCase() : undefined });
+                        cls: "turn-postal-service postal-service-" + ev.direction });   // no head tooltip: the kind badge already says coordination, delegation or question (the user 2026-09-12)
   // the delivery state: an icon at the head's right edge, and — while the message has not landed (handed to the
   // relay, or parked for an unreachable host) — the SAME provisional dress the user's own pending send wears
   // (the queued bubble's class and tokens, the T302 amendment): solid again once the receipt says delivered,


### PR DESCRIPTION
The hover over a mail card's head repeated the kind its badge already shows (coordination, delegation, question). The user asked for it to go (2026-09-12, with a screenshot). The postal card's notice spec sets no tip now; the badge stands alone. The postal card test pins the absence (red on main).

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
