### PR TITLE
The lightbox column keeps a floor of its download-and-copy group, a second copy press resets the control, and the directory truncates before the basename

### DIFF
--- a/tests/test_lightbox_bar_browser.py
+++ b/tests/test_lightbox_bar_browser.py
@@ -73,7 +73,7 @@ const ctx = await browser.newContext({ viewport: { width: 1100, height: 640 } })
 const page = await ctx.newPage();
 await page.goto(cfg.chat);
 await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
-await page.waitForFunction(() => { const is = Array.from(document.querySelectorAll(".path-full-img")); return is.length >= 2 && is.every((i) => i.complete && i.naturalWidth > 0); }, null, { timeout: 30000 });
+await page.waitForFunction(() => { const is = Array.from(document.querySelectorAll(".path-full-img")); return is.length >= 3 && is.every((i) => i.complete && i.naturalWidth > 0); }, null, { timeout: 30000 });
 await page.waitForTimeout(200);
 const r1 = (v) => Math.round(v * 10) / 10;
 const rectOf = "(e) => { const b = e.getBoundingClientRect(); const r = (v) => Math.round(v * 10) / 10; return { top: r(b.top), bottom: r(b.bottom), left: r(b.left), right: r(b.right), w: r(b.width), h: r(b.height) }; }";
@@ -110,6 +110,8 @@ const measure = (label) => page.evaluate(([label, rectSrc, dressSrc]) => {
     barClasses: bar.className, barBorderBottom: getComputedStyle(bar).borderBottomColor, barPadding: getComputedStyle(bar).padding,
     nameMinWidth: (bar.querySelector(".fileview-name") ? getComputedStyle(bar.querySelector(".fileview-name")).minWidth : ""), barContain: getComputedStyle(bar).contain,
     baseOverflow: base ? getComputedStyle(base).overflow : "", imgNatural: img.naturalWidth,
+    title2: { baseWhole: base ? base.scrollWidth <= base.clientWidth + 0.5 : null, dirClipped: dir ? dir.scrollWidth > dir.clientWidth + 0.5 : null, baseW: base ? base.getBoundingClientRect().width : null },
+    actsRect: rect(acts), floor: getComputedStyle(inner).minWidth,
     title: { dir: dir && dir.textContent, base: base && base.textContent, full: (bar.querySelector(".fileview-name") || bar.querySelector(".romp-lightbox-name") || {}).title || "", baseColor: base && getComputedStyle(base).color, dirColor: dir && getComputedStyle(dir).color },
     controls, actsChildren: acts ? Array.from(acts.children).map((c) => c.className) : [], bodyLight: document.body.classList.contains("theme-light") };
 }, [label, rectOf, dressOf]);
@@ -134,6 +136,17 @@ await page.waitForSelector("#romp-lightbox .romp-lightbox-bar", { timeout: 15000
 await page.waitForFunction(() => { const i = document.querySelector("#romp-lightbox .romp-lightbox-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 15000 });
 await page.waitForTimeout(150);
 out.narrow = await measure("narrow");
+await page.keyboard.press("Escape"); await page.waitForTimeout(120);
+// the TINY picture: 48px, narrower than the three controls; the column keeps a floor of their width and every control stays inside it
+await page.click(".path-full-img >> nth=2");
+await page.waitForSelector("#romp-lightbox .romp-lightbox-bar", { timeout: 15000 });
+await page.waitForFunction(() => { const i = document.querySelector("#romp-lightbox .romp-lightbox-img"); return !!(i && i.complete && i.naturalWidth > 0); }, null, { timeout: 15000 });
+await page.waitForTimeout(150);
+out.tiny = await measure("tiny");
+if (cfg.shots) {
+  const clip = await page.evaluate(() => { const b = document.querySelector("#romp-lightbox .romp-lightbox-inner").getBoundingClientRect(); return { x: Math.max(0, b.left - 24), y: Math.max(0, b.top - 24), width: Math.min(window.innerWidth, b.width + 48), height: Math.min(window.innerHeight, b.height + 48) }; });
+  await page.screenshot({ path: cfg.shots + "-tiny-dark.png", clip });
+}
 if (cfg.shots) {
   const clip = await page.evaluate(() => { const b = document.querySelector("#romp-lightbox .romp-lightbox-inner").getBoundingClientRect(); return { x: Math.max(0, b.left - 24), y: Math.max(0, b.top - 24), width: Math.min(window.innerWidth, b.width + 48), height: Math.min(window.innerHeight, b.height + 48) }; });
   await page.screenshot({ path: cfg.shots + "-narrow-dark.png", clip });
@@ -186,6 +199,7 @@ class ServedLightboxBar(unittest.TestCase):
         cls.figure = os.path.join(cwd, "docs", "figure.png")
         Path(cls.figure).write_bytes(_png())
         Path(cwd, "docs", "narrow.png").write_bytes(_png(120, 80, (4, 120, 178)))   # narrower than the bar's controls: the picture must still set the column
+        Path(cwd, "docs", "tiny.png").write_bytes(_png(48, 32, (178, 60, 4)))        # narrower than the controls themselves: the column keeps a floor of their width
         proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))
         os.makedirs(proj, exist_ok=True)
         t0 = int(time.time()) - 900
@@ -197,7 +211,7 @@ class ServedLightboxBar(unittest.TestCase):
                  "message": {"role": "user", "content": "where is the figure for the notes-api guide?"}},
                 {"type": "assistant", "timestamp": iso(t0 + 5), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
                  "message": {"role": "assistant", "model": "claude-opus-5", "stop_reason": "end_turn",
-                             "content": [{"type": "text", "text": "The guide's figure is at docs/figure.png and its thumbnail at docs/narrow.png."}]}}]
+                             "content": [{"type": "text", "text": "The guide's figure is at docs/figure.png, its thumbnail at docs/narrow.png and its icon at docs/tiny.png."}]}}]
         Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
         Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
         cls.port, cls.token = _free_port(), "testtok-lightbox"
@@ -329,6 +343,34 @@ class ServedLightboxBar(unittest.TestCase):
         for c in m["controls"]:
             self.assertGreaterEqual(c["rect"]["left"], m["inner"]["left"] - 0.5, "every control stays inside the column: " + json.dumps(c["rect"]))
             self.assertLessEqual(c["rect"]["right"], m["inner"]["right"] + 0.5, "every control stays inside the column: " + json.dumps(c["rect"]))
+
+    def test_a_picture_narrower_than_the_controls_gets_a_column_floored_at_their_width_with_every_control_inside(self):
+        """Round two's low: at 48px the download and copy group sat 18px outside the column to the left. The column keeps a floor
+        of the actions' measured width (a variable the lightbox sets when it mounts), so the controls stay inside it and the
+        picture centres under them."""
+        m = self._run()["tiny"]
+        table = "\n  " + json.dumps({"inner": m["inner"], "img": m["img"], "acts": m["actsRect"], "floor": m["floor"], "controls": [c["rect"] for c in m["controls"]]})
+        self.assertEqual(m["imgNatural"], 48)
+        self.assertAlmostEqual(m["img"]["w"], 48, delta=0.5, msg="the tiny picture at its own size" + table)
+        group = [c for c in m["controls"] if "fileview-group" in c["group"]]
+        need = sum(c["rect"]["w"] for c in group) + 4 * (len(group) - 1)
+        self.assertGreaterEqual(m["inner"]["w"], need - 0.5, "the column is at least as wide as the download-and-copy group" + table)
+        self.assertNotEqual(m["floor"], "0px", "the floor variable is set (the lightbox measured its group)" + table)
+        for c in m["controls"]:
+            self.assertGreaterEqual(c["rect"]["left"], m["inner"]["left"] - 0.5, "every control inside the column: " + json.dumps(c["rect"]) + table)
+            self.assertLessEqual(c["rect"]["right"], m["inner"]["right"] + 0.5, "every control inside the column: " + json.dumps(c["rect"]) + table)
+        centre = (m["img"]["left"] + m["img"]["right"]) / 2
+        self.assertAlmostEqual(centre, (m["inner"]["left"] + m["inner"]["right"]) / 2, delta=1.5, msg="the picture centres in the wider column" + table)
+
+    def test_under_a_narrow_picture_the_basename_reads_whole_and_the_directory_carries_the_ellipsis(self):
+        """Round two's low: both halves shared the deficit (do... narrow.p...), against the viewer's rule that only the directory
+        truncates. The directory absorbs the deficit first; the basename shrinks only when it does not fit alone."""
+        m = self._run()["narrow"]
+        table = "\n  " + json.dumps(m["title2"]) + " " + json.dumps(m["title"])
+        self.assertTrue(m["title2"]["baseWhole"], "the basename is not clipped at 120px" + table)
+        self.assertTrue(m["title2"]["dirClipped"], "…the directory carries the ellipsis" + table)
+        t = self._run()["tiny"]
+        self.assertEqual(t["title2"]["dirClipped"], True, "at 48px the directory is gone to its ellipsis first: " + json.dumps(t["title2"]))
 
     def test_escape_closes_the_lightbox(self):
         self.assertTrue(self._run()["afterEscape"]["gone"])

--- a/ui/webview/lightbox-bar.test.ts
+++ b/ui/webview/lightbox-bar.test.ts
@@ -21,6 +21,8 @@ type El = {
   setAttribute: (k: string, v: string) => void; getAttribute: (k: string) => string | null; addEventListener: () => void; querySelector: () => null;
 };
 function mkEl(tag: string): El {
+  const style: Record<string, string> & { setProperty?: (k: string, v: string) => void } = {};
+  style.setProperty = (k, v) => { style[k] = v; };
   const e: El = {
     tag, className: "", id: "", children: [], parent: null, textContent: "", innerHTML: "", title: "", attrs: {}, dataset: {}, type: "", href: "", download: "", src: "", alt: "",
     classList: {
@@ -36,6 +38,8 @@ function mkEl(tag: string): El {
     setAttribute: (k, v) => { e.attrs[k] = v; }, getAttribute: (k) => (k in e.attrs ? e.attrs[k] : null),
     addEventListener: () => {}, querySelector: () => null,
   };
+  (e as El & { style: typeof style }).style = style;
+  (e as El & { getBoundingClientRect: () => unknown }).getBoundingClientRect = () => ({ left: 0, right: 30, top: 0, bottom: 22, width: 30, height: 22 });   // the floor measurement reads the group's controls
   return e;
 }
 function classes(e: El): string[] { return e.className.split(/\s+/).filter(Boolean); }
@@ -52,7 +56,8 @@ function wins(a: [number, number, number], b: [number, number, number]): boolean
 }
 
 type Nav = Array<{ path: string; sid?: string | null; pin?: string }>;
-function lift(kind: "img" | "pdf", nav: Nav = [], clipboard = false): { body: El; open: (p: string, sid?: string | null, pin?: string) => void; keys: Array<(ev: { key: string; stopPropagation: () => void; preventDefault: () => void }) => void> } {
+type Win = { setTimeout: (fn: () => void, ms: number) => number; clearTimeout: (h: number) => void };
+function lift(kind: "img" | "pdf", nav: Nav = [], clipboard: boolean | { write: () => Promise<void> } = false, win?: Win): { body: El; open: (p: string, sid?: string | null, pin?: string) => void; keys: Array<(ev: { key: string; stopPropagation: () => void; preventDefault: () => void }) => void> } {
   const a = PREVIEW.indexOf("export function openLightbox(path: string, sid?: string | null, pin?: string): void {");
   const b = PREVIEW.indexOf("\n}\n", a);
   assert.ok(a > 0 && b > a, "openLightbox: anchors not found; re-anchor");
@@ -60,16 +65,17 @@ function lift(kind: "img" | "pdf", nav: Nav = [], clipboard = false): { body: El
   const body = mkEl("body");
   const keys: Array<(ev: { key: string; stopPropagation: () => void; preventDefault: () => void }) => void> = [];
   const document = { createElement: mkEl, getElementById: () => null, body, addEventListener: (_t: string, fn: (ev: unknown) => void) => { keys.push(fn as never); }, removeEventListener: () => {} };
-  const H = { kind, nav, clipboard };
+  const H = { kind, nav, clipboard: !!clipboard, clip: typeof clipboard === "object" ? clipboard : null, window: win || null };
   const prelude = `
     const previewKind = (p) => H.kind;
     const fileUrl = (p, sid) => "/file?path=" + encodeURIComponent(p) + "&sid=" + (sid || "");
     const wirePinchZoom = (stage, img) => ({ retarget: () => {} });
     const lightboxNav = H.nav.length ? (() => H.nav) : null;
     const ICON_DOWNLOAD = '<svg data-icon="download"/>', ICON_COPY = '<svg data-icon="copy"/>', ICON_CHECK = '<svg data-icon="check"/>', ICON_CROSS = '<svg data-icon="cross"/>';
-    const navigator = H.clipboard ? { clipboard: { write: () => Promise.resolve() } } : {};
+    const navigator = H.clipboard ? { clipboard: H.clip || { write: () => Promise.resolve() } } : {};
+    const fetch = () => Promise.resolve({ blob: () => Promise.resolve({ type: "image/png" }) });
     const ClipboardItem = H.clipboard ? function ClipboardItem() {} : undefined;
-    const window = { setTimeout: () => 1, clearTimeout: () => {} };
+    const window = H.window || { setTimeout: () => 1, clearTimeout: () => {} };
   `;
   const open = (new Function("H", "document", prelude + code + "\nreturn openLightbox;") as (h: unknown, d: unknown) => (p: string, sid?: string | null, pin?: string) => void)(H, document);
   return { body, open, keys };
@@ -182,4 +188,33 @@ test("styles: the lightbox's own chip rules are gone, the shared bar rules stand
   assert.equal((CSS.match(/^\.fileview-bar \{/gm) || []).length, 1);
   assert.match(CSS, /^\.fileview-btn\.fileview-icon \{/m);
   assert.match(CSS, /^a\.fileview-btn \{ text-decoration: none; display: inline-flex; align-items: center; \}/m, "the download anchor wears the button treatment");
+});
+
+test("a second copy press inside the pulse clears the first press's restore timer (the review's low): the dim is never wiped while the write is in flight", async () => {
+  const timers: Array<{ id: number; ms: number; fn: () => void }> = []; const cleared: number[] = []; let nextId = 1;
+  const win: Win = { setTimeout: (fn, ms) => { const id = nextId++; timers.push({ id, ms, fn }); return id; }, clearTimeout: (h) => { cleared.push(h); } };
+  let resolveWrite: (() => void) | null = null;
+  const clip = { write: () => new Promise<void>((res) => { resolveWrite = res; }) };
+  const { body, open } = lift("img", [], clip, win);
+  open("plots/run1.png", "s1");
+  const cp = column(body).children[0].children[1].children[0].children[1] as El & { onclick?: (ev: unknown) => void };
+  assert.ok(classes(cp).includes("romp-lightbox-copy"));
+  const ev = { stopPropagation: () => {} };
+  cp.onclick!(ev);
+  assert.ok(classes(cp).includes("fileview-busy"), "the first press dims in its own tick");
+  resolveWrite!(); await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r));
+  assert.deepEqual(timers.map((t) => t.ms), [1400], "the first write landed: the ack pulse's restore timer is armed");
+  assert.ok(classes(cp).includes("ok") && !classes(cp).includes("fileview-busy"));
+  cp.onclick!(ev);   // a second press inside the pulse
+  assert.deepEqual(cleared, [1], "the second press clears the first press's restore timer before its write starts");
+  assert.ok(classes(cp).includes("fileview-busy") && !classes(cp).includes("ok"), "…and dims again");
+  timers[0].fn();   // had the first timer fired anyway, it must not have (cleared); firing it here models the bug: the dim would be wiped
+  resolveWrite!(); await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r));
+  assert.deepEqual(timers.map((t) => t.ms), [1400, 1400], "the second write armed its own restore");
+});
+
+test("styles (the review's lows): the column keeps a floor of the controls' width, and the directory absorbs the title's deficit ahead of the basename", () => {
+  assert.match(CSS, /^\.romp-lightbox-inner \{ [^}]*min-width: var\(--lb-acts-w, 0px\);/m, "the floor: the download-and-copy group's width, set by the lightbox when it mounts");
+  assert.match(PREVIEW, /const ctl = Array\.from\(group\.children\) as HTMLElement\[\];\s*\n\s*inner\.style\.setProperty\("--lb-acts-w", Math\.ceil\(ctl\.reduce\(\(a, c\) => a \+ c\.getBoundingClientRect\(\)\.width, 0\) \+ 4 \* Math\.max\(0, ctl\.length - 1\) \+ 8\) \+ "px"\);/, "read off the group's own controls (intrinsic widths), once per open, after the mount");
+  assert.match(CSS, /^#romp-lightbox \.romp-lightbox-bar \.fileview-dir \{ flex-shrink: 1000; \}/m, "the directory gives up its room first; the basename shrinks only when it does not fit alone");
 });

--- a/ui/webview/lightbox-copy.test.ts
+++ b/ui/webview/lightbox-copy.test.ts
@@ -45,7 +45,7 @@ test("the click acknowledges immediately and failures state why — both self-re
   assert.match(PREVIEW, /\(e\) => say\(ICON_CROSS, "Copy failed: " \+ \(\(e && \(e as Error\)\.message\) \|\| String\(e\)\), "err", 3000\)\);/);
   assert.match(PREVIEW, /const say = \(icon: string, word: string, cls: string, ms: number \| null\) => \{\s*\n\s*btn\.innerHTML = icon; btn\.title = word; btn\.setAttribute\("aria-label", word\);/);
   // the viewer's click-safety (T385 review): the press dims in its own tick, and ONE restore timer is cleared on every swap
-  assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss\s*\n\s*btn\.classList\.add\("fileview-busy"\);/, "the same-tick acknowledgement");
+  assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss\s*\n\s*say\(COPY_SVG, "Copy image", "", null\);[^\n]*\n\s*btn\.classList\.add\("fileview-busy"\);/, "the same-tick acknowledgement, after the one state-setter reset the glyph and cleared a pulse's pending restore (review, round two)");
   assert.match(PREVIEW, /btn\.classList\.remove\("ok", "err", "fileview-busy"\); if \(cls\) btn\.classList\.add\(cls\);/);
   assert.match(PREVIEW, /if \(copyTimer\) \{ window\.clearTimeout\(copyTimer\); copyTimer = null; \}\s*\n\s*if \(ms !== null\) copyTimer = window\.setTimeout\(\(\) => say\(COPY_SVG, "Copy image", "", null\), ms\);/, "one timer, cleared on every swap");
   assert.match(PREVIEW, /ev\.stopPropagation\(\);\s*\/\/ copying must not also dismiss/);

--- a/ui/webview/preview.ts
+++ b/ui/webview/preview.ts
@@ -399,6 +399,7 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
     say(COPY_SVG, "Copy image", "", null);
     btn.onclick = (ev) => {
       ev.stopPropagation();                                // copying must not also dismiss
+      say(COPY_SVG, "Copy image", "", null);               // a press inside the last pulse: its check and its restore timer go, so the restore never wipes this press's dim (review, round two)
       btn.classList.add("fileview-busy");                  // the same-tick acknowledgement
       const src = curImg!().src;
       const png = (async () => {
@@ -439,6 +440,13 @@ export function openLightbox(path: string, sid?: string | null, pin?: string): v
   wrap.onclick = (ev) => { if (ev.target === wrap) dismiss(); };   // backdrop closes; content clicks don't
   document.addEventListener("keydown", onKey, true);
   document.body.appendChild(wrap);
+  // the column's FLOOR (review, round two): a picture narrower than the download-and-copy group (about 68px) let the group run
+  // out of the column to the left, since the bar contributes no intrinsic width (contain: inline-size: the picture sets the
+  // column, never the path text). The floor is the GROUP's own width, read off its controls (their widths are intrinsic:
+  // flex 0 0 auto buttons in a constrained box still measure themselves), set once per open as the variable the sheet reads
+  // (.romp-lightbox-inner min-width). The close may wrap beneath the group under a tiny picture; the picture centres under them.
+  const ctl = Array.from(group.children) as HTMLElement[];
+  inner.style.setProperty("--lb-acts-w", Math.ceil(ctl.reduce((a, c) => a + c.getBoundingClientRect().width, 0) + 4 * Math.max(0, ctl.length - 1) + 8) + "px");
 }
 
 // FULL-SIZE inline render for a mentioned image in the CHAT (the user 2026-07-20, who wanted not even a

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -3421,7 +3421,7 @@ body.drop-over::after { content: ""; position: fixed; inset: 0; pointer-events: 
    browser's native viewer. Above every overlay layer. Backdrop click / Esc / ✕ closes. */
 #romp-lightbox { position: fixed; inset: 0; z-index: 1300; background: rgba(0, 0, 0, 0.72);
   display: flex; align-items: center; justify-content: center; }
-.romp-lightbox-inner { display: flex; flex-direction: column; gap: 8px; max-width: 92vw; max-height: 90vh; }
+.romp-lightbox-inner { display: flex; flex-direction: column; gap: 8px; max-width: 92vw; max-height: 90vh; min-width: var(--lb-acts-w, 0px); }   /* the floor: the bar's download-and-copy group, measured by openLightbox (review, round two) */
 .romp-lightbox-img { max-width: 92vw; max-height: 82vh; object-fit: contain; border-radius: 8px; align-self: center;
   box-shadow: var(--shadow-modal);
   transform-origin: 0 0; will-change: transform; }   /* pinch-zoom renders translate+scale from this corner (T162; pinch.ts) */
@@ -3445,6 +3445,9 @@ body.drop-over::after { content: ""; position: fixed; inset: 0; pointer-events: 
 #romp-lightbox .romp-lightbox-bar { padding: 0 2px 6px; contain: inline-size; }
 #romp-lightbox .romp-lightbox-bar .fileview-name { min-width: 0; overflow: hidden; }
 #romp-lightbox .romp-lightbox-bar .fileview-base { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+/* the viewer's rule kept as far as the column allows (review, round two): the directory gives up its room first, by a shrink weight
+   a thousand times the basename's, so the basename reads whole down to the width where it alone does not fit */
+#romp-lightbox .romp-lightbox-bar .fileview-dir { flex-shrink: 1000; }
 /* the backdrop is 72% black in BOTH themes, so inside the lightbox the bar's tokens are the dark theme's whatever the
    page wears: the light theme's near-black prose, hairline and clay accent would sit on a dark field otherwise */
 #romp-lightbox { --fg: #e8e8e8; --dim: #b8b8b8; --accent: #9cd2ff; --accent-fg: #0c1a2e; --accent-wash: rgba(156, 210, 255, 0.12);


### PR DESCRIPTION
The three lows from the lightbox bar's second review round (pull request 1533).

- **A floor for the column.** A picture narrower than the download-and-copy group (about 68px) let the group run out of the column to the left, since the bar contributes no intrinsic width (the picture sets the column). The lightbox now reads the group's own controls when it mounts (their widths are intrinsic even in a constrained box) and sets the column's minimum width from them (`--lb-acts-w`, read by `.romp-lightbox-inner`), so every control stays inside and the picture centres under them; the close may wrap beneath the group under a tiny picture.
- **A second copy press resets the control.** A press inside the ack pulse had its dim wiped by the first press's restore timer. The click now resets the control through its one state-setter (glyph, classes and the pending timer) before dimming.
- **Only the directory truncates.** The title's two halves shared the deficit against the viewer's rule. The directory's shrink weight is a thousand times the basename's, so the basename reads whole down to the width where it alone does not fit.

**Tests**
- `lightbox-bar.test.ts`: the lift drives two presses with a stubbed clipboard and recorded timers (red before: nothing cleared); pins for the floor variable, its measurement and the shrink rule.
- `tests/test_lightbox_bar_browser.py`: a 48px figure joins the lab: the column at least the group's width, every control inside it, the picture centred; the 120px figure's title halves are read: the basename unclipped, the directory carrying the ellipsis. Both red against main's bundle through `LB_DIST`.
- `lightbox-copy.test.ts` re-pinned to the click's reset.

Tier: fix
