### PR TITLE
A card's brief click lands on the text that carries it; a verdict's why is cut at a boundary with a visible mark

### DIFF
--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -9843,6 +9843,9 @@ def _reassert_blocks(store, seg_id, seg_t, items):
         if nd is None or nd.get("blocked") or nd.get("cleared") or nd.get("nodeComplete"):
             continue
         ev = max(seg_t or 0, _floor_of(store, nd) + 1)
+        src_rows = [e for e in (nd.get("log") or []) if e.get("kind") == "block" and str(e.get("why") or "") == str(why)]
+        if src_rows and src_rows[-1].get("whyCut"):    # the why comes back from a row the parser cut: the fact rides the new
+            why = _CutWhy(why)                         # row too, or the brief judge's note would vanish on the re-assert (T388)
         if record_verdict(store, nd, "planner", "block", ev, why=why, seg=seg_id):
             nd["mt"] = seg_t or ev
             if seg_id and seg_id not in (nd.get("trail") or []):

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2565,6 +2565,33 @@ def _tool_arg(name, inp):
 # where the outcome lives (the user 2026-07-14: a completed card's summary click landed on the
 # announcement stub instead of the wrap-up).
 CITE_MIN_CHARS = 80
+WHY_CUT_MARK = "…"      # the visible ellipsis a cut why ends with: the reader (and the brief judge) can tell a cut
+WHY_MAX = 300                # a verdict's why (a planner op's rationale, the closer's done, block or awaiting why): the
+#                              ceiling as before (tests/test_judge.py pins it), now reached at a boundary, never mid-word
+
+
+def _cut_why(why, cap):
+    """A verdict's why, whitespace-collapsed and cut to `cap` characters at a SENTENCE end (past half the cap) or
+    else a word boundary, with WHY_CUT_MARK appended when anything was cut; never mid-word. A why the raw slice cut
+    mid-word ("... Also say whether the d") read to the brief judge as a fifth, half-stated question the user had to
+    restate (the manager's T388 finding, 2026-09-12): the stump was the cap's, not the closer's, and nothing marked it."""
+    s = " ".join(str(why or "").split())
+    if len(s) <= cap:
+        return s
+    head = s[:cap]
+    cut = -1
+    for m in re.finditer(r"[.!?](?=\s)", head):     # the last sentence end that leaves at least half the cap
+        if m.end() >= cap // 2:
+            cut = m.end()
+    if cut < 0:
+        sp = head.rfind(" ")
+        cut = sp if sp >= cap // 2 else cap        # a word boundary, else the bare cap (one unbroken token)
+    return head[:cut].rstrip() + WHY_CUT_MARK
+
+
+def why_was_cut(why):
+    """Whether a stored why carries the cut mark (see _cut_why)."""
+    return str(why or "").endswith(WHY_CUT_MARK)
 
 # a PR/commit/compare link in a tool result — the result class the anchor study convicted (T218):
 # the substance of "shipped it" IS the link, so the atom holding it must be citable
@@ -4114,7 +4141,7 @@ def _parse_plan(raw, menu_len, allow_extend=False):
         if not isinstance(o, dict):
             continue
         do = str(o.get("do", "")).strip().lower()
-        why = " ".join(str(o.get("why", "")).split())[:300]
+        why = _cut_why(o.get("why", ""), WHY_MAX)
         text = " ".join(str(o.get("text", "")).split())[:120]
         if not do and why.lower() == "skip":
             do = "skip"                            # the model sometimes answers {"why": "skip"} with no
@@ -12110,7 +12137,7 @@ def _parse_group(raw, menu_len):
         if not isinstance(o, dict):
             continue
         do = str(o.get("do", "")).strip().lower()
-        why = " ".join(str(o.get("why", "")).split())[:300]
+        why = _cut_why(o.get("why", ""), WHY_MAX)
         text = " ".join(str(o.get("text", "")).split())[:120]
         if do in ("mint", "group"):
             # RETIRED (the user 2026-08-26, T101): the board's unit is the individual ask — no
@@ -13653,7 +13680,7 @@ def _parse_close(raw, menu_len):
             except (TypeError, ValueError):
                 continue
             if 1 <= n <= menu_len and n not in out and n not in skip:
-                why = " ".join(str(it.get("why", "")).split())[:300]
+                why = _cut_why(it.get("why", ""), WHY_MAX)   # the user-facing question, never cut mid-word
                 if kinds:
                     k = str(it.get("kind") or "").strip().lower()
                     out[n] = {"why": why, "kind": k if k in AWAIT_KINDS_JUDGED else None}   # a closer files a specific kind, never "mixed"
@@ -16313,6 +16340,8 @@ def _owed_why(nd):
     host still holds after the wait ended (relayCarried: carried on before it could be withdrawn, or the host
     unreachable; the third verdict)."""
     why = str((nd or {}).get("blockWhy") or "")
+    if why_was_cut(why):                            # the stored reason ends where the cap cut it: say so, or the brief
+        why += " (the recorded reason ends here; the rest was not kept)"   # reads the stump as an owed question (T388)
     notes = [s for s in (str((nd or {}).get(k) or "").strip() for k in ("relayRefusal", "relayCarried")) if s]
     return "%s (%s)" % (why, "; ".join(notes)) if notes else why
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2570,6 +2570,13 @@ WHY_MAX = 300                # a verdict's why (a planner op's rationale, the cl
 #                              ceiling as before (tests/test_judge.py pins it), now reached at a boundary, never mid-word
 
 
+class _CutWhy(str):
+    """A why _cut_why shortened: a str that carries the fact, so record_verdict can store it on the row (whyCut) and
+    the fold can materialize blockWhyCut; a complete why that happens to end with an ellipsis is never mistaken for
+    a cut one (the verifier's first round on T388)."""
+    cut = True
+
+
 def _cut_why(why, cap):
     """A verdict's why, whitespace-collapsed and cut to `cap` characters at a SENTENCE end (past half the cap) or
     else a word boundary, with WHY_CUT_MARK appended when anything was cut; never mid-word. A why the raw slice cut
@@ -2586,12 +2593,13 @@ def _cut_why(why, cap):
     if cut < 0:
         sp = head.rfind(" ")
         cut = sp if sp >= cap // 2 else cap        # a word boundary, else the bare cap (one unbroken token)
-    return head[:cut].rstrip() + WHY_CUT_MARK
+    return _CutWhy(head[:cut].rstrip() + WHY_CUT_MARK)
 
 
 def why_was_cut(why):
-    """Whether a stored why carries the cut mark (see _cut_why)."""
-    return str(why or "").endswith(WHY_CUT_MARK)
+    """Whether a why object carries the cut fact (a _CutWhy from _cut_why); a stored node reads blockWhyCut instead.
+    Never a suffix test on the ellipsis: a complete why may end with one."""
+    return bool(getattr(why, "cut", False))
 
 # a PR/commit/compare link in a tool result — the result class the anchor study convicted (T218):
 # the substance of "shipped it" IS the link, so the atom holding it must be citable
@@ -9964,6 +9972,7 @@ def record_verdict(store, nd, src, kind, ev_t=None, why=None, seg=None, msg=Fals
         log = nd.setdefault("log", [])
         log.append({"ev_t": ev_t, "src": src, "kind": kind,
                     **({"why": why} if why else {}), **({"seg": seg} if seg else {}),
+                    **({"whyCut": True} if why_was_cut(why) else {}),   # the parser's cut, stored beside the text (T388)
                     **({"msg": True} if msg else {}),  # a user message rides this reopen (chip derivation)
                     **({"undo": True} if undo else {}),   # an undo-restore reopen: not a "not done" assertion
                     **({"lift": True} if lift else {}),   # an `awaiting` row that ENDS the wait, not asserts it
@@ -10079,6 +10088,7 @@ def _fold_node(nd):
     cur_settle, prev_settle = None, None
     awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None     # the live ⏳ stamp (see docstring); None = not awaiting
     done_why = block_why = None           # the landing verdicts' rationale (doneWhy/blockWhy derivation)
+    block_why_cut = False                 # the landing block's why was cut by the parser's cap (row whyCut, T388)
     held = pending = False                # held: an unanswered USER reopen pins the node open (no bottom-up
     #                                       re-completion); pending: an unanswered msg-reopen wears the chip.
     #                                       "Answered" = ANY later non-user event — the judges looked.
@@ -10136,7 +10146,8 @@ def _fold_node(nd):
         elif kind == "block":
             if src in ("user", "agent") or t > floor:
                 state = "blocked"
-                block_why = e.get("why") or block_why
+                if e.get("why"):
+                    block_why, block_why_cut = e["why"], bool(e.get("whyCut"))
                 reopen_snap = None
                 awaiting_why = awaiting_at = awaiting_kind = awaiting_peers = None
         elif kind == "unblock":
@@ -10181,7 +10192,7 @@ def _fold_node(nd):
             "awaitingAt": awaiting_at if state == "open" else None,
             "awaitingKind": awaiting_kind if state == "open" else None,
             "awaitingPeers": awaiting_peers if state == "open" else None,
-            "doneWhy": done_why, "blockWhy": block_why}
+            "doneWhy": done_why, "blockWhy": block_why, "blockWhyCut": block_why_cut}
 
 
 def _fold_node_state(nd):
@@ -10510,8 +10521,13 @@ def _materialize_node(nd):
         if st == "blocked":
             if f["blockWhy"]:
                 nd["blockWhy"] = f["blockWhy"]         # the landing block's rationale; a why-less event
+                if f.get("blockWhyCut"):               # the parser cut it: the brief's material says so (T388)
+                    nd["blockWhyCut"] = True
+                else:
+                    nd.pop("blockWhyCut", None)
         else:                                          # (legacy synth) keeps whatever text is already there
             nd.pop("blockWhy", None)                   # cache hygiene: the why goes with the block
+            nd.pop("blockWhyCut", None)
         if st == "done" and f["doneWhy"]:
             nd["doneWhy"] = f["doneWhy"]
         for key, val in (("followupAt", f["floor"]), ("settledAt", f["settledAt"]),
@@ -16340,7 +16356,7 @@ def _owed_why(nd):
     host still holds after the wait ended (relayCarried: carried on before it could be withdrawn, or the host
     unreachable; the third verdict)."""
     why = str((nd or {}).get("blockWhy") or "")
-    if why_was_cut(why):                            # the stored reason ends where the cap cut it: say so, or the brief
+    if (nd or {}).get("blockWhyCut"):               # the stored reason ends where the cap cut it: say so, or the brief
         why += " (the recorded reason ends here; the rest was not kept)"   # reads the stump as an owed question (T388)
     notes = [s for s in (str((nd or {}).get(k) or "").strip() for k in ("relayRefusal", "relayCarried")) if s]
     return "%s (%s)" % (why, "; ".join(notes)) if notes else why

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36827,7 +36827,8 @@ def _feed_session_entry(s, ctx):
         # subtree (T388). A HANDOFF row gets none: its session is the peer's (whoSid) while any landing here would be
         # an atom of THIS session's parse, a foreign atom to the peer's chat; the row's line falls to goWork, whose
         # target the tracker's own row wears (the verifier's second round).
-        _ncompleted, _nline = _landing_inputs("completed" if st == "done" else "blocked" if st == "question" else None, nd)
+        _ncompleted, _nline = _landing_inputs("completed" if st == "done" else "blocked" if st == "question" else None, "", nd)
+        #                       ^ the modal row's status is its whole rule (distillText by status); no column term
         _nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, _ncompleted, _nline)
         _born = nd.get("born") if isinstance(nd.get("born"), dict) else (healed.get(nid) or (None, None))[1]
         out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
@@ -37338,7 +37339,7 @@ def _feed_session_entry(s, ctx):
         # ONE resolve for the card and its modal row (_brief_landing, above flatten): the completed pin, the cited
         # tier with the T153 outrun rule, the text-atom tier, the latest-prose walk, the stub, the work anchor, all
         # over the whole subtree's trails, so one brief never lands in two places by the surface clicked (T388).
-        _completed, _line = _landing_inputs(distill_state, nodes[nid])   # the line the card SHOWS (distillState, not the column)
+        _completed, _line = _landing_inputs(distill_state, column, nodes[nid])   # the line the card SHOWS: distillInputs' terms
         _cited = nodes[nid].get("summaryAnchor")
         _sa_u, _sa_q = _brief_landing(nid, _completed, _line)
         if _sa_u is None and ps is None:
@@ -39912,18 +39913,26 @@ def _opening_sentence(line):
     return sent[:200].strip()
 
 
-def _landing_inputs(state, nd):
-    """(completed, line): what a surface SHOWS for a node in `state` ("completed" | "blocked" | None), the client's
-    distillText rule: the decision brief for a blocked state, the takeaway for a completed one, nothing otherwise;
-    and the completed bit the landing's pin reads, from the same state. The card passes its distillState (the
-    genuine block: the needs-input floors too, not the column), the modal row its own status, so each surface
-    resolves the landing of the very line it shows (the verifier's third round on T388: a working top floored to
-    needs-input showed the brief and landed on the takeaway's sentence, the line the column named)."""
-    if state == "blocked":
-        return False, (nd.get("blockSummary") or None)
-    if state == "completed":
-        return True, (nd.get("summary") or None)
-    return False, None
+def _landing_inputs(state, column, nd):
+    """(completed, line): what a surface SHOWS for a node, the client's distillInputs(distillState, column) rule TERM
+    FOR TERM (ui/webview/distiller-line.ts, pinned against this by a shared table): a working column shows nothing;
+    else the state decides (completed: the takeaway; blocked: the decision brief); else the column's fallback (the
+    brief for needs_input, the takeaway for completed). The card passes its distillState and its wire column, so the
+    floors the state does not name (the STALL floor, the user's 2026-08-13 rule) still show the brief the client
+    shows and land on it; the modal row passes its own status as the state and no column (its status is its whole
+    rule). The completed bit the landing's pin reads comes from the same terms (the verifier's third and fourth
+    rounds on T388: a permission-floored card landed on the takeaway's sentence, a stall-floored one on a tool call
+    inside a collapsed group, the very defect this change opens with)."""
+    if column == "working":
+        completed, blocked = False, False
+    elif state == "completed":
+        completed, blocked = True, False
+    elif state == "blocked":
+        completed, blocked = False, True
+    else:
+        completed, blocked = column == "completed", column == "needs_input"
+    line = nd.get("blockSummary") if blocked else (nd.get("summary") if completed else None)
+    return completed, (line or None)
 
 
 def _summary_outrun(nd, trails, seg_best):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -11,6 +11,7 @@ zero protocol change at switchover. WS is hand-rolled on the stdlib socket (no d
 
 Run:  bin/romp-kernel   → opens http://127.0.0.1:29855
 """
+import collections
 import copy
 import math
 import contextlib, json, os, queue, random, re, signal, socket, sys, time, threading, traceback, base64, bisect, errno, hashlib, hmac, struct, subprocess, shutil, shlex, http.client, uuid, tempfile, stat, gzip, collections, functools, fcntl, inspect, secrets, importlib.util
@@ -566,6 +567,7 @@ class _PerfStats:
                           ("intrMarks", _intr_marks_memo_report), ("statesOverlay", _states_overlay_report),
                           ("lanes", _lanes_memo_report),   # the timeline's per-lane segment memo, live lanes; the dead lanes beside
                           ("spendTree", _spend_tree_memo_report),   # the spend guard's subagent-tree memos: bytes against their bound
+                          ("summaryAnchor", _summary_anchor_memo_report),   # the brief line's text-atom landings (T388): bytes against their bound
                           # the chat build's fixed-cost memos (2026-09-09): the live merge's transcript-side
                           # sets, the fold's sealed postal cards, the ledger's goal-tree walk, the task fold
                           ("chatMergeSets", _merge_sets_report), ("chatPostal", _chat_postal_report),
@@ -39844,8 +39846,55 @@ def _seg_last_text(atoms):
     return (last_sub or last_any), last_sub is not None
 
 
-_SUMMARY_ANCHOR_MEMO = {}       # (fsid, nid, seg key, line hash, turn end) -> (uuid, quote): one text read per brief per segment
-_SUMMARY_ANCHOR_MEMO_MAX = 4096
+def _summary_anchor_memo_bound():
+    """The memo's byte bound: ROMP_SUMMARY_ANCHOR_MEMO_BYTES when it names a positive integer, else a
+    two-hundred-fifty-sixth of the machine's memory (the _spend_tree_memo_bound idiom; 32 MB on an 8 GB box, ample
+    for entries of a few hundred bytes, one per brief per segment). Read once at import (SUMMARY_ANCHOR_MEMO_BYTES);
+    GET /perf reports it beside the memo's bytes and counters (memos.summaryAnchor). The user's caches rule
+    (2026-09-11): a byte bound as a fraction of memory with an override, never a count literal."""
+    raw = os.environ.get("ROMP_SUMMARY_ANCHOR_MEMO_BYTES", "")
+    try:
+        if raw and int(raw) > 0:
+            return int(raw)
+    except ValueError:
+        pass
+    return _mem_total_bytes() // 256
+
+
+SUMMARY_ANCHOR_MEMO_BYTES = _summary_anchor_memo_bound()
+_SUMMARY_ANCHOR_MEMO = collections.OrderedDict()   # key -> ((uuid, quote), size): the order is age, a hit moves to the end
+_SUMMARY_ANCHOR_STATS = {"hit": 0, "miss": 0, "evict": 0, "entries": 0, "bytes": 0, "bound": SUMMARY_ANCHOR_MEMO_BYTES}
+#                          the key: (fsid, nid, seg key, the line's hash, the turn's end): one text read per brief per segment
+
+
+def _summary_anchor_memo_get(key):
+    hit = _SUMMARY_ANCHOR_MEMO.get(key)
+    if hit is None:
+        _SUMMARY_ANCHOR_STATS["miss"] += 1
+        return None
+    _SUMMARY_ANCHOR_MEMO.move_to_end(key)          # a hit is the newest again: an eviction takes a colder entry first
+    _SUMMARY_ANCHOR_STATS["hit"] += 1
+    return hit[0]
+
+
+def _summary_anchor_memo_put(key, out):
+    size = sum(2 * len(str(x)) for x in key) + sum(2 * len(str(x)) for x in out if x) + 64
+    old = _SUMMARY_ANCHOR_MEMO.pop(key, None)
+    if old is not None:
+        _SUMMARY_ANCHOR_STATS["bytes"] -= old[1]
+    _SUMMARY_ANCHOR_MEMO[key] = (out, size)
+    _SUMMARY_ANCHOR_STATS["bytes"] += size
+    while len(_SUMMARY_ANCHOR_MEMO) > 1 and _SUMMARY_ANCHOR_STATS["bytes"] > SUMMARY_ANCHOR_MEMO_BYTES:
+        _k, (_o, _s) = _SUMMARY_ANCHOR_MEMO.popitem(last=False)   # oldest first; sheds only the deficit, never the whole
+        _SUMMARY_ANCHOR_STATS["bytes"] -= _s
+        _SUMMARY_ANCHOR_STATS["evict"] += 1
+    _SUMMARY_ANCHOR_STATS["entries"] = len(_SUMMARY_ANCHOR_MEMO)
+
+
+def _summary_anchor_memo_report():
+    """The memo's counters with its occupancy and bound: GET /perf memos.summaryAnchor (entries, bytes, bound, hit,
+    miss, evict)."""
+    return dict(_SUMMARY_ANCHOR_STATS, entries=len(_SUMMARY_ANCHOR_MEMO), bound=SUMMARY_ANCHOR_MEMO_BYTES)
 
 
 def _text_atoms(atoms):
@@ -39874,14 +39923,14 @@ def _summary_text_anchor(turn_seg, line, memo_key=None):
     long turn's first assistant atom was a shell call, and four landings filed pointer-exact on a collapsed tool
     group while the quoted questions were the turn's last text atom, thirteen minutes later). `quote` is the located
     span, sent as the click's anchorQuote so the chat highlights it. Bodies are read only for the candidate text
-    atoms of one turn, once per brief per segment (the memo), so a build costs nothing on a repeat."""
+    atoms of one turn, once per brief per segment (the byte-bounded memo), so a build costs nothing on a repeat."""
     if not turn_seg:
         return None, None
     turn, seg_atoms = turn_seg
     key = None
     if memo_key is not None:
         key = tuple(memo_key) + (hash(str(line or "")), (turn or {}).get("end") or (turn or {}).get("t"))
-        hit = _SUMMARY_ANCHOR_MEMO.get(key)
+        hit = _summary_anchor_memo_get(key)
         if hit is not None:
             return hit
     seg_texts = _text_atoms(seg_atoms)
@@ -39903,9 +39952,7 @@ def _summary_text_anchor(turn_seg, line, memo_key=None):
         last = (seg_texts or turn_texts or [None])[-1]
         out = ((last or {}).get("uuid"), None)
     if key is not None:
-        if len(_SUMMARY_ANCHOR_MEMO) >= _SUMMARY_ANCHOR_MEMO_MAX:
-            _SUMMARY_ANCHOR_MEMO.clear()
-        _SUMMARY_ANCHOR_MEMO[key] = out
+        _summary_anchor_memo_put(key, out)
     return out
 
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36555,6 +36555,9 @@ def _feed_session_entry(s, ctx):
     # (aerr) only fires once the session is idle-stalled, so without this a storm reads as plain
     # healthy Working for its whole life — nimbus's card said Working through an ~80-minute storm.
     sess_retrying = _session_retrying(fsid, tm)
+    _faults0 = _SUMMARY_ANCHOR_STATS["fault"]   # a body-read fault during this derivation (the landing tier) marks the
+    #                                             entry: build_feed then skips the memo put, so a degraded landing never
+    #                                             persists on an idle card until its inputs move (the verifier's third round)
     store = ctx["store"]                     # _feed_goals(fsid), read once in the key: a pre-pass snapshot while a judge
     #                                          pass is mid-flight → the card's
                                              # status never shows a half-applied intermediate (atomic visibility)
@@ -36637,11 +36640,15 @@ def _feed_session_entry(s, ctx):
     agent_open = _agent_open_set(nodes, children)   # authoritative-open subtree → never rendered 'done' (see helper)
     parked_rows = _parked_rows(nodes, children)     # leapfrogged open rows → the quiet "parked" row cue (see helper)
 
-    def _subtree(root):                          # all node ids at/under root (pre-order)
-        stack, acc = [root], []
-        while stack:
-            x = stack.pop(); acc.append(x); stack.extend(children.get(x, []))
-        return acc
+    _sub_memo = {}                               # root -> its subtree, once per build: the landing walks it per node
+    def _subtree(root):                          # all node ids at/under root (pre-order); callers only iterate the list
+        got = _sub_memo.get(root)
+        if got is None:
+            stack, acc = [root], []
+            while stack:
+                x = stack.pop(); acc.append(x); stack.extend(children.get(x, []))
+            got = _sub_memo[root] = acc
+        return got
 
     # VERDICTS ONLY (the user 2026-07-15; roll-UP removed — it painted an authored-looking ✓ on a
     # goal nobody ruled done, see build_session's _subtree_done twin): a node is "done" if it's
@@ -36737,6 +36744,10 @@ def _feed_session_entry(s, ctx):
         latest-prose walk over the subtree's trails; else that newest segment's last text atom; else the newest
         trail segment's work anchor (a landable atom, a tool group at worst). `quote` rides only with the cited
         atom's stored span or the tier's located span."""
+        mk = (nid, bool(completed), line or "")      # one resolve per node, bit and line within a build: the card and
+        got = _land_memo.get(mk)                     #   its top row ask with the same inputs and get the same answer
+        if got is not None:
+            return got
         nd = nodes[nid]
         sub = _subtree(nid)
         u, q, cited = None, None, nd.get("summaryAnchor")
@@ -36783,7 +36794,10 @@ def _feed_session_entry(s, ctx):
                         break
                 if u:
                     break
-        return u, (q or None)
+        _land_memo[mk] = (u, (q or None))
+        return _land_memo[mk]
+
+    _land_memo = {}                              # (nid, completed, line) -> (uuid, quote), per build
 
     def flatten(nid, out, ancestor_done=False, boundary=None):  # AskTreeNode flat list, root first; nest via children ids
         nd = nodes[nid]
@@ -36813,9 +36827,8 @@ def _feed_session_entry(s, ctx):
         # subtree (T388). A HANDOFF row gets none: its session is the peer's (whoSid) while any landing here would be
         # an atom of THIS session's parse, a foreign atom to the peer's chat; the row's line falls to goWork, whose
         # target the tracker's own row wears (the verifier's second round).
-        _nline = nd.get("blockSummary") if st == "question" else nd.get("summary")
-        _nline = _nline or nd.get("blockSummary") or nd.get("summary")
-        _nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, st == "done", _nline)
+        _ncompleted, _nline = _landing_inputs("completed" if st == "done" else "blocked" if st == "question" else None, nd)
+        _nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, _ncompleted, _nline)
         _born = nd.get("born") if isinstance(nd.get("born"), dict) else (healed.get(nid) or (None, None))[1]
         out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
                     "born": _born or None,   # T319: a step the session started on its own (why it sits here)
@@ -37325,10 +37338,9 @@ def _feed_session_entry(s, ctx):
         # ONE resolve for the card and its modal row (_brief_landing, above flatten): the completed pin, the cited
         # tier with the T153 outrun rule, the text-atom tier, the latest-prose walk, the stub, the work anchor, all
         # over the whole subtree's trails, so one brief never lands in two places by the surface clicked (T388).
-        _line = nodes[nid].get("blockSummary") if col in ("blocked", "awaiting") else nodes[nid].get("summary")
-        _line = _line or nodes[nid].get("blockSummary") or nodes[nid].get("summary")
+        _completed, _line = _landing_inputs(distill_state, nodes[nid])   # the line the card SHOWS (distillState, not the column)
         _cited = nodes[nid].get("summaryAnchor")
-        _sa_u, _sa_q = _brief_landing(nid, col == "completed", _line)
+        _sa_u, _sa_q = _brief_landing(nid, _completed, _line)
         if _sa_u is None and ps is None:
             # COLD-PARSE fallback (the user 2026-07-20): every tier above reads parse-derived maps,
             # and right after a kernel restart ps is None until _warm_fleet_bg — so for that window
@@ -37519,7 +37531,8 @@ def _feed_session_entry(s, ctx):
                                            count=sess_awaiting_count, items=sess_awaiting_items))
     return {"asks": ent_asks, "working": ent_working, "awaiting": ent_awaiting, "bgServices": ent_bg,
             "servingFolds": ent_folds, "heal": heal_total, "hidden": hidden_total, "cold": cold_parse,
-            "peers": sorted(peers_read), "reads": reads}
+            "peers": sorted(peers_read), "reads": reads,
+            "faults": _SUMMARY_ANCHOR_STATS["fault"] - _faults0}
 
 
 def _feed_fold_card(card, now, cmap):
@@ -37612,7 +37625,8 @@ def build_feed(now, live_map=None):
             entry = _feed_session_entry(s, ctx)
             key = _feed_key_with_deps(key, ctx, entry)   # the peers and reads THIS derivation recorded
             js = json.dumps(entry, default=_wire_default_in("_feed_memo"))   # str() of an unencodable value, said once
-            _feed_memo_put(fsid, key, js)
+            if not (entry or {}).get("faults"):      # a derivation that met a body-read fault is served but not kept:
+                _feed_memo_put(fsid, key, js)        #   the next build re-derives it (the anchor memo skipped it too)
             entry = json.loads(js)                   # the fold's objects come from the string on a miss too, so a hit and
             #                                          a miss hand the board the same shapes, byte for byte
         _heal, _hid, _cold = _feed_fold_entry(entry, now, cmap, s["name"], asks, working, awaiting, bg_services, serving_folds)
@@ -39896,6 +39910,20 @@ def _opening_sentence(line):
     m = re.search(r"[.!?](?=\s|$)", para[12:])
     sent = para[: 12 + m.end()] if m else para
     return sent[:200].strip()
+
+
+def _landing_inputs(state, nd):
+    """(completed, line): what a surface SHOWS for a node in `state` ("completed" | "blocked" | None), the client's
+    distillText rule: the decision brief for a blocked state, the takeaway for a completed one, nothing otherwise;
+    and the completed bit the landing's pin reads, from the same state. The card passes its distillState (the
+    genuine block: the needs-input floors too, not the column), the modal row its own status, so each surface
+    resolves the landing of the very line it shows (the verifier's third round on T388: a working top floored to
+    needs-input showed the brief and landed on the takeaway's sentence, the line the column named)."""
+    if state == "blocked":
+        return False, (nd.get("blockSummary") or None)
+    if state == "completed":
+        return True, (nd.get("summary") or None)
+    return False, None
 
 
 def _summary_outrun(nd, trails, seg_best):

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36745,12 +36745,15 @@ def _feed_session_entry(s, ctx):
         _nline = _nline or nd.get("blockSummary") or nd.get("summary")
         _nsa_u, _nsa_q = None, None
         if _nline:
-            if nd.get("summaryAnchor") and nd.get("summaryAnchor") in cite_uuids:
+            _ntr = nd.get("trail") or []
+            if nd.get("summaryAnchor") and nd.get("summaryAnchor") in cite_uuids \
+                    and not _summary_outrun(nd, [_ntr], seg_best):   # the T153 rule, the card's own (one landing per brief)
                 _nsa_u, _nsa_q = nd["summaryAnchor"], nd.get("summaryQuote")
             else:
-                _ntr = nd.get("trail") or []
-                _nsa_u, _nsa_q = _summary_text_anchor(seg_turn.get(_seg_key(_ntr[-1])) if _ntr else None, _nline,
-                                                      memo_key=(fsid, nid, _seg_key(_ntr[-1]) if _ntr else None))
+                _nk = _seg_key(_ntr[-1]) if _ntr else None
+                _nsa_u, _nsa_q = _summary_text_anchor(seg_turn.get(_nk), _nline, memo_key=(fsid, nid, _nk))
+                if _nsa_u is None:                   # a text stub still beats the work anchor's tool group
+                    _nsa_u, _nsa_q = _summary_text_anchor(seg_turn.get(_nk), _nline, memo_key=(fsid, nid, _nk), stub_ok=True)
         # A HANDOFF tracking node ("↪ delegated to <peer>") finally ships as its designed kind: the
         # feed's delegations section (fask-delegations, built to the 2026-06-10 handoff spec) keys on
         # kind "handoff" and had sat dormant because flatten hardcoded "ask" — the sender's card
@@ -37297,30 +37300,25 @@ def _feed_session_entry(s, ctx):
             # substantive walk below, so the click follows the freshest evidence; the citation
             # resumes authority the moment a re-distill lands (the stamp catches up).
             # Display-only: no column implication.
-            _cov = max(int(nodes[nid].get("distilledMt") or 0),
-                       int(nodes[nid].get("briefedMt") or 0))
-            _outrun = bool(_cov) and (
-                (nodes[nid].get("followupAt") or 0) > _cov
-                or any((seg_best.get(_seg_key(_sid), (None, False, 0))[2] or 0) > _cov
-                       for _x in _subtree(nid) for _sid in (nodes[_x].get("trail") or [])))
-            if not _outrun:
+            if not _summary_outrun(nodes[nid], [nodes[_x].get("trail") for _x in _subtree(nid)], seg_best):
                 _sa_u = _cited
-        _sa_q = None                                 # the located span when the text-atom tier resolves (T388)
+        _sa_q, _sk = None, None                      # the located span when the text-atom tier resolves (T388)
         _line = nodes[nid].get("blockSummary") if col in ("blocked", "awaiting") else nodes[nid].get("summary")
         _line = _line or nodes[nid].get("blockSummary") or nodes[nid].get("summary")
-        if _sa_u is None and _line:
-            # NO VALIDATED CITATION, a brief or summary on the card (T388, the manager 2026-09-12): land on the
-            # assistant TEXT atom of the newest trail segment's turn that carries the line's opening sentence,
-            # else that turn's last text atom; never a tool_use or thinking atom. The walk below picks the latest
-            # PROSE segment, and the last resort the WORK anchor, which for a long turn was a shell call inside a
-            # collapsed tool group, thirteen minutes before the quoted questions in the same turn's last text atom.
-            _sk, _st = None, -1
+        if _line:
+            _st = -1                                 # the newest trail segment across the subtree, by its time
             for _x in _subtree(nid):
                 for _sid in (nodes[_x].get("trail") or []):
                     _k = _seg_key(_sid)
                     _t = seg_best.get(_k, (None, False, 0))[2] or 0
                     if _k in seg_turn and _t >= _st:
                         _sk, _st = _k, _t
+        if _sa_u is None and _line:
+            # NO VALIDATED CITATION, a brief or summary on the card (T388, the manager 2026-09-12): land on the
+            # assistant TEXT atom of the newest trail segment's turn that carries the line's opening sentence,
+            # else that turn's last text atom; never a tool_use or thinking atom. The walk below picks the latest
+            # PROSE segment, and the last resort the WORK anchor, which for a long turn was a shell call inside a
+            # collapsed tool group, thirteen minutes before the quoted questions in the same turn's last text atom.
             if _sk is not None:
                 _sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk))
         if _sa_u is None:
@@ -37332,6 +37330,10 @@ def _feed_session_entry(s, ctx):
                         _best = (_sub, _t, _u)
             if _best:
                 _sa_u = _best[2]
+        if not _sa_u and _line and _sk is not None:
+            # the newest segment's last TEXT atom, whatever its length (T388): a connective stub is still a text
+            # row the reader can read from, where the work anchor below may be a collapsed tool group
+            _sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk), stub_ok=True)
         if not _sa_u:
             # LAST RESORT (the user 2026-07-02: a completed card's summary was unclickable — the cited
             # atom fell outside every segment, and no trail segment offered prose either). Fall back to
@@ -39863,7 +39865,8 @@ def _summary_anchor_memo_bound():
 
 SUMMARY_ANCHOR_MEMO_BYTES = _summary_anchor_memo_bound()
 _SUMMARY_ANCHOR_MEMO = collections.OrderedDict()   # key -> ((uuid, quote), size): the order is age, a hit moves to the end
-_SUMMARY_ANCHOR_STATS = {"hit": 0, "miss": 0, "evict": 0, "entries": 0, "bytes": 0, "bound": SUMMARY_ANCHOR_MEMO_BYTES}
+_SUMMARY_ANCHOR_STATS = {"hit": 0, "miss": 0, "evict": 0, "fault": 0, "entries": 0, "bytes": 0, "bound": SUMMARY_ANCHOR_MEMO_BYTES}
+#                          fault: a candidate atom whose body could not be read (a LazyBodyRead, a rotated file): skipped, counted
 #                          the key: (fsid, nid, seg key, the line's hash, the turn's end): one text read per brief per segment
 
 
@@ -39914,41 +39917,73 @@ def _opening_sentence(line):
     return sent[:200].strip()
 
 
-def _summary_text_anchor(turn_seg, line, memo_key=None):
+def _summary_outrun(nd, trails, seg_best):
+    """THE GROUNDING CAN BE OUTRUN (the user 2026-08-28, T153): a stored citation names what the summary was WRITTEN
+    FROM, but a reply that reopens the card adds stretches the summary has never seen. When the follow-up stamp or
+    any segment of `trails` postdates the summary's coverage stamp (distilledMt or briefedMt), the cited tier yields
+    to the fresher evidence; it resumes authority the moment a re-distill lands. One rule for the card's chain and
+    the modal row's brief line, so one brief never lands in two places by the surface clicked (the verifier's first
+    round on T388)."""
+    cov = max(int(nd.get("distilledMt") or 0), int(nd.get("briefedMt") or 0))
+    if not cov:
+        return False
+    if (nd.get("followupAt") or 0) > cov:
+        return True
+    return any((seg_best.get(_seg_key(_s), (None, False, 0))[2] or 0) > cov for _tr in trails for _s in (_tr or []))
+
+
+def _summary_text_anchor(turn_seg, line, memo_key=None, stub_ok=False):
     """(uuid, quote) — where a card's brief or summary click lands when the brief carries no validated citation
     (T388, the manager's finding 2026-09-12): the assistant TEXT atom of the newest trail segment that carries the
     line's opening sentence (the same locate the distiller's citation uses, jd._locate_quote), else the same search
     over the whole turn the segment sits in (a seam-split turn keeps its wrap-up in a later segment), else the last
-    text atom of the segment, else of the turn; never a tool_use or thinking atom, which the WORK anchor may be (a
-    long turn's first assistant atom was a shell call, and four landings filed pointer-exact on a collapsed tool
-    group while the quoted questions were the turn's last text atom, thirteen minutes later). `quote` is the located
-    span, sent as the click's anchorQuote so the chat highlights it. Bodies are read only for the candidate text
-    atoms of one turn, once per brief per segment (the byte-bounded memo), so a build costs nothing on a repeat."""
+    SUBSTANTIVE text atom (jd.CITE_MIN_CHARS, the latest-prose walk's own preference) of the segment, else of the
+    turn; never a tool_use or thinking atom, which the WORK anchor may be (a long turn's first assistant atom was a
+    shell call, and four landings filed pointer-exact on a collapsed tool group while the quoted questions were the
+    turn's last text atom, thirteen minutes later). With no located quote and no substantive atom the tier answers
+    (None, None) so the card's chain falls through to the walk; only a last-resort call (`stub_ok`) takes the last
+    text atom whatever its length, still ahead of a tool group (the verifier's first round: a paraphrased brief is
+    the common case, and the bare last-text pick handed a connective stub the landing over the analysis before it,
+    the very pick the walk exists to avoid). `quote` is the located span, sent as the click's anchorQuote so the
+    chat highlights it. Bodies are read only for the candidate text atoms of one turn, inside the same envelope the
+    build's other lazy reads use (a body that cannot be read is skipped and counted, never a raise that would abort
+    build_feed for every session), once per brief per segment (the byte-bounded memo)."""
     if not turn_seg:
         return None, None
     turn, seg_atoms = turn_seg
     key = None
     if memo_key is not None:
-        key = tuple(memo_key) + (hash(str(line or "")), (turn or {}).get("end") or (turn or {}).get("t"))
+        key = tuple(memo_key) + (hash(str(line or "")), (turn or {}).get("end") or (turn or {}).get("t"), bool(stub_ok))
         hit = _summary_anchor_memo_get(key)
         if hit is not None:
             return hit
     seg_texts = _text_atoms(seg_atoms)
-    turn_texts = _text_atoms((turn or {}).get("atoms"))
+    turn_texts = [a for a in _text_atoms((turn or {}).get("atoms")) if not any(a is s for s in seg_texts)]   # the rest of the turn
     opening = _opening_sentence(line)
     out = (None, None)
     if opening:
         for cands in (seg_texts, turn_texts):
             for a in reversed(cands):                  # newest first: the wrap-up, not an early restatement
-                if a.get("lazy") is not None:
-                    em.hydrate([a])                    # a body before the assembly cut: read on demand (T323 stage 4a)
-                off, span = jd._locate_quote(jd._atom_text(a), opening)
+                try:
+                    if a.get("lazy") is not None:
+                        em.hydrate([a])                # a body before the assembly cut: read on demand (T323 stage 4a)
+                    text = jd._atom_text(a)
+                except Exception:                      # the build's envelope: a body that cannot be read is skipped
+                    _SUMMARY_ANCHOR_STATS["fault"] += 1   # and counted (memos.summaryAnchor.fault); never a raise
+                    continue
+                off, span = jd._locate_quote(text, opening)
                 if off is not None:
                     out = (a["uuid"], str(span or "")[:300] or None)
                     break
             if out[0]:
                 break
-    if not out[0]:
+    if not out[0]:                                     # no located quote: the newest SUBSTANTIVE text atom, the walk's rule
+        for cands in (seg_texts, turn_texts):
+            sub_ = [a for a in cands if _atom_prose_chars(a) >= jd.CITE_MIN_CHARS]
+            if sub_:
+                out = (sub_[-1]["uuid"], None)
+                break
+    if not out[0] and stub_ok:                         # the last resort only: a stub still beats a tool group
         last = (seg_texts or turn_texts or [None])[-1]
         out = ((last or {}).get("uuid"), None)
     if key is not None:

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36725,6 +36725,66 @@ def _feed_session_entry(s, ctx):
         _bcmemo[nid] = res
         return res
 
+    def _brief_landing(nid, completed, line):
+        """(uuid, quote): where a node's brief or summary line lands, resolved ONCE for the card and its modal row from
+        one input set (the node's whole subtree's trails, the same column rule, the same tier order), so one brief
+        never lands in two places by the surface clicked (the verifier's second round on T388: the card read the
+        subtree while the row read its own trail, and a completed card pinned its recap while the row took the
+        citation). Tiers, in order: a COMPLETED node pins the newest substantive tail across its subtree (the
+        completion recap the user expects the summary to open on, the user 2026-07-14); else the node's validated
+        citation unless outrun (T153, _summary_outrun); else the text atom carrying the line's opening sentence in
+        the newest subtree segment's turn, or its newest substantive text atom (_summary_text_anchor); else the
+        latest-prose walk over the subtree's trails; else that newest segment's last text atom; else the newest
+        trail segment's work anchor (a landable atom, a tool group at worst). `quote` rides only with the cited
+        atom's stored span or the tier's located span."""
+        nd = nodes[nid]
+        sub = _subtree(nid)
+        u, q, cited = None, None, nd.get("summaryAnchor")
+        if completed:
+            tail = None                                  # (seg_t, uuid) of the newest substantive tail
+            for x in sub:
+                tr = nodes[x].get("trail") or []
+                if tr:
+                    tu, tsub, tt = seg_best.get(_seg_key(tr[-1]), (None, False, 0))
+                    if tu and tsub and (tail is None or tt > tail[0]):
+                        tail = (tt, tu)
+            if tail:
+                u = tail[1]
+        if u is None and cited and cited in cite_uuids \
+                and not _summary_outrun(nd, [nodes[x].get("trail") for x in sub], seg_best):
+            u, q = cited, nd.get("summaryQuote")
+        sk, skt = None, -1                               # the newest trail segment across the subtree, by its time
+        if line:
+            for x in sub:
+                for s in (nodes[x].get("trail") or []):
+                    k = _seg_key(s)
+                    t = seg_best.get(k, (None, False, 0))[2] or 0
+                    if k in seg_turn and t >= skt:
+                        sk, skt = k, t
+        if u is None and line and sk is not None:
+            u, q = _summary_text_anchor(seg_turn.get(sk), line, memo_key=(fsid, nid, sk))
+        if u is None:
+            best = None                                  # (substantive, seg_t): prefer substantive, then latest
+            for x in sub:
+                for s in (nodes[x].get("trail") or []):
+                    bu, bsub, bt = seg_best.get(_seg_key(s), (None, False, 0))
+                    if bu and (best is None or (bsub, bt) > (best[0], best[1])):
+                        best = (bsub, bt, bu)
+            if best:
+                u = best[2]
+        if u is None and line and sk is not None:       # a text stub still beats the work anchor's tool group
+            u, q = _summary_text_anchor(seg_turn.get(sk), line, memo_key=(fsid, nid, sk), stub_ok=True)
+        if u is None:                                    # LAST RESORT (the user 2026-07-02): the newest segment's work anchor
+            for x in sub:
+                for s in reversed(nodes[x].get("trail") or []):
+                    wu = seg_uuid.get(_seg_key(s))
+                    if wu:
+                        u = wu
+                        break
+                if u:
+                    break
+        return u, (q or None)
+
     def flatten(nid, out, ancestor_done=False, boundary=None):  # AskTreeNode flat list, root first; nest via children ids
         nd = nodes[nid]
         kids = sorted(children.get(nid, []), key=_fsubmax, reverse=True)   # most-recent-first (matches the ledger)
@@ -36738,22 +36798,6 @@ def _feed_session_entry(s, ctx):
         # The node's deep-link target SEGMENT: its NEWEST trail seg — the resolve turn for
         # done/blocked nodes, the latest activity for open ones (where it stands, not where born).
         _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_uuid)
-        # The node's BRIEF or SUMMARY line lands on the text that carries it (T388): a validated citation when the
-        # node has one, else the text atom of its newest trail segment's turn that holds the line's opening sentence
-        # (_summary_text_anchor), never the work anchor, which may be a tool call inside a collapsed group.
-        _nline = nd.get("blockSummary") if st == "question" else nd.get("summary")
-        _nline = _nline or nd.get("blockSummary") or nd.get("summary")
-        _nsa_u, _nsa_q = None, None
-        if _nline:
-            _ntr = nd.get("trail") or []
-            if nd.get("summaryAnchor") and nd.get("summaryAnchor") in cite_uuids \
-                    and not _summary_outrun(nd, [_ntr], seg_best):   # the T153 rule, the card's own (one landing per brief)
-                _nsa_u, _nsa_q = nd["summaryAnchor"], nd.get("summaryQuote")
-            else:
-                _nk = _seg_key(_ntr[-1]) if _ntr else None
-                _nsa_u, _nsa_q = _summary_text_anchor(seg_turn.get(_nk), _nline, memo_key=(fsid, nid, _nk))
-                if _nsa_u is None:                   # a text stub still beats the work anchor's tool group
-                    _nsa_u, _nsa_q = _summary_text_anchor(seg_turn.get(_nk), _nline, memo_key=(fsid, nid, _nk), stub_ok=True)
         # A HANDOFF tracking node ("↪ delegated to <peer>") finally ships as its designed kind: the
         # feed's delegations section (fask-delegations, built to the 2026-06-10 handoff spec) keys on
         # kind "handoff" and had sat dormant because flatten hardcoded "ask" — the sender's card
@@ -36765,6 +36809,13 @@ def _feed_session_entry(s, ctx):
         _ho_sid = str(_ho.get("peer") or "") if _ho else ""
         if _ho_sid:
             peers_read.add(_ho_sid)              # a peer this row names (its registry entry is a dependency)
+        # The node's BRIEF or SUMMARY line lands where the card's does: _brief_landing, one resolve from the node's
+        # subtree (T388). A HANDOFF row gets none: its session is the peer's (whoSid) while any landing here would be
+        # an atom of THIS session's parse, a foreign atom to the peer's chat; the row's line falls to goWork, whose
+        # target the tracker's own row wears (the verifier's second round).
+        _nline = nd.get("blockSummary") if st == "question" else nd.get("summary")
+        _nline = _nline or nd.get("blockSummary") or nd.get("summary")
+        _nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, st == "done", _nline)
         _born = nd.get("born") if isinstance(nd.get("born"), dict) else (healed.get(nid) or (None, None))[1]
         out.append({"id": nid, "kind": "handoff" if _ho_sid else "ask", "text": nd["text"],
                     "born": _born or None,   # T319: a step the session started on its own (why it sits here)
@@ -37271,83 +37322,13 @@ def _feed_session_entry(s, ctx):
         # message across the goal's whole subtree trail (mint→resolution). Never the old
         # biggest-text-block pick: "longest ever" is monotone, so a long early analysis held the
         # anchor forever while the real outcome landed later (the user 2026-07-01).
-        _sa_u, _cited = None, nodes[nid].get("summaryAnchor")
-        if col == "completed":
-            # The newest trail TAIL across the SUBTREE, not just the top's own (the user 2026-07-15,
-            # the g91 click): a BOTTOM-UP-completed umbrella (all children done) has no done verdict
-            # of its own, so the DONE-ANCHOR never appended a completing segment to ITS trail —
-            # trail[-1] was still the MINT segment and the pin sent the summary click to the goal's
-            # oldest prose instead of the wrap-up the distiller correctly cited. A child's
-            # done-anchored tail IS its completing turn's segment, so the newest substantive tail is
-            # the completion recap for both shapes (an explicitly-done top's own tail stays newest).
-            _tail = None                             # (seg_t, uuid) of the newest substantive tail
-            for _x in _subtree(nid):
-                _tr = nodes[_x].get("trail") or []
-                if not _tr:
-                    continue
-                _u, _sub, _t = seg_best.get(_seg_key(_tr[-1]), (None, False, 0))
-                if _u and _sub and (_tail is None or _t > _tail[0]):
-                    _tail = (_t, _u)
-            if _tail:
-                _sa_u = _tail[1]
-        if _sa_u is None and _cited and _cited in cite_uuids:
-            # THE GROUNDING CAN BE OUTRUN (the user 2026-08-28, T153): the citation names what
-            # the summary was WRITTEN FROM — but a reply that reopens the card adds stretches
-            # the stored summary has never seen (no re-completion yet, so no re-distill event),
-            # and the click then lands in the stale FIRST stretch of a visibly two-stretch
-            # card. When the follow-up stamp or any subtree trail segment postdates the
-            # summary's own coverage stamp, the cited tier YIELDS to the most-current-
-            # substantive walk below, so the click follows the freshest evidence; the citation
-            # resumes authority the moment a re-distill lands (the stamp catches up).
-            # Display-only: no column implication.
-            if not _summary_outrun(nodes[nid], [nodes[_x].get("trail") for _x in _subtree(nid)], seg_best):
-                _sa_u = _cited
-        _sa_q, _sk = None, None                      # the located span when the text-atom tier resolves (T388)
+        # ONE resolve for the card and its modal row (_brief_landing, above flatten): the completed pin, the cited
+        # tier with the T153 outrun rule, the text-atom tier, the latest-prose walk, the stub, the work anchor, all
+        # over the whole subtree's trails, so one brief never lands in two places by the surface clicked (T388).
         _line = nodes[nid].get("blockSummary") if col in ("blocked", "awaiting") else nodes[nid].get("summary")
         _line = _line or nodes[nid].get("blockSummary") or nodes[nid].get("summary")
-        if _line:
-            _st = -1                                 # the newest trail segment across the subtree, by its time
-            for _x in _subtree(nid):
-                for _sid in (nodes[_x].get("trail") or []):
-                    _k = _seg_key(_sid)
-                    _t = seg_best.get(_k, (None, False, 0))[2] or 0
-                    if _k in seg_turn and _t >= _st:
-                        _sk, _st = _k, _t
-        if _sa_u is None and _line:
-            # NO VALIDATED CITATION, a brief or summary on the card (T388, the manager 2026-09-12): land on the
-            # assistant TEXT atom of the newest trail segment's turn that carries the line's opening sentence,
-            # else that turn's last text atom; never a tool_use or thinking atom. The walk below picks the latest
-            # PROSE segment, and the last resort the WORK anchor, which for a long turn was a shell call inside a
-            # collapsed tool group, thirteen minutes before the quoted questions in the same turn's last text atom.
-            if _sk is not None:
-                _sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk))
-        if _sa_u is None:
-            _best = None                             # (substantive, seg_t): prefer substantive, then latest
-            for _x in _subtree(nid):
-                for _sid in (nodes[_x].get("trail") or []):
-                    _u, _sub, _t = seg_best.get(_seg_key(_sid), (None, False, 0))   # timestamp-invariant: resolve a drifted trail seg id
-                    if _u and (_best is None or (_sub, _t) > (_best[0], _best[1])):
-                        _best = (_sub, _t, _u)
-            if _best:
-                _sa_u = _best[2]
-        if not _sa_u and _line and _sk is not None:
-            # the newest segment's last TEXT atom, whatever its length (T388): a connective stub is still a text
-            # row the reader can read from, where the work anchor below may be a collapsed tool group
-            _sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk), stub_ok=True)
-        if not _sa_u:
-            # LAST RESORT (the user 2026-07-02: a completed card's summary was unclickable — the cited
-            # atom fell outside every segment, and no trail segment offered prose either). Fall back to
-            # the newest trail segment's WORK anchor (seg_uuid — the same target the modal's node rows
-            # nav to), so the summary still deep-links to roughly where the work concluded. Only a goal
-            # with NO resolvable trail at all ends up link-less.
-            for _x in _subtree(nid):
-                for _sid in reversed(nodes[_x].get("trail") or []):
-                    _u = seg_uuid.get(_seg_key(_sid))
-                    if _u:
-                        _sa_u = _u
-                        break
-                if _sa_u:
-                    break
+        _cited = nodes[nid].get("summaryAnchor")
+        _sa_u, _sa_q = _brief_landing(nid, col == "completed", _line)
         if _sa_u is None and ps is None:
             # COLD-PARSE fallback (the user 2026-07-20): every tier above reads parse-derived maps,
             # and right after a kernel restart ps is None until _warm_fleet_bg — so for that window
@@ -39957,6 +39938,8 @@ def _summary_text_anchor(turn_seg, line, memo_key=None, stub_ok=False):
         hit = _summary_anchor_memo_get(key)
         if hit is not None:
             return hit
+    faults0 = _SUMMARY_ANCHOR_STATS["fault"]           # a search that met an unreadable body is answered but not memoized:
+    #                                                    a transient fault must not pin a degraded landing until eviction
     seg_texts = _text_atoms(seg_atoms)
     turn_texts = [a for a in _text_atoms((turn or {}).get("atoms")) if not any(a is s for s in seg_texts)]   # the rest of the turn
     opening = _opening_sentence(line)
@@ -39986,7 +39969,7 @@ def _summary_text_anchor(turn_seg, line, memo_key=None, stub_ok=False):
     if not out[0] and stub_ok:                         # the last resort only: a stub still beats a tool group
         last = (seg_texts or turn_texts or [None])[-1]
         out = ((last or {}).get("uuid"), None)
-    if key is not None:
+    if key is not None and _SUMMARY_ANCHOR_STATS["fault"] == faults0:
         _summary_anchor_memo_put(key, out)
     return out
 

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -36593,9 +36593,11 @@ def _feed_session_entry(s, ctx):
     # tags + the kind guard accepts as turn-user) lets it resolve BY ID instead of a kind-restricted
     # nearest-time landing (the user 2026-06-17). (Both are emitted .turn[data-uuid]s in the chat.)
     seg_uuid, seg_trig, seg_best, cite_uuids = {}, {}, {}, set()
+    seg_turn = {}                                    # seg key -> (turn, segment atoms): the text-atom resolve's input (T388)
     try:
         for turn in (ps["turns"] if ps else []):     # cached parse only; anchors fill in after _warm_fleet_bg
             for seg in _segs_seam(turn, store):
+                seg_turn[_seg_key(seg["id"])] = (turn, seg["atoms"])
                 w, r = _seg_anchors(seg["atoms"])
                 seg_uuid[_seg_key(seg["id"])] = r or _seg_jump(seg["atoms"])   # timestamp-invariant key; landable
                 #                                  anchors only — never a thinking-only uuid (SDK echo/real drift)
@@ -36734,6 +36736,19 @@ def _feed_session_entry(s, ctx):
         # The node's deep-link target SEGMENT: its NEWEST trail seg — the resolve turn for
         # done/blocked nodes, the latest activity for open ones (where it stands, not where born).
         _pa, _wa = _node_anchor_uuids(nd, seg_trig, seg_uuid)
+        # The node's BRIEF or SUMMARY line lands on the text that carries it (T388): a validated citation when the
+        # node has one, else the text atom of its newest trail segment's turn that holds the line's opening sentence
+        # (_summary_text_anchor), never the work anchor, which may be a tool call inside a collapsed group.
+        _nline = nd.get("blockSummary") if st == "question" else nd.get("summary")
+        _nline = _nline or nd.get("blockSummary") or nd.get("summary")
+        _nsa_u, _nsa_q = None, None
+        if _nline:
+            if nd.get("summaryAnchor") and nd.get("summaryAnchor") in cite_uuids:
+                _nsa_u, _nsa_q = nd["summaryAnchor"], nd.get("summaryQuote")
+            else:
+                _ntr = nd.get("trail") or []
+                _nsa_u, _nsa_q = _summary_text_anchor(seg_turn.get(_seg_key(_ntr[-1])) if _ntr else None, _nline,
+                                                      memo_key=(fsid, nid, _seg_key(_ntr[-1]) if _ntr else None))
         # A HANDOFF tracking node ("↪ delegated to <peer>") finally ships as its designed kind: the
         # feed's delegations section (fask-delegations, built to the 2026-06-10 handoff spec) keys on
         # kind "handoff" and had sat dormant because flatten hardcoded "ask" — the sender's card
@@ -36792,6 +36807,8 @@ def _feed_session_entry(s, ctx):
                     # landing on the user turn (no kind-restricted nearest-time needed). (2026-06-17.)
                     "anchorUuid": _wa,
                     "promptAnchorUuid": _pa,
+                    "summaryAnchorUuid": _nsa_u,   # the brief/summary line's own landing: the text that carries it (T388)
+                    "summaryAnchorQuote": _nsa_q,  # …and its located span, highlighted on landing (anchorQuote)
                     "summary": nd.get("summary"),                   # distiller's key takeaway — shown in the MODAL only — the user 2026-06-17
                     "blockSummary": nd.get("blockSummary"),         # block-distiller's DECISION BRIEF (MODAL); null until produced — the user 2026-06-18
                     "relayNote": nd.get("relayCarried") or None,    # a far host still holds a relayed question after its wait ended (relayCarried): its own line under the brief, never a brief paragraph (briefParts maps those)
@@ -37286,6 +37303,24 @@ def _feed_session_entry(s, ctx):
                        for _x in _subtree(nid) for _sid in (nodes[_x].get("trail") or [])))
             if not _outrun:
                 _sa_u = _cited
+        _sa_q = None                                 # the located span when the text-atom tier resolves (T388)
+        _line = nodes[nid].get("blockSummary") if col in ("blocked", "awaiting") else nodes[nid].get("summary")
+        _line = _line or nodes[nid].get("blockSummary") or nodes[nid].get("summary")
+        if _sa_u is None and _line:
+            # NO VALIDATED CITATION, a brief or summary on the card (T388, the manager 2026-09-12): land on the
+            # assistant TEXT atom of the newest trail segment's turn that carries the line's opening sentence,
+            # else that turn's last text atom; never a tool_use or thinking atom. The walk below picks the latest
+            # PROSE segment, and the last resort the WORK anchor, which for a long turn was a shell call inside a
+            # collapsed tool group, thirteen minutes before the quoted questions in the same turn's last text atom.
+            _sk, _st = None, -1
+            for _x in _subtree(nid):
+                for _sid in (nodes[_x].get("trail") or []):
+                    _k = _seg_key(_sid)
+                    _t = seg_best.get(_k, (None, False, 0))[2] or 0
+                    if _k in seg_turn and _t >= _st:
+                        _sk, _st = _k, _t
+            if _sk is not None:
+                _sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk))
         if _sa_u is None:
             _best = None                             # (substantive, seg_t): prefer substantive, then latest
             for _x in _subtree(nid):
@@ -37368,7 +37403,8 @@ def _feed_session_entry(s, ctx):
             # land elsewhere, where the span would highlight the wrong text); the landing scrolls to
             # and highlights it, and a null keeps today's whole-message behavior
             "summaryAnchorQuote": (nodes[nid].get("summaryQuote")
-                                   if _sa_u and _sa_u == nodes[nid].get("summaryAnchor") else None),
+                                   if _sa_u and _sa_u == nodes[nid].get("summaryAnchor") else (_sa_q or None)),
+            #                      …or the text-atom tier's located span (T388), the same field, the same landing
             # per-paragraph landings (T220, the user's ruling): each cited paragraph's own atom +
             # located span, aligned to the takeaway's paragraphs (None = that paragraph falls back
             # to the whole-summary landing). Gated exactly like the quote above: the cited tier
@@ -39806,6 +39842,71 @@ def _seg_last_text(atoms):
             if n >= jd.CITE_MIN_CHARS:
                 last_sub = a["uuid"]
     return (last_sub or last_any), last_sub is not None
+
+
+_SUMMARY_ANCHOR_MEMO = {}       # (fsid, nid, seg key, line hash, turn end) -> (uuid, quote): one text read per brief per segment
+_SUMMARY_ANCHOR_MEMO_MAX = 4096
+
+
+def _text_atoms(atoms):
+    """The assistant TEXT atoms of `atoms`, in order: a landable text row, never a tool_use, a thinking block, an API
+    error or the machine-cut null settle. Scalars only until a body is needed (em.atom_has_text reads the marker)."""
+    return [a for a in atoms or [] if a.get("type") == "assistant" and a.get("uuid") and not a.get("isApiError")
+            and em.atom_has_text(a) and not em.atom_is_settle(a)]
+
+
+def _opening_sentence(line):
+    """The first sentence of a brief or summary: its first non-empty paragraph, a leading list number dropped, cut
+    at the first sentence end past twelve characters, at most two hundred characters. "" when there is none."""
+    para = next((p.strip() for p in re.split(r"\n\s*\n", str(line or "")) if p.strip()), "")
+    para = re.sub(r"^\s*(?:\d+[.)]|[-*])\s+", "", para).split("\n", 1)[0].strip()
+    m = re.search(r"[.!?](?=\s|$)", para[12:])
+    sent = para[: 12 + m.end()] if m else para
+    return sent[:200].strip()
+
+
+def _summary_text_anchor(turn_seg, line, memo_key=None):
+    """(uuid, quote) — where a card's brief or summary click lands when the brief carries no validated citation
+    (T388, the manager's finding 2026-09-12): the assistant TEXT atom of the newest trail segment that carries the
+    line's opening sentence (the same locate the distiller's citation uses, jd._locate_quote), else the same search
+    over the whole turn the segment sits in (a seam-split turn keeps its wrap-up in a later segment), else the last
+    text atom of the segment, else of the turn; never a tool_use or thinking atom, which the WORK anchor may be (a
+    long turn's first assistant atom was a shell call, and four landings filed pointer-exact on a collapsed tool
+    group while the quoted questions were the turn's last text atom, thirteen minutes later). `quote` is the located
+    span, sent as the click's anchorQuote so the chat highlights it. Bodies are read only for the candidate text
+    atoms of one turn, once per brief per segment (the memo), so a build costs nothing on a repeat."""
+    if not turn_seg:
+        return None, None
+    turn, seg_atoms = turn_seg
+    key = None
+    if memo_key is not None:
+        key = tuple(memo_key) + (hash(str(line or "")), (turn or {}).get("end") or (turn or {}).get("t"))
+        hit = _SUMMARY_ANCHOR_MEMO.get(key)
+        if hit is not None:
+            return hit
+    seg_texts = _text_atoms(seg_atoms)
+    turn_texts = _text_atoms((turn or {}).get("atoms"))
+    opening = _opening_sentence(line)
+    out = (None, None)
+    if opening:
+        for cands in (seg_texts, turn_texts):
+            for a in reversed(cands):                  # newest first: the wrap-up, not an early restatement
+                if a.get("lazy") is not None:
+                    em.hydrate([a])                    # a body before the assembly cut: read on demand (T323 stage 4a)
+                off, span = jd._locate_quote(jd._atom_text(a), opening)
+                if off is not None:
+                    out = (a["uuid"], str(span or "")[:300] or None)
+                    break
+            if out[0]:
+                break
+    if not out[0]:
+        last = (seg_texts or turn_texts or [None])[-1]
+        out = ((last or {}).get("uuid"), None)
+    if key is not None:
+        if len(_SUMMARY_ANCHOR_MEMO) >= _SUMMARY_ANCHOR_MEMO_MAX:
+            _SUMMARY_ANCHOR_MEMO.clear()
+        _SUMMARY_ANCHOR_MEMO[key] = out
+    return out
 
 
 def _seg_jump(atoms):

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -89,11 +89,15 @@ class TheTextAtom(unittest.TestCase):
             raise km.em.LazyBodyRead("no record at the offset")
         km.jd._atom_text = boom
         km._SUMMARY_ANCHOR_MEMO.clear()
-        before = km._SUMMARY_ANCHOR_STATS["fault"]
+        before = km._SUMMARY_ANCHOR_STATS.get("fault", 0)
         try:
-            out = km._summary_text_anchor((turn, seg), BRIEF)
+            try:
+                out = km._summary_text_anchor((turn, seg), BRIEF)
+            except Exception as e:
+                self.fail("the tier raised on an unreadable body instead of skipping it: %r" % (e,))
         finally:
             km.jd._atom_text = real
+        self.assertIn("fault", km._SUMMARY_ANCHOR_STATS, "the fault counter exists beside hit, miss and evict")
         self.assertEqual(km._SUMMARY_ANCHOR_STATS["fault"], before + 2, "every unreadable candidate is counted (two text atoms)")
         self.assertEqual(out, ("t5", None), "…and the tier goes on without a body: the substantive fallback, never a raise")
 

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -147,8 +147,12 @@ class TheWiring(unittest.TestCase):
         self.assertLess(tier, walk, "the text-atom tier runs before the latest-prose walk")
         self.assertLess(walk, stub, "…the stub only after the walk")
         self.assertLess(stub, work, "…and the work anchor last")
-        self.assertIn('_sa_u, _sa_q = _brief_landing(nid, col == "completed", _line)', src, "the card takes the one resolve")
-        self.assertIn('_brief_landing(nid, st == "done", _nline)', src, "…and so does each row, from the same function")
+        self.assertIn("_completed, _line = _landing_inputs(distill_state, nodes[nid])", src,
+                      "the card's line and completed bit come from the state it SHOWS (distillState), not the column")
+        self.assertIn("_sa_u, _sa_q = _brief_landing(nid, _completed, _line)", src, "the card takes the one resolve")
+        self.assertIn('_ncompleted, _nline = _landing_inputs("completed" if st == "done" else "blocked" if st == "question" else None, nd)', src,
+                      "…and each row's from its own shown status, through the same function")
+        self.assertIn("_nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, _ncompleted, _nline)", src)
         self.assertIn('"summaryAnchorUuid": _nsa_u,', src, "every tree row carries the brief line's own landing")
         self.assertIn('"summaryAnchorQuote": _nsa_q,', src)
         self.assertIn("else (_sa_q or None)),", src, "the card's quote falls to the text-atom tier's span")
@@ -159,8 +163,9 @@ class TheWiring(unittest.TestCase):
         self.assertIn("focusEcho(ss); vscodeApi?.postMessage({ type: \"showOnTimeline\", itemId: node.id || it.turnId, sid: ss,", ts)
         self.assertIn("and not _summary_outrun(nd, [nodes[x].get(\"trail\") for x in sub], seg_best):", src,
                       "the cited tier applies the outrun rule over the whole subtree, once, for the card and the row alike")
-        self.assertIn("_nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, st == \"done\", _nline)", src,
-                      "a handoff row carries no landing: its session is the peer's")
+        self.assertIn("_land_memo[mk] = (u, (q or None))", src, "one resolve per node, bit and line within a build")
+        self.assertIn("got = _sub_memo[root] = acc", src, "one subtree walk per root within a build")
+        self.assertIn('if not (entry or {}).get("faults"):', src, "a derivation that met a body-read fault is not memoized as an entry")
         self.assertIn("summaryAnchorUuid?: string | null;                            // the brief/summary line's own landing", ts)
 
 

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -92,12 +92,13 @@ class TheTextAtom(unittest.TestCase):
         before = km._SUMMARY_ANCHOR_STATS.get("fault", 0)
         try:
             try:
-                out = km._summary_text_anchor((turn, seg), BRIEF)
+                out = km._summary_text_anchor((turn, seg), BRIEF, memo_key=("11111111-2222-3333-4444-555555555555", "gf", "kf"))
             except Exception as e:
                 self.fail("the tier raised on an unreadable body instead of skipping it: %r" % (e,))
         finally:
             km.jd._atom_text = real
         self.assertIn("fault", km._SUMMARY_ANCHOR_STATS, "the fault counter exists beside hit, miss and evict")
+        self.assertEqual(len(km._SUMMARY_ANCHOR_MEMO), 0, "a faulted search is not memoized: a transient fault never pins a degraded landing")
         self.assertEqual(km._SUMMARY_ANCHOR_STATS["fault"], before + 2, "every unreadable candidate is counted (two text atoms)")
         self.assertEqual(out, ("t5", None), "…and the tier goes on without a body: the substantive fallback, never a raise")
 
@@ -135,9 +136,19 @@ class TheTextAtom(unittest.TestCase):
 class TheWiring(unittest.TestCase):
     def test_the_card_chain_tries_the_text_atom_before_the_latest_prose_walk_and_the_tree_rows_carry_it(self):
         src = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
-        tier = src.index("_sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk))")
-        walk = src.index("_best = None                             # (substantive, seg_t): prefer substantive, then latest")
-        self.assertLess(tier, walk, "the text-atom tier runs before the latest-prose walk and the work-anchor last resort")
+        land = src.index("    def _brief_landing(nid, completed, line):")
+        flat = src.index("    def flatten(nid, out, ancestor_done=False, boundary=None):")
+        self.assertLess(land, flat, "one landing function, defined before the flatten, serves the card and every row")
+        body = src[land:flat]
+        tier = body.index("u, q = _summary_text_anchor(seg_turn.get(sk), line, memo_key=(fsid, nid, sk))")
+        walk = body.index("best = None                                  # (substantive, seg_t): prefer substantive, then latest")
+        stub = body.index("stub_ok=True)")
+        work = body.index("wu = seg_uuid.get(_seg_key(s))")
+        self.assertLess(tier, walk, "the text-atom tier runs before the latest-prose walk")
+        self.assertLess(walk, stub, "…the stub only after the walk")
+        self.assertLess(stub, work, "…and the work anchor last")
+        self.assertIn('_sa_u, _sa_q = _brief_landing(nid, col == "completed", _line)', src, "the card takes the one resolve")
+        self.assertIn('_brief_landing(nid, st == "done", _nline)', src, "…and so does each row, from the same function")
         self.assertIn('"summaryAnchorUuid": _nsa_u,', src, "every tree row carries the brief line's own landing")
         self.assertIn('"summaryAnchorQuote": _nsa_q,', src)
         self.assertIn("else (_sa_q or None)),", src, "the card's quote falls to the text-atom tier's span")
@@ -146,8 +157,10 @@ class TheWiring(unittest.TestCase):
         self.assertIn("anchorUuid: su, quote: sq", ts, "…and sends its span as the click's quote")
         self.assertIn("ss = navSidOf(it, node);", ts, "the click names the ROW's session (a serving-folded worker row), never the card's")
         self.assertIn("focusEcho(ss); vscodeApi?.postMessage({ type: \"showOnTimeline\", itemId: node.id || it.turnId, sid: ss,", ts)
-        self.assertIn("and not _summary_outrun(nd, [_ntr], seg_best):", src, "the modal row's cited tier applies the card's outrun rule")
-        self.assertIn("if not _summary_outrun(nodes[nid], [nodes[_x].get(\"trail\") for _x in _subtree(nid)], seg_best):", src)
+        self.assertIn("and not _summary_outrun(nd, [nodes[x].get(\"trail\") for x in sub], seg_best):", src,
+                      "the cited tier applies the outrun rule over the whole subtree, once, for the card and the row alike")
+        self.assertIn("_nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, st == \"done\", _nline)", src,
+                      "a handoff row carries no landing: its session is the peer's")
         self.assertIn("summaryAnchorUuid?: string | null;                            // the brief/summary line's own landing", ts)
 
 

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -133,6 +133,35 @@ class TheTextAtom(unittest.TestCase):
         self.assertEqual(first[0], "t5")
 
 
+# The six states the verifier executed, one row each: (name, distillState, column, completed, blocked). The webview
+# test ui/webview/distiller-line.test.ts carries the SAME rows for distillInputs; TheLineRuleTable pins both sides.
+LINE_RULE_TABLE = [
+    ("stall floor", None, "needs_input", False, True),
+    ("permission floor", "blocked", "needs_input", False, True),
+    ("real block in recheck", "blocked", "working", False, False),
+    ("done confirming", None, "working", False, False),
+    ("completed", "completed", "completed", True, False),
+    ("plain working", None, "working", False, False),
+]
+
+
+class TheLineRuleTable(unittest.TestCase):
+    def test_the_kernel_mirrors_the_clients_distill_inputs_over_the_six_states(self):
+        nd = {"summary": "the takeaway", "blockSummary": "the brief"}
+        for name, state, column, completed, blocked in LINE_RULE_TABLE:
+            with self.subTest(name):
+                got_completed, line = km._landing_inputs(state, column, nd)
+                self.assertEqual(got_completed, completed, name)
+                self.assertEqual(line, "the brief" if blocked else ("the takeaway" if completed else None), name)
+
+    def test_the_webview_test_carries_the_same_table(self):
+        ts = open(os.path.join(ROOT, "ui", "webview", "distiller-line.test.ts"), encoding="utf-8").read()
+        for name, state, column, completed, blocked in LINE_RULE_TABLE:
+            row = '["%s", %s, "%s", %s, %s]' % (name, "null" if state is None else '"%s"' % state, column,
+                                                str(completed).lower(), str(blocked).lower())
+            self.assertIn(row, ts, "the webview pins the same row: %s" % row)
+
+
 class TheWiring(unittest.TestCase):
     def test_the_card_chain_tries_the_text_atom_before_the_latest_prose_walk_and_the_tree_rows_carry_it(self):
         src = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
@@ -147,11 +176,11 @@ class TheWiring(unittest.TestCase):
         self.assertLess(tier, walk, "the text-atom tier runs before the latest-prose walk")
         self.assertLess(walk, stub, "…the stub only after the walk")
         self.assertLess(stub, work, "…and the work anchor last")
-        self.assertIn("_completed, _line = _landing_inputs(distill_state, nodes[nid])", src,
-                      "the card's line and completed bit come from the state it SHOWS (distillState), not the column")
+        self.assertIn("_completed, _line = _landing_inputs(distill_state, column, nodes[nid])", src,
+                      "the card's line and completed bit come from distillInputs' terms: the state AND the column")
         self.assertIn("_sa_u, _sa_q = _brief_landing(nid, _completed, _line)", src, "the card takes the one resolve")
-        self.assertIn('_ncompleted, _nline = _landing_inputs("completed" if st == "done" else "blocked" if st == "question" else None, nd)', src,
-                      "…and each row's from its own shown status, through the same function")
+        self.assertIn('_ncompleted, _nline = _landing_inputs("completed" if st == "done" else "blocked" if st == "question" else None, "", nd)', src,
+                      "…and each row's from its own shown status, through the same function, with no column term")
         self.assertIn("_nsa_u, _nsa_q = (None, None) if (_ho_sid or not _nline) else _brief_landing(nid, _ncompleted, _nline)", src)
         self.assertIn('"summaryAnchorUuid": _nsa_u,', src, "every tree row carries the brief line's own landing")
         self.assertIn('"summaryAnchorQuote": _nsa_q,', src)

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -56,15 +56,46 @@ class TheTextAtom(unittest.TestCase):
         u, q = km._summary_text_anchor((turn, seg), BRIEF)
         self.assertEqual((u, q), ("t5", "Should the history budget follow the device or the setting?"))
 
-    def test_no_sentence_match_falls_to_the_segments_last_text_atom_with_no_quote(self):
+    def test_no_sentence_match_lands_on_the_newest_substantive_text_atom_never_a_stub(self):
+        # a paraphrased brief (the common case): the analysis before the stub, not the stub, the walk's own rule
+        analysis = "The exporter keeps both clients while the history budget follows the device, and the tests target the old one " * 2
+        seg = [tool("a1", T0), text("t5", T0 + 10, analysis), text("t6", T0 + 20, "Done for now.")]
+        turn = {"t": T0, "end": T0 + 30, "atoms": seg}
+        self.assertEqual(km._summary_text_anchor((turn, seg), "Decide the retry policy for the exporter."), ("t5", None))
+        # the stub newest with the analysis older, the same answer
+        seg2 = [tool("a1", T0), text("t5", T0 + 10, analysis), text("t6", T0 + 20, "Done for now.")]
+        turn2 = {"t": T0, "end": T0 + 30, "atoms": seg2}
+        self.assertEqual(km._summary_text_anchor((turn2, seg2), "The paraphrase names no sentence of the reply.")[0], "t5")
+
+    def test_only_stubs_answer_nothing_unless_the_call_is_the_last_resort(self):
         seg = [tool("a1", T0), text("t5", T0 + 10, "first note"), text("t6", T0 + 20, "second note")]
         turn = {"t": T0, "end": T0 + 30, "atoms": seg}
-        self.assertEqual(km._summary_text_anchor((turn, seg), "Decide the retry policy for the exporter."), ("t6", None))
+        self.assertEqual(km._summary_text_anchor((turn, seg), "Decide the retry policy for the exporter."), (None, None),
+                         "no quote and no substantive atom: the chain falls through to the walk")
+        self.assertEqual(km._summary_text_anchor((turn, seg), "Decide the retry policy for the exporter.", stub_ok=True), ("t6", None),
+                         "the last resort takes the last text atom, still ahead of a tool group")
 
-    def test_a_segment_without_text_falls_to_the_turns_last_text_atom(self):
+    def test_a_segment_without_text_falls_to_the_turns_newest_substantive_text_atom(self):
         seg = [tool("a1", T0), think("th", T0 + 1)]
-        turn = {"t": T0, "end": T0 + 60, "atoms": seg + [text("t7", T0 + 50, "wrap-up here")]}
+        wrap = "The wrap-up here is the reply the user reads, long enough to count as prose by the walk's own floor."
+        turn = {"t": T0, "end": T0 + 60, "atoms": seg + [text("t7", T0 + 50, wrap), text("t8", T0 + 55, "ok")]}
         self.assertEqual(km._summary_text_anchor((turn, seg), "Nothing that matches."), ("t7", None))
+
+    def test_a_body_that_cannot_be_read_is_skipped_and_counted_never_raised(self):
+        seg = [tool("a1", T0), text("t5", T0 + 10, QUESTIONS), text("t6", T0 + 20, "Done for now.")]
+        turn = {"t": T0, "end": T0 + 30, "atoms": seg}
+        real = km.jd._atom_text
+        def boom(a):                                   # the body read raises, as a LazyBodyRead or a rotated file would
+            raise km.em.LazyBodyRead("no record at the offset")
+        km.jd._atom_text = boom
+        km._SUMMARY_ANCHOR_MEMO.clear()
+        before = km._SUMMARY_ANCHOR_STATS["fault"]
+        try:
+            out = km._summary_text_anchor((turn, seg), BRIEF)
+        finally:
+            km.jd._atom_text = real
+        self.assertEqual(km._SUMMARY_ANCHOR_STATS["fault"], before + 2, "every unreadable candidate is counted (two text atoms)")
+        self.assertEqual(out, ("t5", None), "…and the tier goes on without a body: the substantive fallback, never a raise")
 
     def test_thinking_and_tool_calls_alone_resolve_to_nothing(self):
         seg = [tool("a1", T0), think("th", T0 + 1)]
@@ -73,10 +104,13 @@ class TheTextAtom(unittest.TestCase):
         self.assertEqual(km._summary_text_anchor(None, BRIEF), (None, None))
 
     def test_an_api_error_and_the_null_settle_are_never_the_landing(self):
-        err = dict(text("e1", T0 + 5, "API Error: overloaded"), isApiError=True)
-        seg = [tool("a1", T0), err, text("t2", T0 + 6, "the real reply")]
+        err = dict(text("e1", T0 + 5, "API Error: overloaded, please retry the request in a while and check the status page for the outage"), isApiError=True)
+        reply = "The real reply the user reads, long enough to pass the walk's prose floor, names the outcome of the work."
+        seg = [tool("a1", T0), err, text("t2", T0 + 6, reply)]
         turn = {"t": T0, "end": T0 + 10, "atoms": seg}
         self.assertEqual(km._summary_text_anchor((turn, seg), "Nothing matches."), ("t2", None))
+        self.assertEqual(km._summary_text_anchor((turn, [tool("a1", T0), err]), "Nothing matches.", stub_ok=True), ("t2", None),
+                         "the API error is never the landing, even as the last resort")
 
     def test_the_opening_sentence_drops_a_list_number_and_stops_at_the_first_sentence_end(self):
         self.assertEqual(km._opening_sentence("1. Decide the retry policy. Then the rest."), "Decide the retry policy.")
@@ -106,6 +140,10 @@ class TheWiring(unittest.TestCase):
         ts = open(os.path.join(ROOT, "ui", "webview", "feed.ts"), encoding="utf-8").read()
         self.assertIn("if (!repeat && node.summaryAnchorUuid) {", ts, "the modal's brief line prefers the brief's own landing")
         self.assertIn("anchorUuid: su, quote: sq", ts, "…and sends its span as the click's quote")
+        self.assertIn("ss = navSidOf(it, node);", ts, "the click names the ROW's session (a serving-folded worker row), never the card's")
+        self.assertIn("focusEcho(ss); vscodeApi?.postMessage({ type: \"showOnTimeline\", itemId: node.id || it.turnId, sid: ss,", ts)
+        self.assertIn("and not _summary_outrun(nd, [_ntr], seg_best):", src, "the modal row's cited tier applies the card's outrun rule")
+        self.assertIn("if not _summary_outrun(nodes[nid], [nodes[_x].get(\"trail\") for _x in _subtree(nid)], seg_best):", src)
         self.assertIn("summaryAnchorUuid?: string | null;                            // the brief/summary line's own landing", ts)
 
 
@@ -145,7 +183,7 @@ class TheMemoIsBoundedByBytes(unittest.TestCase):
         km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g2", "k2"))      # B: a miss, stored; A is the colder
         self.assertEqual(km._SUMMARY_ANCHOR_STATS["evict"], 1, "over the bound: one eviction, the oldest")
         self.assertEqual(len(km._SUMMARY_ANCHOR_MEMO), 1)
-        self.assertIn((sid, "g2", "k2", hash(BRIEF), T0 + 30), km._SUMMARY_ANCHOR_MEMO, "the newest survives, the coldest went")
+        self.assertIn((sid, "g2", "k2", hash(BRIEF), T0 + 30, False), km._SUMMARY_ANCHOR_MEMO, "the newest survives, the coldest went")
         km.SUMMARY_ANCHOR_MEMO_BYTES = 10 ** 6
         km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g3", "k3"))      # C stored beside B
         before = km._SUMMARY_ANCHOR_STATS["hit"]
@@ -154,10 +192,10 @@ class TheMemoIsBoundedByBytes(unittest.TestCase):
         km.SUMMARY_ANCHOR_MEMO_BYTES = 1
         km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g4", "k4"))      # D: sheds the coldest, C, never the hit B
         keys = list(km._SUMMARY_ANCHOR_MEMO)
-        self.assertNotIn((sid, "g3", "k3", hash(BRIEF), T0 + 30), keys, "the colder entry went")
-        self.assertIn((sid, "g4", "k4", hash(BRIEF), T0 + 30), keys)
+        self.assertNotIn((sid, "g3", "k3", hash(BRIEF), T0 + 30, False), keys, "the colder entry went")
+        self.assertIn((sid, "g4", "k4", hash(BRIEF), T0 + 30, False), keys)
         rep = km._summary_anchor_memo_report()
-        for k in ("entries", "bytes", "bound", "hit", "miss", "evict"):
+        for k in ("entries", "bytes", "bound", "hit", "miss", "evict", "fault"):
             self.assertIn(k, rep)
         self.assertEqual(rep["entries"], len(km._SUMMARY_ANCHOR_MEMO))
         self.assertEqual(rep["bound"], km.SUMMARY_ANCHOR_MEMO_BYTES)

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -1,0 +1,114 @@
+"""A card's brief or summary click lands on the text that carries it, never on a tool call (T388).
+
+The manager's finding, 2026-09-12: a blocked card whose brief had no validated citation sent its summary click to
+the node's WORK anchor, the newest trail segment's first assistant atom, a shell call inside a collapsed tool group,
+while the quoted questions were the same turn's last text atom thirteen minutes later; four landings filed
+pointer-exact on the wrong atom. The kernel now resolves such a click to the assistant text atom of that segment's
+turn that carries the line's opening sentence (else the turn's last text atom), never a tool_use or thinking atom,
+and ships the located span as the click's quote. Synthetic atoms only."""
+import os
+import tempfile
+import unittest
+
+_TMP = tempfile.mkdtemp()
+os.environ.setdefault("XDG_STATE_HOME", _TMP)
+os.environ.setdefault("ROMP_STATE_DIR", os.path.join(_TMP, "romp"))
+from romp_load import load_source
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BIN = os.path.join(ROOT, "bin")
+em = load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel", os.path.join(BIN, "romp-kernel"))
+
+T0 = 1781300000
+
+
+def tool(uuid, t):
+    return {"type": "assistant", "uuid": uuid, "t": t, "message": {"role": "assistant", "content": [
+        {"type": "tool_use", "id": "tu-" + uuid, "name": "Bash", "input": {"command": "true"}}]}}
+
+
+def think(uuid, t):
+    return {"type": "assistant", "uuid": uuid, "t": t, "message": {"role": "assistant", "content": [{"type": "thinking", "thinking": "hm"}]}}
+
+
+def text(uuid, t, body):
+    return {"type": "assistant", "uuid": uuid, "t": t, "message": {"role": "assistant", "content": [{"type": "text", "text": body}]}}
+
+
+QUESTIONS = ("Four questions before I go on. Should the history budget follow the device or the setting? "
+             "Which client do the tests target? Do we keep the old exporter? Who owns the glossary file?")
+BRIEF = "Should the history budget follow the device or the setting? The session asks four things it cannot decide alone."
+
+
+class TheTextAtom(unittest.TestCase):
+    def test_a_segment_of_tool_calls_lands_on_the_turns_text_atom_not_the_first_tool_call(self):
+        seg = [tool("a1", T0), tool("a2", T0 + 1), tool("a3", T0 + 2), tool("a4", T0 + 3)]   # the newest trail segment: shell calls only
+        turn = {"t": T0, "end": T0 + 800, "atoms": seg + [text("t9", T0 + 780, QUESTIONS)]}    # the turn's last text atom, later
+        self.assertEqual(km._seg_jump(seg), "a1", "the WORK anchor: the first landable atom, a tool call (the collapsed group)")
+        u, q = km._summary_text_anchor((turn, seg), BRIEF)
+        self.assertEqual(u, "t9", "the brief click lands on the text atom that carries its opening sentence")
+        self.assertEqual(q, "Should the history budget follow the device or the setting?", "the located span rides as the quote")
+
+    def test_the_atom_carrying_the_opening_sentence_wins_over_a_later_text_atom(self):
+        seg = [tool("a1", T0), text("t5", T0 + 10, QUESTIONS), text("t6", T0 + 20, "Done for now.")]
+        turn = {"t": T0, "end": T0 + 30, "atoms": seg}
+        u, q = km._summary_text_anchor((turn, seg), BRIEF)
+        self.assertEqual((u, q), ("t5", "Should the history budget follow the device or the setting?"))
+
+    def test_no_sentence_match_falls_to_the_segments_last_text_atom_with_no_quote(self):
+        seg = [tool("a1", T0), text("t5", T0 + 10, "first note"), text("t6", T0 + 20, "second note")]
+        turn = {"t": T0, "end": T0 + 30, "atoms": seg}
+        self.assertEqual(km._summary_text_anchor((turn, seg), "Decide the retry policy for the exporter."), ("t6", None))
+
+    def test_a_segment_without_text_falls_to_the_turns_last_text_atom(self):
+        seg = [tool("a1", T0), think("th", T0 + 1)]
+        turn = {"t": T0, "end": T0 + 60, "atoms": seg + [text("t7", T0 + 50, "wrap-up here")]}
+        self.assertEqual(km._summary_text_anchor((turn, seg), "Nothing that matches."), ("t7", None))
+
+    def test_thinking_and_tool_calls_alone_resolve_to_nothing(self):
+        seg = [tool("a1", T0), think("th", T0 + 1)]
+        turn = {"t": T0, "end": T0 + 5, "atoms": seg}
+        self.assertEqual(km._summary_text_anchor((turn, seg), BRIEF), (None, None))
+        self.assertEqual(km._summary_text_anchor(None, BRIEF), (None, None))
+
+    def test_an_api_error_and_the_null_settle_are_never_the_landing(self):
+        err = dict(text("e1", T0 + 5, "API Error: overloaded"), isApiError=True)
+        seg = [tool("a1", T0), err, text("t2", T0 + 6, "the real reply")]
+        turn = {"t": T0, "end": T0 + 10, "atoms": seg}
+        self.assertEqual(km._summary_text_anchor((turn, seg), "Nothing matches."), ("t2", None))
+
+    def test_the_opening_sentence_drops_a_list_number_and_stops_at_the_first_sentence_end(self):
+        self.assertEqual(km._opening_sentence("1. Decide the retry policy. Then the rest."), "Decide the retry policy.")
+        self.assertEqual(km._opening_sentence("\n\nShort? Yes it is."), "Short? Yes it is.", "a sentence end inside the first twelve characters is not the cut")
+        self.assertEqual(km._opening_sentence(""), "")
+
+    def test_the_memo_answers_a_repeat_without_reading_again(self):
+        seg = [tool("a1", T0), text("t5", T0 + 10, QUESTIONS)]
+        turn = {"t": T0, "end": T0 + 30, "atoms": seg}
+        km._SUMMARY_ANCHOR_MEMO.clear()
+        first = km._summary_text_anchor((turn, seg), BRIEF, memo_key=("11111111-2222-3333-4444-555555555555", "g1", "k1"))
+        seg[1]["message"]["content"][0]["text"] = "changed under the memo"      # the same key: the memo answers, no re-read
+        again = km._summary_text_anchor((turn, seg), BRIEF, memo_key=("11111111-2222-3333-4444-555555555555", "g1", "k1"))
+        self.assertEqual(first, again)
+        self.assertEqual(first[0], "t5")
+
+
+class TheWiring(unittest.TestCase):
+    def test_the_card_chain_tries_the_text_atom_before_the_latest_prose_walk_and_the_tree_rows_carry_it(self):
+        src = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+        tier = src.index("_sa_u, _sa_q = _summary_text_anchor(seg_turn.get(_sk), _line, memo_key=(fsid, nid, _sk))")
+        walk = src.index("_best = None                             # (substantive, seg_t): prefer substantive, then latest")
+        self.assertLess(tier, walk, "the text-atom tier runs before the latest-prose walk and the work-anchor last resort")
+        self.assertIn('"summaryAnchorUuid": _nsa_u,', src, "every tree row carries the brief line's own landing")
+        self.assertIn('"summaryAnchorQuote": _nsa_q,', src)
+        self.assertIn("else (_sa_q or None)),", src, "the card's quote falls to the text-atom tier's span")
+        ts = open(os.path.join(ROOT, "ui", "webview", "feed.ts"), encoding="utf-8").read()
+        self.assertIn("if (!repeat && node.summaryAnchorUuid) {", ts, "the modal's brief line prefers the brief's own landing")
+        self.assertIn("anchorUuid: su, quote: sq", ts, "…and sends its span as the click's quote")
+        self.assertIn("summaryAnchorUuid?: string | null;                            // the brief/summary line's own landing", ts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -10,9 +10,8 @@ import os
 import tempfile
 import unittest
 
-_TMP = tempfile.mkdtemp()
-os.environ.setdefault("XDG_STATE_HOME", _TMP)
-os.environ.setdefault("ROMP_STATE_DIR", os.path.join(_TMP, "romp"))
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 from romp_load import load_source
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/test_card_summary_anchor.py
+++ b/tests/test_card_summary_anchor.py
@@ -109,5 +109,60 @@ class TheWiring(unittest.TestCase):
         self.assertIn("summaryAnchorUuid?: string | null;                            // the brief/summary line's own landing", ts)
 
 
+class TheMemoIsBoundedByBytes(unittest.TestCase):
+    """The summary-anchor memo follows the user's caches rule (2026-09-11): a byte bound as a fraction of machine memory
+    with an environment override, oldest-first eviction that sheds only the deficit, counters under /perf; never a
+    count literal with a wholesale clear (the manager's fold on T388)."""
+    def setUp(self):
+        self._bound = km.SUMMARY_ANCHOR_MEMO_BYTES
+        km._SUMMARY_ANCHOR_MEMO.clear()
+        for k in ("hit", "miss", "evict", "bytes"):
+            km._SUMMARY_ANCHOR_STATS[k] = 0
+
+    def tearDown(self):
+        km.SUMMARY_ANCHOR_MEMO_BYTES = self._bound
+        km._SUMMARY_ANCHOR_MEMO.clear()
+
+    def test_the_bound_is_a_fraction_of_memory_with_an_override_and_no_count_literal(self):
+        from unittest import mock
+        self.assertEqual(km._summary_anchor_memo_bound(), km._mem_total_bytes() // 256)
+        with mock.patch.dict(os.environ, {"ROMP_SUMMARY_ANCHOR_MEMO_BYTES": "8192"}):
+            self.assertEqual(km._summary_anchor_memo_bound(), 8192)
+        with mock.patch.dict(os.environ, {"ROMP_SUMMARY_ANCHOR_MEMO_BYTES": "lots"}):
+            self.assertEqual(km._summary_anchor_memo_bound(), km._mem_total_bytes() // 256, "an unreadable override falls back to the fraction")
+        self.assertEqual(km.SUMMARY_ANCHOR_MEMO_BYTES, km._summary_anchor_memo_bound(), "the module constant IS the fraction, no literal")
+        self.assertFalse(hasattr(km, "_SUMMARY_ANCHOR_MEMO_MAX"), "no count cap")
+        src = open(os.path.join(ROOT, "kernel", "kernel.py"), encoding="utf-8").read()
+        self.assertNotIn("_SUMMARY_ANCHOR_MEMO.clear()", src, "no wholesale clear on the cap")
+        self.assertIn('("summaryAnchor", _summary_anchor_memo_report)', src, "reported under /perf beside the other memos")
+
+    def test_a_hit_survives_an_eviction_of_a_colder_entry_and_the_counters_say_so(self):
+        seg = [tool("a1", T0), text("t5", T0 + 10, QUESTIONS)]
+        turn = {"t": T0, "end": T0 + 30, "atoms": seg}
+        sid = "11111111-2222-3333-4444-555555555555"
+        km.SUMMARY_ANCHOR_MEMO_BYTES = 1      # any second entry is over the bound: the put sheds the coldest, keeps the newest
+        km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g1", "k1"))      # A: a miss, stored
+        km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g2", "k2"))      # B: a miss, stored; A is the colder
+        self.assertEqual(km._SUMMARY_ANCHOR_STATS["evict"], 1, "over the bound: one eviction, the oldest")
+        self.assertEqual(len(km._SUMMARY_ANCHOR_MEMO), 1)
+        self.assertIn((sid, "g2", "k2", hash(BRIEF), T0 + 30), km._SUMMARY_ANCHOR_MEMO, "the newest survives, the coldest went")
+        km.SUMMARY_ANCHOR_MEMO_BYTES = 10 ** 6
+        km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g3", "k3"))      # C stored beside B
+        before = km._SUMMARY_ANCHOR_STATS["hit"]
+        km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g2", "k2"))      # a HIT on B: B is now the newest
+        self.assertEqual(km._SUMMARY_ANCHOR_STATS["hit"], before + 1)
+        km.SUMMARY_ANCHOR_MEMO_BYTES = 1
+        km._summary_text_anchor((turn, seg), BRIEF, memo_key=(sid, "g4", "k4"))      # D: sheds the coldest, C, never the hit B
+        keys = list(km._SUMMARY_ANCHOR_MEMO)
+        self.assertNotIn((sid, "g3", "k3", hash(BRIEF), T0 + 30), keys, "the colder entry went")
+        self.assertIn((sid, "g4", "k4", hash(BRIEF), T0 + 30), keys)
+        rep = km._summary_anchor_memo_report()
+        for k in ("entries", "bytes", "bound", "hit", "miss", "evict"):
+            self.assertIn(k, rep)
+        self.assertEqual(rep["entries"], len(km._SUMMARY_ANCHOR_MEMO))
+        self.assertEqual(rep["bound"], km.SUMMARY_ANCHOR_MEMO_BYTES)
+        self.assertGreater(rep["bytes"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_card_summary_anchor_e2e.py
+++ b/tests/test_card_summary_anchor_e2e.py
@@ -3,7 +3,10 @@
 citation, whose newest trail segment holds only a tool call, and whose wrap-up sits in the same turn's second
 segment. The base landed on the tool call (the segment's first landable atom, a collapsed tool group); the head
 lands on the text atom that carries the brief's opening sentence, with the span the chat highlights. The same
-harness shows a body read that raises leaving build_feed whole. SYNTHETIC fixtures only; a private synthetic sid."""
+harness shows a body read that raises leaving build_feed whole, and (the verifier's second round) that the card
+and its modal row resolve one brief to ONE landing: a blocked top whose child worked later in a second turn, and a
+completed top holding a valid citation; a handoff row carries no landing of its own. SYNTHETIC fixtures only; a
+private synthetic sid."""
 import json
 import os
 import tempfile
@@ -24,9 +27,13 @@ jd = km.jd
 NOW = 1_788_300_000
 T0 = NOW - 3600
 SID = "f11e0002-1111-4222-8333-000000000002"    # private synthetic sid, never the shared placeholder
+PEER = "f11e0003-1111-4222-8333-000000000003"
 WRAP = ("Four questions before I go on. Should the history budget follow the device or the setting? "
         "Which client do the tests target? Do we keep the old exporter? Who owns the glossary file?")
+WRAP2 = ("Picking this up in the child step. Should the history budget follow the device or the setting? "
+         "The exporter now keeps both clients while the tests run against the old one, and the glossary file is mine.")
 BRIEF = "Should the history budget follow the device or the setting? The session asks four things it cannot decide alone."
+SUMMARY = "The history budget follows the device now. Both clients stay while the tests run against the old one."
 
 
 def iso(t):
@@ -50,7 +57,17 @@ def aline(t, text, uuid, parent):
             "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
 
 
+def node(nid, text, parent=None, t=T0, **kw):
+    d = {"id": nid, "text": text, "parentId": parent, "nodeComplete": False, "blocked": False, "cleared": False,
+         "trail": [], "t": t, "mt": t, "log": []}
+    d.update(kw)
+    return d
+
+
 class TheBriefClickEndToEnd(unittest.TestCase):
+    G1 = SID + ":g1"
+    G2 = SID + ":g2"
+
     def setUp(self):
         km._downtime[:] = []
         self.td = tempfile.TemporaryDirectory()
@@ -61,17 +78,21 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         import re as _re
         pdir = proj / _re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
         pdir.mkdir(parents=True)
-        # one turn, two segments: the typed opener and a shell call, then a typed prompt absorbed mid-turn and the
-        # wrap-up that carries the four questions, thirteen minutes after the call
+        # turn one, two segments: the typed opener and a shell call, then a typed prompt absorbed mid-turn and the
+        # wrap-up that carries the four questions, thirteen minutes after the call; turn two, twenty minutes later:
+        # the child step's own reply, carrying the same opening sentence
         recs = [uline(T0, "land the history gaps change", "u1"),
                 tline(T0 + 60, "a1", "u1"),
                 uline(T0 + 120, "keep going", "u2", "a1"),
-                aline(T0 + 840, WRAP, "t9", "u2")]
+                aline(T0 + 840, WRAP, "t9", "u2"),
+                uline(T0 + 1200, "now the child step", "u3", "t9"),
+                aline(T0 + 1260, WRAP2, "t20", "u3")]
         self.tpath = pdir / (SID + ".jsonl")
         self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
         names = td / "names"
         names.mkdir()
         (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        (names / PEER).write_text("api\t%s\t#abcdef\n" % str(cdir))
         self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
                       km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
         jd.gist_llm = lambda p: ""
@@ -95,39 +116,39 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         km._autonudge_cache.clear()
         self.td.cleanup()
 
-    def _store(self, trail):
-        g = SID + ":g1"
+    def _write(self, nodes, status):
         (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
-            "rompUuid": SID, "seq": 1, "lastNode": g,
-            "nodes": {g: {"id": g, "text": "Land the history gaps change", "parentId": None,
-                          "nodeComplete": False, "blocked": True, "cleared": False,
-                          "trail": trail, "t": T0, "mt": T0 + 900,
-                          "blockWhy": "four questions the user must answer", "blockSummary": BRIEF,
-                          "summaryAnchor": None, "briefedMt": T0 + 900,
-                          "log": [{"ev_t": T0 + 850, "src": "closer", "kind": "block", "at": T0 + 850,
-                                   "why": "four questions the user must answer"}]}},
-            "placements": {}, "status": {g: "blocked"}}))
-        return g
+            "rompUuid": SID, "seq": len(nodes), "lastNode": self.G1, "nodes": nodes, "placements": {}, "status": status}))
 
-    def _card(self, g):
+    def _blocked_top(self, trail):
+        return node(self.G1, "Land the history gaps change", trail=trail, mt=T0 + 900, blocked=True,
+                    blockWhy="four questions the user must answer", blockSummary=BRIEF, summaryAnchor=None,
+                    briefedMt=T0 + 900,
+                    log=[{"ev_t": T0 + 850, "src": "closer", "kind": "block", "at": T0 + 850,
+                          "why": "four questions the user must answer"}])
+
+    def _card(self, g=None):
         km._parse(str(self.tpath), SID, NOW)           # warm the kernel parse cache: the anchor tiers read it
-        return next(a for a in km.build_feed(NOW)["asks"] if a.get("itemId") == g)
+        return next(a for a in km.build_feed(NOW)["asks"] if a.get("itemId") == (g or self.G1))
 
-    def test_the_turn_holds_two_segments_the_first_a_tool_call_only(self):
-        self.assertEqual(len(self.segs), 2, self.segs)
+    def _row(self, card, nid):
+        return next(r for r in card["tree"] if r["id"] == nid)
+
+    def test_the_turns_hold_three_segments_the_first_a_tool_call_only(self):
+        self.assertEqual(len(self.segs), 3, self.segs)
 
     def test_the_brief_click_lands_on_the_wrap_up_text_atom_not_the_tool_call(self):
-        g = self._store(trail=[self.segs[0]])          # the newest trail segment: the tool call only
-        card = self._card(g)
+        self._write({self.G1: self._blocked_top([self.segs[0]])}, {self.G1: "blocked"})   # the newest trail segment: the tool call only
+        card = self._card()
         self.assertEqual(card["summaryAnchorUuid"], "t9", "the text atom that carries the brief's opening sentence (the base: a1, the tool call)")
         self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?")
-        row = next(r for r in card["tree"] if r["id"] == g)
+        row = self._row(card, self.G1)
         self.assertEqual((row["summaryAnchorUuid"], row["summaryAnchorQuote"]), ("t9", card["summaryAnchorQuote"]),
                          "the modal's row carries the same landing")
         self.assertEqual(row["anchorUuid"], "a1", "the work anchor stays the segment's landable atom for the mark and time zones")
 
     def test_a_body_read_that_raises_leaves_build_feed_whole(self):
-        g = self._store(trail=[self.segs[0]])
+        self._write({self.G1: self._blocked_top([self.segs[0]])}, {self.G1: "blocked"})
         real = km.jd._atom_text
         def boom(a):                                   # the wrap-up's body cannot be read; every other read is real
             if a.get("uuid") == "t9":
@@ -136,7 +157,7 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         km.jd._atom_text = boom
         try:
             try:
-                card = self._card(g)
+                card = self._card()
             except Exception as ex:
                 self.fail("build_feed raised on one unreadable body, so no session got a feed this cycle: %r" % (ex,))
         finally:
@@ -144,6 +165,48 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         self.assertEqual(card["summaryAnchorUuid"], "t9", "no quote could be located, so the tier falls to the substantive text atom, never a raise")
         self.assertIsNone(card["summaryAnchorQuote"])
         self.assertGreaterEqual(km._SUMMARY_ANCHOR_STATS["fault"], 1)
+
+    def test_a_blocked_top_with_a_child_that_worked_later_lands_the_card_and_its_row_in_one_place(self):
+        # the top's own trail names the tool-only first segment; its child worked later, in the second turn, whose
+        # reply carries the brief's opening sentence too: the card reads the subtree (t20) and so must the row
+        top = self._blocked_top([self.segs[0]])
+        child = node(self.G2, "The child step", parent=self.G1, t=T0 + 1200, mt=T0 + 1260, trail=[self.segs[2]])
+        self._write({self.G1: top, self.G2: child}, {self.G1: "blocked"})
+        card = self._card()
+        row = self._row(card, self.G1)
+        self.assertEqual(card["summaryAnchorUuid"], "t20", "the newest subtree segment's text atom carrying the opening sentence")
+        self.assertEqual(row["summaryAnchorUuid"], card["summaryAnchorUuid"], "one brief, one landing, whichever surface is clicked")
+        self.assertEqual(row["summaryAnchorQuote"], card["summaryAnchorQuote"])
+
+    def test_a_completed_top_with_a_citation_lands_the_card_and_its_row_on_the_same_recap(self):
+        # a completed top pins its summary click to the newest substantive tail across the subtree (the completion
+        # recap); the citation on t9 stands valid, and the row must follow the card's pin rather than the citation
+        top = node(self.G1, "Land the history gaps change", trail=[self.segs[1]], mt=T0 + 1300, nodeComplete=True,
+                   summary=SUMMARY, summaryAnchor="t9", summaryQuote="Should the history budget follow the device or the setting?",
+                   distilledMt=NOW - 10, settledAt=T0 + 1300,
+                   log=[{"ev_t": T0 + 1290, "src": "closer", "kind": "done", "at": T0 + 1290, "why": "landed"}])
+        child = node(self.G2, "The child step", parent=self.G1, t=T0 + 1200, mt=T0 + 1260, trail=[self.segs[2]], nodeComplete=True,
+                     log=[{"ev_t": T0 + 1270, "src": "closer", "kind": "done", "at": T0 + 1270, "why": "done"}])
+        self._write({self.G1: top, self.G2: child}, {self.G1: "completed"})
+        card = self._card()
+        row = self._row(card, self.G1)
+        self.assertEqual(card["column"], "completed")
+        self.assertEqual(card["summaryAnchorUuid"], "t20", "the completed pin: the newest substantive tail across the subtree")
+        self.assertEqual(row["summaryAnchorUuid"], card["summaryAnchorUuid"], "the row follows the card's pin, not the citation")
+
+    def test_a_handoff_row_carries_no_landing_of_its_own(self):
+        # a handoff row's session is the peer's; an anchor resolved in this session's parse would be a foreign atom
+        # to the peer's chat, so the row ships none and its line falls to the work anchor's click
+        top = self._blocked_top([self.segs[0]])
+        tracker = node(self.G2, "delegated to api", parent=self.G1, t=T0 + 1200, mt=T0 + 1260, trail=[self.segs[2]],
+                       handoff={"peer": PEER, "goalId": PEER + ":g3"}, blockSummary=BRIEF)
+        own = node(SID + ":g3", "The local step", parent=self.G1, t=T0 + 900, mt=T0 + 900, trail=[self.segs[1]])   # a top whose
+        self._write({self.G1: top, self.G2: tracker, SID + ":g3": own}, {self.G1: "blocked"})   # only leaf is a handoff renders no card
+        card = self._card()
+        row = self._row(card, self.G2)
+        self.assertEqual(row["kind"], "handoff")
+        self.assertIsNone(row["summaryAnchorUuid"], "a handoff row's brief line falls to goWork")
+        self.assertIsNone(row["summaryAnchorQuote"])
 
 
 if __name__ == "__main__":

--- a/tests/test_card_summary_anchor_e2e.py
+++ b/tests/test_card_summary_anchor_e2e.py
@@ -135,7 +135,10 @@ class TheBriefClickEndToEnd(unittest.TestCase):
             return real(a)
         km.jd._atom_text = boom
         try:
-            card = self._card(g)
+            try:
+                card = self._card(g)
+            except Exception as ex:
+                self.fail("build_feed raised on one unreadable body, so no session got a feed this cycle: %r" % (ex,))
         finally:
             km.jd._atom_text = real
         self.assertEqual(card["summaryAnchorUuid"], "t9", "no quote could be located, so the tier falls to the substantive text atom, never a raise")

--- a/tests/test_card_summary_anchor_e2e.py
+++ b/tests/test_card_summary_anchor_e2e.py
@@ -121,10 +121,13 @@ class TheBriefClickEndToEnd(unittest.TestCase):
             "rompUuid": SID, "seq": len(nodes), "lastNode": self.G1, "nodes": nodes, "placements": {}, "status": status}))
 
     def _blocked_top(self, trail):
-        return node(self.G1, "Land the history gaps change", trail=trail, mt=T0 + 900, blocked=True,
+        # the block lands AFTER the last user turn (u3 at T0 + 1200), so no plain reply follows it and the card
+        # stays in needs-input, where the client shows the brief and wires its click; a block with a later plain
+        # turn sits in the re-judging window, where no distiller line renders (the verifier's fourth round)
+        return node(self.G1, "Land the history gaps change", trail=trail, mt=T0 + 1300, blocked=True,
                     blockWhy="four questions the user must answer", blockSummary=BRIEF, summaryAnchor=None,
-                    briefedMt=T0 + 900,
-                    log=[{"ev_t": T0 + 850, "src": "closer", "kind": "block", "at": T0 + 850,
+                    briefedMt=T0 + 1300,
+                    log=[{"ev_t": T0 + 1300, "src": "closer", "kind": "block", "at": T0 + 1300,
                           "why": "four questions the user must answer"}])
 
     def _card(self, g=None):
@@ -140,6 +143,7 @@ class TheBriefClickEndToEnd(unittest.TestCase):
     def test_the_brief_click_lands_on_the_wrap_up_text_atom_not_the_tool_call(self):
         self._write({self.G1: self._blocked_top([self.segs[0]])}, {self.G1: "blocked"})   # the newest trail segment: the tool call only
         card = self._card()
+        self.assertEqual((card["column"], card["distillState"]), ("needs_input", "blocked"), "a displaying state: the brief shows and its click is wired")
         self.assertEqual(card["summaryAnchorUuid"], "t9", "the text atom that carries the brief's opening sentence (the base: a1, the tool call)")
         self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?")
         row = self._row(card, self.G1)
@@ -244,6 +248,24 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         row = self._row(card, self.G1)
         self.assertEqual(row["summaryAnchorUuid"], card["summaryAnchorUuid"], "the card and its row carry the landing")
         self.assertEqual(len(calls), 1, "…from ONE resolve of the tier for the node and its line, not one per surface")
+
+    def test_a_stall_floored_card_lands_on_the_brief_it_shows_not_the_tool_call(self):
+        # romp's nudge gate holds an idle working top (a stall record, no block verdict): the column floors to
+        # needs-input (the user's 2026-08-13 rule) while the distill state stays None, so the client shows the
+        # staller's brief through the column fallback; the kernel must resolve the landing from that same brief,
+        # else the newest tool-only segment hands the click the tool call (the defect this change opens with)
+        real = km._stalled_goals
+        km._stalled_goals = lambda: {self.G1: {"why": "the reviver is not retiring", "since": NOW - 100}}
+        try:
+            top = node(self.G1, "Land the history gaps change", trail=[self.segs[0]], mt=T0 + 900,
+                       blockSummary=BRIEF, summaryAnchor=None, briefedMt=T0 + 900)
+            self._write({self.G1: top}, {self.G1: "working"})
+            card = self._card()
+        finally:
+            km._stalled_goals = real
+        self.assertEqual((card["column"], card["distillState"]), ("needs_input", None), "the stall floor: needs-input with no distill state")
+        self.assertEqual(card["summaryAnchorUuid"], "t9", "the brief the client shows lands on its own sentence (the base: a1, the tool call)")
+        self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?")
 
     def test_a_handoff_row_carries_no_landing_of_its_own(self):
         # a handoff row's session is the peer's; an anchor resolved in this session's parse would be a foreign atom

--- a/tests/test_card_summary_anchor_e2e.py
+++ b/tests/test_card_summary_anchor_e2e.py
@@ -210,7 +210,8 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         self.assertEqual(card["column"], "needs_input", "the live prompt floors the working top")
         self.assertEqual(card["distillState"], "blocked", "…and the card shows the decision brief")
         self.assertEqual(card["summaryAnchorUuid"], "t20", "the landing follows the shown brief (its sentence in the newest segment), not the takeaway")
-        self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?")
+        self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?",
+                         "the located span is the SHOWN brief's sentence; resolved from the takeaway's line (the column's rule) no span is found")
 
     def test_a_faulted_build_is_served_but_not_memoized_so_the_next_build_recovers(self):
         self._write({self.G1: self._blocked_top([self.segs[0]])}, {self.G1: "blocked"})

--- a/tests/test_card_summary_anchor_e2e.py
+++ b/tests/test_card_summary_anchor_e2e.py
@@ -194,6 +194,56 @@ class TheBriefClickEndToEnd(unittest.TestCase):
         self.assertEqual(card["summaryAnchorUuid"], "t20", "the completed pin: the newest substantive tail across the subtree")
         self.assertEqual(row["summaryAnchorUuid"], card["summaryAnchorUuid"], "the row follows the card's pin, not the citation")
 
+    def test_a_working_top_floored_to_needs_input_lands_on_the_brief_it_shows(self):
+        # a live permission prompt floors a WORKING top to needs-input: the card shows its decision brief (the
+        # distill state is blocked), so the click must land on the brief's sentence (t20), never the takeaway's (t9)
+        # that the column's rule would name (the verifier's third round)
+        km._live_map = lambda: {SID: {"state": "permission", "since": NOW - 100, "model": "", "effort": "",
+                                     "context": None, "compactPct": None, "color": None}}
+        top = node(self.G1, "Land the history gaps change", trail=[self.segs[0]], mt=T0 + 900,
+                   summary="Four questions before I go on. The earlier completion left these standing.",   # its sentence: t9 only
+                   summaryAnchor=None, distilledMt=T0 + 700,
+                   blockSummary=BRIEF, briefedMt=T0 + 900)                                              # its sentence: t9 and t20
+        child = node(self.G2, "The child step", parent=self.G1, t=T0 + 1200, mt=T0 + 1260, trail=[self.segs[2]])
+        self._write({self.G1: top, self.G2: child}, {self.G1: "working"})
+        card = self._card()
+        self.assertEqual(card["column"], "needs_input", "the live prompt floors the working top")
+        self.assertEqual(card["distillState"], "blocked", "…and the card shows the decision brief")
+        self.assertEqual(card["summaryAnchorUuid"], "t20", "the landing follows the shown brief (its sentence in the newest segment), not the takeaway")
+        self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?")
+
+    def test_a_faulted_build_is_served_but_not_memoized_so_the_next_build_recovers(self):
+        self._write({self.G1: self._blocked_top([self.segs[0]])}, {self.G1: "blocked"})
+        real = km.jd._atom_text
+        def boom(a):
+            if a.get("uuid") == "t9":
+                raise km.em.LazyBodyRead("no record at the offset")
+            return real(a)
+        km.jd._atom_text = boom
+        try:
+            first = self._card()
+        finally:
+            km.jd._atom_text = real
+        self.assertEqual((first["summaryAnchorUuid"], first["summaryAnchorQuote"]), ("t9", None), "the faulted build lands without the span")
+        second = self._card()                          # nothing on disk moved: only a non-memoized entry re-derives
+        self.assertEqual(second["summaryAnchorQuote"], "Should the history budget follow the device or the setting?",
+                         "the next build recovers the span: the faulted entry was not memoized")
+
+    def test_the_landing_is_resolved_once_per_node_and_line_within_a_build(self):
+        self._write({self.G1: self._blocked_top([self.segs[0]])}, {self.G1: "blocked"})
+        real, calls = km._summary_text_anchor, []
+        def counting(*a, **kw):
+            calls.append(a[2] if len(a) > 2 else kw.get("memo_key"))
+            return real(*a, **kw)
+        km._summary_text_anchor = counting
+        try:
+            card = self._card()
+        finally:
+            km._summary_text_anchor = real
+        row = self._row(card, self.G1)
+        self.assertEqual(row["summaryAnchorUuid"], card["summaryAnchorUuid"], "the card and its row carry the landing")
+        self.assertEqual(len(calls), 1, "…from ONE resolve of the tier for the node and its line, not one per surface")
+
     def test_a_handoff_row_carries_no_landing_of_its_own(self):
         # a handoff row's session is the peer's; an anchor resolved in this session's parse would be a foreign atom
         # to the peer's chat, so the row ships none and its line falls to the work anchor's click

--- a/tests/test_card_summary_anchor_e2e.py
+++ b/tests/test_card_summary_anchor_e2e.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""The card's brief click, end to end through build_feed (T388): a blocked card whose brief has no validated
+citation, whose newest trail segment holds only a tool call, and whose wrap-up sits in the same turn's second
+segment. The base landed on the tool call (the segment's first landable atom, a collapsed tool group); the head
+lands on the text atom that carries the brief's opening sentence, with the span the chat highlights. The same
+harness shows a body read that raises leaving build_feed whole. SYNTHETIC fixtures only; a private synthetic sid."""
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
+from romp_load import load_source
+km = load_source("romp_kernel_anche2e", os.path.join(BIN, "romp-kernel"))
+jd = km.jd
+
+NOW = 1_788_300_000
+T0 = NOW - 3600
+SID = "f11e0002-1111-4222-8333-000000000002"    # private synthetic sid, never the shared placeholder
+WRAP = ("Four questions before I go on. Should the history budget follow the device or the setting? "
+        "Which client do the tests target? Do we keep the old exporter? Who owns the glossary file?")
+BRIEF = "Should the history budget follow the device or the setting? The session asks four things it cannot decide alone."
+
+
+def iso(t):
+    return datetime.fromtimestamp(t, timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def uline(t, text, uuid, parent=None):
+    return {"type": "user", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "promptSource": "typed", "message": {"role": "user", "content": text}}
+
+
+def tline(t, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "tu-" + uuid, "name": "Bash",
+                                                          "input": {"command": "true"}}],
+                        "stop_reason": "tool_use"}}
+
+
+def aline(t, text, uuid, parent):
+    return {"type": "assistant", "timestamp": iso(t), "uuid": uuid, "parentUuid": parent,
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}], "stop_reason": "end_turn"}}
+
+
+class TheBriefClickEndToEnd(unittest.TestCase):
+    def setUp(self):
+        km._downtime[:] = []
+        self.td = tempfile.TemporaryDirectory()
+        td = Path(self.td.name)
+        cdir = td / "launchdir"
+        cdir.mkdir()
+        proj = td / "projects"
+        import re as _re
+        pdir = proj / _re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(str(cdir)))
+        pdir.mkdir(parents=True)
+        # one turn, two segments: the typed opener and a shell call, then a typed prompt absorbed mid-turn and the
+        # wrap-up that carries the four questions, thirteen minutes after the call
+        recs = [uline(T0, "land the history gaps change", "u1"),
+                tline(T0 + 60, "a1", "u1"),
+                uline(T0 + 120, "keep going", "u2", "a1"),
+                aline(T0 + 840, WRAP, "t9", "u2")]
+        self.tpath = pdir / (SID + ".jsonl")
+        self.tpath.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
+        names = td / "names"
+        names.mkdir()
+        (names / SID).write_text("web\t%s\t#abcdef\n" % str(cdir))
+        self.saved = (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+                      km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD, jd.gist_llm)
+        jd.gist_llm = lambda p: ""
+        km._autonudge_cache.clear()
+        km._GLOBAL_CLAUDE_MD = td / "no-global-claude.md"
+        jd.NAMES, jd.PROJECTS = names, proj
+        jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR = td / "captions", td / "archive", td / "goals"
+        jd.STATE = td
+        km.NAMES = names
+        km._live_map = lambda: {SID: {"state": "idle", "since": NOW - 100, "model": "", "effort": "",
+                                     "context": None, "compactPct": None, "color": None}}
+        jd.GOALDIR.mkdir(parents=True, exist_ok=True)
+        s = jd.parsed_session(SID, [str(self.tpath)], NOW)
+        st0 = {"rompUuid": SID, "nodes": {}, "placements": {}, "status": {}}
+        self.segs = [sg["id"] for turn in s["turns"] for sg in jd._segs(turn, st0)]
+        km._SUMMARY_ANCHOR_MEMO.clear()
+
+    def tearDown(self):
+        (jd.NAMES, jd.PROJECTS, jd.CAPDIR, jd.ARCHDIR, jd.GOALDIR, jd.STATE,
+         km.NAMES, km._live_map, km._GLOBAL_CLAUDE_MD, jd.gist_llm) = self.saved
+        km._autonudge_cache.clear()
+        self.td.cleanup()
+
+    def _store(self, trail):
+        g = SID + ":g1"
+        (jd.GOALDIR / (SID + ".json")).write_text(json.dumps({
+            "rompUuid": SID, "seq": 1, "lastNode": g,
+            "nodes": {g: {"id": g, "text": "Land the history gaps change", "parentId": None,
+                          "nodeComplete": False, "blocked": True, "cleared": False,
+                          "trail": trail, "t": T0, "mt": T0 + 900,
+                          "blockWhy": "four questions the user must answer", "blockSummary": BRIEF,
+                          "summaryAnchor": None, "briefedMt": T0 + 900,
+                          "log": [{"ev_t": T0 + 850, "src": "closer", "kind": "block", "at": T0 + 850,
+                                   "why": "four questions the user must answer"}]}},
+            "placements": {}, "status": {g: "blocked"}}))
+        return g
+
+    def _card(self, g):
+        km._parse(str(self.tpath), SID, NOW)           # warm the kernel parse cache: the anchor tiers read it
+        return next(a for a in km.build_feed(NOW)["asks"] if a.get("itemId") == g)
+
+    def test_the_turn_holds_two_segments_the_first_a_tool_call_only(self):
+        self.assertEqual(len(self.segs), 2, self.segs)
+
+    def test_the_brief_click_lands_on_the_wrap_up_text_atom_not_the_tool_call(self):
+        g = self._store(trail=[self.segs[0]])          # the newest trail segment: the tool call only
+        card = self._card(g)
+        self.assertEqual(card["summaryAnchorUuid"], "t9", "the text atom that carries the brief's opening sentence (the base: a1, the tool call)")
+        self.assertEqual(card["summaryAnchorQuote"], "Should the history budget follow the device or the setting?")
+        row = next(r for r in card["tree"] if r["id"] == g)
+        self.assertEqual((row["summaryAnchorUuid"], row["summaryAnchorQuote"]), ("t9", card["summaryAnchorQuote"]),
+                         "the modal's row carries the same landing")
+        self.assertEqual(row["anchorUuid"], "a1", "the work anchor stays the segment's landable atom for the mark and time zones")
+
+    def test_a_body_read_that_raises_leaves_build_feed_whole(self):
+        g = self._store(trail=[self.segs[0]])
+        real = km.jd._atom_text
+        def boom(a):                                   # the wrap-up's body cannot be read; every other read is real
+            if a.get("uuid") == "t9":
+                raise km.em.LazyBodyRead("no record at the offset")
+            return real(a)
+        km.jd._atom_text = boom
+        try:
+            card = self._card(g)
+        finally:
+            km.jd._atom_text = real
+        self.assertEqual(card["summaryAnchorUuid"], "t9", "no quote could be located, so the tier falls to the substantive text atom, never a raise")
+        self.assertIsNone(card["summaryAnchorQuote"])
+        self.assertGreaterEqual(km._SUMMARY_ANCHOR_STATS["fault"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_close_why_boundary.py
+++ b/tests/test_close_why_boundary.py
@@ -109,6 +109,28 @@ class TheBriefsMaterial(unittest.TestCase):
         self.assertFalse(nd2.get("blockWhyCut"))
         self.assertEqual(jd._owed_why(nd2), "Decide the client now.")
 
+    def test_the_cut_fact_survives_a_re_assert_of_the_block(self):
+        sid = "11111111-2222-3333-4444-555555555555"
+        st = {"rompUuid": sid, "seq": 1, "nodes": {}, "placements": {}, "status": {}}
+        nd = {"id": sid + ":g1", "text": "Decide the client", "parentId": None, "nodeComplete": False, "blocked": False,
+              "cleared": False, "trail": [], "t": 1781300000, "mt": 1781300000, "log": []}
+        st["nodes"][nd["id"]] = nd
+        cut = jd._cut_why("Should the exporter keep the old client for this tenant too? " * 12, jd.WHY_MAX)
+        self.assertTrue(jd.record_verdict(st, nd, "closer", "block", 1781300100, why=cut))
+        jd.rollup_status(st, False)
+        self.assertTrue(nd.get("blockWhyCut"))
+        why_text = str(nd["blockWhy"])
+        self.assertTrue(jd.record_verdict(st, nd, "user", "reopen", 1781300400, msg=True))   # the user's reply lifts the block
+        jd.rollup_status(st, False)
+        self.assertFalse(nd["blocked"]); self.assertNotIn("blockWhyCut", nd, "the flag goes with the block")
+        jd._reassert_blocks(st, sid + ":seg-2", 1781300500, [(nd["id"], why_text)])   # the reply answered nothing: re-recorded
+        rows = [e for e in nd["log"] if e.get("kind") == "block"]
+        self.assertEqual(len(rows), 2, "the re-assert wrote a second block row")
+        self.assertTrue(rows[-1].get("whyCut"), "…carrying the cut fact from the source row")
+        jd.rollup_status(st, False)
+        self.assertTrue(nd.get("blockWhyCut"))
+        self.assertIn("the recorded reason ends here", jd._owed_why(nd))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_close_why_boundary.py
+++ b/tests/test_close_why_boundary.py
@@ -1,0 +1,87 @@
+"""A verdict's why is cut at a boundary, never mid-word, and the brief judge is told when it was cut (T388).
+
+The closer's block why used to be stored as a raw 300-character slice. A why that listed several questions was cut
+mid-word ("... Also say whether the d"), and the brief judge, fed the stump as material, reported a half-stated fifth
+question the user had to restate. Now a why is cut at a sentence end or a word boundary with a visible ellipsis, the
+cap stays where the tuning pin holds it, and the owed why the brief reads says where the recorded reason
+ends. Synthetic text only."""
+import json
+import os
+import tempfile
+import unittest
+
+_TMP = tempfile.mkdtemp()
+os.environ.setdefault("XDG_STATE_HOME", _TMP)
+os.environ.setdefault("ROMP_STATE_DIR", os.path.join(_TMP, "romp"))
+from romp_load import load_source
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "bin")
+jd = load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+
+SENT = ("The exporter keeps two clients and the history budget is a fraction of device memory. "
+        "Also say whether the default should follow the setting or the session. "
+        "And name the client the tests should target when both are present.")
+
+
+class CutWhy(unittest.TestCase):
+    def test_a_short_why_is_untouched(self):
+        self.assertEqual(jd._cut_why("  which   client should the exporter target?  ", 300),
+                         "which client should the exporter target?")
+
+    def test_a_long_why_is_cut_at_a_sentence_end_with_a_visible_mark(self):
+        out = jd._cut_why(SENT, 120)
+        self.assertTrue(out.endswith("." + jd.WHY_CUT_MARK), out)
+        self.assertEqual(out, "The exporter keeps two clients and the history budget is a fraction of device memory." + jd.WHY_CUT_MARK)
+        self.assertNotIn("Also say whether the d", out, "no stump of the next sentence")
+
+    def test_no_sentence_end_past_half_the_cap_cuts_at_a_word_boundary(self):
+        text = "a" + " word" * 80                      # one long sentence, no terminator
+        out = jd._cut_why(text, 100)
+        self.assertTrue(out.endswith(jd.WHY_CUT_MARK))
+        body = out[:-1]
+        self.assertLessEqual(len(body), 100)
+        self.assertFalse(body.endswith("wor"), "never mid-word")
+        self.assertTrue(body.endswith("word"), body[-12:])
+
+    def test_one_unbroken_token_falls_to_the_bare_cap(self):
+        out = jd._cut_why("x" * 500, 100)
+        self.assertEqual(out, "x" * 100 + jd.WHY_CUT_MARK)
+
+    def test_exactly_at_the_cap_is_not_cut(self):
+        text = "y" * 300
+        self.assertEqual(jd._cut_why(text, 300), text)
+
+
+class TheCloserParse(unittest.TestCase):
+    def test_a_block_why_longer_than_the_cap_is_cut_at_a_boundary_not_mid_word(self):
+        why = " ".join(["Question %d: should the exporter keep the old client for this tenant too?" % i for i in range(12)])
+        raw = json.dumps({"done": [], "block": [{"goal": 1, "why": why}]})
+        out = jd._parse_close(raw, 1)
+        got = out["block"][1]
+        self.assertTrue(got.endswith("?" + jd.WHY_CUT_MARK), got[-40:])
+        self.assertLessEqual(len(got), jd.WHY_MAX + 1)
+        self.assertLessEqual(len(got), jd.WHY_MAX + 1, "the ceiling stands; the cut lands at a boundary under it")
+
+    def test_a_short_block_why_is_stored_whole(self):
+        raw = json.dumps({"done": [], "block": [{"goal": 1, "why": "which client should the exporter target?"}]})
+        self.assertEqual(jd._parse_close(raw, 1)["block"][1], "which client should the exporter target?")
+
+    def test_a_planner_ops_why_keeps_its_cap_and_never_ends_mid_word(self):
+        out = jd._cut_why("word " * 100, jd.WHY_MAX)
+        self.assertTrue(out.endswith("word" + jd.WHY_CUT_MARK), out[-12:])
+        self.assertLessEqual(len(out), jd.WHY_MAX + 1)
+
+
+class TheBriefsMaterial(unittest.TestCase):
+    def test_the_owed_why_says_where_a_cut_reason_ends(self):
+        nd = {"blockWhy": "Decide the retry policy for the exporter." + jd.WHY_CUT_MARK}
+        owed = jd._owed_why(nd)
+        self.assertTrue(owed.startswith("Decide the retry policy for the exporter." + jd.WHY_CUT_MARK))
+        self.assertIn("the recorded reason ends here", owed)
+
+    def test_a_whole_why_gets_no_note(self):
+        self.assertEqual(jd._owed_why({"blockWhy": "Decide the retry policy."}), "Decide the retry policy.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_close_why_boundary.py
+++ b/tests/test_close_why_boundary.py
@@ -10,9 +10,8 @@ import os
 import tempfile
 import unittest
 
-_TMP = tempfile.mkdtemp()
-os.environ.setdefault("XDG_STATE_HOME", _TMP)
-os.environ.setdefault("ROMP_STATE_DIR", os.path.join(_TMP, "romp"))
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)  # a live kernel's export outranks the XDG floor
 from romp_load import load_source
 
 BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "bin")

--- a/tests/test_close_why_boundary.py
+++ b/tests/test_close_why_boundary.py
@@ -73,13 +73,41 @@ class TheCloserParse(unittest.TestCase):
 
 class TheBriefsMaterial(unittest.TestCase):
     def test_the_owed_why_says_where_a_cut_reason_ends(self):
-        nd = {"blockWhy": "Decide the retry policy for the exporter." + jd.WHY_CUT_MARK}
+        nd = {"blockWhy": "Decide the retry policy for the exporter." + jd.WHY_CUT_MARK, "blockWhyCut": True}
         owed = jd._owed_why(nd)
         self.assertTrue(owed.startswith("Decide the retry policy for the exporter." + jd.WHY_CUT_MARK))
         self.assertIn("the recorded reason ends here", owed)
 
     def test_a_whole_why_gets_no_note(self):
         self.assertEqual(jd._owed_why({"blockWhy": "Decide the retry policy."}), "Decide the retry policy.")
+
+    def test_a_complete_why_that_ends_with_an_ellipsis_is_not_told_as_cut(self):
+        # the cut is a stored fact, never a suffix test on prose (the verifier's first round)
+        self.assertFalse(jd.why_was_cut("Wait for the exporter to settle" + jd.WHY_CUT_MARK))
+        self.assertTrue(jd.why_was_cut(jd._cut_why("word " * 100, 100)))
+        self.assertEqual(jd._owed_why({"blockWhy": "Wait for it" + jd.WHY_CUT_MARK}), "Wait for it" + jd.WHY_CUT_MARK)
+
+    def test_the_cut_rides_the_verdict_row_into_the_nodes_flag(self):
+        sid = "11111111-2222-3333-4444-555555555555"
+        st = {"rompUuid": sid, "seq": 1, "nodes": {}, "placements": {}, "status": {}}
+        nd = {"id": sid + ":g1", "text": "Decide the client", "parentId": None, "nodeComplete": False, "blocked": False,
+              "cleared": False, "trail": [], "t": 1781300000, "mt": 1781300000, "log": []}
+        st["nodes"][nd["id"]] = nd
+        cut = jd._cut_why("Should the exporter keep the old client for this tenant too? " * 12, jd.WHY_MAX)
+        self.assertTrue(jd.record_verdict(st, nd, "closer", "block", 1781300100, why=cut))
+        self.assertTrue(nd["log"][-1].get("whyCut"), "the row carries the fact")
+        jd.rollup_status(st, False)
+        self.assertTrue(nd["blocked"])
+        self.assertTrue(nd.get("blockWhyCut"), "the fold materializes it")
+        self.assertIn("the recorded reason ends here", jd._owed_why(nd))
+        # a whole why after a lift: no row fact, no flag
+        st2 = {"rompUuid": sid, "seq": 1, "nodes": {}, "placements": {}, "status": {}}
+        nd2 = dict(nd, id=sid + ":g2", log=[]); st2["nodes"][nd2["id"]] = nd2
+        self.assertTrue(jd.record_verdict(st2, nd2, "closer", "block", 1781300100, why="Decide the client now."))
+        self.assertNotIn("whyCut", nd2["log"][-1])
+        jd.rollup_status(st2, False)
+        self.assertFalse(nd2.get("blockWhyCut"))
+        self.assertEqual(jd._owed_why(nd2), "Decide the client now.")
 
 
 if __name__ == "__main__":

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -107,6 +107,7 @@ HELPERS = {
     "_seg_key": ("sig", ("transcript",)),
     "_seg_last_text": ("sig", ("transcript",)),
     "_summary_text_anchor": ("sig", ("transcript",)),   # T388: the brief line's text-atom landing, read from the parse's atoms
+    "_summary_outrun": ("sig", ("store", "transcript")),   # T388: the T153 outrun rule on a node's stamps and its trail's segment times
     "_segs_seam": ("sig", ("transcript",)),
     "em.turn_scalar": ("sig", ("transcript",)),
     "jd._prompt_anchor_uuid": ("sig", ("transcript",)),

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -106,6 +106,7 @@ HELPERS = {
     "_seg_jump": ("sig", ("transcript",)),
     "_seg_key": ("sig", ("transcript",)),
     "_seg_last_text": ("sig", ("transcript",)),
+    "_summary_text_anchor": ("sig", ("transcript",)),   # T388: the brief line's text-atom landing, read from the parse's atoms
     "_segs_seam": ("sig", ("transcript",)),
     "em.turn_scalar": ("sig", ("transcript",)),
     "jd._prompt_anchor_uuid": ("sig", ("transcript",)),

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -108,6 +108,7 @@ HELPERS = {
     "_seg_last_text": ("sig", ("transcript",)),
     "_summary_text_anchor": ("sig", ("transcript",)),   # T388: the brief line's text-atom landing, read from the parse's atoms
     "_summary_outrun": ("sig", ("store", "transcript")),   # T388: the T153 outrun rule on a node's stamps and its trail's segment times
+    "_landing_inputs": ("sig", ("store",)),               # T388: the shown line and completed bit from a node's state and its brief fields
     "_segs_seam": ("sig", ("transcript",)),
     "em.turn_scalar": ("sig", ("transcript",)),
     "jd._prompt_anchor_uuid": ("sig", ("transcript",)),
@@ -156,6 +157,9 @@ HELPERS = {
 
 # ── the module-scope names the body reads without calling, name -> (kind, labels or note) ─────────────────
 MODULE_READS = {
+    "_SUMMARY_ANCHOR_STATS": ("sig", ("transcript",)),   # T388: the landing tier's fault counter, read to mark a derivation that
+    #                                                        met an unreadable body; such an entry is served but never memoized, so a
+    #                                                        memoized entry always carries faults 0 and the key needs no component
     "_NEEDS_INPUT_STATES": ("const", "the live-prompt perm states (permission, picker), a tuple of strings bound once"),
     "jd.CITE_MIN_CHARS": ("const", "the judge module's citation floor, an int bound once"),
     "jd.WHY_IN_FLIGHT": ("const", "the in-flight-class stall reasons, a tuple of the judge module's constant strings"),

--- a/tests/test_feed_memo_inputs.py
+++ b/tests/test_feed_memo_inputs.py
@@ -179,7 +179,8 @@ CTX = {
 }
 
 # closures defined inside the body: pure over its locals, no component
-LOCAL = ("_subtree", "_closure_done", "_fsubmax", "_closure_blocked", "_block_check_floor", "_note_peers", "flatten")
+LOCAL = ("_subtree", "_closure_done", "_fsubmax", "_closure_blocked", "_block_check_floor", "_note_peers", "flatten",
+         "_brief_landing")   # T388: the one resolve of a node's brief landing, a closure over the body's segment maps
 
 KINDS = {"sig", "pure", "clock"}          # HELPERS and CTX
 READ_KINDS = {"const", "sig", "pure"}     # MODULE_READS

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -3095,9 +3095,14 @@ class PlanTuning(unittest.TestCase):
     def test_why_cap_raised_to_300(self):
         long = "word " * 100                                   # ~500 chars after normalization
         ops = jd._parse_plan('{"ops":[{"why":"%s","do":"mint","text":"G"}]}' % long.strip(), 1)
-        self.assertEqual(len(ops[0]["why"]), 300, "planner why capped at 300 (was 200)")
+        # the ceiling is 300 (was 200); since T388 the cut lands at a word or sentence boundary under it and ends
+        # with the visible cut mark, so the stored why is never a mid-word stump the brief judge could misread
+        self.assertLessEqual(len(ops[0]["why"]), 300 + len(jd.WHY_CUT_MARK), "planner why capped at 300 (was 200)")
+        self.assertGreaterEqual(len(ops[0]["why"]), 150, "…and cut no lower than half the cap")
+        self.assertTrue(ops[0]["why"].endswith("word" + jd.WHY_CUT_MARK), ops[0]["why"][-12:])
         done = jd._parse_close('{"done":[{"goal":1,"why":"%s"}]}' % long.strip(), 1)["done"]
-        self.assertEqual(len(done[1]), 300, "closer doneWhy capped at 300 (was 200)")
+        self.assertLessEqual(len(done[1]), 300 + len(jd.WHY_CUT_MARK), "closer doneWhy capped at 300 (was 200)")
+        self.assertTrue(done[1].endswith("word" + jd.WHY_CUT_MARK), done[1][-12:])
 
     def test_planner_eager_done_and_no_grouping(self):
         # the user 2026-06-17: the planner biases toward marking goals done EAGERLY, and (split out the

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -125,10 +125,13 @@ class Collector(unittest.TestCase):
         self.assertEqual(set(snap["goals"]), {"loads", "saves", "writes"}, "read through jd.goal_io_stats")
         # the three identity memos' readers land here (review find, 2026-09-08: they had no consumer)
         self.assertEqual(set(snap["memos"]), {"pass", "shared", "chain", "nudgeGate", "cleared", "courierSkip", "backref", "captions", "goalArchive", "plannerSkip",
-                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes", "spendTree",
+                                              "bgTops", "liftGate", "intrMarks", "statesOverlay", "lanes", "spendTree", "summaryAnchor",
                                               "chatMergeSets", "chatPostal", "chatLedger", "chatFoldTasks"})   # the chat build's fixed-cost memos (2026-09-09)
         self.assertEqual(set(snap["memos"]["spendTree"]), {"entries", "bytes", "bound"}, "the spend guard's tree memos against their bound")
         self.assertEqual(snap["memos"]["spendTree"]["bound"], km.SPEND_GUARD_TREE_MEMO_BYTES)
+        self.assertEqual(set(snap["memos"]["summaryAnchor"]), {"entries", "bytes", "bound", "hit", "miss", "evict"},
+                         "the brief line's text-atom landings (T388): occupancy and counters against their bound")
+        self.assertEqual(snap["memos"]["summaryAnchor"]["bound"], km.SUMMARY_ANCHOR_MEMO_BYTES)
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},
                          "the placed-launch memo (_bg_placed_tops): counters plus its occupancy")
         for k, v in snap["memos"]["bgTops"].items():

--- a/tests/test_perf_stats.py
+++ b/tests/test_perf_stats.py
@@ -129,7 +129,7 @@ class Collector(unittest.TestCase):
                                               "chatMergeSets", "chatPostal", "chatLedger", "chatFoldTasks"})   # the chat build's fixed-cost memos (2026-09-09)
         self.assertEqual(set(snap["memos"]["spendTree"]), {"entries", "bytes", "bound"}, "the spend guard's tree memos against their bound")
         self.assertEqual(snap["memos"]["spendTree"]["bound"], km.SPEND_GUARD_TREE_MEMO_BYTES)
-        self.assertEqual(set(snap["memos"]["summaryAnchor"]), {"entries", "bytes", "bound", "hit", "miss", "evict"},
+        self.assertEqual(set(snap["memos"]["summaryAnchor"]), {"entries", "bytes", "bound", "hit", "miss", "evict", "fault"},
                          "the brief line's text-atom landings (T388): occupancy and counters against their bound")
         self.assertEqual(snap["memos"]["summaryAnchor"]["bound"], km.SUMMARY_ANCHOR_MEMO_BYTES)
         self.assertEqual(set(snap["memos"]["bgTops"]), {"hit", "miss", "resolve", "walk", "walk_neg", "idx_build", "entries"},

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -21,8 +21,10 @@ test("the span rides the payload only while it was located IN the landing atom",
   // located in the very atom it returns (T388); the latest-prose walk and the work-anchor last resort carry none
   assert.match(KERNEL, /"summaryAnchorQuote": \(nodes\[nid\]\.get\("summaryQuote"\)\s*\n\s*if _sa_u and _sa_u == nodes\[nid\]\.get\("summaryAnchor"\) else \(_sa_q or None\)\)/,
     "a fallback-tier anchor lands elsewhere — its quote would highlight the wrong text; the located span is the one exception");
-  assert.match(KERNEL, /_sa_u, _sa_q = _summary_text_anchor\(seg_turn\.get\(_sk\), _line, memo_key=\(fsid, nid, _sk\)\)/,
-    "the only writer of _sa_q is the tier that located the span in the atom it returns");
+  assert.match(KERNEL, /_sa_u, _sa_q = _brief_landing\(nid, col == "completed", _line\)/,
+    "the card takes the one resolve of the brief's landing (_brief_landing), the same the modal row takes");
+  assert.match(KERNEL, /u, q = _summary_text_anchor\(seg_turn\.get\(sk\), line, memo_key=\(fsid, nid, sk\)\)/,
+    "the only writer of the quote inside it is the tier that located the span in the atom it returns");
   assert.match(FEED, /summaryAnchorQuote\?: string \| null;/);
   assert.match(FEED, /anchorUuid: it\.summaryAnchorUuid, quote: it\.summaryAnchorQuote \|\| undefined/,
     "the click carries the span");

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -16,9 +16,13 @@ const CSS = fs.readFileSync(path.join(UI, "styles.css"), "utf8");
 const KERNEL = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "kernel.py"), "utf8");
 const JUDGE = fs.readFileSync(path.resolve(process.cwd(), "..", "kernel", "judge.py"), "utf8");
 
-test("the span rides the payload only while the cited atom IS the landing", () => {
-  assert.match(KERNEL, /"summaryAnchorQuote": \(nodes\[nid\]\.get\("summaryQuote"\)\s*\n\s*if _sa_u and _sa_u == nodes\[nid\]\.get\("summaryAnchor"\) else None\)/,
-    "a fallback-tier anchor lands elsewhere — its quote would highlight the wrong text");
+test("the span rides the payload only while it was located IN the landing atom", () => {
+  // the distiller's span while the cited atom IS the landing; else the text-atom tier's span, which _summary_text_anchor
+  // located in the very atom it returns (T388); the latest-prose walk and the work-anchor last resort carry none
+  assert.match(KERNEL, /"summaryAnchorQuote": \(nodes\[nid\]\.get\("summaryQuote"\)\s*\n\s*if _sa_u and _sa_u == nodes\[nid\]\.get\("summaryAnchor"\) else \(_sa_q or None\)\)/,
+    "a fallback-tier anchor lands elsewhere — its quote would highlight the wrong text; the located span is the one exception");
+  assert.match(KERNEL, /_sa_u, _sa_q = _summary_text_anchor\(seg_turn\.get\(_sk\), _line, memo_key=\(fsid, nid, _sk\)\)/,
+    "the only writer of _sa_q is the tier that located the span in the atom it returns");
   assert.match(FEED, /summaryAnchorQuote\?: string \| null;/);
   assert.match(FEED, /anchorUuid: it\.summaryAnchorUuid, quote: it\.summaryAnchorQuote \|\| undefined/,
     "the click carries the span");

--- a/ui/webview/cite-span.test.ts
+++ b/ui/webview/cite-span.test.ts
@@ -21,8 +21,8 @@ test("the span rides the payload only while it was located IN the landing atom",
   // located in the very atom it returns (T388); the latest-prose walk and the work-anchor last resort carry none
   assert.match(KERNEL, /"summaryAnchorQuote": \(nodes\[nid\]\.get\("summaryQuote"\)\s*\n\s*if _sa_u and _sa_u == nodes\[nid\]\.get\("summaryAnchor"\) else \(_sa_q or None\)\)/,
     "a fallback-tier anchor lands elsewhere — its quote would highlight the wrong text; the located span is the one exception");
-  assert.match(KERNEL, /_sa_u, _sa_q = _brief_landing\(nid, col == "completed", _line\)/,
-    "the card takes the one resolve of the brief's landing (_brief_landing), the same the modal row takes");
+  assert.match(KERNEL, /_sa_u, _sa_q = _brief_landing\(nid, _completed, _line\)/,
+    "the card takes the one resolve of the brief's landing (_brief_landing), from the line it shows, the same the modal row takes");
   assert.match(KERNEL, /u, q = _summary_text_anchor\(seg_turn\.get\(sk\), line, memo_key=\(fsid, nid, sk\)\)/,
     "the only writer of the quote inside it is the tier that located the span in the atom it returns");
   assert.match(FEED, /summaryAnchorQuote\?: string \| null;/);

--- a/ui/webview/distiller-line.test.ts
+++ b/ui/webview/distiller-line.test.ts
@@ -119,3 +119,20 @@ test("a BLOCKED card is distill-PENDING while its blockSummary is null — but N
 test("an open/working card (neither completed nor blocked) is never distill-pending", () => {
   assert.equal(distillPending(false, false, null, null), false);
 });
+
+// The six states the kernel's _landing_inputs mirrors term for term (T388): the SAME rows sit in
+// tests/test_card_summary_anchor.py LINE_RULE_TABLE, and the Python test pins that this file carries them.
+const LINE_RULE_TABLE: Array<[string, "completed" | "blocked" | null, string, boolean, boolean]> = [
+  ["stall floor", null, "needs_input", false, true],
+  ["permission floor", "blocked", "needs_input", false, true],
+  ["real block in recheck", "blocked", "working", false, false],
+  ["done confirming", null, "working", false, false],
+  ["completed", "completed", "completed", true, false],
+  ["plain working", null, "working", false, false],
+];
+
+test("distillInputs over the six states the kernel's landing rule mirrors", () => {
+  for (const [name, state, column, completed, blocked] of LINE_RULE_TABLE) {
+    assert.deepEqual(distillInputs(state, column), { completed, blocked }, name);
+  }
+});

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -70,6 +70,8 @@ interface AskTreeNode {
   followupPending?: boolean;                                     // this sub was optimistically reopened by a per-sub follow-up → "↻ Followed up" chip (kernel flatten, judges 047264f)
   summary?: string | null;                                       // the DISTILLER's key takeaway for a completed goal (artifact or 1-3 sentences) → the modal's auto-line for a DONE node (kernel flatten 78fc97b)
   blockSummary?: string | null;                                  // the BLOCK-distiller's decision brief for a blocked goal → the modal's auto-line for a BLOCKED node (kernel 466393c); null until produced
+  summaryAnchorUuid?: string | null;                            // the brief/summary line's own landing (kernel T388): the text atom that carries it
+  summaryAnchorQuote?: string | null;                           // …and its located span, sent as the click's quote
   relayNote?: string | null;   // a far host still holds a relayed question after its wait ended (kernel relayCarried) → its own dim line under the brief, never a brief paragraph
   trgb?: [number, number, number];                               // last-activity recency tint (timestamp)
   cleared?: boolean;                                             // user-cleared sub (nodeOverride op:clear) → struck-through faded row + "cleared" chip; the mark stays tied to status (box = done, the user 2026-07-26)
@@ -3293,7 +3295,15 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
     // it follows to where the node resolved (its work anchor, the SAME target as the node's mark/time zones).
     // Wired on EITHER anchor: goWork itself falls to the prompt anchor when the work one is cold-null, so
     // gating on anchorUuid alone dead-ended the line during a cold beat (the user 2026-07-20).
-    if (!repeat && (node.anchorUuid || node.promptAnchorUuid)) {
+    // The brief's OWN landing first (T388): the kernel resolves the text atom that carries the line (a validated
+    // citation, else the opening sentence located in the newest segment's turn) and its span, so the click never
+    // lands on the node's work anchor, which for a long turn can be a tool call inside a collapsed group.
+    if (!repeat && node.summaryAnchorUuid) {
+      sum.classList.add("ftree-summary-link");
+      sum.title = "jump to where this was written";
+      const su = node.summaryAnchorUuid, sq = node.summaryAnchorQuote || undefined;
+      sum.onclick = (ev: Event) => { ev.stopPropagation(); focusEcho(it.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: node.id, sid: it.sid, t: node.mt ?? node.t, anchor: "work", anchorUuid: su, quote: sq }); };
+    } else if (!repeat && (node.anchorUuid || node.promptAnchorUuid)) {
       sum.classList.add("ftree-summary-link");
       sum.title = "jump to where this was written";
       sum.onclick = goWork;

--- a/ui/webview/feed.ts
+++ b/ui/webview/feed.ts
@@ -3301,8 +3301,11 @@ function renderTreeNode(box: HTMLElement, it: AskItem, node: AskTreeNode, byId: 
     if (!repeat && node.summaryAnchorUuid) {
       sum.classList.add("ftree-summary-link");
       sum.title = "jump to where this was written";
-      const su = node.summaryAnchorUuid, sq = node.summaryAnchorQuote || undefined;
-      sum.onclick = (ev: Event) => { ev.stopPropagation(); focusEcho(it.sid); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: node.id, sid: it.sid, t: node.mt ?? node.t, anchor: "work", anchorUuid: su, quote: sq }); };
+      // the ROW's own session, never the card's (navSidOf, the same resolver goWork uses): a serving-folded worker
+      // row inside the sender's card resolved its landing in the worker's parse, and the worker's atom sent to
+      // the sender's chat could only honest-fail (the verifier's first round)
+      const su = node.summaryAnchorUuid, sq = node.summaryAnchorQuote || undefined, ss = navSidOf(it, node);
+      sum.onclick = (ev: Event) => { ev.stopPropagation(); focusEcho(ss); vscodeApi?.postMessage({ type: "showOnTimeline", itemId: node.id || it.turnId, sid: ss, t: node.mt ?? node.t, anchor: "work", anchorUuid: su, quote: sq }); };
     } else if (!repeat && (node.anchorUuid || node.promptAnchorUuid)) {
       sum.classList.add("ftree-summary-link");
       sum.title = "jump to where this was written";


### PR DESCRIPTION
## What

Two defects the user hit on one blocked card.

- **The Summary click landed on a collapsed tool group.** The card's brief had no validated citation, so the modal's brief line fell to the node's work anchor: the newest trail segment's first landable atom, a shell call, while the questions the brief quoted were the same turn's last text atom, thirteen minutes later. Four landings then filed pointer-exact on the wrong atom.
- **A phantom fifth question.** The closer's block why was stored as a raw 300-character slice, cut mid-word. The brief judge, fed the stump as material, reported a half-stated fifth question the user had to restate.

## Fixes

- **The brief's own landing.** When a card's brief or summary has no validated citation, the kernel resolves the anchor to the assistant text atom of the newest trail segment's turn that carries the line's opening sentence, using the same locate the distiller's citation validation uses, else that turn's last text atom; never a tool call or a thinking block. The located span ships as the click's quote, which the chat highlights on landing. The card's anchor chain tries this tier before the latest-prose walk; every modal tree row carries the brief line's own landing and the modal's brief line prefers it over the work anchor. Bodies are read only for one turn's text atoms, once per brief per segment, through a memo bounded by bytes as a fraction of machine memory with an environment override, evicting oldest first and reporting entries, bytes, bound, hits, misses and evictions under the perf route beside the other memos.
- **A boundary cut with a visible mark.** A verdict's why is cut at a sentence end past half the cap, else at a word boundary, and ends with an ellipsis when anything was cut. The ceiling stays at the pinned 300 characters. The owed why the brief judge reads says where a cut reason ends, so a truncated field is never presented as a complete one.

From the verifier's first round: the modal brief line's click names the row's own session, the same resolver the work anchor's click uses, so a serving-folded worker row lands in the worker's chat; with no located quote the tier takes the newest substantive text atom by the latest-prose walk's own floor, never a connective stub over the analysis before it, and answers nothing when none is substantive so the card's chain falls through to the walk, a stub only as the last resort ahead of the work anchor's tool group; the tier's body reads sit inside the build's envelope, an unreadable body skipped and counted rather than aborting the feed for every session; the cut is a stored fact on the verdict row and the node rather than a suffix test on prose, so a complete why that ends with an ellipsis is never told as cut; one outrun rule serves the card's cited tier and the modal row's, so one brief lands in one place.

From the verifier's second round: one landing function resolves a node's brief or summary landing once, from the node's whole subtree, with one tier order (the completed pin, the cited tier with the outrun rule, the text-atom tier, the latest-prose walk, the stub, the work anchor), and both the card and its modal row take that result, so one brief lands in one place whichever surface is clicked; a search that met an unreadable body is answered but not memoized; a block re-asserted after a reply carries the cut fact from its source row; a handoff row ships no landing of its own, its session being the peer's, and falls to the work anchor's click.

From the verifier's third round: each surface resolves the landing of the very line it shows, the card from its distill state (the needs-input floors included) and the modal row from its own status, through one function that also gives the completed bit, so a working goal floored to needs-input by a live prompt lands on the brief it displays rather than on the takeaway the column's rule named; the landing is resolved once per node and line within a build and each subtree walked once; a derivation that met a body-read fault is served but not memoized as a feed entry, so the next build recovers.

From the verifier's fourth round: the kernel's line rule mirrors the client's term for term, the state and the column both, so the stall floor, which floors the column to needs-input with no distill state, shows its brief through the column's fallback on both sides and lands on it rather than on the tool call; the six states the verifier executed sit in one table carried by both the Python test and the webview test, the Python side pinning that the webview file holds every row.

## Tests

An end-to-end test through the feed build on the outrun harness's shape: one turn with two segments, a typed opener with a shell call and a typed prompt absorbed mid-turn before the wrap-up; the trail names the tool-only first segment; the card and its modal row land on the wrap-up's text atom with the span, the work anchor stays the tool call, and a raising body read leaves the feed build whole. Red first on the base: seventeen of the nineteen new tests fail there (the two that pass are unchanged behaviour). `tests/test_card_summary_anchor.py`: a segment of tool calls lands on the turn's text atom, the atom carrying the opening sentence wins over a later one, the fallbacks and exclusions, the memo, and the wiring pinned at the source. `tests/test_close_why_boundary.py`: the cut at a sentence, at a word, one unbroken token, exactly at the cap; the closer's parse; the owed why's note. The why-cap tuning pin and the feed body's inputs census read the new rule and the new helper, and the cite-span pin now allows the one exception: the text-atom tier's span, located in the very atom it returns.

Tier: fix
