### PR TITLE
Every link in chat prose wears one dress: the link token, a solid underline, never dotted; the served dark theme's link colour is the accent (T378)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -48981,7 +48981,7 @@ THEME_CSS = """@font-face{font-family:'Inter';src:url(/media/InterVariable.woff2
 --vscode-focusBorder:#007fd4;--vscode-input-background:#3c3c3c;--vscode-input-foreground:#cccccc;
 --vscode-input-border:#3c3c3c;--vscode-menu-background:#252526;--vscode-menu-foreground:#cccccc;
 --vscode-menu-selectionBackground:#094771;--vscode-menu-selectionForeground:#fff;
---vscode-scrollbarSlider-background:rgba(121,121,121,.4);--vscode-textLink-foreground:#3794ff;}
+--vscode-scrollbarSlider-background:rgba(121,121,121,.4);--vscode-textLink-foreground:#9cd2ff;}
 html,body{background:var(--vscode-editor-background);}
 body{font-family:var(--vscode-font-family);font-size:13px;color:var(--vscode-foreground);margin:0;padding:0;}"""
 

--- a/tests/test_glossary_browser.py
+++ b/tests/test_glossary_browser.py
@@ -33,7 +33,7 @@ SID = "11111111-2222-3333-4444-555555555555"
 FIX = json.loads(Path(HERE, "fixtures", "glossary_grammar.json").read_text())
 REPLY = ("I tesselled the fixes from your review and pushed the tessel head; the quill was security, and the quill again. The keytoken previews whole. "
          "The spar on `tessel` stays as code, and docs/guide.md#tessel is a path, not a term. Two tessels landed. "
-         "The unverified docs/widget/tessel.md and the host example.com/tessel/y stay plain too.")
+         "The unverified docs/widget/tessel.md and the host example.com/tessel/y stay plain too. The write-up is at https://example.com/notes-api/readme for the curious, and [the guide](https://example.com/notes-api/guide) has the rest.")
 USER = "Did the tessel cover the second quill?"
 
 
@@ -64,6 +64,21 @@ const links = () => page.evaluate(() => Array.from(document.querySelectorAll("#c
 const out = { links: await links() };
 out.codeLinks = await page.evaluate(() => document.querySelectorAll("#content code .term-link, #content a .term-link, #content .file-uri-link .term-link").length);
 out.pathLink = await page.evaluate(() => { const a = document.querySelector('#content .file-uri-link[data-path="docs/guide.md"]'); return a ? { text: a.textContent, frag: a.dataset.frag } : null; });
+// three kinds of link in one message, at rest, in both themes: the computed colour and underline of a term, a
+// path and a bare URL must be one dress (T378, the user 2026-09-12: one light blue, one solid underline, never dotted)
+const dressOf = () => page.evaluate(() => {
+  const pick = (sel) => { const e = document.querySelector(sel); if (!e) return null; const cs = getComputedStyle(e);
+    const chain = []; let n = e.parentElement; for (let i = 0; n && i < 6; i++, n = n.parentElement) chain.push(n.className || n.tagName.toLowerCase());
+    return { tag: e.tagName.toLowerCase(), cls: e.className, color: cs.color, line: cs.textDecorationLine, style: cs.textDecorationStyle, chain }; };
+  return { term: pick('#content .term-link[data-term="tessel-head"]'), path: pick('#content .file-uri-link[data-path="docs/guide.md"]'),
+           url: pick('#content a[href*="notes-api/readme"], #content [data-url*="notes-api/readme"], #content .file-uri-link[data-path*="notes-api/readme"]'),
+           mdlink: pick('#content a[href*="notes-api/guide"]') };
+});
+await page.mouse.move(900, 700); await page.waitForTimeout(200);
+out.dressDark = await dressOf();
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(200);
+out.dressLight = await dressOf();
+await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(200);
 // the hover on "tessel head" (the multi-word term): the glossary file's section at the term's heading, through the slice
 // route like any file link with a section (T375); no card of the term's own
 const before = requests; const filesBefore = fileUrls.length;
@@ -185,7 +200,25 @@ class ServedGlossary(unittest.TestCase):
             k.kill(); k.wait()
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
-    def test_terms_link_where_written_the_card_needs_no_request_and_a_click_lands_the_viewer_on_the_heading(self):
+    def test_a_term_a_path_and_a_url_link_compute_one_colour_and_one_solid_underline_in_both_themes(self):
+        r = self._result()
+        for theme in ("dressDark", "dressLight"):
+            d = r[theme]
+            for kind in ("term", "path", "url", "mdlink"):
+                self.assertIsNotNone(d[kind], "%s: the %s link is on the page: %r" % (theme, kind, d))
+            dress = {k: (d[k]["color"], d[k]["line"], d[k]["style"]) for k in ("term", "path", "url", "mdlink")}
+            self.assertEqual(set(dress.values()), {(d["url"]["color"], "underline", "solid")},
+                             "%s: a term, a path, a bare URL and a titled link wear one dress at rest, the bare URL's colour and a solid underline: %r" % (theme, d))
+        self.assertNotEqual(r["dressDark"]["url"]["color"], r["dressLight"]["url"]["color"], "the two themes differ (the measurement saw both): %r" % r)
+
+    _r = None
+
+    def _result(self):
+        """One driver run per class (the driver rewrites the glossary and appends a transcript record, so a second run
+        would read a different page); both tests read its measurements."""
+        cls = type(self)
+        if cls._r is not None:
+            return cls._r
         cfg = os.path.join(self.lab, "cfg.json")
         with open(cfg, "w") as f:
             json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sid": SID, "glossary": self.glossary, "transcript": self.transcript,
@@ -200,7 +233,11 @@ class ServedGlossary(unittest.TestCase):
         self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
         line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
         self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
-        r = json.loads(line[len("RESULT:"):])
+        cls._r = json.loads(line[len("RESULT:"):])
+        return cls._r
+
+    def test_terms_link_where_written_the_card_needs_no_request_and_a_click_lands_the_viewer_on_the_heading(self):
+        r = self._result()
         texts = [(l["text"], l["term"]) for l in r["links"]]
         # the assistant's words: tesselled (alias), tessel head (longest first: one term), quill once (first), tessels (plural);
         # the user's words: tessel and quill (its own message, its own first)

--- a/ui/webview/file-uri-link.test.ts
+++ b/ui/webview/file-uri-link.test.ts
@@ -50,7 +50,7 @@ test("linkify works inside INLINE backticks (agents backtick paths), skips exist
   assert.match(CSS, /^pre code \.file-uri-link \{ color: var\(--accent\); \}/m, "the link keeps the accent over the highlight's token colour");
 });
 
-test(".file-uri-link is styled as a wrapping accent link", () => {
-  assert.match(CSS, /\.file-uri-link \{[\s\S]*?cursor: pointer[\s\S]*?color: var\(--accent\)/);
+test(".file-uri-link is styled as a wrapping link in the chat's one link dress (T378)", () => {
+  assert.match(CSS, /\.file-uri-link \{[\s\S]*?cursor: pointer[\s\S]*?color: var\(--link\)/, "the link token, as .md a and .term-link (T378)");
   assert.match(CSS, /\.file-uri-link:hover \{ text-decoration: underline; \}/);
 });

--- a/ui/webview/glossary-links.test.ts
+++ b/ui/webview/glossary-links.test.ts
@@ -61,7 +61,7 @@ test("a linked term is a path link to the glossary's section and nothing more: n
   assert.ok(!/s\.title = e\.plainWords/.test(RENDER), "no native title beside the hover card: one mechanism");
   assert.match(TERM_SKIP_SELECTOR, /code, pre, a, \.file-uri-link, h1, h2, h3, h4, h5, h6, \.katex, svg, \.term-link, \.cmt-pop, \.file-preview-pop/);
   // the dress: a link like any link (the user 2026-09-12): the link colour token, a solid underline, the pointer
-  assert.match(CSS, /\.term-link \{ color: var\(--link\); text-decoration: underline solid; cursor: pointer; \}/);
+  assert.match(CSS, /\.term-link \{ color: var\(--link\); text-decoration: underline solid; text-underline-offset: 2px; cursor: pointer; \}/);
   assert.ok(!/\.term-link[^\n]*dotted/.test(CSS) && !/\.term-link[^\n]*cursor: help/.test(CSS), "no dotted underline, no help cursor");
   assert.ok(!/\.term-link\.term-retired \{ opacity/.test(CSS), "no distinct dress for a retired term either: only the link marks a term");
   assert.ok(!CSS.includes(".fp-term") && !CSS.includes(".fp-open"), "the card-only styling and the open control's rules are gone");
@@ -79,7 +79,7 @@ test("the wiring: the frame per session, the matcher per index, links at the two
   assert.doesNotMatch(RENDER, /querySelectorAll\("\.md"\)\)\) linkTerms/, "no relink over every .md");
   assert.equal((RENDER.match(/const full = el\("div", "nudge-full md"\);\s*\n\s*full\.innerHTML = md\(ev\.md\);\s*\n\s*linkTerms\(full\);/g) || []).length, 2,
                "the Continue-send and tagged-template bubbles link at render too (the review's low: built as nudge-full md with no linkTerms, they never linked)");
-  assert.match(CSS, /\.term-link \{ color: var\(--link\); text-decoration: underline solid; cursor: pointer; \}/, "the ordinary link dress (T375; the dress test above says the rest)");
+  assert.match(CSS, /\.term-link \{ color: var\(--link\); text-decoration: underline solid; text-underline-offset: 2px; cursor: pointer; \}/, "the ordinary link dress (T375; the dress test above says the rest)");
   // the kernel: the frame on the pusher's cycle beside the comments frame, on its own slot; the route; the byte cap and its /perf note
   assert.match(KERNEL, /gfr = _glossary_frame\(s\["sid"\]\)[\s\S]{0,400}?_send_client\(c, \("glossary", s\["sid"\]\), gfr\)/);
   assert.match(KERNEL, /if p\.startswith\("\/glossary\/"\):[\s\S]{0,300}?_glossary_lookup\(\(q\.get\("sid"\) or \[None\]\)\[0\], unquote\(p\[len\("\/glossary\/"\):\]\)\)/, "the route sits in the GET router beside the file route");

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -2186,11 +2186,11 @@ body.chat-theme-yatharth .meta-btn.mode-risky, body.chat-theme-yatharth .meta-it
   text-decoration: underline dotted; text-underline-offset: 2px;
 }
 .img-link:hover { text-decoration: underline; }
-/* a bare file:// URL in a chat message, made clickable (opens in the host's default app) — the romp
-   accent so it reads as a followable link; a long path wraps inside the bubble */
+/* a bare file:// URL or a path in a chat message, made clickable (opens in the host's default app) — the link
+   dress, exactly as .md a wears it (T378; the accent and a dotted underline before); a long path wraps inside the bubble */
 .file-uri-link {
-  cursor: pointer; overflow-wrap: anywhere; color: var(--accent);
-  text-decoration: underline dotted; text-underline-offset: 2px;
+  cursor: pointer; overflow-wrap: anywhere; color: var(--link);
+  text-decoration: underline solid; text-underline-offset: 2px;
 }
 .file-uri-link:hover { text-decoration: underline; }
 pre code .file-uri-link { color: var(--accent); }   /* a fenced block's path (2026-09-12): the accent over the highlight's token colour beneath it */
@@ -2749,8 +2749,11 @@ pre code .file-uri-link { color: var(--accent); }   /* a fenced block's path (20
 .md li { margin: 0.2em 0; }
 .md strong { color: var(--vscode-foreground, #fff); font-weight: 600; }
 .md em { font-style: italic; }
-.md a { color: var(--link); text-decoration: none; }
-.md a:hover { text-decoration: underline; }
+/* every link in chat prose wears ONE dress (T378, the user 2026-09-12: one light blue, one solid underline, never dotted):
+   the link token, a solid underline at rest, the same offset — a titled or bare URL here, a path (.file-uri-link) and a
+   glossary term (.term-link) below all read this exact pair. The dark theme's --link is the accent on the served page
+   (kernel.py THEME_CSS emulates --vscode-textLink-foreground with it; VS Code's own theme colours it in the editor). */
+.md a { color: var(--link); text-decoration: underline solid; text-underline-offset: 2px; }
 /* PR references linked in plain-text surfaces (pr-links.ts): card titles, distiller lines, checklists,
    outline goal rows. Inside .md the generic anchor rule already inks them; this covers the rest, in the
    same hyperlink ink. */
@@ -3395,7 +3398,7 @@ body.drop-over::after { content: ""; position: fixed; inset: 0; pointer-events: 
 .path-full-pdfcard:hover { border-color: var(--accent); }
 /* a whole-backtick URL, tappable but still dressed as code (render.ts linkifyFileUris) */
 .url-code-link { text-decoration: none; cursor: pointer; }
-.url-code-link code { text-decoration: underline dotted; text-underline-offset: 2px; }
+.url-code-link code { text-decoration: underline solid; text-underline-offset: 2px; }   /* solid: no link is dotted (T378) */
 .url-code-link:hover code { color: var(--accent); }
 /* a kernel-VERIFIED preview whose bytes failed to arrive (restart, tunnel blip) — visible, retryable,
    never silently removed (preview.ts previewFull) */
@@ -3675,8 +3678,8 @@ mark.cmt-hl.hl-last { border-top-right-radius: 2px; border-bottom-right-radius: 
 /* the glossary's term links (T351 stage 2, design A): a quiet dotted underline in the text colour, no colour change;
    a retired term greys (its card says to use the plain phrase) */
 /* a glossary term is a link to the glossary's section and dresses as one (T375, the user 2026-09-12): the link colour,
-   a solid underline, the pointer; nothing else marks it */
-.term-link { color: var(--link); text-decoration: underline solid; cursor: pointer; }
+   a solid underline at the same offset as .md a (T378), the pointer; nothing else marks it */
+.term-link { color: var(--link); text-decoration: underline solid; text-underline-offset: 2px; cursor: pointer; }
 .term-link:focus-visible { outline: none; }
 .md-callout-label { font-size: 0.72em; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--accent); margin: 0 0 2px; }
 /* the popover's boot loader (the user 2026-08-25: a fresh thread flashed the plain msgs projection

--- a/ui/webview/url-code-link.test.ts
+++ b/ui/webview/url-code-link.test.ts
@@ -25,6 +25,6 @@ test("a whole-backtick http(s) URL becomes a tappable link that still looks like
     "inline spans only, never inside a block or an existing anchor");
   assert.match(RENDER, /a\.className = "url-code-link";/);
   assert.match(RENDER, /code\.replaceWith\(a\);\s*\n\s*a\.appendChild\(code\);/, "the code keeps its dress inside the link");
-  assert.match(CSS, /\.url-code-link code \{ text-decoration: underline dotted;/);
+  assert.match(CSS, /\.url-code-link code \{ text-decoration: underline solid;/);
   assert.match(CSS, /\.url-code-link:hover code \{ color: var\(--accent\); \}/);
 });


### PR DESCRIPTION
**Fix (T378).** Every link in chat prose wears one dress: the link token's colour and a solid underline, never dotted. On the served dark theme that colour is romp's accent.

**Measured before the change** (the glossary lab on the served chat page, dark theme, at rest): a bare URL and a titled markdown link were `rgb(55, 148, 255)` with no underline, a glossary term the same blue with a solid underline, a path link the accent `rgb(156, 210, 255)` with a dotted underline. The blue is VS Code Dark+'s text-link colour, emulated by the kernel's served theme sheet and read through the `--link` token.

**Change.** The served sheet emulates `--vscode-textLink-foreground` with the accent, so `--link` computes to it on every served pane in the dark theme (the cream theme's value stands; a VS Code webview keeps the editor's). `.md a`, `.file-uri-link` and `.term-link` read the same pair: the link token and a solid underline at one offset. A whole-backtick URL's code span underlines solid. A fenced block's path keeps the accent over the highlight; the user's own bubble keeps white links.

**Test.** The glossary lab renders a term, a path, a bare URL and a titled link in one message and asserts one computed colour (the bare URL's) and a solid underline at rest in both themes, with the two themes differing. Red on upstream/main.
