### PR TITLE
The converge pass writes an idle leaf's assembly document from the boot's own parse, so the next boot reads its tail (T376)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1041,8 +1041,9 @@ half handles the assembly write runs inside the same hold, before the held drop
 pops that entry, and both documents come from the one read; no read of records,
 charged to the same cycle budget. A leaf is looked at once per file state:
 written, or refused for a property of its cut, it is done; a blip is tried
-twice; a leaf with no whole entry to write from is re-examined each cycle and
-counted once. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
+twice (a blip inside the fold half's hold gets its second try over the entry
+the paid drop popped, so that leaf waits for the next boot's read); a leaf with
+no whole entry to write from is re-examined each cycle and counted once. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
 own switch and a zero byte budget, as for the drop write. The owed table
 is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1030,7 +1030,14 @@ The knobs: `ROMP_CKPT_CONVERGE_MS=0` turns the pass off and the drop write with
 it (the drop then pops as it did before the write existed); `ROMP_CKPT_CONVERGE_MB`
 is the cycle budget both charge, and `0` turns the drop write off the same way
 rather than deferring every drop; both are read where the drop lives, so they
-hold from the first fold, before the first pusher cycle begins. The owed table
+hold from the first fold, before the first pusher cycle begins. The pass also
+writes the ASSEMBLY document of an idle leaf that has none (the assembly
+document is otherwise written only at a settle, which an idle session never
+reaches, so the parse read those leaves whole at every boot: 31 of 60 on the
+devbox, about 2.5 GB): from the whole assembly entry the boot's own parse built,
+through the settle's writer, no read of records, charged to the same cycle
+budget, once per file state (written, or refused for a property of its cut);
+`ROMP_ASM_CONVERGE=0` turns that step off, and the pass's own switch covers it. The owed table
 is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under
@@ -1489,7 +1496,10 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   (`noEntry`, `restored`, `written`, `noBoundary`, `unsplittable`,
   `reconstruction`, `oversize`, `unencodable`, `offsets`, `stat`, `write`),
   `hydratedAtoms` and `hydratedBytes` (bodies read on demand for atoms before
-  a cut) and `hydratedBy` (those bytes per calling function).
+  a cut), `hydratedBy` (those bytes per calling function), and `converge`: the
+  pass's writes of idle leaves' documents from the boot's own parse
+  (`candidates`, `writes`, `bytes`, `deferred`, `skipped` per the writer's
+  reason).
 - `asmIndex`: the lazy index (T323 stage 4c) a restored session's pre-cut turns
   come from: `materialized` atoms built from the document's rows since boot,
   `materializedBy` (per consumer), `resident` (the process-wide LRU, `cap`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1035,9 +1035,15 @@ writes the ASSEMBLY document of an idle leaf that has none (the assembly
 document is otherwise written only at a settle, which an idle session never
 reaches, so the parse read those leaves whole at every boot: 31 of 60 on the
 devbox, about 2.5 GB): from the whole assembly entry the boot's own parse built,
-through the settle's writer, no read of records, charged to the same cycle
-budget, once per file state (written, or refused for a property of its cut);
-`ROMP_ASM_CONVERGE=0` turns that step off, and the pass's own switch covers it. The owed table
+through the settle's writer, while the reader's whole record entry is still
+resident (the writer takes its record offsets from it), so for a leaf the fold
+half handles the assembly write runs inside the same hold, before the held drop
+pops that entry, and both documents come from the one read; no read of records,
+charged to the same cycle budget. A leaf is looked at once per file state:
+written, or refused for a property of its cut, it is done; a blip is tried
+twice; a leaf with no whole entry to write from is re-examined each cycle and
+counted once. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
+own switch and a zero byte budget, as for the drop write. The owed table
 is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent
 file's whole entry (two minutes) is refused by the pass and counted under

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4998,50 +4998,55 @@ def _tree_key(tree):
     return (id(tree), len(turns), turns[-1].get("id") if turns else None)
 
 
-def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None):
+def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason_out=None, who="settle"):
     """Write the leaf's assembly checkpoint from its WHOLE assembly entry. False when there is nothing to write: no
     entry, an entry restored from a document (its cut stands until a compaction moves it), no compaction boundary in
     the tree (the whole file would be the tail), a cut that would not split the chronological order the fold's gate
-    needs (garbled stamps), or a document past the cap; each counted under asmCheckpoint.skipped."""
+    needs (garbled stamps), or a document past the cap; each counted under asmCheckpoint.skipped, and appended to
+    `reason_out` when a list is given (the converge pass reads its refusal there; T376 review). `who` names the caller
+    in the blip line (the settle, the converge pass), said once per leaf and reason."""
     cp = _asm_ckpt_file(leaf_path)
     if cp is None:
         return False
+
+    def _skip(reason):
+        if reason_out is not None:
+            reason_out.append(reason)
+        return _asm_ckpt_skip(reason)
     key = (os.path.realpath(str(leaf_path)), str(rompuuid), bool(sdk_human))
     with _asm_key_lock(key):
         with _ASM_LOCK:
             entry = _ASM_CACHE.get(key)
         if entry is None:
-            return _asm_ckpt_skip("noEntry")
+            return _skip("noEntry")
         if entry.get("prefix") or entry.get("preTurns"):
-            return _asm_ckpt_skip("restored")            # the document it came from stands
+            return _skip("restored")            # the document it came from stands
         if entry.get("docWritten") and cp.exists() and (tree is None or entry.get("docTurns")
                                                           or entry.get("docNoTurns") == _tree_key(tree)):
-            return _asm_ckpt_skip("written")             # this entry's pre-cut part has not moved (a fold appends after the cut);
+            return _skip("written")             # this entry's pre-cut part has not moved (a fold appends after the cut);
         #                                                  a document written without a tree is written again once one is given,
         #                                                  one whose tree yielded no section is not, for that tree (review low 4)
         ad = entry["ad"]
         atoms = entry["atoms"]
         bounds = [a for a in atoms if a.get("type") == "system" and a.get("subtype") == "compact_boundary"]
         if not bounds:
-            return _asm_ckpt_skip("noBoundary")
+            return _skip("noBoundary")
         active = ad.active_path()
         verdicts = ad.chain_verdicts(active)
         turns = segment_turns([dict(a) for a in atoms], rompuuid)
         last_b = max(bounds, key=lambda a: (a["t"], a.get("_seq", 0)))
         memo = entry.get("docSkip")
         if memo is not None and memo[0] == last_b["uuid"]:
-            return _asm_ckpt_skip(memo[1])               # this cut already failed to write: nothing rebuilt until it moves
+            return _skip(memo[1])               # this cut already failed to write: nothing rebuilt until it moves
 
         def skip(reason):
             if reason in _ASM_SKIP_STRUCTURAL:            # a property of this cut: memoized like a success (docWritten),
                 entry["docSkip"] = (last_b["uuid"], reason)   #  re-armed when the cut moves
                 _say_once("assembly checkpoint: %s not written: %s (said once until its cut moves)" % (leaf_path, reason))
             else:                                         # a blip (a stat or a write failing, a record landing between the
-                try:                                      #  parse and the offsets): said each time, tried again next settle
-                    sys.stderr.write("assembly checkpoint: %s not written this settle: %s\n" % (leaf_path, reason))
-                except Exception:
-                    pass
-            return _asm_ckpt_skip(reason)
+                _say_once("assembly checkpoint: %s not written by the %s: %s (said once per leaf; tried again at the next %s)"
+                          % (leaf_path, who, reason, who))   #  parse and the offsets): named for its caller, once per leaf
+            return _skip(reason)
         bi = next(i for i, t in enumerate(turns) if any(a.get("uuid") == last_b["uuid"] for a in t["atoms"]))
         if last_b["uuid"] in ad._adopted and bi > 0:
             bi -= 1                                       # an adopted manual compact: its /compact episode is the turn before
@@ -5694,9 +5699,12 @@ def hydrate(atoms, rompuuid=None, by=None):
         return 0
     if by is None:
         try:
-            by = sys._getframe(1).f_code.co_name
-            if by in _HYDRATE_TEXT_READERS:               # a text reader every walker shares says nothing about WHO walked: its
-                by = "%s<-%s" % (by, sys._getframe(2).f_code.co_name)   #  own caller is recorded with it (T377: naming the boot's reader)
+            f = sys._getframe(1); by = f.f_code.co_name
+            if by in _HYDRATE_TEXT_READERS:               # a text reader every walker shares says nothing about WHO walked: the
+                g = f.f_back                              #  first caller outside the shared readers is recorded with it (T377:
+                while g is not None and g.f_code.co_name in _HYDRATE_TEXT_READERS:   #  naming the boot's reader; a reader reached
+                    g = g.f_back                          #  through another reader still names the walker)
+                by = "%s<-%s" % (by, g.f_code.co_name if g is not None else "?")
         except Exception:
             by = "?"
     filled, by_file = 0, {}

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4806,7 +4806,10 @@ def asm_index_stats():
                 "restoredTurns": _ASM_INDEX_STATS["restoredTurns"], "rowDecodes": _ASM_INDEX_STATS["rowDecodes"]}
 _ASM_CKPT_CAP = 16 * 1024 * 1024   # a document past this is not written (counted): that session parses whole as today
 _ASM_CKPT_STATS = {"written": 0, "restored": 0, "fallbacks": {}, "skipped": {}, "hydratedBytes": 0, "hydratedAtoms": 0,
-                   "hydratedBy": {}}     # bytes per calling function: a whole-tree hydration anywhere shows here
+                   "hydratedBy": {},     # bytes per calling function: a whole-tree hydration anywhere shows here
+                   "converge": {"writes": 0, "bytes": 0, "deferred": 0, "candidates": 0, "skipped": {}}}   # the pass's writes for
+#                                          idle leaves from the boot's own parse (T376): looked at, written, deferred for the budget,
+#                                          skipped per the writer's reason
 _ASM_CKPT_LOCK = threading.Lock()
 _ASM_CKPT_SAID = set()             # (path, reason) said once per process
 _LAZY_FILES = {}                   # rompuuid -> {fsid: path}: where hydrate finds a lazy atom's record
@@ -4855,7 +4858,31 @@ def asm_checkpoint_stats():
     with _ASM_CKPT_LOCK:
         out = dict(_ASM_CKPT_STATS); out["fallbacks"] = dict(out["fallbacks"]); out["skipped"] = dict(out["skipped"])
         out["hydratedBy"] = dict(out["hydratedBy"])
+        cv = out["converge"] = dict(out["converge"]); cv["skipped"] = dict(cv["skipped"])
     return out
+
+
+def asm_converge_stat(name, n=1):
+    """Count the converge pass's assembly work under asmCheckpoint.converge (T376)."""
+    with _ASM_CKPT_LOCK:
+        cv = _ASM_CKPT_STATS["converge"]
+        cv[name] = cv.get(name, 0) + n
+
+
+def asm_converge_skip(reason):
+    with _ASM_CKPT_LOCK:
+        sk = _ASM_CKPT_STATS["converge"]["skipped"]
+        sk[reason] = sk.get(reason, 0) + 1
+
+
+def asm_entry_whole(leaf_path, rompuuid, sdk_human=False):
+    """Whether this process holds a WHOLE (unrestored) assembly entry for the session over `leaf_path`: the boot's own parse,
+    which the converge pass writes an idle leaf's document from (T376); a restored entry's document already stands, and no
+    entry means no write (never a parse of the pass's own)."""
+    key = (os.path.realpath(str(leaf_path)), str(rompuuid), bool(sdk_human))
+    with _ASM_LOCK:
+        entry = _ASM_CACHE.get(key)
+    return entry is not None and not entry.get("prefix") and not entry.get("preTurns")
 
 
 def _atom_kind(a):
@@ -5620,6 +5647,9 @@ def _hydrate_one(a, rec):
     a.pop("lazy", None)
 
 
+_HYDRATE_TEXT_READERS = ("_unit_text", "_prompt_text", "_atom_text")   # the judges' shared text readers: attributed with their caller
+
+
 def hydrate(atoms, rompuuid=None, by=None):
     """Fill the bodies of the lazy atoms among `atoms` (a list, a turn's atoms, a whole session's turns) from their
     records on disk, one open per file and one seek-read per atom, through a byte-capped memo; returns how many
@@ -5634,6 +5664,8 @@ def hydrate(atoms, rompuuid=None, by=None):
     if by is None:
         try:
             by = sys._getframe(1).f_code.co_name
+            if by in _HYDRATE_TEXT_READERS:               # a text reader every walker shares says nothing about WHO walked: its
+                by = "%s<-%s" % (by, sys._getframe(2).f_code.co_name)   #  own caller is recorded with it (T377: naming the boot's reader)
         except Exception:
             by = "?"
     filled, by_file = 0, {}

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9982,8 +9982,10 @@ def _converge_checkpoints(now):
             else:
                 unhealed = em.drop_cold_cursors(p)
             if quiescent:                                  # the ASSEMBLY document from the same resident read, BEFORE the held drop
-                _converge_assembly_leaf(p, leaf_sid.get(p), t0)   #  pops the record entry (T376 round one, medium: the pop came first
-        #                                                    and the assembly writer found no record entry for its offsets)
+                try:                                       #  pops the record entry (T376 round one, medium: the pop came first and
+                    _converge_assembly_leaf(p, leaf_sid.get(p), t0)   #  the assembly writer found no record entry for its offsets); a
+                except Exception:                          #  raise here must not discard the held drop or abort the cycle (round two)
+                    sys.stderr.write("assembly converge: %s\n" % traceback.format_exc())
         if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
             em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
         if em.pay_held_drops().get(p) and quiescent:       # the held drop wrote the document from the boot's read (converge.dropWrites,
@@ -10023,10 +10025,12 @@ def _converge_assembly(now, t0):
     per file and the cut's guard. Charged to the cycle's byte budget (an estimate from the leaf's size, trued up), deferred
     over it; bounded by the pass's wall; off with the drop write (a zero budget). A leaf is looked at once per file state:
     written, or refused by the writer for a property of its cut (no boundary, an unsplittable cut, an oversize document), it
-    enters the done table; a blip (a stat, the offsets) is tried twice; a leaf with no entry to write from is re-examined each
-    cycle (counted once), never parsed or read by the pass. Live leaves are the settle's. The fold half of the pass writes a
-    candidate leaf's assembly document itself, inside its hold, before the held drop pops the record entry
-    (`_converge_assembly_leaf`); this step covers the leaves the fold half did not touch. Returns the documents written."""
+    enters the done table; a blip (a stat, the offsets) is tried twice, the second time on a later cycle (a blip inside the
+    fold half's hold gets its second try from this step in the same cycle, over the entry the paid drop popped, so that leaf
+    waits for the next boot's read; round two, low 1); a leaf with no entry to write from is re-examined each cycle (counted
+    once), never parsed or read by the pass. Live leaves are the settle's. The fold half of the pass writes a candidate leaf's
+    assembly document itself, inside its hold, before the held drop pops the record entry (`_converge_assembly_leaf`); this
+    step covers the leaves the fold half did not touch. Returns the documents written."""
     if not ASM_CONVERGE or not em.checkpoint_drop_writes_on():
         return 0
     n = 0
@@ -10036,7 +10040,10 @@ def _converge_assembly(now, t0):
             continue
         if time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0:
             break                                          # the cycle's wall: the rest wait for the next one
-        r = _converge_assembly_leaf(str(leaf), sid, t0)
+        try:
+            r = _converge_assembly_leaf(str(leaf), sid, t0)
+        except Exception:                                  # one leaf's raise (a stat, a backend hook) leaves the rest their turn
+            sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); continue
         if r is None:
             break                                          # the budget: the rest wait for the next cycle
         n += 1 if r else 0

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9826,6 +9826,8 @@ CKPT_PERIOD_S = float(os.environ.get("ROMP_CKPT_PERIOD_S", "30"))   # a session 
 CKPT_CONVERGE_MS = em._CKPT_CONVERGE_MS_DEFAULT   # the converge pass's wall budget per pusher cycle (T360); 0 turns the pass off and the
 #                                                    quiescence drop's write with it (T362); the event model reads the knob so both reach
 #                                                    the drop before the first cycle begins
+ASM_CONVERGE = os.environ.get("ROMP_ASM_CONVERGE", "1") != "0"   # the pass writes idle leaves' ASSEMBLY documents from the boot's own
+#                                                                    parse (T376); 0 turns that off (the pass's own switch covers it too)
 CKPT_CONVERGE_BYTES = em._CKPT_CYCLE_CAP_DEFAULT   # ...and its bytes (documents written plus leaves read for a heal), the cycle budget the
 #                                                     quiescence drop's writes share (T362); 0 turns those writes off too (the drop then pops as before)
 
@@ -9934,16 +9936,20 @@ def _converge_checkpoints(now):
     so an idle session's document is written once and then left alone. A quiescent leaf (T361) is refused unless the boot's
     own whole read is still resident, in which case the prime's launch fold writes its document at the quiescence drop from
     that read (`viaDrop`), no read of the pass's own. Returns the documents written."""
-    if CKPT_CONVERGE_MS <= 0 or not em.checkpoint_has_work():
+    if CKPT_CONVERGE_MS <= 0:
         _CKPT_JUST_WRITTEN.clear()
-        return 0                                           # off (ROMP_CKPT_CONVERGE_MS=0), or nothing dirty and nothing cold: a quiet
-    just_written = set(_CKPT_JUST_WRITTEN); _CKPT_JUST_WRITTEN.clear()   #  cycle costs the pass no lock and no stat (T361)
+        return 0                                           # off (ROMP_CKPT_CONVERGE_MS=0): neither the fold documents nor the assembly ones
+    t0 = time.monotonic()
+    if not em.checkpoint_has_work():
+        _CKPT_JUST_WRITTEN.clear()                         # nothing dirty and nothing cold: the fold work costs no lock and no stat
+        return _converge_assembly(now, t0)                 #  (T361); the assembly step has its own done table (T376)
+    just_written = set(_CKPT_JUST_WRITTEN); _CKPT_JUST_WRITTEN.clear()
     cands = [p for p in em.checkpoint_converge_candidates() if p not in just_written and not _converge_skipped(p)]
     if not cands:
-        return 0
+        return _converge_assembly(now, t0)
     em.converge_stat("passes")
     leaves = {str(s.get("path")) for s in _sessions(now) if s.get("path")}
-    t0 = time.monotonic(); n = 0
+    n = 0
     for i, p in enumerate(cands):
         if i and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or not em.checkpoint_cycle_room(0)):
             em.converge_stat("deferred", len(cands) - i)   # gated on candidates PROCESSED, not documents written: a first
@@ -9990,6 +9996,82 @@ def _converge_checkpoints(now):
             em.converge_stat("writes"); em.converge_stat("bytes", size); em.checkpoint_cycle_charge(size)
         else:
             em.converge_stat("failed"); _converge_skip(p)  # nothing to write, or the write failed: not again until the file changes
+    return n + _converge_assembly(now, t0)
+
+
+_ASM_CONVERGE_DONE = {}             # leaf -> the file's (mtime_ns, size) once its assembly document stands, was written here, or the
+#                                     writer refused it for a property of its cut (T376): looked at once per file state, never per cycle
+_ASM_CONVERGE_BLIP = {}             # leaf -> the file state under which the writer's one blip retry was spent
+_ASM_CONVERGE_NOENTRY = {}          # leaf -> the file state under which "no entry" was counted (once, not per cycle)
+_ASM_STRUCTURAL = set(em._ASM_SKIP_STRUCTURAL) | {"noBoundary", "written", "restored"}   # the writer's reasons that hold until the cut moves
+
+
+def _converge_assembly(now, t0):
+    """The converge pass's assembly step (T376): an idle session never settles, so its leaf never had an assembly document
+    and the parse read it whole at every boot (31 of 60 leaves on the devbox, about 2.5 GB, the boot's remaining cost).
+    For every session leaf that is quiescent, has no assembly document on disk, and whose WHOLE assembly entry the boot's own
+    parse built is in memory, the document is written from that entry through the settle's writer (`asm_checkpoint_write`,
+    with the parse store's tree as the settle hands it): no read of records, a stat per file and the cut's guard. Charged to
+    the cycle's byte budget (an estimate from the leaf's size, trued up), deferred over it; bounded by the pass's wall. A
+    leaf is looked at once per file state: written, or refused by the writer for a property of its cut (no boundary, an
+    unsplittable cut, an oversize document), it enters the done table; a blip (a stat, the offsets) is retried once; no entry
+    in the assembly cache is a counted skip, never a parse of the pass's own. Live leaves are the settle's. Returns the
+    documents written."""
+    if not ASM_CONVERGE:
+        return 0
+    for table in (_ASM_CONVERGE_DONE, _ASM_CONVERGE_BLIP, _ASM_CONVERGE_NOENTRY):
+        if len(table) > 4096:                              # bounded like the pass's skip table (a leaf per session ever seen)
+            table.clear()
+    n = 0
+    for s in _sessions(now):
+        leaf, sid = s.get("path"), s.get("sid")
+        if not leaf or not sid:
+            continue
+        key = str(leaf)
+        st = _stat_key_ns(key)
+        if st is None or _ASM_CONVERGE_DONE.get(key) == st:
+            continue
+        if time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0:
+            break                                          # the cycle's wall: the rest wait for the next one
+        cp = em._asm_ckpt_file(key)
+        if cp is None:
+            return n
+        if cp.exists():
+            _ASM_CONVERGE_DONE[key] = st                   # the settle's document, or an earlier cycle's, stands
+            continue
+        if not em.file_quiescent(key):
+            continue                                       # a live leaf: its settle writes the document
+        human = _display_sdk_human(sid)
+        if not em.asm_entry_whole(key, sid, human):
+            if _ASM_CONVERGE_NOENTRY.get(key) != st:       # the parse never ran here, or the entry left the cache: nothing to write
+                _ASM_CONVERGE_NOENTRY[key] = st; em.asm_converge_skip("noEntry")   #  from, and never a parse of our own
+            continue
+        em.asm_converge_stat("candidates")
+        est = max(4096, st[1] // 64)
+        if not em.checkpoint_cycle_take(est):
+            em.asm_converge_stat("deferred")
+            break
+        before = em.asm_checkpoint_stats()["skipped"]
+        try:
+            wrote = em.asm_checkpoint_write(key, sid, human, tree=_stored_tree(key, sid))
+        except Exception:
+            sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); wrote = False
+        if wrote:
+            try:
+                size = cp.stat().st_size
+            except OSError:
+                size = 0
+            em.asm_converge_stat("writes"); em.asm_converge_stat("bytes", size); em.checkpoint_cycle_charge(size - est)
+            _ASM_CONVERGE_DONE[key] = st; n += 1
+            continue
+        em.checkpoint_cycle_charge(-est)                   # nothing written: the take goes back
+        after = em.asm_checkpoint_stats()["skipped"]
+        reason = next((r for r in after if after[r] > before.get(r, 0)), "failed")
+        em.asm_converge_skip(reason)
+        if reason in _ASM_STRUCTURAL or _ASM_CONVERGE_BLIP.get(key) == st:
+            _ASM_CONVERGE_DONE[key] = st                   # a property of the cut, or the blip's one retry spent: done for this file state
+        else:
+            _ASM_CONVERGE_BLIP[key] = st
     return n
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9948,7 +9948,8 @@ def _converge_checkpoints(now):
     if not cands:
         return _converge_assembly(now, t0)
     em.converge_stat("passes")
-    leaves = {str(s.get("path")) for s in _sessions(now) if s.get("path")}
+    leaf_sid = {str(s.get("path")): s.get("sid") for s in _sessions(now) if s.get("path")}
+    leaves = set(leaf_sid)
     n = 0
     for i, p in enumerate(cands):
         if i and (time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0 or not em.checkpoint_cycle_room(0)):
@@ -9980,6 +9981,9 @@ def _converge_checkpoints(now):
                     em.converge_stat("primed")
             else:
                 unhealed = em.drop_cold_cursors(p)
+            if quiescent:                                  # the ASSEMBLY document from the same resident read, BEFORE the held drop
+                _converge_assembly_leaf(p, leaf_sid.get(p), t0)   #  pops the record entry (T376 round one, medium: the pop came first
+        #                                                    and the assembly writer found no record entry for its offsets)
         if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
             em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
         if em.pay_held_drops().get(p) and quiescent:       # the held drop wrote the document from the boot's read (converge.dropWrites,
@@ -10014,70 +10018,85 @@ def _converge_assembly(now, t0):
     """The converge pass's assembly step (T376): an idle session never settles, so its leaf never had an assembly document
     and the parse read it whole at every boot (31 of 60 leaves on the devbox, about 2.5 GB, the boot's remaining cost).
     For every session leaf that is quiescent, has no assembly document on disk, and whose WHOLE assembly entry the boot's own
-    parse built is in memory, the document is written from that entry through the settle's writer (`asm_checkpoint_write`,
-    with the parse store's tree as the settle hands it): no read of records, a stat per file and the cut's guard. Charged to
-    the cycle's byte budget (an estimate from the leaf's size, trued up), deferred over it; bounded by the pass's wall. A
-    leaf is looked at once per file state: written, or refused by the writer for a property of its cut (no boundary, an
-    unsplittable cut, an oversize document), it enters the done table; a blip (a stat, the offsets) is retried once; no entry
-    in the assembly cache is a counted skip, never a parse of the pass's own. Live leaves are the settle's. Returns the
-    documents written."""
-    if not ASM_CONVERGE:
+    parse built is in memory beside the reader's whole record entry, the document is written from that entry through the
+    settle's writer (`asm_checkpoint_write`, with the parse store's tree as the settle hands it): no read of records, a stat
+    per file and the cut's guard. Charged to the cycle's byte budget (an estimate from the leaf's size, trued up), deferred
+    over it; bounded by the pass's wall; off with the drop write (a zero budget). A leaf is looked at once per file state:
+    written, or refused by the writer for a property of its cut (no boundary, an unsplittable cut, an oversize document), it
+    enters the done table; a blip (a stat, the offsets) is tried twice; a leaf with no entry to write from is re-examined each
+    cycle (counted once), never parsed or read by the pass. Live leaves are the settle's. The fold half of the pass writes a
+    candidate leaf's assembly document itself, inside its hold, before the held drop pops the record entry
+    (`_converge_assembly_leaf`); this step covers the leaves the fold half did not touch. Returns the documents written."""
+    if not ASM_CONVERGE or not em.checkpoint_drop_writes_on():
         return 0
-    for table in (_ASM_CONVERGE_DONE, _ASM_CONVERGE_BLIP, _ASM_CONVERGE_NOENTRY):
-        if len(table) > 4096:                              # bounded like the pass's skip table (a leaf per session ever seen)
-            table.clear()
     n = 0
     for s in _sessions(now):
         leaf, sid = s.get("path"), s.get("sid")
         if not leaf or not sid:
             continue
-        key = str(leaf)
-        st = _stat_key_ns(key)
-        if st is None or _ASM_CONVERGE_DONE.get(key) == st:
-            continue
         if time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0:
             break                                          # the cycle's wall: the rest wait for the next one
-        cp = em._asm_ckpt_file(key)
-        if cp is None:
-            return n
-        if cp.exists():
-            _ASM_CONVERGE_DONE[key] = st                   # the settle's document, or an earlier cycle's, stands
-            continue
-        if not em.file_quiescent(key):
-            continue                                       # a live leaf: its settle writes the document
-        human = _display_sdk_human(sid)
-        if not em.asm_entry_whole(key, sid, human):
-            if _ASM_CONVERGE_NOENTRY.get(key) != st:       # the parse never ran here, or the entry left the cache: nothing to write
-                _ASM_CONVERGE_NOENTRY[key] = st; em.asm_converge_skip("noEntry")   #  from, and never a parse of our own
-            continue
-        em.asm_converge_stat("candidates")
-        est = max(4096, st[1] // 64)
-        if not em.checkpoint_cycle_take(est):
-            em.asm_converge_stat("deferred")
-            break
-        before = em.asm_checkpoint_stats()["skipped"]
-        try:
-            wrote = em.asm_checkpoint_write(key, sid, human, tree=_stored_tree(key, sid))
-        except Exception:
-            sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); wrote = False
-        if wrote:
-            try:
-                size = cp.stat().st_size
-            except OSError:
-                size = 0
-            em.asm_converge_stat("writes"); em.asm_converge_stat("bytes", size); em.checkpoint_cycle_charge(size - est)
-            _ASM_CONVERGE_DONE[key] = st; n += 1
-            continue
-        em.checkpoint_cycle_charge(-est)                   # nothing written: the take goes back
-        after = em.asm_checkpoint_stats()["skipped"]
-        reason = next((r for r in after if after[r] > before.get(r, 0)), "failed")
-        em.asm_converge_skip(reason)
-        if reason in _ASM_STRUCTURAL or _ASM_CONVERGE_BLIP.get(key) == st:
-            _ASM_CONVERGE_DONE[key] = st                   # a property of the cut, or the blip's one retry spent: done for this file state
-        else:
-            _ASM_CONVERGE_BLIP[key] = st
+        r = _converge_assembly_leaf(str(leaf), sid, t0)
+        if r is None:
+            break                                          # the budget: the rest wait for the next cycle
+        n += 1 if r else 0
     return n
 
+
+def _release_oldest(table, cap=4096):
+    while len(table) > cap:                                # bounded like the pass's skip table: the oldest entry released, never
+        table.pop(next(iter(table)))                       #  the table cleared (round one, low 6)
+
+
+def _converge_assembly_leaf(key, sid, t0):
+    """One leaf's assembly write for the pass (see _converge_assembly): True written, False not (done, refused, nothing to
+    write from), None when the budget refused it (the caller defers the rest)."""
+    if not ASM_CONVERGE or not sid or not em.checkpoint_drop_writes_on():
+        return False
+    for table in (_ASM_CONVERGE_DONE, _ASM_CONVERGE_BLIP, _ASM_CONVERGE_NOENTRY):
+        _release_oldest(table)
+    st = _stat_key_ns(key)
+    if st is None or _ASM_CONVERGE_DONE.get(key) == st:
+        return False
+    cp = em._asm_ckpt_file(key)
+    if cp is None:
+        return False
+    if cp.exists():
+        _ASM_CONVERGE_DONE[key] = st                       # the settle's document, or an earlier cycle's, stands
+        return False
+    if not em.file_quiescent(key):
+        return False                                       # a live leaf: its settle writes the document
+    human = _display_sdk_human(sid)
+    if not em.asm_entry_whole(key, sid, human) or not em.entry_whole_resident(key):
+        if _ASM_CONVERGE_NOENTRY.get(key) != st:           # no whole assembly entry, or the reader's record entry gone (the writer
+            _ASM_CONVERGE_NOENTRY[key] = st; em.asm_converge_skip("noEntry")   #  needs both): nothing to write from, never a read
+        return False
+    em.asm_converge_stat("candidates")
+    est = max(4096, st[1] // 64)
+    if not em.checkpoint_cycle_take(est):
+        em.asm_converge_stat("deferred")
+        return None
+    reasons = []
+    try:
+        wrote = em.asm_checkpoint_write(key, sid, human, tree=_stored_tree(key, sid), reason_out=reasons, who="converge pass")
+    except Exception:
+        sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); wrote = False
+    if wrote:
+        try:
+            size = cp.stat().st_size
+        except OSError:
+            size = 0
+        em.asm_converge_stat("writes"); em.asm_converge_stat("bytes", size); em.checkpoint_cycle_charge(size - est)
+        _ASM_CONVERGE_DONE[key] = st
+        return True
+    em.checkpoint_cycle_charge(-est)                       # nothing written: the take goes back
+    reason = reasons[-1] if reasons else "failed"          # the writer's own reason (round one, low 6)
+    em.asm_converge_skip(reason)
+    if reason in _ASM_STRUCTURAL or _ASM_CONVERGE_BLIP.get(key) == st:
+        _ASM_CONVERGE_DONE[key] = st                       # a property of the cut, or the blip's second try spent: done for this file state
+    else:
+        _ASM_CONVERGE_BLIP[key] = st
+    return False
 
 _CONVERGE_SKIP = {}                 # path -> [the file's (mtime_ns, size) when the pass last refused or failed it, the reader's own
 #                                     entry stamp (mtime, size) then, counted] (T361):

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -501,6 +501,35 @@ class ConvergeAssembly(Harness):
         self.assertLess(self.read_before, size, "the next boot reads the tail, not the whole leaf: %d of %d bytes" % (self.read_before, size))
         self.assertEqual(tree, whole)
 
+    def test_the_dirty_leaf_boot_shape_writes_the_fold_document_and_the_assembly_document_in_one_pass(self):
+        """Round one, medium: the ordinary boot shape is a dirty idle leaf (the judges' pass read it whole, its fold document lacks
+        the pairing) with no assembly document. The fold half of the pass healed and primed it and its held quiescence drop
+        POPPED the record entry; the assembly step then found the assembly entry but no record entry (record_offsets None), a
+        skipped write, retried once, abandoned. The assembly write now runs while the record entry is resident, inside the same
+        hold, and the held drop is paid after it: one pop, both documents from the one read, and the next boot restores both."""
+        path = self.idle_leaf("both")
+        km = self.km; jd = km.jd
+        size = os.path.getsize(path)
+        jd._bg_scan(path)                                             # the boot's whole read by a fold: dirty, whole-resident
+        self.assertTrue(em.entry_whole_resident(path))
+        self.assertIn(path, em.checkpoint_converge_candidates(), "a fold candidate too")
+        read0 = em.read_bytes_report().get(path, 0)
+        self.cycle(NOW + 600)
+        cv = em.checkpoint_stats()["converge"]; av = em.asm_checkpoint_stats()["converge"]
+        self.assertEqual((cv["viaDrop"], cv["dropWrites"]), (1, 1), "the fold document, written at the held drop: %s" % cv)
+        self.assertEqual((av["writes"], av["skipped"]), (1, {}), "the assembly document, written from the same read: %s" % av)
+        self.assertTrue(em._asm_ckpt_file(path).exists())
+        self.assertLess(em.read_bytes_report().get(path, 0) - read0, 1024, "no read of records for either")
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(path), "one pop, after both writes")
+        self.fresh(); em.set_checkpoint_dir(lambda: self.ck)
+        for c in list(em._FOLD_REG.values()): c.clear()
+        before = em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0)
+        modes = []; self.parse(path, modes); self.assertEqual(modes, ["restore"], "the assembly document restores")
+        jd._bg_scan(path)
+        self.assertEqual(em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0), before + 1, "the fold document restores")
+        self.assertLess(em.read_bytes_report().get(path, 0), size, "the next boot reads the tail")
+
     def test_a_write_over_the_cycles_budget_is_deferred_to_the_next(self):
         path = self.idle_leaf("budget")
         self.km.CKPT_CONVERGE_BYTES = 1
@@ -511,6 +540,16 @@ class ConvergeAssembly(Harness):
         self.cycle(NOW + 601)
         self.assertTrue(em._asm_ckpt_file(path).exists())
         self.assertEqual(em.asm_checkpoint_stats()["converge"]["writes"], 1)
+
+    def test_a_zero_byte_budget_turns_the_step_off_rather_than_deferring_forever(self):
+        """Round one, low 2: with ROMP_CKPT_CONVERGE_MB=0 every attempt was deferred and candidates and deferred grew each cycle."""
+        path = self.idle_leaf("zero")
+        self.km.CKPT_CONVERGE_BYTES = 0
+        for k in range(3):
+            self.cycle(NOW + 600 + k)
+        cv = em.asm_checkpoint_stats()["converge"]
+        self.assertEqual((cv["candidates"], cv["deferred"], cv["writes"]), (0, 0, 0), "off, as the drop write is: %s" % cv)
+        self.assertFalse(em._asm_ckpt_file(path).exists())
 
     def test_a_leaf_without_a_boundary_is_looked_at_once(self):
         path = self.idle_leaf("plain", scenario=next(n for n in G.SINGLE_FILE if n not in COMPACTING))
@@ -551,6 +590,16 @@ class HydrationAttribution(Harness):
         by = em.asm_checkpoint_stats()["hydratedBy"]
         self.assertEqual(list(by), ["_unit_text<-some_walker"], "%s" % by)
         self.assertEqual(em.hydrate(atoms), 0, "hydrated already: nothing counted twice")
+        self.fresh(); tree = self.parse(path); atoms = [a for t in tree["turns"] for a in t["atoms"]]
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        def _atom_text(atoms):                                  # a reader reached through another shared reader (round one, low 3)
+            return em.hydrate(atoms)
+        def _prompt_text(atoms):
+            return _atom_text(atoms)
+        def other_walker():
+            return _prompt_text(atoms)
+        other_walker()
+        self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["_atom_text<-other_walker"], "the first caller outside the shared readers")
 
 
 class KernelOverRestored(Harness):

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -10,6 +10,7 @@ moved session and a corrupt document each fall back loudly, counted; a body read
 the restore reads are the document, the cut's guard and the tail. Synthetic transcripts only (the golden builders)."""
 import json
 import os
+import time
 import shutil
 import tempfile
 import unittest
@@ -460,7 +461,10 @@ class ConvergeAssembly(Harness):
     def setUp(self):
         super().setUp()
         em._ASM_CKPT_STATS["converge"] = {"writes": 0, "bytes": 0, "deferred": 0, "candidates": 0, "skipped": {}}
-        self.km._ASM_CONVERGE_DONE.clear()
+        with em._CKPT_LOCK:
+            for k in em._CKPT_STATS["converge"]:                   # the fold half's counters too: the tests assert absolutes
+                em._CKPT_STATS["converge"][k] = 0
+        self.km._ASM_CONVERGE_DONE.clear(); self.km._ASM_CONVERGE_BLIP.clear(); self.km._ASM_CONVERGE_NOENTRY.clear()
         for name, val in (("CKPT_CONVERGE_MS", 150.0), ("CKPT_CONVERGE_BYTES", em._CKPT_CYCLE_CAP_DEFAULT), ("ASM_CONVERGE", True)):
             saved = getattr(self.km, name); setattr(self.km, name, val); self.addCleanup(setattr, self.km, name, saved)
 
@@ -550,6 +554,45 @@ class ConvergeAssembly(Harness):
         cv = em.asm_checkpoint_stats()["converge"]
         self.assertEqual((cv["candidates"], cv["deferred"], cv["writes"]), (0, 0, 0), "off, as the drop write is: %s" % cv)
         self.assertFalse(em._asm_ckpt_file(path).exists())
+
+    def test_a_blip_is_tried_twice_then_done_and_the_writer_names_its_caller_once_per_leaf(self):
+        """Round two, low 3: the writer returns its reason (a blip, here the record entry gone before the offsets are read,
+        versus a property of the cut), the pass tries a blip twice for one file state and then leaves it, and the writer's blip
+        line names its caller and is said once per leaf and reason."""
+        path = self.idle_leaf("blip"); km = self.km
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.pop(path, None)                        # the record entry gone: the writer has no offsets (a blip)
+        import io
+        err = io.StringIO(); saved = sys.stderr; sys.stderr = err
+        try:
+            reasons = []
+            self.assertFalse(em.asm_checkpoint_write(path, SID, False, reason_out=reasons, who="converge pass"))
+            self.assertFalse(em.asm_checkpoint_write(path, SID, False, reason_out=reasons, who="converge pass"))
+        finally:
+            sys.stderr = saved
+        self.assertEqual(reasons, ["offsets", "offsets"], "the writer's own reason, per attempt")
+        lines = [l for l in err.getvalue().splitlines() if "not written by the converge pass" in l]
+        self.assertEqual(len(lines), 1, "the blip line names its caller and is said once per leaf: %r" % err.getvalue())
+        # the pass: the blip's two tries, then done for this file state (the record entry must be resident for a write)
+        st = km._stat_key_ns(path)
+        self.assertFalse(km._converge_assembly_leaf(path, SID, time.monotonic()))
+        self.assertEqual(km._ASM_CONVERGE_NOENTRY.get(path), st, "no record entry: nothing to write from, counted once, no try spent")
+        with em._JSONL_CACHE_LOCK:                                 # the record entry back, but the offsets torn away at the write
+            pass
+        self.fresh(); em.set_checkpoint_dir(lambda: self.ck); self.parse(path)   # a whole record entry again
+        real = em.record_offsets; em.record_offsets = lambda p, base: None
+        self.addCleanup(setattr, em, "record_offsets", real)
+        self.assertFalse(km._converge_assembly_leaf(path, SID, time.monotonic()))
+        self.assertEqual(km._ASM_CONVERGE_BLIP.get(path), st, "a blip: the first try spent, not done")
+        self.assertFalse(km._converge_assembly_leaf(path, SID, time.monotonic()))
+        self.assertEqual(km._ASM_CONVERGE_DONE.get(path), st, "the second try spent: done for this file state")
+        self.assertEqual(em.asm_checkpoint_stats()["converge"]["skipped"].get("offsets"), 2)
+
+    def test_the_done_tables_release_their_oldest_past_the_bound(self):
+        """Round two, low 3: past the bound the oldest entry is released, never the table cleared."""
+        table = {"k%d" % i: i for i in range(4100)}
+        self.km._release_oldest(table)
+        self.assertEqual(len(table), 4096); self.assertNotIn("k0", table); self.assertIn("k4099", table); self.assertNotIn("k3", table)
 
     def test_a_leaf_without_a_boundary_is_looked_at_once(self):
         path = self.idle_leaf("plain", scenario=next(n for n in G.SINGLE_FILE if n not in COMPACTING))

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -447,6 +447,112 @@ class WriteValves(Harness):
         self.assertTrue(self.doc(path), "a missing document is written again from the same entry")
 
 
+class ConvergeAssembly(Harness):
+    """T376 (2026-09-12): an idle session never settles, so its leaf never had an assembly document and the parse read it whole
+    at every boot (31 of 60 leaves on the devbox, about 2.5 GB, the boot's remaining cost). The converge pass writes the
+    document for a quiescent leaf from the whole assembly entry the boot's own parse built: no read of records (a stat per
+    file and the cut's guard), charged to the cycle's byte budget, once; the next process restores it and reads the tail."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.km = kernel_module()
+
+    def setUp(self):
+        super().setUp()
+        em._ASM_CKPT_STATS["converge"] = {"writes": 0, "bytes": 0, "deferred": 0, "candidates": 0, "skipped": {}}
+        self.km._ASM_CONVERGE_DONE.clear()
+        for name, val in (("CKPT_CONVERGE_MS", 150.0), ("CKPT_CONVERGE_BYTES", em._CKPT_CYCLE_CAP_DEFAULT), ("ASM_CONVERGE", True)):
+            saved = getattr(self.km, name); setattr(self.km, name, val); self.addCleanup(setattr, self.km, name, saved)
+
+    def idle_leaf(self, name="idle", scenario="compaction_atom", age=600):
+        """A leaf idle past the reader's quiescence window, with no assembly document, parsed once by this process (the boot's
+        read: a whole entry), registered as the only session."""
+        import time
+        records, sent = G.SINGLE_FILE[scenario]
+        path = self.write(name, records(), sent=sent)
+        old = time.time() - age; os.utime(path, (old, old))
+        self.fresh(); self.parse(path)
+        rows = [{"sid": SID, "path": path}]
+        saved = self.km._sessions; self.km._sessions = lambda now, **kw: rows
+        self.addCleanup(setattr, self.km, "_sessions", saved)
+        self.assertFalse(em._asm_ckpt_file(path).exists())
+        return path
+
+    def cycle(self, now):
+        self.km._begin_checkpoint_cycle()
+        return self.km._converge_checkpoints(now)
+
+    def test_the_pass_writes_an_idle_leafs_document_from_the_boots_parse_and_the_next_boot_reads_a_tail(self):
+        path = self.idle_leaf()
+        size = os.path.getsize(path); read0 = em.read_bytes_report().get(path, 0)
+        self.cycle(NOW + 600)
+        self.assertTrue(em._asm_ckpt_file(path).exists(), "written from the entry in hand")
+        self.assertLess(em.read_bytes_report().get(path, 0) - read0, 512, "no read of records: the cut's guard alone")
+        cv = em.asm_checkpoint_stats()["converge"]
+        self.assertEqual((cv["writes"], cv["deferred"], cv["candidates"]), (1, 0, 1), "%s" % cv); self.assertGreater(cv["bytes"], 0)
+        st = em._asm_ckpt_file(path).stat().st_mtime_ns
+        self.cycle(NOW + 601); self.cycle(NOW + 602)
+        cv = em.asm_checkpoint_stats()["converge"]
+        self.assertEqual((cv["writes"], cv["candidates"]), (1, 1), "once: the document stands, the leaf is done: %s" % cv)
+        self.assertEqual(em._asm_ckpt_file(path).stat().st_mtime_ns, st)
+        whole = self.cold(path)
+        tree, modes, n_lazy = self.restored(path)
+        self.assertEqual(modes, ["restore"]); self.assertGreater(n_lazy, 0)
+        self.assertLess(self.read_before, size, "the next boot reads the tail, not the whole leaf: %d of %d bytes" % (self.read_before, size))
+        self.assertEqual(tree, whole)
+
+    def test_a_write_over_the_cycles_budget_is_deferred_to_the_next(self):
+        path = self.idle_leaf("budget")
+        self.km.CKPT_CONVERGE_BYTES = 1
+        self.cycle(NOW + 600)
+        self.assertFalse(em._asm_ckpt_file(path).exists())
+        self.assertEqual(em.asm_checkpoint_stats()["converge"]["deferred"], 1)
+        self.km.CKPT_CONVERGE_BYTES = em._CKPT_CYCLE_CAP_DEFAULT
+        self.cycle(NOW + 601)
+        self.assertTrue(em._asm_ckpt_file(path).exists())
+        self.assertEqual(em.asm_checkpoint_stats()["converge"]["writes"], 1)
+
+    def test_a_leaf_without_a_boundary_is_looked_at_once(self):
+        path = self.idle_leaf("plain", scenario=next(n for n in G.SINGLE_FILE if n not in COMPACTING))
+        for k in range(3):
+            self.cycle(NOW + 600 + k)
+        cv = em.asm_checkpoint_stats()["converge"]
+        self.assertFalse(em._asm_ckpt_file(path).exists())
+        self.assertEqual((cv["candidates"], cv["skipped"].get("noBoundary"), cv["writes"]), (1, 1, 0), "no cut, no document, said once: %s" % cv)
+
+    def test_off_writes_nothing_and_a_live_leaf_is_left_to_the_settle(self):
+        path = self.idle_leaf("off")
+        self.km.ASM_CONVERGE = False
+        self.cycle(NOW + 600)
+        self.assertFalse(em._asm_ckpt_file(path).exists()); self.assertEqual(em.asm_checkpoint_stats()["converge"]["candidates"], 0)
+        self.km.ASM_CONVERGE = True
+        live = self.idle_leaf("live", age=0)                       # fresh: the settle's writer covers it
+        self.cycle(NOW + 601)
+        self.assertFalse(em._asm_ckpt_file(live).exists()); self.assertEqual(em.asm_checkpoint_stats()["converge"]["candidates"], 0)
+        self.assertIn("converge", self.km._PERF_STATS.snapshot()["asmCheckpoint"], "the counters ride /perf")
+
+
+class HydrationAttribution(Harness):
+    def test_a_shared_text_reader_is_attributed_with_its_caller(self):
+        """T377: the boot's 1.06 GB of hydration read as `_unit_text`, the judges' shared text reader, which every walker calls;
+        the bytes are attributed to the reader AND its caller, so the counter names the walker."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("attr", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        tree, _, n_lazy = self.fresh(), None, None
+        modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+        atoms = [a for t in tree["turns"] for a in t["atoms"]]
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        def _unit_text(atoms):                                  # the reader's name, as the judges' is
+            return em.hydrate(atoms)
+        def some_walker():
+            return _unit_text(atoms)
+        some_walker()
+        by = em.asm_checkpoint_stats()["hydratedBy"]
+        self.assertEqual(list(by), ["_unit_text<-some_walker"], "%s" % by)
+        self.assertEqual(em.hydrate(atoms), 0, "hydrated already: nothing counted twice")
+
+
 class KernelOverRestored(Harness):
     """The kernel's and the judges' body readers over a restored tree: every consumer the audit named hydrates what it
     reads, so the same answers come from the restored tree as from the whole parse, with no LazyBodyRead."""

--- a/tests/test_chat_proto2_served.py
+++ b/tests/test_chat_proto2_served.py
@@ -95,8 +95,9 @@ class Proto2Wire(A.RestartOverACheckpointedSession):
             self.assertEqual(f2["firstUuid"], f2["events"][0]["uuid"]); self.assertEqual(f2["lastUuid"], f2["events"][-1]["uuid"])
             # the frame's build read no pre-cut body (the judges' first pass over a fresh store reads the unjudged
             # segments' text through the same memo, under their own caller names; the chat's callers stay at zero)
-            self.assertFalse({"build_session", "_atom_md"} & set(asm["hydratedBy"]), "the first open hydrated for the chat: %s" % asm["hydratedBy"])
-            self.assertLessEqual(set(asm["hydratedBy"]), {"_unit_text", "_atom_text", "_seg_anchors", "_atom_user_text", "_human_prompt_record", "_has_asst_work", "_seg_launches"},
+            readers = {k.split("<-")[0] for k in asm["hydratedBy"]}   # a shared reader's key carries its caller (reader<-caller, T377)
+            self.assertFalse({"build_session", "_atom_md"} & readers, "the first open hydrated for the chat: %s" % asm["hydratedBy"])
+            self.assertLessEqual(readers, {"_unit_text", "_atom_text", "_seg_anchors", "_atom_user_text", "_human_prompt_record", "_has_asst_work", "_seg_launches"},
                                  "only the judges' readers: %s" % asm["hydratedBy"])
             by = perf["checkpoints"]["readByPath"]
             leaf_read0 = by.get(os.path.realpath(self.leaf), by.get(self.leaf, 0))


### PR DESCRIPTION
Fix tier. An idle session never settles, and the assembly document was written only at the settle, so its leaf never had one and the transcript parse read it whole at every boot (31 of 60 leaves on the devbox, about 2.5 GB, the boot's remaining cost once the fold documents converged). Their fold documents were already whole, so the fold pass never touched them, correctly.

**The change:** `_converge_assembly`, run by the converge pass on every cycle. For every session leaf that is quiescent, has no assembly document on disk, and whose whole assembly entry the boot's own parse built is in memory, the document is written from that entry through the settle's writer: no read of records (a stat per file and the cut's guard). Charged to the cycle's shared byte budget, deferred over it, bounded by the pass's wall. A leaf is looked at once per file state (written, or refused by the writer for a property of its cut); a blip is retried once; no entry in the assembly cache is a counted skip, never a parse of the pass's own; live leaves are the settle's. `ROMP_ASM_CONVERGE=0` turns the step off and the pass's own switch covers it. Counters under `asmCheckpoint.converge`.

Also a diagnosis aid for the follow-on task: a shared text reader's hydration is attributed together with its caller (`_unit_text<-walker`), since the boot's other 1.76 GB of reads are hydration through that reader and the counter named only the reader.

**Tests** (`tests/test_asm_checkpoint.py`, red first on main): the write from the boot's parse with under 512 bytes read and the next process restoring and reading the tail; idempotence; the budget deferral; a leaf without a boundary looked at once; off, and a live leaf left to the settle; the counters on /perf; the attribution. Full Python suite green locally (12,479 passed).

**Measurement after deploy:** leaf reads from 2.47 GB (about 0.7 GB is this change's share), the census of boundary-carrying leaves without an assembly document (25) to zero, `asmCheckpoint.converge.writes` on the first boot and `asmCheckpoint.restored` on the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)