### PR TITLE
The chat's background box names every row by its kind: one hue per kind, the tracked task nobody waits on in its kind's section with the verdict as a suffix (T394)

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25731,6 +25731,16 @@ def _awaiting_task_ids(sid, path):
     return [t["tid"] for t in awaited if t.get("tid")]
 
 
+def _bg_service_ids(sid, path):
+    """The live background tasks the judge classified as SERVICES (_bg_split's other half: the closer audited past
+    the launch without a wait, so nobody waits on them), as launch ids, for the chat's box (T394, 2026-09-12): the
+    box words that verdict on the row (kept running, not waited on) and dims it. Shipped in EVERY turn state, unlike
+    awaitingTaskIds (a wait's rows): the verdict is the judge's, and the box must never infer it from a task the rows
+    happen not to name (mid-turn the rows enumerate pending launches only). [] when nothing runs or nothing is furniture."""
+    _, services = _bg_split(sid, path, _bg_live_norm(sid, path))
+    return [t["tid"] for t in services if t.get("tid")]
+
+
 def _bg_service_descs(sid, path):
     """The live background-task descriptions the judge classified as SERVICES (_bg_split) — persistent
     processes the session keeps around, surfaced as the feed's neutral per-session chip (bgServices in
@@ -34427,6 +34437,9 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                   # …and the same tasks' launch ids, so the #bg-tasks box outlines exactly the awaited
                   # rows in the chip's await-green (the user 2026-08-19)
                   "awaitingTaskIds": (_awaiting_task_ids(sid, sess["path"]) if awaiting_why else []),
+                  # …and the launch ids the JUDGE called services (kept running, nobody waiting), in every turn state, so the
+                  # box words that verdict only where the judge gave it (T394 round one)
+                  "bgServiceIds": _bg_service_ids(sid, sess["path"]),
                   "apiTooLong": bool(aerr and aerr.get("tooLong")),
                   # a spend cap is on-you like tooLong (red tab, "raise your cap") AND never auto-retried:
                   # the client's apiRetryTick skips it, and the global pause it engages stops the loop too

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -25731,13 +25731,16 @@ def _awaiting_task_ids(sid, path):
     return [t["tid"] for t in awaited if t.get("tid")]
 
 
-def _bg_service_ids(sid, path):
+def _bg_service_ids(sid, path, live_map=None):
     """The live background tasks the judge classified as SERVICES (_bg_split's other half: the closer audited past
     the launch without a wait, so nobody waits on them), as launch ids, for the chat's box (T394, 2026-09-12): the
     box words that verdict on the row (kept running, not waited on) and dims it. Shipped in EVERY turn state, unlike
     awaitingTaskIds (a wait's rows): the verdict is the judge's, and the box must never infer it from a task the rows
-    happen not to name (mid-turn the rows enumerate pending launches only). [] when nothing runs or nothing is furniture."""
-    _, services = _bg_split(sid, path, _bg_live_norm(sid, path))
+    happen not to name (mid-turn the rows enumerate pending launches only). [] when nothing runs or nothing is furniture.
+    `live_map`: the build's own liveness snapshot, served to the nested reads (_serve_live) so a build handed one takes no
+    fresh registry sweep (tests/test_kernel_pusher_snapshot.py holds the working path to that)."""
+    with _serve_live(live_map):
+        _, services = _bg_split(sid, path, _bg_live_norm(sid, path))
     return [t["tid"] for t in services if t.get("tid")]
 
 
@@ -34439,7 +34442,7 @@ def build_session(sid, now, live_map=None, path_override=None, tail_cap_t=None, 
                   "awaitingTaskIds": (_awaiting_task_ids(sid, sess["path"]) if awaiting_why else []),
                   # …and the launch ids the JUDGE called services (kept running, nobody waiting), in every turn state, so the
                   # box words that verdict only where the judge gave it (T394 round one)
-                  "bgServiceIds": _bg_service_ids(sid, sess["path"]),
+                  "bgServiceIds": _bg_service_ids(sid, sess["path"], live_map),
                   "apiTooLong": bool(aerr and aerr.get("tooLong")),
                   # a spend cap is on-you like tooLong (red tab, "raise your cap") AND never auto-retried:
                   # the client's apiRetryTick skips it, and the global pause it engages stops the loop too

--- a/plans/subagent-transcripts.md
+++ b/plans/subagent-transcripts.md
@@ -347,9 +347,12 @@ right and is untouched; the box must not flap.
   `awaitBreakdown`), the worst tracked status as the dot (a failed task stays glanceable while collapsed;
   running-yellow otherwise), NO note. Row affordances are identical in both states (`bgRow` fed by
   `awaitRowSpec` / `taskRowSpec`; `s.bgTasks` still lends command rows their output tail and Stop handle).
-  Tracked tasks the wait does not name list under "Also running" (was "Background tasks"); when the kernel
-  names no rows at all the working header counts them as the commands they are ("In the background · 1
-  command" for a dev server). The `bg-awaited` outline is one toggle: a wait, or a tracked task named in
+  Tracked tasks the wait does not name list in their KIND's section after the awaited rows (T394, 2026-09-12;
+  before that under an "Also running" section, earlier "Background tasks"): agent-shaped by their agentId,
+  else commands. A task the judge called a service (kernel `bgServiceIds`, `_bg_split`'s furniture verdict)
+  is dimmed and carries "kept running, not waited on" as a muted suffix while it runs; a task the kernel
+  named neither awaited nor a service lists under its kind with no verdict word. The header counts every
+  row it lists: the awaited breakdown, then "N kept running" for the rows wearing the suffix. The `bg-awaited` outline is one toggle: a wait, or a tracked task named in
   `awaitingTaskIds` — the ids' presence, never the chip state; mid-turn the box wears its neutral border.
   `bgFoldOpen` is only ever written by the header toggle and the chip click, so the status-only frame that
   flips `awaitingWhy` (through `awaitKey`) finds the fold as it was.

--- a/tests/test_bg_kinds_browser.py
+++ b/tests/test_bg_kinds_browser.py
@@ -90,11 +90,18 @@ const f0 = cfg.frame; const task = (id) => f0.bgTasks.tasks.find((t) => t.id ===
 const only = (tasks, serviceIds, state) => ({ ...f0, status: { ...f0.status, state, awaitingItems: [], awaitingTaskIds: [], bgServiceIds: serviceIds }, bgTasks: { count: tasks.length, tasks } });
 const settle = async (f) => { await page.evaluate((x) => window.postMessage(x, "*"), f); await page.waitForTimeout(500); return probe(); };
 const placedOnly = await settle(only([task(cfg.placedId)], [], "working"));
-const placedKept = await settle(only([task(cfg.placedId)], [cfg.placedId], "working"));
+// the verdict arrives by a BARE STATUS frame (round three, low 4): a session frame repaints the box unconditionally for the active
+// tab, a status frame only through awaitKey, so this is the executed coverage of the key carrying bgServiceIds
+const placedKept = await settle({ type: "status", id: f0.id, status: { ...f0.status, state: "working", awaitingItems: [], awaitingTaskIds: [], bgServiceIds: [cfg.placedId] } });
 const doneOnly = await settle(only([task(cfg.doneId)], [], "idle"));
+// the one-kind idle wait with tracked rows beyond it (round three, low 3): waiting on one command, a kept service and a finished
+// command listed too; every listed row counted, the kept subset after
+const idleOne = await settle({ ...f0, status: { ...f0.status, state: "idle", awaitingWhy: "waiting on a background command: Build the docs site", awaitingKind: "commands", awaitingCount: 1,
+                                               awaitingItems: f0.status.awaitingItems.filter((it) => it.kind === "commands"), awaitingTaskIds: [cfg.cmdId], bgServiceIds: [cfg.svcId, cfg.doneId] },
+                                bgTasks: { count: 3, tasks: [task(cfg.cmdId), task(cfg.svcId), task(cfg.doneId)] } });
 if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-T394-bg-kinds-light-served.png" }); }
 await browser.close();
-process.stdout.write("RESULT:" + JSON.stringify({ dark, light, placedOnly, placedKept, doneOnly }) + "\n", () => process.exit(0));
+process.stdout.write("RESULT:" + JSON.stringify({ dark, light, placedOnly, placedKept, doneOnly, idleOne }) + "\n", () => process.exit(0));
 """
 
 
@@ -202,7 +209,7 @@ class ServedBgKinds(unittest.TestCase):
                          {"id": DONE_ID, "status": "completed", "summary": "Warm the docs cache", "command": "mkdocs build --dirty", "output": "done"}]}}
             cfg = os.path.join(self.lab, "cfg.json")
             with open(cfg, "w") as f:
-                json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "frame": frame, "placedId": PLACED_ID, "doneId": DONE_ID,
+                json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "frame": frame, "placedId": PLACED_ID, "doneId": DONE_ID, "cmdId": CMD_ID, "svcId": SVC_ID,
                            "shots": os.environ.get("BG_KINDS_SHOTS", "")}, f)
             driver = os.path.join(self.lab, "driver.mjs")
             with open(driver, "w") as f:
@@ -289,11 +296,21 @@ class ServedBgKinds(unittest.TestCase):
         self.assertEqual([(x["section"], x["label"], x["kept"]) for x in po["rows"]], [(None, "Run the parser test chunk", None)], "one row, no verdict word: %r" % po["rows"])
         self.assertEqual(po["header"], "In the background · 1 command", "the header counts the listed row: %r" % po["header"])
         pk = r["placedKept"]
-        self.assertEqual([x["kept"] for x in pk["rows"]], [KEPT_WORD], "the verdict-only frame repainted the box: the row wears the suffix: %r" % pk["rows"])
+        self.assertEqual([x["kept"] for x in pk["rows"]], [KEPT_WORD], "the verdict by a bare status frame repainted the box: the row wears the suffix (round three, low 4): %r" % pk["rows"])
         self.assertEqual(pk["header"], "In the background · 1 command · 1 kept running", "…and the header counts it as kept: %r" % pk["header"])
+        self.assertIn("bg-kept", pk["rows"][0]["cls"].split(), "…and the kept class: %r" % pk["rows"][0]["cls"])
         do = r["doneOnly"]
         self.assertEqual([(x["label"], x["caption"], x["kept"]) for x in do["rows"]], [("Warm the docs cache", "completed", None)], "the finished task, unmarked: %r" % do["rows"])
         self.assertEqual(do["header"], "In the background · 1 command", "counted, never a separator with nothing after it: %r" % do["header"])
+
+    def test_the_one_kind_idle_header_counts_every_listed_row_by_the_headers_rule(self):
+        # round three, lows 1 to 3. THE RULE: the leading word is the wait and its count is the awaited rows (the chip's number); the
+        # breakdown counts every row the list shows, by kind; N kept running is the subset wearing the verdict, never a partition
+        r = self._result()
+        io = r["idleOne"]
+        self.assertEqual([(x["label"], x["kept"]) for x in io["rows"]], [("Build the docs site", None), ("Serve the docs preview", KEPT_WORD), ("Warm the docs cache", None)], "the wait's row, the kept service, the finished command: %r" % io["rows"])
+        self.assertEqual(io["header"], "Awaiting command · a background command: Build the docs site · 3 commands · 1 kept running",
+                         "the wait's word and sentence, then every listed row by kind, then the kept subset: %r" % io["header"])
 
     def test_a_completed_only_box_wears_the_dim_ink_on_its_header_dot(self):
         # round two, low 2: the worst status seeds from the tasks, so a completed-only box reads completed, the dim ink, not the running gold

--- a/tests/test_bg_kinds_browser.py
+++ b/tests/test_bg_kinds_browser.py
@@ -6,7 +6,8 @@ section of its own whose title said nothing of why.
 
 The served lab drives the real /chat page over a hermetic kernel (the rescind lab's boot: a synthetic idle session) and sends the
 page one session frame by the shim's own door (window.postMessage, the T357 route): the session working, the kernel's rows (an
-agent, a command, a watch) and the tracked tasks (those two plus a service the rows do not name). It opens the box and reads every
+agent, a command, a watch) and the tracked tasks: those two, a service the judge called furniture (bgServiceIds names it), a
+placed command mid-turn the kernel named neither awaited nor a service, and a completed service. It opens the box and reads every
 row as the browser computes it, in the dark theme and then the cream one:
 
   1. the sections and the rows in them, the header's words, the suffix on the kept row, the Stop, Cancel, arrow and caret;
@@ -28,7 +29,7 @@ HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
 from test_queued_rescind_browser import BIN, EXT, SID, _free_port, _lab, copy_dist, iso   # noqa: E402  the shared boot's pieces (never its TestCase)
 
-AGENT_ID, CMD_ID, WATCH_ID, SVC_ID = "tu_agent_1", "tu_cmd_1", "watch-1", "tu_svc_1"
+AGENT_ID, CMD_ID, WATCH_ID, SVC_ID, PLACED_ID, DONE_ID = "tu_agent_1", "tu_cmd_1", "watch-1", "tu_svc_1", "tu_placed_1", "tu_svc_done"
 KEPT_WORD = "· kept running, not waited on"
 
 DRIVER = r"""
@@ -49,7 +50,7 @@ await page.waitForTimeout(500);
 await page.evaluate((f) => window.postMessage(f, "*"), cfg.frame);
 await page.waitForSelector("#bg-tasks .bg-fold-head", { timeout: 15000 });
 await page.click("#bg-tasks .bg-fold-head");   // collapsed by default: open the list
-await page.waitForFunction(() => document.querySelectorAll("#bg-tasks .bg-list .bg-task").length >= 4, null, { timeout: 15000 });
+await page.waitForFunction(() => document.querySelectorAll("#bg-tasks .bg-list .bg-task").length >= 6, null, { timeout: 15000 });
 await page.waitForTimeout(200);
 const probe = () => page.evaluate(() => {
   const tok = (v) => { const d = document.createElement("div"); d.style.background = v; document.body.appendChild(d); const c = getComputedStyle(d).backgroundColor; d.remove(); return c; };
@@ -174,15 +175,20 @@ class ServedBgKinds(unittest.TestCase):
         if cls._r is None:
             now = int(time.time())
             frame = {"type": "session", "id": SID, "name": "web", "color": {"bg": "#9cd2ff", "fg": "#0c1a2e"},
-                     "status": {"state": "working", "sinceEpoch": now - 300, "awaitingTaskIds": [],
+                     "status": {"state": "working", "sinceEpoch": now - 300, "awaitingTaskIds": [], "bgServiceIds": [SVC_ID, DONE_ID],
                                 "awaitingItems": [
                                     {"kind": "agents", "id": AGENT_ID, "agentId": "agent-1", "label": "Map the notes-api parser", "since": now - 240},
                                     {"kind": "commands", "id": CMD_ID, "label": "Build the docs site", "since": now - 540},
                                     {"kind": "watches", "id": WATCH_ID, "watchId": WATCH_ID, "label": "the CI run on web", "detail": "gh run watch 1", "since": now - 1860}]},
-                     "bgTasks": {"count": 3, "tasks": [
+                     "bgTasks": {"count": 5, "tasks": [
                          {"id": AGENT_ID, "status": "running", "summary": "Map the notes-api parser", "agentId": "agent-1", "command": "Map the parser module by module"},
                          {"id": CMD_ID, "status": "running", "summary": "Build the docs site", "command": "mkdocs build", "output": "building…"},
-                         {"id": SVC_ID, "status": "running", "summary": "Serve the docs preview", "command": "mkdocs serve", "output": "serving on 8000"}]}}
+                         {"id": SVC_ID, "status": "running", "summary": "Serve the docs preview", "command": "mkdocs serve", "output": "serving on 8000"},
+                         # a placed command mid-turn: the rows do not name it (they enumerate pending launches) and the judge did not call it
+                         # a service; it lists under its kind with no verdict word and no count (round one, medium 2)
+                         {"id": PLACED_ID, "status": "running", "summary": "Run the parser test chunk", "command": "uv run pytest -q tests/test_parser.py", "output": "…"},
+                         # a service that finished: terminal, so no suffix and no count (round one, low 1); its dot the dim ink
+                         {"id": DONE_ID, "status": "completed", "summary": "Warm the docs cache", "command": "mkdocs build --dirty", "output": "done"}]}}
             cfg = os.path.join(self.lab, "cfg.json")
             with open(cfg, "w") as f:
                 json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "frame": frame, "shots": os.environ.get("BG_KINDS_SHOTS", "")}, f)
@@ -205,22 +211,27 @@ class ServedBgKinds(unittest.TestCase):
         d = r["dark"]
         self.assertEqual(d["sections"], ["Agents", "Commands", "Watches"], "the kinds, in display order, and no section of any other name: %r" % d["sections"])
         self.assertEqual([(x["section"], x["label"]) for x in d["rows"]],
-                         [("Agents", "Map the notes-api parser"), ("Commands", "Build the docs site"), ("Commands", "Serve the docs preview"), ("Watches", "the CI run on web")],
-                         "each row under its kind; the service after the awaited command: %r" % d["rows"])
-        agent, cmd, svc, watch = d["rows"]
-        self.assertEqual(d["header"], "In the background · 1 agent · 1 command · 1 watch · 1 kept running", "the header counts every row it lists, the kept one apart")
-        for x, kind in ((agent, "agents"), (cmd, "commands"), (svc, "commands"), (watch, "watches")):
+                         [("Agents", "Map the notes-api parser"), ("Commands", "Build the docs site"), ("Commands", "Serve the docs preview"),
+                          ("Commands", "Run the parser test chunk"), ("Commands", "Warm the docs cache"), ("Watches", "the CI run on web")],
+                         "each row under its kind; the tracked tasks after the awaited command: %r" % d["rows"])
+        agent, cmd, svc, placed, done, watch = d["rows"]
+        self.assertEqual(d["header"], "In the background · 1 agent · 1 command · 1 watch · 1 kept running",
+                         "the header counts every row it lists and only the row wearing the verdict as kept (round one, medium 1 and low 1)")
+        for x, kind in ((agent, "agents"), (cmd, "commands"), (svc, "commands"), (placed, "commands"), (done, "commands"), (watch, "watches")):
             self.assertIn("bg-kind-" + kind, x["cls"].split(), "%s wears its kind: %r" % (x["label"], x["cls"]))
-        self.assertIn("bg-kept", svc["cls"].split(), "the service is the kept row: %r" % svc["cls"])
+        self.assertIn("bg-kept", svc["cls"].split(), "the running service is the kept row: %r" % svc["cls"])
         self.assertEqual(svc["kept"], KEPT_WORD, "the judge's verdict beside the label")
-        for x in (agent, cmd, watch):
-            self.assertNotIn("bg-kept", x["cls"].split(), "%s is awaited, not kept: %r" % (x["label"], x["cls"]))
-            self.assertIsNone(x["kept"], "no suffix on an awaited row: %r" % x)
-        self.assertEqual([x["caption"] for x in d["rows"]], ["running", "running", "running", "armed"])
+        for x in (agent, cmd, watch, placed, done):
+            self.assertNotIn("bg-kept", x["cls"].split(), "%s wears no verdict: %r" % (x["label"], x["cls"]))
+            self.assertIsNone(x["kept"], "no suffix: %r" % x)
+        self.assertEqual([x["caption"] for x in d["rows"]], ["running", "running", "running", "running", "completed", "armed"])
+        self.assertIn("bg-completed", done["cls"].split(), "the finished service keeps its own status: %r" % done["cls"])
         # the affordances stay: the agent's arrow and Stop, the command's Stop and fold caret, the service's Stop, the watch's Cancel
         self.assertTrue(agent["arrow"] and agent["stop"], "agent: arrow and Stop: %r" % agent)
         self.assertTrue(cmd["stop"] and cmd["caret"], "command: Stop and the fold caret: %r" % cmd)
         self.assertTrue(svc["stop"] and svc["caret"], "service: Stop and the fold caret: %r" % svc)
+        self.assertTrue(placed["stop"] and not placed["kept"], "the placed command: Stop, no verdict word: %r" % placed)
+        self.assertFalse(done["stop"], "a finished task has no Stop: %r" % done)
         self.assertTrue(watch["cancel"] and not watch["stop"], "watch: Cancel, no Stop: %r" % watch)
         self.assertEqual(r["light"]["sections"], d["sections"], "the cream theme changes no words")
         self.assertEqual(r["light"]["header"], d["header"])
@@ -230,16 +241,19 @@ class ServedBgKinds(unittest.TestCase):
         for name in ("dark", "light"):
             m = r[name]
             t = m["tokens"]
-            agent, cmd, svc, watch = m["rows"]
+            agent, cmd, svc, placed, done, watch = m["rows"]
             ground = composite(t["box"], t["page"])
             self.assertEqual(agent["dot"], t["working"], "%s: the agent's dot is the working gold: %r" % (name, agent))
             self.assertEqual(cmd["dot"], t["command"], "%s: the command's dot is the command blue: %r" % (name, cmd))
-            self.assertEqual(svc["dot"], t["command"], "%s: the service is a command too: %r" % (name, svc))
+            self.assertEqual(placed["dot"], t["command"], "%s: the placed command's dot is the command blue, undimmed: %r" % (name, placed))
+            self.assertEqual(done["dot"], t["dim"], "%s: a completed row's dot is the dim ink, never the ready blue: %r" % (name, done))
             self.assertEqual(watch["dot"], t["await"], "%s: the watch's dot is the awaiting green: %r" % (name, watch))
             self.assertNotEqual(t["command"], t["working"], "%s: the command hue is not the agents': %r" % (name, t))
-            self.assertEqual(float(svc["dotOpacity"]), 0.55, "%s: the kept row's dot is dimmed: %r" % (name, svc))
-            for x in (agent, cmd, watch):
-                self.assertEqual(float(x["dotOpacity"]), 1.0, "%s: an awaited row's dot is full: %r" % (name, x))
+            # the kept dot is a COLOUR, the hue greyed toward the dim ink (round one, low 2): dimmer than the hue, still 3:1 on the box
+            self.assertNotEqual(svc["dot"], t["command"], "%s: the kept row's dot is not the full hue: %r" % (name, svc))
+            self.assertGreaterEqual(contrast(svc["dot"], ground), 3.0, "%s: the kept dot reads on the box: %r" % (name, svc))
+            for x in m["rows"]:
+                self.assertEqual(float(x["dotOpacity"]), 1.0, "%s: no dot dims by element opacity: %r" % (name, x))
             self.assertEqual(svc["labelColor"], t["dim"], "%s: the kept row's label is the dim ink: %r" % (name, svc))
             self.assertEqual(svc["keptColor"], t["dim"], "%s: …and so is the verdict: %r" % (name, svc))
             self.assertGreaterEqual(contrast(t["dim"], ground), 4.5, "%s: the dim ink reads on the box: %r" % (name, t))

--- a/tests/test_bg_kinds_browser.py
+++ b/tests/test_bg_kinds_browser.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""T394 (the user 2026-09-12, from a screenshot of the chat's background fold): every row of the box sits in its KIND's section
+(Agents, Commands, Watches) with one hue per kind for its dot and caption word, and a tracked task nobody waits on (the judge
+audited its launch without a wait) lists in its kind's section, dimmed, with the verdict as a muted suffix, instead of under a
+section of its own whose title said nothing of why.
+
+The served lab drives the real /chat page over a hermetic kernel (the rescind lab's boot: a synthetic idle session) and sends the
+page one session frame by the shim's own door (window.postMessage, the T357 route): the session working, the kernel's rows (an
+agent, a command, a watch) and the tracked tasks (those two plus a service the rows do not name). It opens the box and reads every
+row as the browser computes it, in the dark theme and then the cream one:
+
+  1. the sections and the rows in them, the header's words, the suffix on the kept row, the Stop, Cancel, arrow and caret;
+  2. the dot and caption colours against the theme's tokens, and each caption's contrast on the box it sits on.
+
+Skips LOUDLY without the extension deps or a Playwright browser (CI installs none). All fixtures synthetic.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_queued_rescind_browser import BIN, EXT, SID, _free_port, _lab, copy_dist, iso   # noqa: E402  the shared boot's pieces (never its TestCase)
+
+AGENT_ID, CMD_ID, WATCH_ID, SVC_ID = "tu_agent_1", "tu_cmd_1", "watch-1", "tu_svc_1"
+KEPT_WORD = "· kept running, not waited on"
+
+DRIVER = r"""
+import { createRequire } from "node:module";
+import fs from "node:fs";
+const require = createRequire(process.env.EXT_PKG);
+const { chromium } = require("playwright");
+const cfg = JSON.parse(fs.readFileSync(process.env.CFG, "utf8"));
+let browser;
+try { browser = await chromium.launch(); }
+catch (e) { console.error("browser-launch-failed: " + e); process.exit(3); }
+const page = await browser.newPage({ viewport: { width: 1000, height: 800 } });
+await page.goto(cfg.chat);
+await page.waitForSelector("#tabs .tab, #tabs [data-sid]", { timeout: 20000 });
+await page.waitForSelector("#composer-input", { timeout: 20000 });
+await page.waitForTimeout(500);
+// the frame: the session working, the kernel's rows and the tracked tasks; the shim hands it to the page like a kernel push
+await page.evaluate((f) => window.postMessage(f, "*"), cfg.frame);
+await page.waitForSelector("#bg-tasks .bg-fold-head", { timeout: 15000 });
+await page.click("#bg-tasks .bg-fold-head");   // collapsed by default: open the list
+await page.waitForFunction(() => document.querySelectorAll("#bg-tasks .bg-list .bg-task").length >= 4, null, { timeout: 15000 });
+await page.waitForTimeout(200);
+const probe = () => page.evaluate(() => {
+  const tok = (v) => { const d = document.createElement("div"); d.style.background = v; document.body.appendChild(d); const c = getComputedStyle(d).backgroundColor; d.remove(); return c; };
+  // an oklch() relative colour comes back as oklch(...) from getComputedStyle; a 1x1 canvas resolves it to rgb
+  const asRGB = (css) => { if (!/^(oklch|oklab|color)\(/.test(css) || /\//.test(css)) return css;
+    const cv = document.createElement("canvas"); cv.width = cv.height = 1; const ctx = cv.getContext("2d");
+    ctx.fillStyle = css; ctx.fillRect(0, 0, 1, 1); const d = ctx.getImageData(0, 0, 1, 1).data;
+    return "rgb(" + d[0] + ", " + d[1] + ", " + d[2] + ")"; };
+  const tokens = { working: tok("var(--st-working-bg)"), await: tok("var(--st-awaitbg-bg)"), command: tok("var(--kind-command)"), dim: tok("var(--dim)"),
+                   page: tok("var(--bg)"), box: tok("var(--box-bg)") };
+  const rows = []; let section = null;
+  for (const el of document.querySelectorAll("#bg-tasks .bg-list > *")) {
+    if (el.classList.contains("bg-group-head")) { section = (el.textContent || "").trim(); continue; }
+    if (!el.classList.contains("bg-task")) continue;
+    const dot = el.querySelector(".bg-dot"), sum = el.querySelector(".bg-sum"), cap = el.querySelector(".bg-status"), kw = el.querySelector(".bg-kept-word");
+    rows.push({ section, label: (sum.textContent || "").trim(), cls: el.className,
+                dot: getComputedStyle(dot).backgroundColor, dotOpacity: getComputedStyle(dot).opacity,
+                caption: cap ? (cap.textContent || "").trim() : null, captionColor: cap ? asRGB(getComputedStyle(cap).color) : null,
+                kept: kw ? (kw.textContent || "").trim() : null, keptColor: kw ? getComputedStyle(kw).color : null, labelColor: getComputedStyle(sum).color,
+                stop: !!el.querySelector(".bg-stop:not(.bg-cancel)"), cancel: !!el.querySelector(".bg-cancel"),
+                arrow: !!el.querySelector(".bg-open-agent"), caret: !!el.querySelector(".bg-head .bg-caret") });
+  }
+  const head = document.querySelector("#bg-tasks .bg-fold-label");
+  return { header: head ? (head.textContent || "").trim() : null, sections: Array.from(document.querySelectorAll("#bg-tasks .bg-group-head")).map((e) => (e.textContent || "").trim()),
+           rows, tokens, theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+});
+const dark = await probe();
+await page.evaluate(() => document.body.classList.add("theme-light"));
+await page.waitForTimeout(250);
+const light = await probe();
+if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-T394-bg-kinds-light-served.png" }); }
+await browser.close();
+process.stdout.write("RESULT:" + JSON.stringify({ dark, light }) + "\n", () => process.exit(0));
+"""
+
+
+def _nums(css):
+    m = re.search(r"color\(srgb ([\d.]+) ([\d.]+) ([\d.]+)(?: / ([\d.]+))?\)", css or "")
+    if m:
+        return [255 * float(m.group(1)), 255 * float(m.group(2)), 255 * float(m.group(3)), 1.0 if m.group(4) is None else float(m.group(4))]
+    n = [float(x) for x in re.findall(r"\d+(?:\.\d+)?", css or "")]
+    return [n[0], n[1], n[2], n[3] if len(n) > 3 else 1.0]
+
+
+def composite(wash, page):
+    w, p = _nums(wash), _nums(page)
+    a = w[3]
+    return "rgb(%d, %d, %d)" % tuple(round(w[i] * a + p[i] * (1 - a)) for i in range(3))
+
+
+def contrast(a, b):
+    def lum(css):
+        ch = [v / 255 for v in _nums(css)[:3]]
+        ch = [c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4 for c in ch]
+        return 0.2126 * ch[0] + 0.7152 * ch[1] + 0.0722 * ch[2]
+    la, lb = lum(a), lum(b)
+    return (max(la, lb) + 0.05) / (min(la, lb) + 0.05)
+
+
+class ServedBgKinds(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isdir(os.path.join(EXT, "node_modules", "playwright")):
+            raise unittest.SkipTest("extension deps absent (npm ci not run here) — the served guard needs them")
+        cls.lab = tempfile.mkdtemp(prefix="bg-kinds-")
+        b = subprocess.run(["node", "esbuild.js"], cwd=EXT, capture_output=True, text=True)
+        if b.returncode != 0:
+            raise unittest.SkipTest("esbuild failed here: " + (b.stderr or b.stdout)[-200:])
+        dist = os.path.join(cls.lab, "dist")
+        copy_dist(os.path.join(EXT, "dist"), dist)
+        state = os.path.join(cls.lab, "xdg", "romp")
+        cwd = os.path.join(cls.lab, "proj")
+        for d in ("names", "sdk", "states"):
+            os.makedirs(os.path.join(state, d), exist_ok=True)
+        Path(state, "session-hosts").write_text("off")     # a state root of our own: no real host for the session (the Testing rule)
+        os.makedirs(cwd, exist_ok=True)
+        Path(state, "names", SID).write_text("web\t%s\t\t\n" % cwd)
+        Path(state, "sdk", SID + ".json").write_text(json.dumps(
+            {"sid": SID, "name": "web", "cwd": cwd, "mode": "auto", "effort": "high",
+             "lastSid": SID, "alive": True, "model": "claude-fable-5-1", "liveModel": "Fable 5.1"}))
+        Path(state, "usage.json").write_text(json.dumps({"five_hour": {"pct": 10}, "seven_day": {"pct": 10}}))
+        claude = os.path.join(cls.lab, "claude")
+        proj = os.path.join(claude, "projects", re.sub(r"[^A-Za-z0-9]", "-", os.path.realpath(cwd)))   # jd._proj_dir's munge
+        os.makedirs(proj, exist_ok=True)
+        t0 = int(time.time()) - 900
+        recs = [   # an idle session: one exchange, the turn closed
+            {"type": "user", "timestamp": iso(t0), "uuid": "u1", "parentUuid": None, "promptSource": "sdk", "sessionId": SID,
+             "message": {"role": "user", "content": "map the notes-api parser"}},
+            {"type": "assistant", "timestamp": iso(t0 + 10), "uuid": "a1", "parentUuid": "u1", "sessionId": SID,
+             "message": {"role": "assistant", "model": "claude-fable-5-1", "stop_reason": "end_turn",
+                         "content": [{"type": "text", "text": "Starting on the parser map."}]}},
+        ]
+        Path(proj, SID + ".jsonl").write_text("".join(json.dumps(r) + "\n" for r in recs))
+        cls.port = _free_port()
+        cls.token = "testtok-bgkinds"
+        env = _lab.kernel_env(cls.lab, claude, dist, cls.port, cls.token)
+        cls.klog = os.path.join(cls.lab, "kernel.log")
+        cls.kernel = subprocess.Popen([os.path.join(BIN, "romp-kernel")], stdout=open(cls.klog, "w"), stderr=subprocess.STDOUT, env=env)
+        import urllib.request
+        for _ in range(120):
+            try:
+                urllib.request.urlopen("http://127.0.0.1:%d/healthz" % cls.port, timeout=1)
+                break
+            except Exception:
+                time.sleep(0.5)
+        else:
+            cls.kernel.kill()
+            raise unittest.SkipTest("hermetic kernel never served /healthz here")
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "kernel", None):
+            cls.kernel.kill()
+            cls.kernel.wait()
+
+    _r = None
+
+    def _result(self):
+        cls = type(self)
+        if cls._r is None:
+            now = int(time.time())
+            frame = {"type": "session", "id": SID, "name": "web", "color": {"bg": "#9cd2ff", "fg": "#0c1a2e"},
+                     "status": {"state": "working", "sinceEpoch": now - 300, "awaitingTaskIds": [],
+                                "awaitingItems": [
+                                    {"kind": "agents", "id": AGENT_ID, "agentId": "agent-1", "label": "Map the notes-api parser", "since": now - 240},
+                                    {"kind": "commands", "id": CMD_ID, "label": "Build the docs site", "since": now - 540},
+                                    {"kind": "watches", "id": WATCH_ID, "watchId": WATCH_ID, "label": "the CI run on web", "detail": "gh run watch 1", "since": now - 1860}]},
+                     "bgTasks": {"count": 3, "tasks": [
+                         {"id": AGENT_ID, "status": "running", "summary": "Map the notes-api parser", "agentId": "agent-1", "command": "Map the parser module by module"},
+                         {"id": CMD_ID, "status": "running", "summary": "Build the docs site", "command": "mkdocs build", "output": "building…"},
+                         {"id": SVC_ID, "status": "running", "summary": "Serve the docs preview", "command": "mkdocs serve", "output": "serving on 8000"}]}}
+            cfg = os.path.join(self.lab, "cfg.json")
+            with open(cfg, "w") as f:
+                json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "frame": frame, "shots": os.environ.get("BG_KINDS_SHOTS", "")}, f)
+            driver = os.path.join(self.lab, "driver.mjs")
+            with open(driver, "w") as f:
+                f.write(DRIVER)
+            p = subprocess.run(["node", driver], capture_output=True, text=True, timeout=300,
+                               env=dict(os.environ, EXT_PKG=os.path.join(EXT, "package.json"), CFG=cfg))
+            if p.returncode == 3:
+                raise unittest.SkipTest("no playwright browser on this box — the served guard needs one (CI installs none)")
+            self.assertEqual(p.returncode, 0, "driver failed:\n" + p.stdout[-3000:] + p.stderr[-3000:] + "\nkernel:\n" + open(self.klog).read()[-1500:])
+            line = next((ln for ln in p.stdout.splitlines() if ln.startswith("RESULT:")), None)
+            self.assertIsNotNone(line, "driver printed no result:\n" + p.stdout[-3000:])
+            cls._r = json.loads(line[len("RESULT:"):])
+        print("RESULT:" + json.dumps(cls._r), file=sys.stderr)   # the whole measurement rides every test's captured stderr (-rA shows it for a pass)
+        return cls._r
+
+    def test_every_row_sits_in_its_kinds_section_and_the_kept_task_wears_the_verdict_as_a_suffix(self):
+        r = self._result()
+        d = r["dark"]
+        self.assertEqual(d["sections"], ["Agents", "Commands", "Watches"], "the kinds, in display order, and no section of any other name: %r" % d["sections"])
+        self.assertEqual([(x["section"], x["label"]) for x in d["rows"]],
+                         [("Agents", "Map the notes-api parser"), ("Commands", "Build the docs site"), ("Commands", "Serve the docs preview"), ("Watches", "the CI run on web")],
+                         "each row under its kind; the service after the awaited command: %r" % d["rows"])
+        agent, cmd, svc, watch = d["rows"]
+        self.assertEqual(d["header"], "In the background · 1 agent · 1 command · 1 watch · 1 kept running", "the header counts every row it lists, the kept one apart")
+        for x, kind in ((agent, "agents"), (cmd, "commands"), (svc, "commands"), (watch, "watches")):
+            self.assertIn("bg-kind-" + kind, x["cls"].split(), "%s wears its kind: %r" % (x["label"], x["cls"]))
+        self.assertIn("bg-kept", svc["cls"].split(), "the service is the kept row: %r" % svc["cls"])
+        self.assertEqual(svc["kept"], KEPT_WORD, "the judge's verdict beside the label")
+        for x in (agent, cmd, watch):
+            self.assertNotIn("bg-kept", x["cls"].split(), "%s is awaited, not kept: %r" % (x["label"], x["cls"]))
+            self.assertIsNone(x["kept"], "no suffix on an awaited row: %r" % x)
+        self.assertEqual([x["caption"] for x in d["rows"]], ["running", "running", "running", "armed"])
+        # the affordances stay: the agent's arrow and Stop, the command's Stop and fold caret, the service's Stop, the watch's Cancel
+        self.assertTrue(agent["arrow"] and agent["stop"], "agent: arrow and Stop: %r" % agent)
+        self.assertTrue(cmd["stop"] and cmd["caret"], "command: Stop and the fold caret: %r" % cmd)
+        self.assertTrue(svc["stop"] and svc["caret"], "service: Stop and the fold caret: %r" % svc)
+        self.assertTrue(watch["cancel"] and not watch["stop"], "watch: Cancel, no Stop: %r" % watch)
+        self.assertEqual(r["light"]["sections"], d["sections"], "the cream theme changes no words")
+        self.assertEqual(r["light"]["header"], d["header"])
+
+    def test_one_hue_per_kind_for_the_dot_and_the_caption_in_both_themes_and_every_caption_reads_on_the_box(self):
+        r = self._result()
+        for name in ("dark", "light"):
+            m = r[name]
+            t = m["tokens"]
+            agent, cmd, svc, watch = m["rows"]
+            ground = composite(t["box"], t["page"])
+            self.assertEqual(agent["dot"], t["working"], "%s: the agent's dot is the working gold: %r" % (name, agent))
+            self.assertEqual(cmd["dot"], t["command"], "%s: the command's dot is the command blue: %r" % (name, cmd))
+            self.assertEqual(svc["dot"], t["command"], "%s: the service is a command too: %r" % (name, svc))
+            self.assertEqual(watch["dot"], t["await"], "%s: the watch's dot is the awaiting green: %r" % (name, watch))
+            self.assertNotEqual(t["command"], t["working"], "%s: the command hue is not the agents': %r" % (name, t))
+            self.assertEqual(float(svc["dotOpacity"]), 0.55, "%s: the kept row's dot is dimmed: %r" % (name, svc))
+            for x in (agent, cmd, watch):
+                self.assertEqual(float(x["dotOpacity"]), 1.0, "%s: an awaited row's dot is full: %r" % (name, x))
+            self.assertEqual(svc["labelColor"], t["dim"], "%s: the kept row's label is the dim ink: %r" % (name, svc))
+            self.assertEqual(svc["keptColor"], t["dim"], "%s: …and so is the verdict: %r" % (name, svc))
+            self.assertGreaterEqual(contrast(t["dim"], ground), 4.5, "%s: the dim ink reads on the box: %r" % (name, t))
+            for x in m["rows"]:
+                self.assertGreaterEqual(contrast(x["captionColor"], ground), 4.5, "%s: the caption word reads on the box: %r" % (name, x))
+            if name == "dark":
+                for x, tokname in ((agent, "working"), (cmd, "command"), (svc, "command"), (watch, "await")):
+                    self.assertEqual(x["captionColor"], t[tokname], "dark: the caption word is the kind hue itself: %r" % x)
+            else:
+                for x, tokname in ((agent, "working"), (cmd, "command"), (watch, "await")):
+                    self.assertNotEqual(x["captionColor"], t[tokname], "cream: the caption word is the hue deepened, not the dot's colour: %r" % x)
+        self.assertNotEqual(r["dark"]["tokens"]["command"], r["light"]["tokens"]["command"], "the command blue is a per-theme token")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bg_kinds_browser.py
+++ b/tests/test_bg_kinds_browser.py
@@ -75,15 +75,26 @@ const probe = () => page.evaluate(() => {
   }
   const head = document.querySelector("#bg-tasks .bg-fold-label");
   return { header: head ? (head.textContent || "").trim() : null, sections: Array.from(document.querySelectorAll("#bg-tasks .bg-group-head")).map((e) => (e.textContent || "").trim()),
-           rows, tokens, theme: document.body.classList.contains("theme-light") ? "light" : "dark" };
+           rows, tokens, theme: document.body.classList.contains("theme-light") ? "light" : "dark",
+           headDot: (() => { const d = document.querySelector("#bg-tasks .bg-fold-head .bg-dot"); return d ? getComputedStyle(d).backgroundColor : null; })() };
 });
 const dark = await probe();
 await page.evaluate(() => document.body.classList.add("theme-light"));
 await page.waitForTimeout(250);
 const light = await probe();
+await page.evaluate(() => document.body.classList.remove("theme-light"));
+// round two: the states where the kernel names no rows. (i) a working session with a placed command the judge neither stamped nor
+// called a service: one row, no verdict, and the header must still count it; (ii) a verdict-only frame: the same, the placed command
+// now a service; (iii) a session whose one tracked task is finished: the header counts it and its dot is the completed tint
+const f0 = cfg.frame; const task = (id) => f0.bgTasks.tasks.find((t) => t.id === id);
+const only = (tasks, serviceIds, state) => ({ ...f0, status: { ...f0.status, state, awaitingItems: [], awaitingTaskIds: [], bgServiceIds: serviceIds }, bgTasks: { count: tasks.length, tasks } });
+const settle = async (f) => { await page.evaluate((x) => window.postMessage(x, "*"), f); await page.waitForTimeout(500); return probe(); };
+const placedOnly = await settle(only([task(cfg.placedId)], [], "working"));
+const placedKept = await settle(only([task(cfg.placedId)], [cfg.placedId], "working"));
+const doneOnly = await settle(only([task(cfg.doneId)], [], "idle"));
 if (cfg.shots) { fs.mkdirSync(cfg.shots, { recursive: true }); await page.screenshot({ path: cfg.shots + "/romp_chat-T394-bg-kinds-light-served.png" }); }
 await browser.close();
-process.stdout.write("RESULT:" + JSON.stringify({ dark, light }) + "\n", () => process.exit(0));
+process.stdout.write("RESULT:" + JSON.stringify({ dark, light, placedOnly, placedKept, doneOnly }) + "\n", () => process.exit(0));
 """
 
 
@@ -191,7 +202,8 @@ class ServedBgKinds(unittest.TestCase):
                          {"id": DONE_ID, "status": "completed", "summary": "Warm the docs cache", "command": "mkdocs build --dirty", "output": "done"}]}}
             cfg = os.path.join(self.lab, "cfg.json")
             with open(cfg, "w") as f:
-                json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "frame": frame, "shots": os.environ.get("BG_KINDS_SHOTS", "")}, f)
+                json.dump({"chat": "http://127.0.0.1:%d/chat?token=%s" % (self.port, self.token), "frame": frame, "placedId": PLACED_ID, "doneId": DONE_ID,
+                           "shots": os.environ.get("BG_KINDS_SHOTS", "")}, f)
             driver = os.path.join(self.lab, "driver.mjs")
             with open(driver, "w") as f:
                 f.write(DRIVER)
@@ -215,8 +227,10 @@ class ServedBgKinds(unittest.TestCase):
                           ("Commands", "Run the parser test chunk"), ("Commands", "Warm the docs cache"), ("Watches", "the CI run on web")],
                          "each row under its kind; the tracked tasks after the awaited command: %r" % d["rows"])
         agent, cmd, svc, placed, done, watch = d["rows"]
-        self.assertEqual(d["header"], "In the background · 1 agent · 1 command · 1 watch · 1 kept running",
-                         "the header counts every row it lists and only the row wearing the verdict as kept (round one, medium 1 and low 1)")
+        # every listed row counted by kind (round two): the awaited command, the kept service, the placed command and the finished
+        # service are four commands; only the running service wears the verdict (round one, medium 1 and low 1)
+        self.assertEqual(d["header"], "In the background · 1 agent · 4 commands · 1 watch · 1 kept running",
+                         "the header counts every row it lists, the kept one apart: %r" % d["header"])
         for x, kind in ((agent, "agents"), (cmd, "commands"), (svc, "commands"), (placed, "commands"), (done, "commands"), (watch, "watches")):
             self.assertIn("bg-kind-" + kind, x["cls"].split(), "%s wears its kind: %r" % (x["label"], x["cls"]))
         self.assertIn("bg-kept", svc["cls"].split(), "the running service is the kept row: %r" % svc["cls"])
@@ -266,6 +280,27 @@ class ServedBgKinds(unittest.TestCase):
                 for x, tokname in ((agent, "working"), (cmd, "command"), (watch, "await")):
                     self.assertNotEqual(x["captionColor"], t[tokname], "cream: the caption word is the hue deepened, not the dot's colour: %r" % x)
         self.assertNotEqual(r["dark"]["tokens"]["command"], r["light"]["tokens"]["command"], "the command blue is a per-theme token")
+
+    def test_the_header_counts_a_tracked_task_the_kernel_names_no_row_for_and_never_ends_at_its_separator(self):
+        # round two, medium: a placed command mid-turn (no kernel row, no verdict) and a finished command on a dormant session both
+        # read "In the background · 1 command"; the verdict alone repaints the box and adds the kept count (round two, low 1)
+        r = self._result()
+        po = r["placedOnly"]
+        self.assertEqual([(x["section"], x["label"], x["kept"]) for x in po["rows"]], [(None, "Run the parser test chunk", None)], "one row, no verdict word: %r" % po["rows"])
+        self.assertEqual(po["header"], "In the background · 1 command", "the header counts the listed row: %r" % po["header"])
+        pk = r["placedKept"]
+        self.assertEqual([x["kept"] for x in pk["rows"]], [KEPT_WORD], "the verdict-only frame repainted the box: the row wears the suffix: %r" % pk["rows"])
+        self.assertEqual(pk["header"], "In the background · 1 command · 1 kept running", "…and the header counts it as kept: %r" % pk["header"])
+        do = r["doneOnly"]
+        self.assertEqual([(x["label"], x["caption"], x["kept"]) for x in do["rows"]], [("Warm the docs cache", "completed", None)], "the finished task, unmarked: %r" % do["rows"])
+        self.assertEqual(do["header"], "In the background · 1 command", "counted, never a separator with nothing after it: %r" % do["header"])
+
+    def test_a_completed_only_box_wears_the_dim_ink_on_its_header_dot(self):
+        # round two, low 2: the worst status seeds from the tasks, so a completed-only box reads completed, the dim ink, not the running gold
+        r = self._result()
+        do = r["doneOnly"]
+        self.assertEqual(do["headDot"], do["tokens"]["dim"], "the header dot is the completed tint, the dim ink: %r vs %r" % (do["headDot"], do["tokens"]))
+        self.assertEqual(r["placedOnly"]["headDot"], r["placedOnly"]["tokens"]["working"], "a running-only box keeps the running gold on its header: %r" % r["placedOnly"]["headDot"])
 
 
 if __name__ == "__main__":

--- a/tests/test_bg_service_ids.py
+++ b/tests/test_bg_service_ids.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""T394 round one (2026-09-12): the chat's background box words the judge's verdict on a tracked task (kept running, not
+waited on) only where the judge gave it. The kernel ships that verdict as launch ids, bgServiceIds, from _bg_split's
+services (the closer audited past the launch without a wait), in every turn state, beside awaitingTaskIds (a wait's rows).
+Synthetic fixtures only."""
+import inspect
+import os
+import tempfile
+import unittest
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+
+# Hermetic state BEFORE the loads — they resolve their state root at import time.
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "testtok")
+km = load_source("romp_kernel_bgsvc", os.path.join(BIN, "romp-kernel"))
+
+SID = "aaaaaaaa-1111-2222-3333-444444444444"
+TASKS = [{"tid": "tu_cmd_1", "type": "shell", "desc": "Build the docs site"},
+         {"tid": "tu_svc_1", "type": "shell", "desc": "Serve the docs preview"},
+         {"tid": "tu_agent_1", "type": "agent", "desc": "Map the parser"},
+         {"tid": "", "type": "shell", "desc": "a launch not yet placed"}]
+
+
+class BgServiceIds(unittest.TestCase):
+    def setUp(self):
+        self._split, self._norm = km._bg_split, km._bg_live_norm
+        km._bg_live_norm = lambda sid, path: list(TASKS)
+        # the judge's split: the awaited launches and the services, as _bg_split answers it
+        km._bg_split = lambda sid, path, tasks: ([t for t in tasks if t["tid"] in ("tu_cmd_1", "tu_agent_1", "")],
+                                                 [t for t in tasks if t["tid"] == "tu_svc_1"])
+
+    def tearDown(self):
+        km._bg_split, km._bg_live_norm = self._split, self._norm
+
+    def test_the_services_launch_ids_are_the_judges_furniture_verdict_and_nothing_else(self):
+        self.assertEqual(km._bg_service_ids(SID, "/synthetic/path.jsonl"), ["tu_svc_1"])
+        self.assertEqual(km._awaiting_task_ids(SID, "/synthetic/path.jsonl"), ["tu_cmd_1", "tu_agent_1"], "the awaited half, unchanged; an unplaced launch has no id")
+
+    def test_the_status_ships_the_ids_in_every_turn_state(self):
+        src = inspect.getsource(km.build_session)
+        self.assertIn('"bgServiceIds": _bg_service_ids(sid, sess["path"]),', src, "shipped unconditionally, beside the awaited ids")
+        self.assertIn('"awaitingTaskIds": (_awaiting_task_ids(sid, sess["path"]) if awaiting_why else []),', src, "the awaited ids still ride a wait only")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bg_service_ids.py
+++ b/tests/test_bg_service_ids.py
@@ -15,6 +15,9 @@ BIN = os.path.join(os.path.dirname(HERE), "bin")
 # Hermetic state BEFORE the loads — they resolve their state root at import time.
 os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
 os.environ.pop("ROMP_STATE_DIR", None)
+os.makedirs(os.path.join(os.environ["XDG_STATE_HOME"], "romp"), exist_ok=True)
+with open(os.path.join(os.environ["XDG_STATE_HOME"], "romp", "session-hosts"), "w") as _f:
+    _f.write("off")   # a state root of our own: no real host for any session (the Testing rule)
 load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
 load_source("romp_judge", os.path.join(BIN, "romp-judge"))
 os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
@@ -45,7 +48,7 @@ class BgServiceIds(unittest.TestCase):
 
     def test_the_status_ships_the_ids_in_every_turn_state(self):
         src = inspect.getsource(km.build_session)
-        self.assertIn('"bgServiceIds": _bg_service_ids(sid, sess["path"]),', src, "shipped unconditionally, beside the awaited ids")
+        self.assertIn('"bgServiceIds": _bg_service_ids(sid, sess["path"], live_map),', src, "shipped unconditionally, beside the awaited ids, over the build's own liveness snapshot")
         self.assertIn('"awaitingTaskIds": (_awaiting_task_ids(sid, sess["path"]) if awaiting_why else []),', src, "the awaited ids still ride a wait only")
 
 

--- a/tests/test_chat_build_sig_inputs.py
+++ b/tests/test_chat_build_sig_inputs.py
@@ -66,6 +66,7 @@ CENSUS = {
     "_auth_both": ("sig", "acct", "the credential store's login and the settings' key presence"),
     "_awaiting_task_descs": ("sig", "bg", "the live task rows; the split reads the stamped tops (stamp), the store and the transcript"),
     "_awaiting_task_ids": ("sig", "bg", "as _awaiting_task_descs"),
+    "_bg_service_ids": ("sig", "bg", "as _awaiting_task_descs"),
     "_awaiting_items_payload": ("sig", "bg", "the wait's own rows (as _session_awaiting), else the rows in flight mid-turn: the row's agents (row), the live task rows and the watches (watch)"),
     "_bg_tasks": ("sig", "row", "the row's live task set gates the transcript's scan; each output tail is a taskout dep; the spawn epoch reads reg and gone"),
     "_chat_agent_open_at": ("pure", "over the events"),

--- a/tools/ui-verify/fixtures/awaiting-rows-chat.html
+++ b/tools/ui-verify/fixtures/awaiting-rows-chat.html
@@ -15,6 +15,7 @@
          running-yellow dot, the box wears its neutral border, there is NO note, and the statusline reads
          Working. Before 2026-09-06 this state showed a legacy "4 background tasks" list instead (or nothing),
          so the box swapped views at every turn boundary.
+     T394 (2026-09-12): every row wears its kind (bg-kind-agents / -commands / -watches), the hue of its dot and caption word.
      Invented content (notes-api demo domain), the DOM class for class as renderBgTasks / bgRow /
      updateStatusline emit it. The two agent rows are the JOINED shape (2026-09-06): each background agent is
      reported by both the SubagentStart hook and the CLI's task stream, and shows ONCE — labelled by its
@@ -32,24 +33,24 @@
   <div class="bg-fold-head bg-await open" data-act="bg-fold"><span class="bg-caret">▾</span><span class="bg-dot"></span><span class="bg-fold-label">Awaiting 4 · 2 agents · 1 command · 1 watch</span></div>
   <div class="bg-list">
     <div class="bg-group-head">Agents</div>
-    <div class="bg-task bg-running">
+    <div class="bg-task bg-running bg-kind-agents">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Map the notes-api parser</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 12m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
     </div>
-    <div class="bg-task bg-running bg-sub">
+    <div class="bg-task bg-running bg-sub bg-kind-commands">
       <div class="bg-head bg-flat"><span class="bg-waits-on">waiting on</span><span class="bg-dot"></span><span class="bg-sum">Run the parser test chunk</span><span class="bg-since">· 3m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
     </div>
-    <div class="bg-task bg-running bg-sub">
+    <div class="bg-task bg-running bg-sub bg-kind-agents">
       <div class="bg-head bg-flat"><span class="bg-waits-on bg-waits-blank"></span><span class="bg-dot"></span><span class="bg-sum">Check the fixture loader</span><span class="bg-deeper">· waiting on 1 command</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 1m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
     </div>
-    <div class="bg-task bg-running">
+    <div class="bg-task bg-running bg-kind-agents">
       <div class="bg-head bg-flat"><span class="bg-dot"></span><span class="bg-sum">Audit the exporter's retries</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 4m</span><span class="bg-status">running</span></div>
     </div>
     <div class="bg-group-head">Commands</div>
-    <div class="bg-task bg-running">
+    <div class="bg-task bg-running bg-kind-commands">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Build the docs site</span><span class="bg-since">· 9m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
     </div>
     <div class="bg-group-head">Watches</div>
-    <div class="bg-task bg-armed">
+    <div class="bg-task bg-armed bg-kind-watches">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">the CI run on web</span><span class="bg-since">· 31m</span><span class="bg-status">armed</span><button class="bg-stop bg-cancel">Cancel</button><span class="bg-caret">▸</span></div>
     </div>
     <div class="bg-await-note">The session is idle until this finishes; it picks back up on its own when the result lands.</div>
@@ -63,24 +64,24 @@
   <div class="bg-fold-head bg-running open" data-act="bg-fold"><span class="bg-caret">▾</span><span class="bg-dot"></span><span class="bg-fold-label">In the background · 2 agents · 1 command · 1 watch</span></div>
   <div class="bg-list">
     <div class="bg-group-head">Agents</div>
-    <div class="bg-task bg-running">
+    <div class="bg-task bg-running bg-kind-agents">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Map the notes-api parser</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 12m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
     </div>
-    <div class="bg-task bg-running bg-sub">
+    <div class="bg-task bg-running bg-sub bg-kind-commands">
       <div class="bg-head bg-flat"><span class="bg-waits-on">waiting on</span><span class="bg-dot"></span><span class="bg-sum">Run the parser test chunk</span><span class="bg-since">· 3m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
     </div>
-    <div class="bg-task bg-running bg-sub">
+    <div class="bg-task bg-running bg-sub bg-kind-agents">
       <div class="bg-head bg-flat"><span class="bg-waits-on bg-waits-blank"></span><span class="bg-dot"></span><span class="bg-sum">Check the fixture loader</span><span class="bg-deeper">· waiting on 1 command</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 1m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button></div>
     </div>
-    <div class="bg-task bg-running">
+    <div class="bg-task bg-running bg-kind-agents">
       <div class="bg-head bg-flat"><span class="bg-dot"></span><span class="bg-sum">Audit the exporter's retries</span><span class="tool-open-agent bg-open-agent" role="button"><svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 3.5H4a1 1 0 0 0-1 1V12a1 1 0 0 0 1 1h7.5a1 1 0 0 0 1-1V9"/><path d="M9.5 3h3.5v3.5"/><path d="M13 3 7.5 8.5"/></svg></span><span class="bg-since">· 4m</span><span class="bg-status">running</span></div>
     </div>
     <div class="bg-group-head">Commands</div>
-    <div class="bg-task bg-running">
+    <div class="bg-task bg-running bg-kind-commands">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">Build the docs site</span><span class="bg-since">· 9m</span><span class="bg-status">running</span><button class="bg-stop">Stop</button><span class="bg-caret">▸</span></div>
     </div>
     <div class="bg-group-head">Watches</div>
-    <div class="bg-task bg-armed">
+    <div class="bg-task bg-armed bg-kind-watches">
       <div class="bg-head" data-act="bg-toggle"><span class="bg-dot"></span><span class="bg-sum">the CI run on web</span><span class="bg-since">· 31m</span><span class="bg-status">armed</span><button class="bg-stop bg-cancel">Cancel</button><span class="bg-caret">▸</span></div>
     </div>
   </div>

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -83,6 +83,12 @@ toggles, in-progress loading dots, the Fleet pill, focus cues — anywhere you w
 romp blue." Do NOT use it for STATUS colors, which keep their own meaning: working =
 `--st-working-bg` (yellow), blocked/API-error = red, ready = `--st-ready-bg`, compacting =
 teal. New accent chrome should reference `var(--accent)`, never re-hardcode the hex.
+ONE exception, the user's choice of 2026-09-12 (T394): the background box's COMMAND rows wear
+the accent blue as their KIND hue (`--kind-command`, the dot and the caption word), beside
+the agents' working gold and the watches' awaiting green. That is a kind, not a status: the
+status still overrides it where it means something (a failed row's dot is the blocked red,
+a completed row's the dim ink). The light theme's accent is an orange, so `--kind-command`
+carries its own blue there (`#356890`).
 
 ### Loading/waiting states: show the romp loader FIRST
 Anytime something is loading, parsing, or otherwise making the user wait, the FIRST

--- a/ui/webview/awaiting-box-sync.test.ts
+++ b/ui/webview/awaiting-box-sync.test.ts
@@ -76,7 +76,7 @@ test("the chip and the box gist take the kind word from ONE count (T225 rider)",
   // gist and the feed pill from the kernel's kind + count + the awaited ROWS — "agent" for one, "3
   // agents" for several, the bare number when the kinds are mixed. kindWord stays underneath for a
   // payload with no rows (an older kernel), so the count still decides the number there.
-  assert.match(RENDER, /import \{ awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow \} from "\.\/spin-caption";/);   // + the nested-wait helpers (2026-09-10)
+  assert.match(RENDER, /import \{ awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, listBreakdown, keptWord, GROUP_TITLE, ROW_KINDS, workingFor, type AwaitRow \} from "\.\/spin-caption";/);   // + the nested-wait helpers (2026-09-10), the kept rows' words and the kind order (T394)
   assert.match(RENDER, /awaitingCount\?: number \| null;/, "the Status shape carries the kernel's count");
   assert.match(RENDER, /awaitingItems\?: AwaitRow\[\];/, "…and the rows (slice 2)");
   // the bar's chip is built by status-chip.ts since T322b: ONE awaitWord call words it for the bar and the tag overview's rows

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -142,14 +142,15 @@ test("the box groups the rows by kind, headers only when more than one group sho
   const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
   assert.match(body, /const groups = groupRows\(items\);/);
   assert.match(body, /const leftovers = tasks\.filter\(\(t\) => !itemIds\.has\(t\.id\)\);/, "tracked tasks the wait does not name still list");
-  assert.match(body, /const headers = groups\.length \+ \(leftovers\.length \? 1 : 0\) >= 2;/);
+  assert.match(body, /const headers = sections\.length >= 2;/, "the sections: the kinds the rows bring, and the kinds only a kept row brings (T394)");
   assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; list\.appendChild\(gh\); \}/);
-  // the trailing group's title (pin changed 2026-09-06): "Background tasks" was the legacy list's word and the
-  // renderer must not say it anywhere; a tracked task the wait does not name is simply also running
-  assert.match(body, /if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = BG_LEFTOVER_TITLE; list\.appendChild\(gh\); \}/);
-  assert.match(RENDER, /const BG_LEFTOVER_TITLE = "Also running";/);
-  // the header: mixed → "Awaiting <n> · <breakdown>"; one kind → the sentence as before
-  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/);
+  // no trailing section for the tracked tasks the wait does not name (T394, the user 2026-09-12: its title said nothing of why
+  // the rows were there): each lists in its KIND's section, after the awaited rows, dimmed, the judge's verdict as a suffix
+  assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"|"Background tasks"/, "no section of its own, under either of its old names");
+  assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/);
+  // the header: mixed → "Awaiting <n> · <breakdown>" counting the kept rows apart; one kind → the sentence as before, the kept count after it
+  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/);
+  assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(kept\.length \? " · " \+ keptWord\(kept\.length\) : ""\);/);
   // the no-rows fallback still expands to the full sentence — never a dead end
   assert.match(body, /if \(!groups\.length && !leftovers\.length\) \{[\s\S]*?const w = el\("div", "bg-await-why"\); w\.textContent = why;/);
   // the header vocabulary is .bg-status's — the notice SOURCE-label rung (0.72em uppercase, 2026-09-08; was 10px), dim
@@ -250,7 +251,7 @@ test("ONE renderer: the grouped rows render whenever rows exist, idle or not; th
   // output tail and Stop handle (awaitRowSpec's `tracked`), and list on their own when the wait names none
   assert.match(body, /const taskById = new Map<string, BgTask>\(tasks\.map\(\(t\) => \[t\.id, t\]\)\);/);
   assert.match(body, /for \(const it of g\.rows\) \{\s*list\.appendChild\(bgRow\(awaitRowSpec\(it, taskById\.get\(it\.id \|\| ""\), peerByName\), sid\)\);/);   // the loop is a block since 2026-09-10 (each agent row's nested waits follow it)
-  assert.match(body, /for \(const t of leftovers\) list\.appendChild\(bgRow\(taskRowSpec\(t, awaited\.has\(t\.id\)\), sid\)\);/);
+  assert.match(body, /const kept = leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\)\)\);/, "the tracked tasks the wait does not name, as rows of their kind (T394)");
   // the awaited outline keys on the wait / the awaited ids' presence as before — never the chip state
   assert.match(body, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
   assert.doesNotMatch(body, /status\.state/, "nothing in the renderer reads the chip state");
@@ -259,8 +260,8 @@ test("ONE renderer: the grouped rows render whenever rows exist, idle or not; th
 test("the header follows the wait: idle → 'Awaiting …' + the idle note; working → 'In the background · <breakdown>' and NO note", () => {
   const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
   assert.match(body, /if \(why\) \{[\s\S]*?const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "idle: today's label, agreeing in number with the chip");
-  assert.match(body, /\} else \{[\s\S]*?const counted: AwaitRow\[\] = items\.length \? items : leftovers\.map\(\(t\) => \(\{ kind: "commands", id: t\.id, label: t\.summary \}\)\);\s*\n\s*lab\.textContent = "In the background · " \+ awaitBreakdown\(counted\);/,
-    "working: the same rows, worded as what they are; a tracked service with no awaited row counts as the command it is");
+  assert.match(body, /\} else \{[\s\S]*?lab\.textContent = "In the background · " \+ listBreakdown\(items, kept\.length\);/,
+    "working: the same rows, worded as what they are; the header counts every row the list shows, the kept rows apart (T394)");
   // the idle note is appended under a wait only — once at the end of the list, once in the no-rows fallback
   assert.match(body, /if \(why\) list\.appendChild\(bgIdleNote\(\)\);/);
   assert.match(body, /det\.appendChild\(bgIdleNote\(\)\);/);
@@ -374,7 +375,7 @@ test("the box draws an agent's waits as indented sub-rows in the SAME row vocabu
 });
 
 test("the header and the chip count the top level only: the breakdown reads `items`, and nested ids still keep their tracked task out of 'Also running'", () => {
-  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/, "the mixed header's breakdown is the top-level rows");
+  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/, "the mixed header's breakdown is the top-level rows, the kept rows counted apart (T394)");
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "the header word: top-level rows + the kernel's top-level count");
   assert.match(RENDER, /const itemIds = rowIds\(items\);/, "a task an agent's wait names is named, not a leftover");
 });

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -149,8 +149,8 @@ test("the box groups the rows by kind, headers only when more than one group sho
   assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"|"Background tasks"/, "no section of its own, under either of its old names");
   assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/);
   // the header: mixed → "Awaiting <n> · <breakdown>" counting the kept rows apart; one kind → the sentence as before, the kept count after it
-  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/);
-  assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(kept\.length \? " · " \+ keptWord\(kept\.length\) : ""\);/);
+  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/);
+  assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(keptN \? " · " \+ keptWord\(keptN\) : ""\);/);
   // the no-rows fallback still expands to the full sentence — never a dead end
   assert.match(body, /if \(!groups\.length && !leftovers\.length\) \{[\s\S]*?const w = el\("div", "bg-await-why"\); w\.textContent = why;/);
   // the header vocabulary is .bg-status's — the notice SOURCE-label rung (0.72em uppercase, 2026-09-08; was 10px), dim
@@ -251,7 +251,7 @@ test("ONE renderer: the grouped rows render whenever rows exist, idle or not; th
   // output tail and Stop handle (awaitRowSpec's `tracked`), and list on their own when the wait names none
   assert.match(body, /const taskById = new Map<string, BgTask>\(tasks\.map\(\(t\) => \[t\.id, t\]\)\);/);
   assert.match(body, /for \(const it of g\.rows\) \{\s*list\.appendChild\(bgRow\(awaitRowSpec\(it, taskById\.get\(it\.id \|\| ""\), peerByName\), sid\)\);/);   // the loop is a block since 2026-09-10 (each agent row's nested waits follow it)
-  assert.match(body, /const kept = leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\)\)\);/, "the tracked tasks the wait does not name, as rows of their kind (T394)");
+  assert.match(body, /const kept = leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\), services\.has\(t\.id\)\)\);/, "the tracked tasks the wait does not name, as rows of their kind, the judge's verdict riding in (T394)");
   // the awaited outline keys on the wait / the awaited ids' presence as before — never the chip state
   assert.match(body, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
   assert.doesNotMatch(body, /status\.state/, "nothing in the renderer reads the chip state");
@@ -260,7 +260,7 @@ test("ONE renderer: the grouped rows render whenever rows exist, idle or not; th
 test("the header follows the wait: idle → 'Awaiting …' + the idle note; working → 'In the background · <breakdown>' and NO note", () => {
   const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
   assert.match(body, /if \(why\) \{[\s\S]*?const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "idle: today's label, agreeing in number with the chip");
-  assert.match(body, /\} else \{[\s\S]*?lab\.textContent = "In the background · " \+ listBreakdown\(items, kept\.length\);/,
+  assert.match(body, /\} else \{[\s\S]*?lab\.textContent = "In the background · " \+ listBreakdown\(items, keptN\);/,
     "working: the same rows, worded as what they are; the header counts every row the list shows, the kept rows apart (T394)");
   // the idle note is appended under a wait only — once at the end of the list, once in the no-rows fallback
   assert.match(body, /if \(why\) list\.appendChild\(bgIdleNote\(\)\);/);
@@ -374,8 +374,8 @@ test("the box draws an agent's waits as indented sub-rows in the SAME row vocabu
   assert.doesNotMatch(STYLES.match(/\.bg-waits-on \{[^}]*\}/)![0], /#[0-9a-fA-F]{3,6}/, "tokens, never hex");
 });
 
-test("the header and the chip count the top level only: the breakdown reads `items`, and nested ids still keep their tracked task out of 'Also running'", () => {
-  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/, "the mixed header's breakdown is the top-level rows, the kept rows counted apart (T394)");
+test("the header and the chip count the top level only: the breakdown reads `items`, and nested ids still keep their tracked task from listing twice as a leftover of its kind", () => {
+  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/, "the mixed header's breakdown is the top-level rows, the kept rows counted apart (T394)");
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "the header word: top-level rows + the kernel's top-level count");
   assert.match(RENDER, /const itemIds = rowIds\(items\);/, "a task an agent's wait names is named, not a leftover");
 });

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -149,7 +149,7 @@ test("the box groups the rows by kind, headers only when more than one group sho
   assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"|"Background tasks"/, "no section of its own, under either of its old names");
   assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/);
   // the header: mixed → "Awaiting <n> · <breakdown>" counting the kept rows apart; one kind → the sentence as before, the kept count after it
-  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/);
+  assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/);
   assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(keptN \? " · " \+ keptWord\(keptN\) : ""\);/);
   // the no-rows fallback still expands to the full sentence — never a dead end
   assert.match(body, /if \(!groups\.length && !leftovers\.length\) \{[\s\S]*?const w = el\("div", "bg-await-why"\); w\.textContent = why;/);
@@ -260,7 +260,7 @@ test("ONE renderer: the grouped rows render whenever rows exist, idle or not; th
 test("the header follows the wait: idle → 'Awaiting …' + the idle note; working → 'In the background · <breakdown>' and NO note", () => {
   const body = RENDER.split("function renderBgTasks(")[1].split("\nfunction ")[0];
   assert.match(body, /if \(why\) \{[\s\S]*?const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "idle: today's label, agreeing in number with the chip");
-  assert.match(body, /\} else \{[\s\S]*?lab\.textContent = "In the background · " \+ listBreakdown\(items, keptN\);/,
+  assert.match(body, /\} else \{[\s\S]*?lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/,
     "working: the same rows, worded as what they are; the header counts every row the list shows, the kept rows apart (T394)");
   // the idle note is appended under a wait only — once at the end of the list, once in the no-rows fallback
   assert.match(body, /if \(why\) list\.appendChild\(bgIdleNote\(\)\);/);
@@ -271,7 +271,7 @@ test("the header follows the wait: idle → 'Awaiting …' + the idle note; work
   // the header dot: await-green under a wait (like the chip), else the worst tracked status — a failed task
   // stays glanceable while collapsed, running-yellow otherwise (never completed-blue for a box of live rows)
   assert.match(body, /const head = el\("div", "bg-fold-head " \+ \(why \? "bg-await" : "bg-" \+ worst\) \+ \(open \? " open" : ""\)\);/);
-  assert.match(body, /const worst = tasks\.reduce\(\(w, t\) => \(BG_RANK\[t\.status\] \|\| 0\) > \(BG_RANK\[w\] \|\| 0\) \? t\.status : w, "running"\);/);
+  assert.match(body, /const worst = tasks\.reduce\(\(w, t\) => \(BG_RANK\[t\.status\] \|\| 0\) > \(BG_RANK\[w\] \|\| 0\) \? t\.status : w, tasks\.length \? \(tasks\[0\]\.status \|\| "running"\) : "running"\);/);
   // the words, EXECUTED: the same rows word both headers, singular and plural
   const rows = [agent("a"), agent("b"), command("c")];
   assert.equal("Awaiting " + awaitWord("mixed", 3, rows) + " · " + awaitBreakdown(rows), "Awaiting 3 · 2 agents · 1 command");
@@ -375,7 +375,7 @@ test("the box draws an agent's waits as indented sub-rows in the SAME row vocabu
 });
 
 test("the header and the chip count the top level only: the breakdown reads `items`, and nested ids still keep their tracked task from listing twice as a leftover of its kind", () => {
-  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/, "the mixed header's breakdown is the top-level rows, the kept rows counted apart (T394)");
+  assert.match(RENDER, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/, "the mixed header's breakdown is every listed row, the kept rows counted apart (T394)");
   assert.match(RENDER, /const word = awaitWord\(s\.status\.awaitingKind, s\.status\.awaitingCount, items\);/, "the header word: top-level rows + the kernel's top-level count");
   assert.match(RENDER, /const itemIds = rowIds\(items\);/, "a task an agent's wait names is named, not a leftover");
 });

--- a/ui/webview/awaiting-rows.test.ts
+++ b/ui/webview/awaiting-rows.test.ts
@@ -150,7 +150,7 @@ test("the box groups the rows by kind, headers only when more than one group sho
   assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/);
   // the header: mixed → "Awaiting <n> · <breakdown>" counting the kept rows apart; one kind → the sentence as before, the kept count after it
   assert.match(body, /\} else if \(groups\.length > 1\) \{\s*\n\s*lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/);
-  assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(keptN \? " · " \+ keptWord\(keptN\) : ""\);/);
+  assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(kept\.length \? " · " \+ listBreakdown\(counted, keptN\) : ""\);/);
   // the no-rows fallback still expands to the full sentence — never a dead end
   assert.match(body, /if \(!groups\.length && !leftovers\.length\) \{[\s\S]*?const w = el\("div", "bg-await-why"\); w\.textContent = why;/);
   // the header vocabulary is .bg-status's — the notice SOURCE-label rung (0.72em uppercase, 2026-09-08; was 10px), dim

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -99,7 +99,7 @@ test("the awaiting WHY lives in the background box, not the statusline (the user
   assert.match(RENDER, /if \(descs\.length > 1\)/);   // the no-rows fallback lists the legacy descriptions only when there are several
   assert.match(RENDER, /bg-await-note/);
   assert.match(RENDER, /const stopId = running \? tracked!\.id : \(it\.stoppable && id \? id : null\);/);   // (2026-09-10: computed once above the kind branches; a kernel-marked stoppable row offers Stop without a tracked task)
-  assert.match(RENDER, /return \{ id, status: "armed", caption: "armed", label: it\.label \|\| "a watch", since: it\.since,\s*\n\s*watchId: it\.watchId \|\| null, command: it\.detail \|\| null \};/, "a watch row: Cancel when the kernel has a handle, never Stop");
+  assert.match(RENDER, /return \{ id, status: "armed", caption: "armed", kind: "watches", label: it\.label \|\| "a watch", since: it\.since,\s*\n\s*watchId: it\.watchId \|\| null, command: it\.detail \|\| null \};/, "a watch row: Cancel when the kernel has a handle, never Stop");
   assert.match(STYLES, /\.bg-fold-head\.bg-await \{ --bgt: var\(--st-awaitbg-bg\); \}/);
 });
 
@@ -117,7 +117,7 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
   // whenever a tracked task is named awaited — one toggle since the one-renderer cut (2026-09-06; the
   // kernel ships the ids only with a wait, so mid-turn the box wears its neutral border under a Working chip)
   assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
-  assert.match(RENDER, /bgRow\(taskRowSpec\(t, awaited\.has\(t\.id\)\), sid\)/);   // the row spec carries the match (slice 2's one row renderer)
+  assert.match(RENDER, /leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\)\)\)/);   // the row spec carries the match (slice 2's one row renderer; the rows join their kind's section since T394)
   assert.match(RENDER, /\(t\.awaited \? " bg-awaited" : ""\)/);
   // the outline is the chip's await-green — the border/outline only; the status DOT rules are untouched
   assert.match(STYLES, /#bg-tasks\.bg-awaited \{ border-color: var\(--st-awaitbg-bg\); \}/);

--- a/ui/webview/awaiting-state.test.ts
+++ b/ui/webview/awaiting-state.test.ts
@@ -117,7 +117,7 @@ test("the awaited tasks wear the chip's green outline — exact launch-id match;
   // whenever a tracked task is named awaited — one toggle since the one-renderer cut (2026-09-06; the
   // kernel ships the ids only with a wait, so mid-turn the box wears its neutral border under a Working chip)
   assert.match(RENDER, /host\.classList\.toggle\("bg-awaited", !!why \|\| tasks\.some\(\(t\) => awaited\.has\(t\.id\)\)\);/);
-  assert.match(RENDER, /leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\)\)\)/);   // the row spec carries the match (slice 2's one row renderer; the rows join their kind's section since T394)
+  assert.match(RENDER, /leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\), services\.has\(t\.id\)\)\)/);   // the row spec carries the match (slice 2's one row renderer; the rows join their kind's section since T394)
   assert.match(RENDER, /\(t\.awaited \? " bg-awaited" : ""\)/);
   // the outline is the chip's await-green — the border/outline only; the status DOT rules are untouched
   assert.match(STYLES, /#bg-tasks\.bg-awaited \{ border-color: var\(--st-awaitbg-bg\); \}/);

--- a/ui/webview/bg-kinds.test.ts
+++ b/ui/webview/bg-kinds.test.ts
@@ -13,6 +13,7 @@ const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview"
 const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
 const FIXTURE = fs.readFileSync(path.resolve(process.cwd(), "..", "tools", "ui-verify", "fixtures", "awaiting-rows-chat.html"), "utf8");
 const fn = (name: string) => RENDER.slice(RENDER.indexOf("function " + name + "("), RENDER.indexOf("\n}\n", RENDER.indexOf("function " + name + "(")));
+const UI_RULES = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "CLAUDE.md"), "utf8");
 
 test("the header's words count the kept rows apart from the awaited breakdown, either alone when the other is empty", () => {
   const rows: AwaitRow[] = [{ kind: "agents", id: "a1", label: "Map the parser" }, { kind: "commands", id: "c1", label: "Build the docs" }, { kind: "watches", id: "w1", label: "the CI run" }];
@@ -29,22 +30,26 @@ test("the sections are the kinds, in the rows' display order, and no section of 
   const body = fn("renderBgTasks");
   assert.deepEqual([...ROW_KINDS], ["agents", "commands", "watches", "peer", "timer"]);
   for (const k of ["agents", "commands", "watches"]) assert.ok(GROUP_TITLE[k], "a title for " + k);
-  assert.match(body, /const kept = leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\)\)\);/, "the tracked tasks the kernel's rows do not name become rows of their kind");
+  assert.match(body, /const kept = leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\), services\.has\(t\.id\)\)\);/, "the tracked tasks the kernel's rows do not name become rows of their kind; the judge's verdict rides in");
+  assert.match(body, /const services = new Set<string>\(s\.status\.bgServiceIds \|\| \[\]\);/, "the kernel ships the judge's furniture verdict as launch ids (round one, medium 2)");
+  assert.match(body, /const keptN = kept\.filter\(\(row\) => row\.kept\)\.length;/, "the header counts the rows wearing the verdict, none other (round one, medium 1)");
   assert.match(body, /const sections: \{ kind: string; rows: AwaitRow\[\] \}\[\] = \[\.\.\.ROW_KINDS, "other"\]\s*\n\s*\.filter\(\(k\) => groups\.some\(\(g\) => g\.kind === k\) \|\| kept\.some\(\(row\) => row\.kind === k\)\)/,
     "a kind the rows bring, or one only a kept row brings, in display order");
   assert.match(body, /for \(const g of sections\) \{\s*\n\s*if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; list\.appendChild\(gh\); \}/);
   assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/, "the kept rows of the kind follow its awaited rows");
   assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"/, "the section and its title are gone");
-  assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(items, kept\.length\);/, "the working header counts every row it lists");
-  assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/, "…and the mixed idle header");
-  assert.match(body, /if \(kept\.length\) lab\.append\(" · " \+ keptWord\(kept\.length\)\);/, "…and the peer-named idle header");
+  assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(items, keptN\);/, "the working header counts every row it lists");
+  assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/, "…and the mixed idle header");
+  assert.match(body, /if \(keptN\) lab\.append\(" · " \+ keptWord\(keptN\)\);/, "…and the peer-named idle header");
 });
 
-test("every row spec carries its kind, and a tracked task the wait does not name is kept unless the kernel names it awaited", () => {
+test("every row spec carries its kind, and a tracked task is kept only where the kernel's verdict names it a service, while it runs", () => {
   const task = fn("taskRowSpec"), aw = fn("awaitRowSpec"), spec = RENDER.slice(RENDER.indexOf("interface BgRowSpec {"), RENDER.indexOf("\n}\n", RENDER.indexOf("interface BgRowSpec {")));
   assert.match(spec, /kind\?: string \| null;/);
   assert.match(spec, /kept\?: boolean;/);
-  assert.match(task, /kind: t\.agentId \? "agents" : "commands", kept: !awaited,/, "an agent-shaped task is an agent; the rest are commands; kept running unless awaited");
+  assert.match(task, /kind: t\.agentId \? "agents" : "commands", kept: service && status === "running",/, "an agent-shaped task is an agent; the rest are commands; kept only on the judge's verdict, and only while running (round one, medium 2 and low 1)");
+  assert.match(RENDER, /function taskRowSpec\(t: BgTask, awaited: boolean, service: boolean\): BgRowSpec \{/);
+  assert.doesNotMatch(task, /kept: !awaited/, "never inferred from a missing row");
   assert.match(aw, /return \{ id, status: "running", caption: "running", kind: "agents",/);
   assert.match(aw, /return \{ id, status, caption: status, kind: "commands",/);
   assert.match(aw, /return \{ id, status: "armed", caption: "armed", kind: "watches",/);
@@ -72,12 +77,19 @@ test("the sheet: one hue per kind, status overriding for failed and completed, t
   assert.doesNotMatch(rules, /\.bg-task\.bg-completed \{ --bgt: var\(--st-ready-bg\); \}/, "the ready blue would collide with the command hue");
   // the kept rules sit AFTER the row label's own rule: the layout pin reads the first `.bg-sum {` as the label's (bg-tasks-layout.test.ts)
   assert.ok(CSS.indexOf(".bg-task.bg-kept .bg-sum {") > CSS.indexOf("\n.bg-sum {"), "the kept label rule follows the label rule");
-  assert.match(CSS, /\.bg-task\.bg-kept \.bg-dot \{ opacity: \.55; \}/);
+  assert.match(CSS, /\.bg-task\.bg-kept \.bg-dot \{ background: color-mix\(in srgb, var\(--bgt\) 45%, var\(--dim\)\); \}/, "the kept dot is a colour, the hue greyed toward the dim ink (round one, low 2), never element opacity");
+  assert.doesNotMatch(CSS, /\.bg-kept \.bg-dot \{[^}]*opacity/);
+  assert.match(CSS, /\.bg-fold-head\.bg-completed \{ --bgt: var\(--dim\); \}/, "the header's completed tint follows the rows (round one, low 4)");
   assert.match(CSS, /\.bg-task\.bg-kept \.bg-sum \{ color: var\(--dim\); \}/);
   assert.match(CSS, /\.bg-kept-word \{ flex: 0 0 auto; font-size: 0\.82em; color: var\(--dim\); white-space: nowrap; \}/);
   assert.doesNotMatch(CSS, /\.bg-task\.bg-kept \{[^}]*opacity/, "the row itself never dims by opacity: every caption would fall under 4.5:1");
   assert.match(CSS, /body\.theme-light \.bg-status \{ color: oklch\(from var\(--bgt\) 0\.46 c h\); \}/, "the T390 lightness rule for the caption word on cream");
   assert.match(CSS, /\.bg-status \{[^}]*color: var\(--bgt\); \}/, "…over the plain hue, which an engine without relative colours keeps");
+});
+
+test("the accent-is-never-a-status-colour rule names its one exception, in the sheet and the UI rules (round one, low 5)", () => {
+  assert.match(CSS, /ONE exception \(the user 2026-09-12, T394\): the background box's command rows wear it as their KIND hue/);
+  assert.match(UI_RULES, /ONE exception, the user's choice of 2026-09-12 \(T394\): the background box's COMMAND rows wear\nthe accent blue as their KIND hue/);
 });
 
 test("the fixture mirrors the builder: every row wears its kind class", () => {

--- a/ui/webview/bg-kinds.test.ts
+++ b/ui/webview/bg-kinds.test.ts
@@ -38,9 +38,16 @@ test("the sections are the kinds, in the rows' display order, and no section of 
   assert.match(body, /for \(const g of sections\) \{\s*\n\s*if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; list\.appendChild\(gh\); \}/);
   assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/, "the kept rows of the kind follow its awaited rows");
   assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"/, "the section and its title are gone");
-  assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(items, keptN\);/, "the working header counts every row it lists");
-  assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/, "…and the mixed idle header");
-  assert.match(body, /if \(keptN\) lab\.append\(" · " \+ keptWord\(keptN\)\);/, "…and the peer-named idle header");
+  assert.match(body, /const counted: AwaitRow\[\] = \[\.\.\.items, \.\.\.kept\.map\(\(row\) => \(\{ kind: row\.kind \|\| "commands", id: row\.id, label: row\.label \}\)\)\];/,
+    "every listed row is counted, the tracked tasks by kind (round two, medium: a box whose only row was a tracked task read a separator with nothing after it)");
+  assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/, "the working header counts every row it lists");
+  assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/, "…and the mixed idle header");
+  assert.match(body, /if \(kept\.length\) lab\.append\(" · " \+ listBreakdown\(kept\.map\(/, "…and the peer-named idle header counts the tracked rows below");
+  assert.doesNotMatch(body, /listBreakdown\(items, keptN\)/, "no header reads the kernel's rows alone");
+  const key = fn("awaitKey");
+  assert.match(key, /st\.awaitingTaskIds \|\| \[\], st\.bgServiceIds \|\| \[\], st\.awaitingItems \|\| \[\]/, "a verdict-only frame repaints the box (round two, low 1)");
+  assert.match(body, /const worst = tasks\.reduce\(\(w, t\) => \(BG_RANK\[t\.status\] \|\| 0\) > \(BG_RANK\[w\] \|\| 0\) \? t\.status : w, tasks\.length \? \(tasks\[0\]\.status \|\| "running"\) : "running"\);/,
+    "the header dot seeds from the tasks' own statuses: a completed-only box reads completed (round two, low 2)");
 });
 
 test("every row spec carries its kind, and a tracked task is kept only where the kernel's verdict names it a service, while it runs", () => {

--- a/ui/webview/bg-kinds.test.ts
+++ b/ui/webview/bg-kinds.test.ts
@@ -43,6 +43,10 @@ test("the sections are the kinds, in the rows' display order, and no section of 
   assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/, "the working header counts every row it lists");
   assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/, "…and the mixed idle header");
   assert.match(body, /if \(kept\.length\) lab\.append\(" · " \+ listBreakdown\(kept\.map\(/, "…and the peer-named idle header counts the tracked rows below");
+  assert.match(body, /lab\.textContent = "Awaiting" \+ \(word \? " " \+ word : ""\) \+ " · " \+ why\.replace\(\/\^\(waiting on\|awaiting\)\\s\+\/i, ""\) \+ \(kept\.length \? " · " \+ listBreakdown\(counted, keptN\) : ""\);/,
+    "…and the one-kind idle header counts the rows beyond the wait's, by kind, with the kept subset (round three, low 3)");
+  assert.match(body, /THE HEADER'S RULE \(T394 round three, lows 1 and 2\): the leading word is the wait and its count is the awaited rows/, "the rule, stated where the header is built");
+  assert.match(body, /subset of those rows wearing the judge's verdict, never a further partition/, "…the kept count is a subset, never a partition");
   assert.doesNotMatch(body, /listBreakdown\(items, keptN\)/, "no header reads the kernel's rows alone");
   const key = fn("awaitKey");
   assert.match(key, /st\.awaitingTaskIds \|\| \[\], st\.bgServiceIds \|\| \[\], st\.awaitingItems \|\| \[\]/, "a verdict-only frame repaints the box (round two, low 1)");

--- a/ui/webview/bg-kinds.test.ts
+++ b/ui/webview/bg-kinds.test.ts
@@ -1,0 +1,87 @@
+// T394 (the user 2026-09-12, from a screenshot of the background fold): every row of the chat's background box sits in its KIND's
+// section (Agents, Commands, Watches), one hue per kind for the dot and the caption word, and a tracked task nobody waits on (the
+// judge audited its launch without a wait) lists in its kind's section, dimmed, with the verdict as a muted suffix, instead of
+// under a section of its own. The header counts every row the list shows. Executed: the header's words; pinned: the row spec, the
+// row builder, the sheet in both themes, the fixture. The served lab (tests/test_bg_kinds_browser.py) reads the computed colours.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { keptWord, listBreakdown, GROUP_TITLE, ROW_KINDS, type AwaitRow } from "./spin-caption";
+
+const RENDER = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "render.ts"), "utf8");
+const CSS = fs.readFileSync(path.resolve(process.cwd(), "..", "ui", "webview", "styles.css"), "utf8");
+const FIXTURE = fs.readFileSync(path.resolve(process.cwd(), "..", "tools", "ui-verify", "fixtures", "awaiting-rows-chat.html"), "utf8");
+const fn = (name: string) => RENDER.slice(RENDER.indexOf("function " + name + "("), RENDER.indexOf("\n}\n", RENDER.indexOf("function " + name + "(")));
+
+test("the header's words count the kept rows apart from the awaited breakdown, either alone when the other is empty", () => {
+  const rows: AwaitRow[] = [{ kind: "agents", id: "a1", label: "Map the parser" }, { kind: "commands", id: "c1", label: "Build the docs" }, { kind: "watches", id: "w1", label: "the CI run" }];
+  assert.equal(keptWord(0), "", "none kept: no word");
+  assert.equal(keptWord(1), "1 kept running");
+  assert.equal(keptWord(2), "2 kept running");
+  assert.equal(listBreakdown(rows, 1), "1 agent · 1 command · 1 watch · 1 kept running");
+  assert.equal(listBreakdown(rows, 0), "1 agent · 1 command · 1 watch", "no kept rows: the breakdown as before");
+  assert.equal(listBreakdown([], 1), "1 kept running", "only a kept row: no leading separator");
+  assert.equal(listBreakdown([], 0), "");
+});
+
+test("the sections are the kinds, in the rows' display order, and no section of its own remains for the kept rows", () => {
+  const body = fn("renderBgTasks");
+  assert.deepEqual([...ROW_KINDS], ["agents", "commands", "watches", "peer", "timer"]);
+  for (const k of ["agents", "commands", "watches"]) assert.ok(GROUP_TITLE[k], "a title for " + k);
+  assert.match(body, /const kept = leftovers\.map\(\(t\) => taskRowSpec\(t, awaited\.has\(t\.id\)\)\);/, "the tracked tasks the kernel's rows do not name become rows of their kind");
+  assert.match(body, /const sections: \{ kind: string; rows: AwaitRow\[\] \}\[\] = \[\.\.\.ROW_KINDS, "other"\]\s*\n\s*\.filter\(\(k\) => groups\.some\(\(g\) => g\.kind === k\) \|\| kept\.some\(\(row\) => row\.kind === k\)\)/,
+    "a kind the rows bring, or one only a kept row brings, in display order");
+  assert.match(body, /for \(const g of sections\) \{\s*\n\s*if \(headers\) \{ const gh = el\("div", "bg-group-head"\); gh\.textContent = GROUP_TITLE\[g\.kind\] \|\| "Other"; list\.appendChild\(gh\); \}/);
+  assert.match(body, /for \(const row of kept\) if \(row\.kind === g\.kind\) list\.appendChild\(bgRow\(row, sid\)\);/, "the kept rows of the kind follow its awaited rows");
+  assert.doesNotMatch(RENDER, /BG_LEFTOVER_TITLE|"Also running"/, "the section and its title are gone");
+  assert.match(body, /lab\.textContent = "In the background · " \+ listBreakdown\(items, kept\.length\);/, "the working header counts every row it lists");
+  assert.match(body, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/, "…and the mixed idle header");
+  assert.match(body, /if \(kept\.length\) lab\.append\(" · " \+ keptWord\(kept\.length\)\);/, "…and the peer-named idle header");
+});
+
+test("every row spec carries its kind, and a tracked task the wait does not name is kept unless the kernel names it awaited", () => {
+  const task = fn("taskRowSpec"), aw = fn("awaitRowSpec"), spec = RENDER.slice(RENDER.indexOf("interface BgRowSpec {"), RENDER.indexOf("\n}\n", RENDER.indexOf("interface BgRowSpec {")));
+  assert.match(spec, /kind\?: string \| null;/);
+  assert.match(spec, /kept\?: boolean;/);
+  assert.match(task, /kind: t\.agentId \? "agents" : "commands", kept: !awaited,/, "an agent-shaped task is an agent; the rest are commands; kept running unless awaited");
+  assert.match(aw, /return \{ id, status: "running", caption: "running", kind: "agents",/);
+  assert.match(aw, /return \{ id, status, caption: status, kind: "commands",/);
+  assert.match(aw, /return \{ id, status: "armed", caption: "armed", kind: "watches",/);
+  assert.match(aw, /return \{ id, status: "waiting", kind: "peer",/);
+  assert.match(aw, /kind: it\.kind, label: it\.label \|\| it\.kind, since: it\.since \};/, "a timer or a newer kernel's kind keeps its own name");
+});
+
+test("the row wears its kind and its verdict: bg-kind-<kind>, bg-kept, and the muted suffix beside the label", () => {
+  const row = fn("bgRow");
+  assert.match(RENDER, /const BG_KEPT_WORD = "· kept running, not waited on";/);
+  assert.match(row, /\(t\.kind \? " bg-kind-" \+ t\.kind : ""\) \+ \(t\.kept \? " bg-kept" : ""\)/);
+  assert.match(row, /rh\.appendChild\(sum\);\s*\n\s*if \(t\.kept\) \{ const kw = el\("span", "bg-kept-word"\); kw\.textContent = BG_KEPT_WORD; rh\.appendChild\(kw\); \}/, "the suffix follows the label, before the cluster");
+});
+
+test("the sheet: one hue per kind, status overriding for failed and completed, the kept row dimmed without element opacity, the cream caption deepened", () => {
+  const root = CSS.slice(CSS.indexOf(":root {"), CSS.indexOf("\n}", CSS.indexOf(":root {")));
+  const light = CSS.slice(CSS.indexOf("body.theme-light {"), CSS.indexOf("\n}", CSS.indexOf("body.theme-light {")));
+  assert.match(root, /--kind-command: var\(--accent\);/, "dark: the accent blue the timeline lane icons wear");
+  assert.match(light, /--kind-command: #356890;/, "cream: the accent's hue at OKLCH lightness 0.50 (the light accent is an orange)");
+  const rules = CSS.slice(CSS.indexOf(".bg-task { --bgt: var(--st-working-bg); }"), CSS.indexOf(".bg-group-head {"));
+  const order = [".bg-task.bg-kind-agents { --bgt: var(--st-working-bg); }", ".bg-task.bg-kind-commands { --bgt: var(--kind-command); }",
+                 ".bg-task.bg-kind-watches { --bgt: var(--st-awaitbg-bg); }", ".bg-task.bg-failed { --bgt: var(--st-blocked-bg); }", ".bg-task.bg-completed { --bgt: var(--dim); }"];
+  let at = -1;
+  for (const r of order) { const i = rules.indexOf(r); assert.ok(i > at, "in cascade order, the status rules after the kind rules: " + r); at = i; }
+  assert.doesNotMatch(rules, /\.bg-task\.bg-completed \{ --bgt: var\(--st-ready-bg\); \}/, "the ready blue would collide with the command hue");
+  // the kept rules sit AFTER the row label's own rule: the layout pin reads the first `.bg-sum {` as the label's (bg-tasks-layout.test.ts)
+  assert.ok(CSS.indexOf(".bg-task.bg-kept .bg-sum {") > CSS.indexOf("\n.bg-sum {"), "the kept label rule follows the label rule");
+  assert.match(CSS, /\.bg-task\.bg-kept \.bg-dot \{ opacity: \.55; \}/);
+  assert.match(CSS, /\.bg-task\.bg-kept \.bg-sum \{ color: var\(--dim\); \}/);
+  assert.match(CSS, /\.bg-kept-word \{ flex: 0 0 auto; font-size: 0\.82em; color: var\(--dim\); white-space: nowrap; \}/);
+  assert.doesNotMatch(CSS, /\.bg-task\.bg-kept \{[^}]*opacity/, "the row itself never dims by opacity: every caption would fall under 4.5:1");
+  assert.match(CSS, /body\.theme-light \.bg-status \{ color: oklch\(from var\(--bgt\) 0\.46 c h\); \}/, "the T390 lightness rule for the caption word on cream");
+  assert.match(CSS, /\.bg-status \{[^}]*color: var\(--bgt\); \}/, "…over the plain hue, which an engine without relative colours keeps");
+});
+
+test("the fixture mirrors the builder: every row wears its kind class", () => {
+  const rows = FIXTURE.match(/<div class="bg-task [^"]*">/g) || [];
+  assert.ok(rows.length >= 6, "rows in the fixture: " + rows.length);
+  for (const r of rows) assert.match(r, /bg-kind-(agents|commands|watches)/, r);
+});

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13900,6 +13900,12 @@ function renderBgTasks() {
   const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);   // ▸ closed → ▾ open (expands DOWNWARD beneath the header)
   head.appendChild(el("span", "bg-dot"));
   const lab = el("span", "bg-fold-label");
+  // THE HEADER'S RULE (T394 round three, lows 1 and 2): the leading word is the wait and its count is the awaited rows (the chip's
+  // number); the breakdown after the separator counts EVERY row the list shows, by kind, awaited or not; "N kept running" is the
+  // subset of those rows wearing the judge's verdict, never a further partition. So "Awaiting 2 · 1 agent · 2 commands · 1 kept
+  // running" is a session waiting on two of three listed rows, one of them a command the judge called furniture. The one-kind idle
+  // header keeps the wait's own sentence and adds the breakdown only when the list shows rows beyond the wait's (else the word
+  // already counts them all).
   if (why) {
     // IDLE, waiting on the rows — the chip reads Awaiting and the header agrees with it in number: ONE rule
     // words both (awaitWord). The kernel's why leads with the verb ("waiting on a background command: …");
@@ -13922,7 +13928,7 @@ function renderBgTasks() {
     } else if (groups.length > 1) {
       lab.textContent = "Awaiting " + word + " · " + listBreakdown(counted, keptN);   // mixed kinds: the number, then every listed row by kind, then the kept rows
     } else {
-      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "") + (keptN ? " · " + keptWord(keptN) : "");
+      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "") + (kept.length ? " · " + listBreakdown(counted, keptN) : "");   // the rows beyond the wait's counted too, by kind, the kept subset after (round three, low 3)
     }
   } else {
     // WORKING (or idle with nothing awaited — a service the session keeps around): the same rows, worded

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -312,7 +312,7 @@ type PeerIdent = { name: string; host?: string; sid?: string; color?: { bg: stri
 // which billing sides this box can bill, and why not for the other (kernel _auth_avail, 2026-09-08): the
 // Billing submenu lists both and greys the unavailable one with the reason in its hover
 interface AuthAvail { login?: boolean; key?: boolean; loginWhy?: string; keyWhy?: string; acct?: string; default?: string; defaultExplicit?: boolean }   // defaultExplicit: set in the Billing flyout's Default group, else the helper rule (T380)
-interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "sdk" | "codex"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
+interface Status { state: ChipState; sinceEpoch: number | null; awaitingWhy?: string | null; awaitingKind?: string | null; awaitingPeers?: PeerIdent[] | null; awaitingTasks?: string[]; awaitingTaskIds?: string[]; bgServiceIds?: string[]; awaitingCount?: number | null; awaitingItems?: AwaitRow[]; effort?: string; model?: string; modelPending?: boolean; effortPending?: boolean; mode?: string; fast?: string; auth?: string; authLive?: string; authPending?: boolean; authBoth?: boolean; authAvail?: AuthAvail; authPickUnavailable?: string; authPickFell?: string; authAcct?: string; ctx?: string; ctxOver?: boolean; ctxColor?: number[]; modelColor?: number[]; effortColor?: number[]; modelTone?: number[]; effortTone?: number[]; ctxTone?: number[]; faded?: boolean; backend?: string; apiTooLong?: boolean; apiSpendLimit?: boolean; apiModelLimit?: boolean; apiAuthErr?: boolean; apiRefusal?: boolean; retrySuppressed?: boolean; retryNextAt?: number | null; retryTries?: number | null; }   // awaitingWhy/awaitingTasks = what an awaitingBg session is waiting on (kernel _session_awaiting's phrasing + the live awaited task descriptions) — the #bg-tasks box renders it as the header of the in-flight rows (renderBgTasks; the user 2026-08-13, who moved it out of the statusline the same day PR #350 put it there)   // retrySuppressed = the user interrupted this thread's API-error storm → romp's auto-retry stays OFF for it until a successful turn re-arms (the user 2026-07-06). backend = "sdk" | "codex"; apiTooLong = the "blocked" is a "prompt is too long" error (on you → red tab) vs a transient API error (amber/retrying); apiSpendLimit = a monthly spend cap (on you → raise it; NEVER auto-retried — retrying can't fix it, the user 2026-07-14); apiModelLimit = this session's MODEL is out of allowance (on you → switch model or add credits; not auto-retried either, the user 2026-08-01); apiRefusal = the model's safeguards refused the prompt itself (on you → rewrite it or drop the thread; never auto-retried — a refusal is deterministic on the same input, so a retry just manufactures the same refusal, the user 2026-08-15); ctxColor = the GLOBAL colormap's RGB for the context%, computed server-side; modelColor/effortColor = the same map's RGB tint for the model name + effort (by capability/effort rank), server-computed; modelPending = a /model switch is resolving → the badge shows switching-dots until the new name lands (server-driven, event-based, the user 2026-07-03); fast = the CLI's fast-mode state ("on"/"off"/"cooldown", from the SDK init's fast_mode_state; absent = unknown/unavailable → no fast badge)
 
 // The side a pick this box cannot bill actually fell to ("login" | "key"), "" when nothing did: the kernel's
 // authPickFell (the launch's own decision, 2026-09-09). An older kernel without the field is read the way the
@@ -13874,13 +13874,19 @@ function renderBgTasks() {
   // (awaitingTaskIds — an exact launch-id match; the ids' PRESENCE, never the chip state); the status DOT
   // keeps its own meaning (yellow = the row is running)
   const awaited = new Set<string>(s.status.awaitingTaskIds || []);
+  // the JUDGE's verdict on the tracked tasks, shipped (kernel _bg_split's services, bgServiceIds, in every turn state): a task
+  // the closer audited past its launch without a wait is furniture the session keeps running. Only that verdict earns the
+  // kept-running word (T394 round one: inferring it from a missing row called a placed task under a stamped top, and every
+  // agent, kept running mid-turn, when the kernel simply enumerates no rows for them then)
+  const services = new Set<string>(s.status.bgServiceIds || []);
   host.classList.toggle("bg-awaited", !!why || tasks.some((t) => awaited.has(t.id)));
   const open = openFolds.has("bgfold:" + sid);
   const groups = groupRows(items);
   const awPeers = s.status.awaitingPeers || [];
   const itemIds = rowIds(items);   // the rows AND what nests under them (an agent's own waits name their tasks too)
   const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
-  const kept = leftovers.map((t) => taskRowSpec(t, awaited.has(t.id)));   // …as rows of their KIND, dimmed, the verdict as a suffix (T394)
+  const kept = leftovers.map((t) => taskRowSpec(t, awaited.has(t.id), services.has(t.id)));   // …as rows of their KIND (T394): the judge's services dimmed, the verdict as a suffix
+  const keptN = kept.filter((row) => row.kept).length;   // the header counts the rows that WEAR the verdict, none other (round one, medium 1)
   // the header dot: await-green while waiting, like the chip; otherwise the worst tracked status, so a
   // failed task is glanceable while collapsed (running-yellow when nothing tracked has failed)
   const worst = tasks.reduce((w, t) => (BG_RANK[t.status] || 0) > (BG_RANK[w] || 0) ? t.status : w, "running");
@@ -13907,17 +13913,17 @@ function renderBgTasks() {
         lab.appendChild(nm);
       });
       lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
-      if (kept.length) lab.append(" · " + keptWord(kept.length));
+      if (keptN) lab.append(" · " + keptWord(keptN));
     } else if (groups.length > 1) {
-      lab.textContent = "Awaiting " + word + " · " + listBreakdown(items, kept.length);   // mixed kinds: the number, then the breakdown, then the kept rows
+      lab.textContent = "Awaiting " + word + " · " + listBreakdown(items, keptN);   // mixed kinds: the number, then the breakdown, then the kept rows
     } else {
-      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "") + (kept.length ? " · " + keptWord(kept.length) : "");
+      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "") + (keptN ? " · " + keptWord(keptN) : "");
     }
   } else {
     // WORKING (or idle with nothing awaited — a service the session keeps around): the same rows, worded
     // as what they are, no idle note. The header counts every row the list shows (T394): the in-flight rows by
     // kind, then the tracked tasks the kernel names no row for, apart, as the kept-running rows they are.
-    lab.textContent = "In the background · " + listBreakdown(items, kept.length);
+    lab.textContent = "In the background · " + listBreakdown(items, keptN);
   }
   head.appendChild(lab);
   host.appendChild(head);
@@ -13997,15 +14003,17 @@ interface BgRowSpec {
   output?: string | null;     // the fold: a command's output tail (never an agent's — its output file IS the transcript; the arrow is the way in)
   peer?: PeerIdent | null;    // a peer row: the name in identity colour
   kind?: string | null;       // the row's kind (agents | commands | watches | peer | timer): its section, and the hue of its dot and caption (T394)
-  kept?: boolean;             // a tracked task nobody waits on (the judge audited its launch without a wait): dimmed, the verdict as a muted suffix (T394)
+  kept?: boolean;             // a tracked task the judge called a service (kernel bgServiceIds: audited past its launch without a wait), still running: dimmed, the verdict as a muted suffix (T394)
   sub?: "first" | "rest" | null;   // a NESTED row — what the agent above it waits on (2026-09-10): indented; "first" wears the "waiting on" label, "rest" its blank twin so the dots align
   deeper?: string | null;     // a nested row that has waits of its own: their count, said in the label ("waiting on 1 command") — the box draws one level
 }
 
-function taskRowSpec(t: BgTask, awaited: boolean): BgRowSpec {
+function taskRowSpec(t: BgTask, awaited: boolean, service: boolean): BgRowSpec {
   const status = t.status || "running";
+  // its kind's section; the kept-running word only on a task the judge called a service (the kernel's verdict, never inferred
+  // from a missing row) and only while it runs: a completed or failed task is finished, not kept (round one, medium 2 and low 1)
   return { id: t.id, status, caption: status, label: t.summary || "Background task", awaited,
-           kind: t.agentId ? "agents" : "commands", kept: !awaited,   // its kind's section; kept running unless the kernel names it awaited (T394)
+           kind: t.agentId ? "agents" : "commands", kept: service && status === "running",
            agentId: t.agentId || null, stopId: status === "running" ? t.id : null,
            command: t.command || null, output: t.agentId ? null : (t.output || "(no output captured)") };
 }

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -13887,9 +13887,14 @@ function renderBgTasks() {
   const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
   const kept = leftovers.map((t) => taskRowSpec(t, awaited.has(t.id), services.has(t.id)));   // …as rows of their KIND (T394): the judge's services dimmed, the verdict as a suffix
   const keptN = kept.filter((row) => row.kept).length;   // the header counts the rows that WEAR the verdict, none other (round one, medium 1)
+  // every row the list shows, by kind (round two, medium): the kernel's rows AND the tracked tasks they do not name, so a box
+  // whose only row is a placed command or a finished one reads "In the background · 1 command", never a separator with nothing after it
+  const counted: AwaitRow[] = [...items, ...kept.map((row) => ({ kind: row.kind || "commands", id: row.id, label: row.label }))];
   // the header dot: await-green while waiting, like the chip; otherwise the worst tracked status, so a
   // failed task is glanceable while collapsed (running-yellow when nothing tracked has failed)
-  const worst = tasks.reduce((w, t) => (BG_RANK[t.status] || 0) > (BG_RANK[w] || 0) ? t.status : w, "running");
+  // seeded from the tasks' own statuses (round two, low 2): seeded "running", a completed-only box wore the running gold and
+  // the header's completed tint matched nothing
+  const worst = tasks.reduce((w, t) => (BG_RANK[t.status] || 0) > (BG_RANK[w] || 0) ? t.status : w, tasks.length ? (tasks[0].status || "running") : "running");
   const head = el("div", "bg-fold-head " + (why ? "bg-await" : "bg-" + worst) + (open ? " open" : ""));
   head.dataset.act = "bg-fold"; head.dataset.id = sid;
   const car = el("span", "bg-caret"); car.textContent = open ? "▾" : "▸"; head.appendChild(car);   // ▸ closed → ▾ open (expands DOWNWARD beneath the header)
@@ -13913,9 +13918,9 @@ function renderBgTasks() {
         lab.appendChild(nm);
       });
       lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
-      if (keptN) lab.append(" · " + keptWord(keptN));
+      if (kept.length) lab.append(" · " + listBreakdown(kept.map((row) => ({ kind: row.kind || "commands", id: row.id, label: row.label })), keptN));   // the tracked rows below, counted (round two)
     } else if (groups.length > 1) {
-      lab.textContent = "Awaiting " + word + " · " + listBreakdown(items, keptN);   // mixed kinds: the number, then the breakdown, then the kept rows
+      lab.textContent = "Awaiting " + word + " · " + listBreakdown(counted, keptN);   // mixed kinds: the number, then every listed row by kind, then the kept rows
     } else {
       lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "") + (keptN ? " · " + keptWord(keptN) : "");
     }
@@ -13923,7 +13928,7 @@ function renderBgTasks() {
     // WORKING (or idle with nothing awaited — a service the session keeps around): the same rows, worded
     // as what they are, no idle note. The header counts every row the list shows (T394): the in-flight rows by
     // kind, then the tracked tasks the kernel names no row for, apart, as the kept-running rows they are.
-    lab.textContent = "In the background · " + listBreakdown(items, keptN);
+    lab.textContent = "In the background · " + listBreakdown(counted, keptN);
   }
   head.appendChild(lab);
   host.appendChild(head);
@@ -17187,7 +17192,7 @@ function awaitChanged(sid: string): void {
 function awaitKey(st: Status | undefined): string {
   if (!st) return "";
   return JSON.stringify([st.state, st.awaitingWhy || "", st.awaitingKind || "", st.awaitingCount ?? null,
-                         st.awaitingTasks || [], st.awaitingTaskIds || [], st.awaitingItems || [],
+                         st.awaitingTasks || [], st.awaitingTaskIds || [], st.bgServiceIds || [], st.awaitingItems || [],   // the verdict repaints the box (round two, low 1)
                          (st.awaitingPeers || []).map((p) => [p.host || "", p.name || ""])]);
 }
 

--- a/ui/webview/render.ts
+++ b/ui/webview/render.ts
@@ -37,7 +37,7 @@ import { loadSettings, onExternalSettingsChange, installSettingsSync, type RompS
 import { backendLabel, effectiveDefaultBackend } from "./backend-names";
 import { delegate } from "./actions";
 import { flash } from "./actions";   // its own line: the import above is pinned verbatim by click-safe.test.ts (the file-view precedent)
-import { awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, GROUP_TITLE, workingFor, type AwaitRow } from "./spin-caption";
+import { awaitWord, awaitBreakdown, groupRows, rowIds, waitsNote, listBreakdown, keptWord, GROUP_TITLE, ROW_KINDS, workingFor, type AwaitRow } from "./spin-caption";
 import { CHIP_LABEL, chipWords, statusChip, type ChipState } from "./status-chip";   // the session status chip: its words and its classes, the one builder the bar and the tag overview's rows share (T322b)
 import { isClearCmd, openTopTitles, clearConfirmDetail, endConfirmDetail } from "./clear-confirm";
 import { prebuildPlan, type ViewState } from "./prebuild";
@@ -13671,7 +13671,13 @@ function renderLedger() {
 // the box's fold + each row's detail fold key into openFolds ("bgfold:<sid>" / "bgrow:<id>") — the ONE fold
 // store since 2026-09-08 (these had their own bgFoldOpen / bgExpanded sets)
 const BG_RANK: Record<string, number> = { failed: 3, running: 2, completed: 1 };
-const BG_LEFTOVER_TITLE = "Also running";   // tracked tasks the wait does not name (a dev server the session keeps around)
+// T394 (the user 2026-09-12, from a screenshot of the fold with a section for tasks merely also running): a tracked task the kernel's rows do
+// not name is still a command or an agent, and what set it apart was a JUDGE'S VERDICT (the closer audited its launch without a
+// wait), not a kind. So it lists in its kind's section, dimmed, with the verdict as a muted suffix on the row (kept running, not
+// waited on), and the header counts it apart from the awaited breakdown; the section of its own, whose title said nothing of
+// that, is gone. One hue per kind for the dot and the caption word (the sheet: bg-kind-*), status overriding for failed and
+// completed rows.
+const BG_KEPT_WORD = "· kept running, not waited on";
 // ── SUBAGENT VIEWER (plans/subagent-transcripts.md, 2026-09-05) ─────────────────────────────────
 // The arrow on an Agent head (or an agent bg-task row) opens the agent's whole transcript as a PEEK tab:
 // a client-only pseudo-session in `sessions`/`order` with id `<parentId>/agent/<agentId>`, fed by the
@@ -13874,6 +13880,7 @@ function renderBgTasks() {
   const awPeers = s.status.awaitingPeers || [];
   const itemIds = rowIds(items);   // the rows AND what nests under them (an agent's own waits name their tasks too)
   const leftovers = tasks.filter((t) => !itemIds.has(t.id));   // tracked tasks the wait does not name (services)
+  const kept = leftovers.map((t) => taskRowSpec(t, awaited.has(t.id)));   // …as rows of their KIND, dimmed, the verdict as a suffix (T394)
   // the header dot: await-green while waiting, like the chip; otherwise the worst tracked status, so a
   // failed task is glanceable while collapsed (running-yellow when nothing tracked has failed)
   const worst = tasks.reduce((w, t) => (BG_RANK[t.status] || 0) > (BG_RANK[w] || 0) ? t.status : w, "running");
@@ -13900,17 +13907,17 @@ function renderBgTasks() {
         lab.appendChild(nm);
       });
       lab.append(" · " + why.replace(/^delegated to [^;]*;\s*/i, "").replace(/^(waiting on|awaiting)\s+/i, ""));
+      if (kept.length) lab.append(" · " + keptWord(kept.length));
     } else if (groups.length > 1) {
-      lab.textContent = "Awaiting " + word + " · " + awaitBreakdown(items);   // mixed kinds: the number, then the breakdown
+      lab.textContent = "Awaiting " + word + " · " + listBreakdown(items, kept.length);   // mixed kinds: the number, then the breakdown, then the kept rows
     } else {
-      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "");
+      lab.textContent = "Awaiting" + (word ? " " + word : "") + " · " + why.replace(/^(waiting on|awaiting)\s+/i, "") + (kept.length ? " · " + keptWord(kept.length) : "");
     }
   } else {
     // WORKING (or idle with nothing awaited — a service the session keeps around): the same rows, worded
-    // as what they are, no idle note. The breakdown counts the in-flight rows, or the tracked tasks when
-    // the kernel names none (they are shell tasks by construction — _bg_split never makes an agent a service).
-    const counted: AwaitRow[] = items.length ? items : leftovers.map((t) => ({ kind: "commands", id: t.id, label: t.summary }));
-    lab.textContent = "In the background · " + awaitBreakdown(counted);
+    // as what they are, no idle note. The header counts every row the list shows (T394): the in-flight rows by
+    // kind, then the tracked tasks the kernel names no row for, apart, as the kept-running rows they are.
+    lab.textContent = "In the background · " + listBreakdown(items, kept.length);
   }
   head.appendChild(lab);
   host.appendChild(head);
@@ -13931,9 +13938,13 @@ function renderBgTasks() {
   }
   const taskById = new Map<string, BgTask>(tasks.map((t) => [t.id, t]));
   const peerByName = new Map<string, PeerIdent>(awPeers.map((p) => [p.name, p]));
-  const headers = groups.length + (leftovers.length ? 1 : 0) >= 2;   // group headers only when there is more than one group to tell apart
+  // the sections, one per KIND in display order: a kind the kernel's rows bring, or one only a kept row brings (T394)
+  const sections: { kind: string; rows: AwaitRow[] }[] = [...ROW_KINDS, "other"]
+    .filter((k) => groups.some((g) => g.kind === k) || kept.some((row) => row.kind === k))
+    .map((k) => ({ kind: k, rows: (groups.find((g) => g.kind === k) || { rows: [] as AwaitRow[] }).rows }));
+  const headers = sections.length >= 2;   // group headers only when there is more than one group to tell apart
   const list = el("div", "bg-list");
-  for (const g of groups) {
+  for (const g of sections) {
     if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = GROUP_TITLE[g.kind] || "Other"; list.appendChild(gh); }
     for (const it of g.rows) {
       list.appendChild(bgRow(awaitRowSpec(it, taskById.get(it.id || ""), peerByName), sid));
@@ -13950,10 +13961,7 @@ function renderBgTasks() {
         list.appendChild(bgRow(spec, sid));
       });
     }
-  }
-  if (leftovers.length) {
-    if (headers) { const gh = el("div", "bg-group-head"); gh.textContent = BG_LEFTOVER_TITLE; list.appendChild(gh); }
-    for (const t of leftovers) list.appendChild(bgRow(taskRowSpec(t, awaited.has(t.id)), sid));
+    for (const row of kept) if (row.kind === g.kind) list.appendChild(bgRow(row, sid));   // the kept rows of this kind, after the awaited ones
   }
   // the plain-words note on what the state means — for the idle wait only, where the state is not obvious
   // from the header; "In the background" says all a working session needs (2026-09-06)
@@ -13988,6 +13996,8 @@ interface BgRowSpec {
   command?: string | null;    // the fold: an agent's prompt, a command's command line, a watch's predicate
   output?: string | null;     // the fold: a command's output tail (never an agent's — its output file IS the transcript; the arrow is the way in)
   peer?: PeerIdent | null;    // a peer row: the name in identity colour
+  kind?: string | null;       // the row's kind (agents | commands | watches | peer | timer): its section, and the hue of its dot and caption (T394)
+  kept?: boolean;             // a tracked task nobody waits on (the judge audited its launch without a wait): dimmed, the verdict as a muted suffix (T394)
   sub?: "first" | "rest" | null;   // a NESTED row — what the agent above it waits on (2026-09-10): indented; "first" wears the "waiting on" label, "rest" its blank twin so the dots align
   deeper?: string | null;     // a nested row that has waits of its own: their count, said in the label ("waiting on 1 command") — the box draws one level
 }
@@ -13995,6 +14005,7 @@ interface BgRowSpec {
 function taskRowSpec(t: BgTask, awaited: boolean): BgRowSpec {
   const status = t.status || "running";
   return { id: t.id, status, caption: status, label: t.summary || "Background task", awaited,
+           kind: t.agentId ? "agents" : "commands", kept: !awaited,   // its kind's section; kept running unless the kernel names it awaited (T394)
            agentId: t.agentId || null, stopId: status === "running" ? t.id : null,
            command: t.command || null, output: t.agentId ? null : (t.output || "(no output captured)") };
 }
@@ -14010,30 +14021,31 @@ function awaitRowSpec(it: AwaitRow, tracked: BgTask | undefined, peerByName: Map
   // the nested rows would have no Stop at all.
   const stopId = running ? tracked!.id : (it.stoppable && id ? id : null);
   if (it.kind === "agents") {
-    return { id, status: "running", caption: "running", label: it.label || (tracked && tracked.summary) || "background agent",
+    return { id, status: "running", caption: "running", kind: "agents", label: it.label || (tracked && tracked.summary) || "background agent",
              agentId: it.agentId || (tracked && tracked.agentId) || null, since: it.since,
              stopId, command: (tracked && tracked.command) || null, output: null };
   }
   if (it.kind === "commands") {
     const status = (tracked && tracked.status) || "running";
-    return { id, status, caption: status, label: it.label || (tracked && tracked.summary) || "background command", since: it.since,
+    return { id, status, caption: status, kind: "commands", label: it.label || (tracked && tracked.summary) || "background command", since: it.since,
              stopId, command: (tracked && tracked.command) || null,
              output: tracked ? (tracked.output || "(no output captured)") : null };
   }
   if (it.kind === "watches") {
-    return { id, status: "armed", caption: "armed", label: it.label || "a watch", since: it.since,
+    return { id, status: "armed", caption: "armed", kind: "watches", label: it.label || "a watch", since: it.since,
              watchId: it.watchId || null, command: it.detail || null };
   }
   if (it.kind === "peer") {
-    return { id, status: "waiting", label: it.label || "a peer", peer: peerByName.get(it.label || "") || null };
+    return { id, status: "waiting", kind: "peer", label: it.label || "a peer", peer: peerByName.get(it.label || "") || null };
   }
-  return { id, status: "waiting", caption: it.kind === "timer" ? "timer" : null, label: it.label || it.kind, since: it.since };
+  return { id, status: "waiting", caption: it.kind === "timer" ? "timer" : null, kind: it.kind, label: it.label || it.kind, since: it.since };
 }
 
 function bgRow(t: BgRowSpec, sid: string): HTMLElement {
   const tOpen = openFolds.has("bgrow:" + t.id);
   const foldable = !!(t.command || t.output);
-  const row = el("div", "bg-task bg-" + (t.status || "running") + (t.awaited ? " bg-awaited" : "") + (t.sub ? " bg-sub" : "") + (tOpen && foldable ? " open" : ""));
+  const row = el("div", "bg-task bg-" + (t.status || "running") + (t.kind ? " bg-kind-" + t.kind : "") + (t.kept ? " bg-kept" : "")
+                     + (t.awaited ? " bg-awaited" : "") + (t.sub ? " bg-sub" : "") + (tOpen && foldable ? " open" : ""));
   const rh = el("div", "bg-head" + (foldable ? "" : " bg-flat"));
   if (foldable) { rh.dataset.act = "bg-toggle"; rh.dataset.id = t.id; }   // the row header toggles; clicks in the detail body don't collapse it
   if (t.sub) {
@@ -14051,6 +14063,7 @@ function bgRow(t: BgRowSpec, sid: string): HTMLElement {
     if (t.peer.color && t.peer.color.bg) sum.style.color = t.peer.color.bg;
   } else sum.textContent = t.label || "Background task";
   rh.appendChild(sum);
+  if (t.kept) { const kw = el("span", "bg-kept-word"); kw.textContent = BG_KEPT_WORD; rh.appendChild(kw); }   // the judge's verdict, muted, beside the label (T394)
   if (t.deeper) {
     // the level the box does not draw, counted in words (the meta rung, like the elapsed time)
     const dp = el("span", "bg-deeper"); dp.textContent = "· waiting on " + t.deeper; rh.appendChild(dp);

--- a/ui/webview/spin-caption.ts
+++ b/ui/webview/spin-caption.ts
@@ -154,6 +154,18 @@ export function awaitBreakdown(items: readonly AwaitRow[] | null | undefined): s
   return groupRows(items).map((g) => g.rows.length + " " + rowWord(g.kind, g.rows.length)).join(" · ");
 }
 
+/** The header's words for the tracked tasks the kernel's rows do not name (T394, the user 2026-09-12): the judge audited
+ *  their launch without a wait, so nobody waits on them; they list in their kind's section, dimmed, and the header counts
+ *  them apart from the awaited breakdown ("1 kept running"), so it agrees with the list. "" when there are none. */
+export function keptWord(n: number): string {
+  return n > 0 ? n + " kept running" : "";
+}
+
+/** The whole list in the header's words: the awaited breakdown, then the kept count; either alone when the other is empty. */
+export function listBreakdown(items: readonly AwaitRow[] | null | undefined, kept: number): string {
+  return [awaitBreakdown(items), keptWord(kept)].filter(Boolean).join(" · ");
+}
+
 // ── nested waits (2026-09-10): what an awaited agent is in turn waiting on ────────────────────────────
 /** Every row beneath these, depth-first: a row's waits, their waits, and so on. */
 export function flattenWaits(items: readonly AwaitRow[] | null | undefined): AwaitRow[] {

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -108,6 +108,8 @@ body.scheme-solarized-dark {
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
      their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
   --accent: #9cd2ff; --accent-fg: #0c1a2e;
+  --kind-command: var(--accent);   /* a command row's hue in the background box (T394): the accent blue the timeline lane icons wear;
+                                      the light block sets its own, its accent being the burnt orange that would read as an error */
   /* THE faint accent wash — the one alpha behind every selected/hovered accent chrome (0.10 and 0.14
      variants drifted in before 2026-08-26). Mirrored in feed.css (own :root). */
   --accent-wash: rgba(156, 210, 255, 0.12);
@@ -252,6 +254,7 @@ body.theme-light {
                                                        a cool one's distance from the ground (T337c, the review of 2026-09-11) */
   --err: #B02A1C;
   --accent: #C2410C; --accent-fg: #FFF8F2;
+  --kind-command: #356890;   /* the dark accent's hue and chroma at OKLCH lightness 0.50 (T394): 4.67:1 as text on the cream box */
   --accent-wash: rgba(194, 65, 12, 0.10);
   --chip-wash: rgba(0, 0, 0, 0.07);   /* a hovered tag chip's ground (T343): on a light card the visible step is darker, and it stays distinct from the card's surface */
   --chip-sel-filter: brightness(0.75);   /* a SELECTED tag chip's strongest level on cream is DARKER (T343 review): brightness(1.3) here paled every selected chip below its faded neighbour; 0.75 lifts each tag's contrast above its rest value */
@@ -992,8 +995,15 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .bg-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; overscroll-behavior: contain;
   display: flex; flex-direction: column; padding: 4px 2px; }
 .bg-task { --bgt: var(--st-working-bg); }
+/* ONE HUE PER KIND (T394, the user 2026-09-12: the kinds could not be told apart, and orange reads as an error): agents keep the
+   working gold, watches the awaiting green, commands take the accent blue (--kind-command, per theme). The row's status still
+   overrides where it means something, in the rules that follow: a failed row's dot is the blocked red, a completed row's the
+   dim ink (the ready blue it wore would collide with the command hue). */
+.bg-task.bg-kind-agents { --bgt: var(--st-working-bg); }
+.bg-task.bg-kind-commands { --bgt: var(--kind-command); }
+.bg-task.bg-kind-watches { --bgt: var(--st-awaitbg-bg); }
 .bg-task.bg-failed { --bgt: var(--st-blocked-bg); }
-.bg-task.bg-completed { --bgt: var(--st-ready-bg); }
+.bg-task.bg-completed { --bgt: var(--dim); }
 /* an armed watch / a peer or timer wait: nothing is computing HERE — the dot wears the await-green (slice 2) */
 .bg-task.bg-armed, .bg-task.bg-waiting { --bgt: var(--st-awaitbg-bg); }
 /* the rows grouped by KIND (slice 2, 2026-09-05): a small dim header per group, in the .bg-status
@@ -1022,6 +1032,14 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
    never push them off-screen; no spacer, no margin-left:auto, no space-between. */
 .bg-sum { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.92em; color: var(--fg); }
 .bg-status { flex: 0 0 auto; font-size: 0.72em; text-transform: uppercase; letter-spacing: .06em; font-weight: 600; color: var(--bgt); }
+/* on cream the kind hues fail as TEXT (the gold 4.0:1, the green 2.1:1 on the box), so the caption word is the hue deepened to
+   OKLCH lightness 0.46, the postal head's rule (T390): gold 5.6:1, green 5.2:1, blue 5.6:1; the dot keeps the full hue (T394) */
+body.theme-light .bg-status { color: oklch(from var(--bgt) 0.46 c h); }
+/* a KEPT row (T394): a tracked task nobody waits on, the judge's verdict as a muted suffix beside a dimmed label and dot; the
+   caption word keeps its hue, and nothing dims by element opacity (that would take every caption under 4.5:1) */
+.bg-task.bg-kept .bg-dot { opacity: .55; }
+.bg-task.bg-kept .bg-sum { color: var(--dim); }
+.bg-kept-word { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); white-space: nowrap; }
 .bg-caret { flex: 0 0 auto; color: var(--dim); font-size: 0.72em; width: 10px; opacity: 0.7; }
 /* level 3: a task's command + output, each its own scrollable block, indented under the line (overscroll-
    contain so the wheel scrolls the body, not the chat behind it — the "expanded view won't scroll" fix) */

--- a/ui/webview/styles.css
+++ b/ui/webview/styles.css
@@ -106,7 +106,9 @@ body.scheme-solarized-dark {
                                                        (postal-wash.ts), since --bg is host-derived in the webview (T337c) */
   /* THE romp accent — light blue (the user 2026-06-24). Use var(--accent) for accent/highlight chrome
      (selected toggles, in-progress loading dots, the Fleet pill, focus) — NOT for STATUS colors, which keep
-     their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it. */
+     their own meaning (--st-working-bg yellow = working, --st-blocked-bg red, etc.). --accent-fg reads on it.
+     ONE exception (the user 2026-09-12, T394): the background box's command rows wear it as their KIND hue
+     (--kind-command, below), a kind and not a status; the status still overrides it for failed and completed rows. */
   --accent: #9cd2ff; --accent-fg: #0c1a2e;
   --kind-command: var(--accent);   /* a command row's hue in the background box (T394): the accent blue the timeline lane icons wear;
                                       the light block sets its own, its accent being the burnt orange that would read as an error */
@@ -988,7 +990,7 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 .bg-stop:hover { border-color: var(--accent); color: var(--accent); background: var(--accent-wash); }
 .bg-stop:disabled { opacity: 0.55; cursor: default; }
 .bg-fold-head.bg-failed { --bgt: var(--st-blocked-bg); }
-.bg-fold-head.bg-completed { --bgt: var(--st-ready-bg); }
+.bg-fold-head.bg-completed { --bgt: var(--dim); }   /* the header's completed tint follows the rows (T394): the ready blue would sit beside the command blue */
 .bg-fold-head.bg-await { --bgt: var(--st-awaitbg-bg); }   /* the Awaiting why header — await-green, like its chip */
 .bg-fold-label { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg); }
 /* level 2: a flat list of task LINES (no boxes) BELOW the header, fills the box and scrolls when many */
@@ -1035,9 +1037,11 @@ body.chat-theme-yatharth .tab.active.colored:not(.tab-blocked) {
 /* on cream the kind hues fail as TEXT (the gold 4.0:1, the green 2.1:1 on the box), so the caption word is the hue deepened to
    OKLCH lightness 0.46, the postal head's rule (T390): gold 5.6:1, green 5.2:1, blue 5.6:1; the dot keeps the full hue (T394) */
 body.theme-light .bg-status { color: oklch(from var(--bgt) 0.46 c h); }
-/* a KEPT row (T394): a tracked task nobody waits on, the judge's verdict as a muted suffix beside a dimmed label and dot; the
-   caption word keeps its hue, and nothing dims by element opacity (that would take every caption under 4.5:1) */
-.bg-task.bg-kept .bg-dot { opacity: .55; }
+/* a KEPT row (T394): a tracked task the judge called a service (kernel bgServiceIds), the verdict as a muted suffix beside a
+   dimmed label and dot; the caption word keeps its hue, and nothing dims by element opacity (a 55 percent dot read 2.0:1 on
+   cream). The dot is the kind hue greyed toward the dim ink, a colour: at this share every hue reads 3:1 or better on the box
+   in both themes (measured 2026-09-12: gold 6.3 dark, 4.9 cream; green 5.4, 3.6; blue 7.1, 5.2) */
+.bg-task.bg-kept .bg-dot { background: color-mix(in srgb, var(--bgt) 45%, var(--dim)); }
 .bg-task.bg-kept .bg-sum { color: var(--dim); }
 .bg-kept-word { flex: 0 0 auto; font-size: 0.82em; color: var(--dim); white-space: nowrap; }
 .bg-caret { flex: 0 0 auto; color: var(--dim); font-size: 0.72em; width: 10px; opacity: 0.7; }

--- a/vscode-extension/src/bg-tasks.test.ts
+++ b/vscode-extension/src/bg-tasks.test.ts
@@ -23,8 +23,8 @@ test("the header is ONE line worded from the rows — 'Awaiting …' idle, 'In t
   // presentations at each turn boundary; one renderer now words the header from the same rows in both states
   assert.doesNotMatch(SRC, /count \+ " background tasks"/);
   assert.doesNotMatch(SRC, /"Background task · "/);
-  assert.match(SRC, /lab\.textContent = "In the background · " \+ awaitBreakdown\(counted\);/);
-  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ awaitBreakdown\(items\);/);
+  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(items, kept\.length\);/);   // every row the list shows, the kept rows counted apart (T394)
+  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/);
   // collapsed by default: when the fold isn't open, only the header renders
   assert.match(SRC, /const open = openFolds\.has\("bgfold:" \+ sid\);/);   // the ONE fold store since 2026-09-08 (was bgFoldOpen)
   assert.match(SRC, /if \(!open\) return;/);
@@ -74,5 +74,5 @@ test("expanded list is capped (never crowds the composer) and scrolls; tasks are
 test("status tints keep their meaning (running yellow, failed red, completed blue — not the accent)", () => {
   assert.match(CSS, /\.bg-task \{ --bgt: var\(--st-working-bg\)/);
   assert.match(CSS, /\.bg-task\.bg-failed \{ --bgt: var\(--st-blocked-bg\); \}/);
-  assert.match(CSS, /\.bg-task\.bg-completed \{ --bgt: var\(--st-ready-bg\); \}/);
+  assert.match(CSS, /\.bg-task\.bg-completed \{ --bgt: var\(--dim\); \}/);   // T394: the dim ink, since the ready blue would collide with the command hue
 });

--- a/vscode-extension/src/bg-tasks.test.ts
+++ b/vscode-extension/src/bg-tasks.test.ts
@@ -23,8 +23,8 @@ test("the header is ONE line worded from the rows — 'Awaiting …' idle, 'In t
   // presentations at each turn boundary; one renderer now words the header from the same rows in both states
   assert.doesNotMatch(SRC, /count \+ " background tasks"/);
   assert.doesNotMatch(SRC, /"Background task · "/);
-  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(items, keptN\);/);   // every row the list shows, the kept rows counted apart (T394)
-  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/);
+  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(counted, keptN\);/);   // every row the list shows, the kept rows counted apart (T394)
+  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(counted, keptN\);/);
   // collapsed by default: when the fold isn't open, only the header renders
   assert.match(SRC, /const open = openFolds\.has\("bgfold:" \+ sid\);/);   // the ONE fold store since 2026-09-08 (was bgFoldOpen)
   assert.match(SRC, /if \(!open\) return;/);

--- a/vscode-extension/src/bg-tasks.test.ts
+++ b/vscode-extension/src/bg-tasks.test.ts
@@ -23,8 +23,8 @@ test("the header is ONE line worded from the rows — 'Awaiting …' idle, 'In t
   // presentations at each turn boundary; one renderer now words the header from the same rows in both states
   assert.doesNotMatch(SRC, /count \+ " background tasks"/);
   assert.doesNotMatch(SRC, /"Background task · "/);
-  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(items, kept\.length\);/);   // every row the list shows, the kept rows counted apart (T394)
-  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, kept\.length\);/);
+  assert.match(SRC, /lab\.textContent = "In the background · " \+ listBreakdown\(items, keptN\);/);   // every row the list shows, the kept rows counted apart (T394)
+  assert.match(SRC, /lab\.textContent = "Awaiting " \+ word \+ " · " \+ listBreakdown\(items, keptN\);/);
   // collapsed by default: when the fold isn't open, only the header renders
   assert.match(SRC, /const open = openFolds\.has\("bgfold:" \+ sid\);/);   // the ONE fold store since 2026-09-08 (was bgFoldOpen)
   assert.match(SRC, /if \(!open\) return;/);
@@ -71,7 +71,7 @@ test("expanded list is capped (never crowds the composer) and scrolls; tasks are
   assert.doesNotMatch(taskRule, /border|background/);
 });
 
-test("status tints keep their meaning (running yellow, failed red, completed blue — not the accent)", () => {
+test("status tints keep their meaning (running yellow, failed red, completed the dim ink); the command kind alone wears the accent blue (T394)", () => {
   assert.match(CSS, /\.bg-task \{ --bgt: var\(--st-working-bg\)/);
   assert.match(CSS, /\.bg-task\.bg-failed \{ --bgt: var\(--st-blocked-bg\); \}/);
   assert.match(CSS, /\.bg-task\.bg-completed \{ --bgt: var\(--dim\); \}/);   // T394: the dim ink, since the ready blue would collide with the command hue


### PR DESCRIPTION
**Fix (T394).** The chat's background box had an "Also running" section whose title said nothing of why its rows were there, and commands wore the agents' gold.

**Change.** Every row sits in its kind's section (Agents, Commands, Watches). A tracked task the kernel's rows do not name (the judge audited its launch without a wait) lists in its kind's section, dimmed, with "kept running, not waited on" as a muted suffix; the section of its own is gone. One hue per kind for the dot and the caption word: agents the working gold, watches the awaiting green, commands a blue token (`--kind-command`: the accent in the dark theme, `#356890` on cream). Status overrides the hue for failed and completed rows. The header counts every row it lists. On cream the caption word is the hue at OKLCH lightness 0.46, so every caption reads at 4.5:1 or better on the box.

**Tests.** `tests/test_bg_kinds_browser.py` drives the served page with one session frame (an agent, a command, a watch, a service) and reads the sections, the header, the suffix, the controls and every computed colour in both themes; red on upstream/main. `bg-kinds.test.ts` pins the builder, the sheet and the fixture; `keptWord` / `listBreakdown` executed.
