### PR TITLE
A glossary term is a link to the glossary's section and nothing more: the ordinary hover, the ordinary dress (T375)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1866,8 +1866,9 @@ the same card:
 
 Stage 1 fills it from the slice route (`markdown`, `section`, `code`) and the
 bytes route (`image` at its natural size capped to the card, `pdf` as its first
-page), or with the text-only card; stage 2 fills it with the `term` kind from the
-glossary index below, no fetch. A previewed document renders on the
+page), or with the text-only card; a glossary term (below) is a path link to the
+glossary file's section and previews as one, through the same slice route. A
+previewed document renders on the
 sanitizer's inert DOM and is stripped of every remote load there, before its
 nodes join the page: an image's `src` or `srcset`, a picture's sources, a video's
 poster or source, an audio, an SVG image, in any spelling the URL parser
@@ -1887,7 +1888,11 @@ anchor}` that fills the `term` kind of the same card.
 
 ## The glossary
 
-A team's coinages, linked where they are written. One file per romp tag group,
+A team's coinages, linked where they are written. A linked term is an ordinary
+link to the glossary file's section (the link colour, a solid underline, the
+pointer): hovering it shows that section through the file preview, exactly as
+hovering any file link with a section does, and clicking it opens the glossary
+in the viewer at the heading; there is no term card of its own. One file per romp tag group,
 `~/.claude/glossaries/<group>.md` (under `CLAUDE_CONFIG_DIR` when set), in the
 grammar of that folder's README: an opening `## Not coinages` list of words never
 linked (each bullet's bold lead, or the text before its colon, read as words), then

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -44305,7 +44305,7 @@ def _slice_allowed(fp, sid):
         return None, "not a kind the preview shows"
     if _slice_kind(fp) != kind:
         return None, "a link dressed as another kind"
-    if not _slice_confined(real, sid):
+    if not _slice_confined(real, sid) and not _glossary_owned(real):   # the glossaries folder is the user's own wherever the config dir points (T375)
         return None, "outside the session's folder and your home"
     try:
         size = os.path.getsize(real)
@@ -44378,6 +44378,18 @@ def _slice_headings(text):
     return out
 
 
+def _glossary_owned(real):
+    """Whether `real` (a real path) is one of the user's own glossary files (a markdown file directly under the glossaries
+    folder, _glossary_dir). The content belt does not apply there (T375): a glossary's every section already reaches the page
+    whole through the index frame and the /glossary route, so a credential-shaped EXAMPLE line in a coinage's definition
+    would refuse the slice of a file the page holds anyway, and the term's hover would fall to the text card."""
+    try:
+        d = os.path.realpath(str(_glossary_dir()))
+    except Exception:
+        return False
+    return os.path.dirname(real) == d and real.endswith(".md")
+
+
 def _slice_load(fp):
     """The text and heading index of `fp` from the cache, keyed on (real path, mtime_ns), read on a miss. Returns
     (entry, hit, why): why is "" on success, else the refusal ("not text", "too large to show", "looks like a secret":
@@ -44404,7 +44416,7 @@ def _slice_load(fp):
     text = _decode_text(raw)
     if text is None:
         return None, False, "not text"
-    if _looks_secret(text):
+    if _looks_secret(text) and not _glossary_owned(fp):
         return None, False, "looks like a secret"
     e = {"text": text, "headings": _slice_headings(text) if _slice_kind(fp) == "markdown" else [],
          "size": len(raw), "mtime_ns": st.st_mtime_ns}
@@ -44509,9 +44521,9 @@ def _slice_body(fp, sid, anchor):
         body.update(kind=None, allowed=False, why=why)           # the content belt, or a size or read refusal
         return 403, body, "application/json"
     text, found, heading, truncated = _slice_of(entry, anchor)
-    if _looks_secret(text):
+    if _looks_secret(text) and not _glossary_owned(os.path.realpath(fp)):
         # the belt over the SERVED slice: the load scanned the file's first 64 KB, and an anchored section can lie past
-        # that mark (the review)
+        # that mark (the review); the user's glossary files are outside the belt at both ends (T375)
         body.update(kind=None, allowed=False, why="looks like a secret")
         return 403, body, "application/json"
     # the heading INDEX stays on the kernel's side: the client reads the slice and the one heading it named, and an

--- a/tests/test_file_slice.py
+++ b/tests/test_file_slice.py
@@ -329,6 +329,27 @@ class Allowed(unittest.TestCase):
         self.assertEqual(km._slice_warm_why(os.path.join(self.cwd, "docs", "nonesuch.md")), "not a file")
 
 
+    def test_the_users_glossary_files_are_outside_the_content_belt(self):
+        # T375: a coinage's definition may show a credential-shaped EXAMPLE line; the glossary already reaches the page
+        # whole through the index frame and the /glossary route, so the belt refusing its slice would only turn every
+        # term's hover into the text card. The same line in a project notes file is still refused.
+        from unittest import mock
+        example = "api" + "_key" + " = " + "Q" * 24
+        section = "## keytoken\n\nAn invented noun whose definition shows an example line.\n\n- example: " + example + "\n"
+        cfg = os.path.join(self.lab, "cfg"); os.makedirs(os.path.join(cfg, "glossaries"))
+        gl = os.path.join(cfg, "glossaries", "web.md"); Path(gl).write_text("## Not coinages\n\n- none\n\n" + section)
+        notes = self.w("proj/docs/notes.md", "# Notes\n\n" + section)
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": cfg}):
+            km._SLICE_CACHE.clear()
+            self.assertTrue(km._glossary_owned(os.path.realpath(gl))); self.assertFalse(km._glossary_owned(os.path.realpath(notes)))
+            e, _hit, why = km._slice_load(gl)
+            self.assertEqual(why, ""); self.assertIn("keytoken", e["text"]); self.assertEqual(e["headings"][-1]["slug"], "keytoken", "the section is indexed like any heading")
+            self.assertEqual(km._slice_warm_why(gl), "", "the glossary's section previews whole, example line and all")
+            self.assertEqual(km._slice_allowed(gl, SID), ("markdown", ""), "…and the folder is confined as the user's own wherever the config dir points (here outside the session folder and the home)")
+            self.assertEqual(km._slice_load(notes)[2], "looks like a secret", "the belt still holds for a notes file")
+            self.assertEqual(km._slice_warm_why(notes), "looks like a secret")
+
+
 class Perf(unittest.TestCase):
     def test_the_slice_counters_ride_the_perf_snapshot(self):
         before = dict(km._PERF_STATS.snapshot()["fileSlice"])

--- a/tests/test_glossary_browser.py
+++ b/tests/test_glossary_browser.py
@@ -31,7 +31,7 @@ import test_ship_reship as _lab   # noqa: E402
 
 SID = "11111111-2222-3333-4444-555555555555"
 FIX = json.loads(Path(HERE, "fixtures", "glossary_grammar.json").read_text())
-REPLY = ("I tesselled the fixes from your review and pushed the tessel head; the quill was security, and the quill again. "
+REPLY = ("I tesselled the fixes from your review and pushed the tessel head; the quill was security, and the quill again. The keytoken previews whole. "
          "The spar on `tessel` stays as code, and docs/guide.md#tessel is a path, not a term. Two tessels landed. "
          "The unverified docs/widget/tessel.md and the host example.com/tessel/y stay plain too.")
 USER = "Did the tessel cover the second quill?"
@@ -51,8 +51,8 @@ let browser;
 try { browser = await chromium.launch(); }
 catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
 const page = await browser.newPage({ viewport: { width: 1100, height: 760 }, deviceScaleFactor: 2 });
-let requests = 0;
-page.on("request", (r) => { if (/\/glossary\/|\/file\?/.test(r.url())) requests++; });
+let requests = 0; const fileUrls = [];
+page.on("request", (r) => { if (/\/glossary\/|\/file\?/.test(r.url())) requests++; if (/\/file\?/.test(r.url())) fileUrls.push(r.url()); });
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab[data-id]", { timeout: 20000 });
 await page.click('#tabs .tab[data-id="' + cfg.sid + '"]');
@@ -64,19 +64,32 @@ const links = () => page.evaluate(() => Array.from(document.querySelectorAll("#c
 const out = { links: await links() };
 out.codeLinks = await page.evaluate(() => document.querySelectorAll("#content code .term-link, #content a .term-link, #content .file-uri-link .term-link").length);
 out.pathLink = await page.evaluate(() => { const a = document.querySelector('#content .file-uri-link[data-path="docs/guide.md"]'); return a ? { text: a.textContent, frag: a.dataset.frag } : null; });
-// the term card: hover "tessel head" (the multi-word term), no request
-const before = requests;
+// the hover on "tessel head" (the multi-word term): the glossary file's section at the term's heading, through the slice
+// route like any file link with a section (T375); no card of the term's own
+const before = requests; const filesBefore = fileUrls.length;
 const shot = async (name) => { if (!cfg.shots) return; fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/" + name + ".png", clip: { x: 0, y: 60, width: 1100, height: 520 } }); };
 await page.hover('#content .term-link[data-term="tessel-head"]');
 await page.waitForFunction(() => { const p = document.getElementById("file-preview-pop"); return !!p && getComputedStyle(p).display !== "none" && !!p.querySelector(".fp-body"); }, null, { timeout: 5000 });
 await page.waitForTimeout(150);
+await page.waitForFunction(() => { const b = document.querySelector("#file-preview-pop .fp-body"); return !!b && !b.querySelector(".rl-in") && (b.textContent || "").length > 20; }, null, { timeout: 8000 });
 out.card = await page.evaluate(() => { const p = document.getElementById("file-preview-pop"); const b = p.querySelector(".fp-body");
-  return { title: p.querySelector(".fp-title")?.textContent, sub: p.querySelector(".fp-sub")?.textContent, kind: b?.className, text: b?.textContent?.trim().slice(0, 300), open: p.querySelector(".fp-open")?.textContent }; });
+  return { title: p.querySelector(".fp-title")?.textContent, sub: p.querySelector(".fp-sub")?.textContent, kind: b?.className, text: b?.textContent?.trim().slice(0, 400), termCard: !!p.querySelector(".fp-term"), open: !!p.querySelector(".fp-open"), note: p.querySelector(".fp-note")?.textContent || null }; });
 out.cardRequests = requests - before;
+out.cardFileUrls = fileUrls.slice(filesBefore).map((u) => u.replace(/token=[^&]*/, "token=x"));
+// the dress: a link like any link (the link colour token, a solid underline, the pointer)
+out.dress = await page.evaluate(() => { const s = document.querySelector('#content .term-link[data-term="tessel-head"]'); const cs = getComputedStyle(s);
+  const probe = document.createElement("a"); probe.style.color = "var(--link)"; document.body.appendChild(probe); const link = getComputedStyle(probe).color; probe.remove();
+  return { color: cs.color, link, line: cs.textDecorationLine, style: cs.textDecorationStyle, cursor: cs.cursor, preview: s.dataset.preview, title: s.getAttribute("title") }; });
 await shot("romp_chat-glossary-dark");
 await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(200);
 await shot("romp_chat-glossary-light");
 await page.evaluate(() => document.body.classList.remove("theme-light"));
+await page.mouse.move(900, 700); await page.waitForTimeout(400);
+// a coinage whose definition carries a credential-shaped example line: the glossary is outside the content belt, so its
+// section still previews (the file already reaches the page whole through the index frame and the route)
+await page.hover('#content .term-link[data-term="keytoken"]');
+await page.waitForFunction(() => { const p = document.getElementById("file-preview-pop"); const b = p && p.querySelector(".fp-body"); return !!p && getComputedStyle(p).display !== "none" && !!b && !b.querySelector(".rl-in") && (b.textContent || "").length > 20; }, null, { timeout: 8000 });
+out.keyCard = await page.evaluate(() => { const p = document.getElementById("file-preview-pop"); const b = p.querySelector(".fp-body"); return { kind: b?.className, sub: p.querySelector(".fp-sub")?.textContent, text: b?.textContent?.trim().slice(0, 300), note: p.querySelector(".fp-note")?.textContent || null }; });
 await page.mouse.move(900, 700); await page.waitForTimeout(400);
 // a click opens the glossary in the viewer at the heading
 await page.click('#content .term-link[data-term="tessel"]');
@@ -139,7 +152,8 @@ class ServedGlossary(unittest.TestCase):
         os.makedirs(os.path.join(claude, "glossaries"), exist_ok=True)
         cls.glossary = os.path.join(claude, "glossaries", "web.md")     # the session's own name: the fallback when it has no tag group
         cls.transcript = None
-        Path(cls.glossary).write_text(FIX["text"])
+        example = "api" + "_key" + " = " + "Q" * 24   # a credential-shaped example line, assembled here (gitleaks reads the repo)
+        Path(cls.glossary).write_text(FIX["text"] + "\n## keytoken\n\nAn invented noun whose definition shows an example line.\n\n- plain words: an example holder\n- also: keytokens\n- status: unconfirmed\n- registered: 2026-09-12 by web\n- example: " + example + "\n")
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         Path(state, "names", SID).write_text("web\t%s\t#9cd2ff\t#0c1a2e\n" % cwd)
@@ -199,12 +213,20 @@ class ServedGlossary(unittest.TestCase):
         for l in r["links"]:
             self.assertTrue(l["path"].endswith("glossaries/web.md")); self.assertEqual(l["frag"], l["term"])
         self.assertTrue(any(l["inUser"] for l in r["links"]), "the user's own words link too")
-        # the card, from the index: no request
+        # the hover: the glossary file's section at the term's heading, through the slice route (T375); no card of its own
         c = r["card"]
-        self.assertEqual((c["title"], c["open"]), ("tessel head", "Open glossary")); self.assertIn("fp-term", c["kind"] or "")
-        self.assertIn("unconfirmed", c["sub"]); self.assertIn("web", c["sub"])
-        self.assertIn("The head a review's fixes land on", c["text"]); self.assertIn("plain words:", c["text"])
-        self.assertEqual(r["cardRequests"], 0, "the term card is filled from the index, no fetch")
+        self.assertFalse(c["termCard"], "no term card element: %r" % c); self.assertFalse(c["open"], "no open control: %r" % c)
+        self.assertIn("fp-section", c["kind"] or "", "the section card, as for any file link with a section: %r" % c)
+        self.assertEqual((c["title"], c["sub"]), ("web.md", "#tessel-head"), "the glossary file and the term's heading: %r" % c)
+        self.assertIn("The head a review's fixes land on", c["text"]); self.assertIn("plain words", c["text"], "the definition and its bullets, the whole section: %r" % c["text"])
+        self.assertEqual(len(r["cardFileUrls"]), 1, "one slice fetch for the hover: %r" % r["cardFileUrls"])
+        self.assertIn("anchor=tessel-head", r["cardFileUrls"][0]); self.assertIn("glossaries", r["cardFileUrls"][0]); self.assertIn("slice=1", r["cardFileUrls"][0], "the slice route, as for any file link with a section")
+        d = r["dress"]
+        self.assertEqual(d["color"], d["link"], "the link colour token: %r" % d); self.assertEqual((d["line"], d["style"], d["cursor"]), ("underline", "solid", "pointer"), "a solid underline and the pointer: %r" % d)
+        self.assertEqual(d["preview"], "markdown", "the kind rides the span from the index"); self.assertIsNone(d["title"], "no native title beside the hover")
+        k = r["keyCard"]
+        self.assertIn("fp-section", k["kind"] or "", "the glossary is outside the content belt: a credential-shaped example line still previews: %r" % k)
+        self.assertEqual(k["sub"], "#keytoken"); self.assertIn("An invented noun whose definition shows an example line", k["text"])
         # the click: the viewer on the heading
         self.assertEqual((r["viewer"]["heading"] or "").strip().lower(), "tessel")
         # the route

--- a/ui/webview/file-preview-pop.test.ts
+++ b/ui/webview/file-preview-pop.test.ts
@@ -97,7 +97,7 @@ test("open carries the section anchor to the viewer through both routes, and the
   assert.match(RENDER, /function openPath\(path: string, sid\?: string \| null, ev\?: MouseEvent \| null, frag\?: string \| null\): void \{/);
   assert.match(RENDER, /window\.parent\.postMessage\(\{ romp: "viewFile", path, sid: to, pane: "pane", frag: frag \|\| null,/, "the pane route names the section");
   assert.match(RENDER, /\} : undefined, frag \|\| null\);/, "…and so does the overlay route");
-  assert.match(RENDER, /openPath\(path, sid, e, frag \|\| null\); \}\);/, "the card's open button hands the anchor over");
+  assert.ok(!RENDER.includes('"fp-open"'), "no card carries an open control (T369 for the file cards, T375 for the last one): the link's own click hands the anchor over, pinned above");
   assert.match(FILEVIEW, /relay\?: \(path: string, sid: string \| null, frag: string \| null\) => void, frag\?: string \| null\): void \{/);
   assert.match(FILEVIEW, /openFileView\(path, sid, \{ frag: frag \?\? null \}\);/);
   assert.match(FILES, /function openHere\(path: string, sid: string \| null, identity: FileViewIdentity \| null, frag: string \| null = null\): void \{/);

--- a/ui/webview/file-preview.test.ts
+++ b/ui/webview/file-preview.test.ts
@@ -39,10 +39,10 @@ test("contentFor fills the one shape per kind; a missing anchor falls back to th
   assert.deepEqual(md, { kind: "markdown", title: "g.md", subtitle: undefined, body: { markdown: "# G\nbody" }, note: undefined });
   const sec = contentFor("docs/g.md", "fold", "markdown", "s", { title: "g.md", text: "## Fold\nabout folds", found: true, allowed: true });
   assert.equal(sec.kind, "section"); assert.equal(sec.subtitle, "#fold");
-  assert.equal(sec.open, undefined, "no open control on a file card: the link itself opens the file at the section (T369)");
+  assert.ok(!("open" in sec), "no open control on a file card: the link itself opens the file at the section (T369); the contract carries no such field since T375");
   const miss = contentFor("docs/g.md", "nope", "markdown", "s", { title: "g.md", text: "# G\nhead", found: false, allowed: true });
   assert.equal(miss.kind, "markdown"); assert.equal(miss.subtitle, undefined);
-  assert.equal(miss.note, 'no section "nope" in this file; its head instead'); assert.equal(miss.open, undefined);
+  assert.equal(miss.note, 'no section "nope" in this file; its head instead'); assert.ok(!("open" in miss));
   const cut = contentFor("docs/g.md", "", "markdown", "s", { title: "g.md", text: "…", found: true, truncated: true, allowed: true });
   assert.equal(cut.note, "the head of the file; the link opens the rest");
   const code = contentFor("src/app.py", "", "code", "s", { title: "app.py", text: "print(1)", allowed: true });

--- a/ui/webview/file-preview.ts
+++ b/ui/webview/file-preview.ts
@@ -12,18 +12,17 @@ export const PREVIEW_DWELL_MS = 350;   // a hover shorter than this is a pass-th
 export const PREVIEW_GRACE_MS = 150;   // leaving the link toward the card must not close it on the way
 
 /** The kinds a preview shows. `text` is the text-only card (a path the popover may not fetch: outside the session's
- *  folder and the user's home, unverified, a secrets-shaped name, not a kind it renders, over the caps). `term` is
- *  stage 2's glossary entry, filled by the lab team's lookup through the same shape. */
-export type PreviewKind = "markdown" | "section" | "image" | "code" | "pdf" | "text" | "term";
+ *  folder and the user's home, unverified, a secrets-shaped name, not a kind it renders, over the caps). A glossary
+ *  term previews as the glossary file's `section` (T375), no kind of its own. */
+export type PreviewKind = "markdown" | "section" | "image" | "code" | "pdf" | "text";
 
 /** THE content contract (docs/reference.md, "The file preview popover"): one shape, whoever fills it. */
 export interface PreviewContent {
   kind: PreviewKind;
-  title: string;                       // the file's name, or the term
-  subtitle?: string;                   // "#slug" for a section, the source path for a term
+  title: string;                       // the file's name
+  subtitle?: string;                   // "#slug" for a section
   body: { markdown?: string; html?: string; text?: string; url?: string; lang?: string };
   note?: string;                       // one line the card says above the body (a missing anchor, why a path is text-only)
-  open?: { label: string; path: string; frag?: string };   // a control to a fuller view; the FILE cards carry none (T369: the link itself opens the file, the user 2026-09-12), the glossary's term card keeps its own
 }
 
 /** `path#slug` → the path and the anchor; a `#` inside a file name is not an anchor unless what follows reads as a

--- a/ui/webview/glossary-links.test.ts
+++ b/ui/webview/glossary-links.test.ts
@@ -5,10 +5,11 @@ import { test } from "node:test";
 import * as assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { pluralForms, linkForms, skipForms, buildMatcher, scanTerms, noLinkZones, seenFromLinked, termContent, TERM_SKIP_SELECTOR, type GlossaryIndex, type GlossaryEntry } from "./glossary-links";
+import { pluralForms, linkForms, skipForms, buildMatcher, scanTerms, noLinkZones, seenFromLinked, TERM_SKIP_SELECTOR, type GlossaryIndex, type GlossaryEntry } from "./glossary-links";
 
 const FIX = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), "..", "tests", "fixtures", "glossary_grammar.json"), "utf8"));
 const IX: GlossaryIndex = { group: "notes-api", path: "~/.claude/glossaries/notes-api.md", skip: FIX.expect.skip, terms: FIX.expect.terms };
+const GL = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "glossary-links.ts"), "utf8");
 const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
@@ -52,29 +53,25 @@ test("the matcher: longest form first, whole word, case-insensitive, Unicode-bou
   assert.deepEqual(scanTerms(t2, m, new Set()).map((s) => s.start), [4, t2.lastIndexOf("tessel")], "only the two prose occurrences");
 });
 
-test("the term card fills the popover's contract from the index, no fetch; a retired term says so first; the cut is a note", () => {
-  const tessel = IX.terms[0] as GlossaryEntry;
-  const c = termContent(tessel, IX);
-  assert.equal(c.kind, "term"); assert.equal(c.title, "tessel");
-  assert.equal(c.subtitle, "unconfirmed · registered 2026-09-11 by web · notes-api");
-  assert.match(c.body.markdown!, /^The fixes from a review/); assert.match(c.body.markdown!, /\*plain words:\* the fixes from a review/); assert.match(c.body.markdown!, /\*scope:\* notes-api team mail/);
-  assert.deepEqual(c.open, { label: "Open glossary", path: IX.path, frag: "tessel" });
-  const spar = termContent(IX.terms[2] as GlossaryEntry, IX);
-  assert.match(spar.body.markdown!, /^\*Retired: say the plain phrase\.\*/);
-  assert.equal(termContent(tessel, { ...IX, truncated: 3 }).note, "3 entries are not linked (the index was cut)", "an older kernel's frame: the sum alone");
-  assert.equal(termContent(tessel, { ...IX, truncated: 3, cutBytes: 3, cutHeadings: 0 }).note, "3 entries beyond the index's byte cap are not linked");
-  assert.equal(termContent(tessel, { ...IX, truncated: 2, cutBytes: 0, cutHeadings: 2 }).note, "2 sections past the heading ceiling are not linked", "a heading cut is named as one, never blamed on the byte cap");
-  assert.equal(termContent(tessel, { ...IX, truncated: 5, cutBytes: 3, cutHeadings: 2 }).note, "3 entries beyond the index's byte cap are not linked; 2 sections past the heading ceiling are not linked");
-  assert.equal(termContent(tessel, IX).note, undefined);
+test("a linked term is a path link to the glossary's section and nothing more: no card of its own, the ordinary link dress (T375)", () => {
+  assert.ok(!GL.includes("termContent"), "the term card builder is gone from the module");
+  assert.ok(!RENDER.includes("if (a.dataset.term)"), "showFilePreview has no term branch: the term rides the file-link road");
+  assert.ok(!RENDER.includes("termContent("), "…and nothing fills a card from the index");
+  assert.match(RENDER, /s\.dataset\.path = m\.index\.path; s\.dataset\.frag = e\.slug;\s*\n\s*s\.dataset\.preview = "markdown";/, "the span carries the glossary path, the slug as the section and the kind the kernel judged");
+  assert.ok(!/s\.title = e\.plainWords/.test(RENDER), "no native title beside the hover card: one mechanism");
   assert.match(TERM_SKIP_SELECTOR, /code, pre, a, \.file-uri-link, h1, h2, h3, h4, h5, h6, \.katex, svg, \.term-link, \.cmt-pop, \.file-preview-pop/);
+  // the dress: a link like any link (the user 2026-09-12): the link colour token, a solid underline, the pointer
+  assert.match(CSS, /\.term-link \{ color: var\(--link\); text-decoration: underline solid; cursor: pointer; \}/);
+  assert.ok(!/\.term-link[^\n]*dotted/.test(CSS) && !/\.term-link[^\n]*cursor: help/.test(CSS), "no dotted underline, no help cursor");
+  assert.ok(!/\.term-link\.term-retired \{ opacity/.test(CSS), "no distinct dress for a retired term either: only the link marks a term");
+  assert.ok(!CSS.includes(".fp-term") && !CSS.includes(".fp-open"), "the card-only styling and the open control's rules are gone");
 });
 
 test("the wiring: the frame per session, the matcher per index, links at the two chat grammars and the mail body, the card on the popover, the click to the viewer", () => {
   assert.match(RENDER, /else if \(m\.type === "glossary" && typeof m\.id === "string"\) \{[\s\S]{0,300}?glossaries\.set\(m\.id, m as GlossaryIndex\);\s*\n\s*relinkTerms\(m\.id\);/);
   assert.equal((RENDER.match(/\blinkTerms\((full|bubble|body)\)/g) || []).length, 6, "the nudge, continue and tagged-template bubbles' full text, the user bubble, the assistant body, the mail body (the review's low: the two bubbles never linked)");
   assert.match(RENDER, /linkifyFileUris\(body, undefined, ev\.spacePaths, ev\.pathLinks, ev\.pathPins, ev\.pathPreview, ev\.pathPreviewWhy\);[^\n]*\n\s*linkTerms\(body\);/, "after the path links, so a path token is never split by a term");
-  assert.match(RENDER, /s\.dataset\.path = m\.index\.path; s\.dataset\.frag = e\.slug;[\s\S]{0,200}?armFilePreview\(s\);/, "a term span is a path link's counterpart: the same hover road");
-  assert.match(RENDER, /if \(a\.dataset\.term\) \{[\s\S]{0,600}?renderFilePreview\(p, termContent\(e, ix\), a\.dataset\.gsid \|\| activeId\);/, "the card from the index, no fetch");
+  assert.match(RENDER, /s\.dataset\.path = m\.index\.path; s\.dataset\.frag = e\.slug;[\s\S]{0,200}?armFilePreview\(s\);/, "a term span IS a path link: the same hover road (the section at the slug through the slice route)");
   assert.match(RENDER, /closest\?\.\("span\.term-link"\)[\s\S]{0,300}?openPath\(s\.dataset\.path \|\| "", s\.dataset\.gsid \|\| activeId, e, s\.dataset\.frag \|\| null\);/, "a click opens the glossary at the heading");
   assert.match(RENDER, /function relinkTerms\(sid: string\): void \{[\s\S]{0,700}?querySelectorAll\("span\.term-link"\)/, "a new index unwraps and re-links the view");
   assert.match(RENDER, /querySelectorAll\("\[data-term-root\]"\)\)\) linkTerms\(root as HTMLElement, sid\);/, "…exactly the marked roots, never every .md (the review's medium)");
@@ -82,7 +79,7 @@ test("the wiring: the frame per session, the matcher per index, links at the two
   assert.doesNotMatch(RENDER, /querySelectorAll\("\.md"\)\)\) linkTerms/, "no relink over every .md");
   assert.equal((RENDER.match(/const full = el\("div", "nudge-full md"\);\s*\n\s*full\.innerHTML = md\(ev\.md\);\s*\n\s*linkTerms\(full\);/g) || []).length, 2,
                "the Continue-send and tagged-template bubbles link at render too (the review's low: built as nudge-full md with no linkTerms, they never linked)");
-  assert.match(CSS, /\.term-link \{ text-decoration: underline dotted;/); assert.match(CSS, /\.term-link\.term-retired \{ opacity: 0\.6; \}/);
+  assert.match(CSS, /\.term-link \{ color: var\(--link\); text-decoration: underline solid; cursor: pointer; \}/, "the ordinary link dress (T375; the dress test above says the rest)");
   // the kernel: the frame on the pusher's cycle beside the comments frame, on its own slot; the route; the byte cap and its /perf note
   assert.match(KERNEL, /gfr = _glossary_frame\(s\["sid"\]\)[\s\S]{0,400}?_send_client\(c, \("glossary", s\["sid"\]\), gfr\)/);
   assert.match(KERNEL, /if p\.startswith\("\/glossary\/"\):[\s\S]{0,300}?_glossary_lookup\(\(q\.get\("sid"\) or \[None\]\)\[0\], unquote\(p\[len\("\/glossary\/"\):\]\)\)/, "the route sits in the GET router beside the file route");

--- a/ui/webview/glossary-links.ts
+++ b/ui/webview/glossary-links.ts
@@ -1,14 +1,12 @@
 // The glossary's client half (T351 stage 2, the user 2026-09-11): the team's coinages, linked where they are written.
 // The kernel ships one INDEX per session (glossary-frame: the author's group file, parsed and bounded by bytes); this
 // module builds the matcher from it and links every whole-word occurrence of a term or its `also` forms (plurals
-// too) in the prose of a message, skipping code, links, headings, math, and the popover cards. The term card is
-// filled from the same index with no fetch (termContent, the file preview popover's contract). Pure: no DOM writes
-// beyond what the caller hands in through `make`. Two limits, by design: a term split across text nodes by an inline
+// too) in the prose of a message, skipping code, links, headings, math, and the popover cards. A linked term is a
+// path link to the glossary file's section (the caller's `make` sets the path, the slug and the preview kind), so the
+// ordinary file-link hover and click serve it; no card of its own (T375). Pure: no DOM writes beyond `make`. Two limits, by design: a term split across text nodes by an inline
 // element (`fo*ld*`, a link inside the words) is not matched, since each text node is scanned alone; and a term inside
 // a path-shaped or host-shaped token (docs/widget/x.md, example.com/y) is never linked, so a path a session named but
 // the kernel could not verify is not split by an underline (the review's medium).
-import type { PreviewContent } from "./file-preview";
-
 export type GlossaryLink = "all" | "first" | "off";
 export interface GlossaryEntry {
   term: string; slug: string; definition: string; plainWords: string; also: string[]; scope: string;
@@ -153,24 +151,4 @@ export function linkifyTerms(root: ParentNode, m: TermMatcher, make: (e: Glossar
     count += spans.length;
   }
   return count;
-}
-
-/** The term card, in the file preview popover's contract: the term, its status and registration as the subtitle,
- *  the definition and the plain words as the body, "Open glossary" landing the viewer on the term's heading. A
- *  retired term says so first. */
-export function termContent(e: GlossaryEntry, ix: GlossaryIndex): PreviewContent {
-  const reg = e.registered && (e.registered.date || e.registered.by)
-    ? " · registered " + [e.registered.date, e.registered.by ? "by " + e.registered.by : ""].filter(Boolean).join(" ") : "";
-  const retired = e.status === "retired";
-  const body = (retired ? "*Retired: say the plain phrase.*\n\n" : "") + (e.definition || "")
-    + (e.plainWords ? "\n\n*plain words:* " + e.plainWords : "")
-    + (e.scope ? "\n\n*scope:* " + e.scope : "");
-  // the index's cuts, each named for what cut it (the review's low: a heading-ceiling cut was blamed on the byte cap)
-  const notes: string[] = [];
-  if (ix.cutBytes) notes.push(ix.cutBytes + " entries beyond the index's byte cap are not linked");
-  if (ix.cutHeadings) notes.push(ix.cutHeadings + " sections past the heading ceiling are not linked");
-  if (!notes.length && ix.truncated) notes.push(ix.truncated + " entries are not linked (the index was cut)");   // an older kernel: the sum alone
-  return { kind: "term", title: e.term, subtitle: (e.status || "unconfirmed") + reg + " · " + ix.group,
-           body: { markdown: body }, note: notes.length ? notes.join("; ") : undefined,
-           open: { label: "Open glossary", path: ix.path, frag: e.slug } };
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -74,7 +74,7 @@ import { viewerPathGate } from "./file-view-links";       // the viewer's code-a
 import { isMarkdownUrl } from "./md-links";
 import { openPathLink, linkifyPathTokens, selectionOpenIn, type PathLinkOptions } from "./path-links";   // the path matcher the chat's links are made from (a shared module)
 import { PREVIEW_DWELL_MS, PREVIEW_GRACE_MS, HoverIntent, parsePreviewLink, previewKindOf, sliceUrl, contentFor, textOnlyContent, stripRemoteLoads, type PreviewContent } from "./file-preview";
-import { buildMatcher, linkifyTerms, termContent, type GlossaryIndex, type GlossaryEntry, type TermMatcher } from "./glossary-links";   // the team's coinages, linked where written (T351 stage 2)   // the file preview popover's pure half (T351)
+import { buildMatcher, linkifyTerms, type GlossaryIndex, type TermMatcher } from "./glossary-links";   // the team's coinages, linked where written (T351 stage 2)   // the file preview popover's pure half (T351)
 import { initFileBrowse, openFileBrowse } from "./file-browse";   // the browser is pane-local here now (the user 2026-08-24)
 import { pastedFilePath } from "./paste-path";
 import { insertAtCaret } from "./composer-insert";
@@ -2215,10 +2215,11 @@ function absorbFragment(link: HTMLElement): void {
 // ── the GLOSSARY (T351 stage 2, the user 2026-09-11): the team's coinages, linked where they are written ──────────
 // The kernel ships one index per session (its author group's glossary file, parsed and byte-bounded) on its own frame;
 // the matcher is compiled once per index and every message's prose is linked at render time (glossary-links.ts). A
-// term wears a quiet dotted underline in the text colour (.term-link); its card rides the file preview popover with no
-// fetch (termContent), and a click opens the glossary file in the viewer at the term's heading. Surfaces: assistant and
-// user text and mail bodies in the chat; never tool heads, the composer or the timeline. The DRESS (design A, the
-// underline and hover card, or design B, a marker and click popover) is the user's pick; the mechanics are the same.
+// term is a LINK to the glossary file's section and nothing more (T375, the user 2026-09-12): it wears the ordinary link
+// dress (.term-link: the link colour, a solid underline, the pointer), its hover rides the ordinary file-link preview
+// (the glossary path with the term's slug as the section, fetched through the slice route and rendered like any file
+// section), and a click opens the glossary file in the viewer at the term's heading. Surfaces: assistant and user text
+// and mail bodies in the chat; never tool heads, the composer or the timeline.
 const glossaries = new Map<string, GlossaryIndex>();        // by session id: the frame's index
 const termMatchers = new Map<string, TermMatcher | null>();  // compiled once per index (dropped when the frame changes)
 function termMatcherFor(sid: string | null): TermMatcher | null {
@@ -2244,9 +2245,9 @@ function linkTerms(root: HTMLElement, sid: string | null = renderingSid): number
     s.textContent = text;
     s.dataset.term = e.slug; s.dataset.gsid = sid || "";
     s.dataset.path = m.index.path; s.dataset.frag = e.slug;
-    s.title = e.plainWords ? e.term + ": " + e.plainWords : e.term;
+    s.dataset.preview = "markdown";   // the kind, from the index: the kernel parsed this file as the group's glossary (T375)
     s.tabIndex = 0;
-    armFilePreview(s);   // the hover card (the popover's dwell and grace), filled from the index without a fetch
+    armFilePreview(s);   // the ordinary file-link hover: the section at the term's heading, through the slice route (no title: one mechanism)
     return s;
   });
 }
@@ -2342,12 +2343,6 @@ function renderFilePreview(p: HTMLElement, c: PreviewContent, sid: string | null
   const head = el("div", "fp-head");
   const title = el("span", "fp-title"); title.textContent = c.title; title.title = c.title; head.appendChild(title);
   if (c.subtitle) { const s = el("span", "fp-sub"); s.textContent = c.subtitle; head.appendChild(s); }
-  if (c.open) {
-    const b = el("button", "fp-open") as HTMLButtonElement; b.type = "button"; b.textContent = c.open.label; b.title = "the whole file, in the viewer";
-    const { path, frag } = c.open;
-    b.addEventListener("click", (e) => { e.stopPropagation(); filePreviewIntent.cancel(); openPath(path, sid, e, frag || null); });
-    head.appendChild(b);
-  }
   p.appendChild(head);
   if (c.note) { const n = el("div", "fp-note"); n.textContent = c.note; p.appendChild(n); }
   const body = el("div", "fp-body fp-" + c.kind);
@@ -2386,23 +2381,6 @@ function previewMdClean(src: string): HTMLElement {
 function showFilePreview(a: HTMLElement): void {
   const open = a.dataset.path || "";
   if (!open) return;
-  if (a.dataset.term) {   // a glossary term (T351 stage 2): the card is filled from the session's index, no request
-    const ix = glossaries.get(a.dataset.gsid || "");
-    const e = ix ? ix.terms.find((x) => x.slug === a.dataset.term) : undefined;
-    if (!ix || !e) return;
-    const p = ensureFilePreview();
-    placeFilePreview(p, a);
-    p.style.display = "";
-    watchFilePreviewAnchor(a);
-    ++filePreviewSeq;
-    renderFilePreview(p, termContent(e, ix), a.dataset.gsid || activeId);
-    // a term card is a few lines: it keeps the file card's width cap but sizes its height to its content (the pane
-    // fraction stays the ceiling), so it never sits mostly empty
-    p.style.maxHeight = p.style.height; p.style.height = "auto";
-    p.style.width = Math.min(parseFloat(p.style.width) || 520, 520) + "px";
-    p.dataset.renderMs = "0"; delete p.dataset.sliceHit;
-    return;
-  }
   const sid = activeId;                          // the kernel resolves a relative path against it and confines by its folder
   const parsed = parsePreviewLink(open);
   const path = parsed.path, anchor = a.dataset.frag || parsed.anchor;   // the section: the absorbed #slug, else one inside a file:// URI

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3663,8 +3663,6 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 .file-preview-pop .fp-head { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
 .file-preview-pop .fp-title { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .file-preview-pop .fp-sub { color: var(--dim); font-family: ui-monospace, monospace; font-size: 0.86em; white-space: nowrap; }
-.file-preview-pop .fp-open { margin-left: auto; flex: 0 0 auto; cursor: pointer; background: transparent; color: var(--accent); border: 1px solid var(--card-border); border-radius: 5px; padding: 2px 10px; font: inherit; font-weight: 600; }
-.file-preview-pop .fp-open:hover { background: var(--accent-wash); }
 .file-preview-pop .fp-note { color: var(--dim); font-style: italic; }
 .file-preview-pop .fp-body { flex: 1 1 auto; min-height: 0; overflow: auto; }
 .file-preview-pop .fp-body.fp-image { display: flex; align-items: center; justify-content: center; }
@@ -3676,9 +3674,10 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 /* a callout (md-wiki.ts calloutBlockquote): the kind as a small label at the top of its blockquote */
 /* the glossary's term links (T351 stage 2, design A): a quiet dotted underline in the text colour, no colour change;
    a retired term greys (its card says to use the plain phrase) */
-.term-link { text-decoration: underline dotted; text-decoration-thickness: 1px; text-underline-offset: 3px; cursor: help; }
-.term-link:hover, .term-link:focus-visible { text-decoration-style: solid; outline: none; }
-.term-link.term-retired { opacity: 0.6; }
+/* a glossary term is a link to the glossary's section and dresses as one (T375, the user 2026-09-12): the link colour,
+   a solid underline, the pointer; nothing else marks it */
+.term-link { color: var(--link); text-decoration: underline solid; cursor: pointer; }
+.term-link:focus-visible { outline: none; }
 .md-callout-label { font-size: 0.72em; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--accent); margin: 0 0 2px; }
 /* the popover's boot loader (the user 2026-08-25: a fresh thread flashed the plain msgs projection
    before jumping into the chat rendering) — the standard romp loader holds the conversation area


### PR DESCRIPTION
Testing the glossary live, the user found that hovering a term showed a card of its own that defined the term, a second mechanism on top of the generic file-link hover, and asked for the generic one alone (2026-09-12). A minute later: the dress should be a link's, a solid underline, the pointer and the link colour, not a dotted underline with the help cursor. That settles the design question as well: plain links.

**What changes**

- A linked term is a path link to the glossary file's section: the glossary path, the term's slug as the absorbed section, and the preview kind from the index the kernel shipped. Its hover rides the ordinary file-link road, so the popover fetches the slice route for the glossary path at that heading and renders the section, the definition through its bullets, exactly as hovering any file link with a section does. The click opens the viewer at the heading as before. There is no native title beside the hover.
- The term content kind, the card builder and the data-term branch are gone, and with the last card that carried one, the open control's field, renderer and styles.
- The dress is the link's: the link colour token, a solid underline, the pointer. No dotted style, no help cursor, no distinct dress for a retired term.
- The user's glossary files are outside the slice route's content belt: every section of a glossary already reaches the page whole through the index frame and the route, so a credential-shaped example line in a coinage's definition must not turn every term's hover into the text card. The same line in a project notes file is still refused.
- Kept: the per-session index frame, the link modes, the Not-coinages skip, and the glossary route lab_manager's consumers read.

**Tests, red first on main.** The glossary unit test pins the span's path, slug and kind, the absence of the card branch and the title, and the dress. The served glossary lab hovers a term and asserts one slice fetch for the glossary path at the term's slug, the section card with the definition and its bullets, no term card, the dress, and a coinage whose definition carries a credential-shaped example line previewing whole. The slice test covers the belt exemption. The stage 1 preview labs are untouched and rerun.

Tier: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
