### PR TITLE
The planner's callers take their units lazily: the emptiness gate from the markers' scalars and the user bodies, the text read by the plan pass after its filters (T396)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1158,7 +1158,11 @@ store already places is yielded with its key and scalars and no text or quote
 (no pre-cut body read), the rest read their text after the placement check;
 the lookup is an index built once per planner call with the episode floor
 taken once per pass, and a consumer that plans a unit yielded as placed reads
-its text then.
+its text then. The planner's own callers take every unit that way (T396): the
+emptiness gate that drops a textless segment is decided from the markers'
+scalars and the user bodies alone, and a work unit's text and quote are read
+by the plan pass after its own filters, so a unit that never reaches the model
+is never read (42.8 MB of assistant bodies per boot before).
 
 What the CLI itself does when its parent goes quiet was measured on Claude Code
 2.1.257 (2026-09-10, the restart-surviving sessions program's stage 3 probe, run

--- a/kernel/judge.py
+++ b/kernel/judge.py
@@ -2659,6 +2659,20 @@ def _prompt_text(atoms):
     return ""
 
 
+def _unit_nonempty(atoms):
+    """Whether `_unit_text(atoms)` would be non-empty, decided from the atoms' scalars and the USER bodies alone (T396):
+    _unit_text frames three sources, a user atom (any author) whose text survives the romp-marker strip, an assistant atom
+    (not an API error) with text, and an assistant tool call. The assistant side is answered by the markers' scalars (nt,
+    the tool calls); the user side reads the user atoms' bodies, small, because a text made only of romp markers strips to
+    nothing (the one case a scalar cannot see). The planner's emptiness gate asks this in place of reading the unit text,
+    which hydrated every assistant body of every unplaced segment at every pass (42.8 MB on one boot)."""
+    for a in atoms:
+        if a.get("type") == "assistant" and not a.get("isApiError") and (em._has_text(a) or em.atom_tool_uses(a)):
+            return True
+    return any(_FOLLOWUP_MARKER_RE.sub("", _atom_text(a)).strip()
+               for a in atoms if a.get("type") == "user" and a.get("author") is not None and em._has_text(a))
+
+
 def _has_asst_work(atoms):
     """True if a unit has any real ASSISTANT output — its own text or a tool_use. The captioner has nothing
     to gloss without it (it refuses or returns empty), so a work-less unit (a bare user message, an
@@ -9126,7 +9140,7 @@ def unit_text_for(seg, phase):
     return _seam_text(seg)
 
 
-def plan_units(session, store=None, floor=_UNSET_FLOOR):
+def plan_units(session, store=None, floor=_UNSET_FLOOR, lazy_text=False):
     """Ordered (seg_id, phase, t, text, human, followup, trigger) planner units for the TWO-RUN model (the
     user 2026-06-21, via link_audit), oldest-first. `trigger` (the user 2026-07-01, via bugs) is the
     segment's trigger atom uuid (seg["trigger"], None for an autonomous/continuation segment with no
@@ -9191,7 +9205,13 @@ def plan_units(session, store=None, floor=_UNSET_FLOOR):
                 if not _memo:                             #  placed yet: a hydration over a restored tree (T377)
                     _memo.append(_seam_text(seg))
                 return _memo[0]
-            if not any(_placed_phase(seg, ph) for ph in ("work", "prompt", "delegation", "live")) and not _wt():
+            _nonempty = []
+
+            def _ne(seg=seg, _nonempty=_nonempty):        # whether the unit text is non-empty: lazy_text decides it from the
+                if not _nonempty:                         #  scalars and the user bodies (_unit_nonempty, T396), never reading
+                    _nonempty.append(_unit_nonempty(seg["atoms"]) if lazy_text else bool(_wt()))   # the assistant bodies
+                return _nonempty[0]
+            if not any(_placed_phase(seg, ph) for ph in ("work", "prompt", "delegation", "live")) and not _ne():
                 continue                                  # an unplaced empty segment drops, as before; a placed segment yields its
             #                                               unit without the emptiness check (no text is read for it), an inert unit
             #                                               at worst, which every consumer skips as placed (review, low 1)
@@ -9207,7 +9227,11 @@ def plan_units(session, store=None, floor=_UNSET_FLOOR):
             def _put(phase, text_fn, human_, followup_, seg=seg, trig=trig):
                 if _placed_phase(seg, phase):             # placed already: the key, time and scalars; no text and no quote read
                     out.append((seg["id"], phase, seg["t"], None, human_, followup_, trig, None)); return
-                t = text_fn()
+                if lazy_text and phase != "prompt":       # T396: the unit's text and quote are read by the consumer, after its own
+                    if _ne():                             #  filters (unit_text_for, _mint_quote: _plan_session's placed-yield road),
+                        out.append((seg["id"], phase, seg["t"], None, human_, followup_, trig, None))   # so a unit that never
+                    return                                #  reaches the model is never read; the emptiness gate is the scalar one.
+                t = text_fn()                             # a prompt unit's text is its one user atom: read here, as before
                 if t:
                     out.append((seg["id"], phase, seg["t"], t, human_, followup_, trig, _quote()))
             if not is_open_final and not _has_asst_work(seg["atoms"]):
@@ -11185,11 +11209,11 @@ def _plan_session(fsid, path, now):
     #                                                   an identical-text twin (crash-heal restart resumes) must
     #                                                   not be swallowed as a "drift" of an already-placed one
     if store.get("placementsV") != PLACEMENTS_V:      # P2: seal/adopt on identity-version change (199118f)
-        ready = [_unit_key(u[0], u[1]) for u in plan_units(session, store, floor=floor)]
+        ready = [_unit_key(u[0], u[1]) for u in plan_units(session, store, floor=floor, lazy_text=True)]
         if _migrate_placements(store, ready, live):
             save_goals(fsid, store)
     units, retired, seen = [], False, set()
-    for u in plan_units(session, store, floor=floor):
+    for u in plan_units(session, store, floor=floor, lazy_text=True):
         seg_id, phase = u[0], u[1]
         key = _unit_key(seg_id, phase)
         if key in seen:                               # plan_units yields one unit per TURN, so a same-second
@@ -11889,7 +11913,7 @@ def fast_forward_placements(fsid, path=None, now=None):
     store = load_goals(fsid)
     placements = store["placements"]
     n = 0
-    for u in plan_units(session, store):
+    for u in plan_units(session, store, lazy_text=True):   # keys alone: no unit text read (T396)
         seg_id, phase = u[0], u[1]
         keys = {_unit_key(seg_id, phase)}
         if phase == "prompt":

--- a/kernel/kernel.py
+++ b/kernel/kernel.py
@@ -12796,7 +12796,7 @@ def _nudge_placement_gate(sid, turns, store):
     try:
         _live = {sg["id"] for tn in turns for sg in jd._segs(tn, store)}
         unplanned = any(not jd._placed_key(store.get("placements") or {}, jd._unit_key(u[0], u[1]), _live)
-                        for u in jd.plan_units({"turns": turns}, store))
+                        for u in jd.plan_units({"turns": turns}, store, lazy_text=True))   # keys alone (T396)
     except Exception:
         unplanned = False                        # minimal/legacy turn shapes → the closer gate stands alone,
         sys.stderr.write("auto-nudge placement gate (session %s): %s\n"   # but never SILENTLY (the user

--- a/tests/test_judge_hidefeed.py
+++ b/tests/test_judge_hidefeed.py
@@ -109,7 +109,7 @@ class FastForwardOnUnmute(unittest.TestCase):
 
     def _run(self, fsid):
         saved_pu, saved_ps = jd.plan_units, jd.parsed_session
-        jd.plan_units = lambda session, store=None: list(self.UNITS)
+        jd.plan_units = lambda session, store=None, **kw: list(self.UNITS)   # the callers pass lazy_text (T396)
         jd.parsed_session = lambda fsid, paths, now: {"turns": []}
         try:
             return jd.fast_forward_placements(fsid, path="/x", now=1700000000)

--- a/tests/test_planner_lazy_unit_text.py
+++ b/tests/test_planner_lazy_unit_text.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""T396 (2026-09-12): the planner read the unit text of every unplaced segment at every pass, as its emptiness gate and as the
+yielded text, before its consumer's filters decided whether the unit reaches the model (42.8 MB of assistant bodies hydrated on
+one boot through _unit_text<-_seam_text). The production callers now take the units lazily: the emptiness gate is decided from
+the markers' scalars and the user bodies (_unit_nonempty), the text and the quote are read by _plan_session after its filters,
+through the placed-yield road T377 built. Synthetic transcripts only (the golden builders)."""
+import inspect
+import os
+import sys
+import unittest
+HERE = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, HERE)
+from test_asm_checkpoint import em, G, SID, NOW, Harness, kernel_module   # noqa: E402
+
+
+def _segments(tree):
+    return [seg for t in tree["turns"] for seg in em.segments(t)]
+
+
+class LazyUnitText(Harness):
+    def test_the_scalar_emptiness_gate_equals_the_unit_texts_over_every_golden_scenario(self):
+        jd = kernel_module().jd
+        n = 0
+        for name in G.SINGLE_FILE:
+            records, sent = G.SINGLE_FILE[name]
+            path = self.write("eq-" + name, records(), sent=sent)
+            self.fresh(); em._CKPT_DIR_FN = None
+            try:
+                tree = self.parse(path)
+            finally:
+                em.set_checkpoint_dir(lambda: self.ck)
+            for seg in _segments(tree):
+                with self.subTest(scenario=name, seg=seg["id"]):
+                    self.assertEqual(jd._unit_nonempty(seg["atoms"]), bool(jd._seam_text(seg)))
+                    n += 1
+        self.assertGreater(n, 20, "segments compared: %d" % n)
+
+    def test_the_gate_over_the_three_sources_and_their_blind_spots(self):
+        jd = kernel_module().jd
+        user = lambda text, author="human": {"type": "user", "author": author, "uuid": "u", "t": 1.0,   # noqa: E731
+                                            "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+        asst = lambda blocks, **kw: dict({"type": "assistant", "uuid": "a", "t": 2.0,                    # noqa: E731
+                                          "message": {"role": "assistant", "content": blocks}}, **kw)
+        self.assertTrue(jd._unit_nonempty([user("a real ask")]))
+        self.assertTrue(jd._unit_nonempty([user("a peer's report", author="teammate")]), "a report is framed too")
+        self.assertFalse(jd._unit_nonempty([user("<!-- romp-injected -->")]), "a text of romp markers alone strips to nothing")
+        self.assertFalse(jd._unit_nonempty([dict(user("authorless"), author=None)]), "an authorless user atom is not framed")
+        self.assertTrue(jd._unit_nonempty([asst([{"type": "text", "text": "a reply"}])]))
+        self.assertFalse(jd._unit_nonempty([asst([{"type": "text", "text": "overloaded"}], isApiError=True)]), "an API error is noise")
+        self.assertTrue(jd._unit_nonempty([asst([{"type": "tool_use", "id": "t1", "name": "Read", "input": {}}])]), "a tool call alone is a unit")
+        self.assertFalse(jd._unit_nonempty([asst([{"type": "thinking", "thinking": "hm"}])]), "thinking alone is not")
+        for atoms in ([user("a real ask")], [asst([{"type": "tool_use", "id": "t1", "name": "Read", "input": {}}])],
+                      [asst([{"type": "text", "text": "overloaded"}], isApiError=True)], [user("<!-- romp-injected -->")]):
+            self.assertEqual(jd._unit_nonempty(atoms), bool(jd._unit_text(atoms)), "%r" % atoms)
+
+    def test_lazy_units_match_the_eager_ones_and_read_no_assistant_body(self):
+        jd = kernel_module().jd
+        records, sent = G.SINGLE_FILE["compaction_atom"]
+        path = self.write("lazy", records(), sent=sent)
+        self.fresh(); self.parse(path); self.assertTrue(self.doc(path))
+        self.fresh(); modes = []; tree = self.parse(path, modes); self.assertEqual(modes, ["restore"])
+        store = {"rompUuid": SID, "seq": 0, "nodes": {}, "placements": {}, "status": {}, "placementsV": jd.PLACEMENTS_V}
+        em._ASM_CKPT_STATS.update(hydratedAtoms=0, hydratedBytes=0, hydratedBy={})
+        lazy = jd.plan_units(tree, store, lazy_text=True)
+        by = dict(em.asm_checkpoint_stats()["hydratedBy"])
+        self.assertFalse([k for k in by if k.startswith("_unit_text")], "no unit text read for the lazy units: %s" % by)
+        eager = jd.plan_units(tree, store)
+        self.assertEqual([(u[0], u[1]) for u in lazy], [(u[0], u[1]) for u in eager], "the same units, in order")
+        self.assertTrue(any(u[1] != "prompt" for u in lazy), "the fixture has work units")
+        for u in lazy:
+            if u[1] != "prompt":
+                self.assertIsNone(u[3], "a lazy unit carries no text: %r" % (u[:2],)); self.assertIsNone(u[7])
+        for lu, eu in zip(lazy, eager):
+            seg = next(s for s in _segments(tree) if s["id"] == lu[0])
+            self.assertEqual(jd.unit_text_for(seg, lu[1]), eu[3], "the consumer's late read equals the eager text")
+
+    def test_the_production_callers_take_the_units_lazily(self):
+        km = kernel_module(); jd = km.jd
+        src = inspect.getsource(jd._plan_session)
+        self.assertEqual(src.count("plan_units(session, store, floor=floor, lazy_text=True)"), 2, "the migration pre-pass and the plan loop")
+        self.assertIn("if text is None:", src, "the consumer reads the text after its filters (T377's road)")
+        self.assertIn("lazy_text=True", inspect.getsource(km._auto_nudge_unplanned) if hasattr(km, "_auto_nudge_unplanned") else
+                      open(km.__file__).read().split('jd.plan_units({"turns": turns}, store')[1][:40], "the nudge gate reads keys alone")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wake_deadman_toggle.py
+++ b/tests/test_wake_deadman_toggle.py
@@ -91,7 +91,7 @@ class _Base(unittest.TestCase):
         km._debt_backstop_tick = lambda now: None
         km._PREV_ALIVE = {SID}                       # no death transition pending
         jd._segs = lambda tn, store: []
-        jd.plan_units = lambda session, store: []
+        jd.plan_units = lambda session, store, **kw: []   # the callers pass lazy_text (T396)
         self.turns = [{"id": "t1", "ended": True, "end": NOW - 8 * H, "t": NOW - 8 * H - 10, "atoms": []}]
         jd.parsed_session = lambda sid, paths, now: {"turns": self.turns}
         self.gid = SID + ":g1"


### PR DESCRIPTION
Fix tier: the planner read every unplaced segment's unit text at every pass before its consumer decided whether the unit reaches the model; a test that fails before it.

**What went wrong:** `plan_units` read `_seam_text(seg)` for every segment with no placed phase, twice over: as the emptiness gate ("an unplaced empty segment drops") and as the yielded unit text, both before `_plan_session`'s own filters (the same-second dedupe, the drift-safe placement key, the pre-episode retire, the moot branch); a store whose placements version differs runs `plan_units` a second time for the migration pre-pass; the auto-nudge gate and the fast-forward on unmute read keys alone and paid the text too. On one boot that was 42.8 MB of assistant bodies hydrated through `_unit_text<-_seam_text`, the largest remaining hydrator after the readers T384 narrowed.

**The change:** `plan_units(..., lazy_text=True)`, passed by the three production callers (the plan pass, the fast-forward, the kernel's nudge gate). The emptiness gate is `_unit_nonempty(atoms)`: exact against `_unit_text`'s framing, answered from the markers' scalars for the assistant side (text present, tool calls) and from the user bodies alone for the user side (small; a text made only of romp markers strips to nothing, the one case a scalar cannot see). A work, live or delegation unit is yielded with no text and no quote; `_plan_session` reads them after its filters through the placed-yield road T377 built (`unit_text_for`, `_mint_quote`). A prompt unit's text is its one user atom and is read as before. Tests that stub `plan_units` accept the keyword. The reference names the rule beside T377's.

**Tests** (`tests/test_planner_lazy_unit_text.py`): the gate equals the unit text's emptiness over every segment of every golden scenario, and over the three sources and their blind spots (a marker-only text, an API-error record, a tool call alone, an authorless user atom); over a restored tree the lazy units match the eager ones in order, carry no text, and hydrate no unit text, while the consumer's late read equals the eager text; the production callers pinned. At the base the module fails on the absent keyword and helper.

**Measurement on the next deploy boot:** the `_unit_text<-_seam_text` row under `asmCheckpoint.hydratedBy` (42.8 MB) to the units that reach the model only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)