### PR TITLE
The end-by-lease guard remembers the host it told to end, so a second End after the first finished opens no second socket

### DIFF
--- a/kernel/sdk_backend.py
+++ b/kernel/sdk_backend.py
@@ -13102,6 +13102,8 @@ class SdkBackend:
             return False
         sock = ht.host_sock(self.state_dir, sid)
         ident = self._kernel_identity()
+        holder = (lease or {}).get("holder") or {}
+        holder_key = (holder.get("pid"), holder.get("start"))   # WHICH host this end is for (a later holder is a new host)
         async def go():
             t = ht.HostTransport(str(sock), kernel=ident, ack=-1, end_grace=ht.sh.END_GRACE_KILL_S)
             try:
@@ -13120,6 +13122,8 @@ class SdkBackend:
                 self._log("host (%s): end by lease failed: %s: %s" % (sid[:8], type(e).__name__, e))
                 return
             await t.end_and_close()             # `end` with the kill bound, whatever the initialize gate says
+            with self._lock:                    # the host named by the lease has been told to end: a later End for the
+                self.__dict__.setdefault("_ended_hosts", {})[sid] = holder_key   # same holder opens no second socket
         def run():
             try:
                 asyncio.run(go())
@@ -13131,6 +13135,13 @@ class SdkBackend:
             # `busy` to the second landed as a false failure row (the commit-17 review's first item); an unstarted
             # thread's is_alive() is False, so the start is inside the lock too
             threads = self.__dict__.setdefault("_end_threads", {})
+            if self.__dict__.get("_ended_hosts", {}).get(sid) == holder_key:
+                # the first End's thread finished before the second arrived (a host answers `end` in milliseconds):
+                # the is_alive check below no longer sees it, and a second socket to a host already told to end landed
+                # as a false failure row (main's Python 3.11 job, 2026-09-12). The lease still names that host, so it
+                # has not gone yet; a NEW holder under the same sid is a new host and ends normally
+                self._log("host (%s): the live host (pid %s) was already told to end through its lease" % (sid[:8], holder.get("pid")))
+                return True
             prev = threads.get(sid)
             if prev is not None and prev.is_alive():
                 self._log("host (%s): an end through the lease is already under way" % sid[:8])

--- a/tests/test_host_transport.py
+++ b/tests/test_host_transport.py
@@ -795,7 +795,7 @@ class BackendHostRules(unittest.TestCase):
         host, stop = self._serve_fake_host(d)
         import threading
         try:
-            with mock.patch.object(sb, "proc_start", lambda p, run=None: {999999997: "1", 999999996: "2"}.get(p)):
+            with mock.patch.object(sb, "proc_start", lambda p, run=None: {999999997: "1", 999999996: "2", 999999995: "3", 999999994: "4"}.get(p)):
                 self.assertEqual(ht.host_lease_state(sb.read_lease(d, SID), time.time()), "attach")
                 self.assertTrue(be.kill(SID))
                 th = be._end_threads[SID]
@@ -819,11 +819,14 @@ class BackendHostRules(unittest.TestCase):
                     if thread.name.startswith("romp-end-host-"):
                         starts.append(held.depth > 0)
                     return real_start(thread)
+                # a NEW host holds the lease (the first was told to end and a later End for it opens no socket): its End starts a thread
+                lease = sb.read_lease(d, SID); lease["holder"] = dict(lease["holder"], pid=999999995, start="3"); sb.write_lease(d, lease)
                 with mock.patch.object(threading.Thread, "start", start_recording):
                     self.assertTrue(be._end_host_by_lease(SID))
                     be._end_threads[SID].join(10)
                 self.assertEqual(starts, [True], "the end thread starts while the lock is held")
-                # two concurrent Ends: one thread, one socket
+                # two concurrent Ends for a host not yet told to end: one thread, one socket
+                lease = sb.read_lease(d, SID); lease["holder"] = dict(lease["holder"], pid=999999994, start="4"); sb.write_lease(d, lease)
                 host.got.clear()
                 results = []
                 racers = [threading.Thread(target=lambda: results.append(be._end_host_by_lease(SID))) for _ in range(2)]
@@ -832,7 +835,32 @@ class BackendHostRules(unittest.TestCase):
                 be._end_threads[SID].join(10)
                 self.assertEqual(results, [True, True])
                 self.assertEqual(sum(1 for f in host.got if f.get("t") == "attach"), 1, "one socket for two concurrent Ends: %r" % [f.get("t") for f in host.got])
-                self.assertEqual(sum(1 for l in be._test_logs if "already under way" in l), 1)
+                self.assertEqual(sum(1 for l in be._test_logs if "already under way" in l or "already told to end" in l), 1,
+                                 "the second End was refused a socket whether the first thread was still alive or had finished: %r" % be._test_logs[-4:])
+        finally:
+            stop()
+
+    def test_a_second_end_after_the_first_finished_opens_no_socket_and_a_new_holder_ends_normally(self):
+        # main's Python 3.11 job (2026-09-12): two concurrent Ends opened two sockets ("attach, end, attach, end") when the
+        # first thread had already finished; the guard remembers the lease holder it told to end
+        d, be = self._be(short=True)
+        self._marked(d); self._host_lease(d)
+        host, stop = self._serve_fake_host(d)
+        try:
+            with mock.patch.object(sb, "proc_start", lambda p, run=None: {999999997: "1", 999999996: "2", 999999995: "3"}.get(p)):
+                self.assertTrue(be._end_host_by_lease(SID))
+                be._end_threads[SID].join(10)
+                self.assertEqual([f.get("t") for f in host.got], ["attach", "end"])
+                self.assertTrue(be._end_host_by_lease(SID), "a later End for the same host is a no-op that reports done")
+                self.assertEqual([f.get("t") for f in host.got], ["attach", "end"], "no second socket to a host already told to end")
+                self.assertEqual(sum(1 for l in be._test_logs if "already told to end" in l), 1)
+                # a NEW host took the lease under the same sid: it is a different holder and ends normally
+                lease = sb.read_lease(d, SID)
+                lease["holder"] = dict(lease["holder"], pid=999999995, start="3")
+                sb.write_lease(d, lease)
+                self.assertTrue(be._end_host_by_lease(SID))
+                be._end_threads[SID].join(10)
+                self.assertEqual([f.get("t") for f in host.got], ["attach", "end", "attach", "end"], "the new holder is ended")
         finally:
             stop()
 


### PR DESCRIPTION
The concurrent-Ends test in `tests/test_host_transport.py` was red on main's Python 3.11 job and on a docs-only pull request: two sockets for two concurrent Ends. The guard held one end thread per sid only while that thread was alive, and a host answers `end` in milliseconds, so a second End arriving after the first finished opened a second socket to a host already told to end.

The guard now remembers the lease holder it told to end (recorded once `end` was sent); a later End for the same holder is a no-op that reports done, a new holder under the same sid ends normally, and a failed end (no hello) records nothing so a retry still runs. Tests cover the finished-first case, the new holder, and the race either way.

Tier: fix
