### PR TITLE
A hermetic kernel never runs the update check: the shell's update banner took the served lab's clicks on CI

### DIFF
--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -7836,6 +7836,11 @@ def _update_check():
     flipping the gear setting takes effect without a restart. A pass acts only when the discovered
     version CHANGES (new information): the same release re-found every few hours must not re-raise
     banners or re-file notices."""
+    if os.environ.get("ROMP_UPDATE_CHECK", "") == "off":
+        # a HERMETIC kernel (a served lab's, tests/test_ship_reship.py kernel_env): the check below reads the release
+        # remote's tags over the network, and a newer release than the checkout's raises the shell's update banner over
+        # the page under test (CI, 2026-09-13: the banner sat on the settings pills and took the lab's clicks)
+        return
     if _update_mode() == "off":
         return
     cur = _semver((_kernel_ver() or "").rstrip("+"))

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -527,7 +527,7 @@ class LabKernelEnv(unittest.TestCase):
     # what the lab itself puts in: its roots, the serve seams, and a postal bus of its own that is never started
     OWN = {"XDG_STATE_HOME": os.path.join(LAB, "xdg"), "CLAUDE_CONFIG_DIR": os.path.join(LAB, "claude"),
            "ROMP_MANAGER_PORT": "1", "ROMP_KERNEL_NO_OPEN": "1", "ROMP_SERVE_TOKEN": "testtok",
-           "ROMP_KERNEL_PORT": "4321", "ROMP_DIST_DIR": os.path.join(LAB, "dist"), "ROMP_MODEL_CATALOG": "off",
+           "ROMP_KERNEL_PORT": "4321", "ROMP_DIST_DIR": os.path.join(LAB, "dist"), "ROMP_MODEL_CATALOG": "off", "ROMP_UPDATE_CHECK": "off",
            "ROMP_POSTAL_PEERS": "0", "ROMP_POSTAL_CLIENT_ONLY": "1", "ROMP_POSTAL_HERMETIC": "1"}
     # the port a kernel with no ROMP_POSTAL_PORT of its own dials: the machine's bus, when a session's shell names it
     MACHINE_BUS_PORT = "25302"

--- a/tests/test_ship_reship.py
+++ b/tests/test_ship_reship.py
@@ -178,6 +178,8 @@ def kernel_env(lab, claude, dist, port, token, **seams):
                ROMP_SERVE_TOKEN=token, ROMP_KERNEL_PORT=str(port),
                ROMP_DIST_DIR=dist,
                ROMP_MODEL_CATALOG="off",     # hermetic: the T222 catalog fetch must never reach the network
+               ROMP_UPDATE_CHECK="off",      # hermetic: the update check reads the release remote's tags over the network, and a
+               #   newer release raises the shell's update banner over the page under test (CI, 2026-09-13)
                ROMP_POSTAL_PORT=str(_free_port()), ROMP_POSTAL_PEERS="0", ROMP_POSTAL_CLIENT_ONLY="1",
                ROMP_POSTAL_HERMETIC="1")   # the port above is this run's own: the bus honours it under a test (2026-09-11)
     env.update(seams)

--- a/tests/test_update_check_hermetic.py
+++ b/tests/test_update_check_hermetic.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""A hermetic kernel never runs the update check (2026-09-13). The check reads the release remote's tags over the
+network (git ls-remote), and when the checkout's release is older than the newest tag it raises the shell's update
+banner, a fixed alert at the top of the window. On CI that banner sat over the settings panel's pills and took every
+click of the tab widgets lab (main red at the tab widgets merge), while the same lab passed on a machine whose
+checkout read newer. So: ROMP_UPDATE_CHECK=off stands the check down before any read, every lab kernel runs with it
+(tests/test_ship_reship.py kernel_env), and the driver's relaunch keeps it. Synthetic; hermetic state; no network."""
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from romp_load import load_source
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+BIN = os.path.join(os.path.dirname(HERE), "bin")
+os.environ["XDG_STATE_HOME"] = tempfile.mkdtemp()
+os.environ.pop("ROMP_STATE_DIR", None)
+os.environ["ROMP_KERNEL_NO_OPEN"] = "1"
+os.environ.setdefault("ROMP_SERVE_TOKEN", "test-token-DO-NOT-USE")
+os.environ["ROMP_MANAGER_PORT"] = "1"
+load_source("romp_event_model", os.path.join(BIN, "romp-event-model"))
+load_source("romp_judge", os.path.join(BIN, "romp-judge"))
+km = load_source("romp_kernel_update_check_hermetic", os.path.join(BIN, "romp-kernel"))
+
+import sys  # noqa: E402
+sys.path.insert(0, HERE)
+import test_ship_reship as lab  # noqa: E402  the lab kernel environment under test
+
+
+class UpdateCheckSeam(unittest.TestCase):
+    def _run_check(self, env_value):
+        """_update_check with a checkout that reads as a release (so the tag read is reached) and a tag reader that
+        records whether it was asked; returns that record."""
+        asked = []
+
+        def reader():
+            asked.append(True)
+            raise RuntimeError("the release remote is not for a hermetic kernel to read")
+        env = dict(os.environ)
+        env.pop("ROMP_UPDATE_CHECK", None)
+        if env_value is not None:
+            env["ROMP_UPDATE_CHECK"] = env_value
+        with mock.patch.dict(os.environ, env, clear=True), \
+             mock.patch.object(km, "_kernel_ver", return_value="v0.1.0"), \
+             mock.patch.object(km, "_latest_release_tag", reader), \
+             mock.patch.object(km, "_update_mode", return_value="ask"):
+            km._update_check()
+        return asked
+
+    def test_off_stands_the_check_down_before_the_release_remote_is_read(self):
+        self.assertEqual(self._run_check("off"), [], "no tag read under ROMP_UPDATE_CHECK=off")
+
+    def test_without_the_seam_the_check_reads_the_release_remote_as_before(self):
+        self.assertEqual(self._run_check(None), [True], "the control: the read happens (and its failure is swallowed loudly)")
+        self.assertEqual(self._run_check("on"), [True], "only the literal off stands it down")
+
+
+class LabKernelsRunWithIt(unittest.TestCase):
+    def test_every_lab_kernel_environment_carries_the_seam_and_the_relaunch_keeps_it(self):
+        d = tempfile.mkdtemp()
+        env = lab.kernel_env(d, os.path.join(d, "claude"), os.path.join(d, "dist"), 1, "test-token-DO-NOT-USE")
+        self.assertEqual(env.get("ROMP_UPDATE_CHECK"), "off")
+        self.assertEqual(lab.relaunch_env(env).get("ROMP_UPDATE_CHECK"), "off", "the driver's relaunch of the lab kernel stays hermetic too")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Main's extension job is red since the tab widgets merge: the served tab widgets lab's click on the settings Feed pill times out on CI, two runs of two. The driver's call log names the cause: `<div id="rupd" role="alert" class="show">` intercepts pointer events. That is the shell's **update banner**, a fixed alert at the top of the window, raised because the hermetic lab kernel ran the update check in its default mode: the check reads the release remote's tags over the network (`git ls-remote`) and, on CI, finds a newer release than the checkout's version. The banner lands exactly over the settings card's pill row, which is new since the widgets change; the same lab passes on a machine whose checkout reads current.

- **The seam.** `ROMP_UPDATE_CHECK=off` stands the kernel's update check down before any read (the release remote's tags are a network read no hermetic kernel should make).
- **Every lab kernel runs with it.** `tests/test_ship_reship.py kernel_env` sets it beside the model-catalog seam, and the driver's relaunch environment keeps it (both pinned).

**Tests**
- `tests/test_update_check_hermetic.py`: with the seam, the check never asks for the tags (red at main: the read happens); without it, the read happens as before, and only the literal `off` stands it down; the lab kernel environment carries the seam and the relaunch keeps it (red at main).

Tier: fix
