### PR TITLE
A new chat column's socket carries one full frame: the pusher withholds session frames while the client's reconnect is armed, and the reset re-arms it under its lock

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -42142,6 +42142,16 @@ def _client_reset_chat_base(client):
         # …and the reconnect skeleton set (2026-09-07): a renderer that just evaluated holds NOTHING, so there
         # is nothing it could lazily reload — every tab must arrive whole, and the status slots go with the set
         client.pop("skeleton", None); client.pop("skeletonOrder", None); client.pop("reconnect", None)
+        # A SKELETON client (a later chat column, ?skeleton=1 at its handshake, 2026-09-11): the pop above took the
+        # `reconnect` the handshake armed, with the set a pre-ready pusher cycle may have built into a document that
+        # could not hear it. Re-armed HERE, from the survivor, so the ready arm's connect push serves the page the same
+        # view (the strip with a skeleton list, one full for the session it opened on, a status per other tab) instead
+        # of the whole board. Popped once: the bundle posts one ready, and a redial finds nothing to re-arm. Under THIS
+        # lock, right behind the pop (2026-09-12): as two statements of the arm's own past the reset, there was an
+        # instant with the set gone and neither flag set, and a pusher iteration landing in it (_send_chat_or_status
+        # reads both under the lock) sent a full for a tab the column holds as a skeleton.
+        if client.pop("skeletonOnReady", False):
+            client["reconnect"] = True
         snt = client.get("sent", {})
         # …and the ("activeChat",) slot (T347): a feed page that reloads registers while its bundle still
         # evaluates, and a tab switch in its window relays a frame to a document with no listener yet; the
@@ -42233,8 +42243,8 @@ def _resolve_reconnect(c, chat_list):
         # go; the session frames themselves wait for the ready, _send_chat_or_status, since the arm re-arms the flag
         # past its reset for the push the page CAN hear and that push is the one full), but the client is NOT stamped ready
         # (_reveal_request aims taps at stamped clients, and this page cannot hear one yet) and the caller consumes
-        # no parked reveal (the return): the ready arm's own stamp and consume run as for any fresh page. The arm
-        # pops `skeletonOnReady` before re-arming, so its own pop here is not fresh.
+        # no parked reveal (the return): the ready arm's own stamp and consume run as for any fresh page. The arm's
+        # reset pops `skeletonOnReady` as it re-arms, so the arm's own pop here is not fresh.
         fresh = bool(c.get("skeletonOnReady"))
         if not fresh:
             # The redial's stamp (2026-09-10): the page listens (the shim dials ?reconnect=1 only once the kernel's caps
@@ -42278,12 +42288,21 @@ def _send_chat_or_status(c, m, ms, change_from, led_changed):
         if sid in (c.get("skeleton") or ()):
             _send_client(c, ("status", sid), {"type": "status", "id": sid, "status": m.get("status")})
             return ms
-        if c.get("skeletonOnReady"):
+        if c.get("skeletonOnReady") or c.get("reconnect"):
             # A skeleton client BEFORE its bundle's ready (the chat split, 2026-09-11): the handshake's `reconnect` woke
             # a pusher cycle into a document that cannot hear it yet, and the ready arm's reset re-sends whatever it
             # held anyway, so a full sent here crossed the wire twice per open (about 95 KB on the lab board; review
             # find 2026-09-11). The strip and the statuses above still go (cheap, and heard when the bundle won the
             # race); the session frames wait for the connect push the ready arm makes, which is then the one full.
+            # …and a client whose `reconnect` is ARMED (2026-09-12): its set is not resolved yet, and the strip sender
+            # that pops the flag serves the active tab's full itself. The pusher's cycle was still in this loop when the
+            # ready arm's reset popped the set and re-armed the flag, and the arm's connect push rebuilds the set only at
+            # its own _resolve_reconnect, past a liveness sweep and the tab list: in that gap neither read above held and
+            # every session this loop visited went out whole, a full for a tab the column holds as a skeleton, an echat
+            # entry, and the arm's strip dropped the sid from its skeleton list as held (the second full on a new column's
+            # socket: one to six per open on a slow runner, never the active tab's, and no ask from the page;
+            # tests/test_chat_skeleton_reconnect.py test_11_d). The reset re-arms under its own lock, so no instant has
+            # neither flag.
             return ms
         return _send_chat_locked(c, m, ms, change_from, led_changed)
 
@@ -57777,14 +57796,8 @@ class Handler(BaseHTTPRequestHandler):
             # its socket died (the user 2026-09-02; duplicating the browser tab always recovered
             # because cached bundles win the race). Same repair as needFull above, client-wide;
             # ready is posted once per renderer life, so this cannot loop.
-            _client_reset_chat_base(client)
-            # A SKELETON client (a later chat column, ?skeleton=1 at its handshake, 2026-09-11): the reset above popped
-            # the `reconnect` the handshake armed, with the set a pre-ready pusher cycle may have built into a document
-            # that could not hear it. Re-armed here, past the reset, so the connect push below serves the page the same
-            # view — the strip with a skeleton list, one full for the session it opened on, a status per other tab —
-            # instead of the whole board. Popped once: the bundle posts one ready, and a redial finds nothing to re-arm.
-            if client.pop("skeletonOnReady", False):
-                client["reconnect"] = True
+            _client_reset_chat_base(client)   # …and, for a skeleton client (a later chat column), re-arms `reconnect` under
+            #                                   its lock, so the connect push below serves the view its handshake declared
             if client.get("app") == "feed":
                 _send_active_chat(client)      # T347: the window's focus, ahead of the first paint
             # Capture the seq of the views blob the pushes below serve — from the frames THIS thread
@@ -58801,9 +58814,9 @@ class Handler(BaseHTTPRequestHandler):
             # redial's diet fits a fresh page exactly — the strip with a skeleton list, ONE full for the active tab, a
             # status per other tab: a view of one session instead of the whole board (17 frames, 9 MB measured above).
             # `reconnect` makes the pusher cycle that lands before the bundle's ready serve that set (into a document
-            # that may not hear it yet: one frame, not the board); `skeletonOnReady` survives the ready arm's
-            # _client_reset_chat_base (which pops `reconnect` with the set) and re-arms the flag there, so the connect
-            # push the bundle CAN hear is the same set. Until that ready, _resolve_reconnect neither stamps the client
+            # that may not hear it yet: one frame, not the board); `skeletonOnReady` survives to the ready arm's
+            # _client_reset_chat_base, which pops `reconnect` with the set and re-arms the flag from it under its own
+            # lock, so the connect push the bundle CAN hear is the same set. Until that ready, _resolve_reconnect neither stamps the client
             # ready nor lets its caller consume a parked reveal (the fresh guard): the page has no listener yet, and
             # the arm's own stamp and consume run as for any fresh page. No `active` (a corrupt blob): the whole push,
             # the fail-safe _resolve_reconnect already has.

--- a/tests/test_chat_skeleton_reconnect.py
+++ b/tests/test_chat_skeleton_reconnect.py
@@ -571,6 +571,68 @@ class SkeletonReconnect(unittest.TestCase):
         finally:
             km._PENDING_REVEAL[0] = None
 
+    def test_11_d_a_pusher_iteration_landing_in_the_ready_arms_gap_sends_no_full(self):
+        # THE SECOND FULL ON A NEW COLUMN'S SOCKET (a slow runner, 2026-09-12; reproduced at the wire: 18 of 27 opens carried
+        # full frames for sessions the column does not hold, up to six per open, and the page asked for none). The pusher
+        # cycle the handshake woke is still in its per-session loop when the ready arm runs. The arm's reset pops the set
+        # and `reconnect`, the survivor re-arms `reconnect`, and the arm's connect push rebuilds the set only at its own
+        # _resolve_reconnect, past a liveness sweep and the tab list. In that gap the client had no set and no
+        # `skeletonOnReady`, and _send_chat_or_status read nothing else: every session the pusher's loop visited fell
+        # through to _send_chat_locked, a full for a tab the column holds as a skeleton, an echat entry, and the arm's
+        # strip dropped the sid from its skeleton list as held whole. The guard reads `reconnect` too now (a client with
+        # the flag armed has no set yet; the strip sender that pops it sends the active tab's full itself), and the reset
+        # pops the survivor and re-arms under its own lock, so no instant exists with neither flag set.
+        def in_the_gap(cl, sid):
+            """The pusher's per-session iteration for `sid`, landing on the handler thread's _push_one: the instant after
+            the arm's reset and re-arm, before its push's _resolve_reconnect."""
+            self.assertNotIn("skeleton", cl, "the reset popped the set")
+            self.assertNotIn("skeletonOnReady", cl, "…and the survivor")
+            self.assertIs(cl.get("reconnect"), True, "…and re-armed the flag for the connect push")
+            m = json.loads(json.dumps(self.SESS[sid]))
+            km._send_chat_or_status(cl, m, None, len(m["events"]), False)
+        # 1. the loop reaches a session the column does NOT hold (the wire shape: every extra full was another tab's)
+        c = self._client(active=S1, reconnect=True, skeletonOnReady=True)
+        km._push([c])                                 # the pre-ready cycle: the set, the strip, a status per other tab
+        self.assertEqual(self._sessions(c), [])
+        c["_frames"].clear()
+        h = _Self(lambda cl: (in_the_gap(cl, S2), km._push([cl], connect=True)))
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(h, {"type": "ready"}, c)
+        self.assertEqual(h.calls, [c])
+        self.assertEqual(self._sessions(c), [S1, S4], "the one full (+ the transcript-less): the pusher's iteration for S2 in the gap sent none")
+        self.assertEqual(sorted(s for s, _ in self._statuses(c)), sorted([S2, S3]), "S2 is a status, as every other tab")
+        to = self._tab_orders(c)
+        self.assertEqual(len(to), 1)
+        self.assertEqual(to[0]["skeleton"], [S3, S2], "S2 is still on the strip's skeleton list: no full won a race against the set")
+        self.assertEqual(c["skeleton"], {S2, S3})
+        self.assertEqual(sorted(c["echat"]), sorted([S1, S4]), "believed held: the active tab and the transcript-less, nothing else")
+        types = [f["type"] for f in c["_frames"]]
+        self.assertLess(types.index("tabOrder"), types.index("session"), "the strip is ahead of every full: the set's invariant")
+        # 2. the loop reaches the ACTIVE session in the gap: its full crosses once, from the arm's push, behind the strip
+        c = self._client(active=S1, reconnect=True, skeletonOnReady=True)
+        km._push([c])
+        c["_frames"].clear()
+        h = _Self(lambda cl: (in_the_gap(cl, S1), km._push([cl], connect=True)))
+        with contextlib.redirect_stderr(io.StringIO()):
+            km.Handler._dispatch_ws(h, {"type": "ready"}, c)
+        self.assertEqual([f["type"] for f in c["_frames"] if f.get("id") == S1 and f["type"] in ("session", "chatTail")], ["session"],
+                         "one full for the active tab and no tail behind it: the iteration in the gap neither sent it nor left a base")
+        self.assertEqual(self._sessions(c), [S1, S4])
+        self.assertEqual(self._tab_orders(c)[0]["skeleton"], [S3, S2])
+        types = [f["type"] for f in c["_frames"]]
+        self.assertLess(types.index("tabOrder"), types.index("session"))
+        # the source: the iteration reads `reconnect` beside `skeletonOnReady`; the reset re-arms under its lock, right
+        # behind the pop, and the arm no longer pops or re-arms on its own (two statements outside the lock were the instant)
+        so = inspect.getsource(km._send_chat_or_status)
+        self.assertIn('if c.get("skeletonOnReady") or c.get("reconnect"):', so)
+        rs = inspect.getsource(km._client_reset_chat_base)
+        self.assertLess(rs.index("with _client_lock(client):"), rs.index('client.pop("reconnect", None)'))
+        self.assertLess(rs.index('client.pop("reconnect", None)'),
+                        rs.index('if client.pop("skeletonOnReady", False):\n            client["reconnect"] = True'))
+        arm = inspect.getsource(km.Handler)
+        body = arm[arm.index('msg.get("type") == "ready"'):][:3500]
+        self.assertNotIn('client.pop("skeletonOnReady"', body)
+
     def test_11_c_a_later_columns_redial_is_stamped_by_its_first_strip_and_lands_a_parked_reveal(self):
         # The shim reads skeleton=1 off the address on EVERY dial of a later column, so its redial after a kernel restart
         # or a laptop sleep carries reconnect=1 AND skeleton=1. Armed with `skeletonOnReady`, that client was never stamped:

--- a/tests/test_chat_split.py
+++ b/tests/test_chat_split.py
@@ -105,16 +105,25 @@ class SplitSourcePins(unittest.TestCase):
         self.assertIn('client["reconnect"] = True\n            if not reconnect:\n                client["skeletonOnReady"] = True', src)
         # a pre-ready skeleton client is sent no session frame: the ready arm's connect push is the one full (the strip and
         # the statuses still go; review find 2026-09-11: the full crossed the wire twice per open)
+        # …and none while `reconnect` is ARMED either (2026-09-12): a client with the flag has no set yet, and a pusher
+        # iteration landing in the ready arm's gap (the set popped, the flag re-armed, the arm's own resolve still ahead)
+        # sent a full for a skeleton tab (test_chat_skeleton_reconnect test_11_d runs the gap)
         so = inspect.getsource(km._send_chat_or_status)
-        self.assertIn('if c.get("skeletonOnReady"):', so)
-        self.assertLess(so.index('if sid in (c.get("skeleton") or ()):'), so.index('if c.get("skeletonOnReady"):'))
-        self.assertLess(so.index('if c.get("skeletonOnReady"):'), so.index('return _send_chat_locked(c, m, ms, change_from, led_changed)'))
-        # the ready arm re-arms the flag PAST the reset and BEFORE its connect push
+        guard = 'if c.get("skeletonOnReady") or c.get("reconnect"):'
+        self.assertIn(guard, so)
+        self.assertLess(so.index('if sid in (c.get("skeleton") or ()):'), so.index(guard))
+        self.assertLess(so.index(guard), so.index('return _send_chat_locked(c, m, ms, change_from, led_changed)'))
+        # the flag is re-armed INSIDE the reset, under its lock and right behind its pop of `reconnect` (2026-09-12: as the
+        # arm's own two statements past the reset there was an instant with neither flag set), and the reset precedes the
+        # arm's connect push
+        rs = inspect.getsource(km._client_reset_chat_base)
+        self.assertIn('if client.pop("skeletonOnReady", False):\n            client["reconnect"] = True', rs)
+        self.assertLess(rs.index("with _client_lock(client):"), rs.index('client.pop("reconnect", None)'))
+        self.assertLess(rs.index('client.pop("reconnect", None)'), rs.index('client.pop("skeletonOnReady", False)'))
         i = src.index('msg.get("type") == "ready"')
         body = src[i:i + 3500]
-        self.assertIn('if client.pop("skeletonOnReady", False):\n                client["reconnect"] = True', body)
-        self.assertLess(body.index("_client_reset_chat_base(client)"), body.index('client.pop("skeletonOnReady", False)'))
-        self.assertLess(body.index('client.pop("skeletonOnReady", False)'), body.index("self._push_one(client)"))
+        self.assertNotIn('client.pop("skeletonOnReady"', body, "the arm's own pop and re-arm are gone: the reset's lock holds both")
+        self.assertLess(body.index("_client_reset_chat_base(client)"), body.index("self._push_one(client)"))
         # a pre-ready pop (the flag still set) neither stamps the client ready nor lets its caller consume a parked reveal:
         # _reveal_request aims taps at stamped clients, and this page has no listener yet
         rr = inspect.getsource(km._resolve_reconnect)

--- a/tests/test_chat_split_served.py
+++ b/tests/test_chat_split_served.py
@@ -708,13 +708,13 @@ class ServedChatSplit(unittest.TestCase):
         self.assertTrue(o["done"], "the observer saw B's transcript painted in column 2: %r" % o)
         self.assertGreaterEqual(s["statusDelta"], BOARD - 1,
                                 "a status frame per other tab on column 2's own socket: the column was served as a skeleton client, not whole: %r" % s)
-        # the diet's fingerprint on column 2's own socket: B's full, never the board (eight per push before 2026-09-11). A
-        # SECOND full for B is not excluded: on a slow runner the page's restore of its wanted tab can run between the strip
-        # and the full of the same burst and ask for B's frame, and the kernel answers (the asks ride col2Asks in the record);
-        # wasteful, not wrong, and not a quantity the paint instant settles, so the bound is two and well under the board
-        self.assertGreaterEqual(s["fullChatDelta"], 1, "B's full reached column 2 by the paint: %r" % s)
-        self.assertLessEqual(s["fullChatDelta"], 2, "at most B's full and one re-ask, never the board: %r" % s)
-        self.assertLess(s["fullChatDelta"], BOARD - 1, "never the board: %r" % s)
+        # the diet's fingerprint on column 2's own socket: B's full, exactly once, never the board (eight per push before
+        # 2026-09-11). The second full a slow runner carried (the bound was two for a day, 2026-09-12) was never the page
+        # asking again: it was the kernel's pusher, still in the per-session loop of the cycle the handshake woke when the
+        # ready arm popped the column's set and re-armed `reconnect`, sending a full for a tab the column does not hold
+        # (reproduced at the wire: up to six per open, none of them B's, and no ask). _send_chat_or_status withholds while
+        # the flag is armed and the reset re-arms under its lock (tests/test_chat_skeleton_reconnect.py test_11_d): one again
+        self.assertEqual(s["fullChatDelta"], 1, "exactly one full per open, B's: never the board (eight per push before 2026-09-11), never another tab's from a pusher iteration in the ready arm's gap (2026-09-12), no prefetch (the column's one member is on screen): %r" % s)
         self.assertEqual(s["col2Asks"], [], "the column asked for nothing: a status delivered ahead of its strip is held for the strip, never the no-base ask that loaded the board behind the view, one ask per withheld tab (2026-09-11): %r" % s)
         # the copy between the call and the paint: the pane loader, never the create flow's words or the no-sessions copy
         self.assertEqual(o["emptyState"], 0, "no 'No session open' / no-sessions copy in a column opened on a session: %r" % o)

--- a/ui/webview/skeleton-tabs-wiring.test.ts
+++ b/ui/webview/skeleton-tabs-wiring.test.ts
@@ -290,8 +290,9 @@ type ChipApi = { showActive: () => void; updateJumpBtn: () => void; sig: () => s
 
 /** A page with two tabs: A, a loaded session whose transcript is `transcript` px tall; B, a skeleton (a stale
  *  pre-outage copy under it with an unread reply on it, its hidden view kept, its name in tabMeta). The pane is
- *  `clientHeight` px in a `innerHeight` px window. */
-function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript: number }) {
+ *  `clientHeight` px in a `innerHeight` px window. `awaiting` adds a third tab the strip listed (its name in tabMeta)
+ *  whose payload has not landed: neither a session nor a skeleton, a new column's own session on its way. */
+function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript: number; awaiting?: string }) {
   assert.equal(LOADER_VH, 60, "the loader's min-height rule (styles.css) is the model's premise");
   assert.match(CSS, /^#content \{[^}]*padding: 8px 0 12px;/m, "the pane's 20px of vertical padding");
   const pane = new ChipPane(opts.clientHeight, opts.innerHeight - 40);
@@ -306,12 +307,14 @@ function chipWorld(opts: { clientHeight: number; innerHeight: number; transcript
   const HOOKS: ChipHooks = { fulls: [], captions: [] };
   const jumpBtn = { hidden: true, offsetHeight: 28, style: {} as Record<string, string> };
   const replyChips = { hidden: true, style: {} as Record<string, string> };
+  const tabMeta = new Map<string, { name: string; color: null }>([["B", { name: "api", color: null }]]);
+  if (opts.awaiting) tabMeta.set(opts.awaiting, { name: "tests", color: null });
   const W = {
     sessions: new Map<string, unknown>([["A", { id: "A", events: [], status: { state: "idle" } }],
                                         ["B", { id: "B", events: [], status: { state: "working" } }]]),   // B's stale copy stays underneath
     views: new Map<string, unknown>([["A", { el: viewA, scrollTop: 0, stick: false, shown: true, stale: false, winStart: 0 }],
                                      ["B", { el: viewB, scrollTop: 0, stick: false, shown: false, stale: true, winStart: 0 }]]),
-    tabMeta: new Map([["B", { name: "api", color: null }]]),
+    tabMeta,
     skeletonTabs: { ids: new Set(["B"]) },
     // B's stale copy carries an unread open reply: with its view kept and a ready thread, the liveSession read is
     // the ONE clause of updateReplyChips' gate that hides the chips over the skeleton (the read #1226 narrowed)
@@ -386,4 +389,21 @@ test("run: the gate reads the skeleton set, not the session map; the last tab cl
   assert.deepEqual(w.HOOKS.captions, [], "no loader, so no caption");
   assert.equal(w.jumpBtn.hidden, true, "no chip over the no-sessions copy");
   assert.equal(w.replyChips.hidden, true, "no reply chip over the no-sessions copy");
+});
+
+test("run: a column's own session, listed by the strip but not among its skeletons, is shown loading and asked for by nobody while its full is in flight", () => {
+  // The second full on a new chat column's socket (a slow runner, 2026-09-12) was a kernel race, not this path
+  // (tests/test_chat_skeleton_reconnect.py test_11_d). A new column opens as a skeleton client of one session: the strip's
+  // skeleton list names every OTHER tab (the kernel excludes the active hint), and the page's restore of its wanted tab
+  // can land here between that strip and the session's full of the same burst. showActive's ask fires only for a tab the
+  // skeleton set names, so the restore shows the loader and posts nothing: the full on its way is the burst's own.
+  const w = chipWorld({ clientHeight: 600, innerHeight: 800, transcript: 4980, awaiting: "C" });
+  w.api.set({ activeId: "C" }); w.api.showActive();
+  assert.deepEqual(w.HOOKS.fulls, [], "no needFull for the session whose full the burst carries");
+  assert.deepEqual(w.HOOKS.captions, ["loading “tests”…"], "the loader over the tab, with the LOADING word");
+  const loader = w.doc.getElementById("tab-loading");
+  assert.ok(loader && loader.cls === "tab-loading-wait", "the loader is up");
+  // …the neighbouring skeleton still asks on its pick: the gate is the set, not the missing session
+  w.api.set({ activeId: "B" }); w.api.showActive();
+  assert.deepEqual(w.HOOKS.fulls, ["skeleton-click:B"]);
 });


### PR DESCRIPTION
## What this fixes

A new chat column sometimes received full session frames for tabs it does not hold, on top of the one full for its own session: two on a lightly loaded runner, up to six at the wire under a half-core cap. The served test's diet fingerprint flapped on continuous integration because of it, and the second strip's skeleton list shrank to the sids not yet sent whole.

## Cause

A kernel thread race. The pusher cycle woken at the skeleton column's handshake was still in its per-session loop when the handler thread's ready arm reset the client (popping its skeleton set and the reconnect flag) and re-armed the flag two statements later outside any lock; the arm's own connect push rebuilt the set only after the liveness sweep and the tab list. In that gap the per-session sender read neither flag and sent every session it visited whole. The page never asked: twenty-seven wired opens recorded zero re-asks, and the extra fulls sat inside the held burst before the page received a frame.

## Fix

- The per-session sender withholds session frames while the client's reconnect flag is armed as well: a client with the flag has no set yet, and the strip sender that pops it sends the active tab's full itself.
- The client reset pops the skeleton-on-ready mark and re-arms reconnect under its own lock, right behind its pop of the flag, so no instant exists with neither flag set; the ready arm's own pop and re-arm are gone.

## Tests

Red first: a kernel test drives the ready arm with one pusher iteration in the gap and asserts one full for the column's session, a status for the other, and the strip's skeleton list intact. A page pin asserts the restore onto a column's own listed-but-unlanded session posts no ask. The served test's fingerprint is back to exactly one full on the column's socket and a status per other tab, passing at the default cap and under a half-core cap; the wired reproduction driver shows one full in eleven of eleven opens after the fix against four of six and three of five before. Whole node suite, the Python suites and both browser globs green (one unrelated browser test fails only under the half-core quota with and without this change).

Tier: fix