### PR TITLE
T366 verifier round two lows: a click of any kind is named, the write's echo marker is one-shot

### DIFF
--- a/ui/webview/chat-proto2-exec.test.ts
+++ b/ui/webview/chat-proto2-exec.test.ts
@@ -186,7 +186,7 @@ function liftAsk(relandAsk: boolean, keepY: number | null, anchorT: number | nul
 test("the reload restore's window ask (a keep offset, no re-land) is a navigation and lands; the re-land's is refused; a card's carries its time (T366)", () => {
   const restore = liftAsk(false, 12, null, null);
   assert.equal(restore.api.requestAround("A", "u1"), true);
-  assert.deepEqual(restore.api.pendingWindowNav.get("A"), { nav: true, named: false, t: null }, "the reader's saved place is theirs to get back: a navigation, unnamed (the plain strip sentence)");
+  assert.deepEqual(restore.api.pendingWindowNav.get("A"), { nav: true, named: false, t: null }, "the reader's saved place is theirs to get back: a navigation, and no click (the plain strip sentence)");
   assert.equal(windowLanding(true, true, restore.api.pendingWindowNav.get("A").nav), "detach", "…so a detaching window lands (no forced re-attach)");
   const reland = liftAsk(true, 12, null, null);
   reland.api.requestAround("A", "u2");
@@ -195,9 +195,12 @@ test("the reload restore's window ask (a keep offset, no re-land) is a navigatio
   const card = liftAsk(false, null, 1700000000, null);
   card.api.requestAround("A", "u3");
   assert.deepEqual(card.api.pendingWindowNav.get("A"), { nav: true, named: true, t: 1700000000 }, "a card's or lane's frame carried the message's time: named, and the strip says the clock");
-  const notch = liftAsk(false, null, null, "prompt");
-  notch.api.requestAround("A", "u4");
-  assert.deepEqual(notch.api.pendingWindowNav.get("A"), { nav: true, named: true, t: null }, "a kind without a time: named, and the strip says the message was opened without a clock");
+  const kindOnly = liftAsk(false, null, null, "prompt");
+  kindOnly.api.requestAround("A", "u4");
+  assert.deepEqual(kindOnly.api.pendingWindowNav.get("A"), { nav: true, named: true, t: null }, "a kind without a time: named, and the strip says the message was opened without a clock");
+  const notch = liftAsk(false, null, null, null);
+  notch.api.requestAround("A", "u5");
+  assert.deepEqual(notch.api.pendingWindowNav.get("A"), { nav: true, named: true, t: null }, "a notch, a reply chip or a comment tick arm neither kind, time nor keep offset: still a click the strip names (verifier low, round two)");
   assert.equal(restore.rows.length, 1); assert.equal(restore.rows[0].k, "windowask");
   assert.deepEqual({ nav: restore.rows[0].d.nav, keep: restore.rows[0].d.keep, reland: restore.rows[0].d.reland, trail: restore.rows[0].d.trail }, { nav: true, keep: true, reland: false, trail: ["pointer-fetch-window"] }, "the ask's diagnostic row names the keep offset and the re-land flag apart, under the scroll rows' budget");
   assert.deepEqual(restore.posted, [{ type: "loadAround", id: "A", uuid: "u1" }], "the ask itself goes out after the mark");

--- a/ui/webview/chat-window.test.ts
+++ b/ui/webview/chat-window.test.ts
@@ -95,7 +95,11 @@ test("the paused strip names a navigation's detach, with the opened message's cl
   assert.ok(strip.indexOf("livePausedTxt.textContent = livePausedText(") > strip.indexOf("document.body.appendChild(livePausedEl);"), "…after the one-time build, so a later detach changes the words");
   const win = RENDER.slice(RENDER.indexOf("function chatWindow(msg: any) {"), RENDER.indexOf("function chatMore(msg: any) {"));
   assert.ok(win.includes("s.detachNav = detached && ask?.named ? { t: ask.t } : null;"), "a landed window records whether a card, lane or deep link detached, and its time");
-  assert.ok(RENDER.includes("pendingWindowNav.set(sid, { nav, named: nav && (pendingAnchorT != null || !!kind), t: nav ? (pendingAnchorT ?? null) : null });"), "the ask carries the navigation's time to the reply, and whether its frame carried a kind or a time (a reload restore has neither: the plain sentence)");
+  assert.ok(RENDER.includes("pendingWindowNav.set(sid, { nav, named: nav && pendingAnchorKeepY == null, t: nav ? (pendingAnchorT ?? null) : null });"), "the ask carries the navigation's time to the reply, and whether it was a click (any anchor landing without a keep offset; the reload restore of the reader's own place keeps the plain sentence)");
+  // the three direct landings (a notch, a reply chip, a comment tick) arm neither kind nor time: still a click, named as opened
+  assert.match(RENDER, /markjump: \(elx\) => \{\s*\n\s*const uuid = elx\.dataset\.uuid;\s*\n\s*if \(!uuid \|\| !activeId\) return;\s*\n\s*flashedAnchor = null;\s*\n\s*scrollToAnchor\(uuid\);/, "the notch lands directly");
+  assert.match(RENDER, /replyjump: \(elx\) => \{[\s\S]*?flashedAnchor = null;[^\n]*\n\s*if \(scrollToAnchor\(uuid\)\) \{/, "the reply chip lands directly");
+  assert.match(RENDER, /cmtjump: \(elx\) => \{[\s\S]*?flashedAnchor = null;\s*\n\s*scrollToAnchor\(uuid\);/, "the comment tick lands directly");
 });
 
 test("an older-history ask needs an upward or unchanged move; a downward gesture never asks (T366)", () => {

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -10924,7 +10924,7 @@ function writeScroll(content: HTMLElement, top: number, writer: string, stick = 
   const before = content.scrollTop;
   content.scrollTop = top;
   const after = content.scrollTop;
-  lastScrollWriteAfter = after;
+  if (after !== before) lastScrollWriteAfter = after;   // a write that moved the view owes exactly one scroll event, its echo; one that did not move owes none, and must not eat a later gesture landing near its target (verifier low, round two)
   lastKnownSh = content.scrollHeight;
   if (after !== before) scrollDiagRow("scrollwrite", scrollWriteRow(activeId || "", writer, before, after, stick, content.scrollHeight, content.clientHeight));
 }
@@ -13057,8 +13057,8 @@ function updateReplyChips(): void {
     const cls = classifyScroll(c.scrollTop, lastScrollWriteAfter);
     const gv = activeId ? views.get(activeId) : null;
     if (gv) gv.gestureScroll = cls === "gesture";   // read once by the edge check this event runs next (T366): a write's echo is no gesture
-    if (cls === "write-echo") lastScrollWriteAfter = null;
-    else scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });
+    lastScrollWriteAfter = null;   // one-shot: the first event after a write consumes its marker, echo or not (a gesture that lands within a pixel of an older write's target is a gesture)
+    if (cls !== "write-echo") scrollDiagRow("scrollgesture", { sid: activeId || "", top: c.scrollTop, gesture: true, sh: c.scrollHeight, ch: c.clientHeight });
     lastKnownSh = c.scrollHeight;   // sh/ch: a clamp reads top == sh - ch after sh dropped (T262e)
   }, { passive: true });
 }
@@ -17070,15 +17070,17 @@ function olderOnServer(s: Session): boolean {
 // sid -> the window was asked by a NAVIGATION (a card, a notch, a deep link, a seek, a reload's restore of the reader's
 // saved place: every anchor landing but one), not by the keep-offset RE-LAND of the reader's own row across a rebuild
 // (relandAsk), the one ask that exists only to keep their row on screen and must never move them off the live run (T366:
-// a window landing mid-flick detached a reader; a navigation's window may, a re-land's never); `named` says the ask came
-// from a frame that carried a kind or the message's time (a card or lane click, a deep link), which the strip names
+// a window landing mid-flick detached a reader; a navigation's window may, a re-land's never); `named` says the ask was a
+// CLICK of the reader's (a card, a lane, a deep link, a notch, a reply chip, a comment tick: any anchor landing with no keep
+// offset), which the strip names as the message they opened, with its time when the frame carried one; the reload restore
+// of their own saved place arms a keep offset and keeps the plain sentence (verifier low, round two)
 const pendingWindowNav = new Map<string, { nav: boolean; named: boolean; t: number | null }>();
 function requestAround(sid: string, uuid: string): boolean {
   const s = sessions.get(sid);
   if (!s || s.proto !== 2 || loadingOlder.has(sid)) return false;
   const nav = !relandAsk;
   const kind = pendingAnchorKind ?? pendingAnchorIntent ?? null;
-  pendingWindowNav.set(sid, { nav, named: nav && (pendingAnchorT != null || !!kind), t: nav ? (pendingAnchorT ?? null) : null });
+  pendingWindowNav.set(sid, { nav, named: nav && pendingAnchorKeepY == null, t: nav ? (pendingAnchorT ?? null) : null });
   // every window ask leaves a diagnostic row (T366: the rows of the report had the reply's landing but nothing said
   // which pass asked for the window): the landing trail so far, the anchor's kind, whether a keep-offset restore asked;
   // under the same per-minute budget as the other scroll rows (verifier low 5)

--- a/ui/webview/scroll-write.test.ts
+++ b/ui/webview/scroll-write.test.ts
@@ -29,6 +29,10 @@ test("a scroll event within a pixel of the last programmatic write is its echo; 
   assert.equal(classifyScroll(1200.5, 1200), "write-echo", "sub-pixel rounding");
   assert.equal(classifyScroll(1230, 1200), "gesture");
   assert.equal(classifyScroll(1200, null), "gesture", "no write pending: the user did it");
+  // the marker is one-shot (verifier low, T366 round two): set only by a write that MOVED the view, consumed by the first
+  // event after it whatever that event was, so a gesture that lands within a pixel of an old write's target is a gesture
+  assert.match(RENDER, /const after = content\.scrollTop;\s*\n\s*if \(after !== before\) lastScrollWriteAfter = after;/, "a write that did not move owes no echo");
+  assert.match(RENDER, /const cls = classifyScroll\(c\.scrollTop, lastScrollWriteAfter\);[\s\S]{0,400}?\n\s*lastScrollWriteAfter = null;/, "the first event after the write consumes the marker, echo or not");
 });
 
 test("the row names the writer and carries before/after/delta/stick, gesture:false", () => {
@@ -41,7 +45,7 @@ test("the row names the writer and carries before/after/delta/stick, gesture:fal
 
 test("render.ts: one helper writes #content.scrollTop, files the row only when the view moved, and no raw write remains", () => {
   assert.match(RENDER, /import \{ ScrollDiagBudget, classifyScroll, scrollWriteRow, tailChangeRow, tailLabel, spacerRow, readScrollDiagCap, summarizeTailMutations, tailMutRow, unitChangeRow, unitChanges, boxChanges, boxLabel, BOX_FROM_TAIL \} from "\.\/scroll-write";/);
-  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*lastScrollWriteAfter = after;\s*\n\s*lastKnownSh = content\.scrollHeight;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
+  assert.match(RENDER, /function writeScroll\(content: HTMLElement, top: number, writer: string, stick = false\): void \{\s*\n\s*const before = content\.scrollTop;\s*\n\s*content\.scrollTop = top;\s*\n\s*const after = content\.scrollTop;\s*\n\s*if \(after !== before\) lastScrollWriteAfter = after;[^\n]*\n\s*lastKnownSh = content\.scrollHeight;\s*\n\s*if \(after !== before\) scrollDiagRow\("scrollwrite", scrollWriteRow\(activeId \|\| "", writer, before, after, stick, content\.scrollHeight, content\.clientHeight\)\);/);
   // the breadcrumb rides the existing clientDiag path, capped, with one capped row at the cap
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind \+ "-capped", data: \{ sid: activeId \|\| "", perMinute: scrollDiagCap \} \}/);   // the cap the page runs with (T262j: configurable)
   assert.match(RENDER, /\{ type: "clientDiag", surface: "chat", what: kind, data \}/);
@@ -55,5 +59,5 @@ test("render.ts: one helper writes #content.scrollTop, files the row only when t
   const raw = RENDER.split("\n").filter((l) => /\b(content|c)\.scrollTop (=|\+=|-=) /.test(l) && !/writeScroll|const |let /.test(l));
   assert.deepEqual(raw.map((l) => l.trim()), ["content.scrollTop = top;"], "the only assignment is the helper's own");
   // the gesture marker: a write's echo is consumed, anything else files a gesture row
-  assert.match(RENDER, /const cls = classifyScroll\(c\.scrollTop, lastScrollWriteAfter\);\s*\n\s*const gv = activeId \? views\.get\(activeId\) : null;\s*\n\s*if \(gv\) gv\.gestureScroll = cls === "gesture";[^\n]*\n\s*if \(cls === "write-echo"\) lastScrollWriteAfter = null;\s*\n\s*else scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true, sh: c\.scrollHeight, ch: c\.clientHeight \}\);/, "the scroll nobody's code asked for is the user's; a write's echo is consumed, never filed (the classification is read once and marks the view for the edge check, T366)");
+  assert.match(RENDER, /const cls = classifyScroll\(c\.scrollTop, lastScrollWriteAfter\);\s*\n\s*const gv = activeId \? views\.get\(activeId\) : null;\s*\n\s*if \(gv\) gv\.gestureScroll = cls === "gesture";[^\n]*\n\s*lastScrollWriteAfter = null;[^\n]*\n\s*if \(cls !== "write-echo"\) scrollDiagRow\("scrollgesture", \{ sid: activeId \|\| "", top: c\.scrollTop, gesture: true, sh: c\.scrollHeight, ch: c\.clientHeight \}\);/, "the scroll nobody's code asked for is the user's; a write's echo is consumed, never filed (the classification is read once and marks the view for the edge check, T366)");
 });


### PR DESCRIPTION
The verifier's round-two lows on the live-updates strip fix (the pull request that merged as 707ae019).

- A click of any kind is named on the strip: a card, a lane, a deep link, and the three direct landings that arm neither kind nor time (a notch on the scroll rail, a reply chip, a comment tick) now read "Showing the message you opened", with the clock when the frame carried a time. Only the reload restore of the reader's own saved place, which arms a keep offset and no click, keeps the plain sentence. The three sites are pinned.
- The served lab carries the restore road the verifier drove: a reader walked to the transcript head over two older fetches, persisted through the shell's hook and reloaded lands back on their saved row at offset 0 through one window ask, no forced re-attach, the plain strip. Red on the previous head, which refused the restore's ask as a re-land.
- The scroll write's echo marker is one-shot: set only by a write that moved the view, consumed by the first scroll event after it whatever that event was, so a gesture that lands within a pixel of an older write's target is read as a gesture.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
