### PR TITLE
The assembly document write accepts a reader entry that grew after the settle's parse, so a continuously active session's leaf gets its document and stops being read whole at every boot (T396)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1557,7 +1557,11 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   `fallbacks` per reason (`version`, `session`, `inputs`, `lineage`, `shrunk`,
   `rewrite`, `guard`, `identity`, `corrupt`, `restore`), `skipped` per reason
   (`noEntry`, `restored`, `written`, `noBoundary`, `unsplittable`,
-  `reconstruction`, `oversize`, `unencodable`, `offsets`, `stat`, `write`),
+  `reconstruction`, `oversize`, `unencodable`, `offsets`, `stat`, `write`;
+  `offsets` is a reader entry holding fewer records than the tree read, or
+  more under another generation: an entry that merely grew since the
+  settle's parse lends the prefix the tree read, so a busy session's
+  document is written between its appends),
   `hydratedAtoms` and `hydratedBytes` (bodies read on demand for atoms before
   a cut), `hydratedBy` (those bytes per calling function), and `converge`: the
   pass's writes of idle leaves' documents from the boot's own parse

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1559,9 +1559,14 @@ The snapshot's fields, all plain numbers (`ms` is milliseconds of wall time):
   (`noEntry`, `restored`, `written`, `noBoundary`, `unsplittable`,
   `reconstruction`, `oversize`, `unencodable`, `offsets`, `stat`, `write`;
   `offsets` is a reader entry holding fewer records than the tree read, or
-  more under another generation: an entry that merely grew since the
-  settle's parse lends the prefix the tree read, so a busy session's
-  document is written between its appends),
+  more for a lineage file or under another generation: a LEAF entry that
+  merely grew since the settle's parse lends the prefix the tree read, so a
+  busy session's document is written between its appends; a lineage file's
+  skip row carries the stat of the records the tree was parsed from, so a
+  record it gained after the parse fails the next boot's check. The standing
+  residual, shared with the reader's grown path: an early record edited in
+  place at equal length plus an append passes the 64-byte guard, like a
+  same-size same-mtime rewrite),
   `hydratedAtoms` and `hydratedBytes` (bodies read on demand for atoms before
   a cut), `hydratedBy` (those bytes per calling function), and `converge`: the
   pass's writes of idle leaves' documents from the boot's own parse

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1595,12 +1595,17 @@ def _scan_jsonl_bytes(data, base_offset, offsets=None):
     return records, base_offset + end + 1
 
 
-def _entry_gen(path):
-    """The reader entry's generation for `path`, None with no entry: what a writer compares its adapter's source key against
-    before trusting the entry's offsets for records the adapter read (T396)."""
+def _entry_offsets_gen(path):
+    """(record offsets from record 0, generation) of the reader's entry for `path` from ONE entry tuple under one lock
+    acquisition, or (None, None) with no entry or a tail entry: what the assembly writer compares its adapter's source
+    key against before trusting the entry's offsets for the records the adapter read (T396 round one, low 2: the
+    _asm_gates pattern, never two reads of the cache that could see two entries)."""
     with _JSONL_CACHE_LOCK:
         ent = _JSONL_CACHE.get(str(path))
-    return ent[6] if ent is not None and len(ent) > 6 else None
+    if ent is None or len(ent) < 8 or ent[5] > 0:
+        return None, None
+    offs = ent[7]
+    return [(offs[i], offs[i + 1]) for i in range(0, len(offs), 2)], ent[6]
 
 
 def record_offsets(path, base):
@@ -2484,6 +2489,8 @@ class FileAdapter:
         # sibling file happens to sort after it
         files = [f for f in candidate_files if Path(f).stem != leaf_stem] + [Path(leaf_path)]
         self._src_keys = {}      # path -> the reader's (gen, base, count) the records came from (the fold's identity gate)
+        self._src_stat = {}      # path -> the (size, mtime) of the file AS READ for those records: the witness a document row
+        #                          carries for a file wholly before the cut, never the write-time stat (T396 round one)
         if seed is not None:
             self._seq = int(seed["seq_base"])
             self.prompt_ids |= seed["prompt_ids"]; self.boundary_pids |= seed["boundary_pids"]
@@ -2498,6 +2505,9 @@ class FileAdapter:
             if cut == "skip":                                   #  a file wholly before the cut (a fork's prior file, immutable)
                 self._src[str(fp)] = []
                 self._src_keys[str(fp)] = ("skip",)
+                st_skip = (seed or {}).get("stat", {}).get(fsid)   # the document's verified witness for it (the load checked it)
+                if st_skip is not None:
+                    self._src_stat[str(fp)] = tuple(st_skip)
                 continue
             if cut is not None:
                 ent = _read_jsonl_entry(fp, tail_ok=True, tail_from=tuple(cut))
@@ -2506,6 +2516,8 @@ class FileAdapter:
             recs = ent[4] if ent is not None else []
             self._src[str(fp)] = recs
             self._src_keys[str(fp)] = (ent[6], ent[5], ent[5] + len(recs)) if ent is not None else (None, 0, 0)
+            if ent is not None:
+                self._src_stat[str(fp)] = (ent[1], ent[0])    # the reader's (size, mtime) for this very read
             if cut is not None and ent is not None and ent[5] < cut[1]:
                 recs = recs[cut[1] - ent[5]:]            # the entry holds records before the cut (a whole reader came
             #                                              first): the seed stands for those, ingest from the cut on
@@ -5164,24 +5176,35 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason
             except OSError:
                 return skip("stat")
             pre_n = max(0, min(len(recs), cut_seq - first_seq[fp]))   # records of this file before the cut
-            offs = record_offsets(fp, 0)
-            # The reader's entry may hold MORE records than the tree's adapter read: a live leaf grows between the settle's
+            is_leaf = Path(fp).stem == Path(leaf_path).stem
+            offs, ent_gen = _entry_offsets_gen(fp)
+            # The reader's entry may hold MORE records than the tree's adapter read: a live LEAF grows between the settle's
             # parse and this write (the CLI appends while the settle runs), and the reader extends its entry by a new list
             # whose prefix is the very records the adapter holds, under the same generation. The document's pre-cut part
-            # is that prefix, so the prefix's offsets stand; a shorter entry, or one under another generation (a rewrite,
-            # a refold from zero), does not (T396: a continuously active 120 MB session never got a document while its
-            # kernel lived, since every settle's write met an entry one record longer than its tree, and every boot read
-            # it whole through whichever reader came first).
+            # is that prefix, so the prefix's offsets stand for the leaf; a shorter entry, or one under another generation
+            # (a rewrite, a refold from zero), does not (T396: a continuously active 120 MB session never got a document
+            # while its kernel lived, since every settle's write met an entry one record longer than its tree, and every
+            # boot read it whole through whichever reader came first). A LINEAGE file longer than the tree still skips
+            # (round one, medium): its row would be a skip row proven by a stat alone, and a prior file that gained a record
+            # after the parse (its own session resumed elsewhere, the case _asm_gates demotes as nonleaf) would be stamped
+            # as wholly before the cut with the appended record missing from every restore of this leaf's kernel life.
             src_gen = (getattr(ad, "_src_keys", {}) or {}).get(fp, (None,))[0]
-            if offs is None or len(offs) < len(recs) or (len(offs) > len(recs) and src_gen != _entry_gen(fp)):
+            if offs is None or len(offs) < len(recs) or (len(offs) > len(recs) and not (is_leaf and src_gen == ent_gen)):
                 return skip("offsets")
-            offs = offs[:len(recs)]
-            file_offs[fp] = offs
+            offs = offs[:len(recs)]                       # defensive: no row index below passes len(recs), so the extra
+            file_offs[fp] = offs                          #  offsets of a grown entry are never read (round one, low 3)
             pre_uuids = [r.get("uuid") for r in recs[:pre_n] if r.get("uuid")]
             f = {"path": fp, "size": st_.st_size, "mtime": st_.st_mtime, "pre": pre_n, "n": len(recs),
                  "first": pre_uuids[0] if pre_uuids else None, "last": pre_uuids[-1] if pre_uuids else None}
-            if pre_n >= len(recs) and Path(fp).stem != Path(leaf_path).stem:
+            if pre_n >= len(recs) and not is_leaf:
                 f["skip"] = True                          # wholly before the cut: never read at restore, stat is its proof
+                st_read = (getattr(ad, "_src_stat", {}) or {}).get(fp)
+                if st_read is None:
+                    return skip("stat")                   # no witness for the records the tree was parsed from: no row
+                f["size"], f["mtime"] = int(st_read[0]), float(st_read[1])   # the stat AS READ, never the write-time one: a
+                #                                            record appended to the prior file between the parse and this write
+                #                                            must fail the next boot's verification, not be stamped away (round
+                #                                            one, medium, the half that needed no reader in between)
             else:
                 cut_off = offs[pre_n][0] if pre_n < len(recs) else st_.st_size
                 try:
@@ -5664,6 +5687,8 @@ def _seed_from_doc(doc):
             landed.add(u)
     for fsid, f in doc["files"].items():
         seed["cuts"][fsid] = "skip" if f.get("skip") else (int(f["cut"][0]), int(f["cut"][1]), bytes.fromhex(f["cut"][2]))
+        if f.get("skip"):
+            seed.setdefault("stat", {})[fsid] = (int(f["size"]), float(f["mtime"]))   # the witness a rewrite carries forward
     return seed, landed
 
 

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -1595,6 +1595,14 @@ def _scan_jsonl_bytes(data, base_offset, offsets=None):
     return records, base_offset + end + 1
 
 
+def _entry_gen(path):
+    """The reader entry's generation for `path`, None with no entry: what a writer compares its adapter's source key against
+    before trusting the entry's offsets for records the adapter read (T396)."""
+    with _JSONL_CACHE_LOCK:
+        ent = _JSONL_CACHE.get(str(path))
+    return ent[6] if ent is not None and len(ent) > 6 else None
+
+
 def record_offsets(path, base):
     """[(byte offset, byte length)] of the reader entry's held records for `path`, record `base` first (the entry's
     base): the assembly checkpoint's record locations. None when the reader holds no entry or its base is later."""
@@ -5157,8 +5165,17 @@ def asm_checkpoint_write(leaf_path, rompuuid, sdk_human=False, tree=None, reason
                 return skip("stat")
             pre_n = max(0, min(len(recs), cut_seq - first_seq[fp]))   # records of this file before the cut
             offs = record_offsets(fp, 0)
-            if offs is None or len(offs) != len(recs):
+            # The reader's entry may hold MORE records than the tree's adapter read: a live leaf grows between the settle's
+            # parse and this write (the CLI appends while the settle runs), and the reader extends its entry by a new list
+            # whose prefix is the very records the adapter holds, under the same generation. The document's pre-cut part
+            # is that prefix, so the prefix's offsets stand; a shorter entry, or one under another generation (a rewrite,
+            # a refold from zero), does not (T396: a continuously active 120 MB session never got a document while its
+            # kernel lived, since every settle's write met an entry one record longer than its tree, and every boot read
+            # it whole through whichever reader came first).
+            src_gen = (getattr(ad, "_src_keys", {}) or {}).get(fp, (None,))[0]
+            if offs is None or len(offs) < len(recs) or (len(offs) > len(recs) and src_gen != _entry_gen(fp)):
                 return skip("offsets")
+            offs = offs[:len(recs)]
             file_offs[fp] = offs
             pre_uuids = [r.get("uuid") for r in recs[:pre_n] if r.get("uuid")]
             f = {"path": fp, "size": st_.st_size, "mtime": st_.st_mtime, "pre": pre_n, "n": len(recs),

--- a/tests/test_asm_checkpoint.py
+++ b/tests/test_asm_checkpoint.py
@@ -425,12 +425,12 @@ class WriteValves(Harness):
         """Review find (third round): a stat, offsets or write failure is a blip, not a property of the cut; memoizing it left
         the session without a document until its next compaction. It is counted and tried again at the next settle."""
         path = self._whole("blip")
-        real = em.record_offsets
-        em.record_offsets = lambda fp, base: None                   # a record landing between the parse and the offsets
-        try:
+        real = em._entry_offsets_gen
+        em._entry_offsets_gen = lambda fp: (None, None)              # a record landing between the parse and the offsets (the
+        try:                                                        #  writer's one entry read, T396)
             self.assertFalse(self.doc(path))
         finally:
-            em.record_offsets = real
+            em._entry_offsets_gen = real
         self.assertEqual(em.asm_checkpoint_stats()["skipped"], {"offsets": 1})
         self.assertIsNone(em._ASM_CACHE[next(iter(em._ASM_CACHE))].get("docSkip"), "not memoized")
         self.assertTrue(self.doc(path), "the next settle writes")
@@ -683,8 +683,8 @@ class ConvergeAssembly(Harness):
         with em._JSONL_CACHE_LOCK:                                 # the record entry back, but the offsets torn away at the write
             pass
         self.fresh(); em.set_checkpoint_dir(lambda: self.ck); self.parse(path)   # a whole record entry again
-        real = em.record_offsets; em.record_offsets = lambda p, base: None
-        self.addCleanup(setattr, em, "record_offsets", real)
+        real = em._entry_offsets_gen; em._entry_offsets_gen = lambda p: (None, None)   # the writer's one entry read (T396)
+        self.addCleanup(setattr, em, "_entry_offsets_gen", real)
         self.assertFalse(km._converge_assembly_leaf(path, SID, time.monotonic()))
         self.assertEqual(km._ASM_CONVERGE_BLIP.get(path), st, "a blip: the first try spent, not done")
         self.assertFalse(km._converge_assembly_leaf(path, SID, time.monotonic()))

--- a/tests/test_asm_write_over_grown_entry.py
+++ b/tests/test_asm_write_over_grown_entry.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""T396 (2026-09-12): a continuously active session never got an assembly document while its kernel lived. The settle's
+document write compared the reader entry's record offsets against the tree's records by count, and a live leaf grows between
+the settle's parse and the write (the CLI appends while the settle runs), so every write met an entry one record longer than
+its tree and skipped ("offsets"); at every boot the leaf was read whole by whichever reader came first (120 MB through the
+interrupt tick's judge parse on the boot after the T384 follow-up). The write takes the entry's prefix under the tree's own
+generation. Synthetic transcripts only (the golden builders)."""
+import json
+import os
+import sys
+import unittest
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402
+
+
+class WriteOverGrownEntry(Harness):
+    def _whole(self):
+        return {k: v["bytes"] for k, v in em.record_cache_stats()["wholeReads"].items()}
+
+    def _reset(self):
+        with em._JSONL_CACHE_LOCK:
+            em._RECORD_CACHE_STATS["wholeReads"] = {}
+
+    def _parsed_then_grown(self, name):
+        """A whole parse of a leaf, then one record appended and the reader's entry extended past the tree's records."""
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write(name, records(), sent=sent)
+        self.fresh()
+        tree = self.parse(path)
+        recs = records(); last = next(r for r in reversed(recs) if r.get("uuid"))
+        t1 = max((em.parse_z(r.get("timestamp")) or 0) for r in recs if r.get("timestamp")) + 60
+        with open(path, "a") as fh:
+            fh.write(json.dumps(G.uline(t1, "one more line while the settle ran", "u_race", last["uuid"])) + "\n")
+        em._read_jsonl_entry(path, tail_ok=True)                        # another reader extends the entry: same generation, one more record
+        em._ASM_CKPT_STATS["skipped"] = {}
+        return path, tree
+
+    def test_a_leaf_that_grew_after_the_settles_parse_still_gets_its_document(self):
+        path, tree = self._parsed_then_grown("grown")
+        reasons = []
+        self.assertTrue(em.asm_checkpoint_write(path, SID, False, tree=tree, reason_out=reasons), "written: %r %r" % (reasons, em._ASM_CKPT_STATS["skipped"]))
+        self.assertTrue(em._asm_ckpt_file(path).exists(), "the document is on disk")
+        self.fresh(); modes = []; self._reset()
+        restored = self.parse(path, modes)
+        self.assertEqual(modes, ["restore"], "the next process restores from it")
+        self.assertEqual(self._whole(), {}, "and reads nothing whole")
+        uuids = {a.get("uuid") for t in restored["turns"] for a in t["atoms"]}
+        self.assertIn("u_race", uuids, "the record appended after the parse is in the restored tree's tail")
+        self.fresh(); whole = self.parse(path)
+        self.assertEqual([len(t["atoms"]) for t in restored["turns"]], [len(t["atoms"]) for t in whole["turns"]], "restored equals whole")
+
+    def test_an_entry_under_another_generation_is_still_refused(self):
+        """A longer entry whose generation is not the tree's (a refold from zero after the append) does not lend its offsets."""
+        path, tree = self._parsed_then_grown("regen")
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.pop(str(path), None)
+        em._read_jsonl_entry(path, tail_ok=False)                        # a fresh generation over the grown file
+        reasons = []
+        self.assertFalse(em.asm_checkpoint_write(path, SID, False, tree=tree, reason_out=reasons))
+        self.assertEqual(reasons, ["offsets"], "%r" % reasons)
+
+    def test_the_judges_parse_over_a_restored_tree_reads_nothing_whole(self):
+        """The interrupt tick's road (jd.parsed_session): over a leaf with a document it restores, whether or not the display
+        parsed first; the boot's whole read was the missing document, not a reader rule."""
+        km = kernel_module(); jd = km.jd
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("tick", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        for display_first in (False, True):
+            self.fresh(); jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear()
+            if display_first:
+                self.parse(path)
+            self._reset(); modes = []
+            turns = jd.parsed_session(SID, [str(path)], NOW, asm_mode_out=modes)["turns"]
+            self.assertEqual(modes, ["serve" if display_first else "restore"])
+            self.assertEqual(self._whole(), {}, "display first %r" % display_first)
+            km._interrupt_marks(turns, SID, family="judge")
+            self.assertEqual(self._whole(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_asm_write_over_grown_entry.py
+++ b/tests/test_asm_write_over_grown_entry.py
@@ -5,13 +5,14 @@ the settle's parse and the write (the CLI appends while the settle runs), so eve
 its tree and skipped ("offsets"); at every boot the leaf was read whole by whichever reader came first (120 MB through the
 interrupt tick's judge parse on the boot after the T384 follow-up). The write takes the entry's prefix under the tree's own
 generation. Synthetic transcripts only (the golden builders)."""
+import gzip
 import json
 import os
 import sys
 import unittest
 HERE = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, HERE)
-from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402
+from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module, compacting_variant, _strip   # noqa: E402
 
 
 class WriteOverGrownEntry(Harness):
@@ -77,6 +78,74 @@ class WriteOverGrownEntry(Harness):
             self.assertEqual(self._whole(), {}, "display first %r" % display_first)
             km._interrupt_marks(turns, SID, family="judge")
             self.assertEqual(self._whole(), {})
+
+    def _lineage(self, name):
+        """The resume lineage (a prior file A wholly before the cut, the leaf B compacting), parsed whole once; returns
+        (pa, pb, cands, states, parse, tree)."""
+        d = self.td / name; d.mkdir()
+        pa, pb = d / (G.FSID_A + ".jsonl"), d / (G.FSID_B + ".jsonl")
+        pa.write_text("".join(json.dumps(r) + "\n" for r in G.scenario_resume_lineage_fileA()))
+        pb.write_text("".join(json.dumps(r) + "\n" for r in compacting_variant(G.scenario_resume_lineage_fileB(), "lin")))
+        states = getattr(G, "RESUME_STATES", None); cands = [str(pa), str(pb)]
+        def parse(modes=None):
+            return em.parse_session(str(pb), rompuuid=SID, name="impl", dir="/TESTDIR", candidate_files=cands, states=states,
+                                    postal_log=[], now=NOW, asm_mode_out=modes)
+        self.fresh()
+        tree = parse()
+        em._ASM_CKPT_STATS["skipped"] = {}
+        return pa, pb, cands, states, parse, tree
+
+    def _append_to_prior(self, pa):
+        recs = G.scenario_resume_lineage_fileA(); last = next(r for r in reversed(recs) if r.get("uuid"))
+        t1 = max((em.parse_z(r.get("timestamp")) or 0) for r in recs if r.get("timestamp")) + 60
+        with open(pa, "a") as fh:                                       # the prior file's own session resumed in another pane
+            fh.write(json.dumps(G.uline(t1, "the prior session speaks again", "u_prior_late", last["uuid"])) + "\n")
+
+    def test_a_lineage_file_longer_than_the_tree_still_refuses_the_write(self):
+        """Round one, medium, the half with a reader in between: the prefix rule is the LEAF's. A prior file that gained a
+        record after the parse, its entry extended by a reader under the same generation, must not be stamped as wholly
+        before the cut with the appended record missing from every restore."""
+        pa, pb, cands, states, parse, tree = self._lineage("lin-grown")
+        self._append_to_prior(pa)
+        em._read_jsonl_entry(pa, tail_ok=True)
+        reasons = []
+        self.assertFalse(em.asm_checkpoint_write(str(pb), SID, False, tree=tree, reason_out=reasons), "refused: %r" % reasons)
+        self.assertEqual(reasons, ["offsets"])
+
+    def test_a_skip_rows_witness_is_the_stat_the_tree_was_parsed_from(self):
+        """Round one, medium, the half with no reader in between: the skip row used to carry the WRITE-time stat, so a record
+        the prior file gained between the parse and the write verified at the next boot and the restore served a tree
+        missing it for the leaf's whole kernel life. The row carries the stat of the records the tree was parsed from, and
+        the next boot's check fails (lineage) and parses whole."""
+        pa, pb, cands, states, parse, tree = self._lineage("lin-stat")
+        self._append_to_prior(pa)                                       # no reader extends A's entry: the tree is stale, unseen
+        reasons = []
+        self.assertTrue(em.asm_checkpoint_write(str(pb), SID, False, tree=tree, reason_out=reasons), "written: %r" % reasons)
+        self.fresh(); modes = []
+        restored = parse(modes)
+        self.assertEqual(modes, ["full"], "the prior file's stat moved past the row's witness: no restore")
+        self.assertIn("lineage", em.asm_checkpoint_stats()["fallbacks"])
+        self.fresh(); saved = em._CKPT_DIR_FN; em._CKPT_DIR_FN = None
+        try:
+            whole = parse()
+        finally:
+            em._CKPT_DIR_FN = saved
+        self.assertEqual(_strip(restored), _strip(whole))
+
+    def test_a_restored_trees_adapter_carries_the_prior_files_witness_forward(self):
+        """A tree restored from a document never read the prior file (its skip row's stat was verified at load); a rewrite
+        from that tree needs the same witness for its own skip row, so the seed carries it and the adapter holds it."""
+        pa, pb, cands, states, parse, tree = self._lineage("lin-carry")
+        self.assertTrue(em.asm_checkpoint_write(str(pb), SID, False, tree=tree))
+        doc = json.load(gzip.open(em._asm_ckpt_file(str(pb))))
+        row = doc["files"][G.FSID_A]; self.assertTrue(row.get("skip"))
+        st = os.stat(pa)
+        self.assertEqual((row["size"], row["mtime"]), (st.st_size, st.st_mtime), "the first write's witness is the read's stat")
+        seed, _landed = em._seed_from_doc(doc)
+        self.assertEqual(seed["stat"][G.FSID_A], (row["size"], row["mtime"]), "the seed carries the skip row's witness")
+        ad = em.FileAdapter(cands, str(pb), seed=seed)
+        self.assertEqual(ad._src_stat[str(pa)], (row["size"], row["mtime"]), "the adapter holds it for the next write")
+        self.assertEqual(ad._src_keys[str(pa)], ("skip",))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix tier: a bug in the document writer with a test that fails before it.

**What went wrong:** the settle's assembly document write compared the reader entry's record offsets against the tree's records by count and refused on a mismatch (`skipped.offsets`). A live leaf grows between the settle's parse and the write (the CLI appends while the settle runs), so a continuously active session met a longer entry at every settle and never got a document while its kernel lived; the exit drain's budget skipped it too. At every boot the leaf was read whole by whichever reader came first: 120 MB through the interrupt tick's judge parse on the boot after the T384 follow-up (the whole-read counter's `upgrade<-_interrupt_block_tick` row, the leaf's own fold checkpoint having restored a tail entry that the whole reader upgraded). The kernel's log carried the same skip for the same leaf in the previous kernel's life.

**The change:** the writer takes the entry's prefix when the entry holds more records than the tree under the tree's own generation (the reader extends a growing file by a new list whose prefix is the very records the adapter read); a shorter entry, or a longer one under another generation (a refold from zero after the append), still skips. The document's cut and guard come from that prefix, so the next boot restores from the cut and reads the tail, the appended records among them. The reference names the rule beside the skip reason.

**Tests** (`tests/test_asm_write_over_grown_entry.py`): a whole parse, one record appended and the reader's entry extended, then the write: written, on disk, the next process restores (mode restore) with no whole read and the appended record in its tail, restored equal to whole; a longer entry under a fresh generation still refused with `offsets`; the judges' parse over a restored tree reads nothing whole whether or not the display parsed first (the tick's road). At the base the first fails: "written: ['offsets'] {'offsets': 1}".

**Measurement on the next deploy boot:** the `_interrupt_block_tick` (or any first reader's) whole-read row for that leaf gone once its document has been written by a settle; `asmCheckpoint.skipped.offsets` near zero over the kernel's life; the census at 50 of 50 leaves with a boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)