### PR TITLE
The feed build re-derives only the sessions whose inputs moved: a per-session card memo, bounded by bytes, counted under /perf (T368)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1530,9 +1530,14 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   session's cards are derived once and served while every input of that
   derivation stands (the transcript, states, names, captions, store, journal
   and archive by identity; the live row, the wait graph, the stall and nudge
-  records, the watches and the background tasks by value; the interrupt and
-  settle-gap booleans the clock decides; the peers the cards read), so a
-  rebuild re-derives only the sessions whose inputs moved. `hit`, `miss` and
+  records, the session's own rows of the postal log, the watches and the
+  background tasks by value; the interrupt, settle-gap and billing-offer
+  booleans the clock decides; the peers the cards read), so a rebuild
+  re-derives only the sessions whose inputs moved. The sections that span
+  sessions (the serving-fold join, the parked handoffs, the quarantine cards,
+  the bell pass, the working and awaiting dot lists, the unreadable-state
+  ring) are never memoized: every build recomposes them from the served
+  entries, decoded fresh, so nothing memoized is mutated. `hit`, `miss` and
   `derived` count per session per build, `evict` the entries shed (a departed
   session, or the byte bound), `entries` and `bytes` are the resident set
   against `bound` (a sixty-fourth of the machine's memory, or
@@ -1540,11 +1545,17 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   per-session key (`transcript`, `parse`, `cut`, `states`, `names`,
   `captions`, `store`, `anchors`, `reg`, `cleared`, `row`, `ask`, `live`,
   `bg`, `wait`, `postal`, `stalls`, `nudge`, `jauth`, `jactive`, `hide`,
-  `watch`, `subagents`, `usage`, `auth`, `downtime`, `debug`,
+  `watch`, `subagents`, `usage`, `offer`, `auth`, `downtime`, `debug`,
   `interrupting`, `closer`, `peers`, plus `cold` for a session with no
   entry) to the re-derivations it caused; a miss with several moved
-  components counts under each. The age tint every card wears is stamped
-  per build outside the memo, so no clock is a component.
+  components counts under each. The nudge records, the key on hand, the
+  host-suspension spans and the debug mode are board-wide inputs: a change
+  to one re-derives every session. The clock is not a component of the key:
+  a card's clock-derived fields either leave the memoized entry and are
+  stamped per build (the age tint, a placeholder's time), or enter the key
+  as the boolean the clock decides (the interrupt window, the settle gap,
+  the billing offer's window), so a served card shows what a rebuilt one
+  would.
 - `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
   `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
   was built and compared, then not sent.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1531,8 +1531,9 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   derivation stands (the transcript, states, names, captions, store, journal
   and archive by identity; the live row, the wait graph, the stall and nudge
   records, the session's own rows of the postal log, the watches and the
-  background tasks by value; the interrupt, settle-gap and billing-offer
-  booleans the clock decides; the peers the cards read), so a rebuild
+  background tasks by value; the interrupt and settle-gap booleans the
+  clock decides and the billing offer's open window as the card renders it;
+  the peers the cards read), so a rebuild
   re-derives only the sessions whose inputs moved. The sections that span
   sessions (the serving-fold join, the parked handoffs, the quarantine cards,
   the bell pass, the working and awaiting dot lists, the unreadable-state
@@ -1553,9 +1554,10 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   to one re-derives every session. The clock is not a component of the key:
   a card's clock-derived fields either leave the memoized entry and are
   stamped per build (the age tint, a placeholder's time), or enter the key
-  as the boolean the clock decides (the interrupt window, the settle gap,
-  the billing offer's window), so a served card shows what a rebuilt one
-  would.
+  as the value the clock decides (the interrupt window and the settle gap
+  as booleans, the billing offer's open window and its reset as the card
+  renders them, a parse's trailing idle edge), so a served card shows what a
+  rebuilt one would.
 - `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
   `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
   was built and compared, then not sent.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1525,7 +1525,26 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   goal-store publish moves that session's `store` component and no other
   tab's; the judge-pass generation busts the feed and timeline caches only.
   `romp perf` prints the split and the non-zero causes after the chat
-  average, and the moved count when it is non-zero.
+  average, and the moved count when it is non-zero. `feed` also carries
+  `memo`, the per-session card memo inside `build_feed`: each living
+  session's cards are derived once and served while every input of that
+  derivation stands (the transcript, states, names, captions, store, journal
+  and archive by identity; the live row, the wait graph, the stall and nudge
+  records, the watches and the background tasks by value; the interrupt and
+  settle-gap booleans the clock decides; the peers the cards read), so a
+  rebuild re-derives only the sessions whose inputs moved. `hit`, `miss` and
+  `derived` count per session per build, `evict` the entries shed (a departed
+  session, or the byte bound), `entries` and `bytes` are the resident set
+  against `bound` (a sixty-fourth of the machine's memory, or
+  `ROMP_FEED_MEMO_BYTES`), and `miss_by` maps each labelled component of the
+  per-session key (`transcript`, `parse`, `cut`, `states`, `names`,
+  `captions`, `store`, `anchors`, `reg`, `cleared`, `row`, `ask`, `live`,
+  `bg`, `wait`, `postal`, `stalls`, `nudge`, `jauth`, `jactive`, `hide`,
+  `watch`, `subagents`, `usage`, `auth`, `downtime`, `debug`,
+  `interrupting`, `closer`, `peers`, plus `cold` for a session with no
+  entry) to the re-derivations it caused; a miss with several moved
+  components counts under each. The age tint every card wears is stamped
+  per build outside the memo, so no clock is a component.
 - `sends`: `full`, `delta`, `deduped`, each a map from slot name (`chat`,
   `feed`, `bars`, `taborder`, ...) to `count` and `bytes`. A deduplicated frame
   was built and compared, then not sent.

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36254,6 +36254,8 @@ def _feed_memo_forget(alive_sids):
             _FEED_MEMO_STATS["bytes"] -= _feed_memo.pop(k)[2]
         _FEED_MEMO_STATS["evict"] += len(gone)
         _FEED_MEMO_STATS["entries"] = len(_feed_memo)
+    for k in [k for k in _SUBAGENT_DIRS_MEMO if k not in alive_sids]:   # the key's walk memo leaves with the session
+        _SUBAGENT_DIRS_MEMO.pop(k, None)
     return len(gone)
 
 
@@ -36286,24 +36288,29 @@ def _feed_peer_facts(p, cleared_by_sid):
             host, _remote_name_of(host, p) if r else None)
 
 
-_SUBAGENT_DIRS_MEMO = {}                         # subagents root → (its directories, their identities): the walk, memoized
+_SUBAGENT_DIRS_MEMO = {}                         # sid → (subagents root, its directories, their identities): the walk,
+#                                                  memoized per living session and dropped with its memo entry (_feed_memo_forget)
 
 
-def _subagent_dirs_ident(d):
+def _subagent_dirs_ident(sid, d):
     """(the directories under the subagents root `d`, their identities), the walk memoized: an unchanged tree costs
     one stat per known directory, not an os.walk per session per build (the T368 review's profile: the walk was a
     third of the memo key's cost). Sound because a directory added or removed under `d` moves its PARENT's mtime,
     and every parent is a known directory, so the known identities standing means the tree stands; any of them
     moving (a sidecar landing, a directory appearing or vanishing, the root itself) re-walks. A root that does not
-    exist is the tree [d] with identity None, and its appearance re-walks the same way."""
-    hit = _SUBAGENT_DIRS_MEMO.get(d)
-    if hit is not None:
-        idents = tuple(_chat_ident(x) for x in hit[0])
-        if idents == hit[1]:
-            return hit
+    exist is the tree [d] with identity None, and its appearance re-walks the same way. Keyed by the session so
+    _feed_memo_forget drops a departed session's entry with its memo entry; a session whose transcript (and so
+    whose root) moved re-walks. A sidecar REWRITTEN in place under its own name moves no directory's mtime, so
+    neither this memo nor _subagent_meta_map's own cache sees it (pre-existing, shared with that cache; the CLI
+    writes a sidecar once, at the agent's spawn)."""
+    hit = _SUBAGENT_DIRS_MEMO.get(sid)
+    if hit is not None and hit[0] == d:
+        idents = tuple(_chat_ident(x) for x in hit[1])
+        if idents == hit[2]:
+            return hit[1], idents
     dirs = tuple(_subagent_dirs(d) or [d])
     idents = tuple(_chat_ident(x) for x in dirs)
-    _SUBAGENT_DIRS_MEMO[d] = (dirs, idents)
+    _SUBAGENT_DIRS_MEMO[sid] = (d, dirs, idents)
     return dirs, idents
 
 
@@ -36343,24 +36350,34 @@ def _postal_maps_indexed():
     return last_any, last_ask, last_await, returned, names, by_party
 
 
+def _cleared_by_sid(cleared):
+    """The clear set indexed by owning session: id → the text before its LAST colon (a node id is <sid>:gN, and a
+    composite session key such as host:name keeps its own colon), so `by[sid]` is exactly the tuple the per-session
+    filter `i.startswith(sid + ":")` returned, sorted; an id with no colon belongs to no session (the filter matched
+    it for none) and is not indexed. Built once per build (_feed_board_facts), read per session and per peer
+    (tests/test_feed_session_memo.py pins the equivalence over every id shape)."""
+    by = {}
+    for i in cleared:
+        if ":" in i:
+            by.setdefault(i.rpartition(":")[0], []).append(i)
+    return {k: tuple(sorted(v)) for k, v in by.items()}
+
+
 def _feed_board_facts(ctx, now):
     """The board-wide inputs of every session's key, taken ONCE per build into ctx (the same value for every
     session: one stat each, not one per living session): the clear set indexed by session, the postal maps indexed
-    by party, the nudge records' identities, usage.json's identity and
-    whether a login-account window sits at its cap with its reset ahead (the `offer` crossing), the key on hand,
+    by party, the nudge records' identities, usage.json's identity and the login-account window sitting at its cap
+    with its reset ahead as (window, resetsAt) or None (the `offer` component's payload), the key on hand,
     the host-suspension spans, the debug mode and its rows' identity. Taken before any session's derivation, so
     every session's read follows its stat (stat-then-read)."""
     b = ctx.get("board")
     if b is None:
         dbg = bool(jd._debug_mode())
-        by_sid = {}
-        for i in ctx["cleared"]:                    # the clear set indexed by the id's session prefix, once per build
-            by_sid.setdefault(i.partition(":")[0], []).append(i)
-        b = {"cleared_by_sid": {k: tuple(sorted(v)) for k, v in by_sid.items()},
+        b = {"cleared_by_sid": _cleared_by_sid(ctx["cleared"]),   # the clear set indexed by owning session, once per build
              "postal": _postal_maps_indexed(),
              "nudge": (_chat_ident(jd.STATE / "auto-nudge.json"), _chat_ident(jd.STATE / "nudge-events.jsonl")),
              "usage_ident": _chat_ident(jd.STATE / "usage.json"),
-             "cap_open": _usage_cap_open(now) is not None,
+             "cap_open": (lambda w: (w["window"], w["resetsAt"]) if w else None)(_usage_cap_open(now)),
              "auth": _auth_key_present(),
              "downtime": (len(_downtime), _downtime[-1] if _downtime else None),
              "debug": (dbg, _chat_ident(jd.ERRORS) if dbg else None)}
@@ -36389,9 +36406,13 @@ def _feed_session_key(s, tm, ctx, prev_entry):
         _bg_live_norm's transcript rung, _bg_owner_tops/_bg_service_descs/_awaiting_task_descs → _bg_placed_tops →
         _parse), the placeholders' _parse (_provisional_card, _blocked_placeholder, _awaiting_card),
         _pure_delegation_top's dictated-prompt read, _open_turn_progress's hydrate, _last_plain_user_turn_t.
-      parse: `_parse_cached(path) is not None`, the warm bit. A cold kernel derives without the parse (no dots, no
-        anchors, the cold-parse summary fallback) and _warm_fleet_bg then fills the cache with NO file change; the
-        bit flipping is what re-derives the session warm.
+      parse: (`_parse_cached(path) is not None`, the last turn's end). The warm bit: a cold kernel derives without
+        the parse (no dots, no anchors, the cold-parse summary fallback) and _warm_fleet_bg then fills the cache
+        with NO file change, and the bit flipping is what re-derives the session warm. The end: the one value in a
+        parse that is not a function of its files (em.parse_session reads the clock for the trailing idle span's
+        end alone, synthesize_idle), so a parse re-run at a later clock with no file change (an evicted parse warmed
+        again) differs there and nowhere else; keying on it re-derives once per re-parse and makes the parse's
+        identity exact without a clock in the key (T368 review round two).
       cut: the SDK backend's pending_cut(sid), a chat DELETE rollback that changes the parse with no file change.
       states: (_chat_ident(STATE/states/<fsid>.jsonl), _chat_ident(STATE/states/<anchor>.jsonl)). The parse key's
         states file, the machine cuts (_interrupt_suppresses_nudge → _last_machine_cut), _session_retrying's
@@ -36435,13 +36456,16 @@ def _feed_session_key(s, tm, ctx, prev_entry):
       hide: _session_flag(fsid, "hideFromFeed"). The session yields no entry while set.
       watch: json of _watch_awaiting(fsid) (the in-memory watches for this sid). An awaiting source.
       subagents: _chat_ident of the transcript's subagents directory and every directory under it (the walk memoized
-        on those identities, _subagent_dirs_ident). _subagent_meta_map.
+        on those identities, _subagent_dirs_ident). _subagent_meta_map. A sidecar rewritten in place under its own
+        name moves no directory's mtime and is invisible here as it is to the map's own cache (pre-existing).
       usage: _chat_ident(STATE/usage.json) when the previous entry recorded reading it (an api error's cap offer,
         _cap_switch_offer), else None. A deps component.
-      offer: whether a login-account usage window sits at its cap with its reset still ahead of the build's clock
-        (_usage_cap_open(now) is not None), when the previous entry recorded reading usage.json, else None. The
-        billing-switch offer's own clock crossing (resets_at passing ends the mint, _cap_switch_offer) as the
-        boolean it decides, the way `interrupting` and `closer` are. A deps component.
+      offer: the login-account usage window sitting at its cap with its reset still ahead of the build's clock, as
+        (window, resetsAt) from _usage_cap_open(now), or None; taken when the previous entry recorded reading
+        usage.json, else None. The billing-switch offer's own clock crossing (resets_at passing ends the mint,
+        _cap_switch_offer) as the payload the card renders, not a boolean: with two windows capped, the earlier
+        reset passing moves the offer to the later window and its time, which a boolean would not see (T368 review
+        round two). A deps component.
       auth: _auth_key_present(). The cap offer's key-on-hand leg.
       downtime: (len(_downtime), its last span). _session_working's host-suspension read (_suspended_after).
       debug: (jd._debug_mode(), _chat_ident(STATE/judge-errors.jsonl) when on). dbg_rows → _card_warn_rows.
@@ -36482,7 +36506,7 @@ def _feed_session_key(s, tm, ctx, prev_entry):
                           if k.startswith(fsid + ":")))
     jauth = tuple(sorted((ctx["jauth_map"].get(fsid) or {}).items(), key=str)) or None
     jactive = fsid in ctx["jactive"]
-    subagents = _subagent_dirs_ident(str(_subagents_dir(path)))[1] if path else None
+    subagents = _subagent_dirs_ident(fsid, str(_subagents_dir(path)))[1] if path else None
     reads_usage = bool(((prev_entry or {}).get("reads") or {}).get("usage"))   # the entry read usage.json (the cap offer)
     usage = board["usage_ident"] if reads_usage else None
     offer = board["cap_open"] if reads_usage else None
@@ -36529,7 +36553,8 @@ def _feed_session_key(s, tm, ctx, prev_entry):
              st is None and not hide)                # a hidden session's skipped read is not a fault
     bg = (tuple((r.get("tid"), r.get("desc"), r.get("t"), r.get("type"), r.get("deadline"), r.get("agentId"))
                 for r in _bg_live_norm(fsid, path)) if (ps is not None and path) else None)
-    return (transcript, ps is not None, cut, states, names, captions, store, anchors, reg, cl, row, ask, live_rev,
+    parse = (ps is not None, (ps["turns"][-1].get("end") if ps and ps.get("turns") else None))   # the warm bit + the parse's own edge
+    return (transcript, parse, cut, states, names, captions, store, anchors, reg, cl, row, ask, live_rev,
             bg, wait, postal, stalls, nudge, jauth, jactive, hide, watch, subagents, usage, offer, auth, downtime,
             debug, interrupting, closer, peers)
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16234,7 +16234,7 @@ def _auth_avail_status():
     return out
 
 
-def _cap_switch_offer(sid, aerr):
+def _cap_switch_offer(sid, aerr, now=None):
     """The explicit billing-switch OFFER for a login-billed session dead on the account's usage cap —
     or None. The user's BINDING ruling (2026-08-30, via the nightly optimizer): a session must NEVER
     silently switch billing in either direction — so romp only OFFERS, and only the user's explicit
@@ -16252,11 +16252,21 @@ def _cap_switch_offer(sid, aerr):
     tm = (_live_map() or {}).get(str(sid)) or {}
     if str(tm.get("authLive") or tm.get("auth") or "") != "login" or not _auth_key_present():
         return None
+    return _usage_cap_open(now)
+
+
+def _usage_cap_open(now=None):
+    """The login account's usage window sitting AT its cap with a readable reset still ahead of `now` (the caller's
+    clock, else the wall clock), as {"resetsAt", "window"}, or None: usage.json's five-hour and seven-day windows
+    (the authority the retry pause reads), the first at 100 percent whose resets_at has not passed. The ONE rule
+    the billing-switch offer mints from (_cap_switch_offer) and the feed memo's `offer` key component reads
+    (T368 review): the offer self-expires when resets_at passes, and that crossing has to move the memo key the
+    way the interrupt window and the settle gap do, or a served card would keep offering a switch past the reset."""
     try:
         u = json.loads((jd.STATE / "usage.json").read_text())
     except Exception:
         return None
-    now = time.time()
+    now = time.time() if now is None else now
     for k in ("five_hour", "seven_day"):
         w = u.get(k) or {}
         if isinstance(w, dict) and (w.get("pct") or 0) >= 100 and (w.get("resets_at") or 0) > now:
@@ -36163,9 +36173,9 @@ def _state_unknown_names(alive, live_map, working, awaiting):
 # recompose per build from the per-session results and are never memoized across sessions.
 _FEED_MEMO_LABELS = ("transcript", "parse", "cut", "states", "names", "captions", "store", "anchors", "reg",
                      "cleared", "row", "ask", "live", "bg", "wait", "postal", "stalls", "nudge", "jauth", "jactive",
-                     "hide", "watch", "subagents", "usage", "auth", "downtime", "debug", "interrupting", "closer",
-                     "peers")
-_FEED_MEMO_DEPS = ("usage", "peers")             # the components evaluated over the PREVIOUS entry's record (see _feed_session_key)
+                     "hide", "watch", "subagents", "usage", "offer", "auth", "downtime", "debug", "interrupting",
+                     "closer", "peers")
+_FEED_MEMO_DEPS = ("usage", "offer", "peers")    # the components evaluated over the PREVIOUS entry's record (see _feed_session_key)
 _feed_memo = {}                                  # sid → (key, entry_json, size); dict order is the LRU order: a served entry
 #                                                  moves to the tail, the head goes first when the bytes exceed the bound
 _feed_memo_lock = threading.Lock()               # the dict ops and the counters only; the derivation runs outside it
@@ -36257,7 +36267,7 @@ def _feed_memo_report():
     return out
 
 
-def _feed_peer_facts(p, cleared):
+def _feed_peer_facts(p, cleared_by_sid):
     """What one card-owning session's derivation read about a PEER p (an origin sender, a handoff recipient, a stamped
     or awaited peer), by identity and value: the peer's goal store, journal and archive (jd._store_identity; the shared
     read-only view the origin badge reads) with whether that view READS (jd.load_goals_shared_or_fault's fault
@@ -36272,8 +36282,92 @@ def _feed_peer_facts(p, cleared):
     return (ident, _chat_ident(jd.GOALDIR / (p + ".json")),   # + ctime: a permissions fault or repair moves it alone
             jd.load_goals_shared_or_fault(p)[1] is not None,
             tuple(_names_parts(p) or ()),
-            tuple(sorted(i for i in cleared if i.startswith(p + ":"))),
+            cleared_by_sid.get(p, ()),
             host, _remote_name_of(host, p) if r else None)
+
+
+_SUBAGENT_DIRS_MEMO = {}                         # subagents root → (its directories, their identities): the walk, memoized
+
+
+def _subagent_dirs_ident(d):
+    """(the directories under the subagents root `d`, their identities), the walk memoized: an unchanged tree costs
+    one stat per known directory, not an os.walk per session per build (the T368 review's profile: the walk was a
+    third of the memo key's cost). Sound because a directory added or removed under `d` moves its PARENT's mtime,
+    and every parent is a known directory, so the known identities standing means the tree stands; any of them
+    moving (a sidecar landing, a directory appearing or vanishing, the root itself) re-walks. A root that does not
+    exist is the tree [d] with identity None, and its appearance re-walks the same way."""
+    hit = _SUBAGENT_DIRS_MEMO.get(d)
+    if hit is not None:
+        idents = tuple(_chat_ident(x) for x in hit[0])
+        if idents == hit[1]:
+            return hit
+    dirs = tuple(_subagent_dirs(d) or [d])
+    idents = tuple(_chat_ident(x) for x in dirs)
+    _SUBAGENT_DIRS_MEMO[d] = (dirs, idents)
+    return dirs, idents
+
+
+def _postal_session_slice(sid, maps=None):
+    """The postal log's rows that can reach ONE session's cards, by value: for every ordered pair the session is a
+    party to (as sender or recipient; a cross-host recipient by its stable id or peer key), the latest message
+    time, the latest reply-expecting ask, the latest reply-requiring send, the returned or withdrawn sends, and the
+    log's display names for the other parties. Everything the body reads of the log is a function of these rows
+    (_peer_answered and _peer_answered_at walk the session's own pairs, _session_stamp_read's superseding clock is
+    that walk, _peer_identity's remote names are the join), so a row between two OTHER sessions leaves this
+    session's key where it was; the whole log's identity keyed every session before (T368 review: one row
+    re-derived the board). The maps are the one cached scan (_postal_wait_maps, keyed on the log's stat)."""
+    sid = str(sid)
+    last_any, last_ask, last_await, returned, names, by_party = maps if maps is not None else _postal_maps_indexed()
+    pairs = by_party.get(sid) or ()
+    rows = tuple((p, last_any.get(p), last_ask.get(p), last_await.get(p),
+                  tuple(sorted((returned.get(p) or {}).items(), key=repr)))
+                 for p in pairs)
+    parties = {x for p in pairs for x in p if x != sid}
+    return (rows, tuple(sorted((x, names.get(x)) for x in parties if x in names)))
+
+
+def _postal_maps_indexed():
+    """The postal wait maps, the returns and the display names from the one cached scan, plus an index party → its
+    ordered pairs (sorted by repr), built once per build (_feed_board_facts) so each session's slice is a lookup
+    rather than a pass over every pair."""
+    last_any, last_ask, last_await = _postal_wait_maps()
+    returned = _postal_returned()
+    names = _postal_peer_names()
+    by_party = {}
+    for p in set(last_any) | set(last_ask) | set(last_await) | set(returned):
+        if isinstance(p, tuple):
+            for x in p:
+                by_party.setdefault(x, []).append(p)
+    for x in by_party:
+        by_party[x] = tuple(sorted(set(by_party[x]), key=repr))
+    return last_any, last_ask, last_await, returned, names, by_party
+
+
+def _feed_board_facts(ctx, now):
+    """The board-wide inputs of every session's key, taken ONCE per build into ctx (the same value for every
+    session: one stat each, not one per living session): the clear set indexed by session, the postal maps indexed
+    by party, the nudge records' identities, usage.json's identity and
+    whether a login-account window sits at its cap with its reset ahead (the `offer` crossing), the key on hand,
+    the host-suspension spans, the debug mode and its rows' identity. Taken before any session's derivation, so
+    every session's read follows its stat (stat-then-read)."""
+    b = ctx.get("board")
+    if b is None:
+        dbg = bool(jd._debug_mode())
+        by_sid = {}
+        for i in ctx["cleared"]:                    # the clear set indexed by the id's session prefix, once per build
+            by_sid.setdefault(i.partition(":")[0], []).append(i)
+        b = {"cleared_by_sid": {k: tuple(sorted(v)) for k, v in by_sid.items()},
+             "postal": _postal_maps_indexed(),
+             "nudge": (_chat_ident(jd.STATE / "auto-nudge.json"), _chat_ident(jd.STATE / "nudge-events.jsonl")),
+             "usage_ident": _chat_ident(jd.STATE / "usage.json"),
+             "cap_open": _usage_cap_open(now) is not None,
+             "auth": _auth_key_present(),
+             "downtime": (len(_downtime), _downtime[-1] if _downtime else None),
+             "debug": (dbg, _chat_ident(jd.ERRORS) if dbg else None)}
+        ctx["board"] = b
+        ctx["usage_ident"] = b["usage_ident"]      # the deps re-evaluation reads these two (see _feed_key_with_deps)
+        ctx["cap_open"] = b["cap_open"]
+    return b
 
 
 def _feed_session_key(s, tm, ctx, prev_entry):
@@ -36328,8 +36422,10 @@ def _feed_session_key(s, tm, ctx, prev_entry):
         parse is warm, else None. The task set the awaiting sources, the blocked-yield ownership, the service chip
         and the awaiting pill read; a deadline crossing (em._bg_expired) is the row leaving the tuple.
       wait: wmap[fsid] as sorted items, or None. The peer-wait floor and the waitingOn chip.
-      postal: _chat_ident(jd.MESSAGES), board-wide. _peer_answered and _peer_answered_at (the wait maps and the returns
-        from the one log scan), _session_stamp_read's log key, _postal_peer_names inside _peer_identity.
+      postal: _postal_session_slice(fsid), the log's rows the session is a party to, by value (the pairs' latest
+        times, asks, reply-requiring sends and returns, the other parties' display names). _peer_answered and
+        _peer_answered_at walk those pairs, _session_stamp_read's superseding clock is that walk, _peer_identity's
+        remote names are the join; a row between two other sessions moves no key of this one.
       stalls: the session's slice of _stalled_goals() as (gid, why, since), sorted. The stalled section and the
         in-flight swirl.
       nudge: (_chat_ident(STATE/auto-nudge.json), _chat_ident(STATE/nudge-events.jsonl)), board-wide.
@@ -36338,9 +36434,14 @@ def _feed_session_key(s, tm, ctx, prev_entry):
       jactive: fsid in {r["fsid"] for r in jd.active_runs()}. The Analyzing swirl's active prong.
       hide: _session_flag(fsid, "hideFromFeed"). The session yields no entry while set.
       watch: json of _watch_awaiting(fsid) (the in-memory watches for this sid). An awaiting source.
-      subagents: _chat_ident of the transcript's subagents directory and every directory under it. _subagent_meta_map.
+      subagents: _chat_ident of the transcript's subagents directory and every directory under it (the walk memoized
+        on those identities, _subagent_dirs_ident). _subagent_meta_map.
       usage: _chat_ident(STATE/usage.json) when the previous entry recorded reading it (an api error's cap offer,
         _cap_switch_offer), else None. A deps component.
+      offer: whether a login-account usage window sits at its cap with its reset still ahead of the build's clock
+        (_usage_cap_open(now) is not None), when the previous entry recorded reading usage.json, else None. The
+        billing-switch offer's own clock crossing (resets_at passing ends the mint, _cap_switch_offer) as the
+        boolean it decides, the way `interrupting` and `closer` are. A deps component.
       auth: _auth_key_present(). The cap offer's key-on-hand leg.
       downtime: (len(_downtime), its last span). _session_working's host-suspension read (_suspended_after).
       debug: (jd._debug_mode(), _chat_ident(STATE/judge-errors.jsonl) when on). dbg_rows → _card_warn_rows.
@@ -36354,9 +36455,10 @@ def _feed_session_key(s, tm, ctx, prev_entry):
     NOT components: the clock (the fold stamps trgb and a clock-stamped placeholder's t per build), the colormap (the
     fold reads it), notify-cards.json (the post-loop notify pass), session-order, the views, the notices (post-loop)."""
     fsid, path = s["sid"], s.get("path")
-    now, cleared = ctx["now"], ctx["cleared"]
+    now = ctx["now"]
     live = tm is not None
     hide = bool(_session_flag(fsid, "hideFromFeed"))
+    board = _feed_board_facts(ctx, now)         # the board-wide identities and indexes, once per build (before any read)
     # ── file identities, every one BEFORE the reads below ──
     transcript = _chat_ident(path) if path else None
     states = tuple(_chat_ident(jd.STATESDIR / (k + ".jsonl"))
@@ -36371,27 +36473,23 @@ def _feed_session_key(s, tm, ctx, prev_entry):
     hold = (_hold.get("cutT"), _hold.get("leaf"), _hold.get("at")) if _hold else None
     anchors = _node_anchor_rev.get(fsid, 0)
     reg = (_chat_ident(jd.STATE / "sdk" / (fsid + ".json")), _chat_ident(jd.GONEDIR / (fsid + ".json")))
-    cl = tuple(sorted(i for i in cleared if i.startswith(fsid + ":")))
+    cl = board["cleared_by_sid"].get(fsid, ())
     row = (tuple(sorted(((k, v) for k, v in tm.items() if k not in ("snapT", "interrupting")), key=lambda kv: kv[0]))
            if tm else None)
-    postal = _chat_ident(jd.MESSAGES)
-    nudge = (_chat_ident(jd.STATE / "auto-nudge.json"), _chat_ident(jd.STATE / "nudge-events.jsonl"))
+    postal = _postal_session_slice(fsid, board["postal"])
+    nudge = board["nudge"]
     stalls = tuple(sorted((k, v.get("why"), v.get("since")) for k, v in ctx["stalls"].items()
                           if k.startswith(fsid + ":")))
     jauth = tuple(sorted((ctx["jauth_map"].get(fsid) or {}).items(), key=str)) or None
     jactive = fsid in ctx["jactive"]
-    if path:
-        _sd = str(_subagents_dir(path))
-        subagents = tuple(_chat_ident(d) for d in (_subagent_dirs(_sd) or [_sd]))
-    else:
-        subagents = None
-    ctx["usage_ident"] = _chat_ident(jd.STATE / "usage.json")   # taken every build; keyed only when the entry read it
-    usage = ctx["usage_ident"] if ((prev_entry or {}).get("reads") or {}).get("usage") else None
-    auth = _auth_key_present()
-    downtime = (len(_downtime), _downtime[-1] if _downtime else None)
-    dbg = bool(jd._debug_mode())
-    debug = (dbg, _chat_ident(jd.ERRORS) if dbg else None)
-    facts = {p: _feed_peer_facts(p, cleared) for p in ((prev_entry or {}).get("peers") or ())}
+    subagents = _subagent_dirs_ident(str(_subagents_dir(path)))[1] if path else None
+    reads_usage = bool(((prev_entry or {}).get("reads") or {}).get("usage"))   # the entry read usage.json (the cap offer)
+    usage = board["usage_ident"] if reads_usage else None
+    offer = board["cap_open"] if reads_usage else None
+    auth = board["auth"]
+    downtime = board["downtime"]
+    debug = board["debug"]
+    facts = {p: _feed_peer_facts(p, board["cleared_by_sid"]) for p in ((prev_entry or {}).get("peers") or ())}
     ctx["peer_facts"] = facts                        # pre-derivation facts: _feed_key_with_deps keeps these for the peers
     peers = tuple((p, facts[p]) for p in sorted(facts)) if prev_entry is not None else None   # the new entry names again
     # ── the in-memory reads ──
@@ -36432,8 +36530,8 @@ def _feed_session_key(s, tm, ctx, prev_entry):
     bg = (tuple((r.get("tid"), r.get("desc"), r.get("t"), r.get("type"), r.get("deadline"), r.get("agentId"))
                 for r in _bg_live_norm(fsid, path)) if (ps is not None and path) else None)
     return (transcript, ps is not None, cut, states, names, captions, store, anchors, reg, cl, row, ask, live_rev,
-            bg, wait, postal, stalls, nudge, jauth, jactive, hide, watch, subagents, usage, auth, downtime, debug,
-            interrupting, closer, peers)
+            bg, wait, postal, stalls, nudge, jauth, jactive, hide, watch, subagents, usage, offer, auth, downtime,
+            debug, interrupting, closer, peers)
 
 
 _FEED_PEERS_UNSETTLED = ("unsettled",)           # a `peers` component no build's key can equal (the builder makes None or
@@ -36441,8 +36539,8 @@ _FEED_PEERS_UNSETTLED = ("unsettled",)           # a `peers` component no build'
 
 
 def _feed_key_with_deps(key, ctx, entry):
-    """The key with its two dependency components re-evaluated over the entry a derivation just produced: `usage`
-    from the entry's `reads`, `peers` from the entry's `peers`, each peer's facts the PRE-derivation ones the key
+    """The key with its dependency components re-evaluated over the entry a derivation just produced: `usage` and
+    `offer` from the entry's `reads`, `peers` from the entry's `peers`, each peer's facts the PRE-derivation ones the key
     took when the previous entry already named that peer. A peer this derivation read for the FIRST time has no
     pre-derivation facts, and facts taken now could pair a new key with old content (the peer's store moving while
     the body read it, the order stat-then-read forbids), so the stored key carries _FEED_PEERS_UNSETTLED instead:
@@ -36451,6 +36549,7 @@ def _feed_key_with_deps(key, ctx, entry):
     k = list(key)
     reads = (entry or {}).get("reads") or {}
     k[_FEED_MEMO_LABELS.index("usage")] = ctx.get("usage_ident") if reads.get("usage") else None
+    k[_FEED_MEMO_LABELS.index("offer")] = ctx.get("cap_open") if reads.get("usage") else None
     if entry is None:
         peers = None
     else:
@@ -36838,7 +36937,8 @@ def _feed_session_entry(s, ctx):
     # the truth. One formula, one truth: awaiting wins; the floor applies only to a session truly dead
     # in the water.
     aerr = _api_error(s["path"]) if (ps and not who_working and not sess_awaiting_why) else None   # cache-only: fills in after the warm
-    _cap_off = _cap_switch_offer(fsid, aerr) if aerr else None   # the billing-switch OFFER (never a silent switch, 2026-08-30)
+    _cap_off = _cap_switch_offer(fsid, aerr, now) if aerr else None   # the billing-switch OFFER (never a silent switch, 2026-08-30);
+    #                                              the build's clock, the one the key's `offer` component reads the cap window against
     if aerr:
         reads["usage"] = True                    # the offer reads usage.json: the key's `usage` component rides this record
     api_top = None

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -528,6 +528,10 @@ class _PerfStats:
             file_slice = dict(self.file_slice_stats)
             glossary_stats = dict(self.glossary_stats)
             since = self.since
+        try:                                           # the feed's per-session card memo (T368): its own lock, a copy per read
+            builds["feed"]["memo"] = _feed_memo_report()
+        except Exception:
+            builds["feed"]["memo"] = {}
         pusher["ring_n"] = len(ring)
         pusher["cycle_ms_p50"] = self._pct(ring, 0.5)
         pusher["cycle_ms_p90"] = self._pct(ring, 0.9)
@@ -35549,7 +35553,7 @@ def _provisional_card(s, name, color, fsid, live, now, store=None):
         text = pre + g if g else prompt[:140].strip()
     t = held.get("t", lt["t"])
     return {"itemId": "provisional:" + fsid, "sid": fsid, "name": name, "color": color, "text": text,
-            "t": t, "live": live, "trgb": list(cm.age_rgb(now - t, _colormap())),
+            "t": t, "live": live, "_ageT": t,   # the tint's epoch; trgb is stamped per build by the feed's fold (_feed_fold_card)
             "turnId": None, "origin": None, "followupPending": None,
             "summary": None, "blockSummary": None, "background": None,
             "blocked": None, "column": "working",
@@ -35574,18 +35578,18 @@ def _awaiting_card(s, name, color, fsid, live, now, why, kind=None, since=None, 
     card's compact "Waiting on task" pill (feed.ts), which lists the live task descriptions."""
     if not live:                                     # a dead session isn't awaiting anything live
         return None
-    t = now
-    try:
+    t, age_t = now, None                             # `t` is the build's clock until a turn dates it; `_ageT` is the epoch the
+    try:                                             #  feed's fold tints from, None while t IS the clock (the fold restamps t)
         turns = _parse(s["path"], fsid, now)["turns"]
-        if turns:
-            t = turns[-1].get("t", now)              # last activity → recency tint, sorts with the working column
+        if turns and turns[-1].get("t") is not None:
+            t = age_t = turns[-1]["t"]               # last activity → recency tint, sorts with the working column
     except Exception:
         pass
     # _session_awaiting already phrases the why ("waiting on a background command: <desc>"); capitalize it for
     # the headline. The task list rides `awaiting` for the pill, so the headline needn't repeat every task.
     text = (why[:1].upper() + why[1:]) if why else "Waiting on a background command"
     return {"itemId": "awaiting:" + fsid, "sid": fsid, "name": name, "color": color, "text": text,
-            "t": t, "live": live, "trgb": list(cm.age_rgb(now - t, _colormap())),
+            "t": t, "live": live, "_ageT": age_t,   # trgb is stamped per build by the feed's fold (_feed_fold_card)
             "turnId": None, "origin": None, "followupPending": None,
             "summary": None, "blockSummary": None, "background": None,
             "blocked": None, "column": "working",
@@ -35613,8 +35617,8 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
     answered work. Event-based: keyed on the live perm/picker state, not a timer; build_feed only asks when the
     session has NO working card AND no focus to floor, so it never duplicates a real card."""
     text = None
-    t = now
-    try:
+    t, age_t = now, None                             # `t` is the build's clock until the live segment dates it; `_ageT` is the
+    try:                                             #  epoch the feed's fold tints from, None while t IS the clock (the fold restamps t)
         turns = _parse(s["path"], fsid, now)["turns"]
     except Exception:
         turns = None
@@ -35623,7 +35627,7 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
         segs = em.segments(lt)
         if segs:
             held = segs[-1]                          # the live segment — what the user is being asked about
-            t = held.get("t", lt["t"])
+            t = age_t = held.get("t", lt["t"])
             if jd._seg_human(held):
                 prompt = re.sub(r"<!--.*?-->", "", _split_reminders(_seg_prompt(held))[0],
                                 flags=re.S).strip()   # markers are plumbing, never display (see _provisional_card)
@@ -35651,7 +35655,7 @@ def _blocked_placeholder(s, name, color, fsid, live, now, perm_state, since):
     if not text:
         text = "Awaiting your input" if perm_state == "picker" else "Awaiting your approval"
     return {"itemId": "blocked:" + fsid, "sid": fsid, "name": name, "color": color, "text": text,
-            "t": t, "live": live, "trgb": list(cm.age_rgb(now - t, _colormap())),
+            "t": t, "live": live, "_ageT": age_t,   # trgb is stamped per build by the feed's fold (_feed_fold_card)
             "turnId": None, "origin": None, "followupPending": None,
             "summary": None, "blockSummary": None, "background": None,
             "blocked": {"state": perm_state,
@@ -36145,12 +36149,1400 @@ def _state_unknown_names(alive, live_map, working, awaiting):
     return out
 
 
+# ───────────────────────── the feed's per-session card memo (T368) ─────────────────────────
+# build_feed derives every living session's cards on every rebuild, and the pusher rebuilds the whole payload on
+# ANY change anywhere (_fleet_view_sig): one transcript append re-derived every session's cards. The memo below
+# holds each session's derived entry (its cards, its dot names, its service chip, its serving-fold candidates, its
+# heal counts) under a key of every input the derivation reads, so a rebuild re-derives only the sessions whose
+# inputs moved. Invalidation is event-based on the inputs alone: no clock rides the key. The clock-derived field
+# (each card's age tint, trgb) leaves the memoized entry and is stamped per build by the fold (_feed_fold_card),
+# and the two booleans the clock decides (_interrupting's stamp window, _closer_pending's settle gap) are computed
+# in the key, so a crossing moves the key and nothing else does. Entries are JSON strings: a hit decodes fresh
+# objects, so the post-loop passes that mutate cards (the serving-fold join, the notify pass) never touch a
+# memoized object. Cross-session sections (stateUnknown, the serving-fold commit, parked handoffs, the notices)
+# recompose per build from the per-session results and are never memoized across sessions.
+_FEED_MEMO_LABELS = ("transcript", "parse", "cut", "states", "names", "captions", "store", "anchors", "reg",
+                     "cleared", "row", "ask", "live", "bg", "wait", "postal", "stalls", "nudge", "jauth", "jactive",
+                     "hide", "watch", "subagents", "usage", "auth", "downtime", "debug", "interrupting", "closer",
+                     "peers")
+_FEED_MEMO_DEPS = ("usage", "peers")             # the components evaluated over the PREVIOUS entry's record (see _feed_session_key)
+_feed_memo = {}                                  # sid → (key, entry_json, size); dict order is the LRU order: a served entry
+#                                                  moves to the tail, the head goes first when the bytes exceed the bound
+_feed_memo_lock = threading.Lock()               # the dict ops and the counters only; the derivation runs outside it
+_FEED_MEMO_STATS = {"hit": 0, "miss": 0, "evict": 0, "entries": 0, "bytes": 0, "bound": 0, "derived": 0,
+                    "miss_by": {k: 0 for k in _FEED_MEMO_LABELS + ("cold",)}}   # /perf builds.feed.memo
+
+
+def _feed_memo_bound():
+    """The memo's byte bound: ROMP_FEED_MEMO_BYTES when it names a positive integer, else a sixty-fourth of the machine's
+    memory (the _spend_tree_memo_bound idiom; 128 MB on an 8 GB box). The entries are the LIVE sessions' serialized
+    card lists, departed sessions dropped after every build (_feed_memo_forget), so the bound is a backstop against a
+    runaway board, not a working-set knob. Read once at import (FEED_MEMO_BYTES); GET /perf reports it beside the
+    memo's bytes (builds.feed.memo)."""
+    raw = os.environ.get("ROMP_FEED_MEMO_BYTES", "")
+    try:
+        if raw and int(raw) > 0:
+            return int(raw)
+    except ValueError:
+        pass
+    return _mem_total_bytes() // 64
+
+
+def _feed_memo_count(key, n=1):
+    with _feed_memo_lock:
+        _FEED_MEMO_STATS[key] = _FEED_MEMO_STATS.get(key, 0) + n
+
+
+def _feed_memo_miss(old, new):
+    """Count a miss and attribute it: the sorted labels of every key component that differs between the cached key
+    `old` and the fresh one `new` (`cold` when there was no cached entry, or its key has another shape). A miss with
+    several moved components counts under each, so miss_by's sum can exceed `miss`."""
+    if old is None or len(old) != len(new):
+        labels = ("cold",)
+    else:
+        labels = tuple(sorted(lab for lab, a, b in zip(_FEED_MEMO_LABELS, old, new) if a != b))
+    with _feed_memo_lock:
+        _FEED_MEMO_STATS["miss"] += 1
+        for lab in labels:
+            _FEED_MEMO_STATS["miss_by"][lab] = _FEED_MEMO_STATS["miss_by"].get(lab, 0) + 1
+    return labels
+
+
+def _feed_memo_get(sid):
+    """The memoized (key, entry_json, size) for sid, or None. A read is a USE: the entry moves to the LRU tail."""
+    with _feed_memo_lock:
+        ent = _feed_memo.pop(sid, None)
+        if ent is not None:
+            _feed_memo[sid] = ent
+        return ent
+
+
+def _feed_memo_put(sid, key, entry_json):
+    """Store sid's entry under its key (replacing any earlier one), then shed the least recently served entries, one at
+    a time, until the bytes fit FEED_MEMO_BYTES. Never clear-at-cap; an entry that alone exceeds the bound still
+    serves (the pages cache's rule), so one very large board cannot make the memo useless."""
+    size = len(entry_json)
+    with _feed_memo_lock:
+        old = _feed_memo.pop(sid, None)
+        if old is not None:
+            _FEED_MEMO_STATS["bytes"] -= old[2]
+        _feed_memo[sid] = (key, entry_json, size)
+        _FEED_MEMO_STATS["bytes"] += size
+        while len(_feed_memo) > 1 and _FEED_MEMO_STATS["bytes"] > FEED_MEMO_BYTES:
+            k = next(iter(_feed_memo))               # the least recently served goes first
+            _FEED_MEMO_STATS["bytes"] -= _feed_memo.pop(k)[2]
+            _FEED_MEMO_STATS["evict"] += 1
+        _FEED_MEMO_STATS["entries"] = len(_feed_memo)
+
+
+def _feed_memo_forget(alive_sids):
+    """Drop the entries of sessions no longer in the build's alive set (a departed session's cards are not coming
+    back under its sid; a revived one re-derives). Called after every build's loop."""
+    with _feed_memo_lock:
+        gone = [k for k in _feed_memo if k not in alive_sids]
+        for k in gone:
+            _FEED_MEMO_STATS["bytes"] -= _feed_memo.pop(k)[2]
+        _FEED_MEMO_STATS["evict"] += len(gone)
+        _FEED_MEMO_STATS["entries"] = len(_feed_memo)
+    return len(gone)
+
+
+def _feed_memo_report():
+    """The memo's counters with its occupancy refreshed (entries, bytes) and its bound: GET /perf builds.feed.memo."""
+    with _feed_memo_lock:
+        out = dict(_FEED_MEMO_STATS)
+        out["miss_by"] = dict(_FEED_MEMO_STATS["miss_by"])
+        out["entries"] = len(_feed_memo)
+        out["bound"] = FEED_MEMO_BYTES
+    return out
+
+
+def _feed_peer_facts(p, cleared):
+    """What one card-owning session's derivation read about a PEER p (an origin sender, a handoff recipient, a stamped
+    or awaited peer), by identity and value: the peer's goal store, journal and archive (jd._store_identity; the shared
+    read-only view the origin badge reads) with whether that view READS (jd.load_goals_shared_or_fault's fault
+    boundary: an EIO moves no stat, and the badge reads absorbed while the sender's store faults; a stat-hit on a
+    healthy store, the same episode table the body's own read then hits), its names-registry entry (the snapshot the
+    build's _name_of/_name_color read), its slice of the clear set (a cleared sender goal dims the badge), and the
+    attached host that owns it with the name that host gave it (_peer_identity's remote rungs). The postal rung rides
+    the board-wide `postal` component."""
+    r = _host_for_sid(p)
+    host = str((r or {}).get("host") or "") if r else ""
+    ident = jd._store_identity(p)[1:]                # BEFORE the read below (stat-then-read)
+    return (ident, _chat_ident(jd.GOALDIR / (p + ".json")),   # + ctime: a permissions fault or repair moves it alone
+            jd.load_goals_shared_or_fault(p)[1] is not None,
+            tuple(_names_parts(p) or ()),
+            tuple(sorted(i for i in cleared if i.startswith(p + ":"))),
+            host, _remote_name_of(host, p) if r else None)
+
+
+def _feed_session_key(s, tm, ctx, prev_entry):
+    """One session's memo key: a tuple in _FEED_MEMO_LABELS order, one component per input _feed_session_entry reads,
+    every file stat'd BEFORE any read below it (stat-then-read: a publish landing between the stat and the read pairs
+    an old key with new content, which the next build's stat sees and re-derives; the other order could pair a new
+    key with old content and never heal). The clock is not a component; the two booleans it decides are. The
+    per-session facts the body needs and this function already computed are handed over in `ctx` (`ps`,
+    `who_working`, `interrupting`, `store`, `closer`, `hide`), so a build reads each once, hit or miss, and their
+    side effects (the live merge's prune/settle, the interrupt stamp's pop, the snapshot punch) run every build as
+    they did before the memo. `prev_entry` is the session's previous decoded entry (None when cold): its `peers` and
+    `reads` records drive the two dependency components, which _feed_key_with_deps re-evaluates over the NEW entry
+    after a derivation (the chat build's deps idiom), so a cold entry hits on the next unchanged build.
+
+    Components, label: what it covers (the reads in the body), how it is taken.
+      transcript: _chat_ident(s["path"]). The cache-only parse (_parse_cached → jd.parse_cached's fileset key), the
+        anchors (_segs_seam, _seg_anchors, _seg_jump, _seg_key, _seg_last_text, _atom_prose_chars, em.turn_scalar),
+        the api-error tail (_api_error), the background scans (_heal_session_tops → _bg_scan_all_cached,
+        _bg_live_norm's transcript rung, _bg_owner_tops/_bg_service_descs/_awaiting_task_descs → _bg_placed_tops →
+        _parse), the placeholders' _parse (_provisional_card, _blocked_placeholder, _awaiting_card),
+        _pure_delegation_top's dictated-prompt read, _open_turn_progress's hydrate, _last_plain_user_turn_t.
+      parse: `_parse_cached(path) is not None`, the warm bit. A cold kernel derives without the parse (no dots, no
+        anchors, the cold-parse summary fallback) and _warm_fleet_bg then fills the cache with NO file change; the
+        bit flipping is what re-derives the session warm.
+      cut: the SDK backend's pending_cut(sid), a chat DELETE rollback that changes the parse with no file change.
+      states: (_chat_ident(STATE/states/<fsid>.jsonl), _chat_ident(STATE/states/<anchor>.jsonl)). The parse key's
+        states file, the machine cuts (_interrupt_suppresses_nudge → _last_machine_cut), _session_retrying's
+        retrying-since fold, the awaiting overlay (_session_awaiting → _states_awaiting_overlay).
+      names: (s["name"], the names snapshot's fields for fsid: _names_parts). The card's name (discover's read) and
+        colour (_name_color); the snapshot's CONTENT, not the file, since the body reads the cycle's snapshot.
+      captions: _chat_ident(CAPDIR/<fsid>.jsonl). The placeholders' gist (_provisional_card / _blocked_placeholder →
+        _seg_caption(_captions(fsid))).
+      store: (jd._store_identity(fsid)[1:] (the store, its override journal, its goals-archive entry), the judge-pass
+        snapshot's stamp when this sid is in it (_goals_snap_at[0], else None: _feed_goals serves the pre-pass
+        snapshot while a pass is mid-flight), the user-gesture mark _user_goal_write[fsid], the punch record
+        _goals_snap_done[fsid], the rewind hold (cutT, leaf, at) or None, whether the read FAULTED (an EIO or a
+        permissions fault moves no stat)). _feed_goals, jd.load_goals_shared inside _bg_placed_tops and
+        _session_stamp_read, jd.review_boundary, jd._done_since and every node read.
+      anchors: _node_anchor_rev[fsid]. The warm-anchor table _node_anchor_uuids serves a cold node from; a chat build's
+        resolve for this sid bumps it.
+      reg: (_chat_ident(STATE/sdk/<fsid>.json), _chat_ident(STATE/gone/<fsid>.json)). The launch ledger
+        (_thread_reg → _bg_live_norm), spawnedAt and the death marker (_sdk_spawned_at, jd._cli_epoch), the SDK-human
+        flag (_display_sdk_human).
+      cleared: the session's own slice of _cleared_ids(), sorted. `nid in cleared` per top, the provisional card's
+        follow-up target check; a peer's slice rides `peers`.
+      row: the live row tm without snapT and interrupting, as sorted items (None when not live). `live`, perm_state,
+        `since`, _session_retrying's retry fields, the subagent and bgTasks sets, authLive (_cap_switch_offer).
+      ask: json of the backend's current_ask(fsid) while the row is on a permission/picker prompt, else None. The
+        blocked placeholder's title.
+      live: Sessions.live_rev(fsid, be). The in-memory live tail _merge_live_atoms folds in ahead of the disk.
+      bg: the normalized live background-task rows (_bg_live_norm: tid, desc, t, type, deadline, agentId) when the
+        parse is warm, else None. The task set the awaiting sources, the blocked-yield ownership, the service chip
+        and the awaiting pill read; a deadline crossing (em._bg_expired) is the row leaving the tuple.
+      wait: wmap[fsid] as sorted items, or None. The peer-wait floor and the waitingOn chip.
+      postal: _chat_ident(jd.MESSAGES), board-wide. _peer_answered and _peer_answered_at (the wait maps and the returns
+        from the one log scan), _session_stamp_read's log key, _postal_peer_names inside _peer_identity.
+      stalls: the session's slice of _stalled_goals() as (gid, why, since), sorted. The stalled section and the
+        in-flight swirl.
+      nudge: (_chat_ident(STATE/auto-nudge.json), _chat_ident(STATE/nudge-events.jsonl)), board-wide.
+        _auto_nudge_data()["nudged"][nid], _nudge_times()[nid].
+      jauth: jd._auth_down_map()[fsid] as sorted items, or None. The judge-auth floor and badge.
+      jactive: fsid in {r["fsid"] for r in jd.active_runs()}. The Analyzing swirl's active prong.
+      hide: _session_flag(fsid, "hideFromFeed"). The session yields no entry while set.
+      watch: json of _watch_awaiting(fsid) (the in-memory watches for this sid). An awaiting source.
+      subagents: _chat_ident of the transcript's subagents directory and every directory under it. _subagent_meta_map.
+      usage: _chat_ident(STATE/usage.json) when the previous entry recorded reading it (an api error's cap offer,
+        _cap_switch_offer), else None. A deps component.
+      auth: _auth_key_present(). The cap offer's key-on-hand leg.
+      downtime: (len(_downtime), its last span). _session_working's host-suspension read (_suspended_after).
+      debug: (jd._debug_mode(), _chat_ident(STATE/judge-errors.jsonl) when on). dbg_rows → _card_warn_rows.
+      interrupting: _interrupting(fsid, ps or {}, now, tm), computed here (the stamp's 120 s cap and its settle).
+      closer: _closer_pending(fsid, path, now, store) under the body's exact gate (live, warm parse, idle, no judge
+        call in flight), the settle gap the Analyzing swirl reads.
+      peers: ((peer sid, _feed_peer_facts(peer)) ...) for every peer the previous derivation read (origin senders
+        via jd.load_goals_shared_or_fault / _name_of / _name_color, handoff rows' _ho_sid, the identities
+        _handoff_peer_identities, _peer_identity and _handoff_card_fields resolved, the awaiting arm's peers);
+        None when cold. A deps component.
+    NOT components: the clock (the fold stamps trgb and a clock-stamped placeholder's t per build), the colormap (the
+    fold reads it), notify-cards.json (the post-loop notify pass), session-order, the views, the notices (post-loop)."""
+    fsid, path = s["sid"], s.get("path")
+    now, cleared = ctx["now"], ctx["cleared"]
+    live = tm is not None
+    hide = bool(_session_flag(fsid, "hideFromFeed"))
+    # ── file identities, every one BEFORE the reads below ──
+    transcript = _chat_ident(path) if path else None
+    states = tuple(_chat_ident(jd.STATESDIR / (k + ".jsonl"))
+                   for k in dict.fromkeys([fsid, str(s.get("anchor") or "")]) if k)
+    names = (s.get("name"), tuple(_names_parts(fsid) or ()))
+    captions = _chat_ident(jd.CAPDIR / (fsid + ".jsonl"))
+    sident = jd._store_identity(fsid)[1:]
+    with _goals_snap_lock:
+        _snap = _goals_snap[0]
+        snap_at = _goals_snap_at[0] if (_snap is not None and fsid in _snap) else None
+    _hold = _rewind_hold_get(fsid)
+    hold = (_hold.get("cutT"), _hold.get("leaf"), _hold.get("at")) if _hold else None
+    anchors = _node_anchor_rev.get(fsid, 0)
+    reg = (_chat_ident(jd.STATE / "sdk" / (fsid + ".json")), _chat_ident(jd.GONEDIR / (fsid + ".json")))
+    cl = tuple(sorted(i for i in cleared if i.startswith(fsid + ":")))
+    row = (tuple(sorted(((k, v) for k, v in tm.items() if k not in ("snapT", "interrupting")), key=lambda kv: kv[0]))
+           if tm else None)
+    postal = _chat_ident(jd.MESSAGES)
+    nudge = (_chat_ident(jd.STATE / "auto-nudge.json"), _chat_ident(jd.STATE / "nudge-events.jsonl"))
+    stalls = tuple(sorted((k, v.get("why"), v.get("since")) for k, v in ctx["stalls"].items()
+                          if k.startswith(fsid + ":")))
+    jauth = tuple(sorted((ctx["jauth_map"].get(fsid) or {}).items(), key=str)) or None
+    jactive = fsid in ctx["jactive"]
+    if path:
+        _sd = str(_subagents_dir(path))
+        subagents = tuple(_chat_ident(d) for d in (_subagent_dirs(_sd) or [_sd]))
+    else:
+        subagents = None
+    ctx["usage_ident"] = _chat_ident(jd.STATE / "usage.json")   # taken every build; keyed only when the entry read it
+    usage = ctx["usage_ident"] if ((prev_entry or {}).get("reads") or {}).get("usage") else None
+    auth = _auth_key_present()
+    downtime = (len(_downtime), _downtime[-1] if _downtime else None)
+    dbg = bool(jd._debug_mode())
+    debug = (dbg, _chat_ident(jd.ERRORS) if dbg else None)
+    facts = {p: _feed_peer_facts(p, cleared) for p in ((prev_entry or {}).get("peers") or ())}
+    ctx["peer_facts"] = facts                        # pre-derivation facts: _feed_key_with_deps keeps these for the peers
+    peers = tuple((p, facts[p]) for p in sorted(facts)) if prev_entry is not None else None   # the new entry names again
+    # ── the in-memory reads ──
+    be = Sessions.backend_for(fsid)
+    _be = _sdk()
+    cut = _be.pending_cut(fsid) if _be else ""
+    live_rev = Sessions.live_rev(fsid, be)
+    watch = json.dumps(_watch_awaiting(fsid), sort_keys=True, default=str)
+    ask = None
+    if (tm or {}).get("state") in _NEEDS_INPUT_STATES:
+        try:
+            ask = json.dumps(be.current_ask(fsid), sort_keys=True, default=str)
+        except Exception:
+            ask = None
+    wait = tuple(sorted((ctx["wmap"].get(fsid) or {}).items(), key=str)) or None
+    # ── the per-session facts the body reads through ctx, once per build (a hidden session reads none of them,
+    #    exactly as the loop's `continue` skipped them) ──
+    ps, st, who_working, interrupting, closer = None, None, False, False, False
+    if not hide:
+        ps = _parse_cached(s["path"]) if path else None   # CACHE-ONLY: the cards paint at once on a cold kernel (the user 2026-06-26)
+        if ps is not None:
+            ps = _merge_live_atoms(ps, fsid)         # the same LIVE-MERGED session the chat chip + timeline lane read
+        try:
+            who_working = _session_working(ps["turns"]) if ps else False
+        except Exception:
+            who_working = False
+        sess_interrupting = _interrupting(fsid, ps or {}, now, tm)   # pops its stamp on the settled path, once per build
+        interrupting = sess_interrupting
+        st = _feed_goals(fsid)                       # the store the body renders (None: the read faulted)
+        closer = bool(live and ps and not who_working and not jactive
+                      and _closer_pending(fsid, path, now, st if st is not None else {"nodes": {}, "status": {}}))
+    ctx.update(ps=ps, who_working=who_working, interrupting=interrupting, store=st, closer=closer, hide=hide)
+    # the store component closes on the READ's outcome (st is None: the read faulted, jd.load_goals_or_fault filed it):
+    # an EIO or a permissions fault moves no stat, so without the bit a faulted derivation (no cards) would serve
+    # on after the fault cleared, and a pre-fault entry would serve through it (tests/test_goal_store_fault_boundary)
+    store = (sident, snap_at, _user_goal_write.get(fsid, 0.0), _goals_snap_done.get(fsid), hold,
+             st is None and not hide)                # a hidden session's skipped read is not a fault
+    bg = (tuple((r.get("tid"), r.get("desc"), r.get("t"), r.get("type"), r.get("deadline"), r.get("agentId"))
+                for r in _bg_live_norm(fsid, path)) if (ps is not None and path) else None)
+    return (transcript, ps is not None, cut, states, names, captions, store, anchors, reg, cl, row, ask, live_rev,
+            bg, wait, postal, stalls, nudge, jauth, jactive, hide, watch, subagents, usage, auth, downtime, debug,
+            interrupting, closer, peers)
+
+
+_FEED_PEERS_UNSETTLED = ("unsettled",)           # a `peers` component no build's key can equal (the builder makes None or
+#                                                  a tuple of (peer, facts) pairs): stored when a peer was read before its facts
+
+
+def _feed_key_with_deps(key, ctx, entry):
+    """The key with its two dependency components re-evaluated over the entry a derivation just produced: `usage`
+    from the entry's `reads`, `peers` from the entry's `peers`, each peer's facts the PRE-derivation ones the key
+    took when the previous entry already named that peer. A peer this derivation read for the FIRST time has no
+    pre-derivation facts, and facts taken now could pair a new key with old content (the peer's store moving while
+    the body read it, the order stat-then-read forbids), so the stored key carries _FEED_PEERS_UNSETTLED instead:
+    the next build re-derives once more, this time with every peer's facts taken before the read, and hits from
+    then on. One extra derivation the first time a session's cards name a new peer, never a stale hit."""
+    k = list(key)
+    reads = (entry or {}).get("reads") or {}
+    k[_FEED_MEMO_LABELS.index("usage")] = ctx.get("usage_ident") if reads.get("usage") else None
+    if entry is None:
+        peers = None
+    else:
+        facts = ctx.get("peer_facts") or {}
+        named = sorted(entry.get("peers") or ())
+        peers = tuple((p, facts[p]) for p in named) if all(p in facts for p in named) else _FEED_PEERS_UNSETTLED
+    k[_FEED_MEMO_LABELS.index("peers")] = peers
+    return tuple(k)
+
+
+def _feed_session_entry(s, ctx):
+    """ONE session's contribution to the feed, derived from its inputs alone: the body of build_feed's per-session
+    loop (T368), memoized per session by build_feed under _feed_session_key. Returns a JSON-able dict, or None for a
+    session muted from the feed (hideFromFeed):
+      asks          its cards, in board order, each carrying "_ageT" (the epoch its age tint is computed from; None
+                    for a placeholder whose time IS the build's clock) and no trgb: the fold stamps the tint per build
+                    (_feed_fold_card), so the memoized entry holds nothing clock-derived
+      working       the session's name when its turn is open (the working-dot list), else None
+      awaiting      the session's name when it is idle and awaiting (the await-green dot list), else None
+      bgServices    the live judge-classified SERVICE descriptions for the session chip, else None
+      servingFolds  [{"tracker", "card"}]: worker mirror cards awaiting the post-loop fold under the sender's row
+      heal, hidden  the session-started tops nested / hidden this derivation (T319 / T333 counts)
+      cold          True when the session is living, unparsed and worth warming (_warm_fleet_bg)
+      peers         the peer sids this derivation read (origin senders, handoff recipients, stamped and awaited
+                    peers): the key's `peers` dependency component re-evaluates them next build
+      reads         {"usage": True} when the derivation read usage.json (an api error's cap offer): the key's `usage`
+    `ctx` carries the build's cross-session reads (now, live_map, cleared, dbg_rows, wmap, stalls, jauth_map,
+    jactive) and the per-session facts the key already computed (ps, who_working, interrupting, store, closer):
+    the body reads those from ctx and nothing twice. Every helper this body calls is covered by a component of
+    _feed_session_key (its docstring maps them); tests/test_feed_memo_inputs.py pins that mapping against this
+    function's source."""
+    now, live_map, cleared, dbg_rows = ctx["now"], ctx["live_map"], ctx["cleared"], ctx["dbg_rows"]
+    wmap, _stalls, _jauth_map, _jactive = ctx["wmap"], ctx["stalls"], ctx["jauth_map"], ctx["jactive"]
+    ent_asks, ent_folds = [], []                     # the entry's cards and serving-fold candidates
+    ent_working = ent_awaiting = ent_bg = None       # the dot names and the service chip
+    heal_total = hidden_total = 0                    # T319 / T333 counts, summed by the caller
+    cold_parse = False                               # a living session not yet parsed → the caller warms it
+    peers_read, reads = set(), {}                    # the dependency record (see the docstring)
+
+    def _note_peers(idents):                         # identity dicts ({name, host, sid, color}) or bare sids
+        for d in idents or ():
+            p = d.get("sid") if isinstance(d, dict) else d
+            if p:
+                peers_read.add(str(p))
+    fsid, name = s["sid"], s["name"]
+    if _session_flag(fsid, "hideFromFeed"):      # muted from the feed (the user 2026-06-19) → timeline-only
+        return None                              # (the key's `hide` component; the caller memoizes the None)
+    color = _name_color(fsid)
+    tm = live_map.get(fsid); live = tm is not None
+    # CACHE-ONLY parse (the user 2026-06-26): the CARDS come from the goal store (cheap) and must paint at
+    # once on a cold start, so the working-dot + the deep-link anchors read the parse ONLY if it's already
+    # cached — never paying the ~1s cold parse here. _warm_fleet_bg fills the cache + re-pushes; the dots
+    # and anchors snap in a beat later.
+    ps = ctx["ps"]                               # _parse_cached, live-merged (_merge_live_atoms): read ONCE per build by
+    #                                              _feed_session_key, hit or miss, so the merge's prune/settle side effects
+    #                                              and the interrupt stamp's pop run every build as they always did
+    if ps is None:
+        if _warm_wanted(s, tm):                      # cold by design otherwise (T323 stage 1): no warm to chase
+            cold_parse = True
+    who_working = ctx["who_working"]             # WORKING from the EVENT MODEL (_session_working over the open turn), not
+    #                                              the row's state: the key computed it for the closer gate; one dot signal
+    if who_working:
+        ent_working = name
+    # the open turn's live narration (the user 2026-08-13) — computed once per session, ridden by
+    # every working card below; cache-warm like the dot (a cold start paints plain, then snaps in)
+    sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None
+    # The card-floor disposition (the user 2026-08-14: NO working card is ever mute — even unknown
+    # shows as such): "open" = a turn is running (the narration above rides when parsed), "quiet" =
+    # parsed and between turns, "unknown" = no parse to read (a cold cache, or a machine that isn't
+    # reporting). The feed's spin ladder renders a floor line for each — see spin-caption.ts.
+    sess_state = "open" if who_working else ("quiet" if ps else "unknown")
+    # The user's LAST action on this session was an INTERRUPT (no message from them since): its quiet
+    # is user-chosen, not a stall — auto-nudge is suppressed (same predicate, _auto_nudge_tick) and
+    # the working card wears an "interrupted" badge saying so (the user 2026-07-05). Cache-only,
+    # like the working dot: the badge snaps in once _warm_fleet_bg fills the parse. The read is memoized
+    # on that cache object's identity (_interrupt_marks, the "display" family), so an unchanged parse
+    # costs no scan per build.
+    try:
+        sess_interrupted = bool(ps) and not who_working and \
+            _interrupt_suppresses_nudge(ps["turns"], fsid, family="display")
+    except Exception:
+        sess_interrupted = False
+    # A user interrupt still IN FLIGHT (dispatched, not yet settled): the card wears a steady
+    # "interrupting…" badge from the click until it settles, THEN falls to the past-tense "interrupted"
+    # badge — never flickering between "working" and "interrupted" while the SDK live-tail retires mid-
+    # settle (the user 2026-07-07). Same derivation as the chat chip + timeline lane (_interrupting):
+    # SDK's own in-flight flag for SDK sessions, the stop record for a row without it. Safe to call again in this push.
+    sess_interrupting = ctx["interrupting"]      # _interrupting(fsid, ps or {}, now, tm), computed in the key (a clock
+    #                                              crossing moves the key; its stamp pop runs once per build, as before)
+    # An api-retry storm INSIDE an open turn (the user 2026-07-09): the live backend state says
+    # "retrying" → the working card wears a "retrying since HH:MM" chip. The API-error badge below
+    # (aerr) only fires once the session is idle-stalled, so without this a storm reads as plain
+    # healthy Working for its whole life — nimbus's card said Working through an ~80-minute storm.
+    sess_retrying = _session_retrying(fsid, tm)
+    store = ctx["store"]                     # _feed_goals(fsid), read once in the key: a pre-pass snapshot while a judge
+    #                                          pass is mid-flight → the card's
+                                             # status never shows a half-applied intermediate (atomic visibility)
+    store_faulted = store is None            # this session's store could not be READ (EACCES, EIO, a directory
+    if store_faulted:                        # at the path): its row is filed (jd.load_goals_or_fault) and THIS
+        store = {"nodes": {}, "status": {}}  # session renders with no goal-derived content — no cards (so no
+        #                                      floors and no swirl, which land only on cards) and nothing
+        #                                      inferred from the absence (the provisional card is gated on the
+        #                                      flag below). A render-only stand-in, never saved. Every other
+        #                                      session is untouched; before this, one such file aborted the
+        #                                      whole build.
+    # ANALYZING (the user 2026-07-13; broadened 2026-08-12): the card must say when romp is working
+    # on it. Two prongs, either lights the swirl:
+    #   * the SETTLE GAP — the turn just settled but the closer hasn't delivered its verdict yet
+    #     (cache-warm only: it needs the parse; the swirl snaps in after _warm_fleet_bg);
+    #   * a judge call for this session ACTUALLY IN FLIGHT — jd.active_runs(), the same in-process
+    #     registry the nudge gate trusts (_revivers_pending), whose comment always claimed "the
+    #     Analyzing… swirl already says so"; now it does. This is what a backlog drain looks like:
+    #     when the judge-auth outage healed, 201 calls swept an 18-hour backlog while every card
+    #     sat inertly in Working (the user 2026-08-12, who asked for the queue to be visible on
+    #     the card) — planner/grouper work on OLDER turns never trips the settle gap, and a fresh
+    #     kernel's caches are cold exactly when the drain runs, so the closer prong alone stayed
+    #     dark. The active prong deliberately needs neither `live` nor a warm parse: the registry
+    #     is an in-process fact, free to read.
+    # Session-scoped (we don't know WHICH goal a verdict will land on until it does); each working
+    # card wears the Analyzing… swirl meanwhile (feed.ts spinCaption).
+    sess_judging = bool(not who_working and (fsid in _jactive or ctx["closer"]))   # closer = the key's
+    #                                          _closer_pending(fsid, path, now, store) under the same live/parse/idle gate
+    nodes, status = store.get("nodes", {}), store.get("status", {})
+    confirming = set(store.get("confirming") or ())   # rollup export: done verdict in, settle pending (judge rollup_status, the user 2026-07-24)
+    # Exact click-to-jump anchors: map each goal segment → the work/reply uuid — the SAME anchors the
+    # timeline/ledger already use — so a card click deep-links to the precise turn BY ID instead of the
+    # old time-nearest heuristic. _parse is cache-backed (cheap); reply uuid preferred (the readable
+    # assistant text). A missing entry → anchorUuid None → feed falls back to time. (the user 2026-06-17.)
+    # seg_uuid → the WORK anchor (reply/work assistant atom, for the mark/time zones); seg_trig → the
+    # PROMPT anchor (the segment's TRIGGER atom = the user's message that opened it, for the TITLE). A
+    # title is prompt-intent and must land on the USER turn — passing the trigger uuid (which the chat
+    # tags + the kind guard accepts as turn-user) lets it resolve BY ID instead of a kind-restricted
+    # nearest-time landing (the user 2026-06-17). (Both are emitted .turn[data-uuid]s in the chat.)
+    seg_uuid, seg_trig, seg_best, cite_uuids = {}, {}, {}, set()
+    try:
+        for turn in (ps["turns"] if ps else []):     # cached parse only; anchors fill in after _warm_fleet_bg
+            for seg in _segs_seam(turn, store):
+                w, r = _seg_anchors(seg["atoms"])
+                seg_uuid[_seg_key(seg["id"])] = r or _seg_jump(seg["atoms"])   # timestamp-invariant key; landable
+                #                                  anchors only — never a thinking-only uuid (SDK echo/real drift)
+                seg_trig[_seg_key(seg["id"])] = jd._prompt_anchor_uuid(seg)   # attachment-safe: a
+                #                                  title click must land on the USER message, never an
+                #                                  attachment record no chat event carries (2026-08-25)
+                _lu, _lsub = _seg_last_text(seg["atoms"])
+                seg_best[_seg_key(seg["id"])] = (_lu, _lsub, seg.get("t", 0))   # latest prose → summary deep-link fallback
+                pcs_ = em.turn_scalar(turn, "pcs")
+                if pcs_ is not None:                 # a restored pre-cut turn: its stored prose chars, no atom built (T358)
+                    cite_uuids.update(u_ for u_, n_ in pcs_.items() if n_ >= jd.CITE_MIN_CHARS)
+                    continue
+                for _a in seg["atoms"]:              # citable-uuid set: gates the distiller's CITED anchor.
+                    # Resolvable in THIS parse AND substantive (the user 2026-07-14): a stored citation
+                    # pointing at a connective stub (a lead-in that merely names the goal) is a wrong
+                    # link by construction — the outcome never lives there — so it falls through to the
+                    # deterministic fallback below, healing bad anchors already in stores at read time.
+                    if _a.get("uuid") and _atom_prose_chars(_a) >= jd.CITE_MIN_CHARS:
+                        cite_uuids.add(_a["uuid"])
+    except Exception:
+        pass
+    healed = _heal_session_tops(s.get("path"), nodes, status)   # T319: machine-rooted tops nest (read-side)
+    heal_total += sum(1 for v in healed.values() if v[0])
+    _hidden = {k for k, v in healed.items() if v[1].get("hidden")}   # T333: rooted in a skill the harness loaded, no
+    hidden_total += len(_hidden)                                     #   request in the store to sit under: no card
+    children = {}
+    for nid, nd in nodes.items():
+        if nid in _hidden:
+            continue                             # the session's own view keeps the work
+        _hp = healed.get(nid)
+        _pk = _hp[0] if (_hp and _hp[0]) else nd.get("parentId")
+        if _pk is not None and _pk not in nodes and isinstance(nd.get("born"), dict):
+            _pk = None                           # T319: a born step whose parent is gone renders as a root that says so
+        children.setdefault(_pk, []).append(nid)
+    agent_open = _agent_open_set(nodes, children)   # authoritative-open subtree → never rendered 'done' (see helper)
+    parked_rows = _parked_rows(nodes, children)     # leapfrogged open rows → the quiet "parked" row cue (see helper)
+
+    def _subtree(root):                          # all node ids at/under root (pre-order)
+        stack, acc = [root], []
+        while stack:
+            x = stack.pop(); acc.append(x); stack.extend(children.get(x, []))
+        return acc
+
+    # VERDICTS ONLY (the user 2026-07-15; roll-UP removed — it painted an authored-looking ✓ on a
+    # goal nobody ruled done, see build_session's _subtree_done twin): a node is "done" if it's
+    # explicitly nodeComplete (verdict or roll-down cache), OR if a done ancestor checks it off
+    # (roll-DOWN, threaded by flatten through ancestor_done — dimmed disc). All-children-done alone
+    # no longer checks a parent; the closer rules those (_subtree_done_candidates) and the check
+    # appears when its verdict lands.
+    _cdone = {}
+    def _closure_done(nid):
+        if nid in _cdone:
+            return _cdone[nid]
+        nd = nodes.get(nid)
+        if not nd:
+            _cdone[nid] = False
+            return False
+        res = bool(nd.get("nodeComplete"))
+        if not res and nd.get("umbrella"):         # ARCHIVED pre-T101 container — history renders
+            # structurally-complete (mints retired; live ones dissolve every rollup): the
+            kids = [c for c in children.get(nid, []) if not nodes[c].get("cleared")]
+            res = bool(kids) and all(_closure_done(c) for c in kids)
+        _cdone[nid] = res
+        return res
+
+    # Order children MOST-RECENT-FIRST by subtree-max mt — the SAME recency key the ledger tree uses
+    # (build_session _submax), so every goal-tree view reads newest-first: the card's inline sub-goal
+    # checklist, the modal tree, and the ledger TOC all agree (the user 2026-06-17). mt (last-touched)
+    # falls back to t for never-modified nodes.
+    _fsmemo = {}
+    def _fsubmax(cid):
+        if cid in _fsmemo:
+            return _fsmemo[cid]
+        cn = nodes.get(cid) or {}
+        m = cn.get("mt", cn.get("t", 0))
+        for k in children.get(cid, []):
+            m = max(m, _fsubmax(k))
+        _fsmemo[cid] = m
+        return m
+
+    # BLOCKED rolls UP the tree (the user 2026-07-11: nimbus's Needs-you traced to a block buried
+    # under a collapsed row — "shouldn't the block propagate up so I see it?"). Mirror of the judge's
+    # any_blocked: a node reads "question" when it — or any descendant chain not inside a completed
+    # subtree — holds an open block (a done subtree's block is moot, same short-circuit). This is
+    # also what the CLIENT was designed for: hasQuestionDescendant exists to find the LOWEST ? (the
+    # actual ask) beneath rolled-up ancestors.
+    _qmemo = {}
+    def _closure_blocked(nid):
+        if nid in _qmemo:
+            return _qmemo[nid]
+        nd = nodes.get(nid)
+        if not nd or nd.get("cleared") or (_closure_done(nid) and nid not in agent_open):
+            _qmemo[nid] = False
+            return False
+        res = bool(nd.get("blocked")) or any(_closure_blocked(c) for c in children.get(nid, []))
+        _qmemo[nid] = res
+        return res
+
+    # The rejudging latch's CLEAR bound (the user 2026-07-31): the block a top card surfaces may
+    # live on a DESCENDANT (blocked rolls up, _closure_blocked above), and the unblocker stamps
+    # blockCheckT on the node it EXAMINES — the blocked child — never on the top. The latch used
+    # to read the top's own watermark, which for a child-held block stays None forever: every
+    # plain reply dropped the card to Working (plain_user_t > 0 is always true) and every landing
+    # turn advanced disp_t past the reply and lifted it back to Needs-You — the same strobe the
+    # watermark bound fixed for top-level blocks (PR #144), reintroduced one level down. The
+    # audited card flipped seconds-apart pairs at every conversational turn for half an hour.
+    # The bound is therefore the OLDEST watermark among the subtree's OPEN blocked nodes (the
+    # exact closure _closure_blocked walks, same done/cleared gates): the card returns to
+    # Needs-You only once EVERY block it is surfacing has been re-examined with evidence
+    # covering the reply. None when the walk finds no open block (a stale rollup) — the caller
+    # falls back to the top's own watermark, the pre-existing semantics.
+    _bcmemo = {}
+    def _block_check_floor(nid):
+        if nid in _bcmemo:
+            return _bcmemo[nid]
+        nd = nodes.get(nid)
+        if not nd or nd.get("cleared") or (_closure_done(nid) and nid not in agent_open):
+            _bcmemo[nid] = None
+            return None
+        vals = [int(nd.get("blockCheckT") or 0)] if nd.get("blocked") else []
+        vals += [v for v in (_block_check_floor(c) for c in children.get(nid, [])) if v is not None]
+        res = min(vals) if vals else None
+        _bcmemo[nid] = res
+        return res
+
+    def flatten(nid, out, ancestor_done=False, boundary=None):  # AskTreeNode flat list, root first; nest via children ids
+        nd = nodes[nid]
+        kids = sorted(children.get(nid, []), key=_fsubmax, reverse=True)   # most-recent-first (matches the ledger)
+        explicit = bool(nd.get("nodeComplete"))
+        # AUTHORITATIVE-open override (the user 2026-07-01): an open agent to-do item — or an umbrella
+        # holding one — is NEVER done, even if a nodeComplete ancestor would roll 'done' down onto it.
+        # Mirrors the judge's rollup_status; without it the open item read 'done' → the "checked off" hover.
+        done = (explicit or _closure_done(nid) or ancestor_done) and nid not in agent_open
+        derived = done and not explicit            # roll-up / roll-down → DIMMED ✓ disc, not the full one
+        st = "done" if done else ("question" if _closure_blocked(nid) else "open")
+        # The node's deep-link target SEGMENT: its NEWEST trail seg — the resolve turn for
+        # done/blocked nodes, the latest activity for open ones (where it stands, not where born).
+        _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_uuid)
+        # A HANDOFF tracking node ("↪ delegated to <peer>") finally ships as its designed kind: the
+        # feed's delegations section (fask-delegations, built to the 2026-06-10 handoff spec) keys on
+        # kind "handoff" and had sat dormant because flatten hardcoded "ask" — the sender's card
+        # showed a bare text row with no recipient identity and no visible cross-card LINK (the user
+        # 2026-08-16, who watched a clear take the linked card with it and had no way to see why).
+        # who/whoSid/whoColor become the RECIPIENT's identity for these rows — exact, from the
+        # courier-recorded handoff.peer, never inferred.
+        _ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
+        _ho_sid = str(_ho.get("peer") or "") if _ho else ""
+        if _ho_sid:
+            peers_read.add(_ho_sid)              # a peer this row names (its registry entry is a dependency)
+        _born = nd.get("born") if isinstance(nd.get("born"), dict) else (healed.get(nid) or (None, None))[1]
+        out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
+                    "born": _born or None,   # T319: a step the session started on its own (why it sits here)
+                    "who": (_name_of(_ho_sid) or _ho_sid[:8]) if _ho_sid else name,
+                    "whoSid": _ho_sid or fsid,
+                    "whoColor": _name_color(_ho_sid) if _ho_sid else color,
+                    "whoWorking": who_working, "status": st, "derived": derived,
+                    # user-cleared sub (nodeOverride op:clear) → renders struck-through + faded with a
+                    # "cleared" chip; `status` above stays honest (box = done, the user 2026-07-26)
+                    "cleared": bool(nd.get("cleared")),
+                    # this DONE sub's outcome was already REVIEWED: its done predates the top's
+                    # review boundary (jd.review_boundary — the same boundary the distiller scopes
+                    # the takeaway with, so the fold and the summary can never disagree). The card
+                    # collapses these behind one "N reviewed earlier" row instead of re-presenting
+                    # them on every re-completion (the user 2026-08-19). `out` is empty only for
+                    # the ROOT row, which is the card head, never a checklist row.
+                    "reviewedEarlier": bool(boundary and out and done
+                                            and jd._done_since(nd) <= boundary) or None,
+                    # a rolled-UP question (the block lives in a descendant, not here) — the client's
+                    # mark tooltip says "blocked inside", and the actual ask keeps its own ⏸ below
+                    "qderived": st == "question" and not nd.get("blocked"),
+                    # LEAPFROGGED row (the user 2026-08-24): open, nothing filed under it, while N
+                    # younger siblings were dispatched past it — the quiet "parked" tag + the card's
+                    # dim sub-goals suffix. Gated on the OPEN render state so a rolled-down or
+                    # closed row can never wear it; mint/retire events live in _parked_rows.
+                    "parked": ({"n": parked_rows[nid]} if (st == "open" and nid in parked_rows) else None),
+                    # AUTHORITATIVE tier: this node mirrors an item on the agent's OWN to-do list, so its
+                    # open/done is agent-asserted (solidity = authority in the disc render). None = a plain
+                    # judge-inferred node. (the user 2026-07-01)
+                    "auth": (nd.get("agentTask") or {}).get("status"),
+                    # `last` drives each row's "(Xm ago)" age + recency tint: the node's LAST ACTIVITY
+                    # (newest mt in its subtree, _fsubmax), so a replied-to / re-touched node freshens in
+                    # the modal tree just as its card does — not pinned to the mint `t` (the user
+                    # 2026-07-01). `t` stays the mint time (the node's nav-time fallback).
+                    "t": nd["t"], "last": _fsubmax(nid),
+                    "_ageT": _fsubmax(nid),   # the epoch the row's recency tint is computed from; trgb itself is the FOLD's
+                    #                           (_feed_fold_card, per build), never the memoized entry's
+                    # mt = last-modified (the segment the planner applied done / block) → a blocked or
+                    # done node deep-links to WHERE IT RESOLVED, not where it was minted. Falls back to
+                    # t for never-modified nodes (open work, derived done). (the user 2026-06-16.)
+                    "mt": nd.get("mt", nd["t"]),
+                    # anchorUuid = the WORK anchor (reply assistant atom of the resolve/mint segment) →
+                    # the mark/time zones deep-link here. promptAnchorUuid = the PROMPT anchor (the
+                    # MINTING segment's trigger = the user's message) → the TITLE deep-links here, by id,
+                    # landing on the user turn (no kind-restricted nearest-time needed). (2026-06-17.)
+                    "anchorUuid": _wa,
+                    "promptAnchorUuid": _pa,
+                    "summary": nd.get("summary"),                   # distiller's key takeaway — shown in the MODAL only — the user 2026-06-17
+                    "blockSummary": nd.get("blockSummary"),         # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18
+                    "relayNote": nd.get("relayCarried") or None,    # a far host still holds a relayed question after its wait ended (relayCarried): its own line under the brief, never a brief paragraph (briefParts maps those)
+                    "followupPending": nd.get("followupPending"),   # per-node "Followed up" chip in the modal tree (business 2026-06-17)
+                    # the per-item story (MODAL, non-done only): newest block/unblock/verdict rows with
+                    # anchors, so an open sub answers 'is this still active?' in place (the user 2026-07-20)
+                    "log": _node_log_rows(nd, seg_uuid) if st != "done" else None,
+                    "children": kids})
+        for c in kids:
+            flatten(c, out, ancestor_done=done, boundary=boundary)
+        return out
+    # HARD blocked floor: a session stopped RIGHT NOW on a live permission prompt (the live row's state)
+    # floors its ACTIVE-FOCUS card under BLOCKED — the strongest signal, beats the goal's planner
+    # status. (The planner's SOFT block, nd["blocked"], is the model's "needs user" verdict; this is
+    # the live event.) Gated on the ROLLED-UP status, NOT the raw nodeComplete flag: a focus that is
+    # nodeComplete but the settled gate still holds at "working" (the session marked it done, then kept
+    # working under it and live-blocked) IS floored — so a live block always surfaces; only a genuinely
+    # settled "completed" (or user-"cleared") card is left alone, its block being for new, not-yet-placed
+    # work. (the user 2026-06-18: a live-blocked nodeComplete-but-working focus wasn't reaching BLOCKED.)
+    perm_top = None
+    perm_state = tm.get("state") if tm else None
+    if perm_state in _NEEDS_INPUT_STATES:               # live prompt (permission Allow/Deny OR a picker)
+        f = store.get("lastNode")
+        while f and nodes.get(f, {}).get("parentId") is not None:
+            f = nodes[f]["parentId"]
+        if f in nodes and status.get(f) not in ("completed", "cleared"):
+            perm_top = f
+    # AWAITING signal (event-model, the user 2026-06-22): the session is paused on AGENT work it
+    # dispatched — a WORKING flavor, never needs-input. Sourced from the live subagent snapshot, the
+    # PENDING background tasks (launch not yet judge-placed; a placed launch's story belongs to the
+    # judge's stamp or the service chip — see _session_awaiting/_bg_split), or the SDK producer's
+    # states overlay; None when actively working.
+    # Computed BEFORE the API-error floor, which must yield to it (the user 2026-07-05).
+    _sess_aw = _session_awaiting(fsid, s["path"], not who_working) if ps else None   # cache-only: fills in after the warm
+    sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
+    sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
+    sess_awaiting_since = _sess_aw.get("since") if _sess_aw else None   # the wait's own event time (the user 2026-08-23)
+    sess_awaiting_count = _sess_aw.get("count") if _sess_aw else None   # how many are awaited — the pill's word agrees in number (T225)
+    sess_awaiting_peers = _sess_aw.get("peers") if _sess_aw else None   # named identities when the arm knows them (2026-08-26)
+    _note_peers(sess_awaiting_peers)
+    sess_awaiting_items = list(_sess_aw.get("items") or []) if _sess_aw else []   # the awaited rows (slice 2) — the pill lists them grouped
+    if sess_awaiting_why and not who_working:
+        ent_awaiting = name                      # the AWAITING dot list (await-green, the user 2026-07-13) — the
+        #                                          same split _session_chip makes; feed/chat dots match the chip
+    # API-error floor: a session stopped on an API error (transcript isApiErrorMessage, event-based)
+    # floors its focus top-goal under BLOCKED with an apiError reason → the feed card shows a red
+    # "API error" badge + a Retry button (the user 2026-06-16). Same focus-goal walk as the perm floor.
+    # GATED on awaiting, like _session_chip (4699) and build_session (5512) — this was the ONE ungated
+    # _api_error read (the user 2026-07-05, jld_audit): a main thread erroring BETWEEN agent waits is
+    # still IN MOTION, but the raw floor made the feed card wear red "API error" + "stalled" while the
+    # chat chip said Working — and api_top then suppressed the very awaiting flip that would have told
+    # the truth. One formula, one truth: awaiting wins; the floor applies only to a session truly dead
+    # in the water.
+    aerr = _api_error(s["path"]) if (ps and not who_working and not sess_awaiting_why) else None   # cache-only: fills in after the warm
+    _cap_off = _cap_switch_offer(fsid, aerr) if aerr else None   # the billing-switch OFFER (never a silent switch, 2026-08-30)
+    if aerr:
+        reads["usage"] = True                    # the offer reads usage.json: the key's `usage` component rides this record
+    api_top = None
+    if aerr:
+        f = store.get("lastNode")
+        while f and nodes.get(f, {}).get("parentId") is not None:
+            f = nodes[f]["parentId"]
+        if f in nodes and status.get(f) not in ("completed", "cleared"):   # rollup status, not raw nodeComplete (see perm floor)
+            api_top = f
+    # JUDGE-AUTH floor (the user 2026-08-12): this session's judges are failing on their CREDENTIAL
+    # (judge.py latched a credential-class error envelope; its next successful call clears it) — romp
+    # cannot analyze the session, so no card here can move on its own, and only the user can fix it
+    # (the key, the login, or the session's billing pick). Floor the focus top to needs-you wearing
+    # the story: the alternative was a board silently frozen in Working, which is exactly how a
+    # login-less host spent 13 hours and ~53k refused calls without a pixel changing. Yields to the
+    # LIVE floors (a permission prompt, the session's own API error): one interrupt at a time, the
+    # present event first — and the api floor's authErr copy already names the same credential fix.
+    jerr = _jauth_map.get(fsid)
+    jauth_top = None
+    if jerr and api_top is None and perm_top is None:
+        f = store.get("lastNode")
+        while f and nodes.get(f, {}).get("parentId") is not None:
+            f = nodes[f]["parentId"]
+        if f in nodes and status.get(f) not in ("completed", "cleared"):
+            jauth_top = f
+    _unnested = False
+    for _f in (perm_top, api_top, jauth_top):    # T319: a floor that RESOLVES to a healed top un-nests exactly that top:
+        _h = healed.get(_f) if _f else None      #   it keeps its card (the floor keys the card on it) and its face; the
+        if _h and _h[0] and _f in children.get(_h[0], []):   #   host's other rows are untouched
+            children[_h[0]].remove(_f)
+            children.setdefault(None, []).append(_f)
+            healed[_f] = (None, _h[1])
+            heal_total -= 1
+            _unnested = True
+        elif _h and _h[1].get("hidden") and _f in _hidden:   # T333: a hidden top the floor keys on comes back as a card
+            children.setdefault(None, []).append(_f)
+            healed[_f] = (None, {k: v for k, v in _h[1].items() if k != "hidden"})
+            _hidden.discard(_f)
+            hidden_total -= 1
+            _unnested = True
+    if _unnested:                                # the derivations below read the tree the card SHOWS (item 8 of the
+        agent_open = _agent_open_set(nodes, children)   #   fourth review): recomputed over the un-nested layout
+        parked_rows = _parked_rows(nodes, children)
+    plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
+    had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
+    had_awaiting = False                         # …and does any of them read AWAITING? → the session's await-green dot (below)
+    # The live background-task set, once per session: OWNERSHIP for the blocked-yield below (any live
+    # task counts there — the yield keys on the dispatch event, not on classification), and the
+    # judge-classified SERVICES for the neutral per-session chip (the user 2026-07-24). Idle-gated
+    # like the awaiting signal: an actively producing turn is just working.
+    live_tasks = _bg_live_norm(fsid, s["path"]) if (ps and not who_working) else []
+    owned = _bg_owner_tops(fsid, s["path"], live_tasks) if live_tasks else {}
+    if live_tasks and live:
+        svc = _bg_service_descs(fsid, s["path"])
+        if svc:
+            ent_bg = svc
+    for nid in children.get(None, []):
+        col = status.get(nid, "working")
+        if col == "cleared" or nid in cleared:
+            continue
+        if _pure_delegation_top(nodes, nid, sid=fsid, path=s["path"]):   # whole top is just peer
+            continue                                 # handoffs → coordination, not an inbox card
+        # AWAITING floor (event-based, the user 2026-06-22): a session paused on dispatched/delegated
+        # work is a WORKING flavor, never needs-input. Floor a working OR stale-blocked top to awaiting
+        # from (a) the session-level awaiting signal (live subagents / SDK states overlay),
+        # or (b) an unanswered outbound to a LIVE peer (postal wait-for — a stale block on a peer-waiting
+        # session yields to it). The live permission / API-error floors still win (the present event).
+        # the peer-wait only applies to a goal that EXISTED when the question was sent — a goal minted
+        # AFTER it can't be awaiting that answer (the user 2026-06-28). Scopes the stale session-level
+        # wait off unrelated newer goals; if every pre-question goal is resolved, nothing floors.
+        _peer_wait = (fsid in wmap and nodes[nid]["t"] <= wmap[fsid]["since"])
+        # A blocked top yields ONLY to a background task ITS OWN subtree dispatched, and only when
+        # that dispatch is NEWER than the block's own evidence. Two guards, both exact:
+        #  - OWNERSHIP (the user 2026-07-17, quartz): the 07-15 time-only guard compared the
+        #    session-wide newest dispatch — a campaign watcher relaunched after a kernel restart
+        #    (89s after an UNRELATED card's block) re-dressed a genuine needs-you as the await-green
+        #    awaiting badge. _bg_owner_tops resolves each live task's launch to its placed top;
+        #    a task owned elsewhere — or one whose launch can't be attributed (subagents, the
+        #    overlay, an unplaced launch) — never flips a blocked card. Genuinely stale blocks are
+        #    retired by the judge's own unblock path (new work filed on this branch), which is
+        #    placement-exact; this floor no longer approximates it session-wide.
+        #  - EVENT ORDER (the user 2026-07-15): even an owned task yields only when dispatched at/
+        #    after the block — an ask newer than the dispatch is live (nimbus ended its turn asking
+        #    the user questions while its own background timer ran).
+        _await_ok = bool(sess_awaiting_why)
+        _owned_why = None
+        _owned_since = None
+        if col == "blocked":
+            _blk_t = max([nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid)
+                          if nodes[x].get("blocked") and not _closure_done(x)] or [0])
+            _own = owned.get(nid)
+            # The yield stands on ownership + event order ALONE (no session-awaiting gate): under the
+            # service split, a placed launch no longer feeds sess_awaiting_why, but a dispatch from
+            # the blocked card's own thread still proves the thread moved past the block.
+            _await_ok = bool(_own) and _own["since"] >= _blk_t
+            if _await_ok:
+                _owned_why = "waiting on a background command%s" % (   # the chip's word for in-harness work (2026-09-05)
+                    (": " + _own["descs"][0]) if _own["descs"] else "")
+                _owned_since = _own["since"]           # the dispatch event that proved the yield
+        # The JUDGE's durable ⏳ stamp (the closer's awaiting verdict, kernel/judge.py): this goal's
+        # latest audited turn ended waiting on async work it set in motion. Store-backed, so it holds
+        # across kernel restarts — exactly where the live snapshot signals above go dark and a
+        # genuinely-waiting goal used to read as plain working, then "stalled". It floors WORKING
+        # only: a real needs-you (block) always outranks the annotation.
+        _sf = (_goal_awaiting_stamp_full(nodes, nid, children, answered_at=_peer_answered(fsid))
+               if col == "working" else None)
+        _stamp_why = _sf[1] if _sf else None
+        _stamp_kind = _sf[2] if _sf else None
+        _stamp_since = (_sf[0] or None) if _sf else None   # the stamp's awaitingAt — when the judge filed the wait
+        # the stamp arm NAMES its peers too (2026-08-26): the judge's awaitPeers keys resolve through
+        # the one identity ladder, so a judge-classified peer wait wears the same identity chips the
+        # delegation arm always has — before this the or-chain hardcoded peers=None on this arm
+        _stamp_peers = (sorted((_peer_identity(p) for p in _sf[3]), key=lambda d_: d_["name"])
+                        if _sf and _stamp_kind == "peer" and _sf[3] else None)
+        _note_peers(_stamp_peers)
+        # DELEGATION-derived awaiting (the courier's durable handoff graph, not the question-regex):
+        # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
+        # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
+        # as "this session should be doing something"). Ends on the graph's own event: run_propagate
+        # checks the handoff off the moment the peer's linked goal completes. The session-scoped
+        # surfaces (rail/chat/timeline) read the SAME evidence via _session_delegated_why in
+        # _session_awaiting's stamp branch — keep the two in step (the user 2026-08-08).
+        _deleg_why = None
+        _deleg_since = None
+        _deleg_peers = None
+        if col == "working" and not _stamp_why and not _await_ok \
+                and _all_outstanding_delegated(nodes, nid):
+            # the SAME open test the gate used (2026-08-26): _all_outstanding_delegated proved every
+            # OPEN LEAF is a handoff via _open_leaves (whose agent-open pierce ignores a done marker),
+            # so the peers/since read here must walk the same set — the raw nodeComplete filter this
+            # replaces could see an EMPTY set the gate saw as non-empty, minting a nameless, durationless
+            # "delegated to a peer" card
+            _hnodes = [x for x in _open_leaves(nodes, nid)
+                       if isinstance(nodes[x].get("handoff"), dict)]
+            _deleg_peers = _handoff_peer_identities(nodes, _hnodes)
+            _note_peers(_deleg_peers)
+            _peers = sorted({d["name"] for d in (_deleg_peers or [])} or {"a peer"})
+            _deleg_why = "delegated to %s; waiting on their result" % ", ".join(_peers)
+            # the newest outstanding handoff's mint — the last local act before the wait began
+            _deleg_since = max([nodes[x].get("t") or 0 for x in _hnodes] or [0]) or None
+        if nid != api_top and nid != perm_top and col in ("working", "blocked") and (
+                _await_ok or _stamp_why or _deleg_why or (col == "blocked" and _peer_wait)):
+            col = "awaiting"
+        # TRACKED delegation payloads (the user 2026-08-24): a report-back handoff renders as ONE
+        # card homed under the DELEGATOR. The sender's card is the PRIMARY — delegTracked names
+        # the recipient identities so the feed shows their live status right on it — and the
+        # recipient's planted copy is the SATELLITE (origin.tracked below) the feed collapses
+        # off the default board, still one click away via that session's own views (nothing runs
+        # in secret, 2026-08-11). Both keys ship only when present, so every untracked payload
+        # is byte-identical to before. The pair link stays the courier's msgId graph: clears and
+        # run_propagate cross it unchanged.
+        _tracked_hn = [x for x in _subtree(nid)
+                       if isinstance(nodes[x].get("handoff"), dict) and nodes[x]["handoff"].get("tracked")
+                       and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
+        _tracked_peers = (_handoff_peer_identities(nodes, _tracked_hn) or None) if _tracked_hn else None
+        _note_peers(_tracked_peers)
+        o = nodes[nid].get("origin")             # courier delegation provenance: planted by a peer
+        origin = None
+        if isinstance(o, dict) and o.get("peer"):
+            # The "↪ from <peer>" badge is PROVENANCE and stays for the card's life (the user
+            # 2026-08-16: the badge used to vanish at the exact moment the recipient finished —
+            # run_propagate completes the sender's tracking node instantly — so a COMPLETED card
+            # never showed where its work came from, and a propagated clear read as one card
+            # mysteriously taking another with it). origin_live says whether the sender's linked
+            # goal is still OPEN: live → the affordance of an active handoff; absorbed → the same
+            # badge, dimmed, purely historical. This is the completed-column MERGE, heuristic-free:
+            # the one surviving card wears both identities, keyed on the courier's recorded link.
+            # NAMED origin_live, never `live`: this block once reused the session-level `live` —
+            # the backend-alive bit set at the top of the session loop — so every LATER card of
+            # the session, and the placeholders built after the loop, wore the badge's bool: a
+            # live session's cards dressed .dead and took the revive path; a dead session's
+            # offered Continue. Badges persist for the card's life, so one absorbed badge
+            # poisoned the session's whole card tail.
+            psid, gid = o["peer"], o.get("goalId")
+            peers_read.add(str(psid))            # the sender's store and registry entry are dependencies of this card
+            pstore, pfault = jd.load_goals_shared_or_fault(psid) if gid else (None, None)   # read-only peer view
+            sgoal = pstore.get("nodes", {}).get(gid) if pstore is not None else None
+            origin_live = bool(sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared")
+                               and gid not in cleared)   # a sender whose store faults reads absorbed (dimmed,
+            #                                              no affordance) rather than aborting the build
+            # Name resolution: the live names registry first (a local sender may have been
+            # renamed), then the courier's plant-time snapshot (the only source for a
+            # FEDERATED sender, whose sid this kernel can't resolve), then the sid stub.
+            # peerHost renders as the same quiet "host:" prefix remote sessions wear on the
+            # timeline (host-prefix.ts) — a local resolve means a local sender, no host.
+            pname = _name_of(psid)
+            origin = {"peer": pname or o.get("peerName") or psid[:8],
+                      "peerHost": ("" if pname else o.get("peerHost") or ""),
+                      "peerSid": psid, "color": _name_color(psid), "live": origin_live}
+        # SENDER-SIDE handoff provenance (the user 2026-08-24): a TOP-LEVEL "↪ delegated to
+        # <peer>" tracking node wore its provenance as the card TITLE, arrow and all. The card
+        # now titles the WORK and ships the delegation as the badge mirroring origin above —
+        # see _handoff_card_fields. Every other card keeps its text untouched.
+        handoff_to, card_text = _handoff_card_fields(nodes, nid)
+        _note_peers([handoff_to] if handoff_to else None)
+        await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
+        await_kind = None                        # the winning why's KIND and SINCE ride beside it,
+        await_since = None                       # mirroring the or-chain exactly (a kindless winner
+        await_peers = None                       # stays kindless; since = the wait's own event time).
+        await_count = None                       # how many are awaited — the SAME number the chat chip words itself
+        await_items = []                         # the awaited ROWS the pill lists, grouped by kind (slice 2, 2026-09-05)
+        if col == "awaiting":                    # from (T228, the user's one-count rule): the live snapshot's own
+            # count, the peers a stamp or delegation names, one owned dispatch; None when the arm cannot know
+            for _w, _k, _s, _p, _n, _it in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count, sess_awaiting_items),
+                                            (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None), _awaiting_peer_items(_stamp_peers)),
+                                            (_deleg_why, "peer", _deleg_since, _deleg_peers, (len(_deleg_peers) if _deleg_peers else None), _awaiting_peer_items(_deleg_peers)),
+                                            (_owned_why, "task", _owned_since, None, 1, [])):
+                if _w:
+                    await_kind, await_since, await_peers, await_items = _k, _s, _p, _it
+                    await_count = _n if isinstance(_n, int) and _n > 0 else None
+                    break
+        # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
+        # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent
+        # such node in its subtree — else (working/awaiting) its LAST ACTIVITY (the newest mt anywhere in
+        # its subtree, _fsubmax). Keying the time badge to the mint `t` made a goal OPENED hours ago but
+        # FINISHED moments ago read as "done hours ago" (the user 2026-06-19); the same pin made a WORKING
+        # goal you JUST replied to still read "15m ago" instead of freshening — a reply advances the goal's
+        # mt, so the card must too (the user 2026-07-01). `created` keeps the true mint time for the record.
+        disp_t = _fsubmax(nid)
+        if col == "completed":
+            # A completed card's time is when the WORK finished / it SETTLED — NEVER a later re-judge that
+            # re-touches the UMBRELLA node's own mt without changing anything (the user 2026-07-08: an
+            # hours-old completed card jumped to "3m ago" after a no-op re-judge re-stamped the top node's
+            # mt; a re-materialize can advance mt even when nothing changed). So derive ONLY from stable
+            # evidence: the settle time + the done DESCENDANTS' completion mt — excluding the top node `nid`
+            # itself, whose (re-touchable) mt _fsubmax had already folded in.
+            dts = [nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid) if x != nid and _closure_done(x)]
+            # settledAt = when the card actually ENTERED the Completed column (the judge stamps it ONCE at
+            # settlement — NOT re-bumped by a no-op re-judge, verified stable while the umbrella mt drifted;
+            # it can lag the done op's mt by many segments). The column sorts by `t` oldest-at-top, so a
+            # just-settled card drops to the BOTTOM where the eye expects it, above older completions whose
+            # stale mt was even further back (the user 2026-06-29).
+            cand = max([nodes[nid].get("settledAt") or 0] + dts)   # settle time OR a real late-completing leaf
+            disp_t = cand or disp_t                                # both absent (legacy/childless) → keep _fsubmax
+        elif col == "blocked":
+            bts = [nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid)
+                   if nodes[x].get("blocked") and not _closure_done(x)]
+            if bts:
+                disp_t = max(bts)
+        # followupAt = when a follow-up OPTIMISTICALLY moved this card into Working (optimistic_followup
+        # stamps it at the flip). Same idea as the Completed column's settledAt: the column sorts
+        # oldest-at-top, so without this the card sorts by its stale blocked-era mt and appears at the TOP,
+        # then the judge re-files the real follow-up work (≈now) and it lurches to the BOTTOM. Flooring
+        # disp_t to now at the flip lands it at the bottom AT ONCE, where the re-file will keep it — no jump
+        # (the user 2026-07-03). Once real work lands, _fsubmax passes followupAt and this is moot.
+        if col == "working":
+            disp_t = max(disp_t, nodes[nid].get("followupAt") or 0)
+        # RE-CHECK (the user 2026-06-27): a SOFT-blocked top you've answered with a TARGETED card-reply/nudge
+        # (followupPending on the top — precise, only this card) is no longer on YOU. It de-urgents (dotted,
+        # dropped from the needs-you tally) and drops to WORKING until the judge resolves or re-blocks it.
+        recheck = bool(col == "blocked" and nid != api_top and nid != perm_top
+                       and nodes[nid].get("followupPending"))
+        # RE-JUDGING (the user 2026-06-30; MOVED to Working 2026-07-02): a PLAIN reply on the thread
+        # AFTER the block moves the card to WORKING — it's the agent's move now, and the delay before
+        # the card left Needs-You was the user's complaint (2026-07-02). The flag holds until the
+        # UNBLOCKER has re-examined the block with evidence covering the reply (blockCheckT, its
+        # persisted watermark, reaches the reply); then the card returns to Needs-You exactly once —
+        # or leaves authoritatively if the judge lifted the block. The "Re-judging…" swirl rides along
+        # in Working. Never the hard floors (api/permission).
+        #
+        # LATCHED ON THE WATERMARK, NOT THE OPEN TURN (the user 2026-07-29). The flag used to be
+        # bounded by who_working, which made a blocked card on an ACTIVE session strobe
+        # working↔needs-you at every turn boundary — the audited card flipped seven times in six
+        # minutes while nothing about it changed. The turn-bound was a proxy for "the judge hasn't
+        # ruled on the reply yet"; blockCheckT IS that event: the unblocker advances it on every
+        # examine AND on the parse give-up path, so the latch cannot stick past a judge look. This is
+        # the same trust the TARGETED-reply arm (followupPending) already places in the judge to
+        # clear its store-backed flag. Cards move on new information, never on activity boundaries.
+        #
+        # NO ECHO ARM (the user 2026-07-22): the flip used to ALSO ride the backend send-echo
+        # (echo_send_t), for a sub-second flip before the turn's atom lands in the cached parse. At the
+        # time a composer slash-command echo never retired (its transcript form is the "<command-name>"
+        # wrapper, which did not text-match the raw echo; since 2026-09-10 the echo lands under
+        # sb.command_text_key, see _echo_landed_in), and the parser skips it from the human floor, so
+        # the stale echo pinned rejudging TRUE forever: the card sat in Working, idle, invisible to the
+        # nudge (which reads the still-blocked store). The latch arms only off the PARSE's plain-reply
+        # turn (a real transcript atom, never the echo), and the watermark clear is judge-driven, so
+        # the stranded-echo failure stays impossible whatever an echo does.
+        # The watermark that bounds the latch is the one covering THE BLOCK THE CARD SURFACES —
+        # a descendant's, when the block rolled up (_block_check_floor above; the user 2026-07-31).
+        _bct = _block_check_floor(nid)
+        rejudging = bool(col == "blocked" and nid != api_top and nid != perm_top
+                         and not nodes[nid].get("followupPending")
+                         and plain_user_t > disp_t
+                         and plain_user_t > (_bct if _bct is not None
+                                             else (nodes[nid].get("blockCheckT") or 0)))
+        # awaiting is a flavor of WORKING → the working column (never needs-input), card time = mint t; the awaiting badge carries the why.
+        # A RE-CHECK'd soft-block (targeted follow-up) drops to WORKING (the user 2026-06-27): once you've
+        # replied to THAT card it's the agent's move, not yours, so it leaves the needs-input column entirely
+        # (still dotted + a "Re-judging…" swirl so you can see it pending). A plain reply (rejudging) now
+        # ALSO drops to Working — but only WHILE in flight (see the rejudging comment above).
+        # A TRANSIENT API error is NOT blocking either (the user 2026-06-29):
+        # auto-retry recovers it, so the card STAYS in Working with the "⚠ API error" chip. But a "prompt
+        # is too long" error IS on you (compact needed) → it floors to needs-input like a real block. So
+        # only api_top WHEN tooLong, or a genuine soft block (col blocked & not recheck), keeps needs_input.
+        # A MODEL-scoped usage limit joins them (the user 2026-08-01): the session cannot run another
+        # turn until you switch model or top up, so leaving the card in Working left a working card on
+        # a session nothing could move — not nudged (the api-error gate suppresses it), not blocked,
+        # not awaiting, for 80 minutes.
+        # A safeguards REFUSAL joins them (the user 2026-08-15): deterministic on the same input,
+        # never auto-retried, so a Working card would sit on a session nothing can move — the
+        # human rewriting or dropping the ask IS the only unblock.
+        api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")
+                                                      or aerr.get("modelLimit")
+                                                      or aerr.get("authErr") or aerr.get("refusal"))))
+        # NUDGE FAILED (plans/stalled-open-todos-nudge.md, the user 2026-07-01): the tick stamped
+        # `failed` on this goal's nudge record — the nudge-response turn completed (judged) and the goal
+        # was still working-stalled; per the anti-loop rule it is never re-nudged, so the card carries
+        # the story instead. Surfaced only while the goal still reads working (a later block/completion
+        # resolves it, and `awaiting` means it's genuinely in flight — no failure to show then). A FORK
+        # nudge (`stalled` — the goal had open authoritative to-dos) that failed additionally FLOORS the
+        # card to needs-you: the agent can't self-block a to-do, we asked once, nothing moved — the
+        # human is the bottleneck now. The floor keeps requiring open to-dos AT DISPLAY TIME (agent_open)
+        # so it self-heals the instant the agent crosses the items off; the live api/permission floors
+        # still win (the present event).
+        nrec = _auto_nudge_data().get("nudged", {}).get(nid) or {}
+        _stall_rec = _stalls.get(nid)             # romp is holding this card (see "stalled" in the payload)
+        # ROUTING (2026-08-13): an in-flight-class hold (jd.WHY_IN_FLIGHT — romp's own review is the
+        # wait) presents as the Analyzing… swirl, never the stalled chip; every other hold paints the
+        # Stalled section. The old screen hid the in-flight records from BOTH surfaces, so one frozen
+        # between retries showed nothing — now the sweep retires them on their events and whatever
+        # stands presents somewhere by definition.
+        _stall_inflight = bool(_stall_rec and _stall_rec.get("why") in jd.WHY_IN_FLIGHT)
+        if _stall_inflight:
+            _stall_rec = None
+        # HARD RULE (the user 2026-08-13): a stalled card on a session that isn't doing anything
+        # files under BLOCKED — it needs eyes, whoever's bottleneck it is; Working is where it hid.
+        # This supersedes the 2026-07-23 "Working column only" stance. Keyed on the stall RECORD
+        # (event-latched: minted by the walk, popped by the sweep) plus the session's idle read —
+        # the same displacement precedent as recheck/rejudging's de-urgent smoothing: the session
+        # taking a turn IS new information, and the card returns to Blocked if the hold outlives it.
+        _stall_block = bool(_stall_rec and not who_working and not sess_awaiting_why)
+        # the chip shows while the failure is the live story: the goal still working, OR blocked BY the
+        # failure itself (the diary's latest block has src "nudge", 2026-07-07). A real judge verdict
+        # (planner/closer block, or completion) takes the story over and the chip yields.
+        _lastblk = next((e.get("src") for e in reversed(nodes[nid].get("log") or [])
+                         if e.get("kind") == "block"), None)
+        # ...and "takes the story over" must survive the card going BACK to working (the user 2026-07-09:
+        # g143 wore "stalled" although the closer had ruled it done after the failed nudge and a later
+        # user follow-up reopened it). The `failed` flag only resets on the NEXT nudge fire, so the
+        # working arm alone would resurrect the chip forever. Event-based retire: any diary event from a
+        # real actor (planner/closer/courier/user/agent) AFTER the nudge's own block means the stall was
+        # answered — the chip yields for good, whatever column the card is in now.
+        _nlog = nodes[nid].get("log") or []
+        _nblk_at = next(((e.get("at") or e.get("ev_t") or 0) for e in reversed(_nlog)
+                         if e.get("kind") == "block" and e.get("src") == "nudge"), None)
+        # The row is the retire anchor, but it's also the write most exposed to a judge pass's
+        # stale save (g52, 2026-07-16: the planner's held-store save erased it while `failed`
+        # survived in auto-nudge.json — with _nblk_at None the chip could never retire, and it
+        # said "waiting on you" straight through the user's own follow-up). Fall back to the
+        # failure stamp's own time (failedAt, written with `failed`); a legacy record carrying
+        # neither retires on any user event at all — of the two failure modes, a false
+        # "waiting on you" is the one that breaks flow.
+        _nfloor = _nblk_at if _nblk_at is not None else nrec.get("failedAt")
+        # "unblocker" is a real actor here (the user 2026-08-14: its unblock ruled the nudge's
+        # block answered and moved the card back to Working, while the chip — whose claim IS that
+        # block — survived it, a red "waiting on you" on a card the judges had just un-waited)
+        _story_moved = (any((e.get("at") or e.get("ev_t") or 0) > _nfloor
+                            and e.get("src") in ("planner", "closer", "courier", "user", "agent",
+                                                 "unblocker")
+                            for e in _nlog) if _nfloor is not None
+                        else any(e.get("src") == "user" for e in _nlog))
+        nudge_failed = (bool(nrec.get("failed")) and not _story_moved
+                        and (col == "working" or (col == "blocked" and _lastblk == "nudge")))
+        # A live picker/permission floor (perm_top) is a GENUINE block, so the kernel reports its column as
+        # needs_input — NOT "working" with the client re-routing it by it.blocked (which was crafty + split
+        # the truth: build_feed said working while the card showed under Blocked, and the distiller line,
+        # keyed on it.column, then stayed hidden). Now it.column is authoritative: the card IS blocked, the
+        # client files by it.column, and the distiller line shows (the user 2026-06-29).
+        column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top or _stall_block
+                                    or (col == "blocked" and not recheck and not rejudging))
+                  else "completed" if col == "completed" else "working")
+        had_working = had_working or column == "working"
+        had_awaiting = had_awaiting or col == "awaiting"   # the FLAVOR, not the column: awaiting rides Working
+        # distillState (the user 2026-07-21): which distilled line the CARD should show — keyed on the
+        # GENUINE resolution state, NOT the transient `column`. recheck/rejudging drop a still-blocked
+        # card to Working the moment its session takes a turn (de-urgent smoothing), and `column`, keyed
+        # on that, flickered the decision brief OFF every time — so a busy session's blocked card read as
+        # "unblocked, no summary" (the docs thread). distillState rides the real block (api_block /
+        # perm_top / col=="blocked"), so the brief/takeaway stays put through the re-judge window; the
+        # column still moves for placement. Completed is stable (never recheck/rejudged), so it matches.
+        distill_state = ("completed" if col == "completed"
+                         else "blocked" if (api_block or nid == jauth_top or nid == perm_top
+                                            or col == "blocked")
+                         else None)
+        # summaryAnchorUuid: where a click on the distilled summary line lands.
+        # COMPLETED goals pin to the COMPLETION TURN'S wrap-up — event-derived, not a guess: the
+        # closer's DONE-ANCHOR appended the completing turn's final segment as the node's trail tail
+        # (judge _close_turn), so that segment's last substantive assistant block is the big turn-end
+        # recap the user expects the summary to open on (the user 2026-07-14: the distiller's own
+        # citation kept naming a mid-turn status note that merely passed the prose floor).
+        # NEXT: the anchor the distiller/brief itself CITED while writing the line
+        # (node["summaryAnchor"], judge _split_source) — the reader that wrote the summary names what
+        # it read (the user 2026-07-01); honored only when the uuid resolves in this parse AND carries
+        # substantive prose (cite_uuids — a citation on a connective stub is wrong by construction,
+        # the user 2026-07-14). This is the primary tier for a BLOCKED brief (no completion turn
+        # exists) and for a completed goal whose recap segment is tool-only.
+        # FALLBACK (older goals, no/invalid/stub citation): the most CURRENT substantive assistant
+        # message across the goal's whole subtree trail (mint→resolution). Never the old
+        # biggest-text-block pick: "longest ever" is monotone, so a long early analysis held the
+        # anchor forever while the real outcome landed later (the user 2026-07-01).
+        _sa_u, _cited = None, nodes[nid].get("summaryAnchor")
+        if col == "completed":
+            # The newest trail TAIL across the SUBTREE, not just the top's own (the user 2026-07-15,
+            # the g91 click): a BOTTOM-UP-completed umbrella (all children done) has no done verdict
+            # of its own, so the DONE-ANCHOR never appended a completing segment to ITS trail —
+            # trail[-1] was still the MINT segment and the pin sent the summary click to the goal's
+            # oldest prose instead of the wrap-up the distiller correctly cited. A child's
+            # done-anchored tail IS its completing turn's segment, so the newest substantive tail is
+            # the completion recap for both shapes (an explicitly-done top's own tail stays newest).
+            _tail = None                             # (seg_t, uuid) of the newest substantive tail
+            for _x in _subtree(nid):
+                _tr = nodes[_x].get("trail") or []
+                if not _tr:
+                    continue
+                _u, _sub, _t = seg_best.get(_seg_key(_tr[-1]), (None, False, 0))
+                if _u and _sub and (_tail is None or _t > _tail[0]):
+                    _tail = (_t, _u)
+            if _tail:
+                _sa_u = _tail[1]
+        if _sa_u is None and _cited and _cited in cite_uuids:
+            # THE GROUNDING CAN BE OUTRUN (the user 2026-08-28, T153): the citation names what
+            # the summary was WRITTEN FROM — but a reply that reopens the card adds stretches
+            # the stored summary has never seen (no re-completion yet, so no re-distill event),
+            # and the click then lands in the stale FIRST stretch of a visibly two-stretch
+            # card. When the follow-up stamp or any subtree trail segment postdates the
+            # summary's own coverage stamp, the cited tier YIELDS to the most-current-
+            # substantive walk below, so the click follows the freshest evidence; the citation
+            # resumes authority the moment a re-distill lands (the stamp catches up).
+            # Display-only: no column implication.
+            _cov = max(int(nodes[nid].get("distilledMt") or 0),
+                       int(nodes[nid].get("briefedMt") or 0))
+            _outrun = bool(_cov) and (
+                (nodes[nid].get("followupAt") or 0) > _cov
+                or any((seg_best.get(_seg_key(_sid), (None, False, 0))[2] or 0) > _cov
+                       for _x in _subtree(nid) for _sid in (nodes[_x].get("trail") or [])))
+            if not _outrun:
+                _sa_u = _cited
+        if _sa_u is None:
+            _best = None                             # (substantive, seg_t): prefer substantive, then latest
+            for _x in _subtree(nid):
+                for _sid in (nodes[_x].get("trail") or []):
+                    _u, _sub, _t = seg_best.get(_seg_key(_sid), (None, False, 0))   # timestamp-invariant: resolve a drifted trail seg id
+                    if _u and (_best is None or (_sub, _t) > (_best[0], _best[1])):
+                        _best = (_sub, _t, _u)
+            if _best:
+                _sa_u = _best[2]
+        if not _sa_u:
+            # LAST RESORT (the user 2026-07-02: a completed card's summary was unclickable — the cited
+            # atom fell outside every segment, and no trail segment offered prose either). Fall back to
+            # the newest trail segment's WORK anchor (seg_uuid — the same target the modal's node rows
+            # nav to), so the summary still deep-links to roughly where the work concluded. Only a goal
+            # with NO resolvable trail at all ends up link-less.
+            for _x in _subtree(nid):
+                for _sid in reversed(nodes[_x].get("trail") or []):
+                    _u = seg_uuid.get(_seg_key(_sid))
+                    if _u:
+                        _sa_u = _u
+                        break
+                if _sa_u:
+                    break
+        if _sa_u is None and ps is None:
+            # COLD-PARSE fallback (the user 2026-07-20): every tier above reads parse-derived maps,
+            # and right after a kernel restart ps is None until _warm_fleet_bg — so for that window
+            # EVERY card shipped summaryAnchorUuid null and the summary click hit the "no anchor was
+            # recorded" toast (a lie: the anchor is on the node). With no parse to validate against,
+            # serve the distiller's stored citation raw — the chat's own landing handles a bad uuid
+            # honestly, and the validated tiers take back over on the first warm push.
+            _sa_u = _cited
+        card = {
+            "itemId": nid, "sid": fsid, "name": name, "color": color, "text": card_text,
+            "t": disp_t, "live": live,
+            "_ageT": disp_t,                 # the epoch the tint is computed from; trgb is the fold's (_feed_fold_card)
+            "turnId": nid, "origin": origin,
+            **({"handoffTo": handoff_to} if handoff_to else {}),
+            **({"delegTracked": _tracked_peers} if _tracked_peers else {}),
+            # the satellite hides ONLY while the pair is INTACT and the work runs its normal
+            # course: a needs-you block always surfaces (interrupt only when the human is the
+            # bottleneck), and a primary that closed or cleared un-hides the copy — origin.live
+            # reads the PRIMARY handoff node, so every pair divergence self-heals to a visible
+            # card instead of work running in secret (review 2026-08-24).
+            **({"satellite": True} if isinstance(o, dict) and o.get("tracked")
+               and origin and origin.get("live") and column != "needs_input" else {}),
+            "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
+            "followupAt": nodes[nid].get("followupAt") or None,   # WHEN the follow-up/continue went — the latched button's honest age (T150)
+            # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
+            # pending. The card STAYS in Working (the settle gate exists precisely so the column never
+            # flickers working↔done) and wears a steady "done, confirming" cue instead. From the
+            # rollup's authoritative export, never the raw nodeComplete flag (which lies for agent-open
+            # umbrellas is_complete refuses).
+            "doneConfirming": (True if (column == "working" and nid in confirming) else None),
+            "waitingOn": (wmap.get(fsid) if (column == "working" and _peer_wait) else None),   # 'waiting on <peer>' chip: unanswered outbound to a live peer, only on a goal that predates the question (the user 2026-06-22/28)
+            # awaiting flavor: held in Working with a ⏳ awaiting badge (waiting on dispatched/delegated
+            # work) — the user 2026-06-22. `tasks` = the live bg-task descriptions (the user 2026-07-13):
+            # when present the card wears the compact "Waiting on task" pill (expands to this list, like
+            # Sub-goals) instead of the boxed why; empty for subagent/overlay flavors, which keep the box.
+            "awaiting": ({"why": await_why, "kind": await_kind, "since": await_since,
+                          "count": await_count,   # the one number every surface words itself from (T228)
+                          "peers": await_peers,   # delegation wait → [{name, host, sid, color}] for the identity-coloured box (the user 2026-08-23)
+                          "items": await_items,   # the awaited rows, grouped by the pill's expansion (slice 2)
+                          "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
+            "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
+            "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
+            "blockSummary": nodes[nid].get("blockSummary"),    # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18
+            "relayNote": nodes[nid].get("relayCarried") or None,   # a far host still holds a relayed question after its wait ended (relayCarried): the card's own line under the brief, never a brief paragraph (the per-paragraph stamps map briefParts onto the brief's paragraphs and allow exactly one extra)
+            "briefParts": nodes[nid].get("briefParts") or None,   # MULTI-item brief: [{id, since}] one per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null for single-item briefs, whose stamp is the card header's age (the user 2026-07-24)
+            "summaryParts": nodes[nid].get("summaryParts") or None,
+            # the user FOLLOWED UP after the takeaway they read (followupAt postdates what the
+            # summary covers) → the summary section says so instead of presenting the old takeaway
+            # as current; self-clears when the re-distill stamps a newer distilledMt (16 live cards
+            # measured reading stale, the user 2026-08-19)
+            "summaryStale": bool((nodes[nid].get("followupAt") or 0) > (nodes[nid].get("distilledMt") or 0)
+                                 and (nodes[nid].get("summary") or "").strip()) or None,   # the DONE twin: [{id, since}] per takeaway paragraph when the distiller split by <completed-items>; done-event times (the user 2026-07-24)
+            "background": nodes[nid].get("background"),    # the distiller's BACKGROUND section: re-orientation for a reader who forgot the thread — collapsed by default on the card (the user 2026-07-02)
+            "summaryAnchorUuid": _sa_u,    # click the summary line → the completion turn's wrap-up (completed pin), else the cited/latest prose (the user 2026-07-14)
+            # the supporting SPAN (T218): the distiller's verbatim quote, located in the cited atom at
+            # write time — shipped ONLY while the resolved anchor IS the cited atom (the fallback tiers
+            # land elsewhere, where the span would highlight the wrong text); the landing scrolls to
+            # and highlights it, and a null keeps today's whole-message behavior
+            "summaryAnchorQuote": (nodes[nid].get("summaryQuote")
+                                   if _sa_u and _sa_u == nodes[nid].get("summaryAnchor") else None),
+            # per-paragraph landings (T220, the user's ruling): each cited paragraph's own atom +
+            # located span, aligned to the takeaway's paragraphs (None = that paragraph falls back
+            # to the whole-summary landing). Gated exactly like the quote above: the cited tier
+            # must hold authority (the T153 outrun rule) — absent on old stores forever, no sweep.
+            "summaryAnchorsPara": ([({"u": e["a"], **({"q": e["q"]} if e.get("q") else {})} if e else None)
+                                    for e in nodes[nid].get("summaryAnchors") or []]
+                                   if (nodes[nid].get("summaryAnchors")
+                                       and _sa_u and _sa_u == nodes[nid].get("summaryAnchor")) else None),
+            "warns": nodes[nid].get("warns") or None,   # judge-stamped anomalies (judge _node_warn) → yellow "warning" chip; click shows each warn's what/why detail (the user 2026-07-02)
+            "failLog": nodes[nid].get("failLog") or None,   # the summarizer's failed attempts (judge _fail_log): model + literal error per try → the chip's hover history + modal "What was tried" (the user 2026-08-18)
+            "nudged": ({"count": int(nrec.get("count", 0)), "times": _nudge_times().get(nid, [])[-8:]}
+                       if nrec.get("count") else None),   # auto-nudge HISTORY (fires + when) → the stalled chip's evidence, on the chip tooltip + modal (the user 2026-07-02)
+            "blocked": ({"state": "apiError",
+                         # the OFFER (2026-08-30): login-billed + capped window + a key on hand →
+                         # the card proposes switching THIS session's billing; the pick is the
+                         # user's alone, both directions (see _cap_switch_offer)
+                         **({"capOffer": _cap_off} if _cap_off else {}),
+                         "status": aerr.get("status"),
+                         "text": aerr.get("text"), "tooLong": bool(aerr.get("tooLong")),
+                         "spendLimit": bool(aerr.get("spendLimit")),
+                         "modelLimit": bool(aerr.get("modelLimit")),
+                         "authErr": bool(aerr.get("authErr")),
+                         "refusal": bool(aerr.get("refusal")),
+                         "what": ("this account hit its monthly spend limit — raise it at claude.ai/settings/usage to continue" if aerr.get("spendLimit")
+                                  else "this session's prompt is too long — compact it to continue" if aerr.get("tooLong")
+                                  # the CLI's own text names the model and the two remedies; the card
+                                  # states them, because "Retry to resume" is false here (the user 2026-08-01)
+                                  else "this session's model is out of allowance — switch its model or add credits to continue" if aerr.get("modelLimit")
+                                  # a dead credential: retrying re-presents it forever — name the fix
+                                  # (per-session auth, the user 2026-08-08)
+                                  else "this session's sign-in or API key isn't working — fix the login (claude /login) or the key, or switch which one it bills" if aerr.get("authErr")
+                                  # a refusal is deterministic: retrying re-sends the same prompt and
+                                  # collects the same refusal — name the real fix (the user 2026-08-15)
+                                  else "the model's safeguards refused this prompt — rewrite it or drop this thread" if aerr.get("refusal")
+                                  else "this session stopped on an API error — Retry to resume")} if nid == api_top
+                        # the session itself is fine — it's romp's ANALYSIS of it whose credential is
+                        # refused, so the copy blames the judges, not the session (the user 2026-08-12)
+                        else {"state": "judgeAuth", "mode": jerr.get("mode"),
+                              "since": jerr.get("t"), "text": jerr.get("note") or "",
+                              "what": ("romp can't analyze this session — the API key its judges bill is being refused. Fix the key behind Claude Code's apiKeyHelper (rotate the vault item) or switch which account this session bills"
+                                       if jerr.get("mode") == "key" else
+                                       "romp can't analyze this session — the login its judges bill is being refused. Sign in again (claude /login) or switch which account this session bills")} if nid == jauth_top
+                        else {"state": perm_state,
+                              "what": ("this session is stopped awaiting your input" if perm_state == "picker"
+                                       else "this session is stopped awaiting your approval")} if nid == perm_top
+                        else None),
+            "retrying": (sess_retrying if column == "working" else None),   # api-retry storm in the OPEN turn → "retrying since HH:MM" chip on the working card; chip only, no column move (the user 2026-07-09)
+            "nudgeFailed": nudge_failed,         # the one auto-nudge didn't resolve the stall → "nudge failed" chip; never re-nudged (plans/stalled-open-todos-nudge.md)
+            # STALLED (the user 2026-07-23): romp's nudge gate is holding this card behind a reviver that
+            # isn't retiring, so nothing is moving it and nothing was saying so. `why` is the kernel's own
+            # mechanical reason; `note` is the staller's plain-language version of it (null until the judge
+            # writes one). Read-side gated on the LIVE stall record, so the note vanishes the moment the
+            # wait clears, without anyone having to erase it. Working column only: a stall is romp being
+            # the bottleneck, never the user, so it must not read as needs-you.
+            "stalled": ({"why": _stall_rec["why"], "since": _stall_rec["since"],
+                         "note": nodes[nid].get("stallSummary") or None,
+                         "blocked": _stall_block}
+                        if (_stall_rec and not nudge_failed
+                            and (column == "working" or _stall_block)) else None),
+            "interrupting": bool(sess_interrupting and (column == "working" or (col == "blocked" and _lastblk == "interrupt"))),   # a user interrupt is IN FLIGHT → steady "interrupting…" badge until it settles (the user 2026-07-07)
+            "interrupted": bool(sess_interrupted and not sess_interrupting and (column == "working" or (col == "blocked" and _lastblk == "interrupt"))),   # the user stopped this session and hasn't re-engaged → "interrupted" badge (only ONCE the interrupt has settled); nudge suppressed until their next message (the user 2026-07-05)
+            "column": column,
+            "recheck": recheck,                  # targeted follow-up on a soft-block → de-urgented (dotted), moved to Working, pending re-judge
+            "rejudging": rejudging,              # plain thread reply after a block → STAYS in Needs-You, "Re-judging…" swirl while a turn is in flight (the user 2026-06-30)
+            "judging": bool((sess_judging or _stall_inflight) and column == "working"),
+            "working": (sess_progress if column == "working" else None),   # open-turn narration: tool count + since (the user 2026-08-13)   # turn settled, closer verdict pending → "Analyzing…" swirl covers the finished-but-still-Working beat (the user 2026-07-13); same key the provisional card wears
+            "sessState": (sess_state if column == "working" else None),   # the mute-proof floor: open | quiet | unknown (the user 2026-08-14 — a working card ALWAYS says its state)
+            "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
+                                         store.get("placements") or {}) or None)
+                        if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section
+            # T319: this root is work the SESSION started (a planner-born step whose parent is gone, or a
+            # pre-rule machine-rooted top the heal found no request to nest under): the face names the
+            # parent request when one is known and says why the work exists, in one line
+            "sessionStarted": _session_started_face(nodes, nid, healed),
+            "tree": flatten(nid, [], boundary=jd.review_boundary(nodes[nid]))}
+        # THE SERVING FOLD, candidate side (the user 2026-08-28, T137: fan-out lives inside the
+        # ask card — the T101 ruling applied to the mirror, view-side): a to-do mirror top the
+        # sync stamped as SERVING a dispatch folds into the sender's ask card instead of
+        # standing alone on the board. Candidate only — the fold commits in the post-pass IFF
+        # the sender's tracker row actually rendered this build (never orphan rows into an
+        # unrendered card; the candidate falls back to its own card). NEEDS-YOU BREAKS THROUGH:
+        # a serving mirror folds ONLY from the quiet columns (working/completed) — any
+        # needs-input state stands on the board like any needs-you card until it lifts, the
+        # store-independent breakthrough rule.
+        _srv = nodes[nid].get("serving")
+        if (isinstance(_srv, dict) and _srv.get("goalId")
+                and column in ("working", "completed")):
+            ent_folds.append({"tracker": _srv["goalId"], "card": card})
+        else:
+            ent_asks.append(card)
+    # A session actively working a brand-new ask shows NO card until the planner classifies the held
+    # segment at turn-end — surface a live-prompt placeholder so it isn't invisible. Only when nothing
+    # already covers it (no working card); replaced by the real card once the planner places it.
+    # THE INVARIANT (the user 2026-08-01): a card sitting in Working must be explained by something —
+    # an actively working session, a judgment in flight, an awaiting, or an error. A session whose only
+    # explanation is "one of my cards is awaiting" was reading READY at the session level while that
+    # very card said "waiting on a background task", because this dot lit ONLY from the session-wide
+    # sources (`sess_awaiting_why`), which deliberately ignore a judge-placed launch. The cards are the
+    # per-goal answer this build already computed — so take it from them. Scoped to the session's own
+    # verdicts, so no sibling card is floored by it (what the session-wide _await_ok would have done).
+    if had_awaiting and not who_working and ent_awaiting is None:
+        ent_awaiting = name
+    if not had_working and perm_top is None and ps:   # cache-only: the live-prompt placeholder needs the parse → after the warm
+        # perm_top excluded: a live-blocked focus card no longer counts as "working" (it reports needs_input
+        # now), so without this guard a session whose ONLY card is the picker-blocked one would ALSO get a
+        # provisional working placeholder — a duplicate. A floored perm_top already covers the live prompt.
+        # store_faulted excluded: "the planner has not placed this yet" is an inference from placements we
+        # could not read, so a session whose store faulted gets no provisional card (its row says why).
+        pc = _provisional_card(s, name, color, fsid, live, now, store) if not store_faulted else None
+        if pc:
+            ent_asks.append(pc)
+        elif perm_state in _NEEDS_INPUT_STATES:      # perm_top is None here (outer guard) → no goal to floor
+            # Hard-blocked on a live permission/picker prompt but with NO goal to floor (the planner hasn't
+            # run — nothing to plan until the ask is answered). Surface a needs-input placeholder so the
+            # block reaches the Blocked column instead of being invisible (the user 2026-06-27). Replaced
+            # by the real card once the planner places the answered work.
+            ent_asks.append(_blocked_placeholder(s, name, color, fsid, live, now, perm_state,
+                                                 tm.get("since") if tm else None))
+        elif sess_awaiting_why:
+            # AWAITING a dispatched background task with NO goal to floor (the user 2026-07-13): the
+            # session's work is all placed/done, but a background task it dispatched is still running
+            # (the same signal the timeline's faded awaiting stretch reads). Surface a working-column
+            # awaiting card so the wait shows in the FEED, not just on the timeline — the hole the user
+            # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
+            ent_asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
+                                           kind=sess_awaiting_kind, since=sess_awaiting_since,
+                                           count=sess_awaiting_count, items=sess_awaiting_items))
+    return {"asks": ent_asks, "working": ent_working, "awaiting": ent_awaiting, "bgServices": ent_bg,
+            "servingFolds": ent_folds, "heal": heal_total, "hidden": hidden_total, "cold": cold_parse,
+            "peers": sorted(peers_read), "reads": reads}
+
+
+def _feed_fold_card(card, now, cmap):
+    """Stamp the clock-derived fields onto one card from a memoized entry, per build: `trgb` from its `_ageT` (the
+    epoch the tint is computed from; popped) on the build's colormap, and `t := now` for a placeholder whose time
+    IS the clock (`_ageT` None); the same for every row of its tree. The card is the fold's own object (a fresh
+    decode of the entry), never the memoized string."""
+    age_t = card.pop("_ageT", None)
+    if age_t is None:
+        card["t"] = now                              # a placeholder with no turn to date it: the build's clock, as before
+        age_t = now
+    card["trgb"] = list(cm.age_rgb(now - age_t, cmap))
+    for r in card.get("tree") or []:
+        rt = r.pop("_ageT", None)
+        r["trgb"] = list(cm.age_rgb(now - (rt if rt is not None else now), cmap))
+    return card
+
+
+def _feed_fold_entry(entry, now, cmap, name, asks, working, awaiting, bg_services, serving_folds):
+    """Fold one session's entry (a fresh decode of its memoized JSON, or the derivation just made) into the build's
+    cross-session accumulators, in the session's place in `alive` order: its cards onto `asks` (tinted for this
+    build), its serving-fold candidates, its dot names, its service chip under `name`. Returns (heal, hidden, cold)
+    for the caller's totals. None (a muted session) folds nothing."""
+    if entry is None:
+        return 0, 0, False
+    for c in entry.get("asks") or []:
+        asks.append(_feed_fold_card(c, now, cmap))
+    for f in entry.get("servingFolds") or []:
+        _feed_fold_card(f["card"], now, cmap)
+        serving_folds.append(f)
+    if entry.get("working"):
+        working.append(entry["working"])
+    if entry.get("awaiting"):
+        awaiting.append(entry["awaiting"])
+    if entry.get("bgServices"):
+        bg_services[name] = entry["bgServices"]
+    return int(entry.get("heal") or 0), int(entry.get("hidden") or 0), bool(entry.get("cold"))
+
+
 def build_feed(now, live_map=None):
     """The {type:"feed"} message the tuned feed.js bundle consumes (ui-parity.md: feed = ADAPT).
     Goals map onto the AskItem/AskTreeNode shape the render already speaks: the goal tree IS the
     card's tree, rolled-up status → the Working/Blocked/Completed column, dead-concept fields
     (relevance/liveness/suspects/openQuestions/decision-briefs) left empty so the render's
-    conditional paths hide them — no edits to the tuned card code. Stream = turn captions."""
+    conditional paths hide them — no edits to the tuned card code. Stream = turn captions.
+
+    PER-SESSION MEMO (T368): each living session's contribution (its cards, dot names, service chip, serving-fold
+    candidates, heal counts) is derived by _feed_session_entry and held in _feed_memo under _feed_session_key, a tuple
+    of every input that derivation reads (files by identity, in-memory state by value, the clock only as the two
+    booleans it decides), so a rebuild re-derives only the sessions whose inputs moved; the clock-derived tint is
+    stamped per build by the fold (_feed_fold_entry), the cross-session sections below recompose per build from the
+    per-session results, and GET /perf reports hits, misses by component, evictions and bytes under
+    builds.feed.memo."""
     if live_map is None:
         live_map = _live_map()
     cleared = _cleared_ids()
@@ -36169,989 +37561,35 @@ def build_feed(now, live_map=None):
     _jauth_map = jd._auth_down_map()                 # judge-auth-down latch → the per-session card floor below
     _jactive = {r.get("fsid") for r in jd.active_runs()}   # judge calls in flight NOW → the Analyzing… prong
     cold_parse = False                               # any living session not yet parsed → warm it in the background
+    cmap = _colormap()                               # the age tint's colormap, once per build: the FOLD's input (never the memo's)
+    ctx = {"now": now, "live_map": live_map, "cleared": cleared, "dbg_rows": dbg_rows, "wmap": wmap,
+           "stalls": _stalls, "jauth_map": _jauth_map, "jactive": _jactive}
     for s in alive:
-        fsid, name = s["sid"], s["name"]
-        if _session_flag(fsid, "hideFromFeed"):      # muted from the feed (the user 2026-06-19) → timeline-only
-            continue
-        color = _name_color(fsid)
-        tm = live_map.get(fsid); live = tm is not None
-        # CACHE-ONLY parse (the user 2026-06-26): the CARDS come from the goal store (cheap) and must paint at
-        # once on a cold start, so the working-dot + the deep-link anchors read the parse ONLY if it's already
-        # cached — never paying the ~1s cold parse here. _warm_fleet_bg fills the cache + re-pushes; the dots
-        # and anchors snap in a beat later.
-        ps = _parse_cached(s["path"])
-        if ps is None:
-            if _warm_wanted(s, tm):                      # cold by design otherwise (T323 stage 1): no warm to chase
-                cold_parse = True
+        # THE PER-SESSION CARD MEMO (T368, see _feed_session_key): the session's entry is served while every input
+        # of its derivation stands, re-derived when one moved, and folded into the board here in `alive` order.
+        fsid = s["sid"]
+        tm = live_map.get(fsid)
+        ent = _feed_memo_get(fsid)
+        prev = json.loads(ent[1]) if ent is not None else None   # the ONE decode per session per build: a hit's fresh
+        #                                                          objects to fold, and the dependency record the key reads
+        key = _feed_session_key(s, tm, ctx, prev)
+        if ent is not None and ent[0] == key:
+            _feed_memo_count("hit")
+            entry = prev
         else:
-            ps = _merge_live_atoms(ps, fsid)         # the same LIVE-MERGED session the chat chip + timeline lane read
-            #                                          (the feed was the one surface deriving from the bare cache, 2026-07-05)
-        try:                                             # WORKING from the EVENT MODEL (open turn), not the row's state —
-            who_working = _session_working(ps["turns"]) if ps else False   # one backend-agnostic dot signal
-        except Exception:
-            who_working = False
-        if who_working:
-            working.append(name)
-        # the open turn's live narration (the user 2026-08-13) — computed once per session, ridden by
-        # every working card below; cache-warm like the dot (a cold start paints plain, then snaps in)
-        sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None
-        # The card-floor disposition (the user 2026-08-14: NO working card is ever mute — even unknown
-        # shows as such): "open" = a turn is running (the narration above rides when parsed), "quiet" =
-        # parsed and between turns, "unknown" = no parse to read (a cold cache, or a machine that isn't
-        # reporting). The feed's spin ladder renders a floor line for each — see spin-caption.ts.
-        sess_state = "open" if who_working else ("quiet" if ps else "unknown")
-        # The user's LAST action on this session was an INTERRUPT (no message from them since): its quiet
-        # is user-chosen, not a stall — auto-nudge is suppressed (same predicate, _auto_nudge_tick) and
-        # the working card wears an "interrupted" badge saying so (the user 2026-07-05). Cache-only,
-        # like the working dot: the badge snaps in once _warm_fleet_bg fills the parse. The read is memoized
-        # on that cache object's identity (_interrupt_marks, the "display" family), so an unchanged parse
-        # costs no scan per build.
-        try:
-            sess_interrupted = bool(ps) and not who_working and \
-                _interrupt_suppresses_nudge(ps["turns"], fsid, family="display")
-        except Exception:
-            sess_interrupted = False
-        # A user interrupt still IN FLIGHT (dispatched, not yet settled): the card wears a steady
-        # "interrupting…" badge from the click until it settles, THEN falls to the past-tense "interrupted"
-        # badge — never flickering between "working" and "interrupted" while the SDK live-tail retires mid-
-        # settle (the user 2026-07-07). Same derivation as the chat chip + timeline lane (_interrupting):
-        # SDK's own in-flight flag for SDK sessions, the stop record for a row without it. Safe to call again in this push.
-        sess_interrupting = _interrupting(fsid, ps or {}, now, tm)
-        # An api-retry storm INSIDE an open turn (the user 2026-07-09): the live backend state says
-        # "retrying" → the working card wears a "retrying since HH:MM" chip. The API-error badge below
-        # (aerr) only fires once the session is idle-stalled, so without this a storm reads as plain
-        # healthy Working for its whole life — nimbus's card said Working through an ~80-minute storm.
-        sess_retrying = _session_retrying(fsid, tm)
-        store = _feed_goals(fsid)                # pre-pass snapshot while a judge pass is mid-flight → the card's
-                                                 # status never shows a half-applied intermediate (atomic visibility)
-        store_faulted = store is None            # this session's store could not be READ (EACCES, EIO, a directory
-        if store_faulted:                        # at the path): its row is filed (jd.load_goals_or_fault) and THIS
-            store = {"nodes": {}, "status": {}}  # session renders with no goal-derived content — no cards (so no
-            #                                      floors and no swirl, which land only on cards) and nothing
-            #                                      inferred from the absence (the provisional card is gated on the
-            #                                      flag below). A render-only stand-in, never saved. Every other
-            #                                      session is untouched; before this, one such file aborted the
-            #                                      whole build.
-        # ANALYZING (the user 2026-07-13; broadened 2026-08-12): the card must say when romp is working
-        # on it. Two prongs, either lights the swirl:
-        #   * the SETTLE GAP — the turn just settled but the closer hasn't delivered its verdict yet
-        #     (cache-warm only: it needs the parse; the swirl snaps in after _warm_fleet_bg);
-        #   * a judge call for this session ACTUALLY IN FLIGHT — jd.active_runs(), the same in-process
-        #     registry the nudge gate trusts (_revivers_pending), whose comment always claimed "the
-        #     Analyzing… swirl already says so"; now it does. This is what a backlog drain looks like:
-        #     when the judge-auth outage healed, 201 calls swept an 18-hour backlog while every card
-        #     sat inertly in Working (the user 2026-08-12, who asked for the queue to be visible on
-        #     the card) — planner/grouper work on OLDER turns never trips the settle gap, and a fresh
-        #     kernel's caches are cold exactly when the drain runs, so the closer prong alone stayed
-        #     dark. The active prong deliberately needs neither `live` nor a warm parse: the registry
-        #     is an in-process fact, free to read.
-        # Session-scoped (we don't know WHICH goal a verdict will land on until it does); each working
-        # card wears the Analyzing… swirl meanwhile (feed.ts spinCaption).
-        sess_judging = bool(not who_working
-                            and (fsid in _jactive
-                                 or (live and ps and _closer_pending(fsid, s["path"], now, store))))
-        nodes, status = store.get("nodes", {}), store.get("status", {})
-        confirming = set(store.get("confirming") or ())   # rollup export: done verdict in, settle pending (judge rollup_status, the user 2026-07-24)
-        # Exact click-to-jump anchors: map each goal segment → the work/reply uuid — the SAME anchors the
-        # timeline/ledger already use — so a card click deep-links to the precise turn BY ID instead of the
-        # old time-nearest heuristic. _parse is cache-backed (cheap); reply uuid preferred (the readable
-        # assistant text). A missing entry → anchorUuid None → feed falls back to time. (the user 2026-06-17.)
-        # seg_uuid → the WORK anchor (reply/work assistant atom, for the mark/time zones); seg_trig → the
-        # PROMPT anchor (the segment's TRIGGER atom = the user's message that opened it, for the TITLE). A
-        # title is prompt-intent and must land on the USER turn — passing the trigger uuid (which the chat
-        # tags + the kind guard accepts as turn-user) lets it resolve BY ID instead of a kind-restricted
-        # nearest-time landing (the user 2026-06-17). (Both are emitted .turn[data-uuid]s in the chat.)
-        seg_uuid, seg_trig, seg_best, cite_uuids = {}, {}, {}, set()
-        try:
-            for turn in (ps["turns"] if ps else []):     # cached parse only; anchors fill in after _warm_fleet_bg
-                for seg in _segs_seam(turn, store):
-                    w, r = _seg_anchors(seg["atoms"])
-                    seg_uuid[_seg_key(seg["id"])] = r or _seg_jump(seg["atoms"])   # timestamp-invariant key; landable
-                    #                                  anchors only — never a thinking-only uuid (SDK echo/real drift)
-                    seg_trig[_seg_key(seg["id"])] = jd._prompt_anchor_uuid(seg)   # attachment-safe: a
-                    #                                  title click must land on the USER message, never an
-                    #                                  attachment record no chat event carries (2026-08-25)
-                    _lu, _lsub = _seg_last_text(seg["atoms"])
-                    seg_best[_seg_key(seg["id"])] = (_lu, _lsub, seg.get("t", 0))   # latest prose → summary deep-link fallback
-                    pcs_ = em.turn_scalar(turn, "pcs")
-                    if pcs_ is not None:                 # a restored pre-cut turn: its stored prose chars, no atom built (T358)
-                        cite_uuids.update(u_ for u_, n_ in pcs_.items() if n_ >= jd.CITE_MIN_CHARS)
-                        continue
-                    for _a in seg["atoms"]:              # citable-uuid set: gates the distiller's CITED anchor.
-                        # Resolvable in THIS parse AND substantive (the user 2026-07-14): a stored citation
-                        # pointing at a connective stub (a lead-in that merely names the goal) is a wrong
-                        # link by construction — the outcome never lives there — so it falls through to the
-                        # deterministic fallback below, healing bad anchors already in stores at read time.
-                        if _a.get("uuid") and _atom_prose_chars(_a) >= jd.CITE_MIN_CHARS:
-                            cite_uuids.add(_a["uuid"])
-        except Exception:
-            pass
-        healed = _heal_session_tops(s.get("path"), nodes, status)   # T319: machine-rooted tops nest (read-side)
-        heal_total += sum(1 for v in healed.values() if v[0])
-        _hidden = {k for k, v in healed.items() if v[1].get("hidden")}   # T333: rooted in a skill the harness loaded, no
-        hidden_total += len(_hidden)                                     #   request in the store to sit under: no card
-        children = {}
-        for nid, nd in nodes.items():
-            if nid in _hidden:
-                continue                             # the session's own view keeps the work
-            _hp = healed.get(nid)
-            _pk = _hp[0] if (_hp and _hp[0]) else nd.get("parentId")
-            if _pk is not None and _pk not in nodes and isinstance(nd.get("born"), dict):
-                _pk = None                           # T319: a born step whose parent is gone renders as a root that says so
-            children.setdefault(_pk, []).append(nid)
-        agent_open = _agent_open_set(nodes, children)   # authoritative-open subtree → never rendered 'done' (see helper)
-        parked_rows = _parked_rows(nodes, children)     # leapfrogged open rows → the quiet "parked" row cue (see helper)
-
-        def _subtree(root):                          # all node ids at/under root (pre-order)
-            stack, acc = [root], []
-            while stack:
-                x = stack.pop(); acc.append(x); stack.extend(children.get(x, []))
-            return acc
-
-        # VERDICTS ONLY (the user 2026-07-15; roll-UP removed — it painted an authored-looking ✓ on a
-        # goal nobody ruled done, see build_session's _subtree_done twin): a node is "done" if it's
-        # explicitly nodeComplete (verdict or roll-down cache), OR if a done ancestor checks it off
-        # (roll-DOWN, threaded by flatten through ancestor_done — dimmed disc). All-children-done alone
-        # no longer checks a parent; the closer rules those (_subtree_done_candidates) and the check
-        # appears when its verdict lands.
-        _cdone = {}
-        def _closure_done(nid):
-            if nid in _cdone:
-                return _cdone[nid]
-            nd = nodes.get(nid)
-            if not nd:
-                _cdone[nid] = False
-                return False
-            res = bool(nd.get("nodeComplete"))
-            if not res and nd.get("umbrella"):         # ARCHIVED pre-T101 container — history renders
-                # structurally-complete (mints retired; live ones dissolve every rollup): the
-                kids = [c for c in children.get(nid, []) if not nodes[c].get("cleared")]
-                res = bool(kids) and all(_closure_done(c) for c in kids)
-            _cdone[nid] = res
-            return res
-
-        # Order children MOST-RECENT-FIRST by subtree-max mt — the SAME recency key the ledger tree uses
-        # (build_session _submax), so every goal-tree view reads newest-first: the card's inline sub-goal
-        # checklist, the modal tree, and the ledger TOC all agree (the user 2026-06-17). mt (last-touched)
-        # falls back to t for never-modified nodes.
-        _fsmemo = {}
-        def _fsubmax(cid):
-            if cid in _fsmemo:
-                return _fsmemo[cid]
-            cn = nodes.get(cid) or {}
-            m = cn.get("mt", cn.get("t", 0))
-            for k in children.get(cid, []):
-                m = max(m, _fsubmax(k))
-            _fsmemo[cid] = m
-            return m
-
-        # BLOCKED rolls UP the tree (the user 2026-07-11: nimbus's Needs-you traced to a block buried
-        # under a collapsed row — "shouldn't the block propagate up so I see it?"). Mirror of the judge's
-        # any_blocked: a node reads "question" when it — or any descendant chain not inside a completed
-        # subtree — holds an open block (a done subtree's block is moot, same short-circuit). This is
-        # also what the CLIENT was designed for: hasQuestionDescendant exists to find the LOWEST ? (the
-        # actual ask) beneath rolled-up ancestors.
-        _qmemo = {}
-        def _closure_blocked(nid):
-            if nid in _qmemo:
-                return _qmemo[nid]
-            nd = nodes.get(nid)
-            if not nd or nd.get("cleared") or (_closure_done(nid) and nid not in agent_open):
-                _qmemo[nid] = False
-                return False
-            res = bool(nd.get("blocked")) or any(_closure_blocked(c) for c in children.get(nid, []))
-            _qmemo[nid] = res
-            return res
-
-        # The rejudging latch's CLEAR bound (the user 2026-07-31): the block a top card surfaces may
-        # live on a DESCENDANT (blocked rolls up, _closure_blocked above), and the unblocker stamps
-        # blockCheckT on the node it EXAMINES — the blocked child — never on the top. The latch used
-        # to read the top's own watermark, which for a child-held block stays None forever: every
-        # plain reply dropped the card to Working (plain_user_t > 0 is always true) and every landing
-        # turn advanced disp_t past the reply and lifted it back to Needs-You — the same strobe the
-        # watermark bound fixed for top-level blocks (PR #144), reintroduced one level down. The
-        # audited card flipped seconds-apart pairs at every conversational turn for half an hour.
-        # The bound is therefore the OLDEST watermark among the subtree's OPEN blocked nodes (the
-        # exact closure _closure_blocked walks, same done/cleared gates): the card returns to
-        # Needs-You only once EVERY block it is surfacing has been re-examined with evidence
-        # covering the reply. None when the walk finds no open block (a stale rollup) — the caller
-        # falls back to the top's own watermark, the pre-existing semantics.
-        _bcmemo = {}
-        def _block_check_floor(nid):
-            if nid in _bcmemo:
-                return _bcmemo[nid]
-            nd = nodes.get(nid)
-            if not nd or nd.get("cleared") or (_closure_done(nid) and nid not in agent_open):
-                _bcmemo[nid] = None
-                return None
-            vals = [int(nd.get("blockCheckT") or 0)] if nd.get("blocked") else []
-            vals += [v for v in (_block_check_floor(c) for c in children.get(nid, [])) if v is not None]
-            res = min(vals) if vals else None
-            _bcmemo[nid] = res
-            return res
-
-        def flatten(nid, out, ancestor_done=False, boundary=None):  # AskTreeNode flat list, root first; nest via children ids
-            nd = nodes[nid]
-            kids = sorted(children.get(nid, []), key=_fsubmax, reverse=True)   # most-recent-first (matches the ledger)
-            explicit = bool(nd.get("nodeComplete"))
-            # AUTHORITATIVE-open override (the user 2026-07-01): an open agent to-do item — or an umbrella
-            # holding one — is NEVER done, even if a nodeComplete ancestor would roll 'done' down onto it.
-            # Mirrors the judge's rollup_status; without it the open item read 'done' → the "checked off" hover.
-            done = (explicit or _closure_done(nid) or ancestor_done) and nid not in agent_open
-            derived = done and not explicit            # roll-up / roll-down → DIMMED ✓ disc, not the full one
-            st = "done" if done else ("question" if _closure_blocked(nid) else "open")
-            # The node's deep-link target SEGMENT: its NEWEST trail seg — the resolve turn for
-            # done/blocked nodes, the latest activity for open ones (where it stands, not where born).
-            _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_uuid)
-            # A HANDOFF tracking node ("↪ delegated to <peer>") finally ships as its designed kind: the
-            # feed's delegations section (fask-delegations, built to the 2026-06-10 handoff spec) keys on
-            # kind "handoff" and had sat dormant because flatten hardcoded "ask" — the sender's card
-            # showed a bare text row with no recipient identity and no visible cross-card LINK (the user
-            # 2026-08-16, who watched a clear take the linked card with it and had no way to see why).
-            # who/whoSid/whoColor become the RECIPIENT's identity for these rows — exact, from the
-            # courier-recorded handoff.peer, never inferred.
-            _ho = nd.get("handoff") if isinstance(nd.get("handoff"), dict) else None
-            _ho_sid = str(_ho.get("peer") or "") if _ho else ""
-            _born = nd.get("born") if isinstance(nd.get("born"), dict) else (healed.get(nid) or (None, None))[1]
-            out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
-                        "born": _born or None,   # T319: a step the session started on its own (why it sits here)
-                        "who": (_name_of(_ho_sid) or _ho_sid[:8]) if _ho_sid else name,
-                        "whoSid": _ho_sid or fsid,
-                        "whoColor": _name_color(_ho_sid) if _ho_sid else color,
-                        "whoWorking": who_working, "status": st, "derived": derived,
-                        # user-cleared sub (nodeOverride op:clear) → renders struck-through + faded with a
-                        # "cleared" chip; `status` above stays honest (box = done, the user 2026-07-26)
-                        "cleared": bool(nd.get("cleared")),
-                        # this DONE sub's outcome was already REVIEWED: its done predates the top's
-                        # review boundary (jd.review_boundary — the same boundary the distiller scopes
-                        # the takeaway with, so the fold and the summary can never disagree). The card
-                        # collapses these behind one "N reviewed earlier" row instead of re-presenting
-                        # them on every re-completion (the user 2026-08-19). `out` is empty only for
-                        # the ROOT row, which is the card head, never a checklist row.
-                        "reviewedEarlier": bool(boundary and out and done
-                                                and jd._done_since(nd) <= boundary) or None,
-                        # a rolled-UP question (the block lives in a descendant, not here) — the client's
-                        # mark tooltip says "blocked inside", and the actual ask keeps its own ⏸ below
-                        "qderived": st == "question" and not nd.get("blocked"),
-                        # LEAPFROGGED row (the user 2026-08-24): open, nothing filed under it, while N
-                        # younger siblings were dispatched past it — the quiet "parked" tag + the card's
-                        # dim sub-goals suffix. Gated on the OPEN render state so a rolled-down or
-                        # closed row can never wear it; mint/retire events live in _parked_rows.
-                        "parked": ({"n": parked_rows[nid]} if (st == "open" and nid in parked_rows) else None),
-                        # AUTHORITATIVE tier: this node mirrors an item on the agent's OWN to-do list, so its
-                        # open/done is agent-asserted (solidity = authority in the disc render). None = a plain
-                        # judge-inferred node. (the user 2026-07-01)
-                        "auth": (nd.get("agentTask") or {}).get("status"),
-                        # `last` drives each row's "(Xm ago)" age + recency tint: the node's LAST ACTIVITY
-                        # (newest mt in its subtree, _fsubmax), so a replied-to / re-touched node freshens in
-                        # the modal tree just as its card does — not pinned to the mint `t` (the user
-                        # 2026-07-01). `t` stays the mint time (the node's nav-time fallback).
-                        "t": nd["t"], "last": _fsubmax(nid), "trgb": list(cm.age_rgb(now - _fsubmax(nid), _colormap())),
-                        # mt = last-modified (the segment the planner applied done / block) → a blocked or
-                        # done node deep-links to WHERE IT RESOLVED, not where it was minted. Falls back to
-                        # t for never-modified nodes (open work, derived done). (the user 2026-06-16.)
-                        "mt": nd.get("mt", nd["t"]),
-                        # anchorUuid = the WORK anchor (reply assistant atom of the resolve/mint segment) →
-                        # the mark/time zones deep-link here. promptAnchorUuid = the PROMPT anchor (the
-                        # MINTING segment's trigger = the user's message) → the TITLE deep-links here, by id,
-                        # landing on the user turn (no kind-restricted nearest-time needed). (2026-06-17.)
-                        "anchorUuid": _wa,
-                        "promptAnchorUuid": _pa,
-                        "summary": nd.get("summary"),                   # distiller's key takeaway — shown in the MODAL only — the user 2026-06-17
-                        "blockSummary": nd.get("blockSummary"),         # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18
-                        "relayNote": nd.get("relayCarried") or None,    # a far host still holds a relayed question after its wait ended (relayCarried): its own line under the brief, never a brief paragraph (briefParts maps those)
-                        "followupPending": nd.get("followupPending"),   # per-node "Followed up" chip in the modal tree (business 2026-06-17)
-                        # the per-item story (MODAL, non-done only): newest block/unblock/verdict rows with
-                        # anchors, so an open sub answers 'is this still active?' in place (the user 2026-07-20)
-                        "log": _node_log_rows(nd, seg_uuid) if st != "done" else None,
-                        "children": kids})
-            for c in kids:
-                flatten(c, out, ancestor_done=done, boundary=boundary)
-            return out
-        # HARD blocked floor: a session stopped RIGHT NOW on a live permission prompt (the live row's state)
-        # floors its ACTIVE-FOCUS card under BLOCKED — the strongest signal, beats the goal's planner
-        # status. (The planner's SOFT block, nd["blocked"], is the model's "needs user" verdict; this is
-        # the live event.) Gated on the ROLLED-UP status, NOT the raw nodeComplete flag: a focus that is
-        # nodeComplete but the settled gate still holds at "working" (the session marked it done, then kept
-        # working under it and live-blocked) IS floored — so a live block always surfaces; only a genuinely
-        # settled "completed" (or user-"cleared") card is left alone, its block being for new, not-yet-placed
-        # work. (the user 2026-06-18: a live-blocked nodeComplete-but-working focus wasn't reaching BLOCKED.)
-        perm_top = None
-        perm_state = tm.get("state") if tm else None
-        if perm_state in _NEEDS_INPUT_STATES:               # live prompt (permission Allow/Deny OR a picker)
-            f = store.get("lastNode")
-            while f and nodes.get(f, {}).get("parentId") is not None:
-                f = nodes[f]["parentId"]
-            if f in nodes and status.get(f) not in ("completed", "cleared"):
-                perm_top = f
-        # AWAITING signal (event-model, the user 2026-06-22): the session is paused on AGENT work it
-        # dispatched — a WORKING flavor, never needs-input. Sourced from the live subagent snapshot, the
-        # PENDING background tasks (launch not yet judge-placed; a placed launch's story belongs to the
-        # judge's stamp or the service chip — see _session_awaiting/_bg_split), or the SDK producer's
-        # states overlay; None when actively working.
-        # Computed BEFORE the API-error floor, which must yield to it (the user 2026-07-05).
-        _sess_aw = _session_awaiting(fsid, s["path"], not who_working) if ps else None   # cache-only: fills in after the warm
-        sess_awaiting_why = _sess_aw["why"] if _sess_aw else None
-        sess_awaiting_kind = _sess_aw["kind"] if _sess_aw else None
-        sess_awaiting_since = _sess_aw.get("since") if _sess_aw else None   # the wait's own event time (the user 2026-08-23)
-        sess_awaiting_count = _sess_aw.get("count") if _sess_aw else None   # how many are awaited — the pill's word agrees in number (T225)
-        sess_awaiting_peers = _sess_aw.get("peers") if _sess_aw else None   # named identities when the arm knows them (2026-08-26)
-        sess_awaiting_items = list(_sess_aw.get("items") or []) if _sess_aw else []   # the awaited rows (slice 2) — the pill lists them grouped
-        if sess_awaiting_why and not who_working:
-            awaiting.append(name)                    # the AWAITING dot list (await-green, the user 2026-07-13) — the
-            #                                          same split _session_chip makes; feed/chat dots match the chip
-        # API-error floor: a session stopped on an API error (transcript isApiErrorMessage, event-based)
-        # floors its focus top-goal under BLOCKED with an apiError reason → the feed card shows a red
-        # "API error" badge + a Retry button (the user 2026-06-16). Same focus-goal walk as the perm floor.
-        # GATED on awaiting, like _session_chip (4699) and build_session (5512) — this was the ONE ungated
-        # _api_error read (the user 2026-07-05, jld_audit): a main thread erroring BETWEEN agent waits is
-        # still IN MOTION, but the raw floor made the feed card wear red "API error" + "stalled" while the
-        # chat chip said Working — and api_top then suppressed the very awaiting flip that would have told
-        # the truth. One formula, one truth: awaiting wins; the floor applies only to a session truly dead
-        # in the water.
-        aerr = _api_error(s["path"]) if (ps and not who_working and not sess_awaiting_why) else None   # cache-only: fills in after the warm
-        _cap_off = _cap_switch_offer(fsid, aerr) if aerr else None   # the billing-switch OFFER (never a silent switch, 2026-08-30)
-        api_top = None
-        if aerr:
-            f = store.get("lastNode")
-            while f and nodes.get(f, {}).get("parentId") is not None:
-                f = nodes[f]["parentId"]
-            if f in nodes and status.get(f) not in ("completed", "cleared"):   # rollup status, not raw nodeComplete (see perm floor)
-                api_top = f
-        # JUDGE-AUTH floor (the user 2026-08-12): this session's judges are failing on their CREDENTIAL
-        # (judge.py latched a credential-class error envelope; its next successful call clears it) — romp
-        # cannot analyze the session, so no card here can move on its own, and only the user can fix it
-        # (the key, the login, or the session's billing pick). Floor the focus top to needs-you wearing
-        # the story: the alternative was a board silently frozen in Working, which is exactly how a
-        # login-less host spent 13 hours and ~53k refused calls without a pixel changing. Yields to the
-        # LIVE floors (a permission prompt, the session's own API error): one interrupt at a time, the
-        # present event first — and the api floor's authErr copy already names the same credential fix.
-        jerr = _jauth_map.get(fsid)
-        jauth_top = None
-        if jerr and api_top is None and perm_top is None:
-            f = store.get("lastNode")
-            while f and nodes.get(f, {}).get("parentId") is not None:
-                f = nodes[f]["parentId"]
-            if f in nodes and status.get(f) not in ("completed", "cleared"):
-                jauth_top = f
-        _unnested = False
-        for _f in (perm_top, api_top, jauth_top):    # T319: a floor that RESOLVES to a healed top un-nests exactly that top:
-            _h = healed.get(_f) if _f else None      #   it keeps its card (the floor keys the card on it) and its face; the
-            if _h and _h[0] and _f in children.get(_h[0], []):   #   host's other rows are untouched
-                children[_h[0]].remove(_f)
-                children.setdefault(None, []).append(_f)
-                healed[_f] = (None, _h[1])
-                heal_total -= 1
-                _unnested = True
-            elif _h and _h[1].get("hidden") and _f in _hidden:   # T333: a hidden top the floor keys on comes back as a card
-                children.setdefault(None, []).append(_f)
-                healed[_f] = (None, {k: v for k, v in _h[1].items() if k != "hidden"})
-                _hidden.discard(_f)
-                hidden_total -= 1
-                _unnested = True
-        if _unnested:                                # the derivations below read the tree the card SHOWS (item 8 of the
-            agent_open = _agent_open_set(nodes, children)   #   fourth review): recomputed over the un-nested layout
-            parked_rows = _parked_rows(nodes, children)
-        plain_user_t = _last_plain_user_turn_t(ps["turns"]) if ps else 0   # re-check: a plain reply after a soft block de-urgents it
-        had_working = False                          # does this session show ANY working card? → drives the provisional placeholder
-        had_awaiting = False                         # …and does any of them read AWAITING? → the session's await-green dot (below)
-        # The live background-task set, once per session: OWNERSHIP for the blocked-yield below (any live
-        # task counts there — the yield keys on the dispatch event, not on classification), and the
-        # judge-classified SERVICES for the neutral per-session chip (the user 2026-07-24). Idle-gated
-        # like the awaiting signal: an actively producing turn is just working.
-        live_tasks = _bg_live_norm(fsid, s["path"]) if (ps and not who_working) else []
-        owned = _bg_owner_tops(fsid, s["path"], live_tasks) if live_tasks else {}
-        if live_tasks and live:
-            svc = _bg_service_descs(fsid, s["path"])
-            if svc:
-                bg_services[name] = svc
-        for nid in children.get(None, []):
-            col = status.get(nid, "working")
-            if col == "cleared" or nid in cleared:
-                continue
-            if _pure_delegation_top(nodes, nid, sid=fsid, path=s["path"]):   # whole top is just peer
-                continue                                 # handoffs → coordination, not an inbox card
-            # AWAITING floor (event-based, the user 2026-06-22): a session paused on dispatched/delegated
-            # work is a WORKING flavor, never needs-input. Floor a working OR stale-blocked top to awaiting
-            # from (a) the session-level awaiting signal (live subagents / SDK states overlay),
-            # or (b) an unanswered outbound to a LIVE peer (postal wait-for — a stale block on a peer-waiting
-            # session yields to it). The live permission / API-error floors still win (the present event).
-            # the peer-wait only applies to a goal that EXISTED when the question was sent — a goal minted
-            # AFTER it can't be awaiting that answer (the user 2026-06-28). Scopes the stale session-level
-            # wait off unrelated newer goals; if every pre-question goal is resolved, nothing floors.
-            _peer_wait = (fsid in wmap and nodes[nid]["t"] <= wmap[fsid]["since"])
-            # A blocked top yields ONLY to a background task ITS OWN subtree dispatched, and only when
-            # that dispatch is NEWER than the block's own evidence. Two guards, both exact:
-            #  - OWNERSHIP (the user 2026-07-17, quartz): the 07-15 time-only guard compared the
-            #    session-wide newest dispatch — a campaign watcher relaunched after a kernel restart
-            #    (89s after an UNRELATED card's block) re-dressed a genuine needs-you as the await-green
-            #    awaiting badge. _bg_owner_tops resolves each live task's launch to its placed top;
-            #    a task owned elsewhere — or one whose launch can't be attributed (subagents, the
-            #    overlay, an unplaced launch) — never flips a blocked card. Genuinely stale blocks are
-            #    retired by the judge's own unblock path (new work filed on this branch), which is
-            #    placement-exact; this floor no longer approximates it session-wide.
-            #  - EVENT ORDER (the user 2026-07-15): even an owned task yields only when dispatched at/
-            #    after the block — an ask newer than the dispatch is live (nimbus ended its turn asking
-            #    the user questions while its own background timer ran).
-            _await_ok = bool(sess_awaiting_why)
-            _owned_why = None
-            _owned_since = None
-            if col == "blocked":
-                _blk_t = max([nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid)
-                              if nodes[x].get("blocked") and not _closure_done(x)] or [0])
-                _own = owned.get(nid)
-                # The yield stands on ownership + event order ALONE (no session-awaiting gate): under the
-                # service split, a placed launch no longer feeds sess_awaiting_why, but a dispatch from
-                # the blocked card's own thread still proves the thread moved past the block.
-                _await_ok = bool(_own) and _own["since"] >= _blk_t
-                if _await_ok:
-                    _owned_why = "waiting on a background command%s" % (   # the chip's word for in-harness work (2026-09-05)
-                        (": " + _own["descs"][0]) if _own["descs"] else "")
-                    _owned_since = _own["since"]           # the dispatch event that proved the yield
-            # The JUDGE's durable ⏳ stamp (the closer's awaiting verdict, kernel/judge.py): this goal's
-            # latest audited turn ended waiting on async work it set in motion. Store-backed, so it holds
-            # across kernel restarts — exactly where the live snapshot signals above go dark and a
-            # genuinely-waiting goal used to read as plain working, then "stalled". It floors WORKING
-            # only: a real needs-you (block) always outranks the annotation.
-            _sf = (_goal_awaiting_stamp_full(nodes, nid, children, answered_at=_peer_answered(fsid))
-                   if col == "working" else None)
-            _stamp_why = _sf[1] if _sf else None
-            _stamp_kind = _sf[2] if _sf else None
-            _stamp_since = (_sf[0] or None) if _sf else None   # the stamp's awaitingAt — when the judge filed the wait
-            # the stamp arm NAMES its peers too (2026-08-26): the judge's awaitPeers keys resolve through
-            # the one identity ladder, so a judge-classified peer wait wears the same identity chips the
-            # delegation arm always has — before this the or-chain hardcoded peers=None on this arm
-            _stamp_peers = (sorted((_peer_identity(p) for p in _sf[3]), key=lambda d_: d_["name"])
-                            if _sf and _stamp_kind == "peer" and _sf[3] else None)
-            # DELEGATION-derived awaiting (the courier's durable handoff graph, not the question-regex):
-            # every OPEN leaf under this top is a handoff-tracking node → the only outstanding work lives
-            # with peers, so the card reads ⏳ "delegated to <peer>" instead of plain working (which reads
-            # as "this session should be doing something"). Ends on the graph's own event: run_propagate
-            # checks the handoff off the moment the peer's linked goal completes. The session-scoped
-            # surfaces (rail/chat/timeline) read the SAME evidence via _session_delegated_why in
-            # _session_awaiting's stamp branch — keep the two in step (the user 2026-08-08).
-            _deleg_why = None
-            _deleg_since = None
-            _deleg_peers = None
-            if col == "working" and not _stamp_why and not _await_ok \
-                    and _all_outstanding_delegated(nodes, nid):
-                # the SAME open test the gate used (2026-08-26): _all_outstanding_delegated proved every
-                # OPEN LEAF is a handoff via _open_leaves (whose agent-open pierce ignores a done marker),
-                # so the peers/since read here must walk the same set — the raw nodeComplete filter this
-                # replaces could see an EMPTY set the gate saw as non-empty, minting a nameless, durationless
-                # "delegated to a peer" card
-                _hnodes = [x for x in _open_leaves(nodes, nid)
-                           if isinstance(nodes[x].get("handoff"), dict)]
-                _deleg_peers = _handoff_peer_identities(nodes, _hnodes)
-                _peers = sorted({d["name"] for d in (_deleg_peers or [])} or {"a peer"})
-                _deleg_why = "delegated to %s; waiting on their result" % ", ".join(_peers)
-                # the newest outstanding handoff's mint — the last local act before the wait began
-                _deleg_since = max([nodes[x].get("t") or 0 for x in _hnodes] or [0]) or None
-            if nid != api_top and nid != perm_top and col in ("working", "blocked") and (
-                    _await_ok or _stamp_why or _deleg_why or (col == "blocked" and _peer_wait)):
-                col = "awaiting"
-            # TRACKED delegation payloads (the user 2026-08-24): a report-back handoff renders as ONE
-            # card homed under the DELEGATOR. The sender's card is the PRIMARY — delegTracked names
-            # the recipient identities so the feed shows their live status right on it — and the
-            # recipient's planted copy is the SATELLITE (origin.tracked below) the feed collapses
-            # off the default board, still one click away via that session's own views (nothing runs
-            # in secret, 2026-08-11). Both keys ship only when present, so every untracked payload
-            # is byte-identical to before. The pair link stays the courier's msgId graph: clears and
-            # run_propagate cross it unchanged.
-            _tracked_hn = [x for x in _subtree(nid)
-                           if isinstance(nodes[x].get("handoff"), dict) and nodes[x]["handoff"].get("tracked")
-                           and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]
-            _tracked_peers = (_handoff_peer_identities(nodes, _tracked_hn) or None) if _tracked_hn else None
-            o = nodes[nid].get("origin")             # courier delegation provenance: planted by a peer
-            origin = None
-            if isinstance(o, dict) and o.get("peer"):
-                # The "↪ from <peer>" badge is PROVENANCE and stays for the card's life (the user
-                # 2026-08-16: the badge used to vanish at the exact moment the recipient finished —
-                # run_propagate completes the sender's tracking node instantly — so a COMPLETED card
-                # never showed where its work came from, and a propagated clear read as one card
-                # mysteriously taking another with it). origin_live says whether the sender's linked
-                # goal is still OPEN: live → the affordance of an active handoff; absorbed → the same
-                # badge, dimmed, purely historical. This is the completed-column MERGE, heuristic-free:
-                # the one surviving card wears both identities, keyed on the courier's recorded link.
-                # NAMED origin_live, never `live`: this block once reused the session-level `live` —
-                # the backend-alive bit set at the top of the session loop — so every LATER card of
-                # the session, and the placeholders built after the loop, wore the badge's bool: a
-                # live session's cards dressed .dead and took the revive path; a dead session's
-                # offered Continue. Badges persist for the card's life, so one absorbed badge
-                # poisoned the session's whole card tail.
-                psid, gid = o["peer"], o.get("goalId")
-                pstore, pfault = jd.load_goals_shared_or_fault(psid) if gid else (None, None)   # read-only peer view
-                sgoal = pstore.get("nodes", {}).get(gid) if pstore is not None else None
-                origin_live = bool(sgoal and not sgoal.get("nodeComplete") and not sgoal.get("cleared")
-                                   and gid not in cleared)   # a sender whose store faults reads absorbed (dimmed,
-                #                                              no affordance) rather than aborting the build
-                # Name resolution: the live names registry first (a local sender may have been
-                # renamed), then the courier's plant-time snapshot (the only source for a
-                # FEDERATED sender, whose sid this kernel can't resolve), then the sid stub.
-                # peerHost renders as the same quiet "host:" prefix remote sessions wear on the
-                # timeline (host-prefix.ts) — a local resolve means a local sender, no host.
-                pname = _name_of(psid)
-                origin = {"peer": pname or o.get("peerName") or psid[:8],
-                          "peerHost": ("" if pname else o.get("peerHost") or ""),
-                          "peerSid": psid, "color": _name_color(psid), "live": origin_live}
-            # SENDER-SIDE handoff provenance (the user 2026-08-24): a TOP-LEVEL "↪ delegated to
-            # <peer>" tracking node wore its provenance as the card TITLE, arrow and all. The card
-            # now titles the WORK and ships the delegation as the badge mirroring origin above —
-            # see _handoff_card_fields. Every other card keeps its text untouched.
-            handoff_to, card_text = _handoff_card_fields(nodes, nid)
-            await_why = (sess_awaiting_why or _stamp_why or _deleg_why or _owned_why) if col == "awaiting" else None   # the ⏳ awaiting badge's "why": live snapshot, then the judge's durable stamp, then the delegation graph, then the blocked-yield's owned dispatch (None for the postal-only case → the waitingOn chip names the peer)
-            await_kind = None                        # the winning why's KIND and SINCE ride beside it,
-            await_since = None                       # mirroring the or-chain exactly (a kindless winner
-            await_peers = None                       # stays kindless; since = the wait's own event time).
-            await_count = None                       # how many are awaited — the SAME number the chat chip words itself
-            await_items = []                         # the awaited ROWS the pill lists, grouped by kind (slice 2, 2026-09-05)
-            if col == "awaiting":                    # from (T228, the user's one-count rule): the live snapshot's own
-                # count, the peers a stamp or delegation names, one owned dispatch; None when the arm cannot know
-                for _w, _k, _s, _p, _n, _it in ((sess_awaiting_why, sess_awaiting_kind, sess_awaiting_since, sess_awaiting_peers, sess_awaiting_count, sess_awaiting_items),
-                                                (_stamp_why, _stamp_kind, _stamp_since, _stamp_peers, (len(_stamp_peers) if _stamp_peers else None), _awaiting_peer_items(_stamp_peers)),
-                                                (_deleg_why, "peer", _deleg_since, _deleg_peers, (len(_deleg_peers) if _deleg_peers else None), _awaiting_peer_items(_deleg_peers)),
-                                                (_owned_why, "task", _owned_since, None, 1, [])):
-                    if _w:
-                        await_kind, await_since, await_peers, await_items = _k, _s, _p, _it
-                        await_count = _n if isinstance(_n, int) and _n > 0 else None
-                        break
-            # The card's TIME reflects its CURRENT STATE, not when the goal was minted: a COMPLETED card
-            # shows when it was completed, a BLOCKED card when it was blocked — the mt of the most-recent
-            # such node in its subtree — else (working/awaiting) its LAST ACTIVITY (the newest mt anywhere in
-            # its subtree, _fsubmax). Keying the time badge to the mint `t` made a goal OPENED hours ago but
-            # FINISHED moments ago read as "done hours ago" (the user 2026-06-19); the same pin made a WORKING
-            # goal you JUST replied to still read "15m ago" instead of freshening — a reply advances the goal's
-            # mt, so the card must too (the user 2026-07-01). `created` keeps the true mint time for the record.
-            disp_t = _fsubmax(nid)
-            if col == "completed":
-                # A completed card's time is when the WORK finished / it SETTLED — NEVER a later re-judge that
-                # re-touches the UMBRELLA node's own mt without changing anything (the user 2026-07-08: an
-                # hours-old completed card jumped to "3m ago" after a no-op re-judge re-stamped the top node's
-                # mt; a re-materialize can advance mt even when nothing changed). So derive ONLY from stable
-                # evidence: the settle time + the done DESCENDANTS' completion mt — excluding the top node `nid`
-                # itself, whose (re-touchable) mt _fsubmax had already folded in.
-                dts = [nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid) if x != nid and _closure_done(x)]
-                # settledAt = when the card actually ENTERED the Completed column (the judge stamps it ONCE at
-                # settlement — NOT re-bumped by a no-op re-judge, verified stable while the umbrella mt drifted;
-                # it can lag the done op's mt by many segments). The column sorts by `t` oldest-at-top, so a
-                # just-settled card drops to the BOTTOM where the eye expects it, above older completions whose
-                # stale mt was even further back (the user 2026-06-29).
-                cand = max([nodes[nid].get("settledAt") or 0] + dts)   # settle time OR a real late-completing leaf
-                disp_t = cand or disp_t                                # both absent (legacy/childless) → keep _fsubmax
-            elif col == "blocked":
-                bts = [nodes[x].get("mt", nodes[x]["t"]) for x in _subtree(nid)
-                       if nodes[x].get("blocked") and not _closure_done(x)]
-                if bts:
-                    disp_t = max(bts)
-            # followupAt = when a follow-up OPTIMISTICALLY moved this card into Working (optimistic_followup
-            # stamps it at the flip). Same idea as the Completed column's settledAt: the column sorts
-            # oldest-at-top, so without this the card sorts by its stale blocked-era mt and appears at the TOP,
-            # then the judge re-files the real follow-up work (≈now) and it lurches to the BOTTOM. Flooring
-            # disp_t to now at the flip lands it at the bottom AT ONCE, where the re-file will keep it — no jump
-            # (the user 2026-07-03). Once real work lands, _fsubmax passes followupAt and this is moot.
-            if col == "working":
-                disp_t = max(disp_t, nodes[nid].get("followupAt") or 0)
-            # RE-CHECK (the user 2026-06-27): a SOFT-blocked top you've answered with a TARGETED card-reply/nudge
-            # (followupPending on the top — precise, only this card) is no longer on YOU. It de-urgents (dotted,
-            # dropped from the needs-you tally) and drops to WORKING until the judge resolves or re-blocks it.
-            recheck = bool(col == "blocked" and nid != api_top and nid != perm_top
-                           and nodes[nid].get("followupPending"))
-            # RE-JUDGING (the user 2026-06-30; MOVED to Working 2026-07-02): a PLAIN reply on the thread
-            # AFTER the block moves the card to WORKING — it's the agent's move now, and the delay before
-            # the card left Needs-You was the user's complaint (2026-07-02). The flag holds until the
-            # UNBLOCKER has re-examined the block with evidence covering the reply (blockCheckT, its
-            # persisted watermark, reaches the reply); then the card returns to Needs-You exactly once —
-            # or leaves authoritatively if the judge lifted the block. The "Re-judging…" swirl rides along
-            # in Working. Never the hard floors (api/permission).
-            #
-            # LATCHED ON THE WATERMARK, NOT THE OPEN TURN (the user 2026-07-29). The flag used to be
-            # bounded by who_working, which made a blocked card on an ACTIVE session strobe
-            # working↔needs-you at every turn boundary — the audited card flipped seven times in six
-            # minutes while nothing about it changed. The turn-bound was a proxy for "the judge hasn't
-            # ruled on the reply yet"; blockCheckT IS that event: the unblocker advances it on every
-            # examine AND on the parse give-up path, so the latch cannot stick past a judge look. This is
-            # the same trust the TARGETED-reply arm (followupPending) already places in the judge to
-            # clear its store-backed flag. Cards move on new information, never on activity boundaries.
-            #
-            # NO ECHO ARM (the user 2026-07-22): the flip used to ALSO ride the backend send-echo
-            # (echo_send_t), for a sub-second flip before the turn's atom lands in the cached parse. At the
-            # time a composer slash-command echo never retired (its transcript form is the "<command-name>"
-            # wrapper, which did not text-match the raw echo; since 2026-09-10 the echo lands under
-            # sb.command_text_key, see _echo_landed_in), and the parser skips it from the human floor, so
-            # the stale echo pinned rejudging TRUE forever: the card sat in Working, idle, invisible to the
-            # nudge (which reads the still-blocked store). The latch arms only off the PARSE's plain-reply
-            # turn (a real transcript atom, never the echo), and the watermark clear is judge-driven, so
-            # the stranded-echo failure stays impossible whatever an echo does.
-            # The watermark that bounds the latch is the one covering THE BLOCK THE CARD SURFACES —
-            # a descendant's, when the block rolled up (_block_check_floor above; the user 2026-07-31).
-            _bct = _block_check_floor(nid)
-            rejudging = bool(col == "blocked" and nid != api_top and nid != perm_top
-                             and not nodes[nid].get("followupPending")
-                             and plain_user_t > disp_t
-                             and plain_user_t > (_bct if _bct is not None
-                                                 else (nodes[nid].get("blockCheckT") or 0)))
-            # awaiting is a flavor of WORKING → the working column (never needs-input), card time = mint t; the awaiting badge carries the why.
-            # A RE-CHECK'd soft-block (targeted follow-up) drops to WORKING (the user 2026-06-27): once you've
-            # replied to THAT card it's the agent's move, not yours, so it leaves the needs-input column entirely
-            # (still dotted + a "Re-judging…" swirl so you can see it pending). A plain reply (rejudging) now
-            # ALSO drops to Working — but only WHILE in flight (see the rejudging comment above).
-            # A TRANSIENT API error is NOT blocking either (the user 2026-06-29):
-            # auto-retry recovers it, so the card STAYS in Working with the "⚠ API error" chip. But a "prompt
-            # is too long" error IS on you (compact needed) → it floors to needs-input like a real block. So
-            # only api_top WHEN tooLong, or a genuine soft block (col blocked & not recheck), keeps needs_input.
-            # A MODEL-scoped usage limit joins them (the user 2026-08-01): the session cannot run another
-            # turn until you switch model or top up, so leaving the card in Working left a working card on
-            # a session nothing could move — not nudged (the api-error gate suppresses it), not blocked,
-            # not awaiting, for 80 minutes.
-            # A safeguards REFUSAL joins them (the user 2026-08-15): deterministic on the same input,
-            # never auto-retried, so a Working card would sit on a session nothing can move — the
-            # human rewriting or dropping the ask IS the only unblock.
-            api_block = (nid == api_top and bool(aerr and (aerr.get("tooLong") or aerr.get("spendLimit")
-                                                          or aerr.get("modelLimit")
-                                                          or aerr.get("authErr") or aerr.get("refusal"))))
-            # NUDGE FAILED (plans/stalled-open-todos-nudge.md, the user 2026-07-01): the tick stamped
-            # `failed` on this goal's nudge record — the nudge-response turn completed (judged) and the goal
-            # was still working-stalled; per the anti-loop rule it is never re-nudged, so the card carries
-            # the story instead. Surfaced only while the goal still reads working (a later block/completion
-            # resolves it, and `awaiting` means it's genuinely in flight — no failure to show then). A FORK
-            # nudge (`stalled` — the goal had open authoritative to-dos) that failed additionally FLOORS the
-            # card to needs-you: the agent can't self-block a to-do, we asked once, nothing moved — the
-            # human is the bottleneck now. The floor keeps requiring open to-dos AT DISPLAY TIME (agent_open)
-            # so it self-heals the instant the agent crosses the items off; the live api/permission floors
-            # still win (the present event).
-            nrec = _auto_nudge_data().get("nudged", {}).get(nid) or {}
-            _stall_rec = _stalls.get(nid)             # romp is holding this card (see "stalled" in the payload)
-            # ROUTING (2026-08-13): an in-flight-class hold (jd.WHY_IN_FLIGHT — romp's own review is the
-            # wait) presents as the Analyzing… swirl, never the stalled chip; every other hold paints the
-            # Stalled section. The old screen hid the in-flight records from BOTH surfaces, so one frozen
-            # between retries showed nothing — now the sweep retires them on their events and whatever
-            # stands presents somewhere by definition.
-            _stall_inflight = bool(_stall_rec and _stall_rec.get("why") in jd.WHY_IN_FLIGHT)
-            if _stall_inflight:
-                _stall_rec = None
-            # HARD RULE (the user 2026-08-13): a stalled card on a session that isn't doing anything
-            # files under BLOCKED — it needs eyes, whoever's bottleneck it is; Working is where it hid.
-            # This supersedes the 2026-07-23 "Working column only" stance. Keyed on the stall RECORD
-            # (event-latched: minted by the walk, popped by the sweep) plus the session's idle read —
-            # the same displacement precedent as recheck/rejudging's de-urgent smoothing: the session
-            # taking a turn IS new information, and the card returns to Blocked if the hold outlives it.
-            _stall_block = bool(_stall_rec and not who_working and not sess_awaiting_why)
-            # the chip shows while the failure is the live story: the goal still working, OR blocked BY the
-            # failure itself (the diary's latest block has src "nudge", 2026-07-07). A real judge verdict
-            # (planner/closer block, or completion) takes the story over and the chip yields.
-            _lastblk = next((e.get("src") for e in reversed(nodes[nid].get("log") or [])
-                             if e.get("kind") == "block"), None)
-            # ...and "takes the story over" must survive the card going BACK to working (the user 2026-07-09:
-            # g143 wore "stalled" although the closer had ruled it done after the failed nudge and a later
-            # user follow-up reopened it). The `failed` flag only resets on the NEXT nudge fire, so the
-            # working arm alone would resurrect the chip forever. Event-based retire: any diary event from a
-            # real actor (planner/closer/courier/user/agent) AFTER the nudge's own block means the stall was
-            # answered — the chip yields for good, whatever column the card is in now.
-            _nlog = nodes[nid].get("log") or []
-            _nblk_at = next(((e.get("at") or e.get("ev_t") or 0) for e in reversed(_nlog)
-                             if e.get("kind") == "block" and e.get("src") == "nudge"), None)
-            # The row is the retire anchor, but it's also the write most exposed to a judge pass's
-            # stale save (g52, 2026-07-16: the planner's held-store save erased it while `failed`
-            # survived in auto-nudge.json — with _nblk_at None the chip could never retire, and it
-            # said "waiting on you" straight through the user's own follow-up). Fall back to the
-            # failure stamp's own time (failedAt, written with `failed`); a legacy record carrying
-            # neither retires on any user event at all — of the two failure modes, a false
-            # "waiting on you" is the one that breaks flow.
-            _nfloor = _nblk_at if _nblk_at is not None else nrec.get("failedAt")
-            # "unblocker" is a real actor here (the user 2026-08-14: its unblock ruled the nudge's
-            # block answered and moved the card back to Working, while the chip — whose claim IS that
-            # block — survived it, a red "waiting on you" on a card the judges had just un-waited)
-            _story_moved = (any((e.get("at") or e.get("ev_t") or 0) > _nfloor
-                                and e.get("src") in ("planner", "closer", "courier", "user", "agent",
-                                                     "unblocker")
-                                for e in _nlog) if _nfloor is not None
-                            else any(e.get("src") == "user" for e in _nlog))
-            nudge_failed = (bool(nrec.get("failed")) and not _story_moved
-                            and (col == "working" or (col == "blocked" and _lastblk == "nudge")))
-            # A live picker/permission floor (perm_top) is a GENUINE block, so the kernel reports its column as
-            # needs_input — NOT "working" with the client re-routing it by it.blocked (which was crafty + split
-            # the truth: build_feed said working while the card showed under Blocked, and the distiller line,
-            # keyed on it.column, then stayed hidden). Now it.column is authoritative: the card IS blocked, the
-            # client files by it.column, and the distiller line shows (the user 2026-06-29).
-            column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top or _stall_block
-                                        or (col == "blocked" and not recheck and not rejudging))
-                      else "completed" if col == "completed" else "working")
-            had_working = had_working or column == "working"
-            had_awaiting = had_awaiting or col == "awaiting"   # the FLAVOR, not the column: awaiting rides Working
-            # distillState (the user 2026-07-21): which distilled line the CARD should show — keyed on the
-            # GENUINE resolution state, NOT the transient `column`. recheck/rejudging drop a still-blocked
-            # card to Working the moment its session takes a turn (de-urgent smoothing), and `column`, keyed
-            # on that, flickered the decision brief OFF every time — so a busy session's blocked card read as
-            # "unblocked, no summary" (the docs thread). distillState rides the real block (api_block /
-            # perm_top / col=="blocked"), so the brief/takeaway stays put through the re-judge window; the
-            # column still moves for placement. Completed is stable (never recheck/rejudged), so it matches.
-            distill_state = ("completed" if col == "completed"
-                             else "blocked" if (api_block or nid == jauth_top or nid == perm_top
-                                                or col == "blocked")
-                             else None)
-            # summaryAnchorUuid: where a click on the distilled summary line lands.
-            # COMPLETED goals pin to the COMPLETION TURN'S wrap-up — event-derived, not a guess: the
-            # closer's DONE-ANCHOR appended the completing turn's final segment as the node's trail tail
-            # (judge _close_turn), so that segment's last substantive assistant block is the big turn-end
-            # recap the user expects the summary to open on (the user 2026-07-14: the distiller's own
-            # citation kept naming a mid-turn status note that merely passed the prose floor).
-            # NEXT: the anchor the distiller/brief itself CITED while writing the line
-            # (node["summaryAnchor"], judge _split_source) — the reader that wrote the summary names what
-            # it read (the user 2026-07-01); honored only when the uuid resolves in this parse AND carries
-            # substantive prose (cite_uuids — a citation on a connective stub is wrong by construction,
-            # the user 2026-07-14). This is the primary tier for a BLOCKED brief (no completion turn
-            # exists) and for a completed goal whose recap segment is tool-only.
-            # FALLBACK (older goals, no/invalid/stub citation): the most CURRENT substantive assistant
-            # message across the goal's whole subtree trail (mint→resolution). Never the old
-            # biggest-text-block pick: "longest ever" is monotone, so a long early analysis held the
-            # anchor forever while the real outcome landed later (the user 2026-07-01).
-            _sa_u, _cited = None, nodes[nid].get("summaryAnchor")
-            if col == "completed":
-                # The newest trail TAIL across the SUBTREE, not just the top's own (the user 2026-07-15,
-                # the g91 click): a BOTTOM-UP-completed umbrella (all children done) has no done verdict
-                # of its own, so the DONE-ANCHOR never appended a completing segment to ITS trail —
-                # trail[-1] was still the MINT segment and the pin sent the summary click to the goal's
-                # oldest prose instead of the wrap-up the distiller correctly cited. A child's
-                # done-anchored tail IS its completing turn's segment, so the newest substantive tail is
-                # the completion recap for both shapes (an explicitly-done top's own tail stays newest).
-                _tail = None                             # (seg_t, uuid) of the newest substantive tail
-                for _x in _subtree(nid):
-                    _tr = nodes[_x].get("trail") or []
-                    if not _tr:
-                        continue
-                    _u, _sub, _t = seg_best.get(_seg_key(_tr[-1]), (None, False, 0))
-                    if _u and _sub and (_tail is None or _t > _tail[0]):
-                        _tail = (_t, _u)
-                if _tail:
-                    _sa_u = _tail[1]
-            if _sa_u is None and _cited and _cited in cite_uuids:
-                # THE GROUNDING CAN BE OUTRUN (the user 2026-08-28, T153): the citation names what
-                # the summary was WRITTEN FROM — but a reply that reopens the card adds stretches
-                # the stored summary has never seen (no re-completion yet, so no re-distill event),
-                # and the click then lands in the stale FIRST stretch of a visibly two-stretch
-                # card. When the follow-up stamp or any subtree trail segment postdates the
-                # summary's own coverage stamp, the cited tier YIELDS to the most-current-
-                # substantive walk below, so the click follows the freshest evidence; the citation
-                # resumes authority the moment a re-distill lands (the stamp catches up).
-                # Display-only: no column implication.
-                _cov = max(int(nodes[nid].get("distilledMt") or 0),
-                           int(nodes[nid].get("briefedMt") or 0))
-                _outrun = bool(_cov) and (
-                    (nodes[nid].get("followupAt") or 0) > _cov
-                    or any((seg_best.get(_seg_key(_sid), (None, False, 0))[2] or 0) > _cov
-                           for _x in _subtree(nid) for _sid in (nodes[_x].get("trail") or [])))
-                if not _outrun:
-                    _sa_u = _cited
-            if _sa_u is None:
-                _best = None                             # (substantive, seg_t): prefer substantive, then latest
-                for _x in _subtree(nid):
-                    for _sid in (nodes[_x].get("trail") or []):
-                        _u, _sub, _t = seg_best.get(_seg_key(_sid), (None, False, 0))   # timestamp-invariant: resolve a drifted trail seg id
-                        if _u and (_best is None or (_sub, _t) > (_best[0], _best[1])):
-                            _best = (_sub, _t, _u)
-                if _best:
-                    _sa_u = _best[2]
-            if not _sa_u:
-                # LAST RESORT (the user 2026-07-02: a completed card's summary was unclickable — the cited
-                # atom fell outside every segment, and no trail segment offered prose either). Fall back to
-                # the newest trail segment's WORK anchor (seg_uuid — the same target the modal's node rows
-                # nav to), so the summary still deep-links to roughly where the work concluded. Only a goal
-                # with NO resolvable trail at all ends up link-less.
-                for _x in _subtree(nid):
-                    for _sid in reversed(nodes[_x].get("trail") or []):
-                        _u = seg_uuid.get(_seg_key(_sid))
-                        if _u:
-                            _sa_u = _u
-                            break
-                    if _sa_u:
-                        break
-            if _sa_u is None and ps is None:
-                # COLD-PARSE fallback (the user 2026-07-20): every tier above reads parse-derived maps,
-                # and right after a kernel restart ps is None until _warm_fleet_bg — so for that window
-                # EVERY card shipped summaryAnchorUuid null and the summary click hit the "no anchor was
-                # recorded" toast (a lie: the anchor is on the node). With no parse to validate against,
-                # serve the distiller's stored citation raw — the chat's own landing handles a bad uuid
-                # honestly, and the validated tiers take back over on the first warm push.
-                _sa_u = _cited
-            card = {
-                "itemId": nid, "sid": fsid, "name": name, "color": color, "text": card_text,
-                "t": disp_t, "live": live,
-                "trgb": list(cm.age_rgb(now - disp_t, _colormap())),
-                "turnId": nid, "origin": origin,
-                **({"handoffTo": handoff_to} if handoff_to else {}),
-                **({"delegTracked": _tracked_peers} if _tracked_peers else {}),
-                # the satellite hides ONLY while the pair is INTACT and the work runs its normal
-                # course: a needs-you block always surfaces (interrupt only when the human is the
-                # bottleneck), and a primary that closed or cleared un-hides the copy — origin.live
-                # reads the PRIMARY handoff node, so every pair divergence self-heals to a visible
-                # card instead of work running in secret (review 2026-08-24).
-                **({"satellite": True} if isinstance(o, dict) and o.get("tracked")
-                   and origin and origin.get("live") and column != "needs_input" else {}),
-                "followupPending": nodes[nid].get("followupPending"),   # optimistic reopen → "Followed up" chip until the judge catches up
-                "followupAt": nodes[nid].get("followupAt") or None,   # WHEN the follow-up/continue went — the latched button's honest age (T150)
-                # DONE-CONFIRMING (the user 2026-07-24): the done verdict is in; only the settle event is
-                # pending. The card STAYS in Working (the settle gate exists precisely so the column never
-                # flickers working↔done) and wears a steady "done, confirming" cue instead. From the
-                # rollup's authoritative export, never the raw nodeComplete flag (which lies for agent-open
-                # umbrellas is_complete refuses).
-                "doneConfirming": (True if (column == "working" and nid in confirming) else None),
-                "waitingOn": (wmap.get(fsid) if (column == "working" and _peer_wait) else None),   # 'waiting on <peer>' chip: unanswered outbound to a live peer, only on a goal that predates the question (the user 2026-06-22/28)
-                # awaiting flavor: held in Working with a ⏳ awaiting badge (waiting on dispatched/delegated
-                # work) — the user 2026-06-22. `tasks` = the live bg-task descriptions (the user 2026-07-13):
-                # when present the card wears the compact "Waiting on task" pill (expands to this list, like
-                # Sub-goals) instead of the boxed why; empty for subagent/overlay flavors, which keep the box.
-                "awaiting": ({"why": await_why, "kind": await_kind, "since": await_since,
-                              "count": await_count,   # the one number every surface words itself from (T228)
-                              "peers": await_peers,   # delegation wait → [{name, host, sid, color}] for the identity-coloured box (the user 2026-08-23)
-                              "items": await_items,   # the awaited rows, grouped by the pill's expansion (slice 2)
-                              "tasks": _awaiting_task_descs(fsid, s["path"])} if col == "awaiting" else None),
-                "summary": nodes[nid].get("summary"),    # the distiller's key takeaway for a completed goal (modal) — the user 2026-06-17
-                "distillState": distill_state,   # "completed" | "blocked" | null — the GENUINE state the distiller line keys on, so the brief/takeaway doesn't flicker off when recheck/rejudging drops `column` to working (the user 2026-07-21)
-                "blockSummary": nodes[nid].get("blockSummary"),    # the block-distiller's decision brief for a blocked goal (modal); null until produced — the user 2026-06-18
-                "relayNote": nodes[nid].get("relayCarried") or None,   # a far host still holds a relayed question after its wait ended (relayCarried): the card's own line under the brief, never a brief paragraph (the per-paragraph stamps map briefParts onto the brief's paragraphs and allow exactly one extra)
-                "briefParts": nodes[nid].get("briefParts") or None,   # MULTI-item brief: [{id, since}] one per paragraph IN ORDER (judge briefParts) → per-paragraph "Nm ago" stamps; null for single-item briefs, whose stamp is the card header's age (the user 2026-07-24)
-                "summaryParts": nodes[nid].get("summaryParts") or None,
-                # the user FOLLOWED UP after the takeaway they read (followupAt postdates what the
-                # summary covers) → the summary section says so instead of presenting the old takeaway
-                # as current; self-clears when the re-distill stamps a newer distilledMt (16 live cards
-                # measured reading stale, the user 2026-08-19)
-                "summaryStale": bool((nodes[nid].get("followupAt") or 0) > (nodes[nid].get("distilledMt") or 0)
-                                     and (nodes[nid].get("summary") or "").strip()) or None,   # the DONE twin: [{id, since}] per takeaway paragraph when the distiller split by <completed-items>; done-event times (the user 2026-07-24)
-                "background": nodes[nid].get("background"),    # the distiller's BACKGROUND section: re-orientation for a reader who forgot the thread — collapsed by default on the card (the user 2026-07-02)
-                "summaryAnchorUuid": _sa_u,    # click the summary line → the completion turn's wrap-up (completed pin), else the cited/latest prose (the user 2026-07-14)
-                # the supporting SPAN (T218): the distiller's verbatim quote, located in the cited atom at
-                # write time — shipped ONLY while the resolved anchor IS the cited atom (the fallback tiers
-                # land elsewhere, where the span would highlight the wrong text); the landing scrolls to
-                # and highlights it, and a null keeps today's whole-message behavior
-                "summaryAnchorQuote": (nodes[nid].get("summaryQuote")
-                                       if _sa_u and _sa_u == nodes[nid].get("summaryAnchor") else None),
-                # per-paragraph landings (T220, the user's ruling): each cited paragraph's own atom +
-                # located span, aligned to the takeaway's paragraphs (None = that paragraph falls back
-                # to the whole-summary landing). Gated exactly like the quote above: the cited tier
-                # must hold authority (the T153 outrun rule) — absent on old stores forever, no sweep.
-                "summaryAnchorsPara": ([({"u": e["a"], **({"q": e["q"]} if e.get("q") else {})} if e else None)
-                                        for e in nodes[nid].get("summaryAnchors") or []]
-                                       if (nodes[nid].get("summaryAnchors")
-                                           and _sa_u and _sa_u == nodes[nid].get("summaryAnchor")) else None),
-                "warns": nodes[nid].get("warns") or None,   # judge-stamped anomalies (judge _node_warn) → yellow "warning" chip; click shows each warn's what/why detail (the user 2026-07-02)
-                "failLog": nodes[nid].get("failLog") or None,   # the summarizer's failed attempts (judge _fail_log): model + literal error per try → the chip's hover history + modal "What was tried" (the user 2026-08-18)
-                "nudged": ({"count": int(nrec.get("count", 0)), "times": _nudge_times().get(nid, [])[-8:]}
-                           if nrec.get("count") else None),   # auto-nudge HISTORY (fires + when) → the stalled chip's evidence, on the chip tooltip + modal (the user 2026-07-02)
-                "blocked": ({"state": "apiError",
-                             # the OFFER (2026-08-30): login-billed + capped window + a key on hand →
-                             # the card proposes switching THIS session's billing; the pick is the
-                             # user's alone, both directions (see _cap_switch_offer)
-                             **({"capOffer": _cap_off} if _cap_off else {}),
-                             "status": aerr.get("status"),
-                             "text": aerr.get("text"), "tooLong": bool(aerr.get("tooLong")),
-                             "spendLimit": bool(aerr.get("spendLimit")),
-                             "modelLimit": bool(aerr.get("modelLimit")),
-                             "authErr": bool(aerr.get("authErr")),
-                             "refusal": bool(aerr.get("refusal")),
-                             "what": ("this account hit its monthly spend limit — raise it at claude.ai/settings/usage to continue" if aerr.get("spendLimit")
-                                      else "this session's prompt is too long — compact it to continue" if aerr.get("tooLong")
-                                      # the CLI's own text names the model and the two remedies; the card
-                                      # states them, because "Retry to resume" is false here (the user 2026-08-01)
-                                      else "this session's model is out of allowance — switch its model or add credits to continue" if aerr.get("modelLimit")
-                                      # a dead credential: retrying re-presents it forever — name the fix
-                                      # (per-session auth, the user 2026-08-08)
-                                      else "this session's sign-in or API key isn't working — fix the login (claude /login) or the key, or switch which one it bills" if aerr.get("authErr")
-                                      # a refusal is deterministic: retrying re-sends the same prompt and
-                                      # collects the same refusal — name the real fix (the user 2026-08-15)
-                                      else "the model's safeguards refused this prompt — rewrite it or drop this thread" if aerr.get("refusal")
-                                      else "this session stopped on an API error — Retry to resume")} if nid == api_top
-                            # the session itself is fine — it's romp's ANALYSIS of it whose credential is
-                            # refused, so the copy blames the judges, not the session (the user 2026-08-12)
-                            else {"state": "judgeAuth", "mode": jerr.get("mode"),
-                                  "since": jerr.get("t"), "text": jerr.get("note") or "",
-                                  "what": ("romp can't analyze this session — the API key its judges bill is being refused. Fix the key behind Claude Code's apiKeyHelper (rotate the vault item) or switch which account this session bills"
-                                           if jerr.get("mode") == "key" else
-                                           "romp can't analyze this session — the login its judges bill is being refused. Sign in again (claude /login) or switch which account this session bills")} if nid == jauth_top
-                            else {"state": perm_state,
-                                  "what": ("this session is stopped awaiting your input" if perm_state == "picker"
-                                           else "this session is stopped awaiting your approval")} if nid == perm_top
-                            else None),
-                "retrying": (sess_retrying if column == "working" else None),   # api-retry storm in the OPEN turn → "retrying since HH:MM" chip on the working card; chip only, no column move (the user 2026-07-09)
-                "nudgeFailed": nudge_failed,         # the one auto-nudge didn't resolve the stall → "nudge failed" chip; never re-nudged (plans/stalled-open-todos-nudge.md)
-                # STALLED (the user 2026-07-23): romp's nudge gate is holding this card behind a reviver that
-                # isn't retiring, so nothing is moving it and nothing was saying so. `why` is the kernel's own
-                # mechanical reason; `note` is the staller's plain-language version of it (null until the judge
-                # writes one). Read-side gated on the LIVE stall record, so the note vanishes the moment the
-                # wait clears, without anyone having to erase it. Working column only: a stall is romp being
-                # the bottleneck, never the user, so it must not read as needs-you.
-                "stalled": ({"why": _stall_rec["why"], "since": _stall_rec["since"],
-                             "note": nodes[nid].get("stallSummary") or None,
-                             "blocked": _stall_block}
-                            if (_stall_rec and not nudge_failed
-                                and (column == "working" or _stall_block)) else None),
-                "interrupting": bool(sess_interrupting and (column == "working" or (col == "blocked" and _lastblk == "interrupt"))),   # a user interrupt is IN FLIGHT → steady "interrupting…" badge until it settles (the user 2026-07-07)
-                "interrupted": bool(sess_interrupted and not sess_interrupting and (column == "working" or (col == "blocked" and _lastblk == "interrupt"))),   # the user stopped this session and hasn't re-engaged → "interrupted" badge (only ONCE the interrupt has settled); nudge suppressed until their next message (the user 2026-07-05)
-                "column": column,
-                "recheck": recheck,                  # targeted follow-up on a soft-block → de-urgented (dotted), moved to Working, pending re-judge
-                "rejudging": rejudging,              # plain thread reply after a block → STAYS in Needs-You, "Re-judging…" swirl while a turn is in flight (the user 2026-06-30)
-                "judging": bool((sess_judging or _stall_inflight) and column == "working"),
-                "working": (sess_progress if column == "working" else None),   # open-turn narration: tool count + since (the user 2026-08-13)   # turn settled, closer verdict pending → "Analyzing…" swirl covers the finished-but-still-Working beat (the user 2026-07-13); same key the provisional card wears
-                "sessState": (sess_state if column == "working" else None),   # the mute-proof floor: open | quiet | unknown (the user 2026-08-14 — a working card ALWAYS says its state)
-                "warnRows": (_card_warn_rows(dbg_rows, fsid, set(_subtree(nid)),
-                                             store.get("placements") or {}) or None)
-                            if dbg_rows is not None else None,   # debug mode only: the card's judge failures, modal "Warnings" section
-                # T319: this root is work the SESSION started (a planner-born step whose parent is gone, or a
-                # pre-rule machine-rooted top the heal found no request to nest under): the face names the
-                # parent request when one is known and says why the work exists, in one line
-                "sessionStarted": _session_started_face(nodes, nid, healed),
-                "tree": flatten(nid, [], boundary=jd.review_boundary(nodes[nid]))}
-            # THE SERVING FOLD, candidate side (the user 2026-08-28, T137: fan-out lives inside the
-            # ask card — the T101 ruling applied to the mirror, view-side): a to-do mirror top the
-            # sync stamped as SERVING a dispatch folds into the sender's ask card instead of
-            # standing alone on the board. Candidate only — the fold commits in the post-pass IFF
-            # the sender's tracker row actually rendered this build (never orphan rows into an
-            # unrendered card; the candidate falls back to its own card). NEEDS-YOU BREAKS THROUGH:
-            # a serving mirror folds ONLY from the quiet columns (working/completed) — any
-            # needs-input state stands on the board like any needs-you card until it lifts, the
-            # store-independent breakthrough rule.
-            _srv = nodes[nid].get("serving")
-            if (isinstance(_srv, dict) and _srv.get("goalId")
-                    and column in ("working", "completed")):
-                serving_folds.append({"tracker": _srv["goalId"], "card": card})
-            else:
-                asks.append(card)
-        # A session actively working a brand-new ask shows NO card until the planner classifies the held
-        # segment at turn-end — surface a live-prompt placeholder so it isn't invisible. Only when nothing
-        # already covers it (no working card); replaced by the real card once the planner places it.
-        # THE INVARIANT (the user 2026-08-01): a card sitting in Working must be explained by something —
-        # an actively working session, a judgment in flight, an awaiting, or an error. A session whose only
-        # explanation is "one of my cards is awaiting" was reading READY at the session level while that
-        # very card said "waiting on a background task", because this dot lit ONLY from the session-wide
-        # sources (`sess_awaiting_why`), which deliberately ignore a judge-placed launch. The cards are the
-        # per-goal answer this build already computed — so take it from them. Scoped to the session's own
-        # verdicts, so no sibling card is floored by it (what the session-wide _await_ok would have done).
-        if had_awaiting and not who_working and name not in awaiting:
-            awaiting.append(name)
-        if not had_working and perm_top is None and ps:   # cache-only: the live-prompt placeholder needs the parse → after the warm
-            # perm_top excluded: a live-blocked focus card no longer counts as "working" (it reports needs_input
-            # now), so without this guard a session whose ONLY card is the picker-blocked one would ALSO get a
-            # provisional working placeholder — a duplicate. A floored perm_top already covers the live prompt.
-            # store_faulted excluded: "the planner has not placed this yet" is an inference from placements we
-            # could not read, so a session whose store faulted gets no provisional card (its row says why).
-            pc = _provisional_card(s, name, color, fsid, live, now, store) if not store_faulted else None
-            if pc:
-                asks.append(pc)
-            elif perm_state in _NEEDS_INPUT_STATES:      # perm_top is None here (outer guard) → no goal to floor
-                # Hard-blocked on a live permission/picker prompt but with NO goal to floor (the planner hasn't
-                # run — nothing to plan until the ask is answered). Surface a needs-input placeholder so the
-                # block reaches the Blocked column instead of being invisible (the user 2026-06-27). Replaced
-                # by the real card once the planner places the answered work.
-                asks.append(_blocked_placeholder(s, name, color, fsid, live, now, perm_state,
-                                                 tm.get("since") if tm else None))
-            elif sess_awaiting_why:
-                # AWAITING a dispatched background task with NO goal to floor (the user 2026-07-13): the
-                # session's work is all placed/done, but a background task it dispatched is still running
-                # (the same signal the timeline's faded awaiting stretch reads). Surface a working-column
-                # awaiting card so the wait shows in the FEED, not just on the timeline — the hole the user
-                # hit ("there's no card there"). Ephemeral: gone the moment sess_awaiting_why clears.
-                asks.append(_awaiting_card(s, name, color, fsid, live, now, sess_awaiting_why,
-                                           kind=sess_awaiting_kind, since=sess_awaiting_since,
-                                           count=sess_awaiting_count, items=sess_awaiting_items))
+            _feed_memo_miss(ent[0] if ent is not None else None, key)
+            _feed_memo_count("derived")
+            entry = _feed_session_entry(s, ctx)
+            key = _feed_key_with_deps(key, ctx, entry)   # the peers and reads THIS derivation recorded
+            js = json.dumps(entry, default=_wire_default_in("_feed_memo"))   # str() of an unencodable value, said once
+            _feed_memo_put(fsid, key, js)
+            entry = json.loads(js)                   # the fold's objects come from the string on a miss too, so a hit and
+            #                                          a miss hand the board the same shapes, byte for byte
+        _heal, _hid, _cold = _feed_fold_entry(entry, now, cmap, s["name"], asks, working, awaiting, bg_services, serving_folds)
+        heal_total += _heal
+        hidden_total += _hid
+        cold_parse = cold_parse or _cold
+    _feed_memo_forget({s["sid"] for s in alive})     # a departed session's entry drops with it
     # THE SERVING FOLD, commit side (T137): join each candidate's rows under its dispatch's
     # tracker row — a read-only render-time join across stores (the node itself stays in the
     # WORKER's store, where plan-sync completion, nudge freshness, and clears live; node ids are
@@ -37866,6 +38304,8 @@ def _spend_tree_memo_bound():
 
 SPEND_GUARD_TREE_MEMO_BYTES = _spend_tree_memo_bound()   # the tree memos together (their path strings, estimated); over
 #                                                          it the largest goes first, and only the deficit is shed
+FEED_MEMO_BYTES = _feed_memo_bound()             # the feed's per-session card memo (T368, defined beside build_feed): its
+_FEED_MEMO_STATS["bound"] = FEED_MEMO_BYTES      #  entries' JSON bytes together; over it the least recently served goes first
 
 
 def _spend_ceiling():

--- a/tests/test_boot_parse_gating.py
+++ b/tests/test_boot_parse_gating.py
@@ -88,7 +88,7 @@ class FeedWarmParsesOnlyWhatMoved(unittest.TestCase):
             _join_new(before)
         self.assertEqual(km._built_feed[1], "a built payload", "the feed cache is left alone")
         self.assertEqual(pokes, [], "and the pusher is not woken")
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn("if _warm_wanted(s, tm):", src, "build_feed asks for a warm only for a session the gate would parse")
         self.assertFalse(km._warm_wanted(rows[0], None), "an unmoved idle session is cold by design")
         self.assertTrue(km._warm_wanted(rows[0], {"state": "working"}))

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""The feed memo's input census (T368).
+
+build_feed serves each living session's cards from _feed_memo while _feed_session_key(s, ...) is unchanged, so the
+key must contain every input _feed_session_entry reads that can change the entry. This module is the census that
+argument rests on, in the shape of tests/test_chat_build_sig_inputs.py: HELPERS classifies every helper the body
+calls by name (`_name(`, `jd.name(` and `em.name(` calls in the function's source, comments and strings excluded),
+CTX every field the body reads from the build's context dict, and LOCAL the closures defined inside the body.
+Each HELPERS or CTX entry is one of:
+
+  sig    an input the key folds, under the named labels (_FEED_MEMO_LABELS; several when the helper reads
+         under more than one component); the first label is the one its main read rides;
+  pure   a function of inputs already classified (a store the key identifies, identities another helper
+         resolved) and nothing else; the note says of what;
+  clock  the build's clock, handed to helpers whose clock-derived outputs LEAVE the entry (a placeholder's
+         `t` and every card's age tint are stamped per build by the fold): tests/test_feed_session_memo.py's
+         clock case pins that two builds apart in time differ in those fields alone.
+
+The test derives the call set from the function's source and requires it to EQUAL the tables' keys, so a helper
+added to the body without a classification fails the suite by name (a future read must be labelled), and so does
+a stale entry for one removed. Further pins: every `sig` label exists in the key's label tuple; every label in
+the tuple is claimed by some read (no dead component); every LOCAL name is a def nested in the body; the label
+tuple matches the list the key builder's docstring documents, in order; the miss attribution map covers the
+labels plus `cold`. Names, not lines: the tables say what each read is, the key builder's docstring says how each
+component is taken. The census enforces ONE level, the helpers the body calls directly; what each reads in turn
+is the classification's claim, verified by the differential cases in tests/test_feed_session_memo.py.
+"""
+import ast
+import inspect
+import io
+import os
+import re
+import tempfile
+import tokenize
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# Hermetic state BEFORE the load: the kernel resolves its state root at import time (a bare unittest run
+# otherwise reads REAL state); this module only reads source, but the load is the same load.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+km = load_source("romp_kernel_feed_memo_inputs", os.path.join(BIN, "romp-kernel"))
+
+# ── the helpers the body calls, helper -> (kind, labels or note) ──────────────────────────────────────────
+HELPERS = {
+    # the transcript (the cache-only parse, the anchors, the api-error tail, the background scans)
+    "_api_error": ("sig", ("transcript",)),
+    "_atom_prose_chars": ("sig", ("transcript",)),
+    "_last_plain_user_turn_t": ("sig", ("transcript",)),
+    "_open_turn_progress": ("sig", ("transcript",)),
+    "_pure_delegation_top": ("sig", ("transcript",)),
+    "_seg_anchors": ("sig", ("transcript",)),
+    "_seg_jump": ("sig", ("transcript",)),
+    "_seg_key": ("sig", ("transcript",)),
+    "_seg_last_text": ("sig", ("transcript",)),
+    "_segs_seam": ("sig", ("transcript",)),
+    "em.turn_scalar": ("sig", ("transcript",)),
+    "jd._prompt_anchor_uuid": ("sig", ("transcript",)),
+    "_heal_session_tops": ("sig", ("transcript", "store")),            # the background scan over the store's tops
+    "_warm_wanted": ("sig", ("transcript", "parse")),                  # moved since boot, or working: worth a warm
+    # the placeholders: their own _parse, the caption gist, the clear set, the current ask
+    "_provisional_card": ("sig", ("transcript", "captions", "cleared")),
+    "_blocked_placeholder": ("sig", ("transcript", "captions", "ask")),
+    "_awaiting_card": ("sig", ("transcript",)),
+    # the states log (machine cuts, the retrying-since fold, the awaiting overlay) and the live row
+    "_interrupt_suppresses_nudge": ("sig", ("states",)),
+    "_session_retrying": ("sig", ("states", "row")),
+    "_session_awaiting": ("sig", ("states", "reg", "row", "bg", "watch", "subagents", "peers")),
+    # the names registry (own sid, and the peers a card names)
+    "_name_color": ("sig", ("names", "peers")),
+    "_name_of": ("sig", ("names", "peers")),
+    # the goal store (every node and status read of ctx["store"], and the shared loads inside the bg memos)
+    "_agent_open_set": ("sig", ("store",)),
+    "_all_outstanding_delegated": ("sig", ("store",)),
+    "_goal_awaiting_stamp_full": ("sig", ("store",)),
+    "_node_log_rows": ("sig", ("store",)),
+    "_open_leaves": ("sig", ("store",)),
+    "_parked_rows": ("sig", ("store",)),
+    "_session_started_face": ("sig", ("store",)),
+    "jd._done_since": ("sig", ("store",)),
+    "jd.review_boundary": ("sig", ("store",)),
+    "_handoff_card_fields": ("sig", ("store", "peers")),
+    "_bg_owner_tops": ("sig", ("transcript", "store", "reg", "bg")),
+    "_bg_service_descs": ("sig", ("transcript", "store", "bg", "postal")),
+    "_awaiting_task_descs": ("sig", ("transcript", "store", "bg")),
+    "_bg_live_norm": ("sig", ("bg", "reg", "row", "transcript")),      # the launch ledger, the row's bgTasks
+    # the warm-anchor table, the postal log, the nudge records, the flags, the debug rows, the cap offer
+    "_node_anchor_uuids": ("sig", ("anchors",)),
+    "_peer_answered": ("sig", ("postal",)),
+    "_peer_identity": ("sig", ("postal", "peers")),
+    "_handoff_peer_identities": ("sig", ("peers",)),
+    "jd.load_goals_shared_or_fault": ("sig", ("peers",)),               # an origin sender's store, by the peers deps
+    "_auto_nudge_data": ("sig", ("nudge",)),
+    "_nudge_times": ("sig", ("nudge",)),
+    "_session_flag": ("sig", ("hide",)),
+    "_card_warn_rows": ("sig", ("debug",)),
+    "_cap_switch_offer": ("sig", ("row", "usage", "auth")),            # authLive, usage.json (recorded), the key on hand
+    # pure over classified inputs
+    "_awaiting_peer_items": ("pure", "over the peer identities _session_awaiting resolved (peers), nothing else"),
+}
+
+# ── the context fields the body reads, field -> (kind, labels or note) ────────────────────────────────────
+CTX = {
+    "now": ("clock", "handed to the placeholders and the stamp reads; every clock-derived output leaves the entry"),
+    "live_map": ("sig", ("row",)),                     # tm = live_map.get(fsid): live, perm_state, since
+    "cleared": ("sig", ("cleared",)),                  # `nid in cleared` per top (the session's slice)
+    "dbg_rows": ("sig", ("debug",)),
+    "wmap": ("sig", ("wait",)),
+    "stalls": ("sig", ("stalls",)),
+    "jauth_map": ("sig", ("jauth",)),
+    "jactive": ("sig", ("jactive",)),
+    "ps": ("sig", ("parse", "transcript", "live", "cut", "states")),   # the cache-only, live-merged parse
+    "who_working": ("sig", ("downtime", "parse")),     # _session_working over the open turn, suspension-aware
+    "interrupting": ("sig", ("interrupting",)),
+    "store": ("sig", ("store",)),                      # _feed_goals(fsid), read once in the key
+    "closer": ("sig", ("closer", "jactive")),          # the settle gap under the body's gate
+}
+
+# closures defined inside the body: pure over its locals, no component
+LOCAL = ("_subtree", "_closure_done", "_fsubmax", "_closure_blocked", "_block_check_floor", "_note_peers")
+
+KINDS = {"sig", "pure", "clock"}
+
+
+def _stripped(src, strings=False):
+    """The source with comments removed and, unless `strings`, every string literal replaced by an empty one,
+    so a mention of a helper in a comment or a message is not counted as a call (the ctx census keeps the
+    literals: the field names are the strings)."""
+    toks = []
+    for t in tokenize.generate_tokens(io.StringIO(src).readline):
+        if t.type == tokenize.COMMENT:
+            continue
+        if t.type == tokenize.STRING and not strings:
+            t = t._replace(string='""')
+        toks.append(t)
+    return tokenize.untokenize(toks)
+
+
+def _calls_of(src):
+    """Every `_name(`, `jd.name(` and `em.name(` call in the stripped source."""
+    text = _stripped(src)
+    own = set(re.findall(r"(?<![\w.])(_[a-z_0-9]+)\(", text))
+    dotted = set("%s.%s" % m for m in re.findall(r"\b(jd|em)\.([a-z_0-9]+)\(", text))
+    return own | dotted
+
+
+def _ctx_reads_of(src):
+    return set(re.findall(r'ctx\["([a-z_]+)"\]', _stripped(src, strings=True)))
+
+
+def _documented_labels():
+    """The component list the key builder's docstring documents: the `label:` lines of its Components block, at
+    the block's own indent, in order."""
+    doc = inspect.cleandoc(km._feed_session_key.__doc__)
+    block = doc.split("Components, label:", 1)[1].split("NOT components", 1)[0]
+    rows = [(len(m.group(1)), m.group(2)) for m in re.finditer(r"^( +)([a-z]+): ", block, re.M)]
+    indent = min(i for i, _ in rows)
+    return tuple(lab for i, lab in rows if i == indent)
+
+
+class Census(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.src = inspect.getsource(km._feed_session_entry)
+        cls.calls = _calls_of(cls.src) - {"_feed_session_entry"}       # the def line names the function itself
+        cls.ctx = _ctx_reads_of(cls.src)
+
+    def test_every_helper_the_body_calls_is_classified_and_nothing_stale_remains(self):
+        table = set(HELPERS) | set(LOCAL)
+        self.assertEqual(self.calls, table,
+                         "a helper _feed_session_entry calls is missing from HELPERS (an unclassified read: label it "
+                         "under the key component that covers it, or add the component), or the table names one the "
+                         "body no longer calls: %r" % sorted(self.calls ^ table))
+
+    def test_every_context_field_the_body_reads_is_classified(self):
+        self.assertEqual(self.ctx, set(CTX), sorted(self.ctx ^ set(CTX)))
+
+    def test_every_entry_has_a_known_kind_and_a_sig_entry_names_labels_of_the_key(self):
+        labels = set(km._FEED_MEMO_LABELS)
+        for table in (HELPERS, CTX):
+            for name, (kind, what) in table.items():
+                self.assertIn(kind, KINDS, name)
+                if kind == "sig":
+                    self.assertIsInstance(what, tuple, name)
+                    self.assertTrue(what, "%s: a sig entry names at least one label" % name)
+                    for lab in what:
+                        self.assertIn(lab, labels, "%s: %r is not a component of _feed_session_key" % (name, lab))
+                else:
+                    self.assertIsInstance(what, str, "%s: a %s entry carries its note" % (name, kind))
+
+    def test_every_component_of_the_key_is_claimed_by_a_read(self):
+        claimed = set()
+        for table in (HELPERS, CTX):
+            for kind, what in table.values():
+                if kind == "sig":
+                    claimed.update(what)
+        self.assertEqual(claimed, set(km._FEED_MEMO_LABELS),
+                         "a key component no read claims is a dead component (or a read lost its label): %r"
+                         % sorted(claimed ^ set(km._FEED_MEMO_LABELS)))
+
+    def test_the_local_closures_are_defs_nested_in_the_body(self):
+        fn = ast.parse(self.src).body[0]
+        nested = {x.name for x in ast.walk(fn) if isinstance(x, ast.FunctionDef) and x is not fn}
+        for name in LOCAL:
+            self.assertIn(name, nested, "%s is listed as a local closure but the body defines no such def" % name)
+        self.assertFalse(set(LOCAL) & set(HELPERS), "a name is a closure or a helper, never both")
+
+    def test_the_helper_names_resolve_in_the_kernel(self):
+        for name in HELPERS:
+            mod, _, attr = name.rpartition(".")
+            owner = getattr(km, mod) if mod else km
+            self.assertTrue(callable(getattr(owner, attr, None)), name)
+
+
+class LabelsAndDocstring(unittest.TestCase):
+    def test_the_label_tuple_matches_the_key_builders_documented_component_list_in_order(self):
+        self.assertEqual(km._FEED_MEMO_LABELS, _documented_labels(),
+                         "the docstring of _feed_session_key lists every component; the tuple must be that list")
+
+    def test_the_labels_are_distinct_and_the_deps_are_labels(self):
+        self.assertEqual(len(set(km._FEED_MEMO_LABELS)), len(km._FEED_MEMO_LABELS))
+        for dep in km._FEED_MEMO_DEPS:
+            self.assertIn(dep, km._FEED_MEMO_LABELS, dep)
+        self.assertEqual(km._FEED_MEMO_LABELS[-1], "peers", "the peers dependency closes the tuple")
+
+    def test_the_miss_attribution_map_covers_every_label_and_cold(self):
+        self.assertEqual(set(km._FEED_MEMO_STATS["miss_by"]), set(km._FEED_MEMO_LABELS) | {"cold"})
+        self.assertEqual(set(km._feed_memo_report()["miss_by"]), set(km._FEED_MEMO_LABELS) | {"cold"})
+
+    def test_the_key_builder_returns_one_value_per_label(self):
+        """A key is compared to the labels by position (_feed_memo_miss zips them), so the return statement must
+        hand back exactly as many values as there are labels: pinned on the source, since a build needs a world."""
+        src = _stripped(inspect.getsource(km._feed_session_key))
+        ret = src.rsplit("return (", 1)[1].rsplit(")", 1)[0]
+        names = [n.strip() for n in ret.replace("\n", " ").split(",") if n.strip()]
+        self.assertEqual(len(names), len(km._FEED_MEMO_LABELS),
+                         "the key's return tuple has %d values for %d labels" % (len(names), len(km._FEED_MEMO_LABELS)))
+
+    def test_the_entry_docstring_names_this_pin(self):
+        self.assertIn("test_feed_memo_inputs", km._feed_session_entry.__doc__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -4,8 +4,9 @@
 build_feed serves each living session's cards from _feed_memo while _feed_session_key(s, ...) is unchanged, so the
 key must contain every input _feed_session_entry reads that can change the entry. This module is the census that
 argument rests on, in the shape of tests/test_chat_build_sig_inputs.py: HELPERS classifies every callee the body
-reads from module scope (the derivation rule below), CTX every field the body reads from the build's context dict,
-and LOCAL the closures defined inside the body. Each HELPERS or CTX entry is one of:
+reads from module scope (the derivation rule below), MODULE_READS every module-scope name the body reads WITHOUT
+calling it (the read rule below), CTX every field the body reads from the build's context dict, and LOCAL the
+closures defined inside the body. Each HELPERS or CTX entry is one of:
 
   sig    an input the key folds, under the named labels (_FEED_MEMO_LABELS; several when the helper reads
          under more than one component); the first label is the one its main read rides;
@@ -15,39 +16,71 @@ and LOCAL the closures defined inside the body. Each HELPERS or CTX entry is one
          `t` and every card's age tint are stamped per build by the fold): tests/test_feed_session_memo.py's
          clock case pins that two builds apart in time differ in those fields alone.
 
-The test derives the call set from the function's AST, every ast.Call in the body (nested defs, lambdas,
-comprehensions and f-strings included), and requires it to EQUAL the tables' keys, so a helper added to the body
-without a classification fails the suite by name (a future read must be labelled), and so does a stale entry for
-one removed. The rule: a callee is reduced to its ROOT by walking down through attribute, subscript and call nodes
-(`a.b`, `a[i]`, `a(...)`) until a node that is none of those, and is read under the dotted name of the root joined
-with the attributes that follow it up to the first subscript or call: `_seg_key`, `jd.load_goals_shared_or_fault`,
-`os.path.basename` (every attribute of a module chain), and `_auto_nudge_data` for `_auto_nudge_data().get(...)`
-(the `.get` is a method on the value the classified call returned). A root that is a Name is one of three things.
-A name the body binds (a parameter of the def, of a nested def or of a lambda; an assignment, for, with, walrus or
-comprehension target; an except handler's name; a nested def's name) is a LOCAL: a callee rooted in it (`tm.get`,
-`out.append`) is skipped, except a nested def's own call, which must be in LOCAL. A name the kernel does not bind
-and the builtins module does is a builtin (`len`, `sorted`, `str`, `dict.fromkeys`) and is skipped, `open`
-excepted: the one builtin that reads a file is classified like any helper. Every other Name is a module-level name
-of the kernel (a helper, a module alias such as jd, em, cm, sb, os or json, a class such as Sessions) and its dotted
-name MUST be in HELPERS, so nothing rooted in module scope passes unlabelled, whatever the shape of the call. A root
-that is not a Name (a literal's method, `", ".join`; a bool-op's, `(nd.get("x") or {}).get`) is a method on a value
-an expression produced: the calls inside that expression are walked on their own and the method itself names
-nothing of module scope, so it is skipped. Further pins: every `sig` label exists in the key's label tuple; every
-label in the tuple is claimed by some read (no dead component); every LOCAL name is a def nested in the body; the
-label tuple matches the list the key builder's docstring documents, in order; the miss attribution map covers the
-labels plus `cold`. Names, not lines: the tables say what each read is, the key builder's docstring says how each
-component is taken. The census enforces ONE level, the helpers the body calls directly; what each reads in turn
-is the classification's claim, verified by the differential cases in tests/test_feed_session_memo.py.
+Each MODULE_READS entry is one of:
+
+  const  a module constant that never changes at runtime (an uppercase name bound once: a tuple or frozenset of
+         strings, an int, a compiled regex, a class such as Path, a module alias); the note says what it is, and
+         the test checks the value is of an immutable type;
+  sig    a runtime table or module state whose content can change the entry, labelled under the key component
+         that covers it, exactly as HELPERS does;
+  pure   a read that cannot change the card, with a note saying why.
+
+THE CALL CENSUS. The test derives the call set from the function's AST, every ast.Call in the body (nested defs,
+lambdas, comprehensions and f-strings included), and requires it to EQUAL the tables' keys, so a helper added to
+the body without a classification fails the suite by name (a future read must be labelled), and so does a stale
+entry for one removed. The rule: a callee is reduced to its ROOT by walking down through attribute, subscript and
+call nodes (`a.b`, `a[i]`, `a(...)`) until a node that is none of those, and is read under the dotted name of the
+root joined with the attributes that follow it up to the first subscript or call: `_seg_key`,
+`jd.load_goals_shared_or_fault`, `os.path.basename` (every attribute of a module chain), and `_auto_nudge_data`
+for `_auto_nudge_data().get(...)` (the `.get` is a method on the value the classified call returned). A root that
+is a Name is one of three things. A name the body binds (a parameter of the def, of a nested def or of a lambda;
+an assignment, for, with, walrus or comprehension target; an except handler's name; a nested def's name) is a
+LOCAL: a callee rooted in it (`tm.get`, `out.append`) is skipped, except a nested def's own call, which must be in
+LOCAL. A name the kernel does not bind and the builtins module does is a builtin (`len`, `sorted`, `str`,
+`dict.fromkeys`) and is skipped, `open` excepted: the one builtin that reads a file is classified like any helper.
+Every other Name is a module-level name of the kernel (a helper, a module alias such as jd, em, cm, sb, os or
+json, a class such as Sessions) and its dotted name MUST be in HELPERS, so nothing rooted in module scope passes
+unlabelled, whatever the shape of the call. A root that is not a Name (a literal's method, `", ".join`; a
+bool-op's, `(nd.get("x") or {}).get`; a path expression's, `(jd.STATE / "x.json").read_text`) is a method on a
+value an expression produced: the calls inside that expression are walked on their own, and the method call is
+subject to the EXPRESSION-METHOD RULE: every module-scope Name inside the callee expression that is not itself a
+counted callee's root is a read (the read rule below counts it), and when there is at least one such read the
+method call is reported as the first such read's dotted name (source order) joined with the method,
+`jd.STATE.read_text` for `(jd.STATE / "x.json").read_text()`, and MUST be in HELPERS, since the method is what
+reads (a Path constant reads nothing; its read_text reads a file). A method on an expression with no such read
+inside (a local's, a literal's, a bool-op over locals, a classified call's value, `(_helper() or {}).get`) names
+nothing of module scope that the census has not already counted, and is skipped.
+
+THE READ CENSUS. Every ast.Name in Load context under the body is classified by the same three-way rule (a body
+local skipped, a builtin the kernel does not bind skipped, `open` excepted), and every module-scope Name that is
+NOT the root of a counted callee chain is a READ, under a dotted name: the Name alone when it is read bare or
+subscripted (`_NEEDS_INPUT_STATES` for `perm_state in _NEEDS_INPUT_STATES`, `_node_anchor_rev` for
+`_node_anchor_rev[fsid]`), or the Name joined with its first attribute for an attribute load (`jd.CITE_MIN_CHARS`,
+`jd.STATE` for `jd.STATE / "x.json"`). The read set must EQUAL MODULE_READS' keys, as the call set must EQUAL
+HELPERS plus LOCAL, so a module table read by subscript, a constant compared against, or a path built from a
+module directory is labelled by name or fails. The only skips in either census are builtins and body locals:
+there is no list of names or modules exempted.
+
+Further pins: every `sig` label exists in the key's label tuple; every label in the tuple is claimed by some read
+(no dead component); every LOCAL name is a def nested in the body; every HELPERS name resolves in the kernel to a
+callable and every MODULE_READS name to a value; a `const` read's value is of an immutable type; the label tuple
+matches the list the key builder's docstring documents, in order; the miss attribution map covers the labels plus
+`cold`. Names, not lines: the tables say what each read is, the key builder's docstring says how each component
+is taken. The census enforces ONE level, the helpers the body calls directly and the module names it reads
+directly; what each reads in turn is the classification's claim, verified by the differential cases in
+tests/test_feed_session_memo.py.
 """
 import ast
 import builtins
 import inspect
 import io
 import os
+import pathlib
 import re
 import tempfile
 import textwrap
 import tokenize
+import types
 import unittest
 from romp_load import load_source
 
@@ -119,6 +152,13 @@ HELPERS = {
     "_awaiting_peer_items": ("pure", "over the peer identities _session_awaiting resolved (peers), nothing else"),
 }
 
+# ── the module-scope names the body reads without calling, name -> (kind, labels or note) ─────────────────
+MODULE_READS = {
+    "_NEEDS_INPUT_STATES": ("const", "the live-prompt perm states (permission, picker), a tuple of strings bound once"),
+    "jd.CITE_MIN_CHARS": ("const", "the judge module's citation floor, an int bound once"),
+    "jd.WHY_IN_FLIGHT": ("const", "the in-flight-class stall reasons, a tuple of the judge module's constant strings"),
+}
+
 # ── the context fields the body reads, field -> (kind, labels or note) ────────────────────────────────────
 CTX = {
     "now": ("clock", "handed to the placeholders and the stamp reads; every clock-derived output leaves the entry"),
@@ -139,7 +179,11 @@ CTX = {
 # closures defined inside the body: pure over its locals, no component
 LOCAL = ("_subtree", "_closure_done", "_fsubmax", "_closure_blocked", "_block_check_floor", "_note_peers", "flatten")
 
-KINDS = {"sig", "pure", "clock"}
+KINDS = {"sig", "pure", "clock"}          # HELPERS and CTX
+READ_KINDS = {"const", "sig", "pure"}     # MODULE_READS
+# the value types a `const` read may hold: bound once, never mutated in place
+CONST_TYPES = (int, float, str, bytes, bool, tuple, frozenset, re.Pattern, type, types.ModuleType, pathlib.PurePath,
+               type(None))
 
 
 def _stripped(src, strings=False):
@@ -160,7 +204,8 @@ def _callee_root(func):
     """A callee reduced to its root (the module docstring's rule): walks down through Attribute, Subscript and Call
     nodes until a node that is none of those, and returns (root node, dotted name), the name the root's id joined
     with the attributes that follow it up to the first Subscript or Call (`os.path.basename`; `_auto_nudge_data` for
-    `_auto_nudge_data().get`), or None when the root is not a Name (a literal, a bool-op: a method on a value)."""
+    `_auto_nudge_data().get`), or None when the root is not a Name (a literal, a bool-op, a path expression: a
+    method on a value)."""
     attrs, f = [], func
     while True:
         if isinstance(f, ast.Attribute):
@@ -198,29 +243,70 @@ def _bound_in(fn):
     return names
 
 
-def _calls_of(fn, module):
-    """The callees the body reads from module scope, plus the nested defs it calls, as dotted names: every ast.Call
-    under `fn`, its callee reduced by _callee_root and its root classified by the module docstring's rule (a local's
-    method skipped, a builtin other than `open` skipped, a non-Name root skipped, everything else kept). `module` is
-    the kernel: a name it binds is never a builtin, however it is spelled."""
+def _read_name(node, parent):
+    """A read's dotted name: the Name joined with its first attribute when it is the value of an Attribute load
+    (`jd.CITE_MIN_CHARS`, `jd.STATE`), else the Name alone (a bare compare, a subscript's value, an operand)."""
+    if isinstance(parent, ast.Attribute) and parent.value is node:
+        return node.id + "." + parent.attr
+    return node.id
+
+
+def _census(fn, module):
+    """(calls, reads) for the body: the callees it reads from module scope plus the nested defs it calls, and the
+    module-scope names it reads without calling, both as dotted names by the module docstring's rules. `module` is
+    the kernel: a name it binds is never a builtin, however it is spelled. One three-way rule classifies every
+    Name: a body local (skipped; a nested def's own call is kept for LOCAL), a builtin the module does not bind
+    (skipped, `open` excepted), else module scope (kept). The call census walks every ast.Call; a callee whose
+    root is a Name is counted under _callee_root's dotted name and that Name node is a callee root; a callee that
+    is an Attribute on an expression (no Name root) is an expression-method call. The read census then counts
+    every Load-context Name of module scope that is not a callee root, under _read_name. Each expression-method
+    call whose callee expression holds at least one such read is counted as the first read's dotted name (source
+    order) joined with the method (`jd.STATE.read_text`); one holding none is a method on a value the census has
+    already accounted for and is skipped."""
     local, nested = _bound_in(fn), {x.name for x in ast.walk(fn) if isinstance(x, ast.FunctionDef) and x is not fn}
     bound = vars(module)
-    calls = set()
+
+    def scoped(name):                             # module scope: neither a body local nor an unshadowed builtin
+        return name not in local and not (name not in bound and hasattr(builtins, name) and name != "open")
+
+    parent = {}
+    for p in ast.walk(fn):
+        for c in ast.iter_child_nodes(p):
+            parent[c] = p
+    calls, roots, on_exprs = set(), set(), []
     for x in ast.walk(fn):
         if not isinstance(x, ast.Call):
             continue
         root, name = _callee_root(x.func)
         if name is None:
-            continue                              # a method on a value an expression produced (its calls walked too)
+            if isinstance(x.func, ast.Attribute):
+                on_exprs.append(x)                # a method on a value an expression produced: ruled on below
+            continue
+        roots.add(root)
         if root.id in nested:
             calls.add(name)                       # a closure's call: LOCAL must name it
-        elif root.id in local:
-            continue                              # a local's method (tm.get, out.append)
-        elif root.id not in bound and hasattr(builtins, root.id) and root.id != "open":
-            continue                              # a builtin (len, sorted, str, dict.fromkeys); open reads a file: kept
-        else:
+        elif scoped(root.id):
             calls.add(name)                       # rooted in module scope: HELPERS must name it
-    return calls
+
+    def read_nodes(under):
+        return [n for n in ast.walk(under)
+                if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load) and n not in roots and scoped(n.id)]
+
+    reads = {_read_name(n, parent[n]) for n in read_nodes(fn)}
+    for x in on_exprs:
+        inner = read_nodes(x.func)
+        if inner:                                 # the method reads on a module-scope value: HELPERS must name it
+            first = min(inner, key=lambda n: (n.lineno, n.col_offset))
+            calls.add(_read_name(first, parent[first]) + "." + x.func.attr)
+    return calls, reads
+
+
+def _calls_of(fn, module):
+    return _census(fn, module)[0]
+
+
+def _reads_of(fn, module):
+    return _census(fn, module)[1]
 
 
 def _ctx_reads_of(src):
@@ -237,12 +323,23 @@ def _documented_labels():
     return tuple(lab for i, lab in rows if i == indent)
 
 
+def _resolve(name):
+    """(object, found): what a dotted name reaches from the kernel's namespace (or, for a classified builtin such
+    as `open`, from builtins), attribute by attribute; found is False when a step is missing."""
+    root, *attrs = name.split(".")
+    missing = object()
+    obj = getattr(km, root) if root in vars(km) else getattr(builtins, root, missing)
+    for a in attrs:
+        obj = getattr(obj, a, missing) if obj is not missing else missing
+    return (None if obj is missing else obj), obj is not missing
+
+
 class Census(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.src = inspect.getsource(km._feed_session_entry)
         cls.fn = ast.parse(textwrap.dedent(cls.src)).body[0]
-        cls.calls = _calls_of(cls.fn, km)
+        cls.calls, cls.reads = _census(cls.fn, km)
         cls.ctx = _ctx_reads_of(cls.src)
 
     def test_every_helper_the_body_calls_is_classified_and_nothing_stale_remains(self):
@@ -252,14 +349,21 @@ class Census(unittest.TestCase):
                          "under the key component that covers it, or add the component), or the table names one the "
                          "body no longer calls: %r" % sorted(self.calls ^ table))
 
+    def test_every_module_name_the_body_reads_is_classified_and_nothing_stale_remains(self):
+        self.assertEqual(self.reads, set(MODULE_READS),
+                         "a module-scope name _feed_session_entry reads without calling is missing from MODULE_READS "
+                         "(a constant: const, with what it is; a runtime table or module state: sig, under the key "
+                         "component that covers it), or the table names one the body no longer reads: %r"
+                         % sorted(self.reads ^ set(MODULE_READS)))
+
     def test_every_context_field_the_body_reads_is_classified(self):
         self.assertEqual(self.ctx, set(CTX), sorted(self.ctx ^ set(CTX)))
 
     def test_every_entry_has_a_known_kind_and_a_sig_entry_names_labels_of_the_key(self):
         labels = set(km._FEED_MEMO_LABELS)
-        for table in (HELPERS, CTX):
+        for table, kinds in ((HELPERS, KINDS), (CTX, KINDS), (MODULE_READS, READ_KINDS)):
             for name, (kind, what) in table.items():
-                self.assertIn(kind, KINDS, name)
+                self.assertIn(kind, kinds, name)
                 if kind == "sig":
                     self.assertIsInstance(what, tuple, name)
                     self.assertTrue(what, "%s: a sig entry names at least one label" % name)
@@ -270,7 +374,7 @@ class Census(unittest.TestCase):
 
     def test_every_component_of_the_key_is_claimed_by_a_read(self):
         claimed = set()
-        for table in (HELPERS, CTX):
+        for table in (HELPERS, CTX, MODULE_READS):
             for kind, what in table.values():
                 if kind == "sig":
                     claimed.update(what)
@@ -288,25 +392,47 @@ class Census(unittest.TestCase):
     def test_the_helper_names_resolve_in_the_kernel(self):
         """Every dotted name walks from the kernel's namespace (or, for a classified builtin such as `open`, from
         builtins) through each attribute to a callable: `os.path.basename` is `km.os`, then `.path`, then
-        `.basename`."""
+        `.basename`; an expression-method entry reaches the method on the value, `jd.STATE.read_text`."""
         for name in HELPERS:
-            root, *attrs = name.split(".")
-            obj = getattr(km, root) if root in vars(km) else getattr(builtins, root, None)
-            for a in attrs:
-                obj = getattr(obj, a, None)
-            self.assertTrue(callable(obj), name)
+            obj, found = _resolve(name)
+            self.assertTrue(found and callable(obj), name)
+
+    def test_the_module_read_names_resolve_in_the_kernel_and_a_const_is_immutable(self):
+        """Every MODULE_READS name reaches a value the same way (`jd.CITE_MIN_CHARS` is `km.jd`, then
+        `.CITE_MIN_CHARS`), and a `const` entry is an uppercase name whose value is of a type that cannot change
+        under it: a tuple or frozenset of such values, an int, a string, a regex, a class, a module, a path. A
+        dict, list or set read under `const` is a table whose content can move, and belongs under `sig` with a
+        label."""
+        def immutable(v):
+            if isinstance(v, (tuple, frozenset)):
+                return all(immutable(i) for i in v)
+            return isinstance(v, CONST_TYPES)
+        for name, (kind, _what) in MODULE_READS.items():
+            obj, found = _resolve(name)
+            self.assertTrue(found, "%s does not resolve in the kernel" % name)
+            if kind == "const":
+                self.assertTrue(immutable(obj), "%s is classified const but holds a %s" % (name, type(obj).__name__))
+                self.assertTrue(name.split(".")[-1].isupper(),
+                                "%s: a const is an uppercase name (a runtime table reads under sig)" % name)
 
     def test_the_derivation_sees_every_callee_shape(self):
         """The rule on a synthetic body, so a regression to a narrower reader fails here rather than passing a read
         unlabelled: a module alias chain, a class method, a bare module helper, a builtin that reads (`open`), a
-        method on a call's result, a local's method, a nested def, a lambda's parameter, an except name."""
+        method on a call's result, a local's method, a nested def, a lambda's parameter, an except name; and the two
+        shapes the call census alone missed (T368 round two): a method on a path expression, which yields the read
+        `jd.STATE` and the call `jd.STATE.read_text`, and a module table read by subscript, `_TABLE[fsid]`, which
+        yields the read `_TABLE` (its `.get` call is counted as today, `_TABLE.get`, and is no read). A bare
+        constant compared against is the read `_STATES`; a method on a classified call's value inside a bool-op,
+        `(_helper() or {}).get`, holds no read and stays skipped, as a method on a local's value does."""
         src = textwrap.dedent('''
             def body(s, ctx):
                 def inner(x):
                     return x
+                fsid = s["sid"]
                 p = os.path.basename(s["path"])
                 be = Sessions.backend_for(p)
                 data = json.dumps(_helper().get("k"), sort_keys=True)
+                more = (_helper() or {}).get("k2")
                 with open(p) as fh:
                     rows = [str(r).strip() for r in fh]
                 try:
@@ -315,13 +441,22 @@ class Census(unittest.TestCase):
                     tm = exc.args
                 f = lambda q: q.lower()
                 out = ", ".join(sorted(rows, key=f)) + (tm or {}).get("x", "")
-                return inner(out), be, data, dict.fromkeys(rows), sb.thing(len(rows))
+                raw = (jd.STATE / "x.json").read_text()
+                row = _TABLE[fsid]
+                got = _TABLE.get(fsid)
+                if tm.get("state") in _STATES:
+                    out += raw
+                return inner(out), be, data, more, row, got, dict.fromkeys(rows), sb.thing(len(rows))
         ''')
         fn = ast.parse(src).body[0]
         module = type(km)("synthetic")            # binds nothing: every non-local, non-builtin root is module scope
-        self.assertEqual(_calls_of(fn, module),
+        calls, reads = _census(fn, module)
+        self.assertEqual(calls,
                          {"os.path.basename", "Sessions.backend_for", "json.dumps", "_helper", "open", "sb.thing",
-                          "inner"})
+                          "inner", "jd.STATE.read_text", "_TABLE.get"})
+        self.assertEqual(reads, {"jd.STATE", "_TABLE", "_STATES"})
+        self.assertEqual(_calls_of(fn, module), calls)
+        self.assertEqual(_reads_of(fn, module), reads)
 
 
 class LabelsAndDocstring(unittest.TestCase):

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -3,10 +3,9 @@
 
 build_feed serves each living session's cards from _feed_memo while _feed_session_key(s, ...) is unchanged, so the
 key must contain every input _feed_session_entry reads that can change the entry. This module is the census that
-argument rests on, in the shape of tests/test_chat_build_sig_inputs.py: HELPERS classifies every helper the body
-calls by name (`_name(`, `jd.name(` and `em.name(` calls in the function's source, comments and strings excluded),
-CTX every field the body reads from the build's context dict, and LOCAL the closures defined inside the body.
-Each HELPERS or CTX entry is one of:
+argument rests on, in the shape of tests/test_chat_build_sig_inputs.py: HELPERS classifies every callee the body
+reads from module scope (the derivation rule below), CTX every field the body reads from the build's context dict,
+and LOCAL the closures defined inside the body. Each HELPERS or CTX entry is one of:
 
   sig    an input the key folds, under the named labels (_FEED_MEMO_LABELS; several when the helper reads
          under more than one component); the first label is the one its main read rides;
@@ -16,21 +15,38 @@ Each HELPERS or CTX entry is one of:
          `t` and every card's age tint are stamped per build by the fold): tests/test_feed_session_memo.py's
          clock case pins that two builds apart in time differ in those fields alone.
 
-The test derives the call set from the function's source and requires it to EQUAL the tables' keys, so a helper
-added to the body without a classification fails the suite by name (a future read must be labelled), and so does
-a stale entry for one removed. Further pins: every `sig` label exists in the key's label tuple; every label in
-the tuple is claimed by some read (no dead component); every LOCAL name is a def nested in the body; the label
-tuple matches the list the key builder's docstring documents, in order; the miss attribution map covers the
+The test derives the call set from the function's AST, every ast.Call in the body (nested defs, lambdas,
+comprehensions and f-strings included), and requires it to EQUAL the tables' keys, so a helper added to the body
+without a classification fails the suite by name (a future read must be labelled), and so does a stale entry for
+one removed. The rule: a callee is reduced to its ROOT by walking down through attribute, subscript and call nodes
+(`a.b`, `a[i]`, `a(...)`) until a node that is none of those, and is read under the dotted name of the root joined
+with the attributes that follow it up to the first subscript or call: `_seg_key`, `jd.load_goals_shared_or_fault`,
+`os.path.basename` (every attribute of a module chain), and `_auto_nudge_data` for `_auto_nudge_data().get(...)`
+(the `.get` is a method on the value the classified call returned). A root that is a Name is one of three things.
+A name the body binds (a parameter of the def, of a nested def or of a lambda; an assignment, for, with, walrus or
+comprehension target; an except handler's name; a nested def's name) is a LOCAL: a callee rooted in it (`tm.get`,
+`out.append`) is skipped, except a nested def's own call, which must be in LOCAL. A name the kernel does not bind
+and the builtins module does is a builtin (`len`, `sorted`, `str`, `dict.fromkeys`) and is skipped, `open`
+excepted: the one builtin that reads a file is classified like any helper. Every other Name is a module-level name
+of the kernel (a helper, a module alias such as jd, em, cm, sb, os or json, a class such as Sessions) and its dotted
+name MUST be in HELPERS, so nothing rooted in module scope passes unlabelled, whatever the shape of the call. A root
+that is not a Name (a literal's method, `", ".join`; a bool-op's, `(nd.get("x") or {}).get`) is a method on a value
+an expression produced: the calls inside that expression are walked on their own and the method itself names
+nothing of module scope, so it is skipped. Further pins: every `sig` label exists in the key's label tuple; every
+label in the tuple is claimed by some read (no dead component); every LOCAL name is a def nested in the body; the
+label tuple matches the list the key builder's docstring documents, in order; the miss attribution map covers the
 labels plus `cold`. Names, not lines: the tables say what each read is, the key builder's docstring says how each
 component is taken. The census enforces ONE level, the helpers the body calls directly; what each reads in turn
 is the classification's claim, verified by the differential cases in tests/test_feed_session_memo.py.
 """
 import ast
+import builtins
 import inspect
 import io
 import os
 import re
 import tempfile
+import textwrap
 import tokenize
 import unittest
 from romp_load import load_source
@@ -98,7 +114,7 @@ HELPERS = {
     "_nudge_times": ("sig", ("nudge",)),
     "_session_flag": ("sig", ("hide",)),
     "_card_warn_rows": ("sig", ("debug",)),
-    "_cap_switch_offer": ("sig", ("row", "usage", "auth")),            # authLive, usage.json (recorded), the key on hand
+    "_cap_switch_offer": ("sig", ("row", "usage", "offer", "auth")),   # authLive, usage.json (recorded), its cap window's crossing, the key on hand
     # pure over classified inputs
     "_awaiting_peer_items": ("pure", "over the peer identities _session_awaiting resolved (peers), nothing else"),
 }
@@ -121,7 +137,7 @@ CTX = {
 }
 
 # closures defined inside the body: pure over its locals, no component
-LOCAL = ("_subtree", "_closure_done", "_fsubmax", "_closure_blocked", "_block_check_floor", "_note_peers")
+LOCAL = ("_subtree", "_closure_done", "_fsubmax", "_closure_blocked", "_block_check_floor", "_note_peers", "flatten")
 
 KINDS = {"sig", "pure", "clock"}
 
@@ -140,12 +156,71 @@ def _stripped(src, strings=False):
     return tokenize.untokenize(toks)
 
 
-def _calls_of(src):
-    """Every `_name(`, `jd.name(` and `em.name(` call in the stripped source."""
-    text = _stripped(src)
-    own = set(re.findall(r"(?<![\w.])(_[a-z_0-9]+)\(", text))
-    dotted = set("%s.%s" % m for m in re.findall(r"\b(jd|em)\.([a-z_0-9]+)\(", text))
-    return own | dotted
+def _callee_root(func):
+    """A callee reduced to its root (the module docstring's rule): walks down through Attribute, Subscript and Call
+    nodes until a node that is none of those, and returns (root node, dotted name), the name the root's id joined
+    with the attributes that follow it up to the first Subscript or Call (`os.path.basename`; `_auto_nudge_data` for
+    `_auto_nudge_data().get`), or None when the root is not a Name (a literal, a bool-op: a method on a value)."""
+    attrs, f = [], func
+    while True:
+        if isinstance(f, ast.Attribute):
+            attrs.append(f.attr)
+            f = f.value
+        elif isinstance(f, ast.Subscript):
+            attrs, f = [], f.value
+        elif isinstance(f, ast.Call):
+            attrs, f = [], f.func
+        else:
+            break
+    return f, (".".join([f.id] + attrs[::-1]) if isinstance(f, ast.Name) else None)
+
+
+def _bound_in(fn):
+    """Every name the body binds, at any depth: the parameters of the def, of a nested def and of a lambda (every
+    ast.arg), every Store-context Name (assignment, augmented assignment, for, with, walrus and comprehension
+    targets, unpacking included), an except handler's name, an import alias, a nested def's or class's name. A name
+    the body declares `global` is not bound here."""
+    names = set()
+    for x in ast.walk(fn):
+        if isinstance(x, ast.arg):
+            names.add(x.arg)
+        elif isinstance(x, ast.Name) and isinstance(x.ctx, ast.Store):
+            names.add(x.id)
+        elif isinstance(x, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and x is not fn:
+            names.add(x.name)
+        elif isinstance(x, ast.ExceptHandler) and x.name:
+            names.add(x.name)
+        elif isinstance(x, ast.alias):
+            names.add((x.asname or x.name).split(".")[0])
+    for x in ast.walk(fn):
+        if isinstance(x, ast.Global):
+            names.difference_update(x.names)
+    return names
+
+
+def _calls_of(fn, module):
+    """The callees the body reads from module scope, plus the nested defs it calls, as dotted names: every ast.Call
+    under `fn`, its callee reduced by _callee_root and its root classified by the module docstring's rule (a local's
+    method skipped, a builtin other than `open` skipped, a non-Name root skipped, everything else kept). `module` is
+    the kernel: a name it binds is never a builtin, however it is spelled."""
+    local, nested = _bound_in(fn), {x.name for x in ast.walk(fn) if isinstance(x, ast.FunctionDef) and x is not fn}
+    bound = vars(module)
+    calls = set()
+    for x in ast.walk(fn):
+        if not isinstance(x, ast.Call):
+            continue
+        root, name = _callee_root(x.func)
+        if name is None:
+            continue                              # a method on a value an expression produced (its calls walked too)
+        if root.id in nested:
+            calls.add(name)                       # a closure's call: LOCAL must name it
+        elif root.id in local:
+            continue                              # a local's method (tm.get, out.append)
+        elif root.id not in bound and hasattr(builtins, root.id) and root.id != "open":
+            continue                              # a builtin (len, sorted, str, dict.fromkeys); open reads a file: kept
+        else:
+            calls.add(name)                       # rooted in module scope: HELPERS must name it
+    return calls
 
 
 def _ctx_reads_of(src):
@@ -166,7 +241,8 @@ class Census(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.src = inspect.getsource(km._feed_session_entry)
-        cls.calls = _calls_of(cls.src) - {"_feed_session_entry"}       # the def line names the function itself
+        cls.fn = ast.parse(textwrap.dedent(cls.src)).body[0]
+        cls.calls = _calls_of(cls.fn, km)
         cls.ctx = _ctx_reads_of(cls.src)
 
     def test_every_helper_the_body_calls_is_classified_and_nothing_stale_remains(self):
@@ -203,17 +279,49 @@ class Census(unittest.TestCase):
                          % sorted(claimed ^ set(km._FEED_MEMO_LABELS)))
 
     def test_the_local_closures_are_defs_nested_in_the_body(self):
-        fn = ast.parse(self.src).body[0]
+        fn = self.fn
         nested = {x.name for x in ast.walk(fn) if isinstance(x, ast.FunctionDef) and x is not fn}
         for name in LOCAL:
             self.assertIn(name, nested, "%s is listed as a local closure but the body defines no such def" % name)
         self.assertFalse(set(LOCAL) & set(HELPERS), "a name is a closure or a helper, never both")
 
     def test_the_helper_names_resolve_in_the_kernel(self):
+        """Every dotted name walks from the kernel's namespace (or, for a classified builtin such as `open`, from
+        builtins) through each attribute to a callable: `os.path.basename` is `km.os`, then `.path`, then
+        `.basename`."""
         for name in HELPERS:
-            mod, _, attr = name.rpartition(".")
-            owner = getattr(km, mod) if mod else km
-            self.assertTrue(callable(getattr(owner, attr, None)), name)
+            root, *attrs = name.split(".")
+            obj = getattr(km, root) if root in vars(km) else getattr(builtins, root, None)
+            for a in attrs:
+                obj = getattr(obj, a, None)
+            self.assertTrue(callable(obj), name)
+
+    def test_the_derivation_sees_every_callee_shape(self):
+        """The rule on a synthetic body, so a regression to a narrower reader fails here rather than passing a read
+        unlabelled: a module alias chain, a class method, a bare module helper, a builtin that reads (`open`), a
+        method on a call's result, a local's method, a nested def, a lambda's parameter, an except name."""
+        src = textwrap.dedent('''
+            def body(s, ctx):
+                def inner(x):
+                    return x
+                p = os.path.basename(s["path"])
+                be = Sessions.backend_for(p)
+                data = json.dumps(_helper().get("k"), sort_keys=True)
+                with open(p) as fh:
+                    rows = [str(r).strip() for r in fh]
+                try:
+                    tm = ctx.get("tm")
+                except Exception as exc:
+                    tm = exc.args
+                f = lambda q: q.lower()
+                out = ", ".join(sorted(rows, key=f)) + (tm or {}).get("x", "")
+                return inner(out), be, data, dict.fromkeys(rows), sb.thing(len(rows))
+        ''')
+        fn = ast.parse(src).body[0]
+        module = type(km)("synthetic")            # binds nothing: every non-local, non-builtin root is module scope
+        self.assertEqual(_calls_of(fn, module),
+                         {"os.path.basename", "Sessions.backend_for", "json.dumps", "_helper", "open", "sb.thing",
+                          "inner"})
 
 
 class LabelsAndDocstring(unittest.TestCase):

--- a/tests/test_feed_session_memo.py
+++ b/tests/test_feed_session_memo.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""build_feed's per-session card memo (T368): a rebuild re-derives only the sessions whose inputs moved.
+
+The pusher keeps the whole feed payload while nothing on the board changes, but any change anywhere rebuilt it
+whole, and the rebuild walked every living session's goal tree and per-session derivations (the loop body of
+build_feed, now _feed_session_entry) whether or not that session had moved: a cost that scaled with sessions
+times goals, not with what changed. The memo (_feed_memo) holds each session's derived entry under a key of every
+input the derivation reads (_feed_session_key), invalidated by those inputs alone and never by the clock.
+
+This module drives the REAL build_feed over a hermetic three-session board (the notes-api demo world: web, api
+and tests, each with a transcript, a names entry, a live row and a goal store holding one top-level goal) and
+pins, per build, how many sessions were derived (/perf builds.feed.memo `derived`) and which component the miss
+was attributed to, beside the card the moved input changes:
+  * cold: three derivations; unchanged: none; a memoized build equals a from-scratch build byte for byte;
+  * one input at a time, each re-deriving ITS session only: a judge verdict (the store file), a user gesture
+    (the override journal), a clear (the session's slice of cleared.jsonl), a live-row change, a transcript
+    append, a states append, a names rewrite, the hideFromFeed flag;
+  * a peer's verdict re-derives the session whose card reads that peer's store (the peers dependency);
+  * the clock: two builds ten minutes apart derive nothing and differ in `now`, `buildId` and the cards' age
+    tint alone (the fold stamps trgb per build; the memo holds nothing clock-derived);
+  * the byte bound (FEED_MEMO_BYTES): entries leave oldest first, counted, and the payload stays complete;
+  * a departed session's entry leaves with it; GET /perf reports the memo's counters.
+
+Harness: tests/test_payload_dedup_invariant.py's world (a hermetic state root the kernel's judge is rebound to,
+names/ entries and projects/<launch dir>/<sid>.jsonl transcripts discover finds, a fixed live map, a warm first
+build so the session-order adoption sits behind the compared builds), extended to three sessions with goal
+stores minted the way tests/test_kernel_goal_cache_wiring.py mints them (jd.apply_plan, jd.rollup_status,
+jd.save_goals). The parses stay cold, as the feed reads them (cache-only), so a card here is the store's card.
+Synthetic fixtures only: private synthetic sids (the goal-store fixture rule: load_goals replays the per-sid
+override journal, so a shared placeholder sid would be re-flagged by other modules' rows), invented text.
+"""
+import json
+import os
+import re
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+# Hermetic state BEFORE the load: the kernel resolves its state root at import time, and only pytest runs
+# conftest's floor (a bare unittest or script run otherwise writes REAL state).
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+km = load_source("romp_kernel_feed_session_memo", os.path.join(BIN, "romp-kernel"))
+jd = km.jd                              # the kernel's judge: the one object build_feed reads stores through
+
+# This module's PRIVATE synthetic sids (never the shared 11111111-2222-... placeholder: see the docstring).
+# (a tuple, unpacked below: a session named after the demo's api service assigned a high-entropy string on its
+# own line reads as a credential to the secret scanner the pre-push hook runs)
+SIDS = ("5f3e2d1c-0b9a-4876-9543-210fedcba001", "5f3e2d1c-0b9a-4876-9543-210fedcba002",
+        "5f3e2d1c-0b9a-4876-9543-210fedcba003")
+WEB, API, TESTS = SIDS
+NAME_OF = {WEB: "web", API: "api", TESTS: "tests"}
+COLOR_OF = {WEB: "#1EA1EB", API: "#E67E22", TESTS: "#2ECC71"}
+GOAL_OF = {WEB: "wire the notes-api web client", API: "add the notes-api list endpoint",
+           TESTS: "cover the notes-api list endpoint"}
+NOW = 1781100000
+T0 = NOW - 3600                         # the goals' mint time: a one-hour age sits inside the tint's fade window
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def aline(t, text, uuid, parent=None, stop="end_turn"):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}],
+                        "stop_reason": stop}}
+
+
+def _dump(feed):
+    """The payload's serialization with the declared clock fields stripped: the dedup's comparison."""
+    return json.dumps({k: v for k, v in feed.items() if k not in km._DEDUP_VOLATILE}, sort_keys=True, default=str)
+
+
+def _without_tints(feed):
+    """The stripped payload with every card's and tree row's age tint removed, for the clock comparison."""
+    f = json.loads(_dump(feed))
+    for c in f["asks"]:
+        c.pop("trgb", None)
+        for r in c.get("tree") or []:
+            r.pop("trgb", None)
+    return json.dumps(f, sort_keys=True)
+
+
+def _reset_memo():
+    """The memo empty and its counters at zero: every test starts cold. A kernel without the memo (the base commit
+    this change's red-first run pins against) has nothing to reset: the walked-sessions pin below then runs red on
+    its own assertion rather than erroring here."""
+    if not hasattr(km, "_feed_memo"):
+        return
+    with km._feed_memo_lock:
+        km._feed_memo.clear()
+        st = km._FEED_MEMO_STATS
+        for k in ("hit", "miss", "evict", "derived", "entries", "bytes"):
+            st[k] = 0
+        for k in st["miss_by"]:
+            st["miss_by"][k] = 0
+
+
+def _memo_snapshot():
+    """(the entries, the counters) as they stand, so a test can hand the process back what it found."""
+    if not hasattr(km, "_feed_memo"):
+        return None
+    with km._feed_memo_lock:
+        return dict(km._feed_memo), json.loads(json.dumps(km._FEED_MEMO_STATS))
+
+
+def _memo_restore(snap):
+    if snap is None:
+        return
+    entries, stats = snap
+    with km._feed_memo_lock:
+        km._feed_memo.clear()
+        km._feed_memo.update(entries)
+        km._FEED_MEMO_STATS.clear()
+        km._FEED_MEMO_STATS.update(stats)
+
+
+class _Board(unittest.TestCase):
+    """The three-session world; every test builds the REAL build_feed over it."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        proj = td / "projects"
+        names = td / "names"
+        names.mkdir()
+        self.tpath, self.cdir = {}, {}
+        for sid in SIDS:
+            cdir = td / ("launch-" + NAME_OF[sid])
+            cdir.mkdir()
+            pdir = proj / re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+            pdir.mkdir(parents=True)
+            tp = pdir / (sid + ".jsonl")
+            tp.write_text("\n".join(json.dumps(r) for r in [
+                uline(T0, "start on: " + GOAL_OF[sid], "u1"),
+                aline(T0 + 40, "On it.", "a1", "u1"),
+            ]) + "\n")
+            (names / sid).write_text("%s\t%s\t%s\n" % (NAME_OF[sid], cdir, COLOR_OF[sid]))
+            self.tpath[sid], self.cdir[sid] = tp, cdir
+        self.saved = (jd.STATE, jd.PROJECTS, km.NAMES, km._GLOBAL_CLAUDE_MD)
+        self.saved_memo = _memo_snapshot()        # the memo and its counters, restored in tearDown
+        # The kernel's judge is ONE module object for every test module in the process, so its STATE (goals,
+        # override journals, cleared.jsonl, session-order.json) is a directory the whole run shares. This board
+        # builds over ITS root and nothing else: _rebind_state moves GOALDIR and every derived dir with it.
+        jd._rebind_state(td)
+        jd.PROJECTS = proj
+        km.NAMES = jd.NAMES
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        km._live_scope.names = None               # no cycle snapshot: the names registry is read from the files
+        km._live_scope.snapshot = None
+        for sid in SIDS:
+            self._mint(sid, GOAL_OF[sid])
+        # Fixed rows, so the stub itself contributes nothing clock-derived (the dedup invariant's idiom).
+        self.live = {sid: self._row() for sid in SIDS}
+        # A session's FIRST build adopts it into the persisted session order (feed `order` reads that file
+        # before _ordered appends the newcomer), so the first sight is a genuine change; warm once so every
+        # compared build is post-adoption, then start the memo cold.
+        jd._discover_cache.clear()
+        km.build_feed(NOW - 1, self.live)
+        _reset_memo()
+
+    def tearDown(self):
+        _memo_restore(self.saved_memo)
+        jd._rebind_state(self.saved[0])
+        jd.PROJECTS, km.NAMES, km._GLOBAL_CLAUDE_MD = self.saved[1:]
+        km._live_scope.names = None
+        km._live_scope.snapshot = None
+        jd._discover_cache.clear()
+        self.td.cleanup()
+
+    # ── the world's writers ──
+    @staticmethod
+    def _row():
+        return {"state": "idle", "since": NOW - 100, "model": "", "effort": "", "context": None,
+                "compactPct": None, "color": None}
+
+    @staticmethod
+    def _mint(sid, text):
+        """One top-level goal, minted the way the planner mints (apply_plan), rolled up and saved: the store
+        the kernel's judge loads (tests/test_kernel_goal_cache_wiring.py's idiom)."""
+        s = {"rompUuid": sid, "seq": 0, "placementsV": jd.PLACEMENTS_V, "nodes": {}, "placements": {},
+             "status": {}}
+        jd.apply_plan(s, "s1", T0, [{"do": "mint", "why": "the request that opened the session", "text": text}], [])
+        jd.rollup_status(s, session_closed=False)
+        jd.save_goals(sid, s)
+
+    @staticmethod
+    def _complete(sid, t=NOW - 30):
+        """A JUDGE VERDICT: the closer records the goal done and rolls the store up with the session's turn
+        closed, which settles the top (rollup_status records the settle verdict itself) so the card enters
+        Completed; the publish moves the store file."""
+        s = jd.load_goals(sid)
+        nd = s["nodes"][sid + ":g1"]
+        assert jd.record_verdict(s, nd, "romp", "done", t, why="Shipped."), "the done verdict passed the gate"
+        jd.rollup_status(s, session_closed=True, now=t)
+        jd.save_goals(sid, s)
+
+    @staticmethod
+    def _publish_raw(sid, text, **node):
+        """A store republished whole in the judge's file shape (the fault-boundary tests' fixture), for a node
+        shape apply_plan does not mint here (a goal carrying a sender's origin)."""
+        gid = sid + ":g1"
+        nd = {"id": gid, "parentId": None, "t": T0, "mt": T0, "text": text, "nodeComplete": False,
+              "blocked": False, "cleared": False, "trail": ["s1"], "log": []}
+        nd.update(node)
+        store = {"rompUuid": sid, "seq": 1, "rev": 7, "placementsV": jd.PLACEMENTS_V, "placements": {},
+                 "nodes": {gid: nd}, "status": {gid: "working"}, "lastNode": gid}
+        p = jd.GOALDIR / (sid + ".json")
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text(json.dumps(store))
+        os.replace(tmp, p)                    # the atomic publish every store writer uses
+
+    # ── the reads ──
+    def _build(self, now=NOW):
+        return km.build_feed(now, self.live)
+
+    def _delta(self, fn):
+        """(the memo counters' movement over fn(), fn's result): hit / miss / derived / evict and the non-zero
+        miss attributions."""
+        b = km._feed_memo_report()
+        bm = b["miss_by"]
+        out = fn()
+        a = km._feed_memo_report()
+        d = {k: a[k] - b[k] for k in ("hit", "miss", "derived", "evict")}
+        d["miss_by"] = {k: v - bm.get(k, 0) for k, v in a["miss_by"].items() if v - bm.get(k, 0)}
+        return d, out
+
+    @staticmethod
+    def _cards(feed):
+        return {a["itemId"]: a for a in feed["asks"]}
+
+
+class ColdWarmAndFromScratch(_Board):
+    def test_a_cold_build_derives_every_session_and_an_unchanged_rebuild_derives_none(self):
+        d, f1 = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (3, 0), d)
+        self.assertEqual(d["miss"], d["derived"], "miss and derived count the same event: one per derivation")
+        self.assertEqual(d["miss_by"], {"cold": 3}, "a session with no entry misses under `cold`")
+        self.assertEqual(sorted(self._cards(f1)), sorted(sid + ":g1" for sid in SIDS), "one card per goal")
+        self.assertEqual({a["column"] for a in f1["asks"]}, {"working"})
+        d, f2 = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (0, 3), d)
+        self.assertEqual(_dump(f1), _dump(f2), "a served build is the derived build, byte for byte")
+        rep = km._feed_memo_report()
+        self.assertEqual(rep["entries"], 3)
+        self.assertEqual(rep["bytes"], sum(e[2] for e in km._feed_memo.values()))
+        self.assertGreater(rep["bytes"], 0)
+
+    def test_one_sessions_store_publish_re_derives_that_session_alone_and_equals_a_from_scratch_build(self):
+        before = self._cards(self._build())
+        self.assertIsNone(before[API + ":g1"]["doneConfirming"])
+        self._complete(API)                   # the closer's verdict lands in api's store
+        d, memoized = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"store": 1}, "the store file moved and nothing else")
+        cards = self._cards(memoized)
+        self.assertEqual(cards[API + ":g1"]["column"], "completed", "the verdict reached the card")
+        self.assertEqual(cards[API + ":g1"]["distillState"], "completed")
+        self.assertEqual(cards[WEB + ":g1"]["column"], "working")
+        self.assertEqual(cards[TESTS + ":g1"]["column"], "working")
+        _reset_memo()                         # the same clock, nothing memoized: every session derived afresh
+        d, scratch = self._delta(self._build)
+        self.assertEqual(d["derived"], 3, d)
+        self.assertEqual(_dump(memoized), _dump(scratch),
+                         "two served entries beside one derivation must equal three derivations, byte for byte")
+
+
+class EveryInputMovesItsSessionOnly(_Board):
+    """Each writer below is one of the events the key covers; each re-derives exactly the session it touched,
+    under exactly its label, and the card shows the change."""
+
+    def test_a_user_gesture_journaled_as_an_override_row(self):
+        self._build()
+        # the user resolves web's card: _resolve_node journals the gesture BEFORE its store save (the journal
+        # is the durable truth load_goals replays); here the journal row alone, the store file untouched
+        jd.append_override(WEB, WEB + ":g1", "resolve", NOW - 20)
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"store": 1}, "the override journal is part of the store identity")
+        card = self._cards(f)[WEB + ":g1"]
+        # the replayed resolve is a done verdict on a top the session still holds as its focus: the settle gate
+        # keeps the column Working and the card wears the "done, confirming" cue (rollup's confirming export)
+        self.assertTrue(card["doneConfirming"], "the replayed resolve reached the card")
+        self.assertEqual(card["column"], "working")
+        d, _ = self._delta(self._build)
+        self.assertEqual(d["derived"], 0, "the replay is idempotent and the journal stands: a hit")
+
+    def test_a_clear_row_for_one_card(self):
+        self._build()
+        with (jd.STATE / "cleared.jsonl").open("a") as fh:      # the ledger row the clear handler appends
+            fh.write(json.dumps({"id": TESTS + ":g1", "t": NOW - 10, "op": "clear"}) + "\n")
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"cleared": 1}, "the ledger is keyed by the session's own slice")
+        self.assertNotIn(TESTS + ":g1", self._cards(f), "the cleared card is gone")
+        self.assertEqual(sorted(self._cards(f)), sorted([WEB + ":g1", API + ":g1"]))
+        self.assertEqual(f["dismissedCount"], 1)
+
+    def test_a_live_row_change(self):
+        self._build()
+        self.live[API] = dict(self._row(), model="opus")        # the row's model badge changes
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"row": 1})
+        self.assertEqual(len(f["asks"]), 3)
+
+    def test_a_transcript_append(self):
+        self._build()
+        with self.tpath[WEB].open("a") as fh:
+            fh.write(json.dumps(uline(NOW - 5, "and the pagination", "u2", "a1")) + "\n")
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertIn("transcript", d["miss_by"])
+        self.assertTrue(set(d["miss_by"]) <= {"transcript", "parse"},
+                        "an append moves the transcript identity (and the parse bit when a parse was cached): %r"
+                        % d["miss_by"])
+        self.assertEqual(len(f["asks"]), 3)
+
+    def test_a_states_append(self):
+        self._build()
+        jd.STATESDIR.mkdir(parents=True, exist_ok=True)
+        with (jd.STATESDIR / (API + ".jsonl")).open("a") as fh:   # a producer's state row
+            fh.write(json.dumps({"t": NOW - 5, "state": "idle"}) + "\n")
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"states": 1})
+        self.assertEqual(len(f["asks"]), 3)
+
+    def test_a_names_rewrite(self):
+        self._build()
+        (jd.NAMES / TESTS).write_text("tests\t%s\t#123456\n" % self.cdir[TESTS])   # the session recolored
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"names": 1})
+        self.assertEqual(self._cards(f)[TESTS + ":g1"]["color"], {"bg": "#123456", "fg": "#ffffff"})
+        self.assertEqual(self._cards(f)[WEB + ":g1"]["color"], {"bg": COLOR_OF[WEB], "fg": "#ffffff"})
+
+    def test_the_hide_from_feed_flag(self):
+        self._build()
+        flags = jd.STATE / "session-flags.json"
+        flags.write_text(json.dumps({API: {"hideFromFeed": True}}))
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (1, 2), d)
+        self.assertEqual(d["miss_by"], {"hide": 1})
+        self.assertNotIn(API, {a["sid"] for a in f["asks"]}, "a muted session's cards vanish")
+        self.assertEqual(sorted(self._cards(f)), sorted([WEB + ":g1", TESTS + ":g1"]))
+        d, _ = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (0, 3), "the muted session's (empty) entry serves too")
+        flags.write_text(json.dumps({}))
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["miss_by"]), (1, {"hide": 1}), d)
+        self.assertIn(API + ":g1", self._cards(f), "unmuted: the card is back")
+
+    def test_a_peers_verdict_re_derives_the_card_that_reads_its_store(self):
+        """api's goal was delegated from web (its origin names web's goal): the card's origin badge reads WEB's
+        store, so a verdict in web's store must re-derive api's card too, or a hit would serve a badge a judge
+        has moved. The key's `peers` component re-evaluates the peers the previous derivation recorded."""
+        self._build()
+        self._publish_raw(API, GOAL_OF[API], origin={"peer": WEB, "goalId": WEB + ":g1"})
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["miss_by"]), (1, {"store": 1}), d)
+        card = self._cards(f)[API + ":g1"]
+        self.assertTrue(card["origin"]["live"], "web's goal is open: the badge reads live")
+        # That derivation read web for the FIRST time, so web's facts were not taken before the read (a publish
+        # landing mid-read could pair a new key with old content): the stored key is unsettled, and the next build
+        # re-derives api once more with web's facts taken before the read, then hits.
+        peers_at = km._FEED_MEMO_LABELS.index("peers")
+        self.assertEqual(km._feed_memo_get(API)[0][peers_at], km._FEED_PEERS_UNSETTLED,
+                         "a peer first read by this derivation leaves the key unsettled")
+        d, _ = self._delta(self._build)
+        self.assertEqual((d["derived"], d["miss_by"]), (1, {"peers": 1}), "the settling derivation: %r" % d)
+        self.assertEqual(km._feed_memo_get(API)[0][peers_at][0][0], WEB,
+                         "api's key names web, with facts taken before the read")
+        d, _ = self._delta(self._build)
+        self.assertEqual(d["derived"], 0, "the peer's facts stand: a hit")
+        self._complete(WEB)                   # the verdict lands in WEB's store, not api's
+        d, f = self._delta(self._build)
+        self.assertEqual(d["derived"], 2, "web (its store) and api (its peer's store): %r" % d)
+        self.assertEqual(d["miss_by"], {"store": 1, "peers": 1})
+        self.assertEqual(self._cards(f)[WEB + ":g1"]["column"], "completed")
+        self.assertFalse(self._cards(f)[API + ":g1"]["origin"]["live"], "the badge dimmed with the sender's goal")
+        self.assertEqual(self._cards(f)[TESTS + ":g1"]["column"], "working")
+
+
+class TheClockIsNotAnInput(_Board):
+    def test_two_builds_ten_minutes_apart_derive_nothing_and_differ_only_in_the_clock_fields_and_the_tints(self):
+        d, a = self._delta(self._build)
+        self.assertEqual(d["derived"], 3)
+        d, b = self._delta(lambda: self._build(NOW + 600))
+        self.assertEqual((d["derived"], d["hit"]), (0, 3), "time passing moves no key component: %r" % d)
+        top = sorted(k for k in set(list(a) + list(b))
+                     if json.dumps(a.get(k), sort_keys=True, default=str) != json.dumps(b.get(k), sort_keys=True, default=str))
+        self.assertEqual(top, ["asks", "now"], "only the clock and the cards (their tints) differ: %r" % top)
+        self.assertEqual(_without_tints(a), _without_tints(b), "with the tints removed the two builds are one")
+        tints_a = [c["trgb"] for c in a["asks"]]
+        tints_b = [c["trgb"] for c in b["asks"]]
+        self.assertNotEqual(tints_a, tints_b, "the fold re-stamped the age tint for the later clock")
+        self.assertTrue(all(len(t) == 3 for t in tints_a + tints_b))
+        for c in a["asks"] + b["asks"]:
+            self.assertNotIn("_ageT", c, "the tint's epoch is the entry's; the folded card carries trgb")
+            for r in c.get("tree") or []:
+                self.assertNotIn("_ageT", r)
+        self.assertIn("now", km._DEDUP_VOLATILE, "the one clock field the builder emits is a declared volatile")
+
+
+class TheBoundAndTheDepartures(_Board):
+    def test_the_byte_bound_sheds_the_oldest_entries_and_the_payload_stays_complete(self):
+        self._build()
+        one = max(e[2] for e in km._feed_memo.values())     # the largest entry: alone at the bound it still serves
+        with mock.patch.object(km, "FEED_MEMO_BYTES", one):
+            _reset_memo()
+            d, f = self._delta(self._build)
+            self.assertEqual(d["derived"], 3)
+            rep = km._feed_memo_report()
+            self.assertEqual(rep["bound"], one)
+            self.assertGreaterEqual(rep["evict"], 2, "the second and third puts each shed the oldest: %r" % rep)
+            self.assertLessEqual(rep["bytes"], one)
+            self.assertEqual(rep["entries"], 1)
+            self.assertEqual(rep["bytes"], sum(e[2] for e in km._feed_memo.values()))
+            self.assertEqual(sorted(self._cards(f)), sorted(sid + ":g1" for sid in SIDS),
+                             "the payload is complete whatever the bound")
+            self.assertEqual(km._PERF_STATS.snapshot()["builds"]["feed"]["memo"], rep,
+                             "GET /perf reports the memo's counters under builds.feed.memo")
+
+    def test_the_bound_is_a_fraction_of_the_machines_memory_unless_the_environment_names_bytes(self):
+        with mock.patch.dict(os.environ, {"ROMP_FEED_MEMO_BYTES": "4096"}):
+            self.assertEqual(km._feed_memo_bound(), 4096)
+        with mock.patch.dict(os.environ, {"ROMP_FEED_MEMO_BYTES": "lots"}):
+            self.assertEqual(km._feed_memo_bound(), km._mem_total_bytes() // 64, "an unparseable value falls to the default")
+        with mock.patch.dict(os.environ, {"ROMP_FEED_MEMO_BYTES": "0"}):
+            self.assertEqual(km._feed_memo_bound(), km._mem_total_bytes() // 64, "zero is not a bound")
+        env = {k: v for k, v in os.environ.items() if k != "ROMP_FEED_MEMO_BYTES"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(km._feed_memo_bound(), km._mem_total_bytes() // 64)
+        self.assertGreater(km.FEED_MEMO_BYTES, 0)
+
+    def test_a_departed_sessions_entry_leaves_with_it(self):
+        self._build()
+        self.assertEqual(km._feed_memo_report()["entries"], 3)
+        self.live.pop(TESTS)                  # the session is gone from the backend's live map ...
+        (jd.NAMES / TESTS).unlink()           # ... and from the names registry
+        jd._discover_cache.clear()
+        d, f = self._delta(self._build)
+        self.assertEqual((d["derived"], d["hit"]), (0, 2), d)
+        self.assertEqual(d["evict"], 1, "the departed entry is counted as an eviction")
+        rep = km._feed_memo_report()
+        self.assertEqual(rep["entries"], 2)
+        self.assertEqual(set(km._feed_memo), {WEB, API})
+        self.assertEqual(rep["bytes"], sum(e[2] for e in km._feed_memo.values()))
+        self.assertNotIn(TESTS + ":g1", self._cards(f))
+
+    def test_the_perf_snapshot_carries_the_memo_beside_the_feed_builds_counters(self):
+        self._build()
+        feed = km._PERF_STATS.snapshot()["builds"]["feed"]
+        self.assertEqual(set(feed), {"cached", "built", "ms", "memo"})
+        self.assertEqual(feed["memo"], km._feed_memo_report())
+        self.assertEqual(set(feed["memo"]), {"hit", "miss", "evict", "entries", "bytes", "bound", "derived", "miss_by"})
+        self.assertEqual(set(feed["memo"]["miss_by"]), set(km._FEED_MEMO_LABELS) | {"cold"})
+        self.assertEqual(feed["memo"]["derived"], 3)
+        self.assertEqual(feed["memo"]["bound"], km.FEED_MEMO_BYTES)
+        json.dumps(feed)                      # serializes as-is
+
+
+class TheRebuildWalksOnlyWhatMoved(_Board):
+    """The pin this change is filed under (it fails on the kernel before the memo): a rebuild of an unchanged board
+    walks NO session's goal tree. _heal_session_tops runs once per session per derivation (the read-side nesting of
+    machine-rooted tops over the session's nodes and status), so its call count is the number of sessions whose
+    trees the build walked. Before the memo it was three on every rebuild, whatever had changed; with it, three on
+    the cold build and none on the unchanged rebuild, then exactly the one session whose store moved."""
+
+    def _walked(self, fn):
+        calls = []
+        real = km._heal_session_tops
+        with mock.patch.object(km, "_heal_session_tops", side_effect=lambda *a, **k: (calls.append(1), real(*a, **k))[1]):
+            out = fn()
+        return len(calls), out
+
+    def test_an_unchanged_rebuild_walks_no_sessions_tree_and_a_moved_store_walks_that_session_alone(self):
+        n_cold, _ = self._walked(self._build)
+        self.assertEqual(n_cold, 3, "the cold build derives every session: one walk each")
+        n_same, feed = self._walked(self._build)
+        self.assertEqual(n_same, 0, "an unchanged board is served from the memo: no session's tree is walked")
+        self.assertEqual(len(feed["asks"]), 3, "and the board is whole")
+        self._complete(API)
+        n_moved, feed = self._walked(self._build)
+        self.assertEqual(n_moved, 1, "one store moved: that session's tree alone is walked again")
+        self.assertEqual(self._cards(feed)[API + ":g1"]["column"], "completed", "and its card wears the verdict")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_feed_session_memo.py
+++ b/tests/test_feed_session_memo.py
@@ -33,6 +33,7 @@ import json
 import os
 import re
 import tempfile
+import time
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -498,6 +499,98 @@ class TheRebuildWalksOnlyWhatMoved(_Board):
         n_moved, feed = self._walked(self._build)
         self.assertEqual(n_moved, 1, "one store moved: that session's tree alone is walked again")
         self.assertEqual(self._cards(feed)[API + ":g1"]["column"], "completed", "and its card wears the verdict")
+
+
+class TheClockDecidedBooleansAreComponents(_Board):
+    """The one read in the derivation's closure that consults its own clock is the billing-switch offer
+    (_cap_switch_offer: a login-account usage window at its cap with resets_at still ahead). The reset passing ends the
+    offer on the base's next build; a memo hit would keep offering a switch past the reset, so the crossing is the
+    `offer` component, a boolean the key computes from usage.json against the build's clock (the verifier's shape,
+    T368 review). Red on the memo without the component: the second build serves the offer with derived 0."""
+
+    def _cap_death(self, sid, resets_at):
+        """web dead on a plain retryable API error, billing the login, a key on hand, the five-hour window at its cap:
+        every leg of the offer."""
+        with open(self.tpath[sid], "a") as fh:
+            fh.write(json.dumps({"type": "assistant", "timestamp": iso(T0 + 80), "uuid": "a2", "parentUuid": "a1",
+                                 "isApiErrorMessage": True, "apiErrorStatus": 529, "error": "overloaded_error",
+                                 "message": {"role": "assistant", "stop_reason": "stop_sequence",   # the failed turn ENDS on the record
+                                             "content": [{"type": "text", "text": "API Error: 529 overloaded"}]}}) + "\n")
+        km._parse(str(self.tpath[sid]), sid, NOW)          # the feed reads the parse cache-only: warm it (the error tail rides the parse)
+        self.live[sid] = dict(self._row(), authLive="login")
+        (jd.STATE / "usage.json").write_text(json.dumps({"five_hour": {"pct": 100, "resets_at": resets_at}}))
+
+    def test_the_offer_leaves_the_card_when_its_reset_passes_on_a_served_entry(self):
+        # The reset sits ahead of BOTH clocks the offer has been read against (the build's, and the wall clock the
+        # memo's first head still minted from), so the served-stale case shows on that head as it did on the
+        # verifier's kernel: the window passes, the entry hits, the card keeps offering.
+        resets_at = max(NOW, int(time.time())) + 600
+        self._cap_death(WEB, resets_at)
+        with mock.patch.object(km, "_auth_key_present", lambda: True), \
+                mock.patch.object(km, "_live_map", lambda: self.live):   # the offer reads the cycle's live snapshot
+            d, f = self._delta(self._build)
+            self.assertEqual(d["derived"], 3)
+            offer = {"resetsAt": resets_at, "window": "five_hour"}
+            blocked = self._cards(f)[WEB + ":g1"]["blocked"]     # the api-error block carries the offer
+            self.assertEqual(blocked.get("capOffer"), offer,
+                             "the offer rides the card while the window is capped with its reset ahead: %r" % blocked)
+            d, f = self._delta(self._build)
+            self.assertEqual(d["derived"], 0, "nothing moved: a hit, the offer still current")
+            self.assertEqual(self._cards(f)[WEB + ":g1"]["blocked"].get("capOffer"), offer)
+            d, f = self._delta(lambda: self._build(resets_at + 1))
+            self.assertEqual((d["derived"], d["miss_by"]), (1, {"offer": 1}),
+                             "the reset passed: the crossing moved web's key and web alone re-derived: %r" % d)
+            blocked = self._cards(f)[WEB + ":g1"]["blocked"]
+            self.assertEqual(blocked.get("state"), "apiError", "the error block stays: %r" % blocked)
+            self.assertNotIn("capOffer", blocked, "a rebuilt card drops the offer; a served one must too")
+            d, f = self._delta(lambda: self._build(resets_at + 2))
+            self.assertEqual(d["derived"], 0, "closed stays closed: a hit")
+            self.assertNotIn("capOffer", self._cards(f)[WEB + ":g1"]["blocked"])
+
+    def test_the_offer_is_keyed_only_for_the_session_that_read_usage(self):
+        self._cap_death(WEB, max(NOW, int(time.time())) + 600)
+        with mock.patch.object(km, "_auth_key_present", lambda: True), \
+                mock.patch.object(km, "_live_map", lambda: self.live):
+            self._build()
+            k_web = km._feed_memo_get(WEB)[0]
+            k_api = km._feed_memo_get(API)[0]
+            at = km._FEED_MEMO_LABELS.index("offer")
+            self.assertIs(k_web[at], True, "web read usage.json: its key carries the window's state")
+            self.assertIsNone(k_api[at], "api did not: the crossing is no input of its card")
+
+
+class ThePostalLogIsKeyedPerSession(_Board):
+    """The postal log is one file every session's derivation reads, but a session's cards read only the rows it is
+    a party to (its own asks, the replies to them, its peers' names), so the key holds that slice by value, not
+    the whole log's identity: a row between two other sessions moves no key of this one (T368 review: the
+    whole-log identity re-derived the board on every row)."""
+
+    def _mail(self, frm, to, kind, t, body):
+        p = jd.MESSAGES
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with open(p, "a") as fh:
+            fh.write(json.dumps({"id": "m-%d" % t, "from_id": frm, "to_id": to, "from": NAME_OF[frm], "to": NAME_OF[to],
+                                 "kind": kind, "t": t, "body": body}) + "\n")
+
+    def test_a_row_between_two_other_sessions_leaves_a_sessions_key_where_it_was(self):
+        self._build()
+        self._mail(WEB, API, "question", NOW - 50, "Is the list endpoint paginated?")
+        d, _ = self._delta(self._build)
+        self.assertEqual(d["derived"], 2, "the two parties re-derive, the third does not: %r" % d)
+        self.assertEqual(d["miss_by"], {"postal": 2, "wait": 1}, "the question also opens the asker's wait edge")
+        self.assertEqual(km._feed_memo_get(TESTS)[0][km._FEED_MEMO_LABELS.index("postal")], ((), ()),
+                         "tests is party to no row: its slice is empty and its key stood")
+        d, _ = self._delta(self._build)
+        self.assertEqual(d["derived"], 0)
+        self._mail(API, WEB, "coordinate", NOW - 40, "Yes, by cursor.")
+        d, _ = self._delta(self._build)
+        self.assertEqual((d["derived"], d["miss_by"]), (2, {"postal": 2, "wait": 1}), "the reply moves the pair's rows and closes the edge: %r" % d)
+        self.assertEqual(km._feed_memo_get(TESTS)[0][km._FEED_MEMO_LABELS.index("postal")], ((), ()))
+        self._mail(TESTS, WEB, "coordinate", NOW - 30, "Covering the cursor case.")
+        d, _ = self._delta(self._build)
+        self.assertEqual((d["derived"], d["miss_by"]), (2, {"postal": 2}), "tests and web, never api: %r" % d)
+        self.assertEqual(km._feed_memo_get(API)[0][km._FEED_MEMO_LABELS.index("postal")][0][0][0], (WEB, API),
+                         "api's slice still holds its own pair alone")
 
 
 if __name__ == "__main__":

--- a/tests/test_feed_session_memo.py
+++ b/tests/test_feed_session_memo.py
@@ -462,6 +462,8 @@ class TheBoundAndTheDepartures(_Board):
         self.assertEqual(set(km._feed_memo), {WEB, API})
         self.assertEqual(rep["bytes"], sum(e[2] for e in km._feed_memo.values()))
         self.assertNotIn(TESTS + ":g1", self._cards(f))
+        self.assertEqual(set(km._SUBAGENT_DIRS_MEMO) & set(SIDS), {WEB, API},
+                         "the key's subagent-walk memo drops the departed session with its entry (round two, low 1)")
 
     def test_the_perf_snapshot_carries_the_memo_beside_the_feed_builds_counters(self):
         self._build()
@@ -499,6 +501,22 @@ class TheRebuildWalksOnlyWhatMoved(_Board):
         n_moved, feed = self._walked(self._build)
         self.assertEqual(n_moved, 1, "one store moved: that session's tree alone is walked again")
         self.assertEqual(self._cards(feed)[API + ":g1"]["column"], "completed", "and its card wears the verdict")
+
+
+class TheClearedIndexMatchesTheFilter(unittest.TestCase):
+    """The per-build clear index (_cleared_by_sid) must hand each session exactly what the per-session filter
+    `i.startswith(sid + ":")` returned, for every id shape the ledger can hold: a node id <sid>:gN, a composite
+    session key with its own colon (host:name:gN, a peer wait key), an id with no colon, and an id of another kind
+    (parked:<msgId>). Round two, low 3: an index on the FIRST colon gave a composite session nothing. The sessions
+    asked are the shapes a session id takes (a uuid, a host:name key, none, an unknown one); a session id is never
+    the bare host half of a composite key, the one prefix the filter would have matched and the index does not."""
+
+    def test_every_shape_indexes_where_the_filter_found_it(self):
+        ids = {WEB + ":g1", WEB + ":g2", API + ":g1", "TESTHOST:api:g3", "TESTHOST:api:g1", "parked:m-1789", "bare-id"}
+        by = km._cleared_by_sid(ids)
+        for sid in (WEB, API, TESTS, "TESTHOST:api", "parked", "bare-id", "", "nobody"):
+            want = tuple(sorted(i for i in ids if i.startswith(sid + ":")))
+            self.assertEqual(by.get(sid, ()), want, "session %r" % sid)
 
 
 class TheClockDecidedBooleansAreComponents(_Board):
@@ -547,6 +565,31 @@ class TheClockDecidedBooleansAreComponents(_Board):
             self.assertEqual(d["derived"], 0, "closed stays closed: a hit")
             self.assertNotIn("capOffer", self._cards(f)[WEB + ":g1"]["blocked"])
 
+    def test_two_capped_windows_the_earlier_reset_passing_moves_the_offer_to_the_later_window(self):
+        """Round two's shape: both windows at their cap, the five-hour one resetting first. The five-hour reset
+        passing leaves a login window capped (the seven-day one), so a boolean would stand and a served card would
+        keep naming a reset already in the past; the component is the payload the card renders, so the crossing
+        moves the key and the rebuilt card names the seven-day window and its reset."""
+        base = max(NOW, int(time.time()))
+        r5, r7 = base + 600, base + 4000
+        self._cap_death(WEB, r5)
+        (jd.STATE / "usage.json").write_text(json.dumps({"five_hour": {"pct": 100, "resets_at": r5},
+                                                         "seven_day": {"pct": 100, "resets_at": r7}}))
+        with mock.patch.object(km, "_auth_key_present", lambda: True), \
+                mock.patch.object(km, "_live_map", lambda: self.live):
+            d, f = self._delta(self._build)
+            self.assertEqual(self._cards(f)[WEB + ":g1"]["blocked"].get("capOffer"), {"resetsAt": r5, "window": "five_hour"})
+            d, f = self._delta(lambda: self._build(r5 + 1))
+            self.assertEqual((d["derived"], d["miss_by"]), (1, {"offer": 1}),
+                             "the five-hour reset passed with the seven-day window still capped: web re-derives: %r" % d)
+            self.assertEqual(self._cards(f)[WEB + ":g1"]["blocked"].get("capOffer"), {"resetsAt": r7, "window": "seven_day"},
+                             "the rebuilt card names the window still capped and ITS reset, never the passed one")
+            d, f = self._delta(lambda: self._build(r5 + 2))
+            self.assertEqual(d["derived"], 0, "and holds: a hit")
+            d, f = self._delta(lambda: self._build(r7 + 1))
+            self.assertEqual((d["derived"], d["miss_by"]), (1, {"offer": 1}), "the seven-day reset passing closes it: %r" % d)
+            self.assertNotIn("capOffer", self._cards(f)[WEB + ":g1"]["blocked"])
+
     def test_the_offer_is_keyed_only_for_the_session_that_read_usage(self):
         self._cap_death(WEB, max(NOW, int(time.time())) + 600)
         with mock.patch.object(km, "_auth_key_present", lambda: True), \
@@ -555,7 +598,8 @@ class TheClockDecidedBooleansAreComponents(_Board):
             k_web = km._feed_memo_get(WEB)[0]
             k_api = km._feed_memo_get(API)[0]
             at = km._FEED_MEMO_LABELS.index("offer")
-            self.assertIs(k_web[at], True, "web read usage.json: its key carries the window's state")
+            self.assertEqual(k_web[at], ("five_hour", max(NOW, int(time.time())) + 600),
+                             "web read usage.json: its key carries the open window and its reset")
             self.assertIsNone(k_api[at], "api did not: the crossing is no input of its card")
 
 

--- a/tests/test_feed_session_started.py
+++ b/tests/test_feed_session_started.py
@@ -390,7 +390,7 @@ class AwaitingPanel(unittest.TestCase):
         self.assertFalse(km._bg_is_agent("local_bash"))
         # the feed's cards are goal nodes only: the card loop reads children[None], nothing else
         import inspect
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn("for nid in children.get(None, [])", src)
         self.assertNotIn("local_workflow", src.split("for nid in children.get(None, [])")[0].split("healed = _heal_session_tops")[0][-4000:],
                          "no card is built from a workflow row")

--- a/tests/test_handoff_card_title.py
+++ b/tests/test_handoff_card_title.py
@@ -139,13 +139,13 @@ class BuildFeedWiring(_Base):
     never was the problem there)."""
 
     def test_the_item_ships_the_derived_title_and_badge(self):
-        src = getsource(km.build_feed)
+        src = getsource(km._feed_session_entry)
         self.assertIn("handoff_to, card_text = _handoff_card_fields(nodes, nid)", src)
         self.assertIn('"text": card_text', src)
         self.assertIn('**({"handoffTo": handoff_to} if handoff_to else {})', src)
 
     def test_nested_tree_rows_keep_their_raw_text(self):
-        src = getsource(km.build_feed)
+        src = getsource(km._feed_session_entry)
         self.assertIn('"kind": "handoff" if _ho_sid else "ask", "text": nd["text"]', src,
                       "flatten's rows are untouched — nested handoff rows render as before")
 

--- a/tests/test_interrupt_marks_memo.py
+++ b/tests/test_interrupt_marks_memo.py
@@ -326,6 +326,8 @@ class MemoAcrossTheCycle(_MemoHarness):
                          [(SID, "display"), (SID, "judge")], "one entry per family after a cycle")
         s0 = self._stats()
         km._interrupt_block_tick(NOW, self.live)
+        km._feed_memo.clear()      # T368: the feed's per-session card memo would serve the unchanged session without running
+        #                            the body; this test is about the MARKS memo the body consults, so make the body run
         km.build_feed(NOW, self.live)
         s1 = self._stats()
         self.assertEqual(s1["miss"], s0["miss"], "the second cycle recomputes nothing")

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -601,14 +601,14 @@ class KernelWiringAndFloorPins(unittest.TestCase):
 
     def test_build_feed_floors_a_latched_session_yielding_to_the_live_floors(self):
         import inspect
-        src = inspect.getsource(self.km.build_feed)
+        src = inspect.getsource(self.km.build_feed) + inspect.getsource(self.km._feed_session_entry)   # T368: the loop body
         self.assertIn("_jauth_map = jd._auth_down_map()", src)
         self.assertIn("jerr and api_top is None and perm_top is None", src)
         self.assertIn('column = ("needs_input" if (api_block or nid == jauth_top or nid == perm_top', src)
 
     def test_the_floored_card_carries_the_judgeAuth_story(self):
         import inspect
-        src = inspect.getsource(self.km.build_feed)
+        src = inspect.getsource(self.km._feed_session_entry)   # T368: build_feed's per-session loop body
         self.assertIn('"state": "judgeAuth"', src)
         # the key-mode copy points at the one key path left (2026-09-08); the login copy is unchanged
         self.assertIn("the API key its judges bill is being refused. Fix the key behind Claude Code's apiKeyHelper "

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1440,16 +1440,19 @@ class ViewBuilder(unittest.TestCase):
             "nodes": {top: gn(top, "research the API", None, why="user asked for the research")},
             "placements": {}, "status": {top: "working"}}))
         saved = km._session_awaiting
+        def _feed():
+            km._feed_memo.clear()          # T368: a patched helper is no input the per-session memo can see; make the body run
+            return km.build_feed(NOW)
         try:
             for n in (1, 3):
                 km._session_awaiting = lambda sid, path, idle, stamp=False, n=n: {
                     "kind": "agents", "why": "%d background agent%s still working" % (n, "" if n == 1 else "s"),
                     "since": T0, "count": n}
-                card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+                card = next(a for a in _feed()["asks"] if a["itemId"] == top)
                 self.assertEqual(card["awaiting"]["kind"], "agents")
                 self.assertEqual(card["awaiting"]["count"], n, "the card's count is the snapshot's own")
             km._session_awaiting = lambda sid, path, idle, stamp=False: {"kind": None, "why": "waiting on dispatched work", "since": None}
-            card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == top)
+            card = next(a for a in _feed()["asks"] if a["itemId"] == top)
             self.assertIsNone(card["awaiting"]["count"], "a source that cannot count ships None, never a guess")
         finally:
             km._session_awaiting = saved
@@ -4856,25 +4859,28 @@ class ViewBuilder(unittest.TestCase):
         # stranding properties to pin are: the echo alone arms nothing, and the watermark always releases.
         g = self._blocked_store()
         saved_p, saved_w = km._last_plain_user_turn_t, km._session_working
+        def _feed():
+            km._feed_memo.clear()          # T368: a patched helper is no input the per-session memo can see; make the body run
+            return km.build_feed(NOW)
         try:
             # NO plain reply since the block in the parse (the slash-command case: its expanded transcript
             # form never text-matches the typed echo, so nothing reads as a reply). Nothing arms the flip,
             # working or idle.
             km._last_plain_user_turn_t = lambda turns: NOW - 300
             km._session_working = lambda turns: False
-            card = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            card = next(a for a in _feed()["asks"] if a["itemId"] == g)
             self.assertFalse(card["rejudging"], "a stranded echo can never arm rejudging — only a parsed reply can")
             self.assertEqual(card["column"], "needs_input",
                              "so the blocked card stays in Needs-You where the nudge sees it — never stuck in Working")
             # a REAL parsed reply after the block arms the latch even while idle (pending the judge)…
             km._last_plain_user_turn_t = lambda turns: NOW - 10
-            card2 = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            card2 = next(a for a in _feed()["asks"] if a["itemId"] == g)
             self.assertTrue(card2["rejudging"], "a parsed plain reply arms the latch — idle or not, it's the judge's move")
             self.assertEqual(card2["column"], "working")
             # …and the unblocker's watermark ALWAYS releases it — advanced on every examine and on the
             # parse give-up path, so the 2026-07-22 stuck-in-Working failure has no revival route.
             g = self._blocked_store(blockCheckT=NOW - 5)
-            card3 = next(a for a in km.build_feed(NOW)["asks"] if a["itemId"] == g)
+            card3 = next(a for a in _feed()["asks"] if a["itemId"] == g)
             self.assertFalse(card3["rejudging"], "the watermark passed the reply → released")
             self.assertEqual(card3["column"], "needs_input")
         finally:

--- a/tests/test_kernel_agent_open_authority.py
+++ b/tests/test_kernel_agent_open_authority.py
@@ -67,7 +67,7 @@ class DoneComputationHonorsAuthority(unittest.TestCase):
     """Source-pins: both projections gate their done-derivation on the authoritative-open set (this repo
     tests build_feed/build_session by inspecting their source, since they read the fleet off disk)."""
     def test_build_feed_flatten_excludes_agent_open_from_done(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn("agent_open = _agent_open_set(nodes, children)", src)
         self.assertIn("and nid not in agent_open", src, "flatten's done must exclude the authoritative-open subtree")
 

--- a/tests/test_kernel_apierror_working.py
+++ b/tests/test_kernel_apierror_working.py
@@ -29,7 +29,7 @@ class ApiErrorWorking(unittest.TestCase):
         self.assertIn('"tooLong": "too long" in text.lower()', src)
 
     def test_only_on_you_errors_floor_the_card_to_needs_input(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         # api_block fires for an ON-YOU api_top — "prompt too long" (compact), a monthly spend cap (raise
         # it, the user 2026-07-14), a spent model allowance, a dead credential (per-session auth, the
         # user 2026-08-08), or a safeguards refusal (the user 2026-08-15); a transient error does NOT
@@ -44,7 +44,7 @@ class ApiErrorWorking(unittest.TestCase):
         # a monthly spend cap is on you (raise it) AND never auto-retried: classified in _api_error_pass,
         # floored to needs-input, and badged with the raise-your-cap guidance (the user 2026-07-14).
         self.assertIn('"spendLimit": _is_spend_limit(text)', inspect.getsource(km._api_error_pass))
-        bf = inspect.getsource(km.build_feed)
+        bf = inspect.getsource(km._feed_session_entry)
         self.assertIn('"spendLimit": bool(aerr.get("spendLimit"))', bf)
         self.assertIn("monthly spend limit — raise it at claude.ai/settings/usage", bf)
         self.assertIn('"apiSpendLimit": bool(aerr and aerr.get("spendLimit"))', inspect.getsource(km.build_session))
@@ -54,7 +54,7 @@ class ApiErrorWorking(unittest.TestCase):
         self.assertIn('"apiTooLong": bool(aerr and aerr.get("tooLong"))', src)
 
     def test_the_card_blocked_badge_distinguishes_tooLong(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('"tooLong": bool(aerr.get("tooLong"))', src)
         self.assertIn("prompt is too long — compact it to continue", src)
 

--- a/tests/test_kernel_blocked_no_goal.py
+++ b/tests/test_kernel_blocked_no_goal.py
@@ -49,7 +49,7 @@ class BlockedNoGoal(unittest.TestCase):
         self.assertEqual(c["blocked"]["what"], "this session is stopped awaiting your approval")
 
     def test_build_feed_synthesizes_it_only_when_blocked_with_no_floorable_goal(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         # the synthesis is gated: no working card AND no top goal to floor under BLOCKED (perm_top None) ...
         self.assertIn("if not had_working and perm_top is None and ps:", src)
         # ... and only as the fallback when there's no provisional card and a live perm/picker state

--- a/tests/test_kernel_deferral_sweep.py
+++ b/tests/test_kernel_deferral_sweep.py
@@ -181,14 +181,14 @@ class HardRuleAndRoutingPins(unittest.TestCase):
     """build_feed's presentation, pinned by source (the build_feed test pattern)."""
 
     def test_stalled_plus_idle_files_under_blocked(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         # the user's hard rule (2026-08-13), superseding the 2026-07-23 Working-only stance
         self.assertIn('_stall_block = bool(_stall_rec and not who_working and not sess_awaiting_why)', src)
         self.assertIn('or nid == perm_top or _stall_block', src)
         self.assertIn('"blocked": _stall_block}', src)
 
     def test_in_flight_holds_route_to_the_swirl(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('_stall_rec.get("why") in jd.WHY_IN_FLIGHT', src)
         self.assertIn('bool((sess_judging or _stall_inflight) and column == "working")', src)
 

--- a/tests/test_kernel_distill_state.py
+++ b/tests/test_kernel_distill_state.py
@@ -25,7 +25,7 @@ km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
 
 class DistillState(unittest.TestCase):
     def test_distill_state_is_computed_from_the_genuine_block_not_the_column(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         # "completed" mirrors col; "blocked" fires for the SAME hard blocks that make the card genuinely
         # needs-you (api_block / the judge-auth floor / a live perm_top / a soft col=="blocked") — but
         # WITHOUT the recheck/rejudging suppression that `column` carries, so the brief survives the
@@ -36,7 +36,7 @@ class DistillState(unittest.TestCase):
         self.assertIn("else None)", src)
 
     def test_distill_state_drops_the_recheck_rejudging_suppression_that_column_keeps(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         # column suppresses needs_input during recheck/rejudging; distill_state must NOT — that suppression is
         # exactly what blanked the brief. Guard: the column line carries the suppression, the distill_state
         # line does not mention recheck/rejudging at all.
@@ -47,7 +47,7 @@ class DistillState(unittest.TestCase):
         self.assertNotIn("rejudging", ds)
 
     def test_the_ask_payload_carries_distillState(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('"distillState": distill_state,', src)
 
 

--- a/tests/test_kernel_done_confirming.py
+++ b/tests/test_kernel_done_confirming.py
@@ -25,7 +25,7 @@ km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
 
 class DoneConfirming(unittest.TestCase):
     def test_the_flag_reads_the_rollup_export_not_the_raw_node_flag(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('confirming = set(store.get("confirming") or ())', src,
                       "the store's rollup export is the one source")
         self.assertIn('"doneConfirming": (True if (column == "working" and nid in confirming) else None),', src,
@@ -34,7 +34,7 @@ class DoneConfirming(unittest.TestCase):
     def test_the_column_is_untouched_by_the_window(self):
         # "I definitely don't want a working done flicker" (the user 2026-07-24): the window annotates the
         # card; the column expression must not consult it.
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         start = src.index('column = ("needs_input"')
         col = src[start: src.index('else "completed" if col == "completed" else "working")', start)]
         self.assertNotIn("confirming", col, "the column expression never reads the confirming window")

--- a/tests/test_kernel_feed_warm.py
+++ b/tests/test_kernel_feed_warm.py
@@ -25,7 +25,8 @@ km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
 
 class FeedCacheOnly(unittest.TestCase):
     def test_build_feed_reads_the_parse_cache_only_never_a_cold_parse(self):
-        src = inspect.getsource(km.build_feed)
+        src = (inspect.getsource(km.build_feed) + inspect.getsource(km._feed_session_key)
+               + inspect.getsource(km._feed_session_entry))   # T368: the loop body and its key builder
         self.assertIn("ps = _parse_cached(s[\"path\"])", src, "the working-dot reads the CACHED parse, no cold parse")
         self.assertIn("cold_parse = True", src)
         self.assertIn("_warm_fleet_bg(now)", src, "an unparsed living session kicks the background warmer")

--- a/tests/test_kernel_goal_cache_wiring.py
+++ b/tests/test_kernel_goal_cache_wiring.py
@@ -64,7 +64,8 @@ def _tm():
 WIRED = {"_open_top_goal": 1, "_deferral_sweep_tick": 1, "_session_stamp_read": 1, "_owned_yield_why": 1,
          "_msg_sum_scan_session": 1,
          "_bg_placed_tops": 1}   # the placed-launch memo: the shared view, or the store the caller hands in
-WIRED_BOUNDARY = {"build_feed": 1, "build_session": 2, "build_timeline": 1}
+WIRED_BOUNDARY = {"_feed_session_entry": 1, "_feed_peer_facts": 1, "build_session": 2, "build_timeline": 1}   # T368: the feed's
+#   per-session body reads the origin sender's store through the boundary; its memo key's peer facts probe the same boundary
 # TWO-PHASE: the awaiting-lift job takes one shared PROBE (through the boundary: a fault forgets the gate so
 # the next tick retries) and one writer load only when the probe found a lift due (jd.load_goals_or_fault,
 # the same boundary around the writer's loader); the decision body (_lift_decisions) loads nothing and

--- a/tests/test_kernel_interrupt.py
+++ b/tests/test_kernel_interrupt.py
@@ -234,7 +234,7 @@ class FeedCardInterruptingBadge(unittest.TestCase):
 
     def test_build_feed_computes_and_gates_the_interrupting_badge(self):
         import inspect
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_key) + inspect.getsource(km._feed_session_entry)   # T368: the key computes it, the body wears it
         self.assertIn("sess_interrupting = _interrupting(fsid, ps or {}, now, tm)", src,
                       "the card reuses the chip's derivation — safe to call again in this push")
         self.assertIn('"interrupting": bool(sess_interrupting', src, "the card carries the in-flight flag")

--- a/tests/test_kernel_judging_active.py
+++ b/tests/test_kernel_judging_active.py
@@ -52,25 +52,30 @@ class BuildFeedWiring(unittest.TestCase):
         self.assertIn('_jactive = {r.get("fsid") for r in jd.active_runs()}', src)
 
     def test_either_prong_lights_the_swirl_and_the_active_prong_needs_no_warm_parse(self):
-        src = inspect.getsource(km.build_feed)
+        # T368: the loop body is _feed_session_entry; the settle-gap prong is computed once per build by the
+        # memo key (_feed_session_key, the `closer` component) and the body reads it from ctx
+        src = inspect.getsource(km._feed_session_entry)
         # the active prong stands alone — no `live`, no `ps`: a fresh kernel's caches are cold at
         # exactly the moment a backlog drain runs, and the registry is an in-process fact
         self.assertIn("sess_judging = bool(not who_working", src)
         self.assertIn("and (fsid in _jactive", src)
         # the settle-gap prong keeps its cache-warm gates — it needs the parse
-        self.assertIn('or (live and ps and _closer_pending(fsid, s["path"], now, store))', src)
+        key = inspect.getsource(km._feed_session_key)
+        self.assertIn("closer = bool(live and ps and not who_working and not jactive", key)
+        self.assertIn("and _closer_pending(fsid, path, now, st", key)
 
     def test_an_open_turn_still_reads_working_not_analyzing(self):
         # who_working guards BOTH prongs: a session actively mid-turn is Working — a captioner call
         # running beside an open turn must not re-dress the card as Analyzing…
-        src = inspect.getsource(km.build_feed)
-        self.assertIn("bool(not who_working\n", src)
+        src = inspect.getsource(km._feed_session_entry)   # T368: the loop body; the settle prong sits in the key
+        self.assertIn('sess_judging = bool(not who_working and (fsid in _jactive or ctx["closer"]))', src)
+        self.assertIn("closer = bool(live and ps and not who_working and not jactive", inspect.getsource(km._feed_session_key))
 
     def test_the_card_key_is_unchanged(self):
         # feed.ts + spin-caption.ts key on `judging` as before — the kernel broadened WHEN it is
         # true (active calls 2026-08-12; in-flight-class stall holds 2026-08-13), not the contract
         self.assertIn('"judging": bool((sess_judging or _stall_inflight) and column == "working")',
-                      inspect.getsource(km.build_feed))
+                      inspect.getsource(km._feed_session_entry))   # T368: build_feed's per-session loop body
 
 
 if __name__ == "__main__":

--- a/tests/test_kernel_model_limit.py
+++ b/tests/test_kernel_model_limit.py
@@ -134,14 +134,14 @@ class SurfacesPinTheOnYouTreatment(unittest.TestCase):
     card moves while the tab still says romp is handling it."""
 
     def test_the_card_floors_to_needs_you(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('or aerr.get("modelLimit")', src,
                       "api_block must include the model limit — otherwise the card sits in Working "
                       "with the nudge suppressed and nothing able to move it")
         self.assertIn('or aerr.get("authErr") or aerr.get("refusal"))))', src)
 
     def test_the_card_names_the_real_remedy(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('"modelLimit": bool(aerr.get("modelLimit"))', src)
         self.assertIn("switch its model or add credits to continue", src)
         self.assertIn("this session stopped on an API error — Retry to resume", src,

--- a/tests/test_kernel_refusal_retry.py
+++ b/tests/test_kernel_refusal_retry.py
@@ -298,13 +298,13 @@ class SurfacesPinTheOnYouTreatment(unittest.TestCase):
                       "client ask share this one decision")
 
     def test_the_card_floors_to_needs_you(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('or aerr.get("authErr") or aerr.get("refusal"))))', src,
                       "api_block must include the refusal — otherwise the card sits in Working "
                       "with the nudge suppressed and nothing able to move it")
 
     def test_the_card_names_the_real_remedy(self):
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('"refusal": bool(aerr.get("refusal"))', src)
         self.assertIn("the model's safeguards refused this prompt — rewrite it or drop this thread",
                       src)

--- a/tests/test_kernel_retrying_chip.py
+++ b/tests/test_kernel_retrying_chip.py
@@ -112,7 +112,7 @@ class FeedCardRetryingChip(unittest.TestCase):
 
     def test_build_feed_computes_and_gates_the_retrying_chip(self):
         import inspect
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn("sess_retrying = _session_retrying(fsid, tm)", src,
                       "the signal comes from the live backend row — the same one the chat chip reads")
         self.assertIn('"retrying": (sess_retrying if column == "working" else None)', src,

--- a/tests/test_kernel_working_narration.py
+++ b/tests/test_kernel_working_narration.py
@@ -51,7 +51,7 @@ class OpenTurnProgress(unittest.TestCase):
 class PayloadPins(unittest.TestCase):
     def test_working_cards_carry_the_narration(self):
         import inspect
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('sess_progress = _open_turn_progress(ps["turns"]) if (ps and who_working) else None', src)
         self.assertIn('"working": (sess_progress if column == "working" else None)', src)
 
@@ -61,7 +61,7 @@ class PayloadPins(unittest.TestCase):
         # read: a cold cache or a machine reporting nothing) — and every working card carries it, so
         # the feed's spin floor can speak even when the narration payload cannot ride.
         import inspect
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('sess_state = "open" if who_working else ("quiet" if ps else "unknown")', src)
         self.assertIn('"sessState": (sess_state if column == "working" else None)', src)
 

--- a/tests/test_ledger_anchors.py
+++ b/tests/test_ledger_anchors.py
@@ -117,7 +117,8 @@ class SharedHelperAntiDrift(unittest.TestCase):
             self.assertIsNotNone(m, "found %s" % fn)
             return m.group(0)
         self.assertIn("_node_anchor_uuids(", body("build_session"), "the ledger resolves anchors via the helper")
-        self.assertIn("_node_anchor_uuids(", body("build_feed"), "the feed resolves anchors via the helper")
+        self.assertIn("_node_anchor_uuids(", body("_feed_session_entry"),   # T368: build_feed's per-session loop body
+                      "the feed resolves anchors via the helper")
 
 
 class GlowByIdRouting(unittest.TestCase):
@@ -243,7 +244,7 @@ class SegJump(unittest.TestCase):
     def test_the_deep_link_maps_use_the_landable_anchor(self):
         # both zone maps (ledger seg_work + feed seg_uuid) resolve through _seg_jump, not bare `r or w`
         import inspect
-        src = inspect.getsource(km.build_session) + inspect.getsource(km.build_feed)
+        src = inspect.getsource(km.build_session) + inspect.getsource(km._feed_session_entry)   # T368: the feed's loop body
         self.assertEqual(src.count('_seg_jump(seg["atoms"])'), 2)
         self.assertNotIn("= r or w", src)
 

--- a/tests/test_nudge_hold_judge_rows.py
+++ b/tests/test_nudge_hold_judge_rows.py
@@ -131,7 +131,7 @@ class TheExemptionSetIsWhatTheCodeUses(unittest.TestCase):
         self.assertNotIn(jd.WHY_TURN_IN_FLIGHT,
                          [w for w in (jd.WHY_JUDGING,) if False] or [],)  # tuple membership is the one definition
         import inspect
-        src = inspect.getsource(km.build_feed)
+        src = inspect.getsource(km._feed_session_entry)
         self.assertIn('_stall_rec.get("why") in jd.WHY_IN_FLIGHT', src,
                       "the feed routes in-flight-class holds to the judging swirl")
 

--- a/tests/test_parked_cue.py
+++ b/tests/test_parked_cue.py
@@ -140,7 +140,7 @@ class RetireGrid(unittest.TestCase):
 
 class BuildFeedWiring(unittest.TestCase):
     def test_the_row_field_ships_gated_on_the_open_render_state(self):
-        src = getsource(km.build_feed)
+        src = getsource(km._feed_session_entry)
         self.assertIn("parked_rows = _parked_rows(nodes, children)", src)
         self.assertIn('"parked": ({"n": parked_rows[nid]} if (st == "open" and nid in parked_rows)'
                       " else None)", src)

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -176,6 +176,26 @@ class Collector(unittest.TestCase):
         self.assertGreaterEqual(snap["uptime_s"], 0)
         json.dumps(snap)                                     # the whole thing serializes as-is
 
+    def test_the_feed_build_block_carries_the_per_session_card_memo(self):
+        """builds.feed gained `memo` (T368): the feed's per-session card memo beside the build counters, its hits and
+        misses per session per build, the misses attributed to the key component that moved (plus `cold`), the
+        evictions, and the resident set against its bound (a fraction of the machine's memory, or ROMP_FEED_MEMO_BYTES).
+        The map is the memo's own report, copied per read; tests/test_feed_session_memo.py drives the values."""
+        snap = self.st.snapshot()
+        self.assertEqual(set(snap["builds"]["feed"]), {"cached", "built", "ms", "memo"})
+        memo = snap["builds"]["feed"]["memo"]
+        self.assertEqual(set(memo), {"hit", "miss", "evict", "entries", "bytes", "bound", "derived", "miss_by"})
+        self.assertEqual(set(memo["miss_by"]), set(km._FEED_MEMO_LABELS) | {"cold"})
+        self.assertEqual(memo["bound"], km.FEED_MEMO_BYTES)
+        self.assertEqual(memo, km._feed_memo_report())
+        for k, v in memo.items():
+            self.assertIsInstance(v, (int, dict), k)
+        for k, v in memo["miss_by"].items():
+            self.assertIsInstance(v, int, k)
+        self.assertIsNot(memo, km._FEED_MEMO_STATS, "a copy per read, never the live counters")
+        for kind in ("chat", "timeline", "feedJson", "thread"):
+            self.assertEqual(set(snap["builds"][kind]) & {"memo"}, set(), "%s: only the feed carries the memo" % kind)
+
     def test_pusher_counters(self):
         self.st.wake(); self.st.wake(); self.st.wake()
         self.st.wake_kind(True); self.st.wake_kind(False); self.st.wake_kind(False)

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -875,7 +875,7 @@ class AuthErrorClass(unittest.TestCase):
         # _api_last_failed read through, so the pin reads that function
         self.assertIn('"authErr": _is_auth_error(text)', inspect.getsource(km._api_error_pass))
         self.assertIn('"apiAuthErr": bool(aerr and aerr.get("authErr"))', inspect.getsource(km.build_session))
-        feed = inspect.getsource(km.build_feed)
+        feed = inspect.getsource(km._feed_session_entry)
         self.assertIn('aerr.get("authErr") or aerr.get("refusal"))))', feed, "the card floors to needs-you")
         self.assertIn("sign-in or API key isn't working", feed, "the card names the real remedy")
 

--- a/tests/test_tracked_delegation.py
+++ b/tests/test_tracked_delegation.py
@@ -230,7 +230,7 @@ class FeedPayloadPins(unittest.TestCase):
         # review 2026-08-24: a needs-you block always surfaces, and a closed/cleared primary
         # un-hides the copy — a pair divergence self-heals to a visible card, never work in secret
         self.assertIn('**({"satellite": True} if isinstance(o, dict) and o.get("tracked")\n'
-                      '                   and origin and origin.get("live") and column != "needs_input" else {}),', KSRC)
+                      '               and origin and origin.get("live") and column != "needs_input" else {}),', KSRC)   # T368: the body's indent
 
     def test_completed_and_cleared_handoffs_drop_off_the_primary(self):
         self.assertIn('and not nodes[x].get("nodeComplete") and not nodes[x].get("cleared")]', KSRC)

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -45,7 +45,9 @@ test("the chat tab dot matches the chip: await-green for awaitingBg, yellow for 
 test("the feed dot matches too: dotFor picks work/await per name, the dot retints in place", () => {
   // the kernel's feed payload carries the awaiting name list beside working; federation merges + prefixes it
   assert.match(KERNEL, /"working": working, "awaiting": awaiting,/);
-  assert.match(KERNEL, /if sess_awaiting_why and not who_working:\s*\n\s*awaiting\.append\(name\)/);
+  // (T368: the per-session body records the dot name on its memoized entry; the fold appends it per build)
+  assert.match(KERNEL, /if sess_awaiting_why and not who_working:\s*\n\s*ent_awaiting = name/);
+  assert.match(KERNEL, /if entry\.get\("awaiting"\):\s*\n\s*awaiting\.append\(entry\["awaiting"\]\)/);
   assert.match(KERNEL, /\{"type": "working", "names": feed\["working"\],\s*\n\s*"awaiting": feed\.get\("awaiting"\) or \[\]\}/);
   assert.match(FEED, /awaitingSet = new Set\(Array\.isArray\(m\.awaiting\) \? m\.awaiting : \[\]\);/);
   // dotFor still ranks work over await; the unreadable-state quarter follows (feed-status-pips.test.ts)

--- a/ui/webview/feed-cap-offer.test.ts
+++ b/ui/webview/feed-cap-offer.test.ts
@@ -38,7 +38,7 @@ test("only the explicit pick switches — the gesture census, both surfaces", ()
 
 test("the offer retires with the window and rides beside the auto-retry, never instead", () => {
   assert.match(KERNEL, /\(w\.get\("resets_at"\) or 0\) > now/, "resets_at passing ends the mint — the deciding event");
-  assert.match(KERNEL, /_cap_off = _cap_switch_offer\(fsid, aerr\) if aerr else None/);
+  assert.match(KERNEL, /_cap_off = _cap_switch_offer\(fsid, aerr, now\) if aerr else None/);   // the build's clock (T368: the memo key reads the same window)
   assert.match(KERNEL, /\*\*\(\{"capOffer": _cap_off\} if _cap_off else \{\}\),/, "sparse — absent payloads are byte-identical");
   // the auto-retry contract is untouched: the retry button (a manual retry, as the chat pane sends) + auto ladder stay
   assert.match(FEED, /vscodeApi\?\.postMessage\(\{ type: "apiRetry", id: it\.sid, manual: true \}\);/);


### PR DESCRIPTION
T368: the feed build re-derives only the sessions whose inputs moved. Tier `fix` (red-first: the walked-sessions pin fails before it).

## The cost

Every feed rebuild walked all sessions' goal trees and per-session derivations (the 989-line body under `for s in alive` in `build_feed`): romp_perf measured 164 rebuilds at 899 ms over 25 minutes on the devbox (150 s, 10 percent of the pusher's wall time, second after the timeline), a cost that scaled with sessions times goals rather than with what changed. The pusher already keeps the whole payload while nothing on the board moves; this memo keeps each session's contribution while that session's inputs stand.

## Design points

- **Per-session entries, keyed on the inputs each one reads.** The loop body is `_feed_session_entry`, returning one session's contribution (its cards, its working and awaiting membership, its background services, its serving folds, its heal counts, the peers it read). The key (`_feed_session_key`) is a labelled tuple, one component per input the body reads: the transcript, the states logs, the names row, the goal store's identity (the store file, the override journal and the archive entry, plus the pre-pass snapshot's identity and the user-write marks, plus the rewind hold), the registration and death marker, the session's slice of the cleared ledger, the live row, the live tail's revision, the background rows' deadline crossings, its wait edge, the postal log, its stalled and nudged slices, the judge-auth and judge-active slices, the hide flag, its watches, the subagents directory, the debug mode, and the two clock crossings the body reads as the booleans they produce. The docstring lists them and `tests/test_feed_memo_inputs.py` pins that every helper the body calls is covered.
- **Event-based, no clock.** The clock never enters the key. The age tint each card wears is recomputed by the fold every build from the card's stored base time, so a served card fades exactly as a rebuilt one did; a placeholder whose time was the clock is re-stamped on the fold.
- **A hit never serves a moved card.** A judge verdict writes the store (its identity moves); a user gesture writes the override journal or the cleared ledger (both in the key); a peer's verdict or rename reaches the card through the peers component, re-evaluated from the peers the previous derivation recorded, the chat signature's dependency idiom. The one read in the derivation's closure that consults its own clock, the billing-switch offer (a usage window at its cap with its reset ahead), enters the key as the payload the card renders (the open window and its reset), so a reset passing re-derives the card: the offer leaves it, or moves to the other window still capped. The parse enters as its warm bit plus the last turn's end, the one value in a parse that is not a function of its files (the trailing idle span's end is read from the clock), so a parse re-run at a later clock re-derives once. The postal log enters as the session's own rows (the pairs it is a party to, by value), so a row between two other sessions moves no key of this one.
- **Cross-session work recomposes.** The entries fold in `alive` order; the serving-fold recomposition, the parked handoffs, the notify pass and the payload's board-wide fields run after the fold on fresh dicts (entries are stored as JSON strings and decoded per build), so nothing memoized is ever mutated across builds.
- **Bounded in bytes as a fraction of memory.** `FEED_MEMO_BYTES` is a sixty-fourth of MemTotal (the spend guard's tree memo idiom), `ROMP_FEED_MEMO_BYTES` overrides it; least recently used entries leave first, one at a time, never a clear at the cap; a departed session's entry leaves with it.
- **Counted.** `/perf builds.feed.memo` reports hits, misses (attributed per moved component), evictions, entries, bytes, the bound and the sessions derived per build.

## Measurement

Read-only, before and after, the same world each time.

**Bench (tools/perf-bench.py, five iterations, `--sessions 0`, against a credential-free copy of the devbox state directory: 29 live sessions, 29 live transcripts).** The build_feed row is the steady state (every parse cached), the world the pusher lives in.

| row | before (base c917ed26) | first head (7c20e00b) | round one (efbdc8f4) | this head |
| --- | --- | --- | --- |
| build_feed, median of 5 (every parse cached: the steady state) | 562.8 ms (min 557.0, max 565.7) | 89.0 ms (min 88.3, max 209.6) | 49.7 ms (min 48.0, max 188.8) | 45.6 ms (min 44.3, max 181.2) |
| build_feed_noparse (parse cache empty: the cards-first boot shape) | 55.9 ms | 83.6 ms | 45.3 ms | 41.4 ms |
| build_timeline_bars (control, untouched) | 371.6 ms | 363.7 ms | 380.2 ms | 364.5 ms |

The steady rebuild costs 91 percent less. The review's profile of the first head put the memo's fixed per-build cost in the key, not the decode (29 sessions: key 77 ms, decode 1.5 ms, fold 1.2 ms): an os.walk of every session's subagents tree on every build, and a filter over the whole cleared set per session. The walk is now memoized on the directories' own identities (a directory added or removed moves its parent's mtime, and every parent is a known directory), the cleared set and the postal maps are indexed once per build, and the board-wide identities are taken once per build; the cold-parse row, 41 percent slower on the first head, is now 19 percent faster than the base.

**Live (/perf builds.feed and stages_ms.push.feed).** romp_perf's 25-minute sample on the devbox before this change: 164 feed builds at 899 ms average, 150 s in push.feed, 10 percent of the pusher's wall time. My own same-kernel windows today were cut three times by redeploys (the kernel restarts on every merge) and the fourth window had no dashboard connected (0 builds in 23 minutes on that kernel), so the live after-figure is to be read from /perf builds.feed.memo once this deploys with a client attached: `hit` against `derived` per build, and `miss_by` naming the components that move in practice.

## Tests

Red first. `tests/test_feed_session_memo.py::TheRebuildWalksOnlyWhatMoved` counts the per-session tree walks (`_heal_session_tops` runs once per session per derivation) over a cold build, an unchanged rebuild and a rebuild after one store moved: on the base commit the unchanged rebuild walks all three sessions (`AssertionError: 3 != 0`, run against c917ed26); with the memo it walks none, and the moved store walks that session alone.

- `tests/test_feed_session_memo.py` (19 tests, a hermetic three-session board over the real build_feed): cold derives three and an unchanged rebuild none, byte for byte the same payload; a judge verdict, a user gesture in the override journal, a clear, a live-row change, a transcript append, a states append, a names rewrite and the hide flag each re-derive their session alone under the named component; a peer's verdict re-derives the session whose card reads that peer's store (the peers dependency: a peer first read leaves the key unsettled, the next build settles it once, then hits); two builds ten minutes apart derive nothing and differ only in the clock fields and the tints; the byte bound sheds oldest first and the payload stays whole; a departed session's entry leaves; /perf carries the memo. Review round one: the billing-switch offer leaves a served card when its reset passes (the `offer` component, red on the first head: the entry hit and the card kept offering), the offer is keyed only for the session that read usage.json, and a postal row between two other sessions leaves a session's key where it was (red on the first head: every row re-derived the board). Round two: with both usage windows capped, the earlier reset passing moves the offer to the later window and its reset (red on the round-one head, where the component was a boolean: the entry hit and the card kept the passed reset); the per-build clear index hands every id shape exactly what the per-session filter did; the key's subagent-walk memo leaves with a departed session.
- `tests/test_feed_memo_inputs.py` (12 tests): a census of every callee `_feed_session_entry` calls, derived by AST (every call shape: a bare helper, a module attribute chain, a class method, `open`; builtins and the body's own locals skipped), each mapped to the key component that covers it; an unlisted callee fails by name; the labels equal the key docstring's component list in order, the key returns one value per label, `miss_by` is the labels plus `cold`.
- `tests/test_perf_stats.py`: `builds.feed` carries `memo` with the documented keys; only the feed block does.
- Repointed, text unchanged: 21 source pins that read the loop body through `getsource(km.build_feed)` now read `km._feed_session_entry` (and the key builder where the line moved there); `tests/test_kernel_goal_cache_wiring.py`'s boundary count names the two functions that read the shared view; three tests that monkeypatch a pure helper between two builds of an unchanged world clear the memo between them (a patched helper is no input a key can see).

## Verification

All on the branch worktree, every suite under the load cap (`capped`, the pool of four slots, no xdist, one process): the full pytest, 12,626 passed, 56 skipped, 1,871 subtests passed, 14 minutes 16 seconds, plus the six modules whose pins the run surfaced re-run green after their repoint (60 passed); the 35 bats files, 580 passed; the feed builders' modules and every repointed module together, 725 passed; `tests/test_kernel.py`, 460 passed with 12 subtests. Red first on the base commit c917ed26: `TheRebuildWalksOnlyWhatMoved` fails with `3 != 0` (the unchanged rebuild walks every session), and the two new modules cannot import the memo. The bench above was read from `tools/perf-bench.py` against a state copy, the live kernel untouched; a second after-run gave build_feed 85.8 ms median (min 84.5, max 133.4).
