### PR TITLE
The incident scan's memo keeps a walked file resident when the drop write is off, and never drops a registered session's own file from another session's scan (T391 follow-up)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1054,7 +1054,9 @@ document's cursor carries a state: against a state the process holds, a cursor
 without one (an over-cap, cold or legacy bare write) is refused and the fold
 reads whole as before, so a complete state is never replaced by a tail-only one.
 The knobs: `ROMP_CKPT_CONVERGE_MS=0` turns the pass off and the drop write with
-it (the drop then pops as it did before the write existed); `ROMP_CKPT_CONVERGE_MB`
+it (the drop then pops as it did before the write existed, except under the
+incident scan's memo, which keeps a walked file's records resident when the
+document write is off, since its memo cannot reach the disk); `ROMP_CKPT_CONVERGE_MB`
 is the cycle budget both charge, and `0` turns the drop write off the same way
 rather than deferring every drop; both are read where the drop lives, so they
 hold from the first fold, before the first pusher cycle begins. The pass also

--- a/kernel/event_model.py
+++ b/kernel/event_model.py
@@ -4312,11 +4312,13 @@ def rewound_uuids(path, drop=True):
     _REWOUND_CACHE[key] = (count, gen, {"uuids": sorted(out)})   # the memo at the walk's own witness, dirty
     with _CKPT_LOCK:
         _FOLD_DIRTY.add(key)
-    if drop:                                              # the quiescence drop over this frozen file writes the document from the
+    if drop and checkpoint_drop_writes_on():              # the quiescence drop over this frozen file writes the document from the
         with _JSONL_CACHE_LOCK:                           #  walk's own read and lets the records go (T362's drop, its budget and its
             ent = _JSONL_CACHE.get(key)                   #  deferral); a file still changing keeps its entry and is written at its
-        if ent is not None and ent[6] == gen:             #  settle; only the very entry the walk read is dropped
-            _drop_quiescent_entry(key, ent, pop=True)
+        if ent is not None and ent[6] == gen:             #  settle; only the very entry the walk read is dropped. With the drop's
+            _drop_quiescent_entry(key, ent, pop=True)     #  document write OFF (a cycle cap of 0) the entry stays resident: the memo
+    #                                                        could not reach the disk, and a drop then made the file a whole read at
+    #                                                        every pass where the old road read it once per process (round two, low 1)
     return out
 
 

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -6087,9 +6087,12 @@ def _per_file_rewound(fsid, files):
             if fp == leaf:                                # the leaf road: the document's pre-cut verdicts and the tail read now
                 out |= em.file_rewound(fp, rompuuid=fsid, sdk_human=_sdk_owned(fsid))
             else:                                         # a dead episode's frozen file: the walk once, its verdict set memoized in
-                out |= em.rewound_uuids(fp, drop=fp not in lineage)   # the file's fold document and restored at the next process
-            #     ^ (T391); a live session's anchor keeps its records resident, since the chain walk above reads it whole at
-            #       every pass and a drop here made that a whole read per pass (round one, medium)
+                out |= em.rewound_uuids(fp, drop=fp not in lineage and not _sdk_owned(fp.stem))   # the file's fold document,
+            #     ^ restored at the next process (T391); a live session's anchor keeps its records resident, since the chain walk
+            #       above reads it whole at every pass and a drop here made that a whole read per pass (round one, medium); so does
+            #       ANY registered session's own file (<sid>.jsonl with a reg): a fork's episode log names its parent's anchor,
+            #       and the fork's scan dropping it made the parent's chain walk read it whole once more per process, by pass
+            #       order (round two, low 2)
             #     ^ the one-file walk asks for the leaf's document quietly: a lineage document (a /clear's anchor, a
             #       resume fork) is not this walk's and stays the display's
         except Exception as e:

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -98,7 +98,7 @@ class RewoundMemo(Harness):
         km = kernel_module(); jd = km.jd
         src = inspect.getsource(jd._per_file_rewound)
         self.assertIn("em.file_rewound(fp, rompuuid=fsid", src, "the leaf: the document's pre-cut verdicts and the tail")
-        self.assertIn("em.rewound_uuids(fp, drop=fp not in lineage)", src, "a dead file: the memo, its entry dropped; a lineage file resident")
+        self.assertIn("em.rewound_uuids(fp, drop=fp not in lineage and not _sdk_owned(fp.stem))", src, "a dead file: the memo, its entry dropped; a lineage file or a registered session's own file resident")
         self.assertLess(src.index("if fp == leaf:"), src.index("em.rewound_uuids(fp, drop="), "the leaf road decided first")
 
     def test_an_over_cap_set_is_recorded_as_such_and_walked_again(self):
@@ -225,6 +225,64 @@ class RewoundMemo(Harness):
         self.assertEqual(got, first, "the walk's verdicts")
         st = em.rewound_memo_stats()
         self.assertEqual((st["walked"], st["fallback"]), (1, 1), "%s" % st)
+
+    def test_with_the_drop_write_off_the_walked_file_stays_resident(self):
+        """Round two, low 1: with the drop's document write off (a cycle cap of 0, a documented knob) the memo road dropped the
+        walked entry and read a dead file whole at EVERY pass where the old road read it once per process (1259 bytes each
+        pass against 1259/0/0). The entry stays resident when the memo cannot reach the disk."""
+        path = self.frozen("capoff"); key = str(path)
+        saved = dict(em._CKPT_CYCLE)
+        with em._CKPT_LOCK:
+            em._CKPT_CYCLE["cap"] = 0
+        def restore():
+            with em._CKPT_LOCK:
+                em._CKPT_CYCLE.update(saved)
+        self.addCleanup(restore)
+        self.fresh_process()
+        with em._CKPT_LOCK:
+            em._CKPT_CYCLE["cap"] = 0
+        self.assertFalse(em.checkpoint_drop_writes_on())
+        first = em.rewound_uuids(path)
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNotNone(em._JSONL_CACHE.get(key), "the entry stays resident: nothing could be written")
+        before = em.read_bytes_report().get(key, 0)
+        self.assertEqual(em.rewound_uuids(path), first)
+        self.assertEqual(em.read_bytes_report().get(key, 0) - before, 0, "the second pass reads nothing")
+        st = em.rewound_memo_stats(); self.assertEqual((st["walked"], st["served"]), (1, 1), "%s" % st)
+
+    def test_a_registered_sessions_own_file_is_not_dropped_by_another_sessions_scan(self):
+        """Round two, low 2: a fork's episode log names its parent's anchor; when the fork's scan walked first and dropped the
+        entry, the parent's chain walk read the anchor whole once more in that process, by pass order. A file that is a
+        registered session's own (<sid>.jsonl with a reg) is never dropped by another session's scan."""
+        jd = kernel_module().jd
+        parent = "7a391000-2222-4333-8444-000000000393"; fork = "7a391000-2222-4333-8444-000000000394"
+        td = Path(tempfile.mkdtemp()); (td / "state").mkdir()
+        saved = jd.STATE; jd._rebind_state(td / "state")
+        def restore():
+            jd._PARSE_CACHE.clear(); jd._CHAIN_MEMO.clear(); jd._rebind_state(saved); shutil.rmtree(td, ignore_errors=True)
+        self.addCleanup(restore)
+        records, _sent = G.SINGLE_FILE["rewind_off_path"]
+        anchor = td / (parent + ".jsonl")
+        anchor.write_text("\n".join(json.dumps(r) for r in records()) + "\n")
+        old = time.time() - 600; os.utime(anchor, (old, old))
+        leaf = td / (fork + ".jsonl")
+        leaf.write_text(json.dumps(G.uline(NOW, "the fork's own first line", "u_fork_0", None)) + "\n")
+        (jd.STATE / "sdk").mkdir(parents=True, exist_ok=True)
+        (jd.STATE / "sdk" / (parent + ".json")).write_text(json.dumps({"spawnedAt": NOW}))   # the parent is a registered session
+        jd.EPIDIR.mkdir(parents=True, exist_ok=True)
+        (jd.EPIDIR / (fork + ".jsonl")).write_text(json.dumps({"head": "u_fork_0", "fsid": parent, "t": NOW}) + "\n")   # names the anchor
+        self.fresh_process()
+        out, fails = jd._per_file_rewound(fork, [str(leaf)])
+        self.assertEqual(fails, 0); self.assertTrue(out, "the anchor's rewound branch is in the fork's scan")
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNotNone(em._JSONL_CACHE.get(str(anchor)), "the parent's anchor stays resident under the fork's scan")
+        (jd.STATE / "sdk" / (parent + ".json")).unlink()                      # no reg: a dead episode's file, dropped as before
+        with em._JSONL_CACHE_LOCK:
+            em._JSONL_CACHE.pop(str(anchor), None)
+        self.fresh_process()
+        jd._per_file_rewound(fork, [str(leaf)])
+        with em._JSONL_CACHE_LOCK:
+            self.assertIsNone(em._JSONL_CACHE.get(str(anchor)), "an unregistered file is dropped after its memo is written")
 
 
 if __name__ == "__main__":

--- a/tests/test_rewind_memo.py
+++ b/tests/test_rewind_memo.py
@@ -255,6 +255,9 @@ class RewoundMemo(Harness):
         entry, the parent's chain walk read the anchor whole once more in that process, by pass order. A file that is a
         registered session's own (<sid>.jsonl with a reg) is never dropped by another session's scan."""
         jd = kernel_module().jd
+        saved_owner = jd._SDK_OWNER_FN                                   # the registry road answers here (a kernel loaded earlier in
+        jd._SDK_OWNER_FN = None                                          #  the process leaves its backend hook, which knows no reg file)
+        self.addCleanup(setattr, jd, "_SDK_OWNER_FN", saved_owner)
         parent = "7a391000-2222-4333-8444-000000000393"; fork = "7a391000-2222-4333-8444-000000000394"
         td = Path(tempfile.mkdtemp()); (td / "state").mkdir()
         saved = jd.STATE; jd._rebind_state(td / "state")


### PR DESCRIPTION
Fix tier: two review lows on the rewound memo (the previous change), each with a test that fails before it.

**Low 1, the drop write off.** With the quiescence drop's document write off (`ROMP_CKPT_CONVERGE_MB=0` or `ROMP_CKPT_CONVERGE_MS=0`, documented knobs) the memo could not reach the disk, yet the drop still popped the walked entry, so a dead file was read whole at every pass where the old road read it once per process. The drop is taken only while the write is on; otherwise the entry stays resident and the memo serves in memory. The knob's paragraph in the reference says so.

**Low 2, a file in two sessions' lists.** A fork's episode log names its parent's anchor. When the fork's scan walked first and dropped the entry, the parent's chain walk read the anchor whole once more in that process, by pass order. A file that is a registered session's own (`<sid>.jsonl` with a reg) is never dropped by another session's scan; an unregistered dead episode's file is dropped after its memo is written, as before.

**Tests** (`tests/test_rewind_memo.py`, two added): with the cap at 0 the walked file's entry stays resident and a second pass reads nothing (served 1, walked 1); a fork whose episode log names a registered parent's anchor leaves the anchor resident after the fork's scan, and the same file without a reg is dropped. At the base both fail: "unexpectedly None : the entry stays resident: nothing could be written" and "unexpectedly None : the parent's anchor stays resident under the fork's scan".

🤖 Generated with [Claude Code](https://claude.com/claude-code)