### PR TITLE
The planner's placement tests use a private synthetic sid, an empty work text drops its unit under a note, the lazy backstop restores the quote, the work text is assembled once (T377 follow-up)

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9032,7 +9032,10 @@ class _PlacementIndex:
     """The placement lookup _placed_key makes, built ONCE per planner call (T377 review, medium 2): the recorded keys by their
     timestamp-invariant form, so the guard per segment is a dictionary lookup and not a walk of every recorded key (with 20
     unplaced of 300 segments over 2,300 keys the nudge gate's derivation had grown twelve-fold). The episode floor is taken
-    once for the index (handed in by the pass, else derived from the first key that needs it) and never moves within it."""
+    once for the index (handed in by the pass, else derived from the first key that needs it) and never moves within it.
+    The build normalizes every recorded key once per plan_units call (about 2 ms at 2,300 keys; the nudge gate's derivation
+    sits at 1.4 to 2.1 times the pre-T377 base where the walk was 10 to 100 times); not memoized across calls on purpose: the
+    consumer mutates the placements dict between calls, and a stale fuzzy row would dedup a real unit away (review, low 6)."""
 
     def __init__(self, placements, live, floor=_UNSET_FLOOR):
         self.placements, self.live, self.floor = placements, live, floor
@@ -9103,7 +9106,8 @@ def unit_text_for(seg, phase):
         ptext = _prompt_text(seg["atoms"])
         return _strip_cmd_prefix(ptext, seg) if _seg_command(seg) else ptext
     if phase == "work":
-        return _work_note(seg) + (_seam_text(seg) or "") if _seam_text(seg) else ""
+        t = _seam_text(seg)
+        return (_work_note(seg) + t) if t else ""
     return _seam_text(seg)
 
 
@@ -9257,7 +9261,8 @@ def plan_units(session, store=None, floor=_UNSET_FLOOR):
                 _put("nudge", _wt, False, followup)
             else:
                 prefix = _work_note(seg)                  # a kernel notice woke this stretch, or the cleared-cards wrap-up
-                _put("work", (lambda: prefix + _wt()) if prefix else _wt, human, followup)   # ENDED segment → WORK-run
+                _put("work", (lambda: (prefix + _wt()) if _wt() else "") if prefix else _wt, human, followup)   # ENDED segment →
+                #                                                                    WORK-run; a note alone is no unit (review, low 3)
     return out
 
 
@@ -11220,12 +11225,14 @@ def _plan_session(fsid, path, now):
         if _placed_key(store["placements"], _unit_key(seg_id, phase), live, floor=floor):
             continue                                  # placed while THIS pass applied an earlier unit — the
         if text is None:                              # yielded as placed (no text read) yet planned here: the text is read now,
-            seg = seg_by_id.get(seg_id)               #  lazily, never None to the model (T377 review, medium 1)
-            if seg is None:
+            seg = seg_by_id.get(seg_id)               #  lazily, never None to the model (T377 review, medium 1), and the quote with
+            if seg is None:                           #  it, so a node minted on this branch carries the trigger's verbatim head
                 continue
             text = unit_text_for(seg, phase)
             if not text:
                 continue
+            if vq is None:
+                vq = _mint_quote(seg)
         #                                               apply loop must uphold the same idempotence the
         #                                               collection loop checked at pass START (2026-07-06)
         away = _rewound_away(fsid, path, trig) if trig else False

--- a/tests/test_planner_placement_first.py
+++ b/tests/test_planner_placement_first.py
@@ -12,7 +12,17 @@ from pathlib import Path
 import sys
 HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
-from test_judge_apierror_no_fabricated_done import jd, uline, aline, SID, NOW, iso   # noqa: E402  the consumer harness
+from test_judge_apierror_no_fabricated_done import jd, uline, aline, NOW, iso   # noqa: E402  the consumer harness
+SID = "7a377000-2222-4333-8444-000000000377"   # this module's PRIVATE synthetic sid (CLAUDE.md's goal-store rule: load_goals replays the
+#                                                 per-sid override journal and node ids collide across modules under the shared placeholder)
+
+
+class _PrivateSid(unittest.TestCase):
+    def tearDown(self):
+        try:
+            (jd._overrides_dir() / (SID + ".jsonl")).unlink()          # this sid's override journal, never left for another module
+        except FileNotFoundError:
+            pass
 
 
 def _records(n):
@@ -25,7 +35,7 @@ def _records(n):
     return recs
 
 
-class FloorTakenOncePerPass(unittest.TestCase):
+class FloorTakenOncePerPass(_PrivateSid):
     def test_a_floor_rising_after_the_planner_returns_never_sends_a_unit_without_text_to_the_model(self):
         calls = []
         with tempfile.TemporaryDirectory() as td:
@@ -60,10 +70,88 @@ class FloorTakenOncePerPass(unittest.TestCase):
             finally:
                 jd.plan_units = real_plan_units
                 (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store, jd.episode_floor) = saved
-        self.assertTrue(all(isinstance(t, str) and t for t in calls), "the model never sees a unit without text: %r" % calls)
+        self.assertEqual(calls, [], "under the pass's one floor the drifted twins still dedup every unit: nothing planned, no None "
+                                    "to the model (the base sent [None])")
+
+    def test_a_unit_yielded_as_placed_but_planned_reads_its_text_and_quote_lazily(self):
+        """The backstop: when the consumer's own verdict disagrees with the planner's (here forced), the unit is planned with its
+        text read then, and the node it mints carries the trigger's verbatim quote (review, low 4)."""
+        calls = []
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td); tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in _records(1)) + "\n")
+            saved = (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store, jd._placed_key)
+            jd.GOALDIR, jd.PCACHE = td / "goals", td / "pcache"
+            def fake(text, *a, **k):
+                calls.append(text); return '{"ops":[{"why":"the ask","do":"mint","text":"Handle item zero"}]}'
+            jd.plan_llm = jd.opener_llm = fake
+            jd._group_store = lambda *a, **k: None
+            try:
+                jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+                session = jd.parsed_session(SID, [str(tpath)], NOW)
+                units = jd.plan_units(session, {"placements": {}, "nodes": {}, "seq": 0})
+                work = [u for u in units if u[1] == "work"]; self.assertEqual(len(work), 1)
+                store = jd.load_goals(SID)
+                store["placements"][jd._unit_key(work[0][0], "work")] = None      # placed for the planner's read...
+                store["placementsV"] = jd.PLACEMENTS_V
+                jd.save_goals(SID, store)
+                real_placed = jd._placed_key
+                state = {"after": False}
+                real_plan_units = jd.plan_units
+                def planned(*a, **k):
+                    out = real_plan_units(*a, **k); state["after"] = True; return out
+                jd.plan_units = planned
+                jd._placed_key = lambda placements, key, live=None, **kw: (False if state["after"] else real_placed(placements, key, live, **kw))
+                jd._plan_session(SID, str(tpath), NOW)                 # ...and unplaced for the consumer's: the backstop reads
+                store = jd.load_goals(SID)                             # read while the goal directory is still the test's
+            finally:
+                jd.plan_units = real_plan_units
+                (jd.GOALDIR, jd.PCACHE, jd.plan_llm, jd.opener_llm, jd._group_store, jd._placed_key) = saved
+        self.assertEqual(len(calls), 1); self.assertTrue(isinstance(calls[0], str) and "item number 0" in calls[0], "%r" % calls)
+        quotes = [n.get("quote") for n in store["nodes"].values() if isinstance(n, dict)]
+        self.assertTrue(quotes and all(q for q in quotes), "the minted node carries the trigger's verbatim quote: %r" % quotes)
 
 
-class PlacementLookupIsAnIndex(unittest.TestCase):
+class HousekeepingNoteAlone(_PrivateSid):
+    def test_a_note_segment_with_an_empty_work_text_and_a_placed_prompt_yields_no_work_unit(self):
+        """Review, low 3: a kernel-notice or clear-wrap segment whose prompt key is placed and whose work text is empty yielded a
+        WORK unit carrying the housekeeping note alone, unplaced and plannable. An empty work text drops the unit, note or not."""
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td); tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in _records(1)) + "\n")
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+            session = jd.parsed_session(SID, [str(tpath)], NOW)
+            seg_id = jd.plan_units(session, {"placements": {}, "nodes": {}, "seq": 0})[0][0]
+            store = {"placements": {jd._unit_key(seg_id, "prompt"): None}, "nodes": {}, "seq": 0}
+            saved = (jd._seam_text, jd._work_note)
+            jd._seam_text = lambda seg: ""                             # the segment's own text empty...
+            jd._work_note = lambda seg: "Note: this stretch was triggered by an automated romp notice.\n\n"   # ...under a note
+            try:
+                units = jd.plan_units(session, store)
+            finally:
+                jd._seam_text, jd._work_note = saved
+        self.assertEqual([u for u in units if u[1] == "work"], [], "no work unit of a note alone: %r" % units)
+
+    def test_the_lazy_text_for_a_work_unit_is_assembled_once(self):
+        """Review, low 5: unit_text_for assembled the work text up to three times."""
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td); tpath = td / (SID + ".jsonl")
+            tpath.write_text("\n".join(json.dumps(r) for r in _records(1)) + "\n")
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+            session = jd.parsed_session(SID, [str(tpath)], NOW)
+            seg = jd._segs(session["turns"][0], None)[0]
+            count = [0]; real = jd._seam_text
+            def counting(s):
+                count[0] += 1; return real(s)
+            jd._seam_text = counting
+            try:
+                text = jd.unit_text_for(seg, "work")
+            finally:
+                jd._seam_text = real
+        self.assertTrue(text); self.assertEqual(count[0], 1, "assembled once: %d" % count[0])
+
+
+class PlacementLookupIsAnIndex(_PrivateSid):
     def test_the_lookup_cost_is_a_build_once_index_not_a_walk_per_segment(self):
         with tempfile.TemporaryDirectory() as td:
             td = Path(td); tpath = td / (SID + ".jsonl")


### PR DESCRIPTION
Fix tier. The six lows from the review of the planner's placement-first read, in two commits:

- **The repo's goal-store rule:** `tests/test_planner_placement_first.py` minted goals under the shared placeholder sid; it now has its own uuid-shaped synthetic sid and a base class whose tearDown removes that sid's override journal (load_goals replays the per-sid journal and node ids collide across modules). The floor test asserts what the head pins (under the pass's one floor nothing is planned and no None reaches the model; the base sent one), and the backstop's positive path has its own test.
- **The planner:** an empty work text drops the unit even under a kernel-notice or clear-wrap note (a note alone was yielded, unplaced and plannable); the lazy backstop reads the minting quote with the text, so a node minted on that branch carries the trigger's verbatim head; `unit_text_for` assembles the work text once; the placement index's build cost (about 2 ms at 2,300 keys) is stated at the class with why it is not memoized across calls.

Red first on main for the three planner lows. Full Python suite green locally (12,455 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)