### PR TITLE
The Billing flyout opens on hover like Tags, through one shared gesture, and carries a per-machine default billing (T380)

### DIFF
--- a/docs/judges.md
+++ b/docs/judges.md
@@ -501,9 +501,11 @@ toward nothing.
 ## Billing, and when the credential itself is broken
 
 A judge call bills **the account of the session it judges**: the same pick the
-session's own Billing selector holds, read from the same registry, with the same
-default (an explicit login pick, the login; otherwise the API key when Claude
-Code's settings carry an `apiKeyHelper`, else the login). Judges run on Claude
+session's own Billing selector holds, read from the same registry, resolved by
+the same rule the launch uses (the kernel wires the backend's resolver into the
+judges): the session's own pick; else the machine's default set in the tab
+menu's Billing flyout, when the machine can bill it; else the API key when
+Claude Code's settings carry an `apiKeyHelper`, else the login. Judges run on Claude
 Code's own credential resolution, and romp holds no key (the user 2026-09-08).
 Every judge child (`claude -p`) launches with no credential in its environment.
 A key-billed call resolves the helper itself, inside its own CLI, the way a

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -324,7 +324,13 @@ and the group's sub-line says which rule holds. Until the default is set here,
 the last per-session pick seeds it (as a model or effort pick does); once set
 here, a per-session pick is about that session alone and moves no default. A
 remote session's flyout names its host, and the pick sets that host's default
-(the op routes to the session's owning kernel).
+(the op routes to the session's owning kernel). The judges follow the same
+resolution: a judge on a session with no pick of its own bills the machine's
+default when the machine can bill it, else the helper rule, exactly as the
+launch does. The flyout places itself to the right of its row, to the left
+when the right would clip and the left has room, below the row when neither
+side has room, above it when below does not fit, and only then clamped inside
+the window; it never covers its row while a place beside or beyond it exists.
 
 On a one-auth box the picker never chooses the missing side. The remembered
 default falls to the side that exists, in both directions: a remembered login

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -305,9 +305,22 @@ used to exist only when both were real): the choice this machine cannot bill
 is greyed and inert, with the reason in its hover, `no Claude login signed in
 on this machine`, `no apiKeyHelper configured`, or `the apiKeyHelper is set in
 managed settings, login cannot apply`. The status payload carries the same
-availability as `authAvail` (`authBoth` rides beside it for older clients).
-Switching reconnects the session to apply, with the same switching-dots the
-effort badge wears.
+availability as `authAvail` (`authBoth` rides beside it for older clients),
+and the machine's default beside it. The flyout opens on hover over the
+Billing row, as the Tags flyout does (one gesture: a short hover opens, a
+click opens at once, leaving both the row and the flyout closes it), and on
+click. Switching reconnects the session to apply, with the same switching-dots
+the effort badge wears.
+
+Below the session's choices the flyout carries **Default for this machine**:
+the same choices as a radio group, the current default marked. That default is
+the seed every new session, and every session with no pick of its own, launches
+on; it lives in the state root's `sdk-defaults.json` as `auth` (never a token),
+and a pick there changes no session that carries its own pick. Until the
+default is set here, the last per-session pick seeds it (as a model or effort
+pick does); once set here, a per-session pick is about that session alone and
+moves no default. A remote session's flyout names its host, and the pick sets
+that host's default (the op routes to the session's owning kernel).
 
 On a one-auth box the picker never chooses the missing side. The remembered
 default falls to the side that exists, in both directions: a remembered login

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -316,11 +316,15 @@ Below the session's choices the flyout carries **Default for this machine**:
 the same choices as a radio group, the current default marked. That default is
 the seed every new session, and every session with no pick of its own, launches
 on; it lives in the state root's `sdk-defaults.json` as `auth` (never a token),
-and a pick there changes no session that carries its own pick. Until the
-default is set here, the last per-session pick seeds it (as a model or effort
-pick does); once set here, a per-session pick is about that session alone and
-moves no default. A remote session's flyout names its host, and the pick sets
-that host's default (the op routes to the session's owning kernel).
+and a pick there changes no session that carries its own pick; a session
+with no pick of its own follows it, in its status at once and at its next
+launch. A third choice, Automatic, is the rule that held before: the API key
+when a helper is configured, else the login; it clears the explicit default,
+and the group's sub-line says which rule holds. Until the default is set here,
+the last per-session pick seeds it (as a model or effort pick does); once set
+here, a per-session pick is about that session alone and moves no default. A
+remote session's flyout names its host, and the pick sets that host's default
+(the op routes to the session's owning kernel).
 
 On a one-auth box the picker never chooses the missing side. The remembered
 default falls to the side that exists, in both directions: a remembered login

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1682,9 +1682,11 @@ def _judge_auth(fsid):
     never a silent fall to the other one — a judge quietly billing the login on a session the user
     put on the key is the same wrong-account failure the per-session picker exists to prevent).
     Same resolution as the picker (sdk_backend default_auth / effective_auth), read from the same
-    registry file: an explicit 'login' pick → login; anything else → the key when Claude Code's
-    settings carry an apiKeyHelper, else login. A call with no session (rows with no session) takes the same default a
-    fresh session would."""
+    registry file: an explicit 'login' or 'key' pick → that side; anything else → the machine's EXPLICIT
+    default when one is set (T380: sdk-defaults.json auth with authExplicit, the Billing flyout's Default
+    group; a key default with no helper on this box falls to the login, as the picker's rule does), else the
+    key when Claude Code's settings carry an apiKeyHelper, else login. A call with no session (rows with no
+    session) takes the same default a fresh session would."""
     a = ""
     if fsid:
         try:
@@ -1693,6 +1695,15 @@ def _judge_auth(fsid):
             a = ""
     if a in ("login", "key"):
         return a
+    try:
+        d = json.loads((STATE / "sdk-defaults.json").read_text())
+        d = d if isinstance(d, dict) else {}
+    except Exception:
+        d = {}
+    if d.get("authExplicit") and d.get("auth") in ("login", "key"):
+        if d["auth"] == "key" and not _key_available():
+            return "login"
+        return d["auth"]
     return "key" if _key_available() else "login"
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -1644,6 +1644,8 @@ def _fast_org_env():
         return env
 
 
+_DEFAULT_AUTH_FN = None        # kernel wiring: fn(reg) -> 'login' | 'key', SdkBackend.default_auth: the ONE billing resolver
+#                                (the reg's own pick, else the machine's explicit default when billable, else the helper rule)
 _LOGIN_AUTH_ENV_FN = None      # login tokens claimed out of the manager's ambient environment: the kernel
                                # wires sdk_backend.startup_auth_env; standalone reads the environment
 
@@ -1681,29 +1683,31 @@ def _judge_auth(fsid):
     user 2026-08-12: a judge rides the account of the session it judges, never a third choice and
     never a silent fall to the other one — a judge quietly billing the login on a session the user
     put on the key is the same wrong-account failure the per-session picker exists to prevent).
-    Same resolution as the picker (sdk_backend default_auth / effective_auth), read from the same
-    registry file: an explicit 'login' or 'key' pick → that side; anything else → the machine's EXPLICIT
-    default when one is set (T380: sdk-defaults.json auth with authExplicit, the Billing flyout's Default
-    group; a key default with no helper on this box falls to the login, as the picker's rule does), else the
-    key when Claude Code's settings carry an apiKeyHelper, else login. A call with no session (rows with no
-    session) takes the same default a fresh session would."""
-    a = ""
+    THE resolution the picker uses, asked of the ONE resolver: the kernel wires _DEFAULT_AUTH_FN to
+    SdkBackend.default_auth, which reads the reg's own pick, else the machine's EXPLICIT default when this
+    box can bill it (T380; auth_unavailable_why: a logged-out login, a managed helper, an expired account
+    file all move the launch, the status and the flyout to the other side, and the judges with them — the
+    round-3 review found a seed re-read here that kept billing the login alone), else the helper rule. A
+    call with no session (rows with no session) takes the same default a fresh session would. Standalone
+    (tests, no kernel wiring) the registry file and the helper rule stand in: an explicit 'login' or 'key'
+    pick → that side; else the key when Claude Code's settings carry an apiKeyHelper, else login."""
+    reg = {}
     if fsid:
         try:
-            a = json.loads((SDKDIR / (fsid + ".json")).read_text()).get("auth") or ""
+            reg = json.loads((SDKDIR / (fsid + ".json")).read_text())
+            reg = reg if isinstance(reg, dict) else {}
         except Exception:
-            a = ""
+            reg = {}
+    if _DEFAULT_AUTH_FN is not None:
+        try:
+            side = str(_DEFAULT_AUTH_FN(reg) or "")
+            if side in ("login", "key"):
+                return side
+        except Exception:
+            pass   # the resolver failed: the standalone rule below decides, never a raise inside a judge call
+    a = reg.get("auth") or ""
     if a in ("login", "key"):
         return a
-    try:
-        d = json.loads((STATE / "sdk-defaults.json").read_text())
-        d = d if isinstance(d, dict) else {}
-    except Exception:
-        d = {}
-    if d.get("authExplicit") and d.get("auth") in ("login", "key"):
-        if d["auth"] == "key" and not _key_available():
-            return "login"
-        return d["auth"]
     return "key" if _key_available() else "login"
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16260,8 +16260,10 @@ def _auth_avail():
 
 
 def _auth_avail_status():
-    """_auth_avail's availability half for the per-session status payload: {login, key, loginWhy?, keyWhy?}
-    — no acct (authAcct rides beside it) and no default (a live session has its own pick). Computed ONCE per
+    """_auth_avail's availability half for the per-session status payload: {login, key, loginWhy?, keyWhy?,
+    default} — no acct (authAcct rides beside it); `default` is the machine's seed, carried since T380 so the
+    tab menu's Billing flyout can mark it in its "Default for this machine" group (a live session has its own
+    pick; the default is what a NEW one, or one with no pick, launches on). Computed ONCE per
     pusher cycle (the cycle's _live_scope memo, the same idiom as its liveness snapshot): build_session asks
     for it per session per push, and each answer re-read sdk-defaults.json and both operator settings files
     (review 2026-09-09). Outside a cycle (a connect push on a handler thread, a test) it computes fresh."""
@@ -16269,7 +16271,7 @@ def _auth_avail_status():
     if memo is not None and "avail_status" in memo:
         return dict(memo["avail_status"])
     a = _auth_avail()
-    out = {k: a[k] for k in ("login", "key", "loginWhy", "keyWhy") if k in a}
+    out = {k: a[k] for k in ("login", "key", "loginWhy", "keyWhy", "default") if k in a}
     if memo is not None:
         memo["avail_status"] = dict(out)
     return out
@@ -17256,6 +17258,17 @@ def _drive(msg, client):
                     "after the current turn finishes." if be is _codex_backend else
                     "The permission mode could not be changed: no running backend owns this session.")
             client["send"](json.dumps({"type": "warn", "text": text}))
+        _push_soon()
+    elif t == "setAuth" and msg.get("value") in ("login", "key") and msg.get("scope") == "machine":
+        # the machine's DEFAULT billing (T380, the user 2026-09-12): the seed every new session and every
+        # session with no pick of its own launches on. Written on THIS kernel (the op routes to the session's
+        # owning host, so a remote session's flyout sets that host's default); no session is touched, so
+        # nothing reconnects. LOUD on refusal, the same reason vocabulary as a per-session pick.
+        if not be.set_auth_default(str(msg["value"])):
+            why = str(getattr(be, "auth_unavailable_why", lambda v: "")(str(msg["value"])) or "")
+            client["send"](json.dumps({"type": "warn",
+                                       "text": ("Couldn't set this machine's default billing: %s." % why) if why
+                                       else "Couldn't set this machine's default billing."}))
         _push_soon()
     elif t == "setAuth" and msg.get("value") in ("login", "key"):
         # per-session billing (login vs the manager env's API key) — SDK-only, applied via reconnect

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16251,7 +16251,10 @@ def _auth_avail():
     elif default == "login" and not login_ok and key:
         default = "key"
     out = {"login": login_ok, "key": key,
-           "acct": _claude_account_label(), "default": default}
+           "acct": _claude_account_label(), "default": default,
+           # T380: the default is EXPLICIT (set in the Billing flyout's Default group) or the helper rule; the
+           # group marks Automatic otherwise and its sub-line says which
+           "defaultExplicit": bool(d.get("authExplicit")) and d.get("auth") in ("login", "key")}
     if not login_ok:
         out["loginWhy"] = jd._cred.WHY_MANAGED_HELPER if managed else jd._cred.WHY_NO_LOGIN
     if not key:
@@ -16271,7 +16274,7 @@ def _auth_avail_status():
     if memo is not None and "avail_status" in memo:
         return dict(memo["avail_status"])
     a = _auth_avail()
-    out = {k: a[k] for k in ("login", "key", "loginWhy", "keyWhy", "default") if k in a}
+    out = {k: a[k] for k in ("login", "key", "loginWhy", "keyWhy", "default", "defaultExplicit") if k in a}
     if memo is not None:
         memo["avail_status"] = dict(out)
     return out
@@ -17259,12 +17262,18 @@ def _drive(msg, client):
                     "The permission mode could not be changed: no running backend owns this session.")
             client["send"](json.dumps({"type": "warn", "text": text}))
         _push_soon()
-    elif t == "setAuth" and msg.get("value") in ("login", "key") and msg.get("scope") == "machine":
+    elif t == "setAuth" and msg.get("scope") == "machine" and msg.get("value") in ("login", "key", "auto"):
         # the machine's DEFAULT billing (T380, the user 2026-09-12): the seed every new session and every
-        # session with no pick of its own launches on. Written on THIS kernel (the op routes to the session's
-        # owning host, so a remote session's flyout sets that host's default); no session is touched, so
-        # nothing reconnects. LOUD on refusal, the same reason vocabulary as a per-session pick.
-        if not be.set_auth_default(str(msg["value"])):
+        # session with no pick of its own launches on ("auto" = the helper rule again). Written on THIS kernel
+        # (the op routes to the session's owning host, so a remote session's flyout sets that host's default);
+        # no session's own pick is touched, so nothing reconnects. LOUD on refusal, the same reason vocabulary as
+        # a per-session pick; a backend that keeps no machine default (Codex) is refused by name, never a raise
+        # swallowed inside the drive (review).
+        _set_def = getattr(be, "set_auth_default", None)
+        if _set_def is None:
+            client["send"](json.dumps({"type": "warn",
+                                       "text": "Couldn't set this machine's default billing: this session's backend keeps no machine billing default."}))
+        elif not _set_def(str(msg["value"])):
             why = str(getattr(be, "auth_unavailable_why", lambda v: "")(str(msg["value"])) or "")
             client["send"](json.dumps({"type": "warn",
                                        "text": ("Couldn't set this machine's default billing: %s." % why) if why

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -17279,6 +17279,12 @@ def _drive(msg, client):
                                        "text": ("Couldn't set this machine's default billing: %s." % why) if why
                                        else "Couldn't set this machine's default billing."}))
         _push_soon()
+    elif t == "setAuth" and msg.get("value") == "auto":
+        # Automatic is a choice for the MACHINE default only (T380 review): a session's own billing is Login or API
+        # key. Reachable from an older remote kernel's flyout, which shows the radio and posts the scoped value the
+        # host cannot take; said, never swallowed.
+        client["send"](json.dumps({"type": "warn",
+                                   "text": "Automatic is a choice for the machine's default billing, not for one session: pick Login or API key here."}))
     elif t == "setAuth" and msg.get("value") in ("login", "key"):
         # per-session billing (login vs the manager env's API key) — SDK-only, applied via reconnect
         # like /effort; mid-compaction → parked in the same FIFO. LOUD on refusal (fail loudly): Codex

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -16034,6 +16034,10 @@ def _sdk_locked():
             # ends, so an idle fleet's usage.json goes stale — measured ~15h — and the rate gate is
             # only as good as that file); the backend picks any live login session to ask
             jd._USAGE_REFRESH_FN = getattr(_sdk_backend, "refresh_usage", None)   # best-effort hook (judge guards None)
+            # the ONE billing resolver (T380): a judge on a session with no pick of its own bills what the launch and
+            # the status resolve for it, the machine's explicit default when this box can bill it, else the helper rule
+            # (default_auth over the reg applies auth_unavailable_why); the judge guards None and falls to its file rule
+            jd._DEFAULT_AUTH_FN = getattr(_sdk_backend, "default_auth", None)
             # the Billing pick's login gate (T124): set_auth refuses 'login' when the credential
             # store names no signed-in account — the same authority the usage bars trust, so the
             # pick can never sit in the UI as applied fact on a box that demonstrably cannot apply it

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -4603,6 +4603,8 @@ def read_sdk_defaults(state_dir: Path) -> dict:
         return {}
 
 
+# the explicit machine default per state root, cached on sdk-defaults.json's (mtime, size): explicit_default_auth (T380)
+_EXPLICIT_DEFAULT_CACHE: dict = {}
 _defaults_lock = threading.Lock()   # serializes the read-modify-writes below: the kernel thread (set_model, the
 #                                     parked-op replay) and the SDK loop thread (_revert_model) both write the file
 
@@ -14121,19 +14123,21 @@ class SdkBackend:
 
     def explicit_default_auth(self) -> str:
         """The machine default the user set explicitly (sdk-defaults.json `auth` with `authExplicit` true), else
-        "". Read per status snapshot, so cached on the file's mtime and size: one stat per call."""
+        "". Read per status snapshot, so cached on the file's mtime and size: one stat per call. The cache is
+        module-level, keyed by the state root, not an attribute on the backend: the perf bench's stand-in backend
+        refuses any attribute it did not anticipate (CI, 2026-09-12)."""
         p = _defaults_path(self.state_dir)
         try:
             st = p.stat()
             key = (st.st_mtime_ns, st.st_size)
         except OSError:
             key = None
-        cache = getattr(self, "_explicit_default_cache", None)
+        cache = _EXPLICIT_DEFAULT_CACHE.get(str(self.state_dir))
         if cache is not None and cache[0] == key:
             return cache[1]
         d = read_sdk_defaults(self.state_dir) if key is not None else {}
         side = d.get("auth") if (d.get("authExplicit") and d.get("auth") in ("login", "key")) else ""
-        self._explicit_default_cache = (key, side)
+        _EXPLICIT_DEFAULT_CACHE[str(self.state_dir)] = (key, side)
         return side
 
     def auth_unavailable_why(self, side: str) -> str:

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -6243,6 +6243,14 @@ class SdkSession:
             return "login"
         if self.auth == "key":
             return "key"
+        # no pick of its own: the machine's EXPLICIT default when one is set and billable (T380: the Billing
+        # flyout's Default group; an unpicked session follows it, at once in the status and at its next launch),
+        # else the helper rule
+        explicit = getattr(self.backend, "explicit_default_auth", None)   # getattr: test doubles
+        if explicit:
+            side = explicit()
+            if side and not self.backend.auth_unavailable_why(side):
+                return side
         if key is None:
             key = self.backend.key_available
         return "key" if key else "login"
@@ -14066,10 +14074,17 @@ class SdkBackend:
     def set_auth_default(self, value: str) -> bool:
         """Set the machine's DEFAULT billing (T380, the user 2026-09-12): the seed every new session and every
         session with no pick of its own launches on (sdk-defaults.json `auth`, what spawn seeds a reg from and
-        default_auth falls to). Refuses a side this box cannot bill with the same reason a per-session pick
-        gets (auth_unavailable_why). Marks the default explicit (`authExplicit`), so a later per-session pick
-        no longer moves it. Touches no session: a session with its own pick keeps it, and one that follows
-        the default takes the new side at its next launch."""
+        default_auth and effective_auth fall to). Refuses a side this box cannot bill with the same reason a
+        per-session pick gets (auth_unavailable_why). Marks the default explicit (`authExplicit`), so a later
+        per-session pick no longer moves it; "auto" clears the flag and the seed (the helper rule again).
+        Touches no session's own pick: a session that follows the default shows the new side in its status at
+        once and launches on it next time."""
+        if value == "auto":
+            # back to the helper rule (the key when an apiKeyHelper is configured, else the login): the flag
+            # clears and the seed empties, so a per-session pick seeds the default again as it did before
+            write_sdk_default(self.state_dir, auth="", authExplicit=False)
+            self._log("auth: the machine's default billing is automatic again (the helper rule)")
+            return True
         if value not in ("login", "key"):
             return False
         why = self.auth_unavailable_why(value)
@@ -14092,11 +14107,34 @@ class SdkBackend:
         return self.fallback_auth()
 
     def fallback_auth(self) -> str:
-        """What an UNPICKED session bills on this box: the key when an apiKeyHelper is configured, else the
-        login. Falls to whichever side exists, in BOTH directions (the user 2026-09-08: no login on the box
-        means everything bills the key, never a dead login) — a box with neither still reads login, the
-        CLI's own resolution, and the launch's auth check rings on what lands."""
+        """What an UNPICKED session bills on this box. The machine's EXPLICIT default when one is set (T380: the
+        Billing flyout's Default group wrote sdk-defaults.json `auth` with `authExplicit`; a session with no pick
+        of its own FOLLOWS it, the review found only new sessions did) and this box can bill that side; else the
+        helper rule as before: the key when an apiKeyHelper is configured, else the login. Falls to whichever
+        side exists, in BOTH directions (the user 2026-09-08: no login on the box means everything bills the key,
+        never a dead login) — a box with neither still reads login, the CLI's own resolution, and the launch's
+        auth check rings on what lands."""
+        side = self.explicit_default_auth()
+        if side and not self.auth_unavailable_why(side):
+            return side
         return "key" if self.key_available else "login"
+
+    def explicit_default_auth(self) -> str:
+        """The machine default the user set explicitly (sdk-defaults.json `auth` with `authExplicit` true), else
+        "". Read per status snapshot, so cached on the file's mtime and size: one stat per call."""
+        p = _defaults_path(self.state_dir)
+        try:
+            st = p.stat()
+            key = (st.st_mtime_ns, st.st_size)
+        except OSError:
+            key = None
+        cache = getattr(self, "_explicit_default_cache", None)
+        if cache is not None and cache[0] == key:
+            return cache[1]
+        d = read_sdk_defaults(self.state_dir) if key is not None else {}
+        side = d.get("auth") if (d.get("authExplicit") and d.get("auth") in ("login", "key")) else ""
+        self._explicit_default_cache = (key, side)
+        return side
 
     def auth_unavailable_why(self, side: str) -> str:
         """Why this box cannot bill `side` ("login" | "key"), as ONE plain sentence for the refusal toast,

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -11893,13 +11893,20 @@ class SdkBackend:
         # pick the box cannot bill with NOTHING to fall to (a key pick on a box with neither) launches
         # plain and the CLI decides, as before.
         side = self.pick_fall(sess.auth) or sess.auth   # the ONE decision, shared with the status rows (authPickFell)
+        if sess.auth not in ("login", "key"):
+            # NO pick of its own (T380 review): the launch follows the machine's EXPLICIT default when one is set and
+            # this box can bill it, the rule the status already uses (effective_auth / fallback_auth), so the readout
+            # and the launch agree (before, an unpicked session read Login in its status and billed the key at launch,
+            # the helper unsuppressed); without one the launch stays plain and the CLI decides, as ever
+            _exp = self.explicit_default_auth()
+            side = _exp if (_exp and not self.auth_unavailable_why(_exp)) else ""
         if side == sess.auth and sess.auth in ("login", "key") and sess._pick_unknown_said != sess.auth:
             why = self.pick_unknown(sess.auth)          # cannot tell just now: the pick stands, said once per session
             if why:
                 sess._pick_unknown_said = sess.auth
                 self._log("auth (%s): cannot tell whether this box can bill '%s' (%s); launching with the pick as is"
                           % (sess.name, sess.auth, why), problem=True)
-        if side != sess.auth and sess._pick_fell_said != sess.auth:
+        if sess.auth in ("login", "key") and side != sess.auth and sess._pick_fell_said != sess.auth:   # a PICK fell; a default followed is no fall
             sess._pick_fell_said = sess.auth
             self._log("auth (%s): billing pick '%s' cannot apply: %s; billing the %s"
                       % (sess.name, sess.auth, self.auth_unavailable_why(sess.auth),
@@ -14129,7 +14136,7 @@ class SdkBackend:
         p = _defaults_path(self.state_dir)
         try:
             st = p.stat()
-            key = (st.st_mtime_ns, st.st_size)
+            key = (st.st_mtime_ns, st.st_size, st.st_ino, st.st_ctime_ns)   # ino and ctime too: a same-size rewrite whose mtime did not advance (review)
         except OSError:
             key = None
         cache = _EXPLICIT_DEFAULT_CACHE.get(str(self.state_dir))

--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -14045,7 +14045,11 @@ class SdkBackend:
         # so a restart must restore "no init has landed yet", never the old side (both readers guard
         # with isinstance(..., bool), so None reads as absent).
         self._update_reg(sid, auth=value, authPending=True, apiKeyAuth=None)
-        write_sdk_default(self.state_dir, auth=value)   # the seed for the NEXT new session, like model/effort
+        # the seed for the NEXT new session, like model/effort — until the user sets the machine's default
+        # EXPLICITLY (set_auth_default, the Billing flyout's Default group, T380): from then on a per-session
+        # pick is about that session and moves no default
+        if not read_sdk_defaults(self.state_dir).get("authExplicit"):
+            write_sdk_default(self.state_dir, auth=value)
         s = self.sessions.get(sid)
         if s:
             s.auth = value
@@ -14057,6 +14061,24 @@ class SdkBackend:
             # transcript record, so without a synthesized chip an idle session's auth change shows
             # nothing at all.
             self._ack_cmd_chip(sid, "/auth", "/auth " + value, s.resume_sid)
+        return True
+
+    def set_auth_default(self, value: str) -> bool:
+        """Set the machine's DEFAULT billing (T380, the user 2026-09-12): the seed every new session and every
+        session with no pick of its own launches on (sdk-defaults.json `auth`, what spawn seeds a reg from and
+        default_auth falls to). Refuses a side this box cannot bill with the same reason a per-session pick
+        gets (auth_unavailable_why). Marks the default explicit (`authExplicit`), so a later per-session pick
+        no longer moves it. Touches no session: a session with its own pick keeps it, and one that follows
+        the default takes the new side at its next launch."""
+        if value not in ("login", "key"):
+            return False
+        why = self.auth_unavailable_why(value)
+        if why:
+            self.last_auth_refusal = why
+            self._log("auth: the machine default cannot be %s on this box: %s" % (value, why), problem=True)
+            return False
+        write_sdk_default(self.state_dir, auth=value, authExplicit=True)
+        self._log("auth: the machine's default billing is now %s (new sessions, and sessions with no pick of their own)" % value)
         return True
 
     def default_auth(self, reg: dict | None = None) -> str:

--- a/tests/test_billing_flyout_browser.py
+++ b/tests/test_billing_flyout_browser.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""The tab menu's Billing flyout opens on HOVER over its row, as the Tags flyout does (one gesture, wireFlyout), and
+carries "Default for this machine" below the session's choices (T380; the user 2026-09-12): the same choices as a radio
+group, the current default marked, a pick writing the seed every new session and every session with no pick of its own
+launches on, touching no session that carries its own pick.
+
+This lab drives the real /chat page of a hermetic kernel whose machine offers BOTH sides (a staged apiKeyHelper in the
+kernel's Claude config dir, a synthetic Claude account in the kernel's own home), with two synthetic sessions: web with
+no pick of its own, api with an explicit key pick. It right-clicks web's tab, HOVERS the Billing row without clicking
+and reads whether the flyout opened and when; reads the flyout (the choices, the Default group's head and radios, the
+marked default); leaves the row and the flyout and reads that the flyout closed with the menu still up; opens again and
+presses Escape; then opens once more and clicks the Login default radio, after which the kernel's sdk-defaults.json
+must read auth login with authExplicit true while api's reg keeps its key pick and web's reg has no pick.
+BILLING_FLYOUT_DIST=<dir> serves another tree's UI bundle (the red run's before; the driver falls back to a click when
+the hover opens nothing, so the rest is still read); BILLING_FLYOUT_SHOTS=<prefix> writes <prefix>-dark.png and
+<prefix>-light.png of the open flyout. Skips LOUDLY without the extension deps or a Playwright browser, and never
+otherwise (CI turns a skip in a served module into a failure). SYNTHETIC fixtures only."""
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
+
+# the notes-api demo world: twenty sessions, enough to wrap the strip onto several rows at a narrow width
+NAMES = ["web", "api"]
+SIDS = {n: "%s-1111-2222-3333-444444444444" % (chr(ord("a") + i) * 8) for i, n in enumerate(NAMES)}
+PALETTE = [("#9cd2ff", "#0c1a2e"), ("#1EA1EB", "#ffffff"), ("#54B204", "#ffffff"), ("#c98cff", "#1a0c2e"),
+           ("#e5a50a", "#1a1200"), ("#4EC9B0", "#00201a")]
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1100, height: 700 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab[data-id]", { timeout: 30000 });
+await page.waitForFunction((n) => document.querySelectorAll("#tabs .tab[data-id]").length >= n, cfg.count, { timeout: 30000 });
+await page.waitForTimeout(600);
+const menuOpen = async () => {
+  const tab = await page.$('#tabs .tab[data-id="' + cfg.sidWeb + '"]');
+  await tab.click({ button: "right" });
+  await page.waitForSelector(".ctx-menu .ctx-item-billing", { timeout: 5000 });
+};
+const billingRow = () => page.$(".ctx-menu .ctx-item-billing");
+const readFly = () => page.evaluate(() => {
+  const fly = document.querySelector(".ctx-sub-billing");
+  if (!fly) return null;
+  const items = Array.from(fly.querySelectorAll(".ctx-item"));
+  const choices = items.filter((i) => !i.classList.contains("ctx-radio") && !i.classList.contains("ctx-sub-head")).map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled") }));
+  const head = fly.querySelector(".ctx-sub-head");
+  const radios = Array.from(fly.querySelectorAll(".ctx-radio")).map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled"), scope: i.dataset.scope }));
+  const r = fly.getBoundingClientRect();
+  return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height } };
+});
+const out = {};
+out.tabs = await page.evaluate(() => Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => ({ id: t.dataset.id, name: (t.querySelector(".tab-label") || t).textContent.trim(), active: t.classList.contains("active") })));
+try {
+await menuOpen();
+let row = await billingRow(); let bb = await row.boundingBox();
+const t0 = Date.now();
+await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+let byHover = true;
+try { await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }); } catch (e) { byHover = false; }
+out.hover = { opened: byHover, ms: Date.now() - t0 };
+if (!byHover) { await row.click(); await page.waitForSelector(".ctx-sub-billing", { timeout: 5000 }).catch(() => {}); }
+out.fly = await readFly();
+// leave both the row and the flyout: the flyout closes after the tolerance window, the menu stays
+await page.mouse.move(5, 690);
+await page.waitForTimeout(450);
+out.afterLeave = await page.evaluate(() => ({ fly: !!document.querySelector(".ctx-sub-billing"), menu: !!document.querySelector(".ctx-menu") }));
+// hover again, then Escape closes the menu (and the flyout with it)
+row = await billingRow(); if (row) { bb = await row.boundingBox(); await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2); await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(() => {}); }
+await page.keyboard.press("Escape"); await page.waitForTimeout(150);
+out.afterEscape = await page.evaluate(() => ({ fly: !!document.querySelector(".ctx-sub-billing"), menu: !!document.querySelector(".ctx-menu") }));
+// the screenshots: the open flyout, dark and light
+for (const theme of ["dark", "light"]) {
+  await page.evaluate((t) => document.body.classList.toggle("theme-light", t === "light"), theme);
+  await page.mouse.move(5, 690); await page.waitForTimeout(100);
+  await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
+  await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+  await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
+  await page.waitForTimeout(150);
+  if (cfg.shots) await page.screenshot({ path: cfg.shots + "-" + theme + ".png", clip: { x: 0, y: 0, width: 960, height: 480 } });
+  await page.keyboard.press("Escape"); await page.waitForTimeout(100);
+}
+await page.evaluate(() => document.body.classList.remove("theme-light"));
+// the default pick: the Login radio (the seed reads key: the helper is the box's default), posting setAuth with scope machine
+await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
+await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
+out.pick = await page.evaluate(() => {
+  const r = Array.from(document.querySelectorAll(".ctx-sub-billing .ctx-radio")).find((i) => i.textContent.trim().startsWith("Login"));
+  if (!r) return { found: false };
+  const disabled = r.classList.contains("disabled");
+  if (!disabled) r.click();
+  return { found: true, disabled, menuGone: !document.querySelector(".ctx-menu") };
+});
+await page.waitForTimeout(1200);   // the op reaches the kernel over the socket and the seed is written
+} catch (e) { out.error = String(e && e.stack || e); }
+fs.writeFileSync(cfg.out, JSON.stringify(out));
+await browser.close();
+console.log("RESULT: ok");
+"""
+
+
+class ServedTabTipTones(unittest.TestCase):
+    maxDiff = None
+    result = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="billing-fly-")
+        before = os.environ.get("BILLING_FLYOUT_DIST", "")
+        if before:
+            src = before
+        else:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+            src = os.path.join(EXT, "dist")
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(src, dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        # a lab root writes its own session-hosts off (the conftest rule): hosts are on by default, and a kernel-side boot
+        # attach for twenty alive sessions would otherwise spawn twenty real session hosts on a developer's machine
+        Path(state, "session-hosts").write_text("off\n")
+        os.makedirs(cwd, exist_ok=True)
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        for i, name in enumerate(NAMES):
+            sid = SIDS[name]
+            bg, fg = PALETTE[i % len(PALETTE)]
+            Path(state, "names", sid).write_text("%s\t%s\t%s\t%s\n" % (name, cwd, bg, fg))
+            reg = {"sid": sid, "name": name, "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": sid, "alive": True,
+                   "model": "claude-opus-5", "liveModel": "Opus 5"}
+            if name == "api":
+                reg["auth"] = "key"          # api carries its OWN pick; web follows the machine default
+            Path(state, "sdk", sid + ".json").write_text(json.dumps(reg))
+            recs = [{"type": "user", "timestamp": iso(t0 + i), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": sid,
+                     "message": {"role": "user", "content": "what does the %s session do in notes-api?" % name}},
+                    {"type": "assistant", "timestamp": iso(t0 + i + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": sid,
+                     "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                                 "content": [{"type": "text", "text": "It keeps the %s side of the notes-api tidy." % name}]}}]
+            Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        # BOTH sides on this machine: a staged apiKeyHelper (read, never run) in the kernel's Claude config dir, and a
+        # synthetic Claude account in the kernel's OWN home (the kernel probes the login side from ~/.claude.json)
+        helper = Path(claude, "helper.sh"); helper.write_text("#!/bin/sh\necho not-a-real-key\n"); helper.chmod(0o700)
+        Path(claude, "settings.json").write_text(json.dumps({"apiKeyHelper": str(helper)}))
+        home = os.path.join(cls.lab, "home"); os.makedirs(home, exist_ok=True)
+        Path(home, ".claude.json").write_text(json.dumps({"oauthAccount": {"accountUuid": "11111111-2222-3333-4444-555555555555",
+                                                                             "emailAddress": "user@example.com", "organizationName": "Example"}}))
+        cls.home = home
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.port, cls.token = _free_port(), "testtok-billing"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST", HOME=cls.home)
+        cls.state = state
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    @classmethod
+    def _run(cls):
+        if cls.result is not None:
+            if isinstance(cls.result, BaseException):
+                raise cls.result
+            return cls.result
+        try:
+            cls.result = cls._drive()
+        except BaseException as e:
+            cls.result = e
+            raise
+        return cls.result
+
+    @classmethod
+    def _drive(cls):
+        cfg = os.path.join(cls.lab, "cfg.json")
+        out = os.path.join(cls.lab, "result.json")
+        with open(cfg, "w") as f:
+            json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (cls.port, cls.token), "count": len(NAMES), "out": out, "sidWeb": SIDS["web"],
+                       "shots": os.environ.get("BILLING_FLYOUT_SHOTS", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=240,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(cls.klog).read()[-1500:])
+        if not os.path.exists(out):
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:])
+        result = json.loads(Path(out).read_text())
+        if os.environ.get("BILLING_FLYOUT_DUMP"):
+            Path(os.environ["BILLING_FLYOUT_DUMP"]).write_text(json.dumps(result, indent=1) + "\n")
+        if result.get("error"):
+            raise AssertionError("the driver threw: " + result["error"] + "\n  tabs: " + json.dumps(result.get("tabs")) + "\nkernel:\n" + open(cls.klog).read()[-1200:])
+        return result
+
+    def test_hovering_the_billing_row_opens_the_flyout_without_a_click(self):
+        r = self._run()
+        self.assertTrue(r["hover"]["opened"], "the flyout opened on hover, no click (the Tags flyout's gesture, T380): " + json.dumps(r["hover"]))
+        self.assertLess(r["hover"]["ms"], 1200, "within the intent window: " + json.dumps(r["hover"]))
+
+    def test_leaving_closes_the_flyout_and_keeps_the_menu_and_escape_closes_both(self):
+        r = self._run()
+        self.assertEqual(r["afterLeave"], {"fly": False, "menu": True}, "leaving the row and the flyout closes the flyout, the menu stays: " + json.dumps(r["afterLeave"]))
+        self.assertEqual(r["afterEscape"], {"fly": False, "menu": False}, "Escape closes the menu and the flyout with it: " + json.dumps(r["afterEscape"]))
+
+    def test_the_default_group_lists_the_same_choices_with_the_machine_default_marked(self):
+        r = self._run()
+        f = r["fly"]
+        self.assertIsNotNone(f, "the flyout was read")
+        table = "\n  " + json.dumps(f)
+        self.assertEqual([c["text"].split(" (")[0] for c in f["choices"]], ["Login", "API key"], table)
+        self.assertTrue(f["sep"], "a divider before the group" + table)
+        self.assertEqual(f["head"], "Default for this machine", table)
+        self.assertIn("sessions that follow the default", f["note"] or "", "the note says which sessions it affects" + table)
+        self.assertIn("own pick keeps it", f["note"] or "", table)
+        self.assertEqual([x["text"].split(" (")[0] for x in f["radios"]], ["Login", "API key"], "the same choices as radios" + table)
+        self.assertTrue(all(x["scope"] == "machine" for x in f["radios"]), table)
+        self.assertEqual([x["current"] for x in f["radios"]], [False, True], "the helper makes the key this box's default until set" + table)
+        self.assertFalse(any(x["disabled"] for x in f["radios"]), "both sides are available on this machine" + table)
+
+    def test_a_default_pick_writes_the_seed_and_touches_no_session(self):
+        r = self._run()
+        self.assertTrue(r["pick"]["found"] and not r["pick"]["disabled"], json.dumps(r["pick"]))
+        self.assertTrue(r["pick"]["menuGone"], "the pick dismisses the menu")
+        d = json.loads(Path(self.state, "sdk-defaults.json").read_text())
+        self.assertEqual((d.get("auth"), d.get("authExplicit")), ("login", True), "the machine default, explicit: " + json.dumps(d))
+        api = json.loads(Path(self.state, "sdk", SIDS["api"] + ".json").read_text())
+        self.assertEqual(api.get("auth"), "key", "a session with its own pick is untouched")
+        web = json.loads(Path(self.state, "sdk", SIDS["web"] + ".json").read_text())
+        self.assertNotIn("auth", web, "a session that follows the default carries no pick of its own; it takes the new side at its next launch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_billing_flyout_browser.py
+++ b/tests/test_billing_flyout_browser.py
@@ -85,7 +85,8 @@ const readFly = () => page.evaluate(() => {
   const head = fly.querySelector(".ctx-sub-head");
   const radios = Array.from(fly.querySelectorAll(".ctx-radio")).map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled"), scope: i.dataset.scope }));
   const r = fly.getBoundingClientRect();
-  return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height } };
+  const row = document.querySelector(".ctx-menu .ctx-item-billing .ctx-item-sub");
+  return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height }, subLine: row ? row.textContent : null };
 });
 const out = {};
 out.tabs = await page.evaluate(() => Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => ({ id: t.dataset.id, name: (t.querySelector(".tab-label") || t).textContent.trim(), active: t.classList.contains("active") })));
@@ -115,7 +116,7 @@ for (const theme of ["dark", "light"]) {
   await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
   await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
   await page.waitForTimeout(150);
-  if (cfg.shots) await page.screenshot({ path: cfg.shots + "-" + theme + ".png", clip: { x: 0, y: 0, width: 960, height: 480 } });
+  if (cfg.shots) await page.screenshot({ path: cfg.shots + "-" + theme + ".png", clip: { x: 0, y: 0, width: 1100, height: 520 } });
   await page.keyboard.press("Escape"); await page.waitForTimeout(100);
 }
 await page.evaluate(() => document.body.classList.remove("theme-light"));
@@ -131,6 +132,14 @@ out.pick = await page.evaluate(() => {
   return { found: true, disabled, menuGone: !document.querySelector(".ctx-menu") };
 });
 await page.waitForTimeout(1200);   // the op reaches the kernel over the socket and the seed is written
+await page.waitForFunction(() => { const s = document.querySelector('#tabs .tab.active'); return !!s; }, null, { timeout: 5000 });
+await page.waitForTimeout(800);     // the next push carries web's new effective side
+await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
+await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
+await page.waitForTimeout(150);
+out.afterPick = await readFly();
+await page.keyboard.press("Escape");
 } catch (e) { out.error = String(e && e.stack || e); }
 fs.writeFileSync(cfg.out, JSON.stringify(out));
 await browser.close();
@@ -223,8 +232,16 @@ class ServedTabTipTones(unittest.TestCase):
     def tearDownClass(cls):
         k = getattr(cls, "kernel", None)
         if k:
-            k.kill(); k.wait()
-        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+            k.terminate()
+            try:
+                k.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                k.kill(); k.wait()
+            time.sleep(0.5)                # a kernel child still writing into the lab's config dir finishes (review: stray dirs)
+        lab = getattr(cls, "lab", "")
+        shutil.rmtree(lab, ignore_errors=True)
+        time.sleep(0.3)
+        shutil.rmtree(lab, ignore_errors=True)   # …and whatever landed between the two
 
     @classmethod
     def _run(cls):
@@ -282,12 +299,14 @@ class ServedTabTipTones(unittest.TestCase):
         self.assertEqual([c["text"].split(" (")[0] for c in f["choices"]], ["Login", "API key"], table)
         self.assertTrue(f["sep"], "a divider before the group" + table)
         self.assertEqual(f["head"], "Default for this machine", table)
-        self.assertIn("sessions that follow the default", f["note"] or "", "the note says which sessions it affects" + table)
-        self.assertIn("own pick keeps it", f["note"] or "", table)
-        self.assertEqual([x["text"].split(" (")[0] for x in f["radios"]], ["Login", "API key"], "the same choices as radios" + table)
+        self.assertIn("sessions with no pick of their own", f["note"] or "", "the note says which sessions it affects (the automatic rule before any explicit default)" + table)
+        self.assertEqual([x["text"].split(" (")[0] for x in f["radios"]], ["Login", "API key", "Automatic"], "the same choices as radios, then Automatic (the helper rule)" + table)
         self.assertTrue(all(x["scope"] == "machine" for x in f["radios"]), table)
-        self.assertEqual([x["current"] for x in f["radios"]], [False, True], "the helper makes the key this box's default until set" + table)
+        self.assertEqual([x["current"] for x in f["radios"]], [False, False, True], "no explicit default yet: Automatic is marked" + table)
+        self.assertIn("automatic:", f["note"], "the sub-line says the helper rule holds" + table)
+        self.assertEqual(f["radios"][2]["text"], "Automatic (API key here)", "and what it resolves to on this machine" + table)
         self.assertFalse(any(x["disabled"] for x in f["radios"]), "both sides are available on this machine" + table)
+        self.assertEqual(f["subLine"], "API key", "web follows the automatic default: the key (the helper)" + table)
 
     def test_a_default_pick_writes_the_seed_and_touches_no_session(self):
         r = self._run()
@@ -299,6 +318,16 @@ class ServedTabTipTones(unittest.TestCase):
         self.assertEqual(api.get("auth"), "key", "a session with its own pick is untouched")
         web = json.loads(Path(self.state, "sdk", SIDS["web"] + ".json").read_text())
         self.assertNotIn("auth", web, "a session that follows the default carries no pick of its own; it takes the new side at its next launch")
+        # the review's shape: an unpicked session FOLLOWS the default at once, in its status and the flyout's marks
+        a = r["afterPick"]
+        self.assertIsNotNone(a, "the flyout was read again after the pick")
+        table = "\n  " + json.dumps(a)
+        # the review's medium first: an unpicked session FOLLOWS the default at once (its status, the flyout's marks)
+        self.assertTrue((a["subLine"] or "").startswith("Login"), "web (no pick of its own) now reads the login, at once" + table)
+        self.assertEqual([c["current"] for c in a["choices"]], [True, False], "…and its own choice marks the login it follows" + table)
+        self.assertEqual([x["current"] for x in a["radios"]], [True, False, False], "the Login default is marked, Automatic no longer" + table)
+        self.assertIn("set here:", a["note"], "the sub-line says the default is explicit" + table)
+        self.assertIn("own pick keeps it", a["note"], table)
 
 
 if __name__ == "__main__":

--- a/tests/test_billing_flyout_browser.py
+++ b/tests/test_billing_flyout_browser.py
@@ -86,7 +86,10 @@ const readFly = () => page.evaluate(() => {
   const radios = Array.from(fly.querySelectorAll(".ctx-radio")).map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled"), scope: i.dataset.scope }));
   const r = fly.getBoundingClientRect();
   const row = document.querySelector(".ctx-menu .ctx-item-billing .ctx-item-sub");
-  return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height }, subLine: row ? row.textContent : null };
+  const rowEl = document.querySelector(".ctx-menu .ctx-item-billing"); const rr = rowEl ? rowEl.getBoundingClientRect() : null;
+  const menuEl = document.querySelector(".ctx-menu:not(.ctx-sub)"); const mr = menuEl ? menuEl.getBoundingClientRect() : null;
+  return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height, right: r.right, bottom: r.bottom }, subLine: row ? row.textContent : null,
+    rowRect: rr ? { left: rr.left, right: rr.right, top: rr.top, bottom: rr.bottom } : null, menuRect: mr ? { left: mr.left, right: mr.right } : null, viewport: window.innerWidth };
 });
 const out = {};
 out.tabs = await page.evaluate(() => Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => ({ id: t.dataset.id, name: (t.querySelector(".tab-label") || t).textContent.trim(), active: t.classList.contains("active") })));
@@ -120,6 +123,18 @@ for (const theme of ["dark", "light"]) {
   await page.keyboard.press("Escape"); await page.waitForTimeout(100);
 }
 await page.evaluate(() => document.body.classList.remove("theme-light"));
+// narrow windows (review: at 560, 760 and 886 px the flyout covered its menu and ran off-screen): inside the viewport, never over the row
+out.narrow = {};
+for (const w of [560, 760, 886]) {
+  await page.setViewportSize({ width: w, height: 700 }); await page.waitForTimeout(150);
+  await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
+  await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+  await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
+  await page.waitForTimeout(150);
+  out.narrow[w] = await readFly();
+  await page.keyboard.press("Escape"); await page.waitForTimeout(100);
+}
+await page.setViewportSize({ width: 1100, height: 700 }); await page.waitForTimeout(150);
 // the default pick: the Login radio (the seed reads key: the helper is the box's default), posting setAuth with scope machine
 await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
 await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
@@ -299,12 +314,13 @@ class ServedTabTipTones(unittest.TestCase):
         self.assertEqual([c["text"].split(" (")[0] for c in f["choices"]], ["Login", "API key"], table)
         self.assertTrue(f["sep"], "a divider before the group" + table)
         self.assertEqual(f["head"], "Default for this machine", table)
-        self.assertIn("sessions with no pick of their own", f["note"] or "", "the note says which sessions it affects (the automatic rule before any explicit default)" + table)
+        self.assertIn("new and unpicked sessions follow it", f["note"] or "", "the note says which sessions it affects (the automatic rule before any explicit default)" + table)
         self.assertEqual([x["text"].split(" (")[0] for x in f["radios"]], ["Login", "API key", "Automatic"], "the same choices as radios, then Automatic (the helper rule)" + table)
         self.assertTrue(all(x["scope"] == "machine" for x in f["radios"]), table)
         self.assertEqual([x["current"] for x in f["radios"]], [False, False, True], "no explicit default yet: Automatic is marked" + table)
         self.assertIn("automatic:", f["note"], "the sub-line says the helper rule holds" + table)
-        self.assertEqual(f["radios"][2]["text"], "Automatic (API key here)", "and what it resolves to on this machine" + table)
+        self.assertEqual(f["radios"][2]["text"], "Automatic (API key)", "and what it resolves to on this machine" + table)
+        self.assertLessEqual(f["rect"]["w"], 380, "a menu's width, not a paragraph's (review: 585 px)" + table)
         self.assertFalse(any(x["disabled"] for x in f["radios"]), "both sides are available on this machine" + table)
         self.assertEqual(f["subLine"], "API key", "web follows the automatic default: the key (the helper)" + table)
 
@@ -327,7 +343,19 @@ class ServedTabTipTones(unittest.TestCase):
         self.assertEqual([c["current"] for c in a["choices"]], [True, False], "…and its own choice marks the login it follows" + table)
         self.assertEqual([x["current"] for x in a["radios"]], [True, False, False], "the Login default is marked, Automatic no longer" + table)
         self.assertIn("set here:", a["note"], "the sub-line says the default is explicit" + table)
-        self.assertIn("own pick keeps it", a["note"], table)
+        self.assertIn("own pick stays", a["note"], table)
+
+    def test_in_a_narrow_window_the_flyout_stays_inside_the_viewport_and_never_covers_its_row(self):
+        r = self._run()
+        for w, f in r["narrow"].items():
+            table = "\n  %s px: %s" % (w, json.dumps(f)[:700])
+            self.assertIsNotNone(f, table)
+            self.assertGreaterEqual(f["rect"]["left"], 8 - 0.5, "inside the viewport, left" + table)
+            self.assertLessEqual(f["rect"]["right"], f["viewport"] - 8 + 0.5, "inside the viewport, right" + table)
+            rr = f["rowRect"]
+            beside = f["rect"]["left"] >= rr["right"] - 0.5 or f["rect"]["right"] <= rr["left"] + 0.5
+            below = f["rect"]["top"] >= rr["bottom"] - 0.5
+            self.assertTrue(beside or below, "never over its own row: beside it, or below it" + table)
 
 
 if __name__ == "__main__":

--- a/tests/test_billing_flyout_browser.py
+++ b/tests/test_billing_flyout_browser.py
@@ -89,7 +89,7 @@ const readFly = () => page.evaluate(() => {
   const rowEl = document.querySelector(".ctx-menu .ctx-item-billing"); const rr = rowEl ? rowEl.getBoundingClientRect() : null;
   const menuEl = document.querySelector(".ctx-menu:not(.ctx-sub)"); const mr = menuEl ? menuEl.getBoundingClientRect() : null;
   return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height, right: r.right, bottom: r.bottom }, subLine: row ? row.textContent : null,
-    rowRect: rr ? { left: rr.left, right: rr.right, top: rr.top, bottom: rr.bottom } : null, menuRect: mr ? { left: mr.left, right: mr.right } : null, viewport: window.innerWidth };
+    rowRect: rr ? { left: rr.left, right: rr.right, top: rr.top, bottom: rr.bottom } : null, menuRect: mr ? { left: mr.left, right: mr.right } : null, viewport: window.innerWidth, viewportH: window.innerHeight };
 });
 const out = {};
 out.tabs = await page.evaluate(() => Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => ({ id: t.dataset.id, name: (t.querySelector(".tab-label") || t).textContent.trim(), active: t.classList.contains("active") })));
@@ -125,13 +125,13 @@ for (const theme of ["dark", "light"]) {
 await page.evaluate(() => document.body.classList.remove("theme-light"));
 // narrow windows (review: at 560, 760 and 886 px the flyout covered its menu and ran off-screen): inside the viewport, never over the row
 out.narrow = {};
-for (const w of [560, 760, 886]) {
-  await page.setViewportSize({ width: w, height: 700 }); await page.waitForTimeout(150);
+for (const [w, h] of [[560, 700], [760, 700], [886, 700], [560, 420], [560, 300]]) {
+  await page.setViewportSize({ width: w, height: h }); await page.waitForTimeout(150);
   await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
   await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
   await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
   await page.waitForTimeout(150);
-  out.narrow[w] = await readFly();
+  out.narrow[w + "x" + h] = await readFly();
   await page.keyboard.press("Escape"); await page.waitForTimeout(100);
 }
 await page.setViewportSize({ width: 1100, height: 700 }); await page.waitForTimeout(150);
@@ -345,17 +345,27 @@ class ServedTabTipTones(unittest.TestCase):
         self.assertIn("set here:", a["note"], "the sub-line says the default is explicit" + table)
         self.assertIn("own pick stays", a["note"], table)
 
-    def test_in_a_narrow_window_the_flyout_stays_inside_the_viewport_and_never_covers_its_row(self):
+    def test_in_a_narrow_or_short_window_the_flyout_stays_inside_the_viewport_and_never_covers_its_row_while_a_place_exists(self):
         r = self._run()
-        for w, f in r["narrow"].items():
-            table = "\n  %s px: %s" % (w, json.dumps(f)[:700])
+        for size, f in r["narrow"].items():
+            table = "\n  %s: %s" % (size, json.dumps(f)[:800])
             self.assertIsNotNone(f, table)
             self.assertGreaterEqual(f["rect"]["left"], 8 - 0.5, "inside the viewport, left" + table)
             self.assertLessEqual(f["rect"]["right"], f["viewport"] - 8 + 0.5, "inside the viewport, right" + table)
-            rr = f["rowRect"]
-            beside = f["rect"]["left"] >= rr["right"] - 0.5 or f["rect"]["right"] <= rr["left"] + 0.5
-            below = f["rect"]["top"] >= rr["bottom"] - 0.5
-            self.assertTrue(beside or below, "never over its own row: beside it, or below it" + table)
+            self.assertGreaterEqual(f["rect"]["top"], -0.5, "inside the viewport, top" + table)
+            self.assertLessEqual(f["rect"]["bottom"], f["viewportH"] + 0.5, "inside the viewport, bottom" + table)
+            rr, fr = f["rowRect"], f["rect"]
+            beside = fr["left"] >= rr["right"] - 0.5 or fr["right"] <= rr["left"] + 0.5
+            below = fr["top"] >= rr["bottom"] - 0.5
+            above = fr["bottom"] <= rr["top"] + 0.5
+            fits_below = rr["bottom"] + 2 + fr["h"] <= f["viewportH"] - 4
+            fits_above = rr["top"] - 2 - fr["h"] >= 0
+            if fits_below or fits_above:
+                self.assertTrue(beside or below or above, "never over its own row while a place beside, below or above exists" + table)
+            if fits_below and not beside:
+                self.assertTrue(below, "below the row when it fits there (review: the clamp pulled it back over the row)" + table)
+            elif fits_above and not beside:
+                self.assertTrue(above, "above the row's top when below does not fit" + table)
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -78,24 +78,50 @@ class TheJudgesFollowTheMachineDefault(unittest.TestCase):
         self.fsid = "11111111-2222-3333-4444-555555555555"
         (jd.SDKDIR / (self.fsid + ".json")).write_text(json.dumps({"sid": self.fsid, "name": "web"}))   # no pick of its own
         self._key = jd._key_available
+        self._fn = jd._DEFAULT_AUTH_FN
+        jd._DEFAULT_AUTH_FN = None
 
     def tearDown(self):
         jd._key_available = self._key
+        jd._DEFAULT_AUTH_FN = self._fn
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_an_unpicked_session_follows_the_explicit_default_and_a_key_default_without_a_helper_falls_to_the_login(self):
+    def test_the_judges_ask_the_one_resolver_the_kernel_wires_so_an_unbillable_default_moves_them_with_the_launch(self):
+        """Round-3 review: a seed re-read here kept billing the login after the machine could no longer bill it (the login
+        logged out, a managed helper appearing) while the launch, the status and the flyout had moved to the key; and an
+        explicit key default with unreadable Claude Code settings made the picker keep the key while the judge said login.
+        The judges now ask SdkBackend.default_auth over the reg, the resolver that applies the availability check."""
+        calls = []
+        # the resolver's verdicts, as the backend would give them for these regs: a logged-out login default → key
+        jd._DEFAULT_AUTH_FN = lambda reg: (calls.append(dict(reg)), "key")[1]
         jd._key_available = lambda: True
-        self.assertEqual(jd._judge_auth(self.fsid), "key", "no default: the helper rule")
-        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"auth": "login", "authExplicit": True}))
-        self.assertEqual(jd._judge_auth(self.fsid), "login", "the explicit login default, as the launch does")
-        self.assertEqual(jd._judge_auth(""), "login", "a call with no session takes the same default a fresh session would")
-        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"auth": "login"}))
-        self.assertEqual(jd._judge_auth(self.fsid), "key", "a remembered pick that is not explicit: the helper rule (a new session seeds from it, an existing one does not follow)")
-        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"auth": "key", "authExplicit": True}))
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "the resolver's word, not a seed re-read")
+        self.assertEqual(calls[-1].get("sid"), self.fsid, "asked over the session's own reg")
+        # the fourth shape: an explicit key default with unreadable settings: the resolver keeps the key (cannot tell is
+        # never a fall), while the standalone helper probe would have said no key
         jd._key_available = lambda: False
-        self.assertEqual(jd._judge_auth(self.fsid), "login", "an explicit key default on a box without a helper falls to the login")
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "the resolver decides even when the judge's own helper probe says no")
+        self.assertEqual(jd._judge_auth(""), "key", "a call with no session asks the resolver over an empty reg")
+        self.assertEqual(calls[-1], {}, "…the empty reg")
+        # a session's own pick: the resolver returns it (default_auth reads the reg first); the judge trusts the resolver
+        (jd.SDKDIR / (self.fsid + ".json")).write_text(json.dumps({"sid": self.fsid, "auth": "login"}))
+        jd._DEFAULT_AUTH_FN = lambda reg: reg.get("auth") or "key"
+        self.assertEqual(jd._judge_auth(self.fsid), "login")
+        # a resolver that fails or answers junk never raises inside a judge call: the standalone rule decides
+        jd._DEFAULT_AUTH_FN = lambda reg: (_ for _ in ()).throw(RuntimeError("boom"))
+        self.assertEqual(jd._judge_auth(self.fsid), "login", "the reg's own pick, standalone")
+        jd._DEFAULT_AUTH_FN = lambda reg: "credit-card"
+        (jd.SDKDIR / (self.fsid + ".json")).write_text(json.dumps({"sid": self.fsid}))
+        jd._key_available = lambda: True
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "junk from the resolver: the helper rule")
+
+    def test_standalone_the_registry_pick_and_the_helper_rule_stand_in(self):
+        jd._key_available = lambda: True
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "no wiring, no pick: the helper rule")
+        jd._key_available = lambda: False
+        self.assertEqual(jd._judge_auth(self.fsid), "login")
         (jd.SDKDIR / (self.fsid + ".json")).write_text(json.dumps({"sid": self.fsid, "auth": "key"}))
-        self.assertEqual(jd._judge_auth(self.fsid), "key", "a session's own pick beats the default")
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "a session's own pick")
 
 
 class _JudgeAuthBase(unittest.TestCase):

--- a/tests/test_judge_auth_billing.py
+++ b/tests/test_judge_auth_billing.py
@@ -32,6 +32,7 @@ is stripped; the staged helper is a path that is read and never run.
 """
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -65,6 +66,36 @@ HELPER_OFF = ["--settings", '{"apiKeyHelper": ""}']   # the login-billed call's 
 def _op_names():
     """Every 1Password CLI name the judge boundary strips: the fixed names plus one under the prefix."""
     return tuple(jd._cred.OP_ENV_NAMES) + (jd._cred.OP_ENV_PREFIX + "acct",)
+
+
+class TheJudgesFollowTheMachineDefault(unittest.TestCase):
+    """T380 review: _judge_auth resolved an unpicked session as key-when-helper-else-login while the launch honours the
+    machine's explicit default; the judges read the same seed (sdk-defaults.json) so they bill the session's account."""
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        jd._rebind_state(Path(self.tmp))
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        self.fsid = "11111111-2222-3333-4444-555555555555"
+        (jd.SDKDIR / (self.fsid + ".json")).write_text(json.dumps({"sid": self.fsid, "name": "web"}))   # no pick of its own
+        self._key = jd._key_available
+
+    def tearDown(self):
+        jd._key_available = self._key
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_an_unpicked_session_follows_the_explicit_default_and_a_key_default_without_a_helper_falls_to_the_login(self):
+        jd._key_available = lambda: True
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "no default: the helper rule")
+        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"auth": "login", "authExplicit": True}))
+        self.assertEqual(jd._judge_auth(self.fsid), "login", "the explicit login default, as the launch does")
+        self.assertEqual(jd._judge_auth(""), "login", "a call with no session takes the same default a fresh session would")
+        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"auth": "login"}))
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "a remembered pick that is not explicit: the helper rule (a new session seeds from it, an existing one does not follow)")
+        (jd.STATE / "sdk-defaults.json").write_text(json.dumps({"auth": "key", "authExplicit": True}))
+        jd._key_available = lambda: False
+        self.assertEqual(jd._judge_auth(self.fsid), "login", "an explicit key default on a box without a helper falls to the login")
+        (jd.SDKDIR / (self.fsid + ".json")).write_text(json.dumps({"sid": self.fsid, "auth": "key"}))
+        self.assertEqual(jd._judge_auth(self.fsid), "key", "a session's own pick beats the default")
 
 
 class _JudgeAuthBase(unittest.TestCase):

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -550,7 +550,7 @@ class AvailabilityOncePerCycle(unittest.TestCase):
             b = km._auth_avail_status()
             self.assertEqual(len(calls), 1, "one compute for the cycle")
             self.assertEqual(a, b)
-            self.assertEqual(a, {"login": True, "key": False, "keyWhy": km.jd._cred.WHY_NO_HELPER}, "the status half only")
+            self.assertEqual(a, {"login": True, "key": False, "keyWhy": km.jd._cred.WHY_NO_HELPER, "default": "login"}, "the status half, with the machine default since T380")
             a["login"] = False
             self.assertTrue(km._auth_avail_status()["login"], "a caller's mutation does not leak into the memo")
             km._live_scope.auth = None                                # the cycle closes
@@ -702,6 +702,31 @@ class SetAuth(_Keyed):
         # …and the next spawn seeds from it
         sid2 = self.be.spawn("m", "/tmp")
         self.assertEqual(sb.read_reg(self.be.state_dir, sid2).get("auth"), "login")
+
+    def test_the_machine_default_is_set_explicitly_and_a_session_pick_then_moves_it_no_more(self):
+        """T380 (the user 2026-09-12): the Billing flyout's Default group writes the seed every new session and every
+        session with no pick of its own launches on; a session with its own pick keeps it; once set explicitly the
+        per-session pick no longer seeds the default (before, the last pick did)."""
+        picked = self.be.spawn("p", "/tmp", auth="login")
+        self.assertTrue(self.be.set_auth_default("key"))
+        d = sb.read_sdk_defaults(self.be.state_dir)
+        self.assertEqual((d.get("auth"), d.get("authExplicit")), ("key", True))
+        self.assertEqual(sb.read_reg(self.be.state_dir, picked)["auth"], "login", "a session with its own pick is untouched")
+        self.assertEqual(sb.read_reg(self.be.state_dir, self.be.spawn("q", "/tmp")).get("auth"), "key", "a new session follows the default")
+        # a per-session pick is about that session now: the default stays where the user set it
+        sid = self.be.spawn("n", "/tmp")
+        self.assertTrue(self.be.set_auth(sid, "login"))
+        self.assertEqual(sb.read_sdk_defaults(self.be.state_dir).get("auth"), "key", "the explicit default is not moved by a session pick")
+        self.assertEqual(sb.read_reg(self.be.state_dir, sid)["auth"], "login")
+        self.assertTrue(self.be.set_auth_default("login"))
+        self.assertEqual(sb.read_sdk_defaults(self.be.state_dir).get("auth"), "login")
+        self.assertFalse(self.be.set_auth_default("credit-card"), "junk is not a side")
+
+    def test_the_machine_default_refuses_a_side_this_box_cannot_bill_with_the_reason(self):
+        self._no_helper()
+        self.assertFalse(self.be.set_auth_default("key"))
+        self.assertEqual(self.be.last_auth_refusal, sb._cred.WHY_NO_HELPER)
+        self.assertNotEqual(sb.read_sdk_defaults(self.be.state_dir).get("auth"), "key")
 
     def test_the_picker_pick_beats_the_remembered_default(self):
         sb.write_sdk_default(self.be.state_dir, auth="login")
@@ -956,16 +981,17 @@ class Availability(unittest.TestCase):
         a = km._auth_avail()
         self.assertNotIn("loginWhy", a)
         self.assertNotIn("keyWhy", a)
-        self.assertEqual(km._auth_avail_status(), {"login": True, "key": True})
+        self.assertEqual(km._auth_avail_status(), {"login": True, "key": True, "default": "key"},
+                         "the status half carries the machine default since T380 (the Billing flyout's Default group marks it)")
         self._world(FAKE_KEY, "")
         a = km._auth_avail()
         self.assertEqual(a["loginWhy"], km.jd._cred.WHY_NO_LOGIN)
-        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_NO_LOGIN})
+        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_NO_LOGIN, "default": "key"})
         self._world("", "aaaaaaaaaaaa")
         self.assertEqual(km._auth_avail()["keyWhy"], km.jd._cred.WHY_NO_HELPER)
         self._world(FAKE_KEY, "aaaaaaaaaaaa", managed=True)
         self.assertEqual(km._auth_avail()["loginWhy"], km.jd._cred.WHY_MANAGED_HELPER)
-        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_MANAGED_HELPER})
+        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_MANAGED_HELPER, "default": "key"})
         self.assertNotIn(FAKE_KEY, json.dumps(km._auth_avail()), "the reasons carry no key material either")
 
     def test_the_default_falls_to_the_side_that_exists_both_ways(self):
@@ -1091,6 +1117,11 @@ class DrivePlumbing(unittest.TestCase):
         self.assertIn('"setAuth", "endSession"', src.replace("\n", " "), "an ID_OPS member")
         self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src)
         self.assertIn("def _set_auth_or_park(be, sid, value):", src)
+        # the machine's default (T380): the same op with scope "machine" writes the seed on THIS kernel and touches no session
+        self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key") and msg.get("scope") == "machine":', src)
+        self.assertIn('if not be.set_auth_default(str(msg["value"])):', src)
+        self.assertLess(src.index('msg.get("scope") == "machine"'), src.index('elif t == "setAuth" and msg.get("value") in ("login", "key"):'),
+                        "the scoped arm is tried first: the plain arm would otherwise swallow it as a per-session pick")
         self.assertIn('_gate_or_park(sid, ("auth", value))', src)   # parks on the gate, or hands over (2026-09-05)
         self.assertIn('elif op[0] == "auth":', src)
         self.assertIn("be.set_auth(sid, op[1])", src)

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -550,7 +550,7 @@ class AvailabilityOncePerCycle(unittest.TestCase):
             b = km._auth_avail_status()
             self.assertEqual(len(calls), 1, "one compute for the cycle")
             self.assertEqual(a, b)
-            self.assertEqual(a, {"login": True, "key": False, "keyWhy": km.jd._cred.WHY_NO_HELPER, "default": "login"}, "the status half, with the machine default since T380")
+            self.assertEqual(a, {"login": True, "key": False, "keyWhy": km.jd._cred.WHY_NO_HELPER, "default": "login"}, "the status half, with the machine default since T380 (this stub of _auth_avail sends no explicit flag)")
             a["login"] = False
             self.assertTrue(km._auth_avail_status()["login"], "a caller's mutation does not leak into the memo")
             km._live_scope.auth = None                                # the cycle closes
@@ -721,6 +721,62 @@ class SetAuth(_Keyed):
         self.assertTrue(self.be.set_auth_default("login"))
         self.assertEqual(sb.read_sdk_defaults(self.be.state_dir).get("auth"), "login")
         self.assertFalse(self.be.set_auth_default("credit-card"), "junk is not a side")
+        # Automatic (review): the flag and the seed clear, the helper rule holds again, and a session pick seeds once more
+        self.assertTrue(self.be.set_auth_default("auto"))
+        d = sb.read_sdk_defaults(self.be.state_dir)
+        self.assertEqual((d.get("auth"), d.get("authExplicit")), ("", False))
+        self.assertEqual(self.be.fallback_auth(), "key", "the helper rule again")
+        self.assertTrue(self.be.set_auth(sid, "key"))
+        self.assertEqual(sb.read_sdk_defaults(self.be.state_dir).get("auth"), "key", "a session pick seeds the default again once it is automatic")
+
+    def test_a_session_with_no_pick_of_its_own_follows_the_explicit_default_at_once(self):
+        """The review of the first cut: the default reached only NEW sessions while the flyout's note promised that
+        sessions with no pick follow it too. default_auth (a dormant reg) and effective_auth (a live session) read
+        the explicit seed when this box can bill it; the launch applies it next time; the marks agree at once."""
+        u = self.be.spawn("u", "/tmp")
+        reg = sb.read_reg(self.be.state_dir, u)
+        self.assertNotIn("auth", reg)
+        self.assertEqual(self.be.default_auth(reg), "key", "the helper rule before any explicit default")
+        live = sb.SdkSession(self.be, reg)
+        self.assertEqual(live.effective_auth(), "key")
+        self.assertTrue(self.be.set_auth_default("login"))
+        self.assertEqual(self.be.default_auth(reg), "login", "a dormant unpicked session follows the explicit default")
+        self.assertEqual(live.effective_auth(), "login", "…and a live one, in its status at once")
+        self.assertEqual(self.be.explicit_default_auth(), "login")
+        # the seed side this box cannot bill is not followed: the helper rule holds and the flyout greys that radio
+        self._no_helper()
+        self.assertTrue(self.be.set_auth_default("login"))
+        sb.write_sdk_default(self.be.state_dir, auth="key", authExplicit=True)   # a stale explicit key on a box that lost its helper
+        self.assertEqual(self.be.default_auth(reg), "login", "an explicit side this box cannot bill is not followed")
+        self.assertEqual(live.effective_auth(), "login")
+        # a session with its own pick is untouched by any of it
+        p = self.be.spawn("p", "/tmp", auth="login")
+        sb.write_sdk_default(self.be.state_dir, auth="key", authExplicit=True)
+        self.assertEqual(self.be.default_auth(sb.read_reg(self.be.state_dir, p)), "login")
+
+    def test_the_kernel_door_refuses_loudly_through_the_drive(self):
+        """The scoped arm's toast (review): a backend without the writer (Codex) is refused by name, a refused side
+        carries the backend's reason; neither raises inside the drive."""
+        sent = []
+        client = {"send": lambda s: sent.append(json.loads(s))}
+        saved = (km.Sessions.backend_for, km._kernel_knows, km._push_soon)
+        try:
+            km._kernel_knows = lambda sid: True
+            km._push_soon = lambda: None
+            class NoWriter:          # a backend that keeps no machine default
+                pass
+            km.Sessions.backend_for = staticmethod(lambda sid: NoWriter())
+            self.assertTrue(km._drive({"type": "setAuth", "id": "11111111-2222-3333-4444-555555555555", "value": "login", "scope": "machine"}, client) is not False)
+            self.assertEqual(sent[-1]["type"], "warn")
+            self.assertIn("keeps no machine billing default", sent[-1]["text"])
+            class Refuser:
+                def set_auth_default(self, v): return False
+                def auth_unavailable_why(self, v): return "no apiKeyHelper configured"
+            km.Sessions.backend_for = staticmethod(lambda sid: Refuser())
+            km._drive({"type": "setAuth", "id": "11111111-2222-3333-4444-555555555555", "value": "key", "scope": "machine"}, client)
+            self.assertEqual(sent[-1]["text"], "Couldn't set this machine's default billing: no apiKeyHelper configured.")
+        finally:
+            km.Sessions.backend_for, km._kernel_knows, km._push_soon = saved
 
     def test_the_machine_default_refuses_a_side_this_box_cannot_bill_with_the_reason(self):
         self._no_helper()
@@ -981,17 +1037,17 @@ class Availability(unittest.TestCase):
         a = km._auth_avail()
         self.assertNotIn("loginWhy", a)
         self.assertNotIn("keyWhy", a)
-        self.assertEqual(km._auth_avail_status(), {"login": True, "key": True, "default": "key"},
-                         "the status half carries the machine default since T380 (the Billing flyout's Default group marks it)")
+        self.assertEqual(km._auth_avail_status(), {"login": True, "key": True, "default": "key", "defaultExplicit": False},
+                         "the status half carries the machine default since T380 (the Billing flyout's Default group marks it), and whether it is explicit")
         self._world(FAKE_KEY, "")
         a = km._auth_avail()
         self.assertEqual(a["loginWhy"], km.jd._cred.WHY_NO_LOGIN)
-        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_NO_LOGIN, "default": "key"})
+        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_NO_LOGIN, "default": "key", "defaultExplicit": False})
         self._world("", "aaaaaaaaaaaa")
         self.assertEqual(km._auth_avail()["keyWhy"], km.jd._cred.WHY_NO_HELPER)
         self._world(FAKE_KEY, "aaaaaaaaaaaa", managed=True)
         self.assertEqual(km._auth_avail()["loginWhy"], km.jd._cred.WHY_MANAGED_HELPER)
-        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_MANAGED_HELPER, "default": "key"})
+        self.assertEqual(km._auth_avail_status(), {"login": False, "key": True, "loginWhy": km.jd._cred.WHY_MANAGED_HELPER, "default": "key", "defaultExplicit": False})
         self.assertNotIn(FAKE_KEY, json.dumps(km._auth_avail()), "the reasons carry no key material either")
 
     def test_the_default_falls_to_the_side_that_exists_both_ways(self):
@@ -1118,8 +1174,9 @@ class DrivePlumbing(unittest.TestCase):
         self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key"):', src)
         self.assertIn("def _set_auth_or_park(be, sid, value):", src)
         # the machine's default (T380): the same op with scope "machine" writes the seed on THIS kernel and touches no session
-        self.assertIn('elif t == "setAuth" and msg.get("value") in ("login", "key") and msg.get("scope") == "machine":', src)
-        self.assertIn('if not be.set_auth_default(str(msg["value"])):', src)
+        self.assertIn('elif t == "setAuth" and msg.get("scope") == "machine" and msg.get("value") in ("login", "key", "auto"):', src)
+        self.assertIn('_set_def = getattr(be, "set_auth_default", None)', src)
+        self.assertIn("keeps no machine billing default", src, "a backend without the writer (Codex) is refused by name, never a raise inside the drive")
         self.assertLess(src.index('msg.get("scope") == "machine"'), src.index('elif t == "setAuth" and msg.get("value") in ("login", "key"):'),
                         "the scoped arm is tried first: the plain arm would otherwise swallow it as a per-session pick")
         self.assertIn('_gate_or_park(sid, ("auth", value))', src)   # parks on the gate, or hands over (2026-09-05)

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -1224,6 +1224,9 @@ class DrivePlumbing(unittest.TestCase):
         # the machine's default (T380): the same op with scope "machine" writes the seed on THIS kernel and touches no session
         self.assertIn('elif t == "setAuth" and msg.get("scope") == "machine" and msg.get("value") in ("login", "key", "auto"):', src)
         self.assertIn('_set_def = getattr(be, "set_auth_default", None)', src)
+        # the judges ask the same resolver the launch and the status use (round 3 of T380): the kernel wires it
+        ksrc = open(os.path.join(os.path.dirname(HERE), "kernel", "kernel.py")).read()
+        self.assertIn('jd._DEFAULT_AUTH_FN = getattr(_sdk_backend, "default_auth", None)', ksrc, "the one billing resolver, wired into the judges")
         self.assertIn("keeps no machine billing default", src, "a backend without the writer (Codex) is refused by name, never a raise inside the drive")
         self.assertLess(src.index('msg.get("scope") == "machine"'), src.index('elif t == "setAuth" and msg.get("value") in ("login", "key"):'),
                         "the scoped arm is tried first: the plain arm would otherwise swallow it as a per-session pick")

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -269,6 +269,35 @@ class OptionsInjection(_OptionsHarness):
         self.assertEqual(s._pick_fell_said, "", "nothing to fall to: no fall, no notice")
 
 
+class UnpickedFollowsTheExplicitDefaultAtLaunch(_OptionsHarness):
+    def test_the_launch_suppresses_the_helper_for_an_unpicked_session_once_the_default_is_login(self):
+        """The round-2 review: the explicit default reached an unpicked session's STATUS but not its LAUNCH (the
+        options read sess.auth, empty when unpicked, so the helper ran and the turn billed the key while the flyout
+        said Login). The launch now resolves the side by the status's rule."""
+        s = self._sess(7)                                        # minted before any default: no pick of its own
+        kw0 = self._options_kw(s)
+        self.assertNotIn("apiKeyHelper", self._settings_of(kw0), "no default: the launch stays plain, the CLI decides")
+        self.assertTrue(s._launched_keyed, "…and on a helper box that means the key")
+        self.assertTrue(self.be.set_auth_default("login"))
+        kw = self._options_kw(s)
+        self.assertEqual(self._settings_of(kw).get("apiKeyHelper"), "", "the explicit login default suppresses the helper for the next connect")
+        self.assertFalse(s._launched_keyed, "the launch means the login, as the status says")
+        self.assertEqual(s.effective_auth(), "login")
+        self.assertNotIn("ANTHROPIC_API_KEY", kw["env"])
+        self.assertFalse([p for p in self.be.problems(10) if "cannot apply" in p["text"]], "following a default is no fall: no problem row")
+        self.assertTrue(self.be.set_auth_default("key"))
+        kw2 = self._options_kw(s)
+        self.assertNotIn("apiKeyHelper", self._settings_of(kw2), "an explicit key default: the helper runs")
+        self.assertTrue(s._launched_keyed)
+        self.assertTrue(self.be.set_auth_default("auto"))
+        kw3 = self._options_kw(s)
+        self.assertNotIn("apiKeyHelper", self._settings_of(kw3), "automatic again: plain")
+        # a session with its own pick is untouched by the default
+        p = self._sess(8, auth="login")
+        self.assertTrue(self.be.set_auth_default("key"))
+        self.assertEqual(self._settings_of(self._options_kw(p)).get("apiKeyHelper"), "", "its own login pick still suppresses the helper")
+
+
 class PickFallsToTheAvailableSide(_OptionsHarness):
     """The user 2026-09-08: no login on the box means everything bills the key, never a dead login — and
     the mirror. A pick this box cannot bill launches on the side it can, says so once per session in the
@@ -775,8 +804,27 @@ class SetAuth(_Keyed):
             km.Sessions.backend_for = staticmethod(lambda sid: Refuser())
             km._drive({"type": "setAuth", "id": "11111111-2222-3333-4444-555555555555", "value": "key", "scope": "machine"}, client)
             self.assertEqual(sent[-1]["text"], "Couldn't set this machine's default billing: no apiKeyHelper configured.")
+            # a session-scoped "auto" (an older remote kernel's flyout would post it) is refused with a toast, never dropped (review)
+            km._drive({"type": "setAuth", "id": "11111111-2222-3333-4444-555555555555", "value": "auto"}, client)
+            self.assertEqual(sent[-1]["type"], "warn")
+            self.assertIn("not for one session", sent[-1]["text"])
         finally:
             km.Sessions.backend_for, km._kernel_knows, km._push_soon = saved
+
+    def test_the_explicit_default_probe_sees_a_same_size_rewrite_with_an_unchanged_mtime(self):
+        """The review's forced probe: (mtime, size) alone kept login while the file said key."""
+        self.assertTrue(self.be.set_auth_default("login"))
+        self.assertEqual(self.be.explicit_default_auth(), "login")
+        p = sb._defaults_path(self.be.state_dir)
+        st = p.stat()
+        raw = p.read_text()
+        self.assertIn('"login"', raw)
+        rewritten = raw.replace('"login"', '"key"')
+        p.write_text(rewritten + " " * (len(raw) - len(rewritten)))   # the same byte length (trailing blanks are JSON's to ignore)
+        os.utime(p, ns=(st.st_atime_ns, st.st_mtime_ns))       # the mtime held back on purpose
+        self.assertEqual(p.stat().st_size, st.st_size, "same size")
+        self.assertEqual(p.stat().st_mtime_ns, st.st_mtime_ns, "same mtime")
+        self.assertEqual(self.be.explicit_default_auth(), "key", "ctime (or the inode) tells the rewrite apart")
 
     def test_the_machine_default_refuses_a_side_this_box_cannot_bill_with_the_reason(self):
         self._no_helper()

--- a/ui/webview/feed-cap-offer.test.ts
+++ b/ui/webview/feed-cap-offer.test.ts
@@ -32,7 +32,12 @@ test("only the explicit pick switches — the gesture census, both surfaces", ()
   // the feed's ONE setAuth send is this button; the chat gear's ONE is the billing selector.
   // Any new sender shows up as a count change here before it ships.
   assert.equal((FEED.match(/type: "setAuth"/g) || []).length, 1, "feed: the offer button only");
-  assert.equal((RENDER.match(/type: "setAuth"/g) || []).length, 1, "chat: the gear billing pick only");
+  // T380: the Billing flyout gained a SECOND sender, the machine-default pick, which carries scope "machine" and
+  // switches no session (it writes the seed new sessions and unpicked sessions launch on); the per-session pick stays
+  // the one sender that switches a session
+  assert.equal((RENDER.match(/type: "setAuth"/g) || []).length, 2, "chat: the Billing flyout's session pick and its machine-default pick");
+  assert.equal((RENDER.match(/type: "setAuth", id, value: c\.value, scope: "machine"/g) || []).length, 1, "the second sender is the machine default: scope machine, no session switched");
+  assert.equal((RENDER.match(/type: "setAuth", id, value: c\.value \}/g) || []).length, 1, "the per-session pick stays the one session switcher");
   assert.match(KERNEL, /a session must NEVER\s*\n\s*silently switch billing in either direction/, "the ruling, verbatim at the mint");
 });
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6850,6 +6850,46 @@ function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag" | "p
   return span;
 }
 
+// The tab menu's ONE flyout gesture (T163 for Tags, the user 2026-08-28; T380 for Billing, the user
+// 2026-09-12): a hover of HOVER_INTENT_MS over the row opens the flyout (the feed's intent debounce:
+// enough to skip a graze, never a wait), a click opens it at once (byClick: a click may focus an input,
+// a hover-open must not steal the keyboard), a second click folds it, leaving the row and the flyout
+// for the same span closes it (native menus' gap tolerance: entering either surface cancels the pending
+// close), and `open` removes any other flyout first so one is up at a time. Timers here are gesture
+// DEFINITIONS (hover intent), not state proxies. No window listener: the timers and the row's own.
+const HOVER_INTENT_MS = 120;
+function wireFlyout(menu: HTMLElement, item: HTMLElement, sel: string, open: (byClick: boolean) => HTMLElement | null): void {
+  let openT: number | null = null;
+  let closeT: number | null = null;
+  const cancel = () => {
+    if (openT != null) { clearTimeout(openT); openT = null; }
+    if (closeT != null) { clearTimeout(closeT); closeT = null; }
+  };
+  const armClose = () => { cancel(); closeT = window.setTimeout(() => { closeT = null; menu.querySelector(sel)?.remove(); }, HOVER_INTENT_MS); };
+  const openNow = (byClick: boolean) => {
+    const fly = open(byClick);
+    if (fly && !fly.dataset.flyWired) {   // leave-tolerance on the flyout itself, wired once per flyout node
+      fly.dataset.flyWired = "1";
+      fly.addEventListener("pointerenter", cancel);
+      fly.addEventListener("pointerleave", armClose);
+    }
+    return fly;
+  };
+  item.addEventListener("pointerenter", () => {
+    cancel();
+    if (menu.querySelector(sel)) return;                         // already open — nothing to intend
+    openT = window.setTimeout(() => { openT = null; openNow(false); }, HOVER_INTENT_MS);
+  });
+  item.addEventListener("pointerleave", armClose);
+  item.addEventListener("click", (ev) => {
+    ev.stopPropagation();
+    cancel();
+    const fly = menu.querySelector(sel);
+    if (fly) { fly.remove(); return; }                           // second click folds the flyout
+    openNow(true);
+  });
+}
+
 function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: the group the right-clicked copy sits in (T264b), a plain string so the menu stays id-keyed
   dismissTabMenu();
   const menu = el("div", "ctx-menu");
@@ -7004,18 +7044,9 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       else postUnionEdits(nv, a, r);
     };
     // HOVER-INTENT open (T163, the user 2026-08-28: hovering down to Tags should open the submenu
-    // without another click): the feed's 120ms intent debounce — enough to skip a graze, never a
-    // wait. Click still opens instantly (and focuses the input; a hover-open must NOT steal the
-    // keyboard). Leaving is tolerant the way native menus are: the same 120ms lets the pointer
-    // cross the gap into the submenu; entering either surface cancels the close, leaving BOTH
-    // closes. Timers here are gesture DEFINITIONS (hover intent), not state proxies.
-    const HOVER_INTENT_MS = 120;
-    let hoverOpenT: number | null = null;
-    let hoverCloseT: number | null = null;
-    const cancelHoverTimers = () => {
-      if (hoverOpenT != null) { clearTimeout(hoverOpenT); hoverOpenT = null; }
-      if (hoverCloseT != null) { clearTimeout(hoverCloseT); hoverCloseT = null; }
-    };
+    // without another click), the one flyout gesture every tab-menu flyout wears since T380 (Billing
+    // too): wireFlyout below the menu builder holds the definition. Click still opens instantly (and
+    // focuses the input; a hover-open must NOT steal the keyboard).
     const openTagsFly = (focusInput: boolean) => {
       const openFly = menu.querySelector(".ctx-sub-tags");
       if (openFly) return openFly as HTMLElement;
@@ -7161,31 +7192,9 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       else sub.style.left = Math.max(8, Math.round(ir.left) - sr.width - 2) + "px";
       sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
       if (focusInput) (sub.querySelector(".ctx-tag-input") as HTMLInputElement | null)?.focus();
-      // leave-tolerance: entering either surface cancels the pending close; leaving both arms it
-      sub.addEventListener("pointerenter", cancelHoverTimers);
-      sub.addEventListener("pointerleave", armHoverClose);
       return sub;
     };
-    const armHoverClose = () => {
-      cancelHoverTimers();
-      hoverCloseT = window.setTimeout(() => {
-        hoverCloseT = null;
-        menu.querySelector(".ctx-sub-tags")?.remove();
-      }, HOVER_INTENT_MS);
-    };
-    tagsItem.addEventListener("pointerenter", () => {
-      cancelHoverTimers();
-      if (menu.querySelector(".ctx-sub-tags")) return;           // already open — nothing to intend
-      hoverOpenT = window.setTimeout(() => { hoverOpenT = null; openTagsFly(false); }, HOVER_INTENT_MS);
-    });
-    tagsItem.addEventListener("pointerleave", armHoverClose);
-    tagsItem.addEventListener("click", (ev) => {
-      ev.stopPropagation();
-      cancelHoverTimers();
-      const openFly = menu.querySelector(".ctx-sub-tags");
-      if (openFly) { openFly.remove(); return; }                 // second click folds the flyout
-      openTagsFly(true);
-    });
+    wireFlyout(menu, tagsItem, ".ctx-sub-tags", openTagsFly);
     menu.appendChild(tagsItem);
   }
   // Move to folder… sits beside Tags (the user 2026-09-01: a subproject became its own repo and the
@@ -7251,7 +7260,13 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
   // kernel's honest record) and the sub-line says so. The key stays labelled plainly 'API key', no
   // fragment of it anywhere. A pick posts the same setAuth the badge used (the session reconnects to
   // apply, so the sub-line says "applying…" while st.authPending rides the status). An older kernel
-  // sends no authAvail: its authBoth keeps the old both-or-nothing gate.
+  // sends no authAvail: its authBoth keeps the old both-or-nothing gate. The flyout opens on HOVER as
+  // the Tags flyout does, and on click (T380, the user 2026-09-12: one gesture, wireFlyout), and below
+  // the session's choices carries "Default for <machine>": the same choices as a radio group, the
+  // current default marked (authAvail.default, the owning kernel's seed, so a remote session's flyout
+  // shows ITS host's default), a pick posting setAuth with scope "machine", which writes the seed every
+  // NEW session and every session with no pick of its own launches on and touches no session that
+  // carries its own pick; the group's note says exactly that.
   const st = s ? s.status : null;
   if (st && st.auth && (st.authAvail || st.authBoth)) {
     const avail: AuthAvail = st.authAvail || { login: true, key: true };
@@ -7273,13 +7288,14 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
     bodyEl.appendChild(sb);
     item.appendChild(bodyEl);
     const caret = el("span", "ctx-caret"); caret.textContent = "▸"; item.appendChild(caret);
-    item.addEventListener("click", (ev) => {
-      ev.stopPropagation();
-      const open = menu.querySelector(".ctx-sub");
-      if (open) { open.remove(); return; }                       // second click folds the flyout
-      const sub = el("div", "ctx-menu ctx-sub");
-      for (const c of [{ label: st.authAcct ? `Login (${st.authAcct})` : "Login", value: "login", why: avail.login ? "" : (avail.loginWhy || "no Claude login signed in on this machine") },
-                       { label: "API key", value: "key", why: avail.key ? "" : (avail.keyWhy || "no apiKeyHelper configured") }]) {
+    const openBillingFly = (): HTMLElement | null => {
+      const already = menu.querySelector(".ctx-sub-billing");
+      if (already) return already as HTMLElement;
+      menu.querySelector(".ctx-sub")?.remove();                    // one flyout at a time
+      const sub = el("div", "ctx-menu ctx-sub ctx-sub-billing");
+      const choices = [{ label: st.authAcct ? `Login (${st.authAcct})` : "Login", value: "login", why: avail.login ? "" : (avail.loginWhy || "no Claude login signed in on this machine") },
+                       { label: "API key", value: "key", why: avail.key ? "" : (avail.keyWhy || "no apiKeyHelper configured") }];
+      for (const c of choices) {
         const opt = el("div", "ctx-item" + (st.auth === c.value ? " current" : "") + (c.why ? " disabled" : ""));
         opt.textContent = c.label;
         if (c.why) {   // unavailable here: greyed, the reason on hover, inert (the user 2026-09-08)
@@ -7294,6 +7310,31 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
         });
         sub.appendChild(opt);
       }
+      // ── Default for this machine (T380) ── the owning kernel's seed (authAvail.default): what a NEW
+      // session, and a session with no pick of its own, launches on. The same choices as radios, the
+      // current one marked; a pick posts setAuth with scope "machine" and changes no session that carries
+      // its own pick. A remote session's flyout names ITS host, whose kernel holds the seed.
+      if (avail.default) {
+        sub.appendChild(el("div", "ctx-sep"));
+        const head = el("div", "ctx-item ctx-item-toggle ctx-sub-head");
+        const hb = el("span", "ctx-item-body");
+        const hl = el("span", "ctx-item-label"); hl.textContent = "Default for " + (hostOf(id) || "this machine"); hb.appendChild(hl);
+        const hs = el("span", "ctx-item-sub"); hs.textContent = "new sessions, and sessions that follow the default; a session with its own pick keeps it"; hb.appendChild(hs);
+        head.appendChild(hb); sub.appendChild(head);
+        for (const c of choices) {
+          const opt = el("div", "ctx-item ctx-radio" + (avail.default === c.value ? " current" : "") + (c.why ? " disabled" : ""));
+          opt.textContent = c.label;
+          opt.dataset.scope = "machine";
+          if (c.why) { opt.title = c.why; opt.setAttribute("aria-disabled", "true"); }
+          opt.addEventListener("click", (ev2) => {
+            ev2.stopPropagation();
+            if (c.why) return;
+            dismissTabMenu();
+            if (avail.default !== c.value && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value, scope: "machine" });
+          });
+          sub.appendChild(opt);
+        }
+      }
       // INSIDE the menu node (so dismissTabMenu and the outside-mousedown check cover it), placed
       // beside the item — .ctx-menu is position:fixed, so the coords are viewport-space, clamped
       menu.appendChild(sub);
@@ -7301,7 +7342,9 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       const sr = sub.getBoundingClientRect();
       sub.style.left = Math.max(0, Math.min(ir.right + 2, window.innerWidth - sr.width - 4)) + "px";
       sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
-    });
+      return sub;
+    };
+    wireFlyout(menu, item, ".ctx-sub-billing", () => openBillingFly());
     menu.appendChild(item);
   }
   // ── 4. FILES: Browse files (web only). A different kind of thing, it opens another surface; last and

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7323,15 +7323,18 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
         const hs = el("span", "ctx-item-sub");
         // the sub-line says which rule holds (review): set here, or automatic (the helper rule) as before
         hs.textContent = explicit
-          ? "set here: new sessions, and sessions that follow the default; a session with its own pick keeps it"
-          : "automatic: the API key when a helper is configured, else the login; new sessions and sessions with no pick of their own";
+          ? "set here: new and unpicked sessions follow it; a session's own pick stays"
+          : "automatic: the API key when a helper is configured, else the login; new and unpicked sessions follow it";
         hb.appendChild(hs);
         head.appendChild(hb); sub.appendChild(head);
         // the same choices as radios, then Automatic (the helper rule), which clears the explicit default (review: the flag
         // was one-way and invisible); the current mark sits on the explicit side, else on Automatic
         const autoWord = avail.key ? "API key" : "Login";
-        const radios = [...choices.map((c) => ({ ...c, cur: explicit && avail.default === c.value })),
-                        { label: `Automatic (${autoWord} here)`, value: "auto", why: "", cur: !explicit }];
+        // an older kernel sends no defaultExplicit and takes no "auto": its flyout marks the side it computed and offers no
+        // Automatic radio (review: the click would be swallowed there)
+        const olderKernel = avail.defaultExplicit === undefined;
+        const radios = [...choices.map((c) => ({ ...c, cur: olderKernel ? avail.default === c.value : (explicit && avail.default === c.value) })),
+                        ...(olderKernel ? [] : [{ label: `Automatic (${autoWord})`, value: "auto", why: "", cur: !explicit }])];
         for (const c of radios) {
           const opt = el("div", "ctx-item ctx-radio" + (c.cur ? " current" : "") + (c.why ? " disabled" : ""));
           opt.textContent = c.label;
@@ -7351,11 +7354,15 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       menu.appendChild(sub);
       const ir = item.getBoundingClientRect();
       const sr = sub.getBoundingClientRect();
-      // the side rule (Tags, the model-version submenus): PREFER right; fall LEFT only when the right edge would
-      // clip — never slide over the row (review: the widened flyout slid over its own menu below about 886 px)
-      if (ir.right + 2 + sr.width <= window.innerWidth - 8) sub.style.left = Math.round(ir.right + 2) + "px";
-      else sub.style.left = Math.max(8, Math.round(ir.left) - sr.width - 2) + "px";
-      sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
+      // the side rule (Tags, the model-version submenus): PREFER right; fall LEFT when the right edge would clip and
+      // the left has room; with room on neither side (a narrow window) the flyout drops BELOW the row, clamped inside
+      // the viewport — never over the row or off-screen (review: at 560 px it covered its menu and ran 33 px out)
+      let left: number, top: number = ir.top;
+      if (ir.right + 2 + sr.width <= window.innerWidth - 8) left = Math.round(ir.right + 2);
+      else if (ir.left - 2 - sr.width >= 8) left = Math.round(ir.left) - sr.width - 2;
+      else { left = Math.max(8, Math.min(Math.round(ir.left), window.innerWidth - sr.width - 8)); top = ir.bottom + 2; }
+      sub.style.left = left + "px";
+      sub.style.top = Math.max(0, Math.min(top, window.innerHeight - sr.height - 4)) + "px";
       return sub;
     };
     wireFlyout(menu, item, ".ctx-sub-billing", () => openBillingFly());

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -309,7 +309,7 @@ interface TodoTask { id: string; subject: string; activeForm?: string; status: s
 type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: string; fg: string } | null };   // a named peer behind a peer-kind wait (kernel _peer_identity, 2026-08-26)
 // which billing sides this box can bill, and why not for the other (kernel _auth_avail, 2026-09-08): the
 // Billing submenu lists both and greys the unavailable one with the reason in its hover
-interface AuthAvail { login?: boolean; key?: boolean; loginWhy?: string; keyWhy?: string; acct?: string; default?: string }
+interface AuthAvail { login?: boolean; key?: boolean; loginWhy?: string; keyWhy?: string; acct?: string; default?: string; defaultExplicit?: boolean }   // defaultExplicit: set in the Billing flyout's Default group, else the helper rule (T380)
 interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "sdk" | "codex"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 
 // The side a pick this box cannot bill actually fell to ("login" | "key"), "" when nothing did: the kernel's
@@ -7316,13 +7316,24 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       // its own pick. A remote session's flyout names ITS host, whose kernel holds the seed.
       if (avail.default) {
         sub.appendChild(el("div", "ctx-sep"));
+        const explicit = !!avail.defaultExplicit;
         const head = el("div", "ctx-item ctx-item-toggle ctx-sub-head");
         const hb = el("span", "ctx-item-body");
         const hl = el("span", "ctx-item-label"); hl.textContent = "Default for " + (hostOf(id) || "this machine"); hb.appendChild(hl);
-        const hs = el("span", "ctx-item-sub"); hs.textContent = "new sessions, and sessions that follow the default; a session with its own pick keeps it"; hb.appendChild(hs);
+        const hs = el("span", "ctx-item-sub");
+        // the sub-line says which rule holds (review): set here, or automatic (the helper rule) as before
+        hs.textContent = explicit
+          ? "set here: new sessions, and sessions that follow the default; a session with its own pick keeps it"
+          : "automatic: the API key when a helper is configured, else the login; new sessions and sessions with no pick of their own";
+        hb.appendChild(hs);
         head.appendChild(hb); sub.appendChild(head);
-        for (const c of choices) {
-          const opt = el("div", "ctx-item ctx-radio" + (avail.default === c.value ? " current" : "") + (c.why ? " disabled" : ""));
+        // the same choices as radios, then Automatic (the helper rule), which clears the explicit default (review: the flag
+        // was one-way and invisible); the current mark sits on the explicit side, else on Automatic
+        const autoWord = avail.key ? "API key" : "Login";
+        const radios = [...choices.map((c) => ({ ...c, cur: explicit && avail.default === c.value })),
+                        { label: `Automatic (${autoWord} here)`, value: "auto", why: "", cur: !explicit }];
+        for (const c of radios) {
+          const opt = el("div", "ctx-item ctx-radio" + (c.cur ? " current" : "") + (c.why ? " disabled" : ""));
           opt.textContent = c.label;
           opt.dataset.scope = "machine";
           if (c.why) { opt.title = c.why; opt.setAttribute("aria-disabled", "true"); }
@@ -7330,7 +7341,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
             ev2.stopPropagation();
             if (c.why) return;
             dismissTabMenu();
-            if (avail.default !== c.value && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value, scope: "machine" });
+            if (!c.cur && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value, scope: "machine" });
           });
           sub.appendChild(opt);
         }
@@ -7340,7 +7351,10 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       menu.appendChild(sub);
       const ir = item.getBoundingClientRect();
       const sr = sub.getBoundingClientRect();
-      sub.style.left = Math.max(0, Math.min(ir.right + 2, window.innerWidth - sr.width - 4)) + "px";
+      // the side rule (Tags, the model-version submenus): PREFER right; fall LEFT only when the right edge would
+      // clip — never slide over the row (review: the widened flyout slid over its own menu below about 886 px)
+      if (ir.right + 2 + sr.width <= window.innerWidth - 8) sub.style.left = Math.round(ir.right + 2) + "px";
+      else sub.style.left = Math.max(8, Math.round(ir.left) - sr.width - 2) + "px";
       sub.style.top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4)) + "px";
       return sub;
     };

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7355,12 +7355,19 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       const ir = item.getBoundingClientRect();
       const sr = sub.getBoundingClientRect();
       // the side rule (Tags, the model-version submenus): PREFER right; fall LEFT when the right edge would clip and
-      // the left has room; with room on neither side (a narrow window) the flyout drops BELOW the row, clamped inside
-      // the viewport — never over the row or off-screen (review: at 560 px it covered its menu and ran 33 px out)
+      // the left has room; with room on neither side (a narrow window) the flyout drops BELOW the row when it fits
+      // there, else ABOVE the row's top, and only when neither fits is it clamped inside the viewport — never over
+      // the row while a place beside or beyond it exists (review: at 560 px it covered its menu and ran 33 px out;
+      // at 560 by 420 the clamp pulled the drop-below back over the row)
       let left: number, top: number = ir.top;
       if (ir.right + 2 + sr.width <= window.innerWidth - 8) left = Math.round(ir.right + 2);
       else if (ir.left - 2 - sr.width >= 8) left = Math.round(ir.left) - sr.width - 2;
-      else { left = Math.max(8, Math.min(Math.round(ir.left), window.innerWidth - sr.width - 8)); top = ir.bottom + 2; }
+      else {
+        left = Math.max(8, Math.min(Math.round(ir.left), window.innerWidth - sr.width - 8));
+        if (ir.bottom + 2 + sr.height <= window.innerHeight - 4) top = ir.bottom + 2;
+        else if (ir.top - 2 - sr.height >= 0) top = ir.top - 2 - sr.height;
+        else top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4));
+      }
       sub.style.left = left + "px";
       sub.style.top = Math.max(0, Math.min(top, window.innerHeight - sr.height - 4)) + "px";
       return sub;

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -701,6 +701,11 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 /* a flyout's group head (the Billing flyout's "Default for this machine", T380): a row that names the radios under it
    and takes no gesture, so no hover wash; the radios below wear the menu's own current mark */
 .ctx-sub-head, .ctx-sub-head:hover { cursor: default; background: transparent; }
+/* the Billing flyout stays a menu's width (review: the note had grown it to 585 px, past narrow windows): the head's
+   note wraps inside it instead of stretching it */
+.ctx-sub-billing { max-width: 22em; }
+.ctx-sub-billing .ctx-sub-head { white-space: normal; }
+.ctx-sub-billing .ctx-sub-head .ctx-item-sub { display: block; white-space: normal; line-height: 1.3; }
 .ctx-item-toggle { display: flex; align-items: flex-start; gap: 8px; }
 /* ON = the romp accent blue, matching the timeline lane's feed/mail icons (the user 2026-06-26); OFF = dim
    gray + slashed. So the same blue marks "enabled" in both the menu and the timeline. */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -698,6 +698,9 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    (the user 2026-06-26). The icon is the same metaphor as the timeline lane toggles; a .off icon is slashed
    + dimmed to show the flag is currently off (matching the timeline). */
 .ctx-sep { height: 1px; margin: 4px 6px; background: var(--box-border); }
+/* a flyout's group head (the Billing flyout's "Default for this machine", T380): a row that names the radios under it
+   and takes no gesture, so no hover wash; the radios below wear the menu's own current mark */
+.ctx-sub-head, .ctx-sub-head:hover { cursor: default; background: transparent; }
 .ctx-item-toggle { display: flex; align-items: flex-start; gap: 8px; }
 /* ON = the romp accent blue, matching the timeline lane's feed/mail icons (the user 2026-06-26); OFF = dim
    gray + slashed. So the same blue marks "enabled" in both the menu and the timeline. */

--- a/ui/webview/tab-tags-flyout.test.ts
+++ b/ui/webview/tab-tags-flyout.test.ts
@@ -38,6 +38,19 @@ test("diagonal tolerance: entering either surface cancels the close; leaving bot
   assert.doesNotMatch(WIRE, /window\.addEventListener/, "no window listener: the harness slices count them");
 });
 
+test("the Billing flyout's placement (T380 review): prefer right, fall left with room, else drop below the row inside the viewport; no Automatic radio for an older kernel", () => {
+  const BILL = RENDER.slice(RENDER.indexOf("const openBillingFly = (): HTMLElement | null => {"), RENDER.indexOf('wireFlyout(menu, item, ".ctx-sub-billing"'));
+  assert.match(BILL, /if \(ir\.right \+ 2 \+ sr\.width <= window\.innerWidth - 8\) left = Math\.round\(ir\.right \+ 2\);/, "prefer right");
+  assert.match(BILL, /else if \(ir\.left - 2 - sr\.width >= 8\) left = Math\.round\(ir\.left\) - sr\.width - 2;/, "fall left only with room");
+  assert.match(BILL, /else \{ left = Math\.max\(8, Math\.min\(Math\.round\(ir\.left\), window\.innerWidth - sr\.width - 8\)\); top = ir\.bottom \+ 2; \}/, "no room either side: below the row, clamped inside the viewport, never over the row");
+  assert.doesNotMatch(BILL, /Math\.max\(0, Math\.min\(ir\.right \+ 2, window\.innerWidth - sr\.width - 4\)\)/, "the old slide-over-the-row rule is gone");
+  assert.match(BILL, /const olderKernel = avail\.defaultExplicit === undefined;/);
+  assert.match(BILL, /\.\.\.\(olderKernel \? \[\] : \[\{ label: `Automatic \(\$\{autoWord\}\)`, value: "auto", why: "", cur: !explicit \}\]\)/, "an older kernel that takes no auto gets no Automatic radio");
+  const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+  assert.match(CSS, /\.ctx-sub-billing \{ max-width: 22em; \}/, "a menu's width: the note wraps");
+  assert.match(CSS, /\.ctx-sub-billing \.ctx-sub-head \.ctx-item-sub \{ display: block; white-space: normal; line-height: 1\.3; \}/);
+});
+
 test("expansion follows the standing side rule and the caret faces right", () => {
   assert.match(block, /if \(ir\.right \+ 2 \+ sr\.width <= window\.innerWidth - 8\) sub\.style\.left = Math\.round\(ir\.right \+ 2\) \+ "px";/);
   assert.match(block, /else sub\.style\.left = Math\.max\(8, Math\.round\(ir\.left\) - sr\.width - 2\) \+ "px";/,

--- a/ui/webview/tab-tags-flyout.test.ts
+++ b/ui/webview/tab-tags-flyout.test.ts
@@ -11,21 +11,31 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const at = RENDER.indexOf('const tagsItem = el("div", "ctx-item ctx-item-toggle ctx-item-tags");');
 const block = RENDER.slice(at, RENDER.indexOf('menu.appendChild(tagsItem);', at));
 
-test("hover-intent opens the flyout: the feed's 120ms, click still instant, hover never steals focus", () => {
-  assert.match(block, /const HOVER_INTENT_MS = 120;/);
-  assert.match(block, /tagsItem\.addEventListener\("pointerenter", \(\) => \{/);
-  assert.match(block, /hoverOpenT = window\.setTimeout\(\(\) => \{ hoverOpenT = null; openTagsFly\(false\); \}, HOVER_INTENT_MS\);/,
-    "hover opens WITHOUT focusing the input — a graze must not grab the keyboard");
-  assert.match(block, /openTagsFly\(true\);/, "click opens instantly and focuses");
-  assert.match(block, /cancelHoverTimers\(\);\s*\n\s*const openFly = menu\.querySelector\(".ctx-sub-tags"\);/,
-    "a click cancels any pending hover intent before acting");
+// the ONE flyout gesture (T380): wireFlyout, declared beside the menu builder, wires Tags and Billing alike
+const WIRE = RENDER.slice(RENDER.indexOf("function wireFlyout("), RENDER.indexOf("\n}\n", RENDER.indexOf("function wireFlyout(")));
+
+test("hover-intent opens the flyout: the feed's 120ms, click still instant, hover never steals focus (the one gesture, wireFlyout)", () => {
+  assert.match(RENDER, /const HOVER_INTENT_MS = 120;\nfunction wireFlyout\(menu: HTMLElement, item: HTMLElement, sel: string, open: \(byClick: boolean\) => HTMLElement \| null\): void \{/);
+  assert.match(block, /wireFlyout\(menu, tagsItem, "\.ctx-sub-tags", openTagsFly\);/, "Tags rides the shared gesture");
+  assert.match(WIRE, /item\.addEventListener\("pointerenter", \(\) => \{/);
+  assert.match(WIRE, /openT = window\.setTimeout\(\(\) => \{ openT = null; openNow\(false\); \}, HOVER_INTENT_MS\);/,
+    "hover opens WITHOUT focusing the input — a graze must not grab the keyboard (open(false))");
+  assert.match(WIRE, /openNow\(true\);/, "click opens instantly and may focus");
+  assert.match(WIRE, /cancel\(\);\s*\n\s*const fly = menu\.querySelector\(sel\);\s*\n\s*if \(fly\) \{ fly\.remove\(\); return; \}/,
+    "a click cancels any pending hover intent before acting; a second click folds the flyout");
+  assert.match(block, /if \(focusInput\) \(sub\.querySelector\("\.ctx-tag-input"\) as HTMLInputElement \| null\)\?\.focus\(\);/, "the click's focus is the Tags builder's own");
+  // Billing wears the same gesture (T380, the user 2026-09-12): hovering the row opens its flyout, no click needed
+  assert.match(RENDER, /wireFlyout\(menu, item, "\.ctx-sub-billing", \(\) => openBillingFly\(\)\);/);
+  assert.doesNotMatch(RENDER, /hoverOpenT|hoverCloseT|cancelHoverTimers|armHoverClose/, "the inline Tags copy of the gesture is gone: one definition");
 });
 
 test("diagonal tolerance: entering either surface cancels the close; leaving both closes", () => {
-  assert.match(block, /sub\.addEventListener\("pointerenter", cancelHoverTimers\);/);
-  assert.match(block, /sub\.addEventListener\("pointerleave", armHoverClose\);/);
-  assert.match(block, /tagsItem\.addEventListener\("pointerleave", armHoverClose\);/);
-  assert.match(block, /hoverCloseT = window\.setTimeout\(/, "the close is armed on leave with the same tolerance window");
+  assert.match(WIRE, /fly\.addEventListener\("pointerenter", cancel\);/);
+  assert.match(WIRE, /fly\.addEventListener\("pointerleave", armClose\);/);
+  assert.match(WIRE, /item\.addEventListener\("pointerleave", armClose\);/);
+  assert.match(WIRE, /closeT = window\.setTimeout\(\(\) => \{ closeT = null; menu\.querySelector\(sel\)\?\.remove\(\); \}, HOVER_INTENT_MS\);/, "the close is armed on leave with the same tolerance window");
+  assert.match(WIRE, /if \(fly && !fly\.dataset\.flyWired\)/, "the flyout's own tolerance listeners are wired once per flyout node");
+  assert.doesNotMatch(WIRE, /window\.addEventListener/, "no window listener: the harness slices count them");
 });
 
 test("expansion follows the standing side rule and the caret faces right", () => {

--- a/ui/webview/tab-tags-flyout.test.ts
+++ b/ui/webview/tab-tags-flyout.test.ts
@@ -42,7 +42,12 @@ test("the Billing flyout's placement (T380 review): prefer right, fall left with
   const BILL = RENDER.slice(RENDER.indexOf("const openBillingFly = (): HTMLElement | null => {"), RENDER.indexOf('wireFlyout(menu, item, ".ctx-sub-billing"'));
   assert.match(BILL, /if \(ir\.right \+ 2 \+ sr\.width <= window\.innerWidth - 8\) left = Math\.round\(ir\.right \+ 2\);/, "prefer right");
   assert.match(BILL, /else if \(ir\.left - 2 - sr\.width >= 8\) left = Math\.round\(ir\.left\) - sr\.width - 2;/, "fall left only with room");
-  assert.match(BILL, /else \{ left = Math\.max\(8, Math\.min\(Math\.round\(ir\.left\), window\.innerWidth - sr\.width - 8\)\); top = ir\.bottom \+ 2; \}/, "no room either side: below the row, clamped inside the viewport, never over the row");
+  // no room either side: below the row when it fits, else above the row's top, and only then clamped (round 3: a short
+  // window's clamp pulled the drop-below back over the row)
+  assert.match(BILL, /left = Math\.max\(8, Math\.min\(Math\.round\(ir\.left\), window\.innerWidth - sr\.width - 8\)\);/, "clamped inside the viewport horizontally");
+  assert.match(BILL, /if \(ir\.bottom \+ 2 \+ sr\.height <= window\.innerHeight - 4\) top = ir\.bottom \+ 2;/, "below the row when it fits");
+  assert.match(BILL, /else if \(ir\.top - 2 - sr\.height >= 0\) top = ir\.top - 2 - sr\.height;/, "else above the row's top");
+  assert.match(BILL, /else top = Math\.max\(0, Math\.min\(ir\.top, window\.innerHeight - sr\.height - 4\)\);/, "only when neither fits, clamped");
   assert.doesNotMatch(BILL, /Math\.max\(0, Math\.min\(ir\.right \+ 2, window\.innerWidth - sr\.width - 4\)\)/, "the old slide-over-the-row rule is gone");
   assert.match(BILL, /const olderKernel = avail\.defaultExplicit === undefined;/);
   assert.match(BILL, /\.\.\.\(olderKernel \? \[\] : \[\{ label: `Automatic \(\$\{autoWord\}\)`, value: "auto", why: "", cur: !explicit \}\]\)/, "an older kernel that takes no auto gets no Automatic radio");


### PR DESCRIPTION
Two asks from the user on the tab menu's Billing submenu (2026-09-12).

**Fix: the Billing flyout opens on hover.** The Tags flyout's hover-intent gesture (T163) is lifted out of the Tags block into one `wireFlyout(menu, item, sel, open)` beside the menu builder, and both Tags and Billing ride it: a 120 ms hover over the row opens the flyout, a click opens it at once (Tags still focuses its input on click, never on a hover-open), a second click folds it, leaving both the row and the flyout for the same span closes it, and opening one flyout removes any other. No window listener. Escape closes the menu and the flyout with it, as before.

**Feature: a per-machine default billing, from the same flyout.** Below the session's choices, a divider and a **Default for this machine** group (the host's name for a remote session) lists the same choices as radios with the current default marked, and a note: new sessions, and sessions that follow the default; a session with its own pick keeps it. A pick posts the existing `setAuth` op with `scope: "machine"`. Design points:
- Where it lives: the machine default is the seed the kernel already reads for every new session, `sdk-defaults.json` `auth` under the state root (never a token), so nothing new is stored and spawn's seeding is unchanged. The kernel door's scoped arm calls a new `set_auth_default(value)` on the backend, which refuses an unavailable side with the same reason a per-session pick gets and writes the seed with `authExplicit: true`; no session is touched and nothing reconnects.
- The per-session pick used to seed the default too (like a model or effort pick). It still does until the default is set explicitly; from then on a per-session pick is about that session alone (`set_auth` reads the `authExplicit` flag). Before an explicit default, behaviour is unchanged.
- A remote session: the op routes to the session's owning kernel, so the pick sets that host's default, and the flyout marks that host's seed because the per-session status payload's `authAvail` now carries `default` (it deliberately omitted it before; the memo per pusher cycle is unchanged).
- The reference's Billing paragraph describes the hover, the group, the seed and the explicit-default rule.

Coordination with the stored-logins pull request (1447, unarmed on the user's check): this lands on main; the Billing flyout's choices loop keeps its indentation and lines inside the new `openBillingFly`, so 1447's `authLoginChoices` loop merges with a small conflict at the function's head; the Default group sits after the loop and will list whatever choices the loop lists once 1447 lands (a stored login as the machine default is 1447's follow-up).

Tests, red first:
- `tests/test_billing_flyout_browser.py`: a hermetic kernel whose machine offers both sides (a staged helper in the kernel's Claude config dir, a synthetic account in the kernel's own home) and two synthetic sessions (web with no pick, api with an explicit key pick). The driver right-clicks web's tab, hovers the Billing row without clicking and reads that the flyout opened (189 ms); leaves and reads the flyout closed with the menu up; presses Escape; reads the group (divider, head, note, radios with the key marked, both enabled); clicks the Login radio and the kernel's `sdk-defaults.json` reads `auth: login, authExplicit: true` while api's reg keeps `key` and web's reg carries no pick. Against the build before the change (`BILLING_FLYOUT_DIST`) 3 of 4 fail (no hover-open, no group, no pick); with the change 4 pass. `BILLING_FLYOUT_SHOTS` wrote `romp_ui-t380-billing-dark.png` and `romp_ui-t380-billing-light.png`.
- `tests/test_session_auth.py`: `set_auth_default` writes the seed with the explicit flag, a new session follows it, a picked session is untouched, a later per-session pick no longer moves it, a second default write moves it, junk and an unavailable side are refused with the reason; the avail status half carries `default`; the kernel door's scoped arm is pinned ahead of the plain arm.
- `ui/webview/tab-tags-flyout.test.ts` re-pointed to the shared gesture (the timings, the no-focus hover-open, the click cancel and fold, the flyout's once-wired tolerance, no window listener) and pins Billing's wiring and the removal of the inline copy.

Executed: the flyout and menu pins (tab-tags-flyout, tab-tags, tag-chip-everywhere, tab-groups, auth-selector, billing-one-auth, tab-strip-skip-exec, tab-snapshot-pane, skeleton-tabs-wiring, tab-backend-tooltip, tab-drag-live) 157 passed, 0 failed; typecheck clean; full extension suite 4601 tests, 4595 passed, 1 failed (the setAuth gesture census, which counted one chat sender; re-pointed to name the scoped second and re-run green with the flyout pins, 16 passed), 5 skipped (node test, concurrency 2, capped); Python `test_session_auth`, `test_cap_switch_offer`, `test_sdk_backend` 329 passed, 35 skipped; the served pins and kernel neighbours (test_served_tests_require, test_state_isolation_order, test_dist_copy_staging, test_kernel_effort_reconnect, test_sdk_spawn_pin_send) 30 passed; the lab under the CI stance 4 passed.

Tier: fix
