### PR TITLE
The incident scan's dead-file walk is memoized per frozen file as a fold of its fold document, so a dead episode's transcript is read whole once (T391)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1542,6 +1542,18 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `corrupt`), `dirty` (files whose folds moved since their last write),
   `readBytes` and `readByPath` (what the JSONL reader pulled off disk since
   boot, in total and per file).
+  `rewoundMemo`: the judges' incident scan used to read every dead episode
+  file of a lineage whole at every boot (`_per_file_rewound`, 542 MB on one
+  devbox boot); its verdict set per frozen file is now the fold `rewoundUuids`
+  of that file's fold document, written from the walk's own read at the
+  quiescence drop and restored at the next boot, so such a file is read whole
+  once (a live session's own files, its /clear anchor among them, stay
+  resident instead, since the chain walk reads them at every pass). The
+  counters: the memo's answers (`served`), the walks it took (`walked`), the
+  walks over a memo the file's growth or rewrite retired (`stale`; a file
+  whose entry merely left memory and came back is walked, not stale) and the
+  walks whose memo could not be read or stored (`fallback`: a document state
+  of the wrong shape, or no reader entry after the walk).
 - `stacks`: every thread's last six frames, keyed by the thread's ident and
   name, when the kernel runs with `ROMP_PERF_STACKS` set (a debugging aid for a
   served test on a runner nobody can log into); `null` otherwise.
@@ -1553,13 +1565,6 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `shrunk` and `upgrade`, and the first calling function outside the event
   model and the parse family), with `count` and `bytes`; a tail read, an
   append and a restore's tail read are not whole reads and are not counted.
-  The judges' incident scan used to read every dead episode file of a lineage
-  whole at every boot (`_per_file_rewound`, 542 MB on one devbox boot); its
-  verdict set per frozen file is now the fold `rewoundUuids` of that file's
-  fold document, written from the walk's own read at the quiescence drop and
-  restored at the next boot, so such a file is read whole once;
-  `checkpoints.rewoundMemo` counts the memo's answers (`served`), the walks it
-  took (`walked`) and the memos an append or rewrite retired (`stale`).
 - `asmCheckpoint`: the assembly documents since boot: `written`, `restored`,
   `fallbacks` per reason (`version`, `session`, `inputs`, `lineage`, `shrunk`,
   `rewrite`, `guard`, `identity`, `corrupt`, `restore`), `skipped` per reason

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1553,6 +1553,13 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `shrunk` and `upgrade`, and the first calling function outside the event
   model and the parse family), with `count` and `bytes`; a tail read, an
   append and a restore's tail read are not whole reads and are not counted.
+  The judges' incident scan used to read every dead episode file of a lineage
+  whole at every boot (`_per_file_rewound`, 542 MB on one devbox boot); its
+  verdict set per frozen file is now the fold `rewoundUuids` of that file's
+  fold document, written from the walk's own read at the quiescence drop and
+  restored at the next boot, so such a file is read whole once;
+  `checkpoints.rewoundMemo` counts the memo's answers (`served`), the walks it
+  took (`walked`) and the memos an append or rewrite retired (`stale`).
 - `asmCheckpoint`: the assembly documents since boot: `written`, `restored`,
   `fallbacks` per reason (`version`, `session`, `inputs`, `lineage`, `shrunk`,
   `rewrite`, `guard`, `identity`, `corrupt`, `restore`), `skipped` per reason

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4248,37 +4248,75 @@ def file_rewound(path, rompuuid=None, sdk_human=None):
 
 _REWOUND_CACHE = {}               # path -> (count, gen, {"uuids": [...]}): file_rewound's verdict set over a FROZEN file, a registered
 #                                   fold (T391) the fold document carries and restores, so a dead episode file is read whole once
-_REWOUND_STATS = {"served": 0, "walked": 0, "stale": 0}   # the memo's answers, the walks it took, the memos an append or rewrite retired
+_REWOUND_STATS = {"served": 0, "walked": 0, "stale": 0, "fallback": 0}   # the memo's answers, the walks it took, the memos an
+#                                   append or rewrite retired, and the walks whose memo could not be read or stored
 
 
-def rewound_uuids(path):
+def _rewound_walk(path):
+    """The plain one-file walk `rewound_uuids` memoizes: file_rewound's road without a rompuuid, returning the verdict set and
+    the reader's (gen, base, count) the adapter's records came from (FileAdapter._src_keys), the witness the memo is stored at.
+    Its own, never re-fetched from the cache after the walk: an append and a refresh between the two would memoize pre-append
+    verdicts at the post-append witness (T391 round one, low 1)."""
+    key = str(path)
+    ad = FileAdapter([key], key)
+    if not ad.by_uuid and Path(path).stat().st_size > 0:
+        raise OSError("transcript read yielded no records")
+    verdicts = dict(ad.chain_verdicts())
+    return {u for u, v in verdicts.items() if v == "rewind"}, ad._src_keys.get(key, (None, 0, 0))
+
+
+def rewound_uuids(path, drop=True):
     """`file_rewound(path)` for a file with no rompuuid road (a dead episode's transcript in a lineage, walked by the judges'
     incident scan), memoized per FROZEN file as the fold `rewoundUuids` of its fold document (T391): the memo rides the
     existing document, its witness (size, mtime, the cut's guard), its restore, its fold state cap and its counted fallbacks,
     and the quiescence drop writes it from the walk's own read, so the file is read whole once and not at the next process.
     fold_records consults it: a hit or a restore at the witness answers with no read; a file that grew or was rewritten steps
     a `step` that retires the state (None), so the walk runs again and the memo is rewritten; an over-cap set is recorded as
-    such and walked again next time. The leaf road with a rompuuid never comes here."""
+    such and walked again next time. The leaf road with a rompuuid never comes here.
+
+    `drop`: whether the walk's entry leaves the reader's cache after the memo is stored (the quiescence drop, when the file
+    has been idle past its window). True for a dead episode's file, which nothing else reads; False for a file of a LIVE
+    session's lineage (its /clear anchor, T391 round one, medium): the chain walk reads that file whole first at every pass,
+    and a memo that popped the entry made the next pass's chain walk read it whole again, every pass, while the memo itself
+    found its cursor at a moved generation and walked. Resident, the anchor is read once per process and the memo's cursor
+    stays at the generation the chain walk's entry holds, so the scan reads nothing at all.
+
+    The counters (checkpoints.rewoundMemo): `served`, a memo answered in memory or from the document at the witness; `walked`,
+    every walk; `stale`, the walks over a memo the file's growth or rewrite retired (an in-process cursor stepped past by an
+    append, a document cursor restored and stepped past, a refold whose count moved); a walk over an unchanged file whose entry
+    left memory and came back under a fresh generation is walked, not stale (round one, low 2); `fallback`, a document state of
+    the wrong shape (walked, never trusted) or a walk whose reader entry was gone before the memo could be stored (round one,
+    low 3), both counted so a memo that never takes is visible on /perf."""
     key = str(path)
     had = _REWOUND_CACHE.get(key)
-    state = fold_records(_REWOUND_CACHE, key, lambda: None, lambda st, o: None, ckpt="rewoundUuids")
+    kinds = []
+    state = fold_records(_REWOUND_CACHE, key, lambda: None, lambda st, o: None, on=kinds.append, ckpt="rewoundUuids")
     if isinstance(state, dict) and isinstance(state.get("uuids"), list):
         with _CKPT_LOCK:
             _REWOUND_STATS["served"] += 1
         return set(state["uuids"])
-    if had is not None and isinstance(had[2], dict):
+    if state is not None:                                 # a state that is not the memo's shape: never trusted, counted, walked
         with _CKPT_LOCK:
-            _REWOUND_STATS["stale"] += 1                  # a state the step retired: the file moved under the memo
-    out = file_rewound(path)                              # the walk (a whole read of a frozen file: the record cache holds it)
-    with _JSONL_CACHE_LOCK:
-        ent = _JSONL_CACHE.get(key)
+            _REWOUND_STATS["fallback"] += 1
+        _REWOUND_CACHE.pop(key, None)
+    out, (gen, base, count) = _rewound_walk(path)         # the walk (a whole read of a frozen file: the record cache holds it)
+    kind = kinds[0] if kinds else None
     with _CKPT_LOCK:
         _REWOUND_STATS["walked"] += 1
-    if ent is not None:                                   # the memo at the reader's witness, dirty; then the quiescence drop over this
-        _REWOUND_CACHE[key] = (ent[5] + len(ent[4]), ent[6], {"uuids": sorted(out)})   #  frozen file writes the document from the
-        with _CKPT_LOCK:                                  #  walk's own read and lets the records go (T362's drop, its budget and its
-            _FOLD_DIRTY.add(key)                          #  deferral); a file still changing keeps its entry and is written at its settle
-        _drop_quiescent_entry(key, ent, pop=True)
+        if kind in ("append", "restore") or (kind == "refold" and had is not None and had[0] != count):
+            _REWOUND_STATS["stale"] += 1                  # a memo stood and the file moved under it
+    if gen is None:                                       # no reader entry for the walk's records: nothing to store the memo at
+        with _CKPT_LOCK:
+            _REWOUND_STATS["fallback"] += 1
+        return out
+    _REWOUND_CACHE[key] = (count, gen, {"uuids": sorted(out)})   # the memo at the walk's own witness, dirty
+    with _CKPT_LOCK:
+        _FOLD_DIRTY.add(key)
+    if drop:                                              # the quiescence drop over this frozen file writes the document from the
+        with _JSONL_CACHE_LOCK:                           #  walk's own read and lets the records go (T362's drop, its budget and its
+            ent = _JSONL_CACHE.get(key)                   #  deferral); a file still changing keeps its entry and is written at its
+        if ent is not None and ent[6] == gen:             #  settle; only the very entry the walk read is dropped
+            _drop_quiescent_entry(key, ent, pop=True)
     return out
 
 

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1560,6 +1560,7 @@ def checkpoint_stats():
         out["oversizeFolds"] = dict(_CKPT_STATS["oversizeFolds"]); out["coldFolds"] = dict(_CKPT_STATS["coldFolds"])
         out["coldWrites"] = dict(_CKPT_STATS["coldWrites"]); out["converge"] = dict(_CKPT_STATS["converge"])
         out["refolds"] = {k: dict(v) for k, v in _CKPT_STATS["refolds"].items()}
+        out["rewoundMemo"] = dict(_REWOUND_STATS)
     d = _ckpt_dir()
     with _READ_BYTES_LOCK:
         out["documentBytes"] = sum(n for p_, n in _READ_BYTES.items() if d is not None and p_.startswith(str(d) + os.sep))
@@ -4243,6 +4244,47 @@ def file_rewound(path, rompuuid=None, sdk_human=None):
         for u, v in ad.seed["verdicts"].items():
             verdicts.setdefault(u, v)
     return {u for u, v in verdicts.items() if v == "rewind"}
+
+
+_REWOUND_CACHE = {}               # path -> (count, gen, {"uuids": [...]}): file_rewound's verdict set over a FROZEN file, a registered
+#                                   fold (T391) the fold document carries and restores, so a dead episode file is read whole once
+_REWOUND_STATS = {"served": 0, "walked": 0, "stale": 0}   # the memo's answers, the walks it took, the memos an append or rewrite retired
+
+
+def rewound_uuids(path):
+    """`file_rewound(path)` for a file with no rompuuid road (a dead episode's transcript in a lineage, walked by the judges'
+    incident scan), memoized per FROZEN file as the fold `rewoundUuids` of its fold document (T391): the memo rides the
+    existing document, its witness (size, mtime, the cut's guard), its restore, its fold state cap and its counted fallbacks,
+    and the quiescence drop writes it from the walk's own read, so the file is read whole once and not at the next process.
+    fold_records consults it: a hit or a restore at the witness answers with no read; a file that grew or was rewritten steps
+    a `step` that retires the state (None), so the walk runs again and the memo is rewritten; an over-cap set is recorded as
+    such and walked again next time. The leaf road with a rompuuid never comes here."""
+    key = str(path)
+    had = _REWOUND_CACHE.get(key)
+    state = fold_records(_REWOUND_CACHE, key, lambda: None, lambda st, o: None, ckpt="rewoundUuids")
+    if isinstance(state, dict) and isinstance(state.get("uuids"), list):
+        with _CKPT_LOCK:
+            _REWOUND_STATS["served"] += 1
+        return set(state["uuids"])
+    if had is not None and isinstance(had[2], dict):
+        with _CKPT_LOCK:
+            _REWOUND_STATS["stale"] += 1                  # a state the step retired: the file moved under the memo
+    out = file_rewound(path)                              # the walk (a whole read of a frozen file: the record cache holds it)
+    with _JSONL_CACHE_LOCK:
+        ent = _JSONL_CACHE.get(key)
+    with _CKPT_LOCK:
+        _REWOUND_STATS["walked"] += 1
+    if ent is not None:                                   # the memo at the reader's witness, dirty; then the quiescence drop over this
+        _REWOUND_CACHE[key] = (ent[5] + len(ent[4]), ent[6], {"uuids": sorted(out)})   #  frozen file writes the document from the
+        with _CKPT_LOCK:                                  #  walk's own read and lets the records go (T362's drop, its budget and its
+            _FOLD_DIRTY.add(key)                          #  deferral); a file still changing keeps its entry and is written at its settle
+        _drop_quiescent_entry(key, ent, pop=True)
+    return out
+
+
+def rewound_memo_stats():
+    with _CKPT_LOCK:
+        return dict(_REWOUND_STATS)
 
 
 def _membership_of(adapter):

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6083,7 +6083,10 @@ def _per_file_rewound(fsid, files):
             # pre-cut verdicts and the tail read now instead of the whole file (T323 stage 4a). A non-empty
             # transcript that yields ZERO records raises OSError there (the incremental reader swallows a
             # permissions break into an empty list): a failed read, not an empty file, and it must count like one.
-            out |= em.file_rewound(fp, rompuuid=fsid if fp == leaf else None, sdk_human=_sdk_owned(fsid) if fp == leaf else None)
+            if fp == leaf:                                # the leaf road: the document's pre-cut verdicts and the tail read now
+                out |= em.file_rewound(fp, rompuuid=fsid, sdk_human=_sdk_owned(fsid))
+            else:                                         # a dead episode's frozen file: the walk once, its verdict set memoized in
+                out |= em.rewound_uuids(fp)               #  the file's fold document and restored at the next process (T391)
             #     ^ the one-file walk asks for the leaf's document quietly: a lineage document (a /clear's anchor, a
             #       resume fork) is not this walk's and stays the display's
         except Exception as e:

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6068,6 +6068,7 @@ def _per_file_rewound(fsid, files):
     out, seen, fails = set(), set(), 0
     leaf = Path(files[0])
     cands = [Path(f) for f in files]
+    lineage = set(cands)                                  # the live session's own files (the leaf, its /clear anchor): resident
     for row in episode_rows(fsid):
         fs = str(row.get("fsid") or "")
         if fs:
@@ -6086,7 +6087,9 @@ def _per_file_rewound(fsid, files):
             if fp == leaf:                                # the leaf road: the document's pre-cut verdicts and the tail read now
                 out |= em.file_rewound(fp, rompuuid=fsid, sdk_human=_sdk_owned(fsid))
             else:                                         # a dead episode's frozen file: the walk once, its verdict set memoized in
-                out |= em.rewound_uuids(fp)               #  the file's fold document and restored at the next process (T391)
+                out |= em.rewound_uuids(fp, drop=fp not in lineage)   # the file's fold document and restored at the next process
+            #     ^ (T391); a live session's anchor keeps its records resident, since the chain walk above reads it whole at
+            #       every pass and a drop here made that a whole read per pass (round one, medium)
             #     ^ the one-file walk asks for the leaf's document quietly: a lineage document (a /clear's anchor, a
             #       resume fork) is not this walk's and stays the display's
         except Exception as e:

--- a/tests/test_fold_checkpoints.py
+++ b/tests/test_fold_checkpoints.py
@@ -1571,7 +1571,7 @@ class KernelFolds(Base):
         snap = km._PERF_STATS.snapshot()
         self.assertIn("converge", em._CKPT_STATS, "the production default carries the converge counters (the fixture injects nothing)")
         self.assertEqual(sorted(snap["checkpoints"]), ["coldFolds", "coldWrites", "converge", "dirty", "documentBytes", "droppedRestores", "fallbacks", "oversizeFolds",
-                                                        "readByPath", "readBytes", "refolds", "restored", "restoredFolds", "skippedFolds", "swept", "writes"])
+                                                        "readByPath", "readBytes", "refolds", "restored", "restoredFolds", "rewoundMemo", "skippedFolds", "swept", "writes"])
         src = open(os.path.join(BIN, "romp-kernel")).read()
         self.assertIn("em.checkpoint_write_dirty(budget_s=EXIT_CKPT_WRITE_BUDGET_S)", src,
                       "exit writes the dirty checkpoints in _drain_and_exit, bounded (2026-09-11: unbounded, it met the manager's SIGKILL)")

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""T391 (2026-09-12): the judges' incident scan walked every dead episode file of a lineage whole at every boot (`_per_file_rewound`
+through `em.file_rewound` with no rompuuid: 542 MB in four reads on one devbox boot). The verdict set per FROZEN file is now the
+fold `rewoundUuids` of that file's fold document: written from the walk's own read at the quiescence drop, restored at the next
+process, retired by an append or rewrite, capped like every fold state, falling to the walk on a corrupt document. Synthetic
+transcripts only (the golden builders)."""
+import gzip
+import inspect
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402  the harness and the golden builders
+
+
+class RewoundMemo(Harness):
+    def setUp(self):
+        super().setUp()
+        em._REWOUND_CACHE.clear()
+        with em._CKPT_LOCK:
+            for k in em._REWOUND_STATS:
+                em._REWOUND_STATS[k] = 0
+            em._FOLD_DIRTY.clear()
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        self.saved_drop = em._DROP_AFTER_QUIESCENT_S
+
+    def tearDown(self):
+        em._DROP_AFTER_QUIESCENT_S = self.saved_drop
+        super().tearDown()
+
+    def frozen(self, name="dead", scenario="rewind_off_path", age=600):
+        """A dead episode's transcript: a scenario with a rewound branch, idle past the reader's quiescence window."""
+        records, sent = G.SINGLE_FILE[scenario]
+        path = self.write(name, records(), sent=sent)
+        old = time.time() - age; os.utime(path, (old, old))
+        return path
+
+    def fresh_process(self):
+        self.fresh(); em.set_checkpoint_dir(lambda: self.ck)
+        for c in list(em._FOLD_REG.values()):
+            c.clear()
+        em._REWOUND_CACHE.clear()
+        with em._CKPT_LOCK:
+            for k in em._REWOUND_STATS:
+                em._REWOUND_STATS[k] = 0
+
+    def whole_reads(self, path):
+        return sum(v["bytes"] for k, v in em.record_cache_stats()["wholeReads"].items())
+
+    def test_a_frozen_file_is_walked_once_and_served_from_its_document_at_the_next_process(self):
+        path = self.frozen()
+        size = os.path.getsize(path)
+        walked = em.file_rewound(path)                                # the verdicts the plain walk gives (the equivalence reference)
+        self.assertTrue(walked, "the fixture has a rewound branch")
+        self.fresh_process()
+        got = em.rewound_uuids(path)
+        self.assertEqual(got, walked, "the first call walks and answers the walk's verdicts")
+        self.assertGreaterEqual(self.whole_reads(path), size, "the first process read the file whole, once")
+        d = json.loads(em._ckpt_file(path).read_text())
+        self.assertEqual(sorted(d["folds"]["rewoundUuids"]["state"]["uuids"]), sorted(walked), "the memo rides the fold document, written at the drop")
+        st = em.rewound_memo_stats(); self.assertEqual((st["walked"], st["served"]), (1, 0))
+        self.fresh_process()
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+        read0 = em.read_bytes_report().get(path, 0)
+        got2 = em.rewound_uuids(path)
+        self.assertEqual(got2, walked, "served from the document: the same verdicts")
+        self.assertEqual(self.whole_reads(path), 0, "no whole read at the next process")
+        self.assertLess(em.read_bytes_report().get(path, 0) - read0, 512, "a tail read of nothing plus the guard: %d" % (em.read_bytes_report().get(path, 0) - read0))
+        st = em.rewound_memo_stats(); self.assertEqual((st["walked"], st["served"]), (0, 1))
+
+    def test_a_file_that_grows_after_the_memo_is_walked_again_and_the_memo_rewritten(self):
+        path = self.frozen("grows")
+        self.fresh_process(); first = em.rewound_uuids(path)
+        seq = json.loads(em._ckpt_file(path).read_text())["seq"]
+        records, _sent = G.SINGLE_FILE["rewind_off_path"]
+        recs = records(); last = next(r for r in reversed(recs) if r.get("uuid"))
+        t1 = max((em.parse_z(r.get("timestamp")) or 0) for r in recs if r.get("timestamp")) + 60
+        with open(path, "a") as fh:
+            fh.write(json.dumps(G.uline(t1, "one more question after the fact", "u_more", last["uuid"])) + "\n")
+        old = time.time() - 600; os.utime(path, (old, old))            # frozen again, larger
+        self.fresh_process()
+        got = em.rewound_uuids(path)
+        self.assertEqual(got, em.file_rewound(path), "the walk ran again over the grown file")
+        st = em.rewound_memo_stats(); self.assertEqual((st["walked"], st["served"]), (1, 0), "%s" % st)
+        d = json.loads(em._ckpt_file(path).read_text())
+        self.assertGreater(d["seq"], seq, "the memo was rewritten")
+        self.assertEqual(sorted(d["folds"]["rewoundUuids"]["state"]["uuids"]), sorted(got))
+
+    def test_the_scan_takes_the_leaf_road_for_the_leaf_and_the_memo_for_a_dead_file(self):
+        km = kernel_module(); jd = km.jd
+        src = inspect.getsource(jd._per_file_rewound)
+        self.assertIn("em.file_rewound(fp, rompuuid=fsid", src, "the leaf: the document's pre-cut verdicts and the tail")
+        self.assertIn("em.rewound_uuids(fp)", src, "a dead file: the memo")
+        self.assertLess(src.index("if fp == leaf:"), src.index("em.rewound_uuids(fp)"), "the leaf road decided first")
+
+    def test_an_over_cap_set_is_recorded_as_such_and_walked_again(self):
+        path = self.frozen("over")
+        saved = em._CKPT_FOLD_CAP; em._CKPT_FOLD_CAP = 8                # a cap below any set: the memo is over it
+        self.addCleanup(setattr, em, "_CKPT_FOLD_CAP", saved)
+        self.fresh_process(); first = em.rewound_uuids(path)
+        d = json.loads(em._ckpt_file(path).read_text())
+        self.assertIn("over", d["folds"]["rewoundUuids"], "the cursor without its state, with the reason: %s" % d["folds"]["rewoundUuids"])
+        self.fresh_process()
+        got = em.rewound_uuids(path)
+        self.assertEqual(got, first); self.assertEqual(em.rewound_memo_stats()["walked"], 1, "walked again: nothing to serve")
+
+    def test_a_corrupt_document_falls_to_the_walk_with_a_counted_fallback(self):
+        path = self.frozen("corrupt")
+        self.fresh_process(); first = em.rewound_uuids(path)
+        em._ckpt_file(path).write_text("{not json")
+        self.fresh_process()
+        em._CKPT_STATS["fallbacks"] = {}
+        got = em.rewound_uuids(path)
+        self.assertEqual(got, first, "the walk's verdicts, never a raise")
+        self.assertEqual(em.rewound_memo_stats()["walked"], 1)
+        self.assertTrue(em.checkpoint_stats()["fallbacks"], "the fallback counted: %s" % em.checkpoint_stats()["fallbacks"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -98,8 +98,8 @@ class RewoundMemo(Harness):
         km = kernel_module(); jd = km.jd
         src = inspect.getsource(jd._per_file_rewound)
         self.assertIn("em.file_rewound(fp, rompuuid=fsid", src, "the leaf: the document's pre-cut verdicts and the tail")
-        self.assertIn("em.rewound_uuids(fp)", src, "a dead file: the memo")
-        self.assertLess(src.index("if fp == leaf:"), src.index("em.rewound_uuids(fp)"), "the leaf road decided first")
+        self.assertIn("em.rewound_uuids(fp, drop=fp not in lineage)", src, "a dead file: the memo, its entry dropped; a lineage file resident")
+        self.assertLess(src.index("if fp == leaf:"), src.index("em.rewound_uuids(fp, drop="), "the leaf road decided first")
 
     def test_an_over_cap_set_is_recorded_as_such_and_walked_again(self):
         path = self.frozen("over")
@@ -122,6 +122,109 @@ class RewoundMemo(Harness):
         self.assertEqual(got, first, "the walk's verdicts, never a raise")
         self.assertEqual(em.rewound_memo_stats()["walked"], 1)
         self.assertTrue(em.checkpoint_stats()["fallbacks"], "the fallback counted: %s" % em.checkpoint_stats()["fallbacks"])
+
+    def _lineage(self):
+        """A live session that has cleared: its anchor <fsid>.jsonl (a rewound branch inside, idle past the quiescence window)
+        and a fresh leaf beside it, the judge's state rebound to a temp dir; returns (jd, anchor, leaf, fsid)."""
+        jd = kernel_module().jd
+        fsid = "7a391000-2222-4333-8444-000000000391"                   # private synthetic sids (the goal-store fixture rule)
+        other = "7a391000-2222-4333-8444-000000000392"
+        td = Path(tempfile.mkdtemp()); (td / "state").mkdir()
+        saved = jd.STATE; jd._rebind_state(td / "state")
+        def restore():
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._RECON_MEMO.clear()
+            jd._rebind_state(saved); shutil.rmtree(td, ignore_errors=True)
+        self.addCleanup(restore)
+        records, _sent = G.SINGLE_FILE["rewind_off_path"]
+        anchor = td / (fsid + ".jsonl")
+        anchor.write_text("\n".join(json.dumps(r) for r in records()) + "\n")
+        old = time.time() - 600; os.utime(anchor, (old, old))
+        leaf = td / (other + ".jsonl")
+        leaf.write_text(json.dumps(G.uline(NOW, "continues after the clear", "u_leaf_0", None)) + "\n")
+        return jd, anchor, leaf, fsid
+
+    def test_a_live_sessions_anchor_stays_resident_and_the_scan_reads_nothing_after_the_first_pass(self):
+        """Round one, medium: the chain walk reads a cleared session's anchor whole first at every reconcile pass; the memo
+        then walked it, popped its entry as quiescent, and the next pass's chain walk read it whole again, every pass (head:
+        1239 then 1303 bytes per pass, the entry popped each time). The anchor is a live session's own file: the memo keeps
+        it resident, and the scan reads nothing after the first pass."""
+        jd, anchor, leaf, fsid = self._lineage()
+        self.fresh_process(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._RECON_MEMO.clear()
+        key = str(anchor); size = os.path.getsize(anchor)
+        deltas, resident = [], []
+        for i in range(3):
+            with open(leaf, "a") as fh:                                 # one leaf append per pass: a live session at work
+                fh.write(json.dumps(G.uline(NOW + 10 * (i + 1), "one more line on the leaf %d" % i, "u_leaf_%d" % (i + 1), "u_leaf_%d" % i)) + "\n")
+            before = em.read_bytes_report().get(key, 0)
+            jd.reconcile_rewound_goals(fsid, str(leaf), NOW + 100 + i)
+            deltas.append(em.read_bytes_report().get(key, 0) - before)
+            with em._JSONL_CACHE_LOCK:
+                resident.append(em._JSONL_CACHE.get(key) is not None)
+        st = em.rewound_memo_stats()
+        self.assertEqual(st["walked"], 1, "the scan walked the anchor once: %s" % st)
+        self.assertGreaterEqual(deltas[0], size, "the first pass read the anchor whole, the chain walk's read: %r" % deltas)
+        self.assertEqual(deltas[1:], [0, 0], "no read of the anchor at the later passes: %r" % deltas)
+        self.assertEqual(resident, [True, True, True], "the anchor's entry stays resident: %r" % resident)
+        self.assertEqual(st["served"], 2, "%s" % st)
+
+    def test_the_memo_is_stored_at_the_walks_own_witness_not_the_caches_after_it(self):
+        """Round one, low 1: the witness was re-fetched from the cache after the walk; an append and a refresh between the two
+        memoized pre-append verdicts at the post-append witness. The walk's own (gen, base, count) is the witness."""
+        path = self.frozen("witness"); key = str(path)
+        self.fresh_process()
+        real = em._rewound_walk; pre = {}
+        def racing(p):
+            out, keys = real(p)
+            pre["count"] = keys[2]
+            recs = G.SINGLE_FILE["rewind_off_path"][0](); last = next(r for r in reversed(recs) if r.get("uuid"))
+            with open(path, "a") as fh:
+                fh.write(json.dumps(G.uline(NOW + 60, "landed between the walk and the memo", "u_race", last["uuid"])) + "\n")
+            em._read_jsonl_entry(path, tail_ok=False)                   # a refresh: the cache's entry is the post-append one now
+            return out, keys
+        em._rewound_walk = racing
+        self.addCleanup(setattr, em, "_rewound_walk", real)
+        em.rewound_uuids(path, drop=False)
+        cur = em._REWOUND_CACHE[key]
+        self.assertEqual(cur[0], pre["count"], "the cursor's count is the walk's, not the grown file's: %r" % (cur[:2],))
+        em._rewound_walk = real
+        got = em.rewound_uuids(path, drop=False)
+        self.assertEqual(em.rewound_memo_stats()["walked"], 2, "the grown file is walked again, never served pre-append verdicts")
+        self.assertEqual(got, em.file_rewound(path))
+
+    def test_stale_counts_a_memo_the_file_moved_under_and_not_a_moved_generation(self):
+        """Round one, low 2: `stale` was gated on an in-process memo, so a document memo retired by growth in a fresh process
+        was never counted while an unchanged file whose entry came back under a fresh generation counted stale."""
+        path = self.frozen("stalegen"); key = str(path)
+        self.fresh_process(); em.rewound_uuids(path, drop=False)
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.pop(key, None)                               # the entry leaves memory and comes back under a fresh generation
+        em._read_jsonl_entry(path, tail_ok=False)
+        em.rewound_uuids(path, drop=False)
+        st = em.rewound_memo_stats()
+        self.assertEqual((st["walked"], st["stale"]), (2, 0), "an unchanged file is walked, not stale: %s" % st)
+        path2 = self.frozen("stalegrow")
+        self.fresh_process(); em.rewound_uuids(path2)                    # walked; the memo written at the drop
+        recs = G.SINGLE_FILE["rewind_off_path"][0](); last = next(r for r in reversed(recs) if r.get("uuid"))
+        t1 = max((em.parse_z(r.get("timestamp")) or 0) for r in recs if r.get("timestamp")) + 60
+        with open(path2, "a") as fh:
+            fh.write(json.dumps(G.uline(t1, "one more question after the fact", "u_more", last["uuid"])) + "\n")
+        old = time.time() - 600; os.utime(path2, (old, old))
+        self.fresh_process(); em.rewound_uuids(path2)
+        st = em.rewound_memo_stats()
+        self.assertEqual((st["walked"], st["stale"]), (1, 1), "the document memo retired by growth is a retirement: %s" % st)
+
+    def test_a_wrong_shaped_document_state_is_walked_and_counted_as_a_fallback(self):
+        """Round one, low 3: a state that is not the memo's shape walked forever with nothing counted."""
+        path = self.frozen("shape")
+        self.fresh_process(); first = em.rewound_uuids(path)
+        f = em._ckpt_file(path); d = json.loads(f.read_text())
+        d["folds"]["rewoundUuids"]["state"] = {"uuids": "not-a-list"}
+        f.write_text(json.dumps(d))
+        self.fresh_process()
+        got = em.rewound_uuids(path)
+        self.assertEqual(got, first, "the walk's verdicts")
+        st = em.rewound_memo_stats()
+        self.assertEqual((st["walked"], st["fallback"]), (1, 1), "%s" % st)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix tier: the memo rides the existing fold document file (a registered fold, `rewoundUuids`), so no new on-disk artifact class.

The judges' incident scan (`_per_file_rewound`) walks a session's candidate files and every episode-log transcript of its lineage through `em.file_rewound`, which for a file without a rompuuid builds a plain adapter over the file: a whole read of a frozen dead-episode file at every boot. The whole-read counter named it on the first boot after T384: 542 MB in four reads, the reader the assembly-document census could never reach, since nothing parses those files.

**The change:** `em.rewound_uuids(path)` memoizes the verdict set per frozen file as the fold `rewoundUuids` of the file's fold document. `fold_records` consults it: a hit or a restore at the witness answers with no read; a file that grew or was rewritten steps a `step` that retires the state, so the walk runs again and the memo is rewritten; after a walk the set is stored at the reader's witness and the quiescence drop writes the document from the walk's own read and lets the records go (the drop's budget and deferral apply); the fold state cap records an over-cap set as such and it is walked again; a corrupt document is the writer's counted fallback, never a raise inside a judge pass. The scan takes the leaf road (the document's pre-cut verdicts and the tail) for the leaf and the memo for every other file. Counted under `checkpoints.rewoundMemo` (served, walked, stale) beside the existing restoredFolds and oversizeFolds rows; the reference says so beside wholeReads.

**Tests** (`tests/test_rewind_memo.py`, over the golden scenario with a rewound branch): the first process walks (a whole read), the document carries the set, the next process is served with no whole read and the same verdicts; a file that grows is walked again and the memo rewritten; the scan's two roads by source; an over-cap set recorded as such and walked again; a corrupt document falls to the walk with a counted fallback. At the base, a probe shows two processes both reading the frozen file whole. Full Python suite green locally (12,523 passed).

**Measurement on the next deploy boot:** the `_per_file_rewound` rows under `recordCache.wholeReads` (542 MB on the first T384 boot) to the first boot's walks only, then zero on the boot after; `checkpoints.rewoundMemo` served against walked; firstCycleS and leaf reads beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)