### PR TITLE
The Billing flyout lists the picks, then one Set default billing entry opening a submenu of the same entries (T387)

### DIFF
--- a/tests/test_billing_flyout_browser.py
+++ b/tests/test_billing_flyout_browser.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python3
-"""The tab menu's Billing flyout opens on HOVER over its row, as the Tags flyout does (one gesture, wireFlyout), and
-carries "Default for this machine" below the session's choices (T380; the user 2026-09-12): the same choices as a radio
-group, the current default marked, a pick writing the seed every new session and every session with no pick of its own
-launches on, touching no session that carries its own pick.
+"""The tab menu's Billing flyout opens on HOVER over its row, as the Tags flyout does (one gesture, wireFlyout; T380), and
+takes the user's shape (T387, the user 2026-09-12): the billings the session can pick from; below them, only when there is
+more than one to choose from, a rule and ONE entry, Set default billing, which opens a further submenu holding exactly the
+same entries with the machine's default check-marked; a click there sets the default; no sub-line anywhere. An Automatic
+way back to the helper rule sits at the END of that submenu behind its own rule, only while an explicit default stands.
 
-This lab drives the real /chat page of a hermetic kernel whose machine offers BOTH sides (a staged apiKeyHelper in the
-kernel's Claude config dir, a synthetic Claude account in the kernel's own home), with two synthetic sessions: web with
-no pick of its own, api with an explicit key pick. It right-clicks web's tab, HOVERS the Billing row without clicking
-and reads whether the flyout opened and when; reads the flyout (the choices, the Default group's head and radios, the
-marked default); leaves the row and the flyout and reads that the flyout closed with the menu still up; opens again and
-presses Escape; then opens once more and clicks the Login default radio, after which the kernel's sdk-defaults.json
-must read auth login with authExplicit true while api's reg keeps its key pick and web's reg has no pick.
+Two labs drive the real /chat page of hermetic kernels. ServedBillingFlyout's machine offers BOTH sides (a staged
+apiKeyHelper in the kernel's Claude config dir, a synthetic Claude account in the kernel's own home) with two synthetic
+sessions: web with no pick of its own, api with an explicit key pick. It right-clicks web's tab, HOVERS the Billing row
+and reads the flyout (the picks, the rule, the entry, the computed absence of sub-lines); hovers the entry and reads the
+nested submenu (its entries against the list, the check mark as the computed pseudo-element, its placement beside the
+entry); leaves and reads the close; presses Escape; clicks Login in the submenu, after which sdk-defaults.json must read
+auth login with authExplicit true while api keeps its key pick and web has none, the reopened submenu marks Login and
+offers Automatic behind a rule; clicks Automatic and reads the seed cleared. ServedBillingFlyoutOneSide's machine has
+NO apiKeyHelper: the flyout lists both sides with the key greyed and shows neither the rule nor the entry.
 BILLING_FLYOUT_DIST=<dir> serves another tree's UI bundle (the red run's before; the driver falls back to a click when
 the hover opens nothing, so the rest is still read); BILLING_FLYOUT_SHOTS=<prefix> writes <prefix>-dark.png and
-<prefix>-light.png of the open flyout. Skips LOUDLY without the extension deps or a Playwright browser, and never
-otherwise (CI turns a skip in a served module into a failure). SYNTHETIC fixtures only."""
+<prefix>-light.png of the open flyout with its submenu. Skips LOUDLY without the extension deps or a Playwright browser,
+and never otherwise (CI turns a skip in a served module into a failure). SYNTHETIC fixtures only."""
 import json
 import os
 import re
@@ -80,17 +83,41 @@ const billingRow = () => page.$(".ctx-menu .ctx-item-billing");
 const readFly = () => page.evaluate(() => {
   const fly = document.querySelector(".ctx-sub-billing");
   if (!fly) return null;
-  const items = Array.from(fly.querySelectorAll(".ctx-item"));
-  const choices = items.filter((i) => !i.classList.contains("ctx-radio") && !i.classList.contains("ctx-sub-head")).map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled") }));
-  const head = fly.querySelector(".ctx-sub-head");
-  const radios = Array.from(fly.querySelectorAll(".ctx-radio")).map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled"), scope: i.dataset.scope }));
-  const r = fly.getBoundingClientRect();
+  const rect = (e) => { const b = e.getBoundingClientRect(); return { left: b.left, top: b.top, w: b.width, h: b.height, right: b.right, bottom: b.bottom }; };
+  const kids = Array.from(fly.children);
+  const lines = kids.map((k) => k.classList.contains("ctx-sep") ? "---" : k.classList.contains("ctx-item-setdefault") ? "[set default]" : k.textContent.trim());
+  const choices = kids.filter((k) => k.classList.contains("ctx-item") && !k.classList.contains("ctx-item-setdefault") && !k.closest(".ctx-sub-default"))
+    .map((i) => ({ text: i.textContent.trim(), current: i.classList.contains("current"), disabled: i.classList.contains("disabled"), title: i.title }));
+  const entry = fly.querySelector(":scope > .ctx-item-setdefault");
+  const readSub = (d) => Array.from(d.children).map((k) => k.classList.contains("ctx-sep") ? { sep: true } : {
+    text: k.textContent.trim(), current: k.classList.contains("current"), disabled: k.classList.contains("disabled"), scope: k.dataset.scope,
+    check: getComputedStyle(k, "::after").content, checkW: parseFloat(getComputedStyle(k, "::after").width) || 0, auto: k.classList.contains("ctx-item-auto") });
+  const d = fly.querySelector(".ctx-sub-default");
   const row = document.querySelector(".ctx-menu .ctx-item-billing .ctx-item-sub");
-  const rowEl = document.querySelector(".ctx-menu .ctx-item-billing"); const rr = rowEl ? rowEl.getBoundingClientRect() : null;
-  const menuEl = document.querySelector(".ctx-menu:not(.ctx-sub)"); const mr = menuEl ? menuEl.getBoundingClientRect() : null;
-  return { choices, head: head ? head.querySelector(".ctx-item-label").textContent : null, note: head ? head.querySelector(".ctx-item-sub").textContent : null, radios, sep: !!fly.querySelector(".ctx-sep"), rect: { left: r.left, top: r.top, w: r.width, h: r.height, right: r.right, bottom: r.bottom }, subLine: row ? row.textContent : null,
-    rowRect: rr ? { left: rr.left, right: rr.right, top: rr.top, bottom: rr.bottom } : null, menuRect: mr ? { left: mr.left, right: mr.right } : null, viewport: window.innerWidth, viewportH: window.innerHeight };
+  const rowEl = document.querySelector(".ctx-menu .ctx-item-billing"); const rr = rowEl ? rect(rowEl) : null;
+  return { lines, choices, sep: kids.some((k) => k.classList.contains("ctx-sep")), subLines: fly.querySelectorAll(".ctx-item-sub").length,
+    heads: fly.querySelectorAll(".ctx-sub-head").length, radios: fly.querySelectorAll(".ctx-radio").length,
+    entry: entry ? { label: entry.querySelector(".ctx-item-label").textContent, caret: (entry.querySelector(".ctx-caret") || {}).textContent || "", rect: rect(entry) } : null,
+    sub: d ? { items: readSub(d), rect: rect(d), inside: d.parentElement === fly } : null,
+    rect: rect(fly), subLine: row ? row.textContent : null, rowRect: rr, viewport: window.innerWidth, viewportH: window.innerHeight };
 });
+const openSub = async () => {   // hover the Set default billing entry: the nested submenu opens by intent, a click is the fallback
+  const e = await page.$(".ctx-sub-billing > .ctx-item-setdefault");
+  if (!e) return { found: false };
+  const eb = await e.boundingBox(); const t0 = Date.now();
+  await page.mouse.move(eb.x + eb.width / 2, eb.y + eb.height / 2);
+  let byHover = true;
+  try { await page.waitForSelector(".ctx-sub-billing .ctx-sub-default", { timeout: 1500 }); } catch (err) { byHover = false; }
+  if (!byHover) { await e.click(); await page.waitForSelector(".ctx-sub-billing .ctx-sub-default", { timeout: 3000 }).catch(() => {}); }
+  await page.waitForTimeout(120);
+  return { found: true, byHover, ms: Date.now() - t0 };
+};
+const hoverBilling = async () => {
+  const row = await billingRow(); const bb = await row.boundingBox();
+  await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
+  await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
+  await page.waitForTimeout(120);
+};
 const out = {};
 out.tabs = await page.evaluate(() => Array.from(document.querySelectorAll("#tabs .tab[data-id]")).map((t) => ({ id: t.dataset.id, name: (t.querySelector(".tab-label") || t).textContent.trim(), active: t.classList.contains("active") })));
 try {
@@ -103,22 +130,21 @@ try { await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }); } catch
 out.hover = { opened: byHover, ms: Date.now() - t0 };
 if (!byHover) { await row.click(); await page.waitForSelector(".ctx-sub-billing", { timeout: 5000 }).catch(() => {}); }
 out.fly = await readFly();
-// leave both the row and the flyout: the flyout closes after the tolerance window, the menu stays
+out.subOpen = await openSub();
+out.withSub = await readFly();
+// leave both the row and the flyout: the flyout (and its submenu) closes after the tolerance window, the menu stays
 await page.mouse.move(5, 690);
 await page.waitForTimeout(450);
-out.afterLeave = await page.evaluate(() => ({ fly: !!document.querySelector(".ctx-sub-billing"), menu: !!document.querySelector(".ctx-menu") }));
+out.afterLeave = await page.evaluate(() => ({ fly: !!document.querySelector(".ctx-sub-billing"), sub: !!document.querySelector(".ctx-sub-default"), menu: !!document.querySelector(".ctx-menu") }));
 // hover again, then Escape closes the menu (and the flyout with it)
 row = await billingRow(); if (row) { bb = await row.boundingBox(); await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2); await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(() => {}); }
 await page.keyboard.press("Escape"); await page.waitForTimeout(150);
 out.afterEscape = await page.evaluate(() => ({ fly: !!document.querySelector(".ctx-sub-billing"), menu: !!document.querySelector(".ctx-menu") }));
-// the screenshots: the open flyout, dark and light
+// the screenshots: the open flyout with its submenu, dark and light
 for (const theme of ["dark", "light"]) {
   await page.evaluate((t) => document.body.classList.toggle("theme-light", t === "light"), theme);
   await page.mouse.move(5, 690); await page.waitForTimeout(100);
-  await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
-  await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
-  await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
-  await page.waitForTimeout(150);
+  await menuOpen(); await hoverBilling(); await openSub();
   if (cfg.shots) await page.screenshot({ path: cfg.shots + "-" + theme + ".png", clip: { x: 0, y: 0, width: 1100, height: 520 } });
   await page.keyboard.press("Escape"); await page.waitForTimeout(100);
 }
@@ -127,20 +153,15 @@ await page.evaluate(() => document.body.classList.remove("theme-light"));
 out.narrow = {};
 for (const [w, h] of [[560, 700], [760, 700], [886, 700], [560, 420], [560, 300]]) {
   await page.setViewportSize({ width: w, height: h }); await page.waitForTimeout(150);
-  await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
-  await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
-  await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
-  await page.waitForTimeout(150);
+  await menuOpen(); await hoverBilling(); await openSub();
   out.narrow[w + "x" + h] = await readFly();
   await page.keyboard.press("Escape"); await page.waitForTimeout(100);
 }
 await page.setViewportSize({ width: 1100, height: 700 }); await page.waitForTimeout(150);
-// the default pick: the Login radio (the seed reads key: the helper is the box's default), posting setAuth with scope machine
-await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
-await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
-await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
+// the default pick: Login in the nested submenu (the seed reads key: the helper is the box's default), posting setAuth with scope machine
+await menuOpen(); await hoverBilling(); await openSub();
 out.pick = await page.evaluate(() => {
-  const r = Array.from(document.querySelectorAll(".ctx-sub-billing .ctx-radio")).find((i) => i.textContent.trim().startsWith("Login"));
+  const r = Array.from(document.querySelectorAll(".ctx-sub-billing .ctx-sub-default > .ctx-item")).find((i) => i.textContent.trim().startsWith("Login"));
   if (!r) return { found: false };
   const disabled = r.classList.contains("disabled");
   if (!disabled) r.click();
@@ -149,11 +170,20 @@ out.pick = await page.evaluate(() => {
 await page.waitForTimeout(1200);   // the op reaches the kernel over the socket and the seed is written
 await page.waitForFunction(() => { const s = document.querySelector('#tabs .tab.active'); return !!s; }, null, { timeout: 5000 });
 await page.waitForTimeout(800);     // the next push carries web's new effective side
-await menuOpen(); row = await billingRow(); bb = await row.boundingBox();
-await page.mouse.move(bb.x + bb.width / 2, bb.y + bb.height / 2);
-await page.waitForSelector(".ctx-sub-billing", { timeout: 1500 }).catch(async () => { await row.click(); });
-await page.waitForTimeout(150);
+await menuOpen(); await hoverBilling(); await openSub();
 out.afterPick = await readFly();
+// the way back: Automatic at the end of the submenu clears the explicit default
+out.autoClick = await page.evaluate(() => {
+  const a = document.querySelector(".ctx-sub-billing .ctx-sub-default > .ctx-item-auto");
+  if (!a) return { found: false };
+  const prev = a.previousElementSibling; const last = a.parentElement.lastElementChild === a;
+  a.click();
+  return { found: true, behindRule: !!(prev && prev.classList.contains("ctx-sep")), last, menuGone: !document.querySelector(".ctx-menu") };
+});
+await page.waitForTimeout(1200);
+await page.waitForTimeout(800);
+await menuOpen(); await hoverBilling(); await openSub();
+out.afterAuto = await readFly();
 await page.keyboard.press("Escape");
 } catch (e) { out.error = String(e && e.stack || e); }
 fs.writeFileSync(cfg.out, JSON.stringify(out));
@@ -162,9 +192,10 @@ console.log("RESULT: ok");
 """
 
 
-class ServedTabTipTones(unittest.TestCase):
+class ServedBillingFlyout(unittest.TestCase):
     maxDiff = None
     result = None
+    BOTH_SIDES = True
 
     @classmethod
     def setUpClass(cls):
@@ -222,8 +253,11 @@ class ServedTabTipTones(unittest.TestCase):
             Path(proj, sid + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         # BOTH sides on this machine: a staged apiKeyHelper (read, never run) in the kernel's Claude config dir, and a
         # synthetic Claude account in the kernel's OWN home (the kernel probes the login side from ~/.claude.json)
-        helper = Path(claude, "helper.sh"); helper.write_text("#!/bin/sh\necho not-a-real-key\n"); helper.chmod(0o700)
-        Path(claude, "settings.json").write_text(json.dumps({"apiKeyHelper": str(helper)}))
+        if cls.BOTH_SIDES:
+            helper = Path(claude, "helper.sh"); helper.write_text("#!/bin/sh\necho not-a-real-key\n"); helper.chmod(0o700)
+            Path(claude, "settings.json").write_text(json.dumps({"apiKeyHelper": str(helper)}))
+        else:
+            Path(claude, "settings.json").write_text(json.dumps({}))   # the login alone: one billing to choose from
         home = os.path.join(cls.lab, "home"); os.makedirs(home, exist_ok=True)
         Path(home, ".claude.json").write_text(json.dumps({"oauthAccount": {"accountUuid": "11111111-2222-3333-4444-555555555555",
                                                                              "emailAddress": "user@example.com", "organizationName": "Example"}}))
@@ -277,7 +311,7 @@ class ServedTabTipTones(unittest.TestCase):
         out = os.path.join(cls.lab, "result.json")
         with open(cfg, "w") as f:
             json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (cls.port, cls.token), "count": len(NAMES), "out": out, "sidWeb": SIDS["web"],
-                       "shots": os.environ.get("BILLING_FLYOUT_SHOTS", "")}, f)
+                       "shots": (os.environ.get("BILLING_FLYOUT_SHOTS", "") + ("" if cls.BOTH_SIDES else "-oneside")) if os.environ.get("BILLING_FLYOUT_SHOTS") else ""}, f)
         driver = os.path.join(cls.lab, "driver.mjs")
         with open(driver, "w") as f:
             f.write(DRIVER)
@@ -301,54 +335,79 @@ class ServedTabTipTones(unittest.TestCase):
         self.assertTrue(r["hover"]["opened"], "the flyout opened on hover, no click (the Tags flyout's gesture, T380): " + json.dumps(r["hover"]))
         self.assertLess(r["hover"]["ms"], 1200, "within the intent window: " + json.dumps(r["hover"]))
 
-    def test_leaving_closes_the_flyout_and_keeps_the_menu_and_escape_closes_both(self):
+    def test_leaving_closes_the_flyout_and_its_submenu_and_keeps_the_menu_and_escape_closes_all(self):
         r = self._run()
-        self.assertEqual(r["afterLeave"], {"fly": False, "menu": True}, "leaving the row and the flyout closes the flyout, the menu stays: " + json.dumps(r["afterLeave"]))
+        self.assertEqual(r["afterLeave"], {"fly": False, "sub": False, "menu": True}, "leaving the row and the flyout closes the flyout and its submenu, the menu stays: " + json.dumps(r["afterLeave"]))
         self.assertEqual(r["afterEscape"], {"fly": False, "menu": False}, "Escape closes the menu and the flyout with it: " + json.dumps(r["afterEscape"]))
 
-    def test_the_default_group_lists_the_same_choices_with_the_machine_default_marked(self):
+    def test_the_flyout_lists_the_picks_then_a_rule_and_one_set_default_billing_entry_with_no_sub_line(self):
         r = self._run()
         f = r["fly"]
         self.assertIsNotNone(f, "the flyout was read")
         table = "\n  " + json.dumps(f)
         self.assertEqual([c["text"].split(" (")[0] for c in f["choices"]], ["Login", "API key"], table)
-        self.assertTrue(f["sep"], "a divider before the group" + table)
-        self.assertEqual(f["head"], "Default for this machine", table)
-        self.assertIn("new and unpicked sessions follow it", f["note"] or "", "the note says which sessions it affects (the automatic rule before any explicit default)" + table)
-        self.assertEqual([x["text"].split(" (")[0] for x in f["radios"]], ["Login", "API key", "Automatic"], "the same choices as radios, then Automatic (the helper rule)" + table)
-        self.assertTrue(all(x["scope"] == "machine" for x in f["radios"]), table)
-        self.assertEqual([x["current"] for x in f["radios"]], [False, False, True], "no explicit default yet: Automatic is marked" + table)
-        self.assertIn("automatic:", f["note"], "the sub-line says the helper rule holds" + table)
-        self.assertEqual(f["radios"][2]["text"], "Automatic (API key)", "and what it resolves to on this machine" + table)
-        self.assertLessEqual(f["rect"]["w"], 380, "a menu's width, not a paragraph's (review: 585 px)" + table)
-        self.assertFalse(any(x["disabled"] for x in f["radios"]), "both sides are available on this machine" + table)
+        self.assertEqual(f["lines"][2:], ["---", "[set default]"], "below the picks: a rule, then the ONE entry, nothing else" + table)
+        self.assertEqual(f["entry"]["label"], "Set default billing", table)
+        self.assertEqual(f["entry"]["caret"], "▸", "the entry opens a further submenu: its caret says so" + table)
+        self.assertEqual(f["subLines"], 0, "no sub-line under anything (the user: self-explanatory)" + table)
+        self.assertEqual((f["heads"], f["radios"]), (0, 0), "the Default group's head and radios are gone" + table)
+        self.assertFalse(any(c["disabled"] for c in f["choices"]), "both sides are available on this machine" + table)
         self.assertEqual(f["subLine"], "API key", "web follows the automatic default: the key (the helper)" + table)
+        self.assertLessEqual(f["rect"]["w"], 380, "a menu's width" + table)
 
-    def test_a_default_pick_writes_the_seed_and_touches_no_session(self):
+    def test_the_entry_opens_a_nested_submenu_by_hover_holding_the_same_entries_none_marked_while_automatic(self):
+        r = self._run()
+        self.assertTrue(r["subOpen"]["found"] and r["subOpen"]["byHover"], "the nested submenu opened on hover over the entry (the same road): " + json.dumps(r["subOpen"]))
+        f = r["withSub"]
+        table = "\n  " + json.dumps(f)
+        self.assertIsNotNone(f["sub"], "the submenu was read" + table)
+        self.assertTrue(f["sub"]["inside"], "appended inside the Billing flyout: leaving both closes both" + table)
+        items = [i for i in f["sub"]["items"] if not i.get("sep")]
+        self.assertEqual([i["text"] for i in items], [c["text"] for c in f["choices"]], "exactly the list's entries, in its order" + table)
+        self.assertTrue(all(i["scope"] == "machine" for i in items), table)
+        self.assertEqual([i["current"] for i in items], [False, False], "no explicit default yet: nothing is check-marked" + table)
+        self.assertTrue(all(i["check"] in ("none", "normal", "") or i["checkW"] == 0 for i in items), "…and no check mark is painted (the computed ::after)" + table)
+        self.assertFalse(any(i.get("sep") for i in f["sub"]["items"]), "no rule and no Automatic while the default is automatic already" + table)
+        self.assertEqual(f["subLines"], 0, "no sub-line in the submenu either" + table)
+        er, sr = f["entry"]["rect"], f["sub"]["rect"]
+        self.assertTrue(sr["left"] >= er["right"] - 0.5 or sr["right"] <= er["left"] + 0.5 or sr["top"] >= er["bottom"] - 0.5 or sr["bottom"] <= er["top"] + 0.5,
+                        "placed beside (or below, or above) its entry, never over it" + table)
+        self.assertLessEqual(abs(sr["top"] - er["top"]), 2, "beside: its top aligned to the entry's row" + table)
+
+    def test_a_default_pick_in_the_submenu_writes_the_seed_touches_no_session_and_marks_itself_with_automatic_behind_a_rule(self):
         r = self._run()
         self.assertTrue(r["pick"]["found"] and not r["pick"]["disabled"], json.dumps(r["pick"]))
         self.assertTrue(r["pick"]["menuGone"], "the pick dismisses the menu")
-        d = json.loads(Path(self.state, "sdk-defaults.json").read_text())
-        self.assertEqual((d.get("auth"), d.get("authExplicit")), ("login", True), "the machine default, explicit: " + json.dumps(d))
+        a = r["afterPick"]
+        self.assertIsNotNone(a and a["sub"], "the submenu was read again after the pick")
+        table = "\n  " + json.dumps(a)
+        self.assertTrue((a["subLine"] or "").startswith("Login"), "web (no pick of its own) now reads the login, at once" + table)
+        self.assertEqual([c["current"] for c in a["choices"]], [True, False], "…and its own choice marks the login it follows" + table)
+        items = a["sub"]["items"]
+        self.assertEqual([i.get("text", "---") for i in items], [a["choices"][0]["text"], "API key", "---", "Automatic"], "the list, then the rule, then Automatic at the END" + table)
+        self.assertEqual([i.get("current") for i in items if not i.get("sep")], [True, False, False], "the explicit Login default wears the check" + table)
+        self.assertEqual(items[0]["check"], '"✓"', "the check mark is the painted pseudo-element" + table)
+        self.assertGreater(items[0]["checkW"], 0, table)
+        self.assertTrue(items[3]["auto"], table)
+        self.assertEqual(a["subLines"], 0, "Automatic carries no sub-line" + table)
         api = json.loads(Path(self.state, "sdk", SIDS["api"] + ".json").read_text())
         self.assertEqual(api.get("auth"), "key", "a session with its own pick is untouched")
         web = json.loads(Path(self.state, "sdk", SIDS["web"] + ".json").read_text())
         self.assertNotIn("auth", web, "a session that follows the default carries no pick of its own; it takes the new side at its next launch")
-        # the review's shape: an unpicked session FOLLOWS the default at once, in its status and the flyout's marks
-        a = r["afterPick"]
-        self.assertIsNotNone(a, "the flyout was read again after the pick")
-        table = "\n  " + json.dumps(a)
-        # the review's medium first: an unpicked session FOLLOWS the default at once (its status, the flyout's marks)
-        self.assertTrue((a["subLine"] or "").startswith("Login"), "web (no pick of its own) now reads the login, at once" + table)
-        self.assertEqual([c["current"] for c in a["choices"]], [True, False], "…and its own choice marks the login it follows" + table)
-        self.assertEqual([x["current"] for x in a["radios"]], [True, False, False], "the Login default is marked, Automatic no longer" + table)
-        self.assertIn("set here:", a["note"], "the sub-line says the default is explicit" + table)
-        self.assertIn("own pick stays", a["note"], table)
+        # then Automatic: the way back clears the explicit default, and the submenu marks nothing and offers no Automatic
+        c = r["autoClick"]
+        self.assertTrue(c["found"] and c["behindRule"] and c["last"] and c["menuGone"], json.dumps(c))
+        d = json.loads(Path(self.state, "sdk-defaults.json").read_text())
+        self.assertEqual((d.get("auth"), d.get("authExplicit")), ("", False), "the seed and the flag cleared: " + json.dumps(d))
+        z = r["afterAuto"]
+        self.assertEqual([i.get("current") for i in z["sub"]["items"] if not i.get("sep")], [False, False], "\n  " + json.dumps(z))
+        self.assertFalse(any(i.get("sep") for i in z["sub"]["items"]), "no Automatic while the default is automatic" + "\n  " + json.dumps(z))
+        self.assertEqual(z["subLine"], "API key", "web follows the helper rule again")
 
-    def test_in_a_narrow_or_short_window_the_flyout_stays_inside_the_viewport_and_never_covers_its_row_while_a_place_exists(self):
+    def test_in_a_narrow_or_short_window_both_levels_stay_inside_the_viewport_and_the_flyout_never_covers_its_row_while_a_place_exists(self):
         r = self._run()
         for size, f in r["narrow"].items():
-            table = "\n  %s: %s" % (size, json.dumps(f)[:800])
+            table = "\n  %s: %s" % (size, json.dumps(f)[:900])
             self.assertIsNotNone(f, table)
             self.assertGreaterEqual(f["rect"]["left"], 8 - 0.5, "inside the viewport, left" + table)
             self.assertLessEqual(f["rect"]["right"], f["viewport"] - 8 + 0.5, "inside the viewport, right" + table)
@@ -366,6 +425,48 @@ class ServedTabTipTones(unittest.TestCase):
                 self.assertTrue(below, "below the row when it fits there (review: the clamp pulled it back over the row)" + table)
             elif fits_above and not beside:
                 self.assertTrue(above, "above the row's top when below does not fit" + table)
+            if f["sub"]:
+                sr = f["sub"]["rect"]
+                self.assertGreaterEqual(sr["left"], 8 - 0.5, "the nested submenu inside the viewport too" + table)
+                self.assertLessEqual(sr["right"], f["viewport"] - 8 + 0.5, table)
+                self.assertGreaterEqual(sr["top"], -0.5, table)
+                self.assertLessEqual(sr["bottom"], f["viewportH"] + 0.5, table)
+
+
+class ServedBillingFlyoutOneSide(ServedBillingFlyout):
+    """The same lab on a machine with NO apiKeyHelper: one billing to choose from, so neither the rule nor the entry."""
+    BOTH_SIDES = False
+    result = None
+
+    def test_hovering_the_billing_row_opens_the_flyout_without_a_click(self):
+        super().test_hovering_the_billing_row_opens_the_flyout_without_a_click()
+
+    def test_leaving_closes_the_flyout_and_its_submenu_and_keeps_the_menu_and_escape_closes_all(self):
+        super().test_leaving_closes_the_flyout_and_its_submenu_and_keeps_the_menu_and_escape_closes_all()
+
+    def test_the_flyout_lists_the_picks_then_a_rule_and_one_set_default_billing_entry_with_no_sub_line(self):
+        r = self._run()
+        f = r["fly"]
+        table = "\n  " + json.dumps(f)
+        self.assertEqual([c["text"].split(" (")[0] for c in f["choices"]], ["Login", "API key"], "both sides still listed" + table)
+        self.assertEqual([c["disabled"] for c in f["choices"]], [False, True], "the key greyed: no apiKeyHelper here" + table)
+        self.assertIn("apiKeyHelper", f["choices"][1]["title"], "with the reason in its hover" + table)
+        self.assertEqual(f["lines"], [c["text"] for c in f["choices"]], "one billing to choose from: no rule, no Set default billing entry" + table)
+        self.assertFalse(f["sep"], table)
+        self.assertIsNone(f["entry"], table)
+        self.assertEqual(f["subLines"], 0, table)
+
+    def test_the_entry_opens_a_nested_submenu_by_hover_holding_the_same_entries_none_marked_while_automatic(self):
+        r = self._run()
+        self.assertFalse(r["subOpen"]["found"], "no entry, so nothing to open: " + json.dumps(r["subOpen"]))
+
+    def test_a_default_pick_in_the_submenu_writes_the_seed_touches_no_session_and_marks_itself_with_automatic_behind_a_rule(self):
+        r = self._run()
+        self.assertFalse(r["pick"]["found"], "no submenu to pick from: " + json.dumps(r["pick"]))
+        self.assertFalse(os.path.exists(os.path.join(self.state, "sdk-defaults.json")), "nothing wrote a seed")
+
+    def test_in_a_narrow_or_short_window_both_levels_stay_inside_the_viewport_and_the_flyout_never_covers_its_row_while_a_place_exists(self):
+        super().test_in_a_narrow_or_short_window_both_levels_stay_inside_the_viewport_and_the_flyout_never_covers_its_row_while_a_place_exists()
 
 
 if __name__ == "__main__":

--- a/tests/test_billing_flyout_browser.py
+++ b/tests/test_billing_flyout_browser.py
@@ -97,7 +97,12 @@ const readFly = () => page.evaluate(() => {
   const rowEl = document.querySelector(".ctx-menu .ctx-item-billing"); const rr = rowEl ? rect(rowEl) : null;
   return { lines, choices, sep: kids.some((k) => k.classList.contains("ctx-sep")), subLines: fly.querySelectorAll(".ctx-item-sub").length,
     heads: fly.querySelectorAll(".ctx-sub-head").length, radios: fly.querySelectorAll(".ctx-radio").length,
-    entry: entry ? { label: entry.querySelector(".ctx-item-label").textContent, caret: (entry.querySelector(".ctx-caret") || {}).textContent || "", rect: rect(entry) } : null,
+    entry: entry ? { label: entry.querySelector(".ctx-item-label").textContent, caret: (entry.querySelector(".ctx-caret") || {}).textContent || "", rect: rect(entry),
+                     caretInset: entry.querySelector(".ctx-caret") ? rect(entry).right - rect(entry.querySelector(".ctx-caret")).right : null } : null,
+    rowCaretInset: (rowEl && rowEl.querySelector(".ctx-caret")) ? rect(rowEl).right - rect(rowEl.querySelector(".ctx-caret")).right : null,
+    fontPx: { menu: rowEl ? parseFloat(getComputedStyle(rowEl).fontSize) : null,
+              fly: kids.filter((k) => k.classList.contains("ctx-item")).length ? parseFloat(getComputedStyle(kids.filter((k) => k.classList.contains("ctx-item"))[0]).fontSize) : null,
+              sub: (d && d.querySelector(".ctx-item")) ? parseFloat(getComputedStyle(d.querySelector(".ctx-item")).fontSize) : null },
     sub: d ? { items: readSub(d), rect: rect(d), inside: d.parentElement === fly } : null,
     rect: rect(fly), subLine: row ? row.textContent : null, rowRect: rr, viewport: window.innerWidth, viewportH: window.innerHeight };
 });
@@ -374,6 +379,17 @@ class ServedBillingFlyout(unittest.TestCase):
                         "placed beside (or below, or above) its entry, never over it" + table)
         self.assertLessEqual(abs(sr["top"] - er["top"]), 2, "beside: its top aligned to the entry's row" + table)
 
+    def test_the_nested_submenu_keeps_the_flyouts_row_size_and_its_entrys_caret_lines_up_with_the_billing_rows(self):
+        """Round one: .ctx-menu's 0.92em compounded at the third level (11.0 px against 10.1 px), and the entry's caret sat about
+        16 px further in than the Billing and Tags carets (the check-mark room). Measured, never read."""
+        f = self._run()["withSub"]
+        table = "\n  " + json.dumps(f["fontPx"]) + " " + json.dumps({"entry": f["entry"]["caretInset"], "row": f["rowCaretInset"]})
+        self.assertIsNotNone(f["sub"], "the submenu was read")
+        self.assertAlmostEqual(f["fontPx"]["sub"], f["fontPx"]["fly"], delta=0.05, msg="the nested level's rows are the flyout's size" + table)
+        self.assertLess(f["fontPx"]["fly"], f["fontPx"]["menu"], "the flyout is a menu inside a menu (0.92em once), as on main" + table)
+        self.assertIsNotNone(f["entry"]["caretInset"]); self.assertIsNotNone(f["rowCaretInset"])
+        self.assertAlmostEqual(f["entry"]["caretInset"], f["rowCaretInset"], delta=1, msg="the Set default billing caret sits where the Billing row's does" + table)
+
     def test_a_default_pick_in_the_submenu_writes_the_seed_touches_no_session_and_marks_itself_with_automatic_behind_a_rule(self):
         r = self._run()
         self.assertTrue(r["pick"]["found"] and not r["pick"]["disabled"], json.dumps(r["pick"]))
@@ -459,6 +475,9 @@ class ServedBillingFlyoutOneSide(ServedBillingFlyout):
     def test_the_entry_opens_a_nested_submenu_by_hover_holding_the_same_entries_none_marked_while_automatic(self):
         r = self._run()
         self.assertFalse(r["subOpen"]["found"], "no entry, so nothing to open: " + json.dumps(r["subOpen"]))
+
+    def test_the_nested_submenu_keeps_the_flyouts_row_size_and_its_entrys_caret_lines_up_with_the_billing_rows(self):
+        self.assertIsNone(self._run()["withSub"]["entry"], "one billing to choose from: no entry, so nothing to measure")
 
     def test_a_default_pick_in_the_submenu_writes_the_seed_touches_no_session_and_marks_itself_with_automatic_behind_a_rule(self):
         r = self._run()

--- a/ui/webview/billing-flyout.test.ts
+++ b/ui/webview/billing-flyout.test.ts
@@ -114,7 +114,7 @@ test("the Set default billing entry opens a nested submenu INSIDE the flyout hol
 });
 
 test("an explicit default is check-marked in the nested submenu, and Automatic sits at the END behind its own rule; the marked entry posts nothing, Automatic posts auto", () => {
-  const { sub, posted } = lift({ login: true, key: true, default: "login", defaultExplicit: true }, "", "");
+  const { sub, posted, dismissed } = lift({ login: true, key: true, default: "login", defaultExplicit: true }, "", "");
   sub.children[3].fire("click");
   const d = sub.querySelector(".ctx-sub-default")!;
   assert.deepEqual(lines(d), ["Login", "API key", "---", "Automatic"]);
@@ -122,6 +122,7 @@ test("an explicit default is check-marked in the nested submenu, and Automatic s
   assert.equal(subLines(d), 0, "Automatic carries no sub-line either");
   d.children[0].fire("click");
   assert.deepEqual(posted, [], "the current default posts nothing");
+  assert.equal(dismissed.length, 1, "…and dismisses the menu, as the picks list does on its current entry (review)");
   d.children[3].fire("click");
   assert.deepEqual(posted, [{ type: "setAuth", id: "11111111-2222-3333-4444-555555555555", value: "auto", scope: "machine" }], "Automatic clears the explicit default (the helper rule again)");
 });
@@ -140,13 +141,22 @@ test("an older kernel that does not say whether the default is explicit shows no
   assert.equal(sub.querySelectorAll(".ctx-item-setdefault").length, 0);
 });
 
-test("the session's own pick list is unchanged: the current pick marked, a click posts an unscoped setAuth, a disabled entry posts nothing", () => {
-  const { sub, posted } = lift({ login: false, loginWhy: "no Claude login signed in on this machine", key: true, default: "key", defaultExplicit: false }, "key", "");
+test("the session's own pick list is unchanged: the current pick marked, a disabled entry posts nothing, the current pick dismisses and posts nothing", () => {
+  const { sub, posted, dismissed } = lift({ login: false, loginWhy: "no Claude login signed in on this machine", key: true, default: "key", defaultExplicit: false }, "key", "");
   assert.deepEqual(sub.children.map((c) => has(c, "current")), [false, true]);
   sub.children[0].fire("click");
   assert.deepEqual(posted, []);
+  assert.equal(dismissed.length, 0, "a disabled entry leaves the menu up");
   sub.children[1].fire("click");
   assert.deepEqual(posted, [], "the current pick posts nothing");
+  assert.equal(dismissed.length, 1, "…and dismisses");
+});
+
+test("an available, non-current pick posts the per-session setAuth with NO scope key, and dismisses", () => {
+  const { sub, posted, dismissed } = lift(BOTH, "key", "user@example.com");
+  sub.children[0].fire("click");
+  assert.deepEqual(posted, [{ type: "setAuth", id: "11111111-2222-3333-4444-555555555555", value: "login" }], "the session switcher: id and value, no scope");
+  assert.equal(dismissed.length, 1);
 });
 
 test("source: ONE entry-list function feeds both menus, both flyouts ride wireFlyout and the shared placement rule", () => {
@@ -168,4 +178,17 @@ test("styles: the head and note rules are gone; both flyouts keep a menu's width
   assert.doesNotMatch(CSS, /\.ctx-sub-head/, "no group head any more");
   assert.match(CSS, /^\.ctx-sub-billing, \.ctx-sub-default \{ max-width: 22em; \}/m);
   assert.match(CSS, /^\.ctx-sub-billing \.ctx-item, \.ctx-sub-default \.ctx-item \{ overflow: hidden; text-overflow: ellipsis; \}/m);
+  // the review: the nested level keeps the flyout's row size (0.92em compounded once more before), and the entry's caret lines
+  // up with the Billing and Tags carets (no check-mark room on a row that opens a submenu)
+  assert.match(CSS, /^\.ctx-sub-default \{ font-size: 1em; \}/m);
+  assert.match(CSS, /^\.ctx-sub\.ctx-sub-billing > \.ctx-item\.ctx-item-setdefault \{ padding-right: 10px; \}/m);
+  // the tiebreak, computed (the lightbox bar's lesson): the caret rule must outrank the generic .ctx-sub .ctx-item padding, which
+  // comes later in the sheet and would win a tie
+  const spec = (sel: string): [number, number, number] => [(sel.match(/#[\w-]+/g) || []).length, (sel.match(/\.[\w-]+|\[[^\]]+\]|:(?!:)[\w-]+(\([^)]*\))?/g) || []).length,
+    (sel.replace(/#[\w-]+|\.[\w-]+|\[[^\]]+\]|::?[\w-]+(\([^)]*\))?/g, " ").match(/(^|\s)[a-zA-Z][\w-]*/g) || []).length];
+  const wins = (a: number[], b: number[]) => a[0] !== b[0] ? a[0] > b[0] : a[1] !== b[1] ? a[1] > b[1] : a[2] > b[2];
+  const caretRule = (CSS.match(/^([^{}\n]*ctx-item-setdefault[^{}\n]*)\{ padding-right: 10px; \}/m) || [])[1];
+  const genericRule = (CSS.match(/^([^{}\n]*)\{ padding-right: 26px; position: relative; \}/m) || [])[1];
+  assert.ok(caretRule && genericRule, "both padding rules found");
+  assert.ok(wins(spec(caretRule.trim()), spec(genericRule.trim())), "the caret rule outranks the generic submenu padding: " + caretRule + " vs " + genericRule);
 });

--- a/ui/webview/billing-flyout.test.ts
+++ b/ui/webview/billing-flyout.test.ts
@@ -1,0 +1,171 @@
+// The tab menu's Billing flyout takes the user's shape (T387, the user 2026-09-12): the session's billings to pick from,
+// then, only when there is more than one to choose from, a rule and ONE entry, Set default billing, which opens a
+// further submenu holding exactly the same entries with the machine's default check-marked; a click sets the default;
+// no sub-line anywhere. An Automatic way back to the helper rule sits at the END of that submenu behind its own rule,
+// only while an explicit default stands (the manager's call for the user, to be vetoed there). render.ts has
+// import-time DOM side effects, so openBillingFly is LIFTED (esbuild's ts loader, the browse-route idiom) with the
+// real billingChoices, placeFlyBeside and wireFlyout beside it, and run on a tiny DOM whose handlers can be fired.
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { createRequire } from "node:module";
+
+const requireCjs = createRequire(__filename);
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const ts = (code: string): string => requireCjs("esbuild").transformSync(code, { loader: "ts" }).code;
+
+type El = {
+  tag: string; className: string; textContent: string; title: string; children: El[]; parent: El | null; dataset: Record<string, string>;
+  attrs: Record<string, string>; style: Record<string, string>; handlers: Record<string, Array<(ev: unknown) => void>>;
+  classList: { add: (...c: string[]) => void; remove: (...c: string[]) => void; contains: (c: string) => boolean };
+  appendChild: (c: El) => El; append: (...c: El[]) => void; remove: () => void; setAttribute: (k: string, v: string) => void;
+  addEventListener: (t: string, fn: (ev: unknown) => void) => void; querySelector: (sel: string) => El | null; querySelectorAll: (sel: string) => El[];
+  getBoundingClientRect: () => { left: number; right: number; top: number; bottom: number; width: number; height: number }; fire: (t: string) => void;
+};
+function has(e: El, cls: string): boolean { return e.className.split(/\s+/).includes(cls); }
+function matches(e: El, sel: string): boolean {
+  // selectors the flyout code uses: ".a", ".a.b" and ".a .b" (descendant: matched by the caller walking)
+  return sel.split(".").filter(Boolean).every((c) => has(e, c));
+}
+function walk(e: El, out: El[] = []): El[] { for (const c of e.children) { out.push(c); walk(c, out); } return out; }
+function mkEl(tag: string, cls = ""): El {
+  const e: El = {
+    tag, className: cls, textContent: "", title: "", children: [], parent: null, dataset: {}, attrs: {}, style: {}, handlers: {},
+    classList: {
+      add: (...c) => { const s = new Set(e.className.split(/\s+/).filter(Boolean)); c.forEach((x) => s.add(x)); e.className = [...s].join(" "); },
+      remove: (...c) => { e.className = e.className.split(/\s+/).filter((x) => x && !c.includes(x)).join(" "); },
+      contains: (c) => has(e, c),
+    },
+    appendChild: (c) => { e.children.push(c); c.parent = e; return c; },
+    append: (...cs) => { cs.forEach((c) => e.appendChild(c)); },
+    remove: () => { const p = e.parent; if (p) { p.children.splice(p.children.indexOf(e), 1); e.parent = null; } },
+    setAttribute: (k, v) => { e.attrs[k] = v; },
+    addEventListener: (t, fn) => { (e.handlers[t] = e.handlers[t] || []).push(fn); },
+    querySelector: (sel) => { const parts = sel.trim().split(/\s+/); if (parts.length === 1) return walk(e).find((c) => matches(c, sel)) || null;
+      const outer = walk(e).filter((c) => matches(c, parts[0])); for (const o of outer) { const inner = walk(o).find((c) => matches(c, parts[1])); if (inner) return inner; } return null; },
+    querySelectorAll: (sel) => walk(e).filter((c) => matches(c, sel)),
+    getBoundingClientRect: () => ({ left: 300, right: 460, top: 200, bottom: 224, width: 160, height: 24 }),
+    fire: (t) => { for (const fn of e.handlers[t] || []) fn({ stopPropagation: () => {}, preventDefault: () => {} }); },
+  };
+  return e;
+}
+function lines(e: El): string[] { return e.children.map((c) => has(c, "ctx-sep") ? "---" : (c.textContent || c.querySelector(".ctx-item-label")?.textContent || "")); }
+function subLines(e: El): number { return e.querySelectorAll(".ctx-item-sub").length; }
+
+type Avail = { login?: boolean; key?: boolean; loginWhy?: string; keyWhy?: string; default?: string; defaultExplicit?: boolean };
+function lift(avail: Avail, auth = "", acct = "") {
+  const a = RENDER.indexOf("    const openBillingFly = (): HTMLElement | null => {");
+  const b = RENDER.indexOf('    wireFlyout(menu, item, ".ctx-sub-billing"', a);
+  assert.ok(a > 0 && b > a, "openBillingFly: anchors not found; re-anchor");
+  const helpers = ["function billingChoices(", "function placeFlyBeside(", "function wireFlyout("].map((anchor) => {
+    const h = RENDER.indexOf(anchor); if (h < 0) return "";
+    return RENDER.slice(h, RENDER.indexOf("\n}\n", h) + 2);
+  }).join("\n");
+  const code = ts(helpers + "\nconst HOVER_INTENT_MS = 120;\n" + RENDER.slice(a, b) + "\nreturn openBillingFly;");
+  const posted: unknown[] = []; const dismissed: number[] = [];
+  const menu = mkEl("div", "ctx-menu"); const item = mkEl("div", "ctx-item ctx-item-toggle ctx-item-billing"); menu.appendChild(item);
+  const H = { st: { auth, authAcct: acct }, avail, id: "11111111-2222-3333-4444-555555555555", posted, dismissed };
+  const prelude = `
+    const el = (tag, cls) => mkEl(tag, cls || "");
+    const st = H.st, avail = H.avail, id = H.id;
+    const hostOf = () => "";
+    const dismissTabMenu = () => { H.dismissed.push(1); };
+    const vscodeApi = { postMessage: (m) => { H.posted.push(m); } };
+    const window = { innerWidth: 1100, innerHeight: 700, setTimeout: (fn) => { fn(); return 1; }, clearTimeout: () => {} };
+    const clearTimeout = window.clearTimeout;
+  `;
+  const open = (new Function("H", "mkEl", "menu", "item", prelude + code) as (h: unknown, m: typeof mkEl, me: El, it: El) => () => El | null)(H, mkEl, menu, item);
+  const sub = open();
+  assert.ok(sub, "the flyout opened");
+  return { sub: sub!, menu, item, posted, dismissed };
+}
+const BOTH = { login: true, key: true, default: "key", defaultExplicit: false };
+
+test("both billings pickable, no explicit default: the picks, a rule, ONE Set default billing entry, and no sub-line anywhere", () => {
+  const { sub } = lift(BOTH, "", "user@example.com");
+  assert.deepEqual(lines(sub), ["Login (user@example.com)", "API key", "---", "Set default billing"]);
+  assert.equal(subLines(sub), 0, "no sub-line under anything: the entries are self-explanatory");
+  const entry = sub.children[3];
+  assert.ok(has(entry, "ctx-item-setdefault") && has(entry, "ctx-item"), entry.className);
+  assert.equal(entry.querySelector(".ctx-caret")?.textContent, "▸", "the entry opens a further submenu: the caret says so");
+  assert.equal(sub.querySelectorAll(".ctx-radio").length, 0, "the radio group is gone");
+  assert.equal(sub.querySelectorAll(".ctx-sub-head").length, 0, "…and its head with the note");
+});
+
+test("the Set default billing entry opens a nested submenu INSIDE the flyout holding exactly the list's entries, none marked before an explicit default", () => {
+  const { sub, posted, dismissed } = lift(BOTH, "key", "user@example.com");
+  const entry = sub.children[3];
+  entry.fire("click");
+  const d = sub.querySelector(".ctx-sub-default");
+  assert.ok(d, "the nested submenu is appended inside the Billing flyout, so leaving both closes both");
+  assert.ok(has(d!, "ctx-sub") && has(d!, "ctx-menu"), d!.className);
+  assert.deepEqual(lines(d!), ["Login (user@example.com)", "API key"], "the same entries as the list above, in the same order");
+  assert.deepEqual(d!.children.map((c) => has(c, "current")), [false, false], "no explicit default: nothing is check-marked");
+  assert.equal(d!.querySelectorAll(".ctx-sep").length, 0, "no Automatic and no rule while the default is automatic already");
+  assert.equal(subLines(d!), 0);
+  assert.ok(d!.children.every((c) => c.dataset.scope === "machine"));
+  d!.children[0].fire("click");
+  assert.deepEqual(posted, [{ type: "setAuth", id: "11111111-2222-3333-4444-555555555555", value: "login", scope: "machine" }], "a click sets the machine default");
+  assert.equal(dismissed.length, 1, "and closes the menu");
+  assert.ok(d!.style.left && d!.style.top, "placed beside its row by the shared placement rule");
+  assert.ok(sub.style.left && sub.style.top);
+});
+
+test("an explicit default is check-marked in the nested submenu, and Automatic sits at the END behind its own rule; the marked entry posts nothing, Automatic posts auto", () => {
+  const { sub, posted } = lift({ login: true, key: true, default: "login", defaultExplicit: true }, "", "");
+  sub.children[3].fire("click");
+  const d = sub.querySelector(".ctx-sub-default")!;
+  assert.deepEqual(lines(d), ["Login", "API key", "---", "Automatic"]);
+  assert.deepEqual(d.children.map((c) => has(c, "current")), [true, false, false, false], "the explicit default wears the check");
+  assert.equal(subLines(d), 0, "Automatic carries no sub-line either");
+  d.children[0].fire("click");
+  assert.deepEqual(posted, [], "the current default posts nothing");
+  d.children[3].fire("click");
+  assert.deepEqual(posted, [{ type: "setAuth", id: "11111111-2222-3333-4444-555555555555", value: "auto", scope: "machine" }], "Automatic clears the explicit default (the helper rule again)");
+});
+
+test("one billing to choose from (the other side unavailable here): no rule, no Set default billing entry; the unavailable side still listed, greyed", () => {
+  const { sub } = lift({ login: true, key: false, keyWhy: "no apiKeyHelper configured", default: "login", defaultExplicit: false }, "", "");
+  assert.deepEqual(lines(sub), ["Login", "API key"]);
+  assert.ok(has(sub.children[1], "disabled") && sub.children[1].title === "no apiKeyHelper configured");
+  assert.equal(sub.querySelectorAll(".ctx-sep").length, 0);
+  assert.equal(sub.querySelectorAll(".ctx-item-setdefault").length, 0);
+});
+
+test("an older kernel that does not say whether the default is explicit shows no Set default billing entry", () => {
+  const { sub } = lift({ login: true, key: true, default: "key" }, "", "");
+  assert.deepEqual(lines(sub), ["Login", "API key"]);
+  assert.equal(sub.querySelectorAll(".ctx-item-setdefault").length, 0);
+});
+
+test("the session's own pick list is unchanged: the current pick marked, a click posts an unscoped setAuth, a disabled entry posts nothing", () => {
+  const { sub, posted } = lift({ login: false, loginWhy: "no Claude login signed in on this machine", key: true, default: "key", defaultExplicit: false }, "key", "");
+  assert.deepEqual(sub.children.map((c) => has(c, "current")), [false, true]);
+  sub.children[0].fire("click");
+  assert.deepEqual(posted, []);
+  sub.children[1].fire("click");
+  assert.deepEqual(posted, [], "the current pick posts nothing");
+});
+
+test("source: ONE entry-list function feeds both menus, both flyouts ride wireFlyout and the shared placement rule", () => {
+  const a = RENDER.indexOf("    const openBillingFly = (): HTMLElement | null => {");
+  const BILL = RENDER.slice(a, RENDER.indexOf('    wireFlyout(menu, item, ".ctx-sub-billing"', a));
+  assert.match(RENDER, /^function billingChoices\(st: Status, avail: AuthAvail\): Array<\{ label: string; value: string; why: string \}> \{/m);
+  assert.equal((BILL.match(/billingChoices\(/g) || []).length, 1, "one call; the nested submenu iterates the SAME array");
+  assert.match(BILL, /const choices = billingChoices\(st, avail\);/);
+  assert.match(BILL, /const pickable = choices\.filter\(\(c\) => !c\.why\);\s*\n\s*if \(pickable\.length > 1 && avail\.default && avail\.defaultExplicit !== undefined\) \{/, "the rule and the entry only with more than one billing to choose from, from a kernel that reports the flag");
+  assert.match(BILL, /wireFlyout\(sub, setDef, "\.ctx-sub-default", \(\) => openDefaultFly\(\)\);/, "the nested level rides the same hover-intent road, scoped to the Billing flyout");
+  assert.match(BILL, /placeFlyBeside\(setDef, d\);/); assert.match(BILL, /placeFlyBeside\(item, sub\);/);
+  assert.match(RENDER, /^function placeFlyBeside\(anchor: HTMLElement, fly: HTMLElement\): void \{/m);
+  assert.doesNotMatch(BILL, /ctx-sub-head|ctx-radio|autoWord|machineChoices|Default for /, "the Default group, its head, note and radios are gone");
+  assert.doesNotMatch(BILL, /ctx-item-sub/, "no sub-line is built anywhere in the flyout");
+  assert.equal((RENDER.match(/type: "setAuth"/g) || []).length, 2, "two senders: the session pick and the machine default (the census in feed-cap-offer.test.ts)");
+});
+
+test("styles: the head and note rules are gone; both flyouts keep a menu's width with long labels truncating", () => {
+  assert.doesNotMatch(CSS, /\.ctx-sub-head/, "no group head any more");
+  assert.match(CSS, /^\.ctx-sub-billing, \.ctx-sub-default \{ max-width: 22em; \}/m);
+  assert.match(CSS, /^\.ctx-sub-billing \.ctx-item, \.ctx-sub-default \.ctx-item \{ overflow: hidden; text-overflow: ellipsis; \}/m);
+});

--- a/ui/webview/feed-cap-offer.test.ts
+++ b/ui/webview/feed-cap-offer.test.ts
@@ -36,7 +36,9 @@ test("only the explicit pick switches — the gesture census, both surfaces", ()
   // switches no session (it writes the seed new sessions and unpicked sessions launch on); the per-session pick stays
   // the one sender that switches a session
   assert.equal((RENDER.match(/type: "setAuth"/g) || []).length, 2, "chat: the Billing flyout's session pick and its machine-default pick");
-  assert.equal((RENDER.match(/type: "setAuth", id, value: c\.value, scope: "machine"/g) || []).length, 1, "the second sender is the machine default: scope machine, no session switched");
+  // T387: the machine-default pick moved into the Set default billing submenu, whose entries and its Automatic way back all
+  // post through ONE helper (post(value)), so the second sender reads `value`, not `c.value`; still two senders in the chat
+  assert.equal((RENDER.match(/type: "setAuth", id, value, scope: "machine"/g) || []).length, 1, "the second sender is the machine default: scope machine, no session switched");
   assert.equal((RENDER.match(/type: "setAuth", id, value: c\.value \}/g) || []).length, 1, "the per-session pick stays the one session switcher");
   assert.match(KERNEL, /a session must NEVER\s*\n\s*silently switch billing in either direction/, "the ruling, verbatim at the mint");
 });

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -7434,9 +7434,10 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
             const cur = explicit && avail.default === c.value;   // the check sits on the EXPLICIT default only; automatic marks nothing
             const opt = el("div", "ctx-item" + (cur ? " current" : "") + (c.why ? " disabled" : ""));
             opt.textContent = c.label;
-            opt.dataset.scope = "machine";
+            opt.dataset.scope = "machine";   // a MARKER for the labs and the sheet, never read for the wire: post() carries the scope
             if (c.why) { opt.title = c.why; opt.setAttribute("aria-disabled", "true"); }
-            opt.addEventListener("click", (ev2) => { ev2.stopPropagation(); if (c.why || cur) return; post(c.value); });
+            // the picks list one level up dismisses on its current entry too (review): the same gesture, the same answer, nothing posted
+            opt.addEventListener("click", (ev2) => { ev2.stopPropagation(); if (c.why) return; if (cur) { dismissTabMenu(); return; } post(c.value); });
             d.appendChild(opt);
           }
           if (explicit) {
@@ -7446,7 +7447,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
             d.appendChild(el("div", "ctx-sep"));
             const auto = el("div", "ctx-item ctx-item-auto");
             auto.textContent = "Automatic";
-            auto.dataset.scope = "machine";
+            auto.dataset.scope = "machine";   // the marker again
             auto.addEventListener("click", (ev2) => { ev2.stopPropagation(); post("auto"); });
             d.appendChild(auto);
           }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -6921,6 +6921,36 @@ function ctxIcon(kind: "feed" | "mail" | "bell" | "bill" | "folder" | "tag" | "p
   return span;
 }
 
+// The Billing flyout's ENTRY LIST (T387): one function for the session's picks and the machine-default submenu, so the
+// two menus can never list different billings. Each entry: its label (Login named by the machine's account when known,
+// the key plainly "API key", no fragment of it anywhere), the setAuth value, and why it is greyed here (a side this box
+// cannot bill, the kernel's reason) or "". When stored logins arrive (the several-logins branch) this is the function
+// that grows, and the default submenu lists them with the picks.
+function billingChoices(st: Status, avail: AuthAvail): Array<{ label: string; value: string; why: string }> {
+  return [{ label: st.authAcct ? `Login (${st.authAcct})` : "Login", value: "login", why: avail.login ? "" : (avail.loginWhy || "no Claude login signed in on this machine") },
+          { label: "API key", value: "key", why: avail.key ? "" : (avail.keyWhy || "no apiKeyHelper configured") }];
+}
+// A flyout placed beside its row (the Billing flyout and its nested default submenu, T387; the side rule the Tags flyout
+// and the model-version submenus follow): PREFER right; fall LEFT when the right edge would clip and the left has room;
+// with room on neither side (a narrow window) drop BELOW the row when it fits there, else ABOVE the row's top, and only
+// when neither fits clamp inside the viewport, never over the row while a place beside or beyond it exists (the T380
+// review: at 560 px it covered its menu and ran 33 px out; at 560 by 420 the clamp pulled the drop-below back over the
+// row). .ctx-menu is position: fixed, so the coordinates are viewport-space. The flyout is in the document already.
+function placeFlyBeside(anchor: HTMLElement, fly: HTMLElement): void {
+  const ir = anchor.getBoundingClientRect();
+  const sr = fly.getBoundingClientRect();
+  let left: number, top: number = ir.top;
+  if (ir.right + 2 + sr.width <= window.innerWidth - 8) left = Math.round(ir.right + 2);
+  else if (ir.left - 2 - sr.width >= 8) left = Math.round(ir.left) - sr.width - 2;
+  else {
+    left = Math.max(8, Math.min(Math.round(ir.left), window.innerWidth - sr.width - 8));
+    if (ir.bottom + 2 + sr.height <= window.innerHeight - 4) top = ir.bottom + 2;
+    else if (ir.top - 2 - sr.height >= 0) top = ir.top - 2 - sr.height;
+    else top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4));
+  }
+  fly.style.left = left + "px";
+  fly.style.top = Math.max(0, Math.min(top, window.innerHeight - sr.height - 4)) + "px";
+}
 // The tab menu's ONE flyout gesture (T163 for Tags, the user 2026-08-28; T380 for Billing, the user
 // 2026-09-12): a hover of HOVER_INTENT_MS over the row opens the flyout (the feed's intent debounce:
 // enough to skip a graze, never a wait), a click opens it at once (byClick: a click may focus an input,
@@ -7332,12 +7362,14 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
   // fragment of it anywhere. A pick posts the same setAuth the badge used (the session reconnects to
   // apply, so the sub-line says "applying…" while st.authPending rides the status). An older kernel
   // sends no authAvail: its authBoth keeps the old both-or-nothing gate. The flyout opens on HOVER as
-  // the Tags flyout does, and on click (T380, the user 2026-09-12: one gesture, wireFlyout), and below
-  // the session's choices carries "Default for <machine>": the same choices as a radio group, the
-  // current default marked (authAvail.default, the owning kernel's seed, so a remote session's flyout
-  // shows ITS host's default), a pick posting setAuth with scope "machine", which writes the seed every
-  // NEW session and every session with no pick of its own launches on and touches no session that
-  // carries its own pick; the group's note says exactly that.
+  // the Tags flyout does, and on click (T380, the user 2026-09-12: one gesture, wireFlyout). Below the
+  // session's choices, behind a rule, ONE entry, "Set default billing" (T387, the user 2026-09-12), opens a
+  // further submenu holding exactly the same entries with the machine's default check-marked
+  // (authAvail.default, the owning kernel's seed, so a remote session's flyout shows ITS host's default);
+  // a click there posts setAuth with scope "machine", which writes the seed every NEW session and every
+  // session with no pick of its own launches on and touches no session that carries its own pick. The
+  // rule and the entry appear only when there is more than one billing to choose from here. No sub-line
+  // under anything: the entries say what they are.
   const st = s ? s.status : null;
   if (st && st.auth && (st.authAvail || st.authBoth)) {
     const avail: AuthAvail = st.authAvail || { login: true, key: true };
@@ -7364,8 +7396,7 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
       if (already) return already as HTMLElement;
       menu.querySelector(".ctx-sub")?.remove();                    // one flyout at a time
       const sub = el("div", "ctx-menu ctx-sub ctx-sub-billing");
-      const choices = [{ label: st.authAcct ? `Login (${st.authAcct})` : "Login", value: "login", why: avail.login ? "" : (avail.loginWhy || "no Claude login signed in on this machine") },
-                       { label: "API key", value: "key", why: avail.key ? "" : (avail.keyWhy || "no apiKeyHelper configured") }];
+      const choices = billingChoices(st, avail);                  // the ONE list both menus below draw from (T387)
       for (const c of choices) {
         const opt = el("div", "ctx-item" + (st.auth === c.value ? " current" : "") + (c.why ? " disabled" : ""));
         opt.textContent = c.label;
@@ -7381,66 +7412,54 @@ function showTabMenu(e: MouseEvent, id: string, copy?: string) {   // `copy`: th
         });
         sub.appendChild(opt);
       }
-      // ── Default for this machine (T380) ── the owning kernel's seed (authAvail.default): what a NEW
-      // session, and a session with no pick of its own, launches on. The same choices as radios, the
-      // current one marked; a pick posts setAuth with scope "machine" and changes no session that carries
-      // its own pick. A remote session's flyout names ITS host, whose kernel holds the seed.
-      if (avail.default) {
+      // ── Set default billing (T387, the user 2026-09-12) ── below the picks, behind a rule, ONE entry opening a further
+      // submenu with exactly the same entries, the machine's default check-marked. Both the rule and the entry only when
+      // there is more than one billing to choose from HERE (a side this box cannot bill is not a choice), and only from a
+      // kernel that says whether the default is explicit (an older one takes no scoped "auto" and marks no default). No
+      // sub-line anywhere. The submenu rides the same hover-intent road, wired on the Billing flyout itself and appended
+      // inside it, so leaving both closes both and the menu's dismissal covers it; the same placement rule places it.
+      const pickable = choices.filter((c) => !c.why);
+      if (pickable.length > 1 && avail.default && avail.defaultExplicit !== undefined) {
         sub.appendChild(el("div", "ctx-sep"));
-        const explicit = !!avail.defaultExplicit;
-        const head = el("div", "ctx-item ctx-item-toggle ctx-sub-head");
-        const hb = el("span", "ctx-item-body");
-        const hl = el("span", "ctx-item-label"); hl.textContent = "Default for " + (hostOf(id) || "this machine"); hb.appendChild(hl);
-        const hs = el("span", "ctx-item-sub");
-        // the sub-line says which rule holds (review): set here, or automatic (the helper rule) as before
-        hs.textContent = explicit
-          ? "set here: new and unpicked sessions follow it; a session's own pick stays"
-          : "automatic: the API key when a helper is configured, else the login; new and unpicked sessions follow it";
-        hb.appendChild(hs);
-        head.appendChild(hb); sub.appendChild(head);
-        // the same choices as radios, then Automatic (the helper rule), which clears the explicit default (review: the flag
-        // was one-way and invisible); the current mark sits on the explicit side, else on Automatic
-        const autoWord = avail.key ? "API key" : "Login";
-        // an older kernel sends no defaultExplicit and takes no "auto": its flyout marks the side it computed and offers no
-        // Automatic radio (review: the click would be swallowed there)
-        const olderKernel = avail.defaultExplicit === undefined;
-        const radios = [...choices.map((c) => ({ ...c, cur: olderKernel ? avail.default === c.value : (explicit && avail.default === c.value) })),
-                        ...(olderKernel ? [] : [{ label: `Automatic (${autoWord})`, value: "auto", why: "", cur: !explicit }])];
-        for (const c of radios) {
-          const opt = el("div", "ctx-item ctx-radio" + (c.cur ? " current" : "") + (c.why ? " disabled" : ""));
-          opt.textContent = c.label;
-          opt.dataset.scope = "machine";
-          if (c.why) { opt.title = c.why; opt.setAttribute("aria-disabled", "true"); }
-          opt.addEventListener("click", (ev2) => {
-            ev2.stopPropagation();
-            if (c.why) return;
-            dismissTabMenu();
-            if (!c.cur && vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value: c.value, scope: "machine" });
-          });
-          sub.appendChild(opt);
-        }
+        const setDef = el("div", "ctx-item ctx-item-toggle ctx-item-setdefault");
+        const sl = el("span", "ctx-item-label"); sl.textContent = "Set default billing"; setDef.appendChild(sl);
+        const sc = el("span", "ctx-caret"); sc.textContent = "▸"; setDef.appendChild(sc);
+        const openDefaultFly = (): HTMLElement | null => {
+          const open = sub.querySelector(".ctx-sub-default");
+          if (open) return open as HTMLElement;
+          const explicit = !!avail.defaultExplicit;
+          const d = el("div", "ctx-menu ctx-sub ctx-sub-default");
+          const post = (value: string) => { dismissTabMenu(); if (vscodeApi) vscodeApi.postMessage({ type: "setAuth", id, value, scope: "machine" }); };
+          for (const c of choices) {
+            const cur = explicit && avail.default === c.value;   // the check sits on the EXPLICIT default only; automatic marks nothing
+            const opt = el("div", "ctx-item" + (cur ? " current" : "") + (c.why ? " disabled" : ""));
+            opt.textContent = c.label;
+            opt.dataset.scope = "machine";
+            if (c.why) { opt.title = c.why; opt.setAttribute("aria-disabled", "true"); }
+            opt.addEventListener("click", (ev2) => { ev2.stopPropagation(); if (c.why || cur) return; post(c.value); });
+            d.appendChild(opt);
+          }
+          if (explicit) {
+            // the way BACK to the helper rule once a default stands (the manager's call for the user, 2026-09-12, open to
+            // their veto): at the end, behind its own rule, only while an explicit default is set, so a set default can be
+            // cleared; the kernel's scoped "auto" (T380) clears the flag and the seed
+            d.appendChild(el("div", "ctx-sep"));
+            const auto = el("div", "ctx-item ctx-item-auto");
+            auto.textContent = "Automatic";
+            auto.dataset.scope = "machine";
+            auto.addEventListener("click", (ev2) => { ev2.stopPropagation(); post("auto"); });
+            d.appendChild(auto);
+          }
+          sub.appendChild(d);
+          placeFlyBeside(setDef, d);
+          return d;
+        };
+        wireFlyout(sub, setDef, ".ctx-sub-default", () => openDefaultFly());
+        sub.appendChild(setDef);
       }
-      // INSIDE the menu node (so dismissTabMenu and the outside-mousedown check cover it), placed
-      // beside the item — .ctx-menu is position:fixed, so the coords are viewport-space, clamped
+      // INSIDE the menu node (so dismissTabMenu and the outside-mousedown check cover it), placed beside the item
       menu.appendChild(sub);
-      const ir = item.getBoundingClientRect();
-      const sr = sub.getBoundingClientRect();
-      // the side rule (Tags, the model-version submenus): PREFER right; fall LEFT when the right edge would clip and
-      // the left has room; with room on neither side (a narrow window) the flyout drops BELOW the row when it fits
-      // there, else ABOVE the row's top, and only when neither fits is it clamped inside the viewport — never over
-      // the row while a place beside or beyond it exists (review: at 560 px it covered its menu and ran 33 px out;
-      // at 560 by 420 the clamp pulled the drop-below back over the row)
-      let left: number, top: number = ir.top;
-      if (ir.right + 2 + sr.width <= window.innerWidth - 8) left = Math.round(ir.right + 2);
-      else if (ir.left - 2 - sr.width >= 8) left = Math.round(ir.left) - sr.width - 2;
-      else {
-        left = Math.max(8, Math.min(Math.round(ir.left), window.innerWidth - sr.width - 8));
-        if (ir.bottom + 2 + sr.height <= window.innerHeight - 4) top = ir.bottom + 2;
-        else if (ir.top - 2 - sr.height >= 0) top = ir.top - 2 - sr.height;
-        else top = Math.max(0, Math.min(ir.top, window.innerHeight - sr.height - 4));
-      }
-      sub.style.left = left + "px";
-      sub.style.top = Math.max(0, Math.min(top, window.innerHeight - sr.height - 4)) + "px";
+      placeFlyBeside(item, sub);
       return sub;
     };
     wireFlyout(menu, item, ".ctx-sub-billing", () => openBillingFly());

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -702,6 +702,14 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    flyout to 585 px, past narrow windows; the note is gone, the cap stays for a long login label), the label truncating
    inside the item instead of stretching it; the check mark sits in the item's padding, unclipped */
 .ctx-sub-billing, .ctx-sub-default { max-width: 22em; }
+/* the nested level is the flyout's size, not 0.92 of it again (the T387 review measured 11.0 px against 10.1 px: .ctx-menu's
+   0.92em compounds at every nesting, the em rule ui/CLAUDE.md names; the 22em cap follows the size, so it matches too) */
+.ctx-sub-default { font-size: 1em; }
+/* the Set default billing row opens a submenu, so its caret lines up with the Billing and Tags carets: no check-mark
+   room on its right (the .ctx-sub .ctx-item 26px is for the entries that can wear the check) */
+/* four classes: it must OUTRANK .ctx-sub .ctx-item's 26px below (equal specificity lost to the later rule: the fold's served
+   lab measured 26 against 10; the repo's cascade rule, pin the tiebreak) */
+.ctx-sub.ctx-sub-billing > .ctx-item.ctx-item-setdefault { padding-right: 10px; }
 .ctx-sub-billing .ctx-item, .ctx-sub-default .ctx-item { overflow: hidden; text-overflow: ellipsis; }
 .ctx-item-toggle { display: flex; align-items: flex-start; gap: 8px; }
 /* ON = the romp accent blue, matching the timeline lane's feed/mail icons (the user 2026-06-26); OFF = dim

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -698,14 +698,11 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    (the user 2026-06-26). The icon is the same metaphor as the timeline lane toggles; a .off icon is slashed
    + dimmed to show the flag is currently off (matching the timeline). */
 .ctx-sep { height: 1px; margin: 4px 6px; background: var(--box-border); }
-/* a flyout's group head (the Billing flyout's "Default for this machine", T380): a row that names the radios under it
-   and takes no gesture, so no hover wash; the radios below wear the menu's own current mark */
-.ctx-sub-head, .ctx-sub-head:hover { cursor: default; background: transparent; }
-/* the Billing flyout stays a menu's width (review: the note had grown it to 585 px, past narrow windows): the head's
-   note wraps inside it instead of stretching it */
-.ctx-sub-billing { max-width: 22em; }
-.ctx-sub-billing .ctx-sub-head { white-space: normal; }
-.ctx-sub-billing .ctx-sub-head .ctx-item-sub { display: block; white-space: normal; line-height: 1.3; }
+/* the Billing flyout and its nested default submenu (T387) stay a menu's width (the T380 review: a note had grown the
+   flyout to 585 px, past narrow windows; the note is gone, the cap stays for a long login label), the label truncating
+   inside the item instead of stretching it; the check mark sits in the item's padding, unclipped */
+.ctx-sub-billing, .ctx-sub-default { max-width: 22em; }
+.ctx-sub-billing .ctx-item, .ctx-sub-default .ctx-item { overflow: hidden; text-overflow: ellipsis; }
 .ctx-item-toggle { display: flex; align-items: flex-start; gap: 8px; }
 /* ON = the romp accent blue, matching the timeline lane's feed/mail icons (the user 2026-06-26); OFF = dim
    gray + slashed. So the same blue marks "enabled" in both the menu and the timeline. */

--- a/ui/webview/tab-tags-flyout.test.ts
+++ b/ui/webview/tab-tags-flyout.test.ts
@@ -38,22 +38,25 @@ test("diagonal tolerance: entering either surface cancels the close; leaving bot
   assert.doesNotMatch(WIRE, /window\.addEventListener/, "no window listener: the harness slices count them");
 });
 
-test("the Billing flyout's placement (T380 review): prefer right, fall left with room, else drop below the row inside the viewport; no Automatic radio for an older kernel", () => {
-  const BILL = RENDER.slice(RENDER.indexOf("const openBillingFly = (): HTMLElement | null => {"), RENDER.indexOf('wireFlyout(menu, item, ".ctx-sub-billing"'));
-  assert.match(BILL, /if \(ir\.right \+ 2 \+ sr\.width <= window\.innerWidth - 8\) left = Math\.round\(ir\.right \+ 2\);/, "prefer right");
-  assert.match(BILL, /else if \(ir\.left - 2 - sr\.width >= 8\) left = Math\.round\(ir\.left\) - sr\.width - 2;/, "fall left only with room");
+test("the flyouts' placement (T380 review, one helper since T387): prefer right, fall left with room, else drop below the row inside the viewport", () => {
+  const PLACE = RENDER.slice(RENDER.indexOf("function placeFlyBeside("), RENDER.indexOf("\n}\n", RENDER.indexOf("function placeFlyBeside(")));
+  assert.match(PLACE, /if \(ir\.right \+ 2 \+ sr\.width <= window\.innerWidth - 8\) left = Math\.round\(ir\.right \+ 2\);/, "prefer right");
+  assert.match(PLACE, /else if \(ir\.left - 2 - sr\.width >= 8\) left = Math\.round\(ir\.left\) - sr\.width - 2;/, "fall left only with room");
   // no room either side: below the row when it fits, else above the row's top, and only then clamped (round 3: a short
   // window's clamp pulled the drop-below back over the row)
-  assert.match(BILL, /left = Math\.max\(8, Math\.min\(Math\.round\(ir\.left\), window\.innerWidth - sr\.width - 8\)\);/, "clamped inside the viewport horizontally");
-  assert.match(BILL, /if \(ir\.bottom \+ 2 \+ sr\.height <= window\.innerHeight - 4\) top = ir\.bottom \+ 2;/, "below the row when it fits");
-  assert.match(BILL, /else if \(ir\.top - 2 - sr\.height >= 0\) top = ir\.top - 2 - sr\.height;/, "else above the row's top");
-  assert.match(BILL, /else top = Math\.max\(0, Math\.min\(ir\.top, window\.innerHeight - sr\.height - 4\)\);/, "only when neither fits, clamped");
-  assert.doesNotMatch(BILL, /Math\.max\(0, Math\.min\(ir\.right \+ 2, window\.innerWidth - sr\.width - 4\)\)/, "the old slide-over-the-row rule is gone");
-  assert.match(BILL, /const olderKernel = avail\.defaultExplicit === undefined;/);
-  assert.match(BILL, /\.\.\.\(olderKernel \? \[\] : \[\{ label: `Automatic \(\$\{autoWord\}\)`, value: "auto", why: "", cur: !explicit \}\]\)/, "an older kernel that takes no auto gets no Automatic radio");
+  assert.match(PLACE, /left = Math\.max\(8, Math\.min\(Math\.round\(ir\.left\), window\.innerWidth - sr\.width - 8\)\);/, "clamped inside the viewport horizontally");
+  assert.match(PLACE, /if \(ir\.bottom \+ 2 \+ sr\.height <= window\.innerHeight - 4\) top = ir\.bottom \+ 2;/, "below the row when it fits");
+  assert.match(PLACE, /else if \(ir\.top - 2 - sr\.height >= 0\) top = ir\.top - 2 - sr\.height;/, "else above the row's top");
+  assert.match(PLACE, /else top = Math\.max\(0, Math\.min\(ir\.top, window\.innerHeight - sr\.height - 4\)\);/, "only when neither fits, clamped");
+  assert.doesNotMatch(PLACE, /Math\.max\(0, Math\.min\(ir\.right \+ 2, window\.innerWidth - sr\.width - 4\)\)/, "the old slide-over-the-row rule is gone");
+  const BILL = RENDER.slice(RENDER.indexOf("const openBillingFly = (): HTMLElement | null => {"), RENDER.indexOf('wireFlyout(menu, item, ".ctx-sub-billing"'));
+  assert.match(BILL, /placeFlyBeside\(item, sub\);/, "the Billing flyout rides the helper…");
+  assert.match(BILL, /placeFlyBeside\(setDef, d\);/, "…and so does its nested default submenu (T387)");
+  assert.match(BILL, /if \(pickable\.length > 1 && avail\.default && avail\.defaultExplicit !== undefined\) \{/, "an older kernel that takes no auto and marks no default gets no Set default billing entry");
+  assert.match(BILL, /if \(explicit\) \{[\s\S]*?auto\.textContent = "Automatic";/, "the way back to the helper rule, only while an explicit default stands");
   const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
-  assert.match(CSS, /\.ctx-sub-billing \{ max-width: 22em; \}/, "a menu's width: the note wraps");
-  assert.match(CSS, /\.ctx-sub-billing \.ctx-sub-head \.ctx-item-sub \{ display: block; white-space: normal; line-height: 1\.3; \}/);
+  assert.match(CSS, /\.ctx-sub-billing, \.ctx-sub-default \{ max-width: 22em; \}/, "a menu's width for both levels");
+  assert.doesNotMatch(CSS, /\.ctx-sub-head/, "the group head and its note are gone (T387)");
 });
 
 test("expansion follows the standing side rule and the caret faces right", () => {


### PR DESCRIPTION
The tab menu's Billing flyout takes the shape the user described (2026-09-12): the billings a session can pick from; below them, only when there is more than one to choose from, a rule and ONE entry, **Set default billing**, which opens a further submenu holding exactly the same entries with the machine's default check-marked; a click there sets the default; no sub-line under anything. The Default group with its radios and its automatic-rule note goes.

**Design points**
- `billingChoices(st, avail)` builds the entry list; both menus iterate the same array, so they can never list different billings. When stored logins arrive (the several-logins branch) this is the function that grows, and the default submenu lists them with the picks.
- `placeFlyBeside(anchor, fly)` is the standing side rule (prefer right, fall left with room, else below or above the row, else clamped inside the viewport) for the Billing flyout and its nested submenu alike.
- The nested level rides the same hover-intent road: `wireFlyout` on the Billing flyout itself, the submenu appended inside it, so leaving both closes both and the menu's dismissal covers it.
- The rule and the entry appear only when more than one billing is pickable here (a side this box cannot bill is not a choice) and the kernel says whether the default is explicit; an older kernel that sends no `defaultExplicit` shows neither.
- An **Automatic** way back to the helper rule sits at the end of the submenu behind its own rule, only while an explicit default stands; without it a set default could never be cleared. A judgment call made for the user, open to their veto.
- Kernel contracts untouched: `setAuth` with scope `machine` and `login`, `key` or `auto`; `set_auth_default`; `explicit_default_auth`; the refusal toasts.

**Tests**
- `ui/webview/billing-flyout.test.ts`: an executed lift of the flyout builder with the real entry-list, placement and hover-intent helpers on a tiny DOM: the picks, the rule and the single entry, the nested submenu's entries equal to the list, the check on an explicit default, Automatic behind its rule only while explicit, the single-billing case (no rule, no entry), the older kernel, the posted messages, no sub-line anywhere. Red on main.
- `tests/test_billing_flyout_browser.py`: the served lab re-derived for the shape, with a second kernel that has no key helper (the rule and the entry absent, the key greyed with its reason). Measured, not read: the check mark as the computed pseudo-element, the sub-lines as a computed count, the submenu's placement beside its entry, both levels inside narrow viewports, the pick through the kernel's seed and the Automatic way back clearing it. Red against main's bundle through `BILLING_FLYOUT_DIST`.
- `tab-tags-flyout.test.ts` re-pinned to the shared placement helper; `feed-cap-offer.test.ts`'s sender census re-pointed to the submenu's one post helper (still two chat senders).

Tier: feature
