### PR TITLE
The reload restore lands its saved row in the same pass (T374)

### DIFF
--- a/tests/test_reload_restore_midrun_browser.py
+++ b/tests/test_reload_restore_midrun_browser.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""T374 (the verifier of T366, 2026-09-12, executed on both heads): after a page reload, a reader whose saved row sat
+MID-run (the restored raw top not in the top band) never asked a window: landActive armed the pending anchor and the keep
+offset AFTER its own landing attempt, so the deep-link land waited for a later render pass that an idle session never
+supplied (no loadAround, no loadOlder, no needFull; the reader parked at a raw pixel offset instead of their row). The
+restore now lands its row in the same pass: resident → landed; outside the fresh window → its window asked at once and
+chatWindow lands it on arrival.
+
+Two served roads (the verifier's): two older fetches, a settle MID-run, a persist through the shell's hook, a reload, and
+the saved row is back on screen through one window ask; and the same walk to the transcript HEAD, whose reload lands the
+saved row at offset 0 with the plain strip (the T366 round-two low: a restore is no click). Both red on main before this
+fix: after the reload the page sent nothing but the restore's own write. Shares its boot with
+test_live_paused_window_browser.py (a synthetic transcript longer than the wire tail). Skips LOUDLY without the extension
+deps or a Playwright browser; all fixtures synthetic.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment (the module, not its classes)
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TURNS = 320   # 640 events: past the wire tail, so older history stays on the server and the page's run is a tail
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+DRIVER_HEAD = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 600 } });
+// every frame the page sends its kernel, by type: the window asks, the older asks and the re-attach ask are the evidence
+await page.addInitScript(() => {
+  const send = WebSocket.prototype.send;
+  window.__sent = [];
+  WebSocket.prototype.send = function (d) {
+    try { const m = JSON.parse(d); if (m && m.type) window.__sent.push(m); } catch (e) { /* not a frame */ }
+    return send.call(this, d);
+  };
+});
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction(() => document.querySelectorAll("#content .turn[data-uuid]").length >= 40, null, { timeout: 30000 });
+await page.waitForTimeout(500);
+const state = () => page.evaluate(() => {
+  const c = document.getElementById("content");
+  const strip = document.getElementById("live-paused");
+  // the run's rendered EVENT turns: a notice unit at the tail (an api-error note) carries a word, not a uuid
+  const turns = Array.from(document.querySelectorAll("#content .turn[data-uuid]")).filter((t) => /^[0-9a-f-]{36}$/.test(t.dataset.uuid));
+  return { top: c.scrollTop, sh: c.scrollHeight, ch: c.clientHeight,
+           atBottom: c.scrollHeight - c.scrollTop - c.clientHeight <= 2,
+           strip: !!strip && !strip.hidden && getComputedStyle(strip).display !== "none",   // fixed-position: no offsetParent to read
+           firstUuid: turns.length ? turns[0].dataset.uuid : null, lastUuid: turns.length ? turns[turns.length - 1].dataset.uuid : null,
+           turns: turns.length,
+           sent: window.__sent.map((m) => m.type + (m.why ? ":" + m.why : "") + (m.what ? ":" + m.what + (m.data && m.data.writer ? ":" + m.data.writer : "") + (m.what === "windowask" && m.data ? ":nav=" + m.data.nav + ":reland=" + m.data.reland : "") : "")) };
+});
+const sentOf = (type) => page.evaluate((t) => window.__sent.filter((m) => m.type === t).length, type);
+const boot = await state();
+if (!boot.atBottom) { console.error("the page did not land at the bottom: " + JSON.stringify(boot)); process.exit(1); }
+// OLDER events of the transcript itself (turns k0..k1, none resident: the page holds the tail), in the wire's shape, so a
+// window around them does not overlap the run and the kernel can place any page ask that follows them
+const pad = (n) => String(n).padStart(12, "0");
+const older = (k0, k1) => Array.from({ length: k1 - k0 }, (_, i) => k0 + i).flatMap((k) => [
+  { uuid: "11111111-2222-3333-4444-" + pad(2 * k), kind: "user", md: "question number " + k + " about the notes api", ts: new Date((cfg.base + 2 * k) * 1000).toISOString() },
+  { uuid: "22222222-3333-4444-5555-" + pad(2 * k + 1), kind: "assistant", md: "Answer " + k + ": the handler reads the note by id and returns it.", ts: new Date((cfg.base + 2 * k + 1) * 1000).toISOString() }]);
+"""
+
+
+# the verifier's road: two older fetches (a walk toward the transcript head), a settle MID-run, a persist through the shell's
+# hook, a reload; the saved row must be back on screen through one window ask
+DRIVER_RESTORE = DRIVER_HEAD + r"""
+const olderAt = async (n) => page.waitForFunction((k) => window.__sent.filter((m) => m.type === "loadOlder").length >= k, n, { timeout: 20000 });
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 1; });
+await olderAt(1); await page.waitForTimeout(800);
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 1; });
+await olderAt(2); await page.waitForTimeout(800);
+// settle mid-run: three screens below the head, off the top band, on a row far above the tail window a fresh page holds
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = c.clientHeight * 3; });
+await page.waitForTimeout(600);
+const settled = await state();
+const savedRow = await page.evaluate(() => {
+  const c = document.getElementById("content"); const cTop = c.getBoundingClientRect().top;
+  for (const t of Array.from(c.querySelectorAll(".turn[data-uuid]"))) { const r = t.getBoundingClientRect(); if (r.bottom > cTop + 1) return { uuid: t.dataset.uuid, y: r.top - cTop }; }
+  return null;
+});
+await page.evaluate(() => window.__rompPersistForReload());
+const saved = await page.evaluate(() => { const raw = sessionStorage.getItem("romp:reloadScroll"); return raw ? JSON.parse(raw) : null; });
+await page.reload();
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction(() => document.querySelectorAll("#content .turn[data-uuid]").length >= 40, null, { timeout: 30000 });
+let landed = false;
+try {
+  await page.waitForFunction((u) => { const t = document.querySelector('#content .turn[data-uuid="' + u + '"]'); if (!t) return false;
+    const c = document.getElementById("content").getBoundingClientRect(), r = t.getBoundingClientRect(); return r.bottom > c.top && r.top < c.bottom; }, savedRow ? savedRow.uuid : "none", { timeout: 15000 });
+  landed = true;
+} catch (e) { landed = false; }
+await page.waitForTimeout(500);
+const reloaded = await state();
+reloaded.landed = landed;
+reloaded.saved = saved;
+reloaded.savedRow = savedRow;
+reloaded.asks = await page.evaluate(() => ({ loadAround: window.__sent.filter((m) => m.type === "loadAround").length, loadOlder: window.__sent.filter((m) => m.type === "loadOlder").length, needFull: window.__sent.filter((m) => m.type === "needFull").length }));
+fs.writeSync(1, "RESULT:" + JSON.stringify({ boot, settled, reloaded }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+# the verifier's second road (T366 round two): a reader walked to the transcript HEAD over two older fetches, persisted through
+# the shell's hook and reloaded lands back on their saved row at offset 0, through one window ask, with the plain strip
+DRIVER_RESTORE_HEAD = DRIVER_HEAD + r"""
+const olderAt = async (n) => page.waitForFunction((k) => window.__sent.filter((m) => m.type === "loadOlder").length >= k, n, { timeout: 20000 });
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 1; });
+await olderAt(1); await page.waitForTimeout(800);
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 1; });
+await olderAt(2); await page.waitForTimeout(800);
+await page.evaluate(() => { const c = document.getElementById("content"); c.scrollTop = 0; });
+await page.waitForTimeout(600);
+const atHead = await state();
+const savedRow = await page.evaluate(() => {
+  const c = document.getElementById("content"); const cTop = c.getBoundingClientRect().top;
+  for (const t of Array.from(c.querySelectorAll(".turn[data-uuid]"))) { const r = t.getBoundingClientRect(); if (r.bottom > cTop + 1) return { uuid: t.dataset.uuid, y: r.top - cTop }; }
+  return null;
+});
+await page.evaluate(() => window.__rompPersistForReload());
+await page.reload();
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction(() => document.querySelectorAll("#content .turn[data-uuid]").length >= 40, null, { timeout: 30000 });
+let landed = false;
+try {
+  await page.waitForFunction((u) => { const t = document.querySelector('#content .turn[data-uuid="' + u + '"]'); if (!t) return false;
+    const c = document.getElementById("content").getBoundingClientRect(), r = t.getBoundingClientRect(); return Math.abs(r.top - c.top) <= 2; }, savedRow ? savedRow.uuid : "none", { timeout: 15000 });
+  landed = true;
+} catch (e) { landed = false; }
+await page.waitForTimeout(500);
+const reloaded = await state();
+reloaded.landed = landed;
+reloaded.savedRow = savedRow;
+reloaded.stripText = await page.evaluate(() => (document.querySelector("#live-paused .live-paused-text") || {}).textContent || "");
+reloaded.asks = await page.evaluate(() => ({ loadAround: window.__sent.filter((m) => m.type === "loadAround").length, needFull: window.__sent.filter((m) => m.type === "needFull").length }));
+fs.writeSync(1, "RESULT:" + JSON.stringify({ boot, atHead, reloaded }) + "\n");
+await browser.close();
+process.exit(0);
+"""
+
+
+class ServedReloadRestoreMidRun(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="reload-restore-midrun-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        cls.state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(cls.state, d), exist_ok=True)
+        os.makedirs(cwd, exist_ok=True)
+        Path(cls.state, "session-hosts").write_text("off\n")   # a lab root of its own: no session host (T348)
+        Path(cls.state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(cls.state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(cls.state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 100}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        # TURNS user/assistant pairs, one a second, ending in the past: past the wire tail, so the page holds a tail
+        recs, prev = [], None
+        base = 1789000000
+        for k in range(TURNS):
+            u = "11111111-2222-3333-4444-%012d" % (2 * k)
+            a = "22222222-3333-4444-5555-%012d" % (2 * k + 1)
+            tu = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(base + 2 * k))
+            ta = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(base + 2 * k + 1))
+            recs.append({"type": "user", "uuid": u, "parentUuid": prev, "timestamp": tu, "sessionId": SID,
+                         "message": {"role": "user", "content": "question number %d about the notes api" % k}})
+            recs.append({"type": "assistant", "uuid": a, "parentUuid": u, "timestamp": ta, "sessionId": SID,
+                         "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                                     "content": [{"type": "text", "text": "Answer %d: the handler reads the note by id and returns it." % k}]}})
+            prev = a
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.deep_uuid = "11111111-2222-3333-4444-%012d" % 20   # the eleventh question: far above the tail the page holds
+        cls.deep_t = base + 20                                     # …and its time, as a card's focus frame carries it
+        cls.base = base
+        cls.port = _free_port()
+        cls.token = "testtok-reloadmidrun"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")],
+                                      stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    def _drive(self, script, name):
+        cfg = os.path.join(self.lab, name + ".json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sid": SID,
+                       "deepUuid": self.deep_uuid, "deepT": self.deep_t, "base": self.base,
+                       "shots": os.environ.get("RELOAD_MIDRUN_SHOTS", "")}, f)
+        driver = os.path.join(self.lab, name + ".mjs")
+        with open(driver, "w") as f:
+            f.write(script)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:])
+        line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+        self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+        return json.loads(line[len("RESULT:"):])
+
+    def test_a_reload_lands_the_reader_on_their_saved_row_mid_run_through_one_window_ask(self):
+        r = self._drive(DRIVER_RESTORE, "restore")
+        print("RESULT:" + json.dumps(r), file=sys.stderr)
+        st, rl = r["settled"], r["reloaded"]
+        self.assertIsNotNone(rl["savedRow"], "a row sat under the viewport top before the reload: %r" % st)
+        self.assertIsNotNone(rl["saved"], "the shell's hook saved the record: %r" % rl)
+        self.assertEqual(rl["saved"]["anchor"]["uuid"], rl["savedRow"]["uuid"], "the record names the row under the viewport top")
+        self.assertTrue(rl["landed"], "the saved row is not back on screen after the reload: %r" % {k: rl[k] for k in ("top", "sh", "asks", "strip")})
+        self.assertEqual(rl["asks"]["loadAround"], 1, "the row outside the fresh window is fetched through ONE window ask: %r" % rl["asks"])
+        self.assertEqual(rl["asks"]["needFull"], 0, "no forced re-attach: %r" % rl["asks"])
+
+    def test_a_reload_from_the_transcript_head_lands_the_saved_row_at_offset_zero_with_the_plain_strip(self):
+        r = self._drive(DRIVER_RESTORE_HEAD, "restore-head")
+        print("RESULT:" + json.dumps(r), file=sys.stderr)
+        rl = r["reloaded"]
+        self.assertIsNotNone(rl["savedRow"], "a row sat at the viewport top before the reload: %r" % r["atHead"])
+        self.assertTrue(rl["landed"], "the saved row is not back at offset 0 after the reload: %r" % {k: rl[k] for k in ("top", "sh", "asks", "strip", "stripText")})
+        self.assertEqual(rl["asks"], {"loadAround": 1, "needFull": 0}, "one window ask for the row, no forced re-attach: %r" % rl["asks"])
+        self.assertTrue(rl["strip"], "restored into older history: the strip shows: %r" % rl)
+        self.assertEqual(rl["stripText"], "Live updates are paused while you read older history.", "a restore is no click: the plain sentence: %r" % rl["stripText"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/reload-restore.test.ts
+++ b/ui/webview/reload-restore.test.ts
@@ -64,6 +64,9 @@ test("landActive's landing consumes the record for the active tab first, then fa
   const body = m![1];
   assert.match(body, /const rs = takeReloadScroll\(pendingReloadScroll, activeId\);\s*\n\s*if \(rs\) \{\s*\n\s*pendingReloadScroll = null;\s*\n\s*v\.stick = rs\.stick;\s*\n\s*if \(rs\.stick\) writeScroll\(content, content\.scrollHeight, "reload-restore", true\);\s*\n\s*else if \(!\(rs\.anchor && restoreScrollAnchor\(content, v, rs\.anchor\)\)\) \{/);
   // the anchor turn outside the fresh window: the raw top is the first guess and the deep-link land finishes it
-  assert.match(body, /writeScroll\(content, rs\.top, "reload-restore"\);\s*\n\s*if \(rs\.anchor\) \{ pendingAnchor = rs\.anchor\.uuid; pendingAnchorKeepY = rs\.anchor\.y; \}/);
+  assert.match(body, /writeScroll\(content, rs\.top, "reload-restore"\);\s*\n\s*if \(rs\.anchor\) \{\s*\n\s*pendingAnchor = rs\.anchor\.uuid; pendingAnchorKeepY = rs\.anchor\.y;/, "the raw top first, then the deep-link land is armed");
+  // …and RUN in the same pass (T374): the pass already made its own attempt before the restore armed anything, and an idle
+  // session sends no frame for another; a row outside the fresh window asks its window here and stays armed for the reply
+  assert.match(body, /landTrail = \[\];\s*\n\s*const landedNow = scrollToAnchor\(rs\.anchor\.uuid\);\s*\n\s*if \(landedNow \|\| !anchorPendingOlder\) \{ pendingAnchor = null; pendingAnchorKeepY = null; \}/, "landed or asked at once; the arm is kept only for a window in flight");
   assert.match(body, /else if \(!v\.shown \|\| v\.stick\) writeScroll\(content, content\.scrollHeight, "land-bottom", true\);\s*\n\s*else writeScroll\(content, v\.scrollTop, "land-saved"\);/);
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -12691,7 +12691,17 @@ function landActive(content: HTMLElement | null, v: View): void {
         // deep-link land, whose window-around-unit and fetch-older paths bring the anchor turn back to its exact
         // offset (review find, 2026-09-08)
         writeScroll(content, rs.top, "reload-restore");
-        if (rs.anchor) { pendingAnchor = rs.anchor.uuid; pendingAnchorKeepY = rs.anchor.y; }
+        if (rs.anchor) {
+          pendingAnchor = rs.anchor.uuid; pendingAnchorKeepY = rs.anchor.y;
+          // …and run that land NOW (T374, the verifier of 2026-09-12 executed the gap on both heads): this pass made its own
+          // landing attempt above, before the restore armed anything, and the next pass comes only with a frame that changes
+          // the run, which an idle session never sends, so a saved row outside the fresh window (mid-run: its raw top not in
+          // the top band, no older ask either) parked the reader at a raw pixel offset for good. Resident → lands here;
+          // outside the run → asks its window here (chatWindow lands it on arrival, the arm stays for that reply).
+          landTrail = [];
+          const landedNow = scrollToAnchor(rs.anchor.uuid);
+          if (landedNow || !anchorPendingOlder) { pendingAnchor = null; pendingAnchorKeepY = null; }
+        }
       }
     }
     else if (!v.shown || v.stick) writeScroll(content, content.scrollHeight, "land-bottom", true);


### PR DESCRIPTION
After a page reload, a reader whose saved row sat mid-run (the restored raw top outside the top band) never got their row back. The landing pass armed the pending anchor and the keep offset only after its own landing attempt, so the deep-link land waited for a later render pass, which an idle session never supplies; the reader parked at a raw pixel offset with no window ask, no older ask and no full ask (the verifier of the strip fix executed the gap on both heads).

The restore now runs the land in the same pass: a resident row lands at once; a row outside the fresh window asks its window at once and the window reply lands it, the arm kept only for that reply.

Red first: `tests/test_reload_restore_midrun_browser.py` drives the verifier's road on the served page (two older fetches, a settle mid-run, the shell's persist hook, a reload) and asserts the saved row is back on screen through one window ask and no forced re-attach; red on main. The reload-restore executed test pins the immediate land.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
