### PR TITLE
The converge pass's assembly step enumerates its candidates from the assembly cache's whole entries, the parses the boot actually did, not from the discover window (T382)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1043,7 +1043,11 @@ charged to the same cycle budget. A leaf is looked at once per file state:
 written, or refused for a property of its cut, it is done; a blip is tried
 twice (a blip inside the fold half's hold gets its second try over the entry
 the paid drop popped, so that leaf waits for the next boot's read); a leaf with
-no whole entry to write from is re-examined each cycle and counted once. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
+no whole entry to write from is re-examined each cycle and counted once. The step's candidates are the assembly cache's whole entries, the parses the
+boot actually did, whatever the session's age (the discover window's rows,
+48 hours by default, would leave every older idle leaf out). A leaf with no
+compaction boundary has no cut and no document: it is read whole at every boot
+by design. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
 own switch and a zero byte budget, as for the drop write. The owed table
 is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1045,9 +1045,15 @@ twice (a blip inside the fold half's hold gets its second try over the entry
 the paid drop popped, so that leaf waits for the next boot's read); a leaf with
 no whole entry to write from is re-examined each cycle and counted once. The step's candidates are the assembly cache's whole entries, the parses the
 boot actually did, whatever the session's age (the discover window's rows,
-48 hours by default, would leave every older idle leaf out). A leaf with no
-compaction boundary has no cut and no document: it is read whole at every boot
-by design. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
+48 hours by default, would leave every older idle leaf out) and whether or not
+the session still has a registry row: a leaf the boot parsed is one the next
+boot parses, so its document is wanted, and the boot's sweep removes the
+documents of vanished files. The document is written under the display
+parse's flag, the one the next boot reads with, and with the turns section
+from the parse under that same flag or none; a leaf parsed only under the
+judges' flag is skipped and counted (`flagMismatch`), since the reader would
+delete a document under the wrong flag. A leaf with no compaction boundary has
+no cut and no document: it is read whole at every boot by design. `ROMP_ASM_CONVERGE=0` turns that step off, and so do the pass's
 own switch and a zero byte budget, as for the drop write. The owed table
 is bounded: over it the oldest owed drop is paid by its pop alone, and an owed
 file since deleted has its entry popped when the cycle pays. A leaf unchanged for longer than the reader keeps a quiescent

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4916,14 +4916,15 @@ def asm_whole_entries():
 
 
 def asm_whole_entry_for(leaf_path):
-    """The (rompuuid, sdk_human) of this process's whole assembly entry over `leaf_path`, or None: how the pass names the session
-    of a leaf the discover window no longer lists (T382)."""
-    real = os.path.realpath(str(leaf_path))
+    """This process's whole assembly entries over `leaf_path` as {rompuuid: set of sdk_human flags}: how the pass names the
+    session of a leaf the discover window no longer lists, and sees which flags it was parsed under (T382; a process can hold
+    two whole entries for one leaf, the judges' flag and the display's)."""
+    real = os.path.realpath(str(leaf_path)); out = {}
     with _ASM_LOCK:
         for k, e in _ASM_CACHE.items():
             if k[0] == real and e is not None and not e.get("prefix") and not e.get("preTurns"):
-                return (k[1], bool(k[2]))
-    return None
+                out.setdefault(k[1], set()).add(bool(k[2]))
+    return out
 
 
 def asm_entry_whole(leaf_path, rompuuid, sdk_human=False):

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4906,6 +4906,26 @@ def asm_converge_skip(reason):
         sk[reason] = sk.get(reason, 0) + 1
 
 
+def asm_whole_entries():
+    """The WHOLE (unrestored) assembly entries this process holds, as (leaf path, rompuuid, sdk_human): the parses the boot
+    actually did, whatever the sessions' age. The converge pass enumerates its assembly candidates from these (T382: the
+    discover window's rows left every idle leaf older than 48 hours out, the very population the step targets)."""
+    with _ASM_LOCK:
+        keys = [k for k, e in _ASM_CACHE.items() if e is not None and not e.get("prefix") and not e.get("preTurns")]
+    return [(k[0], k[1], bool(k[2])) for k in keys]
+
+
+def asm_whole_entry_for(leaf_path):
+    """The (rompuuid, sdk_human) of this process's whole assembly entry over `leaf_path`, or None: how the pass names the session
+    of a leaf the discover window no longer lists (T382)."""
+    real = os.path.realpath(str(leaf_path))
+    with _ASM_LOCK:
+        for k, e in _ASM_CACHE.items():
+            if k[0] == real and e is not None and not e.get("prefix") and not e.get("preTurns"):
+                return (k[1], bool(k[2]))
+    return None
+
+
 def asm_entry_whole(leaf_path, rompuuid, sdk_human=False):
     """Whether this process holds a WHOLE (unrestored) assembly entry for the session over `leaf_path`: the boot's own parse,
     which the converge pass writes an idle leaf's document from (T376); a restored entry's document already stands, and no

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9983,8 +9983,12 @@ def _converge_checkpoints(now):
                 unhealed = em.drop_cold_cursors(p)
             if quiescent:                                  # the ASSEMBLY document from the same resident read, BEFORE the held drop
                 try:                                       #  pops the record entry (T376 round one, medium: the pop came first and
-                    _converge_assembly_leaf(p, leaf_sid.get(p), t0)   #  the assembly writer found no record entry for its offsets); a
-                except Exception:                          #  raise here must not discard the held drop or abort the cycle (round two)
+                    ent = em.asm_whole_entry_for(p)        #  the assembly writer found no record entry for its offsets); the session
+                    if ent is not None:                    #  named by the parse in the cache (T382), else by the window's row; a
+                        _converge_assembly_leaf(p, ent[0], t0, human=ent[1])
+                    else:                                  #  raise here must not discard the held drop or abort the cycle (round two)
+                        _converge_assembly_leaf(p, leaf_sid.get(p), t0)
+                except Exception:
                     sys.stderr.write("assembly converge: %s\n" % traceback.format_exc())
         if unhealed:                                       # a fold the heal cannot rerun here (not one of the leaf's five): its
             em.converge_stat("unhealed", len(unhealed))    #  cursor and cold mark are dropped, the write leaves it out, its next
@@ -10019,8 +10023,10 @@ _ASM_STRUCTURAL = set(em._ASM_SKIP_STRUCTURAL) | {"noBoundary", "written", "rest
 def _converge_assembly(now, t0):
     """The converge pass's assembly step (T376): an idle session never settles, so its leaf never had an assembly document
     and the parse read it whole at every boot (31 of 60 leaves on the devbox, about 2.5 GB, the boot's remaining cost).
-    For every session leaf that is quiescent, has no assembly document on disk, and whose WHOLE assembly entry the boot's own
-    parse built is in memory beside the reader's whole record entry, the document is written from that entry through the
+    For every leaf the boot's own parse built a WHOLE assembly entry for (the assembly cache's unrestored entries, each with
+    its sid and flag: the enumeration is the boot's reads, not the discover window's rows, which leave every idle leaf older
+    than 48 hours out; T382) that is quiescent, has no assembly document on disk, and whose reader's whole record entry is
+    still resident beside it, the document is written from that entry through the
     settle's writer (`asm_checkpoint_write`, with the parse store's tree as the settle hands it): no read of records, a stat
     per file and the cut's guard. Charged to the cycle's byte budget (an estimate from the leaf's size, trued up), deferred
     over it; bounded by the pass's wall; off with the drop write (a zero budget). A leaf is looked at once per file state:
@@ -10034,14 +10040,13 @@ def _converge_assembly(now, t0):
     if not ASM_CONVERGE or not em.checkpoint_drop_writes_on():
         return 0
     n = 0
-    for s in _sessions(now):
-        leaf, sid = s.get("path"), s.get("sid")
-        if not leaf or not sid:
-            continue
+    for leaf, sid, human in em.asm_whole_entries():        # the parses the boot actually did, each with its sid and flag (T382: the
+        if not leaf or not sid:                            #  discover window's rows, 48 hours, left every older idle leaf out: 19 of
+            continue                                       #  the 25 boundary leaves without a document on the devbox)
         if time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0:
             break                                          # the cycle's wall: the rest wait for the next one
         try:
-            r = _converge_assembly_leaf(str(leaf), sid, t0)
+            r = _converge_assembly_leaf(str(leaf), sid, t0, human=human)
         except Exception:                                  # one leaf's raise (a stat, a backend hook) leaves the rest their turn
             sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); continue
         if r is None:
@@ -10055,9 +10060,10 @@ def _release_oldest(table, cap=4096):
         table.pop(next(iter(table)))                       #  the table cleared (round one, low 6)
 
 
-def _converge_assembly_leaf(key, sid, t0):
+def _converge_assembly_leaf(key, sid, t0, human=None):
     """One leaf's assembly write for the pass (see _converge_assembly): True written, False not (done, refused, nothing to
-    write from), None when the budget refused it (the caller defers the rest)."""
+    write from), None when the budget refused it (the caller defers the rest). `human` is the flag of the parse in the cache
+    when the caller knows it (T382); else the display parse's answer."""
     if not ASM_CONVERGE or not sid or not em.checkpoint_drop_writes_on():
         return False
     for table in (_ASM_CONVERGE_DONE, _ASM_CONVERGE_BLIP, _ASM_CONVERGE_NOENTRY):
@@ -10073,7 +10079,7 @@ def _converge_assembly_leaf(key, sid, t0):
         return False
     if not em.file_quiescent(key):
         return False                                       # a live leaf: its settle writes the document
-    human = _display_sdk_human(sid)
+    human = _display_sdk_human(sid) if human is None else bool(human)
     if not em.asm_entry_whole(key, sid, human) or not em.entry_whole_resident(key):
         if _ASM_CONVERGE_NOENTRY.get(key) != st:           # no whole assembly entry, or the reader's record entry gone (the writer
             _ASM_CONVERGE_NOENTRY[key] = st; em.asm_converge_skip("noEntry")   #  needs both): nothing to write from, never a read

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -9898,6 +9898,17 @@ def _heal_cold_folds(leaf):
     return healed
 
 
+def _stored_tree_under(path, sid, human):
+    """The parse store's tree for the leaf under exactly the flag `human`, or None: the assembly document written under one
+    flag must not pair its atoms with the other flag's per-segment human marks in a turns section (T382 review, low 1); with no
+    tree under that flag the document is written without a turns section (the writer's memo rewrites it once one is given)."""
+    try:
+        hit = jd._parse_slot(sid, jd._pending_cut(sid), path, bool(human))
+    except Exception:
+        return None
+    return hit[1] if hit else None
+
+
 def _stored_tree(path, sid):
     """The parse store's tree for a session's leaf when it holds one (the kernel's display parse under its own human flag,
     else the judges'), never a parse of its own: the assembly writer takes it for the document's turns section (T323
@@ -9983,10 +9994,11 @@ def _converge_checkpoints(now):
                 unhealed = em.drop_cold_cursors(p)
             if quiescent:                                  # the ASSEMBLY document from the same resident read, BEFORE the held drop
                 try:                                       #  pops the record entry (T376 round one, medium: the pop came first and
-                    ent = em.asm_whole_entry_for(p)        #  the assembly writer found no record entry for its offsets); the session
-                    if ent is not None:                    #  named by the parse in the cache (T382), else by the window's row; a
-                        _converge_assembly_leaf(p, ent[0], t0, human=ent[1])
-                    else:                                  #  raise here must not discard the held drop or abort the cycle (round two)
+                    ents = em.asm_whole_entry_for(p)       #  the assembly writer found no record entry for its offsets); the session
+                    if ents:                               #  named by the parses in the cache (T382), else by the window's row; a
+                        for sid_, flags in ents.items():   #  raise here must not discard the held drop or abort the cycle (round two)
+                            _converge_assembly_leaf(p, sid_, t0, flags=flags)
+                    else:
                         _converge_assembly_leaf(p, leaf_sid.get(p), t0)
                 except Exception:
                     sys.stderr.write("assembly converge: %s\n" % traceback.format_exc())
@@ -10040,13 +10052,15 @@ def _converge_assembly(now, t0):
     if not ASM_CONVERGE or not em.checkpoint_drop_writes_on():
         return 0
     n = 0
-    for leaf, sid, human in em.asm_whole_entries():        # the parses the boot actually did, each with its sid and flag (T382: the
-        if not leaf or not sid:                            #  discover window's rows, 48 hours, left every older idle leaf out: 19 of
-            continue                                       #  the 25 boundary leaves without a document on the devbox)
-        if time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0:
-            break                                          # the cycle's wall: the rest wait for the next one
+    by_leaf = {}                                           # (leaf, sid) -> the flags the boot parsed it under (T382 review, medium: two
+    for leaf, sid, human in em.asm_whole_entries():        #  whole entries for one leaf, the judges' flag and the display's, and the
+        if leaf and sid:                                   #  document must carry the one the display's next boot reads with)
+            by_leaf.setdefault((str(leaf), sid), set()).add(human)
+    for (leaf, sid), flags in by_leaf.items():             # the parses the boot actually did (T382: the discover window's rows, 48
+        if time.monotonic() - t0 > CKPT_CONVERGE_MS / 1000.0:   #  hours, left every older idle leaf out: 19 of the 25 boundary leaves
+            break                                          #  without a document on the devbox); the cycle's wall: the rest wait
         try:
-            r = _converge_assembly_leaf(str(leaf), sid, t0, human=human)
+            r = _converge_assembly_leaf(leaf, sid, t0, flags=flags)
         except Exception:                                  # one leaf's raise (a stat, a backend hook) leaves the rest their turn
             sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); continue
         if r is None:
@@ -10060,13 +10074,19 @@ def _release_oldest(table, cap=4096):
         table.pop(next(iter(table)))                       #  the table cleared (round one, low 6)
 
 
-def _converge_assembly_leaf(key, sid, t0, human=None):
+_ASM_CONVERGE_FLAG = {}             # leaf -> the file state under which a flag mismatch was counted (once, not per cycle)
+
+
+def _converge_assembly_leaf(key, sid, t0, flags=None):
     """One leaf's assembly write for the pass (see _converge_assembly): True written, False not (done, refused, nothing to
-    write from), None when the budget refused it (the caller defers the rest). `human` is the flag of the parse in the cache
-    when the caller knows it (T382); else the display parse's answer."""
+    write from), None when the budget refused it (the caller defers the rest). `flags`, when the caller knows them, are the
+    sdk_human flags the boot parsed the leaf under; the document is written under the DISPLAY parse's flag (the one the next
+    boot's display parse reads with; the judges' flag differs until the owner provider is wired, and a document under it would
+    take a session fallback at the display's restore and be deleted), and a leaf parsed only under the other flag is skipped,
+    counted `flagMismatch` (T382 review, medium)."""
     if not ASM_CONVERGE or not sid or not em.checkpoint_drop_writes_on():
         return False
-    for table in (_ASM_CONVERGE_DONE, _ASM_CONVERGE_BLIP, _ASM_CONVERGE_NOENTRY):
+    for table in (_ASM_CONVERGE_DONE, _ASM_CONVERGE_BLIP, _ASM_CONVERGE_NOENTRY, _ASM_CONVERGE_FLAG):
         _release_oldest(table)
     st = _stat_key_ns(key)
     if st is None or _ASM_CONVERGE_DONE.get(key) == st:
@@ -10079,7 +10099,11 @@ def _converge_assembly_leaf(key, sid, t0, human=None):
         return False
     if not em.file_quiescent(key):
         return False                                       # a live leaf: its settle writes the document
-    human = _display_sdk_human(sid) if human is None else bool(human)
+    human = bool(_display_sdk_human(sid))
+    if flags is not None and human not in flags:
+        if _ASM_CONVERGE_FLAG.get(key) != st:               # parsed only under the other flag: no document the reader would unlink
+            _ASM_CONVERGE_FLAG[key] = st; em.asm_converge_skip("flagMismatch")
+        return False
     if not em.asm_entry_whole(key, sid, human) or not em.entry_whole_resident(key):
         if _ASM_CONVERGE_NOENTRY.get(key) != st:           # no whole assembly entry, or the reader's record entry gone (the writer
             _ASM_CONVERGE_NOENTRY[key] = st; em.asm_converge_skip("noEntry")   #  needs both): nothing to write from, never a read
@@ -10091,7 +10115,7 @@ def _converge_assembly_leaf(key, sid, t0, human=None):
         return None
     reasons = []
     try:
-        wrote = em.asm_checkpoint_write(key, sid, human, tree=_stored_tree(key, sid), reason_out=reasons, who="converge pass")
+        wrote = em.asm_checkpoint_write(key, sid, human, tree=_stored_tree_under(key, sid, human), reason_out=reasons, who="converge pass")
     except Exception:
         sys.stderr.write("assembly converge: %s\n" % traceback.format_exc()); wrote = False
     if wrote:

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -534,6 +534,24 @@ class ConvergeAssembly(Harness):
         self.assertEqual(em.checkpoint_stats()["restoredFolds"].get("bgJudge", 0), before + 1, "the fold document restores")
         self.assertLess(em.read_bytes_report().get(path, 0), size, "the next boot reads the tail")
 
+    def test_a_leaf_older_than_the_discover_window_is_written_from_the_boots_parse(self):
+        """T382: the step walked _sessions(now), the discover window's rows (48 hours), so an idle leaf older than that was never a
+        candidate although the boot had parsed it (19 of the 25 boundary leaves without a document on the devbox, 20 to 714
+        hours old). The candidates come from the assembly cache's whole unrestored entries, the parses the boot actually did,
+        each with its sid and flag; every other guard stands."""
+        path = self.idle_leaf("aged")
+        self.km._sessions = lambda now, **kw: []                       # no row in the window: the session is too old for discover
+        read0 = em.read_bytes_report().get(path, 0)
+        self.cycle(NOW + 600)
+        self.assertTrue(em._asm_ckpt_file(path).exists(), "written from the parse in the cache, whatever the session's age")
+        av = em.asm_checkpoint_stats()["converge"]
+        self.assertEqual((av["writes"], av["candidates"], av["deferred"]), (1, 1, 0), "%s" % av)
+        self.assertLess(em.read_bytes_report().get(path, 0) - read0, 512, "no read of records")
+        self.cycle(NOW + 601); self.cycle(NOW + 602)
+        self.assertEqual(em.asm_checkpoint_stats()["converge"]["writes"], 1, "once")
+        tree, modes, n_lazy = self.restored(path)
+        self.assertEqual(modes, ["restore"])
+
     def test_a_write_over_the_cycles_budget_is_deferred_to_the_next(self):
         path = self.idle_leaf("budget")
         self.km.CKPT_CONVERGE_BYTES = 1

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -552,6 +552,41 @@ class ConvergeAssembly(Harness):
         tree, modes, n_lazy = self.restored(path)
         self.assertEqual(modes, ["restore"])
 
+    def _parse_as(self, path, human):
+        return em.parse_session(path, rompuuid=SID, name="impl", dir="/TESTDIR", candidate_files=[path], states=self.states,
+                                postal_log=self.sent, now=NOW, sdk_human=human)
+
+    def test_the_document_is_written_under_the_display_parses_flag_whichever_entry_the_cache_yields_first(self):
+        """T382 review, medium: with two whole entries for one leaf (the judges' flag and the display's differ until the owner
+        provider is wired), the step wrote under whichever entry the LRU order yielded first; under the wrong flag the display's
+        next boot took a session fallback, deleted the document and read the leaf whole. The entry whose flag is the display
+        parse's is chosen, in either order."""
+        for order in ((False, True), (True, False)):
+            with self.subTest(order=order):
+                path = self.idle_leaf("flag%d%d" % order)
+                self.fresh(); em.set_checkpoint_dir(lambda: self.ck)
+                for c in list(em._FOLD_REG.values()): c.clear()
+                self.km._ASM_CONVERGE_DONE.clear(); self.km._ASM_CONVERGE_NOENTRY.clear()
+                for human in order:
+                    self._parse_as(path, human)                        # two whole entries, the display's flag (False) first or second
+                self.cycle(NOW + 600)
+                self.assertTrue(em._asm_ckpt_file(path).exists())
+                self.assertFalse(_doc(path)["sdkHuman"], "written under the display parse's flag")
+                tree, modes, n_lazy = self.restored(path)
+                self.assertEqual(modes, ["restore"], "the display's next boot restores it: %s" % em.asm_checkpoint_stats()["fallbacks"])
+
+    def test_a_leaf_parsed_only_under_the_other_flag_is_skipped_and_counted(self):
+        path = self.idle_leaf("otherflag")
+        self.fresh(); em.set_checkpoint_dir(lambda: self.ck)
+        for c in list(em._FOLD_REG.values()): c.clear()
+        self.km._ASM_CONVERGE_DONE.clear(); self.km._ASM_CONVERGE_NOENTRY.clear()
+        self._parse_as(path, True)                                     # the judges' flag alone: a document the display would unlink
+        for k in range(2):
+            self.cycle(NOW + 600 + k)
+        self.assertFalse(em._asm_ckpt_file(path).exists(), "no document the reader would delete")
+        av = em.asm_checkpoint_stats()["converge"]
+        self.assertEqual((av["writes"], av["skipped"].get("flagMismatch")), (0, 1), "skipped once, counted: %s" % av)
+
     def test_a_write_over_the_cycles_budget_is_deferred_to_the_next(self):
         path = self.idle_leaf("budget")
         self.km.CKPT_CONVERGE_BYTES = 1


### PR DESCRIPTION
Fix tier. The first boot after the assembly-document writer landed wrote no document: of the 25 boundary-carrying leaves without one, 19 were older than the discover window's 48 hours, so the step, which walked `_sessions(now)`, never looked at them although the boot had parsed some of them whole; the three it did look at have no compaction boundary (the census greps the file for the boundary string and over-counts; the writer, reading the records, is right).

**The change:** the step's candidates are the assembly cache's whole unrestored entries with their sid and flag (`em.asm_whole_entries()`), the parses the boot actually did, whatever the session's age; the fold half names a candidate leaf's session from the cache too (`asm_whole_entry_for`), falling back to the window's row; the document is written under the flag of the parse that has the entry. Every other guard stands: quiescent, no document, both entries resident, the done table, the budget, the wall, once per file state. The reference says a leaf with no compaction boundary is read whole at every boot by design.

**Test** (`tests/test_asm_checkpoint.py`, red first on main): a parse in the cache and no row in the window; the previous head never looked at the leaf, the head writes its document once (no read of records) and the next process restores it. Full Python suite green locally (12,491 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)