### PR TITLE
Whole reads are counted on /perf by kind and caller; the segment-prompt, tool-uses and echo-set readers hydrate only what they need (T384)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1512,6 +1512,14 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
 - `stacks`: every thread's last six frames, keyed by the thread's ident and
   name, when the kernel runs with `ROMP_PERF_STACKS` set (a debugging aid for a
   served test on a runner nobody can log into); `null` otherwise.
+- `recordCache`: the reader's record cache (the JSONL records held in memory):
+  `entries`, `bytes`, `budgetBytes`, `countCap`, `inserts`, `evictions`,
+  `evictedBytes`, `budgetEvictions`, `dropped` and `droppedBytes` (the
+  quiescence drop), and `wholeReads`: every read that pulled a file whole,
+  keyed `kind<-caller` (the reader's kind, one of `zero`, `rewrite`, `guard`,
+  `shrunk` and `upgrade`, and the first calling function outside the event
+  model and the parse family), with `count` and `bytes`; a tail read, an
+  append and a restore's tail read are not whole reads and are not counted.
 - `asmCheckpoint`: the assembly documents since boot: `written`, `restored`,
   `fallbacks` per reason (`version`, `session`, `inputs`, `lineage`, `shrunk`,
   `rewrite`, `guard`, `identity`, `corrupt`, `restore`), `skipped` per reason

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1629,6 +1629,14 @@ _WHOLE_READ_PASSTHROUGH = set()   # the CODE objects of the parse family every w
 #                                   object, never by name (round two, low 3: a local helper named like one of them was skipped)
 
 
+def _synthetic_scope(fr):
+    """A comprehension's, generator expression's or lambda's own frame (a code name in angle brackets other than the module's):
+    the attribution walks keep going to the enclosing function. Before Python 3.12 a list, set or dict comprehension runs in
+    its own frame (PEP 709 inlines them from 3.12 on); a generator expression and a lambda keep theirs on every version."""
+    n = fr.f_code.co_name
+    return n.startswith("<") and n != "<module>"
+
+
 def register_whole_read_passthrough(*fns):
     """Register functions the whole-read attribution walks past (the parse family a walker reaches the reader through)."""
     for fn in fns:
@@ -1760,8 +1768,9 @@ def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False, tail_from=None
             if kind in _WHOLE_READ_KINDS:                 # a whole read: counted by kind and caller on /perf (T384), always on; the
                 try:                                      #  frame walk runs only here, on the rare whole read, never on a tail or an
                     fr = sys._getframe(1)                 #  append
-                    while fr is not None and (fr.f_code.co_filename == __file__ or fr.f_code in _WHOLE_READ_PASSTHROUGH):
-                        fr = fr.f_back                    #  past this module and past the parse family, to the walker (review, low 1)
+                    while fr is not None and (fr.f_code.co_filename == __file__ or fr.f_code in _WHOLE_READ_PASSTHROUGH
+                                              or _synthetic_scope(fr)):   #  past this module, the parse family and any comprehension's
+                        fr = fr.f_back                    #  or generator expression's own frame, to the walker (review, low 1)
                     who = fr.f_code.co_name if fr is not None else "?"
                 except Exception:
                     who = "?"
@@ -5744,12 +5753,15 @@ def hydrate(atoms, rompuuid=None, by=None):
         return 0
     if by is None:
         try:
-            f = sys._getframe(1); by = f.f_code.co_name
+            f = sys._getframe(1)
+            while f is not None and _synthetic_scope(f):  # a comprehension's or generator expression's own frame is no caller
+                f = f.f_back
+            by = f.f_code.co_name if f is not None else "?"
             if by in _HYDRATE_TEXT_READERS:               # a text reader every walker shares says nothing about WHO walked: the
                 g = f.f_back                              #  first caller outside the shared readers is recorded with it (T377:
-                while g is not None and g.f_code.co_name in _HYDRATE_TEXT_READERS:   #  naming the boot's reader; a reader reached
-                    g = g.f_back                          #  through another reader still names the walker)
-                by = "%s<-%s" % (by, g.f_code.co_name if g is not None else "?")
+                while g is not None and (g.f_code.co_name in _HYDRATE_TEXT_READERS or _synthetic_scope(g)):   #  naming the boot's
+                    g = g.f_back                          #  reader; a reader reached through another reader, or through a
+                by = "%s<-%s" % (by, g.f_code.co_name if g is not None else "?")   #  comprehension's frame, still names the walker)
         except Exception:
             by = "?"
     filled, by_file = 0, {}

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -676,7 +676,12 @@ def _record_cache_default_budget_bytes(meminfo_text=None):
 _JSONL_CACHE_BUDGET_BYTES = (int(float(os.environ["ROMP_RECORD_CACHE_BUDGET_MB"]) * 1024 * 1024)
                              if os.environ.get("ROMP_RECORD_CACHE_BUDGET_MB") else _record_cache_default_budget_bytes())
 _JSONL_CACHE_BYTES = [0]          # the sum of every held entry's weight, kept in step with _JSONL_CACHE under its lock
-_RECORD_CACHE_STATS = {"inserts": 0, "evictions": 0, "evictedBytes": 0, "budgetEvictions": 0, "dropped": 0, "droppedBytes": 0}
+_RECORD_CACHE_STATS = {"inserts": 0, "evictions": 0, "evictedBytes": 0, "budgetEvictions": 0, "dropped": 0, "droppedBytes": 0,
+                       "wholeReads": {}}   # "kind<-caller" -> {"count", "bytes"}: every read that pulled a file WHOLE (from zero, or a
+#                                          tail entry upgraded to the whole file), named by the reader's kind and the first frame
+#                                          outside this module (T384: the way hydratedBy named the planner; the 0.8 GB of whole
+#                                          reads of restored leaves the per-path bytes could not attribute). A restore's tail read
+#                                          and an append are not whole reads and are not counted here.
 _DROP_AFTER_QUIESCENT_S = float(os.environ.get("ROMP_RECORD_CACHE_DROP_QUIESCENT_S", "120"))   # a file this long unchanged
 #                                   is one whose writer has finished (a subagent that returned): its records are not kept
 
@@ -720,8 +725,11 @@ def record_cache_stats() -> dict:
     """The record cache for /perf: entries, held bytes, the budget, and the counters (inserts, evictions by count and by
     budget, evicted bytes, drop-after-fold drops)."""
     with _JSONL_CACHE_LOCK:
-        return {"entries": len(_JSONL_CACHE), "bytes": _JSONL_CACHE_BYTES[0], "budgetBytes": _JSONL_CACHE_BUDGET_BYTES,
-                "countCap": _JSONL_CACHE_MAX, **_RECORD_CACHE_STATS}
+        out = {"entries": len(_JSONL_CACHE), "bytes": _JSONL_CACHE_BYTES[0], "budgetBytes": _JSONL_CACHE_BUDGET_BYTES,
+               "countCap": _JSONL_CACHE_MAX, **_RECORD_CACHE_STATS}
+        table = _RECORD_CACHE_STATS.get("wholeReads")
+        out["wholeReads"] = {k: dict(v) for k, v in table.items()} if isinstance(table, dict) else {}
+        return out
 
 
 _JSONL_TAIL_GUARD = 64            # bytes of pre-offset content re-verified before an incremental read
@@ -1614,6 +1622,7 @@ def _read_jsonl_incremental(path, on_fail=None):
 
 _TAIL_OK = threading.local()      # .flag: the calling fold accepts a tail entry (set by fold_records around its read)
 _READER_TRACE = bool(os.environ.get("ROMP_READER_TRACE"))   # one stderr line per read that pulled bytes (a diagnosis aid)
+_WHOLE_READ_KINDS = ("zero", "rewrite", "guard", "shrunk", "upgrade")   # the reader's kinds that pull a file whole (T384's counter)
 _LAST_ENTRY = threading.local()   # .ent: the entry the last _read_jsonl_incremental on this thread served
 
 
@@ -1738,6 +1747,20 @@ def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False, tail_from=None
             fh.seek(tail_from)
             tail = fh.read(offset - tail_from)
             _count_read(path, len(tail))                  # the guard capture is a read too (/perf's count is what was pulled)
+            if kind in _WHOLE_READ_KINDS:                 # a whole read: counted by kind and caller on /perf (T384), always on; the
+                try:                                      #  frame walk runs only here, on the rare whole read, never on a tail or an
+                    fr = sys._getframe(1)                 #  append
+                    while fr is not None and fr.f_code.co_filename == __file__:
+                        fr = fr.f_back
+                    who = fr.f_code.co_name if fr is not None else "?"
+                except Exception:
+                    who = "?"
+                with _JSONL_CACHE_LOCK:
+                    table = _RECORD_CACHE_STATS.get("wholeReads")
+                    if not isinstance(table, dict):       # a harness that zeroes every counter zeroes this one too: a table again
+                        table = _RECORD_CACHE_STATS["wholeReads"] = {}
+                    wr = table.setdefault("%s<-%s" % (kind, who), {"count": 0, "bytes": 0})
+                    wr["count"] += 1; wr["bytes"] += len(data)
             if _READER_TRACE:
                 fr, inner = sys._getframe(1), []          # the caller outside this module, and the path through it
                 while fr is not None and fr.f_code.co_filename == __file__:

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1623,8 +1623,16 @@ def _read_jsonl_incremental(path, on_fail=None):
 _TAIL_OK = threading.local()      # .flag: the calling fold accepts a tail entry (set by fold_records around its read)
 _READER_TRACE = bool(os.environ.get("ROMP_READER_TRACE"))   # one stderr line per read that pulled bytes (a diagnosis aid)
 _WHOLE_READ_KINDS = ("zero", "rewrite", "guard", "shrunk", "upgrade")   # the reader's kinds that pull a file whole (T384's counter)
-_WHOLE_READ_PASSTHROUGH = ("parse_session", "parsed_session", "parse_cached", "_parse_store", "_parse")   # the parse family every
-#                                   walker shares: the whole-read row names the first caller beyond it, the real walker
+_WHOLE_READ_PASSTHROUGH = set()   # the CODE objects of the parse family every walker shares (this module's parse_session, the judges'
+#                                   parsed_session, parse_cached and _parse_store, the kernel's _parse, each registered where it is
+#                                   defined): the whole-read row names the first caller beyond them, the real walker. Matched by code
+#                                   object, never by name (round two, low 3: a local helper named like one of them was skipped)
+
+
+def register_whole_read_passthrough(*fns):
+    """Register functions the whole-read attribution walks past (the parse family a walker reaches the reader through)."""
+    for fn in fns:
+        _WHOLE_READ_PASSTHROUGH.add(fn.__code__)
 _LAST_ENTRY = threading.local()   # .ent: the entry the last _read_jsonl_incremental on this thread served
 
 
@@ -1752,7 +1760,7 @@ def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False, tail_from=None
             if kind in _WHOLE_READ_KINDS:                 # a whole read: counted by kind and caller on /perf (T384), always on; the
                 try:                                      #  frame walk runs only here, on the rare whole read, never on a tail or an
                     fr = sys._getframe(1)                 #  append
-                    while fr is not None and (fr.f_code.co_filename == __file__ or fr.f_code.co_name in _WHOLE_READ_PASSTHROUGH):
+                    while fr is not None and (fr.f_code.co_filename == __file__ or fr.f_code in _WHOLE_READ_PASSTHROUGH):
                         fr = fr.f_back                    #  past this module and past the parse family, to the walker (review, low 1)
                     who = fr.f_code.co_name if fr is not None else "?"
                 except Exception:
@@ -5719,7 +5727,8 @@ def _hydrate_one(a, rec):
     a.pop("lazy", None)
 
 
-_HYDRATE_TEXT_READERS = ("_unit_text", "_prompt_text", "_atom_text")   # the judges' shared text readers: attributed with their caller
+_HYDRATE_TEXT_READERS = ("_unit_text", "_prompt_text", "_atom_text", "_atom_user_texts")   # the shared text readers (the judges'
+#                                   three and the kernel's user-texts reader): attributed with their caller
 
 
 def hydrate(atoms, rompuuid=None, by=None):
@@ -5969,6 +5978,9 @@ def parse_session(leaf_path, rompuuid=None, name=None, color="#888888", dir=None
         out["cutTurn"] = cut_turn                   # a restored tree only (T323 stage 4b): where its lazy atoms ended
     return out
 
+
+
+register_whole_read_passthrough(parse_session)   # the parse's own entry (T384)
 
 def task_store_dir(fsid):
     """Claude Code's task store for one transcript stem: <CLAUDE_CONFIG_DIR or ~/.claude>/tasks/<fsid>,

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1623,6 +1623,8 @@ def _read_jsonl_incremental(path, on_fail=None):
 _TAIL_OK = threading.local()      # .flag: the calling fold accepts a tail entry (set by fold_records around its read)
 _READER_TRACE = bool(os.environ.get("ROMP_READER_TRACE"))   # one stderr line per read that pulled bytes (a diagnosis aid)
 _WHOLE_READ_KINDS = ("zero", "rewrite", "guard", "shrunk", "upgrade")   # the reader's kinds that pull a file whole (T384's counter)
+_WHOLE_READ_PASSTHROUGH = ("parse_session", "parsed_session", "parse_cached", "_parse_store", "_parse")   # the parse family every
+#                                   walker shares: the whole-read row names the first caller beyond it, the real walker
 _LAST_ENTRY = threading.local()   # .ent: the entry the last _read_jsonl_incremental on this thread served
 
 
@@ -1750,8 +1752,8 @@ def _read_jsonl_entry_unlocked(path, on_fail=None, tail_ok=False, tail_from=None
             if kind in _WHOLE_READ_KINDS:                 # a whole read: counted by kind and caller on /perf (T384), always on; the
                 try:                                      #  frame walk runs only here, on the rare whole read, never on a tail or an
                     fr = sys._getframe(1)                 #  append
-                    while fr is not None and fr.f_code.co_filename == __file__:
-                        fr = fr.f_back
+                    while fr is not None and (fr.f_code.co_filename == __file__ or fr.f_code.co_name in _WHOLE_READ_PASSTHROUGH):
+                        fr = fr.f_back                    #  past this module and past the parse family, to the walker (review, low 1)
                     who = fr.f_code.co_name if fr is not None else "?"
                 except Exception:
                     who = "?"

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -11122,6 +11122,10 @@ def _latch_ask_anchors(fsid, session, store):
     return n
 
 
+em.register_whole_read_passthrough(parsed_session, parse_cached, _parse_store)   # the judges' parse family: a whole read through
+#                                                                                   them names the walker beyond (T384)
+
+
 def _plan_session(fsid, path, now):
     """Advance ONE session's goal tree: place its un-placed planner UNITS oldest-first (each sees the prior
     tree's open menu) and GROUP after every placement (the user 2026-06-17: planner + grouper are both

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15127,7 +15127,9 @@ def _echo_landing_atoms(turns, live):
     (a text lands at or after its send, so no older atom can hold an echo's landing). The stamp is a scalar every lazy atom
     carries, so the atoms below the floor are never hydrated (T384: the comments frame read every user atom of a thread's
     whole parse for this, a body read of every pre-cut user message on every frame with a live echo)."""
-    since = min((float(e.get("t") or 0) for e in live if e.get("_echo_text")), default=None)
+    since = min((float(e.get("t") or 0) for e in live                       # the floor over the echoes the frame can hold:
+                 if sb.echo_text_key(e.get("_echo_text")) and not e.get("command")   #  a dropped or landed one is never popped by the
+                 and not e.get("dropped") and not e.get("_landed")), default=None)   #  backend's prune and must not sink it (round two, low 4)
     if since is None:
         return []
     return [(float(a.get("t") or 0), set(_atom_user_texts(a)))
@@ -25676,15 +25678,13 @@ def _seg_of_tool_uses(ps, store, tool_ids):
             for a in seg["atoms"]:
                 if a.get("type") != "assistant":
                     continue
-                lz = a.get("lazy")
-                if lz is not None and "tu" not in lz:      # a marker older than the scalar: the body answers (a counted read), never
-                    em.hydrate([a])                        #  an empty answer for a call that exists (review, low 4)
-                    uses = [(b.get("id"), b.get("name")) for b in ((a.get("message") or {}).get("content") or [])
-                            if isinstance(b, dict) and b.get("type") == "tool_use"]
-                else:
-                    uses = em.atom_tool_uses(a)            # the ids from the body, or a lazy atom's marker scalars: no hydration
-                for tid, _name in uses:                    #  (T384: every turn was hydrated whole, newest first, 155 MB a boot)
-                    if tid in want:
+                for tid, _name in em.atom_tool_uses(a):   # the ids from the body, or a lazy atom's marker scalars: no hydration
+                    if tid in want:                        #  (T384: every turn was hydrated whole, newest first, 155 MB a boot). A
+                        #                                    marker without `tu` is an assistant answer with no tool call (the writer
+                        #                                    records the scalar only when there are calls; the document's version gate
+                        #                                    and the source pin beside it make any other marker shape unreachable), so
+                        #                                    it means an empty set, never a body read (round two: a fallback read here
+                        #                                    hydrated every prose-only answer the walk met)
                         found[tid] = seg["id"]
                         want.discard(tid)
     return found
@@ -29859,6 +29859,9 @@ def _rewind_holds_boot():
                 _on_rewind_resolved(sid, "spent")
         except Exception:
             sys.stderr.write("rewind-hold boot: %s\n" % traceback.format_exc())
+
+
+em.register_whole_read_passthrough(_parse)   # the kernel's parse entry: a whole read through it names the walker beyond (T384)
 
 
 def _display_sdk_human(sid):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25658,20 +25658,16 @@ def _seg_of_tool_uses(ps, store, tool_ids):
     every id is found; seam-aware (_segs_seam) so the ids match the judge's placement keys."""
     found, want = {}, set(tool_ids)
     for turn in reversed(ps.get("turns") or []):
-        em.hydrate(turn.get("atoms") or [])      # bodies before the assembly cut: read on demand, newest turns first (T323 stage 4a)
         if not want:
             break
         for seg in _segs_seam(turn, store):
             for a in seg["atoms"]:
                 if a.get("type") != "assistant":
                     continue
-                blocks = (a.get("message") or {}).get("content")
-                if not isinstance(blocks, list):
-                    continue
-                for b in blocks:
-                    if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id") in want:
-                        found[b["id"]] = seg["id"]
-                        want.discard(b["id"])
+                for tid, _name in em.atom_tool_uses(a):   # the ids from the body, or a lazy atom's marker scalars: no hydration
+                    if tid in want:                        #  (T384: every turn was hydrated whole, newest first, 155 MB a boot)
+                        found[tid] = seg["id"]
+                        want.discard(tid)
     return found
 
 
@@ -32425,7 +32421,9 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     # The transcript-side sets come from the per-sid memo (_merge_tx_sets): a function of the parsed
     # session alone, which the parse cache hands back as the same object until the transcript changes,
     # and which every build of a cycle (chat, feed, timeline) used to derive again from every atom.
-    echo_floor = min((float(a.get("t") or 0) for a in live if a.get("_echo_text")), default=None)   # the oldest echo's send:
+    echo_floor = min((float(a.get("t") or 0) for a in live if a.get("_echo_text")), default=float("inf"))   # the oldest echo's send;
+    #                                                                                                 no echo: no text can land, none
+    #                                                                                                 is read (T384: None read them all)
     tx_uuids, tx_text_uuids, tx_texts, tx_text_t, human_floor = _merge_tx_sets(session, sid, echo_floor)   # no text lands before it
     # A TEXTLESS disk twin must not land a texty live atom (the user 2026-07-28): on some model+tool
     # combinations (observed: fable-5 replying before an AskUserQuestion) the CLI persists the reply
@@ -39522,8 +39520,9 @@ def _expand_judging(wire):
 
 
 def _seg_prompt(seg):
-    """The segment's request text (its trigger/opener atom) for the prompt-dot tooltip."""
-    em.hydrate(seg.get("atoms") or [])   # bodies before the assembly cut: read on demand (T323 stage 4a)
+    """The segment's request text (its trigger/opener atom) for the prompt-dot tooltip. Over a restored tree the trigger is
+    found by its uuid and type, scalars every lazy atom carries, and that ONE atom is hydrated (T384: the whole segment was
+    hydrated for it, 723 MB on the first boot after the planner stopped filling the memo for everyone after it)."""
     trig = seg.get("trigger")
     atoms = seg["atoms"]
     a = next((x for x in atoms if x.get("uuid") == trig), None) if trig else None
@@ -39531,6 +39530,7 @@ def _seg_prompt(seg):
         a = next((x for x in atoms if x.get("type") == "user"), None)
     if a is None:
         return ""
+    em.hydrate([a])                          # the trigger's body alone, before the assembly cut: read on demand (T323 stage 4a)
     blocks = (a.get("message") or {}).get("content", [])
     if isinstance(blocks, list):
         return " ".join(b.get("text", "") for b in blocks

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -15122,6 +15122,19 @@ def _agent_landed_after(events, msgs, seen):
     return any(m["who"] == "agent" and m["t"] > seen for m in msgs)
 
 
+def _echo_landing_atoms(turns, live):
+    """[(stamp, its texts)] for the user atoms an echo could have landed as: those at or after the oldest live echo's send
+    (a text lands at or after its send, so no older atom can hold an echo's landing). The stamp is a scalar every lazy atom
+    carries, so the atoms below the floor are never hydrated (T384: the comments frame read every user atom of a thread's
+    whole parse for this, a body read of every pre-cut user message on every frame with a live echo)."""
+    since = min((float(e.get("t") or 0) for e in live if e.get("_echo_text")), default=None)
+    if since is None:
+        return []
+    return [(float(a.get("t") or 0), set(_atom_user_texts(a)))
+            for tr in turns for a in (tr.get("atoms") or [])
+            if a.get("type") == "user" and float(a.get("t") or 0) >= since]
+
+
 def _comments_frame(sid, live_map=None):
     """The chat pane's {type:"comments"} frame for parent session `sid`, or None when it has never
     had a thread. Built per push for sessions WITH a store (few) — _send_client's dedup keeps an
@@ -15211,8 +15224,7 @@ def _comments_frame(sid, live_map=None):
                 # deliberate re-send repeat earlier texts, which read as "already in the transcript" and hid a
                 # send the CLI still held (round-5 review). A `dropped` echo (the backend adjudicated the send
                 # LOST — a reconnect with it in flight; the popover shows "never delivered") owes nothing.
-                user_atoms = [(float(a.get("t") or 0), set(_atom_user_texts(a)))       # (stamp, its texts), built once per frame
-                              for tr in turns for a in (tr.get("atoms") or []) if a.get("type") == "user"]
+                user_atoms = _echo_landing_atoms(turns, live)          # (stamp, its texts) from the oldest echo's send up, built once
                 def _landed(e):
                     keys = set(sb.echo_keys(e.get("_echo_text")))     # the plain key and, for a slash send, its words
                     since = float(e.get("t") or 0)                     # the send's own stamp: the record the CLI writes for
@@ -25664,8 +25676,15 @@ def _seg_of_tool_uses(ps, store, tool_ids):
             for a in seg["atoms"]:
                 if a.get("type") != "assistant":
                     continue
-                for tid, _name in em.atom_tool_uses(a):   # the ids from the body, or a lazy atom's marker scalars: no hydration
-                    if tid in want:                        #  (T384: every turn was hydrated whole, newest first, 155 MB a boot)
+                lz = a.get("lazy")
+                if lz is not None and "tu" not in lz:      # a marker older than the scalar: the body answers (a counted read), never
+                    em.hydrate([a])                        #  an empty answer for a call that exists (review, low 4)
+                    uses = [(b.get("id"), b.get("name")) for b in ((a.get("message") or {}).get("content") or [])
+                            if isinstance(b, dict) and b.get("type") == "tool_use"]
+                else:
+                    uses = em.atom_tool_uses(a)            # the ids from the body, or a lazy atom's marker scalars: no hydration
+                for tid, _name in uses:                    #  (T384: every turn was hydrated whole, newest first, 155 MB a boot)
+                    if tid in want:
                         found[tid] = seg["id"]
                         want.discard(tid)
     return found
@@ -32421,9 +32440,7 @@ def _merge_live_atoms(session, sid, shown_texts=()):
     # The transcript-side sets come from the per-sid memo (_merge_tx_sets): a function of the parsed
     # session alone, which the parse cache hands back as the same object until the transcript changes,
     # and which every build of a cycle (chat, feed, timeline) used to derive again from every atom.
-    echo_floor = min((float(a.get("t") or 0) for a in live if a.get("_echo_text")), default=float("inf"))   # the oldest echo's send;
-    #                                                                                                 no echo: no text can land, none
-    #                                                                                                 is read (T384: None read them all)
+    echo_floor = min((float(a.get("t") or 0) for a in live if a.get("_echo_text")), default=None)   # the oldest echo's send:
     tx_uuids, tx_text_uuids, tx_texts, tx_text_t, human_floor = _merge_tx_sets(session, sid, echo_floor)   # no text lands before it
     # A TEXTLESS disk twin must not land a texty live atom (the user 2026-07-28): on some model+tool
     # combinations (observed: fable-5 replying before an AskUserQuestion) the CLI persists the reply

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -695,6 +695,54 @@ class HydrationAttribution(Harness):
         self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["_atom_text<-other_walker"], "the first caller outside the shared readers")
 
 
+class ReadersOverRestoredHydrateOnlyWhatTheyNeed(Harness):
+    """T384 (2026-09-12): after the planner stopped hydrating every pre-cut body, the next walkers paid for the same bodies (the
+    first T377 boot: _seg_prompt 723 MB, _seg_of_tool_uses 155 MB, _atom_user_texts 78 MB of 966). Each reads what it needs:
+    the segment-prompt reader hydrates the one trigger atom, the tool-uses reader takes the ids from the lazy markers' scalars
+    with no hydration, and the echo set reads no user text when no echo can land (an infinite floor). Per-reader bytes over a
+    restored tree, on both builds."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.km = kernel_module()
+
+    def _restored(self, name):
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write(name, records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        return path, tree
+
+    def test_the_segment_prompt_reader_hydrates_the_trigger_atom_alone(self):
+        path, tree = self._restored("segprompt")
+        segs = [seg for t in tree["turns"] for seg in em.segments(t)]
+        pre = [seg for seg in segs if any(a.get("lazy") is not None for a in seg["atoms"])]
+        self.assertTrue(pre, "pre-cut segments in play")
+        prompts = [self.km._seg_prompt(seg) for seg in segs]
+        st = em.asm_checkpoint_stats()
+        self.assertLessEqual(st["hydratedAtoms"], len(pre), "one atom per pre-cut segment, the trigger: %s" % st)
+        self.fresh(); whole = self.parse(path)
+        self.assertEqual(prompts, [self.km._seg_prompt(seg) for t in whole["turns"] for seg in em.segments(t)], "the same prompts as the whole parse")
+
+    def test_the_tool_uses_reader_takes_the_ids_from_the_markers_scalars(self):
+        path, tree = self._restored("tooluses")
+        whole_ids = {b.get("id") for t in self.cold(path)["turns"] for a in t["atoms"] if a.get("type") == "assistant"
+                     for b in ((a.get("message") or {}).get("content") or []) if isinstance(b, dict) and b.get("type") == "tool_use"}
+        self.assertTrue(whole_ids, "the fixture has tool calls")
+        self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        found = self.km._seg_of_tool_uses(tree, {"placements": {}, "nodes": {}, "seq": 0}, list(whole_ids))
+        self.assertEqual(set(found), whole_ids, "every id resolved to its segment")
+        self.assertEqual(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "from the scalars, no body read: %s" % em.asm_checkpoint_stats()["hydratedBy"])
+
+    def test_the_echo_set_reads_no_user_text_when_no_echo_can_land(self):
+        path, tree = self._restored("echoset")
+        self.km._merge_sets_memo.clear()
+        self.km._merge_tx_sets(tree, SID + "-t384", float("inf"))    # no live echo: no text can land, none is read
+        self.assertEqual(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "%s" % em.asm_checkpoint_stats()["hydratedBy"])
+
+
 class KernelOverRestored(Harness):
     """The kernel's and the judges' body readers over a restored tree: every consumer the audit named hydrates what it
     reads, so the same answers come from the restored tree as from the whole parse, with no LazyBodyRead."""

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -736,12 +736,56 @@ class ReadersOverRestoredHydrateOnlyWhatTheyNeed(Harness):
         self.assertEqual(set(found), whole_ids, "every id resolved to its segment")
         self.assertEqual(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "from the scalars, no body read: %s" % em.asm_checkpoint_stats()["hydratedBy"])
 
-    def test_the_echo_set_reads_no_user_text_when_no_echo_can_land(self):
-        path, tree = self._restored("echoset")
-        self.km._merge_sets_memo.clear()
-        self.km._merge_tx_sets(tree, SID + "-t384", float("inf"))    # no live echo: no text can land, none is read
+    def test_the_comments_frames_landing_walk_reads_no_user_text_below_the_oldest_echos_send(self):
+        """The comments frame read every user atom of a thread's whole parse to test whether a live echo had landed (78 MB on
+        the first T377 boot); a text lands at or after its send, so the atoms below the oldest echo's send are never read."""
+        path, tree = self._restored("echoland")
+        pre_users = [a for t in tree["turns"] for a in t["atoms"] if a.get("type") == "user" and a.get("lazy") is not None]
+        self.assertTrue(pre_users, "pre-cut user atoms in play")
+        newest = max(float(a.get("t") or 0) for t in tree["turns"] for a in t["atoms"] if a.get("t"))
+        live = [{"_echo_text": "a typed-ahead line", "t": newest + 5}]   # an echo sent after every recorded atom
+        rows = self.km._echo_landing_atoms(tree["turns"], live)
+        self.assertEqual(rows, [], "no atom at or after the send: nothing to compare, nothing read")
         self.assertEqual(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "%s" % em.asm_checkpoint_stats()["hydratedBy"])
+        self.assertEqual(self.km._echo_landing_atoms(tree["turns"], []), [], "no live echo: no walk")
+        live = [{"_echo_text": "an early line", "t": 0}]                 # an echo older than everything: every user atom is a candidate
+        rows = self.km._echo_landing_atoms(tree["turns"], live)
+        self.assertEqual(len(rows), sum(1 for t in tree["turns"] for a in t["atoms"] if a.get("type") == "user"))
+        self.assertGreaterEqual(em.asm_checkpoint_stats()["hydratedAtoms"], len(pre_users), "below the floor they are read, as before")
 
+    def test_a_marker_without_tool_use_scalars_answers_from_the_body_not_silently_empty(self):
+        """Review, low 4: a lazy assistant marker without `tu` made the tool-uses reader resolve nothing, silently; the body
+        answers instead (a counted hydration), never an empty map for a call that exists."""
+        path, tree = self._restored("notu")
+        whole_ids = {b.get("id") for t in self.cold(path)["turns"] for a in t["atoms"] if a.get("type") == "assistant"
+                     for b in ((a.get("message") or {}).get("content") or []) if isinstance(b, dict) and b.get("type") == "tool_use"}
+        self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+        popped = 0
+        for t in tree["turns"]:
+            for a in t["atoms"]:
+                if a.get("type") == "assistant" and a.get("lazy") is not None and "tu" in a["lazy"]:
+                    a["lazy"].pop("tu"); popped += 1
+        self.assertTrue(popped, "markers without the scalar in play")
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        found = self.km._seg_of_tool_uses(tree, {"placements": {}, "nodes": {}, "seq": 0}, list(whole_ids))
+        self.assertEqual(set(found), whole_ids, "resolved from the bodies")
+        self.assertGreater(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "read, and counted")
+
+    def test_a_whole_read_through_the_parse_family_names_the_walker(self):
+        """Review, low 1: every parse goes through parsed_session, so its whole read was one row for every walker; the counter
+        walks past the parse family to the first caller beyond it."""
+        jd = self.km.jd
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("walker", records(), sent=sent)
+        self.fresh(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        def some_boot_walker():
+            return jd.parsed_session(SID, [path], NOW)
+        some_boot_walker()
+        keys = list(em.record_cache_stats()["wholeReads"])
+        self.assertTrue(any(k.endswith("<-some_boot_walker") for k in keys), "the walker, not the parse family: %s" % keys)
+        self.assertFalse(any(k.split("<-")[-1] in ("parsed_session", "parse_session", "parse_cached", "_parse_store") for k in keys), "%s" % keys)
 
 class KernelOverRestored(Harness):
     """The kernel's and the judges' body readers over a restored tree: every consumer the audit named hydrates what it

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -694,7 +694,7 @@ class HydrationAttribution(Harness):
         other_walker()
         self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["_atom_text<-other_walker"], "the first caller outside the shared readers")
 
-    def test_a_walk_from_inside_a_generator_expression_or_a_comprehension_names_the_enclosing_function(self):
+    def test_a_walk_from_inside_a_generator_expression_names_the_enclosing_function(self):
         """The 1e60c712 head went red on Python 3.10 and 3.11: a list comprehension there runs in its own frame (inlined from
         3.12 on, PEP 709), and the attribution named `<listcomp>`. A generator expression keeps its own frame on every version,
         so the first pin is red everywhere at that head; the comprehension pin is red on 3.10 and 3.11 and green above."""
@@ -710,7 +710,16 @@ class HydrationAttribution(Harness):
             return sum(em.hydrate([a]) for a in atoms)
         genexpr_walker()
         self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["genexpr_walker"], "%s" % em.asm_checkpoint_stats()["hydratedBy"])
-        atoms = restored_atoms()
+
+    def test_a_shared_reader_reached_from_a_list_comprehension_names_the_walker_around_it(self):
+        """The comprehension case alone: red on Python 3.10 and 3.11 at 1e60c712 (`<listcomp>` has its own frame there), green
+        from 3.12 on, where PEP 709 inlines it."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("listcomp", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        atoms = [a for t in tree["turns"] for a in t["atoms"]]
         def _atom_user_texts(a):                                # a shared reader reached from a comprehension inside a walker
             return em.hydrate([a])
         def listcomp_walker():

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -694,6 +694,30 @@ class HydrationAttribution(Harness):
         other_walker()
         self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["_atom_text<-other_walker"], "the first caller outside the shared readers")
 
+    def test_a_walk_from_inside_a_generator_expression_or_a_comprehension_names_the_enclosing_function(self):
+        """The 1e60c712 head went red on Python 3.10 and 3.11: a list comprehension there runs in its own frame (inlined from
+        3.12 on, PEP 709), and the attribution named `<listcomp>`. A generator expression keeps its own frame on every version,
+        so the first pin is red everywhere at that head; the comprehension pin is red on 3.10 and 3.11 and green above."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("scopes", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        def restored_atoms():
+            self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+            em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+            return [a for t in tree["turns"] for a in t["atoms"]]
+        atoms = restored_atoms()
+        def genexpr_walker():
+            return sum(em.hydrate([a]) for a in atoms)
+        genexpr_walker()
+        self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["genexpr_walker"], "%s" % em.asm_checkpoint_stats()["hydratedBy"])
+        atoms = restored_atoms()
+        def _atom_user_texts(a):                                # a shared reader reached from a comprehension inside a walker
+            return em.hydrate([a])
+        def listcomp_walker():
+            return [_atom_user_texts(a) for a in atoms]
+        listcomp_walker()
+        self.assertEqual(list(em.asm_checkpoint_stats()["hydratedBy"]), ["_atom_user_texts<-listcomp_walker"], "%s" % em.asm_checkpoint_stats()["hydratedBy"])
+
 
 class ReadersOverRestoredHydrateOnlyWhatTheyNeed(Harness):
     """T384 (2026-09-12): after the planner stopped hydrating every pre-cut body, the next walkers paid for the same bodies (the

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -753,23 +753,85 @@ class ReadersOverRestoredHydrateOnlyWhatTheyNeed(Harness):
         self.assertEqual(len(rows), sum(1 for t in tree["turns"] for a in t["atoms"] if a.get("type") == "user"))
         self.assertGreaterEqual(em.asm_checkpoint_stats()["hydratedAtoms"], len(pre_users), "below the floor they are read, as before")
 
-    def test_a_marker_without_tool_use_scalars_answers_from_the_body_not_silently_empty(self):
-        """Review, low 4: a lazy assistant marker without `tu` made the tool-uses reader resolve nothing, silently; the body
-        answers instead (a counted hydration), never an empty map for a call that exists."""
-        path, tree = self._restored("notu")
+    def test_a_marker_without_tool_use_scalars_is_an_answer_with_no_tool_call_and_hydrates_nothing(self):
+        """Round two, medium: the writer records `tu` only when an atom has tool calls, so a marker without it is the common
+        prose-only answer (the version gate and the source pin make any other marker shape unreachable). The reader takes it as
+        an empty set: no body read (a fallback read here hydrated every prose-only answer the walk met)."""
+        for name in COMPACTING:                                        # a scenario with a prose-only assistant answer before the cut
+            records, sent = G.SINGLE_FILE[name]
+            path = self.write("notu-" + name, records(), sent=sent)
+            self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+            self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+            prose = [a for t in tree["turns"] for a in t["atoms"] if a.get("type") == "assistant" and a.get("lazy") is not None and "tu" not in a["lazy"]]
+            if prose:
+                break
+        self.assertTrue(prose, "prose-only pre-cut answers in play (markers without tu)")
         whole_ids = {b.get("id") for t in self.cold(path)["turns"] for a in t["atoms"] if a.get("type") == "assistant"
                      for b in ((a.get("message") or {}).get("content") or []) if isinstance(b, dict) and b.get("type") == "tool_use"}
         self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
-        popped = 0
-        for t in tree["turns"]:
-            for a in t["atoms"]:
-                if a.get("type") == "assistant" and a.get("lazy") is not None and "tu" in a["lazy"]:
-                    a["lazy"].pop("tu"); popped += 1
-        self.assertTrue(popped, "markers without the scalar in play")
         em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
-        found = self.km._seg_of_tool_uses(tree, {"placements": {}, "nodes": {}, "seq": 0}, list(whole_ids))
-        self.assertEqual(set(found), whole_ids, "resolved from the bodies")
-        self.assertGreater(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "read, and counted")
+        found = self.km._seg_of_tool_uses(tree, {"placements": {}, "nodes": {}, "seq": 0}, list(whole_ids) + ["toolu_not_anywhere"])
+        self.assertEqual(set(found), whole_ids, "the calls resolved from the scalars; the missing id resolves to nothing")
+        self.assertEqual(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "no prose-only answer read: %s" % em.asm_checkpoint_stats()["hydratedBy"])
+
+    def test_the_comments_frame_itself_reads_no_user_text_for_an_echo_above_the_cut(self):
+        """Round two, low 1: the pin on the call site. The frame is run over the thread's restored parse with a live echo sent
+        after every recorded atom; hydratedBy carries no user-texts row (the frame's inline walk hydrated every pre-cut user
+        atom before)."""
+        km = self.km
+        path, tree = self._restored("frame")
+        newest = max(float(a.get("t") or 0) for t in tree["turns"] for a in t["atoms"] if a.get("t"))
+        echo = {"_echo_text": "a typed-ahead line", "t": newest + 5, "uuid": "echo-1"}
+        class FakeBackend:
+            def session_state(self, tsid): return "working"
+            def live_atoms(self, tsid): return [echo]
+            def pending_queued(self, tsid): return []
+            def launch_error(self, tsid): return None
+        comments = self.td / "comments.json"; comments.write_text("{}")
+        saved = {n: getattr(km, n) for n in ("_comments_path", "_load_comments_cached", "_sdk", "_thread_messages", "_thread_events",
+                                              "_thread_reg", "_thread_turn_read", "_thread_owes_first_reply", "_agent_landed_after")}
+        try:
+            km._comments_path = lambda sid: comments
+            km._load_comments_cached = lambda sid: {"threads": [{"sid": "thread-1", "status": "open", "createdT": 1}]}
+            km._sdk = lambda: FakeBackend()
+            km._thread_messages = lambda *a, **k: []
+            km._thread_events = lambda *a, **k: []
+            km._thread_reg = lambda tsid: {}
+            km._thread_turn_read = lambda *a, **k: (False, False, tree["turns"])
+            km._thread_owes_first_reply = lambda *a, **k: False
+            km._agent_landed_after = lambda *a, **k: False
+            em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+            frame = km._comments_frame(SID)
+        finally:
+            for n, v in saved.items():
+                setattr(km, n, v)
+        self.assertIsNotNone(frame, "the frame was built")
+        by = em.asm_checkpoint_stats()["hydratedBy"]
+        self.assertFalse(any(k.startswith("_atom_user_texts") for k in by), "the frame read no user text: %s" % by)
+
+    def test_the_user_texts_reader_is_attributed_with_its_caller(self):
+        """Round two, low 2: one row, _atom_user_texts, stood for both the frame's walk and the echo set's loop; the rows name
+        the caller (T377's mechanism)."""
+        km = self.km
+        path, tree = self._restored("rows")
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        km._echo_landing_atoms(tree["turns"], [{"_echo_text": "an early line", "t": 0}])
+        km._merge_sets_memo.clear(); km._merge_tx_sets(tree, SID + "-rows", 0.0)
+        by = em.asm_checkpoint_stats()["hydratedBy"]
+        self.assertIn("_atom_user_texts<-_echo_landing_atoms", by, "%s" % by)
+        self.assertIn("_atom_user_texts<-_merge_tx_sets", by, "%s" % by)
+        self.assertNotIn("_atom_user_texts", by, "no bare row: %s" % by)
+
+    def test_a_dropped_echo_below_the_cut_does_not_sink_the_landing_floor(self):
+        """Round two, low 4: the floor was the min over every live echo with a text, but the frame holds only echoes that are not
+        commands, not dropped and not landed, and a dropped one is never popped by the backend's prune; one dropped send older
+        than the compaction sank the floor and every user atom above it was read on each frame."""
+        path, tree = self._restored("dropped")
+        newest = max(float(a.get("t") or 0) for t in tree["turns"] for a in t["atoms"] if a.get("t"))
+        live = [{"_echo_text": "an old dropped line", "t": 0, "dropped": True}, {"_echo_text": "a new line", "t": newest + 5}]
+        rows = self.km._echo_landing_atoms(tree["turns"], live)
+        self.assertEqual(rows, [], "the dropped echo does not set the floor: %r" % rows)
+        self.assertEqual(em.asm_checkpoint_stats()["hydratedAtoms"], 0, "%s" % em.asm_checkpoint_stats()["hydratedBy"])
 
     def test_a_whole_read_through_the_parse_family_names_the_walker(self):
         """Review, low 1: every parse goes through parsed_session, so its whole read was one row for every walker; the counter
@@ -786,6 +848,17 @@ class ReadersOverRestoredHydrateOnlyWhatTheyNeed(Harness):
         keys = list(em.record_cache_stats()["wholeReads"])
         self.assertTrue(any(k.endswith("<-some_boot_walker") for k in keys), "the walker, not the parse family: %s" % keys)
         self.assertFalse(any(k.split("<-")[-1] in ("parsed_session", "parse_session", "parse_cached", "_parse_store") for k in keys), "%s" % keys)
+        # round two, low 3: the family is matched by code object, never by name: a local helper named like one is a walker
+        self.fresh(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        def _parse():
+            return jd.parsed_session(SID, [path], NOW)
+        def outer_walker():
+            return _parse()
+        outer_walker()
+        keys = list(em.record_cache_stats()["wholeReads"])
+        self.assertTrue(any(k.endswith("<-_parse") for k in keys), "a local helper named _parse is a walker, not the family: %s" % keys)
 
 class KernelOverRestored(Harness):
     """The kernel's and the judges' body readers over a restored tree: every consumer the audit named hydrates what it

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import shutil
+from pathlib import Path
 import tempfile
 import threading
 import time
@@ -301,7 +302,29 @@ class WholeReadsByCaller(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.dir, ignore_errors=True)
 
-    def test_a_from_zero_read_and_an_upgrade_are_named_and_an_append_is_not(self):
+    def test_a_tail_entry_upgraded_to_the_whole_file_is_named_as_an_upgrade(self):
+        """Review, low 3: a restored tail entry met by a whole reader is read whole (the reader's `upgrade`), counted as such."""
+        ck = os.path.join(self.dir, "ck"); os.makedirs(ck)
+        em.set_checkpoint_dir(lambda: Path(ck))
+        try:
+            path = os.path.join(self.dir, "leaf.jsonl"); _write_jsonl(path, 30)
+            cache = {}
+            em.fold_records(cache, path, lambda: 0, lambda st, o: st + 1, ckpt="upgradeFold")
+            self.assertTrue(em.checkpoint_write(path))
+            with em._JSONL_CACHE_LOCK:
+                em._JSONL_CACHE.clear(); em._RECORD_CACHE_STATS["wholeReads"] = {}
+            cache.clear(); em.set_checkpoint_dir(lambda: Path(ck))       # a fresh process: the fold restores over a TAIL entry
+            em.fold_records(cache, path, lambda: 0, lambda st, o: st + 1, ckpt="upgradeFold")
+            self.assertEqual(em.record_cache_stats()["wholeReads"], {}, "the restore's tail read is not a whole read")
+            def some_whole_reader():
+                return em._read_jsonl_incremental(path)
+            self.assertEqual(len(some_whole_reader()), 30)
+            wr = em.record_cache_stats()["wholeReads"]
+            self.assertEqual(list(wr), ["upgrade<-some_whole_reader"], "%s" % wr)
+        finally:
+            em.set_checkpoint_dir(None)
+
+    def test_a_from_zero_read_is_named_for_its_caller_and_an_append_is_not(self):
         path = os.path.join(self.dir, "leaf.jsonl"); _write_jsonl(path, 20)
         size = os.path.getsize(path)
         def some_boot_reader():
@@ -317,7 +340,7 @@ class WholeReadsByCaller(unittest.TestCase):
         cache = {}
         em.fold_records(cache, path, lambda: 0, lambda st, o: st + 1)   # a fold's first read: whole, named for the fold's caller
         keys = em.record_cache_stats()["wholeReads"]
-        self.assertTrue(any(k.startswith("zero<-") and k.endswith("test_a_from_zero_read_and_an_upgrade_are_named_and_an_append_is_not") for k in keys), "%s" % keys)
+        self.assertTrue(any(k.startswith("zero<-") and k.endswith("test_a_from_zero_read_is_named_for_its_caller_and_an_append_is_not") for k in keys), "%s" % keys)
 
 
 class RecordCacheDefaultBudget(unittest.TestCase):

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -15,6 +15,7 @@ through, (2) an append costs only its delta, (3) the cap still bounds the cache.
 import json
 import os
 import sys
+import shutil
 import tempfile
 import threading
 import time
@@ -285,6 +286,38 @@ class DropAfterQuiescentFold(unittest.TestCase):
         self.assertIn('"recordCache": em.record_cache_stats(),', src, "/perf carries the record cache")
         unit = open(os.path.join(BIN, "romp-service")).read()
         self.assertIn("Environment=MALLOC_ARENA_MAX=2", unit, "the service unit hands the allocator setting to the manager and its kernels")
+
+
+class WholeReadsByCaller(unittest.TestCase):
+    """T384: every read that pulls a file whole is counted on /perf by the reader's kind and the first frame outside the event
+    model, so a boot's whole reads are named the way hydratedBy named the planner. A tail entry served, an append, and a
+    restore's tail read are not whole reads."""
+
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.clear(); em._RECORD_CACHE_STATS["wholeReads"] = {}
+
+    def tearDown(self):
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def test_a_from_zero_read_and_an_upgrade_are_named_and_an_append_is_not(self):
+        path = os.path.join(self.dir, "leaf.jsonl"); _write_jsonl(path, 20)
+        size = os.path.getsize(path)
+        def some_boot_reader():
+            return em._read_jsonl_incremental(path)
+        self.assertEqual(len(some_boot_reader()), 20)
+        wr = em.record_cache_stats()["wholeReads"]
+        self.assertEqual(wr, {"zero<-some_boot_reader": {"count": 1, "bytes": size}}, "%s" % wr)
+        _write_jsonl(path, 25)                                         # an append: a tail read, not a whole one
+        self.assertEqual(len(some_boot_reader()), 25)
+        self.assertEqual(em.record_cache_stats()["wholeReads"]["zero<-some_boot_reader"]["count"], 1, "the append did not count")
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.clear()
+        cache = {}
+        em.fold_records(cache, path, lambda: 0, lambda st, o: st + 1)   # a fold's first read: whole, named for the fold's caller
+        keys = em.record_cache_stats()["wholeReads"]
+        self.assertTrue(any(k.startswith("zero<-") and k.endswith("test_a_from_zero_read_and_an_upgrade_are_named_and_an_append_is_not") for k in keys), "%s" % keys)
 
 
 class RecordCacheDefaultBudget(unittest.TestCase):

--- a/tests/test_kernel_jsonl_cache.py
+++ b/tests/test_kernel_jsonl_cache.py
@@ -324,6 +324,15 @@ class WholeReadsByCaller(unittest.TestCase):
         finally:
             em.set_checkpoint_dir(None)
 
+    def test_a_whole_read_from_inside_a_generator_expression_names_the_enclosing_function(self):
+        """A generator expression's own frame is no caller: the row names the function around it (the same exposure the
+        hydration attribution had to a comprehension's frame before Python 3.12)."""
+        path = os.path.join(self.dir, "leaf.jsonl"); _write_jsonl(path, 10)
+        def genexpr_reader():
+            return sum(len(em._read_jsonl_incremental(p)) for p in [path])
+        self.assertEqual(genexpr_reader(), 10)
+        self.assertEqual(list(em.record_cache_stats()["wholeReads"]), ["zero<-genexpr_reader"], "%s" % em.record_cache_stats()["wholeReads"])
+
     def test_a_from_zero_read_is_named_for_its_caller_and_an_append_is_not(self):
         path = os.path.join(self.dir, "leaf.jsonl"); _write_jsonl(path, 20)
         size = os.path.getsize(path)


### PR DESCRIPTION
Fix tier, two commits. After the planner stopped hydrating every pre-cut body, the first deploy boot showed the walkers after it paying for the same bodies (966 MB of hydration: the segment-prompt reader 723 MB, the tool-uses reader 155 MB, the echo landing set 78 MB), and about 0.8 GB of whole reads of restored leaves that neither the per-path bytes nor the fold counters could name.

**Commit one, the diagnostic:** every read that pulls a file whole (from zero, or a tail entry upgraded to the whole file) is counted under `recordCache.wholeReads` as `kind<-caller`, the caller being the first frame outside the event model, with count and bytes, the way `hydratedBy` named the planner. A tail read, an append and a restore's tail are not whole reads. Always on; the frame walk runs only on the rare whole read.

**Commit two, the readers:** `_seg_prompt` finds its trigger by uuid and type, scalars every lazy atom carries, and hydrates that one atom instead of the whole segment; `_seg_of_tool_uses` reads the tool-use ids from the lazy markers' scalars (`em.atom_tool_uses`) instead of hydrating every turn newest-first; the echo landing set's caller hands an infinite floor when no live echo exists, so no user text is read where none can land.

**Tests** (red first on main): per-reader bytes over a restored tree (`tests/test_asm_checkpoint.py`): the prompt reader hydrates at most one atom per pre-cut segment and answers the whole parse's prompts; the tool-uses reader resolves every id with zero atoms hydrated; the echo set reads nothing under an infinite floor; the whole-read counter names a from-zero read for its caller, skips an append, and names a fold's first whole read (`tests/test_kernel_jsonl_cache.py`). The sixteen modules pinning the readers or their callers, the planner's identity pins among them: 898 passed. Full Python suite green locally (12,456 passed).

**Measurement on the next deploy boot:** `asmCheckpoint.hydratedBytes` and `hydratedBy` (from 966 MB), `recordCache.wholeReads` by caller (the 0.8 GB residual), `firstCycleS` (26.1 s), leaf reads (2.50 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)