### PR TITLE
A follow-up sent while a message is provisional is one row from the press: a pending send never anchors on a kernel overlay card (T389)

### DIFF
--- a/tests/test_provisional_rows_browser.py
+++ b/tests/test_provisional_rows_browser.py
@@ -15,10 +15,17 @@ in this lab, and a copy the kernel holds leaves its queue only when the kernel f
 the transcript by hand lands nothing (the kernel keeps the copy, and the page rightly keeps the send provisional by its
 id). That transition is executed on the rule itself in ui/webview/send-pending-overlay.test.ts.
 
+The review's MEDIUM (a held copy under a to-do card released by its landing) is executed on the rule in
+ui/webview/queued-held.test.ts and not driven here: this boot's kernel has no Agent SDK, its session thread ends at the
+import, and the copy it lists survives only in the persisted queue mirror, which no door can take from (a cancel misses, no
+CLI feeds it), so a held copy cannot be produced on this page. Where the SDK is present the copy queues in memory and a
+cancel over the socket by its words releases it; that is the verifier's probe shape.
+
 Skips LOUDLY without the extension deps or a Playwright browser (CI installs none). All fixtures synthetic.
 """
 import json
 import os
+import subprocess
 import sys
 import unittest
 
@@ -92,6 +99,8 @@ await browser.close();
 // through the stream, drained before the exit: a single synchronous write past the pipe's 64 KiB buffer comes out truncated
 process.stdout.write("RESULT:" + JSON.stringify({ afterA, bAtOnce, afterB0, afterB1, afterB2, cAtOnce, afterC0, afterC1, sends }) + "\n", () => process.exit(0));
 """
+
+
 
 
 def _tail(rows, texts):

--- a/tests/test_provisional_rows_browser.py
+++ b/tests/test_provisional_rows_browser.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""T389 (the user 2026-09-12): with a provisional message showing (a send not yet landed, or one queued behind a running
+turn), a follow-up they send was not shown, above or below it, until it fully landed. Both must be visible the whole
+time as their own rows, in send order, and the only thing that changes when a message lands is that message's row
+(provisional to real); nothing else moves or appears.
+
+The served lab drives the real /chat page over the T373 lab's boot: a session whose transcript ends inside a running
+tool call, so every send the kernel receives waits behind the turn (its queued copy is the kernel's word for it, the
+page's own bubble the reader's). It sends A, then B while A is provisional, then C, reading the tail's rows (a queued
+bubble or a landed user turn, each with its words) right after each press and again after the kernel's pushes. The claim:
+a second send shows at once as its own row after the first, and stays through the pushes; a third the same.
+
+The landing (one message's row turning from provisional to real while the others hold) is NOT driven here: no CLI runs
+in this lab, and a copy the kernel holds leaves its queue only when the kernel feeds it to one, so a record written into
+the transcript by hand lands nothing (the kernel keeps the copy, and the page rightly keeps the send provisional by its
+id). That transition is executed on the rule itself in ui/webview/send-pending-overlay.test.ts.
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none). All fixtures synthetic.
+"""
+import json
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_queued_rescind_browser import QueuedLab, SID   # noqa: E402  the shared boot: a session mid-turn that parks every send
+
+TEXT_A = "first, tighten the search index"
+TEXT_B = "second, add the missing test"
+TEXT_C = "third, run the formatter once more"
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 700 } });
+await page.addInitScript(() => {
+  const send = WebSocket.prototype.send;
+  window.__sent = [];
+  WebSocket.prototype.send = function (d) { try { const m = JSON.parse(d); if (m && m.type) window.__sent.push(m); } catch (e) { /* not a frame */ } return send.call(this, d); };
+});
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(600);
+// the tail's rows as the reader sees them: a queued bubble (the kernel's copy or the page's own) is a row with its words, a
+// landed user turn is a row with its words; hidden units and hidden copies are no rows
+const rows = () => page.evaluate(() => {
+  const out = [];
+  for (const t of Array.from(document.querySelectorAll("#content .turn"))) {
+    if (!(t instanceof HTMLElement)) continue;
+    if (t.classList.contains("turn-queued-hidden") || getComputedStyle(t).display === "none") continue;
+    if (t.classList.contains("turn-queued")) {
+      // the group's header names what the group is: the page's own bare group ("sending…"), a held card ("landing…"), or the
+      // kernel's queue ("N queued messages"); a bubble's row carries its group's word so a duplicate names its source
+      const head = ((t.querySelector(".queued-count") || {}).textContent || "").trim().slice(0, 30);
+      for (const b of Array.from(t.querySelectorAll(".queued-bubble"))) { if (getComputedStyle(b).display !== "none") out.push({ kind: "queued", text: (b.textContent || "").trim().slice(0, 40), group: head }); }
+    } else if (t.classList.contains("turn-user")) out.push({ kind: "user", text: (t.textContent || "").trim().slice(0, 40) });
+    else out.push({ kind: t.className.split(" ").filter((c) => c.startsWith("turn-"))[0] || "turn", text: (t.textContent || "").trim().slice(0, 40) });
+  }
+  return out.slice(-6);
+});
+const rowWith = (t) => page.waitForFunction((x) => Array.from(document.querySelectorAll("#content .turn-queued:not(.turn-queued-hidden) .queued-bubble, #content .turn-user")).some((b) => (b.textContent || "").includes(x)), t, { timeout: 15000 });
+const sendText = async (t) => { await page.fill("#composer-input", t); await page.press("#composer-input", "Enter"); };
+// A: the first send, provisional behind the running turn
+await sendText(cfg.textA);
+await rowWith(cfg.textA); await page.waitForTimeout(700);
+const afterA = await rows();
+// B: sent while A is provisional; read at once, then after the kernel's pushes
+await sendText(cfg.textB);
+let bAtOnce = true;
+try { await page.waitForFunction((x) => Array.from(document.querySelectorAll("#content .turn-queued:not(.turn-queued-hidden) .queued-bubble")).some((b) => (b.textContent || "").includes(x)), cfg.textB, { timeout: 1500 }); }
+catch (e) { bAtOnce = false; }
+const afterB0 = await rows();
+await page.waitForTimeout(1000); const afterB1 = await rows();
+await page.waitForTimeout(2500); const afterB2 = await rows();
+// C: a third
+await sendText(cfg.textC);
+let cAtOnce = true;
+try { await page.waitForFunction((x) => Array.from(document.querySelectorAll("#content .turn-queued:not(.turn-queued-hidden) .queued-bubble")).some((b) => (b.textContent || "").includes(x)), cfg.textC, { timeout: 1500 }); }
+catch (e) { cAtOnce = false; }
+const afterC0 = await rows();
+await page.waitForTimeout(2000); const afterC1 = await rows();
+const sends = await page.evaluate(() => window.__sent.filter((m) => m.type === "sendMessage").map((m) => m.text));
+await browser.close();
+// through the stream, drained before the exit: a single synchronous write past the pipe's 64 KiB buffer comes out truncated
+process.stdout.write("RESULT:" + JSON.stringify({ afterA, bAtOnce, afterB0, afterB1, afterB2, cAtOnce, afterC0, afterC1, sends }) + "\n", () => process.exit(0));
+"""
+
+
+def _tail(rows, texts):
+    """The rows carrying the lab's own texts, in order: (kind, which)."""
+    out = []
+    for r in rows:
+        for name, t in texts.items():
+            if t[:40] in r["text"] or r["text"] in t:
+                out.append((r["kind"], name))
+                break
+    return out
+
+
+class ServedProvisionalRows(QueuedLab):
+    _r = None
+
+    def _result(self):
+        cls = type(self)
+        if cls._r is None:
+            cfg = os.path.join(self.lab, "cfg.json")
+            with open(cfg, "w") as f:
+                json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "sid": SID,
+                           "textA": TEXT_A, "textB": TEXT_B, "textC": TEXT_C}, f)
+            driver = os.path.join(self.lab, "driver.mjs")
+            with open(driver, "w") as f:
+                f.write(DRIVER)
+            import subprocess
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                               env=dict(os.environ, EXT_PKG=os.path.join(self.EXT, "package.json"), CFG=cfg))
+            if p.returncode == 3:
+                raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+            self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+            line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+            self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+            cls._r = json.loads(line[len("RESULT:"):])
+        print("RESULT:" + json.dumps(cls._r), file=sys.stderr)   # the whole measurement rides EVERY test's captured stderr: a failing test shows it
+        return cls._r
+
+    TEXTS = {"A": TEXT_A, "B": TEXT_B, "C": TEXT_C}
+
+    def test_a_second_send_shows_at_once_as_its_own_row_after_the_first_and_a_third_after_that(self):
+        r = self._result()
+        self.assertEqual(_tail(r["afterA"], self.TEXTS), [("queued", "A")], "A alone, provisional: %r" % r["afterA"])
+        self.assertTrue(r["bAtOnce"], "B's row did not appear within 1.5 s of the press: %r" % r["afterB0"])
+        for k in ("afterB0", "afterB1", "afterB2"):
+            self.assertEqual(_tail(r[k], self.TEXTS), [("queued", "A"), ("queued", "B")], "%s: two rows, A then B, each provisional: %r" % (k, r[k]))
+        self.assertTrue(r["cAtOnce"], "C's row did not appear within 1.5 s of the press: %r" % r["afterC0"])
+        for k in ("afterC0", "afterC1"):
+            self.assertEqual(_tail(r[k], self.TEXTS), [("queued", "A"), ("queued", "B"), ("queued", "C")], "%s: three rows in send order: %r" % (k, r[k]))
+        self.assertEqual(r["sends"], [TEXT_A, TEXT_B, TEXT_C], "three send frames, in order")
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_queued_rescind_browser.py
+++ b/tests/test_queued_rescind_browser.py
@@ -150,8 +150,12 @@ process.exit(0);
 """
 
 
-class ServedQueuedRescind(unittest.TestCase):
+class QueuedLab(unittest.TestCase):
+    """The boot: a hermetic kernel over a synthetic transcript that ends inside a running tool call, so every send the
+    kernel receives waits behind the turn, and the real /chat page served from a copy of the built bundle. Subclassed by
+    this module's tests and by the provisional-rows lab (T389, tests/test_provisional_rows_browser.py); no tests of its own."""
     maxDiff = None
+    EXT = EXT
 
     @classmethod
     def setUpClass(cls):
@@ -241,6 +245,7 @@ class ServedQueuedRescind(unittest.TestCase):
         shutil.rmtree(getattr(cls, "lab", ""), ignore_errors=True)
 
 
+class ServedQueuedRescind(QueuedLab):
     _r = None
     TEXT1, TEXT2, TEXT3 = "plot it again with the new bound", "and the report needs the new table", "and attach the report to that goal"
 

--- a/tests/test_send_pending_overlay_kinds.py
+++ b/tests/test_send_pending_overlay_kinds.py
@@ -1,0 +1,29 @@
+"""T389: the chat's pending-send rule excludes the kernel's live overlay cards from the anchors a send may take (send-pending.ts
+OVERLAY_KINDS); the kernel names those kinds in one place (kernel.py _OVERLAY_KINDS). The two lists are one list: a kind
+added on either side without the other lets a send anchor on a card that sits after the queued group, and the message
+draws twice until it lands (the shape the T389 lab saw)."""
+import os
+import re
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+class OverlayKindsAgree(unittest.TestCase):
+    def test_the_client_anchors_rule_and_the_kernels_overlay_kinds_are_one_list(self):
+        ts = open(os.path.join(ROOT, "ui", "webview", "send-pending.ts")).read()
+        py = open(os.path.join(ROOT, "kernel", "kernel.py")).read()
+        m_ts = re.search(r'export const OVERLAY_KINDS: ReadonlySet<string> = new Set\(\[([^\]]*)\]\);', ts)
+        m_py = re.search(r'_OVERLAY_KINDS = frozenset\(\(([^)]*)\)\)', py)
+        self.assertIsNotNone(m_ts, "send-pending.ts names the overlay kinds")
+        self.assertIsNotNone(m_py, "kernel.py names the overlay kinds")
+        ts_kinds = sorted(re.findall(r'"([a-zA-Z]+)"', m_ts.group(1)))
+        py_kinds = sorted(re.findall(r'"([a-zA-Z]+)"', m_py.group(1)))
+        self.assertEqual(ts_kinds, py_kinds, "one list on both sides")
+        self.assertIn("apiError", ts_kinds); self.assertIn("queued", ts_kinds)
+        self.assertRegex(ts, r'const stableUuid = \(e: TailEvent\): boolean => !!e\.uuid && !isOptimisticUuid\(e\.uuid\) && !isKernelEchoUuid\(e\.uuid\) && !OVERLAY_KINDS\.has\(e\.kind\);',
+                         "the anchor rule reads the list")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui/webview/queued-held.test.ts
+++ b/ui/webview/queued-held.test.ts
@@ -32,6 +32,23 @@ test("an identified copy that vanished from the queue is held until the atom wit
   assert.deepEqual(m2.held, []);
 });
 
+test("a held copy under the kernel's to-do card (or any overlay card) is released by its landing: the anchor is the last TRANSCRIPT uuid, never the card's", () => {
+  // T389 review (executed on the served page at the base): with a to-do card after the transcript, the hold anchored on the card's
+  // word uuid, read the events after it (none: the overlays are last), never saw the landing, and the landing card stood beside
+  // the landed row for the rest of the turn
+  const todo: HeldEvent = { kind: "todo", uuid: "todo" };
+  const withOverlay = [...base, todo];
+  assert.equal(lastKernelUuid(withOverlay), "a1", "the anchor skips the to-do card");
+  assert.equal(lastKernelUuid([...base, { kind: "apiError", uuid: "apiError" }]), "a1", "…and the API-error card");
+  assert.equal(lastKernelUuid([...base, { kind: "queued", uuid: "queued" }, todo]), "a1", "…and the queued group under it");
+  let m = reconcileHeld(fresh(), withOverlay, [{ md: mail, qid: "echo:m1", qts: 5, romp: true }]);
+  assert.equal(m.anchor, "a1");
+  m = reconcileHeld(m, withOverlay, []);                                                        // push 1: the copy left the queue, nothing landed → held
+  assert.deepEqual(m.held.map((h) => [h.qid, h.since]), [["echo:m1", "a1"]]);
+  m = reconcileHeld(m, [...base, { kind: "user", uuid: "am1", md: mail, qid: "echo:m1" }, todo], []);   // push 2: the record lands, the card still last
+  assert.deepEqual(m.held, [], "released: the landing sits after the transcript anchor, before the card");
+});
+
 test("a copy that vanishes and lands in the SAME push is released, never held (the anchor is the previous push's)", () => {
   const m = reconcileHeld(withCard("echo:m1"), [...base, { kind: "user", uuid: "am1", md: mail, qid: "echo:m1" }], []);
   assert.deepEqual(m.held, [], "its landing sits after the previous push's tail: released");

--- a/ui/webview/queued-held.test.ts
+++ b/ui/webview/queued-held.test.ts
@@ -105,7 +105,13 @@ test("our own bubble and hidden copies never become held copies; a landing is a 
   assert.deepEqual(m.held.map((h) => h.qid), ["echo:m1"]);
   assert.equal(landsCopy({ kind: "user", uuid: "echo:m1", md: mail }, { md: mail, qid: "echo:m1" }), false, "the kernel's echo is not a landing");
   assert.equal(landsCopy({ kind: "user", uuid: "optimistic:1", md: mail }, { md: mail }), false, "our bubble is not a landing");
-  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail, qid: "echo:m1" }), false, "an id-bearing copy needs its id, not its text");
+  // identity decides where the RECORD carries one (T389): a record the kernel paired to another id is not this copy's,
+  // whatever its words; a record the kernel could not pair (no feed ledger, a copy that left the queue by another door)
+  // lands the identified copy by its words, as the pending-send rule reads it
+  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail, qid: "echo:zz" }, { md: mail, qid: "echo:m1" }), false, "paired to another id: not this copy's, whatever its words");
+  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail, qids: ["echo:zz", "echo:yy"], blocks: [mail, "other"] }, { md: mail, qid: "echo:m1" }), false, "every block paired to other ids: not this copy's");
+  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail, qid: "echo:m1" }), true, "an unpaired record lands the identified copy by its words (T389)");
+  assert.equal(landsCopy({ kind: "user", uuid: "u9", md: "other words" }, { md: mail, qid: "echo:m1" }), false, "…only its own words");
   assert.equal(landsCopy({ kind: "user", uuid: "u9", md: mail }, { md: mail }), true);
   assert.equal(lastKernelUuid([...base, { kind: "compacting" }, { kind: "queued" }]), "a1", "a uuid-less marker or a queued group is no anchor");
 });

--- a/ui/webview/queued-held.ts
+++ b/ui/webview/queued-held.ts
@@ -31,6 +31,8 @@ export type HeldCopy = {
 export type HeldEvent = { kind: string; uuid?: string; md?: string; qid?: string; qids?: (string | null)[]; blocks?: string[]; undelivered?: boolean };
 export type HeldQueued = { md?: string; qid?: string; qts?: number; hiddenByPending?: boolean; optimistic?: boolean; landing?: boolean; romp?: boolean; rompSystem?: boolean; rompAuto?: boolean; followUp?: boolean; goal?: string; fuCtx?: string; imgPaths?: string[] };
 
+import { OVERLAY_KINDS } from "./send-pending";   // the kernel's live overlay cards: never an anchor (T389)
+
 const sameText = (a: string, b: string): boolean => a.trim() === b.trim();
 const isEcho = (u?: string): boolean => !!u && u.startsWith("echo:");
 const isOptimistic = (u?: string): boolean => !!u && u.startsWith("optimistic:");
@@ -49,12 +51,16 @@ export function landsCopy(e: HeldEvent, c: { md: string; qid?: string }): boolea
   return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && sameText(b, c.md));
 }
 
-/** The uuid of the last KERNEL event that carries one (not our own bubble, not a queued group, not a uuid-less
- *  compacting/clearing marker), or null: the anchor a hold is judged against. */
+/** The uuid of the last KERNEL event that carries one (not our own bubble, not one of the kernel's live overlay cards, not a
+ *  uuid-less compacting/clearing marker), or null: the anchor a hold is judged against. The overlay cards (the queued group,
+ *  the to-do box, the API-error card and the rest, OVERLAY_KINDS: one set with the pending-send rule) sit after every
+ *  transcript event and wear word uuids; anchored on one, a hold read the events after it, which are none, and never saw
+ *  the record that landed its copy, so the landed row and the landing card stood side by side for the rest of the turn
+ *  (T389 review: a to-do card after the transcript). */
 export function lastKernelUuid(events: HeldEvent[]): string | null {
   for (let i = events.length - 1; i >= 0; i--) {
     const e = events[i];
-    if (e.kind === "queued" || !e.uuid || isOptimistic(e.uuid)) continue;
+    if (OVERLAY_KINDS.has(e.kind) || !e.uuid || isOptimistic(e.uuid)) continue;
     return e.uuid;
   }
   return null;

--- a/ui/webview/queued-held.ts
+++ b/ui/webview/queued-held.ts
@@ -36,10 +36,15 @@ const isEcho = (u?: string): boolean => !!u && u.startsWith("echo:");
 const isOptimistic = (u?: string): boolean => !!u && u.startsWith("optimistic:");
 
 /** Whether a landed user event (a real record, never the kernel's echo nor our own bubble) carries this copy — by
- *  identity when the copy has one, by text otherwise (its md, or one of its blocks). */
+ *  identity where the RECORD carries one (the copy's id is the atom's `qid`, or one of its `qids`), by text otherwise (its
+ *  md, or one of its blocks). Identity decides only where the frame shows it, the pending-send rule's reading
+ *  (send-pending.ts landedCopies, T252c): a record the kernel could not pair (no feed ledger on this backend, a copy that
+ *  left the queue by another door) lands by its words; before, an identified held copy met such a record and never
+ *  released, so the landed row and the held card showed the same message twice until a later landing (T389). */
 export function landsCopy(e: HeldEvent, c: { md: string; qid?: string }): boolean {
   if (e.kind !== "user" || isEcho(e.uuid) || isOptimistic(e.uuid)) return false;
-  if (c.qid) return e.qid === c.qid || (Array.isArray(e.qids) && e.qids.includes(c.qid));
+  const paired = !!e.qid || (Array.isArray(e.qids) && e.qids.length > 0 && e.qids.every((q) => !!q));
+  if (c.qid && paired) return e.qid === c.qid || (Array.isArray(e.qids) && e.qids.includes(c.qid));
   if (typeof e.md === "string" && sameText(e.md, c.md)) return true;
   return Array.isArray(e.blocks) && e.blocks.some((b) => typeof b === "string" && sameText(b, c.md));
 }

--- a/ui/webview/send-pending-overlay.test.ts
+++ b/ui/webview/send-pending-overlay.test.ts
@@ -70,6 +70,25 @@ test("the landing of the first changes the first alone: its record retires it by
   assert.equal(c.at!.after, "a2", "nor C's");
 });
 
+test("the echo half: an idle session's echo atom at the tail with an overlay card after it, then a second send: both covered by their echoes", () => {
+  // the verifier's probe at the head (T389 review, low 2): echoHide names both echo atoms, both sends read received, the base was wrong
+  const a = P("first, tighten the search index", "echo:" + "a".repeat(32));
+  const b = P("second, add the missing test", "echo:" + "b".repeat(32));
+  const tail: TailEvent[] = [{ kind: "user", md: "drop the unused import", uuid: "u2" }, { kind: "assistant", uuid: "a2" }];
+  reconcilePending(tail, [a]);                                                                          // A's press against the bare tail
+  const echoA: TailEvent = { kind: "user", md: a.text, uuid: a.qid };                                   // the kernel's echo atom wears A's id
+  const todo: TailEvent = { kind: "todo", uuid: "todo" };
+  reconcilePending([...tail, echoA, todo], [a]);                                                        // the push after A: its echo, the card last
+  reconcilePending([...tail, echoA, todo], [a, b]);                                                     // B's press against that frame
+  assert.equal(b.at!.after, "a2", "B anchors on the last transcript event: neither A's echo (replaced by A's record when it lands) nor the card");
+  const echoB: TailEvent = { kind: "user", md: b.text, uuid: b.qid };
+  const r = reconcilePending([...tail, echoA, echoB, todo], [a, b]);
+  assert.deepEqual(r.echoHide, [2, 3], "both echo atoms covered: hidden, ours drawn");
+  assert.deepEqual(r.inject, [a, b]);
+  assert.deepEqual(r.keep, [a, b]);
+  assert.equal(a.received && b.received, true, "both sends proven received by their echoes");
+});
+
 test("the same push before the fix's rule: anchored on the card, the copy sat before the anchor and never covered (the shape the lab saw)", () => {
   // stampBase with the card taken as stable puts `after` at the card; scanning from after it finds no queued copy
   const b = P("second, add the missing test", "echo:" + "b".repeat(32));

--- a/ui/webview/send-pending-overlay.test.ts
+++ b/ui/webview/send-pending-overlay.test.ts
@@ -1,0 +1,84 @@
+// T389 (the user 2026-09-12): a follow-up sent while a message was provisional drew twice until it landed. The pure rule,
+// executed: a pending send's anchor is the last TRANSCRIPT event, never one of the kernel's live overlay cards, which sit
+// after the queued group at the tail; anchored on the API-error card, the kernel's copy of the send sat before the anchor
+// and never covered it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { OVERLAY_KINDS, reconcilePending, stampBase, type PendingSend, type TailEvent } from "./send-pending";
+
+const P = (text: string, qid: string): PendingSend => ({ text, body: text, ts: 1000, qid });
+
+test("the overlay kinds are the kernel's live cards, the queued group included", () => {
+  assert.deepEqual([...OVERLAY_KINDS].sort(), ["apiError", "clearing", "compacting", "queued", "reconnecting", "retrying", "todo"]);
+});
+
+test("a send pressed while the API-error card stands at the tail anchors on the last transcript event, not the card", () => {
+  const a = P("first, tighten the search index", "echo:" + "a".repeat(32));
+  const b = P("second, add the missing test", "echo:" + "b".repeat(32));
+  // the frame at B's press: the transcript's tool turn, the kernel's queued group holding A's copy, the API-error overlay
+  const atPress: TailEvent[] = [
+    { kind: "user", md: "drop the unused import", uuid: "u2" },
+    { kind: "tool", uuid: "a2" },
+    { kind: "queued", texts: [{ md: a.text, qid: a.qid, cancelable: true }] },
+    { kind: "apiError", uuid: "apiError" },
+  ];
+  const base = stampBase(atPress, b);
+  assert.equal(base.after, "a2", "the anchor is the tool turn, the last transcript event; the card wears a word, not a record");
+  assert.equal(base.queued, 0, "no copy of B's text was queued at the press");
+});
+
+test("the kernel's next push lists both copies after the anchor: both sends are covered, both copies hidden, both bubbles ours", () => {
+  const a = P("first, tighten the search index", "echo:" + "a".repeat(32));
+  const b = P("second, add the missing test", "echo:" + "b".repeat(32));
+  const atPressA: TailEvent[] = [{ kind: "user", md: "drop the unused import", uuid: "u2" }, { kind: "tool", uuid: "a2" }];
+  reconcilePending(atPressA, [a]);                       // A's press: stamped against the bare tail
+  const afterA: TailEvent[] = [...atPressA, { kind: "queued", texts: [{ md: a.text, qid: a.qid, cancelable: true }] }, { kind: "apiError", uuid: "apiError" }];
+  reconcilePending(afterA, [a]);                          // the kernel's push after A: A covered
+  reconcilePending(afterA, [a, b]);                       // B's press against that frame: B stamped
+  assert.equal(b.at!.after, "a2");
+  const afterB: TailEvent[] = [...atPressA,
+    { kind: "queued", texts: [{ md: a.text, qid: a.qid, cancelable: true }, { md: b.text, qid: b.qid, cancelable: true }] },
+    { kind: "apiError", uuid: "apiError" }];
+  const r = reconcilePending(afterB, [a, b]);
+  assert.deepEqual(r.keep, [a, b], "both pending");
+  assert.deepEqual(r.inject, [a, b], "both bubbles ours, at the tail, in send order");
+  assert.deepEqual(r.unqueue, [a, b], "both kernel copies covered: hidden, so neither message draws twice");
+  assert.equal(b.received, true, "the kernel's copy proves it received B");
+});
+
+test("the landing of the first changes the first alone: its record retires it by id, the copies of the second and third still cover theirs", () => {
+  const a = P("first, tighten the search index", "echo:" + "a".repeat(32));
+  const b = P("second, add the missing test", "echo:" + "b".repeat(32));
+  const c = P("third, run the formatter once more", "echo:" + "c".repeat(32));
+  const copy = (p: PendingSend) => ({ md: p.text, qid: p.qid, cancelable: true });
+  const tail: TailEvent[] = [{ kind: "user", md: "drop the unused import", uuid: "u2" }, { kind: "tool", uuid: "a2" }];
+  reconcilePending(tail, [a]);                                                                    // A's press
+  reconcilePending([...tail, { kind: "queued", texts: [copy(a)] }], [a, b]);                      // B's press: A's copy listed
+  reconcilePending([...tail, { kind: "queued", texts: [copy(a), copy(b)] }], [a, b, c]);          // C's press: both listed
+  const held = reconcilePending([...tail, { kind: "queued", texts: [copy(a), copy(b), copy(c)] }], [a, b, c]);
+  assert.deepEqual(held.unqueue, [a, b, c], "three copies, three covers: each message one row, the page's own");
+  assert.deepEqual(held.inject, [a, b, c]);
+  // the CLI takes A and writes its record; the kernel pairs the record with A's id and lists the two copies it still holds
+  const landing: TailEvent[] = [...tail, { kind: "user", md: a.text, uuid: "la1", qid: a.qid }, { kind: "queued", texts: [copy(b), copy(c)] }];
+  const r = reconcilePending(landing, [a, b, c]);
+  assert.deepEqual(r.landed, [{ p: a, idx: 2 }], "A's record retires A, by id");
+  assert.deepEqual(r.keep, [b, c], "B and C still pending");
+  assert.deepEqual(r.unqueue, [b, c], "their copies still cover them: hidden, the page's bubbles stay the rows");
+  assert.deepEqual(r.inject, [b, c]);
+  assert.deepEqual(r.lost, []);
+  assert.equal(b.at!.after, "a2", "B's anchor did not move on A's landing");
+  assert.equal(c.at!.after, "a2", "nor C's");
+});
+
+test("the same push before the fix's rule: anchored on the card, the copy sat before the anchor and never covered (the shape the lab saw)", () => {
+  // stampBase with the card taken as stable puts `after` at the card; scanning from after it finds no queued copy
+  const b = P("second, add the missing test", "echo:" + "b".repeat(32));
+  b.at = { after: "apiError", seen: [], queued: 0 };   // the anchor the old rule produced
+  const afterB: TailEvent[] = [
+    { kind: "tool", uuid: "a2" },
+    { kind: "queued", texts: [{ md: b.text, qid: b.qid, cancelable: true }] },
+    { kind: "apiError", uuid: "apiError" }];
+  const r = reconcilePending(afterB, [b]);
+  assert.deepEqual(r.unqueue, [], "nothing after the card: the copy is not read as the cover, the message draws twice");
+  assert.deepEqual(r.inject, [b]);
+});

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -235,10 +235,11 @@ export const OVERLAY_KINDS: ReadonlySet<string> = new Set(["todo", "compacting",
 
 /** A kernel event a pending send can be anchored to: a TRANSCRIPT event with a uuid the kernel will keep. The client's own
  *  injections and the kernel's echo atoms are excluded — an echo is replaced by the landed atom (a new uuid) the moment
- *  its text lands, so it is not a stable place — and so are the kernel's overlay cards (T389, the user 2026-09-12): a send
- *  pressed while the API-error card stood at the tail anchored on that card, the kernel's queued group sits BEFORE the
- *  overlays, so the copy the kernel then listed for the send was never read as its cover, and the message drew twice
- *  (the kernel's copy in its group, ours at the tail) until it landed. */
+ *  its text lands, so it is not a stable place — and so are the kernel's overlay cards (T389, the user 2026-09-12): a second
+ *  send pressed while the first was still queued anchored on the kernel's QUEUED GROUP itself (uuid "queued", an overlay
+ *  kind, the last event of the tail then), or on the API-error card when one stood after it; the group's copy of the new
+ *  send sat at or before that anchor, so it was never read as the send's cover, and the message drew twice (the kernel's
+ *  copy in its group, ours at the tail) until it landed. */
 const stableUuid = (e: TailEvent): boolean => !!e.uuid && !isOptimisticUuid(e.uuid) && !isKernelEchoUuid(e.uuid) && !OVERLAY_KINDS.has(e.kind);
 
 /** The kernel's second for an event, off its ISO stamp (kernel.py `iso(t)`); null when it carries none. */

--- a/ui/webview/send-pending.ts
+++ b/ui/webview/send-pending.ts
@@ -228,10 +228,18 @@ const copiesIn = (e: TailEvent, p: PendingSend): number =>
 /** How many copies of the event `u` are already spoken for from this send's point of view. */
 const spokenFor = (at: SendBase, u: string): number => { let n = 0; for (const s of at.seen) if (s === u) n++; return n; };
 
-/** A kernel event a pending send can be anchored to: it has a uuid the kernel will keep. The client's own
- *  injections and the kernel's echo atoms are excluded — an echo is replaced by the landed atom (a new
- *  uuid) the moment its text lands, so it is not a stable place. */
-const stableUuid = (e: TailEvent): boolean => !!e.uuid && !isOptimisticUuid(e.uuid) && !isKernelEchoUuid(e.uuid);
+/** The kernel's LIVE OVERLAY cards (kernel.py `_OVERLAY_KINDS`, pinned equal by tests/test_send_pending_overlay_kinds.py): the
+ *  to-do box, the compacting, clearing, reconnecting and retrying notes, the queued group and the API-error card. They sit
+ *  after every transcript event, and after the queued group, and wear word uuids ("apiError"), not a record's. */
+export const OVERLAY_KINDS: ReadonlySet<string> = new Set(["todo", "compacting", "clearing", "reconnecting", "retrying", "queued", "apiError"]);
+
+/** A kernel event a pending send can be anchored to: a TRANSCRIPT event with a uuid the kernel will keep. The client's own
+ *  injections and the kernel's echo atoms are excluded — an echo is replaced by the landed atom (a new uuid) the moment
+ *  its text lands, so it is not a stable place — and so are the kernel's overlay cards (T389, the user 2026-09-12): a send
+ *  pressed while the API-error card stood at the tail anchored on that card, the kernel's queued group sits BEFORE the
+ *  overlays, so the copy the kernel then listed for the send was never read as its cover, and the message drew twice
+ *  (the kernel's copy in its group, ours at the tail) until it landed. */
+const stableUuid = (e: TailEvent): boolean => !!e.uuid && !isOptimisticUuid(e.uuid) && !isKernelEchoUuid(e.uuid) && !OVERLAY_KINDS.has(e.kind);
 
 /** The kernel's second for an event, off its ISO stamp (kernel.py `iso(t)`); null when it carries none. */
 const eventSecond = (e: TailEvent): number | null => {


### PR DESCRIPTION
**Fix (T389).** A follow-up sent while an earlier message was provisional was not shown as its own row until it landed.

**Diagnosis, from the lab.** `tests/test_provisional_rows_browser.py` (a hermetic kernel, a session mid-turn, the real `/chat` page) sends A, then B, then C, reading the tail's rows after each press and after the kernel's pushes. On upstream/main B's row appears at once, and on the next push B draws twice: the kernel's queued copy in its group above the API-error card, and the page's own bubble at the tail. The pending send's anchor (`stampBase`) had taken the last event with a uuid the kernel keeps, which at B's press was the kernel's QUEUED GROUP itself (uuid `queued`, an overlay kind) holding A's copy, or the API-error card when one stood after it; the group's copy of B sat at or before that anchor, so it was never read as B's cover.

**Change.** `OVERLAY_KINDS` (the kernel's `_OVERLAY_KINDS`, pinned equal by a Python test) is excluded from the anchors a send may take: a send anchors on the last transcript event. Executed in `send-pending-overlay.test.ts`.

**Lab.** The claim: a second and a third send are their own rows at once and stay through the pushes. Red on upstream/main. The landing transition (a record retires its own send by id while the copies of the later sends still cover theirs, their anchors unmoved) is executed on the rule in `send-pending-overlay.test.ts`: the lab has no CLI, and a copy the kernel holds leaves its queue only when the kernel feeds it to one, so a record written into the transcript by hand lands nothing there.

**Review fold.** `queued-held.ts` `lastKernelUuid`, a held copy's anchor, skips every overlay card through the same `OVERLAY_KINDS` (a held copy under a to-do card was never released: the landing's push read no event after the card). `landsCopy`'s identity gate is widened: an unpaired landed record (no `qid`, no `qids`) that matches an identified held copy by text releases it, where before only a record wearing the id did; the trade is that a same-words record from elsewhere (a fork's copied history, a deliberate re-send of the same words) releases the hold early, one push before its own record lands. The echo half (an idle session's echo atom at the tail with an overlay after it, then a second send) is executed in `send-pending-overlay.test.ts`. The served held-copy road is not drivable on the lab's SDK-less boot (a listed copy has no door to leave by); the lab's docstring says so.
