### PR TITLE
The image lightbox's controls sit at the top, in the file viewer's bar (T385)

### DIFF
--- a/tests/test_lightbox_bar_browser.py
+++ b/tests/test_lightbox_bar_browser.py
@@ -73,7 +73,7 @@ const ctx = await browser.newContext({ viewport: { width: 1100, height: 640 } })
 const page = await ctx.newPage();
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
-await page.waitForFunction(() => { const i = document.querySelector(".path-full-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 30000 });
+await page.waitForFunction(() => { const is = Array.from(document.querySelectorAll(".path-full-img")); return is.length >= 2 && is.every((i) => i.complete && i.naturalWidth > 0); }, null, { timeout: 30000 });
 await page.waitForTimeout(200);
 const r1 = (v) => Math.round(v * 10) / 10;
 const rectOf = "(e) => { const b = e.getBoundingClientRect(); const r = (v) => Math.round(v * 10) / 10; return { top: r(b.top), bottom: r(b.bottom), left: r(b.left), right: r(b.right), w: r(b.width), h: r(b.height) }; }";
@@ -86,12 +86,12 @@ const viewer = await page.evaluate((src) => {
   const dress = eval(src);
   const bar = document.querySelector("#romp-fileview .fileview-bar");
   const btn = (aria) => Array.from(bar.querySelectorAll("button, a")).find((e) => e.getAttribute("aria-label") === aria);
-  return { download: dress(btn("Download")), close: dress(btn("Close the file viewer")), barPadding: getComputedStyle(bar).padding };
+  return { download: dress(btn("Download")), close: dress(btn("Close the file viewer")), barPadding: getComputedStyle(bar).padding, nameMinWidth: getComputedStyle(bar.querySelector(".fileview-name")).minWidth };
 }, dressOf);
 await page.evaluate(() => document.getElementById("romp-fileview")?.remove());
 await page.waitForTimeout(100);
 // the lightbox: a click on the inline figure
-await page.click(".path-full-img");
+await page.click(".path-full-img >> nth=0");
 await page.waitForSelector("#romp-lightbox .romp-lightbox-bar", { timeout: 15000 });
 await page.waitForFunction(() => { const i = document.querySelector("#romp-lightbox .romp-lightbox-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 15000 });
 await page.waitForTimeout(150);
@@ -108,6 +108,8 @@ const measure = (label) => page.evaluate(([label, rectSrc, dressSrc]) => {
   const base = bar.querySelector(".fileview-base"), dir = bar.querySelector(".fileview-dir");
   return { label, order: Array.from(inner.children).map((c) => c.className), bar: rect(bar), img: rect(img), inner: rect(inner),
     barClasses: bar.className, barBorderBottom: getComputedStyle(bar).borderBottomColor, barPadding: getComputedStyle(bar).padding,
+    nameMinWidth: (bar.querySelector(".fileview-name") ? getComputedStyle(bar.querySelector(".fileview-name")).minWidth : ""), barContain: getComputedStyle(bar).contain,
+    baseOverflow: base ? getComputedStyle(base).overflow : "", imgNatural: img.naturalWidth,
     title: { dir: dir && dir.textContent, base: base && base.textContent, full: (bar.querySelector(".fileview-name") || bar.querySelector(".romp-lightbox-name") || {}).title || "", baseColor: base && getComputedStyle(base).color, dirColor: dir && getComputedStyle(dir).color },
     controls, actsChildren: acts ? Array.from(acts.children).map((c) => c.className) : [], bodyLight: document.body.classList.contains("theme-light") };
 }, [label, rectOf, dressOf]);
@@ -126,6 +128,17 @@ await page.evaluate(() => document.body.classList.remove("theme-light")); await 
 await page.keyboard.press("Escape");
 await page.waitForTimeout(120);
 out.afterEscape = await page.evaluate(() => ({ gone: !document.getElementById("romp-lightbox") }));
+// the NARROW picture: 120px wide, narrower than the bar's three controls; the picture sets the column and the bar wraps inside it
+await page.click(".path-full-img >> nth=1");
+await page.waitForSelector("#romp-lightbox .romp-lightbox-bar", { timeout: 15000 });
+await page.waitForFunction(() => { const i = document.querySelector("#romp-lightbox .romp-lightbox-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 15000 });
+await page.waitForTimeout(150);
+out.narrow = await measure("narrow");
+if (cfg.shots) {
+  const clip = await page.evaluate(() => { const b = document.querySelector("#romp-lightbox .romp-lightbox-inner").getBoundingClientRect(); return { x: Math.max(0, b.left - 24), y: Math.max(0, b.top - 24), width: Math.min(window.innerWidth, b.width + 48), height: Math.min(window.innerHeight, b.height + 48) }; });
+  await page.screenshot({ path: cfg.shots + "-narrow-dark.png", clip });
+}
+await page.keyboard.press("Escape");
 fs.writeFileSync(cfg.out, JSON.stringify(out));
 await browser.close();
 console.log("RESULT: ok");
@@ -172,6 +185,7 @@ class ServedLightboxBar(unittest.TestCase):
         os.makedirs(os.path.join(cwd, "docs"), exist_ok=True)
         cls.figure = os.path.join(cwd, "docs", "figure.png")
         Path(cls.figure).write_bytes(_png())
+        Path(cwd, "docs", "narrow.png").write_bytes(_png(120, 80, (4, 120, 178)))   # narrower than the bar's controls: the picture must still set the column
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         t0 = int(time.time()) - 900
@@ -183,7 +197,7 @@ class ServedLightboxBar(unittest.TestCase):
                  "message": {"role": "user", "content": "where is the figure for the notes-api guide?"}},
                 {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
                  "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
-                             "content": [{"type": "text", "text": "The guide's figure is at docs/figure.png."}]}}]
+                             "content": [{"type": "text", "text": "The guide's figure is at docs/figure.png and its thumbnail at docs/narrow.png."}]}}]
         Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         cls.port, cls.token = _free_port(), "testtok-lightbox"
@@ -293,6 +307,28 @@ class ServedLightboxBar(unittest.TestCase):
         self.assertEqual(l["barBorderBottom"], "rgba(255, 255, 255, 0.18)", "the hairline beneath the bar is the lightbox's light seam in both themes")
         self.assertEqual(d["barBorderBottom"], l["barBorderBottom"])
         self.assertEqual(l["bar"], d["bar"], "the theme moves no geometry")
+
+    def test_the_bars_own_placement_rules_win_the_cascade_on_the_served_page(self):
+        """Round one: the two rules tied with the viewer's later rules and lost (7px 10px, 12em on the served bar). Measured, not read."""
+        r = self._run()
+        m = r["dark"]
+        self.assertEqual(m["barPadding"], "0px 2px 6px", "the lightbox bar's own padding (the viewer's is %s)" % r["viewer"]["barPadding"])
+        self.assertEqual(r["viewer"]["barPadding"], "7px 10px", "…and the viewer keeps its own")
+        self.assertEqual(m["nameMinWidth"], "0px", "the title's 12em floor is lifted in the lightbox (the viewer's: %s)" % r["viewer"]["nameMinWidth"])
+        self.assertNotEqual(r["viewer"]["nameMinWidth"], "0px", "the viewer keeps its floor")
+        self.assertEqual(m["barContain"], "inline-size", "the bar contributes no intrinsic width: the picture sets the column")
+        self.assertEqual(m["baseOverflow"], "hidden", "the basename truncates under a narrow picture")
+
+    def test_a_narrow_picture_sets_the_column_width_and_the_bar_wraps_inside_it(self):
+        m = self._run()["narrow"]
+        self.assertEqual(m["imgNatural"], 120)
+        self.assertAlmostEqual(m["img"]["w"], 120, delta=0.5, msg="the narrow picture at its own size")
+        self.assertAlmostEqual(m["inner"]["w"], m["img"]["w"], delta=1, msg="the column is the picture's width, not the bar's: " + json.dumps({"inner": m["inner"], "img": m["img"], "bar": m["bar"]}))
+        self.assertAlmostEqual(m["bar"]["w"], m["inner"]["w"], delta=1, msg="the bar fills the column and no more")
+        self.assertLessEqual(m["bar"]["bottom"], m["img"]["top"], "the bar still sits above the picture")
+        for c in m["controls"]:
+            self.assertGreaterEqual(c["rect"]["left"], m["inner"]["left"] - 0.5, "every control stays inside the column: " + json.dumps(c["rect"]))
+            self.assertLessEqual(c["rect"]["right"], m["inner"]["right"] + 0.5, "every control stays inside the column: " + json.dumps(c["rect"]))
 
     def test_escape_closes_the_lightbox(self):
         self.assertTrue(self._run()["afterEscape"]["gone"])

--- a/tests/test_lightbox_bar_browser.py
+++ b/tests/test_lightbox_bar_browser.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""The image lightbox's bar at the TOP, in the file viewer's dress (T385, the user 2026-09-12: after opening an image the
+controls should sit above it, consistent with how a file opens). A hermetic kernel serves a synthetic notes-api session
+(TESTHOST, a placeholder sid) whose chat mentions docs/figure.png; the page renders the figure inline, the driver clicks
+it and reads the lightbox: the bar's rect above the picture's, its controls (download, copy, close) with their words and
+glyphs, the computed dress of its buttons against the file viewer's own buttons for the same file, the bar's tokens under
+the light theme (the backdrop is dark in both), and Escape.
+
+LB_DIST=<dir> serves another tree's UI bundle (the red run's before); LB_SHOTS=<prefix> writes <prefix>-dark.png and
+<prefix>-light.png of the open lightbox; LB_DUMP=<path> writes the whole measurement. Skips LOUDLY without the extension
+deps or a Playwright browser (CI sets ROMP_SERVED_TESTS_REQUIRE=1 and installs both, so a skip there is a failure).
+Synthetic throughout: an invented guide, a run-time PNG, no recorded data.
+"""
+import json
+import os
+import re
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.request
+import zlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tests.dist_copy import copy_dist
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.dirname(HERE)
+BIN = os.path.join(ROOT, "bin")
+EXT = os.path.join(ROOT, "vscode-extension")
+sys.path.insert(0, HERE)
+import test_ship_reship as _lab   # noqa: E402  the lab kernel's environment: a list of names, never a copy of the runner's
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _png(w=320, h=200, rgb=(84, 178, 4)):
+    """An opaque PNG, assembled at run time (no binary fixture in the repo); wide enough that the bar fits inside it."""
+    raw = b"".join(b"\x00" + bytes(rgb) * w for _ in range(h))
+    def chunk(tag, data):
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xffffffff)
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw)) + chunk(b"IEND", b""))
+
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const ctx = await browser.newContext({ viewport: { width: 1100, height: 640 } });
+const page = await ctx.newPage();
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForFunction(() => { const i = document.querySelector(".path-full-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 30000 });
+await page.waitForTimeout(200);
+const r1 = (v) => Math.round(v * 10) / 10;
+const rectOf = "(e) => { const b = e.getBoundingClientRect(); const r = (v) => Math.round(v * 10) / 10; return { top: r(b.top), bottom: r(b.bottom), left: r(b.left), right: r(b.right), w: r(b.width), h: r(b.height) }; }";
+const dressOf = "(e) => { const s = getComputedStyle(e); return { fontSize: s.fontSize, padding: s.padding, radius: s.borderRadius, borderWidth: s.borderTopWidth, display: s.display, height: Math.round(e.getBoundingClientRect().height * 10) / 10 }; }";
+// the file viewer's own buttons for the same image: the dress the lightbox's must equal
+await page.evaluate(([path, sid]) => { window.postMessage({ romp: "viewFile", path, sid }, "*"); }, [cfg.figure, cfg.sid]);
+await page.waitForSelector("#romp-fileview .fileview-bar", { timeout: 15000 });
+await page.waitForTimeout(200);
+const viewer = await page.evaluate((src) => {
+  const dress = eval(src);
+  const bar = document.querySelector("#romp-fileview .fileview-bar");
+  const btn = (aria) => Array.from(bar.querySelectorAll("button, a")).find((e) => e.getAttribute("aria-label") === aria);
+  return { download: dress(btn("Download")), close: dress(btn("Close the file viewer")), barPadding: getComputedStyle(bar).padding };
+}, dressOf);
+await page.evaluate(() => document.getElementById("romp-fileview")?.remove());
+await page.waitForTimeout(100);
+// the lightbox: a click on the inline figure
+await page.click(".path-full-img");
+await page.waitForSelector("#romp-lightbox .romp-lightbox-bar", { timeout: 15000 });
+await page.waitForFunction(() => { const i = document.querySelector("#romp-lightbox .romp-lightbox-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 15000 });
+await page.waitForTimeout(150);
+const measure = (label) => page.evaluate(([label, rectSrc, dressSrc]) => {
+  const rect = eval(rectSrc), dress = eval(dressSrc);
+  const wrap = document.getElementById("romp-lightbox");
+  const inner = wrap.querySelector(".romp-lightbox-inner");
+  const bar = inner.querySelector(".romp-lightbox-bar");
+  const img = inner.querySelector(".romp-lightbox-img");
+  const acts = bar.querySelector(".fileview-acts");   // absent on the bar before T385: the controls are then read off the bar itself
+  const controls = Array.from((acts || bar).querySelectorAll("button, a")).map((e) => ({
+    tag: e.tagName.toLowerCase(), aria: e.getAttribute("aria-label") || "", title: e.title || "", text: (e.textContent || "").trim(), cls: e.className,
+    svg: !!e.querySelector("svg"), group: e.closest(".fileview-group") ? e.closest(".fileview-group").className : "row", rect: rect(e), dress: dress(e), download: e.getAttribute("download") || "" }));
+  const base = bar.querySelector(".fileview-base"), dir = bar.querySelector(".fileview-dir");
+  return { label, order: Array.from(inner.children).map((c) => c.className), bar: rect(bar), img: rect(img), inner: rect(inner),
+    barClasses: bar.className, barBorderBottom: getComputedStyle(bar).borderBottomColor, barPadding: getComputedStyle(bar).padding,
+    title: { dir: dir && dir.textContent, base: base && base.textContent, full: (bar.querySelector(".fileview-name") || bar.querySelector(".romp-lightbox-name") || {}).title || "", baseColor: base && getComputedStyle(base).color, dirColor: dir && getComputedStyle(dir).color },
+    controls, actsChildren: acts ? Array.from(acts.children).map((c) => c.className) : [], bodyLight: document.body.classList.contains("theme-light") };
+}, [label, rectOf, dressOf]);
+const out = { viewer, dark: await measure("dark") };
+if (cfg.shots) {
+  const clip = await page.evaluate(() => { const b = document.querySelector("#romp-lightbox .romp-lightbox-inner").getBoundingClientRect(); return { x: Math.max(0, b.left - 24), y: Math.max(0, b.top - 24), width: Math.min(window.innerWidth, b.width + 48), height: Math.min(window.innerHeight, b.height + 48) }; });
+  await page.screenshot({ path: cfg.shots + "-dark.png", clip });
+}
+await page.evaluate(() => document.body.classList.add("theme-light")); await page.waitForTimeout(150);
+out.light = await measure("light");
+if (cfg.shots) {
+  const clip = await page.evaluate(() => { const b = document.querySelector("#romp-lightbox .romp-lightbox-inner").getBoundingClientRect(); return { x: Math.max(0, b.left - 24), y: Math.max(0, b.top - 24), width: Math.min(window.innerWidth, b.width + 48), height: Math.min(window.innerHeight, b.height + 48) }; });
+  await page.screenshot({ path: cfg.shots + "-light.png", clip });
+}
+await page.evaluate(() => document.body.classList.remove("theme-light")); await page.waitForTimeout(60);
+await page.keyboard.press("Escape");
+await page.waitForTimeout(120);
+out.afterEscape = await page.evaluate(() => ({ gone: !document.getElementById("romp-lightbox") }));
+fs.writeFileSync(cfg.out, JSON.stringify(out));
+await browser.close();
+console.log("RESULT: ok");
+"""
+
+
+class ServedLightboxBar(unittest.TestCase):
+    maxDiff = None
+    result = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls._boot()
+        except BaseException:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def _boot(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        probe = subprocess.run(["node", "-e", "const p=require(process.argv[1]);process.stdout.write(p.chromium.executablePath())",
+                                os.path.join(EXT, "node_modules", "playwright")], capture_output=True, text=True)
+        if probe.returncode != 0 or not os.path.exists(probe.stdout.strip()):
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        cls.lab = tempfile.mkdtemp(prefix="lightbox-bar-")
+        before = os.environ.get("LB_DIST", "")
+        if before:
+            src = before
+        else:
+            b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+            if b.returncode != 0:
+                raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+            src = os.path.join(EXT, "dist")
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(src, dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        claude = os.path.join(cls.lab, "claude")
+        cwd = os.path.join(cls.lab, "notes-api")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        Path(state, "session-hosts").write_text("off\n")   # a lab root writes its own session-hosts off (the conftest rule)
+        os.makedirs(os.path.join(cwd, "docs"), exist_ok=True)
+        cls.figure = os.path.join(cwd, "docs", "figure.png")
+        Path(cls.figure).write_bytes(_png())
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        Path(state, "names", SID).write_text("web\t%s\t#9cd2ff\t#0c1a2e\n" % cwd)
+        Path(state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high", "lastSid": SID, "alive": True,
+             "model": "claude-opus-5", "liveModel": "Opus 5"}))
+        recs = [{"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "typed", "sessionId": SID,
+                 "message": {"role": "user", "content": "where is the figure for the notes-api guide?"}},
+                {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+                 "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
+                             "content": [{"type": "text", "text": "The guide's figure is at docs/figure.png."}]}}]
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        cls.port, cls.token = _free_port(), "testtok-lightbox"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token, ROMP_HOST_NAME="TESTHOST")
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        k = getattr(cls, "kernel", None)
+        if k:
+            k.kill(); k.wait()
+        shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
+
+    @classmethod
+    def _run(cls):
+        if cls.result is not None:
+            if isinstance(cls.result, BaseException):
+                raise cls.result
+            return cls.result
+        try:
+            cls.result = cls._drive()
+        except BaseException as e:
+            cls.result = e
+            raise
+        return cls.result
+
+    @classmethod
+    def _drive(cls):
+        cfg = os.path.join(cls.lab, "cfg.json")
+        out = os.path.join(cls.lab, "result.json")
+        origin = "http://127.0.0.1:%d" % cls.port
+        with open(cfg, "w") as f:
+            json.dump({"chat": "%s/chat?token=%s" % (origin, cls.token), "origin": origin, "sid": SID, "figure": cls.figure,
+                       "out": out, "shots": os.environ.get("LB_SHOTS", "")}, f)
+        driver = os.path.join(cls.lab, "driver.mjs")
+        with open(driver, "w") as f:
+            f.write(DRIVER)
+        p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                           env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+        if p.returncode == 3:
+            raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+        if p.returncode != 0:
+            raise AssertionError("driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(cls.klog).read()[-1500:])
+        if not os.path.exists(out):
+            raise AssertionError("driver printed no result:\n" + p.stdout[-3000:])
+        result = json.loads(Path(out).read_text())
+        if os.environ.get("LB_DUMP"):   # a path: the whole measurement, for reading the cases side by side
+            Path(os.environ["LB_DUMP"]).write_text(json.dumps(result, indent=1) + "\n")
+        return result
+
+    @staticmethod
+    def _ctl(m, aria):
+        return next((c for c in m["controls"] if c["aria"] == aria), None)
+
+    def test_the_bar_precedes_the_picture_and_spans_its_column(self):
+        m = self._run()["dark"]
+        self.assertEqual([c.split()[-1] if "romp-lightbox-bar" in c else c for c in m["order"]], ["romp-lightbox-bar", "romp-lightbox-img"],
+                         "the column's children: the bar, then the picture: " + json.dumps(m["order"]))
+        self.assertLessEqual(m["bar"]["bottom"], m["img"]["top"], "the bar sits ABOVE the picture, not over it: " + json.dumps({"bar": m["bar"], "img": m["img"]}))
+        self.assertAlmostEqual(m["bar"]["left"], m["inner"]["left"], delta=1, msg="the bar starts at the column's left edge")
+        self.assertAlmostEqual(m["bar"]["right"], m["inner"]["right"], delta=1, msg="…and ends at its right edge")
+        self.assertGreaterEqual(m["img"]["left"], m["inner"]["left"] - 0.5)
+        self.assertLessEqual(m["img"]["right"], m["inner"]["right"] + 0.5)
+
+    def test_the_bar_is_the_file_viewers_with_download_copy_grouped_and_the_close_alone_at_the_end(self):
+        m = self._run()["dark"]
+        self.assertEqual(sorted(m["barClasses"].split()), ["fileview-bar", "romp-lightbox-bar"])
+        self.assertEqual(m["title"]["base"], "figure.png", "the basename identifies the picture")
+        self.assertEqual(m["title"]["dir"], "docs/", "the directory half, dimmed: the path as the chat mentioned it (relative to the session's cwd)")
+        self.assertEqual(m["title"]["full"], "docs/figure.png", "the whole path one hover away")
+        self.assertEqual([c["aria"] for c in m["controls"]], ["Download", "Copy image", "Close the picture"], json.dumps(m["controls"])[:400])
+        dl, cp, close = (self._ctl(m, a) for a in ("Download", "Copy image", "Close the picture"))
+        self.assertEqual((dl["tag"], dl["svg"], dl["download"]), ("a", True, "figure.png"), "download is an anchor wearing the tray glyph, saving under the basename")
+        self.assertEqual((cp["tag"], cp["svg"]), ("button", True), "copy wears the two-sheets glyph")
+        self.assertEqual(close["text"], "✕")
+        self.assertEqual(dl["group"], cp["group"], "download and copy share the file group")
+        self.assertIn("fileview-group-file", dl["group"])
+        self.assertEqual(close["group"], "row", "the close stands alone outside the group")
+        self.assertEqual([c.split()[0] for c in m["actsChildren"]], ["fileview-group", "fileview-btn"], "the actions: one group, then the close")
+        self.assertLess(cp["rect"]["right"], close["rect"]["left"], "the close is the right-most control")
+        self.assertLess(dl["rect"]["right"], cp["rect"]["left"])
+
+    def test_the_lightboxs_buttons_wear_the_file_viewers_computed_dress(self):
+        r = self._run()
+        m = r["dark"]
+        for aria, key in (("Download", "download"), ("Close the picture", "close")):
+            mine = dict(self._ctl(m, aria)["dress"])
+            theirs = dict(r["viewer"][key])
+            self.assertEqual(mine, theirs, "the %s control's computed dress equals the file viewer's %s: one set of rules" % (aria, key))
+
+    def test_the_bars_tokens_stay_the_dark_themes_under_the_light_theme(self):
+        r = self._run()
+        d, l = r["dark"], r["light"]
+        self.assertTrue(l["bodyLight"], "the light theme was applied for the second measurement")
+        self.assertEqual(l["title"]["baseColor"], "rgb(232, 232, 232)", "the basename keeps the dark theme's prose tone on the dark backdrop")
+        self.assertEqual(l["title"]["baseColor"], d["title"]["baseColor"])
+        self.assertEqual(l["title"]["dirColor"], d["title"]["dirColor"])
+        self.assertEqual(l["barBorderBottom"], "rgba(255, 255, 255, 0.18)", "the hairline beneath the bar is the lightbox's light seam in both themes")
+        self.assertEqual(d["barBorderBottom"], l["barBorderBottom"])
+        self.assertEqual(l["bar"], d["bar"], "the theme moves no geometry")
+
+    def test_escape_closes_the_lightbox(self):
+        self.assertTrue(self._run()["afterEscape"]["gone"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/lightbox-bar.test.ts
+++ b/ui/webview/lightbox-bar.test.ts
@@ -39,6 +39,17 @@ function mkEl(tag: string): El {
   return e;
 }
 function classes(e: El): string[] { return e.className.split(/\s+/).filter(Boolean); }
+// selector specificity (ids, classes + attributes + pseudo-classes, elements) and the cascade's tiebreak between two rules:
+// a strictly higher specificity wins whatever the order; a tie goes to the later rule, which is the trap
+function spec(sel: string): [number, number, number] {
+  const ids = (sel.match(/#[\w-]+/g) || []).length;
+  const cls = (sel.match(/\.[\w-]+|\[[^\]]+\]|:(?!:)[\w-]+(\([^)]*\))?/g) || []).length;
+  const els = (sel.replace(/#[\w-]+|\.[\w-]+|\[[^\]]+\]|::?[\w-]+(\([^)]*\))?/g, " ").match(/(^|\s)[a-zA-Z][\w-]*/g) || []).length;
+  return [ids, cls, els];
+}
+function wins(a: [number, number, number], b: [number, number, number]): boolean {
+  return a[0] !== b[0] ? a[0] > b[0] : a[1] !== b[1] ? a[1] > b[1] : a[2] > b[2];
+}
 
 type Nav = Array<{ path: string; sid?: string | null; pin?: string }>;
 function lift(kind: "img" | "pdf", nav: Nav = [], clipboard = false): { body: El; open: (p: string, sid?: string | null, pin?: string) => void; keys: Array<(ev: { key: string; stopPropagation: () => void; preventDefault: () => void }) => void> } {
@@ -58,7 +69,7 @@ function lift(kind: "img" | "pdf", nav: Nav = [], clipboard = false): { body: El
     const ICON_DOWNLOAD = '<svg data-icon="download"/>', ICON_COPY = '<svg data-icon="copy"/>', ICON_CHECK = '<svg data-icon="check"/>', ICON_CROSS = '<svg data-icon="cross"/>';
     const navigator = H.clipboard ? { clipboard: { write: () => Promise.resolve() } } : {};
     const ClipboardItem = H.clipboard ? function ClipboardItem() {} : undefined;
-    const window = { setTimeout: () => 0 };
+    const window = { setTimeout: () => 1, clearTimeout: () => {} };
   `;
   const open = (new Function("H", "document", prelude + code + "\nreturn openLightbox;") as (h: unknown, d: unknown) => (p: string, sid?: string | null, pin?: string) => void)(H, document);
   return { body, open, keys };
@@ -151,8 +162,19 @@ test("styles: the lightbox's own chip rules are gone, the shared bar rules stand
   assert.doesNotMatch(CSS, /\.romp-lightbox-close \{/, "the close wears .fileview-btn.fileview-close now");
   assert.doesNotMatch(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{/, "download and copy wear .fileview-btn.fileview-icon now");
   assert.doesNotMatch(CSS, /\.romp-lightbox-name \{/, "the title wears .fileview-name (directory + basename) now");
-  assert.match(CSS, /\.romp-lightbox-bar \{ padding: 0 2px 6px; \}/, "the bar's own placement over the backdrop: no side padding, the picture's edges are the column's");
-  assert.match(CSS, /\.romp-lightbox-bar \.fileview-name \{ min-width: 0; \}/, "the title never forces the column wider than the picture; the directory truncates");
+  // the bar's own placement rules must WIN the cascade over the viewer's (round one: two rules of equal specificity
+  // sat 420 lines before .fileview-bar's and lost, so the served bar measured 7px 10px and the title 12em): the
+  // tiebreak is pinned by computed specificity, never by the rule's text alone
+  const rule = (re: RegExp, what: string): string => { const m = CSS.match(re); assert.ok(m, what + ": rule not found"); return m![1].trim(); };
+  const lbBar = rule(/^([^{}\n]*romp-lightbox-bar[^{}\n]*)\{[^}]*padding: 0 2px 6px;/m, "the lightbox bar's padding rule");
+  const vwBar = rule(/^([^{}\n]*\.fileview-bar)\s*\{[^}]*padding: 7px 10px;/m, "the viewer bar's padding rule");
+  assert.ok(wins(spec(lbBar), spec(vwBar)), "the bar's padding rule outranks the viewer's: " + lbBar + " vs " + vwBar);
+  const lbName = rule(/^([^{}\n]*romp-lightbox-bar \.fileview-name[^{}\n]*)\{[^}]*min-width: 0;/m, "the lightbox title's min-width rule");
+  const vwName = rule(/^([^{}\n]*\.fileview-bar \.fileview-name)\s*\{[^}]*min-width: 12em;/m, "the viewer title's min-width rule");
+  assert.ok(wins(spec(lbName), spec(vwName)), "the title's floor is lifted by a rule that outranks the viewer's: " + lbName + " vs " + vwName);
+  assert.match(CSS, /^#romp-lightbox \.romp-lightbox-bar \{ padding: 0 2px 6px; contain: inline-size; \}/m, "the bar contributes no intrinsic width: the PICTURE sets the column");
+  assert.match(CSS, /^#romp-lightbox \.romp-lightbox-bar \.fileview-name \{ min-width: 0; overflow: hidden; \}/m);
+  assert.match(CSS, /^#romp-lightbox \.romp-lightbox-bar \.fileview-base \{ flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; \}/m, "under a narrow picture the basename truncates too (the viewer's card owns its width; the lightbox's column is the picture's)");
   assert.match(CSS, /\.romp-lightbox-img \{ [^}]*align-self: center;/, "a bar wider than a small picture never stretches it");
   assert.match(CSS, /#romp-lightbox \{ --fg: #e8e8e8; --dim: #b8b8b8; --accent: #9cd2ff; --accent-fg: #0c1a2e; --accent-wash: rgba\(156, 210, 255, 0\.12\);\s*\n\s*--err: #f48771; --card-border: rgba\(255, 255, 255, 0\.18\); --box-border: rgba\(255, 255, 255, 0\.18\); \}/);
   assert.match(CSS, /\.romp-lightbox-cue \{ flex: 0 0 auto; font-size: 0\.82em; color: var\(--dim\); font-variant-numeric: tabular-nums; \}/, "the cue keeps the house sub scale");

--- a/ui/webview/lightbox-bar.test.ts
+++ b/ui/webview/lightbox-bar.test.ts
@@ -1,0 +1,163 @@
+// The lightbox's controls sit at the TOP, in the file viewer's bar (T385, the user 2026-09-12: after opening an image the
+// controls should sit above it, consistent with how a file opens). preview.ts has import-time DOM side effects, so
+// openLightbox is LIFTED (esbuild's ts loader, the browse-route precedent) and run on a tiny DOM: the order of the
+// column's children is read, never inferred from source order.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(__filename);
+const PREVIEW = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "preview.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const ts = (code: string): string => requireCjs("esbuild").transformSync(code, { loader: "ts" }).code;
+
+type El = {
+  tag: string; className: string; id: string; children: El[]; parent: El | null; textContent: string; innerHTML: string;
+  title: string; attrs: Record<string, string>; dataset: Record<string, string>; type: string; href: string; download: string; src: string; alt: string;
+  classList: { add: (...c: string[]) => void; remove: (...c: string[]) => void; contains: (c: string) => boolean };
+  appendChild: (c: El) => El; append: (...c: El[]) => void; prepend: (...c: El[]) => void; replaceWith: (n: El) => void; remove: () => void;
+  setAttribute: (k: string, v: string) => void; getAttribute: (k: string) => string | null; addEventListener: () => void; querySelector: () => null;
+};
+function mkEl(tag: string): El {
+  const e: El = {
+    tag, className: "", id: "", children: [], parent: null, textContent: "", innerHTML: "", title: "", attrs: {}, dataset: {}, type: "", href: "", download: "", src: "", alt: "",
+    classList: {
+      add: (...c) => { const s = new Set(e.className.split(/\s+/).filter(Boolean)); c.forEach((x) => s.add(x)); e.className = [...s].join(" "); },
+      remove: (...c) => { e.className = e.className.split(/\s+/).filter((x) => x && !c.includes(x)).join(" "); },
+      contains: (c) => e.className.split(/\s+/).includes(c),
+    },
+    appendChild: (c) => { e.children.push(c); c.parent = e; return c; },
+    append: (...cs) => { cs.forEach((c) => e.appendChild(c)); },
+    prepend: (...cs) => { cs.forEach((c) => { c.parent = e; }); e.children.unshift(...cs); },
+    replaceWith: (n) => { const p = e.parent!; p.children[p.children.indexOf(e)] = n; n.parent = p; },
+    remove: () => { const p = e.parent; if (p) p.children.splice(p.children.indexOf(e), 1); },
+    setAttribute: (k, v) => { e.attrs[k] = v; }, getAttribute: (k) => (k in e.attrs ? e.attrs[k] : null),
+    addEventListener: () => {}, querySelector: () => null,
+  };
+  return e;
+}
+function classes(e: El): string[] { return e.className.split(/\s+/).filter(Boolean); }
+
+type Nav = Array<{ path: string; sid?: string | null; pin?: string }>;
+function lift(kind: "img" | "pdf", nav: Nav = [], clipboard = false): { body: El; open: (p: string, sid?: string | null, pin?: string) => void; keys: Array<(ev: { key: string; stopPropagation: () => void; preventDefault: () => void }) => void> } {
+  const a = PREVIEW.indexOf("export function openLightbox(path: string, sid?: string | null, pin?: string): void {");
+  const b = PREVIEW.indexOf("\n}\n", a);
+  assert.ok(a > 0 && b > a, "openLightbox: anchors not found; re-anchor");
+  const code = ts(PREVIEW.slice(a, b + 2).replace(/^export /, ""));
+  const body = mkEl("body");
+  const keys: Array<(ev: { key: string; stopPropagation: () => void; preventDefault: () => void }) => void> = [];
+  const document = { createElement: mkEl, getElementById: () => null, body, addEventListener: (_t: string, fn: (ev: unknown) => void) => { keys.push(fn as never); }, removeEventListener: () => {} };
+  const H = { kind, nav, clipboard };
+  const prelude = `
+    const previewKind = (p) => H.kind;
+    const fileUrl = (p, sid) => "/file?path=" + encodeURIComponent(p) + "&sid=" + (sid || "");
+    const wirePinchZoom = (stage, img) => ({ retarget: () => {} });
+    const lightboxNav = H.nav.length ? (() => H.nav) : null;
+    const ICON_DOWNLOAD = '<svg data-icon="download"/>', ICON_COPY = '<svg data-icon="copy"/>', ICON_CHECK = '<svg data-icon="check"/>', ICON_CROSS = '<svg data-icon="cross"/>';
+    const navigator = H.clipboard ? { clipboard: { write: () => Promise.resolve() } } : {};
+    const ClipboardItem = H.clipboard ? function ClipboardItem() {} : undefined;
+    const window = { setTimeout: () => 0 };
+  `;
+  const open = (new Function("H", "document", prelude + code + "\nreturn openLightbox;") as (h: unknown, d: unknown) => (p: string, sid?: string | null, pin?: string) => void)(H, document);
+  return { body, open, keys };
+}
+function column(body: El): El {
+  const wrap = body.children[0];
+  assert.equal(wrap.id, "romp-lightbox");
+  const inner = wrap.children[0];
+  assert.ok(classes(inner).includes("romp-lightbox-inner"));
+  return inner;
+}
+
+test("the bar PRECEDES the picture in the column: controls at the top, the way a file opens", () => {
+  const { body, open } = lift("img");
+  open("plots/run1.png", "s1");
+  const inner = column(body);
+  assert.equal(inner.children.length, 2, "the column holds the bar and the picture");
+  assert.ok(classes(inner.children[0]).includes("romp-lightbox-bar"), "first child is the bar, got: " + inner.children[0].className);
+  assert.ok(classes(inner.children[1]).includes("romp-lightbox-img"), "the picture follows it");
+});
+
+test("the pdf kind puts the same bar above its frame", () => {
+  const { body, open } = lift("pdf");
+  open("notes/spec.pdf", "s1");
+  const inner = column(body);
+  assert.ok(classes(inner).includes("pdf"));
+  assert.ok(classes(inner.children[0]).includes("romp-lightbox-bar"), "first child is the bar");
+  assert.ok(classes(inner.children[1]).includes("romp-lightbox-frame"), "the frame follows it");
+});
+
+test("the bar wears the file viewer's vocabulary: its row class, a dimmed-directory + basename title, the actions grouped, the close cross alone at the end", () => {
+  const { body, open } = lift("img", [], true);
+  open("plots/run1.png", "s1");
+  const bar = column(body).children[0];
+  assert.deepEqual(classes(bar).sort(), ["fileview-bar", "romp-lightbox-bar"], "the row IS the viewer's bar, the lightbox class a hook for placement and the stage's tap rule");
+  const [name, acts] = bar.children;
+  assert.equal(bar.children.length, 2, "name then actions (no cue for a single picture)");
+  assert.ok(classes(name).includes("fileview-name"));
+  assert.deepEqual(name.children.map((c) => c.className), ["fileview-dir", "fileview-base"]);
+  assert.deepEqual([name.children[0].textContent, name.children[1].textContent], ["plots/", "run1.png"], "only the directory may truncate; the basename identifies the picture");
+  assert.equal(name.title, "plots/run1.png");
+  assert.ok(classes(acts).includes("fileview-acts"));
+  assert.equal(acts.children.length, 2, "one group, then the close");
+  const [group, close] = acts.children;
+  assert.deepEqual(classes(group).sort(), ["fileview-group", "fileview-group-file"]);
+  assert.deepEqual(group.children.map((c) => c.tag), ["a", "button"], "download (an anchor) then copy, in the file group");
+  const [dl, cp] = group.children;
+  assert.ok(classes(dl).includes("fileview-btn") && classes(dl).includes("fileview-icon") && classes(dl).includes("romp-lightbox-dl"), dl.className);
+  assert.ok(dl.innerHTML.includes('data-icon="download"'), "the tray glyph, not a text chip");
+  assert.equal(dl.title, "Download");
+  assert.ok(classes(cp).includes("fileview-btn") && classes(cp).includes("fileview-icon") && classes(cp).includes("romp-lightbox-copy"), cp.className);
+  assert.ok(cp.innerHTML.includes('data-icon="copy"'));
+  assert.equal(cp.title, "Copy image");
+  assert.deepEqual(classes(close).sort(), ["fileview-btn", "fileview-close", "romp-lightbox-close"]);
+  assert.equal(close.textContent, "✕");
+  assert.equal(close.title, "Close (Esc)");
+});
+
+test("without a clipboard the group holds download alone; the close still ends the bar", () => {
+  const { body, open } = lift("img", [], false);
+  open("plots/run1.png", "s1");
+  const acts = column(body).children[0].children[1];
+  assert.deepEqual(acts.children[0].children.map((c) => c.tag), ["a"]);
+  assert.ok(classes(acts.children[1]).includes("fileview-close"));
+});
+
+test("a sequence puts the position cue beside the title, and an arrow step re-titles the two elements and re-aims the download", () => {
+  const nav: Nav = [{ path: "plots/a.png", sid: "s1", pin: "v1" }, { path: "figs/deep/b.jpg", sid: "s1" }, { path: "c.png", sid: "s1" }];
+  const { body, open, keys } = lift("img", nav, true);
+  open("plots/a.png", "s1", "v1");
+  const bar = column(body).children[0];
+  assert.equal(bar.children.length, 3, "name, cue, actions");
+  const [name, cue, acts] = bar.children;
+  assert.ok(classes(cue).includes("romp-lightbox-cue"));
+  assert.equal(cue.textContent, "1/3");
+  const dl = acts.children[0].children[0];
+  assert.ok(dl.href.includes("pin=v1"), "the download aims at the pinned bytes on screen");
+  assert.equal(keys.length, 1, "one capture keydown listener");
+  keys[0]({ key: "ArrowRight", stopPropagation: () => {}, preventDefault: () => {} });
+  assert.deepEqual([name.children[0].textContent, name.children[1].textContent], ["figs/deep/", "b.jpg"], "the step re-titles directory and basename");
+  assert.equal(name.title, "figs/deep/b.jpg");
+  assert.equal(cue.textContent, "2/3");
+  assert.ok(dl.href.includes(encodeURIComponent("figs/deep/b.jpg")) && !dl.href.includes("pin="), "the download follows the step, unpinned when the entry carries no pin");
+  assert.equal(dl.download, "b.jpg");
+  keys[0]({ key: "ArrowRight", stopPropagation: () => {}, preventDefault: () => {} });
+  assert.deepEqual([name.children[0].textContent, name.children[1].textContent], ["", "c.png"], "a bare basename has no directory half");
+});
+
+test("styles: the lightbox's own chip rules are gone, the shared bar rules stand, and the bar's tokens are the dark theme's inside the lightbox (the backdrop is dark in both themes)", () => {
+  assert.doesNotMatch(CSS, /\.romp-lightbox-close \{/, "the close wears .fileview-btn.fileview-close now");
+  assert.doesNotMatch(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{/, "download and copy wear .fileview-btn.fileview-icon now");
+  assert.doesNotMatch(CSS, /\.romp-lightbox-name \{/, "the title wears .fileview-name (directory + basename) now");
+  assert.match(CSS, /\.romp-lightbox-bar \{ padding: 0 2px 6px; \}/, "the bar's own placement over the backdrop: no side padding, the picture's edges are the column's");
+  assert.match(CSS, /\.romp-lightbox-bar \.fileview-name \{ min-width: 0; \}/, "the title never forces the column wider than the picture; the directory truncates");
+  assert.match(CSS, /\.romp-lightbox-img \{ [^}]*align-self: center;/, "a bar wider than a small picture never stretches it");
+  assert.match(CSS, /#romp-lightbox \{ --fg: #e8e8e8; --dim: #b8b8b8; --accent: #9cd2ff; --accent-fg: #0c1a2e; --accent-wash: rgba\(156, 210, 255, 0\.12\);\s*\n\s*--err: #f48771; --card-border: rgba\(255, 255, 255, 0\.18\); --box-border: rgba\(255, 255, 255, 0\.18\); \}/);
+  assert.match(CSS, /\.romp-lightbox-cue \{ flex: 0 0 auto; font-size: 0\.82em; color: var\(--dim\); font-variant-numeric: tabular-nums; \}/, "the cue keeps the house sub scale");
+  // the shared rules the bar rides (file-view's, T367): present once, so a control added to one bar dresses in the other
+  assert.equal((CSS.match(/^\.fileview-bar \{/gm) || []).length, 1);
+  assert.match(CSS, /^\.fileview-btn\.fileview-icon \{/m);
+  assert.match(CSS, /^a\.fileview-btn \{ text-decoration: none; display: inline-flex; align-items: center; \}/m, "the download anchor wears the button treatment");
+});

--- a/ui/webview/lightbox-copy.test.ts
+++ b/ui/webview/lightbox-copy.test.ts
@@ -41,9 +41,13 @@ test("a png source writes directly; anything else re-encodes to png through a ca
 
 test("the click acknowledges immediately and failures state why — both self-restore", () => {
   // the file viewer's glyph swap (T367, shared since T385): a check and "Copied", a cross whose words carry the reason
-  assert.match(PREVIEW, /say\(ICON_CHECK, "Copied", "ok"\);/);
-  assert.match(PREVIEW, /say\(ICON_CROSS, "Copy failed: " \+ \(\(e && \(e as Error\)\.message\) \|\| String\(e\)\), "err"\);/);
-  assert.match(PREVIEW, /const say = \(icon: string, word: string, cls: string\) => \{\s*\n\s*btn\.innerHTML = icon; btn\.title = word; btn\.setAttribute\("aria-label", word\);/);
+  assert.match(PREVIEW, /\(\) => say\(ICON_CHECK, "Copied", "ok", 1400\),/);
+  assert.match(PREVIEW, /\(e\) => say\(ICON_CROSS, "Copy failed: " \+ \(\(e && \(e as Error\)\.message\) \|\| String\(e\)\), "err", 3000\)\);/);
+  assert.match(PREVIEW, /const say = \(icon: string, word: string, cls: string, ms: number \| null\) => \{\s*\n\s*btn\.innerHTML = icon; btn\.title = word; btn\.setAttribute\("aria-label", word\);/);
+  // the viewer's click-safety (T385 review): the press dims in its own tick, and ONE restore timer is cleared on every swap
+  assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss\s*\n\s*btn\.classList\.add\("fileview-busy"\);/, "the same-tick acknowledgement");
+  assert.match(PREVIEW, /btn\.classList\.remove\("ok", "err", "fileview-busy"\); if \(cls\) btn\.classList\.add\(cls\);/);
+  assert.match(PREVIEW, /if \(copyTimer\) \{ window\.clearTimeout\(copyTimer\); copyTimer = null; \}\s*\n\s*if \(ms !== null\) copyTimer = window\.setTimeout\(\(\) => say\(COPY_SVG, "Copy image", "", null\), ms\);/, "one timer, cleared on every swap");
   assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss/);
 });
 

--- a/ui/webview/lightbox-copy.test.ts
+++ b/ui/webview/lightbox-copy.test.ts
@@ -40,15 +40,19 @@ test("a png source writes directly; anything else re-encodes to png through a ca
 });
 
 test("the click acknowledges immediately and failures state why — both self-restore", () => {
-  assert.match(PREVIEW, /btn\.textContent = "✓"; btn\.classList\.add\("ok"\); btn\.title = "copied";/);
-  assert.match(PREVIEW, /btn\.textContent = "✕"; btn\.classList\.add\("err"\);/);
-  assert.match(PREVIEW, /btn\.title = "copy failed: " \+ \(\(e && \(e as Error\)\.message\) \|\| String\(e\)\);/);
+  // the file viewer's glyph swap (T367, shared since T385): a check and "Copied", a cross whose words carry the reason
+  assert.match(PREVIEW, /say\(ICON_CHECK, "Copied", "ok"\);/);
+  assert.match(PREVIEW, /say\(ICON_CROSS, "Copy failed: " \+ \(\(e && \(e as Error\)\.message\) \|\| String\(e\)\), "err"\);/);
+  assert.match(PREVIEW, /const say = \(icon: string, word: string, cls: string\) => \{\s*\n\s*btn\.innerHTML = icon; btn\.title = word; btn\.setAttribute\("aria-label", word\);/);
   assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss/);
 });
 
-test("the copy chip wears the download chip's exact dress — one control vocabulary", () => {
-  assert.match(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{/);
-  assert.match(CSS, /\.romp-lightbox-dl:hover, \.romp-lightbox-copy:hover \{ border-color: var\(--accent\); \}/);
+test("the copy button wears the download control's exact dress — the file viewer's glyph button (T385), one control vocabulary", () => {
+  assert.match(PREVIEW, /dl\.className = "fileview-btn fileview-icon romp-lightbox-dl";/);
+  assert.match(PREVIEW, /btn\.className = "fileview-btn fileview-icon romp-lightbox-copy";/);
+  assert.doesNotMatch(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{/, "the lightbox's own chip rules are gone: the shared .fileview-btn rules dress both");
+  assert.match(CSS, /^\.fileview-btn\.fileview-icon\.ok \{ color: var\(--accent\); border-color: var\(--accent\); \}/m, "the ack colours are the shared rules'");
+  assert.match(CSS, /^\.fileview-btn\.fileview-icon\.err \{ color: var\(--err\); border-color: var\(--err\); \}/m);
 });
 
 // ── executed replica: the two decisions ───────────────────────────────────────────────────────────

--- a/ui/webview/preview-core.test.ts
+++ b/ui/webview/preview-core.test.ts
@@ -74,8 +74,10 @@ test("the lightbox offers a download beside the close, saving the same bytes it 
     "saved under the file's own basename");
   assert.ok(body.indexOf("dl.onclick = (ev) => ev.stopPropagation()") > 0,
     "saving must not also dismiss the lightbox");
-  assert.ok(body.indexOf('const controls = [dl, ...(cp ? [cp] : []), close]') > 0,
-    "between the filename and the ✕ — with copy slotted beside it where the clipboard API exists (2026-08-31)");
+  assert.ok(body.indexOf('group.append(dl, ...(cp ? [cp] : []));') > 0,
+    "in the file group with copy beside it where the clipboard API exists (2026-08-31); the group then the close (T385, the file viewer's order)");
+  assert.ok(body.indexOf('acts.append(group, close);') > 0, "the close cross alone at the end of the actions");
+  assert.ok(body.indexOf('inner.prepend(bar);') > 0, "the bar precedes the picture (T385; lightbox-bar.test.ts runs the builder and reads the order)");
   // an inline TRAY SVG, not a codepoint: "⭳" (U+2B73) has no coverage in the mac system fonts and
   // rendered as a tofu box (the user 2026-08-19). Same stroke family as the composer's buttons.
   assert.ok(body.indexOf("dl.innerHTML = ICON_DOWNLOAD") > 0, "the tray glyph from icons.ts (T367: one drawing, shared with the file viewer's bar)");
@@ -83,6 +85,7 @@ test("the lightbox offers a download beside the close, saving the same bytes it 
   assert.ok(ICONS.indexOf('<polyline points="7 10 12 15 17 10"/>') > 0, "the arrow-into-tray glyph");
   assert.ok(body.indexOf("\u2b73") < 0 && body.indexOf("⭳") < 0, "the uncovered codepoint is gone");
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
-  assert.match(CSS, /\.romp-lightbox-dl, \.romp-lightbox-copy \{ font: inherit; font-size: 0\.86em;/,
-    "one control vocabulary — download and copy share the chip dress of the close beside them (2026-08-31)");
+  assert.match(body, /dl\.className = "fileview-btn fileview-icon romp-lightbox-dl";/,
+    "one control vocabulary — download, copy and the close wear the file viewer's bar buttons (T385; 2026-08-31 gave them one chip dress)");
+  assert.match(CSS, /^a\.fileview-btn \{ text-decoration: none; display: inline-flex; align-items: center; \}/m, "the anchor wears the button treatment");
 });

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -377,8 +377,11 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   // control). Clipboards take image/png; any other source re-encodes through a canvas. The
   // ClipboardItem takes the PROMISE form so write() runs synchronously inside the click gesture
   // (Safari refuses a write that awaits first — the tailnet phone case). Success and failure both
-  // speak in place, the file viewer's glyph swap (T367): a check and "Copied", or a cross whose words
-  // name the reason, and the button restores itself either way.
+  // speak in place, the file viewer's glyph swap (T367): the press dims the button in the same tick
+  // (click-safe: every press acknowledges, ui/CLAUDE.md; a large jpeg's decode is not instant), then a
+  // check and "Copied", or a cross whose words name the reason, and the button restores itself either
+  // way on ONE timer that every swap clears (two presses inside the pulse never let the first wipe the
+  // second's check early; the viewer's copyTimer rule).
   const COPY_SVG = ICON_COPY;   // icons.ts: the one two-sheets drawing, shared with the file viewer's bar (T367)
   let cp: HTMLButtonElement | null = null;
   if (curImg && typeof ClipboardItem !== "undefined" && navigator.clipboard && navigator.clipboard.write) {
@@ -386,14 +389,17 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
     cp = btn;
     btn.type = "button";
     btn.className = "fileview-btn fileview-icon romp-lightbox-copy";
-    const say = (icon: string, word: string, cls: string) => {
+    let copyTimer: number | null = null;                 // window.setTimeout's handle (a number in the page)
+    const say = (icon: string, word: string, cls: string, ms: number | null) => {
       btn.innerHTML = icon; btn.title = word; btn.setAttribute("aria-label", word);
-      btn.classList.remove("ok", "err"); if (cls) btn.classList.add(cls);
+      btn.classList.remove("ok", "err", "fileview-busy"); if (cls) btn.classList.add(cls);
+      if (copyTimer) { window.clearTimeout(copyTimer); copyTimer = null; }
+      if (ms !== null) copyTimer = window.setTimeout(() => say(COPY_SVG, "Copy image", "", null), ms);
     };
-    say(COPY_SVG, "Copy image", "");
-    const restore = () => say(COPY_SVG, "Copy image", "");
+    say(COPY_SVG, "Copy image", "", null);
     btn.onclick = (ev) => {
       ev.stopPropagation();                                // copying must not also dismiss
+      btn.classList.add("fileview-busy");                  // the same-tick acknowledgement
       const src = curImg!().src;
       const png = (async () => {
         const blob = await (await fetch(src)).blob();
@@ -405,13 +411,9 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
         return await new Promise<Blob>((res, rej) =>
           cv.toBlob((b) => (b ? res(b) : rej(new Error("png encode failed"))), "image/png"));
       })();
-      navigator.clipboard.write([new ClipboardItem({ "image/png": png })]).then(() => {
-        say(ICON_CHECK, "Copied", "ok");
-        window.setTimeout(restore, 1400);                  // the ack pulse, then back to a button
-      }, (e) => {
-        say(ICON_CROSS, "Copy failed: " + ((e && (e as Error).message) || String(e)), "err");   // loud: the reason, never a silent no-op
-        window.setTimeout(restore, 3000);
-      });
+      navigator.clipboard.write([new ClipboardItem({ "image/png": png })]).then(
+        () => say(ICON_CHECK, "Copied", "ok", 1400),        // the ack pulse, then back to a button
+        (e) => say(ICON_CROSS, "Copy failed: " + ((e && (e as Error).message) || String(e)), "err", 3000));   // loud: the reason, never a silent no-op
     };
   }
   const close = document.createElement("button");

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -8,7 +8,7 @@
 
 import { hostOf, bareId } from "./host-prefix";
 import { mediaSrc } from "./media";
-import { ICON_DOWNLOAD, ICON_COPY } from "./icons";   // the shared stroke-family glyphs (T367)
+import { ICON_DOWNLOAD, ICON_COPY, ICON_CHECK, ICON_CROSS } from "./icons";   // the shared stroke-family glyphs (T367)
 import * as pz from "./pinch";
 
 // Extensions the kernel's _PREVIEW_MIME serves — keep the two lists in step (tests pin both).
@@ -318,18 +318,33 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
       img.replaceWith(next);
       img = next;
       pzc.retarget(next);                                // a step lands on the fit view, zoom reset
-      name.textContent = e.path; name.title = e.path;
+      setName(e.path);                                   // the two-element title follows the step
       dl.href = fileUrl(e.path, e.sid) + (e.pin ? "&pin=" + encodeURIComponent(e.pin) : "");
       dl.download = e.path.slice(e.path.lastIndexOf("/") + 1) || "image";
       if (cue) cue.textContent = (at + 1) + "/" + nav.length;
     };
   }
+  // ── the bar, ABOVE the picture (T385, the user 2026-09-12: the controls sit at the top, the way a file opens) ──
+  // It IS the file viewer's bar (file-view.ts, T367): .fileview-bar for the row, .fileview-name as a dimmed directory
+  // and the basename (only the directory may truncate), .fileview-acts holding the file group (download, copy) and the
+  // close cross alone at the end, glyph buttons as .fileview-btn.fileview-icon. One set of rules for both surfaces
+  // (styles.css .fileview-*), so a control added to one wears the same dress in the other. The lightbox's own classes
+  // stay as HOOKS: the bar's placement over the backdrop (styles.css) and the stage's tap rule (wirePinchZoom's
+  // closest(".romp-lightbox-bar")). Prepended to the column below, so it precedes the picture and the PDF frame.
   const bar = document.createElement("div");
-  bar.className = "romp-lightbox-bar";
-  const name = document.createElement("span");
-  name.className = "romp-lightbox-name";
-  name.textContent = path;
-  name.title = path;
+  bar.className = "fileview-bar romp-lightbox-bar";
+  const name = document.createElement("div");
+  name.className = "fileview-name romp-lightbox-name";
+  const dir = document.createElement("span"); dir.className = "fileview-dir";
+  const base = document.createElement("span"); base.className = "fileview-base";
+  name.append(dir, base);
+  const setName = (p: string) => {
+    const cut = p.lastIndexOf("/");
+    dir.textContent = cut >= 0 ? p.slice(0, cut + 1) : "";
+    base.textContent = p.slice(cut + 1);
+    name.title = p;                                       // the full path, one hover away
+  };
+  setName(path);
   // download rides an ANCHOR with the download attribute (the user 2026-08-19): the browser saves
   // the same bytes the lightbox is showing — the pinned URL when a pin rode in, so a re-generated
   // file can't swap the image between viewing and saving. The filename is the path's basename.
@@ -339,16 +354,20 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
     cue.textContent = (at + 1) + "/" + nav.length;
     cue.title = "picture " + (at + 1) + " of " + nav.length + " in this chat — ←/→ to step";
   }
+  const acts = document.createElement("div");
+  acts.className = "fileview-acts";
+  const group = document.createElement("span");
+  group.className = "fileview-group fileview-group-file";
   const dl = document.createElement("a");
-  dl.className = "romp-lightbox-dl";
+  dl.className = "fileview-btn fileview-icon romp-lightbox-dl";
   dl.href = fileUrl(path, sid) + (pin ? "&pin=" + encodeURIComponent(pin) : "");
   dl.download = path.slice(path.lastIndexOf("/") + 1) || "image";
   // the tray icon every download control should wear (the composer buttons' stroke family) as an
   // inline SVG: the old text glyph (U+2B73, arrow-to-bar) has no coverage in the mac system fonts
   // and rendered as a tofu box instead of an icon (the user 2026-08-19). A literal — no sanitize.
   dl.innerHTML = ICON_DOWNLOAD;   // icons.ts: the one tray drawing, shared with the file viewer's bar (T367)
-  dl.title = "download";
-  dl.setAttribute("aria-label", "download");
+  dl.title = "Download";
+  dl.setAttribute("aria-label", "Download");
   dl.onclick = (ev) => ev.stopPropagation();               // saving must not also dismiss
   // copy beside download (the user 2026-08-31): the image ITSELF onto the clipboard. It reads the
   // CURRENT img's src at CLICK time — mkImg bakes the pin param into src and an arrow step rebinds
@@ -358,18 +377,21 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   // control). Clipboards take image/png; any other source re-encodes through a canvas. The
   // ClipboardItem takes the PROMISE form so write() runs synchronously inside the click gesture
   // (Safari refuses a write that awaits first — the tailnet phone case). Success and failure both
-  // speak in place: the icon flips to a check, or to an × whose title names the reason, and the
-  // button restores itself either way.
+  // speak in place, the file viewer's glyph swap (T367): a check and "Copied", or a cross whose words
+  // name the reason, and the button restores itself either way.
   const COPY_SVG = ICON_COPY;   // icons.ts: the one two-sheets drawing, shared with the file viewer's bar (T367)
   let cp: HTMLButtonElement | null = null;
   if (curImg && typeof ClipboardItem !== "undefined" && navigator.clipboard && navigator.clipboard.write) {
     const btn = document.createElement("button");
     cp = btn;
-    btn.className = "romp-lightbox-copy";
-    btn.innerHTML = COPY_SVG;
-    btn.title = "copy image";
-    btn.setAttribute("aria-label", "copy image");
-    const restore = () => { btn.innerHTML = COPY_SVG; btn.title = "copy image"; btn.classList.remove("ok", "err"); };
+    btn.type = "button";
+    btn.className = "fileview-btn fileview-icon romp-lightbox-copy";
+    const say = (icon: string, word: string, cls: string) => {
+      btn.innerHTML = icon; btn.title = word; btn.setAttribute("aria-label", word);
+      btn.classList.remove("ok", "err"); if (cls) btn.classList.add(cls);
+    };
+    say(COPY_SVG, "Copy image", "");
+    const restore = () => say(COPY_SVG, "Copy image", "");
     btn.onclick = (ev) => {
       ev.stopPropagation();                                // copying must not also dismiss
       const src = curImg!().src;
@@ -384,22 +406,24 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
           cv.toBlob((b) => (b ? res(b) : rej(new Error("png encode failed"))), "image/png"));
       })();
       navigator.clipboard.write([new ClipboardItem({ "image/png": png })]).then(() => {
-        btn.textContent = "✓"; btn.classList.add("ok"); btn.title = "copied";
+        say(ICON_CHECK, "Copied", "ok");
         window.setTimeout(restore, 1400);                  // the ack pulse, then back to a button
       }, (e) => {
-        btn.textContent = "✕"; btn.classList.add("err");   // loud: the reason, never a silent no-op
-        btn.title = "copy failed: " + ((e && (e as Error).message) || String(e));
+        say(ICON_CROSS, "Copy failed: " + ((e && (e as Error).message) || String(e)), "err");   // loud: the reason, never a silent no-op
         window.setTimeout(restore, 3000);
       });
     };
   }
   const close = document.createElement("button");
-  close.className = "romp-lightbox-close";
+  close.type = "button";
+  close.className = "fileview-btn fileview-close romp-lightbox-close";
   close.textContent = "✕";
-  close.title = "close (Esc)";
-  const controls = [dl, ...(cp ? [cp] : []), close];
-  if (cue) bar.append(name, cue, ...controls); else bar.append(name, ...controls);
-  inner.appendChild(bar);
+  close.title = "Close (Esc)";
+  close.setAttribute("aria-label", "Close the picture");
+  group.append(dl, ...(cp ? [cp] : []));
+  acts.append(group, close);
+  if (cue) bar.append(name, cue, acts); else bar.append(name, acts);
+  inner.prepend(bar);                                      // FIRST in the column: above the picture and the PDF frame
   wrap.appendChild(inner);
   const dismiss = () => { wrap.remove(); document.removeEventListener("keydown", onKey, true); };
   const onKey = (ev: KeyboardEvent) => {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3417,7 +3417,7 @@ body.drop-over::after { content: ""; position: fixed; inset: 0; pointer-events: 
 #romp-lightbox { position: fixed; inset: 0; z-index: 1300; background: rgba(0, 0, 0, 0.72);
   display: flex; align-items: center; justify-content: center; }
 .romp-lightbox-inner { display: flex; flex-direction: column; gap: 8px; max-width: 92vw; max-height: 90vh; }
-.romp-lightbox-img { max-width: 92vw; max-height: 82vh; object-fit: contain; border-radius: 8px;
+.romp-lightbox-img { max-width: 92vw; max-height: 82vh; object-fit: contain; border-radius: 8px; align-self: center;
   box-shadow: var(--shadow-modal);
   transform-origin: 0 0; will-change: transform; }   /* pinch-zoom renders translate+scale from this corner (T162; pinch.ts) */
 /* the stage owns every touch gesture (T162): pinch must zoom the IMAGE, never the page — the bar's
@@ -3425,24 +3425,20 @@ body.drop-over::after { content: ""; position: fixed; inset: 0; pointer-events: 
 .romp-lightbox-inner { touch-action: none; }
 .romp-lightbox-inner.pdf { width: 88vw; height: 88vh; }
 .romp-lightbox-frame { flex: 1 1 auto; width: 100%; border: 0; border-radius: 8px; background: #fff; }
-.romp-lightbox-bar { display: flex; align-items: center; gap: 10px; min-width: 0; }
-.romp-lightbox-name { flex: 1 1 auto; font-size: 0.86em; color: var(--fg); opacity: 0.85;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.romp-lightbox-close { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
-  padding: 2px 9px; border-radius: 6px; background: transparent; border: 1px solid var(--card-border); color: var(--fg);   /* T151: the one button rest */
-  border: 1px solid rgba(255, 255, 255, 0.18); }
-.romp-lightbox-close:hover { border-color: var(--accent); }
-/* download: an anchor dressed exactly like the close button beside it (one control vocabulary —
-   same chip, same hover cue), sitting between the filename and the ✕ */
+/* the bar sits ABOVE the picture and the PDF frame (T385, the user 2026-09-12: the controls at the top, the way a
+   file opens): it IS the file viewer's bar (.fileview-bar; .fileview-name as dimmed directory + basename; .fileview-acts
+   with the file group and the close cross alone at the end; .fileview-btn.fileview-icon glyph buttons; file-view.ts,
+   T367), one set of rules for both surfaces, so a control added to one wears the same dress in the other. The
+   lightbox's own classes stay as hooks: the placement here and the stage's tap rule (pinch.ts, closest(".romp-lightbox-bar")).
+   No side padding: the picture's edges are the column's. The title never forces the column wider than the picture (the
+   viewer's 12em floor is for a card that owns its width; here the directory truncates instead). */
+.romp-lightbox-bar { padding: 0 2px 6px; }
+.romp-lightbox-bar .fileview-name { min-width: 0; }
+/* the backdrop is 72% black in BOTH themes, so inside the lightbox the bar's tokens are the dark theme's whatever the
+   page wears: the light theme's near-black prose, hairline and clay accent would sit on a dark field otherwise */
+#romp-lightbox { --fg: #e8e8e8; --dim: #b8b8b8; --accent: #9cd2ff; --accent-fg: #0c1a2e; --accent-wash: rgba(156, 210, 255, 0.12);
+  --err: #f48771; --card-border: rgba(255, 255, 255, 0.18); --box-border: rgba(255, 255, 255, 0.18); }
 .romp-lightbox-cue { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); font-variant-numeric: tabular-nums; }   /* the ←/→ position mark (house sub scale) */
-.romp-lightbox-dl, .romp-lightbox-copy { font: inherit; font-size: 0.86em; cursor: pointer; flex: 0 0 auto;
-  display: inline-flex; align-items: center;   /* centers the inline SVG in the chip */
-  padding: 3px 9px; border-radius: 6px; background: transparent; border: 1px solid var(--card-border); color: var(--fg);   /* T151: the one button rest */
-  border: 1px solid rgba(255, 255, 255, 0.18); text-decoration: none; line-height: normal; }
-.romp-lightbox-dl:hover, .romp-lightbox-copy:hover { border-color: var(--accent); }
-/* copy's spoken states: the ✓/✕ glyphs sit where the icon was — same chip, no reflow */
-.romp-lightbox-copy.ok { color: var(--accent); border-color: var(--accent); }
-.romp-lightbox-copy.err { color: #f48771; border-color: #f48771; }
 
 /* The "host:" prefix on a FEDERATED session's name (host-prefix.ts): metadata, not part of the name
    (the user 2026-07-11) — quiet gray, never bold, italic, a step smaller than the name it precedes.

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3430,10 +3430,16 @@ body.drop-over::after { content: ""; position: fixed; inset: 0; pointer-events: 
    with the file group and the close cross alone at the end; .fileview-btn.fileview-icon glyph buttons; file-view.ts,
    T367), one set of rules for both surfaces, so a control added to one wears the same dress in the other. The
    lightbox's own classes stay as hooks: the placement here and the stage's tap rule (pinch.ts, closest(".romp-lightbox-bar")).
-   No side padding: the picture's edges are the column's. The title never forces the column wider than the picture (the
-   viewer's 12em floor is for a card that owns its width; here the directory truncates instead). */
-.romp-lightbox-bar { padding: 0 2px 6px; }
-.romp-lightbox-bar .fileview-name { min-width: 0; }
+   The bar's OWN placement rules are scoped under the lightbox id: an id outranks the viewer's later rules of equal
+   specificity, which a plain .romp-lightbox-bar rule tied with and lost to (round one measured the served bar at the
+   viewer's 7px 10px and the title at 12em; the repo's cascade rule: pin the tiebreak). No side padding: the picture's
+   edges are the column's. contain: inline-size makes the bar contribute NO intrinsic width, so the PICTURE sets the
+   column (a 120px thumbnail is a 120px column, not a bar-wide one) and the bar stretches to it; inside, the title
+   truncates, the basename too (the viewer's card owns its width and keeps its basename whole; the lightbox's column is
+   the picture's), and the actions wrap beneath the title when the picture is narrower than they are. */
+#romp-lightbox .romp-lightbox-bar { padding: 0 2px 6px; contain: inline-size; }
+#romp-lightbox .romp-lightbox-bar .fileview-name { min-width: 0; overflow: hidden; }
+#romp-lightbox .romp-lightbox-bar .fileview-base { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 /* the backdrop is 72% black in BOTH themes, so inside the lightbox the bar's tokens are the dark theme's whatever the
    page wears: the light theme's near-black prose, hairline and clay accent would sit on a dark field otherwise */
 #romp-lightbox { --fg: #e8e8e8; --dim: #b8b8b8; --accent: #9cd2ff; --accent-fg: #0c1a2e; --accent-wash: rgba(156, 210, 255, 0.12);


### PR DESCRIPTION
The image lightbox's controls move to the top, laid out like the file viewer's bar (the user, 2026-09-12, after opening an image: the controls should sit at the top, consistent with how a file opens).

**What changes**
- The bar is prepended to the lightbox column: above the picture, and above the PDF frame in the pdf kind.
- It is the file viewer's bar (`fileview-bar`): the title as a dimmed directory plus the basename (an arrow step re-titles both), `fileview-acts` holding the file group (the download anchor and the copy button as `fileview-btn fileview-icon` glyph buttons) and the close cross (`fileview-close`) alone at the end. One set of rules dresses both bars, so the next control added to one appears in the other in the same dress. The lightbox's own classes stay as hooks for its placement and for the pinch stage's tap rule.
- The copy control acknowledges with the viewer's glyph swap (check, cross) and its words.
- The lightbox's own chip rules are removed. The backdrop is 72% black in both themes, so the bar's tokens inside the lightbox are the dark theme's (a scoped rule on the lightbox root); the light theme's near-black prose and hairline would otherwise sit on a dark field.
- Kept: Escape and backdrop dismissal, arrow stepping with the position cue beside the title, pinch zoom on the stage, download and copy reading the current picture at click time, the pdf kind's frame.

**Tests**
- `ui/webview/lightbox-bar.test.ts`: an executed lift of the builder on a tiny DOM reads the column's child order (red on main: the picture came first), the bar's composition, the pdf kind, the no-clipboard case, a sequence's cue and a step's re-title, and the style pins.
- `tests/test_lightbox_bar_browser.py`: a served lab (hermetic kernel, synthetic session, a run-time PNG mentioned in the chat) clicks the inline figure and measures the bar above the picture spanning its column, the controls and their words, the buttons' computed dress equal to the file viewer's own buttons for the same file, the tokens under the light theme, and Escape. Red against the previous build served through `LB_DIST`.
- Re-derived pins in `lightbox-copy.test.ts` and `preview-core.test.ts` (the old chip rules and control order).

Tier: fix
